### PR TITLE
2.27.0 — install/uninstall lifecycle reliability (root-cause + real-repo net)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.27.0] - 2026-07-05
+
+### Fixed — install/uninstall lifecycle reliability (root-cause pass)
+
+A round of real-repo dogfood feedback traced to one gap: dxkit had deep unit
+coverage but no test of its own most important promise — *restore the exact
+pre-dxkit state, on any repo*. This release fixes the root causes and adds a
+real-repo lifecycle harness so the promise is a continuously-checked invariant.
+
+- **No more data loss on uninstall.** The install manifest now records
+  `provenance` (`created` / `overwritten` / `skipped`) per file. A pre-existing
+  `AGENTS.md` / `CLAUDE.md` dxkit merely kept is recorded as `skipped`, so
+  `uninstall` (even `--force`) will never delete a file the project authored.
+  This also fixes the manifest being left behind after uninstall.
+- **The pre-push hook is no longer inert under pnpm.** `init` now activates
+  `core.hooksPath` itself instead of relying on a `postinstall` script that
+  `pnpm add` may skip. The postinstall wiring stays as a re-apply on clone.
+- **`package.json` edits preserve formatting.** Adding the dxkit devDependency
+  no longer reformats a compact or tab-indented `package.json` — a change
+  uninstall could never cleanly undo. Install and uninstall share one
+  format-preserving JSON serializer.
+- **`tools install` no longer disowns what it installs.** A node devDependency
+  it adds on dxkit's behalf (e.g. `@vitest/coverage-v8`) is recorded in the
+  manifest and removed by `uninstall --remove-devdep`.
+- **`init` sequences its next-step advice** — it points at `tools install` then
+  `baseline create`, so the very next step it suggests doesn't fail.
+- **Docs:** `--detect` is no longer mislabeled as a dry-run preview; the pnpm
+  `minimumReleaseAge` uninstall note is corrected (dxkit does not write that
+  exclusion).
+
+### Added — real-repo lifecycle test harness
+
+`test/lifecycle/` runs the built CLI through `init → uninstall` on realistic
+throwaway git repos and asserts the working tree returns byte-identical to the
+pre-dxkit commit — the net that turns "a user finds it weeks later" into "the PR
+fails". It reproduced every fix above as a failing test first.
+
 ## [2.26.0] - 2026-07-05
 
 ### Fixed — package-manager awareness (from first-real-repo dogfood feedback)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.26.0",
+      "version": "2.27.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.claude/skills/dxkit-init/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-init/SKILL.md
@@ -39,11 +39,14 @@ When `init` finds client HTTP calls and/or server routes, it offers the **integr
 
 ## Steps
 
-1. **Detect the stack** before installing — let the user confirm:
+1. **Install with stack auto-detection** — `--detect` auto-detects the stack and
+   installs with minimal prompts:
    ```bash
    npx vyuh-dxkit init --detect
    ```
-   This auto-detects and previews what `init --full` would do without writing anything.
+   Note: `--detect` INSTALLS (it is not a dry-run preview). To see the detected
+   stack without installing, run a read-only analyzer first (e.g. `npx
+   vyuh-dxkit health .`), or inspect the plan from a throwaway checkout.
 
 2. **Run init**:
    ```bash

--- a/src-templates/.claude/skills/dxkit-uninstall/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-uninstall/SKILL.md
@@ -48,7 +48,7 @@ If you had committed dxkit's files (baselines, workflows), those show as deletio
 ## Package-manager notes
 
 - **After `--remove-devdep`, run your PM's install** to prune the lockfile (the CLI prints the exact command). Non-npm repos need their own PM — `pnpm install` / `yarn install` / `bun install`, not `npm install`.
-- **pnpm with a release-age policy** (`minimumReleaseAge`): if your `pnpm-workspace.yaml` has a `minimumReleaseAgeExclude` entry for `@vyuhlabs/dxkit`, keep it until AFTER `pnpm install` prunes dxkit from the lockfile, THEN remove the exclusion and `pnpm install` again. Removing it first makes the stale lockfile fail `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` before it can prune. (That exclusion was added by pnpm, not dxkit, so uninstall does not touch it.)
+- **pnpm with a release-age policy** (`minimumReleaseAge`): if your `pnpm-workspace.yaml` has a `minimumReleaseAgeExclude` entry for `@vyuhlabs/dxkit` (you or an earlier dxkit added it so a just-published dxkit could install at all), keep it until AFTER `pnpm install` prunes dxkit from the lockfile, THEN remove the exclusion and `pnpm install` again. Removing it first makes the stale lockfile fail `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` before it can prune. Uninstall surfaces this entry in its plan but does not edit your `pnpm-workspace.yaml`.
 - **`@vitest/coverage-v8`**: if you ran `vyuh-dxkit tools install`, it may have added this devDependency for `vyuh-dxkit coverage`. It is not part of dxkit's install manifest, so uninstall leaves it — remove it by hand if you don't want it (`<pm> remove @vitest/coverage-v8`).
 
 ## The feedback prompt (optional, opt-in)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -723,9 +723,15 @@ export async function run(argv: string[]): Promise<void> {
       // dxkit is broken right after they installed it.
       if (shipResults.length > 0) {
         console.log(''); // slop-ok
-        logger.info(`Next: run \`${dxkitCli('baseline create')}\` to capture today's state.`);
-        logger.dim('   (without a baseline, your pre-push hook + CI guardrail have nothing to');
-        logger.dim('    diff against and will fail-fast on the next push)');
+        // Sequence matters: `baseline create` refuses to write an incomplete
+        // baseline when a scanner is missing (e.g. the coverage tool), so point
+        // at `tools install` FIRST — otherwise the very next step init suggests
+        // fails, right after install.
+        logger.info(
+          `Next: run \`${dxkitCli('tools install')}\`, then \`${dxkitCli('baseline create')}\` to capture today's state.`,
+        );
+        logger.dim('   (tools install provisions the scanners baseline needs; without a baseline,');
+        logger.dim('    your pre-push hook + CI guardrail have nothing to diff against)');
       }
 
       console.log(''); // slop-ok

