### PR TITLE
ci(smoke): seed a root commit before baseline create in devcontainer

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -246,7 +246,15 @@ jobs:
           mkdir -p "${{ github.workspace }}/consumer"
           cd "${{ github.workspace }}/consumer"
           git init -q -b main
+          # Seed a root commit so `baseline create` (run inside the
+          # devcontainer below) can derive the deterministic salt
+          # from `git rev-list --max-parents=0 HEAD`. The pack-smoke
+          # job above already follows this pattern.
+          git config user.email "smoke@example.com"
+          git config user.name "smoke"
           echo '{"name":"dc-smoke","private":true}' > package.json
+          git add package.json
+          git commit -q -m "init"
           npm install --save-dev "${{ steps.pack.outputs.tarball }}"
           ./node_modules/.bin/vyuh-dxkit init --with-devcontainer --yes
           test -f .devcontainer/devcontainer.json


### PR DESCRIPTION
## Summary

The devcontainer-smoke job's `baseline create` step has been failing on every main push (verified on `e570876` / v2.5.0 and `691c6c1` / v2.5.1) with:

```
✗ Cannot derive a baseline salt: not a git repository (or no root
  commit reachable). Set DXKIT_BASELINE_SALT or initialize a git repo
  before running baseline commands.
```

Root cause: the consumer dir is `git init`'d but has no commits, so `git rev-list --max-parents=0 HEAD` (the salt-derivation call) returns nothing.

The `pack-smoke` job in the same workflow already follows the right pattern — `git config user.email/name`, then commit after seeding files. Mirroring that in `devcontainer-smoke`.

No product-code change. Smoke turns green; previously-red status on every main push was a workflow-setup gap.

## Test plan

- [ ] Smoke `devcontainer-smoke` job runs `baseline create` successfully
- [ ] `pack-smoke` job remains unaffected (pure addition to the other job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)