### PR TITLE
chore(arch-check): detect dead template conditions in constants.ts

### DIFF
--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -651,6 +651,50 @@ if [ -n "$ROGUE_IDENTITY" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# =============================================================================
+# Sprint 4 (2.5.2): dead template-condition detector.
+# =============================================================================
+#
+# `src/constants.ts:getConditions()` computes IF_<NAME> booleans from
+# the resolved config. Each one is meant to gate a template branch
+# (`{{#IF_NAME}}…{{/IF_NAME}}` in src-templates/) or a generator.ts
+# `copyStatic` call. Conditions that compute but have NO consumer are
+# dead code: harmless in behavior, but they accumulate (we found 4
+# dead conditions sitting since 2026-05-19 because typecheck doesn't
+# catch compute-without-consumer — they're type-correct, just useless).
+#
+# This rule extracts every `IF_*:` key from constants.ts and verifies
+# each has at least one consumer in either:
+#   - src-templates/                (mustache {{#IF_NAME}} blocks)
+#   - src/generator.ts              (conditions.IF_NAME programmatic refs)
+#
+# Allowlist: `// arch-check-ok` on the constants.ts line for any
+# intentional ahead-of-template addition.
+DEAD_CONDS=""
+IF_TOKENS=$(grep -E "^\s+IF_[A-Z_]+:" src/constants.ts 2>/dev/null \
+  | grep -v "// arch-check-ok" \
+  | sed -E 's/^\s+(IF_[A-Z_]+):.*/\1/')
+for cond in $IF_TOKENS; do
+  # Mustache section/inverted/standalone in any template file
+  if grep -rq "{{[#^/]*$cond}}" src-templates/ 2>/dev/null; then
+    continue
+  fi
+  # Programmatic consumer in generator.ts
+  if grep -q "conditions\.$cond\b" src/generator.ts 2>/dev/null; then
+    continue
+  fi
+  DEAD_CONDS="$DEAD_CONDS $cond"
+done
+if [ -n "$DEAD_CONDS" ]; then
+  echo "❌ Dead template conditions computed in src/constants.ts but consumed nowhere:"
+  for c in $DEAD_CONDS; do echo "   • $c"; done
+  echo "   → Either add a template consumer ({{#$c}}…{{/$c}} in src-templates/)"
+  echo "     or remove the IF_ entry from getConditions() in src/constants.ts."
+  echo "   → Annotate '// arch-check-ok' on the constants.ts line for intentional"
+  echo "     ahead-of-template additions (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ $ERRORS -gt 0 ]; then
   echo ""
   echo "Architecture checks failed. See CLAUDE.md for rules."

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -108,11 +108,5 @@ export function buildConditions(config: ResolvedConfig): Record<string, boolean>
     // moved out of `languages` in 10f.4).
     IF_NODE: config.languages.typescript ?? false,
     IF_NEXTJS: config.framework === 'nextjs',
-    IF_POSTGRES: config.infrastructure.postgres,
-    IF_REDIS: config.infrastructure.redis,
-    IF_HAS_SERVICES: config.infrastructure.postgres || config.infrastructure.redis,
-    IF_DOCKER: config.infrastructure.docker,
-    IF_CLAUDE_CODE: config.claudeCode,
-    IF_COVERAGE_ENABLED: parseInt(config.coverageThreshold || DEFAULT_COVERAGE) > 0,
   };
 }


### PR DESCRIPTION
## Summary

Small architectural-discipline PR — adds a new rule to `scripts/check-architecture.sh` that catches the class of incomplete-cleanup bug surfaced during PR #40's tools cleanup, and finishes the canonical follow-through by removing 6 more dead conditions from `constants.ts`.

### The rule

`src/constants.ts:getConditions()` computes `IF_<NAME>` booleans intended to gate template branches or generator.ts logic. Compute-without-consumer is type-correct so typecheck doesn't catch it.

New arch-check extracts every `IF_*:` key from constants.ts and verifies each has at least one consumer:
- `{{[#^/]?IF_NAME}}` mustache reference in `src-templates/`
- `conditions.IF_NAME\b` programmatic ref in `src/generator.ts`

Allowlist via `// arch-check-ok` on the constants.ts line for intentional ahead-of-template additions.

### Dead-condition cleanup

Smoke testing the rule on main caught 6 dead conditions — compute-only since the 2026-05-19 generator simplification removed the `.project.yaml` consumers without removing the computation:

- `IF_POSTGRES`
- `IF_REDIS`
- `IF_HAS_SERVICES`
- `IF_DOCKER`
- `IF_CLAUDE_CODE`
- `IF_COVERAGE_ENABLED`

Removed in the same commit (canonical follow-through on the same disease class). No customer impact — zero templates referenced any of them.

### Why this matters

This is the third pass of the same disease class:
1. Tools cleanup (PR #40, `bc82b91`-completing) — `tools.{gcloud,pulumi,infisical,ghCli}` removed
2. IF_* cleanup (this PR) — `IF_POSTGRES` etc. removed
3. Arch rule (this PR) — prevents pass #4

Going forward, any new `IF_*` added without a corresponding template or generator consumer fails arch-check at pre-commit time.

## Test plan

- [x] Local arch-check passes after cleanup (`bash scripts/check-architecture.sh`)
- [x] Rule fires correctly on a synthetic dead condition (verified by removing the `IF_NEXTJS` consumer in templates temporarily — rule caught it; restored)
- [x] All 214 scoped tests pass
- [x] `npm run typecheck` + `npm run build` clean
- [ ] CI gate

Net: +44 lines arch-check, -8 lines constants.ts. Single commit (~30 min as scoped in the 2.5.2 plan Sprint 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)