### PR TITLE
chore(release): 3.2.0 — flow freshness + honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-07-10
+
+The freshness-and-honesty release for the flow pillar: the committed contract
+snapshots stop going silently stale, flow's numbers say exactly what they can
+and cannot see, and keeping the contract current becomes automatic — with the
+review checkpoint placed where it matters (route removals), not everywhere.
+
 ### Added
 
 - **On-merge flow-contract refresh (opt-in).** `flow.onMergeRefresh: true`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "hosted-git-info": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",


### PR DESCRIPTION
Version bump + changelog for 3.2.0. Content is already on main (PR #120): staleness disclosure, coverage honesty, on-merge contract refresh (standing-PR landing), the flow-cli size refactor, and the stale-2.x docs sweep (incl. the SECURITY.md scope correction).

Standard release path after merge: CI green on main → tag `v3.2.0` → GitHub Release → publish.yml (provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)