### PR TITLE
Flow M3: the integration gate (2.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.21.0] - 2026-07-01
+
+### Added — the integration gate (`flow refresh` + guardrail flow pass)
+
+The Flow feature's third slice turns UI→API traceability into a guardrail: a PR
+that net-new breaks an integration — a frontend call to an endpoint no backend
+serves, or a backend route removal a consumer still binds to — fails the check,
+the same way a net-new secret or CVE does.
+
+- **Net-new broken-integration gate.** The guardrail check now runs an additive,
+  fail-open flow pass over its ref-based `base↔HEAD` comparison. One algorithm
+  covers both directions (dead frontend call / removed backend route), because
+  both reduce to "a consumed binding whose `(method, path)` is not served."
+  Pre-existing breakage is grandfathered — only what the diff *newly* breaks is
+  surfaced. It never touches the existing finding matcher.
+- **Confidence-gated, false-positive-safe.** An exact, fully specified binding
+  blocks; a placeholder-only path (`/{var}`) warns. The gate self-skips when it
+  has no served-side truth to check against (a pure frontend with no committed
+  contract), so it can never false-block a repo it can't fully see, and it fails
+  open on any error.
+- **`vyuh-dxkit flow refresh`** writes the cross-repo contract snapshots
+  (`.dxkit/flow/served.json` + `consumed.json`). A backend publishes what it
+  serves; a frontend commits the counterpart's snapshot and gates against it —
+  so a split-repo setup needs a cross-repo fetch only at refresh time, never on
+  a developer's machine or in the per-check gate. A monorepo gates live against
+  its own routes and needs no snapshot.
+- **Posture.** `.dxkit/policy.json:flow.mode` (`block` / `warn` / `off`, default
+  `block`) governs the verdict; the loop preset overrides it (`security-only`
+  warns, `full-debt` blocks) so an unattended loop can't wedge on a cross-repo
+  false positive. Broken integrations render in the console, `--json`, and
+  PR-comment markdown, and count toward the verdict banner.
+- Runs only in ref-based mode (committed mode has no base flow model to diff);
+  a diff that touches no client call, route, or spec is skipped up front.
+  Binding identity is line-independent and environment-independent, so a
+  committed contract keeps matching when the check moves from a laptop to CI.
+
 ## [2.20.0] - 2026-07-01
 
 ### Added — native flow map + blast radius (`flow`, `flow trace`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.20.0",
+      "version": "2.21.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1016,6 +1016,23 @@ if [ -n "$RULE13_SNAP" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# 13c (Flow M3): the cross-repo flow contract snapshots under `.dxkit/flow/`
+# are read/written only by src/analyzers/flow/contract.ts — the mirror of the
+# ingest-snapshot confinement. Keeps the served/consumed inventory (and a future
+# cross-repo fetch) composing on one primitive rather than drifting per module.
+RULE13_FLOW=$(grep -rnE "\.dxkit/flow|'\.dxkit',[[:space:]]*'flow'" src/ 2>/dev/null \
+  | grep -v "^src/analyzers/flow/contract.ts:" \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | grep -v 'logger\.' \
+  | grep -v "// flow-contract-ok")
+if [ -n "$RULE13_FLOW" ]; then
+  echo "❌ Rule 13 violation: .dxkit/flow contract accessed outside src/analyzers/flow/contract.ts:"
+  echo "$RULE13_FLOW"
+  echo "   → Use read/writeServed|ConsumedContract() from src/analyzers/flow/contract.ts."
+  echo "   → Annotate '// flow-contract-ok' for a justified exception."
+  ERRORS=$((ERRORS + 1))
+fi
+
 # Rule 14 (2.13.1 self-invocation class-fix): generated artifacts invoke the
 # dxkit CLI through ONE canonical helper, and every auto-running surface is
 # in ONE registry.

--- a/src/allowlist/categories.ts
+++ b/src/allowlist/categories.ts
@@ -138,6 +138,11 @@ export const CATEGORIES_BY_KIND: Readonly<Record<IdentityKind, readonly Allowlis
   // accepted-risk or deferred (the marker IS the hygiene issue)
   hygiene: ['accepted-risk', 'deferred'],
 
+  // Broken integration: false-positive (a cross-repo consumer exists that the
+  // scan didn't see, so the binding isn't actually dead); otherwise
+  // accepted-risk or deferred
+  'flow-binding': ['false-positive', 'accepted-risk', 'deferred'],
+
   // Stale-allow (orphaned inline allowlist annotation): never
   // allowlisted. The right response is always "remove the stale
   // annotation" — allowlisting the warning that an annotation is

--- a/src/allowlist/hint.ts
+++ b/src/allowlist/hint.ts
@@ -210,6 +210,13 @@ export function remediationFor(kind: BaselineEntry['kind']): string {
         'Allowlisting THIS finding is not supported; the only remediation is ' +
         'to delete the annotation comment.'
       );
+    case 'flow-binding':
+      return (
+        'A UI call no longer resolves to a served route (or a route a consumer ' +
+        'still binds to was removed). Restore the endpoint, fix the call to match ' +
+        'the current route, or — if a cross-repo consumer the scan cannot see is ' +
+        'intended — allowlist with category=false-positive.'
+      );
   }
 }
 
