### PR TITLE
Flow M2 — native flow map + blast radius (2.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.20.0] - 2026-07-01
+
+### Added — native flow map + blast radius (`flow`, `flow trace`)
+
+The Flow feature's second slice makes UI→API traceability a first-class part of
+the code graph, so a change's cross-boundary blast radius is a query, not a
+guess.
+
+- **Graph schema v2 — the endpoint overlay.** `graph.json` now carries
+  `http-endpoint` nodes (one per served `(method, path)`) and `calls-endpoint`
+  edges (a UI call site → the endpoint it hits) — the cross-boundary join the
+  structural graph could not previously express. The overlay is purely additive:
+  a v1 artifact migrates forward to an empty overlay, and every pre-flow query is
+  untouched. The consuming call site's coordinates ride on the edge, so the map
+  works even where graphify never ran (a pure-frontend repo) — the flow layer
+  stays graphify-independent.
+- **`vyuh-dxkit flow`** writes the overlay and prints every endpoint with its
+  consuming UI surfaces, plus the served-but-unconsumed set (a dead-route or
+  cross-repo-consumer candidate — surfaced, not flagged as a defect).
+- **`vyuh-dxkit flow trace "<METHOD> <path>"`** shows one endpoint's handler,
+  every UI call site, and the change blast radius — direct consumers extended
+  transitively through the structural call graph.
+- Both take `--json`. New pure queries (`endpointCallers`, `flowTrace`,
+  `flowBlastRadius`, `flowMapQuery`) live in the canonical query module; the
+  overlay is regenerated each run (never accumulated).
+
+### Added — advisory file-size budget in the pre-commit slop check
+
+A warn-only, diff-scoped 500-LoC budget nudges when a changed source file
+sprawls, exempting the modules that are large by architectural mandate (language
+packs, the canonical query/registry modules, the CLI dispatch). It never blocks.
+
 ## [2.19.0] - 2026-06-30
 
 ### Added — application-flow extraction (`flow extract`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.19.0",
+      "version": "2.20.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/check-slop.sh
+++ b/scripts/check-slop.sh
@@ -8,6 +8,13 @@
 #   - New `: any` type annotations in TypeScript
 #   - New `debugger;` statements
 #
+# Warns (advisory, never blocks) when:
+#   - A changed source file exceeds the file-size budget (500 LoC) and is
+#     not one of the modules that is large by architectural mandate
+#     (language packs per Rule 6, queries.ts per Rule 12, tool-registry
+#     per Rule 1, the CLI dispatch). Diff-scoped: you only hear about a
+#     file when you are actually touching it, as a nudge to split it.
+#
 # Modes:
 #   (default, pre-commit)  scans `git diff --cached`
 #   (CI, PR job)           scans `git diff $DXKIT_SLOP_BASE...HEAD`
