### PR TITLE
One side-ref writer: baseline publish CLI + policy-recorded anchor transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `git checkout -B` + force-push bash — the push semantics (unchanged-skip,
   self-heal, non-fast-forward retry) live in one tested implementation.
   `doctor`'s deleted-anchor warning points at it as the repair.
+- **`vyuh-dxkit protect` now prevents anchor-branch deletion.** When the policy
+  configures anchor side branches (`baseline.anchor: "branch"` and/or
+  `reports.onMerge: true`), the command ensures a `dxkit-anchor-branches`
+  repository ruleset that blocks deleting them — the prevention layer on top of
+  doctor's detection and the refresh's self-heal. Deletion is the ONLY rule:
+  pushes (including the refresh's force-push) stay allowed, and no checks are
+  required on the side branches. Dry-run first like the rest of `protect`; a
+  plan without rulesets degrades to a warning.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`vyuh-dxkit baseline publish`** — publish `.dxkit/baselines/` to the anchor
+  side branch on the `branch` anchor transport, through the same canonical
+  side-ref writer report snapshots use (git plumbing: no checkout, working tree
+  untouched, idempotent, recreates a deleted anchor branch). The after-merge
+  refresh workflow now runs this instead of carrying its own inline
+  `git checkout -B` + force-push bash — the push semantics (unchanged-skip,
+  self-heal, non-fast-forward retry) live in one tested implementation.
+  `doctor`'s deleted-anchor warning points at it as the repair.
+
+### Fixed
+
+- **An auto-selected `branch` anchor transport is now recorded in
+  `.dxkit/policy.json`.** The guardrail check reads the side-branch anchor only
+  when the committed policy says `baseline.anchor: "branch"` — but the installer
+  used to keep an enforcement-derived pick only inside the workflow's content,
+  so the refresh published to a side branch the check never read (it gated
+  against a stale tree copy instead). The installer persists the resolved
+  transport (non-clobber; an explicit policy value always wins), and existing
+  installs are healed by the next `init`/`update`. Recording it also stops an
+  `update` run that cannot probe branch protection from wrongly migrating a
+  working branch-transport workflow back to `tree`.
+- **A deleted anchor side branch is recreated even when a stale local
+  `origin/<ref>` still matches its content.** The side-ref writer now confirms
+  the ref exists on the remote before skipping an unchanged publish, so the
+  self-heal can't be suppressed by a leftover remote-tracking ref.
+
 ## [3.0.0] - 2026-07-09
 
 The cross-repo release. dxkit's flow pillar — UI→API integration tracing and the

--- a/docs/commands/baseline.md
+++ b/docs/commands/baseline.md
@@ -102,6 +102,31 @@ What lands in the file:
 
 The file is JSON-pretty-printed for git-friendly diffs. Commit it.
 
+## `baseline publish`
+
+Publish the on-disk `.dxkit/baselines/` to the anchor side branch — the write
+half of the [`branch` anchor transport](../configuration/policy.md#anchor-transport-committed-modes).
+The transport and branch name resolve from the committed
+`.dxkit/policy.json:baseline` section, the **same source the guardrail check
+reads them from**, so the publish and the read can never disagree about where
+the anchor lives; the command refuses when the policy transport is not
+`branch` (publishing to a branch the check would never read is drift, not a
+feature).
+
+The push goes through dxkit's canonical side-ref writer (git plumbing — no
+checkout, no commit on your current branch, working tree untouched):
+
+- **idempotent** — when the anchor on the side branch already matches, nothing
+  is pushed;
+- **latest-wins** — each publish replaces the branch content with a single
+  orphan commit (no history accretion);
+- **self-healing** — a deleted anchor branch is recreated even when the
+  baseline is byte-identical (`doctor` points here when it detects one).
+
+The after-merge refresh workflow runs this right after `baseline create
+--force`; run it manually after a local capture on a branch-transport repo to
+make the new baseline the one the guardrail reads.
+
 ## `baseline show`
 
 Pretty-print the on-disk baseline. Default: summary line + per-kind
@@ -134,8 +159,11 @@ vyuh-dxkit baseline create --name release
 ## Refreshing the baseline
 
 The `--with-baseline-refresh` flag on `init` installs a GitHub Actions
-workflow that runs `baseline create --force` on every push to `main`
-and auto-commits the updated file with `[skip ci]`. The next PR's
+workflow that runs `baseline create --force` on every push to `main`,
+then stores the result per the anchor transport: on `tree` it
+auto-commits the updated file with `[skip ci]`; on `branch` it runs
+[`baseline publish`](#baseline-publish) to the unprotected side branch
+(no push to `main` at all). The next PR's
 [`guardrail check`](guardrail.md) reads the refreshed anchor without
 manual intervention.
 

--- a/docs/commands/setup-branch-protection.md
+++ b/docs/commands/setup-branch-protection.md
@@ -95,6 +95,24 @@ Safe to re-run. When an existing protection rule is present:
     → Review-count policy NOT changed (pass --require-reviews=N to require reviews).
 ```
 
+## Anchor side branches: deletion protection
+
+When the committed policy configures anchor side branches — `baseline.anchor:
+"branch"` (default `dxkit-baselines`) and/or `reports.onMerge: true` (default
+`dxkit-reports`) — the command also ensures a **`dxkit-anchor-branches`
+repository ruleset** that blocks deleting those branches. A deleted baseline
+anchor silently strands the guardrail's committed baseline until the next
+refresh; this closes the class at the source (`doctor` detects a deletion,
+`baseline publish` self-heals it, the ruleset prevents it).
+
+The ruleset carries **only the `deletion` rule** — pushes (including the
+refresh's force-push of orphan commits) stay allowed, and no checks are
+required on the side branches (a gated side branch would recreate the refresh
+deadlock the transport exists to avoid). It is created/updated idempotently
+(dry-run first, like the rest of the command), only ever edits the ruleset
+named `dxkit-anchor-branches`, and a repo plan without rulesets degrades to a
+warning with the manual path.
+
 ## See also
 
 - [`setup-prebuild`](setup-prebuild.md) — companion CLI for Codespaces

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -124,6 +124,10 @@ the anchor already matches, and recreates the branch if it was deleted
 (self-heal). Run it manually after a local `baseline create` to make the new
 capture the one the guardrail reads.
 
+To prevent the deletion in the first place, `vyuh-dxkit protect` also adds a
+deletion-only ruleset covering the anchor side branches — see
+[`setup-branch-protection`](../commands/setup-branch-protection.md#anchor-side-branches-deletion-protection).
+
 Run `vyuh-dxkit doctor` to check whether your guardrail is actually _enforced_
 (a required check on a protected branch) rather than merely wired, and
 `vyuh-dxkit protect` (dry-run by default; `--apply` to write) to require the

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -108,8 +108,21 @@ refresh stays fast and automated:
 
 Omit `anchor` and dxkit picks per your protection posture (`branch` on a
 protected default branch, else `tree`; `tree` when protection can't be probed,
-so it never silently reconfigures a repo). `ref-based` mode has no committed
-anchor, so no refresh workflow is installed at all.
+so it never silently reconfigures a repo). When the pick is `branch`, the
+installer **records `anchor: "branch"` into this policy file** (non-clobber —
+an explicit value always wins): the guardrail check reads the side-branch
+anchor only when the committed policy says so, so the transport must live
+where every consumer can see it, not just inside the workflow's content.
+Commit the change. `ref-based` mode has no committed anchor, so no refresh
+workflow is installed at all.
+
+On the `branch` transport the side branch is written by ONE path —
+`vyuh-dxkit baseline publish` (which the refresh workflow runs after
+`baseline create --force`). It publishes `.dxkit/baselines/` to `anchorRef`
+via git plumbing (no checkout, working tree untouched), skips the push when
+the anchor already matches, and recreates the branch if it was deleted
+(self-heal). Run it manually after a local `baseline create` to make the new
+capture the one the guardrail reads.
 
 Run `vyuh-dxkit doctor` to check whether your guardrail is actually _enforced_
 (a required check on a protected branch) rather than merely wired, and

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1299,6 +1299,33 @@ if [ -n "$RULE16_ORPHANED" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# ─── Side-ref push discipline (Rule 2 / Rule 11 for workflow templates) ─────
+# Publishing files to a dxkit side ref (dxkit-baselines, dxkit-reports, …) has
+# ONE implementation: src/baseline/anchor-publish.ts, reached from a workflow
+# via the CLI (`baseline publish` / `report snapshot`). A workflow template
+# that re-implements the push inline — the `git checkout -B` + `git push
+# --force` shape — forks the unchanged-skip/self-heal/idempotence semantics
+# into untested bash (the exact divergence the branch-transport refresh
+# shipped with). Plain `git push` to the DEFAULT branch (the `tree` transport,
+# deep-SAST snapshot commits) is a tracked-file commit, not a side-ref
+# publish, and stays allowed.
+SIDEREF_INLINE_PUSH=""
+for f in src-templates/.github/workflows/*.yml; do
+  hits=$(grep -nE "git checkout -B|git push (--force|-f)( |$)" "$f" 2>/dev/null | grep -v "# side-ref-push-ok" || true)
+  if [ -n "$hits" ]; then
+    SIDEREF_INLINE_PUSH="$SIDEREF_INLINE_PUSH $f"
+  fi
+done
+if [ -n "$SIDEREF_INLINE_PUSH" ]; then
+  echo "❌ Side-ref push violation: a workflow template re-implements the side-ref publish inline:"
+  for f in $SIDEREF_INLINE_PUSH; do echo "     $f"; done
+  echo "   → Publish through the CLI (\`baseline publish\` / \`report snapshot\`), which routes"
+  echo "     through the ONE writer src/baseline/anchor-publish.ts (unchanged-skip + self-heal"
+  echo "     + non-fast-forward retry live there, tested). Annotate '# side-ref-push-ok' on the"
+  echo "     line for a justified exception."
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ $ERRORS -gt 0 ]; then
   echo ""
   echo "Architecture checks failed. See CLAUDE.md for rules."

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
@@ -87,32 +87,18 @@ __DXKIT_CI_RUNTIME_SETUP__
           fi
           "${DXKIT}" baseline create --force
 
-      - name: Push anchor to the unprotected side branch
+      - name: Publish anchor to the unprotected side branch
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          ANCHOR="__DXKIT_ANCHOR_REF__"
-          # Self-heal: does the anchor branch still exist on the remote? If it was
-          # deleted, recreate it even when the baseline is byte-unchanged — else a
-          # deleted anchor stays gone until the next baseline change and the
-          # guardrail silently loses its committed baseline (fail-open).
-          if git ls-remote --exit-code --heads origin "${ANCHOR}" >/dev/null 2>&1; then
-            ANCHOR_PRESENT=1
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            DXKIT=./node_modules/.bin/vyuh-dxkit
           else
-            ANCHOR_PRESENT=0
-            echo "Anchor branch '${ANCHOR}' is missing on the remote — recreating it (self-heal)."
+            DXKIT=vyuh-dxkit
           fi
-          if [ "${ANCHOR_PRESENT}" = "1" ] && git diff --quiet -- .dxkit/baselines/; then
-            echo "Baseline unchanged and anchor '${ANCHOR}' present — nothing to refresh."
-            exit 0
-          fi
-          # Reset the side branch to the current commit plus the refreshed anchor,
-          # then force-push it. It carries only what the guardrail reads back:
-          # .dxkit/baselines/. Force is safe — this branch is dxkit-owned. The
-          # empty-commit allowance lets recreation succeed when the baseline is
-          # byte-identical (self-heal after a deletion).
-          git checkout -B "${ANCHOR}"
-          git add .dxkit/baselines/
-          git commit -m "chore(baseline): refresh anchor" --allow-empty
-          git push --force origin "${ANCHOR}"
-          echo "Anchor pushed to '${ANCHOR}'. The guardrail check hydrates it from there."
+          # The publish goes through dxkit's canonical side-ref writer (git
+          # plumbing, no checkout, never touches the working tree) — the same
+          # primitive report snapshots use. It resolves the side branch
+          # (__DXKIT_ANCHOR_REF__) from the committed .dxkit/policy.json, the
+          # SAME source the guardrail check reads it from; it skips the push
+          # when the anchor already matches, and it recreates the branch if it
+          # was deleted (self-heal) even when the baseline is byte-unchanged.
+          "${DXKIT}" baseline publish

--- a/src/analyzers/flow/config.ts
+++ b/src/analyzers/flow/config.ts
@@ -11,6 +11,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { mergeIntoPolicyFile } from '../../baseline/policy-write';
 
 /** How the guardrail treats a net-new broken integration.
  *   - `block` (default): honor the per-finding verdict — an exact, fully
@@ -122,25 +123,12 @@ export function writeFlowPolicy(
   cwd: string,
   patch: Partial<Pick<FlowConfig, 'mode' | 'stripUrlPrefixes' | 'specs'>>,
 ): boolean {
-  const abs = path.join(cwd, '.dxkit', 'policy.json');
-  let policy: { flow?: Record<string, unknown>; [k: string]: unknown } = {};
-  if (fs.existsSync(abs)) {
-    try {
-      policy = JSON.parse(fs.readFileSync(abs, 'utf8'));
-    } catch {
-      return false; // malformed — leave it; caller surfaces the note
-    }
-  }
-  // Stamp the current schema version LAST so every written flow block carries it
+  // Stamp the current schema version so every written flow block carries it
   // (a one-time migration for legacy versionless blocks, idempotent thereafter).
-  const nextFlow = {
-    ...(policy.flow ?? {}),
-    ...patch,
-    schemaVersion: FLOW_CONFIG_SCHEMA_VERSION,
-  };
-  if (JSON.stringify(policy.flow ?? {}) === JSON.stringify(nextFlow)) return false;
-  policy.flow = nextFlow;
-  fs.mkdirSync(path.dirname(abs), { recursive: true });
-  fs.writeFileSync(abs, JSON.stringify(policy, null, 2) + '\n', 'utf8');
-  return true;
+  // The read-merge-write mechanics live in the canonical policy merge-writer:
+  // sibling sections survive, a malformed file is never clobbered (returns
+  // false; caller surfaces the note), an unchanged merge writes nothing.
+  return mergeIntoPolicyFile(cwd, {
+    flow: { ...patch, schemaVersion: FLOW_CONFIG_SCHEMA_VERSION },
+  }).changed;
 }

--- a/src/anchor-ruleset.ts
+++ b/src/anchor-ruleset.ts
@@ -1,0 +1,161 @@
+/**
+ * Deletion protection for dxkit's anchor side branches — the PREVENT layer of
+ * the deleted-anchor class (doctor DETECTS a missing anchor branch;
+ * `baseline publish` / the refresh workflow SELF-HEAL it; this stops the
+ * deletion from happening at all).
+ *
+ * The anchor side branches (`dxkit-baselines` on the `branch` baseline
+ * transport, `dxkit-reports` for on-merge report snapshots) are deliberately
+ * unprotected against pushes — the refresh force-pushes orphan commits by
+ * design — but nothing should DELETE them: a deleted baseline anchor silently
+ * strands the guardrail's committed baseline until the next refresh. A
+ * repository ruleset with ONLY the `deletion` rule expresses exactly that:
+ * pushes (including forced) stay allowed, deletion is blocked.
+ *
+ * Mirror of the enforcement module's shape (pure classifier + injectable
+ * reads): `anchorRefsFromPolicy` resolves WHICH refs need protecting from the
+ * same committed policy every other consumer reads (Rule 2);
+ * `planAnchorRuleset` is a pure function from (refs, existing ruleset) to the
+ * action to take — unit-testable without GitHub; the thin IO in
+ * `setup-branch-protection.ts` executes the plan through an injectable
+ * `gh` caller.
+ */
+import { loadPolicyFromCwd } from './baseline/policy';
+import { DEFAULT_ANCHOR_REF } from './baseline/modes';
+import { DEFAULT_REPORTS_REF } from './reports/snapshot';
+
+/** Name of the dxkit-owned ruleset. The planner recognizes ONLY this ruleset
+ *  as its own — it never edits a customer's rulesets. */
+export const ANCHOR_RULESET_NAME = 'dxkit-anchor-branches';
+
+/** Subset of GitHub's repository-ruleset shape that the planner touches. */
+export interface RulesetDetail {
+  readonly id?: number;
+  readonly name: string;
+  readonly target?: string;
+  readonly enforcement?: string;
+  readonly conditions?: {
+    readonly ref_name?: { readonly include?: string[]; readonly exclude?: string[] };
+  };
+  readonly rules?: Array<{ readonly type: string }>;
+}
+
+export interface AnchorRulesetPlan {
+  readonly action: 'none' | 'create' | 'update';
+  /** Human-readable why (rendered in dry-run and no-op output). */
+  readonly reason: string;
+  /** Branch names (not fully-qualified refs) the plan protects. */
+  readonly refs: readonly string[];
+  /** Payload for POST (create) or PUT (update). */
+  readonly payload?: RulesetDetail;
+  /** Ruleset id to PUT to when action is 'update'. */
+  readonly rulesetId?: number;
+}
+
+/**
+ * Which side branches carry a dxkit anchor, per the committed policy — the
+ * same sections the writers and readers resolve from, so protect/publish/read
+ * can never disagree about which branches matter:
+ *   - `baseline.anchor: 'branch'` → its `anchorRef` (default `dxkit-baselines`)
+ *   - `reports.onMerge: true`     → its `anchorRef` (default `dxkit-reports`)
+ */
+export function anchorRefsFromPolicy(cwd: string): string[] {
+  let policy;
+  try {
+    policy = loadPolicyFromCwd(cwd);
+  } catch {
+    return [];
+  }
+  const refs: string[] = [];
+  if (policy.baseline?.anchor === 'branch') {
+    refs.push(policy.baseline.anchorRef ?? DEFAULT_ANCHOR_REF);
+  }
+  if (policy.reports?.onMerge === true) {
+    refs.push(policy.reports.anchorRef ?? DEFAULT_REPORTS_REF);
+  }
+  return [...new Set(refs)];
+}
+
+const qualify = (branch: string): string => `refs/heads/${branch}`;
+
+/**
+ * Pure planner: given the anchor branches to protect and dxkit's OWN existing
+ * ruleset (null when absent), decide create / update / nothing.
+ *
+ * The ruleset carries ONLY the `deletion` rule — never `non_fast_forward`
+ * (the baseline anchor is force-pushed orphan commits by design) and never
+ * required checks (a gated side branch is the refresh deadlock the transport
+ * exists to avoid). An update merges missing refs into the include list and
+ * preserves everything else on the ruleset (non-clobber, same discipline as
+ * the policy merge-writer).
+ */
+export function planAnchorRuleset(
+  refs: readonly string[],
+  existing: RulesetDetail | null,
+): AnchorRulesetPlan {
+  if (refs.length === 0) {
+    return {
+      action: 'none',
+      reason:
+        "no anchor side branches configured (baseline.anchor is not 'branch' and " +
+        'reports.onMerge is off)',
+      refs,
+    };
+  }
+  const wanted = refs.map(qualify);
+
+  if (!existing) {
+    return {
+      action: 'create',
+      reason: `no '${ANCHOR_RULESET_NAME}' ruleset yet`,
+      refs,
+      payload: {
+        name: ANCHOR_RULESET_NAME,
+        target: 'branch',
+        enforcement: 'active',
+        conditions: { ref_name: { include: wanted, exclude: [] } },
+        rules: [{ type: 'deletion' }],
+      },
+    };
+  }
+
+  const include = existing.conditions?.ref_name?.include ?? [];
+  const missing = wanted.filter((r) => !include.includes(r));
+  const hasDeletion = (existing.rules ?? []).some((r) => r.type === 'deletion');
+  const active = existing.enforcement === 'active';
+  if (missing.length === 0 && hasDeletion && active) {
+    return {
+      action: 'none',
+      reason: `'${ANCHOR_RULESET_NAME}' already blocks deletion of ${refs.join(', ')}`,
+      refs,
+    };
+  }
+
+  // PUT body: the existing ruleset with the gaps filled, minus its `id` (the
+  // id addresses the endpoint, not the payload).
+  const rest: RulesetDetail & { id?: number } = { ...existing };
+  delete rest.id;
+  return {
+    action: 'update',
+    reason:
+      missing.length > 0
+        ? `'${ANCHOR_RULESET_NAME}' exists but does not cover ${missing.join(', ')}`
+        : !hasDeletion
+          ? `'${ANCHOR_RULESET_NAME}' exists but lost its deletion rule`
+          : `'${ANCHOR_RULESET_NAME}' exists but is not active`,
+    refs,
+    ...(existing.id !== undefined ? { rulesetId: existing.id } : {}),
+    payload: {
+      ...rest,
+      enforcement: 'active',
+      conditions: {
+        ...existing.conditions,
+        ref_name: {
+          include: [...include, ...missing],
+          exclude: existing.conditions?.ref_name?.exclude ?? [],
+        },
+      },
+      rules: hasDeletion ? existing.rules : [...(existing.rules ?? []), { type: 'deletion' }],
+    },
+  };
+}

--- a/src/baseline/anchor-publish.ts
+++ b/src/baseline/anchor-publish.ts
@@ -19,6 +19,9 @@
  * current `origin/<ref>` tip, so unchanged files persist and history accrues
  * (reports append `report-history.jsonl` + refresh `latest/`); `false` writes an
  * orphan single-parentless commit (replace-all, the baseline latest-wins model).
+ * Both modes skip the push when the tree they would write already matches the
+ * remote tip (idempotent refresh) — and because a deleted ref has no tip, a
+ * republish after deletion always goes through (self-heal), even byte-identical.
  * `removePaths` deletes entries (report snapshot pruning). A non-fast-forward
  * push (a concurrent merge advanced the ref) is retried once against the new tip.
  */
@@ -90,6 +93,16 @@ export function readFromAnchorRef(cwd: string, anchorRef: string, relPath: strin
   return null;
 }
 
+/** Does the ref exist on the REMOTE right now? `null` when unknown (offline /
+ *  no ls-remote) — used only to veto the no-change skip, never to fail. */
+function remoteRefExists(git: (args: string[]) => string, anchorRef: string): boolean | null {
+  try {
+    return git(['ls-remote', '--heads', 'origin', anchorRef]).trim().length > 0;
+  } catch {
+    return null;
+  }
+}
+
 /** Resolve the tree-ish + commit of the current side-ref tip, or null if absent. */
 function resolveTip(
   git: (args: string[]) => string,
@@ -147,18 +160,19 @@ export function publishFilesToAnchorRef(opts: PublishToAnchorOptions): PublishRe
 
     const buildAndPush = (): PublishResult => {
       const baseParent = opts.baseParent !== false;
-      if (baseParent) {
-        // Refresh the remote-tracking ref so `resolveTip` bases the commit on the
-        // TRUE remote tip — a prior push-by-refspec doesn't reliably update the
-        // local `origin/<ref>` on every git version, and this also picks up a
-        // concurrent merge's advance before we build.
-        try {
-          git(['fetch', '--depth=1', 'origin', anchorRef]);
-        } catch {
-          /* first publish (ref absent) / offline — resolveTip returns null */
-        }
+      // Refresh the remote-tracking ref so `resolveTip` sees the TRUE remote
+      // tip — a prior push-by-refspec doesn't reliably update the local
+      // `origin/<ref>` on every git version, and this also picks up a
+      // concurrent merge's advance before we build. Both modes need it:
+      // accumulate bases the commit on it, replace-all compares against it for
+      // the no-change skip below.
+      try {
+        git(['fetch', '--depth=1', 'origin', anchorRef]);
+      } catch {
+        /* first publish (ref absent) / offline — resolveTip returns null */
       }
-      const tip = baseParent ? resolveTip(git, anchorRef) : null;
+      const remoteTip = resolveTip(git, anchorRef);
+      const tip = baseParent ? remoteTip : null;
 
       // Seed the temp index from the base tree (accumulate) or empty (orphan).
       if (tip) git(['read-tree', tip.tree]);
@@ -179,8 +193,16 @@ export function publishFilesToAnchorRef(opts: PublishToAnchorOptions): PublishRe
       }
 
       const tree = git(['write-tree']).trim();
-      // No change vs the base tree → nothing to publish (idempotent refresh).
-      if (tip && tree === tip.tree) {
+      // No change vs the remote tip's tree → nothing to publish (idempotent
+      // refresh). This applies in BOTH modes: replace-all compares the orphan
+      // tree it would write against what's already on the ref, so a periodic
+      // refresh with identical content pushes nothing. Before skipping, confirm
+      // the ref still EXISTS on the remote: `resolveTip` falls back to a stale
+      // local `origin/<ref>` when the fetch fails, and a fetch fails both when
+      // offline AND when the remote branch was deleted — in the deleted case a
+      // byte-identical republish must still push (the self-heal path), or the
+      // anchor stays gone until the content next changes.
+      if (remoteTip && tree === remoteTip.tree && remoteRefExists(git, anchorRef) !== false) {
         return { pushed: false, commit: null, reason: 'no change' };
       }
       const commitArgs = ['commit-tree', tree, '-m', opts.message];

--- a/src/baseline/anchor.ts
+++ b/src/baseline/anchor.ts
@@ -10,13 +10,19 @@
  * guardrail check must read the anchor from the side branch, so their verdicts
  * agree — reading a stale tree copy locally is exactly the drift this closes.
  *
- * This module is the single reader of that side branch (`git show
- * origin/<anchorRef>:<path>`), in two flavors:
+ * This module is the single reader AND the single publisher of that side
+ * branch, so the two sides cannot drift (CLAUDE.md Rule 2 — the read and the
+ * write resolve the transport + ref from the SAME policy section):
  *   - `loadAnchorFromBranch` — read-only: writes the anchor to a TEMP file and
  *     returns its path, never touching the working tree (what a `guardrail
  *     check` uses — a read must not mutate a tracked file).
  *   - `hydrateAnchorFromBranch` — materialize the anchor AT `baselinePath` (used
  *     when the tree copy is simply absent, e.g. a CI checkout).
+ *   - `publishBaselineAnchor` — publish `.dxkit/baselines/` to the side branch
+ *     through the canonical side-ref writer (`anchor-publish.ts`), replace-all
+ *     (latest-wins). What `vyuh-dxkit baseline publish` and therefore the
+ *     after-merge refresh workflow run — never an inline `git push` in a
+ *     workflow's bash.
  *
  * Both are scoped to `anchor === 'branch'` and fail-open on any git error (wrong
  * transport, side branch not created yet, offline) returns null/false and the
@@ -29,8 +35,13 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { DEFAULT_ANCHOR_REF } from './modes';
-import { readFromAnchorRef } from './anchor-publish';
-import type { BaselineSection } from './policy';
+import {
+  publishFilesToAnchorRef,
+  readFromAnchorRef,
+  type AnchorFile,
+  type PublishResult,
+} from './anchor-publish';
+import { loadPolicyFromCwd, type BaselineSection } from './policy';
 
 /**
  * Fetch the baseline anchor's content from the side branch. Returns the file
@@ -107,6 +118,116 @@ export interface AnchorBranchStatus {
   anchorRef: string;
   remoteReachable: boolean;
   branchExists: boolean;
+}
+
+/** Outcome of a `baseline publish`. `ok:false` carries `error` (wrong
+ *  transport / nothing captured); a transport failure (no origin, rejected
+ *  push) surfaces on `publish.reason` with `ok:true` left false-ish only via
+ *  `publish.pushed` — the CLI decides loud-vs-quiet per reason. */
+export interface BaselineAnchorPublishOutcome {
+  readonly ok: boolean;
+  readonly anchorRef: string;
+  /** Files published (count of `.dxkit/baselines/` entries). */
+  readonly files: number;
+  /** The side branch was missing on a reachable remote and this publish
+   *  recreated it — the deleted-anchor self-heal path. */
+  readonly selfHealed: boolean;
+  readonly publish?: PublishResult;
+  readonly error?: string;
+}
+
+/** Collect every file under `.dxkit/baselines/` as anchor files (repo-relative
+ *  POSIX paths) — exactly what the guardrail reader resolves off the ref. */
+function collectBaselineFiles(cwd: string): AnchorFile[] {
+  const root = path.join(cwd, '.dxkit', 'baselines');
+  const out: AnchorFile[] = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const abs = path.join(dir, e.name);
+      if (e.isDirectory()) walk(abs);
+      else if (e.isFile()) {
+        out.push({
+          path: path.relative(cwd, abs).split(path.sep).join('/'),
+          content: fs.readFileSync(abs, 'utf8'),
+        });
+      }
+    }
+  };
+  walk(root);
+  return out;
+}
+
+/**
+ * Publish the on-disk `.dxkit/baselines/` to the anchor side branch —
+ * replace-all (latest-wins), through the ONE side-ref writer. Resolves the
+ * transport + ref from the SAME policy section the guardrail reader uses, so
+ * the two sides cannot disagree about where the anchor lives. Refuses (ok:false)
+ * when the policy transport is not `branch` — publishing to a side branch the
+ * check would never read is exactly the drift this module exists to prevent.
+ *
+ * Idempotent + self-healing via the writer: identical content pushes nothing,
+ * while a deleted side branch is recreated even when the content is unchanged.
+ */
+export function publishBaselineAnchor(
+  cwd: string,
+  sectionOverride?: BaselineSection,
+): BaselineAnchorPublishOutcome {
+  let section = sectionOverride;
+  if (section === undefined) {
+    try {
+      section = loadPolicyFromCwd(cwd).baseline;
+    } catch {
+      section = undefined;
+    }
+  }
+  const anchorRef = section?.anchorRef ?? DEFAULT_ANCHOR_REF;
+  if (section?.anchor !== 'branch') {
+    return {
+      ok: false,
+      anchorRef,
+      files: 0,
+      selfHealed: false,
+      error:
+        "the baseline anchor transport is not 'branch' — set .dxkit/policy.json:baseline.anchor " +
+        "to 'branch' (the guardrail check only reads a side-branch anchor when the policy says so).",
+    };
+  }
+  const files = collectBaselineFiles(cwd);
+  if (files.length === 0) {
+    return {
+      ok: false,
+      anchorRef,
+      files: 0,
+      selfHealed: false,
+      error: 'no baseline captured — run `baseline create` first (.dxkit/baselines/ is empty).',
+    };
+  }
+
+  // Probe BEFORE publishing so a recreated-after-deletion push is reported as
+  // the self-heal it is (doctor's deleted-anchor warning points here as the repair).
+  const before = anchorBranchStatus(cwd, section);
+  const missing = before.remoteReachable && !before.branchExists;
+
+  const publish = publishFilesToAnchorRef({
+    cwd,
+    anchorRef,
+    files,
+    message: 'chore(baseline): refresh anchor',
+    baseParent: false,
+  });
+  return {
+    ok: true,
+    anchorRef,
+    files: files.length,
+    selfHealed: missing && publish.pushed,
+    publish,
+  };
 }
 
 export function anchorBranchStatus(

--- a/src/baseline/policy-write.ts
+++ b/src/baseline/policy-write.ts
@@ -1,0 +1,84 @@
+/**
+ * The ONE merge-writer for `.dxkit/policy.json` (CLAUDE.md Rule 2). Every code
+ * path that records configuration into the policy file — `configure --apply`,
+ * the flow setup, the loop-preset seed, the anchor-transport persist — routes
+ * its write through `mergeIntoPolicyFile` so the non-clobber discipline lives
+ * in one place:
+ *
+ *   - existing keys are PRESERVED (deep merge; the patch only adds/overrides
+ *     the keys it names),
+ *   - a malformed existing file is never overwritten (reported, left intact),
+ *   - the write is idempotent (byte-equal merge result → file untouched).
+ *
+ * Domain decisions (WHAT to write, whether an existing value should win) stay
+ * with the callers — this module owns only the read-merge-write mechanics.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface PolicyMergeOutcome {
+  readonly changed: boolean;
+  /** Why nothing was written when `changed` is false. */
+  readonly reason?: 'no-change' | 'malformed-policy';
+}
+
+/** True for a plain (non-array, non-null) object. */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Recursively merge `patch` over `base`, returning a NEW object. Nested plain
+ * objects merge key-by-key (so a patch that sets `flow.mode` preserves a
+ * sibling `flow.specs`); arrays and primitives are replaced by the patch value.
+ * Deterministic and pure over its inputs.
+ */
+export function deepMergePolicy(
+  base: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...base };
+  for (const [key, patchVal] of Object.entries(patch)) {
+    const baseVal = out[key];
+    out[key] =
+      isPlainObject(baseVal) && isPlainObject(patchVal)
+        ? deepMergePolicy(baseVal, patchVal)
+        : patchVal;
+  }
+  return out;
+}
+
+/** Best-effort parse of the existing policy file. `{}` when absent; `null`
+ *  when present but malformed (the caller must not overwrite it). */
+export function readPolicyFileRaw(cwd: string): Record<string, unknown> | null {
+  const abs = path.join(cwd, '.dxkit', 'policy.json');
+  if (!fs.existsSync(abs)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(abs, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Deep-merge `patch` into `.dxkit/policy.json`, preserving every existing key.
+ * Creates the file (and `.dxkit/`) when absent. Refuses to touch a malformed
+ * existing file. Returns whether the file changed.
+ */
+export function mergeIntoPolicyFile(
+  cwd: string,
+  patch: Record<string, unknown>,
+): PolicyMergeOutcome {
+  const policy = readPolicyFileRaw(cwd);
+  if (policy === null) return { changed: false, reason: 'malformed-policy' };
+
+  const merged = deepMergePolicy(policy, patch);
+  if (JSON.stringify(policy) === JSON.stringify(merged)) {
+    return { changed: false, reason: 'no-change' };
+  }
+
+  const abs = path.join(cwd, '.dxkit', 'policy.json');
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, JSON.stringify(merged, null, 2) + '\n', 'utf8');
+  return { changed: true };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,6 +184,13 @@ ${renderCommandIndex().join('\n')}
                                  (read later by guardrail check to gate new regressions).
                                  --mode=committed-full|committed-sanitized|ref-based picks
                                  the on-disk posture; default auto-selects from repo visibility.
+    vyuh-dxkit baseline publish [path]
+                                 Publish .dxkit/baselines/ to the anchor side branch
+                                 (baseline.anchor: 'branch' in .dxkit/policy.json) via
+                                 dxkit's canonical side-ref writer — replace-all, idempotent,
+                                 recreates a deleted anchor branch. The after-merge refresh
+                                 workflow runs this; run it manually after a local
+                                 \`baseline create\` on a branch-transport repo.
     vyuh-dxkit baseline show [path] [--name <n>] [--baseline <path>]
                              [--kind <kind>] [--json]
                                  Pretty-print the on-disk baseline. Default: summary +
@@ -2226,6 +2233,52 @@ export async function run(argv: string[]): Promise<void> {
           logger.fail((err as Error).message);
           process.exit(1);
         }
+        // With the `branch` anchor transport the SIDE BRANCH is what the
+        // guardrail reads — a freshly-captured tree copy is invisible until
+        // published there. Point at the one publish path.
+        try {
+          const { loadPolicyFromCwd } = await import('./baseline/policy');
+          if (loadPolicyFromCwd(targetPath).baseline?.anchor === 'branch') {
+            logger.dim(
+              `  Anchor transport is 'branch': run \`${dxkitCli('baseline publish')}\` to make ` +
+                `this baseline the one the guardrail reads (the refresh workflow does this on merge).`,
+            );
+          }
+        } catch {
+          /* unreadable policy — the create result stands on its own */
+        }
+        break;
+      }
+      if (subCommand === 'publish') {
+        const targetPath = resolveRepoPath(positionals[2]);
+        const { publishBaselineAnchor } = await import('./baseline/anchor');
+        logger.header('vyuh-dxkit baseline publish');
+        const outcome = publishBaselineAnchor(targetPath);
+        if (!outcome.ok) {
+          logger.fail(outcome.error ?? 'baseline publish failed.');
+          process.exit(1);
+        }
+        const publish = outcome.publish;
+        if (publish?.pushed) {
+          logger.success(
+            `Published ${outcome.files} baseline file(s) to '${outcome.anchorRef}' ` +
+              `(${publish.commit?.slice(0, 12)}). The guardrail check hydrates the anchor from there.`,
+          );
+          if (outcome.selfHealed) {
+            logger.info(
+              `The '${outcome.anchorRef}' branch was missing on the remote — recreated it (self-heal).`,
+            );
+          }
+        } else if (publish?.reason === 'no change') {
+          logger.info(
+            `Anchor on '${outcome.anchorRef}' already matches .dxkit/baselines/ — nothing to publish.`,
+          );
+        } else {
+          // No origin / rejected push: in the refresh workflow this is a broken
+          // run, not a soft skip — fail loud so CI surfaces it.
+          logger.fail(`Anchor publish did not push: ${publish?.reason ?? 'unknown'}.`);
+          process.exit(1);
+        }
         break;
       }
       if (subCommand === 'show') {
@@ -2269,6 +2322,7 @@ export async function run(argv: string[]): Promise<void> {
       logger.fail(
         `Unknown baseline subcommand: ${subCommand ?? '(missing)'}. ` +
           `Available: vyuh-dxkit baseline create [path] [--name <name>] [--force] · ` +
+          `vyuh-dxkit baseline publish [path] · ` +
           `vyuh-dxkit baseline show [path] [--name <name>] [--baseline <path>] [--kind <kind>] [--json]`,
       );
       process.exit(1);

--- a/src/configure-cli.ts
+++ b/src/configure-cli.ts
@@ -23,10 +23,9 @@
  * is the conversational driver: it runs `--plan`, shows it, gets the user's
  * confirmation, then runs `--apply`.
  */
-import * as fs from 'fs';
-import * as path from 'path';
 import * as logger from './logger';
 import { gatherConfigPlan, type ConfigPlanItem, type ConfigContext } from './discovery/commands';
+import { deepMergePolicy, mergeIntoPolicyFile } from './baseline/policy-write';
 
 export interface ConfigureOptions {
   /** Write the plan into policy.json (default is plan-only, no write). */
@@ -158,59 +157,18 @@ export interface ApplyResult {
 
 /**
  * Deep-merge every plan item's `patch` into `.dxkit/policy.json`, PRESERVING
- * every existing key — the same non-clobber discipline `writeFlowPolicy` /
- * `ensureLoopPreset` use for their single sections, generalized to the whole
- * configure pass (this is the ONE writer for the configure concern). Idempotent:
- * if the merged result equals what's on disk, the file is left untouched. A
- * malformed existing policy is left intact and reported via the return
+ * every existing key. The read-merge-write mechanics live in the canonical
+ * policy merge-writer (`mergeIntoPolicyFile`, Rule 2); this wrapper folds the
+ * plan's patches into one merged patch and reports which sections it carried.
+ * A malformed existing policy is left intact and reported via the return
  * (`changed: false`), never overwritten.
  */
 export function applyConfigPlan(cwd: string, plan: readonly ConfigPlanItem[]): ApplyResult {
   const sections = plan.map((p) => p.section);
   if (plan.length === 0) return { changed: false, sections };
 
-  const abs = path.join(cwd, '.dxkit', 'policy.json');
-  let policy: Record<string, unknown> = {};
-  if (fs.existsSync(abs)) {
-    try {
-      policy = JSON.parse(fs.readFileSync(abs, 'utf8')) as Record<string, unknown>;
-    } catch {
-      // Malformed — never clobber a file we can't parse.
-      return { changed: false, sections };
-    }
-  }
-
-  const before = JSON.stringify(policy);
-  let merged = policy;
-  for (const item of plan) merged = deepMerge(merged, item.patch);
-  const after = JSON.stringify(merged);
-  if (before === after) return { changed: false, sections };
-
-  fs.mkdirSync(path.dirname(abs), { recursive: true });
-  fs.writeFileSync(abs, JSON.stringify(merged, null, 2) + '\n', 'utf8');
-  return { changed: true, sections };
-}
-
-/** True for a plain (non-array, non-null) object. */
-function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null && !Array.isArray(v);
-}
-
-/**
- * Recursively merge `patch` over `base`, returning a NEW object. Nested plain
- * objects merge key-by-key (so a `patch` that sets `flow.mode` preserves a
- * sibling `flow.specs`); arrays and primitives are replaced by the patch value.
- * Deterministic and pure over its inputs.
- */
-function deepMerge(
-  base: Record<string, unknown>,
-  patch: Record<string, unknown>,
-): Record<string, unknown> {
-  const out: Record<string, unknown> = { ...base };
-  for (const [key, patchVal] of Object.entries(patch)) {
-    const baseVal = out[key];
-    out[key] =
-      isPlainObject(baseVal) && isPlainObject(patchVal) ? deepMerge(baseVal, patchVal) : patchVal;
-  }
-  return out;
+  let patch: Record<string, unknown> = {};
+  for (const item of plan) patch = deepMergePolicy(patch, item.patch);
+  const outcome = mergeIntoPolicyFile(cwd, patch);
+  return { changed: outcome.changed, sections };
 }

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -236,9 +236,11 @@ export const COMMANDS = [
     id: 'baseline',
     audience: 'user',
     group: 'gate',
-    summary: 'Capture / show per-finding baselines for the guardrail',
+    summary: 'Capture / publish / show per-finding baselines for the guardrail',
     docsBlurb:
-      'Record per-finding identities the guardrail check diffs against to gate net-new regressions.',
+      'Record per-finding identities the guardrail check diffs against to gate net-new ' +
+      'regressions. `baseline publish` pushes the captured anchor to the side branch on the ' +
+      '`branch` anchor transport — the one side-ref write path the refresh workflow runs.',
     whenToRecommend: recommendBaseline,
     planConfig: planBaselineMode,
   },

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -99,7 +99,9 @@ export const COMMANDS = [
     aliases: ['protect'],
     summary: 'Set up branch protection / required checks (dry-run by default)',
     docsBlurb:
-      'Configure branch protection so the guardrail check is a required status. `protect` is the dry-run-first alias.',
+      'Configure branch protection so the guardrail check is a required status, and add a ' +
+      'deletion-protection ruleset for the dxkit anchor side branches. `protect` is the ' +
+      'dry-run-first alias.',
   },
   {
     id: 'setup-prebuild',

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -517,10 +517,11 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
               hint:
                 `The '${anchorStatus.anchorRef}' anchor branch is missing (deleted?). The ` +
                 `branch-transport guardrail reads the committed baseline from it — without it ` +
-                `the gate silently loses its baseline. Recapture the baseline and re-run the ` +
-                `refresh workflow (or push .dxkit/baselines/ to '${anchorStatus.anchorRef}'). ` +
-                `Restrict deletion of that branch to prevent recurrence.`,
-              command: dxkitCli('baseline create --force'),
+                `the gate silently loses its baseline. Recapture (\`${dxkitCli('baseline create --force')}\`) ` +
+                `then run \`${dxkitCli('baseline publish')}\` to recreate the branch (self-heal; ` +
+                `the refresh workflow also does this on its next run). Restrict deletion of ` +
+                `that branch to prevent recurrence.`,
+              command: dxkitCli('baseline publish'),
             },
           }),
     });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -519,8 +519,9 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
                 `branch-transport guardrail reads the committed baseline from it — without it ` +
                 `the gate silently loses its baseline. Recapture (\`${dxkitCli('baseline create --force')}\`) ` +
                 `then run \`${dxkitCli('baseline publish')}\` to recreate the branch (self-heal; ` +
