### PR TITLE
fix(baseline): matcher relocates line-anchored findings — benign shifts aren't net-new (2.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-06-17
+
+### Guardrail: benign line shifts no longer read as net-new
+
+- **Fixed a guardrail false-positive where inserting lines above a duplicate
+  block flagged every duplicate as net-new debt.** Duplicate-block findings
+  carry an identity derived from their exact start lines, but the matcher was
+  not relocating them across a change — so a comment added near the top of a
+  file shifted the blocks and the guardrail reported them as new. Duplicate
+  findings (and range-anchored coverage gaps) are now relocated like every
+  other line-anchored finding, so routine churn no longer trips the gate.
+- **Closed the same gap for shallow clones and force-pushed baselines.**
+  Relocation across a change normally uses git history; where that history
+  isn't available, the matcher falls back to a content hash of the finding's
+  surroundings. Duplicate and orphaned-allowlist (`stale-allow`) findings now
+  carry that content hash too, matching the protection secret/code findings
+  already had — so the gate stays correct even on a depth-1 CI checkout.
+- **Hardened the matcher against this whole class of bug.** A finding whose
+  identity moves with line position must be relocatable; new contract tests
+  derive that property automatically for every finding kind and fail if a kind
+  is ever added (or changed) that can drift without a way to relocate it.
+- No baseline re-creation is needed — the finding identity is unchanged, so
+  existing baselines and allowlists keep matching. `vyuh-dxkit update` is a
+  no-op for this release beyond the version bump.
+
 ## [2.11.1] - 2026-06-17
 
 ### Line-aware passive context hook

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.11.1",
+      "version": "2.12.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "description": "AI-native developer experience toolkit for any codebase",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/baseline/entry-to-located.ts
+++ b/src/baseline/entry-to-located.ts
@@ -15,21 +15,41 @@
  * location-pair pass must too. The canonical-rule registry doesn't
  * apply to hygiene markers; the marker IS the canonical name.
  *
- * Whole-file findings (test-gap, coverage-gap, test-file-degradation,
- * god-file, stale-file, large-file) are file-anchored but carry no
- * line. They flow to the matcher's whole-file rename pass with `file`
- * populated and `kind` carried in `rule` — so a pure file rename
- * relocates them (instead of reading as removed+added → false net-new
- * debt), and two different whole-file kinds on the same renamed file
- * never cross-pair. The line-anchored passes skip them (no line); the
- * multiset pass still pairs them by exact identity-hash equality.
+ * Whole-file findings (test-gap, test-file-degradation, god-file,
+ * stale-file, large-file) are file-anchored but carry no line. They flow
+ * to the matcher's whole-file rename pass with `file` populated and `kind`
+ * carried in `rule` — so a pure file rename relocates them (instead of
+ * reading as removed+added → false net-new debt), and two different
+ * whole-file kinds on the same renamed file never cross-pair. The
+ * line-anchored passes skip them (no line); the multiset pass still pairs
+ * them by exact identity-hash equality.
  *
- * Kinds without any file/line locator (dep-vuln, duplication,
- * secret-hmac) fall through to the matcher's multiset pass — paired by
- * exact identity-hash equality, no locator metadata needed.
+ * THE RELOCATION INVARIANT (load-bearing — a regression test enforces it):
+ * if a finding's identity is sensitive to line position — i.e. shifting the
+ * finding down the file (holding its file + content constant) changes its
+ * identity hash — then this converter MUST give it a full `(file, line,
+ * rule)` locator, so the matcher's line-aware pass can relocate it through a
+ * `git diff` and not read benign churn (a comment inserted above it) as a
+ * removed+added pair → false net-new. A kind may be locator-less ONLY when
+ * its identity is line-INDEPENDENT.
+ *
+ * That is why:
+ *   - `duplication` carries a line locator: its identity hashes the block's
+ *     exact start lines, so it moves with the code. The locator uses the
+ *     CANONICAL representative side (`duplicationCanonicalSides`, the same
+ *     ordering the identity hash uses) so prior + current agree on which
+ *     side the matcher maps through the diff.
+ *   - `coverage-gap` is split: a SYMBOL-anchored gap is line-independent
+ *     (identity = `(file, symbol)`, survives vertical drift) → whole-file
+ *     locator; a RANGE-anchored gap (no symbol) is line-dependent → it gets
+ *     a line locator at the range start.
+ *   - `dep-vuln` and `secret-hmac` stay locator-less: their identities are
+ *     genuinely line-independent (advisory id; value HMAC), so the multiset
+ *     pass pairs them by exact identity-hash equality with no locator.
  */
 
 import { canonicalRuleFor } from '../analyzers/tools/fingerprint';
+import { duplicationCanonicalSides } from './finding-identity';
 import type { LocatedIdentity } from './git-aware-match';
 import { isSanitized } from './sanitize';
 import type { BaselineEntry } from './types';
@@ -78,6 +98,14 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
         rule: entry.category,
       };
     case 'coverage-gap':
