### PR TITLE
2.9.3 — targetable fix loop + test generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.3] - 2026-06-09
+
+### Targetable fix loop + test generation
+
+A workflow-depth release: make the fix loop targetable, add the test-writing
+skill the suite was missing, and surface the riskiest test gaps first. Almost
+entirely agent-skill + docs work; one contained, flag-gated analyzer change.
+
+- **Scoped fixes.** `dxkit-action` can burn down one category at a time —
+  dependency/BOM vulnerabilities, security, code quality, tests, or docs. It
+  runs the report that partitions that dimension and works only that worklist,
+  with the usual severity → reachability → blast-radius prioritization applied
+  within the scope. Tests/docs scopes hand off to `dxkit-test` / `dxkit-docs`.
+- **New `dxkit-test` skill** — the testing mirror of `dxkit-docs`. Reads the
+  test-gaps worklist, orients on real behavior via the code graph, and writes
+  meaningful tests that close the highest-risk gaps and move the Tests score
+  without coverage theater (real assertions, the repo's framework, the suite +
+  coverage run to prove it).
+- **Test-gap blast-radius weighting.** With a code graph present
+  (`test-gaps --graph-context`), the untested-file worklist is ranked within
+  each risk tier by how many files depend on each one — the most-depended-on
+  gaps surface first instead of just the largest by line count. Ordering only;
+  the Tests score is unchanged (it derives from the tier counts). Files the
+  graph can't resolve fall back to line-count ranking and are never dropped.
+- **New `dxkit-pr` skill** — opens a pull request with a title + body grounded
+  in the branch's real commits and diff (features, fixes, findings closed),
+  the dxkit signals a reviewer needs (guardrail verdict, allowlist activity,
+  score deltas), and a checklist tailored to the actual change. `dxkit-feature`
+  now offers to write tests for a newly built surface (on confirmation) and
+  hands off to `dxkit-test`.
+- **Docs + roadmap refresh.** Every doc surface updated for the current skill
+  set; the roadmap records why deep-SAST (code-path) reachability is deferred —
+  it needs interprocedural taint analysis dxkit can't do natively (semgrep is
+  intraprocedural; the call graph is too sparse), so the realistic path is
+  surfacing an ingested engine's reachability rather than computing our own.
+
 ## [2.9.2] - 2026-06-09
 
 ### Allowlist lifecycle + Snyk credential ergonomics

--- a/README.md
+++ b/README.md
@@ -184,15 +184,17 @@ Orphaned annotations become their own findings. The TypeScript `@ts-expect-error
 
 dxkit ships a suite of Claude Code skills under `.claude/skills/dxkit-*`. They wrap the CLI in conversational flows:
 
-| Skill                                                                                                     | What it does                                                            |
-| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `dxkit-onboard`                                                                                           | Walks a customer through the full first-install journey                 |
-| `dxkit-reports`                                                                                           | Runs analyzers and explains the output                                  |
-| `dxkit-action`                                                                                            | Reads a report, prioritizes findings, plans and runs fixes, re-verifies |
-| `dxkit-ingest`                                                                                            | Brings external SAST findings (Snyk Code, CodeQL, SARIF) into dxkit     |
-| `dxkit-fix`                                                                                               | Repairs a broken install from doctor output                             |
-| `dxkit-allowlist`                                                                                         | Manages the suppression lifecycle: audit, remove, prune, export to Snyk |
-| `dxkit-feature`, `dxkit-docs`, `dxkit-hooks`, `dxkit-config`, `dxkit-learn`, `dxkit-update`, `dxkit-init` | Focused flows                                                           |
+| Skill                                                                                                     | What it does                                                              |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `dxkit-onboard`                                                                                           | Walks a customer through the full first-install journey                   |
+| `dxkit-reports`                                                                                           | Runs analyzers and explains the output                                    |
+| `dxkit-action`                                                                                            | Reads a report, prioritizes findings, plans and runs fixes, re-verifies   |
+| `dxkit-ingest`                                                                                            | Brings external SAST findings (Snyk Code, CodeQL, SARIF) into dxkit       |
+| `dxkit-fix`                                                                                               | Repairs a broken install from doctor output                               |
+| `dxkit-allowlist`                                                                                         | Manages the suppression lifecycle: audit, remove, prune, export to Snyk   |
+| `dxkit-test`                                                                                              | Writes the missing tests to close gaps + raise the Tests score            |
+| `dxkit-pr`                                                                                                | Opens a PR with a diff-grounded body + dxkit signals + reviewer checklist |
+| `dxkit-feature`, `dxkit-docs`, `dxkit-hooks`, `dxkit-config`, `dxkit-learn`, `dxkit-update`, `dxkit-init` | Focused flows                                                             |
 
 `AGENTS.md` (the open standard read by Codex, Cursor, Aider, and others) also ships in every install. The skill flows are Claude Code-specific today; the AGENTS.md context is portable.
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -63,7 +63,7 @@ CLAUDE.md              # Claude Code shim that points at AGENTS.md
   settings.json        # tool permissions
   skills/dxkit-*/      # lifecycle skills: learn / init / config / hooks /
                        # reports / action / fix / update / onboard / feature /
-                       # docs / ingest / allowlist
+                       # docs / ingest / allowlist / test / pr
   rules/               # per-language coding conventions
 .vyuh-dxkit.json       # install manifest (config, install flags, evolving file hashes)
 ```

--- a/docs/commands/test-gaps.md
+++ b/docs/commands/test-gaps.md
@@ -43,6 +43,15 @@ A file is considered "tested" if:
 Without coverage data, the report opens with a banner explicitly
 calling out the heuristic and pointing to `--with-coverage`.
 
+**Within a tier, `--graph-context` weights the worklist by blast radius.**
+When a code graph is present, the most-depended-on untested files (the ones
+many other files call into) surface first within their risk tier — a
+30-caller untested file is a bigger liability than a 500-line leaf nothing
+calls. Files the graph can't resolve (or languages whose call graph is
+unreliable, e.g. C#) fall back to LOC ranking and are never dropped. This
+re-orders the worklist only; it never changes the Tests score (which comes
+from the tier counts).
+
 ## Output
 
 ```markdown

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@ What dxkit ships today and what is planned next. For per-release detail see [`CH
 ### Agent integration
 
 - [x] `AGENTS.md` (open standard, read by Claude Code, Codex, Cursor, Aider)
-- [x] Twelve `dxkit-*` Claude Code skills for the read, act, verify loop
+- [x] A suite of `dxkit-*` Claude Code skills for the read, act, verify loop
 - [x] Devcontainer with pinned per-stack toolchains
 - [x] Optional install scripts for AI agent CLIs
 
@@ -112,6 +112,49 @@ CI resolve a pinned local binary (not a stale global); `hooks activate`
 restores the hook's executable bit (git silently ignores a non-executable
 hook) and `doctor` verifies it; hook activation chains after an existing
 `postinstall`.
