### PR TITLE
2.9.0 — Deep SAST ingestion (engine-agnostic) + guardrail reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-06-08
+
 ### Deep SAST — engine-agnostic interprocedural findings (2.9)
 
 dxkit's bundled SAST (community semgrep) is intraprocedural and misses the
@@ -17,9 +19,14 @@ than try to re-detect that class. dxkit becomes the governance + agentic-fix
 layer on top of any detector, grounded in the repo's own code graph.
 
 - **`vyuh-dxkit ingest`** brings external SAST findings into dxkit:
-  - `--from-snyk --org <id> --project <id>` reads a project's Snyk Code
-    findings via the REST API (set `SNYK_TOKEN`). It reads stored results, so
-    it does **not** consume the org's Snyk Code test quota.
+  - `--from-snyk` brings in a project's Snyk Code findings and works on **every
+    Snyk plan**. It reads the REST API quota-free where available (an
+    Enterprise entitlement); on Free/Team plans the read returns 403 and dxkit
+    automatically falls back to `snyk code test` (the Snyk Code product, which
+    free includes — one test per run). `--snyk-cli` forces the CLI path. Set
+    `SNYK_TOKEN`; org/project resolve from the flag, then `.vyuh-dxkit.json`,
+    then the environment (`SNYK_ORG_ID` / `SNYK_PROJECT_ID`). dxkit reads these
+    from the environment and does **not** auto-load a `.env` file.
   - `--sarif <file>` ingests SARIF 2.1.0 from any engine (CodeQL, a Snyk
     export, Semgrep Pro, Bearer).
   - `--codeql` runs CodeQL on demand for the active languages (open-source /
@@ -35,16 +42,42 @@ layer on top of any detector, grounded in the repo's own code graph.
   `ingest --from-snyk` needs no flags after first setup.
 - `--with-deep-sast-refresh` installs an on-demand CI workflow
   (`workflow_dispatch`) that re-ingests and commits the snapshot — the one
-  place the token is used. No-ops without the `SNYK_TOKEN` secret.
+  place the token is used. A `method` input selects `api` (Enterprise,
+  quota-free) or `cli` (free/team, one test per run); `api` auto-falls-back to
+  the CLI. No-ops without the `SNYK_TOKEN` secret.
 - New `dxkit-ingest` skill; `dxkit-action` and `dxkit-config` updated. CodeQL
   and Snyk support is declared per language pack; CodeQL is a guarded, opt-in
   tool kept out of the default toolchain.
+
+### Guardrail reliability — the pre-push hook actually fires
+
+A guardrail only protects a repo if the hook runs and resolves the right
+dxkit. Hardening for brownfield repos, found by exercising the full install
+path on a real project:
+
+- **`init` / `update` declare `@vyuhlabs/dxkit` in `devDependencies`** (pinned
+  to the installed version) whenever hooks or CI are installed. The hook and CI
+  workflow resolve `./node_modules/.bin/vyuh-dxkit` before any global, so a
+  project that wired them but never declared the package silently ran a stale
+  global — or failed on a fresh CI runner. `doctor` gains a matching check.
+- **A non-executable hook is no longer a silent no-op.** Git ignores a hook
+  that lacks the executable bit (a hook committed as mode 100644, or checked
+  out on a filesystem that drops it), so pushes sailed through with no check
+  while `doctor` reported a false green. `hooks activate` now restores the bit
+  on every run (self-healing on every clone via the postinstall), and `doctor`
+  verifies executability, not just `core.hooksPath`.
+- **Hook activation chains after an existing `postinstall`** (patch-package, a
+  husky bootstrap) with `&&` instead of bailing with a note, so the pre-push
+  guardrail activates even on repos that already script their install.
 
 Upgrading: after `npm install --save-dev @vyuhlabs/dxkit@latest` +
 `npx vyuh-dxkit update`, run `npx vyuh-dxkit ingest --from-snyk` (or
 `--codeql`) to bring your interprocedural findings into dxkit, then
 `npx vyuh-dxkit baseline create --force` to anchor them. The `dxkit-ingest`
-skill walks through token setup and the license-aware engine choice.
+skill walks through token setup and the license-aware engine choice. On a
+brownfield repo the binary install may hit a peer-dep `ERESOLVE` from your own
+dependency tree — retry with `--legacy-peer-deps` (the `dxkit-update` skill
+walks through it).
 
 ### create-dxkit 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deep SAST — engine-agnostic interprocedural findings (2.9)
+
+dxkit's bundled SAST (community semgrep) is intraprocedural and misses the
+cross-function taint class — path traversal, information exposure, SSRF,
+injection — that interprocedural engines (Snyk Code, CodeQL) catch. 2.9 makes
+dxkit ingest any such engine's findings and treat them as first-class, rather
+than try to re-detect that class. dxkit becomes the governance + agentic-fix
+layer on top of any detector, grounded in the repo's own code graph.
+
+- **`vyuh-dxkit ingest`** brings external SAST findings into dxkit:
+  - `--from-snyk --org <id> --project <id>` reads a project's Snyk Code
+    findings via the REST API (set `SNYK_TOKEN`). It reads stored results, so
+    it does **not** consume the org's Snyk Code test quota.
+  - `--sarif <file>` ingests SARIF 2.1.0 from any engine (CodeQL, a Snyk
+    export, Semgrep Pro, Bearer).
+  - `--codeql` runs CodeQL on demand for the active languages (open-source /
+    GitHub Advanced Security only).
+- Ingested findings are written to a committed `.dxkit/external/<engine>.json`
+  snapshot and enter the security pipeline as first-class code findings:
+  fingerprinted + deduped against native findings, recorded in the baseline,
+  enforced by the guardrail, rendered in the vulnerability report, and
+  graph-linked under `--graph-context` (blast radius + callers for the fix
+  loop). The engine token is needed only at ingest time — every developer and
+  CI run reads the committed snapshot.
+- Persist the engine + Snyk project in `.vyuh-dxkit.json:deepSast` so
+  `ingest --from-snyk` needs no flags after first setup.
+- `--with-deep-sast-refresh` installs an on-demand CI workflow
+  (`workflow_dispatch`) that re-ingests and commits the snapshot — the one
+  place the token is used. No-ops without the `SNYK_TOKEN` secret.
+- New `dxkit-ingest` skill; `dxkit-action` and `dxkit-config` updated. CodeQL
+  and Snyk support is declared per language pack; CodeQL is a guarded, opt-in
+  tool kept out of the default toolchain.
+
+Upgrading: after `npm install --save-dev @vyuhlabs/dxkit@latest` +
+`npx vyuh-dxkit update`, run `npx vyuh-dxkit ingest --from-snyk` (or
+`--codeql`) to bring your interprocedural findings into dxkit, then
+`npx vyuh-dxkit baseline create --force` to anchor them. The `dxkit-ingest`
+skill walks through token setup and the license-aware engine choice.
+
 ### create-dxkit 0.2.1
 
 - **Surfaces the real npm error when bootstrap install fails.** When

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,6 +432,51 @@ Four rules in `scripts/check-architecture.sh` (pre-commit + CI):
 4. No re-implementation of canonical query helpers outside
    `src/explore/queries.ts` — extend it and import.
 
+### 13. External-engine findings flow through the canonical ingest module
+
+dxkit's bundled SAST (community semgrep) is intraprocedural. The
+interprocedural taint class — path traversal, information exposure,
+SSRF, injection — is covered by external engines (Snyk Code, CodeQL,
+Semgrep Pro, or any SARIF-emitting tool). dxkit does not re-detect that
+class; it **ingests** those findings and makes them first-class. Every
+ingested finding MUST enter through `src/ingest/` so it inherits the one
+fingerprint scheme, cross-tool dedup, baseline, guardrail, report
+rendering, and graph linking that native findings get — never a parallel
+pipeline.
+
+- **Parse** SARIF only via `src/ingest/sarif.ts:parseSarif`. It is the
+  single SARIF reader; every engine (CodeQL / Snyk export / Semgrep Pro
+  / Bearer) funnels through it.
+- **Persist** ingested findings only via
+  `src/ingest/snapshot.ts` (`.dxkit/external/<engine>.json`). The
+  committed snapshot is why an engine token is needed only at ingest
+  time (one CI refresh job), not by every developer.
+- **Normalize** to `SecurityFinding` only via
+  `src/ingest/normalize.ts:externalToSecurityFindings`. Identity is NOT
+  computed here — the security aggregator owns fingerprinting + dedup
+  for every code finding (Rule 9), so ingested + native findings share
+  one identity contract.
+- **Select** the engine via
+  `src/ingest/engine-resolver.ts:resolveDeepSastEngine` — the
+  license-aware resolver (mirror of Rule 11). It never runs CodeQL on a
+  non-public repo without `requiresConsent`.
+- **Declare** per-language engine support via
+  `LanguageSupport.deepSast` (Rule 6); consumers read the union through
+  `activeDeepSast` / `codeqlLanguagesFromFlags` /
+  `anyActivePackSupportsSnykCode` — never a per-language branch.
+
+#### Ingestion enforcement
+
+Two rules in `scripts/check-architecture.sh` (pre-commit + CI), plus
+Rule 9's `createHash` ban covering ingested identity:
+
+1. No `physicalLocation` SARIF walk outside `src/ingest/sarif.ts`
+   (the smoking-gun shape of a hand-rolled SARIF parser). Annotate
+   `// ingest-sarif-ok` for a justified exception.
+2. No `.dxkit/external/` snapshot access outside
+   `src/ingest/snapshot.ts`. Annotate `// ingest-snapshot-ok` for a
+   justified exception.
+
 ## Release procedure
 
 **Every release goes through the CI pipeline. No exceptions.** Local

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ This is an additive, fail-open layer. When the graph is missing, or a language's
 
 dxkit's bundled SAST (community semgrep) is intraprocedural — it can't follow tainted data across function boundaries, so it misses the path-traversal / information-exposure / SSRF / injection class that an interprocedural engine like Snyk Code or CodeQL catches. dxkit doesn't try to re-detect that class; it **ingests** it and makes it first-class.
 
-- **`vyuh-dxkit ingest --from-snyk`** reads your Snyk Code findings via the REST API (no Snyk test quota consumed — it reads stored results). **`--sarif <file>`** ingests SARIF from any engine; **`--codeql`** runs CodeQL on demand (open-source / GitHub Advanced Security).
+- **`vyuh-dxkit ingest --from-snyk`** brings in your Snyk Code findings and works on every Snyk plan: it reads the REST API quota-free where you have it (Enterprise), and on Free/Team plans automatically falls back to `snyk code test` (one test per run). **`--sarif <file>`** ingests SARIF from any engine; **`--codeql`** runs CodeQL on demand (open-source / GitHub Advanced Security).
 - Ingested findings enter the same pipeline as native ones: fingerprinted and deduped, written to the baseline, enforced by the guardrail, and graph-linked under `--graph-context` so the `dxkit-action` fix loop sees blast radius + callers — context the source engine's own autofix doesn't have.
 - The findings live in a committed `.dxkit/external/` snapshot, so the engine token is needed only at ingest time (ideally one on-demand CI job) — every developer and CI run reads the snapshot without it.
 

--- a/README.md
+++ b/README.md
@@ -182,15 +182,16 @@ Orphaned annotations become their own findings. The TypeScript `@ts-expect-error
 
 ### AI-agent integration
 
-dxkit ships nine Claude Code skills under `.claude/skills/dxkit-*`. They wrap the CLI in conversational flows:
+dxkit ships twelve Claude Code skills under `.claude/skills/dxkit-*`. They wrap the CLI in conversational flows:
 
-| Skill                                                                      | What it does                                                            |
-| -------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `dxkit-onboard`                                                            | Walks a customer through the full first-install journey                 |
-| `dxkit-reports`                                                            | Runs analyzers and explains the output                                  |
-| `dxkit-action`                                                             | Reads a report, prioritizes findings, plans and runs fixes, re-verifies |
-| `dxkit-fix`                                                                | Repairs a broken install from doctor output                             |
-| `dxkit-hooks`, `dxkit-config`, `dxkit-learn`, `dxkit-update`, `dxkit-init` | Focused flows                                                           |
+| Skill                                                                                                     | What it does                                                            |
+| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `dxkit-onboard`                                                                                           | Walks a customer through the full first-install journey                 |
+| `dxkit-reports`                                                                                           | Runs analyzers and explains the output                                  |
+| `dxkit-action`                                                                                            | Reads a report, prioritizes findings, plans and runs fixes, re-verifies |
+| `dxkit-ingest`                                                                                            | Brings external SAST findings (Snyk Code, CodeQL, SARIF) into dxkit     |
+| `dxkit-fix`                                                                                               | Repairs a broken install from doctor output                             |
+| `dxkit-feature`, `dxkit-docs`, `dxkit-hooks`, `dxkit-config`, `dxkit-learn`, `dxkit-update`, `dxkit-init` | Focused flows                                                           |
 
 `AGENTS.md` (the open standard read by Codex, Cursor, Aider, and others) also ships in every install. The skill flows are Claude Code-specific today; the AGENTS.md context is portable.
 
@@ -205,6 +206,16 @@ dxkit builds a deterministic code graph of your repo (its symbols, call edges, a
 - **`vyuh-dxkit explore`** and a dashboard graph tab let humans ask the same graph what the repo does, where a feature lives, and which files are load-bearing.
 
 This is an additive, fail-open layer. When the graph is missing, or a language's call edges can't be resolved, every command behaves exactly as it did before. It's reliable on TypeScript, Python, and Go. Where the call graph can't be resolved (C#), blast radius is suppressed rather than faked, so a "no callers" reading is never mistaken for "safe to change."
+
+### Deep SAST: interprocedural findings from any engine
+
+dxkit's bundled SAST (community semgrep) is intraprocedural — it can't follow tainted data across function boundaries, so it misses the path-traversal / information-exposure / SSRF / injection class that an interprocedural engine like Snyk Code or CodeQL catches. dxkit doesn't try to re-detect that class; it **ingests** it and makes it first-class.
+
+- **`vyuh-dxkit ingest --from-snyk`** reads your Snyk Code findings via the REST API (no Snyk test quota consumed — it reads stored results). **`--sarif <file>`** ingests SARIF from any engine; **`--codeql`** runs CodeQL on demand (open-source / GitHub Advanced Security).
+- Ingested findings enter the same pipeline as native ones: fingerprinted and deduped, written to the baseline, enforced by the guardrail, and graph-linked under `--graph-context` so the `dxkit-action` fix loop sees blast radius + callers — context the source engine's own autofix doesn't have.
+- The findings live in a committed `.dxkit/external/` snapshot, so the engine token is needed only at ingest time (ideally one on-demand CI job) — every developer and CI run reads the snapshot without it.
+
+dxkit isn't competing with the detection engine — it's the governance + agentic-fix layer on top of whichever one you can run. The `dxkit-ingest` skill walks through setup and picks the engine license-aware (your own Snyk for private repos; CodeQL for open source / GHAS).
 
 ### Reproducible environments
 
@@ -239,7 +250,7 @@ npx vyuh-dxkit setup-prebuild            # Codespaces prebuild
 À la carte if you only want specific pieces:
 
 ```bash
-npx vyuh-dxkit init --with-dxkit-agents       # just the nine Claude skills + AGENTS.md
+npx vyuh-dxkit init --with-dxkit-agents       # just the twelve Claude skills + AGENTS.md
 npx vyuh-dxkit init --with-hooks              # just the pre-push hook
 npx vyuh-dxkit init --with-precommit-hook     # add pre-commit (slow on large repos)
 npx vyuh-dxkit init --with-devcontainer       # just the per-stack devcontainer

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -135,6 +135,38 @@ splits the resulting `toolsUnavailable` list into "Tools not
 installed" vs "Tools that failed at runtime" so users can act on the
 right thing.
 
+## Deep-SAST ingestion (`src/ingest/`)
+
+dxkit's bundled SAST is intraprocedural; the interprocedural taint class
+comes from external engines (Snyk Code, CodeQL, any SARIF tool) ingested
+through one canonical module. The pipeline is deliberately
+engine-agnostic — engines are _producers_, and nothing downstream
+branches on which one ran:
+
+```
+engine → ExternalFinding (normalize) → SecurityFinding
+       → security aggregate (fingerprint + cross-tool dedup, owned by
+         the aggregator) → baseline / guardrail / report / graph-context
+```
+
+- **Parse** SARIF only in [`sarif.ts`](../src/ingest/sarif.ts); **read Snyk**
+  only in [`snyk-api.ts`](../src/ingest/snyk-api.ts) (a quota-free REST
+  read); **run CodeQL** only in [`codeql.ts`](../src/ingest/codeql.ts).
+- **Persist** to a committed `.dxkit/external/<engine>.json` snapshot via
+  [`snapshot.ts`](../src/ingest/snapshot.ts), so the engine token is needed
+  only at ingest time — every later scan reads the snapshot.
+- **Select** the engine via
+  [`engine-resolver.ts`](../src/ingest/engine-resolver.ts) (license-aware:
+  Snyk for private repos, CodeQL for OSS/GHAS with consent).
+- Per-language engine support is declared by each pack
+  (`LanguageSupport.deepSast`) and CodeQL is a guarded, opt-in tool in the
+  registry — kept out of the default toolchain.
+
+CLAUDE.md **Rule 13** + two arch-gate greps keep this path canonical:
+SARIF parsing and snapshot access can't leak outside `src/ingest/`, and
+ingested findings get identity from the aggregator (Rule 9), never a
+parallel hash.
+
 ## The AnalysisResult cache
 
 Every analyzer command builds (or reads) a cached

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -290,6 +290,14 @@ See [`vyuh-dxkit issue`](commands/issue.md) for full details.
 
 ## What's next
 
+- **Deep SAST** — dxkit's bundled scanner is intraprocedural and misses
+  cross-function taint (path traversal, SSRF, injection). Bring in an
+  interprocedural engine's findings with `npx vyuh-dxkit ingest`:
+  `--from-snyk` (works on every Snyk plan — quota-free REST where you have
+  it, an automatic `snyk code test` fallback on free/team), `--sarif <file>`
+  (any SARIF engine), or `--codeql` (open-source / GHAS). Ingested findings
+  are fingerprinted, baselined, guardrailed, and graph-linked like native
+  ones. The `dxkit-ingest` skill walks through token setup.
 - Per-command pages in [`commands/`](commands/) describe options +
   output shape in detail.
 - [Allowlist reference](commands/allowlist.md) — per-finding

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@ What dxkit ships today and what is planned next. For per-release detail see [`CH
 ### Agent integration
 
 - [x] `AGENTS.md` (open standard, read by Claude Code, Codex, Cursor, Aider)
-- [x] Nine `dxkit-*` Claude Code skills for the read, act, verify loop
+- [x] Twelve `dxkit-*` Claude Code skills for the read, act, verify loop
 - [x] Devcontainer with pinned per-stack toolchains
 - [x] Optional install scripts for AI agent CLIs
 
@@ -67,43 +67,43 @@ detection engines; it makes their output enforceable and fixable.
 ### Engine-agnostic ingestion
 
 - [ ] Normalized external-finding ingestion: one pipeline for findings from
-  Snyk Code, CodeQL, Semgrep Pro, or any SARIF-emitting tool. Findings enter
-  through a single normalize layer, receive identity from the canonical
-  fingerprint helpers, and flow into the same aggregate → baseline → guardrail
-  → report → graph-context path as native findings (no engine-specific
-  branches downstream).
+      Snyk Code, CodeQL, Semgrep Pro, or any SARIF-emitting tool. Findings enter
+      through a single normalize layer, receive identity from the canonical
+      fingerprint helpers, and flow into the same aggregate → baseline → guardrail
+      → report → graph-context path as native findings (no engine-specific
+      branches downstream).
 - [ ] `vyuh-dxkit ingest` (`--from-snyk` / `--sarif <file>` / `--codeql`),
-  writing a sanitized snapshot under `.dxkit/external/` that is committed so
-  every developer and CI run reads it without needing an engine token.
+      writing a sanitized snapshot under `.dxkit/external/` that is committed so
+      every developer and CI run reads it without needing an engine token.
 
 ### Snyk Code ingestion (works on the free tier)
 
 - [ ] Snyk REST API reader — pulls a project's already-computed Code findings
-  using a `SNYK_TOKEN`, consuming no Snyk test quota (it reads stored results,
-  it does not re-scan). An admin adds the token once as a CI secret; a refresh
-  workflow commits the snapshot so all users benefit without a local token.
+      using a `SNYK_TOKEN`, consuming no Snyk test quota (it reads stored results,
+      it does not re-scan). An admin adds the token once as a CI secret; a refresh
+      workflow commits the snapshot so all users benefit without a local token.
 
 ### CodeQL on-demand (open-source / GitHub Advanced Security)
 
 - [ ] CodeQL runner that builds a database and runs the per-language security
-  suite on demand (CI / pre-release, not the hook path), emitting SARIF into
-  the same ingestion pipeline. License-gated: free for open-source repos and
-  for private repos under GitHub Advanced Security; dxkit detects repo
-  visibility and prompts for consent before running on private code.
+      suite on demand (CI / pre-release, not the hook path), emitting SARIF into
+      the same ingestion pipeline. License-gated: free for open-source repos and
+      for private repos under GitHub Advanced Security; dxkit detects repo
+      visibility and prompts for consent before running on private code.
 
 ### Recipe + selection + governance
 
 - [ ] Per-pack engine declaration in `LanguageSupport` (which engines apply to
-  a language, CodeQL query suite, whether a build is required) so adding a
-  language or engine extends the recipe rather than branching analyzer code.
+      a language, CodeQL query suite, whether a build is required) so adding a
+      language or engine extends the recipe rather than branching analyzer code.
 - [ ] License-aware engine resolver that picks the engine from repo visibility,
-  GitHub Advanced Security availability, and token presence — the same
-  canonical-resolver pattern the baseline modes use.
+      GitHub Advanced Security availability, and token presence — the same
+      canonical-resolver pattern the baseline modes use.
 - [ ] Ingested findings linked to the code graph (`--graph-context`) so the
-  agent fix loop sees blast radius and callers for an external engine's
-  findings, then verifies the fix by re-running the analyzer and tests.
+      agent fix loop sees blast radius and callers for an external engine's
+      findings, then verifies the fix by re-running the analyzer and tests.
 - [ ] `dxkit-ingest` skill (token setup, pull, refresh, license guidance) and
-  `dxkit-action` updated to triage and fix ingested + graph-linked findings.
+      `dxkit-action` updated to triage and fix ingested + graph-linked findings.
 
 ### Reachability refinements (carried from 2.8)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,9 +39,7 @@ What dxkit ships today and what is planned next. For per-release detail see [`CH
 - [x] Interactive Graph tab in the dashboard (graphify's viewer, bundled to work offline)
 - [x] `--graph-context` on vulnerabilities, test-gaps, and quality, attaching each finding's module and blast radius to the detailed report (suppressed where a language's call graph cannot be resolved, so a "no callers" reading is never mistaken for "safe to change")
 
-## Next release: 2.8
-
-### Graphify pair (deferred from 2.7)
+### Graphify pair + agent skills (2.8)
 
 - [x] `vyuh-dxkit context <file:line>` command that returns a curated source chunk under a token budget, centered on the requested line, plus the enclosing symbol's callers/callees and blast radius. Replaces "agent ingests 15k-line file" with "agent ingests 500 focused lines."
 - [x] Package-level reachability for dep-vuln triage. Marks a finding `reachable` when its package is imported anywhere in source; the flag feeds the composite risk score. (Refinements pending — see below.)
@@ -53,7 +51,61 @@ Both build on the graph foundation that 2.7 shipped.
 - [x] `dxkit-feature` skill — drives net-new development the way `dxkit-action` drives fixes: orient via the code graph (`context` / `explore`) to find where a feature plugs in and what it touches, then run the analyzers + `guardrail check` on the change so the feature doesn't ship a regression. Degrades gracefully to grep + read when no graph is present; verification never depends on the graph.
 - [x] `dxkit-docs` skill — generates the documentation a repo is missing: reads the Documentation dimension's gaps, orients on the real code via the graph, then writes a grounded README / docstrings / API + architecture docs and re-runs the slop check so generated prose doesn't trade Documentation score for Quality score.
 
-### Reachability refinements (pending)
+## Next release: 2.9 — Deep SAST (engine-agnostic interprocedural findings)
+
+dxkit's bundled SAST (community semgrep) is intraprocedural: it cannot follow
+taint across function boundaries, so it misses the interprocedural class of
+finding — path traversal, information exposure, SSRF, injection — that a
+proprietary engine like Snyk Code or an interprocedural engine like CodeQL
+catches. Rather than try to out-detect those engines, 2.9 makes dxkit the
+**engine-agnostic orchestration layer**: ingest any engine's findings, make
+them first-class (fingerprinted, baselined, guardrailed, graph-linked), and
+fix them through the agent loop — enriched with the repo's own code graph in a
+way the source engine's own autofix cannot match. dxkit does not compete with
+detection engines; it makes their output enforceable and fixable.
+
+### Engine-agnostic ingestion
+
+- [ ] Normalized external-finding ingestion: one pipeline for findings from
+  Snyk Code, CodeQL, Semgrep Pro, or any SARIF-emitting tool. Findings enter
+  through a single normalize layer, receive identity from the canonical
+  fingerprint helpers, and flow into the same aggregate → baseline → guardrail
+  → report → graph-context path as native findings (no engine-specific
+  branches downstream).
+- [ ] `vyuh-dxkit ingest` (`--from-snyk` / `--sarif <file>` / `--codeql`),
+  writing a sanitized snapshot under `.dxkit/external/` that is committed so
+  every developer and CI run reads it without needing an engine token.
+
+### Snyk Code ingestion (works on the free tier)
+
+- [ ] Snyk REST API reader — pulls a project's already-computed Code findings
+  using a `SNYK_TOKEN`, consuming no Snyk test quota (it reads stored results,
+  it does not re-scan). An admin adds the token once as a CI secret; a refresh
+  workflow commits the snapshot so all users benefit without a local token.
+
+### CodeQL on-demand (open-source / GitHub Advanced Security)
+
+- [ ] CodeQL runner that builds a database and runs the per-language security
+  suite on demand (CI / pre-release, not the hook path), emitting SARIF into
+  the same ingestion pipeline. License-gated: free for open-source repos and
+  for private repos under GitHub Advanced Security; dxkit detects repo
+  visibility and prompts for consent before running on private code.
+
+### Recipe + selection + governance
+
+- [ ] Per-pack engine declaration in `LanguageSupport` (which engines apply to
+  a language, CodeQL query suite, whether a build is required) so adding a
+  language or engine extends the recipe rather than branching analyzer code.
+- [ ] License-aware engine resolver that picks the engine from repo visibility,
+  GitHub Advanced Security availability, and token presence — the same
+  canonical-resolver pattern the baseline modes use.
+- [ ] Ingested findings linked to the code graph (`--graph-context`) so the
+  agent fix loop sees blast radius and callers for an external engine's
+  findings, then verifies the fix by re-running the analyzer and tests.
+- [ ] `dxkit-ingest` skill (token setup, pull, refresh, license guidance) and
+  `dxkit-action` updated to triage and fix ingested + graph-linked findings.
+
+### Reachability refinements (carried from 2.8)
 
 - [ ] Per-ecosystem reliability gating: only mark a finding `reachable: false` when its language pack resolves imports reliably (TS / Python / Go). For packs whose import resolution is unreliable (C# namespaces ≠ package names, etc.), leave `reachable` unset rather than risk a false "unreachable" that hides a real vuln.
 - [ ] Reachable-first report framing: a `"N reachable / M total"` summary line and reachable-first sort in the vulnerability report (the per-finding `reachable` glyph already renders).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,7 +51,7 @@ Both build on the graph foundation that 2.7 shipped.
 - [x] `dxkit-feature` skill — drives net-new development the way `dxkit-action` drives fixes: orient via the code graph (`context` / `explore`) to find where a feature plugs in and what it touches, then run the analyzers + `guardrail check` on the change so the feature doesn't ship a regression. Degrades gracefully to grep + read when no graph is present; verification never depends on the graph.
 - [x] `dxkit-docs` skill — generates the documentation a repo is missing: reads the Documentation dimension's gaps, orients on the real code via the graph, then writes a grounded README / docstrings / API + architecture docs and re-runs the slop check so generated prose doesn't trade Documentation score for Quality score.
 
-## Next release: 2.9 — Deep SAST (engine-agnostic interprocedural findings)
+## Shipped in 2.9 — Deep SAST (engine-agnostic interprocedural findings)
 
 dxkit's bundled SAST (community semgrep) is intraprocedural: it cannot follow
 taint across function boundaries, so it misses the interprocedural class of
@@ -66,26 +66,27 @@ detection engines; it makes their output enforceable and fixable.
 
 ### Engine-agnostic ingestion
 
-- [ ] Normalized external-finding ingestion: one pipeline for findings from
+- [x] Normalized external-finding ingestion: one pipeline for findings from
       Snyk Code, CodeQL, Semgrep Pro, or any SARIF-emitting tool. Findings enter
       through a single normalize layer, receive identity from the canonical
       fingerprint helpers, and flow into the same aggregate → baseline → guardrail
       → report → graph-context path as native findings (no engine-specific
       branches downstream).
-- [ ] `vyuh-dxkit ingest` (`--from-snyk` / `--sarif <file>` / `--codeql`),
+- [x] `vyuh-dxkit ingest` (`--from-snyk` / `--sarif <file>` / `--codeql`),
       writing a sanitized snapshot under `.dxkit/external/` that is committed so
       every developer and CI run reads it without needing an engine token.
 
 ### Snyk Code ingestion (works on the free tier)
 
-- [ ] Snyk REST API reader — pulls a project's already-computed Code findings
-      using a `SNYK_TOKEN`, consuming no Snyk test quota (it reads stored results,
-      it does not re-scan). An admin adds the token once as a CI secret; a refresh
-      workflow commits the snapshot so all users benefit without a local token.
+- [x] Snyk Code reader on every plan — the REST API reads already-computed
+      findings quota-free where available (Enterprise); on Free/Team plans it
+      automatically falls back to `snyk code test` (one test per run). Either way
+      a `SNYK_TOKEN` is added once as a CI secret and a refresh workflow commits
+      the snapshot so all users benefit without a local token.
 
 ### CodeQL on-demand (open-source / GitHub Advanced Security)
 
-- [ ] CodeQL runner that builds a database and runs the per-language security
+- [x] CodeQL runner that builds a database and runs the per-language security
       suite on demand (CI / pre-release, not the hook path), emitting SARIF into
       the same ingestion pipeline. License-gated: free for open-source repos and
       for private repos under GitHub Advanced Security; dxkit detects repo
@@ -93,19 +94,26 @@ detection engines; it makes their output enforceable and fixable.
 
 ### Recipe + selection + governance
 
-- [ ] Per-pack engine declaration in `LanguageSupport` (which engines apply to
+- [x] Per-pack engine declaration in `LanguageSupport` (which engines apply to
       a language, CodeQL query suite, whether a build is required) so adding a
       language or engine extends the recipe rather than branching analyzer code.
-- [ ] License-aware engine resolver that picks the engine from repo visibility,
+- [x] License-aware engine resolver that picks the engine from repo visibility,
       GitHub Advanced Security availability, and token presence — the same
       canonical-resolver pattern the baseline modes use.
-- [ ] Ingested findings linked to the code graph (`--graph-context`) so the
+- [x] Ingested findings linked to the code graph (`--graph-context`) so the
       agent fix loop sees blast radius and callers for an external engine's
       findings, then verifies the fix by re-running the analyzer and tests.
-- [ ] `dxkit-ingest` skill (token setup, pull, refresh, license guidance) and
+- [x] `dxkit-ingest` skill (token setup, pull, refresh, license guidance) and
       `dxkit-action` updated to triage and fix ingested + graph-linked findings.
 
-### Reachability refinements (carried from 2.8)
+Also in 2.9 — hardening that makes the guardrail actually fire on brownfield
+repos: `init`/`update` declare `@vyuhlabs/dxkit` as a devDependency so hooks +
+CI resolve a pinned local binary (not a stale global); `hooks activate`
+restores the hook's executable bit (git silently ignores a non-executable
+hook) and `doctor` verifies it; hook activation chains after an existing
+`postinstall`.
+
+## Next release — Reachability refinements (carried from 2.8)
 
 - [ ] Per-ecosystem reliability gating: only mark a finding `reachable: false` when its language pack resolves imports reliably (TS / Python / Go). For packs whose import resolution is unreliable (C# namespaces ≠ package names, etc.), leave `reachable` unset rather than risk a false "unreachable" that hides a real vuln.
 - [ ] Reachable-first report framing: a `"N reachable / M total"` summary line and reachable-first sort in the vulnerability report (the per-finding `reachable` glyph already renders).

--- a/docs/why-dxkit.md
+++ b/docs/why-dxkit.md
@@ -23,7 +23,7 @@ It also matters for compliance. Every deduction in the score is traceable to a s
 Most static analysis tools find issues and stop there. dxkit also writes the project-context layer that lets an AI agent operate intelligently on the codebase:
 
 - `AGENTS.md` (open standard, read by Claude Code, Codex, Cursor, Aider)
-- Nine `dxkit-*` conversational skills for Claude Code that wrap the CLI into read, act, verify loops
+- Twelve `dxkit-*` conversational skills for Claude Code that wrap the CLI into read, act, verify loops
 - Per-stack devcontainer with the toolchain pre-installed
 - A guardrail check that emits structured JSON the agent can self-verify against
 
@@ -44,11 +44,21 @@ dxkit is built on open methodology. Every scoring decision references a public s
 
 Scores are evidence-backed and traceable to the findings that produced them. See [`docs/SCORING.md`](SCORING.md) for the per-dimension methodology and citations.
 
+## 4. It orchestrates any detection engine — it doesn't compete with them
+
+dxkit's bundled SAST is intraprocedural and won't match a proprietary interprocedural engine like Snyk Code or CodeQL on taint findings (path traversal, information exposure, SSRF, injection). dxkit's answer isn't to out-detect them — it's to **ingest** whatever engine you can run and own the layer on top:
+
+- **Engine-agnostic.** `vyuh-dxkit ingest` takes Snyk Code (a quota-free REST read), CodeQL, or any SARIF, and makes those findings first-class — fingerprinted, deduped against native findings, baselined, and guardrailed.
+- **Grounded in your code graph.** Ingested findings get blast radius + callers attached (`--graph-context`), so a fix targets the taint's source boundary and re-tests the right callers. That's context the source engine's own autofix doesn't have.
+- **In your repo, in your loop.** Detection runs where it's licensed (your Snyk for private repos; CodeQL for open source / GHAS); enforcement and the agentic fix loop run locally. No lock-in to one vendor's platform.
+
+Snyk and CodeQL _detect_; dxkit makes their output enforceable and fixable.
+
 ## What dxkit is not
 
 - It is not a SaaS. Every scan runs locally. Nothing leaves the repo.
 - It is not an LLM-graded code review tool. There is no LLM in the grading path.
-- It is not a replacement for the underlying scanners. It runs gitleaks, semgrep, osv-scanner, jscpd, cloc, graphify, and per-ecosystem dep tools. It aggregates, deduplicates, and scores their output.
+- It is not a replacement for the underlying scanners. It runs gitleaks, semgrep, osv-scanner, jscpd, cloc, graphify, and per-ecosystem dep tools — and ingests interprocedural engines (Snyk Code, CodeQL) on top. It aggregates, deduplicates, and scores their output.
 - It is not a one-size-fits-all gate. Three baseline modes (`committed-full`, `committed-sanitized`, `ref-based`) match different repo postures. Five typed allowlist categories handle per-finding exceptions. The brownfield policy is fully tunable via `.dxkit/policy.json`.
 
 ## See also

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "AI-native developer experience toolkit for any codebase",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -977,6 +977,45 @@ if [ -n "$DXKIT_VERSION" ] && [ -n "$LAST_DXKIT_VERSION" ] && [ "$DXKIT_VERSION"
   fi
 fi
 
+# ─── Rule 13: external-findings ingestion flows through src/ingest ──────────
+#
+# External-engine findings (Snyk Code, CodeQL, any SARIF) must enter dxkit
+# only through the canonical ingest module, so they inherit the one
+# fingerprint scheme, dedup, baseline, and graph linking instead of a
+# parallel pipeline:
+#   - SARIF is parsed only by src/ingest/sarif.ts (the `physicalLocation`
+#     walk is the smoking-gun shape of a hand-rolled SARIF parser).
+#   - `.dxkit/external/` snapshots are read/written only by
+#     src/ingest/snapshot.ts.
+# Identity for ingested findings comes from the aggregator (Rule 9), not a
+# local hash — already enforced by the createHash rule.
+
+# 13a: no second SARIF parser (physicalLocation outside src/ingest/sarif.ts).
+RULE13_SARIF=$(grep -rnE "physicalLocation" src/ 2>/dev/null \
+  | grep -v "^src/ingest/sarif.ts:" \
+  | grep -v "// ingest-sarif-ok")
+if [ -n "$RULE13_SARIF" ]; then
+  echo "❌ Rule 13 violation: SARIF parsed outside src/ingest/sarif.ts:"
+  echo "$RULE13_SARIF"
+  echo "   → Use parseSarif() from src/ingest/sarif.ts; don't hand-roll a SARIF walk."
+  echo "   → Annotate '// ingest-sarif-ok' for a justified exception."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# 13b: no snapshot access outside src/ingest/snapshot.ts.
+RULE13_SNAP=$(grep -rnE "\.dxkit/external|'\.dxkit',[[:space:]]*'external'" src/ 2>/dev/null \
+  | grep -v "^src/ingest/snapshot.ts:" \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | grep -v 'logger\.' \
+  | grep -v "// ingest-snapshot-ok")
+if [ -n "$RULE13_SNAP" ]; then
+  echo "❌ Rule 13 violation: .dxkit/external snapshot accessed outside src/ingest/snapshot.ts:"
+  echo "$RULE13_SNAP"
+  echo "   → Use readAllSnapshots()/writeSnapshot() from src/ingest/snapshot.ts."
+  echo "   → Annotate '// ingest-snapshot-ok' for a justified exception."
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ $ERRORS -gt 0 ]; then
   echo ""
   echo "Architecture checks failed. See CLAUDE.md for rules."

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -79,6 +79,15 @@ If the "secret" is actually a placeholder in test code (e.g., `"sk_test_xxxxxxxx
 
 If the finding is a true false positive or intentional pattern (test fixture, mitigated externally), suppress via dxkit's allowlist — NOT via semgrep's `// nosemgrep:`. The dxkit allowlist is the canonical surface (single source of truth across every scanner), carries a typed category + reason, and is audit-trackable through `vyuh-dxkit allowlist audit`. See "Allowlisting (when fix is not viable)" below.
 
+### Ingested SAST finding (Snyk Code / CodeQL)
+
+Interprocedural findings ingested from an external engine (`tool: snyk-code` / `codeql`, brought in via the `dxkit-ingest` skill) appear in the report exactly like native code findings — same fingerprint, same allowlist, same baseline. Fix them the same way, with two differences that make them easier, not harder:
+
+- **They're taint findings, so trace the flow, don't just patch the sink.** The title names a source→sink path (e.g. "file data flows to an HTTP response"). Fixing only the flagged line often misses the real fix — sanitize/validate at the boundary the taint enters, then confirm the path is broken.
+- **Lean on `--graph-context`.** Run `npx vyuh-dxkit vulnerabilities --detailed --graph-context` so each ingested finding carries its enclosing symbol + blast radius (caller files). This is context the source engine's own autofix doesn't have: it tells you which callers to re-test after the fix and whether the change is high-blast-radius. Use it to plan the fix and to scope step [5] verification.
+
+Verify by re-running the engine (re-ingest) — a graph-only or semgrep re-run won't confirm an interprocedural fix landed.
+
 ### Dependency vulnerability
 
 ```bash

--- a/src-templates/.claude/skills/dxkit-config/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-config/SKILL.md
@@ -109,6 +109,29 @@ Each finding-kind has `block` (exit 1) and `warn` (log only) lists. Adjust to yo
 
 Run `npx vyuh-dxkit guardrail check --policy=.dxkit/policy.json` to test the new policy. If no `policy.json` exists, dxkit uses the built-in defaults.
 
+## Configuring deep-SAST ingestion (`.vyuh-dxkit.json:deepSast`)
+
+dxkit's bundled SAST is intraprocedural; interprocedural findings (path traversal, info exposure, SSRF, injection) come from an external engine (Snyk Code or CodeQL) ingested via the `dxkit-ingest` skill. Persist the engine + Snyk project once so `ingest --from-snyk` needs no flags:
+
+```jsonc
+// .vyuh-dxkit.json
+{
+  "deepSast": {
+    "engine": "snyk-code",            // or "codeql" (OSS / GitHub Advanced Security only)
+    "snyk": { "orgId": "…", "projectId": "…" }   // from the Snyk UI; NOT the token
+  }
+}
+```
+
+This file is committed and safe — the `SNYK_TOKEN` is **never** stored here; it lives only in the environment (locally) or as a CI secret. CLI flags (`--org`/`--project`) always override config.
+
+How it ties into the rest of the config surface:
+- **Hooks / CI** (see the `dxkit-hooks` skill): the pre-push hook + PR gate enforce against the committed `.dxkit/external/<engine>.json` snapshot — they never run the heavy engine. The engine runs in a separate CI refresh job (or on demand) that re-ingests and commits the snapshot.
+- **What blocks a PR**: ingested findings are code findings, so `.dxkit/policy.json` severity rules apply to them exactly as to native findings.
+- **Excluding noise**: `.dxkit-ignore` paths apply to ingested findings too (a finding in an ignored path is dropped).
+
+To set this up end to end (token, first ingest, baseline, refresh job), hand off to the **dxkit-ingest** skill.
+
 ## Pointing dxkit at a custom tool directory (`.dxkit/tools.json`)
 
 By default dxkit finds scanner binaries (gitleaks, semgrep, jscpd, osv-scanner, cloc, …) on `PATH` and in the usual per-ecosystem locations (npm global, pipx `~/.local/bin`, cargo, go, brew). When tools live somewhere else — a corp-managed directory, a project-local toolbox, or a locked-down Windows box where you can't write to the default locations — declare it here:

--- a/src-templates/.claude/skills/dxkit-ingest/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-ingest/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: dxkit-ingest
+description: Bring an external interprocedural-SAST engine's findings (Snyk Code, CodeQL, or any SARIF) into dxkit so they're fingerprinted, baselined, guardrailed, graph-linked, and fixable. Use when the user says "ingest Snyk", "pull our Snyk Code findings", "import a SARIF file", "run CodeQL and bring it in", or asks why dxkit's SAST finds less than Snyk/CodeQL.
+---
+
+# dxkit-ingest
+
+dxkit's bundled SAST (community semgrep) is **intraprocedural** — it cannot follow tainted data across function boundaries. The findings that dominate a Snyk Code or CodeQL report (path traversal, information exposure, SSRF, injection) are **interprocedural** and live outside that engine. This skill brings those findings INTO dxkit so they become first-class: fingerprinted, deduped against native findings, written to the baseline, enforced by the guardrail, linked to the code graph, and fixable through `dxkit-action`.
+
+dxkit is not re-detecting — it's orchestrating. The detection engine stays whatever the customer can run; dxkit owns the governance + agentic-fix loop on top of it.
+
+## Pick the engine (license-aware)
+
+Run the resolver's logic before ingesting:
+
+| Situation | Engine | Why |
+|---|---|---|
+| Customer already runs **Snyk** (any tier, incl. free) | **Snyk Code via REST** | Reads stored findings — consumes **no** Snyk test quota. Their own license. |
+| **Open-source** repo | **CodeQL on-demand** | CodeQL's CLI is licensed for open source. |
+| **Private** repo with **GitHub Advanced Security** | **CodeQL on-demand** | GHAS covers private-repo CodeQL. Confirm consent first. |
+| Private repo, no GHAS, no Snyk | stay on community semgrep | No licensed interprocedural engine available. Don't run CodeQL on private code without GHAS. |
+
+**Never run CodeQL against a non-public repo without confirming the user has GitHub Advanced Security.** dxkit prompts for this; honor it.
+
+## Path A — ingest Snyk Code (quota-free, works on the free tier)
+
+The findings already exist in the customer's Snyk project (the Snyk UI is a view over them). Read them via the API — do NOT re-scan (that burns their capped Code-test quota).
+
+```bash
+# Token: a free personal API token from Snyk → Account settings → API token.
+export SNYK_TOKEN=...        # in CI, add this once as a repo/org Actions secret
+# org id: Snyk → Settings → Organization ID
+# project id: the project page URL in the Snyk UI
+npx vyuh-dxkit ingest --from-snyk --org <org-id> --project <project-id>
+```
+
+This writes `.dxkit/external/snyk-code.json`. **Commit it** — every developer and CI run then reads the findings WITHOUT needing the token; only whoever runs `ingest` (ideally one CI refresh job) needs it.
+
+If the read fails with an auth error, the token scheme may differ for the tenant — surface the exact API error to the user rather than guessing.
+
+## Path B — ingest a SARIF file (any engine)
+
+For CodeQL, a Snyk SARIF export, Semgrep Pro, Bearer, or anything that emits SARIF 2.1.0:
+
+```bash
+npx vyuh-dxkit ingest --sarif results.sarif      # engine auto-detected from the SARIF
+npx vyuh-dxkit ingest --sarif results.sarif --engine codeql   # or force the label
+```
+
+### Producing the SARIF with CodeQL (OSS / GHAS only)
+
+CodeQL is heavy (~database build + analysis; tens of minutes). Run it on demand / in CI, never on the pre-push hook.
+
+```bash
+codeql database create db --language=javascript-typescript --source-root=.
+codeql database analyze db \
+  codeql/javascript-queries:codeql-suites/javascript-security-extended.qls \
+  --format=sarifv2.1.0 --output=codeql.sarif
+npx vyuh-dxkit ingest --sarif codeql.sarif
+```
+
+Compiled languages (Java, C#, Kotlin, Go) need a working build for CodeQL extraction; JS/TS, Python, Ruby do not.
+
+## After ingesting — the loop
+
+```
+[1] Ingest        → .dxkit/external/<engine>.json (commit it)
+[2] See them      → npx vyuh-dxkit vulnerabilities --graph-context
+[3] Fix them      → hand off to dxkit-action (graph-linked: blast radius + callers)
+[4] Lock the line → baseline picks them up; guardrail blocks net-new regressions
+```
+
+Ingested findings flow through the same aggregate as native findings, so they appear in the vulnerability report (with the engine as the `tool`), get a stable fingerprint, dedupe against any overlapping semgrep finding, and — with `--graph-context` — carry the enclosing symbol + blast radius the agent needs to fix safely. That graph enrichment is the part the source engine's own autofix doesn't have.
+
+## Keeping it fresh (CI)
+
+Add a scheduled refresh (mirrors `dxkit-baseline-refresh`): a CI job with the `SNYK_TOKEN` secret runs `ingest --from-snyk` and commits the updated snapshot. The ingested findings are a point-in-time snapshot of the engine's last scan — re-ingest after the engine re-scans.
+
+## Hand-offs
+
+- To fix the ingested findings → `dxkit-action` (it reads them like any code finding).
+- For token / secret setup questions → `dxkit-config`.
+- For the broader read→act→verify loop → `dxkit-reports` then `dxkit-action`.

--- a/src-templates/.claude/skills/dxkit-ingest/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-ingest/SKILL.md
@@ -22,21 +22,37 @@ Run the resolver's logic before ingesting:
 
 **Never run CodeQL against a non-public repo without confirming the user has GitHub Advanced Security.** dxkit prompts for this; honor it.
 
-## Path A — ingest Snyk Code (quota-free, works on the free tier)
-
-The findings already exist in the customer's Snyk project (the Snyk UI is a view over them). Read them via the API — do NOT re-scan (that burns their capped Code-test quota).
+## Path A — ingest Snyk Code
 
 ```bash
-# Token: a free personal API token from Snyk → Account settings → API token.
+# Token: a Snyk API token from Snyk → Account settings → API token.
+# dxkit reads it from the ENVIRONMENT — it does NOT auto-load a .env file.
 export SNYK_TOKEN=...        # in CI, add this once as a repo/org Actions secret
-# org id: Snyk → Settings → Organization ID
-# project id: the project page URL in the Snyk UI
+# org/project resolve from the flag, then .vyuh-dxkit.json, then the
+# environment (SNYK_ORG_ID / SNYK_PROJECT_ID) — so an exported shell needs
+# no flags. The project id is the project page URL in the Snyk UI.
 npx vyuh-dxkit ingest --from-snyk --org <org-id> --project <project-id>
 ```
 
-This writes `.dxkit/external/snyk-code.json`. **Commit it** — every developer and CI run then reads the findings WITHOUT needing the token; only whoever runs `ingest` (ideally one CI refresh job) needs it.
+`--from-snyk` works on **every Snyk plan**, two ways:
 
-If the read fails with an auth error, the token scheme may differ for the tenant — surface the exact API error to the user rather than guessing.
+- **REST API (quota-free)** — reads stored findings without consuming the
+  org's Snyk Code test quota. But REST API access is a **Snyk Enterprise**
+  entitlement; on Free/Team plans the read returns 403.
+- **CLI fallback (free/team)** — on that 403 dxkit automatically falls back to
+  `snyk code test` (the Snyk Code *product* entitlement that free includes),
+  which writes SARIF dxkit ingests. This **does** cost one Snyk Code test from
+  the quota per run, and only needs the org (no project id). Pass `--snyk-cli`
+  to force this path and skip the REST attempt. dxkit installs the Snyk CLI on
+  demand if it's missing.
+
+So on a free-tier customer, `--from-snyk` "just works" — it tries REST, hits
+403, and runs the CLI test. Either way it writes `.dxkit/external/snyk-code.json`.
+**Commit it** — every developer and CI run then reads the findings WITHOUT a
+token; only whoever runs `ingest` (ideally one CI refresh job) needs it.
+
+If `SNYK_TOKEN` is unset, dxkit says so explicitly — `export` it (or set the CI
+secret); it will not read a `.env` file for you.
 
 ## Path B — ingest a SARIF file (any engine)
 
@@ -74,7 +90,7 @@ Ingested findings flow through the same aggregate as native findings, so they ap
 
 ## Keeping it fresh (CI)
 
-Add a scheduled refresh (mirrors `dxkit-baseline-refresh`): a CI job with the `SNYK_TOKEN` secret runs `ingest --from-snyk` and commits the updated snapshot. The ingested findings are a point-in-time snapshot of the engine's last scan — re-ingest after the engine re-scans.
+Add a scheduled refresh (mirrors `dxkit-baseline-refresh`): a CI job with the `SNYK_TOKEN` secret runs `ingest --from-snyk` and commits the updated snapshot. The bundled `--with-deep-sast-refresh` workflow (`workflow_dispatch`) does exactly this; its `method` input picks `api` (Enterprise, quota-free) or `cli` (free/team, one test per run). The ingested findings are a point-in-time snapshot of the engine's last scan — re-ingest after the engine re-scans.
 
 ## Hand-offs
 

--- a/src-templates/.claude/skills/dxkit-update/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-update/SKILL.md
@@ -94,6 +94,16 @@ If any step fails, **stop**. Don't continue with downstream steps. Surface:
 - Which step failed + its stderr
 - Suggested recovery: "Run `npx vyuh-dxkit doctor` to see current state, or invoke the `dxkit-fix` skill to walk through repair."
 
+**Peer-dep ERESOLVE on the binary install.** The most common failure on a
+brownfield Node repo: `npm install @vyuhlabs/dxkit@<version>` aborts with
+`npm error code ERESOLVE` from a conflict in the project's *own* existing
+dependency tree (not dxkit's). It's a pre-existing conflict the upgrade
+merely surfaces. Recovery: retry the same command with `--legacy-peer-deps`
+(npm's own error message also suggests this), then persist the choice so
+future installs don't re-hit it: `echo "legacy-peer-deps=true" >> .npmrc`.
+After it succeeds, continue the loop. (`doctor` flags a missing `.npmrc`
+persistence as its own operational check.)
+
 ### 6. Verify with doctor
 
 If all steps succeeded, run `npx vyuh-dxkit doctor` and report. If doctor surfaces operational issues post-upgrade (e.g. `summary.fixable[]` not empty), **hand off to dxkit-fix** — say "Upgrade complete, but doctor surfaced N gaps. Walking through dxkit-fix to close them."

--- a/src-templates/.github/workflows/dxkit-deep-sast-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-deep-sast-refresh.yml
@@ -1,0 +1,80 @@
+name: dxkit deep-SAST refresh
+
+# Periodically re-ingest interprocedural SAST findings (Snyk Code) into
+# `.dxkit/external/` and commit the snapshot. The committed snapshot is
+# what the pre-push hook and the PR guardrail enforce against, so this
+# job is the ONE place the external engine's token is needed — every
+# developer and CI run reads the snapshot without it.
+#
+# Setup (one-time, by an admin):
+#   1. Add a repository (or organization) secret `SNYK_TOKEN`
+#      (Settings → Secrets and variables → Actions). The token is never
+#      committed — it lives only here.
+#   2. Set the project in `.vyuh-dxkit.json`:
+#        { "deepSast": { "snyk": { "orgId": "…", "projectId": "…" } } }
+#
+# Reading the Snyk API does NOT consume the org's Snyk Code test quota.
+# The auto-commit carries `[skip ci]` so it doesn't re-trigger CI.
+#
+# This runs ON DEMAND only — trigger it from the Actions tab (Run
+# workflow). To also refresh on a schedule, uncomment the `schedule:`
+# block below.
+
+on:
+  workflow_dispatch: {}
+  # schedule:
+  #   - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install dxkit
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          elif [ -f package.json ]; then
+            npm install
+          else
+            npm install -g @vyuhlabs/dxkit
+          fi
+
+      - name: Ingest Snyk Code findings (quota-free read)
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          if [ -z "${SNYK_TOKEN}" ]; then
+            echo "SNYK_TOKEN secret is not set — skipping deep-SAST refresh."
+            echo "Add it under Settings → Secrets and variables → Actions to enable."
+            exit 0
+          fi
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            DXKIT=./node_modules/.bin/vyuh-dxkit
+          else
+            DXKIT=vyuh-dxkit
+          fi
+          # org/project come from .vyuh-dxkit.json:deepSast.snyk
+          "${DXKIT}" ingest --from-snyk
+
+      - name: Commit and push refreshed snapshot
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- .dxkit/external/; then
+            echo "Ingested snapshot unchanged — nothing to commit."
+            exit 0
+          fi
+          git add .dxkit/external/
+          git commit -m "chore(deep-sast): refresh ingested findings [skip ci]"
+          git push

--- a/src-templates/.github/workflows/dxkit-deep-sast-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-deep-sast-refresh.yml
@@ -10,18 +10,35 @@ name: dxkit deep-SAST refresh
 #   1. Add a repository (or organization) secret `SNYK_TOKEN`
 #      (Settings → Secrets and variables → Actions). The token is never
 #      committed — it lives only here.
-#   2. Set the project in `.vyuh-dxkit.json`:
+#   2. Set the org/project in `.vyuh-dxkit.json`:
 #        { "deepSast": { "snyk": { "orgId": "…", "projectId": "…" } } }
 #
-# Reading the Snyk API does NOT consume the org's Snyk Code test quota.
+# Two read methods (pick via the `method` input when running on demand):
+#   - api (default): read stored findings over the Snyk REST API. Does NOT
+#     consume the org's Snyk Code test quota — but REST API access is an
+#     Enterprise-tier entitlement. On other plans the read 403s and dxkit
+#     auto-falls-back to the CLI method below.
+#   - cli: run `snyk code test` on the checkout (Snyk Code *product*
+#     entitlement, which free/team plans include). Costs one Snyk Code
+#     test from the quota per run. Needs only the org (no project id).
+#
 # The auto-commit carries `[skip ci]` so it doesn't re-trigger CI.
 #
 # This runs ON DEMAND only — trigger it from the Actions tab (Run
 # workflow). To also refresh on a schedule, uncomment the `schedule:`
-# block below.
+# block below; scheduled runs use the default method (`api`, which
+# auto-falls-back to the CLI on non-Enterprise plans).
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      method:
+        description: 'Read method: api (quota-free, Enterprise) or cli (one test/run, free-tier)'
+        type: choice
+        default: api
+        options:
+          - api
+          - cli
   # schedule:
   #   - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
 
@@ -50,9 +67,10 @@ jobs:
             npm install -g @vyuhlabs/dxkit
           fi
 
-      - name: Ingest Snyk Code findings (quota-free read)
+      - name: Ingest Snyk Code findings
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          METHOD: ${{ github.event.inputs.method || 'api' }}
         run: |
           if [ -z "${SNYK_TOKEN}" ]; then
             echo "SNYK_TOKEN secret is not set — skipping deep-SAST refresh."
@@ -64,8 +82,14 @@ jobs:
           else
             DXKIT=vyuh-dxkit
           fi
-          # org/project come from .vyuh-dxkit.json:deepSast.snyk
-          "${DXKIT}" ingest --from-snyk
+          # org/project come from .vyuh-dxkit.json:deepSast.snyk. The api
+          # method auto-falls-back to the CLI on plans without REST access;
+          # the cli method forces `snyk code test` (one test from quota).
+          if [ "${METHOD}" = "cli" ]; then
+            "${DXKIT}" ingest --from-snyk --snyk-cli
+          else
+            "${DXKIT}" ingest --from-snyk
+          fi
 
       - name: Commit and push refreshed snapshot
         run: |

--- a/src/analyzers/cache.ts
+++ b/src/analyzers/cache.ts
@@ -299,6 +299,18 @@ function isWorkingTreeDirty(cwd: string): boolean {
       const m = /^\?\? (.+)$/.exec(line);
       if (!m) return true;
       const segments = stripTrailingSlash(m[1]).split('/');
+      // `.dxkit/external/` holds ingested external-engine findings
+      // (Snyk Code, CodeQL). Unlike dxkit's self-populated outputs
+      // (cache/, reports/, dashboard/), these are a gather INPUT — they
+      // add findings to the aggregate — so a new/changed snapshot MUST
+      // invalidate the cache. Without this, `ingest` followed by
+      // `vulnerabilities` / `health` / `baseline` silently reuses a
+      // pre-ingest cache and the ingested findings never surface.
+      // Handles nesting (a monorepo's `Code/.dxkit/external/`).
+      const isExternalSnapshot = segments.some(
+        (seg, i) => seg === '.dxkit' && segments[i + 1] === 'external',
+      );
+      if (isExternalSnapshot) return true;
       return !segments.some((seg) => seg === '.dxkit' || seg === '.dxkit-ignore');
     });
     return lines.length > 0;

--- a/src/analyzers/security/aggregator.ts
+++ b/src/analyzers/security/aggregator.ts
@@ -127,6 +127,12 @@ export interface DedupCollision {
 export interface AggregateProvenance {
   secrets: { tool: string | null; ran: boolean };
   codePatterns: { tool: string | null; ran: boolean };
+  /** Ingested external-engine provenance. `tools` is the set of
+   *  engines whose findings were ingested this run (e.g. `['codeql']`,
+   *  `['snyk-code']`); `ran` is true when ingestion contributed. Always
+   *  populated by `buildSecurityAggregate`; optional in the type only so
+   *  pre-existing test mocks needn't be rewritten. */
+  external?: { tools: string[]; ran: boolean };
   tlsBypass: { ran: boolean; patternCount: number };
   fileFindings: { ran: boolean };
   depVulns: { tool: string | null; available: boolean; unavailableReason: string };
@@ -236,6 +242,14 @@ export interface SecurityAggregateInput {
   secrets: { findings: SecurityFinding[]; toolUsed: string | null };
   fileFindings: SecurityFinding[];
   codePatterns: { findings: SecurityFinding[]; toolUsed: string | null };
+  /** Findings ingested from external interprocedural-SAST engines
+   *  (Snyk Code, CodeQL, …) via `src/ingest`. Already mapped to
+   *  `SecurityFinding` with the engine as the `tool`. They join the
+   *  same code-side dedup pipeline as native findings, so a Snyk and a
+   *  semgrep finding on the same line collapse to one `CodeFinding`.
+   *  Optional: absent (or empty) yields output identical to a run with
+   *  no ingestion configured. */
+  external?: { findings: SecurityFinding[]; toolsUsed: string[] };
   tlsBypass: SecurityFinding[];
   /** Pattern count from `allTlsBypassPatterns()` — drives the
    *  `provenance.tlsBypass.ran` flag (ran=false when no patterns were
@@ -277,6 +291,7 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
     ...input.secrets.findings,
     ...input.fileFindings,
     ...input.codePatterns.findings,
+    ...(input.external?.findings ?? []),
     ...input.tlsBypass,
   ];
 
@@ -454,6 +469,10 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
     codePatterns: {
       tool: input.codePatterns.toolUsed,
       ran: input.codePatterns.toolUsed !== null,
+    },
+    external: {
+      tools: input.external?.toolsUsed ?? [],
+      ran: (input.external?.toolsUsed.length ?? 0) > 0,
     },
     tlsBypass: {
       // ran=true means the registry walk happened (patterns existed).

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -17,6 +17,8 @@ import { resolveAliases } from '../tools/osv';
 import { buildReachablePackageSet, markReachable } from '../tools/reachability';
 import { scoreFindings } from '../tools/risk-score';
 import { resolveTransitiveUpgradePlans } from '../tools/upgrade-plan-resolver';
+import { externalToSecurityFindings } from '../../ingest/normalize';
+import { readAllSnapshots, snapshotEngines } from '../../ingest/snapshot';
 import { getFindExcludeFlags } from '../tools/exclusions';
 import { walkSourceFiles, commentSyntaxFor, isCommentLine } from '../tools/walk-source-files';
 import * as path from 'path';
@@ -566,10 +568,17 @@ export async function buildSecurityAggregateForHealth(
       }))
     : [];
 
+  // Ingested external-engine findings (Snyk Code / CodeQL / SARIF) read
+  // from committed `.dxkit/external/` snapshots. Absent → empty → the
+  // aggregate is byte-identical to a run with no ingestion configured.
+  const externalFindings = externalToSecurityFindings(readAllSnapshots(cwd));
+  const externalEngines = snapshotEngines(cwd);
+
   return buildSecurityAggregate({
     secrets: { findings: secretFindings, toolUsed: secrets?.tool ?? null },
     fileFindings,
     codePatterns: { findings: codeFindings, toolUsed: codePatterns?.tool ?? null },
+    external: { findings: externalFindings, toolsUsed: externalEngines },
     tlsBypass,
     tlsBypassPatternCount: allTlsBypassPatterns().length,
     depVulns: {

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -1034,6 +1034,30 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
       windows: 'gem install --user-install simplecov',
     },
   },
+  snyk: {
+    name: 'snyk',
+    description: 'Snyk CLI — Snyk Code (SAST) test, free-tier deep-SAST path (opt-in)',
+    install: 'npm install -g snyk',
+    check: 'snyk --version',
+    for: 'all',
+    layer: 'optional',
+    binaries: ['snyk'],
+    versionCheck: 'snyk --version',
+    // Opt-in deep-SAST engine. Reports `n/a` until a caller opts in
+    // (`ingest --from-snyk` falls back to the CLI / `tools install snyk`
+    // set DXKIT_SNYK_CLI), so a normal `tools install` never pulls it.
+    // Detection + install still flow through findTool/the registry per
+    // Rule 1 once opted in.
+    applicabilityGuard: (_cwd: string): string | null =>
+      process.env.DXKIT_SNYK_CLI === '1'
+        ? null
+        : 'opt-in deep-SAST engine — run `vyuh-dxkit ingest --from-snyk` or `tools install snyk`',
+    installCommands: {
+      macos: 'npm install -g snyk',
+      linux: 'npm install -g snyk',
+      windows: 'npm install -g snyk',
+    },
+  },
   codeql: {
     name: 'codeql',
     description: 'Interprocedural SAST engine (deep-SAST, opt-in)',

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -1034,6 +1034,37 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
       windows: 'gem install --user-install simplecov',
     },
   },
+  codeql: {
+    name: 'codeql',
+    description: 'Interprocedural SAST engine (deep-SAST, opt-in)',
+    install: 'see installCommands (downloads the CodeQL bundle)',
+    check: 'codeql version',
+    for: 'all',
+    layer: 'optional',
+    binaries: ['codeql'],
+    probePaths: [`${path.join(os.homedir(), '.cache', 'dxkit', 'codeql')}`],
+    versionCheck: 'codeql version --format=terse',
+    // Opt-in deep-SAST engine: ~1GB download, minutes-long runs, and
+    // license-gated for private repos (GitHub Advanced Security). Kept
+    // OUT of the default toolchain — reports `n/a` until a caller opts
+    // in (`ingest --codeql` / `tools install codeql` set DXKIT_CODEQL),
+    // so a normal `tools install` never pulls it. Detection still flows
+    // through findTool/the registry per Rule 1 once opted in.
+    applicabilityGuard: (_cwd: string): string | null =>
+      process.env.DXKIT_CODEQL === '1'
+        ? null
+        : 'opt-in deep-SAST engine — run `vyuh-dxkit ingest --codeql` or `tools install codeql`',
+    installCommands: {
+      // Download the CodeQL bundle (CLI + precompiled query packs) into
+      // the dxkit cache and symlink the launcher onto the user path.
+      macos:
+        'mkdir -p "$HOME/.cache/dxkit" && curl -sSfL https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-osx64.tar.gz | tar xz -C "$HOME/.cache/dxkit" && mkdir -p "$HOME/.local/bin" && ln -sf "$HOME/.cache/dxkit/codeql/codeql" "$HOME/.local/bin/codeql"',
+      linux:
+        'mkdir -p "$HOME/.cache/dxkit" && curl -sSfL https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-linux64.tar.gz | tar xz -C "$HOME/.cache/dxkit" && mkdir -p "$HOME/.local/bin" && ln -sf "$HOME/.cache/dxkit/codeql/codeql" "$HOME/.local/bin/codeql"',
+      windows:
+        'powershell -Command "New-Item -ItemType Directory -Force $HOME/.cache/dxkit; Invoke-WebRequest -Uri https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-win64.tar.gz -OutFile $env:TEMP/codeql.tar.gz; tar xz -C $HOME/.cache/dxkit -f $env:TEMP/codeql.tar.gz"',
+    },
+  },
 };
 
 // =============================================================================

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -316,6 +316,12 @@ export async function run(argv: string[]): Promise<void> {
       depth: { type: 'string' },
       // graph-context enrichment for detailed reports (vuln/test-gaps/quality)
       'graph-context': { type: 'boolean', default: false },
+      // ingest flags (external SAST engines → .dxkit/external snapshots)
+      sarif: { type: 'string' },
+      'from-snyk': { type: 'boolean', default: false },
+      engine: { type: 'string' },
+      org: { type: 'string' },
+      project: { type: 'string' },
       // baseline create: proceed despite missing scanners (CI/non-interactive)
       'allow-incomplete': { type: 'boolean', default: false },
     },
@@ -1907,6 +1913,32 @@ export async function run(argv: string[]): Promise<void> {
       await runAllowlist(cwd, positionals[1], {
         positionalAfter: positionals[2],
         values: values as Record<string, unknown>,
+      });
+      break;
+    }
+
+    case 'ingest': {
+      const targetPath = resolveRepoPath(positionals[1]);
+      const { runIngest } = await import('./ingest-cli');
+      const { execSync } = await import('child_process');
+      let commitSha: string | undefined;
+      try {
+        commitSha = execSync('git rev-parse HEAD', {
+          cwd: targetPath,
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'ignore'],
+        }).trim();
+      } catch {
+        commitSha = undefined;
+      }
+      await runIngest(targetPath, {
+        sarif: values.sarif as string | undefined,
+        fromSnyk: !!values['from-snyk'],
+        engine: values.engine as string | undefined,
+        org: values.org as string | undefined,
+        project: values.project as string | undefined,
+        generatedAt: new Date().toISOString(),
+        commitSha,
       });
       break;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import {
   installDevcontainer,
   installCiGuardrails,
   installCiBaselineRefresh,
+  installCiDeepSastRefresh,
   installPrReview,
   installIgnoreFiles,
   installHooksPostinstall,
@@ -193,6 +194,7 @@ function printUsage(): void {
     --with-ci                 Install .github/workflows/dxkit-guardrails.yml
                               (PR-gate that posts a markdown summary comment)
     --with-baseline-refresh   Install .github/workflows/dxkit-baseline-refresh.yml
+    --with-deep-sast-refresh  Install .github/workflows/dxkit-deep-sast-refresh.yml (Snyk/CodeQL ingest; opt-in)
     --with-pr-review          Install .github/workflows/pr-review.yml (AI PR review; opt-in)
                               (post-merge auto-regen of .dxkit/baselines/main.json)
     --detect                  Auto-detect stack, minimal prompts
@@ -283,6 +285,7 @@ export async function run(argv: string[]): Promise<void> {
       'with-dxkit-agents': { type: 'boolean', default: false },
       'with-ci': { type: 'boolean', default: false },
       'with-baseline-refresh': { type: 'boolean', default: false },
+      'with-deep-sast-refresh': { type: 'boolean', default: false },
       'with-pr-review': { type: 'boolean', default: false },
       // setup-branch-protection flags
       branch: { type: 'string' },
@@ -466,6 +469,15 @@ export async function run(argv: string[]): Promise<void> {
         shipResults.push({
           label: 'AI PR-review workflow',
           result: installPrReview(cwd, { force: !!values.force }),
+        });
+      }
+      // Opt-in even under --full: the workflow is inert without a
+      // SNYK_TOKEN secret + deepSast config, so shipping it by default
+      // just clutters the Actions tab (same rationale as pr-review).
+      if (values['with-deep-sast-refresh']) {
+        shipResults.push({
+          label: 'CI deep-SAST refresh workflow',
+          result: installCiDeepSastRefresh(cwd, { force: !!values.force }),
         });
       }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -322,6 +322,7 @@ export async function run(argv: string[]): Promise<void> {
       // ingest flags (external SAST engines → .dxkit/external snapshots)
       sarif: { type: 'string' },
       'from-snyk': { type: 'boolean', default: false },
+      'snyk-cli': { type: 'boolean', default: false },
       codeql: { type: 'boolean', default: false },
       engine: { type: 'string' },
       org: { type: 'string' },
@@ -1947,6 +1948,7 @@ export async function run(argv: string[]): Promise<void> {
       await runIngest(targetPath, {
         sarif: values.sarif as string | undefined,
         fromSnyk: !!values['from-snyk'],
+        snykCli: !!values['snyk-cli'],
         codeql: !!values.codeql,
         engine: values.engine as string | undefined,
         org: values.org as string | undefined,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ import {
   installPrReview,
   installIgnoreFiles,
   installHooksPostinstall,
+  installDxkitDevDependency,
 } from './ship-installers';
 import type { ShipInstallResult } from './ship-installers';
 import * as fs from 'fs';
@@ -479,6 +480,18 @@ export async function run(argv: string[]): Promise<void> {
         shipResults.push({
           label: 'CI deep-SAST refresh workflow',
           result: installCiDeepSastRefresh(cwd, { force: !!values.force }),
+        });
+      }
+
+      // dxkit must resolve project-locally for the hooks + CI guardrail
+      // to run a pinned version (both prefer ./node_modules/.bin over a
+      // global). Add it to devDependencies whenever a surface that
+      // invokes it is installed. No-ops for non-Node repos and when the
+      // consumer already declares the dep.
+      if (wantHooks || wantCi) {
+        shipResults.push({
+          label: 'dxkit devDependency',
+          result: installDxkitDevDependency(cwd, { force: !!values.force }),
         });
       }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -319,6 +319,7 @@ export async function run(argv: string[]): Promise<void> {
       // ingest flags (external SAST engines → .dxkit/external snapshots)
       sarif: { type: 'string' },
       'from-snyk': { type: 'boolean', default: false },
+      codeql: { type: 'boolean', default: false },
       engine: { type: 'string' },
       org: { type: 'string' },
       project: { type: 'string' },
@@ -1934,6 +1935,7 @@ export async function run(argv: string[]): Promise<void> {
       await runIngest(targetPath, {
         sarif: values.sarif as string | undefined,
         fromSnyk: !!values['from-snyk'],
+        codeql: !!values.codeql,
         engine: values.engine as string | undefined,
         org: values.org as string | undefined,
         project: values.project as string | undefined,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -155,6 +155,22 @@ function readHooksPath(cwd: string): string | null {
 }
 
 /**
+ * Whether a hook file carries the executable bit. Git silently ignores
+ * a non-executable hook, so this is a hard prerequisite for the hook to
+ * fire. On Windows the bit isn't a meaningful filesystem attribute (git
+ * tracks executability in the index), so we treat it as satisfied there
+ * rather than false-flag every Windows checkout.
+ */
+function hookIsExecutable(hookFile: string): boolean {
+  if (process.platform === 'win32') return true;
+  try {
+    return (fs.statSync(hookFile).mode & 0o111) !== 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Whether `@vyuhlabs/dxkit` is declared in the consumer's package.json
  * (either dependency bucket). The hooks + CI guardrail resolve a
  * project-local `./node_modules/.bin/vyuh-dxkit` first; without the dep
@@ -421,14 +437,21 @@ function runDxChecks(cwd: string, manifest: Manifest | null, hasManifest: boolea
 function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] {
   const checks: CheckResult[] = [];
 
-  // 1. Hooks active. `git config core.hooksPath` should be `.githooks`
-  // when dxkit's pre-push protection is active. Empty → init's auto-
-  // activation didn't fire (most commonly because the repo's existing
-  // postinstall script preserved priority).
+  // 1. Hooks active. Two independent conditions must BOTH hold for the
+  // pre-push guardrail to actually fire: `core.hooksPath` set to
+  // `.githooks` AND the hook file carrying the executable bit. Git
+  // SILENTLY IGNORES a non-executable hook (advice hint only), so a
+  // hook committed as mode 100644 — or checked out on a filesystem
+  // that drops the bit — produces a hooksPath that's "set" but a
+  // guardrail that never runs. Checking only hooksPath would report a
+  // false green on exactly that broken state.
   const hooksPath = readHooksPath(cwd);
-  const hookFileExists = fs.existsSync(path.join(cwd, '.githooks', 'pre-push'));
+  const hookFile = path.join(cwd, '.githooks', 'pre-push');
+  const hookFileExists = fs.existsSync(hookFile);
   if (hookFileExists) {
-    const active = hooksPath === '.githooks';
+    const hooksPathSet = hooksPath === '.githooks';
+    const executable = hookIsExecutable(hookFile);
+    const active = hooksPathSet && executable;
     checks.push({
       label: 'git hooks active (core.hooksPath = .githooks)',
       ok: active,
@@ -437,7 +460,12 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
         ? {}
         : {
             fix: {
-              hint: 'Activate the pre-push hook so dxkit guards regressions before push.',
+              // Tailor the hint to which condition failed; both are
+              // repaired by re-running activate (it sets hooksPath AND
+              // restores the executable bit).
+              hint: !hooksPathSet
+                ? 'Activate the pre-push hook so dxkit guards regressions before push.'
+                : 'The pre-push hook is wired but not executable, so git silently ignores it — no guardrail runs. Re-activate to restore the executable bit.',
               command: 'npx vyuh-dxkit hooks activate',
               skill: 'dxkit-hooks',
             },

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -155,6 +155,30 @@ function readHooksPath(cwd: string): string | null {
 }
 
 /**
+ * Whether `@vyuhlabs/dxkit` is declared in the consumer's package.json
+ * (either dependency bucket). The hooks + CI guardrail resolve a
+ * project-local `./node_modules/.bin/vyuh-dxkit` first; without the dep
+ * declared they silently fall back to a global (possibly stale) install
+ * or fail on a fresh CI runner. Returns null when there's no
+ * package.json (non-Node repo — the global/npx path is expected).
+ */
+function dxkitDeclaredAsDep(cwd: string): boolean | null {
+  const pkgPath = path.join(cwd, 'package.json');
+  if (!fs.existsSync(pkgPath)) return null;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    return Boolean(
+      pkg.dependencies?.['@vyuhlabs/dxkit'] || pkg.devDependencies?.['@vyuhlabs/dxkit'],
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Count failing scanner-tool installs by reading the cached
  * dxkit-tools-status sentinel that `vyuh-dxkit tools install --yes`
  * writes. We avoid re-running `tools list` here because it spawns
@@ -418,6 +442,34 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
               skill: 'dxkit-hooks',
             },
           }),
+    });
+  }
+
+  // 1b. dxkit declared as a project dependency. The hooks + CI guardrail
+  // resolve `./node_modules/.bin/vyuh-dxkit` before any global, so a repo
+  // that wires those surfaces but doesn't declare the dep runs whatever
+  // stale global is on PATH (or fails on a fresh CI runner). Only flag
+  // when a guardrail surface is actually present — a bare Node repo with
+  // no hook/CI has nothing to resolve.
+  const guardrailSurfacePresent =
+    hookFileExists || fs.existsSync(path.join(cwd, '.github', 'workflows', 'dxkit-guardrails.yml'));
+  const declared = dxkitDeclaredAsDep(cwd);
+  if (guardrailSurfacePresent && declared === false) {
+    checks.push({
+      label: 'dxkit in package.json devDependencies',
+      ok: false,
+      tier: 'operational',
+      fix: {
+        hint: 'Declare dxkit as a project-local devDependency so the hooks + CI guardrail run a pinned version instead of a global (or missing) one.',
+        command: 'npm install --save-dev @vyuhlabs/dxkit',
+        skill: 'dxkit-fix',
+      },
+    });
+  } else if (guardrailSurfacePresent && declared === true) {
+    checks.push({
+      label: 'dxkit in package.json devDependencies',
+      ok: true,
+      tier: 'operational',
     });
   }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -122,6 +122,12 @@ const DXKIT_SKILLS = [
   // re-running the slop check so generated prose doesn't trade
   // Documentation score for Quality score.
   'dxkit-docs',
+  // dxkit-ingest: brings an external interprocedural-SAST engine's
+  // findings (Snyk Code, CodeQL, any SARIF) into dxkit so they're
+  // fingerprinted, baselined, guardrailed, graph-linked, and fixable
+  // by dxkit-action. License-aware engine selection; quota-free Snyk
+  // read; committed snapshot so the token is needed only at ingest time.
+  'dxkit-ingest',
 ] as const;
 
 interface GenerateResult {

--- a/src/hooks-cli.ts
+++ b/src/hooks-cli.ts
@@ -12,7 +12,43 @@
  * or `git` is missing, log a dim notice and return cleanly.
  */
 import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as logger from './logger';
+
+/**
+ * Ensure every file in `.githooks/` carries the executable bit. Git
+ * SILENTLY IGNORES a hook that isn't executable (it only prints an
+ * advice hint), so a hook committed as mode 100644, or checked out on
+ * a filesystem that drops the bit, produces a hooksPath that's "set"
+ * but a guardrail that never fires. Because activation runs on every
+ * clone via the postinstall, chmod-ing here is the self-heal: each
+ * `npm install` restores the bit regardless of how the file arrived.
+ * Best-effort — a chmod failure (e.g. Windows, where executability is
+ * carried in the git index instead) must never abort activation.
+ */
+function ensureHooksExecutable(cwd: string): void {
+  const hooksDir = path.join(cwd, '.githooks');
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(hooksDir);
+  } catch {
+    return; // no .githooks dir — nothing to do
+  }
+  for (const name of entries) {
+    const file = path.join(hooksDir, name);
+    try {
+      const st = fs.statSync(file);
+      if (!st.isFile()) continue;
+      // Mirror read bits into execute (0o755-style) without clobbering
+      // existing perms: add execute wherever read is already granted.
+      const withExec = st.mode | 0o111;
+      if (withExec !== st.mode) fs.chmodSync(file, withExec);
+    } catch {
+      /* best-effort per file */
+    }
+  }
+}
 
 export interface ActivateHooksResult {
   /** True when `core.hooksPath` was set during this call. */
@@ -54,6 +90,11 @@ export function activateHooks(cwd: string): ActivateHooksResult {
     if (msg.includes('ENOENT')) return { activated: false, reason: 'git-missing' };
     return { activated: false, reason: 'not-a-git-repo' };
   }
+
+  // Restore the executable bit on every activation — a non-executable
+  // hook is silently ignored by git, so this runs regardless of the
+  // hooksPath outcome below (including the steady-state re-run path).
+  ensureHooksExecutable(cwd);
 
   // Read the current value (if any). `git config --get` exits 1 when
   // the key is unset — that's the happy path for a fresh clone.

--- a/src/ingest-cli.ts
+++ b/src/ingest-cli.ts
@@ -6,7 +6,10 @@
  *   --sarif <file>   parse a SARIF 2.1.0 file from ANY engine (CodeQL,
  *                    Snyk Code export, Semgrep Pro, Bearer, …)
  *   --from-snyk      read a project's Code findings from the Snyk REST
- *                    API (quota-free) using SNYK_TOKEN + org/project
+ *                    API (quota-free) using SNYK_TOKEN + org/project.
+ *                    On plans without REST API access (Enterprise-only)
+ *                    this auto-falls-back to `snyk code test`; pass
+ *                    --snyk-cli to force that path and skip the REST try.
  *
  * Either way the result is written to `.dxkit/external/<engine>.json`,
  * a committed snapshot every later scan reads — so the token is needed
@@ -17,6 +20,7 @@ import * as fs from 'fs';
 import * as logger from './logger';
 import { parseSarif } from './ingest/sarif';
 import { fetchSnykCodeFindings } from './ingest/snyk-api';
+import { runSnykCodeTest } from './ingest/snyk-cli';
 import { runCodeql, type CodeqlTarget } from './ingest/codeql';
 import { readDeepSastConfig } from './ingest/config';
 import { writeSnapshot } from './ingest/snapshot';
@@ -27,6 +31,10 @@ export interface IngestOptions {
   sarif?: string;
   fromSnyk?: boolean;
   codeql?: boolean;
+  /** Force the `snyk code test` CLI path, skipping the REST attempt. The
+   *  REST API is an Enterprise-only entitlement; free/team plans must use
+   *  the CLI (which costs one Snyk Code test from the quota). */
+  snykCli?: boolean;
   /** Override engine label for `--sarif` (else inferred from the file). */
   engine?: string;
   /** Snyk identifiers (CLI flags override config / env). */
@@ -57,6 +65,7 @@ export async function runIngest(cwd: string, opts: IngestOptions): Promise<void>
   logger.dim('  Examples:');
   logger.dim('    vyuh-dxkit ingest --sarif results.sarif');
   logger.dim('    SNYK_TOKEN=… vyuh-dxkit ingest --from-snyk --org <id> --project <id>');
+  logger.dim('    SNYK_TOKEN=… vyuh-dxkit ingest --from-snyk --snyk-cli  # free/team plans');
   logger.dim('    vyuh-dxkit ingest --codeql        # OSS / GitHub Advanced Security only');
   process.exitCode = 1;
 }
@@ -110,26 +119,48 @@ function ingestFromSarif(cwd: string, opts: IngestOptions): void {
   writeAndReport(cwd, engine, findings, opts);
 }
 
+/** A REST failure that means "this plan can't read the API" — Enterprise-
+ *  only entitlement. We fall back to the CLI (Snyk Code product) path. */
+export function isNotEntitled(message: string): boolean {
+  return /\b403\b/.test(message) || /not entitled/i.test(message) || /api access/i.test(message);
+}
+
 async function ingestFromSnyk(cwd: string, opts: IngestOptions): Promise<void> {
   const token = process.env.SNYK_TOKEN;
   if (!token) {
-    logger.warn('SNYK_TOKEN is not set. Export it (or add it as a CI secret) and retry.');
+    logger.warn('SNYK_TOKEN is not set.');
+    logger.dim(
+      '  dxkit reads SNYK_TOKEN from the environment — it does NOT auto-load a .env file.',
+    );
+    logger.dim('  Export it (`export SNYK_TOKEN=…`) or add it as a CI secret, then retry.');
     process.exitCode = 1;
     return;
   }
-  // Flags override persisted config (`.vyuh-dxkit.json:deepSast.snyk`),
-  // so the customer can configure org/project once and run `ingest
-  // --from-snyk` with no flags thereafter.
+  // Org/project resolve flag → persisted config (`.vyuh-dxkit.json:
+  // deepSast.snyk`) → environment, so a sourced shell or configured repo
+  // can run `ingest --from-snyk` with no flags. (dxkit does not read .env;
+  // export the vars or set CI secrets.)
   const cfg = readDeepSastConfig(cwd);
-  const orgId = opts.org ?? cfg.snyk?.orgId;
-  const projectId = opts.project ?? cfg.snyk?.projectId;
+  const orgId = opts.org ?? cfg.snyk?.orgId ?? process.env.SNYK_ORG_ID;
+  const projectId = opts.project ?? cfg.snyk?.projectId ?? process.env.SNYK_PROJECT_ID;
+
+  // Forced CLI path (free/team plans): skip the REST attempt entirely. The
+  // CLI tests the local checkout, so it needs only the org (to scope the
+  // entitlement), not a project id.
+  if (opts.snykCli) {
+    await ingestViaSnykCli(cwd, opts, orgId);
+    return;
+  }
+
   if (!orgId || !projectId) {
-    logger.warn('Snyk org + project are required for --from-snyk.');
-    logger.dim('  Pass --org <id> --project <id>, or set them once in .vyuh-dxkit.json:');
+    logger.warn('Snyk org + project are required to read findings via the REST API.');
+    logger.dim('  Pass --org <id> --project <id>, set them once in .vyuh-dxkit.json:');
     logger.dim('    { "deepSast": { "snyk": { "orgId": "…", "projectId": "…" } } }');
+    logger.dim('  or export SNYK_ORG_ID / SNYK_PROJECT_ID in your environment.');
     logger.dim(
       '  Find them in the Snyk UI (Settings → Org ID; the project page URL → project ID).',
     );
+    logger.dim('  On free/team plans (no REST API access) use --snyk-cli to run a Snyk Code test.');
     process.exitCode = 1;
     return;
   }
@@ -143,7 +174,35 @@ async function ingestFromSnyk(cwd: string, opts: IngestOptions): Promise<void> {
       apiBase: process.env.SNYK_API,
     });
   } catch (err) {
-    logger.warn(`Snyk read failed: ${(err as Error).message}`);
+    const message = (err as Error).message;
+    // REST API access is an Enterprise feature; on other plans the read
+    // 403s. Fall back to `snyk code test` (Snyk Code product entitlement,
+    // which free includes) so one command works on every plan.
+    if (isNotEntitled(message)) {
+      logger.warn('Snyk REST API access is not available on this plan (an Enterprise feature).');
+      logger.dim('  Falling back to `snyk code test` (Snyk Code product, uses one test quota)…');
+      await ingestViaSnykCli(cwd, opts, orgId);
+      return;
+    }
+    logger.warn(`Snyk read failed: ${message}`);
+    process.exitCode = 1;
+    return;
+  }
+  writeAndReport(cwd, 'snyk-code', findings, opts);
+}
+
+/** Run `snyk code test` on the local checkout and snapshot the findings.
+ *  Used both as the explicit `--snyk-cli` path and as the REST fallback. */
+async function ingestViaSnykCli(
+  cwd: string,
+  opts: IngestOptions,
+  orgId: string | undefined,
+): Promise<void> {
+  let findings: ExternalFinding[];
+  try {
+    findings = await runSnykCodeTest({ cwd, org: orgId, onLog: (m) => logger.dim(`  ${m}`) });
+  } catch (err) {
+    logger.warn(`Snyk Code test failed: ${(err as Error).message}`);
     process.exitCode = 1;
     return;
   }

--- a/src/ingest-cli.ts
+++ b/src/ingest-cli.ts
@@ -17,12 +17,15 @@ import * as fs from 'fs';
 import * as logger from './logger';
 import { parseSarif } from './ingest/sarif';
 import { fetchSnykCodeFindings } from './ingest/snyk-api';
+import { runCodeql, type CodeqlTarget } from './ingest/codeql';
 import { writeSnapshot } from './ingest/snapshot';
+import { detectActiveLanguages } from './languages/index';
 import type { SourceEngine, ExternalFinding } from './ingest/types';
 
 export interface IngestOptions {
   sarif?: string;
   fromSnyk?: boolean;
+  codeql?: boolean;
   /** Override engine label for `--sarif` (else inferred from the file). */
   engine?: string;
   /** Snyk identifiers (CLI flags override config / env). */
@@ -41,15 +44,52 @@ export async function runIngest(cwd: string, opts: IngestOptions): Promise<void>
     await ingestFromSnyk(cwd, opts);
     return;
   }
+  if (opts.codeql) {
+    await ingestFromCodeql(cwd, opts);
+    return;
+  }
   if (opts.sarif) {
     ingestFromSarif(cwd, opts);
     return;
   }
-  logger.warn('Nothing to ingest. Pass --sarif <file> or --from-snyk.');
+  logger.warn('Nothing to ingest. Pass --sarif <file>, --from-snyk, or --codeql.');
   logger.dim('  Examples:');
   logger.dim('    vyuh-dxkit ingest --sarif results.sarif');
   logger.dim('    SNYK_TOKEN=… vyuh-dxkit ingest --from-snyk --org <id> --project <id>');
+  logger.dim('    vyuh-dxkit ingest --codeql        # OSS / GitHub Advanced Security only');
   process.exitCode = 1;
+}
+
+async function ingestFromCodeql(cwd: string, opts: IngestOptions): Promise<void> {
+  // CodeQL languages come from the active packs' recipe (Rule 6), so a
+  // new pack auto-extends what gets scanned. JS+TS collapse to one
+  // `javascript` DB.
+  const targets: CodeqlTarget[] = [];
+  const seen = new Set<string>();
+  for (const pack of detectActiveLanguages(cwd)) {
+    const lang = pack.deepSast?.codeqlLanguage;
+    if (lang && !seen.has(lang)) {
+      seen.add(lang);
+      targets.push({ language: lang, querySuite: pack.deepSast?.codeqlQuerySuite });
+    }
+  }
+  if (targets.length === 0) {
+    logger.warn('No active language pack has a CodeQL extractor for this repo.');
+    process.exitCode = 1;
+    return;
+  }
+  logger.info(
+    `Running CodeQL for: ${targets.map((t) => t.language).join(', ')} (this can take many minutes)…`,
+  );
+  let findings: ExternalFinding[];
+  try {
+    findings = await runCodeql({ cwd, targets, onLog: (m) => logger.dim(`  ${m}`) });
+  } catch (err) {
+    logger.warn(`CodeQL run failed: ${(err as Error).message}`);
+    process.exitCode = 1;
+    return;
+  }
+  writeAndReport(cwd, 'codeql', findings, opts);
 }
 
 function ingestFromSarif(cwd: string, opts: IngestOptions): void {

--- a/src/ingest-cli.ts
+++ b/src/ingest-cli.ts
@@ -1,0 +1,129 @@
+/**
+ * `vyuh-dxkit ingest` — bring an external SAST engine's findings into
+ * dxkit's pipeline.
+ *
+ * Two sources today:
+ *   --sarif <file>   parse a SARIF 2.1.0 file from ANY engine (CodeQL,
+ *                    Snyk Code export, Semgrep Pro, Bearer, …)
+ *   --from-snyk      read a project's Code findings from the Snyk REST
+ *                    API (quota-free) using SNYK_TOKEN + org/project
+ *
+ * Either way the result is written to `.dxkit/external/<engine>.json`,
+ * a committed snapshot every later scan reads — so the token is needed
+ * only by whoever runs `ingest` (ideally one CI refresh job), not by
+ * every developer.
+ */
+import * as fs from 'fs';
+import * as logger from './logger';
+import { parseSarif } from './ingest/sarif';
+import { fetchSnykCodeFindings } from './ingest/snyk-api';
+import { writeSnapshot } from './ingest/snapshot';
+import type { SourceEngine, ExternalFinding } from './ingest/types';
+
+export interface IngestOptions {
+  sarif?: string;
+  fromSnyk?: boolean;
+  /** Override engine label for `--sarif` (else inferred from the file). */
+  engine?: string;
+  /** Snyk identifiers (CLI flags override config / env). */
+  org?: string;
+  project?: string;
+  generatedAt: string;
+  commitSha?: string;
+}
+
+function isSourceEngine(s: string | undefined): s is SourceEngine {
+  return s === 'snyk-code' || s === 'codeql' || s === 'semgrep-pro' || s === 'sarif';
+}
+
+export async function runIngest(cwd: string, opts: IngestOptions): Promise<void> {
+  if (opts.fromSnyk) {
+    await ingestFromSnyk(cwd, opts);
+    return;
+  }
+  if (opts.sarif) {
+    ingestFromSarif(cwd, opts);
+    return;
+  }
+  logger.warn('Nothing to ingest. Pass --sarif <file> or --from-snyk.');
+  logger.dim('  Examples:');
+  logger.dim('    vyuh-dxkit ingest --sarif results.sarif');
+  logger.dim('    SNYK_TOKEN=… vyuh-dxkit ingest --from-snyk --org <id> --project <id>');
+  process.exitCode = 1;
+}
+
+function ingestFromSarif(cwd: string, opts: IngestOptions): void {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(opts.sarif as string, 'utf-8');
+  } catch (err) {
+    logger.warn(`Cannot read SARIF file ${opts.sarif}: ${(err as Error).message}`);
+    process.exitCode = 1;
+    return;
+  }
+  const engineOverride = isSourceEngine(opts.engine) ? opts.engine : undefined;
+  const findings = parseSarif(raw, engineOverride);
+  // All findings from one SARIF share an engine; use the first (or the
+  // override / generic `sarif`) as the snapshot's engine label.
+  const engine: SourceEngine = engineOverride ?? findings[0]?.engine ?? 'sarif';
+  writeAndReport(cwd, engine, findings, opts);
+}
+
+async function ingestFromSnyk(cwd: string, opts: IngestOptions): Promise<void> {
+  const token = process.env.SNYK_TOKEN;
+  if (!token) {
+    logger.warn('SNYK_TOKEN is not set. Export it (or add it as a CI secret) and retry.');
+    process.exitCode = 1;
+    return;
+  }
+  const orgId = opts.org;
+  const projectId = opts.project;
+  if (!orgId || !projectId) {
+    logger.warn('--org <id> and --project <id> are required for --from-snyk.');
+    logger.dim(
+      '  Find them in the Snyk UI (Settings → Org ID; the project page URL → project ID).',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  logger.info('Reading Snyk Code findings via the REST API (no test quota consumed)…');
+  let findings: ExternalFinding[];
+  try {
+    findings = await fetchSnykCodeFindings({
+      token,
+      orgId,
+      projectId,
+      apiBase: process.env.SNYK_API,
+    });
+  } catch (err) {
+    logger.warn(`Snyk read failed: ${(err as Error).message}`);
+    process.exitCode = 1;
+    return;
+  }
+  writeAndReport(cwd, 'snyk-code', findings, opts);
+}
+
+function writeAndReport(
+  cwd: string,
+  engine: SourceEngine,
+  findings: ExternalFinding[],
+  opts: IngestOptions,
+): void {
+  const file = writeSnapshot(cwd, {
+    schemaVersion: 1,
+    engine,
+    generatedAt: opts.generatedAt,
+    ...(opts.commitSha ? { commitSha: opts.commitSha } : {}),
+    findings,
+  });
+  const bySev = findings.reduce<Record<string, number>>((acc, f) => {
+    acc[f.severity] = (acc[f.severity] || 0) + 1;
+    return acc;
+  }, {});
+  logger.success(`Ingested ${findings.length} ${engine} finding(s) → ${file}`);
+  logger.dim(
+    `  critical:${bySev.critical || 0} high:${bySev.high || 0} medium:${bySev.medium || 0} low:${bySev.low || 0}`,
+  );
+  logger.dim('  Commit .dxkit/external/ so every scan + CI run sees these without a token.');
+  logger.dim('  Next: `vyuh-dxkit vulnerabilities --graph-context` to see them graph-linked.');
+}

--- a/src/ingest-cli.ts
+++ b/src/ingest-cli.ts
@@ -18,6 +18,7 @@ import * as logger from './logger';
 import { parseSarif } from './ingest/sarif';
 import { fetchSnykCodeFindings } from './ingest/snyk-api';
 import { runCodeql, type CodeqlTarget } from './ingest/codeql';
+import { readDeepSastConfig } from './ingest/config';
 import { writeSnapshot } from './ingest/snapshot';
 import { detectActiveLanguages } from './languages/index';
 import type { SourceEngine, ExternalFinding } from './ingest/types';
@@ -116,10 +117,16 @@ async function ingestFromSnyk(cwd: string, opts: IngestOptions): Promise<void> {
     process.exitCode = 1;
     return;
   }
-  const orgId = opts.org;
-  const projectId = opts.project;
+  // Flags override persisted config (`.vyuh-dxkit.json:deepSast.snyk`),
+  // so the customer can configure org/project once and run `ingest
+  // --from-snyk` with no flags thereafter.
+  const cfg = readDeepSastConfig(cwd);
+  const orgId = opts.org ?? cfg.snyk?.orgId;
+  const projectId = opts.project ?? cfg.snyk?.projectId;
   if (!orgId || !projectId) {
-    logger.warn('--org <id> and --project <id> are required for --from-snyk.');
+    logger.warn('Snyk org + project are required for --from-snyk.');
+    logger.dim('  Pass --org <id> --project <id>, or set them once in .vyuh-dxkit.json:');
+    logger.dim('    { "deepSast": { "snyk": { "orgId": "…", "projectId": "…" } } }');
     logger.dim(
       '  Find them in the Snyk UI (Settings → Org ID; the project page URL → project ID).',
     );

--- a/src/ingest/codeql.ts
+++ b/src/ingest/codeql.ts
@@ -1,0 +1,152 @@
+/**
+ * CodeQL on-demand runner.
+ *
+ * Builds a CodeQL database and runs the per-language security suite,
+ * emitting SARIF that flows through the same `parseSarif` → aggregate →
+ * graph pipeline as every other ingested engine. This is the
+ * open-source / GitHub-Advanced-Security path to interprocedural SAST
+ * (the license gate is enforced by `resolveDeepSastEngine`; this module
+ * only runs once the caller has cleared it).
+ *
+ * CodeQL is heavy — a database build plus query evaluation runs for
+ * minutes, not seconds. It is intended for CI / on-demand "deep scan",
+ * never the pre-push hook (the bundled semgrep tier owns that path).
+ *
+ * Detection + install go through the canonical tool registry (Rule 1):
+ * the runner sets the opt-in env flag so the registry's
+ * applicability-guarded `codeql` entry resolves, then calls `findTool`.
+ * The arg-builders are pure so the command shape is unit-tested without
+ * a (40-minute) real run.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
+import { runDetached } from '../analyzers/tools/runner';
+import { parseSarif } from './sarif';
+import type { ExternalFinding } from './types';
+
+/** Env flag the opt-in paths (`ingest --codeql`, `tools install codeql`)
+ *  set so the registry's applicability-guarded `codeql` entry resolves.
+ *  Absent ⇒ CodeQL reports `n/a` and stays out of the default toolchain. */
+export const CODEQL_OPTIN_ENV = 'DXKIT_CODEQL';
+
+/** True when CodeQL has been explicitly opted into for this process. */
+export function codeqlOptedIn(): boolean {
+  return process.env[CODEQL_OPTIN_ENV] === '1';
+}
+
+/** Default security query suite for a CodeQL language id. Honors a
+ *  per-pack override (`deepSast.codeqlQuerySuite`). */
+export function codeqlQuerySuiteFor(lang: string, override?: string): string {
+  return override ?? `codeql/${lang}-queries:codeql-suites/${lang}-security-extended.qls`;
+}
+
+/** `codeql database create` argv (no shell). */
+export function codeqlDbCreateArgs(lang: string, dbPath: string, sourceRoot: string): string[] {
+  return [
+    'database',
+    'create',
+    dbPath,
+    `--language=${lang}`,
+    `--source-root=${sourceRoot}`,
+    '--overwrite',
+  ];
+}
+
+/** `codeql database analyze` argv (no shell). */
+export function codeqlAnalyzeArgs(dbPath: string, querySuite: string, sarifPath: string): string[] {
+  return [
+    'database',
+    'analyze',
+    dbPath,
+    querySuite,
+    '--format=sarifv2.1.0',
+    `--output=${sarifPath}`,
+    '--threads=0',
+  ];
+}
+
+export interface CodeqlTarget {
+  /** CodeQL language id (e.g. `javascript`, `python`, `java`). */
+  language: string;
+  /** Optional per-pack query-suite override. */
+  querySuite?: string;
+}
+
+export interface RunCodeqlOptions {
+  cwd: string;
+  targets: CodeqlTarget[];
+  /** DB build + analyze are slow; default 30 min per phase. */
+  timeoutMs?: number;
+  /** Progress sink (one line per phase); defaults to no-op. */
+  onLog?: (msg: string) => void;
+}
+
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+
+/**
+ * Run CodeQL across the requested languages and return the union of
+ * findings. Throws when the `codeql` binary isn't installed (with an
+ * install hint) so the caller can surface it; a language whose DB build
+ * or analysis fails is logged and skipped rather than aborting the rest.
+ */
+export async function runCodeql(opts: RunCodeqlOptions): Promise<ExternalFinding[]> {
+  // Opt in so the registry's guarded entry resolves, then detect via
+  // the canonical path (Rule 1) — never a hardcoded binary path.
+  process.env[CODEQL_OPTIN_ENV] = '1';
+  const status = findTool(TOOL_DEFS.codeql, opts.cwd);
+  if (!status.available || !status.path) {
+    throw new Error('CodeQL is not installed. Run `vyuh-dxkit tools install codeql` first.');
+  }
+  const log = opts.onLog ?? (() => {});
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const out: ExternalFinding[] = [];
+
+  for (const target of opts.targets) {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), `dxkit-codeql-${target.language}-`));
+    const dbPath = path.join(workDir, 'db');
+    const sarifPath = path.join(workDir, 'results.sarif');
+    try {
+      log(`codeql: building database for ${target.language} (this can take minutes)…`);
+      const create = await runDetached(
+        status.path,
+        codeqlDbCreateArgs(target.language, dbPath, opts.cwd),
+        { cwd: opts.cwd, timeoutMs },
+      );
+      if (create.code !== 0) {
+        log(
+          `codeql: database build failed for ${target.language} (exit ${create.code}) — skipped. ` +
+            (create.stderr.split('\n').find((l) => l.trim()) ?? ''),
+        );
+        continue;
+      }
+      const suite = codeqlQuerySuiteFor(target.language, target.querySuite);
+      log(`codeql: analyzing ${target.language} with ${suite}…`);
+      const analyze = await runDetached(status.path, codeqlAnalyzeArgs(dbPath, suite, sarifPath), {
+        cwd: opts.cwd,
+        timeoutMs,
+      });
+      if (analyze.code !== 0) {
+        log(`codeql: analysis failed for ${target.language} (exit ${analyze.code}) — skipped.`);
+        continue;
+      }
+      let raw = '';
+      try {
+        raw = fs.readFileSync(sarifPath, 'utf-8');
+      } catch {
+        raw = '';
+      }
+      const findings = parseSarif(raw, 'codeql');
+      log(`codeql: ${target.language} → ${findings.length} finding(s).`);
+      out.push(...findings);
+    } finally {
+      try {
+        fs.rmSync(workDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+  }
+  return out;
+}

--- a/src/ingest/config.ts
+++ b/src/ingest/config.ts
@@ -1,0 +1,37 @@
+/**
+ * Persisted deep-SAST configuration, read from `.vyuh-dxkit.json`.
+ *
+ * So a customer configures the engine + Snyk project ONCE (committed,
+ * non-secret — the token never lives here) instead of repeating
+ * `--org`/`--project` on every `ingest`. CLI flags always override
+ * config; config overrides nothing it doesn't set.
+ *
+ * Shape (all optional):
+ *   {
+ *     "deepSast": {
+ *       "engine": "snyk-code" | "codeql",
+ *       "snyk": { "orgId": "...", "projectId": "..." }
+ *     }
+ *   }
+ *
+ * Fail-open: a missing or malformed manifest yields an empty config —
+ * ingestion must never break on a config-read error.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface DeepSastConfig {
+  engine?: 'snyk-code' | 'codeql';
+  snyk?: { orgId?: string; projectId?: string };
+}
+
+/** Read `.vyuh-dxkit.json:deepSast`, or `{}` when absent/unreadable. */
+export function readDeepSastConfig(cwd: string): DeepSastConfig {
+  try {
+    const raw = fs.readFileSync(path.join(cwd, '.vyuh-dxkit.json'), 'utf-8');
+    const manifest = JSON.parse(raw) as { deepSast?: DeepSastConfig };
+    return manifest.deepSast ?? {};
+  } catch {
+    return {};
+  }
+}

--- a/src/ingest/engine-resolver.ts
+++ b/src/ingest/engine-resolver.ts
@@ -1,0 +1,130 @@
+/**
+ * License-aware deep-SAST engine resolver.
+ *
+ * Interprocedural SAST is not free-and-unconditional the way dxkit's
+ * bundled scanners are: CodeQL's CLI license permits free analysis only
+ * for open-source repos or under GitHub Advanced Security; Snyk Code is
+ * the customer's own licensed engine. So "which engine do we use for
+ * deep SAST?" is a decision that depends on repo visibility, what the
+ * customer already licenses, and explicit consent — exactly the shape
+ * of the baseline-mode resolver (see `src/baseline/modes.ts`), and kept
+ * deliberately parallel to it.
+ *
+ * This module decides; it does not run anything. The caller (the
+ * `ingest` CLI, the `dxkit-ingest` skill) acts on the decision —
+ * including prompting for consent when `requiresConsent` is set, so an
+ * engine never runs on private code without the user accepting the
+ * license terms.
+ *
+ * Pure: the only I/O is the visibility probe, which is injectable for
+ * tests.
+ */
+import { detectRepoVisibility } from '../baseline/visibility';
+import type { RepoVisibility } from '../baseline/visibility';
+
+/** Engines the resolver can recommend. `none` means "no licensed
+ *  interprocedural engine is available — stay on the bundled
+ *  community semgrep tier." */
+export type DeepSastEngine = 'snyk-code' | 'codeql' | 'none';
+
+export type DeepSastSource =
+  | 'flag' // explicit --engine
+  | 'snyk-configured' // SNYK_TOKEN + org/project present
+  | 'visibility-public' // OSS → CodeQL is licensed
+  | 'visibility-private'; // private/internal/unknown → consent needed
+
+export interface DeepSastDecision {
+  readonly engine: DeepSastEngine;
+  readonly source: DeepSastSource;
+  /** True when the caller MUST obtain explicit user consent before
+   *  running the engine — i.e. CodeQL against a non-public repo, where
+   *  free use requires GitHub Advanced Security. Ingesting an engine the
+   *  customer already licenses (Snyk) never requires consent. */
+  readonly requiresConsent: boolean;
+  /** One-line human explanation of how the engine was chosen. */
+  readonly explanation: string;
+  /** Present when there is a licensing constraint the caller should
+   *  surface verbatim. */
+  readonly licenseNote?: string;
+}
+
+export interface ResolveDeepSastOptions {
+  readonly cwd: string;
+  /** Explicit engine override (`--engine`). Highest precedence. */
+  readonly engineFlag?: DeepSastEngine;
+  /** Whether a Snyk token + org/project are configured (env/config).
+   *  When true, ingesting the customer's own Snyk Code results is the
+   *  zero-license-friction default. */
+  readonly snykConfigured?: boolean;
+  /** Injectable for tests; defaults to the real cached probe. */
+  readonly visibilityProbe?: (cwd: string) => RepoVisibility;
+}
+
+const GHAS_NOTE =
+  "CodeQL's license permits free use on open-source repos, academic " +
+  'research, or under GitHub Advanced Security. This repo is not public — ' +
+  'confirm you have GitHub Advanced Security (or ingest an engine you ' +
+  'already license, e.g. Snyk) before running CodeQL.';
+
+/**
+ * Resolve which deep-SAST engine to use. Precedence:
+ *   1. explicit `--engine` flag
+ *   2. a configured Snyk token (ingest the customer's own results —
+ *      license-safe, no consent)
+ *   3. repo visibility: public → CodeQL (licensed for OSS); otherwise
+ *      CodeQL gated behind consent (GHAS), so the caller can prompt or
+ *      fall back.
+ */
+export function resolveDeepSastEngine(opts: ResolveDeepSastOptions): DeepSastDecision {
+  const probe = opts.visibilityProbe ?? detectRepoVisibility;
+
+  // 1. Explicit override.
+  if (opts.engineFlag) {
+    const engine = opts.engineFlag;
+    if (engine === 'codeql') {
+      const visibility = probe(opts.cwd);
+      const consent = visibility !== 'public';
+      return {
+        engine,
+        source: 'flag',
+        requiresConsent: consent,
+        explanation: `engine=codeql (--engine)${consent ? '; consent required (non-public repo)' : ''}`,
+        ...(consent ? { licenseNote: GHAS_NOTE } : {}),
+      };
+    }
+    return {
+      engine,
+      source: 'flag',
+      requiresConsent: false,
+      explanation: `engine=${engine} (--engine)`,
+    };
+  }
+
+  // 2. Snyk configured → ingest the customer's own licensed results.
+  if (opts.snykConfigured) {
+    return {
+      engine: 'snyk-code',
+      source: 'snyk-configured',
+      requiresConsent: false,
+      explanation: 'engine=snyk-code (SNYK_TOKEN + project configured; quota-free read)',
+    };
+  }
+
+  // 3. Visibility-derived default.
+  const visibility = probe(opts.cwd);
+  if (visibility === 'public') {
+    return {
+      engine: 'codeql',
+      source: 'visibility-public',
+      requiresConsent: false,
+      explanation: 'engine=codeql (public repo; CodeQL is licensed for open source)',
+    };
+  }
+  return {
+    engine: 'codeql',
+    source: 'visibility-private',
+    requiresConsent: true,
+    explanation: `engine=codeql (visibility=${visibility}; consent required before running)`,
+    licenseNote: GHAS_NOTE,
+  };
+}

--- a/src/ingest/normalize.ts
+++ b/src/ingest/normalize.ts
@@ -1,0 +1,36 @@
+/**
+ * Normalize ingested external findings into the security pipeline's
+ * `SecurityFinding` shape.
+ *
+ * Deliberately a pure field-map and nothing more. In particular it does
+ * NOT compute identity: the security aggregator owns fingerprinting for
+ * every code finding (`canonicalRuleFor(tool, rule)` →
+ * `computeCodeFingerprint`) and the cross-tool dedup that collapses,
+ * say, a Snyk Code and a semgrep finding on the same line into one
+ * `CodeFinding`. Routing ingested findings through that same path is
+ * what keeps one fingerprint scheme across native + ingested findings
+ * (Rule 9) — an ingest-local hash would silently fork the contract.
+ *
+ * The engine name becomes the finding's `tool` provenance, so the
+ * canonical rule (`canonicalRuleFor(engine, rule)`) and the report's
+ * attribution both trace back to the producing engine.
+ */
+import type { SecurityFinding } from '../analyzers/security/types';
+import type { ExternalFinding } from './types';
+
+/** Map normalized external findings to `SecurityFinding[]` for the
+ *  aggregator. Identity + dedup happen downstream (Rule 9). */
+export function externalToSecurityFindings(
+  findings: ReadonlyArray<ExternalFinding>,
+): SecurityFinding[] {
+  return findings.map((f) => ({
+    severity: f.severity,
+    category: f.category,
+    cwe: f.cwe,
+    rule: f.rule,
+    title: f.title,
+    file: f.file,
+    line: f.line,
+    tool: f.engine,
+  }));
+}

--- a/src/ingest/sarif.ts
+++ b/src/ingest/sarif.ts
@@ -1,0 +1,166 @@
+/**
+ * SARIF 2.1.0 → `ExternalFinding[]`.
+ *
+ * SARIF is the lingua franca of SAST: CodeQL, Snyk Code (`snyk code
+ * test --sarif`), Semgrep Pro, and Bearer all emit it. Parsing it once
+ * here means every current and future interprocedural engine funnels
+ * into dxkit through the same door — the engine-agnostic core of the
+ * deep-SAST tier.
+ *
+ * Severity resolution prefers the numeric `security-severity` property
+ * (a CVSS-style 0–10 score most security rules carry) and falls back to
+ * the SARIF result `level`. CWE comes from the rule's `tags`
+ * (`external/cwe/cwe-022` → `CWE-22`). Rules can live on the driver or
+ * on a tool extension (CodeQL puts the query pack's rules under
+ * `extensions`), so we index both.
+ *
+ * Pure + defensive: a malformed run, a result with no location, or a
+ * missing rule never throws — it's skipped or filled with a safe
+ * default, because ingestion runs against third-party output we don't
+ * control.
+ */
+import type { SourceEngine, ExternalFinding } from './types';
+import type { Severity } from '../analyzers/security/types';
+
+interface SarifRule {
+  id?: string;
+  name?: string;
+  properties?: {
+    'security-severity'?: string | number;
+    'problem.severity'?: string;
+    tags?: string[];
+  };
+  shortDescription?: { text?: string };
+}
+
+interface SarifResult {
+  ruleId?: string;
+  rule?: { id?: string; index?: number };
+  level?: string;
+  message?: { text?: string };
+  locations?: Array<{
+    physicalLocation?: {
+      artifactLocation?: { uri?: string };
+      region?: { startLine?: number };
+    };
+  }>;
+}
+
+interface SarifRun {
+  tool?: {
+    driver?: { name?: string; rules?: SarifRule[] };
+    extensions?: Array<{ rules?: SarifRule[] }>;
+  };
+  results?: SarifResult[];
+}
+
+interface SarifLog {
+  runs?: SarifRun[];
+}
+
+/** Map a SARIF tool driver name to a known engine, when the caller
+ *  didn't pass one explicitly. Unknown drivers fall back to the generic
+ *  `sarif` engine so attribution is still honest. */
+function engineFromDriver(name: string | undefined): SourceEngine {
+  const n = (name || '').toLowerCase();
+  if (n.includes('codeql')) return 'codeql';
+  if (n.includes('snyk')) return 'snyk-code';
+  if (n.includes('semgrep')) return 'semgrep-pro';
+  return 'sarif';
+}
+
+/** `external/cwe/cwe-022` (or `CWE-022`) → `CWE-22`. Returns '' when no
+ *  CWE tag is present. Leading zeros are stripped so the id matches the
+ *  canonical `CWE-<n>` form used elsewhere in dxkit. */
+function cweFromTags(tags: string[] | undefined): string {
+  if (!tags) return '';
+  for (const tag of tags) {
+    const m = /cwe[-/_]?(\d+)/i.exec(tag);
+    if (m) return `CWE-${parseInt(m[1], 10)}`;
+  }
+  return '';
+}
+
+/** Resolve four-tier severity. Prefer numeric `security-severity`
+ *  (CVSS-like 0–10); else the rule's `problem.severity`; else the
+ *  result `level`. */
+function resolveSeverity(rule: SarifRule | undefined, level: string | undefined): Severity {
+  const num = rule?.properties?.['security-severity'];
+  if (num !== undefined && num !== null && num !== '') {
+    const score = typeof num === 'number' ? num : parseFloat(String(num));
+    if (!Number.isNaN(score)) {
+      if (score >= 9.0) return 'critical';
+      if (score >= 7.0) return 'high';
+      if (score >= 4.0) return 'medium';
+      return 'low';
+    }
+  }
+  const ps = rule?.properties?.['problem.severity'];
+  if (ps === 'error') return 'high';
+  if (ps === 'warning' || ps === 'recommendation') return 'medium';
+  // SARIF result level is the last resort.
+  if (level === 'error') return 'high';
+  if (level === 'note') return 'low';
+  if (level === 'warning') return 'medium';
+  return 'medium';
+}
+
+/**
+ * Parse a SARIF 2.1.0 document. `engine` overrides the auto-detected
+ * driver name (callers usually know which engine produced the file);
+ * pass `undefined` to infer from the SARIF tool driver.
+ */
+export function parseSarif(raw: string, engine?: SourceEngine): ExternalFinding[] {
+  let log: SarifLog;
+  try {
+    log = JSON.parse(raw) as SarifLog;
+  } catch {
+    return [];
+  }
+  const out: ExternalFinding[] = [];
+  for (const run of log.runs || []) {
+    const driverName = run.tool?.driver?.name;
+    const resolvedEngine = engine ?? engineFromDriver(driverName);
+
+    // Index rules by id from driver + every extension.
+    const rulesById = new Map<string, SarifRule>();
+    const ruleLists: SarifRule[][] = [];
+    if (run.tool?.driver?.rules) ruleLists.push(run.tool.driver.rules);
+    for (const ext of run.tool?.extensions || []) {
+      if (ext.rules) ruleLists.push(ext.rules);
+    }
+    const flatRules: SarifRule[] = [];
+    for (const list of ruleLists) {
+      for (const r of list) {
+        flatRules.push(r);
+        if (r.id) rulesById.set(r.id, r);
+      }
+    }
+
+    for (const res of run.results || []) {
+      const ruleId = res.ruleId || res.rule?.id;
+      // Rule can be referenced by id or by index into the (flattened) list.
+      let rule: SarifRule | undefined = ruleId ? rulesById.get(ruleId) : undefined;
+      if (!rule && typeof res.rule?.index === 'number') rule = flatRules[res.rule.index];
+
+      const loc = res.locations?.[0]?.physicalLocation;
+      const file = loc?.artifactLocation?.uri;
+      const line = loc?.region?.startLine;
+      // A finding with no source location can't be fingerprinted or
+      // fixed — skip rather than emit a phantom at line 0.
+      if (!file || !line) continue;
+
+      out.push({
+        engine: resolvedEngine,
+        severity: resolveSeverity(rule, res.level),
+        category: 'code',
+        cwe: cweFromTags(rule?.properties?.tags),
+        rule: ruleId || rule?.name || 'unknown',
+        title: res.message?.text || rule?.shortDescription?.text || ruleId || 'SAST finding',
+        file,
+        line,
+      });
+    }
+  }
+  return out;
+}

--- a/src/ingest/sarif.ts
+++ b/src/ingest/sarif.ts
@@ -29,6 +29,9 @@ interface SarifRule {
     'security-severity'?: string | number;
     'problem.severity'?: string;
     tags?: string[];
+    /** Snyk Code SARIF puts CWE(s) in a dedicated array here
+     *  (e.g. `["CWE-94"]`), not in `tags` like CodeQL does. */
+    cwe?: string[];
   };
   shortDescription?: { text?: string };
 }
@@ -69,14 +72,28 @@ function engineFromDriver(name: string | undefined): SourceEngine {
   return 'sarif';
 }
 
-/** `external/cwe/cwe-022` (or `CWE-022`) → `CWE-22`. Returns '' when no
- *  CWE tag is present. Leading zeros are stripped so the id matches the
- *  canonical `CWE-<n>` form used elsewhere in dxkit. */
-function cweFromTags(tags: string[] | undefined): string {
-  if (!tags) return '';
-  for (const tag of tags) {
-    const m = /cwe[-/_]?(\d+)/i.exec(tag);
-    if (m) return `CWE-${parseInt(m[1], 10)}`;
+/** Normalize any CWE-ish string to canonical `CWE-<n>` (leading zeros
+ *  stripped), or '' when none present. */
+function normalizeCwe(s: string | undefined): string {
+  if (!s) return '';
+  const m = /cwe[-/_]?(\d+)/i.exec(s);
+  return m ? `CWE-${parseInt(m[1], 10)}` : '';
+}
+
+/** Resolve the CWE for a rule across engine conventions:
+ *  Snyk Code uses `properties.cwe: ["CWE-94"]`; CodeQL uses
+ *  `properties.tags: ["external/cwe/cwe-094"]`. Checks both. */
+function cweFromRule(rule: SarifRule | undefined): string {
+  const direct = rule?.properties?.cwe;
+  if (Array.isArray(direct)) {
+    for (const c of direct) {
+      const n = normalizeCwe(c);
+      if (n) return n;
+    }
+  }
+  for (const tag of rule?.properties?.tags ?? []) {
+    const n = normalizeCwe(tag);
+    if (n) return n;
   }
   return '';
 }
@@ -154,7 +171,7 @@ export function parseSarif(raw: string, engine?: SourceEngine): ExternalFinding[
         engine: resolvedEngine,
         severity: resolveSeverity(rule, res.level),
         category: 'code',
-        cwe: cweFromTags(rule?.properties?.tags),
+        cwe: cweFromRule(rule),
         rule: ruleId || rule?.name || 'unknown',
         title: res.message?.text || rule?.shortDescription?.text || ruleId || 'SAST finding',
         file,

--- a/src/ingest/snapshot.ts
+++ b/src/ingest/snapshot.ts
@@ -1,0 +1,87 @@
+/**
+ * Persisted ingestion snapshots under `.dxkit/external/`.
+ *
+ * `vyuh-dxkit ingest` writes one snapshot file per engine
+ * (`.dxkit/external/<engine>.json`). The snapshot is committed to the
+ * repo so every developer and every CI run reads the ingested findings
+ * WITHOUT needing the engine's token — only the one CI refresh job that
+ * produced it needs `SNYK_TOKEN` (or a CodeQL license). This is what
+ * makes "an admin adds the token once and everyone benefits" true.
+ *
+ * The snapshot is the normalized `ExternalFinding[]` plus light
+ * metadata for provenance/diagnostics. It deliberately carries no
+ * engine-token or account identifier — only finding data — so it is
+ * safe to commit.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type { SourceEngine, ExternalFinding } from './types';
+
+/** Directory (relative to repo root) where ingestion snapshots live. */
+export const EXTERNAL_DIR = path.join('.dxkit', 'external');
+
+export interface ExternalSnapshot {
+  schemaVersion: 1;
+  engine: SourceEngine;
+  /** ISO timestamp the snapshot was produced. Stamped by the caller so
+   *  this module stays free of clock access (testability). */
+  generatedAt: string;
+  /** Commit the snapshot was produced against, when known. */
+  commitSha?: string;
+  findings: ExternalFinding[];
+}
+
+/** Absolute path to an engine's snapshot file. */
+function snapshotPath(cwd: string, engine: SourceEngine): string {
+  return path.join(cwd, EXTERNAL_DIR, `${engine}.json`);
+}
+
+/** Write (overwrite) an engine's snapshot. Creates `.dxkit/external/`
+ *  if needed. */
+export function writeSnapshot(cwd: string, snapshot: ExternalSnapshot): string {
+  const dir = path.join(cwd, EXTERNAL_DIR);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = snapshotPath(cwd, snapshot.engine);
+  fs.writeFileSync(file, JSON.stringify(snapshot, null, 2) + '\n', 'utf-8');
+  return file;
+}
+
+/**
+ * Read every snapshot under `.dxkit/external/` and return the union of
+ * their findings. Fail-open: a missing directory, an unreadable file,
+ * or a malformed snapshot yields no findings from that file rather than
+ * throwing — ingestion is optional and must never break a scan.
+ */
+export function readAllSnapshots(cwd: string): ExternalFinding[] {
+  const dir = path.join(cwd, EXTERNAL_DIR);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  const out: ExternalFinding[] = [];
+  for (const name of entries) {
+    try {
+      const raw = fs.readFileSync(path.join(dir, name), 'utf-8');
+      const snap = JSON.parse(raw) as ExternalSnapshot;
+      if (Array.isArray(snap.findings)) out.push(...snap.findings);
+    } catch {
+      // skip unreadable / malformed snapshot
+    }
+  }
+  return out;
+}
+
+/** Distinct engines present in `.dxkit/external/` (for provenance). */
+export function snapshotEngines(cwd: string): string[] {
+  const dir = path.join(cwd, EXTERNAL_DIR);
+  try {
+    return fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => f.replace(/\.json$/, ''));
+  } catch {
+    return [];
+  }
+}

--- a/src/ingest/snyk-api.ts
+++ b/src/ingest/snyk-api.ts
@@ -1,0 +1,183 @@
+/**
+ * Snyk Code (SAST) reader — pulls a project's already-computed findings
+ * from the Snyk REST API.
+ *
+ * Why API-read (not `snyk code test`): reading stored issues does NOT
+ * consume the org's Snyk Code test quota. On a free/limited tier where
+ * tests are capped per billing period, this is the only repeatable way
+ * to get the findings out. An admin provides a `SNYK_TOKEN` once
+ * (ideally as a CI secret); the refresh job commits a snapshot so every
+ * other developer and CI run reads it without a token.
+ *
+ * Endpoint (REST):
+ *   GET /rest/orgs/{org_id}/issues
+ *       ?version=<date>&type=code
+ *       &scan_item.type=project&scan_item.id=<project_id>
+ *   Authorization: token <SNYK_TOKEN>
+ *
+ * Field paths (confirmed against the published OpenAPI):
+ *   - severity → attributes.effective_severity_level
+ *                (info|low|medium|high|critical)
+ *   - cwe      → attributes.classes[] where source == 'CWE' (id 'CWE-23')
+ *   - title    → attributes.title
+ *   - location → attributes.coordinates[].representations[].sourceLocation
+ *                .file  +  .region.start.line
+ *
+ * VALIDATION NOTE: the precise auth scheme (`token` vs `Bearer`) and the
+ * exact nesting of `sourceLocation` for code issues must be confirmed
+ * against a REAL response from a live token before this is trusted in
+ * production — synthetic-schema parsers drift from real output. The
+ * parser below is defensive (missing fields skip, never throw) so a
+ * schema surprise degrades to "fewer findings", never a crash.
+ */
+import type { ExternalFinding } from './types';
+import type { Severity } from '../analyzers/security/types';
+
+export interface SnykReadOptions {
+  token: string;
+  orgId: string;
+  projectId: string;
+  /** REST API base; override for self-hosted/regional tenants
+   *  (e.g. https://api.eu.snyk.io). */
+  apiBase?: string;
+  /** REST API version date. Snyk requires an explicit version. */
+  version?: string;
+}
+
+const DEFAULT_API_BASE = 'https://api.snyk.io';
+const DEFAULT_VERSION = '2024-10-15';
+
+/** Snyk's five-level severity → dxkit's four-tier. `info` folds to
+ *  `low` (dxkit has no info tier). */
+function mapSeverity(level: string | undefined): Severity {
+  switch (level) {
+    case 'critical':
+      return 'critical';
+    case 'high':
+      return 'high';
+    case 'medium':
+      return 'medium';
+    case 'low':
+    case 'info':
+      return 'low';
+    default:
+      return 'medium';
+  }
+}
+
+interface SnykClass {
+  id?: string;
+  source?: string;
+}
+interface SnykRepresentation {
+  sourceLocation?: {
+    file?: string;
+    region?: { start?: { line?: number } };
+  };
+}
+interface SnykCoordinate {
+  representations?: SnykRepresentation[];
+}
+interface SnykIssue {
+  id?: string;
+  attributes?: {
+    title?: string;
+    type?: string;
+    effective_severity_level?: string;
+    classes?: SnykClass[];
+    coordinates?: SnykCoordinate[];
+  };
+}
+interface SnykIssuesResponse {
+  data?: SnykIssue[];
+  links?: { next?: string };
+}
+
+/** Extract the first CWE id from an issue's `classes`. */
+function cweFromClasses(classes: SnykClass[] | undefined): string {
+  if (!classes) return '';
+  for (const c of classes) {
+    if ((c.source || '').toUpperCase() === 'CWE' && c.id) {
+      const m = /(\d+)/.exec(c.id);
+      if (m) return `CWE-${parseInt(m[1], 10)}`;
+    }
+  }
+  return '';
+}
+
+/** First resolvable source location (file + line) in an issue. */
+function locationFrom(coords: SnykCoordinate[] | undefined): { file: string; line: number } | null {
+  for (const c of coords || []) {
+    for (const r of c.representations || []) {
+      const file = r.sourceLocation?.file;
+      const line = r.sourceLocation?.region?.start?.line;
+      if (file && line) return { file, line };
+    }
+  }
+  return null;
+}
+
+/** Map one Snyk issue → `ExternalFinding`, or null when it has no
+ *  usable source location (can't be fingerprinted/fixed). */
+export function snykIssueToFinding(issue: SnykIssue): ExternalFinding | null {
+  const a = issue.attributes;
+  if (!a) return null;
+  const loc = locationFrom(a.coordinates);
+  if (!loc) return null;
+  return {
+    engine: 'snyk-code',
+    severity: mapSeverity(a.effective_severity_level),
+    category: 'code',
+    cwe: cweFromClasses(a.classes),
+    rule: issue.id || a.title || 'snyk-code',
+    title: a.title || 'Snyk Code finding',
+    file: loc.file,
+    line: loc.line,
+  };
+}
+
+/**
+ * Fetch all Snyk Code findings for a project, following pagination.
+ * Pure-ish: the only side effect is the network read. Throws on auth /
+ * network failure so the CLI can surface a clear message; a successful
+ * call with zero issues returns `[]`.
+ */
+export async function fetchSnykCodeFindings(opts: SnykReadOptions): Promise<ExternalFinding[]> {
+  const base = opts.apiBase || DEFAULT_API_BASE;
+  const version = opts.version || DEFAULT_VERSION;
+  const params = new URLSearchParams({
+    version,
+    type: 'code',
+    'scan_item.type': 'project',
+    'scan_item.id': opts.projectId,
+    limit: '100',
+  });
+  let url: string | null = `${base}/rest/orgs/${opts.orgId}/issues?${params.toString()}`;
+  const out: ExternalFinding[] = [];
+  let guard = 0;
+
+  while (url && guard < 1000) {
+    guard++;
+    const res: Response = await fetch(url, {
+      headers: {
+        // Snyk REST API convention. If a live token rejects this,
+        // switch to `Bearer ${opts.token}` (see VALIDATION NOTE).
+        Authorization: `token ${opts.token}`,
+        Accept: 'application/vnd.api+json',
+      },
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`Snyk API ${res.status} ${res.statusText}: ${body.slice(0, 200)}`);
+    }
+    const json = (await res.json()) as SnykIssuesResponse;
+    for (const issue of json.data || []) {
+      const f = snykIssueToFinding(issue);
+      if (f) out.push(f);
+    }
+    const next = json.links?.next;
+    // `next` is a relative REST path; resolve against the base.
+    url = next ? (next.startsWith('http') ? next : `${base}${next}`) : null;
+  }
+  return out;
+}

--- a/src/ingest/snyk-cli.ts
+++ b/src/ingest/snyk-cli.ts
@@ -1,0 +1,109 @@
+/**
+ * Snyk Code (SAST) via the Snyk CLI — the free-tier path.
+ *
+ * Reading findings over the Snyk REST API needs Snyk's API-access
+ * entitlement, which is an Enterprise-tier feature. On Free/Team plans
+ * that read returns `403 … not entitled for api access`. But running a
+ * Snyk Code TEST via the CLI uses the Snyk Code *product* entitlement
+ * (which Free includes, with a per-period test quota), and writes the
+ * full results to a local SARIF file — which we then ingest through the
+ * same `parseSarif` path as every other engine.
+ *
+ * So this is the path most customers actually use. It costs one Snyk
+ * Code test per run (vs the quota-free API read on Enterprise).
+ *
+ * Detection + install go through the canonical registry (Rule 1): the
+ * runner opts into the guarded `snyk` entry, and installs it on demand
+ * (it's a small npm package) if missing. The CLI emits a non-fatal
+ * platform-reporting error on plans without API access, but still writes
+ * the SARIF — so we read the file regardless of exit code.
+ */
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { findTool, getInstallCommand, TOOL_DEFS } from '../analyzers/tools/tool-registry';
+import { runDetached } from '../analyzers/tools/runner';
+import { parseSarif } from './sarif';
+import type { ExternalFinding } from './types';
+
+/** Env flag that opts the guarded `snyk` registry entry in. */
+export const SNYK_OPTIN_ENV = 'DXKIT_SNYK_CLI';
+
+/** `snyk code test` argv (no shell). Org scopes the entitlement; omit
+ *  to use the token's default org. */
+export function snykCodeTestArgs(org: string | undefined, sarifPath: string): string[] {
+  const args = ['code', 'test', `--sarif-file-output=${sarifPath}`];
+  if (org) args.push(`--org=${org}`);
+  return args;
+}
+
+export interface RunSnykCodeOptions {
+  cwd: string;
+  /** Snyk org id — scopes which org's Code entitlement/quota is used. */
+  org?: string;
+  /** Snyk Code tests can take a few minutes; default 10 min. */
+  timeoutMs?: number;
+  onLog?: (msg: string) => void;
+}
+
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Run `snyk code test` and return normalized findings. Installs the
+ * Snyk CLI on demand if missing. Throws when no SARIF is produced (a
+ * real failure); a non-zero exit with a written SARIF (findings present,
+ * or the cosmetic platform-report 403) is treated as success.
+ */
+export async function runSnykCodeTest(opts: RunSnykCodeOptions): Promise<ExternalFinding[]> {
+  process.env[SNYK_OPTIN_ENV] = '1';
+  const log = opts.onLog ?? (() => {});
+
+  let status = findTool(TOOL_DEFS.snyk, opts.cwd);
+  if (!status.available || !status.path) {
+    log('Snyk CLI not found — installing it on demand…');
+    try {
+      execSync(getInstallCommand(TOOL_DEFS.snyk), { stdio: 'ignore' });
+    } catch {
+      /* fall through to the availability check below */
+    }
+    status = findTool(TOOL_DEFS.snyk, opts.cwd);
+  }
+  if (!status.available || !status.path) {
+    throw new Error('Snyk CLI is not available. Install it with `vyuh-dxkit tools install snyk`.');
+  }
+
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-snyk-'));
+  const sarifPath = path.join(workDir, 'snyk-code.sarif');
+  try {
+    log('Running `snyk code test` (uses one Snyk Code test from your quota)…');
+    const outcome = await runDetached(status.path, snykCodeTestArgs(opts.org, sarifPath), {
+      cwd: opts.cwd,
+      timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    });
+    let raw = '';
+    try {
+      raw = fs.readFileSync(sarifPath, 'utf-8');
+    } catch {
+      raw = '';
+    }
+    if (!raw) {
+      // No SARIF means the test genuinely failed (auth, network, no Code
+      // entitlement) — surface the CLI's first stderr line.
+      const firstErr = outcome.stderr
+        .split('\n')
+        .map((l) => l.trim())
+        .find((l) => l.length > 0);
+      throw new Error(
+        `Snyk CLI produced no SARIF (exit ${outcome.code})${firstErr ? `: ${firstErr}` : ''}`,
+      );
+    }
+    return parseSarif(raw, 'snyk-code');
+  } finally {
+    try {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+}

--- a/src/ingest/types.ts
+++ b/src/ingest/types.ts
@@ -1,0 +1,69 @@
+/**
+ * External-findings ingestion types.
+ *
+ * dxkit's own scanners (semgrep, gitleaks, osv-scanner, npm-audit) are
+ * intraprocedural / dependency-level. Interprocedural taint SAST —
+ * the class of finding a proprietary engine like Snyk Code or an
+ * interprocedural engine like CodeQL produces — lives outside dxkit's
+ * bundled toolchain. Rather than try to out-detect those engines,
+ * dxkit *ingests* their output and makes it first-class: fingerprinted
+ * (Rule 9), aggregated (Rule 8), baselined (Rule 10), graph-linked
+ * (Rule 12), and fixable through the agent loop.
+ *
+ * Every supported engine funnels into the SAME normalized shape
+ * (`ExternalFinding`) so the rest of the pipeline is engine-agnostic.
+ * Adding an engine is a new *producer* (a function that returns
+ * `ExternalFinding[]`); the normalize → aggregate → graph → fix path
+ * never grows an engine-specific branch.
+ */
+import type { Severity, FindingCategory } from '../analyzers/security/types';
+
+/**
+ * The engines dxkit can ingest from. Each is a *producer* of
+ * `ExternalFinding[]`:
+ *
+ *   - `snyk-code`   — Snyk Code (SAST), read from the Snyk REST API
+ *                     (quota-free; reads stored results) or a SARIF
+ *                     export from `snyk code test --sarif`.
+ *   - `codeql`      — CodeQL, run on-demand where licensing permits
+ *                     (OSS / GitHub Advanced Security), emitting SARIF.
+ *   - `semgrep-pro` — Semgrep Pro engine (interprocedural), if a
+ *                     customer has it; SARIF.
+ *   - `sarif`       — a generic SARIF file from any other tool. The
+ *                     producer-of-last-resort; keeps dxkit open.
+ *
+ * The string also becomes the finding's `tool` provenance so reports
+ * and the aggregator can attribute each finding to its origin.
+ */
+export type SourceEngine = 'snyk-code' | 'codeql' | 'semgrep-pro' | 'sarif';
+
+/**
+ * One normalized finding from an external engine. Deliberately a
+ * superset-mappable shape: it carries exactly the fields the security
+ * aggregator's `SecurityFinding` needs, plus the provenance the report
+ * surfaces. Identity (`fingerprint`) is NOT computed here — it is
+ * assigned by the normalize layer through the canonical helpers so
+ * there is one fingerprint scheme across native + ingested findings
+ * (Rule 9).
+ */
+export interface ExternalFinding {
+  /** Engine that produced this finding; becomes the `tool` field. */
+  engine: SourceEngine;
+  /** Four-tier severity, already mapped from the engine's vocabulary. */
+  severity: Severity;
+  /** `code` for SAST taint findings; `secret`/`config` reserved for
+   *  engines that also emit those kinds. Dependency advisories are NOT
+   *  ingested here — dxkit's own dep-vuln gather is at parity. */
+  category: FindingCategory;
+  /** CWE identifier (e.g. `CWE-23`), or `''` when the engine gives none. */
+  cwe: string;
+  /** Engine-native rule id (e.g. `javascript/path-injection`,
+   *  `SNYK-JS-...`). Combined with `engine` to form the canonical rule. */
+  rule: string;
+  /** Human-readable one-line title. */
+  title: string;
+  /** Repo-relative source path. */
+  file: string;
+  /** 1-based line number of the primary location. */
+  line: number;
+}

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -1514,6 +1514,8 @@ export const csharp: LanguageSupport = {
   tools: ['dotnet-format', 'nuget-license', 'osv-scanner'],
   // p/csharp semgrep ruleset is sparse — skip until it matures.
   semgrepRulesets: [],
+  // CodeQL `csharp` extractor needs a build; Snyk Code supports C#.
+  deepSast: { codeqlLanguage: 'csharp', codeqlBuildRequired: true, snykCode: true },
 
   capabilities: {
     depVulns: csharpDepVulnsProvider,

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -937,6 +937,8 @@ export const go: LanguageSupport = {
 
   tools: ['golangci-lint', 'govulncheck', 'go-licenses'],
   semgrepRulesets: ['p/gosec'],
+  // CodeQL `go` extractor needs a build (autobuild); Snyk Code supports Go.
+  deepSast: { codeqlLanguage: 'go', codeqlBuildRequired: true, snykCode: true },
 
   capabilities: {
     depVulns: goDepVulnsProvider,

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -1,5 +1,5 @@
 import type { DetectedStack } from '../types';
-import type { ArchitecturalShape, LanguageId, LanguageSupport } from './types';
+import type { ArchitecturalShape, DeepSastSupport, LanguageId, LanguageSupport } from './types';
 import { csharp } from './csharp';
 import { go } from './go';
 import { python } from './python';
@@ -81,6 +81,42 @@ export function activeLanguagesFromFlags(flags: DetectedStack['languages']): Lan
  */
 export function allSourceExtensions(): string[] {
   return [...new Set(LANGUAGES.flatMap((l) => l.sourceExtensions))];
+}
+
+/**
+ * The active packs that declare interprocedural deep-SAST support,
+ * paired with their declaration (Rule 6). The engine resolver, the
+ * CodeQL runner, and the `tools install` applicability guard read the
+ * union here instead of branching on language id — so adding a pack (or
+ * an engine field) auto-extends every consumer.
+ */
+export function activeDeepSast(
+  flags: DetectedStack['languages'],
+): Array<{ id: LanguageId; deepSast: DeepSastSupport }> {
+  return activeLanguagesFromFlags(flags)
+    .filter((l) => l.deepSast)
+    .map((l) => ({ id: l.id, deepSast: l.deepSast as DeepSastSupport }));
+}
+
+/**
+ * Distinct CodeQL language ids needed to scan the active stack,
+ * deduplicated (JS+TS collapse to one `javascript`). Empty when no
+ * active pack has a CodeQL extractor — the runner then has nothing to do.
+ */
+export function codeqlLanguagesFromFlags(flags: DetectedStack['languages']): string[] {
+  return [
+    ...new Set(
+      activeDeepSast(flags)
+        .map((d) => d.deepSast.codeqlLanguage)
+        .filter((l): l is string => !!l),
+    ),
+  ];
+}
+
+/** True when any active pack expects Snyk Code coverage — gates whether
+ *  `ingest --from-snyk` is worth offering for this stack. */
+export function anyActivePackSupportsSnykCode(flags: DetectedStack['languages']): boolean {
+  return activeDeepSast(flags).some((d) => d.deepSast.snykCode === true);
 }
 
 /**

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -483,6 +483,8 @@ export const java: LanguageSupport = {
 
   // Semgrep ships a Java ruleset under p/java.
   semgrepRulesets: ['p/java'],
+  // CodeQL `java` extractor needs a build; Snyk Code supports Java.
+  deepSast: { codeqlLanguage: 'java', codeqlBuildRequired: true, snykCode: true },
 
   capabilities: {
     imports: javaImportsProvider,

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -501,6 +501,14 @@ export const kotlin: LanguageSupport = {
   // Semgrep's Kotlin ruleset (`p/kotlin`) is sparse compared to Python/JS
   // — skipping for now until coverage matures, mirroring the csharp pack.
   semgrepRulesets: [],
+  // Kotlin uses CodeQL's `java` extractor (needs a build) and is beta
+  // there; Snyk Code supports Kotlin.
+  deepSast: {
+    codeqlLanguage: 'java',
+    codeqlBuildRequired: true,
+    codeqlBeta: true,
+    snykCode: true,
+  },
 
   capabilities: {
     depVulns: kotlinDepVulnsProvider,

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1046,6 +1046,8 @@ export const python: LanguageSupport = {
 
   tools: ['ruff', 'pip-audit', 'coverage-py', 'pip-licenses'],
   semgrepRulesets: ['p/python'],
+  // CodeQL `python` extractor (no build); Snyk Code supports Python.
+  deepSast: { codeqlLanguage: 'python', snykCode: true },
 
   capabilities: {
     depVulns: pyDepVulnsProvider,

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -738,6 +738,8 @@ export const ruby: LanguageSupport = {
   tools: ['osv-scanner', 'rubocop', 'simplecov'],
 
   semgrepRulesets: ['p/ruby'],
+  // CodeQL `ruby` extractor (no build); Snyk Code supports Ruby.
+  deepSast: { codeqlLanguage: 'ruby', snykCode: true },
 
   capabilities: {
     imports: rubyImportsProvider,

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -883,6 +883,9 @@ export const rust: LanguageSupport = {
   tools: ['clippy', 'cargo-audit', 'cargo-llvm-cov', 'cargo-license'],
   // No dedicated semgrep Rust ruleset; covered by p/security-audit.
   semgrepRulesets: [],
+  // CodeQL `rust` extractor is beta (no build). Snyk Code has no Rust
+  // support today, so leave snykCode unset.
+  deepSast: { codeqlLanguage: 'rust', codeqlBeta: true },
 
   capabilities: {
     depVulns: rustDepVulnsProvider,

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -110,6 +110,32 @@ export interface ArchitecturalShape {
 }
 
 /**
+ * Per-pack interprocedural deep-SAST engine support. Declared by each
+ * language pack (Rule 6) and consumed through the registry helpers in
+ * `src/languages/index.ts`; the cross-cutting ingest/resolver code never
+ * branches on language id.
+ */
+export interface DeepSastSupport {
+  /** CodeQL language id for this pack (as `codeql resolve languages`
+   *  reports). undefined ⇒ CodeQL has no extractor here. JavaScript and
+   *  TypeScript share the single `javascript` extractor. */
+  codeqlLanguage?: string;
+  /** CodeQL query suite; defaults to the language's security-extended
+   *  suite when omitted. */
+  codeqlQuerySuite?: string;
+  /** CodeQL DB creation requires building the project (compiled
+   *  languages: Java/Kotlin/C#/Go). Source extractors (JS/TS, Python,
+   *  Ruby) leave this false. */
+  codeqlBuildRequired?: boolean;
+  /** CodeQL extractor maturity is beta for this pack (Kotlin via the
+   *  java extractor; Rust) — surfaced so callers can warn. */
+  codeqlBeta?: boolean;
+  /** Snyk Code (SAST) supports this language, so `ingest --from-snyk`
+   *  is expected to return findings for it. */
+  snykCode?: boolean;
+}
+
+/**
  * Everything dxkit needs to know about a language lives in one implementation
  * of this interface. See `src/languages/index.ts` for the registry.
  *
@@ -339,6 +365,22 @@ export interface LanguageSupport {
 
   tools: string[];
   semgrepRulesets: string[];
+
+  /**
+   * Interprocedural deep-SAST engine support for this pack.
+   *
+   * dxkit's bundled semgrep tier is intraprocedural; the interprocedural
+   * taint class is covered by external engines (CodeQL, Snyk Code) run
+   * or ingested via `src/ingest`. This is the single place a language's
+   * deep-SAST facts live (Rule 6): the engine resolver, the CodeQL
+   * runner, and the `tools install` applicability guard read it through
+   * the registry helpers — never a per-language branch.
+   *
+   * Optional: a pack with no interprocedural engine support omits it,
+   * and consumers see the empty union (falling back to the bundled
+   * intraprocedural tier).
+   */
+  deepSast?: DeepSastSupport;
 
   /**
    * Tier a lint rule code into a severity bucket. Accepts `string | null |

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1237,6 +1237,9 @@ export const typescript: LanguageSupport = {
 
   tools: ['eslint', 'npm-audit', 'osv-scanner', 'vitest-coverage', 'license-checker-rseidelsohn'],
   semgrepRulesets: ['p/javascript', 'p/typescript'],
+  // CodeQL's `javascript` extractor covers both JS and TS in one DB,
+  // no build needed. Snyk Code supports JS/TS.
+  deepSast: { codeqlLanguage: 'javascript', snykCode: true },
 
   capabilities: {
     depVulns: tsDepVulnsProvider,

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -398,6 +398,17 @@ export function installCiBaselineRefresh(cwd: string, opts: InstallerOpts = {}):
   return result;
 }
 
+export function installCiDeepSastRefresh(cwd: string, opts: InstallerOpts = {}): ShipInstallResult {
+  const result = installWorkflow(cwd, 'dxkit-deep-sast-refresh.yml', opts);
+  if (result.installed.length > 0) {
+    result.notes.push(
+      'deep-SAST refresh workflow installed. To activate: add a SNYK_TOKEN Actions secret and ' +
+        'set deepSast.snyk.{orgId,projectId} in .vyuh-dxkit.json. Without the secret it no-ops.',
+    );
+  }
+  return result;
+}
+
 /**
  * AI PR-review workflow installer. Writes
  * `.github/workflows/pr-review.yml` — a workflow that runs Claude

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -16,6 +16,7 @@ import { execFileSync } from 'child_process';
 import { makeExecutable } from './files';
 import { detect } from './detect';
 import { buildDevcontainerExtensions, buildDevcontainerFeatures } from './languages';
+import { VERSION } from './constants';
 
 /**
  * Detect the consumer repo's default branch so workflow templates
@@ -571,6 +572,78 @@ export function installHooksPostinstall(cwd: string, _opts: InstallerOpts = {}):
   result.notes.push(
     'Wired `vyuh-dxkit hooks activate` into package.json postinstall — every clone + `npm install` ' +
       'will activate `core.hooksPath = .githooks` automatically. (Manual one-time activation no longer needed.)',
+  );
+  return result;
+}
+
+const DXKIT_PACKAGE = '@vyuhlabs/dxkit';
+
+/**
+ * Ensure `@vyuhlabs/dxkit` is in the consumer's package.json
+ * devDependencies, pinned to the version that ran init.
+ *
+ * The git hooks AND the CI guardrail workflow both resolve
+ * `./node_modules/.bin/vyuh-dxkit` first and only fall back to a global
+ * install. Without a project-local devDep they silently run whatever
+ * stale global happens to be on PATH — or fail outright on a fresh CI
+ * runner where no global exists. Pinning the dep makes the guardrail
+ * version-locked to the project, which is the whole point of the
+ * local-first resolution (and the only way CI can re-read a baseline +
+ * external snapshots produced by this version).
+ *
+ * Conflict policy (mirrors the rest of the ship surface):
+ *   - No package.json → skip (non-Node repo; uses the global/npx path).
+ *   - Already in dependencies OR devDependencies → skip, preserving the
+ *     consumer's chosen spec (never repin or downgrade).
+ *   - Otherwise → add `^X.Y.Z` to devDependencies and note that the
+ *     consumer must run `npm install` to provision it.
+ */
+export function installDxkitDevDependency(
+  cwd: string,
+  _opts: InstallerOpts = {},
+): ShipInstallResult {
+  const result = emptyResult();
+  const pkgPath = path.join(cwd, 'package.json');
+  if (!fs.existsSync(pkgPath)) return result;
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(pkgPath, 'utf-8');
+  } catch {
+    return result;
+  }
+
+  type DepMap = Record<string, string>;
+  type PackageJson = { dependencies?: DepMap; devDependencies?: DepMap } & Record<string, unknown>;
+  let pkg: PackageJson;
+  try {
+    pkg = JSON.parse(raw) as PackageJson;
+  } catch {
+    result.notes.push(
+      `Skipped dxkit devDependency wire-up: ${path.relative(cwd, pkgPath)} is not valid JSON.`,
+    );
+    return result;
+  }
+
+  if (pkg.dependencies?.[DXKIT_PACKAGE] || pkg.devDependencies?.[DXKIT_PACKAGE]) {
+    result.skipped.push('package.json (devDependencies)');
+    return result;
+  }
+
+  // Pin to the running version's minor range so hooks/CI stay on a
+  // version that understands this project's baseline + snapshots, while
+  // still picking up patch + minor fixes. A bare `latest` is the
+  // fallback when the version is unreadable (broken install reports
+  // '0.0.0').
+  const spec = VERSION && VERSION !== '0.0.0' ? `^${VERSION}` : 'latest';
+  pkg.devDependencies = { ...(pkg.devDependencies ?? {}), [DXKIT_PACKAGE]: spec };
+
+  const trailingNewline = raw.endsWith('\n') ? '\n' : '';
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + trailingNewline, 'utf-8');
+  result.installed.push('package.json (devDependencies)');
+  result.notes.push(
+    `Added ${DXKIT_PACKAGE}@${spec} to devDependencies — run \`npm install\` to provision it so the ` +
+      `git hooks + CI guardrail resolve a project-local dxkit instead of a global (or missing) one.`,
   );
   return result;
 }

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -554,10 +554,20 @@ export function installHooksPostinstall(cwd: string, _opts: InstallerOpts = {}):
     return result;
   }
   if (existing && existing.trim().length > 0) {
-    // Don't auto-chain — too risky. Surface a clear note instead.
+    // Chain after the existing command. `vyuh-dxkit hooks activate` is
+    // exit-0-safe by design, so `&&`-appending preserves the existing
+    // script's exit semantics (a real failure there still fails the
+    // install) while ensuring hooks activate on every clone. Without
+    // this, the common case of an existing postinstall (patch-package,
+    // a husky bootstrap, etc.) silently leaves the pre-push guardrail
+    // inactive — exactly the gap that lets pushes bypass the check.
+    pkg.scripts = { ...(pkg.scripts ?? {}), postinstall: `${existing} && ${POSTINSTALL_CMD}` };
+    const trailing = raw.endsWith('\n') ? '\n' : '';
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + trailing, 'utf-8');
+    result.installed.push('package.json (postinstall)');
     result.notes.push(
-      `Existing package.json scripts.postinstall preserved. To auto-activate dxkit hooks on every clone, ` +
-        `chain by hand: \`"postinstall": "${existing} && ${POSTINSTALL_CMD}"\`.`,
+      `Chained \`${POSTINSTALL_CMD}\` after your existing postinstall so dxkit hooks activate ` +
+        `on every clone. It exits 0, so your script's result is unaffected.`,
     );
     return result;
   }

--- a/src/update.ts
+++ b/src/update.ts
@@ -7,6 +7,7 @@ import {
   installCiBaselineRefresh,
   installCiGuardrails,
   installDevcontainer,
+  installDxkitDevDependency,
   installHooks,
   installHooksPostinstall,
   installIgnoreFiles,
@@ -204,6 +205,14 @@ export async function runUpdate(cwd: string, force: boolean, rescan = false): Pr
   }
   if (flags.withCiGuardrails) {
     mergeShipResult(aggregate, installCiGuardrails(cwd, { force }));
+  }
+  // Self-heal a missing project-local devDependency on upgrade. Pre-fix
+  // installs wired hooks/CI without declaring the package, so they fall
+  // back to a stale global. This adds it when absent (idempotent — skips
+  // when already declared, so a customer's pin is never repinned here;
+  // the actual version bump is `npm install @latest`, npm's job).
+  if (flags.withHooks || flags.withCiGuardrails) {
+    mergeShipResult(aggregate, installDxkitDevDependency(cwd, { force }));
   }
   if (flags.withBaselineRefresh) {
     mergeShipResult(aggregate, installCiBaselineRefresh(cwd, { force }));

--- a/test/analysis-result-cache.test.ts
+++ b/test/analysis-result-cache.test.ts
@@ -455,6 +455,41 @@ describe('resolveProvenance (real git)', () => {
     expect(provenance.workingTreeDirty).toBe(false);
   });
 
+  it('reports dirty when an ingested .dxkit/external snapshot is present', () => {
+    execSync('git init -q', { cwd: tmp });
+    execSync('git config user.email test@example.com', { cwd: tmp });
+    execSync('git config user.name test', { cwd: tmp });
+    fs.writeFileSync(path.join(tmp, 'file.txt'), 'hello');
+    execSync('git add . && git commit -q -m init', { cwd: tmp });
+
+    // `.dxkit/external/` holds ingested external-engine findings — a
+    // gather INPUT, unlike `.dxkit/cache`/`reports` outputs. A new
+    // snapshot must flip the tree dirty so the cache rebuilds and the
+    // ingested findings actually reach the report/baseline.
+    fs.mkdirSync(path.join(tmp, '.dxkit', 'cache'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, '.dxkit', 'cache', 'analysis-result-abc.json'), '{}');
+    fs.mkdirSync(path.join(tmp, '.dxkit', 'external'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, '.dxkit', 'external', 'snyk-code.json'), '{"findings":[]}');
+
+    expect(resolveProvenance(tmp).workingTreeDirty).toBe(true);
+  });
+
+  it('reports dirty for a nested .dxkit/external snapshot too', () => {
+    execSync('git init -q', { cwd: tmp });
+    execSync('git config user.email test@example.com', { cwd: tmp });
+    execSync('git config user.name test', { cwd: tmp });
+    fs.writeFileSync(path.join(tmp, 'file.txt'), 'hello');
+    execSync('git add . && git commit -q -m init', { cwd: tmp });
+
+    fs.mkdirSync(path.join(tmp, 'Code', 'Source', '.dxkit', 'external'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'Code', 'Source', '.dxkit', 'external', 'codeql.json'),
+      '{"findings":[]}',
+    );
+
+    expect(resolveProvenance(tmp).workingTreeDirty).toBe(true);
+  });
+
   it('ignores nested .dxkit/ directories at any depth', () => {
     execSync('git init -q', { cwd: tmp });
     execSync('git config user.email test@example.com', { cwd: tmp });

--- a/test/cli-init.test.ts
+++ b/test/cli-init.test.ts
@@ -119,6 +119,7 @@ describe('cli init --full --yes (integration, full agent scaffold)', () => {
       'dxkit-onboard',
       'dxkit-feature',
       'dxkit-docs',
+      'dxkit-ingest',
     ];
     for (const name of expected) {
       const skillPath = path.join(tmpDir, '.claude', 'skills', name, 'SKILL.md');

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -169,6 +169,40 @@ describe('doctor: operational health (tier 3)', () => {
     expect(r.stdout).toContain('Suggested fixes');
     expect(r.stdout).toContain('dxkit-fix skill');
   });
+
+  it('flags dxkit-not-a-devDependency when a hook exists but package.json omits it', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-doctor-devdep-missing-'));
+    try {
+      execSync('git init -q', { cwd: tmp });
+      fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'demo' }, null, 2));
+      fs.mkdirSync(path.join(tmp, '.githooks'), { recursive: true });
+      fs.writeFileSync(path.join(tmp, '.githooks', 'pre-push'), '#!/bin/sh\n');
+      const r = runDoctor(tmp);
+      expect(r.stdout).toContain('dxkit in package.json devDependencies');
+      expect(r.stdout).toContain('npm install --save-dev @vyuhlabs/dxkit');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('passes the devDependency check when dxkit is declared', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-doctor-devdep-present-'));
+    try {
+      execSync('git init -q', { cwd: tmp });
+      fs.writeFileSync(
+        path.join(tmp, 'package.json'),
+        JSON.stringify({ name: 'demo', devDependencies: { '@vyuhlabs/dxkit': '^2.9.0' } }, null, 2),
+      );
+      fs.mkdirSync(path.join(tmp, '.githooks'), { recursive: true });
+      fs.writeFileSync(path.join(tmp, '.githooks', 'pre-push'), '#!/bin/sh\n');
+      const r = runDoctor(tmp);
+      // Check present and not in the fixes list for this label.
+      expect(r.stdout).toContain('dxkit in package.json devDependencies');
+      expect(r.stdout).not.toContain('npm install --save-dev @vyuhlabs/dxkit');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('doctor --json: structured output', () => {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -203,6 +203,49 @@ describe('doctor: operational health (tier 3)', () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  // A hook wired into core.hooksPath but left non-executable is silently
+  // ignored by git — doctor must NOT report a false green here.
+  it.skipIf(process.platform === 'win32')(
+    'flags a wired-but-non-executable hook instead of a false green',
+    () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-doctor-hook-nonexec-'));
+      try {
+        execSync('git init -q', { cwd: tmp });
+        execSync('git config --local core.hooksPath .githooks', { cwd: tmp });
+        fs.mkdirSync(path.join(tmp, '.githooks'), { recursive: true });
+        const hook = path.join(tmp, '.githooks', 'pre-push');
+        fs.writeFileSync(hook, '#!/bin/sh\nexit 0\n');
+        fs.chmodSync(hook, 0o644); // wired but not executable
+        const r = runDoctor(tmp);
+        expect(r.stdout).toContain('git hooks active');
+        expect(r.stdout).toContain('not executable');
+        expect(r.stdout).toContain('npx vyuh-dxkit hooks activate');
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'passes the hooks check when wired AND executable',
+    () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-doctor-hook-exec-'));
+      try {
+        execSync('git init -q', { cwd: tmp });
+        execSync('git config --local core.hooksPath .githooks', { cwd: tmp });
+        fs.mkdirSync(path.join(tmp, '.githooks'), { recursive: true });
+        const hook = path.join(tmp, '.githooks', 'pre-push');
+        fs.writeFileSync(hook, '#!/bin/sh\nexit 0\n');
+        fs.chmodSync(hook, 0o755);
+        const r = runDoctor(tmp);
+        expect(r.stdout).toContain('git hooks active');
+        expect(r.stdout).not.toContain('not executable');
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe('doctor --json: structured output', () => {

--- a/test/hooks-cli.test.ts
+++ b/test/hooks-cli.test.ts
@@ -73,4 +73,40 @@ describe('activateHooks', () => {
     // Custom value preserved.
     expect(readHooksPath(tmp)).toBe('.husky');
   });
+
+  // Git silently ignores a non-executable hook, so activation must
+  // restore the bit or the guardrail never fires.
+  it.skipIf(process.platform === 'win32')(
+    'restores the executable bit on a non-executable hook',
+    () => {
+      gitInit(tmp);
+      const hooksDir = path.join(tmp, '.githooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      const hook = path.join(hooksDir, 'pre-push');
+      fs.writeFileSync(hook, '#!/bin/sh\nexit 0\n');
+      fs.chmodSync(hook, 0o644); // committed-as-100644 reproduction
+      expect(fs.statSync(hook).mode & 0o111).toBe(0);
+
+      activateHooks(tmp);
+      // Executable bit restored.
+      expect(fs.statSync(hook).mode & 0o111).not.toBe(0);
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'restores the bit even when hooksPath is already set (steady-state re-run)',
+    () => {
+      gitInit(tmp);
+      const hooksDir = path.join(tmp, '.githooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      const hook = path.join(hooksDir, 'pre-push');
+      fs.writeFileSync(hook, '#!/bin/sh\nexit 0\n');
+      activateHooks(tmp); // sets hooksPath + makes executable
+      fs.chmodSync(hook, 0o644); // bit lost afterwards (e.g. re-checkout)
+
+      const result = activateHooks(tmp);
+      expect(result.reason).toBe('already-set-correctly');
+      expect(fs.statSync(hook).mode & 0o111).not.toBe(0);
+    },
+  );
 });

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -25,6 +25,7 @@ import { externalToSecurityFindings } from '../src/ingest/normalize';
 import { writeSnapshot, readAllSnapshots, snapshotEngines } from '../src/ingest/snapshot';
 import { resolveDeepSastEngine } from '../src/ingest/engine-resolver';
 import { codeqlQuerySuiteFor, codeqlDbCreateArgs, codeqlAnalyzeArgs } from '../src/ingest/codeql';
+import { snykCodeTestArgs } from '../src/ingest/snyk-cli';
 import { TOOL_DEFS } from '../src/analyzers/tools/tool-registry';
 import { readDeepSastConfig } from '../src/ingest/config';
 import { codeqlLanguagesFromFlags, anyActivePackSupportsSnykCode } from '../src/languages/index';
@@ -390,6 +391,38 @@ describe('readDeepSastConfig', () => {
       expect(readDeepSastConfig(dir)).toEqual({});
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Snyk CLI runner helpers + registry guard ─────────────────────────────────
+
+describe('snyk-cli helpers', () => {
+  it('builds `snyk code test` argv, with and without --org', () => {
+    expect(snykCodeTestArgs('org-123', '/tmp/o.sarif')).toEqual([
+      'code',
+      'test',
+      '--sarif-file-output=/tmp/o.sarif',
+      '--org=org-123',
+    ]);
+    expect(snykCodeTestArgs(undefined, '/tmp/o.sarif')).toEqual([
+      'code',
+      'test',
+      '--sarif-file-output=/tmp/o.sarif',
+    ]);
+  });
+
+  it('gates the registry snyk entry behind the opt-in env flag', () => {
+    const guard = TOOL_DEFS.snyk.applicabilityGuard!;
+    const prev = process.env.DXKIT_SNYK_CLI;
+    try {
+      delete process.env.DXKIT_SNYK_CLI;
+      expect(guard('.')).toBeTruthy(); // n/a by default
+      process.env.DXKIT_SNYK_CLI = '1';
+      expect(guard('.')).toBeNull(); // applicable once opted in
+    } finally {
+      if (prev === undefined) delete process.env.DXKIT_SNYK_CLI;
+      else process.env.DXKIT_SNYK_CLI = prev;
     }
   });
 });

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -24,6 +24,22 @@ import { snykIssueToFinding } from '../src/ingest/snyk-api';
 import { externalToSecurityFindings } from '../src/ingest/normalize';
 import { writeSnapshot, readAllSnapshots, snapshotEngines } from '../src/ingest/snapshot';
 import { resolveDeepSastEngine } from '../src/ingest/engine-resolver';
+import { codeqlLanguagesFromFlags, anyActivePackSupportsSnykCode } from '../src/languages/index';
+import type { DetectedStack } from '../src/types';
+
+function flags(over: Partial<DetectedStack['languages']>): DetectedStack['languages'] {
+  return {
+    typescript: false,
+    python: false,
+    go: false,
+    rust: false,
+    csharp: false,
+    kotlin: false,
+    java: false,
+    ruby: false,
+    ...over,
+  };
+}
 
 // ─── SARIF ──────────────────────────────────────────────────────────────────
 
@@ -253,6 +269,29 @@ describe('resolveDeepSastEngine', () => {
     expect(d.source).toBe('visibility-private');
     expect(d.requiresConsent).toBe(true);
     expect(d.licenseNote).toBeTruthy();
+  });
+});
+
+// ─── recipe (per-pack deepSast) ───────────────────────────────────────────────
+
+describe('deepSast recipe helpers', () => {
+  it('unions CodeQL languages across active packs, collapsing JS+TS', () => {
+    expect(codeqlLanguagesFromFlags(flags({ typescript: true, python: true })).sort()).toEqual([
+      'javascript',
+      'python',
+    ]);
+    // TS alone resolves to the single `javascript` extractor.
+    expect(codeqlLanguagesFromFlags(flags({ typescript: true }))).toEqual(['javascript']);
+  });
+
+  it('maps compiled packs to their CodeQL extractor (kotlin → java)', () => {
+    expect(codeqlLanguagesFromFlags(flags({ kotlin: true }))).toEqual(['java']);
+  });
+
+  it('reports Snyk Code support per active stack', () => {
+    expect(anyActivePackSupportsSnykCode(flags({ typescript: true }))).toBe(true);
+    // Rust has no Snyk Code support declared.
+    expect(anyActivePackSupportsSnykCode(flags({ rust: true }))).toBe(false);
   });
 });
 

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -23,6 +23,7 @@ import { parseSarif } from '../src/ingest/sarif';
 import { snykIssueToFinding } from '../src/ingest/snyk-api';
 import { externalToSecurityFindings } from '../src/ingest/normalize';
 import { writeSnapshot, readAllSnapshots, snapshotEngines } from '../src/ingest/snapshot';
+import { resolveDeepSastEngine } from '../src/ingest/engine-resolver';
 
 // ─── SARIF ──────────────────────────────────────────────────────────────────
 
@@ -209,6 +210,49 @@ describe('externalToSecurityFindings', () => {
     });
     // No fingerprint field — that is assigned downstream by the aggregator.
     expect('fingerprint' in sf[0]).toBe(false);
+  });
+});
+
+// ─── engine resolver ─────────────────────────────────────────────────────────
+
+describe('resolveDeepSastEngine', () => {
+  const pub = () => 'public' as const;
+  const priv = () => 'private' as const;
+
+  it('honors an explicit engine flag (snyk-code, no consent)', () => {
+    const d = resolveDeepSastEngine({ cwd: '.', engineFlag: 'snyk-code', visibilityProbe: priv });
+    expect(d.engine).toBe('snyk-code');
+    expect(d.source).toBe('flag');
+    expect(d.requiresConsent).toBe(false);
+  });
+
+  it('requires consent for explicit codeql on a non-public repo', () => {
+    const d = resolveDeepSastEngine({ cwd: '.', engineFlag: 'codeql', visibilityProbe: priv });
+    expect(d.engine).toBe('codeql');
+    expect(d.requiresConsent).toBe(true);
+    expect(d.licenseNote).toMatch(/GitHub Advanced Security/);
+  });
+
+  it('prefers ingesting Snyk when configured (license-safe, no consent)', () => {
+    const d = resolveDeepSastEngine({ cwd: '.', snykConfigured: true, visibilityProbe: priv });
+    expect(d.engine).toBe('snyk-code');
+    expect(d.source).toBe('snyk-configured');
+    expect(d.requiresConsent).toBe(false);
+  });
+
+  it('defaults a public repo to CodeQL with no consent', () => {
+    const d = resolveDeepSastEngine({ cwd: '.', visibilityProbe: pub });
+    expect(d.engine).toBe('codeql');
+    expect(d.source).toBe('visibility-public');
+    expect(d.requiresConsent).toBe(false);
+  });
+
+  it('gates a private repo behind consent', () => {
+    const d = resolveDeepSastEngine({ cwd: '.', visibilityProbe: priv });
+    expect(d.engine).toBe('codeql');
+    expect(d.source).toBe('visibility-private');
+    expect(d.requiresConsent).toBe(true);
+    expect(d.licenseNote).toBeTruthy();
   });
 });
 

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for external-findings ingestion (`src/ingest`).
+ *
+ * All fixtures here are SYNTHETIC — minimal hand-authored SARIF and
+ * Snyk-issue shapes. We deliberately do NOT commit any real engine
+ * output, both to keep the suite hermetic and because real scans are
+ * run against private repos whose paths must not leak into the tree.
+ *
+ * Coverage:
+ *   - SARIF 2.1.0 parse: severity resolution (security-severity →
+ *     level fallback), CWE normalization, location skipping, engine
+ *     auto-detection + override, rules-by-index.
+ *   - Snyk REST issue mapping: severity fold (info→low), CWE from
+ *     classes, sourceLocation extraction, no-location skip.
+ *   - normalize: engine → tool provenance, identity left to the aggregator.
+ *   - snapshot: write → read round-trip + fail-open on a missing dir.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseSarif } from '../src/ingest/sarif';
+import { snykIssueToFinding } from '../src/ingest/snyk-api';
+import { externalToSecurityFindings } from '../src/ingest/normalize';
+import { writeSnapshot, readAllSnapshots, snapshotEngines } from '../src/ingest/snapshot';
+
+// ─── SARIF ──────────────────────────────────────────────────────────────────
+
+function sarifWith(results: unknown[], rules: unknown[], driverName = 'CodeQL'): string {
+  return JSON.stringify({
+    runs: [{ tool: { driver: { name: driverName, rules } }, results }],
+  });
+}
+
+describe('parseSarif', () => {
+  it('parses a CodeQL-style result with security-severity + CWE tag', () => {
+    const raw = sarifWith(
+      [
+        {
+          ruleId: 'js/path-injection',
+          message: { text: 'Uncontrolled data used in path expression.' },
+          locations: [
+            {
+              physicalLocation: {
+                artifactLocation: { uri: 'src/handler.ts' },
+                region: { startLine: 42 },
+              },
+            },
+          ],
+        },
+      ],
+      [
+        {
+          id: 'js/path-injection',
+          properties: { 'security-severity': '8.6', tags: ['external/cwe/cwe-023'] },
+        },
+      ],
+    );
+    const f = parseSarif(raw);
+    expect(f).toHaveLength(1);
+    expect(f[0]).toMatchObject({
+      engine: 'codeql',
+      severity: 'high', // 8.6 → high
+      category: 'code',
+      cwe: 'CWE-23', // cwe-023 → CWE-23 (leading zeros stripped)
+      rule: 'js/path-injection',
+      file: 'src/handler.ts',
+      line: 42,
+    });
+  });
+
+  it('maps security-severity bands to four tiers', () => {
+    const band = (score: string) =>
+      parseSarif(
+        sarifWith(
+          [{ ruleId: 'r', locations: [loc('a.ts', 1)] }],
+          [{ id: 'r', properties: { 'security-severity': score } }],
+        ),
+      )[0]?.severity;
+    expect(band('9.5')).toBe('critical');
+    expect(band('7.0')).toBe('high');
+    expect(band('4.0')).toBe('medium');
+    expect(band('1.0')).toBe('low');
+  });
+
+  it('falls back to result level when no security-severity', () => {
+    const sev = (level: string) =>
+      parseSarif(sarifWith([{ ruleId: 'r', level, locations: [loc('a.ts', 1)] }], [{ id: 'r' }]))[0]
+        ?.severity;
+    expect(sev('error')).toBe('high');
+    expect(sev('warning')).toBe('medium');
+    expect(sev('note')).toBe('low');
+  });
+
+  it('skips results with no source location', () => {
+    const raw = sarifWith([{ ruleId: 'r', message: { text: 'no loc' } }], [{ id: 'r' }]);
+    expect(parseSarif(raw)).toHaveLength(0);
+  });
+
+  it('auto-detects engine from driver name and honors an override', () => {
+    const raw = sarifWith(
+      [{ ruleId: 'r', locations: [loc('a.ts', 1)] }],
+      [{ id: 'r' }],
+      'Snyk Code',
+    );
+    expect(parseSarif(raw)[0].engine).toBe('snyk-code');
+    expect(parseSarif(raw, 'codeql')[0].engine).toBe('codeql');
+  });
+
+  it('resolves a rule referenced by index', () => {
+    const raw = JSON.stringify({
+      runs: [
+        {
+          tool: { driver: { name: 'CodeQL', rules: [{ id: 'r0' }, { id: 'r1' }] } },
+          results: [
+            {
+              rule: { index: 1 },
+              ruleId: 'r1',
+              locations: [loc('a.ts', 5)],
+            },
+          ],
+        },
+      ],
+    });
+    const f = parseSarif(raw);
+    expect(f).toHaveLength(1);
+    expect(f[0].rule).toBe('r1');
+  });
+
+  it('returns [] on malformed JSON instead of throwing', () => {
+    expect(parseSarif('not json')).toEqual([]);
+  });
+});
+
+function loc(uri: string, startLine: number) {
+  return { physicalLocation: { artifactLocation: { uri }, region: { startLine } } };
+}
+
+// ─── Snyk REST issue mapping ──────────────────────────────────────────────────
+
+describe('snykIssueToFinding', () => {
+  const baseIssue = (over: Record<string, unknown> = {}) => ({
+    id: 'abc-123',
+    attributes: {
+      title: 'Insecure path access',
+      type: 'code',
+      effective_severity_level: 'high',
+      classes: [{ id: 'CWE-23', source: 'CWE', type: 'weakness' }],
+      coordinates: [
+        {
+          representations: [
+            { sourceLocation: { file: 'src/x.ts', region: { start: { line: 9 } } } },
+          ],
+        },
+      ],
+      ...over,
+    },
+  });
+
+  it('maps a code issue to an ExternalFinding', () => {
+    expect(snykIssueToFinding(baseIssue())).toEqual({
+      engine: 'snyk-code',
+      severity: 'high',
+      category: 'code',
+      cwe: 'CWE-23',
+      rule: 'abc-123',
+      title: 'Insecure path access',
+      file: 'src/x.ts',
+      line: 9,
+    });
+  });
+
+  it('folds info severity to low', () => {
+    expect(snykIssueToFinding(baseIssue({ effective_severity_level: 'info' }))?.severity).toBe(
+      'low',
+    );
+  });
+
+  it('skips an issue with no source location', () => {
+    expect(snykIssueToFinding(baseIssue({ coordinates: [] }))).toBeNull();
+  });
+});
+
+// ─── normalize ───────────────────────────────────────────────────────────────
+
+describe('externalToSecurityFindings', () => {
+  it('maps engine → tool and preserves the rest (identity is the aggregator’s job)', () => {
+    const sf = externalToSecurityFindings([
+      {
+        engine: 'codeql',
+        severity: 'high',
+        category: 'code',
+        cwe: 'CWE-79',
+        rule: 'r',
+        title: 't',
+        file: 'f.ts',
+        line: 3,
+      },
+    ]);
+    expect(sf[0]).toEqual({
+      severity: 'high',
+      category: 'code',
+      cwe: 'CWE-79',
+      rule: 'r',
+      title: 't',
+      file: 'f.ts',
+      line: 3,
+      tool: 'codeql',
+    });
+    // No fingerprint field — that is assigned downstream by the aggregator.
+    expect('fingerprint' in sf[0]).toBe(false);
+  });
+});
+
+// ─── snapshot ────────────────────────────────────────────────────────────────
+
+describe('snapshot round-trip', () => {
+  it('writes and reads back findings; reports engines', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ingest-snap-'));
+    try {
+      writeSnapshot(dir, {
+        schemaVersion: 1,
+        engine: 'codeql',
+        generatedAt: '2026-01-01T00:00:00Z',
+        findings: [
+          {
+            engine: 'codeql',
+            severity: 'high',
+            category: 'code',
+            cwe: 'CWE-79',
+            rule: 'r',
+            title: 't',
+            file: 'f.ts',
+            line: 1,
+          },
+        ],
+      });
+      expect(readAllSnapshots(dir)).toHaveLength(1);
+      expect(snapshotEngines(dir)).toEqual(['codeql']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails open (empty) when no external dir exists', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ingest-empty-'));
+    try {
+      expect(readAllSnapshots(dir)).toEqual([]);
+      expect(snapshotEngines(dir)).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -26,6 +26,7 @@ import { writeSnapshot, readAllSnapshots, snapshotEngines } from '../src/ingest/
 import { resolveDeepSastEngine } from '../src/ingest/engine-resolver';
 import { codeqlQuerySuiteFor, codeqlDbCreateArgs, codeqlAnalyzeArgs } from '../src/ingest/codeql';
 import { snykCodeTestArgs } from '../src/ingest/snyk-cli';
+import { isNotEntitled } from '../src/ingest-cli';
 import { TOOL_DEFS } from '../src/analyzers/tools/tool-registry';
 import { readDeepSastConfig } from '../src/ingest/config';
 import { codeqlLanguagesFromFlags, anyActivePackSupportsSnykCode } from '../src/languages/index';
@@ -424,6 +425,16 @@ describe('snyk-cli helpers', () => {
       if (prev === undefined) delete process.env.DXKIT_SNYK_CLI;
       else process.env.DXKIT_SNYK_CLI = prev;
     }
+  });
+
+  it('classifies a REST not-entitled failure so it falls back to the CLI', () => {
+    // 403, the literal Snyk phrasing, and the generic "api access" all
+    // trigger the CLI fallback; ordinary failures do not.
+    expect(isNotEntitled('Snyk API 403 Forbidden: …')).toBe(true);
+    expect(isNotEntitled('… not entitled for api access')).toBe(true);
+    expect(isNotEntitled('Your plan does not include API access')).toBe(true);
+    expect(isNotEntitled('Snyk API 500 Internal Server Error')).toBe(false);
+    expect(isNotEntitled('fetch failed: ETIMEDOUT')).toBe(false);
   });
 });
 

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -24,6 +24,8 @@ import { snykIssueToFinding } from '../src/ingest/snyk-api';
 import { externalToSecurityFindings } from '../src/ingest/normalize';
 import { writeSnapshot, readAllSnapshots, snapshotEngines } from '../src/ingest/snapshot';
 import { resolveDeepSastEngine } from '../src/ingest/engine-resolver';
+import { codeqlQuerySuiteFor, codeqlDbCreateArgs, codeqlAnalyzeArgs } from '../src/ingest/codeql';
+import { TOOL_DEFS } from '../src/analyzers/tools/tool-registry';
 import { codeqlLanguagesFromFlags, anyActivePackSupportsSnykCode } from '../src/languages/index';
 import type { DetectedStack } from '../src/types';
 
@@ -292,6 +294,51 @@ describe('deepSast recipe helpers', () => {
     expect(anyActivePackSupportsSnykCode(flags({ typescript: true }))).toBe(true);
     // Rust has no Snyk Code support declared.
     expect(anyActivePackSupportsSnykCode(flags({ rust: true }))).toBe(false);
+  });
+});
+
+// ─── CodeQL runner helpers + registry guard ──────────────────────────────────
+
+describe('codeql helpers', () => {
+  it('builds the default security-extended suite and honors an override', () => {
+    expect(codeqlQuerySuiteFor('javascript')).toBe(
+      'codeql/javascript-queries:codeql-suites/javascript-security-extended.qls',
+    );
+    expect(codeqlQuerySuiteFor('python', 'my/suite.qls')).toBe('my/suite.qls');
+  });
+
+  it('builds DB-create and analyze argv (no shell)', () => {
+    expect(codeqlDbCreateArgs('javascript', '/tmp/db', '/repo')).toEqual([
+      'database',
+      'create',
+      '/tmp/db',
+      '--language=javascript',
+      '--source-root=/repo',
+      '--overwrite',
+    ]);
+    expect(codeqlAnalyzeArgs('/tmp/db', 'suite.qls', '/tmp/o.sarif')).toEqual([
+      'database',
+      'analyze',
+      '/tmp/db',
+      'suite.qls',
+      '--format=sarifv2.1.0',
+      '--output=/tmp/o.sarif',
+      '--threads=0',
+    ]);
+  });
+
+  it('gates the registry codeql entry behind the opt-in env flag', () => {
+    const guard = TOOL_DEFS.codeql.applicabilityGuard!;
+    const prev = process.env.DXKIT_CODEQL;
+    try {
+      delete process.env.DXKIT_CODEQL;
+      expect(guard('.')).toBeTruthy(); // n/a by default (kept out of default toolchain)
+      process.env.DXKIT_CODEQL = '1';
+      expect(guard('.')).toBeNull(); // applicable once opted in
+    } finally {
+      if (prev === undefined) delete process.env.DXKIT_CODEQL;
+      else process.env.DXKIT_CODEQL = prev;
+    }
   });
 });
 

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -26,6 +26,7 @@ import { writeSnapshot, readAllSnapshots, snapshotEngines } from '../src/ingest/
 import { resolveDeepSastEngine } from '../src/ingest/engine-resolver';
 import { codeqlQuerySuiteFor, codeqlDbCreateArgs, codeqlAnalyzeArgs } from '../src/ingest/codeql';
 import { TOOL_DEFS } from '../src/analyzers/tools/tool-registry';
+import { readDeepSastConfig } from '../src/ingest/config';
 import { codeqlLanguagesFromFlags, anyActivePackSupportsSnykCode } from '../src/languages/index';
 import type { DetectedStack } from '../src/types';
 
@@ -338,6 +339,45 @@ describe('codeql helpers', () => {
     } finally {
       if (prev === undefined) delete process.env.DXKIT_CODEQL;
       else process.env.DXKIT_CODEQL = prev;
+    }
+  });
+});
+
+// ─── deep-SAST config ─────────────────────────────────────────────────────────
+
+describe('readDeepSastConfig', () => {
+  it('returns {} when no manifest exists (fail-open)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-cfg-none-'));
+    try {
+      expect(readDeepSastConfig(dir)).toEqual({});
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads the deepSast block from .vyuh-dxkit.json', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-cfg-'));
+    try {
+      fs.writeFileSync(
+        path.join(dir, '.vyuh-dxkit.json'),
+        JSON.stringify({ deepSast: { engine: 'snyk-code', snyk: { orgId: 'o', projectId: 'p' } } }),
+      );
+      expect(readDeepSastConfig(dir)).toEqual({
+        engine: 'snyk-code',
+        snyk: { orgId: 'o', projectId: 'p' },
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns {} on malformed JSON', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-cfg-bad-'));
+    try {
+      fs.writeFileSync(path.join(dir, '.vyuh-dxkit.json'), '{ not json');
+      expect(readDeepSastConfig(dir)).toEqual({});
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -89,6 +89,18 @@ describe('parseSarif', () => {
     });
   });
 
+  it('reads CWE from Snyk-style properties.cwe (not just CodeQL tags)', () => {
+    // Snyk Code SARIF encodes CWE in properties.cwe: ["CWE-94"], with
+    // tags carrying only category labels. Regression for the live-data
+    // gap where CWEs came through empty.
+    const raw = sarifWith(
+      [{ ruleId: 'CodeInjection', locations: [loc('a.ts', 1)] }],
+      [{ id: 'CodeInjection', properties: { tags: ['javascript', 'Security'], cwe: ['CWE-94'] } }],
+      'SnykCode',
+    );
+    expect(parseSarif(raw)[0].cwe).toBe('CWE-94');
+  });
+
   it('maps security-severity bands to four tiers', () => {
     const band = (score: string) =>
       parseSarif(

--- a/test/ship-installers.test.ts
+++ b/test/ship-installers.test.ts
@@ -487,17 +487,33 @@ describe('installHooksPostinstall', () => {
     expect(result.installed).toEqual([]);
   });
 
-  it('leaves existing custom postinstall in place + emits a chain note', () => {
+  it('chains after an existing custom postinstall (exit-0-safe activate)', () => {
     fs.writeFileSync(
       path.join(tmp, 'package.json'),
       JSON.stringify({ name: 'demo', scripts: { postinstall: 'husky install' } }, null, 2),
     );
     const result = installHooksPostinstall(tmp);
-    expect(result.installed).toEqual([]);
-    expect(result.notes.some((n) => n.includes('postinstall preserved'))).toBe(true);
+    expect(result.installed).toContain('package.json (postinstall)');
     const pkg = JSON.parse(fs.readFileSync(path.join(tmp, 'package.json'), 'utf-8'));
-    // Original script untouched.
-    expect(pkg.scripts.postinstall).toBe('husky install');
+    // Existing command preserved, our activation appended with &&.
+    expect(pkg.scripts.postinstall).toBe('husky install && vyuh-dxkit hooks activate');
+  });
+
+  it('is idempotent on a previously-chained postinstall', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify(
+        { name: 'demo', scripts: { postinstall: 'husky install && vyuh-dxkit hooks activate' } },
+        null,
+        2,
+      ),
+    );
+    const result = installHooksPostinstall(tmp);
+    expect(result.skipped).toContain('package.json (postinstall)');
+    expect(result.installed).toEqual([]);
+    const pkg = JSON.parse(fs.readFileSync(path.join(tmp, 'package.json'), 'utf-8'));
+    // No double-append.
+    expect(pkg.scripts.postinstall).toBe('husky install && vyuh-dxkit hooks activate');
   });
 
   it('handles a malformed package.json without crashing', () => {

--- a/test/ship-installers.test.ts
+++ b/test/ship-installers.test.ts
@@ -11,8 +11,10 @@ import {
   installPrReview,
   installIgnoreFiles,
   installHooksPostinstall,
+  installDxkitDevDependency,
   detectDefaultBranch,
 } from '../src/ship-installers';
+import { VERSION } from '../src/constants';
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const TEMPLATES_DIR = path.join(REPO_ROOT, 'templates');
@@ -511,6 +513,82 @@ describe('installHooksPostinstall', () => {
       JSON.stringify({ name: 'demo' }, null, 2) + '\n',
     );
     installHooksPostinstall(tmp);
+    const written = fs.readFileSync(path.join(tmp, 'package.json'), 'utf-8');
+    expect(written.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('installDxkitDevDependency', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-devdep-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('skips cleanly when no package.json exists (non-Node repo)', () => {
+    const result = installDxkitDevDependency(tmp);
+    expect(result.installed).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(result.notes).toEqual([]);
+  });
+
+  it('adds dxkit to devDependencies pinned to the running version', () => {
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'demo' }, null, 2));
+    const result = installDxkitDevDependency(tmp);
+    expect(result.installed).toContain('package.json (devDependencies)');
+    const pkg = JSON.parse(fs.readFileSync(path.join(tmp, 'package.json'), 'utf-8'));
+    expect(pkg.devDependencies['@vyuhlabs/dxkit']).toBe(`^${VERSION}`);
+  });
+
+  it('preserves an existing devDependencies block + other deps', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify({ name: 'demo', devDependencies: { vitest: '^3.0.0' } }, null, 2),
+    );
+    installDxkitDevDependency(tmp);
+    const pkg = JSON.parse(fs.readFileSync(path.join(tmp, 'package.json'), 'utf-8'));
+    expect(pkg.devDependencies.vitest).toBe('^3.0.0');
+    expect(pkg.devDependencies['@vyuhlabs/dxkit']).toBe(`^${VERSION}`);
+  });
+
+  it('skips when dxkit is already in devDependencies (preserves the consumer pin)', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify({ name: 'demo', devDependencies: { '@vyuhlabs/dxkit': '2.5.0' } }, null, 2),
+    );
+    const result = installDxkitDevDependency(tmp);
+    expect(result.skipped).toContain('package.json (devDependencies)');
+    expect(result.installed).toEqual([]);
+    const pkg = JSON.parse(fs.readFileSync(path.join(tmp, 'package.json'), 'utf-8'));
+    expect(pkg.devDependencies['@vyuhlabs/dxkit']).toBe('2.5.0');
+  });
+
+  it('skips when dxkit is in (runtime) dependencies — never moves or duplicates it', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify({ name: 'demo', dependencies: { '@vyuhlabs/dxkit': '2.5.0' } }, null, 2),
+    );
+    const result = installDxkitDevDependency(tmp);
+    expect(result.skipped).toContain('package.json (devDependencies)');
+    const pkg = JSON.parse(fs.readFileSync(path.join(tmp, 'package.json'), 'utf-8'));
+    expect(pkg.devDependencies).toBeUndefined();
+  });
+
+  it('handles a malformed package.json without crashing', () => {
+    fs.writeFileSync(path.join(tmp, 'package.json'), '{ not valid json');
+    const result = installDxkitDevDependency(tmp);
+    expect(result.installed).toEqual([]);
+    expect(result.notes.some((n) => n.includes('not valid JSON'))).toBe(true);
+  });
+
+  it('preserves trailing newline on the original package.json', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify({ name: 'demo' }, null, 2) + '\n',
+    );
+    installDxkitDevDependency(tmp);
     const written = fs.readFileSync(path.join(tmp, 'package.json'), 'utf-8');
     expect(written.endsWith('\n')).toBe(true);
   });


### PR DESCRIPTION
## 2.9.0 — Deep SAST: engine-agnostic interprocedural findings

dxkit's bundled SAST (community semgrep) is intraprocedural and misses the cross-function taint class (path traversal, info exposure, SSRF, injection) that engines like Snyk Code / CodeQL catch. 2.9 makes dxkit **ingest** any such engine's findings and treat them as first-class — fingerprinted, deduped, baselined, guardrailed, graph-linked, and fixable through the agent loop — rather than trying to re-detect that class.

### Highlights

- **`vyuh-dxkit ingest`** — `--from-snyk`, `--sarif <file>` (any SARIF engine), `--codeql` (OSS/GHAS). Findings land in a committed `.dxkit/external/<engine>.json` snapshot; the engine token is needed only at ingest time.
- **Snyk on every plan** — `--from-snyk` reads the REST API quota-free where entitled (Enterprise), and on Free/Team plans automatically falls back to `snyk code test` (`--snyk-cli` forces it). Credentials resolve flag → `.vyuh-dxkit.json` → env (`SNYK_TOKEN` / `SNYK_ORG_ID` / `SNYK_PROJECT_ID`); dxkit does not auto-load `.env`.
- **Engine-agnostic core** — one `ExternalFinding` normalize layer; identity via the canonical fingerprint helpers; per-pack `deepSast` recipe; license-aware engine resolver. New architecture Rule 13.
- **CI refresh workflow** — `--with-deep-sast-refresh` (opt-in), with an `api|cli` method input.
- **New `dxkit-ingest` skill**; `dxkit-action` / `dxkit-config` / `dxkit-update` updated.

### Guardrail reliability (a guardrail only protects if the hook actually fires)

Found by exercising the full install path on a real brownfield repo:

- **`init`/`update` declare `@vyuhlabs/dxkit` in devDependencies** so hooks + CI resolve a pinned local binary, not a stale global (or nothing on a fresh CI runner). New `doctor` check.
- **Non-executable hook is no longer a silent no-op** — git ignores a hook without the executable bit (a hook committed as 100644, or a filesystem that drops it), so pushes sailed through with no check while `doctor` showed a false green. `hooks activate` now restores the bit on every run (self-heals via postinstall); `doctor` verifies executability.
- **Hook activation chains after an existing `postinstall`** (patch-package, husky) instead of bailing with a note.

### Validation

- Affected-scope tests green locally; **full regression runs here in CI** (per release plan).
- Deep-SAST path validated end-to-end on a real customer repo: Snyk REST → 403 → CLI fallback → 174 findings (97H/49M/28L, byte-identical across runs); guardrail fires + blocks net-new + passes clean through a real `git push`.

### Merge strategy

**Rebase-merge** — the branch bundles multiple independently-meaningful units (ingest core, resolver, recipe, CodeQL runner, refresh workflow, REST→CLI fallback, devDep declaration, hooks-executable fix, postinstall chain), each with its own message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)