-                `the refresh workflow also does this on its next run). Restrict deletion of ` +
-                `that branch to prevent recurrence.`,
+                `the refresh workflow also does this on its next run). Then run ` +
+                `\`${dxkitCli('protect --apply')}\` — it adds a deletion-protection ruleset for ` +
+                `the anchor branches so this cannot recur.`,
               command: dxkitCli('baseline publish'),
             },
           }),

--- a/src/loop/scaffold.ts
+++ b/src/loop/scaffold.ts
@@ -19,6 +19,7 @@ import * as path from 'path';
 import type { ShipInstallResult } from '../ship-installers';
 import { DEFAULT_LOOP_PRESET, type LoopPreset } from './policy';
 import { claudeHookCommand } from '../self-invocation';
+import { mergeIntoPolicyFile, readPolicyFileRaw } from '../baseline/policy-write';
 
 /** The command Claude Code runs on Stop. Built from the canonical CLI
  *  invocation (`src/self-invocation.ts`) so the installer, doctor, and any
@@ -220,27 +221,22 @@ function ensureLoopPreset(
   result: ShipInstallResult,
 ): void {
   const rel = path.join('.dxkit', 'policy.json');
-  const abs = path.join(cwd, rel);
 
-  let policy: { loop?: { preset?: string }; [k: string]: unknown } = {};
-  if (fs.existsSync(abs)) {
-    try {
-      policy = JSON.parse(fs.readFileSync(abs, 'utf8'));
-    } catch {
-      result.notes.push(`${rel} is not valid JSON — left untouched. Set loop.preset by hand.`);
-      return;
-    }
+  const policy = readPolicyFileRaw(cwd);
+  if (policy === null) {
+    result.notes.push(`${rel} is not valid JSON — left untouched. Set loop.preset by hand.`);
+    return;
   }
-  const existing = policy.loop?.preset;
-  // Override on explicit; else keep existing; else seed the default.
+  const existing = (policy.loop as { preset?: string } | undefined)?.preset;
+  // Override on explicit; else keep existing; else seed the default. The write
+  // goes through the canonical policy merge-writer (Rule 2): sibling sections
+  // survive, unchanged merges write nothing.
   const target = explicit ?? existing ?? DEFAULT_LOOP_PRESET;
   if (existing === target) {
     result.skipped.push(rel);
     return;
   }
-  policy.loop = { ...policy.loop, preset: target };
-  fs.mkdirSync(path.dirname(abs), { recursive: true });
-  fs.writeFileSync(abs, JSON.stringify(policy, null, 2) + '\n', 'utf8');
+  mergeIntoPolicyFile(cwd, { loop: { preset: target } });
   result.installed.push(rel);
 }
 

--- a/src/setup-branch-protection.ts
+++ b/src/setup-branch-protection.ts
@@ -41,6 +41,12 @@ import {
   GUARDRAIL_CHECK,
   LEGACY_GUARDRAIL_CHECK,
 } from './enforcement';
+import {
+  ANCHOR_RULESET_NAME,
+  anchorRefsFromPolicy,
+  planAnchorRuleset,
+  type RulesetDetail,
+} from './anchor-ruleset';
 
 export interface SetupBranchProtectionOpts {
   /** Branch to protect. Defaults to the repo's default branch. */
