### PR TITLE
2.9.1 — cross-tool dedup + allowlist suppression + ignore sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.1] - 2026-06-08
+
+### Cross-tool dedup + allowlist suppression + ignore sync
+
+A follow-up to 2.9's ingestion: when two engines flag the same weakness, count
+it once; make the allowlist actually suppress; and keep ignores in sync across
+the tools dxkit ingests from.
+
+- **Cross-tool dedup.** Two engines that flag one weakness at one site under
+  different rule names no longer double-count. The aggregator collapses them via
+  a canonical-rule map and a CWE-at-the-same-location bridge (only ever across
+  different tools), keeping the higher severity and recording every contributing
+  tool.
+- **The allowlist now suppresses findings from the guardrail verdict.**
+  Previously it was audit-only (category / reason / expiry + a PR-comment delta)
+  while the baseline was the sole suppressor — a reviewed-and-accepted finding
+  that landed outside the baseline still blocked. An active, unexpired allowlist
+  entry now waives a matching finding from the verdict; expired entries stop
+  suppressing, so the finding re-blocks the moment its window lapses. Suppressed
+  findings surface in their own report section (console / JSON / markdown) —
+  visible for review, never silently dropped, never counted as a live
+  regression.
+- **Robust matching across dedup.** A suppression keyed on a contributing
+  fingerprint still matches the merged finding, so dedup nondeterminism between
+  runs (which engine is present, line wobble) can't silently orphan an
+  acceptance.
+- **Allowlist expiry surfaced.** `vyuh-dxkit doctor` flags expired allowlist
+  entries (their findings re-block) and entries expiring within the audit
+  window. The allowlist docs gain a verdict-behavior + expiry-lifecycle section.
+- **Ignore sync across tools.**
+  - dxkit honors a SARIF result's own `suppressions`: a finding dismissed
+    upstream (Snyk Code, CodeQL, Semgrep Pro) no longer re-surfaces here.
+  - Ingested findings pass through the same `.dxkit-ignore` path exclusions as
+    native findings — an external engine that scans vendored / generated /
+    fixture code no longer leaks findings dxkit would never raise itself.
+
+### Upgrading from 2.9.0 — re-baseline + re-point the allowlist
+
+Cross-tool dedup changes the fingerprints of merged findings, so a baseline or
+allowlist captured on 2.9.0 partially goes stale:
+
+1. **Re-baseline:** `vyuh-dxkit baseline create --force`. (On a real polyglot
+   repo, most findings keep their fingerprint; only the cross-tool merges
+   change.)
+2. **Re-point the allowlist:** run `vyuh-dxkit allowlist audit` to find entries
+   that no longer match a finding, then re-add them against the fresh
+   fingerprints from the guardrail output (`vyuh-dxkit allowlist prune` clears
+   the stale ones). Robust matching prevents _future_ run-to-run orphaning but
+   cannot bridge this one-time fingerprint change, so the re-point is manual.
+
 ## [2.9.0] - 2026-06-08
 
 ### Deep SAST — engine-agnostic interprocedural findings (2.9)

--- a/docs/commands/allowlist.md
+++ b/docs/commands/allowlist.md
@@ -99,6 +99,58 @@ repos), the file carries only `fingerprint + kind + category`; the
 human-readable reason + addedBy live in a gitignored sidecar
 (`.dxkit/allowlist-reasons.local.json`).
 
+## How a suppression affects the guardrail verdict
+
+An **active** allowlist entry waives a matching finding from the
+guardrail verdict: a finding that would otherwise block the PR passes
+instead. The finding is not hidden — the guardrail report lists it
+under a **"Suppressed by allowlist"** section (console, JSON, and the
+PR comment), showing its category and expiry so reviewers still see
+what was accepted. It simply no longer fails the check.
+
+Matching is by the finding's fingerprint **and** kind. When dxkit
+collapses the same weakness reported by two engines into one finding,
+a suppression keyed on either engine's fingerprint still applies — so
+adding or removing a scanner between runs can't silently orphan an
+existing acceptance.
+
+This is the difference from the baseline. A
+[`baseline`](./baseline.md) accepts your **whole existing codebase**
+at a point in time (everything present is "pre-existing debt"). The
+allowlist accepts **one specific finding** — including a brand-new one
+that lands outside the baseline — with a typed reason and, where
+required, an expiry. Use the baseline for "don't block me on the
+mountain of existing issues," and the allowlist for "this particular
+finding is reviewed and accepted."
+
+## Expiry lifecycle
+
+An entry with an `expiresAt` date suppresses its finding **only while
+it's active** — up to and including the expiry date:
+
+1. **Active** — the finding is waived from the verdict. The entry
+   shows in the guardrail report's suppressed section.
+2. **Nearing expiry** — within the audit window (default 14 days),
+   `allowlist audit` lists it under _soon to expire_, and
+   [`vyuh-dxkit doctor`](./doctor.md) raises an
+   **"allowlist suppressions expiring soon"** check so the deadline
+   doesn't sneak up mid-sprint.
+3. **Expired** — the entry stops suppressing. **The underlying finding
+   re-blocks the guardrail on the next run.** `doctor` flags expired
+   entries; `allowlist audit` lists them; `allowlist prune` removes
+   them.
+
+`accepted-risk` and `deferred` always carry an expiry (90-day default)
+because they're assertions that should age out and be re-reviewed.
+`false-positive`, `test-fixture`, and `mitigated-externally` may carry
+one but don't have to — a true false positive doesn't expire.
+
+When an entry expires, you have three honest choices: **fix** the
+finding, **re-add** the entry with a fresh expiry (re-review), or let
+it lapse and accept that the finding blocks again. There's no fourth
+"suppress forever without revisiting" option for the time-boxed
+categories — that's the point.
+
 ## Subcommands
 
 ### `add` — create a new suppression

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -297,7 +297,10 @@ See [`vyuh-dxkit issue`](commands/issue.md) for full details.
   it, an automatic `snyk code test` fallback on free/team), `--sarif <file>`
   (any SARIF engine), or `--codeql` (open-source / GHAS). Ingested findings
   are fingerprinted, baselined, guardrailed, and graph-linked like native
-  ones. The `dxkit-ingest` skill walks through token setup.
+  ones — and stay in sync with the source engine: a finding you dismissed
+  upstream (its SARIF `suppressions`) doesn't re-surface, and `.dxkit-ignore`
+  path exclusions apply to ingested findings the same as native ones. The
+  `dxkit-ingest` skill walks through token setup.
 - Per-command pages in [`commands/`](commands/) describe options +
   output shape in detail.
 - [Allowlist reference](commands/allowlist.md) — per-finding

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "AI-native developer experience toolkit for any codebase",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/analyzers/security/aggregator.ts
+++ b/src/analyzers/security/aggregator.ts
@@ -97,6 +97,12 @@ export interface CodeFinding extends SecurityFinding {
   fingerprint: string;
   canonicalRule: string;
   producedBy: string[];
+  /** Fingerprints of the cross-tool / neighbor-bucket / CWE-bridge
+   *  findings that collapsed into this one, when their own fingerprint
+   *  differed from `fingerprint`. Present only when such a merge fired.
+   *  Lets a suppression keyed on a contributing fingerprint still match
+   *  the merged finding (robust matching against dedup nondeterminism). */
+  absorbedFingerprints?: string[];
 }
 
 /**
@@ -310,6 +316,13 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
     tool: string;
     producedBy: Set<string>;
     raws: Array<{ tool: string; rule: string; line: number; severity: Severity }>;
+    /** Natural fingerprints of findings that merged into this group but
+     *  whose own fingerprint differs from the representative — i.e. the
+     *  cross-tool / neighbor-bucket / CWE-bridge merges. A suppression
+     *  keyed on any of these (e.g. allowlisted from a run where a
+     *  different tool was the representative) still matches the merged
+     *  finding, so dedup nondeterminism between runs can't orphan it. */
+    absorbedFingerprints: Set<string>;
   };
   const groups = new Map<string, Group>();
 
@@ -376,6 +389,13 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
         line: f.line,
         severity: f.severity,
       });
+      // Record the merged finding's own fingerprint when it differs
+      // from the representative — that's the identity a suppression
+      // might have been keyed on in a run where the merge landed the
+      // other way around.
+      if (naturalFingerprint !== existing.fingerprint) {
+        existing.absorbedFingerprints.add(naturalFingerprint);
+      }
       // Prefer the lower line number as the canonical line — semgrep
       // typically reports the declaration (earlier line) while
       // registry-grep reports the assignment; the declaration is the
