### PR TITLE
Model-schema drift gate: pack-declared extraction, spec bridge, guardrail integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Model-schema drift gate.** dxkit now extracts every data model a repo
+  declares and gates breaking changes on the PR diff — a removed field, a
+  changed type, an optional field made required, a removed model. Additive
+  changes surface as warnings or information, never blocks. Recognition is
+  marker-based per language pack (precision over recall): TypeScript/
+  JavaScript entity decorators (TypeORM, MikroORM, sequelize-typescript,
+  NestJS-mongoose, type-graphql) and `BaseEntity` heritage; Python Django /
+  SQLAlchemy / pydantic / SQLModel base classes and `@dataclass`, with ORM
+  field constructors supplying types and `null=`/`nullable=` optionality; Go
+  struct tags (`json:`/`gorm:`/`db:`/`bson:`) with wire names, `omitempty`,
+  and pointer optionality. Any other language — and unmarked DTOs anywhere —
+  participates via spec-declared models: point `schema.specs` at an OpenAPI
+  (`components.schemas`) or JSON Schema document and its models gate
+  identically with zero code extraction. `vyuh-dxkit schema` lists the
+  inventory (with unreadable-type and dynamic-model disclosure);
+  `schema diff --ref <base>` previews the exact verdict the guardrail will
+  reach. The gate is opt-in (`.dxkit/policy.json:schema.mode`, default off),
+  additive, and fail-open; drift findings carry a location-free fingerprint
+  (`model` + `field` + change class), so a model can move files or lines
+  without re-minting, and a deliberate breaking change ships with an
+  expiring `accepted-risk` allowlist entry that stays disclosed in the PR
+  comment. Honesty rules throughout: an unknown never blocks, a rename reads
+  as remove + add, a pure file move produces no findings, and the docs list
+  verbatim what the gate cannot see (constraints, aliased types, dynamic
+  schemas, consumer impact).
+
 ## [3.3.0] - 2026-07-10
 
 The polyglot release for the flow pillar: Python and Go join

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,14 @@ consumer through it (canonical examples added in 2.30):
   `src/analyzers/flow/gather.ts` (loads `stripUrlPrefixes` / `specs` itself, so a
   surface cannot forget them); the raw `gatherFlowModel` is only for
   explicit-config callers (the two-ref gate, cross-repo publish, the map CLI);
+- a repo's declared MODEL SET with its policy config applied →
+  `gatherRepoModelSet` in `src/analyzers/model-schema/gather.ts` (loads
+  `schema.specs` itself; the raw `gatherModelSet` is only for the two-ref
+  gate's explicit-config sides). What schema DRIFT a diff contains →
+  `diffModelSets` in `src/analyzers/model-schema/model.ts`, the ONE drift
+  computation consumed by BOTH the guardrail gate and `schema diff`
+  (pinned by `test/schema-gate-diff-parity.test.ts` — same
+  parity-test discipline as the flow gate/join pair below);
 - whether a consumed `(method, path)` is SERVED → `servedMatch` /
   `catchAllPrefixCovers` in `src/analyzers/flow/model.ts`. BOTH the join (doctor's
   `diagnoseFlow`) and the integration gate (`evaluateFlowGate`) resolve a call

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,6 +279,50 @@ imports, testFramework, licenses }`. Each is a `CapabilityProvider`
   `test/recipe-playbook.test.ts` proves extraction is descriptor-driven
   end-to-end with the synthetic pack.
 
+- **Model schema** — `modelSchema?: ModelSchemaSupport` +
+  `treeSitterGrammars?`, the data-model extraction surface behind the
+  schema drift gate. Same DECLARATION-ONLY recipe as flow — the one
+  extractor (`src/analyzers/model-schema/extract.ts`) reads any grammar
+  through the model-shape table (`src/ast/grammar-model-shape.ts`):
+  1. Declare `treeSitterGrammars`, plus a MODEL-shape row in
+     `src/ast/grammar-model-shape.ts` if the grammar has none (class /
+     field / heritage / tag syntax — verify every node and field name
+     against a real parse first).
+  2. Fill the descriptor from `ModelSchemaSupport`
+     (`src/languages/types.ts`): `modelBaseClasses` (heritage markers),
+     `weakModelBaseClasses` (too-generic names like `Base` — they mark a
+     model only when a `fieldCallees` constructor corroborates),
+     `modelDecorators` (`@Entity`, `@dataclass`), `structTagKeys`
+     (Go-style tags), `fieldCallees` (ORM field constructors carrying
+     type + optionality; `typeFrom: 'callee' | 'firstArg'`),
+     `transparentTypeWrappers` (`Mapped[X]` → `X`), `typeAliases`, and
+     `schemaSignals` for doctor discovery. Worked examples:
+     `typescript.ts`, `python.ts`, `go.ts`. Recognition is
+     PRECISION-FIRST: a missed model is a disclosed gap, a false model
+     floods the drift diff — when unsure, leave it out; `schema.specs`
+     is the honest fallback.
+  3. Pin it: pack extraction tests + a model fixture/row in
+     `test/fixtures-analysis.test.ts`, then real-repo-validate the wave
+     (inventory accuracy, a mutation battery with exact expected drift
+     classes, and a refactor-only battery that must produce ZERO
+     findings).
+
+  `test/languages-contract.test.ts` loud-fails a modelSchema pack whose
+  grammar is missing, model-unshaped, or whose recognition set is
+  vacuous; `test/recipe-playbook.test.ts` proves extraction is
+  descriptor-driven end-to-end with the synthetic pack.
+
+  **Design discipline for the declarative layers (flow + model schema):
+  a framework surprise must land as a DESCRIPTOR capability, never an
+  engine special case.** Every real-repo bug this gate's validation
+  found was fixed by making the descriptor language richer
+  (`weakModelBaseClasses`, `transparentTypeWrappers`, a three-valued
+  optionality marker) — not by teaching the extractor about a framework.
+  If you find yourself adding an `if` for your language inside
+  `src/analyzers/flow/` or `src/analyzers/model-schema/`, the right fix
+  is a new (or extended) descriptor field plus a synthetic-pack
+  assertion, so every other pack inherits it.
+
 - **Init metadata** (LP-recipe — needed by `vyuh-dxkit init` and
   `doctor`) — `permissions[]` (Bash entries for `.claude/settings.json`),
   `ruleFile?` (filename under `src-templates/.claude/rules/`),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,6 +167,34 @@ SARIF parsing and snapshot access can't leak outside `src/ingest/`, and
 ingested findings get identity from the aggregator (Rule 9), never a
 parallel hash.
 
+## The declarative contract gates (`src/analyzers/flow/`, `src/analyzers/model-schema/`)
+
+Two guardrail passes go beyond findings-in-files and gate CONTRACTS the
+code declares: the flow gate (a UI call must resolve to a served route)
+and the model-schema drift gate (a declared data model must not change
+breakingly). Both follow one architecture, layered so a new language is a
+declaration and a framework surprise cannot reach the engine:
+
+- a pack DESCRIPTOR on `LanguageSupport` says WHICH constructs matter
+  (`httpFlow`: clients + routes; `modelSchema`: model markers + field
+  constructors);
+- a per-grammar SYNTAX table in `src/ast/` (`grammar-shape.ts`,
+  `grammar-model-shape.ts`) says HOW to read a call / class / field from
+  that grammar's tree;
+- ONE shared extractor per pillar says WHAT they mean — it contains no
+  grammar node name and no framework literal, and is never edited for a
+  language;
+- a pure two-ref gate core + a fail-open guardrail glue module
+  (`src/baseline/{flow,schema-drift}-gate-check.ts`) fold the verdict
+  into `guardrail check` additively: typed skips, trigger-skip on
+  untouched surfaces, and "unknown never blocks" honesty rules.
+
+Both pillars also accept SPEC-declared truth (OpenAPI / JSON Schema via
+`flow.specs` / `schema.specs`), so any language participates before its
+pack has native extraction. The design discipline (enforced by the
+synthetic-pack playbook test): a framework quirk lands as a new
+descriptor capability — never an `if` in the extractor.
+
 ## The AnalysisResult cache
 
 Every analyzer command builds (or reads) a cached
@@ -230,6 +258,9 @@ dxkit uses layered identity, in priority order:
    - Secrets via `secret-hmac` kind: HMAC of the secret value, so a
      leaked token recognises itself when moved between files
    - Duplicate blocks: normalized content hash of the block
+   - Flow bindings: `(method, path, consuming file)`, line-independent
+   - Schema drift: `(model, field, change class)` — fully location-free,
+     so the finding survives the model moving files
 2. **Location fingerprints** with a 3-line bucket for code,
    secret, config, and hygiene findings. Bucketing absorbs small
    formatter or unrelated-edit drift.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,10 @@ to re-activate manually: `vyuh-dxkit hooks activate`.
 | [`baseline show`](commands/baseline.md)            | Pretty-print or filter the on-disk baseline                     |
 | [`guardrail check`](commands/guardrail.md)         | Diff current scan vs. baseline; block on net-new regressions    |
 | [`checks`](commands/checks.md)                     | List / dry-run your custom repo-invariant + built-in lint gates |
+| `flow`                                             | UI→API integration map + the broken-integration gate            |
+| `schema` / `schema diff`                           | Data-model inventory + the schema drift gate (preview = gate)   |
+| `ingest`                                           | Bring external SAST (SARIF) findings into the same gate         |
+| `receipt`                                          | Emit the PR "dxkit signals" block (verdict + allowlist + score) |
 | [`allowlist add`](commands/allowlist.md)           | Suppress a specific finding (typed category + reason + expiry)  |
 | [`allowlist audit`](commands/allowlist.md)         | Surface stale / soon-to-expire / orphaned / missing-rationale   |
 | [`allowlist export --snyk`](commands/allowlist.md) | Propagate Snyk-originated suppressions to a `.snyk` policy      |
@@ -55,13 +59,21 @@ Once dxkit + its tools are installed, here's the command surface:
 | [`dashboard`](commands/dashboard.md)                             | "Single HTML view of everything I've run"                          | < 5 sec (renders existing reports) |
 | [`explore`](commands/explore.md)                                 | "What does this repo do / where does X live?"                      | < 5 sec (queries the graph)        |
 | [`context`](commands/context.md)                                 | "Token-budgeted structural slice for an LLM"                       | < 5 sec (queries the graph)        |
-| [`report`](commands/report.md)                                   | "Run all of the above in one shot"                                 | 5-30 min                           |
+| [`report`](commands/report.md)                                   | "Run all of the above in one shot" (+ `report history` trend)      | 5-30 min                           |
+| `metrics`                                                        | "What did the gate stop before merge, and how's the score trend?"  | < 5 sec                            |
+| `flow`                                                           | "Which client calls bind to which served routes?"                  | 5-30 sec                           |
+| `schema` / `schema diff`                                         | "What data models do we declare / does my change break one?"       | 5-30 sec                           |
+| `capabilities`                                                   | "What can dxkit do here, and what should this repo adopt?"         | < 5 sec                            |
+| `configure`                                                      | "Compute + apply the config this repo should have"                 | < 30 sec                           |
+| `ingest`                                                         | "Bring Snyk Code / CodeQL / SARIF findings into the gate"          | varies                             |
+| `receipt`                                                        | "Emit the PR signals block (verdict + allowlist + score delta)"    | < 30 sec                           |
 | [`tools`](commands/tools.md)                                     | "What tools are detected / missing?"                               | < 5 sec                            |
 | [`doctor`](commands/doctor.md)                                   | "Why is X not working?"                                            | < 5 sec                            |
 | [`init`](commands/init.md)                                       | "Scaffold a new project with dxkit pre-configured"                 | 5-30 sec                           |
 | [`loop doctor` / `loop ledger`](commands/loop.md)                | "Run a safe autonomous coding loop behind the Stop-gate"           | < 5 sec                            |
 | [`update`](commands/update.md)                                   | "Re-generate scaffolded files, preserving customizations"          | 5-30 sec                           |
 | [`upgrade`](commands/upgrade.md)                                 | "Plan + execute a dxkit version upgrade (binary + scaffold)"       | 1-3 min                            |
+| `uninstall`                                                      | "Remove dxkit, restoring the exact pre-dxkit state (dry-run 1st)"  | < 30 sec                           |
 | [`to-xlsx`](commands/to-xlsx.md)                                 | "Convert a licenses/bom JSON report to 15-col XLSX"                | < 5 sec                            |
 | [`baseline create`](commands/baseline.md)                        | "Capture today's findings as a brownfield anchor"                  | 30s-2m                             |
 | [`baseline show`](commands/baseline.md)                          | "Inspect/filter the on-disk baseline"                              | < 1 sec                            |

--- a/docs/commands/guardrail.md
+++ b/docs/commands/guardrail.md
@@ -149,6 +149,26 @@ git config --unset core.hooksPath
 | `git <cmd> --no-verify`        | standard git bypass (skips ALL git hooks, not just dxkit's)  |
 | `DXKIT_BASELINE_NAME=<n>`      | switch which baseline file the hook checks against           |
 
+### Additive contract gates in the same check
+
+Beyond the finding diff, `guardrail check` runs two additive, fail-open
+gates when configured, and folds their verdicts into the same
+block/warn result and PR comment:
+
+- **Flow** (`policy.json:flow.mode`) — net-new broken UI→API
+  integrations (a call to a route nobody serves, a removed route a
+  consumer still calls).
+- **Schema drift** (`policy.json:schema.mode`, opt-in, default off) —
+  breaking data-model changes (field removed, type changed, optional →
+  required, model removed); additive changes warn or inform. Preview
+  locally with `vyuh-dxkit schema diff` — it runs the same evaluation.
+
+Both skip (with a disclosed reason in `--json`) rather than fail when
+they cannot gate honestly: no base commit, no surface touched by the
+diff, no truth to compare against. A deliberate breaking change ships
+via a per-finding allowlist entry, never a posture flip — see
+[the policy reference](../configuration/policy.md).
+
 ### Existing hooks (additive install)
 
 If `.githooks/<name>` or `.husky/<name>` already exists, the dxkit hook lands as `.githooks/<name>.dxkit` instead. Chain by adding `sh .githooks/<name>.dxkit` to the existing hook. `--force` overrides.

--- a/docs/configuration/language-packs.md
+++ b/docs/configuration/language-packs.md
@@ -144,12 +144,12 @@ recognizes models **by marker, per pack**: each pack declares which
 constructs are models (`modelSchema`), and one shared extractor reads them
 through a per-grammar syntax table. Current coverage:
 
-| Pack       | Recognition markers                                                                                      | Field facts                                                              |
-| ---------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| typescript | `@Entity` / `@Table` / `@Schema` / `@ObjectType` / `@InputType` decorators, `BaseEntity` heritage         | type annotations (`?`, `\| null`)                                        |
-| python     | `models.Model` / SQLAlchemy `Base` / pydantic `BaseModel` / `SQLModel` heritage, `@dataclass`              | annotations + Django field constructors (`null=`), SQLAlchemy `nullable=` |
-| go         | struct tags (`json:` / `gorm:` / `db:` / `bson:`)                                                          | field types (pointer = optional), tag wire names, `omitempty`             |
-| any        | via `schema.specs` (OpenAPI `components.schemas`, JSON Schema)                                             | the spec's own types + `required` list                                    |
+| Pack       | Recognition markers                                                                               | Field facts                                                               |
+| ---------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| typescript | `@Entity` / `@Table` / `@Schema` / `@ObjectType` / `@InputType` decorators, `BaseEntity` heritage | type annotations (`?`, `\| null`)                                         |
+| python     | `models.Model` / SQLAlchemy `Base` / pydantic `BaseModel` / `SQLModel` heritage, `@dataclass`     | annotations + Django field constructors (`null=`), SQLAlchemy `nullable=` |
+| go         | struct tags (`json:` / `gorm:` / `db:` / `bson:`)                                                 | field types (pointer = optional), tag wire names, `omitempty`             |
+| any        | via `schema.specs` (OpenAPI `components.schemas`, JSON Schema)                                    | the spec's own types + `required` list                                    |
 
 What the gate deliberately does **not** see — each either disclosed at run
 time or documented here, never implied covered:

--- a/docs/configuration/language-packs.md
+++ b/docs/configuration/language-packs.md
@@ -136,6 +136,50 @@ Remaining packs (Java, Kotlin, C#, Ruby, Rust) gain `httpFlow` in the
 language-parity waves; the recipe is declaration-only (see CONTRIBUTING.md
 "Adding a new language").
 
+## Model-schema coverage
+
+The schema feature — extracting declared data models and gating breaking
+changes (a removed field, a changed type, an optional field made required) —
+recognizes models **by marker, per pack**: each pack declares which
+constructs are models (`modelSchema`), and one shared extractor reads them
+through a per-grammar syntax table. Current coverage:
+
+| Pack       | Recognition markers                                                                                      | Field facts                                                              |
+| ---------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| typescript | `@Entity` / `@Table` / `@Schema` / `@ObjectType` / `@InputType` decorators, `BaseEntity` heritage         | type annotations (`?`, `\| null`)                                        |
+| python     | `models.Model` / SQLAlchemy `Base` / pydantic `BaseModel` / `SQLModel` heritage, `@dataclass`              | annotations + Django field constructors (`null=`), SQLAlchemy `nullable=` |
+| go         | struct tags (`json:` / `gorm:` / `db:` / `bson:`)                                                          | field types (pointer = optional), tag wire names, `omitempty`             |
+| any        | via `schema.specs` (OpenAPI `components.schemas`, JSON Schema)                                             | the spec's own types + `required` list                                    |
+
+What the gate deliberately does **not** see — each either disclosed at run
+time or documented here, never implied covered:
+
+- **Unmarked models** — a plain interface/class/struct with no framework
+  marker is invisible to code extraction. The honest answer is a spec:
+  point `schema.specs` at an OpenAPI / JSON Schema document and its models
+  gate identically, in any language.
+- **Dynamically-built models** — recognized but statically unenumerable
+  schemas surface in the inventory's dynamic list; their drift is not
+  diffable.
+- **Constraint-level changes** — the diff covers name/type/requiredness. A
+  tightened max-length, a removed enum member, a changed default or
+  validation rule is invisible.
+- **Aliased types** — comparison is lexical after normalization; a type
+  alias whose underlying type changed does not read as drift (resolving it
+  would need a type-checker, which would break the gate's ability to run at
+  a bare git ref).
+- **Serialization renames** outside Go struct tags (a pydantic
+  `Field(alias=...)`).
+- **Migration files / raw SQL** — the gate diffs the code's declaration,
+  not the database.
+- **Consumer impact** — the gate says "this declaration changed
+  breakingly", not "something still reads the removed field".
+
+A rename reads honestly as remove + add (the name is part of the contract);
+a pure file move produces no findings (relocating an unchanged declaration
+is never drift). Remaining packs gain `modelSchema` in the language-parity
+waves — the recipe is declaration-only.
+
 ## Forcing pack activation
 
 If detection misses a pack (rare — typically a missing manifest), you

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -319,6 +319,40 @@ disagree. Because `large-file` identity is per-path (not line-based),
 changing the threshold only changes _which_ files are flagged; it never
 invalidates a baseline or allowlist.
 
+## `schema` — the model-schema drift gate (opt-in)
+
+Extract every declared data model (see [language packs](language-packs.md#model-schema-coverage)
+for what counts as one) and gate breaking changes on the PR diff:
+
+```jsonc
+{
+  "schema": {
+    "mode": "warn",              // off (default) | warn | block
+    "specs": ["api/openapi.json"], // spec-declared models (any language)
+    "blockThreshold": 1          // confidence needed to BLOCK (default 1)
+  }
+}
+```
+
+- `off` (default) — the gate does not run; the capability is opt-in.
+- `warn` — net-new breaking drift (field removed, type changed, optional →
+  required, model removed) surfaces as warnings; additions are informational.
+- `block` — breaking drift fails the check, confidence-gated: a finding
+  degraded by an unknown (an unreadable type) or a fuzzy model pairing can
+  warn but never block.
+
+The gate is additive and fail-open: it runs only when the diff touches a
+model-capable source file or a configured spec, self-skips when neither side
+declares any model, and any infrastructure failure means "did not gate",
+never a failed build. Preview locally with `vyuh-dxkit schema diff` — it
+runs the exact evaluation the guardrail runs. A deliberate breaking change
+ships with an expiring `accepted-risk` allowlist entry
+(`allowlist add --fingerprint=<id> --kind=model-schema-drift
+--category=accepted-risk`), which stays visible in the PR comment's
+suppressed section. Under an autonomous loop the `security-only` preset
+demotes schema blocks to warnings; the preset never activates a gate the
+repo did not configure.
+
 ## `loop.preset` — loop-scoped posture (not read by CI)
 
 A repo running the [loop pack](../commands/loop.md) carries a separate

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -327,10 +327,10 @@ for what counts as one) and gate breaking changes on the PR diff:
 ```jsonc
 {
   "schema": {
-    "mode": "warn",              // off (default) | warn | block
+    "mode": "warn", // off (default) | warn | block
     "specs": ["api/openapi.json"], // spec-declared models (any language)
-    "blockThreshold": 1          // confidence needed to BLOCK (default 1)
-  }
+    "blockThreshold": 1, // confidence needed to BLOCK (default 1)
+  },
 }
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,6 +26,7 @@ this file, so the sections below record what has shipped.
 - [x] Post-merge baseline-refresh workflow gated on PR-check pass
 - [x] CLI tools for `setup-branch-protection` and `setup-prebuild`
 - [x] `vyuh-dxkit issue` CLI for GitHub-routed issue reports