@@ -161,6 +167,26 @@ export async function runSetupBranchProtection(
   }
   const { owner, repo } = ownerRepo;
 
+  const status = protectDefaultBranch(cwd, owner, repo, opts);
+  if (status === 'error') return;
+
+  // Second section: deletion protection for the anchor side branches (the
+  // baseline anchor + the reports ref). Runs regardless of how the
+  // default-branch section resolved short of an error — "already protected"
+  // up top doesn't mean the anchors are.
+  protectAnchorBranches(cwd, {
+    owner,
+    repo,
+    ...(opts.dryRun !== undefined && { dryRun: opts.dryRun }),
+  });
+}
+
+function protectDefaultBranch(
+  cwd: string,
+  owner: string,
+  repo: string,
+  opts: SetupBranchProtectionOpts,
+): 'done' | 'error' {
   const branch = opts.branch ?? resolveDefaultBranch(cwd);
 
   // Warn if the workflow file isn't present — protection-by-name would
@@ -172,7 +198,7 @@ export async function runSetupBranchProtection(
     );
     logger.dim(`  → Run \`${dxkitCli('init --with-ci --yes')}\` first to scaffold the workflow.`);
     process.exitCode = 1;
-    return;
+    return 'error';
   }
 
   // Read the branch's EFFECTIVE enforcement first (classic protection AND
