### PR TITLE
M5 — interactive flow console (2.25.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.25.0] - 2026-07-04
+
+### Added — the interactive flow console (`vyuh-dxkit flow console`)
+
+A self-contained, offline HTML artifact that renders the UI→API map plus a
+request runner per endpoint — the higher-value sibling of the flow CSVs. Where
+the gate says *which* integrations a change breaks, the console lets a reviewer
+or author *exercise* exactly what moved.
+
+- **Generated, not a general API client.** It is a renderer over the same
+  `FlowModel` the map and gate read (no new extraction). `vyuh-dxkit flow console`
+  writes `.dxkit/reports/flow-console.html`; `--diff <ref>` makes it PR-scoped —
+  only the endpoints the change touches, with any net-new broken integration
+  flagged by the existing flow gate.
+- **Load-bearing safety: dxkit makes zero HTTP calls.** It only assembles a
+  static document. The request runner calls *from the browser* when the user
+  opens the file and enters, at runtime, a Base URL (their dev/staging, never
+  prod) and an auth token. That token lives only in the open tab — never
+  committed, logged, baked into the artifact, or seen by dxkit or CI. The HTML
+  carries request templates only.
+- **PR attachment, no required infra.** The shipped guardrails workflow generates
+  the console scoped to the PR base, uploads it as a build artifact (only when the
+  diff touched an integration), and links it from the guardrail PR comment. The
+  step self-skips on a repo with no UI→API surface.
+- The `dxkit-flow` skill gains a `console` mode.
+
 ## [2.24.0] - 2026-07-04
 
 ### Added — `vyuh-dxkit uninstall` (restore the pre-dxkit state)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.24.0",
+      "version": "2.25.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.claude/skills/dxkit-flow/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-flow/SKILL.md
@@ -68,11 +68,27 @@ When the provider a call targets lives in another repo, the gate needs that repo
 
   `flow refresh` writes just this repo's snapshots; `flow publish` unions the whole mesh so this repo resolves calls to services it does not co-locate. Commit the result.
 
+### console — an interactive HTML artifact a reviewer can exercise
+
+Generate a self-contained HTML console of the flow — the UI→API map plus a request runner per endpoint — so an author or reviewer can *exercise* exactly what a change touched, not just read that it broke.
+
+```
+npx vyuh-dxkit flow console                 → full map → .dxkit/reports/flow-console.html
+npx vyuh-dxkit flow console --diff <ref>    → PR-scoped: only endpoints the change touches,
+                                              with any net-new broken integration flagged
+npx vyuh-dxkit flow console --json           → { outPath, scope, broken, ... } for the agent to read
+```
+
+- **It is diff-scoped in `--diff` mode** (the reviewer sees the three integrations this PR moves, not the whole app), and the gate marks the ones this change net-new breaks — the same findings `guardrail check` reports, made tangible.
+- **Safety is load-bearing and unconditional:** dxkit generates the document statically and makes **zero** HTTP calls. The request runner calls FROM THE BROWSER when the user opens the file and enters, at runtime, a Base URL (their dev/staging, never prod) and an auth token. That token lives only in the open tab — it is never committed, logged, baked into the artifact, or seen by dxkit or CI. Point it at a dev/staging origin that allows the page's origin (CORS).
+- In CI the console is generated diff-scoped, uploaded as a build artifact, and linked from the guardrail PR comment — no server, no required infra. It complements the gate (enforcement); it is a reviewer-ergonomics aid, not itself a gate.
+
 ## What lives where
 
 | Artifact | Role |
 |---|---|
 | `.dxkit/policy.json:flow` | posture (`mode`) + URL strip-prefixes + specs |
+| `.dxkit/reports/flow-console.html` | the generated interactive console (git-ignored output) |
 | `.dxkit/workspace.json` | the participants (name, path, ref, base URLs) of a multi-repo system |
 | `.dxkit/flow/served.json` / `consumed.json` | the committed contract snapshots the gate reads |
 

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -98,6 +98,36 @@ jobs:
           fi
           "${DXKIT}" floor check --surface ci
 
+      # Interactive flow console (design §E) — a self-contained HTML artifact
+      # scoped to THIS PR: the UI→API map + a browser-side request runner for the
+      # integrations the diff touches, with any net-new break flagged. dxkit
+      # generates it statically and makes no HTTP call; the runner calls from the
+      # reviewer's browser with a Base URL + token they enter, never committed.
+      # Self-skips (produces nothing to upload) on a repo with no UI→API surface.
+      - name: Generate flow console
+        id: console
+        if: always()
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            DXKIT=./node_modules/.bin/vyuh-dxkit
+          else
+            DXKIT=vyuh-dxkit
+          fi
+          set +e
+          "${DXKIT}" flow console --diff "${{ github.event.pull_request.base.sha }}" \
+            --out flow-console.html --json > console.json 2>/dev/null
+          set -e
+          eps=$(node -e "try{const j=require('./console.json');process.stdout.write(String((j.shownEndpoints||0)+(j.broken||0)))}catch(e){process.stdout.write('0')}" 2>/dev/null || echo 0)
+          echo "endpoints=$eps" >> "$GITHUB_OUTPUT"
+
+      - name: Upload flow console
+        if: always() && steps.console.outputs.endpoints != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: flow-console
+          path: flow-console.html
+          if-no-files-found: ignore
+
       - name: Post PR comment
         if: always()
         env:
@@ -111,6 +141,12 @@ jobs:
             printf '%s\n' "$MARKER"
             cat guardrail-report.md
           } > comment.md
+          # Link the flow console artifact when this PR touched an integration.
+          if [ "${{ steps.console.outputs.endpoints }}" != "0" ] && [ -f flow-console.html ]; then
+            printf '\n\n---\n📊 **[Interactive flow console](%s)** — download from this run'"'"'s **Artifacts** to exercise the %s integration(s) this PR touches (UI→API map + request runner; your auth stays in the browser).\n' \
+              "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              "${{ steps.console.outputs.endpoints }}" >> comment.md
+          fi
           existing=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
             | head -n1)

