### PR TITLE
feat(guardrail): ref-based correctness + opt-in scoped check + two-pillar positioning (2.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.15.0] - 2026-06-22
+
+### Fixed — ref-based guardrail no longer false-blocks on `secret-hmac`
+
+In ref-based mode (the default for public repos), dxkit mints a locator-less
+`secret-hmac` companion alongside each located `secret` for cross-file
+relocation matching. On a fresh or shallow checkout the two sides of the diff
+can derive different salts, so the companions never match and read as net-new —
+a **false block**, even though the located `secret` twins match correctly.
+`secret-hmac` now joins `duplication` and `test-gap` in the set of kinds
+excluded from the ref-based diff (they can't be gathered comparably across a
+detached worktree). The located `secret` kind still gates net-new credentials;
+only the redundant companion is dropped. **Committed modes are unaffected.**
+
+### Added — opt-in `--incremental` for `guardrail check`
+
+`vyuh-dxkit guardrail check --incremental` scopes the gather to the analyzers
+the active policy can actually block on (reusing the loop Stop-gate's
+`scopeForPolicy`) and, in ref-based mode, scopes semgrep to the changed files
+on both sides. Same verdict, far less work — the check scales with PR size
+rather than repo size. **Opt-in and verdict-preserving:** without the flag,
+behavior is byte-identical to 2.14; it falls back to a full scan whenever the
+changed set can't be computed completely. The CLI flag exposes what the loop
+Stop-gate already did internally, so a ref-based CI guardrail (or a hosted
+PR-gate) can run the fast path too.
+
+### Changed — positioning: two pillars (context + gate)
+
+- README hero, package description, and `--help` tagline now lead with both
+  pillars: **"a deterministic stop condition and code-graph context layer for
+  AI coding agents."** The README opening + "What dxkit does" foreground the
+  code graph (callers, callees, blast radius) the agent uses *while making a
+  change*, then the deterministic stop-gate that blocks net-new regressions
+  *before it exits* — so the graph is no longer undersold as a footnote.
+
 ## [2.14.0] - 2026-06-22
 
 ### Changed — the loop Stop-gate gathers far less work per stop

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # dxkit
 
-**A deterministic stop condition for AI coding agents.**
+**A deterministic stop condition and code-graph context layer for AI coding agents.**
 
-Autonomous coding loops need to answer a state question before they exit: did
-this change introduce detector-backed debt relative to the repository baseline?
+Autonomous coding loops face two control problems: orienting in the code while
+they make a change, and deciding whether that change made the repository worse
+before they stop.
 
-dxkit answers that question locally and reproducibly. It baselines existing
-findings, reruns trusted scanners at the stop boundary, and blocks only net-new
-findings with a concrete repair reason. A companion code graph gives the agent
-structural context while it works.
+dxkit addresses both. While the agent works, it provides a code graph of
+callers, callees, blast radius, and the files a change touches. Then, when the
+agent tries to stop, dxkit baselines existing findings, reruns trusted checks,
+and blocks only net-new detector-backed regressions with a concrete repair
+reason.
 
 In our loop benchmark, vanilla Claude Code-style loops stopped with net-new
 debt in **11 of 16 runs**. A prompt that told the agent to self-check still
@@ -23,9 +25,10 @@ finding, and the agent repaired before stopping clean.
 
 dxkit does not reinvent detection. It runs trusted open source scanners
 (gitleaks, Semgrep, OSV, npm audit, and more), and it can ingest results from