--- a/src/files.ts
+++ b/src/files.ts
@@ -7,6 +7,30 @@ export function sha256(content: string): string {
   return createHash('sha256').update(content, 'utf-8').digest('hex');
 }
 
+/**
+ * Re-serialize `obj` to JSON while preserving the ORIGINAL text's formatting —
+ * its indentation (tabs vs N spaces) and whether it ended with a newline, and
+ * whether it was compact (single-line) at all. This is the one source of truth
+ * (Rule 2) for every additive JSON edit dxkit makes to a file the user owns
+ * (`package.json` devDep / postinstall on install; the inverse on uninstall).
+ *
+ * Why it matters: a naive `JSON.stringify(obj, null, 2)` REFORMATS the whole
+ * file, so adding one devDependency rewrites a compact or tab-indented
+ * `package.json` into 2-space-pretty — a change dxkit can never cleanly undo,
+ * because the original style is already lost by uninstall time. Preserving the
+ * style keeps the "exact pre-dxkit state" promise for surgical edits.
+ */
+export function serializePreservingJson(original: string, obj: unknown): string {
+  const trailing = original.endsWith('\n') ? '\n' : '';
+  // Compact: no internal newline in the trimmed source → keep it single-line.
+  if (original.trim().length > 0 && !original.trim().includes('\n')) {
+    return JSON.stringify(obj) + trailing;
+  }
+  const m = original.match(/\n([ \t]+)"/);
+  const indent = m ? (m[1][0] === '\t' ? '\t' : m[1].length) : 2;
+  return JSON.stringify(obj, null, indent) + trailing;
+}
+
 export async function writeFile(
   outputPath: string,
   content: string,

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -216,9 +216,21 @@ export async function generate(
     else if (writeResult === 'skipped') result.skipped.push(rel);
     else if (writeResult === 'overwritten') result.overwritten.push(rel);
 
+    // Provenance is what uninstall trusts to decide what it may remove. A
+    // SKIPPED file already existed — the user owns it — so we record that fact
+    // and store no hash (the hash would be dxkit's template, not the user's
+    // content, and mistaking one for the other is how --force could delete a
+    // project's own AGENTS.md / CLAUDE.md).
+    const provenance =
+      writeResult === 'created'
+        ? 'created'
+        : writeResult === 'overwritten'
+          ? 'overwritten'
+          : 'skipped';
     result.manifest.files[rel] = {
-      hash: evolving ? null : content ? sha256(content) : null,
+      hash: provenance === 'skipped' ? null : evolving ? null : content ? sha256(content) : null,
       evolving,
+      provenance,
     };
   }
 

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -13,7 +13,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
-import { makeExecutable } from './files';
+import { makeExecutable, serializePreservingJson } from './files';
+import { activateHooks } from './hooks-cli';
 import { detect } from './detect';
 import { buildDevcontainerExtensions, buildDevcontainerFeatures } from './languages';
 import { VERSION } from './constants';
@@ -209,9 +210,28 @@ export function installHooks(cwd: string, opts: InstallerOpts = {}): ShipInstall
         '`sh .githooks/<name>.dxkit` line to each existing hook to chain them.',
     );
   }