@@ -408,6 +428,7 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
             severity: f.severity,
           },
         ],
+        absorbedFingerprints: new Set(),
       });
     }
     // Index this finding's CWE + location → its group, so a later
@@ -437,6 +458,9 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
       fingerprint: g.fingerprint,
       canonicalRule: g.canonicalRule,
       producedBy: [...g.producedBy].sort(),
+      ...(g.absorbedFingerprints.size > 0
+        ? { absorbedFingerprints: [...g.absorbedFingerprints].sort() }
+        : {}),
     };
 
     if (g.category === 'secret') {

--- a/src/analyzers/security/aggregator.ts
+++ b/src/analyzers/security/aggregator.ts
@@ -57,7 +57,7 @@
 
 import type { DepVulnFinding } from '../../languages/capabilities/types';
 import type { Severity, FindingCategory, SecurityFinding } from './types';
-import { canonicalRuleFor, computeCodeFingerprint } from '../tools/fingerprint';
+import { canonicalRuleFor, computeCodeFingerprint, lineWindowFor } from '../tools/fingerprint';
 
 // ─── Re-exports for consumer convenience ──────────────────────────────────
 
@@ -313,6 +313,18 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
   };
   const groups = new Map<string, Group>();
 
+  // Cross-tool CWE index: `cwe \0 file \0 lineWindow` → the fingerprint of
+  // the group occupying that spot. Lets two engines that flag the same
+  // weakness at the same place under DIFFERENT rule names (so the
+  // canonical-rule map doesn't bridge them) still collapse — provided
+  // they agree on the CWE. Only ever bridges across tools; a single
+  // tool's own findings are governed by the canonical-rule path above,
+  // so this never collapses findings one tool intentionally reported
+  // separately.
+  const byCweLoc = new Map<string, string>();
+  const cweLocKey = (cwe: string, file: string, line: number): string =>
+    `${cwe}\0${file}\0${lineWindowFor(line)}`;
+
   for (const f of rawCodeFindings) {
     const canonicalRule = canonicalRuleFor(f.tool, f.rule);
     const naturalFingerprint = computeCodeFingerprint(canonicalRule, f.file, f.line);
@@ -335,6 +347,22 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
         if (candidate) {
           existing = candidate;
           fingerprint = neighborFingerprint;
+          break;
+        }
+      }
+    }
+    // Cross-tool CWE fallback. Still no match and this finding has a CWE?
+    // Join a group another tool already opened at the same file +
+    // line-window with the same CWE. Gated to a DIFFERENT tool so one
+    // tool's distinct same-CWE findings are never collapsed (those stay
+    // governed by the canonical-rule path above).
+    if (!existing && f.cwe) {
+      for (const offset of [0, -3, 3]) {
+        const fp = byCweLoc.get(cweLocKey(f.cwe, f.file, f.line + offset));
+        const candidate = fp ? groups.get(fp) : undefined;
+        if (candidate && !candidate.producedBy.has(f.tool)) {
+          existing = candidate;
+          fingerprint = candidate.fingerprint;
           break;
         }
       }
@@ -382,6 +410,9 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
         ],
       });
     }
