### PR TITLE
feat(flow): Python flow extraction + the declaration-only language recipe (M6 wave 1, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Python flow extraction.** The flow pillar's second language: the python
+  pack declares `httpFlow` + its tree-sitter grammar, and every flow surface
+  (map, doctor, contract snapshots, the integration gate) picks it up with
+  zero analyzer changes. Consumed side: `requests` / `httpx` (trusted — their
+  runtime-built URLs are disclosed as dynamic call sites) plus wrapper clients
+  through the same path-literal precision guard the TS pack uses. Served side:
+  FastAPI member verb decorators (`@app.get('/x')`), Flask
+  `@app.route('/x', methods=[...])` (GET-only default), and Django
+  `path('users/<int:pk>/', view)`. Django/Flask angle-bracket converters
+  (`<int:pk>`, `<path:rest>`) canonicalize in the shared normalizer. Django's
+  regex `re_path(...)` routes are out of scope — point `flow.specs` at an
+  OpenAPI document for those.
+- **Method-agnostic (`ANY`) served routes.** A routing layer that binds a path
+  for EVERY verb (Django `path()`, Go's `http.HandleFunc` next wave) publishes
+  one `ANY` route; the join and the gate resolve a call with any method
+  against it, through the same shared predicate (additive on the served.json
+  schema).
+- **Grammar-shape adapter.** The one flow extractor now reads any tree-sitter
+  grammar through a per-grammar node-type table (`src/ast/grammar-shape.ts`),
+  so adding flow for a language is declaration-only: grammars + a descriptor,
+  zero extractor edits. The scaffold, the pack-contract tests, and the
+  synthetic-pack playbook enforce the recipe end to end.
+- **Pack-declared flow discovery.** doctor's "you would benefit from flow"
+  recommendation and `configure`'s warn-mode seed now key off each pack's
+  declared framework signals — a FastAPI/Flask/Django repo is offered the
+  gate, not just JS UI repos.
+
 ## [3.2.0] - 2026-07-10
 
 The freshness-and-honesty release for the flow pillar: the committed contract

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,6 +247,38 @@ imports, testFramework, licenses }`. Each is a `CapabilityProvider`
   `PY_RUFF_CONCISE_PARSE`, `csharp.ts` `CSHARP_MSBUILD_WARNING_PARSE`); Java
   ships a dormant provider (no single zero-config standalone linter). See
   CLAUDE.md Rule 17.
+- **HTTP flow** (M6) — `httpFlow?: HttpFlowSupport` +
+  `treeSitterGrammars?`, the UI→API flow extraction surface. The recipe
+  is DECLARATION-ONLY — the one extractor
+  (`src/analyzers/flow/extract.ts`) reads any grammar through the
+  per-grammar shape table (`src/ast/grammar-shape.ts`) and is never
+  edited for a language:
+  1. Declare `treeSitterGrammars` (extension → logical grammar name —
+     the wasm ships in `tree-sitter-wasms`). If the grammar has no
+     shape row yet, add one row in `src/ast/grammar-shape.ts`; most
+     grammars fit the shared callee-field factory (verify node/field
+     names against a real parse first — an unverified row silently
+     misreads trees).
+  2. Fill the descriptor from the construct families in
+     `HttpFlowSupport` (`src/languages/types.ts`): `clientCallees`
+     (bare `fetch(url)`), `clientMethodCallees` (`recv.get('/x')`,
+     with `bases` naming TRUSTED always-HTTP receivers whose dynamic
+     URLs are disclosed rather than dropped), `routeDecorators`
+     (`@get('/x')`), `routeMemberDecorators` (`@app.get('/x')`),
+     `routePathDecorators` (`@app.route('/x', methods=[...])`),
+     `routeRouterCallees` (`app.get('/x', handler)`), `routeCallees`
+     (verb-less `path(route, view)` → method-agnostic `ANY` routes),
+     `fileRoutes` (file-convention routing). Worked examples:
+     `typescript.ts` (fetch/axios/Express/Next.js) and `python.ts`
+     (requests/httpx/FastAPI/Flask/Django).
+  3. Pin it: a pack test like `test/flow-extract-python.test.ts`, plus
+     a fixture dir + flow row in `test/fixtures-analysis.test.ts`.
+
+  `test/languages-contract.test.ts` loud-fails an httpFlow pack whose
+  grammar is missing, unshaped, or whose descriptor is vacuous;
+  `test/recipe-playbook.test.ts` proves extraction is descriptor-driven
+  end-to-end with the synthetic pack.
+
 - **Init metadata** (LP-recipe — needed by `vyuh-dxkit init` and
   `doctor`) — `permissions[]` (Bash entries for `.claude/settings.json`),
   `ruleFile?` (filename under `src-templates/.claude/rules/`),

--- a/docs/configuration/language-packs.md
+++ b/docs/configuration/language-packs.md
@@ -98,6 +98,35 @@ check** in `policy.json:checks` pointing at your build's checkstyle/PMD task.
 See [`vyuh-dxkit checks`](../commands/checks.md) for the full model (user
 checks + the lint gate, binary vs located findings, the trust boundary).
 
+## Flow (UI→API) coverage
+
+The flow feature — mapping client calls to served routes and gating changes
+that break an integration — extracts from source **per pack**: each pack
+declares which constructs are HTTP (`httpFlow`), and one shared extractor
+reads them through a per-grammar syntax table. Current coverage:
+
+| Pack       | Consumed side (client calls)          | Served side (route declarations)                                             |
+| ---------- | ------------------------------------- | ---------------------------------------------------------------------------- |
+| typescript | `fetch`, axios, app-specific wrappers | Express/LoopBack/NestJS routers + decorators, Next.js App Router file routes |
+| python     | `requests`, `httpx`, wrapper clients  | FastAPI decorators, Flask `route(...)`, Django `path(...)` (method-agnostic) |
+| others     | — (next waves)                        | via `flow.specs` (OpenAPI) today                                             |
+
+Two notes that keep the model honest:
+
+- A **verb-less declaration** (Django `path('users/', view)`) is served for
+  every method at the routing layer, so it is published as an `ANY` route —
+  a client's `PUT` resolves against it. Django's regex `re_path(...)` routes
+  are out of scope (no canonical path to join on); point `flow.specs` at an
+  OpenAPI document for such repos.
+- **Any language can participate in the served side without pack coverage**
+  by publishing an OpenAPI spec (`flow.specs`) or a `served.json` snapshot as
+  a workspace participant — pack coverage adds native source extraction on
+  top.
+
+Remaining packs (Go, Java, Kotlin, C#, Ruby, Rust) gain `httpFlow` in the
+language-parity waves; the recipe is declaration-only (see CONTRIBUTING.md
+"Adding a new language").
+
 ## Forcing pack activation
 
 If detection misses a pack (rare — typically a missing manifest), you

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -226,6 +226,7 @@ blocks, and there is no baseline artifact to maintain).
 
 ### Per-pack capability parity
 
+- [ ] Flow (UI→API) extraction for every pack. TypeScript/JavaScript and Python extract natively today (fetch/axios/Express/Next.js; requests/httpx/FastAPI/Flask/Django); Go is next, then the remaining packs once the extension SDK freezes. Any language can already participate on the served side via `flow.specs` (OpenAPI) or a published `served.json`.
 - [ ] Import-graph resolvers for Rust, C#, Kotlin, Java, Ruby. Currently TS, Python, and Go have full reachability and import-graph test-gap credit. The other packs use the fallback path.
 - [ ] Severity-tiered C# linter (Roslyn analyzers or StyleCop)
 - [ ] License providers for Kotlin, Java, Ruby

--- a/scripts/scaffold-language.js
+++ b/scripts/scaffold-language.js
@@ -349,15 +349,36 @@ export const ${id}: LanguageSupport = {
   // pack's contributions reach each helper.
   //   architecturalShape  — primary-component / route / model path conventions
   //                         + vocabulary + test-gap taxonomy
-  //   httpFlow            — HTTP client callees + route decorators/routers, so
-  //                         the flow extractor (src/analyzers/flow/) maps this
-  //                         language's UI→API→handler integrations. Add it if
-  //                         the language has an HTTP client or web framework
-  //                         (e.g. Python requests/FastAPI, Go net-http/gin,
-  //                         Java Spring @GetMapping, C# ASP.NET [HttpGet]).
   //   deepSast            — CodeQL / Snyk Code interprocedural engine support
   //   callGraphReliability — how much to trust graphify's caller counts here
   //   correctness         — the liveness floor (REQUIRED; wired below)
+
+  // TODO(${id}): OPTIONAL httpFlow — UI→API flow extraction for this language.
+  // Add it if the language has an HTTP client or web framework. The recipe is
+  // DECLARATION-ONLY (zero extractor edits — CONTRIBUTING.md "Adding flow
+  // support to a language pack" is the walkthrough):
+  //   1. Declare \`treeSitterGrammars\` below (extension → logical grammar
+  //      name). The wasm ships in tree-sitter-wasms; if the grammar has no
+  //      shape row yet, add one in src/ast/grammar-shape.ts (most fit the
+  //      shared callee-field factory) — test/languages-contract.test.ts
+  //      loud-fails an httpFlow pack whose grammar is unshaped.
+  //   2. Fill the descriptor. Construct families (see HttpFlowSupport in
+  //      src/languages/types.ts, worked examples in typescript.ts/python.ts):
+  //        clientCallees          — fetch(url)-style bare clients
+  //        clientMethodCallees    — recv.get('/x'); \`bases\` = TRUSTED
+  //                                 always-HTTP receivers (requests, httpx)
+  //        routeDecorators        — bare verb decorators (@get('/x'))
+  //        routeMemberDecorators  — member verb decorators (@app.get('/x'))
+  //        routePathDecorators    — path + methods kwarg (@app.route(...))
+  //        routeRouterCallees     — app.get('/x', handler) router calls
+  //        routeCallees           — verb-less path(route, view) → ANY routes
+  //        fileRoutes             — file-convention routing (route.ts under app/)
+  //   3. Add a fixture under test/fixtures/analysis/ + a flow row in
+  //      test/fixtures-analysis.test.ts, and a pack test like
+  //      test/flow-extract-python.test.ts pinning YOUR declaration.
+  //
+  // httpFlow: { ... },
+  // treeSitterGrammars: { '.${id}': '${id}' },
 
   // REQUIRED(${id}): correctness floor — the loop-safety liveness gate. Two PURE
   // command builders; the runner (src/analyzers/correctness/run.ts) executes

--- a/src-templates/.claude/skills/dxkit-flow/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-flow/SKILL.md
@@ -9,6 +9,8 @@ This skill owns the **UI→API integration gate**: dxkit statically reconstructs
 
 It is **thin orchestration over the deterministic CLI.** It never re-implements extraction: it runs `init` / `doctor` / `guardrail check` / `flow publish`, reads their structured output, and supplies judgment + code edits. The determinism stays in the CLI; the agent supplies the reasoning.
 
+**Language coverage.** Source extraction is per language pack: TypeScript/JavaScript (fetch/axios/wrappers; Express/LoopBack/NestJS/Next.js routes) and Python (requests/httpx; FastAPI/Flask/Django routes — a Django `path()` route is method-agnostic and matches any verb; `re_path()` regex routes are out of scope). Other languages participate on the **served side** without pack coverage: point `flow.specs` at an OpenAPI document, or have the service publish its `served.json` as a workspace participant. If a user asks why a Go/Java service's calls don't appear in the consumed set, that's the reason — native extraction for the remaining packs is on the roadmap.
+
 ## Modes
 
 Pick the mode from what the user is doing. They share context — a fix often starts from a diagnose.

--- a/src/analyzers/flow/extract.ts
+++ b/src/analyzers/flow/extract.ts
@@ -33,7 +33,13 @@ import { getLanguage } from '../../languages';
 import type { HttpFlowSupport, LanguageId } from '../../languages/types';
 import { parseFile, walk, type Node } from '../../ast/parse';
 import { grammarShape, type GrammarShape, type ResolvedCall } from '../../ast/grammar-shape';
-import { normalizeMethod, normalizePath, type HttpMethod, type NormalizeConfig } from './normalize';
+import {
+  normalizeMethod,
+  normalizePath,
+  type HttpMethod,
+  type NormalizeConfig,
+  type ServedMethod,
+} from './normalize';
 import { deriveFileRoutePath, exportedMethodNames } from './file-routes';
 
 /** An outbound HTTP call found in source (the consumed side). */
@@ -53,7 +59,10 @@ export interface ClientCall {
  *  derived from the file's location), or an ingested OpenAPI/spec document
  *  (preferred when available). */
 export interface RouteEndpoint {
-  readonly method: HttpMethod;
+  /** A concrete verb, or `ANY` for a method-agnostic declaration (a routing
+   *  layer that binds a path for every method — Django `path()`, Go
+   *  `http.HandleFunc`). See `ANY_METHOD` in `normalize.ts`. */
+  readonly method: ServedMethod;
   readonly path: string;
   readonly via: 'decorator' | 'router-call' | 'file-route' | 'spec';
   readonly handler: string | null;

--- a/src/analyzers/flow/extract.ts
+++ b/src/analyzers/flow/extract.ts
@@ -3,9 +3,14 @@
  * HTTP integration: outbound client calls (CONSUMED) and inbound route
  * declarations (SERVED).
  *
- * It is the cross-cutting consumer of three seams and hardcodes none of them:
+ * It is the cross-cutting consumer of four seams and hardcodes none of them:
  *   - the canonical AST layer (`src/ast/`) for parsing — graphify-independent,
  *     and registered as its own concern, never folded into graphify's pass;
+ *   - the per-grammar shape table (`src/ast/grammar-shape.ts`) for HOW to read
+ *     a call / member / string / decorator from this grammar's tree — no
+ *     `call_expression` / `attribute` node name lives here, so the one
+ *     extractor walks any grammar and a new language adds flow with ZERO
+ *     extractor edits;
  *   - each pack's `httpFlow` descriptor (Rule 6) for WHICH constructs are HTTP
  *     — no `fetch`/`axios`/`@get` literal lives here;
  *   - the shared normalizer for canonical paths + verbs.
@@ -15,15 +20,19 @@
  * model — a participant is whatever its served/consumed sets make it). Role
  * assignment happens above this module, never inside it.
  *
- * Precision guard (validated): a member call with no declared receiver allowlist
- * (`axios.get`, `requests.get`, `agent.X.del`) only counts as a client call when
- * its first argument is a path-like literal — that filter keeps non-HTTP `.get`/
- * `.delete` (lodash, Maps) out while still catching app-specific wrappers.
+ * Precision guard (validated): a member call on an UNTRUSTED receiver (one not
+ * in the descriptor's `bases`) only counts as a client call when its first
+ * argument is a path-like literal — that filter keeps non-HTTP `.get`/`.delete`
+ * (lodash, Maps, dict.get) out while still catching app-specific wrappers.
+ * A TRUSTED receiver (`requests`, `httpx` — always HTTP by construction) skips
+ * the guard, so its dynamic-URL calls are COUNTED as unverifiable rather than
+ * silently dropped (coverage honesty).
  */
 
 import { getLanguage } from '../../languages';
 import type { HttpFlowSupport, LanguageId } from '../../languages/types';
 import { parseFile, walk, type Node } from '../../ast/parse';
+import { grammarShape, type GrammarShape, type ResolvedCall } from '../../ast/grammar-shape';
 import { normalizeMethod, normalizePath, type HttpMethod, type NormalizeConfig } from './normalize';
 import { deriveFileRoutePath, exportedMethodNames } from './file-routes';
 
@@ -72,34 +81,17 @@ export interface FileFlow {
   readonly dynamicCalls?: DynamicCallSite[];
 }
 
-const HTTP_VERB_METHODS = new Set([
-  'get',
-  'post',
-  'put',
-  'patch',
-  'delete',
-  'del',
-  'head',
-  'options',
-]);
-
 function line(node: Node): number {
   return node.startPosition.row + 1;
-}
-
-/** Text of a string/template-string node, else null (a dynamic argument). */
-function literalText(node: Node | null): string | null {
-  if (!node) return null;
-  return node.type === 'string' || node.type === 'template_string' ? node.text : null;
 }
 
 /**
  * Does a raw literal look like a URL/path at the source level — i.e. could this
  * `.get(...)`/`.post(...)` plausibly be an HTTP call rather than a Map/cache/
- * lodash accessor? Used only for member calls with NO declared receiver
- * allowlist, where it is the precision guard: a leading `/`, a leading template
- * (`${host}/…`), an explicit scheme, or any embedded `/` qualifies; a bare token
- * like `'config-key'` does not. (Route decorators are exempt — a framework route
+ * lodash accessor? Used only for member calls on UNTRUSTED receivers, where it
+ * is the precision guard: a leading `/`, a leading template (`${host}/…`), an
+ * explicit scheme, or any embedded `/` qualifies; a bare token like
+ * `'config-key'` does not. (Route decorators are exempt — a framework route
  * string is known to be a path even without a leading slash.)
  */
 function looksLikeUrlLiteral(raw: string | null): boolean {
@@ -109,37 +101,18 @@ function looksLikeUrlLiteral(raw: string | null): boolean {
   return s.startsWith('/') || s.startsWith('${') || s.includes('://') || s.includes('/');
 }
 
-function firstNamedArg(callOrArgs: Node | null): Node | null {
-  const args = callOrArgs?.childForFieldName('arguments') ?? null;
-  if (!args) return null;
-  for (const c of args.namedChildren) if (c) return c;
-  return null;
-}
-
 /** Does a member-call receiver match one of the declared bases (e.g. `app`, or
  *  `this.app`)? */
 function receiverMatchesBase(receiver: string, bases: readonly string[]): boolean {
   return bases.some((b) => receiver === b || receiver.endsWith(`.${b}`));
 }
 
-/** Pull `method: 'X'` out of a fetch options object (2nd arg), default GET. */
-function fetchMethod(call: Node, hf: HttpFlowSupport): HttpMethod {
-  const args = call.childForFieldName('arguments');
-  const opts = args?.namedChildren?.[1] ?? null;
-  if (opts && opts.type === 'object') {
-    let verb: HttpMethod | null = null;
-    walk(opts, (n) => {
-      if (verb) return false;
-      if (n.type === 'pair') {
-        const key = n.childForFieldName('key');
-        const val = n.childForFieldName('value');
-        const keyName = key ? key.text.replace(/['"`]/g, '') : '';
-        if (keyName === 'method') {
-          const raw = literalText(val);
-          if (raw) verb = normalizeMethod(raw.replace(/['"`]/g, ''), hf.methodAliases);
-        }
-      }
-    });
+/** Pull `method: 'X'` out of a fetch-style options argument, default GET. */
+function fetchMethod(call: Node, shape: GrammarShape, hf: HttpFlowSupport): HttpMethod {
+  const value = shape.optionValue(call, 'method');
+  const raw = value ? shape.stringText(value) : null;
+  if (raw) {
+    const verb = normalizeMethod(raw.replace(/['"`]/g, ''), hf.methodAliases);
     if (verb) return verb;
   }
   return 'GET';
@@ -147,18 +120,18 @@ function fetchMethod(call: Node, hf: HttpFlowSupport): HttpMethod {
 
 /**
  * The handler name a route decorator is attached to (best-effort). Decorators
- * are siblings preceding the member in the class body, so the handler is the
- * decorator's next named sibling (skipping any stacked decorators); a nested
- * grammar shape is handled by an ancestor fallback.
+ * are siblings preceding the definition, so the handler is the decorator's
+ * next named sibling (skipping any stacked decorators); a nested grammar shape
+ * is handled by an ancestor fallback over the shape's definition node types.
  */
-function decoratedHandlerName(decorator: Node): string | null {
+function decoratedHandlerName(decorator: Node, shape: GrammarShape): string | null {
   let sib: Node | null = decorator.nextNamedSibling;
-  while (sib && sib.type === 'decorator') sib = sib.nextNamedSibling;
+  while (sib && shape.decoratorNodes.includes(sib.type)) sib = sib.nextNamedSibling;
   const sibName = sib?.childForFieldName('name');
   if (sibName) return sibName.text;
   let cur: Node | null = decorator.parent;
   for (let i = 0; cur && i < 3; i++) {
-    if (cur.type === 'method_definition' || cur.type === 'function_declaration') {
+    if (shape.functionNodes.includes(cur.type)) {
       const name = cur.childForFieldName('name');
       if (name) return name.text;
     }
@@ -169,11 +142,13 @@ function decoratedHandlerName(decorator: Node): string | null {
 
 /**
  * Extract both HTTP surfaces from one already-parsed tree using a pack's
- * httpFlow descriptor. Pure over its inputs.
+ * httpFlow descriptor (WHAT is HTTP) and the grammar's shape (HOW to read the
+ * tree). Pure over its inputs.
  */
 export function extractFromTree(
   root: Node,
   hf: HttpFlowSupport,
+  shape: GrammarShape,
   file: string,
   config?: NormalizeConfig,
   relPath?: string,
@@ -216,64 +191,65 @@ export function extractFromTree(
   const routerMethods = new Set(hf.routeRouterCallees?.methods ?? []);
   const routerBases = hf.routeRouterCallees?.bases ?? [];
 
+  const literalText = (node: Node | null): string | null => (node ? shape.stringText(node) : null);
+
   walk(root, (node) => {
     // ── decorator routes: @get('/x') ──
-    if (node.type === 'decorator' && routeDecorators.size) {
-      const call = node.namedChildren.find((c) => c?.type === 'call_expression') ?? null;
-      const callee = call?.childForFieldName('function');
-      const name = callee && callee.type === 'identifier' ? callee.text : '';
-      if (call && routeDecorators.has(name)) {
-        const path = normalizePath(literalText(firstNamedArg(call)), config);
-        const method = normalizeMethod(name, hf.methodAliases);
+    if (shape.decoratorNodes.includes(node.type)) {
+      const call = shape.decoratorCall(node);
+      const callee = call ? shape.resolveCall(call) : null;
+      if (call && callee?.kind === 'bare' && routeDecorators.has(callee.name)) {
+        const path = normalizePath(literalText(shape.firstArg(call)), config);
+        const method = normalizeMethod(callee.name, hf.methodAliases);
         if (path && method) {
           routes.push({
             method,
             path,
             via: 'decorator',
-            handler: decoratedHandlerName(node),
+            handler: decoratedHandlerName(node, shape),
             file,
             line: line(node),
           });
         }
       }
-      return; // a decorator's call is bookkeeping, not a client call
+      // A decorator's call is a route declaration, never a client call — skip
+      // the subtree so `@app.get('/x')`'s inner member call isn't double-read
+      // as an outbound `app.get(...)`.
+      return false;
     }
 
-    if (node.type !== 'call_expression') return;
-    const callee = node.childForFieldName('function');
+    if (!shape.callNodes.includes(node.type)) return;
+    const callee = shape.resolveCall(node);
     if (!callee) return;
 
     // ── bare client call: fetch(url, opts) ──
-    if (callee.type === 'identifier' && clientCallees.has(callee.text)) {
-      const raw = literalText(firstNamedArg(node));
+    if (callee.kind === 'bare' && clientCallees.has(callee.name)) {
+      const raw = literalText(shape.firstArg(node));
       if (raw != null) {
         calls.push({
-          method: fetchMethod(node, hf),
+          method: fetchMethod(node, shape, hf),
           rawUrl: raw,
           path: normalizePath(raw, config),
-          receiver: callee.text,
+          receiver: callee.name,
           file,
           line: line(node),
         });
       } else {
         // A known client with a dynamically-built URL — count it (coverage
         // honesty), don't silently drop it.
-        dynamicCalls.push({ receiver: callee.text, file, line: line(node) });
+        dynamicCalls.push({ receiver: callee.name, file, line: line(node) });
       }
       return;
     }
 
     // ── member call: <recv>.<verb>(url|path, ...) ──
-    if (callee.type === 'member_expression') {
-      const prop = callee.childForFieldName('property');
-      const obj = callee.childForFieldName('object');
-      const verb = prop ? prop.text : '';
-      const receiver = obj ? obj.text : '';
-      if (!HTTP_VERB_METHODS.has(verb)) return;
+    if (callee.kind === 'member') {
+      const verb = callee.name;
+      const receiver = callee.receiver;
 
       // router/app route declaration
       if (routerMethods.has(verb) && receiverMatchesBase(receiver, routerBases)) {
-        const path = normalizePath(literalText(firstNamedArg(node)), config);
+        const path = normalizePath(literalText(shape.firstArg(node)), config);
         const method = normalizeMethod(verb, hf.methodAliases);
         if (path && method) {
           routes.push({
@@ -288,19 +264,18 @@ export function extractFromTree(
         return;
       }
 
-      // client call (bases optional). With no allowlist, require a path-like
-      // literal first arg — the precision guard against non-HTTP .get/.delete.
+      // client call. A TRUSTED receiver (declared in `bases` — `requests`,
+      // `httpx`: HTTP by construction) needs no URL-shaped literal, and its
+      // dynamic-URL calls are counted as unverifiable. An UNTRUSTED receiver
+      // must pass the path-like-literal precision guard — that is what admits
+      // app-specific wrappers (`api.get('/x')`) while keeping non-HTTP
+      // `.get`/`.delete` (lodash, Maps, dict.get) out.
       if (methodCallMethods.has(verb)) {
-        const baseOk =
-          !methodCallBases ||
-          receiverMatchesBase(receiver, methodCallBases) ||
-          methodCallBases.includes(receiver);
-        if (!baseOk) return;
-        const raw = literalText(firstNamedArg(node));
-        // Unallowlisted receiver → require a URL-looking literal (precision guard).
-        // That rejection is FILTERING (a non-HTTP map.get), not a blind spot,
-        // so it is deliberately not counted as dynamic.
-        if (!methodCallBases && !looksLikeUrlLiteral(raw)) return;
+        const trusted =
+          methodCallBases !== undefined &&
+          (receiverMatchesBase(receiver, methodCallBases) || methodCallBases.includes(receiver));
+        const raw = literalText(shape.firstArg(node));
+        if (!trusted && !looksLikeUrlLiteral(raw)) return;
         const method = normalizeMethod(verb, hf.methodAliases);
         if (raw != null && method) {
           calls.push({
@@ -312,8 +287,9 @@ export function extractFromTree(
             line: line(node),
           });
         } else if (raw == null && method) {
-          // An ALLOWLISTED client receiver with a dynamic URL — a call flow
+          // A TRUSTED client receiver with a dynamic URL — a call flow
           // recognizes but cannot verify. Counted, not silently dropped.
+          // (Only reachable when trusted: the guard already returned above.)
           dynamicCalls.push({ receiver, file, line: line(node) });
         }
       }
@@ -325,9 +301,9 @@ export function extractFromTree(
 
 /**
  * Extract both HTTP surfaces from one file on disk. Returns empty surfaces when
- * the language has no httpFlow descriptor, and `null` when the file can't be
- * parsed (engine/grammar unavailable or unreadable) — callers treat `null` as
- * "skip this file", never an error.
+ * the language has no httpFlow descriptor or its grammar has no shape row, and
+ * `null` when the file can't be parsed (engine/grammar unavailable or
+ * unreadable) — callers treat `null` as "skip this file", never an error.
  */
 export async function extractFileFlow(
   filePath: string,
@@ -337,10 +313,13 @@ export async function extractFileFlow(
   const parsed = await parseFile(filePath);
   if (!parsed) return null;
   const hf = httpFlowFor(parsed.languageId);
-  if (!hf) return { calls: [], routes: [] };
-  return extractFromTree(parsed.tree.rootNode, hf, filePath, config, relPath);
+  const shape = grammarShape(parsed.grammar);
+  if (!hf || !shape) return { calls: [], routes: [] };
+  return extractFromTree(parsed.tree.rootNode, hf, shape, filePath, config, relPath);
 }
 
 function httpFlowFor(languageId: LanguageId): HttpFlowSupport | undefined {
   return getLanguage(languageId)?.httpFlow;
 }
+
+export type { GrammarShape, ResolvedCall };

--- a/src/analyzers/flow/extract.ts
+++ b/src/analyzers/flow/extract.ts
@@ -34,6 +34,7 @@ import type { HttpFlowSupport, LanguageId } from '../../languages/types';
 import { parseFile, walk, type Node } from '../../ast/parse';
 import { grammarShape, type GrammarShape, type ResolvedCall } from '../../ast/grammar-shape';
 import {
+  ANY_METHOD,
   normalizeMethod,
   normalizePath,
   type HttpMethod,
@@ -199,11 +200,44 @@ export function extractFromTree(
   const routeDecorators = new Set(hf.routeDecorators ?? []);
   const routerMethods = new Set(hf.routeRouterCallees?.methods ?? []);
   const routerBases = hf.routeRouterCallees?.bases ?? [];
+  const memberDecorators = hf.routeMemberDecorators;
+  const memberDecoratorMethods = new Set(memberDecorators?.methods ?? []);
+  const pathDecorators = hf.routePathDecorators;
+  const pathDecoratorNames = new Set(pathDecorators?.names ?? []);
+  const routeCalleeNames = new Set(hf.routeCallees?.names ?? []);
+  const routeCalleeExcludes = new Set(hf.routeCallees?.excludeArgCallees ?? []);
 
   const literalText = (node: Node | null): string | null => (node ? shape.stringText(node) : null);
 
+  /** The route path of a member/path decorator — its first string argument,
+   *  REQUIRED to begin with `/` once unquoted. FastAPI/Flask/Sanic mandate the
+   *  leading slash, and requiring it is the precision guard that keeps
+   *  look-alike member decorators (`@mock.patch('pkg.attr')`) from minting
+   *  phantom routes. (Bare `routeDecorators` keep their historical exemption —
+   *  LoopBack allows `@post('zen/x')`.) */
+  const slashedDecoratorPath = (call: Node): string | null => {
+    const raw = literalText(shape.firstArg(call));
+    if (raw == null) return null;
+    let s = raw.trim();
+    if (s.length >= 2 && /^['"`]/.test(s) && s.endsWith(s[0])) s = s.slice(1, -1);
+    if (!s.startsWith('/')) return null;
+    return normalizePath(raw, config);
+  };
+
+  /** The declared methods of a path-first decorator (`methods=['GET','POST']`),
+   *  read from its keyword argument; absent → the descriptor's defaults. */
+  const pathDecoratorMethods = (call: Node): HttpMethod[] => {
+    const spec = pathDecorators as NonNullable<typeof pathDecorators>;
+    const value = shape.optionValue(call, spec.methodsKeyword);
+    const tokens = value ? shape.listStrings(value).map((s) => s.replace(/['"`]/g, '')) : [];
+    const source = tokens.length > 0 ? tokens : spec.defaultMethods;
+    return source
+      .map((t) => normalizeMethod(t, hf.methodAliases))
+      .filter((m): m is HttpMethod => m !== null);
+  };
+
   walk(root, (node) => {
-    // ── decorator routes: @get('/x') ──
+    // ── decorator routes: @get('/x') / @app.get('/x') / @app.route('/x', methods=[...]) ──
     if (shape.decoratorNodes.includes(node.type)) {
       const call = shape.decoratorCall(node);
       const callee = call ? shape.resolveCall(call) : null;
@@ -220,6 +254,42 @@ export function extractFromTree(
             line: line(node),
           });
         }
+      } else if (
+        call &&
+        callee?.kind === 'member' &&
+        memberDecorators &&
+        memberDecoratorMethods.has(callee.name) &&
+        (memberDecorators.bases === undefined ||
+          receiverMatchesBase(callee.receiver, memberDecorators.bases))
+      ) {
+        // MEMBER-callee verb decorator: FastAPI `@app.get('/x')`.
+        const path = slashedDecoratorPath(call);
+        const method = normalizeMethod(callee.name, hf.methodAliases);
+        if (path && method) {
+          routes.push({
+            method,
+            path,
+            via: 'decorator',
+            handler: decoratedHandlerName(node, shape),
+            file,
+            line: line(node),
+          });
+        }
+      } else if (call && callee && pathDecorators && pathDecoratorNames.has(callee.name)) {
+        // PATH-first decorator with a methods keyword: Flask `@app.route(...)`.
+        const path = slashedDecoratorPath(call);
+        if (path) {
+          for (const method of pathDecoratorMethods(call)) {
+            routes.push({
+              method,
+              path,
+              via: 'decorator',
+              handler: decoratedHandlerName(node, shape),
+              file,
+              line: line(node),
+            });
+          }
+        }
       }
       // A decorator's call is a route declaration, never a client call — skip
       // the subtree so `@app.get('/x')`'s inner member call isn't double-read
@@ -230,6 +300,37 @@ export function extractFromTree(
     if (!shape.callNodes.includes(node.type)) return;
     const callee = shape.resolveCall(node);
     if (!callee) return;
+
+    // ── bare route callee: Django `path('users/<int:pk>/', view)` ──
+    // Method-agnostic at the routing layer → emitted as an `ANY` route (the
+    // join/gate resolve any verb against it). Guards: a string-literal first
+    // arg, a present second arg (the handler), and no argument that is a call
+    // to an excluded name (`include(...)` mounts a sub-conf — its first arg is
+    // a PREFIX, not a served route).
+    if (callee.kind === 'bare' && routeCalleeNames.has(callee.name)) {
+      const args = shape.positionalArgs(node);
+      const raw = args[0] ? shape.stringText(args[0]) : null;
+      const excluded = args.some((a) => {
+        if (!shape.callNodes.includes(a.type)) return false;
+        const inner = shape.resolveCall(a);
+        return inner !== null && routeCalleeExcludes.has(inner.name);
+      });
+      if (raw != null && args.length >= 2 && !excluded) {
+        const path = normalizePath(raw, config);
+        if (path) {
+          const handlerText = args[1]?.text ?? '';
+          routes.push({
+            method: ANY_METHOD,
+            path,
+            via: 'router-call',
+            handler: /^\S+$/.test(handlerText) ? handlerText : null,
+            file,
+            line: line(node),
+          });
+        }
+      }
+      return;
+    }
 
     // ── bare client call: fetch(url, opts) ──
     if (callee.kind === 'bare' && clientCallees.has(callee.name)) {

--- a/src/analyzers/flow/model.ts
+++ b/src/analyzers/flow/model.ts
@@ -22,7 +22,12 @@ import {
   type FileFlow,
   type RouteEndpoint,
 } from './extract';
-import { catchAllStaticPrefix, isCatchAllPath, type NormalizeConfig } from './normalize';
+import {
+  ANY_METHOD,
+  catchAllStaticPrefix,
+  isCatchAllPath,
+  type NormalizeConfig,
+} from './normalize';
 
 /**
  * Why a call did or didn't bind to a route:
@@ -137,13 +142,20 @@ export function buildServedMatcher(servedKeys: Iterable<string>): ServedMatcher 
  * resolution predicate (Rule 2): the gate answers "is this served?" through the
  * same catch-all-aware logic the join uses, so gate and doctor agree on the same
  * commit. An all-placeholder path never prefix-matches a catch-all (no static
- * signal to align).
+ * signal to align). A method-agnostic served route (`ANY /path` — Django
+ * `path()`, Go `http.HandleFunc`) resolves a call with ANY verb on that path,
+ * exactly as the join does: the routing layer genuinely accepts every method
+ * there, dispatching (or 405ing) inside the handler.
  */
 export function servedMatch(method: string, callPath: string, m: ServedMatcher): boolean {
   if (m.exact.has(`${method} ${callPath}`)) return true;
+  if (m.exact.has(`${ANY_METHOD} ${callPath}`)) return true;
   if (isPlaceholderOnlyPath(callPath)) return false;
-  const prefixes = m.catchAllPrefixesByMethod.get(method);
-  return prefixes ? prefixes.some((p) => catchAllPrefixCovers(p, callPath)) : false;
+  const prefixes = [
+    ...(m.catchAllPrefixesByMethod.get(method) ?? []),
+    ...(m.catchAllPrefixesByMethod.get(ANY_METHOD) ?? []),
+  ];
+  return prefixes.some((p) => catchAllPrefixCovers(p, callPath));
 }
 
 /**
@@ -171,14 +183,23 @@ export function joinFlow(
 
   return calls.map((call): FlowBinding => {
     if (call.path == null) return { call, route: null, confidence: 0, reason: 'external' };
-    const route = routeIndex.get(`${call.method} ${call.path}`) ?? null;
+    // A method-agnostic route (`ANY /path`) serves the path for every verb at
+    // the routing layer, so it resolves any concrete method — the same rule
+    // `servedMatch` applies (Rule 2 parity between join and gate).
+    const route =
+      routeIndex.get(`${call.method} ${call.path}`) ??
+      routeIndex.get(`${ANY_METHOD} ${call.path}`) ??
+      null;
     if (route) {
       if (isPlaceholderOnlyPath(call.path)) {
         return { call, route, confidence: 0.3, reason: 'placeholder-only' };
       }
       return { call, route, confidence: 1, reason: 'exact' };
     }
-    const catchAll = bestCatchAllMatch(call.path, catchAllsByMethod.get(call.method));
+    const catchAll = bestCatchAllMatch(call.path, [
+      ...(catchAllsByMethod.get(call.method) ?? []),
+      ...(catchAllsByMethod.get(ANY_METHOD) ?? []),
+    ]);
     if (catchAll) return { call, route: catchAll, confidence: 0.7, reason: 'catch-all' };
     return { call, route: null, confidence: 0, reason: 'no-route' };
   });

--- a/src/analyzers/flow/normalize.ts
+++ b/src/analyzers/flow/normalize.ts
@@ -152,6 +152,7 @@ export function normalizePath(
   //     BEFORE the single-segment collapse below so FastAPI's `{p:path}` and
   //     Next.js `[...slug]` do not degrade to a one-segment `{var}`.
   s = s.replace(/\{[A-Za-z0-9_]+:path\}/g, CATCHALL); // FastAPI/Starlette {file_path:path}
+  s = s.replace(/<path:[A-Za-z0-9_]+>/g, CATCHALL); // Django/Flask <path:rest> (rest-of-path)
   s = s.replace(/\[\[?\.\.\.[^\]]+\]\]?/g, CATCHALL); // Next.js [...slug] / [[...slug]]
   s = s.replace(/\*\*/g, CATCHALL); // Spring /**
   s = s.replace(/(?<=\/)\*[A-Za-z0-9_]*/g, CATCHALL); // Express /*, Rails /*path
@@ -161,6 +162,7 @@ export function normalizePath(
   //     a catch-all is not misconsumed as a one-segment param.
   s = s.replace(/:[A-Za-z0-9_]+/g, PLACEHOLDER); // Express/Rails :id
   s = s.replace(/\[[^\]]+\]/g, PLACEHOLDER); // Next.js file-route [id]
+  s = s.replace(/<[^>]+>/g, PLACEHOLDER); // Django/Flask <int:pk>, <slug:s>, <name>
   s = s.replace(/\{[^}]*\}/g, (m) => (m === CATCHALL ? CATCHALL : PLACEHOLDER)); // {id}, keep {*}
 
   // 7. single leading slash

--- a/src/analyzers/flow/normalize.ts
+++ b/src/analyzers/flow/normalize.ts
@@ -30,6 +30,22 @@
 /** Canonical HTTP verbs the flow feature recognizes. */
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
 
+/**
+ * The method-agnostic marker for a SERVED route declared without a verb.
+ * Several routing layers genuinely bind a path to a handler for EVERY method —
+ * Django's `path('users/', view)`, Go's `http.HandleFunc("/x", h)`, Rails'
+ * `match` — and dispatch (or 405) by method INSIDE the handler. Flow models the
+ * routing layer, so such a declaration is one `ANY` route: a consumed call with
+ * any verb on that path resolves against it (see `servedMatch` / `joinFlow` in
+ * `model.ts`). Only served routes ever carry it — a client call always has a
+ * concrete verb. On the wire (`served.json`) it serializes as the method string
+ * `"ANY"`, additive on schema v1.
+ */
+export const ANY_METHOD = 'ANY';
+
+/** A served route's method: a concrete verb, or the method-agnostic marker. */
+export type ServedMethod = HttpMethod | typeof ANY_METHOD;
+
 /** Per-app normalization inputs (not language facts — see module header). */
 export interface NormalizeConfig {
   /**

--- a/src/ast/grammar-shape.ts
+++ b/src/ast/grammar-shape.ts
@@ -1,0 +1,263 @@
+/**
+ * Grammar shapes — the per-GRAMMAR syntax-access layer that lets ONE flow
+ * extractor walk any tree-sitter grammar.
+ *
+ * Different grammars name the same constructs differently: TypeScript emits
+ * `call_expression` / `member_expression` (fields `object`/`property`), Python
+ * emits `call` / `attribute` (fields `object`/`attribute`), Go emits
+ * `call_expression` / `selector_expression` (fields `operand`/`field`). Those
+ * names are facts about the GRAMMAR ARTIFACT — not about a language pack's
+ * frameworks (which live in `LanguageSupport.httpFlow`, Rule 6) and not about
+ * flow semantics (which live in `src/analyzers/flow/extract.ts`). So they live
+ * here, in the AST layer, beside the logical-grammar-name → wasm mapping
+ * (`parse.ts`) — the same engine-swap boundary.
+ *
+ * The division of labor:
+ *   - `src/languages/<id>.ts:httpFlow`  — WHICH constructs are HTTP (framework
+ *     facts, declarative, per pack);
+ *   - THIS module                        — HOW to read a call / member / string /
+ *     decorator / keyword-argument from this grammar's tree (syntax facts, per
+ *     grammar);
+ *   - `src/analyzers/flow/extract.ts`    — WHAT they mean for flow (semantics,
+ *     grammar-agnostic, edited for no one language).
+ *
+ * Adding flow support for a new language therefore touches no extractor code:
+ * declare `treeSitterGrammars` + `httpFlow` on the pack, and add a row here if
+ * the grammar is new (most rows come from the shared callee-field factory
+ * below). `test/languages-contract.test.ts` loud-fails a pack whose declared
+ * grammar has no shape row.
+ */
+
+import { walk, type Node } from './parse';
+
+/** A call site decomposed into its callee form. */
+export interface ResolvedCall {
+  /** `bare` — `fetch(...)`, `path(...)`; `member` — `requests.get(...)`. */
+  readonly kind: 'bare' | 'member';
+  /** Bare callee name, or the member property/method name (`get`). */
+  readonly name: string;
+  /** Member receiver text (`requests`, `this.http`); `''` for bare calls. */
+  readonly receiver: string;
+}
+
+/**
+ * How to read one grammar's tree. Every function is total over arbitrary nodes
+ * (returns null / empty rather than throwing) so the extractor stays fail-open.
+ */
+export interface GrammarShape {
+  /** Node types that are invocations in this grammar. */
+  readonly callNodes: readonly string[];
+  /** Decompose a call node's callee; null when it is neither bare nor member. */
+  resolveCall(call: Node): ResolvedCall | null;
+  /** First positional (non-keyword) argument node of a call, else null. */
+  firstArg(call: Node): Node | null;
+  /**
+   * A string literal's text — verbatim including quotes/backticks, with any
+   * language-level prefix (Python `f"..."` / `r"..."`) stripped so downstream
+   * normalization sees the quote first. Null for a non-string node.
+   */
+  stringText(node: Node): string | null;
+  /** Node types of decorator/annotation attachments (`[]` = grammar has none). */
+  readonly decoratorNodes: readonly string[];
+  /** The invocation inside a decorator (`@app.get('/x')` → the call), else null. */
+  decoratorCall(decorator: Node): Node | null;
+  /**
+   * Value node of a named option on a call — a keyword argument (Python
+   * `methods=[...]`) or an entry of a trailing object-literal argument (JS
+   * `fetch(url, { method: 'POST' })`). Null when absent.
+   */
+  optionValue(call: Node, name: string): Node | null;
+  /** Texts (verbatim, quoted) of the string elements of a list/array node. */
+  listStrings(node: Node): string[];
+  /** Function/method definition node types (decorated-handler-name fallback). */
+  readonly functionNodes: readonly string[];
+}
+
+/** Inputs to the shared factory for callee-field grammars — those whose call
+ *  node carries a `function` field holding an identifier or a member node
+ *  (the TS/JS family, Python, Go). Fused-callee grammars (Java's
+ *  `method_invocation` puts `object`/`name` on the call itself) get their own
+ *  factory when their wave lands. */
+interface CalleeFieldGrammar {
+  readonly callNodes: readonly string[];
+  readonly identifierNodes: readonly string[];
+  readonly memberNode: string;
+  readonly memberObjectField: string;
+  readonly memberPropertyField: string;
+  /** Node types whose text is a string literal. */
+  readonly stringNodes: readonly string[];
+  /** Strip a letter prefix before the opening quote (Python `f"…"`, `rb'…'`). */
+  readonly stringPrefixes?: boolean;
+  readonly decoratorNodes?: readonly string[];
+  readonly functionNodes: readonly string[];
+  /** Keyword-argument node + its fields, when the grammar has keyword args. */
+  readonly keywordArg?: { node: string; nameField: string; valueField: string };
+  /** Object-literal option bags (`fetch(url, { method: 'POST' })`), when the
+   *  grammar expresses options that way. */
+  readonly optionsObject?: { node: string; pairNode: string; keyField: string; valueField: string };
+  /** Node type of a list/array literal (`methods=["GET"]`). */
+  readonly listNode?: string;
+}
+
+/** Strip quotes/backticks off a literal's verbatim text (for key comparison). */
+function bareKey(text: string): string {
+  return text.replace(/['"`]/g, '');
+}
+
+function calleeFieldShape(g: CalleeFieldGrammar): GrammarShape {
+  const stringTypes = new Set(g.stringNodes);
+  const identifierTypes = new Set(g.identifierNodes);
+  const callTypes = new Set(g.callNodes);
+
+  const stringText = (node: Node): string | null => {
+    if (!stringTypes.has(node.type)) return null;
+    const text = node.text;
+    // Python-style prefixed literals: `f"/x/{id}"`, `r'...'`, `rb'...'` — drop
+    // the prefix so quote-stripping (and the URL guard) see the quote first.
+    return g.stringPrefixes ? text.replace(/^[A-Za-z]{1,3}(?=['"])/, '') : text;
+  };
+
+  const namedArgs = (call: Node): Node[] => {
+    const args = call.childForFieldName('arguments');
+    if (!args) return [];
+    const out: Node[] = [];
+    for (const c of args.namedChildren) if (c) out.push(c);
+    return out;
+  };
+
+  return {
+    callNodes: g.callNodes,
+
+    resolveCall(call: Node): ResolvedCall | null {
+      const callee = call.childForFieldName('function');
+      if (!callee) return null;
+      if (identifierTypes.has(callee.type)) {
+        return { kind: 'bare', name: callee.text, receiver: '' };
+      }
+      if (callee.type === g.memberNode) {
+        const prop = callee.childForFieldName(g.memberPropertyField);
+        const obj = callee.childForFieldName(g.memberObjectField);
+        return { kind: 'member', name: prop?.text ?? '', receiver: obj?.text ?? '' };
+      }
+      return null;
+    },
+
+    firstArg(call: Node): Node | null {
+      for (const arg of namedArgs(call)) {
+        if (g.keywordArg && arg.type === g.keywordArg.node) continue; // positional only
+        return arg;
+      }
+      return null;
+    },
+
+    stringText,
+
+    decoratorNodes: g.decoratorNodes ?? [],
+
+    decoratorCall(decorator: Node): Node | null {
+      for (const child of decorator.namedChildren) {
+        if (child && callTypes.has(child.type)) return child;
+      }
+      return null;
+    },
+
+    optionValue(call: Node, name: string): Node | null {
+      // Keyword-argument form: `route('/x', methods=[...])`.
+      if (g.keywordArg) {
+        for (const arg of namedArgs(call)) {
+          if (arg.type !== g.keywordArg.node) continue;
+          const key = arg.childForFieldName(g.keywordArg.nameField);
+          if (key && key.text === name) return arg.childForFieldName(g.keywordArg.valueField);
+        }
+      }
+      // Options-bag form: `fetch(url, { method: 'POST' })` — any object-literal
+      // argument, searched depth-first (an option can sit under a spread/nesting).
+      if (g.optionsObject) {
+        const oo = g.optionsObject;
+        for (const arg of namedArgs(call)) {
+          if (arg.type !== oo.node) continue;
+          let found: Node | null = null;
+          walk(arg, (n) => {
+            if (found) return false;
+            if (n.type === oo.pairNode) {
+              const key = n.childForFieldName(oo.keyField);
+              if (key && bareKey(key.text) === name) {
+                found = n.childForFieldName(oo.valueField);
+              }
+            }
+            return undefined;
+          });
+          if (found) return found;
+        }
+      }
+      return null;
+    },
+
+    listStrings(node: Node): string[] {
+      if (g.listNode === undefined || node.type !== g.listNode) return [];
+      const out: string[] = [];
+      for (const c of node.namedChildren) {
+        if (!c) continue;
+        const text = stringText(c);
+        if (text !== null) out.push(text);
+      }
+      return out;
+    },
+
+    functionNodes: g.functionNodes,
+  };
+}
+
+// ─── Shape rows ──────────────────────────────────────────────────────────────
+// One row per DISTINCT grammar family. Rows are added with their language
+// wave, each verified against the bundled wasm artifact (an unverified row is
+// worse than a missing one — the contract test would pass while extraction
+// silently misreads the tree).
+
+/** TS / TSX / JS share one shape — the JS-family grammars use identical node
+ *  and field names for every construct the extractor reads. */
+const JS_FAMILY: GrammarShape = calleeFieldShape({
+  callNodes: ['call_expression'],
+  identifierNodes: ['identifier'],
+  memberNode: 'member_expression',
+  memberObjectField: 'object',
+  memberPropertyField: 'property',
+  stringNodes: ['string', 'template_string'],
+  decoratorNodes: ['decorator'],
+  functionNodes: ['method_definition', 'function_declaration'],
+  optionsObject: { node: 'object', pairNode: 'pair', keyField: 'key', valueField: 'value' },
+  listNode: 'array',
+});
+
+const PYTHON: GrammarShape = calleeFieldShape({
+  callNodes: ['call'],
+  identifierNodes: ['identifier'],
+  memberNode: 'attribute',
+  memberObjectField: 'object',
+  memberPropertyField: 'attribute',
+  stringNodes: ['string'],
+  stringPrefixes: true, // f"/x/{id}", r'...', rb'...'
+  decoratorNodes: ['decorator'],
+  functionNodes: ['function_definition'],
+  keywordArg: { node: 'keyword_argument', nameField: 'name', valueField: 'value' },
+  listNode: 'list',
+});
+
+const GRAMMAR_SHAPES: Readonly<Record<string, GrammarShape>> = {
+  typescript: JS_FAMILY,
+  tsx: JS_FAMILY,
+  javascript: JS_FAMILY,
+  python: PYTHON,
+};
+
+/** The shape for a logical grammar name, or null when no row exists yet —
+ *  callers treat null as "this grammar's files cannot contribute flow" and
+ *  skip, never throw. */
+export function grammarShape(grammar: string): GrammarShape | null {
+  return GRAMMAR_SHAPES[grammar] ?? null;
+}
+
+/** Grammar names with a shape row (for the pack-contract completeness test). */
+export function shapedGrammars(): string[] {
+  return Object.keys(GRAMMAR_SHAPES);
+}

--- a/src/ast/grammar-shape.ts
+++ b/src/ast/grammar-shape.ts
@@ -51,6 +51,8 @@ export interface GrammarShape {
   resolveCall(call: Node): ResolvedCall | null;
   /** First positional (non-keyword) argument node of a call, else null. */
   firstArg(call: Node): Node | null;
+  /** All positional (non-keyword) argument nodes of a call, in order. */
+  positionalArgs(call: Node): Node[];
   /**
    * A string literal's text — verbatim including quotes/backticks, with any
    * language-level prefix (Python `f"..."` / `r"..."`) stripped so downstream
@@ -148,6 +150,10 @@ function calleeFieldShape(g: CalleeFieldGrammar): GrammarShape {
         return arg;
       }
       return null;
+    },
+
+    positionalArgs(call: Node): Node[] {
+      return namedArgs(call).filter((arg) => !(g.keywordArg && arg.type === g.keywordArg.node));
     },
 
     stringText,

--- a/src/discovery/advisor.ts
+++ b/src/discovery/advisor.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { resolveBaselineMode } from '../baseline/modes';
 import { FLOW_CONFIG_SCHEMA_VERSION } from '../analyzers/flow/config';
 import { isClaudeLoopInstalled } from '../loop/scaffold';
+import { LANGUAGES } from '../languages';
 import type {
   RecommendContext,
   Recommendation,
@@ -64,33 +65,59 @@ export function recommendBaseline(ctx: RecommendContext): Recommendation | null 
 }
 
 /**
- * Signal: this repo has a UI framework but no flow setup yet — the case where
- * flow's UI→API integration gate adds value. Shared by BOTH the doctor probe
- * (`recommendFlow`) and the deterministic planner (`planFlowMode`) so the two
- * never diverge (Rule 2 — one concept, one code path).
+ * Signal: this repo has an HTTP framework a flow-capable pack declares but no
+ * flow setup yet — the case where flow's integration gate adds value. Shared
+ * by BOTH the doctor probe (`recommendFlow`) and the deterministic planner
+ * (`planFlowMode`) so the two never diverge (Rule 2 — one concept, one code
+ * path). The framework tokens are PACK-DECLARED (`httpFlow.flowSignals`,
+ * Rule 6) — pre-M6 this probe hardcoded a JS UI-framework list against
+ * package.json, so a pure FastAPI/Django repo was never recommended the
+ * capability its pack had just gained.
  */
 function hasFlowSignal(cwd: string): boolean {
-  const pkg = readJsonSafe(path.join(cwd, 'package.json'));
-  if (!pkg) return false;
-  const deps = {
-    ...((pkg.dependencies as Record<string, unknown>) ?? {}),
-    ...((pkg.devDependencies as Record<string, unknown>) ?? {}),
-  };
-  const uiFrameworks = ['react', 'next', 'vue', 'svelte', '@angular/core'];
-  if (!uiFrameworks.some((f) => f in deps)) return false;
   // Already configured? workspace.json or a flow policy block means yes.
   if (existsAt(cwd, '.dxkit', 'workspace.json')) return false;
   const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json'));
   if (policy && 'flow' in policy) return false;
-  return true;
+
+  for (const pack of LANGUAGES) {
+    for (const signal of pack.httpFlow?.flowSignals ?? []) {
+      if (signal.manifest === 'package.json') {
+        // JSON manifests match on dependency KEYS (a word-boundary text search
+        // would also hit versions/scripts).
+        const pkg = readJsonSafe(path.join(cwd, signal.manifest));
+        if (!pkg) continue;
+        const deps = {
+          ...((pkg.dependencies as Record<string, unknown>) ?? {}),
+          ...((pkg.devDependencies as Record<string, unknown>) ?? {}),
+        };
+        if (signal.anyOf.some((f) => f in deps)) return true;
+      } else {
+        // Plain-text manifests (requirements.txt, pyproject.toml, Pipfile…)
+        // match on word-boundary tokens — precise enough for a fail-open
+        // recommendation probe.
+        let text: string;
+        try {
+          text = fs.readFileSync(path.join(cwd, signal.manifest), 'utf8');
+        } catch {
+          continue;
+        }
+        const hit = signal.anyOf.some((f) =>
+          new RegExp(`\\b${f.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(text),
+        );
+        if (hit) return true;
+      }
+    }
+  }
+  return false;
 }
 
-/** Recommend `flow init` on a UI repo with no flow setup. */
+/** Recommend flow setup on a repo with an HTTP-framework signal and no flow config. */
 export function recommendFlow(ctx: RecommendContext): Recommendation | null {
   if (!hasFlowSignal(ctx.cwd)) return null;
   return {
     reason:
-      'detected a UI framework but no flow setup — flow maps UI→API calls and gates changes that break an integration',
+      'detected an HTTP framework but no flow setup — flow maps client calls to served routes and gates changes that break an integration',
     command: 'vyuh-dxkit flow init',
   };
 }
@@ -208,7 +235,7 @@ export function planFlowMode(ctx: ConfigContext): ConfigPlanItem | null {
     summary: 'warn',
     patch: { flow: { mode: 'warn', schemaVersion: FLOW_CONFIG_SCHEMA_VERSION } },
     reason: 'seed the UI→API integration gate at the safe default (warn, never fails a build)',
-    evidence: 'UI framework in package.json, no flow config yet',
+    evidence: 'HTTP framework in a dependency manifest, no flow config yet',
   };
 }
 

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1237,6 +1237,46 @@ export const python: LanguageSupport = {
     },
   },
 
+  // HTTP flow (CLAUDE.md Rule 6): how Python source expresses outbound HTTP
+  // calls + route declarations, consumed by the one flow extractor via the
+  // grammar-shape adapter (`src/ast/grammar-shape.ts`) — zero extractor code
+  // is Python-specific. CLIENT: `requests` / `httpx` are TRUSTED bases (HTTP
+  // by construction — their dynamic-URL calls are counted as unverifiable,
+  // never silently dropped), and any other receiver's `.get('/x')` with a
+  // path-like literal is admitted as a wrapper (`session`, `client`, an
+  // app-specific api object) — the same precision guard the TS pack relies
+  // on keeps `dict.get('key')` out. SERVED, three declarative forms:
+  //   - FastAPI/Sanic/Flask-2 member verb decorators `@app.get('/x')`
+  //     (leading-slash guard keeps `@mock.patch('pkg.attr')` out);
+  //   - Flask `@app.route('/x', methods=['GET','POST'])` via the
+  //     methods-kwarg reader, defaulting to Flask's GET-only;
+  //   - Django `path('users/<int:pk>/', view)` in urls.py, emitted as an
+  //     `ANY` (method-agnostic) route — the routing layer accepts every
+  //     verb there; `include(...)` mounts are prefixes, not routes, and are
+  //     excluded. Django's regex `re_path(...)` routes are OUT of scope
+  //     (a regex route has no canonical path form to join on) — a repo that
+  //     needs them can point `flow.specs` at an OpenAPI document instead.
+  // Angle-bracket converters (`<int:pk>`, `<path:rest>`) canonicalize in the
+  // shared normalizer, so both Django and Flask param forms join client
+  // template URLs.
+  httpFlow: {
+    clientMethodCallees: {
+      methods: ['get', 'post', 'put', 'patch', 'delete'],
+      bases: ['requests', 'httpx'],
+    },
+    routeMemberDecorators: {
+      methods: ['get', 'post', 'put', 'patch', 'delete', 'head', 'options'],
+    },
+    routePathDecorators: { names: ['route'], methodsKeyword: 'methods', defaultMethods: ['GET'] },
+    routeCallees: { names: ['path'], excludeArgCallees: ['include'] },
+  },
+
+  // Tree-sitter grammar for the canonical AST layer (src/ast/). Logical name —
+  // src/ast/ resolves it to the bundled wasm artifact and its shape row.
+  treeSitterGrammars: {
+    '.py': 'python',
+  },
+
   clocLanguageNames: ['Python'],
 
   detect(cwd) {

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1269,6 +1269,13 @@ export const python: LanguageSupport = {
     },
     routePathDecorators: { names: ['route'], methodsKeyword: 'methods', defaultMethods: ['GET'] },
     routeCallees: { names: ['path'], excludeArgCallees: ['include'] },
+    // Discovery-only (doctor's flow recommendation + the config planner):
+    // a web framework in a Python manifest signals a served-side flow surface.
+    flowSignals: [
+      { manifest: 'requirements.txt', anyOf: ['fastapi', 'flask', 'django'] },
+      { manifest: 'pyproject.toml', anyOf: ['fastapi', 'flask', 'django'] },
+      { manifest: 'Pipfile', anyOf: ['fastapi', 'flask', 'django'] },
+    ],
   },
 
   // Tree-sitter grammar for the canonical AST layer (src/ast/). Logical name —

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -257,13 +257,18 @@ export interface HttpFlowSupport {
    * Member-method client calls of the form `<base>.<method>(url, ...)`.
    * `methods` are the property names that map to HTTP verbs
    * (`get`/`post`/`put`/`delete`/`patch`); the verb is the method name.
-   * `bases`, when present, restricts which receiver identifiers count
-   * (`axios`, `http`, `api`, `client`, `request`, ...). When `bases` is
-   * omitted, any receiver whose `.<method>(...)` first argument is a
-   * path-like literal is treated as a client call — this covers
-   * app-specific wrappers (`requests.get('/x')`, `agent.Articles.del(...)`)
-   * that no fixed allowlist can enumerate; the path-like-literal filter
-   * keeps non-HTTP `.get`/`.delete` (lodash, Maps) out.
+   *
+   * `bases` declares TRUSTED receivers — module-level HTTP clients that are
+   * HTTP by construction (`requests`, `httpx`). A trusted receiver's call
+   * counts even when its URL argument is not a literal (recorded as a
+   * DYNAMIC call site — the coverage-honesty channel), because dropping it
+   * would silently understate what flow cannot see. Any OTHER receiver
+   * still counts when its first argument is a path-like literal — that
+   * precision guard is what admits app-specific wrappers
+   * (`api.get('/x')`, `agent.Articles.del(...)`) that no fixed allowlist
+   * can enumerate while keeping non-HTTP `.get`/`.delete` (lodash, Maps,
+   * dict.get) out. `bases` therefore only ever ADDS matches (trust
+   * elevation) — it never narrows the wrapper coverage.
    */
   clientMethodCallees?: { methods: string[]; bases?: string[] };
 

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -341,6 +341,20 @@ export interface HttpFlowSupport {
    * Optional — a pack whose frameworks route only in-source omits it.
    */
   fileRoutes?: FileRouteSupport;
+
+  /**
+   * Cheap dependency-manifest signals that this language's HTTP-flow surface
+   * is present in a repo — each entry names a manifest file and the framework
+   * tokens to look for in it. Drives DISCOVERY only (doctor's "you'd benefit
+   * from flow" recommendation and the config planner's warn-mode seed), never
+   * extraction: extraction runs wherever the descriptor matches source. A
+   * `package.json` manifest is matched on its dependency KEYS; any other
+   * manifest (requirements.txt, pyproject.toml, Gemfile, go.mod) on a
+   * word-boundary text search — precise enough for a fail-open
+   * recommendation probe. Without this field a pack's repos are simply never
+   * proactively recommended flow (extraction still works once configured).
+   */
+  flowSignals?: Array<{ manifest: string; anyOf: string[] }>;
 }
 
 /**

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -288,6 +288,43 @@ export interface HttpFlowSupport {
   routeRouterCallees?: { methods: string[]; bases: string[] };
 
   /**
+   * MEMBER-callee route decorators: `@<recv>.<method>('/path')` on a handler
+   * (FastAPI `@app.get('/x')` / `@router.post('/x')`, Sanic, Flask 2's
+   * `@app.get`). The property name maps to the HTTP verb; the first string
+   * argument is the route path and MUST begin with `/` once unquoted — these
+   * frameworks mandate a leading slash, and requiring it is the precision
+   * guard that keeps look-alike member decorators (`@mock.patch('pkg.attr')`)
+   * out. `bases`, when present, restricts which receiver identifiers count;
+   * omit it for frameworks whose app/router objects are user-named.
+   */
+  routeMemberDecorators?: { methods: string[]; bases?: string[] };
+
+  /**
+   * PATH-first route decorators whose methods ride a keyword argument:
+   * Flask's `@app.route('/x', methods=['GET', 'POST'])`. `names` are the
+   * decorator callee names (member or bare — `@app.route` and `@route` both
+   * match on `route`); the first string argument is the path (leading `/`
+   * required, as above). `methodsKeyword` names the keyword argument carrying
+   * the verb list; when absent the route is emitted once per entry in
+   * `defaultMethods` (Flask's default is GET-only).
+   */
+  routePathDecorators?: { names: string[]; methodsKeyword: string; defaultMethods: string[] };
+
+  /**
+   * BARE-callee route declarations that bind a path to a handler with NO verb:
+   * Django's `path('users/<int:pk>/', view)` in `urls.py`. The declaration is
+   * method-agnostic at the routing layer, so the route is emitted with the
+   * `ANY` method (see `ANY_METHOD` in `analyzers/flow/normalize.ts`) and
+   * resolves a consumed call with any verb on that path. Guards: the callee
+   * name must match, the first argument must be a string literal, and a
+   * second argument (the handler) must be present — `excludeArgCallees` skips
+   * declarations whose arguments include a call to one of these names
+   * (Django's `include(...)` mounts a sub-conf; its first argument is a
+   * PREFIX, not a served route).
+   */
+  routeCallees?: { names: string[]; excludeArgCallees?: string[] };
+
+  /**
    * Canonicalize a matched method token to an uppercase HTTP verb where the
    * token differs from the verb. The motivating alias is LoopBack's `del` →
    * `DELETE`. Tokens absent from the map default to upper-casing

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1791,6 +1791,11 @@ export const typescript: LanguageSupport = {
       baseDirs: ['src/app', 'app'],
       methodExports: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
     },
+    // Discovery-only (doctor's flow recommendation + the config planner):
+    // a UI framework in package.json signals a consumed-side flow surface.
+    flowSignals: [
+      { manifest: 'package.json', anyOf: ['react', 'next', 'vue', 'svelte', '@angular/core'] },
+    ],
   },
 
   // Tree-sitter grammars by extension for the canonical AST layer (src/ast/).

--- a/test/ast-parse.test.ts
+++ b/test/ast-parse.test.ts
@@ -75,10 +75,12 @@ describe('grammarForExtension (pack-driven resolution)', () => {
     expect(grammarForExtension('.tsx')).toEqual({ grammar: 'tsx', languageId: 'typescript' });
     expect(grammarForExtension('.js')?.grammar).toBe('javascript');
     expect(grammarForExtension('.JSX')?.grammar).toBe('javascript'); // case-insensitive
+    // The python pack declares its grammar as of the M6 wave.
+    expect(grammarForExtension('.py')).toEqual({ grammar: 'python', languageId: 'python' });
   });
 
   it('returns null for an extension no pack parses yet', () => {
-    expect(grammarForExtension('.py')).toBeNull(); // python pack has no treeSitterGrammars yet
+    expect(grammarForExtension('.rb')).toBeNull(); // ruby pack: grammar lands in its M6 wave
     expect(grammarForExtension('.zzz')).toBeNull();
   });
 });

--- a/test/discovery/config-plan.test.ts
+++ b/test/discovery/config-plan.test.ts
@@ -88,6 +88,22 @@ describe('config planners — pure functions of repo facts', () => {
     expect(gatherConfigPlan(d, privateProbes).find((p) => p.capability === 'flow')).toBeUndefined();
   });
 
+  it('flow: a PYTHON web framework triggers the same plan (signals are pack-declared)', () => {
+    // Pre-M6 the flow signal hardcoded JS UI frameworks against package.json,
+    // so a pure FastAPI/Django repo was never seeded the gate its pack
+    // supports. The signal now unions every pack's httpFlow.flowSignals.
+    const d = mkTmp();
+    fs.writeFileSync(path.join(d, 'requirements.txt'), 'fastapi==0.111.0\nuvicorn\n');
+    const flow = gatherConfigPlan(d, privateProbes).find((p) => p.capability === 'flow');
+    expect(flow?.summary).toBe('warn');
+    // An unrelated python repo (no web framework) stays silent.
+    const d2 = mkTmp();
+    fs.writeFileSync(path.join(d2, 'requirements.txt'), 'numpy\npandas\n');
+    expect(
+      gatherConfigPlan(d2, privateProbes).find((p) => p.capability === 'flow'),
+    ).toBeUndefined();
+  });
+
   it('checks: linter present + no lint policy → enabled warn-only; opted-in → silent', () => {
     const d = mkTmp();
     fs.writeFileSync(path.join(d, 'eslint.config.mjs'), 'export default {}');

--- a/test/fixtures-analysis.test.ts
+++ b/test/fixtures-analysis.test.ts
@@ -12,8 +12,9 @@
  * single Payload/Next.js fixture — the language-agnostic invariants
  * (`.env.example` is not a finding; a placeholder secret is dropped) are
  * asserted on TS, Python, AND Go, so a fix that only works for one stack fails
- * here. Flow-specific invariants run on the flow-capable pack (TS today); a new
- * language pack (M6) adds a fixture dir + a row and inherits the checks.
+ * here. Flow-specific invariants run on every flow-capable pack (TS + Python
+ * today); a new language pack adds a fixture dir + a row and inherits the
+ * checks — the flow rows additionally pin that stack's served/consumed forms.
  *
  * Each fixture is copied to a throwaway git repo (env-in-git needs `git
  * ls-files`), then the gathers run in-process.
@@ -64,11 +65,13 @@ function stageFixture(stack: string): string {
   return dir;
 }
 
-// Every stack in the matrix. `flow: true` marks the flow-capable packs whose
-// route/call resolution is additionally asserted.
-const STACKS: Array<{ stack: string; flow?: boolean }> = [
-  { stack: 'ts-webapp', flow: true },
-  { stack: 'python-svc' },
+// Every stack in the matrix. `flow` marks the flow-capable packs whose
+// route/call resolution is additionally asserted, with the stack's expected
+// consumed-call count (every one of which must resolve — 0 unresolved is the
+// last-mile of flow correctness on every flow-capable stack, not just TS).
+const STACKS: Array<{ stack: string; flow?: { calls: number } }> = [
+  { stack: 'ts-webapp', flow: { calls: 2 } },
+  { stack: 'python-svc', flow: { calls: 4 } },
   { stack: 'go-svc' },
 ];
 
@@ -145,15 +148,34 @@ describe('analysis fixtures — test-gap import-graph credits non-relative impor
 
 describe('analysis fixtures — flow resolution (flow-capable packs)', () => {
   for (const { stack, flow } of STACKS.filter((s) => s.flow)) {
-    it(`${stack}: base-URL-helper calls resolve via policy stripUrlPrefixes + catch-all`, async () => {
-      // The user-facing surface loads .dxkit/policy.json:flow.stripUrlPrefixes
-      // itself. Both calls use `${getClientSideURL()}`, which the policy strips,
-      // then bind the served catch-all `app/(payload)/api/[...slug]/route.ts`.
-      void flow;
+    it(`${stack}: every consumed call resolves against the stack's served surface`, async () => {
+      // The user-facing surface loads .dxkit/policy.json:flow config itself
+      // (ts-webapp: stripUrlPrefixes + the [...slug] catch-all; python-svc:
+      // FastAPI decorators + Flask methods-kwarg + a Django ANY route).
       const model = await gatherRepoFlowModel(staged[stack]);
       const s = summarize(model);
-      expect(s.calls).toBe(2);
-      expect(s.unresolved).toBe(0); // 0/4 unresolved — the last-mile of flow correctness
+      expect(s.calls).toBe(flow!.calls);
+      expect(s.unresolved).toBe(0); // the last-mile of flow correctness
     });
   }
+
+  it('python-svc: the three Python served forms + coverage honesty hold end-to-end', async () => {
+    const model = await gatherRepoFlowModel(staged['python-svc']);
+    const served = model.routes.map((r) => `${r.method} ${r.path}`).sort();
+    // FastAPI member decorators, Flask methods-kwarg (one route per verb),
+    // Django path() as ANY — and the include('admin/') mount mints NOTHING.
+    expect(served).toEqual([
+      'ANY /reports/{var}',
+      'GET /items/{var}',
+      'GET /legacy',
+      'POST /legacy',
+      'POST /users',
+    ]);
+    // A PUT against the Django route resolves via the ANY rule.
+    const put = model.bindings.find((b) => b.call.method === 'PUT');
+    expect(put?.route?.path).toBe('/reports/{var}');
+    // The runtime-built requests.get(url) is DISCLOSED as dynamic, not dropped.
+    expect(model.dynamicCalls).toHaveLength(1);
+    expect(model.dynamicCalls[0].receiver).toBe('requests');
+  });
 });

--- a/test/fixtures/analysis/python-svc/src/api/app.py
+++ b/test/fixtures/analysis/python-svc/src/api/app.py
@@ -1,0 +1,16 @@
+"""FastAPI-shaped served surface: member verb decorators."""
+
+from fastapi import APIRouter, FastAPI
+
+app = FastAPI()
+router = APIRouter()
+
+
+@app.get("/items/{item_id}")
+def read_item(item_id: int):
+    return {"id": item_id}
+
+
+@router.post("/users")
+def create_user():
+    return {"ok": True}

--- a/test/fixtures/analysis/python-svc/src/clients/backend_client.py
+++ b/test/fixtures/analysis/python-svc/src/clients/backend_client.py
@@ -1,0 +1,28 @@
+"""Consumed surface: requests/httpx calls binding every served form above.
+
+The last call's URL is runtime-built — the coverage-honesty channel must
+COUNT it as a dynamic call site, never silently drop it.
+"""
+
+import httpx
+import requests
+
+
+def fetch_item(item_id: int):
+    return requests.get(f"/items/{item_id}")  # → FastAPI GET /items/{var}
+
+
+def add_user():
+    return httpx.post("/users")  # → FastAPI POST /users
+
+
+def update_report(pk: int):
+    return requests.put(f"/reports/{pk}/")  # → Django ANY /reports/{var}
+
+
+def load_legacy():
+    return requests.get("/legacy")  # → Flask GET /legacy
+
+
+def opaque(url: str):
+    return requests.get(url)  # dynamic: recognized, unverifiable, DISCLOSED

--- a/test/fixtures/analysis/python-svc/src/legacy/webapp.py
+++ b/test/fixtures/analysis/python-svc/src/legacy/webapp.py
@@ -1,0 +1,10 @@
+"""Flask-shaped served surface: path-first decorator with a methods kwarg."""
+
+from flask import Flask
+
+flask_app = Flask(__name__)
+
+
+@flask_app.route("/legacy", methods=["GET", "POST"])
+def legacy():
+    return ""

--- a/test/fixtures/analysis/python-svc/src/site/urls.py
+++ b/test/fixtures/analysis/python-svc/src/site/urls.py
@@ -1,0 +1,11 @@
+"""Django-shaped served surface: verb-less path() declarations (ANY routes)."""
+
+from django.urls import include, path
+
+from . import views
+
+urlpatterns = [
+    path("reports/<int:pk>/", views.report_detail),
+    # A mount is a PREFIX, not a served route — must not mint one.
+    path("admin/", include("site.admin_urls")),
+]

--- a/test/flow-csv-gather.test.ts
+++ b/test/flow-csv-gather.test.ts
@@ -3,6 +3,7 @@ import { writeFileSync, mkdtempSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { parseSource } from '../src/ast/parse';
+import { grammarShape } from '../src/ast/grammar-shape';
 import { extractFromTree } from '../src/analyzers/flow/extract';
 import { buildFlowModel } from '../src/analyzers/flow/model';
 import { callsCsv, routesCsv, mappingCsv, flowCsvFiles } from '../src/analyzers/flow/csv';
@@ -11,10 +12,21 @@ import { getLanguage } from '../src/languages';
 import type { HttpFlowSupport } from '../src/languages/types';
 
 const ts = getLanguage('typescript')!.httpFlow as HttpFlowSupport;
+const tsShape = grammarShape('typescript')!;
 
 async function model(clientSrc: string, serverSrc: string) {
-  const c = extractFromTree((await parseSource(clientSrc, 'typescript'))!.rootNode, ts, 'web/a.ts');
-  const s = extractFromTree((await parseSource(serverSrc, 'typescript'))!.rootNode, ts, 'api/c.ts');
+  const c = extractFromTree(
+    (await parseSource(clientSrc, 'typescript'))!.rootNode,
+    ts,
+    tsShape,
+    'web/a.ts',
+  );
+  const s = extractFromTree(
+    (await parseSource(serverSrc, 'typescript'))!.rootNode,
+    ts,
+    tsShape,
+    'api/c.ts',
+  );
   return buildFlowModel([c, s]);
 }
 

--- a/test/flow-extract-python.test.ts
+++ b/test/flow-extract-python.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The python pack's httpFlow declaration, pinned over the real grammar — the
+ * Python analog of `flow-extract.test.ts` (TS). The ADAPTER and the three
+ * declarative route FORMS have their own tests; this file pins what the PACK
+ * declares: which frameworks' shapes it covers, with which precision choices.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSource } from '../src/ast/parse';
+import { grammarShape } from '../src/ast/grammar-shape';
+import { extractFromTree, type FileFlow } from '../src/analyzers/flow/extract';
+import { getLanguage } from '../src/languages';
+import type { HttpFlowSupport } from '../src/languages/types';
+
+const py = getLanguage('python')!.httpFlow as HttpFlowSupport;
+const pyShape = grammarShape('python')!;
+
+async function extract(src: string): Promise<FileFlow> {
+  const tree = await parseSource(src, 'python');
+  return extractFromTree(tree!.rootNode, py, pyShape, 'sample.py');
+}
+
+describe('python pack — declaration completeness', () => {
+  it('declares httpFlow + a shaped grammar (flow-capable)', () => {
+    const pack = getLanguage('python')!;
+    expect(pack.httpFlow).toBeDefined();
+    expect(pack.treeSitterGrammars?.['.py']).toBe('python');
+    expect(grammarShape('python')).not.toBeNull();
+  });
+});
+
+describe('python pack — consumed side', () => {
+  it('requests/httpx are trusted; wrappers pass the path guard; dict.get is out', async () => {
+    const flow = await extract(`
+import requests, httpx
+
+def f(url, item_id, cfg):
+    requests.get(f"/api/items/{item_id}")
+    httpx.delete("/api/items/9")
+    session.post("/api/wrapped")
+    requests.patch(url)
+    cfg.get("timeout")
+`);
+    const keys = flow.calls.map((c) => `${c.method} ${c.path}`).sort();
+    expect(keys).toEqual(['DELETE /api/items/9', 'GET /api/items/{var}', 'POST /api/wrapped']);
+    expect(flow.dynamicCalls).toHaveLength(1); // requests.patch(url) — disclosed
+    expect(flow.dynamicCalls?.[0].receiver).toBe('requests');
+  });
+
+  it('an external absolute URL is recorded but unresolved (path null)', async () => {
+    const { calls } = await extract(`requests.get("https://api.stripe.com/v1/charges")`);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].path).toBeNull();
+  });
+});
+
+describe('python pack — served side (FastAPI / Flask / Django)', () => {
+  it('covers all three framework shapes in one file set', async () => {
+    const flow = await extract(`
+@app.get("/items/{item_id}")
+def read_item(item_id):
+    return {}
+
+@router.put("/items/{item_id}")
+def replace_item(item_id):
+    return {}
+
+@flask_app.route("/legacy", methods=["POST"])
+def legacy():
+    return ""
+
+urlpatterns = [path("reports/<int:pk>/", views.report_detail)]
+`);
+    const keys = flow.routes.map((r) => `${r.method} ${r.path}`).sort();
+    expect(keys).toEqual([
+      'ANY /reports/{var}',
+      'GET /items/{var}',
+      'POST /legacy',
+      'PUT /items/{var}',
+    ]);
+  });
+
+  it('precision: mock.patch / include() / bare route() calls mint no routes', async () => {
+    const flow = await extract(`
+@mock.patch("requests.get")
+def test_x(m):
+    pass
+
+urlpatterns = [path("api/", include("api.urls"))]
+result = route("/not-a-decorator", handler)
+`);
+    expect(flow.routes).toHaveLength(0);
+    expect(flow.calls).toHaveLength(0);
+  });
+
+  it('the join property: a client call and a FastAPI route reduce to one key', async () => {
+    const client = await extract(`requests.get(f"/articles/{slug}/comments")`);
+    const server = await extract(`
+@app.get("/articles/{slug}/comments")
+def comments(slug):
+    return []
+`);
+    const ck = `${client.calls[0].method} ${client.calls[0].path}`;
+    const sk = `${server.routes[0].method} ${server.routes[0].path}`;
+    expect(ck).toBe('GET /articles/{var}/comments');
+    expect(sk).toBe(ck);
+  });
+});

--- a/test/flow-extract.test.ts
+++ b/test/flow-extract.test.ts
@@ -2,14 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { parseSource } from '../src/ast/parse';
 import { extractFromTree, type FileFlow } from '../src/analyzers/flow/extract';
 import { getLanguage } from '../src/languages';
+import { grammarShape } from '../src/ast/grammar-shape';
 import type { HttpFlowSupport } from '../src/languages/types';
 
 const ts = getLanguage('typescript')!.httpFlow as HttpFlowSupport;
+const tsShape = grammarShape('typescript')!;
 const cfg = { stripUrlPrefixes: ['${Config.apiBase()}'] };
 
 async function extract(src: string): Promise<FileFlow> {
   const tree = await parseSource(src, 'typescript');
-  return extractFromTree(tree!.rootNode, ts, 'sample.ts', cfg);
+  return extractFromTree(tree!.rootNode, ts, tsShape, 'sample.ts', cfg);
 }
 
 describe('flow extract — client calls (consumed side)', () => {
@@ -79,7 +81,7 @@ describe('flow extract — client calls (consumed side)', () => {
     `,
       'typescript',
     );
-    const flow = extractFromTree(tree!.rootNode, withBases, 'sample.ts', cfg);
+    const flow = extractFromTree(tree!.rootNode, withBases, tsShape, 'sample.ts', cfg);
     expect(flow.calls).toHaveLength(1);
     expect(flow.dynamicCalls).toHaveLength(1); // api.* is a KNOWN client
     expect(flow.dynamicCalls?.[0].receiver).toBe('api');

--- a/test/flow-file-routes.test.ts
+++ b/test/flow-file-routes.test.ts
@@ -3,16 +3,18 @@ import { parseSource } from '../src/ast/parse';
 import { extractFromTree } from '../src/analyzers/flow/extract';
 import { deriveFileRoutePath } from '../src/analyzers/flow/file-routes';
 import { getLanguage } from '../src/languages';
+import { grammarShape } from '../src/ast/grammar-shape';
 import type { FileRouteSupport, HttpFlowSupport } from '../src/languages/types';
 
 const ts = getLanguage('typescript')!.httpFlow as HttpFlowSupport;
+const tsShape = grammarShape('typescript')!;
 
 /** Extract routes as `${METHOD} ${path}` keys for a source string served from
  *  `relPath` (the repo-relative path a file-route framework derives its URL
  *  from). */
 async function routeKeys(src: string, relPath: string): Promise<string[]> {
   const tree = await parseSource(src, 'typescript');
-  const { routes } = extractFromTree(tree!.rootNode, ts, relPath, undefined, relPath);
+  const { routes } = extractFromTree(tree!.rootNode, ts, tsShape, relPath, undefined, relPath);
   return routes.map((r) => `${r.method} ${r.path}`).sort();
 }
 
@@ -46,6 +48,7 @@ describe('flow file-routes — Next.js App Router served side', () => {
     const { routes } = extractFromTree(
       tree!.rootNode,
       ts,
+      tsShape,
       'app/health/route.ts',
       undefined,
       'app/health/route.ts',

--- a/test/flow-gate-join-parity.test.ts
+++ b/test/flow-gate-join-parity.test.ts
@@ -54,18 +54,21 @@ function route(path: string, over: Partial<RouteEndpoint> = {}): RouteEndpoint {
   };
 }
 
-/** Calls the JOIN considers resolved (bound to a route). */
-function joinResolvedPaths(calls: ClientCall[], routes: RouteEndpoint[]): Set<string> {
+/** Calls the JOIN considers resolved (bound to a route), as `METHOD path` keys
+ *  — method-aware so a fixture can pit two verbs on one path against each
+ *  other (the `ANY` served-route rule). */
+function joinResolvedKeys(calls: ClientCall[], routes: RouteEndpoint[]): Set<string> {
   return new Set(
     joinFlow(calls, routes)
       .filter((binding) => binding.route !== null)
-      .map((binding) => binding.call.path!),
+      .map((binding) => `${binding.call.method} ${binding.call.path}`),
   );
 }
 
-/** Paths the GATE flags as net-new broken, with base === head served (so every
- *  HEAD-broken call is net-new, isolating the resolution decision). */
-function gateBrokenPaths(calls: ClientCall[], routes: RouteEndpoint[]): Set<string> {
+/** `METHOD path` keys the GATE flags as net-new broken, with base === head
+ *  served (so every HEAD-broken call is net-new, isolating the resolution
+ *  decision). */
+function gateBrokenKeys(calls: ClientCall[], routes: RouteEndpoint[]): Set<string> {
   const model = buildFlowModel([{ calls, routes } as FileFlow]);
   const served = servedKeySet(buildServedContract(model, META));
   const consumed = buildConsumedContract(model, META).bindings;
@@ -75,10 +78,18 @@ function gateBrokenPaths(calls: ClientCall[], routes: RouteEndpoint[]): Set<stri
     headServed: served,
     baseServed: served,
   });
-  return new Set(found.map((f) => f.path));
+  return new Set(found.map((f) => `${f.method} ${f.path}`));
 }
 
-const FIXTURES: { name: string; calls: string[]; routes: string[] }[] = [
+/** `"/path"` (GET) or `"METHOD /path"` — fixtures vary methods so the
+ *  method-agnostic (`ANY`) served-route rule is parity-checked too. */
+type Keyed = string;
+function parseKeyed(k: Keyed): { method: string; path: string } {
+  const sp = k.indexOf(' ');
+  return sp === -1 ? { method: 'GET', path: k } : { method: k.slice(0, sp), path: k.slice(sp + 1) };
+}
+
+const FIXTURES: { name: string; calls: Keyed[]; routes: Keyed[] }[] = [
   {
     name: 'catch-all repo (Payload/Next [...slug])',
     calls: ['/api/users/login', '/api/posts', '/api'],
@@ -104,24 +115,46 @@ const FIXTURES: { name: string; calls: string[]; routes: string[] }[] = [
     calls: ['/api/exact', '/api/other', '/elsewhere'],
     routes: ['/api/exact', '/api/{*}'],
   },
+  {
+    name: 'method-agnostic routes (Django path / Go HandleFunc) serve every verb',
+    calls: ['GET /users', 'POST /users', 'DELETE /users/{var}', 'PUT /typo'],
+    routes: ['ANY /users', 'ANY /users/{var}'],
+  },
+  {
+    name: 'method-agnostic catch-all covers any verb under its prefix',
+    calls: ['POST /api/x', 'GET /api/y/z', 'GET /elsewhere'],
+    routes: ['ANY /api/{*}'],
+  },
+  {
+    name: 'a concrete-method route does NOT become method-agnostic',
+    calls: ['POST /a', 'POST /b', 'GET /a'],
+    routes: ['GET /a', 'ANY /b'],
+  },
 ];
 
 describe('gate ↔ join resolution parity (catch-all regression net)', () => {
   for (const fx of FIXTURES) {
     it(`${fx.name}: every join-resolved call is NOT gate-broken, and misses agree`, () => {
-      const calls = fx.calls.map((p) => call(p));
-      const routes = fx.routes.map((p) => route(p));
+      const calls = fx.calls.map((k) => {
+        const { method, path } = parseKeyed(k);
+        return call(path, { method: method as ClientCall['method'] });
+      });
+      const routes = fx.routes.map((k) => {
+        const { method, path } = parseKeyed(k);
+        return route(path, { method: method as RouteEndpoint['method'] });
+      });
 
-      const resolved = joinResolvedPaths(calls, routes);
-      const broken = gateBrokenPaths(calls, routes);
+      const resolved = joinResolvedKeys(calls, routes);
+      const broken = gateBrokenKeys(calls, routes);
 
       // The invariant: resolved and broken are disjoint. A call doctor says is
       // served must never be a gate block, and vice-versa.
-      for (const p of resolved) {
-        expect(broken.has(p), `join resolved ${p} but the gate flagged it broken`).toBe(false);
+      for (const k of resolved) {
+        expect(broken.has(k), `join resolved ${k} but the gate flagged it broken`).toBe(false);
       }
       // And the complement holds: a call neither resolved is exactly a gate miss.
-      const unresolved = new Set(fx.calls.filter((p) => !resolved.has(p)));
+      const callKeys = calls.map((c) => `${c.method} ${c.path}`);
+      const unresolved = new Set(callKeys.filter((k) => !resolved.has(k)));
       expect(broken).toEqual(unresolved);
     });
   }

--- a/test/flow-model.test.ts
+++ b/test/flow-model.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseSource } from '../src/ast/parse';
+import { grammarShape } from '../src/ast/grammar-shape';
 import { extractFromTree, type FileFlow } from '../src/analyzers/flow/extract';
 import {
   joinFlow,
@@ -15,11 +16,12 @@ import { getLanguage } from '../src/languages';
 import type { HttpFlowSupport } from '../src/languages/types';
 
 const ts = getLanguage('typescript')!.httpFlow as HttpFlowSupport;
+const tsShape = grammarShape('typescript')!;
 const cfg = { stripUrlPrefixes: ['${Config.apiBase()}'] };
 
 async function fileFlow(src: string, file: string): Promise<FileFlow> {
   const tree = await parseSource(src, 'typescript');
-  return extractFromTree(tree!.rootNode, ts, file, cfg);
+  return extractFromTree(tree!.rootNode, ts, tsShape, file, cfg);
 }
 
 describe('flow join', () => {

--- a/test/flow-model.test.ts
+++ b/test/flow-model.test.ts
@@ -67,6 +67,27 @@ describe('flow join', () => {
     expect(bindings[0].confidence).toBeLessThan(1);
     expect(bindings[0].route).not.toBeNull();
   });
+
+  it('a method-agnostic (ANY) route resolves any verb on its path', async () => {
+    const client = await fileFlow(
+      'axios.get(`/users/${id}`); axios.post(`/users/${id}`); axios.delete(`/other`);',
+      'web/a.ts',
+    );
+    const anyRoute = {
+      method: 'ANY' as const,
+      path: '/users/{var}',
+      via: 'router-call' as const,
+      handler: 'user_view',
+      file: 'api/urls.py',
+      line: 3,
+    };
+    const bindings = joinFlow(client.calls, [anyRoute]);
+    const byPath = Object.fromEntries(bindings.map((b) => [`${b.call.method} ${b.call.path}`, b]));
+    expect(byPath['GET /users/{var}'].reason).toBe('exact');
+    expect(byPath['POST /users/{var}'].reason).toBe('exact');
+    expect(byPath['POST /users/{var}'].route?.handler).toBe('user_view');
+    expect(byPath['DELETE /other'].reason).toBe('no-route');
+  });
 });
 
 describe('flow model + summary', () => {
@@ -122,6 +143,24 @@ describe('served matcher (gate ↔ join parity)', () => {
     expect(catchAllPrefixCovers('/api', '/api')).toBe(true);
     expect(catchAllPrefixCovers('', '/anything')).toBe(true);
     expect(catchAllPrefixCovers('/api', '/apix')).toBe(false);
+  });
+
+  it('a method-agnostic (ANY) key resolves every verb on its path', () => {
+    const m = buildServedMatcher(['ANY /users', 'GET /articles']);
+    expect(servedMatch('GET', '/users', m)).toBe(true);
+    expect(servedMatch('POST', '/users', m)).toBe(true);
+    expect(servedMatch('DELETE', '/users', m)).toBe(true);
+    // A concrete-method key stays method-scoped — ANY never leaks sideways.
+    expect(servedMatch('POST', '/articles', m)).toBe(false);
+    expect(servedMatch('GET', '/other', m)).toBe(false);
+  });
+
+  it('a method-agnostic catch-all covers any verb under its prefix', () => {
+    const m = buildServedMatcher(['ANY /api/{*}']);
+    expect(servedMatch('POST', '/api/users', m)).toBe(true);
+    expect(servedMatch('GET', '/api/deep/x', m)).toBe(true);
+    expect(servedMatch('GET', '/elsewhere', m)).toBe(false);
+    expect(servedMatch('GET', '/{var}', m)).toBe(false); // no static signal
   });
 });
 

--- a/test/flow-normalize.test.ts
+++ b/test/flow-normalize.test.ts
@@ -88,6 +88,16 @@ describe('flow normalizePath', () => {
     expect(server).toBe(client);
     expect(spec).toBe(client);
   });
+
+  it('Django/Flask angle-bracket converters canonicalize like every other param form', () => {
+    // Single-segment converters (<int:pk>, <slug:s>, bare <name>) → {var},
+    // joining a client's `/users/${id}`.
+    expect(normalizePath("'users/<int:pk>/'")).toBe('/users/{var}');
+    expect(normalizePath("'/users/<slug:the_slug>'")).toBe('/users/{var}');
+    expect(normalizePath("'/users/<pk>'")).toBe('/users/{var}');
+    // The <path:...> converter consumes the REST of the path → catch-all.
+    expect(normalizePath("'/files/<path:subpath>'")).toBe('/files/{*}');
+  });
 });
 
 describe('flow normalizeMethod', () => {

--- a/test/flow-route-forms.test.ts
+++ b/test/flow-route-forms.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Declarative route forms — the three descriptor shapes that cover frameworks
+ * whose route declarations are not bare decorators or router member-calls:
+ *
+ *   - routeMemberDecorators: FastAPI `@app.get('/x')` (member-callee verb)
+ *   - routePathDecorators:   Flask `@app.route('/x', methods=['GET','POST'])`
+ *   - routeCallees:          Django `path('users/<int:pk>/', view)` → ANY
+ *
+ * Exercised over the PYTHON grammar with SYNTHETIC descriptors: this file pins
+ * the extractor's semantics for the forms; the real python pack's declaration
+ * is pinned separately (its own wave). Also pins the precision guards each
+ * form ships with — the leading-slash rule that keeps `@mock.patch('pkg.attr')`
+ * out, and the include()/arity guards that keep Django prefix mounts out.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSource } from '../src/ast/parse';
+import { grammarShape } from '../src/ast/grammar-shape';
+import { extractFromTree, type FileFlow } from '../src/analyzers/flow/extract';
+import type { HttpFlowSupport } from '../src/languages/types';
+
+const py = grammarShape('python')!;
+
+async function extractPy(src: string, hf: HttpFlowSupport): Promise<FileFlow> {
+  const tree = await parseSource(src, 'python');
+  return extractFromTree(tree!.rootNode, hf, py, 'sample.py');
+}
+
+const routeKeys = (flow: FileFlow): string[] =>
+  flow.routes.map((r) => `${r.method} ${r.path}`).sort();
+
+describe('routeMemberDecorators — member-callee verb decorators (FastAPI shape)', () => {
+  const hf: HttpFlowSupport = {
+    routeMemberDecorators: { methods: ['get', 'post', 'put', 'patch', 'delete'] },
+  };
+
+  it('extracts @recv.verb(path) with params canonicalized and handler resolved', async () => {
+    const flow = await extractPy(
+      `
+@app.get("/items/{item_id}")
+def read_item(item_id):
+    return {}
+
+@router.post("/users")
+async def create_user():
+    return {}
+`,
+      hf,
+    );
+    expect(routeKeys(flow)).toEqual(['GET /items/{var}', 'POST /users']);
+    expect(flow.routes.find((r) => r.method === 'GET')?.handler).toBe('read_item');
+    expect(flow.routes.every((r) => r.via === 'decorator')).toBe(true);
+  });
+
+  it('leading-slash guard: a look-alike member decorator mints no route', async () => {
+    // `patch` is a verb name AND unittest.mock's ubiquitous decorator — its
+    // argument is a dotted target, never a slashed path.
+    const flow = await extractPy(
+      `
+@mock.patch("requests.get")
+def test_x(m):
+    pass
+`,
+      hf,
+    );
+    expect(flow.routes).toHaveLength(0);
+    expect(flow.calls).toHaveLength(0); // and its subtree is not a client call
+  });
+
+  it('bases, when declared, restrict which receivers count', async () => {
+    const restricted: HttpFlowSupport = {
+      routeMemberDecorators: { methods: ['get'], bases: ['app'] },
+    };
+    const flow = await extractPy(
+      `
+@app.get("/yes")
+def a():
+    pass
+
+@other.get("/no")
+def b():
+    pass
+`,
+      restricted,
+    );
+    expect(routeKeys(flow)).toEqual(['GET /yes']);
+  });
+});
+
+describe('routePathDecorators — path-first decorators with a methods keyword (Flask shape)', () => {
+  const hf: HttpFlowSupport = {
+    routePathDecorators: { names: ['route'], methodsKeyword: 'methods', defaultMethods: ['GET'] },
+  };
+
+  it('reads the methods list and emits one route per verb', async () => {
+    const flow = await extractPy(
+      `
+@app.route("/legacy", methods=["GET", "POST"])
+def legacy():
+    return ""
+`,
+      hf,
+    );
+    expect(routeKeys(flow)).toEqual(['GET /legacy', 'POST /legacy']);
+    expect(flow.routes[0].handler).toBe('legacy');
+  });
+
+  it('falls back to defaultMethods when the keyword is absent (Flask default: GET)', async () => {
+    const flow = await extractPy(
+      `
+@app.route("/plain")
+def plain():
+    return ""
+`,
+      hf,
+    );
+    expect(routeKeys(flow)).toEqual(['GET /plain']);
+  });
+
+  it('Flask converters canonicalize: <int:pk> → {var}, <path:rest> → catch-all', async () => {
+    const flow = await extractPy(
+      `
+@app.route("/users/<int:user_id>")
+def user(user_id):
+    return ""
+
+@app.route("/files/<path:subpath>")
+def files(subpath):
+    return ""
+`,
+      hf,
+    );
+    expect(routeKeys(flow)).toEqual(['GET /files/{*}', 'GET /users/{var}']);
+  });
+
+  it('a same-named non-route call is not a route (decorator context required)', async () => {
+    const flow = await extractPy(`result = route("/not-a-decorator", thing)`, hf);
+    expect(flow.routes).toHaveLength(0);
+  });
+});
+
+describe('routeCallees — verb-less route declarations (Django urls.py shape)', () => {
+  const hf: HttpFlowSupport = {
+    routeCallees: { names: ['path'], excludeArgCallees: ['include'] },
+  };
+
+  it('emits ANY routes with Django converters canonicalized', async () => {
+    const flow = await extractPy(
+      `
+urlpatterns = [
+    path("users/", views.user_list),
+    path("users/<int:pk>/", views.user_detail),
+]
+`,
+      hf,
+    );
+    expect(routeKeys(flow)).toEqual(['ANY /users', 'ANY /users/{var}']);
+    expect(flow.routes[0].via).toBe('router-call');
+    expect(flow.routes.map((r) => r.handler)).toEqual(['views.user_list', 'views.user_detail']);
+  });
+
+  it('an include() mount is a PREFIX, not a route — skipped', async () => {
+    const flow = await extractPy(
+      `
+urlpatterns = [
+    path("api/", include("api.urls")),
+    path("health/", views.health),
+]
+`,
+      hf,
+    );
+    expect(routeKeys(flow)).toEqual(['ANY /health']);
+  });
+
+  it('arity guard: a path(...) with no handler argument mints no route', async () => {
+    const flow = await extractPy(`p = path("just/a/string")`, hf);
+    expect(flow.routes).toHaveLength(0);
+  });
+
+  it('a non-literal first argument mints no route', async () => {
+    const flow = await extractPy(`urlpatterns = [path(prefix_var, views.x)]`, hf);
+    expect(flow.routes).toHaveLength(0);
+  });
+});

--- a/test/grammar-shape.test.ts
+++ b/test/grammar-shape.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Grammar-shape adapter — the per-grammar syntax-access layer that lets the ONE
+ * flow extractor (`extractFromTree`) walk any tree-sitter grammar.
+ *
+ * These tests drive the extractor over the PYTHON grammar with a synthetic
+ * descriptor, proving the extractor carries no TS-grammar node names: the same
+ * semantics (client calls, precision guard, dynamic counting, decorator skip)
+ * hold on a grammar whose call/member/string node types are all different.
+ * The real python pack's descriptor is pinned separately (its own wave); this
+ * file pins the ADAPTER.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSource } from '../src/ast/parse';
+import { grammarShape, shapedGrammars } from '../src/ast/grammar-shape';
+import { extractFromTree, type FileFlow } from '../src/analyzers/flow/extract';
+import type { HttpFlowSupport } from '../src/languages/types';
+
+const py = grammarShape('python')!;
+const js = grammarShape('typescript')!;
+
+/** A synthetic Python-ish descriptor — requests/httpx trusted, verbs lowercase. */
+const PY_DESCRIPTOR: HttpFlowSupport = {
+  clientMethodCallees: {
+    methods: ['get', 'post', 'put', 'patch', 'delete'],
+    bases: ['requests', 'httpx'],
+  },
+};
+
+async function extractPy(src: string, hf: HttpFlowSupport = PY_DESCRIPTOR): Promise<FileFlow> {
+  const tree = await parseSource(src, 'python');
+  return extractFromTree(tree!.rootNode, hf, py, 'sample.py');
+}
+
+describe('grammar shape — registry', () => {
+  it('has rows for the JS family and python', () => {
+    for (const g of ['typescript', 'tsx', 'javascript', 'python']) {
+      expect(grammarShape(g), g).not.toBeNull();
+      expect(shapedGrammars()).toContain(g);
+    }
+  });
+
+  it('returns null (never throws) for an unshaped grammar', () => {
+    expect(grammarShape('cobol')).toBeNull();
+  });
+
+  it('the JS family shares one shape object (one row, three names)', () => {
+    expect(grammarShape('typescript')).toBe(grammarShape('tsx'));
+    expect(grammarShape('typescript')).toBe(grammarShape('javascript'));
+  });
+});
+
+describe('grammar shape — python syntax access', () => {
+  it('resolves member calls and reads plain + f-string literals', async () => {
+    const { calls } = await extractPy(`
+import requests
+def f(slug):
+    requests.get("/api/articles")
+    httpx.post(f"/api/articles/{slug}")
+`);
+    const keys = calls.map((c) => `${c.method} ${c.path}`).sort();
+    expect(keys).toEqual(['GET /api/articles', 'POST /api/articles/{var}']);
+  });
+
+  it('trusted bases count dynamic URLs; untrusted receivers need the URL guard', async () => {
+    const flow = await extractPy(`
+def f(url, key):
+    requests.get(url)
+    session.delete("/api/items/3")
+    config.get("retry-count")
+    d.get(key)
+`);
+    // requests.* is trusted → its dynamic call is COUNTED, not dropped.
+    expect(flow.dynamicCalls).toHaveLength(1);
+    expect(flow.dynamicCalls?.[0].receiver).toBe('requests');
+    // session.* is untrusted but path-like → counted as a call (wrapper case).
+    // config.get / d.get carry no path signal → filtered, not counted anywhere.
+    expect(flow.calls.map((c) => `${c.method} ${c.path}`)).toEqual(['DELETE /api/items/3']);
+  });
+
+  it('keyword arguments are not mistaken for the positional URL argument', async () => {
+    const { calls } = await extractPy(`
+def f():
+    requests.get(timeout=5, url="/computed-elsewhere")
+    httpx.post("/api/things", json={"a": 1})
+`);
+    // First call has NO positional arg → dynamic for a trusted base, not a
+    // binding on "timeout=5"; second binds on the string, not the json kwarg.
+    expect(calls.map((c) => `${c.method} ${c.path}`)).toEqual(['POST /api/things']);
+  });
+
+  it('a decorator subtree is never double-read as a client call', async () => {
+    // `@app.get("/items")` contains a member call that LOOKS like a client
+    // call (`app.get` with a path literal) — the decorator branch must skip
+    // the subtree, so the consumed side stays empty.
+    const flow = await extractPy(`
+@app.get("/items")
+def read_items():
+    return []
+`);
+    expect(flow.calls).toHaveLength(0);
+  });
+
+  it('python string prefixes (f/r/rb) are stripped before URL normalization', async () => {
+    const { calls } = await extractPy(`
+def f(x):
+    requests.get(r"/raw/path")
+    requests.get(rb"/bytes/path")
+`);
+    const paths = calls.map((c) => c.path).sort();
+    expect(paths).toEqual(['/bytes/path', '/raw/path']);
+  });
+});
+
+describe('grammar shape — semantics parity across grammars', () => {
+  it('the identical descriptor semantics hold on the JS grammar', async () => {
+    // Same descriptor, same code shape, different grammar — the extractor's
+    // semantics (trusted dynamic counting + untrusted guard) must agree.
+    const tree = await parseSource(
+      `
+      requests.get(url);
+      session.delete('/api/items/3');
+      config.get('retry-count');
+    `,
+      'typescript',
+    );
+    const flow = extractFromTree(tree!.rootNode, PY_DESCRIPTOR, js, 'sample.ts');
+    expect(flow.dynamicCalls).toHaveLength(1);
+    expect(flow.dynamicCalls?.[0].receiver).toBe('requests');
+    expect(flow.calls.map((c) => `${c.method} ${c.path}`)).toEqual(['DELETE /api/items/3']);
+  });
+});

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { LANGUAGES, getLanguage, detectActiveLanguages } from '../src/languages';
 import type { LanguageId, LanguageSupport } from '../src/languages';
 import { TOOL_DEFS } from '../src/analyzers/tools/tool-registry';
+import { grammarShape } from '../src/ast/grammar-shape';
 
 const REQUIRED_IDS: LanguageId[] = ['typescript', 'python', 'go', 'rust', 'csharp'];
 
@@ -438,5 +439,79 @@ describe.each(LANGUAGES as LanguageSupport[])('language contract: $id', (lang) =
     ).toBe(true);
     expect(lang.clocLanguageNames!.length).toBeGreaterThan(0);
     for (const n of lang.clocLanguageNames!) expect(typeof n).toBe('string');
+  });
+
+  // httpFlow (M6): a flow declaration only extracts when the whole chain is
+  // wired — descriptor -> grammar -> shape row -> wasm artifact. A pack that
+  // declares httpFlow with a missing link SILENTLY contributes nothing (the
+  // extractor fail-opens per file), which is exactly the kind of half-landed
+  // capability this contract exists to make loud.
+  it('httpFlow, when declared, is extraction-complete (grammar + shape + wasm) and non-vacuous', () => {
+    if (!lang.httpFlow) return; // packs without a modeled HTTP surface skip
+    const hf = lang.httpFlow;
+
+    // 1. A flow descriptor without a grammar can never parse a file.
+    const grammars = Object.entries(lang.treeSitterGrammars ?? {});
+    expect(
+      grammars.length,
+      `${lang.id}: declares httpFlow but no treeSitterGrammars — no file would ever parse, ` +
+        `so the descriptor is dead. Declare the grammar(s) for its source extensions.`,
+    ).toBeGreaterThan(0);
+
+    for (const [ext, grammar] of grammars) {
+      expect(ext.startsWith('.'), `${lang.id}: grammar key "${ext}" must be a dotted ext`).toBe(
+        true,
+      );
+      // 2. The grammar must have a shape row (src/ast/grammar-shape.ts) — the
+      //    extractor skips files whose grammar it cannot read.
+      expect(
+        grammarShape(grammar),
+        `${lang.id}: grammar "${grammar}" has no shape row in src/ast/grammar-shape.ts — ` +
+          `flow extraction would silently skip every ${ext} file. Add the row (most grammars ` +
+          `fit the shared callee-field factory).`,
+      ).not.toBeNull();
+      // 3. The wasm artifact must actually ship.
+      const wasmsDir = path.dirname(require.resolve('tree-sitter-wasms/package.json'));
+      const wasm = path.join(wasmsDir, 'out', `tree-sitter-${grammar}.wasm`);
+      expect(
+        fs.existsSync(wasm),
+        `${lang.id}: no bundled wasm for grammar "${grammar}" (${wasm})`,
+      ).toBe(true);
+    }
+
+    // 4. Non-vacuous: at least one construct family, and every present family
+    //    well-formed (an empty methods/names list matches nothing, silently).
+    const families = [
+      hf.clientCallees,
+      hf.clientMethodCallees?.methods,
+      hf.routeDecorators,
+      hf.routeRouterCallees?.methods,
+      hf.routeMemberDecorators?.methods,
+      hf.routePathDecorators?.names,
+      hf.routeCallees?.names,
+      hf.fileRoutes ? [hf.fileRoutes.handlerFile] : undefined,
+    ].filter((f): f is string[] => f !== undefined);
+    expect(
+      families.length,
+      `${lang.id}: httpFlow declares no construct family — a vacuous descriptor`,
+    ).toBeGreaterThan(0);
+    for (const family of families) {
+      expect(family.length, `${lang.id}: an httpFlow construct family is empty`).toBeGreaterThan(0);
+    }
+    if (hf.routePathDecorators) {
+      expect(hf.routePathDecorators.methodsKeyword.length).toBeGreaterThan(0);
+      expect(hf.routePathDecorators.defaultMethods.length).toBeGreaterThan(0);
+    }
+    if (hf.routeRouterCallees) expect(hf.routeRouterCallees.bases.length).toBeGreaterThan(0);
+    if (hf.fileRoutes) {
+      expect(hf.fileRoutes.baseDirs.length).toBeGreaterThan(0);
+      expect(hf.fileRoutes.methodExports.length).toBeGreaterThan(0);
+    }
+    // Discovery signals, when declared, must be well-formed (an empty anyOf
+    // silently recommends nothing).
+    for (const signal of hf.flowSignals ?? []) {
+      expect(signal.manifest.length).toBeGreaterThan(0);
+      expect(signal.anyOf.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -66,6 +66,9 @@ import {
 import { runCorrectnessFloor } from '../src/analyzers/correctness/run';
 import { lintGateSpecs } from '../src/analyzers/custom-checks/config';
 import { deriveFileRoutePath } from '../src/analyzers/flow/file-routes';
+import { extractFromTree } from '../src/analyzers/flow/extract';
+import { parseSource } from '../src/ast/parse';
+import { grammarShape } from '../src/ast/grammar-shape';
 import { buildVariables, buildConditions } from '../src/constants';
 import { buildRequiredTools } from '../src/analyzers/tools/tool-registry';
 import { detect } from '../src/detect';
@@ -140,7 +143,12 @@ const mockPlaybookPack = {
     clientMethodCallees: { methods: ['playbookGet'], bases: ['playbookClient'] },
     routeDecorators: ['playbookGet'],
     routeRouterCallees: { methods: ['playbookGet'], bases: ['playbookApp'] },
-    methodAliases: { playbookDel: 'DELETE' },
+    // Non-verb tokens NEED an alias to mint a method — the end-to-end
+    // extraction test below is what proves the alias map flows through.
+    // Keys are LOWERCASE method tokens (normalizeMethod lowercases before
+    // lookup) — this fixture originally used camelCase keys, which the
+    // registry-presence assertion could not catch; the extraction test can.
+    methodAliases: { playbookdel: 'DELETE', playbookget: 'GET' },
     // File-convention routing (2.28): distinctive tokens so the assertion
     // verifies the synthetic pack's fileRoutes descriptor drives the SHARED
     // path algebra (`deriveFileRoutePath`) — codifying "file-route derivation
@@ -789,7 +797,7 @@ describe('recipe playbook — synthetic pack', () => {
     const synthetic = descriptors.find((d) => d.clientCallees?.includes('playbookFetch'));
     expect(synthetic).toBeDefined();
     expect(synthetic?.routeDecorators).toContain('playbookGet');
-    expect(synthetic?.methodAliases?.playbookDel).toBe('DELETE');
+    expect(synthetic?.methodAliases?.playbookdel).toBe('DELETE');
     // Real typescript pack's descriptor also flows through (regression guard
     // against the helper returning only the synthetic contribution).
     const real = descriptors.find((d) => d.clientCallees?.includes('fetch'));
@@ -833,6 +841,35 @@ describe('recipe playbook — synthetic pack', () => {
     expect(deriveFileRoutePath('playbookapp/(group)/things/playbookroute.pbk', fr)).toBe('/things');
     // A non-handler file under the base derives nothing.
     expect(deriveFileRoutePath('playbookapp/widgets/other.pbk', fr)).toBeNull();
+  });
+
+  // END-TO-END extraction: the synthetic descriptor drives the ONE extractor
+  // over a real grammar's shape. This is the proof that flow extraction is
+  // descriptor-driven all the way down — not just that the registry unions
+  // descriptors (the allHttpFlow test above), but that a pack's declared
+  // tokens actually mint calls and routes with ZERO extractor edits. A new
+  // language pack inherits exactly this path: declare grammars + httpFlow.
+  it('the synthetic descriptor extracts calls + routes through the one extractor', async () => {
+    const synthetic = mockPlaybookPack.httpFlow!;
+    const shape = grammarShape('javascript')!; // any shaped grammar exercises the path
+    const tree = await parseSource(
+      `
+      playbookFetch('/from-bare-callee');
+      playbookClient.playbookGet('/from-member-call');
+      playbookApp.playbookGet('/from-router-call', handler);
+      `,
+      'javascript',
+    );
+    const flow = extractFromTree(tree!.rootNode, synthetic, shape, 'widget.pbk');
+    // Every construct family recognized off the DESCRIPTOR's tokens, with the
+    // alias map minting the verbs (playbookGet -> GET).
+    expect(flow.calls.map((c) => `${c.method} ${c.path} via ${c.receiver}`).sort()).toEqual([
+      'GET /from-bare-callee via playbookFetch',
+      'GET /from-member-call via playbookClient',
+    ]);
+    expect(flow.routes.map((r) => `${r.method} ${r.path} via ${r.via}`)).toEqual([
+      'GET /from-router-call via router-call',
+    ]);
   });
 
   // Flow-gate trigger: the surface helpers iterate active packs (httpFlow +


### PR DESCRIPTION
M6 wave 1, part 1: the flow pillar's second language, built so every subsequent language is a declaration, not an engineering project.

## What this is

Python repos now get native flow extraction — and the extractor was rebuilt so they're the LAST language that needs platform work to join.

**Platform (language-agnostic):**

- **Grammar-shape adapter** (`src/ast/grammar-shape.ts`) — the one flow extractor was TypeScript-grammar-shaped (`call_expression`/`member_expression` node names inline). Syntax access now goes through a per-grammar table in the AST layer; extract.ts keeps only flow semantics. Adding a language's flow = declare `treeSitterGrammars` + `httpFlow` on the pack, **zero extractor edits**.
- **Method-agnostic (`ANY`) served routes** — Django's `path('users/', view)` (and Go's `http.HandleFunc`, next wave) bind a path for every verb at the routing layer. One `ANY` route now says exactly that; the join and the gate resolve any verb against it through the same shared predicate, pinned by new method-varying fixtures in the gate↔join parity net. Additive on served.json schema v1.
- **Three declarative route forms** — member verb decorators (`@app.get('/x')`, with a leading-slash guard that keeps `@mock.patch('requests.get')` out), path-first decorators with a methods kwarg (Flask `route('/x', methods=[...])`), and verb-less route callees (Django `path(...)`, `include()` mounts excluded).
- **Trusted client bases** — `clientMethodCallees.bases` becomes trust *elevation*: `requests`/`httpx` calls with runtime-built URLs are disclosed as dynamic call sites (coverage honesty) instead of silently dropped; untrusted receivers keep the path-literal precision guard, so wrapper coverage never narrows.

**Python pack (pure declaration):** requests/httpx + wrappers consumed; FastAPI + Flask + Django `path()` served; Django/Flask `<int:pk>`/`<path:rest>` converters canonicalize in the shared normalizer. `re_path()` regex routes are declared out of scope (no canonical path to join on — `flow.specs` covers those repos).

**Recipe hardening (#20):** the pack-contract test loud-fails an httpFlow pack whose grammar is missing/unshaped/wasm-less or whose descriptor is vacuous; the synthetic-pack playbook proves descriptor-driven extraction end-to-end (and caught a latent fixture bug: camelCase `methodAliases` keys never resolved); the `new-lang` scaffold carries the 3-step flow recipe; CONTRIBUTING has the walkthrough.

**Discovery (Rule 16):** the "you'd benefit from flow" doctor probe + `configure` planner signal is now pack-declared (`httpFlow.flowSignals`) — a FastAPI/Flask/Django repo gets offered the gate, not just JS UI repos.

## Definition-of-done evidence

1. **Lifecycle (update/uninstall/skills):** no new managed artifact, policy key, or identity-scheme change → update/uninstall paths correctly untouched. The dxkit-flow skill gained a language-coverage paragraph (reaches installed repos via the existing scaffold refresh); dxkit-config/update/uninstall skills audited, no stale claims.
2. **Recipe/platform:** everything above; acceptance criterion met — the Go wave (#8) needs only a shape row + descriptor.
3. **Real-repo validation (READ-ONLY, all four repos verified untouched after):**
   - `full-stack-fastapi-template` — 17 distinct FastAPI decorator routes extracted with handlers + canonicalized params (22 grep-truth sites → 17 keys is same-path dedup across routers; the router-mount-prefix limitation is shared with Express and documented). Topology reads `provider-only`; the generated TS client is honestly invisible (object-arg calls, filtered not miscounted).
   - `microblog` (Flask) — 27 route decorator sites → 33 (method,path) keys via `methods=[...]` fan-out; converters + GET default correct; its one real runtime-built `requests.post` is disclosed as a **dynamic call site** (the honesty channel firing on real code).
   - `django-oscar` — 127 `path()` routes extracted as `ANY` with complex handler expressions captured; no `include()` false routes.
   - `gcs-web` (flagship TS regression) — 7/7 bindings resolved, byte-identical to the 3.2 result.
4. **Registration:** no new command; the existing `flow` capability's discovery probe got the language-neutral upgrade above. Docs: language-packs coverage matrix, roadmap parity item, CHANGELOG under Unreleased.

## Verification

Full suite 3455/3455 green (one pre-existing test pinned ".py has no grammar" as its negative fixture — retired in its own commit). typecheck + typecheck:test + lint + format + arch + slop + cross-eco checks all pass; self-guardrail vs origin/main: 0 blocking, 0 suppressed, 89 persisted.

## Merge strategy

**Rebase-merge** — 9 commits, each an independently meaningful unit (adapter / ANY primitive / route forms / pack / recipe / discovery / docs / fixture retirement / changelog), and the M6 working notes reference them individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Geh8vR6khHap4mNYX9F5o2
