### PR TITLE
feat: 10h.5.6 — licenses + vulnerabilities render polish (final 2.3.0 sub-commit)

### DIFF
--- a/src/analyzers/licenses/index.ts
+++ b/src/analyzers/licenses/index.ts
@@ -106,19 +106,35 @@ export function formatLicensesReport(report: LicensesReport, elapsed: string): s
     );
   } else {
     const cap = 50;
-    const rows = [...report.findings].sort((a, b) => a.package.localeCompare(b.package));
+    // Sort top-level packages first, then alphabetical — same ordering
+    // bom uses so readers comparing the two reports see the same "direct
+    // dep" set at the top.
+    const rows = [...report.findings].sort((a, b) => {
+      const topA = a.isTopLevel === true ? 0 : 1;
+      const topB = b.isTopLevel === true ? 0 : 1;
+      if (topA !== topB) return topA - topB;
+      return a.package.localeCompare(b.package);
+    });
     const shown = rows.slice(0, cap);
-    L.push('| Package | Version | License | Description | Source URL |');
-    L.push('|---------|---------|---------|-------------|------------|');
+    // Direct column is the "⭐ fix here first" signal from 10h.5.0;
+    // Released column surfaces the npm-registry date (10h.5.1 / D006).
+    L.push('| Direct | Package | Version | License | Released | Description |');
+    L.push('|:------:|---------|---------|---------|----------|-------------|');
     for (const f of shown) {
       const desc = (f.description || '').replace(/\|/g, '\\|').replace(/\n/g, ' ').slice(0, 80);
-      const url = f.sourceUrl || '';
-      L.push(`| \`${f.package}\` | ${f.version} | ${f.licenseType} | ${desc} | ${url} |`);
+      const released = f.releaseDate ? f.releaseDate.slice(0, 10) : '—';
+      const direct = f.isTopLevel === true ? '⭐' : f.isTopLevel === false ? '' : '—';
+      L.push(
+        `| ${direct} | \`${f.package}\` | ${f.version} | ${f.licenseType} | ${released} | ${desc} |`,
+      );
     }
     if (rows.length > cap) {
       L.push('');
       L.push(
-        `_Showing ${cap} of ${rows.length} packages alphabetically. Run with \`--detailed\` for full inventory + risk review._`,
+        `_Showing ${cap} of ${rows.length} packages (top-level first, then alphabetical). ` +
+          'Run with `--detailed` for full inventory + risk review.' +
+          ` Direct column: ⭐ root manifest dep, blank transitive, — unknown (pack couldn't read lockfile).` +
+          '_',
       );
     }
   }

--- a/src/analyzers/security/index.ts
+++ b/src/analyzers/security/index.ts
@@ -170,28 +170,40 @@ export function formatSecurityReport(report: SecurityReport, elapsed: string): s
   // Dep-vuln per-package detail. Counts already appeared in the
   // Executive Summary; this section gives the actionable list (which
   // packages, which versions, which CVEs) so a reader can act without
