### PR TITLE
feat(reports): score-over-time value surfaces — CI job summary + metrics trend

### DIFF
--- a/src-templates/.claude/skills/dxkit-config/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-config/SKILL.md
@@ -162,6 +162,7 @@ Opt into a score-over-time trend: publish a health snapshot on every merge to th
 ```
 
 - `true` — installs `dxkit-reports-refresh.yml`, which renders the full audit on merge (+ weekly + on demand) and publishes a snapshot to a **dedicated `dxkit-reports` side ref** via git plumbing. It appends one line to `report-history.jsonl` and refreshes a browsable `latest/` dashboard on that ref — **without committing anything to the default branch's tree** (same transport the baseline anchor uses, just a distinct ref, so its churn never touches the baseline). Read the trend back with `npx vyuh-dxkit report history`. Retention is `reports.retain` (how many snapshots to keep).
+  - The merge workflow also writes a **"score moved X→Y" job summary** (per dimension) into the run — `report history --markdown` renders that block, so you can drop it into a PR comment too. And `npx vyuh-dxkit metrics` shows the score-over-time trend alongside the gate's interception ROI, so one command answers both "what did the gate stop" and "how is the score trending".
 - `false` / absent — no snapshots are published (the default).
 
 Two ways to enable it: `npx vyuh-dxkit init --with-reports-refresh` (installs the workflow directly), or set the `reports.onMerge` knob above and run `npx vyuh-dxkit update` (which lays the workflow down). Either way, `update` refreshes it and `uninstall` removes it. It's a reporting/trend feature, not a correctness gate — leave it off unless you want the merge-time score history.

--- a/src-templates/.github/workflows/dxkit-reports-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-reports-refresh.yml
@@ -80,3 +80,17 @@ __DXKIT_CI_RUNTIME_SETUP__
           # ref. Anchor ref + retention come from .dxkit/policy.json:reports.
           "${DXKIT}" report
           "${DXKIT}" report snapshot
+
+      - name: Score-over-time job summary
+        # Read the freshly-published trend back off the dxkit-reports ref and
+        # render "score moved X→Y" (per dimension) into the run's summary — the
+        # merge-time surface that makes the snapshot visible without opening the
+        # dashboard. Best-effort: never fails the job.
+        if: always()
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            DXKIT=./node_modules/.bin/vyuh-dxkit
+          else
+            DXKIT=vyuh-dxkit
+          fi
+          "${DXKIT}" report history --markdown >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1894,6 +1894,7 @@ export async function run(argv: string[]): Promise<void> {
             : runReportHistory({
                 cwd,
                 json: !!values.json,
+                markdown: !!values.markdown,
                 ...(values.ref ? { anchorRef: String(values.ref) } : {}),
                 ...(values.limit ? { limit: Number(values.limit) } : {}),
               });

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -216,7 +216,8 @@ export const COMMANDS = [
     docsBlurb:
       'One command to run all analyzers and render the dashboard — the full-audit entry point. ' +
       '`report snapshot` publishes a per-merge score snapshot to the dxkit-reports ref; ' +
-      '`report history` renders the score-over-time trend. Automate snapshots on merge with ' +
+      '`report history` renders the score-over-time trend (`--markdown` emits a "score moved X→Y" ' +
+      'block for a CI job summary or PR comment). Automate snapshots on merge with ' +
       '`policy.json:reports.onMerge` (the dxkit-reports-refresh workflow).',
     skill: 'dxkit-reports',
   },
@@ -224,9 +225,9 @@ export const COMMANDS = [
     id: 'metrics',
     audience: 'user',
     group: 'assess',
-    summary: 'Findings the gate stopped before merge — the ROI series from the loop ledger',
+    summary: 'Findings the gate stopped before merge + the score-over-time trend',
     docsBlurb:
-      'The champion ROI report, computed not narrated: net-new findings the guardrail intercepted before they reached the base branch, per week and by category, from the append-only loop ledger. Interceptions are the ungameable number; --since <ref|date> scopes the window.',
+      'The champion ROI report, computed not narrated: net-new findings the guardrail intercepted before they reached the base branch, per week and by category, from the append-only loop ledger. Interceptions are the ungameable number; --since <ref|date> scopes the window. Also surfaces the score-over-time trend (how each dimension moved) from the dxkit-reports snapshots when on-merge reports are enabled.',
     skill: 'dxkit-reports',
   },
 

--- a/src/metrics-cli.ts
+++ b/src/metrics-cli.ts
@@ -16,6 +16,10 @@ import { execFileSync } from 'child_process';
 import * as logger from './logger';
 import { readLedger } from './loop/ledger';
 import { computeMetrics, type MetricsReport } from './loop/metrics';
+import { readReportHistory } from './reports/snapshot';
+import { renderTrendText } from './reports/render';
+import { latestDeltas, type ReportHistoryEntry } from './reports/history';
+import { loadPolicyFromCwd } from './baseline/policy';
 
 export interface MetricsOptions {
   /** A git ref (resolved to its commit date) or an ISO date; scopes the window. */
@@ -27,6 +31,13 @@ export async function runMetrics(cwd: string, opts: MetricsOptions = {}): Promis
   const events = readLedger(cwd);
   const since = resolveSince(cwd, opts.since);
   const report = computeMetrics(events, { sinceMs: since.ms });
+  // The score-over-time trend (published on merge to the dxkit-reports ref) is
+  // the OUTCOME half of ROI — what the gate blocked (ledger) plus how the score
+  // actually moved. Only read it when the repo has a `reports` policy: the read
+  // does a `git fetch` of the anchor ref, and `metrics` must stay a local,
+  // offline-friendly command for the (common) repo that never enabled reports.
+  const usesReports = Object.keys(loadPolicyFromCwd(cwd).reports ?? {}).length > 0;
+  const trend = usesReports ? readReportHistory(cwd) : [];
 
   if (opts.json) {
     process.stdout.write(
@@ -35,6 +46,7 @@ export async function runMetrics(cwd: string, opts: MetricsOptions = {}): Promis
           schema: 'metrics.v1',
           since: since.label ?? null,
           ...report,
+          trend: trendJson(trend),
         },
         null,
         2,
@@ -44,6 +56,30 @@ export async function runMetrics(cwd: string, opts: MetricsOptions = {}): Promis
   }
 
   render(report, since);
+  renderTrend(trend);
+}
+
+/** Compact JSON view of the trend: the full series plus the latest merge's
+ *  per-dimension movement (the "score moved X→Y" the renderers show). */
+function trendJson(entries: readonly ReportHistoryEntry[]): {
+  snapshots: number;
+  latest: ReportHistoryEntry | null;
+  deltas: ReturnType<typeof latestDeltas>['deltas'];
+} {
+  const { cur, deltas } = latestDeltas(entries);
+  return { snapshots: entries.length, latest: cur ?? null, deltas };
+}
+
+function renderTrend(entries: readonly ReportHistoryEntry[]): void {
+  const lines = renderTrendText(entries);
+  if (lines.length === 0) return;
+  gap();
+  logger.header('Score over time');
+  logger.info(lines[0]);
+  for (const l of lines.slice(1)) logger.dim(l);
+  gap();
+  logger.dim('Published on merge to the `dxkit-reports` ref (policy.json:reports.onMerge).');
+  logger.dim('Full trend: `vyuh-dxkit report history`.');
 }
 
 interface ResolvedSince {

--- a/src/reports-cli.ts
+++ b/src/reports-cli.ts
@@ -20,6 +20,7 @@ import {
   type SnapshotArtifact,
 } from './reports/snapshot';
 import type { ReportHistoryEntry } from './reports/history';
+import { renderHistoryMarkdown } from './reports/render';
 import { loadPolicyFromCwd, type ReportsPolicy } from './baseline/policy';
 import * as logger from './logger';
 
@@ -152,6 +153,9 @@ export interface ReportHistoryCliOptions {
   readonly anchorRef?: string;
   readonly json?: boolean;
   readonly limit?: number;
+  /** Emit a GitHub-flavored markdown block (for `$GITHUB_STEP_SUMMARY` / a PR
+   *  comment) instead of the terminal table. */
+  readonly markdown?: boolean;
 }
 
 export function runReportHistory(opts: ReportHistoryCliOptions): number {
@@ -161,6 +165,13 @@ export function runReportHistory(opts: ReportHistoryCliOptions): number {
 
   if (opts.json) {
     process.stdout.write(JSON.stringify({ anchorRef, entries: history }) + '\n');
+    return 0;
+  }
+
+  if (opts.markdown) {
+    // Raw markdown to stdout so a workflow can redirect it into
+    // $GITHUB_STEP_SUMMARY; no logger chrome.
+    process.stdout.write(renderHistoryMarkdown(history, opts.limit ? { limit: opts.limit } : {}));
     return 0;
   }
 

--- a/src/reports/history.ts
+++ b/src/reports/history.ts
@@ -47,6 +47,18 @@ export interface ReportHistoryEntry {
   readonly findings?: ReportFindingCounts;
 }
 
+/** The score keys, in canonical display order — the ONE list every consumer
+ *  iterates (parse, delta, render), so a new dimension is added in one place. */
+export const SCORE_KEYS: ReadonlyArray<keyof ReportScores> = [
+  'overall',
+  'security',
+  'quality',
+  'tests',
+  'documentation',
+  'maintainability',
+  'developerExperience',
+];
+
 function isFiniteNumberOrNull(v: unknown): v is number | null {
   return v === null || (typeof v === 'number' && Number.isFinite(v));
 }
@@ -54,17 +66,8 @@ function isFiniteNumberOrNull(v: unknown): v is number | null {
 function coerceScores(raw: unknown): ReportScores | null {
   if (!raw || typeof raw !== 'object') return null;
   const o = raw as Record<string, unknown>;
-  const keys: Array<keyof ReportScores> = [
-    'overall',
-    'security',
-    'quality',
-    'tests',
-    'documentation',
-    'maintainability',
-    'developerExperience',
-  ];
   const out: Record<string, number | null> = {};
-  for (const k of keys) {
+  for (const k of SCORE_KEYS) {
     const v = o[k];
     if (!isFiniteNumberOrNull(v)) return null; // a malformed score line is skipped whole
     out[k] = v;
@@ -103,6 +106,41 @@ export function parseHistory(jsonl: string | null | undefined): ReportHistoryEnt
     out.push(entry);
   }
   return out;
+}
+
+/** One dimension's movement between two snapshots. `delta` is `to - from` only
+ *  when both sides are measured; a null on either side leaves `delta` null (an
+ *  unmeasured dimension has no honest movement). */
+export interface ScoreDelta {
+  readonly key: keyof ReportScores;
+  readonly from: number | null;
+  readonly to: number | null;
+  readonly delta: number | null;
+}
+
+/** Per-dimension movement from `prev` scores to `cur` scores. Pure. When `prev`
+ *  is undefined (the first-ever snapshot) every `from`/`delta` is null. */
+export function scoreDeltas(prev: ReportScores | undefined, cur: ReportScores): ScoreDelta[] {
+  return SCORE_KEYS.map((key) => {
+    const to = cur[key];
+    const from = prev ? prev[key] : null;
+    const delta = typeof from === 'number' && typeof to === 'number' ? to - from : null;
+    return { key, from, to, delta };
+  });
+}
+
+/** The movement of the most recent merge vs the one before it — the "score moved
+ *  X→Y" primitive both the CI job summary and `metrics` read. With <2 entries
+ *  there is no prior, so `prev` is undefined and every delta is null. Pure. */
+export function latestDeltas(entries: readonly ReportHistoryEntry[]): {
+  readonly prev?: ReportHistoryEntry;
+  readonly cur?: ReportHistoryEntry;
+  readonly deltas: ScoreDelta[];
+} {
+  if (entries.length === 0) return { deltas: [] };
+  const cur = entries[entries.length - 1];
+  const prev = entries.length >= 2 ? entries[entries.length - 2] : undefined;
+  return { ...(prev ? { prev } : {}), cur, deltas: scoreDeltas(prev?.scores, cur.scores) };
 }
 
 /** Serialize entries to JSONL (one compact object per line, trailing newline). */

--- a/src/reports/render.ts
+++ b/src/reports/render.ts
@@ -1,0 +1,138 @@
+/**
+ * Pure presentation of the report-history trend — the "score moved X→Y" surfaces
+ * that make the on-merge snapshots (src/reports/snapshot.ts) actually deliver
+ * value. Two renderers, ONE delta primitive (`latestDeltas` in history.ts):
+ *
+ * - `renderHistoryMarkdown` → a GitHub-flavored block for `$GITHUB_STEP_SUMMARY`
+ *   (the reports-refresh workflow appends it after each merge) or a PR comment.
+ * - `renderTrendText` → a compact terminal section `vyuh-dxkit metrics` prints
+ *   under the interception ROI, so the champion report shows BOTH what the gate
+ *   blocked and how the score moved.
+ *
+ * Pure (no I/O): the CLI + workflow read `report-history.jsonl` off the
+ * `dxkit-reports` anchor and hand the parsed entries in.
+ */
+import { SCORE_KEYS, latestDeltas, type ReportHistoryEntry, type ReportScores } from './history';
+
+const DIM_LABELS: Record<keyof ReportScores, string> = {
+  overall: 'Overall',
+  security: 'Security',
+  quality: 'Quality',
+  tests: 'Tests',
+  documentation: 'Docs',
+  maintainability: 'Maintainability',
+  developerExperience: 'Developer Experience',
+};
+
+function score(v: number | null): string {
+  return v == null ? '—' : String(v);
+}
+
+/** A signed movement token: `▲3` / `▼2` / `=` / '' when there is no comparable
+ *  prior. Text + markdown share it so the arrow convention is identical. */
+export function deltaToken(delta: number | null): string {
+  if (delta == null) return '';
+  if (delta > 0) return `▲${delta}`;
+  if (delta < 0) return `▼${Math.abs(delta)}`;
+  return '=';
+}
+
+/** Headline sentence for the latest merge's overall movement. */
+function overallHeadline(entries: readonly ReportHistoryEntry[]): string {
+  const { prev, cur, deltas } = latestDeltas(entries);
+  if (!cur) return 'No report snapshots yet.';
+  const overall = deltas.find((d) => d.key === 'overall');
+  const now = score(cur.scores.overall);
+  if (!prev || !overall || overall.delta == null) {
+    return `Overall health: **${now}**`;
+  }
+  return `Overall health: **${score(overall.from)} → ${now}** (${deltaToken(overall.delta)})`;
+}
+
+export interface TrendRenderOptions {
+  /** Cap the recent-snapshot table to the last N entries (default 10). */
+  readonly limit?: number;
+}
+
+/**
+ * GitHub-flavored markdown: a headline, a per-dimension delta table for the
+ * latest merge, and a compact recent-overall trend. Suitable for
+ * `$GITHUB_STEP_SUMMARY` and PR comments. Never throws on empty input.
+ */
+export function renderHistoryMarkdown(
+  entries: readonly ReportHistoryEntry[],
+  opts: TrendRenderOptions = {},
+): string {
+  if (entries.length === 0) {
+    return '### dxkit — score over time\n\n_No report snapshots on the `dxkit-reports` ref yet._\n';
+  }
+  const { prev, cur, deltas } = latestDeltas(entries);
+  const lines: string[] = ['### dxkit — score over time', '', overallHeadline(entries), ''];
+
+  // Per-dimension movement for the latest merge.
+  lines.push('| Dimension | Previous | Now | Δ |', '| --- | ---: | ---: | :--- |');
+  for (const key of SCORE_KEYS) {
+    const d = deltas.find((x) => x.key === key)!;
+    lines.push(
+      `| ${DIM_LABELS[key]} | ${prev ? score(d.from) : '—'} | ${score(d.to)} | ${deltaToken(d.delta) || '—'} |`,
+    );
+  }
+
+  // Compact recent trend (most-recent last), so the table reads left→right in time.
+  const limit = opts.limit && opts.limit > 0 ? opts.limit : 10;
+  const recent = entries.slice(-limit);
+  if (recent.length > 1) {
+    lines.push('', '<details><summary>Recent snapshots</summary>', '');
+    lines.push('| Date | Commit | Overall |', '| --- | --- | ---: |');
+    for (const e of recent) {
+      lines.push(
+        `| ${e.date.slice(0, 10)} | \`${e.sha.slice(0, 12)}\` | ${score(e.scores.overall)} |`,
+      );
+    }
+    lines.push('', '</details>');
+  }
+  lines.push(
+    '',
+    `_${cur!.dxkitVersion ? `dxkit ${cur!.dxkitVersion} · ` : ''}${entries.length} snapshot(s) on \`dxkit-reports\`._`,
+  );
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Compact terminal lines for `metrics`: the latest merge's per-dimension
+ * movement plus a short overall series. Returns an array of already-formatted
+ * lines (the caller dims/prints them); empty array when there is no history.
+ */
+export function renderTrendText(
+  entries: readonly ReportHistoryEntry[],
+  opts: TrendRenderOptions = {},
+): string[] {
+  if (entries.length === 0) return [];
+  const { prev, cur, deltas } = latestDeltas(entries);
+  const out: string[] = [];
+  out.push(overallHeadline(entries).replace(/\*\*/g, ''));
+
+  if (prev) {
+    // Only the dimensions that actually moved, so the line stays short.
+    const moved = deltas.filter((d) => d.delta != null && d.delta !== 0);
+    if (moved.length > 0) {
+      out.push(
+        '  moved: ' +
+          moved.map((d) => `${DIM_LABELS[d.key].toLowerCase()} ${deltaToken(d.delta)}`).join(' · '),
+      );
+    } else {
+      out.push('  no dimension moved since the previous snapshot');
+    }
+  }
+
+  const limit = opts.limit && opts.limit > 0 ? opts.limit : 6;
+  const recent = entries.slice(-limit);
+  if (recent.length > 1) {
+    out.push(
+      '  overall: ' +
+        recent.map((e) => `${e.date.slice(5, 10)} ${score(e.scores.overall)}`).join('  '),
+    );
+  }
+  void cur;
+  return out;
+}

--- a/test/reports/history.test.ts
+++ b/test/reports/history.test.ts
@@ -3,6 +3,8 @@ import {
   parseHistory,
   serializeHistory,
   foldEntry,
+  scoreDeltas,
+  latestDeltas,
   type ReportHistoryEntry,
 } from '../../src/reports/history';
 
@@ -23,6 +25,43 @@ function entry(sha: string, over = 70): ReportHistoryEntry {
     scores: { ...scores, overall: over },
   };
 }
+
+describe('score deltas', () => {
+  it('scoreDeltas computes to - from only when both are measured', () => {
+    const prev = { ...scores, overall: 70, security: 80, documentation: 40 };
+    const cur = { ...scores, overall: 74, security: 80, documentation: null };
+    const d = scoreDeltas(prev, cur);
+    const by = (k: string) => d.find((x) => x.key === k)!;
+    expect(by('overall')).toMatchObject({ from: 70, to: 74, delta: 4 });
+    expect(by('security')).toMatchObject({ from: 80, to: 80, delta: 0 });
+    // unmeasured now → no fabricated delta
+    expect(by('documentation')).toMatchObject({ from: 40, to: null, delta: null });
+  });
+
+  it('scoreDeltas with no prior yields null from/delta for every key', () => {
+    const d = scoreDeltas(undefined, scores);
+    expect(d.every((x) => x.from === null && x.delta === null)).toBe(true);
+    expect(d.find((x) => x.key === 'overall')!.to).toBe(scores.overall);
+  });
+
+  it('latestDeltas compares the last two entries', () => {
+    const res = latestDeltas([entry('a', 60), entry('b', 65), entry('c', 72)]);
+    expect(res.prev?.sha).toBe('b');
+    expect(res.cur?.sha).toBe('c');
+    expect(res.deltas.find((d) => d.key === 'overall')!.delta).toBe(7);
+  });
+
+  it('latestDeltas on a single entry has no prior', () => {
+    const res = latestDeltas([entry('a', 60)]);
+    expect(res.prev).toBeUndefined();
+    expect(res.cur?.sha).toBe('a');
+    expect(res.deltas.find((d) => d.key === 'overall')!.delta).toBeNull();
+  });
+
+  it('latestDeltas on empty history is inert', () => {
+    expect(latestDeltas([])).toEqual({ deltas: [] });
+  });
+});
 
 describe('report history codec', () => {
   it('round-trips entries through serialize → parse', () => {

--- a/test/reports/render.test.ts
+++ b/test/reports/render.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { deltaToken, renderHistoryMarkdown, renderTrendText } from '../../src/reports/render';
+import type { ReportHistoryEntry, ReportScores } from '../../src/reports/history';
+
+const baseScores: ReportScores = {
+  overall: 70,
+  security: 80,
+  quality: 60,
+  tests: 50,
+  documentation: 40,
+  maintainability: 65,
+  developerExperience: 75,
+};
+
+function entry(
+  sha: string,
+  patch: Partial<ReportScores> = {},
+  date = '2026-07-01',
+): ReportHistoryEntry {
+  return {
+    sha,
+    date: `${date}T00:00:00.000Z`,
+    dxkitVersion: '3.0.0',
+    branch: 'main',
+    scores: { ...baseScores, ...patch },
+  };
+}
+
+describe('deltaToken', () => {
+  it('renders up / down / flat / none', () => {
+    expect(deltaToken(3)).toBe('▲3');
+    expect(deltaToken(-2)).toBe('▼2');
+    expect(deltaToken(0)).toBe('=');
+    expect(deltaToken(null)).toBe('');
+  });
+});
+
+describe('renderHistoryMarkdown', () => {
+  it('handles empty history without throwing', () => {
+    const md = renderHistoryMarkdown([]);
+    expect(md).toContain('No report snapshots');
+    expect(md).toContain('dxkit-reports');
+  });
+
+  it('a single snapshot shows the current overall, no movement', () => {
+    const md = renderHistoryMarkdown([entry('a')]);
+    expect(md).toContain('Overall health: **70**');
+    // no "X → Y" arrow when there is no prior
+    expect(md).not.toMatch(/70 → 70/);
+  });
+
+  it('two snapshots print the overall movement + per-dimension deltas', () => {
+    const md = renderHistoryMarkdown([
+      entry('a', { overall: 70, security: 80 }, '2026-07-01'),
+      entry('b', { overall: 74, security: 78 }, '2026-07-02'),
+    ]);
+    // headline: overall moved 70 → 74 (▲4)
+    expect(md).toContain('Overall health: **70 → 74** (▲4)');
+    // per-dimension row: security dropped 2
+    expect(md).toMatch(/\| Security \| 80 \| 78 \| ▼2 \|/);
+    // the recent-snapshots details block lists both commits
+    expect(md).toContain('Recent snapshots');
+    expect(md).toContain('`a`'.slice(0, 3)); // commit column present
+  });
+
+  it('an unmeasured dimension shows a dash delta, never a fabricated number', () => {
+    const md = renderHistoryMarkdown([
+      entry('a', { documentation: 40 }),
+      entry('b', { documentation: null }),
+    ]);
+    // documentation went 40 → — with no numeric delta
+    expect(md).toMatch(/\| Docs \| 40 \| — \| — \|/);
+  });
+
+  it('respects the limit for the recent-snapshots table', () => {
+    const entries = Array.from({ length: 15 }, (_, i) =>
+      entry(`c${i}`, { overall: 60 + i }, `2026-07-${String(i + 1).padStart(2, '0')}`),
+    );
+    const md = renderHistoryMarkdown(entries, { limit: 3 });
+    // only the last 3 commit shas appear in the details table
+    expect(md).toContain('`c14');
+    expect(md).toContain('`c13');
+    expect(md).toContain('`c12');
+    expect(md).not.toContain('`c11');
+  });
+});
+
+describe('renderTrendText', () => {
+  it('is empty for no history', () => {
+    expect(renderTrendText([])).toEqual([]);
+  });
+
+  it('names only the dimensions that moved', () => {
+    const lines = renderTrendText([
+      entry('a', { overall: 70, security: 80, quality: 60 }),
+      entry('b', { overall: 72, security: 80, quality: 55 }),
+    ]);
+    const joined = lines.join('\n');
+    expect(joined).toContain('Overall health: 70 → 72 (▲2)');
+    expect(joined).toContain('moved:');
+    expect(joined).toContain('quality ▼5');
+    // security did not move → not listed in the moved line
+    expect(joined).not.toContain('security');
+  });
+
+  it('says nothing moved when scores are identical', () => {
+    const lines = renderTrendText([entry('a'), entry('b')]);
+    expect(lines.join('\n')).toContain('no dimension moved');
+  });
+});


### PR DESCRIPTION
Completes the reports-on-merge story shipped in 3.0: the snapshots published score history, but nothing consumed the trend beyond `report history`. This surfaces "score moved X→Y" at the two places a team already looks.

## What's new
- **CI job summary** — the `dxkit-reports-refresh` workflow appends a per-dimension "score moved X→Y" block (+ a recent-snapshots table) to `$GITHUB_STEP_SUMMARY` after publishing. Rendered by the new `report history --markdown`, so the same block drops into a PR comment.
- **`vyuh-dxkit metrics`** — a "Score over time" section under the gate's interception ROI, so one command answers both "what did the gate stop" and "how is the score trending". Gated on the repo having a `reports` policy, so `metrics` stays local/offline for repos that never enabled it.

## Design (Rule 2)
One pure delta primitive drives every surface: `scoreDeltas` / `latestDeltas` in `history.ts`, rendered by `renderHistoryMarkdown` / `renderTrendText` in the new pure `src/reports/render.ts`. Deltas are honest — an unmeasured dimension yields a dash, never a fabricated number. The duplicated score-key list is consolidated to one exported `SCORE_KEYS`.

## Tests
`test/reports/render.test.ts` (markdown + text renderers: empty / single / up / down / flat / unmeasured / limit) and delta-primitive cases in `history.test.ts`. Full suite green (3358). Validated end-to-end against the real bare-remote scratch repo from the 3.0 reports validation.

Post-3.0 follow-up, task #128 (part 2 — the consumption polish). The baseline-refresh migration (part 1) remains deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)