### PR TITLE
docs(readme): drop duplicated fixture-gate link above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ npx vyuh-dxkit loop doctor                         # verify the gate is wired
 ```
 
 The stop verdict has no model in the path: same input, same verdict.
-Existing debt stays grandfathered; only net-new regressions block. Want to
-watch the flow first, on a sandbox dxkit creates? See the
-[fixture gate](#run-a-local-fixture-gate).
+Existing debt stays grandfathered; only net-new regressions block.
 
 [Read the benchmark](docs/benchmarks.md) · [Try it on your repo](#try-it-on-your-repo) · [Run the fixture gate](#run-a-local-fixture-gate)
 


### PR DESCRIPTION
The fixture gate was linked twice within a few lines above the fold — once in the prose ("Want to watch the flow first… See the fixture gate") and again in the nav row ("Run the fixture gate"). Removes the redundant prose sentence; the nav-row link stays.

README-only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)