@@ -234,6 +241,7 @@ function entryLocator(entry: BaselineEntry): { file?: string; line?: number } {
     case 'config':
     case 'hygiene':
     case 'stale-allow':
+    case 'flow-binding':
       return { file: entry.file, line: entry.line };
     case 'coverage-gap':
     case 'test-gap':

--- a/src/analyzers/flow/config.ts
+++ b/src/analyzers/flow/config.ts
@@ -1,0 +1,81 @@
+/**
+ * Flow configuration read from `.dxkit/policy.json:flow` — the single reader of
+ * that section (Rule 2). Kept out of the shared `BrownfieldPolicy` schema (the
+ * same way the loop preset is read separately): the flow concept stays
+ * self-contained, and every flow surface — the `flow` CLI, the `flow refresh`
+ * snapshot writer, and the guardrail gate pass — resolves its config here.
+ *
+ * All fields are optional in the file; a missing / malformed policy yields the
+ * conservative defaults (fail-open), never a throw.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** How the guardrail treats a net-new broken integration.
+ *   - `block` (default): honor the per-finding verdict — an exact, fully
+ *     specified binding fails the build; a low-confidence (placeholder-only)
+ *     one warns.
+ *   - `warn`: every net-new break warns, never fails a build (soft launch, or
+ *     a repo still tuning its served-side inventory).
+ *   - `off`: the gate does not run at all. */
+export type FlowGateMode = 'block' | 'warn' | 'off';
+
+export interface FlowConfig {
+  /** Host-helper prefixes stripped during URL normalization (per-app config,
+   *  e.g. `["https://api.example.com"]`). */
+  readonly stripUrlPrefixes: string[];
+  /** OpenAPI/spec files whose served routes union with static extraction. */
+  readonly specs: string[];
+  /** Guardrail posture for net-new broken integrations. */
+  readonly mode: FlowGateMode;
+  /** Confidence at/above which a net-new break BLOCKS (else warns). Default 1 —
+   *  only exact, fully specified bindings can fail a build. */
+  readonly blockThreshold: number;
+}
+
+const DEFAULTS: FlowConfig = {
+  stripUrlPrefixes: [],
+  specs: [],
+  mode: 'block',
+  blockThreshold: 1,
+};
+
+interface RawFlow {
+  stripUrlPrefixes?: unknown;
+  specs?: unknown;
+  mode?: unknown;
+  blockThreshold?: unknown;
+}
+
+function stringList(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((s): s is string => typeof s === 'string') : [];
+}
+
+function isMode(v: unknown): v is FlowGateMode {
+  return v === 'block' || v === 'warn' || v === 'off';
+}
+
+/**
+ * Read the `flow` section of `.dxkit/policy.json`. Fail-open — a read/parse
+ * error, or an absent `flow` block, returns the defaults so a repo without flow
+ * config behaves as "monorepo, block on exact net-new breaks".
+ */
+export function readFlowConfig(cwd: string): FlowConfig {
+  let raw: RawFlow;
+  try {
+    const text = fs.readFileSync(path.join(cwd, '.dxkit', 'policy.json'), 'utf8');
+    raw = ((JSON.parse(text) as { flow?: RawFlow })?.flow ?? {}) as RawFlow;
+  } catch {
+    return DEFAULTS;
+  }
+  return {
+    stripUrlPrefixes: stringList(raw.stripUrlPrefixes),
+    specs: stringList(raw.specs),
+    mode: isMode(raw.mode) ? raw.mode : DEFAULTS.mode,
+    blockThreshold:
+      typeof raw.blockThreshold === 'number' && raw.blockThreshold > 0
+        ? raw.blockThreshold
+        : DEFAULTS.blockThreshold,
+  };
+}

--- a/src/analyzers/flow/contract.ts
+++ b/src/analyzers/flow/contract.ts
@@ -19,7 +19,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { dedupeServedRoutes, type FlowModel } from './model';
+import { dedupeServedRoutes, isPlaceholderOnlyPath, type FlowModel } from './model';
 
 /** Directory (relative to repo root) where flow contract snapshots live. */
 export const FLOW_DIR = path.join('.dxkit', 'flow');
@@ -36,12 +36,15 @@ export interface ServedRoute {
 
 /** One binding in the consumed-side inventory — a UI call site's dependency on
  *  a served `(method, path)`. `file` + the normalized key are the flow-binding
- *  identity inputs; `line` is display metadata (never hashed). */
+ *  identity inputs; `line` is display metadata (never hashed). `confidence` in
+ *  [0,1] is the path-specificity signal the gate thresholds on — a
+ *  placeholder-only path (`/{var}`) is too generic to block a build. */
 export interface ConsumedBinding {
   readonly method: string;
   readonly path: string;
   readonly file: string;
   readonly line: number;
+  readonly confidence: number;
 }
 
 interface SnapshotMeta {
@@ -97,7 +100,15 @@ export function buildConsumedContract(model: FlowModel, meta: SnapshotMeta): Con
     const key = `${call.method}\0${call.path}\0${call.file}`;
     const existing = byKey.get(key);
     if (!existing || call.line < existing.line) {
-      byKey.set(key, { method: call.method, path: call.path, file: call.file, line: call.line });
+      byKey.set(key, {
+        method: call.method,
+        path: call.path,
+        file: call.file,
+        line: call.line,
+        // A placeholder-only path carries no static signal → low confidence, so
+        // the gate warns rather than blocks on it.
+        confidence: isPlaceholderOnlyPath(call.path) ? 0.3 : 1,
+      });
     }
   }
   const bindings = [...byKey.values()].sort(

--- a/src/analyzers/flow/contract.ts
+++ b/src/analyzers/flow/contract.ts
@@ -1,0 +1,189 @@
+/**
+ * Cross-repo flow contract snapshots under `.dxkit/flow/`.
+ *
+ * The integration gate is cross-repo: each side publishes its inventory as a
+ * committed artifact the OTHER side gates against (mirror of the ingest
+ * snapshot pattern, CLAUDE.md Rule 13). A backend refreshes `served.json`
+ * (every `(method, path)` it serves); a frontend refreshes `consumed.json`
+ * (every binding it depends on). A repo commits the COUNTERPART's snapshot (or
+ * a monorepo computes both live), so the gate needs a cross-repo fetch/token
+ * only at refresh time — never on the developer's machine or in the per-stop
+ * gate.
+ *
+ * This module is the single reader/writer of `.dxkit/flow/`: confining the path
+ * here (arch-check enforced) stops the "different modules pick different
+ * defaults" drift class and keeps a future cross-repo fetch composing on one
+ * primitive. Snapshots carry only finding data (normalized method/path/file) —
+ * no token, no account id — so they are safe to commit.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { dedupeServedRoutes, type FlowModel } from './model';
+
+/** Directory (relative to repo root) where flow contract snapshots live. */
+export const FLOW_DIR = path.join('.dxkit', 'flow');
+export const SERVED_SNAPSHOT = 'served.json';
+export const CONSUMED_SNAPSHOT = 'consumed.json';
+
+/** One served endpoint in the served-side inventory. */
+export interface ServedRoute {
+  readonly method: string;
+  readonly path: string;
+  readonly handler: string | null;
+  readonly via: 'decorator' | 'router-call' | 'spec';
+}
+
+/** One binding in the consumed-side inventory — a UI call site's dependency on
+ *  a served `(method, path)`. `file` + the normalized key are the flow-binding
+ *  identity inputs; `line` is display metadata (never hashed). */
+export interface ConsumedBinding {
+  readonly method: string;
+  readonly path: string;
+  readonly file: string;
+  readonly line: number;
+}
+
+interface SnapshotMeta {
+  readonly schemaVersion: 1;
+  /** ISO timestamp, stamped by the caller so this module stays clock-free
+   *  (testability — mirror of ingest/snapshot.ts). */
+  readonly generatedAt: string;
+  /** Commit the snapshot was produced against, when known. */
+  readonly commitSha?: string;
+}
+
+export interface ServedContract extends SnapshotMeta {
+  readonly side: 'served';
+  readonly routes: ServedRoute[];
+}
+
+export interface ConsumedContract extends SnapshotMeta {
+  readonly side: 'consumed';
+  readonly bindings: ConsumedBinding[];
+}
+
+/** The `${method} ${path}` join key both sides meet on. */
+export function contractKey(method: string, routePath: string): string {
+  return `${method} ${routePath}`;
+}
+
+// ─── Build (from a flow model) ────────────────────────────────────────────────
+
+/**
+ * The served inventory: every distinct `(method, path)` this repo serves,
+ * deduped via the shared helper (spec wins). Sorted for byte-stable snapshots
+ * across runs (a committed artifact should not churn on extraction order).
+ */
+export function buildServedContract(model: FlowModel, meta: SnapshotMeta): ServedContract {
+  const routes = dedupeServedRoutes(model.routes)
+    .map((r) => ({ method: r.method, path: r.path, handler: r.handler, via: r.via }))
+    .sort(byMethodPath);
+  return { ...meta, side: 'served', routes };
+}
+
+/**
+ * The consumed inventory: every internal binding this repo depends on — each
+ * client call that resolved to an internal path (external/absolute URLs, whose
+ * `path` is null, are not internal integrations). Deduped by
+ * `(method, path, file)` — the flow-binding identity — so multiple call sites
+ * for one dependency collapse to one entry (the earliest line kept for
+ * display). Sorted for byte-stability.
+ */
+export function buildConsumedContract(model: FlowModel, meta: SnapshotMeta): ConsumedContract {
+  const byKey = new Map<string, ConsumedBinding>();
+  for (const call of model.calls) {
+    if (call.path == null) continue;
+    const key = `${call.method}\0${call.path}\0${call.file}`;
+    const existing = byKey.get(key);
+    if (!existing || call.line < existing.line) {
+      byKey.set(key, { method: call.method, path: call.path, file: call.file, line: call.line });
+    }
+  }
+  const bindings = [...byKey.values()].sort(
+    (a, b) => byMethodPath(a, b) || a.file.localeCompare(b.file),
+  );
+  return { ...meta, side: 'consumed', bindings };
+}
+
+function byMethodPath(
+  a: { method: string; path: string },
+  b: { method: string; path: string },
+): number {
+  return a.method.localeCompare(b.method) || a.path.localeCompare(b.path);
+}
+
+// ─── Persist ──────────────────────────────────────────────────────────────────
+
+/** Write the served snapshot (overwrite). Returns the file path. */
+export function writeServedContract(cwd: string, contract: ServedContract): string {
+  return writeSnapshot(cwd, SERVED_SNAPSHOT, contract);
+}
+
+/** Write the consumed snapshot (overwrite). Returns the file path. */
+export function writeConsumedContract(cwd: string, contract: ConsumedContract): string {
+  return writeSnapshot(cwd, CONSUMED_SNAPSHOT, contract);
+}
+
+function writeSnapshot(
+  cwd: string,
+  name: string,
+  contract: ServedContract | ConsumedContract,
+): string {
+  const dir = path.join(cwd, FLOW_DIR);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, JSON.stringify(contract, null, 2) + '\n', 'utf-8');
+  return file;
+}
+
+// ─── Load (fail-open) ───────────────────────────────────────────────────────
+
+/**
+ * Read the served snapshot from a repo root (default `.dxkit/flow/served.json`,
+ * or an explicit path for a counterpart's committed snapshot). Fail-open: a
+ * missing / unreadable / malformed file yields `undefined`, never a throw — the
+ * gate degrades to "no contract to check against", never an error.
+ */
+export function readServedContract(cwd: string, filePath?: string): ServedContract | undefined {
+  const raw = readJson(filePath ?? path.join(cwd, FLOW_DIR, SERVED_SNAPSHOT));
+  return isServed(raw) ? raw : undefined;
+}
+
+/** Read the consumed snapshot (see {@link readServedContract}). */
+export function readConsumedContract(cwd: string, filePath?: string): ConsumedContract | undefined {
+  const raw = readJson(filePath ?? path.join(cwd, FLOW_DIR, CONSUMED_SNAPSHOT));
+  return isConsumed(raw) ? raw : undefined;
+}
+
+/** The `${method} ${path}` keys a served contract exposes — the O(1) lookup the
+ *  gate uses to check whether a consumed binding still resolves. */
+export function servedKeySet(contract: ServedContract): Set<string> {
+  return new Set(contract.routes.map((r) => contractKey(r.method, r.path)));
+}
+
+function readJson(absPath: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(absPath, 'utf-8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function isServed(v: unknown): v is ServedContract {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    (v as ServedContract).side === 'served' &&
+    Array.isArray((v as ServedContract).routes)
+  );
+}
+
+function isConsumed(v: unknown): v is ConsumedContract {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    (v as ConsumedContract).side === 'consumed' &&
+    Array.isArray((v as ConsumedContract).bindings)
+  );
+}

--- a/src/analyzers/flow/gate.ts
+++ b/src/analyzers/flow/gate.ts
@@ -1,0 +1,124 @@
+/**
+ * The integration-breakage gate — pure evaluation core.
+ *
+ * Answers "does this diff NET-NEW break a UI→API integration?" from a base↔HEAD
+ * contract comparison, with no running system. One algorithm covers both
+ * directions (CLAUDE.md design §6):
+ *   - a FRONTEND PR that adds a call to an endpoint no backend serves, and
+ *   - a BACKEND PR that removes/renames a route a frontend still calls,
+ * because both reduce to "a consumed binding whose (method, path) is not in the
+ * served set". The diff makes it net-new: a binding already broken BEFORE the
+ * PR (present at base and unresolved against the base served set) is
+ * grandfathered; only a binding the PR NEWLY breaks is surfaced.
+ *
+ * Pure over its inputs — the ref-based gather (base worktree via
+ * `withRefWorktree`, Rule 11) and the guardrail wiring live above this module;
+ * here we only diff two already-materialized contract sides. Identity is the
+ * flow-binding fingerprint (line-independent (method, path, file), Rule 9),
+ * computed through the canonical helper so an emitted finding shares one
+ * identity contract with the baseline + allowlist.
+ */
+
+import { computeFlowBindingFingerprint } from '../tools/fingerprint';
+import { contractKey, type ConsumedBinding } from './contract';
+
+/** Why a binding is broken: the endpoint was never served (a new call to a
+ *  non-existent route, or a typo), or a route that WAS served got removed. */
+export type BrokenReason = 'no-route' | 'route-removed';
+
+/** One net-new broken integration the gate surfaces. */
+export interface BrokenIntegration {
+  /** Flow-binding fingerprint — the durable identity (Rule 9). */
+  readonly id: string;
+  readonly method: string;
+  readonly path: string;
+  readonly file: string;
+  readonly line: number;
+  readonly confidence: number;
+  readonly reason: BrokenReason;
+  /** `block` when confidence clears the threshold (a real, specific breakage),
+   *  else `warn` — conservative by construction to protect the false-positive
+   *  budget (fuzzy / placeholder-only paths never fail a build). */
+  readonly verdict: 'block' | 'warn';
+}
+
+export interface GateInputs {
+  /** Bindings this side depends on at HEAD (the consumed contract post-diff). */
+  readonly headConsumed: readonly ConsumedBinding[];
+  /** Bindings at the base ref — the grandfathering set. */
+  readonly baseConsumed: readonly ConsumedBinding[];
+  /** `${method} ${path}` keys served at HEAD (the counterpart's served
+   *  contract, or this repo's own in a monorepo). */
+  readonly headServed: ReadonlySet<string>;
+  /** Served keys at the base ref. */
+  readonly baseServed: ReadonlySet<string>;
+  /** Confidence at/above which a net-new broken binding BLOCKS (else warns).
+   *  Default 1 — only exact, fully-specified bindings can fail a build. */
+  readonly blockThreshold?: number;
+}
+
+/** The flow-binding identity tuple as a map key (method, path, file). */
+function identityKey(b: { method: string; path: string; file: string }): string {
+  return `${b.method}\0${b.path}\0${b.file}`;
+}
+
+/**
+ * Evaluate the gate. Returns every NET-NEW broken integration, most-severe
+ * (block before warn) first, then by location for stable output. Empty when the
+ * diff breaks nothing new.
+ */
+export function evaluateFlowGate(inputs: GateInputs): BrokenIntegration[] {
+  const blockThreshold = inputs.blockThreshold ?? 1;
+  const baseByIdentity = new Map<string, ConsumedBinding>();
+  for (const b of inputs.baseConsumed) baseByIdentity.set(identityKey(b), b);
+
+  const out: BrokenIntegration[] = [];
+  for (const b of inputs.headConsumed) {
+    const key = contractKey(b.method, b.path);
+    if (inputs.headServed.has(key)) continue; // resolves at HEAD → not broken
+
+    // Broken at HEAD. Was the SAME binding already broken at base? (present at
+    // base AND unresolved against the base served set) → grandfathered.
+    const base = baseByIdentity.get(identityKey(b));
+    const brokenBefore = base !== undefined && !inputs.baseServed.has(key);
+    if (brokenBefore) continue;
+
+    // Net-new. `route-removed` when the binding existed at base and WAS served
+    // then (the PR removed the route); otherwise the call itself is new or
+    // never resolved (`no-route`).
+    const reason: BrokenReason =
+      base !== undefined && inputs.baseServed.has(key) ? 'route-removed' : 'no-route';
+    out.push({
+      id: computeFlowBindingFingerprint(b.method, b.path, b.file),
+      method: b.method,
+      path: b.path,
+      file: b.file,
+      line: b.line,
+      confidence: b.confidence,
+      reason,
+      verdict: b.confidence >= blockThreshold ? 'block' : 'warn',
+    });
+  }
+
+  out.sort(
+    (a, z) =>
+      Number(z.verdict === 'block') - Number(a.verdict === 'block') ||
+      a.file.localeCompare(z.file) ||
+      a.path.localeCompare(z.path),
+  );
+  return out;
+}
+
+/** Does the gate result block? True when any finding's verdict is `block`. */
+export function flowGateBlocks(findings: readonly BrokenIntegration[]): boolean {
+  return findings.some((f) => f.verdict === 'block');
+}
+
+/** Human-readable one-liner for a broken integration (report + Stop-gate). */
+export function describeBrokenIntegration(f: BrokenIntegration): string {
+  const what =
+    f.reason === 'route-removed'
+      ? `removed ${f.method} ${f.path} still called by`
+      : `${f.method} ${f.path} matches no served route —`;
+  return `net-new broken integration: ${what} ${f.file}:${f.line}`;
+}

--- a/src/analyzers/flow/gather.ts
+++ b/src/analyzers/flow/gather.ts
@@ -11,8 +11,8 @@
  * pack auto-extends the scan (Rule 6).
  */
 
-import { join } from 'path';
-import { LANGUAGES } from '../../languages';
+import { join, relative } from 'path';
+import { LANGUAGES, allFlowSourceExtensions } from '../../languages';
 import { walkSourceFiles } from '../tools/walk-source-files';
 import { extractFileFlow, type FileFlow } from './extract';
 import { buildFlowModel, type FlowModel } from './model';
@@ -26,17 +26,31 @@ export interface GatherFlowOptions {
   readonly specs?: readonly string[];
   /** Host-helper prefixes to strip during URL normalization (per-app config). */
   readonly stripUrlPrefixes?: readonly string[];
+  /**
+   * Relabel every extracted call / route `file` relative to this directory.
+   * Off by default (files keep their scanned absolute path — the M2 map/trace
+   * display form). The flow-binding identity contract (Rule 9) requires an
+   * environment-INDEPENDENT locator, so the gate and `flow refresh` set this to
+   * the repo root: a binding gathered from the working tree and the same file
+   * gathered from a detached worktree then share one relative `file`, and the
+   * committed `consumed.json` carries repo-relative paths that mean the same
+   * thing on any machine.
+   */
+  readonly relativeTo?: string;
 }
 
 /** Extensions of packs that can contribute flow (httpFlow + a grammar). */
 function flowExtensions(): string[] {
-  const exts = new Set<string>();
-  for (const pack of LANGUAGES) {
-    if (pack.httpFlow && pack.treeSitterGrammars) {
-      for (const ext of Object.keys(pack.treeSitterGrammars)) exts.add(ext);
-    }
-  }
-  return [...exts];
+  return allFlowSourceExtensions(LANGUAGES);
+}
+
+/** Relabel a file surface's call/route paths relative to `base`. */
+function relabelFileFlow(flow: FileFlow, base: string): FileFlow {
+  const rel = (f: string): string => relative(base, f);
+  return {
+    calls: flow.calls.map((c) => ({ ...c, file: rel(c.file) })),
+    routes: flow.routes.map((r) => ({ ...r, file: rel(r.file) })),
+  };
 }
 
 /** Walk + extract + assemble. Files that don't parse are skipped, never fatal. */
@@ -48,7 +62,7 @@ export async function gatherFlowModel(opts: GatherFlowOptions): Promise<FlowMode
   for (const root of opts.roots) {
     for (const rel of walkSourceFiles(root, { extensions })) {
       const flow = await extractFileFlow(join(root, rel), config);
-      if (flow) fileFlows.push(flow);
+      if (flow) fileFlows.push(opts.relativeTo ? relabelFileFlow(flow, opts.relativeTo) : flow);
     }
   }
 

--- a/src/analyzers/flow/model.ts
+++ b/src/analyzers/flow/model.ts
@@ -44,8 +44,10 @@ export interface FlowModel {
   readonly bindings: readonly FlowBinding[];
 }
 
-/** A path made up entirely of `{var}` segments carries no static signal. */
-function isPlaceholderOnly(path: string): boolean {
+/** A path made up entirely of `{var}` segments carries no static signal. One
+ *  source of truth (Rule 2) for both the join's confidence and the gate's
+ *  confidence gating (a placeholder-only path is too generic to block on). */
+export function isPlaceholderOnlyPath(path: string): boolean {
   return /^(\/\{var\})+$/.test(path);
 }
 
@@ -64,7 +66,7 @@ export function joinFlow(
     if (call.path == null) return { call, route: null, confidence: 0, reason: 'external' };
     const route = routeIndex.get(`${call.method} ${call.path}`) ?? null;
     if (!route) return { call, route: null, confidence: 0, reason: 'no-route' };
-    if (isPlaceholderOnly(call.path)) {
+    if (isPlaceholderOnlyPath(call.path)) {
       return { call, route, confidence: 0.3, reason: 'placeholder-only' };
     }
     return { call, route, confidence: 1, reason: 'exact' };

--- a/src/analyzers/flow/model.ts
+++ b/src/analyzers/flow/model.ts
@@ -71,6 +71,25 @@ export function joinFlow(
   });
 }
 
+/**
+ * Dedup served routes to one per distinct `(method, path)` — the canonical
+ * "what this repo serves" set. A route surfaced by both a spec and static
+ * extraction collapses to one, spec winning (authoritative handler +
+ * provenance). One source of truth (Rule 2) for the graph overlay's endpoint
+ * nodes AND the served contract snapshot.
+ */
+export function dedupeServedRoutes(routes: readonly RouteEndpoint[]): RouteEndpoint[] {
+  const byKey = new Map<string, RouteEndpoint>();
+  for (const route of routes) {
+    const key = `${route.method} ${route.path}`;
+    const existing = byKey.get(key);
+    if (!existing || (existing.via !== 'spec' && route.via === 'spec')) {
+      byKey.set(key, route);
+    }
+  }
+  return [...byKey.values()];
+}
+
 /** Flatten per-file surfaces into one model + its bindings. */
 export function buildFlowModel(fileFlows: readonly FileFlow[]): FlowModel {
   const calls = fileFlows.flatMap((f) => f.calls);

--- a/src/analyzers/tools/fingerprint.ts
+++ b/src/analyzers/tools/fingerprint.ts
@@ -344,6 +344,44 @@ export function computeContentFingerprint(
   return createHash('sha1').update(input).digest('hex').slice(0, 16);
 }
 
+// ─── Flow-binding identity (the integration gate, Rule 9) ─────────────────────
+
+/**
+ * Tool-independent canonical rule for a flow binding — a UI call site's
+ * dependency on a served `(method, path)`. Every flow binding shares this
+ * constant (like secrets share `SECRET_CANONICAL_RULE`) because the finding is
+ * intrinsic ("this component depends on this endpoint"), never a per-tool
+ * classification.
+ */
+export const FLOW_BINDING_CANONICAL_RULE = 'canonical:flow-binding';
+
+/**
+ * Durable identity for a flow binding (the `flow-binding` kind — the unit the
+ * integration gate grandfathers). A binding IS "this consumer file depends on
+ * this `(method, path)`", so identity is exactly that triple — and nothing
+ * else. It is fully LINE-INDEPENDENT by construction (no line, no line-window
+ * bucket), which is strictly more robust than the v1 line-window scheme: the
+ * call can move anywhere in the file, be reformatted, or gain siblings above
+ * it, and the binding keeps its identity. Motion within a file simply is not a
+ * change to which endpoint the file depends on.
+ *
+ * Hashes only inputs dxkit derives itself (Rule 9) — the NORMALIZED join key
+ * (`GET`, `/articles/{var}`, never a tool's raw URL capture) and the consuming
+ * file dxkit read from its own AST pass — so a committed baseline keeps
+ * matching when the scan moves to CI. Multiple calls to the same endpoint from
+ * one file collapse to one identity, which is correct: the file depends on the
+ * endpoint once, however many call sites express it. A pure file rename is
+ * relocated by the matcher's whole-file rename pass (the file locator in
+ * `entryToLocated`), not by the hash.
+ *
+ * Deliberately NOT the graph's enclosing symbol: that would couple identity to
+ * graphify, and the flow layer is graphify-independent by design. Reusing
+ * `computeContentFingerprint` keeps every SHA-1 scheme in this one module.
+ */
+export function computeFlowBindingFingerprint(method: string, path: string, file: string): string {
+  return computeContentFingerprint(FLOW_BINDING_CANONICAL_RULE, file, `${method} ${path}`);
+}
+
 // ─── Secret HMAC primitive ───────────────────────────────────────────────────
 
 /**

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -29,6 +29,8 @@ import * as logger from '../logger';
 import type { ClassifiedPair, EnvelopeDrift, GuardrailCheckResult } from './check';
 import type { BrownfieldPolicy } from './policy';
 import type { FindingStatus, MatchReason } from './types';
+import { describeBrokenIntegration } from '../analyzers/flow/gate';
+import type { FlowGateOutcome } from './flow-gate-check';
 
 // ─── Shared verdict predicates ────────────────────────────────────────────
 
@@ -125,6 +127,8 @@ export function renderConsole(result: GuardrailCheckResult): string {
     lines.push('');
   }
 
+  lines.push(...formatFlowGate(result.flowGate));
+
   // Always show a summary footer — sets expectations for what
   // happens next (exit code, what to read on a fail).
   lines.push(logger.bold('Summary'));
@@ -156,13 +160,40 @@ export function renderConsole(result: GuardrailCheckResult): string {
   return lines.join('\n');
 }
 
+/**
+ * Console lines for the flow integration gate. Silent unless the gate produced
+ * findings — a skipped or clean gate adds no noise. Blocking breakages are
+ * grouped separately from warnings so the actionable set surfaces first.
+ */
+function formatFlowGate(flow: FlowGateOutcome | undefined): string[] {
+  if (!flow || flow.findings.length === 0) return [];
+  const out: string[] = [];
+  const blocking = flow.findings.filter((f) => f.verdict === 'block');
+  const warning = flow.findings.filter((f) => f.verdict === 'warn');
+  if (blocking.length > 0) {
+    out.push(logger.bold(`Flow breakage — blocking (${blocking.length})`));
+    for (const f of blocking) out.push(`  ${describeBrokenIntegration(f)}`);
+    out.push('');
+  }
+  if (warning.length > 0) {
+    out.push(logger.bold(`Flow breakage — warning (${warning.length})`));
+    for (const f of warning) out.push(`  ${describeBrokenIntegration(f)}`);
+    out.push('');
+  }
+  return out;
+}
+
 function verdictBanner(result: GuardrailCheckResult): string {
+  const flow = result.flowGate?.findings ?? [];
   if (result.blocks) {
-    const count = result.pairs.filter(isBlocking).length;
+    const count =
+      result.pairs.filter(isBlocking).length + flow.filter((f) => f.verdict === 'block').length;
     return logger.bold(`Guardrail BLOCKED — ${count} new regression${count === 1 ? '' : 's'}`);
   }
   if (result.warns) {
-    const count = result.pairs.filter((p) => p.classification.warns).length;
+    const count =
+      result.pairs.filter((p) => p.classification.warns).length +
+      flow.filter((f) => f.verdict === 'warn').length;
     return logger.bold(`Guardrail PASSED — ${count} warning${count === 1 ? '' : 's'}`);
   }
   return logger.bold('Guardrail PASSED');
@@ -341,6 +372,27 @@ export interface GuardrailJsonPayload {
     };
     readonly reasons: ReadonlyArray<MatchReason>;
   }>;
+  /** The flow integration gate — net-new UI→API breakages from the base↔HEAD
+   *  contract diff. Absent in committed modes (the gate runs only ref-based).
+   *  When present but `ran` is false, `skipped` says why (e.g. no flow-surface
+   *  change, no served-side truth). */
+  readonly flowGate?: {
+    readonly ran: boolean;
+    readonly skipped?: string;
+    readonly mode: string;
+    readonly blocks: boolean;
+    readonly warns: boolean;
+    readonly findings: ReadonlyArray<{
+      readonly id: string;
+      readonly method: string;
+      readonly path: string;
+      readonly file: string;
+      readonly line: number;
+      readonly confidence: number;
+      readonly reason: string;
+      readonly verdict: 'block' | 'warn';
+    }>;
+  };
 }
 
 export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
@@ -420,6 +472,27 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
         : {}),
       reasons: p.classification.reasons,
     })),
