### PR TITLE
2.9.2 — allowlist lifecycle + Snyk credential ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.2] - 2026-06-09
+
+### Allowlist lifecycle + Snyk credential ergonomics
+
+A follow-up to 2.9.1 closing the self-service gaps the first customer
+walkthrough surfaced: managing the allowlist after a re-baseline without
+hand-editing JSON, propagating suppressions back to Snyk, and reading Snyk
+credentials from a local `.env`.
+
+- **`vyuh-dxkit allowlist remove <fingerprint>`.** Delete a single file-level
+  entry from the CLI. `prune` still removes only expired entries; `remove`
+  handles a stale-but-unexpired one (e.g. a confirmed-gone finding) — no more
+  hand-editing `.dxkit/allowlist.json`.
+- **Orphaned-entry audit.** `vyuh-dxkit allowlist audit --against-baseline`
+  cross-checks every entry against the committed baseline and flags those whose
+  fingerprint matches no current finding. Orphans are flagged for review, never
+  auto-removed — re-baselining can churn fingerprints and an orphan may still
+  suppress an intermittently-detected finding. The matcher counts both a
+  finding's own fingerprint and any cross-tool fingerprints it absorbed, so an
+  entry keyed on a collapsed contributor isn't falsely flagged.
+- **`vyuh-dxkit allowlist export --snyk`.** The outbound half of the Snyk
+  ignore sync (2.9.1 did the inbound SARIF-suppressions direction). Writes a
+  `.snyk` policy ignoring every Snyk Code finding the team has allowlisted in
+  dxkit, keyed on the Snyk rule id + path with the entry's reason + expiry, so
+  the suppression propagates to Snyk's own gate. Round-trip stable with the
+  inbound reader; only Snyk-originated, active entries export.
+- **Opt-in `.env` loading for Snyk credentials.** `ingest --from-snyk` now
+  reads `SNYK_*` keys from a local `.env` as a fallback — and ONLY those keys,
+  never the rest of the file. A real exported env / CI secret always wins, so CI
+  behavior is unchanged. `--no-env-file` opts out; `--env-file <path>` overrides
+  the location. dxkit warns if the file looks committed to git.
+- **New `dxkit-allowlist` skill** covering the full suppression lifecycle
+  (review, audit, remove, prune, the re-baseline → re-point flow, and Snyk
+  export), deferring the fix-vs-suppress decision back to `dxkit-action`.
+- **Baseline refreshes steer to CI.** The skills and docs now warn against an
+  ad-hoc local `baseline create --force` — it bakes the dev machine's scanner
+  versions into the committed baseline, producing spurious tooling-drift
+  warnings and phantom "resolved" findings on the next PR — and route refreshes
+  through the bundled refresh workflow instead. The first local capture stays
+  fine.
+
 ## [2.9.1] - 2026-06-08
 
 ### Cross-tool dedup + allowlist suppression + ignore sync

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Orphaned annotations become their own findings. The TypeScript `@ts-expect-error
 
 ### AI-agent integration
 
-dxkit ships twelve Claude Code skills under `.claude/skills/dxkit-*`. They wrap the CLI in conversational flows:
+dxkit ships a suite of Claude Code skills under `.claude/skills/dxkit-*`. They wrap the CLI in conversational flows:
 
 | Skill                                                                                                     | What it does                                                            |
 | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
@@ -191,6 +191,7 @@ dxkit ships twelve Claude Code skills under `.claude/skills/dxkit-*`. They wrap 
 | `dxkit-action`                                                                                            | Reads a report, prioritizes findings, plans and runs fixes, re-verifies |
 | `dxkit-ingest`                                                                                            | Brings external SAST findings (Snyk Code, CodeQL, SARIF) into dxkit     |
 | `dxkit-fix`                                                                                               | Repairs a broken install from doctor output                             |
+| `dxkit-allowlist`                                                                                         | Manages the suppression lifecycle: audit, remove, prune, export to Snyk |
 | `dxkit-feature`, `dxkit-docs`, `dxkit-hooks`, `dxkit-config`, `dxkit-learn`, `dxkit-update`, `dxkit-init` | Focused flows                                                           |
 
 `AGENTS.md` (the open standard read by Codex, Cursor, Aider, and others) also ships in every install. The skill flows are Claude Code-specific today; the AGENTS.md context is portable.
@@ -250,7 +251,7 @@ npx vyuh-dxkit setup-prebuild            # Codespaces prebuild
 À la carte if you only want specific pieces:
 
 ```bash
-npx vyuh-dxkit init --with-dxkit-agents       # just the twelve Claude skills + AGENTS.md
+npx vyuh-dxkit init --with-dxkit-agents       # just the dxkit-* Claude skills + AGENTS.md
 npx vyuh-dxkit init --with-hooks              # just the pre-push hook
 npx vyuh-dxkit init --with-precommit-hook     # add pre-commit (slow on large repos)
 npx vyuh-dxkit init --with-devcontainer       # just the per-stack devcontainer

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,14 +24,15 @@ Hook activation is automatic via the postinstall chain (no manual
 `git config core.hooksPath .githooks` step needed). If you ever need
 to re-activate manually: `vyuh-dxkit hooks activate`.
 
-| Command                                         | What it does                                                   |
-| ----------------------------------------------- | -------------------------------------------------------------- |
-| [`baseline create`](commands/baseline.md)       | Write per-finding identities to `.dxkit/baselines/<name>.json` |
-| [`baseline show`](commands/baseline.md)         | Pretty-print or filter the on-disk baseline                    |
-| [`guardrail check`](commands/guardrail.md)      | Diff current scan vs. baseline; block on net-new regressions   |
-| [`allowlist add`](commands/allowlist.md)        | Suppress a specific finding (typed category + reason + expiry) |
-| [`allowlist audit`](commands/allowlist.md)      | Surface stale / soon-to-expire / missing-rationale entries     |
-| [`.dxkit/policy.json`](configuration/policy.md) | Tune which classifications block vs. warn                      |
+| Command                                            | What it does                                                   |
+| -------------------------------------------------- | -------------------------------------------------------------- |
+| [`baseline create`](commands/baseline.md)          | Write per-finding identities to `.dxkit/baselines/<name>.json` |
+| [`baseline show`](commands/baseline.md)            | Pretty-print or filter the on-disk baseline                    |
+| [`guardrail check`](commands/guardrail.md)         | Diff current scan vs. baseline; block on net-new regressions   |
+| [`allowlist add`](commands/allowlist.md)           | Suppress a specific finding (typed category + reason + expiry) |
+| [`allowlist audit`](commands/allowlist.md)         | Surface stale / soon-to-expire / orphaned / missing-rationale  |
+| [`allowlist export --snyk`](commands/allowlist.md) | Propagate Snyk-originated suppressions to a `.snyk` policy     |
+| [`.dxkit/policy.json`](configuration/policy.md)    | Tune which classifications block vs. warn                      |
 
 ## What you can run
 

--- a/docs/commands/allowlist.md
+++ b/docs/commands/allowlist.md
@@ -202,12 +202,13 @@ vyuh-dxkit allowlist show <fingerprint> --json
 ### `audit` — find stale + soon-to-expire entries
 
 ```bash
-vyuh-dxkit allowlist audit               # default: 14-day soon window
+vyuh-dxkit allowlist audit                  # default: 14-day soon window
 vyuh-dxkit allowlist audit --soon-days=30
+vyuh-dxkit allowlist audit --against-baseline   # also flag orphaned entries
 vyuh-dxkit allowlist audit --json
 ```
 
-Three buckets:
+Buckets:
 
 - **Expired** — entries past `expiresAt`. Run `prune` to remove.
 - **Soon to expire** — within `--soon-days` (default 14). Either
@@ -216,6 +217,29 @@ Three buckets:
 - **Missing rationale** — entries with empty `reason` field. In
   full mode this should never happen; in sanitized mode it means
   the gitignored reasons sidecar isn't synced locally.
+- **Orphaned** — _only with `--against-baseline`_. Entries whose
+  fingerprint matches no finding in the committed baseline. The check
+  counts both each finding's own fingerprint and any cross-tool
+  fingerprints it absorbed, so an entry keyed on a collapsed
+  contributor isn't falsely flagged. **Orphans are flagged for review,
+  never auto-removed**: re-baselining can churn fingerprints, and an
+  orphan may still suppress an intermittently-detected finding.
+  Confirm the finding is truly gone (re-run the analyzer), then
+  `allowlist remove <fingerprint>`. Needs a baseline on disk — refresh
+  it in CI first (see [`baseline`](./baseline.md)).
+
+### `remove` — delete one entry
+
+```bash
+vyuh-dxkit allowlist remove <fingerprint>
+vyuh-dxkit allowlist remove <fingerprint> --json
+```
+
+Deletes a single file-level entry by fingerprint. Use this for a
+confirmed-orphaned entry or any stale-but-unexpired one — `prune` only
+removes _expired_ entries, so `remove` is the way to drop a still-valid
+entry whose finding is genuinely gone. No more hand-editing
+`.dxkit/allowlist.json`.
 
 ### `prune` — remove expired entries
 
@@ -224,6 +248,30 @@ vyuh-dxkit allowlist prune              # default: removes expired entries
 vyuh-dxkit allowlist prune --dry-run    # preview without writing
 vyuh-dxkit allowlist prune --json       # structured envelope
 ```
+
+### `export --snyk` — propagate suppressions to Snyk
+
+```bash
+vyuh-dxkit allowlist export --snyk             # writes ./.snyk
+vyuh-dxkit allowlist export --snyk --out=path/to/.snyk
+vyuh-dxkit allowlist export --snyk --json
+```
+
+Writes a `.snyk` policy file ignoring every Snyk Code finding the team
+has allowlisted in dxkit, so the suppression propagates to Snyk's own
+gate (`snyk code test`, the Snyk UI). Each ignore is keyed on the Snyk
+rule id + path and carries the entry's reason + expiry. This is the
+**outbound** half of the Snyk ignore sync — dxkit already honors Snyk's
+SARIF `result.suppressions` on the inbound side, and the two are
+round-trip stable (an exported ignore re-read from Snyk's SARIF is
+suppressed, not double-counted).
+
+Only Snyk-originated, **active** (unexpired) entries export; native
+semgrep/gitleaks findings have no Snyk equivalent. Snyk Code (SAST)
+honors `.snyk` ignores only when your org has Snyk's "consistent
+ignores" feature enabled; SCA/dependency ignores are standard. The
+export is opt-in — if dxkit is the only gate, you don't need it. Commit
+the `.snyk` so it applies in CI.
 
 ## Stale annotations (the strict-cleanup loop)
 

--- a/docs/commands/baseline.md
+++ b/docs/commands/baseline.md
@@ -139,6 +139,16 @@ and auto-commits the updated file with `[skip ci]`. The next PR's
 [`guardrail check`](guardrail.md) reads the refreshed anchor without
 manual intervention.
 
+> **Refresh the canonical baseline in CI, not on a dev laptop.** A local
+> `baseline create --force` bakes your machine's scanner versions
+> (semgrep, npm-audit, jscpd, …) into the committed file. When those
+> differ from CI's, the next PR's guardrail emits spurious
+> `TOOLING-DRIFT` warnings and shows phantom "resolved" findings — the
+> baseline and the PR were scanned by different tool versions. The
+> bundled refresh workflow (or any runner pinned to CI's scanner
+> versions) keeps the anchor canonical. Use a local `--force` only for
+> the very first capture or a throwaway experiment.
+
 ## See also
 
 - [`guardrail`](guardrail.md) — diff a current scan against a baseline

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -9,7 +9,7 @@
 > use the short form.
 
 Install the dxkit agent DX layer in a repository: `AGENTS.md` +
-`CLAUDE.md` shim + `.claude/skills/dxkit-*/` (nine lifecycle skills)
+`CLAUDE.md` shim + `.claude/skills/dxkit-*/` (the lifecycle skills)
 
 - `.claude/rules/` (per-language conventions), plus — optionally —
   git hooks, per-stack devcontainer, CI guardrails, and the post-merge
@@ -37,7 +37,7 @@ vyuh-dxkit init [options]
 
 | Option                    | Effect                                                                                                                                                                                                                                                        |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--with-dxkit-agents`     | Install the nine `dxkit-*` skills + `AGENTS.md` + `CLAUDE.md` shim. Default-on under `--full`; opt-in on bare `init`.                                                                                                                                         |