+- [x] Model-schema drift gate: pack-declared model extraction (TS/JS, Python, Go) + spec-declared models (OpenAPI/JSON Schema), `schema` inventory/diff CLI, and a guardrail gate that blocks breaking model changes with a per-finding accepted-risk escape
 
 ### Agent integration
 

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1191,6 +1191,47 @@ if [ -n "$RULE_FLOWGATHER" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# Model-schema mirror of the flow one-concept rules (Rule 2):
+#   (a) raw gatherModelSet() is reserved for explicit-config callers — the
+#       model-schema module itself, the two-ref drift gate, and the schema
+#       CLI's base-side gather. Every single-repo surface goes through
+#       gatherRepoModelSet(cwd), which loads .dxkit/policy.json:schema itself
+#       so the configured specs are always applied.
+RULE_MODELGATHER=$(grep -rn "gatherModelSet(" src/ 2>/dev/null \
+  | grep -E '\.ts:' \
+  | grep -v "^src/analyzers/model-schema/gather.ts:" \
+  | grep -v "^src/baseline/schema-drift-gate-check.ts:" \
+  | grep -v "^src/schema-cli.ts:" \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | grep -v "// model-gather-ok")
+if [ -n "$RULE_MODELGATHER" ]; then
+  echo "❌ One-concept violation: raw gatherModelSet() on a single-repo surface:"
+  echo "$RULE_MODELGATHER"
+  echo "   → Use gatherRepoModelSet(cwd) from src/analyzers/model-schema/gather.ts — it"
+  echo "     loads .dxkit/policy.json:schema so the configured specs are always applied."
+  echo "   → Annotate '// model-gather-ok' for a justified explicit-config caller."
+  ERRORS=$((ERRORS + 1))
+fi
+
+#   (b) the `schema` policy section has ONE reader/writer —
+#       src/analyzers/model-schema/config.ts. A second ad-hoc read of
+#       policy.json's schema block re-opens the split-config bug class the
+#       flow config module closed. (The advisor's presence-probe reads the
+#       block's EXISTENCE via readJsonSafe, which this rule doesn't match.)
+RULE_SCHEMACONFIG=$(grep -rn "policy.json" src/ 2>/dev/null \
+  | grep -E '\.ts:' \
+  | grep -E "\.schema\b|\['schema'\]|\"schema\"" \
+  | grep -v "^src/analyzers/model-schema/config.ts:" \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | grep -v "// schema-config-ok")
+if [ -n "$RULE_SCHEMACONFIG" ]; then
+  echo "❌ One-concept violation: .dxkit/policy.json:schema read outside the config module:"
+  echo "$RULE_SCHEMACONFIG"
+  echo "   → Route through readSchemaConfig / writeSchemaPolicy in src/analyzers/model-schema/config.ts."
+  echo "   → Annotate '// schema-config-ok' for a justified exception."
+  ERRORS=$((ERRORS + 1))
+fi
+
 # Rule 14 (2.13.1 self-invocation class-fix): generated artifacts invoke the
 # dxkit CLI through ONE canonical helper, and every auto-running surface is
 # in ONE registry.

--- a/scripts/scaffold-language.js
+++ b/scripts/scaffold-language.js
@@ -380,6 +380,37 @@ export const ${id}: LanguageSupport = {
   // httpFlow: { ... },
   // treeSitterGrammars: { '.${id}': '${id}' },
 
+  // TODO(${id}): OPTIONAL modelSchema — data-model extraction for the schema
+  // drift gate. Add it if the language has canonical model conventions (an
+  // ORM, entity decorators, struct-tag serialization). DECLARATION-ONLY,
+  // like httpFlow (CONTRIBUTING.md "Adding model-schema support" is the
+  // walkthrough):
+  //   1. \`treeSitterGrammars\` as above, PLUS a model-shape row in
+  //      src/ast/grammar-model-shape.ts (class/field/heritage/tag syntax —
+  //      verify every node/field name against a real parse;
+  //      test/languages-contract.test.ts loud-fails an unshaped pack).
+  //   2. Fill the descriptor (ModelSchemaSupport in src/languages/types.ts;
+  //      worked examples typescript.ts/python.ts/go.ts):
+  //        modelBaseClasses       — heritage markers (models.Model, BaseModel)
+  //        weakModelBaseClasses   — too-generic names (Base): count only when
+  //                                 a fieldCallees constructor corroborates
+  //        modelDecorators        — @Entity / @Table / @dataclass
+  //        structTagKeys          — Go-style tag markers (json/gorm)
+  //        fieldCallees           — ORM field constructors (type + optionality;
+  //                                 typeFrom: 'callee' | 'firstArg')
+  //        transparentTypeWrappers— annotation wrappers to fold (Mapped[X])
+  //        typeAliases            — lowercase lexical folds (charfield→string)
+  //        schemaSignals          — manifest tokens for doctor discovery
+  //      PRECISION-FIRST: a missed model is a disclosed gap; a false model
+  //      floods the drift diff. When unsure, leave it out — schema.specs
+  //      (OpenAPI/JSON Schema) is the honest fallback.
+  //   3. Pin it: extend the pack test + a model fixture/row in
+  //      test/fixtures-analysis.test.ts, then real-repo-validate the wave
+  //      (extraction accuracy + mutation battery — see the release gate in
+  //      the feature's design history).
+  //
+  // modelSchema: { ... },
+
   // REQUIRED(${id}): correctness floor — the loop-safety liveness gate. Two PURE
   // command builders; the runner (src/analyzers/correctness/run.ts) executes
   // them and owns the fail-open/fail-closed + timeout policy — a pack NEVER

--- a/src-templates/.claude/skills/dxkit-config/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-config/SKILL.md
@@ -140,6 +140,21 @@ The UI→API integration gate has its own posture under `flow.mode` in the same 
 
 The gate is additive and fail-open: it only fires when a change touches a client call / route / spec, and self-skips when there is no served-side truth to check against. Set it up with `npx vyuh-dxkit init --flow`, or hand off to the **dxkit-flow** skill for setup / diagnosis / repair.
 
+### Switching the schema-gate posture (`schema.mode`)
+
+The model-schema drift gate (breaking data-model changes) has its own posture under `schema.mode`:
+
+```jsonc
+{ "schema": { "mode": "warn", "specs": ["api/openapi.json"] } }  // off (default) | warn | block
+```
+
+- `off` — the gate does not run (the capability is opt-in).
+- `warn` — net-new breaking drift (field removed, type changed, optional → required) warns, never fails a build.
+- `block` — breaking drift fails the check (confidence-gated: an unknown-degraded finding can only warn).
+- `schema.specs` — OpenAPI / JSON Schema files whose models gate alongside code extraction (the any-language bridge).
+
+Set it up via `npx vyuh-dxkit configure` (it plans `warn` when a data-model framework is detected), or hand off to the **dxkit-schema** skill for inventory / preview / shipping a deliberate breaking change.
+
 ### Keeping the code graph fresh in CI (`graph.refresh`)
 
 The code graph (`.dxkit/reports/graph.json`) is a **gitignored**, rebuilt-on-demand artifact. On a large repo, rebuilding it in CI is slow. Opt into a cache transport that keeps it warm:

--- a/src-templates/.claude/skills/dxkit-learn/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-learn/SKILL.md
@@ -9,7 +9,7 @@ This skill explains how dxkit works. Reach for it when the user asks about dxkit
 
 ## Mental model
 
-dxkit measures a codebase along **6 dimensions** (Security, Code Quality, Tests, Documentation, Maintainability, Developer Experience) using deterministic scanners (gitleaks, semgrep, cloc, jscpd, graphify, ruff, eslint, …). Findings are anchored to a **baseline** (`.dxkit/baselines/main.json`) so today's pre-existing issues don't block tomorrow's PR. A **guardrail check** diffs current state against the baseline and blocks net-new regressions. Hooks + CI wire the guardrail into the developer's workflow.
+dxkit measures a codebase along **6 dimensions** (Security, Code Quality, Tests, Documentation, Maintainability, Developer Experience) using deterministic scanners (gitleaks, semgrep, cloc, jscpd, graphify, ruff, eslint, …). Findings are anchored to a **baseline** (`.dxkit/baselines/main.json`) so today's pre-existing issues don't block tomorrow's PR. A **guardrail check** diffs current state against the baseline and blocks net-new regressions; two additive contract gates ride the same check when configured — **flow** (net-new broken UI→API integrations) and **schema drift** (breaking data-model changes, opt-in). Hooks + CI wire the guardrail into the developer's workflow.
 
 The three contracts to remember:
 

--- a/src-templates/.claude/skills/dxkit-onboard/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-onboard/SKILL.md
@@ -169,7 +169,7 @@ git commit -m "chore: pin baseline mode in policy.json"
 ### 6. Deep configuration — the deterministic, registry-driven pass
 
 Beyond the operational wiring above, dxkit has per-capability configuration —
-what the guardrail blocks on, the loop posture, the flow-gate posture, whether
+what the guardrail blocks on, the loop posture, the flow-gate posture, the schema-gate posture, whether
 the lint gate is on, and so on. The right value for each is not a matter of
 taste; it follows from observable facts about the repo. So dxkit **computes**
 it — the decision lives in code (`vyuh-dxkit configure`), not in your judgment
@@ -198,9 +198,10 @@ present, no lint policy yet`). Present the plan to the customer in plain terms:
   exposes (`capabilities --json` is the same source), so as dxkit grows, new
   capabilities appear in the plan automatically — you never maintain a checklist.
 - **It's a floor, not a ceiling.** The planner seeds each capability at its
-  *safe* default (flow `warn`, lint `warn-only`, the visibility-derived baseline
-  mode). Stricter postures (flow `block`, lint `blocking`) are a deliberate
-  later choice — hand off to the capability's own skill (dxkit-flow,
+  *safe* default (flow `warn`, schema `warn`, lint `warn-only`, the
+  visibility-derived baseline mode). Stricter postures (flow `block`, schema
+  `block`, lint `blocking`) are a deliberate later choice — hand off to the
+  capability's own skill (dxkit-flow, dxkit-schema,
   dxkit-checks, dxkit-loop) when the customer wants to tighten one. Each plan
   item names its driving `skill` for exactly this.
 - **Nothing to do is a valid outcome.** On a repo that's already configured (or
@@ -232,7 +233,7 @@ the values.
 **Never hand-edit policy.json to "configure" a capability the planner covers** —
 run `configure` so the value stays computed and reproducible. Hand-editing is
 for a deliberate override *after* the plan (e.g. bumping flow to `block`), and
-even then the capability's own skill (dxkit-flow, dxkit-checks, dxkit-loop) is
+even then the capability's own skill (dxkit-flow, dxkit-schema, dxkit-checks, dxkit-loop) is
 the better path.
 
 **Enforce it in CI.** `vyuh-dxkit configure check` exits non-zero when a

--- a/src-templates/.claude/skills/dxkit-schema/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-schema/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: dxkit-schema
+description: Configure, read, and act on the dxkit model-schema drift gate — list the data-model inventory, preview drift before pushing, explain why the guardrail blocked a model change, and ship a deliberate breaking change the safe way (migration + expiring accepted-risk allowlist entry). Use when the user says "set up the schema gate", "what models does this repo declare", "the guardrail says I broke a model", "why is removing this field blocked", "we're intentionally changing this schema", or anything about data-model / schema drift gating.
+---
+
+# dxkit-schema
+
+This skill owns the **model-schema drift gate**: dxkit statically extracts every declared data model (ORM entities, tagged structs, spec schemas) and fails a PR that changes one in a breaking way — a removed field, a changed type, an optional field made required, a removed model. Additive changes surface as warnings or information, never blocks.
+
+It is **thin orchestration over the deterministic CLI.** It never re-implements extraction or diffing: it runs `schema` / `schema diff` / `guardrail check`, reads their structured output, and supplies judgment + code edits. The determinism stays in the CLI; the agent supplies the reasoning.
+
+**Language coverage.** Recognition is marker-based per language pack — precision over recall. TypeScript/JavaScript: decorator-marked entity classes (TypeORM/MikroORM `@Entity`, sequelize-typescript `@Table`, NestJS-mongoose `@Schema`, type-graphql `@ObjectType`/`@InputType`) plus `BaseEntity` heritage; field facts from the type annotations. Python: Django `models.Model`, SQLAlchemy `Base`/`DeclarativeBase`, pydantic `BaseModel`, SQLModel, and `@dataclass`; Django/SQLAlchemy field constructors supply types and `null=`/`nullable=` optionality. Go: a struct tagged `json:`/`gorm:`/`db:`/`bson:` IS a wire contract; the tag supplies the wire name, `omitempty` and pointer types read as optional. **Any other language — and unmarked DTOs in covered languages — participate via a spec**: point `.dxkit/policy.json:schema.specs` at an OpenAPI (`components.schemas`) or JSON Schema document and its models are gated identically, no pack extraction needed.
+
+**What the gate does not see** (tell the user honestly when relevant): unmarked plain interfaces/classes; dynamically-built schemas (disclosed in the inventory's dynamic list, not diffable); constraint-level changes (max length, enum members, validation rules, defaults); a type alias whose underlying type changed (comparison is lexical — resolving aliases would need a type-checker); serialization renames outside Go tags; migration files / raw SQL; whether anything actually consumes a removed field.
+
+## Modes
+
+### setup — turn the gate on
+
+Setup is folded into `configure` / policy; **there is no `schema init` command.**
+
+- `npx vyuh-dxkit configure --plan` detects a data-model framework and plans `schema.mode: warn` — show the plan, then `configure --apply`.
+- Or edit `.dxkit/policy.json` directly:
+  - `schema.mode`: `off` (default — the gate is opt-in) / `warn` (surface drift, never fail) / `block` (breaking drift fails the check, confidence-gated).
+  - `schema.specs`: OpenAPI / JSON Schema files whose models union with code extraction — the language-independent bridge.
+- Adoption path: `warn` first; move to `block` once `vyuh-dxkit schema` reads clean.
+
+### inventory — what models does this repo declare?
+
+```
+npx vyuh-dxkit schema [--json]
+```
+
+Lists every extracted model with fields, types, optionality, and provenance (`base-class` / `decorator` / `struct-tag` / `spec`), plus the dynamic-model disclosure list. An `<unreadable>` type is an honest unknown — unknowns never block, so no need to chase them unless the user wants tighter gating.
+
+### preview — will my change pass?
+
+```
+npx vyuh-dxkit schema diff [--ref <base>] [--json]
+```
+
+Runs the SAME evaluation the guardrail gate runs (same diff, same verdicts, same default base ref — the remote default branch), so the preview never tells a different story than CI. Groups: breaking (would block), warnings, informational.
+
+### fix ⭐ — the guardrail blocked a model change
+
+Read the guardrail output (`--json`: the `schemaDriftGate` block). For each finding decide with the user:
+
+1. **Accidental break** (typo'd rename, unintended removal): fix the model. A rename reads as `field-removed` + `field-added` — restoring the old name (or reverting) clears it.
+2. **Deliberate breaking change**: the safe shipping shape is migration + expiring allowlist entry:
+   ```
+   npx vyuh-dxkit allowlist add --fingerprint=<id> --kind=model-schema-drift \
+     --category=accepted-risk --expires=<date> --reason="<migration link / why>"
+   ```
+   The fingerprint is location-free — it survives the model moving files or lines while the PR evolves. The entry shows up in the PR comment's suppressed section, so the decision stays reviewable.
+3. **Misread declaration** (the extractor got a field wrong): allowlist with `--category=false-positive` and report it (`vyuh-dxkit issue`).
+
+**Safety rule: repair or explicitly accept, never bypass.** Do not flip `schema.mode` to `off`/`warn` to clear one finding, and do not edit the base ref. The per-finding allowlist entry (with expiry) is the ONLY escape hatch — it is visible, reviewable, and time-boxed.
+
+## What lives where
+
+| Artifact | Role |
+| --- | --- |
+| `.dxkit/policy.json:schema` | mode / blockThreshold / specs — the single config source |
+| `vyuh-dxkit schema` | inventory (code + spec models, dynamic disclosure) |
+| `vyuh-dxkit schema diff` | pre-push drift preview (gate-identical) |
+| `guardrail check` → `schemaDriftGate` | the gate verdict folded into the PR check |
+| allowlist `--kind=model-schema-drift` | the per-finding escape hatch (accepted-risk + expiry) |
+
+## Boundaries
+
+- Posture / policy edits beyond `schema.*` → **dxkit-config**.
+- Deciding fix-vs-suppress for other finding kinds → **dxkit-action**; allowlist lifecycle (audit, prune, stale) → **dxkit-allowlist**.
+- The UI→API integration gate (routes and calls, not models) → **dxkit-flow**.
+- Unattended-loop posture (the Stop-gate demotes schema blocks to warns under `security-only`) → **dxkit-loop**.

--- a/src/allowlist/categories.ts
+++ b/src/allowlist/categories.ts
@@ -143,6 +143,11 @@ export const CATEGORIES_BY_KIND: Readonly<Record<IdentityKind, readonly Allowlis
   // accepted-risk or deferred
   'flow-binding': ['false-positive', 'accepted-risk', 'deferred'],
 
+  // Schema drift: accepted-risk is THE intended escape hatch (a deliberate
+  // breaking change shipping with its migration, ideally with an expiry);
+  // false-positive covers a misread declaration; deferred parks a decision
+  'model-schema-drift': ['false-positive', 'accepted-risk', 'deferred'],
+
   // Stale-allow (orphaned inline allowlist annotation): never
   // allowlisted. The right response is always "remove the stale
   // annotation" — allowlisting the warning that an annotation is

--- a/src/allowlist/hint.ts
+++ b/src/allowlist/hint.ts
@@ -217,6 +217,14 @@ export function remediationFor(kind: BaselineEntry['kind']): string {
         'the current route, or — if a cross-repo consumer the scan cannot see is ' +
         'intended — allowlist with category=false-positive.'
       );
+    case 'model-schema-drift':
+      return (
+        'A declared data model changed in a breaking way (field removed, type ' +
+        'changed, requiredness tightened, or the model removed). Restore the ' +
+        'contract, or — for a deliberate breaking change shipping with its ' +
+        'migration — allowlist with category=accepted-risk (ideally with an ' +
+        'expiry) so the decision stays visible and time-boxed.'
+      );
     case 'custom-check':
       return (
         'A repo-declared check (a custom `.dxkit/policy.json` invariant, or a ' +
@@ -249,6 +257,7 @@ function entryLocator(entry: BaselineEntry): { file?: string; line?: number } {
     case 'hygiene':
     case 'stale-allow':
     case 'flow-binding':
+    case 'model-schema-drift':
       return { file: entry.file, line: entry.line };
     case 'coverage-gap':
     case 'test-gap':

--- a/src/analyzers/model-schema/config.ts
+++ b/src/analyzers/model-schema/config.ts
@@ -1,0 +1,110 @@
+/**
+ * Model-schema configuration read from `.dxkit/policy.json:schema` — the
+ * single reader AND single writer of that section (Rule 2, the flow-config
+ * discipline). Every schema surface — the `schema` CLI, the guardrail drift
+ * gate, doctor's probe — resolves its config here.
+ *
+ * All fields are optional in the file; a missing / malformed policy yields
+ * the defaults (fail-open), never a throw. The default MODE is `off`: a repo
+ * that never configured the gate spawns nothing (the capability is opt-in;
+ * `configure` plans `warn`, the user promotes to `block`).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { mergeIntoPolicyFile } from '../../baseline/policy-write';
+
+/** How the guardrail treats net-new schema drift.
+ *   - `block`: honor the per-finding verdict — a fully-determined breaking
+ *     change fails the build; an unknown-degraded one warns.
+ *   - `warn`: every drift warns, never fails a build (soft launch).
+ *   - `off` (default): the gate does not run at all. */
+export type SchemaGateMode = 'block' | 'warn' | 'off';
+
+export interface SchemaConfig {
+  /** OpenAPI / JSON Schema files whose declared models union with source
+   *  extraction — the language-independent bridge (mirror of `flow.specs`). */
+  readonly specs: string[];
+  /** Guardrail posture for net-new schema drift. */
+  readonly mode: SchemaGateMode;
+  /** Confidence at/above which a breaking drift BLOCKS (else warns).
+   *  Default 1 — only fully-determined findings can fail a build; anything
+   *  degraded by an unknown or a similarity-matched relocation warns. */
+  readonly blockThreshold: number;
+}
+
+const DEFAULTS: SchemaConfig = {
+  specs: [],
+  mode: 'off',
+  blockThreshold: 1,
+};
+
+/** Current schema version of the committed `.dxkit/policy.json:schema`
+ *  block. Stamped on write so a future restructure is detectable/migratable
+ *  (a versionless block reads as v1 — every field optional-with-default).
+ *  The three keys (specs/mode/blockThreshold) are the FROZEN v1 contract,
+ *  pinned by `test/model-schema-contract-freeze.test.ts`. */
+export const SCHEMA_CONFIG_SCHEMA_VERSION = 1;
+
+interface RawSchema {
+  specs?: unknown;
+  mode?: unknown;
+  blockThreshold?: unknown;
+}
+
+function stringList(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((s): s is string => typeof s === 'string') : [];
+}
+
+function isMode(v: unknown): v is SchemaGateMode {
+  return v === 'block' || v === 'warn' || v === 'off';
+}
+
+function rawSection(cwd: string): RawSchema | undefined {
+  try {
+    const text = fs.readFileSync(path.join(cwd, '.dxkit', 'policy.json'), 'utf8');
+    return (JSON.parse(text) as { schema?: RawSchema })?.schema;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read the `schema` section of `.dxkit/policy.json`. Fail-open — a
+ *  read/parse error or an absent block returns the defaults (gate off). */
+export function readSchemaConfig(cwd: string): SchemaConfig {
+  const raw = rawSection(cwd) ?? {};
+  return {
+    specs: stringList(raw.specs),
+    mode: isMode(raw.mode) ? raw.mode : DEFAULTS.mode,
+    blockThreshold:
+      typeof raw.blockThreshold === 'number' && raw.blockThreshold > 0
+        ? raw.blockThreshold
+        : DEFAULTS.blockThreshold,
+  };
+}
+
+/**
+ * The `schema.mode` EXPLICITLY set in policy, or `undefined` when unset —
+ * distinguishing "the user chose a posture" from "no posture yet", so a
+ * configure/init re-run PRESERVES an evolved choice instead of resetting it
+ * (the init-resets-user-choice bug class flow closed).
+ */
+export function existingSchemaMode(cwd: string): SchemaGateMode | undefined {
+  const raw = rawSection(cwd);
+  return raw && isMode(raw.mode) ? raw.mode : undefined;
+}
+
+/**
+ * Write into `.dxkit/policy.json:schema` through the ONE policy merge-writer
+ * — sibling sections survive, a malformed file is never clobbered, an
+ * unchanged merge writes nothing. The single writer of this section,
+ * paired with the reader above.
+ */
+export function writeSchemaPolicy(
+  cwd: string,
+  patch: Partial<Pick<SchemaConfig, 'mode' | 'specs' | 'blockThreshold'>>,
+): boolean {
+  return mergeIntoPolicyFile(cwd, {
+    schema: { ...patch, schemaVersion: SCHEMA_CONFIG_SCHEMA_VERSION },
+  }).changed;
+}

--- a/src/analyzers/model-schema/extract.ts
+++ b/src/analyzers/model-schema/extract.ts
@@ -61,7 +61,11 @@ function resolveFieldCallee(
   call: Node,
   callShape: GrammarShape,
   specs: readonly FieldCalleeSpec[],
-): { rawType: string | null; descriptorOptional: boolean | null } | null {
+): {
+  rawType: string | null;
+  descriptorOptional: boolean | null;
+  descriptorDefaultOptional: boolean | null;
+} | null {
   const resolved = callShape.resolveCall(call);
   if (!resolved) return null;
   const spec = specs.find((s) => s.names.some((n) => n === resolved.name));
@@ -77,18 +81,21 @@ function resolveFieldCallee(
     rawType = resolved.name;
   }
 
+  // An EXPLICIT keyword (`null=True`, `nullable=False`) is authoritative.
+  // An ABSENT keyword yields only the framework DEFAULT, which ranks below
+  // a folded annotation — SQLAlchemy 2.0 derives nullability from
+  // `Mapped[Optional[X]]` when no kwarg is given (real-repo-validated).
   let descriptorOptional: boolean | null = null;
+  let descriptorDefaultOptional: boolean | null = null;
   if (spec.optionalityKeyword) {
     const value = callShape.optionValue(call, spec.optionalityKeyword);
     const truthy = value ? /^(true|True)$/.test(value.text) : null;
-    // An absent keyword means the framework default applies: nullable
-    // defaults to false (required), required defaults to false (optional).
     const optionalWhenTrue = (spec.optionalityPolarity ?? 'nullable') === 'nullable';
-    if (truthy === null) descriptorOptional = optionalWhenTrue ? false : true;
+    if (truthy === null) descriptorDefaultOptional = optionalWhenTrue ? false : true;
     else descriptorOptional = optionalWhenTrue ? truthy : !truthy;
   }
 
-  return { rawType, descriptorOptional };
+  return { rawType, descriptorOptional, descriptorDefaultOptional };
 }
 
 /** How a class node is marked as a model, or null when it is not one. */
@@ -148,6 +155,7 @@ function extractFields(
     let rawType = modelShape.fieldTypeText(field);
     const markerOptional = modelShape.fieldOptionalMarker(field);
     let descriptorOptional: boolean | null = null;
+    let descriptorDefaultOptional: boolean | null = null;
 
     // Field-constructor form (`models.CharField(null=True)`) — supplies the
     // type token and explicit optionality when the annotation does not.
@@ -158,6 +166,7 @@ function extractFields(
         sawFieldCallee = true;
         if (rawType === null) rawType = resolved.rawType;
         descriptorOptional = resolved.descriptorOptional;
+        descriptorDefaultOptional = resolved.descriptorDefaultOptional;
       }
     }
 
@@ -182,7 +191,9 @@ function extractFields(
         rawType,
         markerOptional,
         descriptorOptional: tagOptional ?? descriptorOptional,
+        descriptorDefaultOptional,
         typeAliases: descriptor.typeAliases,
+        typeWrappers: descriptor.transparentTypeWrappers,
       });
       out.push({ name, ...normalized });
     }

--- a/src/analyzers/model-schema/extract.ts
+++ b/src/analyzers/model-schema/extract.ts
@@ -1,0 +1,241 @@
+/**
+ * Model-schema extraction — the AST pass that turns source into a repo's
+ * declared data models (the substrate the drift gate diffs).
+ *
+ * Cross-cutting consumer of the same seams as flow extraction, hardcoding
+ * none of them: the canonical AST layer (`src/ast/parse.ts`) for parsing;
+ * the per-grammar MODEL shape (`src/ast/grammar-model-shape.ts`) for HOW to
+ * read a class/field/heritage/tag; the per-grammar CALL shape
+ * (`src/ast/grammar-shape.ts`) for decorator/constructor reads; and each
+ * pack's `modelSchema` descriptor (Rule 6) for WHICH constructs are models.
+ * No grammar node name and no framework literal lives in this file — a new
+ * language adds model extraction with ZERO extractor edits.
+ *
+ * Recognition is marker-based (precision-first, the flow lesson): heritage,
+ * decorator, or struct-tag markers from the descriptor. A recognized model
+ * with no statically readable fields is disclosed via `dynamicModels` AND
+ * kept in `models` (so a later readable version diffs as field additions,
+ * never a phantom model-added). A field whose type cannot be read is kept
+ * with `type: null` — the diff's unknown rules make sure a `null` never
+ * blocks anything.
+ */
+
+import { getLanguage } from '../../languages';
+import type { ModelSchemaSupport } from '../../languages/types';
+import { parseFile, walk, type Node } from '../../ast/parse';
+import { grammarShape, type GrammarShape } from '../../ast/grammar-shape';
+import { modelShapeForGrammar, type GrammarModelShape } from '../../ast/grammar-model-shape';
+import { normalizeField, tagWireName } from './normalize';
+import type { DynamicModelSite, ModelEntity, ModelField, ModelSet } from './model';
+
+function line(node: Node): number {
+  return node.startPosition.row + 1;
+}
+
+/** Trailing identifier segment of a dotted path (`models.Model` → `Model`). */
+function tailSegment(text: string): string {
+  const parts = text.split('.');
+  return parts[parts.length - 1];
+}
+
+/** Does a heritage expression match a declared base marker? Both the full
+ *  text and the trailing segment count (`'Model'` matches `models.Model`). */
+function heritageMatches(heritage: string, bases: readonly string[]): boolean {
+  return bases.some((b) => heritage === b || tailSegment(heritage) === b);
+}
+
+/** The name a decorator invokes: `@Entity()` → `Entity`, `@dataclass` →
+ *  `dataclass`, `@orm.Table(...)` → `Table`. Lexical over the decorator's
+ *  text — total, never throws. */
+function decoratorName(decorator: Node): string {
+  const text = decorator.text.replace(/^@/, '');
+  return tailSegment(text.split('(')[0].trim());
+}
+
+type FieldCalleeSpec = NonNullable<ModelSchemaSupport['fieldCallees']>[number];
+
+/** Resolve a field-initializer constructor against the descriptor's
+ *  `fieldCallees`: the matched spec plus the raw type token and explicit
+ *  optionality it carries. */
+function resolveFieldCallee(
+  call: Node,
+  callShape: GrammarShape,
+  specs: readonly FieldCalleeSpec[],
+): { rawType: string | null; descriptorOptional: boolean | null } | null {
+  const resolved = callShape.resolveCall(call);
+  if (!resolved) return null;
+  const spec = specs.find((s) => s.names.some((n) => n === resolved.name));
+  if (!spec) return null;
+
+  let rawType: string | null;
+  if (spec.typeFrom === 'firstArg') {
+    // Column(String, …) / db.Column(db.Integer(80)) — the first positional
+    // argument's head token, dotted-path-tailed and call-parens-stripped.
+    const first = callShape.firstArg(call);
+    rawType = first ? tailSegment(first.text.split('(')[0].trim()) : null;
+  } else {
+    rawType = resolved.name;
+  }
+
+  let descriptorOptional: boolean | null = null;
+  if (spec.optionalityKeyword) {
+    const value = callShape.optionValue(call, spec.optionalityKeyword);
+    const truthy = value ? /^(true|True)$/.test(value.text) : null;
+    // An absent keyword means the framework default applies: nullable
+    // defaults to false (required), required defaults to false (optional).
+    const optionalWhenTrue = (spec.optionalityPolarity ?? 'nullable') === 'nullable';
+    if (truthy === null) descriptorOptional = optionalWhenTrue ? false : true;
+    else descriptorOptional = optionalWhenTrue ? truthy : !truthy;
+  }
+
+  return { rawType, descriptorOptional };
+}
+
+/** How a class node is marked as a model, or null when it is not one. */
+function recognizeModel(
+  node: Node,
+  descriptor: ModelSchemaSupport,
+  modelShape: GrammarModelShape,
+  callShape: GrammarShape | null,
+): ModelEntity['via'] | null {
+  if (descriptor.modelBaseClasses?.length) {
+    const heritage = modelShape.heritage(node);
+    if (heritage.some((h) => heritageMatches(h, descriptor.modelBaseClasses!))) {
+      return 'base-class';
+    }
+  }
+  if (descriptor.modelDecorators?.length && callShape) {
+    const names = modelShape.classDecorators(node).map((d) => decoratorName(d));
+    if (names.some((n) => descriptor.modelDecorators!.includes(n))) return 'decorator';
+  }
+  if (descriptor.structTagKeys?.length) {
+    for (const field of modelShape.fieldNodes(node)) {
+      const tag = modelShape.fieldTag(field);
+      if (tag && descriptor.structTagKeys.some((k) => tagWireName(tag, k) !== null)) {
+        return 'struct-tag';
+      }
+    }
+  }
+  return null;
+}
+
+function extractFields(
+  classNode: Node,
+  descriptor: ModelSchemaSupport,
+  modelShape: GrammarModelShape,
+  callShape: GrammarShape | null,
+): ModelField[] {
+  const out: ModelField[] = [];
+  const tagKeys = descriptor.structTagKeys ?? [];
+  const calleeSpecs = descriptor.fieldCallees ?? [];
+
+  for (const field of modelShape.fieldNodes(classNode)) {
+    const declaredNames = modelShape.fieldNames(field);
+    if (declaredNames.length === 0) continue; // unnamed/embedded
+
+    let rawType = modelShape.fieldTypeText(field);
+    const markerOptional = modelShape.fieldOptionalMarker(field);
+    let descriptorOptional: boolean | null = null;
+
+    // Field-constructor form (`models.CharField(null=True)`) — supplies the
+    // type token and explicit optionality when the annotation does not.
+    if (calleeSpecs.length > 0 && callShape) {
+      const call = modelShape.fieldValueCall(field);
+      const resolved = call ? resolveFieldCallee(call, callShape, calleeSpecs) : null;
+      if (resolved) {
+        if (rawType === null) rawType = resolved.rawType;
+        descriptorOptional = resolved.descriptorOptional;
+      }
+    }
+
+    // Struct-tag wire naming + omitempty (Go): the tag's name replaces the
+    // declared one; a tag-excluded field keeps its declared name.
+    for (const declared of declaredNames) {
+      let name = declared;
+      let tagOptional: boolean | null = null;
+      const tag = modelShape.fieldTag(field);
+      if (tag) {
+        for (const key of tagKeys) {
+          const wire = tagWireName(tag, key);
+          if (wire) {
+            name = wire.name;
+            if (wire.optional) tagOptional = true;
+            break;
+          }
+        }
+      }
+
+      const normalized = normalizeField({
+        rawType,
+        markerOptional,
+        descriptorOptional: tagOptional ?? descriptorOptional,
+        typeAliases: descriptor.typeAliases,
+      });
+      out.push({ name, ...normalized });
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract every marked model from a parsed tree — PURE over its inputs.
+ * `callShape` may be null (a grammar with a model row but no call row);
+ * decorator and field-constructor recognition degrade gracefully.
+ */
+export function extractModelsFromTree(
+  root: Node,
+  descriptor: ModelSchemaSupport,
+  modelShape: GrammarModelShape,
+  callShape: GrammarShape | null,
+  file: string,
+): ModelSet {
+  const models: ModelEntity[] = [];
+  const dynamicModels: DynamicModelSite[] = [];
+  const classTypes = new Set(modelShape.classNodes);
+
+  walk(root, (node) => {
+    if (!classTypes.has(node.type)) return undefined;
+    const name = modelShape.className(node);
+    if (name === null) return undefined;
+    const via = recognizeModel(node, descriptor, modelShape, callShape);
+    if (via === null) return undefined;
+
+    const fields = extractFields(node, descriptor, modelShape, callShape);
+    const entity: ModelEntity = { name, via, file, line: line(node), fields };
+    models.push(entity);
+    if (fields.length === 0) {
+      dynamicModels.push({ name, file, line: line(node) });
+    }
+    return undefined;
+  });
+
+  return { models, dynamicModels };
+}
+
+/** Empty result for files that cannot contribute (no grammar/descriptor/
+ *  shape) — distinct from `null` (unparseable file, skip silently). */
+const EMPTY: ModelSet = { models: [], dynamicModels: [] };
+
+/**
+ * Extract one file's models: parse via the canonical AST layer, resolve the
+ * pack descriptor by the file's language and the shapes by its grammar.
+ * Returns null when the file cannot be parsed — callers skip, never error.
+ */
+export async function extractFileModels(
+  filePath: string,
+  relPath?: string,
+): Promise<ModelSet | null> {
+  const parsed = await parseFile(filePath);
+  if (!parsed) return null;
+  const descriptor = getLanguage(parsed.languageId)?.modelSchema;
+  const modelShape = modelShapeForGrammar(parsed.grammar);
+  if (!descriptor || !modelShape) return EMPTY;
+  const callShape = grammarShape(parsed.grammar);
+  return extractModelsFromTree(
+    parsed.tree.rootNode,
+    descriptor,
+    modelShape,
+    callShape,
+    relPath ?? filePath,
+  );
+}

--- a/src/analyzers/model-schema/extract.ts
+++ b/src/analyzers/model-schema/extract.ts
@@ -97,23 +97,34 @@ function recognizeModel(
   descriptor: ModelSchemaSupport,
   modelShape: GrammarModelShape,
   callShape: GrammarShape | null,
-): ModelEntity['via'] | null {
+): { via: ModelEntity['via']; weak: boolean } | null {
   if (descriptor.modelBaseClasses?.length) {
     const heritage = modelShape.heritage(node);
     if (heritage.some((h) => heritageMatches(h, descriptor.modelBaseClasses!))) {
-      return 'base-class';
+      return { via: 'base-class', weak: false };
     }
   }
   if (descriptor.modelDecorators?.length && callShape) {
     const names = modelShape.classDecorators(node).map((d) => decoratorName(d));
-    if (names.some((n) => descriptor.modelDecorators!.includes(n))) return 'decorator';
+    if (names.some((n) => descriptor.modelDecorators!.includes(n))) {
+      return { via: 'decorator', weak: false };
+    }
   }
   if (descriptor.structTagKeys?.length) {
     for (const field of modelShape.fieldNodes(node)) {
       const tag = modelShape.fieldTag(field);
       if (tag && descriptor.structTagKeys.some((k) => tagWireName(tag, k) !== null)) {
-        return 'struct-tag';
+        return { via: 'struct-tag', weak: false };
       }
+    }
+  }
+  // WEAK heritage last: a too-generic name (`Base`) marks a model only when
+  // field extraction corroborates it (≥1 fieldCallees hit) — the caller
+  // enforces that, discarding uncorroborated weak matches.
+  if (descriptor.weakModelBaseClasses?.length) {
+    const heritage = modelShape.heritage(node);
+    if (heritage.some((h) => heritageMatches(h, descriptor.weakModelBaseClasses!))) {
+      return { via: 'base-class', weak: true };
     }
   }
   return null;
@@ -124,10 +135,11 @@ function extractFields(
   descriptor: ModelSchemaSupport,
   modelShape: GrammarModelShape,
   callShape: GrammarShape | null,
-): ModelField[] {
+): { fields: ModelField[]; sawFieldCallee: boolean } {
   const out: ModelField[] = [];
   const tagKeys = descriptor.structTagKeys ?? [];
   const calleeSpecs = descriptor.fieldCallees ?? [];
+  let sawFieldCallee = false;
 
   for (const field of modelShape.fieldNodes(classNode)) {
     const declaredNames = modelShape.fieldNames(field);
@@ -143,6 +155,7 @@ function extractFields(
       const call = modelShape.fieldValueCall(field);
       const resolved = call ? resolveFieldCallee(call, callShape, calleeSpecs) : null;
       if (resolved) {
+        sawFieldCallee = true;
         if (rawType === null) rawType = resolved.rawType;
         descriptorOptional = resolved.descriptorOptional;
       }
@@ -174,7 +187,7 @@ function extractFields(
       out.push({ name, ...normalized });
     }
   }
-  return out;
+  return { fields: out, sawFieldCallee };
 }
 
 /**
@@ -197,11 +210,14 @@ export function extractModelsFromTree(
     if (!classTypes.has(node.type)) return undefined;
     const name = modelShape.className(node);
     if (name === null) return undefined;
-    const via = recognizeModel(node, descriptor, modelShape, callShape);
-    if (via === null) return undefined;
+    const recognized = recognizeModel(node, descriptor, modelShape, callShape);
+    if (recognized === null) return undefined;
 
-    const fields = extractFields(node, descriptor, modelShape, callShape);
-    const entity: ModelEntity = { name, via, file, line: line(node), fields };
+    const { fields, sawFieldCallee } = extractFields(node, descriptor, modelShape, callShape);
+    // A weak heritage match (a too-generic base name) needs corroboration:
+    // no ORM field constructor in the body → not a model, skip silently.
+    if (recognized.weak && !sawFieldCallee) return undefined;
+    const entity: ModelEntity = { name, via: recognized.via, file, line: line(node), fields };
     models.push(entity);
     if (fields.length === 0) {
       dynamicModels.push({ name, file, line: line(node) });

--- a/src/analyzers/model-schema/gate.ts
+++ b/src/analyzers/model-schema/gate.ts
@@ -1,0 +1,114 @@
+/**
+ * The model-schema drift gate — pure evaluation core.
+ *
+ * Answers "does this diff change a declared data model in a breaking way?"
+ * from a base↔HEAD model-set comparison, with no running system. The diff
+ * itself (`diffModelSets`) is the grandfather: only differences between the
+ * two refs exist, so pre-existing state can never produce a finding.
+ *
+ * The gate's contribution over the diff is the VERDICT: which change classes
+ * break (block), which deserve attention (warn), and which are merely
+ * disclosed (info) — modulated by each finding's intrinsic confidence, so an
+ * unknown-degraded or similarity-paired finding can warn but never block.
+ * Pure over its inputs — the ref-based gather and guardrail wiring live in
+ * `src/baseline/schema-drift-gate-check.ts`. Identity is the location-free
+ * drift fingerprint (Rule 9), computed through the canonical helper so an
+ * emitted finding shares one identity contract with the allowlist.
+ */
+
+import { computeModelSchemaDriftFingerprint } from '../tools/fingerprint';
+import { diffModelSets, type DriftClass, type ModelSet, type SchemaDrift } from './model';
+
+/** Change classes that are breaking by construction: a reader or writer of
+ *  the previous contract can now fail. Block-eligible (confidence-gated). */
+const BREAKING_CLASSES: ReadonlySet<DriftClass> = new Set([
+  'model-removed',
+  'field-removed',
+  'field-type-changed',
+  'field-required-added',
+]);
+
+/** Classes that deserve attention but whose impact is direction-dependent
+ *  (a new required field breaks writers, not readers) — always warn. */
+const WARN_CLASSES: ReadonlySet<DriftClass> = new Set(['field-added-required']);
+
+/** One drift finding with its verdict. `info` findings are DISCLOSED (shown
+ *  in reports) but never count toward blocks/warns. */
+export interface SchemaDriftFinding extends SchemaDrift {
+  /** Location-free drift fingerprint — the durable identity (Rule 9). */
+  readonly id: string;
+  readonly verdict: 'block' | 'warn' | 'info';
+}
+
+export interface SchemaGateInputs {
+  readonly baseModels: ModelSet;
+  readonly headModels: ModelSet;
+  /** Confidence at/above which a breaking drift BLOCKS (else warns).
+   *  Default 1 — only fully-determined findings on exactly-paired models can
+   *  fail a build; unknown-degraded and similarity-paired ones warn. */
+  readonly blockThreshold?: number;
+}
+
+/**
+ * Evaluate the gate. Returns every drift with its verdict, most-severe first
+ * (block, warn, info), then by model/field for stable output. Empty when the
+ * diff changes no declared model.
+ */
+export function evaluateSchemaDriftGate(inputs: SchemaGateInputs): SchemaDriftFinding[] {
+  const blockThreshold = inputs.blockThreshold ?? 1;
+  const out = diffModelSets(inputs.baseModels, inputs.headModels).map((d): SchemaDriftFinding => {
+    let verdict: SchemaDriftFinding['verdict'];
+    if (BREAKING_CLASSES.has(d.changeClass)) {
+      verdict = d.confidence >= blockThreshold ? 'block' : 'warn';
+    } else if (WARN_CLASSES.has(d.changeClass)) {
+      verdict = 'warn';
+    } else {
+      verdict = 'info';
+    }
+    return {
+      ...d,
+      id: computeModelSchemaDriftFingerprint(d.model, d.field, d.changeClass),
+      verdict,
+    };
+  });
+
+  const rank = (v: SchemaDriftFinding['verdict']): number =>
+    v === 'block' ? 0 : v === 'warn' ? 1 : 2;
+  out.sort(
+    (a, z) =>
+      rank(a.verdict) - rank(z.verdict) ||
+      a.model.localeCompare(z.model) ||
+      (a.field ?? '').localeCompare(z.field ?? ''),
+  );
+  return out;
+}
+
+/** Does the gate result block? True when any finding's verdict is `block`. */
+export function schemaDriftGateBlocks(findings: readonly SchemaDriftFinding[]): boolean {
+  return findings.some((f) => f.verdict === 'block');
+}
+
+/** One-line human description of a drift finding, shared by the console
+ *  renderer, the PR comment, and the Stop-gate hand-back. */
+export function describeSchemaDrift(f: SchemaDriftFinding): string {
+  const subject = f.field ? `${f.model}.${f.field}` : f.model;
+  const at = `${f.file}:${f.line}`;
+  switch (f.changeClass) {
+    case 'model-removed':
+      return `${subject} — model removed (was ${f.from ?? 'declared'}) [${at}]`;
+    case 'model-added':
+      return `${subject} — model added [${at}]`;
+    case 'field-removed':
+      return `${subject} — field removed (was ${f.from ?? 'unknown type'}) [${at}]`;
+    case 'field-added':
+      return `${subject} — optional field added (${f.to ?? 'unknown type'}) [${at}]`;
+    case 'field-added-required':
+      return `${subject} — REQUIRED field added (${f.to ?? 'unknown type'}) — breaks writers [${at}]`;
+    case 'field-type-changed':
+      return `${subject} — type changed: ${f.from ?? 'unknown'} → ${f.to ?? 'unknown'} [${at}]`;
+    case 'field-required-added':
+      return `${subject} — optional → required [${at}]`;
+    case 'field-optionality-relaxed':
+      return `${subject} — required → optional [${at}]`;
+  }
+}

--- a/src/analyzers/model-schema/gather.ts
+++ b/src/analyzers/model-schema/gather.ts
@@ -1,0 +1,84 @@
+/**
+ * Model-schema gather — walk a set of roots, extract every marked model, and
+ * assemble one `ModelSet`, unioned with any spec-declared models.
+ *
+ * File discovery goes through the canonical `walkSourceFiles` (Rule 4
+ * exclusions + test-file skipping built in); the scanned extensions are
+ * exactly those of packs declaring BOTH a `modelSchema` descriptor and a
+ * tree-sitter grammar, so a non-model language's files are never parsed and
+ * adding a pack auto-extends the scan (Rule 6).
+ *
+ * `gatherRepoModelSet` is the canonical single-repo entry point (Rule 2): it
+ * reads `.dxkit/policy.json:schema` itself, so a caller cannot forget the
+ * configured specs — the half-landed-config bug class flow closed. The raw
+ * `gatherModelSet` is reserved for explicit-config callers (the two-ref
+ * gate's base side, where config comes from the HEAD checkout's policy).
+ */
+
+import { join, relative, resolve } from 'path';
+import { LANGUAGES, allModelSchemaSourceExtensions } from '../../languages';
+import { walkSourceFiles } from '../tools/walk-source-files';
+import { extractFileModels } from './extract';
+import { loadSpecModels } from './spec-source';
+import { readSchemaConfig } from './config';
+import type { DynamicModelSite, ModelEntity, ModelSet } from './model';
+
+export interface GatherModelOptions {
+  /** Directories to scan for source. */
+  readonly roots: readonly string[];
+  /** OpenAPI / JSON Schema files whose models union with extraction. */
+  readonly specs?: readonly string[];
+  /**
+   * Relabel every extracted model `file` relative to this directory. The
+   * drift identity contract (Rule 9) requires environment-independent
+   * locators, so the gate sets this to the repo root: a model gathered from
+   * the working tree and from a detached worktree share one relative `file`.
+   */
+  readonly relativeTo?: string;
+}
+
+/** Walk + extract + union. Files that don't parse are skipped, never fatal. */
+export async function gatherModelSet(opts: GatherModelOptions): Promise<ModelSet> {
+  const extensions = allModelSchemaSourceExtensions(LANGUAGES);
+  const models: ModelEntity[] = [];
+  const dynamicModels: DynamicModelSite[] = [];
+
+  if (extensions.length > 0) {
+    for (const root of opts.roots) {
+      for (const rel of walkSourceFiles(root, { extensions })) {
+        const abs = join(root, rel);
+        const set = await extractFileModels(
+          abs,
+          opts.relativeTo ? relative(opts.relativeTo, abs) : abs,
+        );
+        if (!set) continue;
+        models.push(...set.models);
+        dynamicModels.push(...set.dynamicModels);
+      }
+    }
+  }
+
+  for (const spec of opts.specs ?? []) {
+    const specModels = loadSpecModels(spec);
+    const label = opts.relativeTo ? relative(opts.relativeTo, spec) : spec;
+    models.push(...specModels.map((m) => ({ ...m, file: label })));
+  }
+
+  return { models, dynamicModels };
+}
+
+/**
+ * Gather a repo's model set with its POLICY CONFIG applied — the canonical
+ * single-repo entry point. `roots` defaults to `[cwd]`.
+ */
+export async function gatherRepoModelSet(
+  cwd: string,
+  opts: { roots?: readonly string[]; relativeTo?: string } = {},
+): Promise<ModelSet> {
+  const config = readSchemaConfig(cwd);
+  return gatherModelSet({
+    roots: opts.roots ?? [cwd],
+    specs: config.specs.map((s) => resolve(cwd, s)),
+    ...(opts.relativeTo !== undefined ? { relativeTo: opts.relativeTo } : {}),
+  });
+}

--- a/src/analyzers/model-schema/model.ts
+++ b/src/analyzers/model-schema/model.ts
@@ -1,0 +1,313 @@
+/**
+ * The model-schema domain model: extracted entities, the name-anchored
+ * base↔head join, and the ONE drift diff (Rule 2 — `diffModelSets` is the
+ * single computation of "what changed", consumed by BOTH the guardrail gate
+ * and the `schema diff` CLI; a parity test pins them).
+ *
+ * Join discipline (decided in design review): a model is a CONTRACT-domain
+ * entity — its name is its address, the file is where it happens to live
+ * today. So pairing anchors on the NAME and tolerates relocation:
+ * relocating an unchanged declaration is never drift; renaming the
+ * declaration is. Identity (Rule 9) follows the same doctrine — the
+ * fingerprint hashes (model, field, changeClass) and nothing locational.
+ */
+
+/** One declared field, normalized. `null` facts are honest unknowns — the
+ *  diff never lets an unknown-touching comparison block. */
+export interface ModelField {
+  readonly name: string;
+  readonly type: string | null;
+  readonly required: boolean | null;
+}
+
+/** One extracted data model. `file` is repo-relative when gathered with
+ *  `relativeTo` (Rule 9 discipline); `line` is display metadata, never
+ *  identity. */
+export interface ModelEntity {
+  readonly name: string;
+  readonly via: 'base-class' | 'decorator' | 'struct-tag' | 'spec';
+  readonly file: string;
+  readonly line: number;
+  readonly fields: readonly ModelField[];
+}
+
+/** A recognized model with no statically readable fields — either genuinely
+ *  empty or dynamically built. Disclosed (mirror of flow's `dynamicCalls`),
+ *  never silently dropped; the entity ALSO stays in `models` so a later
+ *  readable version diffs as field additions, not a phantom model-added. */
+export interface DynamicModelSite {
+  readonly name: string;
+  readonly file: string;
+  readonly line: number;
+}
+
+/** One side's extracted models (one repo at one ref). */
+export interface ModelSet {
+  readonly models: readonly ModelEntity[];
+  readonly dynamicModels: readonly DynamicModelSite[];
+}
+
+export type ModelPairReason = 'exact' | 'relocated' | 'similarity';
+
+/** A base↔head correspondence with match confidence, `matchAcrossRuns`
+ *  style: reasons are structured, confidence is in [0, 1] and propagates
+ *  into every finding minted off the pair. */
+export interface ModelPair {
+  readonly base: ModelEntity;
+  readonly head: ModelEntity;
+  readonly reason: ModelPairReason;
+  readonly confidence: number;
+}
+
+export interface ModelJoin {
+  readonly pairs: readonly ModelPair[];
+  readonly removed: readonly ModelEntity[];
+  readonly added: readonly ModelEntity[];
+}
+
+/** Field-name-set Jaccard similarity — the disambiguator when several
+ *  same-named models exist and file matching leaves candidates unresolved. */
+function fieldSimilarity(a: ModelEntity, b: ModelEntity): number {
+  const an = new Set(a.fields.map((f) => f.name));
+  const bn = new Set(b.fields.map((f) => f.name));
+  if (an.size === 0 && bn.size === 0) return 1;
+  let shared = 0;
+  for (const n of an) if (bn.has(n)) shared++;
+  const union = an.size + bn.size - shared;
+  return union === 0 ? 0 : shared / union;
+}
+
+/** Minimum field-set similarity for a cross-file pairing of same-named
+ *  models when more than one candidate is in play. */
+const SIMILARITY_FLOOR = 0.5;
+
+/**
+ * Pair base and head models: name-anchored, two-stage (exact file, then
+ * field-set similarity). A single candidate on each side pairs regardless
+ * of file — that IS the relocation tolerance.
+ */
+export function pairModels(base: ModelSet, head: ModelSet): ModelJoin {
+  const byName = (models: readonly ModelEntity[]) => {
+    const m = new Map<string, ModelEntity[]>();
+    for (const e of models) {
+      const list = m.get(e.name);
+      if (list) list.push(e);
+      else m.set(e.name, [e]);
+    }
+    return m;
+  };
+  const baseByName = byName(base.models);
+  const headByName = byName(head.models);
+
+  const pairs: ModelPair[] = [];
+  const removed: ModelEntity[] = [];
+  const added: ModelEntity[] = [];
+
+  for (const [name, baseGroup] of baseByName) {
+    const headGroup = headByName.get(name);
+    if (!headGroup) {
+      removed.push(...baseGroup);
+      continue;
+    }
+
+    const baseLeft = [...baseGroup];
+    const headLeft = [...headGroup];
+
+    // Stage 1: exact file.
+    for (let i = baseLeft.length - 1; i >= 0; i--) {
+      const j = headLeft.findIndex((h) => h.file === baseLeft[i].file);
+      if (j >= 0) {
+        pairs.push({ base: baseLeft[i], head: headLeft[j], reason: 'exact', confidence: 1 });
+        baseLeft.splice(i, 1);
+        headLeft.splice(j, 1);
+      }
+    }
+
+    // Stage 2: single leftover on each side pairs unconditionally — the
+    // relocation case. With several candidates, greedy best field-set
+    // similarity above the floor.
+    if (baseLeft.length === 1 && headLeft.length === 1) {
+      pairs.push({ base: baseLeft[0], head: headLeft[0], reason: 'relocated', confidence: 1 });
+      baseLeft.length = 0;
+      headLeft.length = 0;
+    } else {
+      while (baseLeft.length > 0 && headLeft.length > 0) {
+        let best: { bi: number; hi: number; score: number } | null = null;
+        for (let bi = 0; bi < baseLeft.length; bi++) {
+          for (let hi = 0; hi < headLeft.length; hi++) {
+            const score = fieldSimilarity(baseLeft[bi], headLeft[hi]);
+            if (!best || score > best.score) best = { bi, hi, score };
+          }
+        }
+        if (!best || best.score < SIMILARITY_FLOOR) break;
+        pairs.push({
+          base: baseLeft[best.bi],
+          head: headLeft[best.hi],
+          reason: 'similarity',
+          confidence: best.score,
+        });
+        baseLeft.splice(best.bi, 1);
+        headLeft.splice(best.hi, 1);
+      }
+    }
+
+    removed.push(...baseLeft);
+    added.push(...headLeft);
+  }
+
+  for (const [name, headGroup] of headByName) {
+    if (!baseByName.has(name)) added.push(...headGroup);
+  }
+
+  return { pairs, removed, added };
+}
+
+/** The fixed drift taxonomy. Which classes BLOCK is gate posture
+ *  (`gate.ts`), not a property of the diff. */
+export type DriftClass =
+  | 'model-removed'
+  | 'model-added'
+  | 'field-removed'
+  | 'field-added'
+  | 'field-added-required'
+  | 'field-type-changed'
+  | 'field-required-added'
+  | 'field-optionality-relaxed';
+
+/** One detected change. `file`/`line` locate the HEAD side when it exists
+ *  (the base side for removals) — display metadata, never identity. */
+export interface SchemaDrift {
+  readonly changeClass: DriftClass;
+  readonly model: string;
+  readonly field: string | null;
+  /** Normalized before/after facts for the message (null = unknown/absent). */
+  readonly from: string | null;
+  readonly to: string | null;
+  readonly file: string;
+  readonly line: number;
+  /** Intrinsic confidence in [0, 1]: pair confidence, degraded when an
+   *  unknown participates. The gate blocks only at/above its threshold, so
+   *  an unknown-touching finding can warn but never block. */
+  readonly confidence: number;
+}
+
+/** Confidence for a comparison where one side's fact is unknown — below
+ *  every sane block threshold by construction. */
+const UNKNOWN_CONFIDENCE = 0.4;
+
+function fieldMap(e: ModelEntity): Map<string, ModelField> {
+  const m = new Map<string, ModelField>();
+  for (const f of e.fields) m.set(f.name, f);
+  return m;
+}
+
+/**
+ * THE drift diff — pure over two model sets. Base is the grandfather by
+ * construction: only differences between the two refs surface, so
+ * pre-existing state can never produce a finding.
+ */
+export function diffModelSets(base: ModelSet, head: ModelSet): SchemaDrift[] {
+  const { pairs, removed, added } = pairModels(base, head);
+  const out: SchemaDrift[] = [];
+
+  for (const e of removed) {
+    out.push({
+      changeClass: 'model-removed',
+      model: e.name,
+      field: null,
+      from: e.file,
+      to: null,
+      file: e.file,
+      line: e.line,
+      confidence: 1,
+    });
+  }
+  for (const e of added) {
+    out.push({
+      changeClass: 'model-added',
+      model: e.name,
+      field: null,
+      from: null,
+      to: e.file,
+      file: e.file,
+      line: e.line,
+      confidence: 1,
+    });
+  }
+
+  for (const pair of pairs) {
+    const baseFields = fieldMap(pair.base);
+    const headFields = fieldMap(pair.head);
+    const at = { file: pair.head.file, line: pair.head.line };
+
+    for (const [name, bf] of baseFields) {
+      const hf = headFields.get(name);
+      if (!hf) {
+        out.push({
+          changeClass: 'field-removed',
+          model: pair.base.name,
+          field: name,
+          from: bf.type,
+          to: null,
+          ...at,
+          confidence: pair.confidence,
+        });
+        continue;
+      }
+
+      // Type comparison. Both known and different → real drift at pair
+      // confidence. Exactly one side unknown → disclosed at UNKNOWN
+      // confidence (warns, never blocks): the visible fact changed, but we
+      // cannot prove the wire type did. Both unknown → nothing to compare.
+      if (bf.type !== hf.type) {
+        const bothKnown = bf.type !== null && hf.type !== null;
+        if (bothKnown || bf.type !== null || hf.type !== null) {
+          out.push({
+            changeClass: 'field-type-changed',
+            model: pair.base.name,
+            field: name,
+            from: bf.type,
+            to: hf.type,
+            ...at,
+            confidence: bothKnown ? pair.confidence : UNKNOWN_CONFIDENCE,
+          });
+        }
+      }
+
+      // Requiredness transitions only when both sides are known — an
+      // unknown-to-known transition is visibility, not drift.
+      if (bf.required !== null && hf.required !== null && bf.required !== hf.required) {
+        out.push({
+          changeClass: hf.required ? 'field-required-added' : 'field-optionality-relaxed',
+          model: pair.base.name,
+          field: name,
+          from: String(bf.required),
+          to: String(hf.required),
+          ...at,
+          confidence: pair.confidence,
+        });
+      }
+    }
+
+    for (const [name, hf] of headFields) {
+      if (baseFields.has(name)) continue;
+      out.push({
+        changeClass: hf.required === true ? 'field-added-required' : 'field-added',
+        model: pair.base.name,
+        field: name,
+        from: null,
+        to: hf.type,
+        ...at,
+        confidence: pair.confidence,
+      });
+    }
+  }
+
+  // Stable output: model, then field, then class — byte-stable renderings.
+  return out.sort(
+    (a, b) =>
+      a.model.localeCompare(b.model) ||
+      (a.field ?? '').localeCompare(b.field ?? '') ||
+      a.changeClass.localeCompare(b.changeClass),
+  );
+}

--- a/src/analyzers/model-schema/normalize.ts
+++ b/src/analyzers/model-schema/normalize.ts
@@ -36,7 +36,10 @@ function stripWhitespace(text: string): string {
  * absence of a wrapper says nothing (the field's baseline requiredness comes
  * from the grammar marker / descriptor keyword, not from here).
  */
-function foldTypeText(raw: string): { type: string; optional: boolean } {
+function foldTypeText(
+  raw: string,
+  wrappers?: readonly string[],
+): { type: string; optional: boolean } {
   let text = stripWhitespace(raw);
   let optional = false;
 
@@ -46,11 +49,19 @@ function foldTypeText(raw: string): { type: string; optional: boolean } {
     optional = true;
   }
 
-  // Optional[X] → X, optional (Python typing).
-  const optionalMatch = /^Optional\[(.+)\]$/.exec(text);
-  if (optionalMatch) {
-    text = optionalMatch[1];
-    optional = true;
+  // Pack-declared transparent wrappers + Optional[X], folded in a loop so
+  // nesting resolves in any order: so.Mapped[Optional[str]] → str, optional.
+  for (;;) {
+    const wrapper = /^(?:[A-Za-z_][\w.]*\.)?([A-Za-z_]\w*)\[(.+)\]$/.exec(text);
+    if (!wrapper) break;
+    if (wrapper[1] === 'Optional') {
+      text = wrapper[2];
+      optional = true;
+    } else if (wrappers?.includes(wrapper[1])) {
+      text = wrapper[2];
+    } else {
+      break;
+    }
   }
 
   // Union with a nullish member: X|null, None|X, X|null|undefined → X.
@@ -78,36 +89,46 @@ export function applyTypeAliases(
  * Normalize one field's raw facts into its canonical `{ type, required }`.
  *
  * Requiredness resolution, most-specific wins:
- *   1. an explicit descriptor signal (`nullable=True` read off a field
+ *   1. an EXPLICIT descriptor signal (`nullable=True` written on a field
  *      constructor) — `descriptorOptional`;
  *   2. an optionality wrapper folded from the type text (`Optional[X]`,
  *      `| null`, `*X`);
  *   3. the grammar-level marker (`?`, pointer type) — `markerOptional`;
- *   4. otherwise: required when the grammar HAS a marker concept
- *      (markerOptional === false means "marker absent" there), unknown
- *      (null) when it does not (markerOptional === null).
+ *   4. the framework DEFAULT for an absent keyword —
+ *      `descriptorDefaultOptional` (Django's null=False, weakest signal);
+ *   5. otherwise: required when a type is known, unknown (null) when not.
  */
 export function normalizeField(opts: {
   rawType: string | null;
   markerOptional: boolean | null;
   descriptorOptional?: boolean | null;
+  /** The framework default when the optionality keyword is ABSENT — ranks
+   *  below a folded annotation (SQLAlchemy 2.0 derives nullability from
+   *  `Mapped[Optional[X]]`), above bare type-presence. */
+  descriptorDefaultOptional?: boolean | null;
   typeAliases?: Readonly<Record<string, string>>;
+  typeWrappers?: readonly string[];
 }): NormalizedField {
   let type: string | null = null;
   let foldedOptional = false;
   if (opts.rawType !== null && opts.rawType !== '') {
-    const folded = foldTypeText(opts.rawType);
+    const folded = foldTypeText(opts.rawType, opts.typeWrappers);
     type = applyTypeAliases(folded.type, opts.typeAliases);
     foldedOptional = folded.optional;
   }
 
   let required: boolean | null;
   if (opts.descriptorOptional !== undefined && opts.descriptorOptional !== null) {
-    required = !opts.descriptorOptional;
+    required = !opts.descriptorOptional; // explicit kwarg — authoritative
   } else if (foldedOptional) {
-    required = false;
+    required = false; // the annotation said Optional/| null
   } else if (opts.markerOptional !== null) {
     required = !opts.markerOptional;
+  } else if (
+    opts.descriptorDefaultOptional !== undefined &&
+    opts.descriptorDefaultOptional !== null
+  ) {
+    required = !opts.descriptorDefaultOptional; // framework default (weakest signal)
   } else {
     required = type === null ? null : true;
   }

--- a/src/analyzers/model-schema/normalize.ts
+++ b/src/analyzers/model-schema/normalize.ts
@@ -1,0 +1,131 @@
+/**
+ * Model-schema normalization — the shared, identity-bearing canonicalizer
+ * for field types and optionality (mirror of `flow/normalize.ts` for paths
+ * and verbs). Treat changes here with the care of a fingerprint-scheme bump:
+ * a normalization change re-keys every committed allowlist decision that
+ * names a type.
+ *
+ * Deliberately LEXICAL: it canonicalizes spelling (whitespace, optionality
+ * wrappers, pack-declared aliases) and never attempts cross-language or
+ * resolved-type equivalence — `varchar(255)` and `string` stay distinct
+ * unless a pack aliases them, and a type alias's underlying change is a
+ * documented blind spot (resolving it would need a type-checker, which would
+ * break the gate's ref-reliability).
+ */
+
+/** A field's normalized shape facts. `null` = not determinable — and an
+ *  unknown NEVER blocks (the diff caps unknown-touching findings below the
+ *  block threshold). */
+export interface NormalizedField {
+  readonly type: string | null;
+  readonly required: boolean | null;
+}
+
+/** Optionality wrappers folded OUT of a type's text, each mapping to
+ *  "optional": TS/JS `| null` / `| undefined`, Python `Optional[X]` /
+ *  `X | None`, Go's pointer `*X`. Order-independent for unions. */
+const NULLISH_UNION_MEMBERS = new Set(['null', 'undefined', 'none']);
+
+function stripWhitespace(text: string): string {
+  return text.replace(/\s+/g, '');
+}
+
+/**
+ * Fold a raw type text into its canonical token + an optionality signal.
+ * Returns `optional: true` only when an optionality WRAPPER was folded;
+ * absence of a wrapper says nothing (the field's baseline requiredness comes
+ * from the grammar marker / descriptor keyword, not from here).
+ */
+function foldTypeText(raw: string): { type: string; optional: boolean } {
+  let text = stripWhitespace(raw);
+  let optional = false;
+
+  // Go pointer: *X → X, optional.
+  while (text.startsWith('*')) {
+    text = text.slice(1);
+    optional = true;
+  }
+
+  // Optional[X] → X, optional (Python typing).
+  const optionalMatch = /^Optional\[(.+)\]$/.exec(text);
+  if (optionalMatch) {
+    text = optionalMatch[1];
+    optional = true;
+  }
+
+  // Union with a nullish member: X|null, None|X, X|null|undefined → X.
+  if (text.includes('|')) {
+    const members = text.split('|');
+    const solid = members.filter((m) => !NULLISH_UNION_MEMBERS.has(m.toLowerCase()));
+    if (solid.length < members.length) {
+      optional = true;
+      text = solid.join('|');
+    }
+  }
+
+  return { type: text, optional };
+}
+
+/** Fold a type token through a pack's lexical aliases (keys lowercase). */
+export function applyTypeAliases(
+  type: string,
+  aliases: Readonly<Record<string, string>> | undefined,
+): string {
+  return aliases?.[type.toLowerCase()] ?? type;
+}
+
+/**
+ * Normalize one field's raw facts into its canonical `{ type, required }`.
+ *
+ * Requiredness resolution, most-specific wins:
+ *   1. an explicit descriptor signal (`nullable=True` read off a field
+ *      constructor) — `descriptorOptional`;
+ *   2. an optionality wrapper folded from the type text (`Optional[X]`,
+ *      `| null`, `*X`);
+ *   3. the grammar-level marker (`?`, pointer type) — `markerOptional`;
+ *   4. otherwise: required when the grammar HAS a marker concept
+ *      (markerOptional === false means "marker absent" there), unknown
+ *      (null) when it does not (markerOptional === null).
+ */
+export function normalizeField(opts: {
+  rawType: string | null;
+  markerOptional: boolean | null;
+  descriptorOptional?: boolean | null;
+  typeAliases?: Readonly<Record<string, string>>;
+}): NormalizedField {
+  let type: string | null = null;
+  let foldedOptional = false;
+  if (opts.rawType !== null && opts.rawType !== '') {
+    const folded = foldTypeText(opts.rawType);
+    type = applyTypeAliases(folded.type, opts.typeAliases);
+    foldedOptional = folded.optional;
+  }
+
+  let required: boolean | null;
+  if (opts.descriptorOptional !== undefined && opts.descriptorOptional !== null) {
+    required = !opts.descriptorOptional;
+  } else if (foldedOptional) {
+    required = false;
+  } else if (opts.markerOptional !== null) {
+    required = !opts.markerOptional;
+  } else {
+    required = type === null ? null : true;
+  }
+
+  return { type, required };
+}
+
+/** The wire field name carried by a Go-style struct tag for `key`
+ *  (`json:"email,omitempty"` → `email`), plus its omitempty optionality.
+ *  Null when the tag has no entry for the key or excludes the field (`-`). */
+export function tagWireName(
+  tag: string,
+  key: string,
+): { name: string; optional: boolean } | null {
+  const m = new RegExp(`\\b${key}:"([^"]*)"`).exec(tag);
+  if (!m) return null;
+  const parts = m[1].split(',');
+  const name = parts[0];
+  if (name === '' || name === '-') return null;
+  return { name, optional: parts.includes('omitempty') };
+}

