### PR TITLE
2.31.0 — protected-main-safe baseline refresh + enforcement-path checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,25 @@ doctor` flags a bypassable guardrail either way.
   command can now live in committed, reviewable policy, with
   `DXKIT_LOOP_TEST_COMMAND` kept as the per-shell override.
 
+### Fixed — CI audits the dependency tree the repo actually ships
+
+The CI workflow templates installed dependencies with a hardcoded `npm` step and
+did not put the scanner bin directories on `$GITHUB_PATH`. On a non-npm repo that
+meant the guardrail could audit a **fabricated npm resolution** (e.g. a pnpm repo
+got a different, invented tree) and, with the native scanner not on PATH, fall
+back to a wrong-artifact scanner — producing phantom drift warnings and, worse,
+potentially missing a real vuln in the tree the repo ships.
+
+- **Package-manager-aware install.** The guardrails + baseline-refresh workflows
+  now install with the repo's package manager (pnpm / yarn / bun / npm, via
+  corepack) so the audit and the correctness floor see the real tree.
+- **Registry-derived scanner PATH.** `tools install` now exports every tool bin
+  directory dxkit knows about — `getSystemPaths()` + each tool's `probePaths` —
+  to `$GITHUB_PATH`, so the per-language native scanner (osv-scanner, pip-audit,
+  govulncheck, cargo-audit) is found instead of an npm-audit fallback. Because it
+  reads the same sources `findTool` probes, a new language pack's scanner is
+  covered with no workflow edit.
+
 ### Fixed — `init` re-runs preserve an evolved `flow.mode`
 
 Re-running `init` (e.g. `init --with-baseline-refresh --yes`) on an existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,10 @@ The fix decouples the anchor's **store** from the protected branch via a new
 
 The transport auto-selects from your protection posture and is overridable in
 `.dxkit/policy.json`. `ref-based` mode installs no refresh at all. Existing
-installs are unaffected until re-run; `vyuh-dxkit doctor` flags a bypassable
-guardrail either way.
+installs **auto-migrate** on the next `vyuh-dxkit update` (or `init`): a legacy
+direct-push workflow on a now-protected branch is rewritten to the `branch`
+transport, and only ever when the transport actually changed. `vyuh-dxkit
+doctor` flags a bypassable guardrail either way.
 
 ### Added — enforcement-path checks + config durability
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ doctor` flags a bypassable guardrail either way.
 - **`vyuh-dxkit doctor` verifies the enforcement path, not just the wiring.** It
   now warns when the guardrail is _bypassable_ — the workflow is present and
   green but the default branch takes direct pushes, or nothing requires the
-  `dxkit-guardrails` check, so a PR can merge with the guardrail red.
+  `dxkit-guardrails` check, so a PR can merge with the guardrail red. It also
+  flags a legacy direct-push refresh workflow that will _deadlock_ on a protected
+  branch, pointing at `vyuh-dxkit update` to migrate it.
 - **`vyuh-dxkit protect`** — a dry-run-by-default helper that requires the
   `dxkit-guardrails` check + PR review on the default branch. It prints the exact
   change and writes nothing unless you pass `--apply`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.31.0] - 2026-07-05
+
+### Fixed — the baseline refresh no longer deadlocks against branch protection
+
+The after-merge baseline-refresh workflow direct-pushed the recomputed anchor to
+the default branch with `[skip ci]`. On a protected branch — exactly the setup
+dxkit's own onboarding recommends (require the guardrails check + PR review) —
+that deadlocks: the push is rejected, a fresh commit has no passing checks, and
+`[skip ci]` guarantees it never gets them. dxkit's recommended protection broke
+dxkit's own automation.
+
+The fix decouples the anchor's **store** from the protected branch via a new
+`baseline.anchor` transport, keeping the refresh fast and automated:
+
+- **`branch`** (default when the branch is protected): the refresh direct-pushes
+  the anchor to a separate unprotected branch (`baseline.anchorRef`, default
+  `dxkit-baselines`); the guardrail check hydrates it from there. No push to
+  `main`, no PR, no deadlock.
+- **`cache`** (opt-in): the anchor is stored in the CI cache keyed by the base
+  SHA; a cold cache falls back to a live ref-based gather for that one check.
+- **`tree`** (unprotected default): today's direct-push-to-main refresh.
+
+The transport auto-selects from your protection posture and is overridable in
+`.dxkit/policy.json`. `ref-based` mode installs no refresh at all. Existing
+installs are unaffected until re-run; `vyuh-dxkit doctor` flags a bypassable
+guardrail either way.
+
+### Added — enforcement-path checks + config durability
+
+- **`vyuh-dxkit doctor` verifies the enforcement path, not just the wiring.** It
+  now warns when the guardrail is _bypassable_ — the workflow is present and
+  green but the default branch takes direct pushes, or nothing requires the
+  `dxkit-guardrails` check, so a PR can merge with the guardrail red.
+- **`vyuh-dxkit protect`** — a dry-run-by-default helper that requires the
+  `dxkit-guardrails` check + PR review on the default branch. It prints the exact
+  change and writes nothing unless you pass `--apply`.
+- **`loop.testCommand` in `.dxkit/policy.json`** — the loop's postflight test
+  command can now live in committed, reviewable policy, with
+  `DXKIT_LOOP_TEST_COMMAND` kept as the per-shell override.
+
+### Fixed — `init` re-runs preserve an evolved `flow.mode`
+
+Re-running `init` (e.g. `init --with-baseline-refresh --yes`) on an existing
+install silently reset a committed `flow.mode: "block"` back to `"warn"`. The
+non-interactive flow-setup now preserves an evolved posture instead of
+re-applying the gentle default.
+
 ## [2.30.0] - 2026-07-05
 
 ### Fixed — two "half-landed fix" bugs, and the harness that stops the class

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,19 @@ Every external tool (cloc, gitleaks, semgrep, graphify, jscpd, ruff, etc.) MUST 
 
 Builtins (grep, find, wc, git, node) are exempt — they're always available.
 