+
+## Shipped in 2.9.1–2.9.3 — governance depth + the agent loop
+
+Follow-ups that made the ingested + native findings genuinely enforceable and
+the fix loop targetable.
+
+### Cross-tool dedup + allowlist as a real gate (2.9.1)
+
+- [x] Cross-tool dedup — two engines flagging one weakness at one site collapse
+      to a single finding (canonical-rule map + same-location CWE bridge),
+      keeping the higher severity and recording every contributing tool.
+- [x] The allowlist suppresses findings from the guardrail verdict (was
+      audit-only), expiry-aware, with robust matching across dedup so run-to-run
+      nondeterminism can't orphan an acceptance.
+- [x] Inbound Snyk ignore sync — a finding dismissed upstream (SARIF
+      `result.suppressions`) no longer re-surfaces; ingested findings honor the
+      same `.dxkit-ignore` path exclusions as native ones.
+
+### Allowlist lifecycle + Snyk credential ergonomics (2.9.2)
+
+- [x] `allowlist remove <fingerprint>` and `allowlist audit --against-baseline`
+      (orphaned-entry bucket, flag-for-review never auto-removed).
+- [x] `allowlist export --snyk` — outbound ignore sync: writes a `.snyk` policy
+      for allowlisted Snyk Code findings, round-trip stable with the inbound reader.
+- [x] Opt-in `.env` loading scoped strictly to `SNYK_*` keys for
+      `ingest --from-snyk` (real env / CI secret always wins).
+- [x] `dxkit-allowlist` skill; skills + docs steer baseline refreshes to CI.
+
+### Targetable fix loop + test generation (2.9.3)
+
+- [x] Scoped fixes — `dxkit-action` burns down one category at a time
+      (dependency/BOM, security, code quality, tests, docs), running the report
+      that partitions that dimension and prioritizing within scope.
+- [x] `dxkit-test` skill — the testing mirror of `dxkit-docs`: reads the
+      blast-radius-weighted test-gaps worklist, orients via the graph, and writes
+      meaningful tests that close the highest-risk gaps without coverage theater.
+- [x] Test-gap blast-radius weighting — `test-gaps --graph-context` surfaces the
+      most-depended-on untested files first within each tier (ordering only; the
+      Tests score is unchanged).
+- [x] `dxkit-pr` skill — opens a PR with a diff-grounded title + body (features,
+      fixes, findings closed), the dxkit guardrail/allowlist/score signals, and a
+      tailored reviewer checklist. `dxkit-feature` now offers to write tests for a
+      new surface (user-confirmed) and hands off to `dxkit-test`.
 
 ## Next release — Reachability refinements (carried from 2.8)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,7 +116,7 @@ hook) and `doctor` verifies it; hook activation chains after an existing
 ## Next release — Reachability refinements (carried from 2.8)
 
 - [ ] Per-ecosystem reliability gating: only mark a finding `reachable: false` when its language pack resolves imports reliably (TS / Python / Go). For packs whose import resolution is unreliable (C# namespaces ≠ package names, etc.), leave `reachable` unset rather than risk a false "unreachable" that hides a real vuln.
-- [ ] Reachable-first report framing: a `"N reachable / M total"` summary line and reachable-first sort in the vulnerability report (the per-finding `reachable` glyph already renders).
+- [ ] Reachable-first report framing: a `"N reachable / M total"` summary line and reachable-first sort in the vulnerability report (the per-finding `reachable` glyph already renders). _Considered for 2.9.3 and deferred: the dependency table already discounts unreachable advisories 0.25× inside the composite `riskScore`, so this is a presentation refinement (a hard reachable-first sort tier + the summary lens) rather than new signal._
 
 ## Future
 
@@ -135,6 +135,29 @@ hook) and `doctor` verifies it; hook activation chains after an existing
 - [ ] Scoped + incremental scanning for fast pre-commit on monorepos
 - [ ] Symbol-level coverage gaps across all 8 packs
 - [ ] SARIF export for GitHub code-scanning interop
+
+### Deep SAST reachability (interprocedural)
+
+Today `reachable` is a **dependency** concept only — "is the vulnerable package
+imported in source." Code/SAST findings carry no reachability signal, and that's
+a deliberate gap, not an oversight:
+
+- dxkit's bundled SAST is community **semgrep (intraprocedural)** — it cannot do
+  the interprocedural taint analysis that "is this vulnerable code path reachable
+  from an attacker-controlled entry point" requires.
+- dxkit's own **graphify call graph is too sparse for taint** today (~28%
+  method-edge resolution measured during the Snyk-parity investigation).
+
+Code-path reachability is high value — it's the primary false-positive-noise
+reducer the premium engines (Snyk Code, CodeQL dataflow, Endor) compete on. The
+realistic path for dxkit is therefore **to surface the reachability the INGESTED
+engine already computed** (Snyk Code / CodeQL encode it), not to compute our own:
+
+- [ ] Carry an ingested finding's engine-reported reachability through
+      `src/ingest/` → `SecurityFinding`, and render/sort code findings reachable-first
+      when the source engine provides it.
+- [ ] (Longer term) Densify the graphify call graph enough to attempt native
+      intraprocedural→interprocedural reachability; gated on call-graph quality.
 
 ### AI readiness
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.9.2",
+      "version": "2.9.3",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "AI-native developer experience toolkit for any codebase",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -105,6 +105,8 @@ If no patched version exists OR the upgrade breaks other constraints AND the ris
 
 ### Test gap
 
+For one test gap inside a broader fix pass, close it inline:
+
 ```bash
 # 1. Read the source file the test-gap analyzer flagged
 # 2. Write a test that exercises the file's primary contract
@@ -115,6 +117,8 @@ npx vyuh-dxkit test-gaps
 ```
 
 Don't write tests that just import the module — write tests that exercise behavior. Useless tests inflate the count but don't move the dimension.
+
+For a dedicated push to close many gaps / raise the Tests score — reading the blast-radius-weighted worklist, orienting via the graph, writing meaningful tests in the repo's framework — hand off to the **dxkit-test** skill (the testing mirror of dxkit-docs).
 
 ### Slop / code-pattern finding
 
@@ -272,4 +276,6 @@ In those cases: `vyuh-dxkit allowlist add` is the right tool for per-finding dec
 - For hook-related issues during a fix push → `dxkit-hooks` skill
 - For re-running reports between fixes → `dxkit-reports` skill
 - For broken dxkit install (hooks not firing, vyuh-dxkit not on PATH) → `dxkit-fix` skill
+- For a dedicated test-writing push (close many gaps / raise the Tests score) → `dxkit-test` skill
+- For generating missing documentation → `dxkit-docs` skill
 - For allowlist management beyond the per-finding `add` path — auditing existing entries (including orphans after a re-baseline), removing stale fingerprints, pruning expired ones, exporting to a `.snyk`, or reviewing the team's overall suppression posture → **dxkit-allowlist** skill

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -310,4 +310,5 @@ In those cases: `vyuh-dxkit allowlist add` is the right tool for per-finding dec
 - For broken dxkit install (hooks not firing, vyuh-dxkit not on PATH) → `dxkit-fix` skill
 - For a dedicated test-writing push (close many gaps / raise the Tests score) → `dxkit-test` skill
 - For generating missing documentation → `dxkit-docs` skill
