### PR TITLE
Dependency audit covers nested independent lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verbatim what the gate cannot see (constraints, aliased types, dynamic
   schemas, consumer impact).
 
+### Fixed
+
+- **Dependency audit covers nested lockfiles.** The dep audit ran at the
+  repo root only, so a vulnerability introduced in a nested sub-project's
+  lockfile (a `server/` app with its own `package-lock.json` that is not a
+  workspace member) was invisible to `health`, `vulnerabilities`, and the
+  guardrail gate. Each language pack now declares which lockfile basenames
+  mark an independent dependency-resolution root; the audit discovers every
+  nested root (exclusion-aware, depth-unlimited, capped with disclosure)
+  and runs once per root, merging findings on their true identity so the
+  same advisory in two sub-projects stays one finding. Deliberately
+  lockfiles, not manifests: workspace members and Maven modules resolve
+  from the root tree and were already covered. Verified against the
+  originally-reported case: a CVSS 9.8 advisory in a nested lockfile that
+  previously read CLEAN is now detected.
+
 ## [3.3.0] - 2026-07-10
 
 The polyglot release for the flow pillar: Python and Go join

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,13 @@ ${path}` keys, which discards catch-all structure — so it did exact membership
   (`src/package-manager.ts`). A scanner must be pointed at a lockfile it
   understands (`npm audit` needs an npm lockfile; a pnpm/yarn/bun lockfile routes
   to the shared lockfile-aware `gatherOsvScannerDepVulnsResult`). Selecting a
-  scanner without consulting the present lockfile is the bug.
+  scanner without consulting the present lockfile is the bug. The set of
+  dependency-audit ROOTS is likewise one concept: pack-declared
+  `lockfilePatterns` + `discoverNestedDepRoots`
+  (`src/analyzers/security/nested-dep-roots.ts`), consumed at the ONE
+  dispatch primitive (`gatherDepVulnsWithAvailability`) so reports and the
+  gate audit the same lockfile set — the shipped bug: root-only auditing
+  read a nested sub-project's critical vuln as CLEAN.
 - the set of optional SHIP surfaces dxkit installs (CI workflows, git hooks,
   the devcontainer, the loop pack, the dxkit devDependency, the ignore files) →
   `MANAGED_SHIP_SURFACES` in `src/managed-artifacts.ts`. These are NOT recorded

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,16 @@ will fail CI if missing):
 - **Capabilities** — `capabilities?: { depVulns, lint, coverage,
 imports, testFramework, licenses }`. Each is a `CapabilityProvider`
   with an async `gather(cwd)` method; return `null` when nothing to
-  report. The dispatcher fans out across every pack.
+  report. The dispatcher fans out across every pack. A `depVulns`
+  provider MUST declare `manifestPatterns` (the incremental dep-audit
+  skip reads them) and SHOULD declare `lockfilePatterns` — exact
+  basenames marking an INDEPENDENT dependency-resolution root
+  (`package-lock.json`, `Gemfile.lock`, `go.mod`). The dispatch then
+  audits every nested root and merges, so a vuln added to a nested
+  sub-project's lockfile is caught; a pack that omits it keeps
+  root-only auditing. Lockfiles, not plain manifests: a workspace
+  member / Maven module resolves from the root tree and is already
+  covered by the root audit.
 - **Correctness floor** (2.23) — `correctness?: CorrectnessProvider`,
   the loop-safety liveness gate ("does this change still compile, and
   do the tests it affects still pass?"). TWO pure command builders:

--- a/scripts/scaffold-language.js
+++ b/scripts/scaffold-language.js
@@ -321,6 +321,14 @@ export const ${id}: LanguageSupport = {
   // asserted non-empty by test/languages-contract.test.ts — the incremental
   // ref-based dep-audit skip needs it to tell whether a PR touched this pack's
   // dependencies (CLAUDE.md Rule 6).
+  //
+  // ALSO declare \`lockfilePatterns\` when the ecosystem has a lockfile (or a
+  // manifest that independently resolves, like go.mod / requirements.txt):
+  // exact basenames marking an INDEPENDENT dependency-resolution root. The
+  // dep audit then runs once per nested root and merges — without it, a vuln
+  // added to a nested sub-project's lockfile is invisible to the root audit.
+  // Deliberately lockfiles, not plain manifests: a workspace member / Maven
+  // module resolves from the root tree and is already covered.
   capabilities: {},
 
   // TODO(${id}): exported-symbol detection reliability for the graphify

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -26,6 +26,7 @@ import { walkSourceFiles, commentSyntaxFor, isCommentLine } from '../tools/walk-
 import * as path from 'path';
 import { SecurityFinding, DepVulnSummary, Severity } from './types';
 import { buildSecurityAggregate, type SecurityAggregate } from './aggregator';
+import { discoverNestedDepRoots, mergeDepVulnOutcomes } from './nested-dep-roots';
 import { loadAllowlist } from '../../allowlist/file';
 import { defaultDispatcher } from '../dispatcher';
 import { allTlsBypassPatterns, detectActiveLanguages } from '../../languages';
@@ -36,8 +37,9 @@ import {
   SECRETS,
 } from '../../languages/capabilities/descriptors';
 import { providersFor } from '../../languages/capabilities';
-import type { DepVulnResult } from '../../languages/capabilities/types';
+import type { DepVulnGatherOutcome, DepVulnResult } from '../../languages/capabilities/types';
 import type { DepVulnGatherOptions } from '../../languages/capabilities/provider';
+import type { LanguageSupport } from '../../languages/types';
 
 // ─── dispatcher-driven secrets gather ────────────────────────────────────────
 
@@ -294,6 +296,66 @@ const EMPTY_DEP_VULNS: DepVulnSummary = {
  * polyglot repos where one pack activates but has nothing to scan are
  * a clean "we checked, found nothing here" state.
  */
+/** One pack's gatherOutcome under the standard provider deadline, with the
+ *  stall materialised as an `unavailable` outcome (mirrors the dispatcher). */
+async function gatherOutcomeWithDeadline(
+  pack: LanguageSupport,
+  dir: string,
+  opts: DepVulnGatherOptions | undefined,
+  label: string,
+): Promise<DepVulnGatherOutcome> {
+  const deadlineOutcome = await withDeadline(
+    pack.capabilities!.depVulns!.gatherOutcome(dir, opts),
+    DEFAULT_PROVIDER_DEADLINE_MS,
+  );
+  if (deadlineOutcome.stalled) {
+    const seconds = Math.round(deadlineOutcome.stalledMs / 1000);
+    process.stderr.write(
+      `[dxkit] depVulns provider "${pack.id}" stalled after >${seconds}s (deadline)${label} — treating as unavailable\n`,
+    );
+    return { kind: 'unavailable', reason: `stalled at >${seconds}s (deadline)${label}` };
+  }
+  return deadlineOutcome.value;
+}
+
+/**
+ * One pack's dep audit across EVERY independent resolution root: the repo
+ * root plus each nested directory holding one of the pack's declared
+ * lockfiles (the nested-lockfile gap — a vuln added to a nested
+ * sub-project's lockfile read CLEAN when only the root was audited).
+ * Discovery is pack-declared + exclusion-aware
+ * (`src/analyzers/security/nested-dep-roots.ts`); outcomes merge with
+ * per-identity dedup, and a pack with no `lockfilePatterns` (or no nested
+ * roots) keeps byte-identical root-only behavior. Nested audits are
+ * additive recall: a failure there never degrades the root's availability
+ * story. Exported for the playbook test (a fake pack + temp tree prove the
+ * dispatch is declaration-driven).
+ */
+export async function gatherPackDepVulnsAcrossRoots(
+  pack: LanguageSupport,
+  cwd: string,
+  opts: DepVulnGatherOptions | undefined,
+): Promise<DepVulnGatherOutcome> {
+  const root = await gatherOutcomeWithDeadline(pack, cwd, opts, '');
+  const patterns = pack.capabilities!.depVulns!.lockfilePatterns ?? [];
+  if (patterns.length === 0) return root;
+  const discovery = discoverNestedDepRoots(cwd, patterns);
+  if (discovery.roots.length === 0) return root;
+  if (discovery.dropped.length > 0) {
+    process.stderr.write(
+      `[dxkit] depVulns "${pack.id}": ${discovery.roots.length + discovery.dropped.length} nested lockfile roots found, ` +
+        `auditing the first ${discovery.roots.length} (dropped: ${discovery.dropped.join(', ')})\n`,
+    );
+  }
+  const nested: DepVulnGatherOutcome[] = [];
+  for (const rel of discovery.roots) {
+    nested.push(
+      await gatherOutcomeWithDeadline(pack, path.join(cwd, rel), opts, ` (nested root ${rel})`),
+    );
+  }
+  return mergeDepVulnOutcomes(root, nested, discovery.dropped.length > 0);
+}
+
 export async function gatherDepVulnsWithAvailability(
   cwd: string,
   opts?: DepVulnGatherOptions,
@@ -314,24 +376,7 @@ export async function gatherDepVulnsWithAvailability(
   // deadline reason, so the existing availability machinery surfaces
   // it through `toolsUnavailable` without any consumer change.
   const outcomes = await Promise.allSettled(
-    activePacks.map((l) =>
-      withDeadline(
-        l.capabilities!.depVulns!.gatherOutcome(cwd, opts),
-        DEFAULT_PROVIDER_DEADLINE_MS,
-      ).then((deadlineOutcome) => {
-        if (deadlineOutcome.stalled) {
-          const seconds = Math.round(deadlineOutcome.stalledMs / 1000);
-          process.stderr.write(
-            `[dxkit] depVulns provider "${l.id}" stalled after >${seconds}s (deadline) — treating as unavailable\n`,
-          );
-          return {
-            kind: 'unavailable' as const,
-            reason: `stalled at >${seconds}s (deadline)`,
-          };
-        }
-        return deadlineOutcome.value;
-      }),
-    ),
+    activePacks.map((l) => gatherPackDepVulnsAcrossRoots(l, cwd, opts)),
   );
   const successEnvelopes: DepVulnResult[] = [];
   let firstUnavailable: { pack: string; reason: string } | null = null;

--- a/src/analyzers/security/nested-dep-roots.ts
+++ b/src/analyzers/security/nested-dep-roots.ts
@@ -1,0 +1,136 @@
+/**
+ * Nested dependency-audit roots — discovery + outcome merging for the
+ * nested-lockfile gap: the dep audit ran at the repo root only, so a
+ * vulnerability introduced in a nested sub-project's lockfile (a `server/`
+ * app with its own `package-lock.json` that is not a workspace member) was
+ * invisible to `health`, `vulnerabilities`, and the guardrail gate.
+ *
+ * One code path (Rule 2): the shared dispatch primitive
+ * (`gatherDepVulnsWithAvailability`) routes EVERY consumer through this
+ * module, so reports and the gate can never disagree about which lockfiles
+ * were audited. Which basenames mark an independent root is pack-declared
+ * (`DepVulnsProvider.lockfilePatterns`, Rule 6); discovery uses the
+ * canonical depth-unlimited walker (exclusion-aware, so `node_modules` /
+ * `vendor` lockfiles never count).
+ */
+
+import * as path from 'path';
+import { walkPaths } from '../tools/walk-paths';
+import type {
+  DepVulnFinding,
+  DepVulnGatherOutcome,
+  DepVulnResult,
+  SeverityCounts,
+} from '../../languages/capabilities/types';
+
+/**
+ * Ceiling on nested roots audited per pack per run. A pathological tree
+ * (hundreds of vendored sub-projects that somehow escape exclusions) must
+ * not turn one audit into hundreds of scanner invocations. NEVER silent:
+ * the merged envelope's tool string carries a `+capped` marker and the
+ * discovery result reports what was dropped.
+ */
+export const MAX_NESTED_DEP_ROOTS = 8;
+
+export interface NestedRootDiscovery {
+  /** Repo-relative directories (POSIX) to audit IN ADDITION to the root. */
+  readonly roots: readonly string[];
+  /** Directories beyond the cap, disclosed rather than silently dropped. */
+  readonly dropped: readonly string[];
+}
+
+/**
+ * Directories below `cwd` (never the root itself — the root audit already
+ * runs) containing one of the pack's independent-resolution lockfiles.
+ * Exclusion-aware and deterministic (sorted by path, cap applied after).
+ */
+export function discoverNestedDepRoots(
+  cwd: string,
+  lockfileBasenames: readonly string[],
+): NestedRootDiscovery {
+  if (lockfileBasenames.length === 0) return { roots: [], dropped: [] };
+  const files = walkPaths(cwd, { extensions: [], basenames: [...lockfileBasenames] });
+  const dirs = new Set<string>();
+  for (const rel of files) {
+    const dir = path.posix.dirname(rel);
+    if (dir === '.' || dir === '') continue; // the root audit covers these
+    dirs.add(dir);
+  }
+  const sorted = [...dirs].sort();
+  return {
+    roots: sorted.slice(0, MAX_NESTED_DEP_ROOTS),
+    dropped: sorted.slice(MAX_NESTED_DEP_ROOTS),
+  };
+}
+
+const SEVERITY_RANK: Record<DepVulnFinding['severity'], number> = {
+  critical: 3,
+  high: 2,
+  medium: 1,
+  low: 0,
+};
+
+/** Per-package severity counts from a deduped finding list — the documented
+ *  count model (counts are per PACKAGE at its worst severity; findings are
+ *  per advisory). Only used on a multi-root merge; a single outcome passes
+ *  through untouched. */
+function recountByPackage(findings: readonly DepVulnFinding[]): SeverityCounts {
+  const worst = new Map<string, DepVulnFinding['severity']>();
+  for (const f of findings) {
+    const key = `${f.package}\0${f.installedVersion ?? ''}`;
+    const prev = worst.get(key);
+    if (prev === undefined || SEVERITY_RANK[f.severity] > SEVERITY_RANK[prev]) {
+      worst.set(key, f.severity);
+    }
+  }
+  const counts: SeverityCounts = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const sev of worst.values()) counts[sev]++;
+  return counts;
+}
+
+/**
+ * Merge one pack's root + nested audit outcomes into a single outcome.
+ *
+ * - No success anywhere → the ROOT outcome verbatim (the nested audits are
+ *   additive recall; they never degrade the root's availability story).
+ * - Exactly one success and it is the root's, with no nested successes →
+ *   passthrough (byte-identical behavior for the single-lockfile majority).
+ * - Otherwise: findings concatenated and deduped on the finding's true
+ *   identity `(package, installedVersion, advisory id)` — the same vuln in
+ *   two sub-projects is one finding (identity carries no location); counts
+ *   recomputed per-package from the deduped set; tool string is the union
+ *   (`npm-audit+osv-scanner`), with `+capped` appended when discovery
+ *   dropped roots beyond the ceiling.
+ */
+export function mergeDepVulnOutcomes(
+  root: DepVulnGatherOutcome,
+  nested: readonly DepVulnGatherOutcome[],
+  capped: boolean,
+): DepVulnGatherOutcome {
+  const successes: DepVulnResult[] = [];
+  if (root.kind === 'success') successes.push(root.envelope);
+  for (const n of nested) if (n.kind === 'success') successes.push(n.envelope);
+
+  if (successes.length === 0) return root;
+  if (successes.length === 1 && root.kind === 'success' && !capped) return root;
+
+  const seen = new Set<string>();
+  const findings: DepVulnFinding[] = [];
+  for (const env of successes) {
+    for (const f of env.findings ?? []) {
+      const key = `${f.package}\0${f.installedVersion ?? ''}\0${f.id}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      findings.push(f);
+    }
+  }
+
+  const tools = [...new Set(successes.map((e) => e.tool))].join('+');
+  const envelope: DepVulnResult = {
+    ...successes[0],
+    tool: capped ? `${tools}+capped` : tools,
+    counts: recountByPackage(findings),
+    findings,
+  };
+  return { kind: 'success', envelope };
+}

