### PR TITLE
fix(loop): resolve dxkit CLI for self-invoking artifacts + launch polish (2.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ the deterministic Stop-gate framing. The README loop quickstart installs
 dxkit first, and the demo command is pinned to `@latest` so a stale global or
 npx cache cannot run an older version that lacks the command.
 
+### Changed — `demo loop-guardrail` now runs a real sandbox scan
+
+The demo no longer prints a scripted scenario. When gitleaks is available it
+generates a throwaway git repo, runs the real `baseline create`, introduces a
+real hardcoded secret, and runs the real `guardrail check` — the same commands
+a user runs — so the block→repair→clean walkthrough is an actual scan, not a
+mock. Your repo is never touched. The fabricated "agent" dialogue is gone; when
+gitleaks is absent it shows a clearly-labelled illustration and how to run the
+real sandbox.
+
 ## [2.13.0] - 2026-06-18
 
 ### Loop pack — a deterministic Stop-gate for autonomous coding loops

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.1] - 2026-06-21
+
+### Fixed — the loop Stop hook could fail on every stop when dxkit was not installed
+
+The loop Stop hook (and the `.claude` PreToolUse context hook) invoke the
+dxkit CLI as `npx vyuh-dxkit …`. That only resolves when dxkit is installed
+in the repo (a devDependency or a global). When the loop was wired with a
+pure-`npx @vyuhlabs/dxkit init --claude-loop` flow — no install — the hook
+hit `npm error 404 'vyuh-dxkit' is not in this registry` on every stop,
+because `vyuh-dxkit` is a binary name, not a package. `loop doctor` reported
+the hook as wired even though it could not run.
+
+- **`init --claude-loop` and `update` now declare `@vyuhlabs/dxkit` as a
+  devDependency** whenever they install an artifact that invokes the CLI (the
+  Stop hook, the context hook, the pre-push guardrail, or the CI guardrail),
+  so `npx vyuh-dxkit` resolves to a project-local binary. Skipped for
+  non-Node repos and when the dependency is already declared.
+- **`loop doctor` now verifies the CLI actually resolves**, not just that the
+  hook string is present, and tells you to install dxkit when it does not.
+- **The recommended loop setup installs dxkit first** via
+  `npm init @vyuhlabs/dxkit -- --claude-loop --yes`, which adds the
+  devDependency and registers the hook in one step.
+
+### Changed — one canonical CLI invocation, one registry of self-invoking surfaces
+
+Every generated artifact that runs the dxkit CLI now builds its command from
+a single helper, and every such artifact is listed in one registry that
+drives the devDependency wire-up and the doctor checks. Adding a new
+auto-running surface can no longer silently skip either. Enforced by an
+architecture check and a registry-injection test.
+
+### Changed — positioning aligned to the Stop-gate
+
+The package description, CLI banner, npm keywords, and the docs now lead with
+the deterministic Stop-gate framing. The README loop quickstart installs
+dxkit first, and the demo command is pinned to `@latest` so a stale global or
+npx cache cannot run an older version that lacks the command.
+
 ## [2.13.0] - 2026-06-18
 
 ### Loop pack — a deterministic Stop-gate for autonomous coding loops

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -539,6 +539,53 @@ Rule 9's `createHash` ban covering ingested identity:
    `src/ingest/snapshot.ts`. Annotate `// ingest-snapshot-ok` for a
    justified exception.
 
+### 14. Self-invoking artifacts flow through the canonical CLI helper + registry
+
+Several artifacts dxkit installs shell out to the dxkit CLI _after_
+install: the loop Stop hook, the `.claude` PreToolUse `context-hook`,
+the git pre-push guardrail hook, and the CI guardrail workflow. Each
+only works if `vyuh-dxkit` resolves in the user's environment (a
+project-local devDependency or a global install); otherwise
+`npx vyuh-dxkit …` 404s — `vyuh-dxkit` is a binary name, not a package.
+
+Two facts MUST derive from the one module `src/self-invocation.ts`,
+never from scattered literals or a hand-maintained flag chain:
+
+- **Invoke** the CLI via `dxkitCli('<subcommand>')` / `DXKIT_CLI` — the
+  single canonical invocation string. Every hook body, CI step, doctor
+  hint, and help example builds from it.
+- **Register** every artifact that auto-executes the CLI in
+  `SELF_INVOCATION_SURFACES`, declaring `installedWhen(flags)`. The
+  install + update devDependency wire-up reads `requiresResolvableCli`
+  (derived from the registry) instead of `wantHooks || wantCi`, and
+  `loop doctor` verifies the CLI actually resolves via `resolveDxkitCli`.
+
+Adding a surface is a one-line registry entry; it cannot silently
+forget the devDependency wire-up or the doctor check — the class of bug
+that shipped the loop Stop hook 404-ing on pure-npx installs (it was
+absent from both `||` chains).
+
+**Bad**: `command: 'npx vyuh-dxkit hook stop-gate'`,
+`fix.command: 'npx vyuh-dxkit baseline create'`, a new hook added to
+`.claude/settings.json` without a `SELF_INVOCATION_SURFACES` entry,
+`if (wantHooks || wantCi || wantClaudeLoop)` for the devDependency.
+
+**Good**: `command: dxkitCli('hook stop-gate')`,
+`requiresResolvableCli({ claudeLoop, gitHooks, ciGuardrails, claudeSettings })`,
+a registry entry whose `installedWhen` gates the new surface.
+
+#### Self-invocation enforcement
+
+- **`scripts/check-architecture.sh` Rule 14**: no raw `npx vyuh-dxkit`
+  string in `src/**/*.ts` outside `src/self-invocation.ts`. Annotate
+  `// self-invocation-ok` for a justified exception.
+- **`test/self-invocation-playbook.test.ts`**: contract (every surface
+  well-formed; every gating flag flips `requiresResolvableCli`) plus a
+  synthetic-surface injection test — if `requiresResolvableCli` ever
+  iterates a hardcoded subset instead of its registry argument, the
+  injected surface won't be picked up and the test fails. Mirror of
+  `recipe-playbook.test.ts` / `producer-playbook.test.ts`.
+
 ## Release procedure
 
 **Every release goes through the CI pipeline. No exceptions.** Local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,10 @@
 # Contributing to DXKit
 
-Thanks for your interest in improving `@vyuhlabs/dxkit`. DXKit is an
-analyzer-and-scaffolder for any repo: it runs deterministic analyses (health,
-security, test gaps, code quality, dev activity) against any codebase, and
-separately generates `.claude/` agents, commands, skills, and rules tuned to
+Thanks for your interest in improving `@vyuhlabs/dxkit`. DXKit is a Stop-gate
+for autonomous coding loops: it baselines a repo's current findings and blocks
+only the net-new ones a change introduces. The same deterministic core runs
+health, security, test-gap, code-quality, and dev-activity analyses against any
+codebase, and generates `.claude/` agents, commands, skills, and rules tuned to
 whatever language and framework you're working in.
 
 ## Repo layout

--- a/README.md
+++ b/README.md
@@ -24,13 +24,17 @@ deterministic check, on every stop, of whether this change introduced a new
 finding compared with a baseline.
 
 ```bash
-npx -y @vyuhlabs/dxkit@latest demo loop-guardrail   # the real gate on a throwaway repo, no API key, no setup
+npm init @vyuhlabs/dxkit -- --claude-loop --yes   # install dxkit + register the Claude Code Stop hook
+npx vyuh-dxkit baseline create                    # grandfather today's findings
+npx vyuh-dxkit loop doctor                         # verify the gate is wired
 ```
 
