### PR TITLE
fix(cli): resolvable npx next-step hints (2.18.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.18.1] - 2026-06-23
+
+### Fixed — next-step hints now use a resolvable invocation
+
+Actionable "run this next" hints printed by the CLI (after `init`, in `doctor`,
+`tools`, the loop preflight, and elsewhere) referenced the bare `vyuh-dxkit`
+binary. After the common devDependency install (`npm init @vyuhlabs/dxkit`), that
+binary is not on the global PATH, so copy-pasting the hint failed with
+"command not found". Every actionable hint now routes through the canonical
+`npx vyuh-dxkit` invocation, which resolves a project-local devDependency or a
+global install, so the suggested command runs as-is. The demo's conversion CTA is
+fixed the same way: it shows `npm init @vyuhlabs/dxkit` to bootstrap a repo with
+no dxkit yet, and the `npx` form for the follow-up commands.
+
 ## [2.18.0] - 2026-06-23
 
 ### Added — `demo loop-guardrail` converts into setup

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -57,8 +57,8 @@ document is the supporting evidence.
 | Fixing in the loop is cheaper than deferring it       | Moderate        | loop benchmark deferred arm, 8 reps × 2 tasks      | "deferring the same fix cost ~49% more on the test-gap task (mean); weak on the secret task" |
 | Gate identity is deterministic under tested churn     | Strong          | offline matcher benches                            | "0 false net-new on tested line-shift and rename cases"                                      |
 | LLM-as-gate has cost and reproducibility issues       | Strong          | gate-vs-LLM benchmark, 5 reps × 2 models × 2 repos | "an LLM can judge, but not cheaply or reproducibly in-loop"                                  |
-| Graph context reduces observed large-repo token tails | Moderate–strong | Sonnet session study, 30 sessions                  | "lower mean, tail, and variance on a large repo"                                             |
-| Test-gap gating is safe as a default                  | Not claimed     | repair cost of 1.1M–1.6M tokens in validation      | default remains `security-only`; `full-debt` is opt-in                                       |
+| Graph context reduces observed large-repo token tails | Moderate-strong | Sonnet session study, 30 sessions                  | "lower mean, tail, and variance on a large repo"                                             |
+| Test-gap gating is safe as a default                  | Not claimed     | repair cost of 1.1M-1.6M tokens in validation      | default remains `security-only`; `full-debt` is opt-in                                       |
 | dxkit improves every agent session                    | Not claimed     | n/a                                                | do not say this                                                                              |
 | dxkit detects more vulnerabilities than scanners      | Not claimed     | n/a                                                | do not say this                                                                              |
 
@@ -201,7 +201,7 @@ fixing it in the warm loop cheaper than deferring it to a cold session?
 **Headline.** Holding the finding constant, deferring the test-gap repair to a
 cold session cost **~49% more in equivalent cost and ~51% more turns** (means).
 On the secret task the mean premium was ~19% but the signal is weak (the median
-is slightly negative). A conservative floor — real deferral costs more.
+is slightly negative). A conservative floor, real deferral costs more.
 
 **Method.** The `dxkit` (in-loop) and `deferred` (vanilla + cold fix) arms of
 `bench-loop.mjs`; both reach an identical clean final state, so this isolates the
@@ -215,7 +215,7 @@ changes, and grandfather pre-existing debt, every time?
 **Headline.** Confusion matrix tp 3 / fn 0 / tn 2 / fp 0 (catch 1, false-block 0)
 on both repos; exactly 1 net-new finding isolated against 205 / 1,020
 grandfathered items; **0 false regressions** on line-shift and rename churn. This
-is the **deterministic tier** — reproducible offline today, no API key.
+is the **deterministic tier**, reproducible offline today, no API key.
 
 **Method.** Three offline harnesses already published in
 [`benchmarks/`](../benchmarks/): `bench-guardrail.mjs`,
@@ -242,7 +242,7 @@ of the scaffold's overhead?
 
 **Headline.** On the large monorepo: median tokens roughly tied, **mean −30%,
 worst case −57%, variance roughly halved**. On the small app: overhead ≈ zero.
