### PR TITLE
docs(launch): README factual audit + academic positioning pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ check its own work only helped a little.
    so pre-existing issues are grandfathered and never block.
 2. **Run a deterministic Stop-gate on every stop.** A Claude Code Stop hook
    re-runs the guardrail against that baseline. Same input gives the same
-   verdict, in seconds, offline, with no model in the loop.
+   verdict in seconds, with no model in the loop. The stop decision itself runs
+   locally and calls no model; individual detectors keep their own requirements.
 3. **Feed net-new findings back to the agent.** If the change introduced a
    finding, the gate blocks the stop and hands the agent the exact finding to
    fix: do not refresh the baseline, do not touch unrelated debt, fix what this
@@ -77,6 +78,22 @@ Use dxkit if you let coding agents:
 - fix CI or review comments in loops,
 - touch brownfield repos that already carry debt,
 - or work where "new debt" matters more than "all debt."
+
+## What dxkit is, and is not
+
+**It is a deterministic verification layer.** It baselines today's findings,
+fingerprints them across churn, and blocks only net-new regressions.
+
+**It is not a scanner replacement.** It runs and ingests scanners (gitleaks,
+Semgrep, CodeQL, Snyk, SARIF) and makes their findings enforceable. It does not
+claim to find more bugs than they do.
+
+**It is not an LLM judge.** No model decides whether the gate passes. The model
+can repair findings. The gate itself is deterministic, and the prompt does not
+grow as the baseline grows.
+
+**It is not a guarantee of safe code.** It blocks detector-backed net-new
+findings it can observe. You still need tests, review, scanners, and judgment.
 
 ## Built on tools you already trust
 
@@ -192,18 +209,26 @@ ships, the graph bounds how the loop works.
 Three independent benchmark results, one theme: dxkit makes agent work more
 predictable.
 
-| Layer                      | What it bounds                       | Observed result                                                                                                  |
-| -------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| **Stop-gate**              | unsafe final state                   | vanilla loops escaped **11/16** times, prompt-only checklist escaped **9/16**, dxkit escaped **0/16**            |
-| **Deterministic identity** | false "net-new" findings under churn | **100% catch / 0% false-block** on seeded gate tests; **0 false net-new** on tested line shifts and renames      |
-| **Graph context**          | large-repo exploration tails         | median roughly tied, but large-repo mean tokens **30% lower**, worst case **57% lower**, variance roughly halved |
+| Layer                      | What it bounds                       | Observed result                                                                                                                     |
+| -------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Stop-gate**              | net-new detector-backed debt         | vanilla loops escaped **11/16** times, prompt-only checklist escaped **9/16**, dxkit escaped **0/16**                               |
+| **Deterministic identity** | false "net-new" findings under churn | caught **all 3** seeded regressions with **0/2** false blocks on clean edits; **0 false net-new** on tested line shifts and renames |
+| **Graph context**          | large-repo exploration tails         | median roughly tied, but large-repo mean tokens **30% lower**, worst case **57% lower**, variance roughly halved                    |
 
 **Fixing in the loop is cheaper than fixing later.** A fourth arm of the
-loop-safety study measured the "detect on CI, fix later" model: deferring a
-net-new finding to a cold session cost **19–49% more tokens** (and up to 51% more
-turns) than repairing it inside the warm loop, because the cold fixer has to
-re-orient in a context it no longer holds. So the gate is not just safer than
-deferring, it is cheaper.
+loop-safety study measured the "detect on CI, fix later" model: on the test-gap
+task, deferring a net-new finding to a cold session cost **~49% more in
+equivalent cost** and **~51% more turns** than repairing it inside the warm loop,
+because the cold fixer has to re-orient in a context it no longer holds. (The
+secret-task premium pointed the same way but was weak — mean +19%, median
+slightly negative — so we lean on the robust test-gap result.) So the gate is not
+just safer than deferring, it is plausibly cheaper too.
+
+**And the gate is fast enough to run on every stop.** dxkit 2.14.0 scopes the
+Stop-gate scan to the active preset's blockable finding kinds and re-scans only
+the changed files, reusing cached results for everything unchanged. The verdict
+is identical to a full scan; the cost is seconds per stop, not minutes, even on
+large repositories.
 
 > **Benchmark caveats:** the loop-safety study uses controlled synthetic tasks
 > plus real-repo validation, detector-backed findings, and Sonnet runs. It is
@@ -213,22 +238,6 @@ deferring, it is cheaper.
 
 Full methodology, reproducibility notes, artifact status, and caveats are in
 **[docs/benchmarks.md](docs/benchmarks.md)**.
-
-## What dxkit is, and is not
-
-**It is a deterministic verification layer.** It baselines today's findings,
-fingerprints them across churn, and blocks only net-new regressions.
-
-**It is not a scanner replacement.** It runs and ingests scanners (gitleaks,
-Semgrep, CodeQL, Snyk, SARIF) and makes their findings enforceable. It does not
-claim to find more bugs than they do.
-
-**It is not an LLM judge.** No model decides whether the gate passes. The model
-can repair findings. The gate itself is deterministic, and the prompt does not
-grow as the baseline grows.
-
-**It is not a guarantee of safe code.** It blocks detector-backed net-new
-findings it can observe. You still need tests, review, scanners, and judgment.
 
 ## Why not just Snyk, SonarQube, or CodeQL?
 
@@ -240,7 +249,7 @@ every time the agent tries to declare done.
 | Loop Stop-gate need                                         | dxkit | Cloud or CI scanners                   |
 | ----------------------------------------------------------- | ----- | -------------------------------------- |
 | Runs locally on every stop, in seconds                      | yes   | usually CI or cloud cadence            |