-Snyk and CodeQL. What it adds is the piece those tools were not built for: a
-deterministic check, on every stop, of whether this change introduced a new
-finding compared with a baseline.
+Snyk and CodeQL. What dxkit adds is the agent-loop layer around those tools: a
+per-stop, baseline-relative verdict of whether this change introduced a new
+finding, returned to the agent with the exact repair reason while the loop is
+still warm.
 
 ```bash
 npm init @vyuhlabs/dxkit -- --claude-loop --yes   # install dxkit + register the Claude Code Stop hook
@@ -36,9 +39,9 @@ npx vyuh-dxkit loop doctor                         # verify the gate is wired
 The stop verdict has no model in the path: same input, same verdict.
 Existing debt stays grandfathered; only net-new regressions block. Want to
 watch the flow first, on a sandbox dxkit creates? See the
-[walkthrough](#see-it-without-touching-your-repo).
+[fixture gate](#run-a-local-fixture-gate).
 
-[Read the benchmark](docs/benchmarks.md) · [Try it on your repo](#try-it-on-your-repo)
+[Read the benchmark](docs/benchmarks.md) · [Try it on your repo](#try-it-on-your-repo) · [Run the fixture gate](#run-a-local-fixture-gate)
 
 <p>
   <a href="https://www.npmjs.com/package/@vyuhlabs/dxkit"><img alt="npm" src="https://img.shields.io/npm/v/@vyuhlabs/dxkit"></a>
@@ -51,24 +54,27 @@ watch the flow first, on a sandbox dxkit creates? See the
 
 ## The problem: loops do not know when they made things worse
 
-An autonomous loop runs until the agent decides it is done. The only checks in
-that loop today are tests and linters, and those catch broken code, not
-regressed code. There is no notion of "worse than the baseline." So an agent
-can add a feature, leave a new untested path or a hardcoded credential behind,
-run the tests, see green, and declare success.
+An autonomous loop runs until the agent decides it is done. The common checks in
+that loop (tests, linters, scanners, CI-style commands) usually answer whether
+something is broken or flagged. They do not, by themselves, maintain a
+brownfield baseline and answer the loop-level question: did this change
+introduce something net-new? So an agent can add a feature, leave a new untested
+path or a hardcoded credential behind, run the tests, see green, and declare
+success.
 
 In our benchmark this happened in most vanilla runs, and telling the agent to
 check its own work only helped a little.
 
 ## What dxkit does
 
-1. **Baseline today's debt.** `baseline create` records every current finding,
-   so pre-existing issues are grandfathered and never block.
-2. **Run a deterministic Stop-gate on every stop.** A Claude Code Stop hook
-   re-runs the guardrail against that baseline. Same input gives the same
-   verdict in seconds, with no model in the loop. The stop decision itself runs
-   locally and calls no model; individual detectors keep their own requirements.
-3. **Feed net-new findings back to the agent.** If the change introduced a
+1. **Build a structural code graph.** dxkit gives the agent callers, callees,
+   blast radius, and relevant files so it can orient before editing.
+2. **Baseline today's debt.** `baseline create` records current findings, so
+   pre-existing issues are grandfathered and never block.
+3. **Run a deterministic Stop-gate on every stop.** A Claude Code Stop hook
+   reruns the guardrail against that baseline. Same input gives the same
+   verdict; no model decides whether the gate passes.
+4. **Feed net-new findings back to the agent.** If the change introduced a
    finding, the gate blocks the stop and hands the agent the exact finding to
    fix: do not refresh the baseline, do not touch unrelated debt, fix what this
    branch introduced. The loop stops only when clean.
@@ -102,7 +108,7 @@ findings it can observe. You still need tests, review, scanners, and judgment.
 
 dxkit is an orchestration and enforcement layer, not another scanner. It runs
 established open source tools and treats their output as one stream. Which tools
-run depends on the languages in your repo — dxkit covers **8 ecosystems**
+run depends on the languages in your repo. dxkit covers **8 ecosystems**
 (TypeScript / JavaScript, Python, Go, Rust, C# / .NET, Java, Kotlin, Ruby).
 
 Universal, on every repo:
@@ -112,8 +118,8 @@ Universal, on every repo:
 - dependency advisories: OSV.dev
 - size, duplication, and the code graph: cloc, jscpd, graphify
 
-Per language, dxkit adds that ecosystem's own linter and audit tool — for
-example npm audit + ESLint (JS / TS), pip-audit + ruff (Python), govulncheck +
+Per language, dxkit adds that ecosystem's own linter and audit tool. For
+example, npm audit + ESLint (JS / TS), pip-audit + ruff (Python), govulncheck +
 golangci-lint (Go), cargo-audit + clippy (Rust), `dotnet list --vulnerable`
 (C#), osv-scanner + PMD (Java), osv-scanner + detekt (Kotlin), and
 bundler-audit + RuboCop (Ruby). The full per-language matrix is in **Per-pack
@@ -134,7 +140,7 @@ and inside the agent loop.
 ## Try it on your repo
 
 The Stop hook runs dxkit on every stop, so install dxkit into the repo. This
-one command adds it as a devDependency and registers the hook additively — your
+one command adds it as a devDependency and registers the hook additively, so your
 existing `.claude` settings are preserved:
 
 ```bash
@@ -148,9 +154,9 @@ npx vyuh-dxkit loop ledger summarize  # afterwards: blocked vs allowed, repaired
 When the agent tries to stop, dxkit runs the net-new gate against the baseline.
 Existing findings are grandfathered; only findings this change introduced block.
 
-## See it without touching your repo
+## Run a local fixture gate
 
