### PR TITLE
fix: 2.3.1 — install robustness (vitest guard, pipx for Python tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-04-24
+
+Patch release fixing three install-robustness issues reported on a
+real vyuhlabs-platform install:
+
+### Fixed
+
+- **`@vitest/coverage-v8` install crashed with `MODULE_NOT_FOUND`** on
+  repos that don't use vitest (mocha / jest / ava / lb-mocha). The
+  install command called `node -e "require('vitest/package.json')"`
+  to auto-detect the vitest major — unconditionally, so any non-
+  vitest project hit a hard crash during `tools install --yes`.
+  Now prefixed with `test -f node_modules/vitest/package.json ||
+  { echo 'vitest not present — skipping'; exit 0; }` so the install
+  no-ops cleanly when vitest isn't a target-repo dep.
+
+- **Semgrep / pip-audit / ruff / pip-licenses / coverage dep pins
+  colliding in the shared venv**. Pre-2.3.1 installed every Python
+  CLI tool into one venv at `~/.cache/dxkit/tools-venv/`. semgrep's
+  `tomli~=2.0.1` pin lost to pip-audit's newer tomli, breaking
+  semgrep on repos where both tools installed. Every Python CLI
+  (semgrep, ruff, pip-audit, pip-licenses, coverage) now uses
+  `pipx install <tool>`, putting each in its own isolated venv
+  under `~/.local/pipx/venvs/<tool>/`. Binaries symlink into
+  `~/.local/bin/` which is already in `getSystemPaths()`'s probe
+  list, so `findTool()` picks them up without further changes.
+  Bootstrap fragment auto-installs pipx via `pip --user` when
+  absent (handles PEP-668 Debian/Ubuntu with
+  `--break-system-packages` fallback).
+
+- **Graphify stays on the shared venv** — it's a Python *library*
+  that our graphify.ts subprocess imports, not a CLI tool, so pipx
+  doesn't apply. `TOOLS_VENV` narrows to graphify-only.
+
+- **"Install command exited 0 without producing the binary" now
+  reports as skipped, not failed**. Any install command can
+  legitimately no-op (guarded installs like vitest-coverage);
+  those no-ops shouldn't clutter the failure summary. Real
+  failures (non-zero exit) still classify as `failed`.
+
+### Known limitations (not blocking)
+
+- `npm install @vyuhlabs/dxkit` still emits deprecation warnings for
+  `inflight@1`, `glob@7`, `fstream`, `rimraf@2`, `lodash.isequal` —
+  all transitive under `exceljs` (via `archiver` → `archiver-utils`).
+  exceljs@4.4.0 is the latest available; the chain is upstream.
+  Warnings only, no functional impact; would require either switching
+  xlsx libraries (breaking) or upstream archiver modernization.
+
+### Validation on vyuhlabs-platform/userserver
+
+- `vyuh-dxkit tools` reports 12/13 tools found (vitest-coverage
+  correctly listed as missing since lb-mocha is in use)
+- `vyuh-dxkit tools install --yes` reports `0 installed, 1 skipped,
+  0 failed` (clean)
+- `vyuh-dxkit bom --xlsx --filter=top-level` completes in 17s,
+  writes `.dxkit/reports/bom-YYYY-MM-DD.{md,xlsx}` cleanly
+
 ## [2.3.0] - 2026-04-24
 
 Minor release — turns the `bom` report from enumeration (1700+ rows

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "AI-native developer experience toolkit for any repository",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -22,18 +22,43 @@ import type { LanguageId } from '../../languages';
 import { DetectedStack, ToolRequirement } from '../../types';
 
 /**
- * Shared Python venv location for every Python-based tool dxkit installs
- * (graphify, semgrep, ruff, pip-audit, pip-licenses, coverage). Lives
- * under `~/.cache/dxkit/` so it survives `/tmp` cleanup. Previously
- * `/tmp/graphify-venv` — D013's "~50% flake" was that cleanup, plus
- * concurrent-run races on first install. `.cache/` is XDG-compliant
- * and persistent; `test -d` in the shell install commands keeps creation
- * idempotent.
+ * Shared Python venv location for graphify specifically. Graphify is a
+ * Python *library* that our graphify.ts subprocess imports directly,
+ * not a CLI tool — so it needs a stable venv-relative path we can spawn
+ * from, unlike the CLI tools which are better served by pipx (see
+ * below).
+ *
+ * Lives under `~/.cache/dxkit/` so it survives `/tmp` cleanup. Previously
+ * `/tmp/graphify-venv` (D013's "~50% flake" was the cleanup + concurrent-
+ * run race on first install). `.cache/` is XDG-compliant and persistent;
+ * `test -d` in the shell install commands keeps creation idempotent.
  */
 export const TOOLS_VENV = path.join(os.homedir(), '.cache', 'dxkit', 'tools-venv');
 /** Legacy path still probed for backwards compat: repos that already set
  *  up the old venv won't force a reinstall on upgrade. */
 const LEGACY_TOOLS_VENV = '/tmp/graphify-venv';
+
+/**
+ * pipx bootstrap + install fragment. Inlined into every Python CLI tool's
+ * install command so each tool gets its OWN isolated venv under
+ * `~/.local/pipx/venvs/<tool>/` with its own dep resolution. Fixes the
+ * 2.3.0 failure mode where semgrep (tomli~=2.0.1) and pip-audit (newer
+ * tomli) fought in the shared venv.
+ *
+ *   1. If `pipx` is on PATH, use it.
+ *   2. Else try `python3 -m pip install --user pipx` (legacy + non-PEP-668).
+ *   3. PEP 668 distros (Debian 12+, Ubuntu 23.04+) refuse `pip --user` on
+ *      externally-managed Python; fall back to
+ *      `--user --break-system-packages`.
+ *   4. Prepend `~/.local/bin` to PATH so the freshly-installed pipx is
+ *      found within the same shell.
+ *
+ * Result: `pipx install <tool>` symlinks the binary into `~/.local/bin/`,
+ * which is already in `getSystemPaths()` probes so `findTool()` picks it
+ * up on the next run.
+ */
+const PIPX_BOOTSTRAP =
+  'command -v pipx >/dev/null 2>&1 || { python3 -m pip install --user pipx 2>/dev/null || python3 -m pip install --user --break-system-packages pipx; } && export PATH="$HOME/.local/bin:$PATH"';
 
 export interface ToolDefinition extends ToolRequirement {
   /** Binary name(s) to look for in PATH. First match wins. */
@@ -374,7 +399,7 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
   semgrep: {
     name: 'semgrep',
     description: 'Static analysis security scanner (SAST)',
-    install: 'pip install semgrep',
+    install: 'pipx install semgrep',
     check: 'semgrep --version',
     for: 'all',
     layer: 'universal',
@@ -382,11 +407,9 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     probePaths: [`${TOOLS_VENV}/bin`, `${LEGACY_TOOLS_VENV}/bin`],
     versionCheck: 'semgrep --version 2>/dev/null',
     installCommands: {
-      macos:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install -q semgrep && mkdir -p ~/.local/bin && ln -sf $HOME/.cache/dxkit/tools-venv/bin/semgrep ~/.local/bin/semgrep',
-      linux:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install -q semgrep && mkdir -p ~/.local/bin && ln -sf $HOME/.cache/dxkit/tools-venv/bin/semgrep ~/.local/bin/semgrep',
-      windows: 'pip install --user semgrep',
+      macos: `${PIPX_BOOTSTRAP} && pipx install semgrep`,
+      linux: `${PIPX_BOOTSTRAP} && pipx install semgrep`,
+      windows: 'pipx install semgrep',
     },
   },
   eslint: {
@@ -439,42 +462,39 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
   ruff: {
     name: 'ruff',
     description: 'Python linting and formatting',
-    install: 'pip install ruff',
+    install: 'pipx install ruff',
     check: 'ruff --version',
     for: 'python',
     layer: 'language',
     binaries: ['ruff'],
+    probePaths: [`${TOOLS_VENV}/bin`, `${LEGACY_TOOLS_VENV}/bin`],
     versionCheck: 'ruff --version 2>/dev/null',
     installCommands: {
-      // Use the dxkit venv (created during graphify install) for Python tools
-      macos:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install ruff && mkdir -p ~/.local/bin && ln -sf $HOME/.cache/dxkit/tools-venv/bin/ruff ~/.local/bin/ruff',
-      linux:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install ruff && mkdir -p ~/.local/bin && ln -sf $HOME/.cache/dxkit/tools-venv/bin/ruff ~/.local/bin/ruff',
-      windows: 'pip install --user ruff',
+      macos: `${PIPX_BOOTSTRAP} && pipx install ruff`,
+      linux: `${PIPX_BOOTSTRAP} && pipx install ruff`,
+      windows: 'pipx install ruff',
     },
   },
   'pip-audit': {
     name: 'pip-audit',
     description: 'Python dependency vulnerability scanning',
-    install: 'pip install pip-audit',
+    install: 'pipx install pip-audit',
     check: 'pip-audit --version',
     for: 'python',
     layer: 'language',
     binaries: ['pip-audit'],
+    probePaths: [`${TOOLS_VENV}/bin`, `${LEGACY_TOOLS_VENV}/bin`],
     versionCheck: 'pip-audit --version 2>/dev/null',
     installCommands: {
-      macos:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install pip-audit && mkdir -p ~/.local/bin && ln -sf $HOME/.cache/dxkit/tools-venv/bin/pip-audit ~/.local/bin/pip-audit',
-      linux:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install pip-audit && mkdir -p ~/.local/bin && ln -sf $HOME/.cache/dxkit/tools-venv/bin/pip-audit ~/.local/bin/pip-audit',
-      windows: 'pip install --user pip-audit',
+      macos: `${PIPX_BOOTSTRAP} && pipx install pip-audit`,
+      linux: `${PIPX_BOOTSTRAP} && pipx install pip-audit`,
+      windows: 'pipx install pip-audit',
     },
   },
   'pip-licenses': {
     name: 'pip-licenses',
     description: 'License inventory for Python packages in a venv',
-    install: 'pip install pip-licenses',
+    install: 'pipx install pip-licenses',
     check: 'pip-licenses --version',
     for: 'python',
     layer: 'language',
@@ -482,11 +502,9 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     probePaths: [`${TOOLS_VENV}/bin`, `${LEGACY_TOOLS_VENV}/bin`],
     versionCheck: 'pip-licenses --version 2>/dev/null',
     installCommands: {
-      macos:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install pip-licenses && mkdir -p ~/.local/bin && ln -sf $HOME/.cache/dxkit/tools-venv/bin/pip-licenses ~/.local/bin/pip-licenses',
-      linux:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install pip-licenses && mkdir -p ~/.local/bin && ln -sf $HOME/.cache/dxkit/tools-venv/bin/pip-licenses ~/.local/bin/pip-licenses',
-      windows: 'pip install --user pip-licenses',
+      macos: `${PIPX_BOOTSTRAP} && pipx install pip-licenses`,
+      linux: `${PIPX_BOOTSTRAP} && pipx install pip-licenses`,
+      windows: 'pipx install pip-licenses',
     },
   },
   'golangci-lint': {
@@ -621,13 +639,20 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     layer: 'language',
     binaries: [],
     nodePackage: '@vitest/coverage-v8',
+    // Version auto-detect via `require('vitest/package.json')` assumed
+    // vitest was present in the target repo. Repos using mocha/jest/ava
+    // hit a MODULE_NOT_FOUND crash (pre-2.3.1 failure mode). Gate with
+    // an existence check so the install no-ops cleanly when vitest
+    // isn't declared — vitest-coverage is only useful alongside vitest.
     installCommands: {
-      // Version must match installed vitest major — auto-detect it.
       macos:
-        "npm install --save-dev \"@vitest/coverage-v8@$(node -e \"process.stdout.write('^'+require('vitest/package.json').version.split('.')[0])\")\"",
+        "test -f node_modules/vitest/package.json || { echo 'vitest not present in this repo — skipping @vitest/coverage-v8'; exit 0; } && npm install --save-dev \"@vitest/coverage-v8@$(node -e \"process.stdout.write('^'+require('vitest/package.json').version.split('.')[0])\")\"",
       linux:
-        "npm install --save-dev \"@vitest/coverage-v8@$(node -e \"process.stdout.write('^'+require('vitest/package.json').version.split('.')[0])\")\"",
-      windows: 'npm install --save-dev @vitest/coverage-v8',
+        "test -f node_modules/vitest/package.json || { echo 'vitest not present in this repo — skipping @vitest/coverage-v8'; exit 0; } && npm install --save-dev \"@vitest/coverage-v8@$(node -e \"process.stdout.write('^'+require('vitest/package.json').version.split('.')[0])\")\"",
+      // The log call here is inside a `node -e` shell-string argument,
+      // not real TS source. slop-ok on the line silences the gate.
+      windows:
+        "node -e \"try{require('vitest/package.json');process.exit(0)}catch{console.log('vitest not present — skipping');process.exit(0)}\" || npm install --save-dev @vitest/coverage-v8", // slop-ok
     },
   },
   'cargo-llvm-cov': {
@@ -648,18 +673,17 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
   'coverage-py': {
     name: 'coverage-py',
     description: 'Python line-level coverage (produces coverage.json)',
-    install: 'pip install coverage',
+    install: 'pipx install coverage',
     check: 'coverage --version',
     for: 'python',
     layer: 'language',
     binaries: ['coverage'],
+    probePaths: [`${TOOLS_VENV}/bin`, `${LEGACY_TOOLS_VENV}/bin`],
     versionCheck: 'coverage --version 2>/dev/null',
     installCommands: {
-      macos:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install coverage && mkdir -p ~/.local/bin && ln -sf $HOME/.cache/dxkit/tools-venv/bin/coverage ~/.local/bin/coverage',
-      linux:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install coverage && mkdir -p ~/.local/bin && ln -sf $HOME/.cache/dxkit/tools-venv/bin/coverage ~/.local/bin/coverage',
-      windows: 'pip install --user coverage',
+      macos: `${PIPX_BOOTSTRAP} && pipx install coverage`,
+      linux: `${PIPX_BOOTSTRAP} && pipx install coverage`,
+      windows: 'pipx install coverage',
     },
   },
 };

--- a/src/tools-cli.ts
+++ b/src/tools-cli.ts
@@ -162,7 +162,13 @@ async function runInstall(targetPath: string, autoYes: boolean): Promise<void> {
       logger.info(`Running: ${cmd}`);
       const result = runInstallCmd(cmd);
       if (result.success) {
-        // Verify install worked
+        // Verify install worked. An install command can legitimately
+        // exit 0 without producing the binary — e.g. the vitest-coverage
+        // guard no-ops when vitest isn't a target-repo dep. Treat
+        // "exit 0 + tool still missing" as a skip, not a failure: the
+        // script ran cleanly, we just didn't get the binary we wanted.
+        // Real install failures surface through the `result.success ===
+        // false` branch below (non-zero exit).
         const recheck = findTool(def, targetPath);
         if (recheck.available) {
           results.push({ name: s.name, status: 'installed' });
@@ -170,10 +176,10 @@ async function runInstall(targetPath: string, autoYes: boolean): Promise<void> {
         } else {
           results.push({
             name: s.name,
-            status: 'failed',
-            msg: 'install command succeeded but tool not found',
+            status: 'skipped',
+            msg: 'install command exited 0 without producing the binary (likely a guarded no-op)',
           });
-          logger.fail(`${s.name} install command ran but tool not found in PATH`);
+          logger.dim(`${s.name} skipped — install command exited cleanly without installing`);
         }
       } else {
         results.push({ name: s.name, status: 'failed', msg: result.message });


### PR DESCRIPTION
## Summary

Patch release fixing three install-robustness issues a real user hit on `vyuhlabs-platform`:

| Pre-2.3.1 failure | Fix |
|---|---|
| `@vitest/coverage-v8` install crashed with `MODULE_NOT_FOUND` on repos without vitest (mocha / jest / lb-mocha / ava) | Guarded: `test -f node_modules/vitest/package.json \|\| exit 0` before the `require()` |
| semgrep's `tomli~=2.0.1` pin collided with pip-audit's newer tomli in the shared venv, breaking semgrep | Every Python CLI (semgrep, ruff, pip-audit, pip-licenses, coverage) → `pipx install <tool>` (isolated venvs per tool) |
| `tools install` flagged a guarded no-op as "failed" | Exit-0 without producing the binary → classified as "skipped"; real failures (non-zero exit) still "failed" |

## What changed

### `src/analyzers/tools/tool-registry.ts`

- **New `PIPX_BOOTSTRAP` fragment** — inlined into every Python CLI's install command: auto-installs pipx via `python3 -m pip install --user pipx`, with `--break-system-packages` fallback for PEP-668 distros (Debian 12+, Ubuntu 23.04+). Prepends `~/.local/bin` to PATH so the freshly-installed pipx is found within the same shell.

- **5 Python CLI tools migrated**: semgrep, ruff, pip-audit, pip-licenses, coverage. Each now installs via `pipx install <tool>` → its own venv under `~/.local/pipx/venvs/<tool>/` → binary symlinked to `~/.local/bin/` (already in `getSystemPaths()` probes, so `findTool()` picks it up).

- **Graphify stays on `TOOLS_VENV`** — it's a Python *library* the graphify.ts subprocess imports, not a CLI tool. `TOOLS_VENV` narrows to graphify-only. Legacy `/tmp/graphify-venv` still probed for backwards compat.

- **vitest-coverage install command** prefixed with `test -f node_modules/vitest/package.json || { echo 'skipping'; exit 0; } &&` so the install cleanly no-ops on non-vitest repos.

### `src/tools-cli.ts`

Tightened post-flight: install command exits 0 + tool still missing → `skipped` (not `failed`). Applies to any guarded install that intentionally no-ops. Real failures still classify as failed via the non-zero-exit branch.

## Validation on vyuhlabs-platform/userserver

```
$ vyuh-dxkit tools                         # pre-install status
… 12/13 tools found, vitest-coverage missing (correctly — lb-mocha repo)

$ vyuh-dxkit tools install --yes           # post-fix
  vitest-coverage skipped — install command exited cleanly without installing
  → 0 installed, 1 skipped, 0 failed

$ vyuh-dxkit bom --xlsx --filter=top-level # end-to-end
  Packages indexed: 28 of 698 (filter=top-level)
  Vulnerable packages: 2 (3 advisories)
  Completed in 17.1s
  ✓ Report saved to .dxkit/reports/bom-2026-04-24.md
  ✓ XLSX saved to .dxkit/reports/bom-2026-04-24.xlsx
```

## Known limitation (not blocking, not fixing this release)

`npm install @vyuhlabs/dxkit` emits deprecation warnings (`inflight@1`, `glob@7`, `fstream`, `rimraf@2`, `lodash.isequal`). All transitive under `exceljs` → `archiver` → `archiver-utils`. exceljs@4.4.0 is the latest; the chain is upstream. Warnings only, no functional impact. Noted in CHANGELOG.

## Validation

- [x] 697 tests passing (no new tests — install-script fix, not logic)
- [x] Typecheck + lint + format + architecture + pre-push CI-mirror gate clean
- [x] Real-world smoke on vyuhlabs-platform/userserver (see above)

## Reviewer checklist

- [ ] PIPX_BOOTSTRAP handles the PEP-668 case correctly (Debian 12+, Ubuntu 23.04+ refuse `pip --user` without `--break-system-packages`)
- [ ] Legacy `TOOLS_VENV` path probe preserved so existing users don't face a forced reinstall
- [ ] `tools install` skipped/failed semantic change isn't confusing — CHANGELOG calls it out
- [ ] CHANGELOG `[2.3.1]` describes all three fixes + the known exceljs limitation

## Release sequence

After merge: same hardened pipeline as 2.2.1 + 2.3.0 — tag `v2.3.1` → GitHub Release → CI publishes with 4 preflights + provenance + shasum verify.