### PR TITLE
chore(release): 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-07-10
+
+The polyglot release for the flow pillar: Python and Go join
+TypeScript/JavaScript as natively-extracted languages, and the extractor was
+rebuilt so every further language is a declaration, not an engineering
+project — a pack states its grammar and which constructs are HTTP; one shared
+engine does the rest.
+
 ### Added
 
 - **Go flow extraction.** The flow pillar's third language, again by
@@ -38,10 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regex `re_path(...)` routes are out of scope — point `flow.specs` at an
   OpenAPI document for those.
 - **Method-agnostic (`ANY`) served routes.** A routing layer that binds a path
-  for EVERY verb (Django `path()`, Go's `http.HandleFunc` next wave) publishes
-  one `ANY` route; the join and the gate resolve a call with any method
-  against it, through the same shared predicate (additive on the served.json
-  schema).
+  for EVERY verb (Django `path()`, Go's `http.HandleFunc`) publishes one `ANY`
+  route; the join and the gate resolve a call with any method against it,
+  through the same shared predicate (additive on the served.json schema).
 - **Grammar-shape adapter.** The one flow extractor now reads any tree-sitter
   grammar through a per-grammar node-type table (`src/ast/grammar-shape.ts`),
   so adding flow for a language is declaration-only: grammars + a descriptor,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "hosted-git-info": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",


### PR DESCRIPTION
Version bump + changelog stamp for the flow language-parity release (Python + Go extraction, the grammar-shape adapter, ANY served routes, pack-declared discovery — PRs #122 and #123, already on main).

Squash-merge is fine — a single logical change.

After merge + CI green on main, I'll tag `v3.3.0`, create the GitHub Release, and verify the npm publish per the release procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Geh8vR6khHap4mNYX9F5o2