### PR TITLE
feat(2.6): per-finding allowlist — Sprint 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-finding allowlist** — `vyuh-dxkit allowlist add/list/show/audit/prune`.
+  Typed-category suppression (`false-positive`, `test-fixture`,
+  `mitigated-externally`, `accepted-risk`, `deferred`) with required
+  reason + (where relevant) expiry. Two surfaces: inline
+  `// dxkit-allow:<category> reason="..."` annotations and a
+  file-level `.dxkit/allowlist.json`. `accepted-risk` and `deferred`
+  require expiry (default 90 days). See
+  [docs/commands/allowlist.md](docs/commands/allowlist.md).
+- **Strict stale-annotation detection** — orphaned `dxkit-allow:`
+  annotations (where the underlying finding is now gone) emit a
+  new `stale-allow` baseline kind on the next scan. The
+  TypeScript `@ts-expect-error` pattern, applied to suppressions —
+  forces cleanup, prevents the annotation graveyard. Allowlisting
+  a `stale-allow` finding is forbidden; only remediation is to
+  remove the orphaned comment.
+- **Allowlist activity in PR comments** — the
+  `dxkit-guardrails.yml` workflow's sticky PR comment now includes
+  an "Allowlist activity" section listing every entry added (or
+  removed) on this branch versus the baseline commit. Reviewers
+  see new suppressions being introduced and can sanity-check
+  category + reason + expiry before approving.
+- **`vyuh-dxkit issue`** — pre-filled GitHub Issues for false
+  positives, missing findings, bugs, feature requests, and docs
+  gaps. Nothing submits automatically — the CLI opens the
+  customer's browser at a new-issue URL with env metadata
+  pre-populated, customer reviews + clicks "Submit." See
+  [docs/commands/issue.md](docs/commands/issue.md).
+- **`commentSyntax` on language packs** — each pack declares its
+  line-comment marker (`#` for python/ruby; `//` for
+  typescript/go/rust/csharp/kotlin/java). Drives the inline
+  allowlist-annotation generator across every language uniformly.
+  Recipe-enforced: scaffolder ships an empty placeholder so
+  unfilled packs fail the contract test until populated.
+- Three preemptive architecture rules in `scripts/check-architecture.sh`
+  lock down the allowlist canonical entry points: no `createHash`
+  inside `src/allowlist/`, no direct `allowlist.json` IO outside
+  the canonical loader, no language-comment fallback literals
+  (`?? '//'`) anywhere in the module.
+
+### Architectural notes
+
+- Added `stale-allow` as a new `IdentityKind` (Rule 9 + Rule 10
+  compliant: identityFor case + producer + fixture row +
+  removed from `DEFERRED_KINDS` once the gather pass landed).
+- The hint formatter (block-time guidance for blocked findings)
+  consumes the canonical `BaselineEntry` discriminated union
+  directly — no invented intermediate "BlockingFinding" shape.
+  TypeScript exhaustiveness across 6+ switches guarantees new
+  finding kinds can't ship without matching cases.
+- `dxkit-action` skill extended with the typed-category +
+  surfaces description; SAST recipe redirects from semgrep's
+  `// nosemgrep:` to dxkit's `// dxkit-allow:` (single canonical
+  suppression surface across all scanners).
+
 ## [2.5.2] - 2026-05-22
 
 The "scaffold UX + lifecycle skills + setup automation" release. Closes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,6 +226,13 @@ imports, testFramework, licenses }`. Each is a `CapabilityProvider`
   `cliBinaries[]` (commands `doctor` checks for), `defaultVersion?`,
   `versionKey?` (lookup key in `DetectedStack['versions']`; defaults
   to `id` — only override for legacy template-name compat)
+- **Allowlist comment syntax** (2.6) — `commentSyntax: { lineComment,
+blockCommentStart?, blockCommentEnd? }`. Drives inline allowlist
+  annotation insertion (`<lineComment> dxkit-allow:<category>
+reason="..."`). Hash-style (`#`) for python, ruby, shell;
+  slash-style (`//` + `/* */`) for typescript, go, rust, csharp,
+  kotlin, java. Without it, the inline-allowlist code path can't
+  render correct comments for this language.
 - **Lint severity** — `mapLintSeverity?(ruleId)` if your linter has
   rule IDs you can tier into critical/high/medium/low
 - **Per-pack pattern registries** (CI-enforced; the contract test

--- a/README.md
+++ b/README.md
@@ -236,6 +236,58 @@ auto-discovered when present, compiled-in defaults otherwise.
 
 ---
 
+## Allowlist: per-finding suppression
+
+The baseline handles codebase-wide brownfield acceptance ("today's
+mess is grandfathered; tomorrow's must be net-new improvement").
+For per-finding decisions — false positives, intentional test
+fixtures, externally-mitigated risks, deliberately deferred work —
+use the [allowlist](docs/commands/allowlist.md).
+
+Five typed categories signal **why** a finding is suppressed:
+
+| Category               | Meaning                                           | Expiry                         |
+| ---------------------- | ------------------------------------------------- | ------------------------------ |
+| `false-positive`       | Scanner is wrong about this finding               | Optional                       |
+| `test-fixture`         | Intentional pattern in fixture / test code        | Optional                       |
+| `mitigated-externally` | Real risk neutralized at runtime (WAF, env, etc.) | Optional                       |
+| `accepted-risk`        | Real risk, team accepts, signed off               | **Required** (default 90 days) |
+| `deferred`             | Real, will fix later, tracked work                | **Required**                   |
+
+Two surfaces. Inline annotation for source-anchored findings:
+
+```python
+api_key = "sk_test_xxxx"  # dxkit-allow:test-fixture reason="placeholder in unit test"
+```
+
+File-level (`.dxkit/allowlist.json`) for cross-file findings or any
+suppression that needs an expiry. New entries appear in the PR-
+comment automation so reviewers see suppressions being introduced
+and can sanity-check the rationale before approving. `audit` /
+`prune` subcommands handle stale + soon-to-expire entries.
+
+**Strict cleanup**: orphaned `dxkit-allow:` annotations become
+`stale-allow` findings on the next scan. dxkit refuses to allowlist
+those — the only remediation is to remove the annotation. This is
+the TypeScript `@ts-expect-error` pattern: tools that surface their
+own stale suppressions force cleanup, preventing the annotation
+graveyard.
+
+```bash
+# The block message from `guardrail check` prints the exact command
+# to paste for any blocked finding — file:line for inline-compatible
+# kinds, --fingerprint for everything else.
+vyuh-dxkit allowlist add src/auth/oauth.ts:42 \
+    --category=test-fixture --reason="placeholder in unit test"
+
+vyuh-dxkit allowlist audit              # find stale + soon-to-expire entries
+```
+
+See [`vyuh-dxkit allowlist`](docs/commands/allowlist.md) for the
+full surface.
+
+---
+
 ## Git-aware identity matching
 
 A regression check is only useful if the matcher can tell _old issue
@@ -458,6 +510,28 @@ dxkit is local-first.
       cross-file refactor detection (3.0)
 
 ---
+
+## Reporting issues
+
+If a scanner is too noisy, a finding is missing, dxkit itself is
+broken, or the docs are unclear, the fastest path to the dxkit team
+is the built-in issue subcommand:
+
+```bash
+vyuh-dxkit issue --type=false-positive \
+    --fingerprint=<id> \
+    --about="the scanner flags my intentional X as a Y"
+
+vyuh-dxkit issue --type=bug --about="vyuh-dxkit doctor crashes on macOS arm64"
+
+vyuh-dxkit issue --type=feature-request --about="add SARIF export"
+```
+
+It opens a pre-filled [GitHub issue](https://github.com/vyuh-labs/dxkit/issues)
+in your browser with dxkit version + platform info already populated.
+Nothing is submitted until you click "Submit" — you review the
+prefill first. See [`vyuh-dxkit issue`](docs/commands/issue.md) for
+the full reference.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@ to re-activate manually: `vyuh-dxkit hooks activate`.
 | [`baseline create`](commands/baseline.md)       | Write per-finding identities to `.dxkit/baselines/<name>.json` |
 | [`baseline show`](commands/baseline.md)         | Pretty-print or filter the on-disk baseline                    |
 | [`guardrail check`](commands/guardrail.md)      | Diff current scan vs. baseline; block on net-new regressions   |
+| [`allowlist add`](commands/allowlist.md)        | Suppress a specific finding (typed category + reason + expiry) |
+| [`allowlist audit`](commands/allowlist.md)      | Surface stale / soon-to-expire / missing-rationale entries     |
 | [`.dxkit/policy.json`](configuration/policy.md) | Tune which classifications block vs. warn                      |
 
 ## What you can run
@@ -58,6 +60,8 @@ Once dxkit + its tools are installed, here's the command surface:
 | [`guardrail check`](commands/guardrail.md)                       | "Block on net-new regressions vs. the baseline"               | 30s-2m                             |
 | [`setup-branch-protection`](commands/setup-branch-protection.md) | "Mark `dxkit-guardrails` as required check on default branch" | < 5 sec                            |
 | [`setup-prebuild`](commands/setup-prebuild.md)                   | "Configure Codespaces prebuild (cold-start ~7 min → ~30s)"    | < 5 sec                            |
+| [`allowlist`](commands/allowlist.md)                             | "Suppress a specific finding with typed reason + expiry"      | < 1 sec                            |
+| [`issue`](commands/issue.md)                                     | "Open a pre-filled GitHub Issue against dxkit"                | < 5 sec                            |
 
 ## Configuration
 

--- a/docs/commands/allowlist.md
+++ b/docs/commands/allowlist.md
@@ -1,0 +1,234 @@
+# `vyuh-dxkit allowlist`
+
+Per-finding suppression with a typed-category audit trail. The
+allowlist is dxkit's deliberate escape hatch for findings you can't
+fix today: false positives, intentional test-fixture patterns, real
+risks mitigated externally, or work you're deferring with an
+explicit deadline.
+
+The principle: **easier than disabling dxkit, harder than actually
+fixing the issue.** Every allowlist entry carries a typed category,
+a required reason, and (when relevant) an expiry. Reviewers see new
+entries in the PR comment automatically; the `audit` subcommand
+surfaces stale + soon-to-expire entries for periodic cleanup.
+
+## When to use this command
+
+Use the allowlist when fixing isn't viable today and the finding
+deserves explicit acknowledgement rather than silent suppression.
+Common scenarios:
+
+- **False positive**: the scanner is wrong about this specific
+  finding. Allowlist with `category=false-positive` + a reason
+  describing why. Bonus: consider reporting the false positive via
+  [`vyuh-dxkit issue`](./issue.md) so the team can improve the rule.
+- **Intentional test fixture**: the "secret" is a placeholder API
+  key in a test file, or the SAST finding is in a deliberately-bad
+  example. Allowlist with `category=test-fixture`.
+- **Mitigated externally**: a dep-vuln is real but the attack vector
+  is blocked by a WAF rule, network policy, or runtime guard.
+  Allowlist with `category=mitigated-externally` + a reason
+  describing the mitigation.
+- **Accepted risk**: the team has reviewed the finding and accepts
+  it for now. Allowlist with `category=accepted-risk` + an explicit
+  `--expires` date. The expiry forces re-review when the deadline
+  passes.
+- **Deferred fix**: the work is tracked elsewhere (a ticket, a
+  next-sprint plan). Allowlist with `category=deferred` + an
+  `--expires` matching the deadline.
+
+If you find yourself reaching for the allowlist many times for the
+same scanner rule, that's signal — open a `--type=false-positive`
+or `--type=missing-finding` issue (see [`vyuh-dxkit issue`](./issue.md))
+so the team can tune the underlying detection.
+
+## The five categories
+
+| Category               | Meaning                                    | Expiry       | Surfaces                        |
+| ---------------------- | ------------------------------------------ | ------------ | ------------------------------- |
+| `false-positive`       | Scanner is wrong about this finding        | Optional     | Inline annotation OR file-level |
+| `test-fixture`         | Intentional pattern in fixture / test code | Optional     | Inline annotation OR file-level |
+| `mitigated-externally` | Real risk but neutralized at runtime       | Optional     | Inline annotation OR file-level |
+| `accepted-risk`        | Real risk, team accepts, signed off        | **Required** | File-level only                 |
+| `deferred`             | Real, will fix later, tracked work         | **Required** | File-level only                 |
+
+`accepted-risk` and `deferred` require an expiry because they
+describe assertions that should age out. By default the CLI sets
+`--expires` to 90 days from today (industry convention, matches
+Snyk / Dependabot).
+
+## The two surfaces
+
+### Inline annotation
+
+For source-anchored findings (secrets, code patterns, config
+issues, hygiene markers, dep-vuln imports) with an inline-compatible
+category. The annotation lives next to the line it suppresses:
+
+```python
+api_key = "sk_test_xxxx"  # dxkit-allow:test-fixture reason="placeholder in unit test"
+```
+
+Or above for long source lines:
+
+```typescript
+// dxkit-allow:false-positive reason="regex matches intentional placeholder"
+const apiKey = 'sk_test_xxxx';
+```
+
+The annotation grammar is uniform across every language; only the
+comment marker varies (`#` for python/ruby, `//` for typescript/go/
+rust/csharp/kotlin/java). Don't type it by hand — let the CLI
+insert it for you (see `allowlist add` below).
+
+### File-level allowlist (`.dxkit/allowlist.json`)
+
+For everything else:
+
+- Cross-file or whole-file findings (`duplication`, `coverage-gap`,
+  `test-gap`, `god-file`, `large-file`, `stale-file`)
+- Findings with no stable single-line attachment (`dep-vuln`,
+  `secret-hmac`)
+- Any `accepted-risk` or `deferred` suppression, regardless of kind
+  (those categories need expiry + sign-off, which inline
+  annotations can't carry)
+
+The file is committed to git so the team's suppression posture is
+reviewable in PRs. In **sanitized** mode (the default for public
+repos), the file carries only `fingerprint + kind + category`; the
+human-readable reason + addedBy live in a gitignored sidecar
+(`.dxkit/allowlist-reasons.local.json`).
+
+## Subcommands
+
+### `add` — create a new suppression
+
+```bash
+# Inline annotation at file:line — for source-anchored findings
+# with an inline-compatible category
+vyuh-dxkit allowlist add src/auth/oauth.ts:42 \
+    --category=test-fixture \
+    --reason="placeholder in unit test"
+
+# File-level entry — for any kind + category not eligible for
+# inline (or when you want the entry persisted to .dxkit/allowlist.json)
+vyuh-dxkit allowlist add \
+    --fingerprint=a3f9c0e8b7d2e1f4 \
+    --kind=dep-vuln \
+    --category=accepted-risk \
+    --reason="WAF rule X mitigates this CVE" \
+    --expires=2026-08-22
+
+# Acknowledge severity explicitly for accepted-risk on high/critical
+vyuh-dxkit allowlist add \
+    --fingerprint=a3f9c0e8b7d2e1f4 \
+    --kind=secret \
+    --category=accepted-risk \
+    --acknowledged-severity=high \
+    --reason="..."
+```
+
+**Tip**: the guardrail check's block message prints the exact
+`allowlist add` command to paste for every blocked finding. Use the
+guardrail output directly rather than constructing the command by
+hand.
+
+### `list` — review every entry
+
+```bash
+vyuh-dxkit allowlist list             # text table
+vyuh-dxkit allowlist list --json      # structured JSON
+```
+
+### `show` — inspect one entry
+
+```bash
+vyuh-dxkit allowlist show <fingerprint>
+vyuh-dxkit allowlist show <fingerprint> --json
+```
+
+### `audit` — find stale + soon-to-expire entries
+
+```bash
+vyuh-dxkit allowlist audit               # default: 14-day soon window
+vyuh-dxkit allowlist audit --soon-days=30
+vyuh-dxkit allowlist audit --json
+```
+
+Three buckets:
+
+- **Expired** — entries past `expiresAt`. Run `prune` to remove.
+- **Soon to expire** — within `--soon-days` (default 14). Either
+  re-justify (extend expiry) or remove (let the underlying finding
+  re-flag on the next scan).
+- **Missing rationale** — entries with empty `reason` field. In
+  full mode this should never happen; in sanitized mode it means
+  the gitignored reasons sidecar isn't synced locally.
+
+### `prune` — remove expired entries
+
+```bash
+vyuh-dxkit allowlist prune              # default: removes expired entries
+vyuh-dxkit allowlist prune --dry-run    # preview without writing
+vyuh-dxkit allowlist prune --json       # structured envelope
+```
+
+## Stale annotations (the strict-cleanup loop)
+
+If you allowlist a finding inline, then later fix it (or the
+scanner stops flagging it), the orphaned annotation becomes a
+`stale-allow` finding on the next scan. Remediation is always the
+same: **remove the orphaned `dxkit-allow:` comment**. The allowlist
+explicitly refuses to suppress `stale-allow` findings — allowing the
+"please clean up your annotations" warning would defeat the whole
+strict-cleanup model.
+
+This pattern is borrowed from TypeScript's `@ts-expect-error`: tools
+that surface their own stale suppressions force the dev to clean up,
+preventing the annotation graveyard pattern common to less strict
+tools.
+
+## How reviewers see new entries
+
+The `dxkit-guardrails.yml` workflow (installed by
+`vyuh-dxkit init --with-ci`) posts a PR comment with the guardrail
+report. The comment now includes an **"Allowlist activity"**
+section listing every entry added (or removed) on this branch
+versus the baseline commit:
+
+```
+### Allowlist activity (1)
+
+Suppressions changed between baseline @ a3f9c0e8 and current.
+Review each entry's category + reason + expiry before approving.
+
+**Added (1)** — new suppressions on this branch:
+
+| Fingerprint | Kind | Category | Expires | Reason |
+|---|---|---|---|---|
+| `a3f9c0e8b7d2e1f4` | dep-vuln | accepted-risk | 2026-08-22 | WAF rule X mitigates this CVE |
+```
+
+Reviewers see the suppressions being introduced and can sanity-check
+the typed category + reason + expiry before approving — the social-
+review pressure that keeps the allowlist healthy.
+
+## Reporting a false positive upstream
+
+When you allowlist with `category=false-positive`, consider also
+opening an issue against dxkit so the team can fix the underlying
+detection:
+
+```bash
+vyuh-dxkit issue --type=false-positive --fingerprint=<id> \
+    --about="the scanner flags my intentional X as a Y"
+```
+
+See [`vyuh-dxkit issue`](./issue.md) for full details.
+
+## Related
+
+- [`vyuh-dxkit guardrail check`](./guardrail.md) — blocks PRs on new findings; allowlist suppresses individual findings
+- [`vyuh-dxkit baseline create`](./baseline.md) — locks in the codebase-wide brownfield acceptance; the allowlist is the per-finding cousin
+- [`vyuh-dxkit issue`](./issue.md) — report a false positive / bug / feature request to the dxkit team
+- Configuration: [`.dxkit/policy.json`](../configuration/policy.md) — broad-classification tuning; the allowlist handles per-finding suppression

--- a/docs/commands/guardrail.md
+++ b/docs/commands/guardrail.md
@@ -52,6 +52,21 @@ Exit code: `1` when the policy blocks any pair, `0` otherwise.
 | `uncertain`         | Below every threshold; manual review                                       | warns          |
 
 Customise the block/warn split with [`.dxkit/policy.json`](../configuration/policy.md).
+For **per-finding** suppression (false positives, intentional test
+fixtures, accepted risks), use the [allowlist](./allowlist.md) — the
+guardrail's block message prints the exact `allowlist add` command
+for every blocked finding.
+
+## Markdown output: PR-comment review
+
+`guardrail check --markdown` (used by the `dxkit-guardrails.yml`
+workflow installed by `init --with-ci`) emits a markdown report
+that's posted as a sticky PR comment on every pull request. The
+report now includes an **"Allowlist activity"** section listing
+every allowlist entry added (or removed) on this branch versus the
+baseline commit. Reviewers see new suppressions being introduced —
+typed category, reason, expiry — and can sanity-check the rationale
+before approving.
 
 ## Examples
 

--- a/docs/commands/issue.md
+++ b/docs/commands/issue.md
@@ -1,0 +1,132 @@
+# `vyuh-dxkit issue`
+
+Open a pre-filled GitHub Issue against `vyuh-labs/dxkit` in your
+default browser. Use it when you want to report a false positive,
+a missing finding, a dxkit bug, a feature request, or a docs gap.
+
+The dxkit team triages issues in GitHub Issues — this CLI is the
+fastest path from "I noticed something" to "the team has a ticket
+they can search, dedup, and assign."
+
+## Why this exists
+
+The team needs customer signal to improve dxkit:
+
+- **False positives** tell us a scanner rule is too noisy.
+- **Missing findings** tell us a rule is too narrow.
+- **Bugs** tell us the install / hook / report pipeline broke.
+- **Feature requests** tell us where the product should grow.
+- **Docs gaps** tell us where the install/usage story confuses real users.
+
+Sending these to GitHub Issues (rather than email or a web form)
+keeps triage centralized — labels, assignees, dedup search,
+notifications. You also get a public link to your own issue so you
+can subscribe to status updates.
+
+## Usage
+
+```bash
+# Interactive — opens browser to the new-issue form pre-filled
+# with env info + your description
+vyuh-dxkit issue --type=bug --about="vyuh-dxkit doctor crashes on macOS arm64"
+
+# Report a false positive against a specific finding
+vyuh-dxkit issue --type=false-positive \
+    --fingerprint=a3f9c0e8b7d2e1f4 \
+    --about="the scanner flags my intentional test-fixture API key"
+
+# Feature request — no fingerprint needed
+vyuh-dxkit issue --type=feature-request \
+    --about="add SARIF export to vulnerabilities subcommand"
+
+# Print URL to stdout instead of opening a browser
+# (useful in CI / SSH sessions without a browser handler)
+vyuh-dxkit issue --type=docs --about="..." --no-browser
+```
+
+## Types
+
+| `--type`          | When to use                                              | GitHub label      |
+| ----------------- | -------------------------------------------------------- | ----------------- |
+| `false-positive`  | Scanner flagged something that isn't actually an issue   | `false-positive`  |
+| `missing-finding` | Scanner should have flagged something but didn't         | `missing-finding` |
+| `bug`             | dxkit itself is broken (CLI crashes, report wrong, etc.) | `bug`             |
+| `feature-request` | New functionality you'd like                             | `enhancement`     |
+| `docs`            | Documentation is wrong / missing / unclear               | `documentation`   |
+
+## What gets pre-filled
+
+The CLI builds the GitHub Issues URL with:
+
+- **Title**: `[Type] <truncated about>` or `[Type] finding <fingerprint>`
+- **Labels**: per-type from the table above
+- **Body**: dxkit version, Node version, platform/arch, your
+  `--about` description, and optionally the finding fingerprint —
+  plus placeholder sections for "what you expected," "how to
+  reproduce," and "anything else"
+
+Example body:
+
+```markdown
+**Type:** false-positive
+**dxkit version:** 2.6.0
+**Node version:** v22.1.0
+**Platform:** linux / x64
+**Finding fingerprint:** `a3f9c0e8b7d2e1f4`
+
+## What happened
+
+the scanner flags my intentional test-fixture API key
+
+## What you expected
+
+<!-- Describe the behavior you expected -->
+
+...
+```
+
+You review the prefill in the browser and edit before clicking
+"Submit new issue."
+
+## Privacy
+
+**Nothing is submitted automatically.** The CLI builds a URL with
+query-string pre-fill and either opens it in your browser or prints
+it to stdout. The submission happens when YOU click "Submit" in the
+browser, after reviewing what's pre-filled.
+
+The prefill contains:
+
+- dxkit version (already visible in `npx vyuh-dxkit --version`)
+- Node version + platform + arch (standard env info)
+- Your `--about` text (whatever you typed)
+- The fingerprint if you passed `--fingerprint` (a 16-char hex
+  identifier; useful for reproducing the scanner's behavior)
+
+The prefill does NOT contain:
+
+- Source code from your repo
+- Your project name or any path that would identify the customer
+- Any allowlist reason / addedBy data
+
+If you want to include more context (logs, screenshots), you can
+add them in the browser before submitting.
+
+## Flags
+
+```
+--type=<type>             Required. One of: false-positive, missing-finding,
+                          bug, feature-request, docs.
+--about=<text>            Free-form description of the issue. Truncated to
+                          60 chars in the title; full text in the body.
+--fingerprint=<id>        The 16-char hex fingerprint of a specific finding.
+                          Surfaces in the body so triage can reproduce.
+--no-browser              Print the URL to stdout instead of opening a browser.
+                          Use in CI / SSH sessions.
+```
+
+## Related
+
+- [`vyuh-dxkit allowlist add --category=false-positive`](./allowlist.md) — suppress a specific false positive locally while you wait for the upstream fix
+- [`vyuh-dxkit doctor`](./doctor.md) — diagnose install issues before reporting a bug
+- The [`dxkit-fix` skill](https://github.com/vyuh-labs/dxkit) walks you through doctor-driven repair before you reach for an issue

--- a/docs/configuration/dxkit-ignore.md
+++ b/docs/configuration/dxkit-ignore.md
@@ -15,6 +15,21 @@ test-gap discovery — all of them).
 - Long-running migration artifacts you'll clean up later but shouldn't
   count against the current health score
 
+## When NOT to use it
+
+`.dxkit-ignore` is **path-based scoping** — files matched here are
+never scanned, no findings emitted, no scoring impact. That's the
+right tool for "this code isn't ours to maintain."
+
+It is NOT the tool for **per-finding suppression**. If dxkit scans
+a file and emits a specific finding you want to suppress (false
+positive, intentional test fixture, externally mitigated), use the
+[allowlist](../commands/allowlist.md) — it carries a typed category
+
+- reason + (when relevant) expiry, and stays auditable. Ignoring
+  the whole file would also silence any other finding in that file
+  that you DO care about.
+
 ## File location
 
 Place `.dxkit-ignore` at the repo root (where `.git/` lives). DXKit

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -9,6 +9,20 @@ check` auto-loads it. The `--policy <path>` flag overrides the
 auto-discovery and points at an explicit file. When no policy is found,
 the compiled-in defaults apply.
 
+## When NOT to use this file
+
+The policy file is for **broad-classification tuning** — "block on
+every `added` finding," "warn on `tooling_drift`," etc. It applies
+to all findings of a given classification.
+
+For **per-finding suppression** — "suppress this specific finding
+because it's a false positive / test fixture / mitigated externally"
+— use the [allowlist](../commands/allowlist.md) instead. The
+allowlist carries a typed category + required reason + (when
+relevant) expiry per entry, and shows up in PR-comment review.
+Per-finding decisions belong in the allowlist; classification-wide
+tuning belongs here.
+
 ## Defaults
 
 ```json

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -232,7 +232,34 @@ present.
 See [`baseline`](commands/baseline.md) and [`guardrail`](commands/guardrail.md)
 for the full surface.
 
-## 6. What to do when something goes wrong
+## 6. Suppress individual findings
+
+When the guardrail blocks a finding you can't fix today — a false
+positive, an intentional test fixture, a real risk mitigated
+externally — use the [allowlist](commands/allowlist.md). Every
+entry carries a typed category and a required reason:
+
+```bash
+# Inline annotation (for source-anchored findings)
+vyuh-dxkit allowlist add src/auth/oauth.ts:42 \
+    --category=test-fixture \
+    --reason="placeholder in unit test"
+
+# File-level entry (for cross-file findings or accepted-risk / deferred)
+vyuh-dxkit allowlist add \
+    --fingerprint=<id-from-guardrail-output> \
+    --kind=dep-vuln \
+    --category=accepted-risk \
+    --reason="WAF rule mitigates this CVE" \
+    --expires=2026-08-22
+```
+
+The guardrail's block message prints the exact `allowlist add`
+command to paste for every blocked finding — copy-paste rather
+than constructing by hand. Periodic `vyuh-dxkit allowlist audit`
+surfaces stale + soon-to-expire entries.
+
+## 7. What to do when something goes wrong
 
 ```bash
 vyuh-dxkit doctor
@@ -242,10 +269,22 @@ Diagnoses common issues — missing tools, version mismatches, package
 manager misconfig, etc. It's the first stop when a report fails or
 produces no output.
 
+If you've hit a false positive, missing finding, dxkit bug, or docs
+gap, open a pre-filled GitHub issue:
+
+```bash
+vyuh-dxkit issue --type=false-positive --about="..."
+vyuh-dxkit issue --type=bug --about="..."
+```
+
+See [`vyuh-dxkit issue`](commands/issue.md) for full details.
+
 ## What's next
 
 - Per-command pages in [`commands/`](commands/) describe options +
   output shape in detail.
+- [Allowlist reference](commands/allowlist.md) — per-finding
+  suppression with typed categories + expiry.
 - [Exclude noisy paths](configuration/dxkit-ignore.md) from analysis
   with `.dxkit-ignore`.
 - [Language pack detection](configuration/language-packs.md) explains

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -583,7 +583,7 @@ for f in $FINGERPRINT_HELPER_ALLOWLIST; do
   ALLOW_FILTER_FP="$ALLOW_FILTER_FP -e ^${f}:"
 done
 
-ROGUE_HASH=$(grep -rnE "createHash[[:space:]]*\(" src/analyzers/ src/baseline/ 2>/dev/null \
+ROGUE_HASH=$(grep -rnE "createHash[[:space:]]*\(" src/analyzers/ src/baseline/ src/allowlist/ 2>/dev/null \
   | grep -v "// fingerprint-helper-ok" \
   | grep -v -E ':[[:space:]]*(//|\*)' \
   | { [ -n "$ALLOW_FILTER_FP" ] && grep -v $ALLOW_FILTER_FP || cat; })
@@ -593,6 +593,9 @@ if [ -n "$ROGUE_HASH" ]; then
   echo "   → Use computeFingerprint or computeCodeFingerprint from src/analyzers/tools/fingerprint.ts."
   echo "   → For new finding kinds, extend src/baseline/finding-identity.ts:identityFor"
   echo "     with a new IdentityInput discriminant rather than hashing inline."
+  echo "   → The allowlist module CONSUMES fingerprints (string-compares only) —"
+  echo "     it never computes identity. A createHash() inside src/allowlist/ is"
+  echo "     almost certainly a shortcut that should route through identityFor."
   echo "   → Annotate '// fingerprint-helper-ok' for justified non-identity hashing."
   ERRORS=$((ERRORS + 1))
 fi
@@ -692,6 +695,64 @@ if [ -n "$DEAD_CONDS" ]; then
   echo "     or remove the IF_ entry from getConditions() in src/constants.ts."
   echo "   → Annotate '// arch-check-ok' on the constants.ts line for intentional"
   echo "     ahead-of-template additions (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# =============================================================================
+# Allowlist canonical-entry-point discipline (added 2026-05-22).
+# =============================================================================
+#
+# The allowlist module shipped by `src/allowlist/` has two contracts:
+#
+#   - On-disk IO: `.dxkit/allowlist.json` (committed) and the
+#     gitignored sidecar `.dxkit/allowlist-reasons.local.json` are
+#     read/written ONLY through `loadAllowlist()` / `saveAllowlist()`
+#     in `src/allowlist/file.ts`. Bypassing means schema validation
+#     + sidecar merging gets skipped silently; a customer's
+#     hand-edited file could pass the guardrail with malformed
+#     entries that break later runs.
+#
+#   - Per-language comment syntax: inline annotation generation
+#     reads `LanguageSupport.commentSyntax.lineComment`. A fallback
+#     like `?? '//'` would silently produce wrong-language comments
+#     for a future pack whose declaration is missing — defeating
+#     the whole point of the recipe enforcement layer (the contract
+#     test would catch the missing field, but the fallback would
+#     mask the failure if it sneaks past the test).
+#
+# Both checks are scoped tightly so the rules don't accumulate false
+# positives in unrelated code.
+#
+# Annotate `// allowlist-io-ok` (rule 1) or `// comment-syntax-ok`
+# (rule 2) on the violating line for justified exceptions (today:
+# zero needed).
+
+# Rule 1: no direct allowlist.json IO outside src/allowlist/
+ROGUE_ALLOWLIST_IO=$(grep -rnE "['\"](allowlist\.json|allowlist-reasons\.local\.json)['\"]" src/ 2>/dev/null \
+  | grep -v "^src/allowlist/" \
+  | grep -v "// allowlist-io-ok" \
+  | grep -v -E ':[[:space:]]*(//|\*)')
+if [ -n "$ROGUE_ALLOWLIST_IO" ]; then
+  echo "❌ Allowlist IO bypass: direct allowlist.json reference outside src/allowlist/:"
+  echo "$ROGUE_ALLOWLIST_IO"
+  echo "   → Use loadAllowlist(cwd) / saveAllowlist(cwd, file) from"
+  echo "     src/allowlist/file.ts so schema validation + sidecar merging run."
+  echo "   → Annotate '// allowlist-io-ok' for justified exceptions (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Rule 2: no comment-marker fallback literals in src/allowlist/
+ROGUE_COMMENT_FALLBACK=$(grep -rnE "(\?\?|\|\|)[[:space:]]*['\"](//|#)['\"]" src/allowlist/ 2>/dev/null \
+  | grep -v "// comment-syntax-ok" \
+  | grep -v -E ':[[:space:]]*(//|\*)')
+if [ -n "$ROGUE_COMMENT_FALLBACK" ]; then
+  echo "❌ Allowlist comment-syntax fallback: hardcoded language literal as default:"
+  echo "$ROGUE_COMMENT_FALLBACK"
+  echo "   → Inline annotation code MUST drive comment markers from"
+  echo "     LanguageSupport.commentSyntax.lineComment, not a hardcoded default."
+  echo "   → If the language has no commentSyntax, return null / throw — never"
+  echo "     fall back to '//' or '#' (defeats the recipe enforcement layer)."
+  echo "   → Annotate '// comment-syntax-ok' for justified exceptions (rare)."
   ERRORS=$((ERRORS + 1))
 fi
 

--- a/scripts/scaffold-language.js
+++ b/scripts/scaffold-language.js
@@ -273,6 +273,22 @@ export const ${id}: LanguageSupport = {
   id: '${id}',
   displayName: '${displayName}',
 
+  // TODO(${id}): line-comment syntax used by this language. Drives the
+  // allowlist feature's inline-annotation insertion. Required for any
+  // pack that supports inline allowlists (every pack today).
+  //   Hash-style:    { lineComment: '#' }                 // python, ruby, shell
+  //   Slash-style:   { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' }
+  //                    // typescript, go, rust, csharp, kotlin, java
+  // Block-comment fields are reserved for files where line-comment
+  // syntax is unavailable. Omit if not applicable for this language.
+  //
+  // The placeholder below is intentionally empty so the languages-
+  // contract test FAILS until the contributor fills it in (the
+  // assertion checks lineComment.length > 0). Do not "helpfully"
+  // populate this with a default — that would let an unfilled
+  // placeholder leak past CI.
+  commentSyntax: { lineComment: '' },
+
   // TODO(${id}): list source-file extensions (with leading dot).
   sourceExtensions: [],
 
@@ -698,7 +714,7 @@ const nextSteps = [
   HR,
   '',
   `  1. Implement detect${capitalize(id)}() in src/languages/${id}.ts`,
-  `  2. Populate sourceExtensions, testFilePatterns, tools, cliBinaries, defaultVersion, permissions`,
+  `  2. Populate commentSyntax, sourceExtensions, testFilePatterns, tools, cliBinaries, defaultVersion, permissions`,
   `  3. Add TOOL_DEFS entries for ${id}'s tools in src/analyzers/tools/tool-registry.ts`,
   `  4. Harvest real tool-output bytes per test/fixtures/raw/${id}/HARVEST.md`,
   `     (the C# defect lesson — parsers MUST be unit-tested against real bytes)`,

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -47,15 +47,17 @@ npx vyuh-dxkit vulnerabilities --json | jq '.summary.findings'
 
 Don't try to redact the secret in place — the git history still has it. Rotation is the only true fix.
 
+If the "secret" is actually a placeholder in test code (e.g., `"sk_test_xxxxxxxxxxxx"` with no real credential value), confirm with the developer and allowlist via `dxkit-allow:test-fixture` — see "Allowlisting (when fix is not viable)" below.
+
 ### SAST finding (semgrep)
 
 ```bash
 # 1. Read the finding's rule + line range from the report
 # 2. Open the file, understand why semgrep flagged it
-# 3. Either FIX (preferred) or SUPPRESS (carefully)
+# 3. Either FIX (preferred) or ALLOWLIST (carefully — see below)
 ```
 
-Suppression is `// nosemgrep: <rule-id>` on the offending line. Use sparingly — every suppression is a future maintenance burden. Better: fix the underlying issue.
+If the finding is a true false positive or intentional pattern (test fixture, mitigated externally), suppress via dxkit's allowlist — NOT via semgrep's `// nosemgrep:`. The dxkit allowlist is the canonical surface (single source of truth across every scanner), carries a typed category + reason, and is audit-trackable through `vyuh-dxkit allowlist audit`. See "Allowlisting (when fix is not viable)" below.
 
 ### Dependency vulnerability
 
@@ -69,6 +71,8 @@ npx vyuh-dxkit vulnerabilities
 For peer-dep conflicts: `npm install <pkg>@<patched-version> --legacy-peer-deps` (matches the post-create.sh fallback chain).
 
 For Python: `pip install --upgrade <pkg>=<patched>` then re-pip-freeze. For Go: `go get <pkg>@<patched>` then `go mod tidy`. For Ruby: edit Gemfile, `bundle update <pkg>`. For Rust: `cargo update -p <pkg> --precise <patched>`.
+
+If no patched version exists OR the upgrade breaks other constraints AND the risk is mitigated externally (network policy, WAF, runtime guard), allowlist with `category=mitigated-externally` and a reason describing the mitigation. If the team is accepting the risk while waiting on a fix, `category=accepted-risk` + an expiry tied to the fix deadline.
 
 ### Test gap
 
@@ -93,6 +97,79 @@ Don't write tests that just import the module — write tests that exercise beha
 
 If the finding is a false positive, add `// slop-ok: <reason>` on the offending line (or `# slop-ok` for non-JS).
 
+## Allowlisting (when fix is not viable)
+
+**Fix first.** The allowlist is the SECOND option, not the first. When you reach for it, choose deliberately — every allowlist entry is a future maintenance burden the customer's team will revisit.
+
+Five typed categories signal WHY the suppression is in place:
+
+| Category | Meaning | Where it lives |
+|---|---|---|
+| `false-positive` | Scanner is wrong about this code | Inline annotation OR file-level |
+| `test-fixture` | Intentional pattern in a fixture / test file | Inline annotation OR file-level |
+| `mitigated-externally` | Real risk but neutralized at runtime (WAF, env, etc.) | Inline annotation OR file-level |
+| `accepted-risk` | Real risk, accepted by the team, signed off | File-level only (needs expiry + acknowledged severity) |
+| `deferred` | Real, will fix later, tracked work | File-level only (needs expiry) |
+
+`accepted-risk` and `deferred` require an `expiresAt` date because they describe assertions that should age out — by default the CLI sets 90 days. `false-positive`, `test-fixture`, and `mitigated-externally` describe assertions that don't naturally stale; they may omit expiry.
+
+### The two surfaces
+
+**Inline annotation** is the natural fit for source-anchored findings (secrets, code, config, dep-vuln, hygiene) with an inline-compatible category. The annotation lives next to the line it suppresses:
+
+```python
+api_key = "sk_test_xxxx"  # dxkit-allow:test-fixture reason="placeholder in unit test"
+```
+
+Or, for long source lines, above:
+
+```typescript
+// dxkit-allow:false-positive reason="regex matches intentional placeholder"
+const apiKey = "sk_test_xxxx";
+```
+
+The grammar is uniform across every language; only the comment marker varies (`#` for python/ruby, `//` for typescript/go/rust/csharp/kotlin/java). Don't type it by hand — let dxkit insert it for you (see CLI below).
+
+**File-level allowlist** lives at `.dxkit/allowlist.json` and is the surface for:
+
+- Cross-file or whole-file findings (duplication, coverage-gap, test-gap, god-file, large-file, stale-file)
+- Findings with no stable single-line attachment (dep-vuln, secret-hmac)
+- Any `accepted-risk` or `deferred` suppression regardless of kind
+
+### Add an allowlist entry (canonical path)
+
+Don't hand-edit the annotation comment or the JSON file — let the CLI insert it correctly:
+
+```bash
+# Inline annotation at file:line — for source-anchored findings
+# with an inline-compatible category
+npx vyuh-dxkit allowlist add src/auth/oauth.ts:42 \
+    --category=test-fixture --reason="placeholder in unit test"
+
+# File-level entry — for everything else (kind + fingerprint required;
+# both come straight from the guardrail check's output)
+npx vyuh-dxkit allowlist add --fingerprint=a3f9c0e8b7d2e1f4 \
+    --kind=dep-vuln --category=accepted-risk \
+    --reason="WAF rule X mitigates this CVE" --expires=2026-08-22
+```
+
+The guardrail's block message gives you the exact command to paste for every blocked finding — file path + line for inline-compatible kinds, fingerprint + kind for everything else. Just copy-paste.
+
+### Review what's allowlisted
+
+```bash
+npx vyuh-dxkit allowlist list             # all entries (text)
+npx vyuh-dxkit allowlist show <fingerprint>  # one entry's full detail
+npx vyuh-dxkit allowlist audit            # expired / soon-to-expire / missing-rationale
+npx vyuh-dxkit allowlist prune            # remove expired entries
+```
+
+Run `audit` periodically — `accepted-risk` and `deferred` entries that pass their expiry should either be re-justified (renew expiry) or pruned (remove the entry; the underlying finding will re-flag on the next scan).
+
+### Stale annotations
+
+If the underlying finding is fixed but the inline annotation lingers, the next scan emits a `stale-allow` finding pointing at the orphaned comment. The remediation is always to remove the annotation — dxkit refuses to allowlist a stale-allow finding (allowlisting the warning that an annotation is stale would defeat the entire model).
+
 ## Verification — never skip
 
 After each fix:
@@ -111,14 +188,19 @@ If the finding's still there: the fix didn't work, try again.
 
 ## Baseline decisions
 
-Once a finding is fixed AND verified gone, the workflow depends on what changed:
+Once a finding is processed (fixed, allowlisted, or accepted), the workflow depends on which path you took:
 
 | Scenario | Action |
 |---|---|
-| Fix landed via a code change | Commit the code. Baseline is unchanged. Future scans confirm the fix held. |
+| Fix landed via a code change | Commit the code. Baseline + allowlist are unchanged. Future scans confirm the fix held. |
+| Genuine false positive OR intentional pattern | `vyuh-dxkit allowlist add` with `category=false-positive` or `test-fixture`. Commit the annotation / allowlist file. Baseline is unchanged. |
+| Real risk neutralized externally (WAF, runtime guard) | `vyuh-dxkit allowlist add` with `category=mitigated-externally` + a reason describing the mitigation. Baseline unchanged. |
+| Real risk, accepted by team, won't fix | `vyuh-dxkit allowlist add` with `category=accepted-risk` + `--expires=YYYY-MM-DD` (defaults 90 days). Acknowledged-severity required for high/critical. |
+| Real risk, will fix later (tracked work) | `vyuh-dxkit allowlist add` with `category=deferred` + `--expires=YYYY-MM-DD`. The expiry forces re-review when the deadline passes. |
 | Fix landed via a config change (e.g., new entry in `.dxkit-ignore`) | Re-baseline: `npx vyuh-dxkit baseline create --force`. Commit both `.dxkit-ignore` and the new baseline. |
-| Finding accepted as known + not blocking | Re-baseline with explicit reason in the commit message. Future scans treat it as pre-existing, not net-new. |
-| Finding is genuinely a false positive | First try suppression on the offending line. If you can't suppress, re-baseline. |
+| Brownfield acceptance (the whole CURRENT state is known mess; future regressions must be net-new) | Re-baseline with an explicit reason in the commit message. Reserve this for the deliberate "draw a line here" moment, not per-finding suppression. |
+
+**Prefer the allowlist over re-baselining for per-finding decisions.** The allowlist carries a typed category + reason + (when relevant) expiry; the baseline carries only "this finding was here." Future maintainers reading `vyuh-dxkit allowlist show <fingerprint>` see WHY the suppression is in place; reading the baseline file shows only that the finding existed at capture time. Per-finding decisions belong in the allowlist; codebase-wide brownfield acceptance belongs in the baseline.
 
 **Never** re-baseline a finding silently — the commit message should explain why the regression is accepted. Future maintainers reading `git log .dxkit/baselines/` should see the rationale.
 
@@ -134,17 +216,20 @@ Exit 0 = your fixes didn't introduce any net-new regressions (you only removed/f
 
 ## When fixes get expensive
 
-Sometimes the right call is: don't fix, accept as baseline.
+Sometimes the right call is: don't fix, allowlist (or re-baseline if it's brownfield-wide).
 
 Examples:
-- Legacy code on a deprecation path (sunset > fix)
-- A SAST finding in vendored code you don't maintain
-- A test gap on a one-off script that doesn't merit tests
+- Legacy code on a deprecation path (sunset > fix) → `accepted-risk` with expiry matching the sunset date
+- A SAST finding in vendored code you don't maintain → `mitigated-externally` if the vendor patches separately, else `accepted-risk`
+- A test gap on a one-off script that doesn't merit tests → `accepted-risk`
+- An import line flagged by a scanner that you've reviewed and confirmed safe → `false-positive` inline annotation at the import
 
-In those cases: accept-as-baseline with a commit message explaining the call. dxkit's baseline IS designed to support this — the brownfield contract is "today's mess is acknowledged; tomorrow's must be a real improvement." Use it.
+In those cases: `vyuh-dxkit allowlist add` is the right tool for per-finding decisions (typed reason + expiry where relevant). Reserve "accept as baseline" for the deliberate one-shot brownfield moment ("this entire current state is known mess; today's findings are the new baseline"). The two surfaces complement each other — allowlist for individual judgment calls, baseline for the codebase-wide line in the sand.
 
 ## Hand-offs
 
 - For ignore-file edits as part of a fix → `dxkit-config` skill
 - For hook-related issues during a fix push → `dxkit-hooks` skill
 - For re-running reports between fixes → `dxkit-reports` skill
+- For broken dxkit install (hooks not firing, vyuh-dxkit not on PATH) → `dxkit-fix` skill
+- For allowlist management beyond the per-finding `add` path (auditing existing entries, pruning expired ones, reviewing the team's overall suppression posture) → run `npx vyuh-dxkit allowlist audit` / `list` / `prune` directly; no separate skill yet

--- a/src/allowlist/categories.ts
+++ b/src/allowlist/categories.ts
@@ -147,6 +147,15 @@ export const CATEGORIES_BY_KIND: Readonly<Record<IdentityKind, readonly Allowlis
   // here means the CLI rejects allowlist requests for license kinds
   // with a hint pointing at the inventory artifact.
   license: [],
+
+  // Stale-allow (orphaned inline allowlist annotation): never
+  // allowlisted. The right response is always "remove the stale
+  // annotation" — allowlisting the warning that an annotation is
+  // stale would defeat the entire strict-stale-detection model
+  // (TypeScript's @ts-expect-error pattern). Empty array means the
+  // CLI rejects with a hint pointing at the annotation's source
+  // location.
+  'stale-allow': [],
 };
 
 /**

--- a/src/allowlist/categories.ts
+++ b/src/allowlist/categories.ts
@@ -1,0 +1,203 @@
+/**
+ * Allowlist category taxonomy. Single source of truth for:
+ *   - Which categories exist
+ *   - Which categories require an expiry date
+ *   - Which categories may be expressed via inline source annotation
+ *   - Which categories apply to each `IdentityKind`
+ *   - Which finding kinds support inline annotations at all
+ *
+ * Pure module — no I/O, no analyzer dependencies. Consumed by the
+ * allowlist file reader/writer, the inline-annotation parser, the
+ * CLI, the block-time hint formatter, and the new `allowlistHits`
+ * baseline producer.
+ *
+ * See tmp/2.6-allowlist-design.md for the design discussion.
+ */
+
+import type { IdentityKind } from '../baseline/producers';
+
+export type AllowlistCategory =
+  | 'false-positive'
+  | 'test-fixture'
+  | 'mitigated-externally'
+  | 'accepted-risk'
+  | 'deferred';
+
+export const ALL_CATEGORIES: readonly AllowlistCategory[] = [
+  'false-positive',
+  'test-fixture',
+  'mitigated-externally',
+  'accepted-risk',
+  'deferred',
+];
+
+/**
+ * Categories that REQUIRE a finite expiry date. The file-level
+ * allowlist write-path rejects entries in these categories without
+ * an `expiresAt`. The CLI defaults `expiresAt` to 90 days out for
+ * these — see `defaultExpiryDate`.
+ *
+ * Categories OUTSIDE this set represent stable assertions about the
+ * code that don't naturally stale (a test fixture remains a test
+ * fixture; a false positive remains a false positive until the
+ * scanner rule changes). They may carry an `expiresAt` if the
+ * customer chooses, but it's not enforced.
+ */
+export const EXPIRING_CATEGORIES: ReadonlySet<AllowlistCategory> = new Set([
+  'accepted-risk',
+  'deferred',
+]);
+
+/**
+ * Categories that may be expressed via inline source annotation
+ * (`// dxkit-allow:<category> reason="..."`). The complement
+ * (`accepted-risk`, `deferred`) is file-only because those categories
+ * need fields (expiresAt, acknowledgedSeverity) that don't fit
+ * cleanly into a code comment.
+ */
+export const INLINE_COMPATIBLE_CATEGORIES: ReadonlySet<AllowlistCategory> = new Set([
+  'false-positive',
+  'test-fixture',
+  'mitigated-externally',
+]);
+
+/**
+ * Finding kinds that have a stable single-line attachment point and
+ * therefore support inline annotations. Kinds outside this set are
+ * file-only (whole-file findings, cross-file findings, gap findings).
+ *
+ * Inline-compatible:
+ *   - `secret` / `secret-hmac`: the source line is the credential
+ *   - `code` / `config`: the source line is the flagged pattern
+ *   - `dep-vuln`: annotate the import or first-use line
+ *   - `hygiene`: the source line carries the TODO/FIXME/HACK marker
+ *
+ * File-only (no single-line site):
+ *   - `duplication`: two locations across files
+ *   - `coverage-gap` / `test-gap` / `test-file-degradation`: file or
+ *     symbol-range level, not single-line
+ *   - `god-file` / `large-file` / `stale-file`: whole-file findings
+ *   - `license`: not a code position at all (moved to inventory in 2.6)
+ */
+export const INLINE_COMPATIBLE_KINDS: ReadonlySet<IdentityKind> = new Set<IdentityKind>([
+  'secret',
+  'secret-hmac',
+  'code',
+  'config',
+  'dep-vuln',
+  'hygiene',
+]);
+
+/**
+ * Categories applicable to each `IdentityKind`. Reflects what
+ * suppression rationales the kind can plausibly carry — a
+ * `coverage-gap` is rarely a "false positive" in the same way a
+ * scanner finding is; a `dep-vuln` is rarely a "test fixture."
+ *
+ * The CLI presents the applicable list as a multiple-choice prompt
+ * when the customer runs `vyuh-dxkit allowlist add` against a
+ * finding.
+ *
+ * The `Record<IdentityKind, ...>` ties this table to the canonical
+ * union: TypeScript fails the build when a new `IdentityKind`
+ * variant lands without a corresponding entry here.
+ */
+export const CATEGORIES_BY_KIND: Readonly<Record<IdentityKind, readonly AllowlistCategory[]>> = {
+  // Source-level security findings: every category applies
+  secret: ['false-positive', 'test-fixture', 'mitigated-externally', 'accepted-risk', 'deferred'],
+  'secret-hmac': [
+    'false-positive',
+    'test-fixture',
+    'mitigated-externally',
+    'accepted-risk',
+    'deferred',
+  ],
+  code: ['false-positive', 'test-fixture', 'mitigated-externally', 'accepted-risk', 'deferred'],
+  config: ['false-positive', 'test-fixture', 'mitigated-externally', 'accepted-risk', 'deferred'],
+
+  // Dependency vulnerabilities: rarely a test fixture (the dep is real);
+  // every other category applies
+  'dep-vuln': ['false-positive', 'mitigated-externally', 'accepted-risk', 'deferred'],
+
+  // Duplicate blocks: occasionally a false positive (jscpd matched
+  // generated code); otherwise accepted-risk or deferred
+  duplication: ['false-positive', 'accepted-risk', 'deferred'],
+
+  // Coverage / test gaps: not "false-positive" in any practical sense;
+  // only accepted-risk or deferred
+  'coverage-gap': ['accepted-risk', 'deferred'],
+  'test-gap': ['accepted-risk', 'deferred'],
+  'test-file-degradation': ['accepted-risk', 'deferred'],
+
+  // Whole-file findings: false-positive (file IS not actually large /
+  // stale / god when reviewed); otherwise accepted-risk or deferred
+  'god-file': ['false-positive', 'accepted-risk', 'deferred'],
+  'large-file': ['false-positive', 'accepted-risk', 'deferred'],
+  'stale-file': ['false-positive', 'accepted-risk', 'deferred'],
+
+  // TODO / FIXME / HACK / console-log / any-type markers: only
+  // accepted-risk or deferred (the marker IS the hygiene issue)
+  hygiene: ['accepted-risk', 'deferred'],
+
+  // License: never allowlisted in 2.6+. License findings drop out of
+  // the baseline producer registry and move to the inventory artifact
+  // (`.dxkit/inventory/licenses.json`) — Sprint 2 work. Empty array
+  // here means the CLI rejects allowlist requests for license kinds
+  // with a hint pointing at the inventory artifact.
+  license: [],
+};
+
+/**
+ * Whether a (kind, category) tuple may be expressed as an inline
+ * annotation. Both the kind AND the category must be inline-compatible.
+ *
+ * Examples:
+ *   canUseInline('secret', 'test-fixture')      // true
+ *   canUseInline('secret', 'accepted-risk')     // false (category file-only)
+ *   canUseInline('large-file', 'false-positive') // false (kind file-only)
+ *   canUseInline('hygiene', 'accepted-risk')    // false (category file-only)
+ */
+export function canUseInline(kind: IdentityKind, category: AllowlistCategory): boolean {
+  return INLINE_COMPATIBLE_KINDS.has(kind) && INLINE_COMPATIBLE_CATEGORIES.has(category);
+}
+
+/**
+ * Whether a category requires `expiresAt` on the file-level entry.
+ * Source of truth for the write-path validation rule.
+ */
+export function requiresExpiry(category: AllowlistCategory): boolean {
+  return EXPIRING_CATEGORIES.has(category);
+}
+
+/**
+ * Whether a (kind, category) tuple is semantically valid. The CLI
+ * uses this to reject incoherent combinations like
+ * `coverage-gap + false-positive` with a clear error pointing at
+ * the applicable categories for that kind.
+ */
+export function isCategoryValidForKind(kind: IdentityKind, category: AllowlistCategory): boolean {
+  return CATEGORIES_BY_KIND[kind].includes(category);
+}
+
+/**
+ * Number of days into the future the CLI defaults `expiresAt` to
+ * when the customer doesn't specify one. Locked at 90 in Sprint 0
+ * (Snyk + Dependabot industry default). Per-category overrides will
+ * land in `.dxkit/policy.json` (`allowlist.defaultExpiryDays`) in a
+ * follow-up commit if real customer signal demands it.
+ */
+export const DEFAULT_EXPIRY_DAYS = 90;
+
+/**
+ * Compute the default expiry date as an ISO `YYYY-MM-DD` string,
+ * `DEFAULT_EXPIRY_DAYS` from `now`. UTC-anchored to keep the date
+ * stable across timezone-different developers on the same team.
+ *
+ * `now` is injected for deterministic testing — production callers
+ * pass `new Date()` (the default).
+ */
+export function defaultExpiryDate(now: Date = new Date()): string {
+  const expires = new Date(now);
+  expires.setUTCDate(expires.getUTCDate() + DEFAULT_EXPIRY_DAYS);
+  return expires.toISOString().slice(0, 10);
+}

--- a/src/allowlist/categories.ts
+++ b/src/allowlist/categories.ts
@@ -16,20 +16,22 @@
 
 import type { IdentityKind } from '../baseline/producers';
 
-export type AllowlistCategory =
-  | 'false-positive'
-  | 'test-fixture'
-  | 'mitigated-externally'
-  | 'accepted-risk'
-  | 'deferred';
-
-export const ALL_CATEGORIES: readonly AllowlistCategory[] = [
+/**
+ * Single source of truth for category values. The `AllowlistCategory`
+ * union type is derived from this array via `(typeof ...)[number]`,
+ * so adding a new category means appending one string here and every
+ * type-level check (Record-keyed tables, switch exhaustiveness,
+ * function parameter types) auto-updates. No two-place drift.
+ */
+export const ALL_CATEGORIES = [
   'false-positive',
   'test-fixture',
   'mitigated-externally',
   'accepted-risk',
   'deferred',
-];
+] as const;
+
+export type AllowlistCategory = (typeof ALL_CATEGORIES)[number];
 
 /**
  * Categories that REQUIRE a finite expiry date. The file-level

--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -53,20 +53,23 @@ import {
   ALLOWLIST_FILENAME,
   ALL_MODES,
   addEntry,
+  auditAllowlist,
   emptyAllowlistFile,
   findEntry,
   loadAllowlist,
   pathForAllowlist,
+  pruneExpired,
   saveAllowlist,
   validateAllowlistEntry,
   type AllowlistEntry,
   type AllowlistFile,
   type AllowlistMode,
+  type AuditReport,
 } from './file';
 import { insertAnnotation } from './inline';
 
 /** Subcommands recognized under `vyuh-dxkit allowlist`. */
-export const ALLOWLIST_SUBCOMMANDS = ['add', 'list', 'show'] as const;
+export const ALLOWLIST_SUBCOMMANDS = ['add', 'list', 'show', 'audit', 'prune'] as const;
 export type AllowlistSubcommand = (typeof ALLOWLIST_SUBCOMMANDS)[number];
 
 export interface AllowlistAddOpts {
@@ -94,6 +97,22 @@ export interface AllowlistShowOpts {
 
 export interface AllowlistListOpts {
   readonly json?: boolean;
+}
+
+export interface AllowlistAuditOpts {
+  readonly json?: boolean;
+  /** Soon-to-expire horizon in days (default 14). */
+  readonly soonToExpireDays?: number;
+}
+
+export interface AllowlistPruneOpts {
+  readonly json?: boolean;
+  /** Don't write; just print what would be removed. */
+  readonly dryRun?: boolean;
+  /** Skip confirmation prompt + write directly. Default behavior
+   *  in Sprint 1 (no interactive prompts in dxkit yet) — the flag
+   *  is accepted for future-proofing. */
+  readonly yes?: boolean;
 }
 
 /**
@@ -137,6 +156,20 @@ export async function runAllowlist(
       return runAllowlistShow(cwd, {
         fingerprint: args.positionalAfter,
         json: !!args.values.json,
+      });
+    case 'audit': {
+      const horizonRaw = args.values['soon-days'] as string | undefined;
+      const horizon = horizonRaw ? parseInt(horizonRaw, 10) : undefined;
+      return runAllowlistAudit(cwd, {
+        json: !!args.values.json,
+        soonToExpireDays: Number.isFinite(horizon) ? horizon : undefined,
+      });
+    }
+    case 'prune':
+      return runAllowlistPrune(cwd, {
+        json: !!args.values.json,
+        dryRun: !!args.values['dry-run'],
+        yes: !!args.values.yes,
       });
   }
 }
@@ -342,6 +375,119 @@ export async function runAllowlistShow(cwd: string, opts: AllowlistShowOpts): Pr
     logger.info(`Acknowledged sev.:  ${entry.acknowledgedSeverity}`);
   }
   if (entry.reason) logger.info(`Reason:             ${entry.reason}`);
+}
+
+// ─── audit ────────────────────────────────────────────────────────────────
+
+export async function runAllowlistAudit(cwd: string, opts: AllowlistAuditOpts): Promise<void> {
+  const file = loadAllowlist(cwd);
+  if (!file) {
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify(
+          { expired: [], soonToExpire: [], missingRationale: [] } satisfies AuditReport,
+          null,
+          2,
+        ) + '\n',
+      );
+      return;
+    }
+    logger.info(`No allowlist file at ${pathForAllowlist(cwd)} — nothing to audit.`);
+    return;
+  }
+
+  const report = auditAllowlist(file, { soonToExpireDays: opts.soonToExpireDays });
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    return;
+  }
+
+  const total = file.entries.length;
+  const horizon = opts.soonToExpireDays ?? 14;
+  logger.info(
+    `Allowlist audit: ${total} entr${total === 1 ? 'y' : 'ies'} ` +
+      `(mode=${file.mode}); soon-to-expire window=${horizon} days`,
+  );
+
+  if (
+    report.expired.length === 0 &&
+    report.soonToExpire.length === 0 &&
+    report.missingRationale.length === 0
+  ) {
+    logger.success(`No issues found.`);
+    return;
+  }
+
+  if (report.expired.length > 0) {
+    logger.warn(
+      `Expired (${report.expired.length}) — run \`vyuh-dxkit allowlist prune\` to remove:`,
+    );
+    for (const e of report.expired) {
+      logger.info(`  ${e.fingerprint}  ${e.kind}/${e.category}  expired ${e.expiresAt}`);
+    }
+  }
+
+  if (report.soonToExpire.length > 0) {
+    logger.warn(
+      `Soon to expire (${report.soonToExpire.length}; within ${horizon} days) — review or extend:`,
+    );
+    for (const { entry, daysRemaining } of report.soonToExpire) {
+      logger.info(
+        `  ${entry.fingerprint}  ${entry.kind}/${entry.category}` +
+          `  expires ${entry.expiresAt} (in ${daysRemaining}d)`,
+      );
+    }
+  }
+
+  if (report.missingRationale.length > 0) {
+    logger.warn(
+      `Missing rationale (${report.missingRationale.length}) — ` +
+        `add a reason or sync the gitignored reasons sidecar:`,
+    );
+    for (const e of report.missingRationale) {
+      logger.info(`  ${e.fingerprint}  ${e.kind}/${e.category}`);
+    }
+  }
+}
+
+// ─── prune ────────────────────────────────────────────────────────────────
+
+export async function runAllowlistPrune(cwd: string, opts: AllowlistPruneOpts): Promise<void> {
+  const file = loadAllowlist(cwd);
+  if (!file) {
+    logger.info(`No allowlist file at ${pathForAllowlist(cwd)} — nothing to prune.`);
+    return;
+  }
+
+  const { kept, removed } = pruneExpired(file);
+
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify({ dryRun: !!opts.dryRun, removed, keptCount: kept.entries.length }, null, 2) +
+        '\n',
+    );
+    if (!opts.dryRun && removed.length > 0) saveAllowlist(cwd, kept);
+    return;
+  }
+
+  if (removed.length === 0) {
+    logger.info(`No expired entries — allowlist is clean.`);
+    return;
+  }
+
+  const verb = opts.dryRun ? 'Would remove' : 'Removing';
+  logger.warn(`${verb} ${removed.length} expired entr${removed.length === 1 ? 'y' : 'ies'}:`);
+  for (const e of removed) {
+    logger.info(`  ${e.fingerprint}  ${e.kind}/${e.category}  expired ${e.expiresAt}`);
+  }
+
+  if (opts.dryRun) {
+    logger.info(`(dry-run — no changes written; rerun without --dry-run to apply)`);
+    return;
+  }
+  saveAllowlist(cwd, kept);
+  logger.success(`Pruned ${removed.length} expired entries.`);
 }
 
 // ─── Internals ────────────────────────────────────────────────────────────

--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -1,0 +1,451 @@
+/**
+ * `vyuh-dxkit allowlist <subcommand>` — orchestrates the user-facing
+ * write/read paths over the allowlist module.
+ *
+ * Subcommands (Sprint 1 chunk):
+ *
+ *   - `add <file>:<line>` — inline annotation insertion. Kind-agnostic;
+ *     the annotation grammar carries category + reason only. Refuses
+ *     non-inline-compatible categories (accepted-risk / deferred).
+ *
+ *   - `add --fingerprint=<id> --kind=<kind>` — file-level allowlist
+ *     entry. Persists to `.dxkit/allowlist.json` (or its sanitized
+ *     mode + gitignored reasons sidecar). Required for any
+ *     accepted-risk / deferred suppression OR any kind that lacks a
+ *     stable single-line attachment point.
+ *
+ *   - `list` — print every entry across the file-level allowlist.
+ *     Reads only; no mutation. Honors `--json` for structured output.
+ *
+ *   - `show <fingerprint>` — print one entry's full detail. Falls
+ *     back to a "no entry found" message when the fingerprint isn't
+ *     present.
+ *
+ * Subcommands `audit` and `prune` land in a follow-up commit.
+ *
+ * # Architectural posture
+ *
+ * Every IO goes through `loadAllowlist` / `saveAllowlist` in
+ * `src/allowlist/file.ts` (arch-rule 1 enforces this). Inline
+ * annotation insertion goes through `insertAnnotation` in
+ * `src/allowlist/inline.ts`. Per-kind / per-category validation
+ * goes through `categories.ts` helpers. NO duplicated taxonomy or
+ * IO logic here — this file is pure orchestration.
+ */
+
+import * as path from 'path';
+import { execSync } from 'child_process';
+import * as logger from '../logger';
+import { LANGUAGES } from '../languages';
+import type { LanguageSupport } from '../languages/types';
+import type { IdentityKind } from '../baseline/producers';
+import type { FindingSeverity } from '../baseline/types';
+import {
+  ALL_CATEGORIES,
+  DEFAULT_EXPIRY_DAYS,
+  INLINE_COMPATIBLE_CATEGORIES,
+  defaultExpiryDate,
+  isCategoryValidForKind,
+  requiresExpiry,
+  type AllowlistCategory,
+} from './categories';
+import {
+  ALLOWLIST_FILENAME,
+  ALL_MODES,
+  addEntry,
+  emptyAllowlistFile,
+  findEntry,
+  loadAllowlist,
+  pathForAllowlist,
+  saveAllowlist,
+  validateAllowlistEntry,
+  type AllowlistEntry,
+  type AllowlistFile,
+  type AllowlistMode,
+} from './file';
+import { insertAnnotation } from './inline';
+
+/** Subcommands recognized under `vyuh-dxkit allowlist`. */
+export const ALLOWLIST_SUBCOMMANDS = ['add', 'list', 'show'] as const;
+export type AllowlistSubcommand = (typeof ALLOWLIST_SUBCOMMANDS)[number];
+
+export interface AllowlistAddOpts {
+  /** Positional target. `<file>:<line>` for inline form; absent or a
+   *  bare file path for file-level form (requires `--fingerprint`
+   *  + `--kind`). */
+  readonly target?: string;
+  readonly category?: string;
+  readonly reason?: string;
+  readonly kind?: string;
+  readonly fingerprint?: string;
+  readonly expires?: string;
+  readonly acknowledgedSeverity?: string;
+  readonly addedBy?: string;
+  /** Override the configured mode for this write only. Default
+   *  reads from `.dxkit/policy.json` (out of scope here; this
+   *  module accepts a flag to choose). */
+  readonly mode?: AllowlistMode;
+}
+
+export interface AllowlistShowOpts {
+  readonly fingerprint?: string;
+  readonly json?: boolean;
+}
+
+export interface AllowlistListOpts {
+  readonly json?: boolean;
+}
+
+/**
+ * Dispatch entry point called from `src/cli.ts`. Validates the
+ * subcommand name + routes to the per-subcommand handler. Unknown
+ * subcommands exit with a clear error and the list of recognized
+ * names.
+ */
+export async function runAllowlist(
+  cwd: string,
+  subcommand: string | undefined,
+  args: {
+    positionalAfter?: string;
+    values: Record<string, unknown>;
+  },
+): Promise<void> {
+  if (!subcommand || !isAllowlistSubcommand(subcommand)) {
+    logger.fail(
+      `Unknown allowlist subcommand: ${JSON.stringify(subcommand ?? '(none)')}. ` +
+        `Expected one of: ${ALLOWLIST_SUBCOMMANDS.join(', ')}.`,
+    );
+    process.exit(1);
+  }
+
+  switch (subcommand) {
+    case 'add':
+      return runAllowlistAdd(cwd, {
+        target: args.positionalAfter,
+        category: args.values.category as string | undefined,
+        reason: args.values.reason as string | undefined,
+        kind: args.values.kind as string | undefined,
+        fingerprint: args.values.fingerprint as string | undefined,
+        expires: args.values.expires as string | undefined,
+        acknowledgedSeverity: args.values['acknowledged-severity'] as string | undefined,
+        addedBy: args.values['added-by'] as string | undefined,
+        mode: args.values.mode as AllowlistMode | undefined,
+      });
+    case 'list':
+      return runAllowlistList(cwd, { json: !!args.values.json });
+    case 'show':
+      return runAllowlistShow(cwd, {
+        fingerprint: args.positionalAfter,
+        json: !!args.values.json,
+      });
+  }
+}
+
+// ─── add ──────────────────────────────────────────────────────────────────
+
+export async function runAllowlistAdd(cwd: string, opts: AllowlistAddOpts): Promise<void> {
+  // Validate category up-front so the rest of the flow can assume
+  // it's a canonical value.
+  const category = parseCategory(opts.category);
+  const reason = (opts.reason ?? '').trim();
+  if (!reason) {
+    logger.fail('--reason is required (non-empty rationale string)');
+    process.exit(1);
+  }
+
+  // Two routing paths: inline annotation insertion vs file-level entry.
+  // The target shape decides:
+  //   - `<file>:<line>` → inline (category must be inline-compatible)
+  //   - `--fingerprint=<id> --kind=<kind>` → file-level
+  const inlineTarget = parseInlineTarget(opts.target);
+  if (inlineTarget) {
+    return runAddInline({ cwd, target: inlineTarget, category, reason });
+  }
+
+  // File-level form
+  return runAddFileLevel({ cwd, opts, category, reason });
+}
+
+interface InlineTarget {
+  readonly file: string;
+  readonly line: number;
+}
+
+function parseInlineTarget(target: string | undefined): InlineTarget | null {
+  if (!target) return null;
+  const m = target.match(/^(.+):(\d+)$/);
+  if (!m) return null;
+  return { file: m[1], line: parseInt(m[2], 10) };
+}
+
+async function runAddInline(args: {
+  cwd: string;
+  target: InlineTarget;
+  category: AllowlistCategory;
+  reason: string;
+}): Promise<void> {
+  const { cwd, target, category, reason } = args;
+  if (!INLINE_COMPATIBLE_CATEGORIES.has(category)) {
+    logger.fail(
+      `category ${JSON.stringify(category)} is file-only — ` +
+        `use --fingerprint=<id> --kind=<kind> form instead. ` +
+        `Inline-compatible categories: ${[...INLINE_COMPATIBLE_CATEGORIES].join(', ')}.`,
+    );
+    process.exit(1);
+  }
+
+  const absPath = path.resolve(cwd, target.file);
+  const lang = inferLanguage(target.file);
+  if (!lang || !lang.commentSyntax) {
+    logger.fail(
+      `cannot infer language from file extension for ${JSON.stringify(target.file)}; ` +
+        `inline annotation requires a known language pack with commentSyntax`,
+    );
+    process.exit(1);
+  }
+
+  const result = insertAnnotation(absPath, target.line, { category, reason }, lang);
+  logger.info(
+    `Inserted ${result.position} allowlist annotation at ${target.file}:${result.annotationLine} ` +
+      `(category=${category})`,
+  );
+}
+
+async function runAddFileLevel(args: {
+  cwd: string;
+  opts: AllowlistAddOpts;
+  category: AllowlistCategory;
+  reason: string;
+}): Promise<void> {
+  const { cwd, opts, category, reason } = args;
+  const fingerprint = opts.fingerprint?.trim();
+  const kindRaw = opts.kind?.trim();
+  if (!fingerprint || !kindRaw) {
+    logger.fail(
+      `file-level allowlist entry requires --fingerprint=<16-hex> and --kind=<kind> ` +
+        `(or pass <file>:<line> for inline annotation when kind+category are inline-compatible)`,
+    );
+    process.exit(1);
+  }
+  const kind = kindRaw as IdentityKind;
+  if (!isCategoryValidForKind(kind, category)) {
+    logger.fail(
+      `category ${JSON.stringify(category)} does not apply to kind ${JSON.stringify(kind)}`,
+    );
+    process.exit(1);
+  }
+
+  const expiresAt = resolveExpiresAt(opts.expires, category);
+  const addedBy = opts.addedBy?.trim() || resolveGitUserEmail(cwd);
+  if (!addedBy) {
+    logger.fail(`--added-by is required (or set git config user.email so it can be inferred)`);
+    process.exit(1);
+  }
+  const addedAt = todayISO();
+  const acknowledgedSeverity = parseSeverityOpt(opts.acknowledgedSeverity);
+
+  const entry: AllowlistEntry = {
+    fingerprint,
+    kind,
+    category,
+    reason,
+    addedBy,
+    addedAt,
+    ...(expiresAt !== undefined ? { expiresAt } : {}),
+    ...(acknowledgedSeverity !== undefined ? { acknowledgedSeverity } : {}),
+  };
+
+  // Resolve effective mode (CLI override → existing file mode → default 'full').
+  const mode = resolveMode(cwd, opts.mode);
+  const validationErrors = validateAllowlistEntry(entry, mode);
+  if (validationErrors.length > 0) {
+    logger.fail(`allowlist entry failed validation:`);
+    for (const e of validationErrors) {
+      logger.fail(`  - ${e.field}: ${e.message}`);
+    }
+    process.exit(1);
+  }
+
+  const existing = loadAllowlist(cwd) ?? emptyAllowlistFile(mode);
+  if (findEntry(existing, fingerprint)) {
+    logger.fail(
+      `allowlist already contains entry for fingerprint ${fingerprint}. ` +
+        `Run \`vyuh-dxkit allowlist show ${fingerprint}\` to inspect, or remove first.`,
+    );
+    process.exit(1);
+  }
+
+  const updated: AllowlistFile = { ...addEntry(existing, entry), mode };
+  saveAllowlist(cwd, updated);
+  logger.info(
+    `Added allowlist entry for fingerprint ${fingerprint} (kind=${kind}, category=${category})` +
+      (expiresAt ? `, expires ${expiresAt}` : ''),
+  );
+}
+
+// ─── list ─────────────────────────────────────────────────────────────────
+
+export async function runAllowlistList(cwd: string, opts: AllowlistListOpts): Promise<void> {
+  const file = loadAllowlist(cwd);
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(file ?? emptyAllowlistFile('full'), null, 2) + '\n');
+    return;
+  }
+
+  if (!file || file.entries.length === 0) {
+    logger.info(`No allowlist entries. Run \`vyuh-dxkit allowlist add\` to create one.`);
+    return;
+  }
+  logger.info(
+    `${file.entries.length} allowlist entr${file.entries.length === 1 ? 'y' : 'ies'} ` +
+      `(mode=${file.mode}, schema=${file.schemaVersion}):`,
+  );
+  for (const entry of file.entries) {
+    const expires = entry.expiresAt ? ` · expires ${entry.expiresAt}` : '';
+    const reasonPreview = entry.reason ? ` — ${truncate(entry.reason, 60)}` : '';
+    logger.info(
+      `  ${entry.fingerprint}  ${entry.kind}/${entry.category}` +
+        `  (added ${entry.addedAt}${expires})${reasonPreview}`,
+    );
+  }
+}
+
+// ─── show ─────────────────────────────────────────────────────────────────
+
+export async function runAllowlistShow(cwd: string, opts: AllowlistShowOpts): Promise<void> {
+  const fp = opts.fingerprint?.trim();
+  if (!fp) {
+    logger.fail(`Usage: vyuh-dxkit allowlist show <fingerprint>`);
+    process.exit(1);
+  }
+  const file = loadAllowlist(cwd);
+  if (!file) {
+    logger.fail(`No allowlist file at ${pathForAllowlist(cwd)}`);
+    process.exit(1);
+  }
+  const entry = findEntry(file, fp);
+  if (!entry) {
+    logger.fail(`No allowlist entry for fingerprint ${fp}`);
+    process.exit(1);
+  }
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(entry, null, 2) + '\n');
+    return;
+  }
+  logger.info(`Fingerprint:        ${entry.fingerprint}`);
+  logger.info(`Kind:               ${entry.kind}`);
+  logger.info(`Category:           ${entry.category}`);
+  logger.info(`Added at:           ${entry.addedAt}`);
+  if (entry.addedBy) logger.info(`Added by:           ${entry.addedBy}`);
+  if (entry.expiresAt) logger.info(`Expires at:         ${entry.expiresAt}`);
+  if (entry.acknowledgedSeverity) {
+    logger.info(`Acknowledged sev.:  ${entry.acknowledgedSeverity}`);
+  }
+  if (entry.reason) logger.info(`Reason:             ${entry.reason}`);
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────
+
+function isAllowlistSubcommand(value: string): value is AllowlistSubcommand {
+  return (ALLOWLIST_SUBCOMMANDS as readonly string[]).includes(value);
+}
+
+function parseCategory(raw: string | undefined): AllowlistCategory {
+  if (!raw) {
+    logger.fail(`--category is required. One of: ${ALL_CATEGORIES.join(', ')}.`);
+    process.exit(1);
+  }
+  if (!(ALL_CATEGORIES as readonly string[]).includes(raw)) {
+    logger.fail(
+      `--category ${JSON.stringify(raw)} is not a known category. ` +
+        `One of: ${ALL_CATEGORIES.join(', ')}.`,
+    );
+    process.exit(1);
+  }
+  return raw as AllowlistCategory;
+}
+
+const VALID_SEVERITIES: readonly FindingSeverity[] = ['critical', 'high', 'medium', 'low'];
+
+function parseSeverityOpt(raw: string | undefined): FindingSeverity | undefined {
+  if (raw === undefined) return undefined;
+  if (!(VALID_SEVERITIES as readonly string[]).includes(raw)) {
+    logger.fail(
+      `--acknowledged-severity ${JSON.stringify(raw)} is not a known severity. ` +
+        `One of: ${VALID_SEVERITIES.join(', ')}.`,
+    );
+    process.exit(1);
+  }
+  return raw as FindingSeverity;
+}
+
+function resolveExpiresAt(
+  raw: string | undefined,
+  category: AllowlistCategory,
+): string | undefined {
+  if (raw !== undefined) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+      logger.fail(`--expires must be ISO date YYYY-MM-DD; got ${JSON.stringify(raw)}`);
+      process.exit(1);
+    }
+    return raw;
+  }
+  if (requiresExpiry(category)) {
+    // Default to DEFAULT_EXPIRY_DAYS from today
+    return defaultExpiryDate(new Date());
+  }
+  return undefined;
+}
+
+function resolveMode(cwd: string, override: AllowlistMode | undefined): AllowlistMode {
+  if (override !== undefined) {
+    if (!(ALL_MODES as readonly string[]).includes(override)) {
+      logger.fail(
+        `--mode ${JSON.stringify(override)} is not a known mode. ` +
+          `One of: ${ALL_MODES.join(', ')}.`,
+      );
+      process.exit(1);
+    }
+    return override;
+  }
+  const existing = loadAllowlist(cwd);
+  return existing?.mode ?? 'full';
+}
+
+function resolveGitUserEmail(cwd: string): string | undefined {
+  try {
+    const out = execSync('git config --get user.email', {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    }).trim();
+    return out || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function inferLanguage(file: string): LanguageSupport | undefined {
+  const ext = path.extname(file).toLowerCase();
+  if (!ext) return undefined;
+  for (const lang of LANGUAGES) {
+    if (lang.sourceExtensions.includes(ext)) return lang;
+  }
+  return undefined;
+}
+
+function todayISO(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + '…';
+}
+
+// DEFAULT_EXPIRY_DAYS exported for callers that want to surface the
+// default in user-facing messages (e.g., the skill).
+export { DEFAULT_EXPIRY_DAYS };
+// ALLOWLIST_FILENAME exported for downstream tests + callers that
+// want to reference the canonical filename without re-importing.
+export { ALLOWLIST_FILENAME };

--- a/src/allowlist/diff.ts
+++ b/src/allowlist/diff.ts
@@ -1,0 +1,162 @@
+/**
+ * Allowlist delta — what changed between two repo states.
+ *
+ * The guardrail check posts a PR comment whenever new allowlist
+ * entries appear on the PR branch. Reviewers see the suppressions
+ * being introduced and can sanity-check the typed category / reason
+ * / expiry without manually grepping for `dxkit-allow:` lines.
+ *
+ * # Two-state comparison
+ *
+ * `computeAllowlistDelta` compares the current on-disk allowlist
+ * (loaded via the canonical `loadAllowlist`) against the allowlist
+ * at the baseline's commit SHA (read via `git show <sha>:.dxkit/...`).
+ * Each entry's identity is its `fingerprint`; the delta is the
+ * symmetric difference of the two fingerprint sets, hydrated back
+ * to the full entries on each side.
+ *
+ *   added   — entries present in current but not at the baseline SHA
+ *   removed — entries present at the baseline SHA but not in current
+ *
+ * # Graceful degradation
+ *
+ * When the baseline SHA isn't reachable (shallow clone, force-push
+ * orphaned base), the delta reports `baselineAccessible: false` and
+ * an empty `added` / `removed`. Callers (the renderer) treat that
+ * as "delta unavailable" rather than "no changes" — surfacing the
+ * incident so the customer can either deepen the clone or accept
+ * the missing review signal.
+ *
+ * Architectural posture:
+ *   - All IO goes through `loadAllowlist` (CLAUDE.md arch rule 1).
+ *   - `git show` is the only direct git interaction; failure modes
+ *     return null without throwing.
+ *   - Pure function over both inputs (current allowlist + git-resolved
+ *     baseline allowlist) — testable independently of git state.
+ */
+
+import { execFileSync } from 'child_process';
+import {
+  ALLOWLIST_DIR,
+  ALLOWLIST_FILENAME,
+  ALLOWLIST_SCHEMA_VERSION,
+  loadAllowlist,
+  type AllowlistEntry,
+  type AllowlistFile,
+} from './file';
+
+export interface AllowlistDelta {
+  /** Entries present in current but not at the baseline SHA. */
+  readonly added: ReadonlyArray<AllowlistEntry>;
+  /** Entries present at the baseline SHA but not in current. */
+  readonly removed: ReadonlyArray<AllowlistEntry>;
+  /** False when the baseline SHA wasn't reachable (shallow clone,
+   *  force-push that orphaned the base). When false, added/removed
+   *  are always empty — callers surface "delta unavailable" rather
+   *  than "no changes." */
+  readonly baselineAccessible: boolean;
+}
+
+/**
+ * Compute the delta between the current on-disk allowlist and the
+ * allowlist at the baseline's commit SHA. Returns a structurally
+ * empty delta with `baselineAccessible: false` when the baseline
+ * SHA can't be read.
+ *
+ * `baselineCommitSha` must be a non-empty hex SHA; an empty string
+ * (the canonical "no commit" value baseline-create uses outside a
+ * git repo) yields `baselineAccessible: false` immediately.
+ */
+export function computeAllowlistDelta(cwd: string, baselineCommitSha: string): AllowlistDelta {
+  const current = loadAllowlist(cwd);
+  const empty: AllowlistDelta = { added: [], removed: [], baselineAccessible: false };
+
+  if (!baselineCommitSha) return empty;
+
+  const baselineFile = readAllowlistAtSha(cwd, baselineCommitSha);
+  if (baselineFile === null) {
+    // git unreachable OR file genuinely didn't exist at the
+    // baseline SHA. We can still produce a useful delta in the
+    // "file didn't exist" case — every current entry is "added"
+    // (the customer adopted the allowlist after baseline-create).
+    // Distinguish the two cases by checking whether the SHA is at
+    // least resolvable.
+    if (!shaReachable(cwd, baselineCommitSha)) return empty;
+    // SHA reachable but file absent → current entries are all new.
+    return {
+      added: current?.entries ?? [],
+      removed: [],
+      baselineAccessible: true,
+    };
+  }
+
+  const currentEntries = current?.entries ?? [];
+  return diffEntries(baselineFile.entries, currentEntries);
+}
+
+/**
+ * Pure delta over two entry arrays. Exposed for testability —
+ * callers without git state can synthesize before/after fixtures
+ * directly. Uses fingerprint equality (the canonical identity
+ * predicate) for set diff.
+ */
+export function diffEntries(
+  prior: ReadonlyArray<AllowlistEntry>,
+  current: ReadonlyArray<AllowlistEntry>,
+): AllowlistDelta {
+  const priorByFp = new Map<string, AllowlistEntry>();
+  for (const e of prior) priorByFp.set(e.fingerprint, e);
+  const currentByFp = new Map<string, AllowlistEntry>();
+  for (const e of current) currentByFp.set(e.fingerprint, e);
+
+  const added: AllowlistEntry[] = [];
+  for (const [fp, e] of currentByFp) {
+    if (!priorByFp.has(fp)) added.push(e);
+  }
+  const removed: AllowlistEntry[] = [];
+  for (const [fp, e] of priorByFp) {
+    if (!currentByFp.has(fp)) removed.push(e);
+  }
+  return { added, removed, baselineAccessible: true };
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────
+
+function readAllowlistAtSha(cwd: string, sha: string): AllowlistFile | null {
+  const gitPath = `${ALLOWLIST_DIR}/${ALLOWLIST_FILENAME}`;
+  let raw: string;
+  try {
+    raw = execFileSync('git', ['show', `${sha}:${gitPath}`], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    });
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // File existed at the SHA but isn't valid JSON. Treat the same
+    // as "absent" — no useful delta computable.
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const obj = parsed as Partial<AllowlistFile>;
+  if (obj.schemaVersion !== ALLOWLIST_SCHEMA_VERSION) return null;
+  if (!Array.isArray(obj.entries)) return null;
+  return parsed as AllowlistFile;
+}
+
+function shaReachable(cwd: string, sha: string): boolean {
+  try {
+    execFileSync('git', ['cat-file', '-e', sha], {
+      cwd,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/allowlist/file.ts
+++ b/src/allowlist/file.ts
@@ -343,6 +343,101 @@ export function isEntryActive(entry: AllowlistEntry, now: Date = new Date()): bo
 }
 
 /**
+ * Days remaining until an entry expires, or `null` when it has no
+ * expiry. Negative values mean already expired by that many days.
+ */
+export function daysUntilExpiry(entry: AllowlistEntry, now: Date = new Date()): number | null {
+  if (!entry.expiresAt) return null;
+  const expiry = new Date(entry.expiresAt + 'T00:00:00Z');
+  const today = new Date(now.toISOString().slice(0, 10) + 'T00:00:00Z');
+  const msPerDay = 24 * 60 * 60 * 1000;
+  return Math.round((expiry.getTime() - today.getTime()) / msPerDay);
+}
+
+/** One entry in a soon-to-expire audit bucket, with the days
+ *  remaining so callers can render time-to-expiry context. */
+export interface SoonToExpire {
+  readonly entry: AllowlistEntry;
+  readonly daysRemaining: number;
+}
+
+/**
+ * Audit report partitioning the file's entries into the three
+ * actionable categories the `vyuh-dxkit allowlist audit` subcommand
+ * surfaces. Pure function — no I/O, no side effects.
+ *
+ * - `expired` — entries past their `expiresAt`. Prune candidates.
+ *   The underlying suppression no longer applies on the next
+ *   guardrail run.
+ * - `soonToExpire` — entries whose `expiresAt` is within
+ *   `soonToExpireDays` (default 14). Customer should review whether
+ *   the deferred work is still in plan and either fix the finding,
+ *   extend the expiry, or remove the entry.
+ * - `missingRationale` — entries with empty / whitespace-only
+ *   reason. In full mode this should never happen (validator
+ *   rejects); in sanitized mode it may occur when the sidecar is
+ *   missing or stale.
+ */
+export interface AuditReport {
+  readonly expired: ReadonlyArray<AllowlistEntry>;
+  readonly soonToExpire: ReadonlyArray<SoonToExpire>;
+  readonly missingRationale: ReadonlyArray<AllowlistEntry>;
+}
+
+export interface AuditOptions {
+  readonly now?: Date;
+  /** Window in days within which `expiresAt` is considered "soon."
+   *  Default 14 — chosen to match a typical sprint cadence. */
+  readonly soonToExpireDays?: number;
+}
+
+export function auditAllowlist(file: AllowlistFile, options: AuditOptions = {}): AuditReport {
+  const now = options.now ?? new Date();
+  const horizon = options.soonToExpireDays ?? 14;
+  const expired: AllowlistEntry[] = [];
+  const soonToExpire: SoonToExpire[] = [];
+  const missingRationale: AllowlistEntry[] = [];
+
+  for (const entry of file.entries) {
+    const days = daysUntilExpiry(entry, now);
+    if (days !== null && days < 0) {
+      expired.push(entry);
+    } else if (days !== null && days <= horizon) {
+      soonToExpire.push({ entry, daysRemaining: days });
+    }
+    if (!entry.reason || entry.reason.trim().length === 0) {
+      // In sanitized mode the reason may legitimately live in the
+      // gitignored sidecar; flag here so the caller can decide
+      // whether to treat it as a real audit item or just an
+      // "unavailable locally" notice.
+      missingRationale.push(entry);
+    }
+  }
+  return { expired, soonToExpire, missingRationale };
+}
+
+/**
+ * Remove expired entries from the file. Returns a new file (immutable)
+ * plus the list of removed entries so the CLI can render what changed.
+ * Pure function — no I/O.
+ */
+export function pruneExpired(
+  file: AllowlistFile,
+  now: Date = new Date(),
+): { kept: AllowlistFile; removed: ReadonlyArray<AllowlistEntry> } {
+  const removed: AllowlistEntry[] = [];
+  const keptEntries: AllowlistEntry[] = [];
+  for (const entry of file.entries) {
+    if (isEntryActive(entry, now)) {
+      keptEntries.push(entry);
+    } else {
+      removed.push(entry);
+    }
+  }
+  return { kept: { ...file, entries: keptEntries }, removed };
+}
+
+/**
  * Validate every entry in the file against the canonical taxonomy
  * + Sprint-0-locked rules. Pure function; returns an array of
  * `ValidationError` rather than throwing so callers can render

--- a/src/allowlist/file.ts
+++ b/src/allowlist/file.ts
@@ -63,7 +63,15 @@ export const ALLOWLIST_DIR = '.dxkit';
 export const ALLOWLIST_FILENAME = 'allowlist.json';
 export const ALLOWLIST_REASONS_FILENAME = 'allowlist-reasons.local.json';
 
-export type AllowlistMode = 'full' | 'sanitized';
+/**
+ * Single source of truth for mode values. The `AllowlistMode` union
+ * is derived from this array via `(typeof ...)[number]`, so adding
+ * a new mode means appending one string here — the runtime checks
+ * below pick it up via `ALL_MODES.includes(...)` without any
+ * literal-value drift between type and runtime.
+ */
+export const ALL_MODES = ['full', 'sanitized'] as const;
+export type AllowlistMode = (typeof ALL_MODES)[number];
 
 /**
  * One allowlist entry. Two-shape contract:
@@ -187,9 +195,10 @@ export function loadAllowlist(cwd: string): AllowlistFile | null {
         `(${filePath})`,
     );
   }
-  if (obj.mode !== 'full' && obj.mode !== 'sanitized') {
+  if (!isAllowlistMode(obj.mode)) {
     throw new Error(
-      `allowlist file mode is ${JSON.stringify(obj.mode)}; expected 'full' or 'sanitized' (${filePath})`,
+      `allowlist file mode is ${JSON.stringify(obj.mode)}; ` +
+        `expected one of ${JSON.stringify(ALL_MODES)} (${filePath})`,
     );
   }
   if (!Array.isArray(obj.entries)) {
@@ -347,10 +356,10 @@ export function validateAllowlistFile(file: AllowlistFile): ReadonlyArray<Valida
       message: `expected ${JSON.stringify(ALLOWLIST_SCHEMA_VERSION)}, got ${JSON.stringify(file.schemaVersion)}`,
     });
   }
-  if (file.mode !== 'full' && file.mode !== 'sanitized') {
+  if (!isAllowlistMode(file.mode)) {
     errors.push({
       field: 'mode',
-      message: `expected 'full' or 'sanitized', got ${JSON.stringify(file.mode)}`,
+      message: `expected one of ${JSON.stringify(ALL_MODES)}, got ${JSON.stringify(file.mode)}`,
     });
   }
 
@@ -456,6 +465,10 @@ export function validateAllowlistEntry(
 }
 
 // ─── Internals ───────────────────────────────────────────────────────────
+
+function isAllowlistMode(value: unknown): value is AllowlistMode {
+  return typeof value === 'string' && (ALL_MODES as readonly string[]).includes(value);
+}
 
 function writeJsonPretty(filePath: string, value: unknown): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });

--- a/src/allowlist/file.ts
+++ b/src/allowlist/file.ts
@@ -1,0 +1,490 @@
+/**
+ * On-disk allowlist file — `.dxkit/allowlist.json` + optional sidecar
+ * `.dxkit/allowlist-reasons.local.json`.
+ *
+ * The allowlist file is the durable contract for per-finding
+ * suppressions: customer has reviewed this fingerprint, categorized
+ * the reason, and accepts that the guardrail should let the finding
+ * pass on future runs.
+ *
+ * Identity is the 16-char hex fingerprint from
+ * `src/analyzers/tools/fingerprint.ts` (CLAUDE.md Rule 9). An entry
+ * matches a finding when their fingerprint strings are byte-equal.
+ *
+ * # Two modes, one schema
+ *
+ * The mode is recorded in `.dxkit/policy.json` (out of scope for this
+ * module — consumers pass it in via `AllowlistMode`). Both modes use
+ * the same `AllowlistFile` shape on disk; sanitized mode just drops
+ * the human-readable fields and pushes them to a sidecar:
+ *
+ *   `'full'` — every field present on the entry. Default for
+ *   private repos. The committed file carries the full audit trail.
+ *
+ *   `'sanitized'` — entries carry `fingerprint + kind + category +
+ *   addedAt + expiresAt + acknowledgedSeverity` only. The
+ *   `reason` + `addedBy` fields live in the gitignored sidecar
+ *   `.dxkit/allowlist-reasons.local.json`, keyed by fingerprint.
+ *   Default for public repos. Loaders merge the sidecar back when
+ *   present; readers tolerate its absence (no reason field, but
+ *   the suppression still applies because matching is by
+ *   fingerprint).
+ *
+ * # Validation surface
+ *
+ * `validateAllowlistFile` enforces every Sprint-0-locked rule:
+ *   - `reason` is required (full mode) / required in sidecar
+ *     (sanitized mode)
+ *   - `category` is one of the five canonical values
+ *   - `category` is valid for the entry's `kind`
+ *   - `requiresExpiry(category)` ⇒ `expiresAt` is present + parseable
+ *   - `acknowledgedSeverity` is required when `category` is
+ *     `accepted-risk` AND `severity` is `high`/`critical`
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { IdentityKind } from '../baseline/producers';
+import {
+  ALL_CATEGORIES,
+  isCategoryValidForKind,
+  requiresExpiry,
+  type AllowlistCategory,
+} from './categories';
+
+export const ALLOWLIST_SCHEMA_VERSION = 'dxkit-allowlist/v1' as const;
+export type AllowlistSchemaVersion = typeof ALLOWLIST_SCHEMA_VERSION;
+
+export const ALLOWLIST_REASONS_SCHEMA_VERSION = 'dxkit-allowlist-reasons/v1' as const;
+export type AllowlistReasonsSchemaVersion = typeof ALLOWLIST_REASONS_SCHEMA_VERSION;
+
+export const ALLOWLIST_DIR = '.dxkit';
+export const ALLOWLIST_FILENAME = 'allowlist.json';
+export const ALLOWLIST_REASONS_FILENAME = 'allowlist-reasons.local.json';
+
+export type AllowlistMode = 'full' | 'sanitized';
+
+/**
+ * One allowlist entry. Two-shape contract:
+ *   - Full mode: every optional field may be present on disk.
+ *   - Sanitized mode on disk: `reason` + `addedBy` are absent; the
+ *     loader merges them in from the sidecar when present.
+ *
+ * The TypeScript type allows the union so a single in-memory shape
+ * serves both modes; the validator enforces shape invariants.
+ */
+export interface AllowlistEntry {
+  /** SHA-1[0:16] canonical fingerprint matching the target finding. */
+  readonly fingerprint: string;
+  /** Identity kind of the target finding (matches CLAUDE.md Rule 9
+   *  canonical kinds). */
+  readonly kind: IdentityKind;
+  /** Suppression category — one of the five Sprint-0-locked enum
+   *  values. */
+  readonly category: AllowlistCategory;
+  /** Human-readable rationale. Required in full mode; lives in
+   *  sidecar in sanitized mode. */
+  readonly reason?: string;
+  /** Who added the entry. Required in full mode; lives in sidecar
+   *  in sanitized mode. Free-form (typically email, git user, or
+   *  Slack handle). */
+  readonly addedBy?: string;
+  /** ISO `YYYY-MM-DD` of when the entry was added. */
+  readonly addedAt: string;
+  /** ISO `YYYY-MM-DD` after which the entry stops suppressing the
+   *  finding. Required for `accepted-risk` + `deferred` categories;
+   *  optional otherwise. */
+  readonly expiresAt?: string;
+  /** Severity at which the suppression was acknowledged. Required
+   *  when `category` is `accepted-risk` and the finding's severity
+   *  is `high` or `critical` — see `validateAllowlistEntry`. */
+  readonly acknowledgedSeverity?: 'low' | 'medium' | 'high' | 'critical';
+}
+
+export interface AllowlistFile {
+  readonly schemaVersion: AllowlistSchemaVersion;
+  readonly mode: AllowlistMode;
+  readonly entries: ReadonlyArray<AllowlistEntry>;
+}
+
+/**
+ * The gitignored sidecar that carries the human-readable fields in
+ * sanitized mode. Sparse — only the fields that need to live
+ * outside the committed file appear. Loaders are lenient when the
+ * sidecar is absent (no entry merges; suppression still works by
+ * fingerprint).
+ */
+export interface AllowlistReasonsSidecar {
+  readonly schemaVersion: AllowlistReasonsSchemaVersion;
+  readonly reasons: Readonly<
+    Record<
+      /* fingerprint */ string,
+      {
+        readonly reason: string;
+        readonly addedBy: string;
+      }
+    >
+  >;
+}
+
+export interface ValidationError {
+  readonly fingerprint?: string;
+  readonly field: string;
+  readonly message: string;
+}
+
+export function pathForAllowlist(cwd: string): string {
+  return path.join(cwd, ALLOWLIST_DIR, ALLOWLIST_FILENAME);
+}
+
+export function pathForAllowlistReasons(cwd: string): string {
+  return path.join(cwd, ALLOWLIST_DIR, ALLOWLIST_REASONS_FILENAME);
+}
+
+/**
+ * Create an empty allowlist file in the requested mode. Useful for
+ * the `vyuh-dxkit allowlist add` CLI path when no file exists yet.
+ */
+export function emptyAllowlistFile(mode: AllowlistMode = 'full'): AllowlistFile {
+  return { schemaVersion: ALLOWLIST_SCHEMA_VERSION, mode, entries: [] };
+}
+
+/**
+ * Read the on-disk allowlist + (when present) merge the sidecar
+ * reasons. Returns `null` when the main file doesn't exist —
+ * callers treat that as "no allowlist configured."
+ *
+ * Throws on:
+ *   - Malformed JSON in either file
+ *   - Unrecognized `schemaVersion`
+ *   - Root is not an object
+ *
+ * The sidecar's absence is NOT an error: customers in sanitized
+ * mode may have a committed allowlist on disk without the sidecar
+ * cloned (CI checkout, fresh teammate clone). The fingerprint-only
+ * file is still functional as a suppression list.
+ */
+export function loadAllowlist(cwd: string): AllowlistFile | null {
+  const filePath = pathForAllowlist(cwd);
+  if (!fs.existsSync(filePath)) return null;
+
+  const raw = fs.readFileSync(filePath, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`allowlist file is not valid JSON: ${filePath} (${(err as Error).message})`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`allowlist file root is not an object: ${filePath}`);
+  }
+  const obj = parsed as Partial<AllowlistFile>;
+  if (obj.schemaVersion !== ALLOWLIST_SCHEMA_VERSION) {
+    throw new Error(
+      `allowlist file schemaVersion is ${JSON.stringify(obj.schemaVersion)}; ` +
+        `this dxkit understands ${JSON.stringify(ALLOWLIST_SCHEMA_VERSION)} only ` +
+        `(${filePath})`,
+    );
+  }
+  if (obj.mode !== 'full' && obj.mode !== 'sanitized') {
+    throw new Error(
+      `allowlist file mode is ${JSON.stringify(obj.mode)}; expected 'full' or 'sanitized' (${filePath})`,
+    );
+  }
+  if (!Array.isArray(obj.entries)) {
+    throw new Error(`allowlist file entries is not an array (${filePath})`);
+  }
+
+  const base = parsed as AllowlistFile;
+  if (base.mode === 'full') return base;
+
+  // sanitized mode → merge sidecar if present
+  const sidecar = loadAllowlistReasons(cwd);
+  if (!sidecar) return base;
+  return mergeReasons(base, sidecar);
+}
+
+/**
+ * Load the gitignored reasons sidecar. Returns `null` when missing.
+ * Throws on malformed JSON or wrong schemaVersion.
+ */
+export function loadAllowlistReasons(cwd: string): AllowlistReasonsSidecar | null {
+  const filePath = pathForAllowlistReasons(cwd);
+  if (!fs.existsSync(filePath)) return null;
+
+  const raw = fs.readFileSync(filePath, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `allowlist reasons sidecar is not valid JSON: ${filePath} (${(err as Error).message})`,
+    );
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`allowlist reasons sidecar root is not an object: ${filePath}`);
+  }
+  const obj = parsed as Partial<AllowlistReasonsSidecar>;
+  if (obj.schemaVersion !== ALLOWLIST_REASONS_SCHEMA_VERSION) {
+    throw new Error(
+      `allowlist reasons sidecar schemaVersion is ${JSON.stringify(obj.schemaVersion)}; ` +
+        `expected ${JSON.stringify(ALLOWLIST_REASONS_SCHEMA_VERSION)} (${filePath})`,
+    );
+  }
+  if (!obj.reasons || typeof obj.reasons !== 'object' || Array.isArray(obj.reasons)) {
+    throw new Error(`allowlist reasons sidecar 'reasons' is not an object (${filePath})`);
+  }
+  return parsed as AllowlistReasonsSidecar;
+}
+
+/**
+ * Persist the allowlist to disk. Writes the sidecar separately in
+ * sanitized mode: the committed file gets the structural fields;
+ * the sidecar gets `reason` + `addedBy`.
+ *
+ * Validation runs before writing — invalid input throws and the
+ * file isn't touched. Use `validateAllowlistFile` directly when
+ * you want non-throwing error reporting.
+ */
+export function saveAllowlist(cwd: string, file: AllowlistFile): void {
+  const errors = validateAllowlistFile(file);
+  if (errors.length > 0) {
+    throw new Error(
+      `allowlist file failed validation:\n` +
+        errors.map((e) => `  - ${e.field}: ${e.message}`).join('\n'),
+    );
+  }
+
+  if (file.mode === 'full') {
+    writeJsonPretty(pathForAllowlist(cwd), file);
+    return;
+  }
+
+  // sanitized mode: split entries → main + sidecar
+  const sanitizedEntries: AllowlistEntry[] = [];
+  const reasons: Record<string, { reason: string; addedBy: string }> = {};
+  for (const entry of file.entries) {
+    sanitizedEntries.push(sanitizedEntry(entry));
+    if (entry.reason !== undefined && entry.addedBy !== undefined) {
+      reasons[entry.fingerprint] = { reason: entry.reason, addedBy: entry.addedBy };
+    }
+  }
+  const sanitizedFile: AllowlistFile = {
+    schemaVersion: file.schemaVersion,
+    mode: 'sanitized',
+    entries: sanitizedEntries,
+  };
+  const sidecar: AllowlistReasonsSidecar = {
+    schemaVersion: ALLOWLIST_REASONS_SCHEMA_VERSION,
+    reasons,
+  };
+  writeJsonPretty(pathForAllowlist(cwd), sanitizedFile);
+  writeJsonPretty(pathForAllowlistReasons(cwd), sidecar);
+}
+
+/** Find an entry by fingerprint. */
+export function findEntry(file: AllowlistFile, fingerprint: string): AllowlistEntry | undefined {
+  return file.entries.find((e) => e.fingerprint === fingerprint);
+}
+
+/**
+ * Add an entry. Returns a NEW `AllowlistFile` (immutable update).
+ * Throws if `entry.fingerprint` already exists.
+ */
+export function addEntry(file: AllowlistFile, entry: AllowlistEntry): AllowlistFile {
+  if (findEntry(file, entry.fingerprint)) {
+    throw new Error(
+      `allowlist already contains entry for fingerprint ${entry.fingerprint}; ` +
+        `use removeEntry first or update in place`,
+    );
+  }
+  return { ...file, entries: [...file.entries, entry] };
+}
+
+/**
+ * Remove an entry by fingerprint. Returns a NEW `AllowlistFile`.
+ * Silently no-ops when the fingerprint isn't present (CLI surfaces
+ * the "not found" case through a separate read step).
+ */
+export function removeEntry(file: AllowlistFile, fingerprint: string): AllowlistFile {
+  return { ...file, entries: file.entries.filter((e) => e.fingerprint !== fingerprint) };
+}
+
+/**
+ * Whether the allowlist suppresses a given finding. Pure
+ * fingerprint match. Expiry handling is layered on top by
+ * `isEntryActive` (kept separate so the guardrail can distinguish
+ * "matched but expired" from "no match").
+ */
+export function matchesFinding(file: AllowlistFile, fingerprint: string): boolean {
+  return findEntry(file, fingerprint) !== undefined;
+}
+
+/**
+ * Whether an entry is currently active (within its expiry window).
+ * Entries without `expiresAt` are always active. Entries past their
+ * expiry are inactive — guardrail treats the underlying finding as
+ * un-allowlisted and the next run flags the suppression as stale.
+ */
+export function isEntryActive(entry: AllowlistEntry, now: Date = new Date()): boolean {
+  if (!entry.expiresAt) return true;
+  const today = now.toISOString().slice(0, 10);
+  return entry.expiresAt >= today;
+}
+
+/**
+ * Validate every entry in the file against the canonical taxonomy
+ * + Sprint-0-locked rules. Pure function; returns an array of
+ * `ValidationError` rather than throwing so callers can render
+ * structured error messages.
+ */
+export function validateAllowlistFile(file: AllowlistFile): ReadonlyArray<ValidationError> {
+  const errors: ValidationError[] = [];
+  if (file.schemaVersion !== ALLOWLIST_SCHEMA_VERSION) {
+    errors.push({
+      field: 'schemaVersion',
+      message: `expected ${JSON.stringify(ALLOWLIST_SCHEMA_VERSION)}, got ${JSON.stringify(file.schemaVersion)}`,
+    });
+  }
+  if (file.mode !== 'full' && file.mode !== 'sanitized') {
+    errors.push({
+      field: 'mode',
+      message: `expected 'full' or 'sanitized', got ${JSON.stringify(file.mode)}`,
+    });
+  }
+
+  const seen = new Set<string>();
+  for (const entry of file.entries) {
+    if (seen.has(entry.fingerprint)) {
+      errors.push({
+        fingerprint: entry.fingerprint,
+        field: 'fingerprint',
+        message: `duplicate fingerprint`,
+      });
+    }
+    seen.add(entry.fingerprint);
+    for (const err of validateAllowlistEntry(entry, file.mode)) errors.push(err);
+  }
+  return errors;
+}
+
+/**
+ * Validate a single entry. Exposed independently so the CLI's
+ * `allowlist add` can pre-flight before mutating the file.
+ */
+export function validateAllowlistEntry(
+  entry: AllowlistEntry,
+  mode: AllowlistMode,
+): ReadonlyArray<ValidationError> {
+  const errors: ValidationError[] = [];
+  const fp = entry.fingerprint;
+
+  if (!fp || typeof fp !== 'string' || !/^[0-9a-f]{16}$/.test(fp)) {
+    errors.push({
+      fingerprint: fp,
+      field: 'fingerprint',
+      message: 'must be a 16-char lowercase hex string',
+    });
+  }
+  if (!ALL_CATEGORIES.includes(entry.category)) {
+    errors.push({
+      fingerprint: fp,
+      field: 'category',
+      message: `must be one of ${JSON.stringify(ALL_CATEGORIES)}; got ${JSON.stringify(entry.category)}`,
+    });
+  }
+  if (!isCategoryValidForKind(entry.kind, entry.category)) {
+    errors.push({
+      fingerprint: fp,
+      field: 'category',
+      message: `category ${JSON.stringify(entry.category)} does not apply to kind ${JSON.stringify(entry.kind)}`,
+    });
+  }
+  // reason: required in full mode; sidecar-owned in sanitized mode (so
+  // the entry on disk legitimately omits it). The CLI write path emits
+  // a separate validation pass for the sidecar.
+  if (mode === 'full') {
+    if (entry.reason === undefined || entry.reason === null) {
+      errors.push({ fingerprint: fp, field: 'reason', message: 'required in full mode' });
+    } else if (typeof entry.reason !== 'string' || entry.reason.trim().length === 0) {
+      errors.push({
+        fingerprint: fp,
+        field: 'reason',
+        message: 'must be a non-empty string',
+      });
+    }
+    if (entry.addedBy === undefined || entry.addedBy === null) {
+      errors.push({ fingerprint: fp, field: 'addedBy', message: 'required in full mode' });
+    } else if (typeof entry.addedBy !== 'string' || entry.addedBy.trim().length === 0) {
+      errors.push({
+        fingerprint: fp,
+        field: 'addedBy',
+        message: 'must be a non-empty string',
+      });
+    }
+  }
+  if (!entry.addedAt || !/^\d{4}-\d{2}-\d{2}$/.test(entry.addedAt)) {
+    errors.push({
+      fingerprint: fp,
+      field: 'addedAt',
+      message: 'must be ISO date YYYY-MM-DD',
+    });
+  }
+  if (requiresExpiry(entry.category)) {
+    if (!entry.expiresAt) {
+      errors.push({
+        fingerprint: fp,
+        field: 'expiresAt',
+        message: `required for category ${JSON.stringify(entry.category)}`,
+      });
+    }
+  }
+  if (entry.expiresAt !== undefined && !/^\d{4}-\d{2}-\d{2}$/.test(entry.expiresAt)) {
+    errors.push({
+      fingerprint: fp,
+      field: 'expiresAt',
+      message: 'must be ISO date YYYY-MM-DD when present',
+    });
+  }
+  // Note on acknowledgedSeverity: the rule "accepted-risk on a
+  // high/critical finding requires acknowledgedSeverity" can't be
+  // enforced from inside this validator — the finding's severity
+  // doesn't live on the on-disk entry. The CLI's `allowlist add`
+  // path enforces it at write time when the finding is in scope.
+  return errors;
+}
+
+// ─── Internals ───────────────────────────────────────────────────────────
+
+function writeJsonPretty(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + '\n', 'utf8');
+}
+
+function sanitizedEntry(entry: AllowlistEntry): AllowlistEntry {
+  // Strip `reason` + `addedBy`; everything else stays on disk in the
+  // committed file. The fingerprint contract preserves matching.
+  // We intentionally rebuild via property assignment rather than
+  // destructuring so the optional-undefined fields don't survive
+  // serialization as explicit `null`s.
+  const out: AllowlistEntry = {
+    fingerprint: entry.fingerprint,
+    kind: entry.kind,
+    category: entry.category,
+    addedAt: entry.addedAt,
+    ...(entry.expiresAt !== undefined ? { expiresAt: entry.expiresAt } : {}),
+    ...(entry.acknowledgedSeverity !== undefined
+      ? { acknowledgedSeverity: entry.acknowledgedSeverity }
+      : {}),
+  };
+  return out;
+}
+
+function mergeReasons(file: AllowlistFile, sidecar: AllowlistReasonsSidecar): AllowlistFile {
+  const merged = file.entries.map((entry) => {
+    const r = sidecar.reasons[entry.fingerprint];
+    if (!r) return entry;
+    return { ...entry, reason: r.reason, addedBy: r.addedBy };
+  });
+  return { ...file, entries: merged };
+}

--- a/src/allowlist/file.ts
+++ b/src/allowlist/file.ts
@@ -45,6 +45,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { IdentityKind } from '../baseline/producers';
+import type { FindingSeverity } from '../baseline/types';
 import {
   ALL_CATEGORIES,
   isCategoryValidForKind,
@@ -98,7 +99,7 @@ export interface AllowlistEntry {
   /** Severity at which the suppression was acknowledged. Required
    *  when `category` is `accepted-risk` and the finding's severity
    *  is `high` or `critical` — see `validateAllowlistEntry`. */
-  readonly acknowledgedSeverity?: 'low' | 'medium' | 'high' | 'critical';
+  readonly acknowledgedSeverity?: FindingSeverity;
 }
 
 export interface AllowlistFile {

--- a/src/allowlist/gather.ts
+++ b/src/allowlist/gather.ts
@@ -1,0 +1,134 @@
+/**
+ * Inline allowlist annotation gather pass.
+ *
+ * Walks the source tree looking for `<lineComment> dxkit-allow:<category>`
+ * comments and records each occurrence as a `(file, line, category)`
+ * tuple. The `stale-allow` producer uses this list together with the
+ * current scan's secret/code/config findings to detect orphaned
+ * annotations — annotations whose underlying finding is no longer
+ * present, which the developer should remove.
+ *
+ * Architectural posture:
+ *
+ *   - File walk goes through the canonical `walkSourceFiles` helper
+ *     so `.gitignore` + `.dxkit-ignore` + bundled defaults are
+ *     honored uniformly. No custom recursion / exclusion logic
+ *     (per CLAUDE.md G_v4_7).
+ *   - Per-language comment marker comes from each pack's
+ *     `LanguageSupport.commentSyntax` via the inline annotation
+ *     parser. No hardcoded `'//'` / `'#'` literals in this module
+ *     (arch-check rule 2 enforces).
+ *   - Annotation parsing reuses `parseAnnotation` from `inline.ts`
+ *     — single source of grammar truth.
+ *
+ * Test files ARE walked (intentional — annotations often live in
+ * test fixtures suppressing scanner findings against deliberate
+ * placeholder credentials). Auto-generated files are NOT walked
+ * (the developer doesn't author annotations in generated code, and
+ * `walkSourceFiles` already excludes them by default).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { LANGUAGES } from '../languages';
+import type { LanguageSupport } from '../languages/types';
+import { walkSourceFiles } from '../analyzers/tools/walk-source-files';
+import { isStandaloneAnnotationLine, parseAnnotation, type AnnotationPosition } from './inline';
+
+export interface InlineAllowlistOccurrence {
+  /** Project-relative POSIX path. */
+  readonly file: string;
+  /** 1-based line number where the annotation comment LIVES. For
+   *  above-line annotations the value is the line just before the
+   *  finding's target; for same-line it's the finding's own line. */
+  readonly line: number;
+  /** Category named in the annotation (`test-fixture` / `false-positive` /
+   *  etc.). Free-form at gather level; the producer cross-checks
+   *  against the canonical `AllowlistCategory` union. */
+  readonly category: string;
+  /** Where the annotation sits relative to the suppressed line. */
+  readonly position: AnnotationPosition;
+}
+
+export interface GatherInlineOpts {
+  /** Walk test files too. Default: true (test fixtures legitimately
+   *  carry intentional placeholders + suppressions). */
+  readonly includeTests?: boolean;
+}
+
+/**
+ * Walk source files under `cwd` and collect every inline allowlist
+ * annotation occurrence. Cheap on small repos; on large ones the
+ * `walkSourceFiles` cache amortizes the cost across multiple gather
+ * passes within a single baseline-create run.
+ *
+ * Returns occurrences in stable order (file path lexicographic, then
+ * line ascending) so downstream deterministic-output requirements
+ * are satisfied automatically.
+ */
+export function gatherInlineAllowlistAnnotations(
+  cwd: string,
+  opts: GatherInlineOpts = {},
+): InlineAllowlistOccurrence[] {
+  const includeTests = opts.includeTests ?? true;
+  const files = walkSourceFiles(cwd, { includeTests });
+  const out: InlineAllowlistOccurrence[] = [];
+
+  // Build an extension → language lookup once per call. Cheap; the
+  // LANGUAGES registry is small (8 packs today).
+  const langByExt = buildLanguageByExtension();
+
+  for (const relPath of files) {
+    const ext = path.extname(relPath).toLowerCase();
+    const lang = langByExt.get(ext);
+    if (!lang || !lang.commentSyntax) continue;
+
+    const abs = path.join(cwd, relPath);
+    let raw: string;
+    try {
+      raw = fs.readFileSync(abs, 'utf8');
+    } catch {
+      // File disappeared mid-walk (race) or unreadable — skip.
+      continue;
+    }
+    // Fast path: source has no `dxkit-allow:` substring at all.
+    // Avoids per-line regex on the vast majority of files.
+    if (!raw.includes('dxkit-allow:')) continue;
+
+    const lines = raw.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const parsed = parseAnnotation(line, lang);
+      if (!parsed) continue;
+      // `parseAnnotation` returns the category + reason but not
+      // the position. Determine position by inspecting whether the
+      // line is standalone (only whitespace + comment marker + body)
+      // or has source code preceding the comment.
+      const position: AnnotationPosition = isStandaloneAnnotationLine(line, lang)
+        ? 'above'
+        : 'same-line';
+      out.push({
+        file: relPath,
+        line: i + 1,
+        category: parsed.category,
+        position,
+      });
+    }
+  }
+  return out;
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────
+
+function buildLanguageByExtension(): Map<string, LanguageSupport> {
+  const map = new Map<string, LanguageSupport>();
+  for (const lang of LANGUAGES) {
+    for (const ext of lang.sourceExtensions) {
+      const lower = ext.toLowerCase();
+      // First pack wins on duplicate extensions (none today, but
+      // the deterministic-order guarantee survives a future overlap).
+      if (!map.has(lower)) map.set(lower, lang);
+    }
+  }
+  return map;
+}

--- a/src/allowlist/hint.ts
+++ b/src/allowlist/hint.ts
@@ -1,0 +1,293 @@
+/**
+ * Block-time hint generation.
+ *
+ * When the guardrail check rejects a finding, the developer needs
+ * three things to act on it:
+ *
+ *   1. **Remediation** — the recommended fix (rotate the secret,
+ *      upgrade the package, split the file, etc.). Generic per-kind
+ *      prose; the conversational `dxkit-fix` skill produces
+ *      LLM-backed, code-aware fixes when available.
+ *   2. **Inline example** — the exact annotation comment to paste
+ *      when the finding has a stable single-line attachment point
+ *      and the chosen category is inline-compatible.
+ *   3. **CLI command** — the exact `npx vyuh-dxkit allowlist add`
+ *      invocation that handles the mutation without the developer
+ *      typing annotation syntax.
+ *
+ * # Canonical input shape (CLAUDE.md Rule 9)
+ *
+ * This module consumes `BaselineEntry` directly — the canonical
+ * per-kind discriminated union from `src/baseline/types.ts`. NO
+ * intermediate "BlockingFinding" projection. The discriminated
+ * union flows into the switch statements below so TypeScript's
+ * exhaustiveness check fails the build when a new `IdentityKind`
+ * variant is added without matching `case` branches here.
+ *
+ * Language is inferred from the entry's file path (when present)
+ * via the canonical `LANGUAGES` registry. No language-specific
+ * branches; pack additions auto-propagate.
+ *
+ * The returned `BlockHint` is a plain data object so callers can
+ * render it as terminal output, emit it as JSON for the skill /
+ * future MCP surface, etc. Rendering text lives at the call site,
+ * NOT here.
+ */
+
+import * as path from 'path';
+import type { BaselineEntry, FindingSeverity } from '../baseline/types';
+import { LANGUAGES } from '../languages';
+import type { LanguageSupport } from '../languages/types';
+import { CATEGORIES_BY_KIND, INLINE_COMPATIBLE_KINDS, type AllowlistCategory } from './categories';
+import { renderAnnotation } from './inline';
+
+export interface BlockHint {
+  /** Generic per-kind remediation text. Always present. */
+  readonly remediation: string;
+  /** Categories that semantically apply to this kind. Empty for
+   *  `license` (which drops out of the baseline producer registry
+   *  in 2.6+). */
+  readonly applicableCategories: readonly AllowlistCategory[];
+  /** Inline annotation example. Populated only when the entry has
+   *  a stable single-line attachment, the kind's first applicable
+   *  category is inline-compatible, and the language is inferable
+   *  from the file extension. */
+  readonly inlineExample?: string;
+  /** Shell command for the CLI write path. Always present. */
+  readonly cliCommand: string;
+  /** True when the kind has no inline-compatible category
+   *  applicable (e.g. hygiene — only accepted-risk + deferred,
+   *  both file-only). The CLI / skill routes the dev directly to
+   *  the file-level surface when true. */
+  readonly fileLevelOnly: boolean;
+  /** Pointer to the file-level allowlist surface when an expiring
+   *  category (accepted-risk / deferred) might apply. */
+  readonly fileLevelHint?: string;
+}
+
+/**
+ * Build the structured block-time hint from a baseline entry.
+ * Pure function — no IO, no side effects. The caller renders the
+ * fields into its medium of choice.
+ *
+ * The optional `severity` parameter is reserved for future
+ * remediation-prose tuning (e.g. "rotate IMMEDIATELY" for
+ * critical-severity secrets). Currently unused but threaded
+ * through so callers don't need to refactor when the prose
+ * starts varying on severity.
+ */
+export function formatBlockHint(entry: BaselineEntry, severity?: FindingSeverity): BlockHint {
+  const applicableCategories = CATEGORIES_BY_KIND[entry.kind];
+  const inlineCompatibleApplicable = applicableCategories.filter(isInlineCompatibleCategory);
+  const fileLevelOnly =
+    !INLINE_COMPATIBLE_KINDS.has(entry.kind) || inlineCompatibleApplicable.length === 0;
+
+  const firstInlineCategory = inlineCompatibleApplicable[0];
+  const inlineExample = buildInlineExample(entry, firstInlineCategory);
+  const cliCommand = buildCliCommand(entry, applicableCategories);
+  const fileLevelHint = buildFileLevelHint(applicableCategories);
+
+  // Severity threaded for future use; not consumed yet — declare it
+  // touched so an unused-parameter rule doesn't complain.
+  void severity;
+
+  return {
+    remediation: remediationFor(entry.kind),
+    applicableCategories,
+    inlineExample,
+    cliCommand,
+    fileLevelOnly,
+    fileLevelHint,
+  };
+}
+
+/**
+ * Generic per-kind remediation text. Exhaustive switch on the
+ * canonical `BaselineEntry['kind']` union — TypeScript enforces
+ * every variant has prose so a new kind can't ship without
+ * matching `case` branches.
+ */
+export function remediationFor(kind: BaselineEntry['kind']): string {
+  switch (kind) {
+    case 'secret':
+    case 'secret-hmac':
+      return (
+        'Rotate this credential immediately and load it from an environment variable ' +
+        'or secret manager instead of source. Do not commit the replacement to git ' +
+        'history — clean previous commits with git-filter-repo if necessary.'
+      );
+    case 'code':
+      return (
+        'Review the flagged code pattern. If the scanner is wrong (false positive), ' +
+        'suppress via the allowlist with category=false-positive. Otherwise fix the ' +
+        'underlying issue — the scanner caught it for a reason.'
+      );
+    case 'config':
+      return (
+        'Review the configuration setting. Many config-level findings ' +
+        '(TLS validation disabled, debug mode in production, etc.) reflect ' +
+        'operational risk; fix at the deployment / infrastructure layer where ' +
+        'possible rather than in source.'
+      );
+    case 'dep-vuln':
+      return (
+        'Upgrade the vulnerable dependency to the patched version. Run ' +
+        '`npx vyuh-dxkit vulnerabilities` to see the suggested install command ' +
+        'for this ecosystem.'
+      );
+    case 'duplication':
+      return (
+        'Extract the duplicated logic into a shared helper or accept the ' +
+        'duplication via the allowlist when it is intentional ' +
+        '(e.g., parallel test fixtures, generated code that must stay literal).'
+      );
+    case 'coverage-gap':
+      return (
+        'Add a test covering the uncovered region. If the code path is ' +
+        'intentionally untested (build-time only, defensive error paths that ' +
+        'cannot be reached from tests), accept the gap via the allowlist.'
+      );
+    case 'test-gap':
+      return (
+        'Create a test file for this source file. The convention follows the ' +
+        "language's standard (e.g., `*_test.go` for go, `*.test.ts` for " +
+        'typescript, `test_*.py` for python).'
+      );
+    case 'test-file-degradation':
+      return (
+        'Restore the test body. Empty or fully commented-out test functions pass ' +
+        'silently in the test runner but provide no real coverage signal — they ' +
+        'are worse than no test because they hide gaps from view.'
+      );
+    case 'hygiene':
+      return (
+        'Resolve the hygiene marker (TODO, FIXME, HACK, debug-print, or loose ' +
+        '`any` type). Complete the work it points at, file it as a tracked issue ' +
+        'in your task management system, or remove the marker if the underlying ' +
+        'concern is already addressed.'
+      );
+    case 'god-file':
+      return (
+        'Split this file. It has grown beyond the maintainability threshold for ' +
+        'this codebase — large files concentrate change risk and make focused ' +
+        'review difficult. Extract cohesive subsets (related functions, related ' +
+        'types) into separate modules.'
+      );
+    case 'large-file':
+      return (
+        'Split this file into smaller modules. Long files concentrate ' +
+        'cognitive load and make change risk harder to assess; smaller ' +
+        'modules with clear boundaries are easier to maintain.'
+      );
+    case 'stale-file':
+      return (
+        'Remove the stale on-disk artifact (typically `.swp`, `.bak`, `.orig`, ' +
+        'or editor backup files). These should not be tracked in git — add the ' +
+        'pattern to `.gitignore` and untrack the file.'
+      );
+    case 'license':
+      return (
+        'License findings move to the inventory artifact ' +
+        '(`.dxkit/inventory/licenses.json`) in 2.6+ — allowlist suppression is ' +
+        'not the right surface. If a dependency license is acceptable for your ' +
+        'project, the inventory artifact records it without blocking.'
+      );
+  }
+}
+
+// ─── Internals ───────────────────────────────────────────────────────────
+
+/**
+ * Project a `BaselineEntry` to the file + line locator the hint
+ * formatter needs. Exhaustive switch on entry.kind — TypeScript
+ * enforces every variant is handled. Adding a new kind requires
+ * extending this projection.
+ *
+ * Kinds without a stable file:line locator (`dep-vuln`, `duplication`,
+ * `secret-hmac`, `license`) return `{}` and route to the
+ * `--fingerprint=<id>` CLI form.
+ */
+function entryLocator(entry: BaselineEntry): { file?: string; line?: number } {
+  switch (entry.kind) {
+    case 'secret':
+    case 'code':
+    case 'config':
+    case 'hygiene':
+      return { file: entry.file, line: entry.line };
+    case 'coverage-gap':
+    case 'test-gap':
+    case 'test-file-degradation':
+    case 'god-file':
+    case 'large-file':
+    case 'stale-file':
+      return { file: entry.file };
+    case 'secret-hmac':
+    case 'dep-vuln':
+    case 'duplication':
+    case 'license':
+      return {};
+  }
+}
+
+function isInlineCompatibleCategory(c: AllowlistCategory): boolean {
+  return c === 'false-positive' || c === 'test-fixture' || c === 'mitigated-externally';
+}
+
+/**
+ * Look up the language pack matching a file's extension. Reads
+ * from the canonical `LANGUAGES` registry — no per-language
+ * branching here. A new language pack auto-propagates.
+ */
+function inferLanguage(file: string): LanguageSupport | undefined {
+  const ext = path.extname(file).toLowerCase();
+  if (!ext) return undefined;
+  for (const lang of LANGUAGES) {
+    if (lang.sourceExtensions.includes(ext)) return lang;
+  }
+  return undefined;
+}
+
+function buildInlineExample(
+  entry: BaselineEntry,
+  firstInlineCategory: AllowlistCategory | undefined,
+): string | undefined {
+  if (!firstInlineCategory) return undefined;
+  if (!INLINE_COMPATIBLE_KINDS.has(entry.kind)) return undefined;
+  const loc = entryLocator(entry);
+  if (!loc.file || loc.line === undefined) return undefined;
+  const lang = inferLanguage(loc.file);
+  if (!lang || !lang.commentSyntax) return undefined;
+  return renderAnnotation({ category: firstInlineCategory, reason: '<your reason here>' }, lang);
+}
+
+function buildCliCommand(
+  entry: BaselineEntry,
+  applicableCategories: readonly AllowlistCategory[],
+): string {
+  const firstCategory = applicableCategories[0];
+  const reasonArg = `--reason="<rationale here>"`;
+  const categoryArg = firstCategory ? `--category=${firstCategory}` : '--category=<category>';
+  const loc = entryLocator(entry);
+
+  if (INLINE_COMPATIBLE_KINDS.has(entry.kind) && loc.file && loc.line !== undefined) {
+    return `npx vyuh-dxkit allowlist add ${loc.file}:${loc.line} ${categoryArg} ${reasonArg}`;
+  }
+  if (loc.file) {
+    return `npx vyuh-dxkit allowlist add ${loc.file} --kind=${entry.kind} ${categoryArg} ${reasonArg}`;
+  }
+  return `npx vyuh-dxkit allowlist add --fingerprint=${entry.id} --kind=${entry.kind} ${categoryArg} ${reasonArg}`;
+}
+
+function buildFileLevelHint(
+  applicableCategories: readonly AllowlistCategory[],
+): string | undefined {
+  const hasExpiringCategory = applicableCategories.some(
+    (c) => c === 'accepted-risk' || c === 'deferred',
+  );
+  if (!hasExpiringCategory) return undefined;
+  return (
+    'For accepted-risk or deferred suppression (both require an expiry date), ' +
+    'use --category=accepted-risk or --category=deferred with --expires=YYYY-MM-DD, ' +
+    'or edit .dxkit/allowlist.json directly.'
+  );
+}

--- a/src/allowlist/hint.ts
+++ b/src/allowlist/hint.ts
@@ -279,11 +279,17 @@ function buildCliCommand(
   const categoryArg = firstCategory ? `--category=${firstCategory}` : '--category=<category>';
   const loc = entryLocator(entry);
 
+  // Two CLI forms, matching the two paths the `allowlist add` command
+  // accepts. Both are directly executable — no inferred missing args.
+  //
+  //   1. `<file>:<line>` — inline annotation insertion (kind-agnostic,
+  //      grammar-driven). Only chosen when the kind supports inline
+  //      attachment AND the entry carries file + line.
+  //   2. `--fingerprint=<id> --kind=<kind>` — file-level allowlist
+  //      entry. The fingerprint is the identity; the kind is needed
+  //      so the validator can apply per-kind rules.
   if (INLINE_COMPATIBLE_KINDS.has(entry.kind) && loc.file && loc.line !== undefined) {
     return `${ALLOWLIST_ADD_CMD} ${loc.file}:${loc.line} ${categoryArg} ${reasonArg}`;
-  }
-  if (loc.file) {
-    return `${ALLOWLIST_ADD_CMD} ${loc.file} --kind=${entry.kind} ${categoryArg} ${reasonArg}`;
   }
   return `${ALLOWLIST_ADD_CMD} --fingerprint=${entry.id} --kind=${entry.kind} ${categoryArg} ${reasonArg}`;
 }

--- a/src/allowlist/hint.ts
+++ b/src/allowlist/hint.ts
@@ -38,8 +38,20 @@ import * as path from 'path';
 import type { BaselineEntry, FindingSeverity } from '../baseline/types';
 import { LANGUAGES } from '../languages';
 import type { LanguageSupport } from '../languages/types';
-import { CATEGORIES_BY_KIND, INLINE_COMPATIBLE_KINDS, type AllowlistCategory } from './categories';
+import {
+  CATEGORIES_BY_KIND,
+  EXPIRING_CATEGORIES,
+  INLINE_COMPATIBLE_CATEGORIES,
+  INLINE_COMPATIBLE_KINDS,
+  type AllowlistCategory,
+} from './categories';
 import { renderAnnotation } from './inline';
+
+/**
+ * Subcommand string used in every `cliCommand` rendered by this
+ * module. One place to update if the subcommand ever renames.
+ */
+const ALLOWLIST_ADD_CMD = 'npx vyuh-dxkit allowlist add';
 
 export interface BlockHint {
   /** Generic per-kind remediation text. Always present. */
@@ -78,7 +90,9 @@ export interface BlockHint {
  */
 export function formatBlockHint(entry: BaselineEntry, severity?: FindingSeverity): BlockHint {
   const applicableCategories = CATEGORIES_BY_KIND[entry.kind];
-  const inlineCompatibleApplicable = applicableCategories.filter(isInlineCompatibleCategory);
+  const inlineCompatibleApplicable = applicableCategories.filter((c) =>
+    INLINE_COMPATIBLE_CATEGORIES.has(c),
+  );
   const fileLevelOnly =
     !INLINE_COMPATIBLE_KINDS.has(entry.kind) || inlineCompatibleApplicable.length === 0;
 
@@ -229,10 +243,6 @@ function entryLocator(entry: BaselineEntry): { file?: string; line?: number } {
   }
 }
 
-function isInlineCompatibleCategory(c: AllowlistCategory): boolean {
-  return c === 'false-positive' || c === 'test-fixture' || c === 'mitigated-externally';
-}
-
 /**
  * Look up the language pack matching a file's extension. Reads
  * from the canonical `LANGUAGES` registry — no per-language
@@ -270,20 +280,18 @@ function buildCliCommand(
   const loc = entryLocator(entry);
 
   if (INLINE_COMPATIBLE_KINDS.has(entry.kind) && loc.file && loc.line !== undefined) {
-    return `npx vyuh-dxkit allowlist add ${loc.file}:${loc.line} ${categoryArg} ${reasonArg}`;
+    return `${ALLOWLIST_ADD_CMD} ${loc.file}:${loc.line} ${categoryArg} ${reasonArg}`;
   }
   if (loc.file) {
-    return `npx vyuh-dxkit allowlist add ${loc.file} --kind=${entry.kind} ${categoryArg} ${reasonArg}`;
+    return `${ALLOWLIST_ADD_CMD} ${loc.file} --kind=${entry.kind} ${categoryArg} ${reasonArg}`;
   }
-  return `npx vyuh-dxkit allowlist add --fingerprint=${entry.id} --kind=${entry.kind} ${categoryArg} ${reasonArg}`;
+  return `${ALLOWLIST_ADD_CMD} --fingerprint=${entry.id} --kind=${entry.kind} ${categoryArg} ${reasonArg}`;
 }
 
 function buildFileLevelHint(
   applicableCategories: readonly AllowlistCategory[],
 ): string | undefined {
-  const hasExpiringCategory = applicableCategories.some(
-    (c) => c === 'accepted-risk' || c === 'deferred',
-  );
+  const hasExpiringCategory = applicableCategories.some((c) => EXPIRING_CATEGORIES.has(c));
   if (!hasExpiringCategory) return undefined;
   return (
     'For accepted-risk or deferred suppression (both require an expiry date), ' +

--- a/src/allowlist/hint.ts
+++ b/src/allowlist/hint.ts
@@ -206,6 +206,13 @@ export function remediationFor(kind: BaselineEntry['kind']): string {
         'not the right surface. If a dependency license is acceptable for your ' +
         'project, the inventory artifact records it without blocking.'
       );
+    case 'stale-allow':
+      return (
+        'Remove the orphaned `dxkit-allow:` annotation — the finding it ' +
+        'suppressed is no longer present, so the annotation is dead code. ' +
+        'Allowlisting THIS finding is not supported; the only remediation is ' +
+        'to delete the annotation comment.'
+      );
   }
 }
 
@@ -227,6 +234,7 @@ function entryLocator(entry: BaselineEntry): { file?: string; line?: number } {
     case 'code':
     case 'config':
     case 'hygiene':
+    case 'stale-allow':
       return { file: entry.file, line: entry.line };
     case 'coverage-gap':
     case 'test-gap':

--- a/src/allowlist/inline.ts
+++ b/src/allowlist/inline.ts
@@ -296,11 +296,15 @@ function isCanonicalCategory(category: string): boolean {
  * the annotation body. Used to distinguish an above-line annotation
  * from a same-line annotation on a different finding's line.
  *
+ * Exported because the gather pass (`src/allowlist/gather.ts`) needs
+ * the same predicate to label per-occurrence `position`. Single
+ * source of truth for the "what counts as standalone" rule.
+ *
  * Example (python):
  *   `    # dxkit-allow:test-fixture reason="..."`   ← standalone
  *   `x = 1  # dxkit-allow:test-fixture reason="..."`  ← NOT standalone
  */
-function isStandaloneAnnotationLine(line: string, lang: LanguageSupport): boolean {
+export function isStandaloneAnnotationLine(line: string, lang: LanguageSupport): boolean {
   const marker = lang.commentSyntax?.lineComment;
   if (!marker) return false;
   const escapedMarker = escapeForRegex(marker);

--- a/src/allowlist/inline.ts
+++ b/src/allowlist/inline.ts
@@ -46,6 +46,15 @@ import * as fs from 'fs';
 import type { LanguageSupport } from '../languages/types';
 import { ALL_CATEGORIES, INLINE_COMPATIBLE_CATEGORIES, type AllowlistCategory } from './categories';
 
+/**
+ * Annotation prefix. Single source of truth — every consumer
+ * (renderer, parser, standalone-line detector) reads from here so
+ * changing the convention is a one-line edit.
+ */
+const ANNOTATION_PREFIX = 'dxkit-allow:';
+
+export type AnnotationPosition = 'same-line' | 'above';
+
 export interface InlineAnnotation {
   readonly category: AllowlistCategory;
   /** Free-form rationale. `undefined` when the annotation is
@@ -57,7 +66,7 @@ export interface InlineAnnotation {
 
 export interface AnnotationMatch {
   readonly annotation: InlineAnnotation;
-  readonly position: 'same-line' | 'above';
+  readonly position: AnnotationPosition;
   /** 1-indexed line where the annotation comment LIVES (not the
    *  finding's line — though they're the same for `same-line`). */
   readonly annotationLine: number;
@@ -82,7 +91,7 @@ const DEFAULT_SAME_LINE_THRESHOLD = 60;
  * prepending the language's `lineComment` token.
  */
 function annotationBody(annotation: InlineAnnotation): string {
-  let body = `dxkit-allow:${annotation.category}`;
+  let body = `${ANNOTATION_PREFIX}${annotation.category}`;
   if (annotation.reason !== undefined) {
     body += ` reason="${escapeReason(annotation.reason)}"`;
   }
@@ -124,13 +133,14 @@ export function parseAnnotation(line: string, lang: LanguageSupport): InlineAnno
   const marker = lang.commentSyntax?.lineComment;
   if (!marker) return null;
 
-  const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escapedMarker = escapeForRegex(marker);
+  const escapedPrefix = escapeForRegex(ANNOTATION_PREFIX);
   // The annotation prefix may appear at the start of the line
   // (above-line case) or after at least one whitespace following
   // the source code (same-line case). Trailing whitespace after the
   // prefix is tolerated.
   const re = new RegExp(
-    `(?:^|\\s)${escaped}\\s*dxkit-allow:(\\S+?)(?:\\s+reason="((?:[^"\\\\]|\\\\.)*)")?(?:\\s|$)`,
+    `(?:^|\\s)${escapedMarker}\\s*${escapedPrefix}(\\S+?)(?:\\s+reason="((?:[^"\\\\]|\\\\.)*)")?(?:\\s|$)`,
   );
   const match = re.exec(line);
   if (!match) return null;
@@ -220,7 +230,7 @@ export function insertAnnotation(
   annotation: InlineAnnotation,
   lang: LanguageSupport,
   options: InsertOptions = {},
-): { position: 'same-line' | 'above'; annotationLine: number } {
+): { position: AnnotationPosition; annotationLine: number } {
   if (!INLINE_COMPATIBLE_CATEGORIES.has(annotation.category)) {
     throw new Error(
       `category ${JSON.stringify(annotation.category)} is file-only — ` +
@@ -254,7 +264,7 @@ export function insertAnnotation(
   const targetLine = lines[lineNumber - 1];
   const commentText = `${marker} ${annotationBody(annotation)}`;
 
-  let position: 'same-line' | 'above';
+  let position: AnnotationPosition;
   let resultLine: number;
   if (targetLine.length < threshold) {
     // Same-line: append with two-space separator
@@ -293,9 +303,20 @@ function isCanonicalCategory(category: string): boolean {
 function isStandaloneAnnotationLine(line: string, lang: LanguageSupport): boolean {
   const marker = lang.commentSyntax?.lineComment;
   if (!marker) return false;
-  const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const re = new RegExp(`^\\s*${escaped}\\s*dxkit-allow:`);
+  const escapedMarker = escapeForRegex(marker);
+  const escapedPrefix = escapeForRegex(ANNOTATION_PREFIX);
+  const re = new RegExp(`^\\s*${escapedMarker}\\s*${escapedPrefix}`);
   return re.test(line);
+}
+
+/**
+ * Escape regex metacharacters in a string so it can be embedded
+ * literally inside a `RegExp` source. Shared helper so the
+ * escape pattern lives in one place — changing it (e.g., to handle
+ * a new metacharacter class) is a one-line edit.
+ */
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function escapeReason(text: string): string {

--- a/src/allowlist/inline.ts
+++ b/src/allowlist/inline.ts
@@ -1,0 +1,308 @@
+/**
+ * Inline allowlist annotations.
+ *
+ * Grammar:
+ *
+ *   <lineComment> dxkit-allow:<category> reason="<text>"
+ *
+ * Examples:
+ *
+ *   # dxkit-allow:test-fixture reason="placeholder in unit test"
+ *   // dxkit-allow:false-positive reason="regex matches our intentional placeholder"
+ *
+ * Two positions:
+ *
+ *   - **Same-line** — annotation appears on the same source line as
+ *     the finding, separated by at least one space:
+ *
+ *       api_key = "sk_test_xxxx"  # dxkit-allow:test-fixture reason="..."
+ *
+ *   - **Above-line** — annotation occupies its own line, immediately
+ *     preceding the finding (matching its indentation):
+ *
+ *       # dxkit-allow:test-fixture reason="..."
+ *       api_key = "sk_test_xxxx"
+ *
+ * The position is chosen at insert time by `insertAnnotation`: short
+ * source lines (under the configurable threshold) get same-line
+ * annotation; longer lines get above-line so the result stays
+ * readable.
+ *
+ * The grammar applies uniformly across every language; only the
+ * `<lineComment>` token varies (`#` for python/ruby, `//` for
+ * typescript/go/rust/csharp/kotlin/java). Each language pack
+ * declares its token via `LanguageSupport.commentSyntax`.
+ *
+ * # Quoting + escaping
+ *
+ * The reason is a JSON-style string. To embed a literal `"`, escape
+ * as `\"`; to embed a literal `\`, escape as `\\`. The parser
+ * un-escapes both on read; the writer escapes both on insert. No
+ * other escape sequences are supported (no `\n`, `\t`, etc.) — keep
+ * the reason single-line for human review.
+ */
+
+import * as fs from 'fs';
+import type { LanguageSupport } from '../languages/types';
+import { ALL_CATEGORIES, INLINE_COMPATIBLE_CATEGORIES, type AllowlistCategory } from './categories';
+
+export interface InlineAnnotation {
+  readonly category: AllowlistCategory;
+  /** Free-form rationale. `undefined` when the annotation is
+   *  syntactically valid but the `reason="..."` clause was omitted —
+   *  callers typically treat this as a "malformed annotation"
+   *  warning. */
+  readonly reason?: string;
+}
+
+export interface AnnotationMatch {
+  readonly annotation: InlineAnnotation;
+  readonly position: 'same-line' | 'above';
+  /** 1-indexed line where the annotation comment LIVES (not the
+   *  finding's line — though they're the same for `same-line`). */
+  readonly annotationLine: number;
+}
+
+export interface InsertOptions {
+  /**
+   * Maximum source-line length that still gets a same-line annotation.
+   * Longer lines get above-line annotation to keep the result
+   * readable. The annotation itself is typically 50-80 characters,
+   * so totaling source + annotation around 120-140 characters at
+   * this threshold.
+   */
+  readonly sameLineThreshold?: number;
+}
+
+const DEFAULT_SAME_LINE_THRESHOLD = 60;
+
+/**
+ * Build the annotation comment body (no leading whitespace, no
+ * comment marker). The caller composes the full comment by
+ * prepending the language's `lineComment` token.
+ */
+function annotationBody(annotation: InlineAnnotation): string {
+  let body = `dxkit-allow:${annotation.category}`;
+  if (annotation.reason !== undefined) {
+    body += ` reason="${escapeReason(annotation.reason)}"`;
+  }
+  return body;
+}
+
+/**
+ * Render a complete annotation comment for a given language.
+ * Exposed so callers (the CLI, the block-time hint formatter) can
+ * surface the exact string a developer would paste, without going
+ * through the file-mutation path.
+ */
+export function renderAnnotation(annotation: InlineAnnotation, lang: LanguageSupport): string {
+  const marker = lang.commentSyntax?.lineComment;
+  if (!marker) {
+    throw new Error(
+      `language ${lang.id} has no commentSyntax.lineComment; inline annotations unsupported`,
+    );
+  }
+  return `${marker} ${annotationBody(annotation)}`;
+}
+
+/**
+ * Parse a single line for an allowlist annotation. Returns `null`
+ * when no annotation marker is found OR when the category isn't
+ * one of the canonical values.
+ *
+ * Tolerates the `reason="..."` clause being absent — callers decide
+ * whether a missing reason invalidates the suppression.
+ *
+ * False-positive surface: a string literal containing the literal
+ * substring `<lineComment> dxkit-allow:<category>` would match.
+ * Discriminating "is this inside a string" requires real language
+ * parsing and isn't worth the complexity — the worst case is a
+ * legitimate finding gets suppressed when a developer wrote the
+ * grammar literally inside a string. Vanishingly rare in practice.
+ */
+export function parseAnnotation(line: string, lang: LanguageSupport): InlineAnnotation | null {
+  const marker = lang.commentSyntax?.lineComment;
+  if (!marker) return null;
+
+  const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // The annotation prefix may appear at the start of the line
+  // (above-line case) or after at least one whitespace following
+  // the source code (same-line case). Trailing whitespace after the
+  // prefix is tolerated.
+  const re = new RegExp(
+    `(?:^|\\s)${escaped}\\s*dxkit-allow:(\\S+?)(?:\\s+reason="((?:[^"\\\\]|\\\\.)*)")?(?:\\s|$)`,
+  );
+  const match = re.exec(line);
+  if (!match) return null;
+
+  const category = match[1];
+  if (!isCanonicalCategory(category)) return null;
+
+  const reasonRaw = match[2];
+  return {
+    category: category as AllowlistCategory,
+    reason: reasonRaw !== undefined ? unescapeReason(reasonRaw) : undefined,
+  };
+}
+
+/**
+ * Look for an annotation matching a finding at `filePath:lineNumber`
+ * (1-indexed). Checks two positions:
+ *
+ *   1. Same-line: the finding's line itself carries the annotation.
+ *   2. Above-line: the immediately-preceding line is a standalone
+ *      annotation comment.
+ *
+ * Returns `null` when neither position has a parseable annotation.
+ * Throws when the file doesn't exist or `lineNumber` is out of
+ * range — callers are typically operating on findings whose line
+ * numbers came from a fresh scan, so an out-of-range value
+ * indicates a bug worth surfacing.
+ */
+export function findAnnotationAt(
+  filePath: string,
+  lineNumber: number,
+  lang: LanguageSupport,
+): AnnotationMatch | null {
+  if (lineNumber < 1) {
+    throw new Error(`lineNumber must be >= 1, got ${lineNumber}`);
+  }
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split('\n');
+  if (lineNumber > lines.length) {
+    throw new Error(`lineNumber ${lineNumber} exceeds file length ${lines.length} (${filePath})`);
+  }
+
+  // 1. Same-line check
+  const targetLine = lines[lineNumber - 1];
+  const sameLine = parseAnnotation(targetLine, lang);
+  if (sameLine) {
+    return { annotation: sameLine, position: 'same-line', annotationLine: lineNumber };
+  }
+
+  // 2. Above-line check — only when a previous line exists
+  if (lineNumber > 1) {
+    const prev = lines[lineNumber - 2];
+    if (isStandaloneAnnotationLine(prev, lang)) {
+      const above = parseAnnotation(prev, lang);
+      if (above) {
+        return { annotation: above, position: 'above', annotationLine: lineNumber - 1 };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Insert an allowlist annotation at `filePath:lineNumber`. Chooses
+ * same-line vs above-line based on the target line's length:
+ *
+ *   - Target shorter than `sameLineThreshold` → append to target.
+ *   - Target longer than threshold → prepend a new comment line
+ *     above target, copying its indentation.
+ *
+ * Returns the chosen position + the 1-indexed line where the
+ * annotation comment ended up (useful for the CLI to print "added
+ * at file:line").
+ *
+ * Refuses to insert when the category is not inline-compatible —
+ * the caller should route accepted-risk + deferred suppressions
+ * through the file-level allowlist instead.
+ *
+ * Preserves CRLF vs LF line endings: the file is read, split, and
+ * re-joined using the detected style. Files without a trailing
+ * newline keep that property.
+ */
+export function insertAnnotation(
+  filePath: string,
+  lineNumber: number,
+  annotation: InlineAnnotation,
+  lang: LanguageSupport,
+  options: InsertOptions = {},
+): { position: 'same-line' | 'above'; annotationLine: number } {
+  if (!INLINE_COMPATIBLE_CATEGORIES.has(annotation.category)) {
+    throw new Error(
+      `category ${JSON.stringify(annotation.category)} is file-only — ` +
+        `use the file-level allowlist via 'vyuh-dxkit allowlist add'`,
+    );
+  }
+  const marker = lang.commentSyntax?.lineComment;
+  if (!marker) {
+    throw new Error(
+      `language ${lang.id} has no commentSyntax.lineComment; cannot render inline annotation`,
+    );
+  }
+  if (lineNumber < 1) {
+    throw new Error(`lineNumber must be >= 1, got ${lineNumber}`);
+  }
+
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const eol = raw.includes('\r\n') ? '\r\n' : '\n';
+  const hadTrailingNewline = raw.endsWith(eol);
+  const lines = raw.split(/\r?\n/);
+  // `split('\n')` on a trailing newline produces an empty final
+  // element; track and preserve it.
+  if (hadTrailingNewline && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  if (lineNumber > lines.length) {
+    throw new Error(`lineNumber ${lineNumber} exceeds file length ${lines.length} (${filePath})`);
+  }
+
+  const threshold = options.sameLineThreshold ?? DEFAULT_SAME_LINE_THRESHOLD;
+  const targetLine = lines[lineNumber - 1];
+  const commentText = `${marker} ${annotationBody(annotation)}`;
+
+  let position: 'same-line' | 'above';
+  let resultLine: number;
+  if (targetLine.length < threshold) {
+    // Same-line: append with two-space separator
+    lines[lineNumber - 1] = `${targetLine}  ${commentText}`;
+    position = 'same-line';
+    resultLine = lineNumber;
+  } else {
+    // Above-line: insert a new line BEFORE target with matching indent
+    const indent = (targetLine.match(/^[\t ]*/) ?? [''])[0];
+    lines.splice(lineNumber - 1, 0, `${indent}${commentText}`);
+    position = 'above';
+    resultLine = lineNumber;
+  }
+
+  const out = lines.join(eol) + (hadTrailingNewline ? eol : '');
+  fs.writeFileSync(filePath, out, 'utf8');
+  return { position, annotationLine: resultLine };
+}
+
+// ─── Internals ───────────────────────────────────────────────────────────
+
+function isCanonicalCategory(category: string): boolean {
+  return (ALL_CATEGORIES as readonly string[]).includes(category);
+}
+
+/**
+ * Whether a line is a "standalone annotation comment" — meaning it
+ * contains nothing but leading whitespace + the comment marker +
+ * the annotation body. Used to distinguish an above-line annotation
+ * from a same-line annotation on a different finding's line.
+ *
+ * Example (python):
+ *   `    # dxkit-allow:test-fixture reason="..."`   ← standalone
+ *   `x = 1  # dxkit-allow:test-fixture reason="..."`  ← NOT standalone
+ */
+function isStandaloneAnnotationLine(line: string, lang: LanguageSupport): boolean {
+  const marker = lang.commentSyntax?.lineComment;
+  if (!marker) return false;
+  const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`^\\s*${escaped}\\s*dxkit-allow:`);
+  return re.test(line);
+}
+
+function escapeReason(text: string): string {
+  return text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function unescapeReason(text: string): string {
+  // Process left-to-right: each `\<x>` collapses to `<x>`.
+  return text.replace(/\\(.)/g, '$1');
+}

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -399,6 +399,9 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     lines.push('');
   }
 
+  const allowlistLines = formatAllowlistDelta(result);
+  for (const l of allowlistLines) lines.push(l);
+
   lines.push('---');
   lines.push('');
   lines.push(
@@ -444,4 +447,65 @@ function escapeMd(s: string): string {
   // doesn't survive inside table cells in some renderers, so use a
   // visually-similar replacement for pipes.
   return s.replace(/\|/g, '\\|').replace(/`/g, "'");
+}
+
+/**
+ * Render the allowlist delta as a PR-comment section. Returns an
+ * empty array when there's nothing useful to show (no delta + the
+ * baseline SHA was reachable, meaning the file is genuinely
+ * unchanged). When the SHA was unreachable, emits a one-line note
+ * so the customer can see review signal is missing.
+ */
+function formatAllowlistDelta(result: GuardrailCheckResult): string[] {
+  const delta = result.allowlistDelta;
+  if (!delta) return [];
+
+  if (!delta.baselineAccessible) {
+    // Don't emit a section for the "definitely empty" case when
+    // there are also no current entries — too noisy. Only surface
+    // when something's actually obscured.
+    return [];
+  }
+
+  if (delta.added.length === 0 && delta.removed.length === 0) return [];
+
+  const lines: string[] = [];
+  const total = delta.added.length + delta.removed.length;
+  lines.push(`### Allowlist activity (${total})`);
+  lines.push('');
+  lines.push(
+    `Suppressions changed between baseline @ ${shortSha(result.baseline.repo.commitSha)} ` +
+      `and current. Review each entry's category + reason + expiry before approving.`,
+  );
+  lines.push('');
+
+  if (delta.added.length > 0) {
+    lines.push(`**Added (${delta.added.length})** — new suppressions on this branch:`);
+    lines.push('');
+    lines.push('| Fingerprint | Kind | Category | Expires | Reason |');
+    lines.push('|---|---|---|---|---|');
+    for (const e of delta.added) {
+      lines.push(
+        `| \`${escapeMd(e.fingerprint)}\` | ${escapeMd(e.kind)} | ` +
+          `${escapeMd(e.category)} | ${escapeMd(e.expiresAt ?? '—')} | ` +
+          `${escapeMd(e.reason ?? '—')} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (delta.removed.length > 0) {
+    lines.push(`**Removed (${delta.removed.length})** — suppressions deleted on this branch:`);
+    lines.push('');
+    lines.push('| Fingerprint | Kind | Category |');
+    lines.push('|---|---|---|');
+    for (const e of delta.removed) {
+      lines.push(
+        `| \`${escapeMd(e.fingerprint)}\` | ${escapeMd(e.kind)} | ${escapeMd(e.category)} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  return lines;
 }

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -50,6 +50,7 @@ import { classify, DEFAULT_BROWNFIELD_POLICY } from './policy';
 import type { BrownfieldPolicy, ClassifyContext, ClassifyResult } from './policy';
 import type { BaselineEntry, FindingId, FindingSeverity, MatchPair, MatchResult } from './types';
 import type { SecurityAggregate } from '../analyzers/security/aggregator';
+import { computeAllowlistDelta, type AllowlistDelta } from '../allowlist/diff';
 
 export interface RunGuardrailCheckOptions {
   /** Repo root being checked. Caller should pass an absolute path. */
@@ -132,6 +133,12 @@ export interface GuardrailCheckResult {
   /** True when at least one pair warns. Informational; doesn't
    *  affect exit code by itself. */
   readonly warns: boolean;
+  /** Allowlist entries added / removed between the baseline's
+   *  commit SHA and the current working tree. Renderers (the PR
+   *  comment markdown in particular) surface this so reviewers
+   *  see new suppressions being introduced. Absent when the
+   *  baseline SHA wasn't reachable to diff against. */
+  readonly allowlistDelta: AllowlistDelta;
 }
 
 const KIND_DEFAULT_SEVERITY: Readonly<Record<BaselineEntry['kind'], FindingSeverity>> =
@@ -280,6 +287,13 @@ export async function runGuardrailCheck(
     if (p.classification.warns) filteredWarns = true;
   }
 
+  // Allowlist delta between the baseline's anchor SHA and the
+  // current working tree. Surfaced in the markdown renderer so
+  // PR reviewers see new suppressions being introduced; absent /
+  // degenerate when the SHA isn't reachable (shallow clone, etc.)
+  // and the renderer treats that as "delta unavailable."
+  const allowlistDelta: AllowlistDelta = computeAllowlistDelta(cwd, baseline.repo.commitSha);
+
   return {
     baselinePath,
     baseline,
@@ -290,6 +304,7 @@ export async function runGuardrailCheck(
     policy,
     blocks: options.changedOnly ? filteredBlocks : blocks,
     warns: options.changedOnly ? filteredWarns : warns,
+    allowlistDelta,
   };
 }
 

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -150,6 +150,11 @@ const KIND_DEFAULT_SEVERITY: Readonly<Record<BaselineEntry['kind'], FindingSever
     'stale-file': 'low',
     'large-file': 'medium',
     'secret-hmac': 'high',
+    // Stale-allow is a self-detected dxkit hygiene finding (orphaned
+    // allowlist annotation). Low severity — it's a maintenance signal,
+    // not an active risk; the underlying suppressed finding is already
+    // gone.
+    'stale-allow': 'low',
   });
 
 /**

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -45,6 +45,7 @@ import { resolveSalt } from './salt';
 import type { SaltMode } from './salt';
 import type { BaselineEntry } from './types';
 import type { SecurityAggregate } from '../analyzers/security/aggregator';
+import { gatherInlineAllowlistAnnotations } from '../allowlist/gather';
 
 export interface CreateBaselineOptions {
   /** Repo root to baseline. Caller should pass an absolute path. */
@@ -306,6 +307,10 @@ export async function gatherCurrentScan(options: {
   const gitleaksOutcome = gatherGitleaksResult(cwd);
   const rawSecrets: ReadonlyArray<GitleaksRawSecret> =
     gitleaksOutcome.kind === 'success' ? gitleaksOutcome.rawSecrets : [];
+  // Inline `dxkit-allow:` annotations gathered from source so the
+  // stale-allow producer can flag orphans whose underlying findings
+  // are no longer present.
+  const inlineAllowlistAnnotations = gatherInlineAllowlistAnnotations(cwd);
 
   const producerCtx: ProducerContext = {
     cwd,
@@ -315,6 +320,7 @@ export async function gatherCurrentScan(options: {
     testGapsReport,
     hygiene: hygieneMarkers,
     rawSecrets,
+    inlineAllowlistAnnotations,
   };
 
   // Dispatch through the canonical producer registry (CLAUDE.md

--- a/src/baseline/entry-to-located.ts
+++ b/src/baseline/entry-to-located.ts
@@ -52,6 +52,17 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
         rule: entry.marker,
         ...(entry.contentHash !== undefined ? { contentHash: entry.contentHash } : {}),
       };
+    case 'stale-allow':
+      // Annotation comments don't have a tool/rule pair — the
+      // "rule" is the annotation's category. Reuse the field so
+      // the matcher's location-pair pass can treat them like other
+      // source-anchored kinds.
+      return {
+        id: entry.id,
+        file: entry.file,
+        line: entry.line,
+        rule: entry.category,
+      };
     case 'dep-vuln':
     case 'duplication':
     case 'coverage-gap':

--- a/src/baseline/finding-identity.ts
+++ b/src/baseline/finding-identity.ts
@@ -93,6 +93,8 @@ export function identityFor(
       return computeLargeFileIdentity(input.file);
     case 'secret-hmac':
       return computeSecretHmacIdentity(input.tool, input.rule, input.hmac);
+    case 'stale-allow':
+      return computeStaleAllowIdentity(input.file, input.line, input.category);
   }
 }
 
@@ -263,6 +265,20 @@ function computeLargeFileIdentity(file: string): FindingId {
 function computeSecretHmacIdentity(tool: string, rule: string, hmac: string): FindingId {
   const canonicalRule = canonicalRuleFor(tool, rule);
   const input = `secret-hmac\0v1\0${canonicalRule}\0${hmac}`;
+  return createHash('sha1').update(input).digest('hex').slice(0, 16);
+}
+
+/**
+ * Identity for an orphaned inline allowlist annotation. Line is
+ * bucketed via the canonical 3-line window so small formatter /
+ * unrelated-edit drift doesn't churn identity. Category is part of
+ * identity so reclassifying an annotation (test-fixture →
+ * false-positive on the same source line) registers as a fresh
+ * finding — the new category's appropriateness is a separate
+ * judgment worth surfacing.
+ */
+function computeStaleAllowIdentity(file: string, line: number, category: string): FindingId {
+  const input = `stale-allow\0v1\0${file}\0${lineWindowFor(line)}\0${category}`;
   return createHash('sha1').update(input).digest('hex').slice(0, 16);
 }
 

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -53,12 +53,14 @@
 import type { GitleaksRawSecret } from '../../analyzers/tools/gitleaks';
 import type { AnalysisResult } from '../../analysis-result';
 import type { TestGapsReport } from '../../analyzers/tests/types';
+import type { InlineAllowlistOccurrence } from '../../allowlist/gather';
 import type { BaselineEntry } from '../types';
 import { largeFilesToBaselineEntries } from './health';
 import { licensesToBaselineEntries } from './licenses';
 import { duplicationToBaselineEntries, staleFilesToBaselineEntries } from './quality';
 import { rawSecretsToBaselineEntries } from './secret-hmac';
 import { securityAggregateToBaselineEntries } from './security';
+import { staleAllowToBaselineEntries } from './stale-allow';
 import { testGapsToBaselineEntries } from './tests';
 
 /** Every discriminant value the `BaselineEntry` union takes. Mirror
@@ -111,6 +113,10 @@ export interface ProducerContext {
   /** Raw secrets gitleaks captured (process-only; never written to
    *  disk; consumed by the secret-HMAC producer). */
   readonly rawSecrets: ReadonlyArray<GitleaksRawSecret>;
+  /** Inline `dxkit-allow:` annotations gathered from source files.
+   *  Consumed by the stale-allow producer to detect orphaned
+   *  annotations whose underlying finding is gone. */
+  readonly inlineAllowlistAnnotations: ReadonlyArray<InlineAllowlistOccurrence>;
 }
 
 /**
@@ -173,15 +179,6 @@ export const DEFERRED_KINDS: Readonly<
       'Substitute: test-gap covers file-level untested; new uncovered functions ' +
       'inside an already-tested file remain invisible until Phase 3.5 lands.',
     landingPhase: 'Phase 3.5 (5 packs) / 2.6 (remaining)',
-  },
-  'stale-allow': {
-    reason:
-      'inline allowlist annotation gather pass not yet wired into baseline-create. ' +
-      "The kind exists structurally so identityFor's exhaustive switch and the " +
-      'per-kind tables (CATEGORIES_BY_KIND, hint switches) auto-include it; the ' +
-      'producer ships with the gather pass that scans source files for orphaned ' +
-      '`dxkit-allow:` comments and compares against current findings.',
-    landingPhase: '2.6 / strict-stale-annotation-detection chunk',
   },
 });
 
@@ -248,6 +245,17 @@ const TESTS_PRODUCER: BaselineProducer = {
   },
 };
 
+const STALE_ALLOW_PRODUCER: BaselineProducer = {
+  name: 'stale-allow',
+  contributes: ['stale-allow'],
+  produce(ctx) {
+    return staleAllowToBaselineEntries({
+      annotations: ctx.inlineAllowlistAnnotations,
+      aggregate: ctx.analysisResult.capabilities.securityAggregate ?? null,
+    });
+  },
+};
+
 /**
  * The canonical producer list. Order is preserved in baseline-file
  * output for deterministic diffs; adding a new producer appends
@@ -264,6 +272,7 @@ export const PRODUCERS: ReadonlyArray<BaselineProducer> = Object.freeze([
   HEALTH_PRODUCER,
   LICENSES_PRODUCER,
   TESTS_PRODUCER,
+  STALE_ALLOW_PRODUCER,
 ]);
 
 /**

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -174,6 +174,15 @@ export const DEFERRED_KINDS: Readonly<
       'inside an already-tested file remain invisible until Phase 3.5 lands.',
     landingPhase: 'Phase 3.5 (5 packs) / 2.6 (remaining)',
   },
+  'stale-allow': {
+    reason:
+      'inline allowlist annotation gather pass not yet wired into baseline-create. ' +
+      "The kind exists structurally so identityFor's exhaustive switch and the " +
+      'per-kind tables (CATEGORIES_BY_KIND, hint switches) auto-include it; the ' +
+      'producer ships with the gather pass that scans source files for orphaned ' +
+      '`dxkit-allow:` comments and compares against current findings.',
+    landingPhase: '2.6 / strict-stale-annotation-detection chunk',
+  },
 });
 
 // ─── Producer module wrappers ─────────────────────────────────────────────

--- a/src/baseline/producers/stale-allow.ts
+++ b/src/baseline/producers/stale-allow.ts
@@ -1,0 +1,118 @@
+/**
+ * Stale-allow → baseline-entry producer.
+ *
+ * Detects orphaned inline allowlist annotations — `dxkit-allow:`
+ * comments in source files that no longer match any current
+ * finding. The developer added the annotation when something was
+ * flagged; the finding is now gone (resolved, scanner-rule changed,
+ * code refactored); the annotation is dead code that should be
+ * removed.
+ *
+ * # The matching contract
+ *
+ * An annotation at `(file, line)` is considered ACTIVE when at
+ * least one current finding lands at the same `(file, lineWindow)` —
+ * the 3-line window from `lineWindowFor` absorbs small formatter /
+ * line-shift drift so a still-relevant annotation doesn't get
+ * flagged stale by an unrelated edit.
+ *
+ * Annotations with no matching finding emit a `stale-allow`
+ * `BaselineEntry` whose identity is `(file, lineWindow, category)`.
+ * The strict-stale model (TypeScript's `@ts-expect-error` pattern)
+ * forces the developer to clean up — preventing the annotation
+ * graveyard pattern common to less strict tools.
+ *
+ * # What counts as a "covered location"
+ *
+ * Source-anchored finding kinds — `secret`, `code`, `config` —
+ * carry `(file, line)` and contribute to the covered set. The
+ * `findingsByCategory` arrays on the canonical `SecurityAggregate`
+ * are the only source today; the aggregator is the single canonical
+ * fingerprint-deduped source of these findings (CLAUDE.md G_v4_8).
+ *
+ * Kinds without `(file, line)` — `dep-vuln`, `duplication`,
+ * `secret-hmac`, `license`, etc. — never participate in inline-
+ * annotation matching by construction. Annotations targeting those
+ * findings always use the file-level allowlist.
+ *
+ * # Mode handling
+ *
+ * `staleHandling` lives in `.dxkit/policy.json` (out of scope for
+ * this producer — the orchestrator gates whether to call it). When
+ * called, the producer emits `stale-allow` entries unconditionally
+ * for every orphan; the policy-level "lenient mode" surfaces these
+ * as warnings in the renderer rather than as blocking entries.
+ */
+
+import { lineWindowFor } from '../../analyzers/tools/fingerprint';
+import type { SecurityAggregate } from '../../analyzers/security/aggregator';
+import type { InlineAllowlistOccurrence } from '../../allowlist/gather';
+import { identityFor } from '../finding-identity';
+import type { BaselineEntry, StaleAllowIdentityInput } from '../types';
+
+export interface StaleAllowInput {
+  readonly annotations: ReadonlyArray<InlineAllowlistOccurrence>;
+  readonly aggregate: SecurityAggregate | null;
+}
+
+/**
+ * Build `stale-allow` entries from the annotation list + the
+ * canonical security aggregate. Pure function — no I/O, no side
+ * effects. Deterministic over equal inputs.
+ *
+ * Returns an empty array when:
+ *   - The annotation list is empty (nothing to check).
+ *   - The aggregate is null AND the annotation list is empty.
+ *
+ * When the aggregate is null but annotations exist, the producer
+ * conservatively emits NO stale entries — the caller has no way to
+ * know whether annotations are active or stale without the
+ * findings. Surfacing "everything is stale" in that scenario would
+ * be wrong; surfacing "everything is fine" is also wrong but less
+ * actively misleading.
+ */
+export function staleAllowToBaselineEntries(input: StaleAllowInput): BaselineEntry[] {
+  if (input.annotations.length === 0) return [];
+  if (input.aggregate === null) return [];
+
+  const covered = buildCoveredLocations(input.aggregate);
+  const out: BaselineEntry[] = [];
+  for (const occ of input.annotations) {
+    const key = locationKey(occ.file, occ.line);
+    if (covered.has(key)) continue; // active suppression — not stale
+    const identityInput: StaleAllowIdentityInput = {
+      kind: 'stale-allow',
+      file: occ.file,
+      line: occ.line,
+      category: occ.category,
+    };
+    out.push({
+      id: identityFor(identityInput),
+      kind: 'stale-allow',
+      file: occ.file,
+      line: occ.line,
+      category: occ.category,
+    });
+  }
+  return out;
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────
+
+function buildCoveredLocations(aggregate: SecurityAggregate): Set<string> {
+  const out = new Set<string>();
+  for (const f of aggregate.findingsByCategory.secret) {
+    out.add(locationKey(f.file, f.line));
+  }
+  for (const f of aggregate.findingsByCategory.code) {
+    out.add(locationKey(f.file, f.line));
+  }
+  for (const f of aggregate.findingsByCategory.config) {
+    out.add(locationKey(f.file, f.line));
+  }
+  return out;
+}
+
+function locationKey(file: string, line: number): string {
+  return `${file}\0${lineWindowFor(line)}`;
+}

--- a/src/baseline/show.ts
+++ b/src/baseline/show.ts
@@ -209,6 +209,8 @@ function describeEntry(entry: BaselineEntry): string {
       return `${entry.file}  [.${entry.suffix}]`;
     case 'secret-hmac':
       return `[${entry.tool}/${entry.rule}]  hmac:${entry.hmac.slice(0, 12)}`;
+    case 'stale-allow':
+      return `${entry.file}:${entry.line}  [stale dxkit-allow:${entry.category}]`;
   }
 }
 

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -96,7 +96,8 @@ export type IdentityInput =
   | GodFileIdentityInput
   | StaleFileIdentityInput
   | LargeFileIdentityInput
-  | SecretHmacIdentityInput;
+  | SecretHmacIdentityInput
+  | StaleAllowIdentityInput;
 
 /** gitleaks + private-key files + similar secret detectors. */
 export interface SecretIdentityInput {
@@ -330,6 +331,33 @@ export interface SecretHmacIdentityInput {
 }
 
 /**
+ * Orphaned inline allowlist annotation — a `dxkit-allow:<category>`
+ * comment in a source file that matches no current finding. The
+ * developer suppressed something that's since been fixed (or the
+ * scanner stopped flagging), and the annotation should be removed.
+ * TypeScript's `@ts-expect-error` proved this pattern: tools that
+ * surface their own stale suppressions as findings force the dev
+ * to clean up, preventing the annotation graveyard.
+ *
+ * Identity is `(file, lineWindow, category)` — same 3-line window
+ * the code-finding fingerprint uses, so formatter / unrelated-edit
+ * line drift doesn't churn identity. Category is part of identity
+ * because a `# dxkit-allow:test-fixture` becoming
+ * `# dxkit-allow:false-positive` (developer reclassified mid-review)
+ * is a semantically different stale-allow.
+ */
+export interface StaleAllowIdentityInput {
+  readonly kind: 'stale-allow';
+  readonly file: string;
+  readonly line: number;
+  /** The category named in the orphaned annotation. Free-form
+   *  string at identity-input level (the canonical
+   *  `AllowlistCategory` union lives in `src/allowlist/categories.ts`
+   *  to avoid a cross-module import here in the baseline types). */
+  readonly category: string;
+}
+
+/**
  * Per-finding entry stored in a baseline. Carries identity plus the
  * minimum metadata needed for cross-run drift-tolerant matching —
  * never raw payloads (no titles, no secret content, no source
@@ -397,7 +425,8 @@ export type BaselineEntry =
   | { id: FindingId; kind: 'god-file'; file: string }
   | { id: FindingId; kind: 'stale-file'; file: string; suffix: string }
   | { id: FindingId; kind: 'large-file'; file: string }
-  | { id: FindingId; kind: 'secret-hmac'; tool: string; rule: string; hmac: string };
+  | { id: FindingId; kind: 'secret-hmac'; tool: string; rule: string; hmac: string }
+  | { id: FindingId; kind: 'stale-allow'; file: string; line: number; category: string };
 
 /**
  * One pairing decision from the matcher. Carries enough context for

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,6 +128,18 @@ function printUsage(): void {
                                  package.json postinstall by 'init --with-hooks' so every
                                  clone + 'npm install' activates the dxkit hooks
                                  automatically. Safe to run by hand; always exits 0.
+    vyuh-dxkit allowlist add <file:line> --category=<cat> --reason=<text>
+    vyuh-dxkit allowlist add --fingerprint=<id> --kind=<kind> --category=<cat>
+                             --reason=<text> [--expires=<YYYY-MM-DD>]
+                                 Suppress an individual finding with a typed category
+                                 (false-positive / test-fixture / mitigated-externally /
+                                 accepted-risk / deferred) and required reason. Inline
+                                 form inserts a dxkit-allow: annotation; file-level
+                                 form writes to .dxkit/allowlist.json.
+    vyuh-dxkit allowlist list | show <fingerprint> | audit | prune [--dry-run] [--json]
+                                 Review / audit / clean the allowlist. audit surfaces
+                                 expired + soon-to-expire (within 14 days) + missing-
+                                 rationale entries. prune removes expired entries.
     vyuh-dxkit issue --type=<type> [--about=<text>] [--fingerprint=<id>] [--no-browser]
                                  Open a pre-filled GitHub Issue against vyuh-labs/dxkit.
                                  Types: false-positive, missing-finding, bug,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -240,6 +240,14 @@ export async function run(argv: string[]): Promise<void> {
       target: { type: 'string' },
       'dry-run': { type: 'boolean', default: false },
       plan: { type: 'boolean', default: false },
+      // allowlist flags (allowlist add | list | show)
+      category: { type: 'string' },
+      reason: { type: 'string' },
+      fingerprint: { type: 'string' },
+      expires: { type: 'string' },
+      'acknowledged-severity': { type: 'string' },
+      'added-by': { type: 'string' },
+      mode: { type: 'string' },
     },
     allowPositionals: true,
     strict: false,
@@ -1719,6 +1727,17 @@ export async function run(argv: string[]): Promise<void> {
         dryRun: !!values['dry-run'],
         planOnly: !!values.plan,
         json: !!values.json,
+      });
+      break;
+    }
+
+    case 'allowlist': {
+      const { runAllowlist } = await import('./allowlist/cli');
+      // positionals[1] = subcommand (add | list | show)
+      // positionals[2] = optional target (file:line for add, fingerprint for show)
+      await runAllowlist(cwd, positionals[1], {
+        positionalAfter: positionals[2],
+        values: values as Record<string, unknown>,
       });
       break;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -240,7 +240,7 @@ export async function run(argv: string[]): Promise<void> {
       target: { type: 'string' },
       'dry-run': { type: 'boolean', default: false },
       plan: { type: 'boolean', default: false },
-      // allowlist flags (allowlist add | list | show)
+      // allowlist flags (allowlist add | list | show | audit | prune)
       category: { type: 'string' },
       reason: { type: 'string' },
       fingerprint: { type: 'string' },
@@ -248,6 +248,7 @@ export async function run(argv: string[]): Promise<void> {
       'acknowledged-severity': { type: 'string' },
       'added-by': { type: 'string' },
       mode: { type: 'string' },
+      'soon-days': { type: 'string' },
     },
     allowPositionals: true,
     strict: false,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,6 +128,11 @@ function printUsage(): void {
                                  package.json postinstall by 'init --with-hooks' so every
                                  clone + 'npm install' activates the dxkit hooks
                                  automatically. Safe to run by hand; always exits 0.
+    vyuh-dxkit issue --type=<type> [--about=<text>] [--fingerprint=<id>] [--no-browser]
+                                 Open a pre-filled GitHub Issue against vyuh-labs/dxkit.
+                                 Types: false-positive, missing-finding, bug,
+                                 feature-request, docs. Nothing is submitted until
+                                 you click "Submit" in your browser.
 
   ${logger.bold('Init options:')}
     --dx-only                 Just .claude/ + CLAUDE.md (default)
@@ -249,6 +254,10 @@ export async function run(argv: string[]): Promise<void> {
       'added-by': { type: 'string' },
       mode: { type: 'string' },
       'soon-days': { type: 'string' },
+      // issue flags
+      type: { type: 'string' },
+      about: { type: 'string' },
+      'no-browser': { type: 'boolean', default: false },
     },
     allowPositionals: true,
     strict: false,
@@ -1739,6 +1748,17 @@ export async function run(argv: string[]): Promise<void> {
       await runAllowlist(cwd, positionals[1], {
         positionalAfter: positionals[2],
         values: values as Record<string, unknown>,
+      });
+      break;
+    }
+
+    case 'issue': {
+      const { runIssueSubmit } = await import('./issue-cli');
+      await runIssueSubmit(cwd, {
+        type: values.type as string | undefined,
+        fingerprint: values.fingerprint as string | undefined,
+        about: values.about as string | undefined,
+        noBrowser: !!values['no-browser'],
       });
       break;
     }

--- a/src/issue-cli.ts
+++ b/src/issue-cli.ts
@@ -1,0 +1,244 @@
+/**
+ * `vyuh-dxkit issue` — open a pre-filled GitHub Issue against
+ * `vyuh-labs/dxkit` in the customer's default browser.
+ *
+ * The dxkit team triages bugs / false-positive reports / feature
+ * requests in GitHub Issues. Sending customers there directly (vs
+ * email / a custom form) keeps:
+ *
+ *   - Triage centralized (labels, assignees, dedup search)
+ *   - Status visible to the customer (they can subscribe to their
+ *     own issue, see comments, get notified on resolution)
+ *   - Zero infra for us to maintain (no SMTP, no webhook, no DB)
+ *
+ * The CLI builds a URL with pre-filled title + body + labels and
+ * opens it via the platform's default browser. Customer reviews
+ * the prefill before clicking "Submit new issue" — nothing is
+ * sent without their explicit click.
+ *
+ * Body prefill includes:
+ *   - dxkit version (from package.json)
+ *   - Node version, platform, arch (so triage can reproduce)
+ *   - Issue type + optional fingerprint (when reporting a
+ *     false-positive on a specific finding)
+ *   - Customer's `--about` text (free-form description) OR a
+ *     "TODO: describe..." placeholder
+ *
+ * # Privacy
+ *
+ * NOTHING is submitted automatically. The CLI opens a URL with
+ * query-string pre-fill; the customer reviews + edits + clicks
+ * "Submit." All env data in the prefill is the kind already
+ * visible in `npx vyuh-dxkit --version` — no source content, no
+ * customer-identifying paths beyond the project name.
+ */
+
+import { spawn } from 'child_process';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import * as logger from './logger';
+
+export const ISSUE_TYPES = [
+  'false-positive',
+  'missing-finding',
+  'bug',
+  'feature-request',
+  'docs',
+] as const;
+export type IssueType = (typeof ISSUE_TYPES)[number];
+
+/** Per-type GitHub label that will be pre-applied. The labels
+ *  themselves must exist on the repo; dxkit's repo carries these
+ *  by convention. */
+const LABEL_BY_TYPE: Readonly<Record<IssueType, string>> = Object.freeze({
+  'false-positive': 'false-positive',
+  'missing-finding': 'missing-finding',
+  bug: 'bug',
+  'feature-request': 'enhancement',
+  docs: 'documentation',
+});
+
+/** Per-type title prefix surfaced in the GitHub Issues list. */
+const TITLE_PREFIX_BY_TYPE: Readonly<Record<IssueType, string>> = Object.freeze({
+  'false-positive': 'False positive',
+  'missing-finding': 'Missing finding',
+  bug: 'Bug',
+  'feature-request': 'Feature request',
+  docs: 'Docs',
+});
+
+const ISSUES_BASE_URL = 'https://github.com/vyuh-labs/dxkit/issues/new';
+
+export interface IssueSubmitOpts {
+  readonly type?: string;
+  readonly fingerprint?: string;
+  readonly about?: string;
+  /** Print the URL to stdout instead of opening a browser. Useful
+   *  in CI / SSH sessions without a default browser handler. */
+  readonly noBrowser?: boolean;
+}
+
+export interface BuildIssueUrlInput {
+  readonly type: IssueType;
+  readonly about?: string;
+  readonly fingerprint?: string;
+  readonly dxkitVersion: string;
+  readonly nodeVersion: string;
+  readonly platform: string;
+  readonly arch: string;
+}
+
+/**
+ * Pure function: build the GitHub Issues "new issue" URL with
+ * pre-filled title / body / labels. Exposed for unit testing —
+ * callers without browser-open side effects can verify the URL
+ * shape directly.
+ */
+export function buildIssueUrl(input: BuildIssueUrlInput): string {
+  const params = new URLSearchParams();
+  params.set('title', buildTitle(input));
+  params.set('body', buildBody(input));
+  params.set('labels', LABEL_BY_TYPE[input.type]);
+  return `${ISSUES_BASE_URL}?${params.toString()}`;
+}
+
+export async function runIssueSubmit(cwd: string, opts: IssueSubmitOpts): Promise<void> {
+  const type = parseIssueType(opts.type);
+  const url = buildIssueUrl({
+    type,
+    about: opts.about,
+    fingerprint: opts.fingerprint?.trim() || undefined,
+    dxkitVersion: readDxkitVersion(),
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+  });
+
+  if (opts.noBrowser) {
+    // Print URL to stdout so callers in CI / SSH can copy.
+    process.stdout.write(url + '\n');
+    return;
+  }
+
+  logger.info(`Opening pre-filled issue in your browser…`);
+  logger.info(`If the browser doesn't open, copy this URL:`);
+  logger.info(`  ${url}`);
+  void openBrowser(cwd, url);
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────
+
+function parseIssueType(raw: string | undefined): IssueType {
+  if (!raw) {
+    logger.fail(`--type is required. One of: ${ISSUE_TYPES.join(', ')}.`);
+    process.exit(1);
+  }
+  if (!(ISSUE_TYPES as readonly string[]).includes(raw)) {
+    logger.fail(
+      `--type ${JSON.stringify(raw)} is not a known issue type. ` +
+        `One of: ${ISSUE_TYPES.join(', ')}.`,
+    );
+    process.exit(1);
+  }
+  return raw as IssueType;
+}
+
+function buildTitle(input: BuildIssueUrlInput): string {
+  const prefix = TITLE_PREFIX_BY_TYPE[input.type];
+  const aboutShort = input.about ? truncate(input.about, 60) : '';
+  if (aboutShort) {
+    return `[${prefix}] ${aboutShort}`;
+  }
+  if (input.fingerprint) {
+    return `[${prefix}] finding ${input.fingerprint}`;
+  }
+  return `[${prefix}] `;
+}
+
+function buildBody(input: BuildIssueUrlInput): string {
+  const lines: string[] = [];
+  lines.push(`**Type:** ${input.type}`);
+  lines.push(`**dxkit version:** ${input.dxkitVersion}`);
+  lines.push(`**Node version:** ${input.nodeVersion}`);
+  lines.push(`**Platform:** ${input.platform} / ${input.arch}`);
+  if (input.fingerprint) {
+    lines.push(`**Finding fingerprint:** \`${input.fingerprint}\``);
+  }
+  lines.push('');
+  lines.push('## What happened');
+  lines.push('');
+  lines.push(input.about ?? '<!-- Describe what you observed -->');
+  lines.push('');
+  lines.push('## What you expected');
+  lines.push('');
+  lines.push('<!-- Describe the behavior you expected -->');
+  lines.push('');
+  lines.push('## How to reproduce');
+  lines.push('');
+  lines.push('<!-- Minimal repro steps. Pseudo-code / sample input is fine. -->');
+  lines.push('');
+  lines.push('## Anything else');
+  lines.push('');
+  lines.push('<!-- Logs, screenshots, related issues, etc. -->');
+  return lines.join('\n');
+}
+
+function readDxkitVersion(): string {
+  try {
+    // Two possible locations: same package as this module (dev / source)
+    // and `node_modules/@vyuhlabs/dxkit/package.json` (installed).
+    // __dirname points at dist/ or src/ depending on build; resolve
+    // upward to find package.json.
+    const candidates = [
+      path.join(__dirname, '..', 'package.json'),
+      path.join(__dirname, '..', '..', 'package.json'),
+    ];
+    for (const candidate of candidates) {
+      try {
+        const pkg = JSON.parse(readFileSync(candidate, 'utf8')) as { version?: string };
+        if (typeof pkg.version === 'string') return pkg.version;
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    // fall through
+  }
+  return 'unknown';
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + '…';
+}
+
+/**
+ * Open `url` in the customer's default browser. Detached so the CLI
+ * exits without waiting for the browser process. Errors are
+ * swallowed — the URL is also printed to stdout so the customer can
+ * copy it manually if the open fails (corporate workstation, no
+ * `xdg-open` configured, etc.).
+ */
+function openBrowser(cwd: string, url: string): void {
+  let cmd: string;
+  let args: string[];
+  if (process.platform === 'darwin') {
+    cmd = 'open';
+    args = [url];
+  } else if (process.platform === 'win32') {
+    cmd = 'cmd';
+    args = ['/c', 'start', '""', url];
+  } else {
+    // Linux / WSL / *BSD — xdg-open is the freedesktop standard.
+    // WSL2 environments without an X server fall through to no-op
+    // (the URL was already printed by the caller).
+    cmd = 'xdg-open';
+    args = [url];
+  }
+  try {
+    const child = spawn(cmd, args, { cwd, detached: true, stdio: 'ignore' });
+    child.unref();
+  } catch {
+    // Silent — the URL is already in the customer's terminal.
+  }
+}

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -1281,6 +1281,7 @@ const csharpLicensesProvider: LicensesProvider = {
 export const csharp: LanguageSupport = {
   id: 'csharp',
   displayName: 'C#',
+  commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
   sourceExtensions: ['.cs'],
   // Fixes the pattern gap: previously C# tests named `FooTests.cs` were missed
   // because gather.ts only matched *.test.*, *.spec.*, *_test.*, test_*.

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -881,6 +881,7 @@ const goLicensesProvider: LicensesProvider = {
 export const go: LanguageSupport = {
   id: 'go',
   displayName: 'Go',
+  commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
   sourceExtensions: ['.go'],
   testFilePatterns: ['*_test.go'],
   extraExcludes: ['vendor'],

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -412,6 +412,7 @@ const javaDepVulnsProvider: DepVulnsProvider = {
 export const java: LanguageSupport = {
   id: 'java',
   displayName: 'Java',
+  commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
 
   sourceExtensions: ['.java'],
 

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -418,6 +418,7 @@ const kotlinTestFrameworkProvider: CapabilityProvider<TestFrameworkResult> = {
 export const kotlin: LanguageSupport = {
   id: 'kotlin',
   displayName: 'Kotlin (Android)',
+  commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
 
   // `.kts` covers both Gradle build scripts and Kotlin scratch files; the
   // dxkit analyzers treat them as first-class source so coverage and lint

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -973,6 +973,7 @@ const pyLicensesProvider: LicensesProvider = {
 export const python: LanguageSupport = {
   id: 'python',
   displayName: 'Python',
+  commentSyntax: { lineComment: '#' },
   sourceExtensions: ['.py'],
   testFilePatterns: ['test_*.py', '*_test.py'],
   extraExcludes: ['__pycache__', '.pytest_cache', '.ruff_cache', '.venv', 'venv', '.mypy_cache'],

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -658,6 +658,7 @@ const rubyDepVulnsProvider: DepVulnsProvider = {
 export const ruby: LanguageSupport = {
   id: 'ruby',
   displayName: 'Ruby',
+  commentSyntax: { lineComment: '#', blockCommentStart: '=begin', blockCommentEnd: '=end' },
 
   sourceExtensions: ['.rb'],
 

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -827,6 +827,7 @@ export function parseLcov(raw: string, sourceFile: string, cwd: string): Coverag
 export const rust: LanguageSupport = {
   id: 'rust',
   displayName: 'Rust',
+  commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
   sourceExtensions: ['.rs'],
   // Rust convention: tests live in the same file via #[cfg(test)] / #[test],
   // or in a dedicated tests/ directory. Filename patterns cover the latter.

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -379,6 +379,32 @@ export interface LanguageSupport {
   devcontainerExtensions?: string[];
 
   /**
+   * Per-language comment syntax. The allowlist feature uses this to
+   * generate inline annotations
+   * (`// dxkit-allow:<category> reason="..."`) in the right form for
+   * the file's language. Without it, the inline-annotation path
+   * would either hardcode `//` everywhere (broken in Python / Ruby /
+   * shell) or grow a per-language branch in the allowlist module
+   * (a Rule 6 violation).
+   *
+   * `lineComment` is required for any pack that supports allowlist
+   * inline annotations (every pack today). `blockCommentStart` /
+   * `blockCommentEnd` are reserved for future formats where line
+   * comments are unavailable (e.g., HTML/XML config files that
+   * occasionally show up in scanned configs).
+   *
+   * Examples:
+   *   python  / ruby / shell  → `lineComment: '#'`
+   *   typescript / go / rust  → `lineComment: '//'`
+   *   csharp / kotlin / java  → `lineComment: '//'`
+   */
+  commentSyntax?: {
+    lineComment: string;
+    blockCommentStart?: string;
+    blockCommentEnd?: string;
+  };
+
+  /**
    * Key under `DetectedStack.versions` where this pack's version lives —
    * AND the lowercase prefix used to derive template-variable + condition
    * names (`NODE_VERSION`, `IF_NODE`). Defaults to `id` when omitted.

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1147,6 +1147,7 @@ const tsLicensesProvider: LicensesProvider = {
 export const typescript: LanguageSupport = {
   id: 'typescript',
   displayName: 'TypeScript / JavaScript',
+  commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
   sourceExtensions: [...TS_JS_EXT],
   testFilePatterns: [
     '*.test.ts',

--- a/test/allowlist/categories.test.ts
+++ b/test/allowlist/categories.test.ts
@@ -53,6 +53,7 @@ describe('allowlist categories', () => {
       'stale-file',
       'hygiene',
       'license',
+      'stale-allow',
     ];
     for (const k of kinds) {
       expect(CATEGORIES_BY_KIND).toHaveProperty(k);
@@ -74,6 +75,10 @@ describe('allowlist categories', () => {
 
   it('license kind permits zero allowlist categories', () => {
     expect(CATEGORIES_BY_KIND.license).toEqual([]);
+  });
+
+  it('stale-allow kind permits zero allowlist categories (self-suppression forbidden)', () => {
+    expect(CATEGORIES_BY_KIND['stale-allow']).toEqual([]);
   });
 
   it('coverage-gap / test-gap / test-file-degradation are accepted-risk + deferred only', () => {

--- a/test/allowlist/categories.test.ts
+++ b/test/allowlist/categories.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ALL_CATEGORIES,
+  CATEGORIES_BY_KIND,
+  DEFAULT_EXPIRY_DAYS,
+  EXPIRING_CATEGORIES,
+  INLINE_COMPATIBLE_CATEGORIES,
+  INLINE_COMPATIBLE_KINDS,
+  canUseInline,
+  defaultExpiryDate,
+  isCategoryValidForKind,
+  requiresExpiry,
+} from '../../src/allowlist/categories';
+import type { IdentityKind } from '../../src/baseline/producers';
+
+describe('allowlist categories', () => {
+  it('ALL_CATEGORIES contains the five locked values', () => {
+    expect(ALL_CATEGORIES).toEqual([
+      'false-positive',
+      'test-fixture',
+      'mitigated-externally',
+      'accepted-risk',
+      'deferred',
+    ]);
+  });
+
+  it('EXPIRING_CATEGORIES is exactly accepted-risk + deferred', () => {
+    expect([...EXPIRING_CATEGORIES].sort()).toEqual(['accepted-risk', 'deferred']);
+  });
+
+  it('INLINE_COMPATIBLE_CATEGORIES is the complement of EXPIRING_CATEGORIES', () => {
+    for (const cat of ALL_CATEGORIES) {
+      expect(INLINE_COMPATIBLE_CATEGORIES.has(cat)).toBe(!EXPIRING_CATEGORIES.has(cat));
+    }
+  });
+
+  it('CATEGORIES_BY_KIND covers every IdentityKind', () => {
+    // Exhaustiveness — the Record<IdentityKind, ...> already guarantees
+    // this at compile time. Asserting at runtime catches regressions
+    // where a discriminant is added without an entry.
+    const kinds: IdentityKind[] = [
+      'secret',
+      'secret-hmac',
+      'code',
+      'config',
+      'dep-vuln',
+      'duplication',
+      'coverage-gap',
+      'test-gap',
+      'test-file-degradation',
+      'god-file',
+      'large-file',
+      'stale-file',
+      'hygiene',
+      'license',
+    ];
+    for (const k of kinds) {
+      expect(CATEGORIES_BY_KIND).toHaveProperty(k);
+    }
+  });
+
+  it('every category listed under a kind is one of the five canonical values', () => {
+    for (const [kind, cats] of Object.entries(CATEGORIES_BY_KIND)) {
+      for (const cat of cats) {
+        expect(ALL_CATEGORIES).toContain(cat);
+        // Sanity: the table never lists a duplicate
+        expect(cats.filter((c) => c === cat).length).toBe(1);
+      }
+      // The kind variable is consumed by toHaveProperty above; mention
+      // here to keep the linter from flagging an unused binding.
+      expect(typeof kind).toBe('string');
+    }
+  });
+
+  it('license kind permits zero allowlist categories', () => {
+    expect(CATEGORIES_BY_KIND.license).toEqual([]);
+  });
+
+  it('coverage-gap / test-gap / test-file-degradation are accepted-risk + deferred only', () => {
+    expect(CATEGORIES_BY_KIND['coverage-gap']).toEqual(['accepted-risk', 'deferred']);
+    expect(CATEGORIES_BY_KIND['test-gap']).toEqual(['accepted-risk', 'deferred']);
+    expect(CATEGORIES_BY_KIND['test-file-degradation']).toEqual(['accepted-risk', 'deferred']);
+  });
+
+  it('hygiene is accepted-risk + deferred only', () => {
+    expect(CATEGORIES_BY_KIND.hygiene).toEqual(['accepted-risk', 'deferred']);
+  });
+
+  it('source-level security kinds carry all five categories', () => {
+    for (const k of ['secret', 'secret-hmac', 'code', 'config'] as const) {
+      expect(CATEGORIES_BY_KIND[k]).toEqual(ALL_CATEGORIES);
+    }
+  });
+
+  describe('INLINE_COMPATIBLE_KINDS', () => {
+    it('includes the source-attached kinds', () => {
+      for (const k of ['secret', 'secret-hmac', 'code', 'config', 'dep-vuln', 'hygiene'] as const) {
+        expect(INLINE_COMPATIBLE_KINDS.has(k)).toBe(true);
+      }
+    });
+
+    it('excludes whole-file + cross-file + gap kinds', () => {
+      for (const k of [
+        'duplication',
+        'coverage-gap',
+        'test-gap',
+        'test-file-degradation',
+        'god-file',
+        'large-file',
+        'stale-file',
+        'license',
+      ] as const) {
+        expect(INLINE_COMPATIBLE_KINDS.has(k)).toBe(false);
+      }
+    });
+  });
+
+  describe('canUseInline', () => {
+    it('true when both kind and category are inline-compatible', () => {
+      expect(canUseInline('secret', 'test-fixture')).toBe(true);
+      expect(canUseInline('code', 'false-positive')).toBe(true);
+      expect(canUseInline('dep-vuln', 'mitigated-externally')).toBe(true);
+    });
+
+    it('false when category is file-only', () => {
+      expect(canUseInline('secret', 'accepted-risk')).toBe(false);
+      expect(canUseInline('secret', 'deferred')).toBe(false);
+    });
+
+    it('false when kind is file-only', () => {
+      expect(canUseInline('large-file', 'false-positive')).toBe(false);
+      expect(canUseInline('coverage-gap', 'false-positive')).toBe(false);
+      expect(canUseInline('duplication', 'false-positive')).toBe(false);
+    });
+
+    it('false when both are file-only', () => {
+      expect(canUseInline('large-file', 'accepted-risk')).toBe(false);
+    });
+  });
+
+  describe('requiresExpiry', () => {
+    it('true for accepted-risk and deferred', () => {
+      expect(requiresExpiry('accepted-risk')).toBe(true);
+      expect(requiresExpiry('deferred')).toBe(true);
+    });
+
+    it('false for false-positive, test-fixture, mitigated-externally', () => {
+      expect(requiresExpiry('false-positive')).toBe(false);
+      expect(requiresExpiry('test-fixture')).toBe(false);
+      expect(requiresExpiry('mitigated-externally')).toBe(false);
+    });
+  });
+
+  describe('isCategoryValidForKind', () => {
+    it('true when category appears in the kind table', () => {
+      expect(isCategoryValidForKind('secret', 'test-fixture')).toBe(true);
+      expect(isCategoryValidForKind('dep-vuln', 'mitigated-externally')).toBe(true);
+      expect(isCategoryValidForKind('hygiene', 'deferred')).toBe(true);
+    });
+
+    it('false when category does not apply to the kind', () => {
+      expect(isCategoryValidForKind('coverage-gap', 'false-positive')).toBe(false);
+      expect(isCategoryValidForKind('dep-vuln', 'test-fixture')).toBe(false);
+      expect(isCategoryValidForKind('hygiene', 'test-fixture')).toBe(false);
+    });
+
+    it('false for any category against license', () => {
+      for (const cat of ALL_CATEGORIES) {
+        expect(isCategoryValidForKind('license', cat)).toBe(false);
+      }
+    });
+  });
+
+  describe('defaultExpiryDate', () => {
+    it('returns YYYY-MM-DD format', () => {
+      const out = defaultExpiryDate(new Date('2026-05-22T12:34:56Z'));
+      expect(out).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('adds exactly DEFAULT_EXPIRY_DAYS to the input date', () => {
+      // 2026-05-22 + 90 days = 2026-08-20
+      expect(defaultExpiryDate(new Date('2026-05-22T00:00:00Z'))).toBe('2026-08-20');
+    });
+
+    it('handles month/year rollover', () => {
+      // 2026-12-15 + 90 days = 2027-03-15
+      expect(defaultExpiryDate(new Date('2026-12-15T00:00:00Z'))).toBe('2027-03-15');
+    });
+
+    it('DEFAULT_EXPIRY_DAYS is locked at 90 (Sprint 0 decision)', () => {
+      expect(DEFAULT_EXPIRY_DAYS).toBe(90);
+    });
+  });
+});

--- a/test/allowlist/cli.test.ts
+++ b/test/allowlist/cli.test.ts
@@ -1,0 +1,441 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runAllowlistAdd, runAllowlistList, runAllowlistShow } from '../../src/allowlist/cli';
+import {
+  ALLOWLIST_SCHEMA_VERSION,
+  loadAllowlist,
+  pathForAllowlist,
+  type AllowlistFile,
+} from '../../src/allowlist/file';
+import { findAnnotationAt } from '../../src/allowlist/inline';
+import { getLanguage } from '../../src/languages';
+
+function makeTmpdir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-allowlist-cli-'));
+  // Seed git config so resolveGitUserEmail returns deterministic value
+  fs.writeFileSync(path.join(dir, '.gitconfig-script'), '[user]\n  email = test@example.com\n');
+  return dir;
+}
+
+function rmrf(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// Capture process.exit + console output. The CLI module calls
+// process.exit on error paths; we want to detect those without
+// killing the test runner.
+function mockExit() {
+  const exitSpy = vi
+    .spyOn(process, 'exit')
+    .mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    });
+  return exitSpy;
+}
+
+describe('runAllowlistAdd — inline path', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  it('inserts an inline annotation at file:line and exits zero', async () => {
+    const file = path.join(tmp, 'a.py');
+    fs.writeFileSync(file, 'api_key = "x"\n', 'utf8');
+
+    await runAllowlistAdd(tmp, {
+      target: 'a.py:1',
+      category: 'test-fixture',
+      reason: 'placeholder in unit test',
+    });
+
+    const found = findAnnotationAt(file, 1, getLanguage('python')!);
+    expect(found?.annotation.category).toBe('test-fixture');
+    expect(found?.annotation.reason).toBe('placeholder in unit test');
+  });
+
+  it('rejects file-only category for inline path', async () => {
+    const file = path.join(tmp, 'a.py');
+    fs.writeFileSync(file, 'x\n', 'utf8');
+
+    const exit = mockExit();
+    await expect(
+      runAllowlistAdd(tmp, {
+        target: 'a.py:1',
+        category: 'accepted-risk',
+        reason: 'x',
+      }),
+    ).rejects.toThrow(/process\.exit/);
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  it('rejects unknown language extension for inline path', async () => {
+    const file = path.join(tmp, 'a.xyz');
+    fs.writeFileSync(file, 'x\n', 'utf8');
+
+    const exit = mockExit();
+    await expect(
+      runAllowlistAdd(tmp, {
+        target: 'a.xyz:1',
+        category: 'test-fixture',
+        reason: 'x',
+      }),
+    ).rejects.toThrow(/process\.exit/);
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  it('requires --reason', async () => {
+    const file = path.join(tmp, 'a.py');
+    fs.writeFileSync(file, 'x\n', 'utf8');
+
+    const exit = mockExit();
+    await expect(
+      runAllowlistAdd(tmp, {
+        target: 'a.py:1',
+        category: 'test-fixture',
+        reason: '   ',
+      }),
+    ).rejects.toThrow(/process\.exit/);
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  it('requires --category', async () => {
+    const file = path.join(tmp, 'a.py');
+    fs.writeFileSync(file, 'x\n', 'utf8');
+
+    const exit = mockExit();
+    await expect(
+      runAllowlistAdd(tmp, {
+        target: 'a.py:1',
+        reason: 'rationale',
+      }),
+    ).rejects.toThrow(/process\.exit/);
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  it('rejects unknown category value', async () => {
+    const file = path.join(tmp, 'a.py');
+    fs.writeFileSync(file, 'x\n', 'utf8');
+
+    const exit = mockExit();
+    await expect(
+      runAllowlistAdd(tmp, {
+        target: 'a.py:1',
+        category: 'invented',
+        reason: 'rationale',
+      }),
+    ).rejects.toThrow(/process\.exit/);
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+});
+
+describe('runAllowlistAdd — file-level path', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  it('creates a file-level entry with fingerprint + kind', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'WAF rule X mitigates this CVE',
+      addedBy: 'alice@example.com',
+    });
+
+    const loaded = loadAllowlist(tmp);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.entries).toHaveLength(1);
+    expect(loaded!.entries[0]).toMatchObject({
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'WAF rule X mitigates this CVE',
+      addedBy: 'alice@example.com',
+    });
+  });
+
+  it('auto-defaults expiresAt to ~90 days out for accepted-risk', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'accepted-risk',
+      reason: 'accepted',
+      addedBy: 'alice@example.com',
+    });
+    const loaded = loadAllowlist(tmp);
+    expect(loaded!.entries[0].expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // Sanity: expiresAt is in the future
+    const today = new Date().toISOString().slice(0, 10);
+    expect(loaded!.entries[0].expiresAt! >= today).toBe(true);
+  });
+
+  it('rejects category that does not apply to kind', async () => {
+    const exit = mockExit();
+    await expect(
+      runAllowlistAdd(tmp, {
+        fingerprint: 'a3f9c0e8b7d2e1f4',
+        kind: 'coverage-gap',
+        category: 'false-positive', // not applicable to coverage-gap
+        reason: 'r',
+        addedBy: 'a@b.c',
+      }),
+    ).rejects.toThrow(/process\.exit/);
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  it('rejects when --fingerprint missing and no inline target', async () => {
+    const exit = mockExit();
+    await expect(
+      runAllowlistAdd(tmp, {
+        category: 'mitigated-externally',
+        reason: 'r',
+      }),
+    ).rejects.toThrow(/process\.exit/);
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  it('refuses to overwrite an existing entry with the same fingerprint', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'first',
+      addedBy: 'a@b.c',
+    });
+    const exit = mockExit();
+    await expect(
+      runAllowlistAdd(tmp, {
+        fingerprint: 'a3f9c0e8b7d2e1f4',
+        kind: 'dep-vuln',
+        category: 'mitigated-externally',
+        reason: 'second',
+        addedBy: 'a@b.c',
+      }),
+    ).rejects.toThrow(/process\.exit/);
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  it('honors --expires when provided', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'accepted-risk',
+      reason: 'r',
+      addedBy: 'a@b.c',
+      expires: '2027-01-01',
+    });
+    const loaded = loadAllowlist(tmp);
+    expect(loaded!.entries[0].expiresAt).toBe('2027-01-01');
+  });
+
+  it('rejects malformed --expires', async () => {
+    const exit = mockExit();
+    await expect(
+      runAllowlistAdd(tmp, {
+        fingerprint: 'a3f9c0e8b7d2e1f4',
+        kind: 'dep-vuln',
+        category: 'accepted-risk',
+        reason: 'r',
+        addedBy: 'a@b.c',
+        expires: 'last Tuesday',
+      }),
+    ).rejects.toThrow(/process\.exit/);
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  it('honors --acknowledged-severity when valid', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'accepted-risk',
+      reason: 'r',
+      addedBy: 'a@b.c',
+      acknowledgedSeverity: 'high',
+    });
+    const loaded = loadAllowlist(tmp);
+    expect(loaded!.entries[0].acknowledgedSeverity).toBe('high');
+  });
+
+  it('rejects unknown --acknowledged-severity', async () => {
+    const exit = mockExit();
+    await expect(
+      runAllowlistAdd(tmp, {
+        fingerprint: 'a3f9c0e8b7d2e1f4',
+        kind: 'dep-vuln',
+        category: 'accepted-risk',
+        reason: 'r',
+        addedBy: 'a@b.c',
+        acknowledgedSeverity: 'super-critical',
+      }),
+    ).rejects.toThrow(/process\.exit/);
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+});
+
+describe('runAllowlistList', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  it('prints empty hint when no allowlist exists (text mode)', async () => {
+    // No error, no exit. Just runs.
+    await expect(runAllowlistList(tmp, { json: false })).resolves.toBeUndefined();
+  });
+
+  it('emits JSON envelope on --json with empty file', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistList(tmp, { json: true });
+    const printed = stdoutSpy.mock.calls.map((c) => c[0]).join('');
+    const parsed = JSON.parse(printed);
+    expect(parsed).toMatchObject({
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [],
+    });
+    stdoutSpy.mockRestore();
+  });
+
+  it('prints existing entries (text mode)', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'WAF mitigates',
+      addedBy: 'a@b.c',
+    });
+    // No error, no exit.
+    await expect(runAllowlistList(tmp, { json: false })).resolves.toBeUndefined();
+  });
+
+  it('round-trips entries via JSON output', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'WAF mitigates',
+      addedBy: 'a@b.c',
+    });
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistList(tmp, { json: true });
+    const parsed: AllowlistFile = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed.entries).toHaveLength(1);
+    expect(parsed.entries[0].fingerprint).toBe('a3f9c0e8b7d2e1f4');
+    stdoutSpy.mockRestore();
+  });
+});
+
+describe('runAllowlistShow', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  it('rejects when fingerprint missing', async () => {
+    const exit = mockExit();
+    await expect(runAllowlistShow(tmp, {})).rejects.toThrow(/process\.exit/);
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  it('rejects when allowlist file missing', async () => {
+    const exit = mockExit();
+    await expect(runAllowlistShow(tmp, { fingerprint: 'a3f9c0e8b7d2e1f4' })).rejects.toThrow(
+      /process\.exit/,
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  it('rejects when fingerprint not in file', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'r',
+      addedBy: 'a@b.c',
+    });
+    const exit = mockExit();
+    await expect(runAllowlistShow(tmp, { fingerprint: '0000000000000000' })).rejects.toThrow(
+      /process\.exit/,
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  it('prints JSON detail when --json + entry exists', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'r',
+      addedBy: 'a@b.c',
+    });
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistShow(tmp, { fingerprint: 'a3f9c0e8b7d2e1f4', json: true });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed.fingerprint).toBe('a3f9c0e8b7d2e1f4');
+    expect(parsed.kind).toBe('dep-vuln');
+    stdoutSpy.mockRestore();
+  });
+
+  it('prints text detail for existing entry', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'r',
+      addedBy: 'a@b.c',
+    });
+    await expect(
+      runAllowlistShow(tmp, { fingerprint: 'a3f9c0e8b7d2e1f4', json: false }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('saveAllowlist side-effect', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  it('writes .dxkit/allowlist.json with canonical filename', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'r',
+      addedBy: 'a@b.c',
+    });
+    expect(fs.existsSync(pathForAllowlist(tmp))).toBe(true);
+  });
+});

--- a/test/allowlist/cli.test.ts
+++ b/test/allowlist/cli.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { runAllowlistAdd, runAllowlistList, runAllowlistShow } from '../../src/allowlist/cli';
+import {
+  runAllowlistAdd,
+  runAllowlistAudit,
+  runAllowlistList,
+  runAllowlistPrune,
+  runAllowlistShow,
+} from '../../src/allowlist/cli';
 import {
   ALLOWLIST_SCHEMA_VERSION,
   loadAllowlist,
@@ -437,5 +443,181 @@ describe('saveAllowlist side-effect', () => {
       addedBy: 'a@b.c',
     });
     expect(fs.existsSync(pathForAllowlist(tmp))).toBe(true);
+  });
+});
+
+describe('runAllowlistAudit', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  it('no-file: emits empty JSON report on --json', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistAudit(tmp, { json: true });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed).toEqual({ expired: [], soonToExpire: [], missingRationale: [] });
+    stdoutSpy.mockRestore();
+  });
+
+  it('no-file: prints info message in text mode', async () => {
+    await expect(runAllowlistAudit(tmp, { json: false })).resolves.toBeUndefined();
+  });
+
+  it('finds soon-to-expire entries within the default 14-day window', async () => {
+    // Add an entry that expires tomorrow
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'accepted-risk',
+      reason: 'r',
+      addedBy: 'a@b.c',
+      expires: tomorrow,
+    });
+
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistAudit(tmp, { json: true });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed.soonToExpire).toHaveLength(1);
+    expect(parsed.soonToExpire[0].entry.fingerprint).toBe('a3f9c0e8b7d2e1f4');
+    stdoutSpy.mockRestore();
+  });
+
+  it('respects --soon-days parameter for window', async () => {
+    // Entry expiring in 30 days
+    const farOut = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'accepted-risk',
+      reason: 'r',
+      addedBy: 'a@b.c',
+      expires: farOut,
+    });
+
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistAudit(tmp, { json: true, soonToExpireDays: 45 });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed.soonToExpire).toHaveLength(1);
+    stdoutSpy.mockRestore();
+  });
+
+  it('prints text report when entries are healthy', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'a3f9c0e8b7d2e1f4',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'r',
+      addedBy: 'a@b.c',
+    });
+    await expect(runAllowlistAudit(tmp, { json: false })).resolves.toBeUndefined();
+  });
+});
+
+describe('runAllowlistPrune', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  it('no-file: prints info and returns', async () => {
+    await expect(runAllowlistPrune(tmp, {})).resolves.toBeUndefined();
+  });
+
+  it('removes expired entries by default', async () => {
+    // Add an active entry
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'bbbb111111111111',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'still good',
+      addedBy: 'a@b.c',
+    });
+    // Manually inject an expired entry by editing the file directly via the
+    // canonical IO helpers (mutate then save).
+    const { loadAllowlist, saveAllowlist, addEntry } = await import('../../src/allowlist/file');
+    const file = loadAllowlist(tmp)!;
+    const expired: AllowlistFile = addEntry(file, {
+      fingerprint: 'aaaa111111111111',
+      kind: 'dep-vuln',
+      category: 'accepted-risk',
+      reason: 'expired entry',
+      addedBy: 'a@b.c',
+      addedAt: '2020-01-01',
+      expiresAt: '2020-01-02',
+    });
+    saveAllowlist(tmp, expired);
+
+    await runAllowlistPrune(tmp, {});
+
+    const after = loadAllowlist(tmp)!;
+    expect(after.entries.map((e) => e.fingerprint)).toEqual(['bbbb111111111111']);
+  });
+
+  it('--dry-run does not write but prints what would change', async () => {
+    const { loadAllowlist, saveAllowlist, addEntry } = await import('../../src/allowlist/file');
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'bbbb111111111111',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'r',
+      addedBy: 'a@b.c',
+    });
+    const file = loadAllowlist(tmp)!;
+    saveAllowlist(
+      tmp,
+      addEntry(file, {
+        fingerprint: 'aaaa111111111111',
+        kind: 'dep-vuln',
+        category: 'accepted-risk',
+        reason: 'expired',
+        addedBy: 'a@b.c',
+        addedAt: '2020-01-01',
+        expiresAt: '2020-01-02',
+      }),
+    );
+
+    await runAllowlistPrune(tmp, { dryRun: true });
+
+    const after = loadAllowlist(tmp)!;
+    // Both entries still present after dry-run
+    expect(after.entries).toHaveLength(2);
+  });
+
+  it('--json emits structured envelope', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'bbbb111111111111',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'r',
+      addedBy: 'a@b.c',
+    });
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistPrune(tmp, { json: true });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed).toMatchObject({
+      dryRun: false,
+      removed: [],
+      keptCount: 1,
+    });
+    stdoutSpy.mockRestore();
+  });
+
+  it('no-op when allowlist has no expired entries', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'bbbb111111111111',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'r',
+      addedBy: 'a@b.c',
+    });
+    await expect(runAllowlistPrune(tmp, {})).resolves.toBeUndefined();
   });
 });

--- a/test/allowlist/diff.test.ts
+++ b/test/allowlist/diff.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { computeAllowlistDelta, diffEntries } from '../../src/allowlist/diff';
+import {
+  ALLOWLIST_DIR,
+  ALLOWLIST_FILENAME,
+  ALLOWLIST_SCHEMA_VERSION,
+  saveAllowlist,
+  type AllowlistEntry,
+  type AllowlistFile,
+} from '../../src/allowlist/file';
+
+function makeTmpdir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-allowlist-diff-'));
+}
+
+function rmrf(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function makeEntry(partial: Partial<AllowlistEntry> & { fingerprint: string }): AllowlistEntry {
+  return {
+    kind: 'dep-vuln',
+    category: 'accepted-risk',
+    reason: 'r',
+    addedBy: 'a@b.c',
+    addedAt: '2026-05-22',
+    expiresAt: '2026-08-22',
+    ...partial,
+  };
+}
+
+describe('diffEntries (pure)', () => {
+  it('empty inputs → empty delta', () => {
+    expect(diffEntries([], [])).toEqual({
+      added: [],
+      removed: [],
+      baselineAccessible: true,
+    });
+  });
+
+  it('added: entry in current only', () => {
+    const e = makeEntry({ fingerprint: 'aaaa111111111111' });
+    const d = diffEntries([], [e]);
+    expect(d.added).toEqual([e]);
+    expect(d.removed).toEqual([]);
+  });
+
+  it('removed: entry in prior only', () => {
+    const e = makeEntry({ fingerprint: 'aaaa111111111111' });
+    const d = diffEntries([e], []);
+    expect(d.added).toEqual([]);
+    expect(d.removed).toEqual([e]);
+  });
+
+  it('persisted: matching fingerprints excluded from both sides', () => {
+    const e = makeEntry({ fingerprint: 'aaaa111111111111' });
+    const d = diffEntries([e], [e]);
+    expect(d.added).toEqual([]);
+    expect(d.removed).toEqual([]);
+  });
+
+  it('hydrates the CURRENT side for added entries', () => {
+    // Same fingerprint, different reason — current side should
+    // appear in `added` only if fingerprint is new.
+    const prior = makeEntry({ fingerprint: 'aaaa111111111111', reason: 'old' });
+    const current = makeEntry({ fingerprint: 'aaaa111111111111', reason: 'new' });
+    const d = diffEntries([prior], [current]);
+    expect(d.added).toEqual([]);
+    expect(d.removed).toEqual([]);
+  });
+
+  it('mixed prior + current', () => {
+    const persistedPrior = makeEntry({ fingerprint: 'aaaa111111111111' });
+    const persistedCurrent = makeEntry({ fingerprint: 'aaaa111111111111' });
+    const onlyPrior = makeEntry({ fingerprint: 'bbbb111111111111' });
+    const onlyCurrent = makeEntry({ fingerprint: 'cccc111111111111' });
+    const d = diffEntries([persistedPrior, onlyPrior], [persistedCurrent, onlyCurrent]);
+    expect(d.added.map((e) => e.fingerprint)).toEqual(['cccc111111111111']);
+    expect(d.removed.map((e) => e.fingerprint)).toEqual(['bbbb111111111111']);
+  });
+});
+
+describe('computeAllowlistDelta (git-aware)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+    // Initialize a tiny git repo so `git show <sha>:path` resolves.
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: tmp });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: tmp });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: tmp });
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  function commit(message: string): string {
+    execFileSync('git', ['add', '-A'], { cwd: tmp });
+    execFileSync('git', ['commit', '-q', '--allow-empty', '-m', message], { cwd: tmp });
+    return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: tmp, encoding: 'utf8' }).trim();
+  }
+
+  function writeAllowlist(entries: AllowlistEntry[]): void {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries,
+    };
+    saveAllowlist(tmp, file);
+  }
+
+  function clearAllowlist(): void {
+    const p = path.join(tmp, ALLOWLIST_DIR, ALLOWLIST_FILENAME);
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+
+  it('returns baselineAccessible: false when SHA is empty string', () => {
+    const d = computeAllowlistDelta(tmp, '');
+    expect(d).toEqual({ added: [], removed: [], baselineAccessible: false });
+  });
+
+  it('returns baselineAccessible: false when SHA is unreachable', () => {
+    const d = computeAllowlistDelta(tmp, '0000000000000000000000000000000000000000');
+    expect(d.baselineAccessible).toBe(false);
+  });
+
+  it('treats current entries as added when baseline SHA has no allowlist file', () => {
+    // Initial commit, no allowlist file
+    fs.writeFileSync(path.join(tmp, 'README.md'), 'init\n');
+    const baselineSha = commit('init');
+
+    // Add allowlist on a later commit
+    const newEntry = makeEntry({ fingerprint: 'aaaa111111111111' });
+    writeAllowlist([newEntry]);
+    commit('add allowlist');
+
+    const d = computeAllowlistDelta(tmp, baselineSha);
+    expect(d.baselineAccessible).toBe(true);
+    expect(d.added.map((e) => e.fingerprint)).toEqual(['aaaa111111111111']);
+    expect(d.removed).toEqual([]);
+  });
+
+  it('diffs allowlist between baseline SHA and current working tree', () => {
+    const old = makeEntry({ fingerprint: 'aaaa111111111111', reason: 'old' });
+    writeAllowlist([old]);
+    fs.writeFileSync(path.join(tmp, 'README.md'), 'init\n');
+    const baselineSha = commit('baseline');
+
+    const persisted = makeEntry({ fingerprint: 'aaaa111111111111', reason: 'old' });
+    const fresh = makeEntry({ fingerprint: 'bbbb111111111111', reason: 'new' });
+    writeAllowlist([persisted, fresh]);
+    // Don't even need to commit — working tree IS the "current."
+
+    const d = computeAllowlistDelta(tmp, baselineSha);
+    expect(d.baselineAccessible).toBe(true);
+    expect(d.added.map((e) => e.fingerprint)).toEqual(['bbbb111111111111']);
+    expect(d.removed).toEqual([]);
+  });
+
+  it('detects removed entries on the current branch', () => {
+    const a = makeEntry({ fingerprint: 'aaaa111111111111' });
+    const b = makeEntry({ fingerprint: 'bbbb111111111111' });
+    writeAllowlist([a, b]);
+    fs.writeFileSync(path.join(tmp, 'README.md'), 'init\n');
+    const baselineSha = commit('baseline with two entries');
+
+    // Current state: only b remains
+    writeAllowlist([b]);
+
+    const d = computeAllowlistDelta(tmp, baselineSha);
+    expect(d.added).toEqual([]);
+    expect(d.removed.map((e) => e.fingerprint)).toEqual(['aaaa111111111111']);
+  });
+
+  it('returns empty delta when current allowlist matches baseline', () => {
+    const e = makeEntry({ fingerprint: 'aaaa111111111111' });
+    writeAllowlist([e]);
+    fs.writeFileSync(path.join(tmp, 'README.md'), 'init\n');
+    const baselineSha = commit('baseline');
+
+    // Working tree unchanged from baseline
+    const d = computeAllowlistDelta(tmp, baselineSha);
+    expect(d.added).toEqual([]);
+    expect(d.removed).toEqual([]);
+    expect(d.baselineAccessible).toBe(true);
+  });
+
+  it('handles "allowlist file deleted on current branch" via removed entries', () => {
+    const e = makeEntry({ fingerprint: 'aaaa111111111111' });
+    writeAllowlist([e]);
+    fs.writeFileSync(path.join(tmp, 'README.md'), 'init\n');
+    const baselineSha = commit('with allowlist');
+
+    clearAllowlist();
+    const d = computeAllowlistDelta(tmp, baselineSha);
+    expect(d.added).toEqual([]);
+    expect(d.removed.map((x) => x.fingerprint)).toEqual(['aaaa111111111111']);
+  });
+});

--- a/test/allowlist/file.test.ts
+++ b/test/allowlist/file.test.ts
@@ -6,6 +6,8 @@ import {
   ALLOWLIST_REASONS_SCHEMA_VERSION,
   ALLOWLIST_SCHEMA_VERSION,
   addEntry,
+  auditAllowlist,
+  daysUntilExpiry,
   emptyAllowlistFile,
   findEntry,
   isEntryActive,
@@ -14,6 +16,7 @@ import {
   matchesFinding,
   pathForAllowlist,
   pathForAllowlistReasons,
+  pruneExpired,
   removeEntry,
   saveAllowlist,
   validateAllowlistEntry,
@@ -405,5 +408,152 @@ describe('validateAllowlistFile', () => {
       entries: [baseEntry],
     };
     expect(validateAllowlistFile(file)).toEqual([]);
+  });
+});
+
+describe('daysUntilExpiry', () => {
+  const now = new Date('2026-05-22T00:00:00Z');
+
+  it('returns null for entries without expiresAt', () => {
+    expect(daysUntilExpiry(baseEntry, now)).toBeNull();
+  });
+
+  it('returns 0 on the expiry day itself', () => {
+    expect(daysUntilExpiry({ ...baseEntry, expiresAt: '2026-05-22' }, now)).toBe(0);
+  });
+
+  it('returns positive for future expiry', () => {
+    expect(daysUntilExpiry({ ...baseEntry, expiresAt: '2026-06-05' }, now)).toBe(14);
+  });
+
+  it('returns negative for past expiry', () => {
+    expect(daysUntilExpiry({ ...baseEntry, expiresAt: '2026-05-15' }, now)).toBe(-7);
+  });
+});
+
+describe('auditAllowlist', () => {
+  const now = new Date('2026-05-22T00:00:00Z');
+
+  it('classifies expired entries', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [{ ...baseEntry, fingerprint: 'aaaa111111111111', expiresAt: '2026-05-15' }],
+    };
+    const report = auditAllowlist(file, { now });
+    expect(report.expired).toHaveLength(1);
+    expect(report.expired[0].fingerprint).toBe('aaaa111111111111');
+    expect(report.soonToExpire).toHaveLength(0);
+  });
+
+  it('classifies soon-to-expire entries within default 14-day horizon', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [
+        { ...baseEntry, fingerprint: 'bbbb111111111111', expiresAt: '2026-05-30' }, // 8 days
+        { ...baseEntry, fingerprint: 'cccc111111111111', expiresAt: '2026-06-20' }, // 29 days
+      ],
+    };
+    const report = auditAllowlist(file, { now });
+    expect(report.soonToExpire).toHaveLength(1);
+    expect(report.soonToExpire[0].entry.fingerprint).toBe('bbbb111111111111');
+    expect(report.soonToExpire[0].daysRemaining).toBe(8);
+  });
+
+  it('respects custom soonToExpireDays horizon', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [
+        { ...baseEntry, fingerprint: 'cccc111111111111', expiresAt: '2026-06-20' }, // 29 days
+      ],
+    };
+    const report = auditAllowlist(file, { now, soonToExpireDays: 30 });
+    expect(report.soonToExpire).toHaveLength(1);
+  });
+
+  it('does NOT classify entries on the boundary day (0 days remaining) as expired', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [{ ...baseEntry, expiresAt: '2026-05-22' }],
+    };
+    const report = auditAllowlist(file, { now });
+    expect(report.expired).toHaveLength(0);
+    expect(report.soonToExpire).toHaveLength(1);
+  });
+
+  it('flags entries with empty reason as missingRationale', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [
+        { ...baseEntry, fingerprint: 'aaaa222222222222', reason: '' },
+        { ...baseEntry, fingerprint: 'bbbb222222222222', reason: '   ' },
+        { ...baseEntry, fingerprint: 'cccc222222222222' }, // reason present
+      ],
+    };
+    const report = auditAllowlist(file, { now });
+    expect(report.missingRationale.map((e) => e.fingerprint)).toEqual([
+      'aaaa222222222222',
+      'bbbb222222222222',
+    ]);
+  });
+
+  it('empty file produces empty buckets', () => {
+    const file = emptyAllowlistFile('full');
+    expect(auditAllowlist(file, { now })).toEqual({
+      expired: [],
+      soonToExpire: [],
+      missingRationale: [],
+    });
+  });
+});
+
+describe('pruneExpired', () => {
+  const now = new Date('2026-05-22T00:00:00Z');
+
+  it('removes only expired entries; keeps active + no-expiry', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [
+        { ...baseEntry, fingerprint: 'aaaa111111111111', expiresAt: '2026-05-15' }, // expired
+        { ...baseEntry, fingerprint: 'bbbb111111111111', expiresAt: '2026-08-22' }, // active
+        { ...baseEntry, fingerprint: 'cccc111111111111' }, // no expiry
+      ],
+    };
+    const { kept, removed } = pruneExpired(file, now);
+    expect(removed).toHaveLength(1);
+    expect(removed[0].fingerprint).toBe('aaaa111111111111');
+    expect(kept.entries).toHaveLength(2);
+    expect(kept.entries.map((e) => e.fingerprint)).toEqual([
+      'bbbb111111111111',
+      'cccc111111111111',
+    ]);
+  });
+
+  it('returns the same input file shape with 0 removals when nothing is expired', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [baseEntry],
+    };
+    const { kept, removed } = pruneExpired(file, now);
+    expect(removed).toHaveLength(0);
+    expect(kept.entries).toEqual(file.entries);
+    expect(kept.mode).toBe(file.mode);
+  });
+
+  it('preserves file mode + schemaVersion in returned kept file', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'sanitized',
+      entries: [{ ...baseEntry, expiresAt: '2026-05-15' }],
+    };
+    const { kept } = pruneExpired(file, now);
+    expect(kept.mode).toBe('sanitized');
+    expect(kept.schemaVersion).toBe(ALLOWLIST_SCHEMA_VERSION);
   });
 });

--- a/test/allowlist/file.test.ts
+++ b/test/allowlist/file.test.ts
@@ -1,0 +1,409 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  ALLOWLIST_REASONS_SCHEMA_VERSION,
+  ALLOWLIST_SCHEMA_VERSION,
+  addEntry,
+  emptyAllowlistFile,
+  findEntry,
+  isEntryActive,
+  loadAllowlist,
+  loadAllowlistReasons,
+  matchesFinding,
+  pathForAllowlist,
+  pathForAllowlistReasons,
+  removeEntry,
+  saveAllowlist,
+  validateAllowlistEntry,
+  validateAllowlistFile,
+  type AllowlistEntry,
+  type AllowlistFile,
+  type AllowlistReasonsSidecar,
+} from '../../src/allowlist/file';
+
+function makeTmpdir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-allowlist-'));
+}
+
+function rmrf(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+const baseEntry: AllowlistEntry = {
+  fingerprint: 'a3f9c0e8b7d2e1f4',
+  kind: 'secret',
+  category: 'test-fixture',
+  reason: 'placeholder in unit test',
+  addedBy: 'alice@example.com',
+  addedAt: '2026-05-22',
+};
+
+describe('allowlist file IO', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  it('loadAllowlist returns null when file missing', () => {
+    expect(loadAllowlist(tmp)).toBeNull();
+  });
+
+  it('emptyAllowlistFile creates valid empty file', () => {
+    const f = emptyAllowlistFile();
+    expect(f.schemaVersion).toBe(ALLOWLIST_SCHEMA_VERSION);
+    expect(f.mode).toBe('full');
+    expect(f.entries).toEqual([]);
+    expect(validateAllowlistFile(f)).toHaveLength(0);
+  });
+
+  it('saveAllowlist + loadAllowlist round-trip in full mode', () => {
+    const original: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [baseEntry],
+    };
+    saveAllowlist(tmp, original);
+
+    const filePath = pathForAllowlist(tmp);
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const loaded = loadAllowlist(tmp);
+    expect(loaded).toEqual(original);
+  });
+
+  it('saveAllowlist in sanitized mode strips reason+addedBy to sidecar', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'sanitized',
+      entries: [baseEntry],
+    };
+    saveAllowlist(tmp, file);
+
+    // Main file omits reason + addedBy
+    const rawMain = JSON.parse(fs.readFileSync(pathForAllowlist(tmp), 'utf8'));
+    expect(rawMain.entries[0].reason).toBeUndefined();
+    expect(rawMain.entries[0].addedBy).toBeUndefined();
+    expect(rawMain.entries[0].fingerprint).toBe(baseEntry.fingerprint);
+    expect(rawMain.entries[0].category).toBe(baseEntry.category);
+
+    // Sidecar carries reason + addedBy keyed by fingerprint
+    const sidecar = loadAllowlistReasons(tmp);
+    expect(sidecar).not.toBeNull();
+    expect(sidecar!.reasons[baseEntry.fingerprint]).toEqual({
+      reason: baseEntry.reason,
+      addedBy: baseEntry.addedBy,
+    });
+  });
+
+  it('loadAllowlist merges sidecar back in sanitized mode', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'sanitized',
+      entries: [baseEntry],
+    };
+    saveAllowlist(tmp, file);
+
+    const loaded = loadAllowlist(tmp);
+    expect(loaded!.entries[0].reason).toBe(baseEntry.reason);
+    expect(loaded!.entries[0].addedBy).toBe(baseEntry.addedBy);
+  });
+
+  it('loadAllowlist tolerates missing sidecar in sanitized mode', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'sanitized',
+      entries: [baseEntry],
+    };
+    saveAllowlist(tmp, file);
+    // Remove the sidecar — simulate fresh clone in CI
+    fs.unlinkSync(pathForAllowlistReasons(tmp));
+
+    const loaded = loadAllowlist(tmp);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.entries[0].reason).toBeUndefined();
+    expect(loaded!.entries[0].fingerprint).toBe(baseEntry.fingerprint);
+  });
+
+  it('loadAllowlist throws on malformed JSON', () => {
+    fs.mkdirSync(path.join(tmp, '.dxkit'), { recursive: true });
+    fs.writeFileSync(pathForAllowlist(tmp), '{ not json', 'utf8');
+    expect(() => loadAllowlist(tmp)).toThrow(/not valid JSON/);
+  });
+
+  it('loadAllowlist throws on missing schemaVersion', () => {
+    fs.mkdirSync(path.join(tmp, '.dxkit'), { recursive: true });
+    fs.writeFileSync(pathForAllowlist(tmp), JSON.stringify({ mode: 'full', entries: [] }), 'utf8');
+    expect(() => loadAllowlist(tmp)).toThrow(/schemaVersion/);
+  });
+
+  it('loadAllowlist throws on unknown mode', () => {
+    fs.mkdirSync(path.join(tmp, '.dxkit'), { recursive: true });
+    fs.writeFileSync(
+      pathForAllowlist(tmp),
+      JSON.stringify({
+        schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+        mode: 'unknown-mode',
+        entries: [],
+      }),
+      'utf8',
+    );
+    expect(() => loadAllowlist(tmp)).toThrow(/mode/);
+  });
+
+  it('loadAllowlist throws on non-array entries', () => {
+    fs.mkdirSync(path.join(tmp, '.dxkit'), { recursive: true });
+    fs.writeFileSync(
+      pathForAllowlist(tmp),
+      JSON.stringify({
+        schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+        mode: 'full',
+        entries: 'oops',
+      }),
+      'utf8',
+    );
+    expect(() => loadAllowlist(tmp)).toThrow(/entries/);
+  });
+
+  it('saveAllowlist throws on invalid file', () => {
+    const bad: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [{ ...baseEntry, reason: '' }],
+    };
+    expect(() => saveAllowlist(tmp, bad)).toThrow(/failed validation/);
+    // File should NOT have been written
+    expect(fs.existsSync(pathForAllowlist(tmp))).toBe(false);
+  });
+
+  describe('reasons sidecar IO', () => {
+    it('loadAllowlistReasons returns null when missing', () => {
+      expect(loadAllowlistReasons(tmp)).toBeNull();
+    });
+
+    it('throws on bad sidecar schemaVersion', () => {
+      fs.mkdirSync(path.join(tmp, '.dxkit'), { recursive: true });
+      fs.writeFileSync(
+        pathForAllowlistReasons(tmp),
+        JSON.stringify({ schemaVersion: 'wrong', reasons: {} }),
+        'utf8',
+      );
+      expect(() => loadAllowlistReasons(tmp)).toThrow(/schemaVersion/);
+    });
+
+    it('accepts valid sidecar', () => {
+      fs.mkdirSync(path.join(tmp, '.dxkit'), { recursive: true });
+      const sidecar: AllowlistReasonsSidecar = {
+        schemaVersion: ALLOWLIST_REASONS_SCHEMA_VERSION,
+        reasons: { abc123def4567890: { reason: 'because', addedBy: 'me' } },
+      };
+      fs.writeFileSync(pathForAllowlistReasons(tmp), JSON.stringify(sidecar), 'utf8');
+      expect(loadAllowlistReasons(tmp)).toEqual(sidecar);
+    });
+  });
+});
+
+describe('entry helpers', () => {
+  const file: AllowlistFile = {
+    schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+    mode: 'full',
+    entries: [baseEntry],
+  };
+
+  it('findEntry locates by fingerprint', () => {
+    expect(findEntry(file, baseEntry.fingerprint)).toEqual(baseEntry);
+    expect(findEntry(file, 'nonexistent00000')).toBeUndefined();
+  });
+
+  it('matchesFinding is fingerprint-only', () => {
+    expect(matchesFinding(file, baseEntry.fingerprint)).toBe(true);
+    expect(matchesFinding(file, 'nonexistent00000')).toBe(false);
+  });
+
+  it('addEntry returns new file with appended entry', () => {
+    const second: AllowlistEntry = {
+      ...baseEntry,
+      fingerprint: 'b2e4d8a1c9f0a3b5',
+    };
+    const updated = addEntry(file, second);
+    expect(updated.entries).toHaveLength(2);
+    expect(updated.entries).not.toBe(file.entries); // immutable
+    expect(file.entries).toHaveLength(1); // original untouched
+  });
+
+  it('addEntry throws on duplicate fingerprint', () => {
+    expect(() => addEntry(file, baseEntry)).toThrow(/already contains/);
+  });
+
+  it('removeEntry returns new file without entry', () => {
+    const updated = removeEntry(file, baseEntry.fingerprint);
+    expect(updated.entries).toHaveLength(0);
+    expect(file.entries).toHaveLength(1);
+  });
+
+  it('removeEntry is no-op for missing fingerprint', () => {
+    const updated = removeEntry(file, 'nonexistent00000');
+    expect(updated.entries).toHaveLength(1);
+  });
+});
+
+describe('isEntryActive', () => {
+  const fixedNow = new Date('2026-05-22T00:00:00Z');
+
+  it('returns true for entries without expiresAt', () => {
+    expect(isEntryActive(baseEntry, fixedNow)).toBe(true);
+  });
+
+  it('returns true for entries with future expiresAt', () => {
+    expect(isEntryActive({ ...baseEntry, expiresAt: '2026-08-22' }, fixedNow)).toBe(true);
+  });
+
+  it('returns true on the day of expiry (boundary)', () => {
+    expect(isEntryActive({ ...baseEntry, expiresAt: '2026-05-22' }, fixedNow)).toBe(true);
+  });
+
+  it('returns false after expiry', () => {
+    expect(isEntryActive({ ...baseEntry, expiresAt: '2026-05-21' }, fixedNow)).toBe(false);
+  });
+});
+
+describe('validateAllowlistEntry', () => {
+  it('zero errors for a well-formed entry', () => {
+    expect(validateAllowlistEntry(baseEntry, 'full')).toEqual([]);
+  });
+
+  it('flags non-hex fingerprint', () => {
+    const errors = validateAllowlistEntry({ ...baseEntry, fingerprint: 'NOT_HEX_AT_ALL!' }, 'full');
+    expect(errors.some((e) => e.field === 'fingerprint')).toBe(true);
+  });
+
+  it('flags wrong-length fingerprint', () => {
+    const errors = validateAllowlistEntry({ ...baseEntry, fingerprint: 'abc' }, 'full');
+    expect(errors.some((e) => e.field === 'fingerprint')).toBe(true);
+  });
+
+  it('flags uppercase fingerprint', () => {
+    const errors = validateAllowlistEntry(
+      { ...baseEntry, fingerprint: 'A3F9C0E8B7D2E1F4' },
+      'full',
+    );
+    expect(errors.some((e) => e.field === 'fingerprint')).toBe(true);
+  });
+
+  it('flags invalid category', () => {
+    const bad = { ...baseEntry, category: 'invented' as unknown as typeof baseEntry.category };
+    const errors = validateAllowlistEntry(bad, 'full');
+    expect(errors.some((e) => e.field === 'category')).toBe(true);
+  });
+
+  it('flags category not applicable to kind', () => {
+    // hygiene only allows accepted-risk + deferred
+    const bad: AllowlistEntry = {
+      ...baseEntry,
+      kind: 'hygiene',
+      category: 'test-fixture',
+    };
+    const errors = validateAllowlistEntry(bad, 'full');
+    expect(errors.some((e) => e.field === 'category' && /does not apply/.test(e.message))).toBe(
+      true,
+    );
+  });
+
+  it('requires reason in full mode', () => {
+    const noReason = { ...baseEntry, reason: undefined } as unknown as AllowlistEntry;
+    const errors = validateAllowlistEntry(noReason, 'full');
+    expect(errors.some((e) => e.field === 'reason')).toBe(true);
+  });
+
+  it('rejects empty/whitespace reason in full mode', () => {
+    const errors = validateAllowlistEntry({ ...baseEntry, reason: '   ' }, 'full');
+    expect(errors.some((e) => e.field === 'reason')).toBe(true);
+  });
+
+  it('allows missing reason in sanitized mode (sidecar owns it)', () => {
+    const noReason = { ...baseEntry, reason: undefined, addedBy: undefined };
+    const errors = validateAllowlistEntry(noReason, 'sanitized');
+    expect(errors.filter((e) => e.field === 'reason' || e.field === 'addedBy')).toHaveLength(0);
+  });
+
+  it('requires addedAt in ISO format', () => {
+    const errors = validateAllowlistEntry({ ...baseEntry, addedAt: 'last Tuesday' }, 'full');
+    expect(errors.some((e) => e.field === 'addedAt')).toBe(true);
+  });
+
+  it('requires expiresAt for accepted-risk', () => {
+    const noExpiry: AllowlistEntry = {
+      ...baseEntry,
+      kind: 'dep-vuln',
+      category: 'accepted-risk',
+    };
+    const errors = validateAllowlistEntry(noExpiry, 'full');
+    expect(errors.some((e) => e.field === 'expiresAt')).toBe(true);
+  });
+
+  it('requires expiresAt for deferred', () => {
+    const noExpiry: AllowlistEntry = {
+      ...baseEntry,
+      kind: 'dep-vuln',
+      category: 'deferred',
+    };
+    const errors = validateAllowlistEntry(noExpiry, 'full');
+    expect(errors.some((e) => e.field === 'expiresAt')).toBe(true);
+  });
+
+  it('expiresAt optional for test-fixture', () => {
+    const errors = validateAllowlistEntry({ ...baseEntry, category: 'test-fixture' }, 'full');
+    expect(errors.filter((e) => e.field === 'expiresAt')).toHaveLength(0);
+  });
+
+  it('rejects malformed expiresAt', () => {
+    const errors = validateAllowlistEntry({ ...baseEntry, expiresAt: '08/22/2026' }, 'full');
+    expect(errors.some((e) => e.field === 'expiresAt')).toBe(true);
+  });
+
+  it('accepts well-formed accepted-risk with expiresAt + acknowledgedSeverity', () => {
+    const accepted: AllowlistEntry = {
+      ...baseEntry,
+      kind: 'dep-vuln',
+      category: 'accepted-risk',
+      expiresAt: '2026-08-22',
+      acknowledgedSeverity: 'high',
+    };
+    expect(validateAllowlistEntry(accepted, 'full')).toEqual([]);
+  });
+});
+
+describe('validateAllowlistFile', () => {
+  it('detects duplicate fingerprints across entries', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [baseEntry, baseEntry],
+    };
+    const errors = validateAllowlistFile(file);
+    expect(errors.some((e) => e.field === 'fingerprint' && /duplicate/.test(e.message))).toBe(true);
+  });
+
+  it('flags bad schemaVersion', () => {
+    const file: AllowlistFile = {
+      schemaVersion: 'dxkit-allowlist/v0' as 'dxkit-allowlist/v1',
+      mode: 'full',
+      entries: [],
+    };
+    const errors = validateAllowlistFile(file);
+    expect(errors.some((e) => e.field === 'schemaVersion')).toBe(true);
+  });
+
+  it('accepts a well-formed full-mode file', () => {
+    const file: AllowlistFile = {
+      schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+      mode: 'full',
+      entries: [baseEntry],
+    };
+    expect(validateAllowlistFile(file)).toEqual([]);
+  });
+});

--- a/test/allowlist/gather.test.ts
+++ b/test/allowlist/gather.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { gatherInlineAllowlistAnnotations } from '../../src/allowlist/gather';
+import { clearWalkCache } from '../../src/analyzers/tools/walk-source-files';
+
+function makeTmpdir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-gather-allowlist-'));
+}
+
+function rmrf(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function write(dir: string, rel: string, content: string): void {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+}
+
+describe('gatherInlineAllowlistAnnotations', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+    // walkSourceFiles is memoized — clear between tests so files
+    // written in this test aren't shadowed by a stale cache from
+    // a prior test's tmp dir.
+    clearWalkCache();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+    clearWalkCache();
+  });
+
+  it('returns empty array for repo with no source files', () => {
+    expect(gatherInlineAllowlistAnnotations(tmp)).toEqual([]);
+  });
+
+  it('finds same-line annotation in python', () => {
+    write(tmp, 'src/a.py', 'api_key = "x"  # dxkit-allow:test-fixture reason="fix"\n');
+    const out = gatherInlineAllowlistAnnotations(tmp);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      file: 'src/a.py',
+      line: 1,
+      category: 'test-fixture',
+      position: 'same-line',
+    });
+  });
+
+  it('finds above-line annotation in typescript', () => {
+    write(tmp, 'src/a.ts', '// dxkit-allow:false-positive reason="regex"\nconst x = "y";\n');
+    const out = gatherInlineAllowlistAnnotations(tmp);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      file: 'src/a.ts',
+      line: 1,
+      category: 'false-positive',
+      position: 'above',
+    });
+  });
+
+  it('finds multiple annotations in one file', () => {
+    write(
+      tmp,
+      'src/a.py',
+      [
+        '# dxkit-allow:test-fixture reason="r1"',
+        'x = 1',
+        'api = "abc"  # dxkit-allow:false-positive reason="r2"',
+      ].join('\n'),
+    );
+    const out = gatherInlineAllowlistAnnotations(tmp);
+    expect(out).toHaveLength(2);
+    expect(out[0].position).toBe('above');
+    expect(out[1].position).toBe('same-line');
+  });
+
+  it('finds annotations across multiple files in deterministic order', () => {
+    write(tmp, 'src/z.py', '# dxkit-allow:test-fixture reason="z"\nx = 1\n');
+    write(tmp, 'src/a.py', '# dxkit-allow:test-fixture reason="a"\nx = 1\n');
+    const out = gatherInlineAllowlistAnnotations(tmp);
+    expect(out).toHaveLength(2);
+    // walkSourceFiles sorts paths, so 'src/a.py' precedes 'src/z.py'
+    expect(out[0].file).toBe('src/a.py');
+    expect(out[1].file).toBe('src/z.py');
+  });
+
+  it('walks test files by default', () => {
+    write(
+      tmp,
+      'src/__test__/example.test.py',
+      'x = "secret"  # dxkit-allow:test-fixture reason="placeholder"\n',
+    );
+    const out = gatherInlineAllowlistAnnotations(tmp);
+    expect(out.some((o) => o.file.endsWith('example.test.py'))).toBe(true);
+  });
+
+  it('skips files without dxkit-allow: substring (fast path)', () => {
+    write(tmp, 'src/no-annotation.py', 'x = 1\ny = 2\nz = 3\n');
+    const out = gatherInlineAllowlistAnnotations(tmp);
+    expect(out).toEqual([]);
+  });
+
+  it('ignores files with unknown extension (no language pack)', () => {
+    write(tmp, 'src/data.xyz', '# dxkit-allow:test-fixture reason="r"\n');
+    const out = gatherInlineAllowlistAnnotations(tmp);
+    expect(out).toEqual([]);
+  });
+
+  it('detects annotations across all 8 language packs that have commentSyntax', () => {
+    // One annotation per language, mirroring the cross-language
+    // matrix from inline.test.ts.
+    write(tmp, 'a.py', '# dxkit-allow:test-fixture reason="r"\nx = 1\n');
+    write(tmp, 'a.ts', '// dxkit-allow:test-fixture reason="r"\nconst x = 1;\n');
+    write(tmp, 'a.go', '// dxkit-allow:test-fixture reason="r"\nvar x = 1\n');
+    write(tmp, 'a.rs', '// dxkit-allow:test-fixture reason="r"\nlet x = 1;\n');
+    write(tmp, 'a.cs', '// dxkit-allow:test-fixture reason="r"\nvar x = 1;\n');
+    write(tmp, 'a.java', '// dxkit-allow:test-fixture reason="r"\nint x = 1;\n');
+    write(tmp, 'a.kt', '// dxkit-allow:test-fixture reason="r"\nval x = 1\n');
+    write(tmp, 'a.rb', '# dxkit-allow:test-fixture reason="r"\nx = 1\n');
+
+    const out = gatherInlineAllowlistAnnotations(tmp);
+    const filesFound = new Set(out.map((o) => o.file));
+    expect(filesFound.size).toBe(8);
+  });
+
+  it('skips unknown category gracefully (parser returns null)', () => {
+    write(tmp, 'src/a.py', '# dxkit-allow:not-a-real-category reason="r"\nx = 1\n');
+    const out = gatherInlineAllowlistAnnotations(tmp);
+    expect(out).toEqual([]);
+  });
+});

--- a/test/allowlist/hint.test.ts
+++ b/test/allowlist/hint.test.ts
@@ -37,8 +37,8 @@ const ENTRIES: Record<BaselineEntry['kind'], BaselineEntry> = {
     startLineB: 1,
   },
   'coverage-gap': { id: FP, kind: 'coverage-gap', file: 'src/a.ts', symbol: 'fn' },
-  'test-gap': { id: FP, kind: 'test-gap', file: 'src/a.ts', risk: 'HIGH' },
-  hygiene: { id: FP, kind: 'hygiene', file: 'src/a.ts', line: 1, marker: 'TODO' },
+  'test-gap': { id: FP, kind: 'test-gap', file: 'src/a.ts', risk: 'high' },
+  hygiene: { id: FP, kind: 'hygiene', file: 'src/a.ts', line: 1, marker: 'todo' },
   license: { id: FP, kind: 'license', package: 'lodash', version: '4.0.0', licenseType: 'MIT' },
   'test-file-degradation': {
     id: FP,

--- a/test/allowlist/hint.test.ts
+++ b/test/allowlist/hint.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+import type { BaselineEntry, FindingId } from '../../src/baseline/types';
+import { formatBlockHint, remediationFor } from '../../src/allowlist/hint';
+import { CATEGORIES_BY_KIND } from '../../src/allowlist/categories';
+
+const FP: FindingId = 'a3f9c0e8b7d2e1f4';
+
+// Per-kind builders that produce well-formed BaselineEntry values.
+// Centralized so a new kind landing in the canonical union forces
+// one test-helper addition, not scattered struct literals.
+const ENTRIES: Record<BaselineEntry['kind'], BaselineEntry> = {
+  secret: {
+    id: FP,
+    kind: 'secret',
+    tool: 'gitleaks',
+    rule: 'private-key',
+    file: 'src/a.ts',
+    line: 42,
+  },
+  'secret-hmac': { id: FP, kind: 'secret-hmac', tool: 'gitleaks', rule: 'private-key', hmac: 'h0' },
+  code: { id: FP, kind: 'code', tool: 'semgrep', rule: 'eval-use', file: 'src/a.ts', line: 5 },
+  config: { id: FP, kind: 'config', tool: 'semgrep', rule: 'tls-off', file: 'config.ts', line: 12 },
+  'dep-vuln': {
+    id: FP,
+    kind: 'dep-vuln',
+    package: 'lodash',
+    installedVersion: '4.0.0',
+    advisoryId: 'GHSA-xxx',
+  },
+  duplication: {
+    id: FP,
+    kind: 'duplication',
+    fileA: 'a.ts',
+    fileB: 'b.ts',
+    lines: 10,
+    startLineA: 1,
+    startLineB: 1,
+  },
+  'coverage-gap': { id: FP, kind: 'coverage-gap', file: 'src/a.ts', symbol: 'fn' },
+  'test-gap': { id: FP, kind: 'test-gap', file: 'src/a.ts', risk: 'HIGH' },
+  hygiene: { id: FP, kind: 'hygiene', file: 'src/a.ts', line: 1, marker: 'TODO' },
+  license: { id: FP, kind: 'license', package: 'lodash', version: '4.0.0', licenseType: 'MIT' },
+  'test-file-degradation': {
+    id: FP,
+    kind: 'test-file-degradation',
+    file: 'src/a.test.ts',
+    status: 'empty',
+  },
+  'god-file': { id: FP, kind: 'god-file', file: 'src/big.ts' },
+  'stale-file': { id: FP, kind: 'stale-file', file: 'src/old.swp', suffix: 'swp' },
+  'large-file': { id: FP, kind: 'large-file', file: 'src/big.ts' },
+};
+
+const ALL_KINDS = Object.keys(ENTRIES) as BaselineEntry['kind'][];
+
+describe('remediationFor', () => {
+  it('returns non-empty prose for every IdentityKind', () => {
+    for (const kind of ALL_KINDS) {
+      const text = remediationFor(kind);
+      expect(text, `kind=${kind}`).toBeTruthy();
+      expect(text.length, `kind=${kind}`).toBeGreaterThan(40);
+    }
+  });
+
+  it('secret and secret-hmac share the rotate-credential prose', () => {
+    expect(remediationFor('secret')).toContain('Rotate');
+    expect(remediationFor('secret-hmac')).toContain('Rotate');
+  });
+
+  it('dep-vuln points at the vulnerabilities CLI', () => {
+    expect(remediationFor('dep-vuln')).toContain('npx vyuh-dxkit vulnerabilities');
+  });
+
+  it('license prose redirects to inventory artifact', () => {
+    expect(remediationFor('license')).toContain('.dxkit/inventory/licenses.json');
+  });
+});
+
+describe('formatBlockHint — structural invariants', () => {
+  it('every IdentityKind produces a well-formed hint', () => {
+    for (const kind of ALL_KINDS) {
+      const hint = formatBlockHint(ENTRIES[kind]);
+      expect(hint.remediation, `${kind}: remediation`).toBeTruthy();
+      expect(hint.cliCommand, `${kind}: cliCommand`).toBeTruthy();
+      expect(hint.cliCommand, `${kind}: cliCommand`).toContain('npx vyuh-dxkit allowlist add');
+      expect(hint.applicableCategories, `${kind}: applicableCategories`).toEqual(
+        CATEGORIES_BY_KIND[kind],
+      );
+    }
+  });
+
+  it('license has empty applicableCategories', () => {
+    const hint = formatBlockHint(ENTRIES.license);
+    expect(hint.applicableCategories).toEqual([]);
+    expect(hint.inlineExample).toBeUndefined();
+    expect(hint.fileLevelOnly).toBe(true);
+  });
+});
+
+describe('formatBlockHint — inline example', () => {
+  it('renders inline example for typescript secret', () => {
+    // src/a.ts → .ts → typescript pack → '//' marker
+    const hint = formatBlockHint(ENTRIES.secret);
+    expect(hint.inlineExample).toMatch(/^\/\/ dxkit-allow:false-positive/);
+  });
+
+  it('uses python comment syntax for python source', () => {
+    const entry: BaselineEntry = {
+      id: FP,
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'r',
+      file: 'src/auth.py',
+      line: 42,
+    };
+    const hint = formatBlockHint(entry);
+    expect(hint.inlineExample).toMatch(/^# dxkit-allow:false-positive/);
+  });
+
+  it('omits inline example when file extension is unknown', () => {
+    const entry: BaselineEntry = {
+      id: FP,
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'r',
+      file: 'src/cfg.xyz',
+      line: 1,
+    };
+    const hint = formatBlockHint(entry);
+    expect(hint.inlineExample).toBeUndefined();
+  });
+
+  it('omits inline example for file-only kinds (large-file)', () => {
+    const hint = formatBlockHint(ENTRIES['large-file']);
+    expect(hint.inlineExample).toBeUndefined();
+  });
+
+  it('omits inline example for hygiene (only file-only categories apply)', () => {
+    // hygiene IS in INLINE_COMPATIBLE_KINDS but its categories are
+    // accepted-risk + deferred only — both file-only. So inline
+    // is not offered.
+    const hint = formatBlockHint(ENTRIES.hygiene);
+    expect(hint.inlineExample).toBeUndefined();
+    expect(hint.fileLevelOnly).toBe(true);
+  });
+
+  it('omits inline example for dep-vuln (no file:line on BaselineEntry)', () => {
+    // dep-vuln IS in INLINE_COMPATIBLE_KINDS in theory, but the
+    // baseline entry shape has no file/line — identity is package +
+    // version + id. So the hint formatter can't suggest a specific
+    // attachment point at block time. Falls through to fingerprint
+    // CLI form.
+    const hint = formatBlockHint(ENTRIES['dep-vuln']);
+    expect(hint.inlineExample).toBeUndefined();
+  });
+});
+
+describe('formatBlockHint — fileLevelOnly classification', () => {
+  it('false when kind has at least one inline-compatible category', () => {
+    expect(formatBlockHint(ENTRIES.secret).fileLevelOnly).toBe(false);
+    expect(formatBlockHint(ENTRIES['dep-vuln']).fileLevelOnly).toBe(false);
+  });
+
+  it('true when kind is not in INLINE_COMPATIBLE_KINDS', () => {
+    expect(formatBlockHint(ENTRIES['large-file']).fileLevelOnly).toBe(true);
+    expect(formatBlockHint(ENTRIES['coverage-gap']).fileLevelOnly).toBe(true);
+    expect(formatBlockHint(ENTRIES.duplication).fileLevelOnly).toBe(true);
+  });
+
+  it('true when kind has no inline-compatible categories applicable (hygiene)', () => {
+    expect(formatBlockHint(ENTRIES.hygiene).fileLevelOnly).toBe(true);
+  });
+});
+
+describe('formatBlockHint — CLI command shape', () => {
+  it('uses file:line positional for inline-compatible kind + locator', () => {
+    const hint = formatBlockHint(ENTRIES.secret);
+    expect(hint.cliCommand).toContain('src/a.ts:42');
+    expect(hint.cliCommand).toContain('--category=false-positive');
+    expect(hint.cliCommand).not.toContain('--fingerprint');
+  });
+
+  it('uses file positional + --kind for file-only kind with file', () => {
+    const hint = formatBlockHint(ENTRIES['large-file']);
+    expect(hint.cliCommand).toContain('src/big.ts');
+    expect(hint.cliCommand).toContain('--kind=large-file');
+  });
+
+  it('falls back to --fingerprint when no file (duplication)', () => {
+    const hint = formatBlockHint(ENTRIES.duplication);
+    expect(hint.cliCommand).toContain(`--fingerprint=${FP}`);
+    expect(hint.cliCommand).toContain('--kind=duplication');
+  });
+
+  it('falls back to --fingerprint for dep-vuln', () => {
+    const hint = formatBlockHint(ENTRIES['dep-vuln']);
+    expect(hint.cliCommand).toContain(`--fingerprint=${FP}`);
+    expect(hint.cliCommand).toContain('--kind=dep-vuln');
+  });
+
+  it('every cliCommand includes a reason placeholder', () => {
+    for (const kind of ALL_KINDS) {
+      const hint = formatBlockHint(ENTRIES[kind]);
+      expect(hint.cliCommand, `${kind}`).toContain('--reason=');
+    }
+  });
+
+  it('license cliCommand uses --category=<category> placeholder', () => {
+    const hint = formatBlockHint(ENTRIES.license);
+    expect(hint.cliCommand).toContain('--category=<category>');
+  });
+});
+
+describe('formatBlockHint — fileLevelHint', () => {
+  it('present when kind has accepted-risk or deferred applicable', () => {
+    const hint = formatBlockHint(ENTRIES.secret);
+    expect(hint.fileLevelHint).toBeTruthy();
+    expect(hint.fileLevelHint).toContain('.dxkit/allowlist.json');
+  });
+
+  it('absent when no expiring category applies (license has empty list)', () => {
+    const hint = formatBlockHint(ENTRIES.license);
+    expect(hint.fileLevelHint).toBeUndefined();
+  });
+});
+
+describe('formatBlockHint — end-to-end common case', () => {
+  it('typescript secret finding produces all three surfaces', () => {
+    const entry: BaselineEntry = {
+      id: FP,
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'detect-private-key',
+      file: 'src/auth/oauth.ts',
+      line: 42,
+    };
+    const hint = formatBlockHint(entry, 'high');
+
+    expect(hint.remediation).toContain('Rotate this credential');
+    expect(hint.inlineExample).toBe('// dxkit-allow:false-positive reason="<your reason here>"');
+    expect(hint.cliCommand).toBe(
+      'npx vyuh-dxkit allowlist add src/auth/oauth.ts:42 ' +
+        '--category=false-positive --reason="<rationale here>"',
+    );
+    expect(hint.fileLevelOnly).toBe(false);
+    expect(hint.fileLevelHint).toBeTruthy();
+  });
+});

--- a/test/allowlist/hint.test.ts
+++ b/test/allowlist/hint.test.ts
@@ -49,6 +49,13 @@ const ENTRIES: Record<BaselineEntry['kind'], BaselineEntry> = {
   'god-file': { id: FP, kind: 'god-file', file: 'src/big.ts' },
   'stale-file': { id: FP, kind: 'stale-file', file: 'src/old.swp', suffix: 'swp' },
   'large-file': { id: FP, kind: 'large-file', file: 'src/big.ts' },
+  'stale-allow': {
+    id: FP,
+    kind: 'stale-allow',
+    file: 'src/auth.ts',
+    line: 42,
+    category: 'test-fixture',
+  },
 };
 
 const ALL_KINDS = Object.keys(ENTRIES) as BaselineEntry['kind'][];
@@ -94,6 +101,14 @@ describe('formatBlockHint — structural invariants', () => {
     expect(hint.applicableCategories).toEqual([]);
     expect(hint.inlineExample).toBeUndefined();
     expect(hint.fileLevelOnly).toBe(true);
+  });
+
+  it('stale-allow has empty applicableCategories (self-suppression forbidden)', () => {
+    const hint = formatBlockHint(ENTRIES['stale-allow']);
+    expect(hint.applicableCategories).toEqual([]);
+    expect(hint.inlineExample).toBeUndefined();
+    expect(hint.fileLevelOnly).toBe(true);
+    expect(hint.remediation).toContain('Remove the orphaned');
   });
 });
 

--- a/test/allowlist/hint.test.ts
+++ b/test/allowlist/hint.test.ts
@@ -180,10 +180,15 @@ describe('formatBlockHint — CLI command shape', () => {
     expect(hint.cliCommand).not.toContain('--fingerprint');
   });
 
-  it('uses file positional + --kind for file-only kind with file', () => {
+  it('uses --fingerprint + --kind for file-only kind even when file is present', () => {
+    // file-only kinds (large-file, etc.) route through the
+    // fingerprint form because the file path alone isn't a complete
+    // identity. The dev still sees the file path in the finding
+    // output preceding the hint.
     const hint = formatBlockHint(ENTRIES['large-file']);
-    expect(hint.cliCommand).toContain('src/big.ts');
+    expect(hint.cliCommand).toContain(`--fingerprint=${FP}`);
     expect(hint.cliCommand).toContain('--kind=large-file');
+    expect(hint.cliCommand).not.toContain('src/big.ts');
   });
 
   it('falls back to --fingerprint when no file (duplication)', () => {

--- a/test/allowlist/inline.test.ts
+++ b/test/allowlist/inline.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  findAnnotationAt,
+  insertAnnotation,
+  parseAnnotation,
+  renderAnnotation,
+  type InlineAnnotation,
+} from '../../src/allowlist/inline';
+import { LANGUAGES, getLanguage } from '../../src/languages';
+import type { LanguageId, LanguageSupport } from '../../src/languages';
+
+function makeTmpdir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-inline-'));
+}
+
+function rmrf(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+const python: LanguageSupport = getLanguage('python')!;
+const typescript: LanguageSupport = getLanguage('typescript')!;
+const ruby: LanguageSupport = getLanguage('ruby')!;
+
+describe('parseAnnotation', () => {
+  it('parses python-style annotation with reason', () => {
+    const a = parseAnnotation('# dxkit-allow:test-fixture reason="placeholder"', python);
+    expect(a).toEqual({ category: 'test-fixture', reason: 'placeholder' });
+  });
+
+  it('parses typescript-style annotation with reason', () => {
+    const a = parseAnnotation('// dxkit-allow:false-positive reason="regex match"', typescript);
+    expect(a).toEqual({ category: 'false-positive', reason: 'regex match' });
+  });
+
+  it('parses same-line annotation appended to source', () => {
+    const a = parseAnnotation(
+      'api_key = "sk_test"  # dxkit-allow:test-fixture reason="fixture"',
+      python,
+    );
+    expect(a).toEqual({ category: 'test-fixture', reason: 'fixture' });
+  });
+
+  it('parses annotation without reason', () => {
+    const a = parseAnnotation('# dxkit-allow:test-fixture', python);
+    expect(a).toEqual({ category: 'test-fixture', reason: undefined });
+  });
+
+  it('returns null for line without comment marker', () => {
+    expect(parseAnnotation('api_key = "sk_test"', python)).toBeNull();
+  });
+
+  it('returns null for comment without dxkit-allow prefix', () => {
+    expect(parseAnnotation('# just a regular comment', python)).toBeNull();
+  });
+
+  it('returns null for unknown category', () => {
+    expect(parseAnnotation('# dxkit-allow:invented-category reason="x"', python)).toBeNull();
+  });
+
+  it('unescapes embedded double-quote in reason', () => {
+    const a = parseAnnotation('# dxkit-allow:test-fixture reason="he said \\"hi\\""', python);
+    expect(a?.reason).toBe('he said "hi"');
+  });
+
+  it('unescapes embedded backslash in reason', () => {
+    const a = parseAnnotation('# dxkit-allow:test-fixture reason="path\\\\to\\\\foo"', python);
+    expect(a?.reason).toBe('path\\to\\foo');
+  });
+
+  it('parses with extra whitespace between marker and prefix', () => {
+    const a = parseAnnotation('#   dxkit-allow:test-fixture reason="x"', python);
+    expect(a?.category).toBe('test-fixture');
+  });
+
+  it('accepts ruby # marker', () => {
+    const a = parseAnnotation('# dxkit-allow:mitigated-externally reason="WAF"', ruby);
+    expect(a?.category).toBe('mitigated-externally');
+  });
+
+  it('accepts each inline-compatible category', () => {
+    for (const cat of ['false-positive', 'test-fixture', 'mitigated-externally'] as const) {
+      const a = parseAnnotation(`# dxkit-allow:${cat} reason="x"`, python);
+      expect(a?.category).toBe(cat);
+    }
+  });
+
+  it('parses accepted-risk + deferred too (caller decides applicability)', () => {
+    // parser does NOT enforce inline-compatibility — it accepts any
+    // canonical category. The CALLER (CLI) decides whether to honor
+    // it or reject as file-only.
+    expect(parseAnnotation('# dxkit-allow:accepted-risk reason="x"', python)?.category).toBe(
+      'accepted-risk',
+    );
+    expect(parseAnnotation('# dxkit-allow:deferred reason="x"', python)?.category).toBe('deferred');
+  });
+
+  it('returns null when language has no commentSyntax', () => {
+    const bareLang = { id: 'fake' as LanguageId, commentSyntax: undefined } as LanguageSupport;
+    expect(parseAnnotation('# dxkit-allow:test-fixture', bareLang)).toBeNull();
+  });
+});
+
+describe('renderAnnotation', () => {
+  it('renders python annotation with hash marker', () => {
+    const a: InlineAnnotation = { category: 'test-fixture', reason: 'placeholder' };
+    expect(renderAnnotation(a, python)).toBe('# dxkit-allow:test-fixture reason="placeholder"');
+  });
+
+  it('renders typescript annotation with slash marker', () => {
+    const a: InlineAnnotation = { category: 'false-positive', reason: 'regex match' };
+    expect(renderAnnotation(a, typescript)).toBe(
+      '// dxkit-allow:false-positive reason="regex match"',
+    );
+  });
+
+  it('renders without reason when reason undefined', () => {
+    const a: InlineAnnotation = { category: 'test-fixture' };
+    expect(renderAnnotation(a, python)).toBe('# dxkit-allow:test-fixture');
+  });
+
+  it('escapes embedded double-quote in reason', () => {
+    const a: InlineAnnotation = { category: 'test-fixture', reason: 'he said "hi"' };
+    expect(renderAnnotation(a, python)).toBe(
+      '# dxkit-allow:test-fixture reason="he said \\"hi\\""',
+    );
+  });
+
+  it('renders round-trip: render → parse yields original', () => {
+    const a: InlineAnnotation = { category: 'mitigated-externally', reason: 'WAF rule X' };
+    const rendered = renderAnnotation(a, python);
+    expect(parseAnnotation(rendered, python)).toEqual(a);
+  });
+});
+
+describe('findAnnotationAt', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  function write(name: string, content: string): string {
+    const p = path.join(tmp, name);
+    fs.writeFileSync(p, content, 'utf8');
+    return p;
+  }
+
+  it('finds same-line annotation', () => {
+    const file = write('a.py', 'api_key = "sk_test"  # dxkit-allow:test-fixture reason="x"\n');
+    const m = findAnnotationAt(file, 1, python);
+    expect(m).toMatchObject({
+      annotation: { category: 'test-fixture', reason: 'x' },
+      position: 'same-line',
+      annotationLine: 1,
+    });
+  });
+
+  it('finds above-line annotation', () => {
+    const file = write('a.py', '# dxkit-allow:test-fixture reason="x"\napi_key = "sk_test"\n');
+    const m = findAnnotationAt(file, 2, python);
+    expect(m).toMatchObject({
+      annotation: { category: 'test-fixture', reason: 'x' },
+      position: 'above',
+      annotationLine: 1,
+    });
+  });
+
+  it('returns null when neither position has annotation', () => {
+    const file = write('a.py', '# just a comment\napi_key = "sk_test"\n');
+    expect(findAnnotationAt(file, 2, python)).toBeNull();
+  });
+
+  it('returns null when above-line is NOT a standalone annotation', () => {
+    // Above line has code + comment but no annotation prefix
+    const file = write('a.py', 'x = 1  # regular comment\napi_key = "sk_test"\n');
+    expect(findAnnotationAt(file, 2, python)).toBeNull();
+  });
+
+  it('does not pick up annotation two lines above (immediate-prev only)', () => {
+    const file = write('a.py', '# dxkit-allow:test-fixture reason="x"\n\napi_key = "sk_test"\n');
+    expect(findAnnotationAt(file, 3, python)).toBeNull();
+  });
+
+  it('throws on lineNumber < 1', () => {
+    const file = write('a.py', 'x\n');
+    expect(() => findAnnotationAt(file, 0, python)).toThrow(/lineNumber/);
+  });
+
+  it('throws on lineNumber past EOF', () => {
+    const file = write('a.py', 'x\n');
+    expect(() => findAnnotationAt(file, 99, python)).toThrow(/exceeds file length/);
+  });
+
+  it('handles file without trailing newline', () => {
+    const file = write('a.py', 'api_key = "x"  # dxkit-allow:test-fixture reason="y"');
+    const m = findAnnotationAt(file, 1, python);
+    expect(m?.position).toBe('same-line');
+  });
+});
+
+describe('insertAnnotation', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  function write(name: string, content: string): string {
+    const p = path.join(tmp, name);
+    fs.writeFileSync(p, content, 'utf8');
+    return p;
+  }
+
+  it('appends same-line for short target line', () => {
+    const file = write('a.py', 'x = "y"\n');
+    const r = insertAnnotation(file, 1, { category: 'test-fixture', reason: 'fix' }, python);
+    expect(r.position).toBe('same-line');
+    const after = fs.readFileSync(file, 'utf8');
+    expect(after).toBe('x = "y"  # dxkit-allow:test-fixture reason="fix"\n');
+  });
+
+  it('inserts above for long target line', () => {
+    const longLine = 'x = "' + 'a'.repeat(100) + '"';
+    const file = write('a.py', longLine + '\n');
+    const r = insertAnnotation(file, 1, { category: 'test-fixture', reason: 'fix' }, python);
+    expect(r.position).toBe('above');
+    const after = fs.readFileSync(file, 'utf8');
+    expect(after.split('\n')[0]).toBe('# dxkit-allow:test-fixture reason="fix"');
+    expect(after.split('\n')[1]).toBe(longLine);
+  });
+
+  it('preserves indentation when inserting above', () => {
+    const longLine = '    x = "' + 'a'.repeat(100) + '"';
+    const file = write('a.py', longLine + '\n');
+    insertAnnotation(file, 1, { category: 'test-fixture', reason: 'fix' }, python);
+    const after = fs.readFileSync(file, 'utf8');
+    expect(after.split('\n')[0]).toBe('    # dxkit-allow:test-fixture reason="fix"');
+  });
+
+  it('preserves indentation with tab-based source', () => {
+    const longLine = '\t\tx = "' + 'a'.repeat(100) + '"';
+    const file = write('a.go', longLine + '\n');
+    insertAnnotation(file, 1, { category: 'test-fixture', reason: 'fix' }, getLanguage('go')!);
+    const after = fs.readFileSync(file, 'utf8');
+    expect(after.split('\n')[0]).toBe('\t\t// dxkit-allow:test-fixture reason="fix"');
+  });
+
+  it('preserves file without trailing newline', () => {
+    const file = write('a.py', 'x = "y"');
+    insertAnnotation(file, 1, { category: 'test-fixture', reason: 'x' }, python);
+    const after = fs.readFileSync(file, 'utf8');
+    expect(after.endsWith('\n')).toBe(false);
+  });
+
+  it('preserves trailing newline', () => {
+    const file = write('a.py', 'x = "y"\n');
+    insertAnnotation(file, 1, { category: 'test-fixture', reason: 'x' }, python);
+    const after = fs.readFileSync(file, 'utf8');
+    expect(after.endsWith('\n')).toBe(true);
+  });
+
+  it('preserves CRLF line endings', () => {
+    const file = write('a.ts', 'const x = "y";\r\nconst z = 1;\r\n');
+    insertAnnotation(file, 1, { category: 'test-fixture', reason: 'x' }, typescript);
+    const after = fs.readFileSync(file, 'utf8');
+    expect(after).toContain('\r\n');
+    expect(after.split('\r\n')[0]).toBe('const x = "y";  // dxkit-allow:test-fixture reason="x"');
+  });
+
+  it('rejects accepted-risk category', () => {
+    const file = write('a.py', 'x\n');
+    expect(() =>
+      insertAnnotation(file, 1, { category: 'accepted-risk', reason: 'x' }, python),
+    ).toThrow(/file-only/);
+  });
+
+  it('rejects deferred category', () => {
+    const file = write('a.py', 'x\n');
+    expect(() => insertAnnotation(file, 1, { category: 'deferred', reason: 'x' }, python)).toThrow(
+      /file-only/,
+    );
+  });
+
+  it('round-trips: insert → find returns the same annotation', () => {
+    const file = write('a.py', 'x = "y"\n');
+    const inserted: InlineAnnotation = { category: 'test-fixture', reason: 'r' };
+    insertAnnotation(file, 1, inserted, python);
+    const found = findAnnotationAt(file, 1, python);
+    expect(found?.annotation).toEqual(inserted);
+  });
+
+  it('round-trips with embedded quote in reason', () => {
+    const file = write('a.py', 'x = "y"\n');
+    const inserted: InlineAnnotation = { category: 'test-fixture', reason: 'he said "hi"' };
+    insertAnnotation(file, 1, inserted, python);
+    const found = findAnnotationAt(file, 1, python);
+    expect(found?.annotation.reason).toBe('he said "hi"');
+  });
+
+  it('configurable threshold takes effect', () => {
+    const file = write('a.py', 'x = "y"\n');
+    // Force above-line by setting threshold to 0
+    const r = insertAnnotation(file, 1, { category: 'test-fixture', reason: 'x' }, python, {
+      sameLineThreshold: 0,
+    });
+    expect(r.position).toBe('above');
+  });
+
+  it('throws on lineNumber < 1', () => {
+    const file = write('a.py', 'x\n');
+    expect(() =>
+      insertAnnotation(file, 0, { category: 'test-fixture', reason: 'x' }, python),
+    ).toThrow(/lineNumber/);
+  });
+
+  it('throws on lineNumber past EOF', () => {
+    const file = write('a.py', 'x\n');
+    expect(() =>
+      insertAnnotation(file, 99, { category: 'test-fixture', reason: 'x' }, python),
+    ).toThrow(/exceeds file length/);
+  });
+});
+
+describe('cross-language matrix', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  // Every shipped pack should support full round-trip of an inline
+  // annotation through its own commentSyntax. Catches the case where
+  // we added a pack but forgot to populate commentSyntax (the
+  // contract test catches this too, but exercising it through real
+  // insert+parse is the integration-level guarantee).
+  for (const lang of LANGUAGES) {
+    it(`${lang.id}: insert + find round-trip`, () => {
+      const ext = lang.sourceExtensions[0];
+      const file = path.join(tmp, `a${ext}`);
+      fs.writeFileSync(file, 'x = 1\n', 'utf8');
+      const annotation: InlineAnnotation = {
+        category: 'test-fixture',
+        reason: `pack-${lang.id}-fixture`,
+      };
+      insertAnnotation(file, 1, annotation, lang);
+      const found = findAnnotationAt(file, 1, lang);
+      expect(found, `${lang.id}: round-trip failed`).not.toBeNull();
+      expect(found!.annotation).toEqual(annotation);
+    });
+  }
+});

--- a/test/baseline/check.test.ts
+++ b/test/baseline/check.test.ts
@@ -105,6 +105,51 @@ describe('runGuardrailCheck (integration)', () => {
       expect(viaPath.baselinePath).toBe(stashed);
       expect(viaPath.baseline.name).toBe('main');
     }, 300_000);
+
+    it('surfaces allowlist additions in the markdown PR-comment section', async () => {
+      // Baseline-time: no .dxkit/allowlist.json file
+      await createBaseline({ cwd: dir });
+
+      // Add a file-level allowlist entry on the "current" branch
+      // (working tree only — baseline-create won't be re-run).
+      const allowlistDir = join(dir, '.dxkit');
+      execFileSync('mkdir', ['-p', allowlistDir]);
+      writeFileSync(
+        join(allowlistDir, 'allowlist.json'),
+        JSON.stringify(
+          {
+            schemaVersion: 'dxkit-allowlist/v1',
+            mode: 'full',
+            entries: [
+              {
+                fingerprint: 'aaaa111111111111',
+                kind: 'dep-vuln',
+                category: 'accepted-risk',
+                reason: 'WAF rule mitigates the attack vector',
+                addedBy: 'reviewer@example.com',
+                addedAt: '2026-05-22',
+                expiresAt: '2026-08-22',
+              },
+            ],
+          },
+          null,
+          2,
+        ) + '\n',
+      );
+
+      const result = await runGuardrailCheck({ cwd: dir });
+      expect(result.allowlistDelta).toBeDefined();
+      expect(result.allowlistDelta.baselineAccessible).toBe(true);
+      expect(result.allowlistDelta.added).toHaveLength(1);
+      expect(result.allowlistDelta.added[0].fingerprint).toBe('aaaa111111111111');
+
+      const md = renderMarkdown(result);
+      expect(md).toContain('### Allowlist activity');
+      expect(md).toContain('Added (1)');
+      expect(md).toContain('aaaa111111111111');
+      expect(md).toContain('accepted-risk');
+      expect(md).toContain('WAF rule mitigates');
+    }, 300_000);
   });
 
   describe('error + policy + drift paths', () => {

--- a/test/baseline/finding-identity.test.ts
+++ b/test/baseline/finding-identity.test.ts
@@ -593,6 +593,64 @@ const FIXTURES: ReadonlyArray<IdentityFixture> = [
     },
     expected: 'persisted',
   },
+
+  // ─── stale-allow (3) ──────────────────────────────────────────────────
+  {
+    name: 'stale-allow/clean — same file, line, category',
+    prior: {
+      kind: 'stale-allow',
+      file: 'src/auth/oauth.ts',
+      line: 42,
+      category: 'test-fixture',
+    },
+    current: {
+      kind: 'stale-allow',
+      file: 'src/auth/oauth.ts',
+      line: 42,
+      category: 'test-fixture',
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'stale-allow/line-window absorbs small line drift',
+    // The 3-line window in `lineWindowFor` buckets lines by
+    // floor(line / 3) * 3. Lines 42, 43, 44 all bucket to 42,
+    // so a formatter-driven shift inside the bucket doesn't
+    // churn identity. (Lines that cross a bucket boundary —
+    // 41 → bucket 39, 42 → bucket 42 — DO churn; that's the
+    // window's deliberate granularity.)
+    prior: {
+      kind: 'stale-allow',
+      file: 'src/auth/oauth.ts',
+      line: 42,
+      category: 'test-fixture',
+    },
+    current: {
+      kind: 'stale-allow',
+      file: 'src/auth/oauth.ts',
+      line: 44,
+      category: 'test-fixture',
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'stale-allow/category-change → identity changes',
+    // Reclassifying an annotation (test-fixture → false-positive
+    // on the same source line) is semantically a different stale-allow.
+    prior: {
+      kind: 'stale-allow',
+      file: 'src/auth/oauth.ts',
+      line: 42,
+      category: 'test-fixture',
+    },
+    current: {
+      kind: 'stale-allow',
+      file: 'src/auth/oauth.ts',
+      line: 42,
+      category: 'false-positive',
+    },
+    expected: 'changed',
+  },
 ];
 
 describe('identityFor — per-kind deterministic identity', () => {
@@ -731,6 +789,7 @@ const EXPECTED_KINDS = [
   'stale-file',
   'large-file',
   'secret-hmac',
+  'stale-allow',
 ] as const;
 
 describe('identityFor — coverage contract (Rule 9)', () => {

--- a/test/baseline/producer-playbook.test.ts
+++ b/test/baseline/producer-playbook.test.ts
@@ -103,6 +103,7 @@ function fixtureContext(): ProducerContext {
       mixedLanguages: false,
     },
     rawSecrets: [],
+    inlineAllowlistAnnotations: [],
   };
 }
 

--- a/test/baseline/producers-contract.test.ts
+++ b/test/baseline/producers-contract.test.ts
@@ -57,6 +57,7 @@ const ALL_KINDS: ReadonlyArray<IdentityKind> = [
   'stale-file',
   'large-file',
   'secret-hmac',
+  'stale-allow',
 ];
 
 /** Compile-time exhaustiveness check — adding a new kind to

--- a/test/baseline/producers/stale-allow.test.ts
+++ b/test/baseline/producers/stale-allow.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import { staleAllowToBaselineEntries } from '../../../src/baseline/producers/stale-allow';
+import type { InlineAllowlistOccurrence } from '../../../src/allowlist/gather';
+import type { CodeFinding, SecurityAggregate } from '../../../src/analyzers/security/aggregator';
+
+function makeOccurrence(
+  partial: Partial<InlineAllowlistOccurrence> & { file: string; line: number },
+): InlineAllowlistOccurrence {
+  return {
+    category: 'test-fixture',
+    position: 'same-line',
+    ...partial,
+  };
+}
+
+function makeFinding(file: string, line: number, severity: 'high' = 'high'): CodeFinding {
+  return {
+    severity,
+    category: 'secret',
+    cwe: '',
+    rule: 'gitleaks/private-key',
+    title: '',
+    file,
+    line,
+    tool: 'gitleaks',
+    fingerprint: 'fp',
+    canonicalRule: 'gitleaks/private-key',
+    producedBy: ['gitleaks'],
+  };
+}
+
+function makeAggregate(
+  opts: {
+    secrets?: CodeFinding[];
+    code?: CodeFinding[];
+    config?: CodeFinding[];
+  } = {},
+): SecurityAggregate {
+  return {
+    codeBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    depBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    secretsBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    findingsByCategory: {
+      secret: opts.secrets ?? [],
+      code: opts.code ?? [],
+      config: opts.config ?? [],
+      dependency: [],
+    },
+    dependencyAdvisoryUniqueCount: 0,
+    dependencyFindingsRawCount: 0,
+    dedupCollisions: [],
+    provenance: {
+      secrets: { tool: null },
+      codePatterns: { tool: null },
+      depVulns: { tool: null },
+    } as unknown as SecurityAggregate['provenance'],
+  };
+}
+
+describe('staleAllowToBaselineEntries', () => {
+  it('returns empty array when annotations list is empty', () => {
+    const out = staleAllowToBaselineEntries({
+      annotations: [],
+      aggregate: makeAggregate(),
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('returns empty array when aggregate is null (cannot determine staleness)', () => {
+    const out = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 1 })],
+      aggregate: null,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('emits stale-allow entry for orphaned annotation', () => {
+    const out = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 42 })],
+      aggregate: makeAggregate(),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      kind: 'stale-allow',
+      file: 'src/a.ts',
+      line: 42,
+      category: 'test-fixture',
+    });
+    expect(out[0].id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('does NOT emit when annotation has matching secret finding at same line', () => {
+    const out = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 42 })],
+      aggregate: makeAggregate({ secrets: [makeFinding('src/a.ts', 42)] }),
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT emit when annotation has matching code finding at same line', () => {
+    const out = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 42 })],
+      aggregate: makeAggregate({ code: [makeFinding('src/a.ts', 42)] }),
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT emit when annotation has matching config finding at same line', () => {
+    const out = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'config.ts', line: 5 })],
+      aggregate: makeAggregate({ config: [makeFinding('config.ts', 5)] }),
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('matches within the 3-line window (annotation at 42, finding at 44 → active)', () => {
+    // lineWindowFor(42) and lineWindowFor(44) both → 42
+    const out = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 42 })],
+      aggregate: makeAggregate({ secrets: [makeFinding('src/a.ts', 44)] }),
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('flags as stale when annotation is in a different file from finding', () => {
+    const out = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 42 })],
+      aggregate: makeAggregate({ secrets: [makeFinding('src/different.ts', 42)] }),
+    });
+    expect(out).toHaveLength(1);
+  });
+
+  it('flags as stale when annotation is outside the line window', () => {
+    // lineWindowFor(41) → 39; lineWindowFor(42) → 42 — different windows
+    const out = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 41 })],
+      aggregate: makeAggregate({ secrets: [makeFinding('src/a.ts', 42)] }),
+    });
+    expect(out).toHaveLength(1);
+  });
+
+  it('partitions a mixed input correctly', () => {
+    const out = staleAllowToBaselineEntries({
+      annotations: [
+        makeOccurrence({ file: 'src/a.ts', line: 10 }), // active
+        makeOccurrence({ file: 'src/b.ts', line: 20 }), // stale
+        makeOccurrence({ file: 'src/c.ts', line: 30 }), // active (matches code)
+      ],
+      aggregate: makeAggregate({
+        secrets: [makeFinding('src/a.ts', 10)],
+        code: [makeFinding('src/c.ts', 30)],
+      }),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].kind === 'stale-allow' && out[0].file).toBe('src/b.ts');
+  });
+
+  it('preserves the annotation category in the emitted entry', () => {
+    const out = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 10, category: 'false-positive' })],
+      aggregate: makeAggregate(),
+    });
+    expect(out[0].kind === 'stale-allow' && out[0].category).toBe('false-positive');
+  });
+
+  it('produces stable identities for the same input (determinism)', () => {
+    const a = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 42 })],
+      aggregate: makeAggregate(),
+    });
+    const b = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 42 })],
+      aggregate: makeAggregate(),
+    });
+    expect(a[0].id).toBe(b[0].id);
+  });
+});

--- a/test/issue-cli.test.ts
+++ b/test/issue-cli.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { buildIssueUrl, ISSUE_TYPES, type BuildIssueUrlInput } from '../src/issue-cli';
+
+function baseInput(over: Partial<BuildIssueUrlInput> = {}): BuildIssueUrlInput {
+  return {
+    type: 'bug',
+    dxkitVersion: '2.6.0-test',
+    nodeVersion: 'v22.0.0',
+    platform: 'linux',
+    arch: 'x64',
+    ...over,
+  };
+}
+
+function parseUrl(url: string): { title: string; body: string; labels: string } {
+  const u = new URL(url);
+  return {
+    title: u.searchParams.get('title') ?? '',
+    body: u.searchParams.get('body') ?? '',
+    labels: u.searchParams.get('labels') ?? '',
+  };
+}
+
+describe('buildIssueUrl', () => {
+  it('targets the dxkit GitHub Issues new-issue endpoint', () => {
+    const url = buildIssueUrl(baseInput());
+    expect(url).toMatch(/^https:\/\/github\.com\/vyuh-labs\/dxkit\/issues\/new\?/);
+  });
+
+  it('encodes title + body + labels as query params', () => {
+    const url = buildIssueUrl(baseInput());
+    const parsed = parseUrl(url);
+    expect(parsed.title.length).toBeGreaterThan(0);
+    expect(parsed.body.length).toBeGreaterThan(0);
+    expect(parsed.labels.length).toBeGreaterThan(0);
+  });
+
+  it('per-type title prefix surfaces in the title', () => {
+    const cases: Array<[(typeof ISSUE_TYPES)[number], string]> = [
+      ['bug', '[Bug]'],
+      ['false-positive', '[False positive]'],
+      ['missing-finding', '[Missing finding]'],
+      ['feature-request', '[Feature request]'],
+      ['docs', '[Docs]'],
+    ];
+    for (const [type, prefix] of cases) {
+      const parsed = parseUrl(buildIssueUrl(baseInput({ type })));
+      expect(parsed.title, `type=${type}`).toContain(prefix);
+    }
+  });
+
+  it('per-type label is applied', () => {
+    const cases: Array<[(typeof ISSUE_TYPES)[number], string]> = [
+      ['bug', 'bug'],
+      ['false-positive', 'false-positive'],
+      ['missing-finding', 'missing-finding'],
+      ['feature-request', 'enhancement'],
+      ['docs', 'documentation'],
+    ];
+    for (const [type, label] of cases) {
+      const parsed = parseUrl(buildIssueUrl(baseInput({ type })));
+      expect(parsed.labels, `type=${type}`).toBe(label);
+    }
+  });
+
+  it('body includes env metadata (dxkit version, node version, platform, arch)', () => {
+    const parsed = parseUrl(
+      buildIssueUrl(
+        baseInput({
+          dxkitVersion: '2.6.0-test',
+          nodeVersion: 'v22.1.0',
+          platform: 'darwin',
+          arch: 'arm64',
+        }),
+      ),
+    );
+    expect(parsed.body).toContain('**dxkit version:** 2.6.0-test');
+    expect(parsed.body).toContain('**Node version:** v22.1.0');
+    expect(parsed.body).toContain('**Platform:** darwin / arm64');
+  });
+
+  it('body includes the type', () => {
+    const parsed = parseUrl(buildIssueUrl(baseInput({ type: 'false-positive' })));
+    expect(parsed.body).toContain('**Type:** false-positive');
+  });
+
+  it('embeds --fingerprint in the body when provided', () => {
+    const parsed = parseUrl(
+      buildIssueUrl(baseInput({ type: 'false-positive', fingerprint: 'a3f9c0e8b7d2e1f4' })),
+    );
+    expect(parsed.body).toContain('**Finding fingerprint:** `a3f9c0e8b7d2e1f4`');
+  });
+
+  it('embeds the --about text in the title (truncated) and body (full)', () => {
+    const long = 'the scanner flagged my intentional placeholder API key as a real secret';
+    const parsed = parseUrl(buildIssueUrl(baseInput({ about: long })));
+    // Title is truncated to a short summary
+    expect(parsed.title.length).toBeLessThanOrEqual(80);
+    expect(parsed.title).toContain('the scanner flagged');
+    // Body carries the full text
+    expect(parsed.body).toContain(long);
+  });
+
+  it('falls back to placeholder text in body when --about is omitted', () => {
+    const parsed = parseUrl(buildIssueUrl(baseInput({ about: undefined })));
+    expect(parsed.body).toContain('Describe what you observed');
+  });
+
+  it('falls back to fingerprint-based title when --about is omitted', () => {
+    const parsed = parseUrl(
+      buildIssueUrl(baseInput({ type: 'false-positive', fingerprint: 'a3f9c0e8b7d2e1f4' })),
+    );
+    expect(parsed.title).toContain('finding a3f9c0e8b7d2e1f4');
+  });
+
+  it('ISSUE_TYPES is the complete known list', () => {
+    expect([...ISSUE_TYPES]).toEqual([
+      'false-positive',
+      'missing-finding',
+      'bug',
+      'feature-request',
+      'docs',
+    ]);
+  });
+
+  it('URL is < 8KB (GitHub URL limit for safety)', () => {
+    // A maximally pre-filled URL — long about text + fingerprint —
+    // should still fit comfortably under GitHub's effective URL limit.
+    const url = buildIssueUrl(
+      baseInput({
+        about: 'x'.repeat(2000),
+        fingerprint: 'a'.repeat(16),
+      }),
+    );
+    expect(url.length).toBeLessThan(8192);
+  });
+});

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -233,6 +233,33 @@ describe.each(LANGUAGES as LanguageSupport[])('language contract: $id', (lang) =
     expect(lang.devcontainerFeature!.name).toMatch(/^ghcr\.io\/devcontainers/);
   });
 
+  // 2.6 allowlist feature (Sprint 1): every pack declares its line-comment
+  // syntax so the inline-allowlist annotation generator can render
+  // `<lineComment> dxkit-allow:<category> reason="..."` in the right
+  // form for the file's language. A pack missing `commentSyntax` would
+  // make the inline path silently fall back to `#` (broken in TS/Go/
+  // Rust/C#/Kotlin/Java) or hardcode a default in the allowlist module
+  // (a Rule 6 violation). The scaffolder ships a placeholder; this
+  // assertion enforces that the placeholder gets filled in.
+  it('declares commentSyntax with a non-empty lineComment', () => {
+    expect(
+      lang.commentSyntax,
+      `${lang.id}: missing commentSyntax — allowlist inline annotation insertion ` +
+        `would have no per-language comment form`,
+    ).toBeDefined();
+    expect(typeof lang.commentSyntax!.lineComment).toBe('string');
+    expect(
+      lang.commentSyntax!.lineComment.length,
+      `${lang.id}: commentSyntax.lineComment is empty — fill in the scaffolded ` +
+        `placeholder ('#' for hash-style, '//' for slash-style, etc.)`,
+    ).toBeGreaterThan(0);
+    if (lang.commentSyntax!.blockCommentStart !== undefined) {
+      expect(typeof lang.commentSyntax!.blockCommentStart).toBe('string');
+      expect(typeof lang.commentSyntax!.blockCommentEnd).toBe('string');
+      expect(lang.commentSyntax!.blockCommentEnd!.length).toBeGreaterThan(0);
+    }
+  });
+
   it('extraExcludes is an array of strings when defined', () => {
     if (lang.extraExcludes) {
       expect(Array.isArray(lang.extraExcludes)).toBe(true);


### PR DESCRIPTION
## Summary

Sprint 1 of the 2.6 release ships the **per-finding allowlist** — a typed-category, audit-trackable suppression mechanism that complements the codebase-wide baseline. Closes user-stated must-have #1 from the 2.6 plan (`tmp/2.6-plan.md`); design captured in `tmp/2.6-allowlist-design.md`.

16 commits, +48 net tests (1856/1856 passing), cross-stack smoke-walkthrough verified on `external-repos/platform` (TS+Python).

## What landed

### Customer-facing surface

- `vyuh-dxkit allowlist add` — inline-annotation form (`<file>:<line>`) or file-level form (`--fingerprint=<id> --kind=<kind>`)
- `vyuh-dxkit allowlist list / show / audit / prune` — read, inspect, surface stale + soon-to-expire, remove expired
- `vyuh-dxkit issue` — pre-filled GitHub Issues for false-positives / missing-findings / bugs / feature-requests / docs
- PR-comment integration: `guardrail check --markdown` now includes an "Allowlist activity" section listing entries added or removed on the branch vs. baseline commit
- `dxkit-action` skill walks customers through fix-first → allowlist-fallback (semgrep's `// nosemgrep:` redirected to dxkit's canonical `// dxkit-allow:` surface)

### Architectural pieces

- **Five typed categories**: `false-positive` / `test-fixture` / `mitigated-externally` / `accepted-risk` / `deferred`. The last two require `--expires` (default 90d).
- **Two surfaces**: inline `// dxkit-allow:<cat> reason="..."` annotations + file-level `.dxkit/allowlist.json` (with gitignored reasons sidecar in sanitized mode for public repos)
- **`stale-allow` IdentityKind**: orphaned `dxkit-allow:` annotations emit a new finding on the next scan (TypeScript `@ts-expect-error` pattern — forces cleanup, prevents annotation graveyard). Allowlisting a `stale-allow` finding is forbidden.
- **`commentSyntax` on `LanguageSupport`**: each pack declares its line-comment marker; the inline-annotation generator drives off this so no hardcoded `'//'` / `'#'` literals leak into cross-cutting code
- **Three preemptive arch-check rules**: no `createHash` in `src/allowlist/`, no direct `allowlist.json` IO outside the canonical loader, no language-comment fallback literals

### Documentation

- README: new "Allowlist" + "Reporting issues" sections
- `docs/commands/allowlist.md` + `docs/commands/issue.md` (new full references)
- `docs/getting-started.md` steps 6 + 7
- `docs/commands/guardrail.md` updated to mention PR-comment review section
- `docs/configuration/policy.md` + `docs/configuration/dxkit-ignore.md` clarify per-finding vs broad-classification scoping
- CHANGELOG `[Unreleased]` documents every artifact

## Architectural posture

- **CLAUDE.md Rule 6**: language facts via `LanguageSupport.commentSyntax`; arch-check enforces no fallback literals
- **CLAUDE.md Rule 9**: allowlist matches by canonical fingerprint only; zero `createHash` calls in `src/allowlist/`
- **CLAUDE.md Rule 10**: `stale-allow` producer registered in `PRODUCERS`; removed from `DEFERRED_KINDS` once the gather pass landed
- TypeScript exhaustiveness on `BaselineEntry['kind']` enforces 6+ switches across the codebase — new finding kinds can't ship without matching cases
- Two preemptive de-duplication refactors mid-sprint kept the single-source-of-truth discipline tight (`ALL_CATEGORIES` derived via `as const` + `typeof[number]`; `dxkit-allow:` prefix lifted to one constant; the inline-compat / expiring sets always read from the canonical declarations rather than re-implementing inline)

## Test plan

- [x] ~250 unit tests added alongside each module (categories: 24, file IO: 55, inline parsing: 49, hint formatter: 24, CLI: 35, gather: 10, stale-allow producer: 12, diff: 13, issue-cli: 12)
- [x] Integration test: end-to-end "allowlist delta surfaces in PR-comment markdown" in `check.test.ts`
- [x] Per-kind identity fixture rows (Rule 9 contract)
- [x] Full suite: 1856/1856 passing across 107 files
- [x] Typecheck + arch-check + slop + cross-ecosystem coverage gates all pass
- [x] Smoke walkthrough on `external-repos/platform` (vyuhlabs-platform, TS+Python ~50KLOC): inline insertion, file-level entry, list/show/audit/prune, issue URL build, PR-comment markdown — all verified end-to-end; repo restored byte-identical to pre-walkthrough state

## Notable scope decisions

- `staleHandling: 'strict' | 'lenient'` policy flag deferred — strict-default behavior shipped; lenient mode (warnings only) lands later if customer signal indicates need
- Inline annotation grammar restricted to non-expiring categories (false-positive / test-fixture / mitigated-externally); accepted-risk + deferred go file-level only because they need expiry + sign-off that inline can't carry cleanly

## Merge strategy

Per CLAUDE.md release procedure — **rebase-merge** to preserve atomic commits. Each commit represents a discrete architectural unit with a prose-quality commit message; future `git bisect` benefits from the granularity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)