### PR TITLE
fix(loop): gitignore .dxkit/loop + doctor validates local-build hooks; dogfood the gate (2.13.2)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node dist/index.js hook stop-gate"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.dxkit/policy.json
+++ b/.dxkit/policy.json
@@ -1,5 +1,8 @@
 {
   "baseline": {
     "mode": "ref-based"
+  },
+  "loop": {
+    "preset": "security-only"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ graphify-out/
 # ignored — each test constructs its own baseline inside a tmpdir.
 **/.dxkit/reports/
 **/.dxkit/cache/
+**/.dxkit/loop/
 **/.dxkit/salt
 test/fixtures/**/.dxkit/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.2] - 2026-06-22
+
+### Fixed
+
+- `init` and `update` now gitignore `.dxkit/loop/`, so the loop pack's runtime
+  output (the ledger and the last-guardrail snapshot) is no longer committed by
+  repos that use the Stop-gate. Latent since the loop pack shipped in 2.13.0.
+
+### Changed
+
+- `loop doctor` now validates the **actual** registered Stop hook command. It
+  understands both the `npx vyuh-dxkit` / installed-binary form (the binary must
+  resolve) and a local-build `node <script>` form (the script must exist),
+  instead of only the npx form. This lets a repo dogfood the gate against its own
+  build, and gives a correct verdict for any custom hook command.
+
 ## [2.13.1] - 2026-06-21
 
 ### Fixed — the loop Stop hook could fail on every stop when dxkit was not installed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -701,3 +701,24 @@ vyuh-dxkit tools [list|install]   # Tool status & installation
 - `scripts/check-architecture.sh` — pre-commit + CI: enforces CLAUDE.md rules + LP-recipe rules
 - `test/languages-contract.test.ts` — pack contract tests (D009 closure)
 - `test/recipe-playbook.test.ts` — synthetic 6th-pack playbook (LP-architecture regression guard)
+
+<!-- dxkit:loop:start -->
+
+## Autonomous loop safety (dxkit dogfoods its own loop Stop-gate)
+
+This repo runs its own loop Stop-gate. The Claude Code Stop hook in
+`.claude/settings.json` invokes `node dist/index.js hook stop-gate` — the local
+build, mirroring how `dxkit-self-guardrail.yml` invokes `node dist/index.js`
+(this repo IS `@vyuhlabs/dxkit`, so `npx vyuh-dxkit` cannot resolve it). On every
+Stop it re-runs the guardrail (ref-based vs `origin/main`) and blocks completion
+if the change introduced net-new findings, handing them back for repair.
+
+- Build first (`npm run build`) so `dist/` exists, or the hook cannot run.
+- Posture is `loop.preset` in `.dxkit/policy.json` (`security-only`): net-new
+  secrets + crit/high security + reachable dep-vulns block; test-gap + quality
+  warn only.
+- Fix the net-new finding the gate reports. Do NOT refresh the baseline to clear
+  a block, and do NOT fix unrelated pre-existing debt.
+- `node dist/index.js loop doctor` verifies the wiring.
+
+<!-- dxkit:loop:end -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.13.1",
+      "version": "2.13.2",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "A Stop-gate for autonomous coding loops that blocks only net-new findings, running locally with no model in the gate",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/loop/doctor.ts
+++ b/src/loop/doctor.ts
@@ -76,27 +76,54 @@ function refResolves(cwd: string, ref: string): boolean {
 }
 
 /**
- * Does `.claude/settings.json` register the Stop-gate hook? Reads the
- * file defensively (absent / malformed → not registered) and looks for a
- * Stop hook whose command invokes `hook stop-gate`. This is the check
- * that catches the silent-failure class: a loop with no registered Stop
- * hook runs with no gate at all.
+ * The registered Stop-gate hook command, or null if none. Reads
+ * `.claude/settings.json` defensively (absent / malformed → null) and returns
+ * the first Stop hook command that invokes `hook stop-gate`. This is the check
+ * that catches the silent-failure class: a loop with no registered Stop hook
+ * runs with no gate at all.
  */
-function stopHookRegistered(cwd: string): boolean {
+function stopHookCommand(cwd: string): string | null {
   try {
     const raw = fs.readFileSync(path.join(cwd, '.claude', 'settings.json'), 'utf8');
     const parsed = JSON.parse(raw) as {
       hooks?: { Stop?: Array<{ hooks?: Array<{ command?: string }> }> };
     };
-    const stop = parsed.hooks?.Stop ?? [];
-    return stop.some((entry) =>
-      (entry.hooks ?? []).some(
-        (h) => typeof h.command === 'string' && /hook\s+stop-gate/.test(h.command),
-      ),
-    );
+    for (const entry of parsed.hooks?.Stop ?? []) {
+      for (const h of entry.hooks ?? []) {
+        if (typeof h.command === 'string' && /hook\s+stop-gate/.test(h.command)) return h.command;
+      }
+    }
+    return null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+/**
+ * Does the registered Stop hook command actually resolve here? Handles both
+ * forms: the customer npx/binary form (the `vyuh-dxkit` binary must resolve),
+ * and a local-build / monorepo `node <path>.js` form (the script must exist) —
+ * the latter is how this repo dogfoods its own gate, mirroring the
+ * self-guardrail CI.
+ */
+function stopHookResolves(cwd: string, command: string): { ok: boolean; how: string } {
+  const nodeMatch = command.match(/\bnode\s+(\S+\.(?:js|mjs|cjs))\b/);
+  if (nodeMatch) {
+    const rel = nodeMatch[1];
+    const target = path.isAbsolute(rel) ? rel : path.join(cwd, rel);
+    return fs.existsSync(target)
+      ? { ok: true, how: `local script ${rel}` }
+      : { ok: false, how: `${rel} not found (build it first)` };
+  }
+  const res = resolveDxkitCli(cwd);
+  return {
+    ok: res.ok,
+    how: res.ok
+      ? res.how === 'local'
+        ? 'project-local node_modules/.bin'
+        : 'global install'
+      : 'not installed',
+  };
 }
 
 /** Build the structured preflight report (pure of process I/O). */
@@ -158,12 +185,13 @@ export function buildLoopDoctorReport(cwd: string): LoopDoctorReport {
   // 3. Stop hook registered. The safety guarantee is entirely contingent
   // on this — an unregistered hook never fires, so the loop runs with no
   // gate and no error.
-  const hook = stopHookRegistered(cwd);
+  const hookCmd = stopHookCommand(cwd);
+  const hook = !!hookCmd;
   checks.push({
     label: 'Stop-gate hook registered',
     status: hook ? 'pass' : 'fail',
     detail: hook
-      ? '.claude/settings.json invokes `vyuh-dxkit hook stop-gate` on Stop'
+      ? `.claude/settings.json invokes the gate on Stop (\`${hookCmd}\`)`
       : 'no Stop hook invoking the gate — the loop would run UNPROTECTED',
     ...(hook
       ? {}
@@ -182,21 +210,19 @@ export function buildLoopDoctorReport(cwd: string): LoopDoctorReport {
   // devDependency was never provisioned (or a non-Node repo with no global
   // dxkit). Only meaningful once a hook is registered; if it isn't, the
   // check above already fails.
-  if (hook) {
-    const res = resolveDxkitCli(cwd);
+  if (hookCmd) {
+    const res = stopHookResolves(cwd, hookCmd);
     checks.push({
       label: 'Stop-gate hook resolvable',
       status: res.ok ? 'pass' : 'fail',
       detail: res.ok
-        ? `\`vyuh-dxkit\` resolves (${
-            res.how === 'local' ? 'project-local node_modules/.bin' : 'global install'
-          }) — the hook can run`
-        : '`vyuh-dxkit` does not resolve — the Stop hook would fail on every Stop (dxkit is not installed here)',
+        ? `the hook command resolves (${res.how}) — it can run`
+        : `the hook command does not resolve (${res.how}) — it would fail on every Stop`,
       ...(res.ok
         ? {}
         : {
             fix: {
-              hint: 'Install dxkit so the Stop hook can run. The blessed path installs it as a devDependency; then `npm install` provisions it.',
+              hint: 'Make the Stop hook runnable: install dxkit as a devDependency (then `npm install`), or build the local dist if the hook runs `node dist/...`.',
               command: 'npm install --save-dev @vyuhlabs/dxkit',
               skill: 'dxkit-loop',
             },

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -440,6 +440,7 @@ const GITIGNORE_ENTRIES = [
   '.dxkit/reports/',
   '.dxkit/dashboard.html',
   '.dxkit/cache/',
+  '.dxkit/loop/',
   'graphify-out/',
 ];
 

--- a/test/loop/doctor.test.ts
+++ b/test/loop/doctor.test.ts
@@ -108,6 +108,36 @@ describe('loop doctor', () => {
     expect(report.ok).toBe(false);
   });
 
+  it('resolves a local-build `node <script>` hook when the script exists (self-hosted form)', () => {
+    repo = tmpRepo(true);
+    writeCommittedFullPolicy(repo);
+    writeBaseline(repo);
+    fs.mkdirSync(path.join(repo, 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(repo, 'dist', 'index.js'), '// built cli\n');
+    writeSettings(repo, {
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'node dist/index.js hook stop-gate' }] }],
+      },
+    });
+    const report = buildLoopDoctorReport(repo);
+    expect(statusOf(report, 'Stop-gate hook registered')).toBe('pass');
+    expect(statusOf(report, 'Stop-gate hook resolvable')).toBe('pass');
+  });
+
+  it('fails the resolvable check for a `node <script>` hook when the script is missing', () => {
+    repo = tmpRepo(true);
+    writeCommittedFullPolicy(repo);
+    writeBaseline(repo);
+    writeSettings(repo, {
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'node dist/index.js hook stop-gate' }] }],
+      },
+    });
+    const report = buildLoopDoctorReport(repo);
+    expect(statusOf(report, 'Stop-gate hook resolvable')).toBe('fail');
+    expect(report.ok).toBe(false);
+  });
+
   it('does not treat an unrelated Stop hook as the gate', () => {
     repo = tmpRepo(true);
     writeCommittedFullPolicy(repo);


### PR DESCRIPTION
## Summary (2.13.2 patch)

Three commits (rebase-merge):

### 1. `fix(loop):` loop runtime hygiene (shipped)
- **`init`/`update` now gitignore `.dxkit/loop/`** — the loop pack's runtime output (ledger + last-guardrail snapshot) was being committed by repos using the Stop-gate. Latent since 2.13.0. (Also fixed this repo's own `.gitignore`.)
- **`loop doctor` validates the real Stop hook command** — both the `npx vyuh-dxkit` / installed-binary form (unchanged) and a local-build `node <script>` form (the script must exist). Previously it only understood the npx form and would falsely fail on a self-hosted hook.

### 2. `chore:` dogfood the loop Stop-gate on this repo (repo-only, not shipped)
- `.claude/settings.json` registers a Stop hook → `node dist/index.js hook stop-gate` (local build; this repo *is* `@vyuhlabs/dxkit`, so `npx vyuh-dxkit` can't resolve it — mirrors the self-guardrail CI).
- `.dxkit/policy.json` → `loop.preset: security-only`; `CLAUDE.md` documents it.
- `loop doctor` reports **"Loop preflight passed — safe to run unattended."**

### 3. `chore(release):` 2.13.2

## Safety
- Shipped changes are backward-compatible (`doctor.ts`: identical verdict for the npx form; new branch only for `node` hooks) and additive (`ship-installers.ts`: one gitignore entry). The repo config does **not** ship (verified via `npm pack`).
- 2484 tests pass, lint/format/arch/typecheck green. No change to the gate, matcher, or graph behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)