### PR TITLE
Release 2.10.0 — honest scoring under changing scanners, passive graph delivery, tool robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,28 +24,28 @@ a dxkit upgrade, and 7 of "8 CRITICAL" secrets were their own allowlisted unit-t
 fixtures. The score wasn't wrong — the measurement got more honest — but nothing
 in the output explained that. These close the explanation gap.
 
-- **Symmetric unavailable-scanner caps (C-D1).** A missing dependency-audit
+- **Symmetric unavailable-scanner caps.** A missing dependency-audit
   already capped the Security score at the uncertainty tier, but missing
   secret/code-pattern scanners silently scored as "0 findings" — so enabling
   those scanners later read as a phantom regression. The secret and code-pattern
   axes now get the same uncertainty cap when their scan didn't run, surfaced in
   `metrics.toolsUnavailable` and the standalone vuln-scan report.
-- **Allowlisted findings are marked in reports (C-D2).** The vulnerability report
+- **Allowlisted findings are marked in reports.** The vulnerability report
   and dashboard now annotate findings covered by an active allowlist entry and
   render `Subtotal N (M allowlisted)`, so reviewed-and-accepted fixtures no longer
   read as unexplained headline criticals. Raw counts and the score are unchanged
   — only the presentation gains the disclosure.
-- **Scanner-coverage drift is disclosed (C-D3).** When the active scanner set grew
+- **Scanner-coverage drift is disclosed.** When the active scanner set grew
   since the last run, the vuln-scan report leads with a note: findings the new
   scanners surface are newly **visible**, not newly **introduced**. This is the
   root-cause explanation for a score that moved on unchanged code.
-- **Test-fixture credentials are downgraded (C-D4).** Generic hardcoded-credential
+- **Test-fixture credentials are downgraded.** Generic hardcoded-credential
   matches inside test files (classified via the active language packs' test
   patterns) are downgraded to low severity + a `test-fixture` category and
   excluded from the committed-credentials trust-broken cap. They stay visible but
   never headline-critical. Real branded tokens (AWS keys, PATs, private keys) keep
   full severity everywhere — a live credential in a test is still a leak.
-- **Windows dep-audit EPERM (C-D5).** The osv-scanner-fix temp-dir cleanup now
+- **Windows dep-audit EPERM.** The osv-scanner-fix temp-dir cleanup now
   retries with backoff and never throws out of its `finally`, so a Windows handle
   race (npm-install grandchildren / antivirus) can no longer discard the
   already-parsed fix plans — the failure that left a customer's dependency vulns
@@ -81,7 +81,7 @@ defects surfaced while benchmarking on Python 3.14 and large real-world repos.
 
 #### Fixed
 
-- **graphify on Python 3.14 (D-01).** Python 3.14 made `forkserver` the default
+- **graphify on Python 3.14.** Python 3.14 made `forkserver` the default
   multiprocessing start method on Linux. graphify parallelises extraction with a
   `ProcessPoolExecutor`, and under spawn/forkserver each worker re-imports the
   generated script — re-running top-level extraction and crashing the run (no
@@ -92,7 +92,7 @@ defects surfaced while benchmarking on Python 3.14 and large real-world repos.
   (Linux fork/forkserver, macOS/Windows spawn) while keeping multi-core
   extraction. The previous forced `set_start_method('fork')` workaround is
   removed.
-- **graphify cache redirect (D-02).** The on-disk cache is now redirected via
+- **graphify cache redirect.** The on-disk cache is now redirected via
   graphify's public `extract(cache_root=...)` parameter instead of
   monkeypatching the internal `graphify.cache.cache_dir`, whose signature
   changed in graphifyy 0.8 (`cache_dir(root)` → `cache_dir(root, kind)`) and
@@ -100,10 +100,10 @@ defects surfaced while benchmarking on Python 3.14 and large real-world repos.
   writing a stray `graphify-out/` into the scanned repo. The temp cache lives
   under the caller-owned script dir and is reclaimed after the process (and its
   atexit handlers) exit. `graphifyy` is pinned to `0.8.36`.
-- **jscpd version pin (E-01).** jscpd is pinned to `4.2.5`. jscpd 5.x is a Rust
+- **jscpd version pin.** jscpd is pinned to `4.2.5`. jscpd 5.x is a Rust
   rewrite that dropped the `--gitignore` flag (dxkit passed it → exit 2) and
   changed the report JSON schema dxkit parses.
-- **Guardrail matcher — whole-file rename relocation (D-03).** Renaming a source
+- **Guardrail matcher — whole-file rename relocation.** Renaming a source
   file no longer reports its whole-file findings (test-gap, coverage-gap,
   test-file-degradation, god-file, stale-file, large-file) as removed + added,
   which falsely blocked the guardrail on a pure rename. The git-aware matcher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,11 @@ close that gap.
   matcher can't tell a throwaway fixture from a real secret leaked into a test, so
   lowering severity by path would silently hide genuine leaks. Test-file noise is
   managed by the allowlist score-lift above (review fixtures once with
-  `--category test-fixture`), not by hiding.
+  `--category test-fixture`), not by hiding. The vulnerability report now flags how
+  many secret findings sit in test files and points fixtures at the allowlist; the
+  `dxkit-action` and `dxkit-allowlist` skills gain an explicit triage step
+  (confirm fixture vs. real, allowlist fakes, rotate reals) so an agent handles
+  this judgment per finding rather than blanket-ignoring the test directory.
 - **Systematic test-file detection.** Tests organized under Jest's `__tests__/`
   directory — or named with the widespread `.unit.` / `.e2e.` / `.cy.` suffixes —
   were classified as source, corrupting the test ratio, coverage, and test-gap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.5] - 2026-06-12
+
+### Tool-robustness + matcher rename fixes
+
+Hardening pass closing a set of brownfield-install and guardrail-matcher
+defects surfaced while benchmarking on Python 3.14 and large real-world repos.
+
+#### Fixed
+
+- **graphify on Python 3.14 (D-01).** Python 3.14 made `forkserver` the default
+  multiprocessing start method on Linux. graphify parallelises extraction with a
+  `ProcessPoolExecutor`, and under spawn/forkserver each worker re-imports the
+  generated script — re-running top-level extraction and crashing the run (no
+  `.dxkit/reports/graph.json` written; every graph-dependent feature silently
+  degraded). The generated script now wraps its execution body in
+  `if __name__ == '__main__'` — graphify's own documented requirement for
+  parallel extraction — so it is correct on every platform and start method
+  (Linux fork/forkserver, macOS/Windows spawn) while keeping multi-core
+  extraction. The previous forced `set_start_method('fork')` workaround is
+  removed.
+- **graphify cache redirect (D-02).** The on-disk cache is now redirected via
+  graphify's public `extract(cache_root=...)` parameter instead of
+  monkeypatching the internal `graphify.cache.cache_dir`, whose signature
+  changed in graphifyy 0.8 (`cache_dir(root)` → `cache_dir(root, kind)`) and
+  crashed the run. This also stops graphify's `atexit` stat-index flush from
+  writing a stray `graphify-out/` into the scanned repo. The temp cache lives
+  under the caller-owned script dir and is reclaimed after the process (and its
+  atexit handlers) exit. `graphifyy` is pinned to `0.8.36`.
+- **jscpd version pin (E-01).** jscpd is pinned to `4.2.5`. jscpd 5.x is a Rust
+  rewrite that dropped the `--gitignore` flag (dxkit passed it → exit 2) and
+  changed the report JSON schema dxkit parses.
+- **Guardrail matcher — whole-file rename relocation (D-03).** Renaming a source
+  file no longer reports its whole-file findings (test-gap, coverage-gap,
+  test-file-degradation, god-file, stale-file, large-file) as removed + added,
+  which falsely blocked the guardrail on a pure rename. The git-aware matcher
+  now relocates these line-less, file-anchored findings through git's rename
+  detection, keyed on `(renamed-path, kind)` so two different whole-file kinds
+  on the same renamed file never cross-pair.
+
+#### Internal
+
+- New version-pin guard test partitions every registry tool into pinned /
+  audited-unpinned / package-manager-tracked, so a tool can't be added or
+  un-pinned without a deliberate decision. `semgrep` and nine others remain on
+  the audited-unpinned backlog.
+
 ## [2.9.4] - 2026-06-09
 
 ### Connecting findings + PRs to the people who know the code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.9.5] - 2026-06-12
+## [2.10.0] - 2026-06-13
 
-### Tool-robustness + matcher rename fixes
+### Honest scoring under changing scanners, passive graph delivery, tool-robustness
+
+Closes a set of brownfield-install and guardrail-matcher defects (the original
+2.9.5 hardening), a customer-reported "my score got worse after fixing things"
+class of scoring-honesty bugs, a defensive tool-version-pin sweep, and the
+agentic-delivery redesign that finally routes the code graph to the agent in a
+real fix workflow.
+
+#### Scoring honesty (customer-reported)
+
+A customer saw their Security score drop 65 → 40 on an **unchanged commit** after
+a dxkit upgrade, and 7 of "8 CRITICAL" secrets were their own allowlisted unit-test
+fixtures. The score wasn't wrong — the measurement got more honest — but nothing
+in the output explained that. These close the explanation gap.
+
+- **Symmetric unavailable-scanner caps (C-D1).** A missing dependency-audit
+  already capped the Security score at the uncertainty tier, but missing
+  secret/code-pattern scanners silently scored as "0 findings" — so enabling
+  those scanners later read as a phantom regression. The secret and code-pattern
+  axes now get the same uncertainty cap when their scan didn't run, surfaced in
+  `metrics.toolsUnavailable` and the standalone vuln-scan report.
+- **Allowlisted findings are marked in reports (C-D2).** The vulnerability report
+  and dashboard now annotate findings covered by an active allowlist entry and
+  render `Subtotal N (M allowlisted)`, so reviewed-and-accepted fixtures no longer
+  read as unexplained headline criticals. Raw counts and the score are unchanged
+  — only the presentation gains the disclosure.
+- **Scanner-coverage drift is disclosed (C-D3).** When the active scanner set grew
+  since the last run, the vuln-scan report leads with a note: findings the new
+  scanners surface are newly **visible**, not newly **introduced**. This is the
+  root-cause explanation for a score that moved on unchanged code.
+- **Test-fixture credentials are downgraded (C-D4).** Generic hardcoded-credential
+  matches inside test files (classified via the active language packs' test
+  patterns) are downgraded to low severity + a `test-fixture` category and
+  excluded from the committed-credentials trust-broken cap. They stay visible but
+  never headline-critical. Real branded tokens (AWS keys, PATs, private keys) keep
+  full severity everywhere — a live credential in a test is still a leak.
+- **Windows dep-audit EPERM (C-D5).** The osv-scanner-fix temp-dir cleanup now
+  retries with backoff and never throws out of its `finally`, so a Windows handle
+  race (npm-install grandchildren / antivirus) can no longer discard the
+  already-parsed fix plans — the failure that left a customer's dependency vulns
+  invisible for a week.
+
+#### Passive graph delivery (agentic value)
+
+- **Context-hook fires on the tools agents actually use.** Pre-2.10 the graph
+  context-hook fired only on the native `Grep`/`Glob` tools and only when the
+  search pattern substring-matched a symbol name — so in a real fix workflow
+  (agents search via `Bash grep` for a symptom, and read files directly) it
+  almost never engaged. It now fires on **Read/Edit** (keyed on the file touched
+  → that file's structural summary: symbols, callers, callees, module group),
+  **Bash** (parses grep/rg commands; a named source file delivers its summary,
+  else a symbol match on the pattern), and the original **Grep/Glob** path.
+  Per-session, per-file dedup keeps it cheap; the FAIL-OPEN + ADDITIVE contract is
+  preserved (any problem is a silent no-op). **Existing repos must re-run
+  `vyuh-dxkit init`** (or update `.claude/settings.json`) to pick up the broadened
+  `Read|Edit|Bash|Grep|Glob` matcher.
+
+#### Snyk sync
+
+- **`.dxkit-ignore` → `.snyk` exclude sync.** `allowlist export --snyk` now also
+  emits the paths dxkit's analyzers skip (`.dxkit-ignore`) into the `.snyk`
+  `exclude.global` block, so Snyk and dxkit agree on what's out of scope —
+  mirroring the existing allowlist → `.snyk` ignore sync. An export carrying only
+  exclusions still writes.
+
+#### Tool-robustness + matcher rename fixes
 
 Hardening pass closing a set of brownfield-install and guardrail-matcher
 defects surfaced while benchmarking on Python 3.14 and large real-world repos.
@@ -46,12 +111,26 @@ defects surfaced while benchmarking on Python 3.14 and large real-world repos.
   detection, keyed on `(renamed-path, kind)` so two different whole-file kinds
   on the same renamed file never cross-pair.
 
+#### Tool-version pins
+
+- **Defensive pin sweep.** Nine more dxkit-owned, deterministic-output scanners
+  are pinned to their current releases (semgrep `1.165.0`, ruff `0.15.17`,
+  pip-audit `2.10.1`, pip-licenses `5.5.5`, coverage `7.14.1`,
+  license-checker-rseidelsohn `5.0.1`, golangci-lint `v1.64.8` — the v1 line,
+  since v2 is a breaking rewrite on a separate module path — govulncheck `v1.3.0`,
+  go-licenses `v1.6.0`), so a future breaking major can't silently change parsed
+  output or exit codes the way jscpd 5.x and graphifyy 0.8 did. Five tools stay
+  unpinned by design and are now documented as such: `eslint` + `vitest-coverage`
+  (project-local — the consumer owns the version), `snyk` (a SaaS client that
+  self-manages backend compatibility), `codeql` (a GitHub-managed bundle paired
+  with query packs), and `cloc` (non-semver npm tag, lowest-risk schema). Proper
+  schema-adaptive multi-version handling is planned for a later release.
+
 #### Internal
 
-- New version-pin guard test partitions every registry tool into pinned /
-  audited-unpinned / package-manager-tracked, so a tool can't be added or
-  un-pinned without a deliberate decision. `semgrep` and nine others remain on
-  the audited-unpinned backlog.
+- The version-pin guard test partitions every registry tool into pinned /
+  unpinned-by-design / package-manager-tracked, so a tool can't be added or
+  un-pinned without a deliberate decision.
 
 ## [2.9.4] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Honest scoring under changing scanners, passive graph delivery, tool-robustness
 
 Closes a set of brownfield-install and guardrail-matcher defects (the original
-2.9.5 hardening), a customer-reported "my score got worse after fixing things"
-class of scoring-honesty bugs, a defensive tool-version-pin sweep, and the
-agentic-delivery redesign that finally routes the code graph to the agent in a
-real fix workflow.
+2.9.5 hardening), a class of scoring-honesty bugs (a Security score that could get
+worse on an unchanged commit, with nothing explaining why), a defensive
+tool-version-pin sweep, and the agentic-delivery redesign that finally routes the
+code graph to the agent in a real fix workflow.
 
-#### Scoring honesty (customer-reported)
+#### Scoring honesty
 
-A customer saw their Security score drop 65 → 40 on an **unchanged commit** after
-a dxkit upgrade, and 7 of "8 CRITICAL" secrets were their own allowlisted unit-test
-fixtures. The score wasn't wrong — the measurement got more honest — but nothing
-in the output explained that. These close the explanation gap.
+A Security score could drop on an **unchanged commit** — e.g. after an upgrade
+enabled more scanners, or because a repo's own reviewed-and-accepted findings kept
+holding it at a cap. The measurement was getting more honest, but the output
+didn't explain it, and a properly-triaged repo couldn't recover its score. These
+close that gap.
 
 - **Symmetric unavailable-scanner caps.** A missing dependency-audit
   already capped the Security score at the uncertainty tier, but missing
@@ -30,26 +31,34 @@ in the output explained that. These close the explanation gap.
   those scanners later read as a phantom regression. The secret and code-pattern
   axes now get the same uncertainty cap when their scan didn't run, surfaced in
   `metrics.toolsUnavailable` and the standalone vuln-scan report.
-- **Allowlisted findings are marked in reports.** The vulnerability report
-  and dashboard now annotate findings covered by an active allowlist entry and
-  render `Subtotal N (M allowlisted)`, so reviewed-and-accepted fixtures no longer
-  read as unexplained headline criticals. Raw counts and the score are unchanged
-  — only the presentation gains the disclosure.
+- **The score respects the allowlist.** Findings reviewed-and-accepted as
+  `false-positive` / `test-fixture` are now lifted from the Security penalties and
+  caps (not just the guardrail), so a triaged repo scores honestly instead of
+  staying capped on noise it has already accepted. `accepted-risk` / `deferred` /
+  `mitigated-externally` still count — accepting a real risk can't earn an A. The
+  vulnerability report and dashboard also annotate allowlisted findings and render
+  `Subtotal N (M allowlisted)` so the raw counts are explained, not alarming.
 - **Scanner-coverage drift is disclosed.** When the active scanner set grew
   since the last run, the vuln-scan report leads with a note: findings the new
   scanners surface are newly **visible**, not newly **introduced**. This is the
   root-cause explanation for a score that moved on unchanged code.
-- **Test-fixture credentials are downgraded.** Generic hardcoded-credential
-  matches inside test files (classified via the active language packs' test
-  patterns) are downgraded to low severity + a `test-fixture` category and
-  excluded from the committed-credentials trust-broken cap. They stay visible but
-  never headline-critical. Real branded tokens (AWS keys, PATs, private keys) keep
-  full severity everywhere — a live credential in a test is still a leak.
-- **Windows dep-audit EPERM.** The osv-scanner-fix temp-dir cleanup now
-  retries with backoff and never throws out of its `finally`, so a Windows handle
-  race (npm-install grandchildren / antivirus) can no longer discard the
-  already-parsed fix plans — the failure that left a customer's dependency vulns
-  invisible for a week.
+- **Secret severity is never lowered by file path.** A hardcoded credential keeps
+  its natural severity whether it sits in production code or a test — the generic
+  matcher can't tell a throwaway fixture from a real secret leaked into a test, so
+  lowering severity by path would silently hide genuine leaks. Test-file noise is
+  managed by the allowlist score-lift above (review fixtures once with
+  `--category test-fixture`), not by hiding.
+- **Systematic test-file detection.** Tests organized under Jest's `__tests__/`
+  directory — or named with the widespread `.unit.` / `.e2e.` / `.cy.` suffixes —
+  were classified as source, corrupting the test ratio, coverage, and test-gap
+  analysis. The cross-ecosystem test directories (`__tests__/`, `test/`, `tests/`,
+  `spec/`, `e2e/`) are now recognized in any language; the TS pack gains the
+  co-located suffix conventions.
+- **Dependency-audit cleanup on Windows (EPERM).** The osv-scanner-fix temp-dir
+  cleanup now retries with backoff and never throws out of its `finally`, so a
+  Windows handle race (npm-install grandchildren / antivirus) can no longer
+  discard the already-parsed fix plans — which had let dependency vulnerabilities
+  go silently unreported.
 
 #### Passive graph delivery (agentic value)
 

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -91,9 +91,23 @@ with the Label Contract enforced through caps).
 | CRITICAL dependency vulnerabilities    | -15                  |
 | HIGH dependency vulnerabilities        | -5/-10 by count      |
 
-**Caps:** committed credentials trigger `trust-broken` (40);
-dep-vuln scanner unavailable triggers `uncertainty` (65); any open
+**Caps:** committed credentials trigger `trust-broken` (40); a
+dep-vuln, secret, OR code-pattern scanner that didn't run triggers
+`uncertainty` (65) — every measurement axis is treated the same, so a
+missing scanner never reads as a confident "0 findings"; any open
 HIGH+ code finding triggers `fixable-finding` (79).
+
+**Allowlist and the score.** Penalties and caps count only findings that
+are still _open_. A finding allowlisted as `false-positive` or
+`test-fixture` is declared "not a real finding" and is lifted from the
+Security penalties and caps (not just the guardrail), so a repo that has
+genuinely triaged its noise scores honestly rather than staying capped on
+findings it has already reviewed and accepted. `accepted-risk`,
+`deferred`, and `mitigated-externally` accept a _real_ exposure — the
+guardrail stops blocking, but the score keeps counting them, so accepting
+a real risk can't earn an A. Secret findings are never down-ranked by
+file path: a credential in a test keeps full severity until a human
+allowlists it as `test-fixture`.
 
 Severity bands follow **CVSS v4.0** (FIRST.org). Weakness taxonomy
 follows **CWE** (MITRE). Category framing follows

--- a/docs/commands/allowlist.md
+++ b/docs/commands/allowlist.md
@@ -44,18 +44,30 @@ so the team can tune the underlying detection.
 
 ## The five categories
 
-| Category               | Meaning                                    | Expiry       | Surfaces                        |
-| ---------------------- | ------------------------------------------ | ------------ | ------------------------------- |
-| `false-positive`       | Scanner is wrong about this finding        | Optional     | Inline annotation OR file-level |
-| `test-fixture`         | Intentional pattern in fixture / test code | Optional     | Inline annotation OR file-level |
-| `mitigated-externally` | Real risk but neutralized at runtime       | Optional     | Inline annotation OR file-level |
-| `accepted-risk`        | Real risk, team accepts, signed off        | **Required** | File-level only                 |
-| `deferred`             | Real, will fix later, tracked work         | **Required** | File-level only                 |
+| Category               | Meaning                                    | Expiry       | Surfaces                        | Lifts score? |
+| ---------------------- | ------------------------------------------ | ------------ | ------------------------------- | ------------ |
+| `false-positive`       | Scanner is wrong about this finding        | Optional     | Inline annotation OR file-level | **Yes**      |
+| `test-fixture`         | Intentional pattern in fixture / test code | Optional     | Inline annotation OR file-level | **Yes**      |
+| `mitigated-externally` | Real risk but neutralized at runtime       | Optional     | Inline annotation OR file-level | No           |
+| `accepted-risk`        | Real risk, team accepts, signed off        | **Required** | File-level only                 | No           |
+| `deferred`             | Real, will fix later, tracked work         | **Required** | File-level only                 | No           |
 
 `accepted-risk` and `deferred` require an expiry because they
 describe assertions that should age out. By default the CLI sets
 `--expires` to 90 days from today (industry convention, matches
 Snyk / Dependabot).
+
+**The category decides whether the finding still counts toward the
+score, not just the guardrail.** `false-positive` and `test-fixture`
+declare the finding is _not real_ (a misfire, or throwaway test data), so
+it is lifted from the Security dimension's penalties and caps — a repo
+that has triaged its noise scores honestly. The remaining three accept a
+_real_ exposure: the guardrail stops blocking, but the score keeps
+counting them, so accepting a real risk can't earn an A. This is also
+the supported way to quiet a hardcoded credential in a test file — dxkit
+never lowers a secret's severity by path, so confirm it's a fixture and
+allowlist it as `test-fixture` (which removes it from the score); a real
+credential in a test is still rotated, not allowlisted.
 
 ## The two surfaces
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.9.4",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.9.4",
+      "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.9.4",
+  "version": "2.10.0",
   "description": "AI-native developer experience toolkit for any codebase",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -101,7 +101,16 @@ npx vyuh-dxkit vulnerabilities --json | jq '.summary.findings'
 
 Don't try to redact the secret in place — the git history still has it. Rotation is the only true fix.
 
-If the "secret" is actually a placeholder in test code (e.g., `"sk_test_xxxxxxxxxxxx"` with no real credential value), confirm with the developer and allowlist via `dxkit-allow:test-fixture` — see "Allowlisting (when fix is not viable)" below.
+#### Secrets in test files — TRIAGE, don't assume
+
+dxkit deliberately does **not** lower a secret's severity just because it sits in a test file: the scanner can't tell a throwaway fixture from a real credential someone pasted into an integration test, and a real leak in a test is still a leak. So test-file secrets reach you at full severity, and the report flags how many are test-located — that's your cue to triage each one, not to dismiss them:
+
+1. **Open the line and judge the value.** Obvious throwaway fixture (`'password1'`, `'changeme'`, `'sk_test_xxxx'`, low-entropy / dictionary)? Or does it look like a real credential (high-entropy token, a real-looking host/user/password, something that would actually authenticate)?
+2. **Fixture → allowlist it.** `vyuh-dxkit allowlist add <file>:<line> --category=test-fixture --reason="..."`. This is the right tool: it records *why*, and `test-fixture` (like `false-positive`) **lifts the finding from the Security score**, not just the guardrail — so a properly-triaged test file stops dragging the score down. Don't waste effort "rotating" a fake value.
+3. **Real credential → treat it as a live leak.** Rotate in the provider, remove from the file, scrub git history (`git filter-repo` / BFG). Being in a test does not make it safe.
+4. **Unsure? Ask the developer** before allowlisting — never allowlist a value you haven't confirmed is fake.
+
+Allowlisting under `test-fixture` is a deliberate per-finding judgment, not a blanket "ignore tests" — don't add a `.dxkit-ignore` for the test directory to make the noise go away (that also drops the files from coverage + test-gap analysis, and would hide a real leak the same way). See "Allowlisting (when fix is not viable)" below.
 
 ### SAST finding (semgrep)
 
@@ -166,7 +175,7 @@ If the finding is a false positive, add `// slop-ok: <reason>` on the offending 
 
 ## Allowlisting (when fix is not viable)
 
-**Fix first.** The allowlist is the SECOND option, not the first. When you reach for it, choose deliberately — every allowlist entry is a future maintenance burden the customer's team will revisit.
+**Fix first.** The allowlist is the SECOND option, not the first. When you reach for it, choose deliberately — every allowlist entry is a future maintenance burden the team will revisit.
 
 Five typed categories signal WHY the suppression is in place:
 

--- a/src-templates/.claude/skills/dxkit-allowlist/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-allowlist/SKILL.md
@@ -7,6 +7,15 @@ description: Manage the dxkit allowlist over its whole lifecycle — list, inspe
 
 The allowlist is dxkit's per-finding suppression surface: a reviewed finding that the team has categorized (`false-positive`, `test-fixture`, `mitigated-externally`, `accepted-risk`, `deferred`) with a reason, so the guardrail lets it pass on future runs. It's the single source of truth across every scanner — native semgrep/gitleaks and ingested Snyk Code / CodeQL findings alike, all keyed on one fingerprint.
 
+### Categories affect the score, not just the guardrail
+
+The category isn't just a label — it decides whether the finding still counts toward the **Security score**:
+
+- **`false-positive` / `test-fixture`** declare the finding is *not a real finding* (a scanner misfire, or throwaway test data). These are **lifted from the Security penalties and caps**, so a repo that has genuinely triaged its noise scores honestly instead of staying capped on findings it has already reviewed and accepted. This is also why test-file secrets (which dxkit never auto-downgrades by path) should be allowlisted as `test-fixture` once confirmed fake — that's what removes them from the score.
+- **`accepted-risk` / `deferred` / `mitigated-externally`** accept a *real* exposure. The guardrail stops blocking, but the score keeps counting them — accepting a real risk can't earn an A. (`accepted-risk` / `deferred` also require an expiry so the acceptance ages out.)
+
+So `false-positive`/`test-fixture` are the only categories that recover score. Reserve them for findings that genuinely aren't real — miscategorizing a real risk as `false-positive` to lift the score is exactly the self-deception the typed categories exist to prevent.
+
 This skill manages the allowlist's **lifecycle**: reviewing what's there, keeping it honest, and propagating decisions outward. For the upstream question — *should this be fixed instead of suppressed, and how do I add an entry* — that decision and the `add` path live in **dxkit-action**. Fix first; suppress second.
 
 ## The lifecycle at a glance

--- a/src-templates/.claude/skills/dxkit-onboard/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-onboard/SKILL.md
@@ -104,7 +104,7 @@ For each fixable signal in doctor's output, dispatch through `dxkit-fix`'s recov
 
 - `git hooks active` not active → `npx vyuh-dxkit hooks activate`
 - `baseline captured` missing → defer to step 5 (we'll handle that explicitly with the secrets warning)
-- `vyuh-dxkit on PATH` missing → `npm install -g @vyuhlabs/dxkit`
+- `vyuh-dxkit on PATH` missing → `npm install -g @vyuhlabs/dxkit` (a global install — it affects every Node project on the machine and may need elevated permissions; a project-local install or a Node version manager works too)
 - `scanner toolchain` incomplete → `npx vyuh-dxkit tools install --yes`
 
 Don't auto-execute baseline capture here — step 5 has a values-laden warning that needs explicit customer confirmation.
@@ -195,7 +195,7 @@ Local hooks are fast feedback; CI is the unbypassable enforcement. Branch protec
 
 ASK:
 
-> **Configure branch protection now?** Default yes. Adds `dxkit-guardrails` as a required status check on `<default branch>`. Requires admin permission on the GitHub repo. Without this, the CI workflow is informational — PRs can merge even on guardrail failures.
+> **Configure branch protection now?** Default yes. This **modifies your GitHub repository settings** — it adds `dxkit-guardrails` as a required status check on `<default branch>`, and so needs admin permission on the repo. Without it, the CI workflow is informational — PRs can merge even on guardrail failures.
 
 If yes:
 

--- a/src/allowlist/annotate.ts
+++ b/src/allowlist/annotate.ts
@@ -5,10 +5,10 @@
  * The guardrail already consults the allowlist to decide whether a
  * net-new finding blocks a push (`src/baseline/check.ts`). But the
  * vulnerability-scan report and dashboard rendered raw counts with no
- * indication that some findings are reviewed-and-accepted — a customer
- * who correctly allowlisted 7 unit-test fixtures still saw "8 CRITICAL"
- * with zero visual distinction, the proximate trigger for a "the score
- * is lying" support case.
+ * indication that some findings are reviewed-and-accepted — a repo that
+ * has correctly allowlisted, say, its unit-test fixtures still showed
+ * them as headline criticals with no visual distinction, which reads as
+ * "the score is lying."
  *
  * This module marks each finding whose fingerprint matches an ACTIVE
  * (unexpired) allowlist entry so renderers can show "(N allowlisted)"
@@ -59,6 +59,25 @@ function kindForCategory(category: FindingCategory): IdentityKind | null {
     case 'dependency':
       return null;
   }
+}
+
+/**
+ * Whether an active allowlist entry of this category should LIFT the
+ * finding from the dimension score (penalties + caps), not just from
+ * the guardrail.
+ *
+ * `false-positive` and `test-fixture` declare the finding is "not a real
+ * finding" — a misfire or throwaway test data — so a properly-triaged
+ * repo shouldn't carry a score penalty for it (the failure mode where a
+ * repo stays capped at the trust-broken tier despite having reviewed and
+ * accepted every flagged secret). `accepted-risk` and `deferred`, by
+ * contrast, accept a REAL risk: the guardrail stops blocking on them,
+ * but the score must still reflect the residual exposure — you can't
+ * `accepted-risk` your way to an A. `mitigated-externally` counts too:
+ * the risk is real, just handled outside dxkit.
+ */
+export function allowlistLiftsScore(category: AllowlistCategory | undefined): boolean {
+  return category === 'false-positive' || category === 'test-fixture';
 }
 
 /**

--- a/src/allowlist/annotate.ts
+++ b/src/allowlist/annotate.ts
@@ -1,0 +1,102 @@
+/**
+ * C-D2: annotate security findings with their active-allowlist status
+ * for REPORTING (not gating).
+ *
+ * The guardrail already consults the allowlist to decide whether a
+ * net-new finding blocks a push (`src/baseline/check.ts`). But the
+ * vulnerability-scan report and dashboard rendered raw counts with no
+ * indication that some findings are reviewed-and-accepted — a customer
+ * who correctly allowlisted 7 unit-test fixtures still saw "8 CRITICAL"
+ * with zero visual distinction, the proximate trigger for a "the score
+ * is lying" support case.
+ *
+ * This module marks each finding whose fingerprint matches an ACTIVE
+ * (unexpired) allowlist entry so renderers can show "(N allowlisted)"
+ * beside the subtotal. It does NOT change raw counts and does NOT change
+ * the score — dxkit's raw-truth model is preserved; only the
+ * presentation gains an honesty annotation.
+ *
+ * Identity contract (CLAUDE.md Rule 9): this module never computes a
+ * fingerprint. It matches against the fingerprint the aggregator
+ * already stamped on each code/secret/config finding (plus the
+ * `absorbedFingerprints` recorded when cross-tool dedup collapsed
+ * contributors — same robust-match set the guardrail uses). Dependency
+ * findings are keyed by `(package, version, id)` through a producer and
+ * carry no inline fingerprint, so they are out of scope here.
+ */
+import { type AllowlistFile, findEntry, isEntryActive } from './file';
+import type { AllowlistCategory } from './categories';
+import type { FindingCategory } from '../analyzers/security/types';
+import type { IdentityKind } from '../baseline/producers';
+
+/**
+ * The minimal finding shape this module reads + writes. The runtime
+ * objects are richer (`CodeFinding` carries `fingerprint` +
+ * `absorbedFingerprints`); we accept the structural subset so callers
+ * pass their findings directly without a cast.
+ */
+export interface AnnotatableFinding {
+  readonly category: FindingCategory;
+  readonly fingerprint?: string;
+  readonly absorbedFingerprints?: readonly string[];
+  allowlisted?: boolean;
+  allowlistCategory?: AllowlistCategory;
+}
+
+/**
+ * Map a report `FindingCategory` to the canonical `IdentityKind` used
+ * by allowlist entries. Only the three fingerprint-bearing categories
+ * resolve; `dependency` returns null (out of scope — see module doc).
+ */
+function kindForCategory(category: FindingCategory): IdentityKind | null {
+  switch (category) {
+    case 'secret':
+      return 'secret';
+    case 'code':
+      return 'code';
+    case 'config':
+      return 'config';
+    case 'dependency':
+      return null;
+  }
+}
+
+/**
+ * Mutate `findings` in place, setting `allowlisted` + `allowlistCategory`
+ * on each finding matched by an active allowlist entry. Returns the count
+ * of findings annotated, so callers can short-circuit rendering when zero.
+ *
+ * A finding matches when ANY of its candidate fingerprints (its own
+ * `fingerprint`, then any `absorbedFingerprints`) resolves to an
+ * allowlist entry whose `kind` equals the finding's kind and which is
+ * active at `now`. The kind guard rules out a cross-kind hash collision
+ * waiving the wrong finding — mirrors `allowlistSuppressionFor`.
+ */
+export function annotateFindingsWithAllowlist(
+  findings: AnnotatableFinding[],
+  allowlist: AllowlistFile | null,
+  now: Date = new Date(),
+): number {
+  if (!allowlist || allowlist.entries.length === 0) return 0;
+
+  let annotated = 0;
+  for (const f of findings) {
+    const kind = kindForCategory(f.category);
+    if (!kind) continue;
+
+    const candidates: string[] = [];
+    if (f.fingerprint) candidates.push(f.fingerprint);
+    if (f.absorbedFingerprints) candidates.push(...f.absorbedFingerprints);
+
+    for (const fp of candidates) {
+      const entry = findEntry(allowlist, fp);
+      if (!entry || entry.kind !== kind) continue;
+      if (!isEntryActive(entry, now)) continue;
+      f.allowlisted = true;
+      f.allowlistCategory = entry.category;
+      annotated++;
+      break;
+    }
+  }
+  return annotated;
+}

