### PR TITLE
feat: Phase 10h.6 — Tier-2 fix tools + agent handoff + cross-pack resolver (2.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   between depVulns gather and tests. Same pre-1.x-minor-is-breaking
   convention as the TypeScript pack. 5 new tests.
 
+### Added — cross-pack upgrade-plan resolver (Phase 10h.6.4)
+
+- **Shared `isMajorBump` helper** — three identical copies
+  (TS/Python/Rust from 10h.6.1–.3) consolidated into
+  `src/analyzers/tools/semver-bump.ts`. All three packs import from
+  the shared module; 7-test suite at `test/semver-bump.test.ts`
+  supersedes the inline duplicates.
+- **Cross-pack resolver** — new module
+  `src/analyzers/tools/upgrade-plan-resolver.ts` exposing
+  `resolveTransitiveUpgradePlans(findings)`. Runs after per-pack
+  Tier-2 tools and before riskScore composition. Two passes:
+    1. **Reconciliation** — for every advisory id listed in any
+       existing plan's `patches[]`, stamp the same plan onto the
+       matching finding (by id only, case-insensitive). Fills gaps
+       where a Tier-2 tool's `fixed[]` mentions an id that's carried
+       by another finding with a different (package, version) tuple.
+    2. **Free-text parse** — derives a plan from the npm-audit
+       transitive-fix template (`"Upgrade X to Y [major] (transitive
+       fix)"`) when no structured plan exists. Single-advisory scope
+       (patches=[finding.id]) since the free-text doesn't carry
+       cross-advisory rollup. Producer-written plans are
+       authoritative; resolver never overwrites.
+- **Wire-up** — `gatherDepVulns` in `src/analyzers/security/gather.ts`
+  now calls `resolveTransitiveUpgradePlans` after fingerprinting and
+  tier-3 enrichment, before composite `riskScore`. 11 new tests at
+  `test/upgrade-plan-resolver.test.ts`.
+
 ## [2.3.2] - 2026-04-24
 
 PM-grade bom reports. The xlsx and markdown outputs both restructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,15 +27,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   autonomous upgrade bots consume the structured form. New type
   `DepVulnUpgradePlan`.
 
-### Added — Tier-2 fix tools (Phase 10h.6.1)
+### Added — Tier-2 fix tools (Phase 10h.6.1 + 10h.6.2)
 
-- **TypeScript `osv-scanner fix` integration** — wraps `osv-scanner fix
-  --format json --manifest package.json --lockfile package-lock.json`
-  and stamps structured `upgradePlan` on each matching `DepVulnFinding`
-  surfaced by `npm audit`. Per-patch rollup: if one top-level bump
-  resolves N advisories, every finding's `upgradePlan.patches[]` lists
-  all N. Breaking detection normalizes pre-1.x where a minor bump
-  (0.5 → 0.6) is treated as breaking.
+- **TypeScript `osv-scanner fix` integration** (10h.6.1) — wraps
+  `osv-scanner fix --format json --manifest package.json --lockfile
+  package-lock.json` and stamps structured `upgradePlan` on each
+  matching `DepVulnFinding` surfaced by `npm audit`. Per-patch rollup:
+  if one top-level bump resolves N advisories, every finding's
+  `upgradePlan.patches[]` lists all N. Breaking detection normalizes
+  pre-1.x where a minor bump (0.5 → 0.6) is treated as breaking.
+- **Python `pip-audit` upgradePlan population** (10h.6.2) — pip-audit
+  already returns `fix_versions[]` per advisory; we now map the first
+  (minimal-resolving) entry into `DepVulnFinding.upgradePlan` alongside
+  the existing `fixedVersion`. Python's flat dep graph means
+  `upgradePlan.parent` equals the finding's own package — no transitive
+  parent to upgrade, just bump the vulnerable package directly. No new
+  subprocess call required; pure transformation of existing output.
 - **New tool in `TOOL_DEFS`** — `osv-scanner` (Node/TS pack, Tier-2).
   Installs via `go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest`
   (macOS also tries `brew install osv-scanner` first). Soft-fails when
@@ -43,8 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from npm-audit) stays as the fallback and no findings are dropped.
 - **New helper** — `src/analyzers/tools/osv-scanner-fix.ts` exports
   `gatherOsvScannerFixPlans(cwd)`, `parseOsvScannerFixOutput(raw)`, and
-  `enrichWithUpgradePlans(findings, plans)`. 18 new tests with a real
+  `enrichWithUpgradePlans(findings, plans)`. 19 new tests with a real
   osv-scanner sample as fixture.
+- **New helper in Python pack** — `isMajorBump(from, to)` shared
+  between depVulns gather and tests. Same pre-1.x-minor-is-breaking
+  convention as the TypeScript pack. 5 new tests.
 
 ## [2.3.2] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   between depVulns gather and tests. Same pre-1.x-minor-is-breaking
   convention as the TypeScript pack. 5 new tests.
 
+### Fixed — C# multi-project attribution (Phase 10h.6.7, closes D003)
+
+- Multi-project .NET solutions (web app + tests + shared libs) now
+  get correct top-level-dep attribution from every project's graph.
+  Earlier revisions walked to the **first** `obj/project.assets.json`
+  they found and built the attribution index from that one file —
+  advisories reachable only through sibling projects' dep chains
+  ended up without a `topLevelDep`. Fix: enumerate every
+  `project.assets.json` under cwd, merge the edge maps + union
+  top-level sets, run BFS against the merged graph. New exports in
+  `src/languages/csharp.ts`: `findAllProjectAssetsJson` and
+  `mergeAssetParses`. 5 new tests covering the merge semantics + the
+  concrete D003 case (advisory reachable through sibling only).
+
 ### Added — cross-pack upgrade-plan resolver (Phase 10h.6.4)
 
 - **Shared `isMajorBump` helper** — three identical copies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   autonomous upgrade bots consume the structured form. New type
   `DepVulnUpgradePlan`.
 
+### Added — Tier-2 fix tools (Phase 10h.6.1)
+
+- **TypeScript `osv-scanner fix` integration** — wraps `osv-scanner fix
+  --format json --manifest package.json --lockfile package-lock.json`
+  and stamps structured `upgradePlan` on each matching `DepVulnFinding`
+  surfaced by `npm audit`. Per-patch rollup: if one top-level bump
+  resolves N advisories, every finding's `upgradePlan.patches[]` lists
+  all N. Breaking detection normalizes pre-1.x where a minor bump
+  (0.5 → 0.6) is treated as breaking.
+- **New tool in `TOOL_DEFS`** — `osv-scanner` (Node/TS pack, Tier-2).
+  Installs via `go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest`
+  (macOS also tries `brew install osv-scanner` first). Soft-fails when
+  the binary isn't available — existing `upgradeAdvice` (free-text,
+  from npm-audit) stays as the fallback and no findings are dropped.
+- **New helper** — `src/analyzers/tools/osv-scanner-fix.ts` exports
+  `gatherOsvScannerFixPlans(cwd)`, `parseOsvScannerFixOutput(raw)`, and
+  `enrichWithUpgradePlans(findings, plans)`. 18 new tests with a real
+  osv-scanner sample as fixture.
+
 ## [2.3.2] - 2026-04-24
 
 PM-grade bom reports. The xlsx and markdown outputs both restructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if one top-level bump resolves N advisories, every finding's
   `upgradePlan.patches[]` lists all N. Breaking detection normalizes
   pre-1.x where a minor bump (0.5 → 0.6) is treated as breaking.
+- **Rust `cargo-audit` upgradePlan population** (10h.6.3) — mirrors the
+  Python pattern: cargo-audit's existing JSON output already carries
+  per-advisory `versions.patched[]`, so we populate
+  `DepVulnFinding.upgradePlan` as a pure transformation (parent equals
+  the finding's own crate; Rust has no transitive-parent remediation
+  concept at the advisory level). New `isMajorBump` helper shared with
+  the TS/Python packs (identical implementation — flagged for
+  consolidation in 10h.6.4's cross-pack resolver). 5 new tests.
 - **Python `pip-audit` upgradePlan population** (10h.6.2) — pip-audit
   already returns `fix_versions[]` per advisory; we now map the first
   (minimal-resolving) entry into `DepVulnFinding.upgradePlan` alongside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-04-24
+
+Phase 10h.6 complete. Tier-2 fix tools + agent-handoff types +
+cross-pack upgrade-plan resolver + C# multi-project attribution.
+Closes defect D003. One user-facing theme: every `DepVulnFinding`
+that has a viable remediation now carries a structured
+`upgradePlan` that agents can consume directly — no more parsing
+free-text `upgradeAdvice` to figure out what to upgrade.
+
 ### Added — agent handoff (Phase 10h.6 kickoff)
 
 - **Advisory fingerprint** — `DepVulnFinding.fingerprint` is a stable

--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ vyuh-dxkit tools install                      # interactive: prompts per tool
 
 ### Tools integrated
 
-| Layer     | Tools                                                    |
-| --------- | -------------------------------------------------------- |
-| Universal | `cloc`, `gitleaks`, `semgrep`, `jscpd`, `graphify` (AST) |
-| Node / TS | `eslint`, `npm audit`, `@vitest/coverage-v8`             |
-| Python    | `ruff`, `pip-audit`, `coverage` (coverage.py)            |
-| Go        | `golangci-lint`, `govulncheck`                           |
-| Rust      | `clippy`, `cargo-audit`, `cargo-llvm-cov`                |
-| C#        | `dotnet-format` (via SDK — formatter, not a linter)      |
+| Layer     | Tools                                                                     |
+| --------- | ------------------------------------------------------------------------- |
+| Universal | `cloc`, `gitleaks`, `semgrep`, `jscpd`, `graphify` (AST)                  |
+| Node / TS | `eslint`, `npm audit`, `osv-scanner` (fix planner), `@vitest/coverage-v8` |
+| Python    | `ruff`, `pip-audit`, `coverage` (coverage.py)                             |
+| Go        | `golangci-lint`, `govulncheck`                                            |
+| Rust      | `clippy`, `cargo-audit`, `cargo-llvm-cov`                                 |
+| C#        | `dotnet-format` (via SDK — formatter, not a linter)                       |
 
 Install commands are platform-aware (brew on macOS, user-local install on Linux, winget/scoop on Windows). Tools install into `~/.local/bin` or similar user paths — no `sudo` required.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.3.2",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "AI-native developer experience toolkit for any repository",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -14,6 +14,7 @@ import { enrichKev } from '../tools/kev';
 import { resolveAliases } from '../tools/osv';
 import { buildReachablePackageSet, markReachable } from '../tools/reachability';
 import { scoreFindings } from '../tools/risk-score';
+import { resolveTransitiveUpgradePlans } from '../tools/upgrade-plan-resolver';
 import { getFindExcludeFlags } from '../tools/exclusions';
 import { SecurityFinding, DepVulnSummary } from './types';
 import { defaultDispatcher } from '../dispatcher';
@@ -226,6 +227,15 @@ export async function gatherDepVulns(cwd: string): Promise<DepVulnSummary> {
         markReachable(findings, reachable);
       }
     }
