### PR TITLE
2.29.0 — precision patch: flow catch-all, scanner false-positives, PM-aware install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.29.0] - 2026-07-05
+
+### Flow — catch-all routes and base-URL-helper calls now resolve
+
+A client call to a route served by a **catch-all** (`app/api/[...slug]/route.ts`,
+Express `/api/*`, Spring `/api/**`, Rails `*path`, FastAPI `{p:path}`) used to
+show as unresolved, because the join matched only exact paths. Catch-all routes
+now normalize to a distinct `/{prefix}/{*}` marker and the join **prefix-matches**
+concrete calls against them — so a `POST /api/form-submissions` binds the
+Payload catch-all it actually hits. An exact literal route still wins over a
+covering catch-all, and the longest matching prefix wins among catch-alls. A new
+cross-framework matching corpus (`test/flow-matching-corpus.test.ts`) pins the
+behavior so future language packs inherit it.
+
+### Fixed — fewer security false positives on template repos
+
+- **`.env.example` / `.env.template` / `.env.sample` are no longer counted as
+  committed secrets** — those are intentional conventions; a real `.env` /
+  `.env.production` still counts.
+- **Obvious placeholder secret values are dropped**, not flagged:
+  `password: 'password'`, `apiKey = 'your-api-key'`, `<your-key>`, `${VAR}`,
+  repeated-character runs. The heuristics are deliberately narrow to never
+  suppress a real credential. Both live in one benign-conventions module every
+  secret / env detector consults.
+- **Install hints and the tool descriptor now match your package manager.** A
+  `loop doctor` fix hint and the `tools list` install command render as `pnpm
+  add -D` / `yarn add -D` / `bun add -d` on those repos instead of always `npm
+  install --save-dev` (the executed install was already PM-aware).
+
+### Docs
+
+- README quickstart notes the pnpm `minimumReleaseAge` step for a fresh release.
+
 ## [2.28.0] - 2026-07-05
 
 ### Added — file-convention route detection (Next.js App Router & friends)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,34 @@ Before writing a regex or grep pattern, check if an established tool handles it:
 
 Our code only stitches tools together and computes scores.
 
+#### Benign-convention false positives live in one module (2.29)
+
+Convention-based false positives — an `.env.example` (not a leaked `.env`), a
+placeholder secret value (`password: 'password'`, `apiKey = 'your-api-key'`,
+`<your-key>`) — are decided by ONE source of truth,
+`src/analyzers/security/benign.ts` (`isExampleEnvFile`, `isPlaceholderSecret`).
+Every secret / env detector consults it — BOTH secret scanners (the gitleaks
+provider AND the `grep-secrets` generic-credential fallback) plus the env-in-git
+count — so the floor is fixed once and a new pack's secret patterns inherit the
+exemptions. When you add a secret detector, wire it to `isPlaceholderSecret` too
+(the class of bug: a second detector that skips the module silently
+re-introduces the floor — this shipped once, caught by the self-guardrail). Do
+NOT inline a `.env.example` string or a placeholder-value list in an analyzer —
+extend the module. Bias the predicates toward false NEGATIVES (never suppress a
+real credential). `test/security-benign.test.ts` + `test/grep-secrets.test.ts`
+pin the cases.
+
+#### Package-manager commands route through `src/package-manager.ts` (2.26 → 2.29)
+
+Any node devDependency install command shown to or run by a user MUST match the
+repo's package manager (pnpm/yarn/bun/npm) — a raw `npm install --save-dev` on a
+pnpm repo is the class of bug that shipped a 404-ing create-dxkit and npm-only
+doctor hints. Build the command via `addDevCommand` / `pmAwareDevInstall`
+(the canonical npm form lives only in `TOOL_DEFS`, rendered PM-aware at display
+time). `scripts/check-architecture.sh` bans a raw `npm install --save-dev` /
+`npm i -D` literal outside `src/package-manager.ts` + the tool registry
+(annotate `// pm-aware-ok` for a justified exception).
+
 ### 6. Language capabilities live in one file per language
 
 Every language-specific concern (detection, tool list, semgrep rulesets,

--- a/README.md
+++ b/README.md
@@ -191,6 +191,11 @@ npx vyuh-dxkit loop ledger summarize  # afterwards: blocked vs allowed, repaired
 When the agent tries to stop, dxkit runs the net-new gate against the baseline.
 Existing findings are grandfathered; only findings this change introduced block.
 
+> **pnpm with a release-age policy?** If your `pnpm-workspace.yaml` sets
+> `minimumReleaseAge`, a just-published dxkit is blocked until it ages in. Add
+> the package to `minimumReleaseAgeExclude` first so the install resolves — this
+> is your supply-chain policy, so dxkit does not edit that file for you.
+
 ## Run a local fixture gate
 
 Want to see the Stop-gate before installing dxkit into your repo?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.28.0",
+      "version": "2.29.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1081,6 +1081,30 @@ if [ -n "$RULE13_FILEROUTES" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# PM-awareness (2.26 → 2.29): a node devDependency install command shown to or
+# run by a user MUST match the repo's package manager (pnpm/yarn/bun/npm), or it
+# fails the way create-dxkit did on a pnpm repo. The canonical npm form lives in
+# ONE of two places — `src/package-manager.ts` (which rewrites it per PM via
+# `pmAwareDevInstall`/`addDevPrefix`) and the `TOOL_DEFS` registry (whose
+# `install` strings are rendered PM-aware at display time). A raw
+# `npm install --save-dev` / `npm i -D` literal anywhere else is a PM-blind
+# command string — the class of bug that shipped an npm-only doctor hint + tool
+# descriptor on pnpm repos. Route it through `src/package-manager.ts`.
+RULE_PM_DEVINSTALL=$(grep -rnE "npm (install|i) (--save-dev|-D)" src/ 2>/dev/null \
+  | grep -E '\.ts:' \
+  | grep -v "^src/package-manager.ts:" \
+  | grep -v "^src/analyzers/tools/tool-registry.ts:" \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | grep -v "// pm-aware-ok")
+if [ -n "$RULE_PM_DEVINSTALL" ]; then
+  echo "❌ PM-awareness violation: raw 'npm install --save-dev' literal outside the PM module:"
+  echo "$RULE_PM_DEVINSTALL"
+  echo "   → Build the command via pmAwareDevInstall()/addDevCommand() from src/package-manager.ts"
+  echo "     so it matches the repo's package manager (pnpm/yarn/bun/npm)."
+  echo "   → Annotate '// pm-aware-ok' for a justified exception."
+  ERRORS=$((ERRORS + 1))
+fi
+
 # Rule 14 (2.13.1 self-invocation class-fix): generated artifacts invoke the
 # dxkit CLI through ONE canonical helper, and every auto-running surface is
 # in ONE registry.

--- a/src/analyzers/flow/file-routes.ts
+++ b/src/analyzers/flow/file-routes.ts
@@ -29,7 +29,7 @@
 
 import type { Node } from '../../ast/parse';
 import type { FileRouteSupport } from '../../languages/types';
-import { normalizePath, type NormalizeConfig } from './normalize';
+import { normalizePath, CATCHALL, type NormalizeConfig } from './normalize';
 
 /** A route group / layout segment: an entire segment wrapped in parentheses,
  *  organizational only (`(payload)`, `(marketing)`) — dropped from the URL. */
@@ -40,7 +40,7 @@ const PARALLEL_SLOT = /^@/;
 const CATCH_ALL = /^\[\[?\.\.\.[^\]]+\]\]?$/;
 /** A single dynamic segment (`[id]`). */
 const DYNAMIC = /^\[.+\]$/;