-Want the flow first, on a sandbox dxkit creates?
+Want to see the Stop-gate before installing dxkit into your repo?
 
 ```bash
 npx -y @vyuhlabs/dxkit@latest demo loop-guardrail
@@ -161,7 +167,7 @@ net-new secret → BLOCK → repair → CLEAN, then it tears the fixture down. N
 key and no Claude Code, and your own repo is never touched. It needs gitleaks
 installed and takes about 20 seconds; without gitleaks it shows a clearly
 labelled illustration instead. (It does a one-time `npx` download, so it is not
-fully offline — the gate itself is.)
+fully offline, though the gate itself is.)
 
 ### Presets: what blocks the loop
 
@@ -218,13 +224,13 @@ predictable.
 | **Deterministic identity** | false "net-new" findings under churn | caught **all 3** seeded regressions with **0/2** false blocks on clean edits; **0 false net-new** on tested line shifts and renames |
 | **Graph context**          | large-repo exploration tails         | median roughly tied, but large-repo mean tokens **30% lower**, worst case **57% lower**, variance roughly halved                    |
 
-**Fixing in the loop is cheaper than fixing later.** A fourth arm of the
+**Deferral has a re-orientation cost.** A fourth arm of the
 loop-safety study measured the "detect on CI, fix later" model: on the test-gap
 task, deferring a net-new finding to a cold session cost **~49% more in
 equivalent cost** and **~51% more turns** than repairing it inside the warm loop,
 because the cold fixer has to re-orient in a context it no longer holds. (The
-secret-task premium pointed the same way but was weak — mean +19%, median
-slightly negative — so we lean on the robust test-gap result.) So the gate is not
+secret-task premium pointed the same way but was weak (mean +19%, median
+slightly negative), so we lean on the robust test-gap result.) So the gate is not
 just safer than deferring, it is plausibly cheaper too.
 
 **And the gate is fast enough to run on every stop.** dxkit 2.14.0 scopes the
@@ -285,7 +291,7 @@ cloc, jscpd, graphify).
 | Ruby                    | `Gemfile`, `*.rb`           | RuboCop, bundler-audit                    |
 
 <details>
-<summary><strong>Per-pack capabilities</strong> — coverage import, import-graph, severity tiers (click to expand)</summary>
+<summary><strong>Per-pack capabilities</strong>: coverage import, import-graph, severity tiers (click to expand)</summary>
 
 | Language | Detection                             | Coverage import     | Import-graph                                 | Native tools                        | Lint severity tiers    | Vuln severity tiers                           |
 | -------- | ------------------------------------- | ------------------- | -------------------------------------------- | ----------------------------------- | ---------------------- | --------------------------------------------- |
@@ -312,8 +318,8 @@ so it does not inflate the Code Quality score.
 
 ## Reproduce the deterministic tier
 
-The deterministic results — the net-new gate decision and the finding-identity
-matcher — reproduce offline with no API key, so you do not have to trust our
+The deterministic results (the net-new gate decision and the finding-identity
+matcher) reproduce offline with no API key, so you do not have to trust our
 numbers. These harnesses live in `benchmarks/`:
 
 ```bash

--- a/docs/commands/guardrail.md
+++ b/docs/commands/guardrail.md
@@ -19,20 +19,21 @@ confidence in [0, 1] and structured `reason` codes
 
 ```bash
 vyuh-dxkit guardrail check [path] [--name <n>] [--baseline <path>]
-                           [--changed-only] [--policy <path>]
+                           [--changed-only] [--incremental] [--policy <path>]
                            [--json | --markdown]
 ```
 
-| Option           | Effect                                                                                                               |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `path`           | Repo root to scan. Defaults to `.`                                                                                   |
-| `--name <n>`     | Baseline name (`.dxkit/baselines/<n>.json`). Default `main`                                                          |
-| `--baseline <p>` | Explicit baseline file path (overrides `--name`)                                                                     |
-| `--changed-only` | Drop new-side pairs whose anchor line falls outside the working-tree diff. Use in pre-commit hooks; skip in PR-gates |
-| `--policy <p>`   | Explicit `.dxkit/policy.json` override. Auto-discovers `<cwd>/.dxkit/policy.json` when omitted                       |
-| `--json`         | Emit `{ schema: 'dxkit.guardrail-check.v1', ... }` JSON                                                              |
-| `--markdown`     | Emit a markdown report (used by the PR-gate workflow to post a comment)                                              |
-| `--verbose`      | Print per-tool timing to stderr                                                                                      |
+| Option           | Effect                                                                                                                                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `path`           | Repo root to scan. Defaults to `.`                                                                                                                                                                                       |
+| `--name <n>`     | Baseline name (`.dxkit/baselines/<n>.json`). Default `main`                                                                                                                                                              |
+| `--baseline <p>` | Explicit baseline file path (overrides `--name`)                                                                                                                                                                         |
+| `--changed-only` | Drop new-side pairs whose anchor line falls outside the working-tree diff. Use in pre-commit hooks; skip in PR-gates                                                                                                     |
+| `--incremental`  | Scope the gather to the policy's blockable kinds and (ref-based) scope semgrep to changed files. Same verdict, scales with PR size not repo size; falls back to a full scan on any doubt. Opt-in; default is a full scan |
+| `--policy <p>`   | Explicit `.dxkit/policy.json` override. Auto-discovers `<cwd>/.dxkit/policy.json` when omitted                                                                                                                           |
+| `--json`         | Emit `{ schema: 'dxkit.guardrail-check.v1', ... }` JSON                                                                                                                                                                  |
+| `--markdown`     | Emit a markdown report (used by the PR-gate workflow to post a comment)                                                                                                                                                  |
+| `--verbose`      | Print per-tool timing to stderr                                                                                                                                                                                          |
 
 Exit code: `1` when the policy blocks any pair, `0` otherwise.
 