+**CI tool discoverability is registry-derived, never a hardcoded PATH.** The
+places a tool binary can live are declared once — `getSystemPaths()` plus each
+tool's `probePaths` in the registry — and `findTool` probes them. The CI PATH
+export (`exportToolPathsToGithubEnv`, run at the end of `tools install`) reads
+the SAME sources and writes them to `$GITHUB_PATH`, so the per-language dep audit
+finds its native scanner (osv-scanner / pip-audit / govulncheck / cargo-audit)
+in a workflow step instead of silently falling back to a wrong-artifact scanner.
+A new language pack that installs a scanner to a new directory declares it in the
+tool's `probePaths` (already required for detection) and is thereby covered in CI
+automatically — do NOT hardcode a per-ecosystem bin dir in a workflow template.
+`test/tool-paths-ci.test.ts` pins that every tool `probePath` appears in the
+export.
+
 ### 2. Never duplicate tool invocation logic
 
 Each tool has ONE gather function (e.g., `gatherGraphifyMetrics` in `tools/graphify.ts`).

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -78,12 +78,39 @@ visibility-derived defaults (`gh repo view --json visibility` →
 }
 ```
 
-| Field  | Type     | Effect                                                                                                                                      |
-| ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mode` | `string` | `committed-full`, `committed-sanitized`, or `ref-based`. See [baseline modes](../commands/baseline.md#modes) for the disclosure trade-offs. |
-| `ref`  | `string` | Git ref the guardrail diffs against in `ref-based` mode. Default: `origin/HEAD` probe (falls back to `origin/main`).                        |
+| Field       | Type     | Effect                                                                                                                                      |
+| ----------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mode`      | `string` | `committed-full`, `committed-sanitized`, or `ref-based`. See [baseline modes](../commands/baseline.md#modes) for the disclosure trade-offs. |
+| `ref`       | `string` | Git ref the guardrail diffs against in `ref-based` mode. Default: `origin/HEAD` probe (falls back to `origin/main`).                        |
+| `anchor`    | `string` | Where a committed anchor is stored: `tree`, `branch`, or `cache`. See "Anchor transport" below. Auto-selected when omitted.                 |
+| `anchorRef` | `string` | Branch that stores the anchor when `anchor` is `branch`. Default `dxkit-baselines`. Must NOT be a protection-covered branch.                |
 
 CLI `--mode` / `--ref` flags override the policy fields.
+
+### Anchor transport (committed modes)
+
+The after-merge refresh keeps a committed anchor current. If the anchor lives on
+your default branch and that branch is protected (dxkit's own onboarding
+recommends requiring the guardrails check + PR review), a direct-push refresh
+deadlocks — the push is rejected, and a `[skip ci]` commit can never earn the
+required checks. `anchor` decouples the store from the protected branch so the
+refresh stays fast and automated:
+
+| Value    | Where the anchor lives                                                        | Use when                                                                          |
+| -------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `tree`   | committed on the default branch; refreshed by a direct push                   | the default branch is unprotected (direct pushes allowed)                         |
+| `branch` | a separate unprotected branch (`anchorRef`); the check hydrates it from there | **default when the branch is protected** — no push to `main`, no PR, no deadlock  |
+| `cache`  | the CI cache keyed by the base SHA; no git write at all                       | a rule protects _every_ branch (so even the side branch can't be pushed); CI-only |
+
+Omit `anchor` and dxkit picks per your protection posture (`branch` on a
+protected default branch, else `tree`; `tree` when protection can't be probed,
+so it never silently reconfigures a repo). `ref-based` mode has no committed
+anchor, so no refresh workflow is installed at all.
+
+Run `vyuh-dxkit doctor` to check whether your guardrail is actually _enforced_
+(a required check on a protected branch) rather than merely wired, and
+`vyuh-dxkit protect` (dry-run by default; `--apply` to write) to require the
+`dxkit-guardrails` check + PR review.
 
 ## Finding statuses
 
@@ -177,6 +204,20 @@ This key is read **only by the Stop-gate** (`vyuh-dxkit hook stop-gate`).
 The CI / PR `guardrail check` ignores it and always uses the block/warn
 policy above — so changing the loop posture never weakens your CI gate.
 Set it here or via `vyuh-dxkit init --claude-loop --loop-preset <p>`.
+
+### `loop.testCommand` — the postflight test command
+
+After the guardrail passes, the Stop-gate can run the tests your change affects
+and block completion if they fail. Configure that command durably here:
+
+```json
+{ "loop": { "testCommand": "pnpm test:int" } }
+```
+
+`DXKIT_LOOP_TEST_COMMAND` still works as a per-shell override and takes
+precedence, but an env var is the easiest part of the loop config to silently
+lose (per-shell, per-machine) — committing it to policy keeps it durable and
+reviewable. `vyuh-dxkit loop doctor` shows which source (if any) supplied it.
 
 ## Loading order
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.30.0",
+      "version": "2.31.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
@@ -1,0 +1,88 @@
+name: dxkit baseline refresh
+
+# Anchor transport: BRANCH. After a merge to the default branch (or weekly / on
+# demand), recompute the committed baseline anchor and direct-push it to a
+# SEPARATE unprotected branch (__DXKIT_ANCHOR_REF__) — never to the protected
+# default branch.
+#
+# Why: when the default branch is protected (dxkit's onboarding recommends
+# requiring the guardrails check + PR review), the original push-to-main refresh
+# deadlocks — the push is rejected and a [skip ci] commit can never earn the
+# required checks. Pushing the anchor to an unprotected side branch sidesteps
+# that entirely: it stays fast and fully automated (no PR, no human), and the
+# guardrail check hydrates the anchor from this branch at check time.
+#
+# No [skip ci] / paths-ignore loop guard is needed: this workflow triggers on
+# pushes to the default branch, and its own output goes to __DXKIT_ANCHOR_REF__,
+# a different branch — so it never re-triggers itself.
+#
+# NOTE: assumes branch protection targets the default branch specifically (the
+# common case), NOT all branches. If a rule covers __DXKIT_ANCHOR_REF__ too, the
+# push is rejected — switch to the 'cache' anchor transport instead.
+
+on:
+  push:
+    branches: [__DXKIT_DEFAULT_BRANCH__]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install dxkit
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          elif [ -f package.json ]; then
+            npm install
+          else
+            npm install -g @vyuhlabs/dxkit
+          fi
+
+      - name: Install scanner tools
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            ./node_modules/.bin/vyuh-dxkit tools install --yes
+          else
+            vyuh-dxkit tools install --yes
+          fi
+
+      - name: Recompute baseline
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            DXKIT=./node_modules/.bin/vyuh-dxkit
+          else
+            DXKIT=vyuh-dxkit
+          fi
+          "${DXKIT}" baseline create --force
+
+      - name: Push anchor to the unprotected side branch
+        run: |
+          if git diff --quiet -- .dxkit/baselines/; then
+            echo "Baseline unchanged — nothing to refresh."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          ANCHOR="__DXKIT_ANCHOR_REF__"
+          # Reset the side branch to the current commit plus the refreshed anchor,
+          # then force-push it. It carries only what the guardrail reads back:
+          # .dxkit/baselines/. Force is safe — this branch is dxkit-owned.
+          git checkout -B "${ANCHOR}"
+          git add .dxkit/baselines/
+          git commit -m "chore(baseline): refresh anchor"
+          git push --force origin "${ANCHOR}"
+          echo "Anchor pushed to '${ANCHOR}'. The guardrail check hydrates it from there."

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
@@ -42,9 +42,17 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install dxkit
+      - name: Install dependencies + dxkit
         run: |
-          if [ -f package-lock.json ]; then
+          corepack enable >/dev/null 2>&1 || true
+          if [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile
+          elif [ -f yarn.lock ]; then
+            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
+          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
+            npm install -g bun >/dev/null 2>&1 || true
+            bun install --frozen-lockfile
+          elif [ -f package-lock.json ]; then
             npm ci
           elif [ -f package.json ]; then
             npm install
@@ -59,6 +67,13 @@ jobs:
           else
             vyuh-dxkit tools install --yes
           fi
+          # Put every ecosystem's tool-bin dir on PATH so the correct native dep
+          # scanner is found (osv-scanner/pip-audit → ~/.local/bin, govulncheck →
+          # ~/go/bin, cargo-audit → ~/.cargo/bin); else the audit falls back to a
+          # wrong-artifact scanner and the baseline drifts from the gate.
+          for d in "$HOME/.local/bin" "$HOME/go/bin" "$HOME/.cargo/bin"; do
+            echo "$d" >> "$GITHUB_PATH"
+          done
 
       - name: Recompute baseline
         run: |

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
@@ -1,0 +1,74 @@
+name: dxkit baseline refresh
+
+# Anchor transport: CACHE. After a merge to the default branch (or weekly / on
+# demand), recompute the committed baseline anchor and store it in the GitHub
+# Actions cache keyed by the merged commit SHA — NO git write at all.
+#
+# Why: branch protection covers branches, not the Actions cache, so this never
+# needs to push anywhere — it sidesteps the push-to-protected-main deadlock
+# without an extra branch. The guardrail check restores the anchor for the PR's
+# base SHA; a cold cache (eviction / first run) falls back to a live re-gather
+# for that one check.
+#
+# Trade-offs vs the 'branch' transport: caches evict after 7 idle days, are
+# scoped (a cache written on the default branch is readable by PRs into it), and
+# are not available to fork PRs or to a local `guardrail check`. Prefer 'branch'
+# unless a rule protects every branch.
+
+on:
+  push:
+    branches: [__DXKIT_DEFAULT_BRANCH__]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install dxkit
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          elif [ -f package.json ]; then
+            npm install
+          else
+            npm install -g @vyuhlabs/dxkit
+          fi
+
+      - name: Install scanner tools
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            ./node_modules/.bin/vyuh-dxkit tools install --yes
+          else
+            vyuh-dxkit tools install --yes
+          fi
+
+      - name: Recompute baseline
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            DXKIT=./node_modules/.bin/vyuh-dxkit
+          else
+            DXKIT=vyuh-dxkit
+          fi
+          "${DXKIT}" baseline create --force
+
+      - name: Store anchor in the Actions cache
+        uses: actions/cache/save@v4
+        with:
+          path: .dxkit/baselines
+          # Keyed by the merged commit SHA so a PR whose base is this commit
+          # restores exactly this anchor. The guardrail check restores by
+          # base SHA with the `dxkit-baseline-` prefix as the fallback.
+          key: dxkit-baseline-${{ github.sha }}

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
@@ -37,9 +37,17 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install dxkit
+      - name: Install dependencies + dxkit
         run: |
-          if [ -f package-lock.json ]; then
+          corepack enable >/dev/null 2>&1 || true
+          if [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile
+          elif [ -f yarn.lock ]; then
+            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
+          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
+            npm install -g bun >/dev/null 2>&1 || true
+            bun install --frozen-lockfile
+          elif [ -f package-lock.json ]; then
             npm ci
           elif [ -f package.json ]; then
             npm install
@@ -54,6 +62,13 @@ jobs:
           else
             vyuh-dxkit tools install --yes
           fi
+          # Put every ecosystem's tool-bin dir on PATH so the correct native dep
+          # scanner is found (osv-scanner/pip-audit → ~/.local/bin, govulncheck →
+          # ~/go/bin, cargo-audit → ~/.cargo/bin); else the audit falls back to a
+          # wrong-artifact scanner and the baseline drifts from the gate.
+          for d in "$HOME/.local/bin" "$HOME/go/bin" "$HOME/.cargo/bin"; do
+            echo "$d" >> "$GITHUB_PATH"
+          done
 
       - name: Recompute baseline
         run: |

--- a/src-templates/.github/workflows/dxkit-baseline-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh.yml
@@ -38,9 +38,17 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install dxkit
+      - name: Install dependencies + dxkit
         run: |
-          if [ -f package-lock.json ]; then
+          corepack enable >/dev/null 2>&1 || true
+          if [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile
+          elif [ -f yarn.lock ]; then
+            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
+          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
+            npm install -g bun >/dev/null 2>&1 || true
+            bun install --frozen-lockfile
+          elif [ -f package-lock.json ]; then
             npm ci
           elif [ -f package.json ]; then
             npm install
@@ -55,6 +63,13 @@ jobs:
           else
             vyuh-dxkit tools install --yes
           fi
+          # Put every ecosystem's tool-bin dir on PATH so the correct native dep
+          # scanner is found (osv-scanner/pip-audit → ~/.local/bin, govulncheck →
+          # ~/go/bin, cargo-audit → ~/.cargo/bin); else the audit falls back to a
+          # wrong-artifact scanner and the baseline drifts from the gate.
+          for d in "$HOME/.local/bin" "$HOME/go/bin" "$HOME/.cargo/bin"; do
+            echo "$d" >> "$GITHUB_PATH"
+          done
 
       - name: Recompute baseline
         run: |

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -56,6 +56,28 @@ jobs:
             vyuh-dxkit tools install --yes
           fi
 
+      # Baseline anchor transport (committed modes only; see .dxkit/policy.json
+      # baseline.anchor). 'tree' = anchor committed in the repo; 'branch' = dxkit
+      # hydrates it from the side branch itself during the check; 'cache' = restore
+      # it here from the Actions cache the refresh job wrote for this base commit.
+      - name: Detect baseline anchor transport
+        id: anchor
+        run: |
+          T=tree
+          if [ -f .dxkit/policy.json ]; then
+            T=$(node -e "try{const a=(require('./.dxkit/policy.json').baseline||{}).anchor;process.stdout.write(a||'tree')}catch(e){process.stdout.write('tree')}")
+          fi
+          echo "transport=$T" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached baseline anchor
+        if: steps.anchor.outputs.transport == 'cache'
+        uses: actions/cache/restore@v4
+        with:
+          path: .dxkit/baselines
+          key: dxkit-baseline-${{ github.event.pull_request.base.sha }}
+          restore-keys: |
+            dxkit-baseline-
+
       # Capture the markdown report regardless of exit code so we can
       # post it as a PR comment even when the guardrail blocks.
       - name: Run guardrail check
@@ -66,8 +88,16 @@ jobs:
           else
             DXKIT=vyuh-dxkit
           fi
+          # Cache transport with a cold cache (eviction / first run): fall back to
+          # a live ref-based gather for this one run rather than error on a missing
+          # anchor. 'branch'/'tree' always have an anchor by check time.
+          EXTRA=""
+          if [ "${{ steps.anchor.outputs.transport }}" = "cache" ] && ! ls .dxkit/baselines/*.json >/dev/null 2>&1; then
+            echo "cache miss — falling back to a ref-based gather for this run"
+            EXTRA="--mode ref-based"
+          fi
           set +e
-          "${DXKIT}" guardrail check --markdown > guardrail-report.md
+          "${DXKIT}" guardrail check $EXTRA --markdown > guardrail-report.md
           code=$?
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           # Surface WHY it blocked in the job log itself (not only the PR

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -31,12 +31,24 @@ jobs:
         with:
           node-version: '22'
 
-      # Install dxkit. Prefers a project-local install (devDependencies)
-      # so the version is pinned alongside the project. Falls back to a
-      # global install for non-JS projects.
-      - name: Install dxkit
+      # Install the project's deps with ITS package manager so the guardrail
+      # audits the dependency tree the repo actually SHIPS — not a fabricated npm
+      # resolution (a bare `npm install` on a pnpm repo invents a different tree,
+      # so the audit both flags phantom vulns and can miss real ones). corepack
+      # ships with Node and provides pnpm/yarn with no extra setup action, honoring
+      # the repo's `packageManager` field; bun is fetched only when its lockfile is
+      # present. A project-local dxkit devDependency is installed along the way.
+      - name: Install dependencies + dxkit
         run: |
-          if [ -f package-lock.json ]; then
+          corepack enable >/dev/null 2>&1 || true
+          if [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile
+          elif [ -f yarn.lock ]; then
+            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
+          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
+            npm install -g bun >/dev/null 2>&1 || true
+            bun install --frozen-lockfile
+          elif [ -f package-lock.json ]; then
             npm ci
           elif [ -f package.json ]; then
             npm install
@@ -55,6 +67,15 @@ jobs:
           else
             vyuh-dxkit tools install --yes
           fi
+          # Put every ecosystem's tool-bin dir on PATH so the correct NATIVE dep
+          # scanner is found for whatever language this repo is — osv-scanner /
+          # pip-audit in ~/.local/bin, govulncheck in ~/go/bin, cargo-audit in
+          # ~/.cargo/bin. Without this the audit can't find its scanner and
+          # silently falls back to a wrong-artifact one (e.g. npm-audit on a pnpm
+          # repo), drifting from the baseline. Language-agnostic on purpose.
+          for d in "$HOME/.local/bin" "$HOME/go/bin" "$HOME/.cargo/bin"; do
+            echo "$d" >> "$GITHUB_PATH"
+          done
 
       # Baseline anchor transport (committed modes only; see .dxkit/policy.json
       # baseline.anchor). 'tree' = anchor committed in the repo; 'branch' = dxkit

--- a/src/analyzers/flow/config.ts
+++ b/src/analyzers/flow/config.ts
@@ -81,6 +81,28 @@ export function readFlowConfig(cwd: string): FlowConfig {
 }
 
 /**
+ * The `flow.mode` EXPLICITLY set in `.dxkit/policy.json`, or `undefined` when the
+ * file is absent/malformed, has no `flow` block, or carries no valid `mode`.
+ *
+ * Unlike `readFlowConfig().mode` — which collapses "unset" into the `block`
+ * default — this distinguishes "the user chose a posture" from "no posture set
+ * yet". The init flow-setup step needs that distinction to PRESERVE an evolved
+ * choice on a re-run rather than re-apply its gentle `warn` default: the class of
+ * bug where `init --yes` on an existing install silently reset a committed
+ * `flow.mode: "block"` back to `"warn"` (policy.json is the exact file the docs
+ * invite users to tune).
+ */
+export function existingFlowMode(cwd: string): FlowGateMode | undefined {
+  try {
+    const text = fs.readFileSync(path.join(cwd, '.dxkit', 'policy.json'), 'utf8');
+    const raw = (JSON.parse(text) as { flow?: RawFlow })?.flow;
+    return raw && isMode(raw.mode) ? raw.mode : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Write into `.dxkit/policy.json:flow`, merging the patch over the existing
  * `flow` block and PRESERVING every other policy section (loop, baseline, …) —
  * the same discipline `ensureLoopPreset` uses for `loop.preset`. This is the

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -163,6 +163,39 @@ function getSystemPaths(): string[] {
   return paths;
 }
 
+/**
+ * When running inside GitHub Actions (`$GITHUB_PATH` is set), append every tool
+ * bin directory dxkit knows about — the canonical `getSystemPaths()` PLUS every
+ * tool's declared `probePaths` — to `$GITHUB_PATH`. This makes the scanners a
+ * `tools install` just provisioned discoverable BY NAME in later workflow steps,
+ * so the per-language dep audit finds its native scanner (osv-scanner, pip-audit,
+ * govulncheck, cargo-audit, …) instead of silently falling back to a
+ * wrong-artifact one and drifting from the baseline.
+ *
+ * It is the registry-derived, recipe-safe counterpart to `findTool`: it reads
+ * the SAME sources `findTool` probes, so a NEW language pack whose scanner
+ * installs to a new directory (declared via its tool's `probePaths`) is covered
+ * automatically, with no workflow edit. That closes the class where a hardcoded
+ * PATH list in the CI workflow silently omitted a pack's scanner. No-op off CI.
+ * Returns the directories exported (for tests / logging).
+ */
+export function exportToolPathsToGithubEnv(): string[] {
+  const dirs = [
+    ...getSystemPaths(),
+    ...Object.values(TOOL_DEFS).flatMap((d) => d.probePaths ?? []),
+  ];
+  const unique = [...new Set(dirs)];
+  const githubPath = process.env.GITHUB_PATH;
+  if (githubPath) {
+    try {
+      fs.appendFileSync(githubPath, unique.join('\n') + '\n', 'utf8');
+    } catch {
+      /* best-effort — never fail an install over a PATH export */
+    }
+  }
+  return unique;
+}
+
 /** Run a command with short timeout, return stdout or empty string. */
 function quickRun(cmd: string): string {
   try {

--- a/src/baseline/anchor.ts
+++ b/src/baseline/anchor.ts
@@ -1,0 +1,66 @@
+/**
+ * Anchor hydration for the `anchor: 'branch'` transport.
+ *
+ * With that transport the committed baseline is NOT stored in the default
+ * branch's working tree — it lives on a separate unprotected branch
+ * (`anchorRef`, default `dxkit-baselines`) that the after-merge refresh
+ * direct-pushes to (branch protection covers the default branch, not this one).
+ * So a committed-mode `guardrail check` — which reads the anchor from
+ * `.dxkit/baselines/<name>.json` — finds nothing in the tree. This module reads
+ * the anchor back from the side branch and writes it into place, so the normal
+ * committed-mode load then proceeds unchanged. It works in CI and locally
+ * (`git show origin/<anchorRef>:<path>`).
+ *
+ * Fail-open throughout: a git error returns `false` and the caller falls back
+ * to whatever is (or isn't) on disk. This is a transport detail, never a place
+ * to hard-fail a check.
+ */
+
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { DEFAULT_ANCHOR_REF } from './modes';
+import type { BaselineSection } from './policy';
+
+function gitShow(cwd: string, ref: string, relPath: string): string {
+  return execSync(`git show ${JSON.stringify(`${ref}:${relPath}`)}`, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'ignore'],
+    encoding: 'utf8',
+  });
+}
+
+/**
+ * When `section.anchor === 'branch'`, hydrate `baselinePath` from the anchor
+ * branch. Returns `true` if the file was written, `false` otherwise (wrong
+ * transport, or the branch/file is unreachable).
+ */
+export function hydrateAnchorFromBranch(
+  cwd: string,
+  baselinePath: string,
+  section: BaselineSection | undefined,
+): boolean {
+  if (section?.anchor !== 'branch') return false;
+  const anchorRef = section.anchorRef ?? DEFAULT_ANCHOR_REF;
+  const relPath = path.relative(cwd, baselinePath).split(path.sep).join('/');
+
+  // Best-effort fetch so the `origin/<anchorRef>` mirror exists (no-op in CI
+  // where checkout already fetched, or when offline).
+  try {
+    execSync(`git fetch --depth=1 origin ${JSON.stringify(anchorRef)}`, { cwd, stdio: 'ignore' });
+  } catch {
+    /* offline / already present — fall through to the reads below */
+  }
+
+  for (const ref of [`origin/${anchorRef}`, anchorRef]) {
+    try {
+      const content = gitShow(cwd, ref, relPath);
+      fs.mkdirSync(path.dirname(baselinePath), { recursive: true });
+      fs.writeFileSync(baselinePath, content, 'utf8');
+      return true;
+    } catch {
+      /* try the next ref form */
+    }
+  }
+  return false;
+}

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -56,8 +56,9 @@ import { gitAwareMatch } from './git-aware-match';
 import type { LocatedIdentity } from './git-aware-match';
 import { resolveBaselineMode } from './modes';
 import type { ResolvedMode } from './modes';
-import { classify, resolvePolicy } from './policy';
-import type { BrownfieldPolicy, ClassifyContext, ClassifyResult } from './policy';
+import { classify, resolvePolicy, loadPolicyFromCwd } from './policy';
+import type { BrownfieldPolicy, ClassifyContext, ClassifyResult, BaselineSection } from './policy';
+import { hydrateAnchorFromBranch } from './anchor';
 import { gatherFromRef } from './ref-baseline';
 import { type GatherScope, FULL_SCOPE, scopeForPolicy } from './gather-scope';
 import { computeChangedFiles } from './changed-files';
@@ -1003,6 +1004,16 @@ function readChangedLineSet(
  * the matcher needs to compute git-aware diffs + envelope drift
  * against the current scan.
  */
+/** Best-effort read of the `baseline` policy section (for the anchor transport);
+ *  undefined when the policy is absent/unreadable. */
+function safeBaselineSection(cwd: string): BaselineSection | undefined {
+  try {
+    return loadPolicyFromCwd(cwd).baseline;
+  } catch {
+    return undefined;
+  }
+}
+
 async function loadPriorSide(
   cwd: string,
   mode: ResolvedMode,
@@ -1014,10 +1025,15 @@ async function loadPriorSide(
     const baselinePath =
       options.baselinePath ?? pathForBaseline(cwd, options.name ?? DEFAULT_BASELINE_NAME);
     if (!fs.existsSync(baselinePath)) {
-      throw new Error(
-        `baseline file not found: ${baselinePath}. ` +
-          `Run \`${dxkitCli('baseline create')}\` first to capture today's state.`,
-      );
+      // `anchor: 'branch'` transport keeps the committed anchor on a separate
+      // unprotected branch, not in the tree — hydrate it before giving up.
+      const hydrated = hydrateAnchorFromBranch(cwd, baselinePath, safeBaselineSection(cwd));
+      if (!hydrated) {
+        throw new Error(
+          `baseline file not found: ${baselinePath}. ` +
+            `Run \`${dxkitCli('baseline create')}\` first to capture today's state.`,
+        );
+      }
     }
     return { baseline: readBaselineFile(baselinePath), baselinePath };
   }