+    ...(result.flowGate !== undefined
+      ? {
+          flowGate: {
+            ran: result.flowGate.ran,
+            ...(result.flowGate.skipped !== undefined ? { skipped: result.flowGate.skipped } : {}),
+            mode: result.flowGate.mode,
+            blocks: result.flowGate.blocks,
+            warns: result.flowGate.warns,
+            findings: result.flowGate.findings.map((f) => ({
+              id: f.id,
+              method: f.method,
+              path: f.path,
+              file: f.file,
+              line: f.line,
+              confidence: f.confidence,
+              reason: f.reason,
+              verdict: f.verdict,
+            })),
+          },
+        }
+      : {}),
   };
 }
 
@@ -446,7 +519,17 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
   const verdict = result.blocks ? 'BLOCKED' : result.warns ? 'PASSED (with warnings)' : 'PASSED';
   lines.push(`## Guardrail: ${verdict}`);
   lines.push('');
-  lines.push(summarySentence(result, blocking.length, warning.length, resolved.length));
+  const flow = result.flowGate?.findings ?? [];
+  const flowBlocking = flow.filter((f) => f.verdict === 'block').length;
+  const flowWarning = flow.filter((f) => f.verdict === 'warn').length;
+  lines.push(
+    summarySentence(
+      result,
+      blocking.length + flowBlocking,
+      warning.length + flowWarning,
+      resolved.length,
+    ),
+  );
   lines.push('');
 
   if (result.refExcludedKinds.length > 0) {
@@ -467,6 +550,8 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     for (const p of blocking) lines.push(markdownPairRow(p));
     lines.push('');
   }
+
+  lines.push(...markdownFlowGate(result.flowGate));
 
   if (suppressed.length > 0) {
     lines.push('<details>');
@@ -540,6 +625,41 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
   );
 
   return lines.join('\n');
+}
+
+/**
+ * Markdown for the flow integration gate. Blocking breakages render as a
+ * top-level table (they fail the PR); warnings collapse into a `<details>`.
+ * Silent when the gate produced no findings.
+ */
+function markdownFlowGate(flow: FlowGateOutcome | undefined): string[] {
+  if (!flow || flow.findings.length === 0) return [];
+  const out: string[] = [];
+  const blocking = flow.findings.filter((f) => f.verdict === 'block');
+  const warning = flow.findings.filter((f) => f.verdict === 'warn');
+  const row = (f: FlowGateOutcome['findings'][number]): string =>
+    `| ${escapeMd(`${f.method} ${f.path}`)} | ${escapeMd(f.reason)} | ` +
+    `${escapeMd(`${f.file}:${f.line}`)} | ${f.confidence.toFixed(2)} |`;
+  if (blocking.length > 0) {
+    out.push('### Broken integrations');
+    out.push('');
+    out.push('| Endpoint | Reason | Consumer | Confidence |');
+    out.push('|---|---|---|---|');
+    for (const f of blocking) out.push(row(f));
+    out.push('');
+  }
+  if (warning.length > 0) {
+    out.push('<details>');
+    out.push(`<summary>Integration warnings (${warning.length})</summary>`);
+    out.push('');
+    out.push('| Endpoint | Reason | Consumer | Confidence |');
+    out.push('|---|---|---|---|');
+    for (const f of warning) out.push(row(f));
+    out.push('');
+    out.push('</details>');
+    out.push('');
+  }
+  return out;
 }
 
 /** Append ` (ref: <ref>)` to the mode label when running ref-based,

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -62,6 +62,9 @@ import { gatherFromRef } from './ref-baseline';
 import { type GatherScope, FULL_SCOPE, scopeForPolicy } from './gather-scope';
 import { computeChangedFiles } from './changed-files';
 import { changedFilesTouchDependencyManifest, detectActiveLanguages } from '../languages';
+import { evaluateFlowGateForGuardrail } from './flow-gate-check';
+import type { FlowGateOutcome } from './flow-gate-check';
+import type { FlowGateMode } from '../analyzers/flow/config';
 import { isSanitized } from './sanitize';
 import type { BaselineEntry, FindingId, FindingSeverity, MatchPair, MatchResult } from './types';
 import { CURRENT_IDENTITY_SCHEME } from './types';
@@ -150,6 +153,16 @@ export interface RunGuardrailCheckOptions {
    * loop on your own repo keep full coverage).
    */
   readonly untrusted?: boolean;