@@ -187,7 +213,7 @@ export async function runSetupBranchProtection(
       logger.success(
         `${owner}/${repo}#${branch} already requires the ${REQUIRED_CHECK} check — nothing to do.`,
       );
-      return;
+      return 'done';
     }
     if (state.rulesetGoverned) {
       console.log(''); // slop-ok
@@ -197,7 +223,7 @@ export async function runSetupBranchProtection(
       );
       logger.dim(`  → Add '${REQUIRED_CHECK}' to that ruleset's required status checks:`);
       logger.dim(`     https://github.com/${owner}/${repo}/settings/rules`);
-      return;
+      return 'done';
     }
   } catch (e) {
     // Fail-open: if we couldn't read enforcement (gh error, no scope), fall
@@ -212,7 +238,7 @@ export async function runSetupBranchProtection(
   } catch (e) {
     if (e instanceof GhError) {
       process.exitCode = renderGhError(e, 'Read existing protection');
-      return;
+      return 'error';
     }
     throw e;
   }
@@ -242,7 +268,7 @@ export async function runSetupBranchProtection(
     );
     console.log(''); // slop-ok
     logger.info(`Re-run with \`${dxkitCli('protect --apply')}\` to write these settings.`);
-    return;
+    return 'done';
   }
 
   logger.info(
@@ -259,7 +285,7 @@ export async function runSetupBranchProtection(
   } catch (e) {
     if (e instanceof GhError) {
       process.exitCode = renderGhError(e, 'Apply protection');
-      return;
+      return 'error';
     }
     throw e;
   }
@@ -272,4 +298,112 @@ export async function runSetupBranchProtection(
       '  → Review-count policy NOT changed (pass --require-reviews=N to require reviews).',
     );
   }