+      // A symbol-anchored gap has line-independent identity ((file,
+      // symbol)) → whole-file locator (no line). A range-anchored gap (no
+      // symbol) hashes its line range, so it's line-dependent and needs a
+      // line locator at the range start for relocation. (See the
+      // relocation invariant in the module header.)
+      return entry.symbol !== undefined
+        ? { id: entry.id, file: entry.file, rule: entry.kind }
+        : { id: entry.id, file: entry.file, line: entry.lineRange?.[0], rule: entry.kind };
     case 'test-gap':
     case 'test-file-degradation':
     case 'god-file':
@@ -90,9 +118,24 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
       // kinds on the same renamed file from cross-pairing. No line, so
       // the line-anchored passes correctly skip them.
       return { id: entry.id, file: entry.file, rule: entry.kind };
+    case 'duplication': {
+      // Line-dependent identity (hashes the block's exact start lines), so
+      // it MUST be relocatable — give it a line locator on the canonical
+      // representative side (same ordering the identity uses, so prior +
+      // current pick the same side across a shift). `kind` is the rule
+      // discriminator, as for the whole-file kinds above.
+      const [first] = duplicationCanonicalSides(
+        entry.fileA,
+        entry.startLineA,
+        entry.fileB,
+        entry.startLineB,
+      );
+      return { id: entry.id, file: first[0], line: first[1], rule: entry.kind };
+    }
     case 'dep-vuln':
-    case 'duplication':
     case 'secret-hmac':
+      // Line-independent identity (advisory id; value HMAC) → locator-less;
+      // the matcher's multiset pass pairs them by exact identity-hash.
       return { id: entry.id };
   }
 }

--- a/src/baseline/entry-to-located.ts
+++ b/src/baseline/entry-to-located.ts
@@ -29,20 +29,26 @@
  * finding down the file (holding its file + content constant) changes its
  * identity hash — then this converter MUST give it a full `(file, line,
  * rule)` locator, so the matcher's line-aware pass can relocate it through a
- * `git diff` and not read benign churn (a comment inserted above it) as a
- * removed+added pair → false net-new. A kind may be locator-less ONLY when
- * its identity is line-INDEPENDENT.
+ * `git diff`; AND, when the producer can read the file, the entry carries a
+ * `contentHash` that this converter passes through, so the matcher's
+ * git-INDEPENDENT content-hash pass relocates it on a shallow clone /
+ * force-pushed baseline too. Either way, benign churn (a comment inserted
+ * above it) is not read as a removed+added pair → false net-new. A kind may
+ * be locator-less ONLY when its identity is line-INDEPENDENT.
  *
  * That is why:
- *   - `duplication` carries a line locator: its identity hashes the block's
- *     exact start lines, so it moves with the code. The locator uses the
- *     CANONICAL representative side (`duplicationCanonicalSides`, the same
- *     ordering the identity hash uses) so prior + current agree on which
- *     side the matcher maps through the diff.
+ *   - `duplication` carries a line locator AND a contentHash: its identity
+ *     hashes the block's exact start lines, so it moves with the code. The
+ *     locator uses the CANONICAL representative side (`duplicationCanonicalSides`,
+ *     the same ordering the identity hash uses) so prior + current agree on
+ *     which side the matcher maps; the contentHash is taken on that same side.
+ *   - `stale-allow` carries a line locator AND a contentHash: its identity is
+ *     line-window-bucketed, so a shift past the window re-mints it.
  *   - `coverage-gap` is split: a SYMBOL-anchored gap is line-independent
  *     (identity = `(file, symbol)`, survives vertical drift) → whole-file
  *     locator; a RANGE-anchored gap (no symbol) is line-dependent → it gets
- *     a line locator at the range start.
+ *     a line locator at the range start. (Its producer is not wired yet; when
+ *     it lands it should also stamp a contentHash, like the kinds above.)
  *   - `dep-vuln` and `secret-hmac` stay locator-less: their identities are
  *     genuinely line-independent (advisory id; value HMAC), so the multiset
  *     pass pairs them by exact identity-hash equality with no locator.
@@ -90,12 +96,15 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
       // Annotation comments don't have a tool/rule pair — the
       // "rule" is the annotation's category. Reuse the field so
       // the matcher's location-pair pass can treat them like other
-      // source-anchored kinds.
+      // source-anchored kinds. The line-bucketed identity re-mints on a
+      // >window shift, so carry the contentHash for the git-independent
+      // pass too (parity with secret/code/hygiene).
       return {
         id: entry.id,
         file: entry.file,
         line: entry.line,
         rule: entry.category,
+        ...(entry.contentHash !== undefined ? { contentHash: entry.contentHash } : {}),
       };
     case 'coverage-gap':
       // A symbol-anchored gap has line-independent identity ((file,
@@ -130,7 +139,16 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
         entry.fileB,
         entry.startLineB,
       );
-      return { id: entry.id, file: first[0], line: first[1], rule: entry.kind };
+      return {
+        id: entry.id,
+        file: first[0],
+        line: first[1],
+        rule: entry.kind,
+        // Content-hash fallback so the matcher relocates the clone even when
+        // git history is unavailable (shallow clone / force-pushed baseline),
+        // where the git-line pass is skipped.
+        ...(entry.contentHash !== undefined ? { contentHash: entry.contentHash } : {}),
+      };
     }
     case 'dep-vuln':
     case 'secret-hmac':

