### PR TITLE
Sprint 2: explore CLI — six subcommands for repo comprehension

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,6 +107,8 @@ function printUsage(): void {
     vyuh-dxkit coverage [path]   Run per-pack test-with-coverage (side-effecting; materializes the coverage artifact health/test-gaps read)
     vyuh-dxkit dashboard [path]  Render .dxkit/reports/ into a single HTML dashboard
     vyuh-dxkit report [path]     Run every analyzer + dashboard in one shot (full audit)
+    vyuh-dxkit explore <sub>     Repo exploration via the graphify artifact (Sprint 2: hot-files;
+                                 entry-points / file / feature / communities / api-surface coming)
     vyuh-dxkit to-xlsx <json>    Convert a dxkit JSON report to 15-col XLSX
     vyuh-dxkit tools [path]      Show required analysis tools status
     vyuh-dxkit tools install     Interactively install missing tools
@@ -276,6 +278,10 @@ export async function run(argv: string[]): Promise<void> {
       type: { type: 'string' },
       about: { type: 'string' },
       'no-browser': { type: 'boolean', default: false },
+      // explore flags
+      limit: { type: 'string' },
+      refresh: { type: 'boolean', default: false },
+      substring: { type: 'boolean', default: false },
     },
     allowPositionals: true,
     strict: false,
@@ -1810,6 +1816,20 @@ export async function run(argv: string[]): Promise<void> {
         fingerprint: values.fingerprint as string | undefined,
         about: values.about as string | undefined,
         noBrowser: !!values['no-browser'],
+      });
+      break;
+    }
+
+    case 'explore': {
+      const { runExplore } = await import('./explore-cli');
+      // positionals[0] is 'explore'; positionals[1..] are the
+      // explore subcommand name + any subcommand args.
+      await runExplore(cwd, positionals.slice(1), {
+        json: !!values.json,
+        limit: values.limit as string | undefined,
+        refresh: !!values.refresh,
+        substring: !!values.substring,
+        filter: values.filter as string | undefined,
       });
       break;
     }

--- a/src/explore-cli.ts
+++ b/src/explore-cli.ts
@@ -34,8 +34,10 @@ import {
   GraphSchemaVersionError,
   loadGraph,
 } from './explore/load';
+import { runApiSurface } from './explore/cli/api-surface';
 import { runCommunities } from './explore/cli/communities';
 import { runEntryPoints } from './explore/cli/entry-points';
+import { runFeature } from './explore/cli/feature';
 import { runFile } from './explore/cli/file';
 import { runHotFiles } from './explore/cli/hot-files';
 import type { Graph } from './explore/types';
@@ -91,9 +93,13 @@ export async function runExplore(
       runEntryPoints(graph, positionals.slice(1), values, cwd);
       return;
 
-    // Other subcommands land here as Sprint 2 progresses:
-    // case 'feature':       runFeature(graph, ...); return;
-    // case 'api-surface':   runApiSurface(graph, ...); return;
+    case 'api-surface':
+      runApiSurface(graph, positionals.slice(1), values);
+      return;
+
+    case 'feature':
+      runFeature(graph, positionals.slice(1), values);
+      return;
 
     case 'help':
     case '--help':

--- a/src/explore-cli.ts
+++ b/src/explore-cli.ts
@@ -1,0 +1,177 @@
+/**
+ * Top-level dispatcher for the `vyuh-dxkit explore` subcommand family.
+ * The CLI (`src/cli.ts`) routes `case 'explore'` here; this module
+ * dispatches the inner subcommand to the appropriate handler.
+ *
+ * Six subcommands per the Sprint 0 design (`tmp/2.7-explore-cli-design.md`):
+ *   - entry-points  — what does this repo do?
+ *   - hot-files     — what's central? (top files by call in-degree)
+ *   - file <path>   — drill into one file's neighborhood
+ *   - feature <kw>  — where is X implemented?
+ *   - communities   — natural-module summary
+ *   - api-surface   — exported symbols with no internal callers
+ *
+ * Architecture:
+ *   - This file owns argument parsing + subcommand routing only.
+ *   - All graph data comes from `loadGraph(cwd)` (canonical loader,
+ *     CLAUDE.md Rule 12).
+ *   - All graph traversal flows through `./explore/queries.ts`
+ *     (canonical query module, also Rule 12).
+ *   - Output formatting (JSON envelope + markdown tables) flows
+ *     through `./explore/format.ts`.
+ *
+ * Sprint 1 landed the loader + types + query primitives. Sprint 2
+ * adds the high-level queries + subcommand handlers below as each
+ * lands.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
+import {
+  GraphCorruptError,
+  GraphNotFoundError,
+  GraphSchemaVersionError,
+  loadGraph,
+} from './explore/load';
+import { runHotFiles } from './explore/cli/hot-files';
+import type { Graph } from './explore/types';
+
+export interface ExploreCliValues {
+  json?: boolean;
+  limit?: string;
+  refresh?: boolean;
+  substring?: boolean;
+  filter?: string;
+}
+
+/**
+ * Entry point called from `src/cli.ts:case 'explore'`. Receives the
+ * already-parsed `values` from the top-level `parseArgs` plus the
+ * positional arguments after `'explore'` (subcommand name + any
+ * subcommand-specific args).
+ */
+export async function runExplore(
+  cwd: string,
+  positionals: ReadonlyArray<string>,
+  values: ExploreCliValues,
+): Promise<void> {
+  const subcommand = positionals[0];
+  if (!subcommand) {
+    printExploreHelp();
+    return;
+  }
+
+  // Honor --refresh by regenerating graph.json before query. The
+  // simplest implementation: shell out to `vyuh-dxkit health` (which
+  // produces graph.json as a side effect via gatherLayer2Parallel).
+  if (values.refresh) {
+    await refreshGraph(cwd);
+  }
+
+  const graph = loadGraphOrExit(cwd);
+
+  switch (subcommand) {
+    case 'hot-files':
+      runHotFiles(graph, positionals.slice(1), values);
+      return;
+
+    // Other subcommands land here as Sprint 2 progresses:
+    // case 'entry-points':  runEntryPoints(graph, ...); return;
+    // case 'file':          runFile(graph, ...); return;
+    // case 'feature':       runFeature(graph, ...); return;
+    // case 'communities':   runCommunities(graph, ...); return;
+    // case 'api-surface':   runApiSurface(graph, ...); return;
+
+    case 'help':
+    case '--help':
+    case '-h':
+      printExploreHelp();
+      return;
+
+    default:
+      process.stderr.write(`Unknown explore subcommand: ${subcommand}\n\n`);
+      printExploreHelp();
+      process.exit(1);
+  }
+}
+
+/**
+ * Load the graph and exit with a typed error message on failure.
+ * Centralized so every subcommand gets the same diagnostic prose +
+ * exit codes per the Sprint 0 spec (2 = not found, 3 = schema
+ * mismatch, 4 = corrupt).
+ */
+function loadGraphOrExit(cwd: string): Graph {
+  try {
+    return loadGraph(cwd);
+  } catch (err) {
+    if (err instanceof GraphNotFoundError) {
+      process.stderr.write(`${err.message}\n`);
+      process.exit(2);
+    }
+    if (err instanceof GraphSchemaVersionError) {
+      process.stderr.write(`${err.message}\n`);
+      process.exit(3);
+    }
+    if (err instanceof GraphCorruptError) {
+      process.stderr.write(`${err.message}\n`);
+      process.exit(4);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Shell out to `vyuh-dxkit health` to regenerate graph.json. Uses
+ * the locally-installed dxkit (resolved via the same `bin` script
+ * the user invoked). Output streams through to the terminal so the
+ * user sees the health run's progress.
+ */
+async function refreshGraph(cwd: string): Promise<void> {
+  // Resolve the current dxkit entry point. The caller's CLI script
+  // lives at one of two places depending on install flavor; both
+  // resolve via the same node entry.
+  const dxkitBin = resolveDxkitBin();
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn('node', [dxkitBin, 'health', cwd], {
+      stdio: 'inherit',
+      cwd,
+    });
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`vyuh-dxkit health exited with code ${code}`));
+    });
+    child.on('error', reject);
+  });
+}
+
+function resolveDxkitBin(): string {
+  // dist/explore-cli.js → dist/index.js
+  const distEntry = path.resolve(__dirname, 'index.js');
+  if (existsSync(distEntry)) return distEntry;
+  // Fallback for local dev where __dirname might be elsewhere.
+  return 'node_modules/@vyuhlabs/dxkit/dist/index.js';
+}
+
+function printExploreHelp(): void {
+  process.stderr.write(`
+vyuh-dxkit explore <subcommand> [args] [flags]
+
+Subcommands:
+  hot-files                Files most depended on (top by call in-degree)
+  entry-points             Route handlers / controllers / forms (coming)
+  file <path>              Symbols + callers/callees for one file (coming)
+  feature <keyword>        Where is feature X implemented? (coming)
+  communities              Natural-module clusters (coming)
+  api-surface              Exported symbols with no internal callers (coming)
+
+Flags (all subcommands):
+  --json                   Emit structured JSON envelope
+  --limit N                Cap result count (per-subcommand defaults)
+  --refresh                Force-regenerate graph.json before query
+
+Reads from .dxkit/reports/graph.json. Run \`vyuh-dxkit health\` first
+to generate the artifact.
+`);
+}

--- a/src/explore-cli.ts
+++ b/src/explore-cli.ts
@@ -34,6 +34,9 @@ import {
   GraphSchemaVersionError,
   loadGraph,
 } from './explore/load';
+import { runCommunities } from './explore/cli/communities';
+import { runEntryPoints } from './explore/cli/entry-points';
+import { runFile } from './explore/cli/file';
 import { runHotFiles } from './explore/cli/hot-files';
 import type { Graph } from './explore/types';
 
