### PR TITLE
feat(flow): agent-operable flow — setup in init, diagnose in doctor, publish, dxkit-flow skill (2.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.22.0] - 2026-07-02
+
+### Added — the flow feature becomes agent-operable (setup, diagnose, publish, repair)
+
+The UI→API integration gate now has the surfaces an agent (or a person) needs to
+configure, diagnose, and repair it — folded into the commands you already run so
+the CLI stays small.
+
+- **Setup folds into `init`.** There is no standalone `flow init`. When `init`
+  detects a UI→API surface (client calls and/or server routes) it offers the
+  integration gate and asks for the posture — `warn` (default), `block`, or
+  `off` — with a one-line description of each; a repo with no such surface stays
+  silent. `--flow` forces it on with `warn`; `--no-flow` skips it. The dominant
+  base-URL helper to strip and any multiple backend services are surfaced as
+  confirm prompts.
+- **`.dxkit/workspace.json`** — a new top-level participants primitive naming the
+  repos/services of a multi-repo system (path, optional git ref, base URLs).
+- **Diagnose folds into `doctor`.** There is no standalone `flow doctor`. When the
+  repo has a UI→API surface, `doctor` reports a flow-contract diagnosis — the
+  unresolved client calls (each with a reason and a suggested next step), the
+  served routes nobody consumes, and how the served side is resolved — and
+  `doctor --json` carries the whole `flow` object for an agent to read.
+- **`flow publish`** — the multi-repo handshake. Reads `workspace.json` and unions
+  every participant's served routes into this repo's `served.json`, so a consumer
+  repo gates its calls against a provider it does not co-locate. Participants are
+  gathered from a local path, optionally pinned at a git ref; fail-open per
+  participant. A content-hash on the snapshot lets a consumer detect drift.
+- **`dxkit-flow` skill** — the operator surface: setup, diagnose, fix (repair a
+  net-new broken integration a guardrail flagged — never suppress it), and the
+  cross-repo handshake. Thin orchestration over the CLI; `--flow` installs it.
+
 ## [2.21.2] - 2026-07-02
 
 ### Fixed — the flow gate now runs in committed-baseline modes too

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.21.2",
+  "version": "2.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.21.2",
+      "version": "2.22.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.21.2",
+  "version": "2.22.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.claude/skills/dxkit-config/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-config/SKILL.md
@@ -126,6 +126,20 @@ A repo running autonomous coding loops behind the dxkit Stop-gate has a **loop-o
 
 This key is read **only by the Stop-gate** (`vyuh-dxkit hook stop-gate`) — your CI / PR guardrail always uses the full policy above, so changing the loop posture never weakens your CI gate. Edit it here, or run `npx vyuh-dxkit init --claude-loop --loop-preset full-debt`. Use `full-debt` only when you deliberately want an unattended loop to also close test/quality gaps (it can drive a long repair). For setting up or operating the loop, hand off to the **dxkit-loop** skill.
 
+### Switching the flow-gate posture (`flow.mode`)
+
+The UI→API integration gate has its own posture under `flow.mode` in the same file:
+
+```jsonc
+{ "flow": { "mode": "warn" } }  // warn (default) | block | off
+```
+
+- `warn` — surface net-new broken integrations as warnings, never fail a build.
+- `block` — fail the check on an exact break (confidence-gated: only fully-specified bindings block).
+- `off` — the gate does not run.
+
+The gate is additive and fail-open: it only fires when a change touches a client call / route / spec, and self-skips when there is no served-side truth to check against. Set it up with `npx vyuh-dxkit init --flow`, or hand off to the **dxkit-flow** skill for setup / diagnosis / repair.
+
 ## Configuring deep-SAST ingestion (`.vyuh-dxkit.json:deepSast`)
 
 dxkit's bundled SAST is intraprocedural; interprocedural findings (path traversal, info exposure, SSRF, injection) come from an external engine (Snyk Code or CodeQL) ingested via the `dxkit-ingest` skill. Persist the engine + Snyk project once so `ingest --from-snyk` needs no flags:

--- a/src-templates/.claude/skills/dxkit-fix/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-fix/SKILL.md
@@ -18,6 +18,8 @@ The skill consumes `npx vyuh-dxkit doctor --json` output. Doctor returns a struc
 
 The skill iterates `summary.fixable[]`, asks the customer for confirmation on each fix (with the command shown), runs it, then re-runs doctor at the end to verify everything closed.
 
+Doctor also carries an optional top-level `flow` field when the repo has a UI→API surface — a diagnosis of the integration contract (unresolved client calls with reasons + suggestions, served routes nobody consumes, and how the served side is resolved). This is **diagnostic, not an install fix**: it does not appear in `summary.fixable[]`, and dxkit-fix leaves it alone. It surfaces contract health (e.g. a call to a route no backend serves) rather than a broken-install signal.
+
 ## The repair loop
 
 ```

--- a/src-templates/.claude/skills/dxkit-flow/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-flow/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: dxkit-flow
+description: Configure, diagnose, and repair the dxkit UI→API integration gate — set up flow gating, explain the flow-contract diagnosis, fix a net-new broken integration a guardrail flagged, and run the cross-repo handshake. Use when the user says "set up the flow gate", "why is this call unresolved", "the guardrail says I broke an integration", "a route was removed but something still calls it", "wire up flow across repos", "publish the flow contract", or anything about the UI→API integration gate.
+---
+
+# dxkit-flow
+
+This skill owns the **UI→API integration gate**: dxkit statically reconstructs which client calls (`METHOD url`) bind to which server routes, and fails a PR that net-new breaks one — a frontend call to an endpoint no backend serves, or a removed route a consumer still calls.
+
+It is **thin orchestration over the deterministic CLI.** It never re-implements extraction: it runs `init` / `doctor` / `guardrail check` / `flow publish`, reads their structured output, and supplies judgment + code edits. The determinism stays in the CLI; the agent supplies the reasoning.
+
+## Modes
+
+Pick the mode from what the user is doing. They share context — a fix often starts from a diagnose.
+
+### setup — turn the gate on
+
+Flow setup is folded into `init`; **there is no `flow init` command.**
+
+- Fresh or re-run: `npx vyuh-dxkit init --flow` (forces `warn` posture, no prompt) or plain `npx vyuh-dxkit init` (interactive — it detects a UI→API surface and asks for the posture). If the repo has no client calls / routes, init stays silent; there is nothing to gate.
+- The posture lives in `.dxkit/policy.json:flow.mode`:
+  - `warn` — surfaces net-new breaks as warnings, never fails a build (the default; good for adoption).
+  - `block` — fails the check on an exact break (confidence-gated: only fully-specified bindings block).
+  - `off` — scaffold config only, do not gate.
+- To change it later, edit `flow.mode` (or defer to **dxkit-config**).
+
+### diagnose — read the contract's current state
+
+`doctor` carries the flow diagnosis; **there is no `flow doctor` command.**
+
+```
+npx vyuh-dxkit doctor --json   → read the top-level `flow` field
+```
+
+`flow` (when the repo has a UI→API surface) contains:
+- `topology` (monorepo / consumer-only / provider-only), `calls`, `routes`, `resolved`
+- `unresolved[]` — each `{ method, path, reason, suggestion, file, line }`. `reason` is `no-route` / `external` / `placeholder-only`; `suggestion` is `add-route` / `configure-participant` / `adopt-spec` / `annotate`.
+- `servedUnconsumed[]` — served routes no in-repo call hits (dead route, or a cross-repo consumer).
+- `connection.rung` — how the served side is resolved (`monorepo` / `committed-counterpart` / `configured-participants` / `unresolved`).
+
+Walk the `unresolved` tail and, per item, act on its `suggestion`: add the missing route, configure a participant (handshake mode), adopt a spec, or annotate an intentional external call.
+
+### fix — repair a net-new broken integration ⭐
+
+When a guardrail check (or the loop Stop-gate) reports a flow block, read it:
+
+```
+npx vyuh-dxkit guardrail check --json   → read `flowGate.findings[]`
+```
+
+Each finding is `{ method, path, file, line, reason, verdict }`. `reason` is `no-route` (a call to nothing) or `route-removed` (a served route the PR deleted, still consumed). For each:
+
+1. Explain it in one line: which call, which route, what the PR changed.
+2. Propose the **repair** — restore the removed route, update the consumer to the new route, or (only if genuinely intentional) add an explicit annotation / a per-finding allowlist entry that a human reviews.
+
+**Load-bearing safety rule — repair, never suppress.** Fix the integration; do not clear the block by refreshing the baseline or silently allowlisting the finding. An intentional break requires an explicit, reviewed acceptance, never a quiet re-baseline. This mirrors the loop discipline (do NOT refresh the baseline to clear a block) and is what keeps the gate honest when an agent is the one clearing it.
+
+### handshake — gate across repos
+
+When the provider a call targets lives in another repo, the gate needs that repo's served contract. Two ways, both landing in `.dxkit/flow/served.json` (which the gate reads offline):
+
+- **Committed counterpart** — the provider commits its own `served.json`; this repo vendors it. Fully offline, diff-reviewable.
+- **Workspace participants** — declare the services in `.dxkit/workspace.json` (`participants[]` with a local `path` and optional `ref`), then:
+
+  ```
+  npx vyuh-dxkit flow publish   → unions every participant's served routes into this repo's served.json
+  ```
+
+  `flow refresh` writes just this repo's snapshots; `flow publish` unions the whole mesh so this repo resolves calls to services it does not co-locate. Commit the result.
+
+## What lives where
+
+| Artifact | Role |
+|---|---|
+| `.dxkit/policy.json:flow` | posture (`mode`) + URL strip-prefixes + specs |
+| `.dxkit/workspace.json` | the participants (name, path, ref, base URLs) of a multi-repo system |
+| `.dxkit/flow/served.json` / `consumed.json` | the committed contract snapshots the gate reads |
+
+## Boundaries
+
+- WHETHER to gate + posture → this skill (setup) or **dxkit-config**.
+- A broken integration found during a PR → this skill (fix). If it surfaced through the loop Stop-gate, **dxkit-loop** explains the block; the repair is here.
+- Do not use this skill to re-extract flow by hand or to write CSVs — that is the CLI's job.

--- a/src-templates/.claude/skills/dxkit-hooks/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-hooks/SKILL.md
@@ -13,7 +13,7 @@ This skill handles the git-hook surface dxkit ships. Use it to install hooks, de
 
 `.githooks/pre-commit` (opt-in via `--with-precommit-hook`) — same guardrail check but on every commit. Slower on large repos (~1-3 min on 500+ file repos). Not in `--full` by default because the wall-clock cost gates adoption.
 
-Both run `npx vyuh-dxkit guardrail check`. The check exits 1 (blocking) on net-new findings vs. the baseline.
+Both run `npx vyuh-dxkit guardrail check`. The check exits 1 (blocking) on net-new findings vs. the baseline. The same check also runs the **flow integration gate** — a net-new broken UI→API integration (a call to an endpoint no backend serves, or a removed route a consumer still calls) blocks or warns per `.dxkit/policy.json:flow.mode`. To set up, diagnose, or repair that gate, hand off to the **dxkit-flow** skill.
 
 ## Installation
 

--- a/src-templates/.claude/skills/dxkit-init/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-init/SKILL.md
@@ -29,8 +29,13 @@ Ask the user what they want, then pick the right invocation:
 | `--with-baseline-refresh` | `.github/workflows/dxkit-baseline-refresh.yml` (post-merge regen) | Yes |
 | `--with-pr-review` | `.github/workflows/pr-review.yml` (AI PR review; needs `ANTHROPIC_API_KEY`) | No (still opt-in) |
 | `--claude-loop` | Stop-gate hook for autonomous loops (additive merge into `.claude/settings.json` + CLAUDE.md); implies the dxkit skills. Pair with `--loop-preset security-only\|full-debt` | No (opt-in — registers a hook that blocks the agent from stopping) |
+| `--flow` / `--no-flow` | Set up / suppress the UI→API integration gate. When `init` detects a UI→API surface it offers this automatically (interactive prompt for the posture); `--flow` forces it on with `warn`, `--no-flow` skips it. There is **no standalone `flow init`** — flow setup lives inside `init`. | Auto-offered when a UI→API surface is detected (silent otherwise) |
 
 `--yes` accepts all prompts; `--force` overwrites existing files instead of writing `.dxkit` sidecars on conflict.
+
+### The flow step (auto-detected)
+
+When `init` finds client HTTP calls and/or server routes, it offers the **integration gate**: a PR that breaks a UI→API binding (a call to an endpoint no backend serves, or a removed route a consumer still calls) fails the guardrail. Interactively it asks for the posture with a one-line description of each — `warn` (default, surfaces breaks without failing a build), `block` (fails on an exact break), `off` (scaffold config only). It also confirms the dominant base-URL helper to strip and any multiple backend services. On a repo with no UI→API surface (a library, a CLI) the step is silent. Re-run or adjust later with `init --flow`; tune the posture in `.dxkit/policy.json:flow.mode`.
 
 ## Steps
 

--- a/src-templates/.claude/skills/dxkit-onboard/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-onboard/SKILL.md
@@ -31,6 +31,8 @@ Don't use when:
 ```
 [1] State check       → is dxkit installed? scaffold present? baseline captured? hooks active?
 [2] Install if needed → npm init @vyuhlabs/dxkit OR npx vyuh-dxkit init --full --yes
