### PR TITLE
feat: vyuh-dxkit uninstall (restore the pre-dxkit state) — 2.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.0] - 2026-07-04
+
+### Added — `vyuh-dxkit uninstall` (restore the pre-dxkit state)
+
+A clean, non-intrusive way to remove dxkit. Its one guarantee: after uninstall,
+the repo is back to its **exact pre-dxkit state** — every file dxkit created is
+gone, and every additive change dxkit made to a file you already had is reversed,
+leaving your own content byte-for-byte intact.
+
+- **Two kinds of footprint, handled differently.** Files dxkit created (`.dxkit/`,
+  the `dxkit-*` skills, `AGENTS.md`, the git hooks, the `dxkit-*` workflows,
+  `.dxkit-ignore`, `.vyuh-dxkit.json`) are removed. Additive merges into files you
+  already had — the `.gitignore` block, the `CLAUDE.md` loop block, the
+  `settings.json` hooks (`context-hook` / `stop-gate`), and the `package.json`
+  `@vyuhlabs/dxkit` devDependency + postinstall — are surgically reverted, keeping
+  your keys, prose, and formatting. JSON reverts preserve the file's original
+  indent + trailing-newline so there is no spurious diff.
+- **Manifest-driven + hash-guarded.** It reads the install manifest
+  (`.vyuh-dxkit.json`) for the authoritative created-file list, flags, and hashes.
+  A dxkit-created file you have since edited is surfaced and **skipped** (never
+  clobbered) unless you pass `--force`; the manifest is kept in that case so a
+  later `--force` run can still find it.
+- **`vyuh-dxkit uninstall [path] [--yes] [--keep-baselines] [--remove-devdep]
+  [--force] [--no-feedback] [--json]`** — dry-run by default (prints exactly what
+  it will remove/revert); `--yes` applies. `--keep-baselines` keeps the curated,
+  git-tracked artifacts (baselines, allowlist, `external/`). On completion it
+  offers a prefilled GitHub issue for optional feedback — nothing is sent
+  automatically, and `--no-feedback` skips it.
+- **`dxkit-uninstall` skill** — the graceful-exit surface for an agent.
+
+The reversal markers are imported from the installer modules, so a marker change
+breaks install and uninstall together (recipe symmetry); a test asserts every
+install surface and all four self-invocation surfaces have a removal path.
+
 ## [2.23.0] - 2026-07-04
 
 ### Added — the correctness floor (a loop-safety liveness gate)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -203,16 +203,18 @@ blocks, and there is no baseline artifact to maintain).
       unless a test-CI is already detected; fail toward on when uncertain).
 - [ ] Pre-push (merge-base) and CI (full-scope) floor wiring.
 
-### Uninstall / clean removal (pre-3.0)
+### Uninstall / clean removal (2.24.0)
 
