### PR TITLE
docs(benchmarks): tighten report for publication and ship determinist…

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ tmp/
 # the upstream tool emits — reformatting defeats the C-defect-style
 # regression check (synthetic JSON drifts; real-output fixtures don't).
 test/fixtures/raw/
+benchmarks/

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ predictable.
 > dxkit catches every possible bug. The claim is narrower: for findings the
 > detector observes, dxkit gives the loop a deterministic net-new stop decision.
 
-Full methodology, raw artifacts, and the rest of the caveats are in
+Full methodology, reproducibility notes, artifact status, and caveats are in
 **[docs/benchmarks.md](docs/benchmarks.md)**.
 
 ## What dxkit is, and is not
@@ -259,7 +259,7 @@ npx @vyuhlabs/dxkit baseline create
 npx @vyuhlabs/dxkit loop doctor
 ```
 
-Methodology and raw artifacts: **[docs/benchmarks.md](docs/benchmarks.md)**.
+Methodology and caveats: **[docs/benchmarks.md](docs/benchmarks.md)**.
 
 ## Credits
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,79 @@
+# dxkit deterministic benchmark harnesses
+
+These are the offline, no-API-key harnesses behind the deterministic tier of
+[`docs/benchmarks.md`](../docs/benchmarks.md). They establish that the gate
+behaves correctly on controlled, seeded cases: it blocks net-new regressions,
+passes clean edits, grandfathers pre-existing debt, isolates a single net-new
+finding against a large baseline, and does not false-block on mechanical churn.
+
+Three harnesses are included.
+
+- `bench-guardrail.mjs` seeds known regressions (a SAST eval injection, a command
+  injection, and a private-key secret) and clean edits, then builds a confusion
+  matrix of the gate's verdicts.
+- `bench-netnew-isolation.mjs` grandfathers all pre-existing debt, introduces
+  exactly one net-new finding, and checks that the gate isolates that one finding
+  rather than losing it in the noise of the existing debt.
+- `bench-matcher.mjs` applies churn that introduces no finding (line shifts and
+  file renames) and checks that no finding is falsely re-flagged as net-new.
+
+The agent-driven studies in the report (loop safety, the LLM-as-gate comparison,
+and the graph-context sessions) require a model API or subscription and the
+pinned repository checkouts, and are not included here. Their harnesses and raw
+traces will be published separately after redaction.
+
+## Requirements
+
+- Node.js 20 or newer.
+- A dxkit binary. If you have built this repository (`npm run build`), the
+  harnesses use `dist/index.js` automatically. Otherwise they fall back to the
+  published CLI via `npx --yes @vyuhlabs/dxkit`. You can override the binary with
+  the `DXKIT` environment variable.
+- A target git repository, checked out at a fixed commit. The numbers in the
+  report come from two public repositories: OWASP NodeGoat at commit `c5cb68a`,
+  and `strapi/strapi` at commit `dc49217`. The harnesses are repository-agnostic,
+  so any git repository with a dxkit baseline will run.
+
+## Running
+
+Copy `config.example.json` to `config.json` and set `repoDir` to your checkout
+and `pinnedCommit` to the commit to baseline against. Then run a harness with the
+config path as its only argument.
+
+```bash
+# Reproduce the report's NodeGoat numbers.
+git clone https://github.com/OWASP/NodeGoat /tmp/nodegoat
+git -C /tmp/nodegoat checkout c5cb68a
+
+cat > config.json <<'EOF'
+{ "repoDir": "/tmp/nodegoat", "pinnedCommit": "c5cb68a" }
+EOF
+
+node benchmarks/bench-guardrail.mjs config.json
+node benchmarks/bench-matcher.mjs config.json
+node benchmarks/bench-netnew-isolation.mjs config.json
+```
+
+Each harness prints a JSON result to stdout. The harnesses force
+`committed-full` baseline mode, because dxkit auto-selects ref-based mode on a
+public repository, which would re-gather the prior side on demand and defeat the
+frozen-baseline design.
+
+## Expected results
+
+On NodeGoat at `c5cb68a` (baseline of 205 findings), with dxkit 2.13.0:
+
+- `bench-guardrail`: `matrix` of `tp 3, fn 0, tn 2, fp 0`, so `catchRate` 1 and
+  `falseBlockRate` 0.
+- `bench-netnew-isolation`: `debtTotal` 205, `isolationWinRate` 1, and a
+  `fixToGreenTax` of 206 with no baseline against 1 with the dxkit baseline.
+- `bench-matcher`: `falseRegressionRate` 0.
+
+On `strapi/strapi` at `dc49217` (baseline of 1,020 findings), the matcher run
+shows `falseRegressionRate` 0 over a baseline that contains 15 duplication
+findings, and net-new isolation shows `debtTotal` 1,020 with `isolationWinRate`
+1. Strapi is a large monorepo, so its baseline creation is slow.
+
+These are controlled regression suites, not statistical estimates of recall.
+They demonstrate that the gate behaves correctly on the seeded cases, not that it
+catches every possible regression in the wild.

--- a/benchmarks/bench-guardrail.mjs
+++ b/benchmarks/bench-guardrail.mjs
@@ -1,0 +1,141 @@
+/**
+ * Benchmark #1 - Guardrail efficacy (deterministic, no API key).
+ *
+ * The product's reason to exist: block net-new regressions, pass clean changes,
+ * grandfather pre-existing debt. We baseline the target, then apply controlled
+ * commits and check the guardrail's verdict, building a confusion matrix:
+ *
+ *   regression commit (introduces a KNOWN new finding)  → expect BLOCK (exit 1)
+ *   clean commit      (changes code, no new finding)    → expect PASS  (exit 0)
+ *
+ *   TP = regression blocked   FN = regression passed (MISS)
+ *   TN = clean passed         FP = clean blocked (false alarm - the adoption killer)
+ *
+ * Output: { catchRate, falseBlockRate, cases[] }.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { sh, resetTo, saveBaseline, restoreBaseline, createBaseline, guardrailExitCode } from './lib.mjs';
+
+function existingSourceFiles(repoDir) {
+  try {
+    return sh(`git ls-files '*.js'`, repoDir)
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+// Regressions write a NEW file carrying a KNOWN net-new finding (semgrep SAST /
+// gitleaks private-key). A private-key block is detected by structure, so -
+// unlike the AWS documented example key - it can't be allowlisted away.
+const REGRESSIONS = [
+  {
+    name: 'sast-eval-injection',
+    apply(repoDir) {
+      fs.writeFileSync(
+        path.join(repoDir, 'dxkit_bench_evil.js'),
+        'module.exports = (req) => { return eval(req.query.x); };\n', // semgrep: eval
+      );
+    },
+  },
+  {
+    name: 'sast-command-injection',
+    apply(repoDir) {
+      fs.writeFileSync(
+        path.join(repoDir, 'dxkit_bench_cmd.js'),
+        "const cp=require('child_process'); module.exports=(q)=>cp.exec('ls '+q);\n",
+      );
+    },
+  },
+  {
+    name: 'secret-private-key',
+    apply(repoDir) {
+      fs.writeFileSync(
+        path.join(repoDir, 'dxkit_bench_secret.js'),
+        '// embedded credential - gitleaks private-key rule matches the header\n' +
+          'const KEY = `-----BEGIN RSA PRIVATE KEY-----\n' +
+          'MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Q\n' +
+          'uKUpRKfFLfRYC9AIKjbJTWit+Cqvj3Fx001wEAQABAkA=\n' +
+          '-----END RSA PRIVATE KEY-----`;\nmodule.exports = KEY;\n',
+      );
+    },
+  },
+];
+
+// Clean cases churn EXISTING source (a trailing comment) - the realistic shape
+// the matcher must survive without crying "net-new". They introduce no finding,
+// so the guardrail must PASS.
+const CLEANS = [
+  {
+    name: 'comment-existing-file-A',
+    apply(repoDir) {
+      const f = existingSourceFiles(repoDir)[0];
+      if (!f) throw new Error('no existing source file to churn');
+      const abs = path.join(repoDir, f);
+      fs.appendFileSync(abs, '\n// dxkit-bench: harmless trailing comment\n');
+    },
+  },
+  {
+    name: 'comment-existing-file-B',
+    apply(repoDir) {
+      const files = existingSourceFiles(repoDir);
+      const f = files[Math.min(1, files.length - 1)];
+      if (!f) throw new Error('no existing source file to churn');
+      const abs = path.join(repoDir, f);
+      fs.appendFileSync(abs, '\n// dxkit-bench: another harmless comment\n');
+    },
+  },
+];
+
+export function runGuardrailBench(config) {
+  const repoDir = config.repoDir;
+  const tmpBase = path.join(repoDir, '..', '_baseline_guardrail.json');
+
+  // Fresh baseline at the pinned commit (mode-locked + pre-flight asserted).
+  resetTo(repoDir, config.pinnedCommit);
+  const baseline = createBaseline(repoDir);
+  saveBaseline(repoDir, tmpBase);
+
+  const cases = [];
+  const runOne = (kind, c, expectBlock) => {
+    resetTo(repoDir, config.pinnedCommit);
+    restoreBaseline(repoDir, tmpBase);
+    c.apply(repoDir);
+    sh(`git add -A 2>/dev/null || true`, repoDir);
+    const code = guardrailExitCode(repoDir);
+    const blocked = code !== 0;
+    cases.push({
+      kind,
+      name: c.name,
+      expectedBlock: expectBlock,
+      blocked,
+      correct: blocked === expectBlock,
+    });
+  };
+
+  for (const c of REGRESSIONS) runOne('regression', c, true);
+  for (const c of CLEANS) runOne('clean', c, false);
+
+  resetTo(repoDir, config.pinnedCommit);
+
+  const reg = cases.filter((c) => c.kind === 'regression');
+  const clean = cases.filter((c) => c.kind === 'clean');
+  const tp = reg.filter((c) => c.blocked).length;
+  const fp = clean.filter((c) => c.blocked).length;
+  return {
+    baseline, // { total, byKind } - proof the prior debt was grandfathered
+    catchRate: reg.length ? tp / reg.length : null, // want 1.0
+    falseBlockRate: clean.length ? fp / clean.length : null, // want 0.0
+    matrix: { tp, fn: reg.length - tp, tn: clean.length - fp, fp },
+    cases,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const config = JSON.parse(fs.readFileSync(process.argv[2] || 'pilot.json', 'utf8'));
+  const r = runGuardrailBench(config);
+  console.log(JSON.stringify(r, null, 2));
+}

--- a/benchmarks/bench-matcher.mjs
+++ b/benchmarks/bench-matcher.mjs
@@ -1,0 +1,108 @@
+/**
+ * Benchmark #2 - Matcher robustness under drift (deterministic, no API key).
+ *
+ * The foundation under the guardrail: a finding's identity must survive
+ * mechanical churn (reformat, line-shifts, file renames) so the gate doesn't
+ * cry "net-new!" at code that didn't actually change. A noisy matcher → false
+ * blocks → teams disable dxkit, so this number IS the adoption risk, quantified.
+ *
+ * Method: baseline the target, apply a transform that introduces NO new finding,
+ * re-run the guardrail. Any net-new verdict is a FALSE REGRESSION (matcher miss).
+ *
+ * Output per transform: { blocked, netNew } - both should be 0 / false.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { DXKIT, BENCH_MODE, sh, resetTo, saveBaseline, restoreBaseline, createBaseline, guardrailExitCode } from './lib.mjs';
+
+function sourceFiles(repoDir) {
+  try {
+    return sh(`git ls-files '*.js' '*.ts' | head -200`, repoDir)
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+const TRANSFORMS = [
+  {
+    name: 'line-shift (+3 comment lines per file)',
+    apply(repoDir) {
+      for (const f of sourceFiles(repoDir)) {
+        const abs = path.join(repoDir, f);
+        const banner = '// dxkit-bench\n// drift\n// shim\n';
+        fs.writeFileSync(abs, banner + fs.readFileSync(abs, 'utf8'));
+      }
+    },
+  },
+  {
+    name: 'file-rename (move a few source files)',
+    apply(repoDir) {
+      const files = sourceFiles(repoDir).slice(0, 5);
+      for (const f of files) {
+        const moved = f.replace(/(\.[jt]s)$/, '.renamed$1');
+        try {
+          sh(`git mv ${JSON.stringify(f)} ${JSON.stringify(moved)} 2>/dev/null || mv ${JSON.stringify(f)} ${JSON.stringify(moved)}`, repoDir);
+        } catch {
+          /* skip files that can't move */
+        }
+      }
+    },
+  },
+];
+
+function netNewCount(repoDir) {
+  // Prefer a structured verdict if the guardrail exposes JSON; else fall back
+  // to exit code only (netNew unknown → reported as null).
+  try {
+    const out = sh(`${DXKIT} guardrail check --mode ${BENCH_MODE} --json 2>/dev/null`, repoDir);
+    const j = JSON.parse(out);
+    let n = 0;
+    (function walk(x) {
+      if (!x || typeof x !== 'object') return;
+      if (Array.isArray(x)) return x.forEach(walk);
+      if (x.classification === 'added' || x.status === 'added') n++;
+      for (const v of Object.values(x)) walk(v);
+    })(j);
+    return n;
+  } catch {
+    return null;
+  }
+}
+
+export function runMatcherBench(config) {
+  const repoDir = config.repoDir;
+  const tmpBase = path.join(repoDir, '..', '_baseline_matcher.json');
+
+  resetTo(repoDir, config.pinnedCommit);
+  const baseline = createBaseline(repoDir);
+  saveBaseline(repoDir, tmpBase);
+
+  const results = [];
+  for (const t of TRANSFORMS) {
+    resetTo(repoDir, config.pinnedCommit);
+    restoreBaseline(repoDir, tmpBase);
+    t.apply(repoDir);
+    sh(`git add -A 2>/dev/null || true`, repoDir);
+    // Commit the transform so dxkit's git-aware line/rename relocation can
+    // diff baseline-commit → HEAD. Staging alone leaves only the content
+    // fingerprint's ±2-line fuzz, which a +3-line insertion exceeds - a
+    // benchmark-harness artifact, not a matcher miss. The isolation +
+    // guardrail benches already commit their changes; this matches them
+    // (and the real CI/PR flow the matcher models).
+    sh(`git -c user.email=bench@dxkit -c user.name=bench commit -qm ${JSON.stringify('matcher-transform: ' + t.name)} 2>/dev/null || true`, repoDir);
+    const code = guardrailExitCode(repoDir);
+    results.push({ transform: t.name, blocked: code !== 0, netNew: netNewCount(repoDir) });
+  }
+  resetTo(repoDir, config.pinnedCommit);
+
+  const falseRegressions = results.filter((r) => r.blocked).length;
+  return { baseline, falseRegressionRate: falseRegressions / results.length, results };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const config = JSON.parse(fs.readFileSync(process.argv[2] || 'pilot.json', 'utf8'));
+  console.log(JSON.stringify(runMatcherBench(config), null, 2));
+}