--- a/src/analyzers/flow/console-assets.ts
+++ b/src/analyzers/flow/console-assets.ts
@@ -1,0 +1,335 @@
+/**
+ * Client-side assets for the interactive flow console — the CSS and the vanilla
+ * JS app that render the console from its embedded JSON data island. Kept out of
+ * `console.ts` so the pure HTML assembler stays small and the browser app reads
+ * as one self-contained program.
+ *
+ * The app is deliberately dependency-free (beyond the optional bundled
+ * vis-network the assembler inlines): it reads `#dxkit-flow-data`, builds the
+ * endpoint cards + request runner, and — when the vis bundle is present — draws
+ * the UI→API map. The request runner makes calls FROM THE BROWSER only; the base
+ * URL and auth token are entered at runtime, live solely in the open tab, and
+ * are never persisted, logged, or seen by dxkit or CI (design §E). dxkit itself
+ * makes zero HTTP calls — it only generates this document.
+ */
+
+/** Console stylesheet — spliced into the document `<head>` by the assembler. */
+export const CONSOLE_CSS = `
+:root {
+  --bg: #0f1117; --bg-card: #171a21; --bg-2: #1e222b; --border: #2a2f3a;
+  --text: #e6e9ef; --text-dim: #9aa3b2; --accent: #4e79a7;
+  --get: #59a14f; --post: #4e79a7; --put: #edc948; --patch: #b07aa1;
+  --delete: #e15759; --other: #8c8c8c;
+  --broken: #e15759; --affected: #edc948;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px; line-height: 1.5; }
+a { color: var(--accent); }
+code, .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+header.dx-head { padding: 20px 28px; border-bottom: 1px solid var(--border);
+  background: linear-gradient(180deg, #12151c, var(--bg)); }
+header.dx-head h1 { margin: 0 0 4px; font-size: 19px; }
+header.dx-head .sub { color: var(--text-dim); font-size: 13px; }
+.dx-safety { margin: 12px 28px 0; padding: 10px 14px; border-radius: 8px;
+  background: rgba(78,121,167,0.12); border: 1px solid rgba(78,121,167,0.35);
+  color: var(--text-dim); font-size: 12.5px; }
+.dx-safety strong { color: var(--text); }
+.dx-controls { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end;
+  padding: 16px 28px; border-bottom: 1px solid var(--border); }
+.dx-controls .fld { display: flex; flex-direction: column; gap: 4px; }
+.dx-controls label { font-size: 11px; text-transform: uppercase; letter-spacing: .04em;
+  color: var(--text-dim); }
+input, textarea, select { background: var(--bg-2); color: var(--text);
+  border: 1px solid var(--border); border-radius: 6px; padding: 7px 9px;
+  font-size: 13px; font-family: inherit; }
+input:focus, textarea:focus { outline: 1px solid var(--accent); }
+.dx-controls input { min-width: 260px; }
+textarea { width: 100%; resize: vertical; min-height: 60px; }
+.dx-summary { display: flex; gap: 22px; padding: 14px 28px; flex-wrap: wrap;
+  border-bottom: 1px solid var(--border); }
+.dx-summary .stat b { font-size: 20px; } .dx-summary .stat span { color: var(--text-dim);
+  font-size: 12px; display: block; }
+#dx-graph { height: 360px; margin: 0; border-bottom: 1px solid var(--border);
+  background: var(--bg); }
+#dx-graph.empty { height: auto; padding: 14px 28px; color: var(--text-dim); font-size: 12.5px; }
+main { padding: 8px 28px 60px; }
+.dx-section-h { margin: 22px 0 8px; font-size: 13px; text-transform: uppercase;
+  letter-spacing: .05em; color: var(--text-dim); }
+.ep { border: 1px solid var(--border); border-radius: 10px; margin: 10px 0;
+  background: var(--bg-card); overflow: hidden; }
+.ep.broken { border-color: var(--broken); }
+.ep.affected { border-color: var(--affected); }
+.ep-head { display: flex; align-items: center; gap: 10px; padding: 12px 14px;
+  cursor: pointer; user-select: none; }
+.ep-head:hover { background: var(--bg-2); }
+.verb { font-weight: 700; font-size: 11px; padding: 3px 8px; border-radius: 5px;
+  color: #0f1117; min-width: 52px; text-align: center; }
+.verb.GET { background: var(--get); } .verb.POST { background: var(--post); color:#fff;}
+.verb.PUT { background: var(--put); } .verb.PATCH { background: var(--patch); color:#fff;}
+.verb.DELETE { background: var(--delete); color:#fff;} .verb.OTHER { background: var(--other); }
+.ep-path { font-weight: 600; }
+.ep-tags { margin-left: auto; display: flex; gap: 6px; align-items: center; }
+.tag { font-size: 11px; padding: 2px 7px; border-radius: 20px; background: var(--bg-2);
+  color: var(--text-dim); }
+.tag.broken { background: rgba(225,87,89,0.18); color: #ff9a9b; }
+.tag.affected { background: rgba(237,201,72,0.18); color: #f0d86b; }
+.ep-body { padding: 0 14px 14px; display: none; }
+.ep.open .ep-body { display: block; }
+.ep-meta { color: var(--text-dim); font-size: 12.5px; margin: 4px 0 12px; }
+.ep-meta .brk { color: #ff9a9b; }
+.runner { display: grid; gap: 10px; }
+.runner .row { display: flex; gap: 10px; flex-wrap: wrap; }
+.runner .fld { display: flex; flex-direction: column; gap: 4px; flex: 1 1 180px; }
+.runner label { font-size: 11px; color: var(--text-dim); }
+.btn { background: var(--accent); color: #fff; border: none; border-radius: 6px;
+  padding: 8px 16px; font-size: 13px; font-weight: 600; cursor: pointer; align-self: flex-start; }
+.btn:hover { filter: brightness(1.1); } .btn:disabled { opacity: .5; cursor: default; }
+.resp { margin-top: 6px; border: 1px solid var(--border); border-radius: 8px;
+  background: var(--bg); display: none; }
+.resp.show { display: block; }
+.resp .status { padding: 8px 12px; border-bottom: 1px solid var(--border); font-size: 12.5px; }
+.resp .status.ok { color: #8fd18a; } .resp .status.err { color: #ff9a9b; }
+.resp pre { margin: 0; padding: 12px; overflow: auto; max-height: 300px; font-size: 12px;
+  white-space: pre-wrap; word-break: break-word; }
+.consumers { font-size: 12px; color: var(--text-dim); margin-top: 10px; }
+.consumers .f { display: block; }
+.empty-note { color: var(--text-dim); font-style: italic; padding: 8px 0; }
+`;
+
+/**
+ * The browser app. Reads the JSON data island, renders the summary + request
+ * runner cards, and — when `window.vis` (the inlined bundle) is present — draws
+ * the flow map. Written as a plain IIFE string so the assembler can inline it
+ * without a build step; it references no module system and no external globals
+ * beyond the optional `vis`.
+ */
+export const CONSOLE_APP_JS = `
+(function () {
+  "use strict";
+  var el = document.getElementById("dxkit-flow-data");
+  var DATA = {};
+  try { DATA = JSON.parse(el.textContent); } catch (e) { DATA = { endpoints: [], unconsumed: [], meta: {}, totals: {} }; }
+  var esc = function (s) {
+    return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  };
+  var verbClass = function (m) {
+    return ["GET", "POST", "PUT", "PATCH", "DELETE"].indexOf(String(m).toUpperCase()) >= 0
+      ? String(m).toUpperCase() : "OTHER";
+  };
+  var hasBody = function (m) { return ["POST", "PUT", "PATCH", "DELETE"].indexOf(String(m).toUpperCase()) >= 0; };
+
+  // ---- global request config (lives only in this tab) ----
+  var cfg = { baseUrl: "", auth: "" };
+  var baseInput = document.getElementById("dx-base");
+  var authInput = document.getElementById("dx-auth");
+  if (baseInput) baseInput.addEventListener("input", function () { cfg.baseUrl = baseInput.value.trim(); });
+  if (authInput) authInput.addEventListener("input", function () { cfg.auth = authInput.value; });
+
+  // ---- endpoint cards ----
+  var splitPath = function (p) { return String(p || "").split("{var}"); };
+
+  function buildRunner(ep) {
+    var wrap = document.createElement("div");
+    wrap.className = "runner";
+    var parts = splitPath(ep.path);
+    var paramCount = parts.length - 1;
+
+    var pathRow = document.createElement("div");
+    pathRow.className = "row";
+    var paramInputs = [];
+    if (paramCount > 0) {
+      for (var i = 0; i < paramCount; i++) {
+        var f = document.createElement("div"); f.className = "fld";
+        var lab = document.createElement("label"); lab.textContent = "path param " + (i + 1);
+        var inp = document.createElement("input"); inp.placeholder = "value";
+        f.appendChild(lab); f.appendChild(inp); pathRow.appendChild(f);
+        paramInputs.push(inp);
+      }
+      wrap.appendChild(pathRow);
+    }
+
+    var mkArea = function (labelText, ph, val) {
+      var f = document.createElement("div"); f.className = "fld"; f.style.flex = "1 1 100%";
+      var lab = document.createElement("label"); lab.textContent = labelText;
+      var ta = document.createElement("textarea"); ta.placeholder = ph; if (val) ta.value = val;
+      f.appendChild(lab); f.appendChild(ta); wrap.appendChild(f);
+      return ta;
+    };
+    var queryTa = mkArea("query params (one key=value per line)", "limit=10\\noffset=0", "");
+    var headersTa = mkArea("headers (one Name: value per line)", "Accept: application/json",
+      hasBody(ep.method) ? "Content-Type: application/json" : "");
+    var bodyTa = hasBody(ep.method) ? mkArea("request body", '{\\n  "field": "value"\\n}', "") : null;
+
+    var btn = document.createElement("button");
+    btn.className = "btn"; btn.textContent = "Send request";
+    wrap.appendChild(btn);
+
+    var resp = document.createElement("div"); resp.className = "resp";
+    var statusLine = document.createElement("div"); statusLine.className = "status";
+    var pre = document.createElement("pre");
+    resp.appendChild(statusLine); resp.appendChild(pre); wrap.appendChild(resp);
+
+    function buildUrl() {
+      var out = "";
+      for (var i = 0; i < parts.length; i++) {
+        out += parts[i];
+        if (i < paramInputs.length) out += encodeURIComponent(paramInputs[i].value || "");
+      }
+      var qs = [];
+      queryTa.value.split("\\n").forEach(function (ln) {
+        var t = ln.trim(); if (!t) return;
+        var eq = t.indexOf("=");
+        var k = eq >= 0 ? t.slice(0, eq) : t;
+        var v = eq >= 0 ? t.slice(eq + 1) : "";
+        qs.push(encodeURIComponent(k.trim()) + "=" + encodeURIComponent(v.trim()));
+      });
+      var base = cfg.baseUrl.replace(/\\/$/, "");
+      return base + out + (qs.length ? "?" + qs.join("&") : "");
+    }
+    function buildHeaders() {
+      var h = {};
+      headersTa.value.split("\\n").forEach(function (ln) {
+        var t = ln.trim(); if (!t) return;
+        var c = t.indexOf(":"); if (c < 0) return;
+        h[t.slice(0, c).trim()] = t.slice(c + 1).trim();
+      });
+      if (cfg.auth) h["Authorization"] = cfg.auth;
+      return h;
+    }
+
+    btn.addEventListener("click", function () {
+      if (!cfg.baseUrl) {
+        resp.className = "resp show";
+        statusLine.className = "status err";
+        statusLine.textContent = "Enter a Base URL (your dev/staging origin) at the top first.";
+        pre.textContent = ""; return;
+      }
+      var url = buildUrl();
+      var init = { method: ep.method, headers: buildHeaders() };
+      if (bodyTa && bodyTa.value.trim()) init.body = bodyTa.value;
+      resp.className = "resp show";
+      statusLine.className = "status"; statusLine.textContent = ep.method + " " + url + " …";
+      pre.textContent = "";
+      btn.disabled = true;
+      var t0 = Date.now();
+      fetch(url, init).then(function (r) {
+        var ct = r.headers.get("content-type") || "";
+        return r.text().then(function (txt) { return { r: r, txt: txt, ct: ct }; });
+      }).then(function (o) {
+        var ms = Date.now() - t0;
+        statusLine.className = "status " + (o.r.ok ? "ok" : "err");
+        statusLine.textContent = o.r.status + " " + o.r.statusText + "  ·  " + ms + " ms";
+        var body = o.txt;
+        if (o.ct.indexOf("json") >= 0) { try { body = JSON.stringify(JSON.parse(o.txt), null, 2); } catch (e) {} }
+        pre.textContent = body;
+      }).catch(function (err) {
+        statusLine.className = "status err";
+        statusLine.textContent = "Request failed — " + err.message;
+        pre.textContent = "This usually means CORS blocked the call or the server is unreachable.\\n" +
+          "Run the API against a dev/staging origin that allows this page's origin, or enable CORS there.\\n" +
+          "dxkit generated this console statically; the call is made by your browser, not dxkit.";
+      }).then(function () { btn.disabled = false; });
+    });
+    return wrap;
+  }
+
+  function buildCard(ep) {
+    var card = document.createElement("div");
+    card.className = "ep" + (ep.broken ? " broken" : ep.affected ? " affected" : "");
+    card.setAttribute("data-ep", ep.id);
+    var head = document.createElement("div"); head.className = "ep-head";
+    head.innerHTML =
+      '<span class="verb ' + verbClass(ep.method) + '">' + esc(ep.method) + "</span>" +
+      '<span class="ep-path mono">' + esc(ep.path) + "</span>" +
+      '<span class="ep-tags">' +
+        (ep.broken ? '<span class="tag broken">' + esc(ep.broken.verdict) + ": broken</span>" : "") +
+        (ep.affected && !ep.broken ? '<span class="tag affected">touched by diff</span>' : "") +
+        '<span class="tag">' + (ep.consumerCount || 0) + " caller" + (ep.consumerCount === 1 ? "" : "s") + "</span>" +
+        '<span class="tag">' + esc(ep.via) + "</span>" +
+      "</span>";
+    var body = document.createElement("div"); body.className = "ep-body";
+    var meta = document.createElement("div"); meta.className = "ep-meta";
+    var whereLabel = ep.broken ? "called from " : "served at ";
+    meta.innerHTML =
+      whereLabel + "<span class=\\"mono\\">" + esc(ep.sourceFile) + (ep.line ? ":" + ep.line : "") + "</span>" +
+      (ep.handler ? " · handler <span class=\\"mono\\">" + esc(ep.handler) + "</span>" : "") +
+      (ep.broken ? ' · <span class="brk">net-new break: ' + esc(ep.broken.reason) + "</span>" : "");
+    body.appendChild(meta);
+    body.appendChild(buildRunner(ep));
+    if (ep.consumerFiles && ep.consumerFiles.length) {
+      var cons = document.createElement("div"); cons.className = "consumers";
+      cons.innerHTML = "<b>Consumed by:</b>" +
+        ep.consumerFiles.map(function (f) { return '<span class="f mono">' + esc(f) + "</span>"; }).join("");
+      body.appendChild(cons);
+    }
+    card.appendChild(head); card.appendChild(body);
+    head.addEventListener("click", function () { card.classList.toggle("open"); });
+    return card;
+  }
+
+  function renderList(containerId, list, emptyText) {
+    var c = document.getElementById(containerId);
+    if (!c) return;
+    if (!list.length) { c.innerHTML = '<div class="empty-note">' + esc(emptyText) + "</div>"; return; }
+    list.forEach(function (ep) { c.appendChild(buildCard(ep)); });
+  }
+
+  // affected/broken first, then by caller count
+  var order = function (a, b) {
+    return (b.broken ? 1 : 0) - (a.broken ? 1 : 0) ||
+      (b.affected ? 1 : 0) - (a.affected ? 1 : 0) ||
+      (b.consumerCount || 0) - (a.consumerCount || 0) ||
+      String(a.path).localeCompare(String(b.path));
+  };
+  renderList("dx-broken", (DATA.broken || []).slice().sort(order),
+    "No net-new broken integrations — nothing this change breaks.");
+  renderList("dx-endpoints", (DATA.endpoints || []).slice().sort(order),
+    "No consumed endpoints in scope.");
+  renderList("dx-unconsumed", (DATA.unconsumed || []).slice().sort(order),
+    "No served-but-unconsumed endpoints in scope.");
+
+  // ---- flow map (optional; needs the inlined vis bundle) ----
+  var graphEl = document.getElementById("dx-graph");
+  if (graphEl && window.vis && (DATA.endpoints || []).length) {
+    try { drawGraph(graphEl, DATA); }
+    catch (e) { graphEl.className = "empty"; graphEl.textContent = "Flow map unavailable: " + e.message; }
+  } else if (graphEl) {
+    graphEl.className = "empty";
+    graphEl.textContent = window.vis
+      ? "No endpoints in scope to map."
+      : "Interactive map omitted (vis-network bundle absent). The request runner below still works.";
+  }
+
+  function drawGraph(container, data) {
+    var nodes = [], edges = [], seenFile = {};
+    (data.endpoints || []).forEach(function (ep) {
+      var color = ep.broken ? "#e15759" : ep.affected ? "#edc948" : "#4e79a7";
+      nodes.push({ id: ep.id, label: ep.method + " " + ep.path, shape: "box",
+        color: { background: color, border: color }, font: { color: "#0f1117" } });
+      (ep.consumerFiles || []).forEach(function (f) {
+        var fid = "f:" + f;
+        if (!seenFile[fid]) {
+          seenFile[fid] = true;
+          nodes.push({ id: fid, label: f.split("/").pop(), title: f, shape: "dot", size: 8,
+            color: { background: "#9aa3b2", border: "#6b7280" }, font: { color: "#9aa3b2" } });
+        }
+        edges.push({ from: fid, to: ep.id, arrows: "to", color: { color: "#3a4150" } });
+      });
+    });
+    var net = new window.vis.Network(container,
+      { nodes: new window.vis.DataSet(nodes), edges: new window.vis.DataSet(edges) },
+      { physics: { stabilization: true, barnesHut: { gravitationalConstant: -6000 } },
+        interaction: { hover: true }, nodes: { borderWidth: 1 } });
+    net.on("click", function (params) {
+      if (!params.nodes.length) return;
+      var id = params.nodes[0];
+      var card = document.querySelector('[data-ep="' + id + '"]');
+      if (card) { card.classList.add("open"); card.scrollIntoView({ behavior: "smooth", block: "center" }); }
+    });
+  }
+})();
+`;

