### PR TITLE
fix(flow): gate integrations in committed-baseline modes, not only ref-based

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.21.2] - 2026-07-02
+
+### Fixed — the flow gate now runs in committed-baseline modes too
+
+The flow integration gate previously ran only in ref-based mode; in
+committed-full / committed-sanitized it skipped, so a repo pinned to
+`committed-full` (the default for private repos) got no flow gating unless it
+switched to `baseline.mode: ref-based`. The gate needs only a base *commit* to
+diff HEAD against, not a committed prior flow side — so it now uses the
+committed baseline's recorded anchor commit (`repo.commitSha`) as the base and
+gathers that side's flow model fresh from a worktree, exactly as ref-based mode
+gathers from its ref. Net-new broken integrations now block (or warn) the same
+way in every baseline mode. Fail-open, trigger-skip, no-served-truth self-skip,
+and per-finding allowlist suppression are all unchanged. When no base commit is
+resolvable at all (no ref and no baseline anchor), the gate skips as before.
+
 ## [2.21.1] - 2026-07-01
 
 ### Fixed — the flow gate now honors the per-finding allowlist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.21.1",
+      "version": "2.21.2",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -657,13 +657,17 @@ export async function runGuardrailCheck(
   // and the renderer treats that as "delta unavailable."
   const allowlistDelta: AllowlistDelta = computeAllowlistDelta(cwd, baseline.repo.commitSha);
 
-  // The flow integration gate — an additive, fail-open pass over the same
-  // ref-based comparison. It runs its own base↔HEAD flow gather (independent of
-  // the finding matcher above) and never throws; its verdict folds into the
-  // top-level one. Runs only in ref-based mode.
+  // The flow integration gate — an additive, fail-open pass that runs its own
+  // base↔HEAD flow gather (independent of the finding matcher above) and never
+  // throws; its verdict folds into the top-level one. It needs only a base
+  // COMMIT to diff against: the resolved git ref in ref-based mode, or the
+  // committed baseline's anchor SHA in committed mode (flow-binding has no
+  // committed prior side — the base flow model is gathered fresh from that
+  // commit either way, so the gate works in both modes).
+  const flowBaseRef = mode.mode === 'ref-based' ? mode.ref : baseline.repo.commitSha;
   const flowGate = await evaluateFlowGateForGuardrail({
     cwd,
-    mode,
+    ...(flowBaseRef ? { baseRef: flowBaseRef } : {}),
     // Same loaded allowlist + clock the matcher-pair suppression uses, so an
     // active `flow-binding` entry waives a flow block exactly like any other
     // finding kind (the per-finding escape hatch).
@@ -689,7 +693,7 @@ export async function runGuardrailCheck(
     warns: baseWarns || flowGate.warns,
     allowlistDelta,
     refExcludedKinds,
-    ...(flowGate.ran || flowGate.skipped !== 'not-ref-based' ? { flowGate } : {}),
+    ...(flowGate.ran || flowGate.skipped !== 'no-base-ref' ? { flowGate } : {}),
   };
 }
 

--- a/src/baseline/flow-gate-check.ts
+++ b/src/baseline/flow-gate-check.ts
@@ -5,10 +5,15 @@
  * This is guardrail-integration glue, not analysis: it composes the pure flow
  * gate (`analyzers/flow/gate.ts`) with the ref-based gather primitive
  * (`withRefWorktree`, Rule 11) to answer "does this diff net-new break a UI→API
- * integration?" without touching the existing net-new finding matcher. The gate
- * runs only in ref-based mode, where a base↔HEAD comparison is well defined
- * (committed mode has no base flow model — flow-binding is a deferred baseline
- * kind, minted here ref-based rather than at baseline-create).
+ * integration?" without touching the existing net-new finding matcher.
+ *
+ * The gate is mode-agnostic: it needs only a base COMMIT to diff HEAD against,
+ * not a base baseline file. The caller supplies that commit — the resolved git
+ * ref in ref-based mode, or the committed baseline's anchor `repo.commitSha` in
+ * committed mode. Either way the base flow model is gathered fresh from a
+ * worktree at that commit, so flow-binding needs no committed prior side (it's a
+ * deferred baseline kind, minted here at gate time rather than at
+ * baseline-create). When no base commit is resolvable at all, the gate skips.
  *
  * Every failure path degrades to "did not gate" rather than an error: a
  * missing base ref, an unparseable tree, a repo with no server-side truth to
@@ -26,7 +31,6 @@ import * as path from 'path';
 import { changedFilesTouchFlowSurface, detectActiveLanguages } from '../languages';
 import { computeChangedFiles } from './changed-files';
 import { withRefWorktree } from './ref-baseline';
-import type { ResolvedMode } from './modes';
 import { gatherFlowModel } from '../analyzers/flow/gather';
 import {
   buildConsumedContract,
@@ -43,7 +47,7 @@ import type { AllowlistFile } from '../allowlist/file';
 /** Why the gate produced no verdict, when it didn't run. */
 export type FlowGateSkip =
   | 'off' // policy `flow.mode: off`
-  | 'not-ref-based' // committed mode — no base flow model to diff against
+  | 'no-base-ref' // no base commit resolvable (no ref, no baseline anchor SHA)
   | 'no-flow-surface-change' // the diff touched no client call / route / spec
   | 'no-served-truth' // no served inventory (monorepo route set + snapshot both empty)
   | 'error'; // any failure — fail-open
@@ -132,6 +136,11 @@ function partitionByAllowlist(
  * returned `blocks` / `warns` into the overall verdict and attaches the outcome
  * to the result for rendering.
  *
+ * @param baseRef the base commit to diff HEAD against — the resolved git ref in
+ *   ref-based mode, or the committed baseline's anchor `repo.commitSha` in
+ *   committed mode. Both yield a fresh base flow gather from a worktree at that
+ *   commit, so the gate works identically in either mode. When absent (no ref,
+ *   no baseline anchor), the gate skips.
  * @param modeOverride the loop Stop-gate's posture-derived mode (the seam that
  *   lets `security-only` warn while `full-debt` blocks) — wins over the
  *   `.dxkit/policy.json:flow.mode` default.
@@ -142,7 +151,7 @@ function partitionByAllowlist(
  */
 export async function evaluateFlowGateForGuardrail(opts: {
   readonly cwd: string;
-  readonly mode: ResolvedMode;
+  readonly baseRef?: string;
   readonly modeOverride?: FlowGateMode;
   readonly verbose?: boolean;
   readonly allowlist?: AllowlistFile | null;
@@ -153,8 +162,8 @@ export async function evaluateFlowGateForGuardrail(opts: {
   const gateMode = opts.modeOverride ?? config.mode;
 
   if (gateMode === 'off') return skip(gateMode, 'off');
-  if (opts.mode.mode !== 'ref-based' || !opts.mode.ref) return skip(gateMode, 'not-ref-based');
-  const ref = opts.mode.ref;
+  if (!opts.baseRef) return skip(gateMode, 'no-base-ref');
+  const ref = opts.baseRef;
 
   try {
     // Trigger-skip: a net-new broken integration requires a change to a client

--- a/test/baseline/check.test.ts
+++ b/test/baseline/check.test.ts
@@ -433,4 +433,17 @@ describe('runGuardrailCheck — flow integration gate seam', () => {
     expect(result.flowGate?.suppressed.map((s) => s.finding.path)).toContain('/dead');
     expect(result.flowGate?.findings).toEqual([]);
   }, 300_000);
+
+  it('gates in committed mode against the baseline anchor commit (not only ref-based)', async () => {
+    // Committed mode has no committed prior flow side, but it DOES record the
+    // baseline's anchor `repo.commitSha`. The gate must diff HEAD against that
+    // commit — so a private repo on the default committed-full is flow-gated too.
+    await createBaseline({ cwd: dir });
+    writeFileSync(join(dir, 'client.ts'), "axios.get('/articles');\naxios.get('/dead');\n");
+    const result = await runGuardrailCheck({ cwd: dir, cliMode: 'committed-full' });
+    expect(result.mode.mode).toBe('committed-full');
+    expect(result.flowGate?.ran).toBe(true);
+    expect(result.flowGate?.findings.map((f) => f.path)).toContain('/dead');
+    expect(result.blocks).toBe(true);
+  }, 300_000);
 });

--- a/test/baseline/flow-gate-check.test.ts
+++ b/test/baseline/flow-gate-check.test.ts
@@ -14,7 +14,6 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { evaluateFlowGateForGuardrail } from '../../src/baseline/flow-gate-check';
-import type { ResolvedMode } from '../../src/baseline/modes';
 import { computeFlowBindingFingerprint } from '../../src/analyzers/tools/fingerprint';
 import type { AllowlistFile } from '../../src/allowlist/file';
 
@@ -41,23 +40,13 @@ function makeFlowRepo(): string {
   return dir;
 }
 
-const refMode: ResolvedMode = {
-  mode: 'ref-based',
-  source: 'cli',
-  explanation: 'test',
-  ref: 'main',
-};
-
 describe('evaluateFlowGateForGuardrail — skip paths', () => {
-  it('skips when mode is not ref-based (committed mode)', async () => {
+  it('skips when no base commit is resolvable (no ref, no anchor SHA)', async () => {
     const dir = makeFlowRepo();
     try {
-      const out = await evaluateFlowGateForGuardrail({
-        cwd: dir,
-        mode: { mode: 'committed-full', source: 'cli', explanation: 'test' },
-      });
+      const out = await evaluateFlowGateForGuardrail({ cwd: dir });
       expect(out.ran).toBe(false);
-      expect(out.skipped).toBe('not-ref-based');
+      expect(out.skipped).toBe('no-base-ref');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -68,7 +57,7 @@ describe('evaluateFlowGateForGuardrail — skip paths', () => {
     try {
       const out = await evaluateFlowGateForGuardrail({
         cwd: dir,
-        mode: refMode,
+        baseRef: 'main',
         modeOverride: 'off',
       });
       expect(out.ran).toBe(false);
@@ -89,7 +78,7 @@ describe('evaluateFlowGateForGuardrail — real ref-based gate', () => {
   it('blocks a net-new call to a non-served endpoint', async () => {
     // Working tree adds a NEW call to a route nobody serves.
     writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/dead');\n");
-    const out = await evaluateFlowGateForGuardrail({ cwd: dir, mode: refMode });
+    const out = await evaluateFlowGateForGuardrail({ cwd: dir, baseRef: 'main' });
     expect(out.ran).toBe(true);
     expect(out.blocks).toBe(true);
     expect(out.findings.map((f) => f.path)).toContain('/dead');
@@ -102,7 +91,7 @@ describe('evaluateFlowGateForGuardrail — real ref-based gate', () => {
     writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/dead');\n");
     const out = await evaluateFlowGateForGuardrail({
       cwd: dir,
-      mode: refMode,
+      baseRef: 'main',
       modeOverride: 'warn',
     });
     expect(out.ran).toBe(true);
@@ -113,9 +102,20 @@ describe('evaluateFlowGateForGuardrail — real ref-based gate', () => {
 
   it('passes clean when every call still resolves', async () => {
     // No change to the working tree — the one call still resolves.
-    const out = await evaluateFlowGateForGuardrail({ cwd: dir, mode: refMode });
+    const out = await evaluateFlowGateForGuardrail({ cwd: dir, baseRef: 'main' });
     expect(out.blocks).toBe(false);
     expect(out.findings).toEqual([]);
+  });
+
+  it('gates against a raw commit SHA base (committed-mode anchor, not a branch ref)', async () => {
+    // Committed mode supplies the baseline's `repo.commitSha` — a bare commit,
+    // not a branch. The gate must run identically: diff HEAD against that commit.
+    const baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir }).toString().trim();
+    writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/dead');\n");
+    const out = await evaluateFlowGateForGuardrail({ cwd: dir, baseRef: baseSha });
+    expect(out.ran).toBe(true);
+    expect(out.blocks).toBe(true);
+    expect(out.findings.map((f) => f.path)).toContain('/dead');
   });
 
   it('grandfathers a call that was already broken at base', async () => {
@@ -131,14 +131,14 @@ describe('evaluateFlowGateForGuardrail — real ref-based gate', () => {
     );
     const out = await evaluateFlowGateForGuardrail({
       cwd: dir,
-      mode: { ...refMode, ref: 'base2' },
+      baseRef: 'base2',
     });
     expect(out.findings).toEqual([]); // /legacy was broken before → not net-new
   });
 
   it('skips a diff that touches no flow surface (docs-only change)', async () => {
     writeFileSync(join(dir, 'README.md'), '# docs\n');
-    const out = await evaluateFlowGateForGuardrail({ cwd: dir, mode: refMode });
+    const out = await evaluateFlowGateForGuardrail({ cwd: dir, baseRef: 'main' });
     expect(out.ran).toBe(false);
     expect(out.skipped).toBe('no-flow-surface-change');
   });
@@ -174,7 +174,7 @@ describe('evaluateFlowGateForGuardrail — allowlist suppression', () => {
     writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/dead');\n");
     const out = await evaluateFlowGateForGuardrail({
       cwd: dir,
-      mode: refMode,
+      baseRef: 'main',
       allowlist: allowlistFor('GET', '/dead', 'web/List.tsx'),
     });
     expect(out.ran).toBe(true);
@@ -189,7 +189,7 @@ describe('evaluateFlowGateForGuardrail — allowlist suppression', () => {
     writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/dead');\n");
     const out = await evaluateFlowGateForGuardrail({
       cwd: dir,
-      mode: refMode,
+      baseRef: 'main',
       now: new Date('2026-06-01'),
       allowlist: allowlistFor('GET', '/dead', 'web/List.tsx', {
         category: 'deferred',
@@ -205,7 +205,7 @@ describe('evaluateFlowGateForGuardrail — allowlist suppression', () => {
     writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/dead');\n");
     const out = await evaluateFlowGateForGuardrail({
       cwd: dir,
-      mode: refMode,
+      baseRef: 'main',
       allowlist: allowlistFor('GET', '/other', 'web/List.tsx'), // wrong path → different id
     });
     expect(out.blocks).toBe(true);
@@ -229,7 +229,7 @@ describe('evaluateFlowGateForGuardrail — served-truth self-skip', () => {
       git(dir, ['commit', '-q', '-m', 'base']);
       // HEAD adds another call — still no served side anywhere.
       writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\naxios.get('/more');\n");
-      const out = await evaluateFlowGateForGuardrail({ cwd: dir, mode: refMode });
+      const out = await evaluateFlowGateForGuardrail({ cwd: dir, baseRef: 'main' });
       expect(out.ran).toBe(false);
       expect(out.skipped).toBe('no-served-truth');
     } finally {
@@ -266,7 +266,7 @@ describe('evaluateFlowGateForGuardrail — served-truth self-skip', () => {
         join(dir, 'web', 'List.tsx'),
         "axios.get('/articles');\naxios.get('/ghost');\n",
       );
-      const out = await evaluateFlowGateForGuardrail({ cwd: dir, mode: refMode });
+      const out = await evaluateFlowGateForGuardrail({ cwd: dir, baseRef: 'main' });
       expect(out.ran).toBe(true);
       expect(out.blocks).toBe(true);
       // /ghost blocks; /articles resolved against the snapshot and did not.


### PR DESCRIPTION
## What

The flow integration gate ran **only in ref-based mode**. In committed-full / committed-sanitized it returned a `not-ref-based` skip, so a repo pinned to `committed-full` (the default for private repos) got **no flow gating** unless it switched to `baseline.mode: ref-based`. This closes that gap before broad private-repo rollout.

## How

The gate needs only a base **commit** to diff HEAD against — not a committed prior flow side. Made `evaluateFlowGateForGuardrail` mode-agnostic: it now takes a `baseRef` (the base commit) instead of a `ResolvedMode`, and the guardrail resolves that ref:

- **ref-based** → the resolved git ref (today's path)
- **committed** → the committed baseline's anchor `repo.commitSha`

Either way the base flow model is gathered fresh from a worktree at that commit, so net-new broken integrations block (or warn) identically in every baseline mode. Fail-open, trigger-skip, no-served-truth self-skip, and per-finding allowlist suppression are all unchanged. The gate now skips only when **no** base commit is resolvable at all (skip reason renamed `not-ref-based` → `no-base-ref`).

## Tests

- `flow-gate-check.test.ts`: a committed-mode helper case driving the gate with a raw commit SHA (not a branch ref); updated skip-path test for `no-base-ref`.
- `check.test.ts`: a `runGuardrailCheck` committed-full seam test — create baseline → add net-new dead call → assert `result.blocks` + `flowGate.ran` in committed mode.
- Full baseline + flow + loop-policy suites green (412 tests); `npm run build`, `typecheck`, `typecheck:test`, arch check, lint, format all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)