### PR TITLE
release: 2.8.0 — NuGet transitive lockfile fix + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   directory), and points at `npx vyuh-dxkit init --full --yes` as a
   direct path that needs no successful `npm install`.
 
+## [2.8.0] - 2026-06-03
+
+Graph-context navigation, two new agent skills, and broader secret +
+.NET dependency coverage.
+
+### Added
+
+- **`vyuh-dxkit context <file:line>`.** Given a source location, returns
+  the focused source chunk around it — roughly the enclosing symbol
+  rather than the whole file — plus its structural neighborhood (module,
+  blast radius, callers/callees). The chunk is read from disk, carved to
+  a token budget, and centered on the requested line so the line you
+  asked about is always shown. Degrades in layers: a file absent from the
+  graph still returns a centered raw-line window; an unreadable path
+  exits with a clear message. The keyword form `context <query>` is
+  unchanged.
+- **`dxkit-feature` skill.** Drives net-new development the way
+  `dxkit-action` drives fixes: orient via the code graph to find where a
+  feature plugs in and what it touches, build following existing
+  patterns, then run the analyzers + `guardrail check` on the change so
+  the feature doesn't ship a regression. Degrades to grep + read when no
+  graph is present.
+- **`dxkit-docs` skill.** Generates the documentation a repo is missing —
+  reads the Documentation dimension's gaps, orients on the real code via
+  the graph, then writes a grounded README / docstrings / API +
+  architecture docs and re-runs the slop check so generated prose doesn't
+  trade Documentation score for Quality score.
+
+### Fixed
+
+- **Hardcoded passwords are detected even when gitleaks is installed.**
+  gitleaks is keyed to known token formats (AWS / GitHub / Stripe /
+  private keys) and deliberately skips generic credential assignments
+  like `password = "..."`. The pattern scanner already had a
+  hardcoded-password rule but returned nothing whenever gitleaks was
+  present, on a false "strict superset" assumption — so a plain
+  hardcoded password sailed through the guardrail. The pattern scanner
+  now complements gitleaks: generic keyword-assignment patterns
+  (password / api-key / secret / token = a quoted literal,
+  case-insensitive) always run, while branded token shapes stay
+  gitleaks-only to avoid double-counting. The scan also moved off POSIX
+  `grep` onto the in-process source walker, so it works on Windows.
+- **Transitive .NET dependency vulnerabilities are found from committed
+  lock files.** When a repo commits NuGet `packages.lock.json` files but
+  the scanning machine lacked the .NET SDK, a vulnerable transitive
+  dependency could go unreported: the osv path synthesized a lock file
+  from each project's direct `<PackageReference>` entries only and never
+  read the repo's real lock file (which carries the full resolved
+  transitive tree). osv now scans the committed `packages.lock.json`
+  files directly — full transitive coverage with no SDK or restore
+  required — falling back to the direct-reference synthesis only when no
+  lock file is committed.
+
+### Changed
+
+- Package-level dependency reachability (the `reachable` flag feeding the
+  composite risk score) is documented as shipped on the roadmap, with the
+  remaining refinements (per-ecosystem reliability gating, reachable-first
+  report framing) split out as pending.
+
 ## [2.7.1] - 2026-05-31
 
 Windows compatibility. Tool detection, the scanner toolchain, and source

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,14 +44,19 @@ What dxkit ships today and what is planned next. For per-release detail see [`CH
 ### Graphify pair (deferred from 2.7)
 
 - [x] `vyuh-dxkit context <file:line>` command that returns a curated source chunk under a token budget, centered on the requested line, plus the enclosing symbol's callers/callees and blast radius. Replaces "agent ingests 15k-line file" with "agent ingests 500 focused lines."
-- [ ] Reachability Tier-1 for dep-vuln triage. Lifts severity based on whether customer code actually calls the vulnerable surface.
+- [x] Package-level reachability for dep-vuln triage. Marks a finding `reachable` when its package is imported anywhere in source; the flag feeds the composite risk score. (Refinements pending — see below.)
 
 Both build on the graph foundation that 2.7 shipped.
 
 ### Agent skills
 
 - [x] `dxkit-feature` skill — drives net-new development the way `dxkit-action` drives fixes: orient via the code graph (`context` / `explore`) to find where a feature plugs in and what it touches, then run the analyzers + `guardrail check` on the change so the feature doesn't ship a regression. Degrades gracefully to grep + read when no graph is present; verification never depends on the graph.
-- [ ] `dxkit-docs` skill — generates the documentation a repo is missing: reads the Documentation dimension's gaps, orients on the real code via the graph, then writes a grounded README / docstrings / API + architecture docs and re-runs the slop check so generated prose doesn't trade Documentation score for Quality score.
+- [x] `dxkit-docs` skill — generates the documentation a repo is missing: reads the Documentation dimension's gaps, orients on the real code via the graph, then writes a grounded README / docstrings / API + architecture docs and re-runs the slop check so generated prose doesn't trade Documentation score for Quality score.
+
+### Reachability refinements (pending)
+
+- [ ] Per-ecosystem reliability gating: only mark a finding `reachable: false` when its language pack resolves imports reliably (TS / Python / Go). For packs whose import resolution is unreliable (C# namespaces ≠ package names, etc.), leave `reachable` unset rather than risk a false "unreachable" that hides a real vuln.
+- [ ] Reachable-first report framing: a `"N reachable / M total"` summary line and reachable-first sort in the vulnerability report (the per-finding `reachable` glyph already renders).
 
 ## Future
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.7.1",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "description": "AI-native developer experience toolkit for any codebase",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -629,6 +629,76 @@ async function gatherDirectPackageReferenceFallback(
 }
 
 /**
+ * Discover the repo's COMMITTED `packages.lock.json` files. NuGet writes
+ * one next to each project (`<ProjectDir>/packages.lock.json`) when lock
+ * files are enabled (`RestorePackagesWithLockFile` / CI restore), and it
+ * records the FULL resolved transitive tree with pinned versions — the
+ * exact input osv-scanner needs for transitive coverage. Anchored to the
+ * `.csproj` discovery so it shares the canonical depth-unlimited walker.
+ */
+export function findRealPackagesLockFiles(cwd: string): string[] {
+  const out: string[] = [];
+  for (const csproj of findAllCsprojFiles(cwd)) {
+    const lock = path.join(path.dirname(csproj), 'packages.lock.json');
+    if (fs.existsSync(lock)) out.push(lock);
+  }
+  return out;
+}
+
+/**
+ * Scan the repo's real `packages.lock.json` files with osv-scanner. This
+ * is the TRANSITIVE-capable osv path: unlike the direct-PackageReference
+ * fallback (which synthesizes a lockfile from `.csproj` direct refs and
+ * therefore can't see transitive deps), a committed lock file already
+ * carries the entire resolved tree, so osv-scanner surfaces vulnerable
+ * transitive packages (e.g. a CVE in `Azure.Identity` reached through
+ * `Microsoft.Data.SqlClient`) without needing `dotnet` installed or a
+ * `dotnet restore` to have run.
+ *
+ * osv-scanner detects NuGet by the literal filename `packages.lock.json`,
+ * so the real files are passed straight through `--lockfile=`.
+ */
+async function gatherRealLockfilePath(
+  cwd: string,
+  lockfiles: string[],
+): Promise<DepVulnGatherOutcome> {
+  const scanner = findTool(TOOL_DEFS['osv-scanner'], cwd);
+  if (!scanner.available || !scanner.path) {
+    return {
+      kind: 'unavailable',
+      reason: `osv-scanner unavailable for packages.lock.json transitive scan (${lockfiles.length} lock files found)`,
+    };
+  }
+
+  const lockfileFlags = lockfiles.map((f) => `--lockfile=${f}`).join(' ');
+  const raw = run(`${scanner.path} scan source ${lockfileFlags} --format json`, cwd, 180000);
+  if (!raw) {
+    return {
+      kind: 'unavailable',
+      reason: `osv-scanner produced no output on ${lockfiles.length} packages.lock.json file(s)`,
+    };
+  }
+
+  const { counts, findings, vulnsForCvss } = parseOsvScannerFindings(raw, 'NuGet', 'csharp');
+  if (findings.length > 0) {
+    const resolved = await resolveCvssScores(vulnsForCvss);
+    for (const f of findings) {
+      const score = resolved.get(f.id);
+      if (score !== null && score !== undefined) f.cvssScore = score;
+    }
+  }
+
+  const envelope: DepVulnResult = {
+    schemaVersion: 1,
+    tool: 'osv-scanner-nuget-lockfile',
+    enrichment: 'osv.dev',
+    counts,
+    findings,
+  };
+  return { kind: 'success', envelope };
+}
+
+/**
  * Run `dotnet list package --vulnerable --include-transitive` on cwd
  * and return a DepVulnGatherOutcome. The "primary" half of the
  * always-merge G_v4_9 strategy. Pulled out of
@@ -717,10 +787,14 @@ async function runDotnetVulnerablePath(cwd: string): Promise<DepVulnGatherOutcom
  *   surfaces transitive vulns via NuGet's own resolution when
  *   `dotnet restore` has been run.
  *
- *   **osv-scanner-nuget-direct path**: parses every `.csproj` for
- *   direct PackageReferences, writes an adhoc `packages.lock.json`,
- *   runs osv-scanner. Covers ~80% of typical .NET CVE surface
- *   (direct refs only — no transitive resolution).
+ *   **osv path**: prefers the repo's COMMITTED `packages.lock.json`
+ *   files (`osv-scanner-nuget-lockfile`) — these carry the full
+ *   resolved transitive tree, so osv surfaces vulnerable transitive
+ *   deps (e.g. `Azure.Identity` reached through `Microsoft.Data.SqlClient`)
+ *   with no `dotnet`/restore required. When no lock file is committed it
+ *   falls back to `osv-scanner-nuget-direct`: parse every `.csproj` for
+ *   direct PackageReferences, write an adhoc `packages.lock.json`, run
+ *   osv-scanner (direct refs only — no transitive resolution).
  *
  *   Findings union, fingerprint-deduped at (package, installedVersion,
  *   id). Envelope counts recomputed from the merged set. Both tool
@@ -736,11 +810,21 @@ async function gatherCsharpDepVulnsResult(cwd: string): Promise<DepVulnGatherOut
     return { kind: 'no-manifest', reason: 'no .csproj or .sln found within depth 5' };
   }
 
-  // Run both tools in parallel. Each returns a DepVulnGatherOutcome;
-  // we merge whatever succeeds.
+  // Run the dotnet path and the osv path in parallel; merge whatever
+  // succeeds. The osv half prefers the repo's COMMITTED
+  // `packages.lock.json` files (full transitive tree, no `dotnet`
+  // required) and only falls back to the direct-PackageReference
+  // synthesis when no lock file is committed — so a repo that uses lock
+  // files gets transitive coverage from osv even when `dotnet` is absent
+  // (the case that silently dropped vulnerable transitive deps before).
+  const realLockfiles = findRealPackagesLockFiles(cwd);
+  const osvHalf =
+    realLockfiles.length > 0
+      ? gatherRealLockfilePath(cwd, realLockfiles)
+      : gatherDirectPackageReferenceFallback(cwd, 'G_v4_9 always-merge');
   const [primaryOutcome, fallbackOutcome] = await Promise.all([
     runDotnetVulnerablePath(cwd),
-    gatherDirectPackageReferenceFallback(cwd, 'G_v4_9 always-merge'),
+    osvHalf,
   ]);
 
   // Pick the better outcome when both fail to succeed.

--- a/test/languages-csharp-depvulns.test.ts
+++ b/test/languages-csharp-depvulns.test.ts
@@ -8,6 +8,7 @@ import {
   parseProjectAssetsJson,
   buildCsharpTopLevelDepIndex,
   mergeAssetParses,
+  findRealPackagesLockFiles,
 } from '../src/languages/csharp';
 
 // Fixture JSONs mirror the dotnet list package --vulnerable --format json
@@ -554,5 +555,47 @@ describe('csharp depVulns preflight parity with detect() (D035)', () => {
     expect(csharp.detect(tmp)).toBe(false);
     const result = await csharp.capabilities!.depVulns!.gather(tmp);
     expect(result).toBeNull();
+  });
+});
+
+describe('findRealPackagesLockFiles (transitive lockfile discovery)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-nuget-lock-'));
+  });
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  const csproj = '<Project Sdk="Microsoft.NET.Sdk"></Project>';
+
+  it('finds a committed packages.lock.json next to a .csproj', () => {
+    fs.writeFileSync(path.join(tmp, 'App.csproj'), csproj);
+    fs.writeFileSync(path.join(tmp, 'packages.lock.json'), '{"version":1,"dependencies":{}}');
+    const found = findRealPackagesLockFiles(tmp);
+    expect(found).toHaveLength(1);
+    expect(found[0].endsWith('packages.lock.json')).toBe(true);
+  });
+
+  it('returns empty when a .csproj has no adjacent lock file (falls back to direct path)', () => {
+    fs.writeFileSync(path.join(tmp, 'App.csproj'), csproj);
+    expect(findRealPackagesLockFiles(tmp)).toEqual([]);
+  });
+
+  it('discovers one lock file per project in a multi-project layout', () => {
+    for (const proj of ['DataStore', 'DataEngine', 'ConnectorUtils']) {
+      const dir = path.join(tmp, proj);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, `${proj}.csproj`), csproj);
+      fs.writeFileSync(path.join(dir, 'packages.lock.json'), '{"version":1,"dependencies":{}}');
+    }
+    expect(findRealPackagesLockFiles(tmp)).toHaveLength(3);
+  });
+
+  it('only counts lock files that sit next to a project file', () => {
+    // A stray lock file with no adjacent .csproj is not discovered.
+    fs.writeFileSync(path.join(tmp, 'App.csproj'), csproj);
+    const orphan = path.join(tmp, 'unrelated');
+    fs.mkdirSync(orphan, { recursive: true });
+    fs.writeFileSync(path.join(orphan, 'packages.lock.json'), '{"version":1,"dependencies":{}}');
+    expect(findRealPackagesLockFiles(tmp)).toEqual([]);
   });
 });


### PR DESCRIPTION
**Release 2.8.0.** Bundles the final 2.8 fix with the version bump so it's a single merge.

## Commits (rebase-merge to preserve all three)

1. **`fix(csharp)`** — scan committed `packages.lock.json` for transitive dep-vulns. A .NET repo that commits lock files could have a vulnerable **transitive** dependency go unreported when the .NET SDK wasn't on the scanning machine — the osv path synthesized a lock file from direct `<PackageReference>` entries only and never read the real lock file. Now osv scans the committed `packages.lock.json` directly (full transitive tree, no SDK/restore). Proven end-to-end on real osv-scanner; behavior-preserving on repos without lock files (verified inert + clean run on a real 74-project .NET repo). 4 new tests.
2. **`docs(roadmap)`** — correct reachability + skill status: package-level reachability is already shipped (the `reachable` flag feeds the risk score); the refinements (per-ecosystem gating, reachable-first reporting) are split out as pending. `dxkit-docs` checked off.
3. **`chore(release): 2.8.0`** — version bump + CHANGELOG.

## What 2.8.0 ships (cumulative, incl. already-merged #64)

- `vyuh-dxkit context <file:line>` — focused source-chunk surface
- `dxkit-feature` + `dxkit-docs` skills
- hardcoded-password detection even when gitleaks is installed
- transitive .NET dep-vulns from committed lock files (this PR)

## Validation

- Full suite **2137/2137**; lint + format + typecheck:test + arch gate clean.
- CI green (build + npm-pack + init/baseline/guardrail).

## After merge

Tag `v2.8.0` + GitHub Release → CI publishes to npm with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
