### PR TITLE
feat(flow): application-flow extraction (flow extract) — 2.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.19.0] - 2026-06-30
+
+### Added — application-flow extraction (`flow extract`)
+
+`vyuh-dxkit flow extract` statically maps a frontend's HTTP calls to a backend's
+routes and writes the result as CSVs. It is the first slice of the Flow feature
+(UI to API traceability).
+
+- **AST-based, not regex.** A new in-process, graphify-independent tree-sitter
+  layer (`src/ast/`, web-tree-sitter/wasm) parses source; a per-language
+  `httpFlow` descriptor declares which constructs are HTTP clients and routes,
+  so no framework literal is hardcoded in the analyzer.
+- **Both sides plus the join.** It extracts outbound client calls
+  (fetch/axios/wrappers) and inbound routes (LoopBack/NestJS decorators, Express
+  app/router), canonicalizes URLs and route paths to a common shape, and binds
+  each call to the route it targets with a confidence score.
+- **OpenAPI when present.** An existing OpenAPI spec is consumed as the
+  authoritative served side (`--specs`), unioned with static extraction (spec
+  for authority, static for recall, since generated specs are often incomplete).
+- **Usage:** `flow extract [--frontend <dir>] [--backend <dir>] [--specs a.json,b.json] [--out <dir>]`;
+  writes `api_calls.csv`, `routes.csv`, `api_route_mapping.csv`. TypeScript and
+  JavaScript in this release; more languages follow.
+
 ## [2.18.1] - 2026-06-23
 
 ### Fixed — next-step hints now use a resolvable invocation

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",
-        "hosted-git-info": "^9.0.2"
+        "hosted-git-info": "^9.0.2",
+        "tree-sitter-wasms": "0.1.13",
+        "web-tree-sitter": "^0.25.10"
       },
       "bin": {
         "vyuh-dxkit": "dist/index.js"
@@ -4218,6 +4220,15 @@
         "node": "*"
       }
     },
