### PR TITLE
feat: 10h.5.2 — CISA KEV enricher flags confirmed-exploited CVEs

### DIFF
--- a/src/analyzers/bom/index.ts
+++ b/src/analyzers/bom/index.ts
@@ -262,8 +262,8 @@ export function formatBomReport(report: BomReport, elapsed: string): string {
       );
     const cap = 50;
     const shown = vuln.slice(0, cap);
-    L.push('| Severity | Package@Version | License | # Vulns | Max EPSS | Resolution |');
-    L.push('|----------|-----------------|---------|--------:|---------:|------------|');
+    L.push('| Severity | Package@Version | License | # Vulns | KEV | Max EPSS | Resolution |');
+    L.push('|----------|-----------------|---------|--------:|:---:|---------:|------------|');
     for (const e of shown) {
       const advice = e.upgradeAdvice.replace(/\|/g, '\\|');
       const epssScores = e.vulns
@@ -275,8 +275,11 @@ export function formatBomReport(report: BomReport, elapsed: string): string {
       // visible), dash when no CVE had an EPSS entry.
       const epssCell =
         epssScores.length > 0 ? `${(Math.max(...epssScores) * 100).toFixed(2)}%` : '—';
+      // KEV cell: `⚠` when any advisory is in the CISA KEV catalog —
+      // the strongest "fix now" signal we can surface. Empty otherwise.
+      const kevCell = e.vulns.some((v) => v.kev) ? '⚠' : '';
       L.push(
-        `| ${SEV_BADGE[e.maxSeverity!]} | \`${e.package}@${e.version}\` | ${e.licenseType} | ${e.vulns.length} | ${epssCell} | ${advice} |`,
+        `| ${SEV_BADGE[e.maxSeverity!]} | \`${e.package}@${e.version}\` | ${e.licenseType} | ${e.vulns.length} | ${kevCell} | ${epssCell} | ${advice} |`,
       );
     }
     if (vuln.length > cap) {

--- a/src/analyzers/security/detailed.ts
+++ b/src/analyzers/security/detailed.ts
@@ -157,16 +157,20 @@ export function formatSecurityDetailedMarkdown(
       );
       L.push(`Per-advisory detail (${sortedDeps.length} findings):`);
       L.push('');
-      L.push('| Severity | ID | Package | Installed | Fixed | CVSS | EPSS | Tool |');
-      L.push('|----------|----|---------|-----------|-------|-----:|-----:|------|');
+      L.push('| Severity | KEV | ID | Package | Installed | Fixed | CVSS | EPSS | Tool |');
+      L.push('|----------|:---:|----|---------|-----------|-------|-----:|-----:|------|');
       for (const f of sortedDeps) {
         const cvss = f.cvssScore !== undefined ? f.cvssScore.toFixed(1) : '—';
         // EPSS rendered as a percentage (probability of exploitation in
         // the next 30 days per FIRST.org). Dash when no CVE alias was
         // scoreable or the EPSS dataset hasn't caught up to this CVE yet.
         const epss = typeof f.epssScore === 'number' ? `${(f.epssScore * 100).toFixed(2)}%` : '—';
+        // KEV badge: `⚠` when CISA has confirmed active exploitation
+        // — outranks EPSS probability as a remediation signal. Empty
+        // cell (not dash) to keep the column scannable visually.
+        const kev = f.kev ? '⚠' : '';
         L.push(
-          `| ${f.severity.toUpperCase()} | \`${f.id}\` | \`${f.package}\` | ${f.installedVersion ?? '—'} | ${f.fixedVersion ?? '—'} | ${cvss} | ${epss} | ${f.tool} |`,
+          `| ${f.severity.toUpperCase()} | ${kev} | \`${f.id}\` | \`${f.package}\` | ${f.installedVersion ?? '—'} | ${f.fixedVersion ?? '—'} | ${cvss} | ${epss} | ${f.tool} |`,
         );
       }
       L.push('');

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -9,6 +9,7 @@
  */
 import { run } from '../tools/runner';
 import { enrichEpss, extractCveId } from '../tools/epss';
+import { enrichKev } from '../tools/kev';
 import { resolveAliases } from '../tools/osv';
 import { getFindExcludeFlags } from '../tools/exclusions';
 import { SecurityFinding, DepVulnSummary } from './types';
@@ -185,10 +186,15 @@ export async function gatherDepVulns(cwd: string): Promise<DepVulnSummary> {
       }
     }
     if (cveByFinding.size > 0) {
-      const scores = await enrichEpss([...new Set(cveByFinding.values())]);
+      const uniqueCves = [...new Set(cveByFinding.values())];
+      // EPSS + KEV run in parallel — one roundtrip each, independent
+      // endpoints. KEV catalog is a single bulk fetch (~200KB, 1300
+      // entries), so subsequent lookups in the same session are free.
+      const [scores, kevHits] = await Promise.all([enrichEpss(uniqueCves), enrichKev(uniqueCves)]);
       for (const [idx, cve] of cveByFinding) {
         const score = scores.get(cve);
         if (score !== undefined) findings[idx].epssScore = score;
+        if (kevHits.has(cve)) findings[idx].kev = true;
       }
     }
   }

