### PR TITLE
feat: the correctness floor (loop-safety liveness gate) — 2.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.23.0] - 2026-07-04
+
+### Added — the correctness floor (a loop-safety liveness gate)
+
+The guardrail proves "no net-new findings" (secrets, CVEs, SAST, coverage). It
+does not prove the code still **compiles and its affected tests still pass** — so
+an autonomous agent loop can satisfy the finding gate while shipping code that
+does not build, and even a broken test that lifts coverage gets rewarded. The
+correctness floor closes that gap: a liveness check that asks "does this still
+build, and do the tests it affects still pass?" before an agent may declare
+"done". A failing floor is a pass/fail signal, not a fingerprinted, grandfathered
+finding (there is no "grandfather a syntax error"), so it sits outside the
+baseline and allowlist.
+
+- **Pack-declared, runner-executed** (CLAUDE.md Rule 15). Each language pack
+  declares two pure command builders — `syntaxCheck` (the cheap "does it
+  compile/parse" check) and `affectedTests` (run the tests the change reaches).
+  One runner owns the load-bearing policy in a single place: fail-CLOSED on a
+  real failure (a non-zero exit blocks), fail-OPEN on infrastructure (a missing
+  toolchain or a timeout is a skip, never a block — a slow or un-installed
+  toolchain is not broken code; CI is the backstop). A pack never shells out
+  itself.
+- **All 8 packs, verified against real toolchains**, at the affected granularity
+  each ecosystem natively supports:
+
+  | Pack | Compile | Affected-test granularity |
+  | --- | --- | --- |
+  | TypeScript / JavaScript | `tsc --noEmit` (or the project's typecheck script) | per-file (`vitest related` / `jest --findRelatedTests`) |
+  | Python | `py_compile` | per changed test file (pytest) |
+  | Go | `go build ./...` | changed package(s) |
+  | Rust | `cargo check` | changed crate(s) (`-p`) |
+  | C# / .NET | `dotnet build` | changed test project (`dotnet test <proj>`) |
+  | Java | Maven `test-compile` / Gradle `testClasses` | changed build module (Maven `-pl -am`, Gradle `:mod:test`) |
+  | Kotlin | Maven `test-compile` / Gradle `testClasses` | changed build module |
+  | Ruby | `ruby -c` per changed file | changed spec/test file (RSpec / minitest) |
+
+  A change whose dependents live in another package/module/crate is caught at
+  full/CI scope, not the fast affected surface. The two JVM packs share one
+  `jvm-build.ts` provider (Rule 2).
+- **Three surfaces, one adaptive resolver.** The loop Stop-gate runs the floor
+  by default (an agent must not stop on broken code), scoped to what the loop
+  introduced via a testmon-style entry snapshot, so a pre-existing failure never
+  blocks. The pre-push and CI surfaces are adaptive: when the repo already runs
+  its tests in its own CI, the floor defaults to opt-in there; when no test-CI is
+  detected it runs by default; when a CI exists but its test step is opaque it
+  fails toward on. Precedence: an explicit flag, then a `DXKIT_FLOOR_<SURFACE>`
+  env, then `.dxkit/policy.json` `correctness.surfaces.<surface>`, then the
+  adaptive default.
+- **`vyuh-dxkit floor check [--surface pre-push|ci] [--base <ref>]
+  [--correctness | --no-correctness]`** — the entry point the pre-push hook and
+  CI workflow call. It is baseline-independent, so a brand-new repo with no
+  baseline still gets push-time liveness. The installed pre-push hook runs it
+  before the baseline check; the CI guardrail workflow runs it (full scope) after
+  the finding gate.
+
+### Changed
+
+- `LanguageSupport.correctness` is now a required field: the capability shipped
+  optional and tightened once all eight packs declared it, so a new pack that
+  omits it fails to compile (not just at test time). The `new-lang` scaffold
+  wires a dormant provider so a fresh pack still compiles, with TODOs for the
+  real commands.
+
 ## [2.22.0] - 2026-07-02
 
 ### Added — the flow feature becomes agent-operable (setup, diagnose, publish, repair)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -633,7 +633,7 @@ never hardcodes a per-language command (mirror of Rule 6):
 - **Diff-scoped, without a baseline artifact.** The loop Stop-gate
   captures an ENTRY SNAPSHOT of the already-broken set on the pristine
   tree at activation (`src/loop/floor-state.ts`, `vyuh-dxkit loop
-  snapshot`), then blocks only on failures NET-NEW vs that snapshot — a
+snapshot`), then blocks only on failures NET-NEW vs that snapshot — a
   pre-existing failure never blocks. This is testmon's insight (persist
   last-known state) scoped to one loop, so a Stop never pays a git
   worktree + install. Surfaces: loop Stop-gate (entry snapshot,
@@ -665,11 +665,18 @@ runner execute it; the Stop-gate calling `runCorrectnessFloor` +
    catches "the runner stopped iterating the registry", the same way it
    guards `depVulns` / `architecturalShape` / fingerprinting.
 
-The `npm run new-lang` scaffold emits a commented `correctness` stub so
-a new pack is prompted to implement it. `correctness` is optional today
-(TS/JS + Python shipped; other packs rolling out); once all eight
-declare it, the contract test tightens to REQUIRE it — the same
-optional-then-required arc `depVulns.manifestPatterns` followed.
+`correctness` is now REQUIRED. It shipped optional (TS/JS + Python
+first) and tightened once all eight built-in packs declared it — the
+same optional-then-required arc `depVulns.manifestPatterns` followed.
+The field is non-optional on `LanguageSupport`, so a new pack that
+omits it **fails to compile** (not just at test time); the contract
+test additionally asserts both builders are present and well-formed.
+The `npm run new-lang` scaffold wires a DORMANT provider (both builders
+return null) so a fresh pack compiles, with TODOs prompting the author
+to fill in real commands before ship. The two JVM packs (Java, Kotlin)
+share one `src/languages/jvm-build.ts` provider (Maven/Gradle, module-
+level affected) per Rule 2 — a worked example of a shared multi-build-
+system floor.
 
 ## Release procedure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -599,6 +599,78 @@ a registry entry whose `installedWhen` gates the new surface.
   injected surface won't be picked up and the test fails. Mirror of
   `recipe-playbook.test.ts` / `producer-playbook.test.ts`.
 
+### 15. The correctness floor (liveness gate) is pack-declared, runner-executed
+
+The guardrail proves "no net-new FINDINGS" (secrets / CVEs / SAST /
+coverage / flow) but NOT "the code is VALID and RUNS". The correctness
+floor closes that gap: a **liveness** gate ("does this change still
+compile, and do the tests it affects still pass?") that runs before an
+autonomous loop may declare "done". A failing floor is a pass/fail
+SIGNAL, not a fingerprinted, grandfathered finding — there is no
+"grandfather a syntax error", so it sits OUTSIDE baseline/allowlist
+(contrast Rules 9–10).
+
+Every language-specific fact is pack-declared; the cross-cutting code
+never hardcodes a per-language command (mirror of Rule 6):
+
+- **Declared** per-pack in `src/languages/<id>.ts:correctness`
+  (optional `CorrectnessProvider`) as TWO pure command builders —
+  `syntaxCheck` (the cheap "does it compile/parse" check every language
+  can give) and `affectedTests` (run the tests the change reaches;
+  native impact-selection where the ecosystem supports it, else a
+  coarser fallback with CI's `full` scope as the backstop). Each returns
+  a `{ label, bin, args }` command or null. A pack NEVER shells out
+  itself.
+- **Dispatched** via `activeCorrectnessProviders(packs)` in
+  `src/languages/index.ts`.
+- **Executed** via the ONE canonical runner
+  `src/analyzers/correctness/run.ts:runCorrectnessFloor`, which owns the
+  load-bearing policy in one place: fail-CLOSED on a real failure
+  (non-zero exit blocks), fail-OPEN on infrastructure (missing binary /
+  timeout → skipped, never a block — a slow or un-installed toolchain is
+  not broken code; CI is the backstop). Command execution is injected
+  for tests.
+- **Diff-scoped, without a baseline artifact.** The loop Stop-gate
+  captures an ENTRY SNAPSHOT of the already-broken set on the pristine
+  tree at activation (`src/loop/floor-state.ts`, `vyuh-dxkit loop
+  snapshot`), then blocks only on failures NET-NEW vs that snapshot — a
+  pre-existing failure never blocks. This is testmon's insight (persist
+  last-known state) scoped to one loop, so a Stop never pays a git
+  worktree + install. Surfaces: loop Stop-gate (entry snapshot,
+  affected), pre-push (merge-base, affected), CI (full).
+
+**Bad**: a `tsc --noEmit` / `pytest` command string hardcoded in an
+analyzer; calling a pack's `syntaxCheck`/`affectedTests` builder outside
+the runner; a `src/analyzers/**/correctness.ts` that re-implements the
+fail-open/timeout policy; grandfathering a compile error into the
+baseline.
+
+**Good**: `for (const { provider } of activeCorrectnessProviders(...))`
+inside `run.ts`; a pack that returns `{ label, bin, args }` and lets the
+runner execute it; the Stop-gate calling `runCorrectnessFloor` +
+`netNewFloorFailures`.
+
+#### Correctness-floor enforcement
+
+1. **`scripts/check-architecture.sh` Rule (correctness floor)**: a
+   pack's `.syntaxCheck(` / `.affectedTests(` builder is only invoked
+   inside `src/analyzers/correctness/`. Annotate
+   `// correctness-runner-ok` for justified exceptions (rare).
+2. **`test/languages-contract.test.ts`**: a pack declaring
+   `correctness` MUST supply both builders, each returning a well-formed
+   `{ label, bin, args }` or null.
+3. **`test/recipe-playbook.test.ts`**: the synthetic pack declares a
+   `correctness` provider; the playbook asserts
+   `activeCorrectnessProviders` + `runCorrectnessFloor` pick it up —
+   catches "the runner stopped iterating the registry", the same way it
+   guards `depVulns` / `architecturalShape` / fingerprinting.
+
+The `npm run new-lang` scaffold emits a commented `correctness` stub so
+a new pack is prompted to implement it. `correctness` is optional today
+(TS/JS + Python shipped; other packs rolling out); once all eight
+declare it, the contract test tightens to REQUIRE it — the same
+optional-then-required arc `depVulns.manifestPatterns` followed.
+
 ## Release procedure
 
 **Every release goes through the CI pipeline. No exceptions.** Local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,6 +220,20 @@ will fail CI if missing):
 imports, testFramework, licenses }`. Each is a `CapabilityProvider`
   with an async `gather(cwd)` method; return `null` when nothing to
   report. The dispatcher fans out across every pack.
+- **Correctness floor** (2.23) — `correctness?: CorrectnessProvider`,
+  the loop-safety liveness gate ("does this change still compile, and
+  do the tests it affects still pass?"). TWO pure command builders:
+  `syntaxCheck(ctx)` (the cheap compile/parse check every language can
+  give) and `affectedTests(ctx)` (the tests the change reaches — native
+  impact-selection where the ecosystem supports it, else a coarser
+  fallback with CI's `full` scope as the backstop). Each returns a
+  `{ label, bin, args }` command or `null`. A pack NEVER shells out
+  itself — the runner (`src/analyzers/correctness/run.ts`) executes the
+  command and owns the fail-open (missing tool / timeout → skip) vs
+  fail-closed (non-zero exit → block) policy. Optional today; the
+  contract test requires BOTH builders if you declare it. See
+  `typescript.ts` (`tsc --noEmit` + vitest/jest) and `python.ts`
+  (`py_compile` + pytest) for worked examples, and CLAUDE.md Rule 15.
 - **Init metadata** (LP-recipe — needed by `vyuh-dxkit init` and
   `doctor`) — `permissions[]` (Bash entries for `.claude/settings.json`),
   `ruleFile?` (filename under `src-templates/.claude/rules/`),

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -177,6 +177,43 @@ author excluded, a bus-factor signal. Renders names + GitHub @handles, never ema
 - [ ] Per-ecosystem reliability gating: only mark a finding `reachable: false` when its language pack resolves imports reliably (TS / Python / Go). For packs whose import resolution is unreliable (C# namespaces ≠ package names, etc.), leave `reachable` unset rather than risk a false "unreachable" that hides a real vuln.
 - [ ] Reachable-first report framing: a `"N reachable / M total"` summary line and reachable-first sort in the vulnerability report (the per-finding `reachable` glyph already renders). _Considered for 2.9.3 and deferred: the dependency table already discounts unreachable advisories 0.25× inside the composite `riskScore`, so this is a presentation refinement (a hard reachable-first sort tier + the summary lens) rather than new signal._
 
+## In progress — Correctness floor (loop-safety liveness gate, 2.23.0)
+
+The guardrail proves "no net-new findings" (secrets, CVEs, SAST, coverage). It
+does not prove the code still **compiles and its affected tests still pass**, so
+an autonomous agent loop can satisfy the finding gate while shipping code that
+does not build. The correctness floor closes that gap: a liveness check that runs
+before an agent may declare "done", blocking only on failures that are net-new
+versus an entry snapshot of the already-broken set (a pre-existing failure never
+blocks, and there is no baseline artifact to maintain).
+
+- [x] Pack-declared, runner-executed contract (`LanguageSupport.correctness`,
+      required field): each pack builds a `syntaxCheck` and an `affectedTests`
+      command; the runner owns the fail-closed-on-real-failure /
+      fail-open-on-infrastructure (missing toolchain, timeout) policy in one
+      place. No per-language command is hardcoded outside the pack (Rule 6).
+- [x] All 8 packs shipped and verified against real toolchains, at the affected
+      granularity each ecosystem supports: TS/JS and Python fine-grained;
+      Go package; Rust crate; C# project; Java and Kotlin build-module (one
+      shared Maven/Gradle provider); Ruby file-level compile + CI-full.
+- [x] Loop Stop-gate wired (entry-snapshot diff, affected scope, default-on) with
+      a per-command wall-clock budget so a slow suite degrades to a skip, not a
+      block.
+- [ ] Adaptive surface resolver for the CI and pre-push surfaces (default-on
+      unless a test-CI is already detected; fail toward on when uncertain).
+- [ ] Pre-push (merge-base) and CI (full-scope) floor wiring.
+
+### Uninstall / clean removal (pre-3.0)
+
+- [ ] `vyuh-dxkit uninstall` + a `dxkit-uninstall` skill that non-intrusively
+      removes the full dxkit footprint (`.dxkit/`, installed skills and hooks,
+      the git pre-push guardrail, the CI workflow, and the additive blocks dxkit
+      merged into `settings.json` / `CLAUDE.md` / `.gitignore`) by reversing each
+      installer, never a blanket wipe and never touching user code. Dry-run by
+      default with confirmation; deletes only dxkit-authored files. On removal it
+      offers to open a prefilled GitHub issue for feedback via the existing
+      `vyuh-dxkit issue` path, so nothing is ever sent without the user's action.
+
 ## Future
 
 ### Cross-agent reach (decision pending)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.22.0",
+      "version": "2.23.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -734,6 +734,33 @@ if [ -n "$ROGUE_WORKTREE" ]; then
 fi
 
 # =============================================================================
+# Correctness floor (2.23): the liveness gate stays pack-driven.
+# =============================================================================
+#
+# A pack declares its floor as two pure command builders
+# (`correctness.syntaxCheck` / `correctness.affectedTests` in
+# src/languages/<id>.ts). The ONE place that invokes those builders — and
+# executes the resulting commands with the fail-open/closed + timeout policy —
+# is the canonical runner `src/analyzers/correctness/run.ts`. Every surface
+# (loop Stop-gate, pre-push, CI) calls `runCorrectnessFloor`, never a pack's
+# builder directly. This mirrors Rule 2 (one gather path) + Rule 12 (one query
+# point): bypassing the runner means re-implementing the fail-open/timeout
+# policy and silently drifting from the pack-driven contract.
+ROGUE_FLOOR=$(grep -rnE "\.(syntaxCheck|affectedTests)[[:space:]]*\(" src/ 2>/dev/null \
+  | grep -v "// correctness-runner-ok" \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | grep -v "^src/analyzers/correctness/")
+if [ -n "$ROGUE_FLOOR" ]; then
+  echo "❌ Correctness-floor rule violation: a pack's syntaxCheck()/affectedTests() builder"
+  echo "   invoked outside the canonical runner src/analyzers/correctness/run.ts:"
+  echo "$ROGUE_FLOOR"
+  echo "   → Call runCorrectnessFloor() from src/analyzers/correctness/run.ts instead;"
+  echo "     it owns command execution + the fail-open/fail-closed + timeout policy."
+  echo "   → Annotate '// correctness-runner-ok' for justified exceptions (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# =============================================================================
 # Sprint 4 (2.5.2): dead template-condition detector.
 # =============================================================================
 #

--- a/scripts/scaffold-language.js
+++ b/scripts/scaffold-language.js
@@ -357,31 +357,34 @@ export const ${id}: LanguageSupport = {
   //                         Java Spring @GetMapping, C# ASP.NET [HttpGet]).
   //   deepSast            — CodeQL / Snyk Code interprocedural engine support
   //   callGraphReliability — how much to trust graphify's caller counts here
-  //   correctness         — the liveness floor (see the stub below)
+  //   correctness         — the liveness floor (REQUIRED; wired below)
 
-  // TODO(${id}): OPTIONAL correctness floor — the loop-safety liveness gate.
-  // Two PURE command builders; the runner (src/analyzers/correctness/run.ts)
-  // executes them and owns the fail-open/fail-closed + timeout policy — a pack
-  // NEVER shells out itself (CLAUDE.md Rule 6, arch-check enforced). Both return
-  // a { label, bin, args } command or null (skip). \`bin\` is resolved on PATH,
-  // or may be an absolute interpreter path the pack resolved itself. If you
-  // declare \`correctness\`, test/languages-contract.test.ts requires BOTH
-  // builders. syntaxCheck = the cheap "does it compile/parse" check every
+  // REQUIRED(${id}): correctness floor — the loop-safety liveness gate. Two PURE
+  // command builders; the runner (src/analyzers/correctness/run.ts) executes
+  // them and owns the fail-open/fail-closed + timeout policy — a pack NEVER
+  // shells out itself (CLAUDE.md Rule 6 + Rule 15, arch-check enforced). Both
+  // return a { label, bin, args } command or null (skip). \`bin\` is resolved on
+  // PATH, or may be an absolute interpreter path the pack resolved itself. The
+  // field is REQUIRED on LanguageSupport — this scaffold wires a DORMANT (both
+  // builders return null) provider so the pack compiles; fill in real commands
+  // before ship. syntaxCheck = the cheap "does it compile/parse" check every
   // language can give; affectedTests = run the tests the change reaches (native
   // impact-selection where the ecosystem supports it, else a coarser fallback
-  // with CI's full scope as the backstop). See typescript.ts / python.ts.
-  //
-  // correctness: {
-  //   syntaxCheck(ctx) {
-  //     // e.g. compile the changed files; return null when not applicable.
-  //     return null;
-  //   },
-  //   affectedTests(ctx) {
-  //     // ctx.scope === 'affected' → the changed subset (fast surface);
-  //     // 'full' (or empty ctx.changedFiles) → the whole suite (CI).
-  //     return null;
-  //   },
-  // },
+  // with CI's full scope as the backstop). See typescript.ts / python.ts, and
+  // jvm-build.ts for a shared multi-build-system provider.
+  correctness: {
+    syntaxCheck(_ctx) {
+      // TODO(${id}): compile/typecheck the change, e.g.
+      //   return { label: 'compile', bin: '${id}', args: ['build'] };
+      return null;
+    },
+    affectedTests(_ctx) {
+      // TODO(${id}): run the tests the change reaches. ctx.scope === 'affected'
+      // → the changed subset (fast surface); 'full' (or empty ctx.changedFiles)
+      // → the whole suite (CI backstop).
+      return null;
+    },
+  },
 
   // ─── LP-recipe metadata (populate every field) ─────────────────────────
 

--- a/scripts/scaffold-language.js
+++ b/scripts/scaffold-language.js
@@ -357,6 +357,31 @@ export const ${id}: LanguageSupport = {
   //                         Java Spring @GetMapping, C# ASP.NET [HttpGet]).
   //   deepSast            — CodeQL / Snyk Code interprocedural engine support
   //   callGraphReliability — how much to trust graphify's caller counts here
+  //   correctness         — the liveness floor (see the stub below)
+
+  // TODO(${id}): OPTIONAL correctness floor — the loop-safety liveness gate.
+  // Two PURE command builders; the runner (src/analyzers/correctness/run.ts)
+  // executes them and owns the fail-open/fail-closed + timeout policy — a pack
+  // NEVER shells out itself (CLAUDE.md Rule 6, arch-check enforced). Both return
+  // a { label, bin, args } command or null (skip). \`bin\` is resolved on PATH,
+  // or may be an absolute interpreter path the pack resolved itself. If you
+  // declare \`correctness\`, test/languages-contract.test.ts requires BOTH
+  // builders. syntaxCheck = the cheap "does it compile/parse" check every
+  // language can give; affectedTests = run the tests the change reaches (native
+  // impact-selection where the ecosystem supports it, else a coarser fallback
+  // with CI's full scope as the backstop). See typescript.ts / python.ts.
+  //
+  // correctness: {
+  //   syntaxCheck(ctx) {
+  //     // e.g. compile the changed files; return null when not applicable.
+  //     return null;
+  //   },
+  //   affectedTests(ctx) {
+  //     // ctx.scope === 'affected' → the changed subset (fast surface);
+  //     // 'full' (or empty ctx.changedFiles) → the whole suite (CI).
+  //     return null;
+  //   },
+  // },
 
   // ─── LP-recipe metadata (populate every field) ─────────────────────────
 

--- a/src-templates/.githooks/pre-push
+++ b/src-templates/.githooks/pre-push
@@ -51,6 +51,16 @@ else
   exit 1
 fi
 
+# Correctness floor (liveness) — does the change still compile + do the tests
+# it affects pass? This is independent of the baseline, so it runs even before
+# a baseline exists (a brand-new / greenfield repo still gets push-time
+# liveness). It is ADAPTIVE: on a repo that already runs its tests in CI it is
+# a no-op here (opt-in), and on a repo without a test-CI it runs by default.
+# A real failure blocks the push; a missing toolchain fail-opens (CI backstop).
+# Tune via .dxkit/policy.json correctness.surfaces.pre-push, DXKIT_FLOOR_PREPUSH,
+# or bypass everything with: git push --no-verify
+"${DXKIT}" floor check --surface pre-push
+
 BASELINE_NAME="${DXKIT_BASELINE_NAME:-main}"
 BASELINE_FILE=".dxkit/baselines/${BASELINE_NAME}.json"
 

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -81,6 +81,23 @@ jobs:
             echo "✓ dxkit guardrail passed — no net-new findings vs the baseline"
           fi
 
+      # Correctness floor (liveness) — full-scope: does the code compile + do
+      # the tests pass? Runs after the finding gate. ADAPTIVE: if this repo
+      # already runs its tests in its own CI workflow, this is a no-op here
+      # (opt-in). A missing language toolchain fail-opens (this workflow sets up
+      # node + the dxkit scanner tools, not every language runtime), so the
+      # floor is most meaningful on JS/TS repos and on repos with no test-CI;
+      # your own test job is the place for full-language coverage. Tune via
+      # .dxkit/policy.json correctness.surfaces.ci or DXKIT_FLOOR_CI.
+      - name: Run correctness floor
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            DXKIT=./node_modules/.bin/vyuh-dxkit
+          else
+            DXKIT=vyuh-dxkit
+          fi
+          "${DXKIT}" floor check --surface ci
+
       - name: Post PR comment
         if: always()
         env:

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -24,7 +24,12 @@ import type {
   CorrectnessScope,
 } from '../../languages/capabilities/correctness';
 
-export type CorrectnessStatus = 'pass' | 'fail' | 'skipped-unavailable' | 'skipped-none';
+export type CorrectnessStatus =
+  | 'pass'
+  | 'fail'
+  | 'skipped-unavailable'
+  | 'skipped-timeout'
+  | 'skipped-none';
 
 export interface CorrectnessCheckResult {
   readonly pack: LanguageId;
@@ -43,10 +48,15 @@ export interface CorrectnessFloorResult {
   readonly blocks: boolean;
 }
 
-/** Outcome of running one command: `available:false` → the binary isn't on PATH
- *  (fail-open skip); otherwise `code` is the exit status and `output` its tail. */
+/** Outcome of running one command:
+ *  - `available:false` → the binary isn't on PATH (fail-open skip);
+ *  - `timedOut:true`   → the command exceeded its wall-clock budget. A SLOW
+ *    suite is not a BROKEN suite, so this is fail-OPEN (skipped), never a block
+ *    — the fast surface stays fast and CI (unbounded) is the backstop;
+ *  - otherwise `code` is the exit status and `output` its tail. */
 export interface CommandOutcome {
   readonly available: boolean;
+  readonly timedOut?: boolean;
   readonly code: number;
   readonly output: string;
 }
@@ -55,28 +65,52 @@ export type CommandExec = (cmd: CorrectnessCommand, cwd: string) => CommandOutco
 
 const OUTPUT_TAIL = 4000; // cap captured output so a block message stays readable
 
-/** Default exec: resolve on PATH, run, capture combined output tail. */
-export const defaultCommandExec: CommandExec = (cmd, cwd) => {
-  if (!commandExists(cmd.bin)) return { available: false, code: -1, output: '' };
-  try {
-    const out = execFileSync(cmd.bin, [...cmd.args], {
-      cwd,
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    return { available: true, code: 0, output: tail(out) };
-  } catch (e) {
-    const err = e as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
-    const combined = `${err.stdout ?? ''}${err.stderr ?? ''}`;
-    // A non-numeric status (spawn error, signal) is treated as a failure with
-    // code 1 — the binary existed (commandExists passed) but the run broke.
-    return {
-      available: true,
-      code: typeof err.status === 'number' ? err.status : 1,
-      output: tail(combined),
-    };
-  }
-};
+/**
+ * Build a command exec bounded by an optional per-command wall-clock timeout.
+ * On timeout the child is killed and the outcome is `timedOut` (fail-open),
+ * distinct from a non-zero exit (a real failure, fail-closed). `timeoutMs`
+ * undefined/0 → no timeout (CI, where the full suite is expected to run).
+ */
+export function makeCommandExec(timeoutMs?: number): CommandExec {
+  return (cmd, cwd) => {
+    if (!commandExists(cmd.bin)) return { available: false, code: -1, output: '' };
+    try {
+      const out = execFileSync(cmd.bin, [...cmd.args], {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        ...(timeoutMs && timeoutMs > 0 ? { timeout: timeoutMs, killSignal: 'SIGTERM' } : {}),
+      });
+      return { available: true, code: 0, output: tail(out) };
+    } catch (e) {
+      const err = e as {
+        status?: number;
+        code?: string;
+        signal?: string;
+        stdout?: Buffer | string;
+        stderr?: Buffer | string;
+      };
+      const combined = `${err.stdout ?? ''}${err.stderr ?? ''}`;
+      // execFileSync sets `code: 'ETIMEDOUT'` (and signal = killSignal) when it
+      // fired the timeout kill. Treat that as a fail-OPEN skip, not a failure —
+      // the run didn't finish, so it says nothing about correctness.
+      if (err.code === 'ETIMEDOUT') {
+        return { available: true, timedOut: true, code: -1, output: tail(combined) };
+      }
+      // A non-numeric status (spawn error, non-timeout signal) is treated as a
+      // failure with code 1 — the binary existed (commandExists passed) but the
+      // run broke.
+      return {
+        available: true,
+        code: typeof err.status === 'number' ? err.status : 1,
+        output: tail(combined),
+      };
+    }
+  };
+}
+
+/** Default exec: resolve on PATH, run unbounded, capture combined output tail. */
+export const defaultCommandExec: CommandExec = makeCommandExec();
 
 function tail(s: string): string {
   const t = s.trim();
@@ -89,6 +123,10 @@ export interface CorrectnessFloorOptions {
   readonly scope: CorrectnessScope;
   /** Active language packs (from `activeLanguagesFromStack` / `-Flags`). */
   readonly packs: readonly LanguageSupport[];
+  /** Per-command wall-clock budget (ms). A command that exceeds it is a
+   *  fail-OPEN skip, never a block — the fast surface stays fast, CI is the
+   *  backstop. Undefined → no timeout. Ignored when `exec` is injected. */
+  readonly timeoutMs?: number;
   /** Injected for tests; defaults to real PATH resolution + execFileSync. */
   readonly exec?: CommandExec;
 }
@@ -100,7 +138,7 @@ export interface CorrectnessFloorOptions {
  * failed.
  */
 export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessFloorResult {
-  const exec = opts.exec ?? defaultCommandExec;
+  const exec = opts.exec ?? makeCommandExec(opts.timeoutMs);
   const ctx = { cwd: opts.cwd, changedFiles: opts.changedFiles, scope: opts.scope };
   const checks: CorrectnessCheckResult[] = [];
 
@@ -111,6 +149,12 @@ export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessF
       const outcome = exec(cmd, opts.cwd);
       if (!outcome.available) {
         checks.push({ pack: id, label: cmd.label, bin: cmd.bin, status: 'skipped-unavailable' });
+        continue;
+      }
+      if (outcome.timedOut) {
+        // Exceeded the budget — fail-OPEN. The run didn't finish, so it says
+        // nothing about correctness; CI (unbounded) is the backstop.
+        checks.push({ pack: id, label: cmd.label, bin: cmd.bin, status: 'skipped-timeout' });
         continue;
       }
       checks.push({

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -1,0 +1,137 @@
+/**
+ * The correctness-floor runner — executes each active pack's syntax + affected-
+ * test commands and folds them into one pass/fail signal.
+ *
+ * Policy, in one place so every surface behaves the same:
+ *   - fail-CLOSED on a real failure — a non-zero exit from a check that ran is a
+ *     genuine syntax error / failing test, and it BLOCKS.
+ *   - fail-OPEN on infrastructure — a missing binary (the toolchain isn't
+ *     installed here) skips the check rather than failing it. A hook must not
+ *     block a developer who simply hasn't installed a linter locally; CI, where
+ *     the toolchain is present, is the backstop.
+ *
+ * Commands come from `LanguageSupport.correctness` via the registry helper
+ * (Rule 6); this module never hardcodes a per-language command. Command
+ * execution is injected so tests exercise the policy without a real toolchain.
+ */
+
+import { execFileSync } from 'child_process';
+import { commandExists } from '../tools/runner';
+import { activeCorrectnessProviders } from '../../languages';
+import type { LanguageId, LanguageSupport } from '../../languages/types';
+import type {
+  CorrectnessCommand,
+  CorrectnessScope,
+} from '../../languages/capabilities/correctness';
+
+export type CorrectnessStatus = 'pass' | 'fail' | 'skipped-unavailable' | 'skipped-none';
+
+export interface CorrectnessCheckResult {
+  readonly pack: LanguageId;
+  readonly label: string;
+  readonly bin: string;
+  readonly status: CorrectnessStatus;
+  /** Captured output tail — present only on `fail`, for the block message. */
+  readonly output?: string;
+}
+
+export interface CorrectnessFloorResult {
+  /** True when at least one check actually executed (not all skipped). */
+  readonly ran: boolean;
+  readonly checks: readonly CorrectnessCheckResult[];
+  /** True when any check that ran failed — the floor blocks. */
+  readonly blocks: boolean;
+}
+
+/** Outcome of running one command: `available:false` → the binary isn't on PATH
+ *  (fail-open skip); otherwise `code` is the exit status and `output` its tail. */
+export interface CommandOutcome {
+  readonly available: boolean;
+  readonly code: number;
+  readonly output: string;
+}
+
+export type CommandExec = (cmd: CorrectnessCommand, cwd: string) => CommandOutcome;
+
+const OUTPUT_TAIL = 4000; // cap captured output so a block message stays readable
+
+/** Default exec: resolve on PATH, run, capture combined output tail. */
+export const defaultCommandExec: CommandExec = (cmd, cwd) => {
+  if (!commandExists(cmd.bin)) return { available: false, code: -1, output: '' };
+  try {
+    const out = execFileSync(cmd.bin, [...cmd.args], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { available: true, code: 0, output: tail(out) };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    const combined = `${err.stdout ?? ''}${err.stderr ?? ''}`;
+    // A non-numeric status (spawn error, signal) is treated as a failure with
+    // code 1 — the binary existed (commandExists passed) but the run broke.
+    return {
+      available: true,
+      code: typeof err.status === 'number' ? err.status : 1,
+      output: tail(combined),
+    };
+  }
+};
+
+function tail(s: string): string {
+  const t = s.trim();
+  return t.length > OUTPUT_TAIL ? `…${t.slice(-OUTPUT_TAIL)}` : t;
+}
+
+export interface CorrectnessFloorOptions {
+  readonly cwd: string;
+  readonly changedFiles: readonly string[];
+  readonly scope: CorrectnessScope;
+  /** Active language packs (from `activeLanguagesFromStack` / `-Flags`). */
+  readonly packs: readonly LanguageSupport[];
+  /** Injected for tests; defaults to real PATH resolution + execFileSync. */
+  readonly exec?: CommandExec;
+}
+
+/**
+ * Run the correctness floor across the active packs. Never throws — an exec
+ * error surfaces as a `fail` check (fail-closed), a missing binary as
+ * `skipped-unavailable` (fail-open). `blocks` is true iff a check that ran
+ * failed.
+ */
+export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessFloorResult {
+  const exec = opts.exec ?? defaultCommandExec;
+  const ctx = { cwd: opts.cwd, changedFiles: opts.changedFiles, scope: opts.scope };
+  const checks: CorrectnessCheckResult[] = [];
+
+  for (const { id, provider } of activeCorrectnessProviders(opts.packs)) {
+    const commands = [provider.syntaxCheck(ctx), provider.affectedTests(ctx)];
+    for (const cmd of commands) {
+      if (cmd === null) continue; // pack declined this check for this change
+      const outcome = exec(cmd, opts.cwd);
+      if (!outcome.available) {
+        checks.push({ pack: id, label: cmd.label, bin: cmd.bin, status: 'skipped-unavailable' });
+        continue;
+      }
+      checks.push({
+        pack: id,
+        label: cmd.label,
+        bin: cmd.bin,
+        status: outcome.code === 0 ? 'pass' : 'fail',
+        ...(outcome.code === 0 ? {} : { output: outcome.output }),
+      });
+    }
+  }
+
+  const ran = checks.some((c) => c.status === 'pass' || c.status === 'fail');
+  const blocks = checks.some((c) => c.status === 'fail');
+  return { ran, checks, blocks };
+}
+
+/** One-line human summary of a floor result (for the Stop-gate / hook block). */
+export function describeCorrectnessFloor(result: CorrectnessFloorResult): string {
+  const failed = result.checks.filter((c) => c.status === 'fail');
+  if (failed.length === 0) return 'correctness floor: all checks passed';
+  const which = failed.map((c) => `${c.pack} ${c.label}`).join(', ');
+  return `correctness floor: ${failed.length} check(s) failed — ${which}`;
+}

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -16,6 +16,8 @@
  */
 
 import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 import { commandExists } from '../tools/runner';
 import { activeCorrectnessProviders } from '../../languages';
 import type { LanguageId, LanguageSupport } from '../../languages/types';
@@ -23,6 +25,25 @@ import type {
   CorrectnessCommand,
   CorrectnessScope,
 } from '../../languages/capabilities/correctness';
+
+/**
+ * Is a command's `bin` runnable? A bare name is resolved on PATH (`tsc`,
+ * `cargo`, `npx`); a path-like `bin` (a pack that resolved an absolute
+ * interpreter — a project venv's `python`, a `findTool` path) is accepted when
+ * the file exists. Without the latter, a resolved-path bin would be wrongly
+ * treated as missing and the check skipped (fail-open on a tool that IS
+ * present) — so this keeps the fail-open gate honest for every pack.
+ */
+function binaryAvailable(bin: string): boolean {
+  if (bin.includes('/') || bin.includes(path.sep)) {
+    try {
+      return fs.statSync(bin).isFile();
+    } catch {
+      return false;
+    }
+  }
+  return commandExists(bin);
+}
 
 export type CorrectnessStatus =
   | 'pass'
@@ -73,7 +94,7 @@ const OUTPUT_TAIL = 4000; // cap captured output so a block message stays readab
  */
 export function makeCommandExec(timeoutMs?: number): CommandExec {
   return (cmd, cwd) => {
-    if (!commandExists(cmd.bin)) return { available: false, code: -1, output: '' };
+    if (!binaryAvailable(cmd.bin)) return { available: false, code: -1, output: '' };
     try {
       const out = execFileSync(cmd.bin, [...cmd.args], {
         cwd,

--- a/src/analyzers/correctness/surface-run.ts
+++ b/src/analyzers/correctness/surface-run.ts
@@ -1,0 +1,186 @@
+/**
+ * Run the correctness floor for a NON-loop surface (`pre-push` / `ci`).
+ *
+ * The loop Stop-gate has its own runner (`src/loop/stop-gate.ts`) because it
+ * diffs against a cheap entry snapshot to block only on NET-NEW failures. The
+ * pre-push and CI surfaces are point-in-time LIVENESS gates instead: they run
+ * the floor at the current tree and are fail-CLOSED on the surface's scope.
+ * There is no net-new diffing here (that would cost a base-ref worktree run on
+ * every push / PR); the entry-snapshot trick is the loop's alone.
+ *
+ *   - `pre-push` — AFFECTED scope, changed files computed vs the merge-base with
+ *     the integration branch. Runs on the developer's machine where the
+ *     toolchain is present, so the floor is meaningful; a per-command timeout
+ *     keeps `git push` fast. Blocks the push when the affected tests don't pass.
+ *     (It does not distinguish a pre-existing red test in a touched module from
+ *     a newly-broken one — that distinction is the loop Stop-gate's job. Bypass
+ *     with `--no-verify`.)
+ *   - `ci` — FULL scope, no timeout (the full suite is expected to run). The
+ *     backstop.
+ *
+ * Both surfaces are ADAPTIVE (`resolveCorrectnessSurface`): when the repo
+ * already runs its tests in its own CI, the floor defaults to opt-in here, so
+ * this runner returns a disabled no-op unless explicitly enabled.
+ */
+
+import { execFileSync } from 'child_process';
+
+import { detectActiveLanguages } from '../../languages';
+import type { LanguageSupport } from '../../languages/types';
+import { computeChangedFiles } from '../../baseline/changed-files';
+import {
+  runCorrectnessFloor,
+  describeCorrectnessFloor,
+  type CommandExec,
+  type CorrectnessFloorResult,
+} from './run';
+import { resolveCorrectnessSurface } from './surface';
+
+/** The surfaces this runner serves (the loop-stop surface has its own runner). */
+export type RunnableSurface = 'pre-push' | 'ci';
+
+export interface SurfaceFloorOutcome {
+  readonly surface: RunnableSurface;
+  /** Was the floor enabled on this surface (via the resolver)? */
+  readonly enabled: boolean;
+  /** Why it resolved the way it did (or why it was skipped). */
+  readonly reason: string;
+  /** Did any check actually execute (false when disabled / no pack / all skipped)? */
+  readonly ran: boolean;
+  /** Does the floor block this surface (a real failure)? Always false when not `ran`. */
+  readonly blocks: boolean;
+  /** One-line human summary for CLI / hook output. */
+  readonly summary: string;
+  readonly result?: CorrectnessFloorResult;
+}
+
+/** Best-effort git stdout for a fixed arg vector; '' on any failure. */
+function gitOut(cwd: string, args: readonly string[]): string {
+  try {
+    return execFileSync('git', [...args], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * The merge-base of HEAD against the most likely integration branch, so the
+ * pre-push floor scopes to what this branch actually introduces. Tries, in
+ * order: an explicit ref, the tracking upstream, then the common remote/local
+ * default-branch names. Returns '' when none resolve (caller then runs full).
+ */
+export function resolvePrePushBase(cwd: string, explicit?: string): string {
+  const candidates = explicit
+    ? [explicit]
+    : ['@{upstream}', 'origin/HEAD', 'origin/main', 'origin/master', 'main', 'master'];
+  for (const ref of candidates) {
+    const mb = gitOut(cwd, ['merge-base', 'HEAD', ref]);
+    if (mb) return mb;
+  }
+  return '';
+}
+
+/** Per-command wall-clock budget for the fast (pre-push) surface. Env-tunable;
+ *  CI runs unbounded (the full suite is expected to run to completion). */
+function prePushTimeoutMs(): number {
+  const raw = process.env.DXKIT_FLOOR_TIMEOUT_MS;
+  const n = raw ? Number(raw) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : 120_000;
+}
+
+export interface RunFloorForSurfaceOptions {
+  readonly surface: RunnableSurface;
+  readonly cwd: string;
+  /** Explicit base ref for pre-push affected scoping (else auto-resolved). */
+  readonly base?: string;
+  /** Explicit `--correctness` / `--no-correctness` override (highest precedence). */
+  readonly flag?: boolean;
+  /** Injected for tests; defaults to the real PATH-resolving exec. */
+  readonly exec?: CommandExec;
+  /** Injected for tests; defaults to the active packs detected at `cwd`. */
+  readonly packs?: readonly LanguageSupport[];
+  /** Injected for tests; defaults to the real adaptive resolver. */
+  readonly resolveEnabled?: (
+    surface: RunnableSurface,
+    cwd: string,
+  ) => { enabled: boolean; reason: string };
+}
+
+/**
+ * Resolve enablement + scope for a surface and run the floor. Never throws — a
+ * disabled surface, an absent pack, or an all-skipped run all return
+ * `blocks: false` (the caller exits 0); only a real check failure blocks.
+ */
+export function runFloorForSurface(opts: RunFloorForSurfaceOptions): SurfaceFloorOutcome {
+  const { surface, cwd } = opts;
+  const res = opts.resolveEnabled
+    ? opts.resolveEnabled(surface, cwd)
+    : resolveCorrectnessSurface({ surface, cwd, flag: opts.flag });
+  if (!res.enabled) {
+    return {
+      surface,
+      enabled: false,
+      reason: res.reason,
+      ran: false,
+      blocks: false,
+      summary: `correctness floor (${surface}): disabled — ${res.reason}`,
+    };
+  }
+
+  const packs = (opts.packs ?? detectActiveLanguages(cwd)).filter((p) => p.correctness);
+  if (packs.length === 0) {
+    return {
+      surface,
+      enabled: true,
+      reason: res.reason,
+      ran: false,
+      blocks: false,
+      summary: `correctness floor (${surface}): no active language pack provides a floor`,
+    };
+  }
+
+  let scope: 'affected' | 'full' = 'full';
+  let changedFiles: readonly string[] = [];
+  let timeoutMs: number | undefined;
+  if (surface === 'pre-push') {
+    scope = 'affected';
+    const base = resolvePrePushBase(cwd, opts.base);
+    // Empty changedFiles (base unresolved / diff undeterminable) → the packs
+    // treat the scope as full, per the CorrectnessContext contract.
+    changedFiles = base ? (computeChangedFiles(cwd, base) ?? []) : [];
+    timeoutMs = prePushTimeoutMs();
+  }
+  // ci: full scope, no timeout — the full suite runs to completion.
+
+  const result = runCorrectnessFloor({
+    cwd,
+    changedFiles,
+    scope,
+    packs,
+    timeoutMs,
+    exec: opts.exec,
+  });
+  if (!result.ran) {
+    return {
+      surface,
+      enabled: true,
+      reason: res.reason,
+      ran: false,
+      blocks: false,
+      summary: `correctness floor (${surface}): all checks skipped (toolchain not present) — CI is the backstop`,
+    };
+  }
+  return {
+    surface,
+    enabled: true,
+    reason: res.reason,
+    ran: true,
+    blocks: result.blocks,
+    summary: describeCorrectnessFloor(result),
+    result,
+  };
+}

--- a/src/analyzers/correctness/surface.ts
+++ b/src/analyzers/correctness/surface.ts
@@ -1,0 +1,298 @@
+/**
+ * The correctness-floor SURFACE resolver — decides, per surface, whether the
+ * floor runs by default. This is the canonical resolver for the correctness
+ * capability (mirror of `resolveBaselineMode` for baseline modes, Rule 11): one
+ * function, one precedence order, so no two call sites drift on the default.
+ *
+ * Three surfaces run the floor, with different postures:
+ *   - `loop-stop`  — an autonomous loop's Stop-gate. ALWAYS default-on: an agent
+ *     must never declare "done" on code that does not compile or whose tests
+ *     fail. (An explicit flag/policy can still turn it off, but the default is
+ *     on regardless of what CI the repo has.)
+ *   - `pre-push` / `ci` — ADAPTIVE. If the repo already runs its tests in its own
+ *     CI, dxkit's floor is redundant there, so it defaults to OPT-IN. If no
+ *     test-running CI is detected, the floor defaults ON so pushes/PRs are still
+ *     checked. When we cannot tell (a CI exists but its test step is opaque), we
+ *     FAIL TOWARD ON — a redundant floor run is cheap; a missed regression is not.
+ *
+ * Precedence (highest first), mirroring the loop-preset + baseline-mode
+ * resolvers:
+ *   1. explicit `flag` argument (a `--correctness` / `--no-correctness` CLI flag)
+ *   2. `DXKIT_FLOOR_<SURFACE>` env var (benchmark / CI override)
+ *   3. `.dxkit/policy.json` → `correctness.surfaces.<surface>`
+ *   4. the surface's default (always-on for loop-stop; adaptive for pre-push/ci)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { DEFAULT_POLICY_FILENAME } from '../../baseline/policy';
+
+export type CorrectnessSurface = 'loop-stop' | 'pre-push' | 'ci';
+
+export type SurfaceDecisionSource =
+  | 'always-on' // loop-stop default
+  | 'flag' // explicit CLI flag
+  | 'env' // DXKIT_FLOOR_<SURFACE>
+  | 'policy' // .dxkit/policy.json correctness.surfaces.<surface>
+  | 'adaptive-no-test-ci' // no test-running CI → dxkit provides the net
+  | 'adaptive-test-ci-detected' // repo already tests in CI → opt-in (off)
+  | 'adaptive-uncertain'; // CI exists but test step opaque → fail toward on
+
+export interface SurfaceResolution {
+  readonly surface: CorrectnessSurface;
+  readonly enabled: boolean;
+  readonly source: SurfaceDecisionSource;
+  /** One-line human-readable rationale, for `doctor` / CLI output. */
+  readonly reason: string;
+}
+
+export type TestCiStatus = 'has-test-ci' | 'no-test-ci' | 'uncertain';
+
+export interface TestCiDetection {
+  readonly status: TestCiStatus;
+  /** When `has-test-ci`, the file + command that proved it (for the reason). */
+  readonly evidence?: string;
+}
+
+// ─── Test-CI detection ──────────────────────────────────────────────────────
+
+/** CI config files we can read as text and scan for a test invocation. Ordered
+ *  by ubiquity; GitHub Actions workflows are handled separately (a directory). */
+const FLAT_CI_FILES = [
+  '.gitlab-ci.yml',
+  '.gitlab-ci.yaml',
+  'Jenkinsfile',
+  '.circleci/config.yml',
+  'azure-pipelines.yml',
+  'azure-pipelines.yaml',
+  '.travis.yml',
+  'bitbucket-pipelines.yml',
+];
+
+/** Substrings that mark a real test invocation, unioned across ecosystems. Kept
+ *  deliberately specific (a bare "test" would match too much) so a match is a
+ *  confident "this CI runs tests" signal. */
+const TEST_COMMAND_PATTERNS: readonly RegExp[] = [
+  /\bnpm (run )?test\b/,
+  /\byarn (run )?test\b/,
+  /\bpnpm (run )?test\b/,
+  /\bnpx (vitest|jest|mocha|ava|playwright)\b/,
+  /\b(vitest|jest|mocha|ava)\b/,
+  /\bpytest\b/,
+  /\bpython -m (pytest|unittest)\b/,
+  /\b(tox|nox)\b/,
+  /\bgo test\b/,
+  /\bcargo (test|nextest)\b/,
+  /\bmvn (.*\s)?(test|verify)\b/,
+  /\b(\.\/)?gradlew? (.*\s)?(test|check)\b/,
+  /\bdotnet test\b/,
+  /\b(bundle exec )?rspec\b/,
+  /\brake (.*\s)?test\b/,
+  /\bmake (.*\s)?test\b/,
+  /\bjust (.*\s)?test\b/,
+];
+
+/** Is a workflow file one dxkit itself installed? Its own guardrail/floor CI is
+ *  the surface being resolved, not a pre-existing test-CI, so it must not count
+ *  as the repo "already testing in CI". */
+function isDxkitAuthoredWorkflow(name: string): boolean {
+  return name.startsWith('dxkit-');
+}
+
+function textRunsTests(text: string): boolean {
+  return TEST_COMMAND_PATTERNS.some((re) => re.test(text));
+}
+
+function matchedTestCommand(text: string): string | undefined {
+  for (const re of TEST_COMMAND_PATTERNS) {
+    const m = re.exec(text);
+    if (m) return m[0];
+  }
+  return undefined;
+}
+
+/**
+ * Detect whether the repo runs its tests in its OWN CI. Reads GitHub Actions
+ * workflows (excluding dxkit-authored ones) plus the common flat CI configs,
+ * scanning for a test invocation:
+ *   - a matching test command in any file → `has-test-ci`;
+ *   - no CI config found at all → `no-test-ci` (dxkit's floor should default on);
+ *   - CI config exists but no test command matched (opaque `make ci`, a called
+ *     reusable workflow, etc.) → `uncertain` (fail toward on).
+ * Best-effort and never throws — an unreadable file is skipped.
+ */
+export function detectTestCi(cwd: string): TestCiDetection {
+  let sawAnyCi = false;
+
+  // GitHub Actions workflows (a directory of yml/yaml files).
+  const wfDir = path.join(cwd, '.github', 'workflows');
+  let wfNames: string[] = [];
+  try {
+    wfNames = fs
+      .readdirSync(wfDir)
+      .filter((n) => (n.endsWith('.yml') || n.endsWith('.yaml')) && !isDxkitAuthoredWorkflow(n));
+  } catch {
+    /* no workflows dir */
+  }
+  for (const name of wfNames) {
+    sawAnyCi = true;
+    let text: string;
+    try {
+      text = fs.readFileSync(path.join(wfDir, name), 'utf8');
+    } catch {
+      continue;
+    }
+    if (textRunsTests(text)) {
+      return {
+        status: 'has-test-ci',
+        evidence: `.github/workflows/${name}: ${matchedTestCommand(text)}`,
+      };
+    }
+  }
+
+  // Flat CI config files.
+  for (const rel of FLAT_CI_FILES) {
+    let text: string;
+    try {
+      text = fs.readFileSync(path.join(cwd, rel), 'utf8');
+    } catch {
+      continue;
+    }
+    sawAnyCi = true;
+    if (textRunsTests(text)) {
+      return { status: 'has-test-ci', evidence: `${rel}: ${matchedTestCommand(text)}` };
+    }
+  }
+
+  return sawAnyCi ? { status: 'uncertain' } : { status: 'no-test-ci' };
+}
+
+// ─── Policy + env reads ─────────────────────────────────────────────────────
+
+/** Read `correctness.surfaces.<surface>` from `.dxkit/policy.json`. Best-effort:
+ *  a missing / malformed file or absent block yields an empty map. */
+export function readSurfacePolicy(cwd: string): Partial<Record<CorrectnessSurface, boolean>> {
+  try {
+    const raw = fs.readFileSync(path.join(cwd, DEFAULT_POLICY_FILENAME), 'utf8');
+    const parsed = JSON.parse(raw) as {
+      correctness?: { surfaces?: Partial<Record<CorrectnessSurface, unknown>> };
+    };
+    const surfaces = parsed.correctness?.surfaces;
+    if (!surfaces || typeof surfaces !== 'object') return {};
+    const out: Partial<Record<CorrectnessSurface, boolean>> = {};
+    for (const s of ['loop-stop', 'pre-push', 'ci'] as const) {
+      if (typeof surfaces[s] === 'boolean') out[s] = surfaces[s];
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+const ENV_VAR: Record<CorrectnessSurface, string> = {
+  'loop-stop': 'DXKIT_FLOOR_LOOP',
+  'pre-push': 'DXKIT_FLOOR_PREPUSH',
+  ci: 'DXKIT_FLOOR_CI',
+};
+
+/** Parse a truthy/falsy env override, or undefined when unset/unrecognized. */
+function envOverride(surface: CorrectnessSurface): boolean | undefined {
+  const raw = process.env[ENV_VAR[surface]];
+  if (raw === undefined) return undefined;
+  const v = raw.trim().toLowerCase();
+  if (['1', 'true', 'on', 'yes'].includes(v)) return true;
+  if (['0', 'false', 'off', 'no'].includes(v)) return false;
+  return undefined;
+}
+
+// ─── The resolver ───────────────────────────────────────────────────────────
+
+export interface ResolveSurfaceOptions {
+  readonly surface: CorrectnessSurface;
+  readonly cwd: string;
+  /** Explicit `--correctness` / `--no-correctness` CLI flag (highest precedence). */
+  readonly flag?: boolean;
+  /** Injected for tests; defaults to reading `.dxkit/policy.json`. */
+  readonly policySurfaces?: Partial<Record<CorrectnessSurface, boolean>>;
+  /** Injected for tests; defaults to the real `detectTestCi`. */
+  readonly detect?: (cwd: string) => TestCiDetection;
+}
+
+/**
+ * Resolve whether the correctness floor is enabled on a surface. Pure aside from
+ * the default policy/env reads (both injectable); never throws.
+ */
+export function resolveCorrectnessSurface(opts: ResolveSurfaceOptions): SurfaceResolution {
+  const { surface } = opts;
+
+  // 1. explicit CLI flag
+  if (opts.flag !== undefined) {
+    return {
+      surface,
+      enabled: opts.flag,
+      source: 'flag',
+      reason: `explicitly ${opts.flag ? 'enabled' : 'disabled'} via flag`,
+    };
+  }
+
+  // 2. env override
+  const env = envOverride(surface);
+  if (env !== undefined) {
+    return {
+      surface,
+      enabled: env,
+      source: 'env',
+      reason: `${env ? 'enabled' : 'disabled'} via ${ENV_VAR[surface]}`,
+    };
+  }
+
+  // 3. policy file
+  const policy = opts.policySurfaces ?? readSurfacePolicy(opts.cwd);
+  const pol = policy[surface];
+  if (pol !== undefined) {
+    return {
+      surface,
+      enabled: pol,
+      source: 'policy',
+      reason: `${pol ? 'enabled' : 'disabled'} via .dxkit/policy.json correctness.surfaces.${surface}`,
+    };
+  }
+
+  // 4. surface default
+  if (surface === 'loop-stop') {
+    return {
+      surface,
+      enabled: true,
+      source: 'always-on',
+      reason: 'loop Stop-gate runs the floor by default — an agent must not stop on broken code',
+    };
+  }
+
+  // pre-push / ci: adaptive on the repo's own test-CI
+  const det = (opts.detect ?? detectTestCi)(opts.cwd);
+  if (det.status === 'has-test-ci') {
+    return {
+      surface,
+      enabled: false,
+      source: 'adaptive-test-ci-detected',
+      reason: `opt-in — the repo already runs tests in CI (${det.evidence}); enable explicitly to also run dxkit's floor here`,
+    };
+  }
+  if (det.status === 'no-test-ci') {
+    return {
+      surface,
+      enabled: true,
+      source: 'adaptive-no-test-ci',
+      reason:
+        'no test-running CI detected — the floor runs by default so changes are still checked',
+    };
+  }
+  return {
+    surface,
+    enabled: true,
+    source: 'adaptive-uncertain',
+    reason:
+      'a CI exists but its test step is opaque — running the floor to be safe (fail toward on)',
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2105,8 +2105,12 @@ export async function run(argv: string[]): Promise<void> {
         );
         process.exit(1);
       }