+                        (init auto-offers the UI→API integration gate when it
+                         detects client calls + routes — pick a posture then)
 [3] Doctor            → npx vyuh-dxkit doctor (parse summary.fixable[])
 [4] Fix gaps          → dispatch through dxkit-fix for each fixable signal
 [5] Capture baseline  → npx vyuh-dxkit baseline create (with explicit secrets-warning)

--- a/src/analyzers/flow/config.ts
+++ b/src/analyzers/flow/config.ts
@@ -79,3 +79,33 @@ export function readFlowConfig(cwd: string): FlowConfig {
         : DEFAULTS.blockThreshold,
   };
 }
+
+/**
+ * Write into `.dxkit/policy.json:flow`, merging the patch over the existing
+ * `flow` block and PRESERVING every other policy section (loop, baseline, …) —
+ * the same discipline `ensureLoopPreset` uses for `loop.preset`. This is the
+ * single writer of the flow policy section (Rule 2), paired with the reader
+ * above. Returns `true` if the file changed, `false` if it was already at the
+ * target (idempotent) or could not be parsed (malformed policy is left
+ * untouched — the caller reports it rather than clobbering hand-edits).
+ */
+export function writeFlowPolicy(
+  cwd: string,
+  patch: Partial<Pick<FlowConfig, 'mode' | 'stripUrlPrefixes' | 'specs'>>,
+): boolean {
+  const abs = path.join(cwd, '.dxkit', 'policy.json');
+  let policy: { flow?: Record<string, unknown>; [k: string]: unknown } = {};
+  if (fs.existsSync(abs)) {
+    try {
+      policy = JSON.parse(fs.readFileSync(abs, 'utf8'));
+    } catch {
+      return false; // malformed — leave it; caller surfaces the note
+    }
+  }
+  const nextFlow = { ...(policy.flow ?? {}), ...patch };
+  if (JSON.stringify(policy.flow ?? {}) === JSON.stringify(nextFlow)) return false;
+  policy.flow = nextFlow;
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, JSON.stringify(policy, null, 2) + '\n', 'utf8');
+  return true;
+}