@@ -76,11 +79,20 @@ export async function runExplore(
       runHotFiles(graph, positionals.slice(1), values);
       return;
 
+    case 'communities':
+      runCommunities(graph, positionals.slice(1), values);
+      return;
+
+    case 'file':
+      runFile(graph, positionals.slice(1), values, cwd);
+      return;
+
+    case 'entry-points':
+      runEntryPoints(graph, positionals.slice(1), values, cwd);
+      return;
+
     // Other subcommands land here as Sprint 2 progresses:
-    // case 'entry-points':  runEntryPoints(graph, ...); return;
-    // case 'file':          runFile(graph, ...); return;
     // case 'feature':       runFeature(graph, ...); return;
-    // case 'communities':   runCommunities(graph, ...); return;
     // case 'api-surface':   runApiSurface(graph, ...); return;
 
     case 'help':

--- a/src/explore/cli/api-surface.ts
+++ b/src/explore/cli/api-surface.ts
@@ -1,0 +1,91 @@
+/**
+ * `vyuh-dxkit explore api-surface` — exported symbols with no
+ * internal callers (likely public API or CLI entry points).
+ *
+ * Reads per-pack exportDetection reliability from the canonical
+ * registry helper. Packs declared 'unreliable' (today: ruby) are
+ * excluded with an explanatory note.
+ */
+
+import { allExportDetectionDeclarations } from '../../languages';
+import { apiSurfaceQuery } from '../queries';
+import {
+  envelope,
+  markdownFooter,
+  markdownHeader,
+  markdownTable,
+  printJson,
+  printMarkdown,
+} from '../format';
+import type { Graph } from '../types';
+import type { ExploreCliValues } from '../../explore-cli';
+
+const DEFAULT_LIMIT = 25;
+
+export function runApiSurface(
+  graph: Graph,
+  _positionals: ReadonlyArray<string>,
+  values: ExploreCliValues,
+): void {
+  const limit = parseLimit(values.limit, DEFAULT_LIMIT);
+
+  const declarations = allExportDetectionDeclarations();
+  const unreliablePacks = declarations
+    .filter((d) => d.reliability === 'unreliable')
+    .map((d) => ({ pack: d.pack, strategy: d.strategy }));
+  const packsExcluded = unreliablePacks.map((u) => u.pack);
+
+  const results = apiSurfaceQuery(graph, packsExcluded, limit);
+
+  if (values.json) {
+    printJson(
+      envelope('explore.api-surface', { limit, excluded: unreliablePacks }, graph, results),
+    );
+    return;
+  }
+
+  const sections: string[] = [];
+  sections.push(markdownHeader('API surface', 'exported symbols with no internal callers', graph));
+
+  if (unreliablePacks.length > 0) {
+    sections.push(
+      `*Excluded packs* (export detection unreliable): ` +
+        unreliablePacks.map((u) => `**${u.pack}** (${u.strategy})`).join('; '),
+    );
+  }
+
+  if (results.length === 0) {
+    sections.push(
+      'No exported symbols without internal callers found. Either the codebase has no public API surface graphify could detect, or every exported symbol has at least one internal caller.',
+    );
+    printMarkdown(...sections);
+    return;
+  }
+
+  sections.push(
+    markdownTable(
+      ['Path', 'Symbol', 'Kind', 'Pack'] as const,
+      results.map((r) => ({
+        Path: r.line ? `${r.sourceFile}:${r.line}` : r.sourceFile,
+        Symbol: r.symbol,
+        Kind: r.kind,
+        Pack: r.pack,
+      })),
+    ),
+  );
+
+  sections.push(
+    'These are likely public API or CLI entry points. Verify before deleting — a missing internal caller can mean "external consumer only" rather than "dead code." Future releases will add a dedicated dead-code analyzer with stronger heuristics.',
+  );
+
+  sections.push(markdownFooter('Drill into one: `vyuh-dxkit explore file <path>`.'));
+
+  printMarkdown(...sections);
+}
+
+function parseLimit(raw: string | undefined, defaultValue: number): number {
+  if (!raw) return defaultValue;
+  const n = parseInt(raw, 10);
+  if (isNaN(n) || n < 1) return defaultValue;
+  return Math.min(n, 1000);
+}

--- a/src/explore/cli/communities.ts
+++ b/src/explore/cli/communities.ts
@@ -1,0 +1,70 @@
+/**
+ * `vyuh-dxkit explore communities` — natural-module summary.
+ *
+ * Pure pipeline: parse args → call communitiesQuery → format output.
+ * Per CLAUDE.md Rule 12: graph traversal flows through queries.ts.
+ */
+
+import { communitiesQuery } from '../queries';
+import {
+  envelope,
+  markdownFooter,
+  markdownHeader,
+  markdownTable,
+  printJson,
+  printMarkdown,
+} from '../format';
+import type { Graph } from '../types';
+import type { ExploreCliValues } from '../../explore-cli';
+
+const DEFAULT_LIMIT = 8;
+
+export function runCommunities(
+  graph: Graph,
+  _positionals: ReadonlyArray<string>,
+  values: ExploreCliValues,
+): void {
+  const limit = parseLimit(values.limit, DEFAULT_LIMIT);
+  const results = communitiesQuery(graph, limit);
+
+  if (values.json) {
+    printJson(envelope('explore.communities', { limit }, graph, results));
+    return;
+  }
+
+  if (results.length === 0) {
+    printMarkdown(
+      markdownHeader('Communities', 'natural modules in this repo', graph),
+      'No communities found in the graph. Either the repo is too small for Louvain clustering to find structure, or the graph artifact is empty.',
+    );
+    return;
+  }
+
+  const rows = results.map((r) => ({
+    ID: r.id,
+    Dir: r.dominantSourceDir || '—',
+    Pack: r.dominantPack || '—',
+    Nodes: r.nodeCount,
+    Cohesion: r.cohesion.toFixed(2),
+    'Top hot files': r.topHotFiles.map((f) => basename(f)).join(', ') || '—',
+  }));
+  const headers = ['ID', 'Dir', 'Pack', 'Nodes', 'Cohesion', 'Top hot files'] as const;
+
+  printMarkdown(
+    markdownHeader('Communities', 'natural modules in this repo', graph),
+    markdownTable(headers, rows),
+    markdownFooter("Drill into a community's central file: `vyuh-dxkit explore file <path>`."),
+  );
+}
+
+function basename(p: string): string {
+  const i = p.lastIndexOf('/');
+  return i >= 0 ? p.slice(i + 1) : p;
+}
+
+function parseLimit(raw: string | undefined, defaultValue: number): number {
+  if (!raw) return defaultValue;
+  const n = parseInt(raw, 10);
+  if (isNaN(n) || n < 1) return defaultValue;
+  return Math.min(n, 1000);
+}

--- a/src/explore/cli/entry-points.ts
+++ b/src/explore/cli/entry-points.ts
@@ -1,0 +1,123 @@
+/**
+ * `vyuh-dxkit explore entry-points` — what does this repo do?
+ *
+ * Cross-references graph nodes with the active packs'
+ * architecturalShape (per CLAUDE.md Rule 8 — no hardcoded framework
+ * strings here). Detects the project's stack via `detect(cwd)` so
+ * only active-pack patterns contribute.
+ */
+
+import { detect } from '../../detect';
+import { allPrimaryComponentPaths, allRoutePaths, dominantVocabulary } from '../../languages';
+import { entryPointsQuery, type EntryPointResult } from '../queries';
+import {
+  envelope,
+  markdownFooter,
+  markdownHeader,
+  markdownTable,
+  printJson,
+  printMarkdown,
+} from '../format';
+import type { Graph } from '../types';
+import type { ExploreCliValues } from '../../explore-cli';
+
+const DEFAULT_LIMIT = 10;
+
+export function runEntryPoints(
+  graph: Graph,
+  _positionals: ReadonlyArray<string>,
+  values: ExploreCliValues,
+  cwd: string,
+): void {
+  const limit = parseLimit(values.limit, DEFAULT_LIMIT);
+
+  const stack = detect(cwd);
+  const primaryPaths = allPrimaryComponentPaths(stack.languages);
+  const routePaths = allRoutePaths(stack.languages);
+  const vocabulary = dominantVocabulary(stack.languages);
+
+  const results = entryPointsQuery(graph, primaryPaths, routePaths, limit);
+
+  if (values.json) {
+    printJson(
+      envelope(
+        'explore.entry-points',
+        { limit, primaryPaths, routePaths, packs: graph.meta.packs },
+        graph,
+        results,
+      ),
+    );
+    return;
+  }
+
+  if (primaryPaths.length === 0 && routePaths.length === 0) {
+    printMarkdown(
+      markdownHeader('Entry points', 'what does this repo do?', graph),
+      `No entry-point patterns declared for the active packs (${graph.meta.packs.join(', ') || 'none detected'}).\n\n` +
+        'Each language pack declares its own primary-component / route path conventions in `LanguageSupport.architecturalShape` (CLAUDE.md Rule 8). Packs without conventional entry-point paths (e.g. Rust) intentionally omit them.',
+    );
+    return;
+  }
+
+  if (results.length === 0) {
+    printMarkdown(
+      markdownHeader('Entry points', 'what does this repo do?', graph),
+      `No source files matched the active packs' entry-point patterns.\n\n` +
+        `Patterns tried: ${[...primaryPaths, ...routePaths].map((p) => `\`${p}\``).join(', ')}\n\n` +
+        `Either this repo has no conventional entry points, or the patterns don't match this codebase's structure.`,
+    );
+    return;
+  }
+
+  // Group by componentType + emit one table per group.
+  const grouped = new Map<string, EntryPointResult[]>();
+  for (const r of results) {
+    const key = r.componentType;
+    const list = grouped.get(key) ?? [];
+    list.push(r);
+    grouped.set(key, list);
+  }
+
+  const sections: string[] = [];
+  sections.push(markdownHeader('Entry points', 'what does this repo do?', graph));
+
+  // Vocabulary line so the reader knows the pack's framing.
+  const vocabLine: string[] = [];
+  if (vocabulary?.components) vocabLine.push(`components → **${vocabulary.components}**`);
+  if (vocabulary?.routes) vocabLine.push(`routes → **${vocabulary.routes}**`);
+  if (vocabulary?.models) vocabLine.push(`models → **${vocabulary.models}**`);
+  if (vocabLine.length > 0) {
+    sections.push(`*Pack vocabulary*: ${vocabLine.join(', ')}.`);
+  }
+
+  for (const [type, rows] of grouped) {
+    sections.push(`### ${capitalize(type)} (${rows.length})`);
+    sections.push(
+      markdownTable(
+        ['Path', 'Symbol', 'Calls out', 'Pack'] as const,
+        rows.map((r) => ({
+          Path: r.line ? `${r.sourceFile}:${r.line}` : r.sourceFile,
+          Symbol: r.symbol,
+          'Calls out': r.callsOut,
+          Pack: r.pack,
+        })),
+      ),
+    );
+  }
+
+  sections.push(markdownFooter('Drill into one: `vyuh-dxkit explore file <path>`.'));
+
+  printMarkdown(...sections);
+}
+
+function capitalize(s: string): string {
+  if (!s) return s;
+  return s[0].toUpperCase() + s.slice(1);
+}
+
+function parseLimit(raw: string | undefined, defaultValue: number): number {
+  if (!raw) return defaultValue;
+  const n = parseInt(raw, 10);
+  if (isNaN(n) || n < 1) return defaultValue;
+  return Math.min(n, 1000);
+}