+- For raising the PR once fixes are done + guardrail-green → `dxkit-pr` skill (PR body from the diff + the guardrail/allowlist signals + a reviewer checklist)
 - For allowlist management beyond the per-finding `add` path — auditing existing entries (including orphans after a re-baseline), removing stale fingerprints, pruning expired ones, exporting to a `.snyk`, or reviewing the team's overall suppression posture → **dxkit-allowlist** skill

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dxkit-action
-description: Read a dxkit report and execute fixes — prioritize findings by severity, plan the fix sequence, run the fix, verify the score moved, re-baseline if appropriate. Use when the user says "fix these findings", "act on the health report", "close out these vulnerabilities", or after dxkit-reports has surfaced something concrete.
+description: Read a dxkit report and execute fixes — prioritize findings by severity, plan the fix sequence, run the fix, verify the score moved, re-baseline if appropriate. Supports a SCOPED pass to burn down one category at a time (dependency/BOM vulnerabilities, security, code quality, tests, docs). Use when the user says "fix these findings", "act on the health report", "close out these vulnerabilities", "just fix the dependency vulns", "only the security findings", or after dxkit-reports has surfaced something concrete.
 ---
 
 # dxkit-action
@@ -27,6 +27,38 @@ npx vyuh-dxkit vulnerabilities --detailed --graph-context   # or test-gaps / qua
 ```
 
 `--graph-context` adds a "Graph context" column (the module a finding lives in + its blast radius — how many files call into it) so you can plan the fix without separately discovering structure. It's a structural HINT, not ground truth — read "Graph context" below for how to use it safely.
+
+## Scoped fix — fix one category at a time
+
+Often the user doesn't want "fix everything" — they want to burn down **one
+category**: "just the dependency vulns", "only the security findings", "the
+code-quality stuff." Honor that. A scoped pass keeps the change reviewable and
+lets the team sequence the work.
+
+When the user names a scope (or you propose one), run the report that already
+partitions that dimension and work **only** that worklist — prioritization
+(severity → reachability → blast radius) still applies, but within the scope:
+
+| Scope the user asks for | Run | Findings in scope | Notes / hand-off |
+|---|---|---|---|
+| "dependency / BOM vulnerabilities" | `npx vyuh-dxkit bom` (or `vulnerabilities --detailed`) | `dep-vuln` | upgrade-first; see "Dependency vulnerability" below |
+| "security" | `npx vyuh-dxkit vulnerabilities --detailed --graph-context` | code-SAST, secrets, dep-vuln | reachable findings first (the report orders them); secrets always top |
+| "code quality" | `npx vyuh-dxkit quality --detailed --graph-context` | duplication, slop, lint, complexity | see "Slop / code-pattern finding" below |
+| "tests" / "coverage" | `npx vyuh-dxkit test-gaps --detailed --graph-context` | test-gap | hand off to **dxkit-test** for a real test-writing push |
+| "documentation" | `npx vyuh-dxkit health --detailed` (Documentation) | doc-gap | hand off to **dxkit-docs** |
+
+Rules for a scoped pass:
+
+- **Stay in the lane.** If the user said "just deps," don't also start fixing
+  SAST findings you notice — surface them ("I also see 3 HIGH SAST findings;
+  want a separate pass?") but don't expand scope unasked.
+- **Tests / docs scopes are hand-offs, not inline work.** Closing test gaps or
+  writing docs is a dedicated loop — route to `dxkit-test` / `dxkit-docs`
+  rather than half-doing it here.
+- **Verify within the scope.** Step [5] re-runs the scope's own report; the
+  scoped dimension should move and nothing else should regress (guardrail).
+
+Without a named scope, work the full **Priority order** below.
 
 ## Priority order
 

--- a/src-templates/.claude/skills/dxkit-docs/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-docs/SKILL.md
@@ -146,3 +146,5 @@ npx vyuh-dxkit guardrail check
   should leave the new surface documented).
 - Slop findings outside docs (AI-generated code prose, CHANGELOG slop) →
   `dxkit-action`'s slop recipe.
+- Closing test gaps / raising the Tests score (the sibling generator skill) →
+  `dxkit-test`.

--- a/src-templates/.claude/skills/dxkit-feature/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-feature/SKILL.md
@@ -190,6 +190,8 @@ own feature introduced.
 - A finding the guardrail blocked needs fixing → `dxkit-action` (the fix-loop
   recipes for secrets, dep-vulns, SAST).
 - Writing tests for the new (or any untested) surface → `dxkit-test`.
+- Raising the PR once the feature is built + green → `dxkit-pr` (title + body
+  from the diff, dxkit signals, reviewer checklist).
 - Re-running reports between iterations → `dxkit-reports`.
 - Ignore-file / config edits as part of the feature → `dxkit-config`.
 - Hook problems on the verify push → `dxkit-hooks`.

--- a/src-templates/.claude/skills/dxkit-feature/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-feature/SKILL.md
@@ -154,14 +154,22 @@ Exit 0 = the feature added no net-new regressions. Exit 1 = something new
 appeared — **a finding you introduced.** Address it before pushing:
 
 - A real finding in your new code → fix it now (hand off to `dxkit-action`
-  for the fix recipes — secret rotation, dep upgrade, writing the missing
-  test, etc.).
+  for the fix recipes — secret rotation, dep upgrade, SAST, etc.).
 - A genuine false positive / intentional pattern → allowlist with a typed
   category + reason (see `dxkit-action`'s allowlisting section). Fix first;
   allowlist second.
 
 The feature isn't done when it works — it's done when it works **and** the
 guardrail is green.
+
+### Offer to test the new surface
+
+A new feature is the most common source of a fresh test gap. When step [5]'s
+`test-gaps` shows the code you just added is untested — especially if it has
+callers (a non-trivial blast radius) — **offer to write tests for it, and on
+the user's confirmation hand off to `dxkit-test`** to write them grounded in
+the behavior you just built. Keep it an offer: don't auto-generate tests the
+user didn't ask for, but don't let a new untested surface ship silently either.
 
 ## [6] Baseline decision
 
@@ -180,7 +188,8 @@ own feature introduced.
 ## Hand-offs
 
 - A finding the guardrail blocked needs fixing → `dxkit-action` (the fix-loop
-  recipes for secrets, dep-vulns, SAST, test gaps).
+  recipes for secrets, dep-vulns, SAST).
+- Writing tests for the new (or any untested) surface → `dxkit-test`.
 - Re-running reports between iterations → `dxkit-reports`.
 - Ignore-file / config edits as part of the feature → `dxkit-config`.
 - Hook problems on the verify push → `dxkit-hooks`.

--- a/src-templates/.claude/skills/dxkit-init/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-init/SKILL.md
@@ -21,7 +21,7 @@ Ask the user what they want, then pick the right invocation:
 
 | Flag | What it ships | Default under `--full`? |
 |---|---|---|
-| `--with-dxkit-agents` | The 6 dxkit-* skills + AGENTS.md + CLAUDE.md shim | Yes |
+| `--with-dxkit-agents` | The dxkit-* skills + AGENTS.md + CLAUDE.md shim | Yes |
 | `--with-hooks` | `.githooks/pre-push` + postinstall activation wire-up | Yes |
 | `--with-precommit-hook` | Adds `.githooks/pre-commit` (slow on large repos) | No (still opt-in) |
 | `--with-devcontainer` | `.devcontainer/devcontainer.json` (per-stack features) + post-create.sh | Yes |

--- a/src-templates/.claude/skills/dxkit-onboard/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-onboard/SKILL.md
@@ -82,7 +82,7 @@ Before running, ASK:
 
 Optional flags worth surfacing if the customer pushes back on "full":
 
-- `--with-dxkit-agents` — just the 8 dxkit-* skills (no hooks, no CI)
+- `--with-dxkit-agents` — just the dxkit-* skills (no hooks, no CI)
 - `--with-hooks --with-dxkit-agents` — skills + pre-push hook
 - `--with-precommit-hook` — also pre-commit (slow on large repos)
 
@@ -262,7 +262,7 @@ When in doubt, dxkit-onboard handles the full first-install journey and delegate
 ```
 ✓ Fresh dxkit install complete:
    • Binary: 2.5.X installed globally + project-local
