### PR TITLE
feat(flow): detect file-convention routes (Next.js App Router) — 2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.28.0] - 2026-07-05
+
+### Added — file-convention route detection (Next.js App Router & friends)
+
+The flow feature's served side now understands routes served by a handler
+file's **location** on disk, not just in-source decorators (`@get`) and router
+calls (`app.get`). A Next.js App Router repo previously reported "0 routes" —
+every client call showed as unresolved — because `app/**/route.ts` handlers are
+a file convention, not an AST pattern. They are now first-class served routes.
+
+- **Pack-declared, framework-general.** A new `httpFlow.fileRoutes` capability
+  lets a language pack declare the handler filename (`route`, `+server`), the
+  routing base directories (`app`, `src/app`), an optional URL prefix, and the
+  verb-named exports (`GET`/`POST`/…). The shared path algebra — route groups
+  `(payload)`, dynamic `[id]`, catch-all `[[...slug]]`, private `_` segments,
+  parallel `@` slots — lives centrally, so the same seam extends to SvelteKit,
+  Remix, and the Pages Router without new engine code. The TypeScript pack ships
+  the Next.js App Router descriptor.
+- A derived route joins client calls through the exact same normalized
+  `(method, path)` key as every other route, so the integration gate,
+  cross-repo contract, and flow map pick them up unchanged.
+
+### Fixed
+
+- The install/uninstall lifecycle net now also pins the tab-indented
+  `package.json` case, closing the last untested branch of the 2.27.0
+  format-preservation fix.
+
 ## [2.27.0] - 2026-07-05
 
 ### Fixed — install/uninstall lifecycle reliability (root-cause pass)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.27.0",
+      "version": "2.28.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1060,6 +1060,27 @@ if [ -n "$RULE13_FLOW" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# 13d (Flow 2.28 file-routes): file-convention routing (Next.js App Router,
+# SvelteKit, Pages Router) is pack-DECLARED, framework-general in the engine.
+# The handler filename (`route`, `+server`) and routing base dirs (`app`,
+# `src/app`, `pages/api`) are per-framework facts that MUST come from a pack's
+# `httpFlow.fileRoutes` descriptor (Rule 6) — never a literal inside
+# src/analyzers/flow/. The shared path algebra in file-routes.ts encodes only
+# the framework-GENERAL conventions (route groups, `[param]`, catch-all). A
+# hardcoded `'route'`/`'+server'`/`'src/app'`/`'pages/api'` string here would
+# re-hardcode the exact Next.js coupling this capability exists to remove.
+RULE13_FILEROUTES=$(grep -rnE "'(route|\+server|src/app|pages/api|route\.(ts|js))'" src/analyzers/flow/ 2>/dev/null \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | grep -v "// file-route-ok")
+if [ -n "$RULE13_FILEROUTES" ]; then
+  echo "❌ Rule 13d violation: hardcoded file-route framework literal in src/analyzers/flow/:"
+  echo "$RULE13_FILEROUTES"
+  echo "   → Declare handler filename + base dirs in a pack's httpFlow.fileRoutes"
+  echo "     (src/languages/<id>.ts); the engine consumes them via the descriptor."
+  echo "   → Annotate '// file-route-ok' for a justified exception (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
 # Rule 14 (2.13.1 self-invocation class-fix): generated artifacts invoke the
 # dxkit CLI through ONE canonical helper, and every auto-running surface is
 # in ONE registry.