--- a/src/analyzers/tools/kev.ts
+++ b/src/analyzers/tools/kev.ts
@@ -1,0 +1,104 @@
+/**
+ * CISA Known Exploited Vulnerabilities (KEV) enrichment.
+ *
+ * CISA publishes a catalog of CVEs the US-federal-agency ISAC has
+ * confirmed are being actively exploited in the wild (different from
+ * EPSS's *probability of* exploitation). A KEV hit is the strongest
+ * "fix this now" signal we can attach to a finding.
+ *
+ * Feed: `https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json`
+ *
+ * Shape (we only read `vulnerabilities[].cveID`):
+ *   {
+ *     "catalogVersion": "...",
+ *     "dateReleased": "...",
+ *     "count": 1200-ish,
+ *     "vulnerabilities": [
+ *       { "cveID": "CVE-2021-44228", "vendorProject": "Apache", ... }
+ *     ]
+ *   }
+ *
+ * Unlike EPSS (per-CVE lookup), KEV is a bulk download + local
+ * lookup — one HTTP call per session, search is a `Set.has`.
+ *
+ * Design mirrors `osv.ts` / `epss.ts`:
+ *   - Session-scoped cache so the catalog is fetched at most once
+ *     per process (it's ~1300 entries, ~200KB).
+ *   - AbortSignal.timeout prevents stalls.
+ *   - Fetcher injectable for tests.
+ *   - Graceful degradation: if the catalog is unreachable, every
+ *     finding's `kev` stays unset (treated as "no data", not
+ *     "confirmed not KEV").
+ */
+
+/** Cached CVE set for the process lifetime. `null` means "tried and failed". */
+let cachedCatalog: Set<string> | null | undefined = undefined;
+
+/** Shape of the fetcher — swapped in tests to avoid real network. */
+export type KevFetcher = () => Promise<Set<string> | null>;
+
+/** Per-request timeout. The CISA feed is usually fast but can stall under load. */
+const KEV_REQUEST_TIMEOUT_MS = 10000;
+
+interface KevCatalog {
+  vulnerabilities?: Array<{ cveID?: string }>;
+}
+
+/** Production fetcher: downloads the CISA catalog and builds a CVE set. */
+const DEFAULT_FETCHER: KevFetcher = async () => {
+  try {
+    const res = await fetch(
+      'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json',
+      { signal: AbortSignal.timeout(KEV_REQUEST_TIMEOUT_MS) },
+    );
+    if (!res.ok) return null;
+    const body = (await res.json()) as KevCatalog;
+    const set = new Set<string>();
+    for (const row of body.vulnerabilities ?? []) {
+      if (row.cveID) set.add(row.cveID);
+    }
+    return set;
+  } catch (err) {
+    if (process.env.DXKIT_DEBUG_KEV) {
+      process.stderr.write(`[dxkit-kev] catalog fetch failed: ${(err as Error).message}\n`); // slop-ok
+    }
+    return null;
+  }
+};
+
+/**
+ * Fetch (or return cached) KEV catalog as a Set of CVE IDs. Returns
+ * an empty set on network failure so callers can treat "KEV lookup
+ * succeeded but CVE X is not listed" and "KEV fetch failed" the
+ * same way — both collapse to "no KEV flag on this finding". The
+ * distinction is preserved in logs via DXKIT_DEBUG_KEV.
+ */
+export async function getKevCatalog(fetcher: KevFetcher = DEFAULT_FETCHER): Promise<Set<string>> {
+  if (cachedCatalog === undefined) {
+    cachedCatalog = await fetcher();
+  }
+  return cachedCatalog ?? new Set();
+}
+
+/**
+ * Enrich `cves` with KEV membership. Returns the subset of input
+ * CVE IDs that appear in the catalog. Empty result is safe —
+ * callers interpret absence from the result set as "not KEV"
+ * (true negative; caller should set `kev: false`).
+ */
+export async function enrichKev(
+  cves: ReadonlyArray<string>,
+  fetcher: KevFetcher = DEFAULT_FETCHER,
+): Promise<Set<string>> {
+  const catalog = await getKevCatalog(fetcher);
+  const hits = new Set<string>();
+  for (const cve of cves) {
+    if (catalog.has(cve)) hits.add(cve);
+  }
+  return hits;
+}
+
+/** Test-only — reset the process cache between tests. */
+export function __clearKevCache(): void {
+  cachedCatalog = undefined;
+}