-| Can run without network or auth                             | yes   | usually requires network or auth       |
+| Deterministic verdict, no model in the gate                 | yes   | varies (some add an LLM judge)         |
 | Grandfathers existing debt                                  | yes   | tool-dependent                         |
 | Feeds the exact block reason back to the warm agent session | yes   | usually a human-facing dashboard or PR |
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # dxkit
 
-**A deterministic Stop-gate for autonomous coding loops.**
+**A deterministic stop condition for AI coding agents.**
 
-Coding agents keep editing until they decide to stop. Tests and linters catch
-broken code, but they do not know whether the agent made the repo worse than
-the baseline. So loops can quietly ship new secrets, untested paths, and other
-detector-backed regressions, then report success.
+Autonomous coding loops need to answer a state question before they exit: did
+this change introduce detector-backed debt relative to the repository baseline?
+
+dxkit answers that question locally and reproducibly. It baselines existing
+findings, reruns trusted scanners at the stop boundary, and blocks only net-new
+findings with a concrete repair reason. A companion code graph gives the agent
+structural context while it works.
 
 In our loop benchmark, vanilla Claude Code-style loops stopped with net-new
 debt in **11 of 16 runs**. A prompt that told the agent to self-check still
@@ -30,7 +33,7 @@ npx vyuh-dxkit baseline create                    # grandfather today's findings
 npx vyuh-dxkit loop doctor                         # verify the gate is wired
 ```
 
-The gate runs locally with no model: same input, same verdict, in seconds.
+The stop verdict has no model in the path: same input, same verdict.
 Existing debt stays grandfathered; only net-new regressions block. Want to
 watch the flow first, on a sandbox dxkit creates? See the
 [walkthrough](#see-it-without-touching-your-repo).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -19,8 +19,9 @@ Three harnesses are included.
 
 The agent-driven studies in the report (loop safety, the LLM-as-gate comparison,
 and the graph-context sessions) require a model API or subscription and the
-pinned repository checkouts, and are not included here. Their harnesses and raw
-traces will be published separately after redaction.
+pinned repository checkouts. Their harnesses are published in
+[`agentic/`](agentic/) with their own README and verbatim prompts; see that
+directory for how to run them and which numbers each produces.
 
 ## Requirements
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,4 +115,4 @@ vyuh-dxkit --help          # top-level command list
 vyuh-dxkit doctor          # diagnose missing tools or misconfig
 ```
 
-Issues + feedback: <https://github.com/anthropics/claude-code/issues>
+Issues + feedback: <https://github.com/vyuh-labs/dxkit/issues>

--- a/docs/benchmarks/05-graph-context.md
+++ b/docs/benchmarks/05-graph-context.md
@@ -74,7 +74,7 @@ size-gating that [the Amdahl model](./06-amdahl-model.md) formalizes.
 | Statistic            | naive    | dxkit    | Delta            |
 | -------------------- | -------- | -------- | ---------------- |
 | median tokens        | 153,603  | 123,204  | roughly tied     |
-| mean tokens          | 219,249  | 152,056  | **−31%**         |
+| mean tokens          | 219,249  | 152,056  | **−30%**         |
 | worst case (max)     | 652,278  | 281,395  | **−57%**         |
 | coefficient of var.  | 0.72     | 0.41     | **~halved**      |
 


### PR DESCRIPTION
Launch-readiness pass on the README + benchmark docs for the **GitHub-first Show HN** submission, where the README is the primary landing surface. Grounded in two launch-research notes (factual audit + README/HN pattern analysis of successful launches).

## Hero + framing (academic register)
- Hero: `A deterministic Stop-gate for autonomous coding loops` → **`A deterministic stop condition for AI coding agents`** — names the *primitive* (stop condition), with Stop-gate defined as its local implementation later. ("Green is not done" was considered and rejected as too slogan-like.)
- Reworked opening states the loop-level question explicitly ("did this change introduce detector-backed debt relative to the repository baseline?") and surfaces the code graph as the second pillar.
- Moved **"What dxkit is, and is not" high** (before the deep sections and objections).

## Factual / honesty fixes
- Denominators on the gate-correctness claim (caught all 3 seeded regressions, 0/2 false blocks) instead of bare `100% / 0%`.
- Graph-context mean standardized to **30%** (conservative round of the measured 30.65%; was drifting 30/31 across files).
- Cost-of-deferral reworded to lead with the **robust** test-gap result (~49% cost / ~51% turns) and flag the **weak** secret signal, instead of a clean `19–49%` range.
- Added the **2.14.0 latency objection-killer** (scoped + incremental scan; seconds per stop, not minutes; verdict identical to a full scan).
- `unsafe final state` → `net-new detector-backed debt`.
- Softened the offline/no-auth overclaim in two places: the stop decision is deterministic, calls no model, runs locally; detectors keep their own network/auth requirements. Comparison table now contrasts "deterministic verdict, no model in the gate".

## docs
- `docs/benchmarks/05-graph-context.md`: fix internal inconsistency (table −31% vs prose −30%); both now **−30%**.
- `benchmarks/README.md`: fix stale claim that the agentic harnesses are "not included" — they're in `benchmarks/agentic/`; now points there.
- `docs/README.md`: fix launch-day bug — issues link pointed at `anthropics/claude-code`; now `vyuh-labs/dxkit/issues`.

## Verification
On the local 2.14.0 build: `demo loop-guardrail` (real block→repair→clean), `loop doctor`, `loop ledger summarize` all run. `bench-guardrail.mjs` reproduces `tp3/fn0/tn2/fp0` on strapi@dc49217. All README links resolve; no banned "safe code / 0% / guarantee" language (remaining matches are caveats). Repo metadata confirmed launch-aligned.

Deferred by design (not in this PR): the Website / `/try` links (added once the PR-gate page is built).

🤖 Generated with [Claude Code](https://claude.com/claude-code)