--- a/src/baseline/modes.ts
+++ b/src/baseline/modes.ts
@@ -84,6 +84,59 @@ export const BASELINE_MODES: ReadonlyArray<BaselineMode> = Object.freeze([
   'ref-based',
 ]);
 
+/**
+ * WHERE a committed baseline's anchor is stored — see
+ * `BaselineSection.anchor` for the full rationale. Decouples the store from the
+ * protected default branch so the after-merge refresh stays fast + automated
+ * without a direct push to `main`.
+ *
+ *   - `'tree'`   — committed into the default-branch working tree (direct-push
+ *                  refresh; valid only when direct pushes are allowed).
+ *   - `'branch'` — a separate unprotected branch (`anchorRef`); refresh
+ *                  direct-pushes there, checks hydrate from it.
+ *   - `'cache'`  — the CI cache keyed by the main SHA; no git write, CI-only.
+ */
+export type BaselineAnchor = 'tree' | 'branch' | 'cache';
+
+/** Canonical enumeration of the anchor transports. */
+export const BASELINE_ANCHORS: ReadonlyArray<BaselineAnchor> = Object.freeze([
+  'tree',
+  'branch',
+  'cache',
+]);
+
+/** Default branch storing the anchor when `anchor: 'branch'`. Must NOT be a
+ *  protection-covered branch. */
+export const DEFAULT_ANCHOR_REF = 'dxkit-baselines';
+
+/**
+ * Resolve WHERE a committed baseline's anchor should live — the pure decision,
+ * kept beside `resolveBaselineMode` (Rule 11: baseline-config resolution has one
+ * home). `null` means "no committed anchor at all" (ref-based mode: every check
+ * re-gathers from a ref, so nothing is stored).
+ *
+ * Precedence: an explicit `policyAnchor` wins; otherwise the default follows the
+ * protection posture — a PROTECTED default branch cannot take the `'tree'`
+ * direct push, so it defaults to `'branch'`; an unprotected branch keeps the
+ * simplest `'tree'`. `directPushBlocked === undefined` means "protection
+ * unknown" (no gh / no access) → keep `'tree'` (fail-open: never silently
+ * reconfigure a repo we could not probe; doctor surfaces the risk instead).
+ */
+export function resolveAnchorTransport(input: {
+  mode: BaselineMode;
+  policyAnchor?: BaselineAnchor;
+  directPushBlocked?: boolean;
+}): BaselineAnchor | null {
+  if (input.mode === 'ref-based') return null;
+  if (input.policyAnchor) return input.policyAnchor;
+  return input.directPushBlocked === true ? 'branch' : 'tree';
+}
+
+/** True for a valid anchor transport string. */
+export function isBaselineAnchor(v: unknown): v is BaselineAnchor {
+  return v === 'tree' || v === 'branch' || v === 'cache';
+}
+
 /** Where the resolver picked the mode from. Surfaced to the
  *  runtime log + doctor + agent skills so customers see WHY
  *  `committed-full` was picked over `ref-based`. */

--- a/src/baseline/policy.ts
+++ b/src/baseline/policy.ts
@@ -25,7 +25,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import type { BaselineMode } from './modes';
+import type { BaselineMode, BaselineAnchor } from './modes';
 import type { FindingSeverity, FindingStatus, MatchPair, MatchReason } from './types';
 
 /**
@@ -50,6 +50,28 @@ export interface BaselineSection {
    *  the resolver probes `origin/HEAD` and falls back to
    *  `'origin/main'`. */
   readonly ref?: string;
+  /**
+   * WHERE the committed anchor lives, for committed modes. It decouples the
+   * baseline store from the protected default branch so the after-merge refresh
+   * can stay fast + automated without a direct push to `main` (which branch
+   * protection rejects — see `enforcement.ts`).
+   *
+   *   - `'tree'` (default when the branch is unprotected): the anchor is
+   *     committed into the working tree on the default branch and refreshed by a
+   *     direct push. Simplest; only valid when direct pushes are allowed.
+   *   - `'branch'` (default when the default branch is protected): the anchor
+   *     lives on a separate unprotected branch (`anchorRef`, default
+   *     `dxkit-baselines`). The refresh direct-pushes THERE (allowed — protection
+   *     targets `main`), and each check hydrates the anchor from it. Fast,
+   *     automated, no PR, no deadlock.
+   *   - `'cache'`: the anchor is stored in the CI cache keyed by the main SHA;
+   *     no git write at all. A cold cache falls back to a live re-gather for that
+   *     one check. CI-only (a local run cannot read the CI cache).
+   */
+  readonly anchor?: BaselineAnchor;
+  /** Branch that stores the anchor when `anchor: 'branch'`. Default
+   *  `'dxkit-baselines'`. Must NOT be a protection-covered branch. */
+  readonly anchorRef?: string;
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -367,6 +367,8 @@ export async function run(argv: string[]): Promise<void> {
       // setup-branch-protection flags
       branch: { type: 'string' },
       'require-reviews': { type: 'string' },
+      // `protect` applies changes only with --apply (dry-run by default)
+      apply: { type: 'boolean', default: false },
       // setup-prebuild flags (branch reused above)
       regions: { type: 'string' },
       // upgrade flags
@@ -2333,6 +2335,20 @@ export async function run(argv: string[]): Promise<void> {
         branch: values.branch as string | undefined,
         requireReviews: requireReviewsRaw ? parseInt(requireReviewsRaw, 10) : undefined,
         force: !!values.force,
+      });
+      break;
+    }
+
+    case 'protect': {
+      // Friendly alias for setup-branch-protection, dry-run by DEFAULT: dxkit
+      // never silently writes a repo's settings. `--apply` / `--yes` applies.
+      const { runSetupBranchProtection } = await import('./setup-branch-protection');
+      const requireReviewsRaw = values['require-reviews'] as string | undefined;
+      await runSetupBranchProtection(cwd, {
+        branch: values.branch as string | undefined,
+        requireReviews: requireReviewsRaw ? parseInt(requireReviewsRaw, 10) : undefined,
+        force: !!values.force,
+        dryRun: !(values.apply || values.yes),
       });
       break;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { detect } from './detect';
 import { generate } from './generator';
 import { promptForConfig, promptFlowSetup } from './prompts';
 import { detectFlowTopology, applyFlowSetup } from './analyzers/flow/setup';
+import { existingFlowMode } from './analyzers/flow/config';
 import { runUpdate, writeInstallFlags } from './update';
 import { runDoctor } from './doctor';
 import { VERSION } from './constants';
@@ -618,6 +619,10 @@ export async function run(argv: string[]): Promise<void> {
           const decision = await promptFlowSetup(detection, {
             yes: flowYes,
             forceOn: !!values.flow,
+            // Preserve a posture the user already evolved (a committed
+            // `flow.mode: "block"`) instead of re-applying the gentle `warn`
+            // default on this additive re-run.
+            currentMode: existingFlowMode(cwd),
           });
           const written = applyFlowSetup(cwd, decision);
           shipResults.push({

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -9,6 +9,7 @@ import * as logger from './logger';
 import { resolveBaselineMode } from './baseline/modes';
 import { loadPolicyFromCwd } from './baseline/policy';
 import { detectEnforcement } from './enforcement';
+import { detectInstalledRefreshTransport } from './ship-installers';
 import { detectPackageManager, addDevCommand } from './package-manager';
 import { loadAllowlist, auditAllowlist } from './allowlist/file';
 import { diagnoseFlow, type FlowDiagnosis } from './analyzers/flow/diagnose';
@@ -709,6 +710,24 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
               },
             }),
       });
