### PR TITLE
feat: 10h.5.0b — bom nested-project aggregation (D001a)

### DIFF
--- a/src/analyzers/bom/discovery.ts
+++ b/src/analyzers/bom/discovery.ts
@@ -1,0 +1,131 @@
+/**
+ * Project-root discovery for nested BOM aggregation.
+ *
+ * `vyuh-dxkit bom <path>` historically scanned `<path>` as a single
+ * project root. Repos like `vyuhlabs-platform/` (root devtools +
+ * `userserver/` product) fell through the cracks — the scanner saw
+ * only whichever `package.json`/lockfile lived at `<path>`, missing
+ * every sibling or nested sub-project. See D001a in the internal
+ * defect log for the incident write-up.
+ *
+ * This module walks the filesystem starting at cwd and returns every
+ * directory that looks like an independent project root (i.e. has any
+ * language manifest, regardless of whether a parent also does). The
+ * BOM analyzer then runs the existing per-root gather against each
+ * and merges the results.
+ *
+ * Why a hardcoded skip-set rather than `exclusions.ts`: this is a
+ * structural traversal, not a gitignore-based code scan. `exclusions.ts`
+ * is tuned for "which files does the user consider source code?" and
+ * pulls in `.gitignore` rules that would incorrectly hide sibling
+ * projects (e.g. `.gitignore: dist/` would skip a sub-project under
+ * `dist/` even though it might legitimately be a shippable artifact
+ * the user wants inventoried).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** File basenames that mark a directory as a project root. */
+const MANIFEST_BASENAMES: ReadonlySet<string> = new Set([
+  'package.json', // Node
+  'pyproject.toml', // Python (PEP 621 / poetry)
+  'requirements.txt', // Python (pip)
+  'setup.py', // Python (legacy)
+  'Pipfile', // Python (pipenv)
+  'go.mod', // Go
+  'Cargo.toml', // Rust
+]);
+
+/** File extensions that mark a directory as a project root. */
+const MANIFEST_EXTENSIONS: ReadonlyArray<string> = [
+  '.csproj', // C# project
+  '.sln', // C# solution
+];
+
+/**
+ * Directories we never descend into during discovery.
+ *
+ *   - Dependency trees (`node_modules`, `vendor`, `venv`, `.venv`,
+ *     `target`, `bin`, `obj`): contain manifests from installed
+ *     packages, not user projects.
+ *   - Build output (`dist`, `build`, `out`, `.next`, `.turbo`,
+ *     `.cache`): derived, not source-of-truth.
+ *   - VCS / tool metadata (`.git`, `.svn`, `.hg`): never has
+ *     meaningful manifests.
+ *
+ * Any dotfile directory is also skipped — caches, IDE state, etc.
+ */
+const SKIP_DIR_BASENAMES: ReadonlySet<string> = new Set([
+  'node_modules',
+  'vendor',
+  'venv',
+  '.venv',
+  'target',
+  'bin',
+  'obj',
+  'dist',
+  'build',
+  'out',
+  '.next',
+  '.turbo',
+  '.cache',
+  '.git',
+  '.svn',
+  '.hg',
+  'TestResults',
+  'packages',
+]);
+
+/** Default depth cap: enough for `packages/foo/sub`, excess discouraged. */
+const DEFAULT_MAX_DEPTH = 4;
+
+/**
+ * Walk `cwd` and return every directory that contains at least one
+ * language manifest. Always includes `cwd` itself when it has one,
+ * even if nested sub-projects also exist (the aggregator treats all
+ * roots symmetrically and dedupes findings across them).
+ *
+ * Pure over the filesystem: no caching, no side effects beyond
+ * filesystem reads. Returns absolute paths, sorted alphabetically
+ * for deterministic output.
+ *
+ * Exported for unit tests.
+ */
+export function discoverProjectRoots(cwd: string, maxDepth: number = DEFAULT_MAX_DEPTH): string[] {
+  const roots = new Set<string>();
+  walk(cwd, 0, maxDepth, roots);
+  return [...roots].sort();
+}
+
+function walk(dir: string, depth: number, maxDepth: number, roots: Set<string>): void {
+  if (depth > maxDepth) return;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  let isRoot = false;
+  for (const e of entries) {
+    if (!e.isFile()) continue;
+    if (MANIFEST_BASENAMES.has(e.name)) {
+      isRoot = true;
+      break;
+    }
+    if (MANIFEST_EXTENSIONS.some((ext) => e.name.endsWith(ext))) {
+      isRoot = true;
+      break;
+    }
+  }
+  if (isRoot) roots.add(dir);
+
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    if (SKIP_DIR_BASENAMES.has(e.name)) continue;
+    // Skip dotfile directories (caches, IDE state) except the repo root's own.
+    if (e.name.startsWith('.') && depth > 0) continue;
+    walk(path.join(dir, e.name), depth + 1, maxDepth, roots);
+  }
+}