+  /**
+   * Loop-seam override for the flow integration gate's posture (`block` /
+   * `warn` / `off`), winning over `.dxkit/policy.json:flow.mode`. The loop
+   * Stop-gate derives it from the active preset (`security-only` → `warn`,
+   * `full-debt` → `block`) so an unattended loop doesn't wedge on a cross-repo
+   * integration false positive, while CI / `guardrail check` (which don't set
+   * it) honor the repo's configured mode. The gate runs only in ref-based mode
+   * regardless.
+   */
+  readonly flowMode?: FlowGateMode;
 }
 
 /**
@@ -261,6 +274,12 @@ export interface GuardrailCheckResult {
     readonly kind: BaselineEntry['kind'];
     readonly currentCount: number;
   }>;
+  /** The flow integration-gate pass — an additive, fail-open layer that flags
+   *  net-new UI→API breakage from a base↔HEAD contract diff. Runs only in
+   *  ref-based mode; `undefined` in committed modes (nothing to diff a base
+   *  flow model against). Its `blocks` / `warns` are folded into the top-level
+   *  verdict above. Renderers surface `findings` alongside the matched pairs. */
+  readonly flowGate?: FlowGateOutcome;
 }
 
 /**
@@ -638,6 +657,20 @@ export async function runGuardrailCheck(
   // and the renderer treats that as "delta unavailable."
   const allowlistDelta: AllowlistDelta = computeAllowlistDelta(cwd, baseline.repo.commitSha);
 
+  // The flow integration gate — an additive, fail-open pass over the same
+  // ref-based comparison. It runs its own base↔HEAD flow gather (independent of
+  // the finding matcher above) and never throws; its verdict folds into the
+  // top-level one. Runs only in ref-based mode.
+  const flowGate = await evaluateFlowGateForGuardrail({
+    cwd,
+    mode,
+    ...(options.flowMode !== undefined ? { modeOverride: options.flowMode } : {}),
+    ...(options.verbose !== undefined ? { verbose: options.verbose } : {}),
+  });
+
+  const baseBlocks = options.changedOnly ? filteredBlocks : blocks;
+  const baseWarns = options.changedOnly ? filteredWarns : warns;
+
   return {
     mode,
     ...(baselinePath !== undefined ? { baselinePath } : {}),
@@ -647,10 +680,11 @@ export async function runGuardrailCheck(
     pairs: filteredPairs,
     envelopeDrift,
     policy,
-    blocks: options.changedOnly ? filteredBlocks : blocks,
-    warns: options.changedOnly ? filteredWarns : warns,
+    blocks: baseBlocks || flowGate.blocks,
+    warns: baseWarns || flowGate.warns,
     allowlistDelta,
     refExcludedKinds,
+    ...(flowGate.ran || flowGate.skipped !== 'not-ref-based' ? { flowGate } : {}),
   };
 }
 

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -358,6 +358,11 @@ const KIND_DEFAULT_SEVERITY: Readonly<Record<BaselineEntry['kind'], FindingSever
     // not an active risk; the underlying suppressed finding is already
     // gone.
     'stale-allow': 'low',
+    // A net-new broken integration (a UI call that no longer resolves to a
+    // served route, or a served route a consumer still binds to that a PR
+    // removed). High severity — it is a runtime breakage the gate proves
+    // statically, on par with a security regression.
+    'flow-binding': 'high',
   });
 
 /**

--- a/src/baseline/entry-to-located.ts
+++ b/src/baseline/entry-to-located.ts
@@ -150,6 +150,13 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
         ...(entry.contentHash !== undefined ? { contentHash: entry.contentHash } : {}),
       };
     }
+    case 'flow-binding':
+      // Line-INDEPENDENT identity ((method, path, file)) → whole-file locator,
+      // no line: the binding survives the call moving anywhere in the file. The
+      // `file` anchor lets the matcher's whole-file rename pass relocate it on a
+      // pure rename; the `${method} ${path}` join key is the rule discriminator
+      // so two distinct bindings in one renamed file don't cross-pair.
+      return { id: entry.id, file: entry.file, rule: `${entry.method} ${entry.path}` };
     case 'dep-vuln':
     case 'secret-hmac':
       // Line-independent identity (advisory id; value HMAC) → locator-less;

--- a/src/baseline/finding-identity.ts
+++ b/src/baseline/finding-identity.ts
@@ -18,6 +18,7 @@ import {
   computeContentFingerprint,
   computeFingerprint,
   computeFingerprintV1,
+  computeFlowBindingFingerprint,
   lineWindowFor,
   SECRET_CANONICAL_RULE,
 } from '../analyzers/tools/fingerprint';
@@ -127,6 +128,11 @@ export function identityFor(
       return computeSecretHmacIdentity(input.tool, input.rule, input.hmac);
     case 'stale-allow':
       return computeStaleAllowIdentity(input.file, input.line, input.category);
+    case 'flow-binding':
+      // Version-independent + line-independent: hashes only the normalized
+      // (method, path, file) triple — all tool-independent + dxkit-derived
+      // (Rule 9). The call can move anywhere in the file without re-minting.
+      return computeFlowBindingFingerprint(input.method, input.path, input.file);
   }
 }
 

--- a/src/baseline/flow-gate-check.ts
+++ b/src/baseline/flow-gate-check.ts
@@ -1,0 +1,183 @@
+/**
+ * The flow integration-gate pass for the guardrail check — an ADDITIVE,
+ * fail-open layer over `runGuardrailCheck`.
+ *
+ * This is guardrail-integration glue, not analysis: it composes the pure flow
+ * gate (`analyzers/flow/gate.ts`) with the ref-based gather primitive
+ * (`withRefWorktree`, Rule 11) to answer "does this diff net-new break a UI→API
+ * integration?" without touching the existing net-new finding matcher. The gate
+ * runs only in ref-based mode, where a base↔HEAD comparison is well defined
+ * (committed mode has no base flow model — flow-binding is a deferred baseline
+ * kind, minted here ref-based rather than at baseline-create).
+ *
+ * Every failure path degrades to "did not gate" rather than an error: a
+ * missing base ref, an unparseable tree, a repo with no server-side truth to
+ * check against — all yield an empty, non-blocking outcome. A brand-new
+ * cross-repo gate must never wedge a build on its own uncertainty.
+ *
+ * Served-side truth. In a monorepo both surfaces live in the scanned tree, so
+ * the served set is gathered live. In a split repo the counterpart commits its
+ * `served.json` snapshot here (Rule 13 pattern), unioned in below. When neither
+ * yields any served route the gate self-skips: with no served inventory every
+ * consumed binding would look broken, so gating would be all false positives.
+ */
+
+import * as path from 'path';
+import { changedFilesTouchFlowSurface, detectActiveLanguages } from '../languages';
+import { computeChangedFiles } from './changed-files';
+import { withRefWorktree } from './ref-baseline';
+import type { ResolvedMode } from './modes';
+import { gatherFlowModel } from '../analyzers/flow/gather';
+import {
+  buildConsumedContract,
+  buildServedContract,
+  readServedContract,
+  servedKeySet,
+  type ConsumedBinding,
+} from '../analyzers/flow/contract';
+import { evaluateFlowGate, type BrokenIntegration } from '../analyzers/flow/gate';
+import { readFlowConfig, type FlowGateMode } from '../analyzers/flow/config';
+
+/** Why the gate produced no verdict, when it didn't run. */
+export type FlowGateSkip =
+  | 'off' // policy `flow.mode: off`
+  | 'not-ref-based' // committed mode — no base flow model to diff against
+  | 'no-flow-surface-change' // the diff touched no client call / route / spec
+  | 'no-served-truth' // no served inventory (monorepo route set + snapshot both empty)
+  | 'error'; // any failure — fail-open
+
+/** Outcome of the flow gate pass, folded additively into the guardrail verdict. */
+export interface FlowGateOutcome {
+  /** True when the gate actually evaluated a base↔HEAD comparison. */
+  readonly ran: boolean;
+  /** Populated when `ran` is false — the reason no verdict was produced. */
+  readonly skipped?: FlowGateSkip;
+  /** The effective mode after the loop-seam override (block / warn / off). */
+  readonly mode: FlowGateMode;
+  /** Net-new broken integrations. In `warn` mode every finding's verdict is
+   *  demoted to `warn` so renderers present them as warnings. */
+  readonly findings: readonly BrokenIntegration[];
+  /** True when at least one finding blocks (only possible in `block` mode). */
+  readonly blocks: boolean;
+  /** True when at least one finding warns. */
+  readonly warns: boolean;
+}
+
+/** Meta stub for contract building — the gate reads only routes/bindings, never
+ *  the snapshot metadata, so a clock-free placeholder keeps this pure. */
+const GATE_META = { schemaVersion: 1 as const, generatedAt: '' };
+
+function skip(mode: FlowGateMode, reason: FlowGateSkip): FlowGateOutcome {
+  return { ran: false, skipped: reason, mode, findings: [], blocks: false, warns: false };
+}
+
+/**
+ * Run the flow gate for a guardrail check. Never throws — a caller ORs the
+ * returned `blocks` / `warns` into the overall verdict and attaches the outcome
+ * to the result for rendering.
+ *
+ * @param modeOverride the loop Stop-gate's posture-derived mode (the seam that
+ *   lets `security-only` warn while `full-debt` blocks) — wins over the
+ *   `.dxkit/policy.json:flow.mode` default.
+ */
+export async function evaluateFlowGateForGuardrail(opts: {
+  readonly cwd: string;
+  readonly mode: ResolvedMode;
+  readonly modeOverride?: FlowGateMode;
+  readonly verbose?: boolean;
+}): Promise<FlowGateOutcome> {
+  const cwd = path.resolve(opts.cwd);
+  const config = readFlowConfig(cwd);
+  const gateMode = opts.modeOverride ?? config.mode;
+
+  if (gateMode === 'off') return skip(gateMode, 'off');
+  if (opts.mode.mode !== 'ref-based' || !opts.mode.ref) return skip(gateMode, 'not-ref-based');
+  const ref = opts.mode.ref;
+
+  try {
+    // Trigger-skip: a net-new broken integration requires a change to a client
+    // call, a route, or a spec. When the diff touched none, there is nothing to
+    // gate. `computeChangedFiles` returns null on any uncertainty → we can't
+    // prove the diff is flow-free, so we fall through and run (safe default).
+    const changed = computeChangedFiles(cwd, ref) ?? undefined;
+    if (
+      changed &&
+      !changedFilesTouchFlowSurface(changed, detectActiveLanguages(cwd), config.specs)
+    ) {
+      return skip(gateMode, 'no-flow-surface-change');
+    }
+
+    // HEAD side (the working tree). Served truth = live routes ∪ any committed
+    // counterpart snapshot (split-repo case).
+    const headModel = await gatherFlowModel({
+      roots: [cwd],
+      specs: config.specs.map((s) => path.resolve(cwd, s)),
+      stripUrlPrefixes: config.stripUrlPrefixes,
+      // Repo-relative locators so a binding's identity is the same whether it
+      // was gathered here or from the base worktree below (Rule 9).
+      relativeTo: cwd,
+    });
+    const headConsumed = buildConsumedContract(headModel, GATE_META).bindings;
+    const headServed = servedKeySet(buildServedContract(headModel, GATE_META));
+    unionCommittedServed(cwd, headServed);
+
+    // Base side, gathered from a detached worktree at the ref (Rule 11). Read
+    // ITS committed snapshot so the base served set reflects the counterpart as
+    // it was at base — keeping the grandfathering diff honest.
+    const base = await withRefWorktree({ cwd, ref }, async (wt) => {
+      const baseModel = await gatherFlowModel({
+        roots: [wt],
+        specs: config.specs.map((s) => path.resolve(wt, s)),
+        stripUrlPrefixes: config.stripUrlPrefixes,
+        relativeTo: wt, // same repo-relative locators as the HEAD side
+      });
+      const baseServed = servedKeySet(buildServedContract(baseModel, GATE_META));
+      unionCommittedServed(wt, baseServed);
+      return {
+        consumed: buildConsumedContract(baseModel, GATE_META).bindings as ConsumedBinding[],
+        served: [...baseServed],
+      };
+    });
+    const baseServed = new Set(base.served);
+
+    // No server-side truth on either side → cannot distinguish a broken call
+    // from a call served by a repo we can't see. Skip rather than false-block.
+    if (headServed.size === 0 && baseServed.size === 0) return skip(gateMode, 'no-served-truth');
+
+    const found = evaluateFlowGate({
+      headConsumed,
+      baseConsumed: base.consumed,
+      headServed,
+      baseServed,
+      blockThreshold: config.blockThreshold,
+    });
+
+    // Apply the posture. `warn` demotes every finding so renderers show them as
+    // warnings and nothing fails the build; `block` honors each per-finding
+    // verdict (exact → block, placeholder → warn).
+    const findings =
+      gateMode === 'warn' ? found.map((f) => ({ ...f, verdict: 'warn' as const })) : found;
+    const blocks = gateMode === 'block' && findings.some((f) => f.verdict === 'block');
+    const warns = findings.some((f) => f.verdict === 'warn');
+
+    if (opts.verbose && findings.length > 0) {
+      process.stderr.write(
+        `    [flow] ${findings.length} net-new broken integration(s) — ${blocks ? 'blocking' : 'warning'}\n`,
+      );
+    }
+    return { ran: true, mode: gateMode, findings, blocks, warns };
+  } catch {
+    // Fail-open: a ref that can't be checked out, an unparseable tree, a git
+    // error — none of these should fail the guardrail. The gate simply did not
+    // run.
+    return skip(gateMode, 'error');
+  }
+}
+
+/** Union a repo's committed counterpart `served.json` (if any) into a served
+ *  key set. Fail-open: an absent / malformed snapshot is a no-op. */
+function unionCommittedServed(cwd: string, into: Set<string>): void {
+  const committed = readServedContract(cwd);
+  if (!committed) return;
+  for (const k of servedKeySet(committed)) into.add(k);
+}

