### PR TITLE
fix: husky hooks — lint-staged before gates, pre-push mirrors CI

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,13 @@
-bash scripts/check-architecture.sh && bash scripts/check-slop.sh && npx lint-staged && npm run typecheck
+# Order matters: `lint-staged` runs Prettier (+ ESLint --fix) and
+# re-stages the reformatted files. If slop/architecture/typecheck
+# ran first, Prettier could re-introduce a violation AFTER the gate
+# already passed, and the commit would land dirty (this is what
+# happened on feat/10h-5-0-top-level-filter — a `// slop-ok`
+# same-line marker was split by Prettier into a multi-line call
+# and the bare `console.log(` line survived the gate because the
+# gate ran before Prettier). Keeping `lint-staged` first means the
+# gates see the *final* staged state, not a pre-format snapshot.
+npx lint-staged \
+  && bash scripts/check-architecture.sh \
+  && bash scripts/check-slop.sh \
+  && npm run typecheck

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,9 +1,27 @@
-# Build, run the unit suite with coverage, enforce threshold.
+# Mirror the CI gates locally so `git push` fails fast on anything
+# CI would also fail on, instead of finding out 40s later in the PR
+# check. The set below matches `.github/workflows/ci.yml` step-for-step
+# (minus the pack-dry-run smoke, which is covered by prepublishOnly
+# at release time and rarely regresses between commits).
+#
 # Integration tests live under test/integration/ and run via
 # `npm run test:integration` (or in CI) — too slow for every push.
 #
 # Coverage threshold reflects the full unit suite, not --changed scope,
 # so the number is meaningful (a partial run would underreport).
+
+# Fast static gates — fail before burning time on build/tests.
+npm run typecheck
+npx eslint . --max-warnings 0
+npx prettier --check .
+bash scripts/check-architecture.sh
+
+# Slop check against the push target. Matches the CI step's
+# DXKIT_SLOP_BASE=origin/main range-diff so no PR can surface slop
+# that `git push` didn't already surface locally.
+DXKIT_SLOP_BASE=origin/main bash scripts/check-slop.sh
+
+# Build + unit tests with coverage, coverage threshold.
 npm run build
 npx vitest run --coverage
 bash scripts/check-coverage.sh


### PR DESCRIPTION
## Summary

Closes the hook gap exposed on PR #2: pre-commit let a Prettier-introduced slop violation survive into a push because the slop gate ran on a *pre-format* snapshot. CI caught it, pre-commit didn't.

## Root cause

`.husky/pre-commit` ran gates **before** `lint-staged`:

```bash
# Before
bash scripts/check-architecture.sh \
  && bash scripts/check-slop.sh \
  && npx lint-staged \           # <- Prettier runs AFTER gates
  && npm run typecheck
```

So if Prettier reformatted a file (e.g. wrapped a `// slop-ok` marker onto the next line, leaving the bare `console.log(` line un-annotated), the gates had already passed against the pre-format state — the commit landed dirty.

Additionally, `.husky/pre-push` only ran `build + vitest + coverage`. It missed slop, lint, format, architecture — all of which CI runs. A push could fail CI on something the local hook could have caught 40 seconds earlier.

## Fix

- **Pre-commit** — `lint-staged` first, then gates. Gates now see the final, post-Prettier staged state.
- **Pre-push** — mirrors `.github/workflows/ci.yml` step-for-step: typecheck, eslint `--max-warnings 0`, `prettier --check`, architecture rules, slop check (vs `origin/main`), build, vitest coverage, coverage threshold. Local `git push` fails fast on anything CI would fail on.

## Validation

- [x] Pre-push ran locally, all gates passed green
- [x] This PR itself pushed via the new pre-push — dogfood
- [ ] CI on this PR (pending)

## Why this matters

The v2.2.0 incident + D015 hardening codified "no local publish". This PR extends that discipline to the inner loop: **what CI enforces, the local hook enforces too, at the earliest responsible stage**. No more push-CI-fail-push round trips for issues the hook chain can catch.