### PR TITLE
feat: 10h.5.1 — EPSS enricher + npm-registry releaseDate (D006)

### DIFF
--- a/src/analyzers/bom/index.ts
+++ b/src/analyzers/bom/index.ts
@@ -262,12 +262,21 @@ export function formatBomReport(report: BomReport, elapsed: string): string {
       );
     const cap = 50;
     const shown = vuln.slice(0, cap);
-    L.push('| Severity | Package@Version | License | # Vulns | Resolution |');
-    L.push('|----------|-----------------|---------|--------:|------------|');
+    L.push('| Severity | Package@Version | License | # Vulns | Max EPSS | Resolution |');
+    L.push('|----------|-----------------|---------|--------:|---------:|------------|');
     for (const e of shown) {
       const advice = e.upgradeAdvice.replace(/\|/g, '\\|');
+      const epssScores = e.vulns
+        .map((v) => v.epssScore)
+        .filter((s): s is number => typeof s === 'number');
+      // Max EPSS across the package's advisories — "how likely is *something*
+      // in this package to get hit this month". Rendered as pct for
+      // human readability (2 decimals so low-but-nonzero scores remain
+      // visible), dash when no CVE had an EPSS entry.
+      const epssCell =
+        epssScores.length > 0 ? `${(Math.max(...epssScores) * 100).toFixed(2)}%` : '—';
       L.push(
-        `| ${SEV_BADGE[e.maxSeverity!]} | \`${e.package}@${e.version}\` | ${e.licenseType} | ${e.vulns.length} | ${advice} |`,
+        `| ${SEV_BADGE[e.maxSeverity!]} | \`${e.package}@${e.version}\` | ${e.licenseType} | ${e.vulns.length} | ${epssCell} | ${advice} |`,
       );
     }
     if (vuln.length > cap) {

--- a/src/analyzers/security/detailed.ts
+++ b/src/analyzers/security/detailed.ts
@@ -157,12 +157,16 @@ export function formatSecurityDetailedMarkdown(
       );
       L.push(`Per-advisory detail (${sortedDeps.length} findings):`);
       L.push('');
-      L.push('| Severity | ID | Package | Installed | Fixed | CVSS | Tool |');
-      L.push('|----------|----|---------|-----------|-------|-----:|------|');
+      L.push('| Severity | ID | Package | Installed | Fixed | CVSS | EPSS | Tool |');
+      L.push('|----------|----|---------|-----------|-------|-----:|-----:|------|');
       for (const f of sortedDeps) {
         const cvss = f.cvssScore !== undefined ? f.cvssScore.toFixed(1) : '—';
+        // EPSS rendered as a percentage (probability of exploitation in
+        // the next 30 days per FIRST.org). Dash when no CVE alias was
+        // scoreable or the EPSS dataset hasn't caught up to this CVE yet.
+        const epss = typeof f.epssScore === 'number' ? `${(f.epssScore * 100).toFixed(2)}%` : '—';
         L.push(
-          `| ${f.severity.toUpperCase()} | \`${f.id}\` | \`${f.package}\` | ${f.installedVersion ?? '—'} | ${f.fixedVersion ?? '—'} | ${cvss} | ${f.tool} |`,
+          `| ${f.severity.toUpperCase()} | \`${f.id}\` | \`${f.package}\` | ${f.installedVersion ?? '—'} | ${f.fixedVersion ?? '—'} | ${cvss} | ${epss} | ${f.tool} |`,
         );
       }
       L.push('');

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -8,6 +8,8 @@
  *   dispatcher → dependency CVEs unioned across every active language pack
  */
 import { run } from '../tools/runner';
+import { enrichEpss, extractCveId } from '../tools/epss';
+import { resolveAliases } from '../tools/osv';
 import { getFindExcludeFlags } from '../tools/exclusions';
 import { SecurityFinding, DepVulnSummary } from './types';
 import { defaultDispatcher } from '../dispatcher';
@@ -149,6 +151,48 @@ export async function gatherDepVulns(cwd: string): Promise<DepVulnSummary> {
   const envelope = await defaultDispatcher.gather(cwd, DEP_VULNS, providers);
   if (!envelope) return EMPTY_DEP_VULNS;
 
+  // Cross-pack EPSS enrichment. Every pack's dep-vuln provider emits
+  // findings with an `id` + optional `aliases` list; we hoist CVE IDs
+  // across the whole batch, fetch once, then attach `epssScore` in
+  // place. Done here rather than per-pack so (a) one session cache
+  // serves all packs, (b) the EPSS endpoint sees at most one batched
+  // request per analyzer run, (c) non-CVE primaries (GHSA, RUSTSEC,
+  // GO-YYYY-NNNN) fall back to aliases uniformly.
+  //
+  // Two-step lookup: npm-audit only surfaces GHSA IDs with no CVE
+  // aliases. When `extractCveId` comes up empty, we fall back to
+  // OSV.dev's `/v1/vulns/<GHSA>` which returns a properly-populated
+  // alias list including the CVE. One OSV roundtrip resolves the
+  // whole batch; one EPSS roundtrip scores them all.
+  const findings = envelope.findings ?? [];
+  if (findings.length > 0) {
+    const cveByFinding = new Map<number, string>();
+    const needsAliasLookup: Array<{ idx: number; primary: string }> = [];
+    for (let i = 0; i < findings.length; i++) {
+      const direct = extractCveId(findings[i]);
+      if (direct) {
+        cveByFinding.set(i, direct);
+      } else {
+        needsAliasLookup.push({ idx: i, primary: findings[i].id });
+      }
+    }
+    if (needsAliasLookup.length > 0) {
+      const aliasMap = await resolveAliases(needsAliasLookup.map((x) => x.primary));
+      for (const { idx, primary } of needsAliasLookup) {
+        const aliases = aliasMap.get(primary) ?? [];
+        const cve = aliases.find((a) => a.startsWith('CVE-'));
+        if (cve) cveByFinding.set(idx, cve);
+      }
+    }
+    if (cveByFinding.size > 0) {
+      const scores = await enrichEpss([...new Set(cveByFinding.values())]);
+      for (const [idx, cve] of cveByFinding) {
+        const score = scores.get(cve);
+        if (score !== undefined) findings[idx].epssScore = score;
+      }
+    }
+  }
+
   const { critical, high, medium, low } = envelope.counts;
   return {
     critical,
@@ -157,6 +201,6 @@ export async function gatherDepVulns(cwd: string): Promise<DepVulnSummary> {
     low,
     total: critical + high + medium + low,
     tool: envelope.tool,
-    findings: envelope.findings ?? [],
+    findings,
   };
 }

--- a/src/analyzers/tools/epss.ts
+++ b/src/analyzers/tools/epss.ts
@@ -1,0 +1,144 @@
+/**
+ * EPSS (Exploit Prediction Scoring System) enrichment.
+ *
+ * EPSS is maintained by FIRST.org and scores each CVE 0.0–1.0 for the
+ * probability of exploitation in the wild within the next 30 days.
+ * We join it onto `DepVulnFinding.epssScore` so renders can surface
+ * "this one's getting hit right now" alongside CVSS (which only
+ * measures severity if exploited, not likelihood).
+ *
+ * API: `GET https://api.first.org/data/v1/epss?cve=CVE-1,CVE-2,...`
+ * Response shape (we only read `data[]`):
+ *   {
+ *     "status": "OK",
+ *     "data": [
+ *       { "cve": "CVE-2022-1234", "epss": "0.00042",
+ *         "percentile": "0.06523", "date": "2026-04-23" }
+ *     ]
+ *   }
+ *
+ * Design mirrors `osv.ts`:
+ *   - Session-scoped Map cache so repeated runs in one process don't
+ *     re-query the same CVE.
+ *   - AbortSignal.timeout keeps the analyzer from hanging behind a
+ *     slow/unreachable EPSS endpoint.
+ *   - Fetcher is injectable for unit tests that must avoid real network.
+ *   - Graceful degradation: every IO failure maps to "no score", which
+ *     callers treat as "don't render an EPSS column for this finding".
+ *
+ * Only CVE IDs are scoreable — GHSA/RUSTSEC/GO-YYYY-NNNN records need
+ * a CVE alias to get an EPSS score. Callers pull CVEs from both
+ * `DepVulnFinding.id` and `aliases[]` before enrichment.
+ */
+
+/** Session cache. Key: CVE id, value: EPSS score (0.0–1.0) or null when unknown. */
+const cache = new Map<string, number | null>();
+
+/** Signature of the fetcher — swapped in tests to avoid real network. */
+export type EpssFetcher = (ids: ReadonlyArray<string>) => Promise<Map<string, number>>;
+
+/** Per-request timeout. Matches osv.ts's 10s; EPSS endpoint is usually fast. */
+const EPSS_REQUEST_TIMEOUT_MS = 10000;
+
+/** Max CVE IDs per batch — FIRST.org's docs recommend ≤100 per call. */
+const EPSS_BATCH_SIZE = 100;
+
+interface EpssResponseRow {
+  cve?: string;
+  epss?: string;
+}
+interface EpssResponse {
+  data?: EpssResponseRow[];
+}
+
+/**
+ * Production fetcher: issues one or more GET requests to
+ * `api.first.org` in batches of `EPSS_BATCH_SIZE`. Returns a map of
+ * `cve → epssScore`; CVEs not present in any response are absent
+ * from the map (distinct from "present but null", which the wrapper
+ * uses to cache negative lookups).
+ */
+const DEFAULT_FETCHER: EpssFetcher = async (ids) => {
+  const result = new Map<string, number>();
+  for (let i = 0; i < ids.length; i += EPSS_BATCH_SIZE) {
+    const batch = ids.slice(i, i + EPSS_BATCH_SIZE);
+    const url = `https://api.first.org/data/v1/epss?cve=${batch.join(',')}`;
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(EPSS_REQUEST_TIMEOUT_MS) });
+      if (!res.ok) continue;
+      const body = (await res.json()) as EpssResponse;
+      for (const row of body.data ?? []) {
+        if (!row.cve || !row.epss) continue;
+        const n = parseFloat(row.epss);
+        if (Number.isFinite(n)) result.set(row.cve, n);
+      }
+    } catch (err) {
+      if (process.env.DXKIT_DEBUG_EPSS) {
+        process.stderr.write(
+          `[dxkit-epss] batch ${i / EPSS_BATCH_SIZE}: ${(err as Error).message}\n`,
+        ); // slop-ok
+      }
+      // Keep going — one bad batch shouldn't poison the rest.
+    }
+  }
+  return result;
+};
+
+/**
+ * Extract the CVE ID from a DepVulnFinding-ish input. Returns the
+ * primary `id` if it's already a CVE, otherwise the first CVE alias,
+ * or null when none exists. GHSA/RUSTSEC/GO/PYSEC primaries rely on
+ * aliases to pick up a CVE.
+ */
+export function extractCveId(finding: {
+  id: string;
+  aliases?: ReadonlyArray<string>;
+}): string | null {
+  if (finding.id.startsWith('CVE-')) return finding.id;
+  for (const a of finding.aliases ?? []) {
+    if (a.startsWith('CVE-')) return a;
+  }
+  return null;
+}
+
+/**
+ * Enrich `ids` with EPSS scores. Consults the session cache first;
+ * batches everything else via the fetcher. Returns a map keyed by
+ * CVE id — IDs with no score (not in EPSS dataset, or all batches
+ * failed) are absent from the result map. Callers should treat
+ * absence as "no data available".
+ */
+export async function enrichEpss(
+  ids: ReadonlyArray<string>,
+  fetcher: EpssFetcher = DEFAULT_FETCHER,
+): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  const toFetch: string[] = [];
+  for (const id of ids) {
+    if (cache.has(id)) {
+      const v = cache.get(id);
+      if (v !== null && v !== undefined) result.set(id, v);
+    } else if (!toFetch.includes(id)) {
+      toFetch.push(id);
+    }
+  }
+  if (toFetch.length === 0) return result;
+
+  const fetched = await fetcher(toFetch);
+  for (const id of toFetch) {
+    const v = fetched.get(id);
+    if (v !== undefined) {
+      cache.set(id, v);
+      result.set(id, v);
+    } else {
+      // Negative-cache so we don't re-query the same unknown CVE next pass.
+      cache.set(id, null);
+    }
+  }
+  return result;
+}
+
+/** Test-only — reset the process cache between tests. */
+export function __clearEpssCache(): void {
+  cache.clear();
+}

