### PR TITLE
Sprint 0 v1: per-finding identity dispatch + git-aware matcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,58 @@ through the test-gap taxonomy and Maintainability prose — analogous
 to its existing assertion for `depVuln` + `tlsBypass` contributions
 (G_v4_8).
 
+### 9. Per-finding identity flows through the canonical fingerprint helpers
+
+Every actionable per-finding output dxkit surfaces (secrets,
+code-pattern findings, dependency advisories, license attributions,
+duplicate blocks, coverage gaps, test-gap source files, hygiene
+markers, and any future kind) MUST receive its durable identity from
+the canonical helpers, never an inline hash:
+
+- **Compute** via `src/analyzers/tools/fingerprint.ts` — the home of
+  every SHA-1[0:16] fingerprint scheme (`computeFingerprint` for
+  dep-vulns, `computeCodeFingerprint` for code/secret/config,
+  `canonicalRuleFor` for cross-tool dedup, `lineWindowFor` for the
+  shared 3-line bucket).
+- **Dispatch** via `src/baseline/finding-identity.ts:identityFor` —
+  the single switch over `IdentityInput` discriminants. Adding a new
+  finding kind is a three-line change (interface → union →
+  case branch), with TypeScript's exhaustiveness check enforcing
+  switch completeness.
+- **Compare** via `src/baseline/finding-identity.ts:matchAcrossRuns`
+  (multiset-aware set diff) or `src/baseline/git-aware-match.ts`
+  (git-aware line relocation with file-rename support and
+  ±2 line fuzz). Every match pair carries confidence in [0, 1]
+  plus structured reasons (`exact-id`, `git-line-exact`,
+  `git-line-fuzz`, `git-rename`).
+
+The fingerprint is the durable contract between today's scan and
+tomorrow's guardrail check. Bypassing the canonical helpers means
+silently opting out of that contract.
+
+#### Fingerprint-discipline enforcement
+
+Four rules in `scripts/check-architecture.sh` + `test/`:
+
+1. **No `createHash` for finding identity outside the canonical
+   files.** Allowed in `src/analyzers/tools/fingerprint.ts` and
+   `src/baseline/finding-identity.ts`. Annotate
+   `// fingerprint-helper-ok` for justified non-identity hashing
+   (today: zero needed inside `src/analyzers/` and `src/baseline/`).
+2. **No inline `Math.floor(x / N) * N`-style line-bucketing**
+   outside `tools/fingerprint.ts`. Forces consumers through
+   `lineWindowFor()` so the 3-line constant lives in one place.
+3. **Every `IdentityInput` discriminant has a fixture row in
+   `test/baseline/finding-identity.test.ts`.** Asserted at test
+   time: when a new kind lands in the union, a fixture must
+   accompany it or the assertion fails.
+4. **Synthetic-pack findings flow through the canonical helpers.**
+   `test/recipe-playbook.test.ts` asserts the synthetic pack's
+   code-pattern + dep-vuln contributions emerge from the aggregator
+   with non-empty `fingerprint` fields matching the canonical
+   format — codifies "fingerprinting is pack-driven, not
+   analyzer-by-analyzer."
+
 ## Release procedure
 
 **Every release goes through the CI pipeline. No exceptions.** Local

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -555,6 +555,72 @@ if [ -n "$ARCH_SHAPE_WORD_VIOLATIONS" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# ─── Rule 9 (fingerprint discipline): one home for finding-identity hashes ──
+#
+# What this prevents:
+#   A future analyzer rolling its own SHA scheme for finding identity,
+#   silently opting out of the baseline / guardrail contract. Every
+#   per-finding fingerprint flows through the canonical helpers in
+#   `src/analyzers/tools/fingerprint.ts`, dispatched by
+#   `src/baseline/finding-identity.ts:identityFor`.
+#
+# Canonical sites (`createHash` allowed):
+#   - `src/analyzers/tools/fingerprint.ts` — the home of every
+#     SHA-1[0:16] fingerprint scheme.
+#   - `src/baseline/finding-identity.ts` — the dispatch that delegates
+#     to those helpers for cross-kind identity output.
+#
+# Scope:
+#   `src/analyzers/` + `src/baseline/`. `src/files.ts` legitimately
+#   uses SHA-256 for file-content hashing (caching / dedup, NOT finding
+#   identity); it sits outside the scope and is unaffected.
+#
+# Annotate `// fingerprint-helper-ok` on a specific line for a
+# justified non-identity hash inside the scoped directories.
+FINGERPRINT_HELPER_ALLOWLIST="src/analyzers/tools/fingerprint.ts src/baseline/finding-identity.ts"
+ALLOW_FILTER_FP=""
+for f in $FINGERPRINT_HELPER_ALLOWLIST; do
+  ALLOW_FILTER_FP="$ALLOW_FILTER_FP -e ^${f}:"
+done
+
+ROGUE_HASH=$(grep -rnE "createHash[[:space:]]*\(" src/analyzers/ src/baseline/ 2>/dev/null \
+  | grep -v "// fingerprint-helper-ok" \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | { [ -n "$ALLOW_FILTER_FP" ] && grep -v $ALLOW_FILTER_FP || cat; })
+if [ -n "$ROGUE_HASH" ]; then
+  echo "❌ Rule 9 violation: createHash() used outside the canonical fingerprint helpers:"
+  echo "$ROGUE_HASH"
+  echo "   → Use computeFingerprint or computeCodeFingerprint from src/analyzers/tools/fingerprint.ts."
+  echo "   → For new finding kinds, extend src/baseline/finding-identity.ts:identityFor"
+  echo "     with a new IdentityInput discriminant rather than hashing inline."
+  echo "   → Annotate '// fingerprint-helper-ok' for justified non-identity hashing."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Line-bucketing reimplementation gate: the 3-line window used by code-
+# finding fingerprints lives in `lineWindowFor()` and only there. Any
+# `Math.floor(x / N) * N`-shaped expression inside the scoped
+# directories is a candidate for rolling-your-own bucket scheme.
+LINE_BUCKET_ALLOWLIST="src/analyzers/tools/fingerprint.ts"
+ALLOW_FILTER_LB=""
+for f in $LINE_BUCKET_ALLOWLIST; do
+  ALLOW_FILTER_LB="$ALLOW_FILTER_LB -e ^${f}:"
+done
+
+ROGUE_BUCKET=$(grep -rnE "Math\.floor\([^/]*\/[[:space:]]*[0-9]+[[:space:]]*\)[[:space:]]*\*[[:space:]]*[0-9]+" src/analyzers/ src/baseline/ 2>/dev/null \
+  | grep -v "// fingerprint-helper-ok" \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | { [ -n "$ALLOW_FILTER_LB" ] && grep -v $ALLOW_FILTER_LB || cat; })
+if [ -n "$ROGUE_BUCKET" ]; then
+  echo "❌ Rule 9 violation: inline line-bucketing outside the canonical helper:"
+  echo "$ROGUE_BUCKET"
+  echo "   → Import { lineWindowFor } from '../tools/fingerprint' instead of"
+  echo "     reimplementing Math.floor(line / N) * N inline."
+  echo "   → The 3-line constant lives in CODE_FINGERPRINT_LINE_WINDOW."
+  echo "   → Annotate '// fingerprint-helper-ok' for justified exceptions (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ $ERRORS -gt 0 ]; then
   echo ""
   echo "Architecture checks failed. See CLAUDE.md for rules."

--- a/src/analyzers/security/aggregator.ts
+++ b/src/analyzers/security/aggregator.ts
@@ -55,9 +55,9 @@
  * outside this file, mirroring G_v4_7's walker allowlist.
  */
 
-import { createHash } from 'crypto';
 import type { DepVulnFinding } from '../../languages/capabilities/types';
 import type { Severity, FindingCategory, SecurityFinding } from './types';
+import { canonicalRuleFor, computeCodeFingerprint } from '../tools/fingerprint';
 
 // ─── Re-exports for consumer convenience ──────────────────────────────────
 
@@ -203,53 +203,6 @@ export interface SecurityAggregate {
  * double-counting. Future entries land when a new language pack or
  * semgrep ruleset surfaces overlap with an existing finding type.
  */
-const CANONICAL_RULE_MAP = new Map<string, string>([
-  // TLS / certificate validation bypass — D091 closure
-  ['tls-bypass-registry:tls-validation-disabled', 'canonical:tls-bypass'],
-  ['semgrep:bypass-tls-verification', 'canonical:tls-bypass'],
-  ['semgrep:nodejsscan.node_tls_reject_unauthorized', 'canonical:tls-bypass'],
-
-  // Private-key file on disk — find + gitleaks may both surface
-  ['find:private-key-file', 'canonical:private-key-on-disk'],
-  ['gitleaks:private-key', 'canonical:private-key-on-disk'],
-]);
-
-function canonicalRuleFor(tool: string, rule: string): string {
-  return CANONICAL_RULE_MAP.get(`${tool}:${rule}`) ?? `raw:${tool}:${rule}`;
-}
-
-/**
- * Line-window bucketing. Tools report the same code construct at
- * slightly-different lines (semgrep on the declaration, registry-grep
- * on the assignment — D091's `:72` vs `:74` shape). 3-line buckets
- * absorb that drift without collapsing genuinely-different findings
- * in the same file.
- *
- * Boundary edge case closed by C1.10: the natural fixed-boundary
- * bucketing alone would miss adjacent findings straddling a
- * multiple-of-3 (a JS-heavy customer frontend surfaced
- * SetupConfigForm.js:43 + :45 → buckets 42 + 45 → no collapse
- * pre-C1.10). The grouping loop now
- * does a neighbor-bucket lookup (naturalBucket ± 3) after the natural
- * miss, restoring D091's intent across boundary-straddling pairs.
- * Effective collapse window: ~3-5 lines depending on alignment.
- */
-function lineWindowFor(line: number): number {
-  return Math.floor(line / 3) * 3;
-}
-
-/**
- * Stable 16-char hex hash of `(canonicalRule | file | lineWindow)`.
- * NUL-separated so distinct tuples can't collide via concatenation
- * tricks. Mirrors `tools/fingerprint.computeFingerprint`'s format
- * (SHA-1 first 8 bytes hex) so dep-vuln and code-finding fingerprints
- * share a downstream type contract.
- */
-function computeCodeFingerprint(canonicalRule: string, file: string, line: number): string {
-  const input = `${canonicalRule}\0${file}\0${lineWindowFor(line)}`;
-  return createHash('sha1').update(input).digest('hex').slice(0, 16);
-}
-
 // ─── Severity helpers ─────────────────────────────────────────────────────
 
 const SEVERITY_RANK: Record<Severity, number> = {

--- a/src/analyzers/tools/fingerprint.ts
+++ b/src/analyzers/tools/fingerprint.ts
@@ -1,30 +1,29 @@
 /**
- * Advisory fingerprints — durable per-finding identity across runs.
+ * Durable per-finding identity across runs — used by both intra-run dedup
+ * (the security aggregator collapses cross-tool overlaps via fingerprint)
+ * and cross-run diff tooling (baselines compare today's fingerprint set
+ * against yesterday's to surface added / removed / persisted findings).
  *
- * The dispatcher's dep-vuln aggregator (src/analyzers/security/gather.ts)
- * stamps every finding with a stable hash of `(package, installedVersion,
- * id)` before scoring + reporting. The same advisory against the same
- * installed version produces the same fingerprint on every run, so
- * consumers (agent-driven upgrade bots, suppressions, CI gates) can diff
- * a current bom against a stored prior to detect:
+ * Two fingerprint families live here:
  *
- *   - new advisories (fingerprint present now, absent before)
- *   - resolved advisories (fingerprint absent now, present before)
- *   - unchanged advisories (fingerprint in both sets)
+ *   1. Dependency-advisory fingerprints — stable hash of
+ *      `(package, installedVersion, id)`. Used by `gatherDepVulns` +
+ *      BoM. Excludes severity / cvssScore / enrichment fields
+ *      (epssScore, kev, reachable, riskScore), producer `tool`, and
+ *      `upgradeAdvice` / `upgradePlan` so re-scoring the same advisory
+ *      against the same install never mints a new identity.
  *
- * Excluded from the hash:
- *   - severity / cvssScore — re-scoring the same advisory against the
- *     same install must not mint a new identity
- *   - enrichment fields (epssScore, kev, reachable, riskScore) — same
- *     reason; these are signals about the advisory, not part of it
- *   - producer `tool` — the same advisory hit by two producers (e.g.
- *     npm-audit + snyk) should collapse to one identity
- *   - `upgradeAdvice` / `upgradePlan` — resolution suggestions change
- *     across releases of the fix tooling; identity must outlive them
+ *   2. Code/secret/config-finding fingerprints — stable hash of
+ *      `(canonicalRule, file, lineWindow)`. The canonical-rule map
+ *      collapses cross-tool overlaps (e.g. semgrep + a per-language
+ *      grep-based pattern both reporting the same TLS-bypass
+ *      construct). The line-window absorbs the small offset between
+ *      tools that report the declaration vs. the assignment.
  *
- * Format: 16-char lowercase hex (first 8 bytes of SHA-1). Short enough
- * to embed inline in reports, long enough to make collisions between
- * non-identical tuples effectively impossible for repo-scale sets.
+ * Both families share format: 16-char lowercase hex (first 8 bytes of
+ * SHA-1). Short enough to embed inline in reports, long enough to make
+ * collisions between non-identical tuples effectively impossible at
+ * repo scale. Producers may render either inline interchangeably.
  */
 
 import { createHash } from 'crypto';
@@ -79,4 +78,67 @@ export function collectFingerprints(findings: ReadonlyArray<DepVulnFinding>): st
     if (f.fingerprint) set.add(f.fingerprint);
   }
   return [...set].sort();
+}
+
+// ─── Code/secret/config-finding fingerprints ─────────────────────────────────
+
+/**
+ * Maps raw `(tool, rule)` pairs to a canonical rule id. Two raw
+ * findings with the same canonical rule (and same file + line window)
+ * fingerprint identically — the aggregator's dedup pipeline collapses
+ * them into a single CodeFinding with `producedBy` listing every
+ * contributing tool. Adding a new collapse is a one-line addition; no
+ * algorithm changes.
+ *
+ * Unmapped pairs fall through to `raw:${tool}:${rule}` — conservative
+ * default. Never accidentally collapses unrelated findings.
+ */
+export const CANONICAL_RULE_MAP: ReadonlyMap<string, string> = new Map<string, string>([
+  // TLS / certificate validation bypass
+  ['tls-bypass-registry:tls-validation-disabled', 'canonical:tls-bypass'],
+  ['semgrep:bypass-tls-verification', 'canonical:tls-bypass'],
+  ['semgrep:nodejsscan.node_tls_reject_unauthorized', 'canonical:tls-bypass'],
+
+  // Private-key file on disk — find + gitleaks may both surface
+  ['find:private-key-file', 'canonical:private-key-on-disk'],
+  ['gitleaks:private-key', 'canonical:private-key-on-disk'],
+]);
+
+/** Resolve a raw `(tool, rule)` pair to its canonical rule id. */
+export function canonicalRuleFor(tool: string, rule: string): string {
+  return CANONICAL_RULE_MAP.get(`${tool}:${rule}`) ?? `raw:${tool}:${rule}`;
+}
+
+/**
+ * Width of the line-number bucket used by code-finding fingerprints.
+ * Tools report the same construct at slightly different lines (one
+ * tool on the declaration, another on the assignment). Bucketing
+ * absorbs that drift without collapsing unrelated findings on
+ * nearby lines.
+ */
+export const CODE_FINGERPRINT_LINE_WINDOW = 3;
+
+/**
+ * Bucket a line number to its canonical line-window value. Findings
+ * sharing the same `(canonicalRule, file, lineWindow)` tuple share a
+ * fingerprint.
+ *
+ * Note on boundary cases: the aggregator additionally probes the two
+ * neighbor buckets (±lineWindow) to catch adjacent findings that
+ * straddle a bucket boundary; that lookup lives in the aggregator
+ * because it owns the merge policy, not here.
+ */
+export function lineWindowFor(line: number): number {
+  return Math.floor(line / CODE_FINGERPRINT_LINE_WINDOW) * CODE_FINGERPRINT_LINE_WINDOW;
+}
+
+/**
+ * Stable 16-char hex hash of `(canonicalRule, file, lineWindow)`.
+ * NUL-separated so distinct tuples can't collide via concatenation
+ * tricks. Same byte format as `computeFingerprint` so dep-vuln and
+ * code-finding fingerprints share a downstream type contract.
+ */
+export function computeCodeFingerprint(canonicalRule: string, file: string, line: number): string {
+  const input = `${canonicalRule}\0${file}\0${lineWindowFor(line)}`;
+  return createHash('sha1').update(input).digest('hex').slice(0, 16);
 }

--- a/src/baseline/finding-identity.ts
+++ b/src/baseline/finding-identity.ts
@@ -1,0 +1,246 @@
+/**
+ * Per-finding identity dispatch. Pure module — no I/O, deterministic
+ * output for deterministic input. Identity is the unit of comparison
+ * across runs: two findings with the same identity are "the same
+ * finding" for baseline / guardrail purposes.
+ *
+ * Two of the five identity schemes already live in `tools/fingerprint`
+ * (dep-vuln + code/secret/config). This module wraps them in the
+ * baseline's discriminated-union shape and adds the two new schemes
+ * (duplication, coverage-gap) so callers reach all five through a
+ * single dispatch.
+ */
+
+import { createHash } from 'crypto';
+import {
+  canonicalRuleFor,
+  computeCodeFingerprint,
+  computeFingerprint,
+  lineWindowFor,
+} from '../analyzers/tools/fingerprint';
+import type {
+  FindingId,
+  HygieneMarker,
+  IdentityInput,
+  IdentitySchemeVersion,
+  MatchPair,
+  MatchReason,
+  MatchResult,
+  TestGapRisk,
+} from './types';
+
+/**
+ * Compute the durable identity for a finding. `version` defaults to
+ * `'v1'` — explicit so future scheme migrations can co-exist without
+ * silent identity drift.
+ *
+ * Identity is the SAME 16-char hex string format across all kinds, so
+ * a baseline can store identities in a single flat set without
+ * tracking which kind they came from. Mixing across kinds is safe:
+ * the input space for each scheme is disjoint (a dep-vuln tuple of
+ * `(package, version, id)` can never collide with a code-finding
+ * tuple of `(canonicalRule, file, lineWindow)` at SHA-1 strength).
+ */
+export function identityFor(
+  input: IdentityInput,
+  version: IdentitySchemeVersion = 'v1',
+): FindingId {
+  if (version !== 'v1') {
+    throw new Error(`Unsupported identity-scheme version: ${version}`);
+  }
+  switch (input.kind) {
+    case 'secret':
+    case 'code':
+    case 'config': {
+      const canonicalRule = canonicalRuleFor(input.tool, input.rule);
+      return computeCodeFingerprint(canonicalRule, input.file, input.line);
+    }
+    case 'dep-vuln':
+      return computeFingerprint({
+        package: input.package,
+        installedVersion: input.installedVersion,
+        id: input.id,
+      });
+    case 'duplication':
+      return computeDuplicationIdentity(input.fileA, input.fileB, input.tokens);
+    case 'coverage-gap':
+      return computeCoverageGapIdentity(input.file, input.symbol, input.lineRange);
+    case 'test-gap':
+      return computeTestGapIdentity(input.file, input.risk);
+    case 'hygiene':
+      return computeHygieneIdentity(input.file, input.line, input.marker);
+    case 'license':
+      return computeLicenseIdentity(input.package, input.version, input.licenseType);
+  }
+}
+
+/**
+ * Symmetric-by-construction identity for a duplicate-block pair. File
+ * names are sorted lexicographically before hashing so a clone reported
+ * as `(a, b)` in one run and `(b, a)` in another hashes identically.
+ *
+ * `tokens` is included so refactoring one side of the pair (which
+ * shrinks the block's token count) reports a fresh identity — that's
+ * the right signal for a guardrail: "the duplicate moved or shrank,
+ * which deserves a look."
+ */
+function computeDuplicationIdentity(fileA: string, fileB: string, tokens: number): FindingId {
+  const [first, second] = [fileA, fileB].sort();
+  const input = `duplication\0v1\0${first}\0${second}\0${tokens}`;
+  return createHash('sha1').update(input).digest('hex').slice(0, 16);
+}
+
+/**
+ * Identity for an uncovered-code gap. Prefers `(file, symbol)` when
+ * the gap-detection pipeline knew the symbol name — that's stable
+ * across refactors that move code within a file. Falls back to
+ * `(file, lineRange)` when only a line range is available.
+ *
+ * Producers MUST supply at least one of `symbol` or `lineRange`;
+ * supplying neither throws because the resulting identity would be
+ * `(file)` only, which collapses every uncovered region in a file
+ * into a single entry.
+ */
+function computeCoverageGapIdentity(
+  file: string,
+  symbol: string | undefined,
+  lineRange: readonly [number, number] | undefined,
+): FindingId {
+  if (!symbol && !lineRange) {
+    throw new Error(
+      `coverage-gap identity requires either a symbol or a line range (file: ${file})`,
+    );
+  }
+  const discriminator = symbol ? `sym:${symbol}` : `range:${lineRange![0]}-${lineRange![1]}`;
+  const input = `coverage-gap\0v1\0${file}\0${discriminator}`;
+  return createHash('sha1').update(input).digest('hex').slice(0, 16);
+}
+
+/**
+ * Identity for a test-gap source file. Risk tier is part of identity:
+ * a file moving between tiers (CRITICAL → HIGH, or vice versa) is
+ * semantically a fresh finding — the prior tier's identity disappears,
+ * the new tier's identity arrives. Guardrails will fire on the
+ * net-new tier, which is the correct signal for regressions.
+ */
+function computeTestGapIdentity(file: string, risk: TestGapRisk): FindingId {
+  const input = `test-gap\0v1\0${file}\0${risk}`;
+  return createHash('sha1').update(input).digest('hex').slice(0, 16);
+}
+
+/**
+ * Identity for a single hygiene-marker occurrence (TODO / FIXME /
+ * HACK / console-log / any-type). Line number is bucketed via the
+ * shared line-window so a reformat that shifts a TODO by one or two
+ * lines doesn't churn identity. Marker text is NOT included — the
+ * occurrence "is a TODO" regardless of what the comment body says.
+ */
+function computeHygieneIdentity(file: string, line: number, marker: HygieneMarker): FindingId {
+  const input = `hygiene\0v1\0${marker}\0${file}\0${lineWindowFor(line)}`;
+  return createHash('sha1').update(input).digest('hex').slice(0, 16);
+}
+
+/**
+ * Identity for a package license attribution. Includes the license
+ * type so a re-licensing event on the same `(package, version)` pin
+ * registers as a fresh finding — compliance teams want to be
+ * notified when a transitive dep switches from MIT to GPL even
+ * without a version bump.
+ */
+function computeLicenseIdentity(
+  packageName: string,
+  version: string,
+  licenseType: string,
+): FindingId {
+  const input = `license\0v1\0${packageName}\0${version}\0${licenseType}`;
+  return createHash('sha1').update(input).digest('hex').slice(0, 16);
+}
+
+/**
+ * Multiset-aware identity diff — the lowest layer of baseline
+ * comparison. Pairs identities by occurrence count, not by presence:
+ * an identity appearing twice in prior and once in current produces
+ * one persisted pair and one removed pair (set-diff would have
+ * incorrectly collapsed those to a single persisted).
+ *
+ * For each shared identity:
+ *   - the first `min(priorCount, currentCount)` occurrences pair as
+ *     `persisted` with confidence 1.0 (exact byte equality).
+ *   - excess occurrences in `current` produce `added` pairs.
+ *   - excess occurrences in `prior` produce `removed` pairs.
+ *
+ * Output ordering: pairs grouped by identity, then by status. The
+ * flat-array views (`persisted`, `added`, `removed`) preserve
+ * occurrence multiplicity — duplicate ids appear N times when N
+ * occurrences were classified that way. Callers that want a
+ * deduplicated view should run them through a Set themselves.
+ */
+export function matchAcrossRuns(
+  prior: Iterable<FindingId>,
+  current: Iterable<FindingId>,
+): MatchResult {
+  const priorCounts = countMultiset(prior);
+  const currentCounts = countMultiset(current);
+  const allIds = new Set<FindingId>([...priorCounts.keys(), ...currentCounts.keys()]);
+
+  const pairs: MatchPair[] = [];
+  const persisted: FindingId[] = [];
+  const added: FindingId[] = [];
+  const removed: FindingId[] = [];
+  const exactReason: MatchReason = {
+    code: 'exact-id',
+    detail: 'identity fingerprint matched byte-for-byte across runs',
+  };
+  const newReason: MatchReason = {
+    code: 'no-prior-match',
+    detail: 'identity fingerprint not present in the baseline',
+  };
+  const goneReason: MatchReason = {
+    code: 'no-current-match',
+    detail: 'identity fingerprint not present in the current scan',
+  };
+
+  for (const id of allIds) {
+    const p = priorCounts.get(id) ?? 0;
+    const c = currentCounts.get(id) ?? 0;
+    const matched = Math.min(p, c);
+    for (let i = 0; i < matched; i++) {
+      pairs.push({
+        priorId: id,
+        currentId: id,
+        status: 'persisted',
+        confidence: 1.0,
+        reasons: [exactReason],
+      });
+      persisted.push(id);
+    }
+    for (let i = 0; i < c - matched; i++) {
+      pairs.push({
+        currentId: id,
+        status: 'added',
+        confidence: 1.0,
+        reasons: [newReason],
+      });
+      added.push(id);
+    }
+    for (let i = 0; i < p - matched; i++) {
+      pairs.push({
+        priorId: id,
+        status: 'removed',
+        confidence: 1.0,
+        reasons: [goneReason],
+      });
+      removed.push(id);
+    }
+  }
+
+  return { pairs, persisted, added, removed, gitAware: false };
+}
+
+function countMultiset(items: Iterable<FindingId>): Map<FindingId, number> {
+  const counts = new Map<FindingId, number>();
+  for (const id of items) {
+    counts.set(id, (counts.get(id) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/src/baseline/git-aware-match.ts
+++ b/src/baseline/git-aware-match.ts
@@ -1,0 +1,404 @@
+/**
+ * Git-aware match — pairs prior-run identities with current-run
+ * identities through the lens of `git diff baseSha headSha`.
+ *
+ * The line-bucket identity scheme used by code/secret/config/hygiene
+ * findings tolerates ±2 lines of vertical drift. Anything past that
+ * appears to a naive set-diff as "removed + added" even though
+ * semantically the finding hasn't changed — it just moved with the
+ * surrounding code. This module closes the gap.
+ *
+ * Algorithm:
+ *
+ *   1. Exact identity match — every finding present in both runs
+ *      under the same fingerprint is `persisted` immediately.
+ *
+ *   2. For each finding in the `removed` set that carries a file +
+ *      line locator: ask git to map its base-line through the diff
+ *      to the corresponding head-line. If the `added` set contains
+ *      a finding at the same `(file, rule, mappedLine)`, the two
+ *      represent the same underlying issue moved by the diff —
+ *      move both to `persisted`.
+ *
+ *   3. Whatever remains in `added` and `removed` is genuinely new
+ *      or genuinely gone.
+ *
+ * Fallback: when git history is unavailable (no `.git`, baseSha not
+ * reachable, file deleted, etc.) the module degrades to plain
+ * set-diff matching — the same behavior `matchAcrossRuns` produces
+ * on its own. Callers in shallow-clone CI or non-git workflows get
+ * a working (if less precise) result.
+ *
+ * Known limitations (Sprint 0 v1):
+ *   - File renames are not auto-tracked. A renamed file looks like
+ *     "removed prior + added current"; future iterations will use
+ *     `git log --follow` or `git diff -M` rename detection to close
+ *     this gap.
+ *   - Cross-file refactors (function extracted to a new file) are
+ *     reported as removed-and-added.
+ *   - When the line-bucket mapping fails on context edits (tool
+ *     reports finding at a slightly different line in head than the
+ *     diff predicts), we fall back to "unmatched." Sprint 0.x adds
+ *     a content-hash fallback for this class.
+ */
+
+import { execFileSync } from 'child_process';
+import { matchAcrossRuns } from './finding-identity';
+import type { FindingId, MatchPair, MatchReason, MatchResult } from './types';
+
+/** Confidence assigned to a git-mapped pair when the candidate sits
+ *  on exactly the mapped line. Slightly below 1.0 so consumers can
+ *  tell apart "exact identity match" (1.0) from "different identity
+ *  but same finding through diff" (0.95). */
+const CONFIDENCE_GIT_EXACT = 0.95;
+/** Confidence when the candidate sits within ±2 lines of the mapped
+ *  line — scanners often shift the reported line slightly across
+ *  re-runs even when nothing semantic changed. */
+const CONFIDENCE_GIT_FUZZ = 0.88;
+/** Range of the line-fuzz lookup window. */
+const LINE_FUZZ_RANGE = 2;
+
+/**
+ * Per-finding identity plus the locator info needed to query git.
+ * Producers convert `BaselineEntry` (or any equivalent stored form)
+ * into this shape before calling `gitAwareMatch`.
+ *
+ * `file`, `line`, and `rule` are optional only because some finding
+ * kinds (dep-vuln, license) have no file-line locator. Those kinds
+ * are handled entirely by step-1 exact-identity match and skipped
+ * by the step-2 git fallback.
+ */
+export interface LocatedIdentity {
+  readonly id: FindingId;
+  readonly file?: string;
+  readonly line?: number;
+  readonly rule?: string;
+}
+
+export interface GitAwareMatchOptions {
+  /** Working directory of the repository under check. */
+  readonly cwd: string;
+  /** Commit SHA the baseline was created against. The matcher
+   *  requires this SHA to be reachable in `cwd`'s git history. */
+  readonly baseSha: string;
+  /** Commit SHA (or revision spec) to compare against. Defaults to
+   *  `'HEAD'` — the current working-tree's last commit. */
+  readonly headSha?: string;
+}
+
+/**
+ * Map a 1-based line number in `baseSha`'s version of `file` to its
+ * corresponding 1-based line in `headSha`. Returns `null` when the
+ * line was deleted, the file was removed, or git couldn't produce a
+ * diff for any reason.
+ *
+ * Implementation runs `git diff --unified=0 baseSha headSha -- file`
+ * and walks the resulting `@@ -A,B +C,D @@` hunks. Pure-ish: the
+ * only impurity is the git subprocess; the parser is deterministic
+ * over its input.
+ */
+export function mapLineThroughDiff(opts: {
+  readonly cwd: string;
+  readonly baseSha: string;
+  readonly headSha: string;
+  /** Path at `baseSha`. May differ from `newFile` if the caller
+   *  resolved a rename. Pass-through compat: callers that don't
+   *  track renames can use the same value for both. */
+  readonly oldFile?: string;
+  /** Path at `headSha`. */
+  readonly newFile?: string;
+  /** Legacy single-file form. When supplied, both `oldFile` and
+   *  `newFile` default to this value. Kept for back-compat with
+   *  call-sites that pre-date rename support. */
+  readonly file?: string;
+  readonly baseLine: number;
+}): number | null {
+  const oldFile = opts.oldFile ?? opts.file;
+  const newFile = opts.newFile ?? opts.file ?? oldFile;
+  if (!oldFile || !newFile) {
+    throw new Error('mapLineThroughDiff requires `file` or both `oldFile` + `newFile`');
+  }
+  let diff: string;
+  try {
+    diff = execFileSync(
+      'git',
+      [
+        'diff',
+        '--unified=0',
+        '--no-color',
+        '--find-renames',
+        opts.baseSha,
+        opts.headSha,
+        '--',
+        oldFile,
+        ...(newFile !== oldFile ? [newFile] : []),
+      ],
+      { cwd: opts.cwd, encoding: 'utf8' },
+    );
+  } catch {
+    // File missing in one revision, git not available, sha unreachable — any
+    // of these defeats the mapping. Caller treats null as "unmatched."
+    return null;
+  }
+  if (!diff.trim()) {
+    // Identical between revisions: line numbers are 1:1.
+    return opts.baseLine;
+  }
+  return walkHunks(diff, opts.baseLine);
+}
+
+/**
+ * Parse `@@ -oldStart,oldCount +newStart,newCount @@` hunk headers
+ * and resolve `baseLine` to its post-diff line number. Pure
+ * function over the diff text.
+ *
+ * A line falls into one of three regions:
+ *   - Before any hunk that affects it: shifted only by the
+ *     accumulated net delta of earlier hunks.
+ *   - Inside a hunk's deletion span: removed by this diff,
+ *     returns null.
+ *   - After all hunks: shifted by the full accumulated net delta.
+ */
+function walkHunks(diff: string, baseLine: number): number | null {
+  const hunkRe = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/gm;
+  let match: RegExpExecArray | null;
+  let cumulativeShift = 0;
+  while ((match = hunkRe.exec(diff)) !== null) {
+    const oldStart = parseInt(match[1], 10);
+    const oldCount = match[2] !== undefined ? parseInt(match[2], 10) : 1;
+    const newCount = match[4] !== undefined ? parseInt(match[4], 10) : 1;
+    const oldEnd = oldStart + oldCount - 1;
+
+    if (baseLine < oldStart) {
+      // Line lies before this hunk — earlier shifts apply, this hunk doesn't.
+      return baseLine + cumulativeShift;
+    }
+    if (oldCount > 0 && baseLine >= oldStart && baseLine <= oldEnd) {
+      // Line was deleted by this hunk.
+      return null;
+    }
+    cumulativeShift += newCount - oldCount;
+  }
+  return baseLine + cumulativeShift;
+}
+
+/**
+ * Composite matcher. Two passes:
+ *
+ *   1. Location-aware pairing (when git is available): for each
+ *      line-anchored prior finding, map its base line to the
+ *      corresponding head line via `git diff`, then look up a
+ *      current finding at `(effectivePath, rule, mappedLine)`. The
+ *      effective path is the prior path translated through the
+ *      rename map; status is `'relocated'` when the path changed,
+ *      `'persisted'` when it didn't.
+ *      Lookups try the exact mapped line first, then a ±2 fuzz
+ *      window. Confidence is reported per match.
+ *
+ *   2. Multiset exact-identity diff over whatever remains. Catches:
+ *        - findings without a file-line locator (dep-vuln, license,
+ *          symbol-based coverage-gap, duplication)
+ *        - line-anchored findings whose locations didn't survive
+ *          the diff but whose fingerprints happen to coincide
+ *          across runs
+ *        - everything when git history is unreachable (`baseSha`
+ *          missing) and pass 1 was skipped
+ *
+ * Why location-first: the line-bucket fingerprint scheme can produce
+ * spurious "persisted" matches when two findings of the same rule
+ * in the same file naturally shift into each other's buckets. Pass 1
+ * pairs them by real diff position, which is what a developer
+ * intuitively expects.
+ */
+export function gitAwareMatch(
+  prior: ReadonlyArray<LocatedIdentity>,
+  current: ReadonlyArray<LocatedIdentity>,
+  opts: GitAwareMatchOptions,
+): MatchResult {
+  const headSha = opts.headSha ?? 'HEAD';
+  const reachability = checkShaReachable(opts.cwd, opts.baseSha);
+
+  const pairs: MatchPair[] = [];
+  const priorMatched = new Set<LocatedIdentity>();
+  const currentMatched = new Set<LocatedIdentity>();
+
+  if (reachability.ok) {
+    const renames = readRenameMap(opts.cwd, opts.baseSha, headSha);
+
+    // Index current findings by (file, rule, line). One key holds at
+    // most one entry — the multiset diff in pass 2 picks up any
+    // collisions left after location pairing.
+    const currentByLocation = new Map<string, LocatedIdentity[]>();
+    for (const c of current) {
+      if (!c.file || c.line === undefined || !c.rule) continue;
+      const key = locationKey(c.file, c.rule, c.line);
+      const bucket = currentByLocation.get(key);
+      if (bucket) bucket.push(c);
+      else currentByLocation.set(key, [c]);
+    }
+
+    const takeAt = (key: string): LocatedIdentity | undefined => {
+      const bucket = currentByLocation.get(key);
+      if (!bucket || bucket.length === 0) return undefined;
+      const head = bucket.shift();
+      if (bucket.length === 0) currentByLocation.delete(key);
+      return head;
+    };
+
+    for (const p of prior) {
+      if (!p.file || p.line === undefined || !p.rule) continue;
+      const effectivePath = renames.get(p.file) ?? p.file;
+      const pathChanged = effectivePath !== p.file;
+      const mappedLine = mapLineThroughDiff({
+        cwd: opts.cwd,
+        baseSha: opts.baseSha,
+        headSha,
+        oldFile: p.file,
+        newFile: effectivePath,
+        baseLine: p.line,
+      });
+      if (mappedLine === null) continue;
+
+      // Exact mapped line first.
+      let candidate = takeAt(locationKey(effectivePath, p.rule, mappedLine));
+      let confidence = CONFIDENCE_GIT_EXACT;
+      let fuzzDelta = 0;
+      // Line-fuzz fallback: scanners drift the reported line by 1-2
+      // lines on re-runs. Walk outward from the mapped line.
+      if (!candidate) {
+        for (let delta = 1; delta <= LINE_FUZZ_RANGE; delta++) {
+          for (const offset of [-delta, delta]) {
+            const c2 = takeAt(locationKey(effectivePath, p.rule, mappedLine + offset));
+            if (c2) {
+              candidate = c2;
+              confidence = CONFIDENCE_GIT_FUZZ;
+              fuzzDelta = offset;
+              break;
+            }
+          }
+          if (candidate) break;
+        }
+      }
+      if (!candidate) continue;
+
+      priorMatched.add(p);
+      currentMatched.add(candidate);
+      const reasons: MatchReason[] = [
+        {
+          code: 'git-line-' + (fuzzDelta === 0 ? 'exact' : 'fuzz'),
+          detail:
+            fuzzDelta === 0
+              ? `git diff mapped ${p.file}:${p.line} to ${effectivePath}:${mappedLine}`
+              : `git diff mapped ${p.file}:${p.line} to ${effectivePath}:${mappedLine}; ` +
+                `current finding sits ${fuzzDelta > 0 ? '+' : ''}${fuzzDelta} line(s) off (within fuzz window)`,
+        },
+      ];
+      if (pathChanged) {
+        reasons.unshift({
+          code: 'git-rename',
+          detail: `file renamed: ${p.file} → ${effectivePath}`,
+        });
+      }
+      pairs.push({
+        priorId: p.id,
+        currentId: candidate.id,
+        status: pathChanged ? 'relocated' : 'persisted',
+        confidence,
+        reasons,
+      });
+    }
+  }
+
+  // Pass 2 — multiset exact-id diff over leftovers.
+  const priorRemaining: FindingId[] = [];
+  const currentRemaining: FindingId[] = [];
+  for (const p of prior) if (!priorMatched.has(p)) priorRemaining.push(p.id);
+  for (const c of current) if (!currentMatched.has(c)) currentRemaining.push(c.id);
+  const exactRemaining = matchAcrossRuns(priorRemaining, currentRemaining);
+  for (const pair of exactRemaining.pairs) pairs.push(pair);
+
+  // Flatten the legacy views from the pair list.
+  const persisted: FindingId[] = [];
+  const added: FindingId[] = [];
+  const removed: FindingId[] = [];
+  for (const pair of pairs) {
+    switch (pair.status) {
+      case 'persisted':
+      case 'relocated':
+        if (pair.priorId) persisted.push(pair.priorId);
+        if (pair.currentId && pair.currentId !== pair.priorId) persisted.push(pair.currentId);
+        break;
+      case 'added':
+        if (pair.currentId) added.push(pair.currentId);
+        break;
+      case 'removed':
+        if (pair.priorId) removed.push(pair.priorId);
+        break;
+    }
+  }
+
+  return {
+    pairs,
+    persisted,
+    added,
+    removed,
+    gitAware: reachability.ok,
+    degradedReason: reachability.ok ? undefined : reachability.reason,
+  };
+}
+
+function locationKey(file: string, rule: string, line: number): string {
+  return `${file}\0${rule}\0${line}`;
+}
+
+/**
+ * Build a Map<oldPath, newPath> for files renamed between baseSha
+ * and headSha. Uses git's rename detection (`--find-renames`,
+ * default similarity threshold). Files that weren't renamed don't
+ * appear in the map; callers fall back to using the prior path as
+ * the effective path.
+ */
+function readRenameMap(cwd: string, baseSha: string, headSha: string): Map<string, string> {
+  const renames = new Map<string, string>();
+  let output: string;
+  try {
+    output = execFileSync('git', ['diff', '--name-status', '--find-renames', baseSha, headSha], {
+      cwd,
+      encoding: 'utf8',
+    });
+  } catch {
+    return renames;
+  }
+  for (const line of output.split('\n')) {
+    // Rename lines look like:  R100\told/path\tnew/path
+    // M / A / D / C lines have only one path column and are ignored here.
+    if (!line.startsWith('R')) continue;
+    const parts = line.split('\t');
+    if (parts.length < 3) continue;
+    renames.set(parts[1], parts[2]);
+  }
+  return renames;
+}
+
+/**
+ * Check whether the SHA exists in the repo and return a structured
+ * verdict. Distinguishes "not a git repo," "git not installed,"
+ * "valid repo but commit unreachable" — every non-ok case produces
+ * a human-readable reason for `MatchResult.degradedReason`.
+ */
+function checkShaReachable(cwd: string, sha: string): { ok: true } | { ok: false; reason: string } {
+  try {
+    execFileSync('git', ['rev-parse', '--git-dir'], { cwd, stdio: 'ignore' });
+  } catch {
+    return { ok: false, reason: 'cwd is not a git repository (or git is not installed)' };
+  }
+  try {
+    execFileSync('git', ['cat-file', '-e', sha], { cwd, stdio: 'ignore' });
+    return { ok: true };
+  } catch {
+    return {
+      ok: false,
+      reason: `baseline commit ${sha} is not reachable in this checkout (shallow clone or force-push?)`,
+    };
+  }
+}

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -1,0 +1,321 @@
+/**
+ * Baseline types — per-finding fingerprints carried in
+ * `.dxkit-baseline.json` so the guardrail check can compare today's
+ * scan against the recorded baseline.
+ *
+ * # Identity model
+ *
+ * dxkit does not treat a single hash as "the finding's stable
+ * identity." Each finding has up to several fingerprint axes,
+ * differentiated by what they capture:
+ *
+ *   - **Location fingerprint** — `(canonicalRule, file, lineWindow)`
+ *     for code/secret/config/hygiene findings. Locates a finding
+ *     in the source tree with ±2 line drift tolerance via bucket
+ *     windowing. Stable across small reformat / whitespace edits;
+ *     drifts on bigger shifts (closed by git-aware match).
+ *   - **Domain fingerprint** — `(package, version, advisoryId)` for
+ *     dep-vulns; `(package, version, licenseType)` for licenses;
+ *     normalized block hash for jscpd. Captures *what the finding
+ *     is about* independent of source position. Drift-immune.
+ *   - **Semantic fingerprint** — `(file, symbol)` for coverage gaps
+ *     when a symbol is known. Survives any vertical drift within
+ *     the symbol body.
+ *   - **Content fingerprint** — Sprint 0.x. Normalized snippet
+ *     hash; fallback when git history is unreachable.
+ *
+ * The hash format is identical across axes — 16-char lowercase hex
+ * (SHA-1[0:16]). Callers don't need to know which axis a hash came
+ * from to use it for set-diff, but the matcher uses the axis
+ * structure to layer different match strategies (domain first,
+ * then git-aware location, then content fallback, then exact).
+ *
+ * The identity space mirrors the analyzer shapes that produce
+ * findings. Each `IdentityInput` discriminant maps 1:1 to an existing
+ * gather pipeline:
+ *
+ *   - `secret` / `code` / `config` — security analyzer's
+ *     `SecurityFinding` (gitleaks, semgrep, TLS-bypass registry,
+ *     private-key files, env-in-git).
+ *   - `dep-vuln` — security analyzer's `DepVulnFinding` (osv-scanner,
+ *     npm-audit, pip-audit, cargo-audit, etc.).
+ *   - `duplication` — quality analyzer's `CloneGroup` (jscpd).
+ *   - `coverage-gap` — coverage-gap report entries (file + symbol
+ *     when available, fallback to file + line range).
+ *   - `test-gap` — non-test source files flagged by the test-gaps
+ *     analyzer.
+ *   - `hygiene` — TODO / FIXME / HACK / console-log / any-type
+ *     occurrences (per-occurrence identity).
+ *   - `license` — package license attributions.
+ */
+
+/**
+ * 16-char lowercase hex fingerprint. Same byte format as the
+ * `fingerprint` field stamped on `DepVulnFinding` and `CodeFinding`,
+ * so a baseline fingerprint compares directly to a fresh finding's
+ * stamped value without re-hashing.
+ *
+ * Whether this represents a location, domain, semantic, or content
+ * fingerprint depends on the finding kind — see the file header for
+ * the axis model. For line-anchored kinds this is the location
+ * fingerprint; for content-based kinds it IS the domain fingerprint.
+ */
+export type FindingId = string;
+
+/**
+ * Identity-scheme version. Bumping this minor field will be required
+ * if the hashing inputs change in a way that would invalidate stored
+ * baselines. v1 is the only scheme today.
+ */
+export type IdentitySchemeVersion = 'v1';
+
+/**
+ * Discriminated union of every finding kind that participates in
+ * identity. Producers wrap their per-tool finding shape into one of
+ * these before calling `identityFor`.
+ *
+ * Adding a new finding kind to the dispatch is a three-line change:
+ *   1. Add the per-kind interface below.
+ *   2. Append the interface name to this union.
+ *   3. Add the corresponding case branch in `identityFor`.
+ *
+ * The hash format is SHA-1[0:16] across every kind — callers store
+ * identities in one flat set without tracking provenance.
+ */
+export type IdentityInput =
+  | SecretIdentityInput
+  | CodeIdentityInput
+  | ConfigIdentityInput
+  | DepVulnIdentityInput
+  | DuplicationIdentityInput
+  | CoverageGapIdentityInput
+  | TestGapIdentityInput
+  | HygieneOffenderIdentityInput
+  | LicenseIdentityInput;
+
+/** gitleaks + private-key files + similar secret detectors. */
+export interface SecretIdentityInput {
+  readonly kind: 'secret';
+  /** Producer tool name as reported by the analyzer (e.g. 'gitleaks'). */
+  readonly tool: string;
+  /** Producer-specific rule id. The canonical-rule map collapses
+   *  cross-tool overlaps where they exist. */
+  readonly rule: string;
+  /** Project-relative file path. */
+  readonly file: string;
+  /** 1-based line number. Bucketed to absorb small drift between
+   *  tool versions; see `CODE_FINGERPRINT_LINE_WINDOW`. */
+  readonly line: number;
+}
+
+/** semgrep + TLS-bypass registry + per-language code-pattern providers. */
+export interface CodeIdentityInput {
+  readonly kind: 'code';
+  readonly tool: string;
+  readonly rule: string;
+  readonly file: string;
+  readonly line: number;
+}
+
+/** Configuration-class findings (e.g. .env tracked in git). */
+export interface ConfigIdentityInput {
+  readonly kind: 'config';
+  readonly tool: string;
+  readonly rule: string;
+  readonly file: string;
+  /** Line 0 acceptable for whole-file findings. */
+  readonly line: number;
+}
+
+/** Dependency-advisory findings (osv-scanner / npm-audit / pip-audit / ...). */
+export interface DepVulnIdentityInput {
+  readonly kind: 'dep-vuln';
+  /** Package name as reported by the producer. */
+  readonly package: string;
+  /** Installed version string, when known. Absent for findings produced
+   *  without an accessible lockfile. */
+  readonly installedVersion: string | undefined;
+  /** Advisory id (GHSA / CVE / RUSTSEC / etc.). Producer-canonical. */
+  readonly id: string;
+}
+
+/** jscpd-style duplicate-block findings. */
+export interface DuplicationIdentityInput {
+  readonly kind: 'duplication';
+  /** Files on each side of the duplicate pair. Order is normalized
+   *  inside `identityFor` so swapped sides hash identically. */
+  readonly fileA: string;
+  readonly fileB: string;
+  /** Token count of the duplicated block. Stable across pure file
+   *  movement but changes when the block itself is refactored. */
+  readonly tokens: number;
+}
+
+/**
+ * Coverage-gap findings — uncovered code surfaces. Identity prefers
+ * `(file, symbol)` when the gap-detection pipeline has a symbol name
+ * available (graphify-symbols), falling back to `(file, lineRange)`
+ * otherwise.
+ */
+export interface CoverageGapIdentityInput {
+  readonly kind: 'coverage-gap';
+  readonly file: string;
+  /** Function / method / class symbol. Present when the gap is
+   *  attributable to a named symbol; absent for line-range-only
+   *  attribution. */
+  readonly symbol?: string;
+  /** Inclusive `[startLine, endLine]`. Required when `symbol` is
+   *  absent. */
+  readonly lineRange?: readonly [number, number];
+}
+
+/**
+ * Test-gap source file — a non-test file flagged by the test-gaps
+ * analyzer as lacking a matching test. Identity carries the risk
+ * tier: a file moving from MEDIUM gap to CRITICAL gap deserves to
+ * register as a fresh added finding (the previous lower-tier
+ * identity disappears, a new higher-tier identity arrives), which is
+ * the right guardrail signal for "this file's testing situation
+ * regressed."
+ */
+export type TestGapRisk = 'critical' | 'high' | 'medium' | 'low';
+
+export interface TestGapIdentityInput {
+  readonly kind: 'test-gap';
+  readonly file: string;
+  readonly risk: TestGapRisk;
+}
+
+/**
+ * Hygiene marker — one TODO / FIXME / HACK / console-log / any-type
+ * occurrence. Identity is per-occurrence so guardrails can fire on
+ * "a new TODO was added" rather than just "the TODO count went up."
+ * Line numbers are bucketed via the same line-window mechanism used
+ * by code-finding fingerprints, so small drift from formatter runs
+ * or unrelated edits doesn't churn identity.
+ */
+export type HygieneMarker = 'todo' | 'fixme' | 'hack' | 'console-log' | 'any-type';
+
+export interface HygieneOffenderIdentityInput {
+  readonly kind: 'hygiene';
+  readonly file: string;
+  readonly line: number;
+  readonly marker: HygieneMarker;
+}
+
+/**
+ * Package license attribution. Identity includes the license type so
+ * a license change on the same `(package, version)` pin registers
+ * as a fresh finding — compliance teams want to know if a dependency
+ * re-licenses under a different (perhaps more restrictive) license
+ * even when no version bump happened.
+ */
+export interface LicenseIdentityInput {
+  readonly kind: 'license';
+  readonly package: string;
+  readonly version: string;
+  /** Canonical SPDX identifier (`'MIT'`, `'Apache-2.0'`, `'GPL-3.0'`,
+   *  `'UNKNOWN'`). Producer is the existing license-aggregation
+   *  pipeline; identity is byte-stable as long as the producer
+   *  reports the SPDX id consistently. */
+  readonly licenseType: string;
+}
+
+/**
+ * Per-finding entry stored in a baseline. Carries identity plus the
+ * minimum metadata needed for cross-run drift-tolerant matching —
+ * never raw payloads (no titles, no secret content, no source
+ * excerpts). Sufficient for set-diff and for future drift heuristics
+ * (e.g. matching `(rule, file)` pairs across line shifts).
+ */
+export type BaselineEntry =
+  | {
+      id: FindingId;
+      kind: 'secret' | 'code' | 'config';
+      tool: string;
+      rule: string;
+      file: string;
+      line: number;
+    }
+  | {
+      id: FindingId;
+      kind: 'dep-vuln';
+      package: string;
+      installedVersion?: string;
+      advisoryId: string;
+    }
+  | { id: FindingId; kind: 'duplication'; fileA: string; fileB: string; tokens: number }
+  | {
+      id: FindingId;
+      kind: 'coverage-gap';
+      file: string;
+      symbol?: string;
+      lineRange?: readonly [number, number];
+    }
+  | { id: FindingId; kind: 'test-gap'; file: string; risk: TestGapRisk }
+  | { id: FindingId; kind: 'hygiene'; file: string; line: number; marker: HygieneMarker }
+  | { id: FindingId; kind: 'license'; package: string; version: string; licenseType: string };
+
+/**
+ * One pairing decision from the matcher. Carries enough context for
+ * the guardrail to render a clear explanation ("this finding was
+ * relocated from line 42 to line 57 via git diff, 0.95 confidence,
+ * status: relocated") rather than a bare added/removed/persisted
+ * label. Reasons are short codes plus human prose; consumers display
+ * the prose and use the codes for filtering / policy decisions.
+ *
+ * `priorId` and `currentId` are both optional because:
+ *   - `added`   → only `currentId` is present.
+ *   - `removed` → only `priorId` is present.
+ *   - `persisted` / `relocated` → both, and they may differ when a
+ *      location fingerprint shifted across the line-window boundary
+ *      (each "side" has its own hash even though they describe the
+ *      same finding).
+ */
+export type MatchStatus = 'persisted' | 'relocated' | 'added' | 'removed';
+
+export interface MatchReason {
+  /** Short code: 'exact-id', 'git-line-exact', 'git-line-fuzz',
+   *  'git-rename', 'multiset-occurrence'. */
+  readonly code: string;
+  /** Human-readable explanation suitable for end-user rendering. */
+  readonly detail: string;
+}
+
+export interface MatchPair {
+  readonly priorId?: FindingId;
+  readonly currentId?: FindingId;
+  readonly status: MatchStatus;
+  /** Confidence in [0, 1]. 1.0 = exact identity; <1.0 = paired via
+   *  a fallback layer (git relocation, line-fuzz, rename). */
+  readonly confidence: number;
+  readonly reasons: ReadonlyArray<MatchReason>;
+}
+
+/**
+ * Composite result of comparing two runs.
+ *
+ * The structured `pairs` field carries one entry per matched +
+ * unmatched finding occurrence (multiset-aware: an identity that
+ * occurs twice in prior and once in current produces three pairs —
+ * one persisted, one removed).
+ *
+ * `persisted` / `added` / `removed` are flat-array views over the
+ * pair set, retained for callers that want simple set-diff output
+ * without the reason metadata. Identity values appear once per
+ * occurrence (multiset, not set) — duplicate identities are NOT
+ * collapsed.
+ *
+ * `gitAware` reports whether the git-aware location pass actually
+ * ran. `degradedReason` carries a human-readable note when the
+ * pass was skipped (no git, base SHA unreachable, etc.) so the
+ * guardrail CLI can tell the user what mode it ran in.
+ */
+export interface MatchResult {
+  readonly pairs: ReadonlyArray<MatchPair>;
+  readonly persisted: ReadonlyArray<FindingId>;
+  readonly added: ReadonlyArray<FindingId>;
+  readonly removed: ReadonlyArray<FindingId>;
+  readonly gitAware: boolean;
+  readonly degradedReason?: string;
+}

--- a/test/baseline/finding-identity.test.ts
+++ b/test/baseline/finding-identity.test.ts
@@ -504,9 +504,9 @@ describe('matchAcrossRuns — set diff over identity', () => {
     const a = ['aaaa1111bbbb2222', 'cccc3333dddd4444'];
     const b = ['cccc3333dddd4444', 'eeee5555ffff6666'];
     const result = matchAcrossRuns(a, b);
-    expect(result.persisted.sort()).toEqual(['cccc3333dddd4444']);
-    expect(result.added.sort()).toEqual(['eeee5555ffff6666']);
-    expect(result.removed.sort()).toEqual(['aaaa1111bbbb2222']);
+    expect([...result.persisted].sort()).toEqual(['cccc3333dddd4444']);
+    expect([...result.added].sort()).toEqual(['eeee5555ffff6666']);
+    expect([...result.removed].sort()).toEqual(['aaaa1111bbbb2222']);
   });
 
   it('preserves occurrence count via multiset semantics', () => {

--- a/test/baseline/finding-identity.test.ts
+++ b/test/baseline/finding-identity.test.ts
@@ -1,0 +1,621 @@
+import { describe, it, expect } from 'vitest';
+import { identityFor, matchAcrossRuns } from '../../src/baseline/finding-identity';
+import type { IdentityInput } from '../../src/baseline/types';
+
+/**
+ * Each fixture describes a plausible inter-run scenario for one
+ * finding-kind: a prior-run identity input and a current-run
+ * identity input, plus the matcher outcome that should fall out.
+ *
+ *   `persisted`: identity unchanged between runs — the finding is
+ *     still present, regardless of cosmetic drift the scheme is
+ *     designed to absorb.
+ *   `changed`: identity differs between runs — semantically the
+ *     finding is "new + the old one disappeared." `matchAcrossRuns`
+ *     reports it as one `added` plus one `removed`.
+ *
+ * Every fixture name describes the drift class being tested. New
+ * variations land here as plain rows, not new test blocks.
+ */
+type ExpectedOutcome = 'persisted' | 'changed';
+
+interface IdentityFixture {
+  readonly name: string;
+  readonly prior: IdentityInput;
+  readonly current: IdentityInput;
+  readonly expected: ExpectedOutcome;
+}
+
+const FIXTURES: ReadonlyArray<IdentityFixture> = [
+  // ─── gitleaks-style secrets (5) ────────────────────────────────────────
+  {
+    name: 'secret/clean — same rule, same file, same line',
+    prior: {
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'generic-api-key',
+      file: 'src/config/index.ts',
+      line: 42,
+    },
+    current: {
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'generic-api-key',
+      file: 'src/config/index.ts',
+      line: 42,
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'secret/line-shifted within line-window — drift absorbed',
+    prior: {
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'generic-api-key',
+      file: 'src/config/index.ts',
+      line: 42,
+    },
+    current: {
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'generic-api-key',
+      file: 'src/config/index.ts',
+      line: 43,
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'secret/file-renamed — identity changes (file is part of identity)',
+    prior: {
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'generic-api-key',
+      file: 'src/config/old.ts',
+      line: 42,
+    },
+    current: {
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'generic-api-key',
+      file: 'src/config/new.ts',
+      line: 42,
+    },
+    expected: 'changed',
+  },
+  {
+    name: 'secret/cross-tool with canonical-rule mapping — private-key collapses',
+    prior: {
+      kind: 'secret',
+      tool: 'find',
+      rule: 'private-key-file',
+      file: 'certs/server.pem',
+      line: 0,
+    },
+    current: {
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'private-key',
+      file: 'certs/server.pem',
+      line: 0,
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'secret/rule-evolved — different rule string, different identity',
+    prior: {
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'generic-api-key',
+      file: 'src/config/index.ts',
+      line: 42,
+    },
+    current: {
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'aws-access-token',
+      file: 'src/config/index.ts',
+      line: 42,
+    },
+    expected: 'changed',
+  },
+
+  // ─── config-class findings (1) ────────────────────────────────────────
+  {
+    name: 'config/env-tracked-in-git persists at line 0',
+    prior: { kind: 'config', tool: 'git', rule: 'env-in-git', file: '.env', line: 0 },
+    current: { kind: 'config', tool: 'git', rule: 'env-in-git', file: '.env', line: 0 },
+    expected: 'persisted',
+  },
+
+  // ─── semgrep-style code patterns (5) ──────────────────────────────────
+  {
+    name: 'code/clean — same rule, same file, same line',
+    prior: {
+      kind: 'code',
+      tool: 'semgrep',
+      rule: 'path-traversal',
+      file: 'src/api/files.ts',
+      line: 100,
+    },
+    current: {
+      kind: 'code',
+      tool: 'semgrep',
+      rule: 'path-traversal',
+      file: 'src/api/files.ts',
+      line: 100,
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'code/line-shifted within line-window — drift absorbed',
+    prior: {
+      kind: 'code',
+      tool: 'semgrep',
+      rule: 'path-traversal',
+      file: 'src/api/files.ts',
+      line: 99,
+    },
+    current: {
+      kind: 'code',
+      tool: 'semgrep',
+      rule: 'path-traversal',
+      file: 'src/api/files.ts',
+      line: 100,
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'code/file-moved across directories — identity changes',
+    prior: {
+      kind: 'code',
+      tool: 'semgrep',
+      rule: 'path-traversal',
+      file: 'src/api/files.ts',
+      line: 100,
+    },
+    current: {
+      kind: 'code',
+      tool: 'semgrep',
+      rule: 'path-traversal',
+      file: 'src/handlers/files.ts',
+      line: 100,
+    },
+    expected: 'changed',
+  },
+  {
+    name: 'code/cross-tool TLS-bypass canonicalization — registry + semgrep collapse',
+    prior: {
+      kind: 'code',
+      tool: 'tls-bypass-registry',
+      rule: 'tls-validation-disabled',
+      file: 'src/services/upstream.ts',
+      line: 50,
+    },
+    current: {
+      kind: 'code',
+      tool: 'semgrep',
+      rule: 'bypass-tls-verification',
+      file: 'src/services/upstream.ts',
+      line: 50,
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'code/line-shifted across line-window boundary — identity changes',
+    prior: {
+      kind: 'code',
+      tool: 'semgrep',
+      rule: 'path-traversal',
+      file: 'src/api/files.ts',
+      line: 100,
+    },
+    current: {
+      kind: 'code',
+      tool: 'semgrep',
+      rule: 'path-traversal',
+      file: 'src/api/files.ts',
+      line: 200,
+    },
+    expected: 'changed',
+  },
+
+  // ─── dep-vuln (4) ──────────────────────────────────────────────────────
+  {
+    name: 'dep-vuln/clean — same package, version, advisory',
+    prior: {
+      kind: 'dep-vuln',
+      package: 'fixture-pkg-a',
+      installedVersion: '1.2.3',
+      id: 'GHSA-aaaa-bbbb-cccc',
+    },
+    current: {
+      kind: 'dep-vuln',
+      package: 'fixture-pkg-a',
+      installedVersion: '1.2.3',
+      id: 'GHSA-aaaa-bbbb-cccc',
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'dep-vuln/severity-rescored — identity unchanged (severity excluded from hash)',
+    // Note: severity isn't carried in IdentityInput at all, so this fixture
+    // is structurally identical to the clean case; included to document
+    // the contract.
+    prior: {
+      kind: 'dep-vuln',
+      package: 'fixture-pkg-a',
+      installedVersion: '1.2.3',
+      id: 'GHSA-aaaa-bbbb-cccc',
+    },
+    current: {
+      kind: 'dep-vuln',
+      package: 'fixture-pkg-a',
+      installedVersion: '1.2.3',
+      id: 'GHSA-aaaa-bbbb-cccc',
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'dep-vuln/upgraded — installed version changes, identity changes',
+    prior: {
+      kind: 'dep-vuln',
+      package: 'fixture-pkg-a',
+      installedVersion: '1.2.3',
+      id: 'GHSA-aaaa-bbbb-cccc',
+    },
+    current: {
+      kind: 'dep-vuln',
+      package: 'fixture-pkg-a',
+      installedVersion: '1.2.4',
+      id: 'GHSA-aaaa-bbbb-cccc',
+    },
+    expected: 'changed',
+  },
+  {
+    name: 'dep-vuln/new advisory against same install — identity changes',
+    prior: {
+      kind: 'dep-vuln',
+      package: 'fixture-pkg-b',
+      installedVersion: '2.0.0',
+      id: 'GHSA-xxxx-yyyy-zzzz',
+    },
+    current: {
+      kind: 'dep-vuln',
+      package: 'fixture-pkg-b',
+      installedVersion: '2.0.0',
+      id: 'GHSA-1111-2222-3333',
+    },
+    expected: 'changed',
+  },
+
+  // ─── duplication / jscpd (3) ──────────────────────────────────────────
+  {
+    name: 'duplication/clean — same pair, same token count',
+    prior: {
+      kind: 'duplication',
+      fileA: 'src/api/users.ts',
+      fileB: 'src/api/admins.ts',
+      tokens: 240,
+    },
+    current: {
+      kind: 'duplication',
+      fileA: 'src/api/users.ts',
+      fileB: 'src/api/admins.ts',
+      tokens: 240,
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'duplication/pair-order swapped — identity unchanged (sides are symmetric)',
+    prior: {
+      kind: 'duplication',
+      fileA: 'src/api/users.ts',
+      fileB: 'src/api/admins.ts',
+      tokens: 240,
+    },
+    current: {
+      kind: 'duplication',
+      fileA: 'src/api/admins.ts',
+      fileB: 'src/api/users.ts',
+      tokens: 240,
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'duplication/block-refactored — token count drops, identity changes',
+    prior: {
+      kind: 'duplication',
+      fileA: 'src/api/users.ts',
+      fileB: 'src/api/admins.ts',
+      tokens: 240,
+    },
+    current: {
+      kind: 'duplication',
+      fileA: 'src/api/users.ts',
+      fileB: 'src/api/admins.ts',
+      tokens: 80,
+    },
+    expected: 'changed',
+  },
+
+  // ─── coverage gaps (3) ────────────────────────────────────────────────
+  {
+    name: 'coverage-gap/clean — same file + symbol',
+    prior: { kind: 'coverage-gap', file: 'src/services/payments.ts', symbol: 'refundOrder' },
+    current: { kind: 'coverage-gap', file: 'src/services/payments.ts', symbol: 'refundOrder' },
+    expected: 'persisted',
+  },
+  {
+    name: 'coverage-gap/line-range-only — body shifts but range unchanged',
+    prior: { kind: 'coverage-gap', file: 'src/services/payments.ts', lineRange: [120, 180] },
+    current: { kind: 'coverage-gap', file: 'src/services/payments.ts', lineRange: [120, 180] },
+    expected: 'persisted',
+  },
+  {
+    name: 'coverage-gap/symbol-renamed — identity changes',
+    prior: { kind: 'coverage-gap', file: 'src/services/payments.ts', symbol: 'refundOrder' },
+    current: { kind: 'coverage-gap', file: 'src/services/payments.ts', symbol: 'reverseOrder' },
+    expected: 'changed',
+  },
+
+  // ─── test-gap source files (3) ────────────────────────────────────────
+  {
+    name: 'test-gap/clean — same file + same risk tier',
+    prior: { kind: 'test-gap', file: 'src/services/payments.ts', risk: 'high' },
+    current: { kind: 'test-gap', file: 'src/services/payments.ts', risk: 'high' },
+    expected: 'persisted',
+  },
+  {
+    name: 'test-gap/risk-escalated — identity changes (regression signal)',
+    prior: { kind: 'test-gap', file: 'src/services/payments.ts', risk: 'medium' },
+    current: { kind: 'test-gap', file: 'src/services/payments.ts', risk: 'critical' },
+    expected: 'changed',
+  },
+  {
+    name: 'test-gap/file-renamed — identity changes',
+    prior: { kind: 'test-gap', file: 'src/services/old-payments.ts', risk: 'high' },
+    current: { kind: 'test-gap', file: 'src/services/payments.ts', risk: 'high' },
+    expected: 'changed',
+  },
+
+  // ─── hygiene offenders, per-occurrence (4) ────────────────────────────
+  {
+    name: 'hygiene/clean — same TODO at same file + line',
+    prior: { kind: 'hygiene', file: 'src/api/users.ts', line: 42, marker: 'todo' },
+    current: { kind: 'hygiene', file: 'src/api/users.ts', line: 42, marker: 'todo' },
+    expected: 'persisted',
+  },
+  {
+    name: 'hygiene/line-shifted within window — drift absorbed (formatter run)',
+    prior: { kind: 'hygiene', file: 'src/api/users.ts', line: 42, marker: 'todo' },
+    current: { kind: 'hygiene', file: 'src/api/users.ts', line: 43, marker: 'todo' },
+    expected: 'persisted',
+  },
+  {
+    name: 'hygiene/marker-class-changed — TODO became FIXME, identity changes',
+    prior: { kind: 'hygiene', file: 'src/api/users.ts', line: 42, marker: 'todo' },
+    current: { kind: 'hygiene', file: 'src/api/users.ts', line: 42, marker: 'fixme' },
+    expected: 'changed',
+  },
+  {
+    name: 'hygiene/line-shifted past window boundary — identity changes',
+    prior: { kind: 'hygiene', file: 'src/api/users.ts', line: 42, marker: 'console-log' },
+    current: { kind: 'hygiene', file: 'src/api/users.ts', line: 142, marker: 'console-log' },
+    expected: 'changed',
+  },
+
+  // ─── license findings (3) ─────────────────────────────────────────────
+  {
+    name: 'license/clean — same package, version, license type',
+    prior: { kind: 'license', package: 'fixture-pkg-a', version: '1.0.0', licenseType: 'MIT' },
+    current: { kind: 'license', package: 'fixture-pkg-a', version: '1.0.0', licenseType: 'MIT' },
+    expected: 'persisted',
+  },
+  {
+    name: 'license/relicensed at same pin — identity changes (compliance regression)',
+    prior: { kind: 'license', package: 'fixture-pkg-a', version: '1.0.0', licenseType: 'MIT' },
+    current: {
+      kind: 'license',
+      package: 'fixture-pkg-a',
+      version: '1.0.0',
+      licenseType: 'GPL-3.0',
+    },
+    expected: 'changed',
+  },
+  {
+    name: 'license/version-bumped — identity changes',
+    prior: { kind: 'license', package: 'fixture-pkg-a', version: '1.0.0', licenseType: 'MIT' },
+    current: { kind: 'license', package: 'fixture-pkg-a', version: '1.0.1', licenseType: 'MIT' },
+    expected: 'changed',
+  },
+];
+
+describe('identityFor — per-kind deterministic identity', () => {
+  it('produces a stable 16-char lowercase hex id for every fixture', () => {
+    for (const fx of FIXTURES) {
+      const id = identityFor(fx.prior);
+      expect(id, fx.name).toMatch(/^[0-9a-f]{16}$/);
+    }
+  });
+
+  it('is deterministic — repeated calls return the same id', () => {
+    for (const fx of FIXTURES) {
+      expect(identityFor(fx.prior), fx.name).toBe(identityFor(fx.prior));
+    }
+  });
+
+  it('rejects unsupported scheme versions', () => {
+    expect(() =>
+      identityFor(
+        { kind: 'secret', tool: 'gitleaks', rule: 'generic-api-key', file: 'a.ts', line: 1 },
+        // @ts-expect-error — verifying runtime guard on a hypothetical future version
+        'v2',
+      ),
+    ).toThrow(/Unsupported identity-scheme version/);
+  });
+
+  it('rejects coverage-gap inputs missing both symbol and lineRange', () => {
+    expect(() => identityFor({ kind: 'coverage-gap', file: 'src/services/payments.ts' })).toThrow(
+      /requires either a symbol or a line range/,
+    );
+  });
+});
+
+describe('identityFor — fixture-driven drift behavior', () => {
+  for (const fx of FIXTURES) {
+    it(fx.name, () => {
+      const priorId = identityFor(fx.prior);
+      const currentId = identityFor(fx.current);
+      if (fx.expected === 'persisted') {
+        expect(priorId).toBe(currentId);
+      } else {
+        expect(priorId).not.toBe(currentId);
+      }
+    });
+  }
+});
+
+describe('matchAcrossRuns — set diff over identity', () => {
+  it('classifies every fixture into the expected bucket', () => {
+    for (const fx of FIXTURES) {
+      const prior = [identityFor(fx.prior)];
+      const current = [identityFor(fx.current)];
+      const result = matchAcrossRuns(prior, current);
+      if (fx.expected === 'persisted') {
+        expect(result.persisted.length, fx.name).toBe(1);
+        expect(result.added.length, fx.name).toBe(0);
+        expect(result.removed.length, fx.name).toBe(0);
+      } else {
+        expect(result.persisted.length, fx.name).toBe(0);
+        expect(result.added.length, fx.name).toBe(1);
+        expect(result.removed.length, fx.name).toBe(1);
+      }
+    }
+  });
+
+  it('treats empty inputs as empty outputs', () => {
+    const result = matchAcrossRuns([], []);
+    expect(result.persisted).toEqual([]);
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+  });
+
+  it('handles intersection + disjoint sets together', () => {
+    const a = ['aaaa1111bbbb2222', 'cccc3333dddd4444'];
+    const b = ['cccc3333dddd4444', 'eeee5555ffff6666'];
+    const result = matchAcrossRuns(a, b);
+    expect(result.persisted.sort()).toEqual(['cccc3333dddd4444']);
+    expect(result.added.sort()).toEqual(['eeee5555ffff6666']);
+    expect(result.removed.sort()).toEqual(['aaaa1111bbbb2222']);
+  });
+
+  it('preserves occurrence count via multiset semantics', () => {
+    // Two prior instances of the same fingerprint, one current instance:
+    // one persists, one is removed. Set-based dedup would have hidden
+    // the removal and reported a clean "no change" — that's the bug
+    // multiset matching fixes.
+    const a = ['aaaa1111bbbb2222', 'aaaa1111bbbb2222'];
+    const b = ['aaaa1111bbbb2222'];
+    const result = matchAcrossRuns(a, b);
+    expect(result.persisted).toEqual(['aaaa1111bbbb2222']);
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual(['aaaa1111bbbb2222']);
+  });
+
+  it('emits structured pairs with reasons + confidence', () => {
+    const result = matchAcrossRuns(['aaaa1111bbbb2222'], ['aaaa1111bbbb2222']);
+    expect(result.pairs).toHaveLength(1);
+    const [pair] = result.pairs;
+    expect(pair.status).toBe('persisted');
+    expect(pair.confidence).toBe(1.0);
+    expect(pair.reasons[0].code).toBe('exact-id');
+    expect(pair.priorId).toBe('aaaa1111bbbb2222');
+    expect(pair.currentId).toBe('aaaa1111bbbb2222');
+  });
+
+  it('marks the result as non-git-aware', () => {
+    const result = matchAcrossRuns(['aaaa1111bbbb2222'], []);
+    expect(result.gitAware).toBe(false);
+    expect(result.degradedReason).toBeUndefined();
+  });
+});
+
+/**
+ * The list of finding kinds that the dispatch supports. Mirrors the
+ * `IdentityInput` discriminant union in `src/baseline/types.ts`. When
+ * a new kind is added to the union, TypeScript's exhaustiveness check
+ * on `identityFor`'s switch forces a code update; this list is the
+ * matching test-side enforcement that ensures the new kind ships with
+ * fixture coverage.
+ *
+ * Update procedure: add the new kind here, then add at least one
+ * fixture row in `FIXTURES` exercising it.
+ */
+const EXPECTED_KINDS = [
+  'secret',
+  'code',
+  'config',
+  'dep-vuln',
+  'duplication',
+  'coverage-gap',
+  'test-gap',
+  'hygiene',
+  'license',
+] as const;
+
+describe('identityFor — coverage contract (Rule 9)', () => {
+  it('every supported finding kind has at least one fixture row', () => {
+    const covered = new Set(FIXTURES.map((f) => f.prior.kind));
+    for (const kind of EXPECTED_KINDS) {
+      expect(covered.has(kind), `missing fixture row for kind: ${kind}`).toBe(true);
+    }
+  });
+
+  it('every fixture kind appears in the expected-kinds contract list', () => {
+    const expected = new Set<string>(EXPECTED_KINDS);
+    for (const fx of FIXTURES) {
+      expect(
+        expected.has(fx.prior.kind),
+        `fixture "${fx.name}" exercises kind "${fx.prior.kind}" not declared in EXPECTED_KINDS`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('identityFor — cross-kind disjointness', () => {
+  it('does not collide across kinds even with structurally-similar inputs', () => {
+    const ids = new Set<string>([
+      identityFor({
+        kind: 'secret',
+        tool: 'gitleaks',
+        rule: 'api-key',
+        file: 'src/a.ts',
+        line: 10,
+      }),
+      identityFor({ kind: 'code', tool: 'gitleaks', rule: 'api-key', file: 'src/a.ts', line: 10 }),
+      identityFor({
+        kind: 'config',
+        tool: 'gitleaks',
+        rule: 'api-key',
+        file: 'src/a.ts',
+        line: 10,
+      }),
+      identityFor({
+        kind: 'dep-vuln',
+        package: 'gitleaks',
+        installedVersion: 'api-key',
+        id: 'src/a.ts',
+      }),
+      identityFor({ kind: 'duplication', fileA: 'gitleaks', fileB: 'api-key', tokens: 10 }),
+      identityFor({ kind: 'coverage-gap', file: 'src/a.ts', symbol: 'gitleaks' }),
+    ]);
+    // The first three (secret/code/config) intentionally collide — they
+    // share the same canonical-rule + file + lineWindow input space and
+    // the kind itself is NOT part of the hash, only the canonical rule
+    // map is. That's by design: a finding that flips between two
+    // categories (a TLS-bypass that one tool labels as `secret` and
+    // another as `code`) MUST collapse to one identity. The remaining
+    // three are kind-disjoint by their input tuple shape.
+    expect(ids.size).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/test/baseline/git-aware-match.test.ts
+++ b/test/baseline/git-aware-match.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { identityFor } from '../../src/baseline/finding-identity';
+import { gitAwareMatch, mapLineThroughDiff } from '../../src/baseline/git-aware-match';
+import type { LocatedIdentity } from '../../src/baseline/git-aware-match';
+
+/**
+ * Spin up an isolated git repo in the OS temp dir. Every test gets
+ * a fresh directory, deterministic config (user identity, no GPG
+ * signing), and a clean working tree.
+ */
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-baseline-'));
+  execFileSync('git', ['init', '--quiet', '--initial-branch=main'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+  return dir;
+}
+
+function commit(dir: string, message: string): string {
+  execFileSync('git', ['add', '-A'], { cwd: dir });
+  execFileSync('git', ['commit', '--quiet', '-m', message], { cwd: dir });
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir, encoding: 'utf8' }).trim();
+}
+
+function lines(...ls: string[]): string {
+  return ls.join('\n') + '\n';
+}
+
+describe('mapLineThroughDiff', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeRepo();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns the same line when revisions are identical', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'two', 'three'));
+    const sha = commit(dir, 'initial');
+    expect(
+      mapLineThroughDiff({ cwd: dir, baseSha: sha, headSha: sha, file: 'a.ts', baseLine: 2 }),
+    ).toBe(2);
+  });
+
+  it('shifts a line down by an insertion above it', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'two', 'three'));
+    const base = commit(dir, 'initial');
+    writeFileSync(join(dir, 'a.ts'), lines('new-a', 'new-b', 'new-c', 'one', 'two', 'three'));
+    const head = commit(dir, 'prepend three lines');
+    expect(
+      mapLineThroughDiff({ cwd: dir, baseSha: base, headSha: head, file: 'a.ts', baseLine: 2 }),
+    ).toBe(5);
+  });
+
+  it('shifts a line up by a deletion above it', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'two', 'three', 'four', 'five'));
+    const base = commit(dir, 'initial');
+    writeFileSync(join(dir, 'a.ts'), lines('four', 'five'));
+    const head = commit(dir, 'drop first three');
+    expect(
+      mapLineThroughDiff({ cwd: dir, baseSha: base, headSha: head, file: 'a.ts', baseLine: 4 }),
+    ).toBe(1);
+  });
+
+  it('returns null when the line itself was deleted', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'two', 'three'));
+    const base = commit(dir, 'initial');
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'three'));
+    const head = commit(dir, 'drop the middle');
+    expect(
+      mapLineThroughDiff({ cwd: dir, baseSha: base, headSha: head, file: 'a.ts', baseLine: 2 }),
+    ).toBeNull();
+  });
+
+  it('handles multiple hunks with cumulative shift', () => {
+    writeFileSync(
+      join(dir, 'a.ts'),
+      lines('one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'),
+    );
+    const base = commit(dir, 'initial');
+    writeFileSync(
+      join(dir, 'a.ts'),
+      // Insert one line before line 2; delete line 6; nothing else changes.
+      lines('one', 'INSERTED', 'two', 'three', 'four', 'five', 'seven', 'eight', 'nine'),
+    );
+    const head = commit(dir, 'mixed edits');
+    // base line 5 ('five') survives, ends up at head line 6 (one inserted above it).
+    expect(
+      mapLineThroughDiff({ cwd: dir, baseSha: base, headSha: head, file: 'a.ts', baseLine: 5 }),
+    ).toBe(6);
+    // base line 8 ('eight') survives the deletion above: shift is +1 - 1 = 0.
+    expect(
+      mapLineThroughDiff({ cwd: dir, baseSha: base, headSha: head, file: 'a.ts', baseLine: 8 }),
+    ).toBe(8);
+  });
+
+  it('returns null when the file no longer exists at head', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'two', 'three'));
+    const base = commit(dir, 'initial');
+    rmSync(join(dir, 'a.ts'));
+    const head = commit(dir, 'remove a.ts');
+    expect(
+      mapLineThroughDiff({ cwd: dir, baseSha: base, headSha: head, file: 'a.ts', baseLine: 2 }),
+    ).toBeNull();
+  });
+});
+
+describe('gitAwareMatch', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeRepo();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function findingAt(file: string, line: number, rule = 'demo-rule'): LocatedIdentity {
+    return {
+      id: identityFor({ kind: 'code', tool: 'semgrep', rule, file, line }),
+      file,
+      line,
+      rule,
+    };
+  }
+
+  it('persists exact identity matches without consulting git', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'two'));
+    const sha = commit(dir, 'initial');
+    const prior = [findingAt('a.ts', 2)];
+    const current = [findingAt('a.ts', 2)];
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: sha, headSha: sha });
+    expect(result.persisted.length).toBe(1);
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+  });
+
+  it('pairs prior+current across a vertical insertion that crosses the line-bucket boundary', () => {
+    // Twelve-line insertion at top: a finding at line 42 in base ends up at
+    // line 54 in head. Line-bucket fingerprints (3-line buckets at 42 vs 54)
+    // differ — exact-id match alone reports "removed + added." Git-aware
+    // match should re-pair them.
+    const baseContent = Array.from({ length: 50 }, (_, i) => `base-${i + 1}`);
+    writeFileSync(join(dir, 'a.ts'), baseContent.join('\n') + '\n');
+    const base = commit(dir, 'initial');
+    const headContent = [...Array.from({ length: 12 }, (_, i) => `top-${i + 1}`), ...baseContent];
+    writeFileSync(join(dir, 'a.ts'), headContent.join('\n') + '\n');
+    const head = commit(dir, 'prepend 12 lines');
+
+    const prior = [findingAt('a.ts', 42)];
+    const current = [findingAt('a.ts', 54)];
+    expect(prior[0].id).not.toBe(current[0].id); // confirm bucket-different
+
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+    expect(result.persisted.length).toBe(2); // both ids reported as persisted
+    expect(new Set(result.persisted)).toEqual(new Set([prior[0].id, current[0].id]));
+  });
+
+  it('marks a deleted-line finding as removed and a fresh finding as added', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'two', 'three', 'four', 'five'));
+    const base = commit(dir, 'initial');
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'three', 'four', 'NEW-FIVE'));
+    const head = commit(dir, 'delete line2, replace last line');
+
+    const prior = [findingAt('a.ts', 2), findingAt('a.ts', 5)];
+    const current = [findingAt('a.ts', 4)]; // 'NEW-FIVE' at line 4 in head
+
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+    // prior:2 was deleted → removed. prior:5 maps to head:4 (after -1 shift),
+    // but current[0] is at head:4 — pair matches → persisted.
+    expect(new Set(result.removed)).toEqual(new Set([prior[0].id]));
+    expect(result.added).toEqual([]);
+    expect(new Set(result.persisted)).toEqual(new Set([prior[1].id, current[0].id]));
+  });
+
+  it('falls back to set-diff when the base SHA is unreachable', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'two', 'three', 'four', 'five'));
+    commit(dir, 'initial');
+    // Lines 1 and 4 fall into different line-window buckets (bucket 0
+    // vs bucket 3) so their identities differ — confirms the matcher
+    // actually attempted (and failed) the git-aware fallback rather
+    // than the test trivially passing on bucket collision.
+    const prior = [findingAt('a.ts', 1)];
+    const current = [findingAt('a.ts', 4)];
+    expect(prior[0].id).not.toBe(current[0].id);
+    const result = gitAwareMatch(prior, current, {
+      cwd: dir,
+      baseSha: '0000000000000000000000000000000000000000', // not in repo
+    });
+    // No git fallback → reports as removed+added without pairing.
+    expect(new Set(result.removed)).toEqual(new Set([prior[0].id]));
+    expect(new Set(result.added)).toEqual(new Set([current[0].id]));
+    expect(result.persisted).toEqual([]);
+  });
+
+  it('treats non-line-anchored findings via exact identity only', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one'));
+    const sha = commit(dir, 'initial');
+    // A dep-vuln identity has no file/line — must be matched by exact id alone.
+    const depId = identityFor({
+      kind: 'dep-vuln',
+      package: 'fixture-pkg',
+      installedVersion: '1.0.0',
+      id: 'GHSA-aaaa-bbbb-cccc',
+    });
+    const prior: LocatedIdentity[] = [{ id: depId }];
+    const current: LocatedIdentity[] = [{ id: depId }];
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: sha });
+    expect(result.persisted).toEqual([depId]);
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+  });
+
+  it('does not pair findings with different rules even on the same line', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'two'));
+    const base = commit(dir, 'initial');
+    writeFileSync(join(dir, 'a.ts'), lines('zero', 'one', 'two'));
+    const head = commit(dir, 'prepend');
+
+    const prior = [findingAt('a.ts', 1, 'rule-A')];
+    const current = [findingAt('a.ts', 2, 'rule-B')];
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+    expect(new Set(result.removed)).toEqual(new Set([prior[0].id]));
+    expect(new Set(result.added)).toEqual(new Set([current[0].id]));
+    expect(result.persisted).toEqual([]);
+  });
+
+  it('pairs across a file rename — status is "relocated", not "persisted"', () => {
+    writeFileSync(join(dir, 'old-path.ts'), lines('one', 'two', 'three'));
+    const base = commit(dir, 'initial');
+    execFileSync('git', ['mv', 'old-path.ts', 'new-path.ts'], { cwd: dir });
+    const head = commit(dir, 'rename old-path → new-path');
+
+    const prior = [findingAt('old-path.ts', 2)];
+    const current = [findingAt('new-path.ts', 2)];
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+
+    expect(result.removed).toEqual([]);
+    expect(result.added).toEqual([]);
+    expect(result.pairs).toHaveLength(1);
+    const [pair] = result.pairs;
+    expect(pair.status).toBe('relocated');
+    expect(pair.priorId).toBe(prior[0].id);
+    expect(pair.currentId).toBe(current[0].id);
+    expect(pair.reasons.some((r) => r.code === 'git-rename')).toBe(true);
+  });
+
+  it('pairs via line-fuzz when the scanner reports a slightly different line', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('alpha', 'beta', 'gamma'));
+    const base = commit(dir, 'initial');
+    writeFileSync(
+      join(dir, 'a.ts'),
+      lines('TOP-1', 'TOP-2', 'TOP-3', 'TOP-4', 'TOP-5', 'alpha', 'beta', 'gamma'),
+    );
+    const head = commit(dir, 'prepend 5 lines');
+
+    // Prior finding at line 2 → git diff maps to line 7. Pretend the
+    // scanner reported the current finding at line 8 instead — within
+    // the ±2 fuzz window. Different identity (different buckets).
+    const prior = [findingAt('a.ts', 2)];
+    const current = [findingAt('a.ts', 8)];
+    expect(prior[0].id).not.toBe(current[0].id);
+
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+    expect(result.pairs).toHaveLength(1);
+    const [pair] = result.pairs;
+    expect(pair.status).toBe('persisted');
+    expect(pair.confidence).toBeLessThan(1.0);
+    expect(pair.reasons[0].code).toBe('git-line-fuzz');
+  });
+
+  it('reports degraded mode with a reason when the base SHA is unreachable', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one'));
+    commit(dir, 'initial');
+    const result = gitAwareMatch([], [], {
+      cwd: dir,
+      baseSha: '0000000000000000000000000000000000000000',
+    });
+    expect(result.gitAware).toBe(false);
+    expect(result.degradedReason).toBeDefined();
+    expect(result.degradedReason).toMatch(/not reachable/);
+  });
+
+  it('exposes git-aware match reasons + confidence on pair entries', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('alpha', 'beta', 'gamma'));
+    const base = commit(dir, 'initial');
+    writeFileSync(join(dir, 'a.ts'), lines('top-1', 'top-2', 'top-3', 'alpha', 'beta', 'gamma'));
+    const head = commit(dir, 'prepend 3 lines');
+
+    const prior = [findingAt('a.ts', 1)];
+    const current = [findingAt('a.ts', 4)];
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+    expect(result.gitAware).toBe(true);
+    const [pair] = result.pairs;
+    expect(pair.confidence).toBe(0.95);
+    expect(pair.reasons[0].code).toBe('git-line-exact');
+    expect(pair.reasons[0].detail).toContain('a.ts:1');
+    expect(pair.reasons[0].detail).toContain('a.ts:4');
+  });
+});

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -349,6 +349,12 @@ describe('recipe playbook — synthetic pack', () => {
     expect(aggregate.depBySeverity.critical).toBe(1);
     expect(aggregate.depBySeverity.high).toBe(1);
     expect(aggregate.findingsByCategory.dependency).toHaveLength(2);
+    // Rule 9: synthetic-pack dep-vuln findings carry the fingerprint
+    // they entered with — the aggregator must not strip the canonical
+    // identity. Future packs producing dep-vulns inherit this contract.
+    for (const f of aggregate.findingsByCategory.dependency) {
+      expect(f.fingerprint).toBeTruthy();
+    }
   });
 
   it('buildSecurityAggregate collapses cross-tool TLS-bypass regardless of pack identity (G_v4_8 / D091)', async () => {
@@ -400,6 +406,10 @@ describe('recipe playbook — synthetic pack', () => {
     ]);
     expect(aggregate.codeBySeverity.high).toBe(1);
     expect(aggregate.dedupCollisions).toHaveLength(1);
+    // Rule 9: the collapsed CodeFinding carries a fingerprint stamped
+    // by the canonical helper. Synthetic pack contributions inherit
+    // the same identity contract that real packs do.
+    expect(aggregate.findingsByCategory.code[0].fingerprint).toMatch(/^[0-9a-f]{16}$/);
   });
 
   // ─── ArchitecturalShape (2.4.7 C8): per-stack paths + vocabulary