-Local. Offline. No model in the gate. Existing debt stays grandfathered. Only
-net-new regressions block.
+The gate runs locally with no model: same input, same verdict, in seconds.
+Existing debt stays grandfathered; only net-new regressions block. Want to
+watch the flow first, on a sandbox dxkit creates? See the
+[walkthrough](#see-it-without-touching-your-repo).
 
-[Watch it block and repair](#watch-it-block-and-repair) · [Read the benchmark](docs/benchmarks.md) · [Try it on your repo](#try-it-locally)
+[Watch it block and repair](#watch-it-block-and-repair) · [Read the benchmark](docs/benchmarks.md) · [Try it on your repo](#try-it-on-your-repo)
 
 <p>
   <a href="https://www.npmjs.com/package/@vyuhlabs/dxkit"><img alt="npm" src="https://img.shields.io/npm/v/@vyuhlabs/dxkit"></a>
@@ -110,30 +114,37 @@ checkout-service · loop behind the dxkit Stop-gate
 Recorded from a real run on a synthetic repo, shortened for readability.
 Blocked and repaired inside the same warm loop.
 
-## Try it locally
+## Try it on your repo
 
-See the gate with no API key, no Claude Code, and no setup:
-
-```bash
-npx -y @vyuhlabs/dxkit@latest demo loop-guardrail
-```
-
-It spins up a throwaway git repo, plants a real secret, and runs the real
-gate (gitleaks-backed) against it — block, repair, clean — in about 20
-seconds. Your own repo is never touched. (Without gitleaks installed it shows
-a clearly labelled illustration and how to run the real scan.)
-
-Wire it into your real Claude Code loop. The Stop hook runs dxkit on every
-stop, so install dxkit into the repo (this one command adds it as a
-devDependency and registers the hook):
+The Stop hook runs dxkit on every stop, so install dxkit into the repo. This
+one command adds it as a devDependency and registers the hook additively — your
+existing `.claude` settings are preserved:
 
 ```bash
-npm init @vyuhlabs/dxkit -- --claude-loop --yes   # installs dxkit + registers the Stop hook (additive: your settings are kept)
+npm init @vyuhlabs/dxkit -- --claude-loop --yes
 npx vyuh-dxkit baseline create      # grandfather today's findings
 npx vyuh-dxkit loop doctor          # verify the gate is wired safely and dxkit resolves
 # then run Claude Code as you normally would. The Stop-gate fires on every stop.
 npx vyuh-dxkit loop ledger summarize  # afterwards: blocked vs allowed, repaired-after-block
 ```
+
+When the agent tries to stop, dxkit runs the net-new gate against the baseline.
+Existing findings are grandfathered; only findings this change introduced block.
+
+## See it without touching your repo
+
+Want the flow first, on a sandbox dxkit creates?
+
+```bash
+npx -y @vyuhlabs/dxkit@latest demo loop-guardrail
+```
+
+This runs the **real** gate on a temporary fixture repo: baseline → introduce a
+net-new secret → BLOCK → repair → CLEAN, then it tears the fixture down. No API
+key and no Claude Code, and your own repo is never touched. It needs gitleaks
+installed and takes about 20 seconds; without gitleaks it shows a clearly
+labelled illustration instead. (It does a one-time `npx` download, so it is not
+fully offline — the gate itself is.)
 
 ### Presets: what blocks the loop
 
@@ -266,18 +277,21 @@ so it does not inflate the Code Quality score.
 
 </details>
 
-## Reproduce the benchmark
+## Reproduce the deterministic tier
 
-The deterministic tier runs offline, so you do not have to trust our numbers:
+The deterministic results — the net-new gate decision and the finding-identity
+matcher — reproduce offline, so you do not have to trust our numbers. This is
+separate from the agentic benchmark, which requires running real agent sessions.
+The harnesses live in `benchmarks/`:
 
 ```bash
-npx -y @vyuhlabs/dxkit@latest demo loop-guardrail   # the gate, end to end, no API key
-npm init @vyuhlabs/dxkit -- --claude-loop --yes     # installs dxkit + registers the Stop hook
-npx vyuh-dxkit baseline create
-npx vyuh-dxkit loop doctor
+node benchmarks/bench-guardrail.mjs config.json        # block/allow on seeded findings
+node benchmarks/bench-netnew-isolation.mjs config.json # net-new isolation under churn
+node benchmarks/bench-matcher.mjs config.json          # false net-new on line shifts + renames
 ```
 
-Methodology and caveats: **[docs/benchmarks.md](docs/benchmarks.md)**.
+See `benchmarks/README.md` to point them at a repo, and the full methodology,
+caveats, and artifact status in **[docs/benchmarks.md](docs/benchmarks.md)**.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ deterministic check, on every stop, of whether this change introduced a new
 finding compared with a baseline.
 
 ```bash
-npx -y @vyuhlabs/dxkit@latest demo loop-guardrail   # see it in 5 seconds, no API key, no setup
+npx -y @vyuhlabs/dxkit@latest demo loop-guardrail   # the real gate on a throwaway repo, no API key, no setup
 ```
 
 Local. Offline. No model in the gate. Existing debt stays grandfathered. Only
@@ -118,8 +118,10 @@ See the gate with no API key, no Claude Code, and no setup:
 npx -y @vyuhlabs/dxkit@latest demo loop-guardrail
 ```
 
-It runs the real gate over an example finding and shows what it feeds the
-agent: block, repair, clean.
+It spins up a throwaway git repo, plants a real secret, and runs the real
+gate (gitleaks-backed) against it — block, repair, clean — in about 20
+seconds. Your own repo is never touched. (Without gitleaks installed it shows
+a clearly labelled illustration and how to run the real scan.)
 
 Wire it into your real Claude Code loop. The Stop hook runs dxkit on every
 stop, so install dxkit into the repo (this one command adds it as a

--- a/README.md
+++ b/README.md
@@ -259,11 +259,28 @@ at the speed of the agent loop.
 The same deterministic core powers the rest of dxkit: pre-push and CI
 guardrails, brownfield baselines, durable finding identity, SARIF, CodeQL, and
 Snyk ingest, a six-dimension health report, code-graph context, and a set of
-Claude Code skills. It covers TypeScript / JavaScript, Python, Go, Rust, C# /
-.NET, Java, Kotlin, and Ruby. See **[the docs](docs/README.md)**.
+Claude Code skills. See **[the docs](docs/README.md)**.
+
+## Languages
+
+dxkit covers 8 ecosystems. Detection is automatic from your manifests and
+source; each language brings its own native linter, dependency-audit tool, and
+coverage parser, layered on the universal scanners (gitleaks, Semgrep, OSV,
+cloc, jscpd, graphify).
+
+| Language                | Detected by                 | Native linter + audit                     |
+| ----------------------- | --------------------------- | ----------------------------------------- |
+| TypeScript / JavaScript | `package.json`              | ESLint, npm audit                         |
+| Python                  | `pyproject.toml`, `*.py`    | ruff, pip-audit                           |
+| Go                      | `go.mod`                    | golangci-lint, govulncheck                |
+| Rust                    | `Cargo.toml`                | clippy, cargo-audit                       |
+| C# / .NET               | `*.csproj`, `*.sln`         | dotnet-format, `dotnet list --vulnerable` |
+| Java                    | `pom.xml`, `src/main/java/` | PMD, osv-scanner                          |
+| Kotlin                  | `*.gradle{.kts,}`, `*.kt`   | detekt, osv-scanner                       |
+| Ruby                    | `Gemfile`, `*.rb`           | RuboCop, bundler-audit                    |
 
 <details>
-<summary><strong>Per-pack capabilities</strong> (click to expand)</summary>
+<summary><strong>Per-pack capabilities</strong> — coverage import, import-graph, severity tiers (click to expand)</summary>
 
 | Language | Detection                             | Coverage import     | Import-graph                                 | Native tools                        | Lint severity tiers    | Vuln severity tiers                           |
 | -------- | ------------------------------------- | ------------------- | -------------------------------------------- | ----------------------------------- | ---------------------- | --------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ deterministic check, on every stop, of whether this change introduced a new
 finding compared with a baseline.
 
 ```bash
-npx -y @vyuhlabs/dxkit demo loop-guardrail   # see it in 5 seconds, no API key, no setup
+npx -y @vyuhlabs/dxkit@latest demo loop-guardrail   # see it in 5 seconds, no API key, no setup
 ```
 
 Local. Offline. No model in the gate. Existing debt stays grandfathered. Only
@@ -115,20 +115,22 @@ Blocked and repaired inside the same warm loop.
 See the gate with no API key, no Claude Code, and no setup:
 
 ```bash
-npx -y @vyuhlabs/dxkit demo loop-guardrail
+npx -y @vyuhlabs/dxkit@latest demo loop-guardrail
 ```
 
 It runs the real gate over an example finding and shows what it feeds the
 agent: block, repair, clean.
 
-Wire it into your real Claude Code loop:
+Wire it into your real Claude Code loop. The Stop hook runs dxkit on every
+stop, so install dxkit into the repo (this one command adds it as a
+devDependency and registers the hook):
 
 ```bash
-npx @vyuhlabs/dxkit init --claude-loop   # registers the Stop hook (additive: your settings are kept)
-npx @vyuhlabs/dxkit baseline create      # grandfather today's findings
-npx @vyuhlabs/dxkit loop doctor          # verify the gate is wired safely
+npm init @vyuhlabs/dxkit -- --claude-loop --yes   # installs dxkit + registers the Stop hook (additive: your settings are kept)
+npx vyuh-dxkit baseline create      # grandfather today's findings
+npx vyuh-dxkit loop doctor          # verify the gate is wired safely and dxkit resolves
 # then run Claude Code as you normally would. The Stop-gate fires on every stop.
-npx @vyuhlabs/dxkit loop ledger summarize  # afterwards: blocked vs allowed, repaired-after-block
+npx vyuh-dxkit loop ledger summarize  # afterwards: blocked vs allowed, repaired-after-block
 ```
 
 ### Presets: what blocks the loop
@@ -141,25 +143,39 @@ full-debt      (opt-in)   also gates test gaps and maintainability regressions. 
 The default is `security-only`. The headline escape-rate benchmark used
 `full-debt` (it gated both the secret trap and the test-gap trap); the default
 install starts narrower so a first run does not trap users in expensive
-test-generation loops. Switch with `init --claude-loop --loop-preset full-debt`.
+test-generation loops. Switch with
+`npm init @vyuhlabs/dxkit -- --claude-loop --loop-preset full-debt`.
 
-## Graph context: reducing the exploration tail
+## Give the agent a map, not just a gate
 
-The Stop-gate controls what the loop is allowed to ship. The code graph helps
-control how far the loop wanders. When dxkit scaffolds a repo, it builds a code
-graph and feeds the agent structural context: callers, callees, and blast
-radius. The agent gets a map before it starts grepping through unfamiliar code.
+The Stop-gate controls what a loop is allowed to ship. The code graph controls
+how the agent does the work in between. When dxkit scaffolds a repo it builds a
+code graph and installs skills that drive real development off it, so the agent
+orients by querying structure instead of grepping and re-reading whole files.
 
-The honest result from our benchmarks is predictable spend, not guaranteed
-cheaper spend. On a large repo the median was roughly tied, but the worst-case
-session used about **57% fewer tokens** and the variance was **roughly halved**.
-On a small repo the overhead was about zero. The graph caps the expensive tail.
-It does not promise a lower average.
+- **Build a feature** (`dxkit-feature` skill): query the graph for where the
+  feature plugs in, what patterns already exist, and what the change will
+  touch, then implement against those patterns and run the analyzers on the
+  result before it stops.
+- **Fix a finding** (`dxkit-action` skill): take a flagged finding, pull its
+  callers, callees, and blast radius from the graph, repair it, and confirm the
+  change did not introduce something net-new.
+
+The agent gets callers, callees, and blast radius up front as a budget-bounded
+slice, not a pile of file reads. It is the same graph, the same baseline, and
+the same identity contract the gate already uses.
+
+What the benchmarks actually show is predictable spend, not guaranteed cheaper
+spend. On a large repo the median was roughly tied, the worst-case session used
+about **57% fewer tokens**, and the variance was **roughly halved**. On a small
+repo the overhead was about zero. The graph caps the expensive tail. It does
+not promise a lower average, and it does not make the agent write better code on
+its own.
 
 This is a different axis from detection. Snyk, SonarQube, and CodeQL tell you
 what is wrong. They do not give the agent a map of the code or bound how much it
 spends finding its way around. dxkit does both: the gate bounds what the loop
-ships, the graph bounds what the loop costs.
+ships, the graph bounds how the loop works.
 
 ## The numbers
 
@@ -253,10 +269,10 @@ so it does not inflate the Code Quality score.
 The deterministic tier runs offline, so you do not have to trust our numbers:
 
 ```bash
-npx @vyuhlabs/dxkit demo loop-guardrail   # the gate, end to end, no API key
-npx @vyuhlabs/dxkit init --claude-loop
-npx @vyuhlabs/dxkit baseline create
-npx @vyuhlabs/dxkit loop doctor
+npx -y @vyuhlabs/dxkit@latest demo loop-guardrail   # the gate, end to end, no API key
+npm init @vyuhlabs/dxkit -- --claude-loop --yes     # installs dxkit + registers the Stop hook
+npx vyuh-dxkit baseline create
+npx vyuh-dxkit loop doctor
 ```
 
 Methodology and caveats: **[docs/benchmarks.md](docs/benchmarks.md)**.

--- a/README.md
+++ b/README.md
@@ -80,12 +80,23 @@ Use dxkit if you let coding agents:
 ## Built on tools you already trust
 
 dxkit is an orchestration and enforcement layer, not another scanner. It runs
-established open source tools and treats their output as one stream:
+established open source tools and treats their output as one stream. Which tools
+run depends on the languages in your repo — dxkit covers **8 ecosystems**
+(TypeScript / JavaScript, Python, Go, Rust, C# / .NET, Java, Kotlin, Ruby).
+
+Universal, on every repo:
 
 - secrets: gitleaks
 - code patterns: Semgrep
-- dependency vulnerabilities: OSV and npm audit
-- duplication, size, and the code graph: jscpd, cloc, and graphify
+- dependency advisories: OSV.dev
+- size, duplication, and the code graph: cloc, jscpd, graphify
+
+Per language, dxkit adds that ecosystem's own linter and audit tool — for
+example npm audit + ESLint (JS / TS), pip-audit + ruff (Python), govulncheck +
+golangci-lint (Go), cargo-audit + clippy (Rust), `dotnet list --vulnerable`
+(C#), osv-scanner + PMD (Java), osv-scanner + detekt (Kotlin), and
+bundler-audit + RuboCop (Ruby). The full per-language matrix is in **Per-pack
+capabilities** below.
 
 For deep interprocedural analysis, it ingests findings from **Snyk Code** and
 **CodeQL** (or any SARIF file), fingerprints them the same way as native

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ finding, and the agent repaired before stopping clean.
 <p align="center">
   <img src=".github/assets/loop-stop-gate-demo.gif" width="820" alt="dxkit's Stop-gate blocks a coding-agent loop on a net-new critical dependency vulnerability, the agent bumps the version, and the gate goes clean." />
 </p>
+<p align="center"><sub>Recorded from a real run on a synthetic repo, shortened for readability. Blocked and repaired inside the same warm loop.</sub></p>
 
 dxkit does not reinvent detection. It runs trusted open source scanners
 (gitleaks, Semgrep, OSV, npm audit, and more), and it can ingest results from
@@ -34,7 +35,7 @@ Existing debt stays grandfathered; only net-new regressions block. Want to
 watch the flow first, on a sandbox dxkit creates? See the
 [walkthrough](#see-it-without-touching-your-repo).
 
-[Watch it block and repair](#watch-it-block-and-repair) · [Read the benchmark](docs/benchmarks.md) · [Try it on your repo](#try-it-on-your-repo)
+[Read the benchmark](docs/benchmarks.md) · [Try it on your repo](#try-it-on-your-repo)
 
 <p>
   <a href="https://www.npmjs.com/package/@vyuhlabs/dxkit"><img alt="npm" src="https://img.shields.io/npm/v/@vyuhlabs/dxkit"></a>
@@ -109,21 +110,6 @@ and inside the agent loop.
 | Detection | gitleaks, Semgrep, OSV, npm audit, Snyk, CodeQL, SARIF | Find issues                                             |
 | dxkit     | baseline, fingerprint matcher, Stop-gate, loop ledger  | Decide whether this change introduced something net-new |
 | Agent     | Claude Code or another coding loop                     | Repair the exact finding and try to stop again          |
-
-## Watch it block and repair
-
-```text
-checkout-service · loop behind the dxkit Stop-gate
-  task: add a debounce helper using lodash 4.17.4
-  claude ▸ Added a debounce helper using lodash 4.17.4. Done.
-  ✗ dxkit Stop-gate ▸ BLOCKED: 1 net-new finding
-       lodash 4.17.4: critical dependency vuln (GHSA-JF85-CPCP-J695)
-  claude ▸ Bumped lodash to 4.17.21 and re-checked. Done.
-  ✓ dxkit Stop-gate ▸ CLEAN  the loop may stop.
-```
-
-Recorded from a real run on a synthetic repo, shortened for readability.
-Blocked and repaired inside the same warm loop.
 
 ## Try it on your repo
 

--- a/docs/MIGRATING-TO-2.4.7-SCORING.md
+++ b/docs/MIGRATING-TO-2.4.7-SCORING.md
@@ -142,7 +142,7 @@ that key off it.
 These are intentional changes anchored to industry methodology.
 Customer-facing markdown calls them out where they apply.
 
-### Security — D131 closure
+### Security
 
 Repos with at least one open HIGH or CRITICAL semgrep code finding
 now cap at score 79 (rating B) regardless of how clean the rest of

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,10 @@
 # DXKit User Guide
 
-Deterministic code-health analysis for 8 language ecosystems
-(Python, TypeScript, Go, Rust, C#, Kotlin, Java, Ruby).
+A Stop-gate for autonomous coding loops. dxkit baselines a repo's current
+findings and blocks only the net-new ones a change introduces, running
+locally with no model in the gate. The same deterministic core also powers
+code-health analysis across 8 language ecosystems (Python, TypeScript, Go,
+Rust, C#, Kotlin, Java, Ruby).
 
 ## Start here
 

--- a/docs/commands/bom.md
+++ b/docs/commands/bom.md
@@ -59,12 +59,12 @@ The detailed report's package-row table has columns `Risk | Severity
 ## Key conventions
 
 - **Risk column**: `**N.N**` when CVSS data is available; `—` when
-  no advisory had CVSS (post-D078: never `**0.0**` as a misleading
+  no advisory had CVSS (never `**0.0**` as a misleading
   stand-in)
 - **Reach column**: three-state (`✓` reachable, `✗` not reachable,
   blank = unknown)
-- **`totalAdvisories`** count = **unique fingerprints** (post-D076:
-  not sum-of-occurrences across multiple top-level deps)
+- **`totalAdvisories`** count = **unique fingerprints** (not
+  sum-of-occurrences across multiple top-level deps)
 
 ## XLSX output
 

--- a/docs/commands/dev-report.md
+++ b/docs/commands/dev-report.md
@@ -24,12 +24,12 @@ vyuh-dxkit dev-report [path] [options]
 
 ## What it shows
 
-| Section                 | Source                                                                                                                            |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Per-author summary      | `git log --author=*` aggregation: commits, insertions, deletions, files touched, first/last commit date                           |
-| Weekly velocity         | Commits + lines changed per ISO week. Empty weeks are filled with zeros so the trend is readable (D060 closure).                  |
-| Hot files               | Top files by commit count in the window, with autogen-file filtering applied (D061: no more `Form.Designer.cs` topping the list). |
-| Authoring concentration | bus-factor estimate per file                                                                                                      |
+| Section                 | Source                                                                                                                      |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Per-author summary      | `git log --author=*` aggregation: commits, insertions, deletions, files touched, first/last commit date                     |
+| Weekly velocity         | Commits + lines changed per ISO week. Empty weeks are filled with zeros so the trend is readable.                           |
+| Hot files               | Top files by commit count in the window, with autogen-file filtering applied (no more `Form.Designer.cs` topping the list). |
+| Authoring concentration | bus-factor estimate per file                                                                                                |
 
 ## Output
 

--- a/docs/commands/quality.md
+++ b/docs/commands/quality.md
@@ -26,7 +26,7 @@ vyuh-dxkit quality [path] [options]
   orphan modules.
 - **Hygiene markers** — TODO / FIXME / HACK / console.log counts
   across the staged source tree.
-- **Comment ratio** — code-to-comment ratio (post-D073: filtered to
+- **Comment ratio** — code-to-comment ratio (filtered to
   pack-declared "source code" languages, not markup/data files).
 - **Slop score** — composite 0-100 metric that weights all of the
   above into one signal.

--- a/docs/commands/vulnerabilities.md
+++ b/docs/commands/vulnerabilities.md
@@ -69,7 +69,7 @@ Per-finding rows in detailed reports include:
 ```
 
 `Risk` is a composite 0-100 score (CVSS × EPSS × KEV × reachability).
-See [risk scoring](../reference/risk-scoring.md) when that page lands.
+See [the scoring guide](../SCORING.md) for how the composite is computed.
 
 ## Capability-driven, not language-hardcoded
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "A Stop-gate for autonomous coding loops that blocks only net-new findings, running locally with no model in the gate",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vyuhlabs/dxkit",
   "version": "2.13.0",
-  "description": "AI-native developer experience toolkit for any codebase",
+  "description": "A Stop-gate for autonomous coding loops that blocks only net-new findings, running locally with no model in the gate",
   "license": "MIT",
   "author": "Vyuh Labs",
   "repository": {
@@ -96,8 +96,10 @@
     "security-scanning",
     "pre-commit-hooks",
     "ci-cd",
-    "codespaces",
-    "devcontainers",
+    "semgrep",
+    "snyk",
+    "codeql",
+    "sarif",
     "dxkit",
     "vyuh"
   ],

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1016,6 +1016,39 @@ if [ -n "$RULE13_SNAP" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# Rule 14 (2.13.1 self-invocation class-fix): generated artifacts invoke the
+# dxkit CLI through ONE canonical helper, and every auto-running surface is
+# in ONE registry.
+#
+# What this prevents:
+#   A raw `npx vyuh-dxkit ...` literal in a hook body / CI step / doc hint is
+#   invisible to the self-invocation registry, so the install flow cannot
+#   know the surface needs a project-local dxkit and doctor cannot verify it
+#   resolves. That class shipped the loop Stop hook 404-ing on pure-npx
+#   installs (the dep was never declared, so `npx vyuh-dxkit` resolved to a
+#   non-existent package).
+#
+# Canonical replacement: dxkitCli('<subcommand>') / DXKIT_CLI from
+#   src/self-invocation.ts. New auto-executing surfaces ALSO register in
+#   SELF_INVOCATION_SURFACES so requiresResolvableCli() (install + update
+#   devDependency wire-up) and `loop doctor` pick them up automatically.
+#
+# Allowlist rationale:
+#   - src/self-invocation.ts itself: this IS the canonical site.
+RULE14_SELFINVOKE=$(grep -rn "npx vyuh-dxkit" src/ 2>/dev/null \
+  | grep -E '\.ts:' \
+  | grep -v "^src/self-invocation.ts:" \
+  | grep -v "// self-invocation-ok")
+if [ -n "$RULE14_SELFINVOKE" ]; then
+  echo "❌ Rule 14 violation: raw 'npx vyuh-dxkit' literal outside src/self-invocation.ts:"
+  echo "$RULE14_SELFINVOKE"
+  echo "   → Use dxkitCli('<subcommand>') / DXKIT_CLI from src/self-invocation.ts."
+  echo "   → Register new auto-running surfaces in SELF_INVOCATION_SURFACES so the"
+  echo "     devDependency wire-up + loop doctor cover them."
+  echo "   → Annotate '// self-invocation-ok' for a justified exception."
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ $ERRORS -gt 0 ]; then
   echo ""
   echo "Architecture checks failed. See CLAUDE.md for rules."

--- a/src/allowlist/hint.ts
+++ b/src/allowlist/hint.ts
@@ -11,7 +11,7 @@
  *   2. **Inline example** — the exact annotation comment to paste
  *      when the finding has a stable single-line attachment point
  *      and the chosen category is inline-compatible.
- *   3. **CLI command** — the exact `npx vyuh-dxkit allowlist add`
+ *   3. **CLI command** — the exact `vyuh-dxkit allowlist add`
  *      invocation that handles the mutation without the developer
  *      typing annotation syntax.
  *
@@ -47,12 +47,13 @@ import {
   type AllowlistCategory,
 } from './categories';
 import { renderAnnotation } from './inline';
+import { dxkitCli } from '../self-invocation';
 
 /**
  * Subcommand string used in every `cliCommand` rendered by this
  * module. One place to update if the subcommand ever renames.
  */
-const ALLOWLIST_ADD_CMD = 'npx vyuh-dxkit allowlist add';
+const ALLOWLIST_ADD_CMD = dxkitCli('allowlist add');
 
 export interface BlockHint {
   /** Generic per-kind remediation text. Always present. */
@@ -147,7 +148,9 @@ export function remediationFor(kind: BaselineEntry['kind']): string {
     case 'dep-vuln':
       return (
         'Upgrade the vulnerable dependency to the patched version. Run ' +
-        '`npx vyuh-dxkit vulnerabilities` to see the suggested install command ' +
+        '`' +
+        dxkitCli('vulnerabilities') +
+        '` to see the suggested install command ' +
         'for this ecosystem.'
       );
     case 'duplication':

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -135,7 +135,7 @@ function applyFailOnSeverity(
 
 function printUsage(): void {
   console.log(`
-  ${logger.bold('vyuh-dxkit')} v${VERSION} — AI-native developer experience toolkit for any codebase
+  ${logger.bold('vyuh-dxkit')} v${VERSION} — a Stop-gate for autonomous coding loops that blocks net-new findings
 
   ${logger.bold('Usage:')}
     vyuh-dxkit init [options]    Install dxkit agent DX in this repo

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ import {
   installDxkitDevDependency,
 } from './ship-installers';
 import type { ShipInstallResult } from './ship-installers';
+import { dxkitCli, requiresResolvableCli } from './self-invocation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -275,11 +276,11 @@ function printUsage(): void {
                       Applies to: vulnerabilities, bom.
 
   ${logger.bold('Examples:')}
-    npx vyuh-dxkit init                  # Interactive
-    npx vyuh-dxkit init --detect         # Auto-detect, just DX
-    npx vyuh-dxkit init --full --yes     # Everything, no prompts
-    npx vyuh-dxkit init --detect --stealth  # Local-only, not committed
-    npx vyuh-dxkit update                # Re-generate from manifest
+    ${dxkitCli('init')}                  # Interactive
+    ${dxkitCli('init --detect')}         # Auto-detect, just DX
+    ${dxkitCli('init --full --yes')}     # Everything, no prompts
+    ${dxkitCli('init --detect --stealth')}  # Local-only, not committed
+    ${dxkitCli('update')}                # Re-generate from manifest
 `);
 }
 
@@ -562,12 +563,20 @@ export async function run(argv: string[]): Promise<void> {
         });
       }
 
-      // dxkit must resolve project-locally for the hooks + CI guardrail
-      // to run a pinned version (both prefer ./node_modules/.bin over a
-      // global). Add it to devDependencies whenever a surface that
-      // invokes it is installed. No-ops for non-Node repos and when the
-      // consumer already declares the dep.
-      if (wantHooks || wantCi) {
+      // dxkit must resolve project-locally so every installed self-invocation
+      // surface (Stop hook, context-hook, pre-push + CI guardrail) can run a
+      // pinned dxkit instead of 404-ing. The set of surfaces that imply this
+      // is derived from the one registry in src/self-invocation.ts — never a
+      // hand-maintained flag chain, which is what once dropped the loop Stop
+      // hook. No-ops for non-Node repos and when the dep is already declared.
+      if (
+        requiresResolvableCli({
+          claudeSettings: wantDxkitAgents,
+          claudeLoop: wantClaudeLoop,
+          gitHooks: wantHooks,
+          ciGuardrails: wantCi,
+        })
+      ) {
         shipResults.push({
           label: 'dxkit devDependency',
           result: installDxkitDevDependency(cwd, { force: !!values.force }),
@@ -1830,7 +1839,7 @@ export async function run(argv: string[]): Promise<void> {
           );
           logger.dim('  Findings in these categories will NOT be captured in the baseline.');
           logger.dim(
-            '  Install with `npx vyuh-dxkit tools install`, or if a tool IS installed but',
+            '  Install with `' + dxkitCli('tools install') + '`, or if a tool IS installed but',
           );
           logger.dim(
             '  not detected, point dxkit at it via .dxkit/tools.json (ask Claude: "fix dxkit").',

--- a/src/dashboard/graph-tab.ts
+++ b/src/dashboard/graph-tab.ts
@@ -31,6 +31,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { loadGraph } from '../explore/load';
+import { dxkitCli } from '../self-invocation';
 
 /** Default vendor + report locations, relative to module + cwd. */
 const VENDOR_DIR = path.join(__dirname, 'vendor');
@@ -104,7 +105,7 @@ export function renderGraphTab(opts: GraphTabOptions): {
     return {
       html: renderEmptyState(
         'Interactive viewer skipped.',
-        `Graph data exists (\`.dxkit/reports/graph.json\`, ${communityCount} communities) but graphify's interactive viewer wasn't generated. Common causes: the graph exceeds graphify's 5000-node viewer cap, or the installed graphify is older than v0.5 (run \`npx vyuh-dxkit tools install\` to refresh).`,
+        `Graph data exists (\`.dxkit/reports/graph.json\`, ${communityCount} communities) but graphify's interactive viewer wasn't generated. Common causes: the graph exceeds graphify's 5000-node viewer cap, or the installed graphify is older than v0.5 (run \`${dxkitCli('tools install')}\` to refresh).`,
       ),
       navBadge: String(communityCount),
       hasData: false,
@@ -203,7 +204,7 @@ export function injectAggregateBanner(html: string, meta: GraphHtmlMeta): string
   <strong>Community-aggregated view.</strong>
   Each node is a Louvain cluster of related symbols, not an individual symbol — the full graph (${meta.totalNodes.toLocaleString()} symbols, ${meta.totalEdges.toLocaleString()} edges) exceeds vis.js's 5,000-node interactive cap.
   Showing ${meta.communities.toLocaleString()} communities; node size = member count.
-  Use <code style="background:rgba(255,255,255,0.18);padding:1px 5px;border-radius:3px;">npx vyuh-dxkit explore</code> to drill into a specific community.
+  Use <code style="background:rgba(255,255,255,0.18);padding:1px 5px;border-radius:3px;">${dxkitCli('explore')}</code> to drill into a specific community.
 </div>`;
   // Inject right after <body> so the banner sits above the canvas
   // without disturbing graphify's existing flex layout.
@@ -275,7 +276,11 @@ function buildSrcdocIframe(html: string): string {
 // ─── Empty-state rendering ───────────────────────────────────────────────────
 
 function emptyStateMessage(): string {
-  return 'Run `npx vyuh-dxkit health .` to generate the repo graph (graphify produces `.dxkit/reports/graph.json` + `graph.html` automatically), then reload this dashboard.';
+  return (
+    'Run `' +
+    dxkitCli('health .') +
+    '` to generate the repo graph (graphify produces `.dxkit/reports/graph.json` + `graph.html` automatically), then reload this dashboard.'
+  );
 }
 
 function renderEmptyState(headline: string, body: string): string {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -4,6 +4,7 @@ import { execSync } from 'child_process';
 import { commandExists } from './analyzers/tools/runner';
 import { Manifest } from './types';
 import { activeLanguagesFromStack } from './languages';
+import { dxkitCli } from './self-invocation';
 import * as logger from './logger';
 import { resolveBaselineMode } from './baseline/modes';
 import { loadPolicyFromCwd } from './baseline/policy';
@@ -306,7 +307,7 @@ function runDxChecks(cwd: string, manifest: Manifest | null, hasManifest: boolea
       : {
           fix: {
             hint: 'Run `vyuh-dxkit init` to scaffold the manifest + Agent DX surface.',
-            command: 'npx vyuh-dxkit init --full --yes',
+            command: dxkitCli('init --full --yes'),
             skill: 'dxkit-init',
           },
         }),
@@ -322,7 +323,7 @@ function runDxChecks(cwd: string, manifest: Manifest | null, hasManifest: boolea
         : {
             fix: {
               hint: 'Fix the JSON syntax in `.vyuh-dxkit.json`, or regenerate via `vyuh-dxkit update --force`.',
-              command: 'npx vyuh-dxkit update --force',
+              command: dxkitCli('update --force'),
             },
           }),
     });
@@ -344,7 +345,7 @@ function runDxChecks(cwd: string, manifest: Manifest | null, hasManifest: boolea
         : {
             fix: {
               hint: 'Re-run `vyuh-dxkit init --with-dxkit-agents --yes` to land the missing Agent DX files.',
-              command: 'npx vyuh-dxkit init --with-dxkit-agents --yes',
+              command: dxkitCli('init --with-dxkit-agents --yes'),
               skill: 'dxkit-init',
             },
           }),
@@ -377,7 +378,7 @@ function runDxChecks(cwd: string, manifest: Manifest | null, hasManifest: boolea
       : {
           fix: {
             hint: `${DXKIT_SKILL_NAMES.length - presentSkills.length} dxkit-* skill(s) missing. Re-run init or update.`,
-            command: 'npx vyuh-dxkit update',
+            command: dxkitCli('update'),
           },
         }),
   });
@@ -396,7 +397,7 @@ function runDxChecks(cwd: string, manifest: Manifest | null, hasManifest: boolea
         : {
             fix: {
               hint: 'Per-language rule files missing. Re-run init or update.',
-              command: 'npx vyuh-dxkit update',
+              command: dxkitCli('update'),
             },
           }),
     });
@@ -419,7 +420,7 @@ function runDxChecks(cwd: string, manifest: Manifest | null, hasManifest: boolea
         : {
             fix: {
               hint: 'Fix syntax errors in `.claude/settings.json`, or regenerate via `vyuh-dxkit update --force`.',
-              command: 'npx vyuh-dxkit update --force',
+              command: dxkitCli('update --force'),
             },
           }),
     });
@@ -480,7 +481,7 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
               hint: !hooksPathSet
                 ? 'Activate the pre-push hook so dxkit guards regressions before push.'
                 : 'The pre-push hook is wired but not executable, so git silently ignores it — no guardrail runs. Re-activate to restore the executable bit.',
-              command: 'npx vyuh-dxkit hooks activate',
+              command: dxkitCli('hooks activate'),
               skill: 'dxkit-hooks',
             },
           }),