+
+      // 6c. Deadlocking refresh workflow: a legacy 'tree' baseline-refresh
+      // direct-pushes the anchor to the protected branch. That push is rejected,
+      // and its [skip ci] commit can never earn the required checks — so the
+      // refresh fails on every merge and the anchor can never update. Fires only
+      // when the branch is actually protected AND the installed variant is 'tree'.
+      if (enf.directPushBlocked && detectInstalledRefreshTransport(cwd) === 'tree') {
+        checks.push({
+          label: `baseline-refresh workflow will DEADLOCK on protected '${enf.branch}' (direct-push variant)`,
+          ok: false,
+          tier: 'operational',
+          fix: {
+            hint: `The installed refresh workflow pushes the anchor straight to '${enf.branch}', which branch protection rejects — so it fails every run and the anchor can never update. Run update to migrate it to a protection-safe anchor transport (or delete it if you use ref-based mode).`,
+            command: dxkitCli('update'),
+            skill: 'dxkit-init',
+          },
+        });
+      }
     }
   }
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -8,6 +8,7 @@ import { dxkitCli } from './self-invocation';
 import * as logger from './logger';
 import { resolveBaselineMode } from './baseline/modes';
 import { loadPolicyFromCwd } from './baseline/policy';
+import { detectEnforcement } from './enforcement';
 import { detectPackageManager, addDevCommand } from './package-manager';
 import { loadAllowlist, auditAllowlist } from './allowlist/file';
 import { diagnoseFlow, type FlowDiagnosis } from './analyzers/flow/diagnose';
@@ -675,6 +676,40 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
             },
           }),
     });
+  }
+
+  // 6b. Enforcement PATH — not just the wiring. The guardrails workflow can be
+  // present + green while REAL enforcement is zero: if the default branch takes
+  // direct pushes, or nothing REQUIRES the dxkit-guardrails check, a PR (or a
+  // commit) can land without the guardrail ever blocking. Only meaningful once
+  // the workflow exists; stays silent when gh can't answer (probed === false),
+  // so it never fails a check on "we couldn't tell".
+  if (
+    hasManifest &&
+    fs.existsSync(path.join(cwd, '.github', 'workflows', 'dxkit-guardrails.yml'))
+  ) {
+    const enf = detectEnforcement(cwd);
+    if (enf.probed) {
+      const enforced = enf.directPushBlocked && enf.guardrailRequired;
+      checks.push({
+        label: enforced
+          ? `guardrail enforced on '${enf.branch}' (protected + required check)`
+          : `guardrail is BYPASSABLE on '${enf.branch}' — it runs but does not block merges`,
+        ok: enforced,
+        tier: 'operational',
+        ...(enforced
+          ? {}
+          : {
+              fix: {
+                hint: !enf.directPushBlocked
+                  ? `'${enf.branch}' takes direct pushes, so commits (and PRs) can land without the guardrail. Protect the branch and require the dxkit-guardrails check.`
+                  : `'${enf.branch}' is protected but does not require the dxkit-guardrails check, so a PR can merge with the guardrail red. Add it as a required status check.`,
+                command: dxkitCli('protect'),
+                skill: 'dxkit-init',
+              },
+            }),
+      });
+    }
   }
 
   // 7. Allowlist suppression hygiene. An expired entry no longer

--- a/src/enforcement.ts
+++ b/src/enforcement.ts
@@ -1,0 +1,132 @@
+/**
+ * Enforcement-path detection — the ONE place dxkit learns whether its guardrail
+ * is actually ENFORCED on the default branch, as opposed to merely wired.
+ *
+ * The wiring (a `dxkit-guardrails.yml` on `pull_request`, a pre-push hook) can
+ * be present and green while the real enforcement is zero: if the branch takes
+ * direct pushes, or nothing requires the `dxkit-guardrails` check to pass, a PR
+ * can merge — or a commit can land — without the guardrail ever blocking it.
+ * `doctor` reads this to tell the truth instead of reporting a hollow "wired
+ * end-to-end", and the baseline-refresh installer reads it to avoid shipping a
+ * direct-push refresh workflow onto a protected branch (a guaranteed deadlock:
+ * the push is rejected, and a `[skip ci]` commit can never earn the required
+ * checks).
+ *
+ * Probing shells `gh api` for the branch's protection rule. It is fail-open at
+ * every step — a missing / unauthenticated `gh`, no admin scope, or an error
+ * yields `probed: false` (unknown), never a throw and never a false "enforced".
+ * Results are cached per resolved cwd, mirroring `visibility.ts`.
+ */
+
+import * as path from 'path';
+import { ghApi, ghCliAvailable, resolveDefaultBranch, GhError } from './setup-gh';
+
+/** The guardrail status check dxkit installs + expects a protected branch to
+ *  require. Kept in sync with `setup-branch-protection.ts`. */
+export const GUARDRAIL_CHECK = 'dxkit-guardrails';
+
+/** Minimal subset of GitHub's branch-protection payload dxkit reads. */
+interface ProtectionPayload {
+  required_status_checks?: { contexts?: string[] } | null;
+  required_pull_request_reviews?: unknown | null;
+  enforce_admins?: { enabled?: boolean } | boolean | null;
+}
+
+export interface EnforcementState {
+  /** The branch probed (the repo's default branch). */
+  readonly branch: string;
+  /** Whether dxkit could get a definitive answer. `false` when `gh` is
+   *  absent/unauthenticated or the protection read failed (no admin scope,
+   *  network). Consumers must treat `false` as "unknown", never "unprotected". */
+  readonly probed: boolean;
+  /** Direct pushes to `branch` are blocked — a protection rule requires a PR
+   *  and/or passing status checks, so a bare `git push` is rejected. */
+  readonly directPushBlocked: boolean;
+  /** The `dxkit-guardrails` check is a REQUIRED status check on `branch`, i.e.
+   *  the guardrail actually gates merges rather than running informationally. */
+  readonly guardrailRequired: boolean;
+}
+
+/**
+ * Pure classifier: given a branch's protection payload (or `null` for "no rule")
+ * and whether the probe succeeded, decide the enforcement facts. Exported for
+ * direct unit testing without shelling to `gh`.
+ */
+export function classifyEnforcement(
+  branch: string,
+  payload: ProtectionPayload | null,
+  probed: boolean,
+): EnforcementState {
+  if (!probed) {
+    return { branch, probed: false, directPushBlocked: false, guardrailRequired: false };
+  }
+  const contexts = payload?.required_status_checks?.contexts ?? [];
+  const requiresChecks = contexts.length > 0;
+  const requiresPr = payload?.required_pull_request_reviews != null;
+  return {
+    branch,
+    probed: true,
+    // Either a required check or a required PR review forces changes through a
+    // gate a raw push cannot satisfy — so a direct push is blocked.
+    directPushBlocked: requiresChecks || requiresPr,
+    guardrailRequired: contexts.includes(GUARDRAIL_CHECK),
+  };
+}
+
+const CACHE = new Map<string, EnforcementState>();
+
+/** Test seam — drop the per-cwd cache. */
+export function clearEnforcementCache(): void {
+  CACHE.clear();
+}
+
+/**
+ * Probe how the default branch is protected. Cached per resolved cwd. Fail-open:
+ * an inability to answer → `probed: false`. An injected `probe` (for tests)
+ * bypasses `gh`; production shells `gh api .../branches/{branch}/protection`.
+ */
+export function detectEnforcement(
+  cwd: string,
+  opts: { probe?: (cwd: string, branch: string) => ProtectionPayload | null } = {},
+): EnforcementState {
+  const key = path.resolve(cwd);
+  const cached = CACHE.get(key);
+  if (cached) return cached;
+
+  const probeFn =
+    opts.probe ??
+    ((c: string, branch: string): ProtectionPayload | null => {
+      if (!ghCliAvailable()) throw new GhError('gh unavailable');
+      try {
+        return ghApi(`repos/{owner}/{repo}/branches/${branch}/protection`, {
+          cwd: c,
+          method: 'GET',
+        }) as ProtectionPayload;
+      } catch (e) {
+        // 404 = no protection rule (a definitive "unprotected"); anything else
+        // (403 no-admin, network) is genuinely unknown.
+        if (e instanceof GhError && e.httpStatus === 404) return null;
+        throw e;
+      }
+    });
+
+  const branch = safeDefaultBranch(cwd);
+  let state: EnforcementState;
+  try {
+    const payload = probeFn(cwd, branch);
+    state = classifyEnforcement(branch, payload, true);
+  } catch {
+    state = classifyEnforcement(branch, null, false);
+  }
+  CACHE.set(key, state);
+  return state;
+}
+
+/** Resolve the default branch without letting a gh failure escape. */
+function safeDefaultBranch(cwd: string): string {
+  try {
+    return resolveDefaultBranch(cwd);
+  } catch {
+    return 'main';
+  }
+}

--- a/src/loop/doctor.ts
+++ b/src/loop/doctor.ts
@@ -17,7 +17,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
 import { resolveBaselineMode } from '../baseline/modes';
-import { resolveLoopPreset } from './policy';
+import { resolveLoopPreset, resolveLoopTestCommand } from './policy';
 import { LEDGER_FILE } from './ledger';
 import { loopGateActive } from './gate-cache';
 import { dxkitCli, resolveDxkitCli } from '../self-invocation';
@@ -262,20 +262,24 @@ export function buildLoopDoctorReport(cwd: string): LoopDoctorReport {
   });
 
   // 5. Postflight test command — optional. When unset the gate skips the
-  // post-pass test run; that is a real reduction in coverage, so warn.
-  const testCmd = process.env.DXKIT_LOOP_TEST_COMMAND;
+  // post-pass test run; that is a real reduction in coverage, so warn. Resolved
+  // from DXKIT_LOOP_TEST_COMMAND OR the durable .dxkit/policy.json loop.testCommand.
+  const testCmd = resolveLoopTestCommand(cwd);
+  const source = process.env.DXKIT_LOOP_TEST_COMMAND?.trim()
+    ? 'DXKIT_LOOP_TEST_COMMAND'
+    : '.dxkit/policy.json loop.testCommand';
   checks.push({
     label: 'postflight test command',
     status: testCmd && testCmd.trim() ? 'pass' : 'warn',
     detail:
       testCmd && testCmd.trim()
-        ? `DXKIT_LOOP_TEST_COMMAND set (${testCmd.trim().slice(0, 60)})`
-        : 'DXKIT_LOOP_TEST_COMMAND unset — the gate will not run tests after the guardrail passes',
+        ? `set via ${source} (${testCmd.trim().slice(0, 60)})`
+        : 'unset — the gate will not run tests after the guardrail passes',
     ...(testCmd && testCmd.trim()
       ? {}
       : {
           fix: {
-            hint: 'Optionally export DXKIT_LOOP_TEST_COMMAND so the gate also blocks completion on a failing test suite.',
+            hint: 'Set loop.testCommand in .dxkit/policy.json (durable) or export DXKIT_LOOP_TEST_COMMAND so the gate also blocks completion on a failing test suite.',
           },
         }),
   });

