### PR TITLE
feat: advisory fingerprint + structured upgradePlan (Phase 10h.6.5 + .6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — agent handoff (Phase 10h.6 kickoff)
+
+- **Advisory fingerprint** — `DepVulnFinding.fingerprint` is a stable
+  16-char hash of `(package, installedVersion, id)`, stamped by the
+  cross-pack aggregator after enrichment. Identity is input-only —
+  re-scoring or enrichment changes do not mint a new fingerprint.
+  `BomReport.summary.fingerprints` ships the sorted-deduplicated
+  manifest so external tooling (suppressions, CI gates, upgrade bots)
+  can diff two reports by plain set difference. New helper
+  `src/analyzers/tools/fingerprint.ts`.
+
+- **Structured upgradePlan** — `DepVulnFinding.upgradePlan` is a typed
+  sibling to the existing free-text `upgradeAdvice`:
+  `{ parent, parentVersion, patches[], breaking }`. Populated by the
+  Tier-2 fix tools landing in 10h.6.1–.4 (`osv-scanner fix`,
+  `pip-audit --fix`, `cargo audit fix`, the cross-pack transitive
+  resolver). Free-text advice stays for markdown/xlsx readability;
+  autonomous upgrade bots consume the structured form. New type
+  `DepVulnUpgradePlan`.
+
 ## [2.3.2] - 2026-04-24
 
 PM-grade bom reports. The xlsx and markdown outputs both restructure

--- a/src/analyzers/bom/index.ts
+++ b/src/analyzers/bom/index.ts
@@ -16,6 +16,7 @@
 
 import * as path from 'path';
 import { detect } from '../../detect';
+import { collectFingerprints } from '../tools/fingerprint';
 import { run } from '../tools/runner';
 import { discoverProjectRoots } from './discovery';
 import { buildByTopLevelDep, gatherBomEntries, mergeNestedBomEntries } from './gather';
@@ -79,6 +80,12 @@ export async function analyzeBom(
     if (!e.joinedFromBoth) vulnOnlyPackages++;
   }
 
+  // Manifest of every advisory identity in the (post-filter) report.
+  // Drawn from `entries` rather than `rawEntries` so `filter=top-level`
+  // reports surface only the fingerprints the caller actually sees —
+  // diffing two filtered reports stays consistent.
+  const fingerprints = collectFingerprints(entries.flatMap((e) => e.vulns));
+
   return {
     repo: stack.projectName || path.basename(repoPath),
     analyzedAt: new Date().toISOString(),
@@ -96,6 +103,7 @@ export async function analyzeBom(
       filter,
       unfilteredTotalPackages: rawEntries.length,
       projectRoots,
+      fingerprints,
     },
     entries,
     toolsUsed,

--- a/src/analyzers/bom/types.ts
+++ b/src/analyzers/bom/types.ts
@@ -131,6 +131,17 @@ export interface BomReport {
      *  distinct. When nested scan is disabled or only one root was
      *  found, this is `["."]` so consumers can treat it uniformly. */
     projectRoots: string[];
+    /** Sorted, deduplicated list of every advisory `fingerprint`
+     *  covered by this report. Each fingerprint is a stable hash of
+     *  `(package, installedVersion, id)` stamped by the cross-pack
+     *  dep-vuln aggregator. Consumers diff two reports by set
+     *  difference on this list — added fingerprints are new
+     *  advisories, removed ones are resolved. The per-finding
+     *  fingerprint also lives on each `BomEntry.vulns[].fingerprint`
+     *  for attribution; this field is a convenience manifest so
+     *  external tooling (suppressions, CI gates, upgrade bots) can
+     *  diff without walking every entry. */
+    fingerprints: string[];
   };
   entries: ReadonlyArray<BomEntry>;
   toolsUsed: string[];

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -9,6 +9,7 @@
  */
 import { run } from '../tools/runner';
 import { enrichEpss, extractCveId } from '../tools/epss';
+import { stampFingerprints } from '../tools/fingerprint';
 import { enrichKev } from '../tools/kev';
 import { resolveAliases } from '../tools/osv';
 import { buildReachablePackageSet, markReachable } from '../tools/reachability';
@@ -173,6 +174,11 @@ export async function gatherDepVulns(cwd: string): Promise<DepVulnSummary> {
   // alias list including the CVE. One OSV roundtrip resolves the
   // whole batch; one EPSS roundtrip scores them all.
   const findings = envelope.findings ?? [];
+  // Stamp durable identity on every finding before enrichment. The hash
+  // inputs are package/version/id only, so stamping is independent of
+  // EPSS/KEV/reachability results — keeps `fingerprint` stable across
+  // runs even if enrichment tooling changes underneath.
+  stampFingerprints(findings);
   if (findings.length > 0) {
     const cveByFinding = new Map<number, string>();
     const needsAliasLookup: Array<{ idx: number; primary: string }> = [];

--- a/src/analyzers/tools/fingerprint.ts
+++ b/src/analyzers/tools/fingerprint.ts
@@ -1,0 +1,82 @@
+/**
+ * Advisory fingerprints — durable per-finding identity across runs.
+ *
+ * The dispatcher's dep-vuln aggregator (src/analyzers/security/gather.ts)
+ * stamps every finding with a stable hash of `(package, installedVersion,
+ * id)` before scoring + reporting. The same advisory against the same
+ * installed version produces the same fingerprint on every run, so
+ * consumers (agent-driven upgrade bots, suppressions, CI gates) can diff
+ * a current bom against a stored prior to detect:
+ *
+ *   - new advisories (fingerprint present now, absent before)
+ *   - resolved advisories (fingerprint absent now, present before)
+ *   - unchanged advisories (fingerprint in both sets)
+ *
+ * Excluded from the hash:
+ *   - severity / cvssScore — re-scoring the same advisory against the
+ *     same install must not mint a new identity
+ *   - enrichment fields (epssScore, kev, reachable, riskScore) — same
+ *     reason; these are signals about the advisory, not part of it
+ *   - producer `tool` — the same advisory hit by two producers (e.g.
+ *     npm-audit + snyk) should collapse to one identity
+ *   - `upgradeAdvice` / `upgradePlan` — resolution suggestions change
+ *     across releases of the fix tooling; identity must outlive them
+ *
+ * Format: 16-char lowercase hex (first 8 bytes of SHA-1). Short enough
+ * to embed inline in reports, long enough to make collisions between
+ * non-identical tuples effectively impossible for repo-scale sets.
+ */
+
+import { createHash } from 'crypto';
+import type { DepVulnFinding } from '../../languages/capabilities/types';
+
+/**
+ * Stable 16-char hex fingerprint for one DepVulnFinding. Input tuple
+ * is NUL-separated (not present in any legal package / version / id)
+ * so distinct tuples can never collide via concatenation tricks.
+ *
+ * `installedVersion` is normalized to the empty string when absent so
+ * version-less findings (rare — some providers omit it when the lock
+ * file is missing) still get a deterministic fingerprint instead of
+ * mixing an ambient `undefined` into the hash input.
+ */
+export function computeFingerprint(
+  finding: Pick<DepVulnFinding, 'package' | 'installedVersion' | 'id'>,
+): string {
+  const input = `${finding.package}\0${finding.installedVersion ?? ''}\0${finding.id}`;
+  return createHash('sha1').update(input).digest('hex').slice(0, 16);
+}
+
+/**
+ * Stamp `fingerprint` on every finding in place. Called once in
+ * `gatherDepVulns` after cross-pack merge + enrichment so every
+ * downstream consumer (bom, security/detailed, JSON export) sees a
+ * fully-stamped finding.
+ *
+ * Idempotent: re-stamping a finding that already has a fingerprint
+ * overwrites it with the same value. Safe to call multiple times,
+ * though the gather path only invokes it once.
+ */
+export function stampFingerprints(findings: DepVulnFinding[]): void {
+  for (const f of findings) {
+    f.fingerprint = computeFingerprint(f);
+  }
+}
+
+/**
+ * Sorted, deduplicated fingerprint list for a set of findings. Used by
+ * `analyzeBom` to populate `BomReport.summary.fingerprints` — a single
+ * manifest of every advisory identity the report covers, convenient
+ * for external diff tooling without walking `entries[].vulns[]`.
+ *
+ * Silently skips findings missing a fingerprint (should not happen
+ * post-gather, but a safety net against a future producer that emits
+ * findings outside the `gatherDepVulns` path).
+ */
+export function collectFingerprints(findings: ReadonlyArray<DepVulnFinding>): string[] {
+  const set = new Set<string>();
+  for (const f of findings) {
+    if (f.fingerprint) set.add(f.fingerprint);
+  }
+  return [...set].sort();
+}

--- a/src/languages/capabilities/types.ts
+++ b/src/languages/capabilities/types.ts
@@ -38,6 +38,49 @@ export interface CapabilityEnvelope {
 }
 
 /**
+ * Structured upgrade proposal for one advisory. Populated by Tier-2 fix
+ * tools (`osv-scanner fix --dry-run`, `pip-audit --fix --dry-run`,
+ * `cargo audit fix --dry-run`) and by the cross-pack transitive fix
+ * resolver. Lives alongside the free-text `upgradeAdvice` (retained for
+ * markdown readability) so autonomous upgrade bots consume a typed
+ * payload and humans keep readable copy.
+ *
+ * Example: advisory against `minimatch@3.0.4` reachable via
+ * `@loopback/cli@6.0.0` — the Tier-2 tool resolves that upgrading
+ * `@loopback/cli` to `7.0.1` pulls a patched `minimatch`:
+ *
+ *   {
+ *     parent: '@loopback/cli',
+ *     parentVersion: '7.0.1',
+ *     patches: ['GHSA-xxxx-yyyy-zzzz', 'CVE-2022-1234'],
+ *     breaking: true,
+ *   }
+ *
+ * `parent` equals the finding's own `package` when the vulnerable
+ * package itself is a direct dep. `patches` lists every advisory id the
+ * proposed upgrade would resolve (may be > 1 when one parent bump
+ * patches multiple transitive advisories — the common "upgrade
+ * @loopback/cli to fix 29 advisories" case). `breaking` is the tool's
+ * own classification of whether the proposed jump crosses a major
+ * version boundary.
+ */
+export interface DepVulnUpgradePlan {
+  /** Package to upgrade (top-level dep when different from the
+   *  finding's `package`; otherwise the finding's own package). */
+  parent: string;
+  /** Target version for the parent. Semver triple, no range prefix. */
+  parentVersion: string;
+  /** Advisory ids this upgrade resolves — always includes the finding's
+   *  own `id`; may include sibling advisories when one parent bump
+   *  patches several transitives at once. Sorted, deduplicated. */
+  patches: string[];
+  /** True when the target version crosses a major boundary from the
+   *  installed parent version. Producer-classified; consumers treat it
+   *  as a triage hint, not a guarantee. */
+  breaking: boolean;
+}
+
+/**
  * Per-finding detail for dep-vuln reports that need more than counts.
  *
  * Field tiers (when each tier populates which fields):
@@ -47,11 +90,11 @@ export interface CapabilityEnvelope {
  *     cvssScore?, aliases?, summary?, references?
  *   Tier 2 (per-pack fix-tool — osv-scanner fix / pip-audit --fix /
  *           cargo audit fix):
- *     upgradeAdvice, breakingUpgrade, reachable (osv-scanner only)
+ *     upgradeAdvice, breakingUpgrade, upgradePlan, reachable (osv-scanner only)
  *   Tier 3 (exploitability enrichment — EPSS, CISA KEV):
  *     epssScore, kev
  *   Tier 4 (snyk opt-in):
- *     reachable, riskScore, upgradeAdvice, breakingUpgrade
+ *     reachable, riskScore, upgradeAdvice, breakingUpgrade, upgradePlan
  *
  * All non-identity fields are optional so higher tiers can extend without
  * changing this contract.
@@ -73,8 +116,14 @@ export interface DepVulnFinding {
 
   // Resolution. Tier 1 emits fixedVersion only; render derives advice
   // from it. Tier 2/4 may write upgradeAdvice + breakingUpgrade directly.
+  // `upgradePlan` is the structured sibling of `upgradeAdvice` — populated
+  // by Tier-2 fix tools and the cross-pack transitive resolver so
+  // autonomous upgrade bots consume a typed payload; `upgradeAdvice`
+  // stays as the human-readable string for markdown/xlsx. Both may be
+  // present; consumers prefer `upgradePlan` when it exists.
   fixedVersion?: string;
   upgradeAdvice?: string;
+  upgradePlan?: DepVulnUpgradePlan;
   breakingUpgrade?: boolean;
 
   // Exploitability. Tier 3 (EPSS / CISA KEV) and Tier 4 (snyk reachability /
@@ -101,6 +150,17 @@ export interface DepVulnFinding {
   // sufficient for upgrade-scope grouping; refined paths land in 10h.5
   // if reachability analysis needs them.
   topLevelDep?: string[];
+
+  // Durable per-finding identity across runs. Stamped by the cross-pack
+  // aggregator in `gatherDepVulns` after enrichment — producers never
+  // populate it. Enables set-diff of today's findings vs last run: a
+  // fingerprint that disappears means an advisory was resolved; a new
+  // one means a regression. Stable hash of `(package, installedVersion,
+  // id)` — does not include severity/enrichment fields so re-scoring
+  // the same advisory against the same install doesn't mint a new
+  // identity. `BomReport.summary.fingerprints` carries the full list
+  // as a single manifest for external diff tooling.
+  fingerprint?: string;
 }
 
 /** Dependency vulnerabilities, the depVulns capability. */

--- a/test/bom-triage.test.ts
+++ b/test/bom-triage.test.ts
@@ -21,6 +21,7 @@ function mkReport(entries: BomEntry[]): BomReport {
       filter: 'all',
       unfilteredTotalPackages: entries.length,
       projectRoots: ['.'],
+      fingerprints: [],
     },
     entries,
     toolsUsed: [],

--- a/test/fingerprint.test.ts
+++ b/test/fingerprint.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collectFingerprints,
+  computeFingerprint,
+  stampFingerprints,
+} from '../src/analyzers/tools/fingerprint';
+import type { DepVulnFinding } from '../src/languages/capabilities/types';
+
+/** Minimal DepVulnFinding builder for tests — identity + severity only. */
+function mkFinding(
+  overrides: Partial<DepVulnFinding> & Pick<DepVulnFinding, 'id' | 'package'>,
+): DepVulnFinding {
+  return {
+    id: overrides.id,
+    package: overrides.package,
+    installedVersion: overrides.installedVersion ?? '1.0.0',
+    tool: overrides.tool ?? 'npm-audit',
+    severity: overrides.severity ?? 'high',
+    ...overrides,
+  };
+}
+
+describe('computeFingerprint', () => {
+  it('is deterministic for identical (package, installedVersion, id) triples', () => {
+    const a = computeFingerprint({ package: 'axios', installedVersion: '0.18.0', id: 'GHSA-xxx' });
+    const b = computeFingerprint({ package: 'axios', installedVersion: '0.18.0', id: 'GHSA-xxx' });
+    expect(a).toBe(b);
+  });
+
+  it('returns a 16-char lowercase hex string', () => {
+    const fp = computeFingerprint({
+      package: 'lodash',
+      installedVersion: '4.17.0',
+      id: 'CVE-2020-8203',
+    });
+    expect(fp).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('differs when package differs', () => {
+    const a = computeFingerprint({ package: 'axios', installedVersion: '1.0.0', id: 'CVE-2024-1' });
+    const b = computeFingerprint({
+      package: 'lodash',
+      installedVersion: '1.0.0',
+      id: 'CVE-2024-1',
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('differs when version differs', () => {
+    const a = computeFingerprint({
+      package: 'axios',
+      installedVersion: '0.18.0',
+      id: 'CVE-2024-1',
+    });
+    const b = computeFingerprint({
+      package: 'axios',
+      installedVersion: '0.19.0',
+      id: 'CVE-2024-1',
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('differs when id differs', () => {
+    const a = computeFingerprint({
+      package: 'axios',
+      installedVersion: '0.18.0',
+      id: 'CVE-2024-1',
+    });
+    const b = computeFingerprint({
+      package: 'axios',
+      installedVersion: '0.18.0',
+      id: 'CVE-2024-2',
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('treats missing installedVersion as empty string, not undefined string literal', () => {
+    const missing = computeFingerprint({ package: 'pkg', id: 'CVE-x' });
+    const explicitUndef = computeFingerprint({
+      package: 'pkg',
+      installedVersion: undefined,
+      id: 'CVE-x',
+    });
+    const emptyStr = computeFingerprint({ package: 'pkg', installedVersion: '', id: 'CVE-x' });
+    // All three must agree — version-less findings hash the same way.
+    expect(missing).toBe(emptyStr);
+    expect(explicitUndef).toBe(emptyStr);
+    // And the fingerprint must not leak the literal 'undefined' string.
+    const literalUndef = computeFingerprint({
+      package: 'pkg',
+      installedVersion: 'undefined',
+      id: 'CVE-x',
+    });
+    expect(literalUndef).not.toBe(missing);
+  });
+
+  it('does not collide when NUL-separating would matter (ab|c vs a|bc)', () => {
+    // Without the NUL separator, package='ab' + version='c' would produce
+    // the same input stream as package='a' + version='bc'. The separator
+    // defends against that.
+    const a = computeFingerprint({ package: 'ab', installedVersion: 'c', id: 'x' });
+    const b = computeFingerprint({ package: 'a', installedVersion: 'bc', id: 'x' });
+    expect(a).not.toBe(b);
+  });
+
+  it('ignores severity / enrichment / producer tool fields', () => {
+    // Two findings with identical identity but different signals must
+    // produce the same fingerprint — re-scoring an advisory can't mint
+    // a new identity.
+    const base = computeFingerprint({ package: 'p', installedVersion: '1', id: 'i' });
+    const withSeverity = computeFingerprint(
+      mkFinding({ package: 'p', installedVersion: '1', id: 'i', severity: 'critical' }),
+    );
+    const withEnrichment = computeFingerprint(
+      mkFinding({
+        package: 'p',
+        installedVersion: '1',
+        id: 'i',
+        epssScore: 0.9,
+        kev: true,
+        reachable: true,
+        riskScore: 95,
+      }),
+    );
+    const withDifferentTool = computeFingerprint(
+      mkFinding({ package: 'p', installedVersion: '1', id: 'i', tool: 'snyk' }),
+    );
+    expect(withSeverity).toBe(base);
+    expect(withEnrichment).toBe(base);
+    expect(withDifferentTool).toBe(base);
+  });
+});
+
+describe('stampFingerprints', () => {
+  it('stamps every finding in place with its computed fingerprint', () => {
+    const findings: DepVulnFinding[] = [
+      mkFinding({ id: 'CVE-a', package: 'p1' }),
+      mkFinding({ id: 'CVE-b', package: 'p2' }),
+    ];
+    stampFingerprints(findings);
+    expect(findings[0].fingerprint).toBe(
+      computeFingerprint({ package: 'p1', installedVersion: '1.0.0', id: 'CVE-a' }),
+    );
+    expect(findings[1].fingerprint).toBe(
+      computeFingerprint({ package: 'p2', installedVersion: '1.0.0', id: 'CVE-b' }),
+    );
+  });
+
+  it('is idempotent', () => {
+    const findings: DepVulnFinding[] = [mkFinding({ id: 'CVE-1', package: 'axios' })];
+    stampFingerprints(findings);
+    const first = findings[0].fingerprint;
+    stampFingerprints(findings);
+    expect(findings[0].fingerprint).toBe(first);
+  });
+
+  it('handles an empty list without throwing', () => {
+    expect(() => stampFingerprints([])).not.toThrow();
+  });
+});
+
+describe('collectFingerprints', () => {
+  it('returns sorted, deduplicated fingerprints', () => {
+    const findings: DepVulnFinding[] = [
+      mkFinding({ id: 'CVE-a', package: 'p1' }),
+      mkFinding({ id: 'CVE-b', package: 'p2' }),
+      mkFinding({ id: 'CVE-a', package: 'p1' }), // exact duplicate
+    ];
+    stampFingerprints(findings);
+    const list = collectFingerprints(findings);
+    expect(list).toHaveLength(2);
+    expect([...list]).toEqual([...list].sort());
+  });
+
+  it('skips findings missing a fingerprint rather than throwing', () => {
+    const findings: DepVulnFinding[] = [
+      mkFinding({ id: 'CVE-a', package: 'p1' }),
+      mkFinding({ id: 'CVE-b', package: 'p2' }),
+    ];
+    // Only stamp the first one.
+    findings[0].fingerprint = computeFingerprint(findings[0]);
+    const list = collectFingerprints(findings);
+    expect(list).toEqual([findings[0].fingerprint]);
+  });
+});

--- a/test/upgrade-plan.test.ts
+++ b/test/upgrade-plan.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import type { DepVulnFinding, DepVulnUpgradePlan } from '../src/languages/capabilities/types';
+
+/**
+ * Shape contract for `DepVulnUpgradePlan`. The type is populated by
+ * future Tier-2 fix tools (10h.6.1/.2/.3) and the cross-pack transitive
+ * resolver (10h.6.4); this test locks the wire format down early so
+ * those commits can only add producers, never rework the shape.
+ */
+describe('DepVulnUpgradePlan', () => {
+  it('is JSON-serializable without loss', () => {
+    const plan: DepVulnUpgradePlan = {
+      parent: '@loopback/cli',
+      parentVersion: '7.0.1',
+      patches: ['GHSA-xxxx-yyyy-zzzz', 'CVE-2022-1234'],
+      breaking: true,
+    };
+    const round = JSON.parse(JSON.stringify(plan)) as DepVulnUpgradePlan;
+    expect(round).toEqual(plan);
+  });
+
+  it('attaches to a DepVulnFinding alongside upgradeAdvice', () => {
+    // Both fields coexist — upgradeAdvice stays for markdown, upgradePlan
+    // is the agent-consumable structured form. Renderers pick the richer
+    // available value per consumer.
+    const finding: DepVulnFinding = {
+      id: 'GHSA-xxxx-yyyy-zzzz',
+      package: 'minimatch',
+      installedVersion: '3.0.4',
+      tool: 'npm-audit',
+      severity: 'high',
+      upgradeAdvice: 'Upgrade @loopback/cli to 7.0.1 (patches 2 advisories)',
+      upgradePlan: {
+        parent: '@loopback/cli',
+        parentVersion: '7.0.1',
+        patches: ['GHSA-xxxx-yyyy-zzzz', 'CVE-2022-1234'],
+        breaking: true,
+      },
+    };
+    expect(finding.upgradePlan?.parent).toBe('@loopback/cli');
+    expect(finding.upgradePlan?.patches).toHaveLength(2);
+    expect(finding.upgradePlan?.patches).toContain(finding.id);
+  });
+
+  it('supports the direct-dep case where parent equals the finding package', () => {
+    const finding: DepVulnFinding = {
+      id: 'CVE-2024-1',
+      package: 'axios',
+      installedVersion: '0.18.0',
+      tool: 'npm-audit',
+      severity: 'medium',
+      upgradePlan: {
+        parent: 'axios',
+        parentVersion: '1.7.2',
+        patches: ['CVE-2024-1'],
+        breaking: true,
+      },
+    };
+    expect(finding.upgradePlan?.parent).toBe(finding.package);
+  });
+});


### PR DESCRIPTION
## Summary
- **10h.6.5 — `DepVulnFinding.fingerprint`**: stable 16-char hash of `(package, installedVersion, id)` stamped by the cross-pack aggregator after enrichment. Identity is input-only — re-scoring / enrichment changes cannot mint a new fingerprint, so two runs of the same state produce the same identity set. `BomReport.summary.fingerprints` carries the sorted-deduplicated manifest so external consumers (suppressions, CI gates, upgrade bots) diff two reports by plain set difference without walking every entry.
- **10h.6.6 — `DepVulnFinding.upgradePlan`**: typed sibling to the existing free-text `upgradeAdvice` — `{ parent, parentVersion, patches[], breaking }`. Will be populated by `osv-scanner fix` / `pip-audit --fix` / `cargo audit fix` (10h.6.1–.3) and the cross-pack transitive resolver (10h.6.4). Free-text advice stays for markdown/xlsx readability; structured form is for agents. New exported type `DepVulnUpgradePlan`.
- Both fields are optional and backwards-compatible. This PR adds contract surface only — no rendered-output changes yet. Downstream commits in Phase 10h.6 populate them.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test:run` — 731/731 passing across 44 files (up from 715/42 on main)
  - `test/fingerprint.test.ts` — 13 tests: stability, input sensitivity, NUL-separator collision defense, enrichment-invariance, idempotent re-stamp, empty-list safety
  - `test/upgrade-plan.test.ts` — 3 tests: JSON round-trip, coexistence with `upgradeAdvice`, direct-dep case (parent === finding.package)
- [x] `bash scripts/check-architecture.sh` — clean
- [x] `bash scripts/check-slop.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)