### PR TITLE
feat: 10h.5.3 — reachability signal (does your source import the vulnerable package?)

### DIFF
--- a/src/analyzers/bom/index.ts
+++ b/src/analyzers/bom/index.ts
@@ -262,8 +262,12 @@ export function formatBomReport(report: BomReport, elapsed: string): string {
       );
     const cap = 50;
     const shown = vuln.slice(0, cap);
-    L.push('| Severity | Package@Version | License | # Vulns | KEV | Max EPSS | Resolution |');
-    L.push('|----------|-----------------|---------|--------:|:---:|---------:|------------|');
+    L.push(
+      '| Severity | Package@Version | License | # Vulns | KEV | Reach | Max EPSS | Resolution |',
+    );
+    L.push(
+      '|----------|-----------------|---------|--------:|:---:|:-----:|---------:|------------|',
+    );
     for (const e of shown) {
       const advice = e.upgradeAdvice.replace(/\|/g, '\\|');
       const epssScores = e.vulns
@@ -278,8 +282,13 @@ export function formatBomReport(report: BomReport, elapsed: string): string {
       // KEV cell: `⚠` when any advisory is in the CISA KEV catalog —
       // the strongest "fix now" signal we can surface. Empty otherwise.
       const kevCell = e.vulns.some((v) => v.kev) ? '⚠' : '';
+      // Reach cell: `✓` when the repo's source imports this package
+      // (any advisory on it is reachable); empty cell when every
+      // advisory's `reachable === false`. Unset → blank (treated as
+      // "don't know", which is safer than implying non-reachability).
+      const reachCell = e.vulns.some((v) => v.reachable === true) ? '✓' : '';
       L.push(
-        `| ${SEV_BADGE[e.maxSeverity!]} | \`${e.package}@${e.version}\` | ${e.licenseType} | ${e.vulns.length} | ${kevCell} | ${epssCell} | ${advice} |`,
+        `| ${SEV_BADGE[e.maxSeverity!]} | \`${e.package}@${e.version}\` | ${e.licenseType} | ${e.vulns.length} | ${kevCell} | ${reachCell} | ${epssCell} | ${advice} |`,
       );
     }
     if (vuln.length > cap) {

--- a/src/analyzers/security/detailed.ts
+++ b/src/analyzers/security/detailed.ts
@@ -157,8 +157,8 @@ export function formatSecurityDetailedMarkdown(
       );
       L.push(`Per-advisory detail (${sortedDeps.length} findings):`);
       L.push('');
-      L.push('| Severity | KEV | ID | Package | Installed | Fixed | CVSS | EPSS | Tool |');
-      L.push('|----------|:---:|----|---------|-----------|-------|-----:|-----:|------|');
+      L.push('| Severity | KEV | Reach | ID | Package | Installed | Fixed | CVSS | EPSS | Tool |');
+      L.push('|----------|:---:|:-----:|----|---------|-----------|-------|-----:|-----:|------|');
       for (const f of sortedDeps) {
         const cvss = f.cvssScore !== undefined ? f.cvssScore.toFixed(1) : '—';
         // EPSS rendered as a percentage (probability of exploitation in
@@ -169,8 +169,12 @@ export function formatSecurityDetailedMarkdown(
         // — outranks EPSS probability as a remediation signal. Empty
         // cell (not dash) to keep the column scannable visually.
         const kev = f.kev ? '⚠' : '';
+        // Reach badge: `✓` when the repo's source imports this
+        // package, `·` when definitely not, blank when unknown (no
+        // imports data — treated as "can't tell").
+        const reach = f.reachable === true ? '✓' : f.reachable === false ? '·' : '';
         L.push(
-          `| ${f.severity.toUpperCase()} | ${kev} | \`${f.id}\` | \`${f.package}\` | ${f.installedVersion ?? '—'} | ${f.fixedVersion ?? '—'} | ${cvss} | ${epss} | ${f.tool} |`,
+          `| ${f.severity.toUpperCase()} | ${kev} | ${reach} | \`${f.id}\` | \`${f.package}\` | ${f.installedVersion ?? '—'} | ${f.fixedVersion ?? '—'} | ${cvss} | ${epss} | ${f.tool} |`,
         );
       }
       L.push('');

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -11,11 +11,17 @@ import { run } from '../tools/runner';
 import { enrichEpss, extractCveId } from '../tools/epss';
 import { enrichKev } from '../tools/kev';
 import { resolveAliases } from '../tools/osv';
+import { buildReachablePackageSet, markReachable } from '../tools/reachability';
 import { getFindExcludeFlags } from '../tools/exclusions';
 import { SecurityFinding, DepVulnSummary } from './types';
 import { defaultDispatcher } from '../dispatcher';
 import { detectActiveLanguages } from '../../languages';
-import { CODE_PATTERNS, DEP_VULNS, SECRETS } from '../../languages/capabilities/descriptors';
+import {
+  CODE_PATTERNS,
+  DEP_VULNS,
+  IMPORTS,
+  SECRETS,
+} from '../../languages/capabilities/descriptors';
 import { providersFor } from '../../languages/capabilities';
 import type { CapabilityProvider } from '../../languages/capabilities/provider';
 import type { DepVulnResult } from '../../languages/capabilities/types';
@@ -195,6 +201,22 @@ export async function gatherDepVulns(cwd: string): Promise<DepVulnSummary> {
         const score = scores.get(cve);
         if (score !== undefined) findings[idx].epssScore = score;
         if (kevHits.has(cve)) findings[idx].kev = true;
+      }
+    }
+
+    // Reachability — does the repo's source actually import any of
+    // these vulnerable packages? Dispatches the IMPORTS capability
+    // (which packs populate from their per-file specifier extraction)
+    // once, unions into a name set, then marks every finding. When
+    // no pack contributes imports (no source files / all packs
+    // declined), leaves `reachable` unset rather than mass-classify
+    // everything as false.
+    const importsProviders = providersFor(IMPORTS);
+    if (importsProviders.length > 0) {
+      const importsEnvelope = await defaultDispatcher.gather(cwd, IMPORTS, importsProviders);
+      if (importsEnvelope && importsEnvelope.extracted.size > 0) {
+        const reachable = buildReachablePackageSet(importsEnvelope);
+        markReachable(findings, reachable);
       }
     }
   }

--- a/src/analyzers/tools/reachability.ts
+++ b/src/analyzers/tools/reachability.ts
@@ -1,0 +1,102 @@
+/**
+ * Reachability analysis for dependency vulnerabilities.
+ *
+ * Answers the triage question "does *my* code actually touch this
+ * vulnerable package, anywhere?". A critical CVE in `axios` is
+ * meaningful if `import from 'axios'` exists somewhere in my source;
+ * it's usually inert noise if axios is a transitive dev-dep nothing
+ * actually loads.
+ *
+ * Input is the aggregated `ImportsResult` (language packs already
+ * extract per-file specifiers; the dispatcher unions them). Output is
+ * a boolean per `DepVulnFinding.reachable`.
+ *
+ * Matching is *coarse* — name-level, not call-graph level. Importing
+ * `lodash` flags every lodash finding as reachable even if the call
+ * sites only touch safe paths. A precise per-advisory reachability
+ * check (Snyk-style AST walking into the package itself) belongs in
+ * 10h.8 (optional snyk overlay); this module is the OSS-only
+ * predecessor the rest of dxkit ships with.
+ *
+ * Pure functions so renders can be tested without filesystem.
+ */
+
+import type { DepVulnFinding, ImportsResult } from '../../languages/capabilities/types';
+
+/**
+ * Project an import specifier to the external package name it
+ * references, or null for relative / absolute / protocol specifiers.
+ *
+ * Handles three ecosystems consistently:
+ *
+ *   - npm scoped: `@scope/name` or `@scope/name/subpath` → `@scope/name`
+ *   - npm bare:   `lodash` or `lodash/get` → `lodash`
+ *   - Python:     `foo.bar.baz` (from ImportsResult's raw specifier
+ *                 form) → `foo` (top-level module is the package name)
+ *   - Go:         `github.com/user/repo/subpkg` → `github.com/user/repo`
+ *                 (3-slash module-path convention; detected by the
+ *                 dotted first segment)
+ *   - Rust / C#:  not reliably mapped (crate paths / namespaces
+ *                 don't equal package names). Rust's `use serde`
+ *                 does resolve though, since `serde` is both crate
+ *                 and extracted specifier.
+ *
+ * Pure; exported for unit tests.
+ */
+export function specifierToPackage(spec: string): string | null {
+  if (!spec) return null;
+  // Relative or absolute paths aren't external deps.
+  if (spec.startsWith('.') || spec.startsWith('/')) return null;
+  // URLs / protocol imports aren't deps either.
+  if (spec.includes('://')) return null;
+
+  // Scoped npm: @scope/name, @scope/name/subpath
+  if (spec.startsWith('@')) {
+    const parts = spec.split('/');
+    if (parts.length < 2) return null;
+    return `${parts[0]}/${parts[1]}`;
+  }
+
+  const slashParts = spec.split('/');
+
+  // Go module convention: first segment has a dot (github.com, golang.org,
+  // gitlab.com) → keep 3-segment module path.
+  if (slashParts[0].includes('.') && slashParts.length >= 3) {
+    return slashParts.slice(0, 3).join('/');
+  }
+
+  // TS bare (`lodash`, `lodash/get`) or Python dotted (`foo.bar`,
+  // `foo`) — top-level module name is everything before the first
+  // `/` or `.`.
+  return slashParts[0].split('.')[0];
+}
+
+/**
+ * Build a set of external package names referenced from anywhere in
+ * the repo's source. Empty set is safe — means "no imports parsed",
+ * which callers treat as "reachability unknown" (leave findings'
+ * `reachable` unset rather than mass-false).
+ */
+export function buildReachablePackageSet(imports: ImportsResult): Set<string> {
+  const set = new Set<string>();
+  for (const specs of imports.extracted.values()) {
+    for (const spec of specs) {
+      const pkg = specifierToPackage(spec);
+      if (pkg) set.add(pkg);
+    }
+  }
+  return set;
+}
+
+/**
+ * Annotate every finding's `reachable` field. `true` when the finding's
+ * `package` is in the reachable set; `false` otherwise. Unsetting is
+ * intentionally avoided — we always classify once the set is built,
+ * because an empty set (no imports parsed) skips this helper entirely
+ * at the call site in `gatherDepVulns`.
+ */
+export function markReachable(findings: DepVulnFinding[], reachable: ReadonlySet<string>): void {
+  for (const f of findings) {
+    f.reachable = reachable.has(f.package);
+  }
+}

--- a/test/reachability.test.ts
+++ b/test/reachability.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildReachablePackageSet,
+  markReachable,
+  specifierToPackage,
+} from '../src/analyzers/tools/reachability';
+import type { DepVulnFinding, ImportsResult } from '../src/languages/capabilities/types';
+
+describe('specifierToPackage', () => {
+  it('returns null for relative paths', () => {
+    expect(specifierToPackage('./foo')).toBeNull();
+    expect(specifierToPackage('../bar/baz')).toBeNull();
+  });
+
+  it('returns null for absolute paths', () => {
+    expect(specifierToPackage('/abs/path')).toBeNull();
+  });
+
+  it('returns null for URL/protocol specifiers', () => {
+    expect(specifierToPackage('http://example.com/mod')).toBeNull();
+    expect(specifierToPackage('file:///local.js')).toBeNull();
+  });
+
+  it('extracts scoped npm package name', () => {
+    expect(specifierToPackage('@loopback/core')).toBe('@loopback/core');
+    expect(specifierToPackage('@loopback/core/dist/bar')).toBe('@loopback/core');
+  });
+
+  it('returns null for malformed scoped specifier', () => {
+    expect(specifierToPackage('@loopback')).toBeNull();
+  });
+
+  it('extracts bare npm package name', () => {
+    expect(specifierToPackage('lodash')).toBe('lodash');
+    expect(specifierToPackage('lodash/get')).toBe('lodash');
+  });
+
+  it('extracts Python top-level module from dotted specifier', () => {
+    expect(specifierToPackage('foo.bar.baz')).toBe('foo');
+    expect(specifierToPackage('requests')).toBe('requests');
+  });
+
+  it('extracts Go 3-segment module path', () => {
+    expect(specifierToPackage('github.com/user/repo')).toBe('github.com/user/repo');
+    expect(specifierToPackage('github.com/user/repo/subpkg')).toBe('github.com/user/repo');
+    expect(specifierToPackage('golang.org/x/net/idna')).toBe('golang.org/x/net');
+  });
+
+  it('returns null for empty input', () => {
+    expect(specifierToPackage('')).toBeNull();
+  });
+});
+
+describe('buildReachablePackageSet', () => {
+  function imports(specsByFile: Record<string, string[]>): ImportsResult {
+    const extracted = new Map<string, ReadonlyArray<string>>();
+    for (const [f, s] of Object.entries(specsByFile)) extracted.set(f, s);
+    return {
+      schemaVersion: 1,
+      tool: 'test',
+      sourceExtensions: ['.ts'],
+      extracted,
+      edges: new Map(),
+    };
+  }
+
+  it('unions external packages across every file', () => {
+    const result = buildReachablePackageSet(
+      imports({
+        'src/a.ts': ['axios', 'lodash/get', './util'],
+        'src/b.ts': ['@loopback/core', 'foo.bar.baz'],
+      }),
+    );
+    expect(result.has('axios')).toBe(true);
+    expect(result.has('lodash')).toBe(true);
+    expect(result.has('@loopback/core')).toBe(true);
+    expect(result.has('foo')).toBe(true);
+    expect(result.size).toBe(4); // relative path './util' not counted
+  });
+
+  it('returns empty set when all specs are relative', () => {
+    const result = buildReachablePackageSet(
+      imports({
+        'src/a.ts': ['./foo', '../bar', '/abs'],
+      }),
+    );
+    expect(result.size).toBe(0);
+  });
+});
+
+describe('markReachable', () => {
+  function finding(pkg: string): DepVulnFinding {
+    return { id: 'CVE-1', package: pkg, tool: 'test', severity: 'high' };
+  }
+
+  it('sets reachable=true when package is in the set', () => {
+    const fs: DepVulnFinding[] = [finding('axios'), finding('lodash'), finding('untouched')];
+    markReachable(fs, new Set(['axios', 'lodash']));
+    expect(fs[0].reachable).toBe(true);
+    expect(fs[1].reachable).toBe(true);
+    expect(fs[2].reachable).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The triage question behind every CVE in the bom: **does my own code actually touch this package?**

A critical CVE in `lodash` matters when `import 'lodash'` exists in source; it's usually inert noise when lodash is a transitive dev-dep no source file references. This PR adds the third exploitability signal alongside KEV and EPSS:

- **`DepVulnFinding.reachable: boolean`**
  - `true`: at least one source file in the repo imports this package (directly, by name)
  - `false`: no source file references it — safely deprioritizable
  - `undefined`: imports data unavailable (pack couldn't scan, no source files)

## What changed

### `src/analyzers/tools/reachability.ts` — new

Three pure helpers:

- `specifierToPackage(spec)` — projects raw specifiers to external package names across TS (scoped + bare), Python (dotted modules), Go (3-seg module paths). Returns null for relative/absolute/URL specifiers.
- `buildReachablePackageSet(importsResult)` — unions every extracted specifier's package name.
- `markReachable(findings, set)` — writes `reachable=true/false` in place.

### `gatherDepVulns` — dispatch IMPORTS alongside DEP_VULNS

After EPSS/KEV enrichment, dispatch `IMPORTS` once and classify every finding. When no pack contributes imports (no source / all packs declined), leaves `reachable` unset — conservative "can't tell" is safer than "mass-false".

### Render piggyback

| Surface | Change |
|---|---|
| `bom` markdown Vulnerable Packages | New **Reach** column between KEV and EPSS — scan reads severity → KEV → Reach → EPSS left-to-right (natural triage priority) |
| `vulnerabilities --detailed` per-advisory | New **Reach** column: `✓` reachable, `·` definitely not, blank unknown |

## Validation

- [x] 680 tests passing (+12 new reachability tests)
- [x] Typecheck + lint + format + architecture + pre-push gate clean
- [x] **Platform signal-to-noise win**: `vyuhlabs-platform/userserver` — 3/43 findings reachable (axios × 2, pm2). The other **40** sit in transitive deps the userserver code doesn't import directly. This is exactly the decision-doc transformation 10h.5 targets.

## Design notes

- **Matching is coarse**: name-level only. Importing `lodash` flags *every* lodash advisory, regardless of which function is called. A precise per-advisory check (Snyk-style AST walking into `node_modules/`) belongs in Tier 4 (10h.8 optional overlay). This OSS-only predecessor ships now.
- **No graphify dep**: uses per-pack `ImportsResult` (TS, Python, Rust, C# packs already extract raw specifiers). 10f.2's venv fix is still prereq because graphify's structural metrics overlap adjacent analyzers, but reachability specifically uses the simpler pack-level imports path.
- **Test imports count**: a dev-dep only imported from `.test.ts` files still flags `reachable=true`. Could split "prod reachable" vs "test reachable" in a future pass; for now, conservative union.

## Reviewer checklist

- [ ] `specifierToPackage` handles all three ecosystems sensibly — test coverage shows 12 cases
- [ ] Three-state semantics (`true`/`false`/`undefined`) render distinctly (`✓`/`·`/blank)
- [ ] Central dispatch in `gatherDepVulns` is the right layer — vs per-pack classification

## Next

10h.5.4: **composite risk score** = `f(cvssScore, epssScore, kev, reachable)`. Now that all four inputs ship, the formula commit is the next logical step.