### PR TITLE
perf(loop): 2.14.0 — preset-scoped + incremental Stop-gate gather

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.0] - 2026-06-22
+
+### Changed — the loop Stop-gate gathers far less work per stop
+
+After 2.13.3 made the gate cache-aware, two further optimizations cut what an
+unattended loop's `security-only` Stop-gate actually scans on every stop.
+Both are **opt-in** (only the loop Stop-gate enables them) and **verdict-
+preserving** — CI `baseline check`, `createBaseline`, and the `health` report
+are byte-identical and still render every warning. End-to-end on a 3,748-file
+repo with a realistic 2-file loop diff (separate processes), the security-only
+gather dropped from **42.8s → 11.3s (74%)** while still blocking the same
+net-new finding with identical blocking pairs.
+
+- **Preset-scoped gather.** A guardrail can only block on the finding kinds its
+  policy escalates, so a `security-only` posture no longer runs the analyzers
+  that feed only non-blockable kinds (jscpd, lint, coverage, cloc, test-gaps,
+  graphify, licenses). The scope is derived declaratively from the policy
+  (`scopeForPolicy`): a `full-debt` posture, CI, and `health` all resolve to
+  the full scan. A scoped result is partial by construction and never enters
+  the shared `AnalysisResult` cache. (~42.8s → 24.0s.)
+- **Incremental file-scoped scanning.** The current side's semgrep now scans
+  only the files that changed vs the baseline commit. Sound because semgrep is
+  intraprocedural — a net-new code finding can only appear in a file the diff
+  touched. The changed-file set is computed completely or falls back to a full
+  scan on any uncertainty (base unreachable, not a git repo), so a scan can
+  only ever over-cover, never under-cover. The ref/baseline side stays full.
+  (~24.0s → 11.3s.)
+
+Both behaviors are confined to the loop Stop-gate; nothing about the CI
+guardrail or the standalone reports changes.
+
 ## [2.13.3] - 2026-06-22
 
 ### Fixed — the loop Stop-gate no longer pays a full re-scan on every stop

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.13.3",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.13.3",
+      "version": "2.14.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.13.3",
+  "version": "2.14.0",
   "description": "A Stop-gate for autonomous coding loops that blocks only net-new findings, running locally with no model in the gate",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/analyzers/cache.ts
+++ b/src/analyzers/cache.ts
@@ -107,6 +107,16 @@ export interface ReadOrBuildOptions {
   /** Override the wall-clock used for `builtAt`. Tests use this to
    *  produce deterministic timestamps. Defaults to `new Date()`. */
   now?: () => Date;
+
+  /**
+   * This build is a SCOPED/partial gather (some analyzers skipped — see
+   * `GatherScope`). Its `AnalysisResult` is incomplete, so it must never
+   * enter the shared cache where a later FULL consumer (`health`) could
+   * read it as if complete. Set by the loop guardrail path; skips both the
+   * in-memory and on-disk cache for read AND write. The build still runs;
+   * only persistence is bypassed.
+   */
+  partial?: boolean;
 }
 
 // In-memory dedup across subcommands sharing a process. Keyed by the
