### PR TITLE
2.26.0 — package-manager awareness + uninstall/template reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.26.0] - 2026-07-05
+
+### Fixed — package-manager awareness (from first-real-repo dogfood feedback)
+
+dxkit assumed npm everywhere. On a pnpm project that surfaced as a first-touch
+crash and a trail of npm-only hints. dxkit now detects the repo's
+package manager from its lockfile (pnpm / yarn / bun / npm, falling back to the
+`packageManager` field) and phrases every install accordingly.
+
+- **`npm init @vyuhlabs/dxkit` no longer crashes in pnpm/yarn/bun repos.** The
+  bootstrap detected npm unconditionally and ran `npm install`, which errors out
+  in a pnpm workspace. It now adds `@vyuhlabs/dxkit` with the repo's own PM
+  (`pnpm add -D` / `yarn add -D` / `bun add -d` / `npm install --save-dev`); the
+  `--legacy-peer-deps` retry is correctly npm-only.
+- **Install suggestions + executed tool installs are PM-aware.** `doctor` and
+  `tools` now print `pnpm add -D …` / `pnpm install` etc. for your repo, and a
+  node devDependency tool (e.g. `@vitest/coverage-v8`) installs with your PM.
+- **`--yes` already existed** for `tools install` (unattended CI/agent runs);
+  it is now documented in the usage text.
+
+### Fixed — the Next.js rule template activates on any layout
+
+The bundled `.claude/rules/nextjs.md` scoped its `paths:` to `frontend/**` and told
+you to build in `frontend/`. On a single-Next.js-app-at-root repo that matched no
+files, so the rule never activated (installed but inert). Its `paths:` now match
+Next.js files at any depth (App Router, Pages Router, components — root, `src/`,
+`frontend/`, or a monorepo), and the build guidance is package-manager-agnostic.
+
+### Fixed — `uninstall` completeness + discoverability
+
+- **Skills no longer survive an uninstall on repos installed under an older
+  version.** A pre-2.24 manifest didn't record the `dxkit-*` skills, so
+  `uninstall` (which reads the manifest) left all of them behind. It now sweeps
+  `.claude/skills/dxkit-*` by the unambiguous prefix even when an older manifest
+  omits them; your own non-`dxkit-` skills are untouched.
+- **`.gitignore` revert is byte-exact.** It no longer collapses a pre-existing
+  blank line elsewhere in the file — only dxkit's appended block (plus the one
+  separator line it added) is removed.
+- **After `--remove-devdep`, dxkit prints the right "now run install" command**
+  for your PM to prune the lockfile, with a pnpm release-age ordering note.
+- **`uninstall` is now listed in `--help`** and in the `issue --type` list.
+
+### Notes
+
+- **Upgrading in place from ≤2.22 with `--with-hooks`?** Those versions installed
+  `.githooks/pre-push` without setting `core.hooksPath`, so the hook was inert.
+  2.25.0+ wires `core.hooksPath` via a postinstall step; `vyuh-dxkit doctor`
+  flags "hook present but hooksPath unset" and `vyuh-dxkit hooks activate`
+  repairs it.
+- **A package manager's release-age policy can hold back `@latest`.** pnpm's
+  `minimumReleaseAge`, for example, can silently resolve `@vyuhlabs/dxkit@latest`
+  to an older version than what's published. If a feature you expect is missing,
+  check your PM's release-age setting or pin the version explicitly.
+
 ## [2.25.0] - 2026-07-04
 
 ### Added — the interactive flow console (`vyuh-dxkit flow console`)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ npx vyuh-dxkit loop doctor                         # verify the gate is wired
 The stop verdict has no model in the path: same input, same verdict.
 Existing debt stays grandfathered; only net-new regressions block.
 
+> The agent-facing pieces (the skills like `dxkit-onboard` and `dxkit-fix`, the Stop-gate, and "ask Claude to fix dxkit" guidance) activate when your agent session is **rooted in the repo**, meaning it started from the repo directory. Open your agent there, not in a parent folder.
+
 [Read the benchmark](docs/benchmarks.md) · [Try it on your repo](#try-it-on-your-repo) · [Run the fixture gate](#run-a-local-fixture-gate)
 
 <p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.25.0",
+      "version": "2.26.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/packages/create-dxkit/index.js
+++ b/packages/create-dxkit/index.js
@@ -9,21 +9,29 @@
  *
  * Responsibilities, in order:
  *   1. Seed a minimal `package.json` if the cwd doesn't have one
- *      (else `npm install --save-dev` would write to the global one).
- *   2. Run `npm install --save-dev @vyuhlabs/dxkit`. On peer-dep
- *      ERESOLVE, retry once with `--legacy-peer-deps`.
+ *      (else the dev-dep install would write to the global one).
+ *   2. Detect the repo's package manager from its lockfile (pnpm / yarn
+ *      / bun / npm) and add `@vyuhlabs/dxkit` as a devDependency with
+ *      THAT PM — running `npm install` in a pnpm repo crashes npm. On an
+ *      npm peer-dep ERESOLVE, retry once with `--legacy-peer-deps`.
  *   3. Forward the user's args (or `--full --yes` if none) to
  *      `vyuh-dxkit init`.
  *
  * Zero runtime dependencies — keeps the install surface as narrow as
  * possible so a customer hitting this for the first time doesn't pull
- * a transitive that conflicts with their tree.
+ * a transitive that conflicts with their tree. That is also why the
+ * package-manager detection is a small self-contained copy of
+ * `src/package-manager.ts` rather than an import: this shim is a
+ * separate published package and cannot depend on the main one.
  */
 'use strict';
 
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
+
+/** The package this bootstrap installs. */
+const PKG = '@vyuhlabs/dxkit';
 
 // ── Pure helpers (exported for unit tests) ──────────────────────────
 
