### PR TITLE
chore: release 2.2.1 — publish pipeline hardening (D015)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,15 +9,122 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write # required for npm provenance via OIDC
+      actions: read # required for gh api querying the CI run of the tagged SHA
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history — ancestor check needs it
+
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: npm run build
-      - run: npm publish --access public
+
+      # Preflight 1/4 — tag ↔ package.json version. A mismatch here means
+      # someone tagged the wrong commit or forgot to bump. Fail early so
+      # the tarball we build isn't misleading.
+      - name: Preflight — tag matches package.json version
+        run: |
+          TAG_NAME="${GITHUB_REF_NAME}"
+          TAG_VERSION="${TAG_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $TAG_NAME (version $TAG_VERSION) does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+          echo "✓ Tag $TAG_NAME matches package.json version $PKG_VERSION"
+
+      # Preflight 2/4 — tagged commit must be reachable from origin/main.
+      # Blocks the "tagged a feature branch that never merged" mistake.
+      - name: Preflight — tagged commit is on main
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" refs/remotes/origin/main; then
+            echo "::error::Tagged commit ${GITHUB_SHA} is not reachable from origin/main"
+            exit 1
+          fi
+          echo "✓ Tagged commit ${GITHUB_SHA} is an ancestor of origin/main"
+
+      # Preflight 3/4 — CI must have succeeded on the exact tagged SHA.
+      # Prevents "tag pushed before CI finished" or "CI red on main".
+      - name: Preflight — CI is green on tagged commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CONCLUSION=$(gh run list \
+            --workflow CI \
+            --commit "${GITHUB_SHA}" \
+            --json conclusion,status \
+            --jq '.[0].conclusion // "missing"')
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "::error::CI is not green on tagged commit ${GITHUB_SHA} (got: ${CONCLUSION})"
+            echo "Re-run CI on this commit and wait for success before re-triggering the release."
+            exit 1
+          fi
+          echo "✓ CI is green on ${GITHUB_SHA}"
+
+      # Preflight 4/4 — version must not already exist on npm. Catches the
+      # exact 2.2.0 race where a local publish preceded the workflow run.
+      - name: Preflight — version not already on npm
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@vyuhlabs/dxkit@${VERSION}" version >/dev/null 2>&1; then
+            echo "::error::@vyuhlabs/dxkit@${VERSION} is already published on npm"
+            echo "Bump the version and re-tag, or investigate whether a local publish happened."
+            exit 1
+          fi
+          echo "✓ @vyuhlabs/dxkit@${VERSION} is available on npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # Pack first, capture the sha1 we built, then publish *that exact
+      # tarball*. Eliminates any drift between "what npm publish packs"
+      # and "what we verified post-publish".
+      - name: Pack tarball
+        id: pack
+        run: |
+          TARBALL=$(npm pack --silent)
+          SHASUM=$(sha1sum "$TARBALL" | awk '{print $1}')
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+          echo "shasum=$SHASUM" >> "$GITHUB_OUTPUT"
+          echo "✓ Built $TARBALL (sha1: $SHASUM)"
+
+      - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance "${{ steps.pack.outputs.tarball }}"
+
+      # Post-publish — npm's recorded shasum must equal our local sha1.
+      # A mismatch means something replaced the tarball mid-publish or
+      # the registry accepted a different file; bail loudly.
+      - name: Verify npm shasum matches local tarball
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          REMOTE_SHASUM=""
+          for i in 1 2 3 4 5 6; do
+            REMOTE_SHASUM=$(npm view "@vyuhlabs/dxkit@${VERSION}" dist.shasum 2>/dev/null || true)
+            if [ -n "$REMOTE_SHASUM" ]; then break; fi
+            sleep 3
+          done
+          LOCAL_SHASUM="${{ steps.pack.outputs.shasum }}"
+          if [ -z "$REMOTE_SHASUM" ]; then
+            echo "::error::npm never reported a shasum for @vyuhlabs/dxkit@${VERSION}"
+            exit 1
+          fi
+          if [ "$REMOTE_SHASUM" != "$LOCAL_SHASUM" ]; then
+            echo "::error::npm shasum ($REMOTE_SHASUM) does not match local tarball shasum ($LOCAL_SHASUM)"
+            exit 1
+          fi
+          echo "✓ Shasum verified: ${REMOTE_SHASUM}"
+
+      - name: Upload tarball as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vyuhlabs-dxkit-${{ github.ref_name }}
+          path: ${{ steps.pack.outputs.tarball }}
+          retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-04-23
+
+Patch release hardening the publish pipeline after `v2.2.0`'s Publish
+workflow failed with `403 — version already published`. The failure
+was caused by a local `npm publish` that preceded the
+Release-triggered CI publish, not a code defect — the tarball on npm
+byte-matches main. No functional changes in this release; all work
+is on the release path (tracked internally as D015).
+
+### Added — publish pipeline guardrails
+
+- **`scripts/require-ci.js` + `prepublishOnly` guard** — any `npm publish`
+  invocation outside GitHub Actions now fails at the script hook with
+  a clear error pointing to `CLAUDE.md §"Release procedure"`. Prevents
+  accidental local publish before the registry is ever contacted.
+
+- **`publishConfig.provenance: true`** — npm publishes now carry a
+  GitHub Actions provenance attestation. Provenance requires an OIDC
+  token that only exists inside Actions; tarball-mode publishes
+  (`npm publish *.tgz`, which skips `prepublishOnly`) also fail outside
+  CI. Belt-and-suspenders with the script guard.
+
+- **Publish-workflow preflights** (`.github/workflows/publish.yml`) —
+  before `npm publish` runs, the workflow now verifies (in order):
+  1. tag `vX.Y.Z` matches `package.json` version `X.Y.Z`
+  2. tagged commit is reachable from `origin/main` (blocks
+     feature-branch tags)
+  3. the `CI` workflow succeeded on the tagged commit SHA
+  4. `X.Y.Z` is not already on npm (catches the exact 2.2.0 failure)
+
+- **Explicit pack + publish + verify** — workflow packs the tarball,
+  records its sha1, publishes that exact file, then fetches
+  `npm view dist.shasum` and fails on mismatch. Eliminates drift
+  between "what npm packed" and "what we audited."
+
+- **Tarball workflow artifact** — every release archives the published
+  `.tgz` as a workflow artifact (90-day retention) for post-mortem
+  auditability.
+
+### Documented — `CLAUDE.md`
+
+New "Release procedure" section codifying PR → CI-green → merge → tag
+→ CI publishes as the only path. Explicit "no local `npm publish`"
+rule.
+
 ## [2.2.0] - 2026-04-23
 
 Minor release adding Snyk-style top-level dep attribution across every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,47 @@ Reports, analyzers, and tool registries **must not** grow language-specific
 branches. If you find yourself writing one, the right answer is almost
 always to add the capability to `LanguageSupport` and let the pack provide it.
 
