### PR TITLE
fix(flow): honor the per-finding allowlist in the integration gate (2.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.21.1] - 2026-07-01
+
+### Fixed — the flow gate now honors the per-finding allowlist
+
+A net-new broken integration could not be accepted per-finding: the
+`flow-binding` allowlist category and identity existed, but the guardrail's
+flow pass ran outside the matcher-pair suppression path, so an allowlist entry
+never actually waived a flow block. The only escape hatch was the global
+`flow.mode`. Now an active `flow-binding` allowlist entry (matched by
+fingerprint, kind-guarded, expiry-respected) waives the block exactly like any
+other finding kind — the finding is still surfaced as "suppressed by allowlist"
+in the console, `--json`, and PR-comment markdown, but no longer fails the
+build. Expired entries do not waive; the finding re-blocks.
+
+### Known limitation (tracked)
+
+The flow gate runs in **ref-based mode only**. In committed-baseline modes it
+skips (no committed prior flow side to diff against), so a repo pinned to
+`committed-full` is not yet flow-gated unless it sets `baseline.mode: ref-based`.
+A fix that recomputes the base flow model from the baseline's commit is planned.
+
 ## [2.21.0] - 2026-07-01
 
 ### Added — the integration gate (`flow refresh` + guardrail flow pass)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.21.0",
+      "version": "2.21.1",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -166,7 +166,9 @@ export function renderConsole(result: GuardrailCheckResult): string {
  * grouped separately from warnings so the actionable set surfaces first.
  */
 function formatFlowGate(flow: FlowGateOutcome | undefined): string[] {
-  if (!flow || flow.findings.length === 0) return [];
+  if (!flow) return [];
+  const suppressed = flow.suppressed ?? [];
+  if (flow.findings.length === 0 && suppressed.length === 0) return [];
   const out: string[] = [];
   const blocking = flow.findings.filter((f) => f.verdict === 'block');
   const warning = flow.findings.filter((f) => f.verdict === 'warn');
@@ -178,6 +180,15 @@ function formatFlowGate(flow: FlowGateOutcome | undefined): string[] {
   if (warning.length > 0) {
     out.push(logger.bold(`Flow breakage — warning (${warning.length})`));
     for (const f of warning) out.push(`  ${describeBrokenIntegration(f)}`);
+    out.push('');
+  }
+  if (suppressed.length > 0) {
+    out.push(logger.bold(`Flow breakage — suppressed by allowlist (${suppressed.length})`));
+    for (const s of suppressed) {
+      const exp = s.expiresAt ? `, expires ${s.expiresAt}` : '';
+      out.push(`  ${describeBrokenIntegration(s.finding)}`);
+      out.push(`    · allowlisted: ${s.category}${exp} (waived from the verdict)`);
+    }
     out.push('');
   }
   return out;
@@ -392,6 +403,18 @@ export interface GuardrailJsonPayload {
       readonly reason: string;
       readonly verdict: 'block' | 'warn';
     }>;
+    /** Broken integrations an active allowlist entry waived — excluded from
+     *  `blocks` / `warns`, surfaced for audit. */
+    readonly suppressed: ReadonlyArray<{
+      readonly id: string;
+      readonly method: string;
+      readonly path: string;
+      readonly file: string;
+      readonly line: number;
+      readonly reason: string;
+      readonly category: string;
+      readonly expiresAt?: string;
+    }>;
   };
 }
 
@@ -489,6 +512,16 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
               confidence: f.confidence,
               reason: f.reason,
               verdict: f.verdict,
+            })),
+            suppressed: (result.flowGate.suppressed ?? []).map((s) => ({
+              id: s.finding.id,
+              method: s.finding.method,
+              path: s.finding.path,
+              file: s.finding.file,
+              line: s.finding.line,
+              reason: s.finding.reason,
+              category: s.category,
+              ...(s.expiresAt !== undefined ? { expiresAt: s.expiresAt } : {}),
             })),
           },
         }
