### PR TITLE
feat: 10h.5.0 — bom --filter=top-level drops transitive rows while preserving rollup

### DIFF
--- a/src/analyzers/bom/gather.ts
+++ b/src/analyzers/bom/gather.ts
@@ -233,6 +233,15 @@ function buildEntry(
   // Pick the first non-empty `upgradeAdvice` from any finding; fall
   // back to derived advice when all vulns are Tier-1 only.
   const tieredAdvice = vulns.map((v) => v.upgradeAdvice).find((a) => a && a.length > 0);
+  // For vuln-only synthetic rows (no LicenseFinding), treat the
+  // package as top-level iff any finding lists itself in topLevelDep
+  // or has no transitive attribution. Prevents the filter from
+  // dropping pure-vuln rows silently on packs where licenses are
+  // missing (e.g. workspace sub-packages pre-10h.5.0b).
+  let isTopLevel = lic.isTopLevel;
+  if (isTopLevel === undefined && !joinedFromBoth && vulns.length > 0) {
+    isTopLevel = vulns.some((v) => !v.topLevelDep || v.topLevelDep.includes(lic.package));
+  }
   return {
     package: lic.package,
     version: lic.version,
@@ -246,5 +255,6 @@ function buildEntry(
     maxSeverity: maxSeverityOf(vulns),
     upgradeAdvice: tieredAdvice ?? deriveTier1Resolution(vulns),
     joinedFromBoth,
+    isTopLevel,
   };
 }

--- a/src/analyzers/bom/index.ts
+++ b/src/analyzers/bom/index.ts
@@ -22,16 +22,36 @@ import type { BomEntry, BomReport, BomSeverity } from './types';
 
 export type { BomReport, BomEntry } from './types';
 
+export type BomFilter = 'all' | 'top-level';
+
 export interface AnalyzeBomOptions {
   verbose?: boolean;
+  /** Row filter. `'all'` emits every package (default, no behavior change).
+   *  `'top-level'` keeps only direct manifest deps; `byTopLevelDep`
+   *  (which attributes transitive advisories to their parent) is
+   *  computed on the unfiltered set so the rollup still answers
+   *  "upgrading @loopback/cli resolves 29 advisories" even when the
+   *  29 transitive rows themselves are hidden. Entries with
+   *  `isTopLevel === false` are dropped; `undefined` passes through. */
+  filter?: BomFilter;
 }
 
 export async function analyzeBom(
   repoPath: string,
-  _options: AnalyzeBomOptions = {},
+  options: AnalyzeBomOptions = {},
 ): Promise<BomReport> {
   const stack = detect(repoPath);
-  const { entries, toolsUsed, toolsUnavailable } = await gatherBomEntries(repoPath);
+  const { entries: rawEntries, toolsUsed, toolsUnavailable } = await gatherBomEntries(repoPath);
+
+  // byTopLevelDep must be built from the full entry set so the rollup
+  // continues to reflect the complete blast radius of upgrading each
+  // top-level dep — independent of whether the user requested the
+  // filtered row view.
+  const byTopLevelDep = buildByTopLevelDep(rawEntries);
+
+  const filter: BomFilter = options.filter ?? 'all';
+  const entries =
+    filter === 'top-level' ? rawEntries.filter((e) => e.isTopLevel !== false) : rawEntries;
 
   const bySeverity: Record<BomSeverity, number> = { critical: 0, high: 0, medium: 0, low: 0 };
   let vulnerablePackages = 0;
@@ -61,7 +81,9 @@ export async function analyzeBom(
       actionableVulns,
       totalAdvisories,
       vulnOnlyPackages,
-      byTopLevelDep: buildByTopLevelDep(entries),
+      byTopLevelDep,
+      filter,
+      unfilteredTotalPackages: rawEntries.length,
     },
     entries,
     toolsUsed,
@@ -92,7 +114,15 @@ export function formatBomReport(report: BomReport, elapsed: string): string {
   const s = report.summary;
   L.push('## Summary');
   L.push('');
-  L.push(`**${s.totalPackages} packages** indexed across the active language pack(s).`);
+  if (s.filter === 'top-level') {
+    L.push(
+      `**${s.totalPackages} top-level packages** (of ${s.unfilteredTotalPackages} installed) across the active language pack(s). ` +
+        `Transitive rows are hidden; the advisory rollup under "Top-Level Dep Groups" ` +
+        `still reflects the full blast radius.`,
+    );
+  } else {
+    L.push(`**${s.totalPackages} packages** indexed across the active language pack(s).`);
+  }
   L.push('');
   if (s.vulnerablePackages > 0) {
     L.push(

--- a/src/analyzers/bom/types.ts
+++ b/src/analyzers/bom/types.ts
@@ -46,6 +46,14 @@ export interface BomEntry {
    *  the license tool missed; surfaced in the detailed report so the
    *  user can decide whether to trust the license=UNKNOWN row. */
   joinedFromBoth: boolean;
+
+  /** True when this package is a root manifest dep (direct or dev-dep).
+   *  False when definitely transitive. Undefined when the language
+   *  pack couldn't determine it (missing lockfile / manifest parse
+   *  failure). `analyzeBom({ filter: 'top-level' })` drops rows where
+   *  this is `false` — undefined passes through so degraded gathers
+   *  don't accidentally filter the whole report down to zero. */
+  isTopLevel?: boolean;
 }
 
 /**
@@ -95,8 +103,18 @@ export interface BomReport {
     /** Snyk-style upgrade-oriented grouping: per-top-level-dep rollup
      *  built from `vulns[].topLevelDep`. Empty when no findings carry
      *  topLevelDep attribution (e.g. pre-10h.4 packs or projects
-     *  without a parseable dep graph). */
+     *  without a parseable dep graph). Always computed on the
+     *  unfiltered entry set so the rollup reflects full blast radius
+     *  even when the caller requested `filter: 'top-level'`. */
     byTopLevelDep: Record<string, BomTopLevelRollup>;
+    /** Which row filter was applied. Defaults to `'all'` (no filter).
+     *  `'top-level'` drops `BomEntry.isTopLevel === false` rows. */
+    filter: 'all' | 'top-level';
+    /** Total package count in the unfiltered entry set. Equals
+     *  `totalPackages` when `filter === 'all'`; equals the pre-filter
+     *  row count otherwise, so the header can show "120 of 1371
+     *  (filter=top-level)." */
+    unfilteredTotalPackages: number;
   };
   entries: ReadonlyArray<BomEntry>;
   toolsUsed: string[];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,8 @@ function printUsage(): void {
     --detailed   Also write <name>-detailed.md + .json with evidence + ranked actions
     --xlsx       Licenses/bom: also write 15-col BOM XLSX
     --since      Dev-report: start date (YYYY-MM-DD)
+    --filter     Bom: 'all' (default) or 'top-level' (keeps only root manifest deps;
+                 advisory rollup under byTopLevelDep still reflects transitives)
 
   ${logger.bold('Examples:')}
     npx vyuh-dxkit init                  # Interactive
@@ -83,6 +85,7 @@ export async function run(argv: string[]): Promise<void> {
       detailed: { type: 'boolean', default: false },
       output: { type: 'string', short: 'o' },
       xlsx: { type: 'boolean', default: false },
+      filter: { type: 'string' },
     },
     allowPositionals: true,
     strict: false,
@@ -647,8 +650,14 @@ export async function run(argv: string[]): Promise<void> {
       const { analyzeBom, formatBomReport } = await import('./analyzers/bom');
       logger.header('vyuh-dxkit bom');
       logger.info(`Analyzing ${targetPath}...`);
+      const rawFilter = values.filter;
+      if (rawFilter !== undefined && rawFilter !== 'all' && rawFilter !== 'top-level') {
+        logger.fail(`Invalid --filter value: ${rawFilter}. Expected 'all' or 'top-level'.`);
+        process.exit(1);
+      }
+      const filter = rawFilter as 'all' | 'top-level' | undefined;
       const startTime = Date.now();
-      const report = await analyzeBom(targetPath, { verbose: !!values.verbose });
+      const report = await analyzeBom(targetPath, { verbose: !!values.verbose, filter });
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 
       if (values.json) {
@@ -656,7 +665,14 @@ export async function run(argv: string[]): Promise<void> {
       } else {
         const s = report.summary;
         console.log(''); // slop-ok
-        console.log(`  ${logger.bold('Packages indexed:')} ${s.totalPackages}`); // slop-ok
+        if (s.filter === 'top-level') {
+          console.log(
+            // slop-ok
+            `  ${logger.bold('Packages indexed:')} ${s.totalPackages} of ${s.unfilteredTotalPackages} (filter=top-level)`,
+          );
+        } else {
+          console.log(`  ${logger.bold('Packages indexed:')} ${s.totalPackages}`); // slop-ok
+        }
         console.log(
           // slop-ok
           `  ${logger.bold('Vulnerable packages:')} ${s.vulnerablePackages} ` +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -666,10 +666,8 @@ export async function run(argv: string[]): Promise<void> {
         const s = report.summary;
         console.log(''); // slop-ok
         if (s.filter === 'top-level') {
-          console.log(
-            // slop-ok
-            `  ${logger.bold('Packages indexed:')} ${s.totalPackages} of ${s.unfilteredTotalPackages} (filter=top-level)`,
-          );
+          // prettier-ignore
+          console.log(`  ${logger.bold('Packages indexed:')} ${s.totalPackages} of ${s.unfilteredTotalPackages} (filter=top-level)`); // slop-ok
         } else {
           console.log(`  ${logger.bold('Packages indexed:')} ${s.totalPackages}`); // slop-ok
         }

--- a/src/languages/capabilities/types.ts
+++ b/src/languages/capabilities/types.ts
@@ -171,6 +171,12 @@ export interface LicenseFinding {
   supplier?: string;
   /** ISO 8601 release date; present when the registry exposes it. */
   releaseDate?: string;
+  /** True when this package is a root manifest dep (direct or dev-dep) as
+   *  opposed to a transitive. Populated per-pack by the same root-manifest
+   *  parse that seeds `buildXxxTopLevelDepIndex`. Unset when the pack
+   *  can't read the manifest/lockfile — the bom filter treats unset as
+   *  "don't know" and passes the row through rather than dropping it. */
+  isTopLevel?: boolean;
 }
 
 /**

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -767,10 +767,18 @@ function gatherCsharpLicensesResult(cwd: string): LicensesResult | null {
   }
   if (!Array.isArray(data)) return null;
 
+  // Top-level attribution reuses project.assets.json via
+  // loadCsharpTopLevelDepIndex. Same self-parent invariant as the
+  // other packs. Missing assets-json (user hasn't run dotnet restore)
+  // leaves isTopLevel unset.
+  const topLevelIndex = loadCsharpTopLevelDepIndex(cwd);
+  const hasIndex = topLevelIndex.size > 0;
+
   const findings: LicenseFinding[] = [];
   for (const entry of data) {
     if (!entry.PackageId || !entry.PackageVersion) continue;
     const license = entry.License && entry.License.length > 0 ? entry.License : 'UNKNOWN';
+    const parents = hasIndex ? topLevelIndex.get(entry.PackageId) : undefined;
     findings.push({
       package: entry.PackageId,
       version: entry.PackageVersion,
@@ -782,6 +790,7 @@ function gatherCsharpLicensesResult(cwd: string): LicensesResult | null {
       description:
         entry.Description && entry.Description.length > 0 ? entry.Description : undefined,
       supplier: entry.Authors && entry.Authors.length > 0 ? entry.Authors : undefined,
+      isTopLevel: hasIndex ? (parents?.includes(entry.PackageId) ?? false) : undefined,
     });
   }
 

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -660,19 +660,25 @@ function parseGoListModuleStream(raw: string): GoListModule[] {
 }
 
 /**
- * Find the module whose path is the longest prefix of a Go package path,
- * returning its version. go-licenses reports at the package level
- * (`github.com/x/y/subpkg`) while `go list -m all` reports at the module
- * level (`github.com/x/y`); longest-prefix match bridges the two.
+ * Find the module whose path is the longest prefix of a Go package path.
+ * go-licenses reports at the package level (`github.com/x/y/subpkg`)
+ * while module-keyed maps (go list -m all, the top-level index) key on
+ * module paths (`github.com/x/y`); longest-prefix match bridges the two.
+ * Returns an empty string when no module prefixes the package.
  */
-function goVersionForPackage(pkgPath: string, modules: Map<string, string>): string {
+function goModuleForPackage(pkgPath: string, modules: Iterable<string>): string {
   let best = '';
-  for (const mod of modules.keys()) {
+  for (const mod of modules) {
     if ((pkgPath === mod || pkgPath.startsWith(mod + '/')) && mod.length > best.length) {
       best = mod;
     }
   }
-  return modules.get(best) ?? '';
+  return best;
+}
+
+function goVersionForPackage(pkgPath: string, modules: Map<string, string>): string {
+  const mod = goModuleForPackage(pkgPath, modules.keys());
+  return modules.get(mod) ?? '';
 }
 
 /**
@@ -705,6 +711,12 @@ function gatherGoLicensesResult(cwd: string): LicensesResult | null {
     }
   }
 
+  // go-licenses reports packages (`github.com/x/y/subpkg`); the top-level
+  // index keys modules (`github.com/x/y`). Project the CSV row's package
+  // path down to its owning module, then check the self-parent invariant.
+  const topLevelIndex = loadGoTopLevelDepIndex(cwd);
+  const hasIndex = topLevelIndex.size > 0;
+
   const findings: LicenseFinding[] = [];
   for (const line of csvRaw.split('\n')) {
     const trimmed = line.trim();
@@ -714,11 +726,18 @@ function gatherGoLicensesResult(cwd: string): LicensesResult | null {
     const pkg = parts[0].trim();
     const url = parts[1].trim();
     const license = parts[2].trim();
+    let isTopLevel: boolean | undefined;
+    if (hasIndex) {
+      const mod = goModuleForPackage(pkg, topLevelIndex.keys());
+      const parents = mod ? topLevelIndex.get(mod) : undefined;
+      isTopLevel = mod ? (parents?.includes(mod) ?? false) : false;
+    }
     findings.push({
       package: pkg,
       version: goVersionForPackage(pkg, versions),
       licenseType: license || 'UNKNOWN',
       sourceUrl: url || undefined,
+      isTopLevel,
     });
   }
 

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -701,10 +701,18 @@ function gatherPyLicensesResult(cwd: string): LicensesResult | null {
   }
   if (!Array.isArray(data)) return null;
 
+  // Top-level attribution reuses the same pip-show-graph BFS the
+  // depVulns path builds. Self-parent invariant (`index[top]` contains
+  // `top`) classifies every row without a second `pip show` pass.
+  // Empty index (pip tools missing, venv gone) leaves isTopLevel unset.
+  const topLevelIndex = loadPyTopLevelDepIndex(cwd);
+  const hasIndex = topLevelIndex.size > 0;
+
   const findings: LicenseFinding[] = [];
   for (const entry of data) {
     if (!entry.Name || !entry.Version) continue;
     const licenseType = entry.License && entry.License !== 'UNKNOWN' ? entry.License : 'UNKNOWN';
+    const parents = hasIndex ? topLevelIndex.get(entry.Name) : undefined;
     findings.push({
       package: entry.Name,
       version: entry.Version,
@@ -715,6 +723,7 @@ function gatherPyLicensesResult(cwd: string): LicensesResult | null {
       description:
         entry.Description && entry.Description !== 'UNKNOWN' ? entry.Description : undefined,
       supplier: entry.Author && entry.Author !== 'UNKNOWN' ? entry.Author : undefined,
+      isTopLevel: hasIndex ? (parents?.includes(entry.Name) ?? false) : undefined,
     });
   }
 

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -624,9 +624,18 @@ function gatherRustLicensesResult(cwd: string): LicensesResult | null {
   }
   if (!Array.isArray(data)) return null;
 
+  // Same self-parent invariant as the other packs: cargo metadata's
+  // resolve graph seeds BFS from each direct dep, so `index[top]`
+  // always contains `top`. Empty index (cargo missing, not a
+  // workspace) leaves isTopLevel unset — the bom filter will pass
+  // the row through rather than guess.
+  const topLevelIndex = loadRustTopLevelDepIndex(cwd);
+  const hasIndex = topLevelIndex.size > 0;
+
   const findings: LicenseFinding[] = [];
   for (const entry of data) {
     if (!entry.name || !entry.version) continue;
+    const parents = hasIndex ? topLevelIndex.get(entry.name) : undefined;
     findings.push({
       package: entry.name,
       version: entry.version,
@@ -634,6 +643,7 @@ function gatherRustLicensesResult(cwd: string): LicensesResult | null {
       sourceUrl: entry.repository || undefined,
       description: entry.description || undefined,
       supplier: entry.authors || undefined,
+      isTopLevel: hasIndex ? (parents?.includes(entry.name) ?? false) : undefined,
     });
   }
 

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -806,6 +806,16 @@ function gatherTsLicensesResult(cwd: string): LicensesResult | null {
     return null;
   }
 
+  // Load the top-level index once and project it down to `isTopLevel`
+  // per finding. The self-parent invariant — `index[top]` always
+  // contains `top` itself, because BFS starts from each top-level —
+  // is the cheapest signal; checking `parents.includes(pkg)` classifies
+  // every row without a second manifest parse. Empty index (missing
+  // lockfile, unparsable JSON) leaves isTopLevel unset so the bom
+  // filter passes the row through rather than guessing wrong.
+  const topLevelIndex = loadTsTopLevelDepIndex(cwd);
+  const hasIndex = topLevelIndex.size > 0;
+
   const findings: LicenseFinding[] = [];
   for (const [key, entry] of Object.entries(data)) {
     const split = splitTsLicenseCheckerKey(key);
@@ -825,6 +835,7 @@ function gatherTsLicensesResult(cwd: string): LicensesResult | null {
     }
 
     const meta = readTsPackageMetadata(cwd, split.package);
+    const parents = hasIndex ? topLevelIndex.get(split.package) : undefined;
     findings.push({
       package: split.package,
       version: split.version,
@@ -836,6 +847,7 @@ function gatherTsLicensesResult(cwd: string): LicensesResult | null {
       sourceUrl: normalizeRepoUrl(meta.repositoryUrl || entry.repository || entry.url),
       description: meta.description,
       supplier: entry.publisher,
+      isTopLevel: hasIndex ? (parents?.includes(split.package) ?? false) : undefined,
     });
   }
 

--- a/test/bom-gather.test.ts
+++ b/test/bom-gather.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   buildByTopLevelDep,
   compareSemver,
@@ -165,3 +165,84 @@ describe('buildByTopLevelDep', () => {
     expect(result['@loopback/cli'].packages).toEqual(['tar']);
   });
 });
+
+describe('analyzeBom filter', () => {
+  // Pure-ish integration test: mock gatherBomEntries to return a
+  // hand-crafted set, then verify filter='top-level' drops the
+  // expected rows while the byTopLevelDep rollup stays complete.
+  it('keeps isTopLevel=true and undefined, drops isTopLevel=false', async () => {
+    vi.resetModules();
+    vi.doMock('../src/analyzers/bom/gather', async () => {
+      const actual = await vi.importActual<typeof import('../src/analyzers/bom/gather')>(
+        '../src/analyzers/bom/gather',
+      );
+      return {
+        ...actual,
+        gatherBomEntries: vi.fn(async () => ({
+          entries: [
+            mkEntry('react', true),
+            mkEntry('@types/react', true),
+            mkEntry('lodash', false, [
+              {
+                id: 'CVE-X',
+                package: 'lodash',
+                tool: 't',
+                severity: 'high',
+                topLevelDep: ['react'],
+              },
+            ]),
+            mkEntry('minimatch', false, [
+              {
+                id: 'CVE-Y',
+                package: 'minimatch',
+                tool: 't',
+                severity: 'critical',
+                topLevelDep: ['react'],
+              },
+            ]),
+            mkEntry('unknown-origin', undefined),
+          ],
+          toolsUsed: ['test'],
+          toolsUnavailable: [],
+        })),
+      };
+    });
+    const { analyzeBom } = await import('../src/analyzers/bom');
+    const reportAll = await analyzeBom('/tmp/fake-repo');
+    const reportTop = await analyzeBom('/tmp/fake-repo', { filter: 'top-level' });
+
+    expect(reportAll.summary.filter).toBe('all');
+    expect(reportAll.summary.totalPackages).toBe(5);
+    expect(reportAll.summary.unfilteredTotalPackages).toBe(5);
+
+    expect(reportTop.summary.filter).toBe('top-level');
+    expect(reportTop.summary.totalPackages).toBe(3); // react, @types/react, unknown-origin
+    expect(reportTop.summary.unfilteredTotalPackages).toBe(5);
+    const keptNames = reportTop.entries.map((e) => e.package).sort();
+    expect(keptNames).toEqual(['@types/react', 'react', 'unknown-origin']);
+
+    // byTopLevelDep must reflect the full blast radius on both reports —
+    // transitive advisories attribute to 'react' even when the
+    // transitive rows themselves are hidden by the filter.
+    expect(reportTop.summary.byTopLevelDep['react'].advisoryCount).toBe(2);
+    expect(reportTop.summary.byTopLevelDep['react'].packages).toEqual(['lodash', 'minimatch']);
+    vi.doUnmock('../src/analyzers/bom/gather');
+  });
+});
+
+function mkEntry(
+  pkg: string,
+  isTopLevel: boolean | undefined,
+  vulns: DepVulnFinding[] = [],
+): BomEntry {
+  return {
+    package: pkg,
+    version: '1.0.0',
+    licenseType: 'MIT',
+    vulns,
+    maxSeverity: vulns.length > 0 ? vulns[0].severity : null,
+    upgradeAdvice: '',
+    joinedFromBoth: true,
+    isTopLevel,
+  };
+}


### PR DESCRIPTION
## Summary

First sub-commit in Phase 10h.5 — turns `vyuh-dxkit bom` from enumeration into a decision doc. On vyuhlabs-platform the row count collapses 1730 → 145 while the `byTopLevelDep` rollup still answers "upgrading @loopback/cli resolves 29 advisories." No behavior change for existing callers; filter defaults to `all`.

## What changed

### `LicenseFinding.isTopLevel?: boolean`

Populated per-pack from the same manifest-parse logic that seeds `buildXxxTopLevelDepIndex`. Every pack shares a self-parent invariant (`index[top]` always contains `top`), so classification is a three-line lookup — no second manifest parse.

| Pack | Source |
|---|---|
| TypeScript | `package-lock.json` v2/v3 `packages[''].dependencies` + `devDependencies` |
| Python | `pip show` graph (`Required-by` empty → top-level) |
| Go | `go mod graph` + `go.mod`'s non-indirect direct deps (longest-prefix module match bridges the package ↔ module granularity gap) |
| Rust | `cargo metadata --format-version 1` resolve graph from `resolve.root` |
| C# | `obj/project.assets.json` `project.frameworks[fw].dependencies` |

All 5 degrade gracefully: no lockfile / parse failure → `isTopLevel` stays unset, and the filter passes the row through rather than guessing.

### `AnalyzeBomOptions.filter: 'all' | 'top-level'`

- `'all'` (default): no-op — every call site pre-10h.5.0 keeps the same behavior.
- `'top-level'`: drops rows where `isTopLevel === false`. `undefined` passes through.
- `byTopLevelDep` rollup stays computed on the **unfiltered** entry set so the blast-radius answer ("upgrading `@loopback/cli` kills 29 advisories") survives when those 29 transitive rows are hidden.

### Report shape additions

- `BomEntry.isTopLevel?: boolean`
- `BomReport.summary.filter: 'all' | 'top-level'`
- `BomReport.summary.unfilteredTotalPackages` (pre-filter count)

### Renderers

- **CLI**: `Packages indexed: 145 of 1730 (filter=top-level)`
- **Markdown**: top-of-summary callout — "Transitive rows are hidden; rollup still reflects full blast radius"
- **xlsx**: consumes `report.entries` which is already filtered → no code change needed

## Validation

- [x] 633 tests passing (+1 `analyzeBom filter` integration test)
- [x] Typecheck clean, lint clean, format clean
- [x] Architecture rules pass
- [x] Platform benchmark: 1730 → 145 rows (91.6% reduction); `byTopLevelDep['@loopback/cli'] = 29` preserved; `byTopLevelDep` has 42 keys in both filtered and unfiltered views
- [x] Self-dogfood (dxkit): 325 → 17 rows

## Reviewer checklist

- [ ] `LicenseFinding.isTopLevel` population looks right for each pack
- [ ] Go's `goModuleForPackage` longest-prefix logic correct (module/package granularity gap)
- [ ] `vuln-only` synthetic rows in `buildEntry` — sensible isTopLevel fallback?
- [ ] Filter semantics (drop `false`, pass `undefined` through) worth flagging as a call-out in release notes later?

## Next after merge

- 10h.5.0b (workspace sub-package attribution — closes D001 dotenv gap)
- 10h.5.1 (EPSS enricher)
- Then 10h.5.2–.5 (KEV, reachability, risk score, exec summary)

No version bump in this PR — 2.3.0 ships after the full 10h.5 batch lands.