-   • Scaffold: 8 dxkit-* skills, AGENTS.md, CLAUDE.md, devcontainer, hooks, CI workflows
+   • Scaffold: dxkit-* skills, AGENTS.md, CLAUDE.md, devcontainer, hooks, CI workflows
    • Doctor: 14/14 (Reports + Agent DX + Operational health)
    • Baseline: N findings locked in (or "skipped — you're triaging first")
    • Pre-commit: yes/no (your choice)

--- a/src-templates/.claude/skills/dxkit-pr/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-pr/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: dxkit-pr
+description: Open a pull request with a title + body grounded in the branch's real commits and diff — what changed, features implemented, findings fixed — plus a reviewer checklist and the dxkit guardrail/allowlist/score signals a reviewer needs. Use when the user says "raise a PR", "open a pull request", "create the PR", "write the PR description", or after dxkit-feature / dxkit-action finishes a change and it's ready to push for review.
+---
+
+# dxkit-pr
+
+This skill turns a finished branch into a **reviewable** pull request: a title
+and body grounded in what actually changed (not a generic template), and a
+checklist that guides the reviewer through what to verify. It's the natural
+close of `dxkit-feature` (built something) and `dxkit-action` (fixed findings) —
+both hand off here when the work is ready for review.
+
+A good PR description is written from the diff, not from memory. This skill
+reads the branch, summarizes it honestly, and attaches the dxkit signals
+(guardrail verdict, allowlist activity, score movement) a reviewer would
+otherwise have to reconstruct by hand.
+
+## The PR loop
+
+```
+[1] Survey      → branch vs base: commits, diff stat, files touched
+[2] Classify    → features / fixes / refactors / docs / findings closed
+[3] Signals     → guardrail verdict + allowlist activity + score deltas
+[4] Draft       → title + body grounded in [1]–[3] + a reviewer checklist
+[5] Confirm     → show the user the draft; open with `gh pr create` on yes
+```
+
+Don't skip [5]. A PR is outward-facing — show the draft and get a yes before
+opening it.
+
+## [1] Survey — read the branch, don't guess
+
+```bash
+git fetch origin
+BASE=origin/main                      # or the repo's default branch
+git log --oneline $BASE..HEAD         # every commit on this branch
+git diff --stat $BASE...HEAD          # files + churn
+git diff $BASE...HEAD                 # the actual change, when you need detail
+```
+
+Read the commit messages first — on a well-kept branch they already narrate the
+work. Use the diff to verify and fill gaps, not to re-derive everything.
+
+## [2] Classify — group the change for a reviewer
+
+Sort the commits/diff into the buckets a reviewer cares about:
+
+- **Features** — new capability, with the entry point / surface it adds.
+- **Fixes** — bugs or findings closed (name the finding if it came from a dxkit
+  report: rule, file, severity).
+- **Refactors** — behavior-preserving structure changes (flag these — they're
+  where "looks big, reads safe" lives).
+- **Docs / tests / chore** — supporting changes.
+
+Lead the body with the *why* (the problem) and the *what* (the approach), then
+the bucketed change list. Keep it proportional — a one-commit fix gets a short
+body; a multi-commit feature gets sections.
+
+## [3] Signals — attach what dxkit knows
+
+Run the guardrail so the PR states its own verdict, and surface any suppression
+activity a reviewer must sign off on:
+
+```bash
+npx vyuh-dxkit guardrail check                       # PASS/FAIL the PR will get in CI
+npx vyuh-dxkit allowlist audit                        # any new/expiring suppressions?
+npx vyuh-dxkit health --detailed | head -40           # score movement, if relevant
+```
+
+Put in the body:
+
+- **Guardrail verdict** — PASS, or FAIL with the net-new findings named (a
+  reviewer should know before CI tells them).
+- **Allowlist activity** — any suppression added on this branch, with its
+  category + reason + expiry, called out for explicit review (suppressions are
+  the highest-trust thing a reviewer approves).
+- **Score deltas** — only when the change targeted a dimension (e.g. "Tests
+  62 → 71 after closing the auth gaps"). Don't pad with unchanged scores.
+
+## [4] Draft — title, body, reviewer checklist
+
+**Title** — imperative, scoped, specific. `feat(auth): add refresh-token
+rotation`, not `Updates`. Match the repo's existing PR/commit convention
+(check `git log` on the base branch).
+
+**Body** — structure:
+
+```markdown
+## What & why
+<the problem this solves, in 1–3 sentences>
+
+## Changes
+- **Feature:** …
+- **Fix:** … (closes <finding/issue>)
+- **Refactor:** … (behavior-preserving)
+
+## dxkit signals
+- Guardrail: ✅ PASS  (or ❌ + the net-new findings)
+- Allowlist: <new suppressions + reason + expiry, or "no changes">
+- Scores: <dimension deltas, if the change targeted one>
+
+## Reviewer checklist
+- [ ] Change matches the description; scope isn't broader than stated
+- [ ] <feature>: behavior verified (how to exercise it)
+- [ ] Refactors are behavior-preserving (no silent semantic change)
+- [ ] New/changed code is tested; test gaps addressed or noted
+- [ ] Any allowlist suppression is justified (category + reason + expiry)
+- [ ] No secrets/keys/tokens in the diff
+- [ ] Docs updated if behavior or interfaces changed
+```
+
+Tailor the checklist to the *actual* change — drop rows that don't apply, add
+specific ones (a migration step, a config flag to set, a caller to re-test from
+the blast radius). A generic checklist is noise; a targeted one guides the review.
+
+## [5] Confirm + open
+
+Show the user the full draft (title + body) and confirm. On yes:
+
+```bash
+git push -u origin HEAD                # if not already pushed
+gh pr create --base main --title "<title>" --body "<body>"
+```
+
+If `gh` isn't authenticated, print the title + body for the user to paste, and
+point them at `gh auth login`. Never open a PR the user hasn't seen.
+
+## Scope — what NOT to do
+
+- Don't invent changes the diff doesn't show, or claim a finding is fixed
+  without having verified it (re-run the analyzer first — see `dxkit-action`).
+- Don't open the PR before the guardrail is green, unless the user explicitly
+  wants a draft PR for early review — and then mark it draft and say so in the body.
+- Don't restate every commit verbatim — synthesize. The commit log is one click
+  away; the body's job is the narrative + the review guidance.
+
+## Hand-offs
+
+- A guardrail FAIL blocking the PR → `dxkit-action` to fix the net-new findings first.
+- Writing the feature being PR'd → `dxkit-feature`; closing test gaps it opened → `dxkit-test`.
+- Branch-protection / required-check setup so the PR is actually gated → `dxkit-hooks` / repo settings.

--- a/src-templates/.claude/skills/dxkit-reports/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-reports/SKILL.md
@@ -103,7 +103,7 @@ Surface those three when summarizing a dep-vuln finding. The detailed JSON has t
 
 ## When the user wants to ACT on findings
 
-Hand off to the `dxkit-action` skill — that's the workflow for prioritizing + fixing + re-baselining. This skill stops at "here's what's wrong."
+Hand off to the `dxkit-action` skill — that's the workflow for prioritizing + fixing + re-baselining. This skill stops at "here's what's wrong." For a dimension-focused push, hand to the specialist generator skills instead: **dxkit-test** to close test-gaps / raise the Tests score, **dxkit-docs** to write missing documentation.
 
 ## Troubleshooting
 

--- a/src-templates/.claude/skills/dxkit-test/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-test/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: dxkit-test
+description: Write the tests a repo is missing — read the test-gaps report (blast-radius-weighted), orient on what the untested code actually does via the graph, then write real tests that close the highest-risk gaps and move the Tests score without coverage theater. Use when the user says "write tests", "add tests for this module", "improve the test coverage / Tests score", "close the test gaps", "cover the untested files", or after a health report flags Testing.
+---
+
+# dxkit-test
+
+This skill closes the gap `dxkit-action` doesn't: it **writes** the missing
+tests rather than fixing flagged findings. It is the testing mirror of
+`dxkit-docs` — same shape, different dimension. It's built around one hard
+constraint: a test that doesn't actually exercise behavior (an empty `expect(true)`,
+a snapshot of nothing, a call with no assertion) raises the coverage number
+while proving nothing. The whole point of this skill is tests that are
+**grounded in real behavior** and **catch real regressions** — not coverage
+theater.
+
+## The testing loop
+
+```
+[1] Read the gap   → test-gaps: the blast-radius-weighted untested worklist
+[2] Orient         → graph: what the file does, who depends on it, what to assert
+[3] Generate       → write real tests in the repo's framework + patterns
+[4] Verify         → run the suite + coverage; Tests up, nothing red
+[5] Guardrail      → guardrail check before pushing
+```
+
+Don't skip [2] or [4]. [2] is what makes the tests meaningful; [4] is what
+proves they pass and the coverage actually moved.
+
+## [1] Read the gap — what's actually untested, worst-first
+
+Run the test-gaps report with graph context so the worklist is ranked by
+**blast radius** (how many files depend on each untested file), not just size:
+
+```bash
+npx vyuh-dxkit test-gaps --detailed --graph-context
+npx vyuh-dxkit test-gaps --detailed --graph-context --json | jq '.actions, .gaps[0:10]'
+```
+
+The report partitions untested files into CRITICAL / HIGH / MEDIUM / LOW risk
+tiers, and **within each tier the most-depended-on files surface first** (the
+`Graph context` column shows `role · N caller files`). Work top-down: a
+30-caller untested file is a bigger liability than a 500-line leaf nothing
+calls. The `actions` array names the top-K per tier with projected
+score uplift — that's your queue.
+
+A `blast radius n/a` cell means graphify couldn't resolve that language's call
+graph (C# is the known case) — treat it as *unknown*, not "no callers," and
+fall back to the file's role + size to judge its risk.
+
+## [2] Orient — understand the behavior before you assert on it
+
+A test is only as good as your understanding of what the code should do.
+Before writing, learn the real shape from the graph (cheap, structural):
+
+```bash
+npx vyuh-dxkit context src/payments/refund.ts        # the file's symbols, callers, callees
+npx vyuh-dxkit explore file src/payments/refund.ts   # its structural neighborhood
+```
+
+Use it to decide three things:
+
+- **What the public contract is** — the exported symbols are what callers rely
+  on; test those, not private helpers.
+- **What the callers expect** — the caller files (blast radius) tell you the
+  real usage shapes to cover, including the edge cases they pass.
+- **What's risky** — error paths, branching, boundary conditions. Then **read
+  the actual code** — the graph points you at it; it doesn't replace reading
+  it.
+
+## [3] Generate — real tests, the repo's way
+
+- **Match the existing framework + conventions.** Detect what the repo already
+  uses (vitest/jest, pytest, go test, JUnit, RSpec, …) from the existing test
+  files and `test-gaps` output — never introduce a new test framework. Copy the
+  nearest existing test's structure, naming, fixtures, and assertion style so
+  the new tests read like the repo's.
+- **Assert behavior, not existence.** Each test must exercise a real path and
+  assert a real outcome — return values, side effects, error handling,
+  boundaries. A test that calls a function and asserts nothing is slop.
+- **Cover the contract + the edges.** Happy path, the error/edge cases the
+  callers actually hit, and at least one boundary. Prioritize branches over
+  lines.
+- **Don't fake it.** No mocking the unit under test into a tautology; no
+  asserting on a stub you wrote. Mock external boundaries (network, clock,
+  fs) the way the repo already does.
+
+## [4] Verify — Tests up, suite green, no coverage theater
+
+```bash
+# Run the repo's real test command (from package.json / Makefile / etc.)
+<the repo's test command>            # e.g. npm test, pytest, go test ./...
+
+# Re-materialize coverage + the gap report
+npx vyuh-dxkit coverage              # runs the suite to produce real line coverage
+npx vyuh-dxkit test-gaps --detailed  # the targeted gap should be gone / downgraded
+```
+
+The work is done when:
+
+- The new tests **pass** (a failing or skipped test is not coverage).
+- The targeted file is no longer in the gap worklist (or dropped a risk tier).
+- `effectiveCoverage` rose from a real signal — prefer line-coverage truth
+  (`coverage`) over the filename-match heuristic; a name-matched 5-line test on
+  a 200-line file is exactly the theater this skill exists to avoid.
+
+## [5] Guardrail — before pushing
+
+```bash
+npx vyuh-dxkit guardrail check
+```
+
+Exit 0 = your new tests didn't introduce a net-new regression (e.g. a flaky
+test, a slop finding in test prose). Address anything it flags before pushing.
+
+## Scope — what NOT to test
+
+- Don't test auto-generated, vendored, or trivial pass-through code just to
+  move the number — credit comes from covering the files that carry risk.
+- Don't write tests you can't make pass; a `.skip` is a gap, not a closure.
+- Don't assert on implementation details that will break on every refactor —
+  test the contract, not the internals.
+
+## Hand-offs
+
+- Running / interpreting the health or test-gaps report → `dxkit-reports`.
+- A test gap surfaced as one finding inside a broader fix pass → `dxkit-action`.
+- Testing a feature you're building → `dxkit-feature` (it offers to hand the
+  new surface here once the feature lands).
+- Documentation gaps (the sibling generator skill) → `dxkit-docs`.