-      if (!values.json) logger.header('vyuh-dxkit guardrail check');
-      if (!values.json) logger.info(`Checking ${targetPath} against baseline...`);
+      // Suppress the console header/info in --json AND --markdown: both are
+      // machine-captured (piped to a file / a PR comment), so the ANSI-styled
+      // console chrome would leak into the report.
+      const quiet = !!values.json || !!values.markdown;
+      if (!quiet) logger.header('vyuh-dxkit guardrail check');
+      if (!quiet) logger.info(`Checking ${targetPath} against baseline...`);
       const startTime = Date.now();
       try {
         const result = await runGuardrailCheck({
@@ -2121,7 +2125,7 @@ export async function run(argv: string[]): Promise<void> {
           cliMode: cliMode ?? undefined,
           cliRef: values.ref as string | undefined,
         });
-        if (!values.json) logger.info(`Baseline ${result.mode.explanation}`);
+        if (!quiet) logger.info(`Baseline ${result.mode.explanation}`);
         const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
         if (values.json) {
           await emitJson(renderJson(result));
@@ -2362,7 +2366,7 @@ export async function run(argv: string[]): Promise<void> {
         // on the current (pristine) tree — so later Stops block only on
         // NET-NEW failures. Run at loop activation, before the agent changes
         // anything, or the recorded set won't be genuinely pre-existing.
-        const { captureFloorSnapshot } = await import('./loop/stop-gate');
+        const { captureFloorSnapshot } = await import('./loop/floor-gate');
         const { describeCorrectnessFloor } = await import('./analyzers/correctness/run');
         const result = captureFloorSnapshot(cwd);
         if (result === null) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2306,9 +2306,31 @@ export async function run(argv: string[]): Promise<void> {
         await runLoopDoctor(cwd, { json: !!values.json });
         break;
       }
+      if (sub === 'snapshot') {
+        // Capture the correctness-floor entry snapshot — the already-broken set
+        // on the current (pristine) tree — so later Stops block only on
+        // NET-NEW failures. Run at loop activation, before the agent changes
+        // anything, or the recorded set won't be genuinely pre-existing.
+        const { captureFloorSnapshot } = await import('./loop/stop-gate');
+        const { describeCorrectnessFloor } = await import('./analyzers/correctness/run');
+        const result = captureFloorSnapshot(cwd);
+        if (result === null) {
+          logger.info(
+            'No active language pack provides a correctness floor — nothing to snapshot.',
+          );
+          break;
+        }
+        const failing = result.checks.filter((c) => c.status === 'fail').length;
+        logger.success(
+          `Captured correctness-floor entry snapshot (${result.checks.length} check(s), ` +
+            `${failing} already failing). ${describeCorrectnessFloor(result)}`,
+        );
+        break;
+      }
       logger.fail(
         `Unknown loop subcommand: ${sub ?? '(missing)'}. ` +
-          `Available: vyuh-dxkit loop ledger [show | summarize | clear], vyuh-dxkit loop doctor`,
+          `Available: vyuh-dxkit loop ledger [show | summarize | clear], ` +
+          `vyuh-dxkit loop doctor, vyuh-dxkit loop snapshot`,
       );
       process.exit(1);
       break;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -375,6 +375,9 @@ export async function run(argv: string[]): Promise<void> {
       'added-by': { type: 'string' },
       mode: { type: 'string' },
       ref: { type: 'string' },
+      surface: { type: 'string' },
+      correctness: { type: 'boolean' },
+      'no-correctness': { type: 'boolean' },
       'soon-days': { type: 'string' },
       'against-baseline': { type: 'boolean', default: false },
       'baseline-name': { type: 'string' },
@@ -2133,6 +2136,54 @@ export async function run(argv: string[]): Promise<void> {
         logger.fail((err as Error).message);
         process.exit(1);
       }
+      break;
+    }
+
+    case 'floor': {
+      const subCommand = positionals[1];
+      if (subCommand !== 'check') {
+        logger.fail(
+          `Unknown floor subcommand: ${subCommand ?? '(missing)'}. ` +
+            `Available: vyuh-dxkit floor check [path] [--surface pre-push|ci] [--base <ref>] ` +
+            `[--correctness | --no-correctness] [--json]`,
+        );
+        process.exit(1);
+      }
+      const targetPath = resolveRepoPath(positionals[2]);
+      const surfaceRaw = (values.surface as string | undefined) ?? 'pre-push';
+      if (surfaceRaw !== 'pre-push' && surfaceRaw !== 'ci') {
+        logger.fail(`Unknown --surface value: ${surfaceRaw}. Expected one of: pre-push, ci.`);
+        process.exit(1);
+      }
+      // --correctness / --no-correctness → the explicit enable/disable override.
+      const flag = values.correctness ? true : values['no-correctness'] ? false : undefined;
+      const { runFloorForSurface } = await import('./analyzers/correctness/surface-run');
+      const outcome = runFloorForSurface({
+        surface: surfaceRaw,
+        cwd: targetPath,
+        base: values.base as string | undefined,
+        flag,
+      });
+      if (values.json) {
+        await emitJson({
+          surface: outcome.surface,
+          enabled: outcome.enabled,
+          ran: outcome.ran,
+          blocks: outcome.blocks,
+          reason: outcome.reason,
+          checks: outcome.result?.checks ?? [],
+        });
+      } else {
+        if (outcome.blocks) {
+          logger.fail(outcome.summary);
+          for (const c of outcome.result?.checks.filter((c) => c.status === 'fail') ?? []) {
+            if (c.output) process.stdout.write(`\n[${c.pack} ${c.label}]\n${c.output}\n`);
+          }
+        } else {
+          logger.success(outcome.summary);
+        }
+      }
+      process.exit(outcome.blocks ? 1 : 0);
       break;
     }
 

--- a/src/languages/capabilities/correctness.ts
+++ b/src/languages/capabilities/correctness.ts
@@ -1,0 +1,57 @@
+/**
+ * The correctness-floor capability — a language pack's answer to "does this
+ * change still COMPILE, and do the tests it affects still PASS?".
+ *
+ * This is deliberately separate from the finding capabilities (security,
+ * coverage, dep-vulns). Those ask "is this code GOOD"; the correctness floor
+ * asks "is this code VALID" — a prior, load-bearing question for an autonomous
+ * loop, which can otherwise satisfy the finding gate while shipping code that
+ * does not build or whose tests fail. A failing floor is a pass/fail signal, not
+ * a fingerprinted, grandfathered finding (there is no "grandfather a syntax
+ * error").
+ *
+ * Each pack declares two checks. Both return a command to run, or `null` to skip
+ * (tool not applicable, or no relevant change on the fast surface). The runner
+ * (`src/analyzers/correctness/`) executes them; it never hardcodes a per-language
+ * command (Rule 6).
+ */
+
+/** The scope the floor is running at — a fast surface (hook / Stop-gate) runs
+ *  the affected subset; CI runs the full suite. Packs whose ecosystem has no
+ *  impact-based test selection fall back to a coarser command for `affected`. */
+export type CorrectnessScope = 'affected' | 'full';
+
+export interface CorrectnessContext {
+  readonly cwd: string;
+  /** Repo-relative changed files (from `computeChangedFiles`). Empty when the
+   *  caller could not determine the diff — a pack should then treat the scope as
+   *  `full` rather than skip. */
+  readonly changedFiles: readonly string[];
+  readonly scope: CorrectnessScope;
+}
+
+/** A command a correctness check runs. `bin` is resolved on PATH by the runner;
+ *  a missing binary is fail-OPEN (the check is skipped, not failed). */
+export interface CorrectnessCommand {
+  /** Short label for output, e.g. `typecheck` / `affected-tests`. */
+  readonly label: string;
+  readonly bin: string;
+  readonly args: readonly string[];
+}
+
+/**
+ * A pack's correctness-floor provider. Both methods are pure command builders —
+ * they inspect the repo + changed files and return the command to run (or
+ * `null` to skip). Execution + PATH resolution + fail-open/closed policy live in
+ * the runner, so a pack never shells out itself.
+ */
+export interface CorrectnessProvider {
+  /** Compile / typecheck the change. The uniform, cheap floor every pack can
+   *  provide — catches the most common agent failure (non-compiling code). */
+  syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null;
+  /** Run the tests the change affects. Native impact-selection where the
+   *  ecosystem supports it; a coarser (module / full) fallback otherwise, with
+   *  CI's `full` scope as the backstop. Returns `null` when nothing relevant
+   *  changed, or when the pack has no test command at all. */
+  affectedTests(ctx: CorrectnessContext): CorrectnessCommand | null;
+}

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -22,6 +22,11 @@ import type {
   RunTestsOutcome,
 } from './capabilities/provider';
 import type {
+  CorrectnessCommand,
+  CorrectnessContext,
+  CorrectnessProvider,
+} from './capabilities/correctness';
+import type {
   CoverageResult,
   DepVulnFinding,
   DepVulnGatherOutcome,
@@ -1377,6 +1382,88 @@ const csharpLicensesProvider: LicensesProvider = {
   },
 };
 
+/** Does cwd have a build target `dotnet` can auto-discover (a `.sln`, or a
+ *  `.csproj` at the root)? Without one, `dotnet build`/`test` with no argument
+ *  can't tell what to build, so the floor skips rather than erroring. */
+function csharpHasBuildTarget(cwd: string): boolean {
+  try {
+    return fs.readdirSync(cwd).some((f) => f.endsWith('.sln') || f.endsWith('.csproj'));
+  } catch {
+    return false;
+  }
+}
+
+/** The nearest ancestor `.csproj` owning a changed file (repo-relative), or
+ *  null. C#'s affected unit is the project. */
+function csharpNearestProject(cwd: string, relFile: string): string | null {
+  let dir = path.dirname(relFile).replace(/\\/g, '/');
+  for (;;) {
+    try {
+      const entry = fs.readdirSync(path.join(cwd, dir)).find((f) => f.endsWith('.csproj'));
+      if (entry) return (dir === '.' ? entry : `${dir}/${entry}`).replace(/\\/g, '/');
+    } catch {
+      /* dir unreadable — keep walking up */
+    }
+    if (dir === '.' || dir === '') break;
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+/** Is a `.csproj` a test project? Every .NET test project references
+ *  `Microsoft.NET.Test.Sdk`; also accept an explicit `<IsTestProject>` or a
+ *  known test framework, so `dotnet test <proj>` won't be aimed at a
+ *  non-test project (which would error "no tests"). */
+function csharpIsTestProject(cwd: string, relProj: string): boolean {
+  try {
+    const raw = fs.readFileSync(path.join(cwd, relProj), 'utf-8');
+    return /Microsoft\.NET\.Test\.Sdk|<IsTestProject>\s*true|\b(xunit|nunit|MSTest)\b/i.test(raw);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The C# correctness floor.
+ *
+ * syntaxCheck: `dotnet build` — compiles the solution/project `dotnet`
+ * auto-discovers in cwd, reporting compile errors. Incremental via MSBuild's
+ * cache; a cold build is bounded by the runner's timeout (fail-open → CI).
+ *
+ * affectedTests: `dotnet test`. C#'s affected unit is the PROJECT. When the
+ * changed `.cs` files all belong to a SINGLE test project it narrows to
+ * `dotnet test <that.csproj>`; otherwise (a source project changed, or several
+ * projects) it runs the whole solution — `dotnet test` takes one target, so it
+ * can't union several projects, and a source change's dependent test project
+ * isn't cheaply resolvable. A change touching no `.cs` on the fast surface skips.
+ */
+const csharpCorrectnessProvider: CorrectnessProvider = {
+  syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
+    if (!csharpHasBuildTarget(ctx.cwd)) return null;
+    return { label: 'build', bin: 'dotnet', args: ['build', '--nologo'] };
+  },
+
+  affectedTests(ctx: CorrectnessContext): CorrectnessCommand | null {
+    if (!csharpHasBuildTarget(ctx.cwd)) return null;
+    const undeterminable = ctx.changedFiles.length === 0;
+    const changedCs = ctx.changedFiles.filter((f) => f.endsWith('.cs'));
+    if (ctx.scope === 'affected' && !undeterminable) {
+      if (changedCs.length === 0) return null; // no .cs change
+      const projs = new Set(
+        changedCs.map((f) => csharpNearestProject(ctx.cwd, f)).filter((p): p is string => !!p),
+      );
+      if (projs.size === 1) {
+        const [proj] = [...projs];
+        if (csharpIsTestProject(ctx.cwd, proj)) {
+          return { label: 'affected-tests', bin: 'dotnet', args: ['test', proj] };
+        }
+      }
+      // else fall through to the whole solution (safe default)
+    }
+    return { label: 'affected-tests', bin: 'dotnet', args: ['test'] };
+  },
+};
+
 export const csharp: LanguageSupport = {
   id: 'csharp',
   displayName: 'C#',
@@ -1523,6 +1610,8 @@ export const csharp: LanguageSupport = {
   semgrepRulesets: [],
   // CodeQL `csharp` extractor needs a build; Snyk Code supports C#.
   deepSast: { codeqlLanguage: 'csharp', codeqlBuildRequired: true, snykCode: true },
+
+  correctness: csharpCorrectnessProvider,
 
   capabilities: {
     depVulns: csharpDepVulnsProvider,

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -20,6 +20,11 @@ import type {
   RunTestsOutcome,
 } from './capabilities/provider';
 import type {
+  CorrectnessCommand,
+  CorrectnessContext,
+  CorrectnessProvider,
+} from './capabilities/correctness';
+import type {
   CoverageResult,
   DepVulnFinding,
   DepVulnGatherOutcome,
@@ -879,6 +884,55 @@ const goLicensesProvider: LicensesProvider = {
   },
 };
 
+/** The distinct package directories of the changed `.go` files, as Go import
+ *  spec paths (`./pkg`, or `.` for a root-level file). Go's affected unit is
+ *  the package, so tests run per changed package directory. */
+function goChangedPackages(changedFiles: readonly string[]): string[] {
+  const dirs = new Set<string>();
+  for (const f of changedFiles) {
+    if (!f.endsWith('.go')) continue;
+    const dir = path.dirname(f).replace(/\\/g, '/');
+    dirs.add(dir === '.' ? '.' : `./${dir}`);
+  }
+  return [...dirs];
+}
+
+/**
+ * The Go correctness floor.
+ *
+ * syntaxCheck: `go build ./...` — the Go compiler IS the "does it compile / does
+ * it typecheck" check, and it is incremental (unchanged packages are cached),
+ * so building the whole module is both the honest answer and cheap on a warm
+ * cache. A cold build on a large module is bounded by the runner's timeout
+ * (fail-open → CI backstop).
+ *
+ * affectedTests: `go test`. Go's native affected unit is the PACKAGE, so on the
+ * fast surface we test the changed packages' directories; the whole module at
+ * full scope. `go test ./pkg` with no test files in that package is a pass (Go
+ * prints "no test files" and exits 0), so a source-only package change never
+ * false-blocks. (Package-level rung — Go has no per-test impact selection; a
+ * change to a package whose DEPENDENTS have tests is caught at full/CI scope.)
+ */
+const goCorrectnessProvider: CorrectnessProvider = {
+  syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
+    if (!fileExists(ctx.cwd, 'go.mod')) return null; // not a module
+    // No `commandExists('go')` gate here — the runner fail-opens on a missing
+    // `go` binary (skipped-unavailable), so the pack only decides applicability.
+    return { label: 'build', bin: 'go', args: ['build', './...'] };
+  },
+
+  affectedTests(ctx: CorrectnessContext): CorrectnessCommand | null {
+    if (!fileExists(ctx.cwd, 'go.mod')) return null;
+    const undeterminable = ctx.changedFiles.length === 0;
+    if (ctx.scope === 'affected' && !undeterminable) {
+      const pkgs = goChangedPackages(ctx.changedFiles);
+      if (pkgs.length === 0) return null; // no changed .go → nothing to test
+      return { label: 'affected-tests', bin: 'go', args: ['test', ...pkgs] };
+    }
+    return { label: 'affected-tests', bin: 'go', args: ['test', './...'] };
+  },
+};
+
 export const go: LanguageSupport = {
   id: 'go',
   displayName: 'Go',
@@ -940,6 +994,8 @@ export const go: LanguageSupport = {
   semgrepRulesets: ['p/gosec'],
   // CodeQL `go` extractor needs a build (autobuild); Snyk Code supports Go.
   deepSast: { codeqlLanguage: 'go', codeqlBuildRequired: true, snykCode: true },
+
+  correctness: goCorrectnessProvider,
 
   capabilities: {
     depVulns: goDepVulnsProvider,

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -6,6 +6,7 @@ import type {
   LanguageId,
   LanguageSupport,
 } from './types';
+import type { CorrectnessProvider } from './capabilities/correctness';
 import { csharp } from './csharp';
 import { go } from './go';
 import { python } from './python';
@@ -411,6 +412,20 @@ export function allHttpFlow(flags: DetectedStack['languages']): HttpFlowSupport[
  * changed-files flow-surface trigger. Pack-driven (Rule 6): a new flow pack
  * auto-extends the set.
  */
+/**
+ * Active packs that declare a correctness-floor provider, with their id. The
+ * correctness runner (`src/analyzers/correctness/`) iterates this union to build
+ * each pack's syntax + affected-test commands — never a per-language branch
+ * (Rule 6). A pack without a wired toolchain simply doesn't appear.
+ */
+export function activeCorrectnessProviders(
+  packs: readonly LanguageSupport[],
+): { id: LanguageId; provider: CorrectnessProvider }[] {
+  return packs
+    .filter((p) => p.correctness !== undefined)
+    .map((p) => ({ id: p.id, provider: p.correctness as CorrectnessProvider }));
+}
+
 export function allFlowSourceExtensions(packs: readonly LanguageSupport[]): string[] {
   const exts = new Set<string>();
   for (const pack of packs) {

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -8,6 +8,7 @@ import { gatherOsvScannerDepVulnsResult } from '../analyzers/tools/osv-scanner-d
 import { fileExists, run } from '../analyzers/tools/runner';
 import { runTestsWithCoverage } from '../analyzers/tools/run-tests-helper';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
+import { isAndroidGradleBuild, jvmCorrectnessProvider } from './jvm-build';
 import type {
   CapabilityProvider,
   DepVulnsProvider,
@@ -416,6 +417,18 @@ const javaDepVulnsProvider: DepVulnsProvider = {
   },
 };
 
+// ─── Correctness floor (Maven/Gradle compile + module-affected tests) ──────
+//
+// Shared with the kotlin pack via `jvmCorrectnessProvider` (CLAUDE.md Rule 2) —
+// both run on Maven/Gradle with the module as the affected unit. Java's only
+// contribution is its source extension. An Android Gradle build declines (its
+// variant-specific test tasks aren't the standard `test`/`testClasses`).
+
+const javaCorrectnessProvider = jvmCorrectnessProvider({
+  sourceExtensions: ['.java'],
+  declineWhen: isAndroidGradleBuild,
+});
+
 // ─── Pack export ────────────────────────────────────────────────────────────
 
 export const java: LanguageSupport = {
@@ -494,6 +507,8 @@ export const java: LanguageSupport = {
   semgrepRulesets: ['p/java'],
   // CodeQL `java` extractor needs a build; Snyk Code supports Java.
   deepSast: { codeqlLanguage: 'java', codeqlBuildRequired: true, snykCode: true },
+
+  correctness: javaCorrectnessProvider,
 
   capabilities: {
     imports: javaImportsProvider,

--- a/src/languages/jvm-build.ts
+++ b/src/languages/jvm-build.ts
@@ -1,0 +1,242 @@
+/**
+ * Shared JVM build-tool glue for the correctness floor (CLAUDE.md Rule 2 — one
+ * gather/command-builder, consumed by every pack that needs it). Both the Java
+ * and Kotlin packs run on the same two build systems (Maven, Gradle) with the
+ * same multi-module affected unit — the MODULE — so the compile + affected-test
+ * command construction lives here once and is parameterized only by which source
+ * extensions count as a "relevant change".
+ *
+ * The floor's two commands:
+ *   - syntaxCheck: compile the whole reactor/build (main + test sources). Cheap,
+ *     incremental via the build tool's cache, bounded by the runner's timeout
+ *     (fail-open → CI backstop). Not narrowed — compile is fast and a partial
+ *     compile can miss a cross-module break.
+ *   - affectedTests: run the changed MODULES' tests. Maven narrows via
+ *     `-pl <modules> -am`; Gradle via `:<project>:test`. A single-module project
+ *     (no sub-manifests) runs the whole build — that IS its affected surface, the
+ *     same way Rust's single-crate `cargo test` is. A build-file change anywhere,
+ *     or a source file that can't be attributed to a sub-module, falls back to
+ *     the whole build (never silently under-tests). Cross-module DEPENDENTS of a
+ *     change are caught at full/CI scope, not the affected surface — the same
+ *     package/module-level rung as Go and C#.
+ *
+ * The wrapper (`gradlew`) is emitted as an ABSOLUTE path, not `./gradlew`: the
+ * runner's availability check stats the bin against the process cwd while
+ * execution uses the command cwd, so a relative wrapper path would be checked in
+ * the wrong directory. An absolute path is the resolved-path form the runner
+ * explicitly supports (venv python, findTool paths).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { fileExists } from '../analyzers/tools/runner';
+import type {
+  CorrectnessCommand,
+  CorrectnessContext,
+  CorrectnessProvider,
+} from './capabilities/correctness';
+
+type JvmBuildSystem = 'maven' | 'gradle';
+
+interface JvmBuild {
+  readonly system: JvmBuildSystem;
+  /** `mvn`, an absolute `gradlew` wrapper path, or bare `gradle`. */
+  readonly bin: string;
+}
+
+/** Per-system sub-module manifest filenames (a directory owning one of these is
+ *  a build module we can narrow to). */
+const MODULE_MANIFESTS: Record<JvmBuildSystem, readonly string[]> = {
+  maven: ['pom.xml'],
+  gradle: ['build.gradle', 'build.gradle.kts'],
+};
+
+/** Any build-descriptor filename. A change to one of these can affect any
+ *  module (a dependency/plugin/version bump), so it disqualifies narrowing. */
+const JVM_BUILD_FILES = [
+  'pom.xml',
+  'build.gradle',
+  'build.gradle.kts',
+  'settings.gradle',
+  'settings.gradle.kts',
+  'gradle.properties',
+  'libs.versions.toml',
+];
+
+/** The absolute Gradle wrapper path when present, else bare `gradle` (PATH). */
+function gradleBin(cwd: string): string {
+  const wrapper = path.join(cwd, 'gradlew');
+  return fs.existsSync(wrapper) ? wrapper : 'gradle';
+}
+
+/** Detect the build system rooted at cwd. Maven-first when both are present
+ *  (rare); null when neither manifest exists — the floor then skips. */
+function detectJvmBuild(cwd: string): JvmBuild | null {
+  if (fileExists(cwd, 'pom.xml')) return { system: 'maven', bin: 'mvn' };
+  if (
+    fileExists(cwd, 'build.gradle') ||
+    fileExists(cwd, 'build.gradle.kts') ||
+    fileExists(cwd, 'gradlew') ||
+    fileExists(cwd, 'settings.gradle') ||
+    fileExists(cwd, 'settings.gradle.kts')
+  ) {
+    return { system: 'gradle', bin: gradleBin(cwd) };
+  }
+  return null;
+}
+
+function isJvmBuildFile(rel: string): boolean {
+  const base = rel.replace(/\\/g, '/').split('/').pop() ?? '';
+  return JVM_BUILD_FILES.includes(base);
+}
+
+/**
+ * Is this an Android Gradle build? The Android Gradle Plugin replaces the
+ * standard `test` / `testClasses` lifecycle tasks with variant-specific ones
+ * (`testDebugUnitTest`, `compileDebugKotlin`, …), so the plain commands this
+ * module builds don't apply — an Android project should decline the floor and
+ * let CI (which knows the variant) backstop, rather than false-fail on a
+ * "task not found". Cheap signal: the `com.android.*` plugin in a root build
+ * file. Exported so both JVM packs share the one detector.
+ */
+export function isAndroidGradleBuild(cwd: string): boolean {
+  for (const rel of [
+    'build.gradle.kts',
+    'build.gradle',
+    'settings.gradle.kts',
+    'settings.gradle',
+  ]) {
+    if (!fileExists(cwd, rel)) continue;
+    try {
+      if (fs.readFileSync(path.join(cwd, rel), 'utf-8').includes('com.android')) return true;
+    } catch {
+      /* ignore unreadable */
+    }
+  }
+  return false;
+}
+
+/**
+ * The repo-relative directory of the nearest ANCESTOR sub-module owning
+ * `relFile` — the closest directory (below the root) that carries a module
+ * manifest. Returns null when the nearest manifest is the root itself (a
+ * root-level change affects the whole build) or none is found.
+ */
+function nearestModuleDir(
+  cwd: string,
+  relFile: string,
+  manifests: readonly string[],
+): string | null {
+  let dir = path.dirname(relFile).replace(/\\/g, '/');
+  for (;;) {
+    if (dir === '.' || dir === '') return null; // reached the root → not a sub-module
+    try {
+      const entries = fs.readdirSync(path.join(cwd, dir));
+      if (entries.some((f) => manifests.includes(f))) return dir;
+    } catch {
+      /* dir unreadable — keep walking up */
+    }
+    dir = path.dirname(dir);
+  }
+}
+
+/**
+ * The distinct sub-module directories owning the changed source files. Returns
+ * null when ANY changed source file can't be attributed to a sub-module (it
+ * lives at the root, or the project is single-module) — the caller then runs the
+ * whole build, never under-testing.
+ */
+function jvmChangedModules(
+  cwd: string,
+  changedSources: readonly string[],
+  manifests: readonly string[],
+): string[] | null {
+  const mods = new Set<string>();
+  for (const f of changedSources) {
+    const mod = nearestModuleDir(cwd, f, manifests);
+    if (mod === null) return null; // root-level / single-module → whole build
+    mods.add(mod);
+  }
+  return [...mods];
+}
+
+/** Whole-build compile (main + test sources). */
+function compileCommand(build: JvmBuild): CorrectnessCommand {
+  if (build.system === 'maven') {
+    return { label: 'compile', bin: build.bin, args: ['-q', '-B', 'test-compile'] };
+  }
+  // Unqualified `testClasses` runs in every subproject that has it (Gradle
+  // executes an unqualified task name across the root + all subprojects), so it
+  // compiles main + test for the whole build without the root needing the task.
+  return { label: 'compile', bin: build.bin, args: ['testClasses'] };
+}
+
+/** Whole-build test run (the `full`-scope and safe-fallback command). */
+function testCommandFull(build: JvmBuild): CorrectnessCommand {
+  if (build.system === 'maven') {
+    return { label: 'affected-tests', bin: build.bin, args: ['-q', '-B', 'test'] };
+  }
+  return { label: 'affected-tests', bin: build.bin, args: ['test'] };
+}
+
+/** Narrowed test run over the given sub-module directories. */
+function testCommandForModules(build: JvmBuild, mods: readonly string[]): CorrectnessCommand {
+  if (build.system === 'maven') {
+    // -pl takes a comma-joined list of module paths; -am also-makes (compiles)
+    // the upstream dependencies of the listed modules so their tests can build.
+    return {
+      label: 'affected-tests',
+      bin: build.bin,
+      args: ['-q', '-B', '-pl', mods.join(','), '-am', 'test'],
+    };
+  }
+  // Gradle project path: `a/b` → `:a:b`, task `:a:b:test`.
+  const tasks = mods.map((d) => `:${d.replace(/\\/g, '/').split('/').join(':')}:test`);
+  return { label: 'affected-tests', bin: build.bin, args: tasks };
+}
+
+export interface JvmCorrectnessOptions {
+  /** Extensions that count as a relevant source change (`.java`, `.kt`/`.kts`). */
+  readonly sourceExtensions: readonly string[];
+  /** Optional escape hatch: decline the floor entirely when true (e.g. an
+   *  Android Gradle build, whose variant-specific `testDebugUnitTest` tasks the
+   *  standard `test`/`testClasses` commands don't cover — CI backstops). */
+  readonly declineWhen?: (cwd: string) => boolean;
+}
+
+/**
+ * Build a `CorrectnessProvider` for a JVM language pack. Shared by the Java and
+ * Kotlin packs (CLAUDE.md Rule 2) — the two differ only in which extensions mark
+ * a relevant change and whether an Android build should decline.
+ */
+export function jvmCorrectnessProvider(opts: JvmCorrectnessOptions): CorrectnessProvider {
+  const isSource = (f: string): boolean => opts.sourceExtensions.some((e) => f.endsWith(e));
+
+  return {
+    syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
+      if (opts.declineWhen?.(ctx.cwd)) return null;
+      const build = detectJvmBuild(ctx.cwd);
+      if (!build) return null;
+      return compileCommand(build);
+    },
+
+    affectedTests(ctx: CorrectnessContext): CorrectnessCommand | null {
+      if (opts.declineWhen?.(ctx.cwd)) return null;
+      const build = detectJvmBuild(ctx.cwd);
+      if (!build) return null;
+
+      const undeterminable = ctx.changedFiles.length === 0;
+      if (ctx.scope !== 'affected' || undeterminable) return testCommandFull(build);
+
+      const changedSources = ctx.changedFiles.filter(isSource);
+      if (changedSources.length === 0) return null; // no relevant source change → skip
+      // A build-descriptor change can affect any module — don't narrow.
+      if (ctx.changedFiles.some(isJvmBuildFile)) return testCommandFull(build);
+
+      const mods = jvmChangedModules(ctx.cwd, changedSources, MODULE_MANIFESTS[build.system]);
+      if (mods && mods.length > 0) return testCommandForModules(build, mods);
+      return testCommandFull(build); // single-module / unattributable → whole build
+    },
+  };
+}

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -9,6 +9,7 @@ import { walkSourceFiles } from '../analyzers/tools/walk-source-files';
 import { fileExists, run } from '../analyzers/tools/runner';
 import { runTestsWithCoverage } from '../analyzers/tools/run-tests-helper';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
+import { isAndroidGradleBuild, jvmCorrectnessProvider } from './jvm-build';
 import type {
   CapabilityProvider,
   DepVulnsProvider,
@@ -420,6 +421,19 @@ const kotlinTestFrameworkProvider: CapabilityProvider<TestFrameworkResult> = {
   },
 };
 
+// ─── Correctness floor (Maven/Gradle compile + module-affected tests) ──────
+//
+// Shared with the java pack via `jvmCorrectnessProvider` (CLAUDE.md Rule 2).
+// Kotlin contributes both source extensions (`.kt` for sources, `.kts` for
+// build/scratch scripts). An Android Gradle build declines — its variant-
+// specific `testDebugUnitTest` / `compileDebugKotlin` tasks aren't the standard
+// `test`/`testClasses` the shared commands run, so CI (variant-aware) backstops.
+
+const kotlinCorrectnessProvider = jvmCorrectnessProvider({
+  sourceExtensions: ['.kt', '.kts'],
+  declineWhen: isAndroidGradleBuild,
+});
+
 // ─── Pack export ────────────────────────────────────────────────────────────
 
 export const kotlin: LanguageSupport = {
@@ -519,6 +533,8 @@ export const kotlin: LanguageSupport = {
     codeqlBeta: true,
     snykCode: true,
   },
+
+  correctness: kotlinCorrectnessProvider,
 
   capabilities: {
     depVulns: kotlinDepVulnsProvider,

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import { type Coverage, type FileCoverage, round1, toRelative } from '../analyzers/tools/coverage';
 import { enrichOsv, resolveCvssScores } from '../analyzers/tools/osv';
-import { fileExists, run } from '../analyzers/tools/runner';
+import { commandExists, fileExists, run } from '../analyzers/tools/runner';
 import { walkPaths } from '../analyzers/tools/walk-paths';
 import { walkSourceFiles } from '../analyzers/tools/walk-source-files';
 import { runTestsWithCoverage } from '../analyzers/tools/run-tests-helper';
@@ -17,6 +17,11 @@ import type {
   LintProvider,
   RunTestsOutcome,
 } from './capabilities/provider';
+import type {
+  CorrectnessCommand,
+  CorrectnessContext,
+  CorrectnessProvider,
+} from './capabilities/correctness';
 import type {
   CoverageResult,
   DepVulnFinding,
@@ -819,6 +824,85 @@ const pyTestFrameworkProvider: CapabilityProvider<TestFrameworkResult> = {
   },
 };
 
+/** The interpreter the floor runs — the project's venv python (absolute path,
+ *  so it uses the env that actually has pytest installed) when resolvable,
+ *  else `python3` / `python` on PATH. */
+function floorPython(cwd: string): string {
+  return findPyProjectVenvPython(cwd) ?? (commandExists('python3') ? 'python3' : 'python');
+}
+
+/** Is pytest actually installed for the resolved interpreter? A venv python
+ *  (`.../bin/python`) has a sibling `.../bin/pytest`; a PATH interpreter uses
+ *  a PATH `pytest`. Gating on this keeps a project WITHOUT pytest installed
+ *  fail-OPEN (the check is skipped) rather than a fail-CLOSED "No module named
+ *  pytest" that would block a developer who hasn't installed test deps. */
+function pytestInstalledFor(python: string): boolean {
+  if (python.includes('/') || python.includes(path.sep)) {
+    const pytestBin = path.join(path.dirname(python), 'pytest');
+    return isPyExecutable(pytestBin);
+  }
+  return commandExists('pytest');
+}
+
+/** A changed Python file that is a pytest test module (`test_*.py` /
+ *  `*_test.py`, or under a `tests/` directory) — the pack's file-level
+ *  affected-selection unit. */
+function isPyTestFile(rel: string): boolean {
+  const base = path.basename(rel);
+  return (
+    /^test_.*\.py$/.test(base) ||
+    /_test\.py$/.test(base) ||
+    /(^|\/)tests?\//.test(rel.replace(/\\/g, '/'))
+  );
+}
+
+/**
+ * The Python correctness floor.
+ *
+ * syntaxCheck: `python -m py_compile <changed .py>` — the universal, stdlib
+ * parse check (needs only an interpreter, catches exactly syntax errors, and
+ * cannot false-positive on lint the way `ruff` would). Runs on the changed
+ * `.py` files; on the full/undeterminable surface it returns null because the
+ * pytest run below imports every module and surfaces a syntax error on import.
+ *
+ * affectedTests: `python -m pytest`. Native impact-selection needs a plugin
+ * (pytest-testmon / pytest-picked) that cannot be reliably detected without
+ * running, so the honest v1 rung is FILE-LEVEL — the changed test modules on
+ * the fast surface, the whole suite at full scope. A source-only change with no
+ * changed test module is syntax-checked on the fast surface and fully tested in
+ * CI. (Documented ceiling; testmon-based per-test selection is a future upgrade.)
+ */
+const pyCorrectnessProvider: CorrectnessProvider = {
+  syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
+    const changedPy = ctx.changedFiles.filter((f) => f.endsWith('.py'));
+    if (changedPy.length === 0) return null; // full-scope backstop is the pytest import
+    const python = floorPython(ctx.cwd);
+    if (!binaryLike(python)) return null;
+    return { label: 'syntax', bin: python, args: ['-m', 'py_compile', ...changedPy] };
+  },
+
+  affectedTests(ctx: CorrectnessContext): CorrectnessCommand | null {
+    if (gatherPyTestFrameworkResult(ctx.cwd) === null) return null; // no pytest project
+    const python = floorPython(ctx.cwd);
+    if (!pytestInstalledFor(python)) return null; // fail-open: pytest not installed here
+    const undeterminable = ctx.changedFiles.length === 0;
+    const changedTests = ctx.changedFiles.filter((f) => f.endsWith('.py') && isPyTestFile(f));
+    if (ctx.scope === 'affected' && !undeterminable) {
+      if (changedTests.length === 0) return null; // no changed test module → nothing to run
+      return { label: 'affected-tests', bin: python, args: ['-m', 'pytest', ...changedTests] };
+    }
+    // Full scope, or the diff was undeterminable → run the whole suite.
+    return { label: 'affected-tests', bin: python, args: ['-m', 'pytest'] };
+  },
+};
+
+/** A `bin` we can hand the runner: a bare name (resolved on PATH) or an
+ *  existing interpreter path. Mirrors the runner's own availability gate. */
+function binaryLike(bin: string): boolean {
+  if (bin.includes('/') || bin.includes(path.sep)) return isPyExecutable(bin);
+  return commandExists(bin);
+}
+
 /**
  * Raw shape emitted per-entry by `pip-licenses --format=json`. Fields are
  * pip-licenses's capitalised names; we map them to LicenseFinding below.
@@ -1080,6 +1164,8 @@ export const python: LanguageSupport = {
   semgrepRulesets: ['p/python'],
   // CodeQL `python` extractor (no build); Snyk Code supports Python.
   deepSast: { codeqlLanguage: 'python', snykCode: true },
+
+  correctness: pyCorrectnessProvider,
 
   capabilities: {
     depVulns: pyDepVulnsProvider,

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -14,6 +14,11 @@ import type {
   RunTestsOutcome,
 } from './capabilities/provider';
 import type {
+  CorrectnessCommand,
+  CorrectnessContext,
+  CorrectnessProvider,
+} from './capabilities/correctness';
+import type {
   CoverageResult,
   ImportsResult,
   LintGatherOutcome,
@@ -664,6 +669,70 @@ const rubyDepVulnsProvider: DepVulnsProvider = {
 
 // ─── Pack export ────────────────────────────────────────────────────────────
 
+/** A changed Ruby file that is a spec/test (`*_spec.rb`, `*_test.rb`,
+ *  `test_*.rb`) — the pack's file-level affected-selection unit. */
+function isRubyTestFile(rel: string): boolean {
+  const base = path.basename(rel);
+  return /_spec\.rb$/.test(base) || /_test\.rb$/.test(base) || /^test_.*\.rb$/.test(base);
+}
+
+/**
+ * The Ruby correctness floor.
+ *
+ * syntaxCheck: parse every changed `.rb`. `ruby -c` checks one file, so a tiny
+ * `-e` wrapper compiles each via `RubyVM::InstructionSequence.compile`, which
+ * raises `SyntaxError` (non-zero exit + the `file:line` message) on a parse
+ * error and is silent on success — the universal Ruby "does it parse" check,
+ * needing only an interpreter. Runs on the changed files; the full-scope
+ * backstop is the test run, which loads the code.
+ *
+ * affectedTests: FILE-LEVEL selection (Ruby has no native impact analysis; the
+ * honest rung, like Python's). RSpec runs the changed `*_spec.rb` (whole suite
+ * at full scope); minitest / test-unit loads the changed `*_test.rb` (bundled
+ * minitest's `at_exit` runs them), globbing `test/**` at full scope. A change
+ * touching no test file on the fast surface skips (the syntax check still runs;
+ * CI's full scope is the backstop).
+ */
+const rubyCorrectnessProvider: CorrectnessProvider = {
+  syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
+    const changedRb = ctx.changedFiles.filter((f) => f.endsWith('.rb'));
+    if (changedRb.length === 0) return null;
+    return {
+      label: 'syntax',
+      bin: 'ruby',
+      args: [
+        '-e',
+        'ARGV.each { |f| RubyVM::InstructionSequence.compile(File.read(f), f) }',
+        ...changedRb,
+      ],
+    };
+  },
+
+  affectedTests(ctx: CorrectnessContext): CorrectnessCommand | null {
+    const fw = gatherRubyTestFrameworkResult(ctx.cwd);
+    if (fw === null) return null; // no test framework detected
+    const undeterminable = ctx.changedFiles.length === 0;
+    const changedTests = ctx.changedFiles.filter((f) => f.endsWith('.rb') && isRubyTestFile(f));
+    const affected = ctx.scope === 'affected' && !undeterminable;
+    if (affected && changedTests.length === 0) return null; // no changed test file
+
+    if (fw.name === 'rspec') {
+      // `rspec <specs>` on the fast surface; bare `rspec` runs the whole suite.
+      return {
+        label: 'affected-tests',
+        bin: 'rspec',
+        args: affected ? [...changedTests] : [],
+      };
+    }
+    // minitest / test-unit: `load` each test file so bundled minitest's at_exit
+    // runs it. `-Itest -Ilib` puts the conventional dirs on the load path.
+    const loadArgs = affected
+      ? ['-e', 'ARGV.each { |f| load f }', ...changedTests]
+      : ['-e', 'Dir.glob("test/**/*_test.rb").each { |f| load f }'];
+    return { label: 'affected-tests', bin: 'ruby', args: ['-Itest', '-Ilib', ...loadArgs] };
+  },
+};
+
 export const ruby: LanguageSupport = {
   id: 'ruby',
   displayName: 'Ruby',
@@ -743,6 +812,8 @@ export const ruby: LanguageSupport = {
   semgrepRulesets: ['p/ruby'],
   // CodeQL `ruby` extractor (no build); Snyk Code supports Ruby.
   deepSast: { codeqlLanguage: 'ruby', snykCode: true },
+
+  correctness: rubyCorrectnessProvider,
 
   capabilities: {
     imports: rubyImportsProvider,

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -16,6 +16,11 @@ import type {
   RunTestsOutcome,
 } from './capabilities/provider';
 import type {
+  CorrectnessCommand,
+  CorrectnessContext,
+  CorrectnessProvider,
+} from './capabilities/correctness';
+import type {
   CoverageResult,
   DepVulnFinding,
   DepVulnGatherOutcome,
@@ -825,6 +830,111 @@ export function parseLcov(raw: string, sourceFile: string, cwd: string): Coverag
   };
 }
 
+/** Does the root `Cargo.toml` declare a `[workspace]` (multi-crate)? */
+function rustIsWorkspace(cwd: string): boolean {
+  try {
+    return /^\s*\[workspace\]/m.test(fs.readFileSync(path.join(cwd, 'Cargo.toml'), 'utf-8'));
+  } catch {
+    return false;
+  }
+}
+
+/** The `[package] name` declared in a Cargo.toml, or null (virtual manifest /
+ *  unreadable). Scoped to the `[package]` table by scanning line-by-line so a
+ *  `[dependencies] name = …` can't be mistaken for the crate name. */
+function rustCrateNameOf(cargoTomlAbs: string): string | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(cargoTomlAbs, 'utf-8');
+  } catch {
+    return null;
+  }
+  let inPackage = false;
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (/^\[.*\]$/.test(t)) {
+      inPackage = t === '[package]';
+      continue;
+    }
+    if (inPackage) {
+      const m = t.match(/^name\s*=\s*"([^"]+)"/);
+      if (m) return m[1];
+    }
+  }
+  return null;
+}
+
+/**
+ * The distinct workspace-member crate names owning the changed `.rs` files —
+ * each file's nearest ancestor `Cargo.toml` (not above `cwd`). Returns null when
+ * ANY changed `.rs` cannot be attributed to a named crate, so the caller falls
+ * back to the whole-workspace `cargo test` (never silently under-tests).
+ */
+function rustChangedCrates(cwd: string, changedFiles: readonly string[]): string[] | null {
+  const names = new Set<string>();
+  for (const f of changedFiles) {
+    if (!f.endsWith('.rs')) continue;
+    let dir = path.dirname(f).replace(/\\/g, '/');
+    let name: string | null = null;
+    // Walk up to (and including) the repo root looking for the owning manifest.
+    for (;;) {
+      const abs = path.join(cwd, dir, 'Cargo.toml');
+      if (fs.existsSync(abs)) {
+        name = rustCrateNameOf(abs);
+        break;
+      }
+      if (dir === '.' || dir === '') break;
+      dir = path.dirname(dir);
+    }
+    if (!name) return null; // unattributable → caller runs the whole workspace
+    names.add(name);
+  }
+  return [...names];
+}
+
+/**
+ * The Rust correctness floor.
+ *
+ * syntaxCheck: `cargo check` — compiles the crate/workspace WITHOUT producing
+ * binaries (the fast "does it compile + typecheck" path), incremental via
+ * cargo's cache. A cold check on a large workspace is bounded by the runner's
+ * timeout (fail-open → CI backstop).
+ *
+ * affectedTests: `cargo test`. Rust's native affected unit is the CRATE. A
+ * single-crate project runs `cargo test` (that crate). A workspace narrows to
+ * the changed members' crates via `-p <crate>` — falling back to the whole
+ * workspace when a changed `.rs` can't be attributed to a named crate, so it
+ * never silently under-tests. Full scope always runs the whole workspace.
+ * (Crate-level rung, like Go's package-level: a change whose DEPENDENTS live in
+ * another crate is caught at full/CI scope, not the affected surface.)
+ */
+const rustCorrectnessProvider: CorrectnessProvider = {
+  syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
+    if (!fileExists(ctx.cwd, 'Cargo.toml')) return null; // not a cargo project
+    return { label: 'check', bin: 'cargo', args: ['check'] };
+  },
+
+  affectedTests(ctx: CorrectnessContext): CorrectnessCommand | null {
+    if (!fileExists(ctx.cwd, 'Cargo.toml')) return null;
+    const undeterminable = ctx.changedFiles.length === 0;
+    if (ctx.scope === 'affected' && !undeterminable) {
+      if (!ctx.changedFiles.some((f) => f.endsWith('.rs'))) return null; // no .rs change
+      if (rustIsWorkspace(ctx.cwd)) {
+        const crates = rustChangedCrates(ctx.cwd, ctx.changedFiles);
+        if (crates && crates.length > 0) {
+          return {
+            label: 'affected-tests',
+            bin: 'cargo',
+            args: ['test', ...crates.flatMap((c) => ['-p', c])],
+          };
+        }
+        // else fall through to whole-workspace `cargo test` (safe default)
+      }
+    }
+    return { label: 'affected-tests', bin: 'cargo', args: ['test'] };
+  },
+};
+
 export const rust: LanguageSupport = {
   id: 'rust',
   displayName: 'Rust',
@@ -887,6 +997,8 @@ export const rust: LanguageSupport = {
   // CodeQL `rust` extractor is beta (no build). Snyk Code has no Rust
   // support today, so leave snykCode unset.
   deepSast: { codeqlLanguage: 'rust', codeqlBeta: true },
+
+  correctness: rustCorrectnessProvider,
 
   capabilities: {
     depVulns: rustDepVulnsProvider,

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -500,10 +500,15 @@ export interface LanguageSupport {
    * Stop-gate surface (an agent must not Stop on non-compiling / test-failing
    * code).
    *
-   * Optional — a pack without a wired toolchain omits it and contributes no
-   * floor checks (the runner sees the empty union for that language).
+   * REQUIRED. The capability shipped optional (TS/JS + Python first) and
+   * tightened to required once all eight built-in packs declared it — the same
+   * optional-then-required arc `depVulns.manifestPatterns` followed. A new pack
+   * that omits it fails to COMPILE here (not just at test time). A pack whose
+   * toolchain has no meaningful floor still supplies a provider whose builders
+   * return null (a dormant, no-op floor) rather than dropping the field — so the
+   * capability is always wired and the omission class of bug cannot recur.
    */
-  correctness?: CorrectnessProvider;
+  correctness: CorrectnessProvider;
 
   /**
    * Tier a lint rule code into a severity bucket. Accepts `string | null |

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -6,6 +6,7 @@ import type {
   LintProvider,
 } from './capabilities/provider';
 import type { CoverageResult, ImportsResult, TestFrameworkResult } from './capabilities/types';
+import type { CorrectnessProvider } from './capabilities/correctness';
 
 // `LanguageId` lives in `src/types.ts` (where `DetectedStack.languages`
 // references it) to avoid circular imports. Re-exported here for
@@ -488,6 +489,21 @@ export interface LanguageSupport {
    * intraprocedural tier).
    */
   deepSast?: DeepSastSupport;
+
+  /**
+   * The correctness-floor provider for this pack: how to compile/typecheck a
+   * change and run the tests it affects. Consumed by the correctness runner
+   * (`src/analyzers/correctness/`) through the registry helper
+   * `activeCorrectnessProviders` — never a per-language branch (Rule 6). The
+   * floor asks "does this still build + do affected tests pass?", a liveness
+   * question prior to the finding gate, and is default-on for the loop
+   * Stop-gate surface (an agent must not Stop on non-compiling / test-failing
+   * code).
+   *
+   * Optional — a pack without a wired toolchain omits it and contributes no
+   * floor checks (the runner sees the empty union for that language).
+   */
+  correctness?: CorrectnessProvider;
 
   /**
    * Tier a lint rule code into a severity bucket. Accepts `string | null |

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -23,6 +23,11 @@ import type {
   RunTestsOutcome,
 } from './capabilities/provider';
 import type {
+  CorrectnessCommand,
+  CorrectnessContext,
+  CorrectnessProvider,
+} from './capabilities/correctness';
+import type {
   CoverageResult,
   DepVulnFinding,
   DepVulnGatherOutcome,
@@ -841,6 +846,117 @@ const tsCoverageProvider: CapabilityProvider<CoverageResult> = {
 };
 
 /**
+ * Is a project-local CLI (`tsc`, `vitest`, `jest`) actually installed?
+ *
+ * The correctness floor gates every command on the local `node_modules/.bin`
+ * shim EXISTING, not merely on the package appearing in `package.json`. A dep
+ * that is declared but not installed (no `npm install` yet) returns false, so
+ * the floor SKIPS the check — fail-open. Emitting `npx --no-install tsc` for a
+ * missing binary would instead exit non-zero and fail-CLOSED, blocking a
+ * developer who simply hasn't installed dependencies locally. CI, where deps
+ * are installed, is the backstop for that case. The `.cmd` variant is npm's
+ * Windows shim.
+ */
+function hasLocalBin(cwd: string, bin: string): boolean {
+  return (
+    fileExists(cwd, path.join('node_modules', '.bin', bin)) ||
+    fileExists(cwd, path.join('node_modules', '.bin', `${bin}.cmd`))
+  );
+}
+
+/** The installed TS/JS test runner, vitest preferred then jest, or null. */
+function tsTestRunner(cwd: string): 'vitest' | 'jest' | null {
+  if (hasLocalBin(cwd, 'vitest')) return 'vitest';
+  if (hasLocalBin(cwd, 'jest')) return 'jest';
+  return null;
+}
+
+/**
+ * The project's own typecheck npm script, if it declares one — the two
+ * dominant conventions. Preferred over a bare `tsc` because it carries the
+ * project's exact flags and TypeScript project-references (`tsc -b`), the same
+ * command the project's CI runs. Mirrors how the coverage provider prefers a
+ * declared `test:coverage` script over inferring the runner.
+ */
+function tsTypecheckScript(cwd: string): string | null {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8')) as {
+      scripts?: Record<string, string>;
+    };
+    const scripts = pkg.scripts ?? {};
+    for (const name of ['typecheck', 'type-check']) {
+      if (typeof scripts[name] === 'string') return name;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The TS/JS correctness floor. `npx --no-install <tool>` is the portable
+ * invocation — npx resolves the project-local `.bin` shim cross-platform (a
+ * bare `tsc` is not on PATH, and a raw `.bin/tsc` symlink is not Windows-safe),
+ * and `--no-install` guarantees it never reaches the network.
+ */
+const tsCorrectnessProvider: CorrectnessProvider = {
+  syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
+    // Prefer the project's own typecheck script — it carries their exact
+    // compiler flags and project-references, the same command their CI runs.
+    const script = tsTypecheckScript(ctx.cwd);
+    if (script !== null) {
+      return { label: 'typecheck', bin: 'npm', args: ['run', script] };
+    }
+    // Otherwise, only a project that opts into TypeScript (has a tsconfig) with
+    // the compiler installed gets a typecheck floor. A pure-JS repo has no tsc
+    // stage — its syntax errors surface when the test runner loads the file.
+    // `--skipLibCheck` keeps errors INSIDE third-party / generated `.d.ts`
+    // files (which the developer cannot fix and which are not about their
+    // change) from spuriously blocking; it never suppresses an error in the
+    // developer's own source. A liveness floor asks "does my code compile",
+    // not "is every dependency's type declaration internally consistent".
+    if (!fileExists(ctx.cwd, 'tsconfig.json')) return null;
+    if (!hasLocalBin(ctx.cwd, 'tsc')) return null;
+    return {
+      label: 'typecheck',
+      bin: 'npx',
+      args: ['--no-install', 'tsc', '--noEmit', '--skipLibCheck'],
+    };
+  },
+
+  affectedTests(ctx: CorrectnessContext): CorrectnessCommand | null {
+    const runner = tsTestRunner(ctx.cwd);
+    if (runner === null) return null; // no vitest/jest installed → nothing to run
+
+    // On the fast (affected) surface run only the tests the changed source
+    // files reach — native impact-selection both runners support. Fall back to
+    // the full suite at `full` scope, or when the diff was undeterminable
+    // (empty changedFiles → treat as full, per the contract). A non-empty diff
+    // that touched no TS/JS file (docs-only) skips — nothing to run.
+    const undeterminable = ctx.changedFiles.length === 0;
+    const changed = ctx.changedFiles.filter((f) => TS_JS_EXT.some((e) => f.endsWith(e)));
+    if (ctx.scope === 'affected' && !undeterminable && changed.length === 0) return null;
+    const affected = ctx.scope === 'affected' && changed.length > 0;
+
+    // `--passWithNoTests` keeps "no related test" a PASS, not a failure — a
+    // source change with no covering test is a coverage concern (the finding
+    // gate's job), not a liveness failure.
+    if (runner === 'vitest') {
+      const args = affected
+        ? ['--no-install', 'vitest', 'related', '--run', '--passWithNoTests', ...changed]
+        : ['--no-install', 'vitest', 'run', '--passWithNoTests'];
+      return { label: 'affected-tests', bin: 'npx', args };
+    }
+    // jest — `--findRelatedTests` consumes every following positional as its
+    // file list, so it stays last with the changed files as its arguments.
+    const args = affected
+      ? ['--no-install', 'jest', '--passWithNoTests', '--findRelatedTests', ...changed]
+      : ['--no-install', 'jest', '--passWithNoTests'];
+    return { label: 'affected-tests', bin: 'npx', args };
+  },
+};
+
+/**
  * Enumerate TS/JS source files under cwd and pre-compute the pack's
  * per-file imports (raw specifiers) and resolved edges. Uses the
  * cross-platform `walkSourceFiles` walker; `includeTests` +
@@ -1309,6 +1425,8 @@ export const typescript: LanguageSupport = {
   // CodeQL's `javascript` extractor covers both JS and TS in one DB,
   // no build needed. Snyk Code supports JS/TS.
   deepSast: { codeqlLanguage: 'javascript', snykCode: true },
+
+  correctness: tsCorrectnessProvider,
 
   capabilities: {
     depVulns: tsDepVulnsProvider,

--- a/src/loop/floor-gate.ts
+++ b/src/loop/floor-gate.ts
@@ -1,0 +1,174 @@
+/**
+ * The loop's correctness-floor integration — how a Stop-gate runs the liveness
+ * floor and diffs it against the loop's entry snapshot. Split out of
+ * `stop-gate.ts` so that file stays focused on the guardrail/ledger flow (and
+ * under the large-file threshold).
+ *
+ * The gate blocks only on failures that are NET-NEW versus the entry snapshot
+ * captured at loop activation, so a pre-existing compile error / failing test
+ * never blocks (that would punish the agent for debt it did not introduce). The
+ * pre-push and CI surfaces have their own runner (`analyzers/correctness/
+ * surface-run.ts`); this module is the loop-stop surface alone.
+ */
+
+import { execFileSync } from 'child_process';
+
+import { detectActiveLanguages } from '../languages';
+import { computeChangedFiles } from '../baseline/changed-files';
+import {
+  runCorrectnessFloor,
+  type CorrectnessCheckResult,
+  type CorrectnessFloorResult,
+} from '../analyzers/correctness/run';
+import { resolveCorrectnessSurface } from '../analyzers/correctness/surface';
+import { readFloorBaseline, writeFloorBaseline, netNewFloorFailures } from './floor-state';
+import { type CheckStatus } from './ledger';
+
+/**
+ * The correctness-floor outcome for one Stop: the full run plus the failures
+ * that are net-new vs the loop's entry snapshot. `runFloor` (injected into
+ * `computeStopGate`) returns this, or null when no active pack provides a
+ * correctness floor. The gate blocks only on `netNew` — a pre-existing failure
+ * recorded in the entry snapshot never blocks.
+ */
+export interface FloorGateOutcome {
+  readonly result: CorrectnessFloorResult;
+  readonly netNew: readonly CorrectnessCheckResult[];
+}
+
+/** Derive the ledger's typecheck / tests status from a floor run. A failing
+ *  check dominates; else a check that ran is `pass`; else `not_configured`. */
+export function floorLedgerStatuses(result: CorrectnessFloorResult): {
+  typecheck_status: CheckStatus;
+  tests_status: CheckStatus;
+} {
+  const statusFor = (match: (label: string) => boolean): CheckStatus => {
+    const relevant = result.checks.filter((c) => match(c.label));
+    if (relevant.some((c) => c.status === 'fail')) return 'fail';
+    if (relevant.some((c) => c.status === 'pass')) return 'pass';
+    return 'not_configured';
+  };
+  return {
+    typecheck_status: statusFor((l) => /typecheck|compile|build|syntax/.test(l)),
+    tests_status: statusFor((l) => /test/.test(l)),
+  };
+}
+
+/**
+ * The repair message shown to the model when the correctness floor blocks.
+ * Lists each net-new failing check with the captured output tail so the model
+ * can fix it, and is explicit that the fix is the code, not the snapshot.
+ */
+export function buildFloorRepairMessage(netNew: readonly CorrectnessCheckResult[]): string {
+  const lines: string[] = [];
+  lines.push(
+    `dxkit blocked completion because this change introduces ${netNew.length} net-new ` +
+      `correctness failure${netNew.length === 1 ? '' : 's'} (code that does not compile or ` +
+      `whose tests fail).`,
+  );
+  lines.push('');
+  lines.push('Do not refresh the floor snapshot.');
+  lines.push('Fix the failing check(s) below, then try to stop again.');
+  lines.push('');
+  netNew.forEach((c, i) => {
+    lines.push(`${i + 1}. ${c.pack} ${c.label} (${c.bin})`);
+    if (c.output) {
+      const tail = c.output.split('\n').slice(-12).join('\n');
+      lines.push(tail.replace(/^/gm, '   '));
+    }
+  });
+  return lines.join('\n');
+}
+
+/** Per-check wall-clock budget for the floor on the fast surface (ms).
+ *  DXKIT_FLOOR_TIMEOUT_MS overrides; default 120s. A non-positive value
+ *  disables the timeout (unbounded, e.g. to match CI locally). */
+function floorTimeoutMs(): number {
+  const raw = process.env.DXKIT_FLOOR_TIMEOUT_MS;
+  if (raw !== undefined) {
+    const n = Number(raw);
+    if (Number.isFinite(n)) return n;
+  }
+  return 120_000;
+}
+
+/** Best-effort git stdout for a fixed arg vector; '' on any failure. */
+function gitOut(repoDir: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd: repoDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/** The comparison base for the floor's affected scope — the merge-base with
+ *  `origin/main` (the guardrail's default base), falling back to the ref tip,
+ *  then '' (→ full scope). */
+function resolveFloorBase(repoDir: string): string {
+  return (
+    gitOut(repoDir, ['merge-base', 'HEAD', 'origin/main']) ||
+    gitOut(repoDir, ['rev-parse', 'origin/main'])
+  );
+}
+
+/**
+ * The production correctness-floor gate for one Stop: resolve the active packs,
+ * scope to the files changed vs the loop base, run the AFFECTED floor, and diff
+ * it against the loop's entry snapshot. Returns null when no active pack
+ * provides a floor (nothing to run) or when nothing actually executed. Best-
+ * effort — any error returns null so the floor can never break the gate; the
+ * finding guardrail still runs regardless.
+ */
+export function buildFloorGate(repoDir: string): FloorGateOutcome | null {
+  try {
+    // The loop Stop-gate is default-on, but an explicit flag / DXKIT_FLOOR_LOOP /
+    // policy can disable the floor here — resolve through the one canonical
+    // surface resolver so this default never drifts from the other surfaces.
+    if (!resolveCorrectnessSurface({ surface: 'loop-stop', cwd: repoDir }).enabled) return null;
+    const packs = detectActiveLanguages(repoDir).filter((p) => p.correctness);
+    if (packs.length === 0) return null;
+    const base = resolveFloorBase(repoDir);
+    // Empty changedFiles (no base, or diff undeterminable) → the packs treat
+    // the scope as full, per the CorrectnessContext contract.
+    const changed = base ? (computeChangedFiles(repoDir, base) ?? []) : [];
+    const result = runCorrectnessFloor({
+      cwd: repoDir,
+      changedFiles: changed,
+      scope: 'affected',
+      // Bound each check on the fast surface: a change to a widely-imported
+      // "hub" file can make `related` select most of the suite, and a Stop hook
+      // must not hang for minutes. A command that exceeds the budget is a
+      // fail-OPEN skip (CI is the backstop), never a block. Tune with
+      // DXKIT_FLOOR_TIMEOUT_MS; default 120s per check.
+      timeoutMs: floorTimeoutMs(),
+      packs,
+    });
+    if (!result.ran) return null; // every check skipped (toolchain absent) → no-op
+    return { result, netNew: netNewFloorFailures(result, readFloorBaseline(repoDir)) };
+  } catch {
+    return null; // fail-open: the floor must never break the gate
+  }
+}
+
+/**
+ * Capture the loop's entry snapshot — the FULL floor on the current (pristine)
+ * tree. Called at loop activation, before the agent has changed anything, so
+ * the recorded failing set is genuinely pre-existing. Returns the run for
+ * reporting, or null when no active pack provides a floor. Best-effort write.
+ */
+export function captureFloorSnapshot(repoDir: string): CorrectnessFloorResult | null {
+  const packs = detectActiveLanguages(repoDir).filter((p) => p.correctness);
+  if (packs.length === 0) return null;
+  const result = runCorrectnessFloor({
+    cwd: repoDir,
+    changedFiles: [],
+    scope: 'full',
+    packs,
+  });
+  writeFloorBaseline(repoDir, result, gitOut(repoDir, ['rev-parse', 'HEAD']) || null);
+  return result;
+}

--- a/src/loop/floor-state.ts
+++ b/src/loop/floor-state.ts
@@ -1,0 +1,130 @@
+/**
+ * The correctness-floor state ledger for the loop Stop-gate.
+ *
+ * The floor is diff-scoped like the finding gate — a PRE-EXISTING compile
+ * error or failing test must not block the loop — but it is deliberately NOT a
+ * baseline artifact: no fingerprint, no identity scheme, no version to migrate.
+ * A failing test is a pass/fail signal, not a grandfathered finding.
+ *
+ * Instead we capture the ALREADY-BROKEN set ONCE, at loop activation, when the
+ * working tree is still the pristine base the agent has not yet touched, and
+ * store it in `.dxkit/loop/` (gitignored, transient). Each Stop re-runs the
+ * AFFECTED floor and blocks only on failures ABSENT from that entry snapshot
+ * (net-new). This is testmon's insight — persist last-known state rather than
+ * recompute it from a git ref — scoped to one loop, so a Stop never pays a
+ * `git worktree add` + `npm install` + full re-run (minutes) to learn what was
+ * already broken.
+ *
+ * Granularity: a check's identity is `pack:label` (e.g. `typescript:typecheck`,
+ * `typescript:affected-tests`). This is EXACT in the dominant case — a green
+ * base captures an empty failing set, so every failure at a later Stop is
+ * net-new and blocks. It degrades gracefully when the base is ALREADY red in a
+ * check: additional net-new failures piled onto that same already-red check are
+ * not distinguished from the pre-existing one (the check stays reported, not
+ * silently cleared). Per-test attribution is a future refinement; check-level
+ * is the honest v1 because you do not normally start a loop on a red branch —
+ * the snapshot exists for the exception, and there it is conservative about the
+ * pre-existing failure rather than about the new one.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { LEDGER_DIR } from './ledger';
+import type { CorrectnessCheckResult, CorrectnessFloorResult } from '../analyzers/correctness/run';
+
+/** File under `.dxkit/loop/` holding the entry snapshot. */
+export const FLOOR_BASELINE_FILE = 'floor-baseline.json';
+
+/** One check's outcome as recorded in the entry snapshot. Only `pass` / `fail`
+ *  are stored — a skipped check (tool unavailable / nothing to run) carries no
+ *  liveness signal and is omitted so it can never mask a later real failure. */
+export interface FloorCheckState {
+  readonly pack: string;
+  readonly label: string;
+  readonly status: 'pass' | 'fail';
+}
+
+/** The entry snapshot: what the floor looked like on the pristine base. */
+export interface FloorBaseline {
+  /** HEAD at capture time, for staleness detection / auditing. Null when the
+   *  repo had no commit (the floor still works; the field is informational). */
+  readonly capturedAtCommit: string | null;
+  readonly checks: readonly FloorCheckState[];
+}
+
+/** Stable per-check identity used to diff a Stop against the entry snapshot. */
+export function checkKey(pack: string, label: string): string {
+  return `${pack}:${label}`;
+}
+
+function floorBaselinePath(cwd: string): string {
+  return path.join(cwd, LEDGER_DIR, FLOOR_BASELINE_FILE);
+}
+
+/** Keep only the pass/fail checks — skipped ones carry no liveness signal. */
+function liveChecks(checks: readonly CorrectnessCheckResult[]): FloorCheckState[] {
+  return checks
+    .filter((c) => c.status === 'pass' || c.status === 'fail')
+    .map((c) => ({ pack: c.pack, label: c.label, status: c.status as 'pass' | 'fail' }));
+}
+
+/**
+ * Persist the entry snapshot from a floor run on the pristine base. Best-effort
+ * — a write failure leaves no snapshot, which the diff below treats as "assume
+ * the base was green" (every later failure is then net-new, the safe default).
+ */
+export function writeFloorBaseline(
+  cwd: string,
+  result: CorrectnessFloorResult,
+  capturedAtCommit: string | null,
+): void {
+  const baseline: FloorBaseline = { capturedAtCommit, checks: liveChecks(result.checks) };
+  try {
+    const dir = path.join(cwd, LEDGER_DIR);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(floorBaselinePath(cwd), JSON.stringify(baseline, null, 2) + '\n', 'utf8');
+  } catch {
+    /* best-effort — absence is handled as a green base by the diff */
+  }
+}
+
+/** Read the entry snapshot; null when absent or malformed (→ green base). */
+export function readFloorBaseline(cwd: string): FloorBaseline | null {
+  try {
+    const raw = fs.readFileSync(floorBaselinePath(cwd), 'utf8');
+    const parsed = JSON.parse(raw) as FloorBaseline;
+    if (!Array.isArray(parsed.checks)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Delete the entry snapshot (loop teardown). Best-effort. */
+export function clearFloorBaseline(cwd: string): void {
+  try {
+    fs.rmSync(floorBaselinePath(cwd), { force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * The net-new failures at this Stop: checks failing now that were NOT already
+ * failing in the entry snapshot. A null/absent baseline is treated as a green
+ * base — every current failure is net-new — so a missing snapshot fails toward
+ * blocking (broken code), never toward a silent pass.
+ */
+export function netNewFloorFailures(
+  current: CorrectnessFloorResult,
+  baseline: FloorBaseline | null,
+): CorrectnessCheckResult[] {
+  const alreadyFailing = new Set(
+    (baseline?.checks ?? [])
+      .filter((c) => c.status === 'fail')
+      .map((c) => checkKey(c.pack, c.label)),
+  );
+  return current.checks.filter(
+    (c) => c.status === 'fail' && !alreadyFailing.has(checkKey(c.pack, c.label)),
+  );
+}

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -51,6 +51,7 @@ import {
   type CorrectnessCheckResult,
   type CorrectnessFloorResult,
 } from '../analyzers/correctness/run';
+import { resolveCorrectnessSurface } from '../analyzers/correctness/surface';
 import { detectActiveLanguages } from '../languages';
 import { computeChangedFiles } from '../baseline/changed-files';
 import { readFloorBaseline, writeFloorBaseline, netNewFloorFailures } from './floor-state';
@@ -156,6 +157,10 @@ function resolveFloorBase(repoDir: string): string {
  */
 export function buildFloorGate(repoDir: string): FloorGateOutcome | null {
   try {
+    // The loop Stop-gate is default-on, but an explicit flag / DXKIT_FLOOR_LOOP /
+    // policy can disable the floor here — resolve through the one canonical
+    // surface resolver so this default never drifts from the other surfaces.
+    if (!resolveCorrectnessSurface({ surface: 'loop-stop', cwd: repoDir }).enabled) return null;
     const packs = detectActiveLanguages(repoDir).filter((p) => p.correctness);
     if (packs.length === 0) return null;
     const base = resolveFloorBase(repoDir);

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -36,7 +36,7 @@ import {
   type CheckStatus,
   type LedgerEvent,
 } from './ledger';
-import { execSync, execFileSync } from 'child_process';
+import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { dxkitCli } from '../self-invocation';
@@ -47,163 +47,11 @@ import {
   writeStateCache,
 } from './gate-cache';
 import {
-  runCorrectnessFloor,
-  type CorrectnessCheckResult,
-  type CorrectnessFloorResult,
-} from '../analyzers/correctness/run';
-import { resolveCorrectnessSurface } from '../analyzers/correctness/surface';
-import { detectActiveLanguages } from '../languages';
-import { computeChangedFiles } from '../baseline/changed-files';
-import { readFloorBaseline, writeFloorBaseline, netNewFloorFailures } from './floor-state';
-
-/**
- * The correctness-floor outcome for one Stop: the full run plus the failures
- * that are net-new vs the loop's entry snapshot. `runFloor` (injected into
- * `computeStopGate`) returns this, or null when no active pack provides a
- * correctness floor. The gate blocks only on `netNew` — a pre-existing failure
- * recorded in the entry snapshot never blocks.
- */
-export interface FloorGateOutcome {
-  readonly result: CorrectnessFloorResult;
-  readonly netNew: readonly CorrectnessCheckResult[];
-}
-
-/** Derive the ledger's typecheck / tests status from a floor run. A failing
- *  check dominates; else a check that ran is `pass`; else `not_configured`. */
-function floorLedgerStatuses(result: CorrectnessFloorResult): {
-  typecheck_status: CheckStatus;
-  tests_status: CheckStatus;
-} {
-  const statusFor = (match: (label: string) => boolean): CheckStatus => {
-    const relevant = result.checks.filter((c) => match(c.label));
-    if (relevant.some((c) => c.status === 'fail')) return 'fail';
-    if (relevant.some((c) => c.status === 'pass')) return 'pass';
-    return 'not_configured';
-  };
-  return {
-    typecheck_status: statusFor((l) => /typecheck|compile|build|syntax/.test(l)),
-    tests_status: statusFor((l) => /test/.test(l)),
-  };
-}
-
-/**
- * The repair message shown to the model when the correctness floor blocks.
- * Lists each net-new failing check with the captured output tail so the model
- * can fix it, and is explicit that the fix is the code, not the snapshot.
- */
-export function buildFloorRepairMessage(netNew: readonly CorrectnessCheckResult[]): string {
-  const lines: string[] = [];
-  lines.push(
-    `dxkit blocked completion because this change introduces ${netNew.length} net-new ` +
-      `correctness failure${netNew.length === 1 ? '' : 's'} (code that does not compile or ` +
-      `whose tests fail).`,
-  );
-  lines.push('');
-  lines.push('Do not refresh the floor snapshot.');
-  lines.push('Fix the failing check(s) below, then try to stop again.');
-  lines.push('');
-  netNew.forEach((c, i) => {
-    lines.push(`${i + 1}. ${c.pack} ${c.label} (${c.bin})`);
-    if (c.output) {
-      const tail = c.output.split('\n').slice(-12).join('\n');
-      lines.push(tail.replace(/^/gm, '   '));
-    }
-  });
-  return lines.join('\n');
-}
-
-/** Per-check wall-clock budget for the floor on the fast surface (ms).
- *  DXKIT_FLOOR_TIMEOUT_MS overrides; default 120s. A non-positive value
- *  disables the timeout (unbounded, e.g. to match CI locally). */
-function floorTimeoutMs(): number {
-  const raw = process.env.DXKIT_FLOOR_TIMEOUT_MS;
-  if (raw !== undefined) {
-    const n = Number(raw);
-    if (Number.isFinite(n)) return n;
-  }
-  return 120_000;
-}
-
-/** Best-effort git stdout for a fixed arg vector; '' on any failure. */
-function gitOut(repoDir: string, args: string[]): string {
-  try {
-    return execFileSync('git', args, {
-      cwd: repoDir,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-  } catch {
-    return '';
-  }
-}
-
-/** The comparison base for the floor's affected scope — the merge-base with
- *  `origin/main` (the guardrail's default base), falling back to the ref tip,
- *  then '' (→ full scope). */
-function resolveFloorBase(repoDir: string): string {
-  return (
-    gitOut(repoDir, ['merge-base', 'HEAD', 'origin/main']) ||
-    gitOut(repoDir, ['rev-parse', 'origin/main'])
-  );
-}
-
-/**
- * The production correctness-floor gate for one Stop: resolve the active packs,
- * scope to the files changed vs the loop base, run the AFFECTED floor, and diff
- * it against the loop's entry snapshot. Returns null when no active pack
- * provides a floor (nothing to run) or when nothing actually executed. Best-
- * effort — any error returns null so the floor can never break the gate; the
- * finding guardrail still runs regardless.
- */
-export function buildFloorGate(repoDir: string): FloorGateOutcome | null {
-  try {
-    // The loop Stop-gate is default-on, but an explicit flag / DXKIT_FLOOR_LOOP /
-    // policy can disable the floor here — resolve through the one canonical
-    // surface resolver so this default never drifts from the other surfaces.
-    if (!resolveCorrectnessSurface({ surface: 'loop-stop', cwd: repoDir }).enabled) return null;
-    const packs = detectActiveLanguages(repoDir).filter((p) => p.correctness);
-    if (packs.length === 0) return null;
-    const base = resolveFloorBase(repoDir);
-    // Empty changedFiles (no base, or diff undeterminable) → the packs treat
-    // the scope as full, per the CorrectnessContext contract.
-    const changed = base ? (computeChangedFiles(repoDir, base) ?? []) : [];
-    const result = runCorrectnessFloor({
-      cwd: repoDir,
-      changedFiles: changed,
-      scope: 'affected',
-      // Bound each check on the fast surface: a change to a widely-imported
-      // "hub" file can make `related` select most of the suite, and a Stop hook
-      // must not hang for minutes. A command that exceeds the budget is a
-      // fail-OPEN skip (CI is the backstop), never a block. Tune with
-      // DXKIT_FLOOR_TIMEOUT_MS; default 120s per check.
-      timeoutMs: floorTimeoutMs(),
-      packs,
-    });
-    if (!result.ran) return null; // every check skipped (toolchain absent) → no-op
-    return { result, netNew: netNewFloorFailures(result, readFloorBaseline(repoDir)) };
-  } catch {
-    return null; // fail-open: the floor must never break the gate
-  }
-}
-
-/**
- * Capture the loop's entry snapshot — the FULL floor on the current (pristine)
- * tree. Called at loop activation, before the agent has changed anything, so
- * the recorded failing set is genuinely pre-existing. Returns the run for
- * reporting, or null when no active pack provides a floor. Best-effort write.
- */
-export function captureFloorSnapshot(repoDir: string): CorrectnessFloorResult | null {
-  const packs = detectActiveLanguages(repoDir).filter((p) => p.correctness);
-  if (packs.length === 0) return null;
-  const result = runCorrectnessFloor({
-    cwd: repoDir,
-    changedFiles: [],
-    scope: 'full',
-    packs,
-  });
-  writeFloorBaseline(repoDir, result, gitOut(repoDir, ['rev-parse', 'HEAD']) || null);
-  return result;
-}
+  buildFloorGate,
+  buildFloorRepairMessage,
+  floorLedgerStatuses,
+  type FloorGateOutcome,
+} from './floor-gate';
 
 /** Subset of the Claude Code Stop-hook stdin payload we consume. */
 interface StopHookPayload {

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -36,7 +36,7 @@ import {
   type CheckStatus,
   type LedgerEvent,
 } from './ledger';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { dxkitCli } from '../self-invocation';
@@ -46,6 +46,159 @@ import {
   readStateCache,
   writeStateCache,
 } from './gate-cache';
+import {
+  runCorrectnessFloor,
+  type CorrectnessCheckResult,
+  type CorrectnessFloorResult,
+} from '../analyzers/correctness/run';
+import { detectActiveLanguages } from '../languages';
+import { computeChangedFiles } from '../baseline/changed-files';
+import { readFloorBaseline, writeFloorBaseline, netNewFloorFailures } from './floor-state';
+
+/**
+ * The correctness-floor outcome for one Stop: the full run plus the failures
+ * that are net-new vs the loop's entry snapshot. `runFloor` (injected into
+ * `computeStopGate`) returns this, or null when no active pack provides a
+ * correctness floor. The gate blocks only on `netNew` — a pre-existing failure
+ * recorded in the entry snapshot never blocks.
+ */
+export interface FloorGateOutcome {
+  readonly result: CorrectnessFloorResult;
+  readonly netNew: readonly CorrectnessCheckResult[];
+}
+
+/** Derive the ledger's typecheck / tests status from a floor run. A failing
+ *  check dominates; else a check that ran is `pass`; else `not_configured`. */
+function floorLedgerStatuses(result: CorrectnessFloorResult): {
+  typecheck_status: CheckStatus;
+  tests_status: CheckStatus;
+} {
+  const statusFor = (match: (label: string) => boolean): CheckStatus => {
+    const relevant = result.checks.filter((c) => match(c.label));
+    if (relevant.some((c) => c.status === 'fail')) return 'fail';
+    if (relevant.some((c) => c.status === 'pass')) return 'pass';
+    return 'not_configured';
+  };
+  return {
+    typecheck_status: statusFor((l) => /typecheck|compile|build|syntax/.test(l)),
+    tests_status: statusFor((l) => /test/.test(l)),
+  };
+}
+
+/**
+ * The repair message shown to the model when the correctness floor blocks.
+ * Lists each net-new failing check with the captured output tail so the model
+ * can fix it, and is explicit that the fix is the code, not the snapshot.
+ */
+export function buildFloorRepairMessage(netNew: readonly CorrectnessCheckResult[]): string {
+  const lines: string[] = [];
+  lines.push(
+    `dxkit blocked completion because this change introduces ${netNew.length} net-new ` +
+      `correctness failure${netNew.length === 1 ? '' : 's'} (code that does not compile or ` +
+      `whose tests fail).`,
+  );
+  lines.push('');
+  lines.push('Do not refresh the floor snapshot.');
+  lines.push('Fix the failing check(s) below, then try to stop again.');
+  lines.push('');
+  netNew.forEach((c, i) => {
+    lines.push(`${i + 1}. ${c.pack} ${c.label} (${c.bin})`);
+    if (c.output) {
+      const tail = c.output.split('\n').slice(-12).join('\n');
+      lines.push(tail.replace(/^/gm, '   '));
+    }
+  });
+  return lines.join('\n');
+}
+
+/** Per-check wall-clock budget for the floor on the fast surface (ms).
+ *  DXKIT_FLOOR_TIMEOUT_MS overrides; default 120s. A non-positive value
+ *  disables the timeout (unbounded, e.g. to match CI locally). */
+function floorTimeoutMs(): number {
+  const raw = process.env.DXKIT_FLOOR_TIMEOUT_MS;
+  if (raw !== undefined) {
+    const n = Number(raw);
+    if (Number.isFinite(n)) return n;
+  }
+  return 120_000;
+}
+
+/** Best-effort git stdout for a fixed arg vector; '' on any failure. */
+function gitOut(repoDir: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd: repoDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/** The comparison base for the floor's affected scope — the merge-base with
+ *  `origin/main` (the guardrail's default base), falling back to the ref tip,
+ *  then '' (→ full scope). */
+function resolveFloorBase(repoDir: string): string {
+  return (
+    gitOut(repoDir, ['merge-base', 'HEAD', 'origin/main']) ||
+    gitOut(repoDir, ['rev-parse', 'origin/main'])
+  );
+}
+
+/**
+ * The production correctness-floor gate for one Stop: resolve the active packs,
+ * scope to the files changed vs the loop base, run the AFFECTED floor, and diff
+ * it against the loop's entry snapshot. Returns null when no active pack
+ * provides a floor (nothing to run) or when nothing actually executed. Best-
+ * effort — any error returns null so the floor can never break the gate; the
+ * finding guardrail still runs regardless.
+ */
+export function buildFloorGate(repoDir: string): FloorGateOutcome | null {
+  try {
+    const packs = detectActiveLanguages(repoDir).filter((p) => p.correctness);
+    if (packs.length === 0) return null;
+    const base = resolveFloorBase(repoDir);
+    // Empty changedFiles (no base, or diff undeterminable) → the packs treat
+    // the scope as full, per the CorrectnessContext contract.
+    const changed = base ? (computeChangedFiles(repoDir, base) ?? []) : [];
+    const result = runCorrectnessFloor({
+      cwd: repoDir,
+      changedFiles: changed,
+      scope: 'affected',
+      // Bound each check on the fast surface: a change to a widely-imported
+      // "hub" file can make `related` select most of the suite, and a Stop hook
+      // must not hang for minutes. A command that exceeds the budget is a
+      // fail-OPEN skip (CI is the backstop), never a block. Tune with
+      // DXKIT_FLOOR_TIMEOUT_MS; default 120s per check.
+      timeoutMs: floorTimeoutMs(),
+      packs,
+    });
+    if (!result.ran) return null; // every check skipped (toolchain absent) → no-op
+    return { result, netNew: netNewFloorFailures(result, readFloorBaseline(repoDir)) };
+  } catch {
+    return null; // fail-open: the floor must never break the gate
+  }
+}
+
+/**
+ * Capture the loop's entry snapshot — the FULL floor on the current (pristine)
+ * tree. Called at loop activation, before the agent has changed anything, so
+ * the recorded failing set is genuinely pre-existing. Returns the run for
+ * reporting, or null when no active pack provides a floor. Best-effort write.
+ */
+export function captureFloorSnapshot(repoDir: string): CorrectnessFloorResult | null {
+  const packs = detectActiveLanguages(repoDir).filter((p) => p.correctness);
+  if (packs.length === 0) return null;
+  const result = runCorrectnessFloor({
+    cwd: repoDir,
+    changedFiles: [],
+    scope: 'full',
+    packs,
+  });
+  writeFloorBaseline(repoDir, result, gitOut(repoDir, ['rev-parse', 'HEAD']) || null);
+  return result;
+}
 
 /** Subset of the Claude Code Stop-hook stdin payload we consume. */
 interface StopHookPayload {
@@ -161,6 +314,7 @@ export async function computeStopGate(
   cwd: string,
   payload: StopHookPayload,
   runCheck: (repoDir: string) => Promise<GuardrailJsonPayload>,
+  runFloor: (repoDir: string) => FloorGateOutcome | null = () => null,
 ): Promise<StopGateDecision> {
   const start = Date.now();
   const repoDir = payload.cwd || cwd;
@@ -242,7 +396,43 @@ export async function computeStopGate(
     return { outcome: 'block-model', event, message: buildRepairMessage(json) };
   }
 
-  // Guardrail passed — run the optional configured test command.
+  // Guardrail passed — run the correctness FLOOR (liveness) before the optional
+  // configured test command. The floor asks "does this code compile + do the
+  // tests it affects pass", and blocks only on failures that are NET-NEW vs the
+  // loop's entry snapshot — a pre-existing compile error / failing test recorded
+  // on the pristine base never blocks (that would be punishing the agent for
+  // debt it did not introduce). A skipped floor (no active pack provides one,
+  // or the toolchain isn't installed) is a no-op.
+  const floor = runFloor(repoDir);
+  if (floor && floor.netNew.length > 0) {
+    const floorStatuses = floorLedgerStatuses(floor.result);
+    const event = buildLedgerEvent(repoDir, {
+      session_id: session,
+      ...agentFields,
+      cwd: repoDir,
+      branch: json.current.branch,
+      commit: json.current.commitSha,
+      guardrail_status: 'pass',
+      net_new_findings: 0,
+      baseline_findings: json.baseline.findingsCount,
+      files_changed: 0,
+      allowed: false,
+      stop_hook_active: stopActive,
+      tests_status: floorStatuses.tests_status,
+      lint_status: 'not_configured',
+      typecheck_status: floorStatuses.typecheck_status,
+      duration_ms: Date.now() - start,
+    });
+    return { outcome: 'block-model', event, message: buildFloorRepairMessage(floor.netNew) };
+  }
+  const floorStatuses = floor
+    ? floorLedgerStatuses(floor.result)
+    : {
+        typecheck_status: 'not_configured' as CheckStatus,
+        tests_status: 'not_configured' as CheckStatus,
+      };
+
+  // Guardrail + floor passed — run the optional configured test command.
   const tests = runConfiguredTests(repoDir);
   if (tests.status === 'fail') {
     const event = buildLedgerEvent(repoDir, {
@@ -259,7 +449,7 @@ export async function computeStopGate(
       stop_hook_active: stopActive,
       tests_status: 'fail',
       lint_status: 'not_configured',
-      typecheck_status: 'not_configured',
+      typecheck_status: floorStatuses.typecheck_status,
       duration_ms: Date.now() - start,
     });
     return {
@@ -284,9 +474,11 @@ export async function computeStopGate(
     files_changed: 0,
     allowed: true,
     stop_hook_active: stopActive,
-    tests_status: tests.status,
+    // Prefer the explicit configured-test status; otherwise report what the
+    // correctness floor's affected-test stage saw.
+    tests_status: tests.status !== 'not_configured' ? tests.status : floorStatuses.tests_status,
     lint_status: 'not_configured',
-    typecheck_status: 'not_configured',
+    typecheck_status: floorStatuses.typecheck_status,
     duration_ms: Date.now() - start,
   });
   return { outcome: 'allow', event, message: '' };
@@ -395,7 +587,7 @@ export async function runStopGate(cwd: string): Promise<void> {
     return json;
   };
 
-  const decision = await computeStopGate(cwd, payload, runCheck);
+  const decision = await computeStopGate(cwd, payload, runCheck, buildFloorGate);
   // Stamp the active preset onto the ledger line so the audit trail shows
   // which posture was in force when the gate allowed/blocked.
   appendLedgerEvent(repoDir, { ...decision.event, preset });

--- a/test/correctness-run.test.ts
+++ b/test/correctness-run.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import {
   runCorrectnessFloor,
   describeCorrectnessFloor,
+  makeCommandExec,
   type CommandExec,
 } from '../src/analyzers/correctness/run';
 import type { LanguageSupport } from '../src/languages/types';
@@ -76,6 +77,23 @@ describe('runCorrectnessFloor', () => {
     expect(r.checks[0].status).toBe('skipped-unavailable');
   });
 
+  it('fail-OPEN: a timed-out command is skipped, not failed (a slow suite is not a broken one)', () => {
+    const exec: CommandExec = (c) =>
+      c.bin === 'vitest'
+        ? { available: true, timedOut: true, code: -1, output: 'killed' }
+        : { available: true, code: 0, output: '' };
+    const r = runCorrectnessFloor({
+      ...base,
+      packs: [pack('ts', cmd('typecheck', 'tsc'), cmd('affected-tests', 'vitest'))],
+      exec,
+    });
+    expect(r.blocks).toBe(false); // timeout does NOT block
+    const at = r.checks.find((c) => c.label === 'affected-tests');
+    expect(at?.status).toBe('skipped-timeout');
+    // The typecheck still ran and passed, so the floor did run something.
+    expect(r.ran).toBe(true);
+  });
+
   it('skips a check a pack declines (null command)', () => {
     const exec: CommandExec = () => ({ available: true, code: 0, output: '' });
     const r = runCorrectnessFloor({
@@ -96,6 +114,25 @@ describe('runCorrectnessFloor', () => {
       exec,
     });
     expect(r.checks.map((c) => c.pack)).toEqual(['ts']);
+  });
+
+  it('makeCommandExec: a real command exceeding the budget reports timedOut (fail-open)', () => {
+    // `sleep 5` under a 200ms budget must be killed and reported as a timeout,
+    // NOT as a non-zero-exit failure.
+    const exec = makeCommandExec(200);
+    const out = exec({ label: 'slow', bin: 'sleep', args: ['5'] }, process.cwd());
+    expect(out.available).toBe(true);
+    expect(out.timedOut).toBe(true);
+  });
+
+  it('makeCommandExec: a fast command completes normally under the budget', () => {
+    const exec = makeCommandExec(10_000);
+    const out = exec(
+      { label: 'fast', bin: 'node', args: ['-e', 'process.exit(0)'] },
+      process.cwd(),
+    );
+    expect(out.timedOut).toBeFalsy();
+    expect(out.code).toBe(0);
   });
 
   it('describes a floor result', () => {

--- a/test/correctness-run.test.ts
+++ b/test/correctness-run.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the correctness-floor runner (src/analyzers/correctness/run.ts).
+ * Command execution is injected, so these exercise the fail-open / fail-closed
+ * policy without a real toolchain, driven by synthetic packs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  runCorrectnessFloor,
+  describeCorrectnessFloor,
+  type CommandExec,
+} from '../src/analyzers/correctness/run';
+import type { LanguageSupport } from '../src/languages/types';
+import type {
+  CorrectnessCommand,
+  CorrectnessContext,
+} from '../src/languages/capabilities/correctness';
+
+/** A synthetic pack whose provider returns fixed commands (or null). */
+function pack(
+  id: string,
+  syntax: CorrectnessCommand | null,
+  affected: CorrectnessCommand | null,
+): LanguageSupport {
+  return {
+    id,
+    correctness: {
+      syntaxCheck: (_ctx: CorrectnessContext) => syntax,
+      affectedTests: (_ctx: CorrectnessContext) => affected,
+    },
+  } as unknown as LanguageSupport;
+}
+
+const cmd = (label: string, bin: string): CorrectnessCommand => ({ label, bin, args: [] });
+
+const base = { cwd: '/repo', changedFiles: ['a.ts'], scope: 'affected' as const };
+
+describe('runCorrectnessFloor', () => {
+  it('passes when every command exits 0', () => {
+    const exec: CommandExec = () => ({ available: true, code: 0, output: '' });
+    const r = runCorrectnessFloor({
+      ...base,
+      packs: [pack('ts', cmd('typecheck', 'tsc'), cmd('affected-tests', 'vitest'))],
+      exec,
+    });
+    expect(r.ran).toBe(true);
+    expect(r.blocks).toBe(false);
+    expect(r.checks.map((c) => c.status)).toEqual(['pass', 'pass']);
+  });
+
+  it('fail-CLOSED: a non-zero exit blocks and captures output', () => {
+    const exec: CommandExec = (c) =>
+      c.bin === 'tsc'
+        ? { available: true, code: 2, output: 'error TS1005' }
+        : { available: true, code: 0, output: '' };
+    const r = runCorrectnessFloor({
+      ...base,
+      packs: [pack('ts', cmd('typecheck', 'tsc'), cmd('affected-tests', 'vitest'))],
+      exec,
+    });
+    expect(r.blocks).toBe(true);
+    const failed = r.checks.find((c) => c.status === 'fail');
+    expect(failed?.label).toBe('typecheck');
+    expect(failed?.output).toContain('TS1005');
+  });
+
+  it('fail-OPEN: a missing binary is skipped, not failed', () => {
+    const exec: CommandExec = () => ({ available: false, code: -1, output: '' });
+    const r = runCorrectnessFloor({
+      ...base,
+      packs: [pack('ts', cmd('typecheck', 'tsc'), null)],
+      exec,
+    });
+    expect(r.ran).toBe(false); // nothing actually executed
+    expect(r.blocks).toBe(false);
+    expect(r.checks[0].status).toBe('skipped-unavailable');
+  });
+
+  it('skips a check a pack declines (null command)', () => {
+    const exec: CommandExec = () => ({ available: true, code: 0, output: '' });
+    const r = runCorrectnessFloor({
+      ...base,
+      packs: [pack('ts', cmd('typecheck', 'tsc'), null)],
+      exec,
+    });
+    expect(r.checks).toHaveLength(1); // only syntaxCheck ran
+    expect(r.checks[0].label).toBe('typecheck');
+  });
+
+  it('ignores packs without a correctness provider', () => {
+    const exec: CommandExec = () => ({ available: true, code: 0, output: '' });
+    const plain = { id: 'go' } as unknown as LanguageSupport;
+    const r = runCorrectnessFloor({
+      ...base,
+      packs: [plain, pack('ts', cmd('typecheck', 'tsc'), null)],
+      exec,
+    });
+    expect(r.checks.map((c) => c.pack)).toEqual(['ts']);
+  });
+
+  it('describes a floor result', () => {
+    const exec: CommandExec = (c) =>
+      c.bin === 'tsc'
+        ? { available: true, code: 1, output: 'x' }
+        : { available: true, code: 0, output: '' };
+    const r = runCorrectnessFloor({
+      ...base,
+      packs: [pack('ts', cmd('typecheck', 'tsc'), cmd('affected-tests', 'vitest'))],
+      exec,
+    });
+    expect(describeCorrectnessFloor(r)).toContain('ts typecheck');
+    const clean = runCorrectnessFloor({
+      ...base,
+      packs: [pack('ts', cmd('typecheck', 'tsc'), null)],
+      exec: () => ({ available: true, code: 0, output: '' }),
+    });
+    expect(describeCorrectnessFloor(clean)).toContain('all checks passed');
+  });
+});

--- a/test/correctness-surface-run.test.ts
+++ b/test/correctness-surface-run.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { runFloorForSurface } from '../src/analyzers/correctness/surface-run';
+import type { CommandExec } from '../src/analyzers/correctness/run';
+import type { LanguageSupport } from '../src/languages/types';
+import type { CorrectnessCommand } from '../src/languages/capabilities/correctness';
+
+// A minimal fake pack that always emits a compile + test command, so the runner
+// executes the injected exec. Only the `correctness` shape matters here.
+function fakePack(): LanguageSupport {
+  const cmd = (label: string): CorrectnessCommand => ({ label, bin: 'faketool', args: [label] });
+  return {
+    id: 'typescript', // any real LanguageId; only `correctness` is exercised
+    correctness: {
+      syntaxCheck: () => cmd('compile'),
+      affectedTests: () => cmd('affected-tests'),
+    },
+  } as unknown as LanguageSupport;
+}
+
+const pass: CommandExec = () => ({ available: true, code: 0, output: '' });
+const fail: CommandExec = () => ({ available: true, code: 1, output: 'boom' });
+const missing: CommandExec = () => ({ available: false, code: -1, output: '' });
+
+const alwaysOn = () => ({ enabled: true, reason: 'test-enabled' });
+const alwaysOff = () => ({ enabled: false, reason: 'test-disabled' });
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-surfrun-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('runFloorForSurface — enablement', () => {
+  it('disabled surface → no-op (enabled:false, ran:false, blocks:false)', () => {
+    const r = runFloorForSurface({
+      surface: 'ci',
+      cwd: tmp,
+      packs: [fakePack()],
+      exec: fail,
+      resolveEnabled: alwaysOff,
+    });
+    expect(r.enabled).toBe(false);
+    expect(r.ran).toBe(false);
+    expect(r.blocks).toBe(false);
+    expect(r.summary).toContain('disabled');
+  });
+
+  it('enabled but no pack provides a floor → ran:false, blocks:false', () => {
+    const r = runFloorForSurface({
+      surface: 'ci',
+      cwd: tmp,
+      packs: [],
+      exec: fail,
+      resolveEnabled: alwaysOn,
+    });
+    expect(r.enabled).toBe(true);
+    expect(r.ran).toBe(false);
+    expect(r.blocks).toBe(false);
+    expect(r.summary).toContain('no active language pack');
+  });
+});
+
+describe('runFloorForSurface — run outcomes', () => {
+  it('all commands pass → ran:true, blocks:false', () => {
+    const r = runFloorForSurface({
+      surface: 'ci',
+      cwd: tmp,
+      packs: [fakePack()],
+      exec: pass,
+      resolveEnabled: alwaysOn,
+    });
+    expect(r.ran).toBe(true);
+    expect(r.blocks).toBe(false);
+  });
+
+  it('a command fails → blocks:true', () => {
+    const r = runFloorForSurface({
+      surface: 'ci',
+      cwd: tmp,
+      packs: [fakePack()],
+      exec: fail,
+      resolveEnabled: alwaysOn,
+    });
+    expect(r.ran).toBe(true);
+    expect(r.blocks).toBe(true);
+  });
+
+  it('toolchain missing → all skipped → ran:false, blocks:false (fail-open)', () => {
+    const r = runFloorForSurface({
+      surface: 'pre-push',
+      cwd: tmp,
+      packs: [fakePack()],
+      exec: missing,
+      resolveEnabled: alwaysOn,
+    });
+    expect(r.ran).toBe(false);
+    expect(r.blocks).toBe(false);
+    expect(r.summary).toContain('skipped');
+  });
+});
+
+describe('runFloorForSurface — scope selection', () => {
+  it('ci surface runs the packs at FULL scope (empty changedFiles)', () => {
+    const seen: Array<{ scope: string; args: readonly string[] }> = [];
+    const spy: CommandExec = (cmd) => {
+      seen.push({ scope: 'x', args: cmd.args });
+      return { available: true, code: 0, output: '' };
+    };
+    // A pack whose affectedTests encodes the scope it was called with, so we can
+    // assert ci → full.
+    const scopePack = {
+      id: 'typescript',
+      correctness: {
+        syntaxCheck: () => null,
+        affectedTests: (ctx: { scope: string }) => ({
+          label: 'affected-tests',
+          bin: 'faketool',
+          args: [ctx.scope],
+        }),
+      },
+    } as unknown as LanguageSupport;
+    runFloorForSurface({
+      surface: 'ci',
+      cwd: tmp,
+      packs: [scopePack],
+      exec: spy,
+      resolveEnabled: alwaysOn,
+    });
+    expect(seen[0].args).toEqual(['full']);
+  });
+
+  it('pre-push surface runs at AFFECTED scope', () => {
+    const seen: string[][] = [];
+    const spy: CommandExec = (cmd) => {
+      seen.push([...cmd.args]);
+      return { available: true, code: 0, output: '' };
+    };
+    const scopePack = {
+      id: 'typescript',
+      correctness: {
+        syntaxCheck: () => null,
+        affectedTests: (ctx: { scope: string }) => ({
+          label: 'affected-tests',
+          bin: 'faketool',
+          args: [ctx.scope],
+        }),
+      },
+    } as unknown as LanguageSupport;
+    runFloorForSurface({
+      surface: 'pre-push',
+      cwd: tmp,
+      packs: [scopePack],
+      exec: spy,
+      resolveEnabled: alwaysOn,
+    });
+    // No git base resolvable in the bare tmp dir → empty changedFiles, which the
+    // contract says a pack treats as full; but the SURFACE we requested is
+    // affected, so the scope handed to the pack is 'affected'.
+    expect(seen[0]).toEqual(['affected']);
+  });
+});
+
+describe('resolvePrePushBase (via a real git repo)', () => {
+  it('returns "" in a non-git directory', async () => {
+    const { resolvePrePushBase } = await import('../src/analyzers/correctness/surface-run');
+    expect(resolvePrePushBase(tmp)).toBe('');
+  });
+
+  it('resolves the merge-base against an explicit ref', async () => {
+    const { resolvePrePushBase } = await import('../src/analyzers/correctness/surface-run');
+    const git = (...args: string[]) =>
+      execFileSync('git', args, { cwd: tmp, stdio: ['ignore', 'pipe', 'ignore'] })
+        .toString()
+        .trim();
+    git('init', '-q');
+    git('config', 'user.email', 't@t.t');
+    git('config', 'user.name', 't');
+    fs.writeFileSync(path.join(tmp, 'a.txt'), 'a');
+    git('add', '-A');
+    git('commit', '-q', '-m', 'first');
+    const first = git('rev-parse', 'HEAD');
+    fs.writeFileSync(path.join(tmp, 'b.txt'), 'b');
+    git('add', '-A');
+    git('commit', '-q', '-m', 'second');
+    // merge-base HEAD <first> is <first> itself (first is an ancestor of HEAD).
+    expect(resolvePrePushBase(tmp, first)).toBe(first);
+  });
+});

--- a/test/correctness-surface.test.ts
+++ b/test/correctness-surface.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  resolveCorrectnessSurface,
+  detectTestCi,
+  readSurfacePolicy,
+  type CorrectnessSurface,
+  type TestCiDetection,
+} from '../src/analyzers/correctness/surface';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-surface-'));
+  // Ensure a clean env for each test (the resolver reads DXKIT_FLOOR_*).
+  delete process.env.DXKIT_FLOOR_LOOP;
+  delete process.env.DXKIT_FLOOR_PREPUSH;
+  delete process.env.DXKIT_FLOOR_CI;
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  delete process.env.DXKIT_FLOOR_LOOP;
+  delete process.env.DXKIT_FLOOR_PREPUSH;
+  delete process.env.DXKIT_FLOOR_CI;
+});
+
+function writeWorkflow(name: string, body: string): void {
+  const dir = path.join(tmp, '.github', 'workflows');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), body);
+}
+
+const detect = (status: TestCiDetection['status'], evidence?: string) => () => ({
+  status,
+  evidence,
+});
+
+describe('detectTestCi', () => {
+  it('no CI config at all → no-test-ci', () => {
+    expect(detectTestCi(tmp).status).toBe('no-test-ci');
+  });
+
+  it('a workflow that runs npm test → has-test-ci with evidence', () => {
+    writeWorkflow('ci.yml', 'jobs:\n  test:\n    steps:\n      - run: npm test\n');
+    const d = detectTestCi(tmp);
+    expect(d.status).toBe('has-test-ci');
+    expect(d.evidence).toContain('ci.yml');
+  });
+
+  it('detects pytest / go test / cargo test / dotnet test / gradle', () => {
+    for (const cmd of [
+      'pytest -q',
+      'go test ./...',
+      'cargo test',
+      'dotnet test',
+      './gradlew test',
+    ]) {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-ci-'));
+      try {
+        fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
+        fs.writeFileSync(path.join(dir, '.github', 'workflows', 'ci.yml'), `- run: ${cmd}\n`);
+        expect(detectTestCi(dir).status, cmd).toBe('has-test-ci');
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('a workflow with no recognizable test command → uncertain (CI exists, opaque)', () => {
+    writeWorkflow('ci.yml', 'jobs:\n  build:\n    steps:\n      - run: make ci\n');
+    expect(detectTestCi(tmp).status).toBe('uncertain');
+  });
+
+  it('ignores dxkit-authored workflows (its own floor/guardrail is not the repo test-CI)', () => {
+    writeWorkflow('dxkit-guardrails.yml', '- run: npm test\n');
+    // Only dxkit's own workflow present → not counted → no-test-ci.
+    expect(detectTestCi(tmp).status).toBe('no-test-ci');
+  });
+
+  it('reads flat CI configs (.gitlab-ci.yml)', () => {
+    fs.writeFileSync(path.join(tmp, '.gitlab-ci.yml'), 'test:\n  script:\n    - pytest\n');
+    const d = detectTestCi(tmp);
+    expect(d.status).toBe('has-test-ci');
+    expect(d.evidence).toContain('.gitlab-ci.yml');
+  });
+});
+
+describe('readSurfacePolicy', () => {
+  it('returns {} when no policy file', () => {
+    expect(readSurfacePolicy(tmp)).toEqual({});
+  });
+
+  it('reads boolean surface toggles, ignoring non-booleans', () => {
+    fs.mkdirSync(path.join(tmp, '.dxkit'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.dxkit', 'policy.json'),
+      JSON.stringify({
+        correctness: { surfaces: { ci: false, 'pre-push': true, 'loop-stop': 'yes' } },
+      }),
+    );
+    expect(readSurfacePolicy(tmp)).toEqual({ ci: false, 'pre-push': true });
+  });
+
+  it('tolerates malformed JSON', () => {
+    fs.mkdirSync(path.join(tmp, '.dxkit'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, '.dxkit', 'policy.json'), '{ not json');
+    expect(readSurfacePolicy(tmp)).toEqual({});
+  });
+});
+
+describe('resolveCorrectnessSurface — precedence', () => {
+  const base = (over: Partial<Parameters<typeof resolveCorrectnessSurface>[0]> = {}) => ({
+    surface: 'ci' as CorrectnessSurface,
+    cwd: tmp,
+    policySurfaces: {},
+    detect: detect('no-test-ci'),
+    ...over,
+  });
+
+  it('1. explicit flag wins over everything', () => {
+    process.env.DXKIT_FLOOR_CI = '1';
+    const r = resolveCorrectnessSurface(
+      base({ flag: false, policySurfaces: { ci: true }, detect: detect('no-test-ci') }),
+    );
+    expect(r.enabled).toBe(false);
+    expect(r.source).toBe('flag');
+  });
+
+  it('2. env override wins over policy + adaptive', () => {
+    process.env.DXKIT_FLOOR_CI = 'off';
+    const r = resolveCorrectnessSurface(base({ policySurfaces: { ci: true } }));
+    expect(r.enabled).toBe(false);
+    expect(r.source).toBe('env');
+  });
+
+  it('3. policy wins over adaptive default', () => {
+    const r = resolveCorrectnessSurface(
+      base({ policySurfaces: { ci: false }, detect: detect('no-test-ci') }),
+    );
+    expect(r.enabled).toBe(false);
+    expect(r.source).toBe('policy');
+  });
+
+  it('loop-stop is always-on by default (no flag/env/policy)', () => {
+    const r = resolveCorrectnessSurface(base({ surface: 'loop-stop' }));
+    expect(r.enabled).toBe(true);
+    expect(r.source).toBe('always-on');
+  });
+
+  it('loop-stop can still be disabled by an explicit flag', () => {
+    const r = resolveCorrectnessSurface(base({ surface: 'loop-stop', flag: false }));
+    expect(r.enabled).toBe(false);
+    expect(r.source).toBe('flag');
+  });
+});
+
+describe('resolveCorrectnessSurface — adaptive (pre-push / ci)', () => {
+  const adaptive = (status: TestCiDetection['status'], surface: CorrectnessSurface = 'ci') =>
+    resolveCorrectnessSurface({
+      surface,
+      cwd: tmp,
+      policySurfaces: {},
+      detect: detect(status, 'ci.yml: npm test'),
+    });
+
+  it('has-test-ci → OPT-IN (disabled by default)', () => {
+    const r = adaptive('has-test-ci');
+    expect(r.enabled).toBe(false);
+    expect(r.source).toBe('adaptive-test-ci-detected');
+  });
+
+  it('no-test-ci → default ON', () => {
+    const r = adaptive('no-test-ci');
+    expect(r.enabled).toBe(true);
+    expect(r.source).toBe('adaptive-no-test-ci');
+  });
+
+  it('uncertain → FAIL TOWARD ON', () => {
+    const r = adaptive('uncertain');
+    expect(r.enabled).toBe(true);
+    expect(r.source).toBe('adaptive-uncertain');
+  });
+
+  it('applies the same adaptive logic to pre-push', () => {
+    expect(adaptive('has-test-ci', 'pre-push').enabled).toBe(false);
+    expect(adaptive('no-test-ci', 'pre-push').enabled).toBe(true);
+    expect(adaptive('uncertain', 'pre-push').enabled).toBe(true);
+  });
+});

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -275,6 +275,36 @@ describe.each(LANGUAGES as LanguageSupport[])('language contract: $id', (lang) =
     }
   });
 
+  // Correctness floor (2.23): a pack that opts into the liveness gate MUST
+  // supply BOTH command builders. Each is a pure function returning a
+  // `{label,bin,args}` command or null — the runner never hardcodes a
+  // per-language command (CLAUDE.md Rule 6). A pack with `syntaxCheck` but no
+  // `affectedTests` (or vice-versa) is a half-wired provider that would
+  // silently gate only half the liveness signal.
+  it('correctness capability supplies both syntaxCheck and affectedTests if declared', () => {
+    const c = lang.correctness;
+    if (!c) return; // a pack without a liveness floor is exempt (dormant, no-op)
+    expect(
+      typeof c.syntaxCheck,
+      `${lang.id}: correctness provider must supply a syntaxCheck() builder`,
+    ).toBe('function');
+    expect(
+      typeof c.affectedTests,
+      `${lang.id}: correctness provider must supply an affectedTests() builder`,
+    ).toBe('function');
+    // Both builders must return null or a well-formed command for a trivial
+    // context — never throw, never return a malformed shape.
+    const ctx = { cwd: '/nonexistent-repo', changedFiles: [], scope: 'affected' as const };
+    for (const build of [c.syntaxCheck, c.affectedTests]) {
+      const cmd = build(ctx);
+      if (cmd !== null) {
+        expect(typeof cmd.label).toBe('string');
+        expect(typeof cmd.bin).toBe('string');
+        expect(Array.isArray(cmd.args)).toBe(true);
+      }
+    }
+  });
+
   it('extraExcludes is an array of strings when defined', () => {
     if (lang.extraExcludes) {
       expect(Array.isArray(lang.extraExcludes)).toBe(true);

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -275,15 +275,22 @@ describe.each(LANGUAGES as LanguageSupport[])('language contract: $id', (lang) =
     }
   });
 
-  // Correctness floor (2.23): a pack that opts into the liveness gate MUST
-  // supply BOTH command builders. Each is a pure function returning a
-  // `{label,bin,args}` command or null — the runner never hardcodes a
-  // per-language command (CLAUDE.md Rule 6). A pack with `syntaxCheck` but no
-  // `affectedTests` (or vice-versa) is a half-wired provider that would
-  // silently gate only half the liveness signal.
-  it('correctness capability supplies both syntaxCheck and affectedTests if declared', () => {
+  // Correctness floor (2.23): EVERY built-in pack MUST declare the liveness
+  // gate and supply BOTH command builders. The capability shipped optional
+  // (TS/JS + Python first) and tightened to REQUIRED once all eight packs
+  // declared it — the same optional-then-required arc `depVulns.manifestPatterns`
+  // followed. Each builder is a pure function returning a `{label,bin,args}`
+  // command or null — the runner never hardcodes a per-language command
+  // (CLAUDE.md Rule 6). A pack with `syntaxCheck` but no `affectedTests` (or
+  // vice-versa) is a half-wired provider that would silently gate only half the
+  // liveness signal. A NEW pack that omits `correctness` fails HERE.
+  it('declares a correctness provider with both syntaxCheck and affectedTests', () => {
     const c = lang.correctness;
-    if (!c) return; // a pack without a liveness floor is exempt (dormant, no-op)
+    expect(
+      c,
+      `${lang.id}: every pack must declare a correctness (liveness) provider`,
+    ).toBeDefined();
+    if (!c) return; // unreachable once the assertion above holds — narrows the type
     expect(
       typeof c.syntaxCheck,
       `${lang.id}: correctness provider must supply a syntaxCheck() builder`,

--- a/test/languages-csharp.test.ts
+++ b/test/languages-csharp.test.ts
@@ -195,3 +195,80 @@ describe('csharp registration', () => {
     expect(env!.extracted.get('A.cs')).toEqual(['System']);
   });
 });
+
+describe('csharp.correctness', () => {
+  const ctx = (over: Partial<{ changedFiles: string[]; scope: 'affected' | 'full' }> = {}) => ({
+    cwd: tmp,
+    changedFiles: over.changedFiles ?? ['src/App/Program.cs'],
+    scope: over.scope ?? ('affected' as const),
+  });
+  const writeSln = () =>
+    fs.writeFileSync(path.join(tmp, 'App.sln'), 'Microsoft Visual Studio Solution File\n');
+  const writeProj = (rel: string, isTest: boolean) => {
+    fs.mkdirSync(path.join(tmp, path.dirname(rel)), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, rel),
+      isTest
+        ? '<Project><ItemGroup><PackageReference Include="Microsoft.NET.Test.Sdk" /></ItemGroup></Project>'
+        : '<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>',
+    );
+  };
+
+  it('syntaxCheck: dotnet build when a build target exists', () => {
+    writeSln();
+    expect(csharp.correctness!.syntaxCheck(ctx())).toEqual({
+      label: 'build',
+      bin: 'dotnet',
+      args: ['build', '--nologo'],
+    });
+  });
+
+  it('syntaxCheck: null without a .sln/.csproj build target', () => {
+    expect(csharp.correctness!.syntaxCheck(ctx())).toBeNull();
+  });
+
+  it('affectedTests: narrows to a single changed TEST project', () => {
+    writeSln();
+    writeProj('test/App.Tests/App.Tests.csproj', true);
+    const cmd = csharp.correctness!.affectedTests(
+      ctx({ changedFiles: ['test/App.Tests/FooTests.cs', 'README.md'] }),
+    );
+    expect(cmd).toEqual({
+      label: 'affected-tests',
+      bin: 'dotnet',
+      args: ['test', 'test/App.Tests/App.Tests.csproj'],
+    });
+  });
+
+  it('affectedTests: whole solution when a non-test (source) project changed', () => {
+    writeSln();
+    writeProj('src/App/App.csproj', false);
+    const cmd = csharp.correctness!.affectedTests(ctx({ changedFiles: ['src/App/Program.cs'] }));
+    expect(cmd?.args).toEqual(['test']);
+  });
+
+  it('affectedTests: whole solution at full scope', () => {
+    writeSln();
+    writeProj('test/App.Tests/App.Tests.csproj', true);
+    const cmd = csharp.correctness!.affectedTests(
+      ctx({ changedFiles: ['test/App.Tests/FooTests.cs'], scope: 'full' }),
+    );
+    expect(cmd?.args).toEqual(['test']);
+  });
+
+  it('affectedTests: whole solution when the diff is undeterminable', () => {
+    writeSln();
+    expect(
+      csharp.correctness!.affectedTests(ctx({ changedFiles: [], scope: 'affected' }))?.args,
+    ).toEqual(['test']);
+  });
+
+  it('affectedTests: null on the affected surface when no .cs changed', () => {
+    writeSln();
+    expect(csharp.correctness!.affectedTests(ctx({ changedFiles: ['README.md'] }))).toBeNull();
+  });
+
+  it('affectedTests: null without a build target', () => {
+    expect(csharp.correctness!.affectedTests(ctx())).toBeNull();
+  });
+});

--- a/test/languages-go.test.ts
+++ b/test/languages-go.test.ts
@@ -177,3 +177,68 @@ describe('go.mapLintSeverity', () => {
     expect(map('some-random-linter')).toBe('low');
   });
 });
+
+describe('go.correctness', () => {
+  const ctx = (over: Partial<{ changedFiles: string[]; scope: 'affected' | 'full' }> = {}) => ({
+    cwd: tmp,
+    changedFiles: over.changedFiles ?? ['main.go'],
+    scope: over.scope ?? ('affected' as const),
+  });
+
+  it('syntaxCheck: go build ./... when a go.mod is present', () => {
+    fs.writeFileSync(path.join(tmp, 'go.mod'), 'module x\n');
+    expect(go.correctness!.syntaxCheck(ctx())).toEqual({
+      label: 'build',
+      bin: 'go',
+      args: ['build', './...'],
+    });
+  });
+
+  it('syntaxCheck: null without a go.mod (not a module)', () => {
+    expect(go.correctness!.syntaxCheck(ctx())).toBeNull();
+  });
+
+  it('affectedTests: tests the changed packages on the affected surface', () => {
+    fs.writeFileSync(path.join(tmp, 'go.mod'), 'module x\n');
+    const cmd = go.correctness!.affectedTests(
+      ctx({
+        changedFiles: [
+          'internal/svc/svc.go',
+          'internal/svc/help.go',
+          'cmd/app/main.go',
+          'README.md',
+        ],
+      }),
+    );
+    expect(cmd?.bin).toBe('go');
+    // Unique package dirs of the changed .go files, as import specs.
+    expect(cmd?.args).toEqual(['test', './internal/svc', './cmd/app']);
+  });
+
+  it('affectedTests: a root-level .go change tests the current package', () => {
+    fs.writeFileSync(path.join(tmp, 'go.mod'), 'module x\n');
+    const cmd = go.correctness!.affectedTests(ctx({ changedFiles: ['main.go'] }));
+    expect(cmd?.args).toEqual(['test', '.']);
+  });
+
+  it('affectedTests: null on the affected surface when no .go changed', () => {
+    fs.writeFileSync(path.join(tmp, 'go.mod'), 'module x\n');
+    expect(go.correctness!.affectedTests(ctx({ changedFiles: ['README.md'] }))).toBeNull();
+  });
+
+  it('affectedTests: whole module at full scope', () => {
+    fs.writeFileSync(path.join(tmp, 'go.mod'), 'module x\n');
+    expect(go.correctness!.affectedTests(ctx({ scope: 'full' }))?.args).toEqual(['test', './...']);
+  });
+
+  it('affectedTests: whole module when the diff is undeterminable (empty changedFiles)', () => {
+    fs.writeFileSync(path.join(tmp, 'go.mod'), 'module x\n');
+    expect(
+      go.correctness!.affectedTests(ctx({ changedFiles: [], scope: 'affected' }))?.args,
+    ).toEqual(['test', './...']);
+  });
+
+  it('affectedTests: null without a go.mod', () => {
+    expect(go.correctness!.affectedTests(ctx())).toBeNull();
+  });
+});

--- a/test/languages-java.test.ts
+++ b/test/languages-java.test.ts
@@ -16,7 +16,7 @@
  * land.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -370,6 +370,153 @@ describe('parsePmdOutput — real PMD 7.24.0 fixture', () => {
       medium: 0,
       low: 0,
     });
+  });
+});
+
+describe('java.correctness (shared JVM floor)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-jvfx-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const ctx = (over: Partial<{ changedFiles: string[]; scope: 'affected' | 'full' }> = {}) => ({
+    cwd: tmp,
+    changedFiles: over.changedFiles ?? ['src/main/java/com/x/A.java'],
+    scope: over.scope ?? ('affected' as const),
+  });
+
+  function writeMavenSingle(): void {
+    fs.writeFileSync(path.join(tmp, 'pom.xml'), '<project></project>\n');
+  }
+
+  function writeMavenMulti(): void {
+    fs.writeFileSync(
+      path.join(tmp, 'pom.xml'),
+      '<project><modules><module>svc-a</module><module>svc-b</module></modules></project>\n',
+    );
+    for (const m of ['svc-a', 'svc-b']) {
+      fs.mkdirSync(path.join(tmp, m, 'src', 'main', 'java'), { recursive: true });
+      fs.writeFileSync(path.join(tmp, m, 'pom.xml'), '<project></project>\n');
+    }
+  }
+
+  function writeGradleMulti(): void {
+    fs.writeFileSync(path.join(tmp, 'settings.gradle'), "include(':svc-a', ':svc-b')\n");
+    fs.writeFileSync(path.join(tmp, 'build.gradle'), '// root\n');
+    for (const m of ['svc-a', 'svc-b']) {
+      fs.mkdirSync(path.join(tmp, m, 'src', 'main', 'java'), { recursive: true });
+      fs.writeFileSync(path.join(tmp, m, 'build.gradle'), "apply plugin: 'java'\n");
+    }
+    // A wrapper makes the bin the absolute ./gradlew path.
+    fs.writeFileSync(path.join(tmp, 'gradlew'), '#!/bin/sh\n');
+  }
+
+  it('syntaxCheck: null with no JVM build manifest', () => {
+    expect(java.correctness!.syntaxCheck(ctx())).toBeNull();
+  });
+
+  it('syntaxCheck: maven test-compile', () => {
+    writeMavenSingle();
+    expect(java.correctness!.syntaxCheck(ctx())).toEqual({
+      label: 'compile',
+      bin: 'mvn',
+      args: ['-q', '-B', 'test-compile'],
+    });
+  });
+
+  it('syntaxCheck: gradle testClasses via the absolute wrapper path', () => {
+    writeGradleMulti();
+    const cmd = java.correctness!.syntaxCheck(ctx())!;
+    expect(cmd.label).toBe('compile');
+    expect(cmd.bin).toBe(path.join(tmp, 'gradlew'));
+    expect(cmd.args).toEqual(['testClasses']);
+  });
+
+  it('affectedTests: null when no .java changed on the affected surface', () => {
+    writeMavenSingle();
+    expect(java.correctness!.affectedTests(ctx({ changedFiles: ['README.md'] }))).toBeNull();
+  });
+
+  it('affectedTests: single-module maven runs the whole build', () => {
+    writeMavenSingle();
+    expect(java.correctness!.affectedTests(ctx())).toEqual({
+      label: 'affected-tests',
+      bin: 'mvn',
+      args: ['-q', '-B', 'test'],
+    });
+  });
+
+  it('affectedTests: maven narrows to the changed module via -pl -am', () => {
+    writeMavenMulti();
+    const cmd = java.correctness!.affectedTests(
+      ctx({ changedFiles: ['svc-a/src/main/java/com/x/A.java'] }),
+    );
+    expect(cmd?.args).toEqual(['-q', '-B', '-pl', 'svc-a', '-am', 'test']);
+  });
+
+  it('affectedTests: maven unions multiple changed modules', () => {
+    writeMavenMulti();
+    const cmd = java.correctness!.affectedTests(
+      ctx({
+        changedFiles: [
+          'svc-a/src/main/java/com/x/A.java',
+          'svc-b/src/main/java/com/y/B.java',
+          'README.md',
+        ],
+      }),
+    );
+    expect(cmd?.args).toEqual(['-q', '-B', '-pl', 'svc-a,svc-b', '-am', 'test']);
+  });
+
+  it('affectedTests: gradle narrows to the changed project path', () => {
+    writeGradleMulti();
+    const cmd = java.correctness!.affectedTests(
+      ctx({ changedFiles: ['svc-a/src/main/java/com/x/A.java'] }),
+    );
+    expect(cmd?.args).toEqual([':svc-a:test']);
+  });
+
+  it('affectedTests: a build-file change falls back to the whole build', () => {
+    writeMavenMulti();
+    const cmd = java.correctness!.affectedTests(
+      ctx({ changedFiles: ['svc-a/src/main/java/com/x/A.java', 'svc-a/pom.xml'] }),
+    );
+    expect(cmd?.args).toEqual(['-q', '-B', 'test']);
+  });
+
+  it('affectedTests: a root-level source change runs the whole build', () => {
+    writeMavenMulti();
+    // A .java at the root has no owning sub-module → never under-test.
+    const cmd = java.correctness!.affectedTests(ctx({ changedFiles: ['App.java'] }));
+    expect(cmd?.args).toEqual(['-q', '-B', 'test']);
+  });
+
+  it('affectedTests: full scope runs the whole build', () => {
+    writeMavenMulti();
+    expect(
+      java.correctness!.affectedTests(
+        ctx({ changedFiles: ['svc-a/src/main/java/com/x/A.java'], scope: 'full' }),
+      )?.args,
+    ).toEqual(['-q', '-B', 'test']);
+  });
+
+  it('affectedTests: undeterminable diff (empty changedFiles) runs the whole build', () => {
+    writeMavenSingle();
+    expect(java.correctness!.affectedTests(ctx({ changedFiles: [] }))?.args).toEqual([
+      '-q',
+      '-B',
+      'test',
+    ]);
+  });
+
+  it('declines entirely on an Android Gradle build', () => {
+    writeGradleMulti();
+    fs.writeFileSync(path.join(tmp, 'build.gradle'), "plugins { id 'com.android.application' }\n");
+    expect(java.correctness!.syntaxCheck(ctx())).toBeNull();
+    expect(java.correctness!.affectedTests(ctx())).toBeNull();
   });
 });
 

--- a/test/languages-kotlin.test.ts
+++ b/test/languages-kotlin.test.ts
@@ -34,8 +34,9 @@
  * these tests use real fixtures.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import {
   kotlin,
@@ -272,5 +273,67 @@ describe('extractKotlinImportsRaw', () => {
 
   it('returns empty for files with no imports', () => {
     expect(extractKotlinImportsRaw('package com.example\n\nfun main() {}')).toEqual([]);
+  });
+});
+
+describe('kotlin.correctness (shared JVM floor)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-ktfx-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const ctx = (over: Partial<{ changedFiles: string[]; scope: 'affected' | 'full' }> = {}) => ({
+    cwd: tmp,
+    changedFiles: over.changedFiles ?? ['src/main/kotlin/com/x/A.kt'],
+    scope: over.scope ?? ('affected' as const),
+  });
+
+  it('syntaxCheck: gradle testClasses when a gradle manifest is present', () => {
+    fs.writeFileSync(path.join(tmp, 'build.gradle.kts'), '// root\n');
+    expect(kotlin.correctness!.syntaxCheck(ctx())).toEqual({
+      label: 'compile',
+      bin: 'gradle',
+      args: ['testClasses'],
+    });
+  });
+
+  it('affectedTests: a .kt change runs the whole build on a single-module project', () => {
+    fs.writeFileSync(path.join(tmp, 'build.gradle.kts'), '// root\n');
+    expect(kotlin.correctness!.affectedTests(ctx())?.args).toEqual(['test']);
+  });
+
+  it('affectedTests: a .kts build-script change is treated as a relevant source change', () => {
+    fs.writeFileSync(path.join(tmp, 'build.gradle.kts'), '// root\n');
+    // `.kts` is a Kotlin source extension AND a build file — the build-file
+    // guard wins, so it falls back to the whole build (never under-tests).
+    const cmd = kotlin.correctness!.affectedTests(ctx({ changedFiles: ['build.gradle.kts'] }));
+    expect(cmd?.args).toEqual(['test']);
+  });
+
+  it('affectedTests: narrows to the changed module in a multi-module gradle build', () => {
+    fs.writeFileSync(path.join(tmp, 'settings.gradle.kts'), 'include(":svc-a")\n');
+    fs.writeFileSync(path.join(tmp, 'build.gradle.kts'), '// root\n');
+    fs.mkdirSync(path.join(tmp, 'svc-a', 'src', 'main', 'kotlin'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'svc-a', 'build.gradle.kts'), 'plugins { kotlin("jvm") }\n');
+    const cmd = kotlin.correctness!.affectedTests(
+      ctx({ changedFiles: ['svc-a/src/main/kotlin/com/x/A.kt'] }),
+    );
+    expect(cmd?.args).toEqual([':svc-a:test']);
+  });
+
+  it('affectedTests: null with no JVM build manifest and no .kt change', () => {
+    expect(kotlin.correctness!.affectedTests(ctx({ changedFiles: ['README.md'] }))).toBeNull();
+  });
+
+  it('declines entirely on an Android Gradle build', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'build.gradle.kts'),
+      'plugins { id("com.android.application") }\n',
+    );
+    expect(kotlin.correctness!.syntaxCheck(ctx())).toBeNull();
+    expect(kotlin.correctness!.affectedTests(ctx())).toBeNull();
   });
 });

--- a/test/languages-python.test.ts
+++ b/test/languages-python.test.ts
@@ -213,3 +213,73 @@ describe('findPyProjectVenvPython', () => {
     }
   });
 });
+
+describe('python.correctness', () => {
+  /** Write a fake `.venv/bin/<name>` executable so the resolver + pytest gate
+   *  see a project interpreter with pytest installed. */
+  function installVenvBin(name: string): string {
+    const binDir = path.join(tmp, '.venv', 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const exe = path.join(binDir, name);
+    fs.writeFileSync(exe, '#!/bin/sh\n', { mode: 0o755 });
+    return exe;
+  }
+  const ctx = (over: Partial<{ changedFiles: string[]; scope: 'affected' | 'full' }> = {}) => ({
+    cwd: tmp,
+    changedFiles: over.changedFiles ?? ['app.py'],
+    scope: over.scope ?? ('affected' as const),
+  });
+
+  it('syntaxCheck: py_compile on the changed .py files via the venv python', () => {
+    const py = installVenvBin('python');
+    const cmd = python.correctness!.syntaxCheck(ctx({ changedFiles: ['app.py', 'README.md'] }));
+    expect(cmd).toEqual({ label: 'syntax', bin: py, args: ['-m', 'py_compile', 'app.py'] });
+  });
+
+  it('syntaxCheck: null when no .py changed (pytest import is the full-scope backstop)', () => {
+    installVenvBin('python');
+    expect(python.correctness!.syntaxCheck(ctx({ changedFiles: ['README.md'] }))).toBeNull();
+  });
+
+  it('affectedTests: null when the project has no pytest signal', () => {
+    installVenvBin('python');
+    installVenvBin('pytest');
+    // No pytest.ini / conftest.py / [tool.pytest] → not a pytest project.
+    expect(python.correctness!.affectedTests(ctx())).toBeNull();
+  });
+
+  it('affectedTests: runs the changed test modules on the affected surface', () => {
+    fs.writeFileSync(path.join(tmp, 'pytest.ini'), '[pytest]\n');
+    const py = installVenvBin('python');
+    installVenvBin('pytest');
+    const cmd = python.correctness!.affectedTests(
+      ctx({ changedFiles: ['src/app.py', 'tests/test_app.py'] }),
+    );
+    expect(cmd).toEqual({
+      label: 'affected-tests',
+      bin: py,
+      args: ['-m', 'pytest', 'tests/test_app.py'],
+    });
+  });
+
+  it('affectedTests: null on the affected surface when no test module changed', () => {
+    fs.writeFileSync(path.join(tmp, 'pytest.ini'), '[pytest]\n');
+    installVenvBin('python');
+    installVenvBin('pytest');
+    expect(python.correctness!.affectedTests(ctx({ changedFiles: ['src/app.py'] }))).toBeNull();
+  });
+
+  it('affectedTests: whole suite at full scope', () => {
+    fs.writeFileSync(path.join(tmp, 'pytest.ini'), '[pytest]\n');
+    const py = installVenvBin('python');
+    installVenvBin('pytest');
+    const cmd = python.correctness!.affectedTests(ctx({ scope: 'full' }));
+    expect(cmd).toEqual({ label: 'affected-tests', bin: py, args: ['-m', 'pytest'] });
+  });
+
+  it('affectedTests: null (fail-open) when pytest is not installed in the env', () => {
+    fs.writeFileSync(path.join(tmp, 'pytest.ini'), '[pytest]\n');
+    installVenvBin('python'); // python present, but NO pytest sibling
+    expect(python.correctness!.affectedTests(ctx({ scope: 'full' }))).toBeNull();
+  });
+});

--- a/test/languages-ruby.test.ts
+++ b/test/languages-ruby.test.ts
@@ -642,3 +642,112 @@ describe('gatherRubyDepVulnsResult — manifest probe', () => {
     }
   });
 });
+
+describe('ruby.correctness', () => {
+  function tmpDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-ruby-corr-'));
+  }
+  const ctx = (
+    cwd: string,
+    over: Partial<{ changedFiles: string[]; scope: 'affected' | 'full' }> = {},
+  ) => ({
+    cwd,
+    changedFiles: over.changedFiles ?? ['lib/app.rb'],
+    scope: over.scope ?? ('affected' as const),
+  });
+
+  it('syntaxCheck: compiles each changed .rb via a ruby -e wrapper', () => {
+    const dir = tmpDir();
+    try {
+      const cmd = ruby.correctness!.syntaxCheck(
+        ctx(dir, { changedFiles: ['lib/a.rb', 'lib/b.rb', 'README.md'] }),
+      );
+      expect(cmd?.bin).toBe('ruby');
+      expect(cmd?.args[0]).toBe('-e');
+      expect(cmd?.args).toContain('lib/a.rb');
+      expect(cmd?.args).toContain('lib/b.rb');
+      expect(cmd?.args).not.toContain('README.md');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('syntaxCheck: null when no .rb changed', () => {
+    const dir = tmpDir();
+    try {
+      expect(ruby.correctness!.syntaxCheck(ctx(dir, { changedFiles: ['README.md'] }))).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('affectedTests: null when no test framework is detected', () => {
+    const dir = tmpDir();
+    try {
+      expect(ruby.correctness!.affectedTests(ctx(dir))).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('affectedTests: rspec runs the changed specs on the affected surface', () => {
+    const dir = tmpDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'Gemfile'), "gem 'rspec'\n");
+      const cmd = ruby.correctness!.affectedTests(
+        ctx(dir, { changedFiles: ['lib/a.rb', 'spec/a_spec.rb'] }),
+      );
+      expect(cmd).toEqual({ label: 'affected-tests', bin: 'rspec', args: ['spec/a_spec.rb'] });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('affectedTests: rspec runs the whole suite at full scope', () => {
+    const dir = tmpDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'Gemfile'), "gem 'rspec'\n");
+      const cmd = ruby.correctness!.affectedTests(ctx(dir, { scope: 'full' }));
+      expect(cmd).toEqual({ label: 'affected-tests', bin: 'rspec', args: [] });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('affectedTests: minitest loads the changed test files on the affected surface', () => {
+    const dir = tmpDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'Gemfile'), "gem 'minitest'\n");
+      const cmd = ruby.correctness!.affectedTests(
+        ctx(dir, { changedFiles: ['lib/a.rb', 'test/a_test.rb'] }),
+      );
+      expect(cmd?.bin).toBe('ruby');
+      expect(cmd?.args.slice(0, 2)).toEqual(['-Itest', '-Ilib']);
+      expect(cmd?.args).toContain('test/a_test.rb');
+      expect(cmd?.args).toContain('ARGV.each { |f| load f }');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('affectedTests: minitest globs the test tree at full scope', () => {
+    const dir = tmpDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'Gemfile'), "gem 'minitest'\n");
+      const cmd = ruby.correctness!.affectedTests(ctx(dir, { scope: 'full' }));
+      expect(cmd?.args.join(' ')).toContain('Dir.glob("test/**/*_test.rb")');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('affectedTests: null on the affected surface when no test file changed', () => {
+    const dir = tmpDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'Gemfile'), "gem 'minitest'\n");
+      expect(ruby.correctness!.affectedTests(ctx(dir, { changedFiles: ['lib/a.rb'] }))).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/languages-rust.test.ts
+++ b/test/languages-rust.test.ts
@@ -170,3 +170,102 @@ describe('rust.mapLintSeverity (clippy)', () => {
     expect(map('')).toBe('low');
   });
 });
+
+describe('rust.correctness', () => {
+  const ctx = (over: Partial<{ changedFiles: string[]; scope: 'affected' | 'full' }> = {}) => ({
+    cwd: tmp,
+    changedFiles: over.changedFiles ?? ['src/lib.rs'],
+    scope: over.scope ?? ('affected' as const),
+  });
+
+  it('syntaxCheck: cargo check when a Cargo.toml is present', () => {
+    fs.writeFileSync(path.join(tmp, 'Cargo.toml'), '[package]\nname="x"\n');
+    expect(rust.correctness!.syntaxCheck(ctx())).toEqual({
+      label: 'check',
+      bin: 'cargo',
+      args: ['check'],
+    });
+  });
+
+  it('syntaxCheck: null without a Cargo.toml', () => {
+    expect(rust.correctness!.syntaxCheck(ctx())).toBeNull();
+  });
+
+  it('affectedTests: cargo test when a .rs changed on the affected surface', () => {
+    fs.writeFileSync(path.join(tmp, 'Cargo.toml'), '[package]\nname="x"\n');
+    expect(
+      rust.correctness!.affectedTests(ctx({ changedFiles: ['src/lib.rs', 'README.md'] })),
+    ).toEqual({
+      label: 'affected-tests',
+      bin: 'cargo',
+      args: ['test'],
+    });
+  });
+
+  it('affectedTests: null on the affected surface when no .rs changed', () => {
+    fs.writeFileSync(path.join(tmp, 'Cargo.toml'), '[package]\nname="x"\n');
+    expect(rust.correctness!.affectedTests(ctx({ changedFiles: ['README.md'] }))).toBeNull();
+  });
+
+  it('affectedTests: cargo test at full scope', () => {
+    fs.writeFileSync(path.join(tmp, 'Cargo.toml'), '[package]\nname="x"\n');
+    expect(rust.correctness!.affectedTests(ctx({ scope: 'full' }))?.args).toEqual(['test']);
+  });
+
+  it('affectedTests: cargo test when the diff is undeterminable (empty changedFiles)', () => {
+    fs.writeFileSync(path.join(tmp, 'Cargo.toml'), '[package]\nname="x"\n');
+    expect(
+      rust.correctness!.affectedTests(ctx({ changedFiles: [], scope: 'affected' }))?.args,
+    ).toEqual(['test']);
+  });
+
+  it('affectedTests: null without a Cargo.toml', () => {
+    expect(rust.correctness!.affectedTests(ctx())).toBeNull();
+  });
+
+  // Workspace mode: narrow to the changed members' crates via `-p <crate>`.
+  function writeWorkspace(): void {
+    fs.writeFileSync(
+      path.join(tmp, 'Cargo.toml'),
+      '[workspace]\nmembers = ["crates/alpha", "crates/beta"]\n',
+    );
+    for (const [dir, name] of [
+      ['crates/alpha', 'alpha'],
+      ['crates/beta', 'beta'],
+    ]) {
+      fs.mkdirSync(path.join(tmp, dir, 'src'), { recursive: true });
+      fs.writeFileSync(path.join(tmp, dir, 'Cargo.toml'), `[package]\nname = "${name}"\n`);
+    }
+  }
+
+  it('affectedTests: narrows to the changed member crate (-p) in a workspace', () => {
+    writeWorkspace();
+    const cmd = rust.correctness!.affectedTests(ctx({ changedFiles: ['crates/alpha/src/lib.rs'] }));
+    expect(cmd?.args).toEqual(['test', '-p', 'alpha']);
+  });
+
+  it('affectedTests: unions multiple changed member crates', () => {
+    writeWorkspace();
+    const cmd = rust.correctness!.affectedTests(
+      ctx({ changedFiles: ['crates/alpha/src/lib.rs', 'crates/beta/src/main.rs', 'README.md'] }),
+    );
+    expect(cmd?.args).toEqual(['test', '-p', 'alpha', '-p', 'beta']);
+  });
+
+  it('affectedTests: falls back to the whole workspace when a .rs is unattributable', () => {
+    writeWorkspace();
+    // A .rs at the workspace root (virtual manifest, no [package]) can't be
+    // attributed to a named crate → run the whole workspace, never under-test.
+    const cmd = rust.correctness!.affectedTests(ctx({ changedFiles: ['build.rs'] }));
+    expect(cmd?.args).toEqual(['test']);
+  });
+
+  it('affectedTests: workspace full scope runs the whole workspace', () => {
+    writeWorkspace();
+    expect(
+      rust.correctness!.affectedTests(
+        ctx({ changedFiles: ['crates/alpha/src/lib.rs'], scope: 'full' }),
+      )?.args,
+    ).toEqual(['test']);
+  });
+});

--- a/test/languages-typescript.test.ts
+++ b/test/languages-typescript.test.ts
@@ -295,3 +295,106 @@ describe('buildTsTopLevelDepIndex', () => {
     expect(idx.get('b')).toEqual(['a']);
   });
 });
+
+describe('typescript.correctness', () => {
+  /** Write a fake `node_modules/.bin/<bin>` shim so `hasLocalBin` sees it. */
+  function installBin(bin: string): void {
+    const dir = path.join(tmp, 'node_modules', '.bin');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, bin), '#!/bin/sh\n');
+  }
+
+  const ctx = (over: Partial<{ changedFiles: string[]; scope: 'affected' | 'full' }> = {}) => ({
+    cwd: tmp,
+    changedFiles: over.changedFiles ?? ['src/a.ts'],
+    scope: over.scope ?? ('affected' as const),
+  });
+
+  it('syntaxCheck runs tsc --noEmit --skipLibCheck when tsconfig + tsc are present', () => {
+    fs.writeFileSync(path.join(tmp, 'package.json'), '{"name":"x"}');
+    fs.writeFileSync(path.join(tmp, 'tsconfig.json'), '{}');
+    installBin('tsc');
+    const cmd = typescript.correctness!.syntaxCheck(ctx());
+    expect(cmd).toEqual({
+      label: 'typecheck',
+      bin: 'npx',
+      args: ['--no-install', 'tsc', '--noEmit', '--skipLibCheck'],
+    });
+  });
+
+  it('syntaxCheck prefers the project typecheck script', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify({ scripts: { typecheck: 'tsc -b' } }),
+    );
+    fs.writeFileSync(path.join(tmp, 'tsconfig.json'), '{}');
+    installBin('tsc');
+    const cmd = typescript.correctness!.syntaxCheck(ctx());
+    expect(cmd).toEqual({ label: 'typecheck', bin: 'npm', args: ['run', 'typecheck'] });
+  });
+
+  it('syntaxCheck skips without a tsconfig (pure JS)', () => {
+    fs.writeFileSync(path.join(tmp, 'package.json'), '{"name":"x"}');
+    installBin('tsc');
+    expect(typescript.correctness!.syntaxCheck(ctx())).toBeNull();
+  });
+
+  it('syntaxCheck skips (fail-open) when tsc is not installed', () => {
+    fs.writeFileSync(path.join(tmp, 'tsconfig.json'), '{}');
+    expect(typescript.correctness!.syntaxCheck(ctx())).toBeNull();
+  });
+
+  it('affectedTests: vitest related on the affected surface', () => {
+    installBin('vitest');
+    const cmd = typescript.correctness!.affectedTests(
+      ctx({ changedFiles: ['src/a.ts', 'README.md'] }),
+    );
+    expect(cmd).toEqual({
+      label: 'affected-tests',
+      bin: 'npx',
+      args: ['--no-install', 'vitest', 'related', '--run', '--passWithNoTests', 'src/a.ts'],
+    });
+  });
+
+  it('affectedTests: vitest full suite at full scope', () => {
+    installBin('vitest');
+    const cmd = typescript.correctness!.affectedTests(ctx({ scope: 'full' }));
+    expect(cmd).toEqual({
+      label: 'affected-tests',
+      bin: 'npx',
+      args: ['--no-install', 'vitest', 'run', '--passWithNoTests'],
+    });
+  });
+
+  it('affectedTests: full suite when the diff is undeterminable (empty changedFiles)', () => {
+    installBin('vitest');
+    const cmd = typescript.correctness!.affectedTests(ctx({ changedFiles: [], scope: 'affected' }));
+    expect(cmd?.args).toEqual(['--no-install', 'vitest', 'run', '--passWithNoTests']);
+  });
+
+  it('affectedTests: skips when no TS/JS file changed on the affected surface', () => {
+    installBin('vitest');
+    expect(typescript.correctness!.affectedTests(ctx({ changedFiles: ['README.md'] }))).toBeNull();
+  });
+
+  it('affectedTests: jest --findRelatedTests with the file list last', () => {
+    installBin('jest');
+    const cmd = typescript.correctness!.affectedTests(ctx({ changedFiles: ['src/a.ts'] }));
+    expect(cmd).toEqual({
+      label: 'affected-tests',
+      bin: 'npx',
+      args: ['--no-install', 'jest', '--passWithNoTests', '--findRelatedTests', 'src/a.ts'],
+    });
+  });
+
+  it('affectedTests: prefers vitest over jest when both installed', () => {
+    installBin('vitest');
+    installBin('jest');
+    const cmd = typescript.correctness!.affectedTests(ctx());
+    expect(cmd?.args).toContain('vitest');
+  });
+
+  it('affectedTests: skips (fail-open) when no runner is installed', () => {
+    expect(typescript.correctness!.affectedTests(ctx())).toBeNull();
+  });
+});

--- a/test/loop-floor-state.test.ts
+++ b/test/loop-floor-state.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the correctness-floor entry-snapshot ledger (src/loop/floor-state.ts).
+ * Verifies the net-new diff: a green base blocks every failure; a red base
+ * grandfathers only the checks it was already failing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  writeFloorBaseline,
+  readFloorBaseline,
+  clearFloorBaseline,
+  netNewFloorFailures,
+  checkKey,
+  FLOOR_BASELINE_FILE,
+} from '../src/loop/floor-state';
+import type {
+  CorrectnessCheckResult,
+  CorrectnessFloorResult,
+} from '../src/analyzers/correctness/run';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-floor-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function check(
+  pack: string,
+  label: string,
+  status: CorrectnessCheckResult['status'],
+): CorrectnessCheckResult {
+  return { pack: pack as CorrectnessCheckResult['pack'], label, bin: 'x', status };
+}
+
+function floor(checks: CorrectnessCheckResult[]): CorrectnessFloorResult {
+  return {
+    ran: checks.some((c) => c.status === 'pass' || c.status === 'fail'),
+    checks,
+    blocks: checks.some((c) => c.status === 'fail'),
+  };
+}
+
+describe('floor-state entry snapshot', () => {
+  it('round-trips a snapshot, recording only pass/fail (skips omitted)', () => {
+    writeFloorBaseline(
+      tmp,
+      floor([
+        check('typescript', 'typecheck', 'pass'),
+        check('typescript', 'affected-tests', 'fail'),
+        check('go', 'build', 'skipped-unavailable'),
+      ]),
+      'abc123',
+    );
+    const b = readFloorBaseline(tmp);
+    expect(b?.capturedAtCommit).toBe('abc123');
+    expect(b?.checks).toEqual([
+      { pack: 'typescript', label: 'typecheck', status: 'pass' },
+      { pack: 'typescript', label: 'affected-tests', status: 'fail' },
+    ]);
+  });
+
+  it('writes to .dxkit/loop/floor-baseline.json', () => {
+    writeFloorBaseline(tmp, floor([check('typescript', 'typecheck', 'pass')]), null);
+    expect(fs.existsSync(path.join(tmp, '.dxkit', 'loop', FLOOR_BASELINE_FILE))).toBe(true);
+  });
+
+  it('green base: every current failure is net-new', () => {
+    writeFloorBaseline(
+      tmp,
+      floor([
+        check('typescript', 'typecheck', 'pass'),
+        check('typescript', 'affected-tests', 'pass'),
+      ]),
+      null,
+    );
+    const b = readFloorBaseline(tmp);
+    const netNew = netNewFloorFailures(floor([check('typescript', 'typecheck', 'fail')]), b);
+    expect(netNew.map((c) => c.label)).toEqual(['typecheck']);
+  });
+
+  it('red base: a pre-existing failing check is grandfathered', () => {
+    writeFloorBaseline(tmp, floor([check('typescript', 'affected-tests', 'fail')]), null);
+    const b = readFloorBaseline(tmp);
+    // Same check still failing → pre-existing, not net-new.
+    const netNew = netNewFloorFailures(floor([check('typescript', 'affected-tests', 'fail')]), b);
+    expect(netNew).toHaveLength(0);
+  });
+
+  it('red base: a DIFFERENT check failing is still net-new', () => {
+    writeFloorBaseline(tmp, floor([check('typescript', 'affected-tests', 'fail')]), null);
+    const b = readFloorBaseline(tmp);
+    const netNew = netNewFloorFailures(
+      floor([
+        check('typescript', 'affected-tests', 'fail'), // pre-existing
+        check('typescript', 'typecheck', 'fail'), // net-new
+      ]),
+      b,
+    );
+    expect(netNew.map((c) => checkKey(c.pack, c.label))).toEqual(['typescript:typecheck']);
+  });
+
+  it('absent baseline is treated as a green base (all failures net-new)', () => {
+    const netNew = netNewFloorFailures(
+      floor([check('typescript', 'typecheck', 'fail')]),
+      readFloorBaseline(tmp), // null — never captured
+    );
+    expect(netNew).toHaveLength(1);
+  });
+
+  it('malformed baseline reads as null (→ green base)', () => {
+    const dir = path.join(tmp, '.dxkit', 'loop');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, FLOOR_BASELINE_FILE), 'not json');
+    expect(readFloorBaseline(tmp)).toBeNull();
+  });
+
+  it('clearFloorBaseline removes the snapshot', () => {
+    writeFloorBaseline(tmp, floor([check('typescript', 'typecheck', 'pass')]), null);
+    clearFloorBaseline(tmp);
+    expect(readFloorBaseline(tmp)).toBeNull();
+  });
+});

--- a/test/loop/stop-gate.test.ts
+++ b/test/loop/stop-gate.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import {
-  computeStopGate,
-  buildRepairMessage,
-  buildFloorRepairMessage,
-  type FloorGateOutcome,
-} from '../../src/loop/stop-gate';
+import { computeStopGate, buildRepairMessage } from '../../src/loop/stop-gate';
+import { buildFloorRepairMessage, type FloorGateOutcome } from '../../src/loop/floor-gate';
 import type { GuardrailJsonPayload } from '../../src/baseline/check-renderers';
 import type { CorrectnessCheckResult } from '../../src/analyzers/correctness/run';
 

--- a/test/loop/stop-gate.test.ts
+++ b/test/loop/stop-gate.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { computeStopGate, buildRepairMessage } from '../../src/loop/stop-gate';
+import {
+  computeStopGate,
+  buildRepairMessage,
+  buildFloorRepairMessage,
+  type FloorGateOutcome,
+} from '../../src/loop/stop-gate';
 import type { GuardrailJsonPayload } from '../../src/baseline/check-renderers';
+import type { CorrectnessCheckResult } from '../../src/analyzers/correctness/run';
 
 /**
  * The Stop-gate decides whether an autonomous loop may declare "done".
@@ -127,6 +133,110 @@ describe('computeStopGate', () => {
       expect(d.outcome).toBe('allow');
       expect(d.event.tests_status).toBe('pass');
     });
+  });
+
+  describe('correctness floor', () => {
+    const failCheck = (label: string): CorrectnessCheckResult => ({
+      pack: 'typescript',
+      label,
+      bin: 'npx',
+      status: 'fail',
+      output: 'error TS2322: not assignable',
+    });
+    const passCheck = (label: string): CorrectnessCheckResult => ({
+      pack: 'typescript',
+      label,
+      bin: 'npx',
+      status: 'pass',
+    });
+    const floor = (
+      checks: CorrectnessCheckResult[],
+      netNew: CorrectnessCheckResult[],
+    ): FloorGateOutcome => ({
+      result: {
+        ran: checks.some((c) => c.status === 'pass' || c.status === 'fail'),
+        checks,
+        blocks: checks.some((c) => c.status === 'fail'),
+      },
+      netNew,
+    });
+
+    it('blocks the model on a net-new floor failure with a repair message', async () => {
+      const tc = failCheck('typecheck');
+      const d = await computeStopGate(
+        '/repo',
+        { session_id: 's' },
+        async () => payload([]),
+        () => floor([tc], [tc]),
+      );
+      expect(d.outcome).toBe('block-model');
+      expect(d.event.guardrail_status).toBe('pass');
+      expect(d.event.typecheck_status).toBe('fail');
+      expect(d.message).toContain('typescript typecheck');
+      expect(d.message).toContain('Do not refresh the floor snapshot');
+      expect(d.message).toContain('TS2322');
+    });
+
+    it('does NOT block on a pre-existing floor failure (empty net-new)', async () => {
+      const tc = failCheck('affected-tests');
+      const d = await computeStopGate(
+        '/repo',
+        { session_id: 's' },
+        async () => payload([]),
+        () => floor([tc], []), // failing, but net-new is empty → grandfathered
+      );
+      expect(d.outcome).toBe('allow');
+    });
+
+    it('records floor pass status on a clean stop', async () => {
+      const d = await computeStopGate(
+        '/repo',
+        { session_id: 's' },
+        async () => payload([]),
+        () => floor([passCheck('typecheck'), passCheck('affected-tests')], []),
+      );
+      expect(d.outcome).toBe('allow');
+      expect(d.event.typecheck_status).toBe('pass');
+      expect(d.event.tests_status).toBe('pass');
+    });
+
+    it('is a no-op when no pack provides a floor (null)', async () => {
+      const d = await computeStopGate(
+        '/repo',
+        { session_id: 's' },
+        async () => payload([]),
+        () => null,
+      );
+      expect(d.outcome).toBe('allow');
+    });
+
+    it('does not consult the floor when the guardrail already blocks', async () => {
+      let floorCalled = false;
+      const d = await computeStopGate(
+        '/repo',
+        { session_id: 's' },
+        async () => payload([blockingPair()]),
+        () => {
+          floorCalled = true;
+          return null;
+        },
+      );
+      expect(d.outcome).toBe('block-model'); // guardrail block, not floor
+      expect(floorCalled).toBe(false);
+    });
+  });
+});
+
+describe('buildFloorRepairMessage', () => {
+  it('numbers each net-new failing check with its captured output', () => {
+    const msg = buildFloorRepairMessage([
+      { pack: 'typescript', label: 'typecheck', bin: 'npx', status: 'fail', output: 'error TS1005' },
+      { pack: 'go', label: 'build', bin: 'go', status: 'fail', output: 'undefined: Foo' },
+    ]);
+    expect(msg).toContain('introduces 2 net-new correctness failures');
+    expect(msg).toContain('1. typescript typecheck');
+    expect(msg).toContain('TS1005');
+    expect(msg).toContain('2. go build');
   });
 });
 

--- a/test/loop/stop-gate.test.ts
+++ b/test/loop/stop-gate.test.ts
@@ -230,7 +230,13 @@ describe('computeStopGate', () => {
 describe('buildFloorRepairMessage', () => {
   it('numbers each net-new failing check with its captured output', () => {
     const msg = buildFloorRepairMessage([
-      { pack: 'typescript', label: 'typecheck', bin: 'npx', status: 'fail', output: 'error TS1005' },
+      {
+        pack: 'typescript',
+        label: 'typecheck',
+        bin: 'npx',
+        status: 'fail',
+        output: 'error TS1005',
+      },
       { pack: 'go', label: 'build', bin: 'go', status: 'fail', output: 'undefined: Foo' },
     ]);
     expect(msg).toContain('introduces 2 net-new correctness failures');

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -55,11 +55,13 @@ import {
   allTlsBypassPatterns,
   activeLanguagesFromFlags,
   activeLanguagesFromStack,
+  activeCorrectnessProviders,
   buildDevcontainerExtensions,
   buildDevcontainerFeatures,
   detectActiveLanguages,
   dominantVocabulary,
 } from '../src/languages';
+import { runCorrectnessFloor } from '../src/analyzers/correctness/run';
 import { buildVariables, buildConditions } from '../src/constants';
 import { buildRequiredTools } from '../src/analyzers/tools/tool-registry';
 import { detect } from '../src/detect';
@@ -123,6 +125,14 @@ const mockPlaybookPack = {
   // `changedFilesTouchFlowSurface` — codifying "the flow-gate trigger is
   // pack-driven, not a hardcoded extension list."
   treeSitterGrammars: { '.pbk': 'playbook-lang' },
+  // Correctness-floor contribution (2.23). Distinctive bin/labels so the
+  // assertion verifies the synthetic pack's provider flows through
+  // `activeCorrectnessProviders` + `runCorrectnessFloor` — codifying "the
+  // liveness floor is pack-driven, not analyzer-by-analyzer."
+  correctness: {
+    syntaxCheck: () => ({ label: 'playbook-typecheck', bin: 'playbookc-mock', args: ['--check'] }),
+    affectedTests: () => ({ label: 'playbook-tests', bin: 'playbookc-mock', args: ['test'] }),
+  },
   detect: vi.fn(() => false),
   tools: [],
   semgrepRulesets: [],
@@ -265,6 +275,31 @@ describe('recipe playbook — synthetic pack', () => {
     expect(changedFilesTouchDependencyManifest(['app/My.pbkproj'], packs)).toBe(true);
     // A pure source-only change is NOT flagged → the dep audit may be skipped.
     expect(changedFilesTouchDependencyManifest(['src/main.pbk', 'README.md'], packs)).toBe(false);
+  });
+
+  // 2.23: the correctness floor iterates `activeCorrectnessProviders`, so a
+  // synthetic pack that declares a `correctness` provider must be picked up by
+  // the registry helper AND surface its checks through `runCorrectnessFloor` —
+  // codifying "the liveness floor is pack-driven, not analyzer-by-analyzer."
+  // Catches "the runner stopped iterating the registry" empirically.
+  it('activeCorrectnessProviders + runCorrectnessFloor pick up the mock pack (2.23)', () => {
+    const packs = [...LANGUAGES];
+    const providers = activeCorrectnessProviders(packs);
+    expect(providers.some((p) => (p.id as string) === 'playbook')).toBe(true);
+    // The runner emits the synthetic pack's checks. Exec is injected, so no
+    // real toolchain runs — this proves dispatch, not execution.
+    const result = runCorrectnessFloor({
+      cwd: '/nonexistent-repo',
+      changedFiles: ['a.pbk'],
+      scope: 'affected',
+      packs,
+      exec: () => ({ available: true, code: 0, output: '' }),
+    });
+    const playbookChecks = result.checks
+      .filter((c) => (c.pack as string) === 'playbook')
+      .map((c) => c.label);
+    expect(playbookChecks).toContain('playbook-typecheck');
+    expect(playbookChecks).toContain('playbook-tests');
   });
 
   // 2.7 Sprint 1: exported-symbol detection registry helper iterates


### PR DESCRIPTION
## The correctness floor — 2.23.0

The guardrail proves "no net-new **findings**" (secrets, CVEs, SAST, coverage). It does not prove the code still **compiles and its affected tests still pass** — so an autonomous agent loop can satisfy the finding gate while shipping code that does not build, and even a broken test that lifts coverage gets rewarded. This PR closes that gap with a **liveness gate** that runs before an agent may declare "done".

A failing floor is a pass/fail **signal**, not a fingerprinted, grandfathered finding (there is no "grandfather a syntax error"), so it sits outside the baseline and allowlist.

### Design (CLAUDE.md Rule 15)

- **Pack-declared, runner-executed.** Each pack declares two pure command builders — `syntaxCheck` + `affectedTests`; one runner owns the policy in a single place: **fail-CLOSED** on a real failure, **fail-OPEN** on infrastructure (missing toolchain / timeout → skip; CI is the backstop). A pack never shells out itself.
- **`correctness` is now a required field** — a new pack that omits it fails to compile (not just at test time). The scaffold wires a dormant provider so a fresh pack still compiles.

### All 8 packs, verified against real toolchains

| Pack | Compile | Affected granularity |
| --- | --- | --- |
| TS / JS | `tsc --noEmit` | per-file (`vitest related` / `jest --findRelatedTests`) |
| Python | `py_compile` | per changed test file (pytest) |
| Go | `go build ./...` | changed package(s) |
| Rust | `cargo check` | changed crate(s) (`-p`) |
| C# | `dotnet build` | changed test project |
| Java | Maven `test-compile` / Gradle `testClasses` | changed build module (`-pl -am` / `:mod:test`) |
| Kotlin | Maven / Gradle (shared `jvm-build.ts`) | changed build module |
| Ruby | `ruby -c` per file | changed spec/test file |

Each pack was run through a 4-scenario matrix against a real toolchain (clean pass, syntax-error block, failing-test block, affected-selection narrows).

### Three surfaces, one adaptive resolver

- **loop Stop-gate** — default-on; blocks only on failures net-new vs a testmon-style entry snapshot (a pre-existing failure never blocks).
- **pre-push** — affected scope vs the merge-base; runs even with no baseline (greenfield gets push-time liveness).
- **ci** — full scope.

pre-push/ci are **adaptive**: opt-in when the repo already runs tests in its own CI, default-on when no test-CI is detected, fail-toward-on when uncertain. Precedence: flag → `DXKIT_FLOOR_<SURFACE>` env → `.dxkit/policy.json correctness.surfaces` → adaptive default.

New CLI: `vyuh-dxkit floor check [--surface pre-push|ci] [--base <ref>] [--correctness|--no-correctness]`, wired into the installed pre-push hook and the CI guardrail workflow.

### Recipe enforcement
Arch rule + contract test + recipe-playbook synthetic-pack injection, plus the scaffold stub — a new language can't half-add the floor silently.

Full suite green (2843 tests); new surface/surface-run unit tests; JVM packs real-toolchain verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)