### PR TITLE
test(dispatcher): loosen deadline lower bound to fix CI timing flake

### DIFF
--- a/test/dispatcher-deadline.test.ts
+++ b/test/dispatcher-deadline.test.ts
@@ -101,11 +101,15 @@ describe('CapabilityDispatcher per-provider deadline', () => {
       hangingProvider('c'),
     ]);
     const elapsed = Date.now() - t0;
-    // Generous upper bound — node's setTimeout granularity + WSL2
-    // scheduling jitter make tight bounds flaky. The point is the
-    // dispatch DOES return rather than hanging forever; the actual
-    // wall-clock should be ~deadlineMs, never minutes.
-    expect(elapsed).toBeGreaterThanOrEqual(40);
+    // Generous bounds on both sides — node's setTimeout granularity
+    // (~1-2ms) + WSL2 / CI runner scheduling jitter make tight bounds
+    // flaky. The point is the dispatch DOES wait for the deadline
+    // rather than returning immediately (would be <5ms) AND it returns
+    // rather than hanging forever (would be minutes). The deadline is
+    // 40ms; fast runners can fire setTimeout at 38-39ms, so the lower
+    // bound is 25ms — well clear of "no waiting" while tolerating
+    // timer-granularity variance.
+    expect(elapsed).toBeGreaterThanOrEqual(25);
     expect(elapsed).toBeLessThan(2000);
   });
 


### PR DESCRIPTION
## Summary

Fixes the timing flake that took main red after PR #38 merged. **Not a real defect** — pure CI-runner timer-granularity issue.

### Root cause

`test/dispatcher-deadline.test.ts:108` sets `providerDeadlineMs: 40` then asserts `elapsed >= 40`. Node's setTimeout has ~1-2ms granularity, so on fast CI runners the deadline can fire at 38-39ms — 1-2ms under the assertion threshold.

The test's intent is to verify dispatch DID wait for the deadline (vs returning immediately, which would be <5ms). Exact equality with the deadline was never the contract.

### Fix

Lower bound 40 → 25. Still well clear of "no waiting" (would be sub-5ms) while tolerating timer-granularity variance. Upper bound unchanged at 2000ms. Comment updated to explain the trade-off.

### CI evidence

Run that failed: https://github.com/vyuh-labs/dxkit/actions/runs/26255044049
- Failure: `AssertionError: expected 39 to be greater than or equal to 40`
- 1587/1588 tests passed; only this single timing assertion off by 1ms

Local: `npx vitest run test/dispatcher-deadline.test.ts` — 7/7 passing.

## Test plan

- [x] Local vitest run of the fixed test file
- [ ] CI pass on this PR
- [ ] CI green on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)