--- a/test/kev.test.ts
+++ b/test/kev.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { enrichKev, getKevCatalog, __clearKevCache } from '../src/analyzers/tools/kev';
+
+describe('getKevCatalog', () => {
+  beforeEach(() => {
+    __clearKevCache();
+  });
+
+  it('returns the fetched CVE set', async () => {
+    const catalog = await getKevCatalog(async () => new Set(['CVE-2021-44228', 'CVE-2023-1234']));
+    expect(catalog.size).toBe(2);
+    expect(catalog.has('CVE-2021-44228')).toBe(true);
+  });
+
+  it('caches across calls — fetcher invoked once', async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      return new Set(['CVE-A']);
+    };
+    await getKevCatalog(fetcher);
+    await getKevCatalog(fetcher);
+    expect(calls).toBe(1);
+  });
+
+  it('caches null result too — failed fetch is not retried', async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      return null;
+    };
+    const first = await getKevCatalog(fetcher);
+    const second = await getKevCatalog(fetcher);
+    expect(calls).toBe(1);
+    expect(first.size).toBe(0);
+    expect(second.size).toBe(0);
+  });
+});
+
+describe('enrichKev', () => {
+  beforeEach(() => {
+    __clearKevCache();
+  });
+
+  it('returns the subset of input CVEs present in the catalog', async () => {
+    const fetcher = async () => new Set(['CVE-2021-44228', 'CVE-2024-3094']);
+    const hits = await enrichKev(['CVE-2021-44228', 'CVE-2999-0000', 'CVE-2024-3094'], fetcher);
+    expect(hits.size).toBe(2);
+    expect(hits.has('CVE-2021-44228')).toBe(true);
+    expect(hits.has('CVE-2024-3094')).toBe(true);
+    expect(hits.has('CVE-2999-0000')).toBe(false);
+  });
+
+  it('returns empty set when catalog fetch failed', async () => {
+    const fetcher = async () => null;
+    const hits = await enrichKev(['CVE-2021-44228'], fetcher);
+    expect(hits.size).toBe(0);
+  });
+
+  it('handles empty input list', async () => {
+    const fetcher = async () => new Set(['CVE-A']);
+    const hits = await enrichKev([], fetcher);
+    expect(hits.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the second exploitability signal to every BOM/vulnerability finding:

- **`DepVulnFinding.kev: boolean`** — true when CISA's [Known Exploited Vulnerabilities catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) lists the CVE. A KEV hit means the US federal-agency ISAC has **confirmed active exploitation** — stronger remediation signal than EPSS's 30-day probability estimate.

Paired with 10h.5.1's EPSS: the two answer different questions.
- EPSS: "how likely is this to get hit soon?"
- KEV: "has this *already* gotten hit?"

## What changed

### `src/analyzers/tools/kev.ts` — new

Bulk-fetches the CISA catalog once per process (~200KB, ~1500 CVEs today), caches as a `Set<string>`. Per-finding lookup is O(1). Injectable fetcher for tests. Graceful offline fallback: unreachable feed leaves every finding's `kev` unset (null-state, not false).

### `gatherDepVulns` — fan out

EPSS + KEV now run in parallel. Same CVE ID set (hoisted directly from finding IDs or via OSV alias resolution for GHSA primaries) feeds both. One roundtrip per endpoint per analyzer run.

### Render piggyback

| Surface | Change |
|---|---|
| `bom` markdown Vulnerable Packages table | new **KEV** column (`⚠` badge, empty when not listed). Sits before EPSS so remediation priority reads top-down. |
| `vulnerabilities --detailed` per-advisory table | **KEV** column second after Severity — the "stop everything" signal pops visually above CVSS/EPSS. |

## Validation

- [x] 668 tests passing (+6 new KEV tests).
- [x] Pre-push full CI mirror clean.
- [x] KEV catalog fetch smoke: 1579 entries live, `CVE-2021-44228` (log4shell) correctly flagged.
- [x] `vyuhlabs-platform/userserver` benchmark: 0/43 findings in KEV. This is correct — npm-audit surfaces mostly low-profile ReDoS / prototype-pollution CVEs that don't cross CISA's "active exploitation" threshold. Demonstrates graceful "no data" behavior without false positives.

## Reviewer checklist

- [ ] Catalog URL is the canonical feed (`cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json`) — CISA publishes a few alt formats; this one is the machine-readable canonical.
- [ ] KEV cell renders empty (not `—`) when not flagged — keeps the column scannable visually, since most rows won't be KEV.
- [ ] Parallel EPSS + KEV pairing is race-safe — both share the `uniqueCves` input, no cross-state, `Promise.all` composes cleanly.

## Not in scope

- KEV in xlsx col 12 — left to 10h.5.6 (renderer polish).
- Risk score using KEV — 10h.5.4.
- Ransomware-campaign flag (`knownRansomwareCampaignUse` field in KEV) — nice signal but separate field; can add in 10h.5.6 if needed.