+## Release procedure
+
+**Every release goes through the CI pipeline. No exceptions.** Local
+`npm publish` is blocked by `scripts/require-ci.js` (wired as the
+`prepublishOnly` hook) and additionally disabled by
+`publishConfig.provenance: true`, which requires an OIDC token that
+only exists inside GitHub Actions.
+
+Sequence for a new release:
+
+1. Work on a `feat/<phase-or-change>` branch.
+2. Open a PR against `main`. CI must pass (typecheck, lint, format, tests, coverage, architecture rules, slop check, `npm pack --dry-run`).
+3. Merge via the GitHub UI — not a local `git push`. Branch protection on `main` enforces this.
+4. In the PR (or a follow-up), bump `package.json` + `package-lock.json` + add a `CHANGELOG.md` entry for the new version.
+5. After the release commit is on `main` and CI is green there:
+
+   ```bash
+   git checkout main && git pull
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+6. Create a GitHub Release from the tag. This fires `.github/workflows/publish.yml`, which preflights:
+   - tag `vX.Y.Z` matches `package.json` version `X.Y.Z`
+   - tagged commit is reachable from `origin/main` (no feature-branch tags)
+   - the `CI` workflow succeeded on the tagged commit SHA
+   - `X.Y.Z` is not already on npm
+
+   Only then does it `npm pack` + `npm publish --provenance` + verify the
+   registry shasum matches the locally built tarball. The tarball is
+   archived as a workflow artifact for 90 days.
+
+**Why this exists**: the v2.2.0 release shipped from a local
+`npm publish` that raced the CI-driven one (CI lost with 403 — version
+already taken). The code on npm matched main byte-for-byte, but the
+release path was unauditable and provenance was absent. Tracked
+internally as D015.
+
+**Never run `npm publish` locally.** The guard will stop you with a
+clear error message; don't try to work around it.
+
 ## Build & Test
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "AI-native developer experience toolkit for any repository",
   "license": "MIT",
   "author": "Vyuh Labs",
@@ -16,7 +16,8 @@
     "vyuh-dxkit": "./dist/index.js"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "main": "./dist/lib.js",
   "types": "./dist/lib.d.ts",
@@ -39,7 +40,7 @@
   ],
   "scripts": {
     "build": "node scripts/copy-templates.js && tsc",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "node scripts/require-ci.js && npm run build",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/scripts/require-ci.js
+++ b/scripts/require-ci.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * prepublishOnly guard — refuses to publish outside GitHub Actions.
+ *
+ * Why: local `npm publish` bypasses the release pipeline's PR review,
+ * tag-on-main check, CI-green gate, version-not-on-npm preflight, and
+ * provenance attestation. The v2.2.0 release shipped from a local
+ * publish; CI's own publish attempt then 403'd because the version was
+ * already taken (D015 in the internal defect log).
+ *
+ * This hook makes accidental local publish impossible — it fails before
+ * the registry is ever contacted. Belt-and-suspenders with
+ * `publishConfig.provenance: true`, which additionally requires an OIDC
+ * token that only exists inside GitHub Actions.
+ *
+ * Every console.* here is the entire user-facing surface of this
+ * guard, so slop-ok is the correct annotation.
+ */
+
+const { CI, GITHUB_ACTIONS } = process.env;
+
+if (CI !== 'true' || GITHUB_ACTIONS !== 'true') {
+  console.error(''); // slop-ok
+  console.error('  ✗ npm publish is only allowed from GitHub Actions.'); // slop-ok
+  console.error(''); // slop-ok
+  console.error('  Release procedure (see CLAUDE.md §"Release procedure"):'); // slop-ok
+  console.error('    1. Open a PR against main. CI must pass.'); // slop-ok
+  console.error('    2. Merge via the GitHub UI.'); // slop-ok
+  console.error('    3. After main is green, tag: git tag -a vX.Y.Z && git push origin vX.Y.Z'); // slop-ok
+  console.error('    4. Creating a GitHub Release from the tag triggers the publish workflow.'); // slop-ok
+  console.error(''); // slop-ok
+  console.error('  Local `npm publish` was blocked to preserve tag-ancestor, CI-green,'); // slop-ok
+  console.error('  version-not-on-npm, and provenance guarantees that only CI can enforce.'); // slop-ok
+  console.error(''); // slop-ok
+  process.exit(1);
+}
+
+console.log('✓ CI guard: running inside GitHub Actions, publish may proceed'); // slop-ok


### PR DESCRIPTION
## Summary

After v2.2.0's Publish workflow failed with `403 — version already published` (a local `npm publish` raced the CI-driven one and CI lost), this PR lands layered guardrails that make the failure mode impossible going forward. No functional code changes — all work is on the release path.

**Important context:** npm's `@vyuhlabs/dxkit@2.2.0` tarball (shasum `a8733ef6…`) byte-matches main's `npm pack --dry-run` output. The incident shipped no bad bytes — it only broke release provenance and trust. This PR restores both, then ships as 2.2.1.

## What changed (by layer)

**package.json / guard script**
- `scripts/require-ci.js` — new. Fails with an actionable error if `CI !== 'true' || GITHUB_ACTIONS !== 'true'`.
- `prepublishOnly` — now chains `require-ci.js` before `npm run build`. Any local `npm publish` hits the guard before the registry is contacted.
- `publishConfig.provenance: true` — npm publishes carry a GitHub Actions provenance attestation. Provenance needs an OIDC token only present inside Actions; this doubles as a second barrier against local publish (including tarball-mode that skips `prepublishOnly`).

**`.github/workflows/publish.yml` — four preflights + explicit pack/publish/verify**
1. Tag `vX.Y.Z` must match `package.json` version `X.Y.Z`
2. Tagged commit must be reachable from `origin/main`
3. CI workflow must have succeeded on the tagged commit SHA
4. Version must not already exist on npm (this is the one that directly prevents 2.2.0's failure mode)
5. `npm pack` → record sha1 → `npm publish <tarball> --provenance` → `npm view dist.shasum` → fail on mismatch
6. Tarball uploaded as 90-day workflow artifact for post-mortems

**Documentation**
- `CLAUDE.md` — new "Release procedure" section codifying PR → CI-green → merge → tag → CI publishes as the only path. Explicit "no local `npm publish`" rule.
- `CHANGELOG.md` [2.2.1] — describes the layered defense + post-mortem framing.

## Test plan

- [x] Local `node scripts/require-ci.js` exits 1 with the expected error
- [x] Local `CI=true GITHUB_ACTIONS=true node scripts/require-ci.js` passes
- [x] `npm run build` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test:run` — 632/632 passing
- [x] `bash scripts/check-architecture.sh` — clean
- [x] `npm pack --dry-run` — packs 2.2.1
- [x] Coverage pre-push hook — 58.88% (threshold 50%) ✓
- [ ] CI passes on this PR (pending)
- [ ] Post-merge, push `v2.2.1` tag; verify all four publish-workflow preflights run; verify post-publish shasum verification succeeds

## Reviewer checklist

- [ ] Does the publish workflow fail-closed on every preflight? (i.e. missing `gh` token, missing CI run, mismatched tag — all should exit 1, not silently pass)
- [ ] Is `id-token: write` still present in `publish.yml` permissions? (required for provenance OIDC)
- [ ] Any concern with the post-publish shasum-polling loop (6 × 3s = 18s max)?
- [ ] Release procedure in `CLAUDE.md` — anything missing?

## Next steps after merge

1. Configure branch protection on `main` in the GitHub UI (require PR, require `CI` check, require up-to-date, no force-push).
2. Configure tag protection rule on `v*` in the GitHub UI.
3. Tag `v2.2.1` on main.
4. Create GitHub Release from the tag → publish workflow runs with all new guards.
5. Verify 2.2.1 lands on npm with provenance badge.
6. Resume Phase 10h.5.0 (top-level filter) on the waiting `feat/10h-5-0-top-level-filter` branch.