+    // Index this finding's CWE + location → its group, so a later
+    // finding from another tool sharing the CWE can collapse into it.
+    if (f.cwe) byCweLoc.set(cweLocKey(f.cwe, f.file, f.line), fingerprint);
   }
 
   const codeFindingsByCategory: Record<'secret' | 'code' | 'config', CodeFinding[]> = {

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -19,7 +19,7 @@ import { scoreFindings } from '../tools/risk-score';
 import { resolveTransitiveUpgradePlans } from '../tools/upgrade-plan-resolver';
 import { externalToSecurityFindings } from '../../ingest/normalize';
 import { readAllSnapshots, snapshotEngines } from '../../ingest/snapshot';
-import { getFindExcludeFlags } from '../tools/exclusions';
+import { getFindExcludeFlags, isExcludedPath } from '../tools/exclusions';
 import { walkSourceFiles, commentSyntaxFor, isCommentLine } from '../tools/walk-source-files';
 import * as path from 'path';
 import { SecurityFinding, DepVulnSummary, Severity } from './types';
@@ -571,7 +571,16 @@ export async function buildSecurityAggregateForHealth(
   // Ingested external-engine findings (Snyk Code / CodeQL / SARIF) read
   // from committed `.dxkit/external/` snapshots. Absent → empty → the
   // aggregate is byte-identical to a run with no ingestion configured.
-  const externalFindings = externalToSecurityFindings(readAllSnapshots(cwd));
+  //
+  // Path exclusions apply to ingested findings too: an external engine
+  // may scan a wider tree than dxkit (vendored code, generated output,
+  // test fixtures). Filtering here through the one canonical exclusion
+  // check keeps `.dxkit-ignore` authoritative over ingested findings the
+  // same way it already is over native ones — a finding dxkit would
+  // never raise in an excluded path doesn't sneak in via ingestion.
+  const externalFindings = externalToSecurityFindings(readAllSnapshots(cwd)).filter(
+    (f) => !isExcludedPath(cwd, f.file),
+  );
   const externalEngines = snapshotEngines(cwd);
 
   return buildSecurityAggregate({

--- a/src/analyzers/tools/fingerprint.ts
+++ b/src/analyzers/tools/fingerprint.ts
@@ -94,10 +94,20 @@ export function collectFingerprints(findings: ReadonlyArray<DepVulnFinding>): st
  * default. Never accidentally collapses unrelated findings.
  */
 export const CANONICAL_RULE_MAP: ReadonlyMap<string, string> = new Map<string, string>([
-  // TLS / certificate validation bypass
+  // TLS / certificate validation bypass. An ingested engine reports the
+  // same insecure-TLS construct under its own rule (Snyk classes it as
+  // CWE-327 where the registry grep classes it CWE-295), so the CWE
+  // fallback can't bridge them — they're mapped explicitly here.
   ['tls-bypass-registry:tls-validation-disabled', 'canonical:tls-bypass'],
   ['semgrep:bypass-tls-verification', 'canonical:tls-bypass'],
   ['semgrep:nodejsscan.node_tls_reject_unauthorized', 'canonical:tls-bypass'],
+  ['snyk-code:javascript/InsecureTLSConfig', 'canonical:tls-bypass'],
+
+  // Code injection / dynamic require of request-derived input. The
+  // bundled scanner and an interprocedural engine both reach the same
+  // sink under different rule names.
+  ['semgrep:require-request', 'canonical:code-injection'],
+  ['snyk-code:javascript/CodeInjection', 'canonical:code-injection'],
 
   // Private-key file on disk — find + gitleaks may both surface
   ['find:private-key-file', 'canonical:private-key-on-disk'],

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -30,6 +30,26 @@ import type { ClassifiedPair, EnvelopeDrift, GuardrailCheckResult } from './chec
 import type { BrownfieldPolicy } from './policy';
 import type { FindingStatus, MatchReason } from './types';
 
+// ─── Shared verdict predicates ────────────────────────────────────────────
+
+/**
+ * Whether a pair was accepted by an active allowlist entry. Such a
+ * pair would otherwise block, so it carries `classification.blocks ===
+ * true`; the verdict already excludes it (see `pairBlocks` in
+ * `check.ts`). The renderers mirror that here so a suppressed finding
+ * is surfaced in its own bucket — never silently dropped, never
+ * miscounted as a live regression.
+ */
+function isAllowlistSuppressed(p: ClassifiedPair): boolean {
+  return p.suppressedByAllowlist !== undefined;
+}
+
+/** Whether a pair contributes a live BLOCK to the verdict — blocking
+ *  per the classifier AND not waived by an active allowlist entry. */
+function isBlocking(p: ClassifiedPair): boolean {
+  return p.classification.blocks && p.suppressedByAllowlist === undefined;
+}
+
 // ─── Console renderer ─────────────────────────────────────────────────────
 
 /**
@@ -73,7 +93,8 @@ export function renderConsole(result: GuardrailCheckResult): string {
 
   // Group + render pairs by verdict bucket. Buckets ordered so the
   // most actionable surfaces first.
-  const blocking = result.pairs.filter((p) => p.classification.blocks);
+  const blocking = result.pairs.filter(isBlocking);
+  const suppressed = result.pairs.filter(isAllowlistSuppressed);
   const warning = result.pairs.filter((p) => !p.classification.blocks && p.classification.warns);
   const persisted = result.pairs.filter(
     (p) =>
@@ -86,6 +107,11 @@ export function renderConsole(result: GuardrailCheckResult): string {
   if (blocking.length > 0) {
     lines.push(logger.bold(`Blocking (${blocking.length})`));
     for (const p of blocking) lines.push(...formatPairLines(p, '  '));
+    lines.push('');
+  }
+  if (suppressed.length > 0) {
+    lines.push(logger.bold(`Suppressed by allowlist (${suppressed.length})`));
+    for (const p of suppressed) lines.push(...formatPairLines(p, '  '));
     lines.push('');
   }
   if (warning.length > 0) {
@@ -104,6 +130,7 @@ export function renderConsole(result: GuardrailCheckResult): string {
   lines.push(logger.bold('Summary'));
   lines.push(
     `  Pairs:       ${result.pairs.length} (blocking: ${blocking.length}, ` +
+      `suppressed: ${suppressed.length}, ` +
       `warning: ${warning.length}, persisted: ${persisted.length}, ` +
       `resolved: ${removed.length})`,
   );
@@ -122,7 +149,7 @@ export function renderConsole(result: GuardrailCheckResult): string {
 
 function verdictBanner(result: GuardrailCheckResult): string {
   if (result.blocks) {
-    const count = result.pairs.filter((p) => p.classification.blocks).length;
+    const count = result.pairs.filter(isBlocking).length;
     return logger.bold(`Guardrail BLOCKED — ${count} new regression${count === 1 ? '' : 's'}`);
   }
   if (result.warns) {
@@ -144,6 +171,14 @@ function formatPairLines(p: ClassifiedPair, indent: string): string[] {
   );
   for (const r of p.classification.reasons) {
     out.push(`${indent}  · ${r.code}: ${r.detail}`);
+  }
+  if (p.suppressedByAllowlist) {
+    const exp = p.suppressedByAllowlist.expiresAt
+      ? `, expires ${p.suppressedByAllowlist.expiresAt}`
+      : '';
+    out.push(
+      `${indent}  · allowlisted: ${p.suppressedByAllowlist.category}${exp} (waived from the verdict)`,
+    );
   }
   return out;
 }
@@ -267,6 +302,9 @@ export interface GuardrailJsonPayload {
   readonly summary: {
     readonly pairs: number;
     readonly blocking: number;
+    /** Pairs the classifier would block but an active allowlist entry
+     *  waived. Excluded from `blocking`; surfaced for review. */
+    readonly suppressed: number;
     readonly warning: number;
     readonly persisted: number;
     readonly resolved: number;
@@ -283,12 +321,22 @@ export interface GuardrailJsonPayload {
     readonly file?: string;
     readonly line?: number;
     readonly overlapsChangedLines?: boolean;
+    /** Present when an active allowlist entry waived this pair from the
+     *  verdict. `blocks` stays true (the classifier's view); consumers
+     *  deciding pass/fail must treat a pair with this field as
+     *  non-blocking — mirror of the top-level `verdict`. */
+    readonly suppressedByAllowlist?: {
+      readonly fingerprint: string;
+      readonly category: string;
+      readonly expiresAt?: string;
+    };
     readonly reasons: ReadonlyArray<MatchReason>;
   }>;
 }
 
 export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
-  const blocking = result.pairs.filter((p) => p.classification.blocks).length;
+  const blocking = result.pairs.filter(isBlocking).length;
+  const suppressed = result.pairs.filter(isAllowlistSuppressed).length;
   const warning = result.pairs.filter(
     (p) => !p.classification.blocks && p.classification.warns,
   ).length;
@@ -339,6 +387,7 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
     summary: {
       pairs: result.pairs.length,
       blocking,
+      suppressed,
       warning,
       persisted,
       resolved,
@@ -356,6 +405,9 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
       ...(p.line !== undefined ? { line: p.line } : {}),
       ...(p.overlapsChangedLines !== undefined
         ? { overlapsChangedLines: p.overlapsChangedLines }
+        : {}),
+      ...(p.suppressedByAllowlist !== undefined
+        ? { suppressedByAllowlist: p.suppressedByAllowlist }
         : {}),
       reasons: p.classification.reasons,
     })),
@@ -377,7 +429,8 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
  */
 export function renderMarkdown(result: GuardrailCheckResult): string {
   const lines: string[] = [];
-  const blocking = result.pairs.filter((p) => p.classification.blocks);
+  const blocking = result.pairs.filter(isBlocking);
+  const suppressed = result.pairs.filter(isAllowlistSuppressed);
   const warning = result.pairs.filter((p) => !p.classification.blocks && p.classification.warns);
   const resolved = result.pairs.filter((p) => p.classification.status === 'removed');
 
@@ -393,6 +446,30 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     lines.push('| Status | Kind | Severity | Location | Reason |');
     lines.push('|---|---|---|---|---|');
     for (const p of blocking) lines.push(markdownPairRow(p));
+    lines.push('');
+  }
+
+  if (suppressed.length > 0) {
+    lines.push('<details>');
+    lines.push(`<summary>Suppressed by allowlist (${suppressed.length})</summary>`);
+    lines.push('');
+    lines.push(
+      'These findings would block, but an active allowlist entry accepted them. ' +
+        'Review the category + expiry before approving.',
+    );
+    lines.push('');
+    lines.push('| Status | Kind | Severity | Location | Category | Expires |');
+    lines.push('|---|---|---|---|---|---|');
+    for (const p of suppressed) {
+      const s = p.suppressedByAllowlist;
+      lines.push(
+        `| ${escapeMd(statusLabel(p.classification.status))} | ${escapeMd(p.kind)} | ` +
+          `${escapeMd(p.severity ?? '—')} | ${escapeMd(locatorProse(p) || '—')} | ` +
+          `${escapeMd(s?.category ?? '—')} | ${escapeMd(s?.expiresAt ?? '—')} |`,
+      );
+    }
+    lines.push('');
+    lines.push('</details>');
     lines.push('');
   }
 

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -62,6 +62,9 @@ import { isSanitized } from './sanitize';
 import type { BaselineEntry, FindingId, FindingSeverity, MatchPair, MatchResult } from './types';
 import type { SecurityAggregate } from '../analyzers/security/aggregator';
 import { computeAllowlistDelta, type AllowlistDelta } from '../allowlist/diff';
+import { findEntry, isEntryActive, loadAllowlist } from '../allowlist/file';
+import type { AllowlistFile } from '../allowlist/file';
+import type { AllowlistCategory } from '../allowlist/categories';
 
 export interface RunGuardrailCheckOptions {
   /** Repo root being checked. Caller should pass an absolute path. */
@@ -125,6 +128,27 @@ export interface ClassifiedPair {
    *  `newSevereQualityIssueInChangedFiles` / `newUntestedChangedSource`
    *  block rules. */
   readonly overlapsChangedLines?: boolean;
+  /** Present when an active (unexpired) allowlist entry matches this
+   *  finding's fingerprint AND the classifier would otherwise block.
+   *  The block is waived; this field records WHY so renderers can
+   *  show the reviewed-and-accepted rationale instead of silently
+   *  dropping the finding. Expired entries never populate this — the
+   *  finding re-blocks and the stale entry is surfaced for pruning. */
+  readonly suppressedByAllowlist?: AllowlistSuppression;
+}
+
+/**
+ * Why a would-block finding didn't block: an active allowlist entry
+ * accepted it. Carries the audit fields a reviewer needs to judge the
+ * suppression at a glance (category + expiry), keyed by the matched
+ * fingerprint.
+ */
+export interface AllowlistSuppression {
+  readonly fingerprint: string;
+  readonly category: AllowlistCategory;
+  /** ISO `YYYY-MM-DD` expiry when the entry carries one; absent for
+   *  non-expiring categories. */
+  readonly expiresAt?: string;
 }
 
 export interface EnvelopeDrift {
@@ -264,6 +288,14 @@ export async function runGuardrailCheck(
     return cached;
   };
 
+  // Load the per-finding allowlist once. An active (unexpired) entry
+  // whose fingerprint matches a would-block finding waives the block —
+  // this is what makes "I reviewed and accepted this finding" actually
+  // suppress a net-new regression, not just annotate it. Null when no
+  // allowlist file is present (the common case).
+  const allowlist = loadAllowlist(cwd);
+  const now = new Date();
+
   const classifiedPairs: ClassifiedPair[] = [];
   let blocks = false;
   let warns = false;
@@ -301,7 +333,19 @@ export async function runGuardrailCheck(
     };
 
     const classification = classify(pair, policy, context);
-    if (classification.blocks) blocks = true;
+
+    // Allowlist suppression: only consulted when the classifier would
+    // block. An active entry matching this finding's fingerprint (and
+    // kind, to rule out an astronomically-unlikely cross-kind hash
+    // collision) waives the block. Expired entries are skipped here so
+    // the finding re-blocks the moment its accepted-risk window lapses.
+    const suppressedByAllowlist =
+      classification.blocks && allowlist
+        ? allowlistSuppressionFor(allowlist, anchorEntry, now)
+        : undefined;
+
+    const effectiveBlocks = classification.blocks && suppressedByAllowlist === undefined;
+    if (effectiveBlocks) blocks = true;
     if (classification.warns) warns = true;
 
     classifiedPairs.push({
@@ -312,6 +356,7 @@ export async function runGuardrailCheck(
       ...(file !== undefined ? { file } : {}),
       ...(line !== undefined ? { line } : {}),
       ...(overlapsChangedLines !== undefined ? { overlapsChangedLines } : {}),
+      ...(suppressedByAllowlist !== undefined ? { suppressedByAllowlist } : {}),
     });
   }
 
@@ -321,10 +366,12 @@ export async function runGuardrailCheck(
 
   // Re-derive the verdict after filtering — a --changed-only run
   // shouldn't be blocked by a pair that the filter just dropped.
+  // `pairBlocks` folds in allowlist suppression so a suppressed pair
+  // never contributes to the verdict here either.
   let filteredBlocks = false;
   let filteredWarns = false;
   for (const p of filteredPairs) {
-    if (p.classification.blocks) filteredBlocks = true;
+    if (pairBlocks(p)) filteredBlocks = true;
     if (p.classification.warns) filteredWarns = true;
   }
 
@@ -511,6 +558,44 @@ function locatorLine(entry: BaselineEntry): number | undefined {
  * changed line. That's the exact scope a pre-commit / pre-push hook
  * wants — "only flag what this developer just touched."
  */
+/**
+ * Whether a classified pair contributes a BLOCK to the verdict. Folds
+ * the classifier's verdict together with allowlist suppression: a pair
+ * the classifier would block but an active allowlist entry accepted
+ * does not block. Single chokepoint so the main verdict and the
+ * post-`--changed-only` re-derivation can't drift.
+ */
+function pairBlocks(p: ClassifiedPair): boolean {
+  return p.classification.blocks && p.suppressedByAllowlist === undefined;
+}
+
+/**
+ * Resolve the active allowlist suppression for an anchor finding, or
+ * `undefined` when none applies. Matches by fingerprint (`entry.id`)
+ * AND kind — the fingerprint alone is identity, but pinning kind too
+ * rules out a cross-kind hash collision waiving the wrong finding.
+ * Expired entries return `undefined` so the finding re-blocks once its
+ * window lapses.
+ *
+ * Exported for unit testing: the expiry + kind-guard branches are
+ * exercised directly here so the (expensive) integration test only has
+ * to prove the verdict wiring flips.
+ */
+export function allowlistSuppressionFor(
+  allowlist: AllowlistFile,
+  anchorEntry: BaselineEntry,
+  now: Date,
+): AllowlistSuppression | undefined {
+  const entry = findEntry(allowlist, anchorEntry.id);
+  if (!entry || entry.kind !== anchorEntry.kind) return undefined;
+  if (!isEntryActive(entry, now)) return undefined;
+  return {
+    fingerprint: entry.fingerprint,
+    category: entry.category,
+    ...(entry.expiresAt !== undefined ? { expiresAt: entry.expiresAt } : {}),
+  };
+}
+
 function keepUnderChangedOnly(p: ClassifiedPair): boolean {
   if (p.file === undefined || p.line === undefined) return true;
   const isNewSide =

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -571,29 +571,57 @@ function pairBlocks(p: ClassifiedPair): boolean {
 
 /**
  * Resolve the active allowlist suppression for an anchor finding, or
- * `undefined` when none applies. Matches by fingerprint (`entry.id`)
- * AND kind — the fingerprint alone is identity, but pinning kind too
- * rules out a cross-kind hash collision waiving the wrong finding.
- * Expired entries return `undefined` so the finding re-blocks once its
- * window lapses.
+ * `undefined` when none applies. Matches by fingerprint AND kind — the
+ * fingerprint alone is identity, but pinning kind too rules out a
+ * cross-kind hash collision waiving the wrong finding. Expired entries
+ * are skipped so the finding re-blocks once its window lapses.
  *
- * Exported for unit testing: the expiry + kind-guard branches are
- * exercised directly here so the (expensive) integration test only has
- * to prove the verdict wiring flips.
+ * Robust matching: the candidate fingerprints are the finding's
+ * representative id PLUS any `absorbedFingerprints` the aggregator
+ * recorded when it collapsed a cross-tool / neighbor-bucket / CWE-bridge
+ * finding into this one. A suppression keyed on a contributing
+ * fingerprint (e.g. allowlisted from a run where a different engine was
+ * the representative) still matches the merged finding, so dedup
+ * nondeterminism between runs can't silently orphan it.
+ *
+ * Exported for unit testing: the expiry, kind-guard, and absorbed-
+ * fingerprint branches are exercised directly here so the (expensive)
+ * integration test only has to prove the verdict wiring flips.
  */
 export function allowlistSuppressionFor(
   allowlist: AllowlistFile,
   anchorEntry: BaselineEntry,
   now: Date,
 ): AllowlistSuppression | undefined {
-  const entry = findEntry(allowlist, anchorEntry.id);
-  if (!entry || entry.kind !== anchorEntry.kind) return undefined;
-  if (!isEntryActive(entry, now)) return undefined;
-  return {
-    fingerprint: entry.fingerprint,
-    category: entry.category,
-    ...(entry.expiresAt !== undefined ? { expiresAt: entry.expiresAt } : {}),
-  };
+  for (const fp of candidateFingerprints(anchorEntry)) {
+    const entry = findEntry(allowlist, fp);
+    if (!entry || entry.kind !== anchorEntry.kind) continue;
+    if (!isEntryActive(entry, now)) continue;
+    return {
+      fingerprint: entry.fingerprint,
+      category: entry.category,
+      ...(entry.expiresAt !== undefined ? { expiresAt: entry.expiresAt } : {}),
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Fingerprints an allowlist entry may match against for one finding:
+ * the representative `id` first (most direct), then any absorbed
+ * contributing fingerprints. Absorbed fingerprints live only on the
+ * rich secret/code/config variant — a sanitized entry carries id only.
+ */
+function candidateFingerprints(entry: BaselineEntry): string[] {
+  if (isSanitized(entry)) return [entry.id];
+  if (
+    (entry.kind === 'secret' || entry.kind === 'code' || entry.kind === 'config') &&
+    entry.absorbedFingerprints &&
+    entry.absorbedFingerprints.length > 0
+  ) {
+    return [entry.id, ...entry.absorbedFingerprints];
+  }
+  return [entry.id];
 }
 
 function keepUnderChangedOnly(p: ClassifiedPair): boolean {

--- a/src/baseline/producers/security.ts
+++ b/src/baseline/producers/security.ts
@@ -94,6 +94,9 @@ export function securityAggregateToBaselineEntries(
       file: f.file,
       line: f.line,
       ...(contentHash !== undefined ? { contentHash } : {}),
+      ...(f.absorbedFingerprints && f.absorbedFingerprints.length > 0
+        ? { absorbedFingerprints: f.absorbedFingerprints }
+        : {}),
     });
   }
 
@@ -114,6 +117,9 @@ export function securityAggregateToBaselineEntries(
       file: f.file,
       line: f.line,
       ...(contentHash !== undefined ? { contentHash } : {}),
+      ...(f.absorbedFingerprints && f.absorbedFingerprints.length > 0
+        ? { absorbedFingerprints: f.absorbedFingerprints }
+        : {}),
     });
   }
 
@@ -136,6 +142,9 @@ export function securityAggregateToBaselineEntries(
       file: f.file,
       line: f.line,
       ...(contentHash !== undefined ? { contentHash } : {}),
+      ...(f.absorbedFingerprints && f.absorbedFingerprints.length > 0
+        ? { absorbedFingerprints: f.absorbedFingerprints }
+        : {}),
     });
   }
 

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -366,6 +366,13 @@ export type BaselineEntry =
        *  context survives but line shifts past the fuzz window). Absent
        *  when the producer couldn't read the file. */
       contentHash?: string;
+      /** Fingerprints of cross-tool / neighbor-bucket / CWE-bridge
+       *  findings that the aggregator collapsed into this one. Carried
+       *  so an allowlist entry keyed on a contributing fingerprint still
+       *  suppresses the merged finding — robust matching against dedup
+       *  nondeterminism between runs. Present only when such a merge
+       *  fired. */
+      absorbedFingerprints?: readonly string[];
     }
   | {
       id: FindingId;

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -7,6 +7,7 @@ import { activeLanguagesFromStack } from './languages';
 import * as logger from './logger';
 import { resolveBaselineMode } from './baseline/modes';
 import { loadPolicyFromCwd } from './baseline/policy';
+import { loadAllowlist, auditAllowlist } from './allowlist/file';
 
 /**
  * Three-tier doctor:
@@ -98,6 +99,19 @@ function nodeMajorVersion(): number {
 function safeLoadPolicy(cwd: string): ReturnType<typeof loadPolicyFromCwd> | null {
   try {
     return loadPolicyFromCwd(cwd);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Wrap `loadAllowlist` with a swallowing try/catch — a malformed
+ * allowlist file must not break doctor. Returns null on absence or
+ * parse failure; the expiry check simply doesn't emit in that case.
+ */
+function safeLoadAllowlist(cwd: string): ReturnType<typeof loadAllowlist> {
+  try {
+    return loadAllowlist(cwd);
   } catch {
     return null;
   }
@@ -652,6 +666,46 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
             },
           }),
     });
+  }
+
+  // 7. Allowlist suppression hygiene. An expired entry no longer
+  // suppresses — its finding re-blocks the guardrail — and an entry
+  // nearing expiry needs a decision before it lapses. Surface both so
+  // a reviewed-and-accepted finding doesn't silently turn back into a
+  // blocker mid-sprint. Only emits when an allowlist actually exists.
+  const allowlistFile = safeLoadAllowlist(cwd);
+  if (allowlistFile && allowlistFile.entries.length > 0) {
+    const audit = auditAllowlist(allowlistFile);
+    if (audit.expired.length > 0) {
+      checks.push({
+        label: `allowlist suppressions (${audit.expired.length} expired — findings now re-block)`,
+        ok: false,
+        tier: 'operational',
+        fix: {
+          hint: 'Expired allowlist entries no longer suppress, so their findings block again. Prune the ones you no longer need, or re-add with a fresh expiry the ones still being worked.',
+          command: 'npx vyuh-dxkit allowlist prune',
+          skill: 'dxkit-fix',
+        },
+      });
+    } else if (audit.soonToExpire.length > 0) {
+      const soonest = Math.min(...audit.soonToExpire.map((s) => s.daysRemaining));
+      checks.push({
+        label: `allowlist suppressions (${audit.soonToExpire.length} expiring soon, next in ${soonest}d)`,
+        ok: false,
+        tier: 'operational',
+        fix: {
+          hint: 'Allowlist entries are nearing expiry. Fix the underlying finding, extend the window, or let it lapse so the finding re-blocks.',
+          command: 'npx vyuh-dxkit allowlist audit',
+          skill: 'dxkit-fix',
+        },
+      });
+    } else {
+      checks.push({
+        label: 'allowlist suppressions current',
+        ok: true,
+        tier: 'operational',
+      });
+    }
   }
 
   return checks;

--- a/src/ingest/sarif.ts
+++ b/src/ingest/sarif.ts
@@ -47,6 +47,12 @@ interface SarifResult {
       region?: { startLine?: number };
     };
   }>;