--- a/src/baseline/migrate.ts
+++ b/src/baseline/migrate.ts
@@ -116,6 +116,9 @@ export function baselineEntryToIdentityInput(entry: BaselineEntry): IdentityInpu
       return { kind: 'secret-hmac', tool: e.tool, rule: e.rule, hmac: e.hmac };
     case 'stale-allow':
       return { kind: 'stale-allow', file: e.file, line: e.line, category: e.category };
+    case 'flow-binding':
+      // Line is display-only metadata on the entry, never an identity input.
+      return { kind: 'flow-binding', method: e.method, path: e.path, file: e.file };
   }
 }
 

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -180,6 +180,16 @@ export const DEFERRED_KINDS: Readonly<
       'inside an already-tested file remain invisible until Phase 3.5 lands.',
     landingPhase: 'Phase 3.5 (5 packs) / 2.6 (remaining)',
   },
+  'flow-binding': {
+    reason:
+      'the identity + baseline-entry shape ship ahead of the producer so the ' +
+      'integration gate can grandfather bindings the moment it lands. The gate ' +
+      'evaluates the affected scope of a diff against committed contract ' +
+      'snapshots (served.json / consumed.json) rather than a full-scan producer, ' +
+      'so the flow-binding entries are minted by the gate path, not baseline-create. ' +
+      'Substitute: none — net-new broken-integration detection is inert until the gate wires in.',
+    landingPhase: 'Flow M3 (the integration gate)',
+  },
 });
 
 // ─── Producer module wrappers ─────────────────────────────────────────────

--- a/src/baseline/show.ts
+++ b/src/baseline/show.ts
@@ -214,6 +214,8 @@ function describeEntry(entry: BaselineEntry): string {
       return `[${entry.tool}/${entry.rule}]  hmac:${entry.hmac.slice(0, 12)}`;
     case 'stale-allow':
       return `${entry.file}:${entry.line}  [stale dxkit-allow:${entry.category}]`;
+    case 'flow-binding':
+      return `${entry.method} ${entry.path}  ← ${entry.file}:${entry.line}`;
   }
 }
 

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -122,7 +122,8 @@ export type IdentityInput =
   | StaleFileIdentityInput
   | LargeFileIdentityInput
   | SecretHmacIdentityInput
-  | StaleAllowIdentityInput;
+  | StaleAllowIdentityInput
+  | FlowBindingIdentityInput;
 
 /**
  * Content anchor for the secret/code/config identity schemes.
@@ -397,6 +398,23 @@ export interface StaleAllowIdentityInput {
 }
 
 /**
+ * A flow binding — a UI call site's dependency on a served `(method, path)`,
+ * the unit the integration gate grandfathers. Identity is exactly the triple
+ * `(method, path, file)`: the NORMALIZED join key (never the raw URL a tool
+ * captured) plus the consuming file dxkit read from its own AST pass. It is
+ * LINE-INDEPENDENT — the call can move anywhere in the file without re-minting
+ * — so a committed baseline keeps matching in CI. Deliberately not the graph's
+ * enclosing symbol: the flow layer is graphify-independent. (The line lives on
+ * the baseline entry as display metadata, not as an identity input.)
+ */
+export interface FlowBindingIdentityInput {
+  readonly kind: 'flow-binding';
+  readonly method: string;
+  readonly path: string;
+  readonly file: string;
+}
+
+/**
  * Per-finding entry stored in a baseline. Carries identity plus the
  * minimum metadata needed for cross-run drift-tolerant matching —
  * never raw payloads (no titles, no secret content, no source
@@ -480,6 +498,21 @@ export type BaselineEntry =
   | { id: FindingId; kind: 'secret-hmac'; tool: string; rule: string; hmac: string }
   | {
       id: FindingId;
+      kind: 'flow-binding';
+      /** Normalized HTTP method + path — the canonical join key. Together with
+       * `file` these are the only identity inputs (Rule 9): all three are
+       * stored so identity is recomputable from the entry alone. */
+      method: string;
+      path: string;
+      /** Consuming file (the UI module that holds the call). */
+      file: string;
+      /** Representative call-site line — display metadata only (not hashed;
+       * identity is line-independent), so `show` / hints can point a human at
+       * the source. */
+      line: number;
+    }
+  | {
+      id: FindingId;
       kind: 'stale-allow';
       file: string;
       line: number;
@@ -536,7 +569,8 @@ export interface SanitizedBaselineEntry {
     | 'stale-file'
     | 'large-file'
     | 'secret-hmac'
-    | 'stale-allow';
+    | 'stale-allow'
+    | 'flow-binding';
   readonly sanitized: true;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -911,11 +911,19 @@ export async function run(argv: string[]): Promise<void> {
         });
         break;
       }
+      // `flow refresh` → write the served/consumed contract snapshots the
+      // cross-repo integration gate reads.
+      if (subCommand === 'refresh') {
+        const { runFlowRefresh } = await import('./flow-cli');
+        await runFlowRefresh({ cwd, frontend, backend, specs, json: !!values.json });
+        break;
+      }
       logger.fail(`Unknown flow subcommand: ${subCommand}`);
       logger.info('Usage:');
       logger.info('  vyuh-dxkit flow [map] [--frontend <dir>] [--backend <dir>] [--specs <a,b>]');
       logger.info('  vyuh-dxkit flow trace "<METHOD> <path>"');
       logger.info('  vyuh-dxkit flow extract [--out <dir>]');
+      logger.info('  vyuh-dxkit flow refresh');
       process.exit(1);
       break;
     }