-The benefit is predictable tokens, not fewer tokens — and it is size-gated (54%
+The benefit is predictable tokens, not fewer tokens, and it is size-gated (54%
 of files in a slicing proxy were _not_ smaller).
 
 **Method.** `bench-context-efficiency.mjs` (200-symbol slicing proxy) and
@@ -324,7 +324,7 @@ numbers on the pinned NodeGoat and Strapi commits.
 The **agent-driven harnesses** (loop safety, cost of deferral, gate-vs-LLM, and
 the graph-context sessions) require a model subscription or API key and the
 pinned checkouts. They are published under
-[`benchmarks/agentic/`](../benchmarks/agentic/) — `bench-loop.mjs`,
+[`benchmarks/agentic/`](../benchmarks/agentic/), `bench-loop.mjs`,
 `bench-llm-gate.mjs`, `bench-sessions.mjs`, and `bench-context-efficiency.mjs`,
 with `benchmarks/agentic/README.md` documenting the config schema, the pinned
 substrates, and the verbatim prompts. Because these are agent-in-the-loop

--- a/docs/benchmarks/01-loop-safety.md
+++ b/docs/benchmarks/01-loop-safety.md
@@ -1,4 +1,4 @@
-# Study I — Loop safety and the Stop-gate
+# Study I: Loop safety and the Stop-gate
 
 > Detailed write-up for the study summarized in
 > [`docs/benchmarks.md`](../benchmarks.md). The companion economic study that
@@ -6,8 +6,8 @@
 
 ## Question
 
-How often does an autonomous coding loop — an agent that keeps editing until it
-decides to stop — declare itself done while detector-backed net-new debt is still
+How often does an autonomous coding loop, an agent that keeps editing until it
+decides to stop, declare itself done while detector-backed net-new debt is still
 in the tree? And does a deterministic Stop-gate prevent this where a prompt-only
 self-check does not?
 
@@ -29,9 +29,9 @@ for repair. The result is *observed* zero, not *proven* zero.
 Synthetic, controlled repositories, seeded fresh per run, each with exactly one
 injected trap. Two tasks (full prompts below):
 
-- **test-gap trap** — add a payments module; the trap is shipping new code with
+- **test-gap trap**: add a payments module; the trap is shipping new code with
   no test (a net-new test-gap finding).
-- **secret trap** — add a config file following an existing pattern, with a
+- **secret trap**: add a config file following an existing pattern, with a
   live-looking key in the prompt; the trap is hardcoding the credential.
 
 Real-repo validation uses **OWASP NodeGoat** (Apache-2.0), pinned at commit
@@ -41,18 +41,18 @@ Real-repo validation uses **OWASP NodeGoat** (Apache-2.0), pinned at commit
 
 The harness is `bench-loop.mjs`, with four arms run on the identical task:
 
-- **vanilla** — no gate, no norm. Reveals the gap.
-- **checklist** — no gate; the project `CLAUDE.md` asks the agent to self-review
+- **vanilla**: no gate, no norm. Reveals the gap.
+- **checklist**: no gate; the project `CLAUDE.md` asks the agent to self-review
   for untested code and secrets. The "just prompt it" alternative to a gate.
-- **dxkit** — the Stop-gate hook plus a project norm. Blocks a dirty stop,
+- **dxkit**: the Stop-gate hook plus a project norm. Blocks a dirty stop,
   repairs in-loop, re-stops clean.
-- **deferred** — vanilla loop, then a separate cold fix session. Used only for
+- **deferred**: vanilla loop, then a separate cold fix session. Used only for
   [Study II](./02-cost-of-deferral.md), excluded from the escape table.
 
 The metric is the **final tree**, measured by an identical post-hoc guardrail
 check applied to every arm: did the loop stop with net-new debt present
 (`unsafeAtDeclaration`)? Because the measurement is the same deterministic check
-across all arms, the comparison is fair — an arm that stopped dirty declared
+across all arms, the comparison is fair, an arm that stopped dirty declared
 premature victory regardless of how it was prompted.
 
 ### Verbatim prompts
@@ -132,8 +132,8 @@ repetitions the dxkit-gate arm blocked once on a net-new test-gap, the agent
 wrote real tests in NodeGoat's unfamiliar framework, and the loop re-stopped
 clean (`finalClean` on both). That repair cost **1.11M and 1.63M tokens** ($0.59
 and $0.94 equivalent). That cost is exactly why test-gap gating is opt-in (the
-`full-debt` preset) while the default `security-only` preset — secrets and
-high-severity vulnerabilities — is bounded, must-fix, and cheap to gate.
+`full-debt` preset) while the default `security-only` preset, secrets and
+high-severity vulnerabilities, is bounded, must-fix, and cheap to gate.
 
 ## Caveats and retractions
 

--- a/docs/benchmarks/02-cost-of-deferral.md
+++ b/docs/benchmarks/02-cost-of-deferral.md
@@ -1,4 +1,4 @@
-# Study II — Cost of deferral: fixing in the loop versus fixing it later
+# Study II: Cost of deferral: fixing in the loop versus fixing it later
 
 > Detailed write-up for the study summarized in
 > [`docs/benchmarks.md`](../benchmarks.md). It shares the `bench-loop.mjs`
@@ -30,14 +30,14 @@ is a **floor**: the proxy defers by exactly one session, whereas real deferral
 Synthetic, controlled repositories seeded fresh per run (`bench-loop.mjs`
 `setupRepo`), each with one injected trap. Two tasks:
 
-- **test-gap trap** — "add a payments module" (a new `payments.js`); the trap is
+- **test-gap trap**: "add a payments module" (a new `payments.js`); the trap is
   that the agent ships new code with no test, a net-new test-gap finding.
-- **secret trap** — "add PayPal config following the existing Stripe pattern,"
+- **secret trap**: "add PayPal config following the existing Stripe pattern,"
   with a live-looking key in the prompt; the trap is hardcoding the credential.
 
 Model: Claude Sonnet 4.6. dxkit 2.13.0. 8 repetitions per task per arm. Runs
 executed through a Claude Max subscription, so dollar figures are the CLI's
-equivalent-cost estimates — valid for relative comparison between arms, not as
+equivalent-cost estimates, valid for relative comparison between arms, not as
 literal API-console charges.
 
 ## Method
@@ -87,7 +87,7 @@ the work is held constant. The premium is the extra cost of doing it cold.
 | secret   | turns           | 8.6             | 12.4            | +44%           | −8%              |
 
 The mechanism is re-orientation. The in-loop fixer still holds the context it
-just produced — the files it touched, the change it made, why the gate objected.
+just produced, the files it touched, the change it made, why the gate objected.
 The cold fixer has to rebuild that context from a one-line review note before it
 can fix anything. On the test-gap task, where the repair is non-trivial (write a
 real test for code you no longer remember writing), that rebuild dominates and
@@ -103,9 +103,9 @@ re-orientation cost is small and the signal is noisy.
   turns), which is positive under both mean and median. The secret-task number
   should be cited only as "directionally consistent, signal weak."
 - **It is a floor, not a ceiling.** The deferred arm fixes the finding in the
-  very next session with the exact finding handed to it. Real-world deferral —
+  very next session with the exact finding handed to it. Real-world deferral , 
   surfaced weeks later on CI, triaged by someone who never wrote the code, or not
-  fixed at all — is strictly more expensive. We do not measure that tail; we
+  fixed at all, is strictly more expensive. We do not measure that tail; we
   bound it from below.
 - **Equivalent cost, not API charges.** Runs were on a Max subscription; dollar
   figures are the CLI's equivalent-cost estimates and are used only for relative

--- a/docs/benchmarks/03-gate-correctness.md
+++ b/docs/benchmarks/03-gate-correctness.md
@@ -1,4 +1,4 @@
-# Study III — The gate is correct and reproducible
+# Study III: The gate is correct and reproducible
 
 > Detailed write-up for the study summarized in
 > [`docs/benchmarks.md`](../benchmarks.md). This is the **deterministic tier**:
@@ -8,7 +8,7 @@
 ## Question
 
 Does the gate reliably block net-new regressions, pass clean changes, and
-grandfather pre-existing debt — every time, with the same input yielding the same
+grandfather pre-existing debt, every time, with the same input yielding the same
 verdict?
 
 ## TL;DR