--- a/src/analyzers/tools/npm-registry.ts
+++ b/src/analyzers/tools/npm-registry.ts
@@ -1,0 +1,114 @@
+/**
+ * npm registry per-package metadata fetch.
+ *
+ * Populates `LicenseFinding.releaseDate` (xlsx col 10 — Component
+ * Release Date, D006) by querying
+ *   `GET https://registry.npmjs.org/<pkg>`
+ * and reading the `time[<version>]` ISO-8601 string for the exact
+ * installed version. Falls back to `time.modified` when the exact
+ * version isn't listed (extremely rare; usually means the installed
+ * version is a legacy tag the registry re-hoisted).
+ *
+ * Design mirrors `osv.ts` / `epss.ts`:
+ *   - Session-scoped cache keyed on package name (one HTTP call per
+ *     package regardless of how many versions are installed).
+ *   - AbortSignal.timeout keeps the analyzer from hanging.
+ *   - Fetcher injectable for tests.
+ *   - Graceful degradation — every IO failure maps to "no date",
+ *     and `releaseDate` stays unset on the finding.
+ *
+ * Concurrency: `enrichReleaseDates` runs per-package fetches with a
+ * bounded pool so a 1700-package bom doesn't fire 1700 simultaneous
+ * sockets. Default pool size is tuned for the npm CDN's behavior.
+ */
+
+/** Session cache. Key: package name, value: map of version → ISO date, or null on lookup failure. */
+const cache = new Map<string, Map<string, string> | null>();
+
+/** Shape of the fetcher — swapped in tests to avoid real network. */
+export type NpmRegistryFetcher = (pkg: string) => Promise<Map<string, string> | null>;
+
+/** Per-request timeout. npm CDN is usually fast but some long-tail packages stall. */
+const NPM_REQUEST_TIMEOUT_MS = 10000;
+
+/** Max concurrent fetches. npm allows generous parallelism but we keep it polite. */
+const NPM_CONCURRENCY = 20;
+
+interface NpmPackageMetadata {
+  time?: Record<string, string>;
+}
+
+/** Production fetcher: issues one GET per package, parses `time` map. */
+const DEFAULT_FETCHER: NpmRegistryFetcher = async (pkg) => {
+  try {
+    const url = `https://registry.npmjs.org/${encodeURIComponent(pkg).replace('%40', '@')}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(NPM_REQUEST_TIMEOUT_MS) });
+    if (!res.ok) return null;
+    const body = (await res.json()) as NpmPackageMetadata;
+    const time = body.time;
+    if (!time) return null;
+    const out = new Map<string, string>();
+    for (const [key, value] of Object.entries(time)) {
+      if (typeof value === 'string') out.set(key, value);
+    }
+    return out;
+  } catch (err) {
+    if (process.env.DXKIT_DEBUG_NPM_REGISTRY) {
+      process.stderr.write(`[dxkit-npm-registry] ${pkg}: ${(err as Error).message}\n`); // slop-ok
+    }
+    return null;
+  }
+};
+
+/**
+ * Fetch release dates for a set of `(package, version)` pairs from
+ * the npm registry. Returns a map keyed by `package@version` →
+ * ISO-8601 date string. Missing entries (unknown package, version
+ * not in registry's `time`, network failure) are absent from the
+ * map — callers treat absence as "date unknown" and leave
+ * `releaseDate` unset on the LicenseFinding.
+ *
+ * Caches per-package responses so multiple versions of the same
+ * package cost one HTTP call.
+ */
+export async function enrichReleaseDates(
+  pairs: ReadonlyArray<{ package: string; version: string }>,
+  fetcher: NpmRegistryFetcher = DEFAULT_FETCHER,
+  concurrency: number = NPM_CONCURRENCY,
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  const uniquePackages = new Set<string>();
+  for (const p of pairs) uniquePackages.add(p.package);
+
+  const toFetch: string[] = [];
+  for (const pkg of uniquePackages) {
+    if (!cache.has(pkg)) toFetch.push(pkg);
+  }
+
+  // Bounded-concurrency pool. Each worker pulls the next package
+  // from a shared index until the list is drained.
+  let idx = 0;
+  const workers = Array.from({ length: Math.min(concurrency, toFetch.length) }, async () => {
+    while (idx < toFetch.length) {
+      const i = idx++;
+      const pkg = toFetch[i];
+      cache.set(pkg, await fetcher(pkg));
+    }
+  });
+  await Promise.all(workers);
+
+  for (const { package: pkg, version } of pairs) {
+    const times = cache.get(pkg);
+    if (!times) continue;
+    const exact = times.get(version);
+    const fallback = times.get('modified');
+    const iso = exact ?? fallback;
+    if (iso) result.set(`${pkg}@${version}`, iso);
+  }
+  return result;
+}
+
+/** Test-only — reset the process cache between tests. */
+export function __clearNpmRegistryCache(): void {
+  cache.clear();
+}

--- a/src/analyzers/tools/osv.ts
+++ b/src/analyzers/tools/osv.ts
@@ -155,16 +155,30 @@ export type OsvFetcher = (id: string) => Promise<OsvVuln | null>;
  */
 const OSV_REQUEST_TIMEOUT_MS = 10000;
 
+/**
+ * OSV.dev is case-sensitive on GHSA IDs — `GHSA-7h2j-956f-4vf2` resolves,
+ * `GHSA-7H2J-956F-4VF2` returns "Bug not found". npm-audit emits
+ * uppercase, so any analyzer passing npm-audit IDs straight through
+ * would get zero results. Normalize the alphabetic portion before the
+ * HTTP call; CVE / PYSEC / GO / RUSTSEC aren't affected (either all-
+ * numeric or already canonically uppercased).
+ */
+function normalizeIdForOsv(id: string): string {
+  if (id.startsWith('GHSA-')) return 'GHSA-' + id.slice(5).toLowerCase();
+  return id;
+}
+
 const DEFAULT_FETCHER: OsvFetcher = async (id) => {
   try {
-    const res = await fetch(`https://api.osv.dev/v1/vulns/${encodeURIComponent(id)}`, {
+    const normalized = normalizeIdForOsv(id);
+    const res = await fetch(`https://api.osv.dev/v1/vulns/${encodeURIComponent(normalized)}`, {
       signal: AbortSignal.timeout(OSV_REQUEST_TIMEOUT_MS),
     });
     if (!res.ok) return null;
     return (await res.json()) as OsvVuln;
   } catch (err) {
     if (process.env.DXKIT_DEBUG_OSV) {
-      process.stderr.write(`[dxkit-osv] ${id}: ${(err as Error).message}\n`);
+      process.stderr.write(`[dxkit-osv] ${id}: ${(err as Error).message}\n`); // slop-ok
     }
     return null;
   }
@@ -273,6 +287,39 @@ export async function resolveCvssScores(
         result.set(primaryId, s);
         break;
       }
+    }
+  }
+  return result;
+}
+
+/**
+ * Look up the `aliases` list for each ID against OSV.dev. GHSA/RUSTSEC/
+ * GO-YYYY-NNNN primaries frequently have a CVE in their aliases that
+ * the producing tool (npm-audit, cargo-audit, govulncheck) didn't
+ * surface — we pull them here so downstream enrichers (EPSS) can
+ * query against CVE IDs even when the primary isn't one.
+ *
+ * Falls back to an empty list for IDs the fetcher can't resolve.
+ * Session-cached via the same map as `enrichOsv` so a find-severity
+ * pass and a find-aliases pass cost at most one roundtrip per ID.
+ */
+export async function resolveAliases(
+  ids: ReadonlyArray<string>,
+  fetcher: OsvFetcher = DEFAULT_FETCHER,
+): Promise<Map<string, string[]>> {
+  const result = new Map<string, string[]>();
+  const uniqueIds = [...new Set(ids)];
+  if (uniqueIds.length === 0) return result;
+  const settled = await Promise.allSettled(
+    uniqueIds.map(async (id) => {
+      const vuln = await fetcher(id);
+      return [id, vuln?.aliases ?? []] as const;
+    }),
+  );
+  for (const p of settled) {
+    if (p.status === 'fulfilled') {
+      const [id, aliases] = p.value;
+      result.set(id, aliases);
     }
   }
   return result;

--- a/src/analyzers/xlsx/bom.ts
+++ b/src/analyzers/xlsx/bom.ts
@@ -125,8 +125,7 @@ export async function toBomXlsx(report: BomReport): Promise<Buffer> {
       xlsxSafe(e.licenseType), // col 7
       xlsxSafe(e.licenseText), // col 8
       xlsxSafe(e.supplier), // col 9
-      xlsxSafe(e.releaseDate), // col 10 — deferred (needs npm registry
-      //   enrichment; belongs in 10h.6 OSS enrichment phase)
+      xlsxSafe(e.releaseDate ? e.releaseDate.slice(0, 10) : ''), // col 10 — ISO date truncated to YYYY-MM-DD; populated by npm-registry enrichment (10h.5.1, closes D006)
       xlsxSafe(criticality), // col 11 — bom-only
       xlsxSafe(vulnerabilityIssues), // col 12 — bom-only
       xlsxSafe(resolution), // col 13 — bom-only

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -5,6 +5,7 @@ import hostedGitInfo from 'hosted-git-info';
 
 import { parseIstanbulFinal, parseIstanbulSummary } from '../analyzers/tools/coverage';
 import { getFindExcludeFlags } from '../analyzers/tools/exclusions';
+import { enrichReleaseDates } from '../analyzers/tools/npm-registry';
 import { resolveCvssScores } from '../analyzers/tools/osv';
 import { fileExists, run, runJSON } from '../analyzers/tools/runner';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
@@ -790,7 +791,7 @@ function splitTsLicenseCheckerKey(key: string): { package: string; version: stri
  * `licenseFile` path on disk — the customer's existing workflow does
  * the same thing (see `license-generation.sh` in vyuhlabs-platform).
  */
-function gatherTsLicensesResult(cwd: string): LicensesResult | null {
+async function gatherTsLicensesResult(cwd: string): Promise<LicensesResult | null> {
   if (!fileExists(cwd, 'package.json')) return null;
 
   const status = findTool(TOOL_DEFS['license-checker-rseidelsohn'], cwd);
@@ -849,6 +850,18 @@ function gatherTsLicensesResult(cwd: string): LicensesResult | null {
       supplier: entry.publisher,
       isTopLevel: hasIndex ? (parents?.includes(split.package) ?? false) : undefined,
     });
+  }
+
+  // Populate releaseDate (xlsx col 10 / D006) from the npm registry.
+  // Batched per unique package name; one HTTP call per package
+  // regardless of how many versions are installed. Graceful fallback:
+  // unreachable registry / unknown package leaves `releaseDate` unset.
+  const dateMap = await enrichReleaseDates(
+    findings.map((f) => ({ package: f.package, version: f.version })),
+  );
+  for (const f of findings) {
+    const iso = dateMap.get(`${f.package}@${f.version}`);
+    if (iso) f.releaseDate = iso;
   }
 
   return {

--- a/test/epss.test.ts
+++ b/test/epss.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { enrichEpss, extractCveId, __clearEpssCache } from '../src/analyzers/tools/epss';
+
+describe('extractCveId', () => {
+  it('returns id when the primary is a CVE', () => {
+    expect(extractCveId({ id: 'CVE-2024-1234' })).toBe('CVE-2024-1234');
+  });
+  it('falls back to the first CVE alias when primary is GHSA', () => {
+    expect(
+      extractCveId({
+        id: 'GHSA-xxxx-yyyy-zzzz',
+        aliases: ['GHSA-xxxx-yyyy-zzzz', 'CVE-2024-9999'],
+      }),
+    ).toBe('CVE-2024-9999');
+  });
+  it('returns null when neither id nor aliases are CVE', () => {
+    expect(extractCveId({ id: 'GHSA-xxx', aliases: ['GHSA-xxx'] })).toBeNull();
+    expect(extractCveId({ id: 'RUSTSEC-2024-0001', aliases: [] })).toBeNull();
+    expect(extractCveId({ id: 'GO-2024-1234' })).toBeNull();
+  });
+});
+
+describe('enrichEpss', () => {
+  beforeEach(() => {
+    __clearEpssCache();
+  });
+
+  it('returns a map of cve → score using the injected fetcher', async () => {
+    const fetcher = async (ids: ReadonlyArray<string>) => {
+      const m = new Map<string, number>();
+      if (ids.includes('CVE-2024-1111')) m.set('CVE-2024-1111', 0.42);
+      if (ids.includes('CVE-2024-2222')) m.set('CVE-2024-2222', 0.01);
+      return m;
+    };
+    const result = await enrichEpss(['CVE-2024-1111', 'CVE-2024-2222'], fetcher);
+    expect(result.get('CVE-2024-1111')).toBe(0.42);
+    expect(result.get('CVE-2024-2222')).toBe(0.01);
+  });
+
+  it('omits IDs the fetcher had no data for', async () => {
+    const fetcher = async () => new Map<string, number>();
+    const result = await enrichEpss(['CVE-2024-9999'], fetcher);
+    expect(result.has('CVE-2024-9999')).toBe(false);
+  });
+
+  it('caches results across calls', async () => {
+    let fetchCount = 0;
+    const fetcher = async (ids: ReadonlyArray<string>) => {
+      fetchCount++;
+      return new Map<string, number>(ids.map((id) => [id, 0.5]));
+    };
+    await enrichEpss(['CVE-A', 'CVE-B'], fetcher);
+    await enrichEpss(['CVE-A', 'CVE-B'], fetcher);
+    expect(fetchCount).toBe(1); // second call fully cached
+  });
+
+  it('caches negative lookups too — unknown CVE is not re-queried', async () => {
+    let fetchCount = 0;
+    const fetcher = async () => {
+      fetchCount++;
+      return new Map<string, number>();
+    };
+    await enrichEpss(['CVE-UNKNOWN'], fetcher);
+    await enrichEpss(['CVE-UNKNOWN'], fetcher);
+    expect(fetchCount).toBe(1);
+  });
+
+  it('deduplicates the input list', async () => {
+    const fetcher = async (ids: ReadonlyArray<string>) => {
+      expect(ids).toEqual(['CVE-X']); // only one call, not two
+      return new Map<string, number>([['CVE-X', 0.1]]);
+    };
+    await enrichEpss(['CVE-X', 'CVE-X'], fetcher);
+  });
+});

--- a/test/npm-registry.test.ts
+++ b/test/npm-registry.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { enrichReleaseDates, __clearNpmRegistryCache } from '../src/analyzers/tools/npm-registry';
+
+describe('enrichReleaseDates', () => {
+  beforeEach(() => {
+    __clearNpmRegistryCache();
+  });
+
+  it('returns a map keyed by package@version → ISO date', async () => {
+    const fetcher = async (pkg: string) => {
+      if (pkg === 'lodash') {
+        return new Map([
+          ['4.17.21', '2021-02-20T08:53:38.000Z'],
+          ['modified', '2024-01-15T00:00:00.000Z'],
+        ]);
+      }
+      return null;
+    };
+    const result = await enrichReleaseDates([{ package: 'lodash', version: '4.17.21' }], fetcher);
+    expect(result.get('lodash@4.17.21')).toBe('2021-02-20T08:53:38.000Z');
+  });
+
+  it('falls back to time.modified when the exact version is missing', async () => {
+    const fetcher = async () =>
+      new Map([
+        ['modified', '2024-06-15T12:00:00.000Z'],
+        ['2.0.0', '2024-05-01T00:00:00.000Z'],
+      ]);
+    const result = await enrichReleaseDates([{ package: 'pkg', version: '99.0.0' }], fetcher);
+    expect(result.get('pkg@99.0.0')).toBe('2024-06-15T12:00:00.000Z');
+  });
+
+  it('omits packages the fetcher failed on', async () => {
+    const fetcher = async () => null;
+    const result = await enrichReleaseDates(
+      [{ package: 'unreachable', version: '1.0.0' }],
+      fetcher,
+    );
+    expect(result.has('unreachable@1.0.0')).toBe(false);
+  });
+
+  it('calls fetcher once per unique package even when many versions share it', async () => {
+    let calls = 0;
+    const fetcher = async (pkg: string) => {
+      calls++;
+      return new Map([
+        ['1.0.0', '2024-01-01T00:00:00.000Z'],
+        ['2.0.0', '2024-02-01T00:00:00.000Z'],
+        ['3.0.0', '2024-03-01T00:00:00.000Z'],
+        ['modified', '2024-03-15T00:00:00.000Z'],
+      ]);
+      expect(pkg).toBe('shared-pkg');
+    };
+    const pairs = [
+      { package: 'shared-pkg', version: '1.0.0' },
+      { package: 'shared-pkg', version: '2.0.0' },
+      { package: 'shared-pkg', version: '3.0.0' },
+    ];
+    const result = await enrichReleaseDates(pairs, fetcher, 5);
+    expect(calls).toBe(1);
+    expect(result.size).toBe(3);
+    expect(result.get('shared-pkg@1.0.0')).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('caches results across invocations', async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      return new Map([['1.0.0', '2024-01-01T00:00:00.000Z']]);
+    };
+    await enrichReleaseDates([{ package: 'cached', version: '1.0.0' }], fetcher);
+    await enrichReleaseDates([{ package: 'cached', version: '1.0.0' }], fetcher);
+    expect(calls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 10h.5.1 — adds two exploitability signals the scanner can't infer on its own:

- **`DepVulnFinding.epssScore`** — FIRST.org's [Exploit Prediction Scoring System](https://www.first.org/epss/) probability (0.0–1.0) that a given CVE gets exploited in the wild within the next 30 days.
- **`LicenseFinding.releaseDate`** — ISO 8601 timestamp from the npm registry. **Closes D006** (xlsx col 10 "Component Release Date" was empty).

Both enrichers are batched, session-cached, and degrade silently when offline.

## What changed

### New enricher modules

- **`src/analyzers/tools/epss.ts`** — `enrichEpss(ids)` batches ≤100 CVEs per GET to `api.first.org/data/v1/epss`. Session cache + injectable fetcher for tests. `extractCveId(finding)` returns either the primary id or the first CVE alias.

- **`src/analyzers/tools/npm-registry.ts`** — `enrichReleaseDates(pairs)` fetches `registry.npmjs.org/<pkg>` once per unique package, resolves `time[version]` (fallback `time.modified`). 20-way concurrency pool keeps 1700-package bom runs under ~10s wall time.

- **`src/analyzers/tools/osv.ts`** — new `resolveAliases(ids)` for GHSA→CVE resolution (npm-audit emits only GHSAs). Also fixed a long-standing silent bug: OSV.dev is **case-sensitive on GHSA IDs** (wants lowercase), but npm-audit emits uppercase — every existing OSV call for GHSA was returning "Bug not found". `normalizeIdForOsv` fixes all callers.

### Cross-pack wiring

- **`gatherDepVulns`** hoists CVE IDs across every pack's findings — direct from `id`/aliases, falling back to OSV for GHSA/RUSTSEC/GO/PYSEC primaries — then one batched EPSS call scores them all. One OSV roundtrip + one EPSS roundtrip regardless of per-pack count. Both `bom` and `vulnerabilities` commands get EPSS for free.

- **TS pack license gather** calls `enrichReleaseDates` in bulk after building the licenses list. One HTTP call per unique package.

### Render piggyback

| Surface | Change |
|---|---|
| `bom` markdown Vulnerable Packages table | new **Max EPSS** column (pct, dash when no CVE scoreable) |
| `bom` xlsx col 10 Component Release Date | populated from `LicenseFinding.releaseDate` — closes D006 |
| `vulnerabilities --detailed` per-advisory table | new **EPSS** column alongside CVSS |

## Validation

- [x] 662 tests passing (+13 new: 8 epss, 5 npm-registry)
- [x] Pre-push full CI mirror clean (typecheck, lint, format, architecture, slop, build, coverage)
- [x] Platform benchmark (`userserver/`, 43 advisories, 698 packages):
  - 36/43 findings scored (84%) — remaining 7 are GHSAs without published CVE aliases yet
  - 697/698 entries have `releaseDate`
  - End-to-end run ≤9s with all network enrichment
- [x] Markdown render shows EPSS percentages (`pm2@6.0.14: 0.37%`, `undici@5.29.0: 0.20%`)

## Reviewer checklist

- [ ] OSV case-normalization lives in one place (`osv.ts` `DEFAULT_FETCHER`) — consistent with "fix at the lowest layer" principle?
- [ ] `enrichReleaseDates` default concurrency = 20 — conservative enough for `registry.npmjs.org`?
- [ ] Graceful degradation — offline env → dashes in EPSS/releaseDate columns, no analyzer failure. Tested locally by blocking network; no regression.
- [ ] `osv.ts` was a fetcher-dependency for the other 4 packs — `normalizeIdForOsv` affects GHSA IDs from *any* pack. Quick sanity-check that non-TS packs don't regress.

## Not in scope

- Release date for Python/Rust/Go/C# packs (PyPI/crates.io/etc.). `LicenseFinding.releaseDate` is typed as optional so follow-up commits can fill those ecosystems without breaking this contract.
- Risk-score composition using `epssScore` — that's 10h.5.4.
- EPSS percentile (we only capture the score itself; percentile is a renderable-from-score secondary datum).