+| `--with-dxkit-agents`     | Install the `dxkit-*` skills + `AGENTS.md` + `CLAUDE.md` shim. Default-on under `--full`; opt-in on bare `init`.                                                                                                                                              |
 | `--with-hooks`            | Install `.githooks/pre-push` for [guardrail check](guardrail.md). Hook activation is auto-chained via package.json postinstall — teammates who `npm install` get hooks wired automatically. Pre-commit is opt-in (`--with-precommit-hook`).                   |
 | `--with-precommit-hook`   | Additionally install `.githooks/pre-commit`. Implies `--with-hooks`. Use on small/fast repos where every-commit gating is worth the wait.                                                                                                                     |
 | `--with-devcontainer`     | Install `.devcontainer/` with per-stack pinned toolchains (only the languages your project uses) + Claude Code & Codex CLIs                                                                                                                                   |
@@ -61,8 +61,9 @@ AGENTS.md              # open-standard project-context file (Claude Code,
 CLAUDE.md              # Claude Code shim that points at AGENTS.md
 .claude/
   settings.json        # tool permissions
-  skills/dxkit-*/      # nine lifecycle skills: learn / init / config /
-                       # hooks / reports / action / fix / update / onboard
+  skills/dxkit-*/      # lifecycle skills: learn / init / config / hooks /
+                       # reports / action / fix / update / onboard / feature /
+                       # docs / ingest / allowlist
   rules/               # per-language coding conventions
 .vyuh-dxkit.json       # install manifest (config, install flags, evolving file hashes)
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,8 +15,8 @@ npm init @vyuhlabs/dxkit
 ```
 
 This installs `@vyuhlabs/dxkit` as a devDependency in your repo,
-runs `vyuh-dxkit init --full --yes`, and lands all nine `dxkit-*`
-agent skills + devcontainer + git hooks + CI workflows. The post-
+runs `vyuh-dxkit init --full --yes`, and lands the full set of
+`dxkit-*` agent skills + devcontainer + git hooks + CI workflows. The post-
 install hook also auto-activates `core.hooksPath = .githooks` so
 teammates who clone + `npm install` get hooks wired automatically.
 
@@ -165,7 +165,7 @@ from landing — without forcing a cleanup sprint first.
 
 ```bash
 # Install hooks + devcontainer + GitHub Actions PR-gate + baseline-refresh
-# + nine dxkit-* agent skills + AGENTS.md.
+# + the dxkit-* agent skills + AGENTS.md.
 vyuh-dxkit init --full
 
 # Or pick à la carte:
@@ -185,6 +185,15 @@ vyuh-dxkit baseline create
 git add .dxkit/baselines/main.json .githooks .github/workflows/dxkit-*.yml
 git commit -m "chore: enable dxkit guardrails"
 ```
+
+> **First capture local, refreshes in CI.** The initial `baseline create`
+> above is fine to run locally. But later _refreshes_ (after fixing
+> findings, adding scanners, or ingesting an external engine) should run
+> through the bundled `dxkit-baseline-refresh` workflow — not a local
+> `baseline create --force`. A local refresh bakes your machine's
+> scanner versions into the committed baseline, so the next PR's guardrail
+> emits spurious `TOOLING-DRIFT` warnings and phantom "resolved" findings
+> when CI's versions differ. Install it with `--with-baseline-refresh`.
 
 Hook activation is now automatic on `npm install` via the postinstall
 chain (added in 2.5.1). If you ever need to activate manually (e.g.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "AI-native developer experience toolkit for any codebase",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -202,7 +202,7 @@ npx vyuh-dxkit allowlist audit            # expired / soon-to-expire / missing-r
 npx vyuh-dxkit allowlist prune            # remove expired entries
 ```
 
-Run `audit` periodically — `accepted-risk` and `deferred` entries that pass their expiry should either be re-justified (renew expiry) or pruned (remove the entry; the underlying finding will re-flag on the next scan).
+Run `audit` periodically — `accepted-risk` and `deferred` entries that pass their expiry should either be re-justified (renew expiry) or pruned (remove the entry; the underlying finding will re-flag on the next scan). For the full lifecycle — auditing orphaned entries after a re-baseline (`audit --against-baseline`), removing a single stale fingerprint (`allowlist remove`), and exporting Snyk-originated suppressions back to a `.snyk` (`allowlist export --snyk`) — hand off to the **dxkit-allowlist** skill.
 
 ### Stale annotations
 
@@ -270,4 +270,4 @@ In those cases: `vyuh-dxkit allowlist add` is the right tool for per-finding dec
 - For hook-related issues during a fix push → `dxkit-hooks` skill
 - For re-running reports between fixes → `dxkit-reports` skill
 - For broken dxkit install (hooks not firing, vyuh-dxkit not on PATH) → `dxkit-fix` skill