-/** The placeholder every dynamic segment canonicalizes to (matches normalize.ts). */
+/** The placeholder a single dynamic segment canonicalizes to (matches normalize.ts). */
 const PLACEHOLDER = '{var}';
 
 function toPosix(p: string): string {
@@ -73,7 +73,9 @@ function findBaseEnd(segments: readonly string[], baseDirs: readonly string[]): 
 /**
  * Canonicalize one directory segment to its URL contribution:
  *   - `''` → drop (route group / parallel slot: not part of the URL);
- *   - `'{var}'` → dynamic / catch-all segment;
+ *   - `'{*}'` → catch-all segment (`[...slug]`) — a prefix matcher (the shared
+ *     `CATCHALL` marker, distinct from a single dynamic segment);
+ *   - `'{var}'` → single dynamic segment (`[id]`);
  *   - `null` → the whole route is NOT served (a private `_`-segment opts the
  *     subtree out of routing);
  *   - otherwise the literal segment.
@@ -81,7 +83,8 @@ function findBaseEnd(segments: readonly string[], baseDirs: readonly string[]): 
 function classifySegment(seg: string): string | null {
   if (seg.startsWith('_')) return null; // private subtree — not routable
   if (ROUTE_GROUP.test(seg) || PARALLEL_SLOT.test(seg)) return ''; // organizational
-  if (CATCH_ALL.test(seg) || DYNAMIC.test(seg)) return PLACEHOLDER;
+  if (CATCH_ALL.test(seg)) return CATCHALL; // [...slug] → prefix matcher
+  if (DYNAMIC.test(seg)) return PLACEHOLDER; // [id] → single dynamic segment
   return seg;
 }
 

--- a/src/analyzers/flow/model.ts
+++ b/src/analyzers/flow/model.ts
@@ -16,18 +16,22 @@
  */
 
 import { extractFileFlow, type ClientCall, type FileFlow, type RouteEndpoint } from './extract';
-import type { NormalizeConfig } from './normalize';
+import { catchAllStaticPrefix, isCatchAllPath, type NormalizeConfig } from './normalize';
 
 /**
  * Why a call did or didn't bind to a route:
  *   - `exact`            — matched a route on a path with real static signal;
+ *   - `catch-all`        — matched a wildcard route (`/api/{*}` from `[...slug]`,
+ *                          Express `/*`, Spring `/**`) on its static prefix; the
+ *                          call IS served, but via a splat rather than a literal
+ *                          route, so confidence sits below an exact match;
  *   - `placeholder-only` — matched, but the path is all `{var}` (no signal);
  *   - `no-route`         — path resolved to an internal route shape, but no
  *                          served route matches it;
  *   - `external`         — the URL is an external/absolute address we don't
  *                          serve (path is null), so it is not an internal binding.
  */
-export type BindingReason = 'exact' | 'placeholder-only' | 'no-route' | 'external';
+export type BindingReason = 'exact' | 'catch-all' | 'placeholder-only' | 'no-route' | 'external';
 
 /** One client call resolved (or not) against the served routes. */
 export interface FlowBinding {
@@ -60,18 +64,53 @@ export function joinFlow(
   routes: readonly RouteEndpoint[],
 ): FlowBinding[] {
   const routeIndex = new Map<string, RouteEndpoint>();
-  for (const r of routes) routeIndex.set(`${r.method} ${r.path}`, r);
+  // Catch-all routes, grouped by method, each with its static prefix. A concrete
+  // call that misses the exact index falls back to the LONGEST-prefix catch-all
+  // for its method — a splat route (`/api/{*}` from `[...slug]`, Express `/*`,
+  // Spring `/**`) genuinely serves every path under its prefix.
+  const catchAllsByMethod = new Map<HttpMethodKey, { route: RouteEndpoint; prefix: string }[]>();
+  for (const r of routes) {
+    routeIndex.set(`${r.method} ${r.path}`, r);
+    if (isCatchAllPath(r.path)) {
+      const list = catchAllsByMethod.get(r.method) ?? [];
+      list.push({ route: r, prefix: catchAllStaticPrefix(r.path) });
+      catchAllsByMethod.set(r.method, list);
+    }
+  }
 
   return calls.map((call): FlowBinding => {
     if (call.path == null) return { call, route: null, confidence: 0, reason: 'external' };
     const route = routeIndex.get(`${call.method} ${call.path}`) ?? null;
-    if (!route) return { call, route: null, confidence: 0, reason: 'no-route' };
-    if (isPlaceholderOnlyPath(call.path)) {
-      return { call, route, confidence: 0.3, reason: 'placeholder-only' };
+    if (route) {
+      if (isPlaceholderOnlyPath(call.path)) {
+        return { call, route, confidence: 0.3, reason: 'placeholder-only' };
+      }
+      return { call, route, confidence: 1, reason: 'exact' };
     }
-    return { call, route, confidence: 1, reason: 'exact' };
+    const catchAll = bestCatchAllMatch(call.path, catchAllsByMethod.get(call.method));
+    if (catchAll) return { call, route: catchAll, confidence: 0.7, reason: 'catch-all' };
+    return { call, route: null, confidence: 0, reason: 'no-route' };
   });
 }
+
+/** The most-specific catch-all route whose static prefix covers `callPath`
+ *  (`/api` covers `/api/x` and `/api/x/y`), or null. Longest prefix wins so a
+ *  nested `/api/v2/{*}` beats `/api/{*}`; a root catch-all (`''` prefix) matches
+ *  anything. Not applied to an all-placeholder call (no static signal to align). */
+function bestCatchAllMatch(
+  callPath: string,
+  candidates: { route: RouteEndpoint; prefix: string }[] | undefined,
+): RouteEndpoint | null {
+  if (!candidates || isPlaceholderOnlyPath(callPath)) return null;
+  let best: { route: RouteEndpoint; prefix: string } | null = null;
+  for (const c of candidates) {
+    const covers = c.prefix === '' || callPath === c.prefix || callPath.startsWith(c.prefix + '/');
+    if (covers && (!best || c.prefix.length > best.prefix.length)) best = c;
+  }
+  return best?.route ?? null;
+}
+
+type HttpMethodKey = RouteEndpoint['method'];
 
 /**
  * Dedup served routes to one per distinct `(method, path)` — the canonical

--- a/src/analyzers/flow/normalize.ts
+++ b/src/analyzers/flow/normalize.ts
@@ -46,6 +46,33 @@ export interface NormalizeConfig {
 const PLACEHOLDER = '{var}';
 
 /**
+ * The canonical CATCH-ALL / splat marker — a trailing wildcard that serves
+ * every path under its static prefix (Next.js `[...slug]`, Express `/*`, Spring
+ * `/**`, Rails `/*path`, FastAPI/Starlette `{p:path}` all reduce to this). It is
+ * distinct from `{var}` (a single dynamic segment) because the JOIN treats it
+ * differently: a `{var}` matches exactly one segment on the exact key, a `{*}`
+ * prefix-matches any depth (see `catchAllStaticPrefix` + the join in `model.ts`).
+ * Only served routes ever carry it — a client call targets a concrete path.
+ */
+export const CATCHALL = '{*}';
+
+/** Does a normalized route path end in the catch-all marker (a prefix matcher)? */
+export function isCatchAllPath(path: string): boolean {
+  return path === '/' + CATCHALL || path.endsWith('/' + CATCHALL);
+}
+
+/**
+ * The static prefix a catch-all route serves — the path with its trailing
+ * `/{*}` removed. `/api/{*}` → `/api` (serves `/api/anything`); a root catch-all
+ * `/{*}` → `''` (serves everything). Used by the join to prefix-match a concrete
+ * client call against a wildcard route.
+ */
+export function catchAllStaticPrefix(path: string): string {
+  if (path === '/' + CATCHALL) return '';
+  return path.slice(0, -('/' + CATCHALL).length);
+}
+
+/**
  * Canonicalize a raw URL / route literal to a comparable path, or `null` for
  * an external absolute URL or empty / non-path input. A path that is entirely
  * dynamic (`${x}`) normalizes faithfully to `/{var}` rather than being
@@ -105,9 +132,20 @@ export function normalizePath(
   const q = s.indexOf('?');
   if (q !== -1) s = s.slice(0, q);
 
-  // 6. canonicalize path params
+  // 6a. catch-all / splat forms → the {*} marker (a prefix matcher). Must run
+  //     BEFORE the single-segment collapse below so FastAPI's `{p:path}` and
+  //     Next.js `[...slug]` do not degrade to a one-segment `{var}`.
+  s = s.replace(/\{[A-Za-z0-9_]+:path\}/g, CATCHALL); // FastAPI/Starlette {file_path:path}
+  s = s.replace(/\[\[?\.\.\.[^\]]+\]\]?/g, CATCHALL); // Next.js [...slug] / [[...slug]]
+  s = s.replace(/\*\*/g, CATCHALL); // Spring /**
+  s = s.replace(/(?<=\/)\*[A-Za-z0-9_]*/g, CATCHALL); // Express /*, Rails /*path
+
+  // 6b. canonicalize single-segment path params (leaving the {*} marker intact).
+  //     The single `[id]` rule runs AFTER the catch-all `[...slug]` rule above so
+  //     a catch-all is not misconsumed as a one-segment param.
   s = s.replace(/:[A-Za-z0-9_]+/g, PLACEHOLDER); // Express/Rails :id
-  s = s.replace(/\{[^}]*\}/g, PLACEHOLDER); // OpenAPI/LoopBack {id} (and already-{var})
+  s = s.replace(/\[[^\]]+\]/g, PLACEHOLDER); // Next.js file-route [id]
+  s = s.replace(/\{[^}]*\}/g, (m) => (m === CATCHALL ? CATCHALL : PLACEHOLDER)); // {id}, keep {*}
 
   // 7. single leading slash
   if (!s.startsWith('/')) s = '/' + s;