--- a/src/analyzers/model-schema/normalize.ts
+++ b/src/analyzers/model-schema/normalize.ts
@@ -118,10 +118,7 @@ export function normalizeField(opts: {
 /** The wire field name carried by a Go-style struct tag for `key`
  *  (`json:"email,omitempty"` → `email`), plus its omitempty optionality.
  *  Null when the tag has no entry for the key or excludes the field (`-`). */
-export function tagWireName(
-  tag: string,
-  key: string,
-): { name: string; optional: boolean } | null {
+export function tagWireName(tag: string, key: string): { name: string; optional: boolean } | null {
   const m = new RegExp(`\\b${key}:"([^"]*)"`).exec(tag);
   if (!m) return null;
   const parts = m[1].split(',');

--- a/src/analyzers/model-schema/spec-source.ts
+++ b/src/analyzers/model-schema/spec-source.ts
@@ -1,0 +1,104 @@
+/**
+ * Spec-declared models — consume an OpenAPI document's `components.schemas`
+ * (3.x) / `definitions` (2.0), or a bare JSON Schema file, as declared data
+ * models. The language-independent bridge (mirror of flow's
+ * `spec-source.ts`): any repo in any language that carries a spec is
+ * gateable with zero pack extraction, and it is the documented answer for
+ * unmarked DTOs that marker-based code recognition cannot see.
+ *
+ * Output is the same `ModelEntity` shape the AST extractor produces
+ * (`via: 'spec'`), so the join and diff are indifferent to where a model
+ * came from. Type tokens are the spec's own lexical vocabulary (`string`,
+ * `integer`, a `$ref` target's name, `X[]` for arrays) — comparison stays
+ * within the spec's language, per the normalizer's lexical doctrine.
+ *
+ * JSON documents today (YAML is the same fast-follow decision flow has).
+ * Pure over its inputs; the file read is the only I/O. Fail-open: an
+ * unreadable or non-schema file yields `[]`, never a throw.
+ */
+
+import { readFileSync } from 'fs';
+import type { ModelEntity, ModelField } from './model';
+
+type JsonObject = Record<string, unknown>;
+
+function isObject(v: unknown): v is JsonObject {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** The lexical type token of one property schema: `$ref` tail > `type`
+ *  (arrays as `items[]`), else null (an untyped/complex property is an
+ *  honest unknown — the diff's null rules apply to spec models too). */
+function propertyType(prop: unknown): string | null {
+  if (!isObject(prop)) return null;
+  const ref = prop.$ref;
+  if (typeof ref === 'string') {
+    const tail = ref.split('/').pop();
+    return tail && tail.length > 0 ? tail : null;
+  }
+  const type = prop.type;
+  if (type === 'array') {
+    const inner = propertyType(prop.items);
+    return inner ? `${inner}[]` : 'array';
+  }
+  return typeof type === 'string' ? type : null;
+}
+
+/** One named schema object → a ModelEntity, or null when it declares no
+ *  object shape we can field-diff (enums, primitives, allOf compositions —
+ *  documented spec-bridge limits, not errors). */
+function schemaToModel(name: string, schema: unknown, file: string): ModelEntity | null {
+  if (!isObject(schema)) return null;
+  const properties = schema.properties;
+  if (!isObject(properties)) return null;
+  const requiredList = Array.isArray(schema.required)
+    ? new Set(schema.required.filter((r): r is string => typeof r === 'string'))
+    : new Set<string>();
+
+  const fields: ModelField[] = Object.entries(properties).map(([propName, prop]) => ({
+    name: propName,
+    type: propertyType(prop),
+    required: requiredList.has(propName),
+  }));
+  return { name, via: 'spec', file, line: 0, fields };
+}
+
+/**
+ * Models from a parsed document. Recognized containers, in order:
+ * OpenAPI 3.x `components.schemas`, Swagger 2.0 `definitions`, JSON Schema
+ * `$defs` / `definitions`, and finally a single root-level schema (a bare
+ * JSON Schema file with `title` + `properties`).
+ */
+export function modelsFromSpec(doc: unknown, file: string): ModelEntity[] {
+  if (!isObject(doc)) return [];
+  const containers: unknown[] = [
+    isObject(doc.components) ? doc.components.schemas : undefined,
+    doc.definitions,
+    doc.$defs,
+  ];
+  const out: ModelEntity[] = [];
+  for (const container of containers) {
+    if (!isObject(container)) continue;
+    for (const [name, schema] of Object.entries(container)) {
+      const model = schemaToModel(name, schema, file);
+      if (model) out.push(model);
+    }
+  }
+  if (out.length === 0 && typeof doc.title === 'string') {
+    const root = schemaToModel(doc.title, doc, file);
+    if (root) out.push(root);
+  }
+  return out;
+}
+
+/** Read + parse a JSON spec into models. `[]` (never throws) when the file
+ *  is unreadable or not a recognizable schema document. */
+export function loadSpecModels(filePath: string): ModelEntity[] {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return [];
+  }
+  return modelsFromSpec(doc, filePath);
+}

--- a/src/analyzers/tools/fingerprint.ts
+++ b/src/analyzers/tools/fingerprint.ts
@@ -382,6 +382,47 @@ export function computeFlowBindingFingerprint(method: string, path: string, file
   return computeContentFingerprint(FLOW_BINDING_CANONICAL_RULE, file, `${method} ${path}`);
 }
 
+// ─── Model-schema-drift identity (the drift gate, Rule 9) ─────────────────────
+
+/**
+ * Tool-independent canonical rule for a schema-drift finding. Every drift
+ * shares this constant (like secrets and flow bindings) because the finding
+ * is intrinsic ("this field of this model changed in this way"), never a
+ * per-tool classification.
+ */
+export const MODEL_SCHEMA_DRIFT_CANONICAL_RULE = 'canonical:model-schema-drift';
+
+/**
+ * Durable identity for a schema-drift finding. A model is a CONTRACT-domain
+ * entity — its name is its address, the file is where it happens to live
+ * today — so identity follows the dep-vuln precedent (`(package, advisory)`,
+ * no file) rather than the code-finding one: it is LOCATION-FREE by
+ * construction, hashing only `(model, fieldPath, changeClass)`. The finding
+ * survives line AND file moves with no matching machinery, and a follow-up
+ * commit adjusting the same field cannot dodge an allowlist decision (the
+ * before/after values are display metadata, never hashed).
+ *
+ * Disclosed trade-off (design review): two same-named models in different
+ * modules whose same-named field undergoes the same change class in one PR
+ * share an identity, so one allowlist entry suppresses both — vanishingly
+ * rare, visible in the PR comment's suppressed section, and the
+ * accepted-risk decision plausibly covers both. All inputs are
+ * dxkit-normalized (Rule 9): the model NAME from dxkit's own AST/spec read,
+ * the field name, and the fixed taxonomy class — never a type-checker's
+ * rendered text.
+ */
+export function computeModelSchemaDriftFingerprint(
+  model: string,
+  field: string | null,
+  changeClass: string,
+): string {
+  return computeContentFingerprint(
+    MODEL_SCHEMA_DRIFT_CANONICAL_RULE,
+    '',
+    `${model}\0${field ?? ''}\0${changeClass}`,
+  );
+}
+
 // ─── Secret HMAC primitive ───────────────────────────────────────────────────
 
 /**

--- a/src/ast/grammar-model-shape.ts
+++ b/src/ast/grammar-model-shape.ts
@@ -148,11 +148,14 @@ const JS_FAMILY: GrammarModelShape = {
   },
 
   fieldOptionalMarker(field) {
-    // The optional `?` is an anonymous token between name and annotation.
+    // Three-valued (the honesty contract): a `?` token → optional; a type
+    // annotation WITHOUT `?` → required (TS semantics); no annotation at all
+    // (plain JS, or an inferred field) → null — the grammar genuinely cannot
+    // tell, and a fabricated `required` would let the diff block on it.
     for (const c of field.children) {
       if (c && !c.isNamed && c.type === '?') return true;
     }
-    return false;
+    return field.childForFieldName('type') !== null ? false : null;
   },
 
   fieldTag() {

--- a/src/ast/grammar-model-shape.ts
+++ b/src/ast/grammar-model-shape.ts
@@ -1,0 +1,313 @@
+/**
+ * Grammar MODEL shapes — the per-grammar syntax-access layer for data-model
+ * declarations, sibling of `grammar-shape.ts` (which covers call/decorator/
+ * string syntax for the flow extractor).
+ *
+ * Different grammars express "a named type with fields" differently:
+ * TypeScript has `class_declaration` / `public_field_definition` (with the
+ * export-statement decorator quirk), Python has `class_definition` with
+ * `assignment` statements in the body (and `decorated_definition` wrapping),
+ * Go has `type_spec` + `struct_type` + `field_declaration` (with tags and
+ * multi-name declarations). Those are facts about the GRAMMAR ARTIFACT — not
+ * about a pack's frameworks (which live in `LanguageSupport.modelSchema`) and
+ * not about drift semantics (which live in `src/analyzers/model-schema/`).
+ *
+ * The division of labor mirrors flow's:
+ *   - `src/languages/<id>.ts:modelSchema`      — WHICH constructs are models
+ *     (framework facts: base classes, decorators, tag keys — per pack);
+ *   - THIS module                               — HOW to read a class / field /
+ *     type annotation / heritage / tag from this grammar (syntax, per grammar);
+ *   - `src/analyzers/model-schema/extract.ts`   — WHAT they mean (semantics,
+ *     grammar-agnostic, edited for no one language).
+ *
+ * Every function is total over arbitrary nodes (returns null / empty rather
+ * than throwing) so the extractor stays fail-open. Rows are added with their
+ * language wave, each verified against the bundled wasm artifact — an
+ * unverified row is worse than a missing one.
+ */
+
+import type { Node } from './parse';
+
+/** How to read one grammar's model-declaration syntax. */
+export interface GrammarModelShape {
+  /** Node types that can declare a named, field-bearing type. */
+  readonly classNodes: readonly string[];
+  /** The declared name, or null when this node is not a model-bearing
+   *  declaration in this grammar (a Go `type_spec` aliasing a non-struct). */
+  className(node: Node): string | null;
+  /** Heritage expressions as verbatim identifier-path texts (`models.Model`,
+   *  `BaseEntity`). Empty when the grammar/node has none. */
+  heritage(node: Node): string[];
+  /** Decorator nodes attached to this class — encapsulates per-grammar
+   *  attachment quirks (TS hoists decorators of an exported class onto the
+   *  `export_statement`; Python wraps in `decorated_definition`). */
+  classDecorators(node: Node): Node[];
+  /** Field/property declarations in the class body, in source order. */
+  fieldNodes(classNode: Node): Node[];
+  /** Declared names of one field node — plural because Go allows
+   *  `X, Y int` in a single declaration. Empty for unnamed (embedded) fields. */
+  fieldNames(field: Node): string[];
+  /** Verbatim text of the field's declared type, or null when absent. */
+  fieldTypeText(field: Node): string | null;
+  /**
+   * Grammar-level optionality marker ONLY: the TS `?` token, a Go pointer
+   * type. Lexical forms (`| null`, `Optional[...]`, `| None`) fold in the
+   * shared normalizer, and framework forms (`nullable=True`) come from the
+   * pack descriptor. Null when this grammar has no such marker.
+   */
+  fieldOptionalMarker(field: Node): boolean | null;
+  /** The field's struct tag text (Go), verbatim including backticks. */
+  fieldTag(field: Node): string | null;
+  /** The call node initializing this field (`Column(...)`,
+   *  `models.CharField(...)`), for descriptor `fieldCallees` resolution. */
+  fieldValueCall(field: Node): Node | null;
+  /** Decorator nodes attached to this field (`@Column(...)`). */
+  fieldDecorators(field: Node): Node[];
+}
+
+/** Children of `node` occupying grammar field `field`, cursor-collected
+ *  (works for repeated fields, which `childForFieldName` truncates). */
+function childrenForField(node: Node, field: string): Node[] {
+  const out: Node[] = [];
+  const cursor = node.walk();
+  if (cursor.gotoFirstChild()) {
+    do {
+      const n = cursor.currentNode;
+      if (n && n.isNamed && cursor.currentFieldName === field) out.push(n);
+    } while (cursor.gotoNextSibling());
+  }
+  return out;
+}
+
+function namedChildrenOfType(node: Node, type: string): Node[] {
+  const out: Node[] = [];
+  for (const c of node.namedChildren) if (c && c.type === type) out.push(c);
+  return out;
+}
+
+// ─── Shape rows ──────────────────────────────────────────────────────────────
+
+/** TS / TSX / JS share one shape. JS classes have no type annotations or
+ *  `?` markers — those reads return null/false there, which is correct:
+ *  a JS model's facts come from decorators and the normalizer's unknowns. */
+const JS_FAMILY: GrammarModelShape = {
+  classNodes: ['class_declaration'],
+
+  className(node) {
+    return node.childForFieldName('name')?.text ?? null;
+  },
+
+  heritage(node) {
+    // class_heritage is a plain named child (not a field): it wraps
+    // extends_clause (field `value`) and optionally implements_clause.
+    const out: string[] = [];
+    for (const h of namedChildrenOfType(node, 'class_heritage')) {
+      for (const ext of namedChildrenOfType(h, 'extends_clause')) {
+        const v = ext.childForFieldName('value');
+        if (v) out.push(v.text);
+      }
+    }
+    return out;
+  },
+
+  classDecorators(node) {
+    // Decorators of `export class` hoist onto the export_statement. Collected
+    // by node TYPE (not grammar field) — TS attaches them as `decorator`
+    // fields, plain JS as bare children; type-matching covers both.
+    const own = namedChildrenOfType(node, 'decorator');
+    const parent = node.parent;
+    if (parent && parent.type === 'export_statement') {
+      return [...namedChildrenOfType(parent, 'decorator'), ...own];
+    }
+    return own;
+  },
+
+  fieldNodes(classNode) {
+    // TS names the node public_field_definition; plain JS names it
+    // field_definition (verified against both wasms).
+    const body = classNode.childForFieldName('body');
+    if (!body) return [];
+    return [
+      ...namedChildrenOfType(body, 'public_field_definition'),
+      ...namedChildrenOfType(body, 'field_definition'),
+    ];
+  },
+
+  fieldNames(field) {
+    // TS field: `name`; JS field_definition: `property`.
+    const name = field.childForFieldName('name') ?? field.childForFieldName('property');
+    return name ? [name.text] : [];
+  },
+
+  fieldTypeText(field) {
+    // type_annotation's text includes the leading ':'; the named child is the
+    // type itself.
+    const ann = field.childForFieldName('type');
+    const inner = ann?.namedChildren.find((c) => c !== null);
+    return inner?.text ?? null;
+  },
+
+  fieldOptionalMarker(field) {
+    // The optional `?` is an anonymous token between name and annotation.
+    for (const c of field.children) {
+      if (c && !c.isNamed && c.type === '?') return true;
+    }
+    return false;
+  },
+
+  fieldTag() {
+    return null;
+  },
+
+  fieldValueCall(field) {
+    const value = field.childForFieldName('value');
+    return value && value.type === 'call_expression' ? value : null;
+  },
+
+  fieldDecorators(field) {
+    return namedChildrenOfType(field, 'decorator');
+  },
+};
+
+const PYTHON: GrammarModelShape = {
+  classNodes: ['class_definition'],
+
+  className(node) {
+    return node.childForFieldName('name')?.text ?? null;
+  },
+
+  heritage(node) {
+    // superclasses is an argument_list; skip keyword arguments (metaclass=…).
+    const sup = node.childForFieldName('superclasses');
+    if (!sup) return [];
+    const out: string[] = [];
+    for (const c of sup.namedChildren) {
+      if (c && c.type !== 'keyword_argument') out.push(c.text);
+    }
+    return out;
+  },
+
+  classDecorators(node) {
+    // @decorated classes are wrapped: decorated_definition > decorator*,
+    // [definition] class_definition.
+    const parent = node.parent;
+    if (parent && parent.type === 'decorated_definition') {
+      return namedChildrenOfType(parent, 'decorator');
+    }
+    return [];
+  },
+
+  fieldNodes(classNode) {
+    // Class-level fields are `assignment` nodes directly under the body block
+    // (inside expression_statement wrappers). Method bodies are nested deeper
+    // and never direct children, so they are naturally excluded.
+    const body = classNode.childForFieldName('body');
+    if (!body) return [];
+    const out: Node[] = [];
+    for (const stmt of namedChildrenOfType(body, 'expression_statement')) {
+      for (const a of namedChildrenOfType(stmt, 'assignment')) out.push(a);
+    }
+    return out;
+  },
+
+  fieldNames(field) {
+    const left = field.childForFieldName('left');
+    return left && left.type === 'identifier' ? [left.text] : [];
+  },
+
+  fieldTypeText(field) {
+    return field.childForFieldName('type')?.text ?? null;
+  },
+
+  fieldOptionalMarker() {
+    // Python has no grammar-level marker; `Optional[…]` / `| None` are
+    // lexical forms the normalizer folds, `null=True` is a framework fact.
+    return null;
+  },
+
+  fieldTag() {
+    return null;
+  },
+
+  fieldValueCall(field) {
+    const right = field.childForFieldName('right');
+    return right && right.type === 'call' ? right : null;
+  },
+
+  fieldDecorators() {
+    return [];
+  },
+};
+
+const GO: GrammarModelShape = {
+  classNodes: ['type_spec'],
+
+  className(node) {
+    // Only struct-typed specs declare fields; aliases and non-struct types
+    // are not model-bearing.
+    if (node.childForFieldName('type')?.type !== 'struct_type') return null;
+    return node.childForFieldName('name')?.text ?? null;
+  },
+
+  heritage() {
+    return [];
+  },
+
+  classDecorators() {
+    return [];
+  },
+
+  fieldNodes(classNode) {
+    const struct = classNode.childForFieldName('type');
+    if (!struct || struct.type !== 'struct_type') return [];
+    const list = namedChildrenOfType(struct, 'field_declaration_list')[0];
+    if (!list) return [];
+    return namedChildrenOfType(list, 'field_declaration');
+  },
+
+  fieldNames(field) {
+    // `X, Y int` declares several names in one field_declaration; an
+    // embedded field has none and is skipped by the caller.
+    return childrenForField(field, 'name').map((n) => n.text);
+  },
+
+  fieldTypeText(field) {
+    return field.childForFieldName('type')?.text ?? null;
+  },
+
+  fieldOptionalMarker(field) {
+    return field.childForFieldName('type')?.type === 'pointer_type';
+  },
+
+  fieldTag(field) {
+    return field.childForFieldName('tag')?.text ?? null;
+  },
+
+  fieldValueCall() {
+    return null;
+  },
+
+  fieldDecorators() {
+    return [];
+  },
+};
+
+const MODEL_SHAPES: Readonly<Record<string, GrammarModelShape>> = {
+  typescript: JS_FAMILY,
+  tsx: JS_FAMILY,
+  javascript: JS_FAMILY,
+  python: PYTHON,
+  go: GO,
+};
+
+/** The model shape for a logical grammar name, or null when no row exists —
+ *  callers treat null as "this grammar's files cannot contribute models" and
+ *  skip, never throw. */
+export function modelShapeForGrammar(grammar: string): GrammarModelShape | null {
+  return MODEL_SHAPES[grammar] ?? null;
+}
+
+/** Grammar names with a model-shape row (pack-contract completeness test). */
+export function modelShapedGrammars(): string[] {
+  return Object.keys(MODEL_SHAPES);
+}

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -31,6 +31,8 @@ import type { BrownfieldPolicy } from './policy';
 import type { FindingStatus, MatchReason } from './types';
 import { describeBrokenIntegration } from '../analyzers/flow/gate';
 import type { FlowGateOutcome } from './flow-gate-check';
+import { describeSchemaDrift } from '../analyzers/model-schema/gate';
+import type { SchemaDriftGateOutcome } from './schema-drift-gate-check';
 
 // ─── Shared verdict predicates ────────────────────────────────────────────
 
@@ -70,14 +72,29 @@ export interface VerdictCounts {
   readonly warning: number;
   readonly resolved: number;
 }
+/** Active findings of the ADDITIVE gates (flow + schema drift) tallied by
+ *  verdict — the one counting path every surface (verdict banner, summary
+ *  sentence, cached verdict counts) folds gate findings through, so a second
+ *  gate cannot re-introduce the "one report, two stories" divergence flow
+ *  once threaded by hand. Schema `info` findings are disclosure-only and
+ *  never counted. */
+function extraGateTallies(result: GuardrailCheckResult): { block: number; warn: number } {
+  const findings = [
+    ...(result.flowGate?.findings ?? []),
+    ...(result.schemaDriftGate?.findings ?? []),
+  ];
+  return {
+    block: findings.filter((f) => f.verdict === 'block').length,
+    warn: findings.filter((f) => f.verdict === 'warn').length,
+  };
+}
+
 export function verdictCounts(result: GuardrailCheckResult): VerdictCounts {
-  const flow = result.flowGate?.findings ?? [];
+  const extra = extraGateTallies(result);
   return {
     verdict: result.blocks ? 'BLOCKED' : result.warns ? 'PASSED (with warnings)' : 'PASSED',
-    blocking:
-      result.pairs.filter(isBlocking).length + flow.filter((f) => f.verdict === 'block').length,
-    warning:
-      result.pairs.filter(isWarning).length + flow.filter((f) => f.verdict === 'warn').length,
+    blocking: result.pairs.filter(isBlocking).length + extra.block,
+    warning: result.pairs.filter(isWarning).length + extra.warn,
     resolved: result.pairs.filter((p) => p.classification.status === 'removed').length,
   };
 }
@@ -176,6 +193,7 @@ export function renderConsole(result: GuardrailCheckResult): string {
   }
 
   lines.push(...formatFlowGate(result.flowGate));
+  lines.push(...formatSchemaDriftGate(result.schemaDriftGate));
 
   // Always show a summary footer — sets expectations for what
   // happens next (exit code, what to read on a fail).
@@ -198,6 +216,18 @@ export function renderConsole(result: GuardrailCheckResult): string {
     lines.push(
       `  Flow:        ${flowFindings.length + flowSuppressed.length} ` +
         `(blocking: ${fBlock}, warning: ${fWarn}, suppressed: ${flowSuppressed.length})`,
+    );
+  }
+  // Same reconciliation line for the schema drift gate.
+  const schemaFindings = result.schemaDriftGate?.findings ?? [];
+  const schemaSuppressed = result.schemaDriftGate?.suppressed ?? [];
+  if (schemaFindings.length > 0 || schemaSuppressed.length > 0) {
+    const sBlock = schemaFindings.filter((f) => f.verdict === 'block').length;
+    const sWarn = schemaFindings.filter((f) => f.verdict === 'warn').length;
+    const sInfo = schemaFindings.filter((f) => f.verdict === 'info').length;
+    lines.push(
+      `  Schema:      ${schemaFindings.length + schemaSuppressed.length} ` +
+        `(blocking: ${sBlock}, warning: ${sWarn}, info: ${sInfo}, suppressed: ${schemaSuppressed.length})`,
     );
   }
   lines.push(
@@ -292,16 +322,71 @@ function flowFingerprintLine(id: string): string {
   );
 }
 
+/**
+ * Console lines for the model-schema drift gate. Silent unless the gate
+ * produced findings. Blocking drift first, then warnings, then the
+ * disclosure-only info class (additions/relaxations), then suppressions.
+ */
+function formatSchemaDriftGate(gate: SchemaDriftGateOutcome | undefined): string[] {
+  if (!gate) return [];
+  const suppressed = gate.suppressed ?? [];
+  if (gate.findings.length === 0 && suppressed.length === 0) return [];
+  const out: string[] = [];
+  const blocking = gate.findings.filter((f) => f.verdict === 'block');
+  const warning = gate.findings.filter((f) => f.verdict === 'warn');
+  const info = gate.findings.filter((f) => f.verdict === 'info');
+  if (blocking.length > 0) {
+    out.push(logger.bold(`Schema drift — blocking (${blocking.length})`));
+    for (const f of blocking) {
+      out.push(`  ${describeSchemaDrift(f)}`);
+      out.push(schemaFingerprintLine(f.id));
+    }
+    out.push('');
+  }
+  if (warning.length > 0) {
+    out.push(logger.bold(`Schema drift — warning (${warning.length})`));
+    for (const f of warning) {
+      out.push(`  ${describeSchemaDrift(f)}`);
+      out.push(schemaFingerprintLine(f.id));
+    }
+    out.push('');
+  }
+  if (info.length > 0) {
+    out.push(logger.bold(`Schema drift — informational (${info.length})`));
+    for (const f of info) out.push(`  ${describeSchemaDrift(f)}`);
+    out.push('');
+  }
+  if (suppressed.length > 0) {
+    out.push(logger.bold(`Schema drift — suppressed by allowlist (${suppressed.length})`));
+    for (const s of suppressed) {
+      const exp = s.expiresAt ? `, expires ${s.expiresAt}` : '';
+      out.push(`  ${describeSchemaDrift(s.finding)}`);
+      out.push(`    · allowlisted: ${s.category}${exp} (waived from the verdict)`);
+    }
+    out.push('');
+  }
+  return out;
+}
+
+/** The drift fingerprint line + the concrete accept command. The documented
+ *  escape hatch for a DELIBERATE breaking change is accepted-risk (ideally
+ *  with an expiry), so the hint spells that category — contrast flow's
+ *  false-positive default. */
+function schemaFingerprintLine(id: string): string {
+  return (
+    `    · fingerprint: ${id}  (accept if intentional: allowlist add ` +
+    `--fingerprint=${id} --kind=model-schema-drift --category=accepted-risk --reason="<why>")`
+  );
+}
+
 function verdictBanner(result: GuardrailCheckResult): string {
-  const flow = result.flowGate?.findings ?? [];
+  const extra = extraGateTallies(result);
   if (result.blocks) {
-    const count =
-      result.pairs.filter(isBlocking).length + flow.filter((f) => f.verdict === 'block').length;
+    const count = result.pairs.filter(isBlocking).length + extra.block;
     return logger.bold(`Guardrail BLOCKED — ${count} new regression${count === 1 ? '' : 's'}`);
   }
   if (result.warns) {
-    const count =
-      result.pairs.filter(isWarning).length + flow.filter((f) => f.verdict === 'warn').length;
+    const count = result.pairs.filter(isWarning).length + extra.warn;
     return logger.bold(`Guardrail PASSED — ${count} warning${count === 1 ? '' : 's'}`);
   }
   return logger.bold('Guardrail PASSED');
@@ -532,6 +617,38 @@ export interface GuardrailJsonPayload {
       readonly expiresAt?: string;
     }>;
   };
+  /** The model-schema drift gate — net-new breaking model changes from the
+   *  base↔HEAD diff. Absent when the gate is off (the default) or no base
+   *  commit was resolvable. `info` findings are disclosure-only. */
+  readonly schemaDriftGate?: {
+    readonly ran: boolean;
+    readonly skipped?: string;
+    readonly mode: string;
+    readonly blocks: boolean;
+    readonly warns: boolean;
+    readonly findings: ReadonlyArray<{
+      readonly id: string;
+      readonly changeClass: string;
+      readonly model: string;
+      readonly field: string | null;
+      readonly from: string | null;
+      readonly to: string | null;
+      readonly file: string;
+      readonly line: number;
+      readonly confidence: number;
+      readonly verdict: 'block' | 'warn' | 'info';
+    }>;
+    readonly suppressed: ReadonlyArray<{
+      readonly id: string;
+      readonly changeClass: string;
+      readonly model: string;
+      readonly field: string | null;
+      readonly file: string;
+      readonly line: number;
+      readonly category: string;
+      readonly expiresAt?: string;
+    }>;
+  };
 }
 
 export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
@@ -645,6 +762,41 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
           },
         }
       : {}),
+    ...(result.schemaDriftGate !== undefined
+      ? {
+          schemaDriftGate: {
+            ran: result.schemaDriftGate.ran,
+            ...(result.schemaDriftGate.skipped !== undefined
+              ? { skipped: result.schemaDriftGate.skipped }
+              : {}),
+            mode: result.schemaDriftGate.mode,
+            blocks: result.schemaDriftGate.blocks,
+            warns: result.schemaDriftGate.warns,
+            findings: result.schemaDriftGate.findings.map((f) => ({
+              id: f.id,
+              changeClass: f.changeClass,
+              model: f.model,
+              field: f.field,
+              from: f.from,
+              to: f.to,
+              file: f.file,
+              line: f.line,
+              confidence: f.confidence,
+              verdict: f.verdict,
+            })),
+            suppressed: (result.schemaDriftGate.suppressed ?? []).map((s) => ({
+              id: s.finding.id,
+              changeClass: s.finding.changeClass,
+              model: s.finding.model,
+              field: s.finding.field,
+              file: s.finding.file,
+              line: s.finding.line,
+              category: s.category,
+              ...(s.expiresAt !== undefined ? { expiresAt: s.expiresAt } : {}),
+            })),
+          },
+        }
+      : {}),
   };
 }
 