--- a/src/analyzers/bom/gather.ts
+++ b/src/analyzers/bom/gather.ts
@@ -139,6 +139,100 @@ export interface BomGatherResult {
   entries: BomEntry[];
   toolsUsed: string[];
   toolsUnavailable: string[];
+  /** Cwd-relative project-root paths the gather walked. Length 1 for
+   *  single-root scans ("." ); length >1 for nested aggregation. */
+  projectRoots: string[];
+}
+
+/**
+ * Merge per-root gather results into one deduplicated set.
+ *
+ * Dedupe key is `(package, version)` — the same logical package at
+ * the same version installed under two roots is the same artifact,
+ * so reporting two rows would be noise. When the same key appears
+ * under multiple roots:
+ *
+ *   - `sources` unions the sub-paths
+ *   - `isTopLevel` OR-merges — if any root treats the package as
+ *     top-level, the merged entry is top-level (upgrade decisions
+ *     surface under Top-Level Dep Groups)
+ *   - `vulns` unions with dedup on `(id, package, installedVersion)`
+ *     — the same advisory reported from two roots collapses into
+ *     one finding but its `topLevelDep` list unions
+ *   - license metadata (licenseType, sourceUrl, etc.) prefers the
+ *     first root with non-UNKNOWN data, falling back to whatever
+ *     the first-seen entry carried
+ *
+ * Pure function; unit-testable without filesystem.
+ */
+export function mergeNestedBomEntries(
+  perRoot: ReadonlyArray<{ relPath: string; result: BomGatherResult }>,
+): BomGatherResult {
+  const byKey = new Map<string, BomEntry>();
+  const toolsUsed = new Set<string>();
+  const toolsUnavailable = new Set<string>();
+  const projectRoots = new Set<string>();
+
+  for (const { relPath, result } of perRoot) {
+    for (const t of result.toolsUsed) toolsUsed.add(t);
+    for (const t of result.toolsUnavailable) toolsUnavailable.add(t);
+    projectRoots.add(relPath);
+
+    for (const e of result.entries) {
+      const key = `${e.package}@${e.version}`;
+      const existing = byKey.get(key);
+      if (!existing) {
+        byKey.set(key, { ...e, sources: [relPath] });
+        continue;
+      }
+      // Union sources
+      existing.sources = [...new Set([...(existing.sources ?? []), relPath])].sort();
+      // OR-merge isTopLevel (any-root-top-level wins; undefined is
+      // ignored so a degraded pack doesn't mask a definitive true).
+      if (e.isTopLevel === true) existing.isTopLevel = true;
+      // Prefer non-UNKNOWN license metadata from later roots when the
+      // existing entry came up empty.
+      if (existing.licenseType === 'UNKNOWN' && e.licenseType !== 'UNKNOWN') {
+        existing.licenseType = e.licenseType;
+        existing.licenseText ??= e.licenseText;
+        existing.sourceUrl ??= e.sourceUrl;
+        existing.description ??= e.description;
+        existing.supplier ??= e.supplier;
+        existing.releaseDate ??= e.releaseDate;
+      }
+      // Vuln union with dedup on (id, package, installedVersion).
+      if (e.vulns.length > 0) {
+        const seen = new Set(
+          existing.vulns.map((v) => `${v.id}\0${v.package}\0${v.installedVersion ?? ''}`),
+        );
+        for (const v of e.vulns) {
+          const vkey = `${v.id}\0${v.package}\0${v.installedVersion ?? ''}`;
+          if (seen.has(vkey)) continue;
+          seen.add(vkey);
+          existing.vulns.push(v);
+        }
+        // Re-derive maxSeverity + upgradeAdvice after vuln merge.
+        existing.maxSeverity = maxSeverityOf(existing.vulns);
+        const tieredAdvice = existing.vulns
+          .map((v) => v.upgradeAdvice)
+          .find((a) => a && a.length > 0);
+        existing.upgradeAdvice = tieredAdvice ?? deriveTier1Resolution(existing.vulns);
+      }
+      // joinedFromBoth: once both sides of the join have been seen
+      // anywhere, keep it. Only flips true, never back to false.
+      if (e.joinedFromBoth) existing.joinedFromBoth = true;
+    }
+  }
+
+  const entries = [...byKey.values()].sort(
+    (a, b) => a.package.localeCompare(b.package) || compareSemver(a.version, b.version),
+  );
+  return {
+    entries,
+    toolsUsed: [...toolsUsed],
+    toolsUnavailable: [...toolsUnavailable],
+    projectRoots: [...projectRoots].sort(),
+  };
 }
 
 export async function gatherBomEntries(cwd: string): Promise<BomGatherResult> {
@@ -221,6 +315,7 @@ export async function gatherBomEntries(cwd: string): Promise<BomGatherResult> {
     entries,
     toolsUsed: [...toolsUsed],
     toolsUnavailable: [],
+    projectRoots: ['.'],
   };
 }
 

