### PR TITLE
feat: 10h.5.5 — 'This Week's Triage' executive summary tops the bom report

### DIFF
--- a/src/analyzers/bom/index.ts
+++ b/src/analyzers/bom/index.ts
@@ -133,6 +133,91 @@ const SEV_BADGE: Record<BomSeverity, string> = {
   low: 'LOW',
 };
 
+/**
+ * Row in the "This Week's Triage" section. Pure projection over the
+ * flattened advisories sorted by riskScore desc — exposed for tests
+ * so the one-line rationale logic is verifiable without a full report
+ * fixture.
+ */
+export interface TriageRow {
+  risk: number;
+  id: string;
+  packageAtVersion: string;
+  rationale: string;
+  fix: string;
+}
+
+/**
+ * Build the triage list: top N advisories by riskScore across the
+ * whole bom, each with a one-line rationale stitched from the
+ * signals that drove the score. Filters out advisories below
+ * `minRisk` so the section stays the "interesting" subset —
+ * not every advisory the bom touched.
+ *
+ * Rationale is constructed left-to-right from the most decisive
+ * signals: KEV > reachable > high CVSS > high EPSS, so the reader
+ * can immediately see *why* this entry sits high. Examples:
+ *
+ *   - "KEV, reachable, CVSS 9.8"
+ *   - "reachable, CVSS 4.8"
+ *   - "CVSS 9.1" (transitive only, no reach/KEV signal)
+ *
+ * Pure function; exported for unit tests.
+ */
+export function buildTriageRows(report: BomReport, limit: number, minRisk: number): TriageRow[] {
+  interface Flat {
+    risk: number;
+    id: string;
+    packageAtVersion: string;
+    cvss?: number;
+    epss?: number;
+    kev?: boolean;
+    reachable?: boolean;
+    upgradeAdvice: string;
+  }
+  const flat: Flat[] = [];
+  for (const e of report.entries) {
+    for (const v of e.vulns) {
+      if (typeof v.riskScore !== 'number') continue;
+      if (v.riskScore < minRisk) continue;
+      flat.push({
+        risk: v.riskScore,
+        id: v.id,
+        packageAtVersion: `${e.package}@${e.version}`,
+        cvss: v.cvssScore,
+        epss: v.epssScore,
+        kev: v.kev,
+        reachable: v.reachable,
+        upgradeAdvice: v.upgradeAdvice ?? e.upgradeAdvice,
+      });
+    }
+  }
+  flat.sort((a, b) => b.risk - a.risk || a.id.localeCompare(b.id));
+  const top = flat.slice(0, limit);
+
+  return top.map((f) => {
+    const parts: string[] = [];
+    if (f.kev) parts.push('KEV');
+    if (f.reachable === true) parts.push('reachable');
+    if (f.reachable === false) parts.push('not reachable');
+    if (typeof f.cvss === 'number') parts.push(`CVSS ${f.cvss.toFixed(1)}`);
+    if (typeof f.epss === 'number' && f.epss >= 0.01) {
+      parts.push(`EPSS ${(f.epss * 100).toFixed(1)}%`);
+    }
+    const rationale = parts.length > 0 ? parts.join(', ') : '—';
+    // Keep fix concise: strip the leading "PROPOSAL:" noise so the
+    // cell reads as a direct instruction.
+    const fix = (f.upgradeAdvice || '—').replace(/^PROPOSAL:\s*/, '').replace(/\|/g, '\\|');
+    return {
+      risk: f.risk,
+      id: f.id,
+      packageAtVersion: f.packageAtVersion,
+      rationale,
+      fix,
+    };
+  });
+}
+
 export function formatBomReport(report: BomReport, elapsed: string): string {
   const L: string[] = [];
 
@@ -144,6 +229,33 @@ export function formatBomReport(report: BomReport, elapsed: string): string {
   L.push('');
   L.push('---');
   L.push('');
+
+  // "This Week's Triage" — top advisories by riskScore, rendered
+  // before the summary so the reader sees what to fix *first* above
+  // the statistical overview. Only included when at least one
+  // advisory crossed the moderate risk threshold (≥ 15). Limits
+  // to 10 rows to keep it scannable; the full inventory follows.
+  const triage = buildTriageRows(report, 10, 15);
+  if (triage.length > 0) {
+    L.push("## This Week's Triage");
+    L.push('');
+    L.push(
+      `Top ${triage.length} advisor${triage.length === 1 ? 'y' : 'ies'} by composite ` +
+        'risk score (CVSS × KEV × EPSS × reachable). Fix from the top of this list — ' +
+        'higher score = more signal that it matters *right now*.',
+    );
+    L.push('');
+    L.push('| Risk | ID | Package@Version | Rationale | Fix |');
+    L.push('|-----:|----|-----------------|-----------|-----|');
+    for (const row of triage) {
+      L.push(
+        `| **${row.risk.toFixed(0)}** | \`${row.id}\` | \`${row.packageAtVersion}\` | ${row.rationale} | ${row.fix} |`,
+      );
+    }
+    L.push('');
+    L.push('---');
+    L.push('');
+  }
 
   // Summary
   const s = report.summary;

--- a/test/bom-triage.test.ts
+++ b/test/bom-triage.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { buildTriageRows } from '../src/analyzers/bom';
+import type { BomReport, BomEntry } from '../src/analyzers/bom/types';
+import type { DepVulnFinding } from '../src/languages/capabilities/types';
+
+function mkReport(entries: BomEntry[]): BomReport {
+  return {
+    repo: 'test',
+    analyzedAt: '2026-04-24T00:00:00.000Z',
+    commitSha: 'abcdef',
+    branch: 'main',
+    schemaVersion: '1',
+    summary: {
+      totalPackages: entries.length,
+      bySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+      vulnerablePackages: 0,
+      actionableVulns: 0,
+      totalAdvisories: 0,
+      vulnOnlyPackages: 0,
+      byTopLevelDep: {},
+      filter: 'all',
+      unfilteredTotalPackages: entries.length,
+      projectRoots: ['.'],
+    },
+    entries,
+    toolsUsed: [],
+    toolsUnavailable: [],
+  };
+}
+
+function mkEntry(pkg: string, version: string, vulns: DepVulnFinding[]): BomEntry {
+  return {
+    package: pkg,
+    version,
+    licenseType: 'MIT',
+    vulns,
+    maxSeverity: vulns.length > 0 ? vulns[0].severity : null,
+    upgradeAdvice: 'PROPOSAL: Upgrade',
+    joinedFromBoth: true,
+  };
+}
+
+function vuln(
+  id: string,
+  pkg: string,
+  risk: number,
+  extras: Partial<DepVulnFinding> = {},
+): DepVulnFinding {
+  return {
+    id,
+    package: pkg,
+    tool: 't',
+    severity: 'high',
+    riskScore: risk,
+    ...extras,
+  };
+}
+
+describe('buildTriageRows', () => {
+  it('sorts by riskScore desc', () => {
+    const rows = buildTriageRows(
+      mkReport([
+        mkEntry('a', '1.0.0', [vuln('CVE-LOW', 'a', 20)]),
+        mkEntry('b', '1.0.0', [vuln('CVE-HIGH', 'b', 90)]),
+      ]),
+      10,
+      15,
+    );
+    expect(rows.map((r) => r.id)).toEqual(['CVE-HIGH', 'CVE-LOW']);
+  });
+
+  it('filters findings below minRisk', () => {
+    const rows = buildTriageRows(
+      mkReport([
+        mkEntry('a', '1.0.0', [vuln('LOW', 'a', 10)]),
+        mkEntry('b', '1.0.0', [vuln('HIGH', 'b', 50)]),
+      ]),
+      10,
+      15,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('HIGH');
+  });
+
+  it('skips findings without riskScore', () => {
+    const rows = buildTriageRows(
+      mkReport([
+        mkEntry('a', '1.0.0', [vuln('RATED', 'a', 70)]),
+        mkEntry('b', '1.0.0', [{ id: 'UNRATED', package: 'b', tool: 't', severity: 'critical' }]),
+      ]),
+      10,
+      15,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('RATED');
+  });
+
+  it('respects the limit', () => {
+    const entries = Array.from({ length: 5 }, (_, i) =>
+      mkEntry(`pkg${i}`, '1.0.0', [vuln(`CVE-${i}`, `pkg${i}`, 50 + i)]),
+    );
+    const rows = buildTriageRows(mkReport(entries), 3, 15);
+    expect(rows).toHaveLength(3);
+  });
+
+  it('builds rationale from signals (KEV → reachable → CVSS → EPSS)', () => {
+    const rows = buildTriageRows(
+      mkReport([
+        mkEntry('a', '1.0.0', [
+          vuln('ALL', 'a', 90, {
+            kev: true,
+            reachable: true,
+            cvssScore: 9.8,
+            epssScore: 0.12,
+          }),
+        ]),
+      ]),
+      10,
+      15,
+    );
+    expect(rows[0].rationale).toBe('KEV, reachable, CVSS 9.8, EPSS 12.0%');
+  });
+
+  it('omits EPSS below 1% as noise', () => {
+    const rows = buildTriageRows(
+      mkReport([
+        mkEntry('a', '1.0.0', [vuln('X', 'a', 50, { cvssScore: 5.0, epssScore: 0.0001 })]),
+      ]),
+      10,
+      15,
+    );
+    expect(rows[0].rationale).toBe('CVSS 5.0');
+  });
+
+  it('strips PROPOSAL: prefix from fix column', () => {
+    const rows = buildTriageRows(
+      mkReport([
+        mkEntry('a', '1.0.0', [
+          vuln('X', 'a', 50, {
+            upgradeAdvice: 'PROPOSAL: Upgrade to 1.7.0 (resolves 1 vuln)',
+          }),
+        ]),
+      ]),
+      10,
+      15,
+    );
+    expect(rows[0].fix).toBe('Upgrade to 1.7.0 (resolves 1 vuln)');
+  });
+
+  it('returns empty list when nothing crosses threshold', () => {
+    const rows = buildTriageRows(mkReport([mkEntry('a', '1.0.0', [vuln('LOW', 'a', 5)])]), 10, 15);
+    expect(rows).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Bom report now leads with a short, risk-ranked triage list — the "fix this first" queue — before the statistical summary and the full inventory. Turns the bom from enumeration ("here are 1700+ rows") into decision doc ("here are the 5-10 that matter this week").

## Output example

For `vyuhlabs-platform/userserver` (43 advisories total):

```markdown
## This Week's Triage

Top 10 advisories by composite risk score (CVSS × KEV × EPSS × reachable).
Fix from the top of this list — higher score = more signal that it
matters *right now*.

| Risk | ID | Package@Version | Rationale | Fix |
|-----:|----|-----------------|-----------|-----|
| **48** | `GHSA-3P68-RC4W-QGX5` | `axios@1.13.5` | reachable, CVSS 4.8 | No fix available — evaluate replacement |
| **48** | `GHSA-FVCV-3M26-PCQX` | `axios@1.13.5` | reachable, CVSS 4.8 | No fix available — evaluate replacement |
| **43** | `GHSA-X5GF-QVW8-R2RM` | `pm2@6.0.14` | reachable, CVSS 4.3 | No fix available — evaluate replacement |
| **25** | `GHSA-2W6W-674Q-4C4Q` | `handlebars@4.7.8` | not reachable, CVSS 9.8 | … |
| **23** | `GHSA-5RQ4-664W-9X2C` | `basic-ftp@5.0.5` | not reachable, CVSS 9.1 | … |
…
```

The three *reachable* findings (axios × 2, pm2) top the list despite lower CVSS — the whole point of 10h.5's triage-score approach. High-CVSS-but-unreachable findings fall below.

## Design

- **Threshold**: `minRisk = 15` (moderate tier). Below that, findings don't warrant "this week" priority.
- **Limit**: 10 rows. Longer tail stays in the Vulnerable Packages table below.
- **Section omitted** when zero advisories cross the threshold (clean repos don't need a triage banner).
- **Rationale construction** reads left-to-right from most decisive signals: `KEV → reachable → CVSS → EPSS`. Examples:
  - `"KEV, reachable, CVSS 9.8, EPSS 12.0%"`
  - `"reachable, CVSS 4.8"`
  - `"not reachable, CVSS 9.1"`
  - `"CVSS 5.0"` (no reach/KEV signal)
- **Fix column** strips `"PROPOSAL:"` prefix so the cell reads as a direct instruction.
- **EPSS filtered below 1%** as noise — sub-1% probabilities aren't decision-relevant.

## Validation

- [x] 697 tests passing (+8 `buildTriageRows` cases: sort, filter, absence-of-score, limit, rationale composition, EPSS noise threshold, fix cleanup, empty guard)
- [x] Typecheck + lint + format + architecture + pre-push gate clean
- [x] Platform smoke: triage section produces the expected 10-row table with correct ordering

## Reviewer checklist

- [ ] Section placement (top, before Summary) matches reviewer intuition for "what's the first thing I should see"
- [ ] `minRisk = 15` threshold — right for default? Could expose as option if customers want stricter/looser cutoffs
- [ ] `limit = 10` — right default? Long repos could see more (20?); short repos won't fill 10 anyway
- [ ] `buildTriageRows` is exported — future reuse by HTML viewer (10h.7.4) + CI gate reporter (10h.9)

## Phase 10h.5 status after this merge

| Sub-commit | Status |
|---|---|
| 10h.5.0 filter=top-level | ✅ |
| 10h.5.0b nested aggregation | ✅ |
| 10h.5.1 EPSS + releaseDate | ✅ |
| 10h.5.2 CISA KEV | ✅ |
| 10f.2 graphify venv | ✅ |
| 10h.5.3 reachability | ✅ |
| 10h.5.4 composite riskScore | ✅ |
| **10h.5.5 triage summary** | **this PR** |
| 10h.5.6 licenses + vulns render polish | 📋 last |

One sub-commit away from 2.3.0.