--- a/src/loop/policy.ts
+++ b/src/loop/policy.ts
@@ -144,6 +144,35 @@ export function resolveLoopPreset(cwd: string): LoopPreset {
   return readPresetFromPolicyFile(cwd) ?? DEFAULT_LOOP_PRESET;
 }
 
+/** Read `loop.testCommand` from `.dxkit/policy.json`. Best-effort → undefined. */
+function readTestCommandFromPolicyFile(cwd: string): string | undefined {
+  try {
+    const raw = fs.readFileSync(path.join(cwd, DEFAULT_POLICY_FILENAME), 'utf8');
+    const parsed = JSON.parse(raw) as { loop?: { testCommand?: unknown } };
+    const cmd = parsed.loop?.testCommand;
+    return typeof cmd === 'string' && cmd.trim().length > 0 ? cmd : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the loop's postflight test command — the command the Stop-gate runs to
+ * prove the change still passes the tests it affects. Precedence:
+ *   1. `DXKIT_LOOP_TEST_COMMAND` env var (per-shell / CI override).
+ *   2. `.dxkit/policy.json` → `loop.testCommand` (committed + reviewable).
+ *   3. undefined (no postflight test command configured).
+ *
+ * The env var stays the override, but committing the command to policy makes it
+ * durable: an env var is the easiest part of the loop config to silently lose
+ * (per-shell, per-machine), which left the postflight test step quietly unset.
+ */
+export function resolveLoopTestCommand(cwd: string): string | undefined {
+  const env = process.env.DXKIT_LOOP_TEST_COMMAND;
+  if (typeof env === 'string' && env.trim().length > 0) return env;
+  return readTestCommandFromPolicyFile(cwd);
+}
+
 /**
  * Build the loop-scoped policy: the repo's base `BrownfieldPolicy`
  * (confidence thresholds, baseline mode, drift handling preserved) with

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -52,6 +52,7 @@ import {
   floorLedgerStatuses,
   type FloorGateOutcome,
 } from './floor-gate';
+import { resolveLoopTestCommand } from './policy';
 
 /** Subset of the Claude Code Stop-hook stdin payload we consume. */
 interface StopHookPayload {
@@ -145,7 +146,7 @@ export function buildRepairMessage(json: GuardrailJsonPayload): string {
  * tail to surface in the block message. `not_configured` when unset.
  */
 function runConfiguredTests(repoDir: string): { status: CheckStatus; tail: string } {
-  const cmd = process.env.DXKIT_LOOP_TEST_COMMAND;
+  const cmd = resolveLoopTestCommand(repoDir);
   if (!cmd || !cmd.trim()) return { status: 'not_configured', tail: '' };
   try {
     execSync(cmd, { cwd: repoDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -32,20 +32,29 @@ async function confirm(
  * a repo with none never reaches here, so init stays silent on non-flow repos.
  *
  * Non-interactive (`--yes` / `--detect`, or `forceOn` from `--flow`) takes the
- * gentle default: `warn` posture plus the dominant host-helper strip-prefix.
- * Interactive lets the user pick the posture (with a one-line description of
- * each) and confirm the auto-detected strip-prefix + services.
+ * gentle default on a FRESH setup — `warn` posture plus the dominant host-helper
+ * strip-prefix — but on a RE-RUN of an already-configured repo it preserves the
+ * user's evolved config verbatim (`options.currentMode`), so an additive
+ * `init --yes` never silently downgrades a committed `flow.mode: "block"` back to
+ * `"warn"`. Interactive lets the user pick the posture (defaulting the prompt to
+ * the existing one) and confirm the auto-detected strip-prefix + services.
  */
 export async function promptFlowSetup(
   detection: FlowDetection,
-  options: { yes: boolean; forceOn: boolean },
+  options: { yes: boolean; forceOn: boolean; currentMode?: FlowGateMode },
 ): Promise<FlowSetupDecision> {
   const defaultPrefixes = detection.suggestedStripPrefixes.slice(0, 1);
 
-  // Non-interactive default: warn + the dominant strip-prefix, no participants
-  // (recording multiple services is an explicit interactive confirm).
+  // Non-interactive: on an already-configured repo PRESERVE the evolved posture
+  // and leave its strip-prefixes untouched (an empty list makes applyFlowSetup
+  // omit the key, so the writer's shallow merge keeps what's on disk — never a
+  // regeneration). Only a FRESH setup (no mode set yet) takes the gentle `warn`
+  // default + the dominant strip-prefix. Participants stay an explicit
+  // interactive confirm either way.
   if (options.yes || options.forceOn) {
-    return { mode: 'warn', stripUrlPrefixes: defaultPrefixes };
+    return options.currentMode
+      ? { mode: options.currentMode, stripUrlPrefixes: [] }
+      : { mode: 'warn', stripUrlPrefixes: defaultPrefixes };
   }
 
   const rl = readline.createInterface({ input: stdin, output: stdout });
@@ -67,7 +76,7 @@ export async function promptFlowSetup(
     console.log('    warn   surface broken integrations as warnings (recommended)'); // slop-ok
     console.log('    block  fail the check on an exact broken integration (confidence-gated)'); // slop-ok
     console.log('    off    scaffold config only, do not gate yet'); // slop-ok
-    const mode = await selectMode(rl, 'Posture?', 'warn');
+    const mode = await selectMode(rl, 'Posture?', options.currentMode ?? 'warn');
 
     let stripUrlPrefixes: string[] = [];
     if (detection.suggestedStripPrefixes.length > 0) {

--- a/src/setup-branch-protection.ts
+++ b/src/setup-branch-protection.ts
@@ -43,6 +43,10 @@ export interface SetupBranchProtectionOpts {
   requireReviews?: number;
   /** Force overwrite of existing required checks. Default merge. */
   force?: boolean;
+  /** Preview only: print the exact change and DO NOT write to the repo. This is
+   *  the default for `vyuh-dxkit protect` (dxkit never silently reconfigures a
+   *  repo's settings — you apply explicitly with `--apply` / `--yes`). */
+  dryRun?: boolean;
 }
 
 /** Shape of GitHub's branch protection payload — partial subset we touch. */
@@ -186,6 +190,21 @@ export async function runSetupBranchProtection(
   }
 
   const payload = buildPayload(existing, opts);
+
+  if (opts.dryRun) {
+    console.log(''); // slop-ok
+    logger.info(`Would apply to ${owner}/${repo}#${branch} (dry run — no changes written):`);
+    logger.dim(
+      `  → required status checks: [${payload.required_status_checks?.contexts.join(', ')}]`,
+    );
+    logger.dim(
+      `  → required PR review approvals: ${payload.required_pull_request_reviews?.required_approving_review_count ?? 0}`,
+    );
+    console.log(''); // slop-ok
+    logger.info(`Re-run with \`${dxkitCli('protect --apply')}\` to write these settings.`);
+    return;
+  }
+
   logger.info(
     `Applying protection: required checks = [${payload.required_status_checks?.contexts.join(', ')}]; ` +
       `reviews required = ${payload.required_pull_request_reviews?.required_approving_review_count ?? 0}.`,

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -482,11 +482,12 @@ export function baselineRefreshInstallPlan(
 
 /**
  * Classify the anchor transport of an ALREADY-installed refresh workflow by its
- * content shape, so an `update` / re-`init` can migrate a stale variant. Returns
- * null when no refresh workflow is installed (nothing to migrate). The legacy
- * pre-transport workflow (a bare push to the default branch) reads as `tree`.
+ * content shape, so an `update` / re-`init` can migrate a stale variant and
+ * `doctor` can warn about a deadlocking one. Returns null when no refresh
+ * workflow is installed. The legacy pre-transport workflow (a bare push to the
+ * default branch) reads as `tree` — the one that deadlocks on a protected branch.
  */
-function detectInstalledRefreshTransport(cwd: string): BaselineAnchor | null {
+export function detectInstalledRefreshTransport(cwd: string): BaselineAnchor | null {
   const abs = path.join(cwd, '.github', 'workflows', REFRESH_WORKFLOW_DEST);
   let content: string;
   try {

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -18,6 +18,15 @@ import { activateHooks } from './hooks-cli';
 import { detect } from './detect';
 import { buildDevcontainerExtensions, buildDevcontainerFeatures } from './languages';
 import { VERSION } from './constants';
+import {
+  resolveBaselineMode,
+  resolveAnchorTransport,
+  DEFAULT_ANCHOR_REF,
+  type BaselineMode,
+  type BaselineAnchor,
+} from './baseline/modes';
+import { loadPolicyFromCwd } from './baseline/policy';
+import { detectEnforcement, type EnforcementState } from './enforcement';
 
 /**
  * Detect the consumer repo's default branch so workflow templates
@@ -378,10 +387,11 @@ function installWorkflow(
   fileName: string,
   opts: InstallerOpts,
   substitutions: Readonly<Record<string, string>> = {},
+  destName: string = fileName,
 ): ShipInstallResult {
   const result = emptyResult();
   const srcAbs = path.join(templatesDir(), '.github', 'workflows', fileName);
-  const destAbs = path.join(cwd, '.github', 'workflows', fileName);
+  const destAbs = path.join(cwd, '.github', 'workflows', destName);
 
   if (fs.existsSync(destAbs) && !opts.force) {
     result.skipped.push(path.relative(cwd, destAbs));
@@ -406,16 +416,129 @@ export function installCiGuardrails(cwd: string, opts: InstallerOpts = {}): Ship
   return installWorkflow(cwd, 'dxkit-guardrails.yml', opts);
 }
 
-export function installCiBaselineRefresh(cwd: string, opts: InstallerOpts = {}): ShipInstallResult {
-  const defaultBranch = detectDefaultBranch(cwd);
-  const result = installWorkflow(cwd, 'dxkit-baseline-refresh.yml', opts, {
-    __DXKIT_DEFAULT_BRANCH__: defaultBranch,
+/** The single destination filename for the baseline-refresh workflow, whatever
+ *  the anchor transport. Keeping ONE filename means uninstall + update (which key
+ *  off this name) need no per-variant wiring — the transport is the file's
+ *  CONTENT, chosen at install time. */
+const REFRESH_WORKFLOW_DEST = 'dxkit-baseline-refresh.yml';
+
+/** Source template per anchor transport (all copied to REFRESH_WORKFLOW_DEST). */
+const REFRESH_TEMPLATE_BY_TRANSPORT: Record<BaselineAnchor, string> = {
+  tree: 'dxkit-baseline-refresh.yml',
+  branch: 'dxkit-baseline-refresh-branch.yml',
+  cache: 'dxkit-baseline-refresh-cache.yml',
+};
+
+export type RefreshInstallPlan =
+  | { install: false; reason: string; guidance: string[] }
+  | { install: true; transport: BaselineAnchor; anchorRef: string };
+
+/**
+ * Decide WHETHER and in WHICH transport to install the after-merge baseline
+ * refresh. The workflow exists only to keep a COMMITTED anchor current, so:
+ *
+ *   - **ref-based mode** → skip entirely: no committed anchor exists (each check
+ *     re-gathers from origin/main), so there is nothing to refresh.
+ *   - **committed mode** → install, but the transport (`tree` / `branch` /
+ *     `cache`) decouples the store from the protected default branch so the
+ *     direct-push refresh never deadlocks (`resolveAnchorTransport`): a protected
+ *     branch defaults to `branch` (push the anchor to an unprotected side branch)
+ *     rather than `tree` (push to the protected branch — rejected).
+ *
+ * Mode / protection / policy-anchor are injectable for tests.
+ */
+export function baselineRefreshInstallPlan(
+  cwd: string,
+  opts: {
+    mode?: BaselineMode;
+    enforcement?: EnforcementState;
+    policyAnchor?: BaselineAnchor;
+    anchorRef?: string;
+  } = {},
+): RefreshInstallPlan {
+  const section = readPolicyBaselineSection(cwd);
+  const mode = opts.mode ?? resolveBaselineMode({ cwd, policyMode: section?.mode }).mode;
+  if (mode === 'ref-based') {
+    return {
+      install: false,
+      reason: 'ref-based baseline mode keeps no committed anchor to refresh',
+      guidance: [
+        'Every guardrail check re-gathers the prior side from origin/main, so there is no',
+        'baseline file to keep current — the refresh workflow is not needed in this mode.',
+      ],
+    };
+  }
+  const enforcement = opts.enforcement ?? detectEnforcement(cwd);
+  const policyAnchor = opts.policyAnchor ?? section?.anchor;
+  const transport =
+    resolveAnchorTransport({
+      mode,
+      ...(policyAnchor !== undefined ? { policyAnchor } : {}),
+      ...(enforcement.probed ? { directPushBlocked: enforcement.directPushBlocked } : {}),
+    }) ?? 'tree';
+  const anchorRef = opts.anchorRef ?? section?.anchorRef ?? DEFAULT_ANCHOR_REF;
+  return { install: true, transport, anchorRef };
+}
+
+/** Best-effort read of the `baseline` policy section (undefined when
+ *  absent/unreadable, so visibility-/protection-derived defaults apply). */
+function readPolicyBaselineSection(cwd: string) {
+  try {
+    return loadPolicyFromCwd(cwd).baseline;
+  } catch {
+    return undefined;
+  }
+}
+
+export function installCiBaselineRefresh(
+  cwd: string,
+  opts: InstallerOpts & {
+    baselineMode?: BaselineMode;
+    enforcement?: EnforcementState;
+    policyAnchor?: BaselineAnchor;
+    anchorRef?: string;
+  } = {},
+): ShipInstallResult {
+  const plan = baselineRefreshInstallPlan(cwd, {
+    ...(opts.baselineMode !== undefined ? { mode: opts.baselineMode } : {}),
+    ...(opts.enforcement !== undefined ? { enforcement: opts.enforcement } : {}),
+    ...(opts.policyAnchor !== undefined ? { policyAnchor: opts.policyAnchor } : {}),
+    ...(opts.anchorRef !== undefined ? { anchorRef: opts.anchorRef } : {}),
   });
-  if (result.installed.length > 0 && defaultBranch !== 'main') {
-    result.notes.push(
-      `baseline-refresh workflow targets the '${defaultBranch}' branch (detected from your repo). ` +
-        `Edit the workflow's \`branches:\` trigger if you want a different one.`,
-    );
+  if (!plan.install) {
+    const result = emptyResult();
+    result.skipped.push(`.github/workflows/${REFRESH_WORKFLOW_DEST}`);
+    result.notes.push(`baseline-refresh workflow not installed — ${plan.reason}.`, ...plan.guidance);
+    return result;
+  }
+
+  const defaultBranch = detectDefaultBranch(cwd);
+  const result = installWorkflow(
+    cwd,
+    REFRESH_TEMPLATE_BY_TRANSPORT[plan.transport],
+    opts,
+    { __DXKIT_DEFAULT_BRANCH__: defaultBranch, __DXKIT_ANCHOR_REF__: plan.anchorRef },
+    REFRESH_WORKFLOW_DEST,
+  );
+  if (result.installed.length > 0) {
+    if (plan.transport === 'branch') {
+      result.notes.push(
+        `baseline-refresh uses the '${plan.transport}' anchor transport: the recomputed anchor is ` +
+          `pushed to the unprotected '${plan.anchorRef}' branch (not '${defaultBranch}'), so branch ` +
+          `protection never blocks it. Ensure '${plan.anchorRef}' is NOT covered by a protection rule.`,
+      );
+    } else if (plan.transport === 'cache') {
+      result.notes.push(
+        `baseline-refresh uses the 'cache' anchor transport: the anchor is stored in the Actions ` +
+          `cache (no git write). A cold cache falls back to a live re-gather. CI-only.`,
+      );
+    }
+    if (defaultBranch !== 'main') {
+      result.notes.push(
+        `Workflow targets the '${defaultBranch}' branch (detected from your repo). ` +
+          `Edit its \`branches:\` trigger to change it.`,
+      );
+    }
   }
   return result;
 }

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -480,6 +480,26 @@ export function baselineRefreshInstallPlan(
   return { install: true, transport, anchorRef };
 }
 
+/**
+ * Classify the anchor transport of an ALREADY-installed refresh workflow by its
+ * content shape, so an `update` / re-`init` can migrate a stale variant. Returns
+ * null when no refresh workflow is installed (nothing to migrate). The legacy
+ * pre-transport workflow (a bare push to the default branch) reads as `tree`.
+ */
+function detectInstalledRefreshTransport(cwd: string): BaselineAnchor | null {
+  const abs = path.join(cwd, '.github', 'workflows', REFRESH_WORKFLOW_DEST);
+  let content: string;
+  try {
+    content = fs.readFileSync(abs, 'utf8');
+  } catch {
+    return null; // not installed
+  }
+  if (content.includes('actions/cache/save')) return 'cache';
+  if (content.includes('origin "${ANCHOR}"')) return 'branch';
+  if (content.includes('git push')) return 'tree';
+  return null;
+}
+
 /** Best-effort read of the `baseline` policy section (undefined when
  *  absent/unreadable, so visibility-/protection-derived defaults apply). */
 function readPolicyBaselineSection(cwd: string) {
@@ -516,14 +536,29 @@ export function installCiBaselineRefresh(
   }
 
   const defaultBranch = detectDefaultBranch(cwd);
+  // Auto-migrate a dxkit-managed refresh workflow whose transport no longer
+  // matches the resolved one — e.g. a 2.30 install whose 'tree' workflow now
+  // deadlocks because the branch became protected (or an upgrade from a
+  // pre-transport version). This overwrites even without an explicit --force
+  // because it is dxkit's OWN template and the stale variant is broken; it fires
+  // ONLY on a real transport change, so it never churns an up-to-date file.
+  const installedTransport = detectInstalledRefreshTransport(cwd);
+  const migrating = installedTransport !== null && installedTransport !== plan.transport;
+  const effectiveOpts = migrating ? { ...opts, force: true } : opts;
   const result = installWorkflow(
     cwd,
     REFRESH_TEMPLATE_BY_TRANSPORT[plan.transport],
-    opts,
+    effectiveOpts,
     { __DXKIT_DEFAULT_BRANCH__: defaultBranch, __DXKIT_ANCHOR_REF__: plan.anchorRef },
     REFRESH_WORKFLOW_DEST,
   );
   if (result.installed.length > 0) {
+    if (migrating) {
+      result.notes.push(
+        `Migrated the baseline-refresh workflow from the '${installedTransport}' transport to ` +
+          `'${plan.transport}' (branch protection changed, or upgraded from a pre-transport version).`,
+      );
+    }
     if (plan.transport === 'branch') {
       result.notes.push(
         `baseline-refresh uses the '${plan.transport}' anchor transport: the recomputed anchor is ` +

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -508,7 +508,10 @@ export function installCiBaselineRefresh(
   if (!plan.install) {
     const result = emptyResult();
     result.skipped.push(`.github/workflows/${REFRESH_WORKFLOW_DEST}`);
-    result.notes.push(`baseline-refresh workflow not installed — ${plan.reason}.`, ...plan.guidance);
+    result.notes.push(
+      `baseline-refresh workflow not installed — ${plan.reason}.`,
+      ...plan.guidance,
+    );
     return result;
   }
 

--- a/src/tools-cli.ts
+++ b/src/tools-cli.ts
@@ -35,6 +35,7 @@ import {
   getInstallEnv,
   checkAllTools,
   buildRequiredTools,
+  exportToolPathsToGithubEnv,
   ToolStatus,
 } from './analyzers/tools/tool-registry';
 
@@ -404,6 +405,12 @@ async function runInstall(
     console.log('');
     logger.dim(`Run \`${dxkitCli('health')}\` to use the newly installed tools.`);
   }
+
+  // In CI, make every tool bin dir dxkit knows about discoverable by name in
+  // later workflow steps, so the per-language dep audit finds its native scanner
+  // instead of falling back to a wrong-artifact one. Registry-derived, so a new
+  // language pack's scanner dir is covered with no workflow edit. No-op off CI.
+  exportToolPathsToGithubEnv();
 }
 
 export async function runToolsCommand(

--- a/test/baseline-anchor.test.ts
+++ b/test/baseline-anchor.test.ts
@@ -204,6 +204,33 @@ describe('installCiBaselineRefresh — content per transport (anti-recurrence)',
     expect(r.installed).toHaveLength(0);
     expect(r.skipped).toContain('.github/workflows/dxkit-baseline-refresh.yml');
   });
+
+  it('auto-migrates a legacy tree workflow to branch when the repo is now protected (no --force)', () => {
+    // Simulate a 2.30 install: the old direct-push-to-main (tree) workflow.
+    installCiBaselineRefresh(dir, { baselineMode: 'committed-full', enforcement: UNPROTECTED });
+    expect(dest()).toContain('git push');
+    expect(dest()).not.toContain(DEFAULT_ANCHOR_REF);
+    // The branch becomes protected; a plain re-run (no force) must MIGRATE the
+    // deadlocking workflow to the branch transport, not skip it.
+    const r = installCiBaselineRefresh(dir, {
+      baselineMode: 'committed-full',
+      enforcement: PROTECTED,
+    });
+    expect(r.installed).toContain('.github/workflows/dxkit-baseline-refresh.yml');
+    expect(r.notes.join('\n')).toMatch(/Migrated the baseline-refresh workflow from the 'tree'/);
+    expect(dest()).toContain(`ANCHOR="${DEFAULT_ANCHOR_REF}"`);
+  });
+
+  it('does NOT rewrite an up-to-date workflow (migration fires only on a transport change)', () => {
+    installCiBaselineRefresh(dir, { baselineMode: 'committed-full', enforcement: PROTECTED });
+    const r = installCiBaselineRefresh(dir, {
+      baselineMode: 'committed-full',
+      enforcement: PROTECTED,
+    });
+    // Same transport → installWorkflow skips the existing file, no migration note.
+    expect(r.installed).toHaveLength(0);
+    expect(r.notes.join('\n')).not.toMatch(/Migrated/);
+  });
 });
 
 describe('hydrateAnchorFromBranch', () => {

--- a/test/baseline-anchor.test.ts
+++ b/test/baseline-anchor.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Baseline anchor transport (2.31.0) — the fix for the refresh-vs-branch-
+ * protection deadlock. The committed anchor's STORE is decoupled from the
+ * protected default branch so the after-merge refresh stays fast + automated
+ * without a direct push to `main`.
+ *
+ * Covers: the pure transport resolver, the enforcement classifier, the
+ * install-plan + workflow-content selection (the anti-recurrence guard: a
+ * committed+protected repo NEVER gets a workflow that direct-pushes to the
+ * default branch), and the off-tree anchor hydration guard.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  resolveAnchorTransport,
+  DEFAULT_ANCHOR_REF,
+  isBaselineAnchor,
+} from '../src/baseline/modes';
+import { classifyEnforcement, type EnforcementState } from '../src/enforcement';
+import { baselineRefreshInstallPlan, installCiBaselineRefresh } from '../src/ship-installers';
+import { hydrateAnchorFromBranch } from '../src/baseline/anchor';
+
+const PROTECTED: EnforcementState = {
+  branch: 'main',
+  probed: true,
+  directPushBlocked: true,
+  guardrailRequired: true,
+};
+const UNPROTECTED: EnforcementState = {
+  branch: 'main',
+  probed: true,
+  directPushBlocked: false,
+  guardrailRequired: false,
+};
+const UNKNOWN: EnforcementState = {
+  branch: 'main',
+  probed: false,
+  directPushBlocked: false,
+  guardrailRequired: false,
+};
+
+describe('resolveAnchorTransport', () => {
+  it('ref-based mode has no committed anchor (null)', () => {
+    expect(resolveAnchorTransport({ mode: 'ref-based' })).toBeNull();
+    expect(resolveAnchorTransport({ mode: 'ref-based', directPushBlocked: true })).toBeNull();
+  });
+  it('committed + protected default branch → branch transport (avoids the deadlock)', () => {
+    expect(resolveAnchorTransport({ mode: 'committed-full', directPushBlocked: true })).toBe(
+      'branch',
+    );
+  });
+  it('committed + unprotected → tree transport (the simple direct push is fine)', () => {
+    expect(resolveAnchorTransport({ mode: 'committed-full', directPushBlocked: false })).toBe(
+      'tree',
+    );
+  });
+  it('committed + protection UNKNOWN → tree (fail-open; never silently reconfigure)', () => {
+    expect(resolveAnchorTransport({ mode: 'committed-sanitized' })).toBe('tree');
+  });
+  it('an explicit policy anchor wins over the protection-derived default', () => {
+    expect(
+      resolveAnchorTransport({
+        mode: 'committed-full',
+        policyAnchor: 'cache',
+        directPushBlocked: true,
+      }),
+    ).toBe('cache');
+    expect(
+      resolveAnchorTransport({
+        mode: 'committed-full',
+        policyAnchor: 'tree',
+        directPushBlocked: true,
+      }),
+    ).toBe('tree');
+  });
+});
+
+describe('isBaselineAnchor', () => {
+  it('accepts the three transports, rejects anything else', () => {
+    for (const a of ['tree', 'branch', 'cache']) expect(isBaselineAnchor(a)).toBe(true);
+    for (const a of ['', 'ref', 'main', undefined, 3]) expect(isBaselineAnchor(a)).toBe(false);
+  });
+});
+
+describe('classifyEnforcement', () => {
+  it('an unprobed answer is "unknown", never a false "unprotected"', () => {
+    const s = classifyEnforcement('main', null, false);
+    expect(s.probed).toBe(false);
+    expect(s.directPushBlocked).toBe(false);
+    expect(s.guardrailRequired).toBe(false);
+  });
+  it('no protection rule (404 → null) → not blocked, guardrail not required', () => {
+    const s = classifyEnforcement('main', null, true);
+    expect(s.probed).toBe(true);
+    expect(s.directPushBlocked).toBe(false);
+    expect(s.guardrailRequired).toBe(false);
+  });
+  it('required status checks block direct pushes; dxkit-guardrails presence is detected', () => {
+    const s = classifyEnforcement(
+      'main',
+      { required_status_checks: { contexts: ['dxkit-guardrails', 'build'] } },
+      true,
+    );
+    expect(s.directPushBlocked).toBe(true);
+    expect(s.guardrailRequired).toBe(true);
+  });
+  it('a required PR review alone blocks direct pushes (guardrail may still be absent)', () => {
+    const s = classifyEnforcement('main', { required_pull_request_reviews: {} }, true);
+    expect(s.directPushBlocked).toBe(true);
+    expect(s.guardrailRequired).toBe(false);
+  });
+});
+
+describe('baselineRefreshInstallPlan', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-refreshplan-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('ref-based → not installed, with guidance', () => {
+    const plan = baselineRefreshInstallPlan(dir, { mode: 'ref-based', enforcement: UNKNOWN });
+    expect(plan.install).toBe(false);
+    if (!plan.install) expect(plan.reason).toMatch(/ref-based/);
+  });
+  it('committed + protected → install the branch transport', () => {
+    const plan = baselineRefreshInstallPlan(dir, {
+      mode: 'committed-full',
+      enforcement: PROTECTED,
+    });
+    expect(plan).toEqual({ install: true, transport: 'branch', anchorRef: DEFAULT_ANCHOR_REF });
+  });
+  it('committed + unprotected → install the tree transport', () => {
+    const plan = baselineRefreshInstallPlan(dir, {
+      mode: 'committed-full',
+      enforcement: UNPROTECTED,
+    });
+    expect(plan).toEqual({ install: true, transport: 'tree', anchorRef: DEFAULT_ANCHOR_REF });
+  });
+  it('an explicit policy anchor + anchorRef override the default', () => {
+    const plan = baselineRefreshInstallPlan(dir, {
+      mode: 'committed-full',
+      enforcement: PROTECTED,
+      policyAnchor: 'cache',
+      anchorRef: 'my-anchors',
+    });
+    expect(plan).toEqual({ install: true, transport: 'cache', anchorRef: 'my-anchors' });
+  });
+});
+
+describe('installCiBaselineRefresh — content per transport (anti-recurrence)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-refreshinstall-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const dest = (): string =>
+    readFileSync(join(dir, '.github', 'workflows', 'dxkit-baseline-refresh.yml'), 'utf8');
+
+  it('always writes the single dest filename regardless of transport', () => {
+    const r = installCiBaselineRefresh(dir, {
+      baselineMode: 'committed-full',
+      enforcement: PROTECTED,
+    });
+    expect(r.installed).toContain('.github/workflows/dxkit-baseline-refresh.yml');
+  });
+
+  it('committed + protected → branch variant pushes to the side branch, NEVER to the default branch', () => {
+    installCiBaselineRefresh(dir, { baselineMode: 'committed-full', enforcement: PROTECTED });
+    const yml = dest();
+    // The anchor ref substitution landed, and the push targets that side branch...
+    expect(yml).toContain(`ANCHOR="${DEFAULT_ANCHOR_REF}"`);
+    expect(yml).toContain('git push --force origin "${ANCHOR}"');
+    // ...and NEVER a bare `git push` (which defaults to the protected branch — the
+    // deadlock) and never a [skip ci] COMMIT (the hack the side branch obviates).
+    expect(yml).not.toMatch(/git push\s*$/m);
+    expect(yml).not.toMatch(/-m "[^"]*\[skip ci\]/);
+  });
+
+  it('committed + unprotected → tree variant (the original direct-push refresh)', () => {
+    installCiBaselineRefresh(dir, { baselineMode: 'committed-full', enforcement: UNPROTECTED });
+    const yml = dest();
+    expect(yml).toContain('git push');
+    expect(yml).not.toContain(DEFAULT_ANCHOR_REF);
+  });
+
+  it('cache transport → cache-save variant, no git push at all', () => {
+    installCiBaselineRefresh(dir, {
+      baselineMode: 'committed-full',
+      enforcement: PROTECTED,
+      policyAnchor: 'cache',
+    });
+    const yml = dest();
+    expect(yml).toContain('actions/cache/save');
+    expect(yml).not.toContain('git push');
+  });
+
+  it('ref-based → skipped, not installed', () => {
+    const r = installCiBaselineRefresh(dir, { baselineMode: 'ref-based', enforcement: UNKNOWN });
+    expect(r.installed).toHaveLength(0);
+    expect(r.skipped).toContain('.github/workflows/dxkit-baseline-refresh.yml');
+  });
+});
+
+describe('hydrateAnchorFromBranch', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-hydrate-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('is a no-op for non-branch transports (returns false)', () => {
+    expect(hydrateAnchorFromBranch(dir, join(dir, '.dxkit/baselines/main.json'), undefined)).toBe(
+      false,
+    );
+    expect(
+      hydrateAnchorFromBranch(dir, join(dir, '.dxkit/baselines/main.json'), { anchor: 'tree' }),
+    ).toBe(false);
+    expect(
+      hydrateAnchorFromBranch(dir, join(dir, '.dxkit/baselines/main.json'), { anchor: 'cache' }),
+    ).toBe(false);
+  });
+
+  it('returns false (does not throw) when the anchor branch is unreachable', () => {
+    // Non-git dir + anchor:'branch' → every git read fails → false, no throw.
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(join(dir, '.dxkit', 'policy.json'), '{}');
+    expect(
+      hydrateAnchorFromBranch(dir, join(dir, '.dxkit/baselines/main.json'), {
+        anchor: 'branch',
+        anchorRef: 'dxkit-baselines',
+      }),
+    ).toBe(false);
+  });
+});

--- a/test/baseline-anchor.test.ts
+++ b/test/baseline-anchor.test.ts
@@ -24,6 +24,7 @@ import {
   baselineRefreshInstallPlan,
   installCiBaselineRefresh,
   detectInstalledRefreshTransport,
+  installCiGuardrails,
 } from '../src/ship-installers';
 import { hydrateAnchorFromBranch } from '../src/baseline/anchor';
 
@@ -234,6 +235,49 @@ describe('installCiBaselineRefresh — content per transport (anti-recurrence)',
     // Same transport → installWorkflow skips the existing file, no migration note.
     expect(r.installed).toHaveLength(0);
     expect(r.notes.join('\n')).not.toMatch(/Migrated/);
+  });
+});
+
+describe('CI workflow templates audit the right artifact (item #3 anti-recurrence)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-wfpm-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const read = (name: string): string =>
+    readFileSync(join(dir, '.github', 'workflows', name), 'utf8');
+
+  // Every workflow that installs deps + runs the dep audit must (a) install with
+  // the repo's package manager (not a hardcoded npm that fabricates a tree) and
+  // (b) put the scanner bin dirs on PATH so the audit finds its native scanner
+  // rather than falling back to a wrong-artifact one.
+  const auditWorkflows: Array<[string, () => void]> = [
+    ['dxkit-guardrails.yml', () => installCiGuardrails(dir)],
+    [
+      'dxkit-baseline-refresh.yml',
+      () =>
+        installCiBaselineRefresh(dir, { baselineMode: 'committed-full', enforcement: PROTECTED }),
+    ],
+  ];
+
+  it.each(auditWorkflows)('%s is package-manager-aware (not npm-only)', (name, install) => {
+    install();
+    const yml = read(name);
+    expect(yml).toContain('pnpm install --frozen-lockfile');
+    expect(yml).toContain('yarn install');
+    expect(yml).toContain('bun install');
+    // The npm path survives as a branch, but must not be the ONLY install form.
+    expect(yml).toMatch(/if \[ -f pnpm-lock\.yaml \]/);
+  });
+
+  it.each(auditWorkflows)('%s puts the scanner bin dirs on $GITHUB_PATH', (name, install) => {
+    install();
+    const yml = read(name);
+    expect(yml).toContain('GITHUB_PATH');
+    expect(yml).toContain('.local/bin');
+    expect(yml).toContain('go/bin');
+    expect(yml).toContain('.cargo/bin');
   });
 });
 

--- a/test/baseline-anchor.test.ts
+++ b/test/baseline-anchor.test.ts
@@ -20,7 +20,11 @@ import {
   isBaselineAnchor,
 } from '../src/baseline/modes';
 import { classifyEnforcement, type EnforcementState } from '../src/enforcement';
-import { baselineRefreshInstallPlan, installCiBaselineRefresh } from '../src/ship-installers';
+import {
+  baselineRefreshInstallPlan,
+  installCiBaselineRefresh,
+  detectInstalledRefreshTransport,
+} from '../src/ship-installers';
 import { hydrateAnchorFromBranch } from '../src/baseline/anchor';
 
 const PROTECTED: EnforcementState = {
@@ -230,6 +234,30 @@ describe('installCiBaselineRefresh — content per transport (anti-recurrence)',
     // Same transport → installWorkflow skips the existing file, no migration note.
     expect(r.installed).toHaveLength(0);
     expect(r.notes.join('\n')).not.toMatch(/Migrated/);
+  });
+});
+
+describe('detectInstalledRefreshTransport', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-detecttransport-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('returns null when no refresh workflow is installed', () => {
+    expect(detectInstalledRefreshTransport(dir)).toBeNull();
+  });
+  it('classifies each installed variant by its content shape', () => {
+    installCiBaselineRefresh(dir, { baselineMode: 'committed-full', enforcement: UNPROTECTED });
+    expect(detectInstalledRefreshTransport(dir)).toBe('tree');
+    installCiBaselineRefresh(dir, { baselineMode: 'committed-full', enforcement: PROTECTED });
+    expect(detectInstalledRefreshTransport(dir)).toBe('branch');
+    installCiBaselineRefresh(dir, {
+      baselineMode: 'committed-full',
+      enforcement: PROTECTED,
+      policyAnchor: 'cache',
+    });
+    expect(detectInstalledRefreshTransport(dir)).toBe('cache');
   });
 });
 

--- a/test/flow-setup.test.ts
+++ b/test/flow-setup.test.ts
@@ -15,8 +15,10 @@ import {
   servicesFromRoutes,
   detectFlowTopology,
   applyFlowSetup,
+  type FlowDetection,
 } from '../src/analyzers/flow/setup';
-import { readFlowConfig, writeFlowPolicy } from '../src/analyzers/flow/config';
+import { readFlowConfig, writeFlowPolicy, existingFlowMode } from '../src/analyzers/flow/config';
+import { promptFlowSetup } from '../src/prompts';
 import { readWorkspace } from '../src/workspace';
 import type { ClientCall } from '../src/analyzers/flow/extract';
 import type { RouteEndpoint } from '../src/analyzers/flow/extract';
@@ -143,6 +145,95 @@ describe('applyFlowSetup', () => {
     });
     expect(written).toContain('.dxkit/workspace.json');
     expect(readWorkspace(dir)?.participants.map((p) => p.name)).toEqual(['api', 'userserver']);
+  });
+});
+
+describe('existingFlowMode', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-flowexisting-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('returns the explicit posture when the policy sets one', () => {
+    writeFlowPolicy(dir, { mode: 'block' });
+    expect(existingFlowMode(dir)).toBe('block');
+  });
+  it('returns undefined when there is no policy file', () => {
+    expect(existingFlowMode(dir)).toBeUndefined();
+  });
+  it('returns undefined when the policy has no flow block or an invalid mode', () => {
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(
+      join(dir, '.dxkit', 'policy.json'),
+      JSON.stringify({ loop: { preset: 'security-only' } }),
+    );
+    expect(existingFlowMode(dir)).toBeUndefined(); // no flow block
+    writeFileSync(join(dir, '.dxkit', 'policy.json'), JSON.stringify({ flow: { mode: 'bogus' } }));
+    expect(existingFlowMode(dir)).toBeUndefined(); // unknown posture ignored
+  });
+});
+
+describe('promptFlowSetup preserves an evolved posture on a non-interactive re-run', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-flowreinit-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const detection = (suggested: string[] = []): FlowDetection => ({
+    topology: 'monorepo',
+    callCount: 1,
+    routeCount: 1,
+    resolvedCount: 1,
+    suggestedStripPrefixes: suggested,
+    detectedServices: [],
+  });
+
+  it('a fresh --yes setup takes the gentle warn default + detected prefix', async () => {
+    const d = await promptFlowSetup(detection(['${Config.api()}']), {
+      yes: true,
+      forceOn: false,
+      currentMode: existingFlowMode(dir), // undefined — fresh
+    });
+    expect(d.mode).toBe('warn');
+    expect(d.stripUrlPrefixes).toEqual(['${Config.api()}']);
+  });
+
+  it('a --yes re-run keeps a committed flow.mode:block (does not downgrade to warn)', async () => {
+    // This is the exact round-5 repro: init writes warn, the user evolves to
+    // block, an additive re-run must not reset it.
+    writeFlowPolicy(dir, { mode: 'block' });
+    const d = await promptFlowSetup(detection(['${Config.api()}']), {
+      yes: true,
+      forceOn: false,
+      currentMode: existingFlowMode(dir),
+    });
+    applyFlowSetup(dir, d);
+    expect(readFlowConfig(dir).mode).toBe('block'); // preserved
+  });
+
+  it('a --yes re-run leaves an evolved stripUrlPrefixes untouched even when detection suggests one', async () => {
+    writeFlowPolicy(dir, { mode: 'block', stripUrlPrefixes: ['${Config.custom()}'] });
+    const d = await promptFlowSetup(detection(['${Config.detected()}']), {
+      yes: true,
+      forceOn: false,
+      currentMode: existingFlowMode(dir),
+    });
+    applyFlowSetup(dir, d);
+    const cfg = readFlowConfig(dir);
+    expect(cfg.mode).toBe('block');
+    expect(cfg.stripUrlPrefixes).toEqual(['${Config.custom()}']); // not replaced by detection
+  });
+
+  it('forceOn (--flow) also preserves an existing posture rather than forcing warn', async () => {
+    writeFlowPolicy(dir, { mode: 'block' });
+    const d = await promptFlowSetup(detection(), {
+      yes: false,
+      forceOn: true,
+      currentMode: existingFlowMode(dir),
+    });
+    expect(d.mode).toBe('block');
   });
 });
 

--- a/test/lifecycle/roundtrip.test.ts
+++ b/test/lifecycle/roundtrip.test.ts
@@ -157,6 +157,36 @@ describe('install/uninstall round-trip restores the exact pre-dxkit state', () =
   });
 });
 
+describe('re-running init preserves an evolved .dxkit/policy.json (no config clobber)', () => {
+  it('an additive init --yes keeps a committed flow.mode: block', () => {
+    // Round-5 data-loss bug: `init` re-runs flow setup on every invocation and,
+    // under --yes, hard-defaulted flow.mode back to "warn" — silently resetting
+    // a posture the user had committed as "block". policy.json is the exact file
+    // the docs invite tuning, so a re-run must preserve it (or skip), never
+    // regenerate. A flow-capable monorepo (client call + served route) is what
+    // makes init reach the flow-setup step at all.
+    write(repo, 'package.json', JSON.stringify({ name: 'fx', version: '1.0.0' }));
+    write(repo, 'web/List.tsx', "axios.get('/articles');\n");
+    write(repo, 'api/ctrl.ts', "class C { @get('/articles') a() {} }\n");
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'pre-dxkit flow');
+
+    cli(repo, 'init', '--yes');
+    const policyPath = join(repo, '.dxkit', 'policy.json');
+    const p1 = JSON.parse(readFileSync(policyPath, 'utf8')) as { flow?: { mode?: string } };
+    expect(p1.flow?.mode).toBe('warn'); // fresh setup: gentle default
+
+    // The user evolves the posture to block — exactly what the docs tell them to.
+    p1.flow = { ...p1.flow, mode: 'block' };
+    writeFileSync(policyPath, JSON.stringify(p1, null, 2) + '\n');
+
+    // Re-run init with an additive flag (the reviewer's `--with-baseline-refresh`).
+    cli(repo, 'init', '--with-baseline-refresh', '--yes');
+    const p2 = JSON.parse(readFileSync(policyPath, 'utf8')) as { flow?: { mode?: string } };
+    expect(p2.flow?.mode).toBe('block'); // preserved, not clobbered back to warn
+  });
+});
+
 describe('load-bearing activation does not depend on a package-manager hook', () => {
   it('init --with-hooks activates core.hooksPath itself (not via postinstall)', () => {
     write(repo, 'package.json', JSON.stringify({ name: 'hooks', version: '1.0.0' }));

--- a/test/loop/policy.test.ts
+++ b/test/loop/policy.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { DEFAULT_LOOP_PRESET, resolveLoopPolicy, resolveLoopPreset } from '../../src/loop/policy';
+import {
+  DEFAULT_LOOP_PRESET,
+  resolveLoopPolicy,
+  resolveLoopPreset,
+  resolveLoopTestCommand,
+} from '../../src/loop/policy';
 
 function tmpRepo(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-loop-policy-'));
@@ -30,6 +35,34 @@ describe('loop policy presets', () => {
   it('defaults to security-only when nothing is configured', () => {
     expect(resolveLoopPreset(repo)).toBe('security-only');
     expect(DEFAULT_LOOP_PRESET).toBe('security-only');
+  });
+
+  describe('resolveLoopTestCommand precedence', () => {
+    const savedCmd = process.env.DXKIT_LOOP_TEST_COMMAND;
+    afterEach(() => {
+      if (savedCmd === undefined) delete process.env.DXKIT_LOOP_TEST_COMMAND;
+      else process.env.DXKIT_LOOP_TEST_COMMAND = savedCmd;
+    });
+
+    it('is undefined when neither env nor policy sets it', () => {
+      delete process.env.DXKIT_LOOP_TEST_COMMAND;
+      expect(resolveLoopTestCommand(repo)).toBeUndefined();
+    });
+    it('reads the durable policy field when the env var is unset', () => {
+      delete process.env.DXKIT_LOOP_TEST_COMMAND;
+      writePolicy(repo, { loop: { testCommand: 'pnpm test:int' } });
+      expect(resolveLoopTestCommand(repo)).toBe('pnpm test:int');
+    });
+    it('the env var overrides the policy field', () => {
+      writePolicy(repo, { loop: { testCommand: 'pnpm test:int' } });
+      process.env.DXKIT_LOOP_TEST_COMMAND = 'npm test';
+      expect(resolveLoopTestCommand(repo)).toBe('npm test');
+    });
+    it('ignores a blank/whitespace policy value', () => {
+      delete process.env.DXKIT_LOOP_TEST_COMMAND;
+      writePolicy(repo, { loop: { testCommand: '   ' } });
+      expect(resolveLoopTestCommand(repo)).toBeUndefined();
+    });
   });
 
   it('security-only does NOT block test-gap or quality, but DOES block the security class', () => {

--- a/test/tool-paths-ci.test.ts
+++ b/test/tool-paths-ci.test.ts
@@ -1,0 +1,60 @@
+/**
+ * exportToolPathsToGithubEnv — the recipe-safe CI scanner-PATH export.
+ *
+ * In CI, the per-language dep audit must find its NATIVE scanner (osv-scanner,
+ * pip-audit, govulncheck, cargo-audit, …) or it silently falls back to a
+ * wrong-artifact one (npm-audit on a pnpm repo) and drifts from the baseline.
+ * Rather than a hardcoded PATH list in the workflow — which a NEW language pack
+ * would silently outgrow — the export is derived from the SAME sources
+ * `findTool` probes: `getSystemPaths()` + every tool's `probePaths`. These tests
+ * pin that so adding a pack (which already declares its tool's probePaths for
+ * detection) auto-extends CI PATH coverage with no workflow edit.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { exportToolPathsToGithubEnv, TOOL_DEFS } from '../src/analyzers/tools/tool-registry';
+
+describe('exportToolPathsToGithubEnv (CI scanner-PATH, recipe-safe)', () => {
+  const saved = process.env.GITHUB_PATH;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.GITHUB_PATH;
+    else process.env.GITHUB_PATH = saved;
+  });
+
+  it('off CI (no GITHUB_PATH) it is a no-op but still returns the dir list', () => {
+    delete process.env.GITHUB_PATH;
+    expect(exportToolPathsToGithubEnv().length).toBeGreaterThan(0);
+  });
+
+  it('includes EVERY declared tool probePath — a new pack tool is auto-covered', () => {
+    delete process.env.GITHUB_PATH;
+    const dirs = exportToolPathsToGithubEnv();
+    for (const p of Object.values(TOOL_DEFS).flatMap((d) => d.probePaths ?? [])) {
+      expect(dirs).toContain(p);
+    }
+  });
+
+  it('covers each ecosystem bin dir and writes them to $GITHUB_PATH under CI', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-ghpath-'));
+    const file = join(dir, 'gh_path');
+    process.env.GITHUB_PATH = file;
+    try {
+      const dirs = exportToolPathsToGithubEnv();
+      const written = readFileSync(file, 'utf8');
+      // osv-scanner/pip-audit → ~/.local/bin, govulncheck → ~/go/bin,
+      // cargo-audit → ~/.cargo/bin: every native scanner's home is present.
+      for (const suffix of ['.local/bin', 'go/bin', '.cargo/bin']) {
+        expect(
+          dirs.some((d) => d.endsWith(suffix)),
+          `dirs include *${suffix}`,
+        ).toBe(true);
+        expect(written).toContain(suffix);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Why

Round-5 dogfood surfaced a product bug: dxkit's own recommended protection (require the guardrails check + PR review) **breaks dxkit's own baseline-refresh workflow**. The after-merge refresh direct-pushed the recomputed anchor to the default branch with `[skip ci]`; on a protected branch that deadlocks three ways (push rejected → no passing checks → `[skip ci]` guarantees it never earns them). Same root as the reviewer's enforcement-comprehensiveness notes: dxkit reports health it can't back up.

## What

**Protected-main-safe refresh (a new `baseline.anchor` transport).** The deadlock exists only because the anchor lives on the protected branch. Decouple the store:
- **`branch`** (default when protected): refresh direct-pushes the anchor to an unprotected side branch (`anchorRef`, default `dxkit-baselines`); the check hydrates it from there. No push to `main`, no PR, no racy bot PR, seconds-fresh.
- **`cache`** (opt-in): anchor in the Actions cache keyed by base SHA; cold cache → live ref-based fallback. CI-only.
- **`tree`** (unprotected): today's direct push.
- Transport auto-resolves from protection posture, overridable in `.dxkit/policy.json`. `ref-based` installs no refresh.
- **Existing installs auto-migrate** on the next `update`/`init` (only when the transport actually changed).

**Enforcement-path honesty (the reviewer's punch list):**
- `doctor` now warns when the guardrail is **bypassable** (branch takes direct pushes / doesn't require the `dxkit-guardrails` check) — not just whether the workflow exists.
- `vyuh-dxkit protect` — dry-run-by-default helper to require the check + PR review (`--apply` to write). No silent settings writes.
- `loop.testCommand` in `.dxkit/policy.json` (durable) with `DXKIT_LOOP_TEST_COMMAND` as the override.

**Also:** `init` re-runs now preserve an evolved `flow.mode` (round-5 data-loss bug).

## Tests

New: `test/baseline-anchor.test.ts` (transport resolver, enforcement classifier, per-transport install content — a committed+protected repo NEVER gets a direct-push-to-main workflow — auto-migration, hydration fail-open), `resolveLoopTestCommand` precedence, the init `flow.mode` preserve unit + real-CLI lifecycle scenario. Full suite green (3014).

🤖 Generated with [Claude Code](https://claude.com/claude-code)