### PR TITLE
chore(release): 3.1.0 — anchor integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-07-10
+
+The anchor-integrity release. The guardrail's memory — the committed baseline
+anchor — now has one write path, a policy-recorded transport every consumer
+agrees on, and deletion protection: prevent, detect, and heal for the
+deleted-anchor class.
+
 ### Added
 
 - **`vyuh-dxkit baseline publish`** — publish `.dxkit/baselines/` to the anchor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "hosted-git-info": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",


### PR DESCRIPTION
Version bump + changelog for 3.1.0. Content is already on main (PR #118): `baseline publish` (one side-ref writer), policy-recorded anchor transport (guardrail stale-read fix), anchor-branch deletion-prevention ruleset, policy merge-writer consolidation.

Release will follow the standard path once this is on main and CI is green: tag `v3.1.0` → GitHub Release → publish.yml (provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)