--- a/src/languages/capabilities/provider.ts
+++ b/src/languages/capabilities/provider.ts
@@ -133,6 +133,26 @@ export interface DepVulnsProvider extends CapabilityProvider<DepVulnResult> {
    * identical on both sides and never net-new).
    */
   readonly manifestPatterns: readonly string[];
+  /**
+   * Lockfile basenames that mark an INDEPENDENT dependency-resolution root
+   * (`package-lock.json`, `Gemfile.lock`, `go.mod`, `Cargo.lock`). A nested
+   * directory containing one is a sub-project whose dependency tree the
+   * root audit cannot see — common in monorepos with a separate `server/`
+   * or `web/` app that is NOT a workspace member — so the dep audit runs
+   * once per discovered root and merges (the nested-lockfile gap: a
+   * critical vuln added to a nested lockfile read CLEAN at the root).
+   *
+   * Deliberately lockfiles, not manifests: a nested plain manifest (a Maven
+   * module's `pom.xml`, an npm workspace member's `package.json`) resolves
+   * from the ROOT tree and is already covered by the root audit — auditing
+   * it separately would duplicate work, not close a gap. Maven therefore
+   * declares no patterns (no lockfile concept); packs whose audit runs on a
+   * manifest that IS independently resolved (`requirements.txt`, `go.mod`)
+   * declare that manifest here.
+   *
+   * Optional — a pack that omits it keeps root-only auditing.
+   */
+  readonly lockfilePatterns?: readonly string[];
 }
 
 /**

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -937,6 +937,9 @@ const csharpDepVulnsProvider: DepVulnsProvider = {
     'packages.config',
     'Directory.Packages.props',
   ],
+  // NuGet lockfiles are per-project when enabled; csproj deliberately NOT
+  // listed (projects resolve from the solution tree, already root-audited).
+  lockfilePatterns: ['packages.lock.json'],
   async gather(cwd) {
     const outcome = await gatherCsharpDepVulnsResult(cwd);
     return outcome.kind === 'success' ? outcome.envelope : null;

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -453,6 +453,8 @@ async function gatherGoDepVulnsResult(cwd: string): Promise<DepVulnGatherOutcome
 const goDepVulnsProvider: DepVulnsProvider = {
   source: 'go',
   manifestPatterns: ['go.mod', 'go.sum'],
+  // Every go.mod is an independent module root (multi-module repos).
+  lockfilePatterns: ['go.mod'],
   async gather(cwd) {
     const outcome = await gatherGoDepVulnsResult(cwd);
     return outcome.kind === 'success' ? outcome.envelope : null;

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -409,6 +409,9 @@ const javaDepVulnsProvider: DepVulnsProvider = {
     'settings.gradle',
     'settings.gradle.kts',
   ],
+  // Gradle lockfiles resolve per project; Maven pom.xml deliberately NOT
+  // listed (a multi-module build resolves from one tree — no lockfile).
+  lockfilePatterns: ['gradle.lockfile', 'verification-metadata.xml'],
   async gather(cwd) {
     const outcome = await gatherOsvScannerDepVulnsResult(cwd, 'java', 'Maven', JAVA_DEP_MANIFESTS);
     return outcome.kind === 'success' ? outcome.envelope : null;

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -295,6 +295,9 @@ const kotlinDepVulnsProvider: DepVulnsProvider = {
     'settings.gradle',
     'settings.gradle.kts',
   ],
+  // Gradle lockfiles resolve per project; Maven pom.xml deliberately NOT
+  // listed (a multi-module build resolves from one tree — no lockfile).
+  lockfilePatterns: ['gradle.lockfile', 'verification-metadata.xml'],
   async gather(cwd) {
     const outcome = await gatherOsvScannerDepVulnsResult(
       cwd,

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -542,6 +542,10 @@ const pyDepVulnsProvider: DepVulnsProvider = {
     'Pipfile.lock',
     'poetry.lock',
   ],
+  // A nested requirements.txt / pyproject.toml resolves its own
+  // environment (separate services in one repo), unlike a package of a
+  // single rooted environment.
+  lockfilePatterns: ['requirements.txt', 'pyproject.toml', 'Pipfile'],
   async gather(cwd) {
     const outcome = await gatherPyDepVulnsResult(cwd);
     return outcome.kind === 'success' ? outcome.envelope : null;

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -655,6 +655,8 @@ const rubyDepVulnsProvider: DepVulnsProvider = {
   // osv-scanner audits Gemfile.lock; Gemfile / *.gemspec carry the dependency
   // declarations, so include them for the incremental skip check.
   manifestPatterns: [...RUBY_DEP_MANIFESTS, 'Gemfile', '*.gemspec'],
+  // A nested Gemfile.lock is an independently bundled sub-app.
+  lockfilePatterns: ['Gemfile.lock'],
   async gather(cwd) {
     const outcome = await gatherOsvScannerDepVulnsResult(
       cwd,

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -479,6 +479,9 @@ async function gatherRustDepVulnsResult(cwd: string): Promise<DepVulnGatherOutco
 const rustDepVulnsProvider: DepVulnsProvider = {
   source: 'rust',
   manifestPatterns: ['Cargo.toml', 'Cargo.lock'],
+  // A workspace member has no own Cargo.lock; a nested one marks an
+  // independent crate the root audit cannot see.
+  lockfilePatterns: ['Cargo.lock'],
   async gather(cwd) {
     const outcome = await gatherRustDepVulnsResult(cwd);
     return outcome.kind === 'success' ? outcome.envelope : null;

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -531,6 +531,17 @@ const tsDepVulnsProvider: DepVulnsProvider = {
     'yarn.lock',
     'pnpm-lock.yaml',
   ],
+  // Independent-resolution roots: a nested dir with its OWN lockfile is a
+  // sub-project the root audit cannot see (a workspace member has no
+  // nested lockfile, so workspaces are naturally excluded).
+  lockfilePatterns: [
+    'package-lock.json',
+    'npm-shrinkwrap.json',
+    'pnpm-lock.yaml',
+    'yarn.lock',
+    'bun.lock',
+    'bun.lockb',
+  ],
   async gather(cwd) {
     const outcome = await gatherTsDepVulnsResult(cwd);
     return outcome.kind === 'success' ? outcome.envelope : null;

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -305,6 +305,23 @@ describe.each(LANGUAGES as LanguageSupport[])('language contract: $id', (lang) =
     }
   });
 
+  it('depVulns lockfilePatterns, when declared, are exact basenames', () => {
+    const dep = lang.capabilities?.depVulns;
+    if (!dep?.lockfilePatterns) return; // root-only auditing is a valid choice
+    expect(
+      dep.lockfilePatterns.length,
+      `${lang.id}: an EMPTY lockfilePatterns is ambiguous — omit the field for ` +
+        `root-only auditing, or declare the independent-resolution lockfile names`,
+    ).toBeGreaterThan(0);
+    for (const p of dep.lockfilePatterns) {
+      // Nested-root discovery matches EXACT basenames via the canonical
+      // walker — a glob or path segment would silently never match.
+      expect(p.includes('*'), `${lang.id}: lockfilePattern "${p}" must not be a glob`).toBe(false);
+      expect(p.includes('/'), `${lang.id}: lockfilePattern "${p}" must be a basename`).toBe(false);
+      expect(p.length).toBeGreaterThan(0);
+    }
+  });
+
   // Correctness floor (2.23): EVERY built-in pack MUST declare the liveness
   // gate and supply BOTH command builders. The capability shipped optional
   // (TS/JS + Python first) and tightened to REQUIRED once all eight packs

--- a/test/nested-dep-roots.test.ts
+++ b/test/nested-dep-roots.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Nested dependency-audit roots — the fix for the nested-lockfile gap
+ * (a vuln added to a nested sub-project's lockfile read CLEAN because the
+ * dep audit ran at the repo root only).
+ *
+ * Three layers: discovery (canonical walker, exclusion-aware, capped with
+ * disclosure), outcome merging (identity dedup + per-package recount,
+ * root-only behavior byte-identical when nothing nested exists), and the
+ * dispatch composite driven by a FAKE pack — proving per-root auditing is
+ * declaration-driven (`lockfilePatterns`), not hardcoded per ecosystem.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  discoverNestedDepRoots,
+  mergeDepVulnOutcomes,
+  MAX_NESTED_DEP_ROOTS,
+} from '../src/analyzers/security/nested-dep-roots';
+import { gatherPackDepVulnsAcrossRoots } from '../src/analyzers/security/gather';
+import { clearWalkPathsCache } from '../src/analyzers/tools/walk-paths';
+import type {
+  DepVulnFinding,
+  DepVulnGatherOutcome,
+  DepVulnResult,
+} from '../src/languages/capabilities/types';
+import type { LanguageSupport } from '../src/languages/types';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-nested-dep-'));
+  clearWalkPathsCache();
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  clearWalkPathsCache();
+});
+
+function file(rel: string, content = '{}'): void {
+  const abs = path.join(tmp, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+function finding(pkg: string, id: string, severity: DepVulnFinding['severity']): DepVulnFinding {
+  return { id, package: pkg, installedVersion: '1.0.0', tool: 't', severity };
+}
+
+function success(tool: string, findings: DepVulnFinding[]): DepVulnGatherOutcome {
+  const counts = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const f of findings) counts[f.severity]++;
+  const envelope: DepVulnResult = {
+    schemaVersion: 1,
+    tool,
+    enrichment: 'osv.dev',
+    counts,
+    findings,
+  };
+  return { kind: 'success', envelope };
+}
+
+describe('discoverNestedDepRoots', () => {
+  it('finds nested lockfile dirs, never the root, exclusion-aware', () => {
+    file('package-lock.json');
+    file('website-react/server/package-lock.json');
+    file('services/api/pnpm-lock.yaml');
+    file('node_modules/dep/package-lock.json'); // excluded dir
+    const { roots, dropped } = discoverNestedDepRoots(tmp, ['package-lock.json', 'pnpm-lock.yaml']);
+    expect(roots).toEqual(['services/api', 'website-react/server']);
+    expect(dropped).toEqual([]);
+  });
+
+  it('caps at the ceiling and DISCLOSES what was dropped', () => {
+    for (let i = 0; i < MAX_NESTED_DEP_ROOTS + 3; i++) {
+      file(`pkg-${String(i).padStart(2, '0')}/package-lock.json`);
+    }
+    const { roots, dropped } = discoverNestedDepRoots(tmp, ['package-lock.json']);
+    expect(roots).toHaveLength(MAX_NESTED_DEP_ROOTS);
+    expect(dropped).toHaveLength(3);
+  });
+
+  it('empty patterns → no discovery (root-only packs unchanged)', () => {
+    file('sub/package-lock.json');
+    expect(discoverNestedDepRoots(tmp, [])).toEqual({ roots: [], dropped: [] });
+  });
+});
+
+describe('mergeDepVulnOutcomes', () => {
+  it('single root success with no nested successes passes through untouched', () => {
+    const root = success('npm-audit', [finding('lodash', 'GHSA-1', 'high')]);
+    expect(mergeDepVulnOutcomes(root, [{ kind: 'no-manifest', reason: 'x' }], false)).toBe(root);
+  });
+
+  it('root failure passes through when nothing nested succeeded (availability story intact)', () => {
+    const root: DepVulnGatherOutcome = { kind: 'unavailable', reason: 'scanner missing' };
+    expect(mergeDepVulnOutcomes(root, [{ kind: 'no-manifest', reason: 'x' }], false)).toBe(root);
+  });
+
+  it('a nested success rescues a root no-manifest (the sub-project-only repo)', () => {
+    const nested = success('npm-audit', [finding('node-serialize', 'GHSA-crit', 'critical')]);
+    const merged = mergeDepVulnOutcomes({ kind: 'no-manifest', reason: 'x' }, [nested], false);
+    expect(merged.kind).toBe('success');
+    if (merged.kind === 'success') {
+      expect((merged.envelope.findings ?? []).map((f) => f.package)).toEqual(['node-serialize']);
+    }
+  });
+
+  it('dedupes identical findings across roots, recounts per package, unions tools', () => {
+    const root = success('npm-audit', [
+      finding('lodash', 'GHSA-1', 'high'),
+      finding('lodash', 'GHSA-2', 'medium'), // same pkg, 2nd advisory
+    ]);
+    const nested = success('osv-scanner', [
+      finding('lodash', 'GHSA-1', 'high'), // duplicate across roots → dropped
+      finding('node-serialize', 'GHSA-9', 'critical'),
+    ]);
+    const merged = mergeDepVulnOutcomes(root, [nested], false);
+    expect(merged.kind).toBe('success');
+    if (merged.kind !== 'success') return;
+    // Findings: per-advisory, deduped on (package, version, id).
+    expect((merged.envelope.findings ?? []).map((f) => f.id).sort()).toEqual([
+      'GHSA-1',
+      'GHSA-2',
+      'GHSA-9',
+    ]);
+    // Counts: per PACKAGE at worst severity (the documented count model).
+    expect(merged.envelope.counts).toEqual({ critical: 1, high: 1, medium: 0, low: 0 });
+    expect(merged.envelope.tool).toBe('npm-audit+osv-scanner');
+  });
+
+  it('a capped discovery is marked on the tool string, never silent', () => {
+    const root = success('npm-audit', [finding('a', 'G-1', 'low')]);
+    const nested = success('npm-audit', [finding('b', 'G-2', 'low')]);
+    const merged = mergeDepVulnOutcomes(root, [nested], true);
+    expect(merged.kind === 'success' && merged.envelope.tool).toBe('npm-audit+capped');
+  });
+});
+
+describe('gatherPackDepVulnsAcrossRoots — declaration-driven dispatch', () => {
+  function fakePack(lockfilePatterns: string[] | undefined, calls: string[]): LanguageSupport {
+    return {
+      id: 'typescript',
+      capabilities: {
+        depVulns: {
+          source: 'fake',
+          manifestPatterns: ['fake.lock'],
+          ...(lockfilePatterns !== undefined ? { lockfilePatterns } : {}),
+          async gather() {
+            return null;
+          },
+          async gatherOutcome(dir: string) {
+            calls.push(path.relative(tmp, dir) || '.');
+            const rel = path.relative(tmp, dir);
+            return success(`tool@${rel || 'root'}`, [
+              finding(`pkg-${rel || 'root'}`, `G-${rel || 'root'}`, 'high'),
+            ]);
+          },
+        },
+      },
+    } as unknown as LanguageSupport;
+  }
+
+  it('audits the root plus every discovered nested root and merges', async () => {
+    file('fake.lock');
+    file('apps/server/fake.lock');
+    file('apps/web/fake.lock');
+    const calls: string[] = [];
+    const outcome = await gatherPackDepVulnsAcrossRoots(
+      fakePack(['fake.lock'], calls),
+      tmp,
+      undefined,
+    );
+    expect(calls.sort()).toEqual(['.', 'apps/server', 'apps/web']);
+    expect(outcome.kind).toBe('success');
+    if (outcome.kind === 'success') {
+      expect((outcome.envelope.findings ?? []).map((f) => f.package).sort()).toEqual([
+        'pkg-apps/server',
+        'pkg-apps/web',
+        'pkg-root',
+      ]);
+    }
+  });
+
+  it('a pack without lockfilePatterns keeps byte-identical root-only behavior', async () => {
+    file('fake.lock');
+    file('apps/server/fake.lock');
+    const calls: string[] = [];
+    const outcome = await gatherPackDepVulnsAcrossRoots(fakePack(undefined, calls), tmp, undefined);
+    expect(calls).toEqual(['.']);
+    expect(outcome.kind).toBe('success');
+  });
+});

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -79,6 +79,8 @@ import { buildRequiredTools } from '../src/analyzers/tools/tool-registry';
 import { detect } from '../src/detect';
 import * as fs from 'fs';
 import * as os from 'os';
+import { gatherPackDepVulnsAcrossRoots } from '../src/analyzers/security/gather';
+import { clearWalkPathsCache } from '../src/analyzers/tools/walk-paths';
 import * as path from 'path';
 
 // ─── The mock synthetic pack ────────────────────────────────────────────────
@@ -217,6 +219,9 @@ const mockPlaybookPack = {
     depVulns: {
       source: 'playbook-mock',
       manifestPatterns: ['playbook.lock', '*.pbkproj'],
+      // Distinctive lockfile basename so the nested-root dispatch assertion
+      // below proves per-root auditing is declaration-driven.
+      lockfilePatterns: ['playbook.lock'],
       async gather() {
         return null;
       },
@@ -334,6 +339,38 @@ describe('recipe playbook — synthetic pack', () => {
     expect(patterns).toContain('package.json'); // typescript
     expect(patterns).toContain('go.mod'); // go
     expect(patterns).toContain('*.csproj'); // csharp
+  });
+
+  // Nested dep-audit roots (the nested-lockfile gap): the per-root dispatch
+  // reads the pack's DECLARED lockfilePatterns — a synthetic pack with a
+  // nested `playbook.lock` gets its gatherOutcome invoked once per root.
+  it("gatherPackDepVulnsAcrossRoots audits the synthetic pack's nested lockfile roots", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-playbook-nested-'));
+    try {
+      fs.mkdirSync(path.join(dir, 'apps', 'svc'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'playbook.lock'), '{}');
+      fs.writeFileSync(path.join(dir, 'apps', 'svc', 'playbook.lock'), '{}');
+      const calls: string[] = [];
+      const pack = {
+        ...mockPlaybookPack,
+        capabilities: {
+          ...mockPlaybookPack.capabilities,
+          depVulns: {
+            ...mockPlaybookPack.capabilities!.depVulns!,
+            async gatherOutcome(d: string) {
+              calls.push(path.relative(dir, d).split(path.sep).join('/') || '.');
+              return { kind: 'no-manifest' as const, reason: 'mock' };
+            },
+          },
+        },
+      };
+      clearWalkPathsCache();
+      await gatherPackDepVulnsAcrossRoots(pack as never, dir, undefined);
+      expect(calls.sort()).toEqual(['.', 'apps/svc']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      clearWalkPathsCache();
+    }
   });
 
   it('changedFilesTouchDependencyManifest detects the mock pack manifest (2.16)', () => {


### PR DESCRIPTION
Fixes #90 — the dep audit ran at the repo root only, so a vulnerability introduced in a nested sub-project's lockfile (a `server/` app with its own `package-lock.json` that is not a workspace member) was invisible to `health`, `vulnerabilities`, and the guardrail gate.

## The fix (platform-level, per the issue's proposed direction)

- **Pack-declared** (Rule 6): `DepVulnsProvider.lockfilePatterns` — exact basenames marking an INDEPENDENT dependency-resolution root, declared on all eight packs. Deliberately lockfiles, not manifests: an npm workspace member or Maven module resolves from the root tree and is already covered by the root audit (Maven therefore declares none — no lockfile concept).
- **Canonical walker** (G_v4_12): discovery is depth-unlimited and exclusion-aware (`node_modules`/`vendor` lockfiles never count), capped at 8 roots per pack **with disclosure** (stderr note + a `+capped` tool marker — never silent).
- **One code path** (Rule 2): wired at the single dispatch primitive every consumer shares (`gatherDepVulnsWithAvailability`), so reports and the gate audit the identical lockfile set. Findings merge on their true identity `(package, version, advisory)` — the same vuln in two sub-projects stays one finding — with counts recomputed per-package at worst severity (the documented count model). A pack without patterns, or a repo without nested roots, keeps **byte-identical** root-only behavior; a nested failure never degrades the root's availability story.
- **No trigger change needed**: the incremental dep-audit skip already matches manifest basenames at any depth, so nested lockfile changes were already waking the audit — it just had nothing that could see them.

## Recipe surfaces (all updated with the capability)

new-lang scaffold stub · CONTRIBUTING capability walkthrough · languages-contract test (patterns must be exact basenames — a glob or path segment would silently never match) · synthetic-pack playbook assertion (per-root dispatch proven declaration-driven) · CLAUDE.md one-concept entry · CHANGELOG.

## Validation

- Unit + playbook: discovery (exclusions, cap+disclosure), merge (dedup, per-package recount, tool union, root-failure passthrough, nested-success rescue), fake-pack dispatch. Full suite green, arch + slop gates pass, pushed through the pre-push gate.
- **The originally-reported evidence case**: cloned the public repo at the reported PR head and ran the same gather every consumer uses — the nested `node-serialize@0.0.4` (GHSA-Q4V7-4RHW-9HQM, CVSS 9.8) that previously read CLEAN is now detected (118 findings across the nested roots). Clone removed after; no writes to any external repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)