### PR TITLE
2.34.0 — guardrail check-name matches what the workflow emits (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.34.0] - 2026-07-05
+
+### Fixed — the guardrail's required-status-check name matches what the workflow emits
+
+dxkit's guardrails workflow reported a check-run named `guardrail` (GitHub
+derived it from the job id, which had no explicit `name:`), but dxkit's
+enforcement code, `protect`, and docs all expected the check to be called
+`dxkit-guardrails`. So on a correctly-protected repo `doctor` reported the
+guardrail as "BYPASSABLE", and `protect` configured a required status check that
+could never be satisfied (it would block every PR).
+
+- **The workflow's guardrail job now has an explicit `name: dxkit-guardrails`**,
+  so the emitted status-check context matches the name `protect` writes and
+  `classifyEnforcement` matches. This is now a single source of truth pinned by
+  `test/enforcement-check-name.test.ts` — the template's job name and the code's
+  `GUARDRAIL_CHECK` can no longer silently drift (the class of bug).
+- **Legacy recognition + migration.** A protection still requiring the old
+  `guardrail` context is recognized as "guardrail required" (it no longer reads
+  as BYPASSABLE), and `doctor` flags it: the workflow now emits
+  `dxkit-guardrails`, so the required check should be renamed. `protect` drops the
+  stale `guardrail` context when it rewrites classic protection.
+
+**Migration note:** if you configured a branch protection or ruleset to require a
+status check named `guardrail`, update it to require `dxkit-guardrails` after this
+release — otherwise PRs will block on a check name the workflow no longer reports.
+`vyuh-dxkit doctor` will tell you if this applies to your repo.
+
 ## [2.33.0] - 2026-07-05
 
 The "update-path + real-repo-shape correctness" release. Every fix here closed a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "2.33.0",
+      "version": "2.34.0",
       "license": "MIT",
       "dependencies": {
         "exceljs": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -19,6 +19,13 @@ permissions:
 
 jobs:
   guardrail:
+    # The job `name:` IS the status-check context GitHub reports and that a
+    # ruleset / branch protection must require. It must equal dxkit's
+    # GUARDRAIL_CHECK ('dxkit-guardrails') — the name `protect` writes and
+    # `classifyEnforcement` matches. Without an explicit name GitHub used the job
+    # id ('guardrail'), which nothing dxkit configured ever matched. The
+    # invariant is pinned by test/enforcement-check-name.test.ts.
+    name: dxkit-guardrails
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -730,6 +730,23 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
             }),
       });
 
+      // 6b-2. Stale required-check NAME. The protection requires the legacy
+      // `guardrail` context, but the current workflow emits `dxkit-guardrails`
+      // (the job got an explicit name). GitHub will then block every PR on a
+      // required check that never appears. Distinct from BYPASSABLE — here the
+      // guardrail IS required, just under a name the workflow no longer produces.
+      if (enf.guardrailContextLegacyOnly) {
+        checks.push({
+          label: `'${enf.branch}' protection requires the legacy 'guardrail' check — the workflow now emits 'dxkit-guardrails'`,
+          ok: false,
+          tier: 'operational',
+          fix: {
+            hint: `Your branch protection / ruleset requires a status check named 'guardrail', but dxkit's guardrails workflow now reports 'dxkit-guardrails'. Update the required status check to 'dxkit-guardrails' (Settings → Rules, or Branch protection) — otherwise PRs block on a check that never runs.`,
+            skill: 'dxkit-init',
+          },
+        });
+      }
+
       // 6c. Deadlocking refresh workflow: a legacy 'tree' baseline-refresh
       // direct-pushes the anchor to the protected branch. That push is rejected,
       // and its [skip ci] commit can never earn the required checks — so the

--- a/src/enforcement.ts
+++ b/src/enforcement.ts
@@ -36,9 +36,33 @@
 import * as path from 'path';
 import { ghApi, ghCliAvailable, resolveDefaultBranch, GhError } from './setup-gh';
 
