### PR TITLE
feat(demo): convert demo loop-guardrail into setup (2.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.18.0] - 2026-06-23
+
+### Added — `demo loop-guardrail` converts into setup
+
+After the offline walkthrough, `vyuh-dxkit demo loop-guardrail` now shows a next
+step tailored to where it was run, and offers to wire the Stop-gate in for you:
+
+- A **context-aware call to action.** A git repo with no dxkit yet gets the
+  wire-up sequence (`init --claude-loop` then `baseline create` then
+  `loop doctor`); an already-set-up repo gets just `loop doctor`; a non-repo
+  points you at your project. No more one-size-fits-all hint.
+- An **interactive opt-in**, offered only when it is safe to ask: in a git repo
+  with no dxkit yet, on a TTY. It defaults to **no**, never prompts in a piped or
+  CI run (so `npx ... | cat` and CI steps cannot block), and never touches a repo
+  that already has dxkit. On yes it runs the additive, reversible
+  `init --claude-loop` and stops there. You run `baseline create` yourself when
+  you are ready to grandfather today's debt.
+
+A `demo` still never silently changes your repo: the opt-in is the only thing
+that writes, and only with explicit consent.
+
 ## [2.17.0] - 2026-06-23
 
 ### Changed — the guardrail gate skips dependency *remediation* enrichment