+  /** SARIF 2.1.0 suppression state. A result an engine has dismissed —
+   *  Snyk Code via the Snyk UI / API, CodeQL via a dismissed alert,
+   *  Semgrep Pro via a triage action — carries one or more suppression
+   *  entries. `status` defaults to `accepted` when absent (per spec);
+   *  `underReview` / `rejected` mean the dismissal is not in effect. */
+  suppressions?: Array<{ kind?: string; status?: string; justification?: string }>;
 }
 
 interface SarifRun {
@@ -96,6 +102,24 @@ function cweFromRule(rule: SarifRule | undefined): string {
     if (n) return n;
   }
   return '';
+}
+
+/**
+ * Whether a SARIF result has been dismissed upstream. True when it
+ * carries at least one suppression whose status is `accepted` — SARIF
+ * treats an absent `status` as `accepted`, while `underReview` and
+ * `rejected` mean the suppression is NOT yet (or no longer) in effect.
+ *
+ * Honoring this keeps dxkit's ingest in sync with the engine's own
+ * ignore state: a finding a developer dismissed in Snyk / CodeQL does
+ * not re-surface here as a fresh active finding. The decision was
+ * already reviewed in the engine that owns it, so dxkit drops it rather
+ * than re-litigating it.
+ */
+function isResultSuppressed(res: SarifResult): boolean {
+  const s = res.suppressions;
+  if (!Array.isArray(s) || s.length === 0) return false;
+  return s.some((entry) => entry.status === undefined || entry.status === 'accepted');
 }
 
 /** Resolve four-tier severity. Prefer numeric `security-severity`
@@ -155,6 +179,10 @@ export function parseSarif(raw: string, engine?: SourceEngine): ExternalFinding[
     }
 
     for (const res of run.results || []) {
+      // Honor the engine's own dismissal — a finding suppressed in Snyk
+      // / CodeQL / Semgrep Pro must not re-surface in dxkit.
+      if (isResultSuppressed(res)) continue;
+
       const ruleId = res.ruleId || res.rule?.id;
       // Rule can be referenced by id or by index into the (flattened) list.
       let rule: SarifRule | undefined = ruleId ? rulesById.get(ruleId) : undefined;

--- a/test/baseline/allowlist-suppression.test.ts
+++ b/test/baseline/allowlist-suppression.test.ts
@@ -14,10 +14,15 @@ import type { IdentityKind } from '../../src/baseline/producers';
 
 const FP = 'abcd1234abcd1234';
 
-// The resolver only reads `id` + `kind` off the anchor entry, so a
-// minimal stand-in is sufficient and keeps the fixtures readable.
-function anchor(id: string, kind: IdentityKind): BaselineEntry {
-  return { id, kind } as unknown as BaselineEntry;
+// The resolver reads `id`, `kind`, and (for the rich secret/code/config
+// variants) `absorbedFingerprints` off the anchor entry, so a minimal
+// stand-in is sufficient and keeps the fixtures readable.
+function anchor(id: string, kind: IdentityKind, absorbedFingerprints?: string[]): BaselineEntry {
+  return {
+    id,
+    kind,
+    ...(absorbedFingerprints ? { absorbedFingerprints } : {}),
+  } as unknown as BaselineEntry;
 }
 
 function fileWith(entry: AllowlistEntry): AllowlistFile {
@@ -105,5 +110,42 @@ describe('allowlistSuppressionFor', () => {
       addedAt: '2026-05-01',
     });
     expect(allowlistSuppressionFor(file, anchor(FP, 'code'), NOW)).toBeUndefined();
+  });
+
+  it('robust match: suppresses on an absorbed (contributing) fingerprint, not just the representative', () => {
+    // The allowlist was keyed on a contributing fingerprint from a run
+    // where a different engine was the representative. The merged
+    // finding now surfaces under `FP`, but carries `ABSORBED` in its
+    // absorbed set — the suppression must still apply.
+    const ABSORBED = '1111222233334444';
+    const file = fileWith({
+      fingerprint: ABSORBED,
+      kind: 'code',
+      category: 'accepted-risk',
+      reason: 'reviewed under the other engine’s fingerprint',
+      addedBy: 'r@example.com',
+      addedAt: '2026-05-01',
+      expiresAt: '2026-09-01',
+    });
+    const out = allowlistSuppressionFor(file, anchor(FP, 'code', [ABSORBED]), NOW);
+    expect(out).toEqual({
+      fingerprint: ABSORBED,
+      category: 'accepted-risk',
+      expiresAt: '2026-09-01',
+    });
+  });
+
+  it('robust match still honors the kind guard on the absorbed fingerprint', () => {
+    const ABSORBED = '1111222233334444';
+    const file = fileWith({
+      fingerprint: ABSORBED,
+      kind: 'dep-vuln',
+      category: 'accepted-risk',
+      reason: 'wrong kind',
+      addedBy: 'r@example.com',
+      addedAt: '2026-05-01',
+      expiresAt: '2099-01-01',
+    });
+    expect(allowlistSuppressionFor(file, anchor(FP, 'code', [ABSORBED]), NOW)).toBeUndefined();
   });
 });

--- a/test/baseline/allowlist-suppression.test.ts
+++ b/test/baseline/allowlist-suppression.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { allowlistSuppressionFor } from '../../src/baseline/check';
+import type { AllowlistFile, AllowlistEntry } from '../../src/allowlist/file';
+import type { BaselineEntry } from '../../src/baseline/types';
+import type { IdentityKind } from '../../src/baseline/producers';
+
+/**
+ * Pure unit coverage for the allowlist → verdict suppression resolver.
+ * The (expensive) integration test in `check.test.ts` proves the
+ * wiring flips a real verdict; this file exercises the matching
+ * branches — fingerprint match, kind guard, and the expiry window — at
+ * zero analyzer cost.
+ */
+
+const FP = 'abcd1234abcd1234';
+
+// The resolver only reads `id` + `kind` off the anchor entry, so a
+// minimal stand-in is sufficient and keeps the fixtures readable.
+function anchor(id: string, kind: IdentityKind): BaselineEntry {
+  return { id, kind } as unknown as BaselineEntry;
+}
+
+function fileWith(entry: AllowlistEntry): AllowlistFile {
+  return { schemaVersion: 'dxkit-allowlist/v1', mode: 'full', entries: [entry] };
+}
+
+const NOW = new Date('2026-06-08T12:00:00Z');
+
+describe('allowlistSuppressionFor', () => {
+  it('suppresses on a fingerprint + kind match with a non-expiring category', () => {
+    const file = fileWith({
+      fingerprint: FP,
+      kind: 'stale-file',
+      category: 'false-positive',
+      reason: 'reviewed',
+      addedBy: 'r@example.com',
+      addedAt: '2026-05-01',
+    });
+    const out = allowlistSuppressionFor(file, anchor(FP, 'stale-file'), NOW);
+    expect(out).toEqual({ fingerprint: FP, category: 'false-positive' });
+  });
+
+  it('suppresses an accepted-risk entry inside its expiry window, carrying expiresAt', () => {
+    const file = fileWith({
+      fingerprint: FP,
+      kind: 'code',
+      category: 'accepted-risk',
+      reason: 'sandboxed; tracked for hardening',
+      addedBy: 'r@example.com',
+      addedAt: '2026-05-01',
+      expiresAt: '2026-09-01',
+      acknowledgedSeverity: 'high',
+    });
+    const out = allowlistSuppressionFor(file, anchor(FP, 'code'), NOW);
+    expect(out).toEqual({ fingerprint: FP, category: 'accepted-risk', expiresAt: '2026-09-01' });
+  });
+
+  it('does NOT suppress an entry whose expiry has lapsed', () => {
+    const file = fileWith({
+      fingerprint: FP,
+      kind: 'code',
+      category: 'accepted-risk',
+      reason: 'lapsed',
+      addedBy: 'r@example.com',
+      addedAt: '2020-01-01',
+      expiresAt: '2020-02-01',
+    });
+    expect(allowlistSuppressionFor(file, anchor(FP, 'code'), NOW)).toBeUndefined();
+  });
+
+  it('treats expiry as inclusive — an entry expiring today still suppresses', () => {
+    const file = fileWith({
+      fingerprint: FP,
+      kind: 'code',
+      category: 'deferred',
+      reason: 'fix scheduled',
+      addedBy: 'r@example.com',
+      addedAt: '2026-05-01',
+      expiresAt: '2026-06-08',
+    });
+    const out = allowlistSuppressionFor(file, anchor(FP, 'code'), NOW);
+    expect(out?.category).toBe('deferred');
+  });
+
+  it('does NOT suppress when the fingerprint matches but the kind differs (collision guard)', () => {
+    const file = fileWith({
+      fingerprint: FP,
+      kind: 'dep-vuln',
+      category: 'accepted-risk',
+      reason: 'wrong kind',
+      addedBy: 'r@example.com',
+      addedAt: '2026-05-01',
+      expiresAt: '2099-01-01',
+    });
+    expect(allowlistSuppressionFor(file, anchor(FP, 'stale-file'), NOW)).toBeUndefined();
+  });
+
+  it('does NOT suppress when no entry matches the fingerprint', () => {
+    const file = fileWith({
+      fingerprint: 'ffffffffffffffff',
+      kind: 'code',
+      category: 'false-positive',
+      reason: 'other finding',
+      addedBy: 'r@example.com',
+      addedAt: '2026-05-01',
+    });
+    expect(allowlistSuppressionFor(file, anchor(FP, 'code'), NOW)).toBeUndefined();
+  });
+});