@@ -671,14 +823,12 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
   const verdict = result.blocks ? 'BLOCKED' : result.warns ? 'PASSED (with warnings)' : 'PASSED';
   lines.push(`## Guardrail: ${verdict}`);
   lines.push('');
-  const flow = result.flowGate?.findings ?? [];
-  const flowBlocking = flow.filter((f) => f.verdict === 'block').length;
-  const flowWarning = flow.filter((f) => f.verdict === 'warn').length;
+  const extra = extraGateTallies(result);
   lines.push(
     summarySentence(
       result,
-      blocking.length + flowBlocking,
-      warning.length + flowWarning,
+      blocking.length + extra.block,
+      warning.length + extra.warn,
       resolved.length,
     ),
   );
@@ -714,6 +864,7 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
   }
 
   lines.push(...markdownFlowGate(result.flowGate));
+  lines.push(...markdownSchemaDriftGate(result.schemaDriftGate));
 
   if (suppressed.length > 0) {
     lines.push('<details>');
@@ -839,6 +990,85 @@ function markdownFlowGate(flow: FlowGateOutcome | undefined): string[] {
       const f = s.finding;
       out.push(
         `| ${escapeMd(`${f.method} ${f.path}`)} | ${escapeMd(f.reason)} | ` +
+          `${escapeMd(`${f.file}:${f.line}`)} | ${escapeMd(s.category)} | ` +
+          `${escapeMd(s.expiresAt ?? '—')} |`,
+      );
+    }
+    out.push('');
+    out.push('</details>');
+    out.push('');
+  }
+  return out;
+}
+
+/**
+ * Markdown for the model-schema drift gate. Blocking drift renders as a
+ * top-level table (it fails the PR); warnings and the disclosure-only info
+ * class collapse into `<details>`. Silent when the gate produced nothing.
+ */
+function markdownSchemaDriftGate(gate: SchemaDriftGateOutcome | undefined): string[] {
+  if (!gate) return [];
+  const suppressed = gate.suppressed ?? [];
+  if (gate.findings.length === 0 && suppressed.length === 0) return [];
+  const out: string[] = [];
+  const blocking = gate.findings.filter((f) => f.verdict === 'block');
+  const warning = gate.findings.filter((f) => f.verdict === 'warn');
+  const info = gate.findings.filter((f) => f.verdict === 'info');
+  const subject = (f: { model: string; field: string | null }): string =>
+    f.field ? `${f.model}.${f.field}` : f.model;
+  const row = (f: SchemaDriftGateOutcome['findings'][number]): string =>
+    `| ${escapeMd(subject(f))} | ${escapeMd(f.changeClass)} | ` +
+    `${escapeMd(f.from ?? '—')} → ${escapeMd(f.to ?? '—')} | ` +
+    `${escapeMd(`${f.file}:${f.line}`)} | ${f.confidence.toFixed(2)} | \`${escapeMd(f.id)}\` |`;
+  const header = [
+    '| Model / field | Change | From → To | Location | Confidence | Fingerprint |',
+    '|---|---|---|---|---|---|',
+  ];
+  if (blocking.length > 0) {
+    out.push('### Breaking schema drift');
+    out.push('');
+    out.push(...header);
+    for (const f of blocking) out.push(row(f));
+    out.push('');
+    out.push(
+      '_A deliberate breaking change ships with its migration and an expiring ' +
+        '`accepted-risk` allowlist entry (`allowlist add --fingerprint=<id> ' +
+        '--kind=model-schema-drift --category=accepted-risk`)._',
+    );
+    out.push('');
+  }
+  if (warning.length > 0) {
+    out.push('<details>');
+    out.push(`<summary>Schema drift warnings (${warning.length})</summary>`);
+    out.push('');
+    out.push(...header);
+    for (const f of warning) out.push(row(f));
+    out.push('');
+    out.push('</details>');
+    out.push('');
+  }
+  if (info.length > 0) {
+    out.push('<details>');
+    out.push(`<summary>Schema changes (informational, ${info.length})</summary>`);
+    out.push('');
+    out.push(...header);
+    for (const f of info) out.push(row(f));
+    out.push('');
+    out.push('</details>');
+    out.push('');
+  }
+  if (suppressed.length > 0) {
+    out.push('<details>');
+    out.push(`<summary>Schema drift suppressed by allowlist (${suppressed.length})</summary>`);
+    out.push('');
+    out.push('These would block/warn, but an active allowlist entry accepted them.');
+    out.push('');
+    out.push('| Model / field | Change | Location | Category | Expires |');
+    out.push('|---|---|---|---|---|');
+    for (const s of suppressed) {
+      const f = s.finding;
+      out.push(
+        `| ${escapeMd(subject(f))} | ${escapeMd(f.changeClass)} | ` +
           `${escapeMd(`${f.file}:${f.line}`)} | ${escapeMd(s.category)} | ` +
           `${escapeMd(s.expiresAt ?? '—')} |`,
       );

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -67,6 +67,9 @@ import { computeChangedFiles } from './changed-files';
 import { changedFilesTouchDependencyManifest, detectActiveLanguages } from '../languages';
 import { evaluateFlowGateForGuardrail } from './flow-gate-check';
 import type { FlowGateOutcome } from './flow-gate-check';
+import { evaluateSchemaDriftGateForGuardrail } from './schema-drift-gate-check';
+import type { SchemaDriftGateOutcome } from './schema-drift-gate-check';
+import type { SchemaGateMode } from '../analyzers/model-schema/config';
 import type { FlowGateMode } from '../analyzers/flow/config';
 import { isSanitized } from './sanitize';
 import type { BaselineEntry, FindingId, FindingSeverity, MatchPair, MatchResult } from './types';
@@ -170,6 +173,13 @@ export interface RunGuardrailCheckOptions {
    * regardless.
    */
   readonly flowMode?: FlowGateMode;
+  /**
+   * Loop-seam override for the model-schema drift gate's posture, mirroring
+   * `flowMode` with one difference: schema defaults to OFF (opt-in), so the
+   * override softens/hardens an enabled gate but never activates one the
+   * repo did not configure.
+   */
+  readonly schemaMode?: SchemaGateMode;
 }
 
 /**
@@ -288,11 +298,18 @@ export interface GuardrailCheckResult {
     readonly currentCount: number;
   }>;
   /** The flow integration-gate pass — an additive, fail-open layer that flags
-   *  net-new UI→API breakage from a base↔HEAD contract diff. Runs only in
-   *  ref-based mode; `undefined` in committed modes (nothing to diff a base
-   *  flow model against). Its `blocks` / `warns` are folded into the top-level
-   *  verdict above. Renderers surface `findings` alongside the matched pairs. */
+   *  net-new UI→API breakage from a base↔HEAD contract diff. Runs in BOTH
+   *  modes (the base commit is the resolved ref in ref-based mode, the
+   *  committed baseline's anchor SHA in committed modes); `undefined` only
+   *  when no base commit is resolvable at all. Its `blocks` / `warns` are
+   *  folded into the top-level verdict above. Renderers surface `findings`
+   *  alongside the matched pairs. */
   readonly flowGate?: FlowGateOutcome;
+  /** The model-schema drift-gate pass — additive + fail-open like the flow
+   *  gate, diffing declared data models across the same base↔HEAD pair.
+   *  Opt-in (`.dxkit/policy.json:schema.mode`, default off); `undefined`
+   *  when off or when no base commit is resolvable. */
+  readonly schemaDriftGate?: SchemaDriftGateOutcome;
   /** Set when the CURRENT dependency-vulnerability scan could not run — the
    *  scanner was absent / timed out / failed — AND the scan was actually
    *  REQUESTED this run (not incrementally skipped because no manifest changed,
@@ -744,6 +761,18 @@ export async function runGuardrailCheck(
     ...(options.verbose !== undefined ? { verbose: options.verbose } : {}),
   });
 
+  // The model-schema drift gate — same additive, fail-open shape as the flow
+  // gate, sharing its base-commit resolution, allowlist, and clock. Opt-in:
+  // with no `schema` policy block it skips as 'off' at zero cost.
+  const schemaDriftGate = await evaluateSchemaDriftGateForGuardrail({
+    cwd,
+    ...(flowBaseRef ? { baseRef: flowBaseRef } : {}),
+    allowlist,
+    now,
+    ...(options.schemaMode !== undefined ? { modeOverride: options.schemaMode } : {}),
+    ...(options.verbose !== undefined ? { verbose: options.verbose } : {}),
+  });
+
   const baseBlocks = options.changedOnly ? filteredBlocks : blocks;
   const baseWarns = options.changedOnly ? filteredWarns : warns;
 
@@ -756,11 +785,18 @@ export async function runGuardrailCheck(
     pairs: filteredPairs,
     envelopeDrift,
     policy,
-    blocks: baseBlocks || flowGate.blocks,
-    warns: baseWarns || flowGate.warns,
+    blocks: baseBlocks || flowGate.blocks || schemaDriftGate.blocks,
+    warns: baseWarns || flowGate.warns || schemaDriftGate.warns,
     allowlistDelta,
     refExcludedKinds,
     ...(flowGate.ran || flowGate.skipped !== 'no-base-ref' ? { flowGate } : {}),
+    // Attach when the gate is configured on (ran, or skipped for a reason
+    // worth disclosing); an off/no-base-ref skip stays out of the result so
+    // unconfigured repos see nothing new.
+    ...(schemaDriftGate.ran ||
+    (schemaDriftGate.skipped !== 'off' && schemaDriftGate.skipped !== 'no-base-ref')
+      ? { schemaDriftGate }
+      : {}),
     // Fail-loud: a dep scan that was REQUESTED but could not run must not read as
     // a clean "no net-new dep vulns" — surface it. Incrementally-skipped scans
     // (scope.depVulns false) and nothing-to-scan stacks are legitimately silent.

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -415,6 +415,12 @@ const KIND_DEFAULT_SEVERITY: Readonly<Record<BaselineEntry['kind'], FindingSever
     // removed). High severity — it is a runtime breakage the gate proves
     // statically, on par with a security regression.
     'flow-binding': 'high',
+    // Net-new breaking schema drift (a field removed / type changed /
+    // requiredness tightened on a declared data model). High severity — a
+    // statically proven contract break, the same tier as flow-binding. The
+    // additive/info classes never reach the guardrail as findings, so this
+    // default speaks only for the breaking ones.
+    'model-schema-drift': 'high',
     // A custom-check / lint failure. Severity is a neutral default — a custom
     // check's block intent is user/pack-declared (`entry.blocking`), NOT
     // severity-derived, so severity only feeds the confidence-threshold logic

--- a/src/baseline/entry-to-located.ts
+++ b/src/baseline/entry-to-located.ts
@@ -157,6 +157,16 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
       // pure rename; the `${method} ${path}` join key is the rule discriminator
       // so two distinct bindings in one renamed file don't cross-pair.
       return { id: entry.id, file: entry.file, rule: `${entry.method} ${entry.path}` };
+    case 'model-schema-drift':
+      // LOCATION-free identity ((model, field, changeClass)) → whole-file
+      // display locator; the identity triple is the rule discriminator. The
+      // gate path mints and matches these findings itself (fingerprint
+      // lookup), so this projection only serves show/report tooling.
+      return {
+        id: entry.id,
+        file: entry.file,
+        rule: `${entry.model} ${entry.field ?? ''} ${entry.changeClass}`,
+      };
     case 'custom-check':
       // Two shapes. LOCATED (a linter diagnostic, `file` present): line-window-
       // bucketed identity → line-dependent → full (file, line, rule) locator so

--- a/src/baseline/finding-identity.ts
+++ b/src/baseline/finding-identity.ts
@@ -19,6 +19,7 @@ import {
   computeFingerprint,
   computeFingerprintV1,
   computeFlowBindingFingerprint,
+  computeModelSchemaDriftFingerprint,
   lineWindowFor,
   SECRET_CANONICAL_RULE,
 } from '../analyzers/tools/fingerprint';
@@ -133,6 +134,12 @@ export function identityFor(
       // (method, path, file) triple — all tool-independent + dxkit-derived
       // (Rule 9). The call can move anywhere in the file without re-minting.
       return computeFlowBindingFingerprint(input.method, input.path, input.file);
+    case 'model-schema-drift':
+      // Version-independent + LOCATION-free: hashes only (model, field,
+      // changeClass) — the dep-vuln doctrine applied to a contract-domain
+      // finding, so identity survives line AND file moves and a follow-up
+      // tweak to the same field keeps one allowlist decision (Rule 9).
+      return computeModelSchemaDriftFingerprint(input.model, input.field, input.changeClass);
     case 'custom-check':
       // Version-independent. Two shapes: a LOCATED finding (a linter's
       // per-line diagnostic) hashes (check, file, lineWindow, rule) — the

--- a/src/baseline/migrate.ts
+++ b/src/baseline/migrate.ts
@@ -119,6 +119,14 @@ export function baselineEntryToIdentityInput(entry: BaselineEntry): IdentityInpu
     case 'flow-binding':
       // Line is display-only metadata on the entry, never an identity input.
       return { kind: 'flow-binding', method: e.method, path: e.path, file: e.file };
+    case 'model-schema-drift':
+      // from/to/file/line are display-only metadata; identity is the triple.
+      return {
+        kind: 'model-schema-drift',
+        model: e.model,
+        field: e.field,
+        changeClass: e.changeClass,
+      };
     case 'custom-check':
       // `blocking` + `message` are display/verdict metadata on the entry, never
       // identity inputs (Rule 9). File/line/rule reconstruct the located variant;

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -197,6 +197,15 @@ export const DEFERRED_KINDS: Readonly<
       'Substitute: none — net-new broken-integration detection is inert until the gate wires in.',
     landingPhase: 'Flow M3 (the integration gate)',
   },
+  'model-schema-drift': {
+    reason:
+      'drift is a two-ref RELATION, not a standing finding: a change class exists ' +
+      'only between a base and a head model set, so there is no full-scan prior ' +
+      'side for baseline-create to capture. The drift gate mints these findings ' +
+      'itself (mirror of flow-binding), gathering both sides fresh at check time. ' +
+      'Substitute: none needed — the gate is the complete producer for this kind.',
+    landingPhase: 'model-schema drift gate (ships with the kind)',
+  },
 });
 
 // ─── Producer module wrappers ─────────────────────────────────────────────

--- a/src/baseline/schema-drift-gate-check.ts
+++ b/src/baseline/schema-drift-gate-check.ts
@@ -29,10 +29,7 @@ import { changedFilesTouchModelSurface, detectActiveLanguages } from '../languag
 import { computeChangedFiles } from './changed-files';
 import { withRefWorktree } from './ref-baseline';
 import { gatherModelSet } from '../analyzers/model-schema/gather';
-import {
-  evaluateSchemaDriftGate,
-  type SchemaDriftFinding,
-} from '../analyzers/model-schema/gate';
+import { evaluateSchemaDriftGate, type SchemaDriftFinding } from '../analyzers/model-schema/gate';
 import { readSchemaConfig, type SchemaGateMode } from '../analyzers/model-schema/config';
 import { findEntry, isEntryActive } from '../allowlist/file';
 import type { AllowlistFile } from '../allowlist/file';

--- a/src/baseline/schema-drift-gate-check.ts
+++ b/src/baseline/schema-drift-gate-check.ts
@@ -1,0 +1,220 @@
+/**
+ * The model-schema drift-gate pass for the guardrail check — an ADDITIVE,
+ * fail-open layer over `runGuardrailCheck` (mirror of `flow-gate-check.ts`,
+ * layer for layer).
+ *
+ * Guardrail-integration glue, not analysis: it composes the pure drift gate
+ * (`analyzers/model-schema/gate.ts`) with the ref-based gather primitive
+ * (`withRefWorktree`, Rule 11) to answer "does this diff change a declared
+ * data model in a breaking way?" without touching the existing net-new
+ * finding matcher.
+ *
+ * Mode-agnostic like the flow gate: it needs only a base COMMIT — the
+ * resolved git ref in ref-based mode, the committed baseline's anchor
+ * `repo.commitSha` in committed modes — and gathers both sides fresh, so
+ * `model-schema-drift` needs no committed prior side (a deferred baseline
+ * kind, minted here at gate time). Extraction is pure static analysis (no
+ * toolchain), so it is ref-RELIABLE; the day it wants a compiled
+ * type-checker, that half stops being ref-gateable (see
+ * `REF_UNRELIABLE_KINDS` in check.ts for the contrast class).
+ *
+ * Every failure path degrades to "did not gate": a missing base ref, an
+ * unparseable tree, a repo with no recognizable models on either side — all
+ * yield an empty, non-blocking outcome. A gate must never wedge a build on
+ * its own uncertainty.
+ */
+
+import * as path from 'path';
+import { changedFilesTouchModelSurface, detectActiveLanguages } from '../languages';
+import { computeChangedFiles } from './changed-files';
+import { withRefWorktree } from './ref-baseline';
+import { gatherModelSet } from '../analyzers/model-schema/gather';
+import {
+  evaluateSchemaDriftGate,
+  type SchemaDriftFinding,
+} from '../analyzers/model-schema/gate';
+import { readSchemaConfig, type SchemaGateMode } from '../analyzers/model-schema/config';
+import { findEntry, isEntryActive } from '../allowlist/file';
+import type { AllowlistFile } from '../allowlist/file';
+
+/** Why the gate produced no verdict, when it didn't run. */
+export type SchemaDriftGateSkip =
+  | 'off' // policy `schema.mode: off` (the default — the gate is opt-in)
+  | 'no-base-ref' // no base commit resolvable
+  | 'no-model-surface-change' // the diff touched no model-capable source / spec
+  | 'no-models' // neither side declares any model — nothing to compare
+  | 'error'; // any failure — fail-open
+
+/** A drift finding an active allowlist entry waived from the verdict —
+ *  surfaced for audit, excluded from blocks/warns. */
+export interface SchemaDriftSuppression {
+  readonly finding: SchemaDriftFinding;
+  readonly fingerprint: string;
+  readonly category: string;
+  readonly expiresAt?: string;
+}
+
+/** Outcome of the drift-gate pass, folded additively into the guardrail
+ *  verdict. */
+export interface SchemaDriftGateOutcome {
+  /** True when the gate actually evaluated a base↔HEAD comparison. */
+  readonly ran: boolean;
+  /** Populated when `ran` is false — why no verdict was produced. */
+  readonly skipped?: SchemaDriftGateSkip;
+  /** The effective mode after the loop-seam override. */
+  readonly mode: SchemaGateMode;
+  /** Active findings (not allowlist-waived). `info` findings are disclosure
+   *  only; in `warn` mode every block verdict is demoted to warn. */
+  readonly findings: readonly SchemaDriftFinding[];
+  /** Findings an active allowlist entry accepted — audit surface. */
+  readonly suppressed: readonly SchemaDriftSuppression[];
+  /** True when at least one active finding blocks (only in `block` mode). */
+  readonly blocks: boolean;
+  /** True when at least one active finding warns. */
+  readonly warns: boolean;
+}
+
+function skip(mode: SchemaGateMode, reason: SchemaDriftGateSkip): SchemaDriftGateOutcome {
+  return {
+    ran: false,
+    skipped: reason,
+    mode,
+    findings: [],
+    suppressed: [],
+    blocks: false,
+    warns: false,
+  };
+}
+
+/** Partition active vs allowlist-suppressed findings — the per-finding
+ *  escape hatch (an accepted deliberate breaking change), mirroring the flow
+ *  gate's partition. Expired entries do not waive. */
+function partitionByAllowlist(
+  findings: readonly SchemaDriftFinding[],
+  allowlist: AllowlistFile | null | undefined,
+  now: Date,
+): { active: SchemaDriftFinding[]; suppressed: SchemaDriftSuppression[] } {
+  if (!allowlist) return { active: [...findings], suppressed: [] };
+  const active: SchemaDriftFinding[] = [];
+  const suppressed: SchemaDriftSuppression[] = [];
+  for (const f of findings) {
+    const entry = findEntry(allowlist, f.id);
+    if (entry && entry.kind === 'model-schema-drift' && isEntryActive(entry, now)) {
+      suppressed.push({
+        finding: f,
+        fingerprint: entry.fingerprint,
+        category: entry.category,
+        ...(entry.expiresAt !== undefined ? { expiresAt: entry.expiresAt } : {}),
+      });
+    } else {
+      active.push(f);
+    }
+  }
+  return { active, suppressed };
+}
+
+/**
+ * Run the drift gate for a guardrail check. Never throws — the caller ORs
+ * `blocks` / `warns` into the overall verdict and attaches the outcome for
+ * rendering.
+ *
+ * @param baseRef the base commit to diff HEAD against (resolved ref in
+ *   ref-based mode, the baseline anchor SHA in committed modes). Absent →
+ *   the gate skips.
+ * @param modeOverride the loop Stop-gate's posture-derived mode — wins over
+ *   `.dxkit/policy.json:schema.mode` (the `security-only` preset maps to
+ *   `warn` so an unattended loop never wedges on a schema false positive).
+ * @param allowlist active `model-schema-drift` entries waive matching
+ *   findings from the verdict (the per-finding escape hatch).
+ * @param now the clock for allowlist-expiry checks (testability).
+ */
+export async function evaluateSchemaDriftGateForGuardrail(opts: {
+  readonly cwd: string;
+  readonly baseRef?: string;
+  readonly modeOverride?: SchemaGateMode;
+  readonly verbose?: boolean;
+  readonly allowlist?: AllowlistFile | null;
+  readonly now?: Date;
+}): Promise<SchemaDriftGateOutcome> {
+  const cwd = path.resolve(opts.cwd);
+  const config = readSchemaConfig(cwd);
+  // The override softens/hardens an ENABLED gate; it never activates one.
+  // Unlike flow (default block), schema defaults to off — an opt-in
+  // capability — so a loop preset's `warn` must not switch it on for a repo
+  // that never configured it.
+  const gateMode: SchemaGateMode =
+    config.mode === 'off' ? 'off' : (opts.modeOverride ?? config.mode);
+
+  if (gateMode === 'off') return skip(gateMode, 'off');
+  if (!opts.baseRef) return skip(gateMode, 'no-base-ref');
+  const ref = opts.baseRef;
+
+  try {
+    // Trigger-skip: net-new drift requires a change to a model-capable
+    // source file or a configured spec. Null changed-set = can't prove the
+    // diff is model-free → fall through and run (safe default).
+    const changed = computeChangedFiles(cwd, ref) ?? undefined;
+    if (
+      changed &&
+      !changedFilesTouchModelSurface(changed, detectActiveLanguages(cwd), config.specs)
+    ) {
+      return skip(gateMode, 'no-model-surface-change');
+    }
+
+    // HEAD side (the working tree), repo-relative locators so display
+    // metadata is environment-independent and the base side lines up.
+    const headModels = await gatherModelSet({
+      roots: [cwd],
+      specs: config.specs.map((s) => path.resolve(cwd, s)),
+      relativeTo: cwd,
+    });
+
+    // Base side from a detached worktree at the ref (Rule 11), with the SAME
+    // config — the HEAD checkout's policy governs both sides so a policy
+    // edit in the PR cannot split the comparison.
+    const baseModels = await withRefWorktree({ cwd, ref }, async (wt) =>
+      gatherModelSet({
+        roots: [wt],
+        specs: config.specs.map((s) => path.resolve(wt, s)),
+        relativeTo: wt,
+      }),
+    );
+
+    // Neither side declares any model → nothing to compare; gating would be
+    // pure noise on a repo the capability cannot see.
+    if (headModels.models.length === 0 && baseModels.models.length === 0) {
+      return skip(gateMode, 'no-models');
+    }
+
+    const found = evaluateSchemaDriftGate({
+      baseModels,
+      headModels,
+      blockThreshold: config.blockThreshold,
+    });
+
+    // Posture: `warn` demotes block verdicts (info stays disclosure-only).
+    const posture =
+      gateMode === 'warn'
+        ? found.map((f) => (f.verdict === 'block' ? { ...f, verdict: 'warn' as const } : f))
+        : found;
+
+    const { active, suppressed } = partitionByAllowlist(
+      posture,
+      opts.allowlist,
+      opts.now ?? new Date(),
+    );
+    const blocks = gateMode === 'block' && active.some((f) => f.verdict === 'block');
+    const warns = active.some((f) => f.verdict === 'warn');
+
+    if (opts.verbose && active.length > 0) {
+      process.stderr.write(
+        `    [schema] ${active.length} net-new schema drift finding(s) — ${blocks ? 'blocking' : warns ? 'warning' : 'informational'}\n`,
+      );
+    }
+    return { ran: true, mode: gateMode, findings: active, suppressed, blocks, warns };
+  } catch {
+    // Fail-open: a ref that can't be checked out, a git error — the gate
+    // simply did not run.
+    return skip(gateMode, 'error');
+  }
+}

--- a/src/baseline/show.ts
+++ b/src/baseline/show.ts
@@ -216,6 +216,8 @@ function describeEntry(entry: BaselineEntry): string {
       return `${entry.file}:${entry.line}  [stale dxkit-allow:${entry.category}]`;
     case 'flow-binding':
       return `${entry.method} ${entry.path}  ← ${entry.file}:${entry.line}`;
+    case 'model-schema-drift':
+      return `${entry.model}${entry.field ? '.' + entry.field : ''}  [${entry.changeClass}]  ${entry.file}:${entry.line}`;
     case 'custom-check':
       return entry.file !== undefined
         ? `${entry.file}:${entry.line ?? '?'}  [${entry.check}${entry.rule ? '/' + entry.rule : ''}]`

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -124,6 +124,7 @@ export type IdentityInput =
   | SecretHmacIdentityInput
   | StaleAllowIdentityInput
   | FlowBindingIdentityInput
+  | ModelSchemaDriftIdentityInput
   | CustomCheckIdentityInput;
 
 /**
@@ -417,6 +418,28 @@ export interface FlowBindingIdentityInput {
 }
 
 /**
+ * A schema-drift finding — one detected change to a declared data model, the
+ * unit the model-schema drift gate mints and the allowlist waives. Identity
+ * is exactly the triple `(model, field, changeClass)` — LOCATION-FREE by
+ * design (the dep-vuln doctrine: a model is a contract-domain entity whose
+ * name is its address), so the finding survives line and file moves with no
+ * matching machinery. `field` is null for model-level classes
+ * (`model-removed` / `model-added`). The before/after values and the
+ * file/line locator live on the baseline entry as display metadata, never in
+ * the hash — a follow-up commit adjusting the same field cannot dodge an
+ * allowlist decision.
+ */
+export interface ModelSchemaDriftIdentityInput {
+  readonly kind: 'model-schema-drift';
+  /** The model's declared name (dxkit's own AST/spec read, normalized). */
+  readonly model: string;
+  /** Field name, or null for a model-level change class. */
+  readonly field: string | null;
+  /** One of the fixed drift-taxonomy classes (`field-removed`, …). */
+  readonly changeClass: string;
+}
+
+/**
  * A failure emitted by a user-declared custom check (`.dxkit/policy.json:checks`)
  * or a pack-declared built-in check (lint). The check runner turns a check's
  * output into zero or more of these — either ONE binary finding (the command
@@ -548,6 +571,23 @@ export type BaselineEntry =
     }
   | {
       id: FindingId;
+      kind: 'model-schema-drift';
+      /** The identity triple — all three stored so identity is recomputable
+       * from the entry alone (the migration contract). */
+      model: string;
+      field: string | null;
+      changeClass: string;
+      /** Normalized before/after facts — display metadata, never hashed
+       * (identity must survive a follow-up tweak to the same field). */
+      from: string | null;
+      to: string | null;
+      /** Head-side locator (base-side for removals) — display metadata;
+       * identity is location-free by design. */
+      file: string;
+      line: number;
+    }
+  | {
+      id: FindingId;
       kind: 'stale-allow';
       file: string;
       line: number;
@@ -630,6 +670,7 @@ export interface SanitizedBaselineEntry {
     | 'secret-hmac'
     | 'stale-allow'
     | 'flow-binding'
+    | 'model-schema-drift'
     | 'custom-check';
   readonly sanitized: true;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -855,6 +855,26 @@ export async function run(argv: string[]): Promise<void> {
       break;
     }
 
+    case 'schema': {
+      // `schema [inventory]` — the model catalog; `schema diff [--ref]` —
+      // the drift preview through the SAME evaluation the guardrail runs.
+      const sub = positionals[1];
+      const schemaTarget = resolveRepoPath(
+        sub === 'inventory' || sub === 'diff' ? positionals[2] : positionals[1],
+      );
+      if (sub === 'diff') {
+        const { runSchemaDiff } = await import('./schema-cli');
+        await runSchemaDiff(schemaTarget, {
+          ref: values.ref as string | undefined,
+          json: !!values.json,
+        });
+        break;
+      }
+      const { runSchemaInventory } = await import('./schema-cli');
+      await runSchemaInventory(schemaTarget, { json: !!values.json });
+      break;
+    }
+
     case 'receipt': {
       const { runReceipt, receiptFailureHint } = await import('./receipt-cli');
       try {

--- a/src/discovery/advisor.ts
+++ b/src/discovery/advisor.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { resolveBaselineMode } from '../baseline/modes';
 import { FLOW_CONFIG_SCHEMA_VERSION } from '../analyzers/flow/config';
+import { SCHEMA_CONFIG_SCHEMA_VERSION } from '../analyzers/model-schema/config';
 import { isClaudeLoopInstalled } from '../loop/scaffold';
 import { LANGUAGES } from '../languages';
 import type {
@@ -79,37 +80,63 @@ function hasFlowSignal(cwd: string): boolean {
   if (existsAt(cwd, '.dxkit', 'workspace.json')) return false;
   const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json'));
   if (policy && 'flow' in policy) return false;
+  return manifestSignalHit(
+    cwd,
+    LANGUAGES.flatMap((p) => p.httpFlow?.flowSignals ?? []),
+  );
+}
 
-  for (const pack of LANGUAGES) {
-    for (const signal of pack.httpFlow?.flowSignals ?? []) {
-      if (signal.manifest === 'package.json') {
-        // JSON manifests match on dependency KEYS (a word-boundary text search
-        // would also hit versions/scripts).
-        const pkg = readJsonSafe(path.join(cwd, signal.manifest));
-        if (!pkg) continue;
-        const deps = {
-          ...((pkg.dependencies as Record<string, unknown>) ?? {}),
-          ...((pkg.devDependencies as Record<string, unknown>) ?? {}),
-        };
-        if (signal.anyOf.some((f) => f in deps)) return true;
-      } else {
-        // Plain-text manifests (requirements.txt, pyproject.toml, Pipfile…)
-        // match on word-boundary tokens — precise enough for a fail-open
-        // recommendation probe.
-        let text: string;
-        try {
-          text = fs.readFileSync(path.join(cwd, signal.manifest), 'utf8');
-        } catch {
-          continue;
-        }
-        const hit = signal.anyOf.some((f) =>
-          new RegExp(`\\b${f.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(text),
-        );
-        if (hit) return true;
+/**
+ * Does any pack-declared manifest signal match this repo? The ONE
+ * signal-matching implementation (Rule 2), shared by the flow and schema
+ * probes. `package.json` matches on dependency KEYS (a word-boundary text
+ * search would also hit versions/scripts); plain-text manifests
+ * (requirements.txt, pyproject.toml, go.mod…) match on word-boundary tokens
+ * — precise enough for a fail-open recommendation probe.
+ */
+function manifestSignalHit(
+  cwd: string,
+  signals: ReadonlyArray<{ manifest: string; anyOf: string[] }>,
+): boolean {
+  for (const signal of signals) {
+    if (signal.manifest === 'package.json') {
+      const pkg = readJsonSafe(path.join(cwd, signal.manifest));
+      if (!pkg) continue;
+      const deps = {
+        ...((pkg.dependencies as Record<string, unknown>) ?? {}),
+        ...((pkg.devDependencies as Record<string, unknown>) ?? {}),
+      };
+      if (signal.anyOf.some((f) => f in deps)) return true;
+    } else {
+      let text: string;
+      try {
+        text = fs.readFileSync(path.join(cwd, signal.manifest), 'utf8');
+      } catch {
+        continue;
       }
+      const hit = signal.anyOf.some((f) =>
+        new RegExp(`\\b${f.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(text),
+      );
+      if (hit) return true;
     }
   }
   return false;
+}
+
+/**
+ * One signal function for the schema-gate capability, shared by the doctor
+ * probe (`recommendSchema`) and the planner (`planSchemaMode`) so the two
+ * never diverge (Rule 2). Tokens are PACK-DECLARED
+ * (`modelSchema.schemaSignals`, Rule 6). Silenced once a `schema` policy
+ * block exists — configured repos are never re-recommended.
+ */
+function hasSchemaSignal(cwd: string): boolean {
+  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json'));
+  if (policy && 'schema' in policy) return false;
+  return manifestSignalHit(
+    cwd,
+    LANGUAGES.flatMap((p) => p.modelSchema?.schemaSignals ?? []),
+  );
 }
 
 /** Recommend flow setup on a repo with an HTTP-framework signal and no flow config. */
@@ -119,6 +146,17 @@ export function recommendFlow(ctx: RecommendContext): Recommendation | null {
     reason:
       'detected an HTTP framework but no flow setup — flow maps client calls to served routes and gates changes that break an integration',
     command: 'vyuh-dxkit flow init',
+  };
+}
+
+/** Recommend the schema gate on a repo with an ORM/model-framework signal
+ *  and no schema config. */
+export function recommendSchema(ctx: RecommendContext): Recommendation | null {
+  if (!hasSchemaSignal(ctx.cwd)) return null;
+  return {
+    reason:
+      'detected a data-model framework but no schema gate — the gate blocks breaking model changes (field removed, type changed, required tightened) while a deliberate migration ships via an expiring allowlist entry',
+    command: 'vyuh-dxkit schema',
   };
 }
 
@@ -236,6 +274,24 @@ export function planFlowMode(ctx: ConfigContext): ConfigPlanItem | null {
     patch: { flow: { mode: 'warn', schemaVersion: FLOW_CONFIG_SCHEMA_VERSION } },
     reason: 'seed the UI→API integration gate at the safe default (warn, never fails a build)',
     evidence: 'HTTP framework in a dependency manifest, no flow config yet',
+  };
+}
+
+/**
+ * Schema gate: on a repo with a data-model framework and no schema config,
+ * seed the safe default posture — `warn` (surface breaking drift, never fail
+ * a build). The team moves it to `block` once the inventory reads clean.
+ * Reuses `hasSchemaSignal` (shared with the doctor probe, Rule 2).
+ */
+export function planSchemaMode(ctx: ConfigContext): ConfigPlanItem | null {
+  if (!hasSchemaSignal(ctx.cwd)) return null;
+  return {
+    capability: 'schema',
+    section: 'schema.mode',
+    summary: 'warn',
+    patch: { schema: { mode: 'warn', schemaVersion: SCHEMA_CONFIG_SCHEMA_VERSION } },
+    reason: 'seed the model-schema drift gate at the safe default (warn, never fails a build)',
+    evidence: 'data-model framework in a dependency manifest, no schema config yet',
   };
 }
 

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -9,9 +9,11 @@ import {
   recommendConfigure,
   recommendBaseline,
   recommendFlow,
+  recommendSchema,
   recommendChecks,
   planBaselineMode,
   planFlowMode,
+  planSchemaMode,
   planLintGate,
   planLoopPreset,
 } from './advisor';
@@ -305,6 +307,21 @@ export const COMMANDS = [
   },
 
   // ── Integrate ──────────────────────────────────────────────────────────
+  {
+    id: 'schema',
+    audience: 'user',
+    group: 'gate',
+    summary: 'Data-model inventory + the schema drift gate',
+    docsBlurb:
+      'Extract every declared data model (ORM entities, tagged structs, spec schemas) and ' +
+      'gate breaking changes — a removed field, a changed type, an optional field made ' +
+      'required. `schema` lists the inventory, `schema diff --ref <base>` previews the exact ' +
+      'verdict the guardrail will reach; a deliberate breaking change ships via an expiring ' +
+      'accepted-risk allowlist entry.',
+    skill: 'dxkit-schema',
+    whenToRecommend: recommendSchema,
+    planConfig: planSchemaMode,
+  },
   {
     id: 'flow',
     audience: 'user',

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -173,6 +173,12 @@ export const DXKIT_SKILLS = [
   // broken integration the guardrail flagged (never suppresses it),
   // and the handshake mode drives `flow publish` for cross-repo meshes.
   'dxkit-flow',
+  // dxkit-schema: configure/read/act-on the model-schema drift gate.
+  // Thin orchestration over the CLI — setup folds into `configure`,
+  // inventory + pre-push preview via `schema` / `schema diff`, and the
+  // fix mode ships a deliberate breaking change the safe way (migration
+  // + expiring accepted-risk allowlist entry), never a posture bypass.
+  'dxkit-schema',
   // dxkit-uninstall: cleanly remove all of dxkit from a repo, restoring the
   // pre-dxkit state (reverse each additive merge, delete created files),
   // dry-run first. Also captures optional, opt-in feedback via a prefilled

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -1098,6 +1098,31 @@ export const go: LanguageSupport = {
     ],
   },
 
+  // Data-model declarations for the model-schema drift gate. In Go the
+  // wire-contract marker IS the struct tag: a `json:`-tagged struct is a
+  // serialization contract by definition (API payloads, config files), and
+  // `gorm:` / `db:` / `bson:` mark persistence models. The tag also supplies
+  // the wire field name (first token; `omitempty` reads as optional, a
+  // pointer type likewise). Untagged structs are internal shapes and stay
+  // invisible — precision over recall, the documented posture.
+  modelSchema: {
+    structTagKeys: ['json', 'gorm', 'db', 'bson'],
+    // A stdlib-only JSON API has no manifest signal (encoding/json is not a
+    // go.mod entry) — extraction still works once the gate is configured;
+    // the signal fires on the common persistence/ORM stacks.
+    schemaSignals: [
+      {
+        manifest: 'go.mod',
+        anyOf: [
+          'gorm.io/gorm',
+          'github.com/jmoiron/sqlx',
+          'go.mongodb.org/mongo-driver',
+          'entgo.io/ent',
+        ],
+      },
+    ],
+  },
+
   // Tree-sitter grammar for the canonical AST layer (src/ast/). Logical name —
   // src/ast/ resolves it to the bundled wasm artifact and its shape row.
   treeSitterGrammars: {

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -6,6 +6,7 @@ import type {
   HttpFlowSupport,
   LanguageId,
   LanguageSupport,
+  ModelSchemaSupport,
 } from './types';
 import type { CorrectnessProvider } from './capabilities/correctness';
 import type { LintGateProvider } from './capabilities/lint-gate';
@@ -24,6 +25,7 @@ export type {
   LanguageId,
   LanguageSupport,
   LintSeverity,
+  ModelSchemaSupport,
 } from './types';
 
 export const LANGUAGES: readonly LanguageSupport[] = [
@@ -508,6 +510,61 @@ export function changedFilesTouchFlowSurface(
   const exts = allFlowSourceExtensions(packs);
   if (exts.length === 0) return false;
   const specSet = new Set(specPaths.map((s) => s.replace(/\\/g, '/')));
+  return changedFiles.some((f) => {
+    const norm = f.replace(/\\/g, '/');
+    return exts.some((e) => norm.endsWith(e)) || specSet.has(norm);
+  });
+}
+
+/**
+ * Active packs' `modelSchema` descriptors (defined-only) — the model-schema
+ * mirror of `allHttpFlow`. Consumed by the cross-cutting extractor in
+ * `src/analyzers/model-schema/`: it resolves the per-file descriptor by the
+ * file's language and uses this union to decide whether model extraction
+ * applies at all (Rule 6 — no per-language branch, no framework literal in
+ * the analyzer). `recipe-playbook.test.ts` asserts a synthetic pack's
+ * contribution flows through this helper.
+ */
+export function allModelSchema(flags: DetectedStack['languages']): ModelSchemaSupport[] {
+  return activeLanguagesFromFlags(flags)
+    .map((l) => l.modelSchema)
+    .filter((m): m is ModelSchemaSupport => m !== undefined);
+}
+
+/**
+ * Source-file extensions of packs that can contribute models — those
+ * declaring BOTH a `modelSchema` descriptor and a tree-sitter grammar
+ * (extraction needs both). One source of truth (Rule 2) for the model file
+ * walk and the changed-files model-surface trigger; the mirror of
+ * `allFlowSourceExtensions`.
+ */
+export function allModelSchemaSourceExtensions(packs: readonly LanguageSupport[]): string[] {
+  const exts = new Set<string>();
+  for (const pack of packs) {
+    if (pack.modelSchema && pack.treeSitterGrammars) {
+      for (const ext of Object.keys(pack.treeSitterGrammars)) exts.add(ext);
+    }
+  }
+  return [...exts];
+}
+
+/**
+ * Does any changed-file path touch a model surface — a source file in a
+ * model-capable pack's extension set, or a configured schema spec? Drives
+ * the incremental drift-gate trigger-skip in `runGuardrailCheck`: net-new
+ * schema drift requires a change to a model declaration or a spec, so when
+ * this returns false the two-ref gate is skipped entirely. Same fail-safe
+ * contract as `changedFilesTouchFlowSurface`: false only when nothing could
+ * have introduced drift. `specPaths` are repo-relative.
+ */
+export function changedFilesTouchModelSurface(
+  changedFiles: readonly string[],
+  packs: readonly LanguageSupport[],
+  specPaths: readonly string[] = [],
+): boolean {
+  const exts = allModelSchemaSourceExtensions(packs);
+  const specSet = new Set(specPaths.map((s) => s.replace(/\\/g, '/')));
+  if (exts.length === 0 && specSet.size === 0) return false;
   return changedFiles.some((f) => {
     const norm = f.replace(/\\/g, '/');
     return exts.some((e) => norm.endsWith(e)) || specSet.has(norm);

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1287,7 +1287,11 @@ export const python: LanguageSupport = {
   // Known limitation (documented): relation fields fold to their constructor
   // alias (`fk` / `m2m`), so a re-targeted ForeignKey is not a type change.
   modelSchema: {
-    modelBaseClasses: ['Model', 'BaseModel', 'DeclarativeBase', 'Base', 'SQLModel'],
+    modelBaseClasses: ['Model', 'BaseModel', 'DeclarativeBase', 'SQLModel'],
+    // `Base` (classic SQLAlchemy declarative) is too generic to trust alone —
+    // real-repo validation found unrelated homonym `Base` classes minted as
+    // models. Weak: counts only when a Column/mapped_column field corroborates.
+    weakModelBaseClasses: ['Base'],
     modelDecorators: ['dataclass'],
     fieldCallees: [
       {

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1292,6 +1292,9 @@ export const python: LanguageSupport = {
     // real-repo validation found unrelated homonym `Base` classes minted as
     // models. Weak: counts only when a Column/mapped_column field corroborates.
     weakModelBaseClasses: ['Base'],
+    // SQLAlchemy 2.0 annotates through a transparent wrapper:
+    // `so.Mapped[Optional[str]]` is an optional str, never a "Mapped" type.
+    transparentTypeWrappers: ['Mapped'],
     modelDecorators: ['dataclass'],
     fieldCallees: [
       {

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1278,6 +1278,96 @@ export const python: LanguageSupport = {
     ],
   },
 
+  // Data-model declarations for the model-schema drift gate. Marker-based
+  // (precision-first): Django/SQLAlchemy/pydantic base classes and
+  // @dataclass. Field facts come from annotations where present; ORM
+  // constructor fields (`models.CharField(null=True)`, `Column(String,
+  // nullable=False)`) are enriched via fieldCallees — an unlisted exotic
+  // field constructor still surfaces its field with an honest unknown type.
+  // Known limitation (documented): relation fields fold to their constructor
+  // alias (`fk` / `m2m`), so a re-targeted ForeignKey is not a type change.
+  modelSchema: {
+    modelBaseClasses: ['Model', 'BaseModel', 'DeclarativeBase', 'Base', 'SQLModel'],
+    modelDecorators: ['dataclass'],
+    fieldCallees: [
+      {
+        // Django field constructors — the callee IS the type token.
+        names: [
+          'CharField',
+          'TextField',
+          'EmailField',
+          'SlugField',
+          'URLField',
+          'UUIDField',
+          'IntegerField',
+          'BigIntegerField',
+          'SmallIntegerField',
+          'PositiveIntegerField',
+          'PositiveSmallIntegerField',
+          'AutoField',
+          'BigAutoField',
+          'BooleanField',
+          'FloatField',
+          'DecimalField',
+          'DateField',
+          'DateTimeField',
+          'TimeField',
+          'DurationField',
+          'JSONField',
+          'BinaryField',
+          'FileField',
+          'ImageField',
+          'GenericIPAddressField',
+          'ForeignKey',
+          'OneToOneField',
+          'ManyToManyField',
+        ],
+        optionalityKeyword: 'null',
+      },
+      {
+        // SQLAlchemy column forms — the type is the first argument.
+        names: ['Column', 'mapped_column'],
+        typeFrom: 'firstArg',
+        optionalityKeyword: 'nullable',
+      },
+    ],
+    typeAliases: {
+      charfield: 'string',
+      textfield: 'string',
+      emailfield: 'string',
+      slugfield: 'string',
+      urlfield: 'string',
+      genericipaddressfield: 'string',
+      uuidfield: 'uuid',
+      integerfield: 'int',
+      bigintegerfield: 'int',
+      smallintegerfield: 'int',
+      positiveintegerfield: 'int',
+      positivesmallintegerfield: 'int',
+      autofield: 'int',
+      bigautofield: 'int',
+      booleanfield: 'bool',
+      floatfield: 'float',
+      decimalfield: 'decimal',
+      datefield: 'date',
+      datetimefield: 'datetime',
+      timefield: 'time',
+      durationfield: 'duration',
+      jsonfield: 'json',
+      binaryfield: 'bytes',
+      filefield: 'file',
+      imagefield: 'file',
+      foreignkey: 'fk',
+      onetoonefield: 'fk',
+      manytomanyfield: 'm2m',
+    },
+    schemaSignals: [
+      { manifest: 'requirements.txt', anyOf: ['django', 'sqlalchemy', 'pydantic', 'sqlmodel'] },
+      { manifest: 'pyproject.toml', anyOf: ['django', 'sqlalchemy', 'pydantic', 'sqlmodel'] },
+      { manifest: 'Pipfile', anyOf: ['django', 'sqlalchemy', 'pydantic', 'sqlmodel'] },
+    ],
+  },
+
   // Tree-sitter grammar for the canonical AST layer (src/ast/). Logical name —
   // src/ast/ resolves it to the bundled wasm artifact and its shape row.
   treeSitterGrammars: {

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -449,6 +449,14 @@ export interface ModelSchemaSupport {
     optionalityPolarity?: 'nullable' | 'required';
   }>;
   /**
+   * Transparent type wrappers folded OUT of annotation text before any
+   * other normalization: `Mapped[X]` (SQLAlchemy 2.0) reads as `X`, so the
+   * inner `Optional[...]` optionality still folds and a wrapper is never
+   * part of the compared type. Matched on the wrapper's trailing segment
+   * (`so.Mapped[...]` counts as `Mapped[...]`).
+   */
+  transparentTypeWrappers?: string[];
+  /**
    * Lexical type aliases folded by the shared normalizer (mirror of
    * `methodAliases`; keys MUST be lowercase): `{ charfield: 'string',
    * integerfield: 'int' }`. Values are the pack's chosen canonical token —

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -410,6 +410,16 @@ export interface ModelSchemaSupport {
    */
   modelBaseClasses?: string[];
   /**
+   * WEAK heritage markers: names too generic to trust alone (SQLAlchemy's
+   * conventional `Base` — any codebase can have an unrelated class named
+   * `Base`). A weak match marks a model only when corroborated: at least
+   * one field resolves through `fieldCallees` (a `Column(...)`-style
+   * constructor). Real-repo validation forced this split — a strong
+   * `'Base'` marker minted an e-commerce framework's strategy/policy
+   * classes as models.
+   */
+  weakModelBaseClasses?: string[];
+  /**
    * Decorator markers: `@Entity()`, `@Table(...)`, `@dataclass`. Matched on
    * the decorator's callee/name trailing segment; bare and called forms both
    * count.

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -425,13 +425,16 @@ export interface ModelSchemaSupport {
    * Field-initializer callees that carry the field's type and optionality
    * (ORM column constructors): `models.CharField(max_length=…, null=True)`,
    * `Column(String, nullable=False)`, `db.Column(db.Integer)`. Matched on
-   * the callee's trailing segment. The callee name becomes the field's type
-   * token (folded through `typeAliases`); `optionalityKeyword` names the
-   * keyword argument that carries optionality and `optionalityPolarity` its
-   * meaning (`'nullable'`: true ⇒ optional; `'required'`: true ⇒ required).
+   * the callee's trailing segment. `typeFrom` says where the type token
+   * lives: `'callee'` (Django — `CharField` IS the type; the default) or
+   * `'firstArg'` (SQLAlchemy — `Column(String, …)`); the token is folded
+   * through `typeAliases`. `optionalityKeyword` names the keyword argument
+   * that carries optionality and `optionalityPolarity` its meaning
+   * (`'nullable'`: true ⇒ optional; `'required'`: true ⇒ required).
    */
   fieldCallees?: Array<{
     names: string[];
+    typeFrom?: 'callee' | 'firstArg';
     optionalityKeyword?: string;
     optionalityPolarity?: 'nullable' | 'required';
   }>;

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -387,6 +387,72 @@ export interface HttpFlowSupport {
 }
 
 /**
+ * Declares WHICH constructs in this pack's source are data models — the
+ * mirror of {@link HttpFlowSupport} for the model-schema capability.
+ * Framework facts only: HOW to read a class/field/annotation from a grammar
+ * lives in `src/ast/grammar-model-shape.ts`, and WHAT a model diff means
+ * lives in `src/analyzers/model-schema/` (semantics, grammar-agnostic).
+ *
+ * Recognition is marker-based, never path-based: a construct is a model when
+ * it carries a declared marker (base class, decorator, struct-tag
+ * convention). Unmarked types are deliberately invisible to code extraction
+ * — the honest answer for those is a spec-declared model (`schema.specs`),
+ * exactly as `flow.specs` covers un-extractable routes. Bias every list
+ * toward precision: a missed model is a disclosed gap, a false model floods
+ * the drift diff.
+ */
+export interface ModelSchemaSupport {
+  /**
+   * Heritage markers: a class inheriting one of these is a model. Matched
+   * against each heritage expression's verbatim text AND its trailing
+   * identifier segment, so `'Model'` matches `models.Model` and
+   * `'BaseModel'` matches `pydantic.BaseModel`.
+   */
+  modelBaseClasses?: string[];
+  /**
+   * Decorator markers: `@Entity()`, `@Table(...)`, `@dataclass`. Matched on
+   * the decorator's callee/name trailing segment; bare and called forms both
+   * count.
+   */
+  modelDecorators?: string[];
+  /**
+   * Struct-tag markers (Go): a struct any of whose fields carries one of
+   * these tag keys is a model. The tag's value also supplies the wire field
+   * name (first comma-separated token), with `omitempty` read as optional.
+   */
+  structTagKeys?: string[];
+  /**
+   * Field-initializer callees that carry the field's type and optionality
+   * (ORM column constructors): `models.CharField(max_length=…, null=True)`,
+   * `Column(String, nullable=False)`, `db.Column(db.Integer)`. Matched on
+   * the callee's trailing segment. The callee name becomes the field's type
+   * token (folded through `typeAliases`); `optionalityKeyword` names the
+   * keyword argument that carries optionality and `optionalityPolarity` its
+   * meaning (`'nullable'`: true ⇒ optional; `'required'`: true ⇒ required).
+   */
+  fieldCallees?: Array<{
+    names: string[];
+    optionalityKeyword?: string;
+    optionalityPolarity?: 'nullable' | 'required';
+  }>;
+  /**
+   * Lexical type aliases folded by the shared normalizer (mirror of
+   * `methodAliases`; keys MUST be lowercase): `{ charfield: 'string',
+   * integerfield: 'int' }`. Values are the pack's chosen canonical token —
+   * comparison stays within one language, so cross-language agreement is
+   * neither needed nor attempted.
+   */
+  typeAliases?: Record<string, string>;
+  /**
+   * Cheap dependency-manifest signals that this language's model surface is
+   * present (mirror of `flowSignals`). Drives DISCOVERY only — doctor's
+   * "you'd benefit from the schema gate" recommendation and the config
+   * planner — never extraction.
+   */
+  schemaSignals?: Array<{ manifest: string; anyOf: string[] }>;
+}
+
+/**
  * Everything dxkit needs to know about a language lives in one implementation
  * of this interface. See `src/languages/index.ts` for the registry.
  *
@@ -617,6 +683,22 @@ export interface LanguageSupport {
    * sees the empty union for that language. See `HttpFlowSupport`.
    */
   httpFlow?: HttpFlowSupport;
+
+  /**
+   * Model-schema descriptors for this pack: which constructs declare data
+   * models (base classes, decorators, struct tags, ORM field constructors).
+   * Consumed through `allModelSchema` in `src/languages/index.ts` by the
+   * cross-cutting model-schema extractor (`src/analyzers/model-schema/`) —
+   * never a per-language branch, never a hardcoded framework literal in the
+   * analyzer (Rule 6 + Rule 5). Extraction additionally requires
+   * `treeSitterGrammars` and a grammar-model-shape row (the contract test
+   * loud-fails a descriptor missing either).
+   *
+   * Optional — a pack with no canonical model conventions omits it; the
+   * extractor sees the empty union for that language. See
+   * `ModelSchemaSupport`.
+   */
+  modelSchema?: ModelSchemaSupport;
 
   /**
    * Tree-sitter grammars this pack's source files parse with, keyed by file

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1798,6 +1798,33 @@ export const typescript: LanguageSupport = {
     ],
   },
 
+  // Data-model declarations for the model-schema drift gate. Marker-based
+  // (precision-first): decorator-marked entity classes (TypeORM / MikroORM
+  // @Entity, sequelize-typescript @Table, NestJS-mongoose @Schema,
+  // type-graphql @ObjectType/@InputType) plus TypeORM's active-record
+  // BaseEntity heritage. Field facts come from the TS annotations (`?`,
+  // `| null`); JS-only entity classes surface fields with honest unknown
+  // types. Plain unmarked interfaces/DTOs are deliberately invisible — the
+  // documented answer is a spec (`schema.specs`), and builder-style schemas
+  // (zod, Prisma's DSL) are out of code-extraction scope for the same
+  // precision reason.
+  modelSchema: {
+    modelBaseClasses: ['BaseEntity'],
+    modelDecorators: ['Entity', 'Table', 'Schema', 'ObjectType', 'InputType'],
+    schemaSignals: [
+      {
+        manifest: 'package.json',
+        anyOf: [
+          'typeorm',
+          'sequelize-typescript',
+          '@mikro-orm/core',
+          '@nestjs/mongoose',
+          'type-graphql',
+        ],
+      },
+    ],
+  },
+
   // Tree-sitter grammars by extension for the canonical AST layer (src/ast/).
   // .tsx needs the tsx grammar (JSX-aware); .ts uses typescript; .js/.jsx/.mjs/
   // .cjs use javascript. Logical names — src/ast/ resolves them to artifacts.

--- a/src/loop/policy.ts
+++ b/src/loop/policy.ts
@@ -32,6 +32,7 @@ import {
 } from '../baseline/policy';
 import type { FindingStatus } from '../baseline/types';
 import type { FlowGateMode } from '../analyzers/flow/config';
+import type { SchemaGateMode } from '../analyzers/model-schema/config';
 
 /**
  * The two shipped loop postures.
@@ -65,6 +66,13 @@ interface PresetDef {
    * (only exact bindings can block even under `block`).
    */
   readonly flowMode: FlowGateMode;
+  /**
+   * Posture for the model-schema drift gate — same reasoning as `flowMode`
+   * (a contract-drift false positive must never wedge an unattended loop).
+   * The guardrail applies it only when the repo has ENABLED the gate:
+   * schema defaults to off, and a loop preset never activates it.
+   */
+  readonly schemaMode: SchemaGateMode;
 }
 
 /** The security class: secrets, crit/high SAST, crit/high reachable dep
@@ -88,6 +96,7 @@ const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
     block: [],
     blockRules: SECURITY_BLOCK_RULES,
     flowMode: 'warn',
+    schemaMode: 'warn',
   },
   'full-debt': {
     // Any net-new finding blocks (generic `added`), plus every escalation.
@@ -98,6 +107,7 @@ const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
       newSevereQualityIssueInChangedFiles: true,
     },
     flowMode: 'block',
+    schemaMode: 'block',
   },
 });
 
@@ -108,6 +118,7 @@ export interface ResolvedLoopPolicy {
   readonly policy: BrownfieldPolicy;
   readonly preset: LoopPreset;
   readonly flowMode: FlowGateMode;
+  readonly schemaMode: SchemaGateMode;
 }
 
 function isLoopPreset(v: unknown): v is LoopPreset {
@@ -186,6 +197,7 @@ export function resolveLoopPolicy(cwd: string): ResolvedLoopPolicy {
   return {
     preset,
     flowMode: def.flowMode,
+    schemaMode: def.schemaMode,
     policy: {
       ...base,
       block: def.block,

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -330,7 +330,7 @@ export async function runStopGate(cwd: string): Promise<void> {
   // Resolve the loop-scoped posture ONCE (preset → policy). This is the
   // only place the loop preset is read; the CI guardrail never sees it.
   const { resolveLoopPolicy } = await import('./policy');
-  const { policy, preset, flowMode } = resolveLoopPolicy(repoDir);
+  const { policy, preset, flowMode, schemaMode } = resolveLoopPolicy(repoDir);
 
   // ── Fast path: replay the last verdict when the working tree is
   // byte-identical to what was last gathered (a no-change stop — an
@@ -393,6 +393,7 @@ export async function runStopGate(cwd: string): Promise<void> {
       scope,
       incremental: true,
       flowMode,
+      schemaMode,
     });
     const json = renderJson(result);
     // Persist the full machine-readable verdict so the model (and a human)

--- a/src/schema-cli.ts
+++ b/src/schema-cli.ts
@@ -1,0 +1,131 @@
+/**
+ * `vyuh-dxkit schema` — the model-schema surface a developer drives by hand.
+ *
+ * Two subcommands, both thin orchestration over the canonical modules:
+ *   - `schema [inventory]` — the standing catalog: every model the repo
+ *     declares (code extraction + `schema.specs`), per file, with
+ *     unreadable-type disclosure. Reads through `gatherRepoModelSet`
+ *     (Rule 2 — policy config applied, cannot be forgotten).
+ *   - `schema diff [--ref <base>]` — the drift preview a developer runs
+ *     before pushing: the SAME `diffModelSets` + verdict assignment the
+ *     guardrail gate uses (`evaluateSchemaDriftGate`), against the same
+ *     default base resolution, so the preview and the gate can never tell
+ *     two stories (pinned by the parity test).
+ *
+ * Setup is folded into `configure` / policy (there is no `schema init`);
+ * diagnosis is doctor's job; gating is `guardrail check` — the flow-surface
+ * precedent.
+ */
+
+import * as path from 'path';
+import * as logger from './logger';
+import { gatherModelSet, gatherRepoModelSet } from './analyzers/model-schema/gather';
+import { readSchemaConfig } from './analyzers/model-schema/config';
+import {
+  describeSchemaDrift,
+  evaluateSchemaDriftGate,
+  type SchemaDriftFinding,
+} from './analyzers/model-schema/gate';
+import type { ModelSet } from './analyzers/model-schema/model';
+import { withRefWorktree } from './baseline/ref-baseline';
+import { probeOriginHeadRef } from './baseline/modes';
+
+/** `schema inventory` — list every declared model with its fields. */
+export async function runSchemaInventory(cwd: string, opts: { json?: boolean }): Promise<void> {
+  const set = await gatherRepoModelSet(cwd, { relativeTo: cwd });
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ schema: 'schema-inventory.v1', ...set }, null, 2) + '\n');
+    return;
+  }
+  if (set.models.length === 0) {
+    logger.info('No declared data models found.');
+    logger.info(
+      'Recognition is marker-based (ORM base classes, entity decorators, Go struct tags) ' +
+        'plus spec-declared models — point `.dxkit/policy.json:schema.specs` at an OpenAPI/' +
+        'JSON Schema file to cover unmarked DTOs.',
+    );
+    return;
+  }
+  logger.info(logger.bold(`Declared data models (${set.models.length})`));
+  for (const m of [...set.models].sort((a, b) => a.name.localeCompare(b.name))) {
+    logger.info('');
+    logger.info(`  ${logger.bold(m.name)}  (${m.via})  ${m.file}:${m.line}`);
+    for (const f of m.fields) {
+      const req = f.required === null ? '?' : f.required ? 'required' : 'optional';
+      logger.info(`    ${f.name}: ${f.type ?? '<unreadable>'}  [${req}]`);
+    }
+    if (m.fields.length === 0) logger.info('    (no statically readable fields)');
+  }
+  if (set.dynamicModels.length > 0) {
+    logger.info('');
+    logger.info(
+      logger.bold(`Dynamic models (${set.dynamicModels.length})`) +
+        ' — recognized but not statically enumerable; their drift is not gateable:',
+    );
+    for (const d of set.dynamicModels) logger.info(`  ${d.name}  ${d.file}:${d.line}`);
+  }
+}
+
+/** `schema diff --ref <base>` — preview drift vs a base ref, through the
+ *  exact evaluation the guardrail gate runs. */
+export async function runSchemaDiff(
+  cwd: string,
+  opts: { ref?: string; json?: boolean },
+): Promise<void> {
+  const config = readSchemaConfig(cwd);
+  // Default base = the guardrail's own resolution (the remote default
+  // branch), so the preview and the gate judge against the same ref.
+  const ref = opts.ref ?? probeOriginHeadRef(cwd) ?? 'origin/main';
+
+  const headModels = await gatherRepoModelSet(cwd, { relativeTo: cwd });
+  let baseModels: ModelSet;
+  try {
+    baseModels = await withRefWorktree({ cwd, ref }, async (wt) =>
+      gatherModelSet({
+        roots: [wt],
+        specs: config.specs.map((s) => path.resolve(wt, s)),
+        relativeTo: wt,
+      }),
+    );
+  } catch {
+    logger.fail(`Could not gather models at base ref '${ref}' — pass --ref <base>.`);
+    process.exit(1);
+  }
+
+  const findings = evaluateSchemaDriftGate({
+    baseModels,
+    headModels,
+    blockThreshold: config.blockThreshold,
+  });
+
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify({ schema: 'schema-diff.v1', ref, findings }, null, 2) + '\n',
+    );
+    return;
+  }
+  if (findings.length === 0) {
+    logger.info(`No schema drift vs ${ref}.`);
+    return;
+  }
+  const groups: Array<[SchemaDriftFinding['verdict'], string]> = [
+    ['block', 'Breaking (would block)'],
+    ['warn', 'Warnings'],
+    ['info', 'Informational'],
+  ];
+  for (const [verdict, title] of groups) {
+    const of = findings.filter((f) => f.verdict === verdict);
+    if (of.length === 0) continue;
+    logger.info(logger.bold(`${title} (${of.length})`));
+    for (const f of of) {
+      logger.info(`  ${describeSchemaDrift(f)}`);
+      if (verdict !== 'info') logger.info(`    · fingerprint: ${f.id}`);
+    }
+    logger.info('');
+  }
+  logger.info(
+    `Gate posture: schema.mode=${config.mode}. A deliberate breaking change ships with ` +
+      `an expiring accepted-risk allowlist entry (allowlist add --fingerprint=<id> ` +
+      `--kind=model-schema-drift --category=accepted-risk).`,
+  );
+}

--- a/test/allowlist/hint.test.ts
+++ b/test/allowlist/hint.test.ts
@@ -63,6 +63,17 @@ const ENTRIES: Record<BaselineEntry['kind'], BaselineEntry> = {
     file: 'web/List.tsx',
     line: 20,
   },
+  'model-schema-drift': {
+    id: FP,
+    kind: 'model-schema-drift',
+    model: 'User',
+    field: 'email',
+    changeClass: 'field-removed',
+    from: 'string',
+    to: null,
+    file: 'src/user.entity.ts',
+    line: 7,
+  },
   'custom-check': {
     id: FP,
     kind: 'custom-check',

--- a/test/baseline/finding-identity.test.ts
+++ b/test/baseline/finding-identity.test.ts
@@ -759,6 +759,89 @@ const FIXTURES: ReadonlyArray<IdentityFixture> = [
     expected: 'changed',
   },
 
+  // ─── model-schema-drift (5) ───────────────────────────────────────────
+  {
+    name: 'model-schema-drift/clean — same model, field, changeClass',
+    prior: {
+      kind: 'model-schema-drift',
+      model: 'User',
+      field: 'email',
+      changeClass: 'field-removed',
+    },
+    current: {
+      kind: 'model-schema-drift',
+      model: 'User',
+      field: 'email',
+      changeClass: 'field-removed',
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'model-schema-drift/different field → identity changes',
+    prior: {
+      kind: 'model-schema-drift',
+      model: 'User',
+      field: 'email',
+      changeClass: 'field-removed',
+    },
+    current: {
+      kind: 'model-schema-drift',
+      model: 'User',
+      field: 'nick',
+      changeClass: 'field-removed',
+    },
+    expected: 'changed',
+  },
+  {
+    name: 'model-schema-drift/different change class → identity changes',
+    prior: {
+      kind: 'model-schema-drift',
+      model: 'User',
+      field: 'email',
+      changeClass: 'field-removed',
+    },
+    current: {
+      kind: 'model-schema-drift',
+      model: 'User',
+      field: 'email',
+      changeClass: 'field-type-changed',
+    },
+    expected: 'changed',
+  },
+  {
+    name: 'model-schema-drift/different model → identity changes',
+    prior: {
+      kind: 'model-schema-drift',
+      model: 'User',
+      field: null,
+      changeClass: 'model-removed',
+    },
+    current: {
+      kind: 'model-schema-drift',
+      model: 'Person',
+      field: null,
+      changeClass: 'model-removed',
+    },
+    expected: 'changed',
+  },
+  {
+    name: 'model-schema-drift/model-level vs field-level stay distinct',
+    // null field vs a named field must not collide (the \0 separator).
+    prior: {
+      kind: 'model-schema-drift',
+      model: 'User',
+      field: null,
+      changeClass: 'model-removed',
+    },
+    current: {
+      kind: 'model-schema-drift',
+      model: 'User',
+      field: 'model-removed',
+      changeClass: '',
+    },
+    expected: 'changed',
+  },
+
   // ─── custom-check / lint findings (5) ─────────────────────────────────
   {
     name: 'custom-check/located clean — same check, file, line, rule',
@@ -1054,6 +1137,7 @@ const EXPECTED_KINDS = [
   'secret-hmac',
   'stale-allow',
   'flow-binding',
+  'model-schema-drift',
   'custom-check',
 ] as const;
 

--- a/test/baseline/producers-contract.test.ts
+++ b/test/baseline/producers-contract.test.ts
@@ -58,6 +58,7 @@ const ALL_KINDS: ReadonlyArray<IdentityKind> = [
   'secret-hmac',
   'stale-allow',
   'flow-binding',
+  'model-schema-drift',
   'custom-check',
 ];
 

--- a/test/baseline/schema-drift-gate-check.test.ts
+++ b/test/baseline/schema-drift-gate-check.test.ts
@@ -113,10 +113,10 @@ describe('evaluateSchemaDriftGateForGuardrail — real ref-based gate', () => {
     // Working tree: email removed, nick becomes required, org added optional.
     writeFileSync(
       join(dir, 'openapi.json'),
-      specDoc(
-        { id: { type: 'integer' }, nick: { type: 'string' }, org: { type: 'string' } },
-        ['id', 'nick'],
-      ),
+      specDoc({ id: { type: 'integer' }, nick: { type: 'string' }, org: { type: 'string' } }, [
+        'id',
+        'nick',
+      ]),
     );
     const out = await evaluateSchemaDriftGateForGuardrail({ cwd: dir, baseRef: 'main' });
     expect(out.ran).toBe(true);

--- a/test/baseline/schema-drift-gate-check.test.ts
+++ b/test/baseline/schema-drift-gate-check.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Integration tests for src/baseline/schema-drift-gate-check.ts — the
+ * additive, fail-open drift-gate pass over a real ref-based comparison.
+ * Fixtures use the SPEC bridge (policy `schema.specs` + a committed OpenAPI
+ * document), which exercises the full wiring — opt-in gating, trigger-skip,
+ * ref-worktree base gather, no-models self-skip, posture, allowlist, and
+ * fail-open — with zero pack extraction, proving the language-independent
+ * path end-to-end. Pack extraction is pinned by the extraction tests and the
+ * pack-declaration wave.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { evaluateSchemaDriftGateForGuardrail } from '../../src/baseline/schema-drift-gate-check';
+import { computeModelSchemaDriftFingerprint } from '../../src/analyzers/tools/fingerprint';
+import type { AllowlistFile } from '../../src/allowlist/file';
+
+function git(dir: string, args: string[]): void {
+  execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+}
+
+function specDoc(userProps: Record<string, unknown>, required: string[]): string {
+  return JSON.stringify({
+    openapi: '3.0.0',
+    components: {
+      schemas: { User: { type: 'object', required, properties: userProps } },
+    },
+  });
+}
+
+const BASE_SPEC = specDoc(
+  { id: { type: 'integer' }, email: { type: 'string' }, nick: { type: 'string' } },
+  ['id', 'email'],
+);
+
+/** A repo whose models come from a committed OpenAPI spec, with the schema
+ *  gate configured ON in block mode. Committed on `main` as the base. */
+function makeSchemaRepo(mode: 'block' | 'warn' = 'block'): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-schemagate-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'test']);
+  mkdirSync(join(dir, '.dxkit'), { recursive: true });
+  writeFileSync(
+    join(dir, '.dxkit', 'policy.json'),
+    JSON.stringify({ schema: { mode, specs: ['openapi.json'] } }),
+  );
+  writeFileSync(join(dir, 'openapi.json'), BASE_SPEC);
+  writeFileSync(join(dir, 'README.md'), 'fixture\n');
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  return dir;
+}
+
+describe('evaluateSchemaDriftGateForGuardrail — opt-in + skip paths', () => {
+  let dir: string;
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('skips as off with no schema policy — and an override never activates it', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-schemagate-'));
+    git(dir, ['init', '-q', '-b', 'main']);
+    const out = await evaluateSchemaDriftGateForGuardrail({ cwd: dir, baseRef: 'main' });
+    expect(out.skipped).toBe('off');
+    // The loop preset's warn must NOT switch on an unconfigured gate.
+    const overridden = await evaluateSchemaDriftGateForGuardrail({
+      cwd: dir,
+      baseRef: 'main',
+      modeOverride: 'warn',
+    });
+    expect(overridden.skipped).toBe('off');
+  });
+
+  it('skips when no base commit is resolvable', async () => {
+    dir = makeSchemaRepo();
+    const out = await evaluateSchemaDriftGateForGuardrail({ cwd: dir });
+    expect(out.ran).toBe(false);
+    expect(out.skipped).toBe('no-base-ref');
+  });
+
+  it('trigger-skips a diff that touches no model surface', async () => {
+    dir = makeSchemaRepo();
+    writeFileSync(join(dir, 'README.md'), 'docs-only change\n');
+    git(dir, ['add', '.']);
+    git(dir, ['commit', '-q', '-m', 'docs']);
+    const out = await evaluateSchemaDriftGateForGuardrail({ cwd: dir, baseRef: 'main~1' });
+    expect(out.ran).toBe(false);
+    expect(out.skipped).toBe('no-model-surface-change');
+  });
+
+  it('fails open (error skip) on a bogus ref', async () => {
+    dir = makeSchemaRepo();
+    const out = await evaluateSchemaDriftGateForGuardrail({
+      cwd: dir,
+      baseRef: 'no-such-ref-anywhere',
+    });
+    expect(out.ran).toBe(false);
+    expect(out.skipped).toBe('error');
+    expect(out.blocks).toBe(false);
+  });
+});
+
+describe('evaluateSchemaDriftGateForGuardrail — real ref-based gate', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeSchemaRepo();
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('blocks a field removal and a required tightening; disclosures ride along', async () => {
+    // Working tree: email removed, nick becomes required, org added optional.
+    writeFileSync(
+      join(dir, 'openapi.json'),
+      specDoc(
+        { id: { type: 'integer' }, nick: { type: 'string' }, org: { type: 'string' } },
+        ['id', 'nick'],
+      ),
+    );
+    const out = await evaluateSchemaDriftGateForGuardrail({ cwd: dir, baseRef: 'main' });
+    expect(out.ran).toBe(true);
+    expect(out.blocks).toBe(true);
+    const byClass = new Map(out.findings.map((f) => [`${f.changeClass}:${f.field}`, f]));
+    expect(byClass.get('field-removed:email')?.verdict).toBe('block');
+    expect(byClass.get('field-required-added:nick')?.verdict).toBe('block');
+    expect(byClass.get('field-added:org')?.verdict).toBe('info');
+  });
+
+  it('warn mode demotes blocks; verdict warns instead', async () => {
+    rmSync(dir, { recursive: true, force: true });
+    dir = makeSchemaRepo('warn');
+    writeFileSync(join(dir, 'openapi.json'), specDoc({ id: { type: 'integer' } }, ['id']));
+    const out = await evaluateSchemaDriftGateForGuardrail({ cwd: dir, baseRef: 'main' });
+    expect(out.ran).toBe(true);
+    expect(out.blocks).toBe(false);
+    expect(out.warns).toBe(true);
+    expect(out.findings.every((f) => f.verdict !== 'block')).toBe(true);
+  });
+
+  it('an active accepted-risk allowlist entry waives the block, disclosed', async () => {
+    writeFileSync(
+      join(dir, 'openapi.json'),
+      specDoc({ id: { type: 'integer' }, nick: { type: 'string' } }, ['id']),
+    );
+    const fp = computeModelSchemaDriftFingerprint('User', 'email', 'field-removed');
+    const allowlist: AllowlistFile = {
+      version: 1,
+      entries: [
+        {
+          fingerprint: fp,
+          kind: 'model-schema-drift',
+          category: 'accepted-risk',
+          reason: 'v2 migration removes email; clients updated',
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+      ],
+    } as unknown as AllowlistFile;
+    const out = await evaluateSchemaDriftGateForGuardrail({
+      cwd: dir,
+      baseRef: 'main',
+      allowlist,
+      now: new Date('2026-06-01T00:00:00Z'),
+    });
+    expect(out.blocks).toBe(false);
+    expect(out.suppressed).toHaveLength(1);
+    expect(out.suppressed[0].fingerprint).toBe(fp);
+  });
+
+  it('a pure spec-file rename-equivalent (unchanged content) produces no findings', async () => {
+    // Touch the spec with byte-identical model content but reordered JSON —
+    // extraction sees the same models, the gate stays silent.
+    writeFileSync(
+      join(dir, 'openapi.json'),
+      JSON.stringify(JSON.parse(BASE_SPEC)), // re-serialized, same content
+    );
+    const out = await evaluateSchemaDriftGateForGuardrail({ cwd: dir, baseRef: 'main' });
+    // Either trigger-skipped (no diff at all) or ran with zero findings.
+    expect(out.blocks).toBe(false);
+    expect(out.findings).toHaveLength(0);
+  });
+});

--- a/test/fixtures-analysis.test.ts
+++ b/test/fixtures-analysis.test.ts
@@ -28,6 +28,7 @@ import { tmpdir } from 'os';
 import { gatherFileFindings } from '../src/analyzers/security/gather';
 import { gatherGrepSecretsResult } from '../src/analyzers/tools/grep-secrets';
 import { gatherRepoFlowModel } from '../src/analyzers/flow/gather';
+import { gatherRepoModelSet } from '../src/analyzers/model-schema/gather';
 import { summarize } from '../src/analyzers/flow/model';
 import { buildReachable } from '../src/analyzers/tests/import-graph';
 
@@ -118,6 +119,52 @@ describe('analysis fixtures — language-agnostic invariants (every stack)', () 
       // `password: 'password'` / `api_key = 'your-api-key'` are placeholders.
       expect(result!.findings).toHaveLength(0);
       expect(result!.suppressedCount).toBeGreaterThanOrEqual(1);
+    });
+  }
+});
+
+describe('analysis fixtures — model-schema extraction (marker-based, every stack)', () => {
+  // The language-agnostic invariants: a MARKED model extracts with its
+  // optionality forms normalized; an unmarked helper next to it stays
+  // invisible (precision over recall — the capability's documented posture).
+  // One matrix, three stacks: a fix that only works for one framework
+  // overfits and fails here.
+  const MODEL_ROWS: Array<{
+    stack: string;
+    expected: string[];
+    optionalField: { model: string; field: string };
+    invisible: string;
+  }> = [
+    {
+      stack: 'ts-webapp',
+      expected: ['User'],
+      optionalField: { model: 'User', field: 'nick' }, // `?` marker
+      invisible: 'UserMapper',
+    },
+    {
+      stack: 'python-svc',
+      expected: ['Article', 'ArticleDto'],
+      optionalField: { model: 'Article', field: 'summary' }, // null=True
+      invisible: 'ArticleIndexer',
+    },
+    {
+      stack: 'go-svc',
+      expected: ['Report'],
+      optionalField: { model: 'Report', field: 'note' }, // pointer + omitempty
+      invisible: 'reportCache',
+    },
+  ];
+
+  for (const row of MODEL_ROWS) {
+    it(`${row.stack}: marked models extract, helpers stay invisible, optionality normalizes`, async () => {
+      const set = await gatherRepoModelSet(staged[row.stack]);
+      const names = set.models.map((m) => m.name);
+      for (const name of row.expected) expect(names, `missing model ${name}`).toContain(name);
+      expect(names).not.toContain(row.invisible);
+      const model = set.models.find((m) => m.name === row.optionalField.model)!;
+      const field = model.fields.find((f) => f.name === row.optionalField.field);
+      expect(field, `${row.optionalField.model}.${row.optionalField.field}`).toBeDefined();
+      expect(field!.required).toBe(false);
     });
   }
 });

--- a/test/fixtures/analysis/go-svc/internal/models/report.go
+++ b/test/fixtures/analysis/go-svc/internal/models/report.go
@@ -1,0 +1,13 @@
+package models
+
+// A tagged struct (extracted - the tag IS the wire-contract marker) next to
+// an untagged internal struct (invisible).
+type Report struct {
+	ID    int     `json:"id"`
+	Title string  `json:"title"`
+	Note  *string `json:"note,omitempty"`
+}
+
+type reportCache struct {
+	entries map[int]string
+}

--- a/test/fixtures/analysis/python-svc/src/models.py
+++ b/test/fixtures/analysis/python-svc/src/models.py
@@ -1,0 +1,17 @@
+# A Django model + a pydantic model (extracted) next to a plain class
+# (invisible - marker-based recognition, the fixture-matrix invariant).
+from dataclasses import dataclass
+
+
+class Article(models.Model):
+    title = models.CharField(max_length=200)
+    summary = models.TextField(null=True)
+
+
+class ArticleDto(BaseModel):
+    title: str
+    summary: str | None = None
+
+
+class ArticleIndexer:
+    batch_size = 50

--- a/test/fixtures/analysis/ts-webapp/src/entities/user.entity.ts
+++ b/test/fixtures/analysis/ts-webapp/src/entities/user.entity.ts
@@ -1,0 +1,12 @@
+// A decorator-marked entity (extracted) next to a plain helper (invisible —
+// marker-based recognition, the fixture-matrix invariant).
+@Entity()
+export class User {
+  email!: string;
+  nick?: string;
+  bio: string | null = null;
+}
+
+export class UserMapper {
+  cacheKey: string = 'users';
+}

--- a/test/grammar-model-shape.test.ts
+++ b/test/grammar-model-shape.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Grammar MODEL-shape adapter — the per-grammar syntax layer for data-model
+ * declarations (`src/ast/grammar-model-shape.ts`), sibling of the flow shape.
+ *
+ * These tests pin each row against REAL parses of the bundled wasm grammars:
+ * class/struct recognition, heritage, decorator attachment (including the TS
+ * export-statement hoist and the Python decorated_definition wrap), field
+ * enumeration, type text, grammar-level optionality markers, Go struct tags
+ * and multi-name declarations. Pack descriptors and drift semantics are
+ * pinned elsewhere; this file pins the ADAPTER.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSource, type Node } from '../src/ast/parse';
+import { modelShapeForGrammar, modelShapedGrammars } from '../src/ast/grammar-model-shape';
+
+const ts = modelShapeForGrammar('typescript')!;
+const py = modelShapeForGrammar('python')!;
+const go = modelShapeForGrammar('go')!;
+
+async function classesOf(src: string, grammar: string): Promise<Node[]> {
+  const shape = modelShapeForGrammar(grammar)!;
+  const tree = await parseSource(src, grammar);
+  expect(tree, `parse ${grammar}`).not.toBeNull();
+  const out: Node[] = [];
+  const visit = (node: Node) => {
+    if (shape.classNodes.includes(node.type)) out.push(node);
+    for (const c of node.namedChildren) if (c) visit(c);
+  };
+  visit(tree!.rootNode);
+  return out;
+}
+
+describe('grammar model shape — registry', () => {
+  it('has rows for the JS family, python, and go', () => {
+    for (const g of ['typescript', 'tsx', 'javascript', 'python', 'go']) {
+      expect(modelShapeForGrammar(g), g).not.toBeNull();
+      expect(modelShapedGrammars()).toContain(g);
+    }
+  });
+
+  it('returns null (never throws) for an unshaped grammar', () => {
+    expect(modelShapeForGrammar('cobol')).toBeNull();
+  });
+
+  it('the JS family shares one shape object', () => {
+    expect(modelShapeForGrammar('typescript')).toBe(modelShapeForGrammar('tsx'));
+    expect(modelShapeForGrammar('typescript')).toBe(modelShapeForGrammar('javascript'));
+  });
+});
+
+describe('grammar model shape — typescript', () => {
+  const SRC = `
+@Entity()
+export class User extends BaseEntity {
+  @Column({ nullable: true })
+  email?: string;
+  name: string | null = 'x';
+  private secret: string;
+  greet(): void {}
+}
+
+class Plain {
+  id = 1;
+}
+`;
+
+  it('reads name, heritage, and hoisted export decorators', async () => {
+    const [user, plain] = await classesOf(SRC, 'typescript');
+    expect(ts.className(user)).toBe('User');
+    expect(ts.heritage(user)).toEqual(['BaseEntity']);
+    const decorators = ts.classDecorators(user);
+    expect(decorators).toHaveLength(1);
+    expect(decorators[0].text).toBe('@Entity()');
+
+    expect(ts.className(plain)).toBe('Plain');
+    expect(ts.heritage(plain)).toEqual([]);
+    expect(ts.classDecorators(plain)).toEqual([]);
+  });
+
+  it('enumerates fields (not methods) with names, types, markers, decorators', async () => {
+    const [user] = await classesOf(SRC, 'typescript');
+    const fields = ts.fieldNodes(user);
+    expect(fields.map((f) => ts.fieldNames(f)).flat()).toEqual(['email', 'name', 'secret']);
+
+    const [email, name, secret] = fields;
+    expect(ts.fieldTypeText(email)).toBe('string');
+    expect(ts.fieldOptionalMarker(email)).toBe(true);
+    expect(ts.fieldDecorators(email).map((d) => d.text)).toEqual(['@Column({ nullable: true })']);
+
+    expect(ts.fieldTypeText(name)).toBe('string | null');
+    expect(ts.fieldOptionalMarker(name)).toBe(false);
+
+    expect(ts.fieldTypeText(secret)).toBe('string');
+  });
+
+  it('reads a field-initializer call for fieldValueCall', async () => {
+    const [k] = await classesOf(`class K { rel = relation('User'); plain = 3; }`, 'typescript');
+    const [rel, plain] = ts.fieldNodes(k);
+    expect(ts.fieldValueCall(rel)?.text).toBe(`relation('User')`);
+    expect(ts.fieldValueCall(plain)).toBeNull();
+  });
+
+  it('plain JS: field_definition/property naming, untyped reads null', async () => {
+    const js = modelShapeForGrammar('javascript')!;
+    const [k] = await classesOf(`class K { a = 1; @Dec() b = relation(1) }`, 'javascript');
+    const fields = js.fieldNodes(k);
+    expect(fields.map((f) => js.fieldNames(f)).flat()).toEqual(['a', 'b']);
+    const [a, b] = fields;
+    expect(js.fieldTypeText(a)).toBeNull();
+    expect(js.fieldOptionalMarker(a)).toBe(false);
+    expect(js.fieldDecorators(b).map((d) => d.text)).toEqual(['@Dec()']);
+    expect(js.fieldValueCall(b)?.text).toBe('relation(1)');
+  });
+});
+
+describe('grammar model shape — python', () => {
+  const SRC = `
+@dataclass
+class Point:
+    x: int
+    y: int = 0
+
+class User(models.Model, Mixin, metaclass=Meta):
+    email = models.CharField(max_length=255, null=True)
+
+class Item(BaseModel):
+    name: str
+    def save(self):
+        self.tmp = 1
+`;
+
+  it('reads name, superclasses (skipping keyword args), and wrap decorators', async () => {
+    const [point, user, item] = await classesOf(SRC, 'python');
+    expect(py.className(point)).toBe('Point');
+    expect(py.classDecorators(point).map((d) => d.text)).toEqual(['@dataclass']);
+
+    expect(py.className(user)).toBe('User');
+    expect(py.heritage(user)).toEqual(['models.Model', 'Mixin']);
+    expect(py.classDecorators(user)).toEqual([]);
+
+    expect(py.heritage(item)).toEqual(['BaseModel']);
+  });
+
+  it('enumerates class-level assignments only (method bodies excluded)', async () => {
+    const [point, user, item] = await classesOf(SRC, 'python');
+    expect(py.fieldNodes(point).map((f) => py.fieldNames(f)).flat()).toEqual(['x', 'y']);
+    expect(py.fieldNodes(item).map((f) => py.fieldNames(f)).flat()).toEqual(['name']);
+
+    const [email] = py.fieldNodes(user);
+    expect(py.fieldNames(email)).toEqual(['email']);
+    expect(py.fieldTypeText(email)).toBeNull();
+    expect(py.fieldValueCall(email)?.text).toContain('models.CharField');
+    expect(py.fieldOptionalMarker(email)).toBeNull();
+  });
+
+  it('reads annotation type text verbatim (normalizer folds the forms)', async () => {
+    const [k] = await classesOf(
+      `class K(BaseModel):\n    a: Optional[int] = 3\n    b: float | None = None\n`,
+      'python',
+    );
+    const [a, b] = py.fieldNodes(k);
+    expect(py.fieldTypeText(a)).toBe('Optional[int]');
+    expect(py.fieldTypeText(b)).toBe('float | None');
+  });
+});
+
+describe('grammar model shape — go', () => {
+  const SRC = `
+package m
+
+type User struct {
+	Email *string \`json:"email,omitempty"\`
+	X, Y  int
+	inner helper
+	Base
+}
+
+type Alias = User
+type Num int
+`;
+
+  it('recognizes only struct-typed specs as model-bearing', async () => {
+    const specs = await classesOf(SRC, 'go');
+    const names = specs.map((s) => go.className(s));
+    expect(names).toContain('User');
+    // Alias and Num are type_specs/aliases but not struct-typed → null.
+    expect(names.filter((n) => n !== null)).toEqual(['User']);
+  });
+
+  it('enumerates fields with multi-name splits, tags, pointer optionality', async () => {
+    const specs = await classesOf(SRC, 'go');
+    const user = specs.find((s) => go.className(s) === 'User')!;
+    const fields = go.fieldNodes(user);
+
+    const [email, xy, inner, embedded] = fields;
+    expect(go.fieldNames(email)).toEqual(['Email']);
+    expect(go.fieldTypeText(email)).toBe('*string');
+    expect(go.fieldOptionalMarker(email)).toBe(true);
+    expect(go.fieldTag(email)).toBe('`json:"email,omitempty"`');
+
+    expect(go.fieldNames(xy)).toEqual(['X', 'Y']);
+    expect(go.fieldTypeText(xy)).toBe('int');
+    expect(go.fieldOptionalMarker(xy)).toBe(false);
+
+    expect(go.fieldNames(inner)).toEqual(['inner']);
+    // Embedded field: no declared name — caller skips it.
+    expect(go.fieldNames(embedded)).toEqual([]);
+  });
+
+  it('heritage and decorators are empty (Go has neither)', async () => {
+    const specs = await classesOf(SRC, 'go');
+    const user = specs.find((s) => go.className(s) === 'User')!;
+    expect(go.heritage(user)).toEqual([]);
+    expect(go.classDecorators(user)).toEqual([]);
+  });
+});

--- a/test/grammar-model-shape.test.ts
+++ b/test/grammar-model-shape.test.ts
@@ -146,8 +146,18 @@ class Item(BaseModel):
 
   it('enumerates class-level assignments only (method bodies excluded)', async () => {
     const [point, user, item] = await classesOf(SRC, 'python');
-    expect(py.fieldNodes(point).map((f) => py.fieldNames(f)).flat()).toEqual(['x', 'y']);
-    expect(py.fieldNodes(item).map((f) => py.fieldNames(f)).flat()).toEqual(['name']);
+    expect(
+      py
+        .fieldNodes(point)
+        .map((f) => py.fieldNames(f))
+        .flat(),
+    ).toEqual(['x', 'y']);
+    expect(
+      py
+        .fieldNodes(item)
+        .map((f) => py.fieldNames(f))
+        .flat(),
+    ).toEqual(['name']);
 
     const [email] = py.fieldNodes(user);
     expect(py.fieldNames(email)).toEqual(['email']);

--- a/test/grammar-model-shape.test.ts
+++ b/test/grammar-model-shape.test.ts
@@ -108,7 +108,9 @@ class Plain {
     expect(fields.map((f) => js.fieldNames(f)).flat()).toEqual(['a', 'b']);
     const [a, b] = fields;
     expect(js.fieldTypeText(a)).toBeNull();
-    expect(js.fieldOptionalMarker(a)).toBe(false);
+    // No annotation at all → the marker is honestly unknown (three-valued):
+    // a fabricated `required` would let the drift diff block on it.
+    expect(js.fieldOptionalMarker(a)).toBeNull();
     expect(js.fieldDecorators(b).map((d) => d.text)).toEqual(['@Dec()']);
     expect(js.fieldValueCall(b)?.text).toBe('relation(1)');
   });

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -5,6 +5,7 @@ import { LANGUAGES, getLanguage, detectActiveLanguages } from '../src/languages'
 import type { LanguageId, LanguageSupport } from '../src/languages';
 import { TOOL_DEFS } from '../src/analyzers/tools/tool-registry';
 import { grammarShape } from '../src/ast/grammar-shape';
+import { modelShapeForGrammar } from '../src/ast/grammar-model-shape';
 
 const REQUIRED_IDS: LanguageId[] = ['typescript', 'python', 'go', 'rust', 'csharp'];
 
@@ -513,6 +514,72 @@ describe.each(LANGUAGES as LanguageSupport[])('language contract: $id', (lang) =
     // Discovery signals, when declared, must be well-formed (an empty anyOf
     // silently recommends nothing).
     for (const signal of hf.flowSignals ?? []) {
+      expect(signal.manifest.length).toBeGreaterThan(0);
+      expect(signal.anyOf.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('modelSchema, when declared, is extraction-complete (grammar + model shape + wasm) and non-vacuous', () => {
+    if (!lang.modelSchema) return; // packs without canonical model conventions skip
+    const ms = lang.modelSchema;
+
+    // 1. A model descriptor without a grammar can never parse a file.
+    const grammars = Object.entries(lang.treeSitterGrammars ?? {});
+    expect(
+      grammars.length,
+      `${lang.id}: declares modelSchema but no treeSitterGrammars — no file would ever ` +
+        `parse, so the descriptor is dead. Declare the grammar(s) for its source extensions.`,
+    ).toBeGreaterThan(0);
+
+    for (const [ext, grammar] of grammars) {
+      // 2. The grammar must have a MODEL shape row (grammar-model-shape.ts) —
+      //    the extractor skips files whose class/field syntax it cannot read.
+      expect(
+        modelShapeForGrammar(grammar),
+        `${lang.id}: grammar "${grammar}" has no model-shape row in ` +
+          `src/ast/grammar-model-shape.ts — model extraction would silently skip every ` +
+          `${ext} file. Add the row, verified against the bundled wasm.`,
+      ).not.toBeNull();
+      // 3. The wasm artifact must actually ship (shared with the flow check,
+      //    re-asserted here so a model-only pack still fails loud).
+      const wasmsDir = path.dirname(require.resolve('tree-sitter-wasms/package.json'));
+      const wasm = path.join(wasmsDir, 'out', `tree-sitter-${grammar}.wasm`);
+      expect(
+        fs.existsSync(wasm),
+        `${lang.id}: no bundled wasm for grammar "${grammar}" (${wasm})`,
+      ).toBe(true);
+    }
+
+    // 4. Non-vacuous: at least one RECOGNITION family (base classes /
+    //    decorators / struct tags — fieldCallees only enrich, they cannot
+    //    recognize), and every present family/sub-shape well-formed.
+    const recognition = [ms.modelBaseClasses, ms.modelDecorators, ms.structTagKeys].filter(
+      (f): f is string[] => f !== undefined,
+    );
+    expect(
+      recognition.length,
+      `${lang.id}: modelSchema declares no recognition family (modelBaseClasses / ` +
+        `modelDecorators / structTagKeys) — a vacuous descriptor that can never mark a model`,
+    ).toBeGreaterThan(0);
+    for (const family of recognition) {
+      expect(family.length, `${lang.id}: a modelSchema recognition family is empty`).toBeGreaterThan(
+        0,
+      );
+    }
+    for (const fc of ms.fieldCallees ?? []) {
+      expect(fc.names.length, `${lang.id}: a fieldCallees entry has no names`).toBeGreaterThan(0);
+      if (fc.optionalityKeyword !== undefined) {
+        expect(fc.optionalityKeyword.length).toBeGreaterThan(0);
+      }
+    }
+    for (const [key, value] of Object.entries(ms.typeAliases ?? {})) {
+      expect(key, `${lang.id}: typeAliases key "${key}" must be lowercase`).toBe(
+        key.toLowerCase(),
+      );
+      expect(value.length).toBeGreaterThan(0);
+    }
+    // Discovery signals, when declared, must be well-formed.
+    for (const signal of ms.schemaSignals ?? []) {
       expect(signal.manifest.length).toBeGreaterThan(0);
       expect(signal.anyOf.length).toBeGreaterThan(0);
     }

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -562,9 +562,10 @@ describe.each(LANGUAGES as LanguageSupport[])('language contract: $id', (lang) =
         `modelDecorators / structTagKeys) — a vacuous descriptor that can never mark a model`,
     ).toBeGreaterThan(0);
     for (const family of recognition) {
-      expect(family.length, `${lang.id}: a modelSchema recognition family is empty`).toBeGreaterThan(
-        0,
-      );
+      expect(
+        family.length,
+        `${lang.id}: a modelSchema recognition family is empty`,
+      ).toBeGreaterThan(0);
     }
     for (const fc of ms.fieldCallees ?? []) {
       expect(fc.names.length, `${lang.id}: a fieldCallees entry has no names`).toBeGreaterThan(0);
@@ -573,9 +574,7 @@ describe.each(LANGUAGES as LanguageSupport[])('language contract: $id', (lang) =
       }
     }
     for (const [key, value] of Object.entries(ms.typeAliases ?? {})) {
-      expect(key, `${lang.id}: typeAliases key "${key}" must be lowercase`).toBe(
-        key.toLowerCase(),
-      );
+      expect(key, `${lang.id}: typeAliases key "${key}" must be lowercase`).toBe(key.toLowerCase());
       expect(value.length).toBeGreaterThan(0);
     }
     // Discovery signals, when declared, must be well-formed.

--- a/test/model-schema-config-spec.test.ts
+++ b/test/model-schema-config-spec.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Model-schema config + spec bridge — the single policy reader/writer
+ * (`.dxkit/policy.json:schema`, Rule 2) and the language-independent
+ * spec-declared model source (OpenAPI components/definitions, JSON Schema).
+ * The v1 config keys (specs/mode/blockThreshold) are a FROZEN contract —
+ * renaming one breaks committed policy files.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  existingSchemaMode,
+  readSchemaConfig,
+  writeSchemaPolicy,
+  SCHEMA_CONFIG_SCHEMA_VERSION,
+} from '../src/analyzers/model-schema/config';
+import { loadSpecModels, modelsFromSpec } from '../src/analyzers/model-schema/spec-source';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-schema-config-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writePolicy(obj: unknown): void {
+  fs.mkdirSync(path.join(tmp, '.dxkit'), { recursive: true });
+  fs.writeFileSync(path.join(tmp, '.dxkit', 'policy.json'), JSON.stringify(obj));
+}
+
+describe('schema config — reader', () => {
+  it('defaults to OFF with no policy (opt-in capability, fail-open)', () => {
+    expect(readSchemaConfig(tmp)).toEqual({ specs: [], mode: 'off', blockThreshold: 1 });
+    expect(existingSchemaMode(tmp)).toBeUndefined();
+  });
+
+  it('reads the frozen v1 keys', () => {
+    writePolicy({
+      schema: { specs: ['api/openapi.json'], mode: 'block', blockThreshold: 0.8 },
+    });
+    expect(readSchemaConfig(tmp)).toEqual({
+      specs: ['api/openapi.json'],
+      mode: 'block',
+      blockThreshold: 0.8,
+    });
+    expect(existingSchemaMode(tmp)).toBe('block');
+  });
+
+  it('malformed values degrade field-wise to defaults, never throw', () => {
+    writePolicy({ schema: { specs: 'nope', mode: 'loud', blockThreshold: -3 } });
+    expect(readSchemaConfig(tmp)).toEqual({ specs: [], mode: 'off', blockThreshold: 1 });
+    writePolicy({ schema: 42 });
+    expect(readSchemaConfig(tmp).mode).toBe('off');
+  });
+});
+
+describe('schema config — writer', () => {
+  it('merge-writes, stamps schemaVersion, preserves sibling sections', () => {
+    writePolicy({ loop: { preset: 'security-only' }, flow: { mode: 'block' } });
+    expect(writeSchemaPolicy(tmp, { mode: 'warn' })).toBe(true);
+    const on = JSON.parse(fs.readFileSync(path.join(tmp, '.dxkit', 'policy.json'), 'utf8'));
+    expect(on.schema.mode).toBe('warn');
+    expect(on.schema.schemaVersion).toBe(SCHEMA_CONFIG_SCHEMA_VERSION);
+    expect(on.loop.preset).toBe('security-only');
+    expect(on.flow.mode).toBe('block');
+    // Idempotent: same patch again changes nothing.
+    expect(writeSchemaPolicy(tmp, { mode: 'warn' })).toBe(false);
+  });
+});
+
+describe('spec-declared models', () => {
+  const OPENAPI3 = {
+    openapi: '3.0.0',
+    components: {
+      schemas: {
+        User: {
+          type: 'object',
+          required: ['id', 'email'],
+          properties: {
+            id: { type: 'integer' },
+            email: { type: 'string' },
+            nick: { type: 'string' },
+            address: { $ref: '#/components/schemas/Address' },
+            tags: { type: 'array', items: { type: 'string' } },
+          },
+        },
+        Address: { type: 'object', properties: { city: { type: 'string' } } },
+        Color: { type: 'string', enum: ['red'] }, // no properties → not field-diffable
+      },
+    },
+  };
+
+  it('reads OpenAPI 3.x components.schemas with required/$ref/arrays', () => {
+    const models = modelsFromSpec(OPENAPI3, 'openapi.json');
+    expect(models.map((m) => m.name)).toEqual(['User', 'Address']);
+    const user = models[0];
+    expect(user.via).toBe('spec');
+    expect(user.fields).toEqual([
+      { name: 'id', type: 'integer', required: true },
+      { name: 'email', type: 'string', required: true },
+      { name: 'nick', type: 'string', required: false },
+      { name: 'address', type: 'Address', required: false },
+      { name: 'tags', type: 'string[]', required: false },
+    ]);
+  });
+
+  it('reads Swagger 2.0 definitions and JSON Schema $defs', () => {
+    expect(
+      modelsFromSpec(
+        { definitions: { Pet: { properties: { name: { type: 'string' } } } } },
+        's.json',
+      ).map((m) => m.name),
+    ).toEqual(['Pet']);
+    expect(
+      modelsFromSpec(
+        { $defs: { Leg: { properties: { len: { type: 'number' } } } } },
+        's.json',
+      ).map((m) => m.name),
+    ).toEqual(['Leg']);
+  });
+
+  it('reads a bare titled JSON Schema as one root model', () => {
+    const models = modelsFromSpec(
+      { title: 'Config', properties: { debug: { type: 'boolean' } }, required: ['debug'] },
+      'config.schema.json',
+    );
+    expect(models).toEqual([
+      {
+        name: 'Config',
+        via: 'spec',
+        file: 'config.schema.json',
+        line: 0,
+        fields: [{ name: 'debug', type: 'boolean', required: true }],
+      },
+    ]);
+  });
+
+  it('loadSpecModels is fail-open on unreadable/non-schema files', () => {
+    expect(loadSpecModels(path.join(tmp, 'missing.json'))).toEqual([]);
+    const bad = path.join(tmp, 'bad.json');
+    fs.writeFileSync(bad, 'not json');
+    expect(loadSpecModels(bad)).toEqual([]);
+    const notSchema = path.join(tmp, 'plain.json');
+    fs.writeFileSync(notSchema, JSON.stringify({ hello: 'world' }));
+    expect(loadSpecModels(notSchema)).toEqual([]);
+  });
+});

--- a/test/model-schema-config-spec.test.ts
+++ b/test/model-schema-config-spec.test.ts
@@ -115,10 +115,9 @@ describe('spec-declared models', () => {
       ).map((m) => m.name),
     ).toEqual(['Pet']);
     expect(
-      modelsFromSpec(
-        { $defs: { Leg: { properties: { len: { type: 'number' } } } } },
-        's.json',
-      ).map((m) => m.name),
+      modelsFromSpec({ $defs: { Leg: { properties: { len: { type: 'number' } } } } }, 's.json').map(
+        (m) => m.name,
+      ),
     ).toEqual(['Leg']);
   });
 

--- a/test/model-schema-core.test.ts
+++ b/test/model-schema-core.test.ts
@@ -66,6 +66,24 @@ describe('normalize', () => {
     });
   });
 
+  it('folds pack-declared transparent wrappers before other folds', () => {
+    expect(
+      normalizeField({
+        rawType: 'so.Mapped[Optional[str]]',
+        markerOptional: null,
+        typeWrappers: ['Mapped'],
+      }),
+    ).toEqual({ type: 'str', required: false });
+    expect(
+      normalizeField({ rawType: 'Mapped[int]', markerOptional: null, typeWrappers: ['Mapped'] }),
+    ).toEqual({ type: 'int', required: true });
+    // Undeclared wrapper stays — it IS the type.
+    expect(
+      normalizeField({ rawType: 'List[int]', markerOptional: null, typeWrappers: ['Mapped'] })
+        .type,
+    ).toBe('List[int]');
+  });
+
   it('resolves requiredness by specificity: descriptor > fold > marker', () => {
     // Marker says optional (`?`), no fold, no descriptor.
     expect(normalizeField({ rawType: 'string', markerOptional: true }).required).toBe(false);

--- a/test/model-schema-core.test.ts
+++ b/test/model-schema-core.test.ts
@@ -170,9 +170,7 @@ class Item(Base):
       'python',
       {
         modelBaseClasses: ['Base'],
-        fieldCallees: [
-          { names: ['Column'], typeFrom: 'firstArg', optionalityKeyword: 'nullable' },
-        ],
+        fieldCallees: [{ names: ['Column'], typeFrom: 'firstArg', optionalityKeyword: 'nullable' }],
       },
     );
     expect(models[0].fields).toEqual([
@@ -231,7 +229,10 @@ describe('pairModels — name-anchored, relocation-tolerant', () => {
   const fields = [{ name: 'id', type: 'int', required: true }];
 
   it('a pure file move pairs as relocated with confidence 1', () => {
-    const join = pairModels(set(entity('User', 'a/models.ts', fields)), set(entity('User', 'b/models.ts', fields)));
+    const join = pairModels(
+      set(entity('User', 'a/models.ts', fields)),
+      set(entity('User', 'b/models.ts', fields)),
+    );
     expect(join.pairs).toHaveLength(1);
     expect(join.pairs[0].reason).toBe('relocated');
     expect(join.pairs[0].confidence).toBe(1);
@@ -305,7 +306,10 @@ describe('pairModels — name-anchored, relocation-tolerant', () => {
   });
 
   it('a rename is an honest remove + add', () => {
-    const join = pairModels(set(entity('User', 'a.ts', fields)), set(entity('Person', 'a.ts', fields)));
+    const join = pairModels(
+      set(entity('User', 'a.ts', fields)),
+      set(entity('Person', 'a.ts', fields)),
+    );
     expect(join.pairs).toEqual([]);
     expect(join.removed.map((e) => e.name)).toEqual(['User']);
     expect(join.added.map((e) => e.name)).toEqual(['Person']);
@@ -348,9 +352,7 @@ describe('diffModelSets — taxonomy and unknown rules', () => {
   });
 
   it('a pure file move produces ZERO findings', () => {
-    const moved = set(
-      entity('User', 'relocated/models.ts', [...base.models[0].fields]),
-    );
+    const moved = set(entity('User', 'relocated/models.ts', [...base.models[0].fields]));
     expect(diffModelSets(base, moved)).toEqual([]);
   });
 

--- a/test/model-schema-core.test.ts
+++ b/test/model-schema-core.test.ts
@@ -79,8 +79,7 @@ describe('normalize', () => {
     ).toEqual({ type: 'int', required: true });
     // Undeclared wrapper stays — it IS the type.
     expect(
-      normalizeField({ rawType: 'List[int]', markerOptional: null, typeWrappers: ['Mapped'] })
-        .type,
+      normalizeField({ rawType: 'List[int]', markerOptional: null, typeWrappers: ['Mapped'] }).type,
     ).toBe('List[int]');
   });
 

--- a/test/model-schema-core.test.ts
+++ b/test/model-schema-core.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Model-schema core — extraction (grammar-agnostic, descriptor-driven),
+ * normalization folds, the name-anchored relocation-tolerant join, and the
+ * drift diff's taxonomy + unknown rules.
+ *
+ * Descriptors here are SYNTHETIC (pack declarations are pinned with their
+ * own wave, mirror of the flow test layering): these tests prove the
+ * extractor carries no framework literal and the diff carries no posture.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSource } from '../src/ast/parse';
+import { grammarShape } from '../src/ast/grammar-shape';
+import { modelShapeForGrammar } from '../src/ast/grammar-model-shape';
+import { extractModelsFromTree } from '../src/analyzers/model-schema/extract';
+import { normalizeField, tagWireName } from '../src/analyzers/model-schema/normalize';
+import {
+  diffModelSets,
+  pairModels,
+  type ModelEntity,
+  type ModelSet,
+} from '../src/analyzers/model-schema/model';
+import type { ModelSchemaSupport } from '../src/languages/types';
+
+async function extract(
+  src: string,
+  grammar: string,
+  descriptor: ModelSchemaSupport,
+  file = 'sample',
+): Promise<ModelSet> {
+  const tree = await parseSource(src, grammar);
+  expect(tree, `parse ${grammar}`).not.toBeNull();
+  return extractModelsFromTree(
+    tree!.rootNode,
+    descriptor,
+    modelShapeForGrammar(grammar)!,
+    grammarShape(grammar),
+    file,
+  );
+}
+
+function entity(name: string, file: string, fields: ModelEntity['fields']): ModelEntity {
+  return { name, via: 'base-class', file, line: 1, fields };
+}
+function set(...models: ModelEntity[]): ModelSet {
+  return { models, dynamicModels: [] };
+}
+
+describe('normalize', () => {
+  it('folds optionality wrappers out of type text', () => {
+    expect(normalizeField({ rawType: 'Optional[int]', markerOptional: null })).toEqual({
+      type: 'int',
+      required: false,
+    });
+    expect(normalizeField({ rawType: 'str | None', markerOptional: null })).toEqual({
+      type: 'str',
+      required: false,
+    });
+    expect(normalizeField({ rawType: 'string | null', markerOptional: false })).toEqual({
+      type: 'string',
+      required: false,
+    });
+    expect(normalizeField({ rawType: '*string', markerOptional: true })).toEqual({
+      type: 'string',
+      required: false,
+    });
+  });
+
+  it('resolves requiredness by specificity: descriptor > fold > marker', () => {
+    // Marker says optional (`?`), no fold, no descriptor.
+    expect(normalizeField({ rawType: 'string', markerOptional: true }).required).toBe(false);
+    // No marker concept (python), plain annotation → required.
+    expect(normalizeField({ rawType: 'str', markerOptional: null }).required).toBe(true);
+    // Descriptor wins over everything (nullable=True on a required-marked field).
+    expect(
+      normalizeField({ rawType: 'string', markerOptional: false, descriptorOptional: true })
+        .required,
+    ).toBe(false);
+    // Nothing known at all.
+    expect(normalizeField({ rawType: null, markerOptional: null })).toEqual({
+      type: null,
+      required: null,
+    });
+  });
+
+  it('applies lowercase-keyed pack type aliases after folding', () => {
+    expect(
+      normalizeField({
+        rawType: 'CharField',
+        markerOptional: null,
+        typeAliases: { charfield: 'string' },
+      }).type,
+    ).toBe('string');
+  });
+
+  it('reads struct-tag wire names, omitempty, and exclusions', () => {
+    expect(tagWireName('`json:"email,omitempty" gorm:"col"`', 'json')).toEqual({
+      name: 'email',
+      optional: true,
+    });
+    expect(tagWireName('`json:"name"`', 'json')).toEqual({ name: 'name', optional: false });
+    expect(tagWireName('`json:"-"`', 'json')).toBeNull();
+    expect(tagWireName('`gorm:"x"`', 'json')).toBeNull();
+  });
+});
+
+describe('extraction — typescript (decorator markers)', () => {
+  const DESCRIPTOR: ModelSchemaSupport = { modelDecorators: ['Entity'] };
+
+  it('extracts decorated classes only, with ? optionality and null unions', async () => {
+    const { models } = await extract(
+      `
+@Entity()
+export class User extends Base {
+  email?: string;
+  name: string | null;
+  age: number;
+}
+class Helper { x: number; }
+`,
+      'typescript',
+      DESCRIPTOR,
+    );
+    expect(models).toHaveLength(1);
+    expect(models[0].name).toBe('User');
+    expect(models[0].via).toBe('decorator');
+    expect(models[0].fields).toEqual([
+      { name: 'email', type: 'string', required: false },
+      { name: 'name', type: 'string', required: false },
+      { name: 'age', type: 'number', required: true },
+    ]);
+  });
+
+  it('discloses a marked model with no readable fields as dynamic', async () => {
+    const out = await extract(`@Entity() class Ghost { }`, 'typescript', DESCRIPTOR);
+    expect(out.models).toHaveLength(1);
+    expect(out.dynamicModels).toEqual([{ name: 'Ghost', file: 'sample', line: 1 }]);
+  });
+});
+
+describe('extraction — python (heritage + field constructors)', () => {
+  it('django-style: callee type token, optionality keyword, framework default', async () => {
+    const { models } = await extract(
+      `
+class User(models.Model):
+    email = models.CharField(max_length=255, null=True)
+    age = models.IntegerField()
+`,
+      'python',
+      {
+        modelBaseClasses: ['Model'],
+        fieldCallees: [{ names: ['CharField', 'IntegerField'], optionalityKeyword: 'null' }],
+        typeAliases: { charfield: 'string', integerfield: 'int' },
+      },
+    );
+    expect(models[0].via).toBe('base-class');
+    expect(models[0].fields).toEqual([
+      { name: 'email', type: 'string', required: false },
+      { name: 'age', type: 'int', required: true }, // null absent → framework default
+    ]);
+  });
+
+  it('sqlalchemy-style: type from first argument, nullable keyword', async () => {
+    const { models } = await extract(
+      `
+class Item(Base):
+    id = Column(Integer, primary_key=True)
+    label = db.Column(db.String(80), nullable=False)
+`,
+      'python',
+      {
+        modelBaseClasses: ['Base'],
+        fieldCallees: [
+          { names: ['Column'], typeFrom: 'firstArg', optionalityKeyword: 'nullable' },
+        ],
+      },
+    );
+    expect(models[0].fields).toEqual([
+      { name: 'id', type: 'Integer', required: true },
+      { name: 'label', type: 'String', required: true },
+    ]);
+  });
+
+  it('pydantic/dataclass-style: annotations with Optional folds', async () => {
+    const { models } = await extract(
+      `
+@dataclass
+class Point:
+    x: int
+    y: Optional[int] = None
+`,
+      'python',
+      { modelDecorators: ['dataclass'] },
+    );
+    expect(models[0].fields).toEqual([
+      { name: 'x', type: 'int', required: true },
+      { name: 'y', type: 'int', required: false },
+    ]);
+  });
+});
+
+describe('extraction — go (struct-tag markers)', () => {
+  it('extracts tagged structs with wire names, omitempty, pointers, multi-name', async () => {
+    const { models } = await extract(
+      `
+package m
+type User struct {
+	Email *string \`json:"email,omitempty"\`
+	Name  string  \`json:"name"\`
+	X, Y  int     \`json:"-"\`
+	skip  helper
+}
+type helper struct{ n int }
+`,
+      'go',
+      { structTagKeys: ['json'] },
+    );
+    expect(models).toHaveLength(1);
+    expect(models[0].via).toBe('struct-tag');
+    expect(models[0].fields).toEqual([
+      { name: 'email', type: 'string', required: false },
+      { name: 'name', type: 'string', required: true },
+      { name: 'X', type: 'int', required: true }, // json:"-" → declared name kept
+      { name: 'Y', type: 'int', required: true },
+      { name: 'skip', type: 'helper', required: true },
+    ]);
+  });
+});
+
+describe('pairModels — name-anchored, relocation-tolerant', () => {
+  const fields = [{ name: 'id', type: 'int', required: true }];
+
+  it('a pure file move pairs as relocated with confidence 1', () => {
+    const join = pairModels(set(entity('User', 'a/models.ts', fields)), set(entity('User', 'b/models.ts', fields)));
+    expect(join.pairs).toHaveLength(1);
+    expect(join.pairs[0].reason).toBe('relocated');
+    expect(join.pairs[0].confidence).toBe(1);
+    expect(join.removed).toEqual([]);
+    expect(join.added).toEqual([]);
+  });
+
+  it('same-named models in different modules disambiguate by file', () => {
+    const a1 = entity('User', 'mod-a/m.ts', [{ name: 'a', type: 'int', required: true }]);
+    const b1 = entity('User', 'mod-b/m.ts', [{ name: 'b', type: 'int', required: true }]);
+    const join = pairModels(set(a1, b1), set({ ...a1 }, { ...b1 }));
+    expect(join.pairs.every((p) => p.reason === 'exact')).toBe(true);
+    expect(join.pairs).toHaveLength(2);
+  });
+
+  it('move-plus-edit pairs via similarity, not remove+add', () => {
+    const base = set(
+      entity('User', 'a.ts', [
+        { name: 'id', type: 'int', required: true },
+        { name: 'email', type: 'string', required: true },
+        { name: 'age', type: 'int', required: true },
+      ]),
+      entity('User', 'other.ts', [{ name: 'zzz', type: 'int', required: true }]),
+    );
+    const head = set(
+      entity('User', 'moved.ts', [
+        { name: 'id', type: 'int', required: true },
+        { name: 'email', type: 'string', required: true },
+      ]),
+      entity('User', 'other.ts', [{ name: 'zzz', type: 'int', required: true }]),
+    );
+    const join = pairModels(base, head);
+    // After the exact stage pairs other.ts, one candidate remains per side —
+    // it pairs unconditionally as relocated (single-leftover rule).
+    const moved = join.pairs.find((p) => p.head.file === 'moved.ts');
+    expect(moved).toBeDefined();
+    expect(moved!.base.file).toBe('a.ts');
+    expect(moved!.reason).toBe('relocated');
+    expect(join.removed).toEqual([]);
+  });
+
+  it('multiple relocated candidates arbitrate by field-set similarity', () => {
+    const base = set(
+      entity('User', 'a.ts', [
+        { name: 'id', type: 'int', required: true },
+        { name: 'email', type: 'string', required: true },
+      ]),
+      entity('User', 'b.ts', [
+        { name: 'sku', type: 'string', required: true },
+        { name: 'qty', type: 'int', required: true },
+      ]),
+    );
+    const head = set(
+      entity('User', 'x.ts', [
+        { name: 'sku', type: 'string', required: true },
+        { name: 'qty', type: 'int', required: true },
+      ]),
+      entity('User', 'y.ts', [
+        { name: 'id', type: 'int', required: true },
+        { name: 'email', type: 'string', required: true },
+      ]),
+    );
+    const join = pairModels(base, head);
+    expect(join.pairs).toHaveLength(2);
+    expect(join.pairs.every((p) => p.reason === 'similarity')).toBe(true);
+    const byBase = new Map(join.pairs.map((p) => [p.base.file, p.head.file]));
+    expect(byBase.get('a.ts')).toBe('y.ts');
+    expect(byBase.get('b.ts')).toBe('x.ts');
+    expect(join.removed).toEqual([]);
+    expect(join.added).toEqual([]);
+  });
+
+  it('a rename is an honest remove + add', () => {
+    const join = pairModels(set(entity('User', 'a.ts', fields)), set(entity('Person', 'a.ts', fields)));
+    expect(join.pairs).toEqual([]);
+    expect(join.removed.map((e) => e.name)).toEqual(['User']);
+    expect(join.added.map((e) => e.name)).toEqual(['Person']);
+  });
+});
+
+describe('diffModelSets — taxonomy and unknown rules', () => {
+  const base = set(
+    entity('User', 'm.ts', [
+      { name: 'id', type: 'int', required: true },
+      { name: 'email', type: 'string', required: false },
+      { name: 'bio', type: 'string', required: true },
+      { name: 'blob', type: null, required: null },
+    ]),
+  );
+
+  it('classifies every change with the right class and confidence', () => {
+    const head = set(
+      entity('User', 'm.ts', [
+        { name: 'id', type: 'string', required: true }, // type-changed
+        { name: 'email', type: 'string', required: true }, // required-added
+        // bio removed
+        { name: 'blob', type: 'bytes', required: null }, // unknown → known: low conf
+        { name: 'nick', type: 'string', required: false }, // added optional
+        { name: 'org', type: 'string', required: true }, // added required
+      ]),
+      entity('Audit', 'a.ts', [{ name: 'at', type: 'time', required: true }]),
+    );
+    const drifts = diffModelSets(base, head);
+    const byKey = new Map(drifts.map((d) => [`${d.changeClass}:${d.field ?? d.model}`, d]));
+
+    expect(byKey.get('field-type-changed:id')?.confidence).toBe(1);
+    expect(byKey.get('field-required-added:email')?.confidence).toBe(1);
+    expect(byKey.get('field-removed:bio')?.from).toBe('string');
+    expect(byKey.get('field-type-changed:blob')?.confidence).toBeLessThan(1); // unknown never blocks
+    expect(byKey.get('field-added:nick')).toBeDefined();
+    expect(byKey.get('field-added-required:org')).toBeDefined();
+    expect(byKey.get('model-added:Audit')).toBeDefined();
+    expect(drifts).toHaveLength(7);
+  });
+
+  it('a pure file move produces ZERO findings', () => {
+    const moved = set(
+      entity('User', 'relocated/models.ts', [...base.models[0].fields]),
+    );
+    expect(diffModelSets(base, moved)).toEqual([]);
+  });
+
+  it('model removal blocks-shaped; identical sets are silent', () => {
+    expect(diffModelSets(base, set())).toEqual([
+      expect.objectContaining({ changeClass: 'model-removed', model: 'User', confidence: 1 }),
+    ]);
+    expect(diffModelSets(base, base)).toEqual([]);
+  });
+
+  it('both-unknown comparisons emit nothing', () => {
+    const a = set(entity('K', 'k.ts', [{ name: 'x', type: null, required: null }]));
+    const b = set(entity('K', 'k.ts', [{ name: 'x', type: null, required: null }]));
+    expect(diffModelSets(a, b)).toEqual([]);
+  });
+});

--- a/test/model-schema-gate.test.ts
+++ b/test/model-schema-gate.test.ts
@@ -12,11 +12,7 @@ import {
 } from '../src/analyzers/model-schema/gate';
 import type { ModelEntity, ModelSet } from '../src/analyzers/model-schema/model';
 
-function entity(
-  name: string,
-  file: string,
-  fields: ModelEntity['fields'],
-): ModelEntity {
+function entity(name: string, file: string, fields: ModelEntity['fields']): ModelEntity {
   return { name, via: 'base-class', file, line: 1, fields };
 }
 function set(...models: ModelEntity[]): ModelSet {
@@ -51,7 +47,9 @@ describe('evaluateSchemaDriftGate — verdicts', () => {
     expect(schemaDriftGateBlocks(findings)).toBe(true);
     // Ordering: blocks first, then warns, then info.
     const ranks = findings.map((f) => f.verdict);
-    expect(ranks).toEqual([...ranks].sort((a, b) => 'block warn info'.indexOf(a) - 'block warn info'.indexOf(b)));
+    expect(ranks).toEqual(
+      [...ranks].sort((a, b) => 'block warn info'.indexOf(a) - 'block warn info'.indexOf(b)),
+    );
   });
 
   it('an unknown-degraded breaking finding WARNS, never blocks', () => {

--- a/test/model-schema-gate.test.ts
+++ b/test/model-schema-gate.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The model-schema drift gate — pure evaluation core: verdict assignment per
+ * change class, confidence gating (unknown never blocks), threshold
+ * behavior, ordering, and identity stability across relocation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  describeSchemaDrift,
+  evaluateSchemaDriftGate,
+  schemaDriftGateBlocks,
+} from '../src/analyzers/model-schema/gate';
+import type { ModelEntity, ModelSet } from '../src/analyzers/model-schema/model';
+
+function entity(
+  name: string,
+  file: string,
+  fields: ModelEntity['fields'],
+): ModelEntity {
+  return { name, via: 'base-class', file, line: 1, fields };
+}
+function set(...models: ModelEntity[]): ModelSet {
+  return { models, dynamicModels: [] };
+}
+
+const BASE = set(
+  entity('User', 'm.ts', [
+    { name: 'id', type: 'int', required: true },
+    { name: 'email', type: 'string', required: false },
+    { name: 'blob', type: null, required: null },
+  ]),
+);
+
+describe('evaluateSchemaDriftGate — verdicts', () => {
+  it('breaking classes block at full confidence; additive classes warn/info', () => {
+    const head = set(
+      entity('User', 'm.ts', [
+        { name: 'id', type: 'string', required: true }, // type-changed → block
+        // email removed → block
+        { name: 'blob', type: null, required: null },
+        { name: 'nick', type: 'string', required: false }, // added optional → info
+        { name: 'org', type: 'string', required: true }, // added required → warn
+      ]),
+    );
+    const findings = evaluateSchemaDriftGate({ baseModels: BASE, headModels: head });
+    const byClass = new Map(findings.map((f) => [f.changeClass, f]));
+    expect(byClass.get('field-type-changed')?.verdict).toBe('block');
+    expect(byClass.get('field-removed')?.verdict).toBe('block');
+    expect(byClass.get('field-added-required')?.verdict).toBe('warn');
+    expect(byClass.get('field-added')?.verdict).toBe('info');
+    expect(schemaDriftGateBlocks(findings)).toBe(true);
+    // Ordering: blocks first, then warns, then info.
+    const ranks = findings.map((f) => f.verdict);
+    expect(ranks).toEqual([...ranks].sort((a, b) => 'block warn info'.indexOf(a) - 'block warn info'.indexOf(b)));
+  });
+
+  it('an unknown-degraded breaking finding WARNS, never blocks', () => {
+    const head = set(
+      entity('User', 'm.ts', [
+        { name: 'id', type: 'int', required: true },
+        { name: 'email', type: 'string', required: false },
+        { name: 'blob', type: 'bytes', required: null }, // unknown → known transition
+      ]),
+    );
+    const findings = evaluateSchemaDriftGate({ baseModels: BASE, headModels: head });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].changeClass).toBe('field-type-changed');
+    expect(findings[0].verdict).toBe('warn');
+    expect(schemaDriftGateBlocks(findings)).toBe(false);
+  });
+
+  it('blockThreshold demotes similarity-paired findings to warn', () => {
+    // Two same-named models force similarity pairing (confidence < 1) after
+    // a cross-file shuffle with an edit.
+    const base = set(
+      entity('User', 'a.ts', [
+        { name: 'id', type: 'int', required: true },
+        { name: 'email', type: 'string', required: true },
+        { name: 'age', type: 'int', required: true },
+      ]),
+      entity('User', 'b.ts', [
+        { name: 'sku', type: 'string', required: true },
+        { name: 'qty', type: 'int', required: true },
+        { name: 'lot', type: 'string', required: true },
+      ]),
+    );
+    const head = set(
+      entity('User', 'x.ts', [
+        { name: 'id', type: 'int', required: true },
+        { name: 'email', type: 'string', required: true },
+        // age removed — on a similarity pair (conf 2/3 < 1) → warn, not block
+      ]),
+      entity('User', 'y.ts', [
+        { name: 'sku', type: 'string', required: true },
+        { name: 'qty', type: 'int', required: true },
+        { name: 'lot', type: 'string', required: true },
+      ]),
+    );
+    const findings = evaluateSchemaDriftGate({ baseModels: base, headModels: head });
+    const removed = findings.find((f) => f.changeClass === 'field-removed');
+    expect(removed).toBeDefined();
+    expect(removed!.confidence).toBeLessThan(1);
+    expect(removed!.verdict).toBe('warn');
+  });
+
+  it('a pure file move produces zero findings; identity is location-free', () => {
+    const moved = set(entity('User', 'relocated/deep/m.ts', [...BASE.models[0].fields]));
+    expect(evaluateSchemaDriftGate({ baseModels: BASE, headModels: moved })).toEqual([]);
+
+    // Same drift discovered at two different locations mints ONE identity.
+    const dropA = evaluateSchemaDriftGate({
+      baseModels: BASE,
+      headModels: set(entity('User', 'm.ts', [BASE.models[0].fields[0], BASE.models[0].fields[2]])),
+    });
+    const dropB = evaluateSchemaDriftGate({
+      baseModels: set(entity('User', 'other/place.py', [...BASE.models[0].fields])),
+      headModels: set(
+        entity('User', 'other/place.py', [BASE.models[0].fields[0], BASE.models[0].fields[2]]),
+      ),
+    });
+    expect(dropA[0].id).toBe(dropB[0].id);
+  });
+});
+
+describe('describeSchemaDrift', () => {
+  it('renders a one-liner for every change class', () => {
+    const head = set(
+      entity('User', 'm.ts', [
+        { name: 'id', type: 'string', required: true },
+        { name: 'email', type: 'string', required: true },
+        { name: 'blob', type: null, required: false },
+        { name: 'org', type: 'string', required: true },
+      ]),
+      entity('Audit', 'a.ts', []),
+    );
+    const findings = evaluateSchemaDriftGate({ baseModels: BASE, headModels: head });
+    for (const f of findings) {
+      const line = describeSchemaDrift(f);
+      expect(line).toContain(f.model);
+      expect(line.length).toBeGreaterThan(10);
+    }
+  });
+});

--- a/test/model-schema-packs.test.ts
+++ b/test/model-schema-packs.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The three v1 pack `modelSchema` declarations, pinned against realistic
+ * framework source (the pack-descriptor layer; the grammar-agnostic engine
+ * is pinned by model-schema-core.test.ts with synthetic descriptors).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSource } from '../src/ast/parse';
+import { grammarShape } from '../src/ast/grammar-shape';
+import { modelShapeForGrammar } from '../src/ast/grammar-model-shape';
+import { extractModelsFromTree } from '../src/analyzers/model-schema/extract';
+import { getLanguage } from '../src/languages';
+import type { ModelSet } from '../src/analyzers/model-schema/model';
+
+async function extractWithPack(src: string, grammar: string, langId: string): Promise<ModelSet> {
+  const descriptor = getLanguage(langId as never)!.modelSchema!;
+  const tree = await parseSource(src, grammar);
+  expect(tree, `parse ${grammar}`).not.toBeNull();
+  return extractModelsFromTree(
+    tree!.rootNode,
+    descriptor,
+    modelShapeForGrammar(grammar)!,
+    grammarShape(grammar),
+    'sample',
+  );
+}
+
+describe('typescript pack modelSchema', () => {
+  it('extracts a TypeORM entity; helper classes and interfaces stay invisible', async () => {
+    const { models } = await extractWithPack(
+      `
+import { Entity, Column, BaseEntity } from 'typeorm';
+
+@Entity()
+export class User {
+  @Column() email!: string;
+  @Column({ nullable: true }) nick?: string;
+  name: string | null;
+}
+
+export class ArticleService { cache: Map<string, string>; }
+export interface PlainDto { id: number }
+`,
+      'typescript',
+      'typescript',
+    );
+    expect(models.map((m) => m.name)).toEqual(['User']);
+    expect(models[0].via).toBe('decorator');
+    expect(models[0].fields).toEqual([
+      { name: 'email', type: 'string', required: true },
+      { name: 'nick', type: 'string', required: false },
+      { name: 'name', type: 'string', required: false },
+    ]);
+  });
+
+  it('recognizes active-record BaseEntity heritage', async () => {
+    const { models } = await extractWithPack(
+      `export class Post extends BaseEntity { title: string; }`,
+      'typescript',
+      'typescript',
+    );
+    expect(models.map((m) => m.name)).toEqual(['Post']);
+    expect(models[0].via).toBe('base-class');
+  });
+});
+
+describe('python pack modelSchema', () => {
+  it('extracts a Django model with aliased types and null= optionality', async () => {
+    const { models } = await extractWithPack(
+      `
+class Article(models.Model):
+    title = models.CharField(max_length=200)
+    summary = models.TextField(null=True)
+    views = models.PositiveIntegerField()
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
+
+class NotAModel:
+    x = 1
+`,
+      'python',
+      'python',
+    );
+    expect(models.map((m) => m.name)).toEqual(['Article']);
+    expect(models[0].fields).toEqual([
+      { name: 'title', type: 'string', required: true },
+      { name: 'summary', type: 'string', required: false },
+      { name: 'views', type: 'int', required: true },
+      { name: 'author', type: 'fk', required: true },
+    ]);
+  });
+
+  it('extracts pydantic + SQLAlchemy + dataclass forms', async () => {
+    const { models } = await extractWithPack(
+      `
+class Item(BaseModel):
+    name: str
+    price: float | None = None
+
+class OrderRow(Base):
+    id = Column(Integer, primary_key=True)
+    note = mapped_column(String, nullable=True)
+
+@dataclass
+class Point:
+    x: int
+`,
+      'python',
+      'python',
+    );
+    expect(models.map((m) => m.name)).toEqual(['Item', 'OrderRow', 'Point']);
+    const [item, order, point] = models;
+    expect(item.fields).toEqual([
+      { name: 'name', type: 'str', required: true },
+      { name: 'price', type: 'float', required: false },
+    ]);
+    expect(order.fields).toEqual([
+      { name: 'id', type: 'Integer', required: true },
+      { name: 'note', type: 'String', required: false },
+    ]);
+    expect(point.via).toBe('decorator');
+    expect(point.fields).toEqual([{ name: 'x', type: 'int', required: true }]);
+  });
+});
+
+describe('go pack modelSchema', () => {
+  it('extracts tagged structs with wire names; untagged structs invisible', async () => {
+    const { models } = await extractWithPack(
+      `
+package models
+
+type User struct {
+	ID    uint    \`json:"id" gorm:"primaryKey"\`
+	Email string  \`json:"email"\`
+	Nick  *string \`json:"nick,omitempty"\`
+}
+
+type internalCache struct {
+	entries map[string]string
+}
+`,
+      'go',
+      'go',
+    );
+    expect(models.map((m) => m.name)).toEqual(['User']);
+    expect(models[0].via).toBe('struct-tag');
+    expect(models[0].fields).toEqual([
+      { name: 'id', type: 'uint', required: true },
+      { name: 'email', type: 'string', required: true },
+      { name: 'nick', type: 'string', required: false },
+    ]);
+  });
+});

--- a/test/model-schema-packs.test.ts
+++ b/test/model-schema-packs.test.ts
@@ -89,6 +89,25 @@ class NotAModel:
     ]);
   });
 
+  it('weak Base heritage needs Column corroboration (the homonym-Base class)', async () => {
+    // Real-repo validation: frameworks carry their own unrelated `Base`
+    // classes (pricing/availability strategies). A bare `Base` heritage with
+    // no ORM field constructor must NOT mint a model; with one, it must.
+    const { models } = await extractWithPack(
+      `
+class Unavailable(Base):
+    code = "unavailable"
+    message = "n/a"
+
+class OrderRow(Base):
+    id = Column(Integer, primary_key=True)
+`,
+      'python',
+      'python',
+    );
+    expect(models.map((m) => m.name)).toEqual(['OrderRow']);
+  });
+
   it('extracts pydantic + SQLAlchemy + dataclass forms', async () => {
     const { models } = await extractWithPack(
       `

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -44,6 +44,9 @@ import {
   allDocCommentPatterns,
   allExportDetectionDeclarations,
   allFlowSourceExtensions,
+  allModelSchema,
+  allModelSchemaSourceExtensions,
+  changedFilesTouchModelSurface,
   allCiSetupSteps,
   allHttpFlow,
   allModelPaths,
@@ -69,6 +72,8 @@ import { deriveFileRoutePath } from '../src/analyzers/flow/file-routes';
 import { extractFromTree } from '../src/analyzers/flow/extract';
 import { parseSource } from '../src/ast/parse';
 import { grammarShape } from '../src/ast/grammar-shape';
+import { modelShapeForGrammar } from '../src/ast/grammar-model-shape';
+import { extractModelsFromTree } from '../src/analyzers/model-schema/extract';
 import { buildVariables, buildConditions } from '../src/constants';
 import { buildRequiredTools } from '../src/analyzers/tools/tool-registry';
 import { detect } from '../src/detect';
@@ -158,6 +163,18 @@ const mockPlaybookPack = {
       baseDirs: ['playbookapp'],
       methodExports: ['GET', 'POST'],
     },
+  },
+  // Model-schema contribution. Distinctive tokens (`PlaybookRecord`,
+  // `PlaybookEntity`, `playbookColumn`) so the assertions verify the
+  // synthetic pack's modelSchema descriptor flows through `allModelSchema`
+  // AND drives the ONE model extractor — codifying "model extraction is
+  // pack-driven, not analyzer-by-analyzer."
+  modelSchema: {
+    modelBaseClasses: ['PlaybookRecord'],
+    modelDecorators: ['PlaybookEntity'],
+    fieldCallees: [{ names: ['playbookColumn'], optionalityKeyword: 'playbookNullable' }],
+    typeAliases: { playbookcolumn: 'playbook-string' },
+    schemaSignals: [{ manifest: 'playbook.toml', anyOf: ['playbook-orm'] }],
   },
   // A grammar alongside httpFlow makes the synthetic pack flow-CAPABLE, so its
   // extensions flow through `allFlowSourceExtensions` /
@@ -886,6 +903,67 @@ describe('recipe playbook — synthetic pack', () => {
     expect(changedFilesTouchFlowSurface(['app/Widget.pbk'], packs)).toBe(true);
     // A non-flow change does not.
     expect(changedFilesTouchFlowSurface(['README.md'], packs)).toBe(false);
+  });
+
+  // Model-schema: the registry helper + trigger iterate every active pack,
+  // and the synthetic descriptor drives the ONE model extractor over a real
+  // grammar's shapes — the same declaration-driven-all-the-way-down proof the
+  // flow tests establish. A new language pack inherits exactly this path:
+  // declare grammars + modelSchema, zero extractor edits.
+  it('allModelSchema + the model-surface trigger pick up the mock pack', () => {
+    const flags = {
+      typescript: true,
+      python: false,
+      go: false,
+      rust: false,
+      csharp: false,
+      kotlin: false,
+      java: false,
+      ruby: false,
+      playbook: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const descriptors = allModelSchema(flags);
+    expect(
+      descriptors.some((d) => d.modelBaseClasses?.includes('PlaybookRecord')),
+      'synthetic modelSchema missing from allModelSchema',
+    ).toBe(true);
+    const packs = [...LANGUAGES];
+    expect(allModelSchemaSourceExtensions(packs)).toContain('.pbk');
+    expect(changedFilesTouchModelSurface(['src/Widget.pbk'], packs)).toBe(true);
+    expect(changedFilesTouchModelSurface(['README.md'], packs)).toBe(false);
+    // Spec-only trigger: a configured spec path trips it even with no
+    // model-capable extension match.
+    expect(changedFilesTouchModelSurface(['api/models.json'], packs, ['api/models.json'])).toBe(
+      true,
+    );
+  });
+
+  it('the synthetic modelSchema descriptor extracts models through the one extractor', async () => {
+    const synthetic = mockPlaybookPack.modelSchema!;
+    // Any shaped grammar exercises the path — the JS family here.
+    const modelShape = modelShapeForGrammar('javascript')!;
+    const callShape = grammarShape('javascript')!;
+    const tree = await parseSource(
+      `
+      @PlaybookEntity()
+      class Widget {
+        name = playbookColumn({ playbookNullable: true });
+        count;
+      }
+      class Plain { x = 1; }
+      `,
+      'javascript',
+    );
+    const set = extractModelsFromTree(tree!.rootNode, synthetic, modelShape, callShape, 'w.pbk');
+    expect(set.models.map((m) => m.name)).toEqual(['Widget']);
+    expect(set.models[0].via).toBe('decorator');
+    // The field constructor supplied the type token (folded through the
+    // pack's typeAliases) and the optionality keyword.
+    expect(set.models[0].fields).toEqual([
+      { name: 'name', type: 'playbook-string', required: false },
+      { name: 'count', type: null, required: null },
+    ]);
   });
 
   it('allTestGapPriorityPaths unions all three buckets across active packs (C8)', () => {

--- a/test/schema-gate-diff-parity.test.ts
+++ b/test/schema-gate-diff-parity.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Parity net: `schema diff` (the developer preview) and the guardrail's
+ * drift gate are two CONSUMERS of one drift concept. The lossy-projection
+ * lesson (the flow gate-vs-join class) says two consumers holding different
+ * shapes of one concept WILL diverge unless a test runs both on shared
+ * fixtures and asserts they agree — so this does exactly that: one real git
+ * repo, one mutation, both surfaces, identical finding sets (ids, classes,
+ * verdicts).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runSchemaDiff } from '../src/schema-cli';
+import { evaluateSchemaDriftGateForGuardrail } from '../src/baseline/schema-drift-gate-check';
+
+function git(dir: string, args: string[]): void {
+  execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+}
+
+/** A repo with BOTH model sources: a TS entity (code extraction) and an
+ *  OpenAPI spec (the language-independent bridge), gate on in block mode. */
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-schemaparity-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'test']);
+  mkdirSync(join(dir, '.dxkit'), { recursive: true });
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, '.dxkit', 'policy.json'),
+    JSON.stringify({ schema: { mode: 'block', specs: ['openapi.json'] } }),
+  );
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '0.0.0' }));
+  writeFileSync(
+    join(dir, 'src', 'user.entity.ts'),
+    `@Entity()\nexport class User {\n  email!: string;\n  nick?: string;\n}\n`,
+  );
+  writeFileSync(
+    join(dir, 'openapi.json'),
+    JSON.stringify({
+      openapi: '3.0.0',
+      components: {
+        schemas: {
+          Invoice: {
+            type: 'object',
+            required: ['id'],
+            properties: { id: { type: 'integer' }, total: { type: 'number' } },
+          },
+        },
+      },
+    }),
+  );
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  return dir;
+}
+
+describe('schema diff ↔ guardrail gate parity', () => {
+  let dir: string;
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('both surfaces produce the identical finding set on a mixed mutation', async () => {
+    dir = makeRepo();
+    // Mutate BOTH sources: the entity loses a field and tightens one; the
+    // spec changes a type.
+    writeFileSync(
+      join(dir, 'src', 'user.entity.ts'),
+      `@Entity()\nexport class User {\n  nick!: string;\n}\n`,
+    );
+    writeFileSync(
+      join(dir, 'openapi.json'),
+      JSON.stringify({
+        openapi: '3.0.0',
+        components: {
+          schemas: {
+            Invoice: {
+              type: 'object',
+              required: ['id'],
+              properties: { id: { type: 'string' }, total: { type: 'number' } },
+            },
+          },
+        },
+      }),
+    );
+
+    // Surface 1: the guardrail gate.
+    const gate = await evaluateSchemaDriftGateForGuardrail({ cwd: dir, baseRef: 'main' });
+    expect(gate.ran).toBe(true);
+    expect(gate.findings.length).toBeGreaterThan(0);
+
+    // Surface 2: the CLI preview (--json), stdout captured.
+    let captured = '';
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      captured += String(chunk);
+      return true;
+    });
+    await runSchemaDiff(dir, { ref: 'main', json: true });
+    vi.restoreAllMocks();
+    const cli = JSON.parse(captured) as {
+      findings: Array<{ id: string; changeClass: string; verdict: string }>;
+    };
+
+    const key = (f: { id: string; changeClass: string; verdict: string }): string =>
+      `${f.id}:${f.changeClass}:${f.verdict}`;
+    expect(cli.findings.map(key).sort()).toEqual(gate.findings.map(key).sort());
+    // And the set is the expected one: entity email removed + nick tightened
+    // (? removed) + spec id type change — every class from both sources.
+    const classes = gate.findings.map((f) => `${f.model}.${f.field}:${f.changeClass}`).sort();
+    expect(classes).toEqual([
+      'Invoice.id:field-type-changed',
+      'User.email:field-removed',
+      'User.nick:field-required-added',
+    ]);
+  });
+
+  it('both surfaces are silent on a pure model-file move', async () => {
+    dir = makeRepo();
+    git(dir, ['mv', 'src/user.entity.ts', 'src/moved-user.entity.ts']);
+    git(dir, ['commit', '-q', '-m', 'move']);
+
+    const gate = await evaluateSchemaDriftGateForGuardrail({ cwd: dir, baseRef: 'main~1' });
+    // Ran (the diff touched a model-capable file) but found nothing.
+    expect(gate.ran).toBe(true);
+    expect(gate.findings).toHaveLength(0);
+    expect(gate.blocks).toBe(false);
+
+    let captured = '';
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      captured += String(chunk);
+      return true;
+    });
+    await runSchemaDiff(dir, { ref: 'main~1', json: true });
+    vi.restoreAllMocks();
+    const cli = JSON.parse(captured) as { findings: unknown[] };
+    expect(cli.findings).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Model-schema drift gate

dxkit now extracts every data model a repo declares and gates breaking changes on the PR diff — a removed field, a changed type, an optional field made required, a removed model. Additive changes warn or inform, never block. This is the 3.4.0 headline; the design doc's decisions (marker-based recognition, location-free identity, the name-anchored relocation-tolerant join, spec bridge in v1) are all implemented as reviewed.

### Architecture (every platform seam, no shortcuts)

- **Pack = declaration, engine = shared** (Rule 6): a new optional `ModelSchemaSupport` on `LanguageSupport` + a sibling `GrammarModelShape` syntax table in `src/ast/`. The TS/Python/Go declarations are pure descriptor blocks — zero extractor edits, the flow acceptance criterion held again.
- **One concept, one code path** (Rule 2): `gatherRepoModelSet` is the single policy-reading entry point (arch-check-banned otherwise); `diffModelSets` is the ONE drift computation consumed by both `schema diff` and the guardrail gate, pinned by a parity test.
- **Identity** (Rule 9): `model-schema-drift` fingerprints hash `(model, field, changeClass)` — location-free by design (the dep-vuln doctrine), so findings survive line and file moves and a follow-up tweak cannot dodge an allowlist decision. Registered through every contract: `identityFor`, fixtures, `DEFERRED_KINDS` (Rule 10), allowlist categories, severity map, migrate inverse.
- **The gate** mirrors flow-gate-check layer for layer: pure core + fail-open glue (typed skips), trigger-skip on non-model diffs, ref-reliable static extraction, warn-mode demotion, per-finding allowlist escape. One deliberate divergence: schema defaults **off** (opt-in), and the loop-preset override softens an enabled gate but never activates one.
- **Second-gate refactor**: the guardrail's verdict counting now folds "extra gate" findings through one shared tally (flow previously hand-threaded its counts in three places); two stale flow comments fixed.
- **Rule 16**: full `CapabilityDescriptor` (`schema`, group gate), doctor probe + configure planner sharing one pack-declared signal, `dxkit-schema` skill, docs matrix + policy reference + changelog. Lifecycle audit: no managed artifact installed; the policy section has one reader/writer.

### Honesty contract

An unknown never blocks. A rename reads as remove + add. A pure file move produces zero findings. Dynamic models are disclosed, not dropped. The docs carry a verbatim "what the gate does not see" list (constraints/enums, aliased types, serialization renames, migrations, consumer impact) — each disclosed or documented, never implied covered.

### Validation (the 5-tier release gate from the design doc — all passed)

- **Tier 1 — extraction accuracy** (read-only, public repos): a NestJS/TypeORM app (5 entities ✓), a classic SQLAlchemy app (5 models, SQLAlchemy-2.0 `Mapped[...]` optionality correct ✓), a FastAPI/SQLModel template (15 ✓), a large Django e-commerce framework (62 models / 500 fields ✓), a gin/gorm app (14 tagged structs ✓), chi's examples (10, incl. four same-named cross-file models exercising the join ✓). **Three real bugs found and fixed by this tier**: a homonym-`Base` false-positive class (→ weak heritage markers needing constructor corroboration), the `Mapped[...]` wrapper hiding optionality (→ pack-declared transparent wrappers), and an optionality-precedence error (explicit kwarg > annotation fold > marker > framework default).
- **Tiers 2+3 — mutation simulation + false-positive hunt**: 18/18 — ten scripted mutations across TS/SQLAlchemy/Django/Go each produced exactly the expected drift class; the eight-case refactor battery (file moves, move+unrelated-edit, comment churn, field reorder, unmarked helper added, non-model rename, whitespace) produced **zero** findings.
- **Tier 4 — end-to-end guardrail**: the real `guardrail check` on a mutated copy blocked (exit 1) with the PR markdown table + fingerprints; two `allowlist add --category=accepted-risk` entries flipped it to exit 0 with the suppressed-disclosure table; a docs-only diff disclosed `skipped: no-model-surface-change`.
- **Tier 5 — scale**: the 62-model/500-field extraction runs in 0.43 s; flow regression on the gin app is byte-identical to 3.3.0 (12 endpoints).
- All external repos verified untouched after validation (0 modifications).

### Signals

- Full suite 3552/3552 (+78 new tests); typecheck, eslint, prettier, arch-check (with two new model-schema rules), slop check, cross-ecosystem parity all green; pre-push gate passed on push.
- The synthetic-pack playbook caught one latent bug during development (plain-JS fields fabricated `required`), now a three-valued marker — the enforcement net working before ship.

### Reviewer checklist

- [ ] `ModelSchemaSupport` / `GrammarModelShape` shapes are the right SDK-freeze surface (this lands before the freeze so the frozen interface includes them)
- [ ] The `field-added-required` = warn default (direction-dependent breakage) matches your intuition
- [ ] Weak-marker corroboration (`Base` + Column) — right precision/recall trade
- [ ] Location-free fingerprint trade-off (same-named cross-module collision disclosed in docs) acceptable
- [ ] Docs honesty list reads right in `docs/configuration/language-packs.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