--- a/benchmarks/bench-netnew-isolation.mjs
+++ b/benchmarks/bench-netnew-isolation.mjs
@@ -1,0 +1,144 @@
+/**
+ * Benchmark #4 - Net-new isolation on a brownfield repo (deterministic, no key).
+ *
+ * THE differentiated value, made into a number. A real repo carries debt (here
+ * NodeGoat: ~221 pre-existing findings). An agent fixing one finding can ALSO
+ * introduce a net-new regression. The question that separates dxkit from a raw
+ * scanner is: when that regression appears, does the gate ISOLATE it, or is it
+ * lost in the noise of the existing debt?
+ *
+ * Two gate POLICIES over the SAME findings from the SAME scanner (so we measure
+ * gate logic, not scanner quality):
+ *
+ *   Arm A - "scanner, no baseline": the default local posture of `snyk test`,
+ *           `semgrep --error`, `npm audit`, `gitleaks` run pre-commit. Verdict =
+ *           "fail if ANY finding exists." On a repo with prior debt this is RED
+ *           before the agent touches anything → RED after → no signal. To go
+ *           green you must clear ALL findings (or disable the gate).
+ *
+ *   Arm B - "dxkit committed baseline": grandfather the prior debt, block only
+ *           net-new. GREEN before → RED on exactly the 1 regression → precise.
+ *
+ * Output per regression: the two verdicts + the "fix-to-green tax" (how many
+ * findings each policy demands you clear before the gate passes).
+ *
+ * NOTE on fairness: Snyk/Sonar's SERVER-SIDE PR check CAN grandfather vs a base
+ * branch. Arm A models their LOCAL, pre-commit, in-the-agent-loop posture - the
+ * setting dxkit targets - NOT a claim that they can't gate net-new anywhere.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  DXKIT,
+  BENCH_MODE,
+  sh,
+  resetTo,
+  saveBaseline,
+  restoreBaseline,
+  createBaseline,
+  guardrailExitCode,
+} from './lib.mjs';
+
+// "Agent introduces a net-new regression while fixing." Each writes a NEW file
+// carrying one KNOWN finding the bundled scanner detects (semgrep SAST).
+const REGRESSIONS = [
+  {
+    name: 'agent-adds-eval-injection',
+    apply(repoDir) {
+      fs.writeFileSync(
+        path.join(repoDir, 'dxkit_bench_evil.js'),
+        'module.exports = (req) => { return eval(req.query.x); };\n',
+      );
+    },
+  },
+  {
+    name: 'agent-adds-command-injection',
+    apply(repoDir) {
+      fs.writeFileSync(
+        path.join(repoDir, 'dxkit_bench_cmd.js'),
+        "const cp=require('child_process'); module.exports=(q)=>cp.exec('ls '+q);\n",
+      );
+    },
+  },
+];
+
+/** Count net-new findings the dxkit guardrail attributes to this change. */
+function netNewCount(repoDir) {
+  try {
+    const out = sh(`${DXKIT} guardrail check --mode ${BENCH_MODE} --json 2>/dev/null`, repoDir);
+    const j = JSON.parse(out);
+    let n = 0;
+    (function walk(x) {
+      if (!x || typeof x !== 'object') return;
+      if (Array.isArray(x)) return x.forEach(walk);
+      if (x.classification === 'added' || x.status === 'added') n++;
+      for (const v of Object.values(x)) walk(v);
+    })(j);
+    return n;
+  } catch {
+    return null;
+  }
+}
+
+export function runNetNewIsolationBench(config) {
+  const repoDir = config.repoDir;
+  const tmpBase = path.join(repoDir, '..', '_baseline_isolation.json');
+
+  // Snapshot the brownfield debt once (this IS the "raw scanner total" - the
+  // count Arm A's zero-tolerance gate is already red about).
+  resetTo(repoDir, config.pinnedCommit);
+  const baseline = createBaseline(repoDir); // { total, byKind }
+  saveBaseline(repoDir, tmpBase);
+  const debtTotal = baseline.total;
+
+  const cases = [];
+  for (const r of REGRESSIONS) {
+    resetTo(repoDir, config.pinnedCommit);
+    restoreBaseline(repoDir, tmpBase);
+    r.apply(repoDir);
+    sh(`git add -A 2>/dev/null || true`, repoDir);
+
+    // Arm B - dxkit committed baseline.
+    const bBlocked = guardrailExitCode(repoDir) !== 0;
+    const netNew = netNewCount(repoDir);
+    const newCount = netNew === null ? 1 : netNew; // we introduced one known finding
+
+    // Arm A - scanner, no baseline. Same findings; policy = "fail if any."
+    // Red both before (debtTotal > 0) and after (debtTotal + newCount > 0), so
+    // the regression is NOT isolated. Fix-to-green = clear everything.
+    const rawTotalAfter = debtTotal + newCount;
+    const armA = {
+      gateBefore: debtTotal > 0 ? 'RED' : 'GREEN',
+      gateAfter: rawTotalAfter > 0 ? 'RED' : 'GREEN',
+      isolatesRegression: false, // red → red: no delta signal
+      fixToGreen: rawTotalAfter, // must clear all findings
+    };
+    const armB = {
+      gateBefore: 'GREEN', // prior debt grandfathered (asserted by createBaseline)
+      gateAfter: bBlocked ? 'RED' : 'GREEN',
+      isolatesRegression: bBlocked && armA.gateBefore !== 'GREEN' ? true : bBlocked,
+      fixToGreen: newCount, // clear just the regression
+    };
+    cases.push({ name: r.name, netNew: newCount, armA, armB });
+  }
+  resetTo(repoDir, config.pinnedCommit);
+
+  const isolated = cases.filter((c) => c.armB.isolatesRegression && !c.armA.isolatesRegression).length;
+  const avg = (xs) => (xs.length ? Math.round(xs.reduce((a, b) => a + b, 0) / xs.length) : 0);
+  return {
+    debtTotal,
+    debtByKind: baseline.byKind,
+    isolationWinRate: cases.length ? isolated / cases.length : null, // want 1.0
+    fixToGreenTax: {
+      noBaseline: avg(cases.map((c) => c.armA.fixToGreen)), // ~ debtTotal+1
+      dxkit: avg(cases.map((c) => c.armB.fixToGreen)), // ~ 1
+    },
+    cases,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const config = JSON.parse(fs.readFileSync(process.argv[2] || 'pilot.json', 'utf8'));
+  const r = runNetNewIsolationBench(config);
+  console.log(JSON.stringify(r, null, 2));
+}

--- a/benchmarks/config.example.json
+++ b/benchmarks/config.example.json
@@ -1,0 +1,4 @@
+{
+  "repoDir": "/absolute/path/to/your/checkout",
+  "pinnedCommit": "c5cb68a"
+}

--- a/benchmarks/lib.mjs
+++ b/benchmarks/lib.mjs
@@ -1,0 +1,121 @@
+/** Shared helpers for the dxkit benchmark pipeline. */
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// This file lives at <repo-root>/benchmarks/lib.mjs.
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const LOCAL_DIST = path.join(REPO_ROOT, 'dist/index.js');
+// Prefer a locally-built dxkit (fast, and exercises the current source). If the
+// repo is not built, fall back to the published CLI. Override with the DXKIT env
+// var, e.g. DXKIT="npx --yes @vyuhlabs/dxkit" or DXKIT="node /path/to/dist/index.js".
+export const DXKIT =
+  process.env.DXKIT || (fs.existsSync(LOCAL_DIST) ? `node ${LOCAL_DIST}` : 'npx --yes @vyuhlabs/dxkit');
+
+// 10 min: a full baseline create / guardrail check runs osv over every
+// dependency (network-variable on 150+ deps), and the wall-clock timer keeps
+// counting if the machine suspends mid-command - 3 min was too tight and tripped
+// ETIMEDOUT overnight.
+export function sh(cmd, cwd, timeout = 600000) {
+  return execSync(cmd, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout });
+}
+
+/** Run a command, return its exit code (0 = ok) without throwing. */
+export function exitCode(cmd, cwd, timeout = 600000) {
+  try {
+    execSync(cmd, { cwd, stdio: ['ignore', 'ignore', 'ignore'], timeout });
+    return 0;
+  } catch (e) {
+    return typeof e.status === 'number' ? e.status : 1;
+  }
+}
+
+/** Reset the target to a pinned commit but PRESERVE `.dxkit/` (the baseline
+ *  lives there, gitignored - a plain `git clean` would wipe it). */
+export function resetTo(repoDir, commit) {
+  sh(`git checkout -- . 2>/dev/null || true`, repoDir);
+  sh(`git reset --hard ${commit} 2>/dev/null`, repoDir);
+  sh(`git clean -fdq -e .dxkit 2>/dev/null || true`, repoDir);
+}
+
+// The benchmark deliberately uses committed-full mode. dxkit auto-selects
+// ref-based mode on PUBLIC repos (NodeGoat is public), which writes NO baseline
+// file and re-gathers the "prior" side from origin/master on demand - defeating
+// the save/restore-a-frozen-baseline design and making every pre-existing
+// finding read as net-new. Forcing the mode keeps the prior side a fixed file
+// at the pinned commit.
+export const BENCH_MODE = 'committed-full';
+
+/** Create the committed baseline AND pre-flight assert it captured the repo's
+ *  pre-existing debt. The exact bug this guards against (ref-based on a public
+ *  repo) manifests as a MISSING baseline file → caught by the existence check;
+ *  a sparse/empty file is caught by the entry check. Returns a kind breakdown
+ *  so the caller can show the human that grandfathering is real. */
+export function createBaseline(repoDir) {
+  sh(`${DXKIT} baseline create --force --mode ${BENCH_MODE}`, repoDir);
+  const file = path.join(repoDir, '.dxkit/baselines/main.json');
+  if (!fs.existsSync(file)) {
+    throw new Error(
+      `baseline pre-flight FAILED: no committed baseline written at ${file}. ` +
+        `dxkit likely auto-selected ref-based mode (public repo) despite ` +
+        `--mode ${BENCH_MODE}; every prior finding would read as net-new.`,
+    );
+  }
+  const b = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const entries = b.entries || b.findings || [];
+  if (entries.length === 0) {
+    throw new Error(`baseline pre-flight FAILED: ${file} has 0 entries.`);
+  }
+  const byKind = {};
+  for (const e of entries) {
+    const k = e.kind || e.type || '?';
+    byKind[k] = (byKind[k] || 0) + 1;
+  }
+  return { total: entries.length, byKind };
+}
+
+/** Guardrail check at the frozen committed baseline (mode-locked). */
+export function guardrailExitCode(repoDir) {
+  return exitCode(`${DXKIT} guardrail check --mode ${BENCH_MODE}`, repoDir);
+}
+
+export function saveBaseline(repoDir, to) {
+  const src = path.join(repoDir, '.dxkit/baselines/main.json');
+  if (fs.existsSync(src)) fs.copyFileSync(src, to);
+}
+export function restoreBaseline(repoDir, from) {
+  if (!fs.existsSync(from)) return;
+  const dstDir = path.join(repoDir, '.dxkit/baselines');
+  fs.mkdirSync(dstDir, { recursive: true });
+  fs.copyFileSync(from, path.join(dstDir, 'main.json'));
+}
+
+export function readJson(p, dflt = null) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return dflt;
+  }
+}
+export function writeJson(p, v) {
+  fs.writeFileSync(p, JSON.stringify(v, null, 2));
+}
+
+/** Count current code+secret findings via a vulnerabilities scan (used to
+ *  detect "did this change introduce a new finding"). */
+export function scanFindingCount(repoDir) {
+  try {
+    const out = sh(`${DXKIT} vulnerabilities --json 2>/dev/null`, repoDir);
+    const json = JSON.parse(out);
+    let n = 0;
+    (function walk(x) {
+      if (!x || typeof x !== 'object') return;
+      if (Array.isArray(x)) return x.forEach(walk);
+      if (typeof x.fingerprint === 'string' && typeof x.file === 'string') n++;
+      for (const v of Object.values(x)) walk(v);
+    })(json);
+    return n;
+  } catch {
+    return -1;
+  }
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,374 +1,470 @@
 # dxkit benchmarks: methodology and findings
 
-> Sanitized public report. The honest claim throughout is predictability, not
-> reduction. Every headline number carries its caveats; the claim ledger and
-> "what this does not prove" are up front.
+> A sanitized public report. The claim throughout is predictability rather than
+> reduction. Every headline number is presented with its caveats, and the claim
+> ledger and the "what this does not prove" section appear before the evidence.
 
 ---
 
-## TL;DR
+## Summary
 
-Autonomous coding loops (an agent that keeps editing until it decides to
-stop) **ship net-new debt and declare "done" most of the time** — measured at
-**69%** of runs with a vanilla loop, **56%** even when the project prompt
-explicitly tells the agent to self-check. A deterministic **Stop-gate** that
-re-runs a net-new guardrail on every stop drops that to **0%** (reps=8). The
-gate doesn't detect anything new — it enforces, at the loop's tempo, the
-findings dxkit already computes, and feeds them back to the model to repair.
+In our loop benchmark, autonomous coding loops (an agent that keeps editing
+until it decides to stop) frequently stopped with detector-backed net-new debt
+still present.
 
-**dxkit = predictability, not reduction.** Three independent measurements,
-one through-line:
+- A vanilla Claude Code-style loop left net-new debt in 11 of 16 runs.
+- A prompt-only self-check still left it in 9 of 16 runs.
+- With dxkit's Stop-gate, we observed 0 of 16 escapes.
 
-| Layer              | What it bounds                    | Headline                                                |
-| ------------------ | --------------------------------- | ------------------------------------------------------- |
-| Deterministic gate | unsafe final state                | 69%/56% → **0%** escape rate                            |
-| Code graph         | the cost + completeness **tails** | worst-case session tokens **−57%**, variance **halved** |
-| Durable identity   | finding identity under churn      | **0%** false "net-new" on line-shifts / renames         |
+Each figure is n=16 per arm, from 8 repetitions on each of two tasks.
 
-It is **not** a scanner (it ingests Snyk/CodeQL/SARIF), **not** a token-saver
-(mean tokens are often flat), and **not** "more accurate than an LLM" (a
-frontier model with a baseline is an accurate judge — just not a cheap,
-reproducible, or in-loop one).
+The dxkit arm did not discover a new class of bugs. On every stop it re-ran a
+deterministic net-new guardrail, blocked any stop that left debt in the tree,
+and returned the specific finding to the model for repair.
+
+The claim is predictability rather than universal reduction. Three independent
+measurements share one through-line.
+
+| Layer              | What it reduces                       | Result                                                       |
+| ------------------ | ------------------------------------- | ------------------------------------------------------------ |
+| Deterministic gate | unsafe final states                   | vanilla 11/16, checklist 9/16, dxkit 0/16 observed escapes   |
+| Code graph         | observed large-repo exploration tails | worst-case session tokens 57% lower, variance roughly halved |
+| Durable identity   | false "net-new" under churn           | 0 false net-new on tested line shifts and renames            |
+
+dxkit is not a scanner; it ingests Snyk, CodeQL, and other SARIF sources. It is
+not a token-saver, because mean token counts are often flat. It is not "more
+accurate than an LLM": a frontier model can be an accurate judge when given
+enough baseline state. In our benchmark, Opus-with-baseline held its accuracy,
+but it was not cheap, reproducible, or in-loop.
 
 ---
 
 ## Claim ledger
 
-Every claim below, its strength, and the exact public wording we stand behind.
-Read this first; the rest of the doc is the evidence.
+Each claim below is listed with its strength, its evidence, and the exact public
+wording we stand behind. This table is the place to start; the rest of the
+document is the supporting evidence.
 
-| Claim                                              | Status          | Evidence                                           | Public wording                                              |
-| -------------------------------------------------- | --------------- | -------------------------------------------------- | ----------------------------------------------------------- |
-| The Stop-gate prevents observed loop escapes       | Strong          | loop benchmark, 8 reps × 2 tasks                   | "0/16 observed escapes in our benchmark"                    |
-| Prompt-only self-check is insufficient             | Strong          | checklist arm 9/16 escapes                         | "prompting reduced but did not eliminate escapes"           |
-| Gate identity is deterministic under tested churn  | Strong          | offline matcher benches                            | "0 false net-new on tested line-shift / rename cases"       |
-| LLM-as-gate has cost + reproducibility issues      | Strong          | gate-vs-LLM benchmark, 5 reps × 2 models × 2 repos | "an LLM can judge, but not cheaply or reproducibly in-loop" |
-| Graph context bounds large-repo token tails        | Moderate–strong | Sonnet session study, 30 sessions                  | "lower mean / tail / variance on a large repo"              |
-| dxkit improves _every_ agent session               | **Not claimed** | —                                                  | do not say this                                             |
-| dxkit detects _more_ vulnerabilities than scanners | **Not claimed** | —                                                  | do not say this                                             |
+| Claim                                                 | Status          | Evidence                                           | Public wording                                              |
+| ----------------------------------------------------- | --------------- | -------------------------------------------------- | ----------------------------------------------------------- |
+| The Stop-gate prevents observed loop escapes          | Strong          | loop benchmark, 8 reps × 2 tasks                   | "0/16 observed escapes in our benchmark"                    |
+| Prompt-only self-check is insufficient                | Strong          | checklist arm, 9/16 escapes                        | "prompting reduced but did not eliminate escapes"           |
+| Gate identity is deterministic under tested churn     | Strong          | offline matcher benches                            | "0 false net-new on tested line-shift and rename cases"     |
+| LLM-as-gate has cost and reproducibility issues       | Strong          | gate-vs-LLM benchmark, 5 reps × 2 models × 2 repos | "an LLM can judge, but not cheaply or reproducibly in-loop" |
+| Graph context reduces observed large-repo token tails | Moderate–strong | Sonnet session study, 30 sessions                  | "lower mean, tail, and variance on a large repo"            |
+| Test-gap gating is safe as a default                  | Not claimed     | repair cost of 1.1M–1.6M tokens in validation      | default remains `security-only`; `full-debt` is opt-in      |
+| dxkit improves every agent session                    | Not claimed     | n/a                                                | do not say this                                             |
+| dxkit detects more vulnerabilities than scanners      | Not claimed     | n/a                                                | do not say this                                             |
 
 ## What this does not prove
 
-- **0/16 is observed, not proven-zero.** The gate blocked every detector-backed
-  finding surfaced in these seeded runs; that is not a proof that no escape is
-  possible.
-- **dxkit is not a scanner** and does not claim to find more bugs than Snyk,
-  CodeQL, Semgrep, or a frontier model. It ingests them.
-- **The loop benchmark uses synthetic, detector-backed tasks** plus small
-  real-repo validation — not a CVE corpus.
-- **The loop headline includes test-gap behavior**, which is the opt-in
-  `full-debt` preset; the product default (`security-only`) gates secrets +
-  crit/high vulns. (See study I.)
-- **Graph context does not guarantee fewer tokens** in every session; the
-  measured win is lower mean / tail / variance on large, connected tasks.
-- **Opus session results are deferred**; session numbers are Sonnet.
+- The 0/16 result is observed, not proven-zero. The gate blocked every
+  detector-backed finding surfaced in these seeded runs, which is not a proof
+  that no escape is possible.
+- dxkit is not a scanner and does not claim to find more bugs than Snyk, CodeQL,
+  Semgrep, or a frontier model. It ingests their findings.
+- The loop benchmark uses synthetic, detector-backed tasks together with small
+  real-repo validation, not a CVE corpus.
+- The loop headline includes test-gap behavior, which belongs to the opt-in
+  `full-debt` preset. The product default, `security-only`, gates secrets and
+  high-severity vulnerabilities (see study I).
+- Graph context does not guarantee fewer tokens in every session. The measured
+  effect is lower mean, tail, and variance on large, connected tasks.
+- Opus session results are deferred. Session numbers are from Sonnet.
 
 ---
 
-## The thesis: predictability, not reduction
+## The thesis: predictability rather than reduction
 
-A scanner answers "what's wrong?" An autonomous loop needs a different
-answer: **"did I just make it worse, and can I stop?"** That question has to
-be answered the same way every time, in seconds, locally, with feedback the
-_model_ can act on. That's a systems property, not a detection problem — and
-it's the gap dxkit fills:
+A scanner answers the question "what is wrong?" An autonomous loop needs a
+different answer: "did I just make this worse, and may I stop?" That question
+has to be answered the same way every time, in seconds, locally, with feedback
+the model itself can act on. It is a systems property rather than a detection
+problem, and it is the gap dxkit fills, in three parts.
 
-1. **A deterministic net-new gate.** Same input → same verdict, one exit
-   code, $0, offline. Pre-existing debt is grandfathered by a baseline; only
-   regressions block.
-2. **A code graph** that bounds the agent's worst-case exploration cost and
-   completeness, rather than lowering its average cost.
-3. **Durable, content-anchored finding identity** that survives line shifts
-   and renames, so "net-new" means net-new and a committed baseline keeps
-   matching across machines and CI.
+1. A deterministic net-new gate. The same input yields the same verdict, as one
+   exit code, at no LLM cost, offline. Pre-existing debt is grandfathered by a
+   baseline, so only regressions block.
+2. A code graph that reduces the agent's observed worst-case exploration cost,
+   rather than lowering its average cost.
+3. Durable, content-anchored finding identity that survives line shifts and
+   renames, so that "net-new" continues to mean net-new and a committed baseline
+   keeps matching across machines and CI.
 
 ---
 
-## What dxkit is / is NOT (read this before the numbers)
+## What dxkit is, and is not
 
-- **Is:** a deterministic verification + governance layer that stitches
-  established tools (gitleaks, community Semgrep, OSV/npm-audit, jscpd, a
-  code-graph builder, cloc) and **ingests** external engines (Snyk Code,
-  CodeQL, any SARIF), then adds the layer they lack — a net-new gate, a
-  brownfield baseline, durable identity, and graph-scoped context.
-- **Is NOT a scanner.** dxkit does not claim to find more bugs than Snyk or
-  CodeQL. It ingests their findings and makes them enforceable.
-- **Is NOT "the LLM is wrong."** With a baseline provided, a frontier model
-  judges net-new accurately. dxkit's wins are _determinism, $0/check, O(1) at
-  scale, and reproducible identity_ — properties that hold regardless of
-  model IQ.
-- **Is NOT a token-saver.** On a real session the mean token count is often
-  flat; the win is a bounded worst case, not a smaller average.
+dxkit is a deterministic verification and governance layer. It stitches together
+established tools (gitleaks, community Semgrep, OSV and npm-audit, jscpd, a
+code-graph builder, and cloc) and ingests external engines (Snyk Code, CodeQL,
+and any SARIF source). On top of those it adds the layer they lack: a net-new
+gate, a brownfield baseline, durable identity, and graph-scoped context.
+
+It is not a scanner. dxkit does not claim to find more bugs than Snyk or CodeQL;
+it ingests their findings and makes them enforceable. It is not a claim that the
+LLM is wrong: given enough baseline state, a frontier model can judge net-new
+findings accurately, and in our benchmark Opus-with-baseline did so. dxkit's
+advantages are determinism, no LLM cost per check, a prompt
+that does not grow with the baseline, and reproducible identity, all of which
+hold regardless of model capability. Finally, it is not a token-saver. On a real
+session the mean token count is often flat, and the measured benefit is a lower
+observed worst case rather than a smaller average.
 
 ---
 
 ## Methodology (shared across studies)
 
-- **Models:** Claude Sonnet 4.6 for agent-session runs; Claude Opus 4.8 added
-  as a steelman in the gate-vs-LLM study. Sessions run through `claude -p
---output-format stream-json` and are parsed from the raw event stream.
-- **Substrates (two real OSS repos, pinned, sanitized):**
-  - **"small app"** — a small Express app (~2k LOC, an OWASP training
-    target). dxkit baseline: **205 pre-existing findings**.
-  - **"large monorepo"** — a large TypeScript monorepo (~574k LOC, Yarn/Nx).
-    dxkit baseline: **1,020 findings**; code graph: **18,948 nodes / 20,012
-    edges**.
-  - Plus **synthetic repos** for the loop-safety study (small, controlled,
-    one known finding injected per task).
-- **Determinism tier (no API key, fully reproducible):** the gate-correctness
-  benches run offline with seeded regressions + clean/ churn commits and
-  produce a confusion matrix. Anyone can re-run them.
-- **Reps:** safety study **8 reps** per arm per task; session study **3 reps**
-  per cell (30 sessions); gate-vs-LLM **5 reps** per case across 2 models × 2
-  repos. Point estimates without reps are flagged as such.
-- **Honesty discipline:** several headline claims were **retracted** mid-study
-  when traced to harness bugs or unlucky single draws (noted inline). The
-  benchmarks also fed the product — two findings shipped as releases.
+Provenance. These results were produced with dxkit version 2.13.0, at report and
+harness commit `7f801a4`, during June 2026, with model pricing as of June 2026.
+Agent runs were executed through a Claude Max subscription, so per-run dollar
+figures are the CLI's equivalent-cost estimates. They are valid for relative
+comparison between arms rather than as literal API-console charges.
+
+"Sanitized" here means that no proprietary code or private traces are included.
+Public repository names and commit pins are disclosed for reproducibility.
+
+Models. We used Claude Sonnet 4.6 for agent-session runs, and added Claude Opus
+4.8 as a steelman in the gate-vs-LLM study. Sessions ran through `claude -p
+--output-format stream-json` and were parsed from the raw event stream.
+
+Substrates. Two real, public open-source repositories, each pinned to a commit.
+
+- NodeGoat ([OWASP NodeGoat](https://github.com/OWASP/NodeGoat)) is a
+  deliberately vulnerable Node.js and Express training application of roughly 2k
+  lines (Apache-2.0), pinned at commit `c5cb68a`. Its vulnerabilities are
+  intentional and publicly documented, which makes it a clean target for a
+  net-new gate. The dxkit baseline contains 205 pre-existing findings. It is
+  referred to below as the "small app."
+- Strapi ([strapi/strapi](https://github.com/strapi/strapi)) is a large
+  TypeScript monorepo of roughly 574k lines (Yarn and Nx), pinned at commit
+  `dc49217`. Its code graph has 18,948 nodes and 20,012 edges. The dxkit baseline
+  contains 1,020 grandfathered brownfield items, which are overwhelmingly
+  test-gaps, duplication, and quality debt rather than vulnerabilities; this is
+  the pre-existing debt the gate grandfathers so that only regressions block. It
+  is referred to below as the "large monorepo."
+- The loop-safety study also uses synthetic repositories: small and controlled,
+  with one known finding injected per task.
+
+Independence and trademarks. dxkit is an independent project. It is not
+affiliated with or endorsed by OWASP, Strapi, or any benchmarked project, and
+trademarks belong to their owners. The benchmarks run on pinned public commits
+and characterize the agent's behavior under each tool, not the quality or
+security of these projects.
+
+Determinism tier. The gate-correctness benches run offline, with no API key,
+using seeded regressions together with clean and churn commits, and produce a
+confusion matrix. Anyone can re-run them.
+
+Repetitions. The safety study uses 8 repetitions per arm per task; the session
+study uses 3 repetitions per cell (30 sessions); the gate-vs-LLM study uses 5
+repetitions per case across 2 models and 2 repositories. Point estimates without
+repetitions are flagged as such.
+
+Process. Several headline claims were retracted mid-study once they were traced
+to harness bugs or to unlucky single draws; these are noted inline. The
+benchmarks also fed back into the product, and two findings shipped as releases.
 
 ---
 
 ## Findings
 
-### I. Loop safety — the Stop-gate (the headline)
+### I. Loop safety and the Stop-gate
 
-**Question:** how often does an autonomous loop ship net-new debt and declare
-done, and does a deterministic gate prevent it where a prompt doesn't?
+Question. How often does an autonomous loop ship net-new debt and declare itself
+done, and does a deterministic gate prevent this where a prompt does not?
 
-**Method:** `bench-loop.mjs`. Four arms — **vanilla** (no gate), **checklist**
-(no gate; the project prompt tells the agent to self-review for untested code
-_and_ secrets), **dxkit** (Stop-gate hook + project norm), **deferred**
-(vanilla, then a separate cold session fixes the debt — a proxy for the
-"detect on CI, fix later" model). Two tasks (a test-gap trap and a
-secret/hardcode trap), **8 reps each**, Sonnet 4.6. The metric is the **final
-tree** measured by an identical post-hoc guardrail check: did the loop stop
-with net-new debt still present.
+Method. The harness is `bench-loop.mjs`, with four arms. The vanilla arm has no
+gate. The checklist arm has no gate, but the project prompt asks the agent to
+self-review for untested code and for secrets. The dxkit arm wires the Stop-gate
+hook together with a project norm. The deferred arm runs the vanilla loop and
+then uses a separate cold session to fix the debt, as a proxy for the
+detect-on-CI-fix-later model. We used two tasks, a test-gap trap and a
+secret-hardcode trap, with 8 repetitions each, on Sonnet 4.6. The metric is the
+final tree, measured by an identical post-hoc guardrail check: did the loop stop
+with net-new debt still present?
 
-**Results — escape rate (ships net-new debt, never fixed):**
+Results (escape rate, where the loop ships net-new debt and never fixes it):
 
-| arm                        | escape rate     |
-| -------------------------- | --------------- |
-| vanilla                    | **69%** (11/16) |
-| checklist (prompt-only)    | **56%** (9/16)  |
-| dxkit (deterministic gate) | **0%** (0/16)   |
+| arm                        | observed escapes |
+| -------------------------- | ---------------- |
+| vanilla                    | 11/16 (69%)      |
+| checklist (prompt-only)    | 9/16 (56%)       |
+| dxkit (deterministic gate) | 0/16 (observed)  |
 
-- The checklist arm **named both failure modes in the prompt** and still
-  shipped test-gaps 7/8 and hardcoded secrets 2/8. Prompting misses even what
-  you explicitly asked for; the gate is mechanical.
-- The dxkit arm caught and **repaired** every net-new finding (block →
-  model fixes → re-stops clean), with no thrashing.
+The deferred arm is excluded from this table because it intentionally fixes the
+debt in a separate cold session. It is used only for the cost-of-deferral
+comparison below.
 
-**Cost of deferral (in-loop vs fix-it-later):** fixing in the loop is
-**cheaper** than deferring to a cold session — the deferred arm cost **+49%**
-tokens / +51% turns on the test-gap task and **+19%** on the secret task,
-because the cold fixer pays to re-orient in a context it no longer has.
+The checklist arm named both failure modes in the prompt and nonetheless shipped
+test-gaps in 7 of 8 runs and hardcoded secrets in 2 of 8. Prompting misses even
+what you explicitly ask for, whereas the gate is mechanical. The dxkit arm caught
+and repaired every net-new finding: it blocked, the model fixed the finding, and
+the loop re-stopped clean, with no thrashing.
 
-**Real-repo validation (small app, reps=2):** the gate generalized from
-synthetic to a real repo — it blocked on net-new test-gaps, the agent wrote
-real tests in an unfamiliar framework, and it re-stopped clean. That repair
-cost **1.1M–1.6M tokens**, which is exactly why **test-gap gating is opt-in**
-(`full-debt` preset) and **`security-only` is the default** (secrets +
-crit/high vulns — bounded, must-fix, cheap to gate).
+Cost of deferral. Fixing inside the loop was cheaper than deferring to a cold
+session. The deferred arm cost 49% more tokens and 51% more turns on the test-gap
+task, and 19% more tokens on the secret task, because the cold fixer has to
+re-orient in a context it no longer holds.
 
-**Honest caveats:** synthetic tasks are small and detector-backed, not a CVE
-corpus. The secret-specific failure mode is model-dependent — Sonnet 4.6 is
-"secret-secure by default" on an obvious task (it refused to hardcode a live
-key ~62% of the time), so the _test-gap_ trap, not the secret trap, carries
-the headline. An earlier n=1 smoke claimed a ≈0 deferral premium; reps=8
-corrected that to the +19–49% above.
+Real-repo validation (the small app, NodeGoat, with 2 repetitions). The gate
+generalized from synthetic tasks to a real repository. It blocked on net-new
+test-gaps, the agent wrote real tests in an unfamiliar framework, and the loop
+re-stopped clean. That repair cost between 1.1M and 1.6M tokens, which is exactly
+why test-gap gating is opt-in (the `full-debt` preset) while `security-only`,
+covering secrets and high-severity vulnerabilities, is the default. The default
+is bounded, must-fix, and cheap to gate.
 
----
-
-### II. The gate is correct and reproducible (deterministic, $0)
-
-**Question:** does the gate reliably block net-new regressions, pass clean
-changes, and grandfather pre-existing debt — every time?
-
-**Method:** three offline benches (no API key) on both real repos —
-`bench-guardrail.mjs` (seed known regressions + clean edits → confusion
-matrix), `bench-netnew-isolation.mjs` (grandfather all debt, introduce
-exactly one finding), `bench-matcher.mjs` (mechanical churn that adds _no_
-finding — comment-insert line shifts, file renames).
-
-**Results:**
-
-- **100% catch / 0% false-block** on seeded regressions vs clean edits, both
-  repos.
-- **Net-new isolation 100%:** in the large monorepo the gate flags **1
-  against 1,020** grandfathered findings; in the small app **1 against 206**.
-- **Matcher robustness 0% false regressions** across 15 real duplicate blocks
-  under line-shift + rename churn.
-
-**Honest caveat:** the matcher was a **50% defect** in 2.11.1 (a
-duplication-identity bug) — the bench _caught it_, and 2.12.0 fixed it as a
-class (content-anchored identity + a property-based contract test over every
-finding kind). The benchmark drove the release.
+Caveats. The synthetic tasks are small and detector-backed, not a CVE corpus. The
+secret-specific failure mode is model-dependent: Sonnet 4.6 is secret-secure by
+default on an obvious task, refusing to hardcode a live key in about 62% of runs,
+so the test-gap trap rather than the secret trap carries the headline. An earlier
+n=1 smoke test reported a deferral premium of about zero; the 8-repetition run
+corrected this to the 19% to 49% figures above.
 
 ---
 
-### III. Deterministic gate vs LLM-as-the-gate
+### II. The gate is correct and reproducible
 
-**Question:** when an agent or CI asks "is my change safe?", should a
-deterministic gate answer, or should you ask an LLM to _be_ the gate? (This is
-gate-vs-gate, not scanner-vs-scanner.)
+Question. Does the gate reliably block net-new regressions, pass clean changes,
+and grandfather pre-existing debt, every time?
 
-**Method:** `bench-llm-gate.mjs`. 10 seeded cases (7 security regressions, 1
-clean edit, 2 pure-churn refactors), **5 reps**, **both models**, **both
-repos**, ~$51 total. Three arms: dxkit's real verdict; an LLM judging the diff
-**naively** (no baseline); an LLM judging the diff **with the full prior
-findings list** (the steelman), at baseline scales 1 → 205 → 1,020.
+Method. Three offline benches (no API key) on both real repositories.
+`bench-guardrail.mjs` seeds known regressions and clean edits and produces a
+confusion matrix. `bench-netnew-isolation.mjs` grandfathers all debt and then
+introduces exactly one finding. `bench-matcher.mjs` applies mechanical churn that
+adds no finding, namely comment-insert line shifts and file renames.
 
-**Results:**
+Results.
 
-- **dxkit: 100% accuracy / 0% flip across reps / $0 / O(1)** at every scale.
-- **The naive LLM false-blocks a pure file-rename refactor 50% of the time**
-  (both models, both repos); Sonnet flip-flopped on a line-shift **40%** of
-  reps — _determinism empirically violated._
-- **Sonnet with the 1,020-finding baseline missed a real open-redirect
-  regression** (it caught it at smaller baselines — it over-grandfathers by
-  similarity as the list grows).
-- **Cost grows with the baseline (a statefulness tax):** Sonnet $0.22 → $1.05
-  → $4.35 per run as the baseline scales 1 → 205 → 1,020; **Opus at 1,020 ≈
-  $28/run.** dxkit is $0 and O(1).
-- Opus held 100% where Sonnet slipped — a smarter model buys scale-robustness
-  at **~6.5× the cost**, still without a reproducibility guarantee.
+- Catch 3/3 and false-block 0/2 on the seeded confusion matrix (tp3, fn0, tn2,
+  fp0): every seeded regression was blocked, and every clean edit passed.
+- Net-new isolation held in both repository cases. The gate isolated exactly the
+  one injected net-new finding: against 1,020 grandfathered items in the large
+  monorepo (Strapi), and against 205 grandfathered items in the small app
+  (NodeGoat), where the dirty scan therefore contains 206 findings in total, the
+  205 grandfathered items plus the one net-new finding.
+- Matcher robustness held on the large monorepo (Strapi), whose baseline
+  contains 15 duplication findings. Line-shift and rename churn produced 0 false
+  regressions, so all 15 duplications kept their identity. (On the small app the
+  same churn likewise produced 0 false regressions, over its 5 duplication
+  findings.)
 
-**Honest caveat:** this is explicitly **not** "the LLM gives wrong answers."
-Opus-with-baseline is an accurate gate. The defensible wins are determinism,
-$0, and O(1) behavior at scale. (An earlier "the LLM decays 80→0%" claim was
-retracted when traced to a harness bug.)
+These are controlled regression suites, not statistical estimates of scanner
+recall. They establish that the gate behaves correctly on the seeded cases, not
+that it would catch every possible regression in the wild.
 
----
-
-### IV. Graph context: bounding exploration tails
-
-**Question:** does the passive code-graph context actually help a real agent
-session, net of the scaffold's overhead?
-
-**Method:** `bench-context-efficiency.mjs` (proxy: 200 sampled symbols,
-whole-file tokens vs `vyuh-dxkit context` slice) and `bench-sessions.mjs`
-(real `claude -p` sessions, naive repo vs dxkit-scaffolded repo with the
-18,948-node graph + a passive hook; 5 tasks × 2 arms × 3 reps = 30 sessions,
-hook fired 100%).
-
-**Results:**
-
-- **Context slices are ~45% smaller** than reading the whole file on average,
-  up to **~34×** on hot/large files (proxy).
-- **Real sessions, large monorepo:** median tokens **≈ tied** (123k vs 154k),
-  **mean −30%** (152k vs 219k), **worst case −57%** (281k vs 652k — the naive
-  agent rabbit-holes; dxkit caps it), **variance roughly halved** (CV 0.41 vs
-  0.72).
-- **Small app:** overhead **≈ 0** (mean tokens identical) — the scaffold tax
-  is negligible and the tail still tightens slightly.
-
-**The honest claim is "predictable tokens, not fewer tokens."** The win is a
-bounded worst case, which is exactly what matters for an unattended loop.
-(A 1-rep smoke once showed 3.5× — a naive outlier, retracted. The same smoke
-caught a stale scaffold whose hook never fired; fixed.)
-
-Why does the benefit appear only on large repos and vanish (or go negative) on
-small ones? The most likely explanation is **Amdahl's law** (section V): graph
-savings are capped by how much of a session is orientation work, and on a small
-repo the fixed scaffold overhead swamps that small share. We treat this as a
-**likely explanation, not a confirmed one** — the model is directionally
-consistent with these numbers, but its parameters (`f`, `O`, `s`) have not yet
-been fit to the session traces, so it remains a hypothesis to be confirmed.
+Caveat. The matcher contained a 50% defect in version 2.11.1, a
+duplication-identity bug. The bench caught it, and version 2.12.0 fixed it as a
+class, with content-anchored identity and a property-based contract test over
+every finding kind. The benchmark drove the release.
 
 ---
 
-### V. When the graph pays — an Amdahl model (why "75× savings" is misleading)
+### III. Deterministic gate versus LLM-as-the-gate
 
-A code-graph tool's viral "~75× token savings" is real for **one structural
-operation** but **never reaches the session level**. Modeling a session as
-orientation work (fraction `f`, replaceable by graph queries at speedup `s`)
-plus fixed scaffold overhead `O` over total tokens `T`:
+Question. When an agent or a CI pipeline asks "is my change safe?", should a
+deterministic gate answer, or should one ask an LLM to be the gate? This is a
+comparison of gate against gate, not of scanner against scanner.
+
+Method. The harness is `bench-llm-gate.mjs`, with 10 seeded cases (7 security
+regressions, 1 clean edit, and 2 pure-churn refactors), 5 repetitions, both
+models, and both repositories, for a total cost of about $51. There are three
+arms: dxkit's actual verdict; an LLM judging the diff naively, with no baseline;
+and an LLM judging the diff with the full prior-findings list as a steelman, at
+baseline sizes of 1, 205, and 1,020.
+
+Results.
+
+- dxkit reached 100% accuracy with 0% flips across repetitions, at no LLM cost
+  and with no prompt-size growth as the baseline grows, at every scale.
+- The naive LLM false-blocked a pure file-rename refactor 50% of the time, across
+  both models and both repositories, and Sonnet flip-flopped on a line shift in
+  40% of repetitions, so determinism was empirically violated.
+- Sonnet with the 1,020-finding baseline missed a real open-redirect regression.
+  It caught this regression at smaller baselines and began over-grandfathering by
+  similarity as the list grew.
+- Cost grows with the baseline, a statefulness tax. Sonnet cost $0.22, $1.05, and
+  $4.35 per run at baseline sizes of 1, 205, and 1,020, and Opus cost about $28
+  per run at 1,020. The LLM-as-gate prompt grows with the baseline, whereas dxkit
+  stores baseline state outside the model context, so its verdict carries no LLM
+  cost and a prompt that does not grow with baseline size.
+- Opus held 100% accuracy where Sonnet slipped. A stronger model buys
+  scale-robustness at roughly 6.5 times the cost, and still without a
+  reproducibility guarantee.
+
+Caveat. This is explicitly not a claim that the LLM gives wrong answers.
+Opus-with-baseline is an accurate gate. The defensible advantages are
+determinism, no LLM cost, and no prompt-size growth at scale. An earlier claim
+that the LLM decayed from 80% to 0% was retracted once it was traced to a harness
+bug.
+
+---
+
+### IV. Graph context and observed exploration tails
+
+Question. Does the passive code-graph context actually help a real agent session,
+net of the scaffold's overhead?
+
+Method. `bench-context-efficiency.mjs` is a proxy measurement over 200 sampled
+symbols, comparing whole-file tokens against a `vyuh-dxkit context` slice.
+`bench-sessions.mjs` runs real `claude -p` sessions on a naive repository and on
+a dxkit-scaffolded repository that carries the 18,948-node graph and a passive
+hook, across 5 tasks, 2 arms, and 3 repetitions, for 30 sessions in total, with
+the hook firing in every session.
+
+Results.
+
+- Context slices were about 45% smaller than reading the whole file on average,
+  and up to about 34 times smaller on hot or large files, in the proxy
+  measurement.
+- On real sessions in the large monorepo (Strapi), median tokens were roughly
+  tied (123k against 154k), the mean was 30% lower (152k against 219k), the worst
+  case was 57% lower (281k against 652k, where the naive arm had a rabbit-hole
+  run and the dxkit arm had a lower observed worst case), and the variance was
+  roughly halved (a
+  coefficient of variation of 0.41 against 0.72).
+- On the small app the overhead was about zero, with identical mean tokens. The
+  scaffold tax is negligible, and the observed tail still tightens slightly.
+
+The claim is predictable tokens rather than fewer tokens. The benefit is a lower
+observed worst case, which is what matters most for an unattended loop. A 1-rep
+smoke test once reported a factor of 3.5, a naive outlier that we retracted; the
+same smoke test surfaced a stale scaffold whose hook never fired, which was
+fixed.
+
+Scope of this study. It measures token and cost behavior and hook firing, not
+independent task-success quality, so on its own it does not rule out the
+possibility of fewer tokens because of less useful work. Future runs should add
+blinded task-success scoring.
+
+Why does the benefit appear only on large repositories, and vanish or turn
+negative on small ones? The most likely explanation is Amdahl's law, developed in
+section V: graph savings are capped by how much of a session is orientation work,
+and on a small repository the fixed scaffold overhead swamps that small share. We
+treat this as a likely explanation rather than a confirmed one. The model is
+directionally consistent with these numbers, but its parameters (`f`, `O`, and
+`s`) have not yet been fit to the session traces, so it remains a hypothesis to
+be confirmed.
+
+---
+
+### V. When the graph pays: an Amdahl model
+
+Large per-operation graph speedups, such as the often-cited figure of roughly 75
+times, do not automatically translate to whole-session savings. Model a session as
+orientation work (a fraction `f`, replaceable by graph queries at speedup `s`)
+plus a fixed scaffold overhead `O`, over total tokens `T`:
 
 ```
 fractional session savings ≈ f·(1 − 1/s) − O/T
 ```
 
-- Even an **infinite** graph speedup caps whole-session savings at `f` (if
-  orientation is 20% of a session, the ceiling is ~20% — not 75×). The "75×"
-  is `s`, a sub-operation asymptote.
-- On a **small** repo, fixed `O` over small `T` dominates → savings go to zero
-  or **negative** (a forced-graph probe cost **+66%** on the small app).
-- On a **large** repo, `O/T` is negligible and `f` is large → the **−30%
-  mean / −57% tail** above.
+- Even an infinite graph speedup caps whole-session savings at `f`. If
+  orientation is 20% of a session, the ceiling is about 20%, not 75 times. The
+  75-times figure is `s`, a sub-operation asymptote.
+- On a small repository the fixed `O` over a small `T` dominates, so savings fall
+  to zero or go negative. A forced-graph probe cost 66% more on the small app.
+- On a large repository `O/T` is negligible and `f` is large, which gives the
+  30% lower mean and 57% lower tail reported above.
 
-**Three decoupled axes of graph value:** (1) mean token efficiency —
-size-gated, often ≈0; (2) **variance/tail — driven by navigability risk, can
-be positive even when the mean is flat** (this is the loop-relevant one); (3)
-structural correctness/grounding — size-independent, outside tokens entirely.
-The firing rule that falls out: **graph-orient only on large, well-connected,
-orientation-heavy work where the workflow actually substitutes queries for
-reads; read directly otherwise.** This is a falsifiable model, not a
-conclusion — `f`, `O`, `s` are directionally consistent with the data but not
-yet numerically fit.
+There are three decoupled axes of graph value. The first is mean token
+efficiency, which is size-gated and often near zero. The second is variance and
+tail behavior, driven by navigability risk, which can be positive even when the
+mean is flat; this is the axis that matters for loops. The third is structural
+correctness and grounding, which is size-independent and lies outside tokens
+entirely. The firing rule that follows is to graph-orient only on large,
+well-connected, orientation-heavy work where the workflow actually substitutes
+queries for reads, and to read directly otherwise. This is a falsifiable model
+rather than a conclusion: `f`, `O`, and `s` are directionally consistent with the
+data but not yet numerically fit.
 
 ---
 
-## Differentiation: why not just Snyk / SonarQube?
+## Differentiation: why not Snyk or SonarQube?
 
-The difference is **architecture and tempo, not detection.** Cloud scanners
-are detection engines on a CI cadence; they were never built to sit inside an
+The difference is one of architecture and tempo, not detection. Cloud scanners
+are detection engines on a CI cadence, and they were never built to sit inside an
 agent's stop decision.
 
-| What a loop's Stop-gate needs            | dxkit                                      | Cloud scanners (Snyk Code / SonarQube) |
-| ---------------------------------------- | ------------------------------------------ | -------------------------------------- |
-| Fires on every stop, in seconds, locally | ✅ $0, offline, instant                    | ❌ cloud round-trip, CI/PR cadence     |
-| Offline / no egress / no auth            | ✅ local + deterministic                   | ❌ upload-to-cloud / server-side gate  |
-| Feedback the **model** can act on        | ✅ `decision:block + reason` → warm repair | ❌ dashboards / PR comments for humans |
-| Reproducible identity offline            | ✅ content-anchored, env-independent       | ⚠️ "new code" defined server-side      |
+| What a loop's Stop-gate needs            | dxkit                               | Cloud scanners (Snyk Code, SonarQube) |
+| ---------------------------------------- | ----------------------------------- | ------------------------------------- |
+| Fires on every stop, in seconds, locally | yes: no LLM cost, offline, instant  | no: cloud round-trip, CI/PR cadence   |
+| Offline, with no egress and no auth      | yes: local and deterministic        | no: upload-to-cloud, server-side gate |
+| Feedback the model can act on            | yes: a block decision plus a reason | no: dashboards and PR comments        |
+| Reproducible identity offline            | yes: content-anchored               | partial: "new code" defined on server |
 
-**Honesty guardrails (or the claim gets dismantled):** do **not** say cloud
-scanners "can't detect net-new" — SonarQube has a new-code quality gate and
-Snyk has delta concepts. Do **not** say in-loop gating is "impossible" with
-them — you _could_ shell a cloud scan in a Stop hook; it'd just be slow,
-networked, authenticated, and untuned to the loop's baseline. The accurate
-claim is **"not architecturally designed for per-iteration local gating —
-and optionally a detection source dxkit ingests."**
-
----
-
-## Why now (market context)
-
-- Claude Code is reportedly behind **~4% of all public GitHub commits**; loop
-  workflows generate **8× more code, 80%+ AI-authored**.
-- The recognized hard part of a loop is the **gate**. Today's loop validation
-  is tests + linter — which catch _broken_, not _regressed_: there's no
-  net-new-vs-known notion, and an LLM-judge gate adds cost, latency, and
-  non-determinism on every iteration.
-- The sharpest one-line framing: **"the deterministic guardrail your Claude
-  Code loops need."**
+A note on what not to claim, so that the comparison holds up. Do not say cloud
+scanners cannot detect net-new findings, because SonarQube has a new-code quality
+gate and Snyk has delta concepts. Do not say in-loop gating is impossible with
+them, because one could shell a cloud scan inside a Stop hook; it would simply be
+slow, networked, authenticated, and untuned to the loop's baseline. The accurate
+statement is that cloud scanners are not architecturally designed for
+per-iteration local gating, and that they are optionally a detection source dxkit
+can ingest.
 
 ---
 
-## Honest limitations (the disclaimer slide)
+## Why now
 
-- **Two real repos** + synthetic cases. Seeded findings are detector-backed
-  but **not a CVE corpus**; broader language/repo generality is future work.
-- **Not better detection.** dxkit ingests Snyk/CodeQL; it doesn't out-detect
-  them.
-- **Context-efficiency is a proxy**; the session study is the real test.
-- **The Opus session arm is deferred**; session numbers are Sonnet.
-- **The Amdahl model is directional**, not a numerical fit.
-- Several sub-claims were **retracted** when traced to harness bugs or single
-  unlucky draws — they're documented, not buried.
+Coding-agent workflows are moving from one-shot prompts to persistent loops. That
+creates a new control problem: when may the loop stop? Tests and linters catch
+broken code, but they do not distinguish known debt from net-new regressions, and
+an LLM-judge gate adds cost, latency, and non-determinism on every iteration.
+dxkit focuses on that stop decision.
 
 ---
 
-## Reproduce it on your own repo
+## Limitations
 
-The whole point is that you don't have to trust these numbers — the
-deterministic tier runs offline:
+- The study uses two real repositories together with synthetic cases. The seeded
+  findings are detector-backed but do not constitute a CVE corpus, and broader
+  language and repository generality is future work.
+- dxkit does not improve on detection. It ingests Snyk and CodeQL rather than
+  out-detecting them.
+- The context-efficiency measurement is a proxy; the session study is the real
+  test.
+- The Opus session arm is deferred, and session numbers are from Sonnet.
+- The Amdahl model is directional rather than a numerical fit.
+- Several sub-claims were retracted once they were traced to harness bugs or
+  single unlucky draws. They are documented rather than buried.
+
+---
+
+## Artifacts
+
+The three deterministic-tier harnesses are published in the
+[`benchmarks/`](../benchmarks/) directory of this repository:
+`bench-guardrail.mjs` (gate correctness), `bench-netnew-isolation.mjs` (net-new
+isolation), and `bench-matcher.mjs` (matcher robustness). They run offline, with
+no API key, against any git repository that has a dxkit baseline, and
+`benchmarks/README.md` documents how to reproduce the numbers above on the pinned
+NodeGoat and Strapi commits.
+
+The agent-driven harnesses (loop safety, the LLM-as-gate comparison, and the
+graph-context sessions) require a model API or subscription and the pinned
+repository checkouts. Those harnesses and their raw traces will be published
+separately after redaction. Until then, the deterministic-tier numbers are
+reproducible today, and the loop, LLM, and session numbers should be read as
+trust-but-verify rather than as already-linked raw data.
+
+---
+
+## Try the deterministic tier on your own repository
+
+These commands let you run dxkit's deterministic gate on your own repository.
+They evaluate the gate locally; they do not reproduce the benchmark numbers
+above.
 
 ```bash
-npx vyuh-dxkit baseline create          # grandfather today's debt
-npx vyuh-dxkit init --claude-loop        # wire the Stop-gate
-npx vyuh-dxkit loop doctor               # confirm it's safe to run unattended
-# …run your loop, then:
-npx vyuh-dxkit loop ledger summarize     # blocked vs allowed, repaired-after-block
+npx @vyuhlabs/dxkit baseline create        # grandfather today's debt
+npx @vyuhlabs/dxkit init --claude-loop     # wire the Stop-gate
+npx @vyuhlabs/dxkit loop doctor            # confirm it is safe to run unattended
+# then run your loop, and afterwards:
+npx @vyuhlabs/dxkit loop ledger summarize  # blocked versus allowed, and repaired-after-block
 ```
 
-A `vyuh-dxkit evaluate` command (a one-shot "prove it on your repo" report) is
-the planned next step.
+To reproduce the deterministic-tier benchmark numbers themselves (gate
+correctness, net-new isolation, and matcher robustness), see the harnesses and
+instructions in [`benchmarks/`](../benchmarks/). A `vyuh-dxkit evaluate` command,
+a one-shot "prove it on your repo" report, is the planned next step.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,9 @@ export default [
       // tmp/ holds gitignored ephemeral scripts (regression harness,
       // one-off migration scripts). Not part of the shipped code.
       'tmp/**',
+      // benchmarks/ holds standalone reproduction harnesses (Node .mjs scripts),
+      // not part of the shipped product code.
+      'benchmarks/**',
     ],
   },
   js.configs.recommended,


### PR DESCRIPTION
…ic harnesses

Two review passes on docs/benchmarks.md to harden it against a skeptical reader, then a full rewrite into a plain, academic register:

- Lead the summary with counts (11/16, 9/16, 0/16 observed escapes) and spell out n=16 per arm (8 reps on each of two tasks).
- Replace O(1) with "no LLM cost and no prompt-size growth with the baseline".
- Replace "bounds/caps/completeness tails" with observed-tail language.
- Add denominators to the gate-correctness claims (confusion matrix tp3/fn0/ tn2/fp0; net-new isolation 205->206 and 1,020->1,021; matcher 0 false regressions over Strapi's 15 duplication findings).
- Soften the LLM-as-judge framing so it no longer contradicts the Sonnet miss, remove unsourced market stats, add a provenance block (version, commit, date), and drop the self-labelled "honest" framing in favour of showing the evidence.
- Remove em dashes and other stylistic tics; format with Prettier.

Ship the three deterministic, offline benchmark harnesses under benchmarks/ (guardrail correctness, net-new isolation, matcher robustness) with a README and an example config. They are repo-agnostic and reproduce the report's deterministic-tier numbers on the pinned NodeGoat and Strapi commits. Verified on the current build. benchmarks/ is excluded from ESLint and Prettier as it holds standalone Node scripts rather than product code.

<!--
Thanks for contributing to @vyuhlabs/dxkit! A few quick guidelines:

  - Keep PRs scoped to one logical change. Multiple unrelated changes
    are easier to review (and revert) as separate PRs.
  - Run `npm run build && npm run test:run && npm run lint` before
    pushing. Pre-commit hooks will also fail loudly if anything's off.
  - If your change touches scoring, language packs, exclusions, or
    tool invocation, re-read CLAUDE.md — it captures the architectural
    rules these areas must follow.
-->

## Summary

<!-- One or two sentences describing what changed and why. -->

## Motivation

<!-- What problem does this solve, or what capability does it add?
     Link to any related issue: "Closes #123" / "Fixes #456" -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] New language pack (adds support for an additional language)
- [ ] Scoring change (adjusts dimension scores, thresholds, or caps)
- [ ] Tooling / CI / docs only (no runtime behavior change)

## Verification

<!-- How did you test this change? Include commands run and the
     repos/fixtures used. Reviewers should be able to reproduce. -->

- [ ] `npm run build` passes
- [ ] `npm run test:run` passes (note final tests count)
- [ ] `npm run lint` passes
- [ ] `bash scripts/check-architecture.sh` passes
- [ ] Manually verified on a real repo (if applicable)

## Architectural rules checklist

If your change touches any of the following areas, confirm you read
the relevant section of `CLAUDE.md`:

- [ ] Tool invocation goes through `tool-registry.ts` (Rule 1)
- [ ] No duplicate tool invocation logic (Rule 2)
- [ ] Language facts come from `detect.ts` / per-pack files (Rule 3, 6)
- [ ] Exclusions come from `exclusions.ts` (Rule 4)
- [ ] Established tools preferred over custom parsers (Rule 5)
- [ ] Dimension scoring lives in `src/scoring/dimensions/<id>.ts` (Rule 7)
- [ ] Per-stack shape lives in `LanguageSupport.architecturalShape` (Rule 8)
- [ ] N/A — this PR does not touch any of the above

## Screenshots / sample output

<!-- Optional. Paste before/after CLI output, screenshots of
     dashboards, or fixture diffs that show the change in action. -->

## Breaking changes

<!-- If this is a breaking change, describe the user-visible impact
     and the migration path. -->

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to, or
     deliberate trade-offs you made. -->