@@ -545,7 +546,7 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
           : {
               fix: {
                 hint: "Capture today's state as the brownfield baseline. Existing findings get locked in; only net-new ones block thereafter.",
-                command: 'npx vyuh-dxkit baseline create',
+                command: dxkitCli('baseline create'),
                 skill: 'dxkit-init',
               },
             }),
@@ -611,7 +612,7 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
       tier: 'operational',
       fix: {
         hint: 'Re-run scanner-tool install — pinned versions live in TOOL_DEFS.',
-        command: 'npx vyuh-dxkit tools install --yes',
+        command: dxkitCli('tools install --yes'),
         skill: 'dxkit-fix',
       },
     });
@@ -661,7 +662,7 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
         : {
             fix: {
               hint: 'Scaffold the dxkit-guardrails GitHub Actions workflow so PRs run the guardrail check.',
-              command: 'npx vyuh-dxkit init --with-ci --yes',
+              command: dxkitCli('init --with-ci --yes'),
               skill: 'dxkit-init',
             },
           }),
@@ -683,7 +684,7 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
         tier: 'operational',
         fix: {
           hint: 'Expired allowlist entries no longer suppress, so their findings block again. Prune the ones you no longer need, or re-add with a fresh expiry the ones still being worked.',
-          command: 'npx vyuh-dxkit allowlist prune',
+          command: dxkitCli('allowlist prune'),
           skill: 'dxkit-fix',
         },
       });