--- a/src/allowlist/annotate.ts
+++ b/src/allowlist/annotate.ts
@@ -1,5 +1,5 @@
 /**
- * C-D2: annotate security findings with their active-allowlist status
+ * Annotate security findings with their active-allowlist status
  * for REPORTING (not gating).
  *
  * The guardrail already consults the allowlist to decide whether a

--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -44,7 +44,12 @@ import {
 } from '../baseline/baseline-file';
 import { canonicalRuleFor, computeCodeFingerprint } from '../analyzers/tools/fingerprint';
 import { readAllSnapshots } from '../ingest/snapshot';
-import { buildSnykPolicy, expiryToSnykDatetime, type SnykIgnore } from '../ingest/snyk-policy';
+import {
+  buildSnykPolicy,
+  dxkitIgnoreLinesToSnykExcludes,
+  expiryToSnykDatetime,
+  type SnykIgnore,
+} from '../ingest/snyk-policy';
 import { LANGUAGES } from '../languages';
 import type { LanguageSupport } from '../languages/types';
 import type { IdentityKind } from '../baseline/producers';
@@ -625,6 +630,12 @@ export async function runAllowlistRemove(cwd: string, opts: AllowlistRemoveOpts)
  * reason + expiry. Expired entries are skipped (they no longer
  * suppress). Only `snyk-code` findings export — native semgrep /
  * gitleaks findings have no Snyk equivalent.
+ *
+ * 2.10 also syncs the PATH-EXCLUSION half: `.dxkit-ignore` patterns
+ * (the paths dxkit's own analyzers skip) are emitted into the `.snyk`
+ * `exclude.global` block, so Snyk and dxkit agree on what's out of
+ * scope. The two halves compose into one `.snyk`; an export carrying
+ * only exclusions (no allowlisted Snyk findings yet) still writes.
  */
 export async function runAllowlistExport(cwd: string, opts: AllowlistExportOpts): Promise<void> {
   if (!opts.snyk) {
@@ -632,20 +643,14 @@ export async function runAllowlistExport(cwd: string, opts: AllowlistExportOpts)
     process.exit(1);
   }
 
-  const file = loadAllowlist(cwd);
-  if (!file || file.entries.length === 0) {
-    logger.info(`No allowlist entries — nothing to export.`);
-    return;
-  }
+  // Path-exclusion half of the sync: `.dxkit-ignore` → Snyk
+  // `exclude.global`. Independent of allowlist findings, so it's read up
+  // front and can carry an export even when no Snyk findings are
+  // allowlisted (the two halves compose into one `.snyk`).
+  const excludes = readDxkitIgnoreExcludes(cwd);
 
+  const file = loadAllowlist(cwd);
   const snapshots = readAllSnapshots(cwd).filter((f) => f.engine === 'snyk-code');
-  if (snapshots.length === 0) {
-    logger.info(
-      `No Snyk Code findings have been ingested yet. ` +
-        `Run \`vyuh-dxkit ingest --from-snyk\` first.`,
-    );
-    return;
-  }
 
   // Recompute each Snyk finding's canonical fingerprint and match it to
   // an active allowlist entry. Dedup (rule, path) so several findings on
@@ -654,48 +659,72 @@ export async function runAllowlistExport(cwd: string, opts: AllowlistExportOpts)
   const ignores: SnykIgnore[] = [];
   const seenRulePath = new Set<string>();
   let skippedExpired = 0;
-  for (const f of snapshots) {
-    const fingerprint = computeCodeFingerprint(canonicalRuleFor(f.engine, f.rule), f.file, f.line);
-    const entry = findEntry(file, fingerprint);
-    if (!entry) continue;
-    if (!isEntryActive(entry)) {
-      skippedExpired++;
-      continue;
+  if (file && file.entries.length > 0) {
+    for (const f of snapshots) {
+      const fingerprint = computeCodeFingerprint(
+        canonicalRuleFor(f.engine, f.rule),
+        f.file,
+        f.line,
+      );
+      const entry = findEntry(file, fingerprint);
+      if (!entry) continue;
+      if (!isEntryActive(entry)) {
+        skippedExpired++;
+        continue;
+      }
+      const key = `${f.rule}\0${f.file}`;
+      if (seenRulePath.has(key)) continue;
+      seenRulePath.add(key);
+      ignores.push({
+        ruleId: f.rule,
+        path: f.file,
+        reason: entry.reason,
+        expires: expiryToSnykDatetime(entry.expiresAt),
+        created,
+      });
     }
-    const key = `${f.rule}\0${f.file}`;
-    if (seenRulePath.has(key)) continue;
-    seenRulePath.add(key);
-    ignores.push({
-      ruleId: f.rule,
-      path: f.file,
-      reason: entry.reason,
-      expires: expiryToSnykDatetime(entry.expiresAt),
-      created,
-    });
+  }
+
+  // Bail only when there's nothing to act on at all: no usable allowlist
+  // context (entries + ingested snapshots to match them against) AND no
+  // path exclusions. When an allowlist+snapshots context exists we still
+  // write — an empty policy + JSON is meaningful output (preserves the
+  // pre-2.10 behavior the export tests pin).
+  const hasAllowlistContext = !!file && file.entries.length > 0 && snapshots.length > 0;
+  if (!hasAllowlistContext && excludes.length === 0) {
+    if (!file || file.entries.length === 0) {
+      logger.info(`No allowlist entries and no .dxkit-ignore exclusions — nothing to export.`);
+    } else {
+      logger.info(
+        `No Snyk Code findings have been ingested yet and no .dxkit-ignore ` +
+          `exclusions are present. Run \`vyuh-dxkit ingest --from-snyk\` first.`,
+      );
+    }
+    return;
   }
 
   const outPath = path.resolve(cwd, opts.out ?? '.snyk');
-  const policy = buildSnykPolicy(ignores);
+  const policy = buildSnykPolicy(ignores, excludes);
   fs.writeFileSync(outPath, policy, 'utf8');
 
   if (opts.json) {
     process.stdout.write(
-      JSON.stringify({ out: outPath, ignores: ignores.length, skippedExpired }, null, 2) + '\n',
+      JSON.stringify(
+        { out: outPath, ignores: ignores.length, excludes: excludes.length, skippedExpired },
+        null,
+        2,
+      ) + '\n',
     );
     return;
   }
 
-  if (ignores.length === 0) {
-    logger.info(
-      `No Snyk-originated findings are allowlisted — wrote an empty policy to ${outPath}.` +
-        (skippedExpired > 0
-          ? ` (${skippedExpired} expired entr${skippedExpired === 1 ? 'y' : 'ies'} skipped.)`
-          : ''),
-    );
-    return;
+  const parts: string[] = [];
+  parts.push(`${ignores.length} Snyk ignore${ignores.length === 1 ? '' : 's'}`);
+  if (excludes.length > 0) {
+    parts.push(`${excludes.length} path exclusion${excludes.length === 1 ? '' : 's'}`);
   }
   logger.success(
-    `Wrote ${ignores.length} Snyk ignore${ignores.length === 1 ? '' : 's'} to ${outPath}` +
+    `Wrote ${parts.join(' + ')} to ${outPath}` +
       (skippedExpired > 0 ? ` (${skippedExpired} expired skipped)` : '') +
       '.',
   );
@@ -706,6 +735,21 @@ export async function runAllowlistExport(cwd: string, opts: AllowlistExportOpts)
 }
 
 // ─── Internals ────────────────────────────────────────────────────────────
+
+/**
+ * Read `.dxkit-ignore` (if present) and convert its patterns into Snyk
+ * `exclude.global` globs. Returns [] when the file is absent or
+ * unreadable — the exclusion sync is best-effort and never blocks an
+ * allowlist export.
+ */
+function readDxkitIgnoreExcludes(cwd: string): string[] {
+  try {
+    const raw = fs.readFileSync(path.join(cwd, '.dxkit-ignore'), 'utf8');
+    return dxkitIgnoreLinesToSnykExcludes(raw.split('\n'));
+  } catch {
+    return [];
+  }
+}
 
 function isAllowlistSubcommand(value: string): value is AllowlistSubcommand {
   return (ALLOWLIST_SUBCOMMANDS as readonly string[]).includes(value);

--- a/src/analyzers/dashboard/index.ts
+++ b/src/analyzers/dashboard/index.ts
@@ -187,6 +187,10 @@ export function analyzeDashboard(cwd: string, options: DashboardOptions = {}): D
     line?: number;
     package?: string;
     installedVersion?: string;
+    /** C-D2: set upstream when an active allowlist entry accepts this
+     *  finding. Surfaced in the Vulnerabilities tile so the dashboard
+     *  doesn't read as "8 CRITICAL" when 7 are reviewed test fixtures. */
+    allowlisted?: boolean;
   };
   // D047 (2.4.7 fix-forward): the dashboard previously read only
   // `vulns.findings` (code findings — semgrep/gitleaks). Dependency
@@ -221,6 +225,10 @@ export function analyzeDashboard(cwd: string, options: DashboardOptions = {}): D
   // length count. Post-C1.2 both arrays are already dedup'd by the
   // canonical aggregator, so the union is unique-by-construction.
   const vulnFindings: VulnFinding[] = [...codeFindings, ...depFindings];
+  // C-D2: how many of the surfaced findings are reviewed-and-accepted
+  // (active allowlist). Disclosed in the tile sub-line so raw counts
+  // aren't mistaken for unaddressed risk.
+  const vulnAllowlisted = vulnFindings.filter((f) => f.allowlisted).length;
 
   // G_v4_8 (2.4.7 Phase C1.5): severity buckets read directly from
   // `vulns.summary.findings` + `vulns.summary.dependencies` — both
@@ -356,6 +364,7 @@ export function analyzeDashboard(cwd: string, options: DashboardOptions = {}): D
     orderedDims,
     vulnFindings,
     vulnBySeverity,
+    vulnAllowlisted,
     gapCount,
     gapsByRisk,
     advisoryCount,
@@ -481,6 +490,7 @@ interface RenderArgs {
   orderedDims: Array<[string, { score?: number } | undefined]>;
   vulnFindings: unknown[];
   vulnBySeverity: Record<string, number>;
+  vulnAllowlisted: number;
   gapCount: number;
   gapsByRisk: Record<string, number>;
   advisoryCount: number;
@@ -711,7 +721,7 @@ function renderHtml(a: RenderArgs): string {
           <div class="stat-card">
             <div class="label">Vulnerabilities</div>
             <div class="value" style="color:${a.vulnFindings.length > 0 ? 'var(--accent-red)' : 'var(--accent-green)'}">${a.vulnFindings.length}</div>
-            <div class="sub">${a.vulnBySeverity.critical ?? 0} critical · ${a.vulnBySeverity.high ?? 0} high · ${a.vulnBySeverity.medium ?? 0} medium · ${a.vulnBySeverity.low ?? 0} low</div>
+            <div class="sub">${a.vulnBySeverity.critical ?? 0} critical · ${a.vulnBySeverity.high ?? 0} high · ${a.vulnBySeverity.medium ?? 0} medium · ${a.vulnBySeverity.low ?? 0} low${a.vulnAllowlisted > 0 ? ` · <span style="color:var(--text-secondary)">${a.vulnAllowlisted} allowlisted</span>` : ''}</div>
           </div>
           <div class="stat-card">
             <div class="label">Test Gaps</div>

--- a/src/analyzers/dashboard/index.ts
+++ b/src/analyzers/dashboard/index.ts
@@ -187,7 +187,7 @@ export function analyzeDashboard(cwd: string, options: DashboardOptions = {}): D
     line?: number;
     package?: string;
     installedVersion?: string;
-    /** C-D2: set upstream when an active allowlist entry accepts this
+    /** Set upstream when an active allowlist entry accepts this
      *  finding. Surfaced in the Vulnerabilities tile so the dashboard
      *  doesn't read as "8 CRITICAL" when 7 are reviewed test fixtures. */
     allowlisted?: boolean;
@@ -225,7 +225,7 @@ export function analyzeDashboard(cwd: string, options: DashboardOptions = {}): D
   // length count. Post-C1.2 both arrays are already dedup'd by the
   // canonical aggregator, so the union is unique-by-construction.
   const vulnFindings: VulnFinding[] = [...codeFindings, ...depFindings];
-  // C-D2: how many of the surfaced findings are reviewed-and-accepted
+  // How many of the surfaced findings are reviewed-and-accepted
   // (active allowlist). Disclosed in the tile sub-line so raw counts
   // aren't mistaken for unaddressed risk.
   const vulnAllowlisted = vulnFindings.filter((f) => f.allowlisted).length;

--- a/src/analyzers/health.ts
+++ b/src/analyzers/health.ts
@@ -409,9 +409,9 @@ async function gatherCapabilityReport(cwd: string): Promise<CapabilityReport> {
     // gatherWithProvenance: the secret scan needs the same
     // attempted-vs-succeeded discriminant the code-patterns gather has,
     // so a failed secret scan caps the Security score (uncertainty)
-    // instead of silently reading as "0 secrets". The customer-facing
+    // instead of silently reading as "0 secrets". The user-facing
     // symptom of the old silent path: a dxkit upgrade that merely
-    // turned the secret scanners ON looked like a 25-point score drop
+    // turned the secret scanners ON looked like a score drop
     // on an unchanged commit.
     defaultDispatcher.gatherWithProvenance(cwd, SECRETS, providersFor(SECRETS, cwd)),
     // gatherWithProvenance so the cache builder can plumb per-capability

--- a/src/analyzers/health.ts
+++ b/src/analyzers/health.ts
@@ -406,7 +406,7 @@ async function gatherCapabilityReport(cwd: string): Promise<CapabilityReport> {
     defaultDispatcher.gather(cwd, COVERAGE, providersFor(COVERAGE, cwd)),
     defaultDispatcher.gather(cwd, IMPORTS, providersFor(IMPORTS, cwd)),
     defaultDispatcher.gather(cwd, TEST_FRAMEWORK, providersFor(TEST_FRAMEWORK, cwd)),
-    // gatherWithProvenance (C-D1): the secret scan needs the same
+    // gatherWithProvenance: the secret scan needs the same
     // attempted-vs-succeeded discriminant the code-patterns gather has,
     // so a failed secret scan caps the Security score (uncertainty)
     // instead of silently reading as "0 secrets". The customer-facing
@@ -493,7 +493,7 @@ async function gatherCapabilityReport(cwd: string): Promise<CapabilityReport> {
   if (testFramework) report.testFramework = testFramework;
   const secrets = secretsOutcome.envelope;
   if (secrets) report.secrets = secrets;
-  // C-D1: same shape as codePatternsAvailability. Distinguishes "no
+  // Same shape as codePatternsAvailability. Distinguishes "no
   // secret provider active" (vacuous clean) from "secret scan was
   // attempted but every provider returned null" — the latter caps the
   // Security score at the uncertainty tier instead of silently

--- a/src/analyzers/health.ts
+++ b/src/analyzers/health.ts
@@ -254,6 +254,7 @@ export async function gatherAnalysisResultBody(
   // fields populated above. The reason text is consumer-renderable;
   // keep it concise (~one short sentence).
   pushUnavailable(metrics, capabilities.codePatternsAvailability, 'semgrep');
+  pushUnavailable(metrics, capabilities.secretsAvailability, 'secret-scan');
   pushUnavailable(metrics, capabilities.duplicationAvailability, 'jscpd');
   pushUnavailable(metrics, capabilities.structuralAvailability, 'graphify');
   pushUnavailable(metrics, capabilities.lintAvailability, 'lint');
@@ -388,7 +389,7 @@ async function gatherCapabilityReport(cwd: string): Promise<CapabilityReport> {
     coverage,
     imports,
     testFramework,
-    secrets,
+    secretsOutcome,
     codePatternsOutcome,
     duplicationOutcome,
     structuralOutcome,
@@ -405,7 +406,14 @@ async function gatherCapabilityReport(cwd: string): Promise<CapabilityReport> {
     defaultDispatcher.gather(cwd, COVERAGE, providersFor(COVERAGE, cwd)),
     defaultDispatcher.gather(cwd, IMPORTS, providersFor(IMPORTS, cwd)),
     defaultDispatcher.gather(cwd, TEST_FRAMEWORK, providersFor(TEST_FRAMEWORK, cwd)),
-    defaultDispatcher.gather(cwd, SECRETS, providersFor(SECRETS, cwd)),
+    // gatherWithProvenance (C-D1): the secret scan needs the same
+    // attempted-vs-succeeded discriminant the code-patterns gather has,
+    // so a failed secret scan caps the Security score (uncertainty)
+    // instead of silently reading as "0 secrets". The customer-facing
+    // symptom of the old silent path: a dxkit upgrade that merely
+    // turned the secret scanners ON looked like a 25-point score drop
+    // on an unchanged commit.
+    defaultDispatcher.gatherWithProvenance(cwd, SECRETS, providersFor(SECRETS, cwd)),
     // gatherWithProvenance so the cache builder can plumb per-capability
     // availability metadata for tools that may legitimately gather
     // attempted-but-failed (semgrep / jscpd / graphify under resource
@@ -483,7 +491,14 @@ async function gatherCapabilityReport(cwd: string): Promise<CapabilityReport> {
   if (coverage) report.coverage = coverage;
   if (imports) report.imports = imports;
   if (testFramework) report.testFramework = testFramework;
+  const secrets = secretsOutcome.envelope;
   if (secrets) report.secrets = secrets;
+  // C-D1: same shape as codePatternsAvailability. Distinguishes "no
+  // secret provider active" (vacuous clean) from "secret scan was
+  // attempted but every provider returned null" — the latter caps the
+  // Security score at the uncertainty tier instead of silently
+  // scoring an unscanned repo as secret-free.
+  report.secretsAvailability = availabilityFromOutcome(secretsOutcome, 'gitleaks');
   if (codePatterns) report.codePatterns = codePatterns;
   // Same shape as lintAvailability — distinguishes "no rulesets
   // active" (vacuous clean) from "semgrep/jscpd/graphify was

--- a/src/analyzers/security/actions.ts
+++ b/src/analyzers/security/actions.ts
@@ -9,6 +9,7 @@ import { Evidence } from '../evidence';
 import { RemediationAction } from '../remediation';
 import { SecurityReport, SecurityFinding, Severity } from './types';
 import { SecurityScoreInput } from '../../scoring';
+import { allowlistLiftsScore } from '../../allowlist/annotate';
 
 /**
  * Project a SecurityReport into the canonical scoring input shape.
@@ -25,6 +26,13 @@ export function countsFromReport(report: SecurityReport): SecurityScoreInput {
   const codeFindings = { critical: 0, high: 0, medium: 0, low: 0 };
 
   for (const f of report.findings) {
+    // Findings reviewed-and-accepted as false-positive / test-fixture are
+    // lifted from the score (not just the guardrail) — same rule the
+    // health-side aggregate applies — so a triaged repo scores honestly.
+    // accepted-risk / deferred still count (real exposure accepted).
+    if (f.allowlisted && allowlistLiftsScore(f.allowlistCategory)) {
+      continue;
+    }
     if (f.rule === 'private-key-file') {
       privateKeyFiles++;
     } else if (f.rule === 'env-in-git') {

--- a/src/analyzers/security/actions.ts
+++ b/src/analyzers/security/actions.ts
@@ -60,6 +60,11 @@ export function countsFromReport(report: SecurityReport): SecurityScoreInput {
     // `true` for fixtures that pre-date the field (legacy report JSONs
     // saved before 2.4.7).
     depVulnsAvailable: d.available ?? true,
+    // C-D1: same default-true contract — caps only on an explicit
+    // "scan did not run" from the report's provenance-derived summary
+    // fields. Legacy report JSONs (pre-2.10) lack them → no cap.
+    secretsAvailable: report.summary.secretsAvailable ?? true,
+    codePatternsAvailable: report.summary.codePatternsAvailable ?? true,
   };
 }
 

--- a/src/analyzers/security/actions.ts
+++ b/src/analyzers/security/actions.ts
@@ -60,7 +60,7 @@ export function countsFromReport(report: SecurityReport): SecurityScoreInput {
     // `true` for fixtures that pre-date the field (legacy report JSONs
     // saved before 2.4.7).
     depVulnsAvailable: d.available ?? true,
-    // C-D1: same default-true contract — caps only on an explicit
+    // Same default-true contract — caps only on an explicit
     // "scan did not run" from the report's provenance-derived summary
     // fields. Legacy report JSONs (pre-2.10) lack them → no cap.
     secretsAvailable: report.summary.secretsAvailable ?? true,

--- a/src/analyzers/security/aggregator.ts
+++ b/src/analyzers/security/aggregator.ts
@@ -58,6 +58,8 @@
 import type { DepVulnFinding } from '../../languages/capabilities/types';
 import type { Severity, FindingCategory, SecurityFinding } from './types';
 import { canonicalRuleFor, computeCodeFingerprint, lineWindowFor } from '../tools/fingerprint';
+import { annotateFindingsWithAllowlist, allowlistLiftsScore } from '../../allowlist/annotate';
+import type { AllowlistFile } from '../../allowlist/file';
 
 // ─── Re-exports for consumer convenience ──────────────────────────────────
 
@@ -164,6 +166,18 @@ export interface SecurityAggregate {
    *  pick which they own. */
   secretsBySeverity: SeverityCounts;
 
+  /** Code-pattern findings by severity, EXCLUDING findings an active
+   *  allowlist entry lifts from the score (`false-positive` /
+   *  `test-fixture`). The dimension scorer reads these; reports read the
+   *  raw `codeBySeverity`. Equal to `codeBySeverity` when no allowlist
+   *  was supplied or none of the findings are score-lifted. */
+  scoreableCodeBySeverity: SeverityCounts;
+
+  /** Secret + secret-adjacent findings by severity, EXCLUDING
+   *  score-lifting allowlisted findings. Scorer reads this; reports read
+   *  raw `secretsBySeverity`. */
+  scoreableSecretsBySeverity: SeverityCounts;
+
   /** Findings partitioned by category, post-dedup. Renderers iterate
    *  these — never iterate raw envelope arrays. `dependency` is the
    *  fingerprint-unique advisory set. */
@@ -268,6 +282,13 @@ export interface SecurityAggregateInput {
     available: boolean;
     unavailableReason: string;
   };
+  /** The repo's allowlist, loaded by the caller (the aggregator stays
+   *  pure / does no I/O). When present, each code/secret/config finding
+   *  is annotated with its active-allowlist status, and the `scoreable*`
+   *  severity buckets exclude findings allowlisted under a category that
+   *  lifts the score (`false-positive` / `test-fixture`). Absent/null →
+   *  `scoreable*` buckets equal the raw buckets. */
+  allowlist?: AllowlistFile | null;
 }
 
 /**
@@ -489,6 +510,32 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
     }
   }
 
+  // ─── Allowlist annotation + scoreable buckets ───────────────────────
+  // Mark every code/secret/config finding an active allowlist entry
+  // covers (renderers show "(N allowlisted)"), then derive the
+  // score-only buckets that EXCLUDE findings allowlisted under a
+  // category that lifts the score. This is what lets a repo that has
+  // reviewed-and-accepted its findings (false-positive / test-fixture)
+  // score honestly instead of staying capped on noise — while still
+  // counting accepted-risk / deferred, which accept a real exposure.
+  const allCodeSideFindings = [
+    ...codeFindingsByCategory.secret,
+    ...codeFindingsByCategory.code,
+    ...codeFindingsByCategory.config,
+  ];
+  annotateFindingsWithAllowlist(allCodeSideFindings, input.allowlist ?? null);
+
+  const scoreableCodeBySeverity = emptyCounts();
+  const scoreableSecretsBySeverity = emptyCounts();
+  const scoreLifted = (f: CodeFinding): boolean =>
+    !!f.allowlisted && allowlistLiftsScore(f.allowlistCategory);
+  for (const f of codeFindingsByCategory.code) {
+    if (!scoreLifted(f)) bumpCounts(scoreableCodeBySeverity, f.severity);
+  }
+  for (const f of [...codeFindingsByCategory.secret, ...codeFindingsByCategory.config]) {
+    if (!scoreLifted(f)) bumpCounts(scoreableSecretsBySeverity, f.severity);
+  }
+
   // ─── Dep-side dedup ─────────────────────────────────────────────────
   // Group by fingerprint. Findings without a fingerprint (defensive
   // path — shouldn't happen post-`stampFingerprints`) get a synthetic
@@ -549,6 +596,8 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
     codeBySeverity,
     depBySeverity,
     secretsBySeverity,
+    scoreableCodeBySeverity,
+    scoreableSecretsBySeverity,
     findingsByCategory: {
       secret: codeFindingsByCategory.secret,
       code: codeFindingsByCategory.code,

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -24,6 +24,7 @@ import { walkSourceFiles, commentSyntaxFor, isCommentLine } from '../tools/walk-
 import * as path from 'path';
 import { SecurityFinding, DepVulnSummary, Severity } from './types';
 import { buildSecurityAggregate, type SecurityAggregate } from './aggregator';
+import { loadAllowlist } from '../../allowlist/file';
 import { defaultDispatcher } from '../dispatcher';
 import { allTlsBypassPatterns, detectActiveLanguages } from '../../languages';
 import {
@@ -596,5 +597,10 @@ export async function buildSecurityAggregateForHealth(
       available: depVulnsAvailable,
       unavailableReason: depVulnsUnavailableReason,
     },
+    // Loaded here (the aggregator does no I/O) so both the health score
+    // and the standalone vuln-scan — which share this one aggregate via
+    // the analysis cache — see the same allowlist-adjusted scoreable
+    // buckets and the same per-finding allowlist annotations.
+    allowlist: loadAllowlist(cwd),
   });
 }

--- a/src/analyzers/security/index.ts
+++ b/src/analyzers/security/index.ts
@@ -13,6 +13,7 @@ import type { LanguageId } from '../../types';
 import { renderToolsUnavailableLines } from '../tools/tools-unavailable-prose';
 import { loadAllowlist } from '../../allowlist/file';
 import { annotateFindingsWithAllowlist } from '../../allowlist/annotate';
+import { detectScannerCoverageDrift } from './scanner-drift';
 
 export type { SecurityReport, SecurityFinding } from './types';
 
@@ -195,6 +196,18 @@ export async function analyzeSecurity(
     findings: [...aggregate.findingsByCategory.dependency],
   };
 
+  // C-D3: did the scanner set grow since the last run? If so the report
+  // discloses that new findings are newly *visible*, not newly
+  // *introduced* — the root-cause explanation for a score that "got
+  // worse" on an unchanged commit after a dxkit upgrade enabled more
+  // scanners. Read-only + fail-open; compared against the most recent
+  // prior persisted report.
+  const scannerDrift = detectScannerCoverageDrift(
+    result.cwd,
+    toolsUsed,
+    result.builtAt.slice(0, 10),
+  );
+
   return {
     repo: stack.projectName || path.basename(result.cwd),
     analyzedAt: result.builtAt,
@@ -214,6 +227,7 @@ export async function analyzeSecurity(
     findings: codeFindings,
     toolsUsed,
     toolsUnavailable,
+    ...(scannerDrift ? { scannerDrift } : {}),
   };
 }
 
@@ -251,6 +265,21 @@ export function formatSecurityReport(report: SecurityReport, elapsed: string): s
   L.push('');
   L.push('---');
   L.push('');
+
+  // C-D3: scanner-coverage-drift note. Surfaced at the very top so a
+  // reader who sees a worse score knows to attribute it to improved
+  // measurement, not regressed code, BEFORE reading the numbers.
+  if (report.scannerDrift) {
+    const { added, previousDate } = report.scannerDrift;
+    const toolList = added.map((t) => `\`${t}\``).join(', ');
+    L.push(
+      `> ℹ **Scanner coverage expanded since ${previousDate}.** This run added ` +
+        `${toolList}. Findings these scanners surface are newly **visible**, not newly ` +
+        `**introduced** — if the score moved, it reflects improved measurement of code ` +
+        `that was already there, not new risk.`,
+    );
+    L.push('');
+  }
 
   // C2.1 (perception D086 closure): three independent axes, each with
   // its own labeled table. Pre-C2.1 the executive summary had a single

--- a/src/analyzers/security/index.ts
+++ b/src/analyzers/security/index.ts
@@ -11,6 +11,8 @@ import { gatherAnalysisResultBody } from '../health';
 import { getLanguage } from '../../languages';
 import type { LanguageId } from '../../types';
 import { renderToolsUnavailableLines } from '../tools/tools-unavailable-prose';
+import { loadAllowlist } from '../../allowlist/file';
+import { annotateFindingsWithAllowlist } from '../../allowlist/annotate';
 
 export type { SecurityReport, SecurityFinding } from './types';
 
@@ -142,6 +144,14 @@ export async function analyzeSecurity(
     ...aggregate.findingsByCategory.code,
     ...aggregate.findingsByCategory.config,
   ];
+
+  // C-D2: mark findings an active allowlist entry already accepts, so
+  // the renderer can show "(N allowlisted)" beside raw counts. Pure
+  // annotation — counts + score are unchanged; this just stops a repo's
+  // own reviewed test fixtures from reading as unexplained headline
+  // criticals. The aggregator stamps `fingerprint` on every
+  // code/secret/config finding, so no identity is computed here.
+  annotateFindingsWithAllowlist(codeFindings, loadAllowlist(result.cwd));
   const codeSummary = {
     critical: aggregate.codeBySeverity.critical + aggregate.secretsBySeverity.critical,
     high: aggregate.codeBySeverity.high + aggregate.secretsBySeverity.high,
@@ -207,6 +217,30 @@ export async function analyzeSecurity(
   };
 }
 
+/**
+ * C-D2: inline " (N allowlisted)" suffix for a subtotal cell, or empty
+ * string when nothing in the axis is allowlisted. Keeps the raw count
+ * authoritative while disclosing how much of it is reviewed-and-accepted.
+ */
+function allowlistedSuffix(allowlisted: number): string {
+  return allowlisted > 0 ? ` (${allowlisted} allowlisted)` : '';
+}
+
+/**
+ * C-D2: explanatory note under a findings table when some of its
+ * findings are allowlisted. Clarifies that the raw count is unchanged
+ * and the suppressed items are reviewed-and-accepted, not hidden.
+ */
+function pushAllowlistedNote(L: string[], allowlisted: number): void {
+  if (allowlisted <= 0) return;
+  L.push(
+    `> ℹ ${allowlisted} of the above ${allowlisted === 1 ? 'finding is' : 'findings are'} ` +
+      `covered by an active allowlist entry (reviewed and accepted). Counts above are raw ` +
+      `totals; the guardrail does not block on allowlisted findings.`,
+  );
+  L.push('');
+}
+
 export function formatSecurityReport(report: SecurityReport, elapsed: string): string {
   const L: string[] = [];
   L.push('# Vulnerability Scan Report');
@@ -249,6 +283,9 @@ export function formatSecurityReport(report: SecurityReport, elapsed: string): s
   const codeSources = [
     ...new Set(report.findings.filter((f) => f.category === 'code').map((f) => f.tool)),
   ].sort();
+  const codeAllowlisted = report.findings.filter(
+    (f) => f.category === 'code' && f.allowlisted,
+  ).length;
   L.push('### Code Findings');
   L.push('');
   L.push(`_Sources: ${codeSources.join(', ') || '(none)'}_`);
@@ -259,8 +296,9 @@ export function formatSecurityReport(report: SecurityReport, elapsed: string): s
   L.push(`| HIGH     | ${c.high} |`);
   L.push(`| MEDIUM   | ${c.medium} |`);
   L.push(`| LOW      | ${c.low} |`);
-  L.push(`| **Subtotal** | **${c.total}** |`);
+  L.push(`| **Subtotal** | **${c.total}**${allowlistedSuffix(codeAllowlisted)} |`);
   L.push('');
+  pushAllowlistedNote(L, codeAllowlisted);
 
   // Secret + config severity table. Reads `summary.secretsOnly` from
   // the aggregator's `secretsBySeverity` axis.
@@ -271,6 +309,9 @@ export function formatSecurityReport(report: SecurityReport, elapsed: string): s
         .map((f) => f.tool),
     ),
   ].sort();
+  const secretAllowlisted = report.findings.filter(
+    (f) => (f.category === 'secret' || f.category === 'config') && f.allowlisted,
+  ).length;
   L.push('### Secret & Config Findings');
   L.push('');
   L.push(`_Sources: ${secretSources.join(', ') || '(none)'}_`);
@@ -281,8 +322,9 @@ export function formatSecurityReport(report: SecurityReport, elapsed: string): s
   L.push(`| HIGH     | ${k.high} |`);
   L.push(`| MEDIUM   | ${k.medium} |`);
   L.push(`| LOW      | ${k.low} |`);
-  L.push(`| **Subtotal** | **${k.total}** |`);
+  L.push(`| **Subtotal** | **${k.total}**${allowlistedSuffix(secretAllowlisted)} |`);
   L.push('');
+  pushAllowlistedNote(L, secretAllowlisted);
 
   L.push('### Dependency Vulnerabilities');
   L.push('');

--- a/src/analyzers/security/index.ts
+++ b/src/analyzers/security/index.ts
@@ -11,6 +11,7 @@ import { gatherAnalysisResultBody } from '../health';
 import { getLanguage } from '../../languages';
 import type { LanguageId } from '../../types';
 import { renderToolsUnavailableLines } from '../tools/tools-unavailable-prose';
+import { isTestSourceFile } from '../tools/walk-source-files';
 import { detectScannerCoverageDrift } from './scanner-drift';
 
 export type { SecurityReport, SecurityFinding } from './types';
@@ -249,6 +250,26 @@ function pushAllowlistedNote(L: string[], allowlisted: number): void {
   L.push('');
 }
 
+/**
+ * Triage guidance for secret findings that sit in test files and aren't
+ * yet allowlisted. dxkit never lowers a secret's severity by location —
+ * a real credential leaked into a test is still a leak — so these surface
+ * at full severity and the reader decides: throwaway fixture (allowlist
+ * it) or real credential (rotate it). `count` is the un-allowlisted,
+ * test-located secret/config findings.
+ */
+function pushTestSecretGuidance(L: string[], count: number): void {
+  if (count <= 0) return;
+  L.push(
+    `> 🔍 ${count} of the above ${count === 1 ? 'finding is' : 'findings are'} in test files. ` +
+      `dxkit does not lower a secret's severity by location — a real credential leaked into a ` +
+      `test is still a leak. Review each: if it's a throwaway fixture, allowlist it with ` +
+      '`vyuh-dxkit allowlist add --category test-fixture` (which also lifts it from the Security ' +
+      `score); if it's a real credential, rotate it and remove it from git history.`,
+  );
+  L.push('');
+}
+
 export function formatSecurityReport(report: SecurityReport, elapsed: string): string {
   const L: string[] = [];
   L.push('# Vulnerability Scan Report');
@@ -332,8 +353,14 @@ export function formatSecurityReport(report: SecurityReport, elapsed: string): s
         .map((f) => f.tool),
     ),
   ].sort();
-  const secretAllowlisted = report.findings.filter(
-    (f) => (f.category === 'secret' || f.category === 'config') && f.allowlisted,
+  const secretConfig = report.findings.filter(
+    (f) => f.category === 'secret' || f.category === 'config',
+  );
+  const secretAllowlisted = secretConfig.filter((f) => f.allowlisted).length;
+  // Un-allowlisted secrets that live in test files — surfaced for triage
+  // (fixture → allowlist, or real → rotate), never auto-suppressed.
+  const secretsInTests = secretConfig.filter(
+    (f) => !f.allowlisted && isTestSourceFile(f.file),
   ).length;
   L.push('### Secret & Config Findings');
   L.push('');
@@ -348,6 +375,7 @@ export function formatSecurityReport(report: SecurityReport, elapsed: string): s
   L.push(`| **Subtotal** | **${k.total}**${allowlistedSuffix(secretAllowlisted)} |`);
   L.push('');
   pushAllowlistedNote(L, secretAllowlisted);
+  pushTestSecretGuidance(L, secretsInTests);
 
   L.push('### Dependency Vulnerabilities');
   L.push('');

--- a/src/analyzers/security/index.ts
+++ b/src/analyzers/security/index.ts
@@ -11,8 +11,6 @@ import { gatherAnalysisResultBody } from '../health';
 import { getLanguage } from '../../languages';
 import type { LanguageId } from '../../types';
 import { renderToolsUnavailableLines } from '../tools/tools-unavailable-prose';
-import { loadAllowlist } from '../../allowlist/file';
-import { annotateFindingsWithAllowlist } from '../../allowlist/annotate';
 import { detectScannerCoverageDrift } from './scanner-drift';
 
 export type { SecurityReport, SecurityFinding } from './types';
@@ -140,19 +138,15 @@ export async function analyzeSecurity(
   // Derived from the dedup'd aggregate, NOT from raw envelope arrays —
   // that's the D086/D091 closure. Sum of unique findings across the
   // code/secret/config categories.
+  // Already carry their allowlist annotation (`allowlisted` /
+  // `allowlistCategory`) — the aggregator stamps it at build time, so
+  // the renderer's "(N allowlisted)" counts and the score-lift share one
+  // source of truth instead of a second annotation pass here.
   const codeFindings = [
     ...aggregate.findingsByCategory.secret,
     ...aggregate.findingsByCategory.code,
     ...aggregate.findingsByCategory.config,
   ];
-
-  // Mark findings an active allowlist entry already accepts, so
-  // the renderer can show "(N allowlisted)" beside raw counts. Pure
-  // annotation — counts + score are unchanged; this just stops a repo's
-  // own reviewed test fixtures from reading as unexplained headline
-  // criticals. The aggregator stamps `fingerprint` on every
-  // code/secret/config finding, so no identity is computed here.
-  annotateFindingsWithAllowlist(codeFindings, loadAllowlist(result.cwd));
   const codeSummary = {
     critical: aggregate.codeBySeverity.critical + aggregate.secretsBySeverity.critical,
     high: aggregate.codeBySeverity.high + aggregate.secretsBySeverity.high,

--- a/src/analyzers/security/index.ts
+++ b/src/analyzers/security/index.ts
@@ -195,6 +195,11 @@ export async function analyzeSecurity(
       codeOnly: codeOnlySummary,
       secretsOnly: secretsOnlySummary,
       dependencies: depSummary,
+      // C-D1: scanner run-state for the score adapter's uncertainty
+      // caps — same canonical provenance the toolsUnavailable list
+      // above is derived from.
+      secretsAvailable: aggregate.provenance.secrets.ran,
+      codePatternsAvailable: aggregate.provenance.codePatterns.ran,
     },
     findings: codeFindings,
     toolsUsed,

--- a/src/analyzers/security/index.ts
+++ b/src/analyzers/security/index.ts
@@ -146,7 +146,7 @@ export async function analyzeSecurity(
     ...aggregate.findingsByCategory.config,
   ];
 
-  // C-D2: mark findings an active allowlist entry already accepts, so
+  // Mark findings an active allowlist entry already accepts, so
   // the renderer can show "(N allowlisted)" beside raw counts. Pure
   // annotation — counts + score are unchanged; this just stops a repo's
   // own reviewed test fixtures from reading as unexplained headline
@@ -196,7 +196,7 @@ export async function analyzeSecurity(
     findings: [...aggregate.findingsByCategory.dependency],
   };
 
-  // C-D3: did the scanner set grow since the last run? If so the report
+  // Did the scanner set grow since the last run? If so the report
   // discloses that new findings are newly *visible*, not newly
   // *introduced* — the root-cause explanation for a score that "got
   // worse" on an unchanged commit after a dxkit upgrade enabled more
@@ -218,7 +218,7 @@ export async function analyzeSecurity(
       codeOnly: codeOnlySummary,
       secretsOnly: secretsOnlySummary,
       dependencies: depSummary,
-      // C-D1: scanner run-state for the score adapter's uncertainty
+      // Scanner run-state for the score adapter's uncertainty
       // caps — same canonical provenance the toolsUnavailable list
       // above is derived from.
       secretsAvailable: aggregate.provenance.secrets.ran,
@@ -232,7 +232,7 @@ export async function analyzeSecurity(
 }
 
 /**
- * C-D2: inline " (N allowlisted)" suffix for a subtotal cell, or empty
+ * Inline " (N allowlisted)" suffix for a subtotal cell, or empty
  * string when nothing in the axis is allowlisted. Keeps the raw count
  * authoritative while disclosing how much of it is reviewed-and-accepted.
  */
@@ -241,7 +241,7 @@ function allowlistedSuffix(allowlisted: number): string {
 }
 
 /**
- * C-D2: explanatory note under a findings table when some of its
+ * Explanatory note under a findings table when some of its
  * findings are allowlisted. Clarifies that the raw count is unchanged
  * and the suppressed items are reviewed-and-accepted, not hidden.
  */
@@ -266,7 +266,7 @@ export function formatSecurityReport(report: SecurityReport, elapsed: string): s
   L.push('---');
   L.push('');
 
-  // C-D3: scanner-coverage-drift note. Surfaced at the very top so a
+  // Scanner-coverage-drift note. Surfaced at the very top so a
   // reader who sees a worse score knows to attribute it to improved
   // measurement, not regressed code, BEFORE reading the numbers.
   if (report.scannerDrift) {

--- a/src/analyzers/security/scanner-drift.ts
+++ b/src/analyzers/security/scanner-drift.ts
@@ -1,0 +1,90 @@
+/**
+ * C-D3: scanner-coverage drift detection across runs.
+ *
+ * Root cause of the customer "my score got worse after fixing things"
+ * support case: between two runs the active scanner set grew (`gitleaks`
+ * → `gitleaks, grep-secrets` + `snyk-code`), which surfaced 7
+ * pre-existing hardcoded credentials that older dxkit simply couldn't
+ * see. The Security score dropped 65 → 40 on an UNCHANGED commit, with
+ * nothing in the report explaining that the findings were newly
+ * *visible*, not newly *introduced*.
+ *
+ * This module compares the current run's scanner set against the most
+ * recent prior vulnerability-scan report persisted under
+ * `.dxkit/reports/`. When the current run added scanners, the report
+ * renders an honest note so a reader attributes any movement to improved
+ * measurement rather than regressed code.
+ *
+ * Read-only + fail-open: an fs or parse problem yields `null` (no note),
+ * never an error — drift disclosure is a nicety, not a gate.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface ScannerCoverageDrift {
+  /** Scanners present this run but absent from the most recent prior
+   *  report — the tools whose findings are newly visible. */
+  readonly added: string[];
+  /** Date (YYYY-MM-DD) of the prior report compared against. */
+  readonly previousDate: string;
+}
+
+const PREFIX = 'vulnerability-scan-';
+const SUFFIX = '-detailed.json';
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Detect scanners added since the most recent prior vuln-scan report.
+ * Returns `null` when there is no prior report, none is readable, or the
+ * scanner set did not grow (a shrinking or identical set is not the
+ * confusing case this note addresses).
+ *
+ * `currentDate` is this run's report date (YYYY-MM-DD); prior reports on
+ * a strictly earlier date are eligible. Same-day files are skipped: a
+ * report dated today is either this run's own prior invocation (already
+ * the post-expansion set — comparing would hide the drift) or about to
+ * be overwritten, so an earlier day is the honest comparison point.
+ */
+export function detectScannerCoverageDrift(
+  repoPath: string,
+  currentTools: readonly string[],
+  currentDate: string,
+): ScannerCoverageDrift | null {
+  const reportDir = path.join(repoPath, '.dxkit', 'reports');
+  let files: string[];
+  try {
+    files = fs.readdirSync(reportDir);
+  } catch {
+    return null; // no reports dir → first run, nothing to compare
+  }
+
+  const prior = files
+    .filter((f) => f.startsWith(PREFIX) && f.endsWith(SUFFIX))
+    .map((f) => ({ file: f, date: f.slice(PREFIX.length, f.length - SUFFIX.length) }))
+    .filter((e) => DATE_RE.test(e.date) && e.date < currentDate)
+    .sort((a, b) => (a.date < b.date ? 1 : -1)); // most recent first
+
+  const currentSet = [...new Set(currentTools)];
+  for (const entry of prior) {
+    const prevTools = readToolsUsed(path.join(reportDir, entry.file));
+    if (!prevTools) continue; // unreadable → try the next-most-recent
+    const prevSet = new Set(prevTools);
+    const added = currentSet.filter((t) => !prevSet.has(t)).sort();
+    // First readable prior report is the comparison point, added-or-not.
+    return added.length > 0 ? { added, previousDate: entry.date } : null;
+  }
+  return null;
+}
+
+/** Parse `toolsUsed` from a persisted detailed report. Fail-open → null. */
+function readToolsUsed(filePath: string): string[] | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as { toolsUsed?: unknown };
+    if (Array.isArray(parsed.toolsUsed)) {
+      return parsed.toolsUsed.filter((t): t is string => typeof t === 'string');
+    }
+  } catch {
+    // unreadable / malformed → skip
+  }
+  return null;
+}

--- a/src/analyzers/security/scanner-drift.ts
+++ b/src/analyzers/security/scanner-drift.ts
@@ -1,5 +1,5 @@
 /**
- * C-D3: scanner-coverage drift detection across runs.
+ * Scanner-coverage drift detection across runs.
  *
  * Root cause of the customer "my score got worse after fixing things"
  * support case: between two runs the active scanner set grew (`gitleaks`

--- a/src/analyzers/security/scanner-drift.ts
+++ b/src/analyzers/security/scanner-drift.ts
@@ -1,13 +1,13 @@
 /**
  * Scanner-coverage drift detection across runs.
  *
- * Root cause of the customer "my score got worse after fixing things"
- * support case: between two runs the active scanner set grew (`gitleaks`
- * → `gitleaks, grep-secrets` + `snyk-code`), which surfaced 7
- * pre-existing hardcoded credentials that older dxkit simply couldn't
- * see. The Security score dropped 65 → 40 on an UNCHANGED commit, with
- * nothing in the report explaining that the findings were newly
- * *visible*, not newly *introduced*.
+ * Closes the "my score got worse after fixing things" confusion: when
+ * the active scanner set grows between two runs (e.g. `gitleaks` →
+ * `gitleaks, grep-secrets` + `snyk-code`), the newly-added scanners
+ * surface pre-existing findings that older runs simply couldn't see. The
+ * Security score can drop on an UNCHANGED commit, with nothing in the
+ * report explaining that those findings are newly *visible*, not newly
+ * *introduced*.
  *
  * This module compares the current run's scanner set against the most
  * recent prior vulnerability-scan report persisted under

--- a/src/analyzers/security/shallow.ts
+++ b/src/analyzers/security/shallow.ts
@@ -19,6 +19,7 @@ import {
   evaluateSpec,
   ratingFromScore,
 } from '../../scoring';
+import { allowlistLiftsScore } from '../../allowlist/annotate';
 import { DimensionScore, ScoreInput } from '../types';
 
 /**
@@ -57,9 +58,13 @@ export function toSecurityScoreInput(input: ScoreInput): SecurityScoreInput {
   // `m.tlsDisabledCount` and `m.evalCount` as separate signals; the
   // aggregate now carries the tls-bypass findings directly (with
   // file/line and post-dedup), so those manual adds are gone.
+  // The score reads the allowlist-adjusted `scoreableCodeBySeverity`
+  // (excludes findings reviewed-and-accepted as false-positive /
+  // test-fixture); reports keep reading the raw `codeBySeverity`. Same
+  // source either way — the aggregator computes both.
   let codeFindings: { critical: number; high: number; medium: number; low: number };
   if (c.securityAggregate) {
-    codeFindings = { ...c.securityAggregate.codeBySeverity };
+    codeFindings = { ...c.securityAggregate.scoreableCodeBySeverity };
   } else {
     // Legacy fallback (test fixtures, pre-2.4.7 callers without
     // `securityAggregate`). Mirrors the pre-C1.3 behavior so existing
@@ -89,12 +94,19 @@ export function toSecurityScoreInput(input: ScoreInput): SecurityScoreInput {
       };
 
   return {
-    // Test-fixture matches (generic password literals inside test
-    // files, auto-downgraded by grep-secrets) stay visible in reports
-    // but must not drive the committed-credentials penalty/cap — a
-    // customer's own unit-test fixtures capped their Security score at
-    // the trust-broken tier.
-    secretFindings: c.secrets?.findings.filter((f) => f.category !== 'test-fixture').length ?? 0,
+    // Secret count for scoring EXCLUDES findings reviewed-and-accepted
+    // as false-positive / test-fixture, so a repo that has triaged its
+    // flagged secrets isn't held at the committed-credentials cap on
+    // noise it has already accepted. Read
+    // from the annotated aggregate when present (its secret category
+    // carries the allowlist status); fall back to the raw capability
+    // count for legacy ScoreInputs with no aggregate. accepted-risk /
+    // deferred are NOT lifted — those accept a real exposure.
+    secretFindings: c.securityAggregate
+      ? c.securityAggregate.findingsByCategory.secret.filter(
+          (f) => !(f.allowlisted && allowlistLiftsScore(f.allowlistCategory)),
+        ).length
+      : (c.secrets?.findings.length ?? 0),
     privateKeyFiles: m.privateKeyFiles,
     envFilesInGit: m.envFilesInGit,
     codeFindings,

--- a/src/analyzers/security/shallow.ts
+++ b/src/analyzers/security/shallow.ts
@@ -93,7 +93,7 @@ export function toSecurityScoreInput(input: ScoreInput): SecurityScoreInput {
     // files, auto-downgraded by grep-secrets) stay visible in reports
     // but must not drive the committed-credentials penalty/cap — a
     // customer's own unit-test fixtures capped their Security score at
-    // the trust-broken tier (C-D4).
+    // the trust-broken tier.
     secretFindings: c.secrets?.findings.filter((f) => f.category !== 'test-fixture').length ?? 0,
     privateKeyFiles: m.privateKeyFiles,
     envFilesInGit: m.envFilesInGit,
@@ -106,7 +106,7 @@ export function toSecurityScoreInput(input: ScoreInput): SecurityScoreInput {
     // is a downgrade; an explicit `false` from the gather is the only
     // signal we trust to apply it.
     depVulnsAvailable: c.depVulnsAvailability?.available ?? true,
-    // C-D1: same default-true contract as depVulnsAvailable — the
+    // Same default-true contract as depVulnsAvailable — the
     // explicit `false` from the gather is the only signal we trust to
     // apply an uncertainty cap. Closes the asymmetry where a missing
     // dep scan capped the score but missing secret/code scanners

--- a/src/analyzers/security/shallow.ts
+++ b/src/analyzers/security/shallow.ts
@@ -106,6 +106,13 @@ export function toSecurityScoreInput(input: ScoreInput): SecurityScoreInput {
     // is a downgrade; an explicit `false` from the gather is the only
     // signal we trust to apply it.
     depVulnsAvailable: c.depVulnsAvailability?.available ?? true,
+    // C-D1: same default-true contract as depVulnsAvailable — the
+    // explicit `false` from the gather is the only signal we trust to
+    // apply an uncertainty cap. Closes the asymmetry where a missing
+    // dep scan capped the score but missing secret/code scanners
+    // silently scored as clean.
+    secretsAvailable: c.secretsAvailability?.available ?? true,
+    codePatternsAvailable: c.codePatternsAvailability?.available ?? true,
   };
 }
 

--- a/src/analyzers/security/shallow.ts
+++ b/src/analyzers/security/shallow.ts
@@ -89,7 +89,12 @@ export function toSecurityScoreInput(input: ScoreInput): SecurityScoreInput {
       };
 
   return {
-    secretFindings: c.secrets?.findings.length ?? 0,
+    // Test-fixture matches (generic password literals inside test
+    // files, auto-downgraded by grep-secrets) stay visible in reports
+    // but must not drive the committed-credentials penalty/cap — a
+    // customer's own unit-test fixtures capped their Security score at
+    // the trust-broken tier (C-D4).
+    secretFindings: c.secrets?.findings.filter((f) => f.category !== 'test-fixture').length ?? 0,
     privateKeyFiles: m.privateKeyFiles,
     envFilesInGit: m.envFilesInGit,
     codeFindings,

--- a/src/analyzers/security/types.ts
+++ b/src/analyzers/security/types.ts
@@ -3,6 +3,7 @@
  */
 import type { DepVulnFinding } from '../../languages/capabilities/types';
 import type { AllowlistCategory } from '../../allowlist/categories';
+import type { ScannerCoverageDrift } from './scanner-drift';
 
 export type Severity = 'critical' | 'high' | 'medium' | 'low';
 
@@ -111,4 +112,12 @@ export interface SecurityReport {
   findings: SecurityFinding[];
   toolsUsed: string[];
   toolsUnavailable: string[];
+  /**
+   * C-D3: scanners added since the most recent prior vuln-scan report,
+   * when any. Present only when the active scanner set grew run-over-run
+   * — drives the "coverage expanded; findings newly visible, not newly
+   * introduced" note that explains an otherwise-baffling score change on
+   * an unchanged commit. Absent on a first run or a stable scanner set.
+   */
+  scannerDrift?: ScannerCoverageDrift;
 }

--- a/src/analyzers/security/types.ts
+++ b/src/analyzers/security/types.ts
@@ -19,7 +19,7 @@ export interface SecurityFinding {
   line: number;
   tool: string;
   /**
-   * C-D2: true when an ACTIVE (unexpired) allowlist entry matches this
+   * True when an ACTIVE (unexpired) allowlist entry matches this
    * finding's fingerprint. The finding is still reported in full (raw
    * counts are unchanged — dxkit's raw-truth model holds), but renderers
    * surface "(N allowlisted)" alongside the subtotal so a reviewer isn't
@@ -30,7 +30,7 @@ export interface SecurityFinding {
    * through a producer and are out of scope here.
    */
   allowlisted?: boolean;
-  /** C-D2: the matched allowlist entry's category (`test-fixture`,
+  /** The matched allowlist entry's category (`test-fixture`,
    *  `false-positive`, `accepted-risk`, ...) so renderers can explain
    *  WHY the finding is suppressed, not just that it is. Present only
    *  when `allowlisted` is true. */
@@ -98,7 +98,7 @@ export interface SecurityReport {
     secretsOnly: { critical: number; high: number; medium: number; low: number; total: number };
     dependencies: DepVulnSummary;
     /**
-     * C-D1: whether the secret / code-pattern scans actually ran,
+     * Whether the secret / code-pattern scans actually ran,
      * from `aggregate.provenance.{secrets,codePatterns}.ran`. The
      * standalone-side score adapter (`countsFromReport`) plumbs these
      * into the uncertainty caps, mirroring `dependencies.available` —
@@ -113,7 +113,7 @@ export interface SecurityReport {
   toolsUsed: string[];
   toolsUnavailable: string[];
   /**
-   * C-D3: scanners added since the most recent prior vuln-scan report,
+   * Scanners added since the most recent prior vuln-scan report,
    * when any. Present only when the active scanner set grew run-over-run
    * — drives the "coverage expanded; findings newly visible, not newly
    * introduced" note that explains an otherwise-baffling score change on

--- a/src/analyzers/security/types.ts
+++ b/src/analyzers/security/types.ts
@@ -2,6 +2,7 @@
  * Security analyzer types.
  */
 import type { DepVulnFinding } from '../../languages/capabilities/types';
+import type { AllowlistCategory } from '../../allowlist/categories';
 
 export type Severity = 'critical' | 'high' | 'medium' | 'low';
 
@@ -16,6 +17,23 @@ export interface SecurityFinding {
   file: string;
   line: number;
   tool: string;
+  /**
+   * C-D2: true when an ACTIVE (unexpired) allowlist entry matches this
+   * finding's fingerprint. The finding is still reported in full (raw
+   * counts are unchanged — dxkit's raw-truth model holds), but renderers
+   * surface "(N allowlisted)" alongside the subtotal so a reviewer isn't
+   * alarmed by, e.g., 8 CRITICAL secrets when 7 are accepted test
+   * fixtures. Absent (undefined) when no allowlist exists or no entry
+   * matches. Only code/secret/config findings (which carry a
+   * fingerprint) are annotated; dependency findings are keyed by tuple
+   * through a producer and are out of scope here.
+   */
+  allowlisted?: boolean;
+  /** C-D2: the matched allowlist entry's category (`test-fixture`,
+   *  `false-positive`, `accepted-risk`, ...) so renderers can explain
+   *  WHY the finding is suppressed, not just that it is. Present only
+   *  when `allowlisted` is true. */
+  allowlistCategory?: AllowlistCategory;
 }
 
 export interface DepVulnSummary {

--- a/src/analyzers/security/types.ts
+++ b/src/analyzers/security/types.ts
@@ -78,6 +78,17 @@ export interface SecurityReport {
      */
     secretsOnly: { critical: number; high: number; medium: number; low: number; total: number };
     dependencies: DepVulnSummary;
+    /**
+     * C-D1: whether the secret / code-pattern scans actually ran,
+     * from `aggregate.provenance.{secrets,codePatterns}.ran`. The
+     * standalone-side score adapter (`countsFromReport`) plumbs these
+     * into the uncertainty caps, mirroring `dependencies.available` —
+     * a "0 secrets" subtotal printed next to "Sources: (none)" must
+     * not score as a confident clean. Optional: report JSONs saved
+     * before 2.10 lack them (adapter defaults to true).
+     */
+    secretsAvailable?: boolean;
+    codePatternsAvailable?: boolean;
   };
   findings: SecurityFinding[];
   toolsUsed: string[];

--- a/src/analyzers/tools/graphify.ts
+++ b/src/analyzers/tools/graphify.ts
@@ -41,16 +41,22 @@ interface GraphifyResult {
   graph?: GraphJson;
 }
 
-/** Build the graphify Python script with cwd-specific exclusions baked in. */
-function buildGraphifyScript(cwd: string): string {
+/**
+ * Build the graphify Python script with cwd-specific exclusions baked in.
+ *
+ * Exported so the structural contract of the generated script — the
+ * `if __name__ == '__main__'` guard that keeps ProcessPoolExecutor workers
+ * from re-running extraction under spawn/forkserver (Python 3.14's Linux
+ * default), and the public `extract(cache_root=...)` cache redirect that
+ * replaced the fragile `cache_dir` monkeypatch — is unit-testable without a
+ * Python interpreter or graphify installed (mirrors `buildGraphifyEnvelope`).
+ */
+export function buildGraphifyScript(cwd: string): string {
   const { dirsSet, pathsList, fileGlobsList } = getPythonExcludeFilter(cwd);
   return `# Exclusion set derived from src/analyzers/tools/exclusions.ts
-import json, sys, os, tempfile
+import json, sys, os
 from pathlib import Path
 from collections import Counter
-
-# Redirect graphify cache to /tmp so we don't pollute the target repo
-_cache_dir = Path(tempfile.mkdtemp(prefix='dxkit-graphify-'))
 
 try:
     from graphify.extract import extract, collect_files
@@ -60,17 +66,6 @@ try:
 except ImportError:
     print(json.dumps({"error": "graphify not installed"}))
     sys.exit(0)
-
-# Redirect graphify's on-disk cache BEFORE any graphify function runs.
-# collect_files() eagerly resolves cache_dir() during enumeration, so
-# the patch has to land before the first graphify call — not after.
-# Pre-patch, a 'graphify-out/cache/' directory was created in the
-# customer's repo every time the analyzer touched a project.
-import graphify.cache as _gc
-_gc.cache_dir = lambda root=None: _cache_dir / "cache"
-(_cache_dir / "cache").mkdir(parents=True, exist_ok=True)
-
-target = Path(sys.argv[1])
 
 # Three-axis exclusion. EXCLUDE_DIRS is basename-only (any path
 # segment matching skips the file). EXCLUDE_PATHS holds multi-segment
@@ -253,407 +248,418 @@ def _strip_paren_suffix(label):
         s = s.rsplit('.', 1)[1]
     return s
 
-all_files = collect_files(target)
-files = [f for f in all_files if not _is_excluded(f)]
-if not files:
-    print(json.dumps({"error": "no files found"}))
-    sys.exit(0)
+if __name__ == '__main__':
+    # ProcessPoolExecutor workers re-import this module under spawn/
+    # forkserver (the Python 3.14 default on Linux); the __main__ guard
+    # keeps extraction from re-running per worker. graphify's own
+    # _extract_parallel requires this guard (it warns BrokenProcessPool
+    # and dies without it). See graphify/extract.py:_extract_parallel.
+    target = Path(sys.argv[1])
+    # graphify's on-disk cache is redirected here (the public cache_root
+    # param passed to extract() below) so it never lands in the target
+    # repo. The TS caller owns this dir's lifecycle — it lives under the
+    # ephemeral scriptDir and is removed after this process fully exits,
+    # which is the only point that survives graphify's atexit stat-index
+    # flush (graphify/cache.py registers _flush_stat_index at exit, so a
+    # Python-side rmtree here would be undone by that post-exit write).
+    _cache_dir = Path(sys.argv[2])
+    all_files = collect_files(target)
+    files = [f for f in all_files if not _is_excluded(f)]
+    if not files:
+        print(json.dumps({"error": "no files found"}))
+        sys.exit(0)
 
-# Suppress progress output by redirecting stdout during extraction
-import io
-_real_stdout = sys.stdout
-sys.stdout = io.StringIO()
-result = extract(files)
-sys.stdout = _real_stdout
-G = build([result], directed=True)
-communities = cluster(G)
+    # Suppress progress output by redirecting stdout during extraction
+    import io
+    _real_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    result = extract(files, cache_root=_cache_dir)
+    sys.stdout = _real_stdout
+    G = build([result], directed=True)
+    communities = cluster(G)
 
-# Functions vs modules
-nodes = list(G.nodes(data=True))
-functions = [(n, d) for n, d in nodes if "()" in d.get("label", "")]
-modules = [(n, d) for n, d in nodes if "()" not in d.get("label", "")]
+    # Functions vs modules
+    nodes = list(G.nodes(data=True))
+    functions = [(n, d) for n, d in nodes if "()" in d.get("label", "")]
+    modules = [(n, d) for n, d in nodes if "()" not in d.get("label", "")]
 
-# Functions per file
-file_funcs = Counter()
-for n, d in functions:
-    sf = d.get("source_file", "")
-    file_funcs[sf] += 1
+    # Functions per file
+    file_funcs = Counter()
+    for n, d in functions:
+        sf = d.get("source_file", "")
+        file_funcs[sf] += 1
 
-max_file = file_funcs.most_common(1)[0] if file_funcs else ("", 0)
+    max_file = file_funcs.most_common(1)[0] if file_funcs else ("", 0)
 
-# God nodes: graphifyy@0.5.0 renamed the result key "edges" → "degree".
-gods = god_nodes(G, top_n=50)
-god_count = sum(1 for g in gods if g["degree"] > 15)
+    # God nodes: graphifyy@0.5.0 renamed the result key "edges" → "degree".
+    gods = god_nodes(G, top_n=50)
+    god_count = sum(1 for g in gods if g["degree"] > 15)
 
-# Cohesion
-scores = score_all(G, communities) if communities else {}
-avg_cohesion = sum(scores.values()) / len(scores) if scores else 0.0
+    # Cohesion
+    scores = score_all(G, communities) if communities else {}
+    avg_cohesion = sum(scores.values()) / len(scores) if scores else 0.0
 
-# Orphan modules (no inbound imports)
-import_targets = set()
-for u, v, data in G.edges(data=True):
-    if data.get("relation") == "imports_from":
-        import_targets.add(v)
-module_ids = set(n for n, d in modules)
-orphans = module_ids - import_targets
+    # Orphan modules (no inbound imports)
+    import_targets = set()
+    for u, v, data in G.edges(data=True):
+        if data.get("relation") == "imports_from":
+            import_targets.add(v)
+    module_ids = set(n for n, d in modules)
+    orphans = module_ids - import_targets
 
-# Dead imports (imported but never called)
-call_targets = set()
-for u, v, data in G.edges(data=True):
-    if data.get("relation") == "calls":
-        call_targets.add(v)
-dead = import_targets - call_targets - module_ids
+    # Dead imports (imported but never called)
+    call_targets = set()
+    for u, v, data in G.edges(data=True):
+        if data.get("relation") == "calls":
+            call_targets.add(v)
+    dead = import_targets - call_targets - module_ids
 
-# Commented code ratio: source files with 0 function/class AST nodes
-source_files_set = set()
-files_with_nodes = set()
-for n, d in nodes:
-    sf = d.get("source_file", "")
-    if sf:
-        source_files_set.add(sf)
-        if "()" in d.get("label", "") or any(
-            data.get("relation") == "method"
-            for _, _, data in G.edges(n, data=True)
-        ):
-            files_with_nodes.add(sf)
+    # Commented code ratio: source files with 0 function/class AST nodes
+    source_files_set = set()
+    files_with_nodes = set()
+    for n, d in nodes:
+        sf = d.get("source_file", "")
+        if sf:
+            source_files_set.add(sf)
+            if "()" in d.get("label", "") or any(
+                data.get("relation") == "method"
+                for _, _, data in G.edges(n, data=True)
+            ):
+                files_with_nodes.add(sf)
 
-total_src = len(source_files_set)
-empty_files = total_src - len(files_with_nodes)
-commented_ratio = empty_files / total_src if total_src > 0 else 0.0
+    total_src = len(source_files_set)
+    empty_files = total_src - len(files_with_nodes)
+    commented_ratio = empty_files / total_src if total_src > 0 else 0.0
 
 
-# ── Build the full graph artifact ────────────────────────────────────────────
-# 2.7 Sprint 1: emit nodes / edges / communities / symbolIndex alongside
-# the aggregate metrics. Consumers (explore CLI, dashboard viz, future
-# 2.8 context CLI + reachability) read this via src/explore/load.ts.
-# Schema contract documented in tmp/2.7-graph-json-schema.md.
+    # ── Build the full graph artifact ────────────────────────────────────────────
+    # 2.7 Sprint 1: emit nodes / edges / communities / symbolIndex alongside
+    # the aggregate metrics. Consumers (explore CLI, dashboard viz, future
+    # 2.8 context CLI + reachability) read this via src/explore/load.ts.
+    # Schema contract documented in tmp/2.7-graph-json-schema.md.
 
-# Determine class membership: a module-shaped node is a CLASS if it has
-# outbound 'method' edges to other nodes (it's the owner). A function-
-# shaped node ("()" in label) is a METHOD if it has inbound 'method'
-# edges from a class node; otherwise it's a free FUNCTION.
-_class_owners = set()
-_method_members = set()
-for u, v, data in G.edges(data=True):
-    if data.get("relation") == "method":
-        _class_owners.add(u)
-        _method_members.add(v)
+    # Determine class membership: a module-shaped node is a CLASS if it has
+    # outbound 'method' edges to other nodes (it's the owner). A function-
+    # shaped node ("()" in label) is a METHOD if it has inbound 'method'
+    # edges from a class node; otherwise it's a free FUNCTION.
+    _class_owners = set()
+    _method_members = set()
+    for u, v, data in G.edges(data=True):
+        if data.get("relation") == "method":
+            _class_owners.add(u)
+            _method_members.add(v)
 
-def _node_kind(nid, attrs):
-    label = attrs.get('label', '')
-    is_callable = '()' in label
-    if is_callable:
-        return 'method' if nid in _method_members else 'function'
-    return 'class' if nid in _class_owners else 'module'
+    def _node_kind(nid, attrs):
+        label = attrs.get('label', '')
+        is_callable = '()' in label
+        if is_callable:
+            return 'method' if nid in _method_members else 'function'
+        return 'class' if nid in _class_owners else 'module'
 
-# Make node sourceFile paths project-relative (graphify emits absolute
-# paths derived from \`target = sys.argv[1]\`). Mirrors the existing
-# maxFunctionsFilePath path-normalization at the TS layer.
-def _rel(p):
-    if not p:
-        return ''
-    s = str(p).replace(os.sep, '/')
-    t = str(target).replace(os.sep, '/').rstrip('/')
-    if s.startswith(t + '/'):
-        return s[len(t) + 1:]
-    if s == t:
-        return ''
-    return s
+    # Make node sourceFile paths project-relative (graphify emits absolute
+    # paths derived from \`target = sys.argv[1]\`). Mirrors the existing
+    # maxFunctionsFilePath path-normalization at the TS layer.
+    def _rel(p):
+        if not p:
+            return ''
+        s = str(p).replace(os.sep, '/')
+        t = str(target).replace(os.sep, '/').rstrip('/')
+        if s.startswith(t + '/'):
+            return s[len(t) + 1:]
+        if s == t:
+            return ''
+        return s
 
-# Assign stable in-run ids: n0, n1, n2, ... in extraction order. The
-# graphify-internal id strings (long underscored slugs) work but bloat
-# the JSON by ~20 bytes per node; the n<idx> shortening saves ~50KB on
-# a 13k-node repo. IDs are NOT stable across runs (per schema doc).
-_id_remap = {}
-graph_nodes = []
-for idx, (nid, attrs) in enumerate(nodes):
-    short_id = f'n{idx}'
-    _id_remap[nid] = short_id
-    line_no = _parse_line_no(attrs)
-    rel_source = _rel(attrs.get('source_file', ''))
-    label = attrs.get('label', '')
-    name = _strip_paren_suffix(label)
-    kind = _node_kind(nid, attrs)
-    node_obj = {
-        'id': short_id,
-        'kind': kind,
-        'label': label,
-        'sourceFile': rel_source,
-    }
-    if line_no:
-        node_obj['line'] = line_no
-    # Export detection only meaningful for symbol-bearing kinds
-    # (functions, classes, methods). Module-level "is this file
-    # exported?" isn't a useful question — exclude.
-    if kind in ('function', 'class', 'method'):
-        # Resolve to absolute path for the file-line cache (we read
-        # the raw source content; the cache key is the actual path
-        # on disk, not the project-relative form).
-        abs_source = attrs.get('source_file', '')
-        exported = _detect_exported(abs_source, line_no, name)
-        if exported is not None:
-            node_obj['exported'] = exported
-    graph_nodes.append(node_obj)
-
-# Edges remapped to short ids. Drop self-loops and edges where either
-# endpoint was filtered out (defensive — graphify shouldn't produce them
-# but be tolerant). Graphify emits both 'imports' (broad form: \`import X\`)
-# and 'imports_from' (\`from X import Y\` / \`import {Y} from X\`); both
-# carry the same semantic for our schema ("A imports from B"). Merge
-# both into the canonical 'imports_from' edge relation. The 'contains'
-# and 'inherits' relations graphify also produces are intentionally
-# dropped — 'contains' duplicates the file/symbol-membership info
-# already encoded in nodes' sourceFile field, and 'inherits' is
-# class-inheritance which isn't yet a first-class schema relation.
-graph_edges = []
-for u, v, data in G.edges(data=True):
-    if u not in _id_remap or v not in _id_remap:
-        continue
-    graphify_relation = data.get('relation', '')
-    if graphify_relation == 'calls':
-        relation = 'calls'
-    elif graphify_relation in ('imports', 'imports_from'):
-        relation = 'imports_from'
-    elif graphify_relation == 'method':
-        relation = 'method'
-    else:
-        continue
-    edge_obj = {
-        'from': _id_remap[u],
-        'to': _id_remap[v],
-        'relation': relation,
-    }
-    graph_edges.append(edge_obj)
-
-# Communities: for each cluster compute dominantSourceDir + dominantPack.
-# dominantSourceDir = most common ancestor directory (the longest
-# leading-segment path that >= 40% of members share); empty string when
-# no clear dominant. dominantPack = most common pack id among member
-# files' extensions; empty when no dominant pack.
-def _ancestor_dir(rel_path):
-    if not rel_path or '/' not in rel_path:
-        return ''
-    return rel_path.rsplit('/', 1)[0] + '/'
-
-graph_communities = []
-# Graphify's cluster() returns dict[community_id: list[node_id]].
-# Iterate via .items(); the community_id is the actual cluster
-# identifier (used to look up cohesion in scores), members is the
-# node-id list.
-_node_attrs_by_id = dict(nodes)
-for cidx, member_list in communities.items():
-    member_ids = sorted(_id_remap.get(n, '') for n in member_list if n in _id_remap)
-    member_ids = [m for m in member_ids if m]
-    if not member_ids:
-        continue
-    # Per-member source files (project-relative)
-    member_files = []
-    for nid in member_list:
-        if nid in _id_remap:
-            sf = _rel(_node_attrs_by_id.get(nid, {}).get('source_file', ''))
-            if sf:
-                member_files.append(sf)
-    # Dominant directory: longest common ancestor that >= 40% of
-    # members share (or empty if no clear winner).
-    dir_counter = Counter(_ancestor_dir(f) for f in member_files)
-    dir_counter.pop('', None)
-    dominant_dir = ''
-    if dir_counter:
-        top_dir, top_count = dir_counter.most_common(1)[0]
-        if top_count / len(member_files) >= 0.4:
-            dominant_dir = top_dir
-    # Dominant pack
-    pack_counter = Counter()
-    for f in member_files:
-        pk = _EXT_TO_PACK.get(_ext_of(f))
-        if pk:
-            pack_counter[pk] += 1
-    dominant_pack = ''
-    if pack_counter:
-        top_pack, top_pack_count = pack_counter.most_common(1)[0]
-        if top_pack_count / max(1, len(member_files)) >= 0.5:
-            dominant_pack = top_pack
-    cohesion = float(scores.get(cidx, 0.0)) if scores else 0.0
-    graph_communities.append({
-        'id': cidx,
-        'nodeIds': member_ids,
-        'cohesion': round(cohesion, 3),
-        'dominantSourceDir': dominant_dir,
-        'dominantPack': dominant_pack,
-    })
-
-# Symbol index: lowercased label (without trailing ()) → list of nodeIds.
-_symbol_index = {}
-for node_obj in graph_nodes:
-    key = _strip_paren_suffix(node_obj['label']).lower()
-    if not key:
-        continue
-    _symbol_index.setdefault(key, []).append(node_obj['id'])
-
-# Active-pack detection: derive from extensions seen in source files.
-_packs_seen = sorted({_EXT_TO_PACK[e] for e in (_ext_of(_rel(d.get('source_file', '')))
-                                                  for _, d in nodes)
-                       if e in _EXT_TO_PACK})
-
-# Size-budget enforcement. Hard cap 50MB serialized. If we exceed,
-# drop method edges first (densest class — structural noise, doesn't
-# affect call-graph queries).
-import datetime as _dt
-_meta = {
-    'tool': 'graphify',
-    'graphifyVersion': '',  # filled by TS-side post-parse (read from graphifyy package version)
-    'dxkitVersion': '',     # filled by TS-side post-parse (read from package.json)
-    'generatedAt': _dt.datetime.now(_dt.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-    'sourceFilesInGraph': total_src,
-    'excludedFileCount': len(all_files) - len(files),
-    'packs': _packs_seen,
-    'truncated': False,
-    'truncatedReason': '',
-}
-
-_graph_payload = {
-    'schemaVersion': 1,
-    'meta': _meta,
-    'nodes': graph_nodes,
-    'edges': graph_edges,
-    'communities': graph_communities,
-    'symbolIndex': _symbol_index,
-}
-
-# Cheap pre-check on size: serialize once, measure, drop method edges
-# if over the cap, re-serialize. The 50MB cap matches the schema
-# contract; 10MB soft target is informational only (no enforcement).
-_BYTES_HARD_CAP = 50 * 1024 * 1024
-
-def _serialize(payload):
-    return json.dumps(payload, separators=(',', ':'))
-
-_graph_json = _serialize(_graph_payload)
-if len(_graph_json.encode('utf-8')) > _BYTES_HARD_CAP:
-    # Drop method edges first; they're structural (class-owns-method),
-    # not behavioral. Call + import edges carry the actionable info.
-    pre_count = len(_graph_payload['edges'])
-    _graph_payload['edges'] = [e for e in _graph_payload['edges']
-                               if e['relation'] != 'method']
-    post_count = len(_graph_payload['edges'])
-    _meta['truncated'] = True
-    _meta['truncatedReason'] = (
-        f"dropped {pre_count - post_count} method edges to fit under "
-        f"the 50MB hard cap"
-    )
-
-# Render the interactive viewer alongside graph.json so the dashboard
-# Graph tab can embed it. graphify ships its own vis.js-based renderer
-# (graphify.export.to_html). Two emission paths:
-#
-#   - Full graph (G.number_of_nodes() <= MAX_NODES_FOR_VIZ = 5000):
-#     pass the original G + communities. The viewer renders every
-#     symbol; the user can zoom + drill.
-#
-#   - Aggregated community view (G > MAX_NODES_FOR_VIZ): build a
-#     networkx super-graph whose nodes ARE the communities. Sized by
-#     member count via graphify member_counts parameter. Inter-
-#     community edges aggregated to weighted edges. This lets a
-#     customer-scale repo still get a meaningful "what does this
-#     codebase look like" viz instead of a dead empty-state.
-#
-# Either way failures are non-fatal: the dashboard surfaces a clear
-# empty-state when graph.html isn't on disk.
-try:
-    from graphify.export import to_html as _to_html, MAX_NODES_FOR_VIZ as _MAX_VIZ
-    import networkx as _nx
-    _html_dir = target / '.dxkit' / 'reports'
-    _html_dir.mkdir(parents=True, exist_ok=True)
-    _html_path = _html_dir / 'graph.html'
-
-    if G.number_of_nodes() <= _MAX_VIZ:
-        _labels = {
-            c['id']: (c.get('dominantSourceDir') or f"community-{c['id']}")
-            for c in graph_communities
+    # Assign stable in-run ids: n0, n1, n2, ... in extraction order. The
+    # graphify-internal id strings (long underscored slugs) work but bloat
+    # the JSON by ~20 bytes per node; the n<idx> shortening saves ~50KB on
+    # a 13k-node repo. IDs are NOT stable across runs (per schema doc).
+    _id_remap = {}
+    graph_nodes = []
+    for idx, (nid, attrs) in enumerate(nodes):
+        short_id = f'n{idx}'
+        _id_remap[nid] = short_id
+        line_no = _parse_line_no(attrs)
+        rel_source = _rel(attrs.get('source_file', ''))
+        label = attrs.get('label', '')
+        name = _strip_paren_suffix(label)
+        kind = _node_kind(nid, attrs)
+        node_obj = {
+            'id': short_id,
+            'kind': kind,
+            'label': label,
+            'sourceFile': rel_source,
         }
-        _to_html(G, communities, str(_html_path), community_labels=_labels)
-        _viz_mode = 'full'
-    else:
-        # Aggregated community super-graph.
-        _node_to_comm = {}
-        for _cid, _members in communities.items():
-            for _nid in _members:
-                _node_to_comm[_nid] = _cid
+        if line_no:
+            node_obj['line'] = line_no
+        # Export detection only meaningful for symbol-bearing kinds
+        # (functions, classes, methods). Module-level "is this file
+        # exported?" isn't a useful question — exclude.
+        if kind in ('function', 'class', 'method'):
+            # Resolve to absolute path for the file-line cache (we read
+            # the raw source content; the cache key is the actual path
+            # on disk, not the project-relative form).
+            abs_source = attrs.get('source_file', '')
+            exported = _detect_exported(abs_source, line_no, name)
+            if exported is not None:
+                node_obj['exported'] = exported
+        graph_nodes.append(node_obj)
 
-        _G_agg = _nx.DiGraph()
-        _member_counts = {}
-        _labels = {}
-        for _c in graph_communities:
-            _cid = _c['id']
-            _label = _c.get('dominantSourceDir') or f"community-{_cid}"
-            # vis.js node attrs: label drives display; file_type is
-            # surfaced in graphify's sidebar so we set a sentinel
-            # value the dashboard can grep on.
-            _G_agg.add_node(_cid, label=_label, source_file='', file_type='community')
-            _member_counts[_cid] = len(_c['nodeIds'])
-            _labels[_cid] = _label
+    # Edges remapped to short ids. Drop self-loops and edges where either
+    # endpoint was filtered out (defensive — graphify shouldn't produce them
+    # but be tolerant). Graphify emits both 'imports' (broad form: \`import X\`)
+    # and 'imports_from' (\`from X import Y\` / \`import {Y} from X\`); both
+    # carry the same semantic for our schema ("A imports from B"). Merge
+    # both into the canonical 'imports_from' edge relation. The 'contains'
+    # and 'inherits' relations graphify also produces are intentionally
+    # dropped — 'contains' duplicates the file/symbol-membership info
+    # already encoded in nodes' sourceFile field, and 'inherits' is
+    # class-inheritance which isn't yet a first-class schema relation.
+    graph_edges = []
+    for u, v, data in G.edges(data=True):
+        if u not in _id_remap or v not in _id_remap:
+            continue
+        graphify_relation = data.get('relation', '')
+        if graphify_relation == 'calls':
+            relation = 'calls'
+        elif graphify_relation in ('imports', 'imports_from'):
+            relation = 'imports_from'
+        elif graphify_relation == 'method':
+            relation = 'method'
+        else:
+            continue
+        edge_obj = {
+            'from': _id_remap[u],
+            'to': _id_remap[v],
+            'relation': relation,
+        }
+        graph_edges.append(edge_obj)
 
-        # Cross-community edge aggregation. Counter keyed on
-        # (smaller_id, larger_id) for undirected aggregation; we then
-        # add a directed edge in one canonical direction so vis.js
-        # has a definite source/target. The viewer doesn't show
-        # arrows on these (they're community connections, not calls).
-        from collections import Counter as _CommCounter
-        _edge_w = _CommCounter()
-        for _u, _v, _ in G.edges(data=True):
-            _cu = _node_to_comm.get(_u)
-            _cv = _node_to_comm.get(_v)
-            if _cu is None or _cv is None or _cu == _cv:
-                continue
-            _key = (_cu, _cv) if _cu < _cv else (_cv, _cu)
-            _edge_w[_key] += 1
-        for (_a, _b), _w in _edge_w.items():
-            _G_agg.add_edge(_a, _b, relation='inter_community', occurrences=_w)
+    # Communities: for each cluster compute dominantSourceDir + dominantPack.
+    # dominantSourceDir = most common ancestor directory (the longest
+    # leading-segment path that >= 40% of members share); empty string when
+    # no clear dominant. dominantPack = most common pack id among member
+    # files' extensions; empty when no dominant pack.
+    def _ancestor_dir(rel_path):
+        if not rel_path or '/' not in rel_path:
+            return ''
+        return rel_path.rsplit('/', 1)[0] + '/'
 
-        # to_html requires a communities dict; one-element groups
-        # treat each aggregated node as its own community so each
-        # community keeps a distinct color in graphify's palette.
-        _agg_groups = {_cid: [_cid] for _cid in communities}
+    graph_communities = []
+    # Graphify's cluster() returns dict[community_id: list[node_id]].
+    # Iterate via .items(); the community_id is the actual cluster
+    # identifier (used to look up cohesion in scores), members is the
+    # node-id list.
+    _node_attrs_by_id = dict(nodes)
+    for cidx, member_list in communities.items():
+        member_ids = sorted(_id_remap.get(n, '') for n in member_list if n in _id_remap)
+        member_ids = [m for m in member_ids if m]
+        if not member_ids:
+            continue
+        # Per-member source files (project-relative)
+        member_files = []
+        for nid in member_list:
+            if nid in _id_remap:
+                sf = _rel(_node_attrs_by_id.get(nid, {}).get('source_file', ''))
+                if sf:
+                    member_files.append(sf)
+        # Dominant directory: longest common ancestor that >= 40% of
+        # members share (or empty if no clear winner).
+        dir_counter = Counter(_ancestor_dir(f) for f in member_files)
+        dir_counter.pop('', None)
+        dominant_dir = ''
+        if dir_counter:
+            top_dir, top_count = dir_counter.most_common(1)[0]
+            if top_count / len(member_files) >= 0.4:
+                dominant_dir = top_dir
+        # Dominant pack
+        pack_counter = Counter()
+        for f in member_files:
+            pk = _EXT_TO_PACK.get(_ext_of(f))
+            if pk:
+                pack_counter[pk] += 1
+        dominant_pack = ''
+        if pack_counter:
+            top_pack, top_pack_count = pack_counter.most_common(1)[0]
+            if top_pack_count / max(1, len(member_files)) >= 0.5:
+                dominant_pack = top_pack
+        cohesion = float(scores.get(cidx, 0.0)) if scores else 0.0
+        graph_communities.append({
+            'id': cidx,
+            'nodeIds': member_ids,
+            'cohesion': round(cohesion, 3),
+            'dominantSourceDir': dominant_dir,
+            'dominantPack': dominant_pack,
+        })
 
-        _to_html(
-            _G_agg, _agg_groups, str(_html_path),
-            community_labels=_labels, member_counts=_member_counts,
+    # Symbol index: lowercased label (without trailing ()) → list of nodeIds.
+    _symbol_index = {}
+    for node_obj in graph_nodes:
+        key = _strip_paren_suffix(node_obj['label']).lower()
+        if not key:
+            continue
+        _symbol_index.setdefault(key, []).append(node_obj['id'])
+
+    # Active-pack detection: derive from extensions seen in source files.
+    _packs_seen = sorted({_EXT_TO_PACK[e] for e in (_ext_of(_rel(d.get('source_file', '')))
+                                                      for _, d in nodes)
+                           if e in _EXT_TO_PACK})
+
+    # Size-budget enforcement. Hard cap 50MB serialized. If we exceed,
+    # drop method edges first (densest class — structural noise, doesn't
+    # affect call-graph queries).
+    import datetime as _dt
+    _meta = {
+        'tool': 'graphify',
+        'graphifyVersion': '',  # filled by TS-side post-parse (read from graphifyy package version)
+        'dxkitVersion': '',     # filled by TS-side post-parse (read from package.json)
+        'generatedAt': _dt.datetime.now(_dt.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'sourceFilesInGraph': total_src,
+        'excludedFileCount': len(all_files) - len(files),
+        'packs': _packs_seen,
+        'truncated': False,
+        'truncatedReason': '',
+    }
+
+    _graph_payload = {
+        'schemaVersion': 1,
+        'meta': _meta,
+        'nodes': graph_nodes,
+        'edges': graph_edges,
+        'communities': graph_communities,
+        'symbolIndex': _symbol_index,
+    }
+
+    # Cheap pre-check on size: serialize once, measure, drop method edges
+    # if over the cap, re-serialize. The 50MB cap matches the schema
+    # contract; 10MB soft target is informational only (no enforcement).
+    _BYTES_HARD_CAP = 50 * 1024 * 1024
+
+    def _serialize(payload):
+        return json.dumps(payload, separators=(',', ':'))
+
+    _graph_json = _serialize(_graph_payload)
+    if len(_graph_json.encode('utf-8')) > _BYTES_HARD_CAP:
+        # Drop method edges first; they're structural (class-owns-method),
+        # not behavioral. Call + import edges carry the actionable info.
+        pre_count = len(_graph_payload['edges'])
+        _graph_payload['edges'] = [e for e in _graph_payload['edges']
+                                   if e['relation'] != 'method']
+        post_count = len(_graph_payload['edges'])
+        _meta['truncated'] = True
+        _meta['truncatedReason'] = (
+            f"dropped {pre_count - post_count} method edges to fit under "
+            f"the 50MB hard cap"
         )
-        _viz_mode = 'aggregated'
 
-    # Sidecar so the dashboard renderer can label the view honestly.
-    # JSON is tiny (~120B); avoids parsing graph.json twice from TS.
-    _meta_path = _html_dir / 'graph.html.meta.json'
-    _meta_path.write_text(json.dumps({
-        'mode': _viz_mode,
-        'totalNodes': G.number_of_nodes(),
-        'totalEdges': G.number_of_edges(),
-        'communities': len(communities),
-        'aggregatedNodeCount': len(communities) if _viz_mode == 'aggregated' else None,
+    # Render the interactive viewer alongside graph.json so the dashboard
+    # Graph tab can embed it. graphify ships its own vis.js-based renderer
+    # (graphify.export.to_html). Two emission paths:
+    #
+    #   - Full graph (G.number_of_nodes() <= MAX_NODES_FOR_VIZ = 5000):
+    #     pass the original G + communities. The viewer renders every
+    #     symbol; the user can zoom + drill.
+    #
+    #   - Aggregated community view (G > MAX_NODES_FOR_VIZ): build a
+    #     networkx super-graph whose nodes ARE the communities. Sized by
+    #     member count via graphify member_counts parameter. Inter-
+    #     community edges aggregated to weighted edges. This lets a
+    #     customer-scale repo still get a meaningful "what does this
+    #     codebase look like" viz instead of a dead empty-state.
+    #
+    # Either way failures are non-fatal: the dashboard surfaces a clear
+    # empty-state when graph.html isn't on disk.
+    try:
+        from graphify.export import to_html as _to_html, MAX_NODES_FOR_VIZ as _MAX_VIZ
+        import networkx as _nx
+        _html_dir = target / '.dxkit' / 'reports'
+        _html_dir.mkdir(parents=True, exist_ok=True)
+        _html_path = _html_dir / 'graph.html'
+
+        if G.number_of_nodes() <= _MAX_VIZ:
+            _labels = {
+                c['id']: (c.get('dominantSourceDir') or f"community-{c['id']}")
+                for c in graph_communities
+            }
+            _to_html(G, communities, str(_html_path), community_labels=_labels)
+            _viz_mode = 'full'
+        else:
+            # Aggregated community super-graph.
+            _node_to_comm = {}
+            for _cid, _members in communities.items():
+                for _nid in _members:
+                    _node_to_comm[_nid] = _cid
+
+            _G_agg = _nx.DiGraph()
+            _member_counts = {}
+            _labels = {}
+            for _c in graph_communities:
+                _cid = _c['id']
+                _label = _c.get('dominantSourceDir') or f"community-{_cid}"
+                # vis.js node attrs: label drives display; file_type is
+                # surfaced in graphify's sidebar so we set a sentinel
+                # value the dashboard can grep on.
+                _G_agg.add_node(_cid, label=_label, source_file='', file_type='community')
+                _member_counts[_cid] = len(_c['nodeIds'])
+                _labels[_cid] = _label
+
+            # Cross-community edge aggregation. Counter keyed on
+            # (smaller_id, larger_id) for undirected aggregation; we then
+            # add a directed edge in one canonical direction so vis.js
+            # has a definite source/target. The viewer doesn't show
+            # arrows on these (they're community connections, not calls).
+            from collections import Counter as _CommCounter
+            _edge_w = _CommCounter()
+            for _u, _v, _ in G.edges(data=True):
+                _cu = _node_to_comm.get(_u)
+                _cv = _node_to_comm.get(_v)
+                if _cu is None or _cv is None or _cu == _cv:
+                    continue
+                _key = (_cu, _cv) if _cu < _cv else (_cv, _cu)
+                _edge_w[_key] += 1
+            for (_a, _b), _w in _edge_w.items():
+                _G_agg.add_edge(_a, _b, relation='inter_community', occurrences=_w)
+
+            # to_html requires a communities dict; one-element groups
+            # treat each aggregated node as its own community so each
+            # community keeps a distinct color in graphify's palette.
+            _agg_groups = {_cid: [_cid] for _cid in communities}
+
+            _to_html(
+                _G_agg, _agg_groups, str(_html_path),
+                community_labels=_labels, member_counts=_member_counts,
+            )
+            _viz_mode = 'aggregated'
+
+        # Sidecar so the dashboard renderer can label the view honestly.
+        # JSON is tiny (~120B); avoids parsing graph.json twice from TS.
+        _meta_path = _html_dir / 'graph.html.meta.json'
+        _meta_path.write_text(json.dumps({
+            'mode': _viz_mode,
+            'totalNodes': G.number_of_nodes(),
+            'totalEdges': G.number_of_edges(),
+            'communities': len(communities),
+            'aggregatedNodeCount': len(communities) if _viz_mode == 'aggregated' else None,
+        }))
+    except Exception as _html_err:
+        sys.stderr.write(f"dxkit: graph.html not generated ({_html_err})\\n")
+
+    print(json.dumps({
+        "functionCount": len(functions),
+        "classCount": len([n for n, d in modules if any(
+            data.get("relation") == "method" for _, _, data in G.edges(n, data=True)
+        )]),
+        "maxFunctionsInFile": max_file[1] if max_file else 0,
+        "maxFunctionsFilePath": str(max_file[0]) if max_file else "",
+        "godNodeCount": god_count,
+        "communityCount": len(communities),
+        "avgCohesion": round(avg_cohesion, 3),
+        "orphanModuleCount": len(orphans),
+        "deadImportCount": len(dead),
+        "commentedCodeRatio": round(commented_ratio, 3),
+        "sourceFilesInGraph": total_src,
+        "graph": _graph_payload,
     }))
-except Exception as _html_err:
-    sys.stderr.write(f"dxkit: graph.html not generated ({_html_err})\\n")
-
-# Clean up temp cache
-import shutil
-shutil.rmtree(str(_cache_dir), ignore_errors=True)
-
-print(json.dumps({
-    "functionCount": len(functions),
-    "classCount": len([n for n, d in modules if any(
-        data.get("relation") == "method" for _, _, data in G.edges(n, data=True)
-    )]),
-    "maxFunctionsInFile": max_file[1] if max_file else 0,
-    "maxFunctionsFilePath": str(max_file[0]) if max_file else "",
-    "godNodeCount": god_count,
-    "communityCount": len(communities),
-    "avgCohesion": round(avg_cohesion, 3),
-    "orphanModuleCount": len(orphans),
-    "deadImportCount": len(dead),
-    "commentedCodeRatio": round(commented_ratio, 3),
-    "sourceFilesInGraph": total_src,
-    "graph": _graph_payload,
-}))
 `;
 }
 
@@ -792,6 +798,15 @@ async function computeAndCache(cwd: string): Promise<void> {
   // don't litter /tmp across runs.
   const scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-graphify-'));
   const scriptPath = path.join(scriptDir, 'run.py');
+  // graphify's on-disk AST cache is redirected here (passed to the script
+  // as argv[2] → extract(cache_root=...)), keeping it out of the target
+  // repo. It lives under scriptDir so the single `fs.rmSync(scriptDir)`
+  // below reclaims it — crucially AFTER the Python process and its atexit
+  // handlers exit. graphify flushes a stat-index via atexit
+  // (graphify/cache.py), so cleaning the cache from inside the script
+  // would be undone by that post-exit write; owning the lifecycle here is
+  // the only leak-free point.
+  const cacheDir = path.join(scriptDir, 'graphify-cache');
   fs.writeFileSync(scriptPath, buildGraphifyScript(cwd));
   // Spawn-with-process-group so the Python interpreter + any
   // tree-sitter worker subprocesses it starts are all killed
@@ -804,7 +819,7 @@ async function computeAndCache(cwd: string): Promise<void> {
   //
   // runDetached captures stderr natively so the tempfile redirect
   // pattern is no longer needed — same effect, fewer moving parts.
-  const outcome = await runDetached(pythonCmd, [scriptPath, cwd], {
+  const outcome = await runDetached(pythonCmd, [scriptPath, cwd, cacheDir], {
     cwd: scriptDir,
     timeoutMs: 300000, // 5 min — bumped from 120000 in 2.4.7 for multi-thousand-file frontend repos
   });

--- a/src/analyzers/tools/grep-secrets.ts
+++ b/src/analyzers/tools/grep-secrets.ts
@@ -30,7 +30,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { findTool, TOOL_DEFS } from './tool-registry';
 import { applySuppressions, loadSuppressions } from './suppressions';
-import { walkSourceFiles } from './walk-source-files';
+import { isTestSourceFile, walkSourceFiles } from './walk-source-files';
 import type { CapabilityProvider } from '../../languages/capabilities/provider';
 import type { SecretFinding, SecretsResult } from '../../languages/capabilities/types';
 
@@ -98,11 +98,32 @@ export function gatherGrepSecretsResult(cwd: string): SecretsResult | null {
     } catch {
       continue;
     }
+    // Generic keyword-assignment matches inside a test file are almost
+    // always fixtures (`password: 'password1'` in a unit test), not
+    // committed credentials — flagging them CRITICAL buried a real
+    // customer's headline counts under their own test data. Downgrade
+    // to low + tag `test-fixture` (still visible, never headline, and
+    // excluded from the committed-credentials cap by the score
+    // adapter). Branded token shapes keep full severity everywhere: a
+    // real AWS key in a test file is still a leaked credential.
+    const isTest = isTestSourceFile(rel);
     const lines = content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       for (const sp of patterns) {
         if (sp.regex.test(lines[i])) {
-          raw.push({ file: rel, line: i + 1, rule: sp.rule, severity: severityFor(sp.rule) });
+          const fixture = isTest && GENERIC_PATTERNS.includes(sp);
+          raw.push({
+            file: rel,
+            line: i + 1,
+            rule: sp.rule,
+            severity: fixture ? 'low' : severityFor(sp.rule),
+            ...(fixture
+              ? {
+                  category: 'test-fixture' as const,
+                  title: 'Likely test fixture (in a test file) — auto-downgraded',
+                }
+              : {}),
+          });
           break; // at most one finding per line
         }
       }

--- a/src/analyzers/tools/grep-secrets.ts
+++ b/src/analyzers/tools/grep-secrets.ts
@@ -30,7 +30,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { findTool, TOOL_DEFS } from './tool-registry';
 import { applySuppressions, loadSuppressions } from './suppressions';
-import { isTestSourceFile, walkSourceFiles } from './walk-source-files';
+import { walkSourceFiles } from './walk-source-files';
 import type { CapabilityProvider } from '../../languages/capabilities/provider';
 import type { SecretFinding, SecretsResult } from '../../languages/capabilities/types';
 
@@ -98,32 +98,20 @@ export function gatherGrepSecretsResult(cwd: string): SecretsResult | null {
     } catch {
       continue;
     }
-    // Generic keyword-assignment matches inside a test file are almost
-    // always fixtures (`password: 'password1'` in a unit test), not
-    // committed credentials — flagging them CRITICAL buried a real
-    // customer's headline counts under their own test data. Downgrade
-    // to low + tag `test-fixture` (still visible, never headline, and
-    // excluded from the committed-credentials cap by the score
-    // adapter). Branded token shapes keep full severity everywhere: a
-    // real AWS key in a test file is still a leaked credential.
-    const isTest = isTestSourceFile(rel);
+    // Findings keep their natural severity regardless of file path. A
+    // hardcoded credential is severe whether it sits in production code
+    // or a test — the generic matcher cannot tell a throwaway fixture
+    // (`password: 'password1'`) from a real password leaked into an
+    // integration test, so lowering severity by path would silently
+    // hide genuine leaks. Test-file noise is managed downstream instead:
+    // the report groups test-located secrets for review (a pure function
+    // of the path), and the score lifts only the ones a human has
+    // explicitly allowlisted as `test-fixture` / `false-positive`.
     const lines = content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       for (const sp of patterns) {
         if (sp.regex.test(lines[i])) {
-          const fixture = isTest && GENERIC_PATTERNS.includes(sp);
-          raw.push({
-            file: rel,
-            line: i + 1,
-            rule: sp.rule,
-            severity: fixture ? 'low' : severityFor(sp.rule),
-            ...(fixture
-              ? {
-                  category: 'test-fixture' as const,
-                  title: 'Likely test fixture (in a test file) — auto-downgraded',
-                }
-              : {}),
-          });
+          raw.push({ file: rel, line: i + 1, rule: sp.rule, severity: severityFor(sp.rule) });
           break; // at most one finding per line
         }
       }

--- a/src/analyzers/tools/osv-scanner-fix.ts
+++ b/src/analyzers/tools/osv-scanner-fix.ts
@@ -133,7 +133,17 @@ export async function gatherOsvScannerFixPlans(
     if (!outcome.stdout) return new Map();
     return parseOsvScannerFixOutput(outcome.stdout);
   } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    // Best-effort cleanup. On Windows the npm-install grandchildren (or
+    // antivirus scanning their files) can briefly hold handles inside the
+    // temp dir, making the immediate rm fail with EPERM. Retry with
+    // backoff, and never throw out of this finally — a throw here would
+    // discard the already-parsed fix plans, turning a cleanup hiccup into
+    // a week of invisible dep vulns (the original customer symptom).
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+    } catch {
+      // Leaked temp dir < lost dep-audit result. The OS temp cleaner owns it now.
+    }
   }
 }
 

--- a/src/analyzers/tools/osv-scanner-fix.ts
+++ b/src/analyzers/tools/osv-scanner-fix.ts
@@ -137,8 +137,8 @@ export async function gatherOsvScannerFixPlans(
     // antivirus scanning their files) can briefly hold handles inside the
     // temp dir, making the immediate rm fail with EPERM. Retry with
     // backoff, and never throw out of this finally — a throw here would
-    // discard the already-parsed fix plans, turning a cleanup hiccup into
-    // a week of invisible dep vulns (the original customer symptom).
+    // discard the already-parsed fix plans, turning a transient cleanup
+    // hiccup into silently missing dependency vulnerabilities entirely.
     try {
       fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
     } catch {

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -615,7 +615,13 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
   semgrep: {
     name: 'semgrep',
     description: 'Static analysis security scanner (SAST)',
-    install: 'pipx install semgrep',
+    // Pinned (2.10 version-pin sweep). semgrep is the highest-risk
+    // unpinned tool — it runs on every scan and dxkit parses its JSON
+    // output, so a breaking CLI/schema change lands like jscpd 5.x did.
+    // 1.165.0 is the version the 2.9.x benchmark suite validated against.
+    // Proper multi-version/schema-adaptive handling is deferred to a
+    // later release; this freeze is the defensive stopgap.
+    install: 'pipx install "semgrep==1.165.0"',
     check: 'semgrep --version',
     for: 'all',
     layer: 'universal',
@@ -623,9 +629,9 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     probePaths: [`${TOOLS_VENV}/bin`, `${LEGACY_TOOLS_VENV}/bin`],
     versionCheck: 'semgrep --version',
     installCommands: {
-      macos: `${PIPX_BOOTSTRAP} && pipx install semgrep`,
-      linux: `${PIPX_BOOTSTRAP} && pipx install semgrep`,
-      windows: 'pipx install semgrep',
+      macos: `${PIPX_BOOTSTRAP} && pipx install "semgrep==1.165.0"`,
+      linux: `${PIPX_BOOTSTRAP} && pipx install "semgrep==1.165.0"`,
+      windows: 'pipx install "semgrep==1.165.0"',
     },
   },
   eslint: {
@@ -705,7 +711,8 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
   'license-checker-rseidelsohn': {
     name: 'license-checker-rseidelsohn',
     description: 'License inventory for npm dependencies (maintained fork of license-checker)',
-    install: 'npm install -g license-checker-rseidelsohn',
+    // Pinned (2.10 version-pin sweep) — dxkit parses its JSON inventory.
+    install: 'npm install -g license-checker-rseidelsohn@5.0.1',
     check: 'license-checker-rseidelsohn --version',
     for: 'node',
     layer: 'language',
@@ -713,16 +720,19 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     versionCheck: 'license-checker-rseidelsohn --version',
     installCommands: {
       macos:
-        'mkdir -p ~/.local/share/dxkit && cd ~/.local/share/dxkit && npm install license-checker-rseidelsohn && mkdir -p ~/.local/bin && ln -sf ~/.local/share/dxkit/node_modules/.bin/license-checker-rseidelsohn ~/.local/bin/license-checker-rseidelsohn',
+        'mkdir -p ~/.local/share/dxkit && cd ~/.local/share/dxkit && npm install license-checker-rseidelsohn@5.0.1 && mkdir -p ~/.local/bin && ln -sf ~/.local/share/dxkit/node_modules/.bin/license-checker-rseidelsohn ~/.local/bin/license-checker-rseidelsohn',
       linux:
-        'mkdir -p ~/.local/share/dxkit && cd ~/.local/share/dxkit && npm install license-checker-rseidelsohn && mkdir -p ~/.local/bin && ln -sf ~/.local/share/dxkit/node_modules/.bin/license-checker-rseidelsohn ~/.local/bin/license-checker-rseidelsohn',
-      windows: 'npm install -g license-checker-rseidelsohn',
+        'mkdir -p ~/.local/share/dxkit && cd ~/.local/share/dxkit && npm install license-checker-rseidelsohn@5.0.1 && mkdir -p ~/.local/bin && ln -sf ~/.local/share/dxkit/node_modules/.bin/license-checker-rseidelsohn ~/.local/bin/license-checker-rseidelsohn',
+      windows: 'npm install -g license-checker-rseidelsohn@5.0.1',
     },
   },
   ruff: {
     name: 'ruff',
     description: 'Python linting and formatting',
-    install: 'pipx install ruff',
+    // Pinned (2.10 version-pin sweep) to the current release — freezes
+    // fresh installs to today's de-facto version so a future breaking
+    // major can't silently change lint output or exit codes.
+    install: 'pipx install "ruff==0.15.17"',
     check: 'ruff --version',
     for: 'python',
     layer: 'language',
@@ -730,15 +740,16 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     probePaths: [`${TOOLS_VENV}/bin`, `${LEGACY_TOOLS_VENV}/bin`],
     versionCheck: 'ruff --version',
     installCommands: {
-      macos: `${PIPX_BOOTSTRAP} && pipx install ruff`,
-      linux: `${PIPX_BOOTSTRAP} && pipx install ruff`,
-      windows: 'pipx install ruff',
+      macos: `${PIPX_BOOTSTRAP} && pipx install "ruff==0.15.17"`,
+      linux: `${PIPX_BOOTSTRAP} && pipx install "ruff==0.15.17"`,
+      windows: 'pipx install "ruff==0.15.17"',
     },
   },
   'pip-audit': {
     name: 'pip-audit',
     description: 'Python dependency vulnerability scanning',
-    install: 'pipx install pip-audit',
+    // Pinned (2.10 version-pin sweep) — dxkit parses pip-audit's JSON.
+    install: 'pipx install "pip-audit==2.10.1"',
     check: 'pip-audit --version',
     for: 'python',
     layer: 'language',
@@ -746,15 +757,16 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     probePaths: [`${TOOLS_VENV}/bin`, `${LEGACY_TOOLS_VENV}/bin`],
     versionCheck: 'pip-audit --version',
     installCommands: {
-      macos: `${PIPX_BOOTSTRAP} && pipx install pip-audit`,
-      linux: `${PIPX_BOOTSTRAP} && pipx install pip-audit`,
-      windows: 'pipx install pip-audit',
+      macos: `${PIPX_BOOTSTRAP} && pipx install "pip-audit==2.10.1"`,
+      linux: `${PIPX_BOOTSTRAP} && pipx install "pip-audit==2.10.1"`,
+      windows: 'pipx install "pip-audit==2.10.1"',
     },
   },
   'pip-licenses': {
     name: 'pip-licenses',
     description: 'License inventory for Python packages in a venv',
-    install: 'pipx install pip-licenses',
+    // Pinned (2.10 version-pin sweep) — dxkit parses pip-licenses JSON.
+    install: 'pipx install "pip-licenses==5.5.5"',
     check: 'pip-licenses --version',
     for: 'python',
     layer: 'language',
@@ -762,15 +774,21 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     probePaths: [`${TOOLS_VENV}/bin`, `${LEGACY_TOOLS_VENV}/bin`],
     versionCheck: 'pip-licenses --version',
     installCommands: {
-      macos: `${PIPX_BOOTSTRAP} && pipx install pip-licenses`,
-      linux: `${PIPX_BOOTSTRAP} && pipx install pip-licenses`,
-      windows: 'pipx install pip-licenses',
+      macos: `${PIPX_BOOTSTRAP} && pipx install "pip-licenses==5.5.5"`,
+      linux: `${PIPX_BOOTSTRAP} && pipx install "pip-licenses==5.5.5"`,
+      windows: 'pipx install "pip-licenses==5.5.5"',
     },
   },
   'golangci-lint': {
     name: 'golangci-lint',
     description: 'Go linting',
-    install: 'go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest',
+    // Pinned (2.10 version-pin sweep) to the latest v1 release.
+    // golangci-lint v2 is a breaking rewrite on a separate `/v2` module
+    // path (changed config schema + output) — exactly the jscpd-5.x
+    // class. The v1 module path's @latest still resolves to v1.64.8;
+    // we pin it explicitly so a future v1→v2 retag can't surprise us.
+    // brew (macos) tracks its own version and is exempt from the pin.
+    install: 'go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8',
     check: 'golangci-lint --version',
     for: 'go',
     layer: 'language',
@@ -778,38 +796,40 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     versionCheck: 'golangci-lint --version',
     installCommands: {
       macos: 'brew install golangci-lint',
-      linux: 'go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest',
-      windows: 'go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest',
+      linux: 'go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8',
+      windows: 'go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8',
     },
   },
   govulncheck: {
     name: 'govulncheck',
     description: 'Go vulnerability scanning',
-    install: 'go install golang.org/x/vuln/cmd/govulncheck@latest',
+    // Pinned (2.10 version-pin sweep) — dxkit parses govulncheck output.
+    install: 'go install golang.org/x/vuln/cmd/govulncheck@v1.3.0',
     check: 'govulncheck -version',
     for: 'go',
     layer: 'language',
     binaries: ['govulncheck'],
     versionCheck: 'govulncheck -version',
     installCommands: {
-      macos: 'go install golang.org/x/vuln/cmd/govulncheck@latest',
-      linux: 'go install golang.org/x/vuln/cmd/govulncheck@latest',
-      windows: 'go install golang.org/x/vuln/cmd/govulncheck@latest',
+      macos: 'go install golang.org/x/vuln/cmd/govulncheck@v1.3.0',
+      linux: 'go install golang.org/x/vuln/cmd/govulncheck@v1.3.0',
+      windows: 'go install golang.org/x/vuln/cmd/govulncheck@v1.3.0',
     },
   },
   'go-licenses': {
     name: 'go-licenses',
     description: 'License inventory for Go modules',
-    install: 'go install github.com/google/go-licenses@latest',
+    // Pinned (2.10 version-pin sweep) — dxkit parses go-licenses output.
+    install: 'go install github.com/google/go-licenses@v1.6.0',
     check: 'go-licenses --help',
     for: 'go',
     layer: 'language',
     binaries: ['go-licenses'],
     versionCheck: 'go-licenses --help | head -1',
     installCommands: {
-      macos: 'go install github.com/google/go-licenses@latest',
-      linux: 'go install github.com/google/go-licenses@latest',
-      windows: 'go install github.com/google/go-licenses@latest',
+      macos: 'go install github.com/google/go-licenses@v1.6.0',
+      linux: 'go install github.com/google/go-licenses@v1.6.0',
+      windows: 'go install github.com/google/go-licenses@v1.6.0',
     },
   },
   clippy: {
@@ -997,7 +1017,10 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
   'coverage-py': {
     name: 'coverage-py',
     description: 'Python line-level coverage (produces coverage.json)',
-    install: 'pipx install coverage',
+    // Pinned (2.10 version-pin sweep) — dxkit parses coverage.json,
+    // whose schema is stable across the 7.x line. Freeze defends
+    // against a future major that changes the report shape.
+    install: 'pipx install "coverage==7.14.1"',
     check: 'coverage --version',
     for: 'python',
     layer: 'language',
@@ -1005,9 +1028,9 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     probePaths: [`${TOOLS_VENV}/bin`, `${LEGACY_TOOLS_VENV}/bin`],
     versionCheck: 'coverage --version',
     installCommands: {
-      macos: `${PIPX_BOOTSTRAP} && pipx install coverage`,
-      linux: `${PIPX_BOOTSTRAP} && pipx install coverage`,
-      windows: 'pipx install coverage',
+      macos: `${PIPX_BOOTSTRAP} && pipx install "coverage==7.14.1"`,
+      linux: `${PIPX_BOOTSTRAP} && pipx install "coverage==7.14.1"`,
+      windows: 'pipx install "coverage==7.14.1"',
     },
   },
   rubocop: {

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -567,7 +567,14 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
   graphify: {
     name: 'graphify',
     description: 'Deterministic AST extraction via tree-sitter (20+ languages)',
-    install: 'pip install graphifyy',
+    // graphifyy pinned to a tested release. Unpinned, `pip install graphifyy`
+    // pulls the latest, and graphifyy's internal API drifts between minors
+    // (0.8 changed `cache_dir(root)` → `cache_dir(root, kind)`, #582). The
+    // generated script in graphify.ts now drives graphify only through its
+    // public surface (`extract(..., cache_root=...)`), so the pin guards
+    // against a future *public*-API drift, not the cache_dir signature.
+    // Bumping requires retesting the generated script against the new release.
+    install: 'pip install "graphifyy==0.8.36"',
     check: 'python3 -c "import graphify"',
     for: 'all',
     layer: 'optional',
@@ -577,16 +584,21 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
       'python3 -c "import graphify; print(\'installed\')" || $HOME/.cache/dxkit/tools-venv/bin/python -c "import graphify; print(\'installed\')"',
     installCommands: {
       macos:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install -q graphifyy',
+        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install -q "graphifyy==0.8.36"',
       linux:
-        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install -q graphifyy',
-      windows: 'pip install --user graphifyy',
+        'mkdir -p "$HOME/.cache/dxkit" && (test -d "$HOME/.cache/dxkit/tools-venv" || python3 -m venv "$HOME/.cache/dxkit/tools-venv") && "$HOME/.cache/dxkit/tools-venv/bin/pip" install -q "graphifyy==0.8.36"',
+      windows: 'pip install --user "graphifyy==0.8.36"',
     },
   },
   jscpd: {
     name: 'jscpd',
     description: 'Copy-paste / duplicate code detector',
-    install: 'npm install -g jscpd',
+    // jscpd pinned to the last 4.x. jscpd 5.x is a Rust rewrite ("cpd") that
+    // dropped the `--gitignore` flag (jscpd.ts passes it → exit 2) AND changed
+    // the report JSON schema this module parses. Pinning to 4.x is lower-risk
+    // than tracking v5's CLI + schema; revisit as a deliberate v5 migration
+    // (flag + parser) if/when we adopt it.
+    install: 'npm install -g jscpd@4.2.5',
     check: 'jscpd --version',
     for: 'all',
     layer: 'universal',
@@ -594,10 +606,10 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     versionCheck: 'jscpd --version',
     installCommands: {
       macos:
-        'mkdir -p ~/.local/share/dxkit && cd ~/.local/share/dxkit && npm install jscpd && mkdir -p ~/.local/bin && ln -sf ~/.local/share/dxkit/node_modules/.bin/jscpd ~/.local/bin/jscpd',
+        'mkdir -p ~/.local/share/dxkit && cd ~/.local/share/dxkit && npm install jscpd@4.2.5 && mkdir -p ~/.local/bin && ln -sf ~/.local/share/dxkit/node_modules/.bin/jscpd ~/.local/bin/jscpd',
       linux:
-        'mkdir -p ~/.local/share/dxkit && cd ~/.local/share/dxkit && npm install jscpd && mkdir -p ~/.local/bin && ln -sf ~/.local/share/dxkit/node_modules/.bin/jscpd ~/.local/bin/jscpd',
-      windows: 'npm install -g jscpd',
+        'mkdir -p ~/.local/share/dxkit && cd ~/.local/share/dxkit && npm install jscpd@4.2.5 && mkdir -p ~/.local/bin && ln -sf ~/.local/share/dxkit/node_modules/.bin/jscpd ~/.local/bin/jscpd',
+      windows: 'npm install -g jscpd@4.2.5',
     },
   },
   semgrep: {

--- a/src/analyzers/tools/walk-source-files.ts
+++ b/src/analyzers/tools/walk-source-files.ts
@@ -265,6 +265,20 @@ function splitTestPatterns(patterns: string[]): {
 }
 
 /**
+ * Classify a project-relative path as a test file using the active
+ * language packs' test patterns — the same classification the walker's
+ * `includeTests` filter applies. Exported so consumers that walk WITH
+ * tests included (e.g. grep-secrets, which must still see test files)
+ * can distinguish them without re-deriving pattern-matching logic.
+ * Registry-rooted: only call from index-rooted code paths, not from
+ * inside a language pack (see the module-cycle note at the top).
+ */
+export function isTestSourceFile(relPath: string): boolean {
+  const basename = relPath.slice(relPath.lastIndexOf('/') + 1);
+  return isTestFile(relPath, basename, splitTestPatterns(allTestFilePatterns()));
+}
+
+/**
  * Count directories under `cwd`, mirroring `find . -type d ${getFindExcludeFlags(cwd)}`:
  * the root counts as 1, plus every descendant directory not pruned by
  * the centralized exclusion set (`isExcludedPath`). Cross-platform,

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -257,6 +257,13 @@ export interface CapabilityReport {
    *  out under parallel load). */
   codePatternsAvailability?: { available: boolean; unavailableReason: string };
 
+  /** Availability for SECRETS (gitleaks + grep-secrets). Same shape.
+   *  C-D1: read by `toSecurityScoreInput` so a failed secret scan
+   *  caps the Security score (uncertainty tier) instead of silently
+   *  counting as "0 secrets" — the asymmetry that made a customer's
+   *  scanner-enabling upgrade read as a score regression. */
+  secretsAvailability?: { available: boolean; unavailableReason: string };
+
   /** Availability for DUPLICATION (jscpd). Same shape. */
   duplicationAvailability?: { available: boolean; unavailableReason: string };
 

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -258,7 +258,7 @@ export interface CapabilityReport {
   codePatternsAvailability?: { available: boolean; unavailableReason: string };
 
   /** Availability for SECRETS (gitleaks + grep-secrets). Same shape.
-   *  C-D1: read by `toSecurityScoreInput` so a failed secret scan
+   *  read by `toSecurityScoreInput` so a failed secret scan
    *  caps the Security score (uncertainty tier) instead of silently
    *  counting as "0 secrets" — the asymmetry that made a customer's
    *  scanner-enabling upgrade read as a score regression. */

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -260,7 +260,7 @@ export interface CapabilityReport {
   /** Availability for SECRETS (gitleaks + grep-secrets). Same shape.
    *  read by `toSecurityScoreInput` so a failed secret scan
    *  caps the Security score (uncertainty tier) instead of silently
-   *  counting as "0 secrets" — the asymmetry that made a customer's
+   *  counting as "0 secrets" — the asymmetry that made a
    *  scanner-enabling upgrade read as a score regression. */
   secretsAvailability?: { available: boolean; unavailableReason: string };
 

--- a/src/baseline/entry-to-located.ts
+++ b/src/baseline/entry-to-located.ts
@@ -15,11 +15,18 @@
  * location-pair pass must too. The canonical-rule registry doesn't
  * apply to hygiene markers; the marker IS the canonical name.
  *
- * Kinds without file/line locators (dep-vuln, duplication,
- * coverage-gap, test-gap, test-file-degradation, god-file,
- * stale-file, large-file, secret-hmac) fall through to the matcher's
- * multiset pass — they're paired by exact identity-hash equality,
- * which the matcher already handles without any locator metadata.
+ * Whole-file findings (test-gap, coverage-gap, test-file-degradation,
+ * god-file, stale-file, large-file) are file-anchored but carry no
+ * line. They flow to the matcher's whole-file rename pass with `file`
+ * populated and `kind` carried in `rule` — so a pure file rename
+ * relocates them (instead of reading as removed+added → false net-new
+ * debt), and two different whole-file kinds on the same renamed file
+ * never cross-pair. The line-anchored passes skip them (no line); the
+ * multiset pass still pairs them by exact identity-hash equality.
+ *
+ * Kinds without any file/line locator (dep-vuln, duplication,
+ * secret-hmac) fall through to the matcher's multiset pass — paired by
+ * exact identity-hash equality, no locator metadata needed.
  */
 
 import { canonicalRuleFor } from '../analyzers/tools/fingerprint';
@@ -70,14 +77,21 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
         line: entry.line,
         rule: entry.category,
       };
-    case 'dep-vuln':
-    case 'duplication':
     case 'coverage-gap':
     case 'test-gap':
     case 'test-file-degradation':
     case 'god-file':
     case 'stale-file':
     case 'large-file':
+      // Whole-file findings: file-anchored, no line. `file` lets the
+      // matcher's whole-file rename pass relocate them on a pure rename;
+      // `kind` (reused as the `rule` discriminator, like hygiene/marker
+      // and stale-allow/category above) keeps two different whole-file
+      // kinds on the same renamed file from cross-pairing. No line, so
+      // the line-anchored passes correctly skip them.
+      return { id: entry.id, file: entry.file, rule: entry.kind };
+    case 'dep-vuln':
+    case 'duplication':
     case 'secret-hmac':
       return { id: entry.id };
   }

--- a/src/baseline/git-aware-match.ts
+++ b/src/baseline/git-aware-match.ts
@@ -29,11 +29,13 @@
  * on its own. Callers in shallow-clone CI or non-git workflows get
  * a working (if less precise) result.
  *
- * Known limitations (Sprint 0 v1):
- *   - File renames are not auto-tracked. A renamed file looks like
- *     "removed prior + added current"; future iterations will use
- *     `git log --follow` or `git diff -M` rename detection to close
- *     this gap.
+ * File renames are auto-tracked via git's rename detection
+ * (`--find-renames`): line-anchored findings relocate through Pass 1
+ * (the rename map feeds `mapLineThroughDiff`), and whole-file findings
+ * (test-gap, large-file, …) relocate through Pass 1b. A renamed file
+ * therefore reports `relocated`, not removed+added.
+ *
+ * Known limitations:
  *   - Cross-file refactors (function extracted to a new file) are
  *     reported as removed-and-added.
  *   - When the line-bucket mapping fails on context edits (tool
@@ -333,6 +335,60 @@ export function gitAwareMatch(
         reasons,
       });
     }
+
+    // Pass 1b — whole-file rename relocation. Whole-file findings
+    // (test-gap, large-file, stale-file, test-file-degradation, …) are
+    // file-anchored with no line, so Pass 1's line mapping can't reach
+    // them. Their identity is path-based, so a pure file rename makes a
+    // naive diff read them as removed+added → false net-new debt on a
+    // rename. Here we remap each unmatched prior whole-file finding's
+    // file through the rename map and pair it with an unmatched current
+    // whole-file finding of the SAME kind at the renamed path. The key
+    // is (renamed-path, kind) — `entryToLocated` carries the kind in
+    // `rule` — so two different whole-file kinds on one renamed file
+    // never cross-pair (which would mask a genuinely new finding as
+    // relocated). Acts only on files git detected as renamed; same-path
+    // whole-file findings are left to Pass 2's exact-id match.
+    if (renames.size > 0) {
+      const currentWholeFile = new Map<string, LocatedIdentity[]>();
+      for (const c of current) {
+        if (currentMatched.has(c)) continue;
+        if (!c.file || c.line !== undefined) continue; // whole-file only
+        const key = wholeFileKey(c.file, c.rule);
+        const bucket = currentWholeFile.get(key);
+        if (bucket) bucket.push(c);
+        else currentWholeFile.set(key, [c]);
+      }
+      const takeWholeFile = (key: string): LocatedIdentity | undefined => {
+        const bucket = currentWholeFile.get(key);
+        if (!bucket || bucket.length === 0) return undefined;
+        const head = bucket.shift();
+        if (bucket.length === 0) currentWholeFile.delete(key);
+        return head;
+      };
+      for (const p of prior) {
+        if (priorMatched.has(p)) continue;
+        if (!p.file || p.line !== undefined) continue; // whole-file only
+        const renamedPath = renames.get(p.file);
+        if (renamedPath === undefined || renamedPath === p.file) continue; // renamed only
+        const candidate = takeWholeFile(wholeFileKey(renamedPath, p.rule));
+        if (!candidate) continue;
+        priorMatched.add(p);
+        currentMatched.add(candidate);
+        pairs.push({
+          priorId: p.id,
+          currentId: candidate.id,
+          status: 'relocated',
+          confidence: CONFIDENCE_GIT_EXACT,
+          reasons: [
+            {
+              code: 'git-rename',
+              detail: `whole-file finding relocated across rename: ${p.file} → ${renamedPath}`,
+            },
+          ],
+        });
+      }
+    }
   }
 
   // Pass 1.5 — content-hash fallback. Pairs prior+current findings
@@ -428,6 +484,15 @@ function locationKey(file: string, rule: string, line: number): string {
 
 function contentKey(rule: string, contentHash: string): string {
   return `content\0${rule}\0${contentHash}`;
+}
+
+/** Key for the whole-file rename pass: renamed path + the finding's
+ *  kind (carried in `rule` by `entryToLocated`). The kind component
+ *  stops two different whole-file kinds on one renamed file from
+ *  cross-pairing. `rule` is always present for produced whole-file
+ *  findings; the `?? ''` guards a hand-built identity that omits it. */
+function wholeFileKey(file: string, rule: string | undefined): string {
+  return `${file}\0${rule ?? ''}`;
 }
 
 /**

--- a/src/explore/context-hook.ts
+++ b/src/explore/context-hook.ts
@@ -6,15 +6,17 @@
  * `additionalContext`, so the agent needs fewer follow-up whole-file
  * reads.
  *
- * Delivery surfaces (2.10 redesign — F-01/F-02/F-03):
+ * Delivery surfaces:
  *   - **Read** — keyed on the FILE the agent is opening. Injects that
  *     file's structural summary (symbols + who calls it + what it calls).
  *     This is the highest-leverage surface: agents read files constantly,
  *     so the hook fires reliably and is useful regardless of search term.
  *   - **Bash** — parses `grep`/`rg`-style commands. When a concrete
  *     source file is named, delivers that file's summary; otherwise falls
- *     back to a symbol-name match on the search pattern. Closes F-01:
- *     real agents search via `Bash grep`, not the native `Grep` tool.
+ *     back to a symbol-name match on the search pattern. This is what lets
+ *     the hook engage at all in a real fix workflow: agents search via the
+ *     `Bash` tool (`grep -n …`), not the native `Grep` tool, so a
+ *     Grep-only hook almost never fired.
  *   - **Grep / Glob** — the original surface, keyed on `tool_input.pattern`
  *     matched against graph symbol names.
  *

--- a/src/explore/context-hook.ts
+++ b/src/explore/context-hook.ts
@@ -1,50 +1,100 @@
 /**
  * `vyuh-dxkit context-hook` — the Claude Code PreToolUse hook that
  * delivers the token-reduction win passively. Wired into a scaffolded
- * repo's `.claude/settings.json` with a `Grep|Glob` matcher: when an
- * agent is about to search the codebase, this hook injects a slim
- * structural map as `additionalContext` so the agent needs fewer
- * follow-up whole-file reads.
+ * repo's `.claude/settings.json` so that when an agent reads or searches
+ * the codebase, this hook injects a slim structural map as
+ * `additionalContext`, so the agent needs fewer follow-up whole-file
+ * reads.
+ *
+ * Delivery surfaces (2.10 redesign — F-01/F-02/F-03):
+ *   - **Read** — keyed on the FILE the agent is opening. Injects that
+ *     file's structural summary (symbols + who calls it + what it calls).
+ *     This is the highest-leverage surface: agents read files constantly,
+ *     so the hook fires reliably and is useful regardless of search term.
+ *   - **Bash** — parses `grep`/`rg`-style commands. When a concrete
+ *     source file is named, delivers that file's summary; otherwise falls
+ *     back to a symbol-name match on the search pattern. Closes F-01:
+ *     real agents search via `Bash grep`, not the native `Grep` tool.
+ *   - **Grep / Glob** — the original surface, keyed on `tool_input.pattern`
+ *     matched against graph symbol names.
+ *
+ * Pre-2.10 the hook fired ONLY on `Grep`/`Glob` and ONLY when the search
+ * pattern substring-matched a symbol name — which almost never happened
+ * in a real fix workflow (agents grep symptoms like `sendFile` via
+ * `Bash`, not enclosing symbol names via `Grep`). The file-keyed Read
+ * surface is the bridge from proven-deterministic graph value to
+ * realized-agentic delivery.
  *
  * THE CONTRACT IS FAIL-OPEN + ADDITIVE. This hook can only ever ADD
- * context; it never blocks the tool, never replaces grep output, and
+ * context; it never blocks the tool, never replaces tool output, and
  * stays a silent no-op (exit 0, no stdout) on ANY problem — missing
- * graph.json, parse error, no keyword match, unreadable stdin. So
- * Claude Code behaves exactly as it does today whenever the graph is
- * absent or unhelpful; the hook is pure upside.
+ * graph.json, parse error, no match, unreadable stdin. So Claude Code
+ * behaves exactly as it does today whenever the graph is absent or
+ * unhelpful; the hook is pure upside.
  *
  * Claude Code passes the tool call as JSON on stdin
- * (`{ tool_name, tool_input: { pattern, ... }, ... }`) and reads a
- * JSON object on stdout with `hookSpecificOutput.additionalContext`.
+ * (`{ tool_name, tool_input, session_id, cwd, ... }`) and reads a JSON
+ * object on stdout with `hookSpecificOutput.additionalContext`.
  */
-
-import { contextQuery, type ContextResult } from './queries';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { contextQuery, fileSummaryQuery, type ContextResult, type FileSummary } from './queries';
 import { tryLoadGraph } from './load';
 import type { Graph } from './types';
 
-/** Stingier than the manual CLI's 2000 — the hook fires on every grep. */
+/** Stingier than the manual CLI's 2000 — the hook fires on every search/read. */
 const HOOK_BUDGET = 1500;
 
+/** What the agent's tool call resolved to: a specific file, or a search term. */
+type HookTarget = { kind: 'file'; file: string } | { kind: 'pattern'; pattern: string };
+
 /**
- * Entry point for `case 'context-hook'`. Reads stdin, runs the query,
- * writes the hook output. Wrapped so nothing it does can fail the
- * tool call: every failure path resolves to a silent no-op.
+ * Entry point for `case 'context-hook'`. Reads stdin, resolves the
+ * target, runs the query, writes the hook output. Wrapped so nothing it
+ * does can fail the tool call: every failure path resolves to a silent
+ * no-op.
  */
 export async function runContextHook(cwd: string): Promise<void> {
   try {
     const raw = await readStdin();
     if (!raw.trim()) return;
 
-    const pattern = extractPattern(raw);
-    if (!pattern) return;
+    const payload = parsePayload(raw);
+    if (!payload) return;
 
     const graph = tryLoadGraph(cwd);
     if (!graph) return;
 
-    const result = contextQuery(graph, pattern, { budget: HOOK_BUDGET, substring: true });
-    if (!result.matched || result.selection.length === 0) return;
+    const target = resolveHookTarget(payload, graph, cwd);
+    if (!target) return;
 
-    const additionalContext = formatHookContext(result, graph);
+    // Per-session, per-file dedup: a file's structural map is injected at
+    // most once per session, so an agent re-reading the same file doesn't
+    // pay the context cost repeatedly. Best-effort — a dedup-state failure
+    // falls through to injecting (the additive contract wins over the
+    // optimization).
+    if (target.kind === 'file' && payload.sessionId) {
+      if (alreadyInjected(payload.sessionId, target.file)) return;
+    }
+
+    let additionalContext: string | undefined;
+    if (target.kind === 'file') {
+      const summary = fileSummaryQuery(graph, target.file);
+      if (!summary.found || summary.symbols.length === 0) return;
+      additionalContext = formatFileContext(summary, graph);
+    } else {
+      const result = contextQuery(graph, target.pattern, { budget: HOOK_BUDGET, substring: true });
+      if (!result.matched || result.selection.length === 0) return;
+      additionalContext = formatHookContext(result, graph);
+    }
+
+    if (!additionalContext) return;
+
+    if (target.kind === 'file' && payload.sessionId) {
+      markInjected(payload.sessionId, target.file);
+    }
+
     process.stdout.write(
       JSON.stringify({
         hookSpecificOutput: {
@@ -58,10 +108,221 @@ export async function runContextHook(cwd: string): Promise<void> {
   }
 }
 
+/** The fields of the PreToolUse payload the hook consumes. */
+interface HookPayload {
+  toolName?: string;
+  toolInput: Record<string, unknown>;
+  sessionId?: string;
+}
+
+/** Parse the raw stdin JSON into the subset of fields the hook needs. */
+export function parsePayload(rawStdin: string): HookPayload | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawStdin);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const obj = parsed as Record<string, unknown>;
+  const toolInput =
+    obj.tool_input && typeof obj.tool_input === 'object'
+      ? (obj.tool_input as Record<string, unknown>)
+      : {};
+  return {
+    toolName: typeof obj.tool_name === 'string' ? obj.tool_name : undefined,
+    toolInput,
+    sessionId: typeof obj.session_id === 'string' ? obj.session_id : undefined,
+  };
+}
+
 /**
- * Extract the search keyword from the PreToolUse payload. Both Grep
- * and Glob carry it on `tool_input.pattern`. Returns undefined for
- * anything we can't confidently read (→ no-op upstream).
+ * Decide what to inject context about, given the tool the agent invoked.
+ * Returns undefined (→ no-op) for tools/inputs we can't confidently map.
+ */
+export function resolveHookTarget(
+  payload: HookPayload,
+  graph: Graph,
+  cwd: string,
+): HookTarget | undefined {
+  const tool = payload.toolName;
+
+  // Read / Edit / Write — keyed on the file being touched.
+  if (tool === 'Read' || tool === 'Edit' || tool === 'Write' || tool === 'NotebookEdit') {
+    const fp = payload.toolInput.file_path ?? payload.toolInput.notebook_path;
+    if (typeof fp !== 'string' || !fp.trim()) return undefined;
+    const rel = toRepoRelative(fp.trim(), cwd);
+    return graph.nodesByFile.has(rel) ? { kind: 'file', file: rel } : undefined;
+  }
+
+  // Bash — parse a grep/rg-style search command.
+  if (tool === 'Bash') {
+    const cmd = payload.toolInput.command;
+    if (typeof cmd !== 'string' || !cmd.trim()) return undefined;
+    return parseBashForTarget(cmd, graph, cwd);
+  }
+
+  // Grep / Glob (and anything else carrying a `pattern`) — symbol match.
+  const pattern = extractPattern(JSON.stringify({ tool_input: payload.toolInput }));
+  return pattern ? { kind: 'pattern', pattern } : undefined;
+}
+
+/**
+ * Extract a grep/rg target from a Bash command. Prefers a concrete
+ * source file named in the command (→ that file's structural summary);
+ * otherwise falls back to the search pattern (→ symbol-name match). Only
+ * fires for recognised search tools so an arbitrary Bash command is a
+ * clean no-op.
+ */
+export function parseBashForTarget(
+  command: string,
+  graph: Graph,
+  cwd: string,
+): HookTarget | undefined {
+  if (!/\b(grep|egrep|fgrep|rg|ag|ack)\b/.test(command)) return undefined;
+
+  // First clause only — ignore everything past a pipe/`&&`/`;` so a
+  // downstream command's args don't masquerade as search paths.
+  const head = command.split(/\||&&|;/)[0];
+  const tokens = head.split(/\s+/).filter(Boolean).map(stripQuotes);
+
+  const binaries = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+  // 1. A concrete file argument that exists in the graph wins — that's
+  //    the file the agent is looking at, structural map is most useful.
+  for (const tok of tokens) {
+    if (tok.startsWith('-') || binaries.has(tok)) continue;
+    const rel = toRepoRelative(tok, cwd);
+    if (graph.nodesByFile.has(rel)) return { kind: 'file', file: rel };
+  }
+
+  // 2. Else the first plausible search term → symbol match. Skip flags,
+  //    the binary, redirections, and path-ish/dir tokens.
+  for (const tok of tokens) {
+    if (tok.startsWith('-') || binaries.has(tok)) continue;
+    if (/[/<>|*]/.test(tok) || tok.includes('..')) continue;
+    if (tok.length < 2) continue;
+    return { kind: 'pattern', pattern: tok };
+  }
+  return undefined;
+}
+
+/** Strip a single layer of surrounding single/double quotes. */
+function stripQuotes(s: string): string {
+  if (s.length >= 2 && (s[0] === '"' || s[0] === "'") && s[s.length - 1] === s[0]) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+/** Convert an absolute or repo-relative path to the graph's key format
+ *  (project-relative, forward slashes). */
+function toRepoRelative(p: string, cwd: string): string {
+  const rel = path.isAbsolute(p) ? path.relative(cwd, p) : p;
+  return rel.replace(/\\/g, '/');
+}
+
+/**
+ * Compact `additionalContext` body for a FILE target: the file's
+ * symbols, who depends on it (caller files), and what it reaches into
+ * (callee files). Terser than the CLI's markdown — the hook pays this on
+ * every read. Leads with provenance + a best-effort caveat so the agent
+ * calibrates trust.
+ */
+export function formatFileContext(summary: FileSummary, graph: Graph): string {
+  const lines: string[] = [];
+  lines.push(
+    `dxkit graph context for \`${summary.sourceFile}\` (from .dxkit/reports/graph.json, generated ${graph.meta.generatedAt.slice(0, 10)} — structural map, the file's actual contents remain authoritative):`,
+  );
+
+  const topSymbols = summary.symbols.slice(0, 12);
+  if (topSymbols.length > 0) {
+    lines.push(`- Symbols (${summary.symbols.length}):`);
+    for (const s of topSymbols) {
+      const where = s.line ? `:${s.line}` : '';
+      const flags = [s.exported ? 'exported' : '', s.callsIn > 0 ? `${s.callsIn} caller(s)` : '']
+        .filter(Boolean)
+        .join(', ');
+      lines.push(`    ${s.label} (${s.kind}${where})${flags ? ` — ${flags}` : ''}`);
+    }
+    if (summary.symbols.length > topSymbols.length) {
+      lines.push(`    (+${summary.symbols.length - topSymbols.length} more)`);
+    }
+  }
+
+  if (summary.callerFiles.length > 0) {
+    const top = summary.callerFiles.slice(0, 6);
+    lines.push(`- Depended on by ${summary.callerFiles.length} file(s):`);
+    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
+    if (summary.callerFiles.length > top.length) {
+      lines.push(`    (+${summary.callerFiles.length - top.length} more)`);
+    }
+  }
+
+  if (summary.calleeFiles.length > 0) {
+    const top = summary.calleeFiles.slice(0, 6);
+    lines.push(`- Calls into ${summary.calleeFiles.length} file(s):`);
+    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
+    if (summary.calleeFiles.length > top.length) {
+      lines.push(`    (+${summary.calleeFiles.length - top.length} more)`);
+    }
+  }
+
+  if (summary.communityLabel) {
+    lines.push(`- Module group: ${summary.communityLabel}`);
+  }
+
+  return lines.join('\n');
+}
+
+// ─── Per-session, per-file dedup state ───────────────────────────────────────
+
+/** Where the per-session injected-file ledger lives. One file per
+ *  session under the OS temp dir; small JSON array of repo-relative
+ *  paths. Best-effort + self-evicting (temp dir is reclaimed by the OS). */
+function dedupStatePath(sessionId: string): string {
+  // Sanitize the session id to a safe filename component.
+  const safe = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 128);
+  return path.join(os.tmpdir(), `dxkit-context-hook-${safe}.json`);
+}
+
+/** Has this file's context already been injected this session? Fail-open
+ *  to `false` (inject) on any read/parse problem. */
+function alreadyInjected(sessionId: string, file: string): boolean {
+  try {
+    const raw = fs.readFileSync(dedupStatePath(sessionId), 'utf-8');
+    const seen = JSON.parse(raw);
+    return Array.isArray(seen) && seen.includes(file);
+  } catch {
+    return false;
+  }
+}
+
+/** Record that this file's context was injected this session. Best-effort
+ *  — a write failure simply means the file may be re-injected later. */
+function markInjected(sessionId: string, file: string): void {
+  try {
+    const p = dedupStatePath(sessionId);
+    let seen: string[] = [];
+    try {
+      const parsed = JSON.parse(fs.readFileSync(p, 'utf-8'));
+      if (Array.isArray(parsed)) seen = parsed.filter((x): x is string => typeof x === 'string');
+    } catch {
+      // no prior state → start fresh
+    }
+    if (!seen.includes(file)) {
+      seen.push(file);
+      fs.writeFileSync(p, JSON.stringify(seen));
+    }
+  } catch {
+    // Fail-open: dedup is an optimization, not a correctness requirement.
+  }
+}
+
+/**
+ * Extract the search keyword from a Grep/Glob-style payload. Both carry
+ * it on `tool_input.pattern`. Returns undefined for anything we can't
+ * confidently read (→ no-op upstream).
  */
 export function extractPattern(rawStdin: string): string | undefined {
   let parsed: unknown;
@@ -80,9 +341,9 @@ export function extractPattern(rawStdin: string): string | undefined {
 }
 
 /**
- * Compact `additionalContext` body. Terser than the CLI's markdown
- * (the hook pays this cost on every grep): an anchor line, blast
- * radius, and the top symbols grouped by their leading community.
+ * Compact `additionalContext` body for a PATTERN target. Terser than the
+ * CLI's markdown (the hook pays this cost on every grep): an anchor line,
+ * blast radius, and the top symbols grouped by their leading community.
  * Leads with a one-line provenance + best-effort caveat so the agent
  * calibrates trust.
  */

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -55,16 +55,22 @@ function buildSettingsJson(config: ResolvedConfig): string {
           allow: perms,
           deny: [],
         },
-        // PreToolUse hook on code-search tools: injects a slim graph
-        // subgraph as additional context so the agent needs fewer
-        // follow-up whole-file reads (the navigation-layer token win).
-        // ADDITIVE + FAIL-OPEN by construction — `context-hook` only
-        // ever adds context and silently no-ops when graph.json is
-        // absent/stale, so the search tool always works normally.
+        // PreToolUse hook on the tools agents ACTUALLY use to navigate:
+        // Read/Edit (keyed on the file touched → that file's structural
+        // map), Bash (parses grep/rg commands), and Grep/Glob (symbol
+        // match). Injects a slim graph slice as additional context so the
+        // agent needs fewer follow-up whole-file reads (the navigation-
+        // layer token win). Pre-2.10 only Grep/Glob were wired, and the
+        // hook almost never fired because real agents search via
+        // `Bash grep` and read files directly — the Read + Bash surfaces
+        // are what make the passive delivery actually engage.
+        // ADDITIVE + FAIL-OPEN by construction — `context-hook` only ever
+        // adds context and silently no-ops when graph.json is
+        // absent/stale, so the tool always works normally.
         hooks: {
           PreToolUse: [
             {
-              matcher: 'Grep|Glob',
+              matcher: 'Read|Edit|Bash|Grep|Glob',
               hooks: [
                 {
                   type: 'command',

--- a/src/ingest/snyk-policy.ts
+++ b/src/ingest/snyk-policy.ts
@@ -48,6 +48,50 @@ export interface SnykIgnore {
 export const SNYK_POLICY_VERSION = 'v1.25.0' as const;
 
 /**
+ * Convert `.dxkit-ignore` lines (gitignore syntax) into Snyk
+ * `exclude.global` glob patterns — the path-exclusion half of the
+ * dxkit ↔ Snyk sync, mirroring how allowlist entries become `.snyk`
+ * ignores. A directory dxkit skips for analysis should be a directory
+ * Snyk skips too, so the two tools agree on what's out of scope.
+ *
+ * Conversion (conservative — Snyk globs are path-relative):
+ *   - `#` comments and blank lines are dropped.
+ *   - Negations (`!pat`) are dropped: Snyk's exclude list has no
+ *     re-include, and silently inverting one would be worse than
+ *     omitting it.
+ *   - A leading `/` (gitignore "anchored to root") is stripped.
+ *   - A trailing `/` (explicit directory) → `dir/**`.
+ *   - A bare name with no glob metacharacter (e.g. `vendor`,
+ *     `generated`) is treated as a directory → `vendor/**`.
+ *   - Anything already carrying a glob (`*.generated.ts`,
+ *     `fixtures/**`) passes through unchanged.
+ * Results are de-duplicated, order-preserving.
+ */
+export function dxkitIgnoreLinesToSnykExcludes(lines: ReadonlyArray<string>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#') || line.startsWith('!')) continue;
+    let pat = line.replace(/^\/+/, ''); // strip anchoring leading slash
+    if (!pat) continue;
+    if (pat.endsWith('/')) {
+      pat = `${pat}**`;
+    } else if (!/[*?[\]]/.test(pat)) {
+      // No glob metacharacter → a plain path. Treat as a directory so a
+      // bare `vendor` excludes its whole subtree (gitignore semantics),
+      // not just a single file named `vendor`.
+      pat = `${pat}/**`;
+    }
+    if (!seen.has(pat)) {
+      seen.add(pat);
+      out.push(pat);
+    }
+  }
+  return out;
+}
+
+/**
  * Convert an allowlist entry's `expiresAt` (`YYYY-MM-DD`) into the ISO
  * datetime Snyk's policy file expects. Returns `undefined` for a
  * missing date so the caller emits a permanent ignore.
@@ -63,7 +107,10 @@ export function expiryToSnykDatetime(expiresAt: string | undefined): string | un
  * directives. Deterministic ordering (rules + paths sorted) so the
  * committed file has stable diffs across runs.
  */
-export function buildSnykPolicy(ignores: ReadonlyArray<SnykIgnore>): string {
+export function buildSnykPolicy(
+  ignores: ReadonlyArray<SnykIgnore>,
+  excludes: ReadonlyArray<string> = [],
+): string {
   const byRule = new Map<string, SnykIgnore[]>();
   for (const ig of ignores) {
     const list = byRule.get(ig.ruleId) ?? [];
@@ -78,26 +125,35 @@ export function buildSnykPolicy(ignores: ReadonlyArray<SnykIgnore>): string {
 
   if (byRule.size === 0) {
     lines.push('ignore: {}');
-    lines.push('patch: {}');
-    return lines.join('\n') + '\n';
-  }
-
-  lines.push('ignore:');
-  for (const ruleId of [...byRule.keys()].sort()) {
-    lines.push(`  ${quoteKey(ruleId)}:`);
-    const perPath = byRule.get(ruleId)!;
-    // Stable order + one directive per unique path.
-    const seen = new Set<string>();
-    for (const ig of perPath.slice().sort((a, b) => a.path.localeCompare(b.path))) {
-      if (seen.has(ig.path)) continue;
-      seen.add(ig.path);
-      lines.push(`    - ${quoteKey(ig.path)}:`);
-      lines.push(`        reason: ${doubleQuote(ig.reason ?? '')}`);
-      if (ig.expires) lines.push(`        expires: ${ig.expires}`);
-      lines.push(`        created: ${ig.created}`);
+  } else {
+    lines.push('ignore:');
+    for (const ruleId of [...byRule.keys()].sort()) {
+      lines.push(`  ${quoteKey(ruleId)}:`);
+      const perPath = byRule.get(ruleId)!;
+      // Stable order + one directive per unique path.
+      const seen = new Set<string>();
+      for (const ig of perPath.slice().sort((a, b) => a.path.localeCompare(b.path))) {
+        if (seen.has(ig.path)) continue;
+        seen.add(ig.path);
+        lines.push(`    - ${quoteKey(ig.path)}:`);
+        lines.push(`        reason: ${doubleQuote(ig.reason ?? '')}`);
+        if (ig.expires) lines.push(`        expires: ${ig.expires}`);
+        lines.push(`        created: ${ig.created}`);
+      }
     }
   }
   lines.push('patch: {}');
+
+  // exclude.global — the path-exclusion half of the dxkit ↔ Snyk sync,
+  // sourced from `.dxkit-ignore`. Emitted only when present so an
+  // ignore-only export keeps its prior byte-for-byte shape.
+  if (excludes.length > 0) {
+    lines.push('exclude:');
+    lines.push('  global:');
+    for (const pat of excludes) {
+      lines.push(`    - ${quoteKey(pat)}`);
+    }
+  }
   return lines.join('\n') + '\n';
 }
 

--- a/src/languages/capabilities/types.ts
+++ b/src/languages/capabilities/types.ts
@@ -269,6 +269,15 @@ export interface SecretFinding {
   severity: keyof SeverityCounts;
   /** Human-readable description from the scanner (e.g. gitleaks' `Description` field). */
   title?: string;
+  /**
+   * `test-fixture`: a generic keyword-assignment match inside a test
+   * file (per the active packs' test patterns). Auto-downgraded to
+   * `low` severity and excluded from the committed-credentials score
+   * cap — still reported, never headline-critical. Branded token
+   * shapes (real AWS keys etc.) are NEVER tagged: a live credential
+   * in a test file is still a leak.
+   */
+  category?: 'test-fixture';
 }
 
 /**

--- a/src/languages/capabilities/types.ts
+++ b/src/languages/capabilities/types.ts
@@ -269,15 +269,6 @@ export interface SecretFinding {
   severity: keyof SeverityCounts;
   /** Human-readable description from the scanner (e.g. gitleaks' `Description` field). */
   title?: string;
-  /**
-   * `test-fixture`: a generic keyword-assignment match inside a test
-   * file (per the active packs' test patterns). Auto-downgraded to
-   * `low` severity and excluded from the committed-credentials score
-   * cap — still reported, never headline-critical. Branded token
-   * shapes (real AWS keys etc.) are NEVER tagged: a live credential
-   * in a test file is still a leak.
-   */
-  category?: 'test-fixture';
 }
 
 /**

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -120,14 +120,46 @@ export function anyActivePackSupportsSnykCode(flags: DetectedStack['languages'])
 }
 
 /**
- * All test-file patterns across every registered pack, deduplicated.
- * Patterns without a slash are basename-style (matched by find `-name`);
- * patterns containing a slash are path-anchored (e.g. Rust's
- * tests-directory glob for integration tests) and need find
- * `-path` semantics — see `splitTestFilePatterns()`.
+ * Cross-ecosystem test-DIRECTORY conventions. Where tests live is a
+ * structural convention shared across languages (Jest's `__tests__/`,
+ * the near-universal `test/` / `tests/` / `spec/` / `e2e/`), unlike how
+ * test FILES are named (`*Test.java` vs `*_test.go` vs `*.spec.ts`),
+ * which genuinely varies per language and stays in each pack's
+ * `testFilePatterns`. Declaring the directory conventions once here —
+ * rather than copying them into every pack — is why a repo that
+ * organizes tests by directory is classified correctly in any language,
+ * and why adding a new pack inherits them for free.
+ *
+ * Path-anchored (each contains `/`), so `splitTestFilePatterns` routes
+ * them to the path matcher: `__tests__/**` matches `src/__tests__/a.ts`
+ * AND `a/b/__tests__/c.ts` (anywhere in the tree). The walker only
+ * evaluates these against files that already passed the source-extension
+ * filter, so non-source files under a test dir are never misclassified.
+ *
+ * `__mocks__/` is intentionally excluded — mocks are test *support*, not
+ * tests, and counting them would inflate the test-file ratio.
+ */
+export const UNIVERSAL_TEST_DIR_PATTERNS: readonly string[] = [
+  '__tests__/**',
+  'test/**',
+  'tests/**',
+  'spec/**',
+  'e2e/**',
+];
+
+/**
+ * All test-file patterns: each pack's language-specific filename
+ * conventions unioned with the shared cross-ecosystem test-directory
+ * conventions (`UNIVERSAL_TEST_DIR_PATTERNS`), deduplicated. Patterns
+ * without a slash are basename-style (matched by find `-name`); patterns
+ * containing a slash are path-anchored (the test-dir conventions + e.g.
+ * Rust's tests-directory glob) and need find `-path` semantics — see
+ * `splitTestFilePatterns()`.
  */
 export function allTestFilePatterns(): string[] {
-  return [...new Set(LANGUAGES.flatMap((l) => l.testFilePatterns))];
+  return [
+    ...new Set([...LANGUAGES.flatMap((l) => l.testFilePatterns), ...UNIVERSAL_TEST_DIR_PATTERNS]),
+  ];
 }
 
 /**

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1149,6 +1149,13 @@ export const typescript: LanguageSupport = {
   displayName: 'TypeScript / JavaScript',
   commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
   sourceExtensions: [...TS_JS_EXT],
+  // Filename conventions for the JS/TS ecosystem. The `__tests__/`
+  // directory convention is supplied once, cross-ecosystem, by
+  // `UNIVERSAL_TEST_DIR_PATTERNS` (languages/index.ts) — these are the
+  // co-located naming conventions that vary by ecosystem and so belong
+  // in the pack: Jest/Vitest `.test.`/`.spec.`, plus the widespread
+  // `.unit.` / `.e2e.` / `.cy.` (Cypress) suffixes for tests that sit
+  // next to the code they exercise rather than under a test directory.
   testFilePatterns: [
     '*.test.ts',
     '*.test.tsx',
@@ -1162,6 +1169,18 @@ export const typescript: LanguageSupport = {
     '*.spec.jsx',
     '*.spec.mjs',
     '*.spec.cjs',
+    '*.unit.ts',
+    '*.unit.tsx',
+    '*.unit.js',
+    '*.unit.jsx',
+    '*.e2e.ts',
+    '*.e2e.tsx',
+    '*.e2e.js',
+    '*.e2e.jsx',
+    '*.cy.ts',
+    '*.cy.tsx',
+    '*.cy.js',
+    '*.cy.jsx',
   ],
   extraExcludes: ['node_modules', 'dist', '.next', '.turbo', 'coverage', '.cache'],
 

--- a/src/scoring/dimensions/security.ts
+++ b/src/scoring/dimensions/security.ts
@@ -82,7 +82,7 @@ export interface SecurityScoreInput {
    */
   depVulnsAvailable: boolean;
   /**
-   * C-D1: pre-2.10 the unavailability cap was asymmetric — a missing
+   * Pre-2.10 the unavailability cap was asymmetric — a missing
    * dep-vuln scan capped at the uncertainty tier while missing
    * secret/code scanners silently scored as "0 findings". A customer
    * upgrade that merely turned the secret scanners ON then read as a
@@ -95,7 +95,7 @@ export interface SecurityScoreInput {
    * succeeded. "No active provider" stays vacuously true.
    */
   secretsAvailable: boolean;
-  /** See `secretsAvailable` (C-D1) — same contract for the semgrep /
+  /** See `secretsAvailable` — same contract for the semgrep /
    *  code-patterns axis. */
   codePatternsAvailable: boolean;
 }

--- a/src/scoring/dimensions/security.ts
+++ b/src/scoring/dimensions/security.ts
@@ -84,9 +84,9 @@ export interface SecurityScoreInput {
   /**
    * Pre-2.10 the unavailability cap was asymmetric — a missing
    * dep-vuln scan capped at the uncertainty tier while missing
-   * secret/code scanners silently scored as "0 findings". A customer
-   * upgrade that merely turned the secret scanners ON then read as a
-   * 25-point score drop on an unchanged commit. These two flags give
+   * secret/code scanners silently scored as "0 findings". An upgrade
+   * that merely turned the secret scanners ON then read as a score
+   * drop on an unchanged commit. These two flags give
    * every measurement axis the same honest treatment: scanner didn't
    * run → uncertainty cap, never a confident clean score.
    *

--- a/src/scoring/dimensions/security.ts
+++ b/src/scoring/dimensions/security.ts
@@ -81,6 +81,23 @@ export interface SecurityScoreInput {
    * Adapters MUST populate this from `DepVulnSummary.available`.
    */
   depVulnsAvailable: boolean;
+  /**
+   * C-D1: pre-2.10 the unavailability cap was asymmetric — a missing
+   * dep-vuln scan capped at the uncertainty tier while missing
+   * secret/code scanners silently scored as "0 findings". A customer
+   * upgrade that merely turned the secret scanners ON then read as a
+   * 25-point score drop on an unchanged commit. These two flags give
+   * every measurement axis the same honest treatment: scanner didn't
+   * run → uncertainty cap, never a confident clean score.
+   *
+   * Same attempted-and-failed semantics as `depVulnsAvailable`:
+   * false ONLY when the gather was attempted and no provider
+   * succeeded. "No active provider" stays vacuously true.
+   */
+  secretsAvailable: boolean;
+  /** See `secretsAvailable` (C-D1) — same contract for the semgrep /
+   *  code-patterns axis. */
+  codePatternsAvailable: boolean;
 }
 
 /**
@@ -164,6 +181,18 @@ export const SECURITY_SCORING_SPEC: DimensionScoringSpec<SecurityScoreInput> = {
       tier: 'uncertainty',
       describe: () => `dependency vulnerability scan did not run`,
       applies: (i) => !i.depVulnsAvailable,
+    },
+    {
+      id: 'secrets-unavailable',
+      tier: 'uncertainty',
+      describe: () => `secret scan did not run`,
+      applies: (i) => !i.secretsAvailable,
+    },
+    {
+      id: 'code-patterns-unavailable',
+      tier: 'uncertainty',
+      describe: () => `static-analysis (code-pattern) scan did not run`,
+      applies: (i) => !i.codePatternsAvailable,
     },
     {
       id: 'high-plus-code-open',

--- a/test/allowlist/annotate.test.ts
+++ b/test/allowlist/annotate.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  annotateFindingsWithAllowlist,
+  type AnnotatableFinding,
+} from '../../src/allowlist/annotate';
+import type { AllowlistFile, AllowlistEntry } from '../../src/allowlist/file';
+
+/**
+ * C-D2 unit coverage: report findings gain `allowlisted` +
+ * `allowlistCategory` when (and only when) an ACTIVE allowlist entry
+ * matches their fingerprint AND kind. Raw fields are untouched — the
+ * annotation is purely additive (the renderer reads it to disclose
+ * "(N allowlisted)" without changing counts).
+ */
+
+const FP = 'abcd1234abcd1234';
+const NOW = new Date('2026-06-12T12:00:00Z');
+
+function fileWith(...entries: AllowlistEntry[]): AllowlistFile {
+  return { schemaVersion: 'dxkit-allowlist/v1', mode: 'full', entries };
+}
+
+function secretEntry(over: Partial<AllowlistEntry> = {}): AllowlistEntry {
+  return {
+    fingerprint: FP,
+    kind: 'secret',
+    category: 'test-fixture',
+    reason: 'unit-test fixture password',
+    addedBy: 'r@example.com',
+    addedAt: '2026-06-01',
+    ...over,
+  };
+}
+
+describe('annotateFindingsWithAllowlist', () => {
+  it('marks a finding whose fingerprint + kind match an active entry', () => {
+    const findings: AnnotatableFinding[] = [{ category: 'secret', fingerprint: FP }];
+    const count = annotateFindingsWithAllowlist(findings, fileWith(secretEntry()), NOW);
+    expect(count).toBe(1);
+    expect(findings[0].allowlisted).toBe(true);
+    expect(findings[0].allowlistCategory).toBe('test-fixture');
+  });
+
+  it('does NOT mark when the kind differs (guards against hash collision)', () => {
+    const findings: AnnotatableFinding[] = [{ category: 'code', fingerprint: FP }];
+    const count = annotateFindingsWithAllowlist(findings, fileWith(secretEntry()), NOW);
+    expect(count).toBe(0);
+    expect(findings[0].allowlisted).toBeUndefined();
+  });
+
+  it('does NOT mark when the entry has expired', () => {
+    const findings: AnnotatableFinding[] = [{ category: 'secret', fingerprint: FP }];
+    const expired = secretEntry({ category: 'accepted-risk', expiresAt: '2026-06-01' });
+    const count = annotateFindingsWithAllowlist(findings, fileWith(expired), NOW);
+    expect(count).toBe(0);
+    expect(findings[0].allowlisted).toBeUndefined();
+  });
+
+  it('matches via an absorbed fingerprint (cross-tool dedup robustness)', () => {
+    const findings: AnnotatableFinding[] = [
+      { category: 'code', fingerprint: 'ffff0000ffff0000', absorbedFingerprints: [FP] },
+    ];
+    const count = annotateFindingsWithAllowlist(
+      findings,
+      fileWith(secretEntry({ kind: 'code' })),
+      NOW,
+    );
+    expect(count).toBe(1);
+    expect(findings[0].allowlisted).toBe(true);
+  });
+
+  it('ignores dependency findings (no inline fingerprint — out of scope)', () => {
+    const findings: AnnotatableFinding[] = [{ category: 'dependency' }];
+    const count = annotateFindingsWithAllowlist(findings, fileWith(secretEntry()), NOW);
+    expect(count).toBe(0);
+  });
+
+  it('is a no-op on a null or empty allowlist', () => {
+    const findings: AnnotatableFinding[] = [{ category: 'secret', fingerprint: FP }];
+    expect(annotateFindingsWithAllowlist(findings, null, NOW)).toBe(0);
+    expect(annotateFindingsWithAllowlist(findings, fileWith(), NOW)).toBe(0);
+    expect(findings[0].allowlisted).toBeUndefined();
+  });
+
+  it('leaves non-matching findings untouched while marking matches in a mixed batch', () => {
+    const findings: AnnotatableFinding[] = [
+      { category: 'secret', fingerprint: FP }, // matches
+      { category: 'secret', fingerprint: 'deadbeefdeadbeef' }, // no entry
+      { category: 'code', fingerprint: 'cafecafecafecafe' }, // no entry
+    ];
+    const count = annotateFindingsWithAllowlist(findings, fileWith(secretEntry()), NOW);
+    expect(count).toBe(1);
+    expect(findings.map((f) => !!f.allowlisted)).toEqual([true, false, false]);
+  });
+});

--- a/test/allowlist/annotate.test.ts
+++ b/test/allowlist/annotate.test.ts
@@ -6,7 +6,7 @@ import {
 import type { AllowlistFile, AllowlistEntry } from '../../src/allowlist/file';
 
 /**
- * C-D2 unit coverage: report findings gain `allowlisted` +
+ * Unit coverage: report findings gain `allowlisted` +
  * `allowlistCategory` when (and only when) an ACTIVE allowlist entry
  * matches their fingerprint AND kind. Raw fields are untouched — the
  * annotation is purely additive (the renderer reads it to disclose

--- a/test/baseline/entry-to-located.test.ts
+++ b/test/baseline/entry-to-located.test.ts
@@ -58,7 +58,7 @@ describe('entryToLocated', () => {
     });
   });
 
-  it('falls through to identity-only for content-independent kinds', () => {
+  it('falls through to identity-only for kinds with no file/line locator', () => {
     const cases: BaselineEntry[] = [
       { id: 'd1', kind: 'dep-vuln', package: 'lodash', advisoryId: 'GHSA-x' },
       {
@@ -70,9 +70,6 @@ describe('entryToLocated', () => {
         startLineA: 1,
         startLineB: 1,
       },
-      { id: 'd4', kind: 'test-gap', file: 'src/a.ts', risk: 'high' },
-      { id: 'd5', kind: 'large-file', file: 'src/big.ts' },
-      { id: 'd6', kind: 'stale-file', file: '.foo.swp', suffix: 'swp' },
       { id: 'd7', kind: 'secret-hmac', tool: 'gitleaks', rule: 'aws-token', hmac: 'h' },
     ];
     for (const entry of cases) {
@@ -81,6 +78,30 @@ describe('entryToLocated', () => {
       expect(out.file).toBeUndefined();
       expect(out.line).toBeUndefined();
       expect(out.rule).toBeUndefined();
+    }
+  });
+
+  it('carries file + kind (as rule) but no line for whole-file findings', () => {
+    // Whole-file findings are file-anchored with no line. `file` lets the
+    // matcher's whole-file rename pass relocate them across a pure rename;
+    // `rule` carries the kind so two different whole-file kinds on the same
+    // renamed file never cross-pair. No line → the line-anchored passes skip
+    // them. Covers every wired + deferred whole-file kind.
+    const cases = [
+      { id: 'w1', kind: 'test-gap', file: 'src/a.ts', risk: 'high' },
+      { id: 'w2', kind: 'large-file', file: 'src/big.ts' },
+      { id: 'w3', kind: 'stale-file', file: '.foo.swp', suffix: 'swp' },
+      { id: 'w4', kind: 'test-file-degradation', file: 'test/a.test.ts', status: 'empty' },
+      { id: 'w5', kind: 'god-file', file: 'src/kitchen-sink.ts' },
+      { id: 'w6', kind: 'coverage-gap', file: 'src/c.ts', symbol: 'doThing' },
+    ] satisfies BaselineEntry[];
+    for (const entry of cases) {
+      const out = entryToLocated(entry);
+      expect(out.id).toBe(entry.id);
+      expect(out.file).toBe(entry.file);
+      expect(out.rule).toBe(entry.kind);
+      expect(out.line).toBeUndefined();
+      expect(out.contentHash).toBeUndefined();
     }
   });
 

--- a/test/baseline/git-aware-match.test.ts
+++ b/test/baseline/git-aware-match.test.ts
@@ -252,6 +252,102 @@ describe('gitAwareMatch', () => {
     expect(pair.reasons.some((r) => r.code === 'git-rename')).toBe(true);
   });
 
+  // ── Whole-file rename relocation (Pass 1b) ──────────────────────────────
+  // Whole-file findings (test-gap, large-file, …) are file-anchored with no
+  // line. `entryToLocated` gives them `file` + `rule = kind`. On a pure file
+  // rename their path-based identity changes, so without Pass 1b they read as
+  // removed + added → a false net-new block on a rename.
+  function wholeFileFinding(file: string, kind: 'test-gap' | 'large-file'): LocatedIdentity {
+    const id =
+      kind === 'test-gap'
+        ? identityFor({ kind: 'test-gap', file, risk: 'high' })
+        : identityFor({ kind: 'large-file', file });
+    return { id, file, rule: kind }; // no line — whole-file
+  }
+
+  it('relocates a whole-file finding across a pure file rename (Pass 1b)', () => {
+    writeFileSync(join(dir, 'old-service.ts'), lines('a', 'b', 'c'));
+    const base = commit(dir, 'initial');
+    execFileSync('git', ['mv', 'old-service.ts', 'new-service.ts'], { cwd: dir });
+    const head = commit(dir, 'rename service');
+
+    const prior = [wholeFileFinding('old-service.ts', 'test-gap')];
+    const current = [wholeFileFinding('new-service.ts', 'test-gap')];
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+
+    expect(result.removed).toEqual([]);
+    expect(result.added).toEqual([]);
+    expect(result.pairs).toHaveLength(1);
+    const [pair] = result.pairs;
+    expect(pair.status).toBe('relocated');
+    expect(pair.priorId).toBe(prior[0].id);
+    expect(pair.currentId).toBe(current[0].id);
+    expect(pair.reasons.some((r) => r.code === 'git-rename')).toBe(true);
+  });
+
+  it('does not cross-pair different whole-file kinds on the same renamed file', () => {
+    // The correctness guard: a file is renamed; on the old path it had a
+    // test-gap (now resolved — a test was added), on the new path it has a
+    // brand-new large-file finding. Keying the rename pass on (path, kind)
+    // must keep these apart — pairing them would mask a genuinely net-new
+    // finding as a relocation and let real debt through the guardrail.
+    writeFileSync(join(dir, 'old.ts'), lines('a', 'b', 'c'));
+    const base = commit(dir, 'initial');
+    execFileSync('git', ['mv', 'old.ts', 'new.ts'], { cwd: dir });
+    const head = commit(dir, 'rename old → new');
+
+    const prior = [wholeFileFinding('old.ts', 'test-gap')];
+    const current = [wholeFileFinding('new.ts', 'large-file')];
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+
+    // No relocation: the test-gap is genuinely gone, the large-file genuinely new.
+    expect(result.persisted).toEqual([]);
+    expect(result.removed).toEqual([prior[0].id]);
+    expect(result.added).toEqual([current[0].id]);
+    expect(result.pairs.some((p) => p.status === 'relocated')).toBe(false);
+  });
+
+  it('relocates each kind independently when both kinds move with one renamed file', () => {
+    // Same renamed file carries a test-gap AND a large-file on both sides.
+    // Each must relocate to its own kind — never swap.
+    writeFileSync(join(dir, 'old.ts'), lines('a', 'b', 'c'));
+    const base = commit(dir, 'initial');
+    execFileSync('git', ['mv', 'old.ts', 'new.ts'], { cwd: dir });
+    const head = commit(dir, 'rename old → new');
+
+    const priorTg = wholeFileFinding('old.ts', 'test-gap');
+    const priorLf = wholeFileFinding('old.ts', 'large-file');
+    const curTg = wholeFileFinding('new.ts', 'test-gap');
+    const curLf = wholeFileFinding('new.ts', 'large-file');
+    const result = gitAwareMatch([priorTg, priorLf], [curTg, curLf], {
+      cwd: dir,
+      baseSha: base,
+      headSha: head,
+    });
+
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+    const relocated = result.pairs.filter((p) => p.status === 'relocated');
+    expect(relocated).toHaveLength(2);
+    // Each prior id pairs with the current id of the SAME kind.
+    const byPrior = new Map(relocated.map((p) => [p.priorId, p.currentId]));
+    expect(byPrior.get(priorTg.id)).toBe(curTg.id);
+    expect(byPrior.get(priorLf.id)).toBe(curLf.id);
+  });
+
+  it('does not relocate a whole-file finding when the file was not renamed', () => {
+    // Same path on both sides → Pass 1b must not fire (it acts only on
+    // git-detected renames); the exact-id multiset pass persists it instead.
+    writeFileSync(join(dir, 'keep.ts'), lines('a', 'b'));
+    const sha = commit(dir, 'initial');
+    const prior = [wholeFileFinding('keep.ts', 'test-gap')];
+    const current = [wholeFileFinding('keep.ts', 'test-gap')];
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: sha, headSha: sha });
+
+    expect(result.persisted).toEqual([prior[0].id]);
+    expect(result.pairs.some((p) => p.reasons.some((r) => r.code === 'git-rename'))).toBe(false);
+  });
+
   it('pairs via line-fuzz when the scanner reports a slightly different line', () => {
     writeFileSync(join(dir, 'a.ts'), lines('alpha', 'beta', 'gamma'));
     const base = commit(dir, 'initial');
@@ -297,12 +393,12 @@ describe('gitAwareMatch', () => {
     const sha = commit(dir, 'initial');
     const sharedHash = 'abc123def456cafe';
     const prior: LocatedIdentity[] = [
-      { id: 'prior-id', file: 'src/old.ts', line: 10, rule: 'demo-rule', contentHash: sharedHash },
+      { id: 'prior-id', file: 'old.ts', line: 10, rule: 'demo-rule', contentHash: sharedHash },
     ];
     const current: LocatedIdentity[] = [
       {
         id: 'current-id',
-        file: 'src/new.ts',
+        file: 'new.ts',
         line: 99,
         rule: 'demo-rule',
         contentHash: sharedHash,

--- a/test/baseline/producers/security.test.ts
+++ b/test/baseline/producers/security.test.ts
@@ -42,6 +42,8 @@ function emptyAggregate(over: Partial<SecurityAggregate> = {}): SecurityAggregat
     codeBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
     depBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
     secretsBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    scoreableCodeBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    scoreableSecretsBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
     findingsByCategory: { secret: [], code: [], config: [], dependency: [] },
     dependencyAdvisoryUniqueCount: 0,
     dependencyFindingsRawCount: 0,

--- a/test/baseline/producers/stale-allow.test.ts
+++ b/test/baseline/producers/stale-allow.test.ts
@@ -40,6 +40,8 @@ function makeAggregate(
     codeBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
     depBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
     secretsBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    scoreableCodeBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    scoreableSecretsBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
     findingsByCategory: {
       secret: opts.secrets ?? [],
       code: opts.code ?? [],

--- a/test/cli-init.test.ts
+++ b/test/cli-init.test.ts
@@ -96,12 +96,18 @@ describe('cli init --full --yes (integration, full agent scaffold)', () => {
     expect(parsed).toHaveProperty('permissions');
   });
 
-  it('wires the fail-open context-hook as a Grep|Glob PreToolUse hook', () => {
+  it('wires the fail-open context-hook on the Read/Bash/Grep navigation surfaces', () => {
     const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
     const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
     const preToolUse = parsed.hooks?.PreToolUse ?? [];
-    const entry = preToolUse.find((h: { matcher?: string }) => h.matcher === 'Grep|Glob');
-    expect(entry).toBeDefined();
+    const entry = preToolUse.find(
+      (h: { matcher?: string }) =>
+        /\bRead\b/.test(h.matcher ?? '') && /\bBash\b/.test(h.matcher ?? ''),
+    );
+    expect(entry, 'context-hook should fire on Read + Bash (2.10 passive-delivery)').toBeDefined();
+    // The original symbol-search surfaces are retained.
+    expect(entry.matcher).toMatch(/Grep/);
+    expect(entry.matcher).toMatch(/Glob/);
     const cmd = entry.hooks?.[0]?.command ?? '';
     expect(cmd).toContain('vyuh-dxkit context-hook');
   });

--- a/test/explore/context-hook.test.ts
+++ b/test/explore/context-hook.test.ts
@@ -7,9 +7,27 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { extractPattern, formatHookContext } from '../../src/explore/context-hook';
-import type { ContextResult } from '../../src/explore/queries';
+import {
+  extractPattern,
+  formatFileContext,
+  formatHookContext,
+  parseBashForTarget,
+  resolveHookTarget,
+} from '../../src/explore/context-hook';
+import type { ContextResult, FileSummary } from '../../src/explore/queries';
 import type { Graph, GraphJson } from '../../src/explore/types';
+
+/**
+ * A minimal graph stub exposing only `nodesByFile` (the membership set
+ * the hook router consults) and `meta`. The router never traverses
+ * edges, so this is sufficient for resolve/parse coverage.
+ */
+function graphWithFiles(...files: string[]): Graph {
+  return {
+    meta: { generatedAt: '2026-06-12T10:00:00Z' } as GraphJson['meta'],
+    nodesByFile: new Map(files.map((f) => [f, [{ id: f }]])),
+  } as unknown as Graph;
+}
 
 describe('extractPattern', () => {
   it('reads tool_input.pattern from a Grep payload', () => {
@@ -111,5 +129,147 @@ describe('formatHookContext', () => {
   it('notes the omitted neighborhood when truncated', () => {
     const out = formatHookContext(result, graph);
     expect(out).toContain('+17 more symbols');
+  });
+});
+
+describe('resolveHookTarget (2.10 routing)', () => {
+  const cwd = '/repo';
+  const graph = graphWithFiles('src/server.ts');
+
+  it('routes a Read on a graph file to a file target', () => {
+    const t = resolveHookTarget(
+      { toolName: 'Read', toolInput: { file_path: '/repo/src/server.ts' } },
+      graph,
+      cwd,
+    );
+    expect(t).toEqual({ kind: 'file', file: 'src/server.ts' });
+  });
+
+  it('accepts a repo-relative Read path too', () => {
+    const t = resolveHookTarget(
+      { toolName: 'Edit', toolInput: { file_path: 'src/server.ts' } },
+      graph,
+      cwd,
+    );
+    expect(t).toEqual({ kind: 'file', file: 'src/server.ts' });
+  });
+
+  it('no-ops a Read on a file the graph does not know', () => {
+    const t = resolveHookTarget(
+      { toolName: 'Read', toolInput: { file_path: '/repo/README.md' } },
+      graph,
+      cwd,
+    );
+    expect(t).toBeUndefined();
+  });
+
+  it('routes Grep to a pattern target', () => {
+    const t = resolveHookTarget(
+      { toolName: 'Grep', toolInput: { pattern: 'configureApp' } },
+      graph,
+      cwd,
+    );
+    expect(t).toEqual({ kind: 'pattern', pattern: 'configureApp' });
+  });
+
+  it('routes a Bash grep on a graph file to that file', () => {
+    const t = resolveHookTarget(
+      { toolName: 'Bash', toolInput: { command: 'grep -n "sendFile" src/server.ts' } },
+      graph,
+      cwd,
+    );
+    expect(t).toEqual({ kind: 'file', file: 'src/server.ts' });
+  });
+});
+
+describe('parseBashForTarget', () => {
+  const cwd = '/repo';
+  const graph = graphWithFiles('src/server.ts');
+
+  it('prefers a concrete file argument over the pattern', () => {
+    expect(parseBashForTarget('grep -rn "app.use" src/server.ts', graph, cwd)).toEqual({
+      kind: 'file',
+      file: 'src/server.ts',
+    });
+  });
+
+  it('falls back to the search pattern when only a directory is given', () => {
+    expect(parseBashForTarget('grep -rn "sendFile" src/', graph, cwd)).toEqual({
+      kind: 'pattern',
+      pattern: 'sendFile',
+    });
+  });
+
+  it('handles ripgrep', () => {
+    expect(parseBashForTarget('rg authMiddleware', graph, cwd)).toEqual({
+      kind: 'pattern',
+      pattern: 'authMiddleware',
+    });
+  });
+
+  it('ignores everything past a pipe', () => {
+    // `wc` args after the pipe must not be mistaken for search paths.
+    expect(parseBashForTarget('grep -c foo src/ | wc -l', graph, cwd)).toEqual({
+      kind: 'pattern',
+      pattern: 'foo',
+    });
+  });
+
+  it('no-ops on a non-search Bash command', () => {
+    expect(parseBashForTarget('npm run build', graph, cwd)).toBeUndefined();
+    expect(parseBashForTarget('ls -la src/', graph, cwd)).toBeUndefined();
+  });
+});
+
+describe('formatFileContext', () => {
+  const graph = {
+    meta: { generatedAt: '2026-06-12T10:00:00Z' } as GraphJson['meta'],
+  } as Graph;
+
+  const summary: FileSummary = {
+    sourceFile: 'src/server.ts',
+    found: true,
+    symbols: [
+      {
+        id: 'n1',
+        kind: 'function',
+        label: 'configureApp',
+        line: 12,
+        exported: true,
+        callsIn: 3,
+        callsOut: 5,
+      },
+      { id: 'n2', kind: 'function', label: 'startServer', line: 40, callsIn: 1, callsOut: 2 },
+    ],
+    callerFiles: [{ sourceFile: 'src/index.ts', count: 5 }],
+    calleeFiles: [{ sourceFile: 'src/db.ts', count: 2 }],
+    importsIn: [],
+    importsOut: [],
+    communityLabel: 'http-layer',
+  };
+
+  it('leads with provenance + an authoritative-contents caveat', () => {
+    const out = formatFileContext(summary, graph);
+    expect(out).toContain('.dxkit/reports/graph.json');
+    expect(out).toContain('2026-06-12');
+    expect(out).toContain('actual contents remain authoritative');
+  });
+
+  it('lists the file symbols with caller counts', () => {
+    const out = formatFileContext(summary, graph);
+    expect(out).toContain('configureApp (function:12) — exported, 3 caller(s)');
+    expect(out).toContain('startServer (function:40) — 1 caller(s)');
+  });
+
+  it('shows who depends on the file and what it calls into', () => {
+    const out = formatFileContext(summary, graph);
+    expect(out).toContain('Depended on by 1 file(s):');
+    expect(out).toContain('src/index.ts (5 call(s))');
+    expect(out).toContain('Calls into 1 file(s):');
+    expect(out).toContain('src/db.ts (2 call(s))');
+  });
+
+  it('includes the module group when present', () => {
+    expect(formatFileContext(summary, graph)).toContain('Module group: http-layer');
   });
 });

--- a/test/graphify-envelope.test.ts
+++ b/test/graphify-envelope.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import * as path from 'path';
-import { buildGraphifyEnvelope } from '../src/analyzers/tools/graphify';
+import { buildGraphifyEnvelope, buildGraphifyScript } from '../src/analyzers/tools/graphify';
 
 // Minimal valid GraphifyResult shape — only maxFunctionsFilePath is
 // path-bearing; the other fields are numeric counts the envelope
@@ -66,5 +66,47 @@ describe('buildGraphifyEnvelope', () => {
     expect(env.commentedCodeRatio).toBe(0.1);
     expect(env.tool).toBe('graphify');
     expect(env.schemaVersion).toBe(1);
+  });
+});
+
+/**
+ * Structural contract of the generated Python script. These guard the
+ * D-01 (Python 3.14 multiprocessing) and D-02 (graphifyy cache redirect)
+ * fixes at the source level, so a regression is caught in CI even where
+ * graphify isn't installed and the script can't actually be run.
+ */
+describe('buildGraphifyScript — Python 3.14 / cache-redirect contract', () => {
+  const script = buildGraphifyScript('/tmp/repo');
+
+  it("guards execution behind `if __name__ == '__main__'` (D-01)", () => {
+    // ProcessPoolExecutor workers re-import the module under spawn/forkserver
+    // (Python 3.14's Linux default). Without the guard, top-level extraction
+    // re-runs per worker → BrokenProcessPool / crash.
+    expect(script).toContain("if __name__ == '__main__':");
+    // The extraction call must sit inside the guard (indented), not at module
+    // top level.
+    expect(script).toMatch(/\n {4}result = extract\(/);
+  });
+
+  it('redirects the cache via the public cache_root param, not a monkeypatch (D-02)', () => {
+    expect(script).toContain('extract(files, cache_root=_cache_dir)');
+    // The fragile internal-signature monkeypatch must be gone — it broke when
+    // graphifyy 0.8 changed cache_dir(root) → cache_dir(root, kind).
+    expect(script).not.toContain('_gc.cache_dir');
+    expect(script).not.toContain('import graphify.cache');
+  });
+
+  it('does not force a multiprocessing start method (D-01 — the guard makes it unnecessary)', () => {
+    // The old `set_start_method('fork')` hack only papered over the missing
+    // guard on Linux and silently failed on spawn-default platforms.
+    expect(script).not.toContain('set_start_method');
+  });
+
+  it('takes the cache dir from argv[2] so the TS caller owns its lifecycle', () => {
+    // graphify flushes a stat-index via atexit (after the script body), so the
+    // temp cache is reclaimed by the TS layer's scriptDir cleanup, not a
+    // Python-side rmtree that the atexit write would undo.
+    expect(script).toContain('_cache_dir = Path(sys.argv[2])');
+    expect(script).not.toContain('tempfile.mkdtemp');
   });
 });

--- a/test/graphify-envelope.test.ts
+++ b/test/graphify-envelope.test.ts
@@ -71,14 +71,14 @@ describe('buildGraphifyEnvelope', () => {
 
 /**
  * Structural contract of the generated Python script. These guard the
- * D-01 (Python 3.14 multiprocessing) and D-02 (graphifyy cache redirect)
+ * Python 3.14 multiprocessing and graphifyy cache-redirect
  * fixes at the source level, so a regression is caught in CI even where
  * graphify isn't installed and the script can't actually be run.
  */
 describe('buildGraphifyScript — Python 3.14 / cache-redirect contract', () => {
   const script = buildGraphifyScript('/tmp/repo');
 
-  it("guards execution behind `if __name__ == '__main__'` (D-01)", () => {
+  it("guards execution behind `if __name__ == '__main__'` ", () => {
     // ProcessPoolExecutor workers re-import the module under spawn/forkserver
     // (Python 3.14's Linux default). Without the guard, top-level extraction
     // re-runs per worker → BrokenProcessPool / crash.
@@ -88,7 +88,7 @@ describe('buildGraphifyScript — Python 3.14 / cache-redirect contract', () => 
     expect(script).toMatch(/\n {4}result = extract\(/);
   });
 
-  it('redirects the cache via the public cache_root param, not a monkeypatch (D-02)', () => {
+  it('redirects the cache via the public cache_root param, not a monkeypatch', () => {
     expect(script).toContain('extract(files, cache_root=_cache_dir)');
     // The fragile internal-signature monkeypatch must be gone — it broke when
     // graphifyy 0.8 changed cache_dir(root) → cache_dir(root, kind).
@@ -96,7 +96,7 @@ describe('buildGraphifyScript — Python 3.14 / cache-redirect contract', () => 
     expect(script).not.toContain('import graphify.cache');
   });
 
-  it('does not force a multiprocessing start method (D-01 — the guard makes it unnecessary)', () => {
+  it('does not force a multiprocessing start method (the if-__main__ guard makes it unnecessary)', () => {
     // The old `set_start_method('fork')` hack only papered over the missing
     // guard on Linux and silently failed on spawn-default platforms.
     expect(script).not.toContain('set_start_method');

--- a/test/grep-secrets.test.ts
+++ b/test/grep-secrets.test.ts
@@ -80,9 +80,12 @@ describe('gatherGrepSecretsResult (gitleaks-absent fallback)', () => {
     expect(pk!.severity).toBe('critical');
   });
 
-  it('downgrades a generic password match in a test file to low + test-fixture', () => {
-    // The customer case: unit-test fixture passwords were flagged
-    // as headline CRITICALs. Generic matches in test files downgrade.
+  it('keeps full severity for a password in a test file — severity is not lowered by path', () => {
+    // A hardcoded credential is severe wherever it lives: the generic
+    // matcher cannot tell a throwaway fixture from a real password leaked
+    // into a test, so lowering severity by path would hide genuine leaks.
+    // Test-file noise is managed downstream (report grouping + the
+    // allowlist score-lift), never by silently dropping severity here.
     fs.mkdirSync(path.join(tmp, '__tests__'), { recursive: true });
     fs.writeFileSync(
       path.join(tmp, '__tests__', 'validator.unit.test.ts'),
@@ -92,12 +95,10 @@ describe('gatherGrepSecretsResult (gitleaks-absent fallback)', () => {
     expect(result).not.toBeNull();
     const pw = result!.findings.find((f) => f.rule === 'hardcoded-password');
     expect(pw).toBeDefined();
-    expect(pw!.severity).toBe('low');
-    expect(pw!.category).toBe('test-fixture');
+    expect(pw!.severity).toBe('critical');
   });
 
-  it('keeps full severity for branded tokens even inside test files', () => {
-    // A real AWS key in a test file is still a leaked credential.
+  it('keeps full severity for branded tokens in test files too', () => {
     fs.writeFileSync(
       path.join(tmp, 'auth.spec.ts'),
       "const key = 'AKIAIOSFODNN7EXAMPLE';\nexport default key;\n",
@@ -107,7 +108,6 @@ describe('gatherGrepSecretsResult (gitleaks-absent fallback)', () => {
     const aws = result!.findings.find((f) => f.rule === 'aws-access-key');
     expect(aws).toBeDefined();
     expect(aws!.severity).toBe('high');
-    expect(aws!.category).toBeUndefined();
   });
 
   it('keeps critical severity for passwords in non-test source files', () => {
@@ -116,7 +116,6 @@ describe('gatherGrepSecretsResult (gitleaks-absent fallback)', () => {
     const pw = result!.findings.find((f) => f.rule === 'hardcoded-password');
     expect(pw).toBeDefined();
     expect(pw!.severity).toBe('critical');
-    expect(pw!.category).toBeUndefined();
   });
 
   it('returns a success envelope with zero findings on a clean tree', () => {

--- a/test/grep-secrets.test.ts
+++ b/test/grep-secrets.test.ts
@@ -80,6 +80,45 @@ describe('gatherGrepSecretsResult (gitleaks-absent fallback)', () => {
     expect(pk!.severity).toBe('critical');
   });
 
+  it('downgrades a generic password match in a test file to low + test-fixture', () => {
+    // The customer case (C-D4): unit-test fixture passwords were flagged
+    // as headline CRITICALs. Generic matches in test files downgrade.
+    fs.mkdirSync(path.join(tmp, '__tests__'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '__tests__', 'validator.unit.test.ts'),
+      "const user = { password: 'password1' };\nexport default user;\n",
+    );
+    const result = gatherGrepSecretsResult(tmp);
+    expect(result).not.toBeNull();
+    const pw = result!.findings.find((f) => f.rule === 'hardcoded-password');
+    expect(pw).toBeDefined();
+    expect(pw!.severity).toBe('low');
+    expect(pw!.category).toBe('test-fixture');
+  });
+
+  it('keeps full severity for branded tokens even inside test files', () => {
+    // A real AWS key in a test file is still a leaked credential.
+    fs.writeFileSync(
+      path.join(tmp, 'auth.spec.ts'),
+      "const key = 'AKIAIOSFODNN7EXAMPLE';\nexport default key;\n",
+    );
+    const result = gatherGrepSecretsResult(tmp);
+    expect(result).not.toBeNull();
+    const aws = result!.findings.find((f) => f.rule === 'aws-access-key');
+    expect(aws).toBeDefined();
+    expect(aws!.severity).toBe('high');
+    expect(aws!.category).toBeUndefined();
+  });
+
+  it('keeps critical severity for passwords in non-test source files', () => {
+    fs.writeFileSync(path.join(tmp, 'config.ts'), "const password = 'hunter22';\n");
+    const result = gatherGrepSecretsResult(tmp);
+    const pw = result!.findings.find((f) => f.rule === 'hardcoded-password');
+    expect(pw).toBeDefined();
+    expect(pw!.severity).toBe('critical');
+    expect(pw!.category).toBeUndefined();
+  });
+
   it('returns a success envelope with zero findings on a clean tree', () => {
     fs.writeFileSync(path.join(tmp, 'ok.ts'), "export const greeting = 'hello';\n");
     const result = gatherGrepSecretsResult(tmp);

--- a/test/grep-secrets.test.ts
+++ b/test/grep-secrets.test.ts
@@ -81,7 +81,7 @@ describe('gatherGrepSecretsResult (gitleaks-absent fallback)', () => {
   });
 
   it('downgrades a generic password match in a test file to low + test-fixture', () => {
-    // The customer case (C-D4): unit-test fixture passwords were flagged
+    // The customer case: unit-test fixture passwords were flagged
     // as headline CRITICALs. Generic matches in test files downgrade.
     fs.mkdirSync(path.join(tmp, '__tests__'), { recursive: true });
     fs.writeFileSync(

--- a/test/ingest/snyk-policy.test.ts
+++ b/test/ingest/snyk-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildSnykPolicy,
+  dxkitIgnoreLinesToSnykExcludes,
   expiryToSnykDatetime,
   SNYK_POLICY_VERSION,
   type SnykIgnore,
@@ -12,6 +13,59 @@ describe('expiryToSnykDatetime', () => {
   });
   it('returns undefined for a missing date (permanent ignore)', () => {
     expect(expiryToSnykDatetime(undefined)).toBeUndefined();
+  });
+});
+
+describe('dxkitIgnoreLinesToSnykExcludes', () => {
+  it('drops comments, blanks, and negations', () => {
+    expect(dxkitIgnoreLinesToSnykExcludes(['# a comment', '', '   ', '!keep/this'])).toEqual([]);
+  });
+
+  it('expands directory and bare-name patterns to subtree globs', () => {
+    expect(dxkitIgnoreLinesToSnykExcludes(['vendor/', 'generated', 'fixtures/large/'])).toEqual([
+      'vendor/**',
+      'generated/**',
+      'fixtures/large/**',
+    ]);
+  });
+
+  it('passes through existing globs and strips a leading anchor slash', () => {
+    expect(dxkitIgnoreLinesToSnykExcludes(['*.generated.ts', '/build/', 'src/**'])).toEqual([
+      '*.generated.ts',
+      'build/**',
+      'src/**',
+    ]);
+  });
+
+  it('de-duplicates while preserving order', () => {
+    expect(dxkitIgnoreLinesToSnykExcludes(['vendor/', 'vendor', 'legacy'])).toEqual([
+      'vendor/**',
+      'legacy/**',
+    ]);
+  });
+});
+
+describe('buildSnykPolicy with excludes', () => {
+  it('emits an exclude.global block from .dxkit-ignore patterns', () => {
+    const out = buildSnykPolicy([], ['vendor/**', '*.generated.ts']);
+    expect(out).toContain('exclude:');
+    expect(out).toContain('  global:');
+    expect(out).toContain("    - 'vendor/**'");
+    expect(out).toContain("    - '*.generated.ts'");
+  });
+
+  it('omits the exclude block entirely when there are no excludes (stable prior shape)', () => {
+    expect(buildSnykPolicy([])).not.toContain('exclude:');
+  });
+
+  it('combines ignores and excludes in one policy', () => {
+    const out = buildSnykPolicy(
+      [{ ruleId: 'r', path: 'src/a.ts', created: '2026-06-09T00:00:00.000Z' }],
+      ['vendor/**'],
+    );
+    expect(out).toContain("'r':");
+    expect(out).toContain('exclude:');
+    expect(out).toContain("    - 'vendor/**'");
   });
 });
 

--- a/test/scoring-dimensions.test.ts
+++ b/test/scoring-dimensions.test.ts
@@ -11,6 +11,8 @@ import { SECURITY_SCORING_SPEC, SecurityScoreInput, evaluateSpec } from '../src/
 const scoreSecurityFromInput = (input: SecurityScoreInput) =>
   evaluateSpec(SECURITY_SCORING_SPEC, input);
 import { scoreTestGapsCounts } from '../src/analyzers/tests/scoring';
+import { buildSecurityAggregate } from '../src/analyzers/security/aggregator';
+import { canonicalRuleFor, computeCodeFingerprint } from '../src/analyzers/tools/fingerprint';
 import { buildSecurityDetailed } from '../src/analyzers/security/detailed';
 import type { SecurityReport } from '../src/analyzers/security/types';
 import {
@@ -19,7 +21,6 @@ import {
   depVulnCapability,
   lintCapability,
   qualityMeasuredCapabilities,
-  secretsCapability,
   secretsCapabilityWithCount,
   withInput,
 } from './fixtures/score-input';
@@ -149,39 +150,60 @@ describe('scoreSecurityFromInput', () => {
     expect(scoreSecurityFromInput(emptyScoreInput()).score).toBe(100);
   });
 
-  it('test-fixture secrets do not drive secretFindings (no trust-broken cap)', () => {
-    // A repo whose only "secrets" are auto-downgraded unit-test fixtures
-    // must not be capped as committed-credentials. Real findings still count.
-    const fixtureOnly = withInput({
-      capabilities: {
-        secrets: secretsCapability([
-          {
-            file: '__tests__/validator.unit.test.ts',
-            line: 10,
-            rule: 'hardcoded-password',
-            severity: 'low',
-            category: 'test-fixture',
-          },
-        ]),
-      },
-    });
-    expect(toSecurityScoreInput(fixtureOnly).secretFindings).toBe(0);
+  it('allowlisted (false-positive/test-fixture) secrets do not drive secretFindings; real ones do', () => {
+    // A repo that has reviewed and accepted its flagged secrets as
+    // false-positive / test-fixture must not stay capped at the
+    // committed-credentials tier on that noise — but an un-triaged real
+    // secret still counts. The aggregate carries the allowlist-adjusted
+    // scoreable buckets; toSecurityScoreInput reads them.
+    const fixtureFp = computeCodeFingerprint(
+      canonicalRuleFor('grep-secrets', 'hardcoded-password'),
+      'src/__tests__/validator.unit.ts',
+      10,
+    );
+    const buildAgg = (entries: object[]) =>
+      buildSecurityAggregate({
+        secrets: {
+          findings: [
+            {
+              severity: 'critical',
+              category: 'secret',
+              cwe: 'CWE-798',
+              rule: 'hardcoded-password',
+              title: 's',
+              file: 'src/__tests__/validator.unit.ts',
+              line: 10,
+              tool: 'grep-secrets',
+            },
+          ],
+          toolUsed: 'grep-secrets',
+        },
+        fileFindings: [],
+        codePatterns: { findings: [], toolUsed: null },
+        tlsBypass: [],
+        tlsBypassPatternCount: 0,
+        depVulns: { findings: [], tool: null, available: true, unavailableReason: '' },
+        allowlist: { schemaVersion: 'dxkit-allowlist/v1', mode: 'full', entries } as never,
+      });
 
-    const mixed = withInput({
+    // No allowlist → the secret counts (real-secret baseline).
+    const counted = withInput({ capabilities: { securityAggregate: buildAgg([]) } });
+    expect(toSecurityScoreInput(counted).secretFindings).toBe(1);
+
+    // Allowlisted as test-fixture → lifted from the score.
+    const lifted = withInput({
       capabilities: {
-        secrets: secretsCapability([
+        securityAggregate: buildAgg([
           {
-            file: '__tests__/validator.unit.test.ts',
-            line: 10,
-            rule: 'hardcoded-password',
-            severity: 'low',
+            fingerprint: fixtureFp,
+            kind: 'secret',
             category: 'test-fixture',
+            addedAt: '2026-06-01',
           },
-          { file: 'src/keycloak.ts', line: 127, rule: 'hardcoded-password', severity: 'critical' },
         ]),
       },
     });
-    expect(toSecurityScoreInput(mixed).secretFindings).toBe(1);
+    expect(toSecurityScoreInput(lifted).secretFindings).toBe(0);
   });
 
   it('C2.2 / D098: every secret-class signal caps the score at 40', () => {
@@ -323,10 +345,10 @@ describe('scoreSecurityFromInput', () => {
   // ── Symmetric unavailable-scanner honesty caps ────────────────────────────────────────
 
   it('caps at 65 when the secret scan did not run', () => {
-    // Pre-2.10 a missing secret scan silently scored as "0 secrets" —
-    // the customer's Jun-4 report printed a confident clean subtotal
-    // next to "Sources: (none)", and the eventual upgrade read as a
-    // phantom score drop. Same uncertainty treatment as dep-vulns now.
+    // Pre-2.10 a missing secret scan silently scored as "0 secrets" — a
+    // confident clean subtotal next to "Sources: (none)", so enabling the
+    // scanner later read as a phantom score drop. Same uncertainty
+    // treatment as dep-vulns now.
     const s = scoreSecurityFromInput(emptyScoreInput({ secretsAvailable: false }));
     expect(s.score).toBe(65);
     expect(s.capsApplied.map((c) => c.id)).toContain('secrets-unavailable');

--- a/test/scoring-dimensions.test.ts
+++ b/test/scoring-dimensions.test.ts
@@ -137,6 +137,9 @@ function emptyScoreInput(overrides: Partial<SecurityScoreInput> = {}): SecurityS
     // scan ran cleanly. Tests for the cap explicitly override
     // `depVulnsAvailable: false`.
     depVulnsAvailable: true,
+    // C-D1: same happy-path default for the secret + code-pattern axes.
+    secretsAvailable: true,
+    codePatternsAvailable: true,
     ...overrides,
   };
 }
@@ -315,6 +318,33 @@ describe('scoreSecurityFromInput', () => {
     // Sanity check: cap only fires on the false case.
     const s = scoreSecurityFromInput(emptyScoreInput({ depVulnsAvailable: true }));
     expect(s.score).toBe(100);
+  });
+
+  // ── C-D1 symmetric honesty caps ────────────────────────────────────────
+
+  it('C-D1: caps at 65 when the secret scan did not run', () => {
+    // Pre-2.10 a missing secret scan silently scored as "0 secrets" —
+    // the customer's Jun-4 report printed a confident clean subtotal
+    // next to "Sources: (none)", and the eventual upgrade read as a
+    // phantom score drop. Same uncertainty treatment as dep-vulns now.
+    const s = scoreSecurityFromInput(emptyScoreInput({ secretsAvailable: false }));
+    expect(s.score).toBe(65);
+    expect(s.capsApplied.map((c) => c.id)).toContain('secrets-unavailable');
+  });
+
+  it('C-D1: caps at 65 when the code-pattern scan did not run', () => {
+    const s = scoreSecurityFromInput(emptyScoreInput({ codePatternsAvailable: false }));
+    expect(s.score).toBe(65);
+    expect(s.capsApplied.map((c) => c.id)).toContain('code-patterns-unavailable');
+  });
+
+  it('C-D1: trust-broken (40) still dominates an unavailability cap (65)', () => {
+    // Found credentials are worse news than a scanner that didn't run;
+    // most-aggressive cap wins.
+    const s = scoreSecurityFromInput(
+      emptyScoreInput({ secretFindings: 1, codePatternsAvailable: false }),
+    );
+    expect(s.score).toBe(40);
   });
 
   it('dep-availability cap is a ceiling, not a floor — other penalties still drop the score below 65', () => {

--- a/test/scoring-dimensions.test.ts
+++ b/test/scoring-dimensions.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { scoreDocsDimension } from '../src/analyzers/docs/shallow';
 import { scoreMaintainabilityDimension } from '../src/analyzers/maintainability/shallow';
 import { scoreDxDimension } from '../src/analyzers/dx/shallow';
-import { scoreSecurityDimension } from '../src/analyzers/security/shallow';
+import { scoreSecurityDimension, toSecurityScoreInput } from '../src/analyzers/security/shallow';
 import { scoreQualityDimension } from '../src/analyzers/quality/shallow';
 import { scoreTestsDimension } from '../src/analyzers/tests/shallow';
 import { SECURITY_SCORING_SPEC, SecurityScoreInput, evaluateSpec } from '../src/scoring';
@@ -19,6 +19,7 @@ import {
   depVulnCapability,
   lintCapability,
   qualityMeasuredCapabilities,
+  secretsCapability,
   secretsCapabilityWithCount,
   withInput,
 } from './fixtures/score-input';
@@ -143,6 +144,41 @@ function emptyScoreInput(overrides: Partial<SecurityScoreInput> = {}): SecurityS
 describe('scoreSecurityFromInput', () => {
   it('returns 100 for an empty input', () => {
     expect(scoreSecurityFromInput(emptyScoreInput()).score).toBe(100);
+  });
+
+  it('C-D4: test-fixture secrets do not drive secretFindings (no trust-broken cap)', () => {
+    // A repo whose only "secrets" are auto-downgraded unit-test fixtures
+    // must not be capped as committed-credentials. Real findings still count.
+    const fixtureOnly = withInput({
+      capabilities: {
+        secrets: secretsCapability([
+          {
+            file: '__tests__/validator.unit.test.ts',
+            line: 10,
+            rule: 'hardcoded-password',
+            severity: 'low',
+            category: 'test-fixture',
+          },
+        ]),
+      },
+    });
+    expect(toSecurityScoreInput(fixtureOnly).secretFindings).toBe(0);
+
+    const mixed = withInput({
+      capabilities: {
+        secrets: secretsCapability([
+          {
+            file: '__tests__/validator.unit.test.ts',
+            line: 10,
+            rule: 'hardcoded-password',
+            severity: 'low',
+            category: 'test-fixture',
+          },
+          { file: 'src/keycloak.ts', line: 127, rule: 'hardcoded-password', severity: 'critical' },
+        ]),
+      },
+    });
+    expect(toSecurityScoreInput(mixed).secretFindings).toBe(1);
   });
 
   it('C2.2 / D098: every secret-class signal caps the score at 40', () => {

--- a/test/scoring-dimensions.test.ts
+++ b/test/scoring-dimensions.test.ts
@@ -137,7 +137,7 @@ function emptyScoreInput(overrides: Partial<SecurityScoreInput> = {}): SecurityS
     // scan ran cleanly. Tests for the cap explicitly override
     // `depVulnsAvailable: false`.
     depVulnsAvailable: true,
-    // C-D1: same happy-path default for the secret + code-pattern axes.
+    // Same happy-path default for the secret + code-pattern axes.
     secretsAvailable: true,
     codePatternsAvailable: true,
     ...overrides,
@@ -149,7 +149,7 @@ describe('scoreSecurityFromInput', () => {
     expect(scoreSecurityFromInput(emptyScoreInput()).score).toBe(100);
   });
 
-  it('C-D4: test-fixture secrets do not drive secretFindings (no trust-broken cap)', () => {
+  it('test-fixture secrets do not drive secretFindings (no trust-broken cap)', () => {
     // A repo whose only "secrets" are auto-downgraded unit-test fixtures
     // must not be capped as committed-credentials. Real findings still count.
     const fixtureOnly = withInput({
@@ -320,9 +320,9 @@ describe('scoreSecurityFromInput', () => {
     expect(s.score).toBe(100);
   });
 
-  // ── C-D1 symmetric honesty caps ────────────────────────────────────────
+  // ── Symmetric unavailable-scanner honesty caps ────────────────────────────────────────
 
-  it('C-D1: caps at 65 when the secret scan did not run', () => {
+  it('caps at 65 when the secret scan did not run', () => {
     // Pre-2.10 a missing secret scan silently scored as "0 secrets" —
     // the customer's Jun-4 report printed a confident clean subtotal
     // next to "Sources: (none)", and the eventual upgrade read as a
@@ -332,13 +332,13 @@ describe('scoreSecurityFromInput', () => {
     expect(s.capsApplied.map((c) => c.id)).toContain('secrets-unavailable');
   });
 
-  it('C-D1: caps at 65 when the code-pattern scan did not run', () => {
+  it('caps at 65 when the code-pattern scan did not run', () => {
     const s = scoreSecurityFromInput(emptyScoreInput({ codePatternsAvailable: false }));
     expect(s.score).toBe(65);
     expect(s.capsApplied.map((c) => c.id)).toContain('code-patterns-unavailable');
   });
 
-  it('C-D1: trust-broken (40) still dominates an unavailability cap (65)', () => {
+  it('trust-broken (40) still dominates an unavailability cap (65)', () => {
     // Found credentials are worse news than a scanner that didn't run;
     // most-aggressive cap wins.
     const s = scoreSecurityFromInput(

--- a/test/security-aggregator.test.ts
+++ b/test/security-aggregator.test.ts
@@ -77,6 +77,103 @@ describe('buildSecurityAggregate — empty case', () => {
     expect(agg.provenance.tlsBypass.ran).toBe(false);
     expect(agg.provenance.depVulns.available).toBe(true);
   });
+
+  it('scoreable buckets equal raw buckets when no allowlist is supplied', () => {
+    const agg = buildSecurityAggregate({
+      ...emptyInput(),
+      secrets: {
+        findings: [makeFinding({ category: 'secret', severity: 'critical', file: 'a.ts' })],
+        toolUsed: 'gitleaks',
+      },
+      codePatterns: {
+        findings: [makeFinding({ category: 'code', severity: 'high', file: 'b.ts' })],
+        toolUsed: 'semgrep',
+      },
+    });
+    expect(agg.scoreableSecretsBySeverity).toEqual(agg.secretsBySeverity);
+    expect(agg.scoreableCodeBySeverity).toEqual(agg.codeBySeverity);
+  });
+});
+
+describe('buildSecurityAggregate — allowlist score-lift (C-D2 follow-on)', () => {
+  // Build the allowlist entry for a finding using the same canonical
+  // fingerprint scheme the aggregator stamps, so the match is exact.
+  function fpFor(tool: string, rule: string, file: string, line: number): string {
+    return computeCodeFingerprint(canonicalRuleFor(tool, rule), file, line);
+  }
+  function allowEntry(fingerprint: string, kind: 'secret' | 'code', category: string) {
+    return { fingerprint, kind, category, addedAt: '2026-06-01' } as never;
+  }
+
+  it('false-positive / test-fixture secrets are lifted from the scoreable bucket but stay in the raw bucket + annotated', () => {
+    const fpFixture = fpFor('grep-secrets', 'hardcoded-password', 'src/__tests__/a.unit.ts', 1);
+    const agg = buildSecurityAggregate({
+      ...emptyInput(),
+      secrets: {
+        findings: [
+          makeFinding({
+            category: 'secret',
+            severity: 'critical',
+            rule: 'hardcoded-password',
+            tool: 'grep-secrets',
+            file: 'src/__tests__/a.unit.ts',
+            line: 1,
+          }),
+          makeFinding({
+            category: 'secret',
+            severity: 'critical',
+            rule: 'hardcoded-password',
+            tool: 'grep-secrets',
+            file: 'src/services/session.ts',
+            line: 9,
+          }),
+        ],
+        toolUsed: 'grep-secrets',
+      },
+      allowlist: {
+        schemaVersion: 'dxkit-allowlist/v1',
+        mode: 'full',
+        entries: [allowEntry(fpFixture, 'secret', 'test-fixture')],
+      } as never,
+    });
+
+    // Raw bucket still counts both (reports show the truth + "1 allowlisted").
+    expect(agg.secretsBySeverity.critical).toBe(2);
+    // Scoreable bucket excludes the reviewed test-fixture → only the real one.
+    expect(agg.scoreableSecretsBySeverity.critical).toBe(1);
+    const fixture = agg.findingsByCategory.secret.find((f) => f.file === 'src/__tests__/a.unit.ts');
+    expect(fixture?.allowlisted).toBe(true);
+    expect(fixture?.allowlistCategory).toBe('test-fixture');
+  });
+
+  it('accepted-risk does NOT lift the score — a real, accepted exposure still counts', () => {
+    const fp = fpFor('semgrep', 'sql-injection', 'src/db.ts', 12);
+    const agg = buildSecurityAggregate({
+      ...emptyInput(),
+      codePatterns: {
+        findings: [
+          makeFinding({
+            category: 'code',
+            severity: 'high',
+            rule: 'sql-injection',
+            tool: 'semgrep',
+            file: 'src/db.ts',
+            line: 12,
+          }),
+        ],
+        toolUsed: 'semgrep',
+      },
+      allowlist: {
+        schemaVersion: 'dxkit-allowlist/v1',
+        mode: 'full',
+        entries: [allowEntry(fp, 'code', 'accepted-risk')],
+      } as never,
+    });
+    expect(agg.codeBySeverity.high).toBe(1);
+    // accepted-risk is annotated but NOT lifted from the score.
+    expect(agg.scoreableCodeBySeverity.high).toBe(1);
+    expect(agg.findingsByCategory.code[0]?.allowlisted).toBe(true);
+  });
 });
 
 describe('buildSecurityAggregate — D091 cross-tool TLS-bypass dedup', () => {

--- a/test/security-report-framing.test.ts
+++ b/test/security-report-framing.test.ts
@@ -355,3 +355,62 @@ describe('formatDepActionTitle (G_v4_10 / D111)', () => {
     expect(md).not.toContain('to (no patch)');
   });
 });
+
+describe('formatSecurityReport — Secret & Config framing (allowlist + test-located guidance)', () => {
+  function reportWithSecrets(findings: SecurityReport['findings']): SecurityReport {
+    const r = makeReport({});
+    return { ...r, findings };
+  }
+  const secret = (
+    file: string,
+    extra: Partial<SecurityReport['findings'][number]> = {},
+  ): SecurityReport['findings'][number] => ({
+    severity: 'critical',
+    category: 'secret',
+    cwe: 'CWE-798',
+    rule: 'hardcoded-password',
+    title: 'Secret',
+    file,
+    line: 1,
+    tool: 'grep-secrets',
+    ...extra,
+  });
+
+  it('shows the allowlisted suffix + note for reviewed-and-accepted secrets', () => {
+    const md = formatSecurityReport(
+      reportWithSecrets([
+        secret('src/a.ts', { allowlisted: true, allowlistCategory: 'false-positive' }),
+        secret('src/b.ts'),
+      ]),
+      '1.0',
+    );
+    expect(md).toContain('(1 allowlisted)');
+    expect(md).toContain('covered by an active allowlist entry');
+  });
+
+  it('guides triage for un-allowlisted secrets that live in test files', () => {
+    const md = formatSecurityReport(
+      reportWithSecrets([
+        secret('src/__tests__/auth.unit.ts'), // test-located, not allowlisted
+        secret('src/config.ts'), // production
+      ]),
+      '1.0',
+    );
+    expect(md).toContain('1 of the above finding is in test files');
+    expect(md).toContain('allowlist add --category test-fixture');
+    expect(md).toContain('rotate it and remove it from git history');
+  });
+
+  it('does not show the test-file guidance when a test-located secret is already allowlisted', () => {
+    const md = formatSecurityReport(
+      reportWithSecrets([
+        secret('src/__tests__/auth.unit.ts', {
+          allowlisted: true,
+          allowlistCategory: 'test-fixture',
+        }),
+      ]),
+      '1.0',
+    );
+    expect(md).not.toContain('in test files');
+  });
+});

--- a/test/security-scanner-drift.test.ts
+++ b/test/security-scanner-drift.test.ts
@@ -41,7 +41,7 @@ describe('detectScannerCoverageDrift', () => {
     expect(detectScannerCoverageDrift(repo, ['gitleaks'], '2026-06-10')).toBeNull();
   });
 
-  it('detects the customer case: grep-secrets + snyk-code added since the prior run', () => {
+  it('detects scanners added since the prior run (grep-secrets + snyk-code)', () => {
     writePrior('2026-06-09', ['find', 'git', 'gitleaks']);
     const drift = detectScannerCoverageDrift(
       repo,

--- a/test/security-scanner-drift.test.ts
+++ b/test/security-scanner-drift.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { detectScannerCoverageDrift } from '../src/analyzers/security/scanner-drift';
 
 /**
- * C-D3: the scanner-coverage-drift detector compares this run's tool set
+ * The scanner-coverage-drift detector compares this run's tool set
  * against the most recent prior persisted vuln-scan report and reports
  * which scanners are newly active — the signal that explains a score
  * change on an unchanged commit after a dxkit upgrade enabled more

--- a/test/security-scanner-drift.test.ts
+++ b/test/security-scanner-drift.test.ts
@@ -1,0 +1,96 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { detectScannerCoverageDrift } from '../src/analyzers/security/scanner-drift';
+
+/**
+ * C-D3: the scanner-coverage-drift detector compares this run's tool set
+ * against the most recent prior persisted vuln-scan report and reports
+ * which scanners are newly active — the signal that explains a score
+ * change on an unchanged commit after a dxkit upgrade enabled more
+ * scanners.
+ */
+describe('detectScannerCoverageDrift', () => {
+  let repo: string;
+  let reportDir: string;
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-drift-'));
+    reportDir = path.join(repo, '.dxkit', 'reports');
+    fs.mkdirSync(reportDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  function writePrior(date: string, toolsUsed: string[]): void {
+    fs.writeFileSync(
+      path.join(reportDir, `vulnerability-scan-${date}-detailed.json`),
+      JSON.stringify({ toolsUsed }),
+    );
+  }
+
+  it('returns null when there is no reports directory', () => {
+    fs.rmSync(reportDir, { recursive: true, force: true });
+    expect(detectScannerCoverageDrift(repo, ['gitleaks'], '2026-06-10')).toBeNull();
+  });
+
+  it('returns null on a first run (no prior report)', () => {
+    expect(detectScannerCoverageDrift(repo, ['gitleaks'], '2026-06-10')).toBeNull();
+  });
+
+  it('detects the customer case: grep-secrets + snyk-code added since the prior run', () => {
+    writePrior('2026-06-09', ['find', 'git', 'gitleaks']);
+    const drift = detectScannerCoverageDrift(
+      repo,
+      ['find', 'git', 'gitleaks', 'grep-secrets', 'snyk-code'],
+      '2026-06-10',
+    );
+    expect(drift).toEqual({ added: ['grep-secrets', 'snyk-code'], previousDate: '2026-06-09' });
+  });
+
+  it('returns null when the scanner set is unchanged', () => {
+    writePrior('2026-06-09', ['find', 'git', 'gitleaks']);
+    expect(detectScannerCoverageDrift(repo, ['gitleaks', 'find', 'git'], '2026-06-10')).toBeNull();
+  });
+
+  it('returns null when the scanner set shrank (not the confusing case)', () => {
+    writePrior('2026-06-09', ['find', 'git', 'gitleaks', 'snyk-code']);
+    expect(detectScannerCoverageDrift(repo, ['find', 'git', 'gitleaks'], '2026-06-10')).toBeNull();
+  });
+
+  it('compares against the most recent prior report, not an older one', () => {
+    writePrior('2026-06-04', ['gitleaks']);
+    writePrior('2026-06-09', ['gitleaks', 'grep-secrets']);
+    // Most recent prior is 06-09 (already has grep-secrets) → only snyk-code is new.
+    const drift = detectScannerCoverageDrift(
+      repo,
+      ['gitleaks', 'grep-secrets', 'snyk-code'],
+      '2026-06-10',
+    );
+    expect(drift).toEqual({ added: ['snyk-code'], previousDate: '2026-06-09' });
+  });
+
+  it('ignores same-day and future reports', () => {
+    writePrior('2026-06-10', ['gitleaks', 'grep-secrets', 'snyk-code']); // today — skipped
+    writePrior('2026-06-09', ['gitleaks']); // the honest comparison point
+    const drift = detectScannerCoverageDrift(
+      repo,
+      ['gitleaks', 'grep-secrets', 'snyk-code'],
+      '2026-06-10',
+    );
+    expect(drift).toEqual({ added: ['grep-secrets', 'snyk-code'], previousDate: '2026-06-09' });
+  });
+
+  it('fails open past an unreadable prior report to the next-most-recent', () => {
+    fs.writeFileSync(
+      path.join(reportDir, 'vulnerability-scan-2026-06-09-detailed.json'),
+      '{ not valid json',
+    );
+    writePrior('2026-06-08', ['gitleaks']);
+    const drift = detectScannerCoverageDrift(repo, ['gitleaks', 'snyk-code'], '2026-06-10');
+    expect(drift).toEqual({ added: ['snyk-code'], previousDate: '2026-06-08' });
+  });
+});

--- a/test/tool-registry-version-pins.test.ts
+++ b/test/tool-registry-version-pins.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { TOOL_DEFS } from '../src/analyzers/tools/tool-registry';
+
+/**
+ * Version-pin guard for the tool registry.
+ *
+ * Tool-version drift is a recurring defect class: an unpinned install
+ * pulls whatever is newest, and a new major can change a CLI flag or the
+ * JSON schema dxkit parses — breaking the analyzer at runtime with no code
+ * change on our side. Real instances we shipped fixes for:
+ *   - jscpd 5.x (Rust rewrite) dropped `--gitignore` + changed the report
+ *     schema → exit 2.  (pinned jscpd@4.2.5)
+ *   - graphifyy 0.8 changed an internal `cache_dir` signature.  (pinned
+ *     graphifyy==0.8.36; the generated script now also drives graphify only
+ *     through its public API)
+ *
+ * This test locks every tool we install from a versioned GitHub release /
+ * pinned npm-or-pip spec so the pin can't silently regress to "latest".
+ * The expected version is the substring that must appear in every platform
+ * install command (and the top-level `install` hint where it carries one).
+ *
+ * `KNOWN_UNPINNED` is the explicit, visible backlog: tools still installed
+ * unpinned. They are listed here on purpose — so the gap is auditable in one
+ * place rather than discovered the next time a tool ships a breaking major.
+ * Moving a tool from KNOWN_UNPINNED into PINNED_TOOLS (with a tested version)
+ * is the closure step. Package-manager-tracked installs (brew / cargo / go /
+ * gem / dotnet / rustup) are intentionally absent from both lists — they
+ * resolve their own versions and dxkit doesn't author the pin.
+ */
+
+/** tool name → version substring that MUST appear in its install commands. */
+const PINNED_TOOLS: Record<string, string> = {
+  gitleaks: 'v8.24.0',
+  'osv-scanner': 'v2.3.8',
+  pmd: '7.24.0',
+  detekt: 'v1.23.6',
+  graphify: 'graphifyy==0.8.36',
+  jscpd: 'jscpd@4.2.5',
+};
+
+/**
+ * Tools dxkit installs from a spec it authors (npm / pip / `go install`)
+ * that is NOT yet version-pinned — the audited backlog. Pinning one (with a
+ * tested version) is the closure: move it into PINNED_TOOLS. `semgrep` is
+ * the highest-risk entry — universal, runs on every scan, and dxkit parses
+ * its JSON output, so a breaking CLI/schema change lands like jscpd 5.x did.
+ * The go-toolchain entries currently float on `@latest`.
+ */
+const KNOWN_UNPINNED = [
+  'semgrep',
+  'ruff',
+  'pip-audit',
+  'pip-licenses',
+  'coverage-py',
+  'eslint',
+  'vitest-coverage',
+  'license-checker-rseidelsohn',
+  'snyk',
+  'codeql',
+  'cloc',
+  'golangci-lint',
+  'govulncheck',
+  'go-licenses',
+];
+
+/**
+ * Tools installed through a system / language package manager that owns its
+ * own version resolution (brew, cargo, rustup, gem, `dotnet tool`, builtin).
+ * dxkit doesn't author a pinnable spec for these, so they're neither pinned
+ * nor part of the unpinned backlog — but they're listed so the partition
+ * below is exhaustive and a new tool can't slip in unclassified.
+ */
+const PACKAGE_MANAGER_TRACKED = [
+  'cargo-audit',
+  'cargo-license',
+  'cargo-llvm-cov',
+  'clippy',
+  'dotnet-format',
+  'npm-audit',
+  'nuget-license',
+  'rubocop',
+  'simplecov',
+];
+
+function installStrings(name: string): string[] {
+  const def = TOOL_DEFS[name];
+  const cmds = Object.values(def.installCommands ?? {}).filter(
+    (c): c is string => typeof c === 'string' && c.length > 0,
+  );
+  // Some install hints carry the pin on the top-level `install` field too
+  // (e.g. graphify, jscpd); include it when it names the package.
+  return [...cmds, def.install];
+}
+
+describe('tool-registry version pins', () => {
+  for (const [name, version] of Object.entries(PINNED_TOOLS)) {
+    it(`pins ${name} to ${version} in every install command`, () => {
+      const def = TOOL_DEFS[name];
+      expect(def, `TOOL_DEFS.${name} missing`).toBeTruthy();
+      const strings = installStrings(name);
+      // Every concrete install command for this tool must carry the pin.
+      // (The top-level `install` hint is allowed to omit it only when it
+      // delegates to the platform list — but our pinned tools all name the
+      // version, so we require it everywhere it appears as a real command.)
+      for (const cmd of Object.values(def.installCommands ?? {})) {
+        if (typeof cmd !== 'string' || cmd.length === 0) continue;
+        // brew/scoop/winget lines track their own version; only assert the
+        // pin on lines that actually fetch a versioned artifact or package.
+        const isPkgMgrLine =
+          /^(brew install|scoop install|winget install|builtin)/.test(cmd.trim()) &&
+          !/curl|npm install|pip install|releases\/download/.test(cmd);
+        if (isPkgMgrLine) continue;
+        expect(cmd, `${name} install command not pinned: ${cmd}`).toContain(version);
+      }
+      // And at least one of the strings carries it (guards against a tool
+      // whose installCommands were all pkg-mgr lines yet claims a pin).
+      expect(strings.some((s) => s.includes(version))).toBe(true);
+    });
+  }
+
+  it('the three pin-policy buckets exactly partition the registry', () => {
+    // Every tool must be a deliberate decision: pinned, audited-unpinned, or
+    // package-manager-tracked. A tool in none of them is a blind spot; a tool
+    // in two is a contradiction. This forces any newly-added tool to declare
+    // its version-stability story instead of silently floating on "latest".
+    const buckets = [...Object.keys(PINNED_TOOLS), ...KNOWN_UNPINNED, ...PACKAGE_MANAGER_TRACKED];
+    const counts = new Map<string, number>();
+    for (const n of buckets) counts.set(n, (counts.get(n) ?? 0) + 1);
+
+    const duplicated = [...counts].filter(([, c]) => c > 1).map(([n]) => n);
+    expect(duplicated, `tools listed in more than one bucket: ${duplicated.join(', ')}`).toEqual(
+      [],
+    );
+
+    const registry = new Set(Object.keys(TOOL_DEFS));
+    const unclassified = [...registry].filter((n) => !counts.has(n));
+    expect(
+      unclassified,
+      `unclassified tools (add to a pin-policy bucket): ${unclassified.join(', ')}`,
+    ).toEqual([]);
+
+    const stale = [...counts.keys()].filter((n) => !registry.has(n));
+    expect(stale, `bucketed tools no longer in the registry: ${stale.join(', ')}`).toEqual([]);
+  });
+});

--- a/test/tool-registry-version-pins.test.ts
+++ b/test/tool-registry-version-pins.test.ts
@@ -36,32 +36,47 @@ const PINNED_TOOLS: Record<string, string> = {
   detekt: 'v1.23.6',
   graphify: 'graphifyy==0.8.36',
   jscpd: 'jscpd@4.2.5',
+  // 2.10 version-pin sweep: defensive freezes for the dxkit-owned,
+  // deterministic-output scanners so a future breaking major can't
+  // silently change parsed output or exit codes (the jscpd-5.x class).
+  // Proper schema-adaptive multi-version handling is deferred to a
+  // later release. Versions are the current releases as of the sweep
+  // (semgrep is the benchmark-validated 1.165.0). Consumer-owned and
+  // SaaS/managed tools deliberately stay in KNOWN_UNPINNED below.
+  semgrep: 'semgrep==1.165.0',
+  ruff: 'ruff==0.15.17',
+  'pip-audit': 'pip-audit==2.10.1',
+  'pip-licenses': 'pip-licenses==5.5.5',
+  'coverage-py': 'coverage==7.14.1',
+  'license-checker-rseidelsohn': 'license-checker-rseidelsohn@5.0.1',
+  'golangci-lint': '@v1.64.8',
+  govulncheck: '@v1.3.0',
+  'go-licenses': '@v1.6.0',
 };
 
 /**
- * Tools dxkit installs from a spec it authors (npm / pip / `go install`)
- * that is NOT yet version-pinned — the audited backlog. Pinning one (with a
- * tested version) is the closure: move it into PINNED_TOOLS. `semgrep` is
- * the highest-risk entry — universal, runs on every scan, and dxkit parses
- * its JSON output, so a breaking CLI/schema change lands like jscpd 5.x did.
- * The go-toolchain entries currently float on `@latest`.
+ * Tools dxkit installs but does NOT version-pin — each for a deliberate
+ * reason, not an oversight. The 2.10 sweep emptied the "just hasn't been
+ * pinned yet" backlog into PINNED_TOOLS; what remains stays unpinned BY
+ * DESIGN:
+ *
+ *   - `eslint`, `vitest-coverage` — `installScope: 'project-local'`. They
+ *     install into the CONSUMER's package.json; the consumer owns the
+ *     version. dxkit pinning them would override the project's own choice.
+ *   - `snyk` — a SaaS CLI that authenticates against Snyk's backend and
+ *     self-manages client/server compatibility. Pinning an old client
+ *     risks server-side deprecation breaking it; let it float.
+ *   - `codeql` — a GitHub-managed bundle paired with versioned query
+ *     packs; the CLI and packs must stay in lockstep, so GitHub's
+ *     channel owns the version, not dxkit.
+ *   - `cloc` — a stable line-counter on a non-semver npm tag
+ *     (`2.6.0-cloc`); lowest-risk output schema in the registry, and the
+ *     odd version string makes a clean pin fragile for negligible gain.
+ *
+ * Moving a tool here into PINNED_TOOLS (with a tested version) is the
+ * closure step for any future backlog entry.
  */
-const KNOWN_UNPINNED = [
-  'semgrep',
-  'ruff',
-  'pip-audit',
-  'pip-licenses',
-  'coverage-py',
-  'eslint',
-  'vitest-coverage',
-  'license-checker-rseidelsohn',
-  'snyk',
-  'codeql',
-  'cloc',
-  'golangci-lint',
-  'govulncheck',
-  'go-licenses',
-];
+const KNOWN_UNPINNED = ['eslint', 'vitest-coverage', 'snyk', 'codeql', 'cloc'];
 
 /**
  * Tools installed through a system / language package manager that owns its

--- a/test/walk-source-files.test.ts
+++ b/test/walk-source-files.test.ts
@@ -252,9 +252,9 @@ describe('walkSourceFiles — test-file filter', () => {
   });
 
   it('recognizes the cross-ecosystem test-directory conventions (__tests__/, etc.)', () => {
-    // The customer case: tests under Jest's `__tests__/` directory were
-    // counted as source because no pack declared the directory
-    // convention. UNIVERSAL_TEST_DIR_PATTERNS now supplies them.
+    // Tests under Jest's `__tests__/` directory were counted as source
+    // because no pack declared the directory convention.
+    // UNIVERSAL_TEST_DIR_PATTERNS now supplies them.
     write('src/app.ts');
     write('src/__tests__/unit/validator.unit.ts');
     write('src/__tests__/helpers.ts');

--- a/test/walk-source-files.test.ts
+++ b/test/walk-source-files.test.ts
@@ -250,6 +250,30 @@ describe('walkSourceFiles — test-file filter', () => {
     expect(out).toContain('src/a.test.ts');
     expect(out).toContain('tests/b.rs');
   });
+
+  it('recognizes the cross-ecosystem test-directory conventions (__tests__/, etc.)', () => {
+    // The customer case: tests under Jest's `__tests__/` directory were
+    // counted as source because no pack declared the directory
+    // convention. UNIVERSAL_TEST_DIR_PATTERNS now supplies them.
+    write('src/app.ts');
+    write('src/__tests__/unit/validator.unit.ts');
+    write('src/__tests__/helpers.ts');
+    write('e2e/login.ts');
+    const out = walkSourceFiles(tmp);
+    expect(out).toContain('src/app.ts');
+    expect(out).not.toContain('src/__tests__/unit/validator.unit.ts');
+    expect(out).not.toContain('src/__tests__/helpers.ts');
+    expect(out).not.toContain('e2e/login.ts');
+  });
+
+  it('recognizes co-located TS test suffixes (.unit/.e2e/.cy)', () => {
+    write('src/service.ts');
+    write('src/service.unit.ts');
+    write('src/flow.e2e.ts');
+    write('src/page.cy.tsx');
+    const out = walkSourceFiles(tmp);
+    expect(out).toEqual(['src/service.ts']);
+  });
 });
 
 describe('walkSourceFiles — memoization', () => {


### PR DESCRIPTION
## 2.10.0

A release in four themes: honest scoring when the scanner set changes, passive delivery of the code graph to the agent, tool-install robustness, and a Snyk-sync addition. Bumps `package.json` + `package-lock.json` to **2.10.0** with a full `CHANGELOG.md` entry.

> **Suggested merge:** squash. The history includes a commit that adds a path-based secret downgrade and a later one that removes it (the design was reconsidered mid-branch — see "Scoring honesty" below), so a squash gives the cleanest `main` history. Rebase also works if per-commit granularity is preferred.

### Scoring honesty

A Security score could move on an **unchanged commit** — after an upgrade enabled more scanners, or because a repo's own reviewed-and-accepted findings kept holding it at a cap. The measurement was getting more honest; the output didn't explain it, and a properly-triaged repo couldn't recover its score.

- **Symmetric unavailable-scanner caps** — a missing secret or code-pattern scan now caps the Security score at the uncertainty tier, the same as a missing dep-audit already did. No scanner silently reads as a confident "0 findings."
- **The score respects the allowlist** — findings reviewed-and-accepted as `false-positive` / `test-fixture` are lifted from the Security penalties and caps (not just the guardrail); `accepted-risk` / `deferred` / `mitigated-externally` still count. The vuln report + dashboard also annotate allowlisted findings (`Subtotal N (M allowlisted)`).
- **Scanner-coverage drift is disclosed** — when the active scanner set grows since the last run, the report leads with a note: those findings are newly *visible*, not newly *introduced*.
- **Secret severity is never lowered by file path** — a hardcoded credential keeps full severity in a test file (the matcher can't tell a fixture from a real leak). Test-file noise is managed by the allowlist score-lift + a report triage note + a `dxkit-action` / `dxkit-allowlist` skill triage step (confirm fixture vs. real; allowlist fakes, rotate reals), never by hiding.
- **Systematic test-file detection** — tests under `__tests__/` or named `.unit.` / `.e2e.` / `.cy.` were classified as source, corrupting the test ratio, coverage, and test-gap analysis. The cross-ecosystem test directories are now recognized in any language; the TS pack gains the co-located suffix conventions.
- **Windows dep-audit EPERM** — the osv-scanner-fix temp-dir cleanup retries with backoff and never throws out of its `finally`, so a handle race can no longer discard already-parsed fix plans.

### Passive graph delivery

- **The context-hook fires on the tools agents actually use** — Read/Edit (keyed on the file touched → that file's structural summary), Bash (parses grep/rg commands), and the original Grep/Glob. Previously it fired only on native Grep/Glob with a symbol-name match and almost never engaged in a real fix workflow. Per-session, per-file dedup; FAIL-OPEN + ADDITIVE preserved. **Existing repos must re-run `vyuh-dxkit init`** (or update `.claude/settings.json`) for the broadened matcher.

### Tool robustness + version pins

- graphify survives Python 3.14 multiprocessing and redirects its cache via graphify's public API; `graphifyy` pinned to `0.8.36`, `jscpd` to `4.2.5`.
- Guardrail matcher relocates whole-file findings across renames instead of reporting remove + add.
- Defensive pin sweep across nine more dxkit-owned scanners; five tools stay unpinned by design (documented).

### Snyk sync

- `allowlist export --snyk` also emits `.dxkit-ignore` path exclusions into the `.snyk` `exclude.global` block, so Snyk and dxkit agree on what's out of scope.

---

### Validation

- Full local gate green: typecheck (src + test trees), `vitest --coverage` (64.25%, over threshold), lint, format, slop, architecture rules.
- Exercised end-to-end against a real large repo on Python 3.14: graphify builds the graph cleanly, all scanners run, and the scoring/annotation behaviors above were confirmed on real reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