-  result.notes.push(
-    'Activate the hooks: `git config core.hooksPath .githooks` (one-time, per clone).',
-  );
+  // Activate the hooks HERE, directly, rather than relying on the postinstall
+  // script — a package manager (pnpm add, in particular) may skip the root
+  // postinstall, which would ship the pre-push guardrail inert. `activateHooks`
+  // is idempotent and refuses to clobber a custom `core.hooksPath` (husky /
+  // lefthook / a personal setting), so it is safe to always run. The
+  // postinstall wiring remains as a belt-and-suspenders re-apply on clone.
+  const activation = activateHooks(cwd);
+  if (activation.activated) {
+    result.notes.push('Activated the hooks (`core.hooksPath = .githooks`).');
+  } else if (activation.previousValue && activation.previousValue !== '.githooks') {
+    result.notes.push(
+      `Left your existing \`core.hooksPath = ${activation.previousValue}\` untouched; ` +
+        'chain the dxkit hooks from it (see the sidecar note above).',
+    );
+  } else {
+    // Activation couldn't run (e.g. not a git repo yet) — give the one-time
+    // command so the pre-push guardrail never ships silently inert.
+    result.notes.push(
+      'Activate the hooks with `git config core.hooksPath .githooks` ' +
+        '(dxkit does this automatically when run inside a git repo).',
+    );
+  }
   if (!opts.withPrecommit) {
     result.notes.push(
       'pre-commit hook NOT installed (default). The full guardrail re-runs every analyzer ' +
@@ -563,8 +583,7 @@ export function installHooksPostinstall(cwd: string, _opts: InstallerOpts = {}):
     // a husky bootstrap, etc.) silently leaves the pre-push guardrail
     // inactive — exactly the gap that lets pushes bypass the check.
     pkg.scripts = { ...(pkg.scripts ?? {}), postinstall: `${existing} && ${POSTINSTALL_CMD}` };
-    const trailing = raw.endsWith('\n') ? '\n' : '';
-    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + trailing, 'utf-8');
+    fs.writeFileSync(pkgPath, serializePreservingJson(raw, pkg), 'utf-8');
     result.installed.push('package.json (postinstall)');
     result.notes.push(
       `Chained \`${POSTINSTALL_CMD}\` after your existing postinstall so dxkit hooks activate ` +
@@ -575,14 +594,12 @@ export function installHooksPostinstall(cwd: string, _opts: InstallerOpts = {}):
 
   pkg.scripts = { ...(pkg.scripts ?? {}), postinstall: POSTINSTALL_CMD };
 
-  // Preserve trailing newline if the original had one — many editors
-  // and linters expect it.
-  const trailingNewline = raw.endsWith('\n') ? '\n' : '';
-  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + trailingNewline, 'utf-8');
+  fs.writeFileSync(pkgPath, serializePreservingJson(raw, pkg), 'utf-8');
   result.installed.push('package.json (postinstall)');
   result.notes.push(
-    'Wired `vyuh-dxkit hooks activate` into package.json postinstall — every clone + `npm install` ' +
-      'will activate `core.hooksPath = .githooks` automatically. (Manual one-time activation no longer needed.)',
+    'Wired `vyuh-dxkit hooks activate` into package.json postinstall so future clones + ' +
+      'installs re-activate `core.hooksPath = .githooks` automatically. (init already activated ' +
+      'the hooks for this checkout — no manual step needed.)',
   );
   return result;
 }