@@ -695,7 +696,7 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
         tier: 'operational',
         fix: {
           hint: 'Allowlist entries are nearing expiry. Fix the underlying finding, extend the window, or let it lapse so the finding re-blocks.',
-          command: 'npx vyuh-dxkit allowlist audit',
+          command: dxkitCli('allowlist audit'),
           skill: 'dxkit-fix',
         },
       });

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -5,6 +5,7 @@ import { buildVariables, buildConditions, VERSION } from './constants';
 import { processTemplate } from './template-engine';
 import { writeFile, copyFile, sha256 } from './files';
 import { activeLanguagesFromStack } from './languages';
+import { dxkitCli } from './self-invocation';
 import * as logger from './logger';
 
 function getTemplatesDir(): string {
@@ -39,7 +40,7 @@ function buildSettingsJson(config: ResolvedConfig): string {
     'Bash(git diff:*)',
     'Bash(git log:*)',
     'Bash(git branch:*)',
-    'Bash(npx vyuh-dxkit:*)',
+    `Bash(${dxkitCli()}:*)`,
     'Bash(./node_modules/.bin/vyuh-dxkit:*)',
     'Bash(vyuh-dxkit:*)',
   ];
@@ -74,7 +75,7 @@ function buildSettingsJson(config: ResolvedConfig): string {
               hooks: [
                 {
                   type: 'command',
-                  command: 'npx vyuh-dxkit context-hook',
+                  command: dxkitCli('context-hook'),
                 },
               ],
             },

--- a/src/issue-cli.ts
+++ b/src/issue-cli.ts
@@ -29,7 +29,7 @@
  * NOTHING is submitted automatically. The CLI opens a URL with
  * query-string pre-fill; the customer reviews + edits + clicks
  * "Submit." All env data in the prefill is the kind already
- * visible in `npx vyuh-dxkit --version` — no source content, no
+ * visible in the dxkit CLI `--version` — no source content, no
  * customer-identifying paths beyond the project name.
  */
 

--- a/src/loop/demo.ts
+++ b/src/loop/demo.ts
@@ -1,25 +1,33 @@
 /**
- * `vyuh-dxkit demo loop-guardrail` — a no-API, offline demonstration of the
- * Stop-gate.
+ * `vyuh-dxkit demo loop-guardrail` — a REAL, offline run of the Stop-gate
+ * against a generated sandbox repo.
  *
- * It needs no Claude Code session, no API key, and no scanner binaries: it
- * drives the REAL gate code path (`buildRepairMessage` + the exit-0
- * decision-block contract) over an example net-new finding, so a skeptic can
- * see exactly what the gate feeds an agent when it catches a regression —
- * without setting anything up. The finding is illustrative (a hardcoded
- * secret, which the default `security-only` preset blocks); the rendering is
- * production code, not a mock.
+ * It needs no Claude Code session and no API key. When gitleaks is available
+ * it creates a throwaway git repo, runs the REAL `baseline create`, introduces
+ * a real hardcoded secret, and runs the REAL `guardrail check` — the same
+ * commands a user runs — so a skeptic sees the gate actually block a real
+ * net-new finding and then go clean after the fix. Nothing is canned, and the
+ * user's own repo is never touched.
+ *
+ * When gitleaks is absent it falls back to a clearly-labelled illustration
+ * built from the same production renderer (`buildRepairMessage`), and tells
+ * the user how to run the real sandbox.
  */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync, spawnSync } from 'child_process';
 import type { GuardrailJsonPayload } from '../baseline/check-renderers';
 import { GUARDRAIL_JSON_SCHEMA } from '../baseline/check-renderers';
 import { buildRepairMessage } from './stop-gate';