@@ -109,10 +110,10 @@ vyuh-dxkit guardrail check  # auto-discovers .dxkit/policy.json
 
 ### What gets installed
 
-| Flag                                    | Hook                   | When it fires      | Scope                                                                                  | Wall-clock                                                             |
-| --------------------------------------- | ---------------------- | ------------------ | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `--with-hooks` (default under `--full`) | `.githooks/pre-push`   | every `git push`   | full guardrail (every regression since baseline)                                       | scales with repo size (~3 min on a 500-file repo)                      |
-| `--with-precommit-hook` (opt-in)        | `.githooks/pre-commit` | every `git commit` | `--changed-only` (just lines you touched) — but the underlying scan is still full-repo | same as pre-push today; incremental-scope work lands in a future phase |
+| Flag                                    | Hook                   | When it fires      | Scope                                                                                            | Wall-clock                                                                |
+| --------------------------------------- | ---------------------- | ------------------ | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `--with-hooks` (default under `--full`) | `.githooks/pre-push`   | every `git push`   | full guardrail (every regression since baseline)                                                 | scales with repo size (~3 min on a 500-file repo)                         |
+| `--with-precommit-hook` (opt-in)        | `.githooks/pre-commit` | every `git commit` | `--changed-only` (just lines you touched); add `--incremental` to also scope the underlying scan | full scan today, or near-PR-size with `--incremental` (opt-in since 2.15) |
 
 The pre-commit hook is **opt-in** because re-running every analyzer on every commit is slow on large codebases. Pre-push amortises the same cost across the batch of commits in a push; CI runs the same check server-side as an unbypassable backstop. Customers on small/fast repos who want commit-time gating can opt in.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.14.0",