--- a/docs/commands/loop.md
+++ b/docs/commands/loop.md
@@ -95,6 +95,16 @@ anything up.
 vyuh-dxkit demo loop-guardrail
 ```
 
+After the walkthrough it shows a **next step tailored to where you ran it**: a
+git repo with no dxkit yet gets the wire-up commands; an already-set-up repo gets
+`loop doctor`; a non-repo points you at your project. When you run it
+interactively (a TTY) inside a fresh git repo, it also **offers to wire the
+Stop-gate in for you** with one keystroke — that opt-in runs the additive
+`init --claude-loop` and is the only thing that writes anything. It defaults to
+**no**, never prompts in a piped or CI run, and never touches a repo that already
+has dxkit. It stops at `init`; you run `baseline create` yourself when you are
+ready to grandfather today's debt.
+
 ## `vyuh-dxkit loop doctor`
 
 Preflight for an unattended run. Verifies the loop is wired safely BEFORE

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.17.0",
+      "version": "2.18.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/loop/demo.ts
+++ b/src/loop/demo.ts
@@ -16,6 +16,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as readline from 'readline';
 import { execFileSync, spawnSync } from 'child_process';
 import type { GuardrailJsonPayload } from '../baseline/check-renderers';
 import { GUARDRAIL_JSON_SCHEMA } from '../baseline/check-renderers';
@@ -302,6 +303,104 @@ function printIllustration(reason: 'no-gitleaks' | 'sandbox-failed'): void {
   console.log(''); // slop-ok
 }
 
+/**
+ * The state of the directory the demo was invoked from, which decides the
+ * conversion call-to-action shown at the end:
+ *   - `initialized` — `.dxkit/` already exists here; the user is set up, so the
+ *     CTA is just "verify the wiring" rather than "set it up".
+ *   - `git`         — a git repo with no dxkit yet; the prime conversion case,
+ *     and the only state in which we offer the interactive opt-in.
+ *   - `non-git`     — not a git repo (often a throwaway `npx` dir); we can't
+ *     wire anything here, so the CTA points the user at their real project.
+ */
+export type DemoCwdState = 'initialized' | 'git' | 'non-git';
+
+/** True when `cwd` already has a `.dxkit/` directory (dxkit set up here). */
+function isDxkitInitialized(cwd: string): boolean {
+  return fs.existsSync(path.join(cwd, '.dxkit'));
+}
+
+/** True when `cwd` is inside a git work tree. Never throws. */
+function isGitRepo(cwd: string): boolean {
+  const r = spawnSync('git', ['rev-parse', '--is-inside-work-tree'], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  return r.status === 0 && (r.stdout ?? '').trim() === 'true';
+}
+
+/** Classify the invocation directory for the conversion CTA. Pure of output. */
+export function cwdState(cwd: string): DemoCwdState {
+  if (isDxkitInitialized(cwd)) return 'initialized';
+  if (isGitRepo(cwd)) return 'git';
+  return 'non-git';
+}
+
+/**
+ * The tailored "next steps" lines for a given cwd state. Pure (no I/O) so the
+ * exact guidance is unit-testable. The first line is a header; the rest are
+ * indented command hints. Commands are shown literally (the binary name, not
+ * `npx`) to match the rest of this file and dxkit's self-invocation rules.
+ */
+export function buildNextSteps(state: DemoCwdState): string[] {
+  switch (state) {
+    case 'initialized':
+      return [
+        'This repo already has dxkit set up.',
+        '  vyuh-dxkit loop doctor        verify the loop wiring is safe to run unattended',
+      ];
+    case 'git':
+      return [
+        'You are in a git repo. Wire the same Stop-gate in here:',
+        '  vyuh-dxkit init --claude-loop   add the Stop-gate hook + norms (additive, reversible)',
+        "  vyuh-dxkit baseline create      grandfather today's debt so only net-new blocks",
+        '  vyuh-dxkit loop doctor          verify it is safe to run unattended',
+      ];
+    case 'non-git':
+      return [
+        'Run the same Stop-gate in your project (it must be a git repo):',
+        '  cd <your-repo>',
+        '  npm init @vyuhlabs/dxkit -- --claude-loop   set up the loop (or: vyuh-dxkit init --claude-loop)',
+        "  vyuh-dxkit baseline create                  grandfather today's debt",
+      ];
+  }
+}
+
+/**
+ * Whether to offer the interactive "wire it up now?" opt-in. Pure so the gating
+ * is unit-testable. We only ever ask when ALL hold: we are in a git repo with
+ * no dxkit yet (`git` state), AND both stdin and stdout are TTYs. The TTY guard
+ * is essential: a piped or CI invocation (`npx ... | cat`, a CI step) must never
+ * block on a prompt. We never prompt in `initialized` (already set up) or
+ * `non-git` (nothing to wire here).
+ */
+export function shouldOfferInteractive(
+  state: DemoCwdState,
+  stdinIsTty: boolean,
+  stdoutIsTty: boolean,
+): boolean {
+  return state === 'git' && stdinIsTty === true && stdoutIsTty === true;
+}
+
+/** Ask a yes/no question on the TTY. Defaults to NO (anything but y/yes). */
+function promptYesNo(question: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`${question} [y/N] `, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
+/** Print the tailored conversion CTA for the invocation directory. */
+function printNextSteps(state: DemoCwdState): void {
+  const [head, ...rest] = buildNextSteps(state);
+  logger.info(head);
+  for (const line of rest) logger.dim(line);
+}
+
 /** CLI entry for `vyuh-dxkit demo loop-guardrail`. */
 export async function runLoopGuardrailDemo(): Promise<void> {
   logger.header('vyuh-dxkit demo: loop guardrail');
@@ -318,8 +417,31 @@ export async function runLoopGuardrailDemo(): Promise<void> {
   } else {
     printIllustration(hasGitleaks ? 'sandbox-failed' : 'no-gitleaks');
   }
+  console.log(''); // slop-ok
 
-  logger.dim('Run the same gate on your repo:');
-  logger.dim('  npm init @vyuhlabs/dxkit -- --claude-loop --yes  →  vyuh-dxkit baseline create');
+  // Conversion: tailor the call-to-action to where the demo was run, and offer
+  // a one-keystroke opt-in ONLY when it is safe to ask (a git repo, on a TTY).
+  // A `demo` must never silently touch the user's repo, so the opt-in is the
+  // only thing that writes, it runs the additive `init`, and it defaults to NO.
+  const cwd = process.cwd();
+  const state = cwdState(cwd);
+  printNextSteps(state);
+
+  if (shouldOfferInteractive(state, !!process.stdin.isTTY, !!process.stdout.isTTY)) {
+    console.log(''); // slop-ok
+    const yes = await promptYesNo('Wire the Stop-gate into this repo now?');
+    if (yes) {
+      logger.dim('  running: vyuh-dxkit init --claude-loop --yes …');
+      const r = runCli(cwd, ['init', '--claude-loop', '--yes']);
+      console.log(''); // slop-ok
+      if (r.status === 0) {
+        logger.success('Stop-gate wired into this repo (init is additive and reversible).');
+        logger.dim("  Next: vyuh-dxkit baseline create   grandfather today's debt");
+        logger.dim('        vyuh-dxkit loop doctor        verify it is safe to run unattended');
+      } else {
+        logger.warn('init did not complete here. Run it yourself: vyuh-dxkit init --claude-loop');
+      }
+    }
+  }
   process.exit(0);
 }

--- a/test/loop/demo.test.ts
+++ b/test/loop/demo.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from 'vitest';
-import { renderLoopGuardrailDemo } from '../../src/loop/demo';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import * as path from 'path';
+import {
+  renderLoopGuardrailDemo,
+  buildNextSteps,
+  shouldOfferInteractive,
+  cwdState,
+} from '../../src/loop/demo';
 import { buildRepairMessage } from '../../src/loop/stop-gate';
 
 describe('loop guardrail demo', () => {
@@ -20,5 +29,75 @@ describe('loop guardrail demo', () => {
     // Reconstruct from the same builder over an equivalent single-secret payload.
     expect(blockMessage.startsWith('dxkit blocked completion')).toBe(true);
     expect(typeof buildRepairMessage).toBe('function');
+  });
+});
+
+describe('demo conversion CTA — buildNextSteps', () => {
+  it('initialized: points at loop doctor, never at re-init', () => {
+    const lines = buildNextSteps('initialized').join('\n');
+    expect(lines).toContain('already has dxkit set up');
+    expect(lines).toContain('vyuh-dxkit loop doctor');
+    expect(lines).not.toContain('init --claude-loop');
+  });
+
+  it('git: shows the full wire-up sequence', () => {
+    const lines = buildNextSteps('git').join('\n');
+    expect(lines).toContain('vyuh-dxkit init --claude-loop');
+    expect(lines).toContain('vyuh-dxkit baseline create');
+    expect(lines).toContain('vyuh-dxkit loop doctor');
+  });
+
+  it('non-git: points the user at their real project', () => {
+    const lines = buildNextSteps('non-git').join('\n');
+    expect(lines).toContain('must be a git repo');
+    expect(lines).toContain('npm init @vyuhlabs/dxkit');
+  });
+
+  it('never prints a raw `npx vyuh-dxkit` invocation (self-invocation rule)', () => {
+    for (const s of ['initialized', 'git', 'non-git'] as const) {
+      expect(buildNextSteps(s).join('\n')).not.toContain('npx vyuh-dxkit');
+    }
+  });
+});
+
+describe('demo conversion opt-in — shouldOfferInteractive', () => {
+  it('offers ONLY in a git repo with both stdin and stdout as TTYs', () => {
+    expect(shouldOfferInteractive('git', true, true)).toBe(true);
+  });
+
+  it('never offers when not a TTY (piped / CI must not block on a prompt)', () => {
+    expect(shouldOfferInteractive('git', false, true)).toBe(false);
+    expect(shouldOfferInteractive('git', true, false)).toBe(false);
+    expect(shouldOfferInteractive('git', false, false)).toBe(false);
+  });
+
+  it('never offers when already initialized or not a git repo', () => {
+    expect(shouldOfferInteractive('initialized', true, true)).toBe(false);
+    expect(shouldOfferInteractive('non-git', true, true)).toBe(false);
+  });
+});
+
+describe('demo conversion — cwdState detection', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'dxkit-demo-cwd-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('non-git plain directory → non-git', () => {
+    expect(cwdState(dir)).toBe('non-git');
+  });
+
+  it('git repo without dxkit → git', () => {
+    execFileSync('git', ['init', '-q'], { cwd: dir });
+    expect(cwdState(dir)).toBe('git');
+  });
+
+  it('directory with .dxkit → initialized (takes precedence over git)', () => {
+    execFileSync('git', ['init', '-q'], { cwd: dir });
+    mkdirSync(path.join(dir, '.dxkit'), { recursive: true });
+    expect(cwdState(dir)).toBe('initialized');
   });
 });


### PR DESCRIPTION
## What

After the offline walkthrough, `vyuh-dxkit demo loop-guardrail` now converts a demo viewer into a set-up user.

- **Context-aware next step.** A git repo with no dxkit yet gets the wire-up sequence (`init --claude-loop` → `baseline create` → `loop doctor`); an already-set-up repo gets just `loop doctor`; a non-repo points at the user's project.
- **Interactive opt-in**, offered only when safe to ask: a git repo with no dxkit yet, on a TTY. Defaults to **no**, never prompts in a piped/CI run (cannot block `npx ... | cat` or CI), never touches a repo that already has dxkit. On yes it runs the additive, reversible `init --claude-loop --yes` and stops before `baseline create`.

A `demo` still never silently mutates the user's repo: the opt-in is the only writer, and only with explicit consent.

## Tests (all verified)

- New unit tests for `buildNextSteps` / `shouldOfferInteractive` / `cwdState` across every branch.
- PTY-driven end-to-end: interactive **"y"** → runs init, `.dxkit` created; **"n"** → nothing written; **non-TTY git** → no prompt, no hang, no write.
- Full suite: 2,559 tests pass. Lint, format, typecheck, architecture, slop, `npm pack --dry-run` all green.

## Release

2.18.0 (minor; backward-compatible feature add). `package.json` / `package-lock.json` bumped, CHANGELOG + `docs/commands/loop.md` updated. Squash-merge candidate (single logical change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)