@@ -116,8 +154,8 @@ export function normalizePath(
   // 8. trailing slash
   if (s.length > 1 && s.endsWith('/')) s = s.slice(0, -1);
 
-  // 9. require a real path head
-  if (!/^\/([A-Za-z]|\{var\})/.test(s)) return null;
+  // 9. require a real path head (a literal, a single-segment {var}, or a catch-all {*})
+  if (!/^\/([A-Za-z]|\{var\}|\{\*\})/.test(s)) return null;
   return s;
 }
 

--- a/src/analyzers/security/benign.ts
+++ b/src/analyzers/security/benign.ts
@@ -1,0 +1,100 @@
+/**
+ * Benign security conventions — the ONE source of truth for "this looks like a
+ * secret / a committed env file, but it is a near-universal INTENTIONAL
+ * convention, not a finding." Every secret / env-in-git detector consults these
+ * predicates so the false-positive floor is fixed in one place, not
+ * re-litigated per scanner or per language pack.
+ *
+ * Why this exists (round-3 dogfood, template repos): a `.env.example` is not a
+ * leaked `.env`; `password: 'password'` in a seed script and `apiKey =
+ * 'your-api-key'` in demo content are not credentials. Left unmodeled, every
+ * template-based repo starts its baseline with the same handful of false
+ * positives, and every new secret pattern a language pack adds re-introduces
+ * them. Centralizing the conventions means a new pack's patterns inherit the
+ * exemptions automatically.
+ *
+ * Design bias: minimize FALSE NEGATIVES. A predicate only returns true for a
+ * value/path that is UNAMBIGUOUSLY a placeholder or example convention — never
+ * a broad substring match that could swallow a real credential.
+ */
+
+/** Filename segments that mark an env file as an example / template — safe to
+ *  commit, never a leaked secret. `.env.example`, `.env.sample`,
+ *  `.env.template`, `.env.dist`, `.env.defaults`, `.env.local.example`. */
+const EXAMPLE_ENV_MARKERS: ReadonlySet<string> = new Set([
+  'example',
+  'sample',
+  'template',
+  'tmpl',
+  'dist',
+  'defaults',
+]);
+
+/** The basename of a POSIX/Windows path (no path module — pure + tiny). */
+function basename(p: string): string {
+  const parts = p.split(/[\\/]/);
+  return parts[parts.length - 1] ?? p;
+}
+
+/**
+ * Is this an EXAMPLE / template env file (a committed convention), as opposed to
+ * a real `.env` / `.env.production` that leaks secrets? Matches a basename that
+ * is `env` / `.env` followed by an example marker segment
+ * (`.env.example`, `.env.local.sample`, …). A bare `.env` or `.env.production`
+ * returns false — those genuinely should count.
+ */
+export function isExampleEnvFile(path: string): boolean {
+  const base = basename(path).toLowerCase();
+  if (!/^\.?env(\.|$)/.test(base)) return false;
+  return base.split('.').some((seg) => EXAMPLE_ENV_MARKERS.has(seg));
+}
+
+/** Exact placeholder secret values (case-insensitive) — a real credential is
+ *  never literally one of these. */
+const PLACEHOLDER_VALUES: ReadonlySet<string> = new Set([
+  'password',
+  'passw0rd',
+  'changeme',
+  'change-me',
+  'secret',
+  'mysecret',
+  'test',
+  'testing',
+  'example',
+  'todo',
+  'none',
+  'null',
+  'undefined',
+  'placeholder',
+  'dummy',
+  'sample',
+  'redacted',
+  'apikey',
+  'api-key',
+  'api_key',
+  'your-api-key',
+  'your_api_key',
+  'yourapikey',
+  'xxx',
+  'xxxx',
+]);
+
+/**
+ * Does a captured secret VALUE look like an obvious placeholder / demo literal
+ * rather than a real credential? True only for values that are unambiguously
+ * fake: an exact placeholder token, a bracketed placeholder (`<your-key>`,
+ * `${VAR}`, `{{VAR}}`, `%VAR%`), a `your-…` / `…-here` template, or a run of one
+ * repeated character (`xxxxx`, `*****`, `00000`). Deliberately narrow to avoid
+ * suppressing a real secret that merely contains a common word.
+ */
+export function isPlaceholderSecret(value: string): boolean {
+  const v = value.trim();
+  if (v.length === 0) return true;
+  const lower = v.toLowerCase();
+  if (PLACEHOLDER_VALUES.has(lower)) return true;
+  if (/^[<{$%[].*[>}%\]]$/.test(v)) return true; // <your-key> ${VAR} {{VAR}} %VAR% [redacted]
+  if (/^your[-_]/.test(lower)) return true; // your-secret, your_token_here
+  if (/[-_](here|goes[-_]?here|placeholder)$/.test(lower)) return true; // token-here, key_goes_here
+  if (v.length >= 3 && /^(.)\1+$/.test(v)) return true; // xxxxx, *****, 000000
+  return false;
+}