--- a/src/analyzers/flow/contract.ts
+++ b/src/analyzers/flow/contract.ts
@@ -54,6 +54,10 @@ interface SnapshotMeta {
   readonly generatedAt: string;
   /** Commit the snapshot was produced against, when known. */
   readonly commitSha?: string;
+  /** Change-detection digest of the contract's contents — lets a consumer see
+   *  that a published contract drifted (routes changed) even when the commit or
+   *  timestamp did not carry the signal. Set by `flow publish`. */
+  readonly contentHash?: string;
 }
 
 export interface ServedContract extends SnapshotMeta {
@@ -69,6 +73,26 @@ export interface ConsumedContract extends SnapshotMeta {
 /** The `${method} ${path}` join key both sides meet on. */
 export function contractKey(method: string, routePath: string): string {
   return `${method} ${routePath}`;
+}
+
+/**
+ * A short, stable content digest of a served route set. Lets a consumer detect
+ * that a published contract drifted (routes added/removed) even when the commit
+ * SHA or timestamp did not carry the signal. Non-cryptographic (FNV-1a): this
+ * is a change-detection digest, NOT a finding identity, so it deliberately does
+ * not route through the fingerprint helpers (Rule 9 governs identity, not this).
+ */
+export function servedContentHash(routes: readonly ServedRoute[]): string {
+  const canon = routes
+    .map((r) => contractKey(r.method, r.path))
+    .sort()
+    .join('\n');
+  let h = 0x811c9dc5;
+  for (let i = 0; i < canon.length; i++) {
+    h ^= canon.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
 }
 
 // ─── Build (from a flow model) ────────────────────────────────────────────────

--- a/src/analyzers/flow/diagnose.ts
+++ b/src/analyzers/flow/diagnose.ts
@@ -1,0 +1,175 @@
+/**
+ * Flow diagnosis — the "diagnose" surface, folded into `doctor` (there is no
+ * standalone `flow doctor`). Where the gate answers "did this PR break an
+ * integration?", diagnose answers "what is the current state of the contract?":
+ * which client calls do NOT resolve to a served route and why, which served
+ * routes nobody consumes, and how the served side is being resolved (the
+ * connection-resolution ladder).
+ *
+ * The output is deliberately agent-legible — `doctor --json` carries the whole
+ * `FlowDiagnosis`, so the `dxkit-flow` skill reads it as a thin consumer rather
+ * than scraping console prose. Reuses the shared extractor (Rule 2); fail-open
+ * (any error → `null`, and doctor simply omits the flow section).
+ */
+
+import { detectActiveLanguages, allFlowSourceExtensions } from '../../languages';
+import { gatherFlowModel } from './gather';
+import { isPlaceholderOnlyPath, type FlowModel } from './model';
+import { readServedContract } from './contract';
+import { readWorkspace } from '../../workspace';
+import type { FlowTopology } from './setup';
+
+/** Why a client call did not cleanly bind to a served route. */
+export type UnresolvedReason = 'no-route' | 'external' | 'placeholder-only';
+
+/** The recommended next step for an unresolved call. `scaffold-resolver`
+ *  (extend extraction to an unsupported framework) is intentionally NOT emitted
+ *  here — an un-extracted call is absent, not unresolved; that path needs the
+ *  extension SDK. */
+export type FlowFixHint = 'add-route' | 'configure-participant' | 'adopt-spec' | 'annotate';
+
+/** One client call that does not resolve, plus the reason and the suggested fix. */
+export interface UnresolvedCall {
+  readonly method: string;
+  readonly rawUrl: string;
+  readonly path: string | null;
+  readonly file: string;
+  readonly line: number;
+  readonly reason: UnresolvedReason;
+  readonly suggestion: FlowFixHint;
+}
+
+/** A served route no client call binds to — a dead route, or a route consumed
+ *  only by a repo dxkit cannot see (a cross-repo consumer). */
+export interface UnconsumedRoute {
+  readonly method: string;
+  readonly path: string;
+  readonly file: string;
+  readonly line: number;
+}
+
+/** Which rung of the connection-resolution ladder produced the served set. */
+export type ConnectionRung =
+  | 'monorepo'
+  | 'committed-counterpart'
+  | 'configured-participants'
+  | 'unresolved';
+
+export interface FlowDiagnosis {
+  readonly topology: FlowTopology;
+  readonly calls: number;
+  readonly routes: number;
+  readonly resolved: number;
+  /** Client calls that do not cleanly bind, each with a reason + suggestion. */
+  readonly unresolved: readonly UnresolvedCall[];
+  /** Served routes with no consuming call (dead-route / cross-repo candidates). */
+  readonly servedUnconsumed: readonly UnconsumedRoute[];
+  readonly connection: { readonly rung: ConnectionRung; readonly note: string };
+}
+
+function suggestionFor(reason: UnresolvedReason, topology: FlowTopology): FlowFixHint {
+  switch (reason) {
+    case 'external':
+      return 'adopt-spec'; // add the external API's OpenAPI spec to verify it
+    case 'placeholder-only':
+      return 'annotate'; // too generic to verify — annotate if intentional
+    case 'no-route':
+      // A monorepo serves its own routes, so a miss is a missing/typo'd route;
+      // a consumer-only repo's provider lives elsewhere (configure it).
+      return topology === 'monorepo' ? 'add-route' : 'configure-participant';
+  }
+}
+
+/** Classify a binding into the unresolved tail, or `null` when it resolves. */
+function classifyUnresolved(
+  b: FlowModel['bindings'][number],
+  topology: FlowTopology,
+): UnresolvedCall | null {
+  let reason: UnresolvedReason | null = null;
+  if (b.reason === 'external') reason = 'external';
+  else if (b.reason === 'no-route') reason = 'no-route';
+  else if (b.reason === 'placeholder-only') reason = 'placeholder-only';
+  if (reason === null) return null; // 'exact' → resolved
+  return {
+    method: b.call.method,
+    rawUrl: b.call.rawUrl,
+    path: b.call.path,
+    file: b.call.file,
+    line: b.call.line,
+    reason,
+    suggestion: suggestionFor(reason, topology),
+  };
+}
+
+function resolveConnection(cwd: string, model: FlowModel): { rung: ConnectionRung; note: string } {
+  if (model.routes.length > 0) {
+    return { rung: 'monorepo', note: 'This repo serves the routes its calls target.' };
+  }
+  if (readServedContract(cwd)) {
+    return {
+      rung: 'committed-counterpart',
+      note: 'Resolving calls against the counterpart contract this repo commits.',
+    };
+  }
+  const ws = readWorkspace(cwd);
+  if (ws && ws.participants.length > 0) {
+    return {
+      rung: 'configured-participants',
+      note: `Configured participants: ${ws.participants.map((p) => p.name).join(', ')}.`,
+    };
+  }
+  return {
+    rung: 'unresolved',
+    note: 'No served side in this repo and no counterpart contract — the gate stays inert. Publish the provider contract or add a participant.',
+  };
+}
+
+/**
+ * Diagnose the repo's flow contract. Returns `null` (and doctor omits the flow
+ * section) when no flow-capable pack is active, when extraction finds nothing,
+ * or on any error.
+ */
+export async function diagnoseFlow(cwd: string): Promise<FlowDiagnosis | null> {
+  if (allFlowSourceExtensions(detectActiveLanguages(cwd)).length === 0) return null;
+
+  let model: FlowModel;
+  try {
+    model = await gatherFlowModel({ roots: [cwd] });
+  } catch {
+    return null;
+  }
+
+  const calls = model.calls.length;
+  const routes = model.routes.length;
+  if (calls === 0 && routes === 0) return null;
+
+  const topology: FlowTopology =
+    calls > 0 && routes > 0 ? 'monorepo' : calls > 0 ? 'consumer-only' : 'provider-only';
+
+  const unresolved = model.bindings
+    .map((b) => classifyUnresolved(b, topology))
+    .filter((u): u is UnresolvedCall => u !== null);
+  const resolved = calls - unresolved.length;
+
+  // Served routes with no consuming binding. Consumed keys come from resolved
+  // bindings; the union with a committed counterpart's served set does NOT
+  // matter here — we only flag OUR served routes that nobody in scope calls.
+  const consumedKeys = new Set(
+    model.bindings
+      .filter((b) => b.route !== null)
+      .map((b) => `${b.route!.method} ${b.route!.path}`),
+  );
+  const servedUnconsumed: UnconsumedRoute[] = model.routes
+    .filter((r) => !consumedKeys.has(`${r.method} ${r.path}`) && !isPlaceholderOnlyPath(r.path))
+    .map((r) => ({ method: r.method, path: r.path, file: r.file, line: r.line }));
+
+  return {
+    topology,
+    calls,
+    routes,
+    resolved,
+    unresolved,
+    servedUnconsumed,
+    connection: resolveConnection(cwd, model),
+  };
+}

--- a/src/analyzers/flow/publish.ts
+++ b/src/analyzers/flow/publish.ts
@@ -1,0 +1,161 @@
+/**
+ * Flow publish — the multi-repo handshake behind `flow publish`.
+ *
+ * `flow refresh` writes ONE repo's served/consumed snapshots. `flow publish`
+ * goes further: it reads `.dxkit/workspace.json` and, for every participant,
+ * gathers that service's served routes (from its local path, optionally pinned
+ * at a git ref via `withRefWorktree`, Rule 11) and UNIONS them into this repo's
+ * `served.json`. The consuming repo then gates its calls against the whole mesh,
+ * not just the routes it happens to co-locate — the handshake that lets a
+ * frontend repo resolve calls to a backend it does not contain.
+ *
+ * With no participants it degenerates to a single-repo publish (this repo's own
+ * served ∪ nothing), the monorepo case. Fail-open per participant: a missing
+ * path or an unreachable ref drops that participant to zero routes rather than
+ * failing the publish. Reuses the canonical contract builders (Rule 2).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { readWorkspace, type WorkspaceParticipant } from '../../workspace';
+import { withRefWorktree, resolveRefToSha } from '../../baseline/ref-baseline';
+import { gatherFlowModel } from './gather';
+import {
+  buildServedContract,
+  buildConsumedContract,
+  writeServedContract,
+  writeConsumedContract,
+  contractKey,
+  servedContentHash,
+  type ServedRoute,
+  type ServedContract,
+} from './contract';
+
+/** Where a participant's served routes came from. */
+export type ParticipantSource = 'local' | 'ref' | 'missing';
+
+export interface PublishedParticipant {
+  readonly name: string;
+  readonly routes: number;
+  readonly source: ParticipantSource;
+}
+
+export interface PublishResult {
+  readonly servedPath: string;
+  readonly consumedPath: string;
+  /** One entry per workspace participant (empty in the single-repo case). */
+  readonly participants: readonly PublishedParticipant[];
+  /** Total served routes in the unioned mesh contract. */
+  readonly totalServedRoutes: number;
+  /** This repo's own consumed bindings (the mesh's consumed side is per-repo). */
+  readonly consumedBindings: number;
+  readonly contentHash: string;
+}
+
+export interface PublishOptions {
+  readonly stripUrlPrefixes?: readonly string[];
+  readonly specs?: readonly string[];
+  /** Stamped onto the snapshot meta (kept out of this module for testability). */
+  readonly generatedAt: string;
+  readonly commitSha?: string;
+}
+
+/** Meta with only the fields a participant gather needs — routes carry no
+ *  timestamp of their own, so a clock-free placeholder keeps the gather pure. */
+const GATHER_META = { schemaVersion: 1 as const, generatedAt: '' };
+
+/** Dedupe served routes to one per `(method, path)` — the mesh may serve the
+ *  same route from this repo and a participant, or from two participants. */
+function dedupeServed(routes: readonly ServedRoute[]): ServedRoute[] {
+  const seen = new Map<string, ServedRoute>();
+  for (const r of routes) {
+    const key = contractKey(r.method, r.path);
+    if (!seen.has(key)) seen.set(key, r);
+  }
+  return [...seen.values()];
+}
+
+async function servedRoutesFrom(root: string, opts: PublishOptions): Promise<ServedRoute[]> {
+  const model = await gatherFlowModel({
+    roots: [root],
+    ...(opts.specs ? { specs: opts.specs.map((s) => path.resolve(root, s)) } : {}),
+    ...(opts.stripUrlPrefixes ? { stripUrlPrefixes: [...opts.stripUrlPrefixes] } : {}),
+    relativeTo: root,
+  });
+  return buildServedContract(model, GATHER_META).routes;
+}
+
+/** Gather one participant's served routes. Local path by default; pinned at a
+ *  git ref when the participant declares one AND that ref resolves. Fail-open:
+ *  a missing path → zero routes; an unresolvable ref → fall back to the tree. */
+async function gatherParticipant(
+  cwd: string,
+  participant: WorkspaceParticipant,
+  opts: PublishOptions,
+): Promise<{ routes: ServedRoute[]; source: ParticipantSource }> {
+  const abs = path.resolve(cwd, participant.path);
+  if (!fs.existsSync(abs)) return { routes: [], source: 'missing' };
+
+  if (participant.ref && resolveRefToSha(abs, participant.ref)) {
+    try {
+      const routes = await withRefWorktree({ cwd: abs, ref: participant.ref }, (wt) =>
+        servedRoutesFrom(wt, opts),
+      );
+      return { routes, source: 'ref' };
+    } catch {
+      // Worktree/gather failure → fall through to the working tree.
+    }
+  }
+  try {
+    return { routes: await servedRoutesFrom(abs, opts), source: 'local' };
+  } catch {
+    return { routes: [], source: 'missing' };
+  }
+}
+
+/**
+ * Publish the mesh contract: this repo's served routes ∪ every participant's,
+ * written to `.dxkit/flow/served.json`, plus this repo's own `consumed.json`.
+ */
+export async function publishFlow(cwd: string, opts: PublishOptions): Promise<PublishResult> {
+  const baseMeta = {
+    schemaVersion: 1 as const,
+    generatedAt: opts.generatedAt,
+    ...(opts.commitSha ? { commitSha: opts.commitSha } : {}),
+  };
+
+  // This repo's own model — its served routes seed the mesh; its consumed side
+  // is published as-is (consumed is inherently per-repo).
+  const selfModel = await gatherFlowModel({
+    roots: [cwd],
+    ...(opts.specs ? { specs: opts.specs.map((s) => path.resolve(cwd, s)) } : {}),
+    ...(opts.stripUrlPrefixes ? { stripUrlPrefixes: [...opts.stripUrlPrefixes] } : {}),
+    relativeTo: cwd,
+  });
+  const selfServed = buildServedContract(selfModel, baseMeta);
+  const consumed = buildConsumedContract(selfModel, baseMeta);
+
+  const allRoutes: ServedRoute[] = [...selfServed.routes];
+  const participants: PublishedParticipant[] = [];
+  for (const p of readWorkspace(cwd)?.participants ?? []) {
+    const { routes, source } = await gatherParticipant(cwd, p, opts);
+    participants.push({ name: p.name, routes: routes.length, source });
+    allRoutes.push(...routes);
+  }
+
+  const mesh = dedupeServed(allRoutes);
+  const contentHash = servedContentHash(mesh);
+  const servedContract: ServedContract = { side: 'served', ...baseMeta, contentHash, routes: mesh };
+
+  const servedPath = writeServedContract(cwd, servedContract);
+  const consumedPath = writeConsumedContract(cwd, consumed);
+
+  return {
+    servedPath,
+    consumedPath,
+    participants,
+    totalServedRoutes: mesh.length,
+    consumedBindings: consumed.bindings.length,
+    contentHash,
+  };
+}

--- a/src/analyzers/flow/setup.ts
+++ b/src/analyzers/flow/setup.ts
@@ -1,0 +1,164 @@
+/**
+ * Flow setup — the detection + apply behind folding `flow init` into `init`.
+ *
+ * `init` runs `detectFlowTopology` to decide whether a repo even HAS a UI→API
+ * surface worth gating (if not, the init wizard stays silent — zero burden).
+ * When it does, init surfaces the two learnings this module computes — the
+ * dominant host-helper to strip, and any multiple backend services — as confirm
+ * prompts, then `applyFlowSetup` writes the resulting config (`.dxkit/policy.json:flow`
+ * plus `.dxkit/workspace.json` when participants are named).
+ *
+ * Detection reuses the same `gatherFlowModel` the gate runs (Rule 2 — one
+ * extractor); it never re-parses source itself. Fail-open throughout — an error
+ * degrades to "no flow detected", which the caller treats as "don't ask".
+ */
+
+import { detectActiveLanguages, allFlowSourceExtensions } from '../../languages';
+import { gatherFlowModel } from './gather';
+import { isPlaceholderOnlyPath } from './model';
+import { writeFlowPolicy, type FlowGateMode } from './config';
+import { writeWorkspace, type WorkspaceParticipant } from '../../workspace';
+import type { ClientCall, RouteEndpoint } from './extract';
+
+/** Which halves of the UI→API contract this repo contains. */
+export type FlowTopology = 'monorepo' | 'consumer-only' | 'provider-only' | 'none';
+
+export interface FlowDetection {
+  /** monorepo (both sides) · consumer-only (calls, no routes) · provider-only
+   *  (routes, no calls) · none (nothing to gate — stay silent). */
+  readonly topology: FlowTopology;
+  readonly callCount: number;
+  readonly routeCount: number;
+  /** Calls that already bind to a served route — the healthy baseline. */
+  readonly resolvedCount: number;
+  /** Dominant host-helper prefix(es) across client calls — the strip-prefix the
+   *  setup offers so a call like `${Config.api()}/x` matches a served `/x`. */
+  readonly suggestedStripPrefixes: readonly string[];
+  /** Distinct top-level directories that serve routes — a best-effort
+   *  multi-service hint (robust multi-repo splitting is M4.3's `flow publish`). */
+  readonly detectedServices: readonly string[];
+}
+
+const NONE: FlowDetection = {
+  topology: 'none',
+  callCount: 0,
+  routeCount: 0,
+  resolvedCount: 0,
+  suggestedStripPrefixes: [],
+  detectedServices: [],
+};
+
+/**
+ * Detect the repo's flow topology by running the shared extractor. Returns
+ * `topology: 'none'` (and the caller stays silent) when no flow-capable pack is
+ * active, when extraction finds nothing, or on any error.
+ */
+export async function detectFlowTopology(cwd: string): Promise<FlowDetection> {
+  // Cheap gate first: if no active pack extracts flow, don't even run the
+  // extractor (keeps `init --yes` on a non-flow repo fast).
+  if (allFlowSourceExtensions(detectActiveLanguages(cwd)).length === 0) return NONE;
+
+  let model;
+  try {
+    model = await gatherFlowModel({ roots: [cwd] });
+  } catch {
+    return NONE;
+  }
+
+  const callCount = model.calls.length;
+  const routeCount = model.routes.length;
+  if (callCount === 0 && routeCount === 0) return NONE;
+
+  const resolvedCount = model.bindings.filter(
+    (b) => b.route !== null && !isPlaceholderOnlyPath(b.route.path),
+  ).length;
+
+  const topology: FlowTopology =
+    callCount > 0 && routeCount > 0
+      ? 'monorepo'
+      : callCount > 0
+        ? 'consumer-only'
+        : 'provider-only';
+
+  return {
+    topology,
+    callCount,
+    routeCount,
+    resolvedCount,
+    suggestedStripPrefixes: dominantHostPrefixes(model.calls),
+    detectedServices: servicesFromRoutes(model.routes),
+  };
+}
+
+/**
+ * The prefix of a raw client URL that is NOT part of the route path — an
+ * absolute `scheme://host`, or a leading `${...}` base-URL helper template. A
+ * relative URL (`/articles`) has no host prefix. This is exactly what a
+ * strip-prefix removes so a templated call matches a served route.
+ */
+export function hostPrefixOf(rawUrl: string): string | null {
+  // A template-literal URL is captured WITH its backticks (`${Config.api()}/x`);
+  // strip a leading one so the `${...}` head is at the string start. A plain
+  // string literal is captured without quotes, so this is a no-op for it.
+  const s = rawUrl.replace(/^`/, '');
+  const abs = /^(https?:\/\/[^/`]+)/.exec(s);
+  if (abs) return abs[1];
+  const tmpl = /^(\$\{[^}]+\})/.exec(s);
+  if (tmpl) return tmpl[1];
+  return null;
+}
+
+/** Host-helper prefixes ranked by frequency across calls, most common first.
+ *  Empty when calls are all relative (nothing to strip). */
+export function dominantHostPrefixes(calls: readonly ClientCall[]): string[] {
+  const counts = new Map<string, number>();
+  for (const c of calls) {
+    const p = hostPrefixOf(c.rawUrl);
+    if (p) counts.set(p, (counts.get(p) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([p]) => p);
+}
+
+/** Distinct top-level directories that contain served routes — a coarse
+ *  multi-service signal. Returns [] when routes live under one top-level dir
+ *  (a single service). Deeper (nested / multi-repo) service splitting is
+ *  M4.3's concern; here we only surface the obvious top-level split. */
+export function servicesFromRoutes(routes: readonly RouteEndpoint[]): string[] {
+  const dirs = new Set<string>();
+  for (const r of routes) {
+    const top = r.file.split(/[/\\]/)[0];
+    if (top && top !== r.file) dirs.add(top); // skip files at repo root (no dir)
+  }
+  return dirs.size >= 2 ? [...dirs].sort() : [];
+}
+
+/** The confirmed setup a caller applies after the init prompts. */
+export interface FlowSetupDecision {
+  readonly mode: FlowGateMode;
+  readonly stripUrlPrefixes: readonly string[];
+  /** Named participants → written to workspace.json (the multi-service /
+   *  cross-repo case). Omitted for a single-service monorepo. */
+  readonly participants?: readonly WorkspaceParticipant[];
+}
+
+/**
+ * Apply a confirmed flow setup: write `flow.mode` (+ strip prefixes) into
+ * `.dxkit/policy.json` via the canonical writer, and — when participants are
+ * named — `.dxkit/workspace.json`. Returns the repo-relative paths written (for
+ * the init summary). Never throws on an already-current policy (idempotent).
+ */
+export function applyFlowSetup(cwd: string, decision: FlowSetupDecision): string[] {
+  const written: string[] = [];
+  const changed = writeFlowPolicy(cwd, {
+    mode: decision.mode,
+    ...(decision.stripUrlPrefixes.length
+      ? { stripUrlPrefixes: [...decision.stripUrlPrefixes] }
+      : {}),
+  });
+  if (changed) written.push('.dxkit/policy.json');
+  if (decision.participants && decision.participants.length > 0) {
+    writeWorkspace(cwd, { participants: [...decision.participants], external: [] });
+    written.push('.dxkit/workspace.json');
+  }
+  return written;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,8 @@ import { parseArgs } from 'node:util';
 import { suspectVendoredEntries } from './analyzers/tools/vendored-advisor';
 import { detect } from './detect';
 import { generate } from './generator';
-import { promptForConfig } from './prompts';
+import { promptForConfig, promptFlowSetup } from './prompts';
+import { detectFlowTopology, applyFlowSetup } from './analyzers/flow/setup';
 import { runUpdate, writeInstallFlags } from './update';
 import { runDoctor } from './doctor';
 import { VERSION } from './constants';
@@ -245,6 +246,10 @@ function printUsage(): void {
                               CLAUDE.md, preserving your content). Implies dxkit skills.
     --loop-preset <p>         Loop blocking posture: security-only (default) or
                               full-debt. Only meaningful with --claude-loop.
+    --flow                    Set up the UI→API integration gate (warn posture),
+                              no prompt. Auto-offered interactively when init
+                              detects a UI→API surface.
+    --no-flow                 Skip flow setup even when a UI→API surface is detected.
     --detect                  Auto-detect stack, minimal prompts
     --yes                     Accept all defaults, no prompts
     --force                   Overwrite existing files (incl. existing hooks/
@@ -348,6 +353,10 @@ export async function run(argv: string[]): Promise<void> {
       // loop pack: register the Stop-gate hook + CLAUDE.md loop norm
       'claude-loop': { type: 'boolean', default: false },
       'loop-preset': { type: 'string' },
+      // flow setup (folded into init; no standalone `flow init`).
+      // --flow forces it on (warn posture); --no-flow suppresses it.
+      flow: { type: 'boolean', default: false },
+      'no-flow': { type: 'boolean', default: false },
       // setup-branch-protection flags
       branch: { type: 'string' },
       'require-reviews': { type: 'string' },
@@ -575,6 +584,38 @@ export async function run(argv: string[]): Promise<void> {
           label: 'CI deep-SAST refresh workflow',
           result: installCiDeepSastRefresh(cwd, { force: !!values.force }),
         });
+      }
+
+      // Flow setup — folded into `init` (there is no standalone `flow init`).
+      // Detect a UI→API surface; if there is none, stay silent (zero burden on
+      // a library / CLI / data repo). Otherwise prompt for the gate posture
+      // (interactive, with a description of each) or take the gentle `warn`
+      // default (--flow / --yes / non-TTY). --no-flow suppresses it entirely.
+      if (!values['no-flow']) {
+        const detection = await detectFlowTopology(cwd);
+        if (detection.topology !== 'none') {
+          // Non-TTY without an explicit answer can't prompt — fall to the
+          // default rather than hang (mirrors how --yes is handled).
+          const flowYes = promptOpts.yes || !process.stdin.isTTY;
+          const decision = await promptFlowSetup(detection, {
+            yes: flowYes,
+            forceOn: !!values.flow,
+          });
+          const written = applyFlowSetup(cwd, decision);
+          shipResults.push({
+            label: 'Flow integration gate',
+            result: {
+              installed: written,
+              skipped: [],
+              sidecars: [],
+              notes: [
+                `Flow gate posture: ${decision.mode} ` +
+                  `(${detection.callCount} call(s) → ${detection.routeCount} route(s)). ` +
+                  `Change it in .dxkit/policy.json:flow.mode.`,
+              ],
+            },
+          });
+        }
       }
 
       // dxkit must resolve project-locally so every installed self-invocation

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -481,9 +481,12 @@ export async function run(argv: string[]): Promise<void> {
       // via flags but bundled under --full).
       // --claude-loop implies the dxkit skills so the dxkit-loop skill (and
       // its siblings) land — the loop is most useful when the user can ask
-      // Claude to explain a block / switch presets conversationally.
+      // Claude to explain a block / switch presets conversationally. --flow
+      // does the same for the dxkit-flow skill: setting up the integration gate
+      // is most useful when Claude can then diagnose + repair a break with it.
       const wantClaudeLoop = !!values['claude-loop'];
-      const wantDxkitAgents = !!values.full || !!values['with-dxkit-agents'] || wantClaudeLoop;
+      const wantDxkitAgents =
+        !!values.full || !!values['with-dxkit-agents'] || wantClaudeLoop || !!values.flow;
       const result = await generate(
         cwd,
         config,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -959,12 +959,20 @@ export async function run(argv: string[]): Promise<void> {
         await runFlowRefresh({ cwd, frontend, backend, specs, json: !!values.json });
         break;
       }
+      // `flow publish` → the multi-repo handshake: union every workspace
+      // participant's served routes into this repo's served.json.
+      if (subCommand === 'publish') {
+        const { runFlowPublish } = await import('./flow-cli');
+        await runFlowPublish({ cwd, frontend, backend, specs, json: !!values.json });
+        break;
+      }
       logger.fail(`Unknown flow subcommand: ${subCommand}`);
       logger.info('Usage:');
       logger.info('  vyuh-dxkit flow [map] [--frontend <dir>] [--backend <dir>] [--specs <a,b>]');
       logger.info('  vyuh-dxkit flow trace "<METHOD> <path>"');
       logger.info('  vyuh-dxkit flow extract [--out <dir>]');
       logger.info('  vyuh-dxkit flow refresh');
+      logger.info('  vyuh-dxkit flow publish   (multi-repo: union participants’ served routes)');
       process.exit(1);
       break;
     }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -9,6 +9,7 @@ import * as logger from './logger';
 import { resolveBaselineMode } from './baseline/modes';
 import { loadPolicyFromCwd } from './baseline/policy';
 import { loadAllowlist, auditAllowlist } from './allowlist/file';
+import { diagnoseFlow, type FlowDiagnosis } from './analyzers/flow/diagnose';
 
 /**
  * Three-tier doctor:
@@ -64,6 +65,12 @@ export interface DoctorReport {
   generatedAt: string;
   cwd: string;
   checks: CheckResult[];
+  /** The flow-contract diagnosis (unresolved calls + reasons, unconsumed
+   *  routes, connection-resolution rung) — present only when the repo has a
+   *  UI→API surface. This is the "diagnose" surface folded into doctor; there
+   *  is no standalone `flow doctor`. Agent-legible so the dxkit-flow skill reads
+   *  it directly from `doctor --json`. */
+  flow?: FlowDiagnosis;
   summary: {
     reports: { pass: number; fail: number; status: 'ok' | 'fail' };
     dx: { pass: number; fail: number; status: 'ok' | 'partial' | 'absent' };
@@ -796,6 +803,9 @@ function renderProse(report: DoctorReport, hasManifest: boolean): void {
     }
   }
 
+  // Flow contract diagnosis (only when the repo has a UI→API surface).
+  if (report.flow) renderFlowSection(report.flow);
+
   // Summary
   console.log(''); // slop-ok
   logger.header('Results');
@@ -858,6 +868,40 @@ function renderProse(report: DoctorReport, hasManifest: boolean): void {
   console.log(''); // slop-ok
 }
 
+/** Render the flow-contract diagnosis section of `doctor`. A cap keeps the
+ *  console readable; `--json` always carries the full lists for an agent. */
+function renderFlowSection(flow: FlowDiagnosis): void {
+  const CAP = 10;
+  console.log(''); // slop-ok
+  logger.info('Flow contract (UI→API integration):');
+  logger.success(
+    `${flow.topology} — ${flow.calls} call(s) → ${flow.routes} route(s), ${flow.resolved} resolved`,
+  );
+  logger.dim(`  ${flow.connection.note}`);
+
+  if (flow.unresolved.length > 0) {
+    logger.warn(`${flow.unresolved.length} unresolved call(s):`);
+    for (const u of flow.unresolved.slice(0, CAP)) {
+      logger.dim(
+        `  • ${u.method} ${u.path ?? u.rawUrl} (${u.reason} → ${u.suggestion})  ${u.file}:${u.line}`,
+      );
+    }
+    if (flow.unresolved.length > CAP) logger.dim(`  … and ${flow.unresolved.length - CAP} more`);
+  }
+  if (flow.servedUnconsumed.length > 0) {
+    logger.warn(`${flow.servedUnconsumed.length} served route(s) no in-repo call consumes:`);
+    for (const r of flow.servedUnconsumed.slice(0, CAP)) {
+      logger.dim(`  • ${r.method} ${r.path}  ${r.file}:${r.line}`);
+    }
+    if (flow.servedUnconsumed.length > CAP) {
+      logger.dim(`  … and ${flow.servedUnconsumed.length - CAP} more`);
+    }
+  }
+  if (flow.unresolved.length === 0 && flow.servedUnconsumed.length === 0) {
+    logger.success('  Every call resolves and every route has a consumer.');
+  }
+}
+
 // ────────────────────────────────────────────────────────────────────
 // Entry point
 // ────────────────────────────────────────────────────────────────────
@@ -880,7 +924,11 @@ export async function runDoctor(cwd: string, opts: { json?: boolean } = {}): Pro
     ...runOperationalChecks(cwd, hasManifest),
   ];
 
-  const report = buildReport(cwd, checks);
+  const base = buildReport(cwd, checks);
+  // Fold the flow-contract diagnosis into the report (absent on non-flow repos).
+  // Never fails doctor — diagnoseFlow is fail-open (returns null on any error).
+  const flow = await diagnoseFlow(cwd);
+  const report: DoctorReport = flow ? { ...base, flow } : base;
 
   if (opts.json) {
     // Logger is already in stderr mode (setJsonMode was called by cli.ts);

--- a/src/flow-cli.ts
+++ b/src/flow-cli.ts
@@ -19,6 +19,7 @@ import {
   writeConsumedContract,
   writeServedContract,
 } from './analyzers/flow/contract';
+import { publishFlow } from './analyzers/flow/publish';
 
 export interface FlowExtractOptions {
   readonly cwd: string;
@@ -245,4 +246,53 @@ export async function runFlowRefresh(opts: FlowViewOptions): Promise<void> {
   logger.info(`  ${path.relative(opts.cwd, consumedPath)}`);
   logger.info('');
   logger.info('Commit these so the counterpart repo can gate against them.');
+}
+
+/**
+ * `vyuh-dxkit flow publish` — the multi-repo handshake. Reads
+ * `.dxkit/workspace.json`, gathers every participant's served routes (from its
+ * local path, or pinned at a git ref), and writes this repo's `served.json` as
+ * the UNION of the whole mesh — so this repo's gate resolves calls against
+ * services it does not co-locate. With no participants it publishes this repo's
+ * own served/consumed (the monorepo case). See `flow refresh` for the
+ * single-repo snapshot without the mesh union.
+ */
+export async function runFlowPublish(opts: FlowViewOptions): Promise<void> {
+  if (!opts.json) logger.header('vyuh-dxkit flow publish');
+  const config = readFlowConfig(opts.cwd);
+  const commitSha = headCommitSha(opts.cwd);
+  const result = await publishFlow(opts.cwd, {
+    stripUrlPrefixes: config.stripUrlPrefixes,
+    specs: [
+      ...splitPaths(opts.specs, opts.cwd),
+      ...config.specs.map((s) => path.resolve(opts.cwd, s)),
+    ],
+    generatedAt: new Date().toISOString(),
+    ...(commitSha !== undefined ? { commitSha } : {}),
+  });
+
+  if (opts.json) {
+    emitJson({
+      servedPath: result.servedPath,
+      consumedPath: result.consumedPath,
+      totalServedRoutes: result.totalServedRoutes,
+      consumedBindings: result.consumedBindings,
+      contentHash: result.contentHash,
+      participants: result.participants,
+    });
+    return;
+  }
+
+  logger.success(
+    `Published mesh contract: ${result.totalServedRoutes} served route(s) across ${result.participants.length} participant(s) + this repo (hash ${result.contentHash}).`,
+  );
+  for (const p of result.participants) {
+    const detail =
+      p.source === 'missing' ? 'path not found — skipped' : `${p.routes} route(s) (${p.source})`;
+    logger.info(`  • ${p.name}: ${detail}`);
+  }
+  logger.info(`  ${path.relative(opts.cwd, result.servedPath)}`);
+  logger.info(`  ${path.relative(opts.cwd, result.consumedPath)}`);
+  logger.info('');
+  logger.info('Commit these so this repo can gate against the whole mesh offline.');
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -158,6 +158,12 @@ const DXKIT_SKILLS = [
   // ledger, and switches the security-only / full-debt posture. The
   // operator surface for the deterministic preflight/postflight layer.
   'dxkit-loop',
+  // dxkit-flow: configure/diagnose/fix the UI→API integration gate.
+  // Thin orchestration over the CLI — setup folds into `init --flow`,
+  // diagnose reads `doctor`'s flow section, fix repairs a net-new
+  // broken integration the guardrail flagged (never suppresses it),
+  // and the handshake mode drives `flow publish` for cross-repo meshes.
+  'dxkit-flow',
 ] as const;
 
 interface GenerateResult {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -3,6 +3,8 @@ import { stdin, stdout } from 'process';
 import { DetectedStack, ResolvedConfig, GenerationMode } from './types';
 import { DEFAULT_COVERAGE } from './constants';
 import * as logger from './logger';
+import type { FlowDetection, FlowSetupDecision } from './analyzers/flow/setup';
+import type { FlowGateMode } from './analyzers/flow/config';
 
 async function ask(
   rl: readline.Interface,
@@ -22,6 +24,92 @@ async function confirm(
   const answer = await rl.question(`  ${question} [${hint}]: `);
   if (!answer.trim()) return defaultYes;
   return answer.trim().toLowerCase().startsWith('y');
+}
+
+/**
+ * The interactive flow-setup step folded into `init` (there is no standalone
+ * `flow init`). Called only when `detectFlowTopology` found a UI→API surface;
+ * a repo with none never reaches here, so init stays silent on non-flow repos.
+ *
+ * Non-interactive (`--yes` / `--detect`, or `forceOn` from `--flow`) takes the
+ * gentle default: `warn` posture plus the dominant host-helper strip-prefix.
+ * Interactive lets the user pick the posture (with a one-line description of
+ * each) and confirm the auto-detected strip-prefix + services.
+ */
+export async function promptFlowSetup(
+  detection: FlowDetection,
+  options: { yes: boolean; forceOn: boolean },
+): Promise<FlowSetupDecision> {
+  const defaultPrefixes = detection.suggestedStripPrefixes.slice(0, 1);
+
+  // Non-interactive default: warn + the dominant strip-prefix, no participants
+  // (recording multiple services is an explicit interactive confirm).
+  if (options.yes || options.forceOn) {
+    return { mode: 'warn', stripUrlPrefixes: defaultPrefixes };
+  }
+
+  const rl = readline.createInterface({ input: stdin, output: stdout });
+  try {
+    logger.header('UI→API integration gate');
+    logger.info(
+      `Detected ${detection.callCount} client call(s) → ${detection.routeCount} route(s) ` +
+        `(${detection.resolvedCount} already resolved).`,
+    );
+    if (detection.topology !== 'monorepo') {
+      logger.info(
+        `This repo has only the ${detection.topology === 'consumer-only' ? 'client' : 'server'} ` +
+          `side; the gate resolves calls against a counterpart contract (set up later with ` +
+          `cross-repo publish) and stays inert until one is present.`,
+      );
+    }
+    console.log(''); // slop-ok
+    console.log('  How should a PR that breaks an integration be treated?'); // slop-ok
+    console.log('    warn   surface broken integrations as warnings (recommended)'); // slop-ok
+    console.log('    block  fail the check on an exact broken integration (confidence-gated)'); // slop-ok
+    console.log('    off    scaffold config only, do not gate yet'); // slop-ok
+    const mode = await selectMode(rl, 'Posture?', 'warn');
+
+    let stripUrlPrefixes: string[] = [];
+    if (detection.suggestedStripPrefixes.length > 0) {
+      const top = detection.suggestedStripPrefixes[0];
+      const ok = await confirm(
+        rl,
+        `Strip base-URL prefix "${top}" so calls match served routes?`,
+        true,
+      );
+      if (ok) stripUrlPrefixes = [top];
+    }
+
+    let participants: FlowSetupDecision['participants'];
+    if (detection.detectedServices.length >= 2) {
+      const list = detection.detectedServices.join(', ');
+      const ok = await confirm(
+        rl,
+        `Detected ${detection.detectedServices.length} services (${list}). Record them as participants?`,
+        true,
+      );
+      if (ok) participants = detection.detectedServices.map((name) => ({ name, path: name }));
+    }
+
+    return { mode, stripUrlPrefixes, ...(participants ? { participants } : {}) };
+  } finally {
+    rl.close();
+  }
+}
+
+/** Ask for a flow posture, re-prompting until a valid value (or the default on
+ *  an empty answer). Kept local — the only three-way select dxkit prompts for. */
+async function selectMode(
+  rl: readline.Interface,
+  question: string,
+  defaultValue: FlowGateMode,
+): Promise<FlowGateMode> {
+  for (;;) {
+    const answer = (await rl.question(`  ${question} [${defaultValue}]: `)).trim().toLowerCase();
+    if (!answer) return defaultValue;
+    if (answer === 'warn' || answer === 'block' || answer === 'off') return answer;
+    logger.warn('Enter one of: warn, block, off.');
+  }
 }
 
 export async function promptForConfig(

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,109 @@
+/**
+ * `.dxkit/workspace.json` — the cross-repo participants primitive.
+ *
+ * A deliberately shared seam, NOT nested under `flow`: it names the repos /
+ * services that make up a system, and flow contributes the FIRST relationship
+ * over it (consumer→provider api-bindings). Future cross-repo concerns
+ * (shared-datastore, emits/consumes-event, build-dependency) read the same
+ * participant list, so the primitive lives at the top level rather than inside
+ * any one feature's config.
+ *
+ * A `participant` is a repo/service with a source path and optional base URLs
+ * (the addresses its served routes answer on). An `external` is a third-party
+ * API addressed by base URL — optionally with an OpenAPI spec dxkit consumes to
+ * verify calls — that this system talks to but does not serve.
+ *
+ * Single reader/writer of the file (Rule 2). Fail-open: a missing or malformed
+ * file yields `null` (no participants), never a throw — the same posture every
+ * other flow surface takes toward optional config.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** A repo/service in the system — a source root plus the base URLs its served
+ *  routes answer on (used to attribute a consumed call to the provider it
+ *  targets). `path` is repo-relative or a `../sibling` path. */
+export interface WorkspaceParticipant {
+  readonly name: string;
+  readonly path: string;
+  readonly baseUrls?: readonly string[];
+}
+
+/** A third-party API the system consumes but does not serve. `spec` (an
+ *  OpenAPI/spec file) lets dxkit verify the call shape without serving it. */
+export interface WorkspaceExternal {
+  readonly name: string;
+  readonly baseUrls?: readonly string[];
+  readonly spec?: string;
+}
+
+export interface Workspace {
+  readonly participants: readonly WorkspaceParticipant[];
+  readonly external: readonly WorkspaceExternal[];
+}
+
+const WORKSPACE_REL = path.join('.dxkit', 'workspace.json');
+
+/** Absolute path to a repo's workspace file. */
+export function workspacePath(cwd: string): string {
+  return path.join(cwd, WORKSPACE_REL);
+}
+
+function stringList(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((s): s is string => typeof s === 'string') : [];
+}
+
+function normalizeParticipant(v: unknown): WorkspaceParticipant | null {
+  if (!v || typeof v !== 'object') return null;
+  const r = v as { name?: unknown; path?: unknown; baseUrls?: unknown };
+  if (typeof r.name !== 'string' || typeof r.path !== 'string') return null;
+  const baseUrls = stringList(r.baseUrls);
+  return { name: r.name, path: r.path, ...(baseUrls.length ? { baseUrls } : {}) };
+}
+
+function normalizeExternal(v: unknown): WorkspaceExternal | null {
+  if (!v || typeof v !== 'object') return null;
+  const r = v as { name?: unknown; baseUrls?: unknown; spec?: unknown };
+  if (typeof r.name !== 'string') return null;
+  const baseUrls = stringList(r.baseUrls);
+  return {
+    name: r.name,
+    ...(baseUrls.length ? { baseUrls } : {}),
+    ...(typeof r.spec === 'string' ? { spec: r.spec } : {}),
+  };
+}
+
+/** Structure-check a parsed workspace object. Returns `null` when it names no
+ *  participants and no externals (an empty file is indistinguishable from an
+ *  absent one — both mean "no configured topology"). */
+export function normalizeWorkspace(raw: unknown): Workspace | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as { participants?: unknown; external?: unknown };
+  const participants = Array.isArray(r.participants)
+    ? r.participants.map(normalizeParticipant).filter((p): p is WorkspaceParticipant => p !== null)
+    : [];
+  const external = Array.isArray(r.external)
+    ? r.external.map(normalizeExternal).filter((e): e is WorkspaceExternal => e !== null)
+    : [];
+  if (participants.length === 0 && external.length === 0) return null;
+  return { participants, external };
+}
+
+/** Read `.dxkit/workspace.json`. Fail-open: absent or malformed → `null`. */
+export function readWorkspace(cwd: string): Workspace | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(workspacePath(cwd), 'utf8'));
+  } catch {
+    return null;
+  }
+  return normalizeWorkspace(raw);
+}
+
+/** Write `.dxkit/workspace.json`, creating `.dxkit/` as needed. */
+export function writeWorkspace(cwd: string, ws: Workspace): void {
+  const abs = workspacePath(cwd);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, JSON.stringify(ws, null, 2) + '\n', 'utf8');
+}

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -28,6 +28,9 @@ export interface WorkspaceParticipant {
   readonly name: string;
   readonly path: string;
   readonly baseUrls?: readonly string[];
+  /** Git ref to pin the participant's contract at when publishing (e.g. `main`).
+   *  Omitted → gather from the participant's current working tree. */
+  readonly ref?: string;
 }
 
 /** A third-party API the system consumes but does not serve. `spec` (an
@@ -56,10 +59,15 @@ function stringList(v: unknown): string[] {
 
 function normalizeParticipant(v: unknown): WorkspaceParticipant | null {
   if (!v || typeof v !== 'object') return null;
-  const r = v as { name?: unknown; path?: unknown; baseUrls?: unknown };
+  const r = v as { name?: unknown; path?: unknown; baseUrls?: unknown; ref?: unknown };
   if (typeof r.name !== 'string' || typeof r.path !== 'string') return null;
   const baseUrls = stringList(r.baseUrls);
-  return { name: r.name, path: r.path, ...(baseUrls.length ? { baseUrls } : {}) };
+  return {
+    name: r.name,
+    path: r.path,
+    ...(baseUrls.length ? { baseUrls } : {}),
+    ...(typeof r.ref === 'string' ? { ref: r.ref } : {}),
+  };
 }
 
 function normalizeExternal(v: unknown): WorkspaceExternal | null {

--- a/test/cli-init.test.ts
+++ b/test/cli-init.test.ts
@@ -129,6 +129,8 @@ describe('cli init --full --yes (integration, full agent scaffold)', () => {
       'dxkit-allowlist',
       'dxkit-test',
       'dxkit-pr',
+      'dxkit-loop',
+      'dxkit-flow',
     ];
     for (const name of expected) {
       const skillPath = path.join(tmpDir, '.claude', 'skills', name, 'SKILL.md');

--- a/test/flow-diagnose.test.ts
+++ b/test/flow-diagnose.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for src/analyzers/flow/diagnose.ts — the flow-contract diagnosis folded
+ * into `doctor`. Each case builds a small on-disk repo (the extractor reads the
+ * working tree) and asserts the unresolved tail + reasons, the unconsumed-route
+ * list, and the connection-resolution rung.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { diagnoseFlow } from '../src/analyzers/flow/diagnose';
+
+function makeRepo(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-flowdiag-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', version: '0.0.0' }));
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(dir, rel);
+    mkdirSync(join(abs, '..'), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return dir;
+}
+
+describe('diagnoseFlow', () => {
+  it('reports the unresolved tail with reasons + suggestions (monorepo)', async () => {
+    const dir = makeRepo({
+      'web/List.tsx': "axios.get('/articles');\naxios.get('/dead');\n",
+      'api/ctrl.ts': "class C { @get('/articles') a() {} @get('/orphan') b() {} }\n",
+    });
+    try {
+      const d = await diagnoseFlow(dir);
+      expect(d).not.toBeNull();
+      expect(d!.topology).toBe('monorepo');
+      expect(d!.resolved).toBe(1);
+      // The dead call is unresolved: no served route matches, and a monorepo
+      // serves its own routes → the suggestion is to add the route.
+      const dead = d!.unresolved.find((u) => u.path === '/dead');
+      expect(dead).toBeDefined();
+      expect(dead!.reason).toBe('no-route');
+      expect(dead!.suggestion).toBe('add-route');
+      // The orphan route nobody calls is surfaced as served-but-unconsumed.
+      expect(d!.servedUnconsumed.map((r) => r.path)).toContain('/orphan');
+      expect(d!.connection.rung).toBe('monorepo');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('suggests configure-participant for a consumer-only repo with no served side', async () => {
+    const dir = makeRepo({
+      'web/List.tsx': "axios.get('/articles');\n",
+    });
+    try {
+      const d = await diagnoseFlow(dir);
+      expect(d).not.toBeNull();
+      expect(d!.topology).toBe('consumer-only');
+      // No routes in-repo, so the call can't resolve; the provider lives
+      // elsewhere → configure a participant / counterpart.
+      const call = d!.unresolved.find((u) => u.path === '/articles');
+      expect(call?.suggestion).toBe('configure-participant');
+      expect(d!.connection.rung).toBe('unresolved');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a clean contract (no unresolved, no unconsumed) when everything binds', async () => {
+    const dir = makeRepo({
+      'web/List.tsx': "axios.get('/articles');\n",
+      'api/ctrl.ts': "class C { @get('/articles') a() {} }\n",
+    });
+    try {
+      const d = await diagnoseFlow(dir);
+      expect(d!.unresolved).toEqual([]);
+      expect(d!.servedUnconsumed).toEqual([]);
+      expect(d!.resolved).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when the repo has no flow surface (doctor omits the section)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-flowdiag-none-'));
+    try {
+      writeFileSync(join(dir, 'README.md'), '# hi\n');
+      expect(await diagnoseFlow(dir)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/flow-publish.test.ts
+++ b/test/flow-publish.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for src/analyzers/flow/publish.ts (the multi-repo handshake) and the
+ * servedContentHash digest. publishFlow is exercised against on-disk fixtures:
+ * a consumer app plus a sibling backend participant.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { publishFlow } from '../src/analyzers/flow/publish';
+import { servedContentHash, readServedContract } from '../src/analyzers/flow/contract';
+
+const NOW = '2026-07-02T00:00:00.000Z';
+
+function write(root: string, rel: string, content: string): void {
+  const abs = join(root, rel);
+  mkdirSync(join(abs, '..'), { recursive: true });
+  writeFileSync(abs, content);
+}
+
+describe('servedContentHash', () => {
+  it('is stable and order-independent, and changes when routes change', () => {
+    const a = [
+      { method: 'GET', path: '/x', handler: null, via: 'decorator' as const },
+      { method: 'POST', path: '/y', handler: null, via: 'decorator' as const },
+    ];
+    const reordered = [a[1], a[0]];
+    expect(servedContentHash(a)).toBe(servedContentHash(reordered)); // order-independent
+    const changed = [...a, { method: 'GET', path: '/z', handler: null, via: 'decorator' as const }];
+    expect(servedContentHash(changed)).not.toBe(servedContentHash(a)); // drift detected
+  });
+});
+
+describe('publishFlow', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dxkit-flowpub-'));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('unions a participant’s served routes into this repo’s served.json', async () => {
+    // Sibling backend serves two routes.
+    write(root, 'backend/package.json', JSON.stringify({ name: 'be', version: '0.0.0' }));
+    write(
+      root,
+      'backend/api/ctrl.ts',
+      "class C { @get('/articles') a() {} @get('/orphan') b() {} }\n",
+    );
+    // Consumer app calls one served + one missing, with backend as a participant.
+    write(root, 'app/package.json', JSON.stringify({ name: 'app', version: '0.0.0' }));
+    write(root, 'app/web/List.tsx', "axios.get('/articles');\naxios.get('/missing');\n");
+    write(
+      root,
+      'app/.dxkit/workspace.json',
+      JSON.stringify({ participants: [{ name: 'backend', path: '../backend' }], external: [] }),
+    );
+
+    const appDir = join(root, 'app');
+    const result = await publishFlow(appDir, { generatedAt: NOW });
+
+    expect(result.participants).toEqual([{ name: 'backend', routes: 2, source: 'local' }]);
+    expect(result.totalServedRoutes).toBe(2);
+    expect(existsSync(result.servedPath)).toBe(true);
+    const served = readServedContract(appDir);
+    expect(served?.routes.map((r) => `${r.method} ${r.path}`).sort()).toEqual([
+      'GET /articles',
+      'GET /orphan',
+    ]);
+    expect(served?.contentHash).toBe(result.contentHash);
+  });
+
+  it('marks a participant whose path is missing as source=missing without failing', async () => {
+    write(root, 'app/package.json', JSON.stringify({ name: 'app', version: '0.0.0' }));
+    write(root, 'app/web/List.tsx', "axios.get('/articles');\n");
+    write(
+      root,
+      'app/.dxkit/workspace.json',
+      JSON.stringify({ participants: [{ name: 'ghost', path: '../nope' }], external: [] }),
+    );
+    const result = await publishFlow(join(root, 'app'), { generatedAt: NOW });
+    expect(result.participants).toEqual([{ name: 'ghost', routes: 0, source: 'missing' }]);
+  });
+
+  it('publishes this repo’s own served routes when there are no participants', async () => {
+    write(root, 'package.json', JSON.stringify({ name: 'mono', version: '0.0.0' }));
+    write(root, 'web/List.tsx', "axios.get('/articles');\n");
+    write(root, 'api/ctrl.ts', "class C { @get('/articles') a() {} }\n");
+    const result = await publishFlow(root, { generatedAt: NOW });
+    expect(result.participants).toEqual([]);
+    expect(result.totalServedRoutes).toBe(1);
+    expect(result.consumedBindings).toBeGreaterThan(0);
+  });
+});

--- a/test/flow-setup.test.ts
+++ b/test/flow-setup.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for src/analyzers/flow/setup.ts (detection + apply) and the
+ * writeFlowPolicy writer in config.ts. Pure helpers are unit-tested directly;
+ * detectFlowTopology runs against a small on-disk monorepo fixture (the same
+ * shape the flow gate tests use).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  hostPrefixOf,
+  dominantHostPrefixes,
+  servicesFromRoutes,
+  detectFlowTopology,
+  applyFlowSetup,
+} from '../src/analyzers/flow/setup';
+import { readFlowConfig, writeFlowPolicy } from '../src/analyzers/flow/config';
+import { readWorkspace } from '../src/workspace';
+import type { ClientCall } from '../src/analyzers/flow/extract';
+import type { RouteEndpoint } from '../src/analyzers/flow/extract';
+
+function call(rawUrl: string): ClientCall {
+  return { method: 'GET', rawUrl, path: null, receiver: 'axios', file: 'web/x.ts', line: 1 };
+}
+function route(file: string): RouteEndpoint {
+  return { method: 'GET', path: '/x', via: 'decorator', handler: null, file, line: 1 };
+}
+
+describe('hostPrefixOf', () => {
+  it('extracts an absolute scheme://host prefix', () => {
+    expect(hostPrefixOf('https://api.example.com/articles')).toBe('https://api.example.com');
+    expect(hostPrefixOf('http://localhost:3000/x')).toBe('http://localhost:3000');
+  });
+  it('extracts a leading ${...} base-URL helper template', () => {
+    expect(hostPrefixOf('${Config.lb4api()}/articles')).toBe('${Config.lb4api()}');
+  });
+  it('handles a template literal captured with its backticks', () => {
+    // The extractor captures a template-literal URL with backticks intact.
+    expect(hostPrefixOf('`${Config.api()}/articles`')).toBe('${Config.api()}');
+    expect(hostPrefixOf('`https://api.example.com/x`')).toBe('https://api.example.com');
+  });
+  it('returns null for a relative URL (nothing to strip)', () => {
+    expect(hostPrefixOf('/articles')).toBeNull();
+    expect(hostPrefixOf('articles')).toBeNull();
+  });
+});
+
+describe('dominantHostPrefixes', () => {
+  it('ranks prefixes by frequency, most common first', () => {
+    const calls = [
+      call('${Config.api()}/a'),
+      call('${Config.api()}/b'),
+      call('https://ext.example.com/c'),
+      call('/relative'),
+    ];
+    expect(dominantHostPrefixes(calls)).toEqual(['${Config.api()}', 'https://ext.example.com']);
+  });
+  it('is empty when every call is relative', () => {
+    expect(dominantHostPrefixes([call('/a'), call('/b')])).toEqual([]);
+  });
+});
+
+describe('servicesFromRoutes', () => {
+  it('returns the distinct top-level dirs when routes span two or more', () => {
+    expect(
+      servicesFromRoutes([route('api/a.ts'), route('userserver/b.ts'), route('api/c.ts')]),
+    ).toEqual(['api', 'userserver']);
+  });
+  it('returns [] when all routes live under one top-level dir (single service)', () => {
+    expect(servicesFromRoutes([route('api/a.ts'), route('api/b.ts')])).toEqual([]);
+  });
+  it('ignores routes in files at the repo root', () => {
+    expect(servicesFromRoutes([route('server.ts'), route('api/a.ts')])).toEqual([]);
+  });
+});
+
+describe('writeFlowPolicy', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-flowpolicy-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('writes flow.mode and reads back through readFlowConfig', () => {
+    expect(writeFlowPolicy(dir, { mode: 'warn' })).toBe(true);
+    expect(readFlowConfig(dir).mode).toBe('warn');
+  });
+
+  it('preserves other policy sections (loop) when patching flow', () => {
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(
+      join(dir, '.dxkit', 'policy.json'),
+      JSON.stringify({ loop: { preset: 'security-only' } }),
+    );
+    writeFlowPolicy(dir, { mode: 'block' });
+    const parsed = JSON.parse(readFileSync(join(dir, '.dxkit', 'policy.json'), 'utf8'));
+    expect(parsed.loop.preset).toBe('security-only'); // preserved
+    expect(parsed.flow.mode).toBe('block');
+  });
+
+  it('is idempotent — a no-op write returns false', () => {
+    expect(writeFlowPolicy(dir, { mode: 'warn' })).toBe(true);
+    expect(writeFlowPolicy(dir, { mode: 'warn' })).toBe(false);
+  });
+
+  it('leaves a malformed policy untouched (returns false)', () => {
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(join(dir, '.dxkit', 'policy.json'), '{ broken');
+    expect(writeFlowPolicy(dir, { mode: 'block' })).toBe(false);
+    expect(readFileSync(join(dir, '.dxkit', 'policy.json'), 'utf8')).toBe('{ broken');
+  });
+});
+
+describe('applyFlowSetup', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-flowapply-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('writes policy flow.mode + strip prefixes, no workspace when single-service', () => {
+    const written = applyFlowSetup(dir, {
+      mode: 'warn',
+      stripUrlPrefixes: ['${Config.api()}'],
+    });
+    expect(written).toEqual(['.dxkit/policy.json']);
+    const cfg = readFlowConfig(dir);
+    expect(cfg.mode).toBe('warn');
+    expect(cfg.stripUrlPrefixes).toEqual(['${Config.api()}']);
+    expect(readWorkspace(dir)).toBeNull();
+  });
+
+  it('writes workspace.json when participants are named', () => {
+    const written = applyFlowSetup(dir, {
+      mode: 'block',
+      stripUrlPrefixes: [],
+      participants: [
+        { name: 'api', path: 'api' },
+        { name: 'userserver', path: 'userserver' },
+      ],
+    });
+    expect(written).toContain('.dxkit/workspace.json');
+    expect(readWorkspace(dir)?.participants.map((p) => p.name)).toEqual(['api', 'userserver']);
+  });
+});
+
+describe('detectFlowTopology', () => {
+  it('detects a monorepo (calls + routes) and suggests the strip prefix', async () => {
+    // No git needed — detection reads the working tree directly.
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-flowdetect-'));
+    try {
+      mkdirSync(join(dir, 'web'), { recursive: true });
+      mkdirSync(join(dir, 'api'), { recursive: true });
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', version: '0.0.0' }));
+      writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\n");
+      writeFileSync(join(dir, 'api', 'ctrl.ts'), "class C { @get('/articles') a() {} }\n");
+      const d = await detectFlowTopology(dir);
+      expect(d.topology).toBe('monorepo');
+      expect(d.callCount).toBeGreaterThan(0);
+      expect(d.routeCount).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns 'none' on a repo with no flow-capable pack (stays silent)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-flownone-'));
+    try {
+      // A bare text file — no package.json, no flow-capable pack active.
+      writeFileSync(join(dir, 'README.md'), '# hi\n');
+      const d = await detectFlowTopology(dir);
+      expect(d.topology).toBe('none');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for src/workspace.ts — the `.dxkit/workspace.json` participants
+ * primitive: fail-open read, structural normalization, and round-trip write.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readWorkspace, writeWorkspace, normalizeWorkspace, workspacePath } from '../src/workspace';
+
+describe('workspace.json primitive', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-workspace-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('returns null when the file is absent (fail-open)', () => {
+    expect(readWorkspace(dir)).toBeNull();
+  });
+
+  it('returns null on malformed JSON (fail-open, never throws)', () => {
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(workspacePath(dir), '{ not json');
+    expect(readWorkspace(dir)).toBeNull();
+  });
+
+  it('round-trips participants + externals through write/read', () => {
+    writeWorkspace(dir, {
+      participants: [
+        { name: 'web', path: '../web-client' },
+        { name: 'api', path: 'src', baseUrls: ['${Config.api()}'] },
+      ],
+      external: [{ name: 'authz', baseUrls: ['https://auth.example.com'], spec: 'authz.json' }],
+    });
+    expect(existsSync(workspacePath(dir))).toBe(true);
+    const ws = readWorkspace(dir);
+    expect(ws?.participants).toHaveLength(2);
+    expect(ws?.participants[1]).toEqual({
+      name: 'api',
+      path: 'src',
+      baseUrls: ['${Config.api()}'],
+    });
+    expect(ws?.external[0]).toEqual({
+      name: 'authz',
+      baseUrls: ['https://auth.example.com'],
+      spec: 'authz.json',
+    });
+  });
+
+  it('normalizes away malformed entries but keeps well-formed ones', () => {
+    const ws = normalizeWorkspace({
+      participants: [
+        { name: 'ok', path: 'src' },
+        { name: 'missing-path' }, // dropped
+        { path: 'no-name' }, // dropped
+        'not-an-object', // dropped
+      ],
+      external: [{ name: 'x' }, { spec: 'no-name.json' }],
+    });
+    expect(ws?.participants).toEqual([{ name: 'ok', path: 'src' }]);
+    expect(ws?.external).toEqual([{ name: 'x' }]);
+  });
+
+  it('treats an empty (no participants, no externals) object as null', () => {
+    expect(normalizeWorkspace({ participants: [], external: [] })).toBeNull();
+    expect(normalizeWorkspace({})).toBeNull();
+    expect(normalizeWorkspace(null)).toBeNull();
+  });
+
+  it('drops non-string baseUrls entries but keeps string ones', () => {
+    const ws = normalizeWorkspace({
+      participants: [{ name: 'p', path: 's', baseUrls: ['ok', 42, null, 'ok2'] }],
+      external: [],
+    });
+    expect(ws?.participants[0].baseUrls).toEqual(['ok', 'ok2']);
+  });
+});

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -49,6 +49,14 @@ describe('workspace.json primitive', () => {
     });
   });
 
+  it('preserves an optional participant ref (git-ref pin for publish)', () => {
+    const ws = normalizeWorkspace({
+      participants: [{ name: 'backend', path: '../backend', ref: 'main' }],
+      external: [],
+    });
+    expect(ws?.participants[0]).toEqual({ name: 'backend', path: '../backend', ref: 'main' });
+  });
+
   it('normalizes away malformed entries but keeps well-formed ones', () => {
     const ws = normalizeWorkspace({
       participants: [


### PR DESCRIPTION
## What — M4: the flow feature becomes agent-operable (2.22.0)

Adds the surfaces needed to **configure, diagnose, publish, and repair** the UI→API integration gate — folded into the commands you already run so the CLI stays small. Four sub-milestones (rebase-merge to preserve them):

- **M4.1 — setup folds into `init`** (`669630c`). No standalone `flow init`. When init detects a UI→API surface it offers the gate and asks the posture (`warn` default / `block` / `off`) with a description of each; silent on non-flow repos. `--flow` / `--no-flow`. Adds the `.dxkit/workspace.json` participants primitive.
- **M4.2 — diagnose folds into `doctor`** (`a080886`). No standalone `flow doctor`. `doctor` (and `doctor --json`) gains a `flow` diagnosis: unresolved calls with reasons + suggestions, served-but-unconsumed routes, connection-resolution rung.
- **M4.3 — `flow publish`** (`d2f63d0`). The multi-repo handshake: unions every `workspace.json` participant's served routes into this repo's `served.json` so a consumer gates against a provider it doesn't co-locate. Local or git-ref-pinned participant gather; content-hash for drift; fail-open per participant.
- **M4.4 — `dxkit-flow` skill** (`6720c37`). Setup / diagnose / fix / handshake, thin orchestration over the CLI. `--flow` installs it. Fix mode repairs a break, never suppresses it.

## Deferred (tracked, out of scope here)
- Author-extension skill mode → needs the Flow Extension SDK (post-3.0).
- Cross-repo `flow publish` **CI job** + its self-invocation surface → M5.
- Remote-repo participant fetch (clone by URL) → tracked; local/monorepo participants work today.

## Verification
Full suite green (**2712 tests**, 170 files). Each sub-milestone: build, typecheck, `typecheck:test`, architecture, slop, lint, format clean; new unit + fixture tests for workspace, setup, diagnose, publish. End-to-end smoke-tested on temp fixtures (init flow-setup, doctor flow section, publish mesh union, `init --flow` installs the skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)