-  "description": "A Stop-gate for autonomous coding loops that blocks only net-new findings, running locally with no model in the gate",
+  "version": "2.15.0",
+  "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",
   "repository": {

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -58,7 +58,7 @@ import type { ResolvedMode } from './modes';
 import { classify, resolvePolicy } from './policy';
 import type { BrownfieldPolicy, ClassifyContext, ClassifyResult } from './policy';
 import { gatherFromRef } from './ref-baseline';
-import { type GatherScope, FULL_SCOPE } from './gather-scope';
+import { type GatherScope, FULL_SCOPE, scopeForPolicy } from './gather-scope';
 import { computeChangedFiles } from './changed-files';
 import { isSanitized } from './sanitize';
 import type { BaselineEntry, FindingId, FindingSeverity, MatchPair, MatchResult } from './types';
@@ -122,14 +122,21 @@ export interface RunGuardrailCheckOptions {
    */
   readonly scope?: GatherScope;
   /**
-   * Incremental scanning (opt 3): when true, the CURRENT side's semgrep
-   * scans only files that changed vs the baseline's commit, instead of the
-   * whole tree. Sound for a net-new gate (semgrep is intraprocedural — a
-   * net-new code finding only appears in a changed file). The ref/baseline
-   * side stays full so it covers every file. Falls back to a full scan when
-   * the changed set can't be computed completely. Opt-in: only the loop
-   * Stop-gate sets it; CI / `baseline check` leave it false so their full
-   * report is unaffected.
+   * Incremental scanning (opt 3): when true, semgrep scans only files that
+   * changed vs the comparison base, instead of the whole tree. Sound for a
+   * net-new gate (semgrep is intraprocedural — a net-new code finding only
+   * appears in a changed file). Scope by mode:
+   *   - committed: only the CURRENT side is scoped (the prior side is the
+   *     on-disk, already-full baseline), against the baseline's commit.
+   *   - ref-based: the changed set is fully computable (`diff(ref, HEAD)`),
+   *     so BOTH the ref side and the current side are scoped to the SAME
+   *     set, keeping the cross-run diff symmetric. This makes a ref-based
+   *     guardrail (CI, pre-push, the hosted PR gate) scale with PR size
+   *     rather than repo size.
+   * Falls back to a full scan when the changed set can't be computed
+   * completely. Opt-in: the loop Stop-gate sets it, and `guardrail check
+   * --incremental` exposes it on the CLI; otherwise it stays false so the
+   * full report is unaffected.
    */
   readonly incremental?: boolean;
 }
@@ -257,10 +264,24 @@ export interface GuardrailCheckResult {
  * differed only here (duplication 15→0, test-gap 44→12). Excluded from
  * both sides in ref-based mode; committed-full (which captures them once
  * from a fully-provisioned tree) is the mode that gates them. (D-G4.)
+ *
+ * `secret-hmac` joins them for a different reason: it is an internal,
+ * locator-less companion to each located `secret`, identified by a
+ * salt-based HMAC of the secret value. The salt resolves from
+ * `.dxkit/salt` / `DXKIT_BASELINE_SALT` / root-SHA, and on a fresh or
+ * shallow checkout the two sides can derive different salts (the ref
+ * worktree and the working tree need not share the salt source), so the
+ * HMACs don't match across the diff and every companion reads as net-new —
+ * a FALSE block, even though the located `secret` twins match fine. The
+ * located `secret` kind still gates net-new credentials; the companion
+ * exists only for cross-file relocation matching, which a committed salt
+ * provides and ref-based does not. So it is matcher-assist only here and is
+ * excluded from the ref-based diff.
  */
 const REF_UNRELIABLE_KINDS: ReadonlySet<BaselineEntry['kind']> = new Set([
   'duplication',
   'test-gap',
+  'secret-hmac',
 ]);
 
 /**
@@ -350,12 +371,40 @@ export async function runGuardrailCheck(
       policyRef: policy.baseline?.ref,
     });
 
+  // Incremental scanning in ref-based mode: the changed set is the diff of
+  // the ref against the working HEAD, known upfront from `mode.ref`. We scope
+  // BOTH the ref side and the current side to this same set so the cross-run
+  // diff stays symmetric (sound for the net-new gate — semgrep is
+  // intraprocedural). `computeChangedFiles` returns null on any uncertainty,
+  // which maps to `undefined` here, i.e. a full scan (the safe default).
+  const refIncrementalFiles =
+    options.incremental && mode.mode === 'ref-based' && mode.ref
+      ? (computeChangedFiles(cwd, mode.ref) ?? undefined)
+      : undefined;
+
+  // Gather scope. Incremental mode mirrors the loop Stop-gate's fast path: it
+  // scopes the gather to the analyzers the policy can actually block on
+  // (opt 1, via the shared `scopeForPolicy`) IN ADDITION to the changed-files
+  // semgrep scoping (opt 3) — the dominant speed win is skipping the analyzers
+  // a `security-only` posture can never block on (lint, coverage, jscpd,
+  // structural, licenses). An explicit `options.scope` still wins; default
+  // (non-incremental) callers stay on FULL_SCOPE so their full report and
+  // every warning are unaffected. Both sides use the SAME scope so the
+  // cross-run diff stays balanced.
+  const gatherScope = options.scope ?? (options.incremental ? scopeForPolicy(policy) : FULL_SCOPE);
+
   // Load the prior side. Committed modes read from the baseline
   // file on disk; ref-based mode recomputes prior state by checking
   // out a git ref into a temporary worktree. Both paths produce a
   // `BaselineFile`-shaped value so the matcher / classifier
   // downstream stay mode-agnostic.
-  const { baseline, baselinePath } = await loadPriorSide(cwd, mode, options);
+  const { baseline, baselinePath } = await loadPriorSide(
+    cwd,
+    mode,
+    options,
+    refIncrementalFiles,
+    gatherScope,
+  );
 
   // A committed baseline minted under an older identity scheme cannot be
   // meaningfully diffed against the current one — every finding's id
@@ -377,17 +426,22 @@ export async function runGuardrailCheck(
     }
   }
 
-  const scope = options.scope ?? FULL_SCOPE;
-  // Incremental scanning: scope the current side's semgrep to files that
-  // changed vs the baseline commit. `computeChangedFiles` returns null when
-  // it can't enumerate the changed set completely (base unreachable, git
-  // error) — that maps to `undefined` here, i.e. a full scan (the safe
-  // default). The ref/baseline side is NOT incremental: it must cover every
-  // file so the diff has a complete prior to match against.
+  const scope = gatherScope;
+  // Incremental scanning: scope the current side's semgrep to changed files.
+  // `computeChangedFiles` returns null when it can't enumerate the changed
+  // set completely (base unreachable, git error) — that maps to `undefined`
+  // here, i.e. a full scan (the safe default).
+  //   - ref-based: reuse the set already computed from `mode.ref` above; the
+  //     ref/baseline side was scoped to the SAME set, keeping the diff
+  //     symmetric.
+  //   - committed: the prior side is the on-disk (full) baseline, so only the
+  //     current side is scoped, against the baseline's commit.
   const incrementalFiles =
-    options.incremental && baseline.repo.commitSha
-      ? (computeChangedFiles(cwd, baseline.repo.commitSha) ?? undefined)
-      : undefined;
+    mode.mode === 'ref-based'
+      ? refIncrementalFiles
+      : options.incremental && baseline.repo.commitSha
+        ? (computeChangedFiles(cwd, baseline.repo.commitSha) ?? undefined)
+        : undefined;
   const current = await gatherCurrentScan({
     cwd,
     verbose: options.verbose,
@@ -861,6 +915,8 @@ async function loadPriorSide(
   cwd: string,
   mode: ResolvedMode,
   options: RunGuardrailCheckOptions,
+  incrementalFiles?: ReadonlyArray<string>,
+  scope: GatherScope = FULL_SCOPE,
 ): Promise<{ baseline: BaselineFile; baselinePath?: string }> {
   if (mode.mode !== 'ref-based') {
     const baselinePath =
@@ -883,7 +939,14 @@ async function loadPriorSide(
     cwd,
     ref: mode.ref,
     verbose: options.verbose,
-    scope: options.scope ?? FULL_SCOPE,
+    // Same policy-derived scope as the current side (opt 1), so the cross-run
+    // diff stays balanced and the ref side skips the same non-blockable
+    // analyzers.
+    scope,
+    // Symmetric incremental scoping: when the caller scoped the current side
+    // to the changed files, scope the ref side to the SAME set (see the
+    // `refIncrementalFiles` computation in `runGuardrailCheck`).
+    incrementalFiles,
   });
   const baseline: BaselineFile = {
     schemaVersion: BASELINE_SCHEMA_VERSION,

--- a/src/baseline/ref-baseline.ts
+++ b/src/baseline/ref-baseline.ts
@@ -247,17 +247,31 @@ export async function gatherFromRef(opts: {
   /** Scope the ref-side gather identically to the current side so the
    *  cross-run diff stays balanced. Defaults to `FULL_SCOPE`. */
   readonly scope?: GatherScope;
+  /** Incremental scanning (opt 3): scope the ref side's semgrep to just
+   *  these changed files, exactly like the current side. In ref-based mode
+   *  the changed set is fully computable (`diff(ref, HEAD)`), so scoping
+   *  BOTH sides to the same files keeps the cross-run diff symmetric and
+   *  sound for the net-new gate (semgrep is intraprocedural — a net-new
+   *  code finding can only appear in a changed file). Omit for a full ref
+   *  scan. The set is part of the cache key so a scoped ref scan is never
+   *  reused for a full request. */
+  readonly incrementalFiles?: ReadonlyArray<string>;
 }): Promise<CurrentScan> {
   const sha = resolveRefToSha(opts.cwd, opts.ref);
   if (sha === null) throw unreachableRefError(opts.cwd, opts.ref);
 
   const scope = opts.scope ?? FULL_SCOPE;
-  const key = refScanCacheKey(opts.cwd, sha, scope);
+  const key = refScanCacheKey(opts.cwd, sha, scope, opts.incrementalFiles);
   const cached = readRefScanCache(opts.cwd, key);
   if (cached) return cached;
 
   const scan = await withRefWorktree({ cwd: opts.cwd, ref: opts.ref }, async (worktreePath) => {
-    return gatherCurrentScan({ cwd: worktreePath, verbose: opts.verbose, scope });
+    return gatherCurrentScan({
+      cwd: worktreePath,
+      verbose: opts.verbose,
+      scope,
+      incrementalFiles: opts.incrementalFiles,
+    });
   });
   writeRefScanCache(opts.cwd, key, scan);
   return scan;
@@ -295,10 +309,27 @@ function saltSignature(cwd: string): string {
   }
 }
 