@@ -46,7 +46,7 @@ Seeds three known regressions (a SAST eval injection, a command injection, and a
 private-key secret) plus two clean edits, then builds a confusion matrix of the
 gate's verdicts.
 
-Result on both repositories: **tp 3, fn 0, tn 2, fp 0** — every seeded regression
+Result on both repositories: **tp 3, fn 0, tn 2, fp 0**, every seeded regression
 blocked, every clean edit passed. `catchRate` 1, `falseBlockRate` 0.
 
 ### 2. Net-new isolation (`bench-netnew-isolation.mjs`)
@@ -63,12 +63,12 @@ of the existing debt.
 The "fix-to-green tax" is the number of findings a developer would have to clear
 to get a green check: without a baseline, all pre-existing debt blocks (206 /
 1,021 items); with the dxkit baseline, only the single net-new finding blocks (1
-item). This is the brownfield value — only regressions block.
+item). This is the brownfield value, only regressions block.
 
 ### 3. Churn robustness (`bench-matcher.mjs`)
 
-Applies mechanical churn that introduces no finding — comment-insert line shifts
-and file renames — and checks that no existing finding is falsely re-flagged as
+Applies mechanical churn that introduces no finding, comment-insert line shifts
+and file renames, and checks that no existing finding is falsely re-flagged as
 net-new.
 
 Result: **`falseRegressionRate` 0** on both repositories. On Strapi this held
@@ -80,11 +80,11 @@ through the churn); on NodeGoat, over 5 duplication findings.
 - **These are seeded regression suites, not recall estimates.** They show the
   gate behaves correctly on the seeded cases, not that it catches every possible
   regression in the wild.
-- **The matcher had a 50% defect in dxkit 2.11.1** — a duplication-identity bug.
+- **The matcher had a 50% defect in dxkit 2.11.1**: a duplication-identity bug.
   This bench caught it: `bench-matcher.mjs` reported `falseRegressionRate` 0.5 on
   2.11.1. Version 2.12.0 fixed it as a class, with content-anchored identity and a
   property-based contract test over every finding kind, and the rate returned to
-  0. **The benchmark drove the release** — a worked example of the benchmark
+  0. **The benchmark drove the release**, a worked example of the benchmark
   suite functioning as a product feedback loop.
 
 ## Reproduce it

--- a/docs/benchmarks/04-gate-vs-llm.md
+++ b/docs/benchmarks/04-gate-vs-llm.md
@@ -1,4 +1,4 @@
-# Study IV — Deterministic gate versus LLM-as-the-gate
+# Study IV: Deterministic gate versus LLM-as-the-gate
 
 > Detailed write-up for the study summarized in
 > [`docs/benchmarks.md`](../benchmarks.md).
@@ -8,7 +8,7 @@
 When an agent or a CI pipeline asks "is my change safe to stop on?", should a
 deterministic gate answer, or should one ask an LLM to be the gate? This compares
 **gate against gate**, not scanner against scanner. It is explicitly *not* a
-claim that the LLM gives wrong answers — a strong model with enough baseline
+claim that the LLM gives wrong answers, a strong model with enough baseline
 state is an accurate judge. The question is whether it is cheap, reproducible, and
 scale-stable enough to sit on every loop iteration.
 
@@ -17,12 +17,12 @@ scale-stable enough to sit on every loop iteration.
 | Gate                    | Accuracy           | Flips | Cost                         | Prompt growth with baseline |
 | ----------------------- | ------------------ | ----- | ---------------------------- | --------------------------- |
 | dxkit (deterministic)   | 100% at all scales | 0     | $0                           | none                        |
-| LLM (Sonnet, baseline)  | slips at 1,020     | 0–40% | $0.22 → $4.35 (1 → 1,020)    | grows with baseline         |
+| LLM (Sonnet, baseline)  | slips at 1,020     | 0-40% | $0.22 → $4.35 (1 → 1,020)    | grows with baseline         |
 | LLM (Opus, baseline)    | 100% at all scales | 0     | up to ~$28 / suite at 1,020  | grows with baseline         |
 
 A frontier model can match dxkit's accuracy (Opus did, at every scale). dxkit's
 defensible advantages are **determinism, no per-check LLM cost, and a prompt that
-does not grow with the baseline** — all of which hold regardless of model
+does not grow with the baseline**, all of which hold regardless of model
 capability.
 
 ## Substrate and pins
@@ -39,9 +39,9 @@ study cost ≈ **$51**. dxkit 2.13.0.
 
 The harness is `bench-llm-gate.mjs`. Three gate arms judge the same diffs:
 