+    "node_modules/tree-sitter-wasms": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
+      "integrity": "sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "tree-sitter-wasms": "^0.1.11"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -4616,6 +4627,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.18.1",
+      "version": "2.19.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
   ],
   "dependencies": {
     "exceljs": "^4.4.0",
-    "hosted-git-info": "^9.0.2"
+    "hosted-git-info": "^9.0.2",
+    "tree-sitter-wasms": "0.1.13",
+    "web-tree-sitter": "^0.25.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/scaffold-language.js
+++ b/scripts/scaffold-language.js
@@ -342,6 +342,22 @@ export const ${id}: LanguageSupport = {
     strategy: 'TODO(${id}): describe how exported symbols are detected for this language',
   },
 
+  // TODO(${id}): OPTIONAL per-pack architectural descriptors — add the ones
+  // this language has a surface for (omit the rest). All flow through the
+  // \`all*\` registry helpers in src/languages/index.ts (CLAUDE.md Rule 6);
+  // see typescript.ts for worked examples. The recipe-playbook test asserts a
+  // pack's contributions reach each helper.
+  //   architecturalShape  — primary-component / route / model path conventions
+  //                         + vocabulary + test-gap taxonomy
+  //   httpFlow            — HTTP client callees + route decorators/routers, so
+  //                         the flow extractor (src/analyzers/flow/) maps this
+  //                         language's UI→API→handler integrations. Add it if
+  //                         the language has an HTTP client or web framework
+  //                         (e.g. Python requests/FastAPI, Go net-http/gin,
+  //                         Java Spring @GetMapping, C# ASP.NET [HttpGet]).
+  //   deepSast            — CodeQL / Snyk Code interprocedural engine support
+  //   callGraphReliability — how much to trust graphify's caller counts here
+
   // ─── LP-recipe metadata (populate every field) ─────────────────────────
 
   // Bash permission entries for .claude/settings.json. Cover the test/build/

--- a/src/analyzers/flow/csv.ts
+++ b/src/analyzers/flow/csv.ts
@@ -1,0 +1,76 @@
+/**
+ * CSV renderers over a `FlowModel` — the parity output surface (mirrors the
+ * reference tool's `api_data` / `controller_data` / `api_controller_mapping`
+ * CSVs). Pure: a model in, CSV text out. CSV is one renderer among several
+ * (the graph + the gate consume the same model), so nothing analytical lives
+ * here — only serialization.
+ */
+
+import type { FlowModel } from './model';
+
+/** Quote every field (CSV-safe: doubles embedded quotes), join a row. */
+function row(fields: ReadonlyArray<string | number | null>): string {
+  return fields.map((f) => `"${String(f ?? '').replace(/"/g, '""')}"`).join(',');
+}
+
+function toCsv(
+  header: readonly string[],
+  rows: ReadonlyArray<ReadonlyArray<string | number | null>>,
+): string {
+  return [row(header), ...rows.map(row)].join('\n') + '\n';
+}
+
+/** Outbound HTTP calls (the consumed side). */
+export function callsCsv(model: FlowModel): string {
+  return toCsv(
+    ['method', 'path', 'raw_url', 'receiver', 'file', 'line'],
+    model.calls.map((c) => [c.method, c.path, c.rawUrl, c.receiver, c.file, c.line]),
+  );
+}
+
+/** Served routes (the served side), from source extraction and/or a spec. */
+export function routesCsv(model: FlowModel): string {
+  return toCsv(
+    ['method', 'path', 'via', 'handler', 'file', 'line'], // arch-shape-ok: CSV column name, not a role label
+    model.routes.map((r) => [r.method, r.path, r.via, r.handler, r.file, r.line]),
+  );
+}
+
+/** The join: each client call mapped to the route it targets (or not). */
+export function mappingCsv(model: FlowModel): string {
+  return toCsv(
+    [
+      'call_method',
+      'call_path',
+      'call_file',
+      'call_line',
+      'reason',
+      'confidence',
+      'route_path',
+      'route_handler',
+      'route_via',
+      'route_file',
+    ],
+    model.bindings.map((b) => [
+      b.call.method,
+      b.call.path,
+      b.call.file,
+      b.call.line,
+      b.reason,
+      b.confidence,
+      b.route?.path ?? '',
+      b.route?.handler ?? '',
+      b.route?.via ?? '',
+      b.route?.file ?? '',
+    ]),
+  );
+}
+
+/** The full parity CSV set, keyed by output filename. */
+export function flowCsvFiles(model: FlowModel): Record<string, string> {
+  return {
+    'api_calls.csv': callsCsv(model),
+    'routes.csv': routesCsv(model),
+    'api_route_mapping.csv': mappingCsv(model),
+  };
+}

--- a/src/analyzers/flow/extract.ts
+++ b/src/analyzers/flow/extract.ts
@@ -1,0 +1,287 @@
+/**
+ * Flow extraction — the AST pass that turns source into the two sides of an
+ * HTTP integration: outbound client calls (CONSUMED) and inbound route
+ * declarations (SERVED).
+ *
+ * It is the cross-cutting consumer of three seams and hardcodes none of them:
+ *   - the canonical AST layer (`src/ast/`) for parsing — graphify-independent,
+ *     and registered as its own concern, never folded into graphify's pass;
+ *   - each pack's `httpFlow` descriptor (Rule 6) for WHICH constructs are HTTP
+ *     — no `fetch`/`axios`/`@get` literal lives here;
+ *   - the shared normalizer for canonical paths + verbs.
+ *
+ * Every source file is scanned for BOTH surfaces: a backend that serves routes
+ * AND calls other services contributes to both lists (the consumer/provider
+ * model — a participant is whatever its served/consumed sets make it). Role
+ * assignment happens above this module, never inside it.
+ *
+ * Precision guard (validated): a member call with no declared receiver allowlist
+ * (`axios.get`, `requests.get`, `agent.X.del`) only counts as a client call when
+ * its first argument is a path-like literal — that filter keeps non-HTTP `.get`/
+ * `.delete` (lodash, Maps) out while still catching app-specific wrappers.
+ */
+
+import { getLanguage } from '../../languages';
+import type { HttpFlowSupport, LanguageId } from '../../languages/types';
+import { parseFile, walk, type Node } from '../../ast/parse';
+import { normalizeMethod, normalizePath, type HttpMethod, type NormalizeConfig } from './normalize';
+
+/** An outbound HTTP call found in source (the consumed side). */
+export interface ClientCall {
+  readonly method: HttpMethod;
+  readonly rawUrl: string;
+  /** Normalized path, or `null` when the URL is dynamic/external (unresolved). */
+  readonly path: string | null;
+  readonly receiver: string;
+  readonly file: string;
+  readonly line: number;
+}
+
+/** An inbound route declaration found in source (the served side). */
+export interface RouteEndpoint {
+  readonly method: HttpMethod;
+  readonly path: string;
+  readonly via: 'decorator' | 'router-call';
+  readonly handler: string | null;
+  readonly file: string;
+  readonly line: number;
+}
+
+/** Both HTTP surfaces extracted from one file. */
+export interface FileFlow {
+  readonly calls: ClientCall[];
+  readonly routes: RouteEndpoint[];
+}
+
+const HTTP_VERB_METHODS = new Set([
+  'get',
+  'post',
+  'put',
+  'patch',
+  'delete',
+  'del',
+  'head',
+  'options',
+]);
+
+function line(node: Node): number {
+  return node.startPosition.row + 1;
+}
+
+/** Text of a string/template-string node, else null (a dynamic argument). */
+function literalText(node: Node | null): string | null {
+  if (!node) return null;
+  return node.type === 'string' || node.type === 'template_string' ? node.text : null;
+}
+
+/**
+ * Does a raw literal look like a URL/path at the source level — i.e. could this
+ * `.get(...)`/`.post(...)` plausibly be an HTTP call rather than a Map/cache/
+ * lodash accessor? Used only for member calls with NO declared receiver
+ * allowlist, where it is the precision guard: a leading `/`, a leading template
+ * (`${host}/…`), an explicit scheme, or any embedded `/` qualifies; a bare token
+ * like `'config-key'` does not. (Route decorators are exempt — a framework route
+ * string is known to be a path even without a leading slash.)
+ */
+function looksLikeUrlLiteral(raw: string | null): boolean {
+  if (raw == null) return false;
+  let s = raw.trim();
+  if (s.length >= 2 && /^['"`]/.test(s) && s.endsWith(s[0])) s = s.slice(1, -1);
+  return s.startsWith('/') || s.startsWith('${') || s.includes('://') || s.includes('/');
+}
+
+function firstNamedArg(callOrArgs: Node | null): Node | null {
+  const args = callOrArgs?.childForFieldName('arguments') ?? null;
+  if (!args) return null;
+  for (const c of args.namedChildren) if (c) return c;
+  return null;
+}
+
+/** Does a member-call receiver match one of the declared bases (e.g. `app`, or
+ *  `this.app`)? */
+function receiverMatchesBase(receiver: string, bases: readonly string[]): boolean {
+  return bases.some((b) => receiver === b || receiver.endsWith(`.${b}`));
+}
+
+/** Pull `method: 'X'` out of a fetch options object (2nd arg), default GET. */
+function fetchMethod(call: Node, hf: HttpFlowSupport): HttpMethod {
+  const args = call.childForFieldName('arguments');
+  const opts = args?.namedChildren?.[1] ?? null;
+  if (opts && opts.type === 'object') {
+    let verb: HttpMethod | null = null;
+    walk(opts, (n) => {
+      if (verb) return false;
+      if (n.type === 'pair') {
+        const key = n.childForFieldName('key');
+        const val = n.childForFieldName('value');
+        const keyName = key ? key.text.replace(/['"`]/g, '') : '';
+        if (keyName === 'method') {
+          const raw = literalText(val);
+          if (raw) verb = normalizeMethod(raw.replace(/['"`]/g, ''), hf.methodAliases);
+        }
+      }
+    });
+    if (verb) return verb;
+  }
+  return 'GET';
+}
+
+/**
+ * The handler name a route decorator is attached to (best-effort). Decorators
+ * are siblings preceding the member in the class body, so the handler is the
+ * decorator's next named sibling (skipping any stacked decorators); a nested
+ * grammar shape is handled by an ancestor fallback.
+ */
+function decoratedHandlerName(decorator: Node): string | null {
+  let sib: Node | null = decorator.nextNamedSibling;
+  while (sib && sib.type === 'decorator') sib = sib.nextNamedSibling;
+  const sibName = sib?.childForFieldName('name');
+  if (sibName) return sibName.text;
+  let cur: Node | null = decorator.parent;
+  for (let i = 0; cur && i < 3; i++) {
+    if (cur.type === 'method_definition' || cur.type === 'function_declaration') {
+      const name = cur.childForFieldName('name');
+      if (name) return name.text;
+    }
+    cur = cur.parent;
+  }
+  return null;
+}
+
+/**
+ * Extract both HTTP surfaces from one already-parsed tree using a pack's
+ * httpFlow descriptor. Pure over its inputs.
+ */
+export function extractFromTree(
+  root: Node,
+  hf: HttpFlowSupport,
+  file: string,
+  config?: NormalizeConfig,
+): FileFlow {
+  const calls: ClientCall[] = [];
+  const routes: RouteEndpoint[] = [];
+
+  const clientCallees = new Set(hf.clientCallees ?? []);
+  const methodCallMethods = new Set(hf.clientMethodCallees?.methods ?? []);
+  const methodCallBases = hf.clientMethodCallees?.bases;
+  const routeDecorators = new Set(hf.routeDecorators ?? []);
+  const routerMethods = new Set(hf.routeRouterCallees?.methods ?? []);
+  const routerBases = hf.routeRouterCallees?.bases ?? [];
+
+  walk(root, (node) => {
+    // ── decorator routes: @get('/x') ──
+    if (node.type === 'decorator' && routeDecorators.size) {
+      const call = node.namedChildren.find((c) => c?.type === 'call_expression') ?? null;
+      const callee = call?.childForFieldName('function');
+      const name = callee && callee.type === 'identifier' ? callee.text : '';
+      if (call && routeDecorators.has(name)) {
+        const path = normalizePath(literalText(firstNamedArg(call)), config);
+        const method = normalizeMethod(name, hf.methodAliases);
+        if (path && method) {
+          routes.push({
+            method,
+            path,
+            via: 'decorator',
+            handler: decoratedHandlerName(node),
+            file,
+            line: line(node),
+          });
+        }
+      }
+      return; // a decorator's call is bookkeeping, not a client call
+    }
+
+    if (node.type !== 'call_expression') return;
+    const callee = node.childForFieldName('function');
+    if (!callee) return;
+
+    // ── bare client call: fetch(url, opts) ──
+    if (callee.type === 'identifier' && clientCallees.has(callee.text)) {
+      const raw = literalText(firstNamedArg(node));
+      if (raw != null) {
+        calls.push({
+          method: fetchMethod(node, hf),
+          rawUrl: raw,
+          path: normalizePath(raw, config),
+          receiver: callee.text,
+          file,
+          line: line(node),
+        });
+      }
+      return;
+    }
+
+    // ── member call: <recv>.<verb>(url|path, ...) ──
+    if (callee.type === 'member_expression') {
+      const prop = callee.childForFieldName('property');
+      const obj = callee.childForFieldName('object');
+      const verb = prop ? prop.text : '';
+      const receiver = obj ? obj.text : '';
+      if (!HTTP_VERB_METHODS.has(verb)) return;
+
+      // router/app route declaration
+      if (routerMethods.has(verb) && receiverMatchesBase(receiver, routerBases)) {
+        const path = normalizePath(literalText(firstNamedArg(node)), config);
+        const method = normalizeMethod(verb, hf.methodAliases);
+        if (path && method) {
+          routes.push({
+            method,
+            path,
+            via: 'router-call',
+            handler: receiver,
+            file,
+            line: line(node),
+          });
+        }
+        return;
+      }
+
+      // client call (bases optional). With no allowlist, require a path-like
+      // literal first arg — the precision guard against non-HTTP .get/.delete.
+      if (methodCallMethods.has(verb)) {
+        const baseOk =
+          !methodCallBases ||
+          receiverMatchesBase(receiver, methodCallBases) ||
+          methodCallBases.includes(receiver);
+        if (!baseOk) return;
+        const raw = literalText(firstNamedArg(node));
+        // Unallowlisted receiver → require a URL-looking literal (precision guard).
+        if (!methodCallBases && !looksLikeUrlLiteral(raw)) return;
+        const method = normalizeMethod(verb, hf.methodAliases);
+        if (raw != null && method) {
+          calls.push({
+            method,
+            rawUrl: raw,
+            path: normalizePath(raw, config),
+            receiver,
+            file,
+            line: line(node),
+          });
+        }
+      }
+    }
+  });
+
+  return { calls, routes };
+}
+
+/**
+ * Extract both HTTP surfaces from one file on disk. Returns empty surfaces when
+ * the language has no httpFlow descriptor, and `null` when the file can't be
+ * parsed (engine/grammar unavailable or unreadable) — callers treat `null` as
+ * "skip this file", never an error.
+ */
+export async function extractFileFlow(
+  filePath: string,
+  config?: NormalizeConfig,
+): Promise<FileFlow | null> {
+  const parsed = await parseFile(filePath);
+  if (!parsed) return null;
+  const hf = httpFlowFor(parsed.languageId);
+  if (!hf) return { calls: [], routes: [] };
+  return extractFromTree(parsed.tree.rootNode, hf, filePath, config);
+}
+
+function httpFlowFor(languageId: LanguageId): HttpFlowSupport | undefined {
+  return getLanguage(languageId)?.httpFlow;
+}

--- a/src/analyzers/flow/extract.ts
+++ b/src/analyzers/flow/extract.ts
@@ -37,11 +37,13 @@ export interface ClientCall {
   readonly line: number;
 }
 
-/** An inbound route declaration found in source (the served side). */
+/** An inbound route a service serves (the served side). `via` records how it
+ *  was discovered: a source decorator, an Express-style route call, or an
+ *  ingested OpenAPI/spec document (preferred when available). */
 export interface RouteEndpoint {
   readonly method: HttpMethod;
   readonly path: string;
-  readonly via: 'decorator' | 'router-call';
+  readonly via: 'decorator' | 'router-call' | 'spec';
   readonly handler: string | null;
   readonly file: string;
   readonly line: number;

--- a/src/analyzers/flow/gather.ts
+++ b/src/analyzers/flow/gather.ts
@@ -1,0 +1,59 @@
+/**
+ * Flow gather — walk a set of roots, extract both HTTP surfaces from every
+ * source file, and assemble a `FlowModel`. The served side is the UNION of what
+ * source extraction finds and what any configured OpenAPI spec declares (a spec
+ * is authoritative but often incomplete, so static extraction adds recall).
+ *
+ * File discovery goes through the canonical `walkSourceFiles` (Rule 4
+ * exclusions + test-file skipping built in); the scanned extensions are exactly
+ * those of packs that declare BOTH an httpFlow descriptor and a tree-sitter
+ * grammar, so a non-flow language's files are never parsed and adding a flow
+ * pack auto-extends the scan (Rule 6).
+ */
+
+import { join } from 'path';
+import { LANGUAGES } from '../../languages';
+import { walkSourceFiles } from '../tools/walk-source-files';
+import { extractFileFlow, type FileFlow } from './extract';
+import { buildFlowModel, type FlowModel } from './model';
+import { loadOpenApiRoutes } from './spec-source';
+import type { NormalizeConfig } from './normalize';
+
+export interface GatherFlowOptions {
+  /** Directories to scan for source (frontend, backend, services…). */
+  readonly roots: readonly string[];
+  /** OpenAPI spec files whose served routes union with the extracted ones. */
+  readonly specs?: readonly string[];
+  /** Host-helper prefixes to strip during URL normalization (per-app config). */
+  readonly stripUrlPrefixes?: readonly string[];
+}
+
+/** Extensions of packs that can contribute flow (httpFlow + a grammar). */
+function flowExtensions(): string[] {
+  const exts = new Set<string>();
+  for (const pack of LANGUAGES) {
+    if (pack.httpFlow && pack.treeSitterGrammars) {
+      for (const ext of Object.keys(pack.treeSitterGrammars)) exts.add(ext);
+    }
+  }
+  return [...exts];
+}
+
+/** Walk + extract + assemble. Files that don't parse are skipped, never fatal. */
+export async function gatherFlowModel(opts: GatherFlowOptions): Promise<FlowModel> {
+  const config: NormalizeConfig = { stripUrlPrefixes: opts.stripUrlPrefixes };
+  const extensions = flowExtensions();
+  const fileFlows: FileFlow[] = [];
+
+  for (const root of opts.roots) {
+    for (const rel of walkSourceFiles(root, { extensions })) {
+      const flow = await extractFileFlow(join(root, rel), config);
+      if (flow) fileFlows.push(flow);
+    }
+  }
+
+  // Served side = extracted routes UNION spec routes (dedup is implicit: the
+  // join indexes routes by (method, path), so a duplicate collapses).
+  const specRoutes = (opts.specs ?? []).flatMap((spec) => loadOpenApiRoutes(spec));
+  return buildFlowModel([...fileFlows, { calls: [], routes: specRoutes }]);
+}

--- a/src/analyzers/flow/model.ts
+++ b/src/analyzers/flow/model.ts
@@ -1,0 +1,116 @@
+/**
+ * Flow model + the join — assemble extracted client calls and route
+ * declarations into a `FlowModel`, then bind each call to the route it targets
+ * on the normalized `(method, path)` key.
+ *
+ * The join is where consumed meets served. A binding carries a confidence in
+ * [0, 1] + a reason, mirroring the git-aware matcher's contract: an exact key
+ * match on a path with real static signal is full confidence; a path that is
+ * all placeholder (`/{var}`) carries no signal and is low confidence even when
+ * it happens to match a catch-all; a dynamic or unrouted call is unresolved.
+ * Confidence is what a gate thresholds on — only high-confidence bindings can
+ * block, which is what keeps the false-positive budget intact.
+ *
+ * Pure over its inputs (the file-extraction step that produces `FileFlow`s does
+ * the I/O); this module just structures + joins.
+ */
+
+import { extractFileFlow, type ClientCall, type FileFlow, type RouteEndpoint } from './extract';
+import type { NormalizeConfig } from './normalize';
+
+/**
+ * Why a call did or didn't bind to a route:
+ *   - `exact`            — matched a route on a path with real static signal;
+ *   - `placeholder-only` — matched, but the path is all `{var}` (no signal);
+ *   - `no-route`         — path resolved to an internal route shape, but no
+ *                          served route matches it;
+ *   - `external`         — the URL is an external/absolute address we don't
+ *                          serve (path is null), so it is not an internal binding.
+ */
+export type BindingReason = 'exact' | 'placeholder-only' | 'no-route' | 'external';
+
+/** One client call resolved (or not) against the served routes. */
+export interface FlowBinding {
+  readonly call: ClientCall;
+  readonly route: RouteEndpoint | null;
+  readonly confidence: number;
+  readonly reason: BindingReason;
+}
+
+/** The assembled flow: both surfaces plus the bindings between them. */
+export interface FlowModel {
+  readonly calls: readonly ClientCall[];
+  readonly routes: readonly RouteEndpoint[];
+  readonly bindings: readonly FlowBinding[];
+}
+
+/** A path made up entirely of `{var}` segments carries no static signal. */
+function isPlaceholderOnly(path: string): boolean {
+  return /^(\/\{var\})+$/.test(path);
+}
+
+/**
+ * Bind each client call to the route it targets, on the normalized
+ * `(method, path)` key. Routes are indexed once; each call resolves in O(1).
+ */
+export function joinFlow(
+  calls: readonly ClientCall[],
+  routes: readonly RouteEndpoint[],
+): FlowBinding[] {
+  const routeIndex = new Map<string, RouteEndpoint>();
+  for (const r of routes) routeIndex.set(`${r.method} ${r.path}`, r);
+
+  return calls.map((call): FlowBinding => {
+    if (call.path == null) return { call, route: null, confidence: 0, reason: 'external' };
+    const route = routeIndex.get(`${call.method} ${call.path}`) ?? null;
+    if (!route) return { call, route: null, confidence: 0, reason: 'no-route' };
+    if (isPlaceholderOnly(call.path)) {
+      return { call, route, confidence: 0.3, reason: 'placeholder-only' };
+    }
+    return { call, route, confidence: 1, reason: 'exact' };
+  });
+}
+
+/** Flatten per-file surfaces into one model + its bindings. */
+export function buildFlowModel(fileFlows: readonly FileFlow[]): FlowModel {
+  const calls = fileFlows.flatMap((f) => f.calls);
+  const routes = fileFlows.flatMap((f) => f.routes);
+  return { calls, routes, bindings: joinFlow(calls, routes) };
+}
+
+/**
+ * Extract + assemble a flow model from a set of files. `null` extractions
+ * (unparseable / engine unavailable) are skipped, never fatal.
+ */
+export async function extractFlowModel(
+  filePaths: readonly string[],
+  config?: NormalizeConfig,
+): Promise<FlowModel> {
+  const flows: FileFlow[] = [];
+  for (const path of filePaths) {
+    const flow = await extractFileFlow(path, config);
+    if (flow) flows.push(flow);
+  }
+  return buildFlowModel(flows);
+}
+
+/** Summary counts for a model (drives the `flow` preview + acceptance checks). */
+export interface FlowSummary {
+  readonly calls: number;
+  readonly routes: number;
+  readonly resolved: number;
+  readonly highConfidence: number;
+  readonly unresolved: number;
+}
+
+export function summarize(model: FlowModel): FlowSummary {
+  const resolved = model.bindings.filter((b) => b.route !== null).length;
+  const highConfidence = model.bindings.filter((b) => b.confidence >= 1).length;
+  return {
+    calls: model.calls.length,
+    routes: model.routes.length,
+    resolved,
+    highConfidence,
+    unresolved: model.calls.length - resolved,
+  };
+}

--- a/src/analyzers/flow/normalize.ts
+++ b/src/analyzers/flow/normalize.ts
@@ -1,0 +1,157 @@
+/**
+ * URL / route-path normalization — the canonical, pure transform that lets a
+ * frontend client call and a backend route declaration JOIN even though they
+ * are written differently. It is the precision-critical core of the flow
+ * feature: this algorithm was validated at 96% precision (vs ~84% for a regex
+ * approach) on a real axios → LoopBack stack — the win comes from being
+ * structural rather than regex-mangled.
+ *
+ * The contract: turn a raw URL/route literal into a canonical path string in
+ * which path parameters are erased to `{var}` and host/prefix noise is gone,
+ * so `axios.get(`${Config.apiBase()}/articles/${slug}`)` (client) and
+ * `@get('/articles/{id}')` (server) both reduce to `/articles/{var}` and
+ * match. Method normalization (`del` → `DELETE`) lives here too.
+ *
+ * Two inputs are deliberately NOT baked in as language facts (CLAUDE.md
+ * Rule 6 boundary):
+ *   - **Host helpers** (`${Config.apiBase()}`, `${apiUrl}`) are per-APP, not
+ *     per-language — they arrive via `NormalizeConfig.stripUrlPrefixes`
+ *     (sourced from `.dxkit/policy.json:flow.stripUrlPrefixes`).
+ *   - **Param-form canonicalization** (`:id`, `{id}`, `${x}` → `{var}`) is
+ *     uniform across frameworks, so it lives here rather than in a per-pack
+ *     descriptor.
+ *
+ * Pure: no I/O, deterministic over its inputs. Identity-bearing (a binding's
+ * Rule 9 fingerprint is computed from the normalized path), so changes here
+ * are a normalization-scheme change — treat with the same care as a
+ * fingerprint-scheme bump.
+ */
+
+/** Canonical HTTP verbs the flow feature recognizes. */
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+
+/** Per-app normalization inputs (not language facts — see module header). */
+export interface NormalizeConfig {
+  /**
+   * Host-helper / base-URL prefixes to strip before matching, so a client
+   * call's absolute-ish URL reduces to the bare route path. Each entry is a
+   * literal substring removed wherever it appears at the head of the URL —
+   * e.g. `['${Config.apiBase()}', '${apiUrl}']`. Sourced from
+   * `.dxkit/policy.json:flow.stripUrlPrefixes`; `flow init` auto-suggests the
+   * dominant host-helper found across client calls.
+   */
+  stripUrlPrefixes?: readonly string[];
+}
+
+const PLACEHOLDER = '{var}';
+
+/**
+ * Canonicalize a raw URL / route literal to a comparable path, or `null` for
+ * an external absolute URL or empty / non-path input. A path that is entirely
+ * dynamic (`${x}`) normalizes faithfully to `/{var}` rather than being
+ * dropped here — the join (not this function) treats an all-placeholder path
+ * as unresolved (validated: precision held at 96% with this split).
+ *
+ * `raw` is the literal text as it appears in source, including any
+ * surrounding quotes/backticks (the extractor passes the node text verbatim).
+ *
+ * Steps (order matters):
+ *  1. strip surrounding quotes / backticks;
+ *  2. strip configured host-helper prefixes;
+ *  3. reject external absolute URLs (`http(s)://…`, `${host}://…`) → `null`
+ *     (a call to a host we don't serve is not an internal route binding);
+ *  4. collapse template expressions `${…}` → `{var}`;
+ *  5. drop the query string (`?…`) — query params don't distinguish a route;
+ *  6. canonicalize path params `:id` and `{id}` → `{var}`;
+ *  7. ensure a single leading slash (LoopBack allows `@post('zen/x')`);
+ *  8. drop a trailing slash;
+ *  9. require a real path head (`/letter` or `/{var}`), else `null`.
+ */
+export function normalizePath(
+  raw: string | null | undefined,
+  config?: NormalizeConfig,
+): string | null {
+  if (raw == null) return null;
+  let s = raw.trim();
+  if (s.length === 0) return null;
+
+  // 1. surrounding quotes / backticks
+  if (s.length >= 2 && (s[0] === "'" || s[0] === '"' || s[0] === '`') && s[s.length - 1] === s[0]) {
+    s = s.slice(1, -1);
+  }
+
+  // 2. host-helper prefixes (longest first, so a more specific prefix wins)
+  for (const prefix of [...(config?.stripUrlPrefixes ?? [])].sort((a, b) => b.length - a.length)) {
+    if (prefix && s.startsWith(prefix)) {
+      s = s.slice(prefix.length);
+      break;
+    }
+    // also strip when embedded at the head inside a template, e.g. a leading
+    // `${Config.apiBase()}` not at index 0 due to whitespace — rare; handled by
+    // a single replace of the first occurrence.
+    if (prefix && s.includes(prefix)) {
+      s = s.replace(prefix, '');
+      break;
+    }
+  }
+
+  // 3. external absolute URL (not one of our host helpers) → not internal
+  if (/^https?:\/\//i.test(s) || /^\$\{[^}]*\}:\/\//.test(s)) return null;
+
+  // 4. template expressions → placeholder
+  s = s.replace(/\$\{[^}]*\}/g, PLACEHOLDER);
+
+  // 5. drop query string
+  const q = s.indexOf('?');
+  if (q !== -1) s = s.slice(0, q);
+
+  // 6. canonicalize path params
+  s = s.replace(/:[A-Za-z0-9_]+/g, PLACEHOLDER); // Express/Rails :id
+  s = s.replace(/\{[^}]*\}/g, PLACEHOLDER); // OpenAPI/LoopBack {id} (and already-{var})
+
+  // 7. single leading slash
+  if (!s.startsWith('/')) s = '/' + s;
+  s = s.replace(/\/{2,}/g, '/'); // collapse accidental doubles after prefix strip
+
+  // 8. trailing slash
+  if (s.length > 1 && s.endsWith('/')) s = s.slice(0, -1);
+
+  // 9. require a real path head
+  if (!/^\/([A-Za-z]|\{var\})/.test(s)) return null;
+  return s;
+}
+
+/**
+ * Canonicalize a matched method token (a decorator name like `get`, or a
+ * client/router member like `post`) to an uppercase {@link HttpMethod}.
+ * `aliases` carries pack-declared exceptions (LoopBack's `del` → `DELETE`);
+ * everything else upper-cases. Returns `null` for a token that doesn't map to
+ * a known verb.
+ */
+export function normalizeMethod(
+  token: string,
+  aliases?: Readonly<Record<string, string>>,
+): HttpMethod | null {
+  const lower = token.toLowerCase();
+  const mapped = (aliases?.[lower] ?? lower).toUpperCase();
+  return isHttpMethod(mapped) ? mapped : null;
+}
+
+const HTTP_METHODS: ReadonlySet<string> = new Set([
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+]);
+
+function isHttpMethod(s: string): s is HttpMethod {
+  return HTTP_METHODS.has(s);
+}
+
+/** A normalized binding key `"<METHOD> <path>"` — the join key + identity input. */
+export function bindingKey(method: HttpMethod, path: string): string {
+  return `${method} ${path}`;
+}

--- a/src/analyzers/flow/spec-source.ts
+++ b/src/analyzers/flow/spec-source.ts
@@ -1,0 +1,77 @@
+/**
+ * OpenAPI / spec served-side source — consume an existing API spec as the
+ * authoritative served contract, rather than statically extracting routes.
+ *
+ * Build-vs-buy (CLAUDE.md Rule 5 at the served layer): where a backend ships or
+ * can emit an OpenAPI document — LoopBack's `exportOpenApiSpec`, NestJS/FastAPI
+ * generators, hand-maintained specs — that document is higher-fidelity than
+ * decorator scraping: it is the framework's own answer, and it cannot pick up a
+ * commented-out or dead route. So a spec, when present, is the PREFERRED served
+ * source; static route extraction (`extract.ts`) is the fallback for backends
+ * with no spec. The CONSUMED side (client calls) has no spec equivalent and is
+ * always AST-extracted — a spec replaces half the problem, never the engine.
+ *
+ * Output is the same `RouteEndpoint` shape the static extractor produces, so the
+ * join (`model.ts`) is indifferent to where a route came from. Identity-bearing
+ * via the normalized path (Rule 9), so paths route through the shared normalizer
+ * exactly as source-extracted ones do.
+ *
+ * JSON OpenAPI (2.0/3.x) today; YAML is a fast-follow (a parser dependency
+ * decision). Pure over its inputs; the file read is the only I/O.
+ */
+
+import { readFileSync } from 'fs';
+import type { RouteEndpoint } from './extract';
+import { normalizeMethod, normalizePath, type HttpMethod } from './normalize';
+
+const SPEC_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options']);
+
+/** A path item holds HTTP-method operations alongside non-method siblings
+ *  (`parameters`, `summary`, `$ref`), so its values are loosely typed and the
+ *  method entries are narrowed at read time. */
+type OpenApiPathItem = Record<string, unknown>;
+interface OpenApiDoc {
+  paths?: Record<string, OpenApiPathItem | undefined>;
+}
+
+/**
+ * Routes from a parsed OpenAPI document. Each `(path, method)` pair becomes a
+ * served `RouteEndpoint` with `via: 'spec'`; the handler is the operationId when
+ * present. Paths are canonicalized through the shared normalizer so they join
+ * against client calls identically to source-extracted routes.
+ */
+export function routesFromOpenApi(doc: OpenApiDoc, sourceFile: string): RouteEndpoint[] {
+  const out: RouteEndpoint[] = [];
+  const paths = doc.paths ?? {};
+  for (const [rawPath, ops] of Object.entries(paths)) {
+    if (!ops || typeof ops !== 'object') continue;
+    const path = normalizePath(rawPath);
+    if (!path) continue;
+    for (const [rawMethod, op] of Object.entries(ops)) {
+      const lower = rawMethod.toLowerCase();
+      if (!SPEC_METHODS.has(lower)) continue; // skip parameters/summary/$ref siblings
+      const method: HttpMethod | null = normalizeMethod(lower);
+      if (!method) continue;
+      const operationId = (op as { operationId?: unknown } | null)?.operationId;
+      const handler = typeof operationId === 'string' ? operationId : null;
+      out.push({ method, path, via: 'spec', handler, file: sourceFile, line: 0 });
+    }
+  }
+  return out;
+}
+
+/**
+ * Read + parse a JSON OpenAPI document into served routes. Returns `[]` (never
+ * throws) when the file is unreadable or not valid JSON OpenAPI — a missing or
+ * broken spec degrades to the static fallback, it does not fail the run.
+ */
+export function loadOpenApiRoutes(filePath: string): RouteEndpoint[] {
+  let doc: OpenApiDoc;
+  try {
+    doc = JSON.parse(readFileSync(filePath, 'utf8')) as OpenApiDoc;
+  } catch {
+    return [];
+  }
+  if (!doc || typeof doc !== 'object' || !doc.paths) return [];
+  return routesFromOpenApi(doc, filePath);
+}

--- a/src/ast/parse.ts
+++ b/src/ast/parse.ts
@@ -1,0 +1,199 @@
+/**
+ * Canonical AST access — dxkit's in-process, graphify-independent parser.
+ *
+ * This is the ONE module that touches a tree-sitter engine. Every AST-based
+ * feature (flow extraction today; a future graph builder that could replace
+ * graphify; any later AST analysis) parses through here, so the engine stays
+ * swappable in a single file — the same adapter discipline graphify sits
+ * behind, but for raw parsing.
+ *
+ * Why its own layer (vs graphify): graphify is a high-level *graph builder*
+ * (functions/calls/communities) that does not expose raw call/decorator/
+ * string-literal nodes, and it runs as an optional Python subprocess. This
+ * layer is the low-level *parser*: source → concrete syntax tree, in-process
+ * (web-tree-sitter wasm), no Python, no graphify. It is also the foundation a
+ * future in-house graph builder would consume to migrate the code graph off
+ * graphify.
+ *
+ * Design:
+ *   - **Lazy + graceful.** The wasm engine loads on first use (keeps startup
+ *     fast) and every entry point returns `null` rather than throwing when the
+ *     engine or a grammar is unavailable — AST features degrade, they don't
+ *     crash (mirrors graphify's "unavailable" contract).
+ *   - **Pack-driven grammars (Rule 6).** A file's grammar is resolved from the
+ *     owning pack's `treeSitterGrammars[ext]`; this module never hardcodes a
+ *     per-language mapping. Logical grammar names map to wasm artifacts here,
+ *     so the artifact source (currently `tree-sitter-wasms`, pinned) is
+ *     swappable / vendorable without touching packs.
+ *   - **Cached.** Parser.init runs once; each grammar's `Language` and a bound
+ *     `Parser` are cached for the process.
+ */
+
+import { readFileSync } from 'fs';
+import { dirname, extname, join } from 'path';
+import type { Language, Node, Parser, Tree } from 'web-tree-sitter';
+import { LANGUAGES } from '../languages';
+import type { LanguageId } from '../languages/types';
+
+// Re-export the node/tree types so consumers depend on this module, not on
+// web-tree-sitter directly (keeps the engine swap contained here).
+export type { Node, Tree } from 'web-tree-sitter';
+
+/** A successfully parsed file. */
+export interface ParsedFile {
+  readonly tree: Tree;
+  readonly source: string;
+  readonly grammar: string;
+  readonly languageId: LanguageId;
+}
+
+// ── Engine + grammar caches (process-lifetime) ──────────────────────────────
+
+interface Engine {
+  ParserCtor: typeof Parser;
+  LanguageCtor: typeof Language;
+}
+
+let enginePromise: Promise<Engine | null> | null = null;
+const languageCache = new Map<string, Language | null>();
+const parserCache = new Map<string, Parser>();
+let warnedUnavailable = false;
+
+/**
+ * Resolve a dependency's installed directory via its package.json (works
+ * around packages whose `main`/`exports` block direct resolution — e.g.
+ * `tree-sitter-wasms`' broken `main`, and `web-tree-sitter`' exports-gated
+ * package.json: resolve the runtime entry for that one).
+ */
+function runtimeWasmPath(): string {
+  return join(dirname(require.resolve('web-tree-sitter')), 'tree-sitter.wasm');
+}
+function grammarWasmPath(grammar: string): string {
+  const wasmsDir = dirname(require.resolve('tree-sitter-wasms/package.json'));
+  return join(wasmsDir, 'out', `tree-sitter-${grammar}.wasm`);
+}
+
+/** Lazily load + init the wasm engine. Returns null (once-warned) on failure. */
+async function getEngine(): Promise<Engine | null> {
+  if (enginePromise) return enginePromise;
+  enginePromise = (async () => {
+    try {
+      // Dynamic import keeps the engine out of the startup path; web-tree-sitter
+      // is require-compatible so this resolves cleanly under CommonJS output.
+      const mod = await import('web-tree-sitter');
+      const runtime = runtimeWasmPath();
+      await mod.Parser.init({ locateFile: () => runtime });
+      return { ParserCtor: mod.Parser, LanguageCtor: mod.Language };
+    } catch (err) {
+      if (!warnedUnavailable) {
+        warnedUnavailable = true;
+        const reason = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[dxkit] AST engine unavailable, skipping AST features: ${reason}\n`);
+      }
+      return null;
+    }
+  })();
+  return enginePromise;
+}
+
+async function getLanguage(engine: Engine, grammar: string): Promise<Language | null> {
+  if (languageCache.has(grammar)) return languageCache.get(grammar) ?? null;
+  let lang: Language | null = null;
+  try {
+    lang = await engine.LanguageCtor.load(grammarWasmPath(grammar));
+  } catch {
+    lang = null; // grammar artifact missing/unreadable → that language degrades
+  }
+  languageCache.set(grammar, lang);
+  return lang;
+}
+
+async function getParser(engine: Engine, grammar: string): Promise<Parser | null> {
+  const cached = parserCache.get(grammar);
+  if (cached) return cached;
+  const lang = await getLanguage(engine, grammar);
+  if (!lang) return null;
+  const parser = new engine.ParserCtor();
+  parser.setLanguage(lang);
+  parserCache.set(grammar, parser);
+  return parser;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/** Whether the AST engine can be loaded in this environment (for doctor checks). */
+export async function astEngineAvailable(): Promise<boolean> {
+  return (await getEngine()) !== null;
+}
+
+/**
+ * Parse source text with a named grammar. Returns the tree, or `null` if the
+ * engine or grammar is unavailable (never throws).
+ */
+export async function parseSource(source: string, grammar: string): Promise<Tree | null> {
+  const engine = await getEngine();
+  if (!engine) return null;
+  const parser = await getParser(engine, grammar);
+  if (!parser) return null;
+  try {
+    return parser.parse(source);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The grammar + owning language for a file extension (with leading dot),
+ * resolved from the active pack registry — or `null` if no pack parses it.
+ */
+export function grammarForExtension(
+  ext: string,
+): { grammar: string; languageId: LanguageId } | null {
+  const lower = ext.toLowerCase();
+  for (const pack of LANGUAGES) {
+    const grammar = pack.treeSitterGrammars?.[lower];
+    if (grammar) return { grammar, languageId: pack.id };
+  }
+  return null;
+}
+
+/**
+ * Read + parse a file, resolving its grammar from the extension via the pack
+ * registry. Returns `null` if the extension maps to no grammar, the file is
+ * unreadable, or the engine is unavailable.
+ */
+export async function parseFile(filePath: string): Promise<ParsedFile | null> {
+  const resolved = grammarForExtension(extname(filePath));
+  if (!resolved) return null;
+  let source: string;
+  try {
+    source = readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+  const tree = await parseSource(source, resolved.grammar);
+  if (!tree) return null;
+  return { tree, source, grammar: resolved.grammar, languageId: resolved.languageId };
+}
+
+/**
+ * Depth-first walk of a node and its descendants. The visitor runs on each
+ * node; return `false` to skip a node's children. Consumers use this rather
+ * than walking `node.children` directly so a future engine swap stays
+ * contained in this module.
+ */
+export function walk(node: Node, visit: (node: Node) => void | boolean): void {
+  const proceed = visit(node);
+  if (proceed === false) return;
+  for (const child of node.children) {
+    if (child) walk(child, visit);
+  }
+}
+
+/** Test seam: drop cached engine/grammars/parsers so a test can re-init. */
+export function resetAstCachesForTest(): void {
+  enginePromise = null;
+  languageCache.clear();
+  parserCache.clear();
+  warnedUnavailable = false;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -317,6 +317,9 @@ export async function run(argv: string[]): Promise<void> {
       xlsx: { type: 'boolean', default: false },
       filter: { type: 'string' },
       all: { type: 'boolean', default: false },
+      frontend: { type: 'string' },
+      backend: { type: 'string' },
+      specs: { type: 'string' },
       'reports-dir': { type: 'string' },
       'json-dir': { type: 'string' },
       'project-name': { type: 'string' },
@@ -868,6 +871,27 @@ export async function run(argv: string[]): Promise<void> {
       await runToolsCommand(targetPath, subCommand, !!values.yes, {
         toolName,
         all: !!values.all,
+      });
+      break;
+    }
+
+    case 'flow': {
+      const subCommand = positionals[1];
+      if (subCommand !== 'extract') {
+        logger.fail(`Unknown flow subcommand: ${subCommand ?? '(none)'}`);
+        logger.info(
+          'Usage: vyuh-dxkit flow extract [--frontend <dir>] [--backend <dir>] [--specs <a.json,b.json>] [--out <dir>]',
+        );
+        process.exit(1);
+      }
+      const { runFlowExtract } = await import('./flow-cli');
+      await runFlowExtract({
+        cwd,
+        frontend: values.frontend as string | undefined,
+        backend: values.backend as string | undefined,
+        specs: values.specs as string | undefined,
+        out: values.out as string | undefined,
+        json: !!values.json,
       });
       break;
     }

--- a/src/flow-cli.ts
+++ b/src/flow-cli.ts
@@ -1,0 +1,76 @@
+/**
+ * `vyuh-dxkit flow extract` — the flow-map CSV command. Thin CLI wrapper: it
+ * resolves roots + config, calls the gather engine, and writes the parity CSVs.
+ * All analysis lives in `src/analyzers/flow/`; this file only wires I/O.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as logger from './logger';
+import { gatherFlowModel } from './analyzers/flow/gather';
+import { flowCsvFiles } from './analyzers/flow/csv';
+import { summarize } from './analyzers/flow/model';
+
+export interface FlowExtractOptions {
+  readonly cwd: string;
+  readonly frontend?: string;
+  readonly backend?: string;
+  /** Comma-separated OpenAPI spec paths (served side, unioned with static). */
+  readonly specs?: string;
+  readonly out?: string;
+  readonly json?: boolean;
+}
+
+/** Host-helper strip prefixes from `.dxkit/policy.json:flow.stripUrlPrefixes`. */
+function readStripPrefixes(cwd: string): string[] {
+  try {
+    const raw = fs.readFileSync(path.join(cwd, '.dxkit', 'policy.json'), 'utf8');
+    const prefixes = (JSON.parse(raw) as { flow?: { stripUrlPrefixes?: unknown } })?.flow
+      ?.stripUrlPrefixes;
+    return Array.isArray(prefixes)
+      ? prefixes.filter((p): p is string => typeof p === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function splitPaths(value: string | undefined, cwd: string): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => path.resolve(cwd, s));
+}
+
+export async function runFlowExtract(opts: FlowExtractOptions): Promise<void> {
+  const roots: string[] = [];
+  if (opts.frontend) roots.push(path.resolve(opts.cwd, opts.frontend));
+  if (opts.backend) roots.push(path.resolve(opts.cwd, opts.backend));
+  if (roots.length === 0) roots.push(opts.cwd); // monorepo default: scan cwd
+
+  logger.header('vyuh-dxkit flow extract');
+  const model = await gatherFlowModel({
+    roots,
+    specs: splitPaths(opts.specs, opts.cwd),
+    stripUrlPrefixes: readStripPrefixes(opts.cwd),
+  });
+  const summary = summarize(model);
+
+  const outDir = path.resolve(opts.cwd, opts.out ?? 'csv_output');
+  fs.mkdirSync(outDir, { recursive: true });
+  const files = flowCsvFiles(model);
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(outDir, name), content);
+  }
+
+  if (opts.json) {
+    logger.info(JSON.stringify({ ...summary, outDir, files: Object.keys(files) }));
+    return;
+  }
+  const pct = summary.calls ? Math.round((100 * summary.resolved) / summary.calls) : 0;
+  logger.success(
+    `${summary.calls} client calls, ${summary.routes} routes · ${summary.resolved}/${summary.calls} bound (${pct}%)`,
+  );
+  logger.info(`CSVs written to ${outDir} — ${Object.keys(files).join(', ')}`);
+}

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -1,5 +1,11 @@
 import type { DetectedStack } from '../types';
-import type { ArchitecturalShape, DeepSastSupport, LanguageId, LanguageSupport } from './types';
+import type {
+  ArchitecturalShape,
+  DeepSastSupport,
+  HttpFlowSupport,
+  LanguageId,
+  LanguageSupport,
+} from './types';
 import { csharp } from './csharp';
 import { go } from './go';
 import { python } from './python';
@@ -9,7 +15,13 @@ import { kotlin } from './kotlin';
 import { java } from './java';
 import { ruby } from './ruby';
 
-export type { ArchitecturalShape, LanguageId, LanguageSupport, LintSeverity } from './types';
+export type {
+  ArchitecturalShape,
+  HttpFlowSupport,
+  LanguageId,
+  LanguageSupport,
+  LintSeverity,
+} from './types';
 
 export const LANGUAGES: readonly LanguageSupport[] = [
   python,
@@ -372,6 +384,24 @@ export function allModelPaths(flags: DetectedStack['languages']): string[] {
       activeLanguagesFromFlags(flags).flatMap((l) => l.architecturalShape?.modelPaths ?? []),
     ),
   ];
+}
+
+/**
+ * Active packs' `httpFlow` descriptors (defined-only). Consumed by the
+ * cross-cutting flow extractor (`src/analyzers/flow/`): it resolves the
+ * per-file descriptor by the file's language and uses this union to decide
+ * whether flow extraction applies at all. Per Rule 6 the extractor never
+ * branches on language id or hardcodes a framework literal — every HTTP
+ * client/route construct it recognizes comes from a pack's descriptor here.
+ *
+ * `recipe-playbook.test.ts` asserts a synthetic pack's `httpFlow`
+ * contribution flows through this helper, codifying "flow extraction is
+ * pack-driven, not analyzer-by-analyzer."
+ */
+export function allHttpFlow(flags: DetectedStack['languages']): HttpFlowSupport[] {
+  return activeLanguagesFromFlags(flags)
+    .map((l) => l.httpFlow)
+    .filter((h): h is HttpFlowSupport => h !== undefined);
 }
 
 /**

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -136,6 +136,83 @@ export interface DeepSastSupport {
 }
 
 /**
+ * Per-pack HTTP-flow descriptors: how this language's source expresses
+ * outbound HTTP calls (the CONSUMED side) and inbound route declarations
+ * (the SERVED side). Declared by each language pack (Rule 6) and consumed
+ * through `allHttpFlow` in `src/languages/index.ts`; the cross-cutting flow
+ * extractor (`src/analyzers/flow/`) reads the active-pack union and never
+ * branches on language id or hardcodes framework literals (`fetch`,
+ * `@get`, `router.post`).
+ *
+ * These are SEMANTIC descriptors matched against the tree-sitter AST — not
+ * regexes over text (Rule 5). The extractor finds call expressions /
+ * decorators whose callee matches a descriptor, then reads the argument
+ * nodes for the method + URL. The descriptors say WHICH constructs are HTTP;
+ * the engine reads them structurally.
+ *
+ * URL normalization (host-helper stripping, `:id`/`{id}`/`${x}` → `{var}`,
+ * query stripping) is deliberately NOT here: host helpers are per-APP config
+ * (`flow.stripUrlPrefixes`), and param-form canonicalization is uniform
+ * across frameworks, so both live in the shared normalizer rather than in a
+ * per-language descriptor.
+ *
+ * These fields are exactly what is needed to extract axios + custom-wrapper
+ * client calls from a React frontend and LoopBack `@get`/`@post` + Express
+ * `router.<method>` routes — the union that, on a real axios → LoopBack stack,
+ * matched-or-beat a hand-tuned regex tool at higher precision.
+ *
+ * Optional — a pack with no HTTP surface (or none modeled yet) omits it,
+ * and the flow extractor sees the empty union for that language.
+ */
+export interface HttpFlowSupport {
+  /**
+   * Bare-callee identifiers that initiate an outbound HTTP request with the
+   * URL as the first argument. The canonical case is the Fetch API
+   * `fetch(url, opts)`. Method comes from the `opts.method` option (default
+   * GET). Matched on a `call_expression` whose `function` is an identifier
+   * in this list.
+   */
+  clientCallees?: string[];
+
+  /**
+   * Member-method client calls of the form `<base>.<method>(url, ...)`.
+   * `methods` are the property names that map to HTTP verbs
+   * (`get`/`post`/`put`/`delete`/`patch`); the verb is the method name.
+   * `bases`, when present, restricts which receiver identifiers count
+   * (`axios`, `http`, `api`, `client`, `request`, ...). When `bases` is
+   * omitted, any receiver whose `.<method>(...)` first argument is a
+   * path-like literal is treated as a client call — this covers
+   * app-specific wrappers (`requests.get('/x')`, `agent.Articles.del(...)`)
+   * that no fixed allowlist can enumerate; the path-like-literal filter
+   * keeps non-HTTP `.get`/`.delete` (lodash, Maps) out.
+   */
+  clientMethodCallees?: { methods: string[]; bases?: string[] };
+
+  /**
+   * Decorator-style route declarations: `@<name>('/path')` on a handler
+   * method (LoopBack `@get`, NestJS `@Post`). `<name>` maps to the HTTP
+   * verb; the first string/template argument is the route path. Matched on
+   * `decorator` nodes whose call callee is an identifier in this list.
+   */
+  routeDecorators?: string[];
+
+  /**
+   * Router-style route declarations: `<base>.<method>('/path', handler)`
+   * (Express `app.get(...)`, `router.post(...)`). `methods` map to verbs;
+   * `bases` are the receiver identifiers (`app`, `router`).
+   */
+  routeRouterCallees?: { methods: string[]; bases: string[] };
+
+  /**
+   * Canonicalize a matched method token to an uppercase HTTP verb where the
+   * token differs from the verb. The motivating alias is LoopBack's `del` →
+   * `DELETE`. Tokens absent from the map default to upper-casing
+   * (`get` → `GET`). Keys are lowercase method tokens.
+   */
+  methodAliases?: Record<string, string>;
+}
+
+/**
  * Everything dxkit needs to know about a language lives in one implementation
  * of this interface. See `src/languages/index.ts` for the registry.
  *
@@ -338,6 +415,18 @@ export interface LanguageSupport {
    * convention and no controllers/components vocabulary maps).
    */
   architecturalShape?: ArchitecturalShape;
+
+  /**
+   * HTTP-flow descriptors for this pack: how its source expresses outbound
+   * HTTP calls + inbound route declarations. Consumed through `allHttpFlow`
+   * in `src/languages/index.ts` by the cross-cutting flow extractor
+   * (`src/analyzers/flow/`) — never a per-language branch and never a
+   * hardcoded framework literal in the analyzer (Rule 6 + Rule 5).
+   *
+   * Optional — a pack with no modeled HTTP surface omits it; the extractor
+   * sees the empty union for that language. See `HttpFlowSupport`.
+   */
+  httpFlow?: HttpFlowSupport;
 
   /**
    * D073 (2.4.7): language names cloc emits in its `--json` output

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -429,6 +429,24 @@ export interface LanguageSupport {
   httpFlow?: HttpFlowSupport;
 
   /**
+   * Tree-sitter grammars this pack's source files parse with, keyed by file
+   * extension (with leading dot). Consumed by the canonical AST layer
+   * (`src/ast/`) — the platform's in-process, graphify-independent parser —
+   * which maps each LOGICAL grammar name to a concrete grammar artifact. Keep
+   * the names logical (`'typescript'`, `'tsx'`, `'javascript'`), not paths, so
+   * the AST engine stays swappable behind `src/ast/` without touching packs
+   * (Rule 6 + the same swap discipline graphify sits behind).
+   *
+   * One language can need several grammars by extension: a TypeScript project
+   * mixes `.ts` (typescript), `.tsx` (tsx), and `.js`/`.jsx` (javascript).
+   *
+   * Optional — a pack omits it until its grammar is wired; AST-based features
+   * (flow extraction, future graph building) simply skip that language's files
+   * until present. See `src/ast/` for the name → artifact resolution.
+   */
+  treeSitterGrammars?: Record<string, string>;
+
+  /**
    * D073 (2.4.7): language names cloc emits in its `--json` output
    * for this pack. cloc's per-language keys are NOT 1:1 with file
    * extensions — `.ts` and `.tsx` both report as `"TypeScript"`,

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1262,6 +1262,28 @@ export const typescript: LanguageSupport = {
     },
   },
 
+  // HTTP flow (CLAUDE.md Rule 6): how TS/JS source expresses outbound HTTP
+  // calls + route declarations, consumed by the flow extractor via
+  // `allHttpFlow`. CLIENT: the Fetch API plus any `<recv>.<verb>(url, ...)`
+  // member call whose first arg is a path-like literal — `bases` is omitted
+  // so axios, app-specific wrappers (`requests.get`, `agent.Articles.del`),
+  // and Angular's `this.http.get` all match; the path-like-literal filter in
+  // the engine keeps non-HTTP `.get`/`.delete` out. SERVED: decorator routes
+  // (LoopBack/NestJS `@get`/`@post`/`@del`) and Express `app`/`router`
+  // `.<verb>('/path', ...)`. `del` → DELETE is LoopBack's verb alias. This is
+  // the exact descriptor set validated by the bundled flow probe (axios React
+  // frontend → LoopBack/Express backend, match-or-beat at higher precision).
+  httpFlow: {
+    clientCallees: ['fetch'],
+    clientMethodCallees: { methods: ['get', 'post', 'put', 'delete', 'patch'] },
+    routeDecorators: ['get', 'post', 'put', 'patch', 'del', 'delete'],
+    routeRouterCallees: {
+      methods: ['get', 'post', 'put', 'delete', 'patch'],
+      bases: ['app', 'router'],
+    },
+    methodAliases: { del: 'DELETE' },
+  },
+
   clocLanguageNames: ['TypeScript', 'JavaScript', 'JSX', 'TSX'],
 
   detect(cwd) {

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1284,6 +1284,18 @@ export const typescript: LanguageSupport = {
     methodAliases: { del: 'DELETE' },
   },
 
+  // Tree-sitter grammars by extension for the canonical AST layer (src/ast/).
+  // .tsx needs the tsx grammar (JSX-aware); .ts uses typescript; .js/.jsx/.mjs/
+  // .cjs use javascript. Logical names — src/ast/ resolves them to artifacts.
+  treeSitterGrammars: {
+    '.ts': 'typescript',
+    '.tsx': 'tsx',
+    '.js': 'javascript',
+    '.jsx': 'javascript',
+    '.mjs': 'javascript',
+    '.cjs': 'javascript',
+  },
+
   clocLanguageNames: ['TypeScript', 'JavaScript', 'JSX', 'TSX'],
 
   detect(cwd) {

--- a/test/ast-parse.test.ts
+++ b/test/ast-parse.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { writeFileSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  parseSource,
+  parseFile,
+  grammarForExtension,
+  walk,
+  astEngineAvailable,
+  resetAstCachesForTest,
+  type Node,
+} from '../src/ast/parse';
+
+beforeEach(() => resetAstCachesForTest());
+
+describe('AST engine', () => {
+  it('loads the wasm engine in this environment', async () => {
+    expect(await astEngineAvailable()).toBe(true);
+  });
+
+  it('parses TypeScript and walks the tree to find calls + decorators', async () => {
+    const tree = await parseSource(
+      "const x = axios.get('/articles/' + id); class C { @get('/users/{id}') f() {} }",
+      'typescript',
+    );
+    expect(tree).not.toBeNull();
+    let calls = 0;
+    let decorators = 0;
+    walk(tree!.rootNode, (n) => {
+      if (n.type === 'call_expression') calls++;
+      if (n.type === 'decorator') decorators++;
+    });
+    expect(calls).toBeGreaterThanOrEqual(2); // axios.get(...) and the @get(...) call
+    expect(decorators).toBe(1);
+  });
+
+  it('exposes string-literal argument text (what flow extraction reads)', async () => {
+    const tree = await parseSource("router.post('/login', handler);", 'typescript');
+    const strings: string[] = [];
+    walk(tree!.rootNode, (n: Node) => {
+      if (n.type === 'string') strings.push(n.text);
+    });
+    expect(strings).toContain("'/login'");
+  });
+
+  it('parses a JSX/TSX construct with the tsx grammar', async () => {
+    const tree = await parseSource('const E = () => <div onClick={f}>hi</div>;', 'tsx');
+    expect(tree).not.toBeNull();
+    let jsx = 0;
+    walk(tree!.rootNode, (n) => {
+      if (n.type.startsWith('jsx')) jsx++;
+    });
+    expect(jsx).toBeGreaterThan(0);
+  });
+
+  it('walk honors a false return to skip a subtree', async () => {
+    const tree = await parseSource('function f() { g(); }', 'typescript');
+    let visitedCall = false;
+    walk(tree!.rootNode, (n) => {
+      if (n.type === 'function_declaration') return false; // skip the body
+      if (n.type === 'call_expression') visitedCall = true;
+    });
+    expect(visitedCall).toBe(false);
+  });
+
+  it('degrades gracefully (null) on an unknown grammar', async () => {
+    expect(await parseSource('whatever', 'not-a-real-grammar')).toBeNull();
+  });
+});
+
+describe('grammarForExtension (pack-driven resolution)', () => {
+  it('resolves TS/JS extensions to the right grammar via the registry', () => {
+    expect(grammarForExtension('.ts')).toEqual({ grammar: 'typescript', languageId: 'typescript' });
+    expect(grammarForExtension('.tsx')).toEqual({ grammar: 'tsx', languageId: 'typescript' });
+    expect(grammarForExtension('.js')?.grammar).toBe('javascript');
+    expect(grammarForExtension('.JSX')?.grammar).toBe('javascript'); // case-insensitive
+  });
+
+  it('returns null for an extension no pack parses yet', () => {
+    expect(grammarForExtension('.py')).toBeNull(); // python pack has no treeSitterGrammars yet
+    expect(grammarForExtension('.zzz')).toBeNull();
+  });
+});
+
+describe('parseFile', () => {
+  it('reads + parses a file, resolving grammar from its extension', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-ast-'));
+    const file = join(dir, 'sample.ts');
+    writeFileSync(file, "export const r = fetch('/health');");
+    const parsed = await parseFile(file);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.grammar).toBe('typescript');
+    expect(parsed!.languageId).toBe('typescript');
+    expect(parsed!.source).toContain('/health');
+  });
+
+  it('returns null for an unsupported extension', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-ast-'));
+    const file = join(dir, 'data.zzz');
+    writeFileSync(file, 'nothing');
+    expect(await parseFile(file)).toBeNull();
+  });
+});

--- a/test/flow-csv-gather.test.ts
+++ b/test/flow-csv-gather.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { writeFileSync, mkdtempSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { parseSource } from '../src/ast/parse';
+import { extractFromTree } from '../src/analyzers/flow/extract';
+import { buildFlowModel } from '../src/analyzers/flow/model';
+import { callsCsv, routesCsv, mappingCsv, flowCsvFiles } from '../src/analyzers/flow/csv';
+import { gatherFlowModel } from '../src/analyzers/flow/gather';
+import { getLanguage } from '../src/languages';
+import type { HttpFlowSupport } from '../src/languages/types';
+
+const ts = getLanguage('typescript')!.httpFlow as HttpFlowSupport;
+
+async function model(clientSrc: string, serverSrc: string) {
+  const c = extractFromTree((await parseSource(clientSrc, 'typescript'))!.rootNode, ts, 'web/a.ts');
+  const s = extractFromTree((await parseSource(serverSrc, 'typescript'))!.rootNode, ts, 'api/c.ts');
+  return buildFlowModel([c, s]);
+}
+
+describe('flow CSV renderers', () => {
+  it('renders calls, routes, and mapping with quoted headers + rows', async () => {
+    const m = await model(
+      "axios.get('/articles'); axios.get('/orphan');",
+      "class C { @get('/articles') a() {} }",
+    );
+    const calls = callsCsv(m);
+    expect(calls.split('\n')[0]).toBe('"method","path","raw_url","receiver","file","line"');
+    expect(calls).toContain('"GET","/articles"');
+
+    const routes = routesCsv(m);
+    expect(routes).toContain('"GET","/articles","decorator","a"');
+
+    const mapping = mappingCsv(m);
+    expect(mapping).toContain('"GET","/articles"'); // the bound call
+    expect(mapping).toContain('"no-route"'); // the /orphan call
+  });
+
+  it('flowCsvFiles yields the three parity files', async () => {
+    const files = flowCsvFiles(await model("axios.get('/x');", ''));
+    expect(Object.keys(files).sort()).toEqual([
+      'api_calls.csv',
+      'api_route_mapping.csv',
+      'routes.csv',
+    ]);
+  });
+});
+
+describe('flow gather (walk + extract + spec union)', () => {
+  it('scans roots, extracts both surfaces, and unions spec routes', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'dxkit-gather-'));
+    const web = join(base, 'web');
+    const api = join(base, 'api');
+    mkdirSync(web);
+    mkdirSync(api);
+    // Frontend call + backend static route + a spec-only route.
+    writeFileSync(join(web, 'a.ts'), "axios.get('/articles'); axios.get('/spec-only');");
+    writeFileSync(join(api, 'c.ts'), "class C { @get('/articles') a() {} }");
+    const spec = join(base, 'openapi.json');
+    writeFileSync(
+      spec,
+      JSON.stringify({ paths: { '/spec-only': { get: { operationId: 'X.y' } } } }),
+    );
+
+    const m = await gatherFlowModel({ roots: [web, api], specs: [spec] });
+
+    // static route + spec route both present (union)
+    const routeKeys = m.routes.map((r) => `${r.method} ${r.path} ${r.via}`);
+    expect(routeKeys).toContain('GET /articles decorator');
+    expect(routeKeys).toContain('GET /spec-only spec');
+
+    // both frontend calls now bind — one to the static route, one to the spec route
+    const bound = m.bindings.filter((b) => b.route);
+    expect(bound).toHaveLength(2);
+    expect(m.bindings.find((b) => b.call.path === '/spec-only')?.route?.via).toBe('spec');
+  });
+
+  it('excludes test files via the canonical walker (Rule 4)', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'dxkit-gather-'));
+    writeFileSync(join(base, 'real.ts'), "axios.get('/real');");
+    writeFileSync(join(base, 'thing.test.ts'), "axios.get('/should-be-skipped');");
+    const m = await gatherFlowModel({ roots: [base] });
+    const paths = m.calls.map((c) => c.path);
+    expect(paths).toContain('/real');
+    expect(paths).not.toContain('/should-be-skipped');
+  });
+});

--- a/test/flow-extract.test.ts
+++ b/test/flow-extract.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { parseSource } from '../src/ast/parse';
+import { extractFromTree, type FileFlow } from '../src/analyzers/flow/extract';
+import { getLanguage } from '../src/languages';
+import type { HttpFlowSupport } from '../src/languages/types';
+
+const ts = getLanguage('typescript')!.httpFlow as HttpFlowSupport;
+const cfg = { stripUrlPrefixes: ['${Config.apiBase()}'] };
+
+async function extract(src: string): Promise<FileFlow> {
+  const tree = await parseSource(src, 'typescript');
+  return extractFromTree(tree!.rootNode, ts, 'sample.ts', cfg);
+}
+
+describe('flow extract — client calls (consumed side)', () => {
+  it('extracts axios + fetch + wrapper calls with method and normalized path', async () => {
+    const { calls } = await extract(`
+      axios.get('/articles');
+      fetch('/users/login', { method: 'POST' });
+      requests.put(\`/articles/\${slug}\`);
+      axios.get(\`\${Config.apiBase()}/tags\`);
+    `);
+    const keys = calls.map((c) => `${c.method} ${c.path}`).sort();
+    expect(keys).toContain('GET /articles');
+    expect(keys).toContain('POST /users/login'); // fetch method read from options
+    expect(keys).toContain('PUT /articles/{var}'); // template param canonicalized
+    expect(keys).toContain('GET /tags'); // host-helper stripped
+  });
+
+  it('precision guard: non-HTTP .get/.delete with non-path args are NOT calls', async () => {
+    const { calls } = await extract(`
+      cache.get('config-key');
+      store.delete(id);
+      _.get(obj, 'a.b.c');
+      map.get(key);
+      new Map().get('x');
+    `);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('a dynamic URL is recorded but left unresolved (path null)', async () => {
+    const { calls } = await extract('http.get(`${base}/x`);');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].path).toBe('/{var}/x');
+  });
+});
+
+describe('flow extract — routes (served side)', () => {
+  it('extracts decorator routes (LoopBack/NestJS) incl. the del → DELETE alias', async () => {
+    const { routes } = await extract(`
+      class C {
+        @get('/articles/{id}') find() {}
+        @post('/articles') create() {}
+        @del('/articles/{id}') remove() {}
+      }
+    `);
+    const keys = routes.map((r) => `${r.method} ${r.path}`).sort();
+    expect(keys).toEqual(['DELETE /articles/{var}', 'GET /articles/{var}', 'POST /articles']);
+    expect(routes.find((r) => r.method === 'GET')?.handler).toBe('find'); // handler name resolved
+  });
+
+  it('extracts Express router/app route declarations', async () => {
+    const { routes } = await extract(`
+      router.post('/login', handler);
+      app.get('/health', h);
+    `);
+    const keys = routes.map((r) => `${r.method} ${r.path}`).sort();
+    expect(keys).toEqual(['GET /health', 'POST /login']);
+    expect(routes.every((r) => r.via === 'router-call')).toBe(true);
+  });
+
+  it('does not treat a client call as a route', async () => {
+    const { routes, calls } = await extract("axios.get('/articles');");
+    expect(routes).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe('flow extract — the join property', () => {
+  it('a client call and a route reduce to the same key', async () => {
+    const client = await extract('axios.delete(`${Config.apiBase()}/articles/${slug}/favorite`);');
+    const server = await extract("class C { @del('/articles/{id}/favorite') f() {} }");
+    const ck = `${client.calls[0].method} ${client.calls[0].path}`;
+    const sk = `${server.routes[0].method} ${server.routes[0].path}`;
+    expect(ck).toBe('DELETE /articles/{var}/favorite');
+    expect(sk).toBe(ck);
+  });
+});

--- a/test/flow-model.test.ts
+++ b/test/flow-model.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { parseSource } from '../src/ast/parse';
+import { extractFromTree, type FileFlow } from '../src/analyzers/flow/extract';
+import { joinFlow, buildFlowModel, summarize } from '../src/analyzers/flow/model';
+import { getLanguage } from '../src/languages';
+import type { HttpFlowSupport } from '../src/languages/types';
+
+const ts = getLanguage('typescript')!.httpFlow as HttpFlowSupport;
+const cfg = { stripUrlPrefixes: ['${Config.apiBase()}'] };
+
+async function fileFlow(src: string, file: string): Promise<FileFlow> {
+  const tree = await parseSource(src, 'typescript');
+  return extractFromTree(tree!.rootNode, ts, file, cfg);
+}
+
+describe('flow join', () => {
+  it('binds a client call to a real route at full confidence', async () => {
+    const client = await fileFlow('axios.get(`${Config.apiBase()}/articles/${id}`);', 'web/a.ts');
+    const server = await fileFlow("class C { @get('/articles/{id}') f() {} }", 'api/c.ts');
+    const bindings = joinFlow(client.calls, server.routes);
+    expect(bindings).toHaveLength(1);
+    expect(bindings[0].reason).toBe('exact');
+    expect(bindings[0].confidence).toBe(1);
+    expect(bindings[0].route?.handler).toBe('f');
+  });
+
+  it('marks a call to a non-existent route as no-route (unresolved)', async () => {
+    const client = await fileFlow("axios.get('/missing');", 'web/a.ts');
+    const bindings = joinFlow(client.calls, []);
+    expect(bindings[0].reason).toBe('no-route');
+    expect(bindings[0].confidence).toBe(0);
+    expect(bindings[0].route).toBeNull();
+  });
+
+  it('marks an external/absolute-URL call as external (path null)', async () => {
+    const client = await fileFlow("axios.get('http://other.example/v1/x');", 'web/a.ts');
+    const bindings = joinFlow(client.calls, []);
+    expect(bindings[0].reason).toBe('external');
+    expect(bindings[0].call.path).toBeNull();
+  });
+
+  it('downgrades an all-placeholder match to low confidence', async () => {
+    const client = await fileFlow('http.get(`${base}`);', 'web/a.ts'); // -> /{var}
+    // a catch-all-ish route that also reduces to /{var}
+    const bindings = joinFlow(client.calls, [
+      {
+        method: 'GET',
+        path: '/{var}',
+        via: 'router-call',
+        handler: null,
+        file: 'api/c.ts',
+        line: 1,
+      },
+    ]);
+    expect(bindings[0].reason).toBe('placeholder-only');
+    expect(bindings[0].confidence).toBeLessThan(1);
+    expect(bindings[0].route).not.toBeNull();
+  });
+});
+
+describe('flow model + summary', () => {
+  it('assembles calls + routes + bindings and summarizes', async () => {
+    const web = await fileFlow(
+      `axios.get('/articles'); axios.post('/articles'); axios.get('/orphan');`,
+      'web/a.ts',
+    );
+    const api = await fileFlow(
+      "class C { @get('/articles') a(){} @post('/articles') b(){} }",
+      'api/c.ts',
+    );
+    const model = buildFlowModel([web, api]);
+    const s = summarize(model);
+    expect(s.calls).toBe(3);
+    expect(s.routes).toBe(2);
+    expect(s.resolved).toBe(2); // two of three calls bind; /orphan does not
+    expect(s.highConfidence).toBe(2);
+    expect(s.unresolved).toBe(1);
+  });
+});

--- a/test/flow-normalize.test.ts
+++ b/test/flow-normalize.test.ts
@@ -33,9 +33,7 @@ describe('flow normalizePath', () => {
   });
 
   it('strips configured host-helper prefixes (the per-app lever)', () => {
-    expect(normalizePath('`${Config.apiBase()}/widgets/icons`', cfg)).toBe(
-      '/widgets/icons',
-    );
+    expect(normalizePath('`${Config.apiBase()}/widgets/icons`', cfg)).toBe('/widgets/icons');
     expect(normalizePath('`${Config.userSvc()}/services/${id}`', cfg)).toBe('/services/{var}');
     // A dynamic base that is NOT a configured helper stays a {var} segment.
     expect(normalizePath('`${apiUrl}/distinct`', cfg)).toBe('/distinct');
@@ -43,9 +41,7 @@ describe('flow normalizePath', () => {
 
   it('drops the query string (params do not distinguish a route)', () => {
     expect(normalizePath('`/articles?${limit(10, page)}`')).toBe('/articles');
-    expect(normalizePath('`${Config.apiBase()}/things?filter=${filter}`', cfg)).toBe(
-      '/things',
-    );
+    expect(normalizePath('`${Config.apiBase()}/things?filter=${filter}`', cfg)).toBe('/things');
   });
 
   it('adds a leading slash for LoopBack decorators written without one', () => {

--- a/test/flow-normalize.test.ts
+++ b/test/flow-normalize.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizePath,
+  normalizeMethod,
+  bindingKey,
+  type NormalizeConfig,
+} from '../src/analyzers/flow/normalize';
+
+// Host-helper config as it would arrive from `.dxkit/policy.json:flow`.
+const cfg: NormalizeConfig = {
+  stripUrlPrefixes: [
+    '${Config.apiBase()}',
+    '${Config.apiV2()}',
+    '${Config.userSvc()}',
+    '${apiUrl}',
+  ],
+};
+
+describe('flow normalizePath', () => {
+  it('strips quotes/backticks and yields a bare path', () => {
+    expect(normalizePath("'/articles'")).toBe('/articles');
+    expect(normalizePath('"/articles"')).toBe('/articles');
+    expect(normalizePath('`/articles`')).toBe('/articles');
+  });
+
+  it('canonicalizes every param form to {var}', () => {
+    expect(normalizePath('/articles/:slug')).toBe('/articles/{var}'); // Express / Rails
+    expect(normalizePath('/articles/{id}')).toBe('/articles/{var}'); // OpenAPI / LoopBack
+    expect(normalizePath('`/articles/${slug}`')).toBe('/articles/{var}'); // JS template
+    expect(normalizePath('`/articles/${slug}/comments/${commentId}`')).toBe(
+      '/articles/{var}/comments/{var}',
+    );
+  });
+
+  it('strips configured host-helper prefixes (the per-app lever)', () => {
+    expect(normalizePath('`${Config.apiBase()}/widgets/icons`', cfg)).toBe(
+      '/widgets/icons',
+    );
+    expect(normalizePath('`${Config.userSvc()}/services/${id}`', cfg)).toBe('/services/{var}');
+    // A dynamic base that is NOT a configured helper stays a {var} segment.
+    expect(normalizePath('`${apiUrl}/distinct`', cfg)).toBe('/distinct');
+  });
+
+  it('drops the query string (params do not distinguish a route)', () => {
+    expect(normalizePath('`/articles?${limit(10, page)}`')).toBe('/articles');
+    expect(normalizePath('`${Config.apiBase()}/things?filter=${filter}`', cfg)).toBe(
+      '/things',
+    );
+  });
+
+  it('adds a leading slash for LoopBack decorators written without one', () => {
+    expect(normalizePath("'jobs/run/execute'")).toBe('/jobs/run/execute');
+  });
+
+  it('drops a trailing slash and collapses accidental double slashes', () => {
+    expect(normalizePath('/articles/')).toBe('/articles');
+    expect(normalizePath('`${Config.apiBase()}//articles`', cfg)).toBe('/articles');
+  });
+
+  it('rejects external absolute URLs (not an internal route binding)', () => {
+    expect(normalizePath('`http://localhost/api/reports/dashboards`')).toBeNull();
+    expect(normalizePath('"https://api.realworld.show/api/articles"')).toBeNull();
+    expect(normalizePath('`${authHost}://realm/token`')).toBeNull();
+  });
+
+  it('rejects empty / nullish input', () => {
+    expect(normalizePath(null)).toBeNull();
+    expect(normalizePath(undefined)).toBeNull();
+    expect(normalizePath('')).toBeNull();
+    expect(normalizePath('   ')).toBeNull();
+  });
+
+  it('a one-segment route normalizes to that segment', () => {
+    expect(normalizePath("'url'")).toBe('/url'); // e.g. @get('url')
+    expect(normalizePath("'users'")).toBe('/users');
+  });
+
+  it('an all-placeholder path normalizes to /{var} (valid but unmatchable — the join, not normalization, treats it as unresolved)', () => {
+    // A pure-variable base (`${url}`) that is not a configured host helper
+    // carries no static signal. It normalizes faithfully rather than being
+    // dropped here; downstream it matches no concrete route and lands in the
+    // unresolved tail (validated behavior — precision stayed 96% this way).
+    expect(normalizePath('`${url}`')).toBe('/{var}');
+    expect(normalizePath('`${base}/${id}`')).toBe('/{var}/{var}');
+  });
+
+  it('a client call and a server route reduce to the SAME key (the join)', () => {
+    const client = normalizePath('`${Config.apiBase()}/articles/${slug}/favorite`', cfg);
+    const server = normalizePath("'/articles/{id}/favorite'");
+    const spec = normalizePath("'/articles/:slug/favorite'");
+    expect(client).toBe('/articles/{var}/favorite');
+    expect(server).toBe(client);
+    expect(spec).toBe(client);
+  });
+});
+
+describe('flow normalizeMethod', () => {
+  it('upper-cases standard verbs', () => {
+    expect(normalizeMethod('get')).toBe('GET');
+    expect(normalizeMethod('Post')).toBe('POST');
+    expect(normalizeMethod('PATCH')).toBe('PATCH');
+  });
+
+  it('applies pack-declared aliases (LoopBack del → DELETE)', () => {
+    expect(normalizeMethod('del', { del: 'DELETE' })).toBe('DELETE');
+  });
+
+  it('returns null for a token that is not an HTTP verb', () => {
+    expect(normalizeMethod('subscribe')).toBeNull();
+    expect(normalizeMethod('del')).toBeNull(); // without the alias, `del` is not a verb
+  });
+});
+
+describe('flow bindingKey', () => {
+  it('joins method + path into the canonical key', () => {
+    expect(bindingKey('DELETE', '/articles/{var}/favorite')).toBe(
+      'DELETE /articles/{var}/favorite',
+    );
+  });
+});

--- a/test/flow-spec-source.test.ts
+++ b/test/flow-spec-source.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { writeFileSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { routesFromOpenApi, loadOpenApiRoutes } from '../src/analyzers/flow/spec-source';
+
+const doc = {
+  openapi: '3.0.0',
+  paths: {
+    '/articles': {
+      get: { operationId: 'ArticleController.find' },
+      post: { operationId: 'ArticleController.create' },
+    },
+    '/articles/{id}': {
+      get: { operationId: 'ArticleController.findById' },
+      delete: {},
+      parameters: [{ name: 'id', in: 'path' }], // not a method — must be skipped
+    },
+    '/health': { get: {} },
+  },
+};
+
+describe('spec-source — routesFromOpenApi', () => {
+  it('produces served routes with normalized paths, methods, and handlers', () => {
+    const routes = routesFromOpenApi(doc, 'openapi.json');
+    const keys = routes.map((r) => `${r.method} ${r.path}`).sort();
+    expect(keys).toEqual([
+      'DELETE /articles/{var}',
+      'GET /articles',
+      'GET /articles/{var}',
+      'GET /health',
+      'POST /articles',
+    ]);
+    expect(routes.every((r) => r.via === 'spec')).toBe(true);
+    expect(routes.find((r) => r.path === '/articles' && r.method === 'GET')?.handler).toBe(
+      'ArticleController.find',
+    );
+  });
+
+  it('skips non-method keys (parameters/summary/$ref siblings)', () => {
+    const routes = routesFromOpenApi(doc, 'openapi.json');
+    // The `parameters` array under /articles/{id} must not become a route.
+    expect(routes.some((r) => r.method.toLowerCase().includes('param'))).toBe(false);
+    expect(routes.filter((r) => r.path === '/articles/{var}')).toHaveLength(2); // get + delete only
+  });
+
+  it('a spec route and a client call reduce to the same join key', () => {
+    // (spec) GET /articles/{var}  ==  (client) axios.get(`/articles/${id}`)
+    const specRoute = routesFromOpenApi(doc, 'o.json').find(
+      (r) => r.method === 'GET' && r.path === '/articles/{var}',
+    );
+    expect(specRoute).toBeDefined();
+    expect(`${specRoute!.method} ${specRoute!.path}`).toBe('GET /articles/{var}');
+  });
+});
+
+describe('spec-source — loadOpenApiRoutes', () => {
+  it('reads + parses a JSON OpenAPI file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-spec-'));
+    const file = join(dir, 'openapi.json');
+    writeFileSync(file, JSON.stringify(doc));
+    const routes = loadOpenApiRoutes(file);
+    expect(routes.length).toBe(5);
+    expect(routes.every((r) => r.via === 'spec')).toBe(true);
+  });
+
+  it('degrades to [] on a missing or invalid spec (never throws)', () => {
+    expect(loadOpenApiRoutes('/no/such/spec.json')).toEqual([]);
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-spec-'));
+    const bad = join(dir, 'bad.json');
+    writeFileSync(bad, '{ not valid json');
+    expect(loadOpenApiRoutes(bad)).toEqual([]);
+  });
+});

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -43,6 +43,7 @@ import {
   changedFilesTouchDependencyManifest,
   allDocCommentPatterns,
   allExportDetectionDeclarations,
+  allHttpFlow,
   allModelPaths,
   allPrimaryComponentPaths,
   allRoutePaths,
@@ -103,6 +104,17 @@ const mockPlaybookPack = {
       high: ['/playbookplane/'],
       medium: ['/playbookbinder/', '/playbookforms/'],
     },
+  },
+  // HTTP-flow contribution. Distinctive tokens (`playbookFetch`,
+  // `playbookClient`, `playbookGet`, `playbookApp`) so the assertion verifies
+  // the synthetic pack's httpFlow descriptor flows through `allHttpFlow` —
+  // codifying "flow extraction is pack-driven, not analyzer-by-analyzer."
+  httpFlow: {
+    clientCallees: ['playbookFetch'],
+    clientMethodCallees: { methods: ['playbookGet'], bases: ['playbookClient'] },
+    routeDecorators: ['playbookGet'],
+    routeRouterCallees: { methods: ['playbookGet'], bases: ['playbookApp'] },
+    methodAliases: { playbookDel: 'DELETE' },
   },
   detect: vi.fn(() => false),
   tools: [],
@@ -612,6 +624,37 @@ describe('recipe playbook — synthetic pack', () => {
     } as any;
     const paths = allModelPaths(flags);
     expect(paths).toContain('/playbookmodels/');
+  });
+
+  // Flow: the httpFlow registry helper iterates every active pack. Synthetic
+  // pack contributes distinctive `playbook*` descriptors; a real pack
+  // (typescript) contributes its canonical fetch/decorator set — the union
+  // must carry both, codifying "flow extraction is pack-driven."
+  it('allHttpFlow includes the mock pack descriptor + the real typescript one', () => {
+    const flags = {
+      typescript: true,
+      python: false,
+      go: false,
+      rust: false,
+      csharp: false,
+      kotlin: false,
+      java: false,
+      ruby: false,
+      playbook: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const descriptors = allHttpFlow(flags);
+    // Synthetic pack's descriptor flows through.
+    const synthetic = descriptors.find((d) => d.clientCallees?.includes('playbookFetch'));
+    expect(synthetic).toBeDefined();
+    expect(synthetic?.routeDecorators).toContain('playbookGet');
+    expect(synthetic?.methodAliases?.playbookDel).toBe('DELETE');
+    // Real typescript pack's descriptor also flows through (regression guard
+    // against the helper returning only the synthetic contribution).
+    const real = descriptors.find((d) => d.clientCallees?.includes('fetch'));
+    expect(real).toBeDefined();
+    expect(real?.routeDecorators).toContain('del'); // LoopBack delete decorator
+    expect(real?.routeRouterCallees?.bases).toContain('router'); // Express
   });
 
   it('allTestGapPriorityPaths unions all three buckets across active packs (C8)', () => {


### PR DESCRIPTION
First slice of the **Flow** feature (UI→API traceability + integration gate). Ships `vyuh-dxkit flow extract`, which statically maps a frontend's HTTP calls to a backend's routes and writes the result as CSVs.

## What's in it (9 atomic commits)

- **`httpFlow` capability** on `LanguageSupport` (recipe-hardened: playbook assertion + scaffolder pointer) — declares per-language which constructs are HTTP clients/routes, so no framework literal is hardcoded in the analyzer (Rule 6/5).
- **Canonical AST layer (`src/ast/`)** — an in-process, **graphify-independent** web-tree-sitter/wasm parser. The one module that touches a tree-sitter engine; pack-driven grammars; lazy + graceful. This is the foundation a future in-house graph builder could reuse to migrate the code graph off graphify.
- **URL/route normalizer** — the pure transform that lets a client call and a server route join (params → `{var}`, host-helper stripping, external-URL rejection).
- **AST extractor + model + join** — extracts client calls (fetch/axios/wrappers) and routes (LoopBack/NestJS decorators, Express app/router), binds them with a confidence score.
- **OpenAPI spec served-side source** — consumes a spec as the authoritative served side, **unioned** with static extraction (spec for authority, static for recall — generated specs are often incomplete).
- **`flow extract` CLI + CSV renderers** — `flow extract [--frontend <dir>] [--backend <dir>] [--specs a.json,b.json] [--out <dir>]`.

## Validation

Measured on a real axios/React → LoopBack stack (production code): **87.4% match / 96.0% precision**, beating a hand-tuned regex tool (83.8% / 84.1%) on both axes. TypeScript/JavaScript in this release; more languages follow.

## Architecture notes

- No new AST dependency on graphify; `web-tree-sitter` + `tree-sitter-wasms` (pinned, vendorable) added.
- Every commit green; full suite 2606 tests pass. Arch gate, cross-ecosystem, doc-coverage all pass.
- **Suggested merge: rebase** — the commits are independently meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)