@@ -48,6 +55,38 @@ SOURCE=$(echo "$FILE_LIST" \
 
 if [ -z "$SOURCE" ]; then
   exit $ERRORS
+fi
+
+# ─── File-size budget (advisory, warn-only) ────────────────────────────────
+# Nudge when a changed file sprawls past the budget. Allowlisted modules are
+# large by architectural mandate — splitting them would violate a CLAUDE.md
+# rule (one file per language pack, one canonical query/registry module) — so
+# they are exempt. Never increments ERRORS: this warns, it does not block.
+SIZE_BUDGET=500
+is_size_exempt() {
+  case "$1" in
+    src/languages/*.ts) return 0 ;;              # Rule 6 — one file per pack
+    src/explore/queries.ts) return 0 ;;          # Rule 12 — canonical query module
+    src/analyzers/tools/tool-registry.ts) return 0 ;; # Rule 1 — canonical registry
+    src/cli.ts) return 0 ;;                       # CLI dispatch aggregator
+    *) return 1 ;;
+  esac
+}
+SIZE_WARNINGS=""
+for f in $SOURCE; do
+  [ -f "$f" ] || continue
+  case "$f" in *.ts | *.tsx) ;; *) continue ;; esac
+  is_size_exempt "$f" && continue
+  loc=$(wc -l <"$f" 2>/dev/null | tr -d ' ')
+  if [ -n "$loc" ] && [ "$loc" -gt "$SIZE_BUDGET" ]; then
+    SIZE_WARNINGS="${SIZE_WARNINGS}   ${f} (${loc} LoC)\n"
+  fi
+done
+if [ -n "$SIZE_WARNINGS" ]; then
+  echo "⚠️  File-size budget (${SIZE_BUDGET} LoC) — consider splitting (advisory, not blocking):"
+  printf "%b" "$SIZE_WARNINGS"
+  echo "   → Extract cohesive units into new modules, or exempt in scripts/check-slop.sh"
+  echo "     if the file is canonical single-source by a CLAUDE.md rule."
 fi
 
 # Helper: grep added lines (prefixed with + but not ++, the file header) for

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -877,22 +877,46 @@ export async function run(argv: string[]): Promise<void> {
 
     case 'flow': {
       const subCommand = positionals[1];
-      if (subCommand !== 'extract') {
-        logger.fail(`Unknown flow subcommand: ${subCommand ?? '(none)'}`);
-        logger.info(
-          'Usage: vyuh-dxkit flow extract [--frontend <dir>] [--backend <dir>] [--specs <a.json,b.json>] [--out <dir>]',
-        );
-        process.exit(1);
+      const frontend = values.frontend as string | undefined;
+      const backend = values.backend as string | undefined;
+      const specs = values.specs as string | undefined;
+
+      // `flow` / `flow map` → the traceability map (writes the graph overlay).
+      if (subCommand === undefined || subCommand === 'map') {
+        const { runFlowMap } = await import('./flow-cli');
+        await runFlowMap({ cwd, frontend, backend, specs, json: !!values.json });
+        break;
       }
-      const { runFlowExtract } = await import('./flow-cli');
-      await runFlowExtract({
-        cwd,
-        frontend: values.frontend as string | undefined,
-        backend: values.backend as string | undefined,
-        specs: values.specs as string | undefined,
-        out: values.out as string | undefined,
-        json: !!values.json,
-      });
+      // `flow trace "<METHOD> <path>"` → one endpoint's full trace.
+      if (subCommand === 'trace') {
+        const target = positionals.slice(2).join(' ').trim();
+        if (!target) {
+          logger.fail('Usage: vyuh-dxkit flow trace "<METHOD> <path>"');
+          process.exit(1);
+        }
+        const { runFlowTrace } = await import('./flow-cli');
+        await runFlowTrace({ cwd, frontend, backend, specs, json: !!values.json, target });
+        break;
+      }
+      // `flow extract` → the parity CSVs.
+      if (subCommand === 'extract') {
+        const { runFlowExtract } = await import('./flow-cli');
+        await runFlowExtract({
+          cwd,
+          frontend,
+          backend,
+          specs,
+          out: values.out as string | undefined,
+          json: !!values.json,
+        });
+        break;
+      }
+      logger.fail(`Unknown flow subcommand: ${subCommand}`);
+      logger.info('Usage:');
+      logger.info('  vyuh-dxkit flow [map] [--frontend <dir>] [--backend <dir>] [--specs <a,b>]');
+      logger.info('  vyuh-dxkit flow trace "<METHOD> <path>"');
+      logger.info('  vyuh-dxkit flow extract [--out <dir>]');
+      process.exit(1);
       break;
     }
 

--- a/src/dashboard/graph-adapter.ts
+++ b/src/dashboard/graph-adapter.ts
@@ -30,7 +30,7 @@
  */
 
 import { callersOf, calleesOf, communitiesQuery, nodesInFile } from '../explore/queries';
-import type { Graph, GraphEdge } from '../explore/types';
+import type { Graph } from '../explore/types';
 
 // ─── Cytoscape element shapes ────────────────────────────────────────────────
 //
@@ -276,12 +276,16 @@ export function adaptToTier2(graph: Graph, communityId: number): CytoscapeElemen
   // Aggregate edges to the file level. Walk every node in the
   // community + every outbound edge; bucket by (sourceFile,
   // targetFile, relation).
-  const edgeKey = (from: string, to: string, rel: GraphEdge['relation']) =>
+  // Tier 2 renders the STRUCTURAL file graph only. The `calls-endpoint`
+  // flow overlay (whose `to` is an endpoint, never a structural node) is
+  // not a file-to-file relation, so it is filtered out below.
+  type StructuralRelation = 'calls' | 'imports_from' | 'method';
+  const edgeKey = (from: string, to: string, rel: StructuralRelation) =>
     `${from}\x00${to}\x00${rel}`;
   type EdgeBucket = {
     from: string;
     to: string;
-    relation: GraphEdge['relation'];
+    relation: StructuralRelation;
     occurrences: number;
   };
   const edgeBuckets = new Map<string, EdgeBucket>();
@@ -291,7 +295,7 @@ export function adaptToTier2(graph: Graph, communityId: number): CytoscapeElemen
     if (!fromNode?.sourceFile) continue;
     const fromFile = fromNode.sourceFile;
     for (const e of graph.edgesFromNode.get(nodeId) ?? []) {
-      if (e.relation === 'method') continue;
+      if (e.relation !== 'calls' && e.relation !== 'imports_from') continue;
       const toNode = graph.nodeById.get(e.to);
       if (!toNode?.sourceFile) continue;
       const toFile = toNode.sourceFile;

--- a/src/explore/flow-graph.ts
+++ b/src/explore/flow-graph.ts
@@ -1,0 +1,178 @@
+/**
+ * Flow → graph composition (the writer side of the v2 overlay). Turns a
+ * `FlowModel` (the consumed/served join) into the `http-endpoint` nodes +
+ * `calls-endpoint` edges that ride on top of the structural graph, then
+ * merges them onto whatever graphify already wrote and persists the result.
+ *
+ * The two producers stay decoupled per §10 of the design: graphify owns the
+ * structural nodes/edges and writes a v1 artifact unaware of flow; this module
+ * owns the flow overlay and composes ON TOP of graphify's output without
+ * graphify importing it (or vice versa). When graphify is absent the overlay
+ * still writes — a minimal v2 skeleton whose `calls-endpoint` edges carry the
+ * consuming call site's coordinates directly (Rule: the flow layer is
+ * graphify-independent, so the map degrades to "endpoints + who calls them by
+ * file", never to nothing).
+ *
+ * Graph reads/writes stay in the explore layer (Rule 12): the base is loaded
+ * via `tryLoadGraph`, endpoint anchoring resolves through the `queries.ts`
+ * primitive `enclosingNodeIdFor`, and this module is the flow overlay's single
+ * writer — the mirror of graphify's `writeGraphArtifact`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { FlowModel } from '../analyzers/flow/model';
+import type { RouteEndpoint } from '../analyzers/flow/extract';
+import { tryLoadGraph } from './load';
+import { enclosingNodeIdFor } from './queries';
+import {
+  GRAPH_REPORT_PATH,
+  GRAPH_SCHEMA_VERSION,
+  type Graph,
+  type GraphEdge,
+  type GraphJson,
+  type HttpEndpointNode,
+} from './types';
+
+/** The disjoint slice of the v2 graph the flow layer contributes. */
+export interface FlowContribution {
+  readonly endpoints: HttpEndpointNode[];
+  readonly edges: GraphEdge[];
+}
+
+/** The `${method} ${path}` join key an endpoint / call reduces to. */
+function endpointKey(method: string, routePath: string): string {
+  return `${method} ${routePath}`;
+}
+
+/**
+ * Build the flow overlay from a model. One `http-endpoint` node per distinct
+ * served `(method, path)` (deduped — a route surfaced by both a spec and static
+ * extraction collapses to one endpoint, spec winning as the authoritative
+ * provenance), and one `calls-endpoint` edge per RESOLVED binding (a call that
+ * matched a served route).
+ *
+ * `base` is the structural graph when available: the edge's `from` anchors onto
+ * the enclosing structural node so the UI→API edge composes with the real call
+ * graph. Without a base (or when a call sits outside any known symbol) `from` is
+ * empty and the call site lives on the edge's `fromFile` / `fromLine` — enough
+ * to answer "who calls this endpoint" by file. Pure over its inputs.
+ */
+export function buildFlowContribution(model: FlowModel, base?: Graph): FlowContribution {
+  // Dedup routes → endpoint nodes, keyed by the normalized join key. A spec
+  // route supersedes a static one for the same key (authoritative handler).
+  const byKey = new Map<string, RouteEndpoint>();
+  for (const route of model.routes) {
+    const key = endpointKey(route.method, route.path);
+    const existing = byKey.get(key);
+    if (!existing || (existing.via !== 'spec' && route.via === 'spec')) {
+      byKey.set(key, route);
+    }
+  }
+
+  const endpoints: HttpEndpointNode[] = [];
+  const endpointIdByKey = new Map<string, string>();
+  let idx = 0;
+  for (const [key, route] of byKey) {
+    const id = `ep${idx++}`;
+    endpointIdByKey.set(key, id);
+    endpoints.push({
+      id,
+      kind: 'http-endpoint',
+      label: `${route.method} ${route.path}`,
+      method: route.method,
+      path: route.path,
+      via: route.via,
+      handler: route.handler,
+      sourceFile: route.file,
+      line: route.line,
+    });
+  }
+
+  // One calls-endpoint edge per resolved binding. Unresolved bindings
+  // (external / no-route) have no endpoint to point at — they are the map's
+  // "dangling call" set, surfaced by queries, not as edges.
+  const edges: GraphEdge[] = [];
+  for (const binding of model.bindings) {
+    if (!binding.route) continue;
+    const key = endpointKey(binding.route.method, binding.route.path);
+    const endpointId = endpointIdByKey.get(key);
+    if (!endpointId) continue;
+    const from = base ? (enclosingNodeIdFor(base, binding.call.file, binding.call.line) ?? '') : '';
+    edges.push({
+      from,
+      to: endpointId,
+      relation: 'calls-endpoint',
+      fromFile: binding.call.file,
+      fromLine: binding.call.line,
+    });
+  }
+
+  return { endpoints, edges };
+}
+
+/**
+ * Compose a full v2 `GraphJson` from a (possibly absent) structural base and a
+ * flow model. With a base, the structural nodes/edges/communities/symbolIndex
+ * are preserved verbatim and the flow overlay is appended (edges into the
+ * shared `edges` array, endpoints into the new `endpoints` array); the schema
+ * version is stamped to v2. Without a base, a minimal skeleton carries the
+ * overlay alone, so `vyuh-dxkit flow` produces a map even where graphify never
+ * ran (a pure-frontend repo, a CI job without Python).
+ */
+export function mergeFlowIntoGraph(base: Graph | undefined, model: FlowModel): GraphJson {
+  const contribution = buildFlowContribution(model, base);
+  if (base) {
+    return {
+      schemaVersion: GRAPH_SCHEMA_VERSION,
+      meta: base.meta,
+      nodes: base.nodes,
+      edges: [...base.edges, ...contribution.edges],
+      communities: base.communities,
+      symbolIndex: base.symbolIndex,
+      endpoints: contribution.endpoints,
+    };
+  }
+  return {
+    schemaVersion: GRAPH_SCHEMA_VERSION,
+    meta: {
+      tool: 'graphify',
+      graphifyVersion: '',
+      dxkitVersion: '',
+      generatedAt: '',
+      sourceFilesInGraph: 0,
+      excludedFileCount: 0,
+      packs: [],
+      truncated: false,
+      truncatedReason: '',
+    },
+    nodes: [],
+    edges: contribution.edges,
+    communities: [],
+    symbolIndex: {},
+    endpoints: contribution.endpoints,
+  };
+}
+
+/**
+ * Persist the flow-augmented graph to its canonical disk location, composing
+ * onto graphify's base when one exists. Returns the merged graph so an
+ * in-memory caller (the `flow` CLI) can render without a disk round-trip.
+ *
+ * Mirror of graphify's `writeGraphArtifact`: a failed write is a warning, not a
+ * throw — the graph is a convenience artifact, and the CLI already has the
+ * model in hand for its terminal output.
+ */
+export function writeFlowGraph(cwd: string, model: FlowModel): GraphJson {
+  const base = tryLoadGraph(cwd);
+  const merged = mergeFlowIntoGraph(base, model);
+  const absPath = path.join(cwd, GRAPH_REPORT_PATH);
+  try {
+    fs.mkdirSync(path.dirname(absPath), { recursive: true });
+    fs.writeFileSync(absPath, JSON.stringify(merged));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`dxkit: failed to write ${GRAPH_REPORT_PATH}: ${msg}\n`);
+  }
+  return merged;
+}

--- a/src/explore/flow-graph.ts
+++ b/src/explore/flow-graph.ts
@@ -123,11 +123,16 @@ export function buildFlowContribution(model: FlowModel, base?: Graph): FlowContr
 export function mergeFlowIntoGraph(base: Graph | undefined, model: FlowModel): GraphJson {
   const contribution = buildFlowContribution(model, base);
   if (base) {
+    // The overlay is REGENERATED each run, never accumulated: strip any
+    // calls-endpoint edges a previous flow run left on the base (endpoints are
+    // already replaced wholesale below), then append this run's fresh edges.
+    // Without this, re-running `flow` stacks duplicate bindings.
+    const structuralEdges = base.edges.filter((e) => e.relation !== 'calls-endpoint');
     return {
       schemaVersion: GRAPH_SCHEMA_VERSION,
       meta: base.meta,
       nodes: base.nodes,
-      edges: [...base.edges, ...contribution.edges],
+      edges: [...structuralEdges, ...contribution.edges],
       communities: base.communities,
       symbolIndex: base.symbolIndex,
       endpoints: contribution.endpoints,

--- a/src/explore/flow-view.ts
+++ b/src/explore/flow-view.ts
@@ -1,0 +1,93 @@
+/**
+ * Flow read-side orchestration for the `vyuh-dxkit flow` CLI. Composes the
+ * three explore primitives the CLI is not allowed to touch directly (Rule 12
+ * confines graph load + query to the explore layer): write the overlay
+ * (`flow-graph.ts`), reload the indexed graph (`load.ts`), run the pure query
+ * (`queries.ts`). The CLI consumes the returned view and renders — it never
+ * loads or traverses the graph itself.
+ */
+
+import { writeFlowGraph } from './flow-graph';
+import { tryLoadGraph } from './load';
+import { flowMapQuery, flowTrace, type FlowMap, type FlowTrace } from './queries';
+import type { FlowModel } from '../analyzers/flow/model';
+import type { Graph, HttpEndpointNode } from './types';
+
+const EMPTY_MAP: FlowMap = {
+  endpoints: [],
+  unconsumedEndpoints: [],
+  totalEndpoints: 0,
+  totalBindings: 0,
+};
+
+/**
+ * Build the flow map: persist the overlay onto graph.json, then read it back
+ * and run `flowMapQuery`. Reloading (rather than indexing the merged json
+ * in-memory) keeps the on-disk artifact and the rendered view guaranteed
+ * consistent, and the graph.json is a small file. Degrades to an empty map if
+ * the write+reload fails (never throws for the CLI).
+ */
+export function buildFlowMap(cwd: string, model: FlowModel): FlowMap {
+  writeFlowGraph(cwd, model);
+  const graph = tryLoadGraph(cwd);
+  return graph ? flowMapQuery(graph) : EMPTY_MAP;
+}
+
+/** Not-found trace carries the candidate endpoint labels so the CLI can print a
+ *  "did you mean" list keyed off the same graph. */
+export interface FlowTraceView {
+  trace: FlowTrace;
+  candidates: string[];
+}
+
+/**
+ * Build the trace for one endpoint. `target` resolves against the freshly
+ * written graph by, in order: exact endpoint id (`ep3`), exact join key
+ * (`GET /articles/{var}`), then the method-uppercased key — so a user can paste
+ * the label shown by `flow map` verbatim. On no match, `trace.found` is false
+ * and `candidates` lists every endpoint label for a "did you mean" hint.
+ */
+export function buildFlowTrace(cwd: string, model: FlowModel, target: string): FlowTraceView {
+  writeFlowGraph(cwd, model);
+  const graph = tryLoadGraph(cwd);
+  if (!graph) {
+    return { trace: notFoundTrace(target), candidates: [] };
+  }
+  const endpoint = resolveEndpoint(graph, target);
+  if (!endpoint) {
+    return {
+      trace: notFoundTrace(target),
+      candidates: graph.endpoints.map((e) => e.label).sort(),
+    };
+  }
+  return { trace: flowTrace(graph, endpoint.id), candidates: [] };
+}
+
+function resolveEndpoint(graph: Graph, target: string): HttpEndpointNode | undefined {
+  const t = target.trim();
+  const byId = graph.endpointById.get(t);
+  if (byId) return byId;
+  const byKey = graph.endpointByKey.get(t);
+  if (byKey) return byKey;
+  const space = t.indexOf(' ');
+  if (space > 0) {
+    const upper = `${t.slice(0, space).toUpperCase()} ${t.slice(space + 1)}`;
+    return graph.endpointByKey.get(upper);
+  }
+  return undefined;
+}
+
+function notFoundTrace(_target: string): FlowTrace {
+  return {
+    found: false,
+    handler: null,
+    consumers: [],
+    blastRadius: {
+      endpointId: '',
+      directConsumers: 0,
+      consumerFiles: 0,
+      upstreamCallers: 0,
+      upstreamFiles: 0,
+    },
+  };
+}

--- a/src/explore/load.ts
+++ b/src/explore/load.ts
@@ -20,6 +20,7 @@ import {
   type GraphEdge,
   type GraphJson,
   type GraphNode,
+  type HttpEndpointNode,
 } from './types';
 
 // Re-export for backwards-compat with consumers that import the path
@@ -112,8 +113,6 @@ function validateAndUpgrade(absPath: string, raw: unknown): GraphJson {
   if (v > GRAPH_SCHEMA_VERSION) {
     throw new GraphSchemaVersionError(absPath, v, GRAPH_SCHEMA_VERSION);
   }
-  // Future migrations: switch on v here when v2+ lands. Today v === 1
-  // is the only supported version; no migration needed.
 
   for (const key of ['meta', 'nodes', 'edges', 'communities', 'symbolIndex']) {
     if (!(key in obj)) {
@@ -129,8 +128,17 @@ function validateAndUpgrade(absPath: string, raw: unknown): GraphJson {
   if (!Array.isArray(obj.communities)) {
     throw new GraphCorruptError(absPath, '"communities" is not an array');
   }
+
+  // v1 → v2 migration: the flow overlay is purely additive, so a v1
+  // artifact (no `endpoints` field) migrates forward to an empty
+  // endpoint set. A v2 artifact must carry an array when present.
+  if ('endpoints' in obj && !Array.isArray(obj.endpoints)) {
+    throw new GraphCorruptError(absPath, '"endpoints" is not an array');
+  }
+  const endpoints = Array.isArray(obj.endpoints) ? obj.endpoints : [];
+
   // Trust the rest; runtime errors in queries surface deeper issues.
-  return raw as GraphJson;
+  return { ...(raw as GraphJson), endpoints: endpoints as HttpEndpointNode[] };
 }
 
 function indexGraph(json: GraphJson): Graph {
@@ -162,6 +170,13 @@ function indexGraph(json: GraphJson): Graph {
     for (const nid of c.nodeIds) communityByNode.set(nid, c);
   }
 
+  const endpointById = new Map<string, HttpEndpointNode>();
+  const endpointByKey = new Map<string, HttpEndpointNode>();
+  for (const ep of json.endpoints) {
+    endpointById.set(ep.id, ep);
+    endpointByKey.set(`${ep.method} ${ep.path}`, ep);
+  }
+
   return {
     ...json,
     nodeById,
@@ -170,5 +185,7 @@ function indexGraph(json: GraphJson): Graph {
     nodesByFile,
     communityById,
     communityByNode,
+    endpointById,
+    endpointByKey,
   };
 }

--- a/src/explore/queries.ts
+++ b/src/explore/queries.ts
@@ -15,7 +15,7 @@
  */
 
 import type { DetectedStack } from '../types';
-import type { Community, Graph, GraphNode } from './types';
+import type { Community, Graph, GraphNode, HttpEndpointNode } from './types';
 
 // ─── Low-level primitives ────────────────────────────────────────────────────
 
@@ -1296,6 +1296,184 @@ export function fileLineContextQuery(
     callees,
     community,
     blastRadius: { callerFiles: summary.callerFiles.length, callers: fileCallers },
+  };
+}
+
+// ─── Flow queries (the v2 endpoint overlay: UI→API traceability) ──────────────
+
+/**
+ * One consumer of an endpoint — a client call site that binds to it. `nodeId` /
+ * `symbol` are present when the call was anchored onto a structural node (a base
+ * graph existed); otherwise only the source coordinates are known (the flow map
+ * is graphify-independent, so `file` + `line` are always populated from the
+ * `calls-endpoint` edge).
+ */
+export interface EndpointCaller {
+  file: string;
+  line?: number;
+  nodeId?: string;
+  symbol?: string;
+}
+
+/**
+ * Every UI surface that hits an endpoint — the `calls-endpoint` in-edges of the
+ * endpoint node, mapped to their consuming call sites. The core cross-boundary
+ * query the graph could not previously answer. Rule 12: relation-filtered edge
+ * traversal lives here, never re-walked by a consumer.
+ */
+export function endpointCallers(graph: Graph, endpointId: string): EndpointCaller[] {
+  const out: EndpointCaller[] = [];
+  for (const e of graph.edgesToNode.get(endpointId) ?? []) {
+    if (e.relation !== 'calls-endpoint') continue;
+    const node = e.from ? graph.nodeById.get(e.from) : undefined;
+    out.push({
+      file: e.fromFile ?? node?.sourceFile ?? '',
+      line: e.fromLine,
+      nodeId: node?.id,
+      symbol: node ? stripParens(node.label) : undefined,
+    });
+  }
+  return out;
+}
+
+/**
+ * Blast radius of an endpoint: the surface a change to it (delete, rename,
+ * verb-change) would touch. `directConsumers` / `consumerFiles` count the
+ * immediate UI call sites; `upstreamCallers` / `upstreamFiles` extend that
+ * transitively through the structural `calls` graph (which functions call the
+ * consuming ones), bounded by a visited set. Upstream counts are only as
+ * complete as the base graph — zero when graphify never ran, so consumers label
+ * them as best-effort.
+ */
+export interface FlowBlastRadius {
+  endpointId: string;
+  directConsumers: number;
+  consumerFiles: number;
+  upstreamCallers: number;
+  upstreamFiles: number;
+}
+
+export function flowBlastRadius(graph: Graph, endpointId: string): FlowBlastRadius {
+  const consumers = endpointCallers(graph, endpointId);
+  const consumerFiles = new Set<string>();
+  for (const c of consumers) if (c.file) consumerFiles.add(c.file);
+
+  // Transitive upstream over `calls` edges, seeded by the anchored consumer
+  // nodes. BFS with a visited set — bounded by the graph size.
+  const upstreamNodes = new Set<string>();
+  const upstreamFiles = new Set<string>();
+  const queue: string[] = [];
+  for (const c of consumers) if (c.nodeId) queue.push(c.nodeId);
+  const seen = new Set<string>(queue);
+  while (queue.length) {
+    const id = queue.shift()!;
+    for (const caller of callersOf(graph, id)) {
+      if (seen.has(caller.id)) continue;
+      seen.add(caller.id);
+      upstreamNodes.add(caller.id);
+      if (caller.sourceFile) upstreamFiles.add(caller.sourceFile);
+      queue.push(caller.id);
+    }
+  }
+
+  return {
+    endpointId,
+    directConsumers: consumers.length,
+    consumerFiles: consumerFiles.size,
+    upstreamCallers: upstreamNodes.size,
+    upstreamFiles: upstreamFiles.size,
+  };
+}
+
+/**
+ * The full trace for one endpoint: its served-side identity (handler +
+ * provenance) plus the consumed side (every UI call site). The UI→API→handler
+ * path in one object; the deeper handler→model hop is left to a future pass
+ * (the graph does not yet carry data-model edges). `found: false` when no
+ * endpoint has that id.
+ */
+export interface FlowTrace {
+  found: boolean;
+  endpoint?: HttpEndpointNode;
+  handler: string | null;
+  consumers: EndpointCaller[];
+  blastRadius: FlowBlastRadius;
+}
+
+export function flowTrace(graph: Graph, endpointId: string): FlowTrace {
+  const endpoint = graph.endpointById.get(endpointId);
+  if (!endpoint) {
+    return {
+      found: false,
+      handler: null,
+      consumers: [],
+      blastRadius: {
+        endpointId,
+        directConsumers: 0,
+        consumerFiles: 0,
+        upstreamCallers: 0,
+        upstreamFiles: 0,
+      },
+    };
+  }
+  return {
+    found: true,
+    endpoint,
+    handler: endpoint.handler,
+    consumers: endpointCallers(graph, endpointId),
+    blastRadius: flowBlastRadius(graph, endpointId),
+  };
+}
+
+/** One endpoint row of the flow map: the served route + how many UI surfaces
+ *  consume it. */
+export interface FlowMapEndpoint {
+  endpoint: HttpEndpointNode;
+  consumerCount: number;
+  consumerFiles: string[];
+}
+
+/**
+ * The whole flow map read from the graph: every served endpoint ranked by
+ * consumer count, plus the served-but-unconsumed set (endpoints no UI in this
+ * graph calls — a candidate dead route OR a cross-repo consumer not scanned, so
+ * surfaced separately, not as a defect). `totalBindings` counts the
+ * `calls-endpoint` edges. The integration-test-gap signal (endpoints with
+ * consumers but no covering test) composes on top of this in a later phase.
+ */
+export interface FlowMap {
+  endpoints: FlowMapEndpoint[];
+  unconsumedEndpoints: HttpEndpointNode[];
+  totalEndpoints: number;
+  totalBindings: number;
+}
+
+export function flowMapQuery(graph: Graph): FlowMap {
+  const rows: FlowMapEndpoint[] = [];
+  const unconsumed: HttpEndpointNode[] = [];
+  let totalBindings = 0;
+
+  for (const endpoint of graph.endpoints) {
+    const consumers = endpointCallers(graph, endpoint.id);
+    totalBindings += consumers.length;
+    const files = [...new Set(consumers.map((c) => c.file).filter(Boolean))].sort();
+    if (consumers.length === 0) {
+      unconsumed.push(endpoint);
+      continue;
+    }
+    rows.push({ endpoint, consumerCount: consumers.length, consumerFiles: files });
+  }
+
+  rows.sort(
+    (a, b) => b.consumerCount - a.consumerCount || a.endpoint.label.localeCompare(b.endpoint.label),
+  );
+  unconsumed.sort((a, b) => a.label.localeCompare(b.label));
+
+  return {
+    endpoints: rows,
+    unconsumedEndpoints: unconsumed,
+    totalEndpoints: graph.endpoints.length,
+    totalBindings,
   };
 }
 

--- a/src/explore/queries.ts
+++ b/src/explore/queries.ts
@@ -1130,6 +1130,42 @@ export function enclosingSymbolFor(
   return best ? stripParens(best.label) : undefined;
 }
 
+/**
+ * Resolve the id of the structural node enclosing a source location —
+ * the node-id sibling of {@link enclosingSymbolFor}. Used by the flow
+ * writer to anchor the `from` end of a `calls-endpoint` edge onto the
+ * real call graph when graphify is present (so a UI→API edge composes
+ * with the structural `calls` edges for multi-hop blast radius). Returns
+ * `undefined` when the file declares no symbol at-or-above `line` AND has
+ * no module node (the writer then leaves `from` empty and relies on the
+ * edge's fromFile / fromLine coordinates, keeping the map
+ * graphify-independent).
+ *
+ * Prefers the nearest non-module declaration at-or-above `line`; falls
+ * back to the file's module node (a top-level call outside any symbol
+ * still anchors to its file). Graph traversal stays in this module
+ * (Rule 12).
+ */
+export function enclosingNodeIdFor(
+  graph: Graph,
+  sourceFile: string,
+  line: number,
+): string | undefined {
+  const nodes = graph.nodesByFile.get(sourceFile);
+  if (!nodes) return undefined;
+  let best: GraphNode | undefined;
+  let moduleFallback: GraphNode | undefined;
+  for (const n of nodes) {
+    if (n.kind === 'module') {
+      moduleFallback = n;
+      continue;
+    }
+    if (typeof n.line !== 'number' || n.line > line) continue;
+    if (best?.line === undefined || n.line > best.line) best = n;
+  }
+  return (best ?? moduleFallback)?.id;
+}
+
 // ─── File-line context query (the `context <file:line>` structural half) ─────
 
 /**

--- a/src/explore/types.ts
+++ b/src/explore/types.ts
@@ -15,8 +15,16 @@
 
 import type { LanguageId } from '../types';
 
-/** Current schema version. Bump on breaking change; loader handles migration. */
-export const GRAPH_SCHEMA_VERSION = 1;
+/**
+ * Current schema version. Bump on breaking change; loader handles migration.
+ *
+ * v2 (flow map): adds the `endpoints` overlay (`http-endpoint` nodes) and the
+ * `calls-endpoint` edge relation — the cross-boundary UI→API join the graph
+ * could not previously express. The overlay is purely additive: a v1 artifact
+ * migrates forward to an empty endpoint set, and the structural node/edge kinds
+ * are untouched, so every pre-flow query keeps working unchanged.
+ */
+export const GRAPH_SCHEMA_VERSION = 2;
 
 /**
  * Canonical disk location for the graph artifact, relative to cwd.
@@ -29,7 +37,7 @@ export const GRAPH_REPORT_PATH = '.dxkit/reports/graph.json';
 
 export type GraphNodeKind = 'function' | 'class' | 'method' | 'module';
 
-export type GraphEdgeRelation = 'calls' | 'imports_from' | 'method';
+export type GraphEdgeRelation = 'calls' | 'imports_from' | 'method' | 'calls-endpoint';
 
 export type ExportDetectionReliability = 'full' | 'partial' | 'unreliable';
 
@@ -57,6 +65,14 @@ export interface GraphNode {
  * for `calls` edges; `importedSymbol` only populated for
  * `imports_from` edges when graphify surfaces the per-symbol info
  * (today: omitted; reserved for future graphify extension).
+ *
+ * `fromFile` / `fromLine` are populated ONLY on `calls-endpoint` edges
+ * (the flow overlay): they carry the consuming call site's source
+ * coordinates directly on the edge. When graphify is present the flow
+ * writer resolves `from` to the enclosing structural node id (linking the
+ * consumer into the real call graph for multi-hop blast radius); when it
+ * is absent `from` is the empty string and these coordinates are the only
+ * consumer anchor — which is what keeps the flow map graphify-independent.
  */
 export interface GraphEdge {
   readonly from: string;
@@ -64,6 +80,33 @@ export interface GraphEdge {
   readonly relation: GraphEdgeRelation;
   readonly occurrences?: number;
   readonly importedSymbol?: string;
+  readonly fromFile?: string;
+  readonly fromLine?: number;
+}
+
+/**
+ * An HTTP endpoint a service serves — one per distinct `(method, path)`
+ * a backend exposes. The `to` end of every `calls-endpoint` edge. Lives
+ * in the separate `GraphJson.endpoints` overlay rather than in `nodes`,
+ * so the four structural node kinds (and every query that switches on
+ * them) stay untouched by the flow layer.
+ *
+ * `method` / `path` are the NORMALIZED join key (`GET`, `/articles/{var}`)
+ * — the same canonical form a client call reduces to, so the two sides
+ * meet on `${method} ${path}`. `via` records discovery provenance
+ * (source decorator, Express-style route call, or an ingested spec);
+ * `handler` is the best-effort handler symbol when known.
+ */
+export interface HttpEndpointNode {
+  readonly id: string;
+  readonly kind: 'http-endpoint';
+  readonly label: string;
+  readonly method: string;
+  readonly path: string;
+  readonly via: 'decorator' | 'router-call' | 'spec';
+  readonly handler: string | null;
+  readonly sourceFile: string;
+  readonly line?: number;
 }
 
 /**
@@ -114,6 +157,12 @@ export interface GraphMeta {
 /**
  * The on-disk wire format. `schemaVersion` at root level
  * matches the existing `StructuralResult` envelope pattern.
+ *
+ * `endpoints` is the v2 flow overlay: absent in a v1 artifact (the
+ * loader migrates it to `[]`), present-but-possibly-empty in v2. The
+ * `calls-endpoint` edges that reference these endpoints live in the
+ * normal `edges` array (relation-filtered, so they never leak into a
+ * structural `calls` / `imports_from` traversal).
  */
 export interface GraphJson {
   readonly schemaVersion: number;
@@ -122,6 +171,7 @@ export interface GraphJson {
   readonly edges: ReadonlyArray<GraphEdge>;
   readonly communities: ReadonlyArray<Community>;
   readonly symbolIndex: SymbolIndex;
+  readonly endpoints: ReadonlyArray<HttpEndpointNode>;
 }
 
 /**
@@ -138,4 +188,8 @@ export interface Graph extends GraphJson {
   readonly nodesByFile: ReadonlyMap<string, ReadonlyArray<GraphNode>>;
   readonly communityById: ReadonlyMap<number, Community>;
   readonly communityByNode: ReadonlyMap<string, Community>;
+  /** The flow overlay, indexed by endpoint id. */
+  readonly endpointById: ReadonlyMap<string, HttpEndpointNode>;
+  /** The flow overlay, indexed by the `${method} ${path}` join key. */
+  readonly endpointByKey: ReadonlyMap<string, HttpEndpointNode>;
 }

--- a/src/flow-cli.ts
+++ b/src/flow-cli.ts
@@ -9,7 +9,8 @@ import * as path from 'path';
 import * as logger from './logger';
 import { gatherFlowModel } from './analyzers/flow/gather';
 import { flowCsvFiles } from './analyzers/flow/csv';
-import { summarize } from './analyzers/flow/model';
+import { summarize, type FlowModel } from './analyzers/flow/model';
+import { buildFlowMap, buildFlowTrace } from './explore/flow-view';
 
 export interface FlowExtractOptions {
   readonly cwd: string;
@@ -18,6 +19,15 @@ export interface FlowExtractOptions {
   /** Comma-separated OpenAPI spec paths (served side, unioned with static). */
   readonly specs?: string;
   readonly out?: string;
+  readonly json?: boolean;
+}
+
+/** Shared options for the graph-backed `flow` / `flow trace` views. */
+export interface FlowViewOptions {
+  readonly cwd: string;
+  readonly frontend?: string;
+  readonly backend?: string;
+  readonly specs?: string;
   readonly json?: boolean;
 }
 
@@ -35,6 +45,16 @@ function readStripPrefixes(cwd: string): string[] {
   }
 }
 
+/**
+ * Emit a machine payload to stdout. In `--json` mode cli.ts routes all logger
+ * prose to stderr (`setJsonMode`), so the JSON contract requires writing the
+ * payload straight to stdout — never through the logger, which would land it on
+ * stderr and corrupt the contract. Mirrors the allowlist / reviewers CLIs.
+ */
+function emitJson(payload: unknown): void {
+  process.stdout.write(JSON.stringify(payload) + '\n');
+}
+
 function splitPaths(value: string | undefined, cwd: string): string[] {
   return (value ?? '')
     .split(',')
@@ -43,18 +63,27 @@ function splitPaths(value: string | undefined, cwd: string): string[] {
     .map((s) => path.resolve(cwd, s));
 }
 
-export async function runFlowExtract(opts: FlowExtractOptions): Promise<void> {
+/** Resolve scan roots from --frontend/--backend, defaulting to cwd (monorepo). */
+function resolveRoots(opts: { cwd: string; frontend?: string; backend?: string }): string[] {
   const roots: string[] = [];
   if (opts.frontend) roots.push(path.resolve(opts.cwd, opts.frontend));
   if (opts.backend) roots.push(path.resolve(opts.cwd, opts.backend));
-  if (roots.length === 0) roots.push(opts.cwd); // monorepo default: scan cwd
+  if (roots.length === 0) roots.push(opts.cwd);
+  return roots;
+}
 
-  logger.header('vyuh-dxkit flow extract');
-  const model = await gatherFlowModel({
-    roots,
+/** Gather one flow model — shared by extract / map / trace. */
+async function gatherModel(opts: FlowViewOptions): Promise<FlowModel> {
+  return gatherFlowModel({
+    roots: resolveRoots(opts),
     specs: splitPaths(opts.specs, opts.cwd),
     stripUrlPrefixes: readStripPrefixes(opts.cwd),
   });
+}
+
+export async function runFlowExtract(opts: FlowExtractOptions): Promise<void> {
+  logger.header('vyuh-dxkit flow extract');
+  const model = await gatherModel(opts);
   const summary = summarize(model);
 
   const outDir = path.resolve(opts.cwd, opts.out ?? 'csv_output');
@@ -65,7 +94,7 @@ export async function runFlowExtract(opts: FlowExtractOptions): Promise<void> {
   }
 
   if (opts.json) {
-    logger.info(JSON.stringify({ ...summary, outDir, files: Object.keys(files) }));
+    emitJson({ ...summary, outDir, files: Object.keys(files) });
     return;
   }
   const pct = summary.calls ? Math.round((100 * summary.resolved) / summary.calls) : 0;
@@ -73,4 +102,92 @@ export async function runFlowExtract(opts: FlowExtractOptions): Promise<void> {
     `${summary.calls} client calls, ${summary.routes} routes · ${summary.resolved}/${summary.calls} bound (${pct}%)`,
   );
   logger.info(`CSVs written to ${outDir} — ${Object.keys(files).join(', ')}`);
+}
+
+/**
+ * `vyuh-dxkit flow` — the traceability map. Writes the flow overlay onto
+ * graph.json (the native artifact the dashboard + gate also read) and prints
+ * every served endpoint with how many UI surfaces consume it, plus the
+ * served-but-unconsumed set (dead-route or cross-repo candidates).
+ */
+export async function runFlowMap(opts: FlowViewOptions): Promise<void> {
+  if (!opts.json) logger.header('vyuh-dxkit flow');
+  const model = await gatherModel(opts);
+  const map = buildFlowMap(opts.cwd, model);
+
+  if (opts.json) {
+    emitJson(map);
+    return;
+  }
+
+  logger.success(
+    `${map.totalEndpoints} endpoints · ${map.totalBindings} UI→API bindings · ${map.unconsumedEndpoints.length} unconsumed`,
+  );
+  if (map.endpoints.length) {
+    logger.info('');
+    logger.info('Consumed endpoints (by UI surfaces):');
+    for (const row of map.endpoints) {
+      const files = row.consumerFiles.slice(0, 3).join(', ');
+      const more = row.consumerFiles.length > 3 ? ` +${row.consumerFiles.length - 3} more` : '';
+      logger.info(`  ${row.endpoint.label}  ← ${row.consumerCount} call(s): ${files}${more}`);
+    }
+  }
+  if (map.unconsumedEndpoints.length) {
+    logger.info('');
+    logger.info('Served but unconsumed (dead route or cross-repo consumer):');
+    for (const ep of map.unconsumedEndpoints.slice(0, 20)) {
+      logger.info(`  ${ep.label}`);
+    }
+    if (map.unconsumedEndpoints.length > 20) {
+      logger.info(`  … and ${map.unconsumedEndpoints.length - 20} more`);
+    }
+  }
+  logger.info('');
+  logger.info('Trace one: vyuh-dxkit flow trace "<METHOD> <path>"');
+}
+
+/**
+ * `vyuh-dxkit flow trace "<METHOD> <path>"` — the full trace for one endpoint:
+ * its served-side handler + every UI call site + the change blast radius.
+ */
+export async function runFlowTrace(opts: FlowViewOptions & { target: string }): Promise<void> {
+  if (!opts.json) logger.header('vyuh-dxkit flow trace');
+  const model = await gatherModel(opts);
+  const { trace, candidates } = buildFlowTrace(opts.cwd, model, opts.target);
+
+  if (opts.json) {
+    emitJson({ trace, candidates });
+    return;
+  }
+
+  if (!trace.found || !trace.endpoint) {
+    logger.fail(`No endpoint matches "${opts.target}".`);
+    if (candidates.length) {
+      logger.info('Known endpoints:');
+      for (const c of candidates.slice(0, 20)) logger.info(`  ${c}`);
+      if (candidates.length > 20) logger.info(`  … and ${candidates.length - 20} more`);
+    }
+    return;
+  }
+
+  const ep = trace.endpoint;
+  logger.success(ep.label);
+  logger.info(`  handler: ${trace.handler ?? '(unknown)'}  ·  via: ${ep.via}`);
+  logger.info(`  served at: ${ep.sourceFile}${ep.line ? `:${ep.line}` : ''}`);
+  logger.info('');
+  if (trace.consumers.length) {
+    logger.info(`Consumed by ${trace.consumers.length} UI call site(s):`);
+    for (const c of trace.consumers) {
+      const sym = c.symbol ? `${c.symbol}  ` : '';
+      logger.info(`  ${sym}${c.file}${c.line ? `:${c.line}` : ''}`);
+    }
+  } else {
+    logger.info('No UI call site in this scan consumes it.');
+  }
+  const br = trace.blastRadius;
+  logger.info('');
+  logger.info(
+    `Blast radius: ${br.directConsumers} direct consumer(s) in ${br.consumerFiles} file(s)` +
+      (br.upstreamCallers ? `, ${br.upstreamCallers} upstream caller(s)` : ''),
+  );
 }

--- a/test/dashboard/graph-adapter.test.ts
+++ b/test/dashboard/graph-adapter.test.ts
@@ -70,6 +70,7 @@ function makeGraph(nodes: GraphNode[], edges: GraphEdge[], communities: Communit
     edges,
     communities,
     symbolIndex: {} as SymbolIndex,
+    endpoints: [],
   };
 
   return {
@@ -80,6 +81,8 @@ function makeGraph(nodes: GraphNode[], edges: GraphEdge[], communities: Communit
     nodesByFile,
     communityById,
     communityByNode,
+    endpointById: new Map(),
+    endpointByKey: new Map(),
   };
 }
 

--- a/test/explore/cli/context.test.ts
+++ b/test/explore/cli/context.test.ts
@@ -61,6 +61,7 @@ function makeGraph(
     edges,
     communities,
     symbolIndex,
+    endpoints: [],
   };
   return {
     ...json,
@@ -70,6 +71,8 @@ function makeGraph(
     nodesByFile,
     communityById,
     communityByNode,
+    endpointById: new Map(),
+    endpointByKey: new Map(),
   };
 }
 

--- a/test/explore/context-query.test.ts
+++ b/test/explore/context-query.test.ts
@@ -63,6 +63,7 @@ function makeGraph(
     edges,
     communities,
     symbolIndex,
+    endpoints: [],
   };
 
   return {
@@ -73,6 +74,8 @@ function makeGraph(
     nodesByFile,
     communityById,
     communityByNode,
+    endpointById: new Map(),
+    endpointByKey: new Map(),
   };
 }
 

--- a/test/explore/file-line-context.test.ts
+++ b/test/explore/file-line-context.test.ts
@@ -49,6 +49,7 @@ function makeGraph(nodes: GraphNode[], edges: GraphEdge[], communities: Communit
     edges,
     communities,
     symbolIndex: {},
+    endpoints: [],
   };
 
   return {
@@ -59,6 +60,8 @@ function makeGraph(nodes: GraphNode[], edges: GraphEdge[], communities: Communit
     nodesByFile,
     communityById,
     communityByNode,
+    endpointById: new Map(),
+    endpointByKey: new Map(),
   };
 }
 

--- a/test/explore/flow-graph.test.ts
+++ b/test/explore/flow-graph.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for src/explore/flow-graph.ts — the flow → graph overlay writer.
+ * Covers the pure builder (endpoint dedup, spec-wins provenance, one edge per
+ * resolved binding, `from` anchoring with/without a base graph), the merge
+ * (structural base preserved + overlay appended; skeleton when graphify absent),
+ * and the write → loadGraph round-trip (the artifact is a valid v2 graph).
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildFlowContribution,
+  mergeFlowIntoGraph,
+  writeFlowGraph,
+} from '../../src/explore/flow-graph';
+import { loadGraph } from '../../src/explore/load';
+import { GRAPH_REPORT_PATH, type Graph, type GraphNode } from '../../src/explore/types';
+import type { ClientCall, RouteEndpoint } from '../../src/analyzers/flow/extract';
+import type { FlowModel } from '../../src/analyzers/flow/model';
+
+function call(over: Partial<ClientCall> = {}): ClientCall {
+  return {
+    method: 'GET',
+    rawUrl: '/articles',
+    path: '/articles',
+    receiver: 'axios',
+    file: 'web/List.tsx',
+    line: 20,
+    ...over,
+  };
+}
+
+function route(over: Partial<RouteEndpoint> = {}): RouteEndpoint {
+  return {
+    method: 'GET',
+    path: '/articles',
+    via: 'router-call',
+    handler: 'ArticleController.find',
+    file: 'api/articles.ts',
+    line: 5,
+    ...over,
+  };
+}
+
+/** A minimal FlowModel from calls + routes, joining on the (method, path) key. */
+function model(calls: ClientCall[], routes: RouteEndpoint[]): FlowModel {
+  const index = new Map(routes.map((r) => [`${r.method} ${r.path}`, r]));
+  const bindings = calls.map((c) => {
+    const r = c.path == null ? null : (index.get(`${c.method} ${c.path}`) ?? null);
+    return {
+      call: c,
+      route: r,
+      confidence: r ? 1 : 0,
+      reason: r ? ('exact' as const) : ('no-route' as const),
+    };
+  });
+  return { calls, routes, bindings };
+}
+
+/** A tiny indexed base graph with one function node in web/List.tsx. */
+function baseGraph(): Graph {
+  const nodes: GraphNode[] = [
+    { id: 'n0', kind: 'module', label: 'web/List.tsx', sourceFile: 'web/List.tsx' },
+    { id: 'n1', kind: 'function', label: 'List()', sourceFile: 'web/List.tsx', line: 10 },
+  ];
+  const nodesByFile = new Map<string, GraphNode[]>([['web/List.tsx', nodes]]);
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
+  return {
+    schemaVersion: 2,
+    meta: {
+      tool: 'graphify',
+      graphifyVersion: '',
+      dxkitVersion: '2.20.0',
+      generatedAt: '',
+      sourceFilesInGraph: 1,
+      excludedFileCount: 0,
+      packs: ['typescript'],
+      truncated: false,
+      truncatedReason: '',
+    },
+    nodes,
+    edges: [{ from: 'n0', to: 'n1', relation: 'method' }],
+    communities: [],
+    symbolIndex: { list: ['n1'] },
+    endpoints: [],
+    nodeById,
+    edgesFromNode: new Map([['n0', [{ from: 'n0', to: 'n1', relation: 'method' }]]]),
+    edgesToNode: new Map([['n1', [{ from: 'n0', to: 'n1', relation: 'method' }]]]),
+    nodesByFile,
+    communityById: new Map(),
+    communityByNode: new Map(),
+    endpointById: new Map(),
+    endpointByKey: new Map(),
+  };
+}
+
+describe('buildFlowContribution', () => {
+  it('creates one endpoint per distinct (method, path) and one edge per resolved binding', () => {
+    const m = model([call(), call({ method: 'POST', path: '/articles', line: 30 })], [route()]);
+    const { endpoints, edges } = buildFlowContribution(m);
+
+    expect(endpoints).toHaveLength(1);
+    expect(endpoints[0]).toMatchObject({ kind: 'http-endpoint', method: 'GET', path: '/articles' });
+    // GET binding resolved → one edge; POST call has no route → no edge.
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      to: 'ep0',
+      relation: 'calls-endpoint',
+      fromFile: 'web/List.tsx',
+      fromLine: 20,
+    });
+  });
+
+  it('dedups a route surfaced twice, with spec provenance winning', () => {
+    const m = model(
+      [call()],
+      [route({ via: 'router-call' }), route({ via: 'spec', handler: 'spec.find' })],
+    );
+    const { endpoints } = buildFlowContribution(m);
+    expect(endpoints).toHaveLength(1);
+    expect(endpoints[0].via).toBe('spec');
+    expect(endpoints[0].handler).toBe('spec.find');
+  });
+
+  it('anchors the edge `from` onto the enclosing node when a base graph is present', () => {
+    const m = model([call({ line: 20 })], [route()]);
+    const { edges } = buildFlowContribution(m, baseGraph());
+    // web/List.tsx has List() @10 — the call @20 is inside it → n1.
+    expect(edges[0].from).toBe('n1');
+    // Coordinates still ride on the edge regardless.
+    expect(edges[0].fromFile).toBe('web/List.tsx');
+  });
+
+  it('leaves `from` empty when no base graph resolves the call site', () => {
+    const m = model([call()], [route()]);
+    const { edges } = buildFlowContribution(m);
+    expect(edges[0].from).toBe('');
+  });
+});
+
+describe('mergeFlowIntoGraph', () => {
+  it('preserves structural nodes/edges and appends the overlay (schema v2)', () => {
+    const merged = mergeFlowIntoGraph(baseGraph(), model([call()], [route()]));
+    expect(merged.schemaVersion).toBe(2);
+    expect(merged.nodes).toHaveLength(2); // structural preserved
+    expect(merged.endpoints).toHaveLength(1);
+    // one structural 'method' edge + one 'calls-endpoint' edge
+    expect(merged.edges).toHaveLength(2);
+    expect(merged.edges.some((e) => e.relation === 'calls-endpoint')).toBe(true);
+  });
+
+  it('produces a minimal v2 skeleton when no base graph exists', () => {
+    const merged = mergeFlowIntoGraph(undefined, model([call()], [route()]));
+    expect(merged.schemaVersion).toBe(2);
+    expect(merged.nodes).toHaveLength(0);
+    expect(merged.endpoints).toHaveLength(1);
+    expect(merged.edges).toHaveLength(1);
+    expect(merged.edges[0].from).toBe(''); // no base → coordinates-only anchor
+  });
+});
+
+describe('writeFlowGraph', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-flowgraph-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes a v2 artifact that loadGraph reads back with a populated overlay', () => {
+    writeFlowGraph(tmpDir, model([call()], [route()]));
+    expect(fs.existsSync(path.join(tmpDir, GRAPH_REPORT_PATH))).toBe(true);
+
+    const g = loadGraph(tmpDir);
+    expect(g.schemaVersion).toBe(2);
+    expect(g.endpoints).toHaveLength(1);
+    expect(g.endpointByKey.get('GET /articles')?.id).toBe('ep0');
+    expect(g.edgesToNode.get('ep0')?.[0].relation).toBe('calls-endpoint');
+  });
+
+  it('composes onto an existing graphify base already on disk', () => {
+    // Seed a v1 graphify artifact, then merge the flow overlay onto it.
+    const dir = path.join(tmpDir, path.dirname(GRAPH_REPORT_PATH));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, GRAPH_REPORT_PATH),
+      JSON.stringify({
+        schemaVersion: 1,
+        meta: {
+          tool: 'graphify',
+          graphifyVersion: '',
+          dxkitVersion: '2.20.0',
+          generatedAt: '',
+          sourceFilesInGraph: 1,
+          excludedFileCount: 0,
+          packs: ['typescript'],
+          truncated: false,
+          truncatedReason: '',
+        },
+        nodes: [
+          { id: 'n0', kind: 'module', label: 'web/List.tsx', sourceFile: 'web/List.tsx' },
+          { id: 'n1', kind: 'function', label: 'List()', sourceFile: 'web/List.tsx', line: 10 },
+        ],
+        edges: [{ from: 'n0', to: 'n1', relation: 'method' }],
+        communities: [],
+        symbolIndex: {},
+      }),
+    );
+
+    writeFlowGraph(tmpDir, model([call({ line: 20 })], [route()]));
+    const g = loadGraph(tmpDir);
+    expect(g.schemaVersion).toBe(2);
+    expect(g.nodes).toHaveLength(2); // graphify base preserved
+    expect(g.endpoints).toHaveLength(1);
+    // The overlay edge anchored onto the base's List() node.
+    expect(g.edgesToNode.get('ep0')?.[0].from).toBe('n1');
+  });
+});

--- a/test/explore/flow-graph.test.ts
+++ b/test/explore/flow-graph.test.ts
@@ -181,6 +181,16 @@ describe('writeFlowGraph', () => {
     expect(g.edgesToNode.get('ep0')?.[0].relation).toBe('calls-endpoint');
   });
 
+  it('is idempotent — re-running does not accumulate duplicate overlay edges', () => {
+    const m = model([call({ line: 20 })], [route()]);
+    writeFlowGraph(tmpDir, m);
+    writeFlowGraph(tmpDir, m); // second run reads the first run's overlay as base
+    const g = loadGraph(tmpDir);
+    // Exactly one endpoint + one calls-endpoint edge, not two.
+    expect(g.endpoints).toHaveLength(1);
+    expect(g.edges.filter((e) => e.relation === 'calls-endpoint')).toHaveLength(1);
+  });
+
   it('composes onto an existing graphify base already on disk', () => {
     // Seed a v1 graphify artifact, then merge the flow overlay onto it.
     const dir = path.join(tmpDir, path.dirname(GRAPH_REPORT_PATH));

--- a/test/explore/flow-queries.test.ts
+++ b/test/explore/flow-queries.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for the v2 flow queries in src/explore/queries.ts:
+ * endpointCallers, flowBlastRadius, flowTrace, flowMapQuery. Fixtures are built
+ * by writing a merged v2 graph to disk and reading it back through loadGraph, so
+ * the tests exercise the same indexing path production uses.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { writeFlowGraph } from '../../src/explore/flow-graph';
+import { loadGraph } from '../../src/explore/load';
+import {
+  endpointCallers,
+  flowBlastRadius,
+  flowTrace,
+  flowMapQuery,
+} from '../../src/explore/queries';
+import { GRAPH_REPORT_PATH, type Graph } from '../../src/explore/types';
+import type { ClientCall, RouteEndpoint } from '../../src/analyzers/flow/extract';
+import type { FlowModel } from '../../src/analyzers/flow/model';
+
+function call(over: Partial<ClientCall>): ClientCall {
+  return {
+    method: 'GET',
+    rawUrl: '/x',
+    path: '/x',
+    receiver: 'axios',
+    file: 'web/a.tsx',
+    line: 10,
+    ...over,
+  };
+}
+
+function route(over: Partial<RouteEndpoint>): RouteEndpoint {
+  return {
+    method: 'GET',
+    path: '/x',
+    via: 'router-call',
+    handler: 'h',
+    file: 'api/x.ts',
+    line: 1,
+    ...over,
+  };
+}
+
+function model(calls: ClientCall[], routes: RouteEndpoint[]): FlowModel {
+  const index = new Map(routes.map((r) => [`${r.method} ${r.path}`, r]));
+  const bindings = calls.map((c) => {
+    const r = c.path == null ? null : (index.get(`${c.method} ${c.path}`) ?? null);
+    return {
+      call: c,
+      route: r,
+      confidence: r ? 1 : 0,
+      reason: r ? ('exact' as const) : ('no-route' as const),
+    };
+  });
+  return { calls, routes, bindings };
+}
+
+let tmpDir: string;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-flowq-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Seed a graphify base with a call graph so upstream blast radius has edges,
+ *  then merge the flow overlay and load the result. */
+function graphWithBase(m: FlowModel): Graph {
+  fs.mkdirSync(path.join(tmpDir, path.dirname(GRAPH_REPORT_PATH)), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, GRAPH_REPORT_PATH),
+    JSON.stringify({
+      schemaVersion: 1,
+      meta: {
+        tool: 'graphify',
+        graphifyVersion: '',
+        dxkitVersion: '2.20.0',
+        generatedAt: '',
+        sourceFilesInGraph: 2,
+        excludedFileCount: 0,
+        packs: ['typescript'],
+        truncated: false,
+        truncatedReason: '',
+      },
+      nodes: [
+        { id: 'n0', kind: 'module', label: 'web/a.tsx', sourceFile: 'web/a.tsx' },
+        { id: 'n1', kind: 'function', label: 'ArticleList()', sourceFile: 'web/a.tsx', line: 5 },
+        { id: 'n2', kind: 'function', label: 'Page()', sourceFile: 'web/page.tsx', line: 3 },
+      ],
+      // Page() calls ArticleList() — upstream caller of the consuming node.
+      edges: [{ from: 'n2', to: 'n1', relation: 'calls' }],
+      communities: [],
+      symbolIndex: {},
+    }),
+  );
+  writeFlowGraph(tmpDir, m);
+  return loadGraph(tmpDir);
+}
+
+describe('endpointCallers', () => {
+  it('returns each consuming call site, anchored to its enclosing symbol', () => {
+    const g = graphWithBase(model([call({ line: 10 })], [route({})]));
+    const [ep] = g.endpoints;
+    const callers = endpointCallers(g, ep.id);
+    expect(callers).toHaveLength(1);
+    expect(callers[0]).toMatchObject({ file: 'web/a.tsx', line: 10, symbol: 'ArticleList' });
+    expect(callers[0].nodeId).toBe('n1');
+  });
+
+  it('populates file/line even with no base graph (graphify-independent)', () => {
+    writeFlowGraph(tmpDir, model([call({ line: 42 })], [route({})]));
+    const g = loadGraph(tmpDir);
+    const callers = endpointCallers(g, g.endpoints[0].id);
+    expect(callers[0]).toMatchObject({ file: 'web/a.tsx', line: 42 });
+    expect(callers[0].nodeId).toBeUndefined();
+  });
+});
+
+describe('flowBlastRadius', () => {
+  it('counts direct consumers + transitive upstream callers through the call graph', () => {
+    const g = graphWithBase(model([call({ line: 10 })], [route({})]));
+    const br = flowBlastRadius(g, g.endpoints[0].id);
+    expect(br.directConsumers).toBe(1);
+    expect(br.consumerFiles).toBe(1);
+    // Page() (n2) calls ArticleList() (n1, the consumer) → one upstream caller.
+    expect(br.upstreamCallers).toBe(1);
+    expect(br.upstreamFiles).toBe(1);
+  });
+
+  it('reports zero upstream when there is no base call graph', () => {
+    writeFlowGraph(tmpDir, model([call({})], [route({})]));
+    const g = loadGraph(tmpDir);
+    const br = flowBlastRadius(g, g.endpoints[0].id);
+    expect(br.directConsumers).toBe(1);
+    expect(br.upstreamCallers).toBe(0);
+  });
+});
+
+describe('flowTrace', () => {
+  it('returns endpoint identity + handler + consumers for a known endpoint', () => {
+    const g = graphWithBase(model([call({})], [route({ handler: 'ArticleController.find' })]));
+    const trace = flowTrace(g, g.endpoints[0].id);
+    expect(trace.found).toBe(true);
+    expect(trace.handler).toBe('ArticleController.find');
+    expect(trace.consumers).toHaveLength(1);
+  });
+
+  it('reports not-found for an unknown endpoint id', () => {
+    writeFlowGraph(tmpDir, model([call({})], [route({})]));
+    const g = loadGraph(tmpDir);
+    const trace = flowTrace(g, 'ep999');
+    expect(trace.found).toBe(false);
+    expect(trace.consumers).toEqual([]);
+  });
+});
+
+describe('flowMapQuery', () => {
+  it('ranks consumed endpoints and separates the served-but-unconsumed set', () => {
+    const m = model(
+      [call({ path: '/x' }), call({ path: '/x', file: 'web/b.tsx', line: 7 })],
+      [route({ path: '/x' }), route({ path: '/orphan', handler: 'orphan' })],
+    );
+    writeFlowGraph(tmpDir, m);
+    const g = loadGraph(tmpDir);
+    const map = flowMapQuery(g);
+
+    expect(map.totalEndpoints).toBe(2);
+    expect(map.totalBindings).toBe(2);
+    expect(map.endpoints).toHaveLength(1);
+    expect(map.endpoints[0]).toMatchObject({ consumerCount: 2 });
+    expect(map.endpoints[0].consumerFiles).toEqual(['web/a.tsx', 'web/b.tsx']);
+    // /orphan is served but nothing calls it in this graph.
+    expect(map.unconsumedEndpoints.map((e) => e.path)).toEqual(['/orphan']);
+  });
+});

--- a/test/explore/flow-view.test.ts
+++ b/test/explore/flow-view.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for src/explore/flow-view.ts — the read-side orchestration the flow CLI
+ * consumes (write overlay → reload → query). Exercised with a synthetic model
+ * against a temp cwd, so no gather / source parsing is involved.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { buildFlowMap, buildFlowTrace } from '../../src/explore/flow-view';
+import type { ClientCall, RouteEndpoint } from '../../src/analyzers/flow/extract';
+import type { FlowModel } from '../../src/analyzers/flow/model';
+
+function model(calls: ClientCall[], routes: RouteEndpoint[]): FlowModel {
+  const index = new Map(routes.map((r) => [`${r.method} ${r.path}`, r]));
+  const bindings = calls.map((c) => {
+    const r = c.path == null ? null : (index.get(`${c.method} ${c.path}`) ?? null);
+    return {
+      call: c,
+      route: r,
+      confidence: r ? 1 : 0,
+      reason: r ? ('exact' as const) : ('no-route' as const),
+    };
+  });
+  return { calls, routes, bindings };
+}
+
+const CALL: ClientCall = {
+  method: 'GET',
+  rawUrl: '/articles',
+  path: '/articles',
+  receiver: 'axios',
+  file: 'web/List.tsx',
+  line: 20,
+};
+const ROUTE: RouteEndpoint = {
+  method: 'GET',
+  path: '/articles',
+  via: 'router-call',
+  handler: 'ArticleController.find',
+  file: 'api/articles.ts',
+  line: 5,
+};
+
+let tmpDir: string;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-flowview-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('buildFlowMap', () => {
+  it('writes the overlay and returns the queried map', () => {
+    const map = buildFlowMap(tmpDir, model([CALL], [ROUTE]));
+    expect(map.totalEndpoints).toBe(1);
+    expect(map.totalBindings).toBe(1);
+    expect(map.endpoints[0].consumerCount).toBe(1);
+    // The graph artifact was persisted.
+    expect(fs.existsSync(path.join(tmpDir, '.dxkit/reports/graph.json'))).toBe(true);
+  });
+});
+
+describe('buildFlowTrace', () => {
+  it('resolves by exact join key and returns the trace', () => {
+    const { trace, candidates } = buildFlowTrace(tmpDir, model([CALL], [ROUTE]), 'GET /articles');
+    expect(trace.found).toBe(true);
+    expect(trace.handler).toBe('ArticleController.find');
+    expect(candidates).toEqual([]);
+  });
+
+  it('resolves a method-lowercased key (pasted verbatim from a user)', () => {
+    const { trace } = buildFlowTrace(tmpDir, model([CALL], [ROUTE]), 'get /articles');
+    expect(trace.found).toBe(true);
+  });
+
+  it('resolves by endpoint id', () => {
+    const { trace } = buildFlowTrace(tmpDir, model([CALL], [ROUTE]), 'ep0');
+    expect(trace.found).toBe(true);
+  });
+
+  it('returns not-found with candidate labels for an unknown target', () => {
+    const { trace, candidates } = buildFlowTrace(tmpDir, model([CALL], [ROUTE]), 'GET /nope');
+    expect(trace.found).toBe(false);
+    expect(candidates).toContain('GET /articles');
+  });
+});

--- a/test/explore/load.test.ts
+++ b/test/explore/load.test.ts
@@ -39,7 +39,7 @@ function writeGraphFixture(content: unknown) {
 }
 
 const validGraph = () => ({
-  schemaVersion: 1,
+  schemaVersion: 2,
   meta: {
     tool: 'graphify',
     graphifyVersion: '',
@@ -66,6 +66,7 @@ const validGraph = () => ({
   edges: [
     { from: 'n0', to: 'n1', relation: 'method' },
     { from: 'n1', to: 'n2', relation: 'calls' },
+    { from: 'n1', to: 'ep0', relation: 'calls-endpoint', fromFile: 'src/a.ts', fromLine: 6 },
   ],
   communities: [
     {
@@ -77,6 +78,18 @@ const validGraph = () => ({
     },
   ],
   symbolIndex: { foo: ['n1'], bar: ['n2'] },
+  endpoints: [
+    {
+      id: 'ep0',
+      kind: 'http-endpoint',
+      label: 'GET /articles/{var}',
+      method: 'GET',
+      path: '/articles/{var}',
+      via: 'spec',
+      handler: 'ArticleController.find',
+      sourceFile: 'openapi.json',
+    },
+  ],
 });
 
 describe('loadGraph', () => {
@@ -84,11 +97,62 @@ describe('loadGraph', () => {
     writeGraphFixture(validGraph());
     const g = loadGraph(tmpDir);
 
-    expect(g.schemaVersion).toBe(1);
+    expect(g.schemaVersion).toBe(2);
     expect(g.nodes).toHaveLength(3);
-    expect(g.edges).toHaveLength(2);
+    expect(g.edges).toHaveLength(3);
     expect(g.communities).toHaveLength(1);
     expect(Object.keys(g.symbolIndex)).toEqual(['foo', 'bar']);
+    expect(g.endpoints).toHaveLength(1);
+  });
+
+  it('builds endpointById + endpointByKey indices from the flow overlay', () => {
+    writeGraphFixture(validGraph());
+    const g = loadGraph(tmpDir);
+
+    expect(g.endpointById.size).toBe(1);
+    expect(g.endpointById.get('ep0')?.method).toBe('GET');
+    expect(g.endpointByKey.get('GET /articles/{var}')?.id).toBe('ep0');
+    expect(g.endpointByKey.get('POST /nope')).toBeUndefined();
+  });
+
+  it('indexes calls-endpoint edges into edgesFromNode / edgesToNode', () => {
+    writeGraphFixture(validGraph());
+    const g = loadGraph(tmpDir);
+
+    // The consumer's structural node links to the endpoint id.
+    const toEp = g.edgesToNode.get('ep0') ?? [];
+    expect(toEp).toHaveLength(1);
+    expect(toEp[0].relation).toBe('calls-endpoint');
+    expect(toEp[0].from).toBe('n1');
+    expect(toEp[0].fromFile).toBe('src/a.ts');
+    expect(toEp[0].fromLine).toBe(6);
+  });
+
+  it('migrates a v1 artifact (no endpoints field) forward to an empty overlay', () => {
+    const v1 = validGraph() as Record<string, unknown>;
+    v1.schemaVersion = 1;
+    delete v1.endpoints;
+    // Drop the v2-only calls-endpoint edge so the fixture is a clean v1 shape.
+    v1.edges = [
+      { from: 'n0', to: 'n1', relation: 'method' },
+      { from: 'n1', to: 'n2', relation: 'calls' },
+    ];
+    writeGraphFixture(v1);
+
+    const g = loadGraph(tmpDir);
+    expect(g.schemaVersion).toBe(1);
+    expect(g.endpoints).toEqual([]);
+    expect(g.endpointById.size).toBe(0);
+    expect(g.endpointByKey.size).toBe(0);
+  });
+
+  it('throws GraphCorruptError when endpoints is present but not an array', () => {
+    const bad = validGraph() as Record<string, unknown>;
+    bad.endpoints = { not: 'an array' };
+    writeGraphFixture(bad);
+
+    expect(() => loadGraph(tmpDir)).toThrow(GraphCorruptError);
+    expect(() => loadGraph(tmpDir)).toThrow(/endpoints/);
   });
 
   it('builds nodeById index keyed by node id', () => {

--- a/test/explore/queries.test.ts
+++ b/test/explore/queries.test.ts
@@ -80,6 +80,7 @@ function makeGraph(nodes: GraphNode[], edges: GraphEdge[], communities: Communit
     edges,
     communities,
     symbolIndex: {} as SymbolIndex,
+    endpoints: [],
   };
 
   return {
@@ -90,6 +91,8 @@ function makeGraph(nodes: GraphNode[], edges: GraphEdge[], communities: Communit
     nodesByFile,
     communityById,
     communityByNode,
+    endpointById: new Map(),
+    endpointByKey: new Map(),
   };
 }
 


### PR DESCRIPTION
## Flow feature — Milestone 2 (native flow map + cross-repo graph foundation)

Second slice of the Flow feature. M1 (2.19.0) shipped static UI→API extraction to CSVs; M2 makes that traceability a **first-class part of the code graph**, so a change's cross-boundary blast radius is a query, not a guess.

### What's new

- **Graph schema v2 — the endpoint overlay.** `graph.json` gains `http-endpoint` nodes (one per served `(method, path)`) and `calls-endpoint` edges (a UI call site → the endpoint it hits) — the cross-boundary join the structural graph could not previously express. Purely additive: a v1 artifact migrates forward to an empty overlay; every pre-flow query is untouched. The consuming call site's coordinates ride on the edge, so the map works even where graphify never ran — **the flow layer stays graphify-independent**.
- **`vyuh-dxkit flow`** — writes the overlay and prints every endpoint with its consuming UI surfaces + the served-but-unconsumed set (dead-route / cross-repo candidate, surfaced not flagged).
- **`vyuh-dxkit flow trace "<METHOD> <path>"`** — one endpoint's handler, every call site, and the change blast radius (direct consumers extended transitively through the structural call graph).
- Both take `--json`. New pure queries (`endpointCallers`, `flowTrace`, `flowBlastRadius`, `flowMapQuery`) in the canonical query module; the overlay is regenerated each run, never accumulated.
- **Advisory file-size budget** in the pre-commit slop check (warn-only, diff-scoped, exempts the architecturally-large modules).

### Architecture discipline

- Rule 12 honored: graph load + all traversal stay in `src/explore/` (`flow-graph.ts` writes the overlay, `flow-view.ts` orchestrates read, `queries.ts` owns every traversal). The CLI is pure I/O.
- The flow overlay and graphify's structural graph are disjoint contributors to one artifact — neither imports the other.

### Tests

- New: `flow-graph`, `flow-queries`, `flow-view` suites (36 assertions) covering the builder, merge, idempotency, queries, and the write→load round-trip. Loader migration + endpoint-index coverage added.
- Full suite green (2631 tests). Two correctness fixes surfaced by the CLI smoke test are included (overlay-accumulation idempotency; `--json` payload → stdout).

Merge strategy: **rebase** — six independently-meaningful commits (schema, builder, queries, hooks, CLI, release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)