--- a/src/analyzers/tools/generic.ts
+++ b/src/analyzers/tools/generic.ts
@@ -6,7 +6,8 @@
  */
 import { HealthMetrics } from '../types';
 import type { DetectedStack } from '../../types';
-import { run, countLines, fileExists } from './runner';
+import { run, fileExists } from './runner';
+import { isExampleEnvFile } from '../security/benign';
 import { walkSourceFiles, countLineMatches, countDirectories } from './walk-source-files';
 import { gatherDebugStatements } from './debug-statements';
 import {
@@ -211,7 +212,14 @@ export function gatherGenericMetrics(
     includeTests: true,
     includeAutogen: true,
   }).length;
-  const envFilesInGit = countLines('git ls-files .env .env.*', cwd);
+  // Committed env files, EXCLUDING the `.env.example` / `.env.template` /
+  // `.env.sample` conventions — those are intentional and near-universal, not a
+  // leaked `.env`. The benign-conventions module (one source of truth) decides
+  // which basenames are examples; a real `.env` / `.env.production` still counts.
+  const envFilesInGit = (run('git ls-files .env .env.*', cwd) ?? '')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !isExampleEnvFile(l)).length;
   // D034 (2.4.7): TLS-bypass detection derives from the pack registry.
   // D074 (2.4.7): skipComments closes the "vuln-scan rendered a
   // `// NODE_TLS_REJECT_UNAUTHORIZED=0` comment as a HIGH finding"