@@ -148,6 +158,14 @@ export async function readOrBuildAnalysisResult(args: {
   const cacheDir = opts.cacheDir ?? path.join(provenance.cwd, CACHE_SUBDIR);
   const cacheKey = buildCacheKey(provenance);
 
+  // A scoped/partial gather must bypass the shared cache entirely — neither
+  // read (a full entry would mask the requested scope, but more importantly
+  // the inverse is the hazard) nor write (a partial result must never be
+  // served to a later full consumer). Build straight through.
+  if (opts.partial) {
+    return buildResult(cwd, build, provenance, opts.now);
+  }
+
   // In-memory short-circuit. Same provenance, same process: one rebuild.
   if (!opts.rescan) {
     const cached = inMemoryCache.get(cacheKey);
@@ -162,22 +180,7 @@ export async function readOrBuildAnalysisResult(args: {
       const fromDisk = readDiskCache(cacheDir, provenance);
       if (fromDisk) return fromDisk;
     }
-
-    // Build, stamp provenance, persist (when clean).
-    const body = await build(cwd);
-    const now = (opts.now ?? (() => new Date()))();
-    const result: AnalysisResult = {
-      ...body,
-      commitSha: provenance.commitSha,
-      branch: provenance.branch,
-      cwd: provenance.cwd,
-      builtAt: now.toISOString(),
-      dxkitVersion: provenance.dxkitVersion,
-      schemaVersion: ANALYSIS_RESULT_SCHEMA_VERSION,
-      ignoreFileMtime: provenance.ignoreFileMtime,
-      inputsDigest: provenance.inputsDigest,
-      workingTreeDirty: provenance.workingTreeDirty,
-    };
+    const result = await buildResult(cwd, build, provenance, opts.now);
     if (!provenance.workingTreeDirty) {
       writeDiskCache(cacheDir, result);
     }
@@ -189,6 +192,31 @@ export async function readOrBuildAnalysisResult(args: {
   // honest, don't poison subsequent calls with a rejected Promise.
   promise.catch(() => inMemoryCache.delete(cacheKey));
   return promise;
+}
+
+/** Build + stamp provenance into a complete `AnalysisResult`. No caching —
+ *  callers decide whether to persist. Shared by the cached and partial
+ *  (scope-bypass) paths so they produce byte-identical result envelopes. */
+async function buildResult(
+  cwd: string,
+  build: AnalysisResultBuilder,
+  provenance: ResolvedProvenance,
+  now?: () => Date,
+): Promise<AnalysisResult> {
+  const body = await build(cwd);
+  const stamp = (now ?? (() => new Date()))();
+  return {
+    ...body,
+    commitSha: provenance.commitSha,
+    branch: provenance.branch,
+    cwd: provenance.cwd,
+    builtAt: stamp.toISOString(),
+    dxkitVersion: provenance.dxkitVersion,
+    schemaVersion: ANALYSIS_RESULT_SCHEMA_VERSION,
+    ignoreFileMtime: provenance.ignoreFileMtime,
+    inputsDigest: provenance.inputsDigest,
+    workingTreeDirty: provenance.workingTreeDirty,
+  };
 }
 
 /** Test seam — drop in-memory dedup state between test cases. */

--- a/src/analyzers/health.ts
+++ b/src/analyzers/health.ts
@@ -47,6 +47,7 @@ import { scoreMaintainabilityDimension } from './maintainability/shallow';
 import { scoreDxDimension } from './dx/shallow';
 import { computeOverall } from '../scoring';
 import { ScoreInput } from './types';
+import { type GatherScope, FULL_SCOPE } from '../baseline/gather-scope';
 
 /** Default values for all HealthMetrics fields. */
 export function defaultMetrics(): HealthMetrics {
@@ -104,6 +105,15 @@ export function defaultMetrics(): HealthMetrics {
 export interface AnalyzeHealthOptions {
   /** Print per-tool timing to stderr. */
   verbose?: boolean;
+  /**
+   * Restrict the gather to the analyzers a scope needs. Defaults to
+   * `FULL_SCOPE` (every analyzer), so the `health` report and CI guardrail
+   * are unaffected. The loop Stop-gate passes a policy-derived scope so a
+   * `security-only` posture skips the analyzers it can never block on (see
+   * `src/baseline/gather-scope.ts`). A scoped result is partial by
+   * construction and is never written to the shared `AnalysisResult` cache.
+   */
+  scope?: GatherScope;
 }
 
 /**
@@ -158,6 +168,7 @@ export async function gatherAnalysisResultBody(
   options: AnalyzeHealthOptions = {},
 ): Promise<AnalysisResultBody> {
   const verbose = !!options.verbose;
+  const scope = options.scope ?? FULL_SCOPE;
 
   // Step 1: Detect stack
   const stack = timed('detect', verbose, () => detect(repoPath));
@@ -183,7 +194,7 @@ export async function gatherAnalysisResultBody(
   // envelopes (`tools/parallel.ts`), so each tool shells out at most once
   // per analyzer run.
   const layer2 = await timedAsync('layer2 (parallel)', verbose, () =>
-    gatherLayer2Parallel(repoPath, verbose),
+    gatherLayer2Parallel(repoPath, verbose, scope),
   );
   mergeLayer2(metrics, layer2);
 
@@ -192,24 +203,32 @@ export async function gatherAnalysisResultBody(
   // sees the same values from both consumer paths — closes the
   // dual-Quality-formula drift class structurally. The standalone
   // analyzeQuality reads these straight off the cached AnalysisResult.
-  const hygiene = timed('hygiene (grep)', verbose, () => gatherHygieneMarkers(repoPath));
-  metrics.todoCount = hygiene.todoCount;
-  metrics.fixmeCount = hygiene.fixmeCount;
-  metrics.hackCount = hygiene.hackCount;
-  // hygiene.consoleLogCount is intentionally NOT mirrored — Layer 2
-  // already populates metrics.consoleLogCount via the shared
-  // gatherDebugStatements helper, and both paths converge on the
-  // same number by construction.
-  metrics.staleFiles = hygiene.staleFiles.length;
-  metrics.mixedLanguages = hygiene.mixedLanguages;
-  const comments = timed('cloc (comment ratio)', verbose, () => gatherCommentRatio(repoPath));
-  metrics.commentRatio = comments.ratio;
+  // Hygiene markers feed Quality counts + `stale-file`; skipped under a
+  // scope that blocks on neither (the loop's security-only posture).
+  if (scope.hygiene) {
+    const hygiene = timed('hygiene (grep)', verbose, () => gatherHygieneMarkers(repoPath));
+    metrics.todoCount = hygiene.todoCount;
+    metrics.fixmeCount = hygiene.fixmeCount;
+    metrics.hackCount = hygiene.hackCount;
+    // hygiene.consoleLogCount is intentionally NOT mirrored — Layer 2
+    // already populates metrics.consoleLogCount via the shared
+    // gatherDebugStatements helper, and both paths converge on the
+    // same number by construction.
+    metrics.staleFiles = hygiene.staleFiles.length;
+    metrics.mixedLanguages = hygiene.mixedLanguages;
+  }
+  if (scope.cloc) {
+    const comments = timed('cloc (comment ratio)', verbose, () => gatherCommentRatio(repoPath));
+    metrics.commentRatio = comments.ratio;
+  }
 
   // Surface the coverage tool name in `toolsUsed` even though its data
   // lives under `capabilities.coverage`. `loadCoverage` and the COVERAGE
   // dispatcher share the same underlying providers — the call here is
   // served from the dispatcher cache when `gatherCapabilityReport` runs.
-  const coverage = await timedAsync('coverage', verbose, () => loadCoverage(repoPath));
+  const coverage = scope.coverage
+    ? await timedAsync('coverage', verbose, () => loadCoverage(repoPath))
+    : null;
   if (coverage) {
     metrics.toolsUsed.push(`coverage:${coverage.source}`);
   }
@@ -236,7 +255,7 @@ export async function gatherAnalysisResultBody(
   // providers the legacy path already ran are served from the dispatcher
   // cache (free). Scorers read capability-owned fields from this bundle.
   const capabilities = await timedAsync('capabilities', verbose, () =>
-    gatherCapabilityReport(repoPath),
+    gatherCapabilityReport(repoPath, scope),
   );
 
   // Synthesize per-pack tool names (eslint, npm-audit, ruff, pip-audit,
@@ -374,7 +393,23 @@ function splitToolNames(tool: string): string[] {
  * parallel — the descriptor aggregates are pure, and the dispatcher
  * isolates provider failures.
  */
-async function gatherCapabilityReport(cwd: string): Promise<CapabilityReport> {
+async function gatherCapabilityReport(
+  cwd: string,
+  scope: GatherScope = FULL_SCOPE,
+): Promise<CapabilityReport> {
+  // Vacuous outcomes for capabilities the scope skips. Each is byte-
+  // identical to what the gather returns when no active pack supplies a
+  // provider, so every downstream availability/aggregate branch treats a
+  // skipped capability exactly as it already treats "nothing to scan" —
+  // no new code path, no score drift on the full path.
+  const emptyDispatch = {
+    envelope: null,
+    attempted: [] as string[],
+    succeeded: [] as string[],
+    skipped: [] as string[],
+    skipReasons: {} as Record<string, string>,
+  };
+  const emptyAvail = { envelope: null, available: true, unavailableReason: '' };
   // D025b (2.4.7): depVulns gathers via `gatherDepVulnsWithAvailability`
   // (NOT the dispatcher) so the per-pack availability discriminant
   // survives to the health-side scorer. Health doesn't need the
@@ -395,17 +430,25 @@ async function gatherCapabilityReport(cwd: string): Promise<CapabilityReport> {
     structuralOutcome,
     licensesWithAvail,
   ] = await Promise.all([
-    gatherDepVulnsWithAvailability(cwd),
+    scope.depVulns ? gatherDepVulnsWithAvailability(cwd) : Promise.resolve(emptyAvail),
     // gatherWithProvenance (not gather) so the cached LintResult.tool
     // can carry the "(not run: <packs>)" suffix when one of the
     // active packs returned null silently. Standalone analyzeQuality
     // reads the augmented label off the cached envelope — closes the
     // cross-process drift class where two surfaces could disagree on
     // whether a linter ran on a given pack.
-    defaultDispatcher.gatherWithProvenance(cwd, LINT, providersFor(LINT, cwd)),
-    defaultDispatcher.gather(cwd, COVERAGE, providersFor(COVERAGE, cwd)),
-    defaultDispatcher.gather(cwd, IMPORTS, providersFor(IMPORTS, cwd)),
-    defaultDispatcher.gather(cwd, TEST_FRAMEWORK, providersFor(TEST_FRAMEWORK, cwd)),
+    scope.lint
+      ? defaultDispatcher.gatherWithProvenance(cwd, LINT, providersFor(LINT, cwd))
+      : Promise.resolve(emptyDispatch),
+    scope.coverage
+      ? defaultDispatcher.gather(cwd, COVERAGE, providersFor(COVERAGE, cwd))
+      : Promise.resolve(null),
+    scope.imports
+      ? defaultDispatcher.gather(cwd, IMPORTS, providersFor(IMPORTS, cwd))
+      : Promise.resolve(null),
+    scope.testFramework
+      ? defaultDispatcher.gather(cwd, TEST_FRAMEWORK, providersFor(TEST_FRAMEWORK, cwd))
+      : Promise.resolve(null),
     // gatherWithProvenance: the secret scan needs the same
     // attempted-vs-succeeded discriminant the code-patterns gather has,
     // so a failed secret scan caps the Security score (uncertainty)
@@ -413,7 +456,9 @@ async function gatherCapabilityReport(cwd: string): Promise<CapabilityReport> {
     // symptom of the old silent path: a dxkit upgrade that merely
     // turned the secret scanners ON looked like a score drop
     // on an unchanged commit.
-    defaultDispatcher.gatherWithProvenance(cwd, SECRETS, providersFor(SECRETS, cwd)),
+    scope.secrets
+      ? defaultDispatcher.gatherWithProvenance(cwd, SECRETS, providersFor(SECRETS, cwd))
+      : Promise.resolve(emptyDispatch),
     // gatherWithProvenance so the cache builder can plumb per-capability
     // availability metadata for tools that may legitimately gather
     // attempted-but-failed (semgrep / jscpd / graphify under resource
@@ -421,10 +466,16 @@ async function gatherCapabilityReport(cwd: string): Promise<CapabilityReport> {
     // metrics.toolsUnavailable can't distinguish "tool didn't try" from
     // "tool tried and failed silently" — the same dishonest-rendering
     // class as the lint case the LINT switch above closes.
-    defaultDispatcher.gatherWithProvenance(cwd, CODE_PATTERNS, providersFor(CODE_PATTERNS, cwd)),
-    defaultDispatcher.gatherWithProvenance(cwd, DUPLICATION, providersFor(DUPLICATION, cwd)),
-    defaultDispatcher.gatherWithProvenance(cwd, STRUCTURAL, providersFor(STRUCTURAL, cwd)),
-    gatherLicensesWithAvailability(cwd),
+    scope.codePatterns
+      ? defaultDispatcher.gatherWithProvenance(cwd, CODE_PATTERNS, providersFor(CODE_PATTERNS, cwd))
+      : Promise.resolve(emptyDispatch),
+    scope.duplication
+      ? defaultDispatcher.gatherWithProvenance(cwd, DUPLICATION, providersFor(DUPLICATION, cwd))
+      : Promise.resolve(emptyDispatch),
+    scope.structural
+      ? defaultDispatcher.gatherWithProvenance(cwd, STRUCTURAL, providersFor(STRUCTURAL, cwd))
+      : Promise.resolve(emptyDispatch),
+    scope.licenses ? gatherLicensesWithAvailability(cwd) : Promise.resolve(emptyAvail),
   ]);
   const codePatterns = codePatternsOutcome.envelope;
   const duplication = duplicationOutcome.envelope;

--- a/src/analyzers/health.ts
+++ b/src/analyzers/health.ts
@@ -38,6 +38,7 @@ import {
 } from '../languages/capabilities/descriptors';
 import { providersFor } from '../languages/capabilities';
 import { buildSecurityAggregateForHealth, gatherDepVulnsWithAvailability } from './security/gather';
+import { incrementalSemgrepProvider } from './tools/semgrep';
 import { gatherLicensesWithAvailability } from './licenses/gather';
 import { scoreTestsDimension } from './tests/shallow';
 import { scoreQualityDimension } from './quality/shallow';
@@ -114,6 +115,15 @@ export interface AnalyzeHealthOptions {
    * construction and is never written to the shared `AnalysisResult` cache.
    */
   scope?: GatherScope;
+  /**
+   * Incremental scanning (opt 3): when set, semgrep scans ONLY these
+   * project-relative changed files instead of the whole tree. Sound for a
+   * net-new gate because semgrep is intraprocedural — a net-new code
+   * finding can only appear in a changed file. Like `scope`, this makes the
+   * result partial (it never enters the shared cache). Only the loop
+   * Stop-gate sets it; CI / `health` leave it undefined (full scan).
+   */
+  incrementalFiles?: ReadonlyArray<string>;
 }
 
 /**
@@ -255,7 +265,7 @@ export async function gatherAnalysisResultBody(
   // providers the legacy path already ran are served from the dispatcher
   // cache (free). Scorers read capability-owned fields from this bundle.
   const capabilities = await timedAsync('capabilities', verbose, () =>
-    gatherCapabilityReport(repoPath, scope),
+    gatherCapabilityReport(repoPath, scope, options.incrementalFiles),
   );
 
   // Synthesize per-pack tool names (eslint, npm-audit, ruff, pip-audit,
@@ -396,7 +406,14 @@ function splitToolNames(tool: string): string[] {
 async function gatherCapabilityReport(
   cwd: string,
   scope: GatherScope = FULL_SCOPE,
+  incrementalFiles?: ReadonlyArray<string>,
 ): Promise<CapabilityReport> {
+  // Incremental scanning (opt 3): swap the full-tree semgrep provider for
+  // one bound to just the changed files. Same `source: 'semgrep'` identity,
+  // so the dispatcher's envelope/provenance handling is identical.
+  const codePatternsProviders = incrementalFiles
+    ? [incrementalSemgrepProvider(incrementalFiles)]
+    : providersFor(CODE_PATTERNS, cwd);
   // Vacuous outcomes for capabilities the scope skips. Each is byte-
   // identical to what the gather returns when no active pack supplies a
   // provider, so every downstream availability/aggregate branch treats a
@@ -467,7 +484,7 @@ async function gatherCapabilityReport(
     // "tool tried and failed silently" — the same dishonest-rendering
     // class as the lint case the LINT switch above closes.
     scope.codePatterns
-      ? defaultDispatcher.gatherWithProvenance(cwd, CODE_PATTERNS, providersFor(CODE_PATTERNS, cwd))
+      ? defaultDispatcher.gatherWithProvenance(cwd, CODE_PATTERNS, codePatternsProviders)
       : Promise.resolve(emptyDispatch),
     scope.duplication
       ? defaultDispatcher.gatherWithProvenance(cwd, DUPLICATION, providersFor(DUPLICATION, cwd))

--- a/src/analyzers/tests/types.ts
+++ b/src/analyzers/tests/types.ts
@@ -116,3 +116,37 @@ export interface TestGapsReport {
   toolsUsed: string[];
   toolsUnavailable: string[];
 }
+
+/**
+ * A vacuous test-gaps report — no gaps, no test files. Used by the
+ * scope-aware guardrail gather when a posture cannot block on test-gap
+ * findings (`scope.testGaps === false`), so the expensive test-gap
+ * analyzer is skipped. The `tests` producer reads only `gaps` +
+ * `testFiles`, so it emits zero entries from this — the single source of
+ * truth for the empty shape, kept beside the type it mirrors.
+ */
+export function emptyTestGapsReport(): TestGapsReport {
+  return {
+    repo: '',
+    analyzedAt: '',
+    commitSha: '',
+    branch: '',
+    summary: {
+      testFiles: 0,
+      activeTestFiles: 0,
+      commentedOutFiles: 0,
+      effectiveCoverage: 0,
+      coverageSource: 'filename-match',
+      coverageFidelity: 'filename-match',
+      sourceFiles: 0,
+      untestedCritical: 0,
+      untestedHigh: 0,
+      untestedMedium: 0,
+      untestedLow: 0,
+    },
+    testFiles: [],
+    gaps: [],
+    toolsUsed: [],
+    toolsUnavailable: [],
+  };
+}

--- a/src/analyzers/tools/parallel.ts
+++ b/src/analyzers/tools/parallel.ts
@@ -24,42 +24,57 @@ import { HealthMetrics } from '../types';
 import { gatherClocMetrics } from './cloc';
 import { gatherGitleaksResult } from './gitleaks';
 import { gatherGraphifyGraph, gatherGraphifyResult } from './graphify';
+import { type GatherScope, FULL_SCOPE } from '../../baseline/gather-scope';
 
 export async function gatherLayer2Parallel(
   cwd: string,
   _verbose = false,
+  scope: GatherScope = FULL_SCOPE,
 ): Promise<Partial<HealthMetrics>> {
-  const clocPartial = gatherClocMetrics(cwd);
+  // cloc warms the line-count metrics (language breakdown, large-file,
+  // comment ratio); skip it when the scope blocks on none of those.
+  const clocPartial = scope.cloc ? gatherClocMetrics(cwd) : {};
 
   const toolsUsed: string[] = [...(clocPartial.toolsUsed ?? [])];
   const toolsUnavailable: string[] = [...(clocPartial.toolsUnavailable ?? [])];
 
-  const gitleaks = gatherGitleaksResult(cwd);
-  if (gitleaks.kind === 'success') {
-    toolsUsed.push('gitleaks');
-  } else {
-    // `not installed` renders as bare `gitleaks`, every other failure
-    // mode carries its reason as a parenthetical — byte-identical to
-    // the pre-C.7 string the report surfaces.
-    toolsUnavailable.push(
-      gitleaks.reason === 'not installed' ? 'gitleaks' : `gitleaks (${gitleaks.reason})`,
-    );
+  // Run gitleaks here only when the scope needs secrets — it warms the
+  // outcome the later SECRETS capability dispatch reuses. When secrets are
+  // out of scope, the dispatch is skipped too, so gitleaks never runs.
+  if (scope.secrets) {
+    const gitleaks = gatherGitleaksResult(cwd);
+    if (gitleaks.kind === 'success') {
+      toolsUsed.push('gitleaks');
+    } else {
+      // `not installed` renders as bare `gitleaks`, every other failure
+      // mode carries its reason as a parenthetical — byte-identical to
+      // the pre-C.7 string the report surfaces.
+      toolsUnavailable.push(
+        gitleaks.reason === 'not installed' ? 'gitleaks' : `gitleaks (${gitleaks.reason})`,
+      );
+    }
   }
 
-  const graphify = await gatherGraphifyResult(cwd);
-  if (graphify.kind === 'success') {
-    toolsUsed.push('graphify');
-  } else {
-    toolsUnavailable.push(`graphify (${graphify.reason})`);
-  }
+  // graphify (AST stats + the graph.json side-effect write) feeds only
+  // structural/maintainability metrics + import reachability — never a
+  // kind the gate blocks on (the classifier never reads dep-vuln
+  // reachability). Skip it when structural is out of scope.
+  if (scope.structural) {
+    const graphify = await gatherGraphifyResult(cwd);
+    if (graphify.kind === 'success') {
+      toolsUsed.push('graphify');
+    } else {
+      toolsUnavailable.push(`graphify (${graphify.reason})`);
+    }
 
-  // Trigger the graph.json side-effect write. Shares the Python
-  // invocation with gatherGraphifyResult above via the promise-
-  // coalesced cache — no second shell-out. The disk write powers
-  // the explore CLI (Sprint 2) + dashboard viz (Sprint 3) + future
-  // 2.8 context CLI + reachability flows, all of which read from
-  // .dxkit/reports/graph.json via the canonical loader.
-  await gatherGraphifyGraph(cwd);
+    // Trigger the graph.json side-effect write. Shares the Python
+    // invocation with gatherGraphifyResult above via the promise-
+    // coalesced cache — no second shell-out. The disk write powers
+    // the explore CLI (Sprint 2) + dashboard viz (Sprint 3) + future
+    // 2.8 context CLI + reachability flows, all of which read from
+    // .dxkit/reports/graph.json via the canonical loader.
+    await gatherGraphifyGraph(cwd);
+  }
 
   return {
     sourceFiles: clocPartial.sourceFiles,

--- a/src/analyzers/tools/semgrep.ts
+++ b/src/analyzers/tools/semgrep.ts
@@ -135,12 +135,33 @@ function collectRulesets(cwd: string): string[] {
  * separately, and so the wall-clock-deadline kill cleans up
  * grandchildren (semgrep's internal worker pool).
  */
-export async function gatherSemgrepResult(cwd: string): Promise<CodePatternsGatherOutcome> {
+export async function gatherSemgrepResult(
+  cwd: string,
+  opts: { readonly targetFiles?: ReadonlyArray<string> } = {},
+): Promise<CodePatternsGatherOutcome> {
   const status = findTool(TOOL_DEFS.semgrep, cwd);
   if (!status.available || !status.path) return { kind: 'unavailable', reason: 'not installed' };
 
   const rulesets = collectRulesets(cwd);
   if (rulesets.length === 0) return { kind: 'unavailable', reason: 'no rulesets' };
+
+  // Incremental mode (opt 3): scan only the explicitly-listed changed
+  // files instead of the whole tree. Sound because semgrep is
+  // intraprocedural (CLAUDE.md Rule 13) — every code finding is local to
+  // one file, so a NET-NEW finding can only appear in a file the diff
+  // touched. An empty list means nothing changed → a vacuous clean scan
+  // (running semgrep with no positional target would error).
+  const incremental = opts.targetFiles !== undefined;
+  const targets = (opts.targetFiles ?? []).map((f) => path.resolve(cwd, f));
+  if (incremental && targets.length === 0) {
+    const envelope: CodePatternsResult = {
+      schemaVersion: 1,
+      tool: 'semgrep',
+      findings: [],
+      suppressedCount: 0,
+    };
+    return { kind: 'success', envelope };
+  }
 
   const reportPath = path.join(os.tmpdir(), `dxkit-semgrep-${Date.now()}.json`);
   const args = ['scan'];
@@ -148,14 +169,19 @@ export async function gatherSemgrepResult(cwd: string): Promise<CodePatternsGath
   args.push('--json', '--quiet', '--output', reportPath);
   // getSemgrepExcludeFlags returns a single space-separated string
   // shaped for execSync (`--exclude foo --exclude bar`). Split it
-  // into the array form runDetached expects.
+  // into the array form runDetached expects. The exclude filters still
+  // apply in incremental mode (harmless — the changed-file list is
+  // already curated, and an excluded path simply gets filtered).
   const excludeFlagString = getSemgrepExcludeFlags(cwd);
   if (excludeFlagString) {
     for (const tok of excludeFlagString.split(/\s+/).filter((t) => t.length > 0)) {
       args.push(tok);
     }
   }
-  args.push(cwd);
+  // Positional scan target(s): the changed files in incremental mode, else
+  // the whole repo root.
+  if (incremental) args.push(...targets);
+  else args.push(cwd);
 
   const outcome = await runDetached(status.path, args, { cwd, timeoutMs: 300000 });
   let raw: string;
@@ -267,3 +293,29 @@ export const semgrepProvider: CapabilityProvider<CodePatternsResult> & {
     return gatherSemgrepResult(cwd);
   },
 };
+
+/**
+ * A semgrep code-patterns provider that scans ONLY the given changed files
+ * (opt 3 incremental scanning). Same `source: 'semgrep'` identity as the
+ * full provider so the dispatcher's envelope + provenance handling is
+ * identical — the only difference is the bound changed-file target list.
+ * Passed to `gatherWithProvenance` in place of `semgrepProvider` on the
+ * loop Stop-gate's current-side gather; every other caller keeps the full
+ * provider. Sound by the intraprocedural argument in `gatherSemgrepResult`.
+ */
+export function incrementalSemgrepProvider(
+  targetFiles: ReadonlyArray<string>,
+): CapabilityProvider<CodePatternsResult> & {
+  gatherOutcome(cwd: string): Promise<CodePatternsGatherOutcome>;
+} {
+  return {
+    source: 'semgrep',
+    async gather(cwd) {
+      const outcome = await gatherSemgrepResult(cwd, { targetFiles });
+      return outcome.kind === 'success' ? outcome.envelope : null;
+    },
+    async gatherOutcome(cwd) {
+      return gatherSemgrepResult(cwd, { targetFiles });
+    },
+  };
+}

--- a/src/baseline/changed-files.ts
+++ b/src/baseline/changed-files.ts
@@ -1,0 +1,63 @@
+/**
+ * Changed-file computation for incremental scanning (opt 3).
+ *
+ * The loop guardrail blocks only on NET-NEW findings, and the scanners it
+ * file-scopes (semgrep) are intraprocedural — every finding is local to a
+ * single file. So a net-new finding can only live in a file the working
+ * tree changed relative to the comparison base. Scanning just those files
+ * catches every net-new finding while skipping the unchanged majority.
+ *
+ * # Safety: this set MUST be COMPLETE or fail safe
+ *
+ * If this under-reports the changed set, the gather would skip a file that
+ * actually changed and miss a real net-new finding — a false negative in a
+ * safety gate. So the contract is: return the COMPLETE set of files that
+ * differ from the base (tracked edits + staged + untracked), or `null` on
+ * ANY uncertainty (base unreachable, not a git repo, git error). A `null`
+ * tells the caller to fall back to a FULL scan — the safe default. Never
+ * return a partial set on error.
+ */
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import * as path from 'path';
+
+/** Best-effort git stdout as lines; throws are surfaced to the caller so
+ *  it can fail safe. `args` is fixed + caller-controlled (no shell). */
+function gitLines(cwd: string, args: string[]): string[] {
+  const out = execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * The complete set of project-relative files that differ from `baseSha` in
+ * the working tree — tracked modifications/additions (staged + unstaged)
+ * plus untracked files — restricted to files that still exist on disk (a
+ * deleted file has no current content to scan).
+ *
+ * Returns `null` when the set cannot be computed completely (base
+ * unreachable, not a git repo, any git failure). The caller MUST treat
+ * `null` as "scan everything" — never as "nothing changed".
+ */
+export function computeChangedFiles(cwd: string, baseSha: string): ReadonlyArray<string> | null {
+  if (!baseSha) return null;
+  try {
+    // `git diff --name-only <base>` compares base → working tree, covering
+    // both staged and unstaged changes to tracked files (and additions).
+    const tracked = gitLines(cwd, ['diff', '--name-only', baseSha, '--']);
+    // Untracked, not-ignored files — these are new and unseen by the base.
+    const untracked = gitLines(cwd, ['ls-files', '--others', '--exclude-standard']);
+    const all = new Set<string>([...tracked, ...untracked]);
+    // Keep only files that exist on disk now (drop deletions / renames-away).
+    return [...all].filter((rel) => existsSync(path.join(cwd, rel)));
+  } catch {
+    return null; // any failure → full scan (safe default)
+  }
+}

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -58,6 +58,7 @@ import type { ResolvedMode } from './modes';
 import { classify, resolvePolicy } from './policy';
 import type { BrownfieldPolicy, ClassifyContext, ClassifyResult } from './policy';
 import { gatherFromRef } from './ref-baseline';
+import { type GatherScope, FULL_SCOPE } from './gather-scope';
 import { isSanitized } from './sanitize';
 import type { BaselineEntry, FindingId, FindingSeverity, MatchPair, MatchResult } from './types';
 import { CURRENT_IDENTITY_SCHEME } from './types';
@@ -108,6 +109,17 @@ export interface RunGuardrailCheckOptions {
   /** Explicit CLI flag value for the ref (`--ref=<R>`). Only
    *  consulted when the resolved mode is `ref-based`. */
   readonly cliRef?: string;
+  /**
+   * Restrict both sides of the gather to the analyzers a scope needs.
+   * Defaults to `FULL_SCOPE`, so CI / `baseline check` gather everything
+   * and still render every warning. The loop Stop-gate passes a
+   * policy-derived scope (`scopeForPolicy`) so a `security-only` posture
+   * skips the analyzers it can never block on. Both the current side and
+   * the ref side are scoped identically so the cross-run diff stays
+   * balanced. Opt-in by construction: only callers that pass a scope
+   * change what is gathered.
+   */
+  readonly scope?: GatherScope;
 }
 
 /**
@@ -353,7 +365,8 @@ export async function runGuardrailCheck(
     }
   }
 
-  const current = await gatherCurrentScan({ cwd, verbose: options.verbose });
+  const scope = options.scope ?? FULL_SCOPE;
+  const current = await gatherCurrentScan({ cwd, verbose: options.verbose, scope });
 
   // In ref-based mode the prior side came from a detached worktree that
   // can't gather the build-artifact-dependent kinds; drop them from both
@@ -839,7 +852,12 @@ async function loadPriorSide(
     // mode. A missing ref here would be a programming error.
     throw new Error('ref-based baseline mode requires a resolved ref; got undefined.');
   }
-  const refScan = await gatherFromRef({ cwd, ref: mode.ref, verbose: options.verbose });
+  const refScan = await gatherFromRef({
+    cwd,
+    ref: mode.ref,
+    verbose: options.verbose,
+    scope: options.scope ?? FULL_SCOPE,
+  });
   const baseline: BaselineFile = {
     schemaVersion: BASELINE_SCHEMA_VERSION,
     name: options.name ?? DEFAULT_BASELINE_NAME,

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -59,6 +59,7 @@ import { classify, resolvePolicy } from './policy';
 import type { BrownfieldPolicy, ClassifyContext, ClassifyResult } from './policy';
 import { gatherFromRef } from './ref-baseline';
 import { type GatherScope, FULL_SCOPE } from './gather-scope';
+import { computeChangedFiles } from './changed-files';
 import { isSanitized } from './sanitize';
 import type { BaselineEntry, FindingId, FindingSeverity, MatchPair, MatchResult } from './types';
 import { CURRENT_IDENTITY_SCHEME } from './types';
@@ -120,6 +121,17 @@ export interface RunGuardrailCheckOptions {
    * change what is gathered.
    */
   readonly scope?: GatherScope;
+  /**
+   * Incremental scanning (opt 3): when true, the CURRENT side's semgrep
+   * scans only files that changed vs the baseline's commit, instead of the
+   * whole tree. Sound for a net-new gate (semgrep is intraprocedural — a
+   * net-new code finding only appears in a changed file). The ref/baseline
+   * side stays full so it covers every file. Falls back to a full scan when
+   * the changed set can't be computed completely. Opt-in: only the loop
+   * Stop-gate sets it; CI / `baseline check` leave it false so their full
+   * report is unaffected.
+   */
+  readonly incremental?: boolean;
 }
 
 /**
@@ -366,7 +378,22 @@ export async function runGuardrailCheck(
   }
 
   const scope = options.scope ?? FULL_SCOPE;
-  const current = await gatherCurrentScan({ cwd, verbose: options.verbose, scope });
+  // Incremental scanning: scope the current side's semgrep to files that
+  // changed vs the baseline commit. `computeChangedFiles` returns null when
+  // it can't enumerate the changed set completely (base unreachable, git
+  // error) — that maps to `undefined` here, i.e. a full scan (the safe
+  // default). The ref/baseline side is NOT incremental: it must cover every
+  // file so the diff has a complete prior to match against.
+  const incrementalFiles =
+    options.incremental && baseline.repo.commitSha
+      ? (computeChangedFiles(cwd, baseline.repo.commitSha) ?? undefined)
+      : undefined;
+  const current = await gatherCurrentScan({
+    cwd,
+    verbose: options.verbose,
+    scope,
+    incrementalFiles,
+  });
 
   // In ref-based mode the prior side came from a detached worktree that
   // can't gather the build-artifact-dependent kinds; drop them from both

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -25,13 +25,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { gatherAnalysisResultBody } from '../analyzers/health';
 import { readOrBuildAnalysisResult } from '../analyzers/cache';
-import { gatherHygieneMarkers } from '../analyzers/quality/gather';
-import { analyzeTestGaps } from '../analyzers/tests';
-import { emptyTestGapsReport } from '../analyzers/tests/types';
 import { type GatherScope, FULL_SCOPE, isFullScope } from './gather-scope';
-import type { HygieneSnapshot } from './producers';
-import { gatherGitleaksResult } from '../analyzers/tools/gitleaks';
-import type { GitleaksRawSecret } from '../analyzers/tools/gitleaks';
+import { gatherScopedProducerInputs } from './scoped-inputs';
 import { checkAllTools, findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
 import { detect } from '../detect';
 import { coverageFromToolStatuses } from './coverage';
@@ -55,7 +50,6 @@ import { sanitizeFile } from './sanitize';
 import type { RichBaselineEntry } from './types';
 import { CURRENT_IDENTITY_SCHEME } from './types';
 import type { SecurityAggregate } from '../analyzers/security/aggregator';
-import { gatherInlineAllowlistAnnotations } from '../allowlist/gather';
 
 export interface CreateBaselineOptions {
   /** Repo root to baseline. Caller should pass an absolute path. */
@@ -297,38 +291,17 @@ export interface CurrentScan {
  * Pure-orchestrator: each step has a single responsibility (analyze
  * → produce entries → resolve envelope metadata).
  */
-/** Vacuous hygiene snapshot for the scope-aware gather when a posture
- *  cannot block on `stale-file` / hygiene counts (`scope.hygiene === false`),
- *  so the hygiene grep is skipped. The `quality` producer reads
- *  `hygiene.staleFiles` and emits zero entries from the empty list. */
-const EMPTY_HYGIENE_SNAPSHOT: HygieneSnapshot = {
-  staleFiles: [],
-  todoCount: 0,
-  fixmeCount: 0,
-  hackCount: 0,
-  consoleLogCount: 0,
-  mixedLanguages: false,
-};
-
 export async function gatherCurrentScan(options: {
   readonly cwd: string;
   readonly verbose?: boolean;
-  /**
-   * Restrict the gather to the analyzers a scope needs. Defaults to
-   * `FULL_SCOPE`, so `createBaseline` and the CI guardrail gather
-   * everything unchanged. The loop Stop-gate passes a policy-derived scope
-   * so a `security-only` posture skips the analyzers it can never block on.
-   * A scoped scan is partial and never enters the shared `AnalysisResult`
-   * cache (`partial: true` below).
-   */
+  /** Restrict the gather to the analyzers a scope needs (defaults to
+   *  `FULL_SCOPE`). Only the loop Stop-gate passes a policy-derived scope;
+   *  `createBaseline` / CI gather everything. See `gather-scope.ts`. */
   readonly scope?: GatherScope;
-  /**
-   * Incremental scanning (opt 3): when set, semgrep scans ONLY these
-   * project-relative changed files. Makes the scan partial. Only the loop
-   * Stop-gate's current side sets it; the ref side is always full so the
-   * baseline covers every file. Sound by semgrep's intraprocedural nature
-   * (a net-new code finding only appears in a changed file).
-   */
+  /** Incremental scanning (opt 3): semgrep scans ONLY these changed files.
+   *  Loop Stop-gate's current side only; the ref side stays full. Sound by
+   *  semgrep's intraprocedural nature (a net-new code finding only appears
+   *  in a changed file). */
   readonly incrementalFiles?: ReadonlyArray<string>;
 }): Promise<CurrentScan> {
   const cwd = path.resolve(options.cwd);
@@ -371,24 +344,12 @@ export async function gatherCurrentScan(options: {
   // here (or earlier inside readOrBuildAnalysisResult) so producers
   // can be pure or near-pure consumers — adding a new producer
   // means extending this context with one more input, never
-  // adding another producer-specific block in this function.
-  // Each input feeds exactly one producer family; skip the gather when the
-  // scope can't block on that family (the producer then emits zero entries
-  // from the empty input, and the ref side is scoped identically so the
-  // diff stays balanced — see gather-scope.ts).
-  const testGapsReport = scope.testGaps
-    ? await analyzeTestGaps(cwd, { verbose: !!options.verbose })
-    : emptyTestGapsReport();
-  const hygieneMarkers = scope.hygiene ? gatherHygieneMarkers(cwd) : EMPTY_HYGIENE_SNAPSHOT;
-  const gitleaksOutcome = scope.secrets
-    ? gatherGitleaksResult(cwd)
-    : ({ kind: 'unavailable', reason: 'scoped out' } as const);
-  const rawSecrets: ReadonlyArray<GitleaksRawSecret> =
-    gitleaksOutcome.kind === 'success' ? gitleaksOutcome.rawSecrets : [];
-  // Inline `dxkit-allow:` annotations gathered from source so the
-  // stale-allow producer can flag orphans whose underlying findings
-  // are no longer present.
-  const inlineAllowlistAnnotations = gatherInlineAllowlistAnnotations(cwd);
+  // adding another producer-specific block in this function. The
+  // scope-aware analyzer inputs (test-gaps, hygiene, raw secrets,
+  // inline annotations) come from one helper that skips the gathers a
+  // scope can't block on (see scoped-inputs.ts).
+  const { testGapsReport, hygiene, rawSecrets, inlineAllowlistAnnotations } =
+    await gatherScopedProducerInputs(cwd, scope, !!options.verbose);
 
   const producerCtx: ProducerContext = {
     cwd,
@@ -396,7 +357,7 @@ export async function gatherCurrentScan(options: {
     salt,
     analysisResult,
     testGapsReport,
-    hygiene: hygieneMarkers,
+    hygiene,
     rawSecrets,
     inlineAllowlistAnnotations,
   };

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -27,6 +27,9 @@ import { gatherAnalysisResultBody } from '../analyzers/health';
 import { readOrBuildAnalysisResult } from '../analyzers/cache';
 import { gatherHygieneMarkers } from '../analyzers/quality/gather';
 import { analyzeTestGaps } from '../analyzers/tests';
+import { emptyTestGapsReport } from '../analyzers/tests/types';
+import { type GatherScope, FULL_SCOPE, isFullScope } from './gather-scope';
+import type { HygieneSnapshot } from './producers';
 import { gatherGitleaksResult } from '../analyzers/tools/gitleaks';
 import type { GitleaksRawSecret } from '../analyzers/tools/gitleaks';
 import { checkAllTools, findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
@@ -294,15 +297,40 @@ export interface CurrentScan {
  * Pure-orchestrator: each step has a single responsibility (analyze
  * → produce entries → resolve envelope metadata).
  */
+/** Vacuous hygiene snapshot for the scope-aware gather when a posture
+ *  cannot block on `stale-file` / hygiene counts (`scope.hygiene === false`),
+ *  so the hygiene grep is skipped. The `quality` producer reads
+ *  `hygiene.staleFiles` and emits zero entries from the empty list. */
+const EMPTY_HYGIENE_SNAPSHOT: HygieneSnapshot = {
+  staleFiles: [],
+  todoCount: 0,
+  fixmeCount: 0,
+  hackCount: 0,
+  consoleLogCount: 0,
+  mixedLanguages: false,
+};
+
 export async function gatherCurrentScan(options: {
   readonly cwd: string;
   readonly verbose?: boolean;
+  /**
+   * Restrict the gather to the analyzers a scope needs. Defaults to
+   * `FULL_SCOPE`, so `createBaseline` and the CI guardrail gather
+   * everything unchanged. The loop Stop-gate passes a policy-derived scope
+   * so a `security-only` posture skips the analyzers it can never block on.
+   * A scoped scan is partial and never enters the shared `AnalysisResult`
+   * cache (`partial: true` below).
+   */
+  readonly scope?: GatherScope;
 }): Promise<CurrentScan> {
   const cwd = path.resolve(options.cwd);
+  const scope = options.scope ?? FULL_SCOPE;
+  const partial = !isFullScope(scope);
 
   const analysisResult = await readOrBuildAnalysisResult({
     cwd,
-    build: (innerCwd) => gatherAnalysisResultBody(innerCwd, { verbose: !!options.verbose }),
+    build: (innerCwd) => gatherAnalysisResultBody(innerCwd, { verbose: !!options.verbose, scope }),
+    opts: { partial },
   });
   const aggregate = analysisResult.capabilities.securityAggregate;
   if (!aggregate) {
@@ -328,9 +356,17 @@ export async function gatherCurrentScan(options: {
   // can be pure or near-pure consumers — adding a new producer
   // means extending this context with one more input, never
   // adding another producer-specific block in this function.
-  const testGapsReport = await analyzeTestGaps(cwd, { verbose: !!options.verbose });
-  const hygieneMarkers = gatherHygieneMarkers(cwd);
-  const gitleaksOutcome = gatherGitleaksResult(cwd);
+  // Each input feeds exactly one producer family; skip the gather when the
+  // scope can't block on that family (the producer then emits zero entries
+  // from the empty input, and the ref side is scoped identically so the
+  // diff stays balanced — see gather-scope.ts).
+  const testGapsReport = scope.testGaps
+    ? await analyzeTestGaps(cwd, { verbose: !!options.verbose })
+    : emptyTestGapsReport();
+  const hygieneMarkers = scope.hygiene ? gatherHygieneMarkers(cwd) : EMPTY_HYGIENE_SNAPSHOT;
+  const gitleaksOutcome = scope.secrets
+    ? gatherGitleaksResult(cwd)
+    : ({ kind: 'unavailable', reason: 'scoped out' } as const);
   const rawSecrets: ReadonlyArray<GitleaksRawSecret> =
     gitleaksOutcome.kind === 'success' ? gitleaksOutcome.rawSecrets : [];
   // Inline `dxkit-allow:` annotations gathered from source so the

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -322,14 +322,30 @@ export async function gatherCurrentScan(options: {
    * cache (`partial: true` below).
    */
   readonly scope?: GatherScope;
+  /**
+   * Incremental scanning (opt 3): when set, semgrep scans ONLY these
+   * project-relative changed files. Makes the scan partial. Only the loop
+   * Stop-gate's current side sets it; the ref side is always full so the
+   * baseline covers every file. Sound by semgrep's intraprocedural nature
+   * (a net-new code finding only appears in a changed file).
+   */
+  readonly incrementalFiles?: ReadonlyArray<string>;
 }): Promise<CurrentScan> {
   const cwd = path.resolve(options.cwd);
   const scope = options.scope ?? FULL_SCOPE;
-  const partial = !isFullScope(scope);
+  // A scoped OR incrementally-scanned result is partial — it must never
+  // enter the shared cache where a later full `health` read would consume
+  // an incomplete codePatterns set.
+  const partial = !isFullScope(scope) || options.incrementalFiles !== undefined;
 
   const analysisResult = await readOrBuildAnalysisResult({
     cwd,
-    build: (innerCwd) => gatherAnalysisResultBody(innerCwd, { verbose: !!options.verbose, scope }),
+    build: (innerCwd) =>
+      gatherAnalysisResultBody(innerCwd, {
+        verbose: !!options.verbose,
+        scope,
+        incrementalFiles: options.incrementalFiles,
+      }),
     opts: { partial },
   });
   const aggregate = analysisResult.capabilities.securityAggregate;

--- a/src/baseline/gather-scope.ts
+++ b/src/baseline/gather-scope.ts
@@ -1,0 +1,179 @@
+/**
+ * Gather scope — which analyzers a guardrail gather actually needs to run.
+ *
+ * # Why this exists (2.14.0 opt 1)
+ *
+ * The full current-side gather runs every analyzer (semgrep, gitleaks,
+ * graphify AST, jscpd, OSV, lint, coverage, cloc, test-gaps, licenses, …).
+ * On a large repo that is ~60s. But a guardrail check can only ever BLOCK
+ * on the finding kinds its policy escalates — see `evaluateBlockRules` in
+ * `./policy.ts`. A `security-only` loop posture blocks on secrets + crit/
+ * high SAST + critical dep-vulns and NOTHING else, so gathering jscpd /
+ * lint / coverage / cloc / test-gaps / graphify for it is pure waste: those
+ * analyzers feed only kinds the policy can't act on.
+ *
+ * This module derives, from a `BrownfieldPolicy`, the minimal set of
+ * analyzers whose output can change the verdict, so the gather can skip the
+ * rest. It is the single source of truth for that mapping.
+ *
+ * # Safety contract (load-bearing)
+ *
+ * Scoping is correct ONLY because the verdict depends solely on BLOCKING
+ * pairs, and a kind the policy cannot block can never produce one. The map
+ * below therefore tracks `evaluateBlockRules` exactly:
+ *
+ *   - `policy.block` non-empty (e.g. `['added']`, the `full-debt` posture)
+ *     means ANY kind blocks by status alone → FULL_SCOPE, gather everything.
+ *   - otherwise each enabled `blockRule` pulls in exactly the analyzer(s)
+ *     that feed its kind.
+ *
+ * Two structural guarantees keep this honest:
+ *   1. Scoping is OPT-IN. Every existing caller (CI guardrail, `createBaseline`,
+ *      the `health` report) gets `FULL_SCOPE` and is byte-identical. Only the
+ *      loop Stop-gate passes a derived scope.
+ *   2. The security aggregate's cheap intrinsic scans (tls-bypass + file
+ *      findings, ~0.5s) always run inside `buildSecurityAggregateForHealth`,
+ *      so a `code`/`config` security finding can never be skipped by scoping.
+ *
+ * If a new block rule lands in `evaluateBlockRules`, `scopeForPolicy` MUST
+ * gain the matching analyzer here or a real finding could be skipped — the
+ * scope contract test pins this.
+ */
+import type { BrownfieldPolicy } from './policy';
+
+/**
+ * One boolean per skippable analyzer. `true` = run it. The names mirror the
+ * gather steps in `health.ts` / `create.ts` so threading is mechanical.
+ *
+ * Not represented (always run, never scoped away):
+ *   - the cheap tls-bypass + file-finding scans intrinsic to the security
+ *     aggregate (they contribute blockable `code`/`config` findings);
+ *   - generic Layer-0 metrics + package.json (microseconds).
+ */
+export interface GatherScope {
+  /** gitleaks + grep-secrets → `secret` (+ raw secrets → `secret-hmac`). */
+  readonly secrets: boolean;
+  /** semgrep → `code` SAST findings. */
+  readonly codePatterns: boolean;
+  /** OSV / per-pack dep audit → `dep-vuln`. */
+  readonly depVulns: boolean;
+  /** graphify AST → structural metrics + import reachability. */
+  readonly structural: boolean;
+  /** jscpd → `duplication`. */
+  readonly duplication: boolean;
+  /** per-pack linters → Quality dimension + `code`-adjacent hygiene. */
+  readonly lint: boolean;
+  /** coverage providers → Tests dimension. */
+  readonly coverage: boolean;
+  /** license scan → attribution (never a blockable kind). */
+  readonly licenses: boolean;
+  /** import graph → dep-vuln reachability + DX metrics. */
+  readonly imports: boolean;
+  /** test-framework detection → DX metrics. */
+  readonly testFramework: boolean;
+  /** cloc line counts → `large-file`, comment ratio, language breakdown. */
+  readonly cloc: boolean;
+  /** test-gap analyzer → `test-gap` / `test-file-degradation`. */
+  readonly testGaps: boolean;
+  /** hygiene markers (TODO/FIXME/stale) → `stale-file` + Quality counts. */
+  readonly hygiene: boolean;
+}
+
+/** Everything on — the default every non-loop caller gets. */
+export const FULL_SCOPE: GatherScope = Object.freeze({
+  secrets: true,
+  codePatterns: true,
+  depVulns: true,
+  structural: true,
+  duplication: true,
+  lint: true,
+  coverage: true,
+  licenses: true,
+  imports: true,
+  testFramework: true,
+  cloc: true,
+  testGaps: true,
+  hygiene: true,
+});
+
+/** All-off starting point for the additive derivation below. */
+const EMPTY_SCOPE: GatherScope = Object.freeze({
+  secrets: false,
+  codePatterns: false,
+  depVulns: false,
+  structural: false,
+  duplication: false,
+  lint: false,
+  coverage: false,
+  licenses: false,
+  imports: false,
+  testFramework: false,
+  cloc: false,
+  testGaps: false,
+  hygiene: false,
+});
+
+/** True when no analyzer at all is required — caller can short-circuit. */
+export function isEmptyScope(s: GatherScope): boolean {
+  return !Object.values(s).some(Boolean);
+}
+
+/** True when this is the full gather (no analyzer skipped). */
+export function isFullScope(s: GatherScope): boolean {
+  return Object.values(s).every(Boolean);
+}
+
+/**
+ * A compact, deterministic signature of which analyzers a scope runs.
+ * Used to namespace the ref-scan cache so a scoped ref gather is never
+ * served as if it were a full one (and vice versa). Order is fixed by the
+ * sorted key list, so the signature is stable across calls.
+ */
+export function scopeSignature(s: GatherScope): string {
+  if (isFullScope(s)) return 'full';
+  return (Object.keys(s) as Array<keyof GatherScope>)
+    .sort()
+    .filter((k) => s[k])
+    .join('+');
+}
+
+/**
+ * Derive the minimal gather scope a policy needs.
+ *
+ * The verdict can only be changed by a kind the policy BLOCKS, so the scope
+ * tracks `evaluateBlockRules` (in `./policy.ts`) one-to-one:
+ *
+ *   newSecret                              → secrets
+ *   newCriticalSecurity / newHighSecurity  → codePatterns
+ *   newCritical/HighReachableDependency…   → depVulns
+ *   newUntestedChangedSource               → testGaps
+ *   newSevereQualityIssueInChangedFiles    → codePatterns + hygiene
+ *
+ * A non-empty `policy.block` list (statuses that block regardless of kind,
+ * e.g. `full-debt`'s `['added']`) means any kind can block, so we cannot
+ * skip anything → `FULL_SCOPE`.
+ *
+ * NB: `newHighReachableDependencyVulnerability` needs reachability, which the
+ * guardrail's classifier never populates today (`context.reachable` is unset
+ * on the check path), so it cannot actually fire — but we still scope in
+ * `depVulns` for it so the mapping stays a faithful, future-proof mirror of
+ * the rule table rather than relying on that downstream gap.
+ */
+export function scopeForPolicy(policy: BrownfieldPolicy): GatherScope {
+  // Any status-based block applies across all kinds — nothing is safe to skip.
+  if (policy.block.length > 0) return FULL_SCOPE;
+
+  const r = policy.blockRules;
+  const scope = { ...EMPTY_SCOPE };
+  if (r.newSecret) scope.secrets = true;
+  if (r.newCriticalSecurity || r.newHighSecurity) scope.codePatterns = true;
+  if (r.newCriticalDependencyVulnerability || r.newHighReachableDependencyVulnerability) {
+    scope.depVulns = true;
+  }
+  if (r.newUntestedChangedSource) scope.testGaps = true;
+  if (r.newSevereQualityIssueInChangedFiles) {
+    scope.codePatterns = true;
+    scope.hygiene = true;
+  }
+  return Object.freeze(scope);
+}

--- a/src/baseline/ref-baseline.ts
+++ b/src/baseline/ref-baseline.ts
@@ -66,6 +66,7 @@ import { VERSION } from '../constants';
 import { CURRENT_IDENTITY_SCHEME } from './types';
 import { gatherCurrentScan } from './create';
 import type { CurrentScan } from './create';
+import { type GatherScope, FULL_SCOPE, scopeSignature } from './gather-scope';
 
 /**
  * Recoverable error from the ref-based gather path. Carries an
@@ -243,16 +244,20 @@ export async function gatherFromRef(opts: {
   readonly cwd: string;
   readonly ref: string;
   readonly verbose?: boolean;
+  /** Scope the ref-side gather identically to the current side so the
+   *  cross-run diff stays balanced. Defaults to `FULL_SCOPE`. */
+  readonly scope?: GatherScope;
 }): Promise<CurrentScan> {
   const sha = resolveRefToSha(opts.cwd, opts.ref);
   if (sha === null) throw unreachableRefError(opts.cwd, opts.ref);
 
-  const key = refScanCacheKey(opts.cwd, sha);
+  const scope = opts.scope ?? FULL_SCOPE;
+  const key = refScanCacheKey(opts.cwd, sha, scope);
   const cached = readRefScanCache(opts.cwd, key);
   if (cached) return cached;
 
   const scan = await withRefWorktree({ cwd: opts.cwd, ref: opts.ref }, async (worktreePath) => {
-    return gatherCurrentScan({ cwd: worktreePath, verbose: opts.verbose });
+    return gatherCurrentScan({ cwd: worktreePath, verbose: opts.verbose, scope });
   });
   writeRefScanCache(opts.cwd, key, scan);
   return scan;
@@ -291,14 +296,16 @@ function saltSignature(cwd: string): string {
 }
 
 /** Deterministic cache key over every input that can change a ref scan.
- *  Exported for testing. */
-export function refScanCacheKey(cwd: string, sha: string): string {
+ *  Includes the gather scope so a scoped ref scan is never reused for a
+ *  full request (or vice versa). Exported for testing. */
+export function refScanCacheKey(cwd: string, sha: string, scope: GatherScope = FULL_SCOPE): string {
   const material = [
     `fmt:${REF_SCAN_CACHE_FORMAT}`,
     `sha:${sha}`,
     `ver:${VERSION}`,
     `scheme:${CURRENT_IDENTITY_SCHEME}`,
     `salt:${saltSignature(cwd)}`,
+    `scope:${scopeSignature(scope)}`,
   ].join('\0');
   return createHash('sha256').update(material).digest('hex').slice(0, 32); // fingerprint-helper-ok
 }

--- a/src/baseline/scoped-inputs.ts
+++ b/src/baseline/scoped-inputs.ts
@@ -1,0 +1,68 @@
+/**
+ * Scope-aware producer-context inputs.
+ *
+ * Extracted from `create.ts` so `gatherCurrentScan` stays focused on
+ * orchestration. The producer registry (CLAUDE.md Rule 10) reads a handful
+ * of analyzer outputs from `ProducerContext` beyond the cached
+ * `AnalysisResult`: the test-gaps report, hygiene markers, raw secrets, and
+ * inline allowlist annotations. Each feeds exactly one producer family, so a
+ * gather scope that can't block on that family skips the (sometimes
+ * expensive) gather and substitutes an empty input — the producer then
+ * emits zero entries. The ref side is scoped identically, so the cross-run
+ * diff stays balanced (see `gather-scope.ts`).
+ */
+import { analyzeTestGaps } from '../analyzers/tests';
+import { emptyTestGapsReport, type TestGapsReport } from '../analyzers/tests/types';
+import { gatherHygieneMarkers } from '../analyzers/quality/gather';
+import { gatherGitleaksResult } from '../analyzers/tools/gitleaks';
+import type { GitleaksRawSecret } from '../analyzers/tools/gitleaks';
+import { gatherInlineAllowlistAnnotations } from '../allowlist/gather';
+import type { InlineAllowlistOccurrence } from '../allowlist/gather';
+import type { GatherScope } from './gather-scope';
+import type { HygieneSnapshot } from './producers';
+
+/** Vacuous hygiene snapshot for the scope-aware gather when a posture
+ *  cannot block on `stale-file` / hygiene counts (`scope.hygiene === false`),
+ *  so the hygiene grep is skipped. The `quality` producer reads
+ *  `hygiene.staleFiles` and emits zero entries from the empty list. */
+const EMPTY_HYGIENE_SNAPSHOT: HygieneSnapshot = {
+  staleFiles: [],
+  todoCount: 0,
+  fixmeCount: 0,
+  hackCount: 0,
+  consoleLogCount: 0,
+  mixedLanguages: false,
+};
+
+/** The non-cached analyzer outputs the producer registry consumes. */
+export interface ScopedProducerInputs {
+  readonly testGapsReport: TestGapsReport;
+  readonly hygiene: HygieneSnapshot;
+  readonly rawSecrets: ReadonlyArray<GitleaksRawSecret>;
+  readonly inlineAllowlistAnnotations: ReadonlyArray<InlineAllowlistOccurrence>;
+}
+
+/**
+ * Gather the producer-context inputs a scope needs. Each gather is skipped
+ * when its scope flag is off, substituting an empty value so the
+ * corresponding producer emits zero entries. `inlineAllowlistAnnotations` is
+ * always gathered (a cheap source scan that feeds the stale-allow producer,
+ * which has no scope flag).
+ */
+export async function gatherScopedProducerInputs(
+  cwd: string,
+  scope: GatherScope,
+  verbose: boolean,
+): Promise<ScopedProducerInputs> {
+  const testGapsReport = scope.testGaps
+    ? await analyzeTestGaps(cwd, { verbose })
+    : emptyTestGapsReport();
+  const hygiene = scope.hygiene ? gatherHygieneMarkers(cwd) : EMPTY_HYGIENE_SNAPSHOT;
+  const gitleaksOutcome = scope.secrets
+    ? gatherGitleaksResult(cwd)
+    : ({ kind: 'unavailable', reason: 'scoped out' } as const);
+  const rawSecrets: ReadonlyArray<GitleaksRawSecret> =
+    gitleaksOutcome.kind === 'success' ? gitleaksOutcome.rawSecrets : [];
+  const inlineAllowlistAnnotations = gatherInlineAllowlistAnnotations(cwd);
+  return { testGapsReport, hygiene, rawSecrets, inlineAllowlistAnnotations };
+}

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -366,7 +366,11 @@ export async function runStopGate(cwd: string): Promise<void> {
   const runCheck = async (dir: string): Promise<GuardrailJsonPayload> => {
     const { runGuardrailCheck } = await import('../baseline/check');
     const { renderJson } = await import('../baseline/check-renderers');
-    const result = await runGuardrailCheck({ cwd: dir, policy, scope });
+    // `incremental: true` scopes the current side's semgrep to changed
+    // files (opt 3). Verdict-safe: semgrep is intraprocedural, so a net-new
+    // code finding only appears in a file the diff touched, and the scan
+    // falls back to full whenever the changed set can't be computed.
+    const result = await runGuardrailCheck({ cwd: dir, policy, scope, incremental: true });
     const json = renderJson(result);
     // Persist the full machine-readable verdict so the model (and a human)
     // can read the exact net-new findings the block message points to.

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -355,10 +355,18 @@ export async function runStopGate(cwd: string): Promise<void> {
     }
   }
 
+  // Scope the gather to the analyzers this posture can actually block on.
+  // A `security-only` loop skips jscpd / lint / coverage / cloc / test-gaps /
+  // graphify — they feed only kinds the policy can't act on, so skipping them
+  // cannot change the verdict (see src/baseline/gather-scope.ts). Both sides
+  // of the diff are scoped identically. `full-debt` derives FULL_SCOPE.
+  const { scopeForPolicy } = await import('../baseline/gather-scope');
+  const scope = scopeForPolicy(policy);
+
   const runCheck = async (dir: string): Promise<GuardrailJsonPayload> => {
     const { runGuardrailCheck } = await import('../baseline/check');
     const { renderJson } = await import('../baseline/check-renderers');
-    const result = await runGuardrailCheck({ cwd: dir, policy });
+    const result = await runGuardrailCheck({ cwd: dir, policy, scope });
     const json = renderJson(result);
     // Persist the full machine-readable verdict so the model (and a human)
     // can read the exact net-new findings the block message points to.

--- a/test/baseline/changed-files.test.ts
+++ b/test/baseline/changed-files.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { computeChangedFiles } from '../../src/baseline/changed-files';
+
+/**
+ * `computeChangedFiles` is the safety core of incremental scanning (opt 3):
+ * if it ever UNDER-reports the changed set, the gather skips a file that
+ * really changed and misses a net-new finding — a false negative in a
+ * safety gate. So these tests pin the two non-negotiables: the set is
+ * COMPLETE (tracked edits + untracked, no false omissions), and ANY
+ * uncertainty yields `null` (→ caller does a full scan), never a partial set.
+ */
+
+function git(repo: string, args: string[]): void {
+  execFileSync('git', args, { cwd: repo, stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function commitAll(repo: string, msg: string): string {
+  git(repo, ['add', '-A']);
+  git(repo, ['commit', '-qm', msg]);
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim();
+}
+
+describe('computeChangedFiles', () => {
+  let repo: string;
+  let base: string;
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'dxkit-changed-'));
+    git(repo, ['init', '-q', '-b', 'main']);
+    git(repo, ['config', 'user.email', 't@t.co']);
+    git(repo, ['config', 'user.name', 't']);
+    mkdirSync(join(repo, 'src'), { recursive: true });
+    writeFileSync(join(repo, 'src', 'a.ts'), 'export const a = 1;\n');
+    writeFileSync(join(repo, 'src', 'b.ts'), 'export const b = 2;\n');
+    base = commitAll(repo, 'base');
+  });
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('reports nothing changed on a clean tree at the base', () => {
+    expect(computeChangedFiles(repo, base)).toEqual([]);
+  });
+
+  it('detects a modified tracked file (unstaged)', () => {
+    writeFileSync(join(repo, 'src', 'a.ts'), 'export const a = 99;\n');
+    expect(computeChangedFiles(repo, base)).toEqual(['src/a.ts']);
+  });
+
+  it('detects a staged-but-uncommitted change', () => {
+    writeFileSync(join(repo, 'src', 'b.ts'), 'export const b = 42;\n');
+    git(repo, ['add', 'src/b.ts']);
+    expect(computeChangedFiles(repo, base)).toEqual(['src/b.ts']);
+  });
+
+  it('detects an untracked new file', () => {
+    writeFileSync(join(repo, 'src', 'c.ts'), 'export const c = 3;\n');
+    const changed = computeChangedFiles(repo, base);
+    expect(changed).toContain('src/c.ts');
+  });
+
+  it('detects changes committed AFTER the base (HEAD ahead of base)', () => {
+    writeFileSync(join(repo, 'src', 'a.ts'), 'export const a = 7;\n');
+    commitAll(repo, 'later');
+    // base is the parent commit; the working tree differs from it.
+    expect(computeChangedFiles(repo, base)).toEqual(['src/a.ts']);
+  });
+
+  it('excludes a deleted file (no current content to scan)', () => {
+    unlinkSync(join(repo, 'src', 'b.ts'));
+    const changed = computeChangedFiles(repo, base);
+    // b.ts changed (deleted) vs base, but has no on-disk content — must not
+    // appear in the scan set.
+    expect(changed).not.toContain('src/b.ts');
+  });
+
+  it('returns null for an unreachable base SHA (→ caller full-scans)', () => {
+    expect(computeChangedFiles(repo, '0000000000000000000000000000000000000000')).toBeNull();
+  });
+
+  it('returns null for an empty base', () => {
+    expect(computeChangedFiles(repo, '')).toBeNull();
+  });
+
+  it('returns null outside a git repo (→ caller full-scans)', () => {
+    const plain = mkdtempSync(join(tmpdir(), 'dxkit-nogit-'));
+    try {
+      expect(computeChangedFiles(plain, 'HEAD')).toBeNull();
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/baseline/gather-scope.test.ts
+++ b/test/baseline/gather-scope.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  scopeForPolicy,
+  scopeSignature,
+  isFullScope,
+  isEmptyScope,
+  FULL_SCOPE,
+  type GatherScope,
+} from '../../src/baseline/gather-scope';
+import type { BrownfieldPolicy } from '../../src/baseline/policy';
+import { DEFAULT_BROWNFIELD_POLICY } from '../../src/baseline/policy';
+import { resolveLoopPolicy } from '../../src/loop/policy';
+import { gatherCurrentScan } from '../../src/baseline/create';
+
+/**
+ * The gather scope is the load-bearing safety boundary for opt 1: it decides
+ * which analyzers a guardrail run skips. A bug here either gathers too much
+ * (no speedup) or — the dangerous direction — skips an analyzer whose finding
+ * the policy CAN block on, silently changing a verdict. These tests pin both
+ * the pure derivation and the observable effect on a real gather.
+ */
+
+/** A `security-only`-shaped policy: empty generic block list, security
+ *  block-rules only. Mirrors `src/loop/policy.ts`'s preset. */
+const SECURITY_ONLY: BrownfieldPolicy = {
+  ...DEFAULT_BROWNFIELD_POLICY,
+  block: [],
+  blockRules: {
+    newSecret: true,
+    newCriticalSecurity: true,
+    newHighSecurity: true,
+    newCriticalDependencyVulnerability: true,
+    newHighReachableDependencyVulnerability: true,
+    newUntestedChangedSource: false,
+    newSevereQualityIssueInChangedFiles: false,
+  },
+};
+
+describe('scopeForPolicy', () => {
+  it('security-only enables ONLY the analyzers feeding its blockable kinds', () => {
+    const s = scopeForPolicy(SECURITY_ONLY);
+    expect(s.secrets).toBe(true); // newSecret
+    expect(s.codePatterns).toBe(true); // newCritical/HighSecurity
+    expect(s.depVulns).toBe(true); // newCritical/HighReachableDependency
+    // Everything a security-only posture can never block on is skipped.
+    expect(s.structural).toBe(false);
+    expect(s.duplication).toBe(false);
+    expect(s.lint).toBe(false);
+    expect(s.coverage).toBe(false);
+    expect(s.licenses).toBe(false);
+    expect(s.imports).toBe(false);
+    expect(s.testFramework).toBe(false);
+    expect(s.cloc).toBe(false);
+    expect(s.testGaps).toBe(false);
+    expect(s.hygiene).toBe(false);
+    expect(isFullScope(s)).toBe(false);
+    expect(isEmptyScope(s)).toBe(false);
+  });
+
+  it('a non-empty generic block list (full-debt) forces FULL_SCOPE', () => {
+    // full-debt blocks any `added` finding regardless of kind, so nothing
+    // is safe to skip.
+    const fullDebt: BrownfieldPolicy = { ...SECURITY_ONLY, block: ['added'] };
+    expect(scopeForPolicy(fullDebt)).toEqual(FULL_SCOPE);
+    expect(isFullScope(scopeForPolicy(fullDebt))).toBe(true);
+  });
+
+  it('the shipped full-debt loop preset derives FULL_SCOPE end-to-end', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-scope-fd-'));
+    try {
+      process.env.DXKIT_LOOP_PRESET = 'full-debt';
+      const { policy } = resolveLoopPolicy(dir);
+      expect(isFullScope(scopeForPolicy(policy))).toBe(true);
+    } finally {
+      delete process.env.DXKIT_LOOP_PRESET;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('the shipped security-only loop preset derives the security subset', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-scope-so-'));
+    try {
+      process.env.DXKIT_LOOP_PRESET = 'security-only';
+      const { policy } = resolveLoopPolicy(dir);
+      const s = scopeForPolicy(policy);
+      expect(s.secrets && s.codePatterns && s.depVulns).toBe(true);
+      expect(s.testGaps || s.duplication || s.lint || s.structural).toBe(false);
+    } finally {
+      delete process.env.DXKIT_LOOP_PRESET;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * SAFETY CONTRACT: every block rule that can fire MUST pull at least one
+   * analyzer into scope. If a future rule is added to `evaluateBlockRules`
+   * without a matching scope branch, a security-only-style posture would
+   * silently skip the analyzer that feeds it — a missed-finding bug. This
+   * asserts each rule, toggled alone, yields a non-empty scope.
+   */
+  it('every block rule individually yields a non-empty scope (no silent skips)', () => {
+    const rules = [
+      'newSecret',
+      'newCriticalSecurity',
+      'newHighSecurity',
+      'newCriticalDependencyVulnerability',
+      'newHighReachableDependencyVulnerability',
+      'newUntestedChangedSource',
+      'newSevereQualityIssueInChangedFiles',
+    ] as const;
+    for (const rule of rules) {
+      const policy: BrownfieldPolicy = {
+        ...DEFAULT_BROWNFIELD_POLICY,
+        block: [],
+        blockRules: {
+          newSecret: false,
+          newCriticalSecurity: false,
+          newHighSecurity: false,
+          newCriticalDependencyVulnerability: false,
+          newHighReachableDependencyVulnerability: false,
+          newUntestedChangedSource: false,
+          newSevereQualityIssueInChangedFiles: false,
+          [rule]: true,
+        },
+      };
+      expect(isEmptyScope(scopeForPolicy(policy)), `rule ${rule} must scope in an analyzer`).toBe(
+        false,
+      );
+    }
+  });
+});
+
+describe('scopeSignature', () => {
+  it('is "full" for the full scope and stable + distinct otherwise', () => {
+    expect(scopeSignature(FULL_SCOPE)).toBe('full');
+    const a = scopeForPolicy(SECURITY_ONLY);
+    expect(scopeSignature(a)).toBe(scopeSignature(a)); // deterministic
+    expect(scopeSignature(a)).not.toBe('full');
+    const justSecrets: GatherScope = { ...a, codePatterns: false, depVulns: false };
+    expect(scopeSignature(justSecrets)).not.toBe(scopeSignature(a));
+  });
+});
+
+describe('scoped gather drops non-security analyzers (observable effect)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-scoped-gather-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir });
+    // An untested source file → the test-gap analyzer (no external binary,
+    // filename-match fallback) produces a `test-gap` finding under a full
+    // gather. A security-only scope skips that analyzer entirely.
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(
+      join(dir, 'src', 'app.ts'),
+      'export function handler(req: unknown) {\n  return req;\n}\n',
+    );
+    writeFileSync(join(dir, 'package.json'), '{"name":"fixture","version":"1.0.0"}\n');
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: dir });
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('full scope produces test-gap findings; security-only scope does not', async () => {
+    const full = await gatherCurrentScan({ cwd: dir });
+    const scoped = await gatherCurrentScan({ cwd: dir, scope: scopeForPolicy(SECURITY_ONLY) });
+
+    const kindsOf = (s: { findings: ReadonlyArray<{ kind: string }> }) =>
+      new Set(s.findings.map((f) => f.kind));
+
+    // The non-security analyzer ran (or at least could) under full scope...
+    expect(kindsOf(full).has('test-gap')).toBe(true);
+    // ...and is genuinely skipped under the security-only scope.
+    expect(kindsOf(scoped).has('test-gap')).toBe(false);
+    expect(kindsOf(scoped).has('test-file-degradation')).toBe(false);
+
+    // The security pipeline still ran under the scoped gather — the
+    // aggregate is present, so a real secret / SAST finding would still be
+    // caught. (Empty here because the fixture has none.)
+    expect(scoped.aggregate).toBeDefined();
+    expect(Array.isArray(scoped.aggregate.findingsByCategory.secret)).toBe(true);
+  });
+});


### PR DESCRIPTION
## 2.14.0 — loop Stop-gate gather optimizations

Two **opt-in, verdict-preserving** optimizations cut what an unattended loop's `security-only` Stop-gate scans on every stop. CI `baseline check`, `createBaseline`, and the `health` report are byte-identical and still render every warning — only the loop Stop-gate changes.

### Realized savings (end-to-end, proven)
Strapi (3,748 files), realistic 2-file loop diff, **separate processes** (the real Stop-gate runs fresh per stop):

| Config | Gather | Blocks net-new secret |
|---|---|---|
| pre-2.14 (full) | 42.8s | ✅ 2 pairs |
| opt 1 (scoped) | 24.0s | ✅ 2 pairs |
| opt 1 + 3 (scoped + incremental) | **11.3s (−74%)** | ✅ 2 pairs |

All three block the same planted net-new github-PAT with identical blocking pairs.

### opt 1 — preset-scoped gather (`0857ea5`)
A guardrail can only block on the finding kinds its policy escalates, so a `security-only` posture no longer runs analyzers feeding only non-blockable kinds (jscpd, lint, coverage, cloc, test-gaps, graphify, licenses). Scope derived declaratively from the policy (`scopeForPolicy`); `full-debt`/CI/`health` resolve to FULL_SCOPE. A scoped result is partial and never enters the shared `AnalysisResult` cache.

**Verdict-safe:** the classifier blocks security-only on secret/code/dep-vuln only, and `context.reachable` is never set on the gate path, so graphify is provably unconsulted.

### opt 3 — incremental file-scoped scanning (`c4edfc2`)
The current side's semgrep scans only files changed vs the baseline commit. Sound because semgrep is intraprocedural (CLAUDE.md Rule 13) — a net-new code finding can only appear in a changed file. `computeChangedFiles` is **complete-or-null** (null → full scan), so a scan can only ever over-cover, never under-cover. The ref/baseline side stays full; gitleaks/OSV stay full (cheap).

### opt 2 (graphify cache) — dropped
Profiling showed graphify is ~0.1s and already cross-process cached via its Python `cache_root`; a TS-level graph cache would be redundant.

### Safety re-confirmation
Loop-safety **0% escape holds on 2.14.0**: the real `computeStopGate` decision (security-only + incremental path, separate processes) blocks every net-new finding across scenarios (0/8 escapes) and never falsely blocks a clean tree (0/8 false-blocks).

### Tests
- `test/baseline/gather-scope.test.ts` — scope contract incl. "every block rule yields a non-empty scope" guard + observable-effect test.
- `test/baseline/changed-files.test.ts` — changed-file completeness contract (tracked + staged + untracked, excludes deletions, null on unreachable base / non-repo).
- Full suite: 2521 tests pass; arch + typecheck + lint clean.

**Merge note:** three independently-meaningful commits (opt 1, opt 3, release) → **rebase-merge** per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)