+/** Stable signature of an incremental changed-file set (order-independent),
+ *  or a sentinel for a full (non-incremental) scan. Part of the cache key so
+ *  a scan scoped to one changed set is never reused for a different set or a
+ *  full request. */
+function incrementalSignature(incrementalFiles?: ReadonlyArray<string>): string {
+  if (incrementalFiles === undefined) return 'full';
+  if (incrementalFiles.length === 0) return 'incremental:empty';
+  const joined = [...incrementalFiles].sort().join('\n');
+  return `incremental:${createHash('sha256').update(joined).digest('hex').slice(0, 16)}`; // fingerprint-helper-ok
+}
+
 /** Deterministic cache key over every input that can change a ref scan.
  *  Includes the gather scope so a scoped ref scan is never reused for a
- *  full request (or vice versa). Exported for testing. */
-export function refScanCacheKey(cwd: string, sha: string, scope: GatherScope = FULL_SCOPE): string {
+ *  full request (or vice versa), and the incremental changed-file set so a
+ *  symmetric ref-based incremental scan keys distinctly. Exported for testing. */
+export function refScanCacheKey(
+  cwd: string,
+  sha: string,
+  scope: GatherScope = FULL_SCOPE,
+  incrementalFiles?: ReadonlyArray<string>,
+): string {
   const material = [
     `fmt:${REF_SCAN_CACHE_FORMAT}`,
     `sha:${sha}`,
@@ -306,6 +337,7 @@ export function refScanCacheKey(cwd: string, sha: string, scope: GatherScope = F
     `scheme:${CURRENT_IDENTITY_SCHEME}`,
     `salt:${saltSignature(cwd)}`,
     `scope:${scopeSignature(scope)}`,
+    `incr:${incrementalSignature(incrementalFiles)}`,
   ].join('\0');
   return createHash('sha256').update(material).digest('hex').slice(0, 32); // fingerprint-helper-ok
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -135,7 +135,7 @@ function applyFailOnSeverity(
 
 function printUsage(): void {
   console.log(`
-  ${logger.bold('vyuh-dxkit')} v${VERSION} — a Stop-gate for autonomous coding loops that blocks net-new findings
+  ${logger.bold('vyuh-dxkit')} v${VERSION} — a deterministic stop condition + code-graph context layer for AI coding agents
 
   ${logger.bold('Usage:')}
     vyuh-dxkit init [options]    Install dxkit agent DX in this repo
@@ -175,12 +175,15 @@ function printUsage(): void {
                                  per-kind counts. --kind drills into one kind. --json
                                  emits a schema-banner-wrapped payload.
     vyuh-dxkit guardrail check [path] [--name <n>] [--baseline <path>]
-                               [--changed-only] [--policy <path>]
+                               [--changed-only] [--incremental] [--policy <path>]
                                [--mode=<mode>] [--ref=<ref>]
                                [--json | --markdown]
                                  Diff current scan against the named baseline; block on net-new
                                  regressions per brownfield policy. Exit code 1 when blocked.
                                  --mode/--ref mirror baseline create (override policy.json).
+                                 --incremental scopes semgrep to changed files (both sides in
+                                 ref-based mode) so the check scales with PR size, not repo size;
+                                 same verdict, much faster. Falls back to a full scan on any doubt.
     vyuh-dxkit hooks activate [path]
                                  Idempotently set core.hooksPath = .githooks. Wired into
                                  package.json postinstall by 'init --with-hooks' so every
@@ -316,6 +319,7 @@ export async function run(argv: string[]): Promise<void> {
       'no-fail-fast': { type: 'boolean', default: false },
       'with-coverage': { type: 'boolean', default: false },
       'changed-only': { type: 'boolean', default: false },
+      incremental: { type: 'boolean', default: false },
       baseline: { type: 'string' },
       policy: { type: 'string' },
       markdown: { type: 'boolean', default: false },
@@ -1992,6 +1996,7 @@ export async function run(argv: string[]): Promise<void> {
           name: values.name as string | undefined,
           baselinePath: values.baseline as string | undefined,
           changedOnly: !!values['changed-only'],
+          incremental: !!values.incremental,
           policyPath: values.policy as string | undefined,
           verbose: !!values.verbose,
           cliMode: cliMode ?? undefined,

--- a/test/baseline/ref-based-exclusion.test.ts
+++ b/test/baseline/ref-based-exclusion.test.ts
@@ -34,6 +34,26 @@ describe('partitionForRefBasedDiff', () => {
     expect(out.diffableCurrent.map((x) => x.tag)).toEqual(['c1']);
   });
 
+  it('ref-based mode: drops secret-hmac too (salt non-comparable across worktree), keeps located secret', () => {
+    // secret-hmac is the locator-less companion to each `secret`. On a fresh/
+    // shallow ref worktree the two sides can derive different salts, so the
+    // HMAC companions never match and read as net-new — a FALSE block. The
+    // located `secret` still gates the credential; the companion is dropped.
+    const prior = [f('secret', 'p1'), f('secret-hmac', 'p2')];
+    const current = [f('secret', 'c1'), f('secret-hmac', 'c2')];
+    const out = partitionForRefBasedDiff(prior, current, true);
+    expect(out.diffablePrior.map((x) => x.tag)).toEqual(['p1']);
+    expect(out.diffableCurrent.map((x) => x.tag)).toEqual(['c1']);
+  });
+
+  it('committed mode: secret-hmac is NOT dropped (salt is consistent there)', () => {
+    const prior = [f('secret', 'p1'), f('secret-hmac', 'p2')];
+    const current = [f('secret', 'c1'), f('secret-hmac', 'c2')];
+    const out = partitionForRefBasedDiff(prior, current, false);
+    expect(out.diffablePrior.map((x) => x.tag)).toEqual(['p1', 'p2']);
+    expect(out.diffableCurrent.map((x) => x.tag)).toEqual(['c1', 'c2']);
+  });
+
   it('ref-based mode: a worktree-unreliable kind on BOTH sides never reaches the diff (the bug it fixes)', () => {
     // The original bug: 15 duplication on current, 0 on prior (worktree
     // produced none) → all 15 flagged net-new. After exclusion neither side

--- a/test/loop/stop-gate-cache.test.ts
+++ b/test/loop/stop-gate-cache.test.ts
@@ -160,6 +160,17 @@ describe('ref-scan cache', () => {
     expect(refScanCacheKey(repo, 'sha-aaa')).not.toBe(refScanCacheKey(repo, 'sha-bbb'));
   });
 
+  it('incremental changed-file set is part of the key (scoped never reused for full or a different set)', () => {
+    const full = refScanCacheKey(repo, 'sha-aaa');
+    const incrA = refScanCacheKey(repo, 'sha-aaa', undefined, ['a.ts', 'b.ts']);
+    const incrB = refScanCacheKey(repo, 'sha-aaa', undefined, ['c.ts']);
+    // A scoped scan must not collide with a full scan or a different set.
+    expect(incrA).not.toBe(full);
+    expect(incrA).not.toBe(incrB);
+    // ...but is order-independent and stable for the same set.
+    expect(refScanCacheKey(repo, 'sha-aaa', undefined, ['b.ts', 'a.ts'])).toBe(incrA);
+  });
+
   it('write then read returns the cached scan', () => {
     const key = refScanCacheKey(repo, 'sha-aaa');
     writeRefScanCache(repo, key, minimalScan);


### PR DESCRIPTION
2.15.0: two ref-based-mode improvements, a positioning refresh, and a human-prose pass. **Backward compatible by construction** except a strictly-safer ref-based correctness fix.

## Guardrail
**Fix — ref-based no longer false-blocks on `secret-hmac`.** The locator-less `secret-hmac` companion (minted alongside each located `secret` for cross-file relocation matching) now joins `duplication` + `test-gap` in `REF_UNRELIABLE_KINDS`. On fresh/shallow checkouts the two diff sides can derive different salts, so the companions never match and read as net-new (a false BLOCK). The located `secret` still gates real credentials; only the redundant companion is dropped. **Committed modes untouched.**

**Add — opt-in `--incremental` on `guardrail check`.** Scopes the gather to the policy's blockable kinds (reuses the loop's `scopeForPolicy`) and, in ref-based mode, scopes semgrep to changed files on both sides. Same verdict, scales with PR size not repo size; falls back to a full scan on any doubt. **Default off → byte-identical to 2.14 without the flag.**

## Positioning (two pillars: context + gate)
- README hero / npm description / `--help` tagline now lead with both pillars: *"a deterministic stop condition and code-graph context layer for AI coding agents."*
- Review-driven precision pass: "two control problems" framing; "agent-loop layer around those tools" (instead of "tools were not built for"); problem section no longer overgeneralizes ("tests and linters" → "common checks … do not maintain a brownfield baseline"); deferral heading softened to "Deferral has a re-orientation cost" (matches the ledger's *Moderate* rating; body numbers unchanged + verified vs `docs/benchmarks/02`); fixture gate promoted to the top link row and renamed "Run a local fixture gate."
- Human-prose pass: removed every em-dash from the README + new docs copy.

## Safety / compatibility
| Change | Affects existing consumers? |
|---|---|
| `--incremental` flag + internal API params | No — opt-in, default off; all params optional/defaulted |
| `secret-hmac` fix | Only ref-based, only **removes false blocks** (never misses a real secret) |
| positioning / version / docs | Cosmetic / metadata |

Deliberately conservative: **not** auto-adding `--incremental` to generated CI/pre-push templates — existing users' guardrails keep the full scan.

## Verification
- Full suite **2521/2521**; new tests lock both behaviors (secret-hmac exclusion ref-based vs committed; `refScanCacheKey` incremental signature).
- Deterministic benchmarks unaffected (committed-full mode + ref-based-only change).
- End-to-end: minimal-repo with planted secret + vulnerable lodash → **BLOCK in ~10s** (secret high + dep-vuln critical), no false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)