### PR TITLE
feat: 10h.5.4 — composite riskScore ranks the triage queue

### DIFF
--- a/src/analyzers/bom/index.ts
+++ b/src/analyzers/bom/index.ts
@@ -249,24 +249,37 @@ export function formatBomReport(report: BomReport, elapsed: string): string {
   if (s.vulnerablePackages > 0) {
     L.push('## Vulnerable Packages');
     L.push('');
-    L.push('Sorted by severity (worst-first), then alphabetical. ');
-    L.push('Resolution column shows the Tier-1 derived upgrade target ');
-    L.push('(or "No fix available" when an advisory has no published patch).');
+    L.push(
+      'Sorted by **composite risk score** (CVSS × KEV × EPSS × reachable) when available, ' +
+        'falling back to severity + alphabetical. Resolution shows the Tier-1 derived upgrade ' +
+        'target (or "No fix available" when an advisory has no published patch).',
+    );
     L.push('');
     const SEV_RANK: Record<BomSeverity, number> = { critical: 0, high: 1, medium: 2, low: 3 };
+    const maxRisk = (e: BomEntry): number => {
+      let best = -1;
+      for (const v of e.vulns) {
+        if (typeof v.riskScore === 'number' && v.riskScore > best) best = v.riskScore;
+      }
+      return best;
+    };
     const vuln: BomEntry[] = report.entries
       .filter((e) => e.maxSeverity)
-      .sort(
-        (a, b) =>
-          SEV_RANK[a.maxSeverity!] - SEV_RANK[b.maxSeverity!] || a.package.localeCompare(b.package),
-      );
+      .sort((a, b) => {
+        const ra = maxRisk(a);
+        const rb = maxRisk(b);
+        if (ra !== rb) return rb - ra; // higher risk first
+        return (
+          SEV_RANK[a.maxSeverity!] - SEV_RANK[b.maxSeverity!] || a.package.localeCompare(b.package)
+        );
+      });
     const cap = 50;
     const shown = vuln.slice(0, cap);
     L.push(
-      '| Severity | Package@Version | License | # Vulns | KEV | Reach | Max EPSS | Resolution |',
+      '| Risk | Severity | CVSS | Package@Version | License | # Vulns | KEV | Reach | EPSS | Resolution |',
     );
     L.push(
-      '|----------|-----------------|---------|--------:|:---:|:-----:|---------:|------------|',
+      '|-----:|----------|-----:|-----------------|---------|--------:|:---:|:-----:|-----:|------------|',
     );
     for (const e of shown) {
       const advice = e.upgradeAdvice.replace(/\|/g, '\\|');
@@ -279,6 +292,14 @@ export function formatBomReport(report: BomReport, elapsed: string): string {
       // visible), dash when no CVE had an EPSS entry.
       const epssCell =
         epssScores.length > 0 ? `${(Math.max(...epssScores) * 100).toFixed(2)}%` : '—';
+      // Max CVSS across the package's advisories — exposes the raw
+      // numeric severity alongside the categorical bucket so readers
+      // can distinguish 7.1 from 9.8 when both bucket as HIGH. Dash
+      // when no advisory had CVSS data.
+      const cvssScores = e.vulns
+        .map((v) => v.cvssScore)
+        .filter((s): s is number => typeof s === 'number');
+      const cvssCell = cvssScores.length > 0 ? Math.max(...cvssScores).toFixed(1) : '—';
       // KEV cell: `⚠` when any advisory is in the CISA KEV catalog —
       // the strongest "fix now" signal we can surface. Empty otherwise.
       const kevCell = e.vulns.some((v) => v.kev) ? '⚠' : '';
@@ -287,8 +308,13 @@ export function formatBomReport(report: BomReport, elapsed: string): string {
       // advisory's `reachable === false`. Unset → blank (treated as
       // "don't know", which is safer than implying non-reachability).
       const reachCell = e.vulns.some((v) => v.reachable === true) ? '✓' : '';
+      // Risk: max composite riskScore across the package's advisories.
+      // Leading column so the eye catches priority first. Dash when
+      // no advisory had a CVSS (riskScore uncomputable).
+      const risk = maxRisk(e);
+      const riskCell = risk >= 0 ? `**${risk.toFixed(0)}**` : '—';
       L.push(
-        `| ${SEV_BADGE[e.maxSeverity!]} | \`${e.package}@${e.version}\` | ${e.licenseType} | ${e.vulns.length} | ${kevCell} | ${reachCell} | ${epssCell} | ${advice} |`,
+        `| ${riskCell} | ${SEV_BADGE[e.maxSeverity!]} | ${cvssCell} | \`${e.package}@${e.version}\` | ${e.licenseType} | ${e.vulns.length} | ${kevCell} | ${reachCell} | ${epssCell} | ${advice} |`,
       );
     }
     if (vuln.length > cap) {

--- a/src/analyzers/security/detailed.ts
+++ b/src/analyzers/security/detailed.ts
@@ -147,34 +147,37 @@ export function formatSecurityDetailedMarkdown(
     L.push(`| **Total** | **${d.total}** |`);
     L.push('');
     if (d.findings.length > 0) {
-      // Per-advisory inventory. Sorted by (severity, package, id) so the
-      // table reads top-down from worst-first within each pack's output.
-      const sortedDeps: DepVulnFinding[] = [...d.findings].sort(
-        (a, b) =>
+      // Per-advisory inventory. Sorted by composite riskScore when
+      // available (primary triage key), falling back to severity + package
+      // for findings where CVSS was missing. Highest risk first.
+      const sortedDeps: DepVulnFinding[] = [...d.findings].sort((a, b) => {
+        const ra = a.riskScore ?? -1;
+        const rb = b.riskScore ?? -1;
+        if (ra !== rb) return rb - ra;
+        return (
           SEV_ORDER[a.severity] - SEV_ORDER[b.severity] ||
           a.package.localeCompare(b.package) ||
-          a.id.localeCompare(b.id),
-      );
+          a.id.localeCompare(b.id)
+        );
+      });
       L.push(`Per-advisory detail (${sortedDeps.length} findings):`);
       L.push('');
-      L.push('| Severity | KEV | Reach | ID | Package | Installed | Fixed | CVSS | EPSS | Tool |');
-      L.push('|----------|:---:|:-----:|----|---------|-----------|-------|-----:|-----:|------|');
+      L.push(
+        '| Risk | Severity | KEV | Reach | ID | Package | Installed | Fixed | CVSS | EPSS | Tool |',
+      );
+      L.push(
+        '|-----:|----------|:---:|:-----:|----|---------|-----------|-------|-----:|-----:|------|',
+      );
       for (const f of sortedDeps) {
         const cvss = f.cvssScore !== undefined ? f.cvssScore.toFixed(1) : '—';
-        // EPSS rendered as a percentage (probability of exploitation in
-        // the next 30 days per FIRST.org). Dash when no CVE alias was
-        // scoreable or the EPSS dataset hasn't caught up to this CVE yet.
         const epss = typeof f.epssScore === 'number' ? `${(f.epssScore * 100).toFixed(2)}%` : '—';
-        // KEV badge: `⚠` when CISA has confirmed active exploitation
-        // — outranks EPSS probability as a remediation signal. Empty
-        // cell (not dash) to keep the column scannable visually.
         const kev = f.kev ? '⚠' : '';
-        // Reach badge: `✓` when the repo's source imports this
-        // package, `·` when definitely not, blank when unknown (no
-        // imports data — treated as "can't tell").
         const reach = f.reachable === true ? '✓' : f.reachable === false ? '·' : '';
+        // Composite risk (0–100). Bold since it's the primary sort key;
+        // dash when CVSS was missing (risk uncomputable).
+        const risk = typeof f.riskScore === 'number' ? `**${f.riskScore.toFixed(0)}**` : '—';
         L.push(
-          `| ${f.severity.toUpperCase()} | ${kev} | ${reach} | \`${f.id}\` | \`${f.package}\` | ${f.installedVersion ?? '—'} | ${f.fixedVersion ?? '—'} | ${cvss} | ${epss} | ${f.tool} |`,
+          `| ${risk} | ${f.severity.toUpperCase()} | ${kev} | ${reach} | \`${f.id}\` | \`${f.package}\` | ${f.installedVersion ?? '—'} | ${f.fixedVersion ?? '—'} | ${cvss} | ${epss} | ${f.tool} |`,
         );
       }
       L.push('');

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -12,6 +12,7 @@ import { enrichEpss, extractCveId } from '../tools/epss';
 import { enrichKev } from '../tools/kev';
 import { resolveAliases } from '../tools/osv';
 import { buildReachablePackageSet, markReachable } from '../tools/reachability';
+import { scoreFindings } from '../tools/risk-score';
 import { getFindExcludeFlags } from '../tools/exclusions';
 import { SecurityFinding, DepVulnSummary } from './types';
 import { defaultDispatcher } from '../dispatcher';
@@ -219,6 +220,12 @@ export async function gatherDepVulns(cwd: string): Promise<DepVulnSummary> {
         markReachable(findings, reachable);
       }
     }
+
+    // Composite riskScore = f(cvss, epss, kev, reachable). Runs last
+    // so every signal is populated. Formula is documented in
+    // risk-score.ts; skipped for findings without CVSS so we don't
+    // fabricate severity from partial data.
+    scoreFindings(findings);
   }
 
   const { critical, high, medium, low } = envelope.counts;

--- a/src/analyzers/tools/risk-score.ts
+++ b/src/analyzers/tools/risk-score.ts
@@ -1,0 +1,96 @@
+/**
+ * Composite risk score for dependency advisories.
+ *
+ * Combines four signals into a single 0–100 number that orders
+ * remediation priority without requiring the user to juggle CVSS,
+ * EPSS, KEV, and reachability in their head:
+ *
+ *   - CVSS base severity (how bad if exploited) — 0–10
+ *   - EPSS (probability of exploitation in 30d)   — 0.0–1.0
+ *   - KEV (CISA confirmed in-the-wild exploit)    — boolean
+ *   - reachable (my source imports it)            — true/false/undefined
+ *
+ * Formula (multiplicative, clamped):
+ *
+ *   base   = cvss * 10                              (0–100)
+ *   kevMul = kev ? 2.0 : 1.0
+ *   epssMul = 1 + 2 * epss                          (1.0 – 3.0)
+ *   reachMul =
+ *       true      → 1.0    (no change)
+ *       false     → 0.25   (heavy discount for provably unreachable)
+ *       undefined → 0.7    (conservative middle — can't tell, don't zero it)
+ *   score = clamp(base * kevMul * epssMul * reachMul, 0, 100)
+ *
+ * Worked examples:
+ *   - Critical (9.8) + KEV + reachable + EPSS 0.5:
+ *       98 * 2.0 * 2.0 * 1.0 = 392  →  100
+ *   - Critical + not reachable + no KEV + EPSS 0.01:
+ *       98 * 1.0 * 1.02 * 0.25 ≈ 25
+ *   - Low (2.0) + reachable + no KEV + EPSS 0:
+ *       20 * 1.0 * 1.0 * 1.0  = 20
+ *   - Medium (5.5) + no signals, reachable unknown:
+ *       55 * 1.0 * 1.0 * 0.7  ≈ 39
+ *
+ * Returns `null` when CVSS is unavailable — callers leave the column
+ * blank rather than fabricate a score from partial data. The formula
+ * is documented and transparent so reviewers can sanity-check the
+ * relative ordering before trusting it. Future 10h.8 Snyk overlay
+ * can layer a tool-sourced score on top without changing this OSS
+ * baseline.
+ *
+ * Pure function; no IO, no state. Unit-testable with synthetic inputs.
+ */
+
+import type { DepVulnFinding } from '../../languages/capabilities/types';
+
+export interface RiskScoreInputs {
+  cvssScore?: number;
+  epssScore?: number;
+  kev?: boolean;
+  reachable?: boolean;
+}
+
+/**
+ * Compute the composite risk score for one finding, or null when
+ * CVSS is missing (we don't fabricate severity from side signals).
+ */
+export function computeRiskScore(inputs: RiskScoreInputs): number | null {
+  const cvss = inputs.cvssScore;
+  if (cvss === undefined) return null;
+
+  const base = cvss * 10;
+  const kevMul = inputs.kev ? 2.0 : 1.0;
+  const epssMul = 1 + 2 * (inputs.epssScore ?? 0);
+  const reachMul = inputs.reachable === true ? 1.0 : inputs.reachable === false ? 0.25 : 0.7;
+
+  const raw = base * kevMul * epssMul * reachMul;
+  return Math.min(100, Math.max(0, Math.round(raw * 10) / 10));
+}
+
+/**
+ * Convenience: classify a riskScore into a triage tier for render
+ * sorting and color-coding. Thresholds picked so most findings land
+ * outside "must-fix-now" — the riskScore's job is to make those
+ * stand out.
+ */
+export type RiskTier = 'critical' | 'high' | 'moderate' | 'low' | 'none';
+
+export function riskTier(score: number | null): RiskTier {
+  if (score === null) return 'none';
+  if (score >= 70) return 'critical';
+  if (score >= 40) return 'high';
+  if (score >= 15) return 'moderate';
+  return 'low';
+}
+
+/**
+ * Annotate every finding's `riskScore` field in place. Skips findings
+ * with no CVSS (riskScore stays unset; renderers handle that as
+ * "—" / blank column).
+ */
+export function scoreFindings(findings: DepVulnFinding[]): void {
+  for (const f of findings) {
+    const s = computeRiskScore(f);
+    if (s !== null) f.riskScore = s;
+  }
+}

--- a/test/risk-score.test.ts
+++ b/test/risk-score.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { computeRiskScore, riskTier, scoreFindings } from '../src/analyzers/tools/risk-score';
+import type { DepVulnFinding } from '../src/languages/capabilities/types';
+
+describe('computeRiskScore', () => {
+  it('returns null when CVSS is missing', () => {
+    expect(computeRiskScore({})).toBeNull();
+    expect(computeRiskScore({ epssScore: 0.5, kev: true })).toBeNull();
+  });
+
+  it('multiplies CVSS by 10 when no modifiers apply and reachable is unknown', () => {
+    // base=98, kevMul=1, epssMul=1, reachMul=0.7 → 98 * 1 * 1 * 0.7 ≈ 68.6
+    expect(computeRiskScore({ cvssScore: 9.8 })).toBe(68.6);
+  });
+
+  it('caps at 100 for high-risk combos', () => {
+    // base=98, kev=2, epss→1+2*0.8=2.6, reach=1.0 → 509.6 → clamped
+    expect(computeRiskScore({ cvssScore: 9.8, kev: true, epssScore: 0.8, reachable: true })).toBe(
+      100,
+    );
+  });
+
+  it('discounts heavily when definitely not reachable', () => {
+    // base=98, kev=1, epss=1.02, reach=0.25 → 24.99 → 25.0
+    expect(computeRiskScore({ cvssScore: 9.8, reachable: false, epssScore: 0.01 })).toBeCloseTo(
+      25.0,
+      1,
+    );
+  });
+
+  it('doubles the score under KEV alone', () => {
+    const plain = computeRiskScore({ cvssScore: 5.0, reachable: true });
+    const kev = computeRiskScore({ cvssScore: 5.0, reachable: true, kev: true });
+    expect(plain).toBe(50);
+    expect(kev).toBe(100); // 50 * 2 = 100
+  });
+
+  it('rounds to one decimal', () => {
+    const s = computeRiskScore({ cvssScore: 3.33, reachable: true });
+    expect(s).toBe(33.3);
+  });
+});
+
+describe('riskTier', () => {
+  it('maps score ranges to tiers', () => {
+    expect(riskTier(null)).toBe('none');
+    expect(riskTier(0)).toBe('low');
+    expect(riskTier(14.9)).toBe('low');
+    expect(riskTier(15)).toBe('moderate');
+    expect(riskTier(39.9)).toBe('moderate');
+    expect(riskTier(40)).toBe('high');
+    expect(riskTier(69.9)).toBe('high');
+    expect(riskTier(70)).toBe('critical');
+    expect(riskTier(100)).toBe('critical');
+  });
+});
+
+describe('scoreFindings', () => {
+  function finding(cvss?: number, kev?: boolean, reachable?: boolean): DepVulnFinding {
+    return {
+      id: 'CVE-X',
+      package: 'p',
+      tool: 't',
+      severity: 'high',
+      cvssScore: cvss,
+      kev,
+      reachable,
+    };
+  }
+
+  it('writes riskScore in place for findings with CVSS', () => {
+    const fs: DepVulnFinding[] = [finding(9.8, true, true), finding(2.0, false, false)];
+    scoreFindings(fs);
+    expect(fs[0].riskScore).toBe(100);
+    expect(fs[1].riskScore).toBeCloseTo(5.0, 1);
+  });
+
+  it('leaves riskScore unset when CVSS is missing', () => {
+    const fs: DepVulnFinding[] = [finding()];
+    scoreFindings(fs);
+    expect(fs[0].riskScore).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Combines the four exploitability signals shipped in 10h.5.1–.3 into a single 0–100 composite that orders the remediation queue:

| Signal | Measures |
|---|---|
| CVSS (0–10) | severity *if* exploited |
| EPSS (0–1) | *probability* of exploitation in 30 days |
| KEV (bool) | CISA *confirmed* active exploitation |
| reachable (tri-state) | does *my* source import it |

## Formula (documented in `risk-score.ts`)

```
base    = cvss * 10                            (0–100)
kevMul  = kev ? 2.0 : 1.0
epssMul = 1 + 2 * epss                         (1.0 – 3.0)
reachMul:
    true      → 1.0
    false     → 0.25   (heavy discount)
    undefined → 0.7    (conservative "don't know")
score = clamp(base * kevMul * epssMul * reachMul, 0, 100)
```

Multiplicative so any weak signal tempers the others. Null CVSS → null score (renders as dash) — we don't fabricate severity from side signals.

## Render

- **bom markdown** Vulnerable Packages: new **Risk** leading column + **Max CVSS** for numeric parity with `vulnerabilities`. Sort key is now `riskScore desc`, falling back to severity+name.
- **vulnerabilities --detailed**: same Risk column + sort.
- Every individual signal stays exposed: CVSS, Severity bucket, KEV badge, Reach badge, EPSS%, Risk score — all separate columns. JSON output unchanged (every `DepVulnFinding` already carries the raw fields).

## Validation

- [x] 689 tests passing (+9 new: null-on-missing-CVSS, 100-cap, KEV doubling, reachable discount, tier thresholds)
- [x] Typecheck + lint + format + architecture + pre-push gate clean
- [x] **Platform signal-to-noise win**:

```
top-10 by riskScore (vyuhlabs-platform/userserver, 43 advisories)
  48.0  axios       GHSA-3P68-…  cvss=4.8  reach=true
  48.0  axios       GHSA-FVCV-…  cvss=4.8  reach=true
  43.3  pm2         GHSA-X5GF-…  cvss=4.3  reach=true   epss=0.37%
  24.6  handlebars  GHSA-2W6W-…  cvss=9.8  reach=false  ← high CVSS, deprioritized
  22.8  basic-ftp   GHSA-5RQ4-…  cvss=9.1  reach=false
  …
```

The three reachable findings rise to the top of a 43-item queue despite lower CVSS; high-CVSS-but-unreachable findings fall below. That's the triage transformation 10h.5 was designed for.

## Reviewer checklist

- [ ] Formula weights — KEV doubling, reachable 0.25 discount, EPSS 3x cap — are these reasonable defaults? (Tunable later via config if customer feedback calls for different tradeoffs.)
- [ ] `undefined` reachable → 0.7 multiplier (conservative middle) — OK vs treating as 1.0 or dropping score entirely?
- [ ] Null score on missing CVSS — correct not to fabricate from side signals, even if KEV is present?

## Next

**10h.5.5** surfaces this list into a "This Week's Triage" executive summary at the top of the bom report — top 5–10 rows by riskScore with one-line rationale.