### PR TITLE
2.11.1 — line-aware passive context hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.1] - 2026-06-17
+
+### Line-aware passive context hook
+
+- **The PreToolUse context hook now uses the line the agent is reading.** When a
+  `Read` carries an `offset`, the hook injects the *location's* structural
+  neighborhood — the enclosing symbol plus its direct callers/callees, and the
+  file's cross-file role — instead of only a flat file-level symbol map. Reading
+  the body of a function now yields "you're inside `addUser`; it calls
+  `getNextSequence`, `getRandomFutureDate`" rather than a list of every symbol in
+  the file. No source text is injected (the `Read` already returns the lines); the
+  hook adds only the structure the read doesn't show.
+- **The hook also fires for symbol-less but connected files.** The old gate
+  skipped any file with zero named symbols, which silently blanked out top-level
+  config / entrypoint modules even when other files import them. The gate is now
+  "fire iff there's useful structure" (named symbols *or* cross-file edges),
+  applied uniformly to the file-level and line-level paths.
+- The fail-open/additive contract is unchanged: when the graph has no structure
+  for a location, the hook stays a silent no-op and the agent proceeds exactly as
+  without dxkit.
+
+No identity-scheme change; no migration. `vyuh-dxkit update` (or `npm i -D
+@vyuhlabs/dxkit@latest`) picks up the refreshed hook scaffolding.
+
 ## [2.11.0] - 2026-06-16
 
 ### Code-graph quality, guardrail reliability on JS/TS, and a dogfooding pass

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "AI-native developer experience toolkit for any codebase",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/explore/context-hook-format.ts
+++ b/src/explore/context-hook-format.ts
@@ -1,0 +1,197 @@
+/**
+ * Presentation layer for `vyuh-dxkit context-hook` — the compact
+ * `additionalContext` bodies the hook injects. Split out of
+ * `context-hook.ts` (which owns the stdin/route/dedup orchestration) so
+ * each file stays a cohesive unit under the large-file bar: this module is
+ * pure string-building over already-queried graph data, trivially unit-
+ * testable without touching stdin or the filesystem.
+ *
+ * Three shapes, one per hook target:
+ *   - `formatFileContext` — a FILE the agent opened (whole-file read): its
+ *     symbols + who depends on it + what it calls into.
+ *   - `formatFileLineContext` — a FILE at a LINE (Read's `offset`): the
+ *     location's enclosing symbol + its direct callers/callees, plus the
+ *     file's cross-file role. Useful even for symbol-less regions.
+ *   - `formatHookContext` — a search PATTERN (Bash/Grep/Glob): the anchor
+ *     symbol, blast radius, and the top neighborhood symbols.
+ *
+ * Each returns '' when there's nothing worth the token cost, which the
+ * hook treats as "don't fire" (the additive/fail-open contract).
+ */
+import type { ContextResult, FileLineContext, FileSummary } from './queries';
+import type { Graph } from './types';
+
+/**
+ * Compact `additionalContext` body for a FILE target: the file's
+ * symbols, who depends on it (caller files), and what it reaches into
+ * (callee files). Terser than the CLI's markdown — the hook pays this on
+ * every read. Leads with provenance + a best-effort caveat so the agent
+ * calibrates trust.
+ */
+export function formatFileContext(summary: FileSummary, graph: Graph): string {
+  // Fire only when there's structure worth the tokens: named symbols, or the
+  // file's cross-file role (who imports it / what it reaches into). A file
+  // with none of those (and no line to localize) has nothing useful to add —
+  // return '' so the hook stays a silent no-op (additive contract).
+  if (
+    summary.symbols.length === 0 &&
+    summary.callerFiles.length === 0 &&
+    summary.calleeFiles.length === 0
+  ) {
+    return '';
+  }
+  const lines: string[] = [];
+  lines.push(
+    `dxkit graph context for \`${summary.sourceFile}\` (from .dxkit/reports/graph.json, generated ${graph.meta.generatedAt.slice(0, 10)} — structural map, the file's actual contents remain authoritative):`,
+  );
+
+  const topSymbols = summary.symbols.slice(0, 12);
+  if (topSymbols.length > 0) {
+    lines.push(`- Symbols (${summary.symbols.length}):`);
+    for (const s of topSymbols) {
+      const where = s.line ? `:${s.line}` : '';
+      const flags = [s.exported ? 'exported' : '', s.callsIn > 0 ? `${s.callsIn} caller(s)` : '']
+        .filter(Boolean)
+        .join(', ');
+      lines.push(`    ${s.label} (${s.kind}${where})${flags ? ` — ${flags}` : ''}`);
+    }
+    if (summary.symbols.length > topSymbols.length) {
+      lines.push(`    (+${summary.symbols.length - topSymbols.length} more)`);
+    }
+  }
+
+  if (summary.callerFiles.length > 0) {
+    const top = summary.callerFiles.slice(0, 6);
+    lines.push(`- Depended on by ${summary.callerFiles.length} file(s):`);
+    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
+    if (summary.callerFiles.length > top.length) {
+      lines.push(`    (+${summary.callerFiles.length - top.length} more)`);
+    }
+  }
+
+  if (summary.calleeFiles.length > 0) {
+    const top = summary.calleeFiles.slice(0, 6);
+    lines.push(`- Calls into ${summary.calleeFiles.length} file(s):`);
+    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
+    if (summary.calleeFiles.length > top.length) {
+      lines.push(`    (+${summary.calleeFiles.length - top.length} more)`);
+    }
+  }
+
+  if (summary.communityLabel) {
+    lines.push(`- Module group: ${summary.communityLabel}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Compact `additionalContext` for a FILE target with a LINE (Read's
+ * `offset`). Frames the location's structural neighborhood: the enclosing
+ * symbol + its direct callers/callees, plus the file's cross-file role
+ * (who imports it, what it reaches into) and module group.
+ *
+ * It deliberately injects NO source text — the Read the agent just issued
+ * already returns the lines; the hook's value is the structure the Read
+ * does NOT show (who reaches this symbol, blast radius, what it calls).
+ * That's also why this works for symbol-less regions (top-level config,
+ * an entrypoint's middleware block): even with no enclosing symbol, the
+ * file's role orients the agent — exactly the case a file-level symbol map
+ * left empty. Returns '' (→ silent no-op) when there's no enclosing symbol
+ * AND no cross-file edges to report.
+ */
+export function formatFileLineContext(
+  ctx: FileLineContext,
+  summary: FileSummary,
+  graph: Graph,
+  file: string,
+  line: number,
+): string {
+  const enc = ctx.enclosingSymbol;
+  const hasFileEdges = summary.callerFiles.length > 0 || summary.calleeFiles.length > 0;
+  if (!enc && !hasFileEdges) return '';
+
+  const lines: string[] = [];
+  lines.push(
+    `dxkit graph context for \`${file}:${line}\` (from .dxkit/reports/graph.json, generated ${graph.meta.generatedAt.slice(0, 10)} — structural map, the file's actual contents remain authoritative):`,
+  );
+
+  if (enc) {
+    const where = enc.line ? `${enc.kind}, declared :${enc.line}` : enc.kind;
+    lines.push(
+      `- Inside \`${enc.symbol}\` (${where}) — ${enc.callsIn} caller(s), ${enc.callsOut} callee(s).`,
+    );
+    if (ctx.callers.length > 0) {
+      const top = ctx.callers.slice(0, 6);
+      lines.push(`- Callers of \`${enc.symbol}\`:`);
+      for (const c of top)
+        lines.push(`    ${c.symbol} — ${c.line ? `${c.sourceFile}:${c.line}` : c.sourceFile}`);
+    }
+    if (ctx.callees.length > 0) {
+      const top = ctx.callees.slice(0, 6);
+      lines.push(`- \`${enc.symbol}\` calls:`);
+      for (const c of top)
+        lines.push(`    ${c.symbol} — ${c.line ? `${c.sourceFile}:${c.line}` : c.sourceFile}`);
+    }
+  } else {
+    lines.push(
+      `- Line ${line} is module-level (top of file / config) — not inside a tracked symbol.`,
+    );
+  }
+
+  if (summary.callerFiles.length > 0) {
+    const top = summary.callerFiles.slice(0, 6);
+    lines.push(`- File depended on by ${summary.callerFiles.length} file(s):`);
+    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
+  }
+  if (summary.calleeFiles.length > 0) {
+    const top = summary.calleeFiles.slice(0, 6);
+    lines.push(`- File calls into ${summary.calleeFiles.length} file(s):`);
+    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
+  }
+  if (summary.communityLabel) lines.push(`- Module group: ${summary.communityLabel}`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Compact `additionalContext` body for a PATTERN target. Terser than the
+ * CLI's markdown (the hook pays this cost on every grep): an anchor line,
+ * blast radius, and the top symbols grouped by their leading community.
+ * Leads with a one-line provenance + best-effort caveat so the agent
+ * calibrates trust.
+ */
+export function formatHookContext(result: ContextResult, graph: Graph): string {
+  const lines: string[] = [];
+  lines.push(
+    `dxkit graph context for \`${result.query}\` (from .dxkit/reports/graph.json, generated ${graph.meta.generatedAt.slice(0, 10)} — structural hint, grep results remain authoritative):`,
+  );
+
+  if (result.anchor) {
+    const a = result.anchor;
+    const where = a.line ? `${a.sourceFile}:${a.line}` : a.sourceFile;
+    lines.push(`- Start here: \`${a.symbol}\` (${where}), called from ${a.calledFrom} place(s).`);
+  }
+  if (result.blastRadius.callers > 0) {
+    lines.push(
+      `- Blast radius: ${result.blastRadius.callers} caller(s) across ${result.blastRadius.callerFiles} file(s).`,
+    );
+  }
+
+  // Top symbols overall (seeds first, then by in-degree), capped tight.
+  const top = [...result.selection]
+    .sort((a, b) => a.hop - b.hop || b.callsIn - a.callsIn)
+    .slice(0, 10);
+  if (top.length > 0) {
+    lines.push('- Relevant symbols:');
+    for (const s of top) {
+      const where = s.line ? `${s.sourceFile}:${s.line}` : s.sourceFile;
+      lines.push(`    ${s.symbol} (${where})`);
+    }
+  }
+  if (result.truncated) {
+    lines.push(`- (+${result.omittedCount} more symbols in the wider neighborhood)`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/explore/context-hook.ts
+++ b/src/explore/context-hook.ts
@@ -41,15 +41,30 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { contextQuery, fileSummaryQuery, type ContextResult, type FileSummary } from './queries';
+import {
+  contextQuery,
+  fileLineContextQuery,
+  fileSummaryQuery,
+  type ContextResult,
+  type FileLineContext,
+  type FileSummary,
+} from './queries';
 import { tryLoadGraph } from './load';
 import type { Graph } from './types';
 
 /** Stingier than the manual CLI's 2000 — the hook fires on every search/read. */
 const HOOK_BUDGET = 1500;
 
-/** What the agent's tool call resolved to: a specific file, or a search term. */
-type HookTarget = { kind: 'file'; file: string } | { kind: 'pattern'; pattern: string };
+/**
+ * What the agent's tool call resolved to. A file target may carry the
+ * `line` the agent is reading (Read's `offset`): with a line we inject the
+ * location's structural neighborhood (enclosing symbol + its edges + the
+ * file's role) — useful even for files with no named symbols, like
+ * top-level config; without one we inject the file's symbol map.
+ */
+type HookTarget =
+  | { kind: 'file'; file: string; line?: number }
+  | { kind: 'pattern'; pattern: string };
 
 /**
  * Entry point for `case 'context-hook'`. Reads stdin, resolves the
@@ -83,8 +98,23 @@ export async function runContextHook(cwd: string): Promise<void> {
     let additionalContext: string | undefined;
     if (target.kind === 'file') {
       const summary = fileSummaryQuery(graph, target.file);
-      if (!summary.found || summary.symbols.length === 0) return;
-      additionalContext = formatFileContext(summary, graph);
+      if (!summary.found) return;
+      // With a line, frame the location's structural neighborhood (enclosing
+      // symbol + its edges + the file's role); without one, the file's symbol
+      // map. Either formatter returns '' when there's genuinely nothing useful
+      // to add — that empty string is the single "don't fire" gate (replacing
+      // the old `symbols.length === 0` check, which blanked out symbol-less but
+      // well-connected files like top-level config).
+      additionalContext =
+        target.line !== undefined
+          ? formatFileLineContext(
+              fileLineContextQuery(graph, target.file, target.line),
+              summary,
+              graph,
+              target.file,
+              target.line,
+            )
+          : formatFileContext(summary, graph);
     } else {
       const result = contextQuery(graph, target.pattern, { budget: HOOK_BUDGET, substring: true });
       if (!result.matched || result.selection.length === 0) return;
@@ -154,7 +184,17 @@ export function resolveHookTarget(
     const fp = payload.toolInput.file_path ?? payload.toolInput.notebook_path;
     if (typeof fp !== 'string' || !fp.trim()) return undefined;
     const rel = toRepoRelative(fp.trim(), cwd);
-    return graph.nodesByFile.has(rel) ? { kind: 'file', file: rel } : undefined;
+    if (!graph.nodesByFile.has(rel)) return undefined;
+    // Read carries `offset` = the 1-based line the agent starts reading at.
+    // Use it to deliver location-local structure (the enclosing symbol's
+    // neighborhood) rather than only a file-level symbol map — which is
+    // what lets the hook help on findings inside symbol-less regions
+    // (top-level config, an entrypoint's middleware setup). Edit/Write
+    // carry no line, so they fall back to the file map.
+    const off = payload.toolInput.offset;
+    const line =
+      tool === 'Read' && typeof off === 'number' && off > 0 ? Math.floor(off) : undefined;
+    return line !== undefined ? { kind: 'file', file: rel, line } : { kind: 'file', file: rel };
   }
 
   // Bash — parse a grep/rg-style search command.
@@ -232,6 +272,17 @@ function toRepoRelative(p: string, cwd: string): string {
  * calibrates trust.
  */
 export function formatFileContext(summary: FileSummary, graph: Graph): string {
+  // Fire only when there's structure worth the tokens: named symbols, or the
+  // file's cross-file role (who imports it / what it reaches into). A file
+  // with none of those (and no line to localize) has nothing useful to add —
+  // return '' so the hook stays a silent no-op (additive contract).
+  if (
+    summary.symbols.length === 0 &&
+    summary.callerFiles.length === 0 &&
+    summary.calleeFiles.length === 0
+  ) {
+    return '';
+  }
   const lines: string[] = [];
   lines.push(
     `dxkit graph context for \`${summary.sourceFile}\` (from .dxkit/reports/graph.json, generated ${graph.meta.generatedAt.slice(0, 10)} — structural map, the file's actual contents remain authoritative):`,
@@ -273,6 +324,75 @@ export function formatFileContext(summary: FileSummary, graph: Graph): string {
   if (summary.communityLabel) {
     lines.push(`- Module group: ${summary.communityLabel}`);
   }
+
+  return lines.join('\n');
+}
+
+/**
+ * Compact `additionalContext` for a FILE target with a LINE (Read's
+ * `offset`). Frames the location's structural neighborhood: the enclosing
+ * symbol + its direct callers/callees, plus the file's cross-file role
+ * (who imports it, what it reaches into) and module group.
+ *
+ * It deliberately injects NO source text — the Read the agent just issued
+ * already returns the lines; the hook's value is the structure the Read
+ * does NOT show (who reaches this symbol, blast radius, what it calls).
+ * That's also why this works for symbol-less regions (top-level config,
+ * an entrypoint's middleware block): even with no enclosing symbol, the
+ * file's role orients the agent — exactly the case a file-level symbol map
+ * left empty. Returns '' (→ silent no-op) when there's no enclosing symbol
+ * AND no cross-file edges to report.
+ */
+export function formatFileLineContext(
+  ctx: FileLineContext,
+  summary: FileSummary,
+  graph: Graph,
+  file: string,
+  line: number,
+): string {
+  const enc = ctx.enclosingSymbol;
+  const hasFileEdges = summary.callerFiles.length > 0 || summary.calleeFiles.length > 0;
+  if (!enc && !hasFileEdges) return '';
+
+  const lines: string[] = [];
+  lines.push(
+    `dxkit graph context for \`${file}:${line}\` (from .dxkit/reports/graph.json, generated ${graph.meta.generatedAt.slice(0, 10)} — structural map, the file's actual contents remain authoritative):`,
+  );
+
+  if (enc) {
+    const where = enc.line ? `${enc.kind}, declared :${enc.line}` : enc.kind;
+    lines.push(
+      `- Inside \`${enc.symbol}\` (${where}) — ${enc.callsIn} caller(s), ${enc.callsOut} callee(s).`,
+    );
+    if (ctx.callers.length > 0) {
+      const top = ctx.callers.slice(0, 6);
+      lines.push(`- Callers of \`${enc.symbol}\`:`);
+      for (const c of top)
+        lines.push(`    ${c.symbol} — ${c.line ? `${c.sourceFile}:${c.line}` : c.sourceFile}`);
+    }
+    if (ctx.callees.length > 0) {
+      const top = ctx.callees.slice(0, 6);
+      lines.push(`- \`${enc.symbol}\` calls:`);
+      for (const c of top)
+        lines.push(`    ${c.symbol} — ${c.line ? `${c.sourceFile}:${c.line}` : c.sourceFile}`);
+    }
+  } else {
+    lines.push(
+      `- Line ${line} is module-level (top of file / config) — not inside a tracked symbol.`,
+    );
+  }
+
+  if (summary.callerFiles.length > 0) {
+    const top = summary.callerFiles.slice(0, 6);
+    lines.push(`- File depended on by ${summary.callerFiles.length} file(s):`);
+    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
+  }
+  if (summary.calleeFiles.length > 0) {
+    const top = summary.calleeFiles.slice(0, 6);
+    lines.push(`- File calls into ${summary.calleeFiles.length} file(s):`);
+    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
+  }
+  if (summary.communityLabel) lines.push(`- Module group: ${summary.communityLabel}`);
 
   return lines.join('\n');
 }

--- a/src/explore/context-hook.ts
+++ b/src/explore/context-hook.ts
@@ -41,14 +41,8 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import {
-  contextQuery,
-  fileLineContextQuery,
-  fileSummaryQuery,
-  type ContextResult,
-  type FileLineContext,
-  type FileSummary,
-} from './queries';
+import { contextQuery, fileLineContextQuery, fileSummaryQuery } from './queries';
+import { formatFileContext, formatFileLineContext, formatHookContext } from './context-hook-format';
 import { tryLoadGraph } from './load';
 import type { Graph } from './types';
 
@@ -264,139 +258,6 @@ function toRepoRelative(p: string, cwd: string): string {
   return rel.replace(/\\/g, '/');
 }
 
-/**
- * Compact `additionalContext` body for a FILE target: the file's
- * symbols, who depends on it (caller files), and what it reaches into
- * (callee files). Terser than the CLI's markdown — the hook pays this on
- * every read. Leads with provenance + a best-effort caveat so the agent
- * calibrates trust.
- */
-export function formatFileContext(summary: FileSummary, graph: Graph): string {
-  // Fire only when there's structure worth the tokens: named symbols, or the
-  // file's cross-file role (who imports it / what it reaches into). A file
-  // with none of those (and no line to localize) has nothing useful to add —
-  // return '' so the hook stays a silent no-op (additive contract).
-  if (
-    summary.symbols.length === 0 &&
-    summary.callerFiles.length === 0 &&
-    summary.calleeFiles.length === 0
-  ) {
-    return '';
-  }
-  const lines: string[] = [];
-  lines.push(
-    `dxkit graph context for \`${summary.sourceFile}\` (from .dxkit/reports/graph.json, generated ${graph.meta.generatedAt.slice(0, 10)} — structural map, the file's actual contents remain authoritative):`,
-  );
-
-  const topSymbols = summary.symbols.slice(0, 12);
-  if (topSymbols.length > 0) {
-    lines.push(`- Symbols (${summary.symbols.length}):`);
-    for (const s of topSymbols) {
-      const where = s.line ? `:${s.line}` : '';
-      const flags = [s.exported ? 'exported' : '', s.callsIn > 0 ? `${s.callsIn} caller(s)` : '']
-        .filter(Boolean)
-        .join(', ');
-      lines.push(`    ${s.label} (${s.kind}${where})${flags ? ` — ${flags}` : ''}`);
-    }
-    if (summary.symbols.length > topSymbols.length) {
-      lines.push(`    (+${summary.symbols.length - topSymbols.length} more)`);
-    }
-  }
-
-  if (summary.callerFiles.length > 0) {
-    const top = summary.callerFiles.slice(0, 6);
-    lines.push(`- Depended on by ${summary.callerFiles.length} file(s):`);
-    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
-    if (summary.callerFiles.length > top.length) {
-      lines.push(`    (+${summary.callerFiles.length - top.length} more)`);
-    }
-  }
-
-  if (summary.calleeFiles.length > 0) {
-    const top = summary.calleeFiles.slice(0, 6);
-    lines.push(`- Calls into ${summary.calleeFiles.length} file(s):`);
-    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
-    if (summary.calleeFiles.length > top.length) {
-      lines.push(`    (+${summary.calleeFiles.length - top.length} more)`);
-    }
-  }
-
-  if (summary.communityLabel) {
-    lines.push(`- Module group: ${summary.communityLabel}`);
-  }
-
-  return lines.join('\n');
-}
-
-/**
- * Compact `additionalContext` for a FILE target with a LINE (Read's
- * `offset`). Frames the location's structural neighborhood: the enclosing
- * symbol + its direct callers/callees, plus the file's cross-file role
- * (who imports it, what it reaches into) and module group.
- *
- * It deliberately injects NO source text — the Read the agent just issued
- * already returns the lines; the hook's value is the structure the Read
- * does NOT show (who reaches this symbol, blast radius, what it calls).
- * That's also why this works for symbol-less regions (top-level config,
- * an entrypoint's middleware block): even with no enclosing symbol, the
- * file's role orients the agent — exactly the case a file-level symbol map
- * left empty. Returns '' (→ silent no-op) when there's no enclosing symbol
- * AND no cross-file edges to report.
- */
-export function formatFileLineContext(
-  ctx: FileLineContext,
-  summary: FileSummary,
-  graph: Graph,
-  file: string,
-  line: number,
-): string {
-  const enc = ctx.enclosingSymbol;
-  const hasFileEdges = summary.callerFiles.length > 0 || summary.calleeFiles.length > 0;
-  if (!enc && !hasFileEdges) return '';
-
-  const lines: string[] = [];
-  lines.push(
-    `dxkit graph context for \`${file}:${line}\` (from .dxkit/reports/graph.json, generated ${graph.meta.generatedAt.slice(0, 10)} — structural map, the file's actual contents remain authoritative):`,
-  );
-
-  if (enc) {
-    const where = enc.line ? `${enc.kind}, declared :${enc.line}` : enc.kind;
-    lines.push(
-      `- Inside \`${enc.symbol}\` (${where}) — ${enc.callsIn} caller(s), ${enc.callsOut} callee(s).`,
-    );
-    if (ctx.callers.length > 0) {
-      const top = ctx.callers.slice(0, 6);
-      lines.push(`- Callers of \`${enc.symbol}\`:`);
-      for (const c of top)
-        lines.push(`    ${c.symbol} — ${c.line ? `${c.sourceFile}:${c.line}` : c.sourceFile}`);
-    }
-    if (ctx.callees.length > 0) {
-      const top = ctx.callees.slice(0, 6);
-      lines.push(`- \`${enc.symbol}\` calls:`);
-      for (const c of top)
-        lines.push(`    ${c.symbol} — ${c.line ? `${c.sourceFile}:${c.line}` : c.sourceFile}`);
-    }
-  } else {
-    lines.push(
-      `- Line ${line} is module-level (top of file / config) — not inside a tracked symbol.`,
-    );
-  }
-
-  if (summary.callerFiles.length > 0) {
-    const top = summary.callerFiles.slice(0, 6);
-    lines.push(`- File depended on by ${summary.callerFiles.length} file(s):`);
-    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
-  }
-  if (summary.calleeFiles.length > 0) {
-    const top = summary.calleeFiles.slice(0, 6);
-    lines.push(`- File calls into ${summary.calleeFiles.length} file(s):`);
-    for (const c of top) lines.push(`    ${c.sourceFile} (${c.count} call(s))`);
-  }
-  if (summary.communityLabel) lines.push(`- Module group: ${summary.communityLabel}`);
-
-  return lines.join('\n');
-}
-
 // ─── Per-session, per-file dedup state ───────────────────────────────────────
 
 /** Where the per-session injected-file ledger lives. One file per
@@ -460,48 +321,6 @@ export function extractPattern(rawStdin: string): string | undefined {
   if (typeof pattern !== 'string') return undefined;
   const trimmed = pattern.trim();
   return trimmed.length > 0 ? trimmed : undefined;
-}
-
-/**
- * Compact `additionalContext` body for a PATTERN target. Terser than the
- * CLI's markdown (the hook pays this cost on every grep): an anchor line,
- * blast radius, and the top symbols grouped by their leading community.
- * Leads with a one-line provenance + best-effort caveat so the agent
- * calibrates trust.
- */
-export function formatHookContext(result: ContextResult, graph: Graph): string {
-  const lines: string[] = [];
-  lines.push(
-    `dxkit graph context for \`${result.query}\` (from .dxkit/reports/graph.json, generated ${graph.meta.generatedAt.slice(0, 10)} — structural hint, grep results remain authoritative):`,
-  );
-
-  if (result.anchor) {
-    const a = result.anchor;
-    const where = a.line ? `${a.sourceFile}:${a.line}` : a.sourceFile;
-    lines.push(`- Start here: \`${a.symbol}\` (${where}), called from ${a.calledFrom} place(s).`);
-  }
-  if (result.blastRadius.callers > 0) {
-    lines.push(
-      `- Blast radius: ${result.blastRadius.callers} caller(s) across ${result.blastRadius.callerFiles} file(s).`,
-    );
-  }
-
-  // Top symbols overall (seeds first, then by in-degree), capped tight.
-  const top = [...result.selection]
-    .sort((a, b) => a.hop - b.hop || b.callsIn - a.callsIn)
-    .slice(0, 10);
-  if (top.length > 0) {
-    lines.push('- Relevant symbols:');
-    for (const s of top) {
-      const where = s.line ? `${s.sourceFile}:${s.line}` : s.sourceFile;
-      lines.push(`    ${s.symbol} (${where})`);
-    }
-  }
-  if (result.truncated) {
-    lines.push(`- (+${result.omittedCount} more symbols in the wider neighborhood)`);
-  }
-
-  return lines.join('\n');
 }
 
 /** Read all of stdin as a string. Resolves '' if stdin is a TTY/empty. */

--- a/test/explore/context-hook.test.ts
+++ b/test/explore/context-hook.test.ts
@@ -9,12 +9,14 @@
 import { describe, expect, it } from 'vitest';
 import {
   extractPattern,
-  formatFileContext,
-  formatFileLineContext,
-  formatHookContext,
   parseBashForTarget,
   resolveHookTarget,
 } from '../../src/explore/context-hook';
+import {
+  formatFileContext,
+  formatFileLineContext,
+  formatHookContext,
+} from '../../src/explore/context-hook-format';
 import type { ContextResult, FileLineContext, FileSummary } from '../../src/explore/queries';
 import type { Graph, GraphJson } from '../../src/explore/types';
 

--- a/test/explore/context-hook.test.ts
+++ b/test/explore/context-hook.test.ts
@@ -10,11 +10,12 @@ import { describe, expect, it } from 'vitest';
 import {
   extractPattern,
   formatFileContext,
+  formatFileLineContext,
   formatHookContext,
   parseBashForTarget,
   resolveHookTarget,
 } from '../../src/explore/context-hook';
-import type { ContextResult, FileSummary } from '../../src/explore/queries';
+import type { ContextResult, FileLineContext, FileSummary } from '../../src/explore/queries';
 import type { Graph, GraphJson } from '../../src/explore/types';
 
 /**
@@ -172,6 +173,33 @@ describe('resolveHookTarget (2.10 routing)', () => {
     expect(t).toEqual({ kind: 'pattern', pattern: 'configureApp' });
   });
 
+  it("carries Read's offset as the line, so the hook can localize context", () => {
+    const t = resolveHookTarget(
+      { toolName: 'Read', toolInput: { file_path: 'src/server.ts', offset: 78 } },
+      graph,
+      cwd,
+    );
+    expect(t).toEqual({ kind: 'file', file: 'src/server.ts', line: 78 });
+  });
+
+  it('omits the line for a whole-file Read (no offset) → file-level map', () => {
+    const t = resolveHookTarget(
+      { toolName: 'Read', toolInput: { file_path: 'src/server.ts' } },
+      graph,
+      cwd,
+    );
+    expect(t).toEqual({ kind: 'file', file: 'src/server.ts' });
+  });
+
+  it('ignores offset on Edit (only Read paginates by line)', () => {
+    const t = resolveHookTarget(
+      { toolName: 'Edit', toolInput: { file_path: 'src/server.ts', offset: 50 } },
+      graph,
+      cwd,
+    );
+    expect(t).toEqual({ kind: 'file', file: 'src/server.ts' });
+  });
+
   it('routes a Bash grep on a graph file to that file', () => {
     const t = resolveHookTarget(
       { toolName: 'Bash', toolInput: { command: 'grep -n "sendFile" src/server.ts' } },
@@ -271,5 +299,106 @@ describe('formatFileContext', () => {
 
   it('includes the module group when present', () => {
     expect(formatFileContext(summary, graph)).toContain('Module group: http-layer');
+  });
+});
+
+describe('formatFileContext — fire gate', () => {
+  const graph = { meta: { generatedAt: '2026-06-12T10:00:00Z' } as GraphJson['meta'] } as Graph;
+
+  it("returns '' (silent no-op) when a file has no symbols and no cross-file edges", () => {
+    // A symbol-less, unconnected file (e.g. top-level config) has nothing
+    // structural worth the token cost — the hook must stay silent.
+    const empty: FileSummary = {
+      found: true,
+      sourceFile: 'server.js',
+      symbols: [],
+      callerFiles: [],
+      calleeFiles: [],
+    } as unknown as FileSummary;
+    expect(formatFileContext(empty, graph)).toBe('');
+  });
+
+  it('fires for a symbol-less file that is still connected (imported by others)', () => {
+    const connected: FileSummary = {
+      found: true,
+      sourceFile: 'config/index.js',
+      symbols: [],
+      callerFiles: [{ sourceFile: 'src/app.js', count: 4 }],
+      calleeFiles: [],
+    } as unknown as FileSummary;
+    expect(formatFileContext(connected, graph)).toContain('Depended on by 1 file(s):');
+  });
+});
+
+describe('formatFileLineContext (line-aware delivery)', () => {
+  const graph = { meta: { generatedAt: '2026-06-17T10:00:00Z' } as GraphJson['meta'] } as Graph;
+  const summaryNoEdges: FileSummary = {
+    found: true,
+    sourceFile: 'app/data/user-dao.js',
+    symbols: [],
+    callerFiles: [],
+    calleeFiles: [],
+  } as unknown as FileSummary;
+
+  it('frames the enclosing symbol + its direct callees (the precise neighborhood)', () => {
+    const ctx: FileLineContext = {
+      found: true,
+      sourceFile: 'app/data/user-dao.js',
+      enclosingSymbol: {
+        id: 'n',
+        symbol: 'addUser',
+        line: 17,
+        kind: 'method',
+        callsIn: 0,
+        callsOut: 2,
+      },
+      callers: [],
+      callees: [
+        { symbol: 'getNextSequence', sourceFile: 'app/data/user-dao.js', line: 109 },
+        { symbol: 'getRandomFutureDate', sourceFile: 'app/data/user-dao.js', line: 49 },
+      ],
+      blastRadius: { callerFiles: 0, callers: 0 },
+    };
+    const out = formatFileLineContext(ctx, summaryNoEdges, graph, 'app/data/user-dao.js', 30);
+    expect(out).toContain('app/data/user-dao.js:30');
+    expect(out).toContain('Inside `addUser` (method, declared :17) — 0 caller(s), 2 callee(s).');
+    expect(out).toContain('getNextSequence');
+    // No source text is injected — the Read already returns the lines.
+    expect(out).not.toContain('```');
+  });
+
+  it('still helps a module-level line (no enclosing symbol) via the file role', () => {
+    const ctx: FileLineContext = {
+      found: true,
+      sourceFile: 'config/index.js',
+      enclosingSymbol: undefined,
+      callers: [],
+      callees: [],
+      blastRadius: { callerFiles: 1, callers: 4 },
+    };
+    const summary: FileSummary = {
+      found: true,
+      sourceFile: 'config/index.js',
+      symbols: [],
+      callerFiles: [{ sourceFile: 'src/app.js', count: 4 }],
+      calleeFiles: [],
+    } as unknown as FileSummary;
+    const out = formatFileLineContext(ctx, summary, graph, 'config/index.js', 12);
+    expect(out).toContain('module-level');
+    expect(out).toContain('File depended on by 1 file(s):');
+  });
+
+  it("returns '' when there is neither an enclosing symbol nor any cross-file edge", () => {
+    // The true server.js case: zero graph structure → nothing to inject →
+    // silent no-op → the dxkit arm behaves exactly like vanilla here.
+    const ctx: FileLineContext = {
+      found: true,
+      sourceFile: 'server.js',
+      enclosingSymbol: undefined,
+      callers: [],
+      callees: [],
+      blastRadius: { callerFiles: 0, callers: 0 },
+    };
+    expect(formatFileLineContext(ctx, summaryNoEdges, graph, 'server.js', 78)).toBe('');
   });
 });


### PR DESCRIPTION
## What

Makes the PreToolUse context hook **line-aware**: a `Read`'s `offset` is used to deliver the *location's* structural neighborhood (enclosing symbol + its callers/callees + the file's cross-file role) instead of only a flat file-level symbol map. Replaces the `symbols.length === 0` fire gate with a uniform "fire iff there's useful structure" rule, so symbol-less-but-connected files (top-level config / entrypoints imported by others) also get context.

No source text is injected (the Read already returns the lines) — the hook adds only the structure the read doesn't show. Fail-open/additive contract unchanged.

## Why

A dogfooding benchmark surfaced two gaps: reading deep inside a large file got the whole symbol list rather than the relevant neighborhood, and findings in symbol-less files got nothing. This is the hook-layer fix.

(Files that produce *no* graph structure at all — only top-level statements + anonymous callbacks — remain a graph-extraction gap, tracked separately.)

## Verification

- Full suite **2411 passing**; lint / format / arch / slop clean.
- Deterministic check: `Read user-dao.js:30` → "Inside `addUser` — calls getNextSequence, getRandomFutureDate"; `Read server.js:78` (no graph structure) → silent no-op (fail-open preserved).
- New unit tests: offset→line routing, line-level formatting (symbol-bearing, module-level-but-connected, no-structure no-op), file-level empty gate.

Patch release: no identity-scheme change, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)