### PR TITLE
docs: note npx-vs-global-install gotcha (post-2.4.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ npx @vyuhlabs/dxkit init --full --yes         # everything: DX + quality + hooks
 
 The two modes are complementary. The analyzers run anywhere; the scaffolder writes `.claude/` so Claude Code and other agents have project-specific context and slash commands that delegate to the same analyzers.
 
+> **Already installed dxkit globally? Upgrade explicitly.** `npx @vyuhlabs/dxkit@<version>` resolves the `vyuh-dxkit` binary off PATH first — if you previously ran `npm install -g @vyuhlabs/dxkit`, npx silently uses that older global binary regardless of the `@<version>` you specified. This is npx behavior, not a dxkit bug. To pick up the latest fixes (e.g. the 2.4.5 osv-scanner-fix data-mutation fix), run:
+>
+> ```bash
+> npm install -g @vyuhlabs/dxkit@latest
+> # or, if you don't need a global install, remove the old one and rely on npx:
+> npm uninstall -g @vyuhlabs/dxkit
+> ```
+
 ---
 
 ## Analyzer CLI (`vyuh-dxkit <command>`)


### PR DESCRIPTION
## Summary

- Adds a Quick Start note in `README.md` warning that `npx @vyuhlabs/dxkit@<version>` resolves the `vyuh-dxkit` binary off PATH first — a stale `npm install -g` from a previous version silently shadows the `@<version>` spec.
- Surfaced during 2.4.5 post-ship smoke: a stale global symlink to 2.4.2 made it look like 2.4.5 was reproducing the osv-scanner-fix node_modules wipe. It wasn't — npx was just running 2.4.2.
- Two-line fix: `npm install -g @vyuhlabs/dxkit@latest`, or `npm uninstall -g` and rely on npx exclusively.

## Test plan

- [x] Local pre-push gates green (typecheck, docs-coverage, format, full test suite, coverage threshold)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)