--- a/src/baseline/finding-identity.ts
+++ b/src/baseline/finding-identity.ts
@@ -151,6 +151,30 @@ export function identityFor(
  * Without this, three intra-file clones in a single file would all
  * collapse to one identity.
  */
+/**
+ * The two `(file, startLine)` sides of a duplicate pair, sorted into a
+ * canonical order: by file path, then by start line. Sorting makes a clone
+ * reported as `(a:10, b:20)` and one reported as `(b:20, a:10)` resolve to the
+ * same first/second side, so the identity below and the matcher's relocation
+ * locator (`entryToLocated`) agree on which side is the representative WITHOUT
+ * duplicating the sort in two places — keeping them in lockstep is load-bearing
+ * for relocation (the locator's line must be the same side the prior entry
+ * stored, or the git-diff line mapping pairs the wrong occurrences).
+ */
+export function duplicationCanonicalSides(
+  fileA: string,
+  startLineA: number,
+  fileB: string,
+  startLineB: number,
+): readonly [readonly [string, number], readonly [string, number]] {
+  const pairs: Array<[string, number]> = [
+    [fileA, startLineA],
+    [fileB, startLineB],
+  ];
+  pairs.sort((x, y) => (x[0] < y[0] ? -1 : x[0] > y[0] ? 1 : x[1] - y[1]));
+  return [pairs[0], pairs[1]];
+}
+
 function computeDuplicationIdentity(
   fileA: string,
   fileB: string,
@@ -158,12 +182,8 @@ function computeDuplicationIdentity(
   startLineA: number,
   startLineB: number,
 ): FindingId {
-  const pairs: Array<[string, number]> = [
-    [fileA, startLineA],
-    [fileB, startLineB],
-  ];
-  pairs.sort((x, y) => (x[0] < y[0] ? -1 : x[0] > y[0] ? 1 : x[1] - y[1]));
-  const input = `duplication\0v1\0${pairs[0][0]}\0${pairs[0][1]}\0${pairs[1][0]}\0${pairs[1][1]}\0${lines}`;
+  const [first, second] = duplicationCanonicalSides(fileA, startLineA, fileB, startLineB);
+  const input = `duplication\0v1\0${first[0]}\0${first[1]}\0${second[0]}\0${second[1]}\0${lines}`;
   return createHash('sha1').update(input).digest('hex').slice(0, 16);
 }
 

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -215,7 +215,10 @@ const QUALITY_PRODUCER: BaselineProducer = {
   contributes: ['duplication', 'stale-file'],
   produce(ctx) {
     return [
-      ...duplicationToBaselineEntries(ctx.analysisResult.capabilities.duplication),
+      ...duplicationToBaselineEntries(ctx.analysisResult.capabilities.duplication, {
+        cwd: ctx.cwd,
+        commitSha: ctx.commitSha,
+      }),
       ...staleFilesToBaselineEntries(ctx.hygiene.staleFiles),
     ];
   },
@@ -244,6 +247,7 @@ const STALE_ALLOW_PRODUCER: BaselineProducer = {
     return staleAllowToBaselineEntries({
       annotations: ctx.inlineAllowlistAnnotations,
       aggregate: ctx.analysisResult.capabilities.securityAggregate ?? null,
+      commit: { cwd: ctx.cwd, commitSha: ctx.commitSha },
     });
   },
 };

--- a/src/baseline/producers/quality.ts
+++ b/src/baseline/producers/quality.ts
@@ -27,7 +27,8 @@
  *     positions, not just counts. Pending in a follow-up commit.
  */
 
-import { identityFor } from '../finding-identity';
+import { computeContentHashFromCommit } from '../content-hash';
+import { duplicationCanonicalSides, identityFor } from '../finding-identity';
 import type { RichBaselineEntry, DuplicationIdentityInput, StaleFileIdentityInput } from '../types';
 import type { DuplicationResult } from '../../languages/capabilities/types';
 
@@ -37,9 +38,20 @@ import type { DuplicationResult } from '../../languages/capabilities/types';
  *  the path. */
 const STALE_SUFFIXES = new Set(['swp', 'swo', 'bak', 'orig', 'tmp', 'log', 'pyc']);
 
-/** Build `duplication` entries from a jscpd-style envelope. */
+/**
+ * Build `duplication` entries from a jscpd-style envelope.
+ *
+ * When `opts` carries the repo + baseline commit, each entry is stamped with a
+ * `contentHash` of the block content at the canonical representative side — the
+ * same `(file, startLine)` the matcher's locator uses, so prior + current agree
+ * on what to hash. That lets the matcher's content-hash pass relocate the clone
+ * across a line shift WITHOUT git history (shallow clones / force-pushed
+ * baselines), matching the protection secret/code/hygiene already have. Omitted
+ * (best-effort) when no commit is available or the file can't be read.
+ */
 export function duplicationToBaselineEntries(
   duplication: DuplicationResult | undefined,
+  opts?: { readonly cwd: string; readonly commitSha: string },
 ): RichBaselineEntry[] {
   if (!duplication) return [];
   const out: RichBaselineEntry[] = [];
@@ -52,6 +64,17 @@ export function duplicationToBaselineEntries(
       startLineA: clone.a.startLine,
       startLineB: clone.b.startLine,
     };
+    let contentHash: string | undefined;
+    if (opts) {
+      const [first] = duplicationCanonicalSides(
+        clone.a.file,
+        clone.a.startLine,
+        clone.b.file,
+        clone.b.startLine,
+      );
+      contentHash =
+        computeContentHashFromCommit(opts.cwd, opts.commitSha, first[0], first[1]) ?? undefined;
+    }
     out.push({
       id: identityFor(input),
       kind: 'duplication',
@@ -60,6 +83,7 @@ export function duplicationToBaselineEntries(
       lines: clone.lines,
       startLineA: clone.a.startLine,
       startLineB: clone.b.startLine,
+      ...(contentHash !== undefined ? { contentHash } : {}),
     });
   }
   return out;

--- a/src/baseline/producers/stale-allow.ts
+++ b/src/baseline/producers/stale-allow.ts
@@ -47,18 +47,27 @@
 import { lineWindowFor } from '../../analyzers/tools/fingerprint';
 import type { SecurityAggregate } from '../../analyzers/security/aggregator';
 import type { InlineAllowlistOccurrence } from '../../allowlist/gather';
+import { computeContentHashFromCommit } from '../content-hash';
 import { identityFor } from '../finding-identity';
 import type { RichBaselineEntry, StaleAllowIdentityInput } from '../types';
 
 export interface StaleAllowInput {
   readonly annotations: ReadonlyArray<InlineAllowlistOccurrence>;
   readonly aggregate: SecurityAggregate | null;
+  /** Repo + baseline commit. When present, each stale entry is stamped with a
+   * `contentHash` of the annotation's surrounding context, so the matcher's
+   * content-hash pass relocates it without git (the line-bucketed identity
+   * re-mints on a >window shift). Best-effort: omitted when absent or the file
+   * can't be read at the commit. */
+  readonly commit?: { readonly cwd: string; readonly commitSha: string };
 }
 
 /**
  * Build `stale-allow` entries from the annotation list + the
- * canonical security aggregate. Pure function — no I/O, no side
- * effects. Deterministic over equal inputs.
+ * canonical security aggregate. Deterministic over equal inputs; the
+ * only I/O is the best-effort `contentHash` read when `input.commit`
+ * is supplied (reading the annotation's context from the baseline
+ * commit, same as the secret/code producer).
  *
  * Returns an empty array when:
  *   - The annotation list is empty (nothing to check).
@@ -86,12 +95,21 @@ export function staleAllowToBaselineEntries(input: StaleAllowInput): RichBaselin
       line: occ.line,
       category: occ.category,
     };
+    const contentHash = input.commit
+      ? (computeContentHashFromCommit(
+          input.commit.cwd,
+          input.commit.commitSha,
+          occ.file,
+          occ.line,
+        ) ?? undefined)
+      : undefined;
     out.push({
       id: identityFor(identityInput),
       kind: 'stale-allow',
       file: occ.file,
       line: occ.line,
       category: occ.category,
+      ...(contentHash !== undefined ? { contentHash } : {}),
     });
   }
   return out;

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -441,6 +441,13 @@ export type BaselineEntry =
       lines: number;
       startLineA: number;
       startLineB: number;
+      /** 16-char hex hash of the normalized block content at the canonical
+       * representative side, stamped at baseline-create time. Lets the
+       * matcher's content-hash pass relocate the clone WITHOUT git (shallow
+       * clones, force-pushed baselines) — the git-line pass needs reachable
+       * history, this does not. Absent when the producer couldn't read the
+       * file. Same role as the secret/code/hygiene `contentHash`. */
+      contentHash?: string;
     }
   | {
       id: FindingId;
@@ -471,7 +478,18 @@ export type BaselineEntry =
   | { id: FindingId; kind: 'stale-file'; file: string; suffix: string }
   | { id: FindingId; kind: 'large-file'; file: string }
   | { id: FindingId; kind: 'secret-hmac'; tool: string; rule: string; hmac: string }
-  | { id: FindingId; kind: 'stale-allow'; file: string; line: number; category: string }
+  | {
+      id: FindingId;
+      kind: 'stale-allow';
+      file: string;
+      line: number;
+      category: string;
+      /** Content-hash of the annotation's surrounding context, so the matcher
+       * relocates it without git when a >window line shift re-mints the
+       * line-bucketed identity. Same role as the secret/code/hygiene field;
+       * absent when the file can't be read. */
+      contentHash?: string;
+    }
   | SanitizedBaselineEntry;
 
 /**

--- a/test/baseline/entry-to-located.test.ts
+++ b/test/baseline/entry-to-located.test.ts
@@ -58,18 +58,13 @@ describe('entryToLocated', () => {
     });
   });
 
-  it('falls through to identity-only for kinds with no file/line locator', () => {
+  it('falls through to identity-only ONLY for line-independent locator-less kinds', () => {
+    // dep-vuln (advisory id) and secret-hmac (value HMAC) have
+    // line-independent identity, so they correctly carry no locator and pair
+    // by exact identity-hash. duplication is NOT here — its identity hashes
+    // exact start lines, so it must carry a line locator (asserted below).
     const cases: BaselineEntry[] = [
       { id: 'd1', kind: 'dep-vuln', package: 'lodash', advisoryId: 'GHSA-x' },
-      {
-        id: 'd2',
-        kind: 'duplication',
-        fileA: 'a',
-        fileB: 'b',
-        lines: 10,
-        startLineA: 1,
-        startLineB: 1,
-      },
       { id: 'd7', kind: 'secret-hmac', tool: 'gitleaks', rule: 'aws-token', hmac: 'h' },
     ];
     for (const entry of cases) {
@@ -79,6 +74,25 @@ describe('entryToLocated', () => {
       expect(out.line).toBeUndefined();
       expect(out.rule).toBeUndefined();
     }
+  });
+
+  it('gives duplication a line locator on the canonical representative side', () => {
+    // Line-dependent identity → must be relocatable. The locator side matches
+    // the identity's canonical ordering (sorted by file, then line) so a line
+    // shift relocates instead of false-flagging as net-new.
+    const out = entryToLocated({
+      id: 'd2',
+      kind: 'duplication',
+      fileA: 'b',
+      fileB: 'a',
+      lines: 10,
+      startLineA: 20,
+      startLineB: 5,
+    });
+    expect(out.id).toBe('d2');
+    expect(out.file).toBe('a'); // lexicographically smaller side
+    expect(out.line).toBe(5);
+    expect(out.rule).toBe('duplication');
   });
 
   it('carries file + kind (as rule) but no line for whole-file findings', () => {
@@ -103,6 +117,21 @@ describe('entryToLocated', () => {
       expect(out.line).toBeUndefined();
       expect(out.contentHash).toBeUndefined();
     }
+  });
+
+  it('gives a range-anchored coverage-gap a line locator at the range start', () => {
+    // A coverage-gap with no symbol hashes its line range → line-dependent →
+    // needs a line locator so a shift relocates. (Symbol-anchored gaps are
+    // line-independent and stay line-less, covered above.)
+    const out = entryToLocated({
+      id: 'cg',
+      kind: 'coverage-gap',
+      file: 'src/c.ts',
+      lineRange: [42, 60],
+    });
+    expect(out.file).toBe('src/c.ts');
+    expect(out.line).toBe(42);
+    expect(out.rule).toBe('coverage-gap');
   });
 
   it('entriesToLocated maps each element', () => {

--- a/test/baseline/git-aware-match.test.ts
+++ b/test/baseline/git-aware-match.test.ts
@@ -200,6 +200,43 @@ describe('gitAwareMatch', () => {
     expect(result.persisted).toEqual([]);
   });
 
+  it('relocates a duplicate via content-hash when the base SHA is unreachable', () => {
+    // A duplicate block shifted down the file: its line-exact identity differs,
+    // and the base SHA is unreachable (shallow clone / force-pushed baseline),
+    // so the git-line pass is skipped. The content-hash pass must still pair
+    // the two — this is the protection that makes the relocation fix complete
+    // for the git-unavailable case, at parity with secret/code/hygiene.
+    const prior: LocatedIdentity[] = [
+      {
+        id: 'dup0prior0000000',
+        file: 'a.js',
+        line: 3,
+        rule: 'duplication',
+        contentHash: 'block00hash000000',
+      },
+    ];
+    const current: LocatedIdentity[] = [
+      {
+        id: 'dup0current00000',
+        file: 'a.js',
+        line: 6,
+        rule: 'duplication',
+        contentHash: 'block00hash000000',
+      },
+    ];
+    expect(prior[0].id).not.toBe(current[0].id);
+    const result = gitAwareMatch(prior, current, {
+      cwd: dir,
+      baseSha: '0000000000000000000000000000000000000000', // not in repo → git pass skipped
+    });
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+    expect(result.pairs).toHaveLength(1);
+    const [pair] = result.pairs;
+    expect(pair.status).toBe('persisted'); // same file → persisted, not relocated
+    expect(pair.reasons.some((r) => r.code === 'content-hash')).toBe(true);
+  });
+
   it('treats non-line-anchored findings via exact identity only', () => {
     writeFileSync(join(dir, 'a.ts'), lines('one'));
     const sha = commit(dir, 'initial');

--- a/test/baseline/matcher-relocation-contract.test.ts
+++ b/test/baseline/matcher-relocation-contract.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+
+import { baselineEntryToIdentityInput } from '../../src/baseline/migrate';
+import { entryToLocated } from '../../src/baseline/entry-to-located';
+import { identityFor } from '../../src/baseline/finding-identity';
+import type { BaselineEntry, IdentityKind } from '../../src/baseline/types';
+
+/**
+ * THE MATCHER RELOCATION INVARIANT (the class-level guard).
+ *
+ * A finding whose identity is sensitive to line position — shifting it down
+ * the file changes its identity hash — MUST receive a full `(file, line,
+ * rule)` locator from `entryToLocated`, so the matcher's line-aware pass can
+ * relocate it through a `git diff` instead of reading benign churn (a comment
+ * inserted above it) as removed+added → false net-new debt. A kind may be
+ * locator-less (or line-less) ONLY when its identity is line-INDEPENDENT.
+ *
+ * This was violated once: `duplication` (added to the baseline producers
+ * later) hashed exact start lines yet sat in the locator-less group with
+ * dep-vuln + secret-hmac, so any line shift false-flagged every duplicate as
+ * net-new. `coverage-gap`'s range variant had the same latent shape. Rather
+ * than fix those two by hand and wait for the next kind to repeat it, this
+ * test derives line-sensitivity empirically (shift the sample, recompute the
+ * id) and asserts the locator is complete whenever it matters — so a future
+ * kind that lands line-sensitive-but-locator-less fails here, not in a user's
+ * guardrail.
+ *
+ * Mirror of the recipe/producer playbook tests: it makes "the matcher stopped
+ * being relocation-complete" an empirical, automatic failure.
+ */
+
+const ID = '0'.repeat(16);
+const SHIFT = 50; // larger than any line-window bucket, so a line-based id must move
+
+interface Sample {
+  readonly label: string;
+  readonly entry: BaselineEntry;
+  /** The same finding moved SHIFT lines down the file (benign churn). */
+  readonly shifted: BaselineEntry;
+}
+
+const SAMPLES: ReadonlyArray<Sample> = [
+  {
+    label: 'secret',
+    entry: { id: ID, kind: 'secret', tool: 'gitleaks', rule: 'aws-key', file: 'a.js', line: 10 },
+    shifted: {
+      id: ID,
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'aws-key',
+      file: 'a.js',
+      line: 10 + SHIFT,
+    },
+  },
+  {
+    label: 'code',
+    entry: { id: ID, kind: 'code', tool: 'semgrep', rule: 'eval', file: 'a.js', line: 10 },
+    shifted: {
+      id: ID,
+      kind: 'code',
+      tool: 'semgrep',
+      rule: 'eval',
+      file: 'a.js',
+      line: 10 + SHIFT,
+    },
+  },
+  {
+    label: 'config',
+    entry: { id: ID, kind: 'config', tool: 'git', rule: 'env-in-git', file: '.env', line: 0 },
+    shifted: { id: ID, kind: 'config', tool: 'git', rule: 'env-in-git', file: '.env', line: SHIFT },
+  },
+  {
+    label: 'dep-vuln',
+    entry: { id: ID, kind: 'dep-vuln', package: 'lodash', advisoryId: 'GHSA-1234' },
+    shifted: { id: ID, kind: 'dep-vuln', package: 'lodash', advisoryId: 'GHSA-1234' },
+  },
+  {
+    label: 'duplication',
+    entry: {
+      id: ID,
+      kind: 'duplication',
+      fileA: 'a.js',
+      fileB: 'b.js',
+      lines: 13,
+      startLineA: 10,
+      startLineB: 20,
+    },
+    shifted: {
+      id: ID,
+      kind: 'duplication',
+      fileA: 'a.js',
+      fileB: 'b.js',
+      lines: 13,
+      startLineA: 10 + SHIFT,
+      startLineB: 20 + SHIFT,
+    },
+  },
+  {
+    label: 'coverage-gap (symbol-anchored)',
+    entry: { id: ID, kind: 'coverage-gap', file: 'a.js', symbol: 'doThing', lineRange: [10, 20] },
+    shifted: {
+      id: ID,
+      kind: 'coverage-gap',
+      file: 'a.js',
+      symbol: 'doThing',
+      lineRange: [10 + SHIFT, 20 + SHIFT],
+    },
+  },
+  {
+    label: 'coverage-gap (range-anchored)',
+    entry: { id: ID, kind: 'coverage-gap', file: 'a.js', lineRange: [10, 20] },
+    shifted: { id: ID, kind: 'coverage-gap', file: 'a.js', lineRange: [10 + SHIFT, 20 + SHIFT] },
+  },
+  {
+    label: 'test-gap',
+    entry: { id: ID, kind: 'test-gap', file: 'a.js', risk: 'CRITICAL' },
+    shifted: { id: ID, kind: 'test-gap', file: 'a.js', risk: 'CRITICAL' },
+  },
+  {
+    label: 'hygiene',
+    entry: { id: ID, kind: 'hygiene', file: 'a.js', line: 10, marker: 'TODO' },
+    shifted: { id: ID, kind: 'hygiene', file: 'a.js', line: 10 + SHIFT, marker: 'TODO' },
+  },
+  {
+    label: 'test-file-degradation',
+    entry: { id: ID, kind: 'test-file-degradation', file: 'a.test.js', status: 'empty' },
+    shifted: { id: ID, kind: 'test-file-degradation', file: 'a.test.js', status: 'empty' },
+  },
+  {
+    label: 'god-file',
+    entry: { id: ID, kind: 'god-file', file: 'a.js' },
+    shifted: { id: ID, kind: 'god-file', file: 'a.js' },
+  },
+  {
+    label: 'stale-file',
+    entry: { id: ID, kind: 'stale-file', file: 'a.js.bak', suffix: 'bak' },
+    shifted: { id: ID, kind: 'stale-file', file: 'a.js.bak', suffix: 'bak' },
+  },
+  {
+    label: 'large-file',
+    entry: { id: ID, kind: 'large-file', file: 'a.js' },
+    shifted: { id: ID, kind: 'large-file', file: 'a.js' },
+  },
+  {
+    label: 'secret-hmac',
+    entry: { id: ID, kind: 'secret-hmac', tool: 'gitleaks', rule: 'aws-key', hmac: 'deadbeef' },
+    shifted: { id: ID, kind: 'secret-hmac', tool: 'gitleaks', rule: 'aws-key', hmac: 'deadbeef' },
+  },
+  {
+    label: 'stale-allow',
+    entry: { id: ID, kind: 'stale-allow', file: 'a.js', line: 10, category: 'false-positive' },
+    shifted: {
+      id: ID,
+      kind: 'stale-allow',
+      file: 'a.js',
+      line: 10 + SHIFT,
+      category: 'false-positive',
+    },
+  },
+];
+
+/** Empirically: does shifting this finding down the file change its identity? */
+function isLineSensitive(s: Sample): boolean {
+  const base = baselineEntryToIdentityInput(s.entry);
+  const moved = baselineEntryToIdentityInput(s.shifted);
+  if (!base || !moved) throw new Error(`${s.label}: identity input was undefined`);
+  return identityFor(base) !== identityFor(moved);
+}
+
+describe('matcher relocation invariant', () => {
+  it('covers every IdentityKind (a new kind must add a sample here)', () => {
+    // Exhaustiveness: this list mirrors the IdentityKind union. The
+    // `satisfies` check fails to compile if a union member is dropped; the
+    // runtime check fails if a kind has no sample, so a new finding kind
+    // cannot land without being put through the invariant below.
+    const allKinds = [
+      'secret',
+      'code',
+      'config',
+      'dep-vuln',
+      'duplication',
+      'coverage-gap',
+      'test-gap',
+      'hygiene',
+      'test-file-degradation',
+      'god-file',
+      'stale-file',
+      'large-file',
+      'secret-hmac',
+      'stale-allow',
+    ] as const satisfies ReadonlyArray<IdentityKind>;
+    const sampled = new Set(SAMPLES.map((s) => s.entry.kind));
+    for (const kind of allKinds) {
+      expect(sampled.has(kind), `no relocation sample for kind '${kind}'`).toBe(true);
+    }
+  });
+
+  for (const s of SAMPLES) {
+    it(`${s.label}: line-sensitive identity ⟹ a full (file,line,rule) locator`, () => {
+      const located = entryToLocated(s.entry);
+      if (isLineSensitive(s)) {
+        expect(located.file, `${s.label} is line-sensitive but has no file locator`).toBeDefined();
+        expect(
+          located.line,
+          `${s.label} is line-sensitive but has no line locator — the matcher cannot relocate it across a shift, so benign churn reads as net-new`,
+        ).toBeDefined();
+        expect(
+          located.rule,
+          `${s.label} is line-sensitive but has no rule discriminator`,
+        ).toBeDefined();
+      }
+    });
+  }
+});
+
+describe('duplication relocation locator', () => {
+  it('uses the canonical representative side, stable across a line shift', () => {
+    // The locator side must match the side the identity hash canonicalizes
+    // on (sorted by file, then line), so prior + current pick the same side
+    // and the matcher maps the right line through the diff.
+    const entry: BaselineEntry = {
+      id: ID,
+      kind: 'duplication',
+      // Deliberately B-before-A by sort: 'a.js' < 'b.js', so the A side is
+      // canonical regardless of declaration order.
+      fileA: 'b.js',
+      fileB: 'a.js',
+      lines: 13,
+      startLineA: 20,
+      startLineB: 5,
+    };
+    const located = entryToLocated(entry);
+    expect(located.file).toBe('a.js'); // canonical first side (lexicographically smaller file)
+    expect(located.line).toBe(5);
+    expect(located.rule).toBe('duplication');
+  });
+});

--- a/test/baseline/matcher-relocation-contract.test.ts
+++ b/test/baseline/matcher-relocation-contract.test.ts
@@ -3,7 +3,12 @@ import { describe, it, expect } from 'vitest';
 import { baselineEntryToIdentityInput } from '../../src/baseline/migrate';
 import { entryToLocated } from '../../src/baseline/entry-to-located';
 import { identityFor } from '../../src/baseline/finding-identity';
-import type { BaselineEntry, IdentityKind } from '../../src/baseline/types';
+import type { BaselineEntry } from '../../src/baseline/types';
+
+/** Every discriminant the BaselineEntry union takes (mirror of the
+ *  `IdentityKind` alias in producers/index.ts, inlined to avoid importing the
+ *  producer module into a pure-matcher test). */
+type IdentityKind = BaselineEntry['kind'];
 
 /**
  * THE MATCHER RELOCATION INVARIANT (the class-level guard).
@@ -113,13 +118,13 @@ const SAMPLES: ReadonlyArray<Sample> = [
   },
   {
     label: 'test-gap',
-    entry: { id: ID, kind: 'test-gap', file: 'a.js', risk: 'CRITICAL' },
-    shifted: { id: ID, kind: 'test-gap', file: 'a.js', risk: 'CRITICAL' },
+    entry: { id: ID, kind: 'test-gap', file: 'a.js', risk: 'critical' },
+    shifted: { id: ID, kind: 'test-gap', file: 'a.js', risk: 'critical' },
   },
   {
     label: 'hygiene',
-    entry: { id: ID, kind: 'hygiene', file: 'a.js', line: 10, marker: 'TODO' },
-    shifted: { id: ID, kind: 'hygiene', file: 'a.js', line: 10 + SHIFT, marker: 'TODO' },
+    entry: { id: ID, kind: 'hygiene', file: 'a.js', line: 10, marker: 'todo' },
+    shifted: { id: ID, kind: 'hygiene', file: 'a.js', line: 10 + SHIFT, marker: 'todo' },
   },
   {
     label: 'test-file-degradation',
@@ -234,4 +239,86 @@ describe('duplication relocation locator', () => {
     expect(located.line).toBe(5);
     expect(located.rule).toBe('duplication');
   });
+});
+
+describe('content-hash passthrough (git-independent relocation)', () => {
+  // The matcher's content-hash pass relocates a finding WITHOUT git history
+  // (shallow clone / force-pushed baseline) — but only if entryToLocated
+  // propagates the stamped contentHash to the LocatedIdentity. Dropping it
+  // silently (as stale-allow once did) leaves that kind unprotected whenever
+  // git is unavailable. Every kind whose entry can carry a contentHash must
+  // pass it through; this guards against the drop.
+  const HASH = 'feedfacefeedface';
+  const withHash: ReadonlyArray<{ label: string; entry: BaselineEntry }> = [
+    {
+      label: 'secret',
+      entry: {
+        id: ID,
+        kind: 'secret',
+        tool: 'gitleaks',
+        rule: 'aws-key',
+        file: 'a.js',
+        line: 10,
+        contentHash: HASH,
+      },
+    },
+    {
+      label: 'code',
+      entry: {
+        id: ID,
+        kind: 'code',
+        tool: 'semgrep',
+        rule: 'eval',
+        file: 'a.js',
+        line: 10,
+        contentHash: HASH,
+      },
+    },
+    {
+      label: 'config',
+      entry: {
+        id: ID,
+        kind: 'config',
+        tool: 'git',
+        rule: 'env-in-git',
+        file: '.env',
+        line: 0,
+        contentHash: HASH,
+      },
+    },
+    {
+      label: 'hygiene',
+      entry: { id: ID, kind: 'hygiene', file: 'a.js', line: 10, marker: 'todo', contentHash: HASH },
+    },
+    {
+      label: 'duplication',
+      entry: {
+        id: ID,
+        kind: 'duplication',
+        fileA: 'a.js',
+        fileB: 'b.js',
+        lines: 13,
+        startLineA: 10,
+        startLineB: 20,
+        contentHash: HASH,
+      },
+    },
+    {
+      label: 'stale-allow',
+      entry: {
+        id: ID,
+        kind: 'stale-allow',
+        file: 'a.js',
+        line: 10,
+        category: 'false-positive',
+        contentHash: HASH,
+      },
+    },
+  ];
+
+  for (const { label, entry } of withHash) {
+    it(`${label}: entryToLocated propagates the stamped contentHash`, () => {
+      expect(entryToLocated(entry).contentHash).toBe(HASH);
+    });
+  }
 });


### PR DESCRIPTION
## What

Fixes a guardrail false-positive: inserting lines above a duplicate block
flagged every duplicate as net-new debt, blocking the gate on benign churn.
Fixes it as a **class**, not a one-off, and enforces the invariant so it
can't recur.

## Root cause

The matcher has an (until now unenforced) **relocation contract**: a finding
whose identity moves with line position must be *relocatable*. `duplication`
violated it — its identity hashes the block's exact start lines, yet
`entryToLocated` put it in the locator-less group with `dep-vuln` /
`secret-hmac` (whose identities are genuinely line-independent). With no
locator it only matched via exact-id, which a line shift defeats →
removed+added → false net-new. `coverage-gap`'s range variant had the same
latent shape. It didn't surface earlier because the `duplication` kind was
added to the baseline producers after the matcher-robustness coverage was
written.

## Fix (two commits)

1. **Relocate line-anchored findings.** `entryToLocated` gives `duplication`
   (and range-anchored `coverage-gap`) a `(file, line, rule)` locator on the
   canonical representative side (shared `duplicationCanonicalSides` helper, so
   the locator and the identity hash never disagree). A new contract test
   derives line-sensitivity empirically for **every** identity kind and fails
   if a kind is line-sensitive but not relocatable.
2. **Git-independent fallback.** The git-line pass needs reachable history;
   on a shallow clone / force-pushed baseline it's skipped. `duplication` and
   `stale-allow` now carry a `contentHash` (like secret/code/hygiene) so the
   matcher's content-hash pass relocates them without git. A second contract
   test guards the contentHash passthrough.

Identity is unchanged → **no baseline re-creation, no scheme bump**; existing
baselines/allowlists keep matching, and `update` is a no-op beyond the version
bump.

## Verification

- Full suite green (2437); arch/lint/format/typecheck/coverage all pass.
- Matcher-robustness benchmark: false-regression rate back to **0%** on a
  baseline containing `duplication` findings (was 50%).
- **Upgrade path:** a baseline created by the previously-shipped release, then
  line-shifted, passes clean under this build with **no re-baseline** — the
  locator is computed from fields already stored in the old baseline.
- **External real-world repo (v1 baseline):** stale-scheme guard fires →
  migration re-anchors 21/23 allowlist entries (0 unmapped, 0 lost) →
  post-migration guardrail clean (703 persisted, 0 net-new). Repo restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)