--- a/src/analyzers/flow/console.ts
+++ b/src/analyzers/flow/console.ts
@@ -1,0 +1,195 @@
+/**
+ * The interactive flow console — a renderer over `FlowModel` (mirror of
+ * `csv.ts`), producing a single self-contained HTML document. It is the
+ * higher-value sibling of the CSV renderer (design §E): the UI→API map plus a
+ * per-endpoint, browser-side request runner an author or reviewer can exercise.
+ *
+ * Load-bearing safety design: dxkit stays a STATIC analyzer — this module
+ * assembles a document, it never makes an HTTP call. The document is
+ * interactive client-side; the base URL and auth token are entered at runtime,
+ * live only in the open browser tab, and are never baked into the artifact,
+ * committed, logged, or seen by dxkit or CI. The generated HTML carries request
+ * TEMPLATES only.
+ *
+ * Pure over its inputs (`buildFlowConsole` does no I/O): the vis-network bundle
+ * is passed in already-read by the CLI layer, so this builder stays testable and
+ * deterministic. The endpoint model is assembled from the flow map + optional
+ * diff scope + optional gate findings by `console-view.ts`.
+ */
+
+import { CONSOLE_APP_JS, CONSOLE_CSS } from './console-assets';
+
+/** One endpoint as the console renders it — a served route plus how the UI
+ *  consumes it, and optional per-PR annotations (touched by the diff / broken
+ *  by the gate). */
+export interface ConsoleEndpoint {
+  readonly id: string;
+  readonly method: string;
+  /** Normalized served path; `{var}` segments become fillable inputs. */
+  readonly path: string;
+  readonly via: string;
+  readonly handler: string | null;
+  readonly sourceFile: string;
+  readonly line?: number;
+  readonly consumerCount: number;
+  readonly consumerFiles: readonly string[];
+  /** The diff touched this endpoint's served file or a consuming file. */
+  readonly affected?: boolean;
+  /** The integration gate flagged this endpoint as a net-new break. */
+  readonly broken?: { readonly reason: string; readonly verdict: 'block' | 'warn' } | null;
+}
+
+export interface FlowConsoleInput {
+  readonly repoName?: string;
+  readonly generatedAt: string;
+  readonly dxkitVersion?: string;
+  /** `full` = the whole map; `diff` = only endpoints the PR touches (§E). */
+  readonly scope: 'full' | 'diff';
+  readonly baseRef?: string;
+  readonly diffFileCount?: number;
+  readonly endpoints: readonly ConsoleEndpoint[];
+  /** Served-but-unconsumed endpoints (dead-route or cross-repo candidates). */
+  readonly unconsumed: readonly ConsoleEndpoint[];
+  /** Net-new broken integrations the gate flagged for this change (§E: the gate
+   *  says WHICH bindings broke, the console lets a reviewer exercise them). Each
+   *  is a consumed call whose target route is missing/removed at HEAD, so it has
+   *  no served endpoint in the map above — surfaced as its own section. Only
+   *  populated in `diff` scope. */
+  readonly broken: readonly ConsoleEndpoint[];
+  readonly totals: { readonly endpoints: number; readonly bindings: number };
+  /** The bundled vis-network source, or '' to omit the interactive map (the
+   *  request runner still works). Injected by the CLI (I/O), so the builder
+   *  stays pure. */
+  readonly visNetworkBundle: string;
+}
+
+/** HTML-escape text destined for element content / attributes. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Serialize the data model for a `<script type="application/json">` island.
+ * Escaping `<`/`>`/`&` (and the two line-separator code points JSON leaves raw)
+ * makes the payload safe to embed regardless of what file paths or handler names
+ * it carries — no string can break out of the script element or inject markup.
+ */
+export function serializeDataIsland(model: unknown): string {
+  return JSON.stringify(model)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+/** Guard the inlined vis-network bundle against a stray `</script>` closing the
+ *  surrounding element (mirror of the dashboard's defensive escape). */
+function safeScriptBody(js: string): string {
+  return js.replace(/<\/script>/gi, '<\\/script>');
+}
+
+function scopeLine(input: FlowConsoleInput): string {
+  if (input.scope === 'diff') {
+    const base = input.baseRef ? ` vs <code>${escapeHtml(input.baseRef)}</code>` : '';
+    const files = input.diffFileCount != null ? ` · ${input.diffFileCount} changed file(s)` : '';
+    return `Scoped to this change${base}${files} — showing only the integrations it touches.`;
+  }
+  return 'Full map — every UI→API integration dxkit found in this repo.';
+}
+
+/**
+ * Assemble the self-contained console HTML. The data model is embedded as a
+ * JSON island the inlined app reads; CSS + app JS + (optional) vis-network are
+ * inlined so the file opens offline with no external fetch.
+ */
+export function buildFlowConsole(input: FlowConsoleInput): string {
+  const model = {
+    meta: {
+      repoName: input.repoName ?? null,
+      generatedAt: input.generatedAt,
+      dxkitVersion: input.dxkitVersion ?? null,
+      scope: input.scope,
+      baseRef: input.baseRef ?? null,
+      diffFileCount: input.diffFileCount ?? null,
+    },
+    totals: input.totals,
+    endpoints: input.endpoints,
+    unconsumed: input.unconsumed,
+    broken: input.broken,
+  };
+  const dataIsland = serializeDataIsland(model);
+  const visTag = input.visNetworkBundle
+    ? `<script>${safeScriptBody(input.visNetworkBundle)}</script>`
+    : '';
+
+  const title = input.repoName ? `Flow console — ${escapeHtml(input.repoName)}` : 'Flow console';
+  const scopedCount = input.endpoints.length + input.unconsumed.length;
+
+  // The broken-integrations section only makes sense for a diffed view (the
+  // gate needs a base to diff against). In full scope it is omitted entirely.
+  const brokenSection =
+    input.scope === 'diff'
+      ? `  <div class="dx-section-h">Net-new broken integrations</div>
+  <div id="dx-broken"></div>
+`
+      : '';
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${title}</title>
+<style>${CONSOLE_CSS}</style>
+</head>
+<body>
+<header class="dx-head">
+  <h1>${title}</h1>
+  <div class="sub">${scopeLine(input)}</div>
+</header>
+
+<div class="dx-safety">
+  <strong>Runs in your browser.</strong> Enter a Base URL (a dev or staging origin — never prod)
+  and, if needed, an auth token below. Both stay only in this tab: they are never committed,
+  logged, or sent to dxkit or CI. dxkit generated this page statically and makes no requests
+  itself. The API must allow this page's origin (CORS), or open the file against a local/dev server.
+</div>
+
+<div class="dx-controls">
+  <div class="fld">
+    <label for="dx-base">Base URL</label>
+    <input id="dx-base" type="url" placeholder="https://staging.example.com" autocomplete="off" spellcheck="false" />
+  </div>
+  <div class="fld">
+    <label for="dx-auth">Authorization header (optional)</label>
+    <input id="dx-auth" type="password" placeholder="Bearer …" autocomplete="off" spellcheck="false" />
+  </div>
+</div>
+
+<div class="dx-summary">
+  <div class="stat"><b>${input.totals.endpoints}</b><span>endpoints served</span></div>
+  <div class="stat"><b>${input.totals.bindings}</b><span>UI→API bindings</span></div>
+  <div class="stat"><b>${scopedCount}</b><span>in this view</span></div>
+</div>
+
+<div id="dx-graph"></div>
+
+<main>
+${brokenSection}  <div class="dx-section-h">Consumed endpoints</div>
+  <div id="dx-endpoints"></div>
+  <div class="dx-section-h">Served but unconsumed</div>
+  <div id="dx-unconsumed"></div>
+</main>
+
+<script id="dxkit-flow-data" type="application/json">${dataIsland}</script>
+${visTag}
+<script>${safeScriptBody(CONSOLE_APP_JS)}</script>
+</body>
+</html>
+`;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -386,6 +386,9 @@ export async function run(argv: string[]): Promise<void> {
       'baseline-name': { type: 'string' },
       snyk: { type: 'boolean', default: false },
       out: { type: 'string' },
+      // flow console flags: scope to a diff base + optionally skip the gate pass
+      diff: { type: 'string' },
+      'no-gate': { type: 'boolean', default: false },
       // issue flags
       type: { type: 'string' },
       about: { type: 'string' },
@@ -961,6 +964,22 @@ export async function run(argv: string[]): Promise<void> {
         });
         break;
       }
+      // `flow console` → the interactive HTML console (map + request runner).
+      // `--diff <ref>` scopes it to the change and marks net-new breaks.
+      if (subCommand === 'console') {
+        const { runFlowConsole } = await import('./flow-cli');
+        await runFlowConsole({
+          cwd,
+          frontend,
+          backend,
+          specs,
+          diff: values.diff as string | undefined,
+          out: values.out as string | undefined,
+          noGate: !!values['no-gate'],
+          json: !!values.json,
+        });
+        break;
+      }
       // `flow refresh` → write the served/consumed contract snapshots the
       // cross-repo integration gate reads.
       if (subCommand === 'refresh') {
@@ -980,6 +999,7 @@ export async function run(argv: string[]): Promise<void> {
       logger.info('  vyuh-dxkit flow [map] [--frontend <dir>] [--backend <dir>] [--specs <a,b>]');
       logger.info('  vyuh-dxkit flow trace "<METHOD> <path>"');
       logger.info('  vyuh-dxkit flow extract [--out <dir>]');
+      logger.info('  vyuh-dxkit flow console [--diff <ref>] [--out <file>] [--no-gate]');
       logger.info('  vyuh-dxkit flow refresh');
       logger.info('  vyuh-dxkit flow publish   (multi-repo: union participants’ served routes)');
       process.exit(1);

--- a/src/dashboard/graph-tab.ts
+++ b/src/dashboard/graph-tab.ts
@@ -32,9 +32,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { loadGraph } from '../explore/load';
 import { dxkitCli } from '../self-invocation';
+import { VENDOR_DIR, readVisNetworkBundle } from './vendor';
 
-/** Default vendor + report locations, relative to module + cwd. */
-const VENDOR_DIR = path.join(__dirname, 'vendor');
+/** Default report location, relative to cwd. (Vendor dir lives in `vendor.ts`.) */
 const GRAPH_HTML_REL = path.join('.dxkit', 'reports', 'graph.html');
 
 /** Options accepted by the tab renderer. */
@@ -153,13 +153,7 @@ export function renderGraphTab(opts: GraphTabOptions): {
   };
 }
 
-// ─── Vendor + HTML manipulation ──────────────────────────────────────────────
-
-function readVisNetworkBundle(vendorDir: string): string | undefined {
-  const file = path.join(vendorDir, 'vis-network.min.js');
-  if (!fs.existsSync(file)) return undefined;
-  return fs.readFileSync(file, 'utf-8');
-}
+// ─── HTML manipulation ───────────────────────────────────────────────────────
 
 /** Sidecar metadata produced by the graphify gather. */
 interface GraphHtmlMeta {

--- a/src/dashboard/vendor.ts
+++ b/src/dashboard/vendor.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared vis-network vendor bundle reader — the ONE place that locates and
+ * reads the offline-friendly `vis-network.min.js` dxkit ships alongside the
+ * dashboard (Rule 2: one gather per external asset). Both the dashboard graph
+ * tab (which swaps graphify's CDN `<script>` for this bundle) and the flow
+ * console (which builds its own vis-network view) read the bundle through here,
+ * so neither re-derives the vendor path or the missing-bundle fallback.
+ *
+ * `scripts/copy-templates.js` copies the bundle from `node_modules/vis-network`
+ * into `dist/dashboard/vendor/` at build time; `__dirname` resolves to
+ * `dist/dashboard` at runtime, so the default `VENDOR_DIR` points at that copy.
+ * A missing bundle (dxkit built without `npm run build`) returns `undefined`
+ * rather than throwing — the consumer degrades gracefully (an offline-only
+ * note, or a list-only flow view).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** The bundled vis-network location, relative to the compiled module. */
+export const VENDOR_DIR = path.join(__dirname, 'vendor');
+
+/**
+ * Read the bundled `vis-network.min.js`, or `undefined` when it is absent.
+ * `vendorDir` is overridable so tests can point at a fixture without depending
+ * on a real build having populated `dist/`.
+ */
+export function readVisNetworkBundle(vendorDir: string = VENDOR_DIR): string | undefined {
+  const file = path.join(vendorDir, 'vis-network.min.js');
+  if (!fs.existsSync(file)) return undefined;
+  return fs.readFileSync(file, 'utf-8');
+}

--- a/src/flow-cli.ts
+++ b/src/flow-cli.ts
@@ -20,6 +20,16 @@ import {
   writeServedContract,
 } from './analyzers/flow/contract';
 import { publishFlow } from './analyzers/flow/publish';
+import {
+  buildFlowConsole,
+  type ConsoleEndpoint,
+  type FlowConsoleInput,
+} from './analyzers/flow/console';
+import { computeChangedFiles } from './baseline/changed-files';
+import { evaluateFlowGateForGuardrail } from './baseline/flow-gate-check';
+import { loadAllowlist } from './allowlist/file';
+import { readVisNetworkBundle } from './dashboard/vendor';
+import { readDxkitVersion } from './issue-cli';
 
 export interface FlowExtractOptions {
   readonly cwd: string;
@@ -192,6 +202,164 @@ export async function runFlowTrace(opts: FlowViewOptions & { target: string }): 
   logger.info(
     `Blast radius: ${br.directConsumers} direct consumer(s) in ${br.consumerFiles} file(s)` +
       (br.upstreamCallers ? `, ${br.upstreamCallers} upstream caller(s)` : ''),
+  );
+}
+
+/** Default on-disk location for the generated console artifact. */
+const CONSOLE_REPORT_REL = path.join('.dxkit', 'reports', 'flow-console.html');
+
+export interface FlowConsoleOptions extends FlowViewOptions {
+  /** Base ref to scope the console to (and gate against). Absent → full map. */
+  readonly diff?: string;
+  /** Output HTML path (default `.dxkit/reports/flow-console.html`). */
+  readonly out?: string;
+  /** Skip the broken-integration gate pass even in diff scope. */
+  readonly noGate?: boolean;
+}
+
+/**
+ * `vyuh-dxkit flow console` — generate the self-contained interactive HTML
+ * console (design §E): the UI→API map plus a browser-side request runner per
+ * endpoint. A renderer over the same `FlowModel` the map/gate read; dxkit makes
+ * no HTTP call, it only writes the document.
+ *
+ * With `--diff <ref>` the console is PR-scoped: only endpoints the change
+ * touches are shown, and the integration gate marks any net-new broken bindings
+ * so a reviewer can exercise exactly what moved. Without it, the full map.
+ */
+export async function runFlowConsole(opts: FlowConsoleOptions): Promise<void> {
+  if (!opts.json) logger.header('vyuh-dxkit flow console');
+
+  // Diff scope: the files this change touched (or null → can't scope → full).
+  // Computed BEFORE the overlay write below so dxkit's own `graph.json` output
+  // never leaks into the changed set.
+  let scope: 'full' | 'diff' = opts.diff ? 'diff' : 'full';
+  let changedSet: Set<string> | null = null;
+  let diffFileCount: number | undefined;
+  if (opts.diff) {
+    const changed = computeChangedFiles(opts.cwd, opts.diff);
+    if (changed) {
+      changedSet = new Set(changed);
+      diffFileCount = changed.length;
+    } else {
+      scope = 'full'; // base unreachable / not a git repo → don't fake a scope
+    }
+  }
+
+  // Repo-relative locators — diff scoping matches `computeChangedFiles` (which
+  // reports repo-relative paths) and the artifact is portable across machines
+  // (Rule 9 pattern, as `flow refresh`).
+  const model = await gatherModel(opts, { relativeTo: opts.cwd });
+  const map = buildFlowMap(opts.cwd, model);
+  const isAffected = (sourceFile: string, consumerFiles: readonly string[]): boolean =>
+    changedSet !== null &&
+    (changedSet.has(sourceFile) || consumerFiles.some((f) => changedSet!.has(f)));
+
+  // Gate: net-new broken integrations for this change (diff scope only).
+  const broken: ConsoleEndpoint[] = [];
+  if (scope === 'diff' && opts.diff && !opts.noGate) {
+    try {
+      const outcome = await evaluateFlowGateForGuardrail({
+        cwd: opts.cwd,
+        baseRef: opts.diff,
+        allowlist: loadAllowlist(opts.cwd),
+      });
+      if (outcome.ran) {
+        for (const f of outcome.findings) {
+          broken.push({
+            id: f.id,
+            method: f.method,
+            path: f.path,
+            via: 'call-site',
+            handler: null,
+            sourceFile: f.file,
+            line: f.line,
+            consumerCount: 1,
+            consumerFiles: [f.file],
+            affected: true,
+            broken: { reason: f.reason, verdict: f.verdict },
+          });
+        }
+      }
+    } catch {
+      // Fail-open: the console is a reviewer aid, never itself a gate.
+    }
+  }
+
+  const consumed: ConsoleEndpoint[] = map.endpoints.map((e) => ({
+    id: e.endpoint.id,
+    method: e.endpoint.method,
+    path: e.endpoint.path,
+    via: e.endpoint.via,
+    handler: e.endpoint.handler,
+    sourceFile: e.endpoint.sourceFile,
+    line: e.endpoint.line,
+    consumerCount: e.consumerCount,
+    consumerFiles: e.consumerFiles,
+    affected: isAffected(e.endpoint.sourceFile, e.consumerFiles),
+  }));
+  const unconsumed: ConsoleEndpoint[] = map.unconsumedEndpoints.map((ep) => ({
+    id: ep.id,
+    method: ep.method,
+    path: ep.path,
+    via: ep.via,
+    handler: ep.handler,
+    sourceFile: ep.sourceFile,
+    line: ep.line,
+    consumerCount: 0,
+    consumerFiles: [],
+    affected: isAffected(ep.sourceFile, []),
+  }));
+
+  const shownEndpoints = scope === 'diff' ? consumed.filter((e) => e.affected) : consumed;
+  const shownUnconsumed = scope === 'diff' ? unconsumed.filter((e) => e.affected) : unconsumed;
+
+  const bundle = readVisNetworkBundle() ?? '';
+  const input: FlowConsoleInput = {
+    repoName: path.basename(path.resolve(opts.cwd)),
+    generatedAt: new Date().toISOString(),
+    dxkitVersion: readDxkitVersion(),
+    scope,
+    baseRef: scope === 'diff' ? opts.diff : undefined,
+    diffFileCount,
+    endpoints: shownEndpoints,
+    unconsumed: shownUnconsumed,
+    broken,
+    totals: { endpoints: map.totalEndpoints, bindings: map.totalBindings },
+    visNetworkBundle: bundle,
+  };
+  const html = buildFlowConsole(input);
+  const outPath = path.resolve(opts.cwd, opts.out ?? CONSOLE_REPORT_REL);
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, html);
+
+  if (opts.json) {
+    emitJson({
+      outPath,
+      scope,
+      totalEndpoints: map.totalEndpoints,
+      shownEndpoints: shownEndpoints.length + shownUnconsumed.length,
+      broken: broken.length,
+      bindings: map.totalBindings,
+      hasGraph: !!bundle,
+    });
+    return;
+  }
+
+  const scopeNote =
+    scope === 'diff'
+      ? `scoped to ${diffFileCount ?? '?'} changed file(s) vs ${opts.diff}`
+      : 'full map';
+  logger.success(
+    `Flow console written (${scopeNote}): ${map.totalEndpoints} endpoint(s), ${broken.length} net-new break(s).`,
+  );
+  logger.info(`  ${path.relative(opts.cwd, outPath)}`);
+  logger.info('');
+  logger.info(
+    'Open it in a browser, enter a dev/staging Base URL + token, and exercise the calls.',
+  );
+  logger.info(
+    'Auth stays in your tab — dxkit generated this page statically and makes no requests.',
   );
 }
 

--- a/test/flow-console-view.test.ts
+++ b/test/flow-console-view.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests for `runFlowConsole` (src/flow-cli.ts) — the read
+ * orchestrator behind `vyuh-dxkit flow console`. Exercised end-to-end against a
+ * real on-disk git fixture (a monorepo frontend + backend), so the diff scope
+ * (via `computeChangedFiles`) and the gate pass (via `withRefWorktree`) run for
+ * real, not mocked.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, readFileSync, rmSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runFlowConsole } from '../src/flow-cli';
+
+function write(root: string, rel: string, content: string): void {
+  const abs = join(root, rel);
+  mkdirSync(join(abs, '..'), { recursive: true });
+  writeFileSync(abs, content);
+}
+function git(root: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+/** The generated console captures its output path in --json mode; recover it
+ *  and read the embedded data island back. */
+function readConsole(root: string, outPath: string): Record<string, unknown> {
+  const html = readFileSync(outPath, 'utf8');
+  const m = html.match(
+    /<script id="dxkit-flow-data" type="application\/json">([\s\S]*?)<\/script>/,
+  );
+  if (!m) throw new Error('no data island');
+  return JSON.parse(m[1]) as Record<string, unknown>;
+}
+
+const FRONTEND = `import axios from 'axios';
+export const listArticles = () => axios.get('/articles');
+export const getArticle = (slug) => axios.get(\`/articles/\${slug}\`);
+export const createArticle = (d) => axios.post('/articles', d);
+`;
+const BACKEND = `import { Router } from 'express';
+const app = Router();
+app.get('/articles', (req, res) => res.json([]));
+app.get('/articles/:slug', (req, res) => res.json({}));
+app.post('/articles', (req, res) => res.json({}));
+export default app;
+`;
+
+describe('runFlowConsole', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'dxkit-flowconsole-'));
+    write(root, 'package.json', JSON.stringify({ name: 'fx', version: '1.0.0' }));
+    write(root, 'tsconfig.json', JSON.stringify({ compilerOptions: { module: 'commonjs' } }));
+    write(root, 'frontend/api.ts', FRONTEND);
+    write(root, 'backend/routes.ts', BACKEND);
+    git(root, 'init', '-q');
+    git(root, 'config', 'user.email', 't@t.t');
+    git(root, 'config', 'user.name', 'test');
+    git(root, 'add', '-A');
+    git(root, 'commit', '-qm', 'base');
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('full scope: writes a self-contained HTML console with every endpoint', async () => {
+    await runFlowConsole({ cwd: root });
+    const outPath = join(root, '.dxkit', 'reports', 'flow-console.html');
+    const html = readFileSync(outPath, 'utf8');
+    expect(html.startsWith('<!doctype html>')).toBe(true);
+    const data = readConsole(root, outPath);
+    expect((data.meta as { scope: string }).scope).toBe('full');
+    // 3 served routes, all consumed by the frontend.
+    expect((data.endpoints as unknown[]).length).toBe(3);
+    expect((data.broken as unknown[]).length).toBe(0);
+  });
+
+  it('diff scope: a net-new dead call is surfaced as a broken integration', async () => {
+    const base = git(root, 'rev-parse', 'HEAD').trim();
+    // Working-tree only: a new call to a route no backend serves.
+    appendFileSync(
+      join(root, 'frontend/api.ts'),
+      'export const getWidget = (id) => axios.get(`/widgets/${id}`);\n',
+    );
+    await runFlowConsole({ cwd: root, diff: base });
+    const data = readConsole(root, join(root, '.dxkit', 'reports', 'flow-console.html'));
+    expect((data.meta as { scope: string }).scope).toBe('diff');
+    const broken = data.broken as Array<{ path: string; broken: { reason: string } }>;
+    expect(broken).toHaveLength(1);
+    expect(broken[0].path).toBe('/widgets/{var}');
+    expect(broken[0].broken.reason).toBe('no-route');
+  });
+
+  it('diff scope + --no-gate: still scopes to the change but runs no gate pass', async () => {
+    const base = git(root, 'rev-parse', 'HEAD').trim();
+    appendFileSync(
+      join(root, 'frontend/api.ts'),
+      'export const getWidget = (id) => axios.get(`/widgets/${id}`);\n',
+    );
+    await runFlowConsole({ cwd: root, diff: base, noGate: true });
+    const data = readConsole(root, join(root, '.dxkit', 'reports', 'flow-console.html'));
+    expect((data.meta as { scope: string }).scope).toBe('diff');
+    expect((data.broken as unknown[]).length).toBe(0);
+  });
+
+  it('honours --out for the artifact location', async () => {
+    const out = join(root, 'custom', 'console.html');
+    await runFlowConsole({ cwd: root, out });
+    expect(() => readFileSync(out, 'utf8')).not.toThrow();
+  });
+});