-  // bouncing to the --detailed report.
+  // bouncing to the --detailed report. Sorted by composite riskScore
+  // desc so "this week's triage" sits at the top — matches bom's
+  // triage ordering.
   if (d.tool && d.findings.length > 0) {
     L.push(`## ${sectionNum}. Dependency Vulnerabilities`);
     L.push('');
-    L.push(`${d.findings.length} advisories across third-party packages (counts above).`);
-    L.push('');
-    const sorted = [...d.findings].sort(
-      (a, b) => SORDER[a.severity] - SORDER[b.severity] || a.package.localeCompare(b.package),
+    L.push(
+      `${d.findings.length} advisories across third-party packages (counts above), ` +
+        'ranked by composite risk score (CVSS × KEV × EPSS × reachable).',
     );
+    L.push('');
+    const sorted = [...d.findings].sort((a, b) => {
+      const ra = a.riskScore ?? -1;
+      const rb = b.riskScore ?? -1;
+      if (ra !== rb) return rb - ra;
+      return SORDER[a.severity] - SORDER[b.severity] || a.package.localeCompare(b.package);
+    });
     const cap = 50;
     const shown = sorted.slice(0, cap);
-    L.push('| Severity | Package@Version | ID | Fix | Tool |');
-    L.push('|----------|-----------------|----|-----|------|');
+    L.push('| Risk | Severity | KEV | Reach | Package@Version | ID | Fix | EPSS | Tool |');
+    L.push('|-----:|----------|:---:|:-----:|-----------------|----|-----|-----:|------|');
     for (const f of shown) {
+      const risk = typeof f.riskScore === 'number' ? `**${f.riskScore.toFixed(0)}**` : '—';
+      const kev = f.kev ? '⚠' : '';
+      const reach = f.reachable === true ? '✓' : f.reachable === false ? '·' : '';
+      const epss = typeof f.epssScore === 'number' ? `${(f.epssScore * 100).toFixed(2)}%` : '—';
       L.push(
-        `| ${f.severity.toUpperCase()} | \`${f.package}@${f.installedVersion ?? '?'}\` | \`${f.id}\` | ${f.fixedVersion ?? '—'} | ${f.tool} |`,
+        `| ${risk} | ${f.severity.toUpperCase()} | ${kev} | ${reach} | \`${f.package}@${f.installedVersion ?? '?'}\` | \`${f.id}\` | ${f.fixedVersion ?? '—'} | ${epss} | ${f.tool} |`,
       );
     }
     if (sorted.length > cap) {
       L.push('');
       L.push(
-        `_Showing ${cap} of ${sorted.length} advisories worst-first. Run with \`--detailed\` for the full inventory._`,
+        `_Showing ${cap} of ${sorted.length} advisories ranked by risk score. Run with \`--detailed\` for the full inventory + CVSS column._`,
       );
     }
     L.push('');


### PR DESCRIPTION
## Summary

Final polish PR for Phase 10h.5. Brings the `licenses` and `vulnerabilities` command renders up to full parity with `bom`'s decision-doc surface — so any dxkit command the user reaches for shows the same triage-relevant signals in the same order.

## What changed

### `licenses` markdown

| Before | After |
|---|---|
| Alphabetical packages table | Top-level deps (⭐) first, transitive below, alphabetical within each group |
| Columns: Package, Version, License, Description, Source URL | Columns: **Direct** (⭐/blank/—), Package, Version, License, **Released**, Description |

- Ordering matches `bom --filter=top-level` so cross-referencing the two reports Just Works.
- **Released** column = `LicenseFinding.releaseDate` from the npm registry (closes D006 in the licenses surface too, not just bom xlsx).
- Footer caption explains the Direct column semantics (⭐ = root manifest dep; blank = transitive; — = unknown, pack couldn't read lockfile).

### `vulnerabilities` markdown (main report, not `--detailed`)

- Per-advisory table **sorted by composite riskScore desc** (matches bom's triage ordering).
- New columns: **Risk** (bold leading), **KEV** (⚠ badge), **Reach** (✓ / · / blank), **EPSS** (pct).
- Existing columns (Severity, Package@Version, ID, Fix, Tool) stay.
- CVSS lives only in `--detailed` so the main report stays compact.

## Individual-signal exposure (unchanged — already done in 10h.5.1–.4)

- `DepVulnFinding`: cvssScore, epssScore, kev, reachable, riskScore — all raw in JSON
- `LicenseFinding`: isTopLevel, sources, releaseDate — all raw in JSON
- `bom` markdown already shows all of the above; **this PR brings licenses + vulnerabilities to parity**

## Validation

- [x] 697 tests passing (no new tests — polish-only; underlying enrichment already has coverage)
- [x] Typecheck + lint + format + architecture + pre-push gate clean
- [x] Platform licenses smoke: 15 direct deps (crypto-js, eslint, pm2, jsonwebtoken, pg, …) render with ⭐ at top; transitives start below with their npm registry dates
- [x] Platform vulnerabilities smoke: top-3 by risk match bom (axios × 2 + pm2 at 43–48); high-CVSS-unreachable handlebars/basic-ftp at 23–25

## Reviewer checklist

- [ ] Direct column ordering puts ⭐ at top — intuitive for reviewers?
- [ ] Description trimmed to 80 chars — still useful, or worth giving more room?
- [ ] Released column as `YYYY-MM-DD` (not full ISO) — matches xlsx col 10; consistent?
- [ ] vulnerabilities main report still readable without CVSS column (moved to --detailed)?

## Phase 10h.5 status after this merge

| Sub-commit | Status |
|---|---|
| 10h.5.0 filter=top-level | ✅ |
| 10h.5.0b nested aggregation | ✅ |
| 10h.5.1 EPSS + releaseDate | ✅ |
| 10h.5.2 CISA KEV | ✅ |
| 10f.2 graphify venv | ✅ |
| 10h.5.3 reachability | ✅ |
| 10h.5.4 composite riskScore | ✅ |
| 10h.5.5 triage summary | ✅ |
| **10h.5.6 render polish** | **this PR** |

**All 9 sub-commits landed. Ready for 2.3.0 release cut after merge.**