@@ -658,8 +675,7 @@ export function installDxkitDevDependency(
   const spec = VERSION && VERSION !== '0.0.0' ? `^${VERSION}` : 'latest';
   pkg.devDependencies = { ...(pkg.devDependencies ?? {}), [DXKIT_PACKAGE]: spec };
 
-  const trailingNewline = raw.endsWith('\n') ? '\n' : '';
-  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + trailingNewline, 'utf-8');
+  fs.writeFileSync(pkgPath, serializePreservingJson(raw, pkg), 'utf-8');
   result.installed.push('package.json (devDependencies)');
   result.notes.push(
     `Added ${DXKIT_PACKAGE}@${spec} to devDependencies — run \`npm install\` to provision it so the ` +

--- a/src/tools-cli.ts
+++ b/src/tools-cli.ts
@@ -18,11 +18,14 @@
  * - `vyuh-dxkit tools install --yes` → install all missing, no prompts
  */
 import * as readline from 'readline/promises';
+import * as fs from 'fs';
+import * as path from 'path';
 import { dxkitCli } from './self-invocation';
 import { stdin, stdout } from 'process';
 import { execSync } from 'child_process';
 import { detect } from './detect';
-import { DetectedStack } from './types';
+import { DetectedStack, type Manifest } from './types';
+import { serializePreservingJson } from './files';
 import { detectPackageManager, provisionCommand, pmAwareDevInstall } from './package-manager';
 import * as logger from './logger';
 import {
@@ -183,6 +186,27 @@ function showStatus(targetPath: string): ToolStatus[] {
   return statuses;
 }
 
+/**
+ * Append a dxkit-installed node devDependency to the install manifest so
+ * `vyuh-dxkit uninstall` can remove it. No-op when the repo has no manifest
+ * (dxkit wasn't init'd there) or the entry is already recorded. Best-effort:
+ * a manifest write failure never fails the install.
+ */
+function recordToolDep(cwd: string, pkg: string): void {
+  const manifestPath = path.join(cwd, '.vyuh-dxkit.json');
+  try {
+    const raw = fs.readFileSync(manifestPath, 'utf-8');
+    const manifest = JSON.parse(raw) as Manifest;
+    const toolDeps = manifest.toolDeps ?? [];
+    if (toolDeps.some((d) => d.package === pkg && d.ecosystem === 'node')) return;
+    toolDeps.push({ package: pkg, ecosystem: 'node' });
+    manifest.toolDeps = toolDeps;
+    fs.writeFileSync(manifestPath, serializePreservingJson(raw, manifest), 'utf-8');
+  } catch {
+    // no manifest / unreadable / unwritable → nothing to record, never fatal
+  }
+}
+
 async function confirm(rl: readline.Interface, question: string): Promise<boolean> {
   const answer = await rl.question(`  ${question} [Y/n]: `);
   if (!answer.trim()) return true;
@@ -336,6 +360,11 @@ async function runInstall(
         const recheck = findTool(def, targetPath);
         if (recheck.available) {
           results.push({ name: s.name, status: 'installed' });
+          // A project-local node devDep landed in the user's package.json on
+          // dxkit's behalf — record it so uninstall OWNS it (a dxkit-driven
+          // install dxkit then disowns breaks the "exact pre-dxkit state"
+          // promise). Global/isolated tools (no nodePackage) aren't recorded.
+          if (def.nodePackage) recordToolDep(targetPath, def.nodePackage);
           logger.success(`${s.name} installed (${recheck.source})`);
         } else {
           results.push({

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,17 @@ export interface FileEntry {
 export interface ManifestFileEntry {
   hash: string | null;
   evolving: boolean;
+  /**
+   * How dxkit related to this path at install time:
+   *   - `created`     — dxkit wrote the file (it did not exist before).
+   *   - `overwritten` — dxkit replaced a pre-existing file (only with --force).
+   *   - `skipped`     — the file already existed and dxkit kept the user's
+   *                     version. The user OWNS it; dxkit must never delete it,
+   *                     and `hash` is null (dxkit doesn't know its content).
+   * Optional — absent on manifests written before 2.27; uninstall falls back to
+   * the pre-provenance behavior (treat any entry as dxkit's) for those.
+   */
+  provenance?: 'created' | 'overwritten' | 'skipped';
 }
 
 /**
@@ -138,12 +149,26 @@ export interface ManifestInstallFlags {
   withClaudeLoop?: boolean;
 }
 
+/** A dependency `vyuh-dxkit tools install` added to the repo on dxkit's behalf
+ *  (e.g. a coverage scanner). Recorded so uninstall can OWN it — a dxkit-driven
+ *  install whose artifact dxkit then disowns would break the "exact pre-dxkit
+ *  state" guarantee. `ecosystem` drives how uninstall removes it. */
+export interface ManifestToolDep {
+  /** Package/coordinate name (e.g. `@vitest/coverage-v8`). */
+  package: string;
+  /** Which ecosystem's manifest it landed in (`node` → package.json devDeps). */
+  ecosystem: 'node';
+}
+
 export interface Manifest {
   version: string;
   mode: GenerationMode;
   generatedAt: string;
   config: ResolvedConfig;
   files: Record<string, ManifestFileEntry>;
+  /** Tools `tools install` added on dxkit's behalf. Optional — absent until a
+   *  tool is installed, or on manifests written before 2.27. */
+  toolDeps?: ManifestToolDep[];
   /**
    * Optional — present on manifests written by dxkit 2.5.2 or later.
    * Older manifests fall back to workspace detection in `update`.

--- a/src/uninstall/index.ts
+++ b/src/uninstall/index.ts
@@ -14,7 +14,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
 
-import { sha256 } from '../files';
+import { sha256, serializePreservingJson } from '../files';
 import { detectInstallFlags, type InstallFlags } from '../update';
 import { ALLOWLIST_FILENAME, ALLOWLIST_REASONS_FILENAME } from '../allowlist/file';
 import type { Manifest } from '../types';
@@ -78,6 +78,13 @@ function readManifest(cwd: string): Manifest | null {
 
 function exists(cwd: string, rel: string): boolean {
   return fs.existsSync(path.join(cwd, rel));
+}
+
+/** Node package names `tools install` recorded as dxkit-added devDeps — the set
+ *  uninstall also strips from package.json (under --remove-devdep) so a
+ *  dxkit-driven tool install doesn't outlive the uninstall. */
+function nodeToolDeps(manifest: Manifest | null): string[] {
+  return (manifest?.toolDeps ?? []).filter((d) => d.ecosystem === 'node').map((d) => d.package);
 }
 
 /** Ship-installer artifacts keyed by install flag (not in manifest.files — the
@@ -145,9 +152,13 @@ export function planUninstall(cwd: string, opts: UninstallOptions = {}): Uninsta
   }
   if (exists(cwd, 'CLAUDE.md')) {
     const claudeEntry = manifest?.files['CLAUDE.md'];
+    // dxkit MADE the file only when it created it — a `skipped` entry means the
+    // user's own CLAUDE.md that dxkit merely appended a loop block to. Legacy
+    // manifests (no provenance) keep the pre-2.27 behavior of trusting the hash.
+    const claudeMadeByDxkit = !!claudeEntry && claudeEntry.provenance !== 'skipped';
     const current = read(cwd, 'CLAUDE.md');
     const stripped = stripClaudeLoopBlock(current);
-    if (claudeEntry && claudeEntry.hash && sha256(stripped.content) === claudeEntry.hash) {
+    if (claudeMadeByDxkit && claudeEntry!.hash && sha256(stripped.content) === claudeEntry!.hash) {
       // dxkit created the whole file, and stripping dxkit's own loop block leaves
       // exactly the recorded dxkit shim (no user edits) → remove the whole file
       // (pre-dxkit state had no CLAUDE.md).
@@ -157,7 +168,7 @@ export function planUninstall(cwd: string, opts: UninstallOptions = {}): Uninsta
         detail: 'dxkit-created Claude config',
         status: 'pending',
       });
-    } else if (claudeEntry && stripped.changed) {
+    } else if (claudeMadeByDxkit && stripped.changed) {
       // dxkit created it but the user has since edited the shim → keep their
       // version, remove only dxkit's loop block; surface that we kept the file.
       actions.push({
@@ -169,8 +180,9 @@ export function planUninstall(cwd: string, opts: UninstallOptions = {}): Uninsta
       warnings.push(
         'CLAUDE.md was created by dxkit but you edited it — kept your version, removed only the loop block',
       );
-    } else if (!claudeEntry && stripped.changed) {
-      // The user's own pre-existing CLAUDE.md that dxkit only appended to.
+    } else if (stripped.changed) {
+      // The user's own pre-existing CLAUDE.md that dxkit only appended to
+      // (no manifest entry, or a `skipped` one) — strip only the loop block.
       actions.push({
         kind: 'revert-claude',
         target: 'CLAUDE.md',
@@ -181,7 +193,10 @@ export function planUninstall(cwd: string, opts: UninstallOptions = {}): Uninsta
   }
   if (exists(cwd, '.claude/settings.json')) {
     const parsed = tryJson(read(cwd, '.claude/settings.json'));
-    const dxkitCreated = !!manifest?.files['.claude/settings.json'];
+    const settingsEntry = manifest?.files['.claude/settings.json'];
+    // Created only when dxkit wrote the whole file; a `skipped`/absent entry
+    // means a pre-existing settings.json dxkit merged its hooks into → revert.
+    const dxkitCreated = !!settingsEntry && settingsEntry.provenance !== 'skipped';
     if (parsed && stripSettingsDxkit(parsed, { dxkitCreated }).changed) {
       actions.push({
         kind: 'revert-settings',
@@ -193,20 +208,26 @@ export function planUninstall(cwd: string, opts: UninstallOptions = {}): Uninsta
   }
   if (opts.removeDevDependency && exists(cwd, 'package.json')) {
     const parsed = tryJson(read(cwd, 'package.json'));
-    if (parsed && stripPackageJsonDxkit(parsed).changed) {
+    const tools = nodeToolDeps(manifest);
+    if (parsed && stripPackageJsonDxkit(parsed, tools).changed) {
+      const toolNote = tools.length ? ` + ${tools.length} tool devDep(s)` : '';
       actions.push({
         kind: 'revert-package',
         target: 'package.json',
-        detail: 'remove @vyuhlabs/dxkit devDependency + postinstall',
+        detail: `remove @vyuhlabs/dxkit devDependency + postinstall${toolNote}`,
         status: 'pending',
       });
     }
   }
 
   // 2. Delete generator-created files from the manifest (except merge targets).
+  //    A `skipped` entry is a file that PRE-EXISTED dxkit — the user owns it, so
+  //    it is never deleted (deleting it would be silent data loss; a --force
+  //    that removed a project's own AGENTS.md is exactly the bug this guards).
   const recorded = new Set(Object.keys(manifest?.files ?? {}));
   for (const [rel, entry] of Object.entries(manifest?.files ?? {})) {
     if (MERGE_TARGETS.has(rel)) continue;
+    if (entry.provenance === 'skipped') continue;
     del(rel, 'dxkit-created file', entry.evolving, entry.hash);
   }
 
@@ -350,23 +371,27 @@ export function executeUninstall(
         const original = read(cwd, '.claude/settings.json');
         const parsed = tryJson(original)!;
         const manifest = readManifest(cwd);
-        const dxkitCreated = !!manifest?.files['.claude/settings.json'];
+        const settingsEntry = manifest?.files['.claude/settings.json'];
+        const dxkitCreated = !!settingsEntry && settingsEntry.provenance !== 'skipped';
         const { result, isDxkitOnly } = stripSettingsDxkit(parsed, { dxkitCreated });
         if (isDxkitOnly) {
           rm(abs);
           pruneEmptyParents(cwd, abs);
         } else {
-          fs.writeFileSync(abs, serializePreserving(original, result), 'utf-8');
+          fs.writeFileSync(abs, serializePreservingJson(original, result), 'utf-8');
         }
         reverted.push(a.target);
         break;
       }
       case 'revert-package': {
         const original = read(cwd, 'package.json');
-        const { result } = stripPackageJsonDxkit(tryJson(original)!);
+        const { result } = stripPackageJsonDxkit(
+          tryJson(original)!,
+          nodeToolDeps(readManifest(cwd)),
+        );
         // Preserve the file's original indent + trailing-newline style so the
         // reverted file is byte-identical to its pre-dxkit content (git-clean).
-        fs.writeFileSync(abs, serializePreserving(original, result), 'utf-8');
+        fs.writeFileSync(abs, serializePreservingJson(original, result), 'utf-8');
         reverted.push(a.target);
         break;
       }
@@ -388,15 +413,6 @@ export function executeUninstall(
 
 function read(cwd: string, rel: string): string {
   return fs.readFileSync(path.join(cwd, rel), 'utf-8');
-}
-/** Re-serialize `obj` matching `original`'s indentation and trailing-newline
- *  style, so a surgical JSON revert leaves the file byte-identical to how the
- *  user's editor/tooling would have written it (no spurious git diff). */
-function serializePreserving(original: string, obj: unknown): string {
-  const m = original.match(/\n([ \t]+)"/);
-  const indent = m ? (m[1][0] === '\t' ? '\t' : m[1].length) : 2;
-  const json = JSON.stringify(obj, null, indent);
-  return original.endsWith('\n') ? json + '\n' : json;
 }
 function tryJson(s: string): Record<string, unknown> | null {
   try {

--- a/src/uninstall/reversals.ts
+++ b/src/uninstall/reversals.ts
@@ -164,7 +164,10 @@ function entryInvokes(entry: unknown, re: RegExp): boolean {
  *     suffix, or dropping the whole `postinstall` key when it was the sole cmd).
  * Nothing else is touched. Returns which pieces were removed for reporting.
  */
-export function stripPackageJsonDxkit(parsed: JsonRecord): {
+export function stripPackageJsonDxkit(
+  parsed: JsonRecord,
+  extraDevDeps: readonly string[] = [],
+): {
   changed: boolean;
   result: JsonRecord;
   removedDevDep: boolean;
@@ -174,13 +177,22 @@ export function stripPackageJsonDxkit(parsed: JsonRecord): {
   let removedDevDep = false;
   let removedPostinstall = false;
 
+  // The dxkit devDep plus any node tools `tools install` added on dxkit's
+  // behalf (recorded in the manifest) — all removed so the round-trip is clean.
+  const toRemove = [DXKIT_PACKAGE, ...extraDevDeps];
   const dev = obj.devDependencies as JsonRecord | undefined;
-  if (dev && typeof dev === 'object' && DXKIT_PACKAGE in dev) {
+  if (dev && typeof dev === 'object') {
     const nextDev = { ...dev };
-    delete nextDev[DXKIT_PACKAGE];
-    removedDevDep = true;
-    if (Object.keys(nextDev).length === 0) delete obj.devDependencies;
-    else obj.devDependencies = nextDev;
+    for (const name of toRemove) {
+      if (name in nextDev) {
+        delete nextDev[name];
+        removedDevDep = true;
+      }
+    }
+    if (removedDevDep) {
+      if (Object.keys(nextDev).length === 0) delete obj.devDependencies;
+      else obj.devDependencies = nextDev;
+    }
   }
 
   const scripts = obj.scripts as JsonRecord | undefined;

--- a/test/lifecycle/roundtrip.test.ts
+++ b/test/lifecycle/roundtrip.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Install/uninstall LIFECYCLE harness — the real-repo net.
+ *
+ * Every dogfood-reported install/uninstall bug lived in the seam between dxkit
+ * and a real repo (its package manager, its pre-existing files, its toolchain) —
+ * a seam the unit suite never exercises because it uses synthetic fixtures and
+ * dxkit dogfoods itself. This harness runs the REAL CLI (built `dist/index.js`)
+ * against realistic throwaway git repos and asserts the load-bearing promise:
+ * after `uninstall`, the working tree is byte-identical to the pre-dxkit commit,
+ * and dxkit never claims provenance over a file it didn't author.
+ *
+ * It shells out to a separate node process, so it stays cheap even under the
+ * default suite's coverage instrumentation, and it is package-manager-agnostic
+ * (it drives dxkit's own code paths; the PM-behavior scenarios that need a real
+ * pnpm live in the multi-ecosystem fixtures).
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const CLI = join(__dirname, '..', '..', 'dist', 'index.js');
+
+beforeAll(() => {
+  if (!existsSync(CLI)) {
+    throw new Error(`dist/index.js missing — run \`npm run build\` first (test:run does this).`);
+  }
+});
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+}
+function cli(cwd: string, ...args: string[]): string {
+  return execFileSync('node', [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+function write(root: string, rel: string, content: string): void {
+  const abs = join(root, rel);
+  mkdirSync(join(abs, '..'), { recursive: true });
+  writeFileSync(abs, content);
+}
+function porcelain(cwd: string): string {
+  return git(cwd, 'status', '--porcelain').trim();
+}
+
+let repo: string;
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), 'dxkit-lifecycle-'));
+  git(repo, 'init', '-q');
+  git(repo, 'config', 'user.email', 't@t.t');
+  git(repo, 'config', 'user.name', 'test');
+});
+afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+describe('install/uninstall round-trip restores the exact pre-dxkit state', () => {
+  it('a fresh repo returns byte-clean after uninstall', () => {
+    write(repo, 'package.json', JSON.stringify({ name: 'fresh', version: '1.0.0' }));
+    write(repo, 'src/index.ts', 'export const x = 1;\n');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'pre-dxkit');
+
+    cli(repo, 'init', '--with-dxkit-agents', '--yes');
+    expect(porcelain(repo)).not.toBe(''); // dxkit added files
+    cli(repo, 'uninstall', '--yes', '--remove-devdep');
+    expect(porcelain(repo)).toBe(''); // …and removed every trace
+    expect(existsSync(join(repo, '.vyuh-dxkit.json'))).toBe(false); // manifest gone too
+  });
+
+  it('a tool `tools install` recorded is removed on uninstall (no disowned artifact)', () => {
+    write(repo, 'package.json', '{\n  "name": "cov",\n  "version": "1.0.0"\n}\n');
+    write(repo, 'src/index.ts', 'export const x = 1;\n');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'pre-dxkit');
+
+    cli(repo, 'init', '--with-dxkit-agents', '--yes');
+    // Simulate what `tools install` now does: add a coverage devDep AND record
+    // it in the manifest so uninstall owns it (real `tools install` needs a
+    // network install; here we drive the recorded-state contract directly).
+    const pkgPath = join(repo, 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+      devDependencies?: Record<string, string>;
+    };
+    pkg.devDependencies = { ...(pkg.devDependencies ?? {}), '@vitest/coverage-v8': '^4.0.0' };
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+    const mPath = join(repo, '.vyuh-dxkit.json');
+    const m = JSON.parse(readFileSync(mPath, 'utf8')) as { toolDeps?: unknown[] };
+    m.toolDeps = [{ package: '@vitest/coverage-v8', ecosystem: 'node' }];
+    writeFileSync(mPath, JSON.stringify(m, null, 2) + '\n');
+    // Everything dxkit added stays UNCOMMITTED (as in a real install), so a
+    // clean uninstall returns the tree to the committed pre-dxkit state.
+
+    cli(repo, 'uninstall', '--yes', '--remove-devdep');
+    expect(porcelain(repo)).toBe(''); // coverage devDep removed too → byte-clean
+    expect(readFileSync(pkgPath, 'utf8')).not.toMatch(/coverage-v8/);
+  });
+
+  it('NEVER claims a pre-existing AGENTS.md / CLAUDE.md as dxkit-created (data-loss guard)', () => {
+    // These files predate dxkit — the project authored them.
+    const agents = '# My Project\n\nProject-authored agent guidance.\n';
+    const claude = '# My CLAUDE config\n\nProject-authored notes.\n';
+    write(repo, 'AGENTS.md', agents);
+    write(repo, 'CLAUDE.md', claude);
+    write(repo, 'package.json', JSON.stringify({ name: 'brown', version: '1.0.0' }));
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'pre-dxkit brownfield');
+
+    cli(repo, 'init', '--with-dxkit-agents', '--yes');
+
+    // The manifest must not mark a file dxkit merely skipped as one it created.
+    const manifest = JSON.parse(readFileSync(join(repo, '.vyuh-dxkit.json'), 'utf8')) as {
+      files: Record<string, { provenance?: string }>;
+    };
+    for (const f of ['AGENTS.md']) {
+      const entry = manifest.files[f];
+      if (entry) expect(entry.provenance, `${f} provenance`).not.toBe('created');
+    }
+
+    // The uninstall plan must never offer to --force-delete a project file.
+    const plan = cli(repo, 'uninstall');
+    expect(plan).not.toMatch(/AGENTS\.md.*use --force to remove/);
+
+    // Even a --force uninstall must NOT delete or alter the project's own files.
+    cli(repo, 'uninstall', '--yes', '--force', '--remove-devdep');
+    expect(existsSync(join(repo, 'AGENTS.md')), 'AGENTS.md survives --force').toBe(true);
+    expect(readFileSync(join(repo, 'AGENTS.md'), 'utf8')).toBe(agents);
+    expect(readFileSync(join(repo, 'CLAUDE.md'), 'utf8')).toBe(claude);
+    expect(porcelain(repo)).toBe(''); // byte-clean: project files intact, dxkit gone
+  });
+});
+
+describe('load-bearing activation does not depend on a package-manager hook', () => {
+  it('init --with-hooks activates core.hooksPath itself (not via postinstall)', () => {
+    write(repo, 'package.json', JSON.stringify({ name: 'hooks', version: '1.0.0' }));
+    write(repo, 'src/index.ts', 'export const x = 1;\n');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'pre-dxkit');
+
+    // No package manager runs here — init must not defer the load-bearing
+    // git-config write to a postinstall script that a given PM may skip.
+    cli(repo, 'init', '--with-hooks', '--yes');
+    const hooksPath = git(repo, 'config', '--local', '--get', 'core.hooksPath').trim();
+    expect(hooksPath).toBe('.githooks');
+  });
+});


### PR DESCRIPTION
A round of real-repo dogfood feedback traced to one gap: dxkit had 2900+ unit tests but no test of its own most important promise — **restore the exact pre-dxkit state, on any repo**. Every reported install/uninstall bug lived in the seam between dxkit and a real repo (its package manager, its pre-existing files, its toolchain) — exactly what synthetic fixtures + self-dogfooding never exercise. This is a root-cause pass plus a real-repo lifecycle harness that makes the promise a continuously-checked invariant.

## The net (the anti-recurrence mechanism)

`test/lifecycle/roundtrip.test.ts` runs the **built CLI** through `init → uninstall` on realistic throwaway git repos and asserts the working tree returns byte-identical to the pre-dxkit commit. It reproduced every fix below as a failing test first, and gates every PR.

## Root-cause fixes (platform-level, all 8 packs)

- **No data loss on uninstall (HIGH).** The manifest now records `provenance` (`created`/`overwritten`/`skipped`). A pre-existing `AGENTS.md`/`CLAUDE.md` dxkit merely kept is `skipped`, so `uninstall` — even `--force` — never deletes a file the project authored. Also fixes the manifest being left behind (a false-skip no longer keeps it).
- **Pre-push hook no longer inert under pnpm (HIGH).** `init` activates `core.hooksPath` itself instead of relying on a `postinstall` script `pnpm add` may skip. Postinstall stays as a re-apply on clone.
- **`package.json` byte-exactness.** One shared `serializePreservingJson` (Rule 2): install no longer reformats a compact/tab-indented `package.json` into 2-space pretty — a change uninstall could never undo.
- **No disowned tools.** `tools install` records node devDeps it adds (`toolDeps`, ecosystem-tagged); `uninstall --remove-devdep` removes them.
- **`init` next-step** sequences `tools install` before `baseline create`.
- **Docs:** `--detect` isn't a dry-run; the pnpm `minimumReleaseAge` note is corrected.

## Why this addresses the pattern

The reason we kept getting surprised is that dxkit's core promise was never an automated, continuously-checked invariant. Now it is. The remaining reported item — Next.js catch-all route extraction — is a flow-extraction quality improvement (distinct from this lifecycle class) and ships as a focused **2.28.0** (a pack-declarable file-route capability).

Rebase-merge (2 commits). Full suite green (2913+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)