+
+    // Cross-pack upgrade-plan resolver (Phase 10h.6.4). Runs after
+    // per-pack Tier-2 tools have stamped what they can, and before
+    // risk scoring so the composite riskScore can factor in the
+    // "actionable" bit (future 10h.9.2 CI gate uses it too). Fills
+    // gaps by (a) reconciling advisories across plans' `patches[]`
+    // lists and (b) parsing the npm-audit transitive-fix free-text
+    // template into a structured plan when no tool produced one.
+    resolveTransitiveUpgradePlans(findings);
 
     // Composite riskScore = f(cvss, epss, kev, reachable). Runs last
     // so every signal is populated. Formula is documented in

--- a/src/analyzers/tools/osv-scanner-fix.ts
+++ b/src/analyzers/tools/osv-scanner-fix.ts
@@ -1,0 +1,227 @@
+/**
+ * osv-scanner fix — Tier-2 upgrade-plan enricher for the TypeScript pack.
+ *
+ * `npm audit` (Tier-1, typescript pack's primary dep-vuln source) produces
+ * per-advisory findings with `fixedVersion` and, for transitive advisories,
+ * a free-text `upgradeAdvice` like "Upgrade vitest to 4.1.5 [major]
+ * (transitive fix)". That's good for humans reading markdown but leaves
+ * autonomous upgrade bots to re-parse the string.
+ *
+ * `osv-scanner fix --format json --manifest <pkg.json> --lockfile <lock>`
+ * produces a structured plan: for each proposed patch, which top-level
+ * package to bump (`packageUpdates[]`) and which advisories it would
+ * resolve (`fixed[]`). This module wraps that call and stamps the
+ * structured result onto each matching `DepVulnFinding.upgradePlan` —
+ * the typed sibling to the free-text `upgradeAdvice` that 10h.6.6 added.
+ *
+ * Degradation: if osv-scanner isn't installed, runs fine but returns
+ * zero enrichments. The underlying npm-audit flow populates
+ * `upgradeAdvice` either way. Downstream consumers that want the
+ * structured form check `upgradePlan` presence.
+ */
+
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { DepVulnFinding, DepVulnUpgradePlan } from '../../languages/capabilities/types';
+import { findTool, TOOL_DEFS } from './tool-registry';
+
+/** Raw osv-scanner `fix --format json` output shape. Kept internal —
+ *  anything exposed outside this module is normalized first. */
+interface OsvFixOutput {
+  path: string;
+  ecosystem: string;
+  /** `relax` / `in-place` / `override` — the remediation strategy osv-scanner
+   *  picked. We don't surface this; consumers care about the concrete plan. */
+  strategy?: string;
+  vulnerabilities?: OsvFixVuln[];
+  patches?: OsvFixPatch[];
+}
+
+interface OsvFixVuln {
+  id: string;
+  packages?: Array<{ name: string; version: string }>;
+  /** `true` when osv-scanner couldn't find a non-breaking upgrade path.
+   *  Mapped to a `breaking: true` plan with empty `patches[]` so consumers
+   *  see the attempt; today we just skip — no plan rather than a broken one. */
+  unactionable?: boolean;
+}
+
+interface OsvFixPatch {
+  /** Null entries appear in the output for some strategies (e.g. a
+   *  no-op alternative). Treated as "no updates in this patch". */
+  packageUpdates?: Array<{
+    name: string;
+    versionFrom: string;
+    versionTo: string;
+    transitive: boolean;
+  }> | null;
+  fixed?: OsvFixVuln[];
+}
+
+/**
+ * Run osv-scanner against a TypeScript project and return a map keyed on
+ * the `(package, installedVersion, advisoryId)` tuple → upgradePlan. Caller
+ * iterates findings and copies the plan onto each match.
+ *
+ * Returns an empty map when:
+ *   - osv-scanner binary is not available (tool missing — soft-fail)
+ *   - package.json or package-lock.json is absent (osv-scanner fix needs both)
+ *   - osv-scanner exits with parse-breaking output (log and degrade)
+ *
+ * Never throws. `gatherTsDepVulnsResult` calls this unconditionally and
+ * treats the empty map as "no enrichment available".
+ */
+export async function gatherOsvScannerFixPlans(
+  cwd: string,
+): Promise<Map<string, DepVulnUpgradePlan>> {
+  const manifestRel = 'package.json';
+  const lockfileRel = 'package-lock.json';
+  const manifestAbs = path.join(cwd, manifestRel);
+  const lockfileAbs = path.join(cwd, lockfileRel);
+  if (!fs.existsSync(manifestAbs) || !fs.existsSync(lockfileAbs)) {
+    return new Map();
+  }
+  const tool = findTool(TOOL_DEFS['osv-scanner'], cwd);
+  if (!tool.available || !tool.path) return new Map();
+  // Quote paths defensively — repo paths with spaces break shell parsing
+  // otherwise, and osv-scanner's CLI is shell-parsed.
+  const cmd =
+    `${tool.path} fix --format json --manifest ${JSON.stringify(manifestRel)} ` +
+    `--lockfile ${JSON.stringify(lockfileRel)}`;
+  let raw: string;
+  try {
+    raw = execSync(cmd, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 120_000,
+    });
+  } catch (err) {
+    // osv-scanner exits non-zero whenever it finds vulns, even though the
+    // JSON payload is complete. Capture stdout from the error and proceed.
+    const e = err as { stdout?: Buffer | string };
+    if (!e.stdout) return new Map();
+    raw = typeof e.stdout === 'string' ? e.stdout : e.stdout.toString('utf8');
+  }
+  return parseOsvScannerFixOutput(raw);
+}
+
+/**
+ * Parse raw `osv-scanner fix --format json` stdout into a plan-lookup map.
+ *
+ * The command prefixes JSON with a warning line when it falls back to
+ * `npm install --legacy-peer-deps` (seen on 2026-04-24's dxkit sample
+ * capture); skip anything before the first `{`. On parse failure,
+ * returns an empty map rather than throwing — enrichment is best-effort.
+ *
+ * Exported for test coverage.
+ */
+export function parseOsvScannerFixOutput(raw: string): Map<string, DepVulnUpgradePlan> {
+  const plans = new Map<string, DepVulnUpgradePlan>();
+  const jsonStart = raw.indexOf('{');
+  if (jsonStart < 0) return plans;
+  let parsed: OsvFixOutput;
+  try {
+    parsed = JSON.parse(raw.slice(jsonStart)) as OsvFixOutput;
+  } catch {
+    return plans;
+  }
+
+  for (const patch of parsed.patches ?? []) {
+    const updates = patch.packageUpdates;
+    if (!updates || updates.length === 0) continue;
+    const fixedIds = (patch.fixed ?? []).map((f) => f.id).sort();
+    // Each patch may bundle multiple top-level updates (e.g. `vitest` +
+    // `@vitest/coverage-v8` as a coordinated bump). The finding carries
+    // only ONE upgradePlan; pick the direct-dep update as the "parent"
+    // — it's the one a human would type — and attach the full patch
+    // set via `patches[]`. Transitive-only updates fall back to the
+    // first packageUpdate.
+    const directUpdate = updates.find((u) => !u.transitive) ?? updates[0];
+    const plan: DepVulnUpgradePlan = {
+      parent: directUpdate.name,
+      parentVersion: normalizeVersion(directUpdate.versionTo),
+      patches: fixedIds,
+      breaking: isSemverMajorBump(directUpdate.versionFrom, directUpdate.versionTo),
+    };
+    // Key every fixed advisory onto the same plan so renderers find it
+    // when iterating findings.
+    for (const fixed of patch.fixed ?? []) {
+      for (const pkg of fixed.packages ?? []) {
+        plans.set(planKey(pkg.name, pkg.version, fixed.id), plan);
+      }
+    }
+  }
+  return plans;
+}
+
+/**
+ * Stamp upgradePlan on every finding with a matching `(package,
+ * installedVersion, id)` tuple in the provided plan map. In-place;
+ * finds with no matching plan are left unchanged. Idempotent.
+ */
+export function enrichWithUpgradePlans(
+  findings: DepVulnFinding[],
+  plans: Map<string, DepVulnUpgradePlan>,
+): number {
+  if (plans.size === 0) return 0;
+  let count = 0;
+  for (const f of findings) {
+    if (!f.installedVersion) continue;
+    const key = planKey(f.package, f.installedVersion, f.id);
+    const plan = plans.get(key);
+    if (plan) {
+      f.upgradePlan = plan;
+      count++;
+    }
+  }
+  return count;
+}
+
+/** Shared key between plan-map construction and finding lookup.
+ *
+ *  GHSA/CVE/SNYK IDs are case-insensitive per their respective specs but
+ *  producers disagree in practice — npm-audit emits uppercase
+ *  (`GHSA-W5HQ-...`), osv-scanner emits lowercase (`GHSA-w5hq-...`).
+ *  Lowercasing the ID component keeps plan lookups hit-or-miss-free when
+ *  the two merge. Package names in npm are already lowercase; version
+ *  strings have no case. */
+export function planKey(pkg: string, version: string, advisoryId: string): string {
+  return `${pkg}\0${version}\0${advisoryId.toLowerCase()}`;
+}
+
+/** Strip leading semver range operators so the plan carries a concrete
+ *  version string (what a consumer would write in a manifest). osv-scanner
+ *  emits `^3.2.4` / `~1.2.0` in the relax strategy; the structured payload
+ *  is cleaner without the prefix. */
+function normalizeVersion(v: string): string {
+  return v.replace(/^[\^~>=<\s]+/, '').trim();
+}
+
+/** True when `to`'s major segment is higher than `from`'s. Pre-1.x
+ *  versions (0.x.y) treat a minor bump as effectively breaking — osv-scanner
+ *  doesn't flag it but semver does. Conservative — a jump that crosses
+ *  a 0.x boundary (0.5.0 → 1.0.0) is also breaking. */
+function isSemverMajorBump(from: string, to: string): boolean {
+  const fromMajor = extractMajor(from);
+  const toMajor = extractMajor(to);
+  if (fromMajor === null || toMajor === null) return false;
+  if (fromMajor !== toMajor) return true;
+  if (fromMajor === 0) {
+    const fromMinor = extractMinor(from);
+    const toMinor = extractMinor(to);
+    if (fromMinor !== null && toMinor !== null && fromMinor !== toMinor) return true;
+  }
+  return false;
+}
+
+function extractMajor(v: string): number | null {
+  const m = v.match(/^[\^~>=<\s]*(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+function extractMinor(v: string): number | null {
+  const m = v.match(/^[\^~>=<\s]*\d+\.(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+}

--- a/src/analyzers/tools/osv-scanner-fix.ts
+++ b/src/analyzers/tools/osv-scanner-fix.ts
@@ -24,6 +24,7 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { DepVulnFinding, DepVulnUpgradePlan } from '../../languages/capabilities/types';
+import { isMajorBump } from './semver-bump';
 import { findTool, TOOL_DEFS } from './tool-registry';
 
 /** Raw osv-scanner `fix --format json` output shape. Kept internal —
@@ -143,7 +144,10 @@ export function parseOsvScannerFixOutput(raw: string): Map<string, DepVulnUpgrad
       parent: directUpdate.name,
       parentVersion: normalizeVersion(directUpdate.versionTo),
       patches: fixedIds,
-      breaking: isSemverMajorBump(directUpdate.versionFrom, directUpdate.versionTo),
+      breaking: isMajorBump(
+        normalizeVersion(directUpdate.versionFrom),
+        normalizeVersion(directUpdate.versionTo),
+      ),
     };
     // Key every fixed advisory onto the same plan so renderers find it
     // when iterating findings.
@@ -197,31 +201,4 @@ export function planKey(pkg: string, version: string, advisoryId: string): strin
  *  is cleaner without the prefix. */
 function normalizeVersion(v: string): string {
   return v.replace(/^[\^~>=<\s]+/, '').trim();
-}
-
-/** True when `to`'s major segment is higher than `from`'s. Pre-1.x
- *  versions (0.x.y) treat a minor bump as effectively breaking — osv-scanner
- *  doesn't flag it but semver does. Conservative — a jump that crosses
- *  a 0.x boundary (0.5.0 → 1.0.0) is also breaking. */
-function isSemverMajorBump(from: string, to: string): boolean {
-  const fromMajor = extractMajor(from);
-  const toMajor = extractMajor(to);
-  if (fromMajor === null || toMajor === null) return false;
-  if (fromMajor !== toMajor) return true;
-  if (fromMajor === 0) {
-    const fromMinor = extractMinor(from);
-    const toMinor = extractMinor(to);
-    if (fromMinor !== null && toMinor !== null && fromMinor !== toMinor) return true;
-  }
-  return false;
-}
-
-function extractMajor(v: string): number | null {
-  const m = v.match(/^[\^~>=<\s]*(\d+)/);
-  return m ? parseInt(m[1], 10) : null;
-}
-
-function extractMinor(v: string): number | null {
-  const m = v.match(/^[\^~>=<\s]*\d+\.(\d+)/);
-  return m ? parseInt(m[1], 10) : null;
 }

--- a/src/analyzers/tools/semver-bump.ts
+++ b/src/analyzers/tools/semver-bump.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared semver-bump classification used across language packs and the
+ * cross-pack resolver. Originally duplicated in
+ * `languages/{python,rust}.ts` + `analyzers/tools/osv-scanner-fix.ts`
+ * (Phases 10h.6.1–10h.6.3); consolidated here in 10h.6.4 so every pack
+ * and the transitive resolver agree on what "breaking" means.
+ *
+ * Convention:
+ *   - Different major segment → breaking.
+ *   - Pre-1.x (0.x) minor bump (0.5.0 → 0.6.0) → breaking. Semver says
+ *     anything under 1.0 is development-unstable; npm-audit's own
+ *     `isSemVerMajor` heuristic treats 0.x lines this way too.
+ *   - Unparseable input → false (non-breaking). Conservative so we
+ *     don't over-flag when we can't decide.
+ */
+
+export function isMajorBump(from: string, to: string): boolean {
+  const fromParts = from.split('.').map((p) => parseInt(p, 10));
+  const toParts = to.split('.').map((p) => parseInt(p, 10));
+  if (fromParts.some(isNaN) || toParts.some(isNaN)) return false;
+  if ((fromParts[0] ?? 0) !== (toParts[0] ?? 0)) return true;
+  if ((fromParts[0] ?? 0) === 0 && (fromParts[1] ?? 0) !== (toParts[1] ?? 0)) return true;
+  return false;
+}

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -442,6 +442,28 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
       windows: 'builtin',
     },
   },
+  'osv-scanner': {
+    name: 'osv-scanner',
+    description:
+      'OSV.dev dependency scanner + fix planner — populates structured upgradePlan on dep-vuln findings (Tier-2, Node/npm pack)',
+    install: 'go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest',
+    check: 'osv-scanner --version',
+    for: 'node',
+    layer: 'language',
+    binaries: ['osv-scanner'],
+    // Go installs to $GOBIN (→ $GOPATH/bin by default, or ~/go/bin) which
+    // is typically in $PATH on dev machines. Probe the canonical default
+    // explicitly so detection works on machines that only have `go` in
+    // PATH but not `go/bin`.
+    probePaths: [path.join(os.homedir(), 'go', 'bin')],
+    versionCheck: 'osv-scanner --version 2>/dev/null',
+    installCommands: {
+      macos:
+        'brew install osv-scanner || go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest',
+      linux: 'go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest',
+      windows: 'go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest',
+    },
+  },
   'license-checker-rseidelsohn': {
     name: 'license-checker-rseidelsohn',
     description: 'License inventory for npm dependencies (maintained fork of license-checker)',

--- a/src/analyzers/tools/upgrade-plan-resolver.ts
+++ b/src/analyzers/tools/upgrade-plan-resolver.ts
@@ -1,0 +1,148 @@
+/**
+ * Cross-pack upgrade-plan resolver — Phase 10h.6.4.
+ *
+ * Runs after every pack has contributed its Tier-1/Tier-2 dep-vuln
+ * findings and the per-pack Tier-2 fix tools (osv-scanner fix in TS,
+ * pip-audit's fix_versions in Python, cargo-audit's patched[] in Rust)
+ * have stamped `upgradePlan` on whichever findings they could. This
+ * resolver fills the gaps in two passes:
+ *
+ *   Pass 1 — plan reconciliation. osv-scanner's structured output
+ *   frequently lists multiple advisories under one patch (e.g. a single
+ *   `vitest ^2 → ^3` bump patches both vite + esbuild CVEs). Only the
+ *   advisories in `patches[]` get stamped by 10h.6.1's enricher because
+ *   it keys on (package, version, id). If another producer (npm-audit's
+ *   default output, Snyk later) emits a finding for an advisory that
+ *   ALSO appears in some plan's `patches[]` but with a different
+ *   package/version tuple, the reconciliation pass stamps it too.
+ *
+ *   Pass 2 — transitive free-text parse. npm-audit emits free-text
+ *   `upgradeAdvice` like `"Upgrade @loopback/cli to 7.0.1 [major]
+ *   (transitive fix)"` on transitive advisories. That string is
+ *   structured data trapped in a string; this pass parses it into a
+ *   proper `upgradePlan` when no better one is available. Conservative:
+ *   only activates when `upgradeAdvice` matches the exact transitive-
+ *   fix template the TS pack emits. Future producers that emit the
+ *   same shape benefit automatically.
+ *
+ * Purity: mutates findings in place (stamps `upgradePlan`) and returns
+ * a count of additions. Never overwrites an existing plan — the
+ * per-pack producers are authoritative.
+ */
+
+import type { DepVulnFinding, DepVulnUpgradePlan } from '../../languages/capabilities/types';
+
+/**
+ * Matches the TS pack's transitive-fix `upgradeAdvice` template:
+ *   "Upgrade <pkg> to <version>[ [major]] (transitive fix)"
+ * Captures pkg + version + optional [major] flag.
+ */
+const TRANSITIVE_ADVICE_RE = /^Upgrade (\S+) to (\S+?)(?:\s+\[major\])? \(transitive fix\)$/;
+
+/** Result summary — useful for tests and for the security/gather caller
+ *  that wants to log how much reconciliation actually happened. */
+export interface ResolverStats {
+  reconciled: number;
+  fromFreeText: number;
+}
+
+/**
+ * Run the resolver over a flat finding set. Mutates in place; returns
+ * per-pass counts. Idempotent — re-running on the same set after
+ * resolver-stamping yields zero additions.
+ */
+export function resolveTransitiveUpgradePlans(findings: DepVulnFinding[]): ResolverStats {
+  return {
+    reconciled: reconcileUpgradePlans(findings),
+    fromFreeText: stampFromFreeTextAdvice(findings),
+  };
+}
+
+/**
+ * Pass 1 — for every advisory id listed in any existing plan's
+ * `patches[]`, ensure the matching finding (if any, by id only) carries
+ * the same `upgradePlan`. Case-insensitive id matching matches the
+ * osv-scanner-fix planKey convention.
+ *
+ * Exported for test coverage.
+ */
+export function reconcileUpgradePlans(findings: DepVulnFinding[]): number {
+  // Build: advisory id → canonical plan. When an advisory id appears in
+  // multiple plans' patches[] (possible if two tools emit overlapping
+  // plans), keep the one with the highest parentVersion so the rollup
+  // reflects the most aggressive viable remediation.
+  const plansByAdvisoryId = new Map<string, DepVulnUpgradePlan>();
+  for (const f of findings) {
+    if (!f.upgradePlan) continue;
+    for (const id of f.upgradePlan.patches) {
+      const key = id.toLowerCase();
+      const existing = plansByAdvisoryId.get(key);
+      if (!existing) {
+        plansByAdvisoryId.set(key, f.upgradePlan);
+      } else if (
+        f.upgradePlan.parent === existing.parent &&
+        compareVersions(f.upgradePlan.parentVersion, existing.parentVersion) > 0
+      ) {
+        plansByAdvisoryId.set(key, f.upgradePlan);
+      }
+    }
+  }
+  // Stamp plans on findings whose id appears in some plan's patches[]
+  // but whose own `upgradePlan` is absent. Reconciliation only —
+  // never overwrites.
+  let stamped = 0;
+  for (const f of findings) {
+    if (f.upgradePlan) continue;
+    const plan = plansByAdvisoryId.get(f.id.toLowerCase());
+    if (plan) {
+      f.upgradePlan = plan;
+      stamped++;
+    }
+  }
+  return stamped;
+}
+
+/**
+ * Pass 2 — derive `upgradePlan` from the npm-audit-style transitive-fix
+ * `upgradeAdvice` free-text template. Activates only when the string
+ * matches exactly and no structured plan exists. Outputs a
+ * single-advisory plan (patches = [finding.id]) since the free-text
+ * template doesn't carry cross-advisory rollup.
+ *
+ * Exported for test coverage.
+ */
+export function stampFromFreeTextAdvice(findings: DepVulnFinding[]): number {
+  let stamped = 0;
+  for (const f of findings) {
+    if (f.upgradePlan) continue;
+    if (!f.upgradeAdvice) continue;
+    const m = f.upgradeAdvice.match(TRANSITIVE_ADVICE_RE);
+    if (!m) continue;
+    f.upgradePlan = {
+      parent: m[1],
+      parentVersion: m[2],
+      patches: [f.id],
+      breaking: f.upgradeAdvice.includes('[major]'),
+    };
+    stamped++;
+  }
+  return stamped;
+}
+
+/**
+ * Numeric semver compare for the plan-selection tiebreaker. Returns
+ * positive when `a > b`, negative when `a < b`, 0 when equal. Falls
+ * back to lexicographic compare for non-numeric segments.
+ */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map((p) => parseInt(p, 10));
+  const pb = b.split('.').map((p) => parseInt(p, 10));
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const xa = pa[i];
+    const xb = pb[i];
+    if (isNaN(xa) || isNaN(xb)) return a.localeCompare(b);
+    if (xa !== xb) return xa - xb;
+  }
+  return 0;
+}

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -381,32 +381,41 @@ export function buildCsharpTopLevelDepIndex(parsed: {
 }
 
 /**
- * Locate the nearest `obj/project.assets.json` under cwd (NuGet's
- * lockfile equivalent, created by `dotnet restore`). Unlike the
- * shared `findMatchingRecursive`, we cannot skip `obj/` here —
- * that's literally where the file lives. Walks up to 4 levels deep
- * to handle solutions with nested projects. Returns the absolute
- * path of the first match, or null.
+ * Locate every `obj/project.assets.json` under cwd (NuGet's lockfile
+ * equivalent, created by `dotnet restore`). Unlike the shared
+ * `findMatchingRecursive`, we can't skip `obj/` — that's where the
+ * file lives. Walks up to `maxDepth` levels to cover solutions with
+ * multiple nested projects.
  *
- * Multi-project solutions currently use the first-found file's
- * graph — noted as a known limitation in the phase commit.
+ * Phase 10h.6.7 (closes D003): earlier revisions returned only the
+ * first match, so multi-project solutions got transitive attribution
+ * from one project's graph, missing vulns reachable only through
+ * siblings. `loadCsharpTopLevelDepIndex` now calls this and merges
+ * every returned graph before BFS.
+ *
+ * Exported for test coverage.
  */
-function findProjectAssetsJson(cwd: string, maxDepth = 4): string | null {
-  function search(dir: string, depth: number): string | null {
-    if (depth > maxDepth) return null;
+export function findAllProjectAssetsJson(cwd: string, maxDepth = 4): string[] {
+  const out: string[] = [];
+  function search(dir: string, depth: number): void {
+    if (depth > maxDepth) return;
     let entries: fs.Dirent[];
     try {
       entries = fs.readdirSync(dir, { withFileTypes: true });
     } catch {
-      return null;
+      return;
     }
-    // Direct-child shortcut: if this directory is `obj`, check for
-    // the file right here before recursing.
-    for (const e of entries) {
-      if (e.isFile() && e.name === 'project.assets.json') {
-        // Only accept if parent directory is `obj`.
-        if (path.basename(dir) === 'obj') return path.join(dir, e.name);
+    // Direct-child shortcut: if this directory is `obj`, collect the
+    // file right here before recursing siblings. Skipping recursion
+    // into `obj/` keeps the walk bounded (obj/ contains no deeper
+    // projects of its own).
+    if (path.basename(dir) === 'obj') {
+      for (const e of entries) {
+        if (e.isFile() && e.name === 'project.assets.json') {
+          out.push(path.join(dir, e.name));
+        }
       }
+      return;
     }
     for (const e of entries) {
       if (
@@ -416,33 +425,63 @@ function findProjectAssetsJson(cwd: string, maxDepth = 4): string | null {
         continue;
       }
       if (e.isDirectory()) {
-        const nested = search(path.join(dir, e.name), depth + 1);
-        if (nested) return nested;
+        search(path.join(dir, e.name), depth + 1);
       }
     }
-    return null;
   }
-  return search(cwd, 0);
+  search(cwd, 0);
+  return out;
 }
 
 /**
- * Read + parse `obj/project.assets.json` and build the top-level
- * attribution index. Returns an empty map on any failure — transitive
- * findings simply ship without attribution rather than blocking the
- * scan. Matches Python pack's missing-venv semantics.
+ * Merge multiple `project.assets.json` parse results into a single
+ * graph. `topLevels` unions across projects; `edges` unions the
+ * adjacency sets — if project A lists `Newtonsoft.Json` → `Foo` and
+ * project B lists `Newtonsoft.Json` → `Bar`, the merged graph shows
+ * both children. Run BFS against the union so advisories reachable
+ * through any project's dep graph get attribution.
+ *
+ * Exported for test coverage.
+ */
+export function mergeAssetParses(
+  parses: ReadonlyArray<{ topLevels: string[]; edges: Map<string, Set<string>> }>,
+): { topLevels: string[]; edges: Map<string, Set<string>> } {
+  const edges = new Map<string, Set<string>>();
+  const topLevels = new Set<string>();
+  for (const p of parses) {
+    for (const t of p.topLevels) topLevels.add(t);
+    for (const [src, children] of p.edges) {
+      const bucket = edges.get(src) ?? new Set<string>();
+      for (const child of children) bucket.add(child);
+      edges.set(src, bucket);
+    }
+  }
+  return { topLevels: [...topLevels].sort(), edges };
+}
+
+/**
+ * Read + parse every discovered `obj/project.assets.json` under cwd
+ * and build the unified top-level attribution index. Returns an empty
+ * map on complete failure (no files / all files unreadable) —
+ * transitive findings then ship without attribution rather than
+ * blocking the scan.
  */
 function loadCsharpTopLevelDepIndex(cwd: string): Map<string, string[]> {
-  const assetsPath = findProjectAssetsJson(cwd);
-  if (!assetsPath) return new Map();
-  let raw: string;
-  try {
-    raw = fs.readFileSync(assetsPath, 'utf-8');
-  } catch {
-    return new Map();
+  const assetsPaths = findAllProjectAssetsJson(cwd);
+  if (assetsPaths.length === 0) return new Map();
+  const parses: Array<{ topLevels: string[]; edges: Map<string, Set<string>> }> = [];
+  for (const assetsPath of assetsPaths) {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(assetsPath, 'utf-8');
+    } catch {
+      continue;
+    }
+    const parsed = parseProjectAssetsJson(raw);
+    if (parsed) parses.push(parsed);
   }
-  const parsed = parseProjectAssetsJson(raw);
-  if (!parsed) return new Map();
-  return buildCsharpTopLevelDepIndex(parsed);
+  if (parses.length === 0) return new Map();
+  return buildCsharpTopLevelDepIndex(mergeAssetParses(parses));
 }
 
 /**

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -300,6 +300,18 @@ async function gatherPyDepVulnsResult(cwd: string): Promise<DepVulnGatherOutcome
         // minimal upgrade that resolves the issue.
         if (v.fix_versions && v.fix_versions.length > 0) {
           finding.fixedVersion = v.fix_versions[0];
+          // Tier-2 structured plan (10h.6.2): Python's dep graph is flat —
+          // the fix is always an upgrade of the package itself, so parent
+          // == finding.package. `patches[]` carries just this advisory's
+          // id (pip-audit doesn't roll up "one upgrade fixes N advisories"
+          // the way osv-scanner does on npm). `breaking` derives from a
+          // major-version jump from the installed version to the target.
+          finding.upgradePlan = {
+            parent: finding.package,
+            parentVersion: v.fix_versions[0],
+            patches: [v.id],
+            breaking: isMajorBump(dep.version ?? '', v.fix_versions[0]),
+          };
         }
         // Filter empty alias entries — ECHO advisories occasionally emit [].
         const aliases = (v.aliases ?? []).filter((a) => a && a.length > 0);
@@ -740,6 +752,22 @@ const pyLicensesProvider: CapabilityProvider<LicensesResult> = {
     return gatherPyLicensesResult(cwd);
   },
 };
+
+/**
+ * True when `to`'s major segment exceeds `from`'s. Pre-1.x (`0.x`)
+ * minor bumps treated as breaking too — convention matches the
+ * osv-scanner-fix module. Returns false when either input is unparseable.
+ *
+ * Exported for test coverage.
+ */
+export function isMajorBump(from: string, to: string): boolean {
+  const fromParts = from.split('.').map((p) => parseInt(p, 10));
+  const toParts = to.split('.').map((p) => parseInt(p, 10));
+  if (fromParts.some(isNaN) || toParts.some(isNaN)) return false;
+  if ((fromParts[0] ?? 0) !== (toParts[0] ?? 0)) return true;
+  if ((fromParts[0] ?? 0) === 0 && (fromParts[1] ?? 0) !== (toParts[1] ?? 0)) return true;
+  return false;
+}
 
 export const python: LanguageSupport = {
   id: 'python',

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -5,6 +5,7 @@ import { parseCoveragePy } from '../analyzers/tools/coverage';
 import { getFindExcludeFlags } from '../analyzers/tools/exclusions';
 import { enrichOsv, resolveCvssScores } from '../analyzers/tools/osv';
 import { fileExists, run } from '../analyzers/tools/runner';
+import { isMajorBump } from '../analyzers/tools/semver-bump';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
 import type { CapabilityProvider } from './capabilities/provider';
 import type {
@@ -752,22 +753,6 @@ const pyLicensesProvider: CapabilityProvider<LicensesResult> = {
     return gatherPyLicensesResult(cwd);
   },
 };
-
-/**
- * True when `to`'s major segment exceeds `from`'s. Pre-1.x (`0.x`)
- * minor bumps treated as breaking too — convention matches the
- * osv-scanner-fix module. Returns false when either input is unparseable.
- *
- * Exported for test coverage.
- */
-export function isMajorBump(from: string, to: string): boolean {
-  const fromParts = from.split('.').map((p) => parseInt(p, 10));
-  const toParts = to.split('.').map((p) => parseInt(p, 10));
-  if (fromParts.some(isNaN) || toParts.some(isNaN)) return false;
-  if ((fromParts[0] ?? 0) !== (toParts[0] ?? 0)) return true;
-  if ((fromParts[0] ?? 0) === 0 && (fromParts[1] ?? 0) !== (toParts[1] ?? 0)) return true;
-  return false;
-}
 
 export const python: LanguageSupport = {
   id: 'python',

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -6,6 +6,7 @@ import { getFindExcludeFlags } from '../analyzers/tools/exclusions';
 import { parseCoberturaXml } from './csharp';
 import { parseCvssV3BaseScore, resolveCvssScores, scoreToTier } from '../analyzers/tools/osv';
 import { fileExists, run } from '../analyzers/tools/runner';
+import { isMajorBump } from '../analyzers/tools/semver-bump';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
 import type { CapabilityProvider } from './capabilities/provider';
 import type {
@@ -675,23 +676,6 @@ const rustLicensesProvider: CapabilityProvider<LicensesResult> = {
     return gatherRustLicensesResult(cwd);
   },
 };
-
-/**
- * True when `to`'s major segment exceeds `from`'s. Pre-1.x (`0.x`)
- * minor bumps treated as breaking too — convention shared with the
- * TypeScript and Python packs. Returns false when either input is
- * unparseable.
- *
- * Exported for test coverage.
- */
-export function isMajorBump(from: string, to: string): boolean {
-  const fromParts = from.split('.').map((p) => parseInt(p, 10));
-  const toParts = to.split('.').map((p) => parseInt(p, 10));
-  if (fromParts.some(isNaN) || toParts.some(isNaN)) return false;
-  if ((fromParts[0] ?? 0) !== (toParts[0] ?? 0)) return true;
-  if ((fromParts[0] ?? 0) === 0 && (fromParts[1] ?? 0) !== (toParts[1] ?? 0)) return true;
-  return false;
-}
 
 function round1(n: number): number {
   return Math.round(n * 10) / 10;

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -236,7 +236,22 @@ export function parseCargoAuditOutput(
       // (e.g. ">=1.2.5"). Strip the leading comparator so the
       // bom render's "Upgrade to X" text reads cleanly. Multiple
       // patched constraints (rare) fall through with the first.
-      finding.fixedVersion = patched[0].replace(/^[<>=^~\s]+/, '').trim() || patched[0];
+      const cleanFix = patched[0].replace(/^[<>=^~\s]+/, '').trim() || patched[0];
+      finding.fixedVersion = cleanFix;
+      // Tier-2 structured plan (10h.6.3): Rust's dep graph is resolved
+      // by cargo in one go — there's no "transitive parent" concept like
+      // npm's where the fix is at a different package. The upgrade
+      // target IS the vulnerable crate itself, so parent == finding
+      // package. patches[] carries just this advisory's id (cargo-audit
+      // doesn't bundle multi-advisory rollups the way osv-scanner does).
+      // `breaking` derives from the semver-major comparison; same pre-
+      // 1.x convention as the TS/Python packs.
+      finding.upgradePlan = {
+        parent: finding.package,
+        parentVersion: cleanFix,
+        patches: [adv.id],
+        breaking: isMajorBump(v.package?.version ?? '', cleanFix),
+      };
     }
     const aliases = (adv.aliases ?? []).filter((a) => a && a.length > 0);
     if (aliases.length > 0) finding.aliases = aliases;
@@ -660,6 +675,23 @@ const rustLicensesProvider: CapabilityProvider<LicensesResult> = {
     return gatherRustLicensesResult(cwd);
   },
 };
+
+/**
+ * True when `to`'s major segment exceeds `from`'s. Pre-1.x (`0.x`)
+ * minor bumps treated as breaking too — convention shared with the
+ * TypeScript and Python packs. Returns false when either input is
+ * unparseable.
+ *
+ * Exported for test coverage.
+ */
+export function isMajorBump(from: string, to: string): boolean {
+  const fromParts = from.split('.').map((p) => parseInt(p, 10));
+  const toParts = to.split('.').map((p) => parseInt(p, 10));
+  if (fromParts.some(isNaN) || toParts.some(isNaN)) return false;
+  if ((fromParts[0] ?? 0) !== (toParts[0] ?? 0)) return true;
+  if ((fromParts[0] ?? 0) === 0 && (fromParts[1] ?? 0) !== (toParts[1] ?? 0)) return true;
+  return false;
+}
 
 function round1(n: number): number {
   return Math.round(n * 10) / 10;

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -7,6 +7,10 @@ import { parseIstanbulFinal, parseIstanbulSummary } from '../analyzers/tools/cov
 import { getFindExcludeFlags } from '../analyzers/tools/exclusions';
 import { enrichReleaseDates } from '../analyzers/tools/npm-registry';
 import { resolveCvssScores } from '../analyzers/tools/osv';
+import {
+  enrichWithUpgradePlans,
+  gatherOsvScannerFixPlans,
+} from '../analyzers/tools/osv-scanner-fix';
 import { fileExists, run, runJSON } from '../analyzers/tools/runner';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
 import type { CapabilityProvider } from './capabilities/provider';
@@ -416,6 +420,17 @@ async function gatherTsDepVulnsResult(cwd: string): Promise<DepVulnGatherOutcome
         const score = resolved.get(f.id);
         if (score !== null && score !== undefined) f.cvssScore = score;
       }
+    }
+
+    // Tier-2 enrichment — run osv-scanner fix to populate structured
+    // `upgradePlan` on every finding it has a proposal for. Free-text
+    // `upgradeAdvice` from npm-audit already set above stays as-is (it's
+    // the human-readable form for markdown); `upgradePlan` is the
+    // agent-consumable form. Degrades silently when osv-scanner is
+    // unavailable — zero enrichment, existing advice preserved.
+    if (findings.length > 0) {
+      const plans = await gatherOsvScannerFixPlans(cwd);
+      enrichWithUpgradePlans(findings, plans);
     }
 
     const envelope: DepVulnResult = {
@@ -904,7 +919,7 @@ export const typescript: LanguageSupport = {
 
   mapLintSeverity: mapEslintRuleSeverity,
 
-  tools: ['eslint', 'npm-audit', 'vitest-coverage', 'license-checker-rseidelsohn'],
+  tools: ['eslint', 'npm-audit', 'osv-scanner', 'vitest-coverage', 'license-checker-rseidelsohn'],
   semgrepRulesets: ['p/javascript', 'p/typescript'],
 
   capabilities: {

--- a/test/fixtures/osv-scanner/dxkit-sample.json
+++ b/test/fixtures/osv-scanner/dxkit-sample.json
@@ -1,0 +1,70 @@
+{
+  "path": "package.json",
+  "ecosystem": "npm",
+  "strategy": "relax",
+  "vulnerabilities": [
+    {
+      "id": "GHSA-4w7w-66w2-5vf9",
+      "packages": [
+        {
+          "name": "vite",
+          "version": "5.4.21"
+        }
+      ]
+    },
+    {
+      "id": "GHSA-67mh-4wv8-2f99",
+      "packages": [
+        {
+          "name": "esbuild",
+          "version": "0.21.5"
+        }
+      ]
+    },
+    {
+      "id": "GHSA-w5hq-g745-h8pq",
+      "packages": [
+        {
+          "name": "uuid",
+          "version": "8.3.2"
+        }
+      ],
+      "unactionable": true
+    }
+  ],
+  "patches": [
+    {
+      "packageUpdates": null
+    },
+    {
+      "packageUpdates": [
+        {
+          "name": "vitest",
+          "versionFrom": "^2.1.4",
+          "versionTo": "^3.2.4",
+          "transitive": false
+        }
+      ],
+      "fixed": [
+        {
+          "id": "GHSA-4w7w-66w2-5vf9",
+          "packages": [
+            {
+              "name": "vite",
+              "version": "5.4.21"
+            }
+          ]
+        },
+        {
+          "id": "GHSA-67mh-4wv8-2f99",
+          "packages": [
+            {
+              "name": "esbuild",
+              "version": "0.21.5"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/languages-csharp-depvulns.test.ts
+++ b/test/languages-csharp-depvulns.test.ts
@@ -3,6 +3,7 @@ import {
   parseDotnetVulnerableOutput,
   parseProjectAssetsJson,
   buildCsharpTopLevelDepIndex,
+  mergeAssetParses,
 } from '../src/languages/csharp';
 
 // Fixture JSONs mirror the dotnet list package --vulnerable --format json
@@ -430,5 +431,66 @@ describe('buildCsharpTopLevelDepIndex', () => {
     });
     expect(idx.get('A')).toEqual(['A']);
     expect(idx.get('B')).toEqual(['A']);
+  });
+});
+
+describe('mergeAssetParses (D003 — multi-project merge)', () => {
+  it('unions top-level sets across projects', () => {
+    const a = { topLevels: ['Alpha', 'Shared'], edges: new Map<string, Set<string>>() };
+    const b = { topLevels: ['Beta', 'Shared'], edges: new Map<string, Set<string>>() };
+    const merged = mergeAssetParses([a, b]);
+    expect(merged.topLevels).toEqual(['Alpha', 'Beta', 'Shared']);
+  });
+
+  it('unions edge adjacency for the same source package', () => {
+    // Project A sees Newtonsoft.Json → Foo; project B sees it → Bar.
+    // The merged graph shows both children reachable from Newtonsoft.Json.
+    const a = {
+      topLevels: ['Alpha'],
+      edges: new Map<string, Set<string>>([['Newtonsoft.Json', new Set(['Foo'])]]),
+    };
+    const b = {
+      topLevels: ['Beta'],
+      edges: new Map<string, Set<string>>([['Newtonsoft.Json', new Set(['Bar'])]]),
+    };
+    const merged = mergeAssetParses([a, b]);
+    expect(merged.edges.get('Newtonsoft.Json')).toEqual(new Set(['Foo', 'Bar']));
+  });
+
+  it('enables attribution reachable through a sibling project only', () => {
+    // This is the core D003 case: vulnerability in `Leaf` reachable ONLY
+    // via `Beta` project's graph. First-project-wins logic would miss it.
+    const a = {
+      topLevels: ['Alpha'],
+      edges: new Map<string, Set<string>>([['Alpha', new Set(['UnrelatedDep'])]]),
+    };
+    const b = {
+      topLevels: ['Beta'],
+      edges: new Map<string, Set<string>>([
+        ['Beta', new Set(['Middle'])],
+        ['Middle', new Set(['Leaf'])],
+      ]),
+    };
+    const merged = mergeAssetParses([a, b]);
+    const idx = buildCsharpTopLevelDepIndex(merged);
+    // Pre-fix, attribution would be empty because only project A's
+    // assets was read. Post-fix, Leaf is correctly attributed to Beta.
+    expect(idx.get('Leaf')).toEqual(['Beta']);
+  });
+
+  it('handles empty input gracefully', () => {
+    const merged = mergeAssetParses([]);
+    expect(merged.topLevels).toEqual([]);
+    expect(merged.edges.size).toBe(0);
+  });
+
+  it('handles a single-project input identically to pre-fix behavior', () => {
+    const single = {
+      topLevels: ['Solo'],
+      edges: new Map<string, Set<string>>([['Solo', new Set(['Child'])]]),
+    };
+    const merged = mergeAssetParses([single]);
+    expect(merged.topLevels).toEqual(['Solo']);
+    expect(merged.edges.get('Solo')).toEqual(new Set(['Child']));
   });
 });

--- a/test/languages-python-depvulns.test.ts
+++ b/test/languages-python-depvulns.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parsePipShowOutput, buildPyTopLevelDepIndex, isMajorBump } from '../src/languages/python';
+import { parsePipShowOutput, buildPyTopLevelDepIndex } from '../src/languages/python';
 
 // `pip show` output is RFC-822-ish Key: Value blocks separated by '---'.
 // Fixtures match the real tool's emission pattern (trailing newline,
@@ -97,26 +97,5 @@ describe('buildPyTopLevelDepIndex', () => {
   });
 });
 
-describe('isMajorBump', () => {
-  it('flags major-version upgrade as breaking', () => {
-    expect(isMajorBump('1.2.3', '2.0.0')).toBe(true);
-  });
-
-  it('flags pre-1.x minor bump as breaking (0.x convention)', () => {
-    expect(isMajorBump('0.5.0', '0.6.0')).toBe(true);
-  });
-
-  it('does not flag same-major patch bump as breaking', () => {
-    expect(isMajorBump('1.2.3', '1.2.4')).toBe(false);
-    expect(isMajorBump('2.0.0', '2.5.1')).toBe(false);
-  });
-
-  it('does not flag pre-1.x patch-level bump as breaking', () => {
-    expect(isMajorBump('0.5.0', '0.5.1')).toBe(false);
-  });
-
-  it('returns false when either input is unparseable', () => {
-    expect(isMajorBump('', '1.0.0')).toBe(false);
-    expect(isMajorBump('1.0.0', 'not-semver')).toBe(false);
-  });
-});
+// `isMajorBump` shared helper moved to src/analyzers/tools/semver-bump.ts
+// in Phase 10h.6.4; full test coverage lives in test/semver-bump.test.ts.

--- a/test/languages-python-depvulns.test.ts
+++ b/test/languages-python-depvulns.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parsePipShowOutput, buildPyTopLevelDepIndex } from '../src/languages/python';
+import { parsePipShowOutput, buildPyTopLevelDepIndex, isMajorBump } from '../src/languages/python';
 
 // `pip show` output is RFC-822-ish Key: Value blocks separated by '---'.
 // Fixtures match the real tool's emission pattern (trailing newline,
@@ -94,5 +94,29 @@ describe('buildPyTopLevelDepIndex', () => {
     // `missing` should still be attributed because BFS visits it.
     expect(idx.get('missing')).toEqual(['foo']);
     expect(idx.get('foo')).toEqual(['foo']);
+  });
+});
+
+describe('isMajorBump', () => {
+  it('flags major-version upgrade as breaking', () => {
+    expect(isMajorBump('1.2.3', '2.0.0')).toBe(true);
+  });
+
+  it('flags pre-1.x minor bump as breaking (0.x convention)', () => {
+    expect(isMajorBump('0.5.0', '0.6.0')).toBe(true);
+  });
+
+  it('does not flag same-major patch bump as breaking', () => {
+    expect(isMajorBump('1.2.3', '1.2.4')).toBe(false);
+    expect(isMajorBump('2.0.0', '2.5.1')).toBe(false);
+  });
+
+  it('does not flag pre-1.x patch-level bump as breaking', () => {
+    expect(isMajorBump('0.5.0', '0.5.1')).toBe(false);
+  });
+
+  it('returns false when either input is unparseable', () => {
+    expect(isMajorBump('', '1.0.0')).toBe(false);
+    expect(isMajorBump('1.0.0', 'not-semver')).toBe(false);
   });
 });

--- a/test/languages-rust-depvulns.test.ts
+++ b/test/languages-rust-depvulns.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  parseCargoAuditOutput,
-  buildRustTopLevelDepIndex,
-  isMajorBump,
-} from '../src/languages/rust';
+import { parseCargoAuditOutput, buildRustTopLevelDepIndex } from '../src/languages/rust';
 
 // Fixture JSONs mirror the cargo-audit --json schema documented at
 // https://docs.rs/rustsec/latest/rustsec/advisory/struct.Advisory.html.
@@ -279,25 +275,5 @@ describe('buildRustTopLevelDepIndex', () => {
   });
 });
 
-describe('isMajorBump (rust pack)', () => {
-  it('flags major-version upgrade as breaking', () => {
-    expect(isMajorBump('1.2.3', '2.0.0')).toBe(true);
-  });
-
-  it('flags pre-1.x minor bump as breaking (0.x convention shared with ts + python packs)', () => {
-    expect(isMajorBump('0.5.0', '0.6.0')).toBe(true);
-  });
-
-  it('does not flag same-major patch bump as breaking', () => {
-    expect(isMajorBump('1.2.3', '1.2.4')).toBe(false);
-  });
-
-  it('does not flag pre-1.x patch-level bump as breaking', () => {
-    expect(isMajorBump('0.5.0', '0.5.1')).toBe(false);
-  });
-
-  it('returns false when either input is unparseable', () => {
-    expect(isMajorBump('', '1.0.0')).toBe(false);
-    expect(isMajorBump('1.0.0', 'not-semver')).toBe(false);
-  });
-});
+// `isMajorBump` shared helper moved to src/analyzers/tools/semver-bump.ts
+// in Phase 10h.6.4; full test coverage lives in test/semver-bump.test.ts.

--- a/test/languages-rust-depvulns.test.ts
+++ b/test/languages-rust-depvulns.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { parseCargoAuditOutput, buildRustTopLevelDepIndex } from '../src/languages/rust';
+import {
+  parseCargoAuditOutput,
+  buildRustTopLevelDepIndex,
+  isMajorBump,
+} from '../src/languages/rust';
 
 // Fixture JSONs mirror the cargo-audit --json schema documented at
 // https://docs.rs/rustsec/latest/rustsec/advisory/struct.Advisory.html.
@@ -272,5 +276,28 @@ describe('buildRustTopLevelDepIndex', () => {
     });
     const idx = buildRustTopLevelDepIndex(raw);
     expect(idx.get('bytes')).toEqual(['reqwest', 'tokio']);
+  });
+});
+
+describe('isMajorBump (rust pack)', () => {
+  it('flags major-version upgrade as breaking', () => {
+    expect(isMajorBump('1.2.3', '2.0.0')).toBe(true);
+  });
+
+  it('flags pre-1.x minor bump as breaking (0.x convention shared with ts + python packs)', () => {
+    expect(isMajorBump('0.5.0', '0.6.0')).toBe(true);
+  });
+
+  it('does not flag same-major patch bump as breaking', () => {
+    expect(isMajorBump('1.2.3', '1.2.4')).toBe(false);
+  });
+
+  it('does not flag pre-1.x patch-level bump as breaking', () => {
+    expect(isMajorBump('0.5.0', '0.5.1')).toBe(false);
+  });
+
+  it('returns false when either input is unparseable', () => {
+    expect(isMajorBump('', '1.0.0')).toBe(false);
+    expect(isMajorBump('1.0.0', 'not-semver')).toBe(false);
   });
 });

--- a/test/languages-typescript.test.ts
+++ b/test/languages-typescript.test.ts
@@ -143,6 +143,7 @@ describe('typescript registration', () => {
     expect(typescript.tools).toEqual([
       'eslint',
       'npm-audit',
+      'osv-scanner',
       'vitest-coverage',
       'license-checker-rseidelsohn',
     ]);

--- a/test/osv-scanner-fix.test.ts
+++ b/test/osv-scanner-fix.test.ts
@@ -1,0 +1,243 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+import {
+  enrichWithUpgradePlans,
+  parseOsvScannerFixOutput,
+  planKey,
+} from '../src/analyzers/tools/osv-scanner-fix';
+import type { DepVulnFinding } from '../src/languages/capabilities/types';
+
+/** Captured from running `osv-scanner fix --format json --manifest package.json
+ *  --lockfile package-lock.json` against dxkit itself on 2026-04-24. Covers
+ *  three realistic shapes: a normal patch, a patch with null packageUpdates
+ *  (no-op alternative), and an unactionable vuln (uuid with no fix path). */
+const FIXTURE = fs.readFileSync(
+  path.join(__dirname, 'fixtures/osv-scanner/dxkit-sample.json'),
+  'utf8',
+);
+
+function mkFinding(
+  overrides: Partial<DepVulnFinding> & Pick<DepVulnFinding, 'id' | 'package'>,
+): DepVulnFinding {
+  return {
+    id: overrides.id,
+    package: overrides.package,
+    installedVersion: overrides.installedVersion ?? '1.0.0',
+    tool: overrides.tool ?? 'npm-audit',
+    severity: overrides.severity ?? 'medium',
+    ...overrides,
+  };
+}
+
+describe('parseOsvScannerFixOutput — sample output', () => {
+  it('returns plans for every fixed advisory in a patch', () => {
+    const plans = parseOsvScannerFixOutput(FIXTURE);
+    // Sample fixture has one actionable patch (vitest) fixing two advisories
+    // (GHSA-4w7w-66w2-5vf9 on vite@5.4.21, GHSA-67mh-4wv8-2f99 on esbuild@0.21.5).
+    expect(plans.size).toBe(2);
+    expect(plans.has(planKey('vite', '5.4.21', 'GHSA-4w7w-66w2-5vf9'))).toBe(true);
+    expect(plans.has(planKey('esbuild', '0.21.5', 'GHSA-67mh-4wv8-2f99'))).toBe(true);
+  });
+
+  it('points every fixed-advisory entry at the same parent upgrade', () => {
+    const plans = parseOsvScannerFixOutput(FIXTURE);
+    const vitePlan = plans.get(planKey('vite', '5.4.21', 'GHSA-4w7w-66w2-5vf9'));
+    const esbuildPlan = plans.get(planKey('esbuild', '0.21.5', 'GHSA-67mh-4wv8-2f99'));
+    expect(vitePlan?.parent).toBe('vitest');
+    expect(esbuildPlan?.parent).toBe('vitest');
+    // Both advisories sit under the same patch, so the plan's patches[]
+    // lists both ids — consumers see "one upgrade patches 2 advisories".
+    expect(vitePlan?.patches).toEqual(['GHSA-4w7w-66w2-5vf9', 'GHSA-67mh-4wv8-2f99'].sort());
+    expect(esbuildPlan?.patches).toEqual(vitePlan?.patches);
+  });
+
+  it('strips semver range operators from parentVersion', () => {
+    const plans = parseOsvScannerFixOutput(FIXTURE);
+    const plan = plans.get(planKey('vite', '5.4.21', 'GHSA-4w7w-66w2-5vf9'));
+    // Fixture has versionTo: "^3.2.4" → agent-consumable form is 3.2.4.
+    expect(plan?.parentVersion).toBe('3.2.4');
+  });
+
+  it('flags a major-version parent bump as breaking', () => {
+    const plans = parseOsvScannerFixOutput(FIXTURE);
+    const plan = plans.get(planKey('vite', '5.4.21', 'GHSA-4w7w-66w2-5vf9'));
+    // ^2.1.4 → ^3.2.4 crosses major — breaking
+    expect(plan?.breaking).toBe(true);
+  });
+
+  it('skips unactionable vulns (no plan emitted)', () => {
+    const plans = parseOsvScannerFixOutput(FIXTURE);
+    // uuid@8.3.2 / GHSA-w5hq-g745-h8pq has unactionable: true in fixture;
+    // no patch fixes it, so no plan entry.
+    expect(plans.has(planKey('uuid', '8.3.2', 'GHSA-w5hq-g745-h8pq'))).toBe(false);
+  });
+
+  it('ignores patches with null packageUpdates', () => {
+    // Sample fixture contains one such patch; the parser must not crash
+    // on it (parser crashed was the original implementation without the
+    // null guard).
+    const plans = parseOsvScannerFixOutput(FIXTURE);
+    expect(plans.size).toBeGreaterThan(0);
+  });
+});
+
+describe('parseOsvScannerFixOutput — resilience', () => {
+  it('strips preamble text before the first { (osv legacy-peer-deps warning)', () => {
+    const withPreamble = 'npm install failed. Trying again with `--legacy-peer-deps`\n' + FIXTURE;
+    const plans = parseOsvScannerFixOutput(withPreamble);
+    expect(plans.size).toBe(2);
+  });
+
+  it('returns empty map on no JSON at all', () => {
+    expect(parseOsvScannerFixOutput('').size).toBe(0);
+    expect(parseOsvScannerFixOutput('not json anywhere').size).toBe(0);
+  });
+
+  it('returns empty map on malformed JSON (no throw)', () => {
+    const plans = parseOsvScannerFixOutput('{ "incomplete":');
+    expect(plans.size).toBe(0);
+  });
+
+  it('returns empty map when patches array is absent', () => {
+    const plans = parseOsvScannerFixOutput('{"path":"x","ecosystem":"npm"}');
+    expect(plans.size).toBe(0);
+  });
+
+  it('marks pre-1.x minor bump as breaking (0.5 → 0.6)', () => {
+    const json = JSON.stringify({
+      path: 'package.json',
+      ecosystem: 'npm',
+      patches: [
+        {
+          packageUpdates: [
+            { name: 'p', versionFrom: '^0.5.0', versionTo: '^0.6.0', transitive: false },
+          ],
+          fixed: [{ id: 'CVE-x', packages: [{ name: 'p', version: '0.5.0' }] }],
+        },
+      ],
+    });
+    const plans = parseOsvScannerFixOutput(json);
+    const plan = plans.get(planKey('p', '0.5.0', 'CVE-x'));
+    expect(plan?.breaking).toBe(true);
+  });
+
+  it('does not mark same-major patch bump as breaking (1.2.3 → 1.2.4)', () => {
+    const json = JSON.stringify({
+      patches: [
+        {
+          packageUpdates: [
+            { name: 'p', versionFrom: '^1.2.3', versionTo: '^1.2.4', transitive: false },
+          ],
+          fixed: [{ id: 'CVE-x', packages: [{ name: 'p', version: '1.2.3' }] }],
+        },
+      ],
+    });
+    const plans = parseOsvScannerFixOutput(json);
+    expect(plans.get(planKey('p', '1.2.3', 'CVE-x'))?.breaking).toBe(false);
+  });
+
+  it('prefers direct (non-transitive) update as the parent over transitive ones', () => {
+    const json = JSON.stringify({
+      patches: [
+        {
+          packageUpdates: [
+            {
+              name: 'transitive-dep',
+              versionFrom: '^1.0.0',
+              versionTo: '^2.0.0',
+              transitive: true,
+            },
+            {
+              name: 'direct-parent',
+              versionFrom: '^2.0.0',
+              versionTo: '^3.0.0',
+              transitive: false,
+            },
+          ],
+          fixed: [{ id: 'CVE-x', packages: [{ name: 'leaf', version: '1.0.0' }] }],
+        },
+      ],
+    });
+    const plans = parseOsvScannerFixOutput(json);
+    const plan = plans.get(planKey('leaf', '1.0.0', 'CVE-x'));
+    expect(plan?.parent).toBe('direct-parent');
+  });
+});
+
+describe('enrichWithUpgradePlans', () => {
+  it('stamps upgradePlan on matching findings', () => {
+    const plans = parseOsvScannerFixOutput(FIXTURE);
+    const findings: DepVulnFinding[] = [
+      mkFinding({
+        id: 'GHSA-4w7w-66w2-5vf9',
+        package: 'vite',
+        installedVersion: '5.4.21',
+      }),
+      mkFinding({
+        id: 'GHSA-67mh-4wv8-2f99',
+        package: 'esbuild',
+        installedVersion: '0.21.5',
+      }),
+    ];
+    const stamped = enrichWithUpgradePlans(findings, plans);
+    expect(stamped).toBe(2);
+    expect(findings[0].upgradePlan?.parent).toBe('vitest');
+    expect(findings[1].upgradePlan?.parent).toBe('vitest');
+  });
+
+  it('leaves findings unchanged when no matching plan exists', () => {
+    const plans = parseOsvScannerFixOutput(FIXTURE);
+    const findings: DepVulnFinding[] = [
+      mkFinding({ id: 'UNKNOWN-1', package: 'axios', installedVersion: '0.18.0' }),
+    ];
+    enrichWithUpgradePlans(findings, plans);
+    expect(findings[0].upgradePlan).toBeUndefined();
+  });
+
+  it('ignores findings without installedVersion', () => {
+    const plans = parseOsvScannerFixOutput(FIXTURE);
+    const findings: DepVulnFinding[] = [
+      mkFinding({ id: 'GHSA-4w7w-66w2-5vf9', package: 'vite', installedVersion: undefined }),
+    ];
+    const stamped = enrichWithUpgradePlans(findings, plans);
+    expect(stamped).toBe(0);
+    expect(findings[0].upgradePlan).toBeUndefined();
+  });
+
+  it('is idempotent (stamping twice yields same plan)', () => {
+    const plans = parseOsvScannerFixOutput(FIXTURE);
+    const findings: DepVulnFinding[] = [
+      mkFinding({
+        id: 'GHSA-4w7w-66w2-5vf9',
+        package: 'vite',
+        installedVersion: '5.4.21',
+      }),
+    ];
+    enrichWithUpgradePlans(findings, plans);
+    const first = findings[0].upgradePlan;
+    enrichWithUpgradePlans(findings, plans);
+    expect(findings[0].upgradePlan).toBe(first);
+  });
+
+  it('returns 0 for empty plan map without walking findings', () => {
+    const findings: DepVulnFinding[] = [mkFinding({ id: 'x', package: 'p' })];
+    const stamped = enrichWithUpgradePlans(findings, new Map());
+    expect(stamped).toBe(0);
+  });
+
+  it('matches case-insensitive GHSA ids (npm-audit emits uppercase; osv-scanner emits lowercase)', () => {
+    const plans = parseOsvScannerFixOutput(FIXTURE);
+    // npm-audit would emit this finding with an uppercased ID; ensure
+    // enrichment finds the plan regardless.
+    const findings: DepVulnFinding[] = [
+      mkFinding({
+        id: 'GHSA-4W7W-66W2-5VF9', // uppercase
+        package: 'vite',
+        installedVersion: '5.4.21',
+      }),
+    ];
+    enrichWithUpgradePlans(findings, plans);
+    expect(findings[0].upgradePlan?.parent).toBe('vitest');
+  });
+});

--- a/test/semver-bump.test.ts
+++ b/test/semver-bump.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isMajorBump } from '../src/analyzers/tools/semver-bump';
+
+describe('isMajorBump', () => {
+  it('flags major-version upgrade as breaking', () => {
+    expect(isMajorBump('1.2.3', '2.0.0')).toBe(true);
+  });
+
+  it('flags pre-1.x minor bump as breaking (0.x convention)', () => {
+    // 0.x lines are considered unstable; any minor bump is potentially breaking.
+    expect(isMajorBump('0.5.0', '0.6.0')).toBe(true);
+  });
+
+  it('does not flag same-major patch bump as breaking', () => {
+    expect(isMajorBump('1.2.3', '1.2.4')).toBe(false);
+    expect(isMajorBump('2.0.0', '2.5.1')).toBe(false);
+  });
+
+  it('does not flag pre-1.x patch-level bump as breaking', () => {
+    expect(isMajorBump('0.5.0', '0.5.1')).toBe(false);
+  });
+
+  it('flags pre-1.x → 1.0 as breaking (crosses stability boundary)', () => {
+    expect(isMajorBump('0.9.5', '1.0.0')).toBe(true);
+  });
+
+  it('returns false when either input is unparseable', () => {
+    expect(isMajorBump('', '1.0.0')).toBe(false);
+    expect(isMajorBump('1.0.0', 'not-semver')).toBe(false);
+    expect(isMajorBump('x.y.z', '1.0.0')).toBe(false);
+  });
+
+  it('handles version strings with fewer than three segments', () => {
+    // The TS/Python/Rust packs sometimes hand in two-segment versions
+    // (e.g. `0.5`) pulled from pyproject/Cargo.toml.
+    expect(isMajorBump('1', '2')).toBe(true);
+    expect(isMajorBump('0.5', '0.6')).toBe(true);
+    expect(isMajorBump('1.2', '1.3')).toBe(false);
+  });
+});

--- a/test/upgrade-plan-resolver.test.ts
+++ b/test/upgrade-plan-resolver.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import {
+  reconcileUpgradePlans,
+  resolveTransitiveUpgradePlans,
+  stampFromFreeTextAdvice,
+} from '../src/analyzers/tools/upgrade-plan-resolver';
+import type { DepVulnFinding } from '../src/languages/capabilities/types';
+
+function mkFinding(
+  overrides: Partial<DepVulnFinding> & Pick<DepVulnFinding, 'id' | 'package'>,
+): DepVulnFinding {
+  return {
+    id: overrides.id,
+    package: overrides.package,
+    installedVersion: overrides.installedVersion ?? '1.0.0',
+    tool: overrides.tool ?? 'npm-audit',
+    severity: overrides.severity ?? 'medium',
+    ...overrides,
+  };
+}
+
+describe('reconcileUpgradePlans', () => {
+  it('stamps a plan on findings whose id is in the plan patches[] but lack an upgradePlan', () => {
+    const findings: DepVulnFinding[] = [
+      mkFinding({
+        id: 'CVE-1',
+        package: 'vite',
+        upgradePlan: {
+          parent: 'vitest',
+          parentVersion: '3.2.4',
+          patches: ['CVE-1', 'CVE-2'],
+          breaking: true,
+        },
+      }),
+      // Sibling advisory — same patch, no plan yet.
+      mkFinding({ id: 'CVE-2', package: 'esbuild' }),
+    ];
+    const stamped = reconcileUpgradePlans(findings);
+    expect(stamped).toBe(1);
+    expect(findings[1].upgradePlan?.parent).toBe('vitest');
+    expect(findings[1].upgradePlan).toBe(findings[0].upgradePlan);
+  });
+
+  it('is case-insensitive on advisory id matching', () => {
+    const findings: DepVulnFinding[] = [
+      mkFinding({
+        id: 'ghsa-aaaa-bbbb-cccc',
+        package: 'x',
+        upgradePlan: {
+          parent: 'p',
+          parentVersion: '2.0.0',
+          patches: ['GHSA-AAAA-BBBB-CCCC', 'GHSA-dddd-eeee-ffff'],
+          breaking: false,
+        },
+      }),
+      mkFinding({ id: 'GHSA-DDDD-EEEE-FFFF', package: 'y' }),
+    ];
+    reconcileUpgradePlans(findings);
+    expect(findings[1].upgradePlan?.parent).toBe('p');
+  });
+
+  it('never overwrites an existing plan', () => {
+    const original = {
+      parent: 'producerA',
+      parentVersion: '1.0.0',
+      patches: ['CVE-1'],
+      breaking: false,
+    };
+    const findings: DepVulnFinding[] = [
+      mkFinding({ id: 'CVE-1', package: 'pkg', upgradePlan: original }),
+      mkFinding({
+        id: 'CVE-2',
+        package: 'other',
+        upgradePlan: {
+          parent: 'producerB',
+          parentVersion: '2.0.0',
+          patches: ['CVE-1', 'CVE-2'],
+          breaking: true,
+        },
+      }),
+    ];
+    reconcileUpgradePlans(findings);
+    // The finding with the pre-existing plan keeps it — producer-written
+    // plans are authoritative; reconciliation only fills gaps.
+    expect(findings[0].upgradePlan).toBe(original);
+  });
+
+  it('prefers the higher parentVersion when multiple plans list the same id', () => {
+    const findings: DepVulnFinding[] = [
+      mkFinding({
+        id: 'CVE-SEED',
+        package: 'a',
+        upgradePlan: {
+          parent: 'p',
+          parentVersion: '2.0.0',
+          patches: ['CVE-SEED', 'CVE-UNSTAMPED'],
+          breaking: true,
+        },
+      }),
+      mkFinding({
+        id: 'CVE-OTHER',
+        package: 'b',
+        upgradePlan: {
+          parent: 'p',
+          parentVersion: '3.5.0',
+          patches: ['CVE-OTHER', 'CVE-UNSTAMPED'],
+          breaking: true,
+        },
+      }),
+      mkFinding({ id: 'CVE-UNSTAMPED', package: 'c' }),
+    ];
+    reconcileUpgradePlans(findings);
+    // The unstamped finding gets the 3.5.0 plan, not the 2.0.0 plan.
+    expect(findings[2].upgradePlan?.parentVersion).toBe('3.5.0');
+  });
+
+  it('is idempotent — second run stamps nothing new', () => {
+    const findings: DepVulnFinding[] = [
+      mkFinding({
+        id: 'CVE-1',
+        package: 'a',
+        upgradePlan: {
+          parent: 'p',
+          parentVersion: '2.0.0',
+          patches: ['CVE-1', 'CVE-2'],
+          breaking: false,
+        },
+      }),
+      mkFinding({ id: 'CVE-2', package: 'b' }),
+    ];
+    reconcileUpgradePlans(findings);
+    const second = reconcileUpgradePlans(findings);
+    expect(second).toBe(0);
+  });
+
+  it('ignores findings not mentioned in any plan patches[]', () => {
+    const findings: DepVulnFinding[] = [
+      mkFinding({
+        id: 'CVE-1',
+        package: 'a',
+        upgradePlan: { parent: 'p', parentVersion: '1.0.0', patches: ['CVE-1'], breaking: false },
+      }),
+      mkFinding({ id: 'CVE-UNRELATED', package: 'z' }),
+    ];
+    reconcileUpgradePlans(findings);
+    expect(findings[1].upgradePlan).toBeUndefined();
+  });
+});
+
+describe('stampFromFreeTextAdvice', () => {
+  it('parses the transitive-fix template into a structured plan', () => {
+    const findings: DepVulnFinding[] = [
+      mkFinding({
+        id: 'GHSA-xxx',
+        package: 'minimatch',
+        upgradeAdvice: 'Upgrade @loopback/cli to 7.0.1 [major] (transitive fix)',
+      }),
+    ];
+    const stamped = stampFromFreeTextAdvice(findings);
+    expect(stamped).toBe(1);
+    expect(findings[0].upgradePlan).toEqual({
+      parent: '@loopback/cli',
+      parentVersion: '7.0.1',
+      patches: ['GHSA-xxx'],
+      breaking: true,
+    });
+  });
+
+  it('detects non-major transitive upgrades', () => {
+    const findings: DepVulnFinding[] = [
+      mkFinding({
+        id: 'CVE-minor',
+        package: 'child',
+        upgradeAdvice: 'Upgrade parent to 1.2.3 (transitive fix)',
+      }),
+    ];
+    stampFromFreeTextAdvice(findings);
+    expect(findings[0].upgradePlan?.breaking).toBe(false);
+  });
+
+  it('never overwrites an existing plan (pre-existing takes precedence)', () => {
+    const existing = { parent: 'x', parentVersion: '1.0.0', patches: ['CVE-x'], breaking: false };
+    const findings: DepVulnFinding[] = [
+      mkFinding({
+        id: 'CVE-x',
+        package: 'y',
+        upgradeAdvice: 'Upgrade other to 2.0.0 (transitive fix)',
+        upgradePlan: existing,
+      }),
+    ];
+    const stamped = stampFromFreeTextAdvice(findings);
+    expect(stamped).toBe(0);
+    expect(findings[0].upgradePlan).toBe(existing);
+  });
+
+  it('skips findings with no advice or with non-template advice', () => {
+    const findings: DepVulnFinding[] = [
+      mkFinding({ id: 'a', package: 'a' }), // no advice
+      mkFinding({
+        id: 'b',
+        package: 'b',
+        upgradeAdvice: 'PROPOSAL: Upgrade to 1.0.0 (resolves 1 vuln)', // Tier-1 template, not transitive
+      }),
+      mkFinding({ id: 'c', package: 'c', upgradeAdvice: 'some random text' }),
+    ];
+    const stamped = stampFromFreeTextAdvice(findings);
+    expect(stamped).toBe(0);
+    expect(findings.every((f) => !f.upgradePlan)).toBe(true);
+  });
+});
+
+describe('resolveTransitiveUpgradePlans', () => {
+  it('runs reconciliation and free-text parse in order', () => {
+    const findings: DepVulnFinding[] = [
+      // Tier-2 stamped finding
+      mkFinding({
+        id: 'CVE-seed',
+        package: 'a',
+        upgradePlan: {
+          parent: 'parent',
+          parentVersion: '2.0.0',
+          patches: ['CVE-seed', 'CVE-twin'],
+          breaking: true,
+        },
+      }),
+      // Should be reconciled via patches[] lookup
+      mkFinding({ id: 'CVE-twin', package: 'b' }),
+      // Should be stamped from free-text only (no reconciliation match)
+      mkFinding({
+        id: 'CVE-lonely',
+        package: 'c',
+        upgradeAdvice: 'Upgrade libX to 3.0.0 (transitive fix)',
+      }),
+    ];
+    const stats = resolveTransitiveUpgradePlans(findings);
+    expect(stats.reconciled).toBe(1);
+    expect(stats.fromFreeText).toBe(1);
+    expect(findings[1].upgradePlan?.parent).toBe('parent');
+    expect(findings[2].upgradePlan?.parent).toBe('libX');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 10h.6 complete, ships as 2.4.0. Six sub-commits on the integration branch `feat/10h.6`:

| Sub-commit | What | Lines |
|---|---|---|
| [10h.6.1](../commit/04f1a66) | TypeScript \`osv-scanner fix\` wrap — stamps structured \`upgradePlan\` on every npm-audit finding osv-scanner has a proposal for. Dog-fooded end-to-end (delete + reinstall via \`dxkit tools install\`). | +606 |
| [10h.6.2](../commit/0ffdd72) | Python \`pip-audit\` upgradePlan population — pure transformation of existing \`fix_versions[]\` data; no new subprocess call. | +73 |
| [10h.6.3](../commit/795761a) | Rust \`cargo-audit\` upgradePlan population — same pattern as Python; flat dep graph means parent == package. | +69 |
| [10h.6.4](../commit/c05969c) | Cross-pack upgrade-plan resolver + consolidation of \`isMajorBump\` into \`semver-bump.ts\`. Two-pass resolver: (a) reconciliation via \`patches[]\` lookup, (b) free-text \`upgradeAdvice\` parse. | +503 |
| [10h.6.7](../commit/1327364) | **Closes D003** — C# multi-project attribution merge. Enumerates every \`obj/project.assets.json\`, merges edge maps, BFS against union. | +151 |
| [release commit](../commit/6fd34b8) | Version bump 2.3.2 → 2.4.0; CHANGELOG promote. | +12 |

Plus the earlier 10h.6.5 + 10h.6.6 type additions (fingerprint + upgradePlan contract) that shipped via [PR #15](../pull/15).

## User-facing theme

Every \`DepVulnFinding\` that has a viable remediation now carries a **structured \`upgradePlan\`** an autonomous upgrade bot can consume directly:

\`\`\`ts
upgradePlan: {
  parent: 'vitest',          // what to upgrade
  parentVersion: '3.2.4',    // target version (no range prefix)
  patches: ['GHSA-4w7w-...', 'GHSA-67mh-...'],  // advisories this resolves
  breaking: true              // conservative — pre-1.x minor = breaking too
}
\`\`\`

Free-text \`upgradeAdvice\` stays for markdown/xlsx readability.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run format:check\` — clean
- [x] \`npm run test:run\` — **773/773 passing across 47 files** (up from 715/42 at v2.3.2)
- [x] \`bash scripts/check-architecture.sh\` — clean
- [x] \`bash scripts/check-slop.sh\` — clean
- [x] Dog-fooded osv-scanner install end-to-end via \`dxkit tools install\`
- [x] Verified structured \`upgradePlan\` populates on dxkit's own \`vulnerabilities --json\`
- [ ] Post-merge: tag v2.4.0, create GitHub Release → publish workflow fires

## Defects closed

- **D003** (C# multi-project attribution) — 10h.6.7

## Remaining after this PR

Per \`tmp/phase-10h-roadmap.md\`: 2.5.0 scopes **Phase 10i** (agent + PM report parity + language-parity fixes), then 10h.7 (HTML viewer), 10h.9 (suppressions + CI gate), 10h.8 (optional Snyk), 10f.3–.5 (reliability polish), 10g (AI Readiness, BREAKING).

🤖 Generated with [Claude Code](https://claude.com/claude-code)