--- a/test/flow-console.test.ts
+++ b/test/flow-console.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildFlowConsole,
+  serializeDataIsland,
+  type ConsoleEndpoint,
+  type FlowConsoleInput,
+} from '../src/analyzers/flow/console';
+
+function endpoint(over: Partial<ConsoleEndpoint> = {}): ConsoleEndpoint {
+  return {
+    id: 'ep0',
+    method: 'GET',
+    path: '/articles/{var}',
+    via: 'router-call',
+    handler: 'getArticle',
+    sourceFile: 'backend/routes.ts',
+    line: 12,
+    consumerCount: 2,
+    consumerFiles: ['frontend/api.ts'],
+    ...over,
+  };
+}
+
+function input(over: Partial<FlowConsoleInput> = {}): FlowConsoleInput {
+  return {
+    repoName: 'demo',
+    generatedAt: '2026-07-04T00:00:00.000Z',
+    dxkitVersion: '2.25.0',
+    scope: 'full',
+    endpoints: [endpoint()],
+    unconsumed: [],
+    broken: [],
+    totals: { endpoints: 1, bindings: 2 },
+    visNetworkBundle: '',
+    ...over,
+  };
+}
+
+/** Pull the JSON data island out of the generated HTML. */
+function parseIsland(html: string): Record<string, unknown> {
+  const m = html.match(
+    /<script id="dxkit-flow-data" type="application\/json">([\s\S]*?)<\/script>/,
+  );
+  expect(m, 'data island present').toBeTruthy();
+  return JSON.parse(m![1]) as Record<string, unknown>;
+}
+
+describe('buildFlowConsole', () => {
+  it('emits a complete self-contained HTML document', () => {
+    const html = buildFlowConsole(input());
+    expect(html.startsWith('<!doctype html>')).toBe(true);
+    expect(html).toContain('</html>');
+    // No external fetches — CSS + app JS are inline.
+    expect(html).not.toMatch(/<link\b[^>]*rel=["']stylesheet/i);
+    expect(html).not.toMatch(/<script\b[^>]*\bsrc=/i);
+  });
+
+  it('embeds the model as a parseable JSON data island', () => {
+    const data = parseIsland(buildFlowConsole(input()));
+    expect((data.endpoints as unknown[]).length).toBe(1);
+    expect((data.totals as { endpoints: number }).endpoints).toBe(1);
+    expect((data.meta as { scope: string }).scope).toBe('full');
+  });
+
+  it('inlines the vis-network bundle when supplied and omits it otherwise', () => {
+    const withVis = buildFlowConsole(input({ visNetworkBundle: 'window.vis={Network:1};' }));
+    expect(withVis).toContain('window.vis={Network:1};');
+    const withoutVis = buildFlowConsole(input({ visNetworkBundle: '' }));
+    expect(withoutVis).not.toContain('window.vis=');
+  });
+
+  it('renders the request runner app (a browser-side, not dxkit-side, caller)', () => {
+    const html = buildFlowConsole(input());
+    expect(html).toContain('Send request');
+    expect(html).toContain('Base URL');
+    // The safety contract must be stated in the document.
+    expect(html).toMatch(/never (committed|prod)/i);
+  });
+
+  it('shows the broken-integrations section only in diff scope', () => {
+    expect(buildFlowConsole(input({ scope: 'full' }))).not.toContain('id="dx-broken"');
+    const diff = buildFlowConsole(
+      input({
+        scope: 'diff',
+        baseRef: 'main',
+        diffFileCount: 3,
+        endpoints: [],
+        totals: { endpoints: 0, bindings: 0 },
+      }),
+    );
+    expect(diff).toContain('id="dx-broken"');
+    expect(diff).toContain('Net-new broken integrations');
+  });
+
+  it('carries the diff scope + base ref in the header and model', () => {
+    const html = buildFlowConsole(
+      input({ scope: 'diff', baseRef: 'origin/main', diffFileCount: 4 }),
+    );
+    expect(html).toMatch(/Scoped to this change/);
+    expect(html).toContain('origin/main');
+    const data = parseIsland(html);
+    expect((data.meta as { baseRef: string }).baseRef).toBe('origin/main');
+    expect((data.meta as { diffFileCount: number }).diffFileCount).toBe(4);
+  });
+
+  it('propagates a broken finding into the model', () => {
+    const broken = endpoint({
+      id: 'ep9',
+      method: 'POST',
+      path: '/widgets',
+      via: 'call-site',
+      handler: null,
+      sourceFile: 'frontend/api.ts',
+      consumerCount: 1,
+      consumerFiles: ['frontend/api.ts'],
+      affected: true,
+      broken: { reason: 'no-route', verdict: 'block' },
+    });
+    const data = parseIsland(buildFlowConsole(input({ scope: 'diff', broken: [broken] })));
+    const list = data.broken as Array<{ broken: { reason: string; verdict: string } }>;
+    expect(list).toHaveLength(1);
+    expect(list[0].broken.verdict).toBe('block');
+  });
+
+  it('a hostile file path cannot break out of the data island or inject markup', () => {
+    const evil = endpoint({ sourceFile: 'x</script><img src=x onerror=alert(1)>.ts' });
+    const html = buildFlowConsole(input({ endpoints: [evil] }));
+    // The raw closing-tag sequence must not appear verbatim inside the island;
+    // the data island still parses and preserves the original string.
+    const island = html.match(
+      /<script id="dxkit-flow-data" type="application\/json">([\s\S]*?)<\/script>/,
+    );
+    expect(island).toBeTruthy();
+    expect(island![1]).not.toContain('</script>');
+    const data = JSON.parse(island![1]) as { endpoints: Array<{ sourceFile: string }> };
+    expect(data.endpoints[0].sourceFile).toContain('onerror');
+    // Only ONE real </script> closes the app script that follows the island.
+  });
+});
+
+describe('serializeDataIsland', () => {
+  it('escapes the characters that could break out of a <script> element', () => {
+    const out = serializeDataIsland({ a: '</script>', b: '<b>&', c: 'x>y' });
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
+    expect(out).not.toContain('&');
+    expect(out).toContain('\\u003c'); // <
+    expect(out).toContain('\\u003e'); // >
+    expect(out).toContain('\\u0026'); // &
+  });
+
+  it('round-trips to the original object after unescaping via JSON.parse', () => {
+    const obj = { path: '/a/{var}', note: 'a < b && c > d' };
+    // The escaped \u00xx sequences are valid JSON escapes, so JSON.parse
+    // recovers the original string.
+    expect(JSON.parse(serializeDataIsland(obj))).toEqual(obj);
+  });
+});


### PR DESCRIPTION
## M5 — the interactive HTML flow console

`vyuh-dxkit flow console` — a self-contained, offline HTML artifact that renders the UI→API map plus a request runner per endpoint. It is the higher-value sibling of the flow CSVs and the reviewer-facing complement to the gate: where the gate says *which* integrations a change breaks, the console lets a reviewer or author *exercise* exactly what moved.

### What ships
- **`flow console` CLI** — a renderer over the same `FlowModel` the map + gate read (no new extraction; mirror of `csv.ts`). Writes `.dxkit/reports/flow-console.html`.
- **`--diff <ref>`** — PR-scoped: only the endpoints the change touches, with any net-new broken integration flagged by reusing the existing flow gate (`evaluateFlowGateForGuardrail`, not reimplemented).
- **CI/PR surface** — the shipped guardrails workflow generates the console scoped to the PR base, uploads it as a build artifact (only when the diff touched an integration), and links it from the guardrail PR comment. No server, no required infra; self-skips on repos with no UI→API surface.
- **`dxkit-flow` skill** gains a `console` mode (same-PR skill sweep).

### Load-bearing safety
dxkit stays a **static analyzer and makes zero HTTP calls** — it only assembles the document. The runner calls *from the browser* when the user opens the file and enters, at runtime, a Base URL (their dev/staging, never prod) and an auth token that lives only in the open tab: never committed, logged, baked into the artifact, or seen by dxkit or CI. The HTML carries request templates only.

### Platform respect
- Rule 2: the vis-network vendor-bundle reader is extracted into `src/dashboard/vendor.ts` as the one reader; the dashboard graph tab now imports it.
- Rule 12: graph reads stay behind `buildFlowMap` (explore layer); the pure builder just takes data.
- `buildFlowConsole` is pure + deterministic (the vis bundle is injected by the CLI); the model is an escaped JSON island rendered by a small inline vanilla-JS app.

### Tests
- `test/flow-console.test.ts` — pure builder (self-containment, data-island parse, XSS-safe hostile path, diff/broken sections, escaping).
- `test/flow-console-view.test.ts` — end-to-end orchestrator against a real git fixture (full scope, diff scope + net-new break, `--no-gate`, `--out`).

Rebase-merge (three independently-meaningful commits: console engine, CI surface, release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)