+  return 'done';
+}
+
+/** `ghApi`-shaped caller, injectable for tests (the gh-api harness). */
+export type GhApiFn = typeof ghApi;
+
+export interface AnchorProtectionArgs {
+  owner: string;
+  repo: string;
+  dryRun?: boolean;
+  gh?: GhApiFn;
+}
+
+/**
+ * Deletion protection for the anchor side branches — executes the pure
+ * `planAnchorRuleset` plan (see `anchor-ruleset.ts` for the why). Add-on
+ * semantics: silent when the policy configures no anchor branches, and a
+ * failure here WARNS without failing the command (rulesets aren't available
+ * on every plan; doctor still detects a deleted anchor, and the refresh
+ * self-heals it — this layer is prevention, not the only net).
+ */
+export function protectAnchorBranches(cwd: string, args: AnchorProtectionArgs): void {
+  const gh = args.gh ?? ghApi;
+  const { owner, repo } = args;
+  const refs = anchorRefsFromPolicy(cwd);
+  if (refs.length === 0) return;
+
+  console.log(''); // slop-ok
+  logger.info(
+    `Anchor side branch(es) per .dxkit/policy.json: ${refs.join(', ')} — checking deletion protection...`,
+  );
+
+  let existing: RulesetDetail | null = null;
+  try {
+    const list = gh(`repos/${owner}/${repo}/rulesets`, { cwd, method: 'GET' }) as Array<{
+      id: number;
+      name: string;
+    }> | null;
+    const mine = (list ?? []).find((rs) => rs.name === ANCHOR_RULESET_NAME);
+    if (mine) {
+      existing = gh(`repos/${owner}/${repo}/rulesets/${mine.id}`, {
+        cwd,
+        method: 'GET',
+      }) as RulesetDetail;
+    }
+  } catch (e) {
+    if (e instanceof GhError) {
+      logger.warn(`Could not read repository rulesets: ${e.message}`);
+      logger.dim(
+        `  → Skipping anchor-branch deletion protection (doctor still detects a deleted ` +
+          `anchor, and the refresh workflow recreates it).`,
+      );
+      return;
+    }
+    throw e;
+  }
+
+  const plan = planAnchorRuleset(refs, existing);
+  if (plan.action === 'none') {
+    logger.success(`  ${plan.reason}.`);
+    return;
+  }
+
+  if (args.dryRun) {
+    logger.info(
+      `Would ${plan.action} the '${ANCHOR_RULESET_NAME}' ruleset (dry run — no changes written):`,
+    );
+    logger.dim(`  → why: ${plan.reason}`);
+    logger.dim(`  → blocks: deletion of ${refs.map((r) => `refs/heads/${r}`).join(', ')}`);
+    logger.dim(
+      `  → allows: every push, including the refresh's force-push (no non-fast-forward rule, ` +
+        `no required checks — a gated side branch would deadlock the refresh).`,
+    );
+    logger.info(`Re-run with \`${dxkitCli('protect --apply')}\` to write it.`);
+    return;
+  }
+
+  try {
+    if (plan.action === 'create') {
+      gh(`repos/${owner}/${repo}/rulesets`, {
+        cwd,
+        method: 'POST',
+        inputJson: JSON.stringify(plan.payload),
+      });
+    } else {
+      gh(`repos/${owner}/${repo}/rulesets/${plan.rulesetId}`, {
+        cwd,
+        method: 'PUT',
+        inputJson: JSON.stringify(plan.payload),
+      });
+    }
+  } catch (e) {
+    if (e instanceof GhError) {
+      logger.warn(`Could not ${plan.action} the anchor ruleset: ${e.message}`);
+      logger.dim(
+        `  → Repository rulesets need GitHub Free+ (public repos) / Team+ (private). ` +
+          `Without one, restrict deletion of ${refs.join(', ')} manually in Settings → Rules.`,
+      );
+      return;
+    }
+    throw e;
+  }
+
+  logger.success(
+    `Deletion protection ${plan.action === 'create' ? 'created' : 'updated'} for ` +
+      `${refs.join(', ')} ('${ANCHOR_RULESET_NAME}' ruleset).`,
+  );
+  logger.dim(`  → Verify: https://github.com/${owner}/${repo}/settings/rules`);
 }

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -31,6 +31,7 @@ import {
   type BaselineAnchor,
 } from './baseline/modes';
 import { loadPolicyFromCwd } from './baseline/policy';