@@ -67,6 +75,56 @@ function npmBin(platform = process.platform) {
 }
 function npxBin(platform = process.platform) {
   return platform === 'win32' ? 'npx.cmd' : 'npx';
+}
+
+/**
+ * Detect the repo's package manager — lockfile first (it reflects what actually
+ * provisioned node_modules), then the `packageManager` field (corepack), else
+ * npm. Self-contained copy of `src/package-manager.ts:detectPackageManager`
+ * (this shim can't import from the main package). `fsMod`/`pathMod` are
+ * injectable for unit tests.
+ */
+function detectPackageManager(cwd, fsMod = fs, pathMod = path) {
+  const has = (f) => fsMod.existsSync(pathMod.join(cwd, f));
+  if (has('pnpm-lock.yaml')) return 'pnpm';
+  if (has('yarn.lock')) return 'yarn';
+  if (has('bun.lockb') || has('bun.lock')) return 'bun';
+  if (has('package-lock.json')) return 'npm';
+  try {
+    const pkg = JSON.parse(fsMod.readFileSync(pathMod.join(cwd, 'package.json'), 'utf8'));
+    if (typeof pkg.packageManager === 'string') {
+      const name = pkg.packageManager.split('@')[0].trim();
+      if (name === 'pnpm' || name === 'yarn' || name === 'bun' || name === 'npm') return name;
+    }
+  } catch {
+    // no/invalid package.json → fall through to npm
+  }
+  return 'npm';
+}
+
+/** Platform-aware executable name for a package manager. The JS PMs ship as
+ *  `.cmd` shims on Windows; bun ships as `bun.exe`. */
+function pmBin(pm, platform = process.platform) {
+  if (platform !== 'win32') return pm;
+  return pm === 'bun' ? 'bun.exe' : `${pm}.cmd`;
+}
+
+/**
+ * The args that add `@vyuhlabs/dxkit` as a devDependency with the given PM.
+ * `--no-audit` (npm) suppresses the host project's vuln tally mid-install —
+ * those numbers describe the customer's own deps, not anything dxkit added.
+ */
+function installArgs(pm) {
+  switch (pm) {
+    case 'pnpm':
+      return ['add', '-D', PKG];
+    case 'yarn':
+      return ['add', '-D', PKG];
+    case 'bun':
+      return ['add', '-d', PKG];
+    default:
+      return ['install', '--save-dev', '--no-audit', PKG];
+  }
 }
 
 /**
@@ -125,30 +183,36 @@ function extractNpmLogPath(text) {
  * log when one is named, and offers the npx-init escape hatch that
  * doesn't need a successful `npm install` at all.
  *
- * @param {{ stderrChunks?: string[] }} opts
+ * @param {{ stderrChunks?: string[], pm?: string }} opts
  */
 function formatInstallFailure(opts = {}) {
   const stderrChunks = (opts.stderrChunks || []).filter((s) => s && s.length > 0);
+  const pm = opts.pm || 'npm';
   const lines = [];
 
   const combined = stderrChunks.join('\n');
   if (combined.length > 0) {
-    lines.push('npm reported:');
+    lines.push(`${pm} reported:`);
     lines.push(combined.trimEnd());
     lines.push('');
   }
 
-  const logPath = extractNpmLogPath(combined);
-  if (logPath) {
-    lines.push(`Full npm error log: ${logPath}`);
-  } else {
-    lines.push(
-      'npm wrote the failure detail to its debug log — see the ' +
-        '"complete log of this run" path npm printed above, under ' +
-        'your npm cache `_logs/` directory.',
-    );
+  // Only npm routes its failure detail to a `_logs/*-debug.log` and prints a
+  // "complete log of this run" pointer; the other PMs surface the cause on
+  // stderr directly (already shown above).
+  if (pm === 'npm') {
+    const logPath = extractNpmLogPath(combined);
+    if (logPath) {
+      lines.push(`Full npm error log: ${logPath}`);
+    } else {
+      lines.push(
+        'npm wrote the failure detail to its debug log — see the ' +
+          '"complete log of this run" path npm printed above, under ' +
+          'your npm cache `_logs/` directory.',
+      );
+    }
+    lines.push('');
   }
-  lines.push('');
   lines.push('Could not install @vyuhlabs/dxkit. Common causes:');
   lines.push('  • a private-registry auth or proxy issue (check the log above),');
   lines.push("  • an unresolved peer-dep conflict in this folder's package.json,");
@@ -168,6 +232,9 @@ module.exports = {
   ensurePackageJson,
   npmBin,
   npxBin,
+  detectPackageManager,
+  pmBin,
+  installArgs,
   persistLegacyPeerDeps,
   extractNpmLogPath,
   formatInstallFailure,
@@ -195,55 +262,53 @@ if (require.main === module) {
     return spawnSync(cmd, args, { stdio: ['inherit', 'inherit', 'pipe'], shell: false });
   }
 
-  // `--no-audit` keeps npm from printing "N vulnerabilities" at the end of
-  // a successful install. Those numbers describe the HOST project's deps,
-  // not anything dxkit introduced — surfacing them mid-install made
-  // customers think dxkit added them. `vyuh-dxkit vulnerabilities`
-  // is the right surface for dep-vuln triage anyway.
-  const INSTALL_BASE = ['install', '--save-dev', '--no-audit', '@vyuhlabs/dxkit'];
+  // Detect the repo's package manager from its lockfile and install with THAT
+  // PM — `npm install` in a pnpm repo crashes npm ("Cannot read properties of
+  // null"). The dev-dep add args (`--no-audit` etc.) come from `installArgs`.
+  const pm = detectPackageManager(cwd);
+  const addArgs = installArgs(pm);
 
-  console.log('Installing @vyuhlabs/dxkit as devDependency...'); // slop-ok
+  console.log(`Installing ${PKG} as a devDependency with ${pm}...`); // slop-ok
 
-  // Attempt 1: strict peer-dep resolution. On a clean tree this works in
-  // one shot; on most non-trivial customer repos there's at least one
-  // peer-dep mismatch (eslint 8↔10, react cross-pkg, etc.) that fails
-  // here.
-  const attempt1 = runCaptureStderr(npmBin(), INSTALL_BASE);
+  // Attempt 1: strict resolution. On a clean tree this works in one shot; on a
+  // non-trivial npm repo there's often a peer-dep mismatch (eslint 8↔10, react
+  // cross-pkg, etc.) that fails here — hence the legacy-peer-deps retry below.
+  const attempt1 = runCaptureStderr(pmBin(pm), addArgs);
   let rc = attempt1.status;
   let usedLegacy = false;
   let attempt2 = null;
 
-  if (rc !== 0) {
+  // The `--legacy-peer-deps` retry is npm-specific — pnpm / yarn / bun are
+  // lenient on peer deps by default, so a failure there is a real error, not a
+  // strictness knob to relax.
+  if (rc !== 0 && pm === 'npm') {
     console.log('Peer-dep conflict detected. Retrying with --legacy-peer-deps...'); // slop-ok
-    // Attempt 2: capture stderr too. The earlier version inherited
-    // stderr here, so when this leg failed its npm error was never
-    // captured and the customer saw "Resolve the npm error above" with
-    // nothing above (D158). Capturing lets us surface the real cause —
-    // including the npm debug-log path, where modern npm puts ERESOLVE /
-    // registry / auth detail.
-    attempt2 = runCaptureStderr(npmBin(), [...INSTALL_BASE, '--legacy-peer-deps']);
+    // Capture stderr here too, so a second failure surfaces the real cause
+    // (including the npm debug-log path) rather than an empty error wall.
+    attempt2 = runCaptureStderr(pmBin(pm), [...addArgs, '--legacy-peer-deps']);
     rc = attempt2.status;
     usedLegacy = true;
   }
 
   if (rc !== 0) {
-    // Both attempts failed. Surface every captured stderr + the npm
+    // Both attempts failed. Surface every captured stderr + (for npm) the
     // debug-log path, and offer the npx-init escape hatch that needs no
-    // successful `npm install`. See `formatInstallFailure`.
+    // successful install. See `formatInstallFailure`.
     const toStr = (b) => (b ? b.toString() : '');
     process.stderr.write(
       '\n' +
         formatInstallFailure({
           stderrChunks: [toStr(attempt1.stderr), attempt2 ? toStr(attempt2.stderr) : ''],
+          pm,
         }) +
         '\n',
     );
     process.exit(rc ?? 1);
   }
 
-  // Install succeeded. If we had to fall back to --legacy-peer-deps,
-  // persist that choice so the customer's next `npm install` doesn't
-  // re-hit the same ERESOLVE wall without us in the loop to recover.
+  // Install succeeded. If we had to fall back to --legacy-peer-deps (npm only),
+  // persist that choice so the customer's next `npm install` doesn't re-hit the
+  // same ERESOLVE wall without us in the loop to recover.
   if (usedLegacy) {
     const result = persistLegacyPeerDeps(cwd);
     if (result.changed) {

--- a/packages/create-dxkit/package.json
+++ b/packages/create-dxkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vyuhlabs/create-dxkit",
-  "version": "0.2.1",
-  "description": "One-command bootstrap for @vyuhlabs/dxkit. Runs `npm install --save-dev @vyuhlabs/dxkit` then `vyuh-dxkit init`.",
+  "version": "0.3.0",
+  "description": "One-command bootstrap for @vyuhlabs/dxkit. Detects your package manager (pnpm/yarn/bun/npm) to add it as a devDependency, then runs `vyuh-dxkit init`.",
   "license": "MIT",
   "author": "Vyuh Labs",
   "repository": {

--- a/src-templates/.claude/rules/nextjs.md
+++ b/src-templates/.claude/rules/nextjs.md
@@ -1,17 +1,19 @@
 ---
 paths:
-  - "frontend/**/*.ts"
-  - "frontend/**/*.tsx"
-  - "frontend/**/*.js"
-  - "frontend/**/*.jsx"
+  - "**/app/**/*.tsx"
+  - "**/app/**/*.ts"
+  - "**/pages/**/*.tsx"
+  - "**/pages/**/*.ts"
+  - "**/components/**/*.tsx"
+  - "**/*.tsx"
 ---
 
 # Next.js Rules
 
-- Use App Router (`app/` directory), not Pages Router
+- Use App Router (`app/` directory) for new routes; follow the router the repo already uses
 - Prefer Server Components by default; add `"use client"` only when needed
 - Never expose secrets or sensitive data in client components
 - Use TypeScript strict mode — no `any` types
 - Validate API inputs with zod at route handlers
-- Use Tailwind CSS for styling (configured in project)
-- Run `npm run build` in `frontend/` to catch type errors before committing
+- Use Tailwind CSS for styling when the project is set up for it
+- Run the project's build (e.g. `npm run build`, or `pnpm build` / `yarn build` to match your package manager) to catch type errors before committing

--- a/src-templates/.claude/skills/dxkit-uninstall/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-uninstall/SKILL.md
@@ -29,7 +29,7 @@ npx vyuh-dxkit uninstall --yes
 
 Useful flags:
 
-- `--remove-devdep` — also remove the `@vyuhlabs/dxkit` devDependency + postinstall from `package.json` (kept by default so a lockfile install doesn't break mid-cleanup; run `npm install` afterward if you use it).
+- `--remove-devdep` — also remove the `@vyuhlabs/dxkit` devDependency + postinstall from `package.json` (kept by default so a lockfile install doesn't break mid-cleanup). After it edits `package.json`, run your package manager's install to prune the lockfile — the CLI prints the exact command for your PM (`npm ci` / `pnpm install` / `yarn install` / `bun install`).
 - `--keep-baselines` — keep the curated, git-tracked artifacts (`.dxkit/baselines/`, the allowlist, `.dxkit/external/`) and remove only the runtime state. Use this if you want to pause dxkit but keep your grandfathered debt inventory.
 - `--force` — also remove dxkit-created files you have edited (default: skip + warn).
 - `--no-feedback` — skip the feedback prompt.
@@ -44,6 +44,12 @@ git status        # after `uninstall --yes`, dxkit's changes are gone
 ```
 
 If you had committed dxkit's files (baselines, workflows), those show as deletions to commit — that is expected; uninstall only edits the working tree, never git history.
+
+## Package-manager notes
+
+- **After `--remove-devdep`, run your PM's install** to prune the lockfile (the CLI prints the exact command). Non-npm repos need their own PM — `pnpm install` / `yarn install` / `bun install`, not `npm install`.
+- **pnpm with a release-age policy** (`minimumReleaseAge`): if your `pnpm-workspace.yaml` has a `minimumReleaseAgeExclude` entry for `@vyuhlabs/dxkit`, keep it until AFTER `pnpm install` prunes dxkit from the lockfile, THEN remove the exclusion and `pnpm install` again. Removing it first makes the stale lockfile fail `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` before it can prune. (That exclusion was added by pnpm, not dxkit, so uninstall does not touch it.)
+- **`@vitest/coverage-v8`**: if you ran `vyuh-dxkit tools install`, it may have added this devDependency for `vyuh-dxkit coverage`. It is not part of dxkit's install manifest, so uninstall leaves it — remove it by hand if you don't want it (`<pm> remove @vitest/coverage-v8`).
 
 ## The feedback prompt (optional, opt-in)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,6 +141,12 @@ function printUsage(): void {
   ${logger.bold('Usage:')}
     vyuh-dxkit init [options]    Install dxkit agent DX in this repo
     vyuh-dxkit update [options]  Re-generate (preserves evolved files)
+    vyuh-dxkit uninstall [options]
+                                 Remove dxkit, restoring the exact pre-dxkit state:
+                                 delete files dxkit created + surgically revert its
+                                 additive merges (.gitignore / CLAUDE.md / settings.json
+                                 / package.json). Dry-run by default; --yes applies.
+                                 [--keep-baselines] [--remove-devdep] [--force]
     vyuh-dxkit doctor            Verify setup
     vyuh-dxkit health [path]     Run deterministic health analysis
     vyuh-dxkit vulnerabilities [path]  Run deep security scan
@@ -221,8 +227,8 @@ function printUsage(): void {
     vyuh-dxkit issue --type=<type> [--about=<text>] [--fingerprint=<id>] [--no-browser]
                                  Open a pre-filled GitHub Issue against vyuh-labs/dxkit.
                                  Types: false-positive, missing-finding, bug,
-                                 feature-request, docs. Nothing is submitted until
-                                 you click "Submit" in your browser.
+                                 feature-request, docs, uninstall. Nothing is submitted
+                                 until you click "Submit" in your browser.
 
   ${logger.bold('Init options:')}
     --dx-only                 Just .claude/ + CLAUDE.md (default)
@@ -2220,6 +2226,23 @@ export async function run(argv: string[]): Promise<void> {
             : '') +
           '. dxkit has been uninstalled.',
       );
+
+      // When we edited package.json (devDep removed), the lockfile is now stale.
+      // Point the user at their PM's install so the prune completes. pnpm has an
+      // extra wrinkle when a release-age policy pinned dxkit — see the skill.
+      if (opts.removeDevDependency && result.reverted.includes('package.json')) {
+        const { detectPackageManager, provisionCommand } = await import('./package-manager');
+        const pm = detectPackageManager(targetPath);
+        logger.info('');
+        logger.info(
+          `package.json changed — run \`${provisionCommand(pm)}\` to prune @vyuhlabs/dxkit from your lockfile.`,
+        );
+        if (pm === 'pnpm') {
+          logger.dim(
+            '  (pnpm + a release-age policy: keep any minimumReleaseAgeExclude for dxkit until AFTER this install prunes it, then remove it and install again.)',
+          );
+        }
+      }
 
       // Optional, skippable feedback — a prefilled GitHub issue the user opens
       // themselves (no telemetry, no auto-submit).

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -8,6 +8,7 @@ import { dxkitCli } from './self-invocation';
 import * as logger from './logger';
 import { resolveBaselineMode } from './baseline/modes';
 import { loadPolicyFromCwd } from './baseline/policy';
+import { detectPackageManager, addDevCommand } from './package-manager';
 import { loadAllowlist, auditAllowlist } from './allowlist/file';
 import { diagnoseFlow, type FlowDiagnosis } from './analyzers/flow/diagnose';
 
@@ -511,7 +512,7 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
       tier: 'operational',
       fix: {
         hint: 'Declare dxkit as a project-local devDependency so the hooks + CI guardrail run a pinned version instead of a global (or missing) one.',
-        command: 'npm install --save-dev @vyuhlabs/dxkit',
+        command: addDevCommand(detectPackageManager(cwd), '@vyuhlabs/dxkit'),
         skill: 'dxkit-fix',
       },
     });

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -95,7 +95,7 @@ function buildSettingsJson(config: ResolvedConfig): string {
  * skill content references the canonical `vyuh-dxkit` CLI surface
  * and doesn't need per-project variables).
  */
-const DXKIT_SKILLS = [
+export const DXKIT_SKILLS = [
   'dxkit-learn',
   'dxkit-init',
   'dxkit-config',

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -1,0 +1,95 @@
+/**
+ * Package-manager detection + command building — one source of truth for
+ * "which PM manages this repo, and how do I phrase an install for it".
+ *
+ * dxkit long assumed npm everywhere: doctor + tools hints told users to run
+ * `npm install …` regardless of their lockfile, and a first-real-repo install
+ * on a pnpm project surfaced the gap (npm choked on a pnpm workspace). This
+ * module centralizes detection so every "install this" string dxkit prints
+ * matches the repo's actual PM.
+ *
+ * Note on the `create-dxkit` bootstrap: that shim is a SEPARATE zero-dependency
+ * published package (`packages/create-dxkit/index.js`) and cannot import from
+ * `src/`, so it carries its own small copy of this logic. Two published
+ * packages legitimately each need the primitive — this is not a Rule 2
+ * duplication within one package. Keep the two in step when either changes.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+/** Read the `packageManager` field (corepack, e.g. `pnpm@9.0.0`) and map it to
+ *  a known PM, or null when absent/unrecognized. */
+function packageManagerField(cwd: string): PackageManager | null {
+  try {
+    const pkg = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8')) as {
+      packageManager?: unknown;
+    };
+    if (typeof pkg.packageManager !== 'string') return null;
+    const name = pkg.packageManager.split('@')[0].trim();
+    if (name === 'pnpm' || name === 'yarn' || name === 'bun' || name === 'npm') return name;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect the package manager for a repo. Lockfiles win — they reflect what
+ * actually provisioned `node_modules` — and only when none is present do we
+ * fall back to the `packageManager` field (a declared intent), then to npm.
+ */
+export function detectPackageManager(cwd: string): PackageManager {
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn';
+  if (existsSync(join(cwd, 'bun.lockb')) || existsSync(join(cwd, 'bun.lock'))) return 'bun';
+  if (existsSync(join(cwd, 'package-lock.json'))) return 'npm';
+  return packageManagerField(cwd) ?? 'npm';
+}
+
+/** The command PREFIX that adds a dev dependency with the given PM (no package
+ *  yet). `npm install --save-dev` is the token dxkit historically hardcoded, so
+ *  it is also the substring other install strings are rewritten from. */
+export function addDevPrefix(pm: PackageManager): string {
+  switch (pm) {
+    case 'pnpm':
+      return 'pnpm add -D';
+    case 'yarn':
+      return 'yarn add -D';
+    case 'bun':
+      return 'bun add -d';
+    case 'npm':
+      return 'npm install --save-dev';
+  }
+}
+
+/** The command to add a package as a dev dependency with the given PM. */
+export function addDevCommand(pm: PackageManager, pkg: string): string {
+  return `${addDevPrefix(pm)} ${pkg}`;
+}
+
+/** Rewrite a hardcoded `npm install --save-dev …` install string to the given
+ *  PM's equivalent. A no-op for npm (and when the token isn't present), so it is
+ *  safe to apply to any command; used to make a tool's node-devDep install match
+ *  the repo's PM without templating every registry entry. */
+export function pmAwareDevInstall(command: string, pm: PackageManager): string {
+  if (pm === 'npm') return command;
+  return command.split('npm install --save-dev').join(addDevPrefix(pm));
+}
+
+/** The command to (re)provision `node_modules` from the manifest + lockfile —
+ *  the "your project-local tools aren't installed, run this" hint. */
+export function provisionCommand(pm: PackageManager): string {
+  switch (pm) {
+    case 'pnpm':
+      return 'pnpm install';
+    case 'yarn':
+      return 'yarn install';
+    case 'bun':
+      return 'bun install';
+    case 'npm':
+      return 'npm ci';
+  }
+}

--- a/src/tools-cli.ts
+++ b/src/tools-cli.ts
@@ -23,6 +23,7 @@ import { stdin, stdout } from 'process';
 import { execSync } from 'child_process';
 import { detect } from './detect';
 import { DetectedStack } from './types';
+import { detectPackageManager, provisionCommand, pmAwareDevInstall } from './package-manager';
 import * as logger from './logger';
 import {
   TOOL_DEFS,
@@ -100,9 +101,7 @@ function formatStatusLine(s: ToolStatus): string {
   // Project-local tools (F-UX-3): annotate so users don't confuse a
   // missing dev-dep with a missing system tool.
   const scopeNote =
-    s.requirement.installScope === 'project-local'
-      ? ' \x1b[2m(project-local — `npm ci`)\x1b[0m'
-      : '';
+    s.requirement.installScope === 'project-local' ? ' \x1b[2m(project-local dev-dep)\x1b[0m' : '';
   return `  \x1b[31m✗\x1b[0m ${name}  ${layer}  ${forStack}  \x1b[2mmissing\x1b[0m${scopeNote}`;
 }
 
@@ -170,8 +169,9 @@ function showStatus(targetPath: string): ToolStatus[] {
     const globalMissing = missing.filter((s) => s.requirement.installScope !== 'project-local');
 
     if (projectLocalMissing.length > 0) {
+      const provision = provisionCommand(detectPackageManager(targetPath));
       logger.dim(
-        `${projectLocalMissing.length} project-local tool${projectLocalMissing.length === 1 ? '' : 's'} (${projectLocalMissing.map((s) => s.name).join(', ')}) — run \`npm ci\` (or \`npm install\`) in this repo to provision them from package.json devDependencies.`,
+        `${projectLocalMissing.length} project-local tool${projectLocalMissing.length === 1 ? '' : 's'} (${projectLocalMissing.map((s) => s.name).join(', ')}) — run \`${provision}\` in this repo to provision them from package.json devDependencies.`,
       );
     }
     if (globalMissing.length > 0) {
@@ -294,11 +294,18 @@ async function runInstall(
         results.push({ name: s.name, status: 'skipped', msg: 'no install command' });
         continue;
       }
-      const cmd = getInstallCommand(def);
-      if (cmd === 'builtin' || cmd === 'builtin (npm)' || cmd === 'builtin (dotnet SDK)') {
+      const rawCmd = getInstallCommand(def);
+      if (rawCmd === 'builtin' || rawCmd === 'builtin (npm)' || rawCmd === 'builtin (dotnet SDK)') {
         results.push({ name: s.name, status: 'skipped', msg: 'builtin' });
         continue;
       }
+      // A node devDep tool (e.g. @vitest/coverage-v8) installs INTO the user's
+      // repo, so its `npm install --save-dev …` must match the repo's PM — else
+      // it fails the way create-dxkit did on a pnpm project. Tools installed
+      // into an isolated dxkit dir (no nodePackage) keep their npm command.
+      const cmd = def.nodePackage
+        ? pmAwareDevInstall(rawCmd, detectPackageManager(targetPath))
+        : rawCmd;
 
       console.log('');
       console.log(`  ${logger.bold(s.name)} — ${def.description}`);

--- a/src/uninstall/index.ts
+++ b/src/uninstall/index.ts
@@ -204,9 +204,33 @@ export function planUninstall(cwd: string, opts: UninstallOptions = {}): Uninsta
   }
 
   // 2. Delete generator-created files from the manifest (except merge targets).
+  const recorded = new Set(Object.keys(manifest?.files ?? {}));
   for (const [rel, entry] of Object.entries(manifest?.files ?? {})) {
     if (MERGE_TARGETS.has(rel)) continue;
     del(rel, 'dxkit-created file', entry.evolving, entry.hash);
+  }
+
+  // 2b. Resilience sweep for `.claude/skills/dxkit-*`. A manifest written by an
+  //     older dxkit (before skills were recorded) omits them, so the loop above
+  //     misses them and the skills survive an uninstall — a repo that
+  //     "uninstalled" dxkit still advertises its skills to every agent session.
+  //     Every `dxkit-`-prefixed skill dir is unambiguously dxkit's, so remove
+  //     any that the manifest did NOT already account for (recorded ones keep
+  //     their hash-guarded per-file handling above + empty-dir pruning).
+  const skillsRoot = '.claude/skills';
+  if (exists(cwd, skillsRoot)) {
+    for (const name of safeReaddir(path.join(cwd, skillsRoot))) {
+      if (!name.startsWith('dxkit-')) continue;
+      const dir = `${skillsRoot}/${name}`;
+      if (!statIsDir(cwd, dir)) continue;
+      if (recorded.has(`${dir}/SKILL.md`)) continue; // handled by the manifest loop
+      actions.push({
+        kind: 'delete-dir',
+        target: dir,
+        detail: 'dxkit skill (not recorded by an older manifest)',
+        status: 'pending',
+      });
+    }
   }
 
   // 3. Delete gated ship-installer artifacts by flag / presence.

--- a/src/uninstall/reversals.ts
+++ b/src/uninstall/reversals.ts
@@ -27,34 +27,31 @@ export interface ReversalResult {
 export const STEALTH_HEADER = '# dxkit (stealth mode — local only, not committed)';
 
 /**
- * Remove a dxkit block from `.gitignore`. The installer writes each block as
- * `\n<HEADER>\n<entries…>\n` (a header line followed by its entries, up to the
- * next blank line or EOF). We strip from the header line through the run of
- * non-blank lines that follows it, leaving every other line — including the
- * user's own entries — untouched.
+ * Remove a dxkit block from `.gitignore`, byte-exactly. The installer appends
+ * each block as `'\n' + HEADER + '\n' + entries.join('\n') + '\n'` — one
+ * separator blank line, the header, its entries, a trailing newline. The
+ * reversal removes EXACTLY that: the header + the contiguous non-blank entry
+ * lines below it, plus the single blank line immediately above the header (the
+ * separator dxkit prepended). It performs no global whitespace collapse, so a
+ * user's own blank lines elsewhere in the file are preserved byte-for-byte —
+ * the guarantee the skill promises.
  */
 export function stripGitignoreBlock(content: string, header: string): ReversalResult {
   const lines = content.split('\n');
-  const out: string[] = [];
-  let changed = false;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim() === header) {
-      changed = true;
-      // Skip the header and the contiguous non-blank entry lines under it.
-      i++;
-      while (i < lines.length && lines[i].trim() !== '') i++;
-      // `i` now points at the blank line (or EOF); the for-loop's i++ consumes
-      // that blank separator so we don't leave a double blank behind.
-      continue;
-    }
-    out.push(lines[i]);
-  }
-  if (!changed) return { changed: false, content };
-  // Collapse a leading blank the block may have left, and trailing blanks.
-  let result = out
-    .join('\n')
-    .replace(/^\n+/, '')
-    .replace(/\n{3,}/g, '\n\n');
+  const headerIdx = lines.findIndex((l) => l.trim() === header);
+  if (headerIdx === -1) return { changed: false, content };
+
+  // The block spans the header through the contiguous non-blank entry lines.
+  let end = headerIdx + 1;
+  while (end < lines.length && lines[end].trim() !== '') end++;
+
+  // Remove the one separator blank line the installer prepended above the
+  // header — but only that one, never a user's blank two lines up.
+  let start = headerIdx;
+  if (start > 0 && lines[start - 1].trim() === '') start--;
+
+  const kept = [...lines.slice(0, start), ...lines.slice(end)];
+  let result = kept.join('\n');
   if (result.trim() === '') result = '';
   return { changed: true, content: result };
 }

--- a/test/create-dxkit.test.ts
+++ b/test/create-dxkit.test.ts
@@ -26,7 +26,10 @@ const shim = require('../packages/create-dxkit/index.js') as {
     pathMod?: typeof path,
   ) => { changed: boolean; reason: string };
   extractNpmLogPath: (text: string | null | undefined) => string | null;
-  formatInstallFailure: (opts?: { stderrChunks?: string[] }) => string;
+  formatInstallFailure: (opts?: { stderrChunks?: string[]; pm?: string }) => string;
+  detectPackageManager: (cwd: string, fsMod?: typeof fs, pathMod?: typeof path) => string;
+  pmBin: (pm: string, platform?: NodeJS.Platform) => string;
+  installArgs: (pm: string) => string[];
 };
 
 let tmp: string;
@@ -225,5 +228,60 @@ describe('npmBin / npxBin', () => {
   it('returns plain names on darwin', () => {
     expect(shim.npmBin('darwin')).toBe('npm');
     expect(shim.npxBin('darwin')).toBe('npx');
+  });
+});
+
+describe('detectPackageManager (shim self-contained copy)', () => {
+  it('detects each PM from its lockfile', () => {
+    const cases: Array<[string, string]> = [
+      ['pnpm-lock.yaml', 'pnpm'],
+      ['yarn.lock', 'yarn'],
+      ['bun.lockb', 'bun'],
+      ['package-lock.json', 'npm'],
+    ];
+    for (const [lockfile, pm] of cases) {
+      const d = fs.mkdtempSync(path.join(os.tmpdir(), 'create-dxkit-pm-'));
+      fs.writeFileSync(path.join(d, lockfile), '');
+      expect(shim.detectPackageManager(d), lockfile).toBe(pm);
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it('reads the packageManager field when no lockfile, else defaults to npm', () => {
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ packageManager: 'pnpm@9' }));
+    expect(shim.detectPackageManager(tmp)).toBe('pnpm');
+    const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'create-dxkit-pm-'));
+    expect(shim.detectPackageManager(bare)).toBe('npm');
+    fs.rmSync(bare, { recursive: true, force: true });
+  });
+});
+
+describe('installArgs / pmBin (shim)', () => {
+  it('builds the right dev-dep add args per PM', () => {
+    expect(shim.installArgs('npm')).toEqual([
+      'install',
+      '--save-dev',
+      '--no-audit',
+      '@vyuhlabs/dxkit',
+    ]);
+    expect(shim.installArgs('pnpm')).toEqual(['add', '-D', '@vyuhlabs/dxkit']);
+    expect(shim.installArgs('yarn')).toEqual(['add', '-D', '@vyuhlabs/dxkit']);
+    expect(shim.installArgs('bun')).toEqual(['add', '-d', '@vyuhlabs/dxkit']);
+  });
+
+  it('pmBin is plain on posix and .cmd/.exe on win32', () => {
+    expect(shim.pmBin('pnpm', 'linux')).toBe('pnpm');
+    expect(shim.pmBin('pnpm', 'win32')).toBe('pnpm.cmd');
+    expect(shim.pmBin('bun', 'win32')).toBe('bun.exe');
+  });
+});
+
+describe('formatInstallFailure — PM-aware', () => {
+  it('names the actual PM and omits the npm debug-log guidance for non-npm', () => {
+    const pnpm = shim.formatInstallFailure({ stderrChunks: ['ERR_PNPM'], pm: 'pnpm' });
+    expect(pnpm).toContain('pnpm reported:');
+    expect(pnpm).not.toMatch(/npm cache `_logs`/);
+    const npm = shim.formatInstallFailure({ stderrChunks: ['ERESOLVE'], pm: 'npm' });
+    expect(npm).toContain('npm reported:');
   });
 });

--- a/test/package-manager.test.ts
+++ b/test/package-manager.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  detectPackageManager,
+  addDevPrefix,
+  addDevCommand,
+  provisionCommand,
+  pmAwareDevInstall,
+} from '../src/package-manager';
+
+describe('detectPackageManager', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-pm-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('detects each PM from its lockfile', () => {
+    const cases: Array<[string, string]> = [
+      ['pnpm-lock.yaml', 'pnpm'],
+      ['yarn.lock', 'yarn'],
+      ['bun.lockb', 'bun'],
+      ['bun.lock', 'bun'],
+      ['package-lock.json', 'npm'],
+    ];
+    for (const [lockfile, pm] of cases) {
+      const d = mkdtempSync(join(tmpdir(), 'dxkit-pm-'));
+      writeFileSync(join(d, lockfile), '');
+      expect(detectPackageManager(d), lockfile).toBe(pm);
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it('lockfile wins over the packageManager field', () => {
+    writeFileSync(join(dir, 'pnpm-lock.yaml'), '');
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ packageManager: 'yarn@4.0.0' }));
+    expect(detectPackageManager(dir)).toBe('pnpm');
+  });
+
+  it('falls back to the packageManager field when no lockfile', () => {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ packageManager: 'pnpm@9.1.0' }));
+    expect(detectPackageManager(dir)).toBe('pnpm');
+  });
+
+  it('defaults to npm with neither lockfile nor field', () => {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x' }));
+    expect(detectPackageManager(dir)).toBe('npm');
+    // and with no package.json at all
+    expect(detectPackageManager(mkdtempSync(join(tmpdir(), 'dxkit-pm-')))).toBe('npm');
+  });
+});
+
+describe('command builders', () => {
+  it('addDevCommand phrases the dev-dep install per PM', () => {
+    expect(addDevCommand('npm', 'x')).toBe('npm install --save-dev x');
+    expect(addDevCommand('pnpm', 'x')).toBe('pnpm add -D x');
+    expect(addDevCommand('yarn', 'x')).toBe('yarn add -D x');
+    expect(addDevCommand('bun', 'x')).toBe('bun add -d x');
+  });
+
+  it('provisionCommand phrases the lockfile install per PM', () => {
+    expect(provisionCommand('npm')).toBe('npm ci');
+    expect(provisionCommand('pnpm')).toBe('pnpm install');
+    expect(provisionCommand('yarn')).toBe('yarn install');
+    expect(provisionCommand('bun')).toBe('bun install');
+  });
+
+  it('pmAwareDevInstall rewrites an npm-hardcoded string to the PM equivalent', () => {
+    const cmd = 'npm install --save-dev "@vitest/coverage-v8@^4"';
+    expect(pmAwareDevInstall(cmd, 'npm')).toBe(cmd); // no-op for npm
+    expect(pmAwareDevInstall(cmd, 'pnpm')).toBe('pnpm add -D "@vitest/coverage-v8@^4"');
+    expect(pmAwareDevInstall(cmd, 'bun')).toBe('bun add -d "@vitest/coverage-v8@^4"');
+    // leaves a non-matching command untouched
+    expect(pmAwareDevInstall('brew install cloc', 'pnpm')).toBe('brew install cloc');
+  });
+
+  it('addDevPrefix is the substring pmAwareDevInstall rewrites from', () => {
+    expect(addDevPrefix('npm')).toBe('npm install --save-dev');
+    expect(addDevPrefix('pnpm')).toBe('pnpm add -D');
+  });
+});

--- a/test/rule-templates.test.ts
+++ b/test/rule-templates.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Framework rule templates must be layout-agnostic: their `paths:` frontmatter
+ * has to match the framework's files wherever they live in the repo, not one
+ * hardcoded subdirectory. The `nextjs.md` template previously scoped to
+ * `frontend/**` only, so on a single-app-at-root repo the rule matched no files
+ * and never activated (dead on arrival). This guards against that regression.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const RULES_DIR = join(__dirname, '..', 'src-templates', '.claude', 'rules');
+
+function pathsBlock(file: string): string {
+  const content = readFileSync(join(RULES_DIR, file), 'utf8');
+  const fm = content.match(/^---\n([\s\S]*?)\n---/);
+  return fm ? fm[1] : '';
+}
+
+describe('framework rule templates are layout-agnostic', () => {
+  it('nextjs.md does not lock its paths to a single subdirectory', () => {
+    const paths = pathsBlock('nextjs.md');
+    // No hardcoded `frontend/` prefix — that made the rule dead on arrival when
+    // the Next.js app lived at the repo root (or src/, apps/web, …).
+    expect(paths).not.toMatch(/frontend\//);
+    // Matches Next.js files at any depth (the `**/` prefix spans root + nested).
+    expect(paths).toMatch(/\*\*\/app\//);
+  });
+
+  it('nextjs.md build guidance is not hardcoded to npm in frontend/', () => {
+    const content = readFileSync(join(RULES_DIR, 'nextjs.md'), 'utf8');
+    expect(content).not.toMatch(/`npm run build` in `frontend\/`/);
+  });
+});

--- a/test/skills-parity.test.ts
+++ b/test/skills-parity.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Skills-parity guard: every skill authored under `src-templates/.claude/skills/`
+ * MUST be listed in the generator's `DXKIT_SKILLS` (so init/update installs it),
+ * and vice versa. Without this, a skill can be authored but silently never
+ * shipped — exactly the "the uninstall skill exists in templates but wasn't
+ * installed" class of bug from real dogfood feedback.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, statSync, existsSync } from 'fs';
+import { join } from 'path';
+import { DXKIT_SKILLS } from '../src/generator';
+
+const SKILLS_DIR = join(__dirname, '..', 'src-templates', '.claude', 'skills');
+
+function authoredSkills(): string[] {
+  return readdirSync(SKILLS_DIR)
+    .filter((name) => statSync(join(SKILLS_DIR, name)).isDirectory())
+    .filter((name) => name.startsWith('dxkit-'));
+}
+
+describe('skills parity', () => {
+  it('every authored skill is registered in DXKIT_SKILLS (installed on init)', () => {
+    const registered = new Set<string>(DXKIT_SKILLS);
+    const missing = authoredSkills().filter((s) => !registered.has(s));
+    expect(missing, `authored but not shipped: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('every registered skill has an authored SKILL.md', () => {
+    const missing = DXKIT_SKILLS.filter((s) => !existsSync(join(SKILLS_DIR, s, 'SKILL.md')));
+    expect(missing, `registered but no template: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('the uninstall skill specifically is present + registered', () => {
+    expect(DXKIT_SKILLS).toContain('dxkit-uninstall');
+    expect(existsSync(join(SKILLS_DIR, 'dxkit-uninstall', 'SKILL.md'))).toBe(true);
+  });
+});

--- a/test/uninstall-plan.test.ts
+++ b/test/uninstall-plan.test.ts
@@ -200,3 +200,55 @@ describe('recipe symmetry — every install surface has a removal path', () => {
     expect(targets).toContain('.github/workflows/dxkit-guardrails.yml');
   });
 });
+
+describe('planUninstall — skills resilience for older manifests', () => {
+  it('removes .claude/skills/dxkit-* dirs even when the manifest did not record them', () => {
+    // Simulate a repo installed by an OLDER dxkit whose manifest omits skills.
+    write('.claude/skills/dxkit-learn/SKILL.md', '# learn');
+    write('.claude/skills/dxkit-flow/SKILL.md', '# flow');
+    write('.claude/skills/my-own-skill/SKILL.md', '# not dxkit'); // must be preserved
+    write(
+      '.vyuh-dxkit.json',
+      JSON.stringify({
+        version: '2.22.0',
+        mode: 'committed-full',
+        generatedAt: 't',
+        config: {},
+        files: {}, // no skills recorded — the older-manifest bug
+        installFlags: ALL_FLAGS,
+      }),
+    );
+
+    const plan = planUninstall(tmp);
+    const targets = plan.actions.filter((a) => a.status === 'pending').map((a) => a.target);
+    expect(targets).toContain('.claude/skills/dxkit-learn');
+    expect(targets).toContain('.claude/skills/dxkit-flow');
+    expect(targets).not.toContain('.claude/skills/my-own-skill');
+
+    executeUninstall(tmp, plan);
+    expect(exists('.claude/skills/dxkit-learn')).toBe(false);
+    expect(exists('.claude/skills/dxkit-flow')).toBe(false);
+    expect(exists('.claude/skills/my-own-skill')).toBe(true); // user skill untouched
+  });
+
+  it('does not double-remove skills the manifest DID record (hash-guarded path wins)', () => {
+    write('.claude/skills/dxkit-learn/SKILL.md', '# learn');
+    const hash = sha256('# learn');
+    write(
+      '.vyuh-dxkit.json',
+      JSON.stringify({
+        version: '2.26.0',
+        mode: 'committed-full',
+        generatedAt: 't',
+        config: {},
+        files: { '.claude/skills/dxkit-learn/SKILL.md': { hash, evolving: false } },
+        installFlags: ALL_FLAGS,
+      }),
+    );
+    const plan = planUninstall(tmp);
+    // Recorded as the SKILL.md file, not a duplicate delete-dir.
+    const learnActions = plan.actions.filter((a) => a.target.includes('dxkit-learn'));
+    expect(learnActions).toHaveLength(1);
+    expect(learnActions[0].target).toBe('.claude/skills/dxkit-learn/SKILL.md');
+  });
+});

--- a/test/uninstall-reversals.test.ts
+++ b/test/uninstall-reversals.test.ts
@@ -46,6 +46,8 @@ describe('stripGitignoreBlock — preserves user entries', () => {
   });
 
   it('stripAllGitignoreBlocks removes both runtime + stealth blocks', () => {
+    // Realistic installer output: the user's `node_modules/\n`, then each block
+    // appended as `'\n' + HEADER + '\n' + entries + '\n'` (trailing newline).
     const content = [
       'node_modules/',
       '',
@@ -55,10 +57,11 @@ describe('stripGitignoreBlock — preserves user entries', () => {
       STEALTH_HEADER,
       '.dxkit/',
       '.vyuh-dxkit.json',
+      '',
     ].join('\n');
     const { changed, content: out } = stripAllGitignoreBlocks(content);
     expect(changed).toBe(true);
-    expect(out).toBe('node_modules/\n');
+    expect(out).toBe('node_modules/\n'); // byte-exact restore of the pre-dxkit file
   });
 });
 
@@ -177,5 +180,22 @@ describe('stripPackageJsonDxkit', () => {
   it('no-op when dxkit is absent', () => {
     const parsed = { devDependencies: { react: '^18.0.0' } };
     expect(stripPackageJsonDxkit(parsed).changed).toBe(false);
+  });
+});
+
+describe('stripGitignoreBlock — byte-exact (no collapse of user blanks)', () => {
+  it('preserves a pre-existing double blank line elsewhere in the file', () => {
+    const original = 'dist\n\n\n# Playwright\ntest-results\n';
+    // installer appends: '\n' + HEADER + '\n' + entries + '\n'
+    const installed = original + '\n' + GITIGNORE_HEADER + '\n.dxkit/reports\n.dxkit/loop\n';
+    const out = stripGitignoreBlock(installed, GITIGNORE_HEADER);
+    expect(out.changed).toBe(true);
+    expect(out.content).toBe(original); // byte-for-byte
+  });
+
+  it('removes exactly one separator blank above the header, not a user blank two lines up', () => {
+    const original = 'node_modules\n\n';
+    const installed = original + '\n' + GITIGNORE_HEADER + '\n.dxkit/reports\n';
+    expect(stripGitignoreBlock(installed, GITIGNORE_HEADER).content).toBe(original);
   });
 });


### PR DESCRIPTION
Reliability release from first-real-repo dogfood feedback (a pnpm project). Rebase-merge — five independently-meaningful commits.

## Root cause: dxkit assumed npm everywhere

- **`npm init @vyuhlabs/dxkit` crashed in pnpm/yarn/bun repos** (npm errors on a pnpm-lock tree). The bootstrap now detects the repo's PM from its lockfile (then the `packageManager` field, else npm) and adds dxkit with that PM. The legacy-peer-deps retry is npm-only; the failure message names the actual PM.
- **doctor/tools install hints are PM-aware**, and a node devDependency tool (`@vitest/coverage-v8`) installs with the repo's PM.
- New `src/package-manager.ts` is the single detector + command builder; the zero-dep create-dxkit shim carries a small self-contained copy.

## uninstall completeness + discoverability

- **Skills no longer survive an uninstall on repos installed under an older dxkit.** A pre-2.24 manifest didn't record skills, so uninstall left every `.claude/skills/dxkit-*` behind. Now swept by the unambiguous `dxkit-` prefix even when the manifest omits them; your own non-dxkit skills are untouched.
- **`.gitignore` revert is byte-exact** — removes only dxkit's block + its one separator line, no global blank-line collapse (which had swallowed a user's pre-existing blank line).
- **`--remove-devdep`** now prints the PM-aware `run <pm> install` command (with a pnpm release-age ordering note).
- **`uninstall` is listed in `--help`** and the `issue --type` list.
- New **skills-parity test** — a skill can never again be authored but silently not shipped.

## Next.js rule template (dead on arrival)

`.claude/rules/nextjs.md` scoped `paths:` to `frontend/**` with a `npm run build in frontend/` command, so on a single-app-at-root repo it matched no files and never activated. Broadened to match Next.js files at any depth (App Router / Pages Router / components), PM-agnostic build guidance, + regression test. Audited all 10 rule templates — Next.js was the only one with the layout-locked bug.

## Docs
README repo-rooted-session note; uninstall skill PM notes (post-uninstall install, pnpm prune ordering, coverage-v8); CHANGELOG incl. the ≤2.22 hooksPath migration + PM release-age holdback notes.

## Tests
Full suite green (2904+), new: `package-manager.test.ts`, `skills-parity.test.ts`, `rule-templates.test.ts`, + uninstall byte-exact & skills-sweep cases.

**Follow-up:** a new `@vyuhlabs/create-dxkit@0.3.0` also needs its own tag/release (separate publish pipeline) so the shim fix reaches `npm init` users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)