--- a/src/explore/cli/feature.ts
+++ b/src/explore/cli/feature.ts
@@ -1,0 +1,128 @@
+/**
+ * `vyuh-dxkit explore feature <keyword>` — where is feature X
+ * implemented? The marquee query of the explore CLI.
+ *
+ * Three-stage resolution (per Sprint 0 spec):
+ *   1. Direct symbolIndex match
+ *   2. Substring expansion (opt-in via --substring; off by default)
+ *   3. Structural expansion (community + 1-hop callers/callees)
+ *
+ * On zero hits, prints "did you mean..." suggestions from
+ * edit-distance against symbolIndex keys.
+ */
+
+import { featureQuery, type FeatureCluster } from '../queries';
+import {
+  envelope,
+  markdownFooter,
+  markdownHeader,
+  markdownTable,
+  printJson,
+  printMarkdown,
+} from '../format';
+import type { Graph } from '../types';
+import type { ExploreCliValues } from '../../explore-cli';
+
+const DEFAULT_LIMIT = 50;
+
+export function runFeature(
+  graph: Graph,
+  positionals: ReadonlyArray<string>,
+  values: ExploreCliValues,
+): void {
+  const keyword = positionals[0];
+  if (!keyword) {
+    process.stderr.write(
+      'Usage: vyuh-dxkit explore feature <keyword> [--substring] [--limit 50]\n',
+    );
+    process.exit(1);
+  }
+
+  const limit = parseLimit(values.limit, DEFAULT_LIMIT);
+  const substring = !!values.substring;
+  const result = featureQuery(graph, keyword, { limit, substring });
+
+  if (values.json) {
+    printJson(envelope('explore.feature', { keyword, limit, substring }, graph, result));
+    return;
+  }
+
+  const sections: string[] = [];
+  sections.push(markdownHeader('Feature', `\`${keyword}\``, graph));
+
+  if (result.results.length === 0) {
+    if (result.suggestions.length > 0) {
+      const lines = result.suggestions
+        .map((s) => `  - \`${s.key}\` (${s.hits} hit${s.hits === 1 ? '' : 's'})`)
+        .join('\n');
+      sections.push(
+        `No exact symbol match for \`${keyword}\`. Related symbols (substring or typo-distance):\n\n${lines}\n\nRerun with \`--substring\` to expand structurally from these (the typical "where is X implemented?" workflow), or pick a specific symbol above.`,
+      );
+    } else {
+      sections.push(
+        `No symbols matched \`${keyword}\` (no close alternatives found either). Try a different keyword, rerun with \`--substring\` for broader matching, or check \`vyuh-dxkit explore communities\` to see the natural-module structure.`,
+      );
+    }
+    printMarkdown(...sections);
+    return;
+  }
+
+  // Summary line + central entry point (if any).
+  const totalSeeds = result.results.reduce((sum, c) => sum + c.seedHits, 0);
+  sections.push(
+    `**Seed matches**: ${totalSeeds} symbol${totalSeeds === 1 ? '' : 's'} across ${result.results.length} cluster${result.results.length === 1 ? '' : 's'}.`,
+  );
+
+  // Per-cluster sections.
+  for (const cluster of result.results) {
+    sections.push(buildClusterSection(cluster));
+  }
+
+  if (result.centralEntryPoint) {
+    const cep = result.centralEntryPoint;
+    const where = cep.line ? `${cep.sourceFile}:${cep.line}` : cep.sourceFile;
+    sections.push(
+      `\nThe most-called seed symbol is **\`${cep.symbol}\`** at \`${where}\` — called from ${cep.calledFrom} place${cep.calledFrom === 1 ? '' : 's'}. A natural starting read.`,
+    );
+  }
+
+  sections.push(markdownFooter('Drill into one: `vyuh-dxkit explore file <path>`.'));
+
+  printMarkdown(...sections);
+}
+
+function buildClusterSection(cluster: FeatureCluster): string {
+  const lines: string[] = [];
+  const id = cluster.clusterId + 1;
+  const role = cluster.role;
+  const seedNote = cluster.seedHits === 0 ? ' (expansion only — no direct seed)' : '';
+  lines.push(`### Cluster ${id} — ${role}${seedNote}`);
+  if (cluster.communityId !== undefined) {
+    lines.push(
+      `*Community*: ${cluster.communityId}${cluster.dominantSourceDir ? ` (${cluster.dominantSourceDir})` : ''}`,
+    );
+  }
+  if (cluster.keySymbols.length > 0) {
+    lines.push(`*Key symbols*: ${cluster.keySymbols.map((s) => `\`${s}\``).join(', ')}`);
+  }
+  lines.push('');
+  lines.push(
+    markdownTable(
+      ['File'] as const,
+      cluster.files.slice(0, 12).map((f) => ({ File: f })),
+    ),
+  );
+  if (cluster.files.length > 12) {
+    lines.push(
+      `\n*+ ${cluster.files.length - 12} more file${cluster.files.length - 12 === 1 ? '' : 's'}*`,
+    );
+  }
+  return lines.join('\n');
+}
+
+function parseLimit(raw: string | undefined, defaultValue: number): number {
+  if (!raw) return defaultValue;
+  const n = parseInt(raw, 10);
+  if (isNaN(n) || n < 1) return defaultValue;
+  return Math.min(n, 1000);
+}

--- a/src/explore/cli/file.ts
+++ b/src/explore/cli/file.ts
@@ -1,0 +1,145 @@
+/**
+ * `vyuh-dxkit explore file <path>` — drill into a single file's
+ * neighborhood. Per CLAUDE.md Rule 12: graph traversal flows through
+ * queries.ts.
+ *
+ * If the user passes an absolute path, convert to project-relative
+ * (the graph artifact uses project-relative paths throughout).
+ */
+
+import * as path from 'node:path';
+import { fileSummaryQuery } from '../queries';
+import {
+  envelope,
+  markdownFooter,
+  markdownHeader,
+  markdownTable,
+  printJson,
+  printMarkdown,
+} from '../format';
+import type { Graph } from '../types';
+import type { ExploreCliValues } from '../../explore-cli';
+
+export function runFile(
+  graph: Graph,
+  positionals: ReadonlyArray<string>,
+  values: ExploreCliValues,
+  cwd: string,
+): void {
+  const rawPath = positionals[0];
+  if (!rawPath) {
+    process.stderr.write(
+      'Usage: vyuh-dxkit explore file <path>\nProvide a path (relative or absolute) to a source file in the repo.\n',
+    );
+    process.exit(1);
+  }
+
+  // Convert absolute to project-relative if needed. Graphify writes
+  // project-relative paths to graph.json so the lookup key must
+  // match that shape.
+  const resolved = path.isAbsolute(rawPath)
+    ? path.relative(cwd, rawPath).replace(/\\/g, '/')
+    : rawPath.replace(/\\/g, '/');
+
+  const result = fileSummaryQuery(graph, resolved);
+
+  if (values.json) {
+    printJson(envelope('explore.file', { path: resolved }, graph, result));
+    return;
+  }
+
+  if (!result.found) {
+    printMarkdown(
+      markdownHeader('File', resolved, graph),
+      `File \`${resolved}\` is not in the graph. Common reasons:\n` +
+        `- File doesn't exist (typo in path?)\n` +
+        `- Excluded by .dxkit-ignore / minified-detection / unsupported extension\n` +
+        `- Pack for this file's language isn't active in the project`,
+    );
+    return;
+  }
+
+  const symbolRows = result.symbols.map((s) => ({
+    Kind: s.kind,
+    Symbol: s.label,
+    Line: s.line ?? '',
+    Exported: s.exported === undefined ? '?' : s.exported ? '✓' : '·',
+    'Calls in': s.callsIn,
+    'Calls out': s.callsOut,
+  }));
+  const symbolHeaders = ['Kind', 'Symbol', 'Line', 'Exported', 'Calls in', 'Calls out'] as const;
+
+  const callerRows = result.callerFiles
+    .slice(0, 20)
+    .map((c) => ({ File: c.sourceFile, Calls: c.count }));
+  const calleeRows = result.calleeFiles
+    .slice(0, 20)
+    .map((c) => ({ File: c.sourceFile, Calls: c.count }));
+
+  const sections: string[] = [];
+  sections.push(markdownHeader('File', resolved, graph));
+
+  // Community + summary line
+  const summary: string[] = [];
+  if (result.communityId !== undefined) {
+    const dir = result.communityLabel || '—';
+    const pack = result.communityPack || '—';
+    summary.push(`**Community**: ${result.communityId} (${dir}, ${pack})`);
+  }
+  const kindCounts: Record<string, number> = {};
+  for (const s of result.symbols) kindCounts[s.kind] = (kindCounts[s.kind] ?? 0) + 1;
+  const symBreakdown = Object.entries(kindCounts)
+    .map(([k, c]) => `${c} ${k}${c === 1 ? '' : 's'}`)
+    .join(', ');
+  if (symBreakdown) summary.push(`**Symbols**: ${symBreakdown}`);
+  const exportedSymbols = result.symbols.filter((s) => s.exported === true);
+  if (exportedSymbols.length > 0) {
+    summary.push(
+      `**Exported**: ${exportedSymbols
+        .map((s) => s.label)
+        .slice(0, 8)
+        .join(', ')}${exportedSymbols.length > 8 ? ` (+${exportedSymbols.length - 8} more)` : ''}`,
+    );
+  }
+  if (summary.length > 0) sections.push(summary.join('\n'));
+
+  if (symbolRows.length > 0) {
+    sections.push('### Symbols defined here');
+    sections.push(markdownTable(symbolHeaders, symbolRows));
+  }
+
+  if (callerRows.length > 0) {
+    sections.push(
+      `### Callers (${result.callerFiles.length} file${result.callerFiles.length === 1 ? '' : 's'})`,
+    );
+    sections.push(markdownTable(['File', 'Calls'] as const, callerRows));
+  } else {
+    sections.push(
+      '### Callers\n\nNo other files call into this file. Either it is a leaf module (entry point, top-level CLI handler) or its consumers are outside the graphify-extracted set.',
+    );
+  }
+
+  if (calleeRows.length > 0) {
+    sections.push(
+      `### Callees (${result.calleeFiles.length} file${result.calleeFiles.length === 1 ? '' : 's'})`,
+    );
+    sections.push(markdownTable(['File', 'Calls'] as const, calleeRows));
+  }
+
+  if (result.importsOut.length > 0) {
+    sections.push(
+      `### Imports out (${result.importsOut.length} file${result.importsOut.length === 1 ? '' : 's'})`,
+    );
+    sections.push(result.importsOut.map((i) => `- ${i.sourceFile}`).join('\n'));
+  }
+  if (result.importsIn.length > 0) {
+    sections.push(
+      `### Imports in (${result.importsIn.length} file${result.importsIn.length === 1 ? '' : 's'})`,
+    );
+    sections.push(result.importsIn.map((i) => `- ${i.sourceFile}`).join('\n'));
+  }
+
+  sections.push(markdownFooter('Drill into a caller: `vyuh-dxkit explore file <path>`.'));
+
+  printMarkdown(...sections);
+}

--- a/src/explore/cli/hot-files.ts
+++ b/src/explore/cli/hot-files.ts
@@ -1,0 +1,86 @@
+/**
+ * `vyuh-dxkit explore hot-files` — files most depended on.
+ *
+ * Pure pipeline: parse args → call hotFilesQuery → format output.
+ * No graph traversal in here (CLAUDE.md Rule 12 enforces);
+ * everything goes through src/explore/queries.ts.
+ */
+
+import { hotFilesQuery, type HotFileResult } from '../queries';
+import {
+  envelope,
+  markdownFooter,
+  markdownHeader,
+  markdownTable,
+  printJson,
+  printMarkdown,
+} from '../format';
+import type { Graph } from '../types';
+import type { ExploreCliValues } from '../../explore-cli';
+
+const DEFAULT_LIMIT = 20;
+
+export function runHotFiles(
+  graph: Graph,
+  _positionals: ReadonlyArray<string>,
+  values: ExploreCliValues,
+): void {
+  const limit = parseLimit(values.limit, DEFAULT_LIMIT);
+  const results = hotFilesQuery(graph, limit);
+
+  if (values.json) {
+    printJson(envelope('explore.hot-files', { limit }, graph, results));
+    return;
+  }
+
+  // Markdown: header, table, footer hint.
+  const rows = results.map((r) => ({
+    Path: r.sourceFile,
+    'Calls in': r.callsIn,
+    'Imports in': r.importsIn,
+    'Calls out': r.callsOut,
+    Community: r.communityLabel
+      ? `${r.communityId} (${r.communityLabel})`
+      : r.communityId !== undefined
+        ? String(r.communityId)
+        : '',
+  }));
+  const headers = ['Path', 'Calls in', 'Imports in', 'Calls out', 'Community'] as const;
+
+  if (results.length === 0) {
+    printMarkdown(
+      markdownHeader('Hot files', "what's central?", graph),
+      'No files found in the graph. Either the repo has no inbound call edges, or the graph artifact is empty.',
+    );
+    return;
+  }
+
+  printMarkdown(
+    markdownHeader('Hot files', "what's central?", graph),
+    markdownTable(headers, rows),
+    explainResults(results),
+    markdownFooter('Drill into one: `vyuh-dxkit explore file <path>`.'),
+  );
+}
+
+/**
+ * One-line interpretation hint below the table. A file with high
+ * "calls in" + low "calls out" is foundational infrastructure;
+ * inverting that signals a coordinator / orchestrator.
+ */
+function explainResults(results: HotFileResult[]): string {
+  if (results.length === 0) return '';
+  const top = results[0];
+  const ratio = top.callsOut > 0 ? top.callsIn / top.callsOut : top.callsIn;
+  if (ratio >= 3) {
+    return `A file with high "calls in" + low "calls out" is foundational infrastructure. \`${top.sourceFile}\` looks like one.`;
+  }
+  return 'A file with high "calls in" + low "calls out" is foundational infrastructure.';
+}
+
+function parseLimit(raw: string | undefined, defaultValue: number): number {
+  if (!raw) return defaultValue;
+  const n = parseInt(raw, 10);
+  if (isNaN(n) || n < 1) return defaultValue;
+  return Math.min(n, 1000); // sanity cap
+}