+import { mergeIntoPolicyFile } from './baseline/policy-write';
 import { detectEnforcement, type EnforcementState } from './enforcement';
 
 /**
@@ -645,7 +646,12 @@ export function detectInstalledRefreshTransport(cwd: string): BaselineAnchor | n
     return null; // not installed
   }
   if (content.includes('actions/cache/save')) return 'cache';
-  if (content.includes('origin "${ANCHOR}"')) return 'branch';
+  // Current branch-variant shape (publishes via the CLI) and the legacy one
+  // (inline side-branch push) — both classify as 'branch' so an update sees
+  // "already branch" and refreshes the template without a spurious migration.
+  if (content.includes('baseline publish') || content.includes('origin "${ANCHOR}"')) {
+    return 'branch';
+  }
   if (content.includes('git push')) return 'tree';
   return null;
 }
@@ -706,6 +712,36 @@ export function installCiBaselineRefresh(
     },
     REFRESH_WORKFLOW_DEST,
   );
+  // Record a resolved 'branch' transport in the policy so the guardrail READER
+  // activates: `loadAnchorFromBranch` gates on `policy.baseline.anchor ===
+  // 'branch'`, so an enforcement-derived transport that lives only in the
+  // workflow's content leaves the check reading a stale tree copy while the
+  // refresh publishes to a side branch nobody reads (the write/read halves of
+  // one concept resolving from two sources — CLAUDE.md Rule 2). Non-clobber:
+  // written only when the policy has no explicit `anchor` (an explicit value
+  // already won during resolution above). Scoped to 'branch' deliberately —
+  // pinning an auto-derived 'tree' would disable the tree→branch auto-migration
+  // that fires when the default branch later becomes protected, and 'tree' /
+  // 'cache' have no check-time reader that needs the policy to say so.
+  if (plan.transport === 'branch' && readPolicyBaselineSection(cwd)?.anchor === undefined) {
+    const persisted = mergeIntoPolicyFile(cwd, {
+      baseline: {
+        anchor: 'branch',
+        ...(plan.anchorRef !== DEFAULT_ANCHOR_REF ? { anchorRef: plan.anchorRef } : {}),
+      },
+    });
+    if (persisted.changed) {
+      result.notes.push(
+        `Recorded baseline.anchor: 'branch' in .dxkit/policy.json — the guardrail check reads ` +
+          `the anchor from the '${plan.anchorRef}' side branch only when the policy says so. Commit it.`,
+      );
+    } else if (persisted.reason === 'malformed-policy') {
+      result.notes.push(
+        `.dxkit/policy.json is not valid JSON — could not record baseline.anchor: 'branch'. ` +
+          `Fix the file and set it by hand, or the guardrail check will not read the side-branch anchor.`,
+      );
+    }
+  }
   if (result.installed.length > 0) {
     if (migrating) {
       result.notes.push(

--- a/test/anchor-ruleset.test.ts
+++ b/test/anchor-ruleset.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  ANCHOR_RULESET_NAME,
+  anchorRefsFromPolicy,
+  planAnchorRuleset,
+  type RulesetDetail,
+} from '../src/anchor-ruleset';
+import { protectAnchorBranches, type GhApiFn } from '../src/setup-branch-protection';
+import { GhError } from '../src/setup-gh';
+
+/**
+ * The PREVENT layer of the deleted-anchor class. Pure-planner matrix first
+ * (no GitHub needed), then the executor through an injected `gh` recorder —
+ * the gh-api harness that let this layer ship without a live repo.
+ */
+
+describe('anchorRefsFromPolicy', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-anchorrefs-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const writePolicy = (policy: unknown): void => {
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(join(dir, '.dxkit', 'policy.json'), JSON.stringify(policy));
+  };
+
+  it('empty without a policy / without anchor-bearing sections', () => {
+    expect(anchorRefsFromPolicy(dir)).toEqual([]);
+    writePolicy({ baseline: { mode: 'ref-based' } });
+    expect(anchorRefsFromPolicy(dir)).toEqual([]);
+    writePolicy({ baseline: { anchor: 'tree' }, reports: { onMerge: false } });
+    expect(anchorRefsFromPolicy(dir)).toEqual([]);
+  });
+
+  it('resolves the same refs the writers and readers use (defaults + overrides)', () => {
+    writePolicy({ baseline: { anchor: 'branch' } });
+    expect(anchorRefsFromPolicy(dir)).toEqual(['dxkit-baselines']);
+    writePolicy({
+      baseline: { anchor: 'branch', anchorRef: 'my-anchors' },
+      reports: { onMerge: true },
+    });
+    expect(anchorRefsFromPolicy(dir)).toEqual(['my-anchors', 'dxkit-reports']);
+    writePolicy({ reports: { onMerge: true, anchorRef: 'my-reports' } });
+    expect(anchorRefsFromPolicy(dir)).toEqual(['my-reports']);
+  });
+});
+
+describe('planAnchorRuleset (pure)', () => {
+  it('nothing to do when no refs are configured', () => {
+    const plan = planAnchorRuleset([], null);
+    expect(plan.action).toBe('none');
+  });
+
+  it('creates a deletion-only ruleset when none exists', () => {
+    const plan = planAnchorRuleset(['dxkit-baselines', 'dxkit-reports'], null);
+    expect(plan.action).toBe('create');
+    expect(plan.payload).toEqual({
+      name: ANCHOR_RULESET_NAME,
+      target: 'branch',
+      enforcement: 'active',
+      conditions: {
+        ref_name: {
+          include: ['refs/heads/dxkit-baselines', 'refs/heads/dxkit-reports'],
+          exclude: [],
+        },
+      },
+      rules: [{ type: 'deletion' }],
+    });
+    // The load-bearing negative: the refresh force-pushes orphan commits, so
+    // the ruleset must never restrict pushes — deletion is the ONLY rule.
+    expect(plan.payload?.rules).toHaveLength(1);
+  });
+
+  it('no-ops when the existing ruleset already covers every ref', () => {
+    const existing: RulesetDetail = {
+      id: 7,
+      name: ANCHOR_RULESET_NAME,
+      target: 'branch',
+      enforcement: 'active',
+      conditions: { ref_name: { include: ['refs/heads/dxkit-baselines'], exclude: [] } },
+      rules: [{ type: 'deletion' }],
+    };
+    expect(planAnchorRuleset(['dxkit-baselines'], existing).action).toBe('none');
+  });
+
+  it('updates to add a missing ref, preserving everything else (non-clobber)', () => {
+    const existing: RulesetDetail = {
+      id: 7,
+      name: ANCHOR_RULESET_NAME,
+      target: 'branch',
+      enforcement: 'active',
+      conditions: {
+        ref_name: { include: ['refs/heads/dxkit-baselines'], exclude: ['refs/heads/keep'] },
+      },
+      rules: [{ type: 'deletion' }],
+    };
+    const plan = planAnchorRuleset(['dxkit-baselines', 'dxkit-reports'], existing);
+    expect(plan.action).toBe('update');
+    expect(plan.rulesetId).toBe(7);
+    expect(plan.payload?.conditions?.ref_name?.include).toEqual([
+      'refs/heads/dxkit-baselines',
+      'refs/heads/dxkit-reports',
+    ]);
+    expect(plan.payload?.conditions?.ref_name?.exclude).toEqual(['refs/heads/keep']);
+    // PUT body addresses the ruleset by URL, not by an id field.
+    expect(plan.payload && 'id' in plan.payload && plan.payload.id).toBeFalsy();
+  });
+
+  it('repairs a ruleset that lost its deletion rule or was disabled', () => {
+    const noRule: RulesetDetail = {
+      id: 7,
+      name: ANCHOR_RULESET_NAME,
+      enforcement: 'active',
+      conditions: { ref_name: { include: ['refs/heads/dxkit-baselines'], exclude: [] } },
+      rules: [],
+    };
+    const p1 = planAnchorRuleset(['dxkit-baselines'], noRule);
+    expect(p1.action).toBe('update');
+    expect(p1.payload?.rules).toEqual([{ type: 'deletion' }]);
+
+    const disabled: RulesetDetail = {
+      ...noRule,
+      enforcement: 'disabled',
+      rules: [{ type: 'deletion' }],
+    };
+    const p2 = planAnchorRuleset(['dxkit-baselines'], disabled);
+    expect(p2.action).toBe('update');
+    expect(p2.payload?.enforcement).toBe('active');
+  });
+});
+
+describe('protectAnchorBranches (injected gh — the gh-api harness)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-anchorprotect-'));
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(
+      join(dir, '.dxkit', 'policy.json'),
+      JSON.stringify({ baseline: { anchor: 'branch' } }),
+    );
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  interface Call {
+    endpoint: string;
+    method?: string;
+    body?: unknown;
+  }
+  const recorder = (responses: Record<string, unknown> = {}): { calls: Call[]; gh: GhApiFn } => {
+    const calls: Call[] = [];
+    const gh: GhApiFn = (endpoint, opts) => {
+      calls.push({
+        endpoint,
+        ...(opts.method !== undefined ? { method: opts.method } : {}),
+        ...(opts.inputJson !== undefined ? { body: JSON.parse(opts.inputJson) } : {}),
+      });
+      if (endpoint in responses) return responses[endpoint];
+      return null;
+    };
+    return { calls, gh };
+  };
+
+  it('dry run reads but never writes', () => {
+    const { calls, gh } = recorder();
+    protectAnchorBranches(dir, { owner: 'o', repo: 'r', dryRun: true, gh });
+    expect(calls.every((c) => !c.method || c.method === 'GET')).toBe(true);
+  });
+
+  it('apply POSTs the create payload when no ruleset exists', () => {
+    const { calls, gh } = recorder();
+    protectAnchorBranches(dir, { owner: 'o', repo: 'r', gh });
+    const post = calls.find((c) => c.method === 'POST');
+    expect(post?.endpoint).toBe('repos/o/r/rulesets');
+    expect(post?.body).toMatchObject({
+      name: ANCHOR_RULESET_NAME,
+      rules: [{ type: 'deletion' }],
+    });
+  });
+
+  it('apply PUTs a merged update onto the existing dxkit ruleset', () => {
+    const { calls, gh } = recorder({
+      'repos/o/r/rulesets': [{ id: 42, name: ANCHOR_RULESET_NAME }],
+      'repos/o/r/rulesets/42': {
+        id: 42,
+        name: ANCHOR_RULESET_NAME,
+        enforcement: 'active',
+        conditions: { ref_name: { include: ['refs/heads/other'], exclude: [] } },
+        rules: [{ type: 'deletion' }],
+      },
+    });
+    protectAnchorBranches(dir, { owner: 'o', repo: 'r', gh });
+    const put = calls.find((c) => c.method === 'PUT');
+    expect(put?.endpoint).toBe('repos/o/r/rulesets/42');
+    expect((put?.body as RulesetDetail).conditions?.ref_name?.include).toEqual([
+      'refs/heads/other',
+      'refs/heads/dxkit-baselines',
+    ]);
+  });
+
+  it('no-ops (no write) when the ruleset already covers the anchor', () => {
+    const { calls, gh } = recorder({
+      'repos/o/r/rulesets': [{ id: 42, name: ANCHOR_RULESET_NAME }],
+      'repos/o/r/rulesets/42': {
+        id: 42,
+        name: ANCHOR_RULESET_NAME,
+        enforcement: 'active',
+        conditions: { ref_name: { include: ['refs/heads/dxkit-baselines'], exclude: [] } },
+        rules: [{ type: 'deletion' }],
+      },
+    });
+    protectAnchorBranches(dir, { owner: 'o', repo: 'r', gh });
+    expect(calls.some((c) => c.method === 'POST' || c.method === 'PUT')).toBe(false);
+  });
+
+  it('never touches a customer ruleset with a different name', () => {
+    const { calls, gh } = recorder({
+      'repos/o/r/rulesets': [{ id: 9, name: 'corp-branch-rules' }],
+    });
+    protectAnchorBranches(dir, { owner: 'o', repo: 'r', gh });
+    // Not even a detail read of the foreign ruleset; the write creates OURS.
+    expect(calls.some((c) => c.endpoint === 'repos/o/r/rulesets/9')).toBe(false);
+    expect(calls.find((c) => c.method === 'POST')?.endpoint).toBe('repos/o/r/rulesets');
+  });
+
+  it('a gh failure warns and degrades — never throws, never fails the command', () => {
+    const gh: GhApiFn = () => {
+      throw new GhError('Permission denied — you need admin rights on the repo.', {
+        httpStatus: 403,
+      });
+    };
+    expect(() => protectAnchorBranches(dir, { owner: 'o', repo: 'r', gh })).not.toThrow();
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it('silent no-op when the policy configures no anchor branches', () => {
+    writeFileSync(join(dir, '.dxkit', 'policy.json'), JSON.stringify({}));
+    const { calls, gh } = recorder();
+    protectAnchorBranches(dir, { owner: 'o', repo: 'r', gh });
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/test/baseline-anchor.test.ts
+++ b/test/baseline-anchor.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -339,16 +339,63 @@ describe('installCiBaselineRefresh — content per transport (anti-recurrence)',
     expect(r.installed).toContain('.github/workflows/dxkit-baseline-refresh.yml');
   });
 
-  it('committed + protected → branch variant pushes to the side branch, NEVER to the default branch', () => {
+  it('committed + protected → branch variant publishes via the CLI, NEVER an inline git push', () => {
     installCiBaselineRefresh(dir, { baselineMode: 'committed-full', enforcement: PROTECTED });
     const yml = dest();
-    // The anchor ref substitution landed, and the push targets that side branch...
-    expect(yml).toContain(`ANCHOR="${DEFAULT_ANCHOR_REF}"`);
-    expect(yml).toContain('git push --force origin "${ANCHOR}"');
-    // ...and NEVER a bare `git push` (which defaults to the protected branch — the
-    // deadlock) and never a [skip ci] COMMIT (the hack the side branch obviates).
-    expect(yml).not.toMatch(/git push\s*$/m);
+    // The anchor ref substitution landed, and the publish goes through the ONE
+    // side-ref writer (`baseline publish` → anchor-publish.ts), not bespoke bash.
+    expect(yml).toContain(DEFAULT_ANCHOR_REF);
+    expect(yml).toContain('baseline publish');
+    // NO git write of any kind in the workflow body: no push (a bare one targets
+    // the protected branch — the deadlock; a forced one is the inline side-ref
+    // publish this class-fix removed) and no [skip ci] commit.
+    expect(yml).not.toContain('git push');
+    expect(yml).not.toContain('git checkout -B');
     expect(yml).not.toMatch(/-m "[^"]*\[skip ci\]/);
+  });
+
+  it("branch install RECORDS baseline.anchor: 'branch' in policy.json (the reader's activation)", () => {
+    const r = installCiBaselineRefresh(dir, {
+      baselineMode: 'committed-full',
+      enforcement: PROTECTED,
+    });
+    const policy = JSON.parse(readFileSync(join(dir, '.dxkit', 'policy.json'), 'utf8'));
+    expect(policy.baseline.anchor).toBe('branch');
+    // Default ref stays implicit — no need to pin what the default already says.
+    expect(policy.baseline.anchorRef).toBeUndefined();
+    expect(r.notes.join('\n')).toMatch(/Recorded baseline\.anchor/);
+  });
+
+  it('a custom anchorRef is recorded alongside the transport', () => {
+    installCiBaselineRefresh(dir, {
+      baselineMode: 'committed-full',
+      enforcement: PROTECTED,
+      anchorRef: 'my-anchors',
+    });
+    const policy = JSON.parse(readFileSync(join(dir, '.dxkit', 'policy.json'), 'utf8'));
+    expect(policy.baseline).toEqual({ anchor: 'branch', anchorRef: 'my-anchors' });
+  });
+
+  it('the persist is non-clobber: an explicit policy anchor is never rewritten', () => {
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(
+      join(dir, '.dxkit', 'policy.json'),
+      JSON.stringify({ baseline: { anchor: 'cache' }, loop: { preset: 'security-only' } }),
+    );
+    installCiBaselineRefresh(dir, {
+      baselineMode: 'committed-full',
+      enforcement: PROTECTED,
+      policyAnchor: 'branch', // explicit override for this install call
+    });
+    const policy = JSON.parse(readFileSync(join(dir, '.dxkit', 'policy.json'), 'utf8'));
+    // The file's explicit value survives; sibling sections untouched.
+    expect(policy.baseline.anchor).toBe('cache');
+    expect(policy.loop.preset).toBe('security-only');
+  });
+
+  it('a tree install records nothing (pinning tree would disable the tree→branch auto-migration)', () => {
+    installCiBaselineRefresh(dir, { baselineMode: 'committed-full', enforcement: UNPROTECTED });
+    expect(existsSync(join(dir, '.dxkit', 'policy.json'))).toBe(false);
   });
 
   it('committed + unprotected → tree variant (the original direct-push refresh)', () => {
@@ -388,7 +435,7 @@ describe('installCiBaselineRefresh — content per transport (anti-recurrence)',
     });
     expect(r.installed).toContain('.github/workflows/dxkit-baseline-refresh.yml');
     expect(r.notes.join('\n')).toMatch(/Migrated the baseline-refresh workflow from the 'tree'/);
-    expect(dest()).toContain(`ANCHOR="${DEFAULT_ANCHOR_REF}"`);
+    expect(dest()).toContain('baseline publish');
   });
 
   it('does NOT rewrite an up-to-date workflow (migration fires only on a transport change)', () => {
@@ -467,6 +514,25 @@ describe('detectInstalledRefreshTransport', () => {
       policyAnchor: 'cache',
     });
     expect(detectInstalledRefreshTransport(dir)).toBe('cache');
+  });
+  it("classifies a LEGACY branch workflow (pre-CLI inline push) as 'branch', not 'tree'", () => {
+    // The pre-3.1 branch template pushed inline. An update must read it as
+    // 'branch' so the refresh is a plain template refresh, not a spurious
+    // transport migration.
+    mkdirSync(join(dir, '.github', 'workflows'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github', 'workflows', 'dxkit-baseline-refresh.yml'),
+      [
+        'jobs:',
+        '  refresh:',
+        '    steps:',
+        '      - run: |',
+        '          ANCHOR="dxkit-baselines"',
+        '          git checkout -B "${ANCHOR}"',
+        '          git push --force origin "${ANCHOR}"',
+      ].join('\n'),
+    );
+    expect(detectInstalledRefreshTransport(dir)).toBe('branch');
   });
 });
 

--- a/test/baseline/anchor-publish.test.ts
+++ b/test/baseline/anchor-publish.test.ts
@@ -143,6 +143,56 @@ describe('publishFilesToAnchorRef', () => {
     expect(git(bare, 'log', '--oneline', ANCHOR).trim().split('\n')).toHaveLength(1);
   });
 
+  it('replace-all is idempotent too: identical content pushes nothing', () => {
+    const files = [{ path: 'a.txt', content: '1' }];
+    publishFilesToAnchorRef({
+      cwd: repo,
+      anchorRef: ANCHOR,
+      files,
+      baseParent: false,
+      message: 'a',
+    });
+    const res = publishFilesToAnchorRef({
+      cwd: repo,
+      anchorRef: ANCHOR,
+      files,
+      baseParent: false,
+      message: 'a again',
+    });
+    expect(res.pushed).toBe(false);
+    expect(res.reason).toBe('no change');
+    // Still exactly one commit on the ref — the periodic refresh didn't churn it.
+    expect(git(bare, 'log', '--oneline', ANCHOR).trim().split('\n')).toHaveLength(1);
+  });
+
+  it('replace-all self-heals: a deleted ref is recreated even when content is byte-identical', () => {
+    const files = [{ path: 'a.txt', content: '1' }];
+    publishFilesToAnchorRef({
+      cwd: repo,
+      anchorRef: ANCHOR,
+      files,
+      baseParent: false,
+      message: 'a',
+    });
+    // The side branch gets deleted on the remote (the failure class doctor's
+    // deleted-anchor warning detects). The
+    // local remote-tracking ref still remembers the old tip — the hard case:
+    // resolveTip falls back to it (the fetch of a deleted ref fails), the tree
+    // compares equal, and a naive no-change skip would leave the branch gone
+    // until the content next changes. The writer must confirm the ref still
+    // exists on the REMOTE before skipping.
+    git(bare, 'update-ref', '-d', `refs/heads/${ANCHOR}`);
+    const res = publishFilesToAnchorRef({
+      cwd: repo,
+      anchorRef: ANCHOR,
+      files,
+      baseParent: false,
+      message: 'recreate',
+    });
+    expect(res.pushed).toBe(true);
+    expect(readFromAnchorRef(repo, ANCHOR, 'a.txt')).toBe('1');
+  });
+
   it('returns pushed:false with a reason when there is no origin remote', () => {
     const noRemote = mkdtempSync(join(tmpdir(), 'dxkit-anchor-noremote-'));
     try {

--- a/test/baseline/baseline-publish.test.ts
+++ b/test/baseline/baseline-publish.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  loadAnchorFromBranch,
+  publishBaselineAnchor,
+  anchorBranchStatus,
+} from '../../src/baseline/anchor';
+import { DEFAULT_ANCHOR_REF } from '../../src/baseline/modes';
+
+/**
+ * Real-git tests for `baseline publish` — the write half of the branch anchor
+ * transport. The load-bearing assertion is WRITER↔READER PARITY: the publish
+ * and the guardrail's anchor read resolve the transport + ref from the same
+ * policy section, so what `publishBaselineAnchor` pushes is byte-for-byte what
+ * `loadAnchorFromBranch` hands the check. The two consumers hold different
+ * shapes of the concept (a directory of files vs a hydrated temp file), which
+ * is exactly the divergence class CLAUDE.md 2.30 says needs a parity test, not
+ * a grep rule.
+ */
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).toString();
+}
+
+const BASELINE_REL = join('.dxkit', 'baselines', 'default.json');
+
+describe('publishBaselineAnchor', () => {
+  let bare: string;
+  let repo: string;
+
+  const writePolicy = (section: Record<string, unknown>): void => {
+    mkdirSync(join(repo, '.dxkit'), { recursive: true });
+    writeFileSync(join(repo, '.dxkit', 'policy.json'), JSON.stringify({ baseline: section }));
+  };
+  const writeBaseline = (content: string): void => {
+    mkdirSync(join(repo, '.dxkit', 'baselines'), { recursive: true });
+    writeFileSync(join(repo, BASELINE_REL), content);
+  };
+
+  beforeEach(() => {
+    bare = mkdtempSync(join(tmpdir(), 'dxkit-blpub-bare-'));
+    git(bare, 'init', '-q', '--bare', '-b', 'main');
+    repo = mkdtempSync(join(tmpdir(), 'dxkit-blpub-repo-'));
+    git(repo, 'init', '-q', '-b', 'main');
+    git(repo, 'config', 'user.email', 't@e.com');
+    git(repo, 'config', 'user.name', 't');
+    writeFileSync(join(repo, 'README.md'), '# fixture\n');
+    git(repo, 'add', '.');
+    git(repo, 'commit', '-q', '-m', 'initial');
+    git(repo, 'remote', 'add', 'origin', bare);
+    git(repo, 'push', '-q', 'origin', 'main');
+  });
+  afterEach(() => {
+    rmSync(bare, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('refuses when the policy transport is not branch (the check would never read it)', () => {
+    writePolicy({ anchor: 'tree' });
+    writeBaseline('{"findings":[]}');
+    const out = publishBaselineAnchor(repo);
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/anchor transport is not 'branch'/);
+
+    // Policy absent entirely → same refusal (nothing says the side branch is live).
+    rmSync(join(repo, '.dxkit', 'policy.json'));
+    expect(publishBaselineAnchor(repo).ok).toBe(false);
+  });
+
+  it('refuses when nothing has been captured yet', () => {
+    writePolicy({ anchor: 'branch' });
+    const out = publishBaselineAnchor(repo);
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/baseline create/);
+  });
+
+  it('WRITER↔READER PARITY: what publish pushes is exactly what the guardrail read loads', () => {
+    writePolicy({ anchor: 'branch' });
+    const content = JSON.stringify({ identityScheme: 'v2', findings: [{ id: 'abc' }] });
+    writeBaseline(content);
+
+    const treeBefore = git(repo, 'status', '--porcelain');
+    const out = publishBaselineAnchor(repo);
+    expect(out.ok).toBe(true);
+    expect(out.publish?.pushed).toBe(true);
+    expect(out.files).toBe(1);
+    // Plumbing publish: the checkout's working tree stays untouched.
+    expect(git(repo, 'status', '--porcelain')).toBe(treeBefore);
+
+    // The READ side — the exact call `guardrail check` makes — resolves the same
+    // policy section and must hand back the published bytes.
+    const tmp = loadAnchorFromBranch(repo, join(repo, BASELINE_REL), { anchor: 'branch' });
+    expect(tmp).not.toBeNull();
+    expect(readFileSync(tmp as string, 'utf8')).toBe(content);
+  });
+
+  it('publish → read parity holds for a custom anchorRef from the same policy section', () => {
+    writePolicy({ anchor: 'branch', anchorRef: 'my-anchors' });
+    writeBaseline('{"findings":[]}');
+    const out = publishBaselineAnchor(repo);
+    expect(out.ok).toBe(true);
+    expect(out.anchorRef).toBe('my-anchors');
+    const tmp = loadAnchorFromBranch(repo, join(repo, BASELINE_REL), {
+      anchor: 'branch',
+      anchorRef: 'my-anchors',
+    });
+    expect(tmp).not.toBeNull();
+    // And nothing landed on the default ref.
+    expect(
+      anchorBranchStatus(repo, { anchor: 'branch', anchorRef: DEFAULT_ANCHOR_REF }).branchExists,
+    ).toBe(false);
+  });
+
+  it('is idempotent (unchanged content publishes nothing) and latest-wins on change', () => {
+    writePolicy({ anchor: 'branch' });
+    writeBaseline('v1');
+    expect(publishBaselineAnchor(repo).publish?.pushed).toBe(true);
+
+    const again = publishBaselineAnchor(repo);
+    expect(again.ok).toBe(true);
+    expect(again.publish?.pushed).toBe(false);
+    expect(again.publish?.reason).toBe('no change');
+
+    writeBaseline('v2');
+    expect(publishBaselineAnchor(repo).publish?.pushed).toBe(true);
+    const tmp = loadAnchorFromBranch(repo, join(repo, BASELINE_REL), { anchor: 'branch' });
+    expect(readFileSync(tmp as string, 'utf8')).toBe('v2');
+    // Replace-all: the ref history stays a single orphan commit, no accretion.
+    expect(git(bare, 'log', '--oneline', DEFAULT_ANCHOR_REF).trim().split('\n')).toHaveLength(1);
+  });
+
+  it('self-heals a deleted anchor branch even when the baseline is byte-identical', () => {
+    writePolicy({ anchor: 'branch' });
+    writeBaseline('stable');
+    expect(publishBaselineAnchor(repo).publish?.pushed).toBe(true);
+
+    git(bare, 'update-ref', '-d', `refs/heads/${DEFAULT_ANCHOR_REF}`);
+    const healed = publishBaselineAnchor(repo);
+    expect(healed.ok).toBe(true);
+    expect(healed.publish?.pushed).toBe(true);
+    expect(healed.selfHealed).toBe(true);
+    expect(anchorBranchStatus(repo, { anchor: 'branch' }).branchExists).toBe(true);
+  });
+
+  it('degrades to a reported non-push when there is no origin remote', () => {
+    git(repo, 'remote', 'remove', 'origin');
+    writePolicy({ anchor: 'branch' });
+    writeBaseline('x');
+    const out = publishBaselineAnchor(repo);
+    expect(out.ok).toBe(true);
+    expect(out.publish?.pushed).toBe(false);
+    expect(out.publish?.reason).toBe('no origin remote');
+  });
+});


### PR DESCRIPTION
## What

Closes the last known one-concept/two-code-paths divergence from the 3.0 audit: the branch-transport baseline-refresh workflow carried its own inline side-ref push (`git checkout -B` + `commit --allow-empty` + `push --force`, with hand-rolled unchanged-skip and self-heal bash) while `src/baseline/anchor-publish.ts` was the tested canonical writer the report snapshots already use.

Three atomic commits:

1. **`refactor(policy)`** — extract the ONE `.dxkit/policy.json` merge-writer (`mergeIntoPolicyFile`); `configure --apply`, the flow setup, and the loop-preset seed all delegate to it (they carried three copies of the same non-clobber skeleton).
2. **`fix(baseline)`** — the side-ref writer's replace-all mode gains the no-change skip (periodic refreshes no longer force-push identical content), and the skip is deletion-aware: a deleted remote ref republishes even when a stale local `origin/<ref>` still matches (the writer confirms the ref exists on the remote before skipping).
3. **`feat(baseline)`** — `vyuh-dxkit baseline publish`: publishes `.dxkit/baselines/` to the anchor side branch through the canonical writer, resolving transport + ref from the **same policy section the guardrail reader gates on**. The workflow's push step becomes one CLI call. The installer now **records an auto-selected `branch` transport into policy.json** (non-clobber).

## The bug the persist closes

`loadAnchorFromBranch` activates only on `policy.baseline.anchor === 'branch'`, but the installer kept an enforcement-derived transport only inside the workflow's content — so on a protected-branch repo with a silent policy, the refresh published to a side branch the guardrail never read (it gated against a stale tree copy). Write side and read side resolved "which transport?" from two different sources. Recording it also stops an `update` that cannot probe branch protection from wrongly migrating a working branch workflow back to `tree`.

## Nets

- Writer↔reader parity test on a real bare remote (published bytes == what the check loads) — the CLAUDE.md 2.30 net for semantic divergence.
- Arch-check rule: workflow templates may not contain the inline side-ref push shape.
- `detectInstalledRefreshTransport` classifies both the new CLI-shaped and legacy inline-push workflows as `branch` (update = template refresh, not a spurious migration).
- Install-time policy-persist matrix (records on branch, non-clobber on explicit, nothing on tree).

## Verification

- Full suite 3372 green (219 files); typecheck + typecheck:test + lint + format + arch + slop + docs-coverage + cross-eco all pass.
- Built-CLI e2e against a real bare remote: transport refusal, first publish, idempotent re-run, latest-wins single-orphan history, self-heal after remote deletion with a stale tracking ref, loud failure with no origin — 16/16.
- Self-guardrail on this branch: PASSED, 0 blocking, 0 suppressed.

Suggested merge: **rebase** (three independently meaningful units).

🤖 Generated with [Claude Code](https://claude.com/claude-code)