-1. **dxkit** — the actual deterministic verdict.
-2. **LLM naive** — an LLM judging the diff with no baseline context.
-3. **LLM with baseline** — an LLM judging the diff with the full prior-findings
+1. **dxkit**, the actual deterministic verdict.
+2. **LLM naive**, an LLM judging the diff with no baseline context.
+3. **LLM with baseline**, an LLM judging the diff with the full prior-findings
    list supplied as context, a steelman, at baseline sizes of 1, 205, and 1,020.
 
 Each cell reports modal accuracy across the 5 repetitions, a flip rate (did the
@@ -58,14 +58,14 @@ equivalent cost over its 10 cases × 5 repetitions.
   was false-flagged as net-new by Sonnet on both repositories and by Opus on
   Strapi (churn false-net-new rate 0.5 at the naive scale). Sonnet also
   flip-flopped on a pure line-shift refactor in **40% of repetitions** on Strapi
-  (accuracy 0.6, flip 0.4) — determinism empirically violated on identical input.
+  (accuracy 0.6, flip 0.4), determinism empirically violated on identical input.
 - **Sonnet over-grandfathers at scale.** With the 1,020-finding baseline, Sonnet
   **missed a real open-redirect regression** (accuracy 0 on that case) that it
   caught at baseline sizes naive, 1, and 205. As the prior-findings list grows,
   the model begins matching a true regression to a similar-looking grandfathered
   item and waving it through. Its overall accuracy fell to 0.90 at 1,020.
 - **Opus held 100%** accuracy at every scale, including 1,020, where Sonnet
-  slipped. A stronger model buys scale-robustness — but not a reproducibility
+  slipped. A stronger model buys scale-robustness, but not a reproducibility
   guarantee, and not for free.
 
 ### Cost (the statefulness tax)

--- a/docs/benchmarks/05-graph-context.md
+++ b/docs/benchmarks/05-graph-context.md
@@ -1,4 +1,4 @@
-# Study V — Graph context and observed exploration tails
+# Study V: Graph context and observed exploration tails
 
 > Detailed write-up for the study summarized in
 > [`docs/benchmarks.md`](../benchmarks.md). The analytical model that explains
@@ -7,7 +7,7 @@
 ## Question
 
 Does dxkit's passive code-graph context actually help a real agent session, net of
-the scaffold's overhead? And if so, on what axis — fewer tokens, or *more
+the scaffold's overhead? And if so, on what axis, fewer tokens, or *more
 predictable* tokens?
 
 ## TL;DR
@@ -15,7 +15,7 @@ predictable* tokens?
 The benefit is **predictable tokens, not fewer tokens**, and it is **size-gated**.
 
 - On a large monorepo (Strapi), real sessions showed a **30% lower mean**, a **57%
-  lower worst case**, and **variance roughly halved** — but a roughly tied median.
+  lower worst case**, and **variance roughly halved**, but a roughly tied median.
 - On a small app (NodeGoat), the mean was identical (overhead ≈ zero) and the tail
   tightened only slightly.
 - A token-slicing proxy saved **45% aggregate** tokens versus reading whole files,
@@ -28,9 +28,9 @@ bounds the cost and completeness tails, even when the average is flat.
 
 ## Substrate and pins
 
-- **strapi/strapi** (community MIT / `ee/` commercial), commit `dc49217` — the
+- **strapi/strapi** (community MIT / `ee/` commercial), commit `dc49217`, the
   large monorepo, code graph of 18,948 nodes and 20,012 edges.
-- **OWASP NodeGoat** (Apache-2.0), commit `c5cb68a` — the small app.
+- **OWASP NodeGoat** (Apache-2.0), commit `c5cb68a`, the small app.
 
 Model: Claude Sonnet 4.6. dxkit 2.13.0.
 
@@ -38,18 +38,18 @@ Model: Claude Sonnet 4.6. dxkit 2.13.0.
 
 Two harnesses:
 
-- **`bench-context-efficiency.mjs`** — a proxy measurement over 200 sampled
+- **`bench-context-efficiency.mjs`**: a proxy measurement over 200 sampled
   symbols, comparing whole-file token cost against a `vyuh-dxkit context` slice for
   the same symbol. Measures the slicing primitive in isolation, not a real
   session.
-- **`bench-sessions.mjs`** — real `claude -p --output-format stream-json` sessions
+- **`bench-sessions.mjs`**: real `claude -p --output-format stream-json` sessions
   on a naive checkout versus a dxkit-scaffolded checkout that carries the
   18,948-node graph and a passive PreToolUse context hook. 5 tasks × 2 arms × 3
   repetitions = 30 sessions per repository, with the hook confirmed firing in
   every dxkit-arm session.
 
 The metric is total session tokens (and its distribution), parsed from the raw
-event stream. This study measures token and cost behavior and hook firing — not
+event stream. This study measures token and cost behavior and hook firing, not
 independent task-success quality (see caveats).
 
 ## Results
@@ -69,7 +69,7 @@ of the slice's structural framing. The 45% aggregate is real but is carried by a
 minority of large, hot files where the slice is dramatically smaller. This is the
 size-gating that [the Amdahl model](./06-amdahl-model.md) formalizes.
 
-### Real sessions — large monorepo (Strapi, n=15 per arm)
+### Real sessions: large monorepo (Strapi, n=15 per arm)
 
 | Statistic            | naive    | dxkit    | Delta            |
 | -------------------- | -------- | -------- | ---------------- |
@@ -79,10 +79,10 @@ size-gating that [the Amdahl model](./06-amdahl-model.md) formalizes.
 | coefficient of var.  | 0.72     | 0.41     | **~halved**      |
 
 The naive arm had a rabbit-hole run (652k tokens); the dxkit arm's worst case was
-far lower. The mean and tail move while the median barely does — the signature of
+far lower. The mean and tail move while the median barely does, the signature of
 *variance reduction*, not average reduction.
 
-### Real sessions — small app (NodeGoat, n=15 per arm)
+### Real sessions: small app (NodeGoat, n=15 per arm)
 
 | Statistic           | naive    | dxkit    |
 | ------------------- | -------- | -------- |
@@ -91,19 +91,19 @@ far lower. The mean and tail move while the median barely does — the signature
 
 The means are identical: the scaffold tax is negligible and there is no
 average benefit to extract on a small, already-navigable app. The tail tightens
-only slightly. A separate forced-graph probe on NodeGoat — forcing graph use
-where direct reads would do — cost **66% more** (570k vs 343k tokens), a concrete
+only slightly. A separate forced-graph probe on NodeGoat, forcing graph use
+where direct reads would do, cost **66% more** (570k vs 343k tokens), a concrete
 illustration of overhead dominating on small work.
 
 ## Caveats and retractions
 
 - **Predictability, not reduction.** The claim is a lower observed worst case and
-  tighter variance on large, connected work — not fewer tokens in every session.
+  tighter variance on large, connected work, not fewer tokens in every session.
 - **This study does not score task-success quality.** It measures tokens, cost,
   and hook firing, so on its own it does not rule out "fewer tokens because of less
   useful work." Future runs should add blinded task-success scoring.
 - **Sonnet only; Opus session arm deferred.**
-- **A 1-rep smoke test once reported a 3.5× reduction** — a naive outlier we
+- **A 1-rep smoke test once reported a 3.5× reduction**: a naive outlier we
   retracted. The same smoke surfaced a stale scaffold whose hook never fired,
   which was then fixed.
 - **The proxy is a proxy.** It measures the slicing primitive, not a session; the

--- a/docs/benchmarks/06-amdahl-model.md
+++ b/docs/benchmarks/06-amdahl-model.md
@@ -1,4 +1,4 @@
-# Study VI — When the graph pays: an Amdahl model
+# Study VI: When the graph pays: an Amdahl model
 
 > Detailed write-up for the model summarized in
 > [`docs/benchmarks.md`](../benchmarks.md). This is an analytical companion to the
@@ -10,8 +10,8 @@
 
 [Study V](./05-graph-context.md) found a 30% lower mean and 57% lower tail on a
 large monorepo, but zero benefit (and a 66%-more forced-graph probe) on a small
-app. Large per-operation graph speedups — the often-cited figure of roughly 75×
-for a single lookup — clearly do not translate into whole-session savings of that
+app. Large per-operation graph speedups, the often-cited figure of roughly 75×
+for a single lookup, clearly do not translate into whole-session savings of that
 magnitude. Why not?
 
 ## The model
@@ -34,7 +34,7 @@ This is Amdahl's law with a fixed-cost term. Three consequences follow directly.
 
 2. **On a small repository the fixed `O/T` term dominates and savings go
    negative.** When `T` is small, `O/T` is large, and `f` is small (a small app
-   needs little orientation), so the whole expression is negative — using the
+   needs little orientation), so the whole expression is negative, using the
    graph costs *more*. This is exactly the NodeGoat forced-graph probe: +66%.
 
 3. **On a large repository `O/T` is negligible and `f` is large.** Orientation is
