### PR TITLE
2.33.0 — update-path + real-repo-shape correctness (#10–#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.33.0] - 2026-07-05
+
+The "update-path + real-repo-shape correctness" release. Every fix here closed a
+class that only appears in the seam between dxkit and a real customer repo — a
+GitHub ruleset, a pnpm lockfile, an `update` over user-authored files — shapes
+dxkit's own repo and the unit suite never exercise.
+
+### Fixed — `update` is now provenance-aware (no more no-ops, no more data loss)
+
+`vyuh-dxkit update` decided per file purely on "does it exist?" + `--force`,
+which produced two whole-command failures:
+
+- **It no longer no-ops its own files.** A dxkit-owned file the user hasn't
+  touched is now REFRESHED to the current template, so a shipped fix (a template,
+  a skill, the guardrails workflow, the pre-push hook) actually reaches the repo
+  on a plain `update`. Before, dxkit treated its own unmodified files as
+  "user-evolved, preserve" and never delivered the fix.
+- **`--force` no longer clobbers user files.** A file the user authored (recorded
+  `provenance: 'skipped'`, or never tracked) is preserved even under `--force` —
+  including a project's own `AGENTS.md` / `CLAUDE.md` and a Stop hook in
+  `.claude/settings.json` (`settings.json` / `CLAUDE.md` / `AGENTS.md` are also
+  protected from `--force` overwrite once user-edited). The disposition mirrors
+  `uninstall`'s provenance model (both read the same manifest `provenance` +
+  `hash`), via the shared `decideUpdateDisposition`.
+- Dxkit-managed workflows refresh in place and the pre-push hook no longer
+  self-sidecars as if it were user-authored. Summary text is honest under
+  `--force` (no "pass --force" when already forced).
+
+### Fixed — branch-protection detection is ruleset-aware
+
+Detection read only the classic `/branches/{b}/protection` endpoint, which 404s
+on a branch protected by a repository RULESET (GitHub's current mechanism) — so a
+protected repo read as UNPROTECTED. The fallout: the baseline-refresh anchor
+auto-selected the deadlocking `tree` transport, `doctor` emitted a false
+"BYPASSABLE" (or nothing), and `protect` errored. dxkit now reads BOTH mechanisms
+(classic protection AND `/rules/branches/{b}`) and unions them, in the single
+`classifyEnforcement` source that every consumer already reads. `doctor` prints
+an explicit ✓/not-verified line either way, and `protect` no longer writes a
+classic rule that would conflict with an existing ruleset.
+
+### Fixed — dependency-scanner selection is lockfile-aware
+
+On a pnpm/yarn/bun repo the TypeScript pack ran `npm audit` unconditionally,
+which cannot read a non-npm lockfile — so the dependency dimension collapsed to
+UNMEASURED. Selection now consults the present lockfile (`detectLockfile`) and
+routes a non-npm lockfile to `osv-scanner`, the lockfile-aware path the Java /
+Kotlin / Ruby packs already share. The 2.32 UNMEASURED hint is now reason-aware:
+it says "run `tools install`" only when the scanner is genuinely absent, not when
+it is present but couldn't run.
+
+### Fixed — `upgrade --plan` binary-install step is PM-aware
+
+The plan printed `npm install @vyuhlabs/dxkit@…` on a pnpm/yarn/bun repo; it now
+renders the repo's package manager (`pnpm add -D`, etc.).
+
+### Changed — the real-repo lifecycle net now covers `update`
+
+`test/lifecycle/` exercised install + uninstall but never `update` — the lane
+where the above shipped. It now drives the real CLI end-to-end over an older
+install with user-authored files, asserting dxkit-owned files refresh AND user
+files survive (default and `--force`). Docs: the pnpm release-age note now covers
+the upgrade transition.
+
 ## [2.32.0] - 2026-07-05
 
 ### Added — stack-aware CI (the CI guardrail works for every language)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,9 +57,32 @@ consumer through it (canonical examples added in 2.30):
   explicit-config callers (the two-ref gate, cross-repo publish, the map CLI);
 - benign secret / env conventions → `isPlaceholderSecret` / `isExampleEnvFile`
   (Rule 5's benign module), consulted by BOTH secret detectors.
+- what dxkit OWNS vs what the user owns, for a managed file → the manifest's
+  `provenance` (`created`/`overwritten`/`skipped`) + `hash`. BOTH the update
+  write path (`decideUpdateDisposition` in `src/update-disposition.ts`, consumed
+  by the generator) and `uninstall` (`src/uninstall/`) read them — so `update`
+  refreshes a dxkit-owned unmodified file yet never clobbers a user file, on the
+  same model uninstall uses. The recurring shape here (2.33): a fix landed in
+  uninstall's provenance handling but update decided on "exists?" + `--force`
+  alone, so it no-op'd its own fixes AND `--force` deleted user files. When you
+  touch how a managed file is written or removed, both paths consult the same
+  fields.
+- effective branch protection → `classifyEnforcement` in `src/enforcement.ts`
+  reads BOTH mechanisms (classic `/branches/{b}/protection` AND repository
+  rulesets `/rules/branches/{b}`) and unions them. Reading only one (the class
+  that shipped: a ruleset-protected branch 404s the classic endpoint and read as
+  "unprotected") is the bug — every consumer (`doctor`, the anchor-transport
+  selector, `protect`) reads this one classifier.
+- which dependency scanner can read this repo → `detectLockfile`
+  (`src/package-manager.ts`). A scanner must be pointed at a lockfile it
+  understands (`npm audit` needs an npm lockfile; a pnpm/yarn/bun lockfile routes
+  to the shared lockfile-aware `gatherOsvScannerDepVulnsResult`). Selecting a
+  scanner without consulting the present lockfile is the bug.
 
 `scripts/check-architecture.sh` gates the first two (a second `git ls-files
-.env` or a config-less `gatherFlowModel` on a single-repo surface fails CI).
+.env` or a config-less `gatherFlowModel` on a single-repo surface fails CI). The
+`update` provenance lane is pinned by `test/lifecycle/` (the update lane) and the
+`test/update-disposition.test.ts` branch matrix.
 
 #### The fixture-repo ANALYSIS harness (`test/fixtures-analysis.test.ts`)
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ Existing findings are grandfathered; only findings this change introduced block.
 > `minimumReleaseAge`, a just-published dxkit is blocked until it ages in. Add
 > the package to `minimumReleaseAgeExclude` first so the install resolves — this
 > is your supply-chain policy, so dxkit does not edit that file for you.
+>
+> **Upgrading** on such a repo: keep the exclusion in place across the bump. If
+> you swap a pinned old version for the new one _before_ installing, the stale
+> lockfile entry violates the policy mid-install and can leave `node_modules` on
+> the new version while your manifests still reference the old one (a broken
+> bin). Exclude the package (not a version), run the upgrade, and you're done —
+> no version juggling.
 
 ## Run a local fixture gate
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.32.0",
+      "version": "2.33.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -58,6 +58,24 @@ function isBlocking(p: ClassifiedPair): boolean {
  * Render the check result as a human-readable text block. Returns a
  * single multi-line string; callers route it to stdout.
  */
+/**
+ * The remediation clause for an UNMEASURED dependency dimension — honest about
+ * WHY the scan didn't run. "run tools install" is correct only when the scanner
+ * is genuinely absent; on a scanner that IS present but couldn't run (a missing
+ * lockfile, a runtime failure) it sends the user down the wrong path (the bug:
+ * a present osv-scanner told to "install the scanner"). Branch on the reason.
+ */
+export function depVulnsUnmeasuredRemediation(reason: string): string {
+  const r = reason.toLowerCase();
+  if (/not installed|not present|not found|no scanner/.test(r)) {
+    return 'Run `vyuh-dxkit tools install` so the scanner is present.';
+  }
+  if (/no lockfile|no manifest|generate one/.test(r)) {
+    return 'Generate a lockfile (run your package manager install) so the scanner can resolve dependency versions.';
+  }
+  return 'The scanner is present but did not produce a result — investigate the reason above rather than reinstalling.';
+}
+
 export function renderConsole(result: GuardrailCheckResult): string {
   const lines: string[] = [];
 
@@ -146,8 +164,8 @@ export function renderConsole(result: GuardrailCheckResult): string {
     lines.push('');
     lines.push(
       `  ⚠ Dependency audit UNMEASURED — ${result.depVulnsUnmeasured.reason}. A pass here ` +
-        `does not verify "no net-new dependency vulnerabilities"; run \`vyuh-dxkit tools ` +
-        `install\` so the scanner is present.`,
+        `does not verify "no net-new dependency vulnerabilities". ` +
+        depVulnsUnmeasuredRemediation(result.depVulnsUnmeasured.reason),
     );
   }
   if (result.refExcludedKinds.length > 0) {
@@ -581,8 +599,8 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     lines.push(
       `> ⚠️ **Dependency audit UNMEASURED** — ${result.depVulnsUnmeasured.reason}. ` +
         `A pass here does **not** mean "no net-new dependency vulnerabilities": the scan ` +
-        `could not run, so zero dep findings are unverified. Install the scanner ` +
-        `(\`vyuh-dxkit tools install\`) so the dependency dimension is actually gated.`,
+        `could not run, so zero dep findings are unverified. ` +
+        depVulnsUnmeasuredRemediation(result.depVulnsUnmeasured.reason),
     );
     lines.push('');
   }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -690,8 +690,27 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
     fs.existsSync(path.join(cwd, '.github', 'workflows', 'dxkit-guardrails.yml'))
   ) {
     const enf = detectEnforcement(cwd);
-    if (enf.probed) {
+    if (!enf.probed) {
+      // Print an explicit line so "couldn't verify" is never indistinguishable
+      // from "verified enforced" (the silent-skip bug). Fail-open: an unknown
+      // answer never fails the check — dxkit can't read protection when gh is
+      // absent/unauthenticated or the token lacks repo read scope.
+      checks.push({
+        label: `guardrail enforcement on '${enf.branch}' — not verified (gh unavailable or lacks repo read access)`,
+        ok: true,
+        tier: 'operational',
+      });
+    } else {
       const enforced = enf.directPushBlocked && enf.guardrailRequired;
+      // A repository ruleset (not classic protection) governs the branch: the
+      // guardrail belongs IN the ruleset, so `dxkit protect` (which writes a
+      // classic rule) is the wrong repair — point the user at the ruleset.
+      const rulesetHint = enf.rulesetGoverned && enf.directPushBlocked && !enf.guardrailRequired;
+      const hint = !enf.directPushBlocked
+        ? `'${enf.branch}' takes direct pushes, so commits (and PRs) can land without the guardrail. Protect the branch and require the dxkit-guardrails check.`
+        : rulesetHint
+          ? `'${enf.branch}' is protected by a repository ruleset that does not require the dxkit-guardrails check, so a PR can merge with the guardrail red. Add 'dxkit-guardrails' to that ruleset's required status checks (Settings → Rules → Rulesets).`
+          : `'${enf.branch}' is protected but does not require the dxkit-guardrails check, so a PR can merge with the guardrail red. Add it as a required status check.`;
       checks.push({
         label: enforced
           ? `guardrail enforced on '${enf.branch}' (protected + required check)`
@@ -702,10 +721,10 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
           ? {}
           : {
               fix: {
-                hint: !enf.directPushBlocked
-                  ? `'${enf.branch}' takes direct pushes, so commits (and PRs) can land without the guardrail. Protect the branch and require the dxkit-guardrails check.`
-                  : `'${enf.branch}' is protected but does not require the dxkit-guardrails check, so a PR can merge with the guardrail red. Add it as a required status check.`,
-                command: dxkitCli('protect'),
+                hint,
+                // A ruleset repair is manual (dxkit won't write a conflicting
+                // classic rule), so no auto-command in that case.
+                ...(rulesetHint ? {} : { command: dxkitCli('protect') }),
                 skill: 'dxkit-init',
               },
             }),

--- a/src/enforcement.ts
+++ b/src/enforcement.ts
@@ -12,10 +12,25 @@
  * the push is rejected, and a `[skip ci]` commit can never earn the required
  * checks).
  *
- * Probing shells `gh api` for the branch's protection rule. It is fail-open at
- * every step — a missing / unauthenticated `gh`, no admin scope, or an error
- * yields `probed: false` (unknown), never a throw and never a false "enforced".
- * Results are cached per resolved cwd, mirroring `visibility.ts`.
+ * A branch can be protected by TWO independent GitHub mechanisms, and dxkit
+ * reads BOTH — reading only one is the bug that shipped once (a repository
+ * ruleset protects `main`, dxkit read only the classic endpoint, saw a 404, and
+ * concluded "unprotected" — then auto-selected the direct-push refresh transport
+ * that deadlocks):
+ *   1. CLASSIC branch protection — `repos/{o}/{r}/branches/{b}/protection`
+ *      (404 when no classic rule exists).
+ *   2. Repository RULESETS — `repos/{o}/{r}/rules/branches/{b}` returns the
+ *      effective rules from all rulesets that match the branch (`[]` when none).
+ *      This endpoint does NOT include classic protection, so it is a UNION with
+ *      (1), never a replacement.
+ *
+ * Probing shells `gh api` for each. It is fail-open — a missing / unauthenticated
+ * `gh`, no read scope, or an error on BOTH reads yields `probed: false`
+ * (unknown), never a throw and never a false "enforced". If either mechanism is
+ * successfully read and shows protection, that is a definitive `probed: true`
+ * even when the other read failed (so a non-admin who can read rulesets but not
+ * classic protection still gets a correct answer). Results are cached per
+ * resolved cwd, mirroring `visibility.ts`.
  */
 
 import * as path from 'path';
@@ -25,52 +40,122 @@ import { ghApi, ghCliAvailable, resolveDefaultBranch, GhError } from './setup-gh
  *  require. Kept in sync with `setup-branch-protection.ts`. */
 export const GUARDRAIL_CHECK = 'dxkit-guardrails';
 
-/** Minimal subset of GitHub's branch-protection payload dxkit reads. */
-interface ProtectionPayload {
+/** Minimal subset of GitHub's CLASSIC branch-protection payload dxkit reads. */
+interface ClassicProtection {
   required_status_checks?: { contexts?: string[] } | null;
   required_pull_request_reviews?: unknown | null;
   enforce_admins?: { enabled?: boolean } | boolean | null;
+}
+
+/** Minimal subset of one effective RULESET rule object (from the rules-for-a-
+ *  branch endpoint). Only the fields dxkit classifies on. */
+interface EffectiveRule {
+  type?: string;
+  parameters?: {
+    /** For `required_status_checks` rules — the checks the ruleset requires.
+     *  Note the shape differs from classic (`contexts: string[]`): rulesets nest
+     *  each check as `{ context }`. */
+    required_status_checks?: { context?: string }[] | null;
+  } | null;
+}
+
+/** Raw reads from both protection mechanisms + whether each read succeeded. The
+ *  pure classifier turns this into the enforcement facts. */
+export interface EnforcementReads {
+  /** Classic branch-protection payload, or `null` for "no classic rule" (404). */
+  readonly classic: ClassicProtection | null;
+  /** Did the classic-protection read succeed (a definitive answer, incl. 404)? */
+  readonly classicKnown: boolean;
+  /** Effective ruleset rules matching the branch (`[]` when none apply). */
+  readonly rules: EffectiveRule[];
+  /** Did the ruleset read succeed? */
+  readonly rulesKnown: boolean;
 }
 
 export interface EnforcementState {
   /** The branch probed (the repo's default branch). */
   readonly branch: string;
   /** Whether dxkit could get a definitive answer. `false` when `gh` is
-   *  absent/unauthenticated or the protection read failed (no admin scope,
+   *  absent/unauthenticated or BOTH protection reads failed (no read scope,
    *  network). Consumers must treat `false` as "unknown", never "unprotected". */
   readonly probed: boolean;
-  /** Direct pushes to `branch` are blocked — a protection rule requires a PR
-   *  and/or passing status checks, so a bare `git push` is rejected. */
+  /** Direct pushes to `branch` are blocked — a protection rule (classic OR a
+   *  ruleset) requires a PR and/or passing status checks, so a bare `git push`
+   *  is rejected. */
   readonly directPushBlocked: boolean;
-  /** The `dxkit-guardrails` check is a REQUIRED status check on `branch`, i.e.
-   *  the guardrail actually gates merges rather than running informationally. */
+  /** The `dxkit-guardrails` check is a REQUIRED status check on `branch` (via
+   *  classic protection or a ruleset), i.e. the guardrail actually gates merges
+   *  rather than running informationally. */
   readonly guardrailRequired: boolean;
+  /** A repository RULESET governs `branch` (at least one effective rule). When
+   *  true, `protect` must not create a conflicting classic rule — the guardrail
+   *  belongs in the ruleset. */
+  readonly rulesetGoverned: boolean;
+}
+
+/** Rule types that reject a direct push (mirror of classic requiresChecks ||
+ *  requiresPr). Ref-integrity rules (`non_fast_forward`, `creation`,
+ *  `deletion`) are deliberately excluded — they don't block a normal commit. */
+const PUSH_BLOCKING_RULE_TYPES = new Set(['pull_request', 'required_status_checks']);
+
+function classicBlocksDirectPush(classic: ClassicProtection | null): boolean {
+  if (!classic) return false;
+  const requiresChecks = (classic.required_status_checks?.contexts ?? []).length > 0;
+  const requiresPr = classic.required_pull_request_reviews != null;
+  return requiresChecks || requiresPr;
+}
+
+function classicRequiresGuardrail(classic: ClassicProtection | null): boolean {
+  return (classic?.required_status_checks?.contexts ?? []).includes(GUARDRAIL_CHECK);
+}
+
+function rulesBlockDirectPush(rules: EffectiveRule[]): boolean {
+  return rules.some((r) => r.type != null && PUSH_BLOCKING_RULE_TYPES.has(r.type));
+}
+
+function rulesRequireGuardrail(rules: EffectiveRule[]): boolean {
+  return rules.some(
+    (r) =>
+      r.type === 'required_status_checks' &&
+      (r.parameters?.required_status_checks ?? []).some((c) => c.context === GUARDRAIL_CHECK),
+  );
 }
 
 /**
- * Pure classifier: given a branch's protection payload (or `null` for "no rule")
- * and whether the probe succeeded, decide the enforcement facts. Exported for
+ * Pure classifier: given the raw reads from both protection mechanisms (or
+ * `null` when nothing could be read), decide the enforcement facts. Exported for
  * direct unit testing without shelling to `gh`.
+ *
+ * `probed` is true when we have a trustworthy answer: either a read showed
+ * protection (definitive "enforced"), or BOTH reads succeeded and showed none
+ * (definitive "unprotected"). It is false only when the reads that succeeded
+ * showed nothing AND at least one read failed — we cannot then rule out
+ * protection we couldn't see.
  */
 export function classifyEnforcement(
   branch: string,
-  payload: ProtectionPayload | null,
-  probed: boolean,
+  reads: EnforcementReads | null,
 ): EnforcementState {
-  if (!probed) {
-    return { branch, probed: false, directPushBlocked: false, guardrailRequired: false };
+  if (!reads) {
+    return {
+      branch,
+      probed: false,
+      directPushBlocked: false,
+      guardrailRequired: false,
+      rulesetGoverned: false,
+    };
   }
-  const contexts = payload?.required_status_checks?.contexts ?? [];
-  const requiresChecks = contexts.length > 0;
-  const requiresPr = payload?.required_pull_request_reviews != null;
-  return {
-    branch,
-    probed: true,
-    // Either a required check or a required PR review forces changes through a
-    // gate a raw push cannot satisfy — so a direct push is blocked.
-    directPushBlocked: requiresChecks || requiresPr,
-    guardrailRequired: contexts.includes(GUARDRAIL_CHECK),
-  };
+  const directPushBlocked =
+    classicBlocksDirectPush(reads.classic) || rulesBlockDirectPush(reads.rules);
+  const guardrailRequired =
+    classicRequiresGuardrail(reads.classic) || rulesRequireGuardrail(reads.rules);
+  const rulesetGoverned = reads.rulesKnown && reads.rules.length > 0;
+
+  const sawProtection = directPushBlocked || guardrailRequired || rulesetGoverned;
+  const bothRead = reads.classicKnown && reads.rulesKnown;
+  const probed = sawProtection || bothRead;
+
+  return { branch, probed, directPushBlocked, guardrailRequired, rulesetGoverned };
 }
 
 const CACHE = new Map<string, EnforcementState>();
@@ -81,42 +166,73 @@ export function clearEnforcementCache(): void {
 }
 
 /**
+ * Read both protection mechanisms via `gh api`. Each read is independently
+ * fail-soft: a 404 is a definitive "no rule of this kind"; any other error
+ * leaves that mechanism `*Known: false`. Throws only when `gh` is unavailable or
+ * NEITHER mechanism could be read (a total inability to answer), which the
+ * caller maps to `probed: false`. This is the ONE place both protection
+ * endpoints are shelled — `protect` and `detectEnforcement` both route here.
+ */
+export function probeEnforcementReads(cwd: string, branch: string): EnforcementReads {
+  if (!ghCliAvailable()) throw new GhError('gh unavailable');
+
+  let classic: ClassicProtection | null = null;
+  let classicKnown = false;
+  try {
+    classic = ghApi(`repos/{owner}/{repo}/branches/${branch}/protection`, {
+      cwd,
+      method: 'GET',
+    }) as ClassicProtection;
+    classicKnown = true;
+  } catch (e) {
+    // 404 = no classic protection rule (definitive). Anything else (403 without
+    // admin scope, network) leaves classic unknown.
+    if (e instanceof GhError && e.httpStatus === 404) classicKnown = true;
+  }
+
+  let rules: EffectiveRule[] = [];
+  let rulesKnown = false;
+  try {
+    const raw = ghApi(`repos/{owner}/{repo}/rules/branches/${branch}`, {
+      cwd,
+      method: 'GET',
+    });
+    rules = Array.isArray(raw) ? (raw as EffectiveRule[]) : [];
+    rulesKnown = true;
+  } catch (e) {
+    // The rules endpoint returns `[]` (200) when no ruleset matches; a 404 means
+    // the branch/repo path resolved to nothing — treat as "no ruleset rules".
+    if (e instanceof GhError && e.httpStatus === 404) rulesKnown = true;
+  }
+
+  if (!classicKnown && !rulesKnown) {
+    throw new GhError('could not read branch protection (classic or ruleset)');
+  }
+  return { classic, classicKnown, rules, rulesKnown };
+}
+
+/**
  * Probe how the default branch is protected. Cached per resolved cwd. Fail-open:
  * an inability to answer → `probed: false`. An injected `probe` (for tests)
- * bypasses `gh`; production shells `gh api .../branches/{branch}/protection`.
+ * bypasses `gh`; production reads both classic protection and rulesets.
  */
 export function detectEnforcement(
   cwd: string,
-  opts: { probe?: (cwd: string, branch: string) => ProtectionPayload | null } = {},
+  opts: { probe?: (cwd: string, branch: string) => EnforcementReads } = {},
 ): EnforcementState {
   const key = path.resolve(cwd);
   const cached = CACHE.get(key);
   if (cached) return cached;
 
-  const probeFn =
-    opts.probe ??
-    ((c: string, branch: string): ProtectionPayload | null => {
-      if (!ghCliAvailable()) throw new GhError('gh unavailable');
-      try {
-        return ghApi(`repos/{owner}/{repo}/branches/${branch}/protection`, {
-          cwd: c,
-          method: 'GET',
-        }) as ProtectionPayload;
-      } catch (e) {
-        // 404 = no protection rule (a definitive "unprotected"); anything else
-        // (403 no-admin, network) is genuinely unknown.
-        if (e instanceof GhError && e.httpStatus === 404) return null;
-        throw e;
-      }
-    });
+  const probeFn = opts.probe ?? probeEnforcementReads;
 
   const branch = safeDefaultBranch(cwd);
   let state: EnforcementState;
   try {
-    const payload = probeFn(cwd, branch);
-    state = classifyEnforcement(branch, payload, true);
+    const reads = probeFn(cwd, branch);
+    state = classifyEnforcement(branch, reads);
   } catch {
-    state = classifyEnforcement(branch, null, false);
+    state = classifyEnforcement(branch, null);
   }
   CACHE.set(key, state);
   return state;

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -3,10 +3,19 @@ import * as path from 'path';
 import { ResolvedConfig, GenerationMode, Manifest } from './types';
 import { buildVariables, buildConditions, VERSION } from './constants';
 import { processTemplate } from './template-engine';
-import { writeFile, copyFile, sha256 } from './files';
+import { sha256 } from './files';
 import { activeLanguagesFromStack } from './languages';
 import { dxkitCli } from './self-invocation';
+import { decideUpdateDisposition } from './update-disposition';
 import * as logger from './logger';
+
+/**
+ * Files the user extends rather than owns outright — a full template overwrite
+ * always destroys their additions (a Stop hook in settings.json, project prose
+ * in CLAUDE.md / AGENTS.md). Update refreshes these only while unmodified;
+ * once user-edited they are preserved even under --force.
+ */
+const USER_MERGE_TARGETS = new Set(['.claude/settings.json', 'CLAUDE.md', 'AGENTS.md']);
 
 function getTemplatesDir(): string {
   return path.join(__dirname, '..', 'templates');
@@ -203,52 +212,99 @@ export async function generate(
     },
   };
 
-  const opts = (evolving: boolean) => ({ force, evolving, skipIfExists: !force });
+  // On UPDATE (or a re-init over an existing install) the prior manifest tells
+  // us, per file, whether dxkit owns it and what dxkit last wrote — so we can
+  // REFRESH dxkit-owned files that shipped fixes while NEVER clobbering files
+  // the user owns (the #10 / #11 class). On a fresh init (no prior manifest) we
+  // fall back to the historical skip-if-exists behavior, unchanged.
+  let priorManifest: Manifest | null = null;
+  try {
+    const mp = path.join(targetDir, '.vyuh-dxkit.json');
+    if (fs.existsSync(mp)) priorManifest = JSON.parse(fs.readFileSync(mp, 'utf-8')) as Manifest;
+  } catch {
+    priorManifest = null;
+  }
 
-  function track(
-    outputPath: string,
+  function trackWritten(
+    rel: string,
+    writeResult: 'created' | 'overwritten',
     content: string | null,
-    writeResult: string,
     evolving: boolean,
   ) {
-    const rel = path.relative(targetDir, outputPath);
     if (writeResult === 'created') result.created.push(rel);
-    else if (writeResult === 'skipped') result.skipped.push(rel);
-    else if (writeResult === 'overwritten') result.overwritten.push(rel);
-
-    // Provenance is what uninstall trusts to decide what it may remove. A
-    // SKIPPED file already existed — the user owns it — so we record that fact
-    // and store no hash (the hash would be dxkit's template, not the user's
-    // content, and mistaking one for the other is how --force could delete a
-    // project's own AGENTS.md / CLAUDE.md).
-    const provenance =
-      writeResult === 'created'
-        ? 'created'
-        : writeResult === 'overwritten'
-          ? 'overwritten'
-          : 'skipped';
+    else result.overwritten.push(rel);
     result.manifest.files[rel] = {
-      hash: provenance === 'skipped' ? null : evolving ? null : content ? sha256(content) : null,
+      hash: evolving ? null : content ? sha256(content) : null,
       evolving,
-      provenance,
+      provenance: writeResult,
     };
+  }
+
+  function trackSkipped(rel: string, evolving: boolean) {
+    result.skipped.push(rel);
+    // Carry the prior lineage forward so uninstall still knows what dxkit owns;
+    // an existing file dxkit never tracked becomes a user-owned 'skipped' entry
+    // (never a stored hash — the hash would be dxkit's template, not the user's
+    // content, and mistaking one for the other is how --force deleted a
+    // project's own AGENTS.md / CLAUDE.md before this).
+    result.manifest.files[rel] = priorManifest?.files[rel] ?? {
+      hash: null,
+      evolving,
+      provenance: 'skipped',
+    };
+  }
+
+  /**
+   * Write one managed file, honoring provenance on update. `copyFrom` set → copy
+   * that file; otherwise write `content`. Returns nothing — it tracks the result.
+   */
+  function applyManaged(
+    outputPath: string,
+    content: string,
+    evolving: boolean,
+    copyFrom: string | null,
+  ) {
+    const rel = path.relative(targetDir, outputPath);
+    const exists = fs.existsSync(outputPath);
+
+    const decision =
+      priorManifest === null
+        ? // Fresh init — the historical skip-if-exists semantics, verbatim.
+          exists && (evolving || !force)
+          ? 'skip'
+          : 'write'
+        : decideUpdateDisposition({
+            exists,
+            evolving,
+            priorEntry: priorManifest.files[rel],
+            onDiskHash: () => sha256(fs.readFileSync(outputPath, 'utf-8')),
+            force,
+            userMergeTarget: USER_MERGE_TARGETS.has(rel),
+          });
+
+    if (decision === 'skip') {
+      trackSkipped(rel, evolving);
+      return;
+    }
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    if (copyFrom) fs.copyFileSync(copyFrom, outputPath);
+    else fs.writeFileSync(outputPath, content, 'utf-8');
+    trackWritten(rel, exists ? 'overwritten' : 'created', content || null, evolving);
   }
 
   async function writeTemplate(templatePath: string, outputRel: string, evolving = false) {
     const raw = readTemplate(templatePath);
     const processed = processTemplate(raw, variables, conditions);
-    const outputPath = path.join(targetDir, outputRel);
-    const res = await writeFile(outputPath, processed, opts(evolving));
-    track(outputPath, processed, res, evolving);
+    applyManaged(path.join(targetDir, outputRel), processed, evolving, null);
   }
 
   function copyStatic(templatePath: string, outputRel: string, evolving = false) {
     const srcPath = path.join(templatesDir, templatePath);
     if (!fs.existsSync(srcPath)) return;
-    const outputPath = path.join(targetDir, outputRel);
-    const res = copyFile(srcPath, outputPath, opts(evolving));
-    const content = evolving ? null : fs.readFileSync(srcPath, 'utf-8');
-    track(outputPath, content, res, evolving);
+    // For a non-evolving copy we hash the source content; an evolving copy stores
+    // no hash (pass '' so trackWritten records null).
+    const content = evolving ? '' : fs.readFileSync(srcPath, 'utf-8');
+    applyManaged(path.join(targetDir, outputRel), content, evolving, srcPath);
   }
 
   if (withDxkitAgents) {
@@ -271,9 +327,7 @@ export async function generate(
     // gcloud/pulumi/docker entries that referenced generic skills that
     // no longer ship.
     const settingsContent = buildSettingsJson(config);
-    const settingsPath = path.join(targetDir, '.claude', 'settings.json');
-    const settingsRes = await writeFile(settingsPath, settingsContent, opts(false));
-    track(settingsPath, settingsContent, settingsRes, false);
+    applyManaged(path.join(targetDir, '.claude', 'settings.json'), settingsContent, false, null);
     logger.success('.claude/settings.json');
 
     // The six dxkit-specific skills. Each ships as a single SKILL.md

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -11,6 +11,8 @@ import {
   enrichWithUpgradePlans,
   gatherOsvScannerFixPlans,
 } from '../analyzers/tools/osv-scanner-fix';
+import { gatherOsvScannerDepVulnsResult } from '../analyzers/tools/osv-scanner-deps';
+import { detectLockfile } from '../package-manager';
 import { fileExists, run, runJSON } from '../analyzers/tools/runner';
 import { runTestsWithCoverage } from '../analyzers/tools/run-tests-helper';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
@@ -334,6 +336,43 @@ async function gatherTsDepVulnsResult(
   if (!fileExists(cwd, 'package.json')) {
     return { kind: 'no-manifest', reason: 'no package.json' };
   }
+
+  // Scanner selection is LOCKFILE-AWARE: `npm audit` can only resolve versions
+  // from an npm lockfile (`package-lock.json` / `npm-shrinkwrap.json`). On a
+  // pnpm/yarn/bun repo it errors and emits unparseable output — the dimension
+  // silently collapsed to UNMEASURED before this. So we route by the lockfile
+  // that is actually present: npm lockfile → npm-audit (richest for npm); any
+  // other lockfile → osv-scanner, which reads pnpm-lock.yaml / yarn.lock / bun
+  // natively (the same lockfile-aware path java/kotlin/ruby already use).
+  const lock = detectLockfile(cwd);
+  if (!lock) {
+    return {
+      kind: 'unavailable',
+      reason:
+        'no lockfile to audit (package-lock.json / pnpm-lock.yaml / yarn.lock); ' +
+        'run your package manager install to generate one',
+    };
+  }
+  if (lock.pm !== 'npm') {
+    // osv-scanner's npm ecosystem covers pnpm/yarn/bun lockfiles. Point it at the
+    // detected lockfile only, so a repo with a stray package-lock.json isn't
+    // double-scanned.
+    return gatherOsvScannerDepVulnsResult(cwd, 'typescript', 'npm', [lock.lockfile]);
+  }
+
+  return gatherTsDepVulnsViaNpmAudit(cwd, opts);
+}
+
+/**
+ * npm-audit dep-vuln gathering — the npm-lockfile path of the selector above.
+ * Reached only when a `package-lock.json` / `npm-shrinkwrap.json` is present
+ * (npm audit needs one), so the osv-scanner-fix enrichment's package-lock.json
+ * assumption below holds.
+ */
+async function gatherTsDepVulnsViaNpmAudit(
+  cwd: string,
+  opts?: DepVulnGatherOptions,
+): Promise<DepVulnGatherOutcome> {
   const auditRaw = run('npm audit --json 2>&1', cwd, 60000);
   if (!auditRaw) return { kind: 'unavailable', reason: 'npm audit produced no output' };
   try {

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -49,6 +49,33 @@ export function detectPackageManager(cwd: string): PackageManager {
   return packageManagerField(cwd) ?? 'npm';
 }
 
+/** The lockfile filename(s) each PM writes, most-specific first. One source of
+ *  truth for "the file a lockfile-aware tool should be pointed at" (mirrors the
+ *  detection order in `detectPackageManager`). */
+const LOCKFILES: Record<PackageManager, string[]> = {
+  pnpm: ['pnpm-lock.yaml'],
+  yarn: ['yarn.lock'],
+  bun: ['bun.lock', 'bun.lockb'],
+  npm: ['package-lock.json', 'npm-shrinkwrap.json'],
+};
+
+/**
+ * The lockfile actually present in the repo (first match, PM-priority order),
+ * with the PM that owns it — or null when no lockfile exists. Dependency-scanner
+ * selection consults this so it never runs a scanner against a lockfile it
+ * cannot read (e.g. `npm audit` needs `package-lock.json`; on a pnpm repo the
+ * scanner must instead read `pnpm-lock.yaml`).
+ */
+export function detectLockfile(cwd: string): { pm: PackageManager; lockfile: string } | null {
+  const order: PackageManager[] = ['pnpm', 'yarn', 'bun', 'npm'];
+  for (const pm of order) {
+    for (const f of LOCKFILES[pm]) {
+      if (existsSync(join(cwd, f))) return { pm, lockfile: f };
+    }
+  }
+  return null;
+}
+
 /** The command PREFIX that adds a dev dependency with the given PM (no package
  *  yet). `npm install --save-dev` is the token dxkit historically hardcoded, so
  *  it is also the substring other install strings are rewritten from. */

--- a/src/setup-branch-protection.ts
+++ b/src/setup-branch-protection.ts
@@ -35,6 +35,7 @@ import {
   resolveDefaultBranch,
   resolveOwnerRepo,
 } from './setup-gh';
+import { classifyEnforcement, probeEnforcementReads, GUARDRAIL_CHECK } from './enforcement';
 
 export interface SetupBranchProtectionOpts {
   /** Branch to protect. Defaults to the repo's default branch. */
@@ -64,7 +65,7 @@ interface ProtectionPayload {
   restrictions: null;
 }
 
-const REQUIRED_CHECK = 'dxkit-guardrails';
+const REQUIRED_CHECK = GUARDRAIL_CHECK;
 
 function readExistingProtection(
   cwd: string,
@@ -163,6 +164,36 @@ export async function runSetupBranchProtection(
     logger.dim(`  → Run \`${dxkitCli('init --with-ci --yes')}\` first to scaffold the workflow.`);
     process.exitCode = 1;
     return;
+  }
+
+  // Read the branch's EFFECTIVE enforcement first (classic protection AND
+  // repository rulesets). Two things depend on it:
+  //   - if the guardrail is already required, there's nothing to do;
+  //   - if a RULESET governs the branch, dxkit must not write a conflicting
+  //     classic protection rule — the check belongs in the ruleset, which dxkit
+  //     won't silently rewrite. Point the user at it instead.
+  try {
+    const state = classifyEnforcement(branch, probeEnforcementReads(cwd, branch));
+    if (state.guardrailRequired) {
+      logger.success(
+        `${owner}/${repo}#${branch} already requires the ${REQUIRED_CHECK} check — nothing to do.`,
+      );
+      return;
+    }
+    if (state.rulesetGoverned) {
+      console.log(''); // slop-ok
+      logger.warn(`${owner}/${repo}#${branch} is governed by a repository ruleset.`);
+      logger.dim(
+        `  → dxkit will not create a conflicting classic branch-protection rule alongside it.`,
+      );
+      logger.dim(`  → Add '${REQUIRED_CHECK}' to that ruleset's required status checks:`);
+      logger.dim(`     https://github.com/${owner}/${repo}/settings/rules`);
+      return;
+    }
+  } catch (e) {
+    // Fail-open: if we couldn't read enforcement (gh error, no scope), fall
+    // through to the classic path below, which does its own guarded read.
+    if (!(e instanceof GhError)) throw e;
   }
 
   logger.info(`Resolving existing protection on ${owner}/${repo}#${branch}...`);

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -248,11 +248,26 @@ export function installHooks(cwd: string, opts: InstallerOpts = {}): ShipInstall
   for (const { name } of hookNames) {
     const destAbs = path.join(destDir, name);
     const huskyAbs = path.join(cwd, '.husky', name);
-    const conflict = fs.existsSync(destAbs) || fs.existsSync(huskyAbs);
-    if (conflict) anyConflict = true;
+
+    // dxkit's OWN hook (marker in the template header) is not a conflict — it's
+    // ours to REFRESH on update. Before this it self-sidecar'd, so a template
+    // fix never reached the installed hook (#10). A genuine USER hook — a husky
+    // hook, or a non-dxkit hook at .githooks/<name> — is the real conflict and
+    // must be preserved via a sidecar.
+    const destExists = fs.existsSync(destAbs);
+    let destIsDxkit = false;
+    if (destExists) {
+      try {
+        destIsDxkit = fs.readFileSync(destAbs, 'utf8').includes(`dxkit ${name} hook`);
+      } catch {
+        destIsDxkit = false;
+      }
+    }
+    const userConflict = fs.existsSync(huskyAbs) || (destExists && !destIsDxkit);
+    if (userConflict) anyConflict = true;
 
     const srcAbs = path.join(tmplDir, name);
-    if (conflict && !opts.force) {
+    if (userConflict && !opts.force) {
       // Always land the dxkit hook at .githooks/<name>.dxkit when
       // there's a conflict, even when the conflict is at a different
       // path (husky). The sidecar is the same regardless of where the
@@ -377,9 +392,17 @@ export function installDevcontainer(cwd: string, opts: InstallerOpts = {}): Ship
     { name: 'install-agent-clis.sh', executable: true },
   ];
 
-  const hasExistingDevcontainer = fs.existsSync(path.join(destDir, 'devcontainer.json'));
+  const devcontainerPath = path.join(destDir, 'devcontainer.json');
+  const hasExistingDevcontainer = fs.existsSync(devcontainerPath);
+  // A devcontainer.json the USER authored (no dxkit marker) is never clobbered —
+  // not even under --force (the #11 data-loss class: --force replaced a project's
+  // own .devcontainer). dxkit's OWN devcontainer (marker present) still refreshes
+  // under --force. When dxkit sidecar'd at install time (the user already had
+  // one), the canonical path is theirs, so this correctly keeps sidecaring.
+  const existingIsUserOwned =
+    hasExistingDevcontainer && !isDxkitManagedDevcontainer(readFileSafe(devcontainerPath));
 
-  if (hasExistingDevcontainer && !opts.force) {
+  if (hasExistingDevcontainer && (!opts.force || existingIsUserOwned)) {
     // Stash the whole dxkit set under a reference dir so the
     // consumer can read it without it interfering with their own.
     // The reference devcontainer.json is rendered with the
@@ -440,6 +463,33 @@ export function installDevcontainer(cwd: string, opts: InstallerOpts = {}): Ship
  * uses this for the consumer's default branch name; the PR-gate
  * workflow ships verbatim.
  */
+/**
+ * Is the workflow already on disk one dxkit MANAGES (vs a same-named file the
+ * user authored)? A dxkit-managed workflow is refreshed to the current template
+ * on `update` — that is what delivers template fixes (the #10 class: `update`
+ * used to treat its OWN unmodified workflow as "preserve" and never ship the
+ * fix). The heuristic recognizes existing installs without a migration: every
+ * dxkit workflow either names itself `dxkit …` or invokes the `vyuh-dxkit` CLI.
+ */
+function isDxkitManagedWorkflow(content: string): boolean {
+  return /^name:\s*dxkit\b/im.test(content) || content.includes('vyuh-dxkit');
+}
+
+/** Read a file, returning '' on any error (used only for ownership sniffing). */
+function readFileSafe(abs: string): string {
+  try {
+    return fs.readFileSync(abs, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+/** Is this devcontainer.json one dxkit generated (vs the user's own)? dxkit's
+ *  carries `"name": "dxkit dev environment"` and invokes `vyuh-dxkit`. */
+function isDxkitManagedDevcontainer(content: string): boolean {
+  return content.includes('dxkit dev environment') || content.includes('vyuh-dxkit');
+}
+
 function installWorkflow(
   cwd: string,
   fileName: string,
@@ -450,23 +500,34 @@ function installWorkflow(
   const result = emptyResult();
   const srcAbs = path.join(templatesDir(), '.github', 'workflows', fileName);
   const destAbs = path.join(cwd, '.github', 'workflows', destName);
+  const rel = path.relative(cwd, destAbs);
 
-  if (fs.existsSync(destAbs) && !opts.force) {
-    result.skipped.push(path.relative(cwd, destAbs));
-    return result;
+  // Render the final content first, so we can no-op when it already matches and
+  // decide ownership from what's actually on disk.
+  let content = fs.readFileSync(srcAbs, 'utf8');
+  for (const [key, value] of Object.entries(substitutions)) {
+    content = content.split(key).join(value);
+  }
+
+  if (fs.existsSync(destAbs)) {
+    const existing = fs.readFileSync(destAbs, 'utf8');
+    if (existing === content) {
+      // Already current — a no-op, not a spurious "updated".
+      result.skipped.push(rel);
+      return result;
+    }
+    // A dxkit-managed workflow is refreshed with the new template (that IS the
+    // point of update). A file the user put at this path is preserved unless
+    // --force explicitly re-applies.
+    if (!isDxkitManagedWorkflow(existing) && !opts.force) {
+      result.skipped.push(rel);
+      return result;
+    }
   }
 
   fs.mkdirSync(path.dirname(destAbs), { recursive: true });
-  if (Object.keys(substitutions).length === 0) {
-    fs.copyFileSync(srcAbs, destAbs);
-  } else {
-    let content = fs.readFileSync(srcAbs, 'utf8');
-    for (const [key, value] of Object.entries(substitutions)) {
-      content = content.split(key).join(value);
-    }
-    fs.writeFileSync(destAbs, content, 'utf8');
-  }
-  result.installed.push(path.relative(cwd, destAbs));
+  fs.writeFileSync(destAbs, content, 'utf8');
+  result.installed.push(rel);
   return result;
 }
 

--- a/src/update-disposition.ts
+++ b/src/update-disposition.ts
@@ -1,0 +1,68 @@
+/**
+ * The per-file disposition `update` (and a re-init over an existing dxkit
+ * install) uses to decide, for each managed file, whether to WRITE the shipped
+ * template or SKIP and preserve what's on disk.
+ *
+ * This is the update-side mirror of `uninstall`'s provenance model (2.27): both
+ * paths must agree on what dxkit owns vs what the user owns, read from the same
+ * manifest fields (`provenance` + `hash`). Before this, update decided purely on
+ * "does the file exist?" + `--force`, which produced two shipped bugs:
+ *   - #10: dxkit's OWN unmodified files (skills, workflows) were treated as
+ *     "user-evolved, preserve", so a fixed template in a new version was never
+ *     delivered — update no-op'd the very files it exists to refresh.
+ *   - #11: `--force` overwrote user-authored files (a project's own AGENTS.md /
+ *     CLAUDE.md / a Stop hook in settings.json) — the manifest already recorded
+ *     them as `provenance: 'skipped'` (user-owned), but the write path never
+ *     read it.
+ *
+ * The rules:
+ *   - absent on disk           → WRITE (re)create the dxkit-owned/new file
+ *   - evolving (user prose)    → SKIP, never overwrite
+ *   - untracked + present      → SKIP, the user owns a file dxkit never wrote
+ *   - provenance 'skipped'     → SKIP even with --force, the user owned it at
+ *                                install time
+ *   - dxkit-owned, unmodified  → WRITE (refresh — this delivers shipped fixes)
+ *   - dxkit-owned, user-edited → SKIP unless --force re-applies the template;
+ *                                for a user-merge target (settings.json /
+ *                                CLAUDE.md / AGENTS.md — files the user extends
+ *                                and a full overwrite always loses their part)
+ *                                SKIP even under --force.
+ */
+
+import type { ManifestFileEntry } from './types';
+
+export type UpdateDecision = 'write' | 'skip';
+
+export interface UpdateDispositionInput {
+  /** The file exists on disk right now. */
+  exists: boolean;
+  /** An "evolving" user-maintained file (gotchas / conventions) — never
+   *  overwritten once it exists. */
+  evolving: boolean;
+  /** The prior manifest entry for this path, or `undefined` when dxkit never
+   *  tracked it (a file the user owns). */
+  priorEntry: ManifestFileEntry | undefined;
+  /** Lazily-computed sha256 of the current on-disk content. A thunk so we don't
+   *  read a file we're going to write regardless. */
+  onDiskHash: () => string;
+  /** `--force` was passed. */
+  force: boolean;
+  /** A user-merge / prose target (settings.json, CLAUDE.md, AGENTS.md): a full
+   *  template overwrite always destroys the user's additions, so a user-edited
+   *  one is preserved even under --force. */
+  userMergeTarget?: boolean;
+}
+
+export function decideUpdateDisposition(input: UpdateDispositionInput): UpdateDecision {
+  const { exists, evolving, priorEntry, onDiskHash, force, userMergeTarget } = input;
+  if (!exists) return 'write';
+  if (evolving) return 'skip';
+  if (!priorEntry) return 'skip';
+  if (priorEntry.provenance === 'skipped') return 'skip';
+  // dxkit-owned (created / overwritten). Refresh only when the on-disk content
+  // still matches what dxkit last wrote — otherwise the user edited a dxkit
+  // file.
+  if (priorEntry.hash && onDiskHash() === priorEntry.hash) return 'write';
+  if (userMergeTarget) return 'skip';
+  return force ? 'write' : 'skip';
+}

--- a/src/update.ts
+++ b/src/update.ts
@@ -275,7 +275,9 @@ export async function runUpdate(cwd: string, force: boolean, rescan = false): Pr
   }
   if (aggregate.skipped.length) {
     logger.warn(
-      `Skipped: ${aggregate.skipped.length} file(s) (preserved — pass --force to overwrite)`,
+      force
+        ? `Skipped: ${aggregate.skipped.length} file(s) (preserved — these are yours; --force re-applies dxkit-owned templates but never overwrites user-authored files)`
+        : `Skipped: ${aggregate.skipped.length} file(s) (preserved — pass --force to re-apply dxkit-owned templates you've edited)`,
     );
   }
   for (const note of aggregate.notes) logger.dim(note);
@@ -290,7 +292,7 @@ export async function runUpdate(cwd: string, force: boolean, rescan = false): Pr
   await migrateIdentityIfStale(cwd);
 
   console.log(''); // slop-ok
-  logger.success('Update complete. Evolved files (gotchas, conventions) preserved.');
+  logger.success('Update complete. dxkit-owned files refreshed; your files preserved.');
 }
 
 /**

--- a/src/upgrade.ts
+++ b/src/upgrade.ts
@@ -25,6 +25,7 @@ import * as path from 'path';
 import { execSync, spawnSync } from 'child_process';
 import { Manifest } from './types';
 import { dxkitCli } from './self-invocation';
+import { detectPackageManager, addDevCommand } from './package-manager';
 import * as logger from './logger';
 
 export type DeltaKind = 'none' | 'patch' | 'minor' | 'major' | 'downgrade';
@@ -178,7 +179,10 @@ export function buildUpgradePlan(cwd: string, opts: UpgradeOpts = {}): UpgradePl
   if (delta !== 'none' || (scaffold && binary && scaffold !== binary)) {
     if (latest) {
       steps.push({
-        command: `npm install @vyuhlabs/dxkit@${latest}`,
+        // dxkit is a devDependency — the install command must match the repo's
+        // package manager (a raw `npm install` fails / mis-resolves on a
+        // pnpm/yarn/bun repo).
+        command: addDevCommand(detectPackageManager(cwd), `@vyuhlabs/dxkit@${latest}`),
         purpose: `Install dxkit binary ${binary ?? '(missing)'} → ${latest}`,
       });
     }

--- a/test/baseline-anchor.test.ts
+++ b/test/baseline-anchor.test.ts
@@ -19,7 +19,13 @@ import {
   DEFAULT_ANCHOR_REF,
   isBaselineAnchor,
 } from '../src/baseline/modes';
-import { classifyEnforcement, type EnforcementState } from '../src/enforcement';
+import {
+  classifyEnforcement,
+  detectEnforcement,
+  clearEnforcementCache,
+  type EnforcementState,
+  type EnforcementReads,
+} from '../src/enforcement';
 import {
   baselineRefreshInstallPlan,
   installCiBaselineRefresh,
@@ -33,18 +39,21 @@ const PROTECTED: EnforcementState = {
   probed: true,
   directPushBlocked: true,
   guardrailRequired: true,
+  rulesetGoverned: false,
 };
 const UNPROTECTED: EnforcementState = {
   branch: 'main',
   probed: true,
   directPushBlocked: false,
   guardrailRequired: false,
+  rulesetGoverned: false,
 };
 const UNKNOWN: EnforcementState = {
   branch: 'main',
   probed: false,
   directPushBlocked: false,
   guardrailRequired: false,
+  rulesetGoverned: false,
 };
 
 describe('resolveAnchorTransport', () => {
@@ -91,31 +100,133 @@ describe('isBaselineAnchor', () => {
 });
 
 describe('classifyEnforcement', () => {
-  it('an unprobed answer is "unknown", never a false "unprotected"', () => {
-    const s = classifyEnforcement('main', null, false);
+  const reads = (r: Partial<EnforcementReads>): EnforcementReads => ({
+    classic: null,
+    classicKnown: true,
+    rules: [],
+    rulesKnown: true,
+    ...r,
+  });
+
+  it('nothing readable → "unknown", never a false "unprotected"', () => {
+    const s = classifyEnforcement('main', null);
     expect(s.probed).toBe(false);
     expect(s.directPushBlocked).toBe(false);
     expect(s.guardrailRequired).toBe(false);
+    expect(s.rulesetGoverned).toBe(false);
   });
-  it('no protection rule (404 → null) → not blocked, guardrail not required', () => {
-    const s = classifyEnforcement('main', null, true);
+  it('both mechanisms read, neither protects → confidently unprotected', () => {
+    const s = classifyEnforcement('main', reads({}));
     expect(s.probed).toBe(true);
     expect(s.directPushBlocked).toBe(false);
     expect(s.guardrailRequired).toBe(false);
+    expect(s.rulesetGoverned).toBe(false);
   });
-  it('required status checks block direct pushes; dxkit-guardrails presence is detected', () => {
+
+  // Classic branch protection
+  it('classic required status checks block direct pushes; dxkit-guardrails is detected', () => {
     const s = classifyEnforcement(
       'main',
-      { required_status_checks: { contexts: ['dxkit-guardrails', 'build'] } },
-      true,
+      reads({ classic: { required_status_checks: { contexts: ['dxkit-guardrails', 'build'] } } }),
     );
     expect(s.directPushBlocked).toBe(true);
     expect(s.guardrailRequired).toBe(true);
+    expect(s.rulesetGoverned).toBe(false);
   });
-  it('a required PR review alone blocks direct pushes (guardrail may still be absent)', () => {
-    const s = classifyEnforcement('main', { required_pull_request_reviews: {} }, true);
+  it('a classic required PR review alone blocks direct pushes (guardrail may be absent)', () => {
+    const s = classifyEnforcement(
+      'main',
+      reads({ classic: { required_pull_request_reviews: {} } }),
+    );
     expect(s.directPushBlocked).toBe(true);
     expect(s.guardrailRequired).toBe(false);
+  });
+
+  // Repository RULESETS — the ruleset-blind bug (#12). A ruleset-protected repo
+  // 404s the classic endpoint (classic: null) but the rules endpoint sees it.
+  it('a ruleset pull_request rule blocks direct pushes and marks the branch ruleset-governed', () => {
+    const s = classifyEnforcement(
+      'main',
+      reads({ classic: null, rules: [{ type: 'pull_request' }] }),
+    );
+    expect(s.probed).toBe(true);
+    expect(s.directPushBlocked).toBe(true);
+    expect(s.guardrailRequired).toBe(false);
+    expect(s.rulesetGoverned).toBe(true);
+  });
+  it('a ruleset required_status_checks rule detects the dxkit-guardrails context (nested shape)', () => {
+    const s = classifyEnforcement(
+      'main',
+      reads({
+        classic: null,
+        rules: [
+          {
+            type: 'required_status_checks',
+            parameters: { required_status_checks: [{ context: 'dxkit-guardrails' }] },
+          },
+        ],
+      }),
+    );
+    expect(s.directPushBlocked).toBe(true);
+    expect(s.guardrailRequired).toBe(true);
+    expect(s.rulesetGoverned).toBe(true);
+  });
+  it('ref-integrity-only ruleset rules (non_fast_forward) do NOT count as a push block', () => {
+    const s = classifyEnforcement('main', reads({ rules: [{ type: 'non_fast_forward' }] }));
+    expect(s.directPushBlocked).toBe(false);
+    // still ruleset-governed — protect must not fight it
+    expect(s.rulesetGoverned).toBe(true);
+    expect(s.probed).toBe(true);
+  });
+
+  // Partial reads — a non-admin can read rulesets but not classic protection.
+  it('a blocking ruleset with classic unread is still a definitive "protected"', () => {
+    const s = classifyEnforcement('main', {
+      classic: null,
+      classicKnown: false,
+      rules: [{ type: 'pull_request' }],
+      rulesKnown: true,
+    });
+    expect(s.probed).toBe(true);
+    expect(s.directPushBlocked).toBe(true);
+  });
+  it('no protection seen but a mechanism was unreadable → unknown, not "unprotected"', () => {
+    const s = classifyEnforcement('main', {
+      classic: null,
+      classicKnown: true,
+      rules: [],
+      rulesKnown: false,
+    });
+    expect(s.probed).toBe(false);
+    expect(s.directPushBlocked).toBe(false);
+  });
+});
+
+describe('detectEnforcement (probe wiring + fail-open)', () => {
+  beforeEach(() => clearEnforcementCache());
+  afterEach(() => clearEnforcementCache());
+
+  it('routes an injected probe through the classifier', () => {
+    const s = detectEnforcement(join(tmpdir(), 'dxkit-enf-a'), {
+      probe: () => ({
+        classic: null,
+        classicKnown: true,
+        rules: [{ type: 'pull_request' }],
+        rulesKnown: true,
+      }),
+    });
+    expect(s.directPushBlocked).toBe(true);
+    expect(s.rulesetGoverned).toBe(true);
+  });
+
+  it('a throwing probe fails open to unknown (never a false "unprotected")', () => {
+    const s = detectEnforcement(join(tmpdir(), 'dxkit-enf-b'), {
+      probe: () => {
+        throw new Error('gh boom');
+      },
+    });
+    expect(s.probed).toBe(false);
+    expect(s.directPushBlocked).toBe(false);
   });
 });
 

--- a/test/baseline/check.test.ts
+++ b/test/baseline/check.test.ts
@@ -71,6 +71,29 @@ describe('runGuardrailCheck (integration)', () => {
       expect(renderJson(base).depVulnsUnmeasured).toBeUndefined();
     });
 
+    it('UNMEASURED remediation is reason-aware — absent vs present-but-unusable (#15)', async () => {
+      await createBaseline({ cwd: dir });
+      const base = await runGuardrailCheck({ cwd: dir });
+
+      // Scanner genuinely absent → "tools install" is the right fix.
+      const absent = { ...base, depVulnsUnmeasured: { reason: 'osv-scanner not installed' } };
+      expect(renderConsole(absent)).toContain('tools install');
+      expect(renderMarkdown(absent)).toContain('tools install');
+
+      // Scanner PRESENT but the repo has no lockfile → don't tell the user to
+      // reinstall; tell them to generate a lockfile.
+      const noLock = {
+        ...base,
+        depVulnsUnmeasured: { reason: 'no lockfile to audit (package-lock.json / pnpm-lock.yaml)' },
+      };
+      expect(renderConsole(noLock)).not.toContain('tools install');
+      expect(renderConsole(noLock).toLowerCase()).toContain('lockfile');
+
+      // Scanner ran and failed at runtime → not an install problem either.
+      const failed = { ...base, depVulnsUnmeasured: { reason: 'npm audit parse error: boom' } };
+      expect(renderConsole(failed)).not.toContain('tools install');
+    });
+
     it('reports no changes, then detects a new stale-file across check + renderers + explicit --baseline path', async () => {
       // Step 1: clean repo. Baseline + immediate check should
       // report no per-finding changes and no envelope drift —

--- a/test/languages-typescript.test.ts
+++ b/test/languages-typescript.test.ts
@@ -30,6 +30,28 @@ describe('typescript.detect', () => {
   });
 });
 
+describe('typescript depVulns — lockfile-aware scanner selection (#15)', () => {
+  const depVulns = typescript.capabilities!.depVulns!;
+
+  it('no package.json → no-manifest', async () => {
+    const out = await depVulns.gatherOutcome!(tmp);
+    expect(out.kind).toBe('no-manifest');
+  });
+
+  it('package.json but NO lockfile → unavailable with a lockfile hint, never an npm-audit run', async () => {
+    // The pre-fix path ran `npm audit` unconditionally and collapsed to a parse
+    // error. Now selection routes on the present lockfile: none → an honest
+    // "generate a lockfile", not a misleading npm-audit failure.
+    fs.writeFileSync(path.join(tmp, 'package.json'), '{"name":"x"}');
+    const out = await depVulns.gatherOutcome!(tmp);
+    expect(out.kind).toBe('unavailable');
+    if (out.kind === 'unavailable') {
+      expect(out.reason).toMatch(/no lockfile/i);
+      expect(out.reason).not.toMatch(/npm audit/i);
+    }
+  });
+});
+
 describe('extractTsImportsRaw', () => {
   const run = extractTsImportsRaw;
 

--- a/test/lifecycle/roundtrip.test.ts
+++ b/test/lifecycle/roundtrip.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'child_process';
+import { createHash } from 'crypto';
 import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -199,5 +200,82 @@ describe('load-bearing activation does not depend on a package-manager hook', ()
     cli(repo, 'init', '--with-hooks', '--yes');
     const hooksPath = git(repo, 'config', '--local', '--get', 'core.hooksPath').trim();
     expect(hooksPath).toBe('.githooks');
+  });
+});
+
+/**
+ * The UPDATE lane (2.33.0) — the untested seam. The install/uninstall lanes
+ * above never exercised `update`, the most-run command in a customer's life, so
+ * two whole-command failures shipped: update NO-OP'd its own dxkit-owned files
+ * (never delivering template fixes — #10) and --force CLOBBERED user-authored
+ * files (data loss — #11). These run the real CLI end-to-end and pin both halves
+ * on a real repo, the same way the round-trip pins uninstall.
+ */
+describe('update refreshes dxkit-owned files but never clobbers user files', () => {
+  const sha256 = (s: string): string => createHash('sha256').update(s, 'utf-8').digest('hex');
+
+  it('#10: a dxkit-owned, UNMODIFIED file is refreshed to the current template (not skipped)', () => {
+    write(repo, 'package.json', JSON.stringify({ name: 'upd', version: '1.0.0' }));
+    write(repo, 'src/index.ts', 'export const x = 1;\n');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'pre-dxkit');
+
+    cli(repo, 'init', '--full', '--yes');
+
+    // Simulate an OLDER install: a dxkit skill sits at a stale version the user
+    // never touched — on-disk content matches the manifest hash (dxkit owns it,
+    // unmodified), but differs from the template this dxkit version ships.
+    const skillRel = '.claude/skills/dxkit-learn/SKILL.md';
+    const skillAbs = join(repo, skillRel);
+    expect(existsSync(skillAbs)).toBe(true);
+    const STALE = '# stale dxkit-learn skill (older version)\n';
+    writeFileSync(skillAbs, STALE);
+    const mPath = join(repo, '.vyuh-dxkit.json');
+    const m = JSON.parse(readFileSync(mPath, 'utf8')) as {
+      files: Record<string, { hash: string | null; evolving: boolean; provenance: string }>;
+    };
+    m.files[skillRel] = { hash: sha256(STALE), evolving: false, provenance: 'created' };
+    writeFileSync(mPath, JSON.stringify(m, null, 2) + '\n');
+
+    // A DEFAULT update (no --force) must deliver the fix — this is the whole
+    // point of update, and exactly what #10 reported broken.
+    cli(repo, 'update');
+    expect(readFileSync(skillAbs, 'utf8')).not.toBe(STALE);
+  });
+
+  it('#10: a dxkit-managed workflow refreshes and the pre-push hook does NOT self-sidecar', () => {
+    write(repo, 'package.json', JSON.stringify({ name: 'upd2', version: '1.0.0' }));
+    write(repo, 'src/index.ts', 'export const x = 1;\n');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'pre-dxkit');
+
+    cli(repo, 'init', '--full', '--yes');
+
+    const wfAbs = join(repo, '.github/workflows/dxkit-guardrails.yml');
+    expect(existsSync(wfAbs)).toBe(true);
+    // A stale-but-dxkit-marked workflow (a real prior install keeps its marker).
+    writeFileSync(wfAbs, 'name: dxkit guardrails\n# STALE-MARKER\n');
+
+    cli(repo, 'update');
+
+    // Refreshed to the current template — the stale marker is gone.
+    expect(readFileSync(wfAbs, 'utf8')).not.toContain('STALE-MARKER');
+    // And dxkit's own pre-push hook was refreshed in place, not sidecar'd as if
+    // it were a user hook.
+    expect(existsSync(join(repo, '.githooks/pre-push'))).toBe(true);
+    expect(existsSync(join(repo, '.githooks/pre-push.dxkit'))).toBe(false);
+  });
+
+  it('#11: update --force NEVER overwrites a user-authored AGENTS.md', () => {
+    const agents = '# My Project\n\nProject-authored guidance the user maintains.\n';
+    write(repo, 'AGENTS.md', agents);
+    write(repo, 'package.json', JSON.stringify({ name: 'upd3', version: '1.0.0' }));
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'pre-dxkit brownfield');
+
+    cli(repo, 'init', '--full', '--yes'); // dxkit skips AGENTS.md → provenance 'skipped'
+    cli(repo, 'update', '--force'); // the reported data-loss trigger
+
+    expect(readFileSync(join(repo, 'AGENTS.md'), 'utf8')).toBe(agents);
   });
 });

--- a/test/package-manager.test.ts
+++ b/test/package-manager.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   detectPackageManager,
+  detectLockfile,
   addDevPrefix,
   addDevCommand,
   provisionCommand,
@@ -37,6 +38,44 @@ describe('detectPackageManager', () => {
     writeFileSync(join(dir, 'pnpm-lock.yaml'), '');
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ packageManager: 'yarn@4.0.0' }));
     expect(detectPackageManager(dir)).toBe('pnpm');
+  });
+});
+
+describe('detectLockfile (dep-scanner selection input, #15)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-lock-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('returns null when no lockfile is present (package.json alone is not enough to audit)', () => {
+    writeFileSync(join(dir, 'package.json'), '{"name":"x"}');
+    expect(detectLockfile(dir)).toBeNull();
+  });
+
+  it('reports the present lockfile and its owning PM', () => {
+    const cases: Array<[string, string]> = [
+      ['pnpm-lock.yaml', 'pnpm'],
+      ['yarn.lock', 'yarn'],
+      ['bun.lock', 'bun'],
+      ['package-lock.json', 'npm'],
+      ['npm-shrinkwrap.json', 'npm'],
+    ];
+    for (const [lockfile, pm] of cases) {
+      const d = mkdtempSync(join(tmpdir(), 'dxkit-lock-'));
+      writeFileSync(join(d, lockfile), '');
+      expect(detectLockfile(d), lockfile).toEqual({ pm, lockfile });
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it('a pnpm lockfile is selected even when a stray package-lock.json also exists', () => {
+    // The bug's shape: both lockfiles present, both scanners "found". Selection
+    // must pick the PM that actually provisioned the repo, so the scanner reads
+    // a lockfile it understands.
+    writeFileSync(join(dir, 'pnpm-lock.yaml'), '');
+    writeFileSync(join(dir, 'package-lock.json'), '');
+    expect(detectLockfile(dir)).toEqual({ pm: 'pnpm', lockfile: 'pnpm-lock.yaml' });
   });
 
   it('falls back to the packageManager field when no lockfile', () => {

--- a/test/ship-installers.test.ts
+++ b/test/ship-installers.test.ts
@@ -178,17 +178,33 @@ describe('installDevcontainer', () => {
     expect(result.notes.some((n) => n.includes('dxkit-reference'))).toBe(true);
   });
 
-  it('force overrides existing devcontainer.json', () => {
+  it('force refreshes a dxkit-OWNED devcontainer.json', () => {
     fs.mkdirSync(path.join(tmp, '.devcontainer'), { recursive: true });
+    // A stale-but-dxkit-marked devcontainer (what a real prior install left).
     fs.writeFileSync(
       path.join(tmp, '.devcontainer/devcontainer.json'),
-      JSON.stringify({ name: 'existing' }),
+      JSON.stringify({ name: 'dxkit dev environment', stale: true }),
     );
 
     const result = installDevcontainer(tmp, { force: true });
     expect(result.installed).toContain('.devcontainer/devcontainer.json');
     const final = fs.readFileSync(path.join(tmp, '.devcontainer/devcontainer.json'), 'utf8');
     expect(final).toContain('dxkit dev environment');
+    expect(final).not.toContain('"stale"');
+  });
+
+  it('force NEVER overwrites a USER-authored devcontainer.json (#11 data-loss guard)', () => {
+    fs.mkdirSync(path.join(tmp, '.devcontainer'), { recursive: true });
+    const userJson = JSON.stringify({ name: 'existing', image: 'custom:latest' });
+    fs.writeFileSync(path.join(tmp, '.devcontainer/devcontainer.json'), userJson);
+
+    const result = installDevcontainer(tmp, { force: true });
+    // Preserved verbatim; dxkit's version lands only as a sidecar reference.
+    expect(fs.readFileSync(path.join(tmp, '.devcontainer/devcontainer.json'), 'utf8')).toBe(
+      userJson,
+    );
+    expect(result.sidecars).toContain('.devcontainer/.dxkit-reference/devcontainer.json');
+    expect(result.installed).not.toContain('.devcontainer/devcontainer.json');
   });
 
   it('renders only Node + GitHub CLI features on an empty (no-stack) repo', () => {

--- a/test/update-disposition.test.ts
+++ b/test/update-disposition.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The per-file disposition update uses to decide write-vs-preserve (#10 / #11).
+ * Mirrors uninstall's provenance model: refresh dxkit-owned unmodified files,
+ * never clobber user-owned ones even under --force.
+ */
+import { describe, it, expect } from 'vitest';
+import { decideUpdateDisposition } from '../src/update-disposition';
+import type { ManifestFileEntry } from '../src/types';
+
+const dxkitOwned = (hash: string): ManifestFileEntry => ({
+  hash,
+  evolving: false,
+  provenance: 'created',
+});
+const userOwned = (): ManifestFileEntry => ({ hash: null, evolving: false, provenance: 'skipped' });
+
+const HASH = 'a'.repeat(64);
+
+describe('decideUpdateDisposition', () => {
+  it('absent on disk → write (re)create it', () => {
+    expect(
+      decideUpdateDisposition({
+        exists: false,
+        evolving: false,
+        priorEntry: undefined,
+        onDiskHash: () => HASH,
+        force: false,
+      }),
+    ).toBe('write');
+  });
+
+  it('evolving file that exists → skip, never overwritten', () => {
+    expect(
+      decideUpdateDisposition({
+        exists: true,
+        evolving: true,
+        priorEntry: dxkitOwned(HASH),
+        onDiskHash: () => HASH,
+        force: true,
+      }),
+    ).toBe('skip');
+  });
+
+  it('existing + untracked (no prior entry) → skip, the user owns it', () => {
+    expect(
+      decideUpdateDisposition({
+        exists: true,
+        evolving: false,
+        priorEntry: undefined,
+        onDiskHash: () => 'x',
+        force: true, // even with --force
+      }),
+    ).toBe('skip');
+  });
+
+  it("provenance 'skipped' (user owned it at install) → skip even with --force (the #11 fix)", () => {
+    expect(
+      decideUpdateDisposition({
+        exists: true,
+        evolving: false,
+        priorEntry: userOwned(),
+        onDiskHash: () => 'anything',
+        force: true,
+      }),
+    ).toBe('skip');
+  });
+
+  it('dxkit-owned + on-disk UNMODIFIED → write (refresh delivers shipped fixes — the #10 fix)', () => {
+    expect(
+      decideUpdateDisposition({
+        exists: true,
+        evolving: false,
+        priorEntry: dxkitOwned(HASH),
+        onDiskHash: () => HASH, // matches what dxkit last wrote
+        force: false, // no --force needed
+      }),
+    ).toBe('write');
+  });
+
+  it('dxkit-owned + user EDITED it → skip without --force', () => {
+    expect(
+      decideUpdateDisposition({
+        exists: true,
+        evolving: false,
+        priorEntry: dxkitOwned(HASH),
+        onDiskHash: () => 'user-edited-different-hash',
+        force: false,
+      }),
+    ).toBe('skip');
+  });
+
+  it('dxkit-owned + user EDITED it + --force → write (re-apply the template)', () => {
+    expect(
+      decideUpdateDisposition({
+        exists: true,
+        evolving: false,
+        priorEntry: dxkitOwned(HASH),
+        onDiskHash: () => 'user-edited-different-hash',
+        force: true,
+      }),
+    ).toBe('write');
+  });
+
+  it('user-merge target (settings.json/CLAUDE.md/AGENTS.md) + user EDITED → skip even with --force', () => {
+    // A full template overwrite always destroys the user's additions, so these
+    // are preserved under --force once edited (a Stop hook in settings.json).
+    expect(
+      decideUpdateDisposition({
+        exists: true,
+        evolving: false,
+        priorEntry: dxkitOwned(HASH),
+        onDiskHash: () => 'user-added-their-own-hook',
+        force: true,
+        userMergeTarget: true,
+      }),
+    ).toBe('skip');
+  });
+
+  it('user-merge target that is UNMODIFIED still refreshes', () => {
+    expect(
+      decideUpdateDisposition({
+        exists: true,
+        evolving: false,
+        priorEntry: dxkitOwned(HASH),
+        onDiskHash: () => HASH,
+        force: false,
+        userMergeTarget: true,
+      }),
+    ).toBe('write');
+  });
+});

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -233,20 +233,36 @@ describe('vyuh-dxkit update: end-to-end refresh', () => {
     expect(r.stdout).toContain('withHooks');
   });
 
-  it('update with --force refreshes the devcontainer.json (picks up per-stack extensions)', () => {
-    // Mutate the devcontainer.json to a stale shape so we can verify
-    // refresh actually overwrote it.
+  it('update with --force refreshes a dxkit-owned devcontainer.json (picks up per-stack extensions)', () => {
+    // Mutate to a stale-but-still-dxkit-marked shape (a real stale dxkit
+    // devcontainer keeps its marker) so refresh recognizes it as ours.
     const dcPath = path.join(tmp, '.devcontainer', 'devcontainer.json');
-    fs.writeFileSync(dcPath, '{ "name": "stale" }\n');
+    fs.writeFileSync(dcPath, '{ "name": "dxkit dev environment", "stale": true }\n');
 
     const r = runCli(tmp, ['update', '--force']);
     expect(r.exitCode).toBe(0);
 
-    // After --force update, the file should be regenerated and contain
-    // the canonical dxkit shape.
+    // After --force update, the file should be regenerated to the canonical shape.
     const refreshed = fs.readFileSync(dcPath, 'utf-8');
     expect(refreshed).toContain('dxkit dev environment');
     expect(refreshed).not.toContain('"stale"');
+  });
+
+  it('update --force NEVER clobbers a USER-authored devcontainer.json (#11 data-loss guard)', () => {
+    // The user has their own devcontainer at the canonical path (no dxkit
+    // marker). Even --force must preserve it and sidecar dxkit's version.
+    const dcPath = path.join(tmp, '.devcontainer', 'devcontainer.json');
+    const userContent = '{ "name": "my own devcontainer", "image": "custom:latest" }\n';
+    fs.writeFileSync(dcPath, userContent);
+
+    const r = runCli(tmp, ['update', '--force']);
+    expect(r.exitCode).toBe(0);
+
+    expect(fs.readFileSync(dcPath, 'utf-8')).toBe(userContent);
+    // dxkit's version lands as a sidecar reference instead.
+    expect(
+      fs.existsSync(path.join(tmp, '.devcontainer', '.dxkit-reference', 'devcontainer.json')),
+    ).toBe(true);
   });
 
   it('update completes without errors on a real init-tree (smoke)', () => {

--- a/test/upgrade.test.ts
+++ b/test/upgrade.test.ts
@@ -6,6 +6,9 @@
  * JSON-mode schema that dxkit-update consumes.
  */
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import { classifyDelta, buildUpgradePlan } from '../src/upgrade';
 
 describe('classifyDelta', () => {
@@ -81,9 +84,27 @@ describe('buildUpgradePlan: schema invariants', () => {
     });
     const required = plan.steps.filter((s) => !s.optional);
     expect(required.length).toBe(3);
-    expect(required[0].command).toContain('npm install @vyuhlabs/dxkit@');
+    // dxkit is a devDependency — /tmp has no lockfile so the PM resolves to npm.
+    expect(required[0].command).toContain('npm install --save-dev @vyuhlabs/dxkit@');
     expect(required[1].command).toContain('vyuh-dxkit update');
     expect(required[2].command).toContain('vyuh-dxkit doctor');
+  });
+
+  it('the binary-upgrade step is PM-aware — pnpm repo gets `pnpm add -D` (#14)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-upg-pm-'));
+    try {
+      writeFileSync(join(dir, 'pnpm-lock.yaml'), 'lockfileVersion: 6.0\n');
+      const plan = buildUpgradePlan(dir, {
+        target: '99.99.99',
+        _readBinary: () => '2.5.1',
+        _readLatest: () => '99.99.99',
+      });
+      const step = plan.steps.find((s) => !s.optional);
+      expect(step?.command).toContain('pnpm add -D @vyuhlabs/dxkit@99.99.99');
+      expect(step?.command).not.toContain('npm install');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('warns about major-version jumps', () => {


### PR DESCRIPTION
Round-6 dogfood from the customer repo (`tmp/feedback/feedback_log.md` items #10–#15). Every fix closed a class that only appears in the seam between dxkit and a real repo — a GitHub **ruleset**, a **pnpm lockfile**, an **`update` over user-authored files** — shapes dxkit's own repo and the unit suite never exercise. Same diagnosis as 2.27 / 2.30, but `update` (the most-run command) had no real-repo net.

Fixed at root, all languages, single-source — no per-symptom patches. **5 atomic commits** (rebase-merge candidate — each independently meaningful).

## #10 / #11 — provenance-aware `update` (headline)
`update` decided per file on "does it exist?" + `--force` alone, producing two whole-command failures:
- **#10** — it treated its OWN unmodified files (templates, skills, guardrails workflow, pre-push hook) as "preserve" and never delivered a shipped fix.
- **#11** — `--force` overwrote user-authored files: a project's own `AGENTS.md` / `CLAUDE.md`, a Stop hook in `.claude/settings.json`, `.devcontainer/`.

The write path now reads the manifest `provenance` + `hash` via the shared pure `decideUpdateDisposition` (mirror of `uninstall`'s model): refresh a dxkit-owned *unmodified* file, never overwrite a user-owned one even under `--force`, never full-overwrite a user-edited merge target. Ship-installer artifacts get the same ownership-aware treatment (workflows refresh in place, the pre-push hook stops self-sidecaring, a user's own devcontainer survives `--force`).

## #12 — ruleset-aware branch-protection detection
Detection read only the classic `/branches/{b}/protection` endpoint, which 404s on a **repository ruleset** → a protected repo read as UNPROTECTED (deadlocking `tree` anchor, false doctor "BYPASSABLE", `protect` 404). `classifyEnforcement` now reads BOTH mechanisms (classic AND `/rules/branches/{b}`, which returns rulesets *only*) and unions them, in the single source every consumer reads. doctor prints ✓/not-verified either way; `protect` won't write a classic rule that fights a ruleset.

## #15 — lockfile-aware dependency-scanner selection
The TS pack ran `npm audit` unconditionally → UNMEASURED on pnpm/yarn/bun. Selection now consults the present lockfile (`detectLockfile`) and routes a non-npm lockfile to the shared lockfile-aware `osv-scanner` path (the one Java/Kotlin/Ruby already use). The UNMEASURED hint is reason-aware: "run tools install" only when the scanner is genuinely absent.

## #13 / #14 — `upgrade --plan` PM-aware + docs
The plan's binary-install step renders the repo's package manager (`pnpm add -D`, …). README's pnpm release-age note now covers the upgrade transition.

## Anti-recurrence
`test/lifecycle/` gained an **update lane** — the untested seam where all of this shipped — driving the real CLI over an older install with user files and asserting dxkit files refresh AND user files survive (default and `--force`). Plus `test/update-disposition.test.ts` branch matrix, and CLAUDE.md records the three new single-sources.

Full suite: **3064 tests green**, arch gate + test-typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)