--- a/src/explore/flow-graph.ts
+++ b/src/explore/flow-graph.ts
@@ -21,8 +21,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import type { FlowModel } from '../analyzers/flow/model';
-import type { RouteEndpoint } from '../analyzers/flow/extract';
+import { dedupeServedRoutes, type FlowModel } from '../analyzers/flow/model';
 import { tryLoadGraph } from './load';
 import { enclosingNodeIdFor } from './queries';
 import {
@@ -59,23 +58,13 @@ function endpointKey(method: string, routePath: string): string {
  * to answer "who calls this endpoint" by file. Pure over its inputs.
  */
 export function buildFlowContribution(model: FlowModel, base?: Graph): FlowContribution {
-  // Dedup routes → endpoint nodes, keyed by the normalized join key. A spec
-  // route supersedes a static one for the same key (authoritative handler).
-  const byKey = new Map<string, RouteEndpoint>();
-  for (const route of model.routes) {
-    const key = endpointKey(route.method, route.path);
-    const existing = byKey.get(key);
-    if (!existing || (existing.via !== 'spec' && route.via === 'spec')) {
-      byKey.set(key, route);
-    }
-  }
-
+  // Dedup routes → endpoint nodes, one per normalized join key (spec wins).
   const endpoints: HttpEndpointNode[] = [];
   const endpointIdByKey = new Map<string, string>();
   let idx = 0;
-  for (const [key, route] of byKey) {
+  for (const route of dedupeServedRoutes(model.routes)) {
     const id = `ep${idx++}`;
-    endpointIdByKey.set(key, id);
+    endpointIdByKey.set(endpointKey(route.method, route.path), id);
     endpoints.push({
       id,
       kind: 'http-endpoint',

--- a/src/flow-cli.ts
+++ b/src/flow-cli.ts
@@ -4,6 +4,7 @@
  * All analysis lives in `src/analyzers/flow/`; this file only wires I/O.
  */
 
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as logger from './logger';
@@ -11,6 +12,13 @@ import { gatherFlowModel } from './analyzers/flow/gather';
 import { flowCsvFiles } from './analyzers/flow/csv';
 import { summarize, type FlowModel } from './analyzers/flow/model';
 import { buildFlowMap, buildFlowTrace } from './explore/flow-view';
+import { readFlowConfig } from './analyzers/flow/config';
+import {
+  buildConsumedContract,
+  buildServedContract,
+  writeConsumedContract,
+  writeServedContract,
+} from './analyzers/flow/contract';
 
 export interface FlowExtractOptions {
   readonly cwd: string;
@@ -29,20 +37,6 @@ export interface FlowViewOptions {
   readonly backend?: string;
   readonly specs?: string;
   readonly json?: boolean;
-}
-
-/** Host-helper strip prefixes from `.dxkit/policy.json:flow.stripUrlPrefixes`. */
-function readStripPrefixes(cwd: string): string[] {
-  try {
-    const raw = fs.readFileSync(path.join(cwd, '.dxkit', 'policy.json'), 'utf8');
-    const prefixes = (JSON.parse(raw) as { flow?: { stripUrlPrefixes?: unknown } })?.flow
-      ?.stripUrlPrefixes;
-    return Array.isArray(prefixes)
-      ? prefixes.filter((p): p is string => typeof p === 'string')
-      : [];
-  } catch {
-    return [];
-  }
 }
 
 /**
@@ -72,12 +66,20 @@ function resolveRoots(opts: { cwd: string; frontend?: string; backend?: string }
   return roots;
 }
 
-/** Gather one flow model — shared by extract / map / trace. */
-async function gatherModel(opts: FlowViewOptions): Promise<FlowModel> {
+/** Gather one flow model — shared by extract / map / trace / refresh. Specs
+ *  come from BOTH the `--specs` flag and `.dxkit/policy.json:flow.specs`; strip
+ *  prefixes and other flow config come from that same policy section. */
+async function gatherModel(
+  opts: FlowViewOptions,
+  extra?: { relativeTo?: string },
+): Promise<FlowModel> {
+  const config = readFlowConfig(opts.cwd);
+  const policySpecs = config.specs.map((s) => path.resolve(opts.cwd, s));
   return gatherFlowModel({
     roots: resolveRoots(opts),
-    specs: splitPaths(opts.specs, opts.cwd),
-    stripUrlPrefixes: readStripPrefixes(opts.cwd),
+    specs: [...splitPaths(opts.specs, opts.cwd), ...policySpecs],
+    stripUrlPrefixes: config.stripUrlPrefixes,
+    ...(extra?.relativeTo !== undefined ? { relativeTo: extra.relativeTo } : {}),
   });
 }
 
@@ -190,4 +192,57 @@ export async function runFlowTrace(opts: FlowViewOptions & { target: string }): 
     `Blast radius: ${br.directConsumers} direct consumer(s) in ${br.consumerFiles} file(s)` +
       (br.upstreamCallers ? `, ${br.upstreamCallers} upstream caller(s)` : ''),
   );
+}
+
+/** Current HEAD commit SHA, or undefined outside a git repo (best-effort). */
+function headCommitSha(cwd: string): string | undefined {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * `vyuh-dxkit flow refresh` — write this repo's flow contract snapshots
+ * (`.dxkit/flow/served.json` + `consumed.json`). A backend commits `served.json`
+ * so a frontend in another repo can gate against it; a frontend commits
+ * `consumed.json` so a backend can see who still binds each route. A monorepo
+ * commits both (or neither — its guardrail computes both sides live). This is
+ * the one command that needs a full flow gather + write; the per-PR gate reads
+ * the committed snapshots (or gathers live in a monorepo) without a refresh.
+ */
+export async function runFlowRefresh(opts: FlowViewOptions): Promise<void> {
+  if (!opts.json) logger.header('vyuh-dxkit flow refresh');
+  // Repo-relative locators — the snapshots are committed + cross-repo, so a
+  // binding's `file` must mean the same thing on every machine (Rule 9).
+  const model = await gatherModel(opts, { relativeTo: opts.cwd });
+  const meta = {
+    schemaVersion: 1 as const,
+    generatedAt: new Date().toISOString(),
+    ...(headCommitSha(opts.cwd) !== undefined ? { commitSha: headCommitSha(opts.cwd) } : {}),
+  };
+  const served = buildServedContract(model, meta);
+  const consumed = buildConsumedContract(model, meta);
+  const servedPath = writeServedContract(opts.cwd, served);
+  const consumedPath = writeConsumedContract(opts.cwd, consumed);
+
+  if (opts.json) {
+    emitJson({
+      served: { path: servedPath, routes: served.routes.length },
+      consumed: { path: consumedPath, bindings: consumed.bindings.length },
+    });
+    return;
+  }
+  logger.success(
+    `served.json: ${served.routes.length} route(s) · consumed.json: ${consumed.bindings.length} binding(s)`,
+  );
+  logger.info(`  ${path.relative(opts.cwd, servedPath)}`);
+  logger.info(`  ${path.relative(opts.cwd, consumedPath)}`);
+  logger.info('');
+  logger.info('Commit these so the counterpart repo can gate against them.');
 }

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -405,6 +405,49 @@ export function allHttpFlow(flags: DetectedStack['languages']): HttpFlowSupport[
 }
 
 /**
+ * Source-file extensions of packs that can contribute flow — those declaring
+ * BOTH an `httpFlow` descriptor and a tree-sitter grammar (extraction needs
+ * both). One source of truth (Rule 2) for the flow file walk and the
+ * changed-files flow-surface trigger. Pack-driven (Rule 6): a new flow pack
+ * auto-extends the set.
+ */
+export function allFlowSourceExtensions(packs: readonly LanguageSupport[]): string[] {
+  const exts = new Set<string>();
+  for (const pack of packs) {
+    if (pack.httpFlow && pack.treeSitterGrammars) {
+      for (const ext of Object.keys(pack.treeSitterGrammars)) exts.add(ext);
+    }
+  }
+  return [...exts];
+}
+
+/**
+ * Does any changed-file path touch a flow surface — a source file in a
+ * flow-capable pack's extension set, or a configured OpenAPI spec? Drives the
+ * incremental flow-gate trigger-skip in `runGuardrailCheck`: a net-new broken
+ * integration requires a change to a client call, a route declaration, or a
+ * spec, so when this returns false the ref-based gate is skipped entirely.
+ *
+ * Fail-safe returns false (skip) ONLY when there is genuinely nothing to gate:
+ * no flow-capable pack is active. With flow-capable packs present but no
+ * matching change, it also returns false — correctly, since the diff cannot
+ * have introduced a net-new binding. `specPaths` are repo-relative.
+ */
+export function changedFilesTouchFlowSurface(
+  changedFiles: readonly string[],
+  packs: readonly LanguageSupport[],
+  specPaths: readonly string[] = [],
+): boolean {
+  const exts = allFlowSourceExtensions(packs);
+  if (exts.length === 0) return false;
+  const specSet = new Set(specPaths.map((s) => s.replace(/\\/g, '/')));
+  return changedFiles.some((f) => {
+    const norm = f.replace(/\\/g, '/');
+    return exts.some((e) => norm.endsWith(e)) || specSet.has(norm);
+  });
+}
+
+/**
  * Per-bucket union of active packs' test-gap path patterns. Empty
  * arrays for any bucket no pack declares. Consumed by
  * `analyzers/tests/gather.ts:classifyRisk` to tier source files into

--- a/src/loop/policy.ts
+++ b/src/loop/policy.ts
@@ -31,6 +31,7 @@ import {
   resolvePolicy,
 } from '../baseline/policy';
 import type { FindingStatus } from '../baseline/types';
+import type { FlowGateMode } from '../analyzers/flow/config';
 
 /**
  * The two shipped loop postures.
@@ -56,6 +57,14 @@ interface PresetDef {
   readonly block: ReadonlyArray<FindingStatus>;
   /** Per-kind escalation rules (see `BrownfieldBlockRules`). */
   readonly blockRules: BrownfieldBlockRules;
+  /**
+   * Posture for the flow integration gate. `security-only` WARNS on a net-new
+   * broken integration (like test-gap / quality — it isn't a security class,
+   * and a cross-repo integration false positive must never wedge an unattended
+   * loop); `full-debt` BLOCKS on it. Both keep the gate's own confidence gating
+   * (only exact bindings can block even under `block`).
+   */
+  readonly flowMode: FlowGateMode;
 }
 
 /** The security class: secrets, crit/high SAST, crit/high reachable dep
@@ -78,6 +87,7 @@ const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
     // Blocking comes solely from SECURITY_BLOCK_RULES.
     block: [],
     blockRules: SECURITY_BLOCK_RULES,
+    flowMode: 'warn',
   },
   'full-debt': {
     // Any net-new finding blocks (generic `added`), plus every escalation.
@@ -87,14 +97,17 @@ const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
       newUntestedChangedSource: true,
       newSevereQualityIssueInChangedFiles: true,
     },
+    flowMode: 'block',
   },
 });
 
 /** Resolved loop posture: the policy the Stop-gate hands to the guardrail,
- *  plus the preset name that produced it (recorded in the ledger). */
+ *  plus the preset name that produced it (recorded in the ledger) and the
+ *  flow-gate mode the preset dictates (passed as the guardrail's `flowMode`). */
 export interface ResolvedLoopPolicy {
   readonly policy: BrownfieldPolicy;
   readonly preset: LoopPreset;
+  readonly flowMode: FlowGateMode;
 }
 
 function isLoopPreset(v: unknown): v is LoopPreset {
@@ -143,6 +156,7 @@ export function resolveLoopPolicy(cwd: string): ResolvedLoopPolicy {
   const def = PRESETS[preset];
   return {
     preset,
+    flowMode: def.flowMode,
     policy: {
       ...base,
       block: def.block,

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -314,7 +314,7 @@ export async function runStopGate(cwd: string): Promise<void> {
   // Resolve the loop-scoped posture ONCE (preset → policy). This is the
   // only place the loop preset is read; the CI guardrail never sees it.
   const { resolveLoopPolicy } = await import('./policy');
-  const { policy, preset } = resolveLoopPolicy(repoDir);
+  const { policy, preset, flowMode } = resolveLoopPolicy(repoDir);
 
   // ── Fast path: replay the last verdict when the working tree is
   // byte-identical to what was last gathered (a no-change stop — an
@@ -371,7 +371,13 @@ export async function runStopGate(cwd: string): Promise<void> {
     // files (opt 3). Verdict-safe: semgrep is intraprocedural, so a net-new
     // code finding only appears in a file the diff touched, and the scan
     // falls back to full whenever the changed set can't be computed.
-    const result = await runGuardrailCheck({ cwd: dir, policy, scope, incremental: true });
+    const result = await runGuardrailCheck({
+      cwd: dir,
+      policy,
+      scope,
+      incremental: true,
+      flowMode,
+    });
     const json = renderJson(result);
     // Persist the full machine-readable verdict so the model (and a human)
     // can read the exact net-new findings the block message points to.

--- a/test/allowlist/hint.test.ts
+++ b/test/allowlist/hint.test.ts
@@ -55,6 +55,14 @@ const ENTRIES: Record<BaselineEntry['kind'], BaselineEntry> = {
     line: 42,
     category: 'test-fixture',
   },
+  'flow-binding': {
+    id: FP,
+    kind: 'flow-binding',
+    method: 'GET',
+    path: '/articles/{var}',
+    file: 'web/List.tsx',
+    line: 20,
+  },
 };
 
 const ALL_KINDS = Object.keys(ENTRIES) as BaselineEntry['kind'][];

--- a/test/baseline/check.test.ts
+++ b/test/baseline/check.test.ts
@@ -350,3 +350,55 @@ describe('runGuardrailCheck — identity-scheme migration guard', () => {
     await expect(runGuardrailCheck({ cwd: dir })).rejects.toThrow(/scheme/i);
   }, 300_000);
 });
+
+describe('runGuardrailCheck — flow integration gate seam', () => {
+  // Proves the flow gate is actually folded into the top-level verdict — not
+  // just that the helper works in isolation. A monorepo fixture (backend route
+  // + frontend call) run ref-based against `main` with a net-new dead call must
+  // flip result.blocks and attach result.flowGate. Full pipeline (~15s).
+  function makeFlowRepo(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-guardrail-flow-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', version: '0.0.0' }));
+    writeFileSync(join(dir, 'client.ts'), "axios.get('/articles');\n");
+    writeFileSync(join(dir, 'server.ts'), "class C { @get('/articles') a() {} }\n");
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync('git', ['commit', '-q', '-m', 'base'], { cwd: dir });
+    return dir;
+  }
+
+  let dir: string;
+  beforeEach(() => {
+    dir = makeFlowRepo();
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('folds a net-new broken integration into the top-level BLOCK verdict', async () => {
+    writeFileSync(join(dir, 'client.ts'), "axios.get('/articles');\naxios.get('/dead');\n");
+    const result = await runGuardrailCheck({ cwd: dir, cliMode: 'ref-based', cliRef: 'main' });
+    expect(result.blocks).toBe(true);
+    expect(result.flowGate?.ran).toBe(true);
+    expect(result.flowGate?.findings.map((f) => f.path)).toContain('/dead');
+    // The finding surfaces in the JSON payload the CLI + Stop-gate consume.
+    const json = renderJson(result);
+    expect(json.flowGate?.findings.some((f) => f.path === '/dead')).toBe(true);
+    expect(json.verdict.blocks).toBe(true);
+  }, 300_000);
+
+  it('warn flowMode surfaces the breakage without blocking the build', async () => {
+    writeFileSync(join(dir, 'client.ts'), "axios.get('/articles');\naxios.get('/dead');\n");
+    const result = await runGuardrailCheck({
+      cwd: dir,
+      cliMode: 'ref-based',
+      cliRef: 'main',
+      flowMode: 'warn',
+    });
+    expect(result.flowGate?.ran).toBe(true);
+    expect(result.flowGate?.findings.map((f) => f.path)).toContain('/dead');
+    // Flow warns, so IT does not block; the overall verdict isn't forced by flow.
+    expect(result.flowGate?.blocks).toBe(false);
+  }, 300_000);
+});

--- a/test/baseline/finding-identity.test.ts
+++ b/test/baseline/finding-identity.test.ts
@@ -717,6 +717,47 @@ const FIXTURES: ReadonlyArray<IdentityFixture> = [
     },
     expected: 'changed',
   },
+
+  // ─── flow-binding (4) ─────────────────────────────────────────────────
+  {
+    name: 'flow-binding/clean — same method, path, file',
+    prior: { kind: 'flow-binding', method: 'GET', path: '/articles/{var}', file: 'web/List.tsx' },
+    current: { kind: 'flow-binding', method: 'GET', path: '/articles/{var}', file: 'web/List.tsx' },
+    expected: 'persisted',
+  },
+  {
+    name: 'flow-binding/verb change → identity changes',
+    // A call re-pointed from GET to DELETE is a different integration.
+    prior: { kind: 'flow-binding', method: 'GET', path: '/articles/{var}', file: 'web/List.tsx' },
+    current: {
+      kind: 'flow-binding',
+      method: 'DELETE',
+      path: '/articles/{var}',
+      file: 'web/List.tsx',
+    },
+    expected: 'changed',
+  },
+  {
+    name: 'flow-binding/path change → identity changes',
+    prior: { kind: 'flow-binding', method: 'GET', path: '/articles/{var}', file: 'web/List.tsx' },
+    current: { kind: 'flow-binding', method: 'GET', path: '/comments/{var}', file: 'web/List.tsx' },
+    expected: 'changed',
+  },
+  {
+    name: 'flow-binding/moving the call to a different consuming file → identity changes',
+    // Identity is line-INDEPENDENT (a call moving within a file persists), but
+    // the consuming FILE is an identity input: a different file is a different
+    // integration dependency. (A pure file rename is relocated by the matcher's
+    // whole-file rename pass, not the hash.)
+    prior: { kind: 'flow-binding', method: 'GET', path: '/articles/{var}', file: 'web/List.tsx' },
+    current: {
+      kind: 'flow-binding',
+      method: 'GET',
+      path: '/articles/{var}',
+      file: 'web/Detail.tsx',
+    },
+    expected: 'changed',
+  },
 ];
 
 describe('identityFor — per-kind deterministic identity', () => {
@@ -934,6 +975,7 @@ const EXPECTED_KINDS = [
   'large-file',
   'secret-hmac',
   'stale-allow',
+  'flow-binding',
 ] as const;
 
 describe('identityFor — coverage contract (Rule 9)', () => {

--- a/test/baseline/flow-gate-check.test.ts
+++ b/test/baseline/flow-gate-check.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Integration tests for src/baseline/flow-gate-check.ts — the additive,
+ * fail-open flow gate pass over a real ref-based comparison. Each test builds a
+ * small monorepo git fixture (backend routes + frontend calls), commits a base
+ * state, mutates the working tree, and asserts the gate's verdict against the
+ * base ref. The pure net-new algorithm is covered by flow-gate.test.ts; here we
+ * exercise the wiring — trigger-skip, ref gather, served-truth self-skip, mode
+ * override, and fail-open.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { evaluateFlowGateForGuardrail } from '../../src/baseline/flow-gate-check';
+import type { ResolvedMode } from '../../src/baseline/modes';
+
+function git(dir: string, args: string[]): void {
+  execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+}
+
+/** A monorepo: backend serves GET /articles, frontend calls it. Committed on
+ *  `main` as the base state. */
+function makeFlowRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-flowgate-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'test']);
+  mkdirSync(join(dir, 'web'), { recursive: true });
+  mkdirSync(join(dir, 'api'), { recursive: true });
+  // A package.json makes the TypeScript pack detect as active — the surface
+  // trigger checks active packs (Rule 6), and every real Node repo has one.
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '0.0.0' }));
+  writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\n");
+  writeFileSync(join(dir, 'api', 'ctrl.ts'), "class C { @get('/articles') a() {} }\n");
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  return dir;
+}
+
+const refMode: ResolvedMode = {
+  mode: 'ref-based',
+  source: 'cli',
+  explanation: 'test',
+  ref: 'main',
+};
+
+describe('evaluateFlowGateForGuardrail — skip paths', () => {
+  it('skips when mode is not ref-based (committed mode)', async () => {
+    const dir = makeFlowRepo();
+    try {
+      const out = await evaluateFlowGateForGuardrail({
+        cwd: dir,
+        mode: { mode: 'committed-full', source: 'cli', explanation: 'test' },
+      });
+      expect(out.ran).toBe(false);
+      expect(out.skipped).toBe('not-ref-based');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips when policy mode is off', async () => {
+    const dir = makeFlowRepo();
+    try {
+      const out = await evaluateFlowGateForGuardrail({
+        cwd: dir,
+        mode: refMode,
+        modeOverride: 'off',
+      });
+      expect(out.ran).toBe(false);
+      expect(out.skipped).toBe('off');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('evaluateFlowGateForGuardrail — real ref-based gate', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeFlowRepo();
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('blocks a net-new call to a non-served endpoint', async () => {
+    // Working tree adds a NEW call to a route nobody serves.
+    writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/dead');\n");
+    const out = await evaluateFlowGateForGuardrail({ cwd: dir, mode: refMode });
+    expect(out.ran).toBe(true);
+    expect(out.blocks).toBe(true);
+    expect(out.findings.map((f) => f.path)).toContain('/dead');
+    const dead = out.findings.find((f) => f.path === '/dead')!;
+    expect(dead.reason).toBe('no-route');
+    expect(dead.verdict).toBe('block');
+  });
+
+  it('warn mode demotes a would-block breakage to a warning', async () => {
+    writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/dead');\n");
+    const out = await evaluateFlowGateForGuardrail({
+      cwd: dir,
+      mode: refMode,
+      modeOverride: 'warn',
+    });
+    expect(out.ran).toBe(true);
+    expect(out.blocks).toBe(false);
+    expect(out.warns).toBe(true);
+    expect(out.findings.every((f) => f.verdict === 'warn')).toBe(true);
+  });
+
+  it('passes clean when every call still resolves', async () => {
+    // No change to the working tree — the one call still resolves.
+    const out = await evaluateFlowGateForGuardrail({ cwd: dir, mode: refMode });
+    expect(out.blocks).toBe(false);
+    expect(out.findings).toEqual([]);
+  });
+
+  it('grandfathers a call that was already broken at base', async () => {
+    // Commit a broken call as the base, then make an UNRELATED change at HEAD.
+    writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/legacy');\n");
+    git(dir, ['add', '.']);
+    git(dir, ['commit', '-q', '-m', 'pre-existing break']);
+    git(dir, ['tag', 'base2']);
+    // HEAD: touch the file but keep the pre-existing broken call.
+    writeFileSync(
+      join(dir, 'web', 'List.tsx'),
+      "axios.get('/articles');\naxios.get('/legacy');\n// edit\n",
+    );
+    const out = await evaluateFlowGateForGuardrail({
+      cwd: dir,
+      mode: { ...refMode, ref: 'base2' },
+    });
+    expect(out.findings).toEqual([]); // /legacy was broken before → not net-new
+  });
+
+  it('skips a diff that touches no flow surface (docs-only change)', async () => {
+    writeFileSync(join(dir, 'README.md'), '# docs\n');
+    const out = await evaluateFlowGateForGuardrail({ cwd: dir, mode: refMode });
+    expect(out.ran).toBe(false);
+    expect(out.skipped).toBe('no-flow-surface-change');
+  });
+});
+
+describe('evaluateFlowGateForGuardrail — served-truth self-skip', () => {
+  it('skips when neither side has any served route (frontend-only, no snapshot)', async () => {
+    // A repo that only makes calls and serves nothing — with no committed
+    // served.json, there is no truth to gate against, so it must not false-block.
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-flowgate-fe-'));
+    try {
+      git(dir, ['init', '-q', '-b', 'main']);
+      git(dir, ['config', 'user.email', 'test@example.com']);
+      git(dir, ['config', 'user.name', 'test']);
+      mkdirSync(join(dir, 'web'), { recursive: true });
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fe', version: '0.0.0' }));
+      writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\n");
+      git(dir, ['add', '.']);
+      git(dir, ['commit', '-q', '-m', 'base']);
+      // HEAD adds another call — still no served side anywhere.
+      writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/more');\n");
+      const out = await evaluateFlowGateForGuardrail({ cwd: dir, mode: refMode });
+      expect(out.ran).toBe(false);
+      expect(out.skipped).toBe('no-served-truth');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('gates a frontend against a committed counterpart served.json (cross-repo)', async () => {
+    // A frontend repo serving nothing itself, but carrying the backend's
+    // committed served.json snapshot. The gate must resolve calls against that
+    // snapshot: a new call NOT in it blocks; a call that IS in it does not.
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-flowgate-xrepo-'));
+    try {
+      git(dir, ['init', '-q', '-b', 'main']);
+      git(dir, ['config', 'user.email', 'test@example.com']);
+      git(dir, ['config', 'user.name', 'test']);
+      mkdirSync(join(dir, 'web'), { recursive: true });
+      mkdirSync(join(dir, '.dxkit', 'flow'), { recursive: true });
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fe', version: '0.0.0' }));
+      writeFileSync(
+        join(dir, '.dxkit', 'flow', 'served.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          generatedAt: '',
+          side: 'served',
+          routes: [{ method: 'GET', path: '/articles', handler: null, via: 'spec' }],
+        }),
+      );
+      writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\n");
+      git(dir, ['add', '.']);
+      git(dir, ['commit', '-q', '-m', 'base']);
+      // HEAD: keep the resolving call, add one the counterpart does NOT serve.
+      writeFileSync(
+        join(dir, 'web', 'List.tsx'),
+        "axios.get('/articles');\naxios.get('/ghost');\n",
+      );
+      const out = await evaluateFlowGateForGuardrail({ cwd: dir, mode: refMode });
+      expect(out.ran).toBe(true);
+      expect(out.blocks).toBe(true);
+      // /ghost blocks; /articles resolved against the snapshot and did not.
+      expect(out.findings.map((f) => f.path)).toEqual(['/ghost']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/baseline/producers-contract.test.ts
+++ b/test/baseline/producers-contract.test.ts
@@ -57,6 +57,7 @@ const ALL_KINDS: ReadonlyArray<IdentityKind> = [
   'large-file',
   'secret-hmac',
   'stale-allow',
+  'flow-binding',
 ];
 
 /** Compile-time exhaustiveness check — adding a new kind to

--- a/test/flow-config.test.ts
+++ b/test/flow-config.test.ts
@@ -1,0 +1,80 @@
+/** Tests for src/analyzers/flow/config.ts — the single reader of the
+ *  `.dxkit/policy.json:flow` section. Fail-open to conservative defaults. */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readFlowConfig } from '../src/analyzers/flow/config';
+
+function repoWith(policy: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-flowcfg-'));
+  mkdirSync(join(dir, '.dxkit'), { recursive: true });
+  writeFileSync(join(dir, '.dxkit', 'policy.json'), JSON.stringify(policy));
+  return dir;
+}
+
+describe('readFlowConfig', () => {
+  it('returns conservative defaults when no policy file exists', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-flowcfg-none-'));
+    try {
+      const c = readFlowConfig(dir);
+      expect(c).toEqual({ stripUrlPrefixes: [], specs: [], mode: 'block', blockThreshold: 1 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads a full flow section', () => {
+    const dir = repoWith({
+      flow: {
+        stripUrlPrefixes: ['https://api.example.com'],
+        specs: ['openapi.json', 'v2.yaml'],
+        mode: 'warn',
+        blockThreshold: 0.5,
+      },
+    });
+    try {
+      expect(readFlowConfig(dir)).toEqual({
+        stripUrlPrefixes: ['https://api.example.com'],
+        specs: ['openapi.json', 'v2.yaml'],
+        mode: 'warn',
+        blockThreshold: 0.5,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back per-field on bad types (fail-open)', () => {
+    const dir = repoWith({ flow: { mode: 'nonsense', blockThreshold: -3, specs: 'not-array' } });
+    try {
+      const c = readFlowConfig(dir);
+      expect(c.mode).toBe('block'); // invalid mode → default
+      expect(c.blockThreshold).toBe(1); // non-positive → default
+      expect(c.specs).toEqual([]); // non-array → empty
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns defaults on malformed JSON', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-flowcfg-bad-'));
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(join(dir, '.dxkit', 'policy.json'), '{ not json');
+    try {
+      expect(readFlowConfig(dir).mode).toBe('block');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('drops non-string entries from string lists', () => {
+    const dir = repoWith({ flow: { specs: ['ok.json', 3, null, 'also.yaml'] } });
+    try {
+      expect(readFlowConfig(dir).specs).toEqual(['ok.json', 'also.yaml']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/flow-contract.test.ts
+++ b/test/flow-contract.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for src/analyzers/flow/contract.ts — the cross-repo served/consumed
+ * snapshots. Covers building from a model (dedup, spec-wins, sort stability),
+ * the write→read round-trip, fail-open reads, and the served key-set lookup.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildServedContract,
+  buildConsumedContract,
+  writeServedContract,
+  writeConsumedContract,
+  readServedContract,
+  readConsumedContract,
+  servedKeySet,
+  FLOW_DIR,
+  SERVED_SNAPSHOT,
+} from '../src/analyzers/flow/contract';
+import type { ClientCall, RouteEndpoint } from '../src/analyzers/flow/extract';
+import type { FlowModel } from '../src/analyzers/flow/model';
+
+const META = { schemaVersion: 1 as const, generatedAt: '2026-07-01T00:00:00Z' };
+
+function call(over: Partial<ClientCall>): ClientCall {
+  return {
+    method: 'GET',
+    rawUrl: '/x',
+    path: '/x',
+    receiver: 'axios',
+    file: 'web/a.tsx',
+    line: 10,
+    ...over,
+  };
+}
+function route(over: Partial<RouteEndpoint>): RouteEndpoint {
+  return {
+    method: 'GET',
+    path: '/x',
+    via: 'router-call',
+    handler: 'h',
+    file: 'api/x.ts',
+    line: 1,
+    ...over,
+  };
+}
+function model(calls: ClientCall[], routes: RouteEndpoint[]): FlowModel {
+  return { calls, routes, bindings: [] };
+}
+
+let tmpDir: string;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-contract-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('buildServedContract', () => {
+  it('dedups by (method, path) with spec winning, sorted stably', () => {
+    const c = buildServedContract(
+      model(
+        [],
+        [
+          route({ path: '/b', via: 'router-call' }),
+          route({ path: '/a', via: 'router-call' }),
+          route({ path: '/a', via: 'spec', handler: 'spec.a' }),
+        ],
+      ),
+      META,
+    );
+    expect(c.side).toBe('served');
+    expect(c.routes.map((r) => r.path)).toEqual(['/a', '/b']); // sorted
+    const a = c.routes.find((r) => r.path === '/a');
+    expect(a?.via).toBe('spec');
+    expect(a?.handler).toBe('spec.a');
+  });
+});
+
+describe('buildConsumedContract', () => {
+  it('keeps internal calls, drops external (null path), dedups by (method,path,file)', () => {
+    const c = buildConsumedContract(
+      model(
+        [
+          call({ path: '/x', file: 'web/a.tsx', line: 30 }),
+          call({ path: '/x', file: 'web/a.tsx', line: 10 }), // dup, lower line kept
+          call({ path: null, file: 'web/a.tsx', line: 5 }), // external → dropped
+          call({ path: '/y', method: 'POST', file: 'web/b.tsx', line: 3 }),
+        ],
+        [],
+      ),
+      META,
+    );
+    expect(c.side).toBe('consumed');
+    expect(c.bindings).toHaveLength(2);
+    const x = c.bindings.find((b) => b.path === '/x');
+    expect(x?.line).toBe(10); // earliest line kept for display
+    expect(c.bindings.some((b) => b.method === 'POST' && b.path === '/y')).toBe(true);
+  });
+});
+
+describe('write → read round-trip', () => {
+  it('served snapshot round-trips and lands at .dxkit/flow/served.json', () => {
+    const c = buildServedContract(model([], [route({ path: '/a' })]), META);
+    const file = writeServedContract(tmpDir, c);
+    expect(file).toBe(path.join(tmpDir, FLOW_DIR, SERVED_SNAPSHOT));
+    const back = readServedContract(tmpDir);
+    expect(back?.routes.map((r) => r.path)).toEqual(['/a']);
+  });
+
+  it('consumed snapshot round-trips', () => {
+    const c = buildConsumedContract(model([call({ path: '/x' })], []), META);
+    writeConsumedContract(tmpDir, c);
+    const back = readConsumedContract(tmpDir);
+    expect(back?.bindings[0]).toMatchObject({ method: 'GET', path: '/x', file: 'web/a.tsx' });
+  });
+});
+
+describe('fail-open reads', () => {
+  it('returns undefined for a missing snapshot', () => {
+    expect(readServedContract(tmpDir)).toBeUndefined();
+    expect(readConsumedContract(tmpDir)).toBeUndefined();
+  });
+
+  it('returns undefined for a malformed or wrong-side snapshot', () => {
+    fs.mkdirSync(path.join(tmpDir, FLOW_DIR), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, FLOW_DIR, SERVED_SNAPSHOT), '{ not json');
+    expect(readServedContract(tmpDir)).toBeUndefined();
+    // A consumed doc read as served → undefined (side guard).
+    const consumed = buildConsumedContract(model([call({})], []), META);
+    writeConsumedContract(tmpDir, consumed);
+    expect(
+      readServedContract(tmpDir, path.join(tmpDir, FLOW_DIR, 'consumed.json')),
+    ).toBeUndefined();
+  });
+});
+
+describe('servedKeySet', () => {
+  it('exposes the ${method} ${path} lookup keys', () => {
+    const c = buildServedContract(
+      model([], [route({ path: '/a' }), route({ method: 'POST', path: '/b' })]),
+      META,
+    );
+    const keys = servedKeySet(c);
+    expect(keys.has('GET /a')).toBe(true);
+    expect(keys.has('POST /b')).toBe(true);
+    expect(keys.has('DELETE /a')).toBe(false);
+  });
+});

--- a/test/flow-gate.test.ts
+++ b/test/flow-gate.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for src/analyzers/flow/gate.ts — the pure net-new broken-integration
+ * evaluation. Exercises both PR directions (frontend adds a dead call; backend
+ * removes a live route), the net-new-vs-grandfathered boundary, and confidence
+ * gating (block vs warn).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { evaluateFlowGate, flowGateBlocks, type GateInputs } from '../src/analyzers/flow/gate';
+import type { ConsumedBinding } from '../src/analyzers/flow/contract';
+
+function b(over: Partial<ConsumedBinding>): ConsumedBinding {
+  return {
+    method: 'GET',
+    path: '/articles',
+    file: 'web/List.tsx',
+    line: 20,
+    confidence: 1,
+    ...over,
+  };
+}
+
+function inputs(over: Partial<GateInputs>): GateInputs {
+  return {
+    headConsumed: [],
+    baseConsumed: [],
+    headServed: new Set(),
+    baseServed: new Set(),
+    ...over,
+  };
+}
+
+describe('evaluateFlowGate — net-new detection', () => {
+  it('frontend PR: a NEW call to a non-served endpoint is net-new broken', () => {
+    const call = b({ path: '/usrs' }); // typo — never served
+    const found = evaluateFlowGate(
+      inputs({
+        headConsumed: [call],
+        baseConsumed: [], // the call did not exist at base
+        headServed: new Set(['GET /articles']),
+        baseServed: new Set(['GET /articles']),
+      }),
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ path: '/usrs', reason: 'no-route', verdict: 'block' });
+  });
+
+  it('backend PR: removing a route a consumer still binds to is net-new broken', () => {
+    const call = b({ path: '/articles' });
+    const found = evaluateFlowGate(
+      inputs({
+        headConsumed: [call],
+        baseConsumed: [call], // the binding existed at base
+        headServed: new Set(), // route removed at HEAD
+        baseServed: new Set(['GET /articles']), // ...but served at base
+      }),
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      path: '/articles',
+      reason: 'route-removed',
+      verdict: 'block',
+    });
+  });
+
+  it('grandfathers a binding already broken BEFORE the PR', () => {
+    const call = b({ path: '/legacy' });
+    const found = evaluateFlowGate(
+      inputs({
+        headConsumed: [call],
+        baseConsumed: [call], // present at base
+        headServed: new Set(['GET /articles']),
+        baseServed: new Set(['GET /articles']), // /legacy unresolved at base too
+      }),
+    );
+    expect(found).toEqual([]); // pre-existing breakage → not net-new
+  });
+
+  it('a resolving binding is never flagged', () => {
+    const found = evaluateFlowGate(
+      inputs({
+        headConsumed: [b({ path: '/articles' })],
+        headServed: new Set(['GET /articles']),
+        baseServed: new Set(['GET /articles']),
+      }),
+    );
+    expect(found).toEqual([]);
+  });
+});
+
+describe('evaluateFlowGate — confidence gating', () => {
+  it('a low-confidence (placeholder-only) net-new break WARNS, never blocks', () => {
+    const found = evaluateFlowGate(
+      inputs({
+        headConsumed: [b({ path: '/{var}', confidence: 0.3 })],
+        headServed: new Set(),
+        baseServed: new Set(),
+      }),
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].verdict).toBe('warn');
+    expect(flowGateBlocks(found)).toBe(false);
+  });
+
+  it('respects a custom block threshold', () => {
+    const found = evaluateFlowGate(
+      inputs({
+        headConsumed: [b({ path: '/x', confidence: 0.5 })],
+        headServed: new Set(),
+        baseServed: new Set(),
+        blockThreshold: 0.4,
+      }),
+    );
+    expect(found[0].verdict).toBe('block');
+  });
+});
+
+describe('evaluateFlowGate — identity + ordering', () => {
+  it('stamps a stable 16-char flow-binding fingerprint', () => {
+    const found = evaluateFlowGate(
+      inputs({ headConsumed: [b({ path: '/x' })], headServed: new Set(), baseServed: new Set() }),
+    );
+    expect(found[0].id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('orders blocks before warns', () => {
+    const found = evaluateFlowGate(
+      inputs({
+        headConsumed: [
+          b({ path: '/{var}', file: 'web/a.tsx', confidence: 0.3 }), // warn
+          b({ path: '/dead', file: 'web/b.tsx', confidence: 1 }), // block
+        ],
+        headServed: new Set(),
+        baseServed: new Set(),
+      }),
+    );
+    expect(found.map((f) => f.verdict)).toEqual(['block', 'warn']);
+  });
+});

--- a/test/flow-surface.test.ts
+++ b/test/flow-surface.test.ts
@@ -1,0 +1,45 @@
+/** Tests for the flow-surface registry helpers in src/languages/index.ts —
+ *  the pack-driven set of extensions that can carry flow, and the changed-files
+ *  trigger that gates the ref-based flow gate. */
+
+import { describe, it, expect } from 'vitest';
+import { LANGUAGES, allFlowSourceExtensions, changedFilesTouchFlowSurface } from '../src/languages';
+
+describe('allFlowSourceExtensions', () => {
+  it('includes the TypeScript pack extensions (httpFlow + a grammar)', () => {
+    const exts = allFlowSourceExtensions(LANGUAGES);
+    expect(exts).toContain('.ts');
+    expect(exts).toContain('.tsx');
+    expect(exts).toContain('.js');
+  });
+
+  it('is empty for a pack set with no flow-capable pack', () => {
+    expect(allFlowSourceExtensions([])).toEqual([]);
+  });
+});
+
+describe('changedFilesTouchFlowSurface', () => {
+  it('is true when a source file in a flow extension changed', () => {
+    expect(changedFilesTouchFlowSurface(['web/List.tsx', 'README.md'], LANGUAGES)).toBe(true);
+  });
+
+  it('is false when only non-source files changed', () => {
+    expect(
+      changedFilesTouchFlowSurface(['README.md', 'docs/x.png', '.github/ci.yml'], LANGUAGES),
+    ).toBe(false);
+  });
+
+  it('is true when a configured spec changed even with no source change', () => {
+    expect(
+      changedFilesTouchFlowSurface(['api/openapi.json'], LANGUAGES, ['api/openapi.json']),
+    ).toBe(true);
+  });
+
+  it('normalizes backslash paths (Windows changed-file lists)', () => {
+    expect(changedFilesTouchFlowSurface(['web\\src\\List.tsx'], LANGUAGES)).toBe(true);
+  });
+
+  it('is false (nothing to gate) when no flow-capable pack is active', () => {
+    expect(changedFilesTouchFlowSurface(['web/List.tsx'], [])).toBe(false);
+  });
+});

--- a/test/loop/policy.test.ts
+++ b/test/loop/policy.test.ts
@@ -33,8 +33,11 @@ describe('loop policy presets', () => {
   });
 
   it('security-only does NOT block test-gap or quality, but DOES block the security class', () => {
-    const { preset, policy } = resolveLoopPolicy(repo);
+    const { preset, policy, flowMode } = resolveLoopPolicy(repo);
     expect(preset).toBe('security-only');
+    // Flow integration breakage warns (not a security class; a cross-repo false
+    // positive must never wedge an unattended loop).
+    expect(flowMode).toBe('warn');
     // No generic status-based block — debt findings (added) warn, never block.
     expect(policy.block).toEqual([]);
     // Open-ended debt off.
@@ -50,11 +53,13 @@ describe('loop policy presets', () => {
 
   it('full-debt blocks every net-new finding incl. test-gap + quality', () => {
     writePolicy(repo, { loop: { preset: 'full-debt' } });
-    const { preset, policy } = resolveLoopPolicy(repo);
+    const { preset, policy, flowMode } = resolveLoopPolicy(repo);
     expect(preset).toBe('full-debt');
     expect(policy.block).toEqual(['added']);
     expect(policy.blockRules.newUntestedChangedSource).toBe(true);
     expect(policy.blockRules.newSevereQualityIssueInChangedFiles).toBe(true);
+    // Full-debt blocks integration breakage too.
+    expect(flowMode).toBe('block');
   });
 
   it('reads loop.preset from .dxkit/policy.json', () => {

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -43,8 +43,10 @@ import {
   changedFilesTouchDependencyManifest,
   allDocCommentPatterns,
   allExportDetectionDeclarations,
+  allFlowSourceExtensions,
   allHttpFlow,
   allModelPaths,
+  changedFilesTouchFlowSurface,
   allPrimaryComponentPaths,
   allRoutePaths,
   allSourceExtensions,
@@ -116,6 +118,11 @@ const mockPlaybookPack = {
     routeRouterCallees: { methods: ['playbookGet'], bases: ['playbookApp'] },
     methodAliases: { playbookDel: 'DELETE' },
   },
+  // A grammar alongside httpFlow makes the synthetic pack flow-CAPABLE, so its
+  // extensions flow through `allFlowSourceExtensions` /
+  // `changedFilesTouchFlowSurface` — codifying "the flow-gate trigger is
+  // pack-driven, not a hardcoded extension list."
+  treeSitterGrammars: { '.pbk': 'playbook-lang' },
   detect: vi.fn(() => false),
   tools: [],
   semgrepRulesets: [],
@@ -655,6 +662,22 @@ describe('recipe playbook — synthetic pack', () => {
     expect(real).toBeDefined();
     expect(real?.routeDecorators).toContain('del'); // LoopBack delete decorator
     expect(real?.routeRouterCallees?.bases).toContain('router'); // Express
+  });
+
+  // Flow-gate trigger: the surface helpers iterate active packs (httpFlow +
+  // grammar). The synthetic pack contributes `.pbk`; the real typescript pack
+  // contributes `.ts`/`.tsx` — the union must carry both, and a changed file in
+  // either extension must trip the trigger. Codifies "the ref-based flow-gate
+  // skip is pack-driven, not a hardcoded extension list."
+  it('allFlowSourceExtensions + changedFilesTouchFlowSurface pick up the mock pack', () => {
+    const packs = [...LANGUAGES]; // LANGUAGES includes the injected synthetic pack (beforeAll)
+    const exts = allFlowSourceExtensions(packs);
+    expect(exts).toContain('.pbk'); // synthetic pack's flow extension
+    expect(exts).toContain('.ts'); // real typescript pack's
+    // A changed synthetic-flow source file trips the trigger.
+    expect(changedFilesTouchFlowSurface(['app/Widget.pbk'], packs)).toBe(true);
+    // A non-flow change does not.
+    expect(changedFilesTouchFlowSurface(['README.md'], packs)).toBe(false);
   });
 
   it('allTestGapPriorityPaths unions all three buckets across active packs (C8)', () => {


### PR DESCRIPTION
The Flow feature's third slice — turns UI→API traceability into a guardrail. A PR that net-new breaks an integration (a frontend call to an endpoint no backend serves, or a backend route removal a consumer still binds to) now fails the check, the same way a net-new secret or CVE does.

## What's in it (rebase-merge — 4 independently-meaningful commits + release bump)

1. **`flow-binding` identity** — a line-independent, environment-independent `(method, path, file)` finding identity wired through the whole identity contract (fingerprint, baseline entry, allowlist, migration, exhaustive-consumer ripples).
2. **Cross-repo contract snapshots** (`.dxkit/flow/served.json` + `consumed.json`) — the committed inventory each side gates the other against; single reader/writer confined by arch Rule 13c.
3. **Pure gate core** (`evaluateFlowGate`) — net-new broken-integration detection over a base↔HEAD contract diff; one algorithm both directions, grandfathers pre-existing breakage, confidence-gated.
4. **Guardrail wiring** — folds the gate into `runGuardrailCheck` as an additive, fail-open pass (ref-based base↔HEAD gather via `withRefWorktree`; pack-driven trigger-skip; self-skips with no served-side truth). Adds `flow refresh`, the `flow.mode` policy knob + loop-preset override, and console/JSON/markdown rendering.

## Testing
- Pure gate: 15 tests · wiring helper: 8 real-git integration tests · **2 full-pipeline seam tests** proving `runGuardrailCheck` folds the verdict into `result.blocks` + `result.flowGate` + `renderJson` · cross-repo `served.json` union test · config/surface/recipe/loop-preset tests.
- Recipe hardened: a synthetic pack flows through the new pack-driven surface helpers.
- Live end-to-end verified: `guardrail check --mode ref-based` blocks a net-new dead call with exit 1.
- Full suite: 2674 pass.

## Safety
Runs ref-based only, confidence-gated (placeholder paths warn), self-skips when it has no served-side truth, and fails open on any error — it can never false-block a repo it can't fully see. The loop preset keeps it to a warning under `security-only` so an unattended loop can't wedge on a cross-repo false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)