### PR TITLE
chore: gitignore Claude Code per-user local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ coverage/
 graphify-out/
 .ai/reports/
 .dxkit/
+
+# Claude Code local state — per-user, not committed
+.claude/settings.local.json
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

Two untracked files kept re-appearing in \`git status\` during development:
- \`.claude/settings.local.json\` — per-user Bash permission allowlist (Claude Code convention: team-shared settings live in \`settings.json\`, user-local in \`settings.local.json\`)
- \`.claude/scheduled_tasks.lock\` — runtime lock from Claude Code's scheduler

Neither belongs in version control. Adds both patterns to \`.gitignore\`.

## Test plan

- [x] \`git status\` — clean after deleting the files
- [x] \`npm run format:check\` — clean
- [x] Typecheck (via husky pre-commit) — clean

Pure gitignore change; no tests or code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)