### PR DESCRIPTION
## Summary

First slice of the 2.5.0 release — the identity layer that every
baseline + guardrail feature in the rest of the release builds on.
Ships behind no flag; no public CLI surface yet (that's Phase 3).

**Identity dispatch** (`src/baseline/finding-identity.ts`):
- 9 finding kinds covered through one `identityFor()`: secret,
  code-pattern, config, dep-vuln, duplication, coverage-gap, test-gap,
  per-occurrence hygiene marker, license attribution
- Reuses the shared dep-vuln + code-finding fingerprint helpers (now
  consolidated in `tools/fingerprint.ts`); adds new schemes for the
  five kinds that didn't have one
- Pure module: no I/O, deterministic output for deterministic input

**Cross-run matcher** (`src/baseline/git-aware-match.ts`):
- Multiset-aware diff — preserves occurrence count (closes a
  set-collapse correctness bug where two prior findings sharing an
  identity would silently report one persisted + zero removed)
- Git-aware location pass — maps prior-line through `git diff` to
  find the corresponding head-line, pairs across line shifts of any
  size (not just within the ±2 bucket window)
- File-rename detection via `git diff --name-status --find-renames`;
  renamed-file pairs report `'relocated'` rather than `'persisted'`
- ±2 line fuzz on the mapped-line lookup (confidence 0.88 vs 0.95)
  for scanner re-run drift
- Graceful degrade to plain set-diff when git history is unreachable
  (shallow clone, force-push); every result carries a `gitAware`
  flag + human-readable `degradedReason`

**Match output shape** — every pair carries `confidence ∈ [0, 1]` +
structured reason codes (`exact-id`, `git-line-exact`,
`git-line-fuzz`, `git-rename`) so downstream consumers can render
explainable guardrail output, not bare added/removed.

**Architectural gates** — new CLAUDE.md Rule 9 + four enforcement
gates so future analyzers/packs can't silently bypass the
fingerprinting discipline (rogue `createHash`, inline line-bucketing,
new IdentityInput kind without fixture coverage, synthetic-pack
findings without stamped fingerprints).

## Validation

- 1325/1325 full test suite (60 new tests — 44 identity fixtures + 16
  synthetic-git-repo matcher scenarios)
- 100% coverage on `finding-identity.ts`, 96.22% on `git-aware-match.ts`
- 0 byte-stability mismatches between `identityFor()` output and the
  pre-existing fingerprints stamped on 33 real production-shape
  security-report findings
- 20/20 production-shape findings persist through a simulated 15-line
  vertical shift via git-aware match
- Architecture + slop + lint gates all silent

## Merge strategy

**Rebase merge** — each of the 4 commits is independently meaningful:

1. `refactor`: extract code-finding fingerprint helpers to the shared
   tools module
2. `feat(baseline)`: identity dispatch + git-aware matcher
3. `arch`: codify Rule 9 + enforcement gates
4. `fix(baseline)`: spread ReadonlyArray before sorting in matcher
   tests (typecheck-only)

## Test plan

- [x] Build clean (`npm run build`)
- [x] Typecheck clean (`npm run typecheck`, `npm run typecheck:test`)
- [x] Tests pass (`npm run test:run` — 1325/1325)
- [x] Architecture gates pass (`bash scripts/check-architecture.sh`)
- [x] Slop check passes (`bash scripts/check-slop.sh`)
- [x] Lint clean (`npm run lint`)
- [x] Coverage threshold met (55.88% / 50%)
- [x] Customer-data validation (33 fingerprints byte-stable, 20
      findings persist 15-line shift)

## Out of scope (deferred to later 2.5.0 phases)

Tracked in `tmp/2.5-release-plan/roadmap.md`. Headlines:

- Phase 2: 4 missing finding kinds (test-file degradation, god files,
  stale files, large files), secret HMAC identity, content-hash
  fallback, FindingStatus enum, brownfield policy
- Phase 3: `dxkit baseline create / show / guardrail check` CLI,
  stable JSON schema, output renderers
- Phase 4: pre-commit + pre-push githooks, GH Actions workflow,
  devcontainer with claude+codex+dxkit+tools
- Phase 5: 3-customer repo audit, demo GIF, README rewrite

## Related docs

- `tmp/2.5-release-plan/roadmap.md` — full 2.5.0 phase plan
- `tmp/2.5-release-plan/finding-identity-drift.md` — design rationale
  for the git-aware-first matching strategy
- `tmp/2.5-release-plan/dxkit-git-aware-fingerprinting-review-and-recommendations.md`
  — external review that drove the multiset + confidence + rename +
  fuzz hardening
- `tmp/finding-identity-fixtures/coverage-audit.md` — per-finding
  identity coverage audit (HIGH / MEDIUM / LOW priority)
- `tmp/finding-identity-fixtures/validation-log.md` — customer-data
  validation methodology + results

🤖 Generated with [Claude Code](https://claude.com/claude-code)