### PR TITLE
2.9.4 — finding attribution + reviewer recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.4] - 2026-06-09
+
+### Connecting findings + PRs to the people who know the code
+
+Two features on a shared **active-owner model** — recency-weighted git history
+scoped to who is still active, with bots and departed contributors filtered, the
+change author excluded, and a bus-factor signal. Output renders names + GitHub
+@handles, never raw emails (the @handle is both privacy-safe and the actionable
+identifier — it's @-mentionable and feeds `gh --reviewer`).
+
+- **`vyuh-dxkit reviewers`** suggests reviewers for a change (`--base <ref>` /
+  `--staged`). It ranks the active owners of the touched files — recency-weighted,
+  bot-free, departed-dev-aware, author-excluded — blended with `CODEOWNERS`, and
+  warns on a bus factor of 1. The differentiation over a platform's naive
+  last-touch suggestion is the activity grounding + active-only scoping. The
+  `dxkit-pr` skill consumes it for a "Suggested reviewers" block and
+  `gh pr create --reviewer`.
+- **`--attribute` "who to ask"** on the detailed vulnerability / test-gaps /
+  quality reports. For a pre-existing finding it adds a "Who to ask" column:
+  line-level findings are `git blame`d and routed through the owner model (an
+  inactive author is forwarded to the file's current owner); file-level findings
+  (test gaps) attribute to the file's current owner. Opt-in and historical only —
+  a net-new finding the guardrail just blocked was introduced by your own change,
+  so its owner is the PR author. The column is honest that blame is last-touch,
+  not necessarily who introduced the finding.
+
+### Privacy
+
+Author emails are used only as the internal identity key for clustering; they
+are never rendered in any report or PR output. Everything user-facing is a
+display name or a GitHub @handle.
+
 ## [2.9.3] - 2026-06-09
 
 ### Targetable fix loop + test generation

--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ dxkit builds a deterministic code graph of your repo (its symbols, call edges, a
 
 This is an additive, fail-open layer. When the graph is missing, or a language's call edges can't be resolved, every command behaves exactly as it did before. It's reliable on TypeScript, Python, and Go. Where the call graph can't be resolved (C#), blast radius is suppressed rather than faked, so a "no callers" reading is never mistaken for "safe to change."
 
+### Connect findings and PRs to the people who know the code
+
+A finding or a PR is more actionable when you know who to ask. dxkit grounds that in an **active-owner model** — recency-weighted git history, scoped to who is still active, with bots and departed contributors filtered, the change author excluded, and a bus-factor signal.
+
+- **`vyuh-dxkit reviewers`** suggests reviewers for a change, ranked by active ownership of the touched files and blended with `CODEOWNERS` — a better signal than a platform's naive last-touch suggestion. The `dxkit-pr` skill folds it into the PR body.
+- **`--attribute`** adds a "who to ask" column to a detailed report: a pre-existing finding is traced to its current owner (an inactive author is routed to whoever owns the file now). It's opt-in and historical — a net-new finding is introduced by your own change.
+
+Output is names + GitHub @handles, never raw emails — the @handle is both privacy-safe and @-mentionable.
+
 ### Deep SAST: interprocedural findings from any engine
 
 dxkit's bundled SAST (community semgrep) is intraprocedural — it can't follow tainted data across function boundaries, so it misses the path-traversal / information-exposure / SSRF / injection class that an interprocedural engine like Snyk Code or CodeQL catches. dxkit doesn't try to re-detect that class; it **ingests** it and makes it first-class.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,33 +38,34 @@ to re-activate manually: `vyuh-dxkit hooks activate`.
 
 Once dxkit + its tools are installed, here's the command surface:
 
-| Command                                                          | Question it answers                                           | Typical runtime                    |
-| ---------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------- |
-| [`health`](commands/health.md)                                   | "What's the overall shape of this codebase?"                  | 1-4 min                            |
-| [`vulnerabilities`](commands/vulnerabilities.md)                 | "What security issues are there?"                             | 1-3 min                            |
-| [`test-gaps`](commands/test-gaps.md)                             | "Which untested files are riskiest?"                          | 30-90 sec                          |
-| [`quality`](commands/quality.md)                                 | "Where's the technical debt + duplication?"                   | 1-8 min (jscpd is the long-pole)   |
-| [`dev-report`](commands/dev-report.md)                           | "Who's working on what, where are the hot files?"             | 5-30 sec                           |
-| [`licenses`](commands/licenses.md)                               | "What licenses are in my dependency tree?"                    | 30-60 sec                          |
-| [`bom`](commands/bom.md)                                         | "Full dependency × license × CVE × upgrade view"              | 1-3 min                            |
-| [`coverage`](commands/coverage.md)                               | "Materialize real line-coverage data"                         | varies (runs your tests)           |
-| [`dashboard`](commands/dashboard.md)                             | "Single HTML view of everything I've run"                     | < 5 sec (renders existing reports) |
-| [`explore`](commands/explore.md)                                 | "What does this repo do / where does X live?"                 | < 5 sec (queries the graph)        |
-| [`context`](commands/context.md)                                 | "Token-budgeted structural slice for an LLM"                  | < 5 sec (queries the graph)        |
-| [`report`](commands/report.md)                                   | "Run all of the above in one shot"                            | 5-30 min                           |
-| [`tools`](commands/tools.md)                                     | "What tools are detected / missing?"                          | < 5 sec                            |
-| [`doctor`](commands/doctor.md)                                   | "Why is X not working?"                                       | < 5 sec                            |
-| [`init`](commands/init.md)                                       | "Scaffold a new project with dxkit pre-configured"            | 5-30 sec                           |
-| [`update`](commands/update.md)                                   | "Re-generate scaffolded files, preserving customizations"     | 5-30 sec                           |
-| [`upgrade`](commands/upgrade.md)                                 | "Plan + execute a dxkit version upgrade (binary + scaffold)"  | 1-3 min                            |
-| [`to-xlsx`](commands/to-xlsx.md)                                 | "Convert a licenses/bom JSON report to 15-col XLSX"           | < 5 sec                            |
-| [`baseline create`](commands/baseline.md)                        | "Capture today's findings as a brownfield anchor"             | 30s-2m                             |
-| [`baseline show`](commands/baseline.md)                          | "Inspect/filter the on-disk baseline"                         | < 1 sec                            |
-| [`guardrail check`](commands/guardrail.md)                       | "Block on net-new regressions vs. the baseline"               | 30s-2m                             |
-| [`setup-branch-protection`](commands/setup-branch-protection.md) | "Mark `dxkit-guardrails` as required check on default branch" | < 5 sec                            |
-| [`setup-prebuild`](commands/setup-prebuild.md)                   | "Configure Codespaces prebuild (cold-start ~7 min → ~30s)"    | < 5 sec                            |
-| [`allowlist`](commands/allowlist.md)                             | "Suppress a specific finding with typed reason + expiry"      | < 1 sec                            |
-| [`issue`](commands/issue.md)                                     | "Open a pre-filled GitHub Issue against dxkit"                | < 5 sec                            |
+| Command                                                          | Question it answers                                                | Typical runtime                    |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------- |
+| [`health`](commands/health.md)                                   | "What's the overall shape of this codebase?"                       | 1-4 min                            |
+| [`vulnerabilities`](commands/vulnerabilities.md)                 | "What security issues are there?"                                  | 1-3 min                            |
+| [`test-gaps`](commands/test-gaps.md)                             | "Which untested files are riskiest?"                               | 30-90 sec                          |
+| [`quality`](commands/quality.md)                                 | "Where's the technical debt + duplication?"                        | 1-8 min (jscpd is the long-pole)   |
+| [`dev-report`](commands/dev-report.md)                           | "Who's working on what, where are the hot files?"                  | 5-30 sec                           |
+| [`licenses`](commands/licenses.md)                               | "What licenses are in my dependency tree?"                         | 30-60 sec                          |
+| [`bom`](commands/bom.md)                                         | "Full dependency × license × CVE × upgrade view"                   | 1-3 min                            |
+| [`coverage`](commands/coverage.md)                               | "Materialize real line-coverage data"                              | varies (runs your tests)           |
+| [`dashboard`](commands/dashboard.md)                             | "Single HTML view of everything I've run"                          | < 5 sec (renders existing reports) |
+| [`explore`](commands/explore.md)                                 | "What does this repo do / where does X live?"                      | < 5 sec (queries the graph)        |
+| [`context`](commands/context.md)                                 | "Token-budgeted structural slice for an LLM"                       | < 5 sec (queries the graph)        |
+| [`report`](commands/report.md)                                   | "Run all of the above in one shot"                                 | 5-30 min                           |
+| [`tools`](commands/tools.md)                                     | "What tools are detected / missing?"                               | < 5 sec                            |
+| [`doctor`](commands/doctor.md)                                   | "Why is X not working?"                                            | < 5 sec                            |
+| [`init`](commands/init.md)                                       | "Scaffold a new project with dxkit pre-configured"                 | 5-30 sec                           |
+| [`update`](commands/update.md)                                   | "Re-generate scaffolded files, preserving customizations"          | 5-30 sec                           |
+| [`upgrade`](commands/upgrade.md)                                 | "Plan + execute a dxkit version upgrade (binary + scaffold)"       | 1-3 min                            |
+| [`to-xlsx`](commands/to-xlsx.md)                                 | "Convert a licenses/bom JSON report to 15-col XLSX"                | < 5 sec                            |
+| [`baseline create`](commands/baseline.md)                        | "Capture today's findings as a brownfield anchor"                  | 30s-2m                             |
+| [`baseline show`](commands/baseline.md)                          | "Inspect/filter the on-disk baseline"                              | < 1 sec                            |
+| [`guardrail check`](commands/guardrail.md)                       | "Block on net-new regressions vs. the baseline"                    | 30s-2m                             |
+| [`setup-branch-protection`](commands/setup-branch-protection.md) | "Mark `dxkit-guardrails` as required check on default branch"      | < 5 sec                            |
+| [`setup-prebuild`](commands/setup-prebuild.md)                   | "Configure Codespaces prebuild (cold-start ~7 min → ~30s)"         | < 5 sec                            |
+| [`allowlist`](commands/allowlist.md)                             | "Suppress a specific finding with typed reason + expiry"           | < 1 sec                            |
+| [`reviewers`](commands/reviewers.md)                             | "Who should review this change?" (active-owner model + CODEOWNERS) | < 5 sec                            |
+| [`issue`](commands/issue.md)                                     | "Open a pre-filled GitHub Issue against dxkit"                     | < 5 sec                            |
 
 ## Configuration
 

--- a/docs/commands/quality.md
+++ b/docs/commands/quality.md
@@ -33,12 +33,13 @@ vyuh-dxkit quality [path] [options]
 
 ## Options
 
-| Option            | Effect                                                                                                             |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `--detailed`      | Write detailed report (top-10 duplicate clones, top hygiene offenders, slop breakdown)                             |
-| `--json`          | Stdout JSON                                                                                                        |
-| `--no-save`       | Skip files                                                                                                         |
-| `--graph-context` | Attach each offender file's module + blast radius to the detailed report (fail-open — see [`context`](context.md)) |
+| Option            | Effect                                                                                                                                 |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `--detailed`      | Write detailed report (top-10 duplicate clones, top hygiene offenders, slop breakdown)                                                 |
+| `--json`          | Stdout JSON                                                                                                                            |
+| `--no-save`       | Skip files                                                                                                                             |
+| `--graph-context` | Attach each offender file's module + blast radius to the detailed report (fail-open — see [`context`](context.md))                     |
+| `--attribute`     | Attach a "Who to ask" column (each offender file's current owner, via the active-owner model). Opt-in; names + @handles, never emails. |
 
 ## Output
 

--- a/docs/commands/reviewers.md
+++ b/docs/commands/reviewers.md
@@ -1,0 +1,59 @@
+# `vyuh-dxkit reviewers`
+
+Suggest reviewers for a change, grounded on an **active-owner model** rather
+than a platform's naive last-touch blame.
+
+```bash
+vyuh-dxkit reviewers [--base <ref>] [--staged] [--limit N] [--json]
+```
+
+## How it picks
+
+The candidate set is the contributors who have touched the changed files,
+ranked by an active-owner model:
+
+- **Recency-weighted** — sustained recent work ranks far above an ancient single
+  commit (exponential half-life decay).
+- **Active-only** — "active" means a non-merge commit repo-wide within the recent
+  window. A contributor who has gone quiet (left the team) is flagged inactive
+  and not silently suggested.
+- **Bots filtered** — `dependabot`, CI, release bots, and similar automation are
+  excluded.
+- **Author excluded** — you are never suggested as a reviewer of your own change.
+- **`CODEOWNERS` blended in** — when a `CODEOWNERS` file matches the touched
+  paths, its owners are authoritative and surfaced first.
+- **Bus-factor signal** — if a single active owner covers the touched files, the
+  command warns (a single point of failure on that code).
+
+When every contributor who knows the files is inactive, the command says so and
+leans on `CODEOWNERS` / current ownership rather than naming someone unreachable.
+
+## Output
+
+Names + **GitHub @handles** — never raw emails. The @handle is both the
+privacy-safe identifier and the actionable one: it's @-mentionable and feeds
+`gh pr create --reviewer`.
+
+## Options
+
+| Option       | Effect                                                                               |
+| ------------ | ------------------------------------------------------------------------------------ |
+| `--base <r>` | Diff `<r>...HEAD` for the changed files (default: `origin/HEAD`, else `origin/main`) |
+| `--staged`   | Use the staged changes instead of a branch diff                                      |
+| `--limit N`  | Cap the number of suggestions (default 3)                                            |
+| `--json`     | Emit a structured payload (consumed by the `dxkit-pr` skill)                         |
+
+## Where it fits
+
+The `dxkit-pr` skill runs `reviewers --json` to add a "Suggested reviewers"
+block to the PR body and can pass the handles to `gh pr create --reviewer`.
+
+## Privacy
+
+Author emails are used only as the internal identity key for clustering aliases;
+they are never rendered. Everything user-facing is a display name or @handle.
+
+## See also
+
+- [`dev-report`](./dev-report.md) — the contributor-activity analysis this builds on
+- [`bom`](./bom.md) / [`vulnerabilities`](./vulnerabilities.md) — `--attribute` adds a "who to ask" column to findings

--- a/docs/commands/test-gaps.md
+++ b/docs/commands/test-gaps.md
@@ -22,6 +22,7 @@ vyuh-dxkit test-gaps [path] [options]
 | `--json`          | Stdout JSON                                                                                                                                                       |
 | `--no-save`       | Skip files                                                                                                                                                        |
 | `--graph-context` | Attach each gap file's module + blast radius to the detailed report (a high-blast-radius untested file is higher-stakes; fail-open — see [`context`](context.md)) |
+| `--attribute`     | Attach a "Who to ask" column (each untested file's current owner, via the active-owner model). Opt-in; names + @handles, never emails.                            |
 
 ## How it ranks
 

--- a/docs/commands/vulnerabilities.md
+++ b/docs/commands/vulnerabilities.md
@@ -27,12 +27,13 @@ vyuh-dxkit vuln [path]  # alias
 
 ## Options
 
-| Option            | Effect                                                                                                                      |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `--detailed`      | Write the detailed report + JSON                                                                                            |
-| `--json`          | Stdout JSON                                                                                                                 |
-| `--no-save`       | Skip writing files                                                                                                          |
-| `--graph-context` | Attach each finding's module + blast radius to the detailed report (needs a graph; fail-open — see [`context`](context.md)) |
+| Option            | Effect                                                                                                                                                                                                                     |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--detailed`      | Write the detailed report + JSON                                                                                                                                                                                           |
+| `--json`          | Stdout JSON                                                                                                                                                                                                                |
+| `--no-save`       | Skip writing files                                                                                                                                                                                                         |
+| `--graph-context` | Attach each finding's module + blast radius to the detailed report (needs a graph; fail-open — see [`context`](context.md))                                                                                                |
+| `--attribute`     | Attach a "Who to ask" column (git blame → active-owner model; inactive authors routed to the current owner). Opt-in; names + @handles, never emails. Historical only — net-new findings are introduced by your own change. |
 
 ## Output
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -113,7 +113,7 @@ restores the hook's executable bit (git silently ignores a non-executable
 hook) and `doctor` verifies it; hook activation chains after an existing
 `postinstall`.
 
-## Shipped in 2.9.1–2.9.3 — governance depth + the agent loop
+## Shipped in 2.9.1–2.9.4 — governance depth + the agent loop
 
 Follow-ups that made the ingested + native findings genuinely enforceable and
 the fix loop targetable.
@@ -155,6 +155,22 @@ the fix loop targetable.
       fixes, findings closed), the dxkit guardrail/allowlist/score signals, and a
       tailored reviewer checklist. `dxkit-feature` now offers to write tests for a
       new surface (user-confirmed) and hands off to `dxkit-test`.
+
+### Connecting findings + PRs to people (2.9.4)
+
+Both grounded on a new active-owner model (`src/analyzers/developer/ownership.ts`):
+recency-weighted git history, bots + departed contributors filtered, the change
+author excluded, a bus-factor signal. Renders names + GitHub @handles, never emails.
+
+- [x] **`vyuh-dxkit reviewers`** — suggests reviewers for a change from the
+      active-owner model blended with `CODEOWNERS`, with a bus-factor warning and
+      an inactive-owner fallback. Consumed by `dxkit-pr`. Beats naive last-touch
+      blame by being activity-weighted + active-only.
+- [x] **`--attribute` "who to ask"** on the detailed vulnerability / test-gaps /
+      quality reports — line-level findings are git-blamed and routed through the
+      owner model (inactive author → current owner); file-level findings (test
+      gaps) attribute to the file's current owner. Opt-in; net-new findings need no
+      blame (the introducer is the PR author). Honesty: blame is last-touch.
 
 ## Next release — Reachability refinements (carried from 2.8)
 
@@ -202,51 +218,18 @@ engine already computed** (Snyk Code / CodeQL encode it), not to compute our own
 - [ ] (Longer term) Densify the graphify call graph enough to attempt native
       intraprocedural→interprocedural reachability; gated on call-graph quality.
 
-### Finding attribution + reviewer recommendation
+### Attribution + reviewer recommendation — remaining
 
-Connect findings and PRs to the people who know the code, building on the
-existing dev-report analyzer (`ContributorStats` / `HotFile` from git history)
-and the code graph.
+The core shipped in 2.9.4 (see Shipped above). Deferred follow-ons:
 
-- [ ] **Net-new finding attribution.** When the guardrail blocks a PR, name the
-      introducing commit + author for each net-new finding. This is cheap and
-      accurate — the introducer is the PR's own commits — and non-political (you
-      annotate your own change), so "who to ask" is unambiguous.
-- [ ] **Historical-finding attribution (opt-in, with care).** `git blame` for
-      pre-existing/baselined findings is fuzzy (it gives _last to touch_, not
-      _who introduced_ — a formatter run or file move reassigns it) and socially
-      loaded, which cuts against dxkit's "grandfather the past, gate the future"
-      stance. Gate it behind an explicit opt-in, and treat author emails with the
-      same disclosure posture as the baseline (don't bake PII into committed
-      reports on public repos).
-- [ ] **Reviewer recommendation in `dxkit-pr`.** Suggest reviewers for a PR
-      grounded on the **dev-report analyzer** (`ContributorStats` over the
-      analysis window) — not ad-hoc `git blame` — so the candidate set is already
-      scoped to _active_ contributors. Rank by history on the touched files +
-      ownership of the blast-radius modules (the graph knows the dependents),
-      honoring `CODEOWNERS` when present. "Who knows this code" is a safer,
-      higher-value signal than "who broke it," and it slots next to the reviewer
-      checklist the skill already generates.
-
-  **Edge cases that make or break this feature:**
-  - **Exclude the PR author** — never recommend someone to review their own change.
-  - **Departed contributors** — the dev who knows a file best may have left.
-    Grounding on the dev-report's analysis window naturally drops long-inactive
-    authors, but handle the case where _every_ knowledgeable contributor is gone:
-    fall back to current module owners / most-active live contributors /
-    `CODEOWNERS`, and say so ("original authors inactive — suggesting by current
-    ownership") rather than recommending someone unreachable.
-  - **Bots + automation** — exclude dependabot / CI / release-bot commits from
-    both attribution and reviewer ranking; they're not people to ask.
-  - **Recency-weight** — a single commit three years ago is weak signal next to
-    sustained recent activity; weight accordingly.
-  - **Don't recommend a single point of failure** — if one person owns
-    everything touched, surface that as a bus-factor signal, not just a reviewer.
-
-  The same active-contributor + bot-exclusion filtering applies to finding
-  attribution above: attributing a finding to someone who has left the company is
-  a dead end ("who to ask" = nobody), so attribution should flag when the
-  introducer is no longer active and route to the current owner instead.
+- [ ] **GitHub API handle resolution.** Today @handles resolve offline from
+      `…@users.noreply.github.com` emails; a real-email author has no handle.
+      Optionally resolve commit→login via the GitHub API where `gh` is
+      authenticated (network, opt-in) to fill the gap.
+- [ ] **Blast-radius ownership blend in `reviewers`.** Expand the candidate set
+      to owners of the touched files' dependents (the graph knows the callers),
+      not just the touched files themselves — a change's reviewers include the
+      people whose code it could break.
 
 ### AI readiness
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.9.3",
+      "version": "2.9.4",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "AI-native developer experience toolkit for any codebase",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -28,6 +28,8 @@ npx vyuh-dxkit vulnerabilities --detailed --graph-context   # or test-gaps / qua
 
 `--graph-context` adds a "Graph context" column (the module a finding lives in + its blast radius — how many files call into it) so you can plan the fix without separately discovering structure. It's a structural HINT, not ground truth — read "Graph context" below for how to use it safely.
 
+Add **`--attribute`** when you need to know *who to ask* about a pre-existing finding — it adds a "Who to ask" column from `git blame` routed through the active-owner model, so an inactive author is forwarded to the file's current owner (names + @handles, never emails). It's opt-in and **historical only**: a net-new finding the guardrail just blocked was introduced by your own change, so "who to ask" there is simply the PR author — no blame needed. Honor the honesty caveat (blame is last-touch, not necessarily who introduced it).
+
 ## Scoped fix — fix one category at a time
 
 Often the user doesn't want "fix everything" — they want to burn down **one

--- a/src-templates/.claude/skills/dxkit-pr/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-pr/SKILL.md
@@ -78,6 +78,22 @@ Put in the body:
 - **Score deltas** — only when the change targeted a dimension (e.g. "Tests
   62 → 71 after closing the auth gaps"). Don't pad with unchanged scores.
 
+### Suggested reviewers
+
+```bash
+npx vyuh-dxkit reviewers --base <base-branch> --json
+```
+
+This ranks reviewers by the **active-owner model** — recency-weighted git
+history on the touched files, with bots and departed contributors filtered, the
+PR author excluded, blended with `CODEOWNERS`. Better signal than the platform's
+naive last-touch suggestion. Surface the top few in the body with the *why*
+("@alice — owns 3/4 touched files, active"), and you can pass them to
+`gh pr create --reviewer`. Honor the output's caveats: if it returns a
+`busFactor: 1`, note the single-point-of-failure; if it returns a `note`
+(original authors inactive / no signal), say so rather than inventing a
+reviewer. Renders `@handle`s, never emails.
+
 ## [4] Draft — title, body, reviewer checklist
 
 **Title** — imperative, scoped, specific. `feat(auth): add refresh-token
@@ -100,6 +116,10 @@ rotation`, not `Updates`. Match the repo's existing PR/commit convention
 - Allowlist: <new suppressions + reason + expiry, or "no changes">
 - Scores: <dimension deltas, if the change targeted one>
 
+## Suggested reviewers
+- @alice — owns 3/4 touched files, active · @bob — CODEOWNERS
+  (or the `note` when there's no active-owner signal)
+
 ## Reviewer checklist
 - [ ] Change matches the description; scope isn't broader than stated
 - [ ] <feature>: behavior verified (how to exercise it)
@@ -120,7 +140,8 @@ Show the user the full draft (title + body) and confirm. On yes:
 
 ```bash
 git push -u origin HEAD                # if not already pushed
-gh pr create --base main --title "<title>" --body "<body>"
+gh pr create --base main --title "<title>" --body "<body>" \
+    --reviewer <handle1>,<handle2>     # the active owners from `reviewers`, if any
 ```
 
 If `gh` isn't authenticated, print the title + body for the user to paste, and

--- a/src/analyzers/developer/gather.ts
+++ b/src/analyzers/developer/gather.ts
@@ -16,7 +16,7 @@ import { ContributorStats, HotFile, CommitQuality, WeeklyVelocity } from './type
  * placeholders (`root`, `unknown`). Bot rows still appear in the
  * leaderboard but get tagged so they don't crowd out human signal.
  */
-function isBotAuthor(name: string, email: string): boolean {
+export function isBotAuthor(name: string, email: string): boolean {
   if (/\[bot\]/.test(name)) return true;
   if (/^(dependabot|renovate|github-actions|snyk-bot|deepsource-io)$/i.test(name)) return true;
   if (/^(dependabot|renovate|github-actions|noreply)@/.test(email)) return true;
@@ -31,7 +31,7 @@ function isBotAuthor(name: string, email: string): boolean {
  * collapse to the same cluster key. Lowercase the whole thing so
  * casing differences don't split a cluster.
  */
-function normalizeEmail(email: string): string {
+export function normalizeEmail(email: string): string {
   return email.toLowerCase().replace(/^\d+\+/, '');
 }
 

--- a/src/analyzers/developer/ownership.ts
+++ b/src/analyzers/developer/ownership.ts
@@ -1,0 +1,247 @@
+/**
+ * Active-owner model — who knows a set of files, and which of them are
+ * still around to ask. Shared substrate for finding attribution ("who
+ * introduced / who to ask") and reviewer recommendation ("who should
+ * review this"). All git-based; `git` is a builtin (tool-registry
+ * exemption).
+ *
+ * The module is split so the ranking logic is testable without git:
+ *   - `rankOwners(touches, activeEmails, opts)` — PURE. Given per-commit
+ *     authorship touching the files plus the set of currently-active
+ *     authors, produces the ranked owners + bus-factor + all-inactive flag.
+ *   - `ownersFor(cwd, files, opts)` — IO wrapper. Gathers the touches +
+ *     the active-author set via git, then delegates to `rankOwners`.
+ *
+ * Edge cases (the make-or-break list) all live in `rankOwners`:
+ *   - Active = present in the repo-wide recent window. A contributor who
+ *     last touched a file two years ago and hasn't committed since is
+ *     marked `active: false` (left the team / went quiet) — never silently
+ *     recommended.
+ *   - Bots excluded (reuses `isBotAuthor`).
+ *   - Recency-weighted — a single commit long ago ranks far below sustained
+ *     recent work (exponential half-life decay).
+ *   - `excludeEmails` drops e.g. the PR author from the ranking.
+ *   - `busFactor` surfaces single-point-of-failure ownership.
+ *   - `allInactive` lets callers fall back to current ownership / CODEOWNERS
+ *     and SAY SO rather than naming someone unreachable.
+ *
+ * Identity vs output: `email` is the INTERNAL join key (git's stable
+ * identity for clustering aliases) — it is NOT for display. Committed
+ * output (reports / PR bodies) renders `name` + the GitHub `@handle`
+ * (resolved offline from `…@users.noreply.github.com` emails when
+ * possible), never the raw email. The handle is both the privacy-safe
+ * identifier AND the actionable one — it's @-mentionable and is what
+ * `gh pr create --reviewer` consumes. Callers must not surface `email`
+ * in any committed artifact.
+ */
+import { run } from '../tools/runner';
+import { isBotAuthor, normalizeEmail } from './gather';
+
+/**
+ * Best-effort GitHub handle from a commit email, offline + deterministic.
+ * GitHub's privacy-relay emails encode the login:
+ *   `username@users.noreply.github.com`        → `username`
+ *   `12345+username@users.noreply.github.com`  → `username`
+ * Returns `undefined` for any other email (a real handle then needs the
+ * GitHub API, which the reviewers CLI may resolve where available).
+ */
+export function handleFromEmail(email: string): string | undefined {
+  const m = email
+    .toLowerCase()
+    .match(/^(?:\d+\+)?([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)@users\.noreply\.github\.com$/);
+  return m ? m[1] : undefined;
+}
+
+/** One commit that touched the queried files. */
+export interface CommitTouch {
+  readonly name: string;
+  readonly email: string;
+  /** Author date, ISO 8601 (`%aI`). */
+  readonly dateISO: string;
+}
+
+/** A ranked owner of the queried files. */
+export interface FileOwner {
+  readonly name: string;
+  /** Internal join key only — git's stable identity. NEVER render this in
+   *  committed output; use `name` / `githubHandle` instead. */
+  readonly email: string;
+  /** GitHub @handle when resolvable offline from the email (privacy-safe,
+   *  @-mentionable, feeds `gh --reviewer`). Absent ⇒ render `name`. */
+  readonly githubHandle?: string;
+  /** Commits (within the knowledge window) touching the queried files. */
+  readonly commits: number;
+  /** ISO date of this owner's most recent touch of the files. */
+  readonly lastTouched: string;
+  /** Whether the owner is still active repo-wide (in the recent window). */
+  readonly active: boolean;
+  /** Recency-weighted score; higher = stronger current ownership. */
+  readonly score: number;
+}
+
+export interface OwnershipResult {
+  /** Owners sorted by score desc. Includes inactive owners (flagged) so
+   *  attribution can say "original author inactive" rather than hiding them. */
+  readonly ranked: ReadonlyArray<FileOwner>;
+  /** Number of distinct ACTIVE owners whose combined score covers ~50% of
+   *  the active ownership — a bus-factor signal. 0 when no active owner. */
+  readonly busFactor: number;
+  /** True when no ACTIVE human owner was found (everyone who knows these
+   *  files has gone quiet / left). Callers fall back to current ownership. */
+  readonly allInactive: boolean;
+}
+
+export interface RankOwnersOptions {
+  /** Normalized emails to drop from the ranking (e.g. the PR author). */
+  readonly excludeEmails?: ReadonlySet<string>;
+  /** "Now" for recency decay — injectable for deterministic tests. */
+  readonly now: Date;
+  /** Half-life (days) for the recency decay. Default 180 (~2 quarters). */
+  readonly halfLifeDays?: number;
+}
+
+const DEFAULT_HALF_LIFE_DAYS = 180;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Pure ranking core. `activeEmails` is the set of NORMALIZED emails
+ * considered currently active (repo-wide recent window). `touches` is one
+ * entry per commit that touched the queried files (bots included — they're
+ * filtered here).
+ */
+export function rankOwners(
+  touches: ReadonlyArray<CommitTouch>,
+  activeEmails: ReadonlySet<string>,
+  opts: RankOwnersOptions,
+): OwnershipResult {
+  const halfLife = opts.halfLifeDays ?? DEFAULT_HALF_LIFE_DAYS;
+  const nowMs = opts.now.getTime();
+  const exclude = opts.excludeEmails ?? new Set<string>();
+
+  interface Acc {
+    name: string;
+    email: string;
+    handle?: string;
+    commits: number;
+    score: number;
+    lastTouchedMs: number;
+  }
+  const byEmail = new Map<string, Acc>();
+
+  for (const t of touches) {
+    if (isBotAuthor(t.name, t.email)) continue;
+    const key = normalizeEmail(t.email);
+    if (exclude.has(key)) continue;
+    const touchedMs = Date.parse(t.dateISO);
+    if (Number.isNaN(touchedMs)) continue;
+    const ageDays = Math.max(0, (nowMs - touchedMs) / MS_PER_DAY);
+    const weight = Math.pow(0.5, ageDays / halfLife);
+    const handle = handleFromEmail(t.email);
+    const existing = byEmail.get(key);
+    if (existing) {
+      existing.commits += 1;
+      existing.score += weight;
+      // Keep any resolvable handle, even if it came from a different alias.
+      if (!existing.handle && handle) existing.handle = handle;
+      if (touchedMs > existing.lastTouchedMs) {
+        existing.lastTouchedMs = touchedMs;
+        existing.name = t.name; // prefer the name on the most recent commit
+      }
+    } else {
+      byEmail.set(key, {
+        name: t.name,
+        email: t.email,
+        ...(handle ? { handle } : {}),
+        commits: 1,
+        score: weight,
+        lastTouchedMs: touchedMs,
+      });
+    }
+  }
+
+  const ranked: FileOwner[] = [...byEmail.entries()]
+    .map(([key, a]) => ({
+      name: a.name,
+      email: a.email,
+      ...(a.handle ? { githubHandle: a.handle } : {}),
+      commits: a.commits,
+      lastTouched: new Date(a.lastTouchedMs).toISOString().slice(0, 10),
+      active: activeEmails.has(key),
+      score: a.score,
+    }))
+    .sort((x, y) => y.score - x.score || y.commits - x.commits || x.name.localeCompare(y.name));
+
+  // Bus factor: among active owners, how many cover ~50% of active score.
+  const activeOwners = ranked.filter((o) => o.active);
+  const activeTotal = activeOwners.reduce((s, o) => s + o.score, 0);
+  let busFactor = 0;
+  if (activeTotal > 0) {
+    let cum = 0;
+    for (const o of activeOwners) {
+      busFactor += 1;
+      cum += o.score;
+      if (cum >= activeTotal * 0.5) break;
+    }
+  }
+
+  return { ranked, busFactor, allInactive: activeOwners.length === 0 };
+}
+
+export interface OwnersForOptions {
+  /** Recent-activity window for "active" (git `--since`). Default 6 months. */
+  readonly activeSince?: string;
+  /** Knowledge-window for who-touched-the-files (git `--since`). Omit for
+   *  full history (recency decay handles down-weighting old work). */
+  readonly knowledgeSince?: string;
+  /** Normalized emails to exclude (e.g. the PR author). */
+  readonly excludeEmails?: ReadonlySet<string>;
+  readonly now?: Date;
+  readonly halfLifeDays?: number;
+}
+
+/**
+ * Gather ownership for `files` via git, then rank. Returns an empty result
+ * (no owners) when git produces nothing — callers treat that as "unknown,"
+ * never as "no owners exist."
+ */
+export function ownersFor(
+  cwd: string,
+  files: ReadonlyArray<string>,
+  opts: OwnersForOptions = {},
+): OwnershipResult {
+  const now = opts.now ?? new Date();
+  if (files.length === 0) {
+    return { ranked: [], busFactor: 0, allInactive: true };
+  }
+
+  // Per-file authorship: one line per commit touching any of the files.
+  // `%x1f` (unit separator) avoids collisions with names/emails.
+  const since = opts.knowledgeSince ? `--since='${opts.knowledgeSince}'` : '';
+  const pathArgs = files.map((f) => `'${f.replace(/'/g, "'\\''")}'`).join(' ');
+  const logOut = run(
+    `git log --no-merges ${since} --format='%aN%x1f%aE%x1f%aI' -- ${pathArgs}`,
+    cwd,
+    30000,
+  );
+  const touches: CommitTouch[] = [];
+  for (const line of (logOut || '').split('\n')) {
+    if (!line.trim()) continue;
+    const [name, email, dateISO] = line.split('\x1f');
+    if (name && email && dateISO) touches.push({ name, email, dateISO });
+  }
+
+  // Active set: anyone with a non-merge commit repo-wide in the recent window.
+  const activeSince = opts.activeSince ?? '6 months ago';
+  const activeOut = run(`git shortlog -sne --no-merges --since='${activeSince}' HEAD`, cwd, 30000);
+  const activeEmails = new Set<string>();
+  for (const line of (activeOut || '').split('\n')) {
+    const m = line.trim().match(/^\d+\s+.+?\s+<([^>]+)>$/);
+    if (m) activeEmails.add(normalizeEmail(m[1]));
+  }
+
+  return rankOwners(touches, activeEmails, {
+    excludeEmails: opts.excludeEmails,
+    now,
+    ...(opts.halfLifeDays !== undefined ? { halfLifeDays: opts.halfLifeDays } : {}),
+  });
+}

--- a/src/analyzers/developer/ownership.ts
+++ b/src/analyzers/developer/ownership.ts
@@ -187,6 +187,23 @@ export function rankOwners(
   return { ranked, busFactor, allInactive: activeOwners.length === 0 };
 }
 
+/**
+ * The set of NORMALIZED author emails considered currently active — anyone
+ * with a non-merge commit repo-wide within `since`. Departed contributors
+ * (no recent commit anywhere) are absent. Shared by the ownership ranking
+ * and by finding attribution (to decide whether a blamed author is still
+ * around to ask).
+ */
+export function gatherActiveEmails(cwd: string, since = '6 months ago'): Set<string> {
+  const out = run(`git shortlog -sne --no-merges --since='${since}' HEAD`, cwd, 30000);
+  const emails = new Set<string>();
+  for (const line of (out || '').split('\n')) {
+    const m = line.trim().match(/^\d+\s+.+?\s+<([^>]+)>$/);
+    if (m) emails.add(normalizeEmail(m[1]));
+  }
+  return emails;
+}
+
 export interface OwnersForOptions {
   /** Recent-activity window for "active" (git `--since`). Default 6 months. */
   readonly activeSince?: string;
@@ -230,14 +247,7 @@ export function ownersFor(
     if (name && email && dateISO) touches.push({ name, email, dateISO });
   }
 
-  // Active set: anyone with a non-merge commit repo-wide in the recent window.
-  const activeSince = opts.activeSince ?? '6 months ago';
-  const activeOut = run(`git shortlog -sne --no-merges --since='${activeSince}' HEAD`, cwd, 30000);
-  const activeEmails = new Set<string>();
-  for (const line of (activeOut || '').split('\n')) {
-    const m = line.trim().match(/^\d+\s+.+?\s+<([^>]+)>$/);
-    if (m) activeEmails.add(normalizeEmail(m[1]));
-  }
+  const activeEmails = gatherActiveEmails(cwd, opts.activeSince ?? '6 months ago');
 
   return rankOwners(touches, activeEmails, {
     excludeEmails: opts.excludeEmails,

--- a/src/analyzers/quality/detailed.ts
+++ b/src/analyzers/quality/detailed.ts
@@ -16,6 +16,11 @@ import {
   locationKey,
   type DetailedGraphContext,
 } from '../../explore/finding-context';
+import {
+  formatAttributionCell,
+  attributionProvenanceLine,
+  type DetailedAttribution,
+} from '../../attribution/attribute';
 
 export interface QualityDetailedReport extends QualityReport {
   /** Schema version for agent consumers. Bump on breaking shape changes. */
@@ -28,11 +33,15 @@ export interface QualityDetailedReport extends QualityReport {
    * loaded.
    */
   graphContext?: DetailedGraphContext;
+  /** Per-file "who to ask" (owner), keyed by file path. Present only when
+   *  the run passed `--attribute`. */
+  attribution?: DetailedAttribution;
 }
 
 export function buildQualityDetailed(
   report: QualityReport,
   graphContext?: DetailedGraphContext,
+  attribution?: DetailedAttribution,
 ): QualityDetailedReport {
   const actions = rank(buildSlopActions(report.metrics), report.metrics, (m) =>
     evaluateSpec(QUALITY_SCORING_SPEC, qualityMetricsToScoreInput(m)),
@@ -42,6 +51,7 @@ export function buildQualityDetailed(
     schemaVersion: '11',
     actions,
     ...(graphContext ? { graphContext } : {}),
+    ...(attribution ? { attribution } : {}),
   };
 }
 
@@ -127,12 +137,28 @@ export function formatQualityDetailedMarkdown(
   // when --graph-context ran, so a reader sees how central each
   // offender file is before deciding to touch it.
   const gc = detailed.graphContext;
+  const attr = detailed.attribution;
   let provenancePrinted = false;
   const offenderProvenance = () => {
-    if (gc && !provenancePrinted) {
-      L.push(graphContextProvenanceLine(gc));
-      L.push('');
-      provenancePrinted = true;
+    if (provenancePrinted) return;
+    if (gc) L.push(graphContextProvenanceLine(gc));
+    if (attr) L.push(attributionProvenanceLine());
+    if (gc || attr) L.push('');
+    provenancePrinted = true;
+  };
+
+  // Column-driven offender table — graph context + attribution compose.
+  const offenderTable = (files: ReadonlyArray<{ file: string; count: number }>) => {
+    const headers = ['File', 'Count'];
+    if (gc) headers.push('Graph context');
+    if (attr) headers.push('Who to ask');
+    L.push(`| ${headers.join(' | ')} |`);
+    L.push(`|${headers.map((h) => (h === 'Count' ? '-----:' : '---')).join('|')}|`);
+    for (const f of files) {
+      const cells = [`\`${f.file}\``, String(f.count)];
+      if (gc) cells.push(formatGraphContextCell(gc.contexts[locationKey(f.file)]));
+      if (attr) cells.push(formatAttributionCell(attr.attributions[locationKey(f.file)]));
+      L.push(`| ${cells.join(' | ')} |`);
     }
   };
 
@@ -140,19 +166,7 @@ export function formatQualityDetailedMarkdown(
     L.push('## Files with Most Console Statements');
     L.push('');
     offenderProvenance();
-    if (gc) {
-      L.push('| File | Count | Graph context |');
-      L.push('|------|------:|----------------|');
-      for (const f of m.topConsoleFiles) {
-        L.push(
-          `| \`${f.file}\` | ${f.count} | ${formatGraphContextCell(gc.contexts[locationKey(f.file)])} |`,
-        );
-      }
-    } else {
-      L.push('| File | Count |');
-      L.push('|------|------:|');
-      for (const f of m.topConsoleFiles) L.push(`| \`${f.file}\` | ${f.count} |`);
-    }
+    offenderTable(m.topConsoleFiles);
     L.push('');
   }
 
@@ -160,19 +174,7 @@ export function formatQualityDetailedMarkdown(
     L.push('## Files with Most TODO/FIXME/HACK');
     L.push('');
     offenderProvenance();
-    if (gc) {
-      L.push('| File | Count | Graph context |');
-      L.push('|------|------:|----------------|');
-      for (const f of m.topTodoFiles) {
-        L.push(
-          `| \`${f.file}\` | ${f.count} | ${formatGraphContextCell(gc.contexts[locationKey(f.file)])} |`,
-        );
-      }
-    } else {
-      L.push('| File | Count |');
-      L.push('|------|------:|');
-      for (const f of m.topTodoFiles) L.push(`| \`${f.file}\` | ${f.count} |`);
-    }
+    offenderTable(m.topTodoFiles);
     L.push('');
   }
 

--- a/src/analyzers/security/detailed.ts
+++ b/src/analyzers/security/detailed.ts
@@ -13,6 +13,11 @@ import {
   locationKey,
   type DetailedGraphContext,
 } from '../../explore/finding-context';
+import {
+  formatAttributionCell,
+  attributionProvenanceLine,
+  type DetailedAttribution,
+} from '../../attribution/attribute';
 
 export interface SecurityDetailedReport extends SecurityReport {
   schemaVersion: string;
@@ -24,11 +29,17 @@ export interface SecurityDetailedReport extends SecurityReport {
    * AND a graph.json was loadable; absent otherwise (fail-open).
    */
   graphContext?: DetailedGraphContext;
+  /**
+   * Per-finding "who to ask" attribution, keyed by `file:line`. Present
+   * only when the run passed `--attribute`; absent otherwise (fail-open).
+   */
+  attribution?: DetailedAttribution;
 }
 
 export function buildSecurityDetailed(
   report: SecurityReport,
   graphContext?: DetailedGraphContext,
+  attribution?: DetailedAttribution,
 ): SecurityDetailedReport {
   const input = countsFromReport(report);
   const scoreFromInput = (i: SecurityScoreInput) => evaluateSpec(SECURITY_SCORING_SPEC, i);
@@ -41,6 +52,7 @@ export function buildSecurityDetailed(
     securityScore: scoreFromInput(input).score,
     actions,
     ...(graphContext ? { graphContext } : {}),
+    ...(attribution ? { attribution } : {}),
   };
 }
 
@@ -138,25 +150,29 @@ export function formatSecurityDetailedMarkdown(
   );
   if (sorted.length === 0) {
     L.push('No code findings.');
-  } else if (detailed.graphContext) {
-    const gc = detailed.graphContext;
-    L.push(graphContextProvenanceLine(gc));
-    L.push('');
-    L.push('| Severity | Rule | File:Line | Tool | CWE | Graph context |');
-    L.push('|----------|------|-----------|------|-----|----------------|');
-    for (const f of sorted) {
-      const ctx = gc.contexts[locationKey(f.file, f.line)];
-      L.push(
-        `| ${f.severity.toUpperCase()} | \`${f.rule}\` | \`${f.file}${f.line ? ':' + f.line : ''}\` | ${f.tool} | ${f.cwe || '—'} | ${formatGraphContextCell(ctx)} |`,
-      );
-    }
   } else {
-    L.push('| Severity | Rule | File:Line | Tool | CWE |');
-    L.push('|----------|------|-----------|------|-----|');
+    const gc = detailed.graphContext;
+    const attr = detailed.attribution;
+    if (gc) L.push(graphContextProvenanceLine(gc));
+    if (attr) L.push(attributionProvenanceLine());
+    if (gc || attr) L.push('');
+    // Column-driven so graph context + attribution compose cleanly.
+    const headers = ['Severity', 'Rule', 'File:Line', 'Tool', 'CWE'];
+    if (gc) headers.push('Graph context');
+    if (attr) headers.push('Who to ask');
+    L.push(`| ${headers.join(' | ')} |`);
+    L.push(`|${headers.map(() => '---').join('|')}|`);
     for (const f of sorted) {
-      L.push(
-        `| ${f.severity.toUpperCase()} | \`${f.rule}\` | \`${f.file}${f.line ? ':' + f.line : ''}\` | ${f.tool} | ${f.cwe || '—'} |`,
-      );
+      const cells = [
+        f.severity.toUpperCase(),
+        `\`${f.rule}\``,
+        `\`${f.file}${f.line ? ':' + f.line : ''}\``,
+        f.tool,
+        f.cwe || '—',
+      ];
+      if (gc) cells.push(formatGraphContextCell(gc.contexts[locationKey(f.file, f.line)]));
+      if (attr) cells.push(formatAttributionCell(attr.attributions[locationKey(f.file, f.line)]));
+      L.push(`| ${cells.join(' | ')} |`);
     }
   }
   L.push('');

--- a/src/analyzers/tests/detailed.ts
+++ b/src/analyzers/tests/detailed.ts
@@ -12,6 +12,11 @@ import {
   locationKey,
   type DetailedGraphContext,
 } from '../../explore/finding-context';
+import {
+  formatAttributionCell,
+  attributionProvenanceLine,
+  type DetailedAttribution,
+} from '../../attribution/attribute';
 
 export interface TestGapsDetailedReport extends TestGapsReport {
   schemaVersion: string;
@@ -23,11 +28,15 @@ export interface TestGapsDetailedReport extends TestGapsReport {
    * Present only when `--graph-context` ran AND a graph loaded.
    */
   graphContext?: DetailedGraphContext;
+  /** Per-gap "who to ask" (file owner), keyed by file path. Present only
+   *  when the run passed `--attribute`. */
+  attribution?: DetailedAttribution;
 }
 
 export function buildTestGapsDetailed(
   report: TestGapsReport,
   graphContext?: DetailedGraphContext,
+  attribution?: DetailedAttribution,
 ): TestGapsDetailedReport {
   const counts = countsFromReport(report);
   // When a graph is present, re-rank the gap worklist by blast radius so
@@ -44,6 +53,7 @@ export function buildTestGapsDetailed(
     coverageScore: scoreTestGapsCounts(counts).score,
     actions,
     ...(graphContext ? { graphContext } : {}),
+    ...(attribution ? { attribution } : {}),
   };
 }
 
@@ -123,10 +133,10 @@ export function formatTestGapsDetailedMarkdown(
   L.push('## All Gaps by Risk Tier');
   L.push('');
   const gc = detailed.graphContext;
-  if (gc) {
-    L.push(graphContextProvenanceLine(gc));
-    L.push('');
-  }
+  const attr = detailed.attribution;
+  if (gc) L.push(graphContextProvenanceLine(gc));
+  if (attr) L.push(attributionProvenanceLine());
+  if (gc || attr) L.push('');
   // Within a tier, prefer higher blast radius (most-depended-on first)
   // when the graph stamped it, falling back to LOC. Mirrors the worklist
   // ranking so the table and the actions agree on ordering.
@@ -149,21 +159,24 @@ export function formatTestGapsDetailedMarkdown(
     if (items.length === 0) continue;
     L.push(`### ${tier.toUpperCase()} (${items.length})`);
     L.push('');
-    if (gc) {
-      L.push('| File | Type | Lines | Graph context |');
-      L.push('|------|------|------:|----------------|');
-      for (const g of items.slice(0, 50)) {
-        const ctx = gc.contexts[locationKey(g.path)];
-        L.push(`| \`${g.path}\` | ${g.type} | ${g.lines} | ${formatGraphContextCell(ctx)} |`);
-      }
-      if (items.length > 50) L.push(`| … and ${items.length - 50} more | | | |`);
-    } else {
-      L.push('| File | Type | Lines |');
-      L.push('|------|------|------:|');
-      for (const g of items.slice(0, 50)) {
-        L.push(`| \`${g.path}\` | ${g.type} | ${g.lines} |`);
-      }
-      if (items.length > 50) L.push(`| … and ${items.length - 50} more | | |`);
+    const headers = ['File', 'Type', 'Lines'];
+    if (gc) headers.push('Graph context');
+    if (attr) headers.push('Who to ask');
+    L.push(`| ${headers.join(' | ')} |`);
+    L.push(`|${headers.map((h) => (h === 'Lines' ? '-----:' : '---')).join('|')}|`);
+    for (const g of items.slice(0, 50)) {
+      const cells = [`\`${g.path}\``, g.type, String(g.lines)];
+      if (gc) cells.push(formatGraphContextCell(gc.contexts[locationKey(g.path)]));
+      if (attr) cells.push(formatAttributionCell(attr.attributions[locationKey(g.path)]));
+      L.push(`| ${cells.join(' | ')} |`);
+    }
+    if (items.length > 50) {
+      L.push(
+        `| … and ${items.length - 50} more |${headers
+          .slice(1)
+          .map(() => ' |')
+          .join('')}`,
+      );
     }
     L.push('');
   }

--- a/src/attribution/attribute.ts
+++ b/src/attribution/attribute.ts
@@ -1,0 +1,201 @@
+/**
+ * Finding attribution — "who to ask" about a finding, grounded in the
+ * active-owner model. The OPT-IN historical counterpart to net-new
+ * attribution (a net-new finding's introducer is the PR's own commits;
+ * that needs no blame). This module answers it for pre-existing findings
+ * via `git blame`, then routes through who is still active.
+ *
+ * Honesty: `git blame` reports who LAST TOUCHED a line, not necessarily who
+ * introduced the finding — a formatter run or a move reassigns it. The
+ * provenance line states this; the routing softens it by pointing at the
+ * current owner when the blamed author has left.
+ *
+ * Privacy: emails are the internal join key only. Rendered output is the
+ * display name + GitHub @handle, never a raw email (same posture as the
+ * ownership model).
+ *
+ * Shape mirrors `explore/finding-context.ts` so threading `--attribute`
+ * through the detailed reports is identical to `--graph-context`.
+ */
+import { execSync } from 'child_process';
+import {
+  gatherActiveEmails,
+  ownersFor,
+  handleFromEmail,
+  type FileOwner,
+} from '../analyzers/developer/ownership';
+import { normalizeEmail } from '../analyzers/developer/gather';
+import { locationKey } from '../explore/finding-context';
+
+/** Attribution for one finding location. */
+export interface FindingAttribution {
+  /** Display name — the author who last touched the line (line-level
+   *  findings) or the file's current owner (file-level findings). */
+  readonly author: string;
+  /** GitHub @handle when resolvable offline. */
+  readonly handle?: string;
+  /** Short commit sha that last touched the line. Absent for file-level
+   *  (owner-based) attribution, which has no single introducing commit. */
+  readonly commit?: string;
+  /** Whether that person is still active repo-wide. */
+  readonly active: boolean;
+  /** Line-level: when the blamed author is inactive, the current active
+   *  owner of the file to ask instead. Absent for file-level attribution
+   *  (the author IS the current owner). */
+  readonly currentOwner?: { name: string; handle?: string };
+  /** True when this is file-level (owner-based) rather than blame-based. */
+  readonly fileLevel?: boolean;
+}
+
+export interface DetailedAttribution {
+  /** Keyed by `locationKey(file, line)`; only resolved locations present. */
+  readonly attributions: Record<string, FindingAttribution>;
+}
+
+export interface BuildAttributionOptions {
+  /** Budget cap on unique locations blamed (each is a git call). */
+  readonly maxFindings?: number;
+  /** Active-window for "still around to ask." Default 6 months. */
+  readonly activeSince?: string;
+  readonly now?: Date;
+}
+
+interface BlameLine {
+  readonly author: string;
+  readonly email: string;
+  readonly commit: string;
+}
+
+/** Parse `git blame --porcelain -L n,n` output for the author + commit of a
+ *  single line. Pure — exported for tests. Returns `null` when the porcelain
+ *  has no author (empty / error). */
+export function parseBlamePorcelain(out: string): BlameLine | null {
+  const lines = out.split('\n');
+  const commit = lines[0]?.split(' ')[0];
+  let author = '';
+  let email = '';
+  for (const l of lines) {
+    if (l.startsWith('author ')) author = l.slice('author '.length).trim();
+    else if (l.startsWith('author-mail '))
+      email = l.slice('author-mail '.length).trim().replace(/^<|>$/g, '');
+  }
+  if (!commit || !author) return null;
+  return { author, email, commit: commit.slice(0, 8) };
+}
+
+function blameLine(cwd: string, file: string, line: number): BlameLine | null {
+  try {
+    const out = execSync(
+      `git blame --porcelain -L ${line},${line} -- '${file.replace(/'/g, "'\\''")}'`,
+      { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    return parseBlamePorcelain(out);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build per-finding attribution for a list of locations. Fail-open: returns
+ * `undefined` when git produces nothing usable. Only locations with a `line`
+ * are blamed (a file-level finding has no single line to attribute).
+ */
+export function buildAttributionMap(
+  cwd: string,
+  locations: ReadonlyArray<{ file: string; line?: number }>,
+  opts: BuildAttributionOptions = {},
+): DetailedAttribution | undefined {
+  const max = opts.maxFindings ?? 200;
+  const now = opts.now ?? new Date();
+  const activeEmails = gatherActiveEmails(cwd, opts.activeSince ?? '6 months ago');
+
+  const attributions: Record<string, FindingAttribution> = {};
+  const currentOwnerCache = new Map<string, { name: string; handle?: string } | undefined>();
+  let blamed = 0;
+
+  for (const loc of locations) {
+    if (blamed >= max) break;
+    const key = locationKey(loc.file, loc.line);
+    if (key in attributions) continue;
+
+    // File-level finding (no line, e.g. a test gap): attribute to the
+    // file's current active owner — "who should test/own this," not who
+    // wrote a specific line.
+    if (typeof loc.line !== 'number') {
+      if (!currentOwnerCache.has(loc.file)) {
+        currentOwnerCache.set(loc.file, topActiveOwner(cwd, loc.file, now));
+      }
+      const owner = currentOwnerCache.get(loc.file);
+      if (owner) {
+        attributions[key] = {
+          author: owner.name,
+          ...(owner.handle ? { handle: owner.handle } : {}),
+          active: true,
+          fileLevel: true,
+        };
+      }
+      continue;
+    }
+
+    const bl = blameLine(cwd, loc.file, loc.line);
+    blamed++;
+    if (!bl) continue;
+
+    const active = activeEmails.has(normalizeEmail(bl.email));
+    const handle = handleFromEmail(bl.email);
+    let currentOwner: { name: string; handle?: string } | undefined;
+    if (!active) {
+      if (!currentOwnerCache.has(loc.file)) {
+        currentOwnerCache.set(loc.file, topActiveOwner(cwd, loc.file, now));
+      }
+      currentOwner = currentOwnerCache.get(loc.file);
+    }
+
+    attributions[key] = {
+      author: bl.author,
+      ...(handle ? { handle } : {}),
+      commit: bl.commit,
+      active,
+      ...(currentOwner ? { currentOwner } : {}),
+    };
+  }
+
+  if (Object.keys(attributions).length === 0) return undefined;
+  return { attributions };
+}
+
+function topActiveOwner(
+  cwd: string,
+  file: string,
+  now: Date,
+): { name: string; handle?: string } | undefined {
+  const owners = ownersFor(cwd, [file], { now });
+  const top = owners.ranked.find((o: FileOwner) => o.active);
+  if (!top) return undefined;
+  return { name: top.name, ...(top.githubHandle ? { handle: top.githubHandle } : {}) };
+}
+
+/** Compact cell rendering — name/@handle, never email. `—` when unresolved. */
+export function formatAttributionCell(attr: FindingAttribution | undefined): string {
+  if (!attr) return '—';
+  const who = attr.handle ? `@${attr.handle}` : attr.author;
+  if (attr.fileLevel) return `${who} (owner)`;
+  if (attr.active) return `${who} (active)`;
+  if (attr.currentOwner) {
+    const owner = attr.currentOwner.handle
+      ? `@${attr.currentOwner.handle}`
+      : attr.currentOwner.name;
+    return `${who} (inactive) → ask ${owner}`;
+  }
+  return `${who} (inactive)`;
+}
+
+/** Provenance + honesty line printed above an attributed section. */
+export function attributionProvenanceLine(): string {
+  return (
+    `_"Who to ask" is the author who LAST TOUCHED the line (\`git blame\`), not ` +
+    `necessarily who introduced the finding — a formatter run or a move can reassign ` +
+    `it. An inactive author is routed to the file's current active owner. Names + ` +
+    `GitHub @handles only; never emails._`
+  );
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,6 +137,11 @@ function printUsage(): void {
                                  (hot-files / entry-points / file / feature / communities / api-surface / context)
     vyuh-dxkit context <query>   Slim structural slice for a query — token-efficient
                                  codebase context for LLMs (--budget / --depth / --substring / --json)
+    vyuh-dxkit reviewers [--base <ref>|--staged] [--limit N] [--json]
+                                 Suggest reviewers for the change — active-owner model
+                                 (recency-weighted git history, bots + departed devs
+                                 filtered, excludes the author) blended with CODEOWNERS,
+                                 with a bus-factor signal. Names + @handles, never emails.
     vyuh-dxkit to-xlsx <json>    Convert a dxkit JSON report to 15-col XLSX
     vyuh-dxkit tools [path]      Show required analysis tools status
     vyuh-dxkit tools install     Interactively install missing tools
@@ -329,6 +334,9 @@ export async function run(argv: string[]): Promise<void> {
       limit: { type: 'string' },
       refresh: { type: 'boolean', default: false },
       substring: { type: 'boolean', default: false },
+      // reviewers flags
+      staged: { type: 'boolean', default: false },
+      base: { type: 'string' },
       // context flags
       budget: { type: 'string' },
       depth: { type: 'string' },
@@ -1998,6 +2006,19 @@ export async function run(argv: string[]): Promise<void> {
         fingerprint: values.fingerprint as string | undefined,
         about: values.about as string | undefined,
         noBrowser: !!values['no-browser'],
+      });
+      break;
+    }
+
+    case 'reviewers': {
+      const { runReviewers } = await import('./reviewers-cli');
+      const limitRaw = values.limit as string | undefined;
+      const limit = limitRaw ? parseInt(limitRaw, 10) : undefined;
+      runReviewers(cwd, {
+        base: values.base as string | undefined,
+        staged: !!values.staged,
+        json: !!values.json,
+        ...(Number.isFinite(limit) ? { limit } : {}),
       });
       break;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,6 +70,23 @@ async function buildGraphContextIfRequested(
   return gc;
 }
 
+async function buildAttributionIfRequested(
+  enabled: boolean,
+  cwd: string,
+  locations: ReadonlyArray<{ file: string; line?: number }>,
+) {
+  if (!enabled) return undefined;
+  const { buildAttributionMap } = await import('./attribution/attribute');
+  const attr = buildAttributionMap(cwd, locations);
+  if (!attr) {
+    logger.dim('--attribute: no attributable locations (git blame produced nothing) — skipped.');
+    return undefined;
+  }
+  const n = Object.keys(attr.attributions).length;
+  logger.dim(`--attribute: "who to ask" attached to ${n}/${locations.length} finding location(s).`);
+  return attr;
+}
+
 /**
  * Apply `--fail-on-score` to a higher-is-better score. Exits with
  * code 1 + a logged reason when the gate fires. Skips when the user
@@ -234,6 +251,11 @@ function printUsage(): void {
     --graph-context   Vulnerabilities/test-gaps/quality: attach per-finding graph context
                       (module + blast radius) to the detailed report. Needs a graph.json
                       (run health first); fail-open — skipped silently if absent.
+    --attribute       Vulnerabilities/test-gaps/quality: attach a "who to ask" column to
+                      the detailed report (git blame → active-owner model; inactive authors
+                      routed to the current owner). Names + @handles, never emails. Opt-in;
+                      fail-open. Historical only — net-new findings are introduced by your
+                      own change.
     --xlsx            Licenses/bom: also write 15-col BOM XLSX
     --since           Dev-report: start date (YYYY-MM-DD)
     --filter          Bom: 'all' (default) or 'top-level' (keeps only root manifest deps;
@@ -342,6 +364,8 @@ export async function run(argv: string[]): Promise<void> {
       depth: { type: 'string' },
       // graph-context enrichment for detailed reports (vuln/test-gaps/quality)
       'graph-context': { type: 'boolean', default: false },
+      // attribution enrichment for detailed reports — "who to ask" (opt-in)
+      attribute: { type: 'boolean', default: false },
       // ingest flags (external SAST engines → .dxkit/external snapshots)
       sarif: { type: 'string' },
       'from-snyk': { type: 'boolean', default: false },
@@ -842,12 +866,18 @@ export async function run(argv: string[]): Promise<void> {
         // D032 (2.4.7): detailed JSON + MD always written so dashboard finds fresh inputs.
         const { buildSecurityDetailed, formatSecurityDetailedMarkdown } =
           await import('./analyzers/security/detailed');
+        const securityLocations = report.findings.map((f) => ({ file: f.file, line: f.line }));
         const graphContext = await buildGraphContextIfRequested(
           !!values['graph-context'],
           targetPath,
-          report.findings.map((f) => ({ file: f.file, line: f.line })),
+          securityLocations,
         );
-        const securityDetailed = buildSecurityDetailed(report, graphContext);
+        const securityAttribution = await buildAttributionIfRequested(
+          !!values.attribute,
+          targetPath,
+          securityLocations,
+        );
+        const securityDetailed = buildSecurityDetailed(report, graphContext, securityAttribution);
         const securityDetailedJsonPath = path.join(
           reportDir,
           `vulnerability-scan-${date}-detailed.json`,
@@ -968,7 +998,16 @@ export async function run(argv: string[]): Promise<void> {
           targetPath,
           report.gaps.map((g) => ({ file: g.path })),
         );
-        const testGapsDetailed = buildTestGapsDetailed(report, testGapsGraphContext);
+        const testGapsAttribution = await buildAttributionIfRequested(
+          !!values.attribute,
+          targetPath,
+          report.gaps.map((g) => ({ file: g.path })),
+        );
+        const testGapsDetailed = buildTestGapsDetailed(
+          report,
+          testGapsGraphContext,
+          testGapsAttribution,
+        );
         const testGapsDetailedJsonPath = path.join(reportDir, `test-gaps-${date}-detailed.json`);
         const testGapsDetailedMdPath = path.join(reportDir, `test-gaps-${date}-detailed.md`);
         fs.writeFileSync(
@@ -1068,14 +1107,25 @@ export async function run(argv: string[]): Promise<void> {
         // D032 (2.4.7): detailed JSON + MD always written so dashboard finds fresh inputs.
         const { buildQualityDetailed, formatQualityDetailedMarkdown } =
           await import('./analyzers/quality/detailed');
+        const qualityLocations = [
+          ...(report.metrics.topConsoleFiles ?? []),
+          ...(report.metrics.topTodoFiles ?? []),
+        ].map((f) => ({ file: f.file }));
         const qualityGraphContext = await buildGraphContextIfRequested(
           !!values['graph-context'],
           targetPath,
-          [...(report.metrics.topConsoleFiles ?? []), ...(report.metrics.topTodoFiles ?? [])].map(
-            (f) => ({ file: f.file }),
-          ),
+          qualityLocations,
         );
-        const qualityDetailed = buildQualityDetailed(report, qualityGraphContext);
+        const qualityAttribution = await buildAttributionIfRequested(
+          !!values.attribute,
+          targetPath,
+          qualityLocations,
+        );
+        const qualityDetailed = buildQualityDetailed(
+          report,
+          qualityGraphContext,
+          qualityAttribution,
+        );
         const qualityDetailedJsonPath = path.join(
           reportDir,
           `quality-review-${date}-detailed.json`,

--- a/src/reviewers-cli.ts
+++ b/src/reviewers-cli.ts
@@ -1,0 +1,278 @@
+/**
+ * `vyuh-dxkit reviewers` — suggest reviewers for a change, grounded on the
+ * active-owner model (dev-report git history) rather than naive last-touch
+ * blame, blended with CODEOWNERS.
+ *
+ * The differentiation over a platform's built-in suggested-reviewers: the
+ * candidates are activity-weighted (recent, sustained work ranks highest),
+ * scoped to who is still active (a departed owner is never silently
+ * suggested), bot-free, exclude the change's own author, and carry a
+ * bus-factor signal. CODEOWNERS, when present, is authoritative and merged
+ * in. Output renders names + GitHub @handles — never raw emails.
+ *
+ * Pure helpers (`parseCodeowners`, `matchCodeowners`, `buildSuggestions`)
+ * are unit-tested without git; `runReviewers` is the IO entry point.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import * as logger from './logger';
+import { ownersFor, type OwnershipResult } from './analyzers/developer/ownership';
+import { normalizeEmail } from './analyzers/developer/gather';
+
+export interface CodeownersRule {
+  /** The path pattern (gitignore-ish). */
+  readonly pattern: string;
+  /** Owner tokens — `@handle`, `@org/team`, or an email. */
+  readonly owners: ReadonlyArray<string>;
+}
+
+/**
+ * Parse a CODEOWNERS file. Each non-comment line is `<pattern> <owner>...`.
+ * Returns rules in file order; CODEOWNERS semantics are "last matching rule
+ * wins," so callers iterate in reverse.
+ */
+export function parseCodeowners(content: string): CodeownersRule[] {
+  const rules: CodeownersRule[] = [];
+  for (const raw of content.split(/\r?\n/)) {
+    const line = raw.replace(/#.*$/, '').trim();
+    if (!line) continue;
+    const parts = line.split(/\s+/);
+    const pattern = parts[0];
+    const owners = parts.slice(1).filter(Boolean);
+    if (pattern && owners.length > 0) rules.push({ pattern, owners });
+  }
+  return rules;
+}
+
+/** Translate a CODEOWNERS pattern to a RegExp (subset: `*`, `**`, leading
+ *  `/`, trailing `/`). Good enough for the common cases; unmatched exotic
+ *  globs simply don't match (conservative — never over-claims ownership). */
+function patternToRegExp(pattern: string): RegExp {
+  let p = pattern;
+  const anchored = p.startsWith('/');
+  if (anchored) p = p.slice(1);
+  const dirOnly = p.endsWith('/');
+  if (dirOnly) p = p.slice(0, -1);
+  // Tokenize so `**` -> `.*` and `*` -> `[^/]*` without a fragile placeholder;
+  // every other regex-special char is escaped.
+  let body = '';
+  for (let i = 0; i < p.length; i++) {
+    const c = p[i];
+    if (c === '*') {
+      if (p[i + 1] === '*') {
+        body += '.*';
+        i++;
+      } else {
+        body += '[^/]*';
+      }
+    } else if (/[.+^${}()|[\]\\?]/.test(c)) {
+      body += '\\' + c;
+    } else {
+      body += c;
+    }
+  }
+  const full = dirOnly ? `${body}/.*` : `${body}(?:/.*)?`;
+  return new RegExp(anchored ? `^${full}$` : `(?:^|/)${full}$`);
+}
+
+/** Owners for one file: the LAST matching CODEOWNERS rule wins. Empty when
+ *  no rule matches. */
+export function matchCodeowners(rules: ReadonlyArray<CodeownersRule>, file: string): string[] {
+  for (let i = rules.length - 1; i >= 0; i--) {
+    if (patternToRegExp(rules[i].pattern).test(file)) return [...rules[i].owners];
+  }
+  return [];
+}
+
+export interface ReviewerSuggestion {
+  /** Display name (from git) or the CODEOWNERS token when git-less. */
+  readonly name: string;
+  /** GitHub @handle when known (offline-resolved or a CODEOWNERS `@handle`). */
+  readonly handle?: string;
+  readonly active: boolean;
+  readonly isCodeowner: boolean;
+  /** Human rationale for the suggestion. */
+  readonly reason: string;
+  readonly score: number;
+}
+
+export interface ReviewersResult {
+  readonly touchedFiles: ReadonlyArray<string>;
+  readonly reviewers: ReadonlyArray<ReviewerSuggestion>;
+  readonly busFactor: number;
+  /** Set when no active git owner was found — suggestions then lean on
+   *  CODEOWNERS / a stated fallback rather than naming someone unreachable. */
+  readonly note?: string;
+}
+
+export interface BuildSuggestionsOptions {
+  readonly limit?: number;
+  /** CODEOWNERS owner tokens matched to the touched files (deduped). */
+  readonly codeowners?: ReadonlyArray<string>;
+}
+
+/**
+ * Compose the active-owner ranking with CODEOWNERS into a ranked reviewer
+ * list. Pure. CODEOWNERS owners are authoritative (always included, flagged);
+ * active git owners follow, ranked by score; inactive owners are dropped from
+ * the suggestion list (they're surfaced only via the `note` fallback).
+ */
+export function buildSuggestions(
+  ownership: OwnershipResult,
+  opts: BuildSuggestionsOptions = {},
+): ReviewersResult & { reviewers: ReviewerSuggestion[] } {
+  const limit = opts.limit ?? 3;
+  const codeowners = dedupe(opts.codeowners ?? []);
+  const out: ReviewerSuggestion[] = [];
+  const seen = new Set<string>();
+
+  // 1. CODEOWNERS first — authoritative.
+  for (const token of codeowners) {
+    const handle = token.startsWith('@') ? token.slice(1) : undefined;
+    const key = token.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({
+      name: token,
+      ...(handle ? { handle } : {}),
+      active: true, // CODEOWNERS is a maintained, current declaration
+      isCodeowner: true,
+      reason: 'listed in CODEOWNERS for the touched paths',
+      score: Number.POSITIVE_INFINITY,
+    });
+  }
+
+  // 2. Active git owners, ranked.
+  const activeOwners = ownership.ranked.filter((o) => o.active);
+  for (const o of activeOwners) {
+    const handle = o.githubHandle;
+    const key = (handle ? `@${handle}` : o.name).toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({
+      name: o.name,
+      ...(handle ? { handle } : {}),
+      active: true,
+      isCodeowner: false,
+      reason: `${o.commits} recent commit${o.commits === 1 ? '' : 's'} to the touched files (last ${o.lastTouched})`,
+      score: o.score,
+    });
+  }
+
+  const reviewers = out.slice(0, limit);
+
+  let note: string | undefined;
+  if (activeOwners.length === 0 && codeowners.length === 0) {
+    note =
+      ownership.ranked.length > 0
+        ? 'Every contributor who has touched these files is inactive — no current owner to suggest. Route by current team ownership.'
+        : 'No git history or CODEOWNERS for the touched files — no reviewer signal.';
+  } else if (activeOwners.length === 0) {
+    note = 'Original authors are inactive — suggesting by CODEOWNERS only.';
+  }
+
+  return {
+    touchedFiles: [],
+    reviewers,
+    busFactor: ownership.busFactor,
+    ...(note ? { note } : {}),
+  };
+}
+
+function dedupe(xs: ReadonlyArray<string>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of xs) {
+    const k = x.toLowerCase();
+    if (!seen.has(k)) {
+      seen.add(k);
+      out.push(x);
+    }
+  }
+  return out;
+}
+
+// ─── IO entry point ─────────────────────────────────────────────────────────
+
+export interface ReviewersOptions {
+  readonly base?: string;
+  readonly staged?: boolean;
+  readonly json?: boolean;
+  readonly limit?: number;
+}
+
+function gitOut(cmd: string, cwd: string): string {
+  try {
+    return execSync(cmd, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function touchedFiles(cwd: string, opts: ReviewersOptions): string[] {
+  if (opts.staged) {
+    return gitOut('git diff --cached --name-only', cwd).split('\n').filter(Boolean);
+  }
+  const base = opts.base || gitOut('git rev-parse --abbrev-ref origin/HEAD', cwd) || 'origin/main';
+  const out = gitOut(`git diff --name-only ${base}...HEAD`, cwd);
+  return out.split('\n').filter(Boolean);
+}
+
+function readCodeowners(cwd: string): CodeownersRule[] {
+  for (const rel of ['.github/CODEOWNERS', 'CODEOWNERS', 'docs/CODEOWNERS']) {
+    const p = path.join(cwd, rel);
+    if (fs.existsSync(p)) return parseCodeowners(fs.readFileSync(p, 'utf8'));
+  }
+  return [];
+}
+
+export function runReviewers(cwd: string, opts: ReviewersOptions): void {
+  const files = touchedFiles(cwd, opts);
+  if (files.length === 0) {
+    logger.info('No changed files detected (pass --base <ref> or --staged). Nothing to suggest.');
+    return;
+  }
+
+  // Exclude the change author from suggestions (never review your own PR).
+  const authorEmail = gitOut('git config --get user.email', cwd);
+  const excludeEmails = authorEmail ? new Set([normalizeEmail(authorEmail)]) : undefined;
+
+  const ownership = ownersFor(cwd, files, { ...(excludeEmails ? { excludeEmails } : {}) });
+
+  // CODEOWNERS owners for the touched files (deduped across files).
+  const rules = readCodeowners(cwd);
+  const coOwners: string[] = [];
+  for (const f of files) coOwners.push(...matchCodeowners(rules, f));
+
+  const result: ReviewersResult = {
+    ...buildSuggestions(ownership, {
+      ...(opts.limit !== undefined ? { limit: opts.limit } : {}),
+      codeowners: coOwners,
+    }),
+    touchedFiles: files,
+  };
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return;
+  }
+
+  logger.info(
+    `Suggested reviewers for ${files.length} changed file${files.length === 1 ? '' : 's'}:`,
+  );
+  if (result.reviewers.length === 0) {
+    logger.info('  (none)');
+  }
+  for (const r of result.reviewers) {
+    const who = r.handle ? `@${r.handle}` : r.name;
+    const tag = r.isCodeowner ? ' [CODEOWNERS]' : '';
+    logger.info(`  ${who}${tag} — ${r.reason}`);
+  }
+  if (result.busFactor === 1) {
+    logger.warn(
+      '  Bus factor 1: a single active owner covers these files — consider spreading knowledge.',
+    );
+  }
+  if (result.note) logger.dim(`  ${result.note}`);
+}

--- a/test/analyzers/developer/ownership.test.ts
+++ b/test/analyzers/developer/ownership.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  rankOwners,
+  handleFromEmail,
+  type CommitTouch,
+} from '../../../src/analyzers/developer/ownership';
+
+const NOW = new Date('2026-06-09T00:00:00Z');
+
+function touch(name: string, email: string, daysAgo: number): CommitTouch {
+  const d = new Date(NOW.getTime() - daysAgo * 24 * 60 * 60 * 1000);
+  return { name, email, dateISO: d.toISOString() };
+}
+
+describe('handleFromEmail', () => {
+  it('extracts the login from a GitHub noreply email', () => {
+    expect(handleFromEmail('octocat@users.noreply.github.com')).toBe('octocat');
+    expect(handleFromEmail('12345+octocat@users.noreply.github.com')).toBe('octocat');
+  });
+  it('returns undefined for a real email', () => {
+    expect(handleFromEmail('jane@corp.com')).toBeUndefined();
+  });
+});
+
+describe('rankOwners', () => {
+  it('ranks recent, sustained activity above an old single commit', () => {
+    const touches: CommitTouch[] = [
+      touch('Old Hand', 'old@c.com', 900), // one ancient commit
+      touch('Recent A', 'a@c.com', 10),
+      touch('Recent A', 'a@c.com', 20),
+      touch('Recent A', 'a@c.com', 30),
+    ];
+    const active = new Set(['old@c.com', 'a@c.com']);
+    const out = rankOwners(touches, active, { now: NOW });
+    expect(out.ranked[0].name).toBe('Recent A');
+    expect(out.ranked[1].name).toBe('Old Hand');
+  });
+
+  it('marks an author who has gone quiet as inactive (departed)', () => {
+    const touches: CommitTouch[] = [touch('Gone Dev', 'gone@c.com', 800)];
+    const active = new Set<string>(); // not in the recent window
+    const out = rankOwners(touches, active, { now: NOW });
+    expect(out.ranked).toHaveLength(1);
+    expect(out.ranked[0].active).toBe(false);
+    expect(out.allInactive).toBe(true);
+  });
+
+  it('excludes bots from the ranking', () => {
+    const touches: CommitTouch[] = [
+      touch('dependabot[bot]', 'dependabot@github.com', 5),
+      touch('Real Dev', 'real@c.com', 5),
+    ];
+    const out = rankOwners(touches, new Set(['real@c.com']), { now: NOW });
+    expect(out.ranked.map((o) => o.name)).toEqual(['Real Dev']);
+  });
+
+  it('excludes the PR author via excludeEmails (normalized)', () => {
+    const touches: CommitTouch[] = [
+      touch('Author', 'author@c.com', 5),
+      touch('Reviewer', 'rev@c.com', 5),
+    ];
+    const out = rankOwners(touches, new Set(['author@c.com', 'rev@c.com']), {
+      now: NOW,
+      excludeEmails: new Set(['author@c.com']),
+    });
+    expect(out.ranked.map((o) => o.name)).toEqual(['Reviewer']);
+  });
+
+  it('clusters aliases that share a normalized email (incl. noreply +digits)', () => {
+    const touches: CommitTouch[] = [
+      touch('Jane Laptop', 'jane@c.com', 10),
+      touch('Jane Corp', '99+jane@c.com', 5), // normalizes to jane@c.com
+    ];
+    const out = rankOwners(touches, new Set(['jane@c.com']), { now: NOW });
+    expect(out.ranked).toHaveLength(1);
+    expect(out.ranked[0].commits).toBe(2);
+    expect(out.ranked[0].name).toBe('Jane Corp'); // most recent commit's name
+  });
+
+  it('resolves a github handle offline from a noreply alias', () => {
+    const touches: CommitTouch[] = [touch('Octo', 'octo@users.noreply.github.com', 5)];
+    const out = rankOwners(touches, new Set(['octo@users.noreply.github.com']), { now: NOW });
+    expect(out.ranked[0].githubHandle).toBe('octo');
+    // email is the internal key; handle is the renderable identity
+    expect(out.ranked[0].email).toBe('octo@users.noreply.github.com');
+  });
+
+  it('computes bus factor over ACTIVE owners only', () => {
+    // One dominant active owner → bus factor 1 (single point of failure).
+    const touches: CommitTouch[] = [
+      ...Array.from({ length: 8 }, (_, i) => touch('Dominant', 'dom@c.com', 5 + i)),
+      touch('Minor', 'min@c.com', 5),
+    ];
+    const out = rankOwners(touches, new Set(['dom@c.com', 'min@c.com']), { now: NOW });
+    expect(out.busFactor).toBe(1);
+    expect(out.allInactive).toBe(false);
+  });
+
+  it('busFactor is 0 and allInactive true when no owner is active', () => {
+    const touches: CommitTouch[] = [touch('A', 'a@c.com', 400), touch('B', 'b@c.com', 500)];
+    const out = rankOwners(touches, new Set<string>(), { now: NOW });
+    expect(out.busFactor).toBe(0);
+    expect(out.allInactive).toBe(true);
+  });
+});

--- a/test/attribution.test.ts
+++ b/test/attribution.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseBlamePorcelain,
+  formatAttributionCell,
+  attributionProvenanceLine,
+  type FindingAttribution,
+} from '../src/attribution/attribute';
+
+describe('parseBlamePorcelain', () => {
+  it('extracts author + email + short commit', () => {
+    const out = [
+      'a1b2c3d4e5f6 12 12 1',
+      'author Jane Doe',
+      'author-mail <jane@corp.com>',
+      'author-time 1700000000',
+      '\tconst x = 1;',
+    ].join('\n');
+    const bl = parseBlamePorcelain(out);
+    expect(bl).toEqual({ author: 'Jane Doe', email: 'jane@corp.com', commit: 'a1b2c3d4' });
+  });
+
+  it('returns null when there is no author', () => {
+    expect(parseBlamePorcelain('')).toBeNull();
+    expect(parseBlamePorcelain('justonewordnoauthor')).toBeNull();
+  });
+});
+
+describe('formatAttributionCell', () => {
+  const base: FindingAttribution = { author: 'Jane', commit: 'abc12345', active: true };
+
+  it('renders an active author by handle', () => {
+    expect(formatAttributionCell({ ...base, handle: 'jane' })).toBe('@jane (active)');
+  });
+
+  it('falls back to display name when no handle', () => {
+    expect(formatAttributionCell(base)).toBe('Jane (active)');
+  });
+
+  it('routes an inactive author to the current owner', () => {
+    expect(
+      formatAttributionCell({
+        author: 'Gone',
+        commit: 'abc',
+        active: false,
+        currentOwner: { name: 'Carol', handle: 'carol' },
+      }),
+    ).toBe('Gone (inactive) → ask @carol');
+  });
+
+  it('marks an inactive author with no current owner', () => {
+    expect(formatAttributionCell({ author: 'Gone', commit: 'abc', active: false })).toBe(
+      'Gone (inactive)',
+    );
+  });
+
+  it('renders a file-level owner attribution', () => {
+    expect(
+      formatAttributionCell({ author: 'Owner', handle: 'owner', active: true, fileLevel: true }),
+    ).toBe('@owner (owner)');
+  });
+
+  it('renders a dash for an unresolved location', () => {
+    expect(formatAttributionCell(undefined)).toBe('—');
+  });
+
+  it('never renders an email', () => {
+    const cell = formatAttributionCell({ ...base, handle: 'jane' });
+    expect(cell).not.toContain('@corp.com');
+  });
+});
+
+describe('attributionProvenanceLine', () => {
+  it('states the last-touch honesty caveat + no-emails posture', () => {
+    const line = attributionProvenanceLine();
+    expect(line).toMatch(/last touched/i);
+    expect(line).toMatch(/handle/i);
+    expect(line).toMatch(/never emails/i);
+  });
+});

--- a/test/reviewers.test.ts
+++ b/test/reviewers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { parseCodeowners, matchCodeowners, buildSuggestions } from '../src/reviewers-cli';
+import type { OwnershipResult, FileOwner } from '../src/analyzers/developer/ownership';
+
+function owner(p: Partial<FileOwner> & { name: string }): FileOwner {
+  return {
+    email: `${p.name.toLowerCase()}@c.com`,
+    commits: 1,
+    lastTouched: '2026-06-01',
+    active: true,
+    score: 1,
+    ...p,
+  };
+}
+
+function ownership(ranked: FileOwner[], busFactor = 1): OwnershipResult {
+  return { ranked, busFactor, allInactive: ranked.every((o) => !o.active) };
+}
+
+describe('parseCodeowners + matchCodeowners', () => {
+  const rules = parseCodeowners(
+    ['# comment', '* @org/default', '/src/payments/ @alice @bob', '*.md @docs-team'].join('\n'),
+  );
+
+  it('parses pattern + owners, skips comments', () => {
+    expect(rules).toHaveLength(3);
+    expect(rules[1]).toEqual({ pattern: '/src/payments/', owners: ['@alice', '@bob'] });
+  });
+
+  it('last matching rule wins', () => {
+    expect(matchCodeowners(rules, 'src/payments/refund.ts')).toEqual(['@alice', '@bob']);
+    expect(matchCodeowners(rules, 'README.md')).toEqual(['@docs-team']);
+    expect(matchCodeowners(rules, 'src/other/x.ts')).toEqual(['@org/default']);
+  });
+});
+
+describe('buildSuggestions', () => {
+  it('puts CODEOWNERS first (authoritative), then active git owners', () => {
+    const out = buildSuggestions(
+      ownership([owner({ name: 'Carol', githubHandle: 'carol', score: 5 })]),
+      { codeowners: ['@alice'] },
+    );
+    expect(out.reviewers[0]).toMatchObject({ handle: 'alice', isCodeowner: true });
+    expect(out.reviewers[1]).toMatchObject({ handle: 'carol', isCodeowner: false });
+  });
+
+  it('drops inactive owners from suggestions but notes the fallback', () => {
+    const out = buildSuggestions(ownership([owner({ name: 'Gone', active: false })]));
+    expect(out.reviewers).toHaveLength(0);
+    expect(out.note).toMatch(/inactive/i);
+  });
+
+  it('honors the limit', () => {
+    const out = buildSuggestions(
+      ownership([
+        owner({ name: 'A', githubHandle: 'a', score: 3 }),
+        owner({ name: 'B', githubHandle: 'b', score: 2 }),
+        owner({ name: 'C', githubHandle: 'c', score: 1 }),
+      ]),
+      { limit: 2 },
+    );
+    expect(out.reviewers).toHaveLength(2);
+    expect(out.reviewers.map((r) => r.handle)).toEqual(['a', 'b']);
+  });
+
+  it('dedupes a CODEOWNER who is also a git owner', () => {
+    const out = buildSuggestions(
+      ownership([owner({ name: 'alice', githubHandle: 'alice', score: 5 })]),
+      { codeowners: ['@alice'] },
+    );
+    expect(out.reviewers.filter((r) => r.handle === 'alice')).toHaveLength(1);
+    expect(out.reviewers[0].isCodeowner).toBe(true);
+  });
+
+  it('never renders an email — only name/handle surface', () => {
+    const out = buildSuggestions(ownership([owner({ name: 'Dave', githubHandle: 'dave' })]));
+    const blob = JSON.stringify(out.reviewers);
+    expect(blob).not.toContain('@c.com');
+  });
+});


### PR DESCRIPTION
Connect findings and PRs to the people who know the code, on a shared **active-owner model**. Rebase-merge candidate (atomic commits).

## What's in it

- **`ownership.ts` core** — given files, rank active contributors: recency-weighted git history, bots + departed devs filtered, author-excluded, bus-factor + all-inactive signals. Pure `rankOwners` (10 edge-case unit tests) + a git wrapper. Email is the internal key only; output is name + GitHub @handle (offline-resolved from noreply emails).
- **`vyuh-dxkit reviewers`** (`--base`/`--staged`/`--limit`/`--json`) — owner-grounded reviewer suggestions blended with CODEOWNERS, bus-factor warning, inactive-owner fallback. Beats naive last-touch blame. `dxkit-pr` consumes it.
- **`--attribute` "who to ask"** on the detailed vuln / test-gaps / quality reports — line-level findings git-blamed + routed through the owner model (inactive → current owner); file-level (test gaps) → file owner. Opt-in, historical only (net-new = the PR author). Findings tables are now column-driven so graph-context + attribution compose.

## Privacy

Author emails are an internal join key only — never rendered. All user-facing output is a display name or @handle (the @handle is privacy-safe *and* @-mentionable / feeds `gh --reviewer`).

## Edge cases (handled, tested)

Author exclusion · departed contributors (active-window scoping + fallback note) · bot/automation exclusion · recency weighting · bus-factor / single-point-of-failure · all-inactive fallback. CODEOWNERS last-match-wins.

## Testing

Affected-scope green locally (ownership 10, reviewers 7, attribution 9, + the detailed-report renderer suites confirm the column-driven refactor is behavior-preserving) + `typecheck:test`. Real-repo smoke test confirmed git blame + owner attribution end-to-end. Full suite + cross-ecosystem matrix runs here in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)