@@ -633,7 +666,9 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
  * Silent when the gate produced no findings.
  */
 function markdownFlowGate(flow: FlowGateOutcome | undefined): string[] {
-  if (!flow || flow.findings.length === 0) return [];
+  if (!flow) return [];
+  const suppressed = flow.suppressed ?? [];
+  if (flow.findings.length === 0 && suppressed.length === 0) return [];
   const out: string[] = [];
   const blocking = flow.findings.filter((f) => f.verdict === 'block');
   const warning = flow.findings.filter((f) => f.verdict === 'warn');
@@ -655,6 +690,28 @@ function markdownFlowGate(flow: FlowGateOutcome | undefined): string[] {
     out.push('| Endpoint | Reason | Consumer | Confidence |');
     out.push('|---|---|---|---|');
     for (const f of warning) out.push(row(f));
+    out.push('');
+    out.push('</details>');
+    out.push('');
+  }
+  if (suppressed.length > 0) {
+    out.push('<details>');
+    out.push(
+      `<summary>Integration findings suppressed by allowlist (${suppressed.length})</summary>`,
+    );
+    out.push('');
+    out.push('These would block/warn, but an active allowlist entry accepted them.');
+    out.push('');
+    out.push('| Endpoint | Reason | Consumer | Category | Expires |');
+    out.push('|---|---|---|---|---|');
+    for (const s of suppressed) {
+      const f = s.finding;
+      out.push(
+        `| ${escapeMd(`${f.method} ${f.path}`)} | ${escapeMd(f.reason)} | ` +
+          `${escapeMd(`${f.file}:${f.line}`)} | ${escapeMd(s.category)} | ` +
+          `${escapeMd(s.expiresAt ?? '—')} |`,
+      );
+    }
     out.push('');
     out.push('</details>');
     out.push('');

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -664,6 +664,11 @@ export async function runGuardrailCheck(
   const flowGate = await evaluateFlowGateForGuardrail({
     cwd,
     mode,
+    // Same loaded allowlist + clock the matcher-pair suppression uses, so an
+    // active `flow-binding` entry waives a flow block exactly like any other
+    // finding kind (the per-finding escape hatch).
+    allowlist,
+    now,
     ...(options.flowMode !== undefined ? { modeOverride: options.flowMode } : {}),
     ...(options.verbose !== undefined ? { verbose: options.verbose } : {}),
   });

--- a/src/baseline/flow-gate-check.ts
+++ b/src/baseline/flow-gate-check.ts
@@ -37,6 +37,8 @@ import {
 } from '../analyzers/flow/contract';
 import { evaluateFlowGate, type BrokenIntegration } from '../analyzers/flow/gate';
 import { readFlowConfig, type FlowGateMode } from '../analyzers/flow/config';
+import { findEntry, isEntryActive } from '../allowlist/file';
+import type { AllowlistFile } from '../allowlist/file';
 
 /** Why the gate produced no verdict, when it didn't run. */
 export type FlowGateSkip =
@@ -46,6 +48,16 @@ export type FlowGateSkip =
   | 'no-served-truth' // no served inventory (monorepo route set + snapshot both empty)
   | 'error'; // any failure — fail-open
 
+/** A broken integration that an active allowlist entry waived from the verdict.
+ *  Mirrors the matcher pairs' `suppressedByAllowlist`: the finding is still
+ *  surfaced (for audit), but it does not block or warn. */
+export interface FlowGateSuppression {
+  readonly finding: BrokenIntegration;
+  readonly fingerprint: string;
+  readonly category: string;
+  readonly expiresAt?: string;
+}
+
 /** Outcome of the flow gate pass, folded additively into the guardrail verdict. */
 export interface FlowGateOutcome {
   /** True when the gate actually evaluated a base↔HEAD comparison. */
@@ -54,12 +66,16 @@ export interface FlowGateOutcome {
   readonly skipped?: FlowGateSkip;
   /** The effective mode after the loop-seam override (block / warn / off). */
   readonly mode: FlowGateMode;
-  /** Net-new broken integrations. In `warn` mode every finding's verdict is
+  /** Net-new broken integrations that count toward the verdict (active — NOT
+   *  waived by an allowlist entry). In `warn` mode every finding's verdict is
    *  demoted to `warn` so renderers present them as warnings. */
   readonly findings: readonly BrokenIntegration[];
-  /** True when at least one finding blocks (only possible in `block` mode). */
+  /** Broken integrations an active allowlist entry accepted — surfaced for
+   *  audit, excluded from `blocks` / `warns`. */
+  readonly suppressed: readonly FlowGateSuppression[];
+  /** True when at least one active finding blocks (only possible in `block` mode). */
   readonly blocks: boolean;
-  /** True when at least one finding warns. */
+  /** True when at least one active finding warns. */
   readonly warns: boolean;
 }
 
@@ -68,7 +84,47 @@ export interface FlowGateOutcome {
 const GATE_META = { schemaVersion: 1 as const, generatedAt: '' };
 
 function skip(mode: FlowGateMode, reason: FlowGateSkip): FlowGateOutcome {
-  return { ran: false, skipped: reason, mode, findings: [], blocks: false, warns: false };
+  return {
+    ran: false,
+    skipped: reason,
+    mode,
+    findings: [],
+    suppressed: [],
+    blocks: false,
+    warns: false,
+  };
+}
+
+/**
+ * Partition net-new broken integrations into active (count toward the verdict)
+ * and allowlist-suppressed. A `flow-binding` allowlist entry whose fingerprint
+ * matches a finding's id, is the right kind, and is unexpired waives it —
+ * mirroring the matcher-pair suppression so "I reviewed and accepted this
+ * integration finding" is an honored, per-finding escape hatch (not just the
+ * global `flow.mode`). Expired entries do not waive — the finding re-blocks.
+ */
+function partitionByAllowlist(
+  findings: readonly BrokenIntegration[],
+  allowlist: AllowlistFile | null | undefined,
+  now: Date,
+): { active: BrokenIntegration[]; suppressed: FlowGateSuppression[] } {
+  if (!allowlist) return { active: [...findings], suppressed: [] };
+  const active: BrokenIntegration[] = [];
+  const suppressed: FlowGateSuppression[] = [];
+  for (const f of findings) {
+    const entry = findEntry(allowlist, f.id);
+    if (entry && entry.kind === 'flow-binding' && isEntryActive(entry, now)) {
+      suppressed.push({
+        finding: f,
+        fingerprint: entry.fingerprint,
+        category: entry.category,
+        ...(entry.expiresAt !== undefined ? { expiresAt: entry.expiresAt } : {}),
+      });
+    } else {
+      active.push(f);
+    }
+  }
+  return { active, suppressed };
 }
 
 /**
@@ -79,12 +135,18 @@ function skip(mode: FlowGateMode, reason: FlowGateSkip): FlowGateOutcome {
  * @param modeOverride the loop Stop-gate's posture-derived mode (the seam that
  *   lets `security-only` warn while `full-debt` blocks) — wins over the
  *   `.dxkit/policy.json:flow.mode` default.
+ * @param allowlist the loaded per-finding allowlist; an active `flow-binding`
+ *   entry matching a finding waives it from the verdict (the per-finding escape
+ *   hatch). Omit / null for no suppression.
+ * @param now the clock for allowlist-expiry checks (passed for testability).
  */
 export async function evaluateFlowGateForGuardrail(opts: {
   readonly cwd: string;
   readonly mode: ResolvedMode;
   readonly modeOverride?: FlowGateMode;
   readonly verbose?: boolean;
+  readonly allowlist?: AllowlistFile | null;
+  readonly now?: Date;
 }): Promise<FlowGateOutcome> {
   const cwd = path.resolve(opts.cwd);
   const config = readFlowConfig(cwd);
@@ -155,17 +217,25 @@ export async function evaluateFlowGateForGuardrail(opts: {
     // Apply the posture. `warn` demotes every finding so renderers show them as
     // warnings and nothing fails the build; `block` honors each per-finding
     // verdict (exact → block, placeholder → warn).
-    const findings =
+    const posture =
       gateMode === 'warn' ? found.map((f) => ({ ...f, verdict: 'warn' as const })) : found;
-    const blocks = gateMode === 'block' && findings.some((f) => f.verdict === 'block');
-    const warns = findings.some((f) => f.verdict === 'warn');
 
-    if (opts.verbose && findings.length > 0) {
+    // Per-finding allowlist suppression — an accepted integration finding is
+    // waived from the verdict but still surfaced for audit.
+    const { active, suppressed } = partitionByAllowlist(
+      posture,
+      opts.allowlist,
+      opts.now ?? new Date(),
+    );
+    const blocks = gateMode === 'block' && active.some((f) => f.verdict === 'block');
+    const warns = active.some((f) => f.verdict === 'warn');
+
+    if (opts.verbose && active.length > 0) {
       process.stderr.write(
-        `    [flow] ${findings.length} net-new broken integration(s) — ${blocks ? 'blocking' : 'warning'}\n`,
+        `    [flow] ${active.length} net-new broken integration(s) — ${blocks ? 'blocking' : 'warning'}\n`,
       );
     }
-    return { ran: true, mode: gateMode, findings, blocks, warns };
+    return { ran: true, mode: gateMode, findings: active, suppressed, blocks, warns };
   } catch {
     // Fail-open: a ref that can't be checked out, an unparseable tree, a git
     // error — none of these should fail the guardrail. The gate simply did not

--- a/test/baseline/check.test.ts
+++ b/test/baseline/check.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'child_process';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { createBaseline } from '../../src/baseline/create';
 import { runGuardrailCheck } from '../../src/baseline/check';
 import { renderConsole, renderJson, renderMarkdown } from '../../src/baseline/check-renderers';
+import { computeFlowBindingFingerprint } from '../../src/analyzers/tools/fingerprint';
 
 /**
  * End-to-end exercise of the guardrail-check orchestrator. The
@@ -400,5 +401,36 @@ describe('runGuardrailCheck — flow integration gate seam', () => {
     expect(result.flowGate?.findings.map((f) => f.path)).toContain('/dead');
     // Flow warns, so IT does not block; the overall verdict isn't forced by flow.
     expect(result.flowGate?.blocks).toBe(false);
+  }, 300_000);
+
+  it('an allowlisted flow finding is waived from the top-level verdict', async () => {
+    writeFileSync(join(dir, 'client.ts'), "axios.get('/articles');\naxios.get('/dead');\n");
+    // Commit an allowlist accepting the /dead binding by its fingerprint — the
+    // guardrail's own loadAllowlist must honor it for flow, like any kind.
+    const fp = computeFlowBindingFingerprint('GET', '/dead', 'client.ts');
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(
+      join(dir, '.dxkit', 'allowlist.json'),
+      JSON.stringify({
+        schemaVersion: 'dxkit-allowlist/v1',
+        mode: 'full',
+        identityScheme: 'v2',
+        entries: [
+          {
+            fingerprint: fp,
+            kind: 'flow-binding',
+            category: 'false-positive',
+            addedAt: '2026-01-01',
+            reason: 'served externally',
+            addedBy: 'test',
+          },
+        ],
+      }),
+    );
+    const result = await runGuardrailCheck({ cwd: dir, cliMode: 'ref-based', cliRef: 'main' });
+    expect(result.flowGate?.ran).toBe(true);
+    expect(result.blocks).toBe(false); // the flow block was waived
+    expect(result.flowGate?.suppressed.map((s) => s.finding.path)).toContain('/dead');
+    expect(result.flowGate?.findings).toEqual([]);
   }, 300_000);
 });

--- a/test/baseline/flow-gate-check.test.ts
+++ b/test/baseline/flow-gate-check.test.ts
@@ -15,6 +15,8 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { evaluateFlowGateForGuardrail } from '../../src/baseline/flow-gate-check';
 import type { ResolvedMode } from '../../src/baseline/modes';
+import { computeFlowBindingFingerprint } from '../../src/analyzers/tools/fingerprint';
+import type { AllowlistFile } from '../../src/allowlist/file';
 
 function git(dir: string, args: string[]): void {
   execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
@@ -142,6 +144,75 @@ describe('evaluateFlowGateForGuardrail — real ref-based gate', () => {
   });
 });
 
+describe('evaluateFlowGateForGuardrail — allowlist suppression', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeFlowRepo();
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function allowlistFor(method: string, routePath: string, file: string, over = {}): AllowlistFile {
+    return {
+      schemaVersion: 'dxkit-allowlist/v1',
+      mode: 'full',
+      identityScheme: 'v2',
+      entries: [
+        {
+          fingerprint: computeFlowBindingFingerprint(method, routePath, file),
+          kind: 'flow-binding',
+          category: 'false-positive',
+          addedAt: '2026-01-01',
+          reason: 'served by a system dxkit cannot see',
+          addedBy: 'test',
+          ...over,
+        },
+      ],
+    } as AllowlistFile;
+  }
+
+  it('an active allowlist entry waives a flow block (per-finding escape hatch)', async () => {
+    writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/dead');\n");
+    const out = await evaluateFlowGateForGuardrail({
+      cwd: dir,
+      mode: refMode,
+      allowlist: allowlistFor('GET', '/dead', 'web/List.tsx'),
+    });
+    expect(out.ran).toBe(true);
+    expect(out.blocks).toBe(false); // waived
+    expect(out.findings).toEqual([]); // not counted
+    expect(out.suppressed).toHaveLength(1);
+    expect(out.suppressed[0]).toMatchObject({ category: 'false-positive' });
+    expect(out.suppressed[0].finding.path).toBe('/dead');
+  });
+
+  it('an EXPIRED allowlist entry does not waive — the finding re-blocks', async () => {
+    writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/dead');\n");
+    const out = await evaluateFlowGateForGuardrail({
+      cwd: dir,
+      mode: refMode,
+      now: new Date('2026-06-01'),
+      allowlist: allowlistFor('GET', '/dead', 'web/List.tsx', {
+        category: 'deferred',
+        expiresAt: '2020-01-01', // long past
+      }),
+    });
+    expect(out.blocks).toBe(true);
+    expect(out.suppressed).toEqual([]);
+    expect(out.findings.map((f) => f.path)).toContain('/dead');
+  });
+
+  it('an entry for a DIFFERENT binding does not waive this one', async () => {
+    writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/dead');\n");
+    const out = await evaluateFlowGateForGuardrail({
+      cwd: dir,
+      mode: refMode,
+      allowlist: allowlistFor('GET', '/other', 'web/List.tsx'), // wrong path → different id
+    });
+    expect(out.blocks).toBe(true);
+    expect(out.suppressed).toEqual([]);
+  });
+});
+
 describe('evaluateFlowGateForGuardrail — served-truth self-skip', () => {
   it('skips when neither side has any served route (frontend-only, no snapshot)', async () => {
     // A repo that only makes calls and serves nothing — with no committed
@@ -181,7 +252,7 @@ describe('evaluateFlowGateForGuardrail — served-truth self-skip', () => {
       writeFileSync(
         join(dir, '.dxkit', 'flow', 'served.json'),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 'dxkit-allowlist/v1',
           generatedAt: '',
           side: 'served',
           routes: [{ method: 'GET', path: '/articles', handler: null, via: 'spec' }],


### PR DESCRIPTION
## The gap

The flow integration gate (shipped in 2.21.0) ran **outside** the matcher-pair allowlist-suppression path. So although `flow-binding` is a real allowlist category with a computable fingerprint, an allowlist entry **never actually waived a flow block** — the only escape hatch was the global `flow.mode: warn/off`. That's a hole in the "false-positive-safe" promise: there was no per-finding "I reviewed and accept this integration finding" path.

## The fix

`evaluateFlowGateForGuardrail` now partitions net-new broken integrations against the loaded allowlist (matched by fingerprint, kind-guarded, expiry-respected). An accepted finding is **waived from the verdict** and surfaced as "suppressed by allowlist" in the console, `--json`, and PR-comment markdown — rather than failing the build. Expired entries do not waive; the finding re-blocks. `check.ts` passes the same `loadAllowlist` result + clock the matcher-pair path already uses.

## Tests
- 3 unit (active waives / expired re-blocks / wrong-binding doesn't waive)
- 1 end-to-end seam: commits a real `.dxkit/allowlist.json` and asserts the guardrail's own `loadAllowlist` honors it for flow
- Full suite: 2678 pass

## Tracked limitation (documented in CHANGELOG, not fixed here)
The flow gate runs in **ref-based mode only** — committed-baseline modes skip it (no committed prior flow side to diff against). A repo pinned to `committed-full` is not yet flow-gated unless it sets `baseline.mode: ref-based`. Fix planned (recompute base flow from the baseline's commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)