-- For allowlist management beyond the per-finding `add` path (auditing existing entries, pruning expired ones, reviewing the team's overall suppression posture) → run `npx vyuh-dxkit allowlist audit` / `list` / `prune` directly; no separate skill yet
+- For allowlist management beyond the per-finding `add` path — auditing existing entries (including orphans after a re-baseline), removing stale fingerprints, pruning expired ones, exporting to a `.snyk`, or reviewing the team's overall suppression posture → **dxkit-allowlist** skill

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -235,12 +235,14 @@ Once a finding is processed (fixed, allowlisted, or accepted), the workflow depe
 | Real risk neutralized externally (WAF, runtime guard) | `vyuh-dxkit allowlist add` with `category=mitigated-externally` + a reason describing the mitigation. Baseline unchanged. |
 | Real risk, accepted by team, won't fix | `vyuh-dxkit allowlist add` with `category=accepted-risk` + `--expires=YYYY-MM-DD` (defaults 90 days). Acknowledged-severity required for high/critical. |
 | Real risk, will fix later (tracked work) | `vyuh-dxkit allowlist add` with `category=deferred` + `--expires=YYYY-MM-DD`. The expiry forces re-review when the deadline passes. |
-| Fix landed via a config change (e.g., new entry in `.dxkit-ignore`) | Re-baseline: `npx vyuh-dxkit baseline create --force`. Commit both `.dxkit-ignore` and the new baseline. |
+| Fix landed via a config change (e.g., new entry in `.dxkit-ignore`) | Re-baseline through the `dxkit-baseline-refresh` CI workflow (NOT a local `baseline create --force` — see the note below). Commit the `.dxkit-ignore` change; let CI refresh + commit the baseline. |
 | Brownfield acceptance (the whole CURRENT state is known mess; future regressions must be net-new) | Re-baseline with an explicit reason in the commit message. Reserve this for the deliberate "draw a line here" moment, not per-finding suppression. |
 
 **Prefer the allowlist over re-baselining for per-finding decisions.** The allowlist carries a typed category + reason + (when relevant) expiry; the baseline carries only "this finding was here." Future maintainers reading `vyuh-dxkit allowlist show <fingerprint>` see WHY the suppression is in place; reading the baseline file shows only that the finding existed at capture time. Per-finding decisions belong in the allowlist; codebase-wide brownfield acceptance belongs in the baseline.
 
 **Never** re-baseline a finding silently — the commit message should explain why the regression is accepted. Future maintainers reading `git log .dxkit/baselines/` should see the rationale.
+
+**Refresh the baseline in CI, not locally.** When a re-baseline is the right call, run it through the bundled `dxkit-baseline-refresh` workflow (or a runner pinned to CI's scanner versions) — not a local `npx vyuh-dxkit baseline create --force`. A local refresh records your machine's semgrep / npm-audit / jscpd versions in the committed baseline; when they differ from CI's, the next PR's guardrail surfaces spurious `TOOLING-DRIFT` warnings and phantom "resolved" findings. A local `--force` is fine only for the very first capture or a throwaway experiment.
 
 ## Workflow guardrail
 

--- a/src-templates/.claude/skills/dxkit-allowlist/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-allowlist/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: dxkit-allowlist
+description: Manage the dxkit allowlist over its whole lifecycle — list, inspect, audit (including orphaned entries after a re-baseline), remove stale entries, prune expired ones, and export Snyk-originated suppressions to a .snyk policy. Use when the user says "review our allowlist", "what suppressions do we have", "this allowlist entry is stale", "remove this fingerprint", "the allowlist drifted after re-baselining", "audit our accepted-risk entries", or "push our Snyk ignores back to Snyk". For the fix-vs-suppress DECISION and adding a new entry, defer to dxkit-action.
+---
+
+# dxkit-allowlist
+
+The allowlist is dxkit's per-finding suppression surface: a reviewed finding that the team has categorized (`false-positive`, `test-fixture`, `mitigated-externally`, `accepted-risk`, `deferred`) with a reason, so the guardrail lets it pass on future runs. It's the single source of truth across every scanner — native semgrep/gitleaks and ingested Snyk Code / CodeQL findings alike, all keyed on one fingerprint.
+
+This skill manages the allowlist's **lifecycle**: reviewing what's there, keeping it honest, and propagating decisions outward. For the upstream question — *should this be fixed instead of suppressed, and how do I add an entry* — that decision and the `add` path live in **dxkit-action**. Fix first; suppress second.
+
+## The lifecycle at a glance
+
+```
+add ──▶ list / show ──▶ audit ──▶ { renew | remove | prune } ──▶ export --snyk
+(dxkit-action)  inspect    keep honest   clean up                 propagate to Snyk
+```
+
+## Review what's suppressed
+
+```bash
+npx vyuh-dxkit allowlist list                # every entry (text); --json for structured
+npx vyuh-dxkit allowlist show <fingerprint>  # one entry's full detail
+```
+
+Reading is always safe — no mutation. Use these to brief the team on the overall suppression posture before a release or audit.
+
+## Audit — keep the allowlist honest
+
+```bash
+npx vyuh-dxkit allowlist audit                      # expired / soon-to-expire / missing-rationale
+npx vyuh-dxkit allowlist audit --soon-days=30       # widen the soon-to-expire window
+npx vyuh-dxkit allowlist audit --against-baseline   # ALSO flag orphaned entries
+```
+
+`audit` partitions entries into actionable buckets:
+
+- **expired** — past their `expiresAt`. The suppression no longer applies; the finding will re-flag on the next scan. Prune or renew.
+- **soon-to-expire** — within the window (default 14 days). `accepted-risk` / `deferred` entries approaching expiry should be re-justified or removed.
+- **missing-rationale** — no reason on the entry (only happens in sanitized mode when the gitignored reasons sidecar is absent).
+- **orphaned** — *only with `--against-baseline`*. The entry's fingerprint matches no finding in the committed baseline.
+
+### Orphaned entries — flag, never bulk-remove
+
+`--against-baseline` reads the committed baseline and reports entries whose fingerprint isn't present in the current finding set (it counts both each finding's own fingerprint and any cross-tool fingerprints absorbed into it, so an entry keyed on a collapsed contributor is *not* falsely flagged).
+
+**An orphan is not automatically stale.** Two things produce orphans:
+
+1. **The finding is genuinely gone** (fixed, file deleted) → the entry is dead weight; remove it.
+2. **Re-baselining churned the fingerprint** — semgrep is nondeterministic run-to-run, and cross-tool dedup can shift which tool's fingerprint represents a merged finding. The suppressed finding may still exist intermittently. Removing the entry would let it block a future PR.
+
+So treat the orphaned bucket as a **review queue**: confirm each finding is truly gone (re-run the analyzer and check the fingerprint is absent), *then* remove. Never script a bulk-remove of the orphaned set.
+
+## Remove a single entry
+
+```bash
+npx vyuh-dxkit allowlist remove <fingerprint>
+```
+
+Deletes one file-level entry. Use this for a confirmed-orphaned entry, or any stale-but-unexpired entry (which `prune` won't touch — `prune` removes only *expired* entries). No more hand-editing `.dxkit/allowlist.json`.
+
+## Prune expired entries
+
+```bash
+npx vyuh-dxkit allowlist prune --dry-run   # preview what would go
+npx vyuh-dxkit allowlist prune             # remove all expired entries
+```
+
+`prune` is the bulk counterpart to `remove`, scoped to expired entries only (those are unambiguously inactive). Run it periodically; renew anything still relevant before pruning.
+
+## The re-baseline → re-point flow (self-serve)
+
+After a baseline refresh, some fingerprints churn and a few valid suppressions orphan. The self-serve recovery:
+
+```bash
+npx vyuh-dxkit allowlist audit --against-baseline   # 1. discover orphans
+# 2. for each orphan: re-run the analyzer, confirm the finding is truly gone
+npx vyuh-dxkit vulnerabilities                      #    (grep output for the fingerprint)
+npx vyuh-dxkit allowlist remove <fingerprint>       # 3a. gone → remove
+npx vyuh-dxkit allowlist add --fingerprint=<new> …  # 3b. churned → re-point to the new fp (see dxkit-action)
+```
+
+> **Refresh the baseline in CI, not on your laptop.** A local `baseline create --force` bakes your machine's scanner versions into the committed baseline, which produces spurious tooling-drift warnings and phantom "resolved" findings on the next PR — and *causes* exactly this fingerprint churn. Use the bundled `dxkit-baseline-refresh` workflow (workflow_dispatch) so the canonical baseline is captured with CI's scanner versions. See **dxkit-ingest** for the refresh-job pattern.
+
+## Export to Snyk — propagate suppressions outward
+
+```bash
+npx vyuh-dxkit allowlist export --snyk            # writes ./.snyk
+npx vyuh-dxkit allowlist export --snyk --out=path/to/.snyk
+```
+
+When the team allowlists a **Snyk-originated** finding (one ingested via `dxkit-ingest`, `tool: snyk-code`), the decision lives only in dxkit by default — Snyk's own gate (`snyk code test`, the Snyk UI) still reports it as open. `export --snyk` closes that loop: it writes a `.snyk` policy ignoring every Snyk Code finding that maps to an *active* allowlist entry, keyed on the Snyk rule id + path, carrying the entry's reason + expiry. Expired entries are skipped; native semgrep/gitleaks findings don't export (no Snyk equivalent).
+
+This is the outbound mirror of the inbound sync dxkit already does (it honors Snyk's SARIF `result.suppressions` at ingest). The two are round-trip stable — an exported ignore re-read from Snyk's SARIF is suppressed, not double-counted.
+
+**Prerequisite:** Snyk Code (SAST) honors `.snyk` ignores only when the org has Snyk's "consistent ignores" feature enabled; SCA/dependency ignores are standard. Commit the `.snyk` so it applies in CI. It's opt-in — if dxkit is the only gate, you don't need it.
+
+## Stale inline annotations
+
+Inline `dxkit-allow:` annotations are a different surface (source-anchored, managed by `dxkit-action`'s `add` path). If the underlying finding is fixed but the annotation lingers, the next scan emits a `stale-allow` finding pointing at the orphaned comment. The fix is always to delete the comment — dxkit refuses to allowlist a stale-allow.
+
+## Hand-offs
+
+- For the **fix-vs-suppress decision** and **adding** a new entry (inline or file-level, the typed-category table, the canonical `add` path) → **dxkit-action**.
+- For **ingesting** Snyk/CodeQL findings in the first place, and the **CI baseline/deep-SAST refresh** jobs → **dxkit-ingest**.
+- For **ignore-file** (`.dxkit-ignore`) edits and policy tuning → **dxkit-config**.
+- For a **broken install** (guardrail not firing, command not found) → **dxkit-fix**.

--- a/src-templates/.claude/skills/dxkit-config/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-config/SKILL.md
@@ -155,7 +155,7 @@ A `npx vyuh-dxkit doctor` or `tools list` showing tools as missing **when they a
 1. Create / edit `.dxkit/tools.json` and add that directory to `probePaths`.
 2. Re-run `npx vyuh-dxkit tools list` — the tool should now show as available.
 3. If the user wants dxkit to *install* tools into a specific dir, set `installDir`, then `npx vyuh-dxkit tools install`.
-4. Regenerate the baseline so it reflects the now-available scanners: `npx vyuh-dxkit baseline create --force`.
+4. Regenerate the baseline so it reflects the now-available scanners — through the `dxkit-baseline-refresh` CI workflow, not a local `baseline create --force` (see "What NOT to do" for why).
 
 ## Workflow
 
@@ -163,11 +163,11 @@ When the user asks for a config change:
 
 1. Identify which file owns the concern (path exclusion → `.dxkit-ignore`; severity routing → `.dxkit/policy.json`; detection override → `.npx vyuh-dxkit.json`).
 2. Open the file, propose the edit, confirm.
-3. After writing, run `npx vyuh-dxkit baseline create --force` if exclusions changed (so the baseline doesn't carry stale findings from the now-excluded paths).
-4. Commit both: the config file + the regenerated baseline.
+3. If exclusions changed, refresh the baseline so it doesn't carry stale findings from the now-excluded paths — via the `dxkit-baseline-refresh` CI workflow, not a local `baseline create --force` (see "What NOT to do").
+4. Commit the config file; let CI refresh + commit the baseline.
 
 ## What NOT to do
 
 - Don't edit `.dxkit/cache/` or `.dxkit/reports/` — they're regenerated on every run (gitignored).
-- Don't manually mutate `.dxkit/baselines/main.json` — use `baseline create --force` to regenerate.
+- Don't manually mutate `.dxkit/baselines/main.json` — regenerate it. And regenerate it in CI (the `dxkit-baseline-refresh` workflow), NOT with a local `baseline create --force`: a local refresh bakes your machine's scanner versions into the committed baseline, so the next PR's guardrail emits spurious `TOOLING-DRIFT` warnings and phantom "resolved" findings when CI's versions differ. A local `--force` is fine only for the first capture or a throwaway experiment.
 - Don't add `.dxkit/` to `.dxkit-ignore` — dxkit itself doesn't scan its own outputs.

--- a/src-templates/.claude/skills/dxkit-fix/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-fix/SKILL.md
@@ -91,7 +91,7 @@ If doctor flags a tool (git, dotnet, node, npm, a scanner) as missing but the cu
 2. Add that directory to `.dxkit/tools.json` `probePaths` (hand off to **dxkit-config**, which documents the file).
 3. Re-run `npx vyuh-dxkit doctor` to confirm it now resolves.
 
-This matters: an undetected scanner means `baseline create` silently captured ZERO findings for that tool's category — re-baseline (`baseline create --force`) once detection is fixed.
+This matters: an undetected scanner means `baseline create` silently captured ZERO findings for that tool's category — refresh the baseline once detection is fixed. Do that through the `dxkit-baseline-refresh` CI workflow, not a local `baseline create --force`: a local refresh records your machine's scanner versions in the committed baseline, so the next PR's guardrail emits spurious `TOOLING-DRIFT` warnings and phantom "resolved" findings when CI's versions differ.
 
 ## Capturing the FIRST baseline — be deliberate
 

--- a/src-templates/.claude/skills/dxkit-ingest/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-ingest/SKILL.md
@@ -88,6 +88,8 @@ Compiled languages (Java, C#, Kotlin, Go) need a working build for CodeQL extrac
 
 Ingested findings flow through the same aggregate as native findings, so they appear in the vulnerability report (with the engine as the `tool`), get a stable fingerprint, dedupe against any overlapping semgrep finding, and — with `--graph-context` — carry the enclosing symbol + blast radius the agent needs to fix safely. That graph enrichment is the part the source engine's own autofix doesn't have.
 
+> **Step [4] belongs in CI, not on your laptop.** Adding ingested findings changes the finding set, so the baseline must be refreshed to pick them up. Do that through the bundled `dxkit-baseline-refresh` workflow (workflow_dispatch / post-merge), NOT a local `baseline create --force`. A local refresh bakes your machine's scanner versions into the committed baseline; when they differ from CI's, the next PR gets spurious `TOOLING-DRIFT` warnings and phantom "resolved" findings. Refresh the snapshot AND the baseline from CI so both are captured with CI's tool versions.
+
 ## Keeping it fresh (CI)
 
 Add a scheduled refresh (mirrors `dxkit-baseline-refresh`): a CI job with the `SNYK_TOKEN` secret runs `ingest --from-snyk` and commits the updated snapshot. The bundled `--with-deep-sast-refresh` workflow (`workflow_dispatch`) does exactly this; its `method` input picks `api` (Enterprise, quota-free) or `cli` (free/team, one test per run). The ingested findings are a point-in-time snapshot of the engine's last scan — re-ingest after the engine re-scans.

--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -42,6 +42,9 @@ import {
   pathForBaseline,
   readBaselineFile,
 } from '../baseline/baseline-file';
+import { canonicalRuleFor, computeCodeFingerprint } from '../analyzers/tools/fingerprint';
+import { readAllSnapshots } from '../ingest/snapshot';
+import { buildSnykPolicy, expiryToSnykDatetime, type SnykIgnore } from '../ingest/snyk-policy';
 import { LANGUAGES } from '../languages';
 import type { LanguageSupport } from '../languages/types';
 import type { IdentityKind } from '../baseline/producers';
@@ -62,6 +65,7 @@ import {
   auditAllowlist,
   emptyAllowlistFile,
   findEntry,
+  isEntryActive,
   loadAllowlist,
   pathForAllowlist,
   pruneExpired,
@@ -76,7 +80,15 @@ import {
 import { insertAnnotation } from './inline';
 
 /** Subcommands recognized under `vyuh-dxkit allowlist`. */
-export const ALLOWLIST_SUBCOMMANDS = ['add', 'list', 'show', 'audit', 'prune', 'remove'] as const;
+export const ALLOWLIST_SUBCOMMANDS = [
+  'add',
+  'list',
+  'show',
+  'audit',
+  'prune',
+  'remove',
+  'export',
+] as const;
 export type AllowlistSubcommand = (typeof ALLOWLIST_SUBCOMMANDS)[number];
 
 export interface AllowlistAddOpts {
@@ -122,6 +134,17 @@ export interface AllowlistAuditOpts {
 export interface AllowlistRemoveOpts {
   readonly fingerprint?: string;
   readonly json?: boolean;
+}
+
+export interface AllowlistExportOpts {
+  /** Target format. Only `--snyk` is supported today. */
+  readonly snyk?: boolean;
+  /** Output path (default `.snyk` in cwd). */
+  readonly out?: string;
+  readonly json?: boolean;
+  /** ISO datetime stamped as each ignore's `created`. Defaults to now;
+   *  injectable for deterministic tests. */
+  readonly now?: string;
 }
 
 export interface AllowlistPruneOpts {
@@ -195,6 +218,12 @@ export async function runAllowlist(
     case 'remove':
       return runAllowlistRemove(cwd, {
         fingerprint: args.positionalAfter,
+        json: !!args.values.json,
+      });
+    case 'export':
+      return runAllowlistExport(cwd, {
+        snyk: !!args.values.snyk,
+        out: args.values.out as string | undefined,
         json: !!args.values.json,
       });
   }
@@ -579,6 +608,101 @@ export async function runAllowlistRemove(cwd: string, opts: AllowlistRemoveOpts)
     return;
   }
   logger.success(`Removed allowlist entry ${fp} (kind=${entry.kind}, category=${entry.category}).`);
+}
+
+// ─── export ─────────────────────────────────────────────────────────────────
+
+/**
+ * `allowlist export --snyk` — emit a `.snyk` policy file that ignores
+ * every Snyk-originated finding the team has allowlisted in dxkit, so
+ * the suppression propagates to Snyk's own gate (the OUTBOUND half of
+ * the sync; 2.9.1 did the inbound SARIF-suppressions direction).
+ *
+ * Each ingested Snyk finding's canonical fingerprint is recomputed via
+ * the shared helpers (Rule 9 — no parallel hash). A finding whose
+ * fingerprint matches an ACTIVE allowlist entry becomes a `.snyk`
+ * ignore keyed on the Snyk-native rule id + path, carrying the entry's
+ * reason + expiry. Expired entries are skipped (they no longer
+ * suppress). Only `snyk-code` findings export — native semgrep /
+ * gitleaks findings have no Snyk equivalent.
+ */
+export async function runAllowlistExport(cwd: string, opts: AllowlistExportOpts): Promise<void> {
+  if (!opts.snyk) {
+    logger.fail(`allowlist export currently supports only --snyk. Usage: allowlist export --snyk`);
+    process.exit(1);
+  }
+
+  const file = loadAllowlist(cwd);
+  if (!file || file.entries.length === 0) {
+    logger.info(`No allowlist entries — nothing to export.`);
+    return;
+  }
+
+  const snapshots = readAllSnapshots(cwd).filter((f) => f.engine === 'snyk-code');
+  if (snapshots.length === 0) {
+    logger.info(
+      `No Snyk Code findings have been ingested yet. ` +
+        `Run \`vyuh-dxkit ingest --from-snyk\` first.`,
+    );
+    return;
+  }
+
+  // Recompute each Snyk finding's canonical fingerprint and match it to
+  // an active allowlist entry. Dedup (rule, path) so several findings on
+  // the same rule+path collapse to one ignore directive.
+  const created = opts.now ?? new Date().toISOString();
+  const ignores: SnykIgnore[] = [];
+  const seenRulePath = new Set<string>();
+  let skippedExpired = 0;
+  for (const f of snapshots) {
+    const fingerprint = computeCodeFingerprint(canonicalRuleFor(f.engine, f.rule), f.file, f.line);
+    const entry = findEntry(file, fingerprint);
+    if (!entry) continue;
+    if (!isEntryActive(entry)) {
+      skippedExpired++;
+      continue;
+    }
+    const key = `${f.rule}\0${f.file}`;
+    if (seenRulePath.has(key)) continue;
+    seenRulePath.add(key);
+    ignores.push({
+      ruleId: f.rule,
+      path: f.file,
+      reason: entry.reason,
+      expires: expiryToSnykDatetime(entry.expiresAt),
+      created,
+    });
+  }
+
+  const outPath = path.resolve(cwd, opts.out ?? '.snyk');
+  const policy = buildSnykPolicy(ignores);
+  fs.writeFileSync(outPath, policy, 'utf8');
+
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify({ out: outPath, ignores: ignores.length, skippedExpired }, null, 2) + '\n',
+    );
+    return;
+  }
+
+  if (ignores.length === 0) {
+    logger.info(
+      `No Snyk-originated findings are allowlisted — wrote an empty policy to ${outPath}.` +
+        (skippedExpired > 0
+          ? ` (${skippedExpired} expired entr${skippedExpired === 1 ? 'y' : 'ies'} skipped.)`
+          : ''),
+    );
+    return;
+  }
+  logger.success(
+    `Wrote ${ignores.length} Snyk ignore${ignores.length === 1 ? '' : 's'} to ${outPath}` +
+      (skippedExpired > 0 ? ` (${skippedExpired} expired skipped)` : '') +
+      '.',
+  );
+  logger.dim(
+    '  Note: Snyk Code (SAST) honors .snyk ignores only with the "consistent ignores" ' +
+      'feature enabled for your org; SCA/dependency ignores are standard.',
+  );
 }
 
 // ─── Internals ────────────────────────────────────────────────────────────

--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -33,9 +33,15 @@
  * IO logic here — this file is pure orchestration.
  */
 
+import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import * as logger from '../logger';
+import {
+  DEFAULT_BASELINE_NAME,
+  pathForBaseline,
+  readBaselineFile,
+} from '../baseline/baseline-file';
 import { LANGUAGES } from '../languages';
 import type { LanguageSupport } from '../languages/types';
 import type { IdentityKind } from '../baseline/producers';
@@ -59,6 +65,7 @@ import {
   loadAllowlist,
   pathForAllowlist,
   pruneExpired,
+  removeEntry,
   saveAllowlist,
   validateAllowlistEntry,
   type AllowlistEntry,
@@ -69,7 +76,7 @@ import {
 import { insertAnnotation } from './inline';
 
 /** Subcommands recognized under `vyuh-dxkit allowlist`. */
-export const ALLOWLIST_SUBCOMMANDS = ['add', 'list', 'show', 'audit', 'prune'] as const;
+export const ALLOWLIST_SUBCOMMANDS = ['add', 'list', 'show', 'audit', 'prune', 'remove'] as const;
 export type AllowlistSubcommand = (typeof ALLOWLIST_SUBCOMMANDS)[number];
 
 export interface AllowlistAddOpts {
@@ -103,6 +110,18 @@ export interface AllowlistAuditOpts {
   readonly json?: boolean;
   /** Soon-to-expire horizon in days (default 14). */
   readonly soonToExpireDays?: number;
+  /** Cross-check fingerprints against the committed baseline so the
+   *  audit can flag orphaned entries (suppress nothing in the current
+   *  finding set). Off by default — keeps `audit` a pure read of the
+   *  allowlist file unless the user opts in. */
+  readonly againstBaseline?: boolean;
+  /** Named baseline to diff against (default `main`). */
+  readonly baselineName?: string;
+}
+
+export interface AllowlistRemoveOpts {
+  readonly fingerprint?: string;
+  readonly json?: boolean;
 }
 
 export interface AllowlistPruneOpts {
@@ -163,6 +182,8 @@ export async function runAllowlist(
       return runAllowlistAudit(cwd, {
         json: !!args.values.json,
         soonToExpireDays: Number.isFinite(horizon) ? horizon : undefined,
+        againstBaseline: !!args.values['against-baseline'],
+        baselineName: args.values['baseline-name'] as string | undefined,
       });
     }
     case 'prune':
@@ -170,6 +191,11 @@ export async function runAllowlist(
         json: !!args.values.json,
         dryRun: !!args.values['dry-run'],
         yes: !!args.values.yes,
+      });
+    case 'remove':
+      return runAllowlistRemove(cwd, {
+        fingerprint: args.positionalAfter,
+        json: !!args.values.json,
       });
   }
 }
@@ -396,7 +422,26 @@ export async function runAllowlistAudit(cwd: string, opts: AllowlistAuditOpts): 
     return;
   }
 
-  const report = auditAllowlist(file, { soonToExpireDays: opts.soonToExpireDays });
+  // Orphan detection is opt-in: only when `--against-baseline` is set
+  // do we read the committed baseline and build the current-finding
+  // fingerprint set. Without it, audit stays a pure read of the file.
+  let currentFingerprints: ReadonlySet<string> | undefined;
+  if (opts.againstBaseline) {
+    currentFingerprints = baselineFingerprintSet(cwd, opts.baselineName);
+    if (!currentFingerprints) {
+      logger.warn(
+        `--against-baseline requested but no baseline found at ` +
+          `${pathForBaseline(cwd, opts.baselineName ?? DEFAULT_BASELINE_NAME)} — ` +
+          `skipping orphan detection. Refresh the baseline in CI first ` +
+          `(see the dxkit-baseline-refresh workflow).`,
+      );
+    }
+  }
+
+  const report = auditAllowlist(file, {
+    soonToExpireDays: opts.soonToExpireDays,
+    ...(currentFingerprints ? { currentFingerprints } : {}),
+  });
 
   if (opts.json) {
     process.stdout.write(JSON.stringify(report, null, 2) + '\n');
@@ -413,7 +458,8 @@ export async function runAllowlistAudit(cwd: string, opts: AllowlistAuditOpts): 
   if (
     report.expired.length === 0 &&
     report.soonToExpire.length === 0 &&
-    report.missingRationale.length === 0
+    report.missingRationale.length === 0 &&
+    (report.orphaned?.length ?? 0) === 0
   ) {
     logger.success(`No issues found.`);
     return;
@@ -447,6 +493,19 @@ export async function runAllowlistAudit(cwd: string, opts: AllowlistAuditOpts): 
     );
     for (const e of report.missingRationale) {
       logger.info(`  ${e.fingerprint}  ${e.kind}/${e.category}`);
+    }
+  }
+
+  if (report.orphaned && report.orphaned.length > 0) {
+    logger.warn(
+      `Orphaned (${report.orphaned.length}) — fingerprint matches no current finding. ` +
+        `REVIEW, don't bulk-remove: re-baselining can churn fingerprints, and an ` +
+        `orphan may still suppress an intermittently-detected finding. Confirm the ` +
+        `finding is truly gone, then \`vyuh-dxkit allowlist remove <fingerprint>\`:`,
+    );
+    for (const e of report.orphaned) {
+      const reasonPreview = e.reason ? ` — ${truncate(e.reason, 50)}` : '';
+      logger.info(`  ${e.fingerprint}  ${e.kind}/${e.category}${reasonPreview}`);
     }
   }
 }
@@ -490,10 +549,71 @@ export async function runAllowlistPrune(cwd: string, opts: AllowlistPruneOpts): 
   logger.success(`Pruned ${removed.length} expired entries.`);
 }
 
+// ─── remove ─────────────────────────────────────────────────────────────────
+
+export async function runAllowlistRemove(cwd: string, opts: AllowlistRemoveOpts): Promise<void> {
+  const fp = opts.fingerprint?.trim();
+  if (!fp) {
+    logger.fail(`Usage: vyuh-dxkit allowlist remove <fingerprint>`);
+    process.exit(1);
+  }
+  const file = loadAllowlist(cwd);
+  if (!file) {
+    logger.fail(`No allowlist file at ${pathForAllowlist(cwd)} — nothing to remove.`);
+    process.exit(1);
+  }
+  const entry = findEntry(file, fp);
+  if (!entry) {
+    logger.fail(
+      `No allowlist entry for fingerprint ${fp}. ` +
+        `Run \`vyuh-dxkit allowlist list\` to see current entries.`,
+    );
+    process.exit(1);
+  }
+
+  const updated = removeEntry(file, fp);
+  saveAllowlist(cwd, updated);
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ removed: entry }, null, 2) + '\n');
+    return;
+  }
+  logger.success(`Removed allowlist entry ${fp} (kind=${entry.kind}, category=${entry.category}).`);
+}
+
 // ─── Internals ────────────────────────────────────────────────────────────
 
 function isAllowlistSubcommand(value: string): value is AllowlistSubcommand {
   return (ALLOWLIST_SUBCOMMANDS as readonly string[]).includes(value);
+}
+
+/**
+ * Build the set of fingerprints present in the committed baseline —
+ * the union of every entry's `id` plus its `absorbedFingerprints`.
+ * The absorbed set matters: cross-tool dedup collapses several
+ * findings into one representative, and an allowlist entry keyed on a
+ * collapsed contributor still suppresses the merged finding (CLAUDE.md
+ * Rule 9 robust matching). Including absorbed fingerprints here keeps
+ * such entries OUT of the orphaned bucket.
+ *
+ * Returns `undefined` when no baseline exists on disk (the caller
+ * renders a steer-to-CI notice rather than reporting false orphans).
+ */
+function baselineFingerprintSet(
+  cwd: string,
+  name: string | undefined,
+): ReadonlySet<string> | undefined {
+  const baselinePath = pathForBaseline(cwd, name ?? DEFAULT_BASELINE_NAME);
+  if (!fs.existsSync(baselinePath)) return undefined;
+  const baseline = readBaselineFile(baselinePath);
+  const set = new Set<string>();
+  for (const entry of baseline.findings) {
+    set.add(entry.id);
+    if ('absorbedFingerprints' in entry && entry.absorbedFingerprints) {
+      for (const fp of entry.absorbedFingerprints) set.add(fp);
+    }
+  }
+  return set;
 }
 
 function parseCategory(raw: string | undefined): AllowlistCategory {

--- a/src/allowlist/file.ts
+++ b/src/allowlist/file.ts
@@ -377,11 +377,23 @@ export interface SoonToExpire {
  *   reason. In full mode this should never happen (validator
  *   rejects); in sanitized mode it may occur when the sidecar is
  *   missing or stale.
+ * - `orphaned` — entries whose fingerprint matches no current
+ *   finding. Only populated when the caller supplies the set of
+ *   current finding fingerprints via `AuditOptions.currentFingerprints`
+ *   (otherwise `undefined` — audit stays pure-over-file). An orphaned
+ *   entry is NOT necessarily stale: re-baselining churns some
+ *   fingerprints (semgrep nondeterminism, cross-tool dedup ordering),
+ *   and an entry may suppress an intermittently-detected finding. So
+ *   this bucket FLAGS for review — it never drives auto-removal.
  */
 export interface AuditReport {
   readonly expired: ReadonlyArray<AllowlistEntry>;
   readonly soonToExpire: ReadonlyArray<SoonToExpire>;
   readonly missingRationale: ReadonlyArray<AllowlistEntry>;
+  /** Entries whose fingerprint is absent from the supplied current-
+   *  finding set. `undefined` when no set was supplied (the caller
+   *  didn't ask for orphan detection). */
+  readonly orphaned?: ReadonlyArray<AllowlistEntry>;
 }
 
 export interface AuditOptions {
@@ -389,6 +401,12 @@ export interface AuditOptions {
   /** Window in days within which `expiresAt` is considered "soon."
    *  Default 14 — chosen to match a typical sprint cadence. */
   readonly soonToExpireDays?: number;
+  /** Set of fingerprints present in the current finding set (the
+   *  union of every baseline entry's `id` plus its
+   *  `absorbedFingerprints`, so an entry keyed on a collapsed
+   *  contributor isn't falsely flagged). When provided, entries whose
+   *  fingerprint isn't in this set land in the `orphaned` bucket. */
+  readonly currentFingerprints?: ReadonlySet<string>;
 }
 
 export function auditAllowlist(file: AllowlistFile, options: AuditOptions = {}): AuditReport {
@@ -397,6 +415,7 @@ export function auditAllowlist(file: AllowlistFile, options: AuditOptions = {}):
   const expired: AllowlistEntry[] = [];
   const soonToExpire: SoonToExpire[] = [];
   const missingRationale: AllowlistEntry[] = [];
+  const orphaned: AllowlistEntry[] = [];
 
   for (const entry of file.entries) {
     const days = daysUntilExpiry(entry, now);
@@ -412,8 +431,16 @@ export function auditAllowlist(file: AllowlistFile, options: AuditOptions = {}):
       // "unavailable locally" notice.
       missingRationale.push(entry);
     }
+    if (options.currentFingerprints && !options.currentFingerprints.has(entry.fingerprint)) {
+      orphaned.push(entry);
+    }
   }
-  return { expired, soonToExpire, missingRationale };
+  return {
+    expired,
+    soonToExpire,
+    missingRationale,
+    ...(options.currentFingerprints ? { orphaned } : {}),
+  };
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -342,6 +342,9 @@ export async function run(argv: string[]): Promise<void> {
       engine: { type: 'string' },
       org: { type: 'string' },
       project: { type: 'string' },
+      // ingest: opt-in .env loading of SNYK_* creds
+      'no-env-file': { type: 'boolean', default: false },
+      'env-file': { type: 'string' },
       // baseline create: proceed despite missing scanners (CI/non-interactive)
       'allow-incomplete': { type: 'boolean', default: false },
     },
@@ -1980,6 +1983,8 @@ export async function run(argv: string[]): Promise<void> {
         engine: values.engine as string | undefined,
         org: values.org as string | undefined,
         project: values.project as string | undefined,
+        noEnvFile: !!values['no-env-file'],
+        envFile: values['env-file'] as string | undefined,
         generatedAt: new Date().toISOString(),
         commitSha,
       });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -174,7 +174,17 @@ function printUsage(): void {
     vyuh-dxkit allowlist list | show <fingerprint> | audit | prune [--dry-run] [--json]
                                  Review / audit / clean the allowlist. audit surfaces
                                  expired + soon-to-expire (within 14 days) + missing-
-                                 rationale entries. prune removes expired entries.
+                                 rationale entries; add --against-baseline to also flag
+                                 orphaned entries (match no current finding). prune
+                                 removes expired entries.
+    vyuh-dxkit allowlist remove <fingerprint>
+                                 Delete one file-level allowlist entry by fingerprint.
+                                 Use after a re-baseline orphans an entry whose finding
+                                 is confirmed gone (see allowlist audit --against-baseline).
+    vyuh-dxkit allowlist export --snyk [--out=<.snyk>]
+                                 Write a .snyk policy file ignoring every Snyk-originated
+                                 allowlisted finding, so the team's dxkit suppressions
+                                 propagate to Snyk's own gate.
     vyuh-dxkit issue --type=<type> [--about=<text>] [--fingerprint=<id>] [--no-browser]
                                  Open a pre-filled GitHub Issue against vyuh-labs/dxkit.
                                  Types: false-positive, missing-finding, bug,
@@ -297,7 +307,7 @@ export async function run(argv: string[]): Promise<void> {
       target: { type: 'string' },
       'dry-run': { type: 'boolean', default: false },
       plan: { type: 'boolean', default: false },
-      // allowlist flags (allowlist add | list | show | audit | prune)
+      // allowlist flags (allowlist add | list | show | audit | prune | remove | export)
       category: { type: 'string' },
       reason: { type: 'string' },
       fingerprint: { type: 'string' },
@@ -307,6 +317,10 @@ export async function run(argv: string[]): Promise<void> {
       mode: { type: 'string' },
       ref: { type: 'string' },
       'soon-days': { type: 'string' },
+      'against-baseline': { type: 'boolean', default: false },
+      'baseline-name': { type: 'string' },
+      snyk: { type: 'boolean', default: false },
+      out: { type: 'string' },
       // issue flags
       type: { type: 'string' },
       about: { type: 'string' },
@@ -1935,8 +1949,8 @@ export async function run(argv: string[]): Promise<void> {
 
     case 'allowlist': {
       const { runAllowlist } = await import('./allowlist/cli');
-      // positionals[1] = subcommand (add | list | show)
-      // positionals[2] = optional target (file:line for add, fingerprint for show)
+      // positionals[1] = subcommand (add | list | show | audit | prune | remove | export)
+      // positionals[2] = optional target (file:line for add; fingerprint for show / remove)
       await runAllowlist(cwd, positionals[1], {
         positionalAfter: positionals[2],
         values: values as Record<string, unknown>,

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -82,7 +82,7 @@ function buildSettingsJson(config: ResolvedConfig): string {
 }
 
 /**
- * The six dxkit-specific skills shipped under `--with-dxkit-agents`.
+ * The dxkit-specific skills shipped under `--with-dxkit-agents`.
  * Each lives at `.claude/skills/<name>/SKILL.md` in the template dir;
  * generator copies them verbatim (no template substitution — the
  * skill content references the canonical `vyuh-dxkit` CLI surface
@@ -128,6 +128,12 @@ const DXKIT_SKILLS = [
   // by dxkit-action. License-aware engine selection; quota-free Snyk
   // read; committed snapshot so the token is needed only at ingest time.
   'dxkit-ingest',
+  // dxkit-allowlist: suppression-lifecycle surface. Reviews, audits
+  // (including orphans after a re-baseline), removes stale entries,
+  // prunes expired ones, and exports Snyk-originated suppressions to a
+  // `.snyk` policy. The fix-vs-suppress decision + the `add` path stay
+  // in dxkit-action; this owns everything after an entry exists.
+  'dxkit-allowlist',
 ] as const;
 
 interface GenerateResult {

--- a/src/ingest-cli.ts
+++ b/src/ingest-cli.ts
@@ -10,6 +10,9 @@
  *                    On plans without REST API access (Enterprise-only)
  *                    this auto-falls-back to `snyk code test`; pass
  *                    --snyk-cli to force that path and skip the REST try.
+ *                    SNYK_* credentials are read from the environment and,
+ *                    as a fallback, from a local `.env` (only SNYK_* keys;
+ *                    --no-env-file opts out, --env-file <path> overrides).
  *
  * Either way the result is written to `.dxkit/external/<engine>.json`,
  * a committed snapshot every later scan reads — so the token is needed
@@ -23,6 +26,7 @@ import { fetchSnykCodeFindings } from './ingest/snyk-api';
 import { runSnykCodeTest } from './ingest/snyk-cli';
 import { runCodeql, type CodeqlTarget } from './ingest/codeql';
 import { readDeepSastConfig } from './ingest/config';
+import { loadSnykEnv } from './ingest/env-file';
 import { writeSnapshot } from './ingest/snapshot';
 import { detectActiveLanguages } from './languages/index';
 import type { SourceEngine, ExternalFinding } from './ingest/types';
@@ -42,6 +46,10 @@ export interface IngestOptions {
   project?: string;
   generatedAt: string;
   commitSha?: string;
+  /** Skip opt-in `.env` loading of `SNYK_*` credentials (`--no-env-file`). */
+  noEnvFile?: boolean;
+  /** Explicit `.env` path for `SNYK_*` credentials (`--env-file <path>`). */
+  envFile?: string;
 }
 
 function isSourceEngine(s: string | undefined): s is SourceEngine {
@@ -66,6 +74,7 @@ export async function runIngest(cwd: string, opts: IngestOptions): Promise<void>
   logger.dim('    vyuh-dxkit ingest --sarif results.sarif');
   logger.dim('    SNYK_TOKEN=… vyuh-dxkit ingest --from-snyk --org <id> --project <id>');
   logger.dim('    SNYK_TOKEN=… vyuh-dxkit ingest --from-snyk --snyk-cli  # free/team plans');
+  logger.dim('    vyuh-dxkit ingest --from-snyk   # SNYK_* read from .env when present');
   logger.dim('    vyuh-dxkit ingest --codeql        # OSS / GitHub Advanced Security only');
   process.exitCode = 1;
 }
@@ -126,20 +135,36 @@ export function isNotEntitled(message: string): boolean {
 }
 
 async function ingestFromSnyk(cwd: string, opts: IngestOptions): Promise<void> {
+  // Opt-in: lift ONLY SNYK_* keys from a local `.env` into the
+  // environment (real exported env / CI secret always wins). Disabled
+  // by --no-env-file; path overridable by --env-file. CI has no .env →
+  // no-op, so behavior there is unchanged.
+  const envLoad = loadSnykEnv(cwd, { noEnvFile: opts.noEnvFile, envFile: opts.envFile });
+  if (envLoad) {
+    for (const w of envLoad.warnings) logger.warn(w);
+    if (envLoad.loadedKeys.length > 0) {
+      logger.dim(`  Loaded ${envLoad.loadedKeys.join(', ')} from ${envLoad.path}`);
+    }
+  }
+
   const token = process.env.SNYK_TOKEN;
   if (!token) {
     logger.warn('SNYK_TOKEN is not set.');
     logger.dim(
-      '  dxkit reads SNYK_TOKEN from the environment — it does NOT auto-load a .env file.',
+      '  dxkit reads SNYK_TOKEN from the environment. It also auto-loads SNYK_* keys ' +
+        'from a local .env (only those keys, never the rest of the file).',
     );
-    logger.dim('  Export it (`export SNYK_TOKEN=…`) or add it as a CI secret, then retry.');
+    logger.dim(
+      '  Export it (`export SNYK_TOKEN=…`), put it in .env, or add it as a CI secret, then retry. ' +
+        'Use --no-env-file to skip .env, or --env-file <path> to point elsewhere.',
+    );
     process.exitCode = 1;
     return;
   }
   // Org/project resolve flag → persisted config (`.vyuh-dxkit.json:
   // deepSast.snyk`) → environment, so a sourced shell or configured repo
-  // can run `ingest --from-snyk` with no flags. (dxkit does not read .env;
-  // export the vars or set CI secrets.)
+  // can run `ingest --from-snyk` with no flags. SNYK_ORG_ID / SNYK_PROJECT_ID
+  // also come from a local .env via loadSnykEnv above (SNYK_* keys only).
   const cfg = readDeepSastConfig(cwd);
   const orgId = opts.org ?? cfg.snyk?.orgId ?? process.env.SNYK_ORG_ID;
   const projectId = opts.project ?? cfg.snyk?.projectId ?? process.env.SNYK_PROJECT_ID;

--- a/src/ingest/env-file.ts
+++ b/src/ingest/env-file.ts
@@ -1,0 +1,152 @@
+/**
+ * Opt-in `.env` loading for Snyk credentials — scoped strictly to the
+ * `SNYK_*` prefix.
+ *
+ * dxkit deliberately does NOT auto-load a whole `.env` into
+ * `process.env` (pulling a developer's entire secrets file — GitHub
+ * tokens, database URLs, unrelated API keys — into the process is a
+ * footgun). But a local developer who keeps their Snyk token in `.env`
+ * shouldn't have to re-`export` it before every `ingest --from-snyk`.
+ *
+ * The compromise: read the cwd's `.env` (or an explicit `--env-file`
+ * path), parse it, and lift ONLY keys beginning with `SNYK_` into the
+ * environment — and only when they aren't already set, so a real
+ * exported env / CI Actions secret always wins. CI, which sets the
+ * token via the environment and has no `.env`, is a no-op.
+ *
+ * This module is pure data-in/data-out: it mutates `process.env` for
+ * the lifted keys and returns a structured result (the keys it set +
+ * any advisory warnings). The CLI renders the one-line notice + the
+ * warnings; the module logs nothing itself, which keeps it testable.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+/** Prefix that gates which keys may be lifted from the file. Nothing
+ *  outside this prefix is ever read into the environment. */
+export const SNYK_ENV_PREFIX = 'SNYK_';
+
+export interface SnykEnvLoadOptions {
+  /** Skip `.env` loading entirely (`--no-env-file`). */
+  readonly noEnvFile?: boolean;
+  /** Explicit path override (`--env-file <path>`). Relative paths
+   *  resolve against `cwd`. When set and the file is missing, that's
+   *  a surfaced warning (the user asked for a specific file). */
+  readonly envFile?: string;
+}
+
+export interface SnykEnvLoadResult {
+  /** Absolute path of the file that was read. */
+  readonly path: string;
+  /** `SNYK_*` keys lifted into `process.env` (only those that weren't
+   *  already set). Empty when the file had none or they were all
+   *  already present in the environment. */
+  readonly loadedKeys: ReadonlyArray<string>;
+  /** Advisory messages for the caller to surface (e.g. the file looks
+   *  committed to git). Never fatal. */
+  readonly warnings: ReadonlyArray<string>;
+}
+
+/**
+ * Parse a `.env`-style file body into key/value pairs, keeping ONLY
+ * keys that start with `SNYK_`. Tolerant of the common shapes:
+ * blank lines, `#` comments, an optional `export ` prefix, and
+ * single/double-quoted values. No variable interpolation — values are
+ * taken literally (after unquoting), which is correct for opaque
+ * tokens and ids.
+ */
+export function parseSnykEnv(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const m = line.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    if (!key.startsWith(SNYK_ENV_PREFIX)) continue;
+    out[key] = unquote(m[2]);
+  }
+  return out;
+}
+
+function unquote(value: string): string {
+  const v = value.trim();
+  if (v.length >= 2) {
+    const first = v[0];
+    const last = v[v.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return v.slice(1, -1);
+    }
+  }
+  return v;
+}
+
+/**
+ * Lift `SNYK_*` keys from the cwd's `.env` (or `--env-file`) into
+ * `process.env`, unless `--no-env-file` is set or no file exists.
+ * Real environment values are never overwritten. Returns `null` when
+ * nothing was attempted (disabled, or no file present and none
+ * explicitly requested); otherwise a result describing what happened.
+ */
+export function loadSnykEnv(cwd: string, opts: SnykEnvLoadOptions = {}): SnykEnvLoadResult | null {
+  if (opts.noEnvFile) return null;
+
+  const explicit = opts.envFile !== undefined;
+  const filePath = explicit ? path.resolve(cwd, opts.envFile as string) : path.join(cwd, '.env');
+
+  if (!fs.existsSync(filePath)) {
+    if (explicit) {
+      return { path: filePath, loadedKeys: [], warnings: [`env-file not found: ${filePath}`] };
+    }
+    return null;
+  }
+
+  let body: string;
+  try {
+    body = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    return {
+      path: filePath,
+      loadedKeys: [],
+      warnings: [`could not read env-file ${filePath}: ${(err as Error).message}`],
+    };
+  }
+
+  const parsed = parseSnykEnv(body);
+  const loadedKeys: string[] = [];
+  for (const [key, value] of Object.entries(parsed)) {
+    // Real exported env / CI secret always wins. Treat an empty string
+    // as "unset" so a blank export doesn't shadow a populated .env.
+    const current = process.env[key];
+    if (current === undefined || current === '') {
+      process.env[key] = value;
+      loadedKeys.push(key);
+    }
+  }
+
+  const warnings: string[] = [];
+  if (isTrackedByGit(cwd, filePath)) {
+    warnings.push(
+      `${path.basename(filePath)} appears to be committed to git — a secrets file ` +
+        `should be gitignored. Move SNYK_TOKEN out of version control.`,
+    );
+  }
+
+  return { path: filePath, loadedKeys, warnings };
+}
+
+/** Whether `filePath` is tracked in the git index at `cwd`. Best-effort
+ *  — any failure (not a repo, git missing) is treated as "not tracked"
+ *  so the advisory simply doesn't fire. */
+function isTrackedByGit(cwd: string, filePath: string): boolean {
+  try {
+    execSync(`git ls-files --error-unmatch ${JSON.stringify(filePath)}`, {
+      cwd,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/ingest/snyk-policy.ts
+++ b/src/ingest/snyk-policy.ts
@@ -1,0 +1,119 @@
+/**
+ * Writer for Snyk's `.snyk` policy file — the OUTBOUND half of the
+ * Snyk ↔ dxkit suppression sync.
+ *
+ * 2.9.1 wired the INBOUND direction: dxkit honors SARIF
+ * `result.suppressions` so a finding the team dismissed in Snyk is
+ * dropped at ingest time (`src/ingest/sarif.ts`). This module is the
+ * mirror: when the team allowlists a Snyk-originated finding in dxkit,
+ * `allowlist export --snyk` writes a `.snyk` ignore so the decision
+ * propagates back to Snyk's own gate (`snyk code test`, the Snyk UI).
+ *
+ * The `.snyk` file is YAML. dxkit carries no YAML dependency, so this
+ * is a small CONTROLLED serializer for exactly the policy shape Snyk's
+ * tooling reads — not a general YAML emitter. The structure is fixed:
+ *
+ *   version: v1.25.0
+ *   ignore:
+ *     '<rule-id>':
+ *       - '<path>':
+ *           reason: "<reason>"
+ *           expires: <ISO datetime>     # omitted for a permanent ignore
+ *           created: <ISO datetime>
+ *   patch: {}
+ *
+ * Caveat surfaced to the user by the CLI: Snyk Code (SAST) honors
+ * `.snyk` ignores only when the org has Snyk's "consistent ignores"
+ * feature enabled; SCA/dependency ignores are standard. dxkit writes
+ * the file either way — the caller documents the prerequisite.
+ */
+
+/** One ignore directive — a single (rule, path) pair plus metadata. */
+export interface SnykIgnore {
+  /** Snyk-native rule / issue id (e.g. `javascript/InsecureTLSConfig`). */
+  readonly ruleId: string;
+  /** Repo-relative path the ignore applies to. */
+  readonly path: string;
+  /** Human rationale carried over from the allowlist entry. */
+  readonly reason?: string;
+  /** ISO 8601 datetime after which the ignore lapses. Omitted →
+   *  permanent ignore (Snyk treats a missing `expires` as no expiry). */
+  readonly expires?: string;
+  /** ISO 8601 datetime the ignore was written. */
+  readonly created: string;
+}
+
+/** Snyk policy schema version dxkit emits. Matches the version Snyk's
+ *  own `snyk ignore` writes for the ignore/patch shape used here. */
+export const SNYK_POLICY_VERSION = 'v1.25.0' as const;
+
+/**
+ * Convert an allowlist entry's `expiresAt` (`YYYY-MM-DD`) into the ISO
+ * datetime Snyk's policy file expects. Returns `undefined` for a
+ * missing date so the caller emits a permanent ignore.
+ */
+export function expiryToSnykDatetime(expiresAt: string | undefined): string | undefined {
+  if (!expiresAt) return undefined;
+  return `${expiresAt}T00:00:00.000Z`;
+}
+
+/**
+ * Serialize ignores into `.snyk` policy YAML. Groups by rule id (the
+ * file's top-level ignore key), each carrying a list of per-path
+ * directives. Deterministic ordering (rules + paths sorted) so the
+ * committed file has stable diffs across runs.
+ */
+export function buildSnykPolicy(ignores: ReadonlyArray<SnykIgnore>): string {
+  const byRule = new Map<string, SnykIgnore[]>();
+  for (const ig of ignores) {
+    const list = byRule.get(ig.ruleId) ?? [];
+    list.push(ig);
+    byRule.set(ig.ruleId, list);
+  }
+
+  const lines: string[] = [
+    '# Snyk (https://snyk.io) policy file, written by dxkit allowlist export.',
+    `version: ${SNYK_POLICY_VERSION}`,
+  ];
+
+  if (byRule.size === 0) {
+    lines.push('ignore: {}');
+    lines.push('patch: {}');
+    return lines.join('\n') + '\n';
+  }
+
+  lines.push('ignore:');
+  for (const ruleId of [...byRule.keys()].sort()) {
+    lines.push(`  ${quoteKey(ruleId)}:`);
+    const perPath = byRule.get(ruleId)!;
+    // Stable order + one directive per unique path.
+    const seen = new Set<string>();
+    for (const ig of perPath.slice().sort((a, b) => a.path.localeCompare(b.path))) {
+      if (seen.has(ig.path)) continue;
+      seen.add(ig.path);
+      lines.push(`    - ${quoteKey(ig.path)}:`);
+      lines.push(`        reason: ${doubleQuote(ig.reason ?? '')}`);
+      if (ig.expires) lines.push(`        expires: ${ig.expires}`);
+      lines.push(`        created: ${ig.created}`);
+    }
+  }
+  lines.push('patch: {}');
+  return lines.join('\n') + '\n';
+}
+
+// ─── Minimal scalar quoting ───────────────────────────────────────────────
+
+/** Single-quote a YAML key/scalar, escaping embedded single quotes by
+ *  doubling (the YAML single-quote rule). Used for rule ids + paths,
+ *  which never contain newlines. */
+function quoteKey(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+/** Double-quote a YAML scalar. JSON's string encoding is a valid YAML
+ *  double-quoted flow scalar (YAML is a JSON superset), so JSON.stringify
+ *  gives correct escaping for reasons that may carry quotes, colons, or
+ *  other special characters. */
+function doubleQuote(value: string): string {
+  return JSON.stringify(value);
+}

--- a/test/allowlist/cli.test.ts
+++ b/test/allowlist/cli.test.ts
@@ -7,6 +7,7 @@ import {
   runAllowlistAudit,
   runAllowlistList,
   runAllowlistPrune,
+  runAllowlistRemove,
   runAllowlistShow,
 } from '../../src/allowlist/cli';
 import {
@@ -619,5 +620,174 @@ describe('runAllowlistPrune', () => {
       addedBy: 'a@b.c',
     });
     await expect(runAllowlistPrune(tmp, {})).resolves.toBeUndefined();
+  });
+});
+
+describe('runAllowlistRemove', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  it('removes an existing entry by fingerprint', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'bbbb111111111111',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'r',
+      addedBy: 'a@b.c',
+    });
+    await runAllowlistRemove(tmp, { fingerprint: 'bbbb111111111111' });
+    const after = loadAllowlist(tmp);
+    expect(after?.entries ?? []).toHaveLength(0);
+  });
+
+  it('fails when fingerprint is missing from the allowlist', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'bbbb111111111111',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'r',
+      addedBy: 'a@b.c',
+    });
+    const exitSpy = mockExit();
+    await expect(runAllowlistRemove(tmp, { fingerprint: 'cccc222222222222' })).rejects.toThrow(
+      /process\.exit\(1\)/,
+    );
+    // Original entry untouched
+    expect(loadAllowlist(tmp)?.entries).toHaveLength(1);
+    exitSpy.mockRestore();
+  });
+
+  it('fails with no positional fingerprint', async () => {
+    const exitSpy = mockExit();
+    await expect(runAllowlistRemove(tmp, {})).rejects.toThrow(/process\.exit\(1\)/);
+    exitSpy.mockRestore();
+  });
+
+  it('--json emits the removed entry', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'bbbb111111111111',
+      kind: 'dep-vuln',
+      category: 'mitigated-externally',
+      reason: 'r',
+      addedBy: 'a@b.c',
+    });
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistRemove(tmp, { fingerprint: 'bbbb111111111111', json: true });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed.removed.fingerprint).toBe('bbbb111111111111');
+    stdoutSpy.mockRestore();
+  });
+});
+
+describe('runAllowlistAudit --against-baseline (orphaned bucket)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  async function writeBaseline(
+    ids: ReadonlyArray<{ id: string; absorbed?: readonly string[] }>,
+  ): Promise<void> {
+    const { writeBaselineFile, pathForBaseline, BASELINE_SCHEMA_VERSION, DEFAULT_BASELINE_NAME } =
+      await import('../../src/baseline/baseline-file');
+    writeBaselineFile(pathForBaseline(tmp, DEFAULT_BASELINE_NAME), {
+      schemaVersion: BASELINE_SCHEMA_VERSION,
+      name: DEFAULT_BASELINE_NAME,
+      createdAt: '2026-06-09T00:00:00.000Z',
+      repo: { commitSha: 'a'.repeat(40), branch: 'main', root: '/repo' },
+      analysis: {
+        dxkitVersion: '2.9.2',
+        policyHash: 'p'.repeat(16),
+        ignoreHash: 'i'.repeat(16),
+        toolchainHash: 't'.repeat(16),
+        configHash: 'c'.repeat(16),
+      },
+      tools: { semgrep: '1.161.0' },
+      saltMode: 'deterministic',
+      findings: ids.map((e) => ({
+        id: e.id,
+        kind: 'code' as const,
+        tool: 'semgrep',
+        rule: 'r',
+        file: 'f.ts',
+        line: 1,
+        ...(e.absorbed ? { absorbedFingerprints: e.absorbed } : {}),
+      })),
+    });
+  }
+
+  it('flags an entry whose fingerprint is absent from the baseline', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'aaaa111111111111',
+      kind: 'code',
+      category: 'false-positive',
+      reason: 'fp',
+      addedBy: 'a@b.c',
+    });
+    await writeBaseline([{ id: 'dddd999999999999' }]); // different fp
+
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistAudit(tmp, { json: true, againstBaseline: true });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed.orphaned).toHaveLength(1);
+    expect(parsed.orphaned[0].fingerprint).toBe('aaaa111111111111');
+    stdoutSpy.mockRestore();
+  });
+
+  it('does NOT flag an entry matched only via absorbedFingerprints', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'aaaa111111111111',
+      kind: 'code',
+      category: 'false-positive',
+      reason: 'fp',
+      addedBy: 'a@b.c',
+    });
+    // The entry's fp is a collapsed contributor of a current finding.
+    await writeBaseline([{ id: 'dddd999999999999', absorbed: ['aaaa111111111111'] }]);
+
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistAudit(tmp, { json: true, againstBaseline: true });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed.orphaned).toHaveLength(0);
+    stdoutSpy.mockRestore();
+  });
+
+  it('omits the orphaned bucket entirely without --against-baseline', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'aaaa111111111111',
+      kind: 'code',
+      category: 'false-positive',
+      reason: 'fp',
+      addedBy: 'a@b.c',
+    });
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistAudit(tmp, { json: true });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed.orphaned).toBeUndefined();
+    stdoutSpy.mockRestore();
+  });
+
+  it('warns and skips orphan detection when no baseline exists', async () => {
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'aaaa111111111111',
+      kind: 'code',
+      category: 'false-positive',
+      reason: 'fp',
+      addedBy: 'a@b.c',
+    });
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistAudit(tmp, { json: true, againstBaseline: true });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    // No baseline → no orphaned bucket computed.
+    expect(parsed.orphaned).toBeUndefined();
+    stdoutSpy.mockRestore();
   });
 });