-/** The guardrail status check dxkit installs + expects a protected branch to
- *  require. Kept in sync with `setup-branch-protection.ts`. */
+/**
+ * The status-check CONTEXT dxkit's guardrails workflow emits and that a
+ * protected branch must require. This is the SINGLE SOURCE OF TRUTH for that
+ * name: the workflow template sets its guardrail job's `name:` to this value, so
+ * the check-run GitHub reports (and a ruleset must require) is exactly this
+ * string. `protect` writes it; `classifyEnforcement` matches it.
+ *
+ * The invariant "the workflow emits GUARDRAIL_CHECK" is pinned by
+ * `test/enforcement-check-name.test.ts` (it parses the template's job name) — the
+ * guard against the class of bug where the emitted context drifts from the name
+ * the code/`protect`/docs expect (the job had no explicit `name:`, so GitHub used
+ * the job id `guardrail`, and nothing required-checkable matched
+ * `dxkit-guardrails`).
+ */
 export const GUARDRAIL_CHECK = 'dxkit-guardrails';
+
+/**
+ * The context dxkit's workflow emitted BEFORE the job got an explicit `name:`
+ * (GitHub derived it from the job id `guardrail`). A branch protected against
+ * that older workflow requires `guardrail`; it is still recognized as "the dxkit
+ * guardrail is required" so an existing setup doesn't read as BYPASSABLE, and
+ * `doctor` flags the rename so the ruleset can be migrated to GUARDRAIL_CHECK.
+ */
+export const LEGACY_GUARDRAIL_CHECK = 'guardrail';
+
+/** Every context string that means "dxkit's guardrail check is required". */
+const GUARDRAIL_CONTEXTS: readonly string[] = [GUARDRAIL_CHECK, LEGACY_GUARDRAIL_CHECK];
 
 /** Minimal subset of GitHub's CLASSIC branch-protection payload dxkit reads. */
 interface ClassicProtection {
@@ -83,10 +107,16 @@ export interface EnforcementState {
    *  ruleset) requires a PR and/or passing status checks, so a bare `git push`
    *  is rejected. */
   readonly directPushBlocked: boolean;
-  /** The `dxkit-guardrails` check is a REQUIRED status check on `branch` (via
+  /** The dxkit guardrail check is a REQUIRED status check on `branch` (via
    *  classic protection or a ruleset), i.e. the guardrail actually gates merges
-   *  rather than running informationally. */
+   *  rather than running informationally. True for EITHER the canonical
+   *  `dxkit-guardrails` context or the legacy `guardrail` one. */
   readonly guardrailRequired: boolean;
+  /** The guardrail is required ONLY under the legacy `guardrail` context, not the
+   *  canonical `dxkit-guardrails` the current workflow emits — so once the
+   *  workflow update lands, that requirement matches a check that no longer
+   *  appears and would block PRs. `doctor` surfaces this as a migration action. */
+  readonly guardrailContextLegacyOnly: boolean;
   /** A repository RULESET governs `branch` (at least one effective rule). When
    *  true, `protect` must not create a conflicting classic rule — the guardrail
    *  belongs in the ruleset. */
@@ -105,20 +135,30 @@ function classicBlocksDirectPush(classic: ClassicProtection | null): boolean {
   return requiresChecks || requiresPr;
 }
 
-function classicRequiresGuardrail(classic: ClassicProtection | null): boolean {
-  return (classic?.required_status_checks?.contexts ?? []).includes(GUARDRAIL_CHECK);
-}
-
 function rulesBlockDirectPush(rules: EffectiveRule[]): boolean {
   return rules.some((r) => r.type != null && PUSH_BLOCKING_RULE_TYPES.has(r.type));
 }
 
-function rulesRequireGuardrail(rules: EffectiveRule[]): boolean {
-  return rules.some(
-    (r) =>
-      r.type === 'required_status_checks' &&
-      (r.parameters?.required_status_checks ?? []).some((c) => c.context === GUARDRAIL_CHECK),
-  );
+/**
+ * The set of dxkit guardrail contexts (canonical + legacy) a protection actually
+ * requires — collected across classic protection AND every ruleset
+ * required_status_checks rule. Empty when the guardrail isn't required at all.
+ */
+function requiredGuardrailContexts(
+  classic: ClassicProtection | null,
+  rules: EffectiveRule[],
+): Set<string> {
+  const found = new Set<string>();
+  for (const ctx of classic?.required_status_checks?.contexts ?? []) {
+    if (GUARDRAIL_CONTEXTS.includes(ctx)) found.add(ctx);
+  }
+  for (const r of rules) {
+    if (r.type !== 'required_status_checks') continue;
+    for (const c of r.parameters?.required_status_checks ?? []) {
+      if (c.context && GUARDRAIL_CONTEXTS.includes(c.context)) found.add(c.context);
+    }
+  }
+  return found;
 }
 
 /**
@@ -142,20 +182,29 @@ export function classifyEnforcement(
       probed: false,
       directPushBlocked: false,
       guardrailRequired: false,
+      guardrailContextLegacyOnly: false,
       rulesetGoverned: false,
     };
   }
   const directPushBlocked =
     classicBlocksDirectPush(reads.classic) || rulesBlockDirectPush(reads.rules);
-  const guardrailRequired =
-    classicRequiresGuardrail(reads.classic) || rulesRequireGuardrail(reads.rules);
+  const guardrailContexts = requiredGuardrailContexts(reads.classic, reads.rules);
+  const guardrailRequired = guardrailContexts.size > 0;
+  const guardrailContextLegacyOnly = guardrailRequired && !guardrailContexts.has(GUARDRAIL_CHECK);
   const rulesetGoverned = reads.rulesKnown && reads.rules.length > 0;
 
   const sawProtection = directPushBlocked || guardrailRequired || rulesetGoverned;
   const bothRead = reads.classicKnown && reads.rulesKnown;
   const probed = sawProtection || bothRead;
 
-  return { branch, probed, directPushBlocked, guardrailRequired, rulesetGoverned };
+  return {
+    branch,
+    probed,
+    directPushBlocked,
+    guardrailRequired,
+    guardrailContextLegacyOnly,
+    rulesetGoverned,
+  };
 }
 
 const CACHE = new Map<string, EnforcementState>();

--- a/src/setup-branch-protection.ts
+++ b/src/setup-branch-protection.ts
@@ -35,7 +35,12 @@ import {
   resolveDefaultBranch,
   resolveOwnerRepo,
 } from './setup-gh';
-import { classifyEnforcement, probeEnforcementReads, GUARDRAIL_CHECK } from './enforcement';
+import {
+  classifyEnforcement,
+  probeEnforcementReads,
+  GUARDRAIL_CHECK,
+  LEGACY_GUARDRAIL_CHECK,
+} from './enforcement';
 
 export interface SetupBranchProtectionOpts {
   /** Branch to protect. Defaults to the repo's default branch. */
@@ -97,8 +102,12 @@ function buildPayload(
   existing: ProtectionPayload | null,
   opts: SetupBranchProtectionOpts,
 ): ProtectionPayload {
-  // Existing required checks — preserve, then ensure dxkit-guardrails is in the set.
-  const existingChecks = existing?.required_status_checks?.contexts ?? [];
+  // Existing required checks — preserve, then ensure dxkit-guardrails is in the
+  // set. Drop the LEGACY `guardrail` context if present: the workflow no longer
+  // emits it, so leaving it required would block every PR on a phantom check.
+  const existingChecks = (existing?.required_status_checks?.contexts ?? []).filter(
+    (c) => c !== LEGACY_GUARDRAIL_CHECK,
+  );
   const mergedChecks = opts.force
     ? [REQUIRED_CHECK]
     : [...new Set([...existingChecks, REQUIRED_CHECK])];

--- a/test/baseline-anchor.test.ts
+++ b/test/baseline-anchor.test.ts
@@ -39,6 +39,7 @@ const PROTECTED: EnforcementState = {
   probed: true,
   directPushBlocked: true,
   guardrailRequired: true,
+  guardrailContextLegacyOnly: false,
   rulesetGoverned: false,
 };
 const UNPROTECTED: EnforcementState = {
@@ -46,6 +47,7 @@ const UNPROTECTED: EnforcementState = {
   probed: true,
   directPushBlocked: false,
   guardrailRequired: false,
+  guardrailContextLegacyOnly: false,
   rulesetGoverned: false,
 };
 const UNKNOWN: EnforcementState = {
@@ -53,6 +55,7 @@ const UNKNOWN: EnforcementState = {
   probed: false,
   directPushBlocked: false,
   guardrailRequired: false,
+  guardrailContextLegacyOnly: false,
   rulesetGoverned: false,
 };
 
@@ -171,6 +174,52 @@ describe('classifyEnforcement', () => {
     expect(s.guardrailRequired).toBe(true);
     expect(s.rulesetGoverned).toBe(true);
   });
+  // Legacy check-name recognition (#16). The pre-fix workflow emitted the job
+  // id `guardrail`; a protection requiring it must still read as "guardrail
+  // required" (not BYPASSABLE), flagged legacy-only so doctor prompts a rename.
+  it('a legacy `guardrail` classic context counts as required, flagged legacy-only', () => {
+    const s = classifyEnforcement(
+      'main',
+      reads({ classic: { required_status_checks: { contexts: ['guardrail'] } } }),
+    );
+    expect(s.guardrailRequired).toBe(true);
+    expect(s.guardrailContextLegacyOnly).toBe(true);
+  });
+  it('a legacy `guardrail` ruleset context counts as required, flagged legacy-only', () => {
+    const s = classifyEnforcement(
+      'main',
+      reads({
+        classic: null,
+        rules: [
+          {
+            type: 'required_status_checks',
+            parameters: { required_status_checks: [{ context: 'guardrail' }] },
+          },
+        ],
+      }),
+    );
+    expect(s.guardrailRequired).toBe(true);
+    expect(s.guardrailContextLegacyOnly).toBe(true);
+  });
+  it('the canonical `dxkit-guardrails` context is NOT legacy-only', () => {
+    const s = classifyEnforcement(
+      'main',
+      reads({ classic: { required_status_checks: { contexts: ['dxkit-guardrails'] } } }),
+    );
+    expect(s.guardrailRequired).toBe(true);
+    expect(s.guardrailContextLegacyOnly).toBe(false);
+  });
+  it('both canonical + legacy present → required, not legacy-only', () => {
+    const s = classifyEnforcement(
+      'main',
+      reads({
+        classic: { required_status_checks: { contexts: ['guardrail', 'dxkit-guardrails'] } },
+      }),
+    );
+    expect(s.guardrailRequired).toBe(true);
+    expect(s.guardrailContextLegacyOnly).toBe(false);
+  });
+
   it('ref-integrity-only ruleset rules (non_fast_forward) do NOT count as a push block', () => {
     const s = classifyEnforcement('main', reads({ rules: [{ type: 'non_fast_forward' }] }));
     expect(s.directPushBlocked).toBe(false);

--- a/test/enforcement-check-name.test.ts
+++ b/test/enforcement-check-name.test.ts
@@ -1,0 +1,48 @@
+/**
+ * The load-bearing invariant behind the enforcement-path checks: the
+ * status-check CONTEXT dxkit's guardrails workflow emits MUST equal the name
+ * dxkit's code + `protect` require (`GUARDRAIL_CHECK`). When they drift, a
+ * correctly-protected repo reads as "BYPASSABLE" and `protect` writes a
+ * never-satisfiable required check — the class of bug that shipped when the
+ * guardrail job had no explicit `name:` and GitHub used the job id `guardrail`
+ * while the code expected `dxkit-guardrails`.
+ *
+ * GitHub derives an Actions check-run's context from the job's `name:` (or the
+ * job id when `name:` is absent). This test parses the workflow TEMPLATE's
+ * guardrail job name and pins it to `GUARDRAIL_CHECK`, so the two can never
+ * silently diverge again.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { GUARDRAIL_CHECK, LEGACY_GUARDRAIL_CHECK } from '../src/enforcement';
+
+/** The check-run context the workflow will emit: the guardrail job's `name:`
+ *  (4-space indented, job level) or the job id `guardrail` when none is set. */
+function emittedGuardrailContext(workflow: string): string {
+  const lines = workflow.split('\n');
+  const jobIdx = lines.findIndex((l) => /^ {2}guardrail:\s*$/.test(l));
+  if (jobIdx === -1) throw new Error('guardrail job not found in template');
+  for (let i = jobIdx + 1; i < lines.length; i++) {
+    // Stop at the next top-level job (2-space key) — we've left the guardrail job.
+    if (/^ {2}\S/.test(lines[i])) break;
+    const m = lines[i].match(/^ {4}name:\s*(\S+)\s*$/); // job-level name (not a 6-space step name)
+    if (m) return m[1];
+  }
+  return 'guardrail'; // job id fallback (the pre-fix behavior)
+}
+
+describe('guardrails workflow emits the context dxkit requires', () => {
+  const template = readFileSync(
+    join(__dirname, '..', 'src-templates', '.github', 'workflows', 'dxkit-guardrails.yml'),
+    'utf8',
+  );
+
+  it('the guardrail job name equals GUARDRAIL_CHECK (so protect + doctor + the ruleset all match)', () => {
+    expect(emittedGuardrailContext(template)).toBe(GUARDRAIL_CHECK);
+  });
+
+  it('the emitted context is no longer the bare legacy job id', () => {
+    expect(emittedGuardrailContext(template)).not.toBe(LEGACY_GUARDRAIL_CHECK);
+  });
+});


### PR DESCRIPTION
Round-7 dogfood follow-up (`tmp/feedback/feedback_log.md` #16). A gap the 2.33.0 #12 enforcement fix didn't close.

## Root cause
dxkit's guardrails workflow reported a check-run named **`guardrail`** — GitHub derives an Actions check-run's context from the job's `name:`, and the guardrail job had none, so it used the job id. But dxkit's enforcement code (`GUARDRAIL_CHECK`), `protect`, and docs all expect **`dxkit-guardrails`**. Consequences:
- on a correctly-protected repo, `doctor` reported the guardrail as "BYPASSABLE" (false negative);
- `protect` configured a required status check (`dxkit-guardrails`) that the workflow never produces — a latent bug that would block *every* PR on any repo that ran `protect --apply`.

## The fix — and the anti-recurrence guard for this class
The class is "the status-check context the workflow emits drifts from the name the code/`protect`/docs require." Closed by making the name a **single source of truth** and pinning it:
- The workflow's guardrail job now has an explicit **`name: dxkit-guardrails`**, so the emitted context is exactly what dxkit configures and matches.
- **`test/enforcement-check-name.test.ts`** parses the template's job name and asserts it equals `GUARDRAIL_CHECK`. The template and the code can no longer silently diverge — this is the guard against the whole class.

## Migration handling (non-breaking, guided)
- `classifyEnforcement` recognizes the legacy `guardrail` context as "guardrail required" (an existing setup no longer reads as BYPASSABLE) and flags it *legacy-only*.
- `doctor` surfaces a clear migration action when a protection still requires `guardrail` (the workflow now emits `dxkit-guardrails`).
- `protect` drops the stale `guardrail` context when it rewrites classic protection.

**Migration note:** a branch protection / ruleset requiring a check named `guardrail` should be updated to require `dxkit-guardrails` after this release; `doctor` reports when it applies.

Full suite: **3070 tests green**, arch gate + test-typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)