--- a/src/analyzers/flow/contract.ts
+++ b/src/analyzers/flow/contract.ts
@@ -31,7 +31,7 @@ export interface ServedRoute {
   readonly method: string;
   readonly path: string;
   readonly handler: string | null;
-  readonly via: 'decorator' | 'router-call' | 'spec';
+  readonly via: 'decorator' | 'router-call' | 'file-route' | 'spec';
 }
 
 /** One binding in the consumed-side inventory — a UI call site's dependency on

--- a/src/analyzers/flow/extract.ts
+++ b/src/analyzers/flow/extract.ts
@@ -25,6 +25,7 @@ import { getLanguage } from '../../languages';
 import type { HttpFlowSupport, LanguageId } from '../../languages/types';
 import { parseFile, walk, type Node } from '../../ast/parse';
 import { normalizeMethod, normalizePath, type HttpMethod, type NormalizeConfig } from './normalize';
+import { deriveFileRoutePath, exportedMethodNames } from './file-routes';
 
 /** An outbound HTTP call found in source (the consumed side). */
 export interface ClientCall {
@@ -38,12 +39,14 @@ export interface ClientCall {
 }
 
 /** An inbound route a service serves (the served side). `via` records how it
- *  was discovered: a source decorator, an Express-style route call, or an
- *  ingested OpenAPI/spec document (preferred when available). */
+ *  was discovered: a source decorator, an Express-style route call, a
+ *  file-convention route handler (Next.js App Router / SvelteKit — the URL is
+ *  derived from the file's location), or an ingested OpenAPI/spec document
+ *  (preferred when available). */
 export interface RouteEndpoint {
   readonly method: HttpMethod;
   readonly path: string;
-  readonly via: 'decorator' | 'router-call' | 'spec';
+  readonly via: 'decorator' | 'router-call' | 'file-route' | 'spec';
   readonly handler: string | null;
   readonly file: string;
   readonly line: number;
@@ -159,9 +162,37 @@ export function extractFromTree(
   hf: HttpFlowSupport,
   file: string,
   config?: NormalizeConfig,
+  relPath?: string,
 ): FileFlow {
   const calls: ClientCall[] = [];
   const routes: RouteEndpoint[] = [];
+
+  // ── file-convention routes (Next.js App Router / SvelteKit) ──
+  // The served URL is derived from the handler file's LOCATION, so this needs
+  // the repo-relative path (`relPath`), falling back to `file` when the caller
+  // has only the scanned path. Additive to the in-source walk below: a route
+  // handler can also make outbound calls, and both surfaces are recorded.
+  if (hf.fileRoutes) {
+    const routePath = deriveFileRoutePath(relPath ?? file, hf.fileRoutes, config);
+    if (routePath) {
+      for (const { name, line: exportLine } of exportedMethodNames(
+        root,
+        hf.fileRoutes.methodExports,
+      )) {
+        const method = normalizeMethod(name, hf.methodAliases);
+        if (method) {
+          routes.push({
+            method,
+            path: routePath,
+            via: 'file-route',
+            handler: name,
+            file,
+            line: exportLine,
+          });
+        }
+      }
+    }
+  }
 
   const clientCallees = new Set(hf.clientCallees ?? []);
   const methodCallMethods = new Set(hf.clientMethodCallees?.methods ?? []);
@@ -276,12 +307,13 @@ export function extractFromTree(
 export async function extractFileFlow(
   filePath: string,
   config?: NormalizeConfig,
+  relPath?: string,
 ): Promise<FileFlow | null> {
   const parsed = await parseFile(filePath);
   if (!parsed) return null;
   const hf = httpFlowFor(parsed.languageId);
   if (!hf) return { calls: [], routes: [] };
-  return extractFromTree(parsed.tree.rootNode, hf, filePath, config);
+  return extractFromTree(parsed.tree.rootNode, hf, filePath, config, relPath);
 }
 
 function httpFlowFor(languageId: LanguageId): HttpFlowSupport | undefined {

--- a/src/analyzers/flow/file-routes.ts
+++ b/src/analyzers/flow/file-routes.ts
@@ -1,0 +1,201 @@
+/**
+ * File-convention route derivation — the served side for frameworks that route
+ * by a handler file's LOCATION on disk (Next.js App Router `route.ts` under
+ * `app/`, SvelteKit `+server.ts` under `src/routes/`, Next.js Pages Router
+ * files under `pages/api/`) rather than an in-source decorator or router call.
+ *
+ * Two concerns live here, both framework-GENERAL:
+ *
+ *   1. The **path algebra** (`deriveFileRoutePath`) — turn a repo-relative file
+ *      path into the served URL by stripping the routing base, dropping
+ *      organizational segments (route groups `(x)`, parallel slots `@x`),
+ *      excluding private `_`-segments, and canonicalizing dynamic segments
+ *      (`[id]` / `[[...slug]]` / `[...slug]`) to `{var}`. These conventions are
+ *      shared across every file-route framework, so — like the `:id`→`{var}`
+ *      canonicalization in `normalize.ts` (Rule 6 boundary) — they are NOT a
+ *      per-pack fact. The pack supplies only the framework-specific inputs
+ *      (`FileRouteSupport`: handler filename, base dirs, url prefix, verb
+ *      exports); no `'route'` / `'app'` literal ever appears in this file.
+ *
+ *   2. The **verb-export read** (`exportedMethodNames`) — which HTTP-verb-named
+ *      exports a handler file declares. Next.js App Router + SvelteKit express
+ *      the method as the exported symbol's name (`export function GET`).
+ *
+ * Pure over its inputs. Every derived path is finished through the shared
+ * `normalizePath`, so a file-route endpoint and a client call that targets it
+ * reduce to the SAME canonical key and join — identity (Rule 9) stays uniform
+ * across every route-discovery mechanism.
+ */
+
+import type { Node } from '../../ast/parse';
+import type { FileRouteSupport } from '../../languages/types';
+import { normalizePath, type NormalizeConfig } from './normalize';
+
+/** A route group / layout segment: an entire segment wrapped in parentheses,
+ *  organizational only (`(payload)`, `(marketing)`) — dropped from the URL. */
+const ROUTE_GROUP = /^\(.+\)$/;
+/** A parallel-route slot (`@modal`) — renders into a slot, adds no URL segment. */
+const PARALLEL_SLOT = /^@/;
+/** A catch-all / optional-catch-all segment (`[...slug]`, `[[...slug]]`). */
+const CATCH_ALL = /^\[\[?\.\.\.[^\]]+\]\]?$/;
+/** A single dynamic segment (`[id]`). */
+const DYNAMIC = /^\[.+\]$/;
+/** The placeholder every dynamic segment canonicalizes to (matches normalize.ts). */
+const PLACEHOLDER = '{var}';
+
+function toPosix(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+function stripExt(basename: string): string {
+  const dot = basename.lastIndexOf('.');
+  return dot > 0 ? basename.slice(0, dot) : basename;
+}
+
+/**
+ * Locate the routing base within `segments`. Returns the index of the first
+ * segment AFTER the base (where the route path begins), or -1 when no base
+ * matches. The longest (most-specific) declared base wins, so `src/app` is
+ * preferred over `app` when a path contains both.
+ */
+function findBaseEnd(segments: readonly string[], baseDirs: readonly string[]): number {
+  const bases = [...baseDirs]
+    .map((b) => toPosix(b).split('/').filter(Boolean))
+    .sort((a, b) => b.length - a.length);
+  for (const base of bases) {
+    for (let i = 0; i + base.length <= segments.length; i++) {
+      if (base.every((seg, k) => segments[i + k] === seg)) return i + base.length;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Canonicalize one directory segment to its URL contribution:
+ *   - `''` → drop (route group / parallel slot: not part of the URL);
+ *   - `'{var}'` → dynamic / catch-all segment;
+ *   - `null` → the whole route is NOT served (a private `_`-segment opts the
+ *     subtree out of routing);
+ *   - otherwise the literal segment.
+ */
+function classifySegment(seg: string): string | null {
+  if (seg.startsWith('_')) return null; // private subtree — not routable
+  if (ROUTE_GROUP.test(seg) || PARALLEL_SLOT.test(seg)) return ''; // organizational
+  if (CATCH_ALL.test(seg) || DYNAMIC.test(seg)) return PLACEHOLDER;
+  return seg;
+}
+
+/**
+ * Derive the served URL path for a handler file at `relPath` (repo-relative,
+ * either separator), or `null` when the file is not a served route under this
+ * descriptor — a non-handler basename, a file outside every base dir, a private
+ * subtree, or a base-root handler with no path segments (a bare `/`, which the
+ * shared normalizer drops as signal-free). The result is the canonical path the
+ * flow join keys on.
+ */
+export function deriveFileRoutePath(
+  relPath: string,
+  desc: FileRouteSupport,
+  config?: NormalizeConfig,
+): string | null {
+  const segments = toPosix(relPath).split('/').filter(Boolean);
+  if (segments.length === 0) return null;
+
+  const basename = segments[segments.length - 1];
+  const stem = stripExt(basename);
+  const wildcard = desc.handlerFile === '*';
+  if (!wildcard && stem !== desc.handlerFile) return null;
+
+  const baseEnd = findBaseEnd(segments, desc.baseDirs);
+  if (baseEnd < 0) return null;
+
+  // Route segments: the dirs between the base and the handler file. In wildcard
+  // mode the filename IS the last path segment (`index` collapses to its dir).
+  const routeSegments = wildcard
+    ? [...segments.slice(baseEnd, segments.length - 1), stem].filter((s) => s !== 'index')
+    : segments.slice(baseEnd, segments.length - 1);
+
+  const parts: string[] = [];
+  for (const seg of routeSegments) {
+    const mapped = classifySegment(seg);
+    if (mapped === null) return null; // private subtree
+    if (mapped === '') continue; // organizational segment
+    parts.push(mapped);
+  }
+
+  const prefix = desc.urlPrefix ? toPosix(desc.urlPrefix).split('/').filter(Boolean) : [];
+  const raw = '/' + [...prefix, ...parts].join('/');
+  return normalizePath(raw, config);
+}
+
+/** A verb-named export found in a handler file: the method name + its line. */
+export interface MethodExport {
+  readonly name: string;
+  readonly line: number;
+}
+
+/**
+ * Collect the HTTP-verb-named exports a handler file declares, intersected with
+ * the descriptor's `methodExports`. Handles the three export shapes a route
+ * handler uses: `export function GET`, `export const GET =`, and
+ * `export { GET }`. Only DIRECT exports count — a verb-named function nested
+ * inside another (non-exported) declaration is not a route method. Deduped by
+ * name (first occurrence wins for the line).
+ */
+export function exportedMethodNames(root: Node, methodExports: readonly string[]): MethodExport[] {
+  const wanted = new Set(methodExports);
+  const found = new Map<string, number>();
+
+  for (const stmt of allNamedDescendants(root)) {
+    if (stmt.type !== 'export_statement') continue;
+
+    const decl = stmt.childForFieldName('declaration');
+    if (decl) {
+      if (decl.type === 'function_declaration' || decl.type === 'generator_function_declaration') {
+        addIfWanted(decl.childForFieldName('name'), wanted, found);
+      } else if (decl.type === 'lexical_declaration' || decl.type === 'variable_declaration') {
+        for (const d of decl.namedChildren) {
+          if (d && d.type === 'variable_declarator')
+            addIfWanted(d.childForFieldName('name'), wanted, found);
+        }
+      }
+      continue;
+    }
+
+    // `export { GET, POST }`
+    const clause = stmt.namedChildren.find((c) => c?.type === 'export_clause') ?? null;
+    if (clause) {
+      for (const spec of clause.namedChildren) {
+        if (spec && spec.type === 'export_specifier')
+          addIfWanted(spec.childForFieldName('name'), wanted, found);
+      }
+    }
+  }
+
+  return [...found].map(([name, line]) => ({ name, line }));
+}
+
+function addIfWanted(
+  nameNode: Node | null,
+  wanted: ReadonlySet<string>,
+  found: Map<string, number>,
+): void {
+  if (
+    nameNode &&
+    nameNode.type === 'identifier' &&
+    wanted.has(nameNode.text) &&
+    !found.has(nameNode.text)
+  ) {
+    found.set(nameNode.text, nameNode.startPosition.row + 1);
+  }
+}
+
+/**
+ * Top-level named children only — an export can appear as a direct child of the
+ * program, so walking the immediate named descendants suffices and avoids
+ * descending into function bodies (where a nested `export`-shaped node cannot
+ * legally live anyway). Kept as a helper so the intent is explicit.
+ */
+function allNamedDescendants(root: Node): Node[] {
+  return root.namedChildren.filter((c): c is Node => c !== null);
+}

--- a/src/analyzers/flow/gather.ts
+++ b/src/analyzers/flow/gather.ts
@@ -61,7 +61,10 @@ export async function gatherFlowModel(opts: GatherFlowOptions): Promise<FlowMode
 
   for (const root of opts.roots) {
     for (const rel of walkSourceFiles(root, { extensions })) {
-      const flow = await extractFileFlow(join(root, rel), config);
+      // `rel` (root-relative) is what file-convention routing derives its URL
+      // from — the routing base (`app`, `src/app`) is relative to the scanned
+      // participant root, not the absolute path or the repo-root relabel.
+      const flow = await extractFileFlow(join(root, rel), config, rel);
       if (flow) fileFlows.push(opts.relativeTo ? relabelFileFlow(flow, opts.relativeTo) : flow);
     }
   }

--- a/src/explore/types.ts
+++ b/src/explore/types.ts
@@ -103,7 +103,7 @@ export interface HttpEndpointNode {
   readonly label: string;
   readonly method: string;
   readonly path: string;
-  readonly via: 'decorator' | 'router-call' | 'spec';
+  readonly via: 'decorator' | 'router-call' | 'file-route' | 'spec';
   readonly handler: string | null;
   readonly sourceFile: string;
   readonly line?: number;

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -165,6 +165,54 @@ export interface DeepSastSupport {
  * Optional — a pack with no HTTP surface (or none modeled yet) omits it,
  * and the flow extractor sees the empty union for that language.
  */
+/**
+ * File-convention routing: how a pack's framework serves a route from a file's
+ * LOCATION on disk rather than an in-source decorator or router call. Next.js
+ * App Router (`app/**` `/route.ts` exporting `GET`/`POST`), SvelteKit
+ * (`src/routes/**` `/+server.ts`), and Next.js Pages Router (`pages/api/**`)
+ * all fit this shape — the served URL is derived from the directory path and
+ * the HTTP verb is an exported symbol's name.
+ *
+ * The pack declares only what is genuinely framework-specific — the handler
+ * filename, the routing base directories, an optional fixed URL prefix, and the
+ * verb-named exports. The uniform "file-route path algebra" (route groups,
+ * `[param]` / `[[...catch-all]]` dynamics, private `_`-segments, parallel
+ * `@`-slots) lives centrally in `src/analyzers/flow/file-routes.ts`, the same
+ * Rule 6 boundary the URL normalizer draws — those conventions are shared
+ * across every file-route framework, so they are not a per-pack fact.
+ */
+export interface FileRouteSupport {
+  /**
+   * Basename (without extension) of a route-handler file — Next.js App Router
+   * `'route'`, SvelteKit `'+server'`. Use `'*'` when EVERY file under a base
+   * serves a route (Next.js Pages Router `pages/api`, where the filename itself
+   * becomes the last path segment and `index` collapses to its directory).
+   * Matched against the file's basename with its extension removed.
+   */
+  handlerFile: string;
+
+  /**
+   * Repo-relative directory prefixes under which routing begins; the URL path
+   * is derived from the segments AFTER the matched base. The longest (most
+   * specific) matching base wins, so `['src/app', 'app']` prefers `src/app`.
+   */
+  baseDirs: string[];
+
+  /**
+   * Fixed URL prefix prepended to every derived path — for a base whose own
+   * name is part of the served URL (`pages/api` serves under `/api`). Optional;
+   * App Router / SvelteKit omit it because the base directory is not served.
+   */
+  urlPrefix?: string;
+
+  /**
+   * Named exports whose name IS an HTTP verb (`GET`, `POST`, `PUT`, `PATCH`,
+   * `DELETE`, `HEAD`, `OPTIONS`). The export's name is the method. Matched
+   * against `export function GET`, `export const GET =`, and `export { GET }`.
+   */
+  methodExports: string[];
+}
+
 export interface HttpFlowSupport {
   /**
    * Bare-callee identifiers that initiate an outbound HTTP request with the
@@ -211,6 +259,16 @@ export interface HttpFlowSupport {
    * (`get` → `GET`). Keys are lowercase method tokens.
    */
   methodAliases?: Record<string, string>;
+
+  /**
+   * File-convention routing (Next.js App Router / SvelteKit / Pages Router):
+   * routes served by a handler file's LOCATION, not an in-source decorator or
+   * router call. The extractor derives the served URL from the file's directory
+   * and reads verb-named exports for the methods. See {@link FileRouteSupport}.
+   *
+   * Optional — a pack whose frameworks route only in-source omits it.
+   */
+  fileRoutes?: FileRouteSupport;
 }
 
 /**

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1398,6 +1398,17 @@ export const typescript: LanguageSupport = {
       bases: ['app', 'router'],
     },
     methodAliases: { del: 'DELETE' },
+    // File-convention routing: Next.js App Router serves each `route.ts` under
+    // `app/` (or `src/app/`) with the verb as an exported function name
+    // (`export async function GET`). The shared file-route algebra
+    // (`src/analyzers/flow/file-routes.ts`) handles route groups `(payload)`,
+    // dynamic `[id]`, and catch-all `[[...slug]]` — this descriptor supplies
+    // only the framework-specific handler filename, bases, and verb exports.
+    fileRoutes: {
+      handlerFile: 'route',
+      baseDirs: ['src/app', 'app'],
+      methodExports: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
+    },
   },
 
   // Tree-sitter grammars by extension for the canonical AST layer (src/ast/).

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -154,9 +154,10 @@ function copyAdditive(
  * matching hook (via .githooks/ or .husky/), emits a `.dxkit`
  * sidecar instead and prints merge instructions.
  *
- * Customer still needs to run `git config core.hooksPath .githooks`
- * to activate. We don't run it for them — that's a global git config
- * mutation outside dxkit's purview.
+ * Activation (`git config core.hooksPath .githooks`) happens here directly
+ * via `activateHooks` (idempotent; refuses to clobber a custom hooksPath such
+ * as husky's) rather than relying on a postinstall script — pnpm skips the
+ * dxkit devDependency's postinstall, which would ship the guardrail inert.
  *
  * Why pre-commit is opt-in: see `InstallerOpts.withPrecommit`.
  */

--- a/test/flow-file-routes.test.ts
+++ b/test/flow-file-routes.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { parseSource } from '../src/ast/parse';
+import { extractFromTree } from '../src/analyzers/flow/extract';
+import { deriveFileRoutePath } from '../src/analyzers/flow/file-routes';
+import { getLanguage } from '../src/languages';
+import type { FileRouteSupport, HttpFlowSupport } from '../src/languages/types';
+
+const ts = getLanguage('typescript')!.httpFlow as HttpFlowSupport;
+
+/** Extract routes as `${METHOD} ${path}` keys for a source string served from
+ *  `relPath` (the repo-relative path a file-route framework derives its URL
+ *  from). */
+async function routeKeys(src: string, relPath: string): Promise<string[]> {
+  const tree = await parseSource(src, 'typescript');
+  const { routes } = extractFromTree(tree!.rootNode, ts, relPath, undefined, relPath);
+  return routes.map((r) => `${r.method} ${r.path}`).sort();
+}
+
+// The Next.js App Router descriptor the TS pack must declare (2.28.0).
+const nextAppRouter: FileRouteSupport = {
+  handlerFile: 'route',
+  baseDirs: ['src/app', 'app'],
+  methodExports: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
+};
+
+describe('flow file-routes — Next.js App Router served side', () => {
+  it('TS pack declares a fileRoutes descriptor', () => {
+    expect(ts.fileRoutes).toBeDefined();
+    expect(ts.fileRoutes?.handlerFile).toBe('route');
+    expect(ts.fileRoutes?.baseDirs).toContain('app');
+  });
+
+  it('derives METHOD + path from directory for exported HTTP-verb functions', async () => {
+    const keys = await routeKeys(
+      `
+      export async function GET(req) { return Response.json([]); }
+      export async function POST(req) { return Response.json({}); }
+    `,
+      'app/api/users/route.ts',
+    );
+    expect(keys).toEqual(['GET /api/users', 'POST /api/users']);
+  });
+
+  it('marks derived routes via file-route with the export name as handler', async () => {
+    const tree = await parseSource('export function GET() {}', 'typescript');
+    const { routes } = extractFromTree(
+      tree!.rootNode,
+      ts,
+      'app/health/route.ts',
+      undefined,
+      'app/health/route.ts',
+    );
+    expect(routes).toHaveLength(1);
+    expect(routes[0].via).toBe('file-route');
+    expect(routes[0].handler).toBe('GET');
+    expect(routes[0].path).toBe('/health');
+  });
+
+  it('strips route groups (parenthesized dirs) and honors src/app base', async () => {
+    const keys = await routeKeys(
+      `export async function POST() {}`,
+      'src/app/(payload)/api/form-submissions/route.ts',
+    );
+    expect(keys).toEqual(['POST /api/form-submissions']);
+  });
+
+  it('canonicalizes [id] dynamic and [[...slug]] catch-all segments to {var}', async () => {
+    expect(await routeKeys(`export function GET() {}`, 'app/api/users/[id]/route.ts')).toEqual([
+      'GET /api/users/{var}',
+    ]);
+    expect(
+      await routeKeys(`export async function POST() {}`, 'app/(payload)/api/[[...slug]]/route.ts'),
+    ).toEqual(['POST /api/{var}']);
+  });
+
+  it('recognizes `export const GET` and `export { POST }` forms', async () => {
+    expect(
+      await routeKeys(`export const GET = async () => Response.json([]);`, 'app/api/me/route.ts'),
+    ).toEqual(['GET /api/me']);
+    expect(
+      await routeKeys(`async function POST() {}\nexport { POST };`, 'app/api/webhooks/route.ts'),
+    ).toEqual(['POST /api/webhooks']);
+  });
+
+  it('ignores non-verb exports and non-exported verb functions (precision)', async () => {
+    expect(
+      await routeKeys(
+        `export const config = { runtime: 'edge' };\nfunction GET() {}\nexport function helper() {}`,
+        'app/api/x/route.ts',
+      ),
+    ).toEqual([]);
+  });
+
+  it('does NOT derive routes for a handler file outside any base dir', async () => {
+    expect(await routeKeys(`export function GET() {}`, 'lib/route.ts')).toEqual([]);
+  });
+
+  it('does NOT derive routes for a non-handler file under a base dir', async () => {
+    // page.tsx is not the route handler; its exports are not HTTP verbs.
+    expect(await routeKeys(`export function GET() {}`, 'app/api/users/page.tsx')).toEqual([]);
+  });
+
+  it('excludes private (_-prefixed) segments from routing', async () => {
+    expect(await routeKeys(`export function GET() {}`, 'app/_internal/api/route.ts')).toEqual([]);
+  });
+});
+
+describe('deriveFileRoutePath — the central path algebra (framework-general)', () => {
+  const d = (relPath: string): string | null => deriveFileRoutePath(relPath, nextAppRouter);
+
+  it('drops parallel-route slots (@-prefixed) as non-path segments', () => {
+    expect(d('app/@modal/api/photos/route.ts')).toBe('/api/photos');
+  });
+
+  it('applies a urlPrefix for bases whose name is part of the served URL', () => {
+    const pagesApi: FileRouteSupport = {
+      handlerFile: '*',
+      baseDirs: ['pages/api'],
+      urlPrefix: '/api',
+      methodExports: ['default'],
+    };
+    expect(deriveFileRoutePath('pages/api/users/[id].ts', pagesApi)).toBe('/api/users/{var}');
+    expect(deriveFileRoutePath('pages/api/health/index.ts', pagesApi)).toBe('/api/health');
+  });
+
+  it('returns null for a handler file at the base root (bare / route)', () => {
+    expect(d('app/route.ts')).toBeNull();
+  });
+});

--- a/test/lifecycle/roundtrip.test.ts
+++ b/test/lifecycle/roundtrip.test.ts
@@ -99,6 +99,30 @@ describe('install/uninstall round-trip restores the exact pre-dxkit state', () =
     expect(readFileSync(pkgPath, 'utf8')).not.toMatch(/coverage-v8/);
   });
 
+  it('preserves a TAB-indented package.json byte-for-byte across the round-trip', () => {
+    // 2.27.0 root cause: init reformatted package.json (compact/tab → 2-space
+    // pretty), a change uninstall could not undo. `serializePreservingJson`
+    // detects the original style; the compact + 2-space branches are covered by
+    // the scenarios above, this pins the TAB branch — a real style dxkit must
+    // not silently rewrite to spaces on a devDep add.
+    const tabPkg = '{\n\t"name": "tabbed",\n\t"version": "1.0.0"\n}\n';
+    write(repo, 'package.json', tabPkg);
+    write(repo, 'src/index.ts', 'export const x = 1;\n');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'pre-dxkit tab-indented');
+
+    cli(repo, 'init', '--with-dxkit-agents', '--yes');
+    // If init added a devDep it must have kept the tab indentation (no diff on
+    // the pre-existing lines); if it touched package.json at all, the style
+    // holds. Either way the round-trip must land byte-clean.
+    const afterInit = readFileSync(join(repo, 'package.json'), 'utf8');
+    if (afterInit !== tabPkg) expect(afterInit).toMatch(/\n\t"/); // still tab-indented
+
+    cli(repo, 'uninstall', '--yes', '--remove-devdep');
+    expect(readFileSync(join(repo, 'package.json'), 'utf8')).toBe(tabPkg);
+    expect(porcelain(repo)).toBe('');
+  });
+
   it('NEVER claims a pre-existing AGENTS.md / CLAUDE.md as dxkit-created (data-loss guard)', () => {
     // These files predate dxkit — the project authored them.
     const agents = '# My Project\n\nProject-authored agent guidance.\n';

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -62,6 +62,7 @@ import {
   dominantVocabulary,
 } from '../src/languages';
 import { runCorrectnessFloor } from '../src/analyzers/correctness/run';
+import { deriveFileRoutePath } from '../src/analyzers/flow/file-routes';
 import { buildVariables, buildConditions } from '../src/constants';
 import { buildRequiredTools } from '../src/analyzers/tools/tool-registry';
 import { detect } from '../src/detect';
@@ -119,6 +120,15 @@ const mockPlaybookPack = {
     routeDecorators: ['playbookGet'],
     routeRouterCallees: { methods: ['playbookGet'], bases: ['playbookApp'] },
     methodAliases: { playbookDel: 'DELETE' },
+    // File-convention routing (2.28): distinctive tokens so the assertion
+    // verifies the synthetic pack's fileRoutes descriptor drives the SHARED
+    // path algebra (`deriveFileRoutePath`) — codifying "file-route derivation
+    // is pack-driven, not hardcoded to Next.js's `route`/`app` names."
+    fileRoutes: {
+      handlerFile: 'playbookroute',
+      baseDirs: ['playbookapp'],
+      methodExports: ['GET', 'POST'],
+    },
   },
   // A grammar alongside httpFlow makes the synthetic pack flow-CAPABLE, so its
   // extensions flow through `allFlowSourceExtensions` /
@@ -697,6 +707,43 @@ describe('recipe playbook — synthetic pack', () => {
     expect(real).toBeDefined();
     expect(real?.routeDecorators).toContain('del'); // LoopBack delete decorator
     expect(real?.routeRouterCallees?.bases).toContain('router'); // Express
+    // File-convention routing flows through the same union (2.28): the
+    // synthetic pack's fileRoutes descriptor is present, and the real
+    // typescript pack's Next.js App Router descriptor is too.
+    expect(synthetic?.fileRoutes?.handlerFile).toBe('playbookroute');
+    expect(real?.fileRoutes?.handlerFile).toBe('route');
+    expect(real?.fileRoutes?.baseDirs).toContain('app');
+  });
+
+  // File-route path algebra: the SHARED deriver consumes any pack's descriptor,
+  // proving the route-group / dynamic-segment rules aren't hardcoded to Next.js.
+  // The synthetic pack's own `playbookapp` base + `playbookroute` handler derive
+  // a route through the identical code path the real TS pack uses.
+  it('deriveFileRoutePath derives routes from the synthetic pack descriptor', () => {
+    const flags = {
+      typescript: false,
+      python: false,
+      go: false,
+      rust: false,
+      csharp: false,
+      kotlin: false,
+      java: false,
+      ruby: false,
+      playbook: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const synthetic = allHttpFlow(flags).find((d) => d.fileRoutes?.handlerFile === 'playbookroute');
+    expect(synthetic?.fileRoutes).toBeDefined();
+    const fr = synthetic!.fileRoutes!;
+    // Literal + dynamic + route-group all handled by the shared algebra, driven
+    // purely off the synthetic pack's declared base/handler names.
+    expect(deriveFileRoutePath('playbookapp/widgets/playbookroute.pbk', fr)).toBe('/widgets');
+    expect(deriveFileRoutePath('playbookapp/widgets/[id]/playbookroute.pbk', fr)).toBe(
+      '/widgets/{var}',
+    );
+    expect(deriveFileRoutePath('playbookapp/(group)/things/playbookroute.pbk', fr)).toBe('/things');
+    // A non-handler file under the base derives nothing.
+    expect(deriveFileRoutePath('playbookapp/widgets/other.pbk', fr)).toBeNull();
   });
 
   // Flow-gate trigger: the surface helpers iterate active packs (httpFlow +


### PR DESCRIPTION
## What

Teaches the flow feature's **served side** to detect routes served by a handler file's **location** on disk — Next.js App Router `app/**/route.ts`, not just in-source decorators (`@get`) and router calls (`app.get`).

**The bug this closes:** a Next.js App Router repo reported *0 routes* — every client call showed as unresolved — because `route.ts` handlers are a file convention, not an AST pattern. They are now first-class served routes that join client calls through the same normalized `(method, path)` key.

## How (platform pattern, not a Next.js hack)

- **Pack-declared** (Rule 6): a new `httpFlow.fileRoutes` capability lets a pack declare only the framework-specific facts — handler filename (`route`, `+server`), routing base dirs (`app`, `src/app`), an optional URL prefix, and the verb-named exports. The TypeScript pack ships the Next.js App Router descriptor.
- **Framework-general engine**: the shared path algebra (`flow/file-routes.ts`) owns route groups `(payload)`, dynamic `[id]`, catch-all `[[...slug]]`, private `_`-segments, and parallel `@`-slots — the same Rule 6 boundary the URL normalizer draws. The seam extends to SvelteKit / Remix / Pages Router with **zero new engine code**.
- Derived routes finish through the same `normalizePath`, so the gate, cross-repo contract, flow map, and identity all pick them up unchanged.

## Recipe-hardened

- **Architecture rule 13d**: bans hardcoded framework file-route literals (`route`, `+server`, `src/app`, `pages/api`) inside `src/analyzers/flow/` — negative-tested.
- **Synthetic-pack playbook**: asserts a pack's `fileRoutes` descriptor drives the shared deriver, codifying "file-route derivation is pack-driven, not hardcoded to Next.js."

## Also

- Lifecycle harness now pins the **tab-indented** `package.json` round-trip — the last untested branch of the 2.27.0 format-preservation fix.

## Verification

- 2925 tests green (+12 new); lint / format / arch / slop / cross-ecosystem all pass.
- End-to-end: a Next.js App Router fixture goes from **0 → 4 routes**, and a templated client call joins its file-route at full confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)