--- a/test/allowlist/cli.test.ts
+++ b/test/allowlist/cli.test.ts
@@ -5,11 +5,14 @@ import * as path from 'path';
 import {
   runAllowlistAdd,
   runAllowlistAudit,
+  runAllowlistExport,
   runAllowlistList,
   runAllowlistPrune,
   runAllowlistRemove,
   runAllowlistShow,
 } from '../../src/allowlist/cli';
+import { canonicalRuleFor, computeCodeFingerprint } from '../../src/analyzers/tools/fingerprint';
+import { writeSnapshot } from '../../src/ingest/snapshot';
 import {
   ALLOWLIST_SCHEMA_VERSION,
   loadAllowlist,
@@ -788,6 +791,107 @@ describe('runAllowlistAudit --against-baseline (orphaned bucket)', () => {
     const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
     // No baseline → no orphaned bucket computed.
     expect(parsed.orphaned).toBeUndefined();
+    stdoutSpy.mockRestore();
+  });
+});
+
+describe('runAllowlistExport --snyk', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = makeTmpdir();
+  });
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  function seedSnykFinding(rule: string, file: string, line: number): string {
+    writeSnapshot(tmp, {
+      schemaVersion: 1,
+      engine: 'snyk-code',
+      generatedAt: '2026-06-09T00:00:00.000Z',
+      findings: [
+        {
+          engine: 'snyk-code',
+          severity: 'high',
+          category: 'code',
+          cwe: 'CWE-23',
+          rule,
+          title: 'Path Traversal',
+          file,
+          line,
+        },
+      ],
+    });
+    // The fingerprint dxkit would compute for this finding.
+    return computeCodeFingerprint(canonicalRuleFor('snyk-code', rule), file, line);
+  }
+
+  it('fails without --snyk', async () => {
+    const exitSpy = mockExit();
+    await expect(runAllowlistExport(tmp, {})).rejects.toThrow(/process\.exit\(1\)/);
+    exitSpy.mockRestore();
+  });
+
+  it('exports a .snyk ignore for an allowlisted Snyk-originated finding', async () => {
+    const fp = seedSnykFinding('javascript/PT', 'src/handler.ts', 42);
+    await runAllowlistAdd(tmp, {
+      fingerprint: fp,
+      kind: 'code',
+      category: 'accepted-risk',
+      reason: 'reviewed: input is internal',
+      addedBy: 'a@b.c',
+      expires: '2027-01-01',
+    });
+
+    await runAllowlistExport(tmp, { snyk: true, now: '2026-06-09T00:00:00.000Z' });
+
+    const snyk = fs.readFileSync(path.join(tmp, '.snyk'), 'utf8');
+    expect(snyk).toContain("'javascript/PT':");
+    expect(snyk).toContain("'src/handler.ts':");
+    expect(snyk).toContain('reason: "reviewed: input is internal"');
+    expect(snyk).toContain('expires: 2027-01-01T00:00:00.000Z');
+  });
+
+  it('skips an expired allowlist entry', async () => {
+    const fp = seedSnykFinding('javascript/PT', 'src/handler.ts', 42);
+    // Inject an expired entry directly.
+    const { loadAllowlist, saveAllowlist, addEntry, emptyAllowlistFile } =
+      await import('../../src/allowlist/file');
+    saveAllowlist(
+      tmp,
+      addEntry(loadAllowlist(tmp) ?? emptyAllowlistFile('full'), {
+        fingerprint: fp,
+        kind: 'code',
+        category: 'accepted-risk',
+        reason: 'expired',
+        addedBy: 'a@b.c',
+        addedAt: '2020-01-01',
+        expiresAt: '2020-01-02',
+      }),
+    );
+
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistExport(tmp, { snyk: true, json: true, now: '2026-06-09T00:00:00.000Z' });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed.ignores).toBe(0);
+    expect(parsed.skippedExpired).toBe(1);
+    stdoutSpy.mockRestore();
+  });
+
+  it('does not export a finding that is not allowlisted', async () => {
+    seedSnykFinding('javascript/PT', 'src/handler.ts', 42);
+    // Allowlist a DIFFERENT fingerprint.
+    await runAllowlistAdd(tmp, {
+      fingerprint: 'ffff000011112222',
+      kind: 'code',
+      category: 'false-positive',
+      reason: 'unrelated',
+      addedBy: 'a@b.c',
+    });
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runAllowlistExport(tmp, { snyk: true, json: true, now: '2026-06-09T00:00:00.000Z' });
+    const parsed = JSON.parse(stdoutSpy.mock.calls.map((c) => c[0]).join(''));
+    expect(parsed.ignores).toBe(0);
     stdoutSpy.mockRestore();
   });
 });