--- a/src/analyzers/bom/index.ts
+++ b/src/analyzers/bom/index.ts
@@ -17,7 +17,8 @@
 import * as path from 'path';
 import { detect } from '../../detect';
 import { run } from '../tools/runner';
-import { buildByTopLevelDep, gatherBomEntries } from './gather';
+import { discoverProjectRoots } from './discovery';
+import { buildByTopLevelDep, gatherBomEntries, mergeNestedBomEntries } from './gather';
 import type { BomEntry, BomReport, BomSeverity } from './types';
 
 export type { BomReport, BomEntry } from './types';
@@ -34,6 +35,13 @@ export interface AnalyzeBomOptions {
    *  29 transitive rows themselves are hidden. Entries with
    *  `isTopLevel === false` are dropped; `undefined` passes through. */
   filter?: BomFilter;
+  /** When `true` (default), walk the repo and aggregate every sub-project
+   *  root with a language manifest. Closes D001a: `bom platform/` would
+   *  previously miss `platform/userserver/` entirely. Set `false` to
+   *  restore the pre-10h.5.0b root-only behavior (useful when the caller
+   *  has already narrowed to a single project and wants to avoid the
+   *  walk cost / cross-root merge). */
+  nested?: boolean;
 }
 
 export async function analyzeBom(
@@ -41,7 +49,9 @@ export async function analyzeBom(
   options: AnalyzeBomOptions = {},
 ): Promise<BomReport> {
   const stack = detect(repoPath);
-  const { entries: rawEntries, toolsUsed, toolsUnavailable } = await gatherBomEntries(repoPath);
+  const nested = options.nested ?? true;
+  const gatherResult = nested ? await gatherNested(repoPath) : await gatherBomEntries(repoPath);
+  const { entries: rawEntries, toolsUsed, toolsUnavailable, projectRoots } = gatherResult;
 
   // byTopLevelDep must be built from the full entry set so the rollup
   // continues to reflect the complete blast radius of upgrading each
@@ -84,11 +94,36 @@ export async function analyzeBom(
       byTopLevelDep,
       filter,
       unfilteredTotalPackages: rawEntries.length,
+      projectRoots,
     },
     entries,
     toolsUsed,
     toolsUnavailable,
   };
+}
+
+/**
+ * Run gatherBomEntries against every discovered project root and
+ * merge. When only one root is found (single-project repos, the
+ * common case), short-circuits to a normal gather with
+ * `projectRoots: ["."]` — zero overhead beyond the directory walk.
+ */
+async function gatherNested(
+  repoPath: string,
+): Promise<ReturnType<typeof gatherBomEntries> extends Promise<infer T> ? T : never> {
+  const absRoots = discoverProjectRoots(repoPath);
+  if (absRoots.length <= 1) {
+    // No sub-roots discovered (or only cwd itself): fall through to
+    // the non-nested path so the output shape is identical.
+    return gatherBomEntries(repoPath);
+  }
+  const perRoot = await Promise.all(
+    absRoots.map(async (absRoot) => ({
+      relPath: path.relative(repoPath, absRoot) || '.',
+      result: await gatherBomEntries(absRoot),
+    })),
+  );
+  return mergeNestedBomEntries(perRoot);
 }
 
 const SEV_BADGE: Record<BomSeverity, string> = {
@@ -114,6 +149,14 @@ export function formatBomReport(report: BomReport, elapsed: string): string {
   const s = report.summary;
   L.push('## Summary');
   L.push('');
+  if (s.projectRoots.length > 1) {
+    L.push(
+      `**Aggregated across ${s.projectRoots.length} project roots** — ` +
+        s.projectRoots.map((r) => `\`${r}\``).join(', ') +
+        '. Each row unions the roots that installed the package (see `sources`).',
+    );
+    L.push('');
+  }
   if (s.filter === 'top-level') {
     L.push(
       `**${s.totalPackages} top-level packages** (of ${s.unfilteredTotalPackages} installed) across the active language pack(s). ` +

--- a/src/analyzers/bom/types.ts
+++ b/src/analyzers/bom/types.ts
@@ -54,6 +54,17 @@ export interface BomEntry {
    *  this is `false` — undefined passes through so degraded gathers
    *  don't accidentally filter the whole report down to zero. */
   isTopLevel?: boolean;
+
+  /** Cwd-relative paths of the sub-project roots this package was
+   *  found in (e.g. `["."]`, `["userserver"]`, or
+   *  `[".", "userserver", "tools"]`). Populated only when
+   *  `analyzeBom({ nested: true })` discovers more than one root.
+   *  When a package appears under multiple roots (common for shared
+   *  transitives like `lodash`), the sources list unions the
+   *  sub-paths so the reader can see the full blast radius of an
+   *  upgrade. Unset when nested scan was disabled or only one root
+   *  existed. */
+  sources?: string[];
 }
 
 /**
@@ -115,6 +126,11 @@ export interface BomReport {
      *  row count otherwise, so the header can show "120 of 1371
      *  (filter=top-level)." */
     unfilteredTotalPackages: number;
+    /** Cwd-relative paths of every project root the nested scan
+     *  discovered (e.g. `["."]` or `[".", "userserver"]`). Sorted,
+     *  distinct. When nested scan is disabled or only one root was
+     *  found, this is `["."]` so consumers can treat it uniformly. */
+    projectRoots: string[];
   };
   entries: ReadonlyArray<BomEntry>;
   toolsUsed: string[];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,8 @@ function printUsage(): void {
     --since      Dev-report: start date (YYYY-MM-DD)
     --filter     Bom: 'all' (default) or 'top-level' (keeps only root manifest deps;
                  advisory rollup under byTopLevelDep still reflects transitives)
+    --no-nested  Bom: disable nested-project aggregation (default scans the repo
+                 for all sub-projects with manifests and merges their BOMs)
 
   ${logger.bold('Examples:')}
     npx vyuh-dxkit init                  # Interactive
@@ -86,6 +88,7 @@ export async function run(argv: string[]): Promise<void> {
       output: { type: 'string', short: 'o' },
       xlsx: { type: 'boolean', default: false },
       filter: { type: 'string' },
+      'no-nested': { type: 'boolean', default: false },
     },
     allowPositionals: true,
     strict: false,
@@ -656,8 +659,13 @@ export async function run(argv: string[]): Promise<void> {
         process.exit(1);
       }
       const filter = rawFilter as 'all' | 'top-level' | undefined;
+      const nested = !values['no-nested'];
       const startTime = Date.now();
-      const report = await analyzeBom(targetPath, { verbose: !!values.verbose, filter });
+      const report = await analyzeBom(targetPath, {
+        verbose: !!values.verbose,
+        filter,
+        nested,
+      });
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 
       if (values.json) {
@@ -665,6 +673,11 @@ export async function run(argv: string[]): Promise<void> {
       } else {
         const s = report.summary;
         console.log(''); // slop-ok
+        if (s.projectRoots.length > 1) {
+          logger.info(
+            `Aggregated across ${s.projectRoots.length} project roots: ${s.projectRoots.join(', ')}`,
+          );
+        }
         if (s.filter === 'top-level') {
           // prettier-ignore
           console.log(`  ${logger.bold('Packages indexed:')} ${s.totalPackages} of ${s.unfilteredTotalPackages} (filter=top-level)`); // slop-ok

--- a/test/bom-discovery.test.ts
+++ b/test/bom-discovery.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { discoverProjectRoots } from '../src/analyzers/bom/discovery';
+
+describe('discoverProjectRoots', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-discovery-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function write(rel: string, body = '{}'): void {
+    const abs = path.join(tmp, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  }
+
+  function mkdir(rel: string): void {
+    fs.mkdirSync(path.join(tmp, rel), { recursive: true });
+  }
+
+  it('detects the cwd itself as a root when it has a manifest', () => {
+    write('package.json');
+    expect(discoverProjectRoots(tmp)).toEqual([tmp]);
+  });
+
+  it('finds nested sub-projects', () => {
+    write('package.json');
+    write('userserver/package.json');
+    write('tools/cli/package.json');
+    const roots = discoverProjectRoots(tmp);
+    expect(roots).toEqual([tmp, path.join(tmp, 'tools/cli'), path.join(tmp, 'userserver')].sort());
+  });
+
+  it('skips node_modules entirely', () => {
+    write('package.json');
+    write('node_modules/some-dep/package.json'); // should NOT be reported
+    const roots = discoverProjectRoots(tmp);
+    expect(roots).toEqual([tmp]);
+  });
+
+  it('skips build-output and vcs directories', () => {
+    write('package.json');
+    write('dist/package.json');
+    write('target/foo/Cargo.toml');
+    write('obj/Release/bar.csproj');
+    write('.git/package.json');
+    expect(discoverProjectRoots(tmp)).toEqual([tmp]);
+  });
+
+  it('detects multiple languages side-by-side', () => {
+    write('package.json');
+    write('py-tool/pyproject.toml');
+    write('go-svc/go.mod');
+    write('rust-cli/Cargo.toml');
+    write('dotnet-app/app.csproj');
+    const roots = discoverProjectRoots(tmp);
+    expect(roots.sort()).toEqual(
+      [
+        tmp,
+        path.join(tmp, 'dotnet-app'),
+        path.join(tmp, 'go-svc'),
+        path.join(tmp, 'py-tool'),
+        path.join(tmp, 'rust-cli'),
+      ].sort(),
+    );
+  });
+
+  it('respects maxDepth', () => {
+    write('package.json');
+    write('a/b/c/d/e/package.json'); // depth 5 — beyond default
+    expect(discoverProjectRoots(tmp)).toEqual([tmp]);
+  });
+
+  it('returns empty array when cwd has no manifests and no sub-projects', () => {
+    mkdir('src');
+    write('src/index.ts', '// code');
+    expect(discoverProjectRoots(tmp)).toEqual([]);
+  });
+
+  it('returns cwd even when no direct manifest if nested roots exist', () => {
+    write('packages/a/package.json'); // "packages" is on skip list — should NOT be descended
+    const roots = discoverProjectRoots(tmp);
+    // `packages/` is skipped entirely; cwd has no manifest → no roots.
+    expect(roots).toEqual([]);
+  });
+
+  it('treats a solution + projects correctly (multiple C# roots)', () => {
+    write('Mono.sln');
+    write('ProjA/ProjA.csproj');
+    write('ProjB/ProjB.csproj');
+    const roots = discoverProjectRoots(tmp);
+    expect(roots).toEqual([tmp, path.join(tmp, 'ProjA'), path.join(tmp, 'ProjB')].sort());
+  });
+});

--- a/test/bom-gather.test.ts
+++ b/test/bom-gather.test.ts
@@ -4,6 +4,7 @@ import {
   compareSemver,
   deriveTier1Resolution,
   maxSemver,
+  mergeNestedBomEntries,
 } from '../src/analyzers/bom/gather';
 import type { DepVulnFinding } from '../src/languages/capabilities/types';
 import type { BomEntry } from '../src/analyzers/bom/types';
@@ -204,6 +205,7 @@ describe('analyzeBom filter', () => {
           ],
           toolsUsed: ['test'],
           toolsUnavailable: [],
+          projectRoots: ['.'],
         })),
       };
     });
@@ -246,3 +248,91 @@ function mkEntry(
     isTopLevel,
   };
 }
+
+describe('mergeNestedBomEntries', () => {
+  function result(entries: BomEntry[], roots: string[] = ['.']) {
+    return { entries, toolsUsed: ['test'], toolsUnavailable: [], projectRoots: roots };
+  }
+
+  it('passes through a single root unchanged except for sources', () => {
+    const m = mergeNestedBomEntries([{ relPath: '.', result: result([mkEntry('react', true)]) }]);
+    expect(m.entries).toHaveLength(1);
+    expect(m.entries[0].sources).toEqual(['.']);
+    expect(m.projectRoots).toEqual(['.']);
+  });
+
+  it('dedupes same (package, version) across roots and unions sources', () => {
+    const m = mergeNestedBomEntries([
+      { relPath: '.', result: result([mkEntry('lodash', false)]) },
+      { relPath: 'userserver', result: result([mkEntry('lodash', false)]) },
+    ]);
+    expect(m.entries).toHaveLength(1);
+    expect(m.entries[0].sources).toEqual(['.', 'userserver']);
+    expect(m.projectRoots).toEqual(['.', 'userserver']);
+  });
+
+  it('OR-merges isTopLevel — any-true wins', () => {
+    const m = mergeNestedBomEntries([
+      { relPath: '.', result: result([mkEntry('axios', false)]) },
+      { relPath: 'userserver', result: result([mkEntry('axios', true)]) },
+    ]);
+    expect(m.entries[0].isTopLevel).toBe(true);
+  });
+
+  it('leaves isTopLevel undefined if no root determined it', () => {
+    const m = mergeNestedBomEntries([
+      { relPath: '.', result: result([mkEntry('mystery', undefined)]) },
+      { relPath: 'userserver', result: result([mkEntry('mystery', undefined)]) },
+    ]);
+    expect(m.entries[0].isTopLevel).toBeUndefined();
+  });
+
+  it('keeps separate rows for different versions of the same package', () => {
+    const e1 = mkEntry('react', false);
+    e1.version = '17.0.2';
+    const e2 = mkEntry('react', true);
+    e2.version = '18.2.0';
+    const m = mergeNestedBomEntries([
+      { relPath: '.', result: result([e1]) },
+      { relPath: 'userserver', result: result([e2]) },
+    ]);
+    expect(m.entries).toHaveLength(2);
+    expect(m.entries.map((e) => e.version).sort()).toEqual(['17.0.2', '18.2.0']);
+  });
+
+  it('unions vulns with dedup on (id, package, installedVersion)', () => {
+    const v1: DepVulnFinding = {
+      id: 'CVE-1',
+      package: 'tar',
+      installedVersion: '6.0.0',
+      tool: 'npm-audit',
+      severity: 'high',
+    };
+    const v2: DepVulnFinding = { ...v1 };
+    const v3: DepVulnFinding = {
+      id: 'CVE-2',
+      package: 'tar',
+      installedVersion: '6.0.0',
+      tool: 'npm-audit',
+      severity: 'critical',
+    };
+    const m = mergeNestedBomEntries([
+      { relPath: '.', result: result([mkEntry('tar', false, [v1])]) },
+      { relPath: 'userserver', result: result([mkEntry('tar', false, [v2, v3])]) },
+    ]);
+    expect(m.entries).toHaveLength(1);
+    expect(m.entries[0].vulns.map((v) => v.id).sort()).toEqual(['CVE-1', 'CVE-2']);
+    // CVE-2 is critical → merged maxSeverity must be critical
+    expect(m.entries[0].maxSeverity).toBe('critical');
+  });
+
+  it('upgrades licenseType from UNKNOWN when a later root has real data', () => {
+    const unknownEntry: BomEntry = { ...mkEntry('pkg', false), licenseType: 'UNKNOWN' };
+    const knownEntry: BomEntry = { ...mkEntry('pkg', false), licenseType: 'MIT' };
+    const m = mergeNestedBomEntries([
+      { relPath: '.', result: result([unknownEntry]) },
+      { relPath: 'userserver', result: result([knownEntry]) },
+    ]);
+    expect(m.entries[0].licenseType).toBe('MIT');
+  });
+});


### PR DESCRIPTION
## Summary

Second sub-commit in Phase 10h.5. Scope pivot from "TS workspace attribution" (originally 10h.5.0b) to the *actual* underlying gap uncovered while investigating D001: `dxkit bom <repo>` only scans the directory it's invoked in, silently missing every sub-project with its own manifest. Logged as **D001a** and fixed here.

## The real bug

On `vyuhlabs-platform/`:
- Root has `package.json` (dev-tooling, ~1730 packages at install time)
- `userserver/` has its own `package.json` + `node_modules/` (the actual product, ~698 packages)
- Pre-10h.5.0b: `dxkit bom platform/` saw only root → `userserver/` invisible
- Post-10h.5.0b: sees both, dedupes across, reports unified BOM

Generalizes to any monorepo-style layout across every language pack.

## What changed

### Discovery (`src/analyzers/bom/discovery.ts` — new)

Pure walker. Any directory containing any of these manifests is a root:

| Pack | Triggers |
|---|---|
| Node | `package.json` |
| Python | `pyproject.toml`, `requirements.txt`, `setup.py`, `Pipfile` |
| Go | `go.mod` |
| Rust | `Cargo.toml` |
| C# | `*.csproj`, `*.sln` |

Skips `node_modules`, `vendor`, `venv`, `.venv`, `target`, `bin`, `obj`, `dist`, `build`, `out`, `.next`, `.turbo`, `.cache`, `.git`, `.svn`, `.hg`, `TestResults`, `packages`, plus dotfile subdirs. `maxDepth=4`.

### Merge (`mergeNestedBomEntries` in `gather.ts`)

Dedupe key `(package, version)`. When a package appears under multiple roots:

- `sources: string[]` unions cwd-relative paths
- `isTopLevel` OR-merges — any-root-true wins (upgrades surface in Top-Level Dep Groups)
- `vulns` union with dedup on `(id, package, installedVersion)`; `maxSeverity` + `upgradeAdvice` re-derived
- License metadata upgrades from UNKNOWN when a later root has real data

### API

```ts
interface AnalyzeBomOptions {
  nested?: boolean;   // default TRUE — new behavior ON by default
  // ...
}
```

- CLI: `--no-nested` to opt out
- Report shape: `summary.projectRoots: string[]` (sorted, distinct; `["."]` when single-root), `BomEntry.sources?: string[]`
- Renderers: CLI + markdown callout when `>1` root discovered

### Side-benefit: D003 partially addressed

C# multi-project solutions (`app.sln + app/app.csproj + tests/tests.csproj`) now naturally get one scan per `.csproj` merged by the nested aggregator — previously `findProjectAssetsJson` took the first hit from a depth-4 walk. Full D003 closure (plus attribution merge quality) still scheduled for 10h.6.7.

## Validation

- [x] 649 tests passing (+16: 9 discovery + 7 merge)
- [x] Typecheck + lint + format + architecture clean (pre-push gates, hardened in PR #3)
- [x] Platform benchmark default (nested ON): `projectRoots=[".", "userserver"]`, 1767 packages (vs 1730 root-only + 698 userserver — 661 dedup merges), 39 vulnerable, 89 advisories
- [x] Platform benchmark `--no-nested`: identical to prior — 1730 packages, 31 vulnerable, 71 advisories (escape hatch verified)
- [x] Platform benchmark `--filter=top-level` + nested: 149 of 1767 top-level, 9 vulnerable
- [x] Self-dogfood: 8 roots discovered (dxkit + 7 test fixtures); main report unchanged since fixtures contribute ~0 deps

## Reviewer checklist

- [ ] Discovery skip-list covers the important ignores — anything missing? (Considered adding `tmp/` given dxkit's own convention; left out because other projects use `tmp` for persistent data.)
- [ ] Merge OR-semantics for `isTopLevel` and vulns are intuitive?
- [ ] Default-ON vs opt-in: new behavior changes output shape (more rows on monorepos). Consumers reading `totalPackages` via JSON may see counts shift on next release. Worth a `BREAKING.md` note, or acceptable under additive?

## Not in scope

- **dotenv gap from D001**: confirmed to be benchmark artifact — dotenv is absent from the platform repo entirely (no manifest, no lockfile entry, no installed dir). Will recommend customer benchmark scrub in a follow-up note.
- **Language-pack-level nested awareness**: e.g. Python shared-venv scenarios, Rust cargo workspaces, npm `workspaces[]` declarations. Covered enough by directory-level aggregation for now; specialized handling can land per-pack if concrete gaps emerge.