--- a/test/baseline/check.test.ts
+++ b/test/baseline/check.test.ts
@@ -151,6 +151,81 @@ describe('runGuardrailCheck (integration)', () => {
       expect(md).toContain('accepted-risk');
       expect(md).toContain('WAF rule mitigates');
     }, 300_000);
+
+    it('an active allowlist entry waives a net-new blocking finding from the verdict', async () => {
+      // The expiry + kind-guard branches are unit-tested in
+      // `allowlist-suppression.test.ts` (pure, instant). This case
+      // proves the END-TO-END wiring: a real blocking finding's
+      // verdict flips from block → pass once it's allowlisted.
+      await createBaseline({ cwd: dir });
+
+      // Introduce a net-new stale `.bak` — the quality producer flags
+      // it as a `stale-file` finding with status `added`, which the
+      // default brownfield policy blocks.
+      writeFileSync(join(dir, 'leftover.bak'), 'old\n');
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-q', '-m', 'drop a .bak'], { cwd: dir });
+
+      const findStale = (r: Awaited<ReturnType<typeof runGuardrailCheck>>) =>
+        r.pairs.find((p) => p.kind === 'stale-file' && p.classification.status === 'added');
+
+      // Step A — no allowlist: the finding blocks and carries no
+      // suppression.
+      const before = await runGuardrailCheck({ cwd: dir });
+      const staleBefore = findStale(before);
+      expect(staleBefore).toBeDefined();
+      expect(staleBefore?.classification.blocks).toBe(true);
+      expect(staleBefore?.suppressedByAllowlist).toBeUndefined();
+      expect(before.blocks).toBe(true);
+      const fp = staleBefore?.pair.currentId;
+      expect(fp).toBeTruthy();
+
+      // Step B — active (non-expiring) entry: the classifier still
+      // says "would block," but an active allowlist match waives the
+      // verdict. The pair records WHY.
+      const dxkitDir = join(dir, '.dxkit');
+      execFileSync('mkdir', ['-p', dxkitDir]);
+      writeFileSync(
+        join(dxkitDir, 'allowlist.json'),
+        JSON.stringify(
+          {
+            schemaVersion: 'dxkit-allowlist/v1',
+            mode: 'full',
+            entries: [
+              {
+                fingerprint: fp,
+                kind: 'stale-file',
+                category: 'false-positive',
+                reason: 'reviewed — generated build artifact, not source debt',
+                addedBy: 'reviewer@example.com',
+                addedAt: '2026-05-01',
+              },
+            ],
+          },
+          null,
+          2,
+        ) + '\n',
+      );
+      const suppressed = await runGuardrailCheck({ cwd: dir });
+      const staleSupp = findStale(suppressed);
+      expect(staleSupp?.classification.blocks).toBe(true);
+      expect(staleSupp?.suppressedByAllowlist?.category).toBe('false-positive');
+      expect(staleSupp?.suppressedByAllowlist?.fingerprint).toBe(fp);
+      expect(suppressed.blocks).toBe(false);
+
+      // Renderers surface the suppression in its own bucket — verdict
+      // PASSED, zero live blocks, but the finding stays visible.
+      const consoleOut = renderConsole(suppressed);
+      expect(consoleOut).toContain('Guardrail PASSED');
+      expect(consoleOut).toContain('Suppressed by allowlist (1)');
+      const jsonOut = renderJson(suppressed);
+      expect(jsonOut.verdict.blocks).toBe(false);
+      expect(jsonOut.summary.blocking).toBe(0);
+      expect(jsonOut.summary.suppressed).toBe(1);
+      const mdOut = renderMarkdown(suppressed);
+      expect(mdOut).toContain('## Guardrail: PASSED');
+      expect(mdOut).toContain('Suppressed by allowlist (1)');
+    }, 300_000);
   });
 
   describe('error + policy + drift paths', () => {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -204,6 +204,65 @@ describe('doctor: operational health (tier 3)', () => {
     }
   });
 
+  const writeAllowlist = (dir: string, entries: unknown[]) => {
+    fs.mkdirSync(path.join(dir, '.dxkit'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, '.dxkit', 'allowlist.json'),
+      JSON.stringify({ schemaVersion: 'dxkit-allowlist/v1', mode: 'full', entries }, null, 2),
+    );
+  };
+
+  it('flags expired allowlist entries — the suppressed finding re-blocks', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-doctor-allow-expired-'));
+    try {
+      execSync('git init -q', { cwd: tmp });
+      writeAllowlist(tmp, [
+        {
+          fingerprint: 'a1a1a1a1a1a1a1a1',
+          kind: 'code',
+          category: 'accepted-risk',
+          reason: 'temporary acceptance, now lapsed',
+          addedBy: 'r@example.com',
+          addedAt: '2020-01-01',
+          expiresAt: '2020-02-01',
+        },
+      ]);
+      const r = runDoctor(tmp);
+      expect(r.stdout).toContain('allowlist suppressions');
+      expect(r.stdout).toContain('expired');
+      expect(r.stdout).toContain('npx vyuh-dxkit allowlist prune');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('flags allowlist entries expiring soon before they lapse', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-doctor-allow-soon-'));
+    try {
+      execSync('git init -q', { cwd: tmp });
+      // Compute a date 5 days out so the test is stable regardless of
+      // the wall-clock date it runs on (doctor uses the real `now`).
+      const soon = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+      writeAllowlist(tmp, [
+        {
+          fingerprint: 'b2b2b2b2b2b2b2b2',
+          kind: 'code',
+          category: 'deferred',
+          reason: 'fix scheduled next sprint',
+          addedBy: 'r@example.com',
+          addedAt: '2026-05-01',
+          expiresAt: soon,
+        },
+      ]);
+      const r = runDoctor(tmp);
+      expect(r.stdout).toContain('allowlist suppressions');
+      expect(r.stdout).toContain('expiring soon');
+      expect(r.stdout).toContain('npx vyuh-dxkit allowlist audit');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   // A hook wired into core.hooksPath but left non-executable is silently
   // ignored by git — doctor must NOT report a false green here.
   it.skipIf(process.platform === 'win32')(

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -29,6 +29,7 @@ import { snykCodeTestArgs } from '../src/ingest/snyk-cli';
 import { isNotEntitled } from '../src/ingest-cli';
 import { TOOL_DEFS } from '../src/analyzers/tools/tool-registry';
 import { readDeepSastConfig } from '../src/ingest/config';
+import { isExcludedPath, clearExclusionsCache } from '../src/analyzers/tools/exclusions';
 import { codeqlLanguagesFromFlags, anyActivePackSupportsSnykCode } from '../src/languages/index';
 import type { DetectedStack } from '../src/types';
 
@@ -532,6 +533,45 @@ describe('snapshot round-trip', () => {
       expect(readAllSnapshots(dir)).toEqual([]);
       expect(snapshotEngines(dir)).toEqual([]);
     } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('ingested findings respect path exclusions (.dxkit-ignore sync)', () => {
+  it('drops ingested findings in excluded paths, keeps in-scope ones', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ingest-exclude-'));
+    try {
+      clearExclusionsCache();
+      // A custom user exclusion the external engine doesn't know about.
+      fs.writeFileSync(path.join(dir, '.dxkit-ignore'), 'third_party_snyk_only/\n');
+      const f = (file: string) => ({
+        engine: 'snyk-code' as const,
+        severity: 'high' as const,
+        category: 'code' as const,
+        cwe: 'CWE-94',
+        rule: 'r',
+        title: 't',
+        file,
+        line: 5,
+      });
+      writeSnapshot(dir, {
+        schemaVersion: 1,
+        engine: 'snyk-code',
+        generatedAt: '2026-01-01T00:00:00Z',
+        findings: [
+          f('third_party_snyk_only/lib.js'), // custom .dxkit-ignore exclusion
+          f('node_modules/pkg/index.js'), // default exclusion
+          f('src/app.ts'), // in scope
+        ],
+      });
+      // Exactly the filter gather.ts applies at read time.
+      const kept = externalToSecurityFindings(readAllSnapshots(dir)).filter(
+        (x) => !isExcludedPath(dir, x.file),
+      );
+      expect(kept.map((x) => x.file)).toEqual(['src/app.ts']);
+    } finally {
+      clearExclusionsCache();
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -131,6 +131,64 @@ describe('parseSarif', () => {
     expect(parseSarif(raw)).toHaveLength(0);
   });
 
+  it('honors upstream suppression — drops a result dismissed in the engine', () => {
+    // A finding the developer dismissed in Snyk / CodeQL carries a
+    // SARIF `suppressions` entry. dxkit must not re-surface it.
+    const suppressed = sarifWith(
+      [
+        {
+          ruleId: 'r',
+          locations: [loc('a.ts', 1)],
+          suppressions: [{ kind: 'external', justification: 'reviewed, not exploitable' }],
+        },
+      ],
+      [{ id: 'r' }],
+    );
+    expect(parseSarif(suppressed)).toHaveLength(0);
+
+    // status defaults to `accepted` when absent (SARIF spec) — also dropped.
+    const acceptedStatus = sarifWith(
+      [{ ruleId: 'r', locations: [loc('a.ts', 1)], suppressions: [{ status: 'accepted' }] }],
+      [{ id: 'r' }],
+    );
+    expect(parseSarif(acceptedStatus)).toHaveLength(0);
+  });
+
+  it('does NOT drop results whose suppression is underReview or rejected', () => {
+    // A proposed-but-not-accepted dismissal is not in effect; the
+    // finding is still active and must be ingested.
+    for (const status of ['underReview', 'rejected']) {
+      const raw = sarifWith(
+        [{ ruleId: 'r', locations: [loc('a.ts', 1)], suppressions: [{ status }] }],
+        [{ id: 'r' }],
+      );
+      expect(parseSarif(raw)).toHaveLength(1);
+    }
+    // An empty suppressions array is not a suppression either.
+    const emptyArr = sarifWith(
+      [{ ruleId: 'r', locations: [loc('a.ts', 1)], suppressions: [] }],
+      [{ id: 'r' }],
+    );
+    expect(parseSarif(emptyArr)).toHaveLength(1);
+  });
+
+  it('drops only the suppressed result in a mixed run', () => {
+    const raw = sarifWith(
+      [
+        { ruleId: 'r', locations: [loc('active.ts', 1)] },
+        {
+          ruleId: 'r',
+          locations: [loc('dismissed.ts', 2)],
+          suppressions: [{ status: 'accepted' }],
+        },
+      ],
+      [{ id: 'r' }],
+    );
+    const out = parseSarif(raw);
+    expect(out).toHaveLength(1);
+    expect(out[0].file).toBe('active.ts');
+  });
+
   it('auto-detects engine from driver name and honors an override', () => {
     const raw = sarifWith(
       [{ ruleId: 'r', locations: [loc('a.ts', 1)] }],

--- a/test/security-aggregator.test.ts
+++ b/test/security-aggregator.test.ts
@@ -235,6 +235,158 @@ describe('buildSecurityAggregate — D091 cross-tool TLS-bypass dedup', () => {
   });
 });
 
+describe('buildSecurityAggregate — cross-tool dedup of ingested + native findings', () => {
+  it('collapses the native + Snyk Code RCE at the same site via the canonical map', () => {
+    const input = emptyInput();
+    input.codePatterns = {
+      toolUsed: 'semgrep',
+      findings: [
+        makeFinding({
+          rule: 'require-request',
+          tool: 'semgrep',
+          file: 'src/server.ts',
+          line: 810,
+          cwe: '',
+          severity: 'high',
+        }),
+      ],
+    };
+    input.external = {
+      toolsUsed: ['snyk-code'],
+      findings: [
+        makeFinding({
+          rule: 'javascript/CodeInjection',
+          tool: 'snyk-code',
+          file: 'src/server.ts',
+          line: 810,
+          cwe: 'CWE-94',
+          severity: 'high',
+        }),
+      ],
+    };
+    const agg = buildSecurityAggregate(input);
+    expect(agg.findingsByCategory.code).toHaveLength(1);
+    expect(agg.findingsByCategory.code[0].producedBy).toEqual(['semgrep', 'snyk-code']);
+    expect(agg.findingsByCategory.code[0].canonicalRule).toBe('canonical:code-injection');
+  });
+
+  it('collapses Snyk InsecureTLSConfig with registry TLS bypass despite different CWEs (via map)', () => {
+    const input = emptyInput();
+    input.tlsBypass = [
+      makeFinding({
+        rule: 'tls-validation-disabled',
+        tool: 'tls-bypass-registry',
+        file: 'src/controllers/sites.controller.ts',
+        line: 389,
+        cwe: 'CWE-295',
+        severity: 'high',
+      }),
+    ];
+    input.external = {
+      toolsUsed: ['snyk-code'],
+      findings: [
+        makeFinding({
+          rule: 'javascript/InsecureTLSConfig',
+          tool: 'snyk-code',
+          file: 'src/controllers/sites.controller.ts',
+          line: 389,
+          cwe: 'CWE-327', // different from the registry's CWE-295
+          severity: 'high',
+        }),
+      ],
+    };
+    const agg = buildSecurityAggregate(input);
+    expect(agg.findingsByCategory.code).toHaveLength(1);
+    expect(agg.findingsByCategory.code[0].canonicalRule).toBe('canonical:tls-bypass');
+  });
+
+  it('CWE fallback: collapses unmapped cross-tool rules that share a CWE + location', () => {
+    const input = emptyInput();
+    input.codePatterns = {
+      toolUsed: 'semgrep',
+      findings: [
+        makeFinding({
+          rule: 'some-native-sqli',
+          tool: 'semgrep',
+          file: 'src/db.ts',
+          line: 100,
+          cwe: 'CWE-89',
+        }),
+      ],
+    };
+    input.external = {
+      toolsUsed: ['snyk-code'],
+      findings: [
+        makeFinding({
+          rule: 'javascript/Sqli',
+          tool: 'snyk-code',
+          file: 'src/db.ts',
+          line: 101, // within the line window
+          cwe: 'CWE-89',
+        }),
+      ],
+    };
+    const agg = buildSecurityAggregate(input);
+    expect(agg.findingsByCategory.code).toHaveLength(1);
+    expect(agg.findingsByCategory.code[0].producedBy).toEqual(['semgrep', 'snyk-code']);
+  });
+
+  it('CWE fallback does NOT collapse same-tool distinct findings sharing a CWE', () => {
+    const input = emptyInput();
+    input.external = {
+      toolsUsed: ['snyk-code'],
+      findings: [
+        makeFinding({
+          rule: 'javascript/RuleA',
+          tool: 'snyk-code',
+          file: 'src/x.ts',
+          line: 10,
+          cwe: 'CWE-79',
+        }),
+        makeFinding({
+          rule: 'javascript/RuleB',
+          tool: 'snyk-code',
+          file: 'src/x.ts',
+          line: 11,
+          cwe: 'CWE-79',
+        }),
+      ],
+    };
+    const agg = buildSecurityAggregate(input);
+    expect(agg.findingsByCategory.code).toHaveLength(2);
+  });
+
+  it('CWE fallback does NOT collapse cross-tool findings with different CWEs', () => {
+    const input = emptyInput();
+    input.codePatterns = {
+      toolUsed: 'semgrep',
+      findings: [
+        makeFinding({
+          rule: 'native-xss',
+          tool: 'semgrep',
+          file: 'src/y.ts',
+          line: 50,
+          cwe: 'CWE-79',
+        }),
+      ],
+    };
+    input.external = {
+      toolsUsed: ['snyk-code'],
+      findings: [
+        makeFinding({
+          rule: 'javascript/Ssrf',
+          tool: 'snyk-code',
+          file: 'src/y.ts',
+          line: 50,
+          cwe: 'CWE-918',
+        }),
+      ],
+    };
+    const agg = buildSecurityAggregate(input);
+    expect(agg.findingsByCategory.code).toHaveLength(2);
+  });
+});
+
 describe('buildSecurityAggregate — D086 health/vuln-scan parity', () => {
   it('produces ONE code-finding count surface both consumers read from', () => {
     // The D086 root cause was two separate aggregation paths:

--- a/test/security-aggregator.test.ts
+++ b/test/security-aggregator.test.ts
@@ -27,6 +27,7 @@ import {
   type SecurityAggregateInput,
   type SecurityFinding,
 } from '../src/analyzers/security/aggregator';
+import { canonicalRuleFor, computeCodeFingerprint } from '../src/analyzers/tools/fingerprint';
 import type { DepVulnFinding } from '../src/languages/capabilities/types';
 
 function makeFinding(overrides: Partial<SecurityFinding>): SecurityFinding {
@@ -329,6 +330,18 @@ describe('buildSecurityAggregate — cross-tool dedup of ingested + native findi
     const agg = buildSecurityAggregate(input);
     expect(agg.findingsByCategory.code).toHaveLength(1);
     expect(agg.findingsByCategory.code[0].producedBy).toEqual(['semgrep', 'snyk-code']);
+
+    // Robust matching: the merged finding records the absorbed engine's
+    // own fingerprint so a suppression keyed on it still matches even
+    // though the representative is now the other engine.
+    const merged = agg.findingsByCategory.code[0];
+    const snykNaturalFp = computeCodeFingerprint(
+      canonicalRuleFor('snyk-code', 'javascript/Sqli'),
+      'src/db.ts',
+      101,
+    );
+    expect(merged.fingerprint).not.toBe(snykNaturalFp);
+    expect(merged.absorbedFingerprints).toEqual([snykNaturalFp]);
   });
 
   it('CWE fallback does NOT collapse same-tool distinct findings sharing a CWE', () => {


### PR DESCRIPTION
Follow-up to 2.9's ingestion. When two engines flag one weakness, count it once; make the allowlist actually suppress; and keep ignores in sync across the tools dxkit ingests from.

## What's in it
- **Cross-tool dedup** (`029b653`) — two engines flagging one weakness at one site under different rule names collapse to one finding (canonical-rule map + same-CWE-same-location bridge, cross-tool only), keeping max severity + every contributing tool.
- **Allowlist → guardrail verdict** (`c5615f0`) — an active, unexpired allowlist entry now waives a matching finding from the verdict (was audit-only; the baseline was the sole suppressor). Expired entries stop suppressing → the finding re-blocks. Suppressed findings surface in their own report section (console/JSON/markdown), never silently dropped.
- **Robust matching** (`d79314b`) — a suppression keyed on a contributing fingerprint still matches the merged finding, so dedup nondeterminism between runs can't orphan an acceptance.
- **Doctor expiry surfacing + docs** (`ed59947`) — `doctor` flags expired + soon-to-expire allowlist entries; allowlist docs gain verdict-behavior + expiry-lifecycle sections.
- **SARIF `result.suppressions` honored** (`3f85477`) — a finding dismissed upstream (Snyk Code / CodeQL / Semgrep Pro) no longer re-surfaces in dxkit.
- **`.dxkit-ignore` applies to ingested findings** (`053eb96`) — an external engine scanning vendored/generated/fixture code no longer leaks findings dxkit would never raise natively.

## Upgrading (2.9.0 → 2.9.1)
Dedup changes the fingerprints of merged findings, so a 2.9.0 baseline/allowlist partially goes stale: re-baseline (`baseline create --force`) and re-point orphaned allowlist entries (`allowlist audit` → re-add against fresh fingerprints). Robust matching prevents *future* run-to-run orphaning but cannot bridge this one-time change. CHANGELOG has the full note.

## Testing
- Full suite green locally: 2204 tests, 127 files.
- Validated end-to-end on a real polyglot customer repo via the rc tarball + real `npx`: adoption (install/hooks/baseline refresh), doctor expiry check on real entries, and measured the migration impact (14/19 allowlist entries survive a refresh, 5 orphaned).

## Merge
Rebase — each commit is independently meaningful and bisect-worthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)