-- [ ] `vyuh-dxkit uninstall` + a `dxkit-uninstall` skill that non-intrusively
+- [x] `vyuh-dxkit uninstall` + a `dxkit-uninstall` skill that non-intrusively
       removes the full dxkit footprint (`.dxkit/`, installed skills and hooks,
       the git pre-push guardrail, the CI workflow, and the additive blocks dxkit
-      merged into `settings.json` / `CLAUDE.md` / `.gitignore`) by reversing each
-      installer, never a blanket wipe and never touching user code. Dry-run by
-      default with confirmation; deletes only dxkit-authored files. On removal it
-      offers to open a prefilled GitHub issue for feedback via the existing
-      `vyuh-dxkit issue` path, so nothing is ever sent without the user's action.
+      merged into `settings.json` / `CLAUDE.md` / `.gitignore` / `package.json`)
+      by reversing each installer, restoring the exact pre-dxkit state — never a
+      blanket wipe and never touching user content. Dry-run by default with
+      confirmation; manifest-driven and hash-guarded (an edited dxkit file is
+      skipped, not clobbered). On removal it offers to open a prefilled GitHub
+      issue for feedback via the existing `vyuh-dxkit issue` path, so nothing is
+      ever sent without the user's action.
 
 ## Future
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.23.0",
+      "version": "2.24.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.claude/skills/dxkit-uninstall/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-uninstall/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: dxkit-uninstall
+description: Cleanly and non-intrusively remove dxkit from a repo, restoring its exact pre-dxkit state — reverse every additive merge (settings.json, CLAUDE.md, .gitignore, package.json), delete every file dxkit created, and clean up hooks + CI + the .dxkit/ tree. Dry-run first. Use when the user says "remove dxkit", "uninstall dxkit", "get rid of dxkit", "clean up dxkit from this repo", "how do I undo dxkit init", or wants to stop using dxkit.
+---
+
+# dxkit-uninstall
+
+This skill owns **removing dxkit** from a repo. Its one guarantee: after uninstall, the repo is back to its **exact pre-dxkit state** — every file dxkit created is gone, and every additive change dxkit made to a file you already had is reversed, leaving your own content byte-for-byte intact.
+
+## What it removes vs reverts
+
+dxkit's footprint falls into two kinds, handled differently:
+
+- **Files dxkit created** (they didn't exist before): `.dxkit/`, the `dxkit-*` skills under `.claude/`, `AGENTS.md`, the git hooks in `.githooks/`, the `dxkit-*` GitHub workflows, `.dxkit-ignore`, and `.vyuh-dxkit.json`. These are **removed** outright.
+- **Additive merges into files you already had**: the `.gitignore` runtime-output block, the `CLAUDE.md` loop block (between `<!-- dxkit:loop:start -->` / `end -->`), the `.claude/settings.json` hooks (`context-hook` / `stop-gate`), and the `package.json` `@vyuhlabs/dxkit` devDependency + postinstall. These are **surgically reverted** — only dxkit's additions are stripped; your keys, prose, and formatting are preserved.
+
+It knows exactly what is dxkit's because `init` recorded a manifest (`.vyuh-dxkit.json`) with a hash of every created file. A dxkit-created file you have since **edited** is surfaced and **skipped** (not clobbered) unless you pass `--force`.
+
+## How to run it
+
+```bash
+# 1. Dry run FIRST (default) — prints exactly what will be removed/reverted,
+#    changes nothing.
+npx vyuh-dxkit uninstall
+
+# 2. Apply it.
+npx vyuh-dxkit uninstall --yes
+```
+
+Useful flags:
+
+- `--remove-devdep` — also remove the `@vyuhlabs/dxkit` devDependency + postinstall from `package.json` (kept by default so a lockfile install doesn't break mid-cleanup; run `npm install` afterward if you use it).
+- `--keep-baselines` — keep the curated, git-tracked artifacts (`.dxkit/baselines/`, the allowlist, `.dxkit/external/`) and remove only the runtime state. Use this if you want to pause dxkit but keep your grandfathered debt inventory.
+- `--force` — also remove dxkit-created files you have edited (default: skip + warn).
+- `--no-feedback` — skip the feedback prompt.
+- `--json` — machine-readable plan/result.
+
+## Verifying the restore
+
+On a git repo, the definitive check is that the working tree returns to clean:
+
+```bash
+git status        # after `uninstall --yes`, dxkit's changes are gone
+```
+
+If you had committed dxkit's files (baselines, workflows), those show as deletions to commit — that is expected; uninstall only edits the working tree, never git history.
+
+## The feedback prompt (optional, opt-in)
+
+On completion, the CLI prints a **prefilled GitHub issue URL** and invites you to share why you're removing dxkit. Nothing is sent automatically — it is a link you choose to open; there is no telemetry. Skip it with `--no-feedback`. If the user wants to leave feedback, open the URL it printed (or run `npx vyuh-dxkit issue --type=uninstall --about="…"`).
+
+## What NOT to do
+
+- Do **not** hand-delete `.dxkit/` and the workflows and call it done — that leaves the additive merges (settings.json hooks, CLAUDE.md block, .gitignore entries, package.json devDep) behind. Use `uninstall`, which reverses those too.
+- Do **not** run `--force` reflexively — the skip-and-warn on edited files is there so you don't lose work you put into a dxkit-created file. Review the warnings first.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -378,6 +378,9 @@ export async function run(argv: string[]): Promise<void> {
       surface: { type: 'string' },
       correctness: { type: 'boolean' },
       'no-correctness': { type: 'boolean' },
+      'keep-baselines': { type: 'boolean', default: false },
+      'remove-devdep': { type: 'boolean', default: false },
+      'no-feedback': { type: 'boolean', default: false },
       'soon-days': { type: 'string' },
       'against-baseline': { type: 'boolean', default: false },
       'baseline-name': { type: 'string' },
@@ -2140,6 +2143,84 @@ export async function run(argv: string[]): Promise<void> {
         logger.fail((err as Error).message);
         process.exit(1);
       }
+      break;
+    }
+
+    case 'uninstall': {
+      const targetPath = resolveRepoPath(positionals[1]);
+      const { planUninstall, executeUninstall } = await import('./uninstall');
+      const opts = {
+        keepBaselines: !!values['keep-baselines'],
+        removeDevDependency: !!values['remove-devdep'],
+        force: !!values.force,
+      };
+      const plan = planUninstall(targetPath, opts);
+
+      if (values.json) {
+        await emitJson({ empty: plan.empty, warnings: plan.warnings, actions: plan.actions });
+        process.exit(0);
+      }
+
+      logger.header('vyuh-dxkit uninstall');
+      if (plan.empty) {
+        logger.info('No dxkit footprint found in this repo — nothing to remove.');
+        process.exit(0);
+      }
+
+      const active = plan.actions.filter((a) => a.status === 'pending');
+      logger.info(`Will restore the pre-dxkit state by ${active.length} change(s):`);
+      for (const a of active) {
+        const verb = a.kind.startsWith('revert')
+          ? 'revert'
+          : a.kind === 'git-config-unset'
+            ? 'unset'
+            : 'remove';
+        process.stdout.write(`  ${verb.padEnd(6)} ${a.target}  (${a.detail})\n`);
+      }
+      for (const w of plan.warnings) logger.warn(w);
+      if (!opts.removeDevDependency) {
+        logger.dim(
+          '  (package.json @vyuhlabs/dxkit devDependency kept — pass --remove-devdep to remove it)',
+        );
+      }
+
+      if (!values.yes) {
+        logger.info('');
+        logger.info(
+          `Dry run — nothing changed. Re-run with ${dxkitCli('uninstall --yes')} to apply.`,
+        );
+        process.exit(0);
+      }
+
+      const result = executeUninstall(targetPath, plan, opts);
+      logger.success(
+        `Removed ${result.removed.length}, reverted ${result.reverted.length}` +
+          (result.skipped.length
+            ? `, skipped ${result.skipped.length} (edited — use --force)`
+            : '') +
+          '. dxkit has been uninstalled.',
+      );
+
+      // Optional, skippable feedback — a prefilled GitHub issue the user opens
+      // themselves (no telemetry, no auto-submit).
+      if (!values['no-feedback']) {
+        const { buildIssueUrl, readDxkitVersion } = await import('./issue-cli');
+        const url = buildIssueUrl({
+          type: 'uninstall',
+          about: '',
+          dxkitVersion: readDxkitVersion(),
+          nodeVersion: process.version,
+          platform: process.platform,
+          arch: process.arch,
+        });
+        logger.info('');
+        logger.info(
+          'Mind sharing why? It genuinely helps. Open a prefilled issue (nothing is sent automatically):',
+        );
+        logger.dim(`  ${url}`);
+        logger.dim('  (skip with --no-feedback)');
+      }
+      process.exit(0);
       break;
     }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -164,6 +164,11 @@ const DXKIT_SKILLS = [
   // broken integration the guardrail flagged (never suppresses it),
   // and the handshake mode drives `flow publish` for cross-repo meshes.
   'dxkit-flow',
+  // dxkit-uninstall: cleanly remove all of dxkit from a repo, restoring the
+  // pre-dxkit state (reverse each additive merge, delete created files),
+  // dry-run first. Also captures optional, opt-in feedback via a prefilled
+  // GitHub issue. The graceful-exit surface.
+  'dxkit-uninstall',
 ] as const;
 
 interface GenerateResult {

--- a/src/issue-cli.ts
+++ b/src/issue-cli.ts
@@ -44,6 +44,7 @@ export const ISSUE_TYPES = [
   'bug',
   'feature-request',
   'docs',
+  'uninstall',
 ] as const;
 export type IssueType = (typeof ISSUE_TYPES)[number];
 
@@ -56,6 +57,7 @@ const LABEL_BY_TYPE: Readonly<Record<IssueType, string>> = Object.freeze({
   bug: 'bug',
   'feature-request': 'enhancement',
   docs: 'documentation',
+  uninstall: 'uninstall-feedback',
 });
 
 /** Per-type title prefix surfaced in the GitHub Issues list. */
@@ -65,6 +67,7 @@ const TITLE_PREFIX_BY_TYPE: Readonly<Record<IssueType, string>> = Object.freeze(
   bug: 'Bug',
   'feature-request': 'Feature request',
   docs: 'Docs',
+  uninstall: 'Uninstall feedback',
 });
 
 const ISSUES_BASE_URL = 'https://github.com/vyuh-labs/dxkit/issues/new';
@@ -183,7 +186,7 @@ function buildBody(input: BuildIssueUrlInput): string {
   return lines.join('\n');
 }
 
-function readDxkitVersion(): string {
+export function readDxkitVersion(): string {
   try {
     // Two possible locations: same package as this module (dev / source)
     // and `node_modules/@vyuhlabs/dxkit/package.json` (installed).

--- a/src/loop/scaffold.ts
+++ b/src/loop/scaffold.ts
@@ -38,8 +38,8 @@ export const STOP_HOOK_TIMEOUT_SECONDS = 600;
 
 /** Sentinel markers bounding the dxkit-managed region of CLAUDE.md. Only
  *  the text between them is ever rewritten. */
-const CLAUDE_BLOCK_START = '<!-- dxkit:loop:start -->';
-const CLAUDE_BLOCK_END = '<!-- dxkit:loop:end -->';
+export const CLAUDE_BLOCK_START = '<!-- dxkit:loop:start -->';
+export const CLAUDE_BLOCK_END = '<!-- dxkit:loop:end -->';
 
 /** Preset-agnostic loop norm. Points at `.dxkit/policy.json` as the
  *  source of truth for the active posture, so this prose stays correct

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -435,8 +435,8 @@ export function installPrReview(cwd: string, opts: InstallerOpts = {}): ShipInst
   return result;
 }
 
-const GITIGNORE_HEADER = '# dxkit — runtime outputs (analyzer reports + dashboard)';
-const GITIGNORE_ENTRIES = [
+export const GITIGNORE_HEADER = '# dxkit — runtime outputs (analyzer reports + dashboard)';
+export const GITIGNORE_ENTRIES = [
   '.dxkit/reports/',
   '.dxkit/dashboard.html',
   '.dxkit/cache/',
@@ -518,7 +518,7 @@ export function installIgnoreFiles(cwd: string, opts: InstallerOpts = {}): ShipI
  *     and emit a note asking the consumer to chain. Auto-chaining
  *     risks breaking their existing script's exit-code semantics.
  */
-const POSTINSTALL_CMD = 'vyuh-dxkit hooks activate';
+export const POSTINSTALL_CMD = 'vyuh-dxkit hooks activate';
 
 export function installHooksPostinstall(cwd: string, _opts: InstallerOpts = {}): ShipInstallResult {
   const result = emptyResult();
@@ -587,7 +587,7 @@ export function installHooksPostinstall(cwd: string, _opts: InstallerOpts = {}):
   return result;
 }
 
-const DXKIT_PACKAGE = '@vyuhlabs/dxkit';
+export const DXKIT_PACKAGE = '@vyuhlabs/dxkit';
 
 /**
  * Ensure `@vyuhlabs/dxkit` is in the consumer's package.json

--- a/src/uninstall/index.ts
+++ b/src/uninstall/index.ts
@@ -256,13 +256,18 @@ export function planUninstall(cwd: string, opts: UninstallOptions = {}): Uninsta
     });
   }
 
-  // 6. The manifest itself — always last.
+  // 6. The manifest itself — always last, and only when nothing was skipped.
+  //    If we skipped a user-edited dxkit file, keep the manifest so a later
+  //    `uninstall --force` can still find and remove it.
   if (exists(cwd, '.vyuh-dxkit.json')) {
+    const hasSkips = actions.some((a) => a.status === 'skip-modified');
     actions.push({
       kind: 'delete-file',
       target: '.vyuh-dxkit.json',
-      detail: 'the dxkit install manifest',
-      status: 'pending',
+      detail: hasSkips
+        ? 'the dxkit install manifest (kept — edited files were skipped)'
+        : 'the dxkit install manifest',
+      status: hasSkips ? 'skip-modified' : 'pending',
     });
   }
 

--- a/src/uninstall/index.ts
+++ b/src/uninstall/index.ts
@@ -1,0 +1,430 @@
+/**
+ * The uninstall engine — plan (pure, read-only) then execute. Its one job is to
+ * restore the repo's PRE-DXKIT state: remove every file dxkit created, and
+ * surgically reverse every additive merge dxkit made into a pre-existing user
+ * file, without touching a byte the user owns.
+ *
+ * `planUninstall` reads the manifest (`.vyuh-dxkit.json`) + the install flags and
+ * builds an ordered action list, marking any dxkit-created file the user has
+ * since edited as `skip-modified` (surfaced, never clobbered). `executeUninstall`
+ * applies a plan. The CLI wraps them with dry-run-by-default + confirmation.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+import { sha256 } from '../files';
+import { detectInstallFlags, type InstallFlags } from '../update';
+import { ALLOWLIST_FILENAME, ALLOWLIST_REASONS_FILENAME } from '../allowlist/file';
+import type { Manifest } from '../types';
+import {
+  stripAllGitignoreBlocks,
+  stripClaudeLoopBlock,
+  stripSettingsDxkit,
+  stripPackageJsonDxkit,
+} from './reversals';
+
+export type ActionKind =
+  | 'delete-file'
+  | 'delete-dir'
+  | 'revert-gitignore'
+  | 'revert-claude'
+  | 'revert-settings'
+  | 'revert-package'
+  | 'git-config-unset';
+
+export type ActionStatus = 'pending' | 'absent' | 'skip-modified';
+
+export interface UninstallAction {
+  readonly kind: ActionKind;
+  /** Repo-relative path, or a symbolic target (`core.hooksPath`). */
+  readonly target: string;
+  readonly detail: string;
+  readonly status: ActionStatus;
+}
+
+export interface UninstallPlan {
+  readonly actions: readonly UninstallAction[];
+  /** dxkit-created files the user edited — reported, skipped by default. */
+  readonly warnings: readonly string[];
+  readonly flags: InstallFlags;
+  /** True when nothing dxkit-related was found at all. */
+  readonly empty: boolean;
+}
+
+export interface UninstallOptions {
+  /** Keep the curated, git-tracked artifacts (baselines/, allowlist, external/). */
+  readonly keepBaselines?: boolean;
+  /** Remove the @vyuhlabs/dxkit devDependency + postinstall from package.json. */
+  readonly removeDevDependency?: boolean;
+  /** Force-remove dxkit-created files the user edited (default: skip + warn). */
+  readonly force?: boolean;
+}
+
+/** Files dxkit MERGES into (reverted, not deleted) — never delete-file these. */
+const MERGE_TARGETS = new Set(['.gitignore', 'CLAUDE.md', '.claude/settings.json', 'package.json']);
+
+/** Curated, intentionally git-tracked `.dxkit/` paths kept under --keep-baselines. */
+const CURATED_DXKIT = ['baselines', ALLOWLIST_FILENAME, ALLOWLIST_REASONS_FILENAME, 'external'];
+
+function readManifest(cwd: string): Manifest | null {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(cwd, '.vyuh-dxkit.json'), 'utf-8')) as Manifest;
+  } catch {
+    return null;
+  }
+}
+
+function exists(cwd: string, rel: string): boolean {
+  return fs.existsSync(path.join(cwd, rel));
+}
+
+/** Ship-installer artifacts keyed by install flag (not in manifest.files — the
+ *  generator's `track()` covers only its own templates). */
+function gatedArtifacts(flags: InstallFlags): string[] {
+  const out: string[] = [];
+  if (flags.withHooks) out.push('.githooks/pre-push');
+  if (flags.withPrecommit) out.push('.githooks/pre-commit');
+  if (flags.withCiGuardrails) out.push('.github/workflows/dxkit-guardrails.yml');
+  if (flags.withBaselineRefresh) out.push('.github/workflows/dxkit-baseline-refresh.yml');
+  if (flags.withPrReview) out.push('.github/workflows/pr-review.yml');
+  // deep-sast refresh is opt-in and not tracked in installFlags — detect by file.
+  out.push('.github/workflows/dxkit-deep-sast-refresh.yml');
+  if (flags.withDevcontainer) {
+    out.push(
+      '.devcontainer/devcontainer.json',
+      '.devcontainer/post-create.sh',
+      '.devcontainer/install-agent-clis.sh',
+    );
+  }
+  out.push('.dxkit-ignore');
+  return out;
+}
+
+/** Build the ordered uninstall plan without touching the filesystem. */
+export function planUninstall(cwd: string, opts: UninstallOptions = {}): UninstallPlan {
+  const manifest = readManifest(cwd);
+  const flags = manifest?.installFlags ?? detectInstallFlags(cwd);
+  const actions: UninstallAction[] = [];
+  const warnings: string[] = [];
+
+  const del = (rel: string, detail: string, evolving = true, storedHash: string | null = null) => {
+    if (!exists(cwd, rel)) {
+      actions.push({ kind: 'delete-file', target: rel, detail, status: 'absent' });
+      return;
+    }
+    // Hash-guard non-evolving dxkit files: a mismatch means the user edited a
+    // dxkit-created file. Removing it still restores pre-dxkit state, but we
+    // surface it and skip unless --force.
+    if (!evolving && storedHash) {
+      let current = '';
+      try {
+        current = sha256(fs.readFileSync(path.join(cwd, rel), 'utf-8'));
+      } catch {
+        /* unreadable → treat as present */
+      }
+      if (current && current !== storedHash && !opts.force) {
+        warnings.push(`${rel} was edited after dxkit created it — skipped (use --force to remove)`);
+        actions.push({ kind: 'delete-file', target: rel, detail, status: 'skip-modified' });
+        return;
+      }
+    }
+    actions.push({ kind: 'delete-file', target: rel, detail, status: 'pending' });
+  };
+
+  // 1. Additive-merge reversals (surgical — preserve user content). No-op when
+  //    the marker is absent, so always safe to attempt.
+  if (exists(cwd, '.gitignore') && stripAllGitignoreBlocks(read(cwd, '.gitignore')).changed) {
+    actions.push({
+      kind: 'revert-gitignore',
+      target: '.gitignore',
+      detail: 'strip dxkit runtime-output entries',
+      status: 'pending',
+    });
+  }
+  if (exists(cwd, 'CLAUDE.md')) {
+    const claudeEntry = manifest?.files['CLAUDE.md'];
+    const current = read(cwd, 'CLAUDE.md');
+    const stripped = stripClaudeLoopBlock(current);
+    if (claudeEntry && claudeEntry.hash && sha256(stripped.content) === claudeEntry.hash) {
+      // dxkit created the whole file, and stripping dxkit's own loop block leaves
+      // exactly the recorded dxkit shim (no user edits) → remove the whole file
+      // (pre-dxkit state had no CLAUDE.md).
+      actions.push({
+        kind: 'delete-file',
+        target: 'CLAUDE.md',
+        detail: 'dxkit-created Claude config',
+        status: 'pending',
+      });
+    } else if (claudeEntry && stripped.changed) {
+      // dxkit created it but the user has since edited the shim → keep their
+      // version, remove only dxkit's loop block; surface that we kept the file.
+      actions.push({
+        kind: 'revert-claude',
+        target: 'CLAUDE.md',
+        detail: 'strip the dxkit loop block (keeping your edits)',
+        status: 'pending',
+      });
+      warnings.push(
+        'CLAUDE.md was created by dxkit but you edited it — kept your version, removed only the loop block',
+      );
+    } else if (!claudeEntry && stripped.changed) {
+      // The user's own pre-existing CLAUDE.md that dxkit only appended to.
+      actions.push({
+        kind: 'revert-claude',
+        target: 'CLAUDE.md',
+        detail: 'strip the dxkit loop block',
+        status: 'pending',
+      });
+    }
+  }
+  if (exists(cwd, '.claude/settings.json')) {
+    const parsed = tryJson(read(cwd, '.claude/settings.json'));
+    const dxkitCreated = !!manifest?.files['.claude/settings.json'];
+    if (parsed && stripSettingsDxkit(parsed, { dxkitCreated }).changed) {
+      actions.push({
+        kind: 'revert-settings',
+        target: '.claude/settings.json',
+        detail: 'remove dxkit hooks (context-hook / stop-gate)',
+        status: 'pending',
+      });
+    }
+  }
+  if (opts.removeDevDependency && exists(cwd, 'package.json')) {
+    const parsed = tryJson(read(cwd, 'package.json'));
+    if (parsed && stripPackageJsonDxkit(parsed).changed) {
+      actions.push({
+        kind: 'revert-package',
+        target: 'package.json',
+        detail: 'remove @vyuhlabs/dxkit devDependency + postinstall',
+        status: 'pending',
+      });
+    }
+  }
+
+  // 2. Delete generator-created files from the manifest (except merge targets).
+  for (const [rel, entry] of Object.entries(manifest?.files ?? {})) {
+    if (MERGE_TARGETS.has(rel)) continue;
+    del(rel, 'dxkit-created file', entry.evolving, entry.hash);
+  }
+
+  // 3. Delete gated ship-installer artifacts by flag / presence.
+  for (const rel of gatedArtifacts(flags)) {
+    if (exists(cwd, rel)) del(rel, 'dxkit-installed artifact');
+  }
+
+  // 4. Runtime trees.
+  if (exists(cwd, '.dxkit')) {
+    if (opts.keepBaselines) {
+      // Delete each top-level .dxkit entry except the curated ones.
+      for (const name of safeReaddir(path.join(cwd, '.dxkit'))) {
+        if (CURATED_DXKIT.includes(name)) continue;
+        const rel = `.dxkit/${name}`;
+        actions.push({
+          kind: statIsDir(cwd, rel) ? 'delete-dir' : 'delete-file',
+          target: rel,
+          detail: 'dxkit runtime output',
+          status: 'pending',
+        });
+      }
+    } else {
+      actions.push({
+        kind: 'delete-dir',
+        target: '.dxkit',
+        detail: 'all dxkit state (baselines, reports, loop, policy)',
+        status: 'pending',
+      });
+    }
+  }
+  if (exists(cwd, 'graphify-out')) {
+    actions.push({
+      kind: 'delete-dir',
+      target: 'graphify-out',
+      detail: 'graph analyzer output',
+      status: 'pending',
+    });
+  }
+
+  // 5. Unset the git hooksPath if dxkit pointed it at .githooks.
+  if (flags.withHooks && gitHooksPath(cwd) === '.githooks') {
+    actions.push({
+      kind: 'git-config-unset',
+      target: 'core.hooksPath',
+      detail: 'unset core.hooksPath (was .githooks)',
+      status: 'pending',
+    });
+  }
+
+  // 6. The manifest itself — always last.
+  if (exists(cwd, '.vyuh-dxkit.json')) {
+    actions.push({
+      kind: 'delete-file',
+      target: '.vyuh-dxkit.json',
+      detail: 'the dxkit install manifest',
+      status: 'pending',
+    });
+  }
+
+  const empty = actions.every((a) => a.status === 'absent');
+  return { actions, warnings, flags, empty };
+}
+
+export interface ExecuteResult {
+  readonly removed: readonly string[];
+  readonly reverted: readonly string[];
+  readonly skipped: readonly string[];
+}
+
+/** Apply a plan. Only `pending` actions run; `absent`/`skip-modified` are recorded. */
+export function executeUninstall(
+  cwd: string,
+  plan: UninstallPlan,
+  opts: UninstallOptions = {},
+): ExecuteResult {
+  const removed: string[] = [];
+  const reverted: string[] = [];
+  const skipped: string[] = [];
+
+  for (const a of plan.actions) {
+    if (a.status !== 'pending') {
+      if (a.status === 'skip-modified') skipped.push(a.target);
+      continue;
+    }
+    const abs = path.join(cwd, a.target);
+    switch (a.kind) {
+      case 'delete-file':
+        rm(abs);
+        pruneEmptyParents(cwd, abs);
+        removed.push(a.target);
+        break;
+      case 'delete-dir':
+        fs.rmSync(abs, { recursive: true, force: true });
+        pruneEmptyParents(cwd, abs);
+        removed.push(a.target);
+        break;
+      case 'revert-gitignore': {
+        const out = stripAllGitignoreBlocks(read(cwd, '.gitignore')).content;
+        if (out === '') rm(abs);
+        else fs.writeFileSync(abs, out, 'utf-8');
+        reverted.push(a.target);
+        break;
+      }
+      case 'revert-claude': {
+        const out = stripClaudeLoopBlock(read(cwd, 'CLAUDE.md')).content;
+        if (out === '') rm(abs);
+        else fs.writeFileSync(abs, out, 'utf-8');
+        reverted.push(a.target);
+        break;
+      }
+      case 'revert-settings': {
+        const original = read(cwd, '.claude/settings.json');
+        const parsed = tryJson(original)!;
+        const manifest = readManifest(cwd);
+        const dxkitCreated = !!manifest?.files['.claude/settings.json'];
+        const { result, isDxkitOnly } = stripSettingsDxkit(parsed, { dxkitCreated });
+        if (isDxkitOnly) {
+          rm(abs);
+          pruneEmptyParents(cwd, abs);
+        } else {
+          fs.writeFileSync(abs, serializePreserving(original, result), 'utf-8');
+        }
+        reverted.push(a.target);
+        break;
+      }
+      case 'revert-package': {
+        const original = read(cwd, 'package.json');
+        const { result } = stripPackageJsonDxkit(tryJson(original)!);
+        // Preserve the file's original indent + trailing-newline style so the
+        // reverted file is byte-identical to its pre-dxkit content (git-clean).
+        fs.writeFileSync(abs, serializePreserving(original, result), 'utf-8');
+        reverted.push(a.target);
+        break;
+      }
+      case 'git-config-unset':
+        try {
+          execFileSync('git', ['config', '--unset', 'core.hooksPath'], { cwd, stdio: 'ignore' });
+        } catch {
+          /* best-effort */
+        }
+        reverted.push(a.target);
+        break;
+    }
+  }
+  void opts;
+  return { removed, reverted, skipped };
+}
+
+// ─── small fs helpers ───────────────────────────────────────────────────────
+
+function read(cwd: string, rel: string): string {
+  return fs.readFileSync(path.join(cwd, rel), 'utf-8');
+}
+/** Re-serialize `obj` matching `original`'s indentation and trailing-newline
+ *  style, so a surgical JSON revert leaves the file byte-identical to how the
+ *  user's editor/tooling would have written it (no spurious git diff). */
+function serializePreserving(original: string, obj: unknown): string {
+  const m = original.match(/\n([ \t]+)"/);
+  const indent = m ? (m[1][0] === '\t' ? '\t' : m[1].length) : 2;
+  const json = JSON.stringify(obj, null, indent);
+  return original.endsWith('\n') ? json + '\n' : json;
+}
+function tryJson(s: string): Record<string, unknown> | null {
+  try {
+    const v = JSON.parse(s);
+    return v && typeof v === 'object' ? (v as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+function rm(abs: string): void {
+  try {
+    fs.rmSync(abs, { force: true });
+  } catch {
+    /* ignore */
+  }
+}
+function statIsDir(cwd: string, rel: string): boolean {
+  try {
+    return fs.statSync(path.join(cwd, rel)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+function safeReaddir(abs: string): string[] {
+  try {
+    return fs.readdirSync(abs);
+  } catch {
+    return [];
+  }
+}
+function gitHooksPath(cwd: string): string | null {
+  try {
+    return (
+      execFileSync('git', ['config', '--get', 'core.hooksPath'], {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim() || null
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** After removing a file/dir, delete any now-empty ancestor directories up to
+ *  (but not including) cwd — cleans up dxkit-only dir trees (.claude/skills, …)
+ *  while leaving any dir that still holds user content. */
+function pruneEmptyParents(cwd: string, abs: string): void {
+  let dir = path.dirname(abs);
+  const root = path.resolve(cwd);
+  while (path.resolve(dir) !== root && path.resolve(dir).startsWith(root)) {
+    try {
+      if (fs.readdirSync(dir).length > 0) break;
+      fs.rmdirSync(dir);
+    } catch {
+      break;
+    }
+    dir = path.dirname(dir);
+  }
+}

--- a/src/uninstall/reversals.ts
+++ b/src/uninstall/reversals.ts
@@ -1,0 +1,216 @@
+/**
+ * Pure reversals for dxkit's additive merges — the inverse of each installer's
+ * merge into a PRE-EXISTING user file. Each takes the current file content and
+ * returns the content with ONLY dxkit's additions removed, preserving the
+ * user's own lines/keys byte-for-byte. These are the load-bearing functions for
+ * the uninstall feature's primary guarantee: restore the pre-dxkit state.
+ *
+ * The markers are imported from the installer modules (not re-declared), so a
+ * marker change breaks install and uninstall together (recipe symmetry).
+ */
+
+import { GITIGNORE_HEADER, POSTINSTALL_CMD, DXKIT_PACKAGE } from '../ship-installers';
+import { CLAUDE_BLOCK_START, CLAUDE_BLOCK_END } from '../loop/scaffold';
+
+/** Result of a reversal: the new content and whether anything was removed.
+ *  `content: null` means "the file is now empty of everything but dxkit's own
+ *  content — the caller may delete it" (used when dxkit created the file). */
+export interface ReversalResult {
+  readonly changed: boolean;
+  readonly content: string;
+}
+
+// ─── .gitignore ─────────────────────────────────────────────────────────────
+
+/** Stealth-mode header (mirrors `STEALTH_HEADER` in cli.ts; kept as a literal
+ *  here to avoid importing the CLI entry module). */
+export const STEALTH_HEADER = '# dxkit (stealth mode — local only, not committed)';
+
+/**
+ * Remove a dxkit block from `.gitignore`. The installer writes each block as
+ * `\n<HEADER>\n<entries…>\n` (a header line followed by its entries, up to the
+ * next blank line or EOF). We strip from the header line through the run of
+ * non-blank lines that follows it, leaving every other line — including the
+ * user's own entries — untouched.
+ */
+export function stripGitignoreBlock(content: string, header: string): ReversalResult {
+  const lines = content.split('\n');
+  const out: string[] = [];
+  let changed = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === header) {
+      changed = true;
+      // Skip the header and the contiguous non-blank entry lines under it.
+      i++;
+      while (i < lines.length && lines[i].trim() !== '') i++;
+      // `i` now points at the blank line (or EOF); the for-loop's i++ consumes
+      // that blank separator so we don't leave a double blank behind.
+      continue;
+    }
+    out.push(lines[i]);
+  }
+  if (!changed) return { changed: false, content };
+  // Collapse a leading blank the block may have left, and trailing blanks.
+  let result = out
+    .join('\n')
+    .replace(/^\n+/, '')
+    .replace(/\n{3,}/g, '\n\n');
+  if (result.trim() === '') result = '';
+  return { changed: true, content: result };
+}
+
+/** Strip both the runtime-outputs block and the stealth block from `.gitignore`. */
+export function stripAllGitignoreBlocks(content: string): ReversalResult {
+  const a = stripGitignoreBlock(content, GITIGNORE_HEADER);
+  const b = stripGitignoreBlock(a.content, STEALTH_HEADER);
+  return { changed: a.changed || b.changed, content: b.content };
+}
+
+// ─── CLAUDE.md (loop block) ─────────────────────────────────────────────────
+
+/**
+ * Remove the dxkit loop block delimited by `<!-- dxkit:loop:start -->` …
+ * `<!-- dxkit:loop:end -->` from `CLAUDE.md`, including the sentinels and the
+ * surrounding blank lines the installer added. Everything else is preserved.
+ */
+export function stripClaudeLoopBlock(content: string): ReversalResult {
+  const start = content.indexOf(CLAUDE_BLOCK_START);
+  const end = content.indexOf(CLAUDE_BLOCK_END);
+  if (start === -1 || end === -1 || end < start) return { changed: false, content };
+  const before = content.slice(0, start);
+  const after = content.slice(end + CLAUDE_BLOCK_END.length);
+  // Join, collapsing the blank lines the block was fenced with.
+  let result = (before.replace(/\n+$/, '') + '\n' + after.replace(/^\n+/, '')).trim();
+  result = result === '' ? '' : result + '\n';
+  return { changed: true, content: result };
+}
+
+// ─── .claude/settings.json ──────────────────────────────────────────────────
+
+type JsonRecord = Record<string, unknown>;
+
+/**
+ * Remove dxkit's contributions from a parsed `settings.json`:
+ *   - the Stop hook whose command invokes `hook stop-gate` (loop gate),
+ *   - the PreToolUse hook whose command invokes `context-hook` (passive graph).
+ * Empty `hooks.Stop` / `hooks.PreToolUse` arrays and an empty `hooks` object are
+ * pruned. The user's other hooks, permissions, and keys are preserved.
+ *
+ * `dxkitCreated` (the file is in the manifest) additionally strips the
+ * dxkit-authored permission block and reports `content: '{}'`-equivalent
+ * emptiness via `isDxkitOnly` so the caller can delete the file outright.
+ */
+export function stripSettingsDxkit(
+  parsed: JsonRecord,
+  opts: { dxkitCreated: boolean } = { dxkitCreated: false },
+): { changed: boolean; result: JsonRecord; isDxkitOnly: boolean } {
+  let changed = false;
+  const obj: JsonRecord = { ...parsed };
+
+  const hooks = obj.hooks as JsonRecord | undefined;
+  if (hooks && typeof hooks === 'object') {
+    const nextHooks: JsonRecord = { ...hooks };
+    for (const [event, matchRe] of [
+      ['Stop', /hook\s+stop-gate/],
+      ['PreToolUse', /context-hook/],
+    ] as const) {
+      const arr = nextHooks[event];
+      if (Array.isArray(arr)) {
+        const kept = arr.filter((entry) => !entryInvokes(entry, matchRe));
+        if (kept.length !== arr.length) changed = true;
+        if (kept.length === 0) delete nextHooks[event];
+        else nextHooks[event] = kept;
+      }
+    }
+    if (Object.keys(nextHooks).length === 0) delete obj.hooks;
+    else obj.hooks = nextHooks;
+  }
+
+  // When dxkit created the file, its permission block + $schema are dxkit's too.
+  // Drop them so the emptiness check can decide the file is deletable.
+  if (opts.dxkitCreated) {
+    if ('permissions' in obj) {
+      delete obj.permissions;
+      changed = true;
+    }
+    if ('$schema' in obj) delete obj.$schema;
+  }
+
+  const isDxkitOnly = Object.keys(obj).length === 0;
+  return { changed, result: obj, isDxkitOnly };
+}
+
+/** Does a hook-group entry (`{matcher?, hooks:[{command}]}` or `{command}`)
+ *  invoke a command matching `re`? */
+function entryInvokes(entry: unknown, re: RegExp): boolean {
+  if (!entry || typeof entry !== 'object') return false;
+  const e = entry as JsonRecord;
+  if (typeof e.command === 'string' && re.test(e.command)) return true;
+  if (Array.isArray(e.hooks)) {
+    return e.hooks.some(
+      (h) =>
+        h &&
+        typeof h === 'object' &&
+        typeof (h as JsonRecord).command === 'string' &&
+        re.test((h as JsonRecord).command as string),
+    );
+  }
+  return false;
+}
+
+// ─── package.json ───────────────────────────────────────────────────────────
+
+/**
+ * Remove dxkit's contributions from a parsed `package.json`:
+ *   - the `@vyuhlabs/dxkit` devDependency,
+ *   - the `vyuh-dxkit hooks activate` postinstall (trimming a chained ` && …`
+ *     suffix, or dropping the whole `postinstall` key when it was the sole cmd).
+ * Nothing else is touched. Returns which pieces were removed for reporting.
+ */
+export function stripPackageJsonDxkit(parsed: JsonRecord): {
+  changed: boolean;
+  result: JsonRecord;
+  removedDevDep: boolean;
+  removedPostinstall: boolean;
+} {
+  const obj: JsonRecord = { ...parsed };
+  let removedDevDep = false;
+  let removedPostinstall = false;
+
+  const dev = obj.devDependencies as JsonRecord | undefined;
+  if (dev && typeof dev === 'object' && DXKIT_PACKAGE in dev) {
+    const nextDev = { ...dev };
+    delete nextDev[DXKIT_PACKAGE];
+    removedDevDep = true;
+    if (Object.keys(nextDev).length === 0) delete obj.devDependencies;
+    else obj.devDependencies = nextDev;
+  }
+
+  const scripts = obj.scripts as JsonRecord | undefined;
+  if (scripts && typeof scripts === 'object' && typeof scripts.postinstall === 'string') {
+    const cmd = scripts.postinstall;
+    if (cmd.includes(POSTINSTALL_CMD)) {
+      const nextScripts = { ...scripts };
+      const trimmed = cmd
+        .replace(new RegExp(`\\s*&&\\s*${escapeRe(POSTINSTALL_CMD)}`), '') // chained suffix
+        .replace(new RegExp(`${escapeRe(POSTINSTALL_CMD)}\\s*&&\\s*`), '') // chained prefix
+        .trim();
+      if (trimmed === '' || trimmed === POSTINSTALL_CMD) delete nextScripts.postinstall;
+      else nextScripts.postinstall = trimmed;
+      if (Object.keys(nextScripts).length === 0) delete obj.scripts;
+      else obj.scripts = nextScripts;
+      removedPostinstall = true;
+    }
+  }
+
+  return {
+    changed: removedDevDep || removedPostinstall,
+    result: obj,
+    removedDevDep,
+    removedPostinstall,
+  };
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/test/issue-cli.test.ts
+++ b/test/issue-cli.test.ts
@@ -120,6 +120,7 @@ describe('buildIssueUrl', () => {
       'bug',
       'feature-request',
       'docs',
+      'uninstall',
     ]);
   });
 

--- a/test/uninstall-plan.test.ts
+++ b/test/uninstall-plan.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { planUninstall, executeUninstall } from '../src/uninstall';
+import { sha256 } from '../src/files';
+import { GITIGNORE_HEADER, GITIGNORE_ENTRIES, DXKIT_PACKAGE } from '../src/ship-installers';
+import { CLAUDE_BLOCK_START, CLAUDE_BLOCK_END } from '../src/loop/scaffold';
+import type { InstallFlags } from '../src/update';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-uninst-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function write(rel: string, content: string): void {
+  const abs = path.join(tmp, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+function exists(rel: string): boolean {
+  return fs.existsSync(path.join(tmp, rel));
+}
+function read(rel: string): string {
+  return fs.readFileSync(path.join(tmp, rel), 'utf-8');
+}
+
+const ALL_FLAGS: InstallFlags = {
+  withDxkitAgents: true,
+  withHooks: true,
+  withPrecommit: true,
+  withDevcontainer: true,
+  withCiGuardrails: true,
+  withBaselineRefresh: true,
+  withPrReview: true,
+  withClaudeLoop: true,
+};
+
+function writeManifest(
+  files: Record<string, { hash: string | null; evolving: boolean }>,
+  flags = ALL_FLAGS,
+): void {
+  write(
+    '.vyuh-dxkit.json',
+    JSON.stringify({
+      version: '2.24.0',
+      mode: 'full',
+      generatedAt: 'x',
+      config: {},
+      files,
+      installFlags: flags,
+    }),
+  );
+}
+
+describe('planUninstall / executeUninstall — restores pre-dxkit state', () => {
+  it('reverts additive merges into pre-existing user files, byte-for-byte', () => {
+    // A user who already had .gitignore + CLAUDE.md; dxkit appended to both.
+    const userGitignore = 'node_modules/\ndist/\n';
+    const userClaude = '# My rules\n\nDo the thing.\n';
+    write(
+      '.gitignore',
+      userGitignore + '\n' + GITIGNORE_HEADER + '\n' + GITIGNORE_ENTRIES.join('\n') + '\n',
+    );
+    write(
+      'CLAUDE.md',
+      userClaude + '\n' + CLAUDE_BLOCK_START + '\nloop stuff\n' + CLAUDE_BLOCK_END + '\n',
+    );
+    // package.json the user owns, with dxkit's devDep added (no trailing newline).
+    write(
+      'package.json',
+      JSON.stringify(
+        { name: 'x', devDependencies: { [DXKIT_PACKAGE]: '^2.24.0', react: '^18' } },
+        null,
+        2,
+      ),
+    );
+    // CLAUDE.md is NOT in the manifest → dxkit only appended (user's own file).
+    writeManifest({});
+
+    const plan = planUninstall(tmp, { removeDevDependency: true });
+    executeUninstall(tmp, plan, { removeDevDependency: true });
+
+    expect(read('.gitignore')).toBe(userGitignore); // dxkit block gone, user lines intact
+    expect(read('CLAUDE.md')).toBe(userClaude); // loop block gone, prose intact
+    const pkg = JSON.parse(read('package.json'));
+    expect(pkg.devDependencies).toEqual({ react: '^18' }); // only dxkit removed
+    expect(pkg.name).toBe('x');
+  });
+
+  it("deletes a dxkit-CREATED CLAUDE.md entirely (was not the user's)", () => {
+    const shim = '# Project — Claude config\n\ndxkit shim prose\n';
+    write('CLAUDE.md', shim + '\n' + CLAUDE_BLOCK_START + '\nloop\n' + CLAUDE_BLOCK_END + '\n');
+    writeManifest({ 'CLAUDE.md': { hash: sha256(shim), evolving: false } });
+
+    const plan = planUninstall(tmp);
+    executeUninstall(tmp, plan);
+    expect(exists('CLAUDE.md')).toBe(false); // whole dxkit-created file removed
+  });
+
+  it('deletes created files + the .dxkit tree, pruning empty dxkit dirs', () => {
+    write('.claude/skills/dxkit-learn/SKILL.md', 'x');
+    write('.claude/skills/dxkit-loop/SKILL.md', 'x');
+    write('AGENTS.md', 'agents');
+    write('.dxkit/policy.json', '{}');
+    write('.dxkit/reports/health.md', '#');
+    writeManifest({
+      'AGENTS.md': { hash: null, evolving: true },
+      '.claude/skills/dxkit-learn/SKILL.md': { hash: null, evolving: true },
+      '.claude/skills/dxkit-loop/SKILL.md': { hash: null, evolving: true },
+    });
+
+    const plan = planUninstall(tmp);
+    executeUninstall(tmp, plan);
+    expect(exists('AGENTS.md')).toBe(false);
+    expect(exists('.claude/skills/dxkit-learn/SKILL.md')).toBe(false);
+    expect(exists('.dxkit')).toBe(false);
+    expect(exists('.claude')).toBe(false); // pruned (no non-dxkit content)
+    expect(exists('.vyuh-dxkit.json')).toBe(false); // manifest removed last
+  });
+
+  it('skips a dxkit-created file the user edited (hash mismatch), unless --force', () => {
+    write('AGENTS.md', 'the user rewrote this');
+    writeManifest({ 'AGENTS.md': { hash: sha256('original dxkit content'), evolving: false } });
+
+    const plan = planUninstall(tmp);
+    expect(plan.warnings.some((w) => w.includes('AGENTS.md'))).toBe(true);
+    executeUninstall(tmp, plan);
+    expect(exists('AGENTS.md')).toBe(true); // preserved — not clobbered
+
+    const forced = planUninstall(tmp, { force: true });
+    executeUninstall(tmp, forced, { force: true });
+    expect(exists('AGENTS.md')).toBe(false);
+  });
+
+  it('--keep-baselines preserves the committed curated artifacts', () => {
+    write('.dxkit/baselines/main.json', '{}');
+    write('.dxkit/allowlist.json', '{}');
+    write('.dxkit/reports/x.md', '#');
+    write('.dxkit/policy.json', '{}');
+    writeManifest({});
+
+    const plan = planUninstall(tmp, { keepBaselines: true });
+    executeUninstall(tmp, plan, { keepBaselines: true });
+    expect(exists('.dxkit/baselines/main.json')).toBe(true); // kept
+    expect(exists('.dxkit/allowlist.json')).toBe(true); // kept
+    expect(exists('.dxkit/reports/x.md')).toBe(false); // runtime removed
+    expect(exists('.dxkit/policy.json')).toBe(false);
+  });
+
+  it('reports empty on a repo with no dxkit footprint', () => {
+    write('package.json', '{"name":"x"}');
+    expect(planUninstall(tmp).empty).toBe(true);
+  });
+});
+
+describe('recipe symmetry — every install surface has a removal path', () => {
+  // For each install flag, its gated artifact must appear as a pending removal.
+  const FLAG_ARTIFACT: Array<[keyof InstallFlags, string]> = [
+    ['withHooks', '.githooks/pre-push'],
+    ['withPrecommit', '.githooks/pre-commit'],
+    ['withCiGuardrails', '.github/workflows/dxkit-guardrails.yml'],
+    ['withBaselineRefresh', '.github/workflows/dxkit-baseline-refresh.yml'],
+    ['withPrReview', '.github/workflows/pr-review.yml'],
+  ];
+
+  it.each(FLAG_ARTIFACT)('flag %s → its artifact is planned for removal', (flag, artifact) => {
+    write(artifact, 'content');
+    writeManifest({}, { ...ALL_FLAGS, [flag]: true } as InstallFlags);
+    const plan = planUninstall(tmp);
+    const act = plan.actions.find((a) => a.target === artifact);
+    expect(act, `${artifact} not in plan`).toBeDefined();
+    expect(act!.status).toBe('pending');
+  });
+
+  it('self-invocation surfaces are all reversed (settings hooks + pre-push + CI)', () => {
+    // The four Rule-14 self-invocation surfaces, present together.
+    write(
+      '.claude/settings.json',
+      JSON.stringify({
+        $schema: 's',
+        permissions: { allow: ['Bash(vyuh-dxkit:*)'], deny: [] },
+        hooks: {
+          PreToolUse: [{ matcher: 'Read', hooks: [{ command: 'vyuh-dxkit context-hook' }] }],
+          Stop: [{ hooks: [{ command: 'npx vyuh-dxkit hook stop-gate' }] }],
+        },
+      }),
+    );
+    write('.githooks/pre-push', '#!/bin/sh');
+    write('.github/workflows/dxkit-guardrails.yml', 'name: x');
+    writeManifest({ '.claude/settings.json': { hash: null, evolving: false } });
+
+    const plan = planUninstall(tmp);
+    const targets = plan.actions.filter((a) => a.status === 'pending').map((a) => a.target);
+    expect(targets).toContain('.claude/settings.json'); // both context-hook + stop-gate
+    expect(targets).toContain('.githooks/pre-push');
+    expect(targets).toContain('.github/workflows/dxkit-guardrails.yml');
+  });
+});

--- a/test/uninstall-reversals.test.ts
+++ b/test/uninstall-reversals.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import {
+  stripGitignoreBlock,
+  stripAllGitignoreBlocks,
+  stripClaudeLoopBlock,
+  stripSettingsDxkit,
+  stripPackageJsonDxkit,
+  STEALTH_HEADER,
+} from '../src/uninstall/reversals';
+import { GITIGNORE_HEADER } from '../src/ship-installers';
+import { CLAUDE_BLOCK_START, CLAUDE_BLOCK_END } from '../src/loop/scaffold';
+
+describe('stripGitignoreBlock — preserves user entries', () => {
+  it('removes only the dxkit block, keeping user lines above and below', () => {
+    const content = [
+      'node_modules/',
+      'dist/',
+      '',
+      GITIGNORE_HEADER,
+      '.dxkit/reports/',
+      '.dxkit/cache/',
+      'graphify-out/',
+      '',
+      '*.log',
+    ].join('\n');
+    const { changed, content: out } = stripGitignoreBlock(content, GITIGNORE_HEADER);
+    expect(changed).toBe(true);
+    expect(out).toContain('node_modules/');
+    expect(out).toContain('dist/');
+    expect(out).toContain('*.log');
+    expect(out).not.toContain(GITIGNORE_HEADER);
+    expect(out).not.toContain('.dxkit/reports/');
+    expect(out).not.toContain('graphify-out/');
+  });
+
+  it('no-op when the block is absent', () => {
+    const content = 'node_modules/\ndist/\n';
+    expect(stripGitignoreBlock(content, GITIGNORE_HEADER)).toEqual({ changed: false, content });
+  });
+
+  it('empties the file when it held only the dxkit block', () => {
+    const content = [GITIGNORE_HEADER, '.dxkit/reports/', 'graphify-out/', ''].join('\n');
+    const { changed, content: out } = stripGitignoreBlock(content, GITIGNORE_HEADER);
+    expect(changed).toBe(true);
+    expect(out).toBe('');
+  });
+
+  it('stripAllGitignoreBlocks removes both runtime + stealth blocks', () => {
+    const content = [
+      'node_modules/',
+      '',
+      GITIGNORE_HEADER,
+      '.dxkit/reports/',
+      '',
+      STEALTH_HEADER,
+      '.dxkit/',
+      '.vyuh-dxkit.json',
+    ].join('\n');
+    const { changed, content: out } = stripAllGitignoreBlocks(content);
+    expect(changed).toBe(true);
+    expect(out).toBe('node_modules/\n');
+  });
+});
+
+describe('stripClaudeLoopBlock — preserves user prose', () => {
+  it('removes the sentinel block, keeping surrounding content', () => {
+    const content = [
+      '# My project',
+      '',
+      'Some house rules.',
+      '',
+      CLAUDE_BLOCK_START,
+      'dxkit loop guidance here',
+      CLAUDE_BLOCK_END,
+      '',
+      'More of my own notes.',
+    ].join('\n');
+    const { changed, content: out } = stripClaudeLoopBlock(content);
+    expect(changed).toBe(true);
+    expect(out).toContain('# My project');
+    expect(out).toContain('Some house rules.');
+    expect(out).toContain('More of my own notes.');
+    expect(out).not.toContain(CLAUDE_BLOCK_START);
+    expect(out).not.toContain('dxkit loop guidance here');
+  });
+
+  it('no-op when the block is absent', () => {
+    const content = '# My project\n\nRules.\n';
+    expect(stripClaudeLoopBlock(content).changed).toBe(false);
+  });
+
+  it('empties a CLAUDE.md that held only the loop block', () => {
+    const content = [CLAUDE_BLOCK_START, 'x', CLAUDE_BLOCK_END].join('\n');
+    expect(stripClaudeLoopBlock(content).content).toBe('');
+  });
+});
+
+describe('stripSettingsDxkit — surgical hook removal', () => {
+  it('removes the Stop stop-gate hook, keeping other Stop hooks', () => {
+    const parsed = {
+      hooks: {
+        Stop: [
+          { hooks: [{ type: 'command', command: 'npx vyuh-dxkit hook stop-gate' }] },
+          { hooks: [{ type: 'command', command: 'my-own-hook' }] },
+        ],
+      },
+    };
+    const { changed, result } = stripSettingsDxkit(parsed);
+    expect(changed).toBe(true);
+    const stop = (result.hooks as { Stop: unknown[] }).Stop;
+    expect(stop).toHaveLength(1);
+    expect(JSON.stringify(stop)).toContain('my-own-hook');
+    expect(JSON.stringify(stop)).not.toContain('stop-gate');
+  });
+
+  it('removes the PreToolUse context-hook and prunes empty hooks', () => {
+    const parsed = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Read|Edit',
+            hooks: [{ type: 'command', command: 'vyuh-dxkit context-hook' }],
+          },
+        ],
+      },
+    };
+    const { changed, result, isDxkitOnly } = stripSettingsDxkit(parsed);
+    expect(changed).toBe(true);
+    expect(result.hooks).toBeUndefined();
+    expect(isDxkitOnly).toBe(true);
+  });
+
+  it('preserves the user permissions when not dxkit-created', () => {
+    const parsed = {
+      permissions: { allow: ['Bash(ls:*)'], deny: [] },
+      hooks: { Stop: [{ hooks: [{ command: 'npx vyuh-dxkit hook stop-gate' }] }] },
+    };
+    const { result, isDxkitOnly } = stripSettingsDxkit(parsed, { dxkitCreated: false });
+    expect(result.permissions).toEqual({ allow: ['Bash(ls:*)'], deny: [] });
+    expect(isDxkitOnly).toBe(false);
+  });
+
+  it('when dxkit-created, drops $schema + permissions → isDxkitOnly', () => {
+    const parsed = {
+      $schema: 'x',
+      permissions: { allow: ['Bash(vyuh-dxkit:*)'], deny: [] },
+      hooks: { PreToolUse: [{ hooks: [{ command: 'vyuh-dxkit context-hook' }] }] },
+    };
+    const { isDxkitOnly } = stripSettingsDxkit(parsed, { dxkitCreated: true });
+    expect(isDxkitOnly).toBe(true);
+  });
+});
+
+describe('stripPackageJsonDxkit', () => {
+  it('removes the devDependency, keeping others', () => {
+    const parsed = { devDependencies: { '@vyuhlabs/dxkit': '^2.23.0', react: '^18.0.0' } };
+    const { changed, result, removedDevDep } = stripPackageJsonDxkit(parsed);
+    expect(changed).toBe(true);
+    expect(removedDevDep).toBe(true);
+    expect(result.devDependencies).toEqual({ react: '^18.0.0' });
+  });
+
+  it('drops the whole postinstall when it was only the dxkit cmd', () => {
+    const parsed = { scripts: { postinstall: 'vyuh-dxkit hooks activate', build: 'tsc' } };
+    const { result, removedPostinstall } = stripPackageJsonDxkit(parsed);
+    expect(removedPostinstall).toBe(true);
+    expect((result.scripts as Record<string, string>).postinstall).toBeUndefined();
+    expect((result.scripts as Record<string, string>).build).toBe('tsc');
+  });
+
+  it('trims a chained postinstall suffix, keeping the user command', () => {
+    const parsed = { scripts: { postinstall: 'husky install && vyuh-dxkit hooks activate' } };
+    const { result } = stripPackageJsonDxkit(parsed);
+    expect((result.scripts as Record<string, string>).postinstall).toBe('husky install');
+  });
+
+  it('no-op when dxkit is absent', () => {
+    const parsed = { devDependencies: { react: '^18.0.0' } };
+    expect(stripPackageJsonDxkit(parsed).changed).toBe(false);
+  });
+});


### PR DESCRIPTION
## `vyuh-dxkit uninstall` — 2.24.0

A clean, non-intrusive way to remove dxkit. Its one guarantee: after uninstall, the repo is back to its **exact pre-dxkit state** — every file dxkit created is gone, and every additive change dxkit made to a file you already had is reversed, leaving your own content byte-for-byte intact.

### Design

- **Two kinds of footprint, handled differently.** dxkit-*created* files (`.dxkit/`, `dxkit-*` skills, `AGENTS.md`, git hooks, `dxkit-*` workflows, `.dxkit-ignore`, `.vyuh-dxkit.json`) are removed. *Additive merges* into files you already had (the `.gitignore` block, the `CLAUDE.md` loop block, `settings.json` hooks, the `package.json` devDependency + postinstall) are surgically reverted — keeping your keys, prose, and **exact formatting** (indent + trailing-newline preserved).
- **Manifest-driven + hash-guarded.** Reads `.vyuh-dxkit.json` for the authoritative created-file list, flags, and hashes. A dxkit-created file you've since edited is surfaced and **skipped** (never clobbered) unless `--force`; the manifest is kept in that case so a later `--force` still finds it.
- **Recipe symmetry.** The reversal markers are imported from the installer modules, so a marker change breaks install and uninstall together. A test asserts every install flag + all four Rule-14 self-invocation surfaces have a removal path.

### CLI + skill

`vyuh-dxkit uninstall [path] [--yes] [--keep-baselines] [--remove-devdep] [--force] [--no-feedback] [--json]` — **dry-run by default** (prints the plan), `--yes` applies. On completion, offers a prefilled GitHub issue for optional feedback (new `uninstall` issue type; no telemetry, opt-in). Plus a `dxkit-uninstall` skill.

### Verified on a real repo

A clean git repo → `init` (agents + hooks + CI + loop) → `uninstall --yes --remove-devdep` → **`git status` fully clean** (byte-for-byte pre-dxkit restore). The real-repo test caught two bugs unit tests missed — a stray trailing newline on `package.json` and a dxkit-created `CLAUDE.md` being reverted instead of removed — both fixed.

Full suite green (2870 tests); 27 new uninstall unit + symmetry tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)