--- a/src/analyzers/tools/gitleaks.ts
+++ b/src/analyzers/tools/gitleaks.ts
@@ -16,6 +16,7 @@ import { findTool, TOOL_DEFS } from './tool-registry';
 import { isExcludedPath } from './exclusions';
 import { toProjectRelative } from './paths';
 import { applySuppressions, loadSuppressions } from './suppressions';
+import { isPlaceholderSecret } from '../security/benign';
 import type { CapabilityProvider } from '../../languages/capabilities/provider';
 import type { SecretFinding, SecretsResult } from '../../languages/capabilities/types';
 
@@ -179,7 +180,15 @@ function computeGitleaksOutcome(cwd: string): SecretsGatherOutcome {
 
   // Gitleaks --no-git scans everything on disk (ignores .gitignore), so
   // we re-apply the resolved exclusion set via isExcludedPath().
-  const filteredCombined = combined.filter((c) => !isExcludedPath(cwd, c.finding.file));
+  const pathFiltered = combined.filter((c) => !isExcludedPath(cwd, c.finding.file));
+
+  // Drop obvious placeholder / demo values (`password: 'password'`, `apiKey =
+  // 'your-api-key'`, `<your-secret>`). These are the false-positive floor every
+  // template repo starts with; the benign-conventions module (one source of
+  // truth) decides what counts as a placeholder. Counted as suppressed for
+  // transparency, never silently dropped.
+  const placeholderDropped = pathFiltered.filter((c) => isPlaceholderSecret(c.secret));
+  const filteredCombined = pathFiltered.filter((c) => !isPlaceholderSecret(c.secret));
 
   // Apply `.dxkit-suppressions.json` so known-false positives don't count.
   const suppressions = loadSuppressions(cwd);
@@ -189,6 +198,7 @@ function computeGitleaksOutcome(cwd: string): SecretsGatherOutcome {
     (c) => c.finding.rule,
     (c) => c.finding.file,
   );
+  const suppressedCount = suppressed.length + placeholderDropped.length;
 
   // Per-occurrence secret identity is (canonicalRule, file, ordinal),
   // assembled in the aggregator — value- and salt-free, so it stays stable
@@ -200,7 +210,7 @@ function computeGitleaksOutcome(cwd: string): SecretsGatherOutcome {
     schemaVersion: 1,
     tool: 'gitleaks',
     findings: kept.map((c) => ({ ...c.finding })),
-    suppressedCount: suppressed.length,
+    suppressedCount,
   };
   const rawSecrets: GitleaksRawSecret[] = kept.map((c) => ({
     file: c.finding.file,
@@ -208,7 +218,7 @@ function computeGitleaksOutcome(cwd: string): SecretsGatherOutcome {
     rule: c.finding.rule,
     secret: c.secret,
   }));
-  return { kind: 'success', envelope, suppressedCount: suppressed.length, rawSecrets };
+  return { kind: 'success', envelope, suppressedCount, rawSecrets };
 }
 
 /**

--- a/src/analyzers/tools/grep-secrets.ts
+++ b/src/analyzers/tools/grep-secrets.ts
@@ -31,6 +31,7 @@ import * as path from 'path';
 import { findTool, TOOL_DEFS } from './tool-registry';
 import { applySuppressions, loadSuppressions } from './suppressions';
 import { walkSourceFiles } from './walk-source-files';
+import { isPlaceholderSecret } from '../security/benign';
 import type { CapabilityProvider } from '../../languages/capabilities/provider';
 import type { SecretFinding, SecretsResult } from '../../languages/capabilities/types';
 
@@ -95,6 +96,7 @@ export function gatherGrepSecretsResult(cwd: string): SecretsResult | null {
   // fingerprints identically whether gitleaks or this grep fallback found
   // it, and across environments. So this gather carries no content anchor.
   const raw: SecretFinding[] = [];
+  let placeholderDropped = 0;
   for (const rel of files) {
     let content: string;
     try {
@@ -116,6 +118,14 @@ export function gatherGrepSecretsResult(cwd: string): SecretsResult | null {
       for (const sp of patterns) {
         const m = lines[i].match(sp.regex);
         if (m) {
+          // Drop an obvious placeholder / demo value (`password: 'password'`,
+          // `apiKey = 'your-api-key'`). The benign-conventions module is the ONE
+          // source of truth every secret detector consults — gitleaks and this
+          // grep fallback alike — so the false-positive floor is fixed once.
+          if (m[1] && isPlaceholderSecret(m[1])) {
+            placeholderDropped++;
+            break;
+          }
           raw.push({
             file: rel,
             line: i + 1,
@@ -142,7 +152,7 @@ export function gatherGrepSecretsResult(cwd: string): SecretsResult | null {
     schemaVersion: 1,
     tool: 'grep-secrets',
     findings: kept,
-    suppressedCount: suppressed.length,
+    suppressedCount: suppressed.length + placeholderDropped,
   };
 }
 

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -18,6 +18,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { activeLanguagesFromFlags } from '../../languages';
+import { detectPackageManager, pmAwareDevInstall } from '../../package-manager';
 import { resolveInDirs, resolveOnPath } from './runner';
 import { loadToolsConfig } from './tools-config';
 import { DetectedStack, ToolRequirement } from '../../types';
@@ -1169,6 +1170,22 @@ export function buildRequiredTools(languages: DetectedStack['languages']): ToolR
 /** Check status of all required tools for a stack. */
 export function checkAllTools(languages: DetectedStack['languages'], cwd?: string): ToolStatus[] {
   const required = buildRequiredTools(languages);
+  // Render a node-devDep tool's `install` descriptor in the repo's package
+  // manager, so a human copy-pasting it from `tools list` on a pnpm/yarn/bun
+  // repo gets the right command (the EXECUTED install is already PM-aware in
+  // tools-cli). Detected once — a display concern, npm when there's no cwd.
+  const pm = cwd ? detectPackageManager(cwd) : 'npm';
+  const pmAware = (status: ToolStatus): ToolStatus => {
+    const def = TOOL_DEFS[status.name];
+    if (!def?.nodePackage) return status;
+    return {
+      ...status,
+      requirement: {
+        ...status.requirement,
+        install: pmAwareDevInstall(status.requirement.install, pm),
+      },
+    };
+  };
   return required.map((req) => {
     const def = TOOL_DEFS[req.name];
     if (!def) {
@@ -1181,6 +1198,6 @@ export function checkAllTools(languages: DetectedStack['languages'], cwd?: strin
         requirement: { ...req, binaries: [req.name], installCommands: {} },
       };
     }
-    return findTool(def, cwd);
+    return pmAware(findTool(def, cwd));
   });
 }

--- a/src/loop/doctor.ts
+++ b/src/loop/doctor.ts
@@ -21,6 +21,7 @@ import { resolveLoopPreset } from './policy';
 import { LEDGER_FILE } from './ledger';
 import { loopGateActive } from './gate-cache';
 import { dxkitCli, resolveDxkitCli } from '../self-invocation';
+import { addDevCommand, detectPackageManager } from '../package-manager';
 import * as logger from '../logger';
 
 /** Severity of one preflight check. `fail` = the loop is unsafe to run
@@ -223,8 +224,8 @@ export function buildLoopDoctorReport(cwd: string): LoopDoctorReport {
         ? {}
         : {
             fix: {
-              hint: 'Make the Stop hook runnable: install dxkit as a devDependency (then `npm install`), or build the local dist if the hook runs `node dist/...`.',
-              command: 'npm install --save-dev @vyuhlabs/dxkit',
+              hint: 'Make the Stop hook runnable: install dxkit as a devDependency, or build the local dist if the hook runs `node dist/...`.',
+              command: addDevCommand(detectPackageManager(cwd), '@vyuhlabs/dxkit'),
               skill: 'dxkit-loop',
             },
           }),

--- a/test/flow-file-routes.test.ts
+++ b/test/flow-file-routes.test.ts
@@ -64,13 +64,15 @@ describe('flow file-routes — Next.js App Router served side', () => {
     expect(keys).toEqual(['POST /api/form-submissions']);
   });
 
-  it('canonicalizes [id] dynamic and [[...slug]] catch-all segments to {var}', async () => {
+  it('canonicalizes [id] to a single {var} and [[...slug]] catch-all to {*}', async () => {
     expect(await routeKeys(`export function GET() {}`, 'app/api/users/[id]/route.ts')).toEqual([
       'GET /api/users/{var}',
     ]);
+    // A catch-all is a PREFIX matcher (`{*}`), distinct from a single dynamic
+    // `{var}` — the join prefix-matches it against concrete client calls.
     expect(
       await routeKeys(`export async function POST() {}`, 'app/(payload)/api/[[...slug]]/route.ts'),
-    ).toEqual(['POST /api/{var}']);
+    ).toEqual(['POST /api/{*}']);
   });
 
   it('recognizes `export const GET` and `export { POST }` forms', async () => {

--- a/test/flow-matching-corpus.test.ts
+++ b/test/flow-matching-corpus.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Flow MATCHING golden corpus — the cross-framework net for route/call
+ * resolution. It extends the normalize corpus (which validates path
+ * canonicalization) to the JOIN (which decides whether a client call binds to a
+ * served route), because that is where a whole CLASS of framework-specific
+ * bugs lives: a route form dxkit doesn't model correctly makes every call
+ * against it look unresolved.
+ *
+ * Two tables, both framework-labelled so a new language pack (M6: Python /
+ * Go / Java / Ruby flow) adds ROWS rather than new matching code:
+ *
+ *   1. CATCH_ALL_FORMS — each framework's catch-all / splat route literal must
+ *      normalize to the shared `/{prefix}/{*}` marker. If a pack introduces a
+ *      new splat syntax, it adds a row here and inherits prefix-matching for
+ *      free (the join is framework-agnostic).
+ *   2. JOIN_CASES — (client call, served routes) → the expected binding. Pins
+ *      catch-all prefix-matching, exact-wins-over-splat, longest-prefix-wins,
+ *      method scoping, and the no-over-match guard.
+ *
+ * A regression in either fails CI — the same discipline as
+ * `recipe-playbook.test.ts` for pack contributions, applied to flow precision.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizePath } from '../src/analyzers/flow/normalize';
+import { joinFlow } from '../src/analyzers/flow/model';
+import type { ClientCall, RouteEndpoint } from '../src/analyzers/flow/extract';
+import type { HttpMethod } from '../src/analyzers/flow/normalize';
+
+// ── 1. Catch-all route forms across frameworks → the canonical /{*} marker ──
+
+const CATCH_ALL_FORMS: Array<{ framework: string; raw: string; expected: string }> = [
+  { framework: 'Next.js App Router', raw: '/api/[...slug]', expected: '/api/{*}' },
+  { framework: 'Next.js optional catch-all', raw: '/api/[[...slug]]', expected: '/api/{*}' },
+  { framework: 'Express splat', raw: '/api/*', expected: '/api/{*}' },
+  { framework: 'Spring ant-matcher', raw: '/api/**', expected: '/api/{*}' },
+  { framework: 'Rails glob', raw: '/api/*path', expected: '/api/{*}' },
+  {
+    framework: 'FastAPI/Starlette path-converter',
+    raw: '/api/{file_path:path}',
+    expected: '/api/{*}',
+  },
+  {
+    framework: 'nested catch-all keeps its static prefix',
+    raw: '/api/v2/[...rest]',
+    expected: '/api/v2/{*}',
+  },
+];
+
+describe('flow matching corpus — catch-all route forms normalize to {*}', () => {
+  for (const { framework, raw, expected } of CATCH_ALL_FORMS) {
+    it(`${framework}: ${raw} → ${expected}`, () => {
+      expect(normalizePath(raw)).toBe(expected);
+    });
+  }
+
+  it('a single dynamic segment stays {var} (NOT a catch-all)', () => {
+    expect(normalizePath('/api/[id]')).toBe('/api/{var}'); // note: brackets are file-route form
+    expect(normalizePath('/api/:id')).toBe('/api/{var}');
+    expect(normalizePath('/api/{id}')).toBe('/api/{var}');
+  });
+});
+
+// ── 2. Join cases: (client call, served routes) → expected binding ──
+
+function call(method: HttpMethod, path: string): ClientCall {
+  return { method, rawUrl: path, path, receiver: 'fetch', file: 'web/x.ts', line: 1 };
+}
+function route(method: HttpMethod, path: string): RouteEndpoint {
+  return { method, path, via: 'file-route', handler: null, file: 'api/r.ts', line: 1 };
+}
+
+interface JoinCase {
+  readonly name: string;
+  readonly call: ClientCall;
+  readonly routes: RouteEndpoint[];
+  readonly boundPath: string | null; // expected route path, or null for unresolved
+  readonly reason: string;
+}
+
+const JOIN_CASES: JoinCase[] = [
+  {
+    name: 'catch-all serves a one-segment tail',
+    call: call('POST', '/api/form-submissions'),
+    routes: [route('POST', '/api/{*}')],
+    boundPath: '/api/{*}',
+    reason: 'catch-all',
+  },
+  {
+    name: 'catch-all serves a deeper tail',
+    call: call('GET', '/api/users/me'),
+    routes: [route('GET', '/api/{*}')],
+    boundPath: '/api/{*}',
+    reason: 'catch-all',
+  },
+  {
+    name: 'catch-all does NOT match a different prefix (no over-match)',
+    call: call('GET', '/other/thing'),
+    routes: [route('GET', '/api/{*}')],
+    boundPath: null,
+    reason: 'no-route',
+  },
+  {
+    name: 'an exact literal route wins over a covering catch-all',
+    call: call('GET', '/api/users'),
+    routes: [route('GET', '/api/{*}'), route('GET', '/api/users')],
+    boundPath: '/api/users',
+    reason: 'exact',
+  },
+  {
+    name: 'the longest-prefix catch-all wins',
+    call: call('GET', '/api/v2/widgets'),
+    routes: [route('GET', '/api/{*}'), route('GET', '/api/v2/{*}')],
+    boundPath: '/api/v2/{*}',
+    reason: 'catch-all',
+  },
+  {
+    name: 'catch-all is method-scoped (POST splat does not serve a GET call)',
+    call: call('GET', '/api/x'),
+    routes: [route('POST', '/api/{*}')],
+    boundPath: null,
+    reason: 'no-route',
+  },
+  {
+    name: 'a root catch-all serves any path',
+    call: call('DELETE', '/anything/at/all'),
+    routes: [route('DELETE', '/{*}')],
+    boundPath: '/{*}',
+    reason: 'catch-all',
+  },
+];
+
+describe('flow matching corpus — join resolution', () => {
+  for (const c of JOIN_CASES) {
+    it(c.name, () => {
+      const [binding] = joinFlow([c.call], c.routes);
+      expect(binding.reason).toBe(c.reason);
+      expect(binding.route?.path ?? null).toBe(c.boundPath);
+    });
+  }
+
+  it('a catch-all match resolves (route != null) at sub-exact confidence', () => {
+    const [b] = joinFlow([call('POST', '/api/form-submissions')], [route('POST', '/api/{*}')]);
+    expect(b.route).not.toBeNull();
+    expect(b.confidence).toBeGreaterThan(0);
+    expect(b.confidence).toBeLessThan(1); // a splat is a real bind, but not exact-literal
+  });
+});

--- a/test/grep-secrets.test.ts
+++ b/test/grep-secrets.test.ts
@@ -125,6 +125,29 @@ describe('gatherGrepSecretsResult (gitleaks-absent fallback)', () => {
     expect(result!.findings).toHaveLength(0);
   });
 
+  it('suppresses placeholder / demo values via the benign-conventions module', () => {
+    // The grep fallback consults the SAME benign module as the gitleaks
+    // provider — a placeholder value is not a finding in either detector.
+    // Build the genuine value at runtime so THIS committed test file carries no
+    // flaggable secret literal of its own (only placeholders, which the filter
+    // suppresses) — the tmp fixture below still gets a real credential.
+    const genuine = ['super', 'secret', '123'].join('-');
+    fs.writeFileSync(
+      path.join(tmp, 'seed.ts'),
+      [
+        "const password = 'password';", // exact placeholder
+        "const apiKey = 'your-api-key';", // your- template
+        "const secret = '<your-token>';", // bracketed placeholder
+        `const token = '${genuine}';`, // a genuine value still flags
+      ].join('\n') + '\n',
+    );
+    const result = gatherGrepSecretsResult(tmp);
+    expect(result).not.toBeNull();
+    expect(result!.findings).toHaveLength(1); // only the genuine value survives
+    expect(result!.findings[0].rule).toBe('hardcoded-secret');
+    expect(result!.suppressedCount).toBeGreaterThanOrEqual(3);
+  });
+
   it('honors .dxkit-suppressions.json for gitleaks rule ids', () => {
     fs.writeFileSync(
       path.join(tmp, 'bad.ts'),

--- a/test/security-benign.test.ts
+++ b/test/security-benign.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Benign security conventions — the false-positive floor every template repo
+ * starts with. These cases are drawn directly from round-3 dogfood feedback on a
+ * Payload/Next.js template: `.env.example` flagged as a leaked env file, and
+ * `password: 'password'` / `apiKey = 'your-api-key'` flagged as secrets. The
+ * module is the ONE source of truth both the gitleaks provider and the
+ * env-in-git count consult.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isExampleEnvFile, isPlaceholderSecret } from '../src/analyzers/security/benign';
+
+describe('isExampleEnvFile — example/template env conventions are not leaks', () => {
+  for (const f of [
+    '.env.example',
+    '.env.sample',
+    '.env.template',
+    '.env.dist',
+    '.env.defaults',
+    '.env.local.example',
+    'config/.env.example',
+    'env.example',
+  ]) {
+    it(`treats ${f} as an example (not a committed secret)`, () => {
+      expect(isExampleEnvFile(f)).toBe(true);
+    });
+  }
+
+  for (const f of ['.env', '.env.local', '.env.production', 'src/config.ts', 'README.md']) {
+    it(`does NOT exempt ${f} (a real env file / unrelated file still counts)`, () => {
+      expect(isExampleEnvFile(f)).toBe(false);
+    });
+  }
+});
+
+describe('isPlaceholderSecret — demo/placeholder values are not credentials', () => {
+  for (const v of [
+    'password',
+    'test',
+    'changeme',
+    'secret',
+    'your-api-key',
+    'your_secret_here',
+    '<your-key>',
+    '${API_KEY}',
+    '{{TOKEN}}',
+    '%SECRET%',
+    'xxxxxxx',
+    '*****',
+    'placeholder',
+    '',
+  ]) {
+    it(`flags ${JSON.stringify(v)} as a placeholder`, () => {
+      expect(isPlaceholderSecret(v)).toBe(true);
+    });
+  }
+
+  for (const v of [
+    // Opaque, high-entropy values (NOT provider-prefixed, to avoid tripping
+    // real secret scanners on this test) — a real credential shape.
+    'a7f3c9d2b8e1f04a6c3e9b1d7f2a8c04',
+    'Zx9Kp2mQ7rTvB4nW8sL1jF6hD3gY5cA',
+    'kJ8s-Lm2p_Qr9t.Vn4w',
+    'a7f3c9d2b8e1', // opaque hex, not a repeated char
+  ]) {
+    it(`does NOT flag a real-looking secret ${JSON.stringify(v)} (no false negative)`, () => {
+      expect(isPlaceholderSecret(v)).toBe(false);
+    });
+  }
+});


### PR DESCRIPTION
Round-3 dogfood feedback (first clean round: uninstall 0 cleanups / 0 new bugs, file-routes confirmed 0→14 routes). This patch closes the 4 remaining minor items, each paired with an **anti-recurrence** mechanism so the *class* can't return for other languages/frameworks.

## 1. Flow — catch-all routes & base-URL-helper calls resolve
A call to an endpoint served by a catch-all (`app/api/[...slug]/route.ts`, Express `/*`, Spring `/**`, Rails `*path`, FastAPI `{p:path}`) showed as unresolved — the join matched only exact paths. Catch-alls now normalize to a distinct `/{prefix}/{*}` marker and the join **prefix-matches** concrete calls against them (exact-literal still wins; longest prefix wins among splats; method-scoped).
**Anti-recurrence:** the marker + prefix-match live in the *shared* normalizer and join, so every future pack inherits it; `test/flow-matching-corpus.test.ts` is a cross-framework golden corpus that fails CI on a regression.

## 2. Scanner false-positives (`.env.example`, placeholder secrets)
`.env.example`/`.template`/`.sample` no longer count as leaked env files; placeholder literals (`password:'password'`, `apiKey='your-api-key'`, `<your-key>`) no longer flag as secrets (dropped values counted as suppressed, never silently).
**Anti-recurrence:** one benign-conventions module (`src/analyzers/security/benign.ts`) every secret/env detector consults; predicates biased toward false-negatives so a real credential is never suppressed.

## 3. PM-aware install text
The `tools list` descriptor and a `loop doctor` fix hint rendered `npm install --save-dev` on pnpm/yarn/bun repos (execution was already PM-aware). Both now build through `src/package-manager.ts`.
**Anti-recurrence:** an architecture rule bans a raw `npm install --save-dev` / `npm i -D` literal outside the PM module + tool registry — the mirror of the self-invocation rule.

## 4. Docs
README quickstart notes the pnpm `minimumReleaseAge` step for a fresh release.

## Verification
- 2972 tests green (+47); lint / format / arch / slop / cross-ecosystem all pass.
- End-to-end on a Payload/Next.js fixture: the 2 base-URL-helper calls that were `no-route` now bind the catch-all at resolved confidence.
- 5 atomic commits → **rebase-merge** (flow / scanner / tools / docs / release, each independently meaningful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)