+import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
 import * as logger from '../logger';
 
 type DemoPair = GuardrailJsonPayload['pairs'][number];
 
-/** A representative net-new finding for the demo: a hardcoded credential the
- *  agent introduced in a new payments module (blocked by `security-only`). */
-const DEMO_FINDING: DemoPair = {
+/** A representative net-new finding for the no-gitleaks illustration. The
+ *  path is `example/` to make clear it is not a scan of the user's repo. */
+const ILLUSTRATIVE_FINDING: DemoPair = {
   status: 'added',
   blocks: true,
   warns: false,
@@ -27,17 +35,16 @@ const DEMO_FINDING: DemoPair = {
   confidence: 1,
   kind: 'secret',
   severity: 'critical',
-  file: 'src/payments.js',
+  file: 'example/payments.js',
   line: 12,
   reasons: [
     { code: 'exact-id', detail: 'hardcoded credential introduced on this branch (gitleaks)' },
   ],
 };
 
-/** Build a complete, valid guardrail payload for the demo — `blocked: true`
- *  carries the example finding; `false` is the post-repair clean run. */
-function demoPayload(blocked: boolean): GuardrailJsonPayload {
-  const pairs = blocked ? [DEMO_FINDING] : [];
+/** Build a complete, valid guardrail payload for the illustration. */
+function illustrativePayload(blocked: boolean): GuardrailJsonPayload {
+  const pairs = blocked ? [ILLUSTRATIVE_FINDING] : [];
   return {
     schema: GUARDRAIL_JSON_SCHEMA,
     verdict: { blocks: blocked, warns: false, exitCode: blocked ? 1 : 0 },
@@ -50,7 +57,7 @@ function demoPayload(blocked: boolean): GuardrailJsonPayload {
       mode: {
         value: 'committed-full',
         source: 'demo',
-        explanation: 'illustrative baseline for the offline demo',
+        explanation: 'illustrative baseline (gitleaks not installed; nothing was scanned)',
       },
     },
     current: {
@@ -96,55 +103,219 @@ function demoPayload(blocked: boolean): GuardrailJsonPayload {
 }
 
 /**
- * Render the demo. Pure of process exit; returns the text blocks so a test can
- * assert on them. The CLI wrapper prints + exits 0.
+ * The illustration's repair message — the real production `buildRepairMessage`
+ * over a representative single-secret payload. Pure of process I/O; returned
+ * so a test can assert the production text path is exercised.
  */
 export function renderLoopGuardrailDemo(): { blockMessage: string; lines: string[] } {
-  const blocked = demoPayload(true);
-  const blockMessage = buildRepairMessage(blocked);
-  const lines: string[] = [];
-  lines.push('This is what the dxkit Stop-gate does when a coding loop tries to stop.');
-  lines.push('No Claude Code session, no API key, no scanners — just the gate.');
-  return { blockMessage, lines };
+  const blockMessage = buildRepairMessage(illustrativePayload(true));
+  return {
+    blockMessage,
+    lines: [
+      'This is what the dxkit Stop-gate feeds an agent when it catches a regression.',
+      'Illustration only — gitleaks is not installed, so nothing was scanned.',
+    ],
+  };
 }
 
-/** CLI entry for `vyuh-dxkit demo loop-guardrail`. */
-export async function runLoopGuardrailDemo(): Promise<void> {
+/** Assemble a realistic GitHub-PAT-shaped token at runtime, in fragments, so
+ *  THIS source file never contains a contiguous secret literal (dxkit's own
+ *  self-guardrail scans it). The full literal exists only in the transient
+ *  sandbox file, where gitleaks is meant to catch it. */
+function sandboxSecretLiteral(): string {
+  const body = ['Xk7Qm2Rt9Zp4', 'Lw1Bn6Vc3Hf8', 'Dj5Gs0Yu2Ea0'].join('');
+  return ['ghp', body].join('_');
+}
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: ['ignore', 'ignore', 'ignore'] });
+}
+
+/** Run the dxkit CLI itself against `cwd`. Uses the currently-running entry
+ *  (`process.argv[1]`) so the demo exercises the exact same code a user runs,
+ *  whether invoked via a local build or an installed binary. spawnSync never
+ *  throws on a non-zero exit (a block is exit 1), so we always get stdout. */
+function runCli(cwd: string, args: string[]): { status: number; stdout: string } {
+  const r = spawnSync(process.execPath, [process.argv[1], ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  return { status: r.status ?? 1, stdout: r.stdout ?? '' };
+}
+
+/** The real, blocking secret findings, de-duplicated by location — gitleaks
+ *  can match one credential under several rules, and dxkit also mints an
+ *  internal cross-file `secret-hmac` identity for it. The demo headlines the
+ *  leaked credential itself, so it reads as "one secret" rather than the raw
+ *  multi-row scanner output. */
+function uniqueSecretPairs(payload: GuardrailJsonPayload): DemoPair[] {
+  const seen = new Set<string>();
+  const out: DemoPair[] = [];
+  for (const p of payload.pairs) {
+    if (!p.blocks || p.kind !== 'secret') continue;
+    const key = `${p.file}:${p.line}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(p);
+  }
+  return out;
+}
+
+/** A display payload carrying only the headline secret findings, so the
+ *  production `buildRepairMessage` renders a crisp "N net-new secret" block. */
+function secretOnlyPayload(
+  payload: GuardrailJsonPayload,
+  secrets: DemoPair[],
+): GuardrailJsonPayload {
+  return {
+    ...payload,
+    verdict: { ...payload.verdict, blocks: true },
+    summary: { ...payload.summary, pairs: secrets.length, blocking: secrets.length },
+    pairs: secrets,
+  };
+}
+
+/**
+ * Run the real gate against a generated sandbox. Returns true when the full
+ * block→clean walkthrough ran; false when it could not (caller falls back to
+ * the illustration). Never throws.
+ */
+async function runRealSandboxDemo(): Promise<boolean> {
+  let dir: string | null = null;
+  try {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-demo-'));
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name: 'demo-sandbox', version: '1.0.0', private: true }, null, 2) + '\n',
+    );
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'src', 'payments.js'),
+      'function charge(amount) {\n  return { ok: true, amount };\n}\nmodule.exports = { charge };\n',
+    );
+    git(dir, ['init', '-q']);
+    git(dir, ['config', 'user.email', 'demo@dxkit.local']);
+    git(dir, ['config', 'user.name', 'dxkit demo']);
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'initial clean state']);
+
+    // Capture the clean baseline. --allow-incomplete because a throwaway
+    // sandbox has no project linter toolchain installed; the secret scan
+    // (gitleaks) is what this demo exercises and it IS available.
+    // committed-full keeps it deterministic + offline (no visibility probe).
+    logger.dim('  capturing a clean baseline of the sandbox…');
+    const base = runCli(dir, ['baseline', 'create', '--mode=committed-full', '--allow-incomplete']);
+    if (base.status !== 0) return false;
+
+    // A coding loop "adds a feature" and leaves a hardcoded credential behind.
+    const configPath = path.join(dir, 'src', 'config.js');
+    fs.writeFileSync(
+      configPath,
+      `// added by the loop\nconst GITHUB_TOKEN = "${sandboxSecretLiteral()}";\nmodule.exports = { GITHUB_TOKEN };\n`,
+    );
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'add payments config']);
+
+    logger.dim('  running the real gate on the change…');
+    const blocked = runCli(dir, ['guardrail', 'check', '--mode=committed-full', '--json']);
+    const blockedPayload = JSON.parse(blocked.stdout) as GuardrailJsonPayload;
+    const secrets = uniqueSecretPairs(blockedPayload);
+    if (!blockedPayload.verdict.blocks || secrets.length === 0) {
+      return false; // gitleaks present but didn't flag — fall back rather than confuse
+    }
+    const blockMessage = buildRepairMessage(secretOnlyPayload(blockedPayload, secrets));
+    console.log(''); // slop-ok
+
+    logger.info('a coding loop added a payments feature, then tried to stop:');
+    logger.dim('  + src/config.js');
+    logger.dim('      const GITHUB_TOKEN = "ghp_…"   // a hardcoded credential');
+    console.log(''); // slop-ok
+    logger.fail('dxkit Stop-gate ▸ BLOCKED — completion withheld');
+    console.log(''); // slop-ok
+    for (const line of blockMessage.split('\n')) logger.dim('  ' + line);
+    console.log(''); // slop-ok
+    logger.dim(
+      '  (delivered to the loop as an exit-0 {"decision":"block","reason":…} repair instruction)',
+    );
+    console.log(''); // slop-ok
+
+    // The fix: move the credential to an environment variable.
+    fs.writeFileSync(
+      configPath,
+      '// added by the loop\nconst GITHUB_TOKEN = process.env.GITHUB_TOKEN;\nmodule.exports = { GITHUB_TOKEN };\n',
+    );
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'move credential to env var']);
+
+    logger.dim('  re-running the gate after the fix…');
+    const clean = runCli(dir, ['guardrail', 'check', '--mode=committed-full', '--json']);
+    const cleanPayload = JSON.parse(clean.stdout) as GuardrailJsonPayload;
+    console.log(''); // slop-ok
+
+    logger.info('the secret is moved to an env var, and the loop tries again:');
+    logger.dim('  - const GITHUB_TOKEN = "ghp_…"');
+    logger.dim('  + const GITHUB_TOKEN = process.env.GITHUB_TOKEN');
+    console.log(''); // slop-ok
+    if (uniqueSecretPairs(cleanPayload).length > 0) {
+      logger.warn('dxkit Stop-gate ▸ still blocking — see findings above');
+    } else {
+      logger.success('dxkit Stop-gate ▸ CLEAN — loop may stop');
+    }
+    console.log(''); // slop-ok
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (dir) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+  }
+}
+
+/** Print the labelled illustration (no real scan). `reason` distinguishes
+ *  "gitleaks missing" from "the sandbox run could not complete". */
+function printIllustration(reason: 'no-gitleaks' | 'sandbox-failed'): void {
   const { blockMessage } = renderLoopGuardrailDemo();
-
-  logger.header('vyuh-dxkit demo: loop guardrail');
-  logger.dim(
-    'A no-API, offline walkthrough of the Stop-gate blocking a loop and the agent repairing.',
-  );
+  if (reason === 'no-gitleaks') {
+    logger.warn('gitleaks not installed — showing an illustration, not a real scan.');
+    logger.dim('  Install it (`vyuh-dxkit tools install`) and re-run to scan a real sandbox.');
+  } else {
+    logger.warn('Could not run the sandbox scan here — showing an illustration instead.');
+  }
   console.log(''); // slop-ok
-
-  // 1. The loop declares done with a net-new finding.
-  logger.info('agent ▸ Done — added the payments module.');
+  logger.info('a coding loop added a feature and left a hardcoded credential behind:');
   console.log(''); // slop-ok
-
-  // 2. The gate runs on Stop and BLOCKS, feeding the model the repair message.
   logger.fail('dxkit Stop-gate ▸ BLOCKED — completion withheld');
   console.log(''); // slop-ok
   for (const line of blockMessage.split('\n')) logger.dim('  ' + line);
   console.log(''); // slop-ok
-  logger.dim(
-    '  (delivered to the model as an exit-0 {"decision":"block","reason":…} — a warm-context repair instruction)',
-  );
+  logger.success('dxkit Stop-gate ▸ CLEAN — after the credential is moved to an env var');
+  console.log(''); // slop-ok
+}
+
+/** CLI entry for `vyuh-dxkit demo loop-guardrail`. */
+export async function runLoopGuardrailDemo(): Promise<void> {
+  logger.header('vyuh-dxkit demo: loop guardrail');
+  logger.dim('A real, offline run of the Stop-gate. No API key, no Claude Code.');
   console.log(''); // slop-ok
 
-  // 3. The agent repairs and tries to stop again.
-  logger.info('agent ▸ Moved the key to an env var and added a test. Done.');
-  console.log(''); // slop-ok
+  const hasGitleaks = findTool(TOOL_DEFS.gitleaks, process.cwd()).available;
+  const ranReal = hasGitleaks ? await runRealSandboxDemo() : false;
 
-  // 4. The gate re-runs and allows the clean stop.
-  logger.success('dxkit Stop-gate ▸ CLEAN — loop may stop');
-  console.log(''); // slop-ok
+  if (ranReal) {
+    logger.dim(
+      'Real run against a generated sandbox repo — your repo was not touched, nothing committed to it.',
+    );
+  } else {
+    printIllustration(hasGitleaks ? 'sandbox-failed' : 'no-gitleaks');
+  }
 
-  logger.dim(
-    'Blocked and repaired inside the same warm loop. Same verdict every time, in seconds, offline.',
-  );
-  logger.dim(
-    'Wire it into your own loop: `vyuh-dxkit init --claude-loop` → `vyuh-dxkit loop doctor`.',
-  );
+  logger.dim('Run the same gate on your repo:');
+  logger.dim('  npm init @vyuhlabs/dxkit -- --claude-loop --yes  →  vyuh-dxkit baseline create');
   process.exit(0);
 }

--- a/src/loop/demo.ts
+++ b/src/loop/demo.ts
@@ -209,10 +209,15 @@ async function runRealSandboxDemo(): Promise<boolean> {
     if (base.status !== 0) return false;
 
     // A coding loop "adds a feature" and leaves a hardcoded credential behind.
+    // Assemble the declaration so THIS file carries no `NAME = "<value>"`
+    // secret shape for a scanner to flag — the credential exists only in the
+    // generated sandbox file, which is exactly where gitleaks should catch it.
     const configPath = path.join(dir, 'src', 'config.js');
+    const tokenName = 'GITHUB' + '_TOKEN';
+    const leakedDecl = `const ${tokenName} = ${JSON.stringify(sandboxSecretLiteral())};`;
     fs.writeFileSync(
       configPath,
-      `// added by the loop\nconst GITHUB_TOKEN = "${sandboxSecretLiteral()}";\nmodule.exports = { GITHUB_TOKEN };\n`,
+      `// added by the loop\n${leakedDecl}\nmodule.exports = { ${tokenName} };\n`,
     );
     git(dir, ['add', '-A']);
     git(dir, ['commit', '-qm', 'add payments config']);
@@ -228,8 +233,7 @@ async function runRealSandboxDemo(): Promise<boolean> {
     console.log(''); // slop-ok
 
     logger.info('a coding loop added a payments feature, then tried to stop:');
-    logger.dim('  + src/config.js');
-    logger.dim('      const GITHUB_TOKEN = "ghp_…"   // a hardcoded credential');
+    logger.dim('  + src/config.js  — hardcodes a GitHub token (ghp_…) in plain source');
     console.log(''); // slop-ok
     logger.fail('dxkit Stop-gate ▸ BLOCKED — completion withheld');
     console.log(''); // slop-ok
@@ -254,8 +258,8 @@ async function runRealSandboxDemo(): Promise<boolean> {
     console.log(''); // slop-ok
 
     logger.info('the secret is moved to an env var, and the loop tries again:');
-    logger.dim('  - const GITHUB_TOKEN = "ghp_…"');
-    logger.dim('  + const GITHUB_TOKEN = process.env.GITHUB_TOKEN');
+    logger.dim('  - the hardcoded ghp_… token in src/config.js');
+    logger.dim('  + read it from process.env.GITHUB_TOKEN instead');
     console.log(''); // slop-ok
     if (uniqueSecretPairs(cleanPayload).length > 0) {
       logger.warn('dxkit Stop-gate ▸ still blocking — see findings above');

--- a/src/loop/doctor.ts
+++ b/src/loop/doctor.ts
@@ -19,6 +19,7 @@ import { execFileSync } from 'child_process';
 import { resolveBaselineMode } from '../baseline/modes';
 import { resolveLoopPreset } from './policy';
 import { LEDGER_FILE } from './ledger';
+import { dxkitCli, resolveDxkitCli } from '../self-invocation';
 import * as logger from '../logger';
 
 /** Severity of one preflight check. `fail` = the loop is unsafe to run
@@ -147,7 +148,7 @@ export function buildLoopDoctorReport(cwd: string): LoopDoctorReport {
         : {
             fix: {
               hint: 'Capture the current state as the loop baseline; existing debt is locked in, only net-new findings block.',
-              command: 'npx vyuh-dxkit baseline create',
+              command: dxkitCli('baseline create'),
               skill: 'dxkit-init',
             },
           }),
@@ -169,11 +170,39 @@ export function buildLoopDoctorReport(cwd: string): LoopDoctorReport {
       : {
           fix: {
             hint: 'Register the Stop-gate hook in .claude/settings.json (additive — your existing hooks are preserved).',
-            command: 'npx vyuh-dxkit init --claude-loop',
+            command: dxkitCli('init --claude-loop'),
             skill: 'dxkit-loop',
           },
         }),
   });
+
+  // 3b. Stop hook RESOLVABLE. The registered hook invokes the dxkit CLI;
+  // verify it actually resolves here. A registered-but-unresolvable hook
+  // 404s on every Stop — the failure mode of a pure-npx install whose
+  // devDependency was never provisioned (or a non-Node repo with no global
+  // dxkit). Only meaningful once a hook is registered; if it isn't, the
+  // check above already fails.
+  if (hook) {
+    const res = resolveDxkitCli(cwd);
+    checks.push({
+      label: 'Stop-gate hook resolvable',
+      status: res.ok ? 'pass' : 'fail',
+      detail: res.ok
+        ? `\`vyuh-dxkit\` resolves (${
+            res.how === 'local' ? 'project-local node_modules/.bin' : 'global install'
+          }) — the hook can run`
+        : '`vyuh-dxkit` does not resolve — the Stop hook would fail on every Stop (dxkit is not installed here)',
+      ...(res.ok
+        ? {}
+        : {
+            fix: {
+              hint: 'Install dxkit so the Stop hook can run. The blessed path installs it as a devDependency; then `npm install` provisions it.',
+              command: 'npm install --save-dev @vyuhlabs/dxkit',
+              skill: 'dxkit-loop',
+            },
+          }),
+    });
+  }
 
   // 4. Active preset — informational. Surfaces the posture so an operator
   // knows what the loop will block on before trusting it unattended.
@@ -221,7 +250,7 @@ export function buildLoopDoctorReport(cwd: string): LoopDoctorReport {
         : {
             fix: {
               hint: 'Regenerate the code graph so orientation context matches current code.',
-              command: 'npx vyuh-dxkit explore graph',
+              command: dxkitCli('explore graph'),
               skill: 'dxkit-feature',
             },
           }),

--- a/src/loop/scaffold.ts
+++ b/src/loop/scaffold.ts
@@ -18,10 +18,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { ShipInstallResult } from '../ship-installers';
 import { DEFAULT_LOOP_PRESET, type LoopPreset } from './policy';
+import { dxkitCli } from '../self-invocation';
 
-/** The command Claude Code runs on Stop. Kept in one place so the
- *  installer, doctor, and any future tooling agree on the exact string. */
-export const STOP_HOOK_COMMAND = 'npx vyuh-dxkit hook stop-gate';
+/** The command Claude Code runs on Stop. Built from the canonical CLI
+ *  invocation (`src/self-invocation.ts`) so the installer, doctor, and any
+ *  future tooling agree on the exact string and the loop Stop hook is a
+ *  registered self-invocation surface (devDependency + doctor coverage). */
+export const STOP_HOOK_COMMAND = dxkitCli('hook stop-gate');
 
 /** Sentinel markers bounding the dxkit-managed region of CLAUDE.md. Only
  *  the text between them is ever rewritten. */

--- a/src/self-invocation.ts
+++ b/src/self-invocation.ts
@@ -1,0 +1,161 @@
+/**
+ * Self-invocation — the ONE place that knows how dxkit's own generated
+ * artifacts call the dxkit CLI, and which of those artifacts auto-execute
+ * it at runtime.
+ *
+ * Several things dxkit installs shell out to the dxkit CLI after install:
+ * the loop Stop hook, the `.claude` PreToolUse `context-hook`, the git
+ * pre-push guardrail hook, and the CI guardrail workflow. Every one of
+ * them only works if `vyuh-dxkit` actually resolves in the user's
+ * environment (a project-local devDependency or a global install). When it
+ * does not, the invocation `npx vyuh-dxkit …` 404s — `vyuh-dxkit` is a
+ * binary name, not a package — and the surface fails on every fire.
+ *
+ * Two facts used to live as scattered string literals and hand-maintained
+ * `wantHooks || wantCi` conditionals, so a new surface (the loop Stop
+ * hook) was added without being taught to either — it shipped 404-ing on
+ * pure-npx installs. This module makes both facts derive from ONE list:
+ *
+ *   1. The canonical invocation string (`DXKIT_CLI` / `dxkitCli`).
+ *   2. The registry of self-invoking surfaces (`SELF_INVOCATION_SURFACES`),
+ *      from which `requiresResolvableCli` (the install/update devDependency
+ *      decision) and the doctor resolvability checks are derived.
+ *
+ * Adding a surface is a one-line registry entry; it cannot silently forget
+ * the devDependency wire-up or the doctor check. Enforced by
+ * `scripts/check-architecture.sh` (no raw `npx vyuh-dxkit` literal in
+ * `src/` outside this file) and `test/self-invocation-playbook.test.ts`.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+/**
+ * The canonical way a generated artifact invokes the dxkit CLI. Resolves
+ * to a project-local `./node_modules/.bin/vyuh-dxkit` (when dxkit is a
+ * devDependency) or a global install; both are what `requiresResolvableCli`
+ * + the install flow guarantee for any active self-invocation surface.
+ */
+export const DXKIT_CLI = 'npx vyuh-dxkit'; // self-invocation-ok
+
+/** Build a CLI invocation string. `dxkitCli('hook stop-gate')` →
+ *  `'npx vyuh-dxkit hook stop-gate'`; `dxkitCli()` → `'npx vyuh-dxkit'`. */
+export function dxkitCli(subcommand = ''): string {
+  return subcommand ? `${DXKIT_CLI} ${subcommand}` : DXKIT_CLI;
+}
+
+/**
+ * The install-time decisions that determine which self-invocation surfaces
+ * a given `init`/`update` run actually writes. Each surface maps itself to
+ * one of these via `installedWhen`.
+ */
+export interface SurfaceFlags {
+  /** `.claude/settings.json` is written (carries the PreToolUse
+   *  `context-hook`) — true on every `init` that scaffolds `.claude`. */
+  readonly claudeSettings?: boolean;
+  /** The loop pack (Stop hook) is installed (`init --claude-loop`). */
+  readonly claudeLoop?: boolean;
+  /** The git pre-push guardrail hook is installed (`--with-hooks`). */
+  readonly gitHooks?: boolean;
+  /** The CI guardrail workflow is installed (`--with-ci`). */
+  readonly ciGuardrails?: boolean;
+}
+
+/** One artifact that auto-executes the dxkit CLI after install. */
+export interface SelfInvocationSurface {
+  /** Stable id (used in tests + audit output). */
+  readonly id: string;
+  /** Human-readable description of the artifact. */
+  readonly description: string;
+  /** The CLI subcommand it invokes (for audit; the body itself is built
+   *  with `dxkitCli` at the surface's own site). */
+  readonly invokes: string;
+  /** True when this surface is installed for the given flags. */
+  installedWhen(flags: SurfaceFlags): boolean;
+}
+
+/**
+ * Every dxkit-installed artifact that shells out to the dxkit CLI at
+ * runtime. The single source of truth for the devDependency decision and
+ * the doctor resolvability checks. Add new auto-running surfaces here.
+ */
+export const SELF_INVOCATION_SURFACES: readonly SelfInvocationSurface[] = [
+  {
+    id: 'context-hook',
+    description: '.claude/settings.json PreToolUse hook (passive graph context)',
+    invokes: 'context-hook',
+    installedWhen: (f) => !!f.claudeSettings,
+  },
+  {
+    id: 'loop-stop-gate-hook',
+    description: '.claude/settings.json Stop hook (loop pack guardrail gate)',
+    invokes: 'hook stop-gate',
+    installedWhen: (f) => !!f.claudeLoop,
+  },
+  {
+    id: 'pre-push-guardrail-hook',
+    description: '.githooks/pre-push guardrail check',
+    invokes: 'guardrail check',
+    installedWhen: (f) => !!f.gitHooks,
+  },
+  {
+    id: 'ci-guardrail-workflow',
+    description: '.github/workflows/dxkit-guardrails.yml guardrail check',
+    invokes: 'guardrail check',
+    installedWhen: (f) => !!f.ciGuardrails,
+  },
+];
+
+/**
+ * The surfaces active for a given install decision. `registry` is injectable
+ * (defaults to the canonical list) so the playbook test can prove a newly
+ * registered surface flows through `requiresResolvableCli` without the
+ * function having to hardcode the set — the same registry-as-argument seam
+ * `runProducers` uses.
+ */
+export function activeSelfInvocationSurfaces(
+  flags: SurfaceFlags,
+  registry: readonly SelfInvocationSurface[] = SELF_INVOCATION_SURFACES,
+): SelfInvocationSurface[] {
+  return registry.filter((s) => s.installedWhen(flags));
+}
+
+/**
+ * Does this install need a project-local (or global) dxkit so its
+ * generated artifacts can run? True when ANY self-invocation surface is
+ * active. Replaces the hand-maintained `wantHooks || wantCi` conditional in
+ * both `cli.ts` (init) and `update.ts`.
+ */
+export function requiresResolvableCli(
+  flags: SurfaceFlags,
+  registry: readonly SelfInvocationSurface[] = SELF_INVOCATION_SURFACES,
+): boolean {
+  return activeSelfInvocationSurfaces(flags, registry).length > 0;
+}
+
+/** Where a runtime `vyuh-dxkit` invocation resolves from, if anywhere. */
+export type CliResolution =
+  | { readonly ok: true; readonly how: 'local' | 'global' }
+  | { readonly ok: false; readonly how: 'none' };
+
+/**
+ * Does `vyuh-dxkit` actually resolve in `cwd` right now? Mirrors how the
+ * generated artifacts resolve it: a project-local `./node_modules/.bin`
+ * binary first, then a global one on PATH. This is the runtime truth the
+ * doctor checks — a surface can be registered (settings.json written) yet
+ * still 404 at fire time if the devDependency was declared but never
+ * `npm install`-ed, or the repo is non-Node with no global install.
+ */
+export function resolveDxkitCli(cwd: string): CliResolution {
+  const isWin = process.platform === 'win32';
+  const localBin = path.join(cwd, 'node_modules', '.bin', isWin ? 'vyuh-dxkit.cmd' : 'vyuh-dxkit');
+  if (fs.existsSync(localBin)) return { ok: true, how: 'local' };
+  try {
+    execFileSync(isWin ? 'where' : 'which', ['vyuh-dxkit'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return { ok: true, how: 'global' };
+  } catch {
+    return { ok: false, how: 'none' };
+  }
+}

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -635,6 +635,15 @@ export function installDxkitDevDependency(
     return result;
   }
 
+  // Never add dxkit as a dependency of dxkit itself. The dxkit repo runs its
+  // own generated artifacts against the local build, and a package declaring
+  // itself as a devDependency is invalid. (Only reachable when init/update
+  // runs inside this repo; no customer package is named DXKIT_PACKAGE.)
+  if (pkg.name === DXKIT_PACKAGE) {
+    result.skipped.push('package.json (devDependencies)');
+    return result;
+  }
+
   if (pkg.dependencies?.[DXKIT_PACKAGE] || pkg.devDependencies?.[DXKIT_PACKAGE]) {
     result.skipped.push('package.json (devDependencies)');
     return result;

--- a/src/update.ts
+++ b/src/update.ts
@@ -17,6 +17,7 @@ import {
 import * as logger from './logger';
 import { detectStaleScheme, migrateIdentity } from './baseline/migrate';
 import { installClaudeLoop, isClaudeLoopInstalled } from './loop/scaffold';
+import { requiresResolvableCli } from './self-invocation';
 
 /**
  * Re-exports the shared type so callers within the update module can
@@ -210,11 +211,20 @@ export async function runUpdate(cwd: string, force: boolean, rescan = false): Pr
     mergeShipResult(aggregate, installCiGuardrails(cwd, { force }));
   }
   // Self-heal a missing project-local devDependency on upgrade. Pre-fix
-  // installs wired hooks/CI without declaring the package, so they fall
-  // back to a stale global. This adds it when absent (idempotent — skips
-  // when already declared, so a customer's pin is never repinned here;
-  // the actual version bump is `npm install @latest`, npm's job).
-  if (flags.withHooks || flags.withCiGuardrails) {
+  // installs wired self-invocation surfaces without declaring the package, so
+  // they fall back to a stale (or missing) global. The set of surfaces that
+  // imply the dep is derived from the one registry in src/self-invocation.ts
+  // (same source the init flow uses), so update can't drift from init. Adds
+  // it when absent (idempotent — skips when already declared, so a customer's
+  // pin is never repinned here; the version bump is `npm install`, npm's job).
+  if (
+    requiresResolvableCli({
+      claudeSettings: flags.withDxkitAgents,
+      claudeLoop: flags.withClaudeLoop,
+      gitHooks: flags.withHooks,
+      ciGuardrails: flags.withCiGuardrails,
+    })
+  ) {
     mergeShipResult(aggregate, installDxkitDevDependency(cwd, { force }));
   }
   if (flags.withBaselineRefresh) {

--- a/src/upgrade.ts
+++ b/src/upgrade.ts
@@ -10,8 +10,8 @@
  *
  *   (no flag, or `--yes`) — execute. Runs the three-step upgrade:
  *     1. `npm install @vyuhlabs/dxkit@<target>`     (binary)
- *     2. `npx vyuh-dxkit update`                    (scaffold refresh)
- *     3. `npx vyuh-dxkit doctor`                    (verify)
+ *     2. the dxkit `update` subcommand                (scaffold refresh)
+ *     3. the dxkit `doctor` subcommand                (verify)
  *   Then prints devcontainer-rebuild instructions if .devcontainer/
  *   was refreshed.
  *
@@ -24,6 +24,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execSync, spawnSync } from 'child_process';
 import { Manifest } from './types';
+import { dxkitCli } from './self-invocation';
 import * as logger from './logger';
 
 export type DeltaKind = 'none' | 'patch' | 'minor' | 'major' | 'downgrade';
@@ -42,7 +43,7 @@ export interface UpgradePlan {
   generatedAt: string;
   cwd: string;
   current: {
-    /** Installed binary version (from `npx vyuh-dxkit --version`). */
+    /** Installed binary version (from the dxkit CLI `--version`). */
     binary: string | null;
     /** Scaffold version recorded in manifest. */
     scaffold: string | null;
@@ -187,7 +188,7 @@ export function buildUpgradePlan(cwd: string, opts: UpgradeOpts = {}): UpgradePl
   // a binary upgrade (scaffold may need updating to match the new binary).
   if (latest) {
     steps.push({
-      command: 'npx vyuh-dxkit update',
+      command: dxkitCli('update'),
       purpose:
         'Refresh scaffold (.devcontainer, .githooks, .claude/skills, CI workflows) + ' +
         'migrate baseline & allowlist if the finding-identity scheme changed',
@@ -197,7 +198,7 @@ export function buildUpgradePlan(cwd: string, opts: UpgradeOpts = {}): UpgradePl
   // Step 3: verify with doctor.
   if (latest) {
     steps.push({
-      command: 'npx vyuh-dxkit doctor',
+      command: dxkitCli('doctor'),
       purpose: 'Verify operational health post-upgrade',
     });
   }

--- a/test/loop/demo.test.ts
+++ b/test/loop/demo.test.ts
@@ -6,7 +6,7 @@ describe('loop guardrail demo', () => {
   it('produces the real repair message for the example net-new finding', () => {
     const { blockMessage } = renderLoopGuardrailDemo();
     // It must list the example finding with its location…
-    expect(blockMessage).toContain('src/payments.js:12');
+    expect(blockMessage).toContain('example/payments.js:12');
     expect(blockMessage).toContain('secret');
     // …and carry the loop norm (don't refresh baseline / don't fix unrelated debt).
     expect(blockMessage.toLowerCase()).toContain('do not refresh the baseline');

--- a/test/loop/doctor.test.ts
+++ b/test/loop/doctor.test.ts
@@ -4,6 +4,8 @@ import * as os from 'os';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
 import { buildLoopDoctorReport } from '../../src/loop/doctor';
+import { STOP_HOOK_COMMAND } from '../../src/loop/scaffold';
+import { resolveDxkitCli } from '../../src/self-invocation';
 
 function tmpRepo(git: boolean): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-loop-doctor-'));
@@ -26,6 +28,15 @@ function writeSettings(cwd: string, obj: unknown): void {
 function writeBaseline(cwd: string): void {
   fs.mkdirSync(path.join(cwd, '.dxkit', 'baselines'), { recursive: true });
   fs.writeFileSync(path.join(cwd, '.dxkit', 'baselines', 'main.json'), '{}');
+}
+
+/** Make `vyuh-dxkit` resolve project-locally (so the resolvability check
+ *  passes), exactly as `npm install` of the devDependency would. */
+function provisionLocalCli(cwd: string): void {
+  const bin = path.join(cwd, 'node_modules', '.bin');
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(path.join(bin, 'vyuh-dxkit'), '#!/bin/sh\n');
+  fs.writeFileSync(path.join(bin, 'vyuh-dxkit.cmd'), '@echo off\n');
 }
 
 function writeCommittedFullPolicy(cwd: string): void {
@@ -66,17 +77,35 @@ describe('loop doctor', () => {
     expect(statusOf(report, 'Stop-gate hook')).toBe('fail');
   });
 
-  it('passes baseline + hook checks when both are wired (committed mode)', () => {
+  it('passes baseline + hook checks when fully wired and dxkit resolves (committed mode)', () => {
     repo = tmpRepo(true);
     writeCommittedFullPolicy(repo);
     writeBaseline(repo);
     writeSettings(repo, {
-      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'npx vyuh-dxkit hook stop-gate' }] }] },
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: STOP_HOOK_COMMAND }] }] },
     });
+    provisionLocalCli(repo);
     const report = buildLoopDoctorReport(repo);
     expect(statusOf(report, 'baseline')).toBe('pass');
-    expect(statusOf(report, 'Stop-gate hook')).toBe('pass');
+    expect(statusOf(report, 'Stop-gate hook registered')).toBe('pass');
+    expect(statusOf(report, 'Stop-gate hook resolvable')).toBe('pass');
     expect(report.ok).toBe(true);
+  });
+
+  it('fails the resolvable check when the hook is registered but dxkit does not resolve', () => {
+    repo = tmpRepo(true);
+    writeCommittedFullPolicy(repo);
+    writeBaseline(repo);
+    writeSettings(repo, {
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: STOP_HOOK_COMMAND }] }] },
+    });
+    // Do NOT provision a local bin. Skip if this environment has a global
+    // vyuh-dxkit on PATH (then resolution legitimately succeeds).
+    if (resolveDxkitCli(repo).ok) return;
+    const report = buildLoopDoctorReport(repo);
+    expect(statusOf(report, 'Stop-gate hook registered')).toBe('pass');
+    expect(statusOf(report, 'Stop-gate hook resolvable')).toBe('fail');
+    expect(report.ok).toBe(false);
   });
 
   it('does not treat an unrelated Stop hook as the gate', () => {

--- a/test/self-invocation-playbook.test.ts
+++ b/test/self-invocation-playbook.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Self-invocation playbook + contract — closes the class of bug where a
+ * surface that auto-invokes the dxkit CLI is added without teaching the
+ * install flow it needs a resolvable dxkit. That class shipped the loop
+ * Stop hook 404-ing on pure-npx installs (it was absent from the
+ * hand-maintained `wantHooks || wantCi` chain). Mirror of
+ * `recipe-playbook.test.ts` (language packs) and `producer-playbook.test.ts`
+ * (baseline producers).
+ *
+ * Two guarantees:
+ *   1. Contract — every registered surface is well-formed, and every flag
+ *      that gates a surface actually flips `requiresResolvableCli`.
+ *   2. Playbook — a synthetic surface injected into the registry flows
+ *      through `requiresResolvableCli`. If a future refactor makes that
+ *      function iterate a hardcoded subset instead of its registry argument,
+ *      this fails — the architecture stopped being registry-driven.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  DXKIT_CLI,
+  dxkitCli,
+  SELF_INVOCATION_SURFACES,
+  activeSelfInvocationSurfaces,
+  requiresResolvableCli,
+  type SelfInvocationSurface,
+  type SurfaceFlags,
+} from '../src/self-invocation';
+
+describe('dxkitCli — canonical CLI invocation', () => {
+  it('builds the bare and sub-command forms', () => {
+    expect(DXKIT_CLI).toBe('npx vyuh-dxkit');
+    expect(dxkitCli()).toBe('npx vyuh-dxkit');
+    expect(dxkitCli('hook stop-gate')).toBe('npx vyuh-dxkit hook stop-gate');
+    expect(dxkitCli('baseline create')).toBe('npx vyuh-dxkit baseline create');
+  });
+});
+
+describe('SELF_INVOCATION_SURFACES — contract', () => {
+  it('registers the four auto-running surfaces with unique ids', () => {
+    const ids = SELF_INVOCATION_SURFACES.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    // The four surfaces that auto-execute the dxkit CLI after install.
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'context-hook',
+        'loop-stop-gate-hook',
+        'pre-push-guardrail-hook',
+        'ci-guardrail-workflow',
+      ]),
+    );
+  });
+
+  it('every surface is well-formed', () => {
+    for (const s of SELF_INVOCATION_SURFACES) {
+      expect(s.id).toBeTruthy();
+      expect(s.description).toBeTruthy();
+      expect(s.invokes).toBeTruthy();
+      expect(typeof s.installedWhen).toBe('function');
+    }
+  });
+
+  it('no flags → no surface active → CLI not required', () => {
+    expect(activeSelfInvocationSurfaces({})).toEqual([]);
+    expect(requiresResolvableCli({})).toBe(false);
+  });
+
+  it('each surface flag independently requires a resolvable CLI', () => {
+    const cases: Array<[keyof SurfaceFlags, string]> = [
+      ['claudeSettings', 'context-hook'],
+      ['claudeLoop', 'loop-stop-gate-hook'],
+      ['gitHooks', 'pre-push-guardrail-hook'],
+      ['ciGuardrails', 'ci-guardrail-workflow'],
+    ];
+    for (const [flag, expectedId] of cases) {
+      const flags: SurfaceFlags = { [flag]: true };
+      expect(requiresResolvableCli(flags)).toBe(true);
+      expect(activeSelfInvocationSurfaces(flags).map((s) => s.id)).toContain(expectedId);
+    }
+  });
+});
+
+describe('self-invocation playbook — synthetic surface injection', () => {
+  it('a newly registered surface flows through requiresResolvableCli', () => {
+    const sentinel: SelfInvocationSurface = {
+      id: 'synthetic-surface',
+      description: 'synthetic test surface that invokes the CLI',
+      invokes: 'synthetic-subcommand',
+      // Active only on a flag no real surface reads, so the assertion is
+      // unambiguous: it must be THIS surface flipping the result.
+      installedWhen: (f) => (f as Record<string, unknown>).__synthetic === true,
+    };
+    const registry = [...SELF_INVOCATION_SURFACES, sentinel];
+    const flags = { __synthetic: true } as unknown as SurfaceFlags;
+
+    // The real registry doesn't know this flag → no surface.
+    expect(requiresResolvableCli(flags)).toBe(false);
+    // The injected registry does → the function iterates what it's given.
+    expect(requiresResolvableCli(flags, registry)).toBe(true);
+    expect(activeSelfInvocationSurfaces(flags, registry).map((s) => s.id)).toEqual([
+      'synthetic-surface',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

A launch-readiness pass that fixes a real bug in the hero feature and aligns positioning. Three independently-meaningful commits (rebase-merge recommended).

### 1. `fix(loop):` resolve the dxkit CLI for every self-invoking artifact
The loop Stop hook (and the `.claude` context-hook) invoke `npx vyuh-dxkit …`, which only resolves when dxkit is installed. A pure-npx loop setup that never installed dxkit hit `npm error 404 'vyuh-dxkit' is not in this registry` **on every stop**, and `loop doctor` reported the hook as wired anyway.

Root cause: the "which installs imply the devDependency" decision was a hand-maintained `wantHooks || wantCi` chain (the loop surface was dropped from it), and the invocation was a raw literal in ~30 sites.

Platform fix in `src/self-invocation.ts`:
- `DXKIT_CLI` / `dxkitCli()` — one canonical invocation string.
- `SELF_INVOCATION_SURFACES` — registry of artifacts that auto-run the CLI.
- `requiresResolvableCli()` — derived from the registry; init + update now declare the dxkit devDependency for any active surface.
- `resolveDxkitCli()` — `loop doctor` verifies the CLI actually resolves.
- Guard against dxkit declaring itself as a dependency.
- Enforced by check-architecture.sh **Rule 14** + a synthetic-surface playbook test.

`STOP_HOOK_COMMAND` is byte-identical, so the gate's behavior is unchanged.

### 2. `docs:` reposition to the Stop-gate + scrub internal IDs
Description / CLI banner / npm keywords lead with the Stop-gate; README graph "second act" section; **install-first** loop quickstart via `npm init @vyuhlabs/dxkit`; demo pinned to `@latest`; broken docs link fixed; internal defect/phase IDs scrubbed from user-facing docs.

### 3. `chore(release):` 2.13.1

## Validation
- 2482 unit tests, lint, format, arch-check, typecheck, slop, cross-ecosystem, docs-coverage: all pass
- **External-repo e2e (fastify) with the packed build**: init → declare devDep → install → `npx vyuh-dxkit`=2.13.1 → `loop doctor` resolvable PASS → baseline → clean tree allows → **net-new secret BLOCKS**
- All 6 analyzers run clean; `demo loop-guardrail` works
- **Benchmarks unchanged**: diff touches zero measured-behavior core files; `bench-matcher` output identical between this build and published 2.13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)