--- a/src/explore/format.ts
+++ b/src/explore/format.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared output helpers for the explore CLI subcommands. Pure
+ * formatters — JSON envelope shape + markdown table builders — so
+ * each subcommand handler stays a thin pipeline (parse args → call
+ * queries → format output).
+ *
+ * Per the Sprint 0 design (`tmp/2.7-explore-cli-design.md`):
+ *   - JSON mode emits a stable envelope: command / args / meta / results
+ *   - Markdown mode emits header → meta line → result block → footer hint
+ *   - Adding fields later is additive; never mutate existing field
+ *     names within v1
+ */
+
+import type { Graph } from './types';
+
+/**
+ * Stable JSON envelope every `--json` mode subcommand emits. Skills
+ * and scripts consume `results` directly; `meta` carries the artifact
+ * provenance so consumers can detect a stale graph + decide whether
+ * to suggest `--refresh`.
+ */
+export interface ExploreEnvelope<T> {
+  command: string;
+  args: Record<string, unknown>;
+  meta: {
+    schemaVersion: number;
+    graphGeneratedAt: string;
+    truncated: boolean;
+  };
+  results: T;
+}
+
+/**
+ * Build the JSON envelope from a query result + the graph metadata.
+ * Pure function — no I/O, no side effects. Subcommands call this in
+ * `--json` mode and print the result via `JSON.stringify`.
+ */
+export function envelope<T>(
+  command: string,
+  args: Record<string, unknown>,
+  graph: Graph,
+  results: T,
+): ExploreEnvelope<T> {
+  return {
+    command,
+    args,
+    meta: {
+      schemaVersion: graph.schemaVersion,
+      graphGeneratedAt: graph.meta.generatedAt,
+      truncated: graph.meta.truncated,
+    },
+    results,
+  };
+}
+
+/**
+ * Build the standard markdown header that every subcommand emits.
+ * Includes the meta line (file count + node count + generation
+ * timestamp) so the reader knows what artifact they're looking at,
+ * plus a truncation note when applicable.
+ */
+export function markdownHeader(title: string, framing: string, graph: Graph): string {
+  const m = graph.meta;
+  const dateOnly = m.generatedAt.slice(0, 10);
+  const lines = [
+    `## ${title} — ${framing}`,
+    '',
+    `From .dxkit/reports/graph.json (generated ${dateOnly}, ${m.sourceFilesInGraph} source files, ${graph.nodes.length} nodes).`,
+  ];
+  if (m.truncated) {
+    lines.push('');
+    lines.push(`> ⚠ Graph is truncated: ${m.truncatedReason}. Results may be incomplete.`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Build a markdown table from a row set. `headers` defines the
+ * column order; `rows` is an array of records keyed by the same
+ * header strings. Missing values render as empty strings.
+ */
+export function markdownTable<R extends Record<string, string | number>>(
+  headers: ReadonlyArray<keyof R & string>,
+  rows: ReadonlyArray<R>,
+): string {
+  if (rows.length === 0) return '';
+  const lines: string[] = [];
+  lines.push('| ' + headers.join(' | ') + ' |');
+  lines.push('|' + headers.map(() => '---').join('|') + '|');
+  for (const row of rows) {
+    const cells = headers.map((h) => {
+      const v = row[h];
+      return v === undefined || v === null ? '' : String(v);
+    });
+    lines.push('| ' + cells.join(' | ') + ' |');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Build the standard footer hint pointing at the natural next
+ * subcommand. Optional; subcommands omit when no clear next step.
+ */
+export function markdownFooter(hint: string): string {
+  return `\n${hint}`;
+}
+
+/**
+ * Print a JSON envelope to stdout. Output is single-line (no
+ * pretty-print) so it stays pipe-friendly for `jq` consumers.
+ */
+export function printJson<T>(env: ExploreEnvelope<T>): void {
+  process.stdout.write(JSON.stringify(env) + '\n');
+}
+
+/**
+ * Print markdown sections to stdout, joined by a blank line. Each
+ * section is a multi-line string built by the helpers above.
+ */
+export function printMarkdown(...sections: string[]): void {
+  process.stdout.write(sections.filter((s) => s && s.length > 0).join('\n\n') + '\n');
+}

--- a/src/explore/queries.ts
+++ b/src/explore/queries.ts
@@ -47,11 +47,103 @@ export function nodesInFile(graph: Graph, sourceFile: string): GraphNode[] {
   return [...(graph.nodesByFile.get(sourceFile) ?? [])];
 }
 
-// ─── High-level queries (Sprint 2 fills bodies) ──────────────────────────────
+// ─── High-level queries ──────────────────────────────────────────────────────
 
-// Sprint 2 implements: entryPointsQuery, hotFilesQuery, fileSummaryQuery,
-// featureQuery, communitiesQuery, apiSurfaceQuery.
-//
-// The skeleton stays minimal — Sprint 1 only needs the file to exist so
-// Rule 12 has a canonical target to lock onto. Real implementations
-// arrive with the CLI subcommands.
+/**
+ * One row of `vyuh-dxkit explore hot-files` output. A "hot" file is
+ * one many other files depend on (high total in-degree across all the
+ * symbols it declares + inbound imports to the file's module node).
+ *
+ * - `callsIn`: count of `calls` edges terminating at any symbol in
+ *   the file (summed across the file's function / class / method
+ *   nodes)
+ * - `importsIn`: count of `imports_from` edges terminating at the
+ *   file's module node
+ * - `callsOut`: count of `calls` edges originating from any symbol
+ *   in the file
+ * - `communityId` / `communityLabel`: the community the file's
+ *   module node belongs to, when one exists; label is the
+ *   community's dominantSourceDir for a quick visual anchor
+ */
+export interface HotFileResult {
+  sourceFile: string;
+  callsIn: number;
+  importsIn: number;
+  callsOut: number;
+  communityId?: number;
+  communityLabel?: string;
+}
+
+/**
+ * Top-N files by total in-degree (callers + importers). The
+ * "centrality" proxy — files many other files depend on. Useful as
+ * a "what's the foundational layer of this repo?" answer.
+ *
+ * Files are derived from the union of `sourceFile` across all nodes;
+ * the per-file aggregation traverses each node's inbound/outbound
+ * edges. Limit defaults to 20 per the Sprint 0 spec.
+ */
+export function hotFilesQuery(graph: Graph, limit = 20): HotFileResult[] {
+  const perFile = new Map<string, { callsIn: number; callsOut: number; nodes: GraphNode[] }>();
+
+  for (const node of graph.nodes) {
+    if (!node.sourceFile) continue;
+    let agg = perFile.get(node.sourceFile);
+    if (!agg) {
+      agg = { callsIn: 0, callsOut: 0, nodes: [] };
+      perFile.set(node.sourceFile, agg);
+    }
+    agg.nodes.push(node);
+    for (const e of graph.edgesToNode.get(node.id) ?? []) {
+      if (e.relation === 'calls') agg.callsIn++;
+    }
+    for (const e of graph.edgesFromNode.get(node.id) ?? []) {
+      if (e.relation === 'calls') agg.callsOut++;
+    }
+  }
+
+  // Imports-in: count edges into the FILE's module node. Module
+  // nodes have `kind === 'module'` and their `sourceFile` IS the
+  // file path. Aggregate to the file by matching on that.
+  const importsInByFile = new Map<string, number>();
+  for (const node of graph.nodes) {
+    if (node.kind !== 'module' || !node.sourceFile) continue;
+    let count = 0;
+    for (const e of graph.edgesToNode.get(node.id) ?? []) {
+      if (e.relation === 'imports_from') count++;
+    }
+    importsInByFile.set(node.sourceFile, (importsInByFile.get(node.sourceFile) ?? 0) + count);
+  }
+
+  const results: HotFileResult[] = [];
+  for (const [sourceFile, agg] of perFile) {
+    const importsIn = importsInByFile.get(sourceFile) ?? 0;
+    // Pick a community via any of the file's nodes — module node
+    // first if present, else any symbol's community.
+    const moduleNode = agg.nodes.find((n) => n.kind === 'module');
+    const sampleNode = moduleNode ?? agg.nodes[0];
+    const community = sampleNode ? graph.communityByNode.get(sampleNode.id) : undefined;
+    results.push({
+      sourceFile,
+      callsIn: agg.callsIn,
+      importsIn,
+      callsOut: agg.callsOut,
+      communityId: community?.id,
+      communityLabel: community?.dominantSourceDir || undefined,
+    });
+  }
+
+  // Rank by total in-degree (calls + imports). Ties broken by
+  // alphabetical source file path for stable output.
+  results.sort((a, b) => {
+    const ai = a.callsIn + a.importsIn;
+    const bi = b.callsIn + b.importsIn;
+    if (bi !== ai) return bi - ai;
+    return a.sourceFile.localeCompare(b.sourceFile);
+  });
+
+  return results.slice(0, limit);
+}
+
+// Sprint 2 will add: entryPointsQuery, fileSummaryQuery, featureQuery,
+// communitiesQuery, apiSurfaceQuery as each subcommand lands.

--- a/src/explore/queries.ts
+++ b/src/explore/queries.ts
@@ -15,7 +15,7 @@
  */
 
 import type { DetectedStack } from '../types';
-import type { Graph, GraphNode } from './types';
+import type { Community, Graph, GraphNode } from './types';
 
 // ─── Low-level primitives ────────────────────────────────────────────────────
 
@@ -497,5 +497,335 @@ function packFromExt(sourceFile: string): string {
 // pulling DetectedStack from src/types.ts directly.
 export type LanguageFlags = DetectedStack['languages'];
 
-// Sprint 2 will add: featureQuery, apiSurfaceQuery as each
-// subcommand lands.
+/**
+ * One row of `vyuh-dxkit explore api-surface` output. An "API surface"
+ * symbol is one that the language pack identifies as exported AND has
+ * zero internal callers (no other file in the graph calls into it).
+ *
+ * Typically this set falls into three buckets:
+ *   - Genuine public API (library entry points, named exports)
+ *   - CLI entry points (legitimately not internally imported)
+ *   - Dead exports (false positives surfaced honestly)
+ *
+ * The consumer should verify before treating any as dead code.
+ */
+export interface ApiSurfaceResult {
+  sourceFile: string;
+  line?: number;
+  symbol: string;
+  kind: 'function' | 'class' | 'method' | 'module';
+  pack: string;
+}
+
+/**
+ * Find exported symbols with zero internal callers. `packsExcluded`
+ * lists pack ids whose `exportDetection.reliability === 'unreliable'`
+ * — those packs' nodes are skipped because we can't trust their
+ * `exported` flag (today: ruby). The consumer surfaces the exclusion
+ * as a note in its output.
+ */
+export function apiSurfaceQuery(
+  graph: Graph,
+  packsExcluded: ReadonlyArray<string>,
+  limit = 25,
+): ApiSurfaceResult[] {
+  const excluded = new Set(packsExcluded);
+  const results: ApiSurfaceResult[] = [];
+
+  for (const node of graph.nodes) {
+    if (node.kind === 'module') continue;
+    if (node.exported !== true) continue; // absent or false → skip
+    const pack = packFromExt(node.sourceFile);
+    if (excluded.has(pack)) continue;
+
+    // Zero internal callers — check inbound calls edges. Note: the
+    // calls in-degree includes potential graphify same-name conflicts
+    // (run() at one site can attract calls meant for run() at another),
+    // so this is a "best effort" — but consumers know that's the limit.
+    let hasCaller = false;
+    for (const e of graph.edgesToNode.get(node.id) ?? []) {
+      if (e.relation === 'calls') {
+        hasCaller = true;
+        break;
+      }
+    }
+    if (hasCaller) continue;
+
+    results.push({
+      sourceFile: node.sourceFile,
+      line: node.line,
+      symbol: node.label,
+      kind: node.kind,
+      pack,
+    });
+  }
+
+  // Sort by sourceFile asc (groups by file naturally) then line asc.
+  results.sort((a, b) => a.sourceFile.localeCompare(b.sourceFile) || (a.line ?? 0) - (b.line ?? 0));
+
+  return results.slice(0, limit);
+}
+
+/**
+ * Options for `featureQuery`. `substring` enables the noisier
+ * keyword-substring expansion (off by default per Sprint 0 spec —
+ * false-positive prone for short keywords).
+ */
+export interface FeatureQueryOpts {
+  substring?: boolean;
+  limit?: number;
+}
+
+/**
+ * A clustering of symbols that look like they implement one feature.
+ * The community membership is the structural backbone — symbols in
+ * the same community are tightly coupled by definition. The role
+ * label comes from the community's dominantPack/dominantSourceDir
+ * + per-pack vocabulary when available.
+ */
+export interface FeatureCluster {
+  clusterId: number;
+  communityId?: number;
+  role: string;
+  dominantSourceDir: string;
+  files: string[];
+  keySymbols: string[];
+  seedHits: number;
+}
+
+/**
+ * Full result of a feature query. `results` is non-empty when at
+ * least one symbol matched the keyword; `suggestions` is populated
+ * only when `results` is empty (edit-distance ≤2 against the
+ * symbolIndex keys, top-3). `centralEntryPoint` names the highest
+ * call-in-degree node across all clusters when results were found
+ * — the natural "if you only look at one file, look here" anchor.
+ */
+export interface FeatureResult {
+  results: FeatureCluster[];
+  suggestions: Array<{ key: string; hits: number }>;
+  centralEntryPoint?: {
+    sourceFile: string;
+    line?: number;
+    symbol: string;
+    calledFrom: number;
+  };
+}
+
+/**
+ * The marquee query — "where is feature X implemented?" Three-stage
+ * resolution:
+ *
+ *   1. Direct symbolIndex lookup (case-insensitive, exact match on
+ *      the stripped name)
+ *   2. Substring expansion (opt-in via opts.substring) — scans every
+ *      node's label for substring match
+ *   3. Structural expansion — for each seed, gather community
+ *      membership + immediate callers + callees, group by community
+ *
+ * On zero hits, computes edit-distance suggestions against the
+ * symbolIndex keys so the caller can prompt the user with "did you
+ * mean..."
+ */
+export function featureQuery(
+  graph: Graph,
+  keyword: string,
+  opts: FeatureQueryOpts = {},
+): FeatureResult {
+  const limit = opts.limit ?? 50;
+  const kw = keyword.toLowerCase().trim();
+  if (!kw) {
+    return { results: [], suggestions: [] };
+  }
+
+  // Stage 1: direct symbolIndex match.
+  const seedIds = new Set<string>(graph.symbolIndex[kw] ?? []);
+
+  // Stage 2: optional substring expansion. Iterate symbolIndex keys
+  // (smaller than nodes) for the substring scan, then collect their
+  // node ids.
+  if (opts.substring) {
+    for (const [key, ids] of Object.entries(graph.symbolIndex)) {
+      if (key.includes(kw)) {
+        for (const id of ids) seedIds.add(id);
+      }
+    }
+  }
+
+  if (seedIds.size === 0) {
+    // "Did you mean" — two flavors, merged:
+    //   1. Substring matches (symbols whose name CONTAINS the keyword)
+    //      — the common case, since users rarely guess exact long
+    //      symbol names like "gatherGraphifyResult" when they ask
+    //      "where is graphify?"
+    //   2. Edit-distance suggestions (Levenshtein ≤2) — catches
+    //      typos like "graphfiy" → "graphify"-prefixed symbols
+    // Substring is only tried for keywords of length >= 3 (anything
+    // shorter generates too many false positives).
+    const suggestions: Array<{ key: string; hits: number }> = [];
+    const seen = new Set<string>();
+    if (kw.length >= 3) {
+      for (const key of Object.keys(graph.symbolIndex)) {
+        if (key.includes(kw)) {
+          suggestions.push({ key, hits: graph.symbolIndex[key].length });
+          seen.add(key);
+        }
+      }
+    }
+    for (const key of Object.keys(graph.symbolIndex)) {
+      if (seen.has(key)) continue;
+      const d = levenshtein(kw, key);
+      if (d <= 2) {
+        suggestions.push({ key, hits: graph.symbolIndex[key].length });
+      }
+    }
+    suggestions.sort((a, b) => b.hits - a.hits || a.key.localeCompare(b.key));
+    return { results: [], suggestions: suggestions.slice(0, 5) };
+  }
+
+  // Stage 3: structural expansion. For each seed, gather its
+  // community + direct callers/callees. Group expanded set by
+  // community id.
+  const expandedByComm = new Map<number, Set<string>>();
+  const unclusteredExpansion = new Set<string>();
+
+  for (const seedId of seedIds) {
+    const community = graph.communityByNode.get(seedId);
+    const bucket = community
+      ? (expandedByComm.get(community.id) ?? new Set<string>())
+      : unclusteredExpansion;
+    bucket.add(seedId);
+
+    // Direct callers (1 hop)
+    for (const e of graph.edgesToNode.get(seedId) ?? []) {
+      if (e.relation === 'calls') bucket.add(e.from);
+    }
+    // Direct callees (1 hop)
+    for (const e of graph.edgesFromNode.get(seedId) ?? []) {
+      if (e.relation === 'calls') bucket.add(e.to);
+    }
+
+    if (community) expandedByComm.set(community.id, bucket);
+  }
+
+  // Build cluster objects, ranked by seed count then size.
+  const clusters: FeatureCluster[] = [];
+  let clusterIdx = 0;
+
+  const buildCluster = (
+    nodeIds: Iterable<string>,
+    community: Community | undefined,
+  ): FeatureCluster => {
+    const files = new Set<string>();
+    const keySymbols = new Set<string>();
+    let seedHits = 0;
+    for (const nid of nodeIds) {
+      const node = graph.nodeById.get(nid);
+      if (!node) continue;
+      if (node.sourceFile) files.add(node.sourceFile);
+      if (seedIds.has(nid)) {
+        seedHits++;
+        // Promote seed nodes to keySymbols list.
+        const stripped = stripParens(node.label);
+        if (stripped) keySymbols.add(stripped);
+      }
+    }
+    // Top-8 key symbols by alpha for stable output.
+    const keySymbolsList = [...keySymbols].sort().slice(0, 8);
+    const filesList = [...files].sort();
+    const role = roleLabel(community);
+    return {
+      clusterId: clusterIdx++,
+      communityId: community?.id,
+      role,
+      dominantSourceDir: community?.dominantSourceDir ?? '',
+      files: filesList,
+      keySymbols: keySymbolsList,
+      seedHits,
+    };
+  };
+
+  for (const [commId, ids] of expandedByComm) {
+    const community = graph.communityById.get(commId);
+    clusters.push(buildCluster(ids, community));
+  }
+  if (unclusteredExpansion.size > 0) {
+    clusters.push(buildCluster(unclusteredExpansion, undefined));
+  }
+
+  // Rank clusters by seedHits desc, then size desc, then community id asc.
+  clusters.sort(
+    (a, b) =>
+      b.seedHits - a.seedHits ||
+      b.files.length - a.files.length ||
+      (a.communityId ?? 9999) - (b.communityId ?? 9999),
+  );
+
+  const limitedClusters = clusters.slice(0, limit);
+
+  // Central entry point: across all seed ids, the one with the
+  // highest call in-degree globally.
+  let centralId: string | undefined;
+  let centralCount = 0;
+  for (const seedId of seedIds) {
+    let inDeg = 0;
+    for (const e of graph.edgesToNode.get(seedId) ?? []) {
+      if (e.relation === 'calls') inDeg++;
+    }
+    if (inDeg > centralCount) {
+      centralCount = inDeg;
+      centralId = seedId;
+    }
+  }
+  let centralEntryPoint: FeatureResult['centralEntryPoint'];
+  if (centralId && centralCount > 0) {
+    const n = graph.nodeById.get(centralId);
+    if (n) {
+      centralEntryPoint = {
+        sourceFile: n.sourceFile,
+        line: n.line,
+        symbol: n.label,
+        calledFrom: centralCount,
+      };
+    }
+  }
+
+  return { results: limitedClusters, suggestions: [], centralEntryPoint };
+}
+
+function roleLabel(community: Community | undefined): string {
+  if (!community) return 'unclustered';
+  if (community.dominantSourceDir) return community.dominantSourceDir;
+  return `community-${community.id}`;
+}
+
+function stripParens(label: string): string {
+  if (!label) return '';
+  let s = label.replace(/\(\)$/, '');
+  if (s.includes('.')) s = s.split('.').pop() ?? s;
+  return s;
+}
+
+/**
+ * Iterative Levenshtein with O(min(a, b)) memory. Fast enough for
+ * the suggestions scan (a few hundred symbolIndex keys × ≤20 chars).
+ */
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  const long = a.length >= b.length ? a : b;
+  const short = a.length >= b.length ? b : a;
+  let prev = new Array<number>(short.length + 1);
+  let curr = new Array<number>(short.length + 1);
+  for (let i = 0; i <= short.length; i++) prev[i] = i;
+  for (let i = 1; i <= long.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= short.length; j++) {
+      const cost = long[i - 1] === short[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[short.length];
+}

--- a/src/explore/queries.ts
+++ b/src/explore/queries.ts
@@ -14,6 +14,7 @@
  * level.
  */
 
+import type { DetectedStack } from '../types';
 import type { Graph, GraphNode } from './types';
 
 // ─── Low-level primitives ────────────────────────────────────────────────────
@@ -145,5 +146,356 @@ export function hotFilesQuery(graph: Graph, limit = 20): HotFileResult[] {
   return results.slice(0, limit);
 }
 
-// Sprint 2 will add: entryPointsQuery, fileSummaryQuery, featureQuery,
-// communitiesQuery, apiSurfaceQuery as each subcommand lands.
+/**
+ * One row of `vyuh-dxkit explore communities` output. A community is
+ * a Louvain-clustered grouping of nodes; the dominant source dir +
+ * pack give the reader a visual anchor ("this is the auth stuff" /
+ * "this is the bom layer").
+ */
+export interface CommunityResult {
+  id: number;
+  nodeCount: number;
+  dominantSourceDir: string;
+  dominantPack: string;
+  cohesion: number;
+  topHotFiles: string[];
+}
+
+/**
+ * Top-N communities by node count, with each community's top-3 hot
+ * files (by in-degree within the community). Gives a "what are the
+ * natural modules in this repo?" answer that complements `hot-files`
+ * (which is global).
+ */
+export function communitiesQuery(graph: Graph, limit = 8): CommunityResult[] {
+  const callsInByNode = computeCallsInByNode(graph);
+  const sortedCommunities = [...graph.communities].sort(
+    (a, b) => b.nodeIds.length - a.nodeIds.length,
+  );
+
+  return sortedCommunities.slice(0, limit).map((c) => {
+    // Per-file in-degree within this community only.
+    const inDegByFile = new Map<string, number>();
+    for (const nid of c.nodeIds) {
+      const node = graph.nodeById.get(nid);
+      if (!node?.sourceFile) continue;
+      const d = callsInByNode.get(nid) ?? 0;
+      inDegByFile.set(node.sourceFile, (inDegByFile.get(node.sourceFile) ?? 0) + d);
+    }
+    const topHotFiles = [...inDegByFile.entries()]
+      .filter(([, d]) => d > 0)
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, 3)
+      .map(([f]) => f);
+
+    return {
+      id: c.id,
+      nodeCount: c.nodeIds.length,
+      dominantSourceDir: c.dominantSourceDir,
+      dominantPack: c.dominantPack,
+      cohesion: c.cohesion,
+      topHotFiles,
+    };
+  });
+}
+
+/**
+ * Internal helper: precompute per-node call in-degree. Shared between
+ * `hotFilesQuery` (file-level aggregation) and `communitiesQuery`
+ * (community-bounded ranking). Per CLAUDE.md Rule 2 — one source of
+ * truth for the calls-in-degree counter.
+ */
+function computeCallsInByNode(graph: Graph): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const node of graph.nodes) {
+    let d = 0;
+    for (const e of graph.edgesToNode.get(node.id) ?? []) {
+      if (e.relation === 'calls') d++;
+    }
+    if (d > 0) m.set(node.id, d);
+  }
+  return m;
+}
+
+/**
+ * One-symbol entry inside a file summary — a function / class /
+ * method declared in the file plus its in/out call counts. Used by
+ * the `explore file <path>` subcommand to show "here's what this
+ * file declares + how it interconnects."
+ */
+export interface FileSymbolSummary {
+  id: string;
+  kind: 'function' | 'class' | 'method' | 'module';
+  label: string;
+  line?: number;
+  exported?: boolean;
+  callsIn: number;
+  callsOut: number;
+}
+
+/**
+ * Full summary for a single file: its symbols, its callers (deduped
+ * to unique files for readability), its callees, its inbound and
+ * outbound imports, and its community membership. Used by `explore
+ * file <path>`.
+ *
+ * `callerFiles` / `calleeFiles` are deduped at the FILE level — if
+ * 12 symbols from src/foo.ts call into this file's symbols, the
+ * caller appears once in `callerFiles` with `count: 12`. The reader
+ * usually wants "which files depend on me" not "every individual
+ * call site" (which would scroll for pages on hot files).
+ */
+export interface FileSummary {
+  sourceFile: string;
+  found: boolean;
+  symbols: FileSymbolSummary[];
+  callerFiles: Array<{ sourceFile: string; count: number }>;
+  calleeFiles: Array<{ sourceFile: string; count: number }>;
+  importsIn: Array<{ sourceFile: string }>;
+  importsOut: Array<{ sourceFile: string }>;
+  communityId?: number;
+  communityLabel?: string;
+  communityPack?: string;
+}
+
+/**
+ * Build the per-file summary. `found: false` when the file isn't in
+ * the graph (excluded by minified detection / vendored / unsupported
+ * extension); the consumer handles that case with an explanatory
+ * note instead of an empty result.
+ */
+export function fileSummaryQuery(graph: Graph, sourceFile: string): FileSummary {
+  const nodes = nodesInFile(graph, sourceFile);
+  if (nodes.length === 0) {
+    return {
+      sourceFile,
+      found: false,
+      symbols: [],
+      callerFiles: [],
+      calleeFiles: [],
+      importsIn: [],
+      importsOut: [],
+    };
+  }
+
+  // Per-symbol summary for non-module nodes.
+  const symbols: FileSymbolSummary[] = [];
+  // Caller / callee aggregation, deduped at the file level.
+  const callerCounts = new Map<string, number>();
+  const calleeCounts = new Map<string, number>();
+  // Imports in/out aggregation against the file's module node.
+  const importsInFiles = new Set<string>();
+  const importsOutFiles = new Set<string>();
+
+  for (const node of nodes) {
+    if (node.kind !== 'module') {
+      let inCalls = 0;
+      let outCalls = 0;
+      for (const e of graph.edgesToNode.get(node.id) ?? []) {
+        if (e.relation === 'calls') {
+          inCalls++;
+          const src = graph.nodeById.get(e.from);
+          if (src?.sourceFile && src.sourceFile !== sourceFile) {
+            callerCounts.set(src.sourceFile, (callerCounts.get(src.sourceFile) ?? 0) + 1);
+          }
+        }
+      }
+      for (const e of graph.edgesFromNode.get(node.id) ?? []) {
+        if (e.relation === 'calls') {
+          outCalls++;
+          const dst = graph.nodeById.get(e.to);
+          if (dst?.sourceFile && dst.sourceFile !== sourceFile) {
+            calleeCounts.set(dst.sourceFile, (calleeCounts.get(dst.sourceFile) ?? 0) + 1);
+          }
+        }
+      }
+      symbols.push({
+        id: node.id,
+        kind: node.kind,
+        label: node.label,
+        line: node.line,
+        exported: node.exported,
+        callsIn: inCalls,
+        callsOut: outCalls,
+      });
+    } else {
+      // Module node: harvest imports edges.
+      for (const e of graph.edgesToNode.get(node.id) ?? []) {
+        if (e.relation === 'imports_from') {
+          const src = graph.nodeById.get(e.from);
+          if (src?.sourceFile && src.sourceFile !== sourceFile) {
+            importsInFiles.add(src.sourceFile);
+          }
+        }
+      }
+      for (const e of graph.edgesFromNode.get(node.id) ?? []) {
+        if (e.relation === 'imports_from') {
+          const dst = graph.nodeById.get(e.to);
+          if (dst?.sourceFile && dst.sourceFile !== sourceFile) {
+            importsOutFiles.add(dst.sourceFile);
+          }
+        }
+      }
+    }
+  }
+
+  // Pick a representative node for community lookup — module first,
+  // else any symbol.
+  const moduleNode = nodes.find((n) => n.kind === 'module');
+  const sampleNode = moduleNode ?? nodes[0];
+  const community = sampleNode ? graph.communityByNode.get(sampleNode.id) : undefined;
+
+  return {
+    sourceFile,
+    found: true,
+    symbols: symbols.sort((a, b) => b.callsIn - a.callsIn || a.label.localeCompare(b.label)),
+    callerFiles: [...callerCounts.entries()]
+      .map(([sourceFile, count]) => ({ sourceFile, count }))
+      .sort((a, b) => b.count - a.count || a.sourceFile.localeCompare(b.sourceFile)),
+    calleeFiles: [...calleeCounts.entries()]
+      .map(([sourceFile, count]) => ({ sourceFile, count }))
+      .sort((a, b) => b.count - a.count || a.sourceFile.localeCompare(b.sourceFile)),
+    importsIn: [...importsInFiles].sort().map((sourceFile) => ({ sourceFile })),
+    importsOut: [...importsOutFiles].sort().map((sourceFile) => ({ sourceFile })),
+    communityId: community?.id,
+    communityLabel: community?.dominantSourceDir || undefined,
+    communityPack: community?.dominantPack || undefined,
+  };
+}
+
+/**
+ * One row of `vyuh-dxkit explore entry-points` output. An entry
+ * point is a symbol declared in a source file whose path matches
+ * one of the active packs' `architecturalShape.primaryComponentPaths`
+ * or `routePaths` (per CLAUDE.md Rule 8 — these are pack-driven, no
+ * hardcoded framework strings here).
+ *
+ * `componentType` carries the matched pattern label (e.g. `routes`,
+ * `controllers`, `forms`) so the consumer can group by surface.
+ * Sourced from the pack's `dominantVocabulary` when available, else
+ * from the matched path segment.
+ */
+export interface EntryPointResult {
+  sourceFile: string;
+  line?: number;
+  symbol: string;
+  componentType: string;
+  callsOut: number;
+  pack: string;
+}
+
+/**
+ * Discover entry-point symbols by intersecting graph nodes with the
+ * union of active packs' `primaryComponentPaths` + `routePaths`. The
+ * rank is by call out-degree — entry points typically fan OUT (they
+ * receive a request, then call many downstream functions). A high
+ * out-degree node in a primary-architecture path is almost certainly
+ * a real entry point.
+ *
+ * `flags` is the per-pack boolean map from `DetectedStack.languages`;
+ * only patterns from active packs contribute. This matches the
+ * existing pack-driven analyzer pattern.
+ */
+export function entryPointsQuery(
+  graph: Graph,
+  primaryPaths: ReadonlyArray<string>,
+  routePaths: ReadonlyArray<string>,
+  limit = 10,
+): EntryPointResult[] {
+  if (primaryPaths.length === 0 && routePaths.length === 0) {
+    return [];
+  }
+
+  // Classify each source file by whether it matches a pattern.
+  // Patterns are case-insensitive substrings of the relative POSIX
+  // path (per the architecturalShape contract). routePaths overlap
+  // primaryComponentPaths in many packs; tag a file by the most
+  // specific match (route > primary > none).
+  const classify = (sourceFile: string): { matched: boolean; label: string; isRoute: boolean } => {
+    const lower = sourceFile.toLowerCase();
+    for (const p of routePaths) {
+      if (lower.includes(p.toLowerCase())) {
+        return { matched: true, label: patternLabel(p), isRoute: true };
+      }
+    }
+    for (const p of primaryPaths) {
+      if (lower.includes(p.toLowerCase())) {
+        return { matched: true, label: patternLabel(p), isRoute: false };
+      }
+    }
+    return { matched: false, label: '', isRoute: false };
+  };
+
+  const results: EntryPointResult[] = [];
+  for (const node of graph.nodes) {
+    if (node.kind === 'module') continue;
+    if (!node.sourceFile) continue;
+    const c = classify(node.sourceFile);
+    if (!c.matched) continue;
+
+    let callsOut = 0;
+    for (const e of graph.edgesFromNode.get(node.id) ?? []) {
+      if (e.relation === 'calls') callsOut++;
+    }
+    if (callsOut === 0) continue; // entry points fan out; zero-out-degree symbols aren't entry points
+
+    // Pack: derive from extension via the helper below. Avoids a
+    // second pack registry import — keeps queries.ts independent of
+    // languages/index.ts for this lookup.
+    results.push({
+      sourceFile: node.sourceFile,
+      line: node.line,
+      symbol: node.label,
+      componentType: c.label,
+      callsOut,
+      pack: packFromExt(node.sourceFile),
+    });
+  }
+
+  // Rank by callsOut desc, ties by sourceFile asc for stability.
+  results.sort((a, b) => b.callsOut - a.callsOut || a.sourceFile.localeCompare(b.sourceFile));
+
+  return results.slice(0, limit);
+}
+
+/**
+ * Extract a human-readable label from a path pattern. E.g.
+ * `/controllers/` → `controllers`, `/Forms/` → `forms`.
+ */
+function patternLabel(pattern: string): string {
+  return pattern.replace(/[/\\]/g, '').toLowerCase();
+}
+
+// Per-extension pack id derivation. Mirrors EXT_TO_PACK in the
+// Python script. Kept here as a private helper rather than imported
+// from the registry to keep queries.ts importable without pulling
+// the whole pack module surface.
+function packFromExt(sourceFile: string): string {
+  const i = sourceFile.lastIndexOf('.');
+  if (i < 0) return '';
+  const ext = sourceFile.slice(i).toLowerCase();
+  const map: Record<string, string> = {
+    '.ts': 'typescript',
+    '.tsx': 'typescript',
+    '.js': 'typescript',
+    '.jsx': 'typescript',
+    '.mjs': 'typescript',
+    '.cjs': 'typescript',
+    '.py': 'python',
+    '.go': 'go',
+    '.rs': 'rust',
+    '.cs': 'csharp',
+    '.kt': 'kotlin',
+    '.kts': 'kotlin',
+    '.java': 'java',
+    '.rb': 'ruby',
+  };
+  return map[ext] ?? '';
+}
+
+// Re-export the type so consumers can satisfy the signature without
+// pulling DetectedStack from src/types.ts directly.
+export type LanguageFlags = DetectedStack['languages'];
+
+// Sprint 2 will add: featureQuery, apiSurfaceQuery as each
+// subcommand lands.

--- a/test/explore/format.test.ts
+++ b/test/explore/format.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for src/explore/format.ts — the shared markdown + JSON
+ * output helpers used by every explore subcommand. Pure functions,
+ * pure assertions.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { envelope, markdownFooter, markdownHeader, markdownTable } from '../../src/explore/format';
+import type { Graph } from '../../src/explore/types';
+
+const SAMPLE_GRAPH = {
+  schemaVersion: 1,
+  meta: {
+    tool: 'graphify',
+    graphifyVersion: '',
+    dxkitVersion: '2.7.0',
+    generatedAt: '2026-05-27T00:00:00Z',
+    sourceFilesInGraph: 100,
+    excludedFileCount: 50,
+    packs: ['typescript'],
+    truncated: false,
+    truncatedReason: '',
+  },
+  nodes: [],
+  edges: [],
+  communities: [],
+  symbolIndex: {},
+  nodeById: new Map(),
+  edgesFromNode: new Map(),
+  edgesToNode: new Map(),
+  nodesByFile: new Map(),
+  communityById: new Map(),
+  communityByNode: new Map(),
+} as unknown as Graph;
+
+describe('envelope', () => {
+  it('packages command + args + meta + results into the stable shape', () => {
+    const env = envelope('explore.test', { foo: 'bar' }, SAMPLE_GRAPH, [1, 2, 3]);
+    expect(env.command).toBe('explore.test');
+    expect(env.args).toEqual({ foo: 'bar' });
+    expect(env.meta.schemaVersion).toBe(1);
+    expect(env.meta.graphGeneratedAt).toBe('2026-05-27T00:00:00Z');
+    expect(env.meta.truncated).toBe(false);
+    expect(env.results).toEqual([1, 2, 3]);
+  });
+
+  it('surfaces truncated state from the graph meta', () => {
+    const truncatedGraph = {
+      ...SAMPLE_GRAPH,
+      meta: { ...SAMPLE_GRAPH.meta, truncated: true, truncatedReason: 'dropped method edges' },
+    } as Graph;
+    const env = envelope('explore.test', {}, truncatedGraph, []);
+    expect(env.meta.truncated).toBe(true);
+  });
+});
+
+describe('markdownHeader', () => {
+  it('renders the title + framing + meta line', () => {
+    const md = markdownHeader('Hot files', "what's central?", SAMPLE_GRAPH);
+    expect(md).toContain("## Hot files — what's central?");
+    expect(md).toContain('100 source files');
+    expect(md).toContain('0 nodes'); // SAMPLE_GRAPH has no nodes
+    expect(md).toContain('2026-05-27');
+  });
+
+  it('emits a truncation note when the graph is truncated', () => {
+    const truncatedGraph = {
+      ...SAMPLE_GRAPH,
+      meta: { ...SAMPLE_GRAPH.meta, truncated: true, truncatedReason: 'method edges dropped' },
+    } as Graph;
+    const md = markdownHeader('Test', 'demo', truncatedGraph);
+    expect(md).toContain('truncated');
+    expect(md).toContain('method edges dropped');
+  });
+});
+
+describe('markdownTable', () => {
+  it('renders rows as a markdown table with header alignment', () => {
+    const md = markdownTable(['Name', 'Count'] as const, [
+      { Name: 'alpha', Count: 1 },
+      { Name: 'beta', Count: 2 },
+    ]);
+    expect(md).toContain('| Name | Count |');
+    expect(md).toContain('|---|---|');
+    expect(md).toContain('| alpha | 1 |');
+    expect(md).toContain('| beta | 2 |');
+  });
+
+  it('returns empty string for empty rows', () => {
+    expect(markdownTable(['A'] as const, [])).toBe('');
+  });
+
+  it('renders empty string for missing values', () => {
+    const md = markdownTable(['A', 'B'] as const, [{ A: 'x' } as { A: string; B: string }]);
+    expect(md).toContain('| x |  |');
+  });
+});
+
+describe('markdownFooter', () => {
+  it('prefixes the hint with a newline for spacing', () => {
+    expect(markdownFooter('Drill in: foo')).toBe('\nDrill in: foo');
+  });
+});

--- a/test/explore/queries.test.ts
+++ b/test/explore/queries.test.ts
@@ -12,7 +12,17 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { callersOf, calleesOf, nodesInFile } from '../../src/explore/queries';
+import {
+  apiSurfaceQuery,
+  callersOf,
+  calleesOf,
+  communitiesQuery,
+  entryPointsQuery,
+  featureQuery,
+  fileSummaryQuery,
+  hotFilesQuery,
+  nodesInFile,
+} from '../../src/explore/queries';
 import type {
   Community,
   Graph,
@@ -164,5 +174,319 @@ describe('nodesInFile', () => {
     result.pop();
     // Subsequent query returns the original two entries.
     expect(nodesInFile(G, 'src/a.ts')).toHaveLength(2);
+  });
+});
+
+// ─── High-level queries (Sprint 2) ────────────────────────────────────────
+
+describe('hotFilesQuery', () => {
+  it('ranks files by total in-degree (calls + imports)', () => {
+    const results = hotFilesQuery(G, 10);
+    // src/c.ts: callsIn=2 (helper + main), importsIn=0, total=2
+    // src/b.ts: callsIn=1 (main), importsIn=1 (a imports b), total=2
+    // src/a.ts: total=0
+    // src/b.ts and src/c.ts tie at total=2; alphabetical break → b.ts first.
+    const top2 = results
+      .slice(0, 2)
+      .map((r) => r.sourceFile)
+      .sort();
+    expect(top2).toEqual(['src/b.ts', 'src/c.ts']);
+    const cResult = results.find((r) => r.sourceFile === 'src/c.ts');
+    expect(cResult?.callsIn).toBe(2);
+  });
+
+  it('honors the limit', () => {
+    expect(hotFilesQuery(G, 2)).toHaveLength(2);
+    expect(hotFilesQuery(G, 1)).toHaveLength(1);
+  });
+
+  it('returns ALL files when limit exceeds graph size', () => {
+    expect(hotFilesQuery(G, 100)).toHaveLength(3);
+  });
+});
+
+describe('communitiesQuery', () => {
+  it('returns empty array when no communities', () => {
+    // G has no communities populated.
+    expect(communitiesQuery(G, 8)).toEqual([]);
+  });
+
+  it('honors the limit', () => {
+    // Build a graph with 2 synthetic communities patched in via
+    // `as unknown as` cast (the canonical Graph has readonly fields;
+    // the cast is intentional for test-only fixture construction).
+    const base = makeGraph(NODES, EDGES);
+    const communities = [
+      {
+        id: 0,
+        nodeIds: ['n0', 'n1'],
+        cohesion: 0.9,
+        dominantSourceDir: 'src/',
+        dominantPack: 'typescript',
+      },
+      {
+        id: 1,
+        nodeIds: ['n2', 'n3'],
+        cohesion: 0.8,
+        dominantSourceDir: 'src/',
+        dominantPack: 'typescript',
+      },
+    ];
+    const gWithCommunities = {
+      ...base,
+      communities,
+      communityById: new Map(communities.map((c) => [c.id, c])),
+    } as unknown as Graph;
+    expect(communitiesQuery(gWithCommunities, 1)).toHaveLength(1);
+    expect(communitiesQuery(gWithCommunities, 5)).toHaveLength(2);
+  });
+});
+
+describe('fileSummaryQuery', () => {
+  it('returns found: false for a file not in the graph', () => {
+    const result = fileSummaryQuery(G, 'src/missing.ts');
+    expect(result.found).toBe(false);
+    expect(result.symbols).toEqual([]);
+  });
+
+  it('summarizes symbols + callers + callees for a known file', () => {
+    const result = fileSummaryQuery(G, 'src/c.ts');
+    expect(result.found).toBe(true);
+    expect(result.symbols.map((s) => s.label).sort()).toEqual(['logger()']);
+    // logger() has 2 callers (helper from b.ts, main from a.ts)
+    expect(result.callerFiles.map((c) => c.sourceFile).sort()).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+
+  it('preserves the exported flag from the node', () => {
+    const nodes: GraphNode[] = [
+      { id: 'm0', kind: 'module', label: 'src/x.ts', sourceFile: 'src/x.ts' },
+      {
+        id: 'f0',
+        kind: 'function',
+        label: 'foo()',
+        sourceFile: 'src/x.ts',
+        line: 1,
+        exported: true,
+      },
+      {
+        id: 'f1',
+        kind: 'function',
+        label: 'bar()',
+        sourceFile: 'src/x.ts',
+        line: 2,
+        exported: false,
+      },
+    ];
+    const g = makeGraph(nodes, []);
+    const result = fileSummaryQuery(g, 'src/x.ts');
+    const exportedSymbols = result.symbols.filter((s) => s.exported === true);
+    expect(exportedSymbols.map((s) => s.label)).toEqual(['foo()']);
+  });
+});
+
+describe('entryPointsQuery', () => {
+  it('returns empty when no patterns supplied', () => {
+    expect(entryPointsQuery(G, [], [])).toEqual([]);
+  });
+
+  it('matches nodes by sourceFile path against primaryPaths', () => {
+    const nodes: GraphNode[] = [
+      {
+        id: 'm0',
+        kind: 'module',
+        label: 'src/controllers/users.ts',
+        sourceFile: 'src/controllers/users.ts',
+      },
+      {
+        id: 'f0',
+        kind: 'function',
+        label: 'createUser()',
+        sourceFile: 'src/controllers/users.ts',
+        line: 5,
+      },
+      {
+        id: 'm1',
+        kind: 'module',
+        label: 'src/utils/helpers.ts',
+        sourceFile: 'src/utils/helpers.ts',
+      },
+      {
+        id: 'f1',
+        kind: 'function',
+        label: 'isValid()',
+        sourceFile: 'src/utils/helpers.ts',
+        line: 1,
+      },
+    ];
+    const edges: GraphEdge[] = [
+      { from: 'f0', to: 'f1', relation: 'calls' }, // createUser calls isValid (gives createUser callsOut=1)
+    ];
+    const g = makeGraph(nodes, edges);
+    const results = entryPointsQuery(g, ['/controllers/'], [], 10);
+    expect(results.map((r) => r.symbol)).toEqual(['createUser()']);
+    expect(results[0].componentType).toBe('controllers');
+    expect(results[0].pack).toBe('typescript');
+  });
+
+  it('filters out symbols with zero call out-degree', () => {
+    const nodes: GraphNode[] = [
+      {
+        id: 'm0',
+        kind: 'module',
+        label: 'src/controllers/users.ts',
+        sourceFile: 'src/controllers/users.ts',
+      },
+      // Function in controllers/ but no outbound calls — not an entry point
+      {
+        id: 'f0',
+        kind: 'function',
+        label: 'unused()',
+        sourceFile: 'src/controllers/users.ts',
+        line: 5,
+      },
+    ];
+    const g = makeGraph(nodes, []);
+    expect(entryPointsQuery(g, ['/controllers/'], [])).toEqual([]);
+  });
+});
+
+describe('apiSurfaceQuery', () => {
+  it('returns exported symbols with zero internal callers', () => {
+    const nodes: GraphNode[] = [
+      { id: 'm0', kind: 'module', label: 'src/index.ts', sourceFile: 'src/index.ts' },
+      {
+        id: 'f0',
+        kind: 'function',
+        label: 'publicApi()',
+        sourceFile: 'src/index.ts',
+        line: 1,
+        exported: true,
+      },
+      {
+        id: 'f1',
+        kind: 'function',
+        label: 'usedInternally()',
+        sourceFile: 'src/index.ts',
+        line: 5,
+        exported: true,
+      },
+      {
+        id: 'f2',
+        kind: 'function',
+        label: 'private()',
+        sourceFile: 'src/index.ts',
+        line: 10,
+        exported: false,
+      },
+    ];
+    const edges: GraphEdge[] = [
+      { from: 'f0', to: 'f1', relation: 'calls' }, // publicApi calls usedInternally → usedInternally has a caller
+    ];
+    const g = makeGraph(nodes, edges);
+    const results = apiSurfaceQuery(g, [], 10);
+    expect(results.map((r) => r.symbol)).toEqual(['publicApi()']);
+  });
+
+  it('skips packs in the packsExcluded list', () => {
+    const nodes: GraphNode[] = [
+      {
+        id: 'f0',
+        kind: 'function',
+        label: 'foo()',
+        sourceFile: 'src/foo.ts',
+        line: 1,
+        exported: true,
+      },
+      {
+        id: 'f1',
+        kind: 'function',
+        label: 'bar()',
+        sourceFile: 'src/bar.rb',
+        line: 1,
+        exported: true,
+      },
+    ];
+    const g = makeGraph(nodes, []);
+    const results = apiSurfaceQuery(g, ['ruby'], 10);
+    expect(results.map((r) => r.symbol)).toEqual(['foo()']);
+  });
+
+  it('ignores symbols where exported is absent (unknown)', () => {
+    const nodes: GraphNode[] = [
+      { id: 'f0', kind: 'function', label: 'foo()', sourceFile: 'src/foo.ts', line: 1 }, // no exported flag
+      {
+        id: 'f1',
+        kind: 'function',
+        label: 'bar()',
+        sourceFile: 'src/bar.ts',
+        line: 1,
+        exported: true,
+      },
+    ];
+    const g = makeGraph(nodes, []);
+    const results = apiSurfaceQuery(g, [], 10);
+    expect(results.map((r) => r.symbol)).toEqual(['bar()']);
+  });
+});
+
+describe('featureQuery', () => {
+  const featureNodes: GraphNode[] = [
+    { id: 'm0', kind: 'module', label: 'src/connectors.ts', sourceFile: 'src/connectors.ts' },
+    { id: 'c0', kind: 'class', label: 'Connector', sourceFile: 'src/connectors.ts', line: 1 },
+    {
+      id: 'f0',
+      kind: 'function',
+      label: 'createConnector()',
+      sourceFile: 'src/connectors.ts',
+      line: 5,
+    },
+    { id: 'f1', kind: 'function', label: 'unrelated()', sourceFile: 'src/other.ts', line: 1 },
+  ];
+  const featureEdges: GraphEdge[] = [
+    { from: 'f0', to: 'c0', relation: 'calls' }, // createConnector references Connector
+  ];
+  const baseFeatureGraph = makeGraph(featureNodes, featureEdges);
+  // Patch in a symbol index via cast (test-only fixture construction;
+  // the canonical Graph has readonly fields).
+  const featureGraph = {
+    ...baseFeatureGraph,
+    symbolIndex: {
+      connector: ['c0'],
+      createconnector: ['f0'],
+      unrelated: ['f1'],
+    },
+  } as unknown as Graph;
+
+  it('returns exact match via symbolIndex', () => {
+    const result = featureQuery(featureGraph, 'connector');
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  it('expands via substring when --substring opt-in', () => {
+    const result = featureQuery(featureGraph, 'conn', { substring: true });
+    // 'conn' substring matches 'connector' + 'createconnector'
+    expect(result.results.length).toBeGreaterThan(0);
+  });
+
+  it('skips substring expansion by default', () => {
+    const result = featureQuery(featureGraph, 'conn');
+    // 'conn' has no exact symbolIndex key, no edit-distance match → suggestions
+    expect(result.results).toEqual([]);
+  });
+
+  it('returns edit-distance + substring suggestions on zero hits', () => {
+    const result = featureQuery(featureGraph, 'connectoq'); // typo of "connector"
+    expect(result.results).toEqual([]);
+    // Substring 'connectoq' has no substring matches but levenshtein
+    // distance to 'connector' is 1 → should suggest 'connector'.
+    expect(result.suggestions.map((s) => s.key)).toContain('connector');
+  });
+
+  it('populates centralEntryPoint as the highest-in-degree seed', () => {
+    // c0 has 1 caller (f0). f0 has 0 callers.
+    const result = featureQuery(featureGraph, 'connector');
+    expect(result.centralEntryPoint?.symbol).toBe('Connector');
+    expect(result.centralEntryPoint?.calledFrom).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Sprint 2 of the 2.7 release lands the six `vyuh-dxkit explore`
subcommands per the Sprint 0 design (`tmp/2.7-explore-cli-design.md`).
All consume the graph artifact via the canonical loader + queries
module landed in Sprint 1 (Rule 12 enforced).

4 atomic commits:

1. **feat(explore): dispatcher + format module + hot-files subcommand** — top-level routing + JSON envelope + markdown helpers + the first subcommand (top files by call in-degree)
2. **feat(explore): communities + file + entry-points subcommands** — Louvain-cluster summary, per-file drill-down, and the first pack-driven query (`architecturalShape`-aware, CLAUDE.md Rule 8)
3. **feat(explore): api-surface + feature subcommands** — exported-symbols-without-callers (per-pack `exportDetection`-gated) + the marquee 3-stage feature query with `centralEntryPoint` identification + Levenshtein-edit-distance suggestions
4. **test(explore): scoped coverage for all six Sprint 2 subcommands** — 27 new unit tests across `queries.test.ts` + new `format.test.ts`

## The six subcommands

```bash
npx vyuh-dxkit explore hot-files [--limit 20]              # What's central?
npx vyuh-dxkit explore communities [--limit 8]             # Natural modules
npx vyuh-dxkit explore file <path>                         # Drill into one file
npx vyuh-dxkit explore entry-points [--limit 10]           # Pack-driven entry points
npx vyuh-dxkit explore api-surface [--limit 25]            # Exported, no internal callers
npx vyuh-dxkit explore feature <keyword> [--substring]     # Where is X implemented?
```

All accept `--json` for stable envelope output. Shared flags: `--refresh` (shell out to `vyuh-dxkit health` to regenerate `graph.json`); `--cwd <path>` (operate against a different repo root).

## Architecture (CLAUDE.md Rule 12)

```
src/explore-cli.ts          # Top-level dispatcher (subcommand routing)
src/explore/
  load.ts                   # Canonical loader (loadGraph + typed errors) [Sprint 1]
  queries.ts                # All graph traversal — pure functions
  format.ts                 # Pure JSON + markdown helpers
  types.ts                  # Graph, GraphNode, GraphEdge, Community, etc. [Sprint 1]
  cli/
    hot-files.ts            # Thin: parse args → call query → format
    communities.ts
    file.ts
    entry-points.ts
    api-surface.ts
    feature.ts              # 3-stage: symbolIndex / substring / structural
```

Rule 12 prevents future code from bypassing the canonical entry points (arch-check active since Sprint 1).

## Real-repo smoke (against the dxkit repo itself)

- `explore hot-files` → ranks `test/suppressions.test.ts` (103 calls in) and `src/logger.ts` (91) at the top
- `explore communities` → 8 communities surfaced, with `src/`, `src/languages/`, `src/analyzers/tools/`, `src/baseline/` as dominant directories
- `explore file src/cli.ts` → identifies `run()` as the only exported symbol, lists 17 caller files + 49 callee files + community membership
- `explore entry-points` → honest empty result (dxkit is a CLI tool, doesn't use a `controllers/` convention)
- `explore api-surface` → 10 likely-public TS symbols; ruby pack excluded with explanation
- `explore feature graphify --substring` → 6 graphify symbols clustered in `src/analyzers/tools/`, `runGraphifyOnce()` identified as the central entry point
- `explore feature license --substring` → 18 license-related symbols across 9 clusters
- `explore feature explore` (no substring) → "did you mean: `runexplore` (1 hit), `printexplorehelp` (1 hit)"

## Test plan

- [x] `npm run typecheck:test` — clean
- [x] `npm run typecheck` — clean
- [x] `npx vitest run test/explore/` — 52/52 passing locally (~840ms)
- [x] `bash scripts/check-architecture.sh` — Rule 12 enforced, zero violations
- [x] Smoke each subcommand against the dxkit repo (see above)
- [ ] CI full suite passes on this PR

## Known limitations (documented, deferred)

- **Substring opt-in default**: `feature <keyword>` requires `--substring` to expand beyond exact symbol-name matches. Cleaner default since substring matching is false-positive prone for short keywords; the "did you mean" suggestions point users to substring matches without forcing them.
- **Sparse `imports_from` edges on TS codebases**: graphify's upstream TS import extraction is limited (1 edge across dxkit's 298 source files). The api-surface query and centrality scoring rely more on `calls` than `imports_from` as a result. Same-language repos in Python / Go / Rust will see richer import data.
- **Same-name symbol conflation**: graphify cannot distinguish `run()` in `src/cli.ts` from `run()` in `src/analyzers/tools/runner.ts` — they share a node id. Per-file aggregates are unaffected; per-symbol numbers are slightly noisier than they appear. Future upstream graphify improvement.
- **camelCase word-component edit-distance**: typos like `graphfiy` against a symbol named `gatherGraphifyResult` aren't suggested because Levenshtein operates on whole strings. Minor polish; future improvement.

## What's NOT in this PR (deferred to later sprints)

- Sprint 3: interactive cytoscape.js graph viz (consumer of the same graph.json)
- Sprint 4: `dxkit-explore` skill + Rule 12 prose in CLAUDE.md + docs + ship