--- a/test/cli-init.test.ts
+++ b/test/cli-init.test.ts
@@ -120,6 +120,7 @@ describe('cli init --full --yes (integration, full agent scaffold)', () => {
       'dxkit-feature',
       'dxkit-docs',
       'dxkit-ingest',
+      'dxkit-allowlist',
     ];
     for (const name of expected) {
       const skillPath = path.join(tmpDir, '.claude', 'skills', name, 'SKILL.md');

--- a/test/ingest/env-file.test.ts
+++ b/test/ingest/env-file.test.ts
@@ -67,7 +67,7 @@ describe('loadSnykEnv', () => {
       'GITHUB_TOKEN=nope\nSNYK_TOKEN=abc\nSNYK_ORG_ID=org-1\n',
     );
     const result = loadSnykEnv(tmp);
-    expect(result?.loadedKeys.sort()).toEqual(['SNYK_ORG_ID', 'SNYK_TOKEN']);
+    expect([...(result?.loadedKeys ?? [])].sort()).toEqual(['SNYK_ORG_ID', 'SNYK_TOKEN']);
     expect(process.env.SNYK_TOKEN).toBe('abc');
     expect(process.env.SNYK_ORG_ID).toBe('org-1');
     // Non-SNYK key was never lifted.

--- a/test/ingest/env-file.test.ts
+++ b/test/ingest/env-file.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { loadSnykEnv, parseSnykEnv } from '../../src/ingest/env-file';
+
+function makeTmpdir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-envfile-'));
+}
+
+function rmrf(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('parseSnykEnv', () => {
+  it('keeps only SNYK_* keys and drops everything else', () => {
+    const out = parseSnykEnv(
+      [
+        'GITHUB_TOKEN=ghp_secret',
+        'INFISICAL_TOKEN=inf_secret',
+        'SNYK_TOKEN=snyk_abc',
+        'SNYK_ORG_ID=org-1',
+        '# a comment',
+        '',
+        'export SNYK_PROJECT_ID=proj-9',
+      ].join('\n'),
+    );
+    expect(out).toEqual({
+      SNYK_TOKEN: 'snyk_abc',
+      SNYK_ORG_ID: 'org-1',
+      SNYK_PROJECT_ID: 'proj-9',
+    });
+    expect(out).not.toHaveProperty('GITHUB_TOKEN');
+    expect(out).not.toHaveProperty('INFISICAL_TOKEN');
+  });
+
+  it('strips matching single and double quotes', () => {
+    const out = parseSnykEnv(['SNYK_TOKEN="quoted"', "SNYK_ORG_ID='single'"].join('\n'));
+    expect(out.SNYK_TOKEN).toBe('quoted');
+    expect(out.SNYK_ORG_ID).toBe('single');
+  });
+});
+
+describe('loadSnykEnv', () => {
+  let tmp: string;
+  const saved: Record<string, string | undefined> = {};
+  const keys = ['SNYK_TOKEN', 'SNYK_ORG_ID', 'SNYK_PROJECT_ID'];
+
+  beforeEach(() => {
+    tmp = makeTmpdir();
+    for (const k of keys) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    rmrf(tmp);
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('lifts SNYK_* keys from .env into process.env', () => {
+    fs.writeFileSync(
+      path.join(tmp, '.env'),
+      'GITHUB_TOKEN=nope\nSNYK_TOKEN=abc\nSNYK_ORG_ID=org-1\n',
+    );
+    const result = loadSnykEnv(tmp);
+    expect(result?.loadedKeys.sort()).toEqual(['SNYK_ORG_ID', 'SNYK_TOKEN']);
+    expect(process.env.SNYK_TOKEN).toBe('abc');
+    expect(process.env.SNYK_ORG_ID).toBe('org-1');
+    // Non-SNYK key was never lifted.
+    expect(process.env.GITHUB_TOKEN).not.toBe('nope');
+  });
+
+  it('does NOT overwrite an already-set environment value', () => {
+    process.env.SNYK_TOKEN = 'from-real-env';
+    fs.writeFileSync(path.join(tmp, '.env'), 'SNYK_TOKEN=from-dotenv\n');
+    const result = loadSnykEnv(tmp);
+    expect(process.env.SNYK_TOKEN).toBe('from-real-env');
+    expect(result?.loadedKeys).not.toContain('SNYK_TOKEN');
+  });
+
+  it('returns null when --no-env-file is set, even if .env exists', () => {
+    fs.writeFileSync(path.join(tmp, '.env'), 'SNYK_TOKEN=abc\n');
+    expect(loadSnykEnv(tmp, { noEnvFile: true })).toBeNull();
+    expect(process.env.SNYK_TOKEN).toBeUndefined();
+  });
+
+  it('returns null silently when no .env exists', () => {
+    expect(loadSnykEnv(tmp)).toBeNull();
+  });
+
+  it('warns when an explicit --env-file path is missing', () => {
+    const result = loadSnykEnv(tmp, { envFile: 'nope.env' });
+    expect(result?.loadedKeys).toEqual([]);
+    expect(result?.warnings.join(' ')).toMatch(/not found/);
+  });
+
+  it('honors an explicit --env-file path', () => {
+    fs.writeFileSync(path.join(tmp, 'creds.env'), 'SNYK_TOKEN=xyz\n');
+    const result = loadSnykEnv(tmp, { envFile: 'creds.env' });
+    expect(result?.loadedKeys).toEqual(['SNYK_TOKEN']);
+    expect(process.env.SNYK_TOKEN).toBe('xyz');
+  });
+});

--- a/test/ingest/snyk-policy.test.ts
+++ b/test/ingest/snyk-policy.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSnykPolicy,
+  expiryToSnykDatetime,
+  SNYK_POLICY_VERSION,
+  type SnykIgnore,
+} from '../../src/ingest/snyk-policy';
+
+describe('expiryToSnykDatetime', () => {
+  it('converts a YYYY-MM-DD date to an ISO datetime', () => {
+    expect(expiryToSnykDatetime('2026-12-31')).toBe('2026-12-31T00:00:00.000Z');
+  });
+  it('returns undefined for a missing date (permanent ignore)', () => {
+    expect(expiryToSnykDatetime(undefined)).toBeUndefined();
+  });
+});
+
+describe('buildSnykPolicy', () => {
+  it('emits an empty policy when there are no ignores', () => {
+    const out = buildSnykPolicy([]);
+    expect(out).toContain(`version: ${SNYK_POLICY_VERSION}`);
+    expect(out).toContain('ignore: {}');
+    expect(out).toContain('patch: {}');
+  });
+
+  it('groups by rule id and lists per-path directives', () => {
+    const ignores: SnykIgnore[] = [
+      {
+        ruleId: 'javascript/InsecureTLSConfig',
+        path: 'src/b.ts',
+        reason: 'accepted risk',
+        expires: '2026-12-31T00:00:00.000Z',
+        created: '2026-06-09T00:00:00.000Z',
+      },
+      {
+        ruleId: 'javascript/InsecureTLSConfig',
+        path: 'src/a.ts',
+        reason: 'also accepted',
+        created: '2026-06-09T00:00:00.000Z',
+      },
+    ];
+    const out = buildSnykPolicy(ignores);
+    // Single rule key, both paths under it, paths sorted (a before b).
+    expect(out).toContain("'javascript/InsecureTLSConfig':");
+    const aIdx = out.indexOf("'src/a.ts':");
+    const bIdx = out.indexOf("'src/b.ts':");
+    expect(aIdx).toBeGreaterThan(-1);
+    expect(bIdx).toBeGreaterThan(aIdx);
+    // Reason is double-quoted; expiry present on one, absent on the other.
+    expect(out).toContain('reason: "accepted risk"');
+    expect(out).toContain('expires: 2026-12-31T00:00:00.000Z');
+  });
+
+  it('safely quotes reasons containing special characters', () => {
+    const out = buildSnykPolicy([
+      {
+        ruleId: 'r',
+        path: 'p.ts',
+        reason: 'has "quotes" and: colons',
+        created: '2026-06-09T00:00:00.000Z',
+      },
+    ]);
+    expect(out).toContain('reason: "has \\"quotes\\" and: colons"');
+  });
+});


### PR DESCRIPTION
Follow-up to 2.9.1 closing the self-service gaps the first customer walkthrough surfaced. Seven atomic commits (rebase-merge candidate — each is independently meaningful).

## What's in it

- **`allowlist remove <fingerprint>`** — delete a single file-level entry from the CLI (no more hand-editing `.dxkit/allowlist.json`). `prune` still handles expired-only.
- **`allowlist audit --against-baseline`** — new "orphaned" bucket: entries matching no current finding. Flag-for-review, never auto-removed (re-baselining churns fingerprints; an orphan may suppress an intermittently-detected finding). Counts absorbed cross-tool fingerprints so collapsed-contributor entries aren't falsely flagged.
- **`allowlist export --snyk`** — outbound half of the Snyk ignore sync (2.9.1 did inbound SARIF suppressions). Writes a `.snyk` ignoring every allowlisted Snyk Code finding, keyed on rule id + path with reason + expiry. Round-trip stable; reuses the canonical fingerprint helpers (no parallel identity path).
- **Opt-in `.env` loading for `SNYK_*` creds** — `ingest --from-snyk` reads ONLY `SNYK_*` keys from a local `.env` (never the rest of the file); real env / CI secret always wins (CI unchanged). `--no-env-file` / `--env-file <path>`.
- **New `dxkit-allowlist` skill** — full suppression lifecycle; defers fix-vs-suppress + `add` to `dxkit-action`.
- **Baseline refreshes steer to CI** — skills + docs warn against a local `baseline create --force` (bakes dev scanner versions → spurious tooling-drift + phantom "resolved" on the next PR); route through the bundled refresh workflow.

Plus a documented investigation (re-baseline churn): the "capture the representative's own natural fp" idea is a no-op (it already equals the id); the real churn source — a contributing tool transiently disappearing — isn't fixable by widening the absorbed set, and is mitigated by the orphan-audit bucket + CI-pinned baseline refresh. A baseline-to-baseline absorbed carry-forward is deferred with over-matching risk noted.

## Testing

Affected-scope suites run green locally (`test/allowlist/`, `test/ingest/`, `test/ingest.test.ts`, `test/cli-init.test.ts`). Full suite + cross-ecosystem matrix runs here in CI.

## Docs

CHANGELOG entry, `docs/commands/allowlist.md` (remove / orphaned / export), `docs/commands/baseline.md` + `getting-started.md` + `init.md` (CI-refresh steer + skill-count fixes), docs index, README skill table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)