### PR TITLE
docs(roadmap): finding→dev attribution + PR reviewer recommendation

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -202,6 +202,29 @@ engine already computed** (Snyk Code / CodeQL encode it), not to compute our own
 - [ ] (Longer term) Densify the graphify call graph enough to attempt native
       intraprocedural→interprocedural reachability; gated on call-graph quality.
 
+### Finding attribution + reviewer recommendation
+
+Connect findings and PRs to the people who know the code, building on the
+existing dev-report analyzer (`ContributorStats` / `HotFile` from git history)
+and the code graph.
+
+- [ ] **Net-new finding attribution.** When the guardrail blocks a PR, name the
+      introducing commit + author for each net-new finding. This is cheap and
+      accurate — the introducer is the PR's own commits — and non-political (you
+      annotate your own change), so "who to ask" is unambiguous.
+- [ ] **Historical-finding attribution (opt-in, with care).** `git blame` for
+      pre-existing/baselined findings is fuzzy (it gives _last to touch_, not
+      _who introduced_ — a formatter run or file move reassigns it) and socially
+      loaded, which cuts against dxkit's "grandfather the past, gate the future"
+      stance. Gate it behind an explicit opt-in, and treat author emails with the
+      same disclosure posture as the baseline (don't bake PII into committed
+      reports on public repos).
+- [ ] **Reviewer recommendation in `dxkit-pr`.** Suggest reviewers for a PR from
+      the git history on the touched files + ownership of the blast-radius modules
+      (the graph already knows the dependents), honoring `CODEOWNERS` when present.
+      "Who knows this code" is a safer, higher-value signal than "who broke it";
+      it slots next to the reviewer checklist the skill already generates.
+
 ### AI readiness
 
 - [ ] Semantic anchors and function-body hashes for cross-file refactor detection

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -219,11 +219,34 @@ and the code graph.
       stance. Gate it behind an explicit opt-in, and treat author emails with the
       same disclosure posture as the baseline (don't bake PII into committed
       reports on public repos).
-- [ ] **Reviewer recommendation in `dxkit-pr`.** Suggest reviewers for a PR from
-      the git history on the touched files + ownership of the blast-radius modules
-      (the graph already knows the dependents), honoring `CODEOWNERS` when present.
-      "Who knows this code" is a safer, higher-value signal than "who broke it";
-      it slots next to the reviewer checklist the skill already generates.
+- [ ] **Reviewer recommendation in `dxkit-pr`.** Suggest reviewers for a PR
+      grounded on the **dev-report analyzer** (`ContributorStats` over the
+      analysis window) — not ad-hoc `git blame` — so the candidate set is already
+      scoped to _active_ contributors. Rank by history on the touched files +
+      ownership of the blast-radius modules (the graph knows the dependents),
+      honoring `CODEOWNERS` when present. "Who knows this code" is a safer,
+      higher-value signal than "who broke it," and it slots next to the reviewer
+      checklist the skill already generates.
+
+  **Edge cases that make or break this feature:**
+  - **Exclude the PR author** — never recommend someone to review their own change.
+  - **Departed contributors** — the dev who knows a file best may have left.
+    Grounding on the dev-report's analysis window naturally drops long-inactive
+    authors, but handle the case where _every_ knowledgeable contributor is gone:
+    fall back to current module owners / most-active live contributors /
+    `CODEOWNERS`, and say so ("original authors inactive — suggesting by current
+    ownership") rather than recommending someone unreachable.
+  - **Bots + automation** — exclude dependabot / CI / release-bot commits from
+    both attribution and reviewer ranking; they're not people to ask.
+  - **Recency-weight** — a single commit three years ago is weak signal next to
+    sustained recent activity; weight accordingly.
+  - **Don't recommend a single point of failure** — if one person owns
+    everything touched, surface that as a bus-factor signal, not just a reviewer.
+
+  The same active-contributor + bot-exclusion filtering applies to finding
+  attribution above: attributing a finding to someone who has left the company is
+  a dead end ("who to ask" = nobody), so attribution should flag when the
+  introducer is no longer active and route to the current owner instead.
 
 ### AI readiness
 


### PR DESCRIPTION
Captures two ideas raised for a future release (2.9.4+), so they carry forward into planning:

- **Net-new finding attribution** — name the introducing commit/author when the guardrail blocks (it's the PR's own commits: cheap, accurate, non-political).
- **Historical-finding attribution** — opt-in only, with caveats: `git blame` gives last-touch not introducer; blame-culture risk; author-email PII → same disclosure posture as the baseline.
- **Reviewer recommendation in `dxkit-pr`** — suggest reviewers from dev-report git history on touched files + blast-radius ownership + CODEOWNERS. Builds on the existing dev-report analyzer + code graph.

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)