--- a/src-templates/.claude/skills/dxkit-update/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-update/SKILL.md
@@ -135,6 +135,10 @@ Iterate optional steps in the plan:
 | "Doctor says X is broken" | `dxkit-fix` |
 | "I want to run a report" | `dxkit-reports` |
 | "Fix these findings" | `dxkit-action` |
+| "Write the missing tests" | `dxkit-test` |
+| "Write the missing docs" | `dxkit-docs` |
+| "Manage / audit the allowlist" | `dxkit-allowlist` |
+| "Raise the PR" | `dxkit-pr` |
 | "Configure dxkit" | `dxkit-config` |
 | "Set up hooks" | `dxkit-hooks` |
 | "Explain dxkit" | `dxkit-learn` |

--- a/src-templates/AGENTS.md.template
+++ b/src-templates/AGENTS.md.template
@@ -12,14 +12,20 @@ For agent-specific config, see the editor-specific files alongside this one — 
 
 This repo is managed by [`@vyuhlabs/dxkit`](https://github.com/vyuh-labs/dxkit). dxkit measures code health across 6 dimensions, captures a per-finding baseline, and gates PRs on net-new regressions.
 
-Six skills are installed under `.claude/skills/` (Claude Code auto-discovers via skill frontmatter):
+The `dxkit-*` skills are installed under `.claude/skills/` (Claude Code auto-discovers via skill frontmatter):
 
 - **dxkit-learn** — explains dxkit concepts (baselines, dimensions, scanners)
-- **dxkit-init** — interactive setup walkthrough
+- **dxkit-onboard** — fresh-install walkthrough; **dxkit-init** — interactive setup
 - **dxkit-config** — edit `.dxkit-ignore`, `.vyuh-dxkit.json`, policy
 - **dxkit-hooks** — install / troubleshoot git hooks
 - **dxkit-reports** — run analyzers, explain output, dashboard
-- **dxkit-action** — prioritize + fix + verify + re-baseline
+- **dxkit-action** — prioritize + fix + verify + re-baseline (scoped to one category if asked)
+- **dxkit-test** — write the missing tests to close gaps; **dxkit-docs** — write the missing docs
+- **dxkit-feature** — graph-guided net-new development
+- **dxkit-ingest** — bring external SAST (Snyk Code / CodeQL / SARIF) into dxkit
+- **dxkit-allowlist** — manage the suppression lifecycle (audit / remove / prune / export to Snyk)
+- **dxkit-pr** — open a PR with a diff-grounded body + reviewer checklist
+- **dxkit-update** — upgrade an existing install; **dxkit-fix** — repair a broken one
 
 Reach for the relevant skill when working in this repo. They wrap the `vyuh-dxkit` CLI with workflow guidance.
 

--- a/src-templates/CLAUDE.md.template
+++ b/src-templates/CLAUDE.md.template
@@ -6,14 +6,20 @@ Whenever Claude Code starts a session in this repo, it reads BOTH files: this on
 
 ## dxkit skills
 
-Six dxkit-specific skills are installed under `.claude/skills/`. Claude Code auto-discovers them via their frontmatter `description` fields:
+The `dxkit-*` skills are installed under `.claude/skills/`. Claude Code auto-discovers them via their frontmatter `description` fields:
 
 - `dxkit-learn` — explain what dxkit does, what scores mean, what scanners run
-- `dxkit-init` — walk through `vyuh-dxkit init` flag choices
+- `dxkit-onboard` / `dxkit-init` — fresh-install walkthrough / `init` flag choices
 - `dxkit-config` — edit `.dxkit-ignore` / `.vyuh-dxkit.json` / policy
 - `dxkit-hooks` — install / troubleshoot git hooks
 - `dxkit-reports` — run analyzers + read output
-- `dxkit-action` — prioritize + fix + verify + re-baseline
+- `dxkit-action` — prioritize + fix + verify + re-baseline (scoped to one category if asked)
+- `dxkit-test` / `dxkit-docs` — write the missing tests / docs to move a dimension
+- `dxkit-feature` — graph-guided net-new development
+- `dxkit-ingest` — bring external SAST (Snyk Code / CodeQL / SARIF) into dxkit
+- `dxkit-allowlist` — manage the suppression lifecycle (audit / remove / prune / export)
+- `dxkit-pr` — open a PR with a diff-grounded body + reviewer checklist
+- `dxkit-update` / `dxkit-fix` — upgrade / repair an install
 
 When the user asks about dxkit concepts or wants to run an analyzer, reach for the matching skill before improvising.
 

--- a/src/analyzers/tests/actions.ts
+++ b/src/analyzers/tests/actions.ts
@@ -5,6 +5,43 @@ import { Evidence } from '../evidence';
 import { RemediationAction } from '../remediation';
 import { TestGapsReport, SourceFile, RiskTier } from './types';
 import { TestGapsCounts } from './scoring';
+import { locationKey, type DetailedGraphContext } from '../../explore/finding-context';
+
+const TIER_RANK: Record<RiskTier, number> = { critical: 0, high: 1, medium: 2, low: 3 };
+
+/**
+ * Re-rank the test-gap worklist by code-graph blast radius so the
+ * most-depended-on untested files surface first WITHIN their risk tier.
+ * Pure function — it receives the pre-built graph context (CLAUDE.md
+ * Rule 12: analyzers never load the graph themselves) and never touches
+ * the Tests score (which comes from summary counts, not gap order).
+ *
+ * Blast radius is stamped only when the file is in the graph AND the
+ * language's call graph is reliable — an untrustworthy `0` from a
+ * language graphify can't resolve (e.g. C#) is treated as UNKNOWN, not
+ * a leaf. Within a tier: known higher-blast first, then by LOC. Files
+ * the graph couldn't resolve keep their LOC rank after the
+ * graph-confirmed high-impact ones — they're re-ordered, never dropped
+ * and never labelled "safe."
+ */
+export function weightGapsByBlastRadius(
+  gaps: ReadonlyArray<SourceFile>,
+  graphContext: DetailedGraphContext,
+): SourceFile[] {
+  const stamped = gaps.map((g) => {
+    const ctx = graphContext.contexts[locationKey(g.path)];
+    const reliable = ctx?.found && ctx.callGraphReliability !== 'unreliable';
+    if (!reliable) return { ...g };
+    return { ...g, blastRadius: ctx.blastRadius.callerFiles };
+  });
+  return stamped.sort((a, b) => {
+    if (TIER_RANK[a.risk] !== TIER_RANK[b.risk]) return TIER_RANK[a.risk] - TIER_RANK[b.risk];
+    const ba = a.blastRadius ?? -1;
+    const bb = b.blastRadius ?? -1;
+    if (ba !== bb) return bb - ba;
+    return b.lines - a.lines;
+  });
+}
 
 export function countsFromReport(report: TestGapsReport): TestGapsCounts {
   const s = report.summary;
@@ -46,7 +83,7 @@ function testTierAction(
   return {
     id: `tests.add-${tier}-${tierFiles.length}`,
     title: `Add tests for top ${tierFiles.length} ${tier.toUpperCase()}-risk untested file${tierFiles.length === 1 ? '' : 's'}`,
-    rationale: `These ${tier} files carry the largest untested risk. Start with the largest by LOC.`,
+    rationale: `These ${tier} files carry the largest untested risk. Start with the most-depended-on (highest blast radius), then the largest by LOC.`,
     evidence: tierFiles.map(fileToEvidence),
     patch: (c) => ({
       ...c,

--- a/src/analyzers/tests/detailed.ts
+++ b/src/analyzers/tests/detailed.ts
@@ -3,7 +3,7 @@
  */
 import { TestGapsReport, SourceFile, RiskTier } from './types';
 import { RankedAction, rank } from '../remediation';
-import { buildTestGapsActions, countsFromReport } from './actions';
+import { buildTestGapsActions, countsFromReport, weightGapsByBlastRadius } from './actions';
 import { TestGapsCounts, scoreTestGapsCounts } from './scoring';
 import { renderToolsUnavailableLines } from '../tools/tools-unavailable-prose';
 import {
@@ -30,9 +30,16 @@ export function buildTestGapsDetailed(
   graphContext?: DetailedGraphContext,
 ): TestGapsDetailedReport {
   const counts = countsFromReport(report);
-  const actions = rank(buildTestGapsActions(report), counts, scoreTestGapsCounts);
+  // When a graph is present, re-rank the gap worklist by blast radius so
+  // the most-depended-on untested files surface first (within tier). This
+  // re-orders only — `counts` (and therefore the score) come from the
+  // summary, untouched by gap order.
+  const weighted = graphContext
+    ? { ...report, gaps: weightGapsByBlastRadius(report.gaps, graphContext) }
+    : report;
+  const actions = rank(buildTestGapsActions(weighted), counts, scoreTestGapsCounts);
   return {
-    ...report,
+    ...weighted,
     schemaVersion: '11',
     coverageScore: scoreTestGapsCounts(counts).score,
     actions,
@@ -120,8 +127,14 @@ export function formatTestGapsDetailedMarkdown(
     L.push(graphContextProvenanceLine(gc));
     L.push('');
   }
+  // Within a tier, prefer higher blast radius (most-depended-on first)
+  // when the graph stamped it, falling back to LOC. Mirrors the worklist
+  // ranking so the table and the actions agree on ordering.
   const sorted: SourceFile[] = [...detailed.gaps].sort(
-    (a, b) => TIER_ORDER[a.risk] - TIER_ORDER[b.risk] || b.lines - a.lines,
+    (a, b) =>
+      TIER_ORDER[a.risk] - TIER_ORDER[b.risk] ||
+      (b.blastRadius ?? -1) - (a.blastRadius ?? -1) ||
+      b.lines - a.lines,
   );
   const grouped: Record<RiskTier, SourceFile[]> = {
     critical: [],

--- a/src/analyzers/tests/types.ts
+++ b/src/analyzers/tests/types.ts
@@ -27,6 +27,16 @@ export interface SourceFile {
   type: string;
   risk: RiskTier;
   hasMatchingTest: boolean;
+  /**
+   * Caller-file count from the code graph — how many files depend on
+   * this one (its blast radius). Stamped only when a graph is present
+   * AND the language's call graph is reliable (so an untrustworthy `0`
+   * from a language graphify can't resolve, e.g. C#, never masquerades
+   * as a leaf). Absent ⇒ unknown, NOT zero. Used to weight the test-gap
+   * worklist so the most-depended-on untested files surface first;
+   * never affects the Tests score (that comes from summary counts).
+   */
+  blastRadius?: number;
 }
 
 /**

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -134,6 +134,12 @@ const DXKIT_SKILLS = [
   // `.snyk` policy. The fix-vs-suppress decision + the `add` path stay
   // in dxkit-action; this owns everything after an entry exists.
   'dxkit-allowlist',
+  // dxkit-test: test-generation surface, the testing mirror of
+  // dxkit-docs. Reads the blast-radius-weighted test-gaps worklist,
+  // orients on real behavior via the graph, and writes meaningful tests
+  // that close the highest-risk gaps + move the Tests score without
+  // coverage theater. dxkit-action triages WHETHER to test; this WRITES.
+  'dxkit-test',
 ] as const;
 
 interface GenerateResult {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -140,6 +140,12 @@ const DXKIT_SKILLS = [
   // that close the highest-risk gaps + move the Tests score without
   // coverage theater. dxkit-action triages WHETHER to test; this WRITES.
   'dxkit-test',
+  // dxkit-pr: opens a pull request with a title + body grounded in the
+  // branch's real commits/diff (features, fixes, findings closed) plus
+  // the dxkit signals (guardrail verdict, allowlist activity, score
+  // deltas) and a tailored reviewer checklist. The close of the
+  // dxkit-feature / dxkit-action loop.
+  'dxkit-pr',
 ] as const;
 
 interface GenerateResult {

--- a/test/cli-init.test.ts
+++ b/test/cli-init.test.ts
@@ -121,6 +121,7 @@ describe('cli init --full --yes (integration, full agent scaffold)', () => {
       'dxkit-docs',
       'dxkit-ingest',
       'dxkit-allowlist',
+      'dxkit-test',
     ];
     for (const name of expected) {
       const skillPath = path.join(tmpDir, '.claude', 'skills', name, 'SKILL.md');

--- a/test/cli-init.test.ts
+++ b/test/cli-init.test.ts
@@ -122,6 +122,7 @@ describe('cli init --full --yes (integration, full agent scaffold)', () => {
       'dxkit-ingest',
       'dxkit-allowlist',
       'dxkit-test',
+      'dxkit-pr',
     ];
     for (const name of expected) {
       const skillPath = path.join(tmpDir, '.claude', 'skills', name, 'SKILL.md');

--- a/test/tests-blast-radius-weighting.test.ts
+++ b/test/tests-blast-radius-weighting.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { weightGapsByBlastRadius } from '../src/analyzers/tests/actions';
+import type { SourceFile } from '../src/analyzers/tests/types';
+import type { DetailedGraphContext } from '../src/explore/finding-context';
+import type { FindingContext } from '../src/explore/queries';
+
+function gap(path: string, lines: number, risk: SourceFile['risk']): SourceFile {
+  return { path, lines, type: 'other', risk, hasMatchingTest: false };
+}
+
+function ctx(
+  sourceFile: string,
+  callerFiles: number,
+  reliability?: FindingContext['callGraphReliability'],
+): FindingContext {
+  return {
+    found: true,
+    sourceFile,
+    blastRadius: { callerFiles, callers: callerFiles, topCallerFiles: [] },
+    ...(reliability ? { callGraphReliability: reliability } : {}),
+  };
+}
+
+function graphContext(contexts: Record<string, FindingContext>): DetailedGraphContext {
+  return { generatedAt: '2026-06-09T00:00:00Z', truncated: false, contexts };
+}
+
+describe('weightGapsByBlastRadius', () => {
+  it('orders most-depended-on first within a tier (overriding LOC)', () => {
+    // Small file with many callers should beat a big file with few callers.
+    const gaps = [gap('src/big.ts', 500, 'high'), gap('src/hub.ts', 40, 'high')];
+    const gc = graphContext({
+      'src/big.ts': ctx('src/big.ts', 1),
+      'src/hub.ts': ctx('src/hub.ts', 30),
+    });
+    const out = weightGapsByBlastRadius(gaps, gc);
+    expect(out.map((g) => g.path)).toEqual(['src/hub.ts', 'src/big.ts']);
+    expect(out[0].blastRadius).toBe(30);
+  });
+
+  it('keeps risk tier as the primary key', () => {
+    const gaps = [gap('src/low-hub.ts', 10, 'low'), gap('src/crit-leaf.ts', 10, 'critical')];
+    const gc = graphContext({
+      'src/low-hub.ts': ctx('src/low-hub.ts', 99),
+      'src/crit-leaf.ts': ctx('src/crit-leaf.ts', 0),
+    });
+    const out = weightGapsByBlastRadius(gaps, gc);
+    // critical tier outranks low regardless of blast radius
+    expect(out[0].path).toBe('src/crit-leaf.ts');
+  });
+
+  it('treats an unreliable call graph as UNKNOWN (no blastRadius stamped, LOC fallback)', () => {
+    const gaps = [gap('a.cs', 100, 'high'), gap('b.cs', 300, 'high')];
+    const gc = graphContext({
+      'a.cs': ctx('a.cs', 0, 'unreliable'),
+      'b.cs': ctx('b.cs', 0, 'unreliable'),
+    });
+    const out = weightGapsByBlastRadius(gaps, gc);
+    // No trustworthy blast radius → fall back to LOC desc (today's behavior)
+    expect(out.map((g) => g.path)).toEqual(['b.cs', 'a.cs']);
+    expect(out[0].blastRadius).toBeUndefined();
+    expect(out[1].blastRadius).toBeUndefined();
+  });
+
+  it('ranks known-blast files ahead of graph-unknown files, then by LOC', () => {
+    const gaps = [
+      gap('src/known.ts', 10, 'medium'), // in graph, 5 callers
+      gap('src/unknown-big.ts', 400, 'medium'), // not in graph
+      gap('src/unknown-small.ts', 20, 'medium'), // not in graph
+    ];
+    const gc = graphContext({ 'src/known.ts': ctx('src/known.ts', 5) });
+    const out = weightGapsByBlastRadius(gaps, gc);
+    expect(out.map((g) => g.path)).toEqual([
+      'src/known.ts', // confirmed impact first
+      'src/unknown-big.ts', // unknowns fall back to LOC desc
+      'src/unknown-small.ts',
+    ]);
+  });
+});

--- a/test/tests-blast-radius-weighting.test.ts
+++ b/test/tests-blast-radius-weighting.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { weightGapsByBlastRadius } from '../src/analyzers/tests/actions';
-import type { SourceFile } from '../src/analyzers/tests/types';
+import { buildTestGapsDetailed } from '../src/analyzers/tests/detailed';
+import type { SourceFile, TestGapsReport } from '../src/analyzers/tests/types';
 import type { DetailedGraphContext } from '../src/explore/finding-context';
 import type { FindingContext } from '../src/explore/queries';
 
@@ -75,5 +76,52 @@ describe('weightGapsByBlastRadius', () => {
       'src/unknown-big.ts', // unknowns fall back to LOC desc
       'src/unknown-small.ts',
     ]);
+  });
+});
+
+describe('buildTestGapsDetailed — weighting is score-invariant (A/B)', () => {
+  function report(gaps: SourceFile[]): TestGapsReport {
+    const byRisk = { critical: 0, high: 0, medium: 0, low: 0 };
+    for (const g of gaps) byRisk[g.risk]++;
+    return {
+      repo: 'r',
+      analyzedAt: '2026-06-09T00:00:00Z',
+      commitSha: 'abc',
+      branch: 'main',
+      summary: {
+        testFiles: 1,
+        activeTestFiles: 1,
+        commentedOutFiles: 0,
+        effectiveCoverage: 40,
+        coverageSource: 'import-graph',
+        coverageFidelity: 'import-graph',
+        sourceFiles: 10,
+        untestedCritical: byRisk.critical,
+        untestedHigh: byRisk.high,
+        untestedMedium: byRisk.medium,
+        untestedLow: byRisk.low,
+      },
+      testFiles: [],
+      gaps,
+      toolsUsed: ['find'],
+      toolsUnavailable: [],
+    } as TestGapsReport;
+  }
+
+  it('produces an IDENTICAL coverageScore with vs without graph context, but reorders gaps', () => {
+    const gaps = [gap('src/big.ts', 500, 'high'), gap('src/hub.ts', 40, 'high')];
+    const gc = graphContext({
+      'src/big.ts': ctx('src/big.ts', 1),
+      'src/hub.ts': ctx('src/hub.ts', 30),
+    });
+
+    const withoutGraph = buildTestGapsDetailed(report(gaps));
+    const withGraph = buildTestGapsDetailed(report(gaps), gc);
+
+    // The score is byte-stable — weighting can never move the Tests dimension.
+    expect(withGraph.coverageScore).toBe(withoutGraph.coverageScore);
+    // But the worklist reorders: the 30-caller hub leads, not the 500-line file.
+    expect(withoutGraph.gaps.map((g) => g.path)).toEqual(['src/big.ts', 'src/hub.ts']);
+    expect(withGraph.gaps.map((g) => g.path)).toEqual(['src/hub.ts', 'src/big.ts']);
   });
 });


### PR DESCRIPTION
Workflow-depth release: make the fix loop targetable, add the test-writing skill the suite was missing, surface the riskiest test gaps first, and add a PR-authoring skill. Almost entirely agent-skill + docs; one contained, flag-gated analyzer change. Rebase-merge candidate (each commit independently meaningful).

## What's in it

- **Scoped fixes** (`dxkit-action`) — burn down one category at a time (deps/BOM, security, code quality, tests, docs); runs the report that partitions that dimension, prioritizes within scope. Skill-only, no CLI change.
- **`dxkit-test` skill** — testing mirror of `dxkit-docs`: read the (blast-radius-weighted) test-gaps worklist → graph-orient → write meaningful tests → verify coverage moved. No coverage theater.
- **Test-gap blast-radius weighting** — `test-gaps --graph-context` ranks untested files within each risk tier by caller-count (most-depended-on first). **Ordering only; the Tests score is unchanged** (proven by a unit-level A/B test). Graceful LOC fallback when no/unreliable graph.
- **`dxkit-pr` skill** — opens a PR with a diff-grounded title + body + dxkit signals (guardrail/allowlist/score) + a tailored reviewer checklist. `dxkit-feature` now offers to write tests for a new surface (user-confirmed) → `dxkit-test`.
- **Docs + roadmap refresh** — every doc surface updated for the current 15-skill set; all stale hardcoded skill counts removed; roadmap records why deep-SAST code-path reachability is deferred (needs interprocedural taint dxkit can't do natively; realistic path = surface the ingested engine's reachability).

## Risk

Low. Only `test-gaps` weighting touches runtime — flag-gated (`--graph-context`), ordering-only, score-invariant (unit A/B proves it), graceful fallback, 5 unit tests. Everything else is skills/docs shipped in templates.

## Testing

Affected-scope suites green locally (test-gaps detailed/actions/weighting, cli-init scaffold, renderers, dashboard) + `typecheck:test`. Full suite + cross-ecosystem matrix runs here in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)