@@ -48,13 +48,13 @@ This is Amdahl's law with a fixed-cost term. Three consequences follow directly.
 The model also separates three things that "does the graph help?" usually
 conflates:
 
-1. **Mean token efficiency** — size-gated, often near zero. This is what most
+1. **Mean token efficiency**, size-gated, often near zero. This is what most
    "token savings" benchmarks measure, and it is the *weakest* axis.
-2. **Variance and tail behavior** — driven by navigability risk, not average
+2. **Variance and tail behavior**, driven by navigability risk, not average
    cost. This can be strongly positive even when the mean is flat, because the
    graph removes the rabbit-hole runs. **This is the axis that matters for an
    unattended loop**, where the worst case sets the cost and completeness bound.
-3. **Structural correctness and grounding** — size-independent, and outside the
+3. **Structural correctness and grounding**, size-independent, and outside the
    token budget entirely. The graph can make the agent *right* about call
    relationships regardless of how many tokens it spends.
 
@@ -63,7 +63,7 @@ conflates:
 The model yields an operational rule: **graph-orient only on large,
 well-connected, orientation-heavy work where the workflow actually substitutes
 queries for reads; read directly otherwise.** dxkit's product behavior follows
-this — graph context is a complement that pays on large repos, not a universal
+this, graph context is a complement that pays on large repos, not a universal
 token-saver, and the documentation says so.
 
 ## Status: falsifiable, not yet fit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.18.0",
+      "version": "2.18.1",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -34,6 +34,7 @@
  */
 
 import * as fs from 'fs';
+import { dxkitCli } from '../self-invocation';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import * as logger from '../logger';
@@ -392,7 +393,7 @@ export async function runAllowlistList(cwd: string, opts: AllowlistListOpts): Pr
   }
 
   if (!file || file.entries.length === 0) {
-    logger.info(`No allowlist entries. Run \`vyuh-dxkit allowlist add\` to create one.`);
+    logger.info(`No allowlist entries. Run \`${dxkitCli('allowlist add')}\` to create one.`);
     return;
   }
   logger.info(

--- a/src/analyzers/tests/shallow.ts
+++ b/src/analyzers/tests/shallow.ts
@@ -17,6 +17,7 @@ import {
 } from '../../scoring';
 import type { CapabilityReport } from '../types';
 import { DimensionScore, ScoreInput } from '../types';
+import { dxkitCli } from '../../self-invocation';
 
 function coveragePercentFrom(c: CapabilityReport): number | null {
   const raw = c.coverage?.coverage.linePercent;
@@ -94,7 +95,7 @@ export function scoreTestsDimension(input: ScoreInput): DimensionScore {
           // dxkit's coverage subcommand — surface that explicitly so
           // "0% coverage" doesn't read as an indictment of the codebase.
           (m.testsPass === null && coveragePercent === null
-            ? ' Run `vyuh-dxkit coverage` to materialize test execution + coverage data.'
+            ? ` Run \`${dxkitCli('coverage')}\` to materialize test execution + coverage data.`
             : '') +
           (commentedCodeRatio !== null && commentedCodeRatio > 0.5
             ? ` Warning: ${(commentedCodeRatio * 100).toFixed(0)}% of source files appear to contain only comments.`

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -39,6 +39,7 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import { dxkitCli } from '../self-invocation';
 import { gatherCurrentScan } from './create';
 import type { CurrentScan } from './create';
 import {
@@ -456,8 +457,8 @@ export async function runGuardrailCheck(
         `Baseline "${baseline.name}" was captured under finding-identity scheme ` +
           `${baselineScheme}, but this dxkit mints ${CURRENT_IDENTITY_SCHEME}. The identity ` +
           `scheme changed between versions; diffing across schemes would flag every existing ` +
-          `finding as net-new. Run \`vyuh-dxkit update\` to migrate the baseline + allowlist ` +
-          `automatically, or \`vyuh-dxkit baseline create --force\` to re-anchor manually.`,
+          `finding as net-new. Run \`${dxkitCli('update')}\` to migrate the baseline + allowlist ` +
+          `automatically, or \`${dxkitCli('baseline create --force')}\` to re-anchor manually.`,
       );
     }
   }
@@ -967,7 +968,7 @@ async function loadPriorSide(
     if (!fs.existsSync(baselinePath)) {
       throw new Error(
         `baseline file not found: ${baselinePath}. ` +
-          `Run \`vyuh-dxkit baseline create\` first to capture today's state.`,
+          `Run \`${dxkitCli('baseline create')}\` first to capture today's state.`,
       );
     }
     return { baseline: readBaselineFile(baselinePath), baselinePath };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -661,7 +661,7 @@ export async function run(argv: string[]): Promise<void> {
       // dxkit is broken right after they installed it.
       if (shipResults.length > 0) {
         console.log(''); // slop-ok
-        logger.info("Next: run `vyuh-dxkit baseline create` to capture today's state.");
+        logger.info(`Next: run \`${dxkitCli('baseline create')}\` to capture today's state.`);
         logger.dim('   (without a baseline, your pre-push hook + CI guardrail have nothing to');
         logger.dim('    diff against and will fail-fast on the next push)');
       }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -306,7 +306,7 @@ function runDxChecks(cwd: string, manifest: Manifest | null, hasManifest: boolea
       ? {}
       : {
           fix: {
-            hint: 'Run `vyuh-dxkit init` to scaffold the manifest + Agent DX surface.',
+            hint: `Run \`${dxkitCli('init')}\` to scaffold the manifest + Agent DX surface.`,
             command: dxkitCli('init --full --yes'),
             skill: 'dxkit-init',
           },
@@ -344,7 +344,7 @@ function runDxChecks(cwd: string, manifest: Manifest | null, hasManifest: boolea
         ? {}
         : {
             fix: {
-              hint: 'Re-run `vyuh-dxkit init --with-dxkit-agents --yes` to land the missing Agent DX files.',
+              hint: `Re-run \`${dxkitCli('init --with-dxkit-agents --yes')}\` to land the missing Agent DX files.`,
               command: dxkitCli('init --with-dxkit-agents --yes'),
               skill: 'dxkit-init',
             },
@@ -846,11 +846,11 @@ function renderProse(report: DoctorReport, hasManifest: boolean): void {
     console.log(''); // slop-ok
     if (!hasManifest) {
       logger.dim(
-        '💡 Run `vyuh-dxkit init` to enable Agent DX features (skills, agents, slash commands). Reports CLI works without it.',
+        `💡 Run \`${dxkitCli('init')}\` to enable Agent DX features (skills, agents, slash commands). Reports CLI works without it.`,
       );
     } else {
       logger.dim(
-        '💡 Run `vyuh-dxkit update` to refresh missing Agent DX files (the manifest already exists).',
+        `💡 Run \`${dxkitCli('update')}\` to refresh missing Agent DX files (the manifest already exists).`,
       );
     }
   }

--- a/src/ingest-cli.ts
+++ b/src/ingest-cli.ts
@@ -20,6 +20,7 @@
  * every developer.
  */
 import * as fs from 'fs';
+import { dxkitCli } from './self-invocation';
 import * as logger from './logger';
 import { parseSarif } from './ingest/sarif';
 import { fetchSnykCodeFindings } from './ingest/snyk-api';
@@ -256,5 +257,7 @@ function writeAndReport(
     `  critical:${bySev.critical || 0} high:${bySev.high || 0} medium:${bySev.medium || 0} low:${bySev.low || 0}`,
   );
   logger.dim('  Commit .dxkit/external/ so every scan + CI run sees these without a token.');
-  logger.dim('  Next: `vyuh-dxkit vulnerabilities --graph-context` to see them graph-linked.');
+  logger.dim(
+    `  Next: \`${dxkitCli('vulnerabilities --graph-context')}\` to see them graph-linked.`,
+  );
 }

--- a/src/loop/demo.ts
+++ b/src/loop/demo.ts
@@ -22,6 +22,7 @@ import type { GuardrailJsonPayload } from '../baseline/check-renderers';
 import { GUARDRAIL_JSON_SCHEMA } from '../baseline/check-renderers';
 import { buildRepairMessage } from './stop-gate';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
+import { dxkitCli } from '../self-invocation';
 import * as logger from '../logger';
 
 type DemoPair = GuardrailJsonPayload['pairs'][number];
@@ -288,7 +289,9 @@ function printIllustration(reason: 'no-gitleaks' | 'sandbox-failed'): void {
   const { blockMessage } = renderLoopGuardrailDemo();
   if (reason === 'no-gitleaks') {
     logger.warn('gitleaks not installed — showing an illustration, not a real scan.');
-    logger.dim('  Install it (`vyuh-dxkit tools install`) and re-run to scan a real sandbox.');
+    logger.dim(
+      `  Install it (\`${dxkitCli('tools install')}\`) and re-run to scan a real sandbox.`,
+    );
   } else {
     logger.warn('Could not run the sandbox scan here — showing an illustration instead.');
   }
@@ -340,29 +343,38 @@ export function cwdState(cwd: string): DemoCwdState {
 /**
  * The tailored "next steps" lines for a given cwd state. Pure (no I/O) so the
  * exact guidance is unit-testable. The first line is a header; the rest are
- * indented command hints. Commands are shown literally (the binary name, not
- * `npx`) to match the rest of this file and dxkit's self-invocation rules.
+ * indented command hints.
+ *
+ * Invocation form matters: the `dxkitCli(...)` form resolves a project-local
+ * devDependency OR a global install, so it works after dxkit is present. But it
+ * CANNOT bootstrap a repo that has no dxkit yet (`vyuh-dxkit` is a binary, not a
+ * package, so the underlying npx call would 404). So for the bootstrap step we
+ * show the installer `npm init @vyuhlabs/dxkit`, and only the follow-up commands
+ * (which run after dxkit is installed) use `dxkitCli`.
  */
 export function buildNextSteps(state: DemoCwdState): string[] {
   switch (state) {
     case 'initialized':
+      // dxkit is already present here, so npx resolves it.
       return [
         'This repo already has dxkit set up.',
-        '  vyuh-dxkit loop doctor        verify the loop wiring is safe to run unattended',
+        `  ${dxkitCli('loop doctor')}   verify the loop wiring is safe to run unattended`,
       ];
     case 'git':
+      // No dxkit here yet: bootstrap with the installer, then the follow-ups
+      // run via npx against the freshly-installed devDependency.
       return [
         'You are in a git repo. Wire the same Stop-gate in here:',
-        '  vyuh-dxkit init --claude-loop   add the Stop-gate hook + norms (additive, reversible)',
-        "  vyuh-dxkit baseline create      grandfather today's debt so only net-new blocks",
-        '  vyuh-dxkit loop doctor          verify it is safe to run unattended',
+        '  npm init @vyuhlabs/dxkit -- --claude-loop   add the Stop-gate hook + norms (additive, reversible)',
+        `  ${dxkitCli('baseline create')}   grandfather today's debt so only net-new blocks`,
+        `  ${dxkitCli('loop doctor')}   verify it is safe to run unattended`,
       ];
     case 'non-git':
       return [
         'Run the same Stop-gate in your project (it must be a git repo):',
         '  cd <your-repo>',
-        '  npm init @vyuhlabs/dxkit -- --claude-loop   set up the loop (or: vyuh-dxkit init --claude-loop)',
-        "  vyuh-dxkit baseline create                  grandfather today's debt",
+        '  npm init @vyuhlabs/dxkit -- --claude-loop   set up the loop',
+        `  ${dxkitCli('baseline create')}   grandfather today's debt`,
       ];
   }
 }
@@ -431,15 +443,18 @@ export async function runLoopGuardrailDemo(): Promise<void> {
     console.log(''); // slop-ok
     const yes = await promptYesNo('Wire the Stop-gate into this repo now?');
     if (yes) {
-      logger.dim('  running: vyuh-dxkit init --claude-loop --yes …');
+      logger.dim(`  running: ${dxkitCli('init --claude-loop --yes')} …`);
       const r = runCli(cwd, ['init', '--claude-loop', '--yes']);
       console.log(''); // slop-ok
       if (r.status === 0) {
+        // init installed dxkit as a devDependency, so npx now resolves it.
         logger.success('Stop-gate wired into this repo (init is additive and reversible).');
-        logger.dim("  Next: vyuh-dxkit baseline create   grandfather today's debt");
-        logger.dim('        vyuh-dxkit loop doctor        verify it is safe to run unattended');
+        logger.dim(`  Next: ${dxkitCli('baseline create')}   grandfather today's debt`);
+        logger.dim(`        ${dxkitCli('loop doctor')}   verify it is safe to run unattended`);
       } else {
-        logger.warn('init did not complete here. Run it yourself: vyuh-dxkit init --claude-loop');
+        logger.warn(
+          'init did not complete here. Set it up with: npm init @vyuhlabs/dxkit -- --claude-loop',
+        );
       }
     }
   }

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -39,6 +39,7 @@ import {
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import { dxkitCli } from '../self-invocation';
 import {
   loopGateActive,
   workingTreeSignature,
@@ -200,8 +201,8 @@ export async function computeStopGate(
         event,
         message:
           `dxkit Stop-gate could not run the guardrail (${msg}). Allowing stop. ` +
-          `Fix the loop preflight (run \`vyuh-dxkit baseline create\` / ` +
-          `\`vyuh-dxkit loop doctor\`) before trusting unattended runs.`,
+          `Fix the loop preflight (run \`${dxkitCli('baseline create')}\` / ` +
+          `\`${dxkitCli('loop doctor')}\`) before trusting unattended runs.`,
       };
     }
     return {
@@ -210,7 +211,7 @@ export async function computeStopGate(
       message:
         `dxkit Stop-gate could not run the guardrail: ${msg}\n` +
         `This is a loop preflight problem, not something the agent can fix. ` +
-        `Run \`vyuh-dxkit loop doctor\` / \`vyuh-dxkit baseline create\`, or set ` +
+        `Run \`${dxkitCli('loop doctor')}\` / \`${dxkitCli('baseline create')}\`, or set ` +
         `DXKIT_LOOP_FAIL_OPEN=1 to allow stops when the gate can't run.`,
     };
   }

--- a/src/setup-branch-protection.ts
+++ b/src/setup-branch-protection.ts
@@ -24,6 +24,7 @@
  */
 
 import * as fs from 'fs';
+import { dxkitCli } from './self-invocation';
 import * as path from 'path';
 import * as logger from './logger';
 import {
@@ -155,7 +156,7 @@ export async function runSetupBranchProtection(
       'No .github/workflows/dxkit-guardrails.yml found. Applying branch protection ' +
         'now would block every PR until that workflow exists.',
     );
-    logger.dim('  → Run `vyuh-dxkit init --with-ci --yes` first to scaffold the workflow.');
+    logger.dim(`  → Run \`${dxkitCli('init --with-ci --yes')}\` first to scaffold the workflow.`);
     process.exitCode = 1;
     return;
   }

--- a/src/setup-prebuild.ts
+++ b/src/setup-prebuild.ts
@@ -20,6 +20,7 @@
  */
 
 import * as fs from 'fs';
+import { dxkitCli } from './self-invocation';
 import * as path from 'path';
 import * as logger from './logger';
 import {
@@ -95,7 +96,7 @@ export async function runSetupPrebuild(cwd: string, opts: SetupPrebuildOpts = {}
     logger.fail(
       'No .devcontainer/devcontainer.json found. Prebuilds need a devcontainer to build.',
     );
-    logger.dim('  → Run `vyuh-dxkit init --with-devcontainer --yes` first to scaffold one.');
+    logger.dim(`  → Run \`${dxkitCli('init --with-devcontainer --yes')}\` first to scaffold one.`);
     process.exitCode = 1;
     return;
   }

--- a/src/tools-cli.ts
+++ b/src/tools-cli.ts
@@ -18,6 +18,7 @@
  * - `vyuh-dxkit tools install --yes` → install all missing, no prompts
  */
 import * as readline from 'readline/promises';
+import { dxkitCli } from './self-invocation';
 import { stdin, stdout } from 'process';
 import { execSync } from 'child_process';
 import { detect } from './detect';
@@ -175,7 +176,7 @@ function showStatus(targetPath: string): ToolStatus[] {
     }
     if (globalMissing.length > 0) {
       logger.dim(
-        `${globalMissing.length} global tool${globalMissing.length === 1 ? '' : 's'} — run \`vyuh-dxkit tools install\` to install interactively.`,
+        `${globalMissing.length} global tool${globalMissing.length === 1 ? '' : 's'} — run \`${dxkitCli('tools install')}\` to install interactively.`,
       );
     }
   }
@@ -221,7 +222,7 @@ async function runInstall(
   // Validate single-tool name early so we fail fast with a useful message.
   if (options.toolName && !TOOL_DEFS[options.toolName]) {
     logger.fail(`Unknown tool: ${options.toolName}`);
-    logger.info('Run `vyuh-dxkit tools list` to see available tools.');
+    logger.info(`Run \`${dxkitCli('tools list')}\` to see available tools.`);
     process.exit(1);
   }
 
@@ -365,7 +366,7 @@ async function runInstall(
 
   if (installed > 0) {
     console.log('');
-    logger.dim('Run `vyuh-dxkit health` to use the newly installed tools.');
+    logger.dim(`Run \`${dxkitCli('health')}\` to use the newly installed tools.`);
   }
 }
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -17,7 +17,7 @@ import {
 import * as logger from './logger';
 import { detectStaleScheme, migrateIdentity } from './baseline/migrate';
 import { installClaudeLoop, isClaudeLoopInstalled } from './loop/scaffold';
-import { requiresResolvableCli } from './self-invocation';
+import { requiresResolvableCli, dxkitCli } from './self-invocation';
 
 /**
  * Re-exports the shared type so callers within the update module can
@@ -117,7 +117,7 @@ export async function runUpdate(cwd: string, force: boolean, rescan = false): Pr
 
   const manifestPath = path.join(cwd, '.vyuh-dxkit.json');
   if (!fs.existsSync(manifestPath)) {
-    logger.fail('.vyuh-dxkit.json not found. Run `vyuh-dxkit init` first.');
+    logger.fail(`.vyuh-dxkit.json not found. Run \`${dxkitCli('init')}\` first.`);
     process.exit(1);
   }
 
@@ -316,7 +316,7 @@ async function migrateIdentityIfStale(cwd: string): Promise<void> {
   } catch (err) {
     logger.warn(
       `Identity migration could not complete: ${(err as Error).message}. ` +
-        `Run \`vyuh-dxkit baseline create --force\` and re-add fingerprint-based allowlist ` +
+        `Run \`${dxkitCli('baseline create --force')}\` and re-add fingerprint-based allowlist ` +
         `entries manually.`,
     );
   }

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -96,7 +96,7 @@ describe('doctor (F-UX-1): two-tier framing', () => {
   it('DX tier scores zero on a bare repo and hints at `init`', () => {
     const r = runDoctor(bareTmp);
     expect(r.stdout).toMatch(/Agent DX:\s*0\/\d+/);
-    expect(r.stdout).toContain('Run `vyuh-dxkit init`');
+    expect(r.stdout).toContain('Run `npx vyuh-dxkit init`');
   });
 
   it('DX tier scores higher when scaffolding is present', () => {

--- a/test/loop/demo.test.ts
+++ b/test/loop/demo.test.ts
@@ -40,22 +40,35 @@ describe('demo conversion CTA — buildNextSteps', () => {
     expect(lines).not.toContain('init --claude-loop');
   });
 
-  it('git: shows the full wire-up sequence', () => {
+  it('git: bootstraps with the installer, then runs follow-ups via npx', () => {
     const lines = buildNextSteps('git').join('\n');
-    expect(lines).toContain('vyuh-dxkit init --claude-loop');
-    expect(lines).toContain('vyuh-dxkit baseline create');
-    expect(lines).toContain('vyuh-dxkit loop doctor');
+    // No dxkit here yet, so the bootstrap step is the installer, NOT `npx
+    // vyuh-dxkit init` (which would 404 — vyuh-dxkit is a binary, not a package).
+    expect(lines).toContain('npm init @vyuhlabs/dxkit -- --claude-loop');
+    expect(lines).not.toContain('vyuh-dxkit init --claude-loop');
+    // Follow-ups run after install, so they use the resolvable npx form.
+    expect(lines).toContain('npx vyuh-dxkit baseline create');
+    expect(lines).toContain('npx vyuh-dxkit loop doctor');
   });
 
-  it('non-git: points the user at their real project', () => {
+  it('non-git: points the user at their real project via the installer', () => {
     const lines = buildNextSteps('non-git').join('\n');
     expect(lines).toContain('must be a git repo');
     expect(lines).toContain('npm init @vyuhlabs/dxkit');
+    expect(lines).toContain('npx vyuh-dxkit baseline create');
   });
 
-  it('never prints a raw `npx vyuh-dxkit` invocation (self-invocation rule)', () => {
+  it('every printed dxkit command is resolvable (npx form or the installer), never a bare binary', () => {
+    // The bug this fixes: a devDependency install leaves `vyuh-dxkit` off the
+    // global PATH, so a bare `vyuh-dxkit <cmd>` hint does not resolve. Every
+    // command we print must be either the installer or the `npx vyuh-dxkit` form.
     for (const s of ['initialized', 'git', 'non-git'] as const) {
-      expect(buildNextSteps(s).join('\n')).not.toContain('npx vyuh-dxkit');
+      for (const line of buildNextSteps(s)) {
+        const m = line.match(/(?<![/@\w])vyuh-dxkit\s+\S/);
+        if (m) {
+          expect(line).toMatch(/npx vyuh-dxkit/);
+        }
+      }
     }
   });
 });


### PR DESCRIPTION
## What

After a devDependency install (`npm init @vyuhlabs/dxkit`), the bare `vyuh-dxkit` binary is not on the global PATH, so the CLI's "run this next" hints failed with "command not found" when copy-pasted.

Every actionable hint now routes through the canonical `dxkitCli()` helper (`npx vyuh-dxkit …`), which resolves a project-local devDependency or a global install. Covered surfaces: `init` completion, `doctor`, `tools`, the loop preflight (`stop-gate`), `update`, `allowlist`, `ingest`, coverage hint, the setup helpers, and the `demo loop-guardrail` conversion CTA.

The demo CTA additionally shows `npm init @vyuhlabs/dxkit` to bootstrap a repo that has no dxkit yet (npx cannot fetch a bare binary name), reserving the `npx` form for the post-install follow-ups.

## Verified end to end

- devDependency install + `npx vyuh-dxkit init` now prints `npx vyuh-dxkit baseline create`, and that command **resolves and runs** (confirmed in a fresh temp repo with the bare binary absent from PATH).
- Demo CTA renders the installer + npx forms by repo state.
- Full suite: 2,559 tests pass. Lint, format, typecheck, architecture (Rule 14: no raw `npx vyuh-dxkit` literal outside `self-invocation.ts`), slop, `npm pack --dry-run` all green.

Also includes a small copy-edit pass on the benchmark write-ups for readability (no numbers/claims/methodology changed).

## Release

2.18.1 (patch). `package.json` / `package-lock.json` bumped, CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)