### PR TITLE
fix(test-gaps): exclude Go's testdata/ from test-file classification

### DIFF
--- a/src/analyzers/tests/gather.ts
+++ b/src/analyzers/tests/gather.ts
@@ -43,15 +43,16 @@ const CRITICAL_PATTERNS = [
 // ─── Test file discovery ────────────────────────────────────────────────────
 
 /**
- * A file under a fixtures / mocks / snapshots directory is test SUPPORT — sample
- * input, factory data, recorded output — NOT a test file. It has no assertions
- * by design, so a test-dir glob that swept it in would classify it as a
- * "degraded" test file (a false positive: dxkit's own analyzer fixtures, and any
- * user's `test/fixtures/**`, are not degraded tests). Matched as a path SEGMENT
- * (`.../fixtures/...`), covering the `__fixtures__` / `__mocks__` / `__snapshots__`
- * conventions too.
+ * A file under a fixtures / mocks / snapshots / testdata directory is test
+ * SUPPORT — sample input, factory data, recorded output — NOT a test file. It
+ * has no assertions by design, so a test-dir glob that swept it in would
+ * classify it as a "degraded" test file (a false positive: dxkit's own analyzer
+ * fixtures, and any user's `test/fixtures/**`, are not degraded tests). Matched
+ * as a path SEGMENT (`.../fixtures/...`), covering the tool-recognized fixture
+ * conventions across ecosystems: `__fixtures__` / `__mocks__` / `__snapshots__`
+ * (jest) and `testdata/` (the Go toolchain itself ignores a `testdata` dir).
  */
-const FIXTURE_SUPPORT_DIR = /(^|\/)(__)?(fixtures?|mocks?|snapshots?)(__)?\//i;
+const FIXTURE_SUPPORT_DIR = /(^|\/)(__)?(fixtures?|mocks?|snapshots?|testdata)(__)?\//i;
 export function isFixtureSupportPath(relPath: string): boolean {
   return FIXTURE_SUPPORT_DIR.test(relPath.replace(/\\/g, '/'));
 }

--- a/test/gather-tests.test.ts
+++ b/test/gather-tests.test.ts
@@ -115,6 +115,10 @@ describe('gatherTestFiles', () => {
     writeFile('test/fixtures/node/index.js', 'module.exports = { sample: true };');
     writeFile('src/__mocks__/thing.ts', 'export const stub = 1;');
     writeFile('test/__snapshots__/foo.snap', 'exports[`x`] = `y`;');
+    // Go's `testdata` convention — the go tool itself ignores a `testdata` dir;
+    // a `test/` glob would otherwise sweep a source file under it in as a
+    // degraded test. Placed under test/ so the dir glob does reach it.
+    writeFile('test/testdata/sample.ts', 'export const golden = { ok: true };');
     // A real test still counts.
     writeFile(
       'test/real.test.ts',
@@ -123,6 +127,7 @@ describe('gatherTestFiles', () => {
     const files = gatherTestFiles(tmp);
     expect(files.map((f) => f.path)).toEqual(['test/real.test.ts']);
     expect(files.some((f) => f.path.includes('fixtures'))).toBe(false);
+    expect(files.some((f) => f.path.includes('testdata'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Context
Investigated the test-file-degradation false positive on fixture directories. The originally-reported `test/fixtures/**` case was **already fixed at root** (the fixtures/mocks/snapshots exclusion in `gatherTestFiles`) — verified: dxkit's own repo reports **0 degraded fixture entries**, and the exact reported paths (`test/fixtures/nextjs/app/page.tsx`, `test/fixtures/node/index.js`) are correctly excluded.

## The residual gap this closes
The exclusion did **not** cover Go's `testdata/` convention. The `go` tool itself ignores a `testdata` directory, so its contents are test support, never tests — but a source file swept in under a test dir's `testdata/` would be misreported as a degraded test. This adds `testdata` to the single `FIXTURE_SUPPORT_DIR` segment matcher and extends the existing regression test to cover it.

One-line matcher change + one test case. Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)