### PR TITLE
feat(extensions): #11b — the extension runtime (rungs 2-3: declared artifacts + the any-language orchestrator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The extension runtime (rungs 2-3 of the extension ladder).** Declared
+  contract artifacts: point `flow.sources` at a Postman collection, Pact
+  contract, `.http`/`.rest` file, or HAR capture (plus OpenAPI) and its
+  calls/routes join the flow map and gate with zero code — readers live in
+  one registry, formats are entries, and the join now resolves concrete
+  artifact paths against `{var}` routes. External extensions: a committed
+  `.dxkit/extensions/<name>/extension.json` points at your existing script
+  (any language); dxkit runs it at refresh time under the bounded-exec
+  primitive, validates its emitted `contract.v1` / `inventory.v1` /
+  `findings.v1` / `export.v1` document field-precisely, and routes it
+  through the same machines native output gets: findings gate net-new-only
+  through the custom-check seam (`gating: block|warn|off` per manifest),
+  inventory entity counts trend on `report history`, export sinks receive
+  the post-run report and deliver it with your existing tooling. Gates and
+  untrusted runs never execute extensions — they read committed snapshots
+  offline with staleness disclosed. New `extensions` CLI (`list`,
+  `refresh [--land pr|push]`, `dev` — the seconds-fast authoring loop,
+  `init` — a scaffold that passes validation immediately), a doctor probe +
+  deterministic `configure` planner that discover undeclared artifacts via
+  the reader registry's own filename signals, an opt-in on-merge refresh
+  workflow (auto-enabled when a manifest declares `refresh: "on-merge"`),
+  and the `dxkit-extensions` agent skill.
+
 - **`@vyuhlabs/dxkit-sdk`: the frozen extension surface (types-first).**
   A new sibling package publishes the contract extensions build against:
   the declarative descriptor language (`HttpFlowSupport`,

--- a/docs/extension-sdk.md
+++ b/docs/extension-sdk.md
@@ -4,10 +4,10 @@ dxkit's core owns the language-agnostic contract level: routes, models,
 dependencies, findings, gates. Everything app-specific or org-specific becomes
 an extension, and the SDK is the frozen surface extensions build against.
 
-This page documents the surface as of SDK 0.x (types-first). The extension
-orchestrator (external extractors in any language) and the in-process plugin
-runtime arrive in later minors; the shapes they will speak are already frozen
-here so nothing you build now gets rewritten.
+This page documents the surface as of SDK 0.x. Rungs 1-3 are live: declared
+contract artifacts (`flow.sources`) and the external-extension orchestrator
+(`vyuh-dxkit extensions`) ship with dxkit 3.5; the in-process plugin runtime
+(rung 4) arrives in a later minor, speaking the shapes already frozen here.
 
 ## The effort ladder
 

--- a/packages/dxkit-sdk/src/http-normalize.ts
+++ b/packages/dxkit-sdk/src/http-normalize.ts
@@ -141,7 +141,11 @@ export function normalizePath(
   // 3. external absolute URL (not one of our host helpers) → not internal
   if (/^https?:\/\//i.test(s) || /^\$\{[^}]*\}:\/\//.test(s)) return null;
 
-  // 4. template expressions → placeholder
+  // 4. template expressions → placeholder. The mustache form `{{host}}`
+  //    (Postman collections, .http files) must collapse BEFORE the
+  //    single-brace param rule in 6b, whose `{…}` would otherwise consume
+  //    only the inner braces and leave a stray `}` (`{{x}}` → `{var}}`).
+  s = s.replace(/\{\{[^}]*\}\}/g, PLACEHOLDER);
   s = s.replace(/\$\{[^}]*\}/g, PLACEHOLDER);
 
   // 5. drop query string

--- a/packages/dxkit-sdk/src/manifest.ts
+++ b/packages/dxkit-sdk/src/manifest.ts
@@ -46,4 +46,12 @@ export interface ExtensionManifest {
   refresh: 'on-merge' | 'manual';
   /** Repo-relative path of the committed snapshot the run writes. */
   output: string;
+  /**
+   * For `findings` extensions: how a NET-NEW finding gates. 'block' fails
+   * the guardrail, 'warn' (the default) surfaces without failing, 'off'
+   * keeps the snapshot out of gating entirely. Pre-existing findings are
+   * grandfathered by the baseline machine either way. Ignored for other
+   * contribution kinds. Additive field (SDK minor).
+   */
+  gating?: 'block' | 'warn' | 'off';
 }

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1367,6 +1367,27 @@ if [ -n "$SIDEREF_INLINE_PUSH" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# ─── Contract-source discipline: artifact formats live in the registry ──────
+# A declared contract artifact (Postman collection, Pact contract, HAR
+# capture, …) is parsed by exactly one reader module under
+# src/analyzers/flow/contract-sources/. A format kind-literal appearing
+# elsewhere in src/ is the smoking-gun shape of a second parser (or a
+# hardcoded kind dispatch) growing outside the registry. 'http'/'openapi'
+# are too common as words to grep; the distinctive kinds are the tripwire.
+ROGUE_FORMAT=$(grep -rnE "'(postman|pact|har)'|\"(postman|pact|har)\"" src/ 2>/dev/null \
+  | grep -v "^src/analyzers/flow/contract-sources/" \
+  | grep -v -E ':[0-9]+:[[:space:]]*(//|\*)' \
+  | grep -v "// contract-source-ok" || true)
+if [ -n "$ROGUE_FORMAT" ]; then
+  echo "❌ Contract-source violation: artifact-format literal outside the reader registry:"
+  echo "$ROGUE_FORMAT"
+  echo "   → Formats are registry entries (CONTRACT_SOURCE_READERS). Extend the"
+  echo "     reader module or add a new one + one entry; never dispatch on a"
+  echo "     format kind elsewhere. Annotate '// contract-source-ok' for"
+  echo "     justified exceptions (docs strings, tests fixtures)."
+  ERRORS=$((ERRORS + 1))
+fi
+
 # ─── Extension-runner discipline (mirror of Rule 17's custom-check gate) ────
 # runExtension EXECUTES repo-declared commands. It is callable only from
 # src/extensions/ (the orchestrator's own modules) and the extensions CLI —

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1367,6 +1367,25 @@ if [ -n "$SIDEREF_INLINE_PUSH" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# ─── Extension-runner discipline (mirror of Rule 17's custom-check gate) ────
+# runExtension EXECUTES repo-declared commands. It is callable only from
+# src/extensions/ (the orchestrator's own modules) and the extensions CLI —
+# every other consumer reads committed snapshots via snapshot.ts. A second
+# call site is how "gates execute extensions" ships by accident.
+ROGUE_EXT_EXEC=$(grep -rnE "runExtension[[:space:]]*\(" src/ 2>/dev/null \
+  | grep -v "// extension-runner-ok" \
+  | grep -v "^src/extensions/" \
+  | grep -v "^src/extensions-cli.ts" || true)
+if [ -n "$ROGUE_EXT_EXEC" ]; then
+  echo "❌ Extension-runner violation: runExtension() called outside the orchestrator:"
+  echo "$ROGUE_EXT_EXEC"
+  echo "   → Execution happens at refresh time only (extensions refresh / the"
+  echo "     on-merge workflow). Gates and reports read committed snapshots via"
+  echo "     src/extensions/snapshot.ts. Annotate '// extension-runner-ok' for"
+  echo "     justified exceptions (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
 # ─── Rule 18 (SDK boundary): the frozen extension surface stays one-way ─────
 # The frozen surface lives in packages/dxkit-sdk; the main package depends on
 # it and re-exports. Two invariants keep the freeze real:

--- a/src-templates/.claude/skills/dxkit-extensions/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-extensions/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: dxkit-extensions
+description: Plug the repo's own extractors, inventories, and delivery sinks into dxkit as extensions — any language, no porting. Use when the user says "run our Python extractor through dxkit", "track our screens/permissions inventory", "make our custom scanner's findings gate the PR", "send dxkit reports to our dashboard/spreadsheet", "declare our Postman collection / pact / HAR", or "how do I write a dxkit extension". For gate-time repo COMMANDS (a lint gate, an architecture script), defer to dxkit-checks; extensions run at refresh time and gates read their committed snapshots offline.
+---
+
+# dxkit-extensions
+
+An **extension** is a script the repo already owns — any language — that dxkit
+orchestrates: it runs at refresh time, emits one JSON document, and dxkit
+validates it and routes it through the same machines native output gets.
+
+Before writing one, climb the ladder from the bottom — most needs stop early:
+
+1. **Config** — a `.dxkit/policy.json` key. No code.
+2. **Declared artifact** — you already have a Postman collection, Pact file,
+   `.http` requests, HAR capture, or OpenAPI document? Declare it:
+
+   ```jsonc
+   // .dxkit/policy.json
+   {
+     "flow": {
+       "sources": [
+         { "kind": "postman", "path": "collections/checkout.postman_collection.json" },
+         { "kind": "pact", "path": "pacts/web-api.json" },
+         { "kind": "har", "path": "fixtures/session.har" },
+       ],
+     },
+   }
+   ```
+
+   Zero code; the artifacts join the flow map and gate like extracted calls.
+3. **External extension** (this skill's core) — a committed manifest points at
+   your existing script.
+4. **TypeScript plugin** — only for AST-level integration; you probably don't
+   need it (it lands with the plugin runtime).
+
+## What an extension can contribute
+
+| `contributes` | The document it emits | Where it lands |
+| --- | --- | --- |
+| `contract` | `contract.v1` — consumed calls / served routes | the flow map + integration gate |
+| `inventory` | `inventory.v1` — named entities (screens, permissions, …) | committed store + entity-count trend on `report history` |
+| `findings` | `findings.v1` — located findings | the guardrail: net-new blocks/warns per the manifest's `gating`, pre-existing debt grandfathered |
+| `export` | `export.v1` receipt (it RECEIVES the report to deliver) | your dashboard / spreadsheet / notifier, unchanged |
+
+## Author one
+
+```bash
+# scaffold (manifest + optional Python starter that already passes validation)
+npx vyuh-dxkit extensions init ui-inventory --kind inventory --stub
+
+# point at an EXISTING script instead
+npx vyuh-dxkit extensions init perm-audit --kind findings \
+  --command "python3 tools/audit_permissions.py"
+
+# the authoring loop — run + validate + summarize, in seconds
+npx vyuh-dxkit extensions dev ui-inventory
+```
+
+The script's contract (any language): read the JSON payload on **stdin**
+(your committed `config` block + repo facts — exclude dirs, active
+languages), write ONE JSON document to **stdout** or to the manifest's
+`output` path. Validation errors from `dev` are field-precise
+(`inventory.v1: entities[3].fields[0].name must be a non-empty string`) —
+fix and re-run.
+
+## Operate
+
+```bash
+npx vyuh-dxkit extensions            # list + snapshot health (ok/age, missing, invalid)
+npx vyuh-dxkit extensions refresh    # run them all, rewrite committed snapshots
+```
+
+Trust model (explain when asked): extensions execute ONLY from the repo's own
+committed manifests, at refresh time on trusted context (a developer machine
+or the on-merge refresh workflow). Gates and untrusted PR runs never execute
+anything — they read the committed snapshots offline, with staleness
+disclosed. Review a PR that edits an `extension.json` or its script like a PR
+that edits a CI workflow.
+
+For a findings extension, gating posture is in the manifest: `"gating":
+"block"` fails the guardrail on a net-new finding, `"warn"` (default)
+surfaces it, `"off"` keeps it out of gating. Suppress an individual finding
+via dxkit-allowlist, same as any native finding.

--- a/src-templates/.github/workflows/dxkit-extensions-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-extensions-refresh.yml
@@ -1,0 +1,78 @@
+name: dxkit extensions refresh
+
+# Keeps the committed extension snapshots (`.dxkit/contrib/*.json`) current
+# after each merge to the default branch (or weekly / on demand). Gates read
+# those snapshots OFFLINE — extensions never execute on a gate surface — so
+# their freshness is what keeps extension-backed verdicts honest.
+#
+# How the refresh LANDS is the CLI's job, not this workflow's bash:
+#   - `--land pr` (default here): one STANDING `dxkit/extensions-refresh` PR,
+#     force-updated in place. Protected-branch-safe; enable auto-merge if
+#     additions-only updates need no ceremony.
+#   - `--land push`: direct [skip ci] commit — unprotected trunks only.
+# A pure generatedAt restamp never lands a commit (the substance check
+# reverts it), so quiet merges stay quiet.
+#
+# Opt-in: installed by `init --with-extensions-refresh`, or automatically
+# when a committed extension declares `refresh: "on-merge"`.
+
+on:
+  push:
+    branches: [__DXKIT_DEFAULT_BRANCH__]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
+
+# contents: write pushes the refresh branch (or the [skip ci] commit in push
+# mode); pull-requests: write lets the CLI open/update the standing PR.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  extensions-refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      # Language runtime(s) for the detected stack, so an extension's
+      # interpreter (python3, ruby, …) is present. Empty on a Node-only repo.
+__DXKIT_CI_RUNTIME_SETUP__
+      - name: Install dependencies + dxkit
+        run: |
+          corepack enable >/dev/null 2>&1 || true
+          if [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile
+          elif [ -f yarn.lock ]; then
+            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
+          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
+            npm install -g bun >/dev/null 2>&1 || true
+            bun install --frozen-lockfile
+          elif [ -f package-lock.json ]; then
+            npm ci
+          elif [ -f package.json ]; then
+            npm install
+          else
+            npm install -g @vyuhlabs/dxkit
+          fi
+
+      - name: Refresh + land the extension snapshots
+        env:
+          # The CLI shells `gh` to open/update the standing PR in `pr` mode.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            DXKIT=./node_modules/.bin/vyuh-dxkit
+          else
+            DXKIT=vyuh-dxkit
+          fi
+          # Runs every committed extension manifest and lands the snapshot
+          # delta — execution/validation/landing logic lives in the tested
+          # CLI, never in this workflow's bash.
+          "${DXKIT}" extensions refresh --land pr

--- a/src/analyzers/custom-checks/gather.ts
+++ b/src/analyzers/custom-checks/gather.ts
@@ -17,6 +17,7 @@ import type { BrownfieldPolicy } from '../../baseline/policy';
 import { lintGateSpecs, normalizeCustomChecks } from './config';
 import { runCustomChecks } from './run';
 import type { CommandExec } from '../tools/bounded-exec';
+import { gatherExtensionFindings } from '../../extensions/extension-findings';
 import type { CustomCheckFinding, CustomCheckSpec } from './types';
 
 export interface GatherCustomChecksOptions {
@@ -56,12 +57,20 @@ export function gatherCustomCheckFindings(
   opts: GatherCustomChecksOptions,
 ): readonly CustomCheckFinding[] {
   const specs = resolveCustomCheckSpecs(opts);
-  if (specs.length === 0) return [];
-  const result = runCustomChecks({
-    cwd: opts.cwd,
-    specs,
-    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
-    ...(opts.exec !== undefined ? { exec: opts.exec } : {}),
-  });
-  return result.findings;
+  const commandFindings =
+    specs.length === 0
+      ? []
+      : runCustomChecks({
+          cwd: opts.cwd,
+          specs,
+          ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+          ...(opts.exec !== undefined ? { exec: opts.exec } : {}),
+        }).findings;
+  // The seam's third consumer (after user checks + pack lint): findings
+  // committed by findings-kind EXTENSIONS. Snapshot reads only — nothing
+  // executes here (extensions run at refresh time; gates stay offline) —
+  // and both the baseline producer and the guardrail current scan reach
+  // extension findings through THIS one entry point, so the two sides
+  // always see the identical set (Rule 2).
+  return [...commandFindings, ...gatherExtensionFindings(opts.cwd)];
 }

--- a/src/analyzers/flow/config.ts
+++ b/src/analyzers/flow/config.ts
@@ -38,6 +38,12 @@ export interface FlowConfig {
   readonly stripUrlPrefixes: string[];
   /** OpenAPI/spec files whose served routes union with static extraction. */
   readonly specs: string[];
+  /** Declared contract artifacts (Postman/Pact/.http/HAR/OpenAPI) resolved
+   *  through the contract-source reader registry. v1-additive: absent reads
+   *  as none, old readers ignore it. Entries are validated against the
+   *  registry at LOAD time (`loadContractSources`), where the unknown-kind
+   *  error can name the known kinds — config reading stays fail-open. */
+  readonly sources: FlowSourceConfigEntry[];
   /** Guardrail posture for net-new broken integrations. */
   readonly mode: FlowGateMode;
   /** Confidence at/above which a net-new break BLOCKS (else warns). Default 1 —
@@ -50,9 +56,17 @@ export interface FlowConfig {
   readonly refreshMode: FlowRefreshMode;
 }
 
+/** One `flow.sources[]` declaration as committed (pre-registry-validation). */
+export interface FlowSourceConfigEntry {
+  readonly kind: string;
+  readonly path: string;
+  readonly side?: string;
+}
+
 const DEFAULTS: FlowConfig = {
   stripUrlPrefixes: [],
   specs: [],
+  sources: [],
   mode: 'block',
   blockThreshold: 1,
   onMergeRefresh: false,
@@ -71,6 +85,7 @@ export const FLOW_CONFIG_SCHEMA_VERSION = 1;
 interface RawFlow {
   stripUrlPrefixes?: unknown;
   specs?: unknown;
+  sources?: unknown;
   mode?: unknown;
   blockThreshold?: unknown;
   onMergeRefresh?: unknown;
@@ -79,6 +94,20 @@ interface RawFlow {
 
 function stringList(v: unknown): string[] {
   return Array.isArray(v) ? v.filter((s): s is string => typeof s === 'string') : [];
+}
+
+/** Keep any object entry carrying string kind+path; deeper validation (kind
+ *  known? side legal?) happens against the registry at load time so its
+ *  errors can name the known kinds. */
+function sourceList(v: unknown): FlowSourceConfigEntry[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter(
+    (e): e is FlowSourceConfigEntry =>
+      typeof e === 'object' &&
+      e !== null &&
+      typeof (e as { kind?: unknown }).kind === 'string' &&
+      typeof (e as { path?: unknown }).path === 'string',
+  );
 }
 
 function isMode(v: unknown): v is FlowGateMode {
@@ -101,6 +130,7 @@ export function readFlowConfig(cwd: string): FlowConfig {
   return {
     stripUrlPrefixes: stringList(raw.stripUrlPrefixes),
     specs: stringList(raw.specs),
+    sources: sourceList(raw.sources),
     mode: isMode(raw.mode) ? raw.mode : DEFAULTS.mode,
     blockThreshold:
       typeof raw.blockThreshold === 'number' && raw.blockThreshold > 0

--- a/src/analyzers/flow/contract-sources/har.ts
+++ b/src/analyzers/flow/contract-sources/har.ts
@@ -1,0 +1,55 @@
+/**
+ * HAR reader (HTTP Archive 1.2 — a browser/proxy capture).
+ *
+ * `log.entries[].request` carries `method` + an ABSOLUTE `url`; a capture
+ * is real observed traffic, so it is high-recall and host-noisy. The
+ * shared normalizer rejects absolute URLs to hosts not covered by
+ * `flow.stripUrlPrefixes` — declaring your own API host there is what
+ * turns a capture into joinable route paths, and the load discloses how
+ * many entries were dropped as external (analytics beacons, CDNs).
+ *
+ * Sides: 'consumed' only — a capture is calls something made.
+ */
+
+import type { ContractSourceParse, ContractSourceReader, RawConsumedCall } from './index';
+
+interface HarEntry {
+  request?: { method?: unknown; url?: unknown } | null;
+}
+
+export const harReader: ContractSourceReader = {
+  kind: 'har',
+  displayName: 'HAR capture',
+  sides: 'consumed',
+  defaultSide: 'consumed',
+  sniff: (p) => p.endsWith('.har'),
+  parse(content, filePath): ContractSourceParse {
+    let doc: { log?: { entries?: unknown } };
+    try {
+      doc = JSON.parse(content) as { log?: { entries?: unknown } };
+    } catch (e) {
+      return {
+        consumed: [],
+        served: [],
+        errors: [`${filePath}: not valid JSON (${e instanceof Error ? e.message : String(e)})`],
+      };
+    }
+    const entries = doc?.log?.entries;
+    if (!Array.isArray(entries)) {
+      return {
+        consumed: [],
+        served: [],
+        errors: [`${filePath}: not a HAR document (no log.entries[])`],
+      };
+    }
+    const consumed: RawConsumedCall[] = [];
+    for (const e of entries as HarEntry[]) {
+      const req = e?.request;
+      if (!req || typeof req !== 'object') continue;
+      const method = typeof req.method === 'string' ? req.method : null;
+      const url = typeof req.url === 'string' ? req.url : null;
+      if (method && url) consumed.push({ method, url, file: filePath, line: 0 });
+    }
+    return { consumed, served: [], errors: [] };
+  },
+};

--- a/src/analyzers/flow/contract-sources/http-file.ts
+++ b/src/analyzers/flow/contract-sources/http-file.ts
@@ -1,0 +1,33 @@
+/**
+ * .http / .rest request-file reader (VS Code REST Client, JetBrains HTTP
+ * client).
+ *
+ * The format is line-oriented: a request line is `<VERB> <url>` (an
+ * optional `HTTP/1.1` suffix tolerated), requests separated by `###`
+ * comments, `#`/`//` lines ignored, `{{variable}}` segments collapse to
+ * `{var}` in the shared normalizer. The only reader with REAL line
+ * numbers — these files are hand-authored, so a broken entry should point
+ * at its line.
+ *
+ * Sides: 'consumed' only — a request file is calls someone makes.
+ */
+
+import type { ContractSourceParse, ContractSourceReader, RawConsumedCall } from './index';
+
+const REQUEST_LINE = /^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(\S+)(\s+HTTP\/[\d.]+)?\s*$/i;
+
+export const httpFileReader: ContractSourceReader = {
+  kind: 'http',
+  displayName: '.http request file',
+  sides: 'consumed',
+  defaultSide: 'consumed',
+  sniff: (p) => p.endsWith('.http') || p.endsWith('.rest'),
+  parse(content, filePath): ContractSourceParse {
+    const consumed: RawConsumedCall[] = [];
+    content.split(/\r?\n/).forEach((line, idx) => {
+      const m = REQUEST_LINE.exec(line.trim());
+      if (m) consumed.push({ method: m[1], url: m[2], file: filePath, line: idx + 1 });
+    });
+    return { consumed, served: [], errors: [] };
+  },
+};

--- a/src/analyzers/flow/contract-sources/index.ts
+++ b/src/analyzers/flow/contract-sources/index.ts
@@ -1,0 +1,241 @@
+/**
+ * CONTRACT_SOURCE_READERS — the registry of declared contract artifacts
+ * (rung 2 of the extension ladder: a path to a file you already have).
+ *
+ * Formats are ENTRIES, not features: each reader is one module that parses
+ * one well-known artifact format (Postman collection, Pact contract,
+ * .http/.rest request file, HAR capture, OpenAPI document) into RAW
+ * consumed/served observations; this module owns everything cross-cutting —
+ * kind dispatch, side legality, path-pattern expansion, and normalization
+ * through the ONE shared normalizer (a reader never normalizes; a client
+ * call and a route can only agree on canonical form because both reduce
+ * here). Adding a format is one module + one entry; the synthetic-reader
+ * playbook test proves consumers pick a new entry up untouched, and the
+ * arch gate keeps format kind-literals confined to this directory.
+ *
+ * Fail-open discipline: a missing file, an unparseable artifact, an unknown
+ * kind, or an illegal side is a DISCLOSURE (collected, surfaced by doctor /
+ * the map), never a crash — declared artifacts degrade the same way specs
+ * always have.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ClientCall, RouteEndpoint } from '../extract';
+import { ANY_METHOD, normalizeMethod, normalizePath, type NormalizeConfig } from '../normalize';
+import { harReader } from './har';
+import { httpFileReader } from './http-file';
+import { openapiReader } from './openapi';
+import { pactReader } from './pact';
+import { postmanReader } from './postman';
+
+/** Which contract side(s) a declared artifact may testify to. */
+export type ContractSide = 'consumed' | 'served';
+
+/** Raw (pre-normalization) observations a reader emits. */
+export interface RawConsumedCall {
+  readonly method: string;
+  readonly url: string;
+  readonly file: string;
+  readonly line: number;
+}
+export interface RawServedRoute {
+  readonly method: string;
+  readonly path: string;
+  readonly handler?: string | null;
+  readonly file: string;
+  readonly line: number;
+}
+export interface ContractSourceParse {
+  readonly consumed: readonly RawConsumedCall[];
+  readonly served: readonly RawServedRoute[];
+  /** Format-level problems, already file-prefixed. */
+  readonly errors: readonly string[];
+}
+
+/** One registered artifact format. */
+export interface ContractSourceReader {
+  /** The `flow.sources[].kind` token. */
+  readonly kind: string;
+  readonly displayName: string;
+  /** Sides this format can testify to ('both' → the declaration may choose). */
+  readonly sides: ContractSide | 'both';
+  /** Side used when the declaration omits one. */
+  readonly defaultSide: ContractSide;
+  /** Cheap filename signal for doctor's "declare this artifact" probe. */
+  sniff(filePath: string): boolean;
+  /** Parse one artifact file into raw observations. Total: parse errors are
+   *  returned, never thrown. */
+  parse(content: string, filePath: string): ContractSourceParse;
+}
+
+export const CONTRACT_SOURCE_READERS: readonly ContractSourceReader[] = [
+  openapiReader,
+  postmanReader,
+  pactReader,
+  httpFileReader,
+  harReader,
+];
+
+export function contractSourceReaderFor(
+  kind: string,
+  registry: readonly ContractSourceReader[] = CONTRACT_SOURCE_READERS,
+): ContractSourceReader | undefined {
+  return registry.find((r) => r.kind === kind);
+}
+
+/** A `flow.sources[]` declaration (validated here, not at config read —
+ *  the registry lives here, so the loud unknown-kind error does too). */
+export interface FlowSourceDecl {
+  readonly kind: string;
+  readonly path: string;
+  readonly side?: string;
+}
+
+export interface ContractSourceLoad {
+  readonly calls: readonly ClientCall[];
+  readonly routes: readonly RouteEndpoint[];
+  /** Everything the load could not use, disclosed: unknown kinds, illegal
+   *  sides, missing files, parse errors, dropped externals. */
+  readonly disclosures: readonly string[];
+}
+
+/**
+ * Expand a declared path: an exact repo-relative path, or a single-`*`
+ * glob in the LAST segment (`requests/*.http`). Deliberately no `**` — a
+ * declaration names artifacts, it does not scan the tree.
+ */
+function expandSourcePattern(cwd: string, pattern: string): string[] {
+  const starIdx = pattern.indexOf('*');
+  if (starIdx === -1) return [pattern];
+  const dir = path.posix.dirname(pattern);
+  const base = path.posix.basename(pattern);
+  if (dir.includes('*') || base.indexOf('*') !== base.lastIndexOf('*')) return [];
+  const re = new RegExp(`^${base.split('*').map(escapeRe).join('.*')}$`);
+  try {
+    return fs
+      .readdirSync(path.join(cwd, dir))
+      .filter((f) => re.test(f))
+      .sort()
+      .map((f) => path.posix.join(dir, f));
+  } catch {
+    return [];
+  }
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Load every declared contract artifact into normalized flow shapes. The
+ * consumed side normalizes with the app's `stripUrlPrefixes` (absolute
+ * URLs in captures/collections reduce to route paths); the served side
+ * normalizes bare, exactly as spec routes always have. Consumed calls
+ * carry the reader kind as their receiver; served routes carry it as
+ * `via` — provenance without new fields.
+ */
+export function loadContractSources(
+  cwd: string,
+  sources: readonly FlowSourceDecl[],
+  normalize: NormalizeConfig,
+  registry: readonly ContractSourceReader[] = CONTRACT_SOURCE_READERS,
+): ContractSourceLoad {
+  const calls: ClientCall[] = [];
+  const routes: RouteEndpoint[] = [];
+  const disclosures: string[] = [];
+
+  for (const decl of sources) {
+    const reader = contractSourceReaderFor(decl.kind, registry);
+    if (!reader) {
+      const known = registry.map((r) => `'${r.kind}'`).join(' | ');
+      disclosures.push(`flow.sources: unknown kind '${decl.kind}' — known kinds: ${known}`);
+      continue;
+    }
+    if (decl.side !== undefined && decl.side !== 'consumed' && decl.side !== 'served') {
+      disclosures.push(
+        `flow.sources[${decl.kind}]: side must be 'consumed' or 'served' (got ${JSON.stringify(decl.side)})`,
+      );
+      continue;
+    }
+    const side: ContractSide = decl.side ?? reader.defaultSide;
+    if (reader.sides !== 'both' && side !== reader.sides) {
+      disclosures.push(
+        `flow.sources[${decl.kind}]: a ${reader.displayName} testifies to the '${reader.sides}' side only`,
+      );
+      continue;
+    }
+
+    const files = expandSourcePattern(cwd, decl.path);
+    if (files.length === 0) {
+      disclosures.push(`flow.sources[${decl.kind}]: no file matches '${decl.path}'`);
+      continue;
+    }
+    for (const rel of files) {
+      let content: string;
+      try {
+        content = fs.readFileSync(path.join(cwd, rel), 'utf-8');
+      } catch {
+        disclosures.push(`flow.sources[${decl.kind}]: cannot read '${rel}'`);
+        continue;
+      }
+      const parsed = reader.parse(content, rel);
+      disclosures.push(...parsed.errors);
+
+      let droppedExternal = 0;
+      if (side === 'consumed') {
+        for (const c of parsed.consumed) {
+          const method = normalizeMethod(c.method);
+          if (!method) continue;
+          const p = normalizePath(c.url, normalize);
+          if (p === null) {
+            droppedExternal++;
+            continue;
+          }
+          calls.push({
+            method,
+            rawUrl: c.url,
+            path: p,
+            receiver: reader.kind,
+            file: c.file,
+            line: c.line,
+          });
+        }
+        // A consumed-side declaration may still carry served evidence the
+        // reader chose to emit (a format that inherently has both); the
+        // side declaration gates what we USE.
+      } else {
+        for (const s of [...parsed.served, ...consumedAsServed(parsed.consumed)]) {
+          const method = s.method === ANY_METHOD ? ANY_METHOD : normalizeMethod(s.method);
+          if (!method) continue;
+          const p = normalizePath(s.path);
+          if (p === null) {
+            droppedExternal++;
+            continue;
+          }
+          routes.push({
+            method,
+            path: p,
+            via: reader.kind,
+            handler: s.handler ?? null,
+            file: s.file,
+            line: s.line,
+          });
+        }
+      }
+      if (droppedExternal > 0) {
+        disclosures.push(
+          `flow.sources[${reader.kind}]: ${rel}: ${droppedExternal} entr${droppedExternal === 1 ? 'y' : 'ies'} dropped (external or non-path URL — add the host to flow.stripUrlPrefixes if it is your own)`,
+        );
+      }
+    }
+  }
+  return { calls, routes, disclosures };
+}
+
+/** A request-shaped artifact declared `side: 'served'` reads each request
+ *  as a route the repo serves (a Postman collection documenting your OWN
+ *  API). */
+function consumedAsServed(consumed: readonly RawConsumedCall[]): RawServedRoute[] {
+  return consumed.map((c) => ({ method: c.method, path: c.url, file: c.file, line: c.line }));
+}

--- a/src/analyzers/flow/contract-sources/openapi.ts
+++ b/src/analyzers/flow/contract-sources/openapi.ts
@@ -1,0 +1,51 @@
+/**
+ * OpenAPI as a registry entry — the convergence of `flow.specs` onto the
+ * contract-source registry (one mechanism for every declared artifact).
+ *
+ * The parsing itself stays in `spec-source.ts` (the module `flow.specs`
+ * has always used — Rule 2: one OpenAPI reader); this entry adapts it to
+ * the reader interface so `flow.sources: [{ kind: 'openapi', ... }]` works
+ * identically to the legacy `flow.specs` list, which remains supported
+ * verbatim (it is frozen v1 config contract).
+ */
+
+import type { ContractSourceParse, ContractSourceReader, RawServedRoute } from './index';
+import { routesFromOpenApi } from '../spec-source';
+
+export const openapiReader: ContractSourceReader = {
+  kind: 'openapi',
+  displayName: 'OpenAPI document',
+  sides: 'served',
+  defaultSide: 'served',
+  sniff: (p) => /openapi.*\.json$|swagger.*\.json$/i.test(p),
+  parse(content, filePath): ContractSourceParse {
+    let doc: Parameters<typeof routesFromOpenApi>[0];
+    try {
+      doc = JSON.parse(content) as Parameters<typeof routesFromOpenApi>[0];
+    } catch (e) {
+      return {
+        consumed: [],
+        served: [],
+        errors: [`${filePath}: not valid JSON (${e instanceof Error ? e.message : String(e)})`],
+      };
+    }
+    if (!doc || typeof doc !== 'object' || !('paths' in doc) || !doc.paths) {
+      return {
+        consumed: [],
+        served: [],
+        errors: [`${filePath}: not an OpenAPI document (no paths object)`],
+      };
+    }
+    // routesFromOpenApi normalizes internally (it predates this registry);
+    // re-normalizing an already-normalized path is a no-op, so routing its
+    // output through the central normalization stays correct.
+    const served: RawServedRoute[] = routesFromOpenApi(doc, filePath).map((r) => ({
+      method: r.method,
+      path: r.path,
+      handler: r.handler,
+      file: r.file,
+      line: r.line,
+    }));
+    return { consumed: [], served, errors: [] };
+  },
+};

--- a/src/analyzers/flow/contract-sources/pact.ts
+++ b/src/analyzers/flow/contract-sources/pact.ts
@@ -1,0 +1,55 @@
+/**
+ * Pact contract reader (Pact Specification v2/v3 JSON).
+ *
+ * A pact's `interactions[]` each carry a `request` (`method` + `path`) the
+ * CONSUMER makes against the provider — so a pact always testifies to the
+ * consumed side. In the consumer's repo that is literally its own calls;
+ * in the PROVIDER's repo the same requests are the partner's consumed
+ * calls joining against the provider's served routes — still the consumed
+ * side of the join (the cross-repo flow model). Hence sides: 'consumed'
+ * only; there is no reading of a pact as served evidence (a pact declares
+ * expectations, not implementation).
+ */
+
+import type { ContractSourceParse, ContractSourceReader, RawConsumedCall } from './index';
+
+interface PactInteraction {
+  description?: unknown;
+  request?: { method?: unknown; path?: unknown } | null;
+}
+
+export const pactReader: ContractSourceReader = {
+  kind: 'pact',
+  displayName: 'Pact contract',
+  sides: 'consumed',
+  defaultSide: 'consumed',
+  sniff: (p) => /pacts?\/.*\.json$/.test(p),
+  parse(content, filePath): ContractSourceParse {
+    let doc: { interactions?: unknown };
+    try {
+      doc = JSON.parse(content) as { interactions?: unknown };
+    } catch (e) {
+      return {
+        consumed: [],
+        served: [],
+        errors: [`${filePath}: not valid JSON (${e instanceof Error ? e.message : String(e)})`],
+      };
+    }
+    if (!doc || typeof doc !== 'object' || !Array.isArray(doc.interactions)) {
+      return {
+        consumed: [],
+        served: [],
+        errors: [`${filePath}: not a Pact contract (no interactions[])`],
+      };
+    }
+    const consumed: RawConsumedCall[] = [];
+    for (const i of doc.interactions as PactInteraction[]) {
+      const req = i?.request;
+      if (!req || typeof req !== 'object') continue;
+      const method = typeof req.method === 'string' ? req.method : null;
+      const path = typeof req.path === 'string' ? req.path : null;
+      if (method && path) consumed.push({ method, url: path, file: filePath, line: 0 });
+    }
+    return { consumed, served: [], errors: [] };
+  },
+};

--- a/src/analyzers/flow/contract-sources/postman.ts
+++ b/src/analyzers/flow/contract-sources/postman.ts
@@ -1,0 +1,84 @@
+/**
+ * Postman Collection reader (v2.x JSON export).
+ *
+ * A collection is a tree: `item[]` entries are either folders (their own
+ * `item[]`) or requests (`request.method` + `request.url`). The url may be
+ * the string form or the object form (`{ raw, path[] }`); `raw` wins when
+ * present because it preserves `{{variable}}` segments, which the shared
+ * normalizer's template collapse reduces to `{var}` — a Postman variable
+ * IS a path parameter for join purposes (after `{{host}}`-style heads are
+ * stripped via flow.stripUrlPrefixes or rejected as external).
+ *
+ * Sides: 'both'. The common case is a collection of calls a team MAKES
+ * (consumed, the default); a collection documenting the repo's OWN API is
+ * declared `side: 'served'` and each request reads as a served route.
+ */
+
+import type { ContractSourceParse, ContractSourceReader, RawConsumedCall } from './index';
+
+interface PostmanUrl {
+  raw?: unknown;
+  path?: unknown;
+}
+interface PostmanItem {
+  name?: unknown;
+  item?: unknown;
+  request?: { method?: unknown; url?: unknown } | null;
+}
+
+function urlText(url: unknown): string | null {
+  if (typeof url === 'string' && url.length > 0) return url;
+  if (typeof url === 'object' && url !== null) {
+    const u = url as PostmanUrl;
+    if (typeof u.raw === 'string' && u.raw.length > 0) return u.raw;
+    if (Array.isArray(u.path)) {
+      const segs = u.path.filter((s): s is string => typeof s === 'string');
+      if (segs.length > 0) return `/${segs.join('/')}`;
+    }
+  }
+  return null;
+}
+
+function walkItems(items: unknown, file: string, out: RawConsumedCall[]): void {
+  if (!Array.isArray(items)) return;
+  for (const entry of items as PostmanItem[]) {
+    if (!entry || typeof entry !== 'object') continue;
+    if (entry.item) walkItems(entry.item, file, out);
+    const req = entry.request;
+    if (req && typeof req === 'object') {
+      const method = typeof req.method === 'string' ? req.method : 'GET';
+      const url = urlText(req.url);
+      if (url) out.push({ method, url, file, line: 0 });
+    }
+  }
+}
+
+export const postmanReader: ContractSourceReader = {
+  kind: 'postman',
+  displayName: 'Postman collection',
+  sides: 'both',
+  defaultSide: 'consumed',
+  sniff: (p) => p.endsWith('.postman_collection.json'),
+  parse(content, filePath): ContractSourceParse {
+    let doc: { item?: unknown };
+    try {
+      doc = JSON.parse(content) as { item?: unknown };
+    } catch (e) {
+      return {
+        consumed: [],
+        served: [],
+        errors: [`${filePath}: not valid JSON (${e instanceof Error ? e.message : String(e)})`],
+      };
+    }
+    if (!doc || typeof doc !== 'object' || !Array.isArray(doc.item)) {
+      return {
+        consumed: [],
+        served: [],
+        errors: [`${filePath}: not a Postman collection (no item[] tree)`],
+      };
+    }
+    const consumed: RawConsumedCall[] = [];
+    walkItems(doc.item, filePath, consumed);
+    return { consumed, served: [], errors: [] };
+  },
+};

--- a/src/analyzers/flow/contract.ts
+++ b/src/analyzers/flow/contract.ts
@@ -32,12 +32,15 @@ export const CONSUMED_SNAPSHOT = 'consumed.json';
  *  `test/flow-contract-freeze.test.ts`. */
 export const SERVED_CONSUMED_SCHEMA_VERSION = 1;
 
-/** One served endpoint in the served-side inventory. */
+/** One served endpoint in the served-side inventory. `via` widened for
+ *  declared contract artifacts (registry kinds — 'openapi', 'postman', …):
+ *  WIRE-ADDITIVE on schema v1, since `via` was always a free string on the
+ *  serialized JSON and consumers read it as display provenance only. */
 export interface ServedRoute {
   readonly method: string;
   readonly path: string;
   readonly handler: string | null;
-  readonly via: 'decorator' | 'router-call' | 'file-route' | 'spec';
+  readonly via: 'decorator' | 'router-call' | 'file-route' | 'spec' | (string & {});
 }
 
 /** One binding in the consumed-side inventory — a UI call site's dependency on

--- a/src/analyzers/flow/extract.ts
+++ b/src/analyzers/flow/extract.ts
@@ -66,7 +66,13 @@ export interface RouteEndpoint {
    *  `http.HandleFunc`). See `ANY_METHOD` in `normalize.ts`. */
   readonly method: ServedMethod;
   readonly path: string;
-  readonly via: 'decorator' | 'router-call' | 'file-route' | 'spec';
+  /** The four static-extraction provenances are the closed core; a declared
+   *  contract artifact contributes its registry kind ('openapi', 'postman',
+   *  'pact', 'http', 'har', a synthetic test kind) — the `(string & {})`
+   *  keeps those open (registry-driven) while preserving completion on the
+   *  core literals. Consumers treat `via` as display provenance; the one
+   *  semantic reader is the spec-preference dedup in `model.ts`. */
+  readonly via: 'decorator' | 'router-call' | 'file-route' | 'spec' | (string & {});
   readonly handler: string | null;
   readonly file: string;
   readonly line: number;

--- a/src/analyzers/flow/gather.ts
+++ b/src/analyzers/flow/gather.ts
@@ -18,6 +18,7 @@ import { extractFileFlow, type FileFlow } from './extract';
 import { buildFlowModel, type FlowModel } from './model';
 import { loadOpenApiRoutes } from './spec-source';
 import { readFlowConfig } from './config';
+import { loadContractSources, type FlowSourceDecl } from './contract-sources';
 import type { NormalizeConfig } from './normalize';
 
 export interface GatherFlowOptions {
@@ -38,6 +39,15 @@ export interface GatherFlowOptions {
    * thing on any machine.
    */
   readonly relativeTo?: string;
+  /**
+   * Declared contract artifacts (`flow.sources`) resolved through the
+   * contract-source reader registry, exactly as `specs` resolves OpenAPI.
+   * `sourcesBase` is the directory artifact paths are relative to (the repo
+   * root of the side being gathered — the base-ref worktree on the gate's
+   * base side, so grandfathering reads the artifacts as they were at base).
+   */
+  readonly sources?: readonly FlowSourceDecl[];
+  readonly sourcesBase?: string;
 }
 
 /** Extensions of packs that can contribute flow (httpFlow + a grammar). */
@@ -74,7 +84,22 @@ export async function gatherFlowModel(opts: GatherFlowOptions): Promise<FlowMode
   // Served side = extracted routes UNION spec routes (dedup is implicit: the
   // join indexes routes by (method, path), so a duplicate collapses).
   const specRoutes = (opts.specs ?? []).flatMap((spec) => loadOpenApiRoutes(spec));
-  return buildFlowModel([...fileFlows, { calls: [], routes: specRoutes }]);
+
+  // Declared contract artifacts (rung 2) union in through the reader
+  // registry — both sides, one normalizer, disclosures carried on the model.
+  const sourceLoad =
+    opts.sources && opts.sources.length > 0
+      ? loadContractSources(opts.sourcesBase ?? opts.roots[0] ?? '.', opts.sources, config)
+      : undefined;
+
+  const model = buildFlowModel([
+    ...fileFlows,
+    { calls: [], routes: specRoutes },
+    ...(sourceLoad ? [{ calls: [...sourceLoad.calls], routes: [...sourceLoad.routes] }] : []),
+  ]);
+  return sourceLoad && sourceLoad.disclosures.length > 0
+    ? { ...model, sourceDisclosures: [...sourceLoad.disclosures] }
+    : model;
 }
 
 /**
@@ -98,6 +123,8 @@ export async function gatherRepoFlowModel(
     roots: opts.roots ?? [cwd],
     specs: config.specs.map((s) => resolve(cwd, s)),
     stripUrlPrefixes: config.stripUrlPrefixes,
+    sources: config.sources,
+    sourcesBase: cwd,
     ...(opts.relativeTo !== undefined ? { relativeTo: opts.relativeTo } : {}),
   });
 }

--- a/src/analyzers/flow/land.ts
+++ b/src/analyzers/flow/land.ts
@@ -23,7 +23,7 @@
  * refresh never hard-fails on missing tooling (the workflow's job is the
  * snapshot; the PR is the vehicle).
  */
-import { landRefreshPaths, makeExec, type Exec } from '../../land-refresh';
+import { landRefreshPaths, type Exec } from '../../land-refresh';
 import {
   contractKey,
   FLOW_DIR,

--- a/src/analyzers/flow/land.ts
+++ b/src/analyzers/flow/land.ts
@@ -23,7 +23,7 @@
  * refresh never hard-fails on missing tooling (the workflow's job is the
  * snapshot; the PR is the vehicle).
  */
-import { execFileSync } from 'child_process';
+import { landRefreshPaths, makeExec, type Exec } from '../../land-refresh';
 import {
   contractKey,
   FLOW_DIR,
@@ -112,27 +112,6 @@ export function refreshPrText(delta: ContractDelta): { title: string; body: stri
   return { title, body: parts.join('\n\n') };
 }
 
-interface Exec {
-  (cmd: string, args: string[], opts?: { allowFail?: boolean }): string;
-}
-
-function makeExec(cwd: string): Exec {
-  return (cmd, args, opts = {}) => {
-    try {
-      return execFileSync(cmd, args, {
-        cwd,
-        encoding: 'utf8',
-        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-        timeout: 60_000,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      }).toString();
-    } catch (e) {
-      if (opts.allowFail) return '';
-      throw e;
-    }
-  };
-}
-
 export interface LandOptions {
   readonly cwd: string;
   readonly mode: FlowLandMode;
@@ -148,25 +127,21 @@ export interface LandOptions {
   readonly exec?: Exec;
 }
 
-const BOT = { name: 'dxkit-bot', email: 'dxkit-bot@users.noreply.github.com' };
-
 /**
  * Land the already-published snapshot changes per `mode`. Call AFTER
  * `publishFlow` wrote `.dxkit/flow/`; reads the delta against the caller's
  * pre-publish snapshot. No-op ('clean') when git sees no snapshot change.
+ *
+ * The git/gh mechanics live in the ONE generic lander
+ * (`src/land-refresh.ts`, shared with the extensions refresh — Rule 2);
+ * this function owns only the flow-shaped parts: the served delta, the
+ * substance check (a publish restamps `generatedAt`/`commitSha` on every
+ * run, and metadata churn must never land a commit), and the PR prose.
  */
 export function landFlowRefresh(opts: LandOptions): LandResult {
-  const exec = opts.exec ?? makeExec(opts.cwd);
-  const identity = opts.identity ?? BOT;
   const delta = servedDelta(opts.before, readServedContract(opts.cwd));
+  const { title, body } = refreshPrText(delta);
 
-  const status = exec('git', ['status', '--porcelain', '--', FLOW_DIR]).trim();
-  if (status === '') return { outcome: 'clean', mode: opts.mode, delta };
-
-  // Every publish restamps `generatedAt` (and possibly `commitSha`), so a
-  // byte-diff alone would land a metadata-churn commit on EVERY merge. Land
-  // only on SUBSTANCE: routes, bindings, or participant provenance changed.
-  // A pure-timestamp refresh reverts the files and reports clean.
   const volatile = (c: ServedContract | ConsumedContract | undefined): string => {
     if (!c) return 'absent';
     const rest: Record<string, unknown> = { ...c };
@@ -174,95 +149,28 @@ export function landFlowRefresh(opts: LandOptions): LandResult {
     delete rest.commitSha;
     return JSON.stringify(rest);
   };
-  const substantive =
-    volatile(opts.before) !== volatile(readServedContract(opts.cwd)) ||
-    volatile(opts.beforeConsumed) !== volatile(readConsumedContract(opts.cwd));
-  if (!substantive) {
-    exec('git', ['checkout', '--', FLOW_DIR], { allowFail: true });
-    return { outcome: 'clean', mode: opts.mode, delta };
-  }
 
-  const commit = (message: string): void => {
-    exec('git', ['add', FLOW_DIR]);
-    exec('git', [
-      '-c',
-      `user.name=${identity.name}`,
-      '-c',
-      `user.email=${identity.email}`,
-      'commit',
-      '-m',
-      message,
-    ]);
-  };
+  const result = landRefreshPaths({
+    cwd: opts.cwd,
+    mode: opts.mode,
+    paths: [FLOW_DIR],
+    branchName: FLOW_REFRESH_BRANCH,
+    defaultBranch: opts.defaultBranch,
+    commitTitle: 'chore(flow): refresh contract snapshots',
+    prTitle: title,
+    prBody: body,
+    isSubstantive: () =>
+      volatile(opts.before) !== volatile(readServedContract(opts.cwd)) ||
+      volatile(opts.beforeConsumed) !== volatile(readConsumedContract(opts.cwd)),
+    ...(opts.identity !== undefined ? { identity: opts.identity } : {}),
+    ...(opts.exec !== undefined ? { exec: opts.exec } : {}),
+  });
 
-  if (opts.mode === 'push') {
-    // Zero-ceremony mode: straight to the default branch. `[skip ci]` keeps the
-    // refresh from re-triggering itself; a protected branch rejects the push
-    // loudly (the caller surfaces the error — switch to `pr`).
-    commit('chore(flow): refresh contract snapshots [skip ci]');
-    exec('git', ['push', 'origin', `HEAD:${opts.defaultBranch}`]);
-    return { outcome: 'pushed', mode: 'push', delta };
-  }
-
-  // PR mode: one standing branch, force-updated (never a pile). Created at
-  // HEAD with the snapshot change committed on top. On a LOCAL run, restore
-  // whatever the user had checked out afterwards (CI checkouts are detached /
-  // ephemeral and skip the restore) — landing a refresh must never leave a
-  // human stranded on the bot branch.
-  const priorRef = exec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { allowFail: true }).trim();
-  exec('git', ['checkout', '-B', FLOW_REFRESH_BRANCH]);
-  const { title, body } = refreshPrText(delta);
-  commit(`${title}\n\n[skip ci]`);
-  exec('git', ['push', '--force', 'origin', FLOW_REFRESH_BRANCH]);
-  if (priorRef && priorRef !== 'HEAD' && priorRef !== FLOW_REFRESH_BRANCH) {
-    exec('git', ['checkout', priorRef], { allowFail: true });
-  }
-
-  // The PR itself is best-effort: no gh / not GitHub → the branch still landed.
-  const existing = exec(
-    'gh',
-    ['pr', 'list', '--head', FLOW_REFRESH_BRANCH, '--state', 'open', '--json', 'url'],
-    { allowFail: true },
-  ).trim();
-  let parsed: Array<{ url: string }> = [];
-  try {
-    parsed = existing ? (JSON.parse(existing) as Array<{ url: string }>) : [];
-  } catch {
-    parsed = [];
-  }
-  if (parsed.length > 0) {
-    // Standing PR exists — refresh its face to match the new delta.
-    exec('gh', ['pr', 'edit', FLOW_REFRESH_BRANCH, '--title', title, '--body', body], {
-      allowFail: true,
-    });
-    return { outcome: 'pr-updated', mode: 'pr', delta, prUrl: parsed[0].url };
-  }
-  const created = exec(
-    'gh',
-    [
-      'pr',
-      'create',
-      '--head',
-      FLOW_REFRESH_BRANCH,
-      '--base',
-      opts.defaultBranch,
-      '--title',
-      title,
-      '--body',
-      body,
-    ],
-    { allowFail: true },
-  ).trim();
-  if (created) {
-    const url = created.split('\n').pop() ?? '';
-    return { outcome: 'pr-opened', mode: 'pr', delta, ...(url ? { prUrl: url } : {}) };
-  }
   return {
-    outcome: 'branch-pushed-no-pr',
-    mode: 'pr',
+    outcome: result.outcome,
+    mode: opts.mode,
     delta,
-    note:
-      `Pushed '${FLOW_REFRESH_BRANCH}' but could not open the PR (no gh CLI / not GitHub / ` +
-      `no permission). Open it manually: ${FLOW_REFRESH_BRANCH} → ${opts.defaultBranch}.`,
+    ...(result.prUrl !== undefined ? { prUrl: result.prUrl } : {}),
+    ...(result.note !== undefined ? { note: result.note } : {}),
   };
 }

--- a/src/analyzers/flow/model.ts
+++ b/src/analyzers/flow/model.ts
@@ -42,7 +42,13 @@ import {
  *   - `external`         — the URL is an external/absolute address we don't
  *                          serve (path is null), so it is not an internal binding.
  */
-export type BindingReason = 'exact' | 'catch-all' | 'placeholder-only' | 'no-route' | 'external';
+export type BindingReason =
+  | 'exact'
+  | 'var-match'
+  | 'catch-all'
+  | 'placeholder-only'
+  | 'no-route'
+  | 'external';
 
 /** One client call resolved (or not) against the served routes. */
 export interface FlowBinding {
@@ -60,6 +66,11 @@ export interface FlowModel {
   /** Recognized client call sites whose URL is dynamic — seen but not
    *  verifiable (the coverage-honesty channel; see extract.ts). */
   readonly dynamicCalls: readonly DynamicCallSite[];
+  /** Disclosures from declared contract artifacts (`flow.sources`): unknown
+   *  kinds, unreadable/unparseable files, dropped external URLs. Absent when
+   *  no sources are declared or every declaration loaded cleanly — the
+   *  fail-open channel, surfaced by the map and doctor, never fatal. */
+  readonly sourceDisclosures?: readonly string[];
 }
 
 /** A path made up entirely of `{var}` segments carries no static signal. One
@@ -108,9 +119,38 @@ export function catchAllPrefixCovers(prefix: string, callPath: string): boolean 
  * of them. Built from the SAME served key set `servedKeySet` produces, so the
  * gate inherits the join's catch-all awareness without re-deriving routes.
  */
+/**
+ * Does a `{var}`-bearing route path cover a CONCRETE call path, segment-wise?
+ * `/articles/{var}` covers `/articles/1` (a route param matches any one
+ * segment); literals must match exactly, and a call's own `{var}` segment
+ * only matches a route `{var}` (an unknown segment never satisfies a literal
+ * claim). This is what lets artifact-declared calls — pact interactions, HAR
+ * captures, .http examples, which always carry concrete example paths — bind
+ * against parameterized routes; source-extracted calls rarely need it (their
+ * dynamic segments already normalize to `{var}`, aligning on the exact key).
+ * One predicate, shared by the join AND the gate matcher (Rule 2 parity).
+ */
+export function varRouteCovers(routePath: string, callPath: string): boolean {
+  if (!routePath.includes('{var}')) return false;
+  const rs = routePath.split('/');
+  const cs = callPath.split('/');
+  if (rs.length !== cs.length) return false;
+  for (let i = 0; i < rs.length; i++) {
+    if (rs[i] === '{var}') {
+      if (cs[i].length === 0) return false;
+      continue;
+    }
+    if (rs[i] !== cs[i]) return false;
+  }
+  return true;
+}
+
 export interface ServedMatcher {
   readonly exact: ReadonlySet<string>;
   readonly catchAllPrefixesByMethod: ReadonlyMap<string, readonly string[]>;
+  /** Non-catch-all served paths containing `{var}`, by method — the
+   *  segment-match candidates for concrete (artifact-borne) call paths. */
+  readonly varPathsByMethod: ReadonlyMap<string, readonly string[]>;
 }
 
 /**
@@ -121,6 +161,7 @@ export interface ServedMatcher {
 export function buildServedMatcher(servedKeys: Iterable<string>): ServedMatcher {
   const exact = new Set<string>();
   const catchAll = new Map<string, string[]>();
+  const varPaths = new Map<string, string[]>();
   for (const key of servedKeys) {
     exact.add(key);
     const sp = key.indexOf(' ');
@@ -131,9 +172,13 @@ export function buildServedMatcher(servedKeys: Iterable<string>): ServedMatcher 
       const list = catchAll.get(method) ?? [];
       list.push(catchAllStaticPrefix(routePath));
       catchAll.set(method, list);
+    } else if (routePath.includes('{var}')) {
+      const list = varPaths.get(method) ?? [];
+      list.push(routePath);
+      varPaths.set(method, list);
     }
   }
-  return { exact, catchAllPrefixesByMethod: catchAll };
+  return { exact, catchAllPrefixesByMethod: catchAll, varPathsByMethod: varPaths };
 }
 
 /**
@@ -151,6 +196,11 @@ export function servedMatch(method: string, callPath: string, m: ServedMatcher):
   if (m.exact.has(`${method} ${callPath}`)) return true;
   if (m.exact.has(`${ANY_METHOD} ${callPath}`)) return true;
   if (isPlaceholderOnlyPath(callPath)) return false;
+  const varPaths = [
+    ...(m.varPathsByMethod.get(method) ?? []),
+    ...(m.varPathsByMethod.get(ANY_METHOD) ?? []),
+  ];
+  if (varPaths.some((p) => varRouteCovers(p, callPath))) return true;
   const prefixes = [
     ...(m.catchAllPrefixesByMethod.get(method) ?? []),
     ...(m.catchAllPrefixesByMethod.get(ANY_METHOD) ?? []),
@@ -172,12 +222,17 @@ export function joinFlow(
   // for its method — a splat route (`/api/{*}` from `[...slug]`, Express `/*`,
   // Spring `/**`) genuinely serves every path under its prefix.
   const catchAllsByMethod = new Map<HttpMethodKey, { route: RouteEndpoint; prefix: string }[]>();
+  const varRoutesByMethod = new Map<HttpMethodKey, RouteEndpoint[]>();
   for (const r of routes) {
     routeIndex.set(`${r.method} ${r.path}`, r);
     if (isCatchAllPath(r.path)) {
       const list = catchAllsByMethod.get(r.method) ?? [];
       list.push({ route: r, prefix: catchAllStaticPrefix(r.path) });
       catchAllsByMethod.set(r.method, list);
+    } else if (r.path.includes('{var}')) {
+      const list = varRoutesByMethod.get(r.method) ?? [];
+      list.push(r);
+      varRoutesByMethod.set(r.method, list);
     }
   }
 
@@ -196,6 +251,11 @@ export function joinFlow(
       }
       return { call, route, confidence: 1, reason: 'exact' };
     }
+    const varRoute = bestVarMatch(call.path, [
+      ...(varRoutesByMethod.get(call.method) ?? []),
+      ...(varRoutesByMethod.get(ANY_METHOD) ?? []),
+    ]);
+    if (varRoute) return { call, route: varRoute, confidence: 0.9, reason: 'var-match' };
     const catchAll = bestCatchAllMatch(call.path, [
       ...(catchAllsByMethod.get(call.method) ?? []),
       ...(catchAllsByMethod.get(ANY_METHOD) ?? []),
@@ -203,6 +263,20 @@ export function joinFlow(
     if (catchAll) return { call, route: catchAll, confidence: 0.7, reason: 'catch-all' };
     return { call, route: null, confidence: 0, reason: 'no-route' };
   });
+}
+
+/** The most-specific `{var}` route covering a concrete call path — most
+ *  literal segments wins (`/a/b/{var}` beats `/a/{var}/{var}`); ties break on
+ *  declaration order. Not applied to an all-placeholder call (no signal). */
+function bestVarMatch(callPath: string, candidates: RouteEndpoint[]): RouteEndpoint | null {
+  if (candidates.length === 0 || isPlaceholderOnlyPath(callPath)) return null;
+  let best: { route: RouteEndpoint; literals: number } | null = null;
+  for (const r of candidates) {
+    if (!varRouteCovers(r.path, callPath)) continue;
+    const literals = r.path.split('/').filter((seg) => seg.length > 0 && seg !== '{var}').length;
+    if (!best || literals > best.literals) best = { route: r, literals };
+  }
+  return best?.route ?? null;
 }
 
 /** The most-specific catch-all route whose static prefix covers `callPath`

--- a/src/analyzers/tools/bounded-exec.ts
+++ b/src/analyzers/tools/bounded-exec.ts
@@ -30,6 +30,18 @@ import { commandExists } from './runner';
 export interface RunnableCommand {
   readonly bin: string;
   readonly args: readonly string[];
+  /**
+   * Text piped to the child's stdin (the extension runner's config
+   * payload). Absent → stdin is ignored, exactly as before this field
+   * existed; the correctness floor and custom-check callers never set it.
+   */
+  readonly stdin?: string;
+  /**
+   * Capture the child's FULL stdout instead of the readable tail. The
+   * extension runner needs the whole emitted wire document; gate-message
+   * callers keep the tail default so block output stays a screenful.
+   */
+  readonly captureFullOutput?: boolean;
 }
 
 /**
@@ -79,10 +91,12 @@ export function makeCommandExec(timeoutMs?: number): CommandExec {
       const out = execFileSync(cmd.bin, [...cmd.args], {
         cwd,
         encoding: 'utf-8',
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: [cmd.stdin !== undefined ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+        ...(cmd.stdin !== undefined ? { input: cmd.stdin } : {}),
+        ...(cmd.captureFullOutput ? { maxBuffer: 64 * 1024 * 1024 } : {}),
         ...(timeoutMs && timeoutMs > 0 ? { timeout: timeoutMs, killSignal: 'SIGTERM' } : {}),
       });
-      return { available: true, code: 0, output: tail(out) };
+      return { available: true, code: 0, output: cmd.captureFullOutput ? out : tail(out) };
     } catch (e) {
       const err = e as {
         status?: number;

--- a/src/baseline/flow-gate-check.ts
+++ b/src/baseline/flow-gate-check.ts
@@ -178,7 +178,12 @@ export async function evaluateFlowGateForGuardrail(opts: {
     const changed = computeChangedFiles(cwd, ref) ?? undefined;
     if (
       changed &&
-      !changedFilesTouchFlowSurface(changed, detectActiveLanguages(cwd), config.specs)
+      !changedFilesTouchFlowSurface(
+        changed,
+        detectActiveLanguages(cwd),
+        config.specs,
+        config.sources.map((src) => src.path),
+      )
     ) {
       return skip(gateMode, 'no-flow-surface-change');
     }
@@ -189,6 +194,8 @@ export async function evaluateFlowGateForGuardrail(opts: {
       roots: [cwd],
       specs: config.specs.map((s) => path.resolve(cwd, s)),
       stripUrlPrefixes: config.stripUrlPrefixes,
+      sources: config.sources,
+      sourcesBase: cwd,
       // Repo-relative locators so a binding's identity is the same whether it
       // was gathered here or from the base worktree below (Rule 9).
       relativeTo: cwd,
@@ -205,6 +212,10 @@ export async function evaluateFlowGateForGuardrail(opts: {
         roots: [wt],
         specs: config.specs.map((s) => path.resolve(wt, s)),
         stripUrlPrefixes: config.stripUrlPrefixes,
+        // Artifacts as they were AT BASE (the worktree), so a call a pact
+        // declared before this PR is grandfathered, not net-new.
+        sources: config.sources,
+        sourcesBase: wt,
         relativeTo: wt, // same repo-relative locators as the HEAD side
       });
       const baseServed = servedKeySet(buildServedContract(baseModel, GATE_META));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,7 @@ import {
   installCiFlowRefresh,
   reportsRefreshEnabled,
   flowRefreshEnabled,
+  extensionsRefreshEnabled,
   installPrReview,
   installIgnoreFiles,
   installHooksPostinstall,
@@ -382,6 +383,10 @@ export async function run(argv: string[]): Promise<void> {
       'with-graph-refresh': { type: 'boolean', default: false },
       'with-reports-refresh': { type: 'boolean', default: false },
       'with-flow-refresh': { type: 'boolean', default: false },
+      'with-extensions-refresh': { type: 'boolean', default: false },
+      // extensions init: the run command line + optional Python starter
+      command: { type: 'string' },
+      stub: { type: 'boolean', default: false },
       'with-pr-review': { type: 'boolean', default: false },
       // loop pack: register the Stop-gate hook + CLAUDE.md loop norm
       'claude-loop': { type: 'boolean', default: false },
@@ -789,6 +794,7 @@ export async function run(argv: string[]): Promise<void> {
         // Flow-refresh: same stamp discipline (flag or flow.onMergeRefresh),
         // so update refreshes the workflow and uninstall removes it.
         withFlowRefresh: !!values['with-flow-refresh'] || flowRefreshEnabled(cwd),
+        withExtensionsRefresh: !!values['with-extensions-refresh'] || extensionsRefreshEnabled(cwd),
       });
 
       console.log('');
@@ -852,6 +858,22 @@ export async function run(argv: string[]): Promise<void> {
       const sub = positionals[1] === 'run' ? 'run' : 'list';
       const target = resolveRepoPath(isSub ? positionals[2] : positionals[1]);
       runChecks(target, sub, { json: !!values.json });
+      break;
+    }
+
+    case 'extensions': {
+      const { runExtensionsCli } = await import('./extensions-cli');
+      const subs = ['list', 'refresh', 'dev', 'init'];
+      const isSub = subs.includes(positionals[1] ?? '');
+      const sub = (isSub ? positionals[1] : 'list') as 'list' | 'refresh' | 'dev' | 'init';
+      const extTarget = isSub ? positionals[2] : undefined;
+      process.exitCode = runExtensionsCli(cwd, sub, extTarget, {
+        json: !!values.json,
+        kind: values.kind as string | undefined,
+        command: values.command as string | undefined,
+        stub: !!values.stub,
+        land: values.land as string | undefined,
+      });
       break;
     }
 

--- a/src/discovery/advisor.ts
+++ b/src/discovery/advisor.ts
@@ -9,6 +9,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { resolveBaselineMode } from '../baseline/modes';
+import { execFileSync } from 'child_process';
+import { CONTRACT_SOURCE_READERS } from '../analyzers/flow/contract-sources';
 import { FLOW_CONFIG_SCHEMA_VERSION } from '../analyzers/flow/config';
 import { SCHEMA_CONFIG_SCHEMA_VERSION } from '../analyzers/model-schema/config';
 import { isClaudeLoopInstalled } from '../loop/scaffold';
@@ -292,6 +294,76 @@ export function planSchemaMode(ctx: ConfigContext): ConfigPlanItem | null {
     patch: { schema: { mode: 'warn', schemaVersion: SCHEMA_CONFIG_SCHEMA_VERSION } },
     reason: 'seed the model-schema drift gate at the safe default (warn, never fails a build)',
     evidence: 'data-model framework in a dependency manifest, no schema config yet',
+  };
+}
+
+/**
+ * One signal for the declared-artifact capability, shared by the doctor probe
+ * (`recommendExtensions`) and the planner (`planFlowSources`) so they never
+ * diverge (Rule 2). Kinds and filename signals are REGISTRY-DERIVED (each
+ * reader's `sniff`) — no format literal lives here, so a new reader extends
+ * this probe automatically. Conservative: silent the moment ANY
+ * `flow.sources` entry exists (a configured repo is never re-nagged), scans
+ * the git-tracked list only (bounded), openapi excluded (`flow.specs` and
+ * the flow planner own specs).
+ */
+function undeclaredContractArtifacts(cwd: string): Array<{ kind: string; path: string }> {
+  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json')) ?? {};
+  const flow = policy.flow as Record<string, unknown> | undefined;
+  const sources = flow?.sources;
+  if (Array.isArray(sources) && sources.length > 0) return [];
+  let files: string[];
+  try {
+    files = execFileSync('git', ['ls-files'], { cwd, encoding: 'utf8', timeout: 10_000 })
+      .split('\n')
+      .slice(0, 20_000);
+  } catch {
+    return [];
+  }
+  const readers = CONTRACT_SOURCE_READERS.filter((r) => r.kind !== 'openapi');
+  const out: Array<{ kind: string; path: string }> = [];
+  for (const f of files) {
+    if (out.length >= 10) break;
+    const reader = readers.find((r) => r.sniff(f));
+    if (reader) out.push({ kind: reader.kind, path: f });
+  }
+  return out;
+}
+
+/** Recommend declaring contract artifacts the repo already has (a Postman
+ *  collection, a pact, a HAR capture, .http files) — zero-code flow evidence. */
+export function recommendExtensions(ctx: RecommendContext): Recommendation | null {
+  const found = undeclaredContractArtifacts(ctx.cwd);
+  if (found.length === 0) return null;
+  const sample = found
+    .slice(0, 3)
+    .map((a) => `${a.path} (${a.kind})`)
+    .join(', ');
+  return {
+    reason:
+      `found contract artifact(s) not declared to dxkit — ${sample} — declaring them in ` +
+      'flow.sources joins them to the integration map + gate with zero code',
+    command: 'vyuh-dxkit extensions',
+  };
+}
+
+/**
+ * Declared artifacts: propose `flow.sources` entries for the contract
+ * artifacts the repo already has. Deterministic from the git-tracked file
+ * list + the reader registry's own filename signals; the user confirms the
+ * plan before anything is written. Reuses `undeclaredContractArtifacts`
+ * (shared with the doctor probe, Rule 2).
+ */
+export function planFlowSources(ctx: ConfigContext): ConfigPlanItem | null {
+  const found = undeclaredContractArtifacts(ctx.cwd);
+  if (found.length === 0) return null;
+  return {
+    capability: 'extensions',
+    section: 'flow.sources',
+    summary: `${found.length} artifact(s) declared`,
+    patch: { flow: { sources: found } },
+    reason: 'join the contract artifacts this repo already has to the flow map + gate (zero code)',
+    evidence: found.map((a) => `${a.path} (${a.kind})`).join(', '),
   };
 }
 

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -16,6 +16,8 @@ import {
   planSchemaMode,
   planLintGate,
   planLoopPreset,
+  recommendExtensions,
+  planFlowSources,
 } from './advisor';
 
 /**
@@ -304,6 +306,22 @@ export const COMMANDS = [
     skill: 'dxkit-checks',
     whenToRecommend: recommendChecks,
     planConfig: planLintGate,
+  },
+
+  {
+    id: 'extensions',
+    audience: 'user',
+    group: 'gate',
+    summary: 'Plug your own extractors and sinks into dxkit (any language)',
+    docsBlurb:
+      'Declare an extension — a manifest pointing at your existing script — and dxkit runs it at ' +
+      'refresh time, validates its emitted contract/inventory/findings/export document, and routes ' +
+      'it through the same machines native output gets (the flow join, the report trend, the ' +
+      'net-new finding gate). `extensions dev <name>` is the seconds-fast authoring loop; ' +
+      '`extensions init` scaffolds a manifest that passes validation immediately.',
+    skill: 'dxkit-extensions',
+    whenToRecommend: recommendExtensions,
+    planConfig: planFlowSources,
   },
 
   // ── Integrate ──────────────────────────────────────────────────────────

--- a/src/explore/types.ts
+++ b/src/explore/types.ts
@@ -103,7 +103,7 @@ export interface HttpEndpointNode {
   readonly label: string;
   readonly method: string;
   readonly path: string;
-  readonly via: 'decorator' | 'router-call' | 'file-route' | 'spec';
+  readonly via: 'decorator' | 'router-call' | 'file-route' | 'spec' | (string & {});
   readonly handler: string | null;
   readonly sourceFile: string;
   readonly line?: number;

--- a/src/extensions-cli.ts
+++ b/src/extensions-cli.ts
@@ -1,0 +1,386 @@
+/**
+ * `vyuh-dxkit extensions [list|refresh|dev|init]` — the user surface of the
+ * extension orchestrator (CLAUDE.md Rule 16).
+ *
+ *   - `list` (default): every committed extension with its kind, gating,
+ *     refresh mode, and snapshot health (ok + age / missing / invalid) —
+ *     plus manifest validation errors, so a silently-broken extension is
+ *     visible in one command.
+ *   - `refresh [name]`: EXECUTE extensions (all, or one by name) and write
+ *     their committed snapshots. This is the trusted-context surface the
+ *     on-merge workflow runs; export sinks receive the latest published
+ *     report-history entry as their delivery document when one exists.
+ *   - `dev <name>`: the authoring loop — run ONE extension, show the
+ *     field-precise validation verdict and a summary of what landed,
+ *     without requiring a full scan. Iteration in seconds; the errors are
+ *     the docs.
+ *   - `init <name> --kind <kind> --command "<cmd>" [--stub]`: scaffold a
+ *     manifest (and optionally a Python starter that reads the stdin
+ *     payload and emits a minimal valid document) that passes validation
+ *     immediately.
+ *
+ * SECURITY: `refresh` and `dev` execute the repo's OWN committed manifests
+ * — the Rule 17 trust boundary. Nothing here accepts a command from a CLI
+ * flag; `init` writes a manifest for review + commit, it does not run it.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as logger from './logger';
+import { discoverExtensions, EXTENSIONS_DIR, type LoadedExtension } from './extensions/manifest';
+import { runExtension, type ExtensionRunOutcome } from './extensions/run';
+import { readExtensionSnapshot } from './extensions/snapshot';
+import { CONTRIBUTION_KINDS } from './extensions/contributions';
+import { loadExclusions } from './analyzers/tools/exclusions';
+import { detectActiveLanguages } from './languages';
+import { landRefreshPaths, type LandMode } from './land-refresh';
+import { detectDefaultBranch } from './ship-installers';
+import type { WireContractDoc, WireFindingsDoc, WireInventoryDoc } from '@vyuhlabs/dxkit-sdk';
+
+export type ExtensionsSubcommand = 'list' | 'refresh' | 'dev' | 'init';
+
+export interface ExtensionsOptions {
+  readonly json?: boolean;
+  /** refresh: land the snapshot changes ('pr' = standing PR, 'push' = direct
+   *  [skip ci] commit). Omitted → refresh writes the working tree only. */
+  readonly land?: string;
+  /** init: contribution kind. */
+  readonly kind?: string;
+  /** init: the run command line (first token = interpreter, rest = args). */
+  readonly command?: string;
+  /** init: also write a Python starter script that passes validation. */
+  readonly stub?: boolean;
+}
+
+/** Repo facts every run receives — the canonical sources, resolved once. */
+function repoFacts(cwd: string): { excludeDirs: string[]; activeLanguages: string[] } {
+  return {
+    excludeDirs: loadExclusions(cwd).dirs,
+    activeLanguages: detectActiveLanguages(cwd).map((l) => l.id),
+  };
+}
+
+/** The delivery document for export sinks: the newest committed report-history
+ *  entry when the repo publishes report snapshots; undefined otherwise (the
+ *  sink is then skipped with a disclosed reason — nothing to deliver yet). */
+function latestDelivery(cwd: string): unknown {
+  try {
+    const dir = path.join(cwd, '.dxkit', 'reports');
+    const newest = fs
+      .readdirSync(dir)
+      .filter((f) => /^health-audit-.*\.json$/.test(f))
+      .sort()
+      .pop();
+    if (!newest) return undefined;
+    return JSON.parse(fs.readFileSync(path.join(dir, newest), 'utf8')) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function describeSnapshot(cwd: string, ext: LoadedExtension): string {
+  const snap = readExtensionSnapshot(cwd, ext);
+  if (snap.status === 'missing') return 'snapshot: missing (run `extensions refresh`)';
+  if (snap.status === 'invalid') return `snapshot: INVALID (${snap.errors.length} error(s))`;
+  const age =
+    snap.ageDays === undefined ? '' : snap.ageDays === 0 ? ' · today' : ` · ${snap.ageDays}d old`;
+  return `snapshot: ok (${snap.schemaId}${age})`;
+}
+
+function summarizeDoc(
+  ext: LoadedExtension,
+  outcome: ExtensionRunOutcome & { status: 'ok' },
+): string[] {
+  const lines: string[] = [];
+  switch (ext.manifest.contributes) {
+    case 'contract': {
+      const doc = outcome.doc as WireContractDoc;
+      lines.push(
+        `  consumed: ${doc.consumed?.length ?? 0} · served: ${doc.served?.length ?? 0} · dynamic: ${doc.dynamicCalls?.length ?? 0}`,
+      );
+      break;
+    }
+    case 'inventory': {
+      const doc = outcome.doc as WireInventoryDoc;
+      const byKind = new Map<string, number>();
+      for (const e of doc.entities) byKind.set(e.kind, (byKind.get(e.kind) ?? 0) + 1);
+      const parts = [...byKind.entries()].map(([k, n]) => `${k} ${n}`);
+      lines.push(
+        `  entities: ${doc.entities.length}${parts.length ? ` (${parts.join(' · ')})` : ''}`,
+      );
+      break;
+    }
+    case 'findings': {
+      const doc = outcome.doc as WireFindingsDoc;
+      const bySev = new Map<string, number>();
+      for (const f of doc.findings) bySev.set(f.severity, (bySev.get(f.severity) ?? 0) + 1);
+      const parts = [...bySev.entries()].map(([s, n]) => `${s} ${n}`);
+      lines.push(
+        `  findings: ${doc.findings.length}${parts.length ? ` (${parts.join(' · ')})` : ''}`,
+      );
+      break;
+    }
+    case 'export':
+      lines.push('  receipt written');
+      break;
+  }
+  lines.push(`  snapshot: ${outcome.outputPath}`);
+  return lines;
+}
+
+function runOne(cwd: string, ext: LoadedExtension): ExtensionRunOutcome {
+  const facts = repoFacts(cwd);
+  const delivery = ext.manifest.contributes === 'export' ? latestDelivery(cwd) : undefined;
+  if (ext.manifest.contributes === 'export' && delivery === undefined) {
+    return {
+      status: 'skipped',
+      reason: 'nothing to deliver yet (run `vyuh-dxkit health` to produce a report first)',
+    };
+  }
+  return runExtension(cwd, ext, {
+    excludeDirs: facts.excludeDirs,
+    activeLanguages: facts.activeLanguages,
+    ...(delivery !== undefined ? { delivery } : {}),
+  });
+}
+
+function reportOutcome(name: string, outcome: ExtensionRunOutcome): boolean {
+  if (outcome.status === 'ok') {
+    logger.success(`  ${name}: ok`);
+    return true;
+  }
+  if (outcome.status === 'skipped') {
+    logger.warn(`  ${name}: skipped — ${outcome.reason}`);
+    return true; // fail-open: a skip is disclosed, not a failure
+  }
+  logger.fail(`  ${name}: invalid`);
+  for (const e of outcome.errors) logger.info(`    ${e}`);
+  return false;
+}
+
+export function runExtensionsCli(
+  cwd: string,
+  sub: ExtensionsSubcommand,
+  target: string | undefined,
+  opts: ExtensionsOptions = {},
+): number {
+  const { extensions, errors } = discoverExtensions(cwd);
+
+  switch (sub) {
+    case 'list': {
+      if (opts.json) {
+        const payload = extensions.map((ext) => ({
+          name: ext.manifest.name,
+          contributes: ext.manifest.contributes,
+          refresh: ext.manifest.refresh,
+          ...(ext.manifest.gating ? { gating: ext.manifest.gating } : {}),
+          output: ext.manifest.output,
+          snapshot: readExtensionSnapshot(cwd, ext),
+        }));
+        process.stdout.write(JSON.stringify({ extensions: payload, errors }) + '\n');
+        return errors.length > 0 ? 1 : 0;
+      }
+      logger.header('vyuh-dxkit extensions');
+      if (extensions.length === 0 && errors.length === 0) {
+        logger.info(`  No extensions declared under ${EXTENSIONS_DIR}/.`);
+        logger.info(
+          '  Scaffold one: vyuh-dxkit extensions init <name> --kind <kind> --command "<cmd>"',
+        );
+        return 0;
+      }
+      for (const ext of extensions) {
+        const gating =
+          ext.manifest.contributes === 'findings'
+            ? ` · gating: ${ext.manifest.gating ?? 'warn'}`
+            : '';
+        logger.info(
+          `  ${logger.bold(ext.manifest.name)}  (${ext.manifest.contributes} · ${ext.manifest.refresh}${gating})`,
+        );
+        logger.info(`    ${describeSnapshot(cwd, ext)}`);
+      }
+      for (const e of errors) logger.fail(`  ${e}`);
+      return errors.length > 0 ? 1 : 0;
+    }
+
+    case 'refresh': {
+      const chosen = target ? extensions.filter((e) => e.manifest.name === target) : extensions;
+      if (target && chosen.length === 0) {
+        logger.fail(`No extension named '${target}' under ${EXTENSIONS_DIR}/.`);
+        return 1;
+      }
+      logger.header('vyuh-dxkit extensions refresh');
+      for (const e of errors) logger.fail(`  ${e}`);
+      if (chosen.length === 0) {
+        logger.info('  Nothing to refresh.');
+        return errors.length > 0 ? 1 : 0;
+      }
+      // Capture pre-refresh snapshot bytes so landing can ignore pure
+      // generatedAt restamps (every run restamps; metadata churn must not
+      // land a commit on every merge — the flow-refresh substance rule).
+      const landable = chosen.filter((e) => e.manifest.contributes !== 'export');
+      const before = new Map<string, string | null>(
+        landable.map((e) => {
+          try {
+            return [e.manifest.output, fs.readFileSync(path.join(cwd, e.manifest.output), 'utf8')];
+          } catch {
+            return [e.manifest.output, null];
+          }
+        }),
+      );
+      let ok = true;
+      const refreshedNames: string[] = [];
+      for (const ext of chosen) {
+        const r = runOne(cwd, ext);
+        if (r.status === 'ok') refreshedNames.push(ext.manifest.name);
+        ok = reportOutcome(ext.manifest.name, r) && ok;
+      }
+      if (opts.land === 'pr' || opts.land === 'push') {
+        const result = landRefreshPaths({
+          cwd,
+          mode: opts.land as LandMode,
+          paths: landable.map((e) => e.manifest.output),
+          branchName: 'dxkit/extensions-refresh',
+          defaultBranch: detectDefaultBranch(cwd),
+          commitTitle: 'chore(extensions): refresh committed snapshots',
+          prTitle: `chore(extensions): snapshot refresh (${refreshedNames.join(', ') || 'no-op'})`,
+          prBody:
+            'Automated extension-snapshot refresh. Gates read these committed ' +
+            'snapshots offline; merging keeps their verdicts current.\n\n' +
+            refreshedNames.map((n) => `- \`${n}\``).join('\n'),
+          isSubstantive: () =>
+            landable.some((e) => {
+              const prev = before.get(e.manifest.output) ?? null;
+              let cur: string | null = null;
+              try {
+                cur = fs.readFileSync(path.join(cwd, e.manifest.output), 'utf8');
+              } catch {
+                cur = null;
+              }
+              const strip = (t: string | null): string => {
+                if (t === null) return 'absent';
+                try {
+                  const o = JSON.parse(t) as Record<string, unknown>;
+                  delete o['generatedAt'];
+                  return JSON.stringify(o);
+                } catch {
+                  return t;
+                }
+              };
+              return strip(prev) !== strip(cur);
+            }),
+        });
+        if (result.outcome === 'clean') logger.info('  land: no substantive snapshot change');
+        else logger.success(`  land: ${result.outcome}${result.prUrl ? ` — ${result.prUrl}` : ''}`);
+        if (result.note) logger.warn(`  ${result.note}`);
+      } else if (opts.land !== undefined) {
+        logger.fail(`--land must be 'pr' or 'push' (got '${opts.land}')`);
+        return 1;
+      }
+      return ok && errors.length === 0 ? 0 : 1;
+    }
+
+    case 'dev': {
+      if (!target) {
+        logger.fail('Usage: vyuh-dxkit extensions dev <name>');
+        return 1;
+      }
+      const ext = extensions.find((e) => e.manifest.name === target);
+      if (!ext) {
+        logger.fail(`No extension named '${target}' under ${EXTENSIONS_DIR}/.`);
+        for (const e of errors.filter((x) => x.includes(target))) logger.info(`  ${e}`);
+        return 1;
+      }
+      logger.header(`vyuh-dxkit extensions dev — ${target}`);
+      const outcome = runOne(cwd, ext);
+      if (outcome.status === 'ok') {
+        logger.success('  emit is VALID');
+        for (const line of summarizeDoc(ext, outcome)) logger.info(line);
+        return 0;
+      }
+      if (outcome.status === 'skipped') {
+        logger.warn(`  skipped — ${outcome.reason}`);
+        return 1;
+      }
+      logger.fail('  emit is INVALID — fix the fields below and re-run:');
+      for (const e of outcome.errors) logger.info(`    ${e}`);
+      return 1;
+    }
+
+    case 'init': {
+      if (!target) {
+        logger.fail('Usage: vyuh-dxkit extensions init <name> --kind <kind> --command "<cmd>"');
+        return 1;
+      }
+      return initExtension(cwd, target, opts);
+    }
+  }
+}
+
+// ── init scaffold ───────────────────────────────────────────────────────────
+
+const PY_STUB = `#!/usr/bin/env python3
+"""dxkit extension starter: reads the stdin payload, emits a minimal valid
+document. Replace the emit with your real extraction — the payload carries
+your committed config block plus repo facts (exclude dirs, active languages).
+Iterate with: vyuh-dxkit extensions dev <name>
+"""
+import json
+import sys
+
+payload = json.load(sys.stdin)
+kind = payload["extension"]["contributes"]
+
+doc = {
+    "contract": {"schema": "contract.v1", "consumed": []},
+    "inventory": {"schema": "inventory.v1", "entities": []},
+    "findings": {"schema": "findings.v1", "findings": []},
+    "export": {"schema": "export.v1", "delivered": False, "detail": "stub"},
+}[kind]
+
+json.dump(doc, sys.stdout)
+`;
+
+function initExtension(cwd: string, name: string, opts: ExtensionsOptions): number {
+  const kinds = CONTRIBUTION_KINDS.map((d) => d.kind);
+  if (!opts.kind || !kinds.includes(opts.kind as (typeof kinds)[number])) {
+    logger.fail(`--kind must be one of ${kinds.map((k) => `'${k}'`).join(' | ')}.`);
+    return 1;
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+    logger.fail('Extension names are lowercase kebab-case.');
+    return 1;
+  }
+  const dir = path.join(cwd, EXTENSIONS_DIR, name);
+  const manifestPath = path.join(dir, 'extension.json');
+  if (fs.existsSync(manifestPath)) {
+    logger.fail(`${EXTENSIONS_DIR}/${name}/extension.json already exists.`);
+    return 1;
+  }
+  const kindDef = CONTRIBUTION_KINDS.find((d) => d.kind === opts.kind)!;
+  const stubRel = `${EXTENSIONS_DIR}/${name}/run.py`;
+  const commandLine = opts.command ?? (opts.stub ? `python3 ${stubRel}` : undefined);
+  if (!commandLine) {
+    logger.fail('Pass --command "<cmd>" (your existing script) or --stub for a Python starter.');
+    return 1;
+  }
+  const [bin, ...args] = commandLine.split(/\s+/);
+  const manifest = {
+    schemaVersion: 1,
+    name,
+    contributes: opts.kind,
+    run: { command: bin, args, timeoutSeconds: 300 },
+    refresh: 'on-merge',
+    output: kindDef.snapshotPathFor(name),
+    ...(opts.kind === 'findings' ? { gating: 'warn' } : {}),
+  };
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  if (opts.stub) fs.writeFileSync(path.join(cwd, stubRel), PY_STUB);
+  logger.header('vyuh-dxkit extensions init');
+  logger.success(`  Wrote ${EXTENSIONS_DIR}/${name}/extension.json`);
+  if (opts.stub) logger.success(`  Wrote ${stubRel} (a starter that already passes validation)`);
+  logger.info('  Next:');
+  logger.info(`    1. vyuh-dxkit extensions dev ${name}   # run + validate in seconds`);
+  logger.info('    2. commit the manifest (and snapshot) — gates read snapshots offline');
+  return 0;
+}

--- a/src/extensions/contributions/index.ts
+++ b/src/extensions/contributions/index.ts
@@ -1,0 +1,170 @@
+/**
+ * CONTRIBUTION_KINDS — the registry of what an extension can contribute.
+ *
+ * One entry per contribution kind (contract | inventory | findings |
+ * export). Each entry owns its versioned wire readers and its snapshot
+ * path convention; the consumer wiring (where a parsed document lands —
+ * the flow join, the inventory store, the baseline producer, the export
+ * dispatcher) attaches per kind as those lanes build out. Everything that
+ * needs to enumerate or dispatch on kinds reads THIS registry: manifest
+ * validation, the runner's output handling, `extensions dev` validation,
+ * `extensions init` menus, docs tables. A fifth kind is one entry here —
+ * no consumer edits (the playbook test injects a synthetic kind and
+ * proves it).
+ *
+ * Versioning (the Rule 9 migration arc on the wire): each kind carries a
+ * reader per SHIPPED schema version, and a shipped reader is never
+ * deleted. A reader validates its version's shape and up-converts to the
+ * CURRENT in-memory document, so consumers see one shape while committed
+ * snapshots of any shipped version keep loading forever. v1 readers
+ * up-convert by identity.
+ */
+
+import type { ContributionKind, WireDoc } from '@vyuhlabs/dxkit-sdk';
+import {
+  castContractV1,
+  castExportV1,
+  castFindingsV1,
+  castInventoryV1,
+  validateContractV1,
+  validateExportV1,
+  validateFindingsV1,
+  validateInventoryV1,
+} from './validate';
+
+/** Reader for ONE shipped wire-schema version of a kind. */
+export interface WireVersionReader {
+  /** The exact `schema` id this reader accepts (e.g. 'contract.v1'). */
+  readonly schemaId: string;
+  /** Field-precise validation; empty array = valid. */
+  validate(raw: unknown): string[];
+  /**
+   * Convert a VALIDATED document of this version to the kind's current
+   * in-memory shape. Called only after `validate` returned no errors.
+   */
+  upConvert(raw: unknown): WireDoc;
+}
+
+/** Registry entry for one contribution kind. */
+export interface ContributionKindDef {
+  readonly kind: ContributionKind;
+  /** The schema id extensions are told to emit today. */
+  readonly currentSchemaId: string;
+  /**
+   * Every shipped version's reader, newest first. Append-only: removing a
+   * reader strands committed snapshots (the contract test pins coverage
+   * of `currentSchemaId`).
+   */
+  readonly versions: readonly WireVersionReader[];
+  /** Conventional committed-snapshot path for an extension of this kind. */
+  snapshotPathFor(extensionName: string): string;
+}
+
+const contractKind: ContributionKindDef = {
+  kind: 'contract',
+  currentSchemaId: 'contract.v1',
+  versions: [{ schemaId: 'contract.v1', validate: validateContractV1, upConvert: castContractV1 }],
+  snapshotPathFor: (name) => `.dxkit/contrib/${name}.json`,
+};
+
+const inventoryKind: ContributionKindDef = {
+  kind: 'inventory',
+  currentSchemaId: 'inventory.v1',
+  versions: [
+    { schemaId: 'inventory.v1', validate: validateInventoryV1, upConvert: castInventoryV1 },
+  ],
+  snapshotPathFor: (name) => `.dxkit/contrib/${name}.json`,
+};
+
+const findingsKind: ContributionKindDef = {
+  kind: 'findings',
+  currentSchemaId: 'findings.v1',
+  versions: [{ schemaId: 'findings.v1', validate: validateFindingsV1, upConvert: castFindingsV1 }],
+  snapshotPathFor: (name) => `.dxkit/contrib/${name}.json`,
+};
+
+const exportKind: ContributionKindDef = {
+  kind: 'export',
+  currentSchemaId: 'export.v1',
+  versions: [{ schemaId: 'export.v1', validate: validateExportV1, upConvert: castExportV1 }],
+  // Export receipts are run OUTCOMES, not repo contract state — they land
+  // under reports, not the committed contrib snapshots.
+  snapshotPathFor: (name) => `.dxkit/reports/export-${name}.json`,
+};
+
+export const CONTRIBUTION_KINDS: readonly ContributionKindDef[] = [
+  contractKind,
+  inventoryKind,
+  findingsKind,
+  exportKind,
+];
+
+export function contributionKindFor(
+  kind: string,
+  registry: readonly ContributionKindDef[] = CONTRIBUTION_KINDS,
+): ContributionKindDef | undefined {
+  return registry.find((d) => d.kind === kind);
+}
+
+export type ParseWireResult =
+  | { readonly ok: true; readonly schemaId: string; readonly doc: WireDoc }
+  | { readonly ok: false; readonly errors: readonly string[] };
+
+/**
+ * The ONE entry point from raw extension output to a canonical document.
+ * Dispatches through the registry (kind → version reader by the document's
+ * own `schema` id), validates field-precisely, and up-converts. Unknown
+ * kind / unknown schema id are loud errors that NAME the known set — the
+ * error message is the documentation (DX doctrine).
+ */
+export function parseWireDoc(
+  kind: string,
+  raw: unknown,
+  registry: readonly ContributionKindDef[] = CONTRIBUTION_KINDS,
+): ParseWireResult {
+  const def = contributionKindFor(kind, registry);
+  if (!def) {
+    const known = registry.map((d) => `'${d.kind}'`).join(' | ');
+    return { ok: false, errors: [`unknown contribution kind '${kind}' — known kinds: ${known}`] };
+  }
+  const schemaId =
+    typeof raw === 'object' && raw !== null && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)['schema']
+      : undefined;
+  const reader = def.versions.find((v) => v.schemaId === schemaId);
+  if (!reader) {
+    const shipped = def.versions.map((v) => `'${v.schemaId}'`).join(' | ');
+    return {
+      ok: false,
+      errors: [
+        `document's schema is ${JSON.stringify(schemaId)} but a '${def.kind}' extension must emit ${shipped} (current: '${def.currentSchemaId}')`,
+      ],
+    };
+  }
+  const errors = reader.validate(raw);
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, schemaId: reader.schemaId, doc: reader.upConvert(raw) };
+}
+
+/**
+ * Text-level sibling of {@link parseWireDoc} for the runner and dev loop:
+ * malformed JSON is a validation failure with the parser's own message,
+ * never a throw (fail-open discipline — a broken emit is a disclosed skip
+ * at the gate, a loud error in `extensions dev`).
+ */
+export function parseWireDocText(
+  kind: string,
+  text: string,
+  registry: readonly ContributionKindDef[] = CONTRIBUTION_KINDS,
+): ParseWireResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (e) {
+    return {
+      ok: false,
+      errors: [`output is not valid JSON: ${e instanceof Error ? e.message : String(e)}`],
+    };
+  }
+  return parseWireDoc(kind, raw, registry);
+}

--- a/src/extensions/contributions/validate.ts
+++ b/src/extensions/contributions/validate.ts
@@ -1,0 +1,271 @@
+/**
+ * Wire-document validators — the field-precise gate between an extension's
+ * emitted JSON and dxkit's machines.
+ *
+ * DX doctrine (the extension design's "errors are the docs"): a validation
+ * failure names the exact field and what is wrong with it —
+ * `inventory.v1: entities[3].fields[0].name must be a non-empty string` —
+ * because for a rung-3 author iterating through `extensions dev`, the error
+ * message IS the documentation. Every validator returns ALL errors it can
+ * find (bounded below), not just the first, so one dev-loop iteration fixes
+ * one emit's worth of mistakes.
+ *
+ * Forward-compatibility bias: UNKNOWN extra fields are tolerated everywhere
+ * (an extension may carry its own bookkeeping alongside the contract; a
+ * future minor may add optional fields that an older dxkit ignores).
+ * Validation is strict about the fields the consuming machine reads and
+ * silent about everything else.
+ */
+
+import type {
+  WireContractDoc,
+  WireExportReceipt,
+  WireFindingsDoc,
+  WireInventoryDoc,
+} from '@vyuhlabs/dxkit-sdk';
+
+/** Stop collecting after this many errors — a malformed 10k-entity emit
+ *  should not produce a 10k-line wall; the first screenful is the signal. */
+const MAX_ERRORS = 25;
+
+class ErrorSink {
+  readonly errors: string[] = [];
+  constructor(private readonly schemaId: string) {}
+  full(): boolean {
+    return this.errors.length >= MAX_ERRORS;
+  }
+  add(path: string, problem: string): void {
+    if (!this.full()) this.errors.push(`${this.schemaId}: ${path} ${problem}`);
+  }
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function describe(v: unknown): string {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'an array';
+  return `a ${typeof v}`;
+}
+
+/** Require a non-empty string at `path`. */
+function checkRequiredString(
+  sink: ErrorSink,
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+): void {
+  const v = obj[key];
+  if (typeof v !== 'string' || v.length === 0) {
+    sink.add(
+      `${path}.${key}`,
+      v === undefined
+        ? 'is missing (required, non-empty string)'
+        : `must be a non-empty string (got ${describe(v)})`,
+    );
+  }
+}
+
+/** Optional string: absent is fine; present must be a string. */
+function checkOptionalString(
+  sink: ErrorSink,
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+): void {
+  const v = obj[key];
+  if (v !== undefined && typeof v !== 'string') {
+    sink.add(`${path}.${key}`, `must be a string when present (got ${describe(v)})`);
+  }
+}
+
+/** Optional 1-based line number: absent fine; present must be a positive integer. */
+function checkOptionalLine(
+  sink: ErrorSink,
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+): void {
+  const v = obj[key];
+  if (v === undefined) return;
+  if (typeof v !== 'number' || !Number.isInteger(v) || v < 1) {
+    sink.add(
+      `${path}.${key}`,
+      `must be a positive integer (1-based line) when present (got ${JSON.stringify(v)})`,
+    );
+  }
+}
+
+/** Optional meta payload: absent fine; present must be a plain object. */
+function checkOptionalMeta(sink: ErrorSink, obj: Record<string, unknown>, path: string): void {
+  const v = obj['meta'];
+  if (v !== undefined && !isObject(v)) {
+    sink.add(`${path}.meta`, `must be an object when present (got ${describe(v)})`);
+  }
+}
+
+/**
+ * Walk an optional array field: absent is fine; present must be an array of
+ * objects, each handed to `each`. Returns early once the sink is full.
+ */
+function checkOptionalArray(
+  sink: ErrorSink,
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+  each: (item: Record<string, unknown>, itemPath: string) => void,
+): void {
+  const v = obj[key];
+  if (v === undefined) return;
+  if (!Array.isArray(v)) {
+    sink.add(`${path}${key}`, `must be an array when present (got ${describe(v)})`);
+    return;
+  }
+  v.forEach((item, i) => {
+    if (sink.full()) return;
+    const itemPath = `${path}${key}[${i}]`;
+    if (!isObject(item)) {
+      sink.add(itemPath, `must be an object (got ${describe(item)})`);
+      return;
+    }
+    each(item, itemPath);
+  });
+}
+
+/** Like checkOptionalArray but the field is required. */
+function checkRequiredArray(
+  sink: ErrorSink,
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+  each: (item: Record<string, unknown>, itemPath: string) => void,
+): void {
+  if (obj[key] === undefined) {
+    sink.add(`${path}${key}`, 'is missing (required array)');
+    return;
+  }
+  checkOptionalArray(sink, obj, key, path, each);
+}
+
+/** Shared shell: doc must be an object whose `schema` is exactly `schemaId`. */
+function checkShell(
+  sink: ErrorSink,
+  raw: unknown,
+  schemaId: string,
+): raw is Record<string, unknown> {
+  if (!isObject(raw)) {
+    sink.add('document', `must be a JSON object (got ${describe(raw)})`);
+    return false;
+  }
+  if (raw['schema'] !== schemaId) {
+    sink.add('schema', `must be the string '${schemaId}' (got ${JSON.stringify(raw['schema'])})`);
+    return false;
+  }
+  return true;
+}
+
+// ── contract.v1 ─────────────────────────────────────────────────────────────
+
+export function validateContractV1(raw: unknown): string[] {
+  const sink = new ErrorSink('contract.v1');
+  if (!checkShell(sink, raw, 'contract.v1')) return sink.errors;
+  checkOptionalArray(sink, raw, 'consumed', '', (item, p) => {
+    checkRequiredString(sink, item, 'method', p);
+    checkRequiredString(sink, item, 'url', p);
+    checkOptionalString(sink, item, 'file', p);
+    checkOptionalLine(sink, item, 'line', p);
+    checkOptionalMeta(sink, item, p);
+  });
+  checkOptionalArray(sink, raw, 'served', '', (item, p) => {
+    checkRequiredString(sink, item, 'method', p);
+    checkRequiredString(sink, item, 'path', p);
+    checkOptionalString(sink, item, 'handler', p);
+    checkOptionalString(sink, item, 'file', p);
+    checkOptionalLine(sink, item, 'line', p);
+    checkOptionalMeta(sink, item, p);
+  });
+  checkOptionalArray(sink, raw, 'dynamicCalls', '', (item, p) => {
+    checkRequiredString(sink, item, 'receiver', p);
+    checkOptionalString(sink, item, 'file', p);
+    checkOptionalLine(sink, item, 'line', p);
+  });
+  return sink.errors;
+}
+
+// ── inventory.v1 ────────────────────────────────────────────────────────────
+
+export function validateInventoryV1(raw: unknown): string[] {
+  const sink = new ErrorSink('inventory.v1');
+  if (!checkShell(sink, raw, 'inventory.v1')) return sink.errors;
+  checkRequiredArray(sink, raw, 'entities', '', (entity, p) => {
+    checkRequiredString(sink, entity, 'kind', p);
+    checkRequiredString(sink, entity, 'name', p);
+    checkOptionalString(sink, entity, 'file', p);
+    checkOptionalLine(sink, entity, 'line', p);
+    checkOptionalMeta(sink, entity, p);
+    checkOptionalArray(sink, entity, 'fields', `${p}.`, (field, fp) => {
+      checkRequiredString(sink, field, 'name', fp);
+      checkOptionalString(sink, field, 'type', fp);
+      const opt = field['optional'];
+      if (opt !== undefined && typeof opt !== 'boolean') {
+        sink.add(`${fp}.optional`, `must be a boolean when present (got ${describe(opt)})`);
+      }
+    });
+    checkOptionalArray(sink, entity, 'relations', `${p}.`, (rel, rp) => {
+      checkRequiredString(sink, rel, 'kind', rp);
+      checkRequiredString(sink, rel, 'target', rp);
+    });
+  });
+  return sink.errors;
+}
+
+// ── findings.v1 ─────────────────────────────────────────────────────────────
+
+const WIRE_SEVERITIES = new Set(['critical', 'high', 'medium', 'low']);
+
+export function validateFindingsV1(raw: unknown): string[] {
+  const sink = new ErrorSink('findings.v1');
+  if (!checkShell(sink, raw, 'findings.v1')) return sink.errors;
+  checkRequiredArray(sink, raw, 'findings', '', (finding, p) => {
+    checkRequiredString(sink, finding, 'rule', p);
+    checkRequiredString(sink, finding, 'message', p);
+    checkRequiredString(sink, finding, 'file', p);
+    const sev = finding['severity'];
+    if (typeof sev !== 'string' || !WIRE_SEVERITIES.has(sev)) {
+      sink.add(
+        `${p}.severity`,
+        `must be one of 'critical' | 'high' | 'medium' | 'low' (got ${JSON.stringify(sev)})`,
+      );
+    }
+    checkOptionalLine(sink, finding, 'line', p);
+    checkOptionalMeta(sink, finding, p);
+  });
+  return sink.errors;
+}
+
+// ── export.v1 ───────────────────────────────────────────────────────────────
+
+export function validateExportV1(raw: unknown): string[] {
+  const sink = new ErrorSink('export.v1');
+  if (!checkShell(sink, raw, 'export.v1')) return sink.errors;
+  const delivered = raw['delivered'];
+  if (typeof delivered !== 'boolean') {
+    sink.add(
+      'delivered',
+      delivered === undefined
+        ? 'is missing (required boolean)'
+        : `must be a boolean (got ${describe(delivered)})`,
+    );
+  }
+  checkOptionalString(sink, raw, 'detail', 'document');
+  return sink.errors;
+}
+
+// Narrowing casts for post-validation use. Safe ONLY after the matching
+// validator returned zero errors — the registry's parse path enforces that
+// ordering, and nothing else may call these.
+export const castContractV1 = (raw: unknown): WireContractDoc => raw as WireContractDoc;
+export const castInventoryV1 = (raw: unknown): WireInventoryDoc => raw as WireInventoryDoc;
+export const castFindingsV1 = (raw: unknown): WireFindingsDoc => raw as WireFindingsDoc;
+export const castExportV1 = (raw: unknown): WireExportReceipt => raw as WireExportReceipt;

--- a/src/extensions/extension-findings.ts
+++ b/src/extensions/extension-findings.ts
@@ -1,0 +1,61 @@
+/**
+ * findings.v1 → the Rule-17 custom-check seam.
+ *
+ * An extension's findings enter the identity machine as the THIRD consumer
+ * of the ONE custom-check seam (user checks + pack lint + extension
+ * findings): each wire finding becomes a `CustomCheckFinding` whose check
+ * label is `extension:<name>`, so it inherits the ENTIRE native-finding
+ * machine — Rule 9 located identity (check + file + lineWindow + rule),
+ * the Rule 10 producer, git-aware matching, brownfield grandfathering,
+ * allowlist, and the guardrail verdict — with zero new identity wiring.
+ * This is Rule 2 applied to gating: a parallel "extension findings"
+ * pipeline would fork everything the seam already owns.
+ *
+ * OFFLINE by construction: this reads committed snapshots via
+ * `snapshot.ts`, never executes anything (the runner is refresh-time
+ * only), so it is safe on every gate surface including untrusted PRs. A
+ * missing or invalid snapshot contributes nothing here — doctor owns that
+ * disclosure; the gate must not fail a repo because an optional artifact
+ * is absent.
+ */
+
+import type { CustomCheckFinding } from '../analyzers/custom-checks/types';
+import type { WireFindingsDoc } from '@vyuhlabs/dxkit-sdk';
+import { discoverExtensions } from './manifest';
+import { readExtensionSnapshot } from './snapshot';
+
+/** The check-label namespace extension findings mint under. */
+export const EXTENSION_CHECK_PREFIX = 'extension:';
+
+/**
+ * Committed findings-extension snapshots as custom-check findings.
+ * `gating: 'off'` extensions are excluded entirely; 'block' maps to a
+ * blocking finding, 'warn' (the default) to non-blocking — the same
+ * block/warn fold every custom check rides through the guardrail.
+ */
+export function gatherExtensionFindings(cwd: string): readonly CustomCheckFinding[] {
+  const { extensions } = discoverExtensions(cwd);
+  const out: CustomCheckFinding[] = [];
+  for (const ext of extensions) {
+    if (ext.manifest.contributes !== 'findings') continue;
+    if (ext.manifest.gating === 'off') continue;
+    const snap = readExtensionSnapshot(cwd, ext);
+    if (snap.status !== 'ok') continue;
+    const doc = snap.doc as WireFindingsDoc;
+    const blocking = ext.manifest.gating === 'block';
+    for (const f of doc.findings) {
+      out.push({
+        check: `${EXTENSION_CHECK_PREFIX}${ext.manifest.name}`,
+        blocking,
+        file: f.file,
+        ...(f.line !== undefined ? { line: f.line } : {}),
+        rule: f.rule,
+        // Severity is display metadata on this seam (identity never hashes
+        // the message — Rule 9); the wire severity rides in front so
+        // renderers and humans see it without a schema change.
+        message: `[${f.severity}] ${f.message}`,
+      });
+    }
+  }
+  return out;
+}

--- a/src/extensions/inventory.ts
+++ b/src/extensions/inventory.ts
@@ -1,0 +1,41 @@
+/**
+ * inventory.v1 → the reports trend (entity COUNTS only).
+ *
+ * The committed inventory snapshot is the store — git history already
+ * preserves every past state and any two refs diff for free. What rides
+ * the reports pillar is the cheap aggregate: per-extension entity counts
+ * by kind, folded into the on-merge report-history entry so
+ * `report history` / `metrics` chart them over time exactly as dimension
+ * scores (the customer's "screens over time" graph, natively). Full
+ * per-entity time-series deliberately stays out — that shape belongs to
+ * the org-level product when it lands, not to a per-repo history line.
+ *
+ * Offline by construction (snapshot reads via the one parse path); absent
+ * or invalid snapshots contribute nothing here — doctor owns disclosure.
+ */
+
+import type { WireInventoryDoc } from '@vyuhlabs/dxkit-sdk';
+import { discoverExtensions } from './manifest';
+import { readExtensionSnapshot } from './snapshot';
+
+/** `{ 'ui-inventory': { screen: 214, permission: 890 } }` — extension name →
+ *  entity kind → count. Undefined when no inventory extension has a readable
+ *  snapshot, so history entries stay clean for repos without extensions. */
+export type InventoryCounts = Record<string, Record<string, number>>;
+
+export function gatherInventoryCounts(cwd: string): InventoryCounts | undefined {
+  const { extensions } = discoverExtensions(cwd);
+  const out: InventoryCounts = {};
+  let any = false;
+  for (const ext of extensions) {
+    if (ext.manifest.contributes !== 'inventory') continue;
+    const snap = readExtensionSnapshot(cwd, ext);
+    if (snap.status !== 'ok') continue;
+    const doc = snap.doc as WireInventoryDoc;
+    const counts: Record<string, number> = {};
+    for (const e of doc.entities) counts[e.kind] = (counts[e.kind] ?? 0) + 1;
+    out[ext.manifest.name] = counts;
+    any = true;
+  }
+  return any ? out : undefined;
+}

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -128,6 +128,10 @@ function validateManifest(raw: unknown, dirName: string, at: string): string[] {
   if (config !== undefined && !isObject(config)) {
     add('config', 'must be an object when present');
   }
+  const gating = raw['gating'];
+  if (gating !== undefined && gating !== 'block' && gating !== 'warn' && gating !== 'off') {
+    add('gating', `must be 'block', 'warn', or 'off' when present (got ${JSON.stringify(gating)})`);
+  }
   return errors;
 }
 

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -1,0 +1,178 @@
+/**
+ * Extension manifest discovery + validation.
+ *
+ * A manifest is `.dxkit/extensions/<name>/extension.json`, committed to the
+ * repo. TRUST BOUNDARY (load-bearing, Rule 17's verbatim): manifests are
+ * honored ONLY from the repo's own tree — the same boundary as npm scripts
+ * and CI config. Nothing here (or anywhere) accepts a manifest from a CLI
+ * flag or any other untrusted source, and extensions EXECUTE only on
+ * trusted context at refresh time (`extensions refresh`, the on-merge
+ * workflow); per-commit gates and untrusted runs read committed snapshots
+ * offline. A PR that edits an extension.json or its script gets reviewed
+ * like a PR that edits a CI workflow.
+ *
+ * Validation is field-precise in the wire-validator style (the error is
+ * the documentation), plus three path-safety guards on values that reach
+ * a spawn or a write:
+ *   - `run.command` / `run.args[*]` must not start with `-` (argument
+ *     injection into the interpreter);
+ *   - `output` must be a repo-relative path without `..` traversal or an
+ *     absolute head (an extension may only write its own committed
+ *     snapshot location);
+ *   - the manifest's `name` must equal its directory name (one identity,
+ *     no aliasing).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ContributionKind, ExtensionManifest } from '@vyuhlabs/dxkit-sdk';
+import { CONTRIBUTION_KINDS, type ContributionKindDef } from './contributions';
+
+export const EXTENSIONS_DIR = '.dxkit/extensions';
+
+/** Ceiling on run.timeoutSeconds — a refresh surface, not a build system. */
+const MAX_TIMEOUT_SECONDS = 3600;
+/** Default when the manifest omits timeoutSeconds. */
+export const DEFAULT_TIMEOUT_SECONDS = 300;
+
+/** A manifest that passed validation, with its repo location attached. */
+export interface LoadedExtension {
+  readonly manifest: ExtensionManifest;
+  /** Repo-relative directory (`.dxkit/extensions/<name>`). */
+  readonly dir: string;
+  /**
+   * The committed config block passed to the extension on stdin (the
+   * manifest's optional `config` object — committed, so inside the same
+   * trust boundary). `{}` when absent.
+   */
+  readonly config: Record<string, unknown>;
+}
+
+export interface DiscoverResult {
+  readonly extensions: readonly LoadedExtension[];
+  /** Per-manifest validation failures, field-precise. Fail-open: a broken
+   *  manifest never hides the healthy ones, and doctor surfaces these. */
+  readonly errors: readonly string[];
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** Repo-relative, no traversal, no absolute head, no leading dash. */
+function safeRelativePath(p: string): boolean {
+  if (p.length === 0 || p.startsWith('-')) return false;
+  if (path.isAbsolute(p) || /^[A-Za-z]:[\\/]/.test(p)) return false;
+  const segments = p.split(/[\\/]+/);
+  return segments.every((s) => s !== '..' && s.length > 0);
+}
+
+function validateManifest(raw: unknown, dirName: string, at: string): string[] {
+  const errors: string[] = [];
+  const add = (field: string, problem: string) => errors.push(`${at}: ${field} ${problem}`);
+  if (!isObject(raw)) {
+    add('manifest', 'must be a JSON object');
+    return errors;
+  }
+  if (raw['schemaVersion'] !== 1) {
+    add('schemaVersion', `must be 1 (got ${JSON.stringify(raw['schemaVersion'])})`);
+  }
+  const name = raw['name'];
+  if (typeof name !== 'string' || !/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+    add('name', 'must be a lowercase kebab-case string');
+  } else if (name !== dirName) {
+    add('name', `('${name}') must equal the extension directory name ('${dirName}')`);
+  }
+  const contributes = raw['contributes'];
+  const knownKinds = CONTRIBUTION_KINDS.map((d: ContributionKindDef) => d.kind);
+  if (typeof contributes !== 'string' || !knownKinds.includes(contributes as ContributionKind)) {
+    add(
+      'contributes',
+      `must be one of ${knownKinds.map((k) => `'${k}'`).join(' | ')} (got ${JSON.stringify(contributes)})`,
+    );
+  }
+  const run = raw['run'];
+  if (!isObject(run)) {
+    add('run', 'is missing (required object with command/args)');
+  } else {
+    const command = run['command'];
+    if (typeof command !== 'string' || command.length === 0 || command.startsWith('-')) {
+      add('run.command', 'must be a non-empty string not starting with "-"');
+    }
+    const args = run['args'];
+    if (args !== undefined) {
+      if (!Array.isArray(args) || args.some((a) => typeof a !== 'string')) {
+        add('run.args', 'must be an array of strings when present');
+      }
+    }
+    const t = run['timeoutSeconds'];
+    if (
+      t !== undefined &&
+      (!Number.isInteger(t) || (t as number) < 1 || (t as number) > MAX_TIMEOUT_SECONDS)
+    ) {
+      add('run.timeoutSeconds', `must be an integer in [1, ${MAX_TIMEOUT_SECONDS}] when present`);
+    }
+  }
+  const refresh = raw['refresh'];
+  if (refresh !== 'on-merge' && refresh !== 'manual') {
+    add('refresh', `must be 'on-merge' or 'manual' (got ${JSON.stringify(refresh)})`);
+  }
+  const output = raw['output'];
+  if (typeof output !== 'string' || !safeRelativePath(output) || !output.endsWith('.json')) {
+    add(
+      'output',
+      'must be a repo-relative .json path (no absolute paths, no "..", no leading "-")',
+    );
+  }
+  const config = raw['config'];
+  if (config !== undefined && !isObject(config)) {
+    add('config', 'must be an object when present');
+  }
+  return errors;
+}
+
+/**
+ * Discover every committed extension manifest under `.dxkit/extensions/`.
+ * Broken manifests are reported, not thrown, and never hide healthy ones.
+ */
+export function discoverExtensions(cwd: string): DiscoverResult {
+  const root = path.join(cwd, EXTENSIONS_DIR);
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return { extensions: [], errors: [] }; // no extensions dir — the common case
+  }
+  const extensions: LoadedExtension[] = [];
+  const errors: string[] = [];
+  for (const entry of entries
+    .filter((e) => e.isDirectory())
+    .sort((a, b) => a.name.localeCompare(b.name))) {
+    const dir = `${EXTENSIONS_DIR}/${entry.name}`;
+    const manifestPath = path.join(root, entry.name, 'extension.json');
+    let text: string;
+    try {
+      text = fs.readFileSync(manifestPath, 'utf-8');
+    } catch {
+      errors.push(`${dir}: missing extension.json`);
+      continue;
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(text);
+    } catch (e) {
+      errors.push(
+        `${dir}/extension.json: not valid JSON (${e instanceof Error ? e.message : String(e)})`,
+      );
+      continue;
+    }
+    const problems = validateManifest(raw, entry.name, `${dir}/extension.json`);
+    if (problems.length > 0) {
+      errors.push(...problems);
+      continue;
+    }
+    const m = raw as unknown as ExtensionManifest & { config?: Record<string, unknown> };
+    extensions.push({ manifest: m, dir, config: m.config ?? {} });
+  }
+  return { extensions, errors };
+}

--- a/src/extensions/run.ts
+++ b/src/extensions/run.ts
@@ -1,0 +1,156 @@
+/**
+ * The ONE extension runner — every extension execution flows through
+ * `runExtension` (arch-gated; mirror of Rule 17's custom-check runner
+ * discipline). Nothing else in the codebase may spawn an extension.
+ *
+ * Execution model (the design's rung 3): the extension gets its committed
+ * config block + canonical repo facts as JSON on stdin, runs with the repo
+ * root as cwd under the shared bounded-exec primitive, and its emitted wire
+ * document (the manifest's `output` file, or stdout as the fallback) is
+ * validated against its contribution kind's registry entry. A valid emit is
+ * rewritten to the output path as pretty-printed canonical JSON with a
+ * `generatedAt` stamp (an additive extra field — the snapshot format IS the
+ * wire format), ready to commit.
+ *
+ * Fail-open policy, in one place: a missing interpreter or a timeout is a
+ * disclosed SKIP (`status: 'skipped'`), never a broken gate — the backstop
+ * is the refresh surface's own CI. A run that finished but emitted an
+ * invalid document is `status: 'invalid'` with the field-precise errors —
+ * loud in `extensions dev` and doctor, still never a crash.
+ *
+ * WHEN this runs (trust, load-bearing): only on trusted context at refresh
+ * time — `extensions refresh` on a developer machine or the on-merge
+ * workflow. Per-commit gates and `--untrusted` runs read committed
+ * snapshots via `snapshot.ts` and never reach this module.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { WireDoc } from '@vyuhlabs/dxkit-sdk';
+import { makeCommandExec, type CommandExec } from '../analyzers/tools/bounded-exec';
+import { parseWireDocText } from './contributions';
+import { DEFAULT_TIMEOUT_SECONDS, type LoadedExtension } from './manifest';
+
+/** Canonical repo facts handed to every extension on stdin — extensions
+ *  inherit the one source of truth for these instead of re-deriving it. */
+export interface ExtensionStdinPayload {
+  readonly payloadVersion: 1;
+  readonly extension: { readonly name: string; readonly contributes: string };
+  /** The manifest's committed `config` block, verbatim. */
+  readonly config: Record<string, unknown>;
+  readonly repo: {
+    /** Directory basenames every dxkit analysis excludes (node_modules, …). */
+    readonly excludeDirs: readonly string[];
+    /** Active language-pack ids in this repo. */
+    readonly activeLanguages: readonly string[];
+  };
+}
+
+export type ExtensionRunOutcome =
+  | {
+      readonly status: 'ok';
+      readonly doc: WireDoc;
+      readonly schemaId: string;
+      readonly outputPath: string;
+    }
+  | { readonly status: 'skipped'; readonly reason: string }
+  | { readonly status: 'invalid'; readonly errors: readonly string[] };
+
+export interface RunExtensionOptions {
+  /** Injected exec (tests); defaults to the bounded primitive. */
+  readonly exec?: CommandExec;
+  /** Repo facts for the stdin payload; callers pass the canonical values. */
+  readonly excludeDirs?: readonly string[];
+  readonly activeLanguages?: readonly string[];
+  /** Clock injection for the generatedAt stamp (tests). */
+  readonly now?: () => Date;
+}
+
+/**
+ * Run one extension and validate + persist its emission. See the module
+ * header for policy; this function owns the mechanics only.
+ */
+export function runExtension(
+  cwd: string,
+  ext: LoadedExtension,
+  opts: RunExtensionOptions = {},
+): ExtensionRunOutcome {
+  const { manifest } = ext;
+  const timeoutMs = (manifest.run.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000;
+  const exec = opts.exec ?? makeCommandExec(timeoutMs);
+  const payload: ExtensionStdinPayload = {
+    payloadVersion: 1,
+    extension: { name: manifest.name, contributes: manifest.contributes },
+    config: ext.config,
+    repo: {
+      excludeDirs: opts.excludeDirs ?? [],
+      activeLanguages: opts.activeLanguages ?? [],
+    },
+  };
+
+  const outputAbs = path.join(cwd, manifest.output);
+  // Remove a stale output first so "file exists after the run" means the
+  // RUN produced it, not a previous invocation.
+  try {
+    fs.rmSync(outputAbs, { force: true });
+  } catch {
+    /* a locked stale file surfaces below as an invalid/missing emit */
+  }
+
+  const outcome = exec(
+    {
+      bin: manifest.run.command,
+      args: manifest.run.args ?? [],
+      stdin: JSON.stringify(payload),
+      captureFullOutput: true,
+    },
+    cwd,
+  );
+
+  if (!outcome.available) {
+    return { status: 'skipped', reason: `interpreter '${manifest.run.command}' not found` };
+  }
+  if (outcome.timedOut) {
+    return {
+      status: 'skipped',
+      reason: `timed out after ${manifest.run.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS}s`,
+    };
+  }
+  if (outcome.code !== 0) {
+    return {
+      status: 'invalid',
+      errors: [
+        `extension exited ${outcome.code}${outcome.output ? ` — output tail: ${outcome.output.slice(-800)}` : ''}`,
+      ],
+    };
+  }
+
+  // Prefer the output file the extension wrote; fall back to stdout.
+  let text: string | null = null;
+  try {
+    text = fs.readFileSync(outputAbs, 'utf-8');
+  } catch {
+    text = outcome.output.trim().length > 0 ? outcome.output : null;
+  }
+  if (text === null) {
+    return {
+      status: 'invalid',
+      errors: [
+        `extension exited 0 but wrote neither its output file (${manifest.output}) nor a document on stdout`,
+      ],
+    };
+  }
+
+  const parsed = parseWireDocText(manifest.contributes, text);
+  if (!parsed.ok) return { status: 'invalid', errors: parsed.errors };
+
+  // Persist the canonical snapshot: the validated wire doc + a generatedAt
+  // stamp (additive extra — validators tolerate it by design, so the
+  // snapshot round-trips through the same parse path).
+  const stamped = { ...(parsed.doc as unknown as Record<string, unknown>) };
+  stamped['generatedAt'] = (opts.now?.() ?? new Date()).toISOString();
+  fs.mkdirSync(path.dirname(outputAbs), { recursive: true });
+  fs.writeFileSync(outputAbs, `${JSON.stringify(stamped, null, 2)}\n`);
+
+  return { status: 'ok', doc: parsed.doc, schemaId: parsed.schemaId, outputPath: manifest.output };
+}

--- a/src/extensions/run.ts
+++ b/src/extensions/run.ts
@@ -44,6 +44,13 @@ export interface ExtensionStdinPayload {
     /** Active language-pack ids in this repo. */
     readonly activeLanguages: readonly string[];
   };
+  /**
+   * For EXPORT extensions only: the post-run document to deliver (a report
+   * / verdict JSON the refresh surface hands over). The sink reads it from
+   * here, delivers it wherever it likes, and returns an export.v1 receipt.
+   * Absent for every other contribution kind.
+   */
+  readonly delivery?: unknown;
 }
 
 export type ExtensionRunOutcome =
@@ -62,6 +69,8 @@ export interface RunExtensionOptions {
   /** Repo facts for the stdin payload; callers pass the canonical values. */
   readonly excludeDirs?: readonly string[];
   readonly activeLanguages?: readonly string[];
+  /** The document an EXPORT extension delivers (see stdin payload). */
+  readonly delivery?: unknown;
   /** Clock injection for the generatedAt stamp (tests). */
   readonly now?: () => Date;
 }
@@ -86,6 +95,7 @@ export function runExtension(
       excludeDirs: opts.excludeDirs ?? [],
       activeLanguages: opts.activeLanguages ?? [],
     },
+    ...(opts.delivery !== undefined ? { delivery: opts.delivery } : {}),
   };
 
   const outputAbs = path.join(cwd, manifest.output);

--- a/src/extensions/snapshot.ts
+++ b/src/extensions/snapshot.ts
@@ -1,0 +1,65 @@
+/**
+ * Committed-snapshot reading — the OFFLINE half of the extension contract.
+ *
+ * Gates, reports, and untrusted runs never execute an extension; they read
+ * the committed snapshot its last refresh wrote (the `served.json`
+ * architecture generalized). The snapshot file IS the wire document (plus
+ * the runner's additive `generatedAt` stamp), so it round-trips through the
+ * same registry parse path as a live emission — one validation code path.
+ *
+ * Staleness is DISCLOSED, never fatal: an old snapshot degrades a
+ * consumer's confidence wording, not its availability (the flow-freshness
+ * discipline). A missing or invalid snapshot is likewise a disclosed state
+ * the consumer folds into its own honesty channel.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { WireDoc } from '@vyuhlabs/dxkit-sdk';
+import { parseWireDocText } from './contributions';
+import type { LoadedExtension } from './manifest';
+
+export type ExtensionSnapshot =
+  | {
+      readonly status: 'ok';
+      readonly doc: WireDoc;
+      readonly schemaId: string;
+      /** ISO timestamp the runner stamped, when present. */
+      readonly generatedAt?: string;
+      /** Whole days since generatedAt (0 for today); undefined when unstamped. */
+      readonly ageDays?: number;
+    }
+  | { readonly status: 'missing'; readonly outputPath: string }
+  | { readonly status: 'invalid'; readonly errors: readonly string[] };
+
+export function readExtensionSnapshot(
+  cwd: string,
+  ext: LoadedExtension,
+  now: () => Date = () => new Date(),
+): ExtensionSnapshot {
+  const abs = path.join(cwd, ext.manifest.output);
+  let text: string;
+  try {
+    text = fs.readFileSync(abs, 'utf-8');
+  } catch {
+    return { status: 'missing', outputPath: ext.manifest.output };
+  }
+  const parsed = parseWireDocText(ext.manifest.contributes, text);
+  if (!parsed.ok) return { status: 'invalid', errors: parsed.errors };
+
+  let generatedAt: string | undefined;
+  try {
+    const raw = JSON.parse(text) as Record<string, unknown>;
+    generatedAt = typeof raw['generatedAt'] === 'string' ? raw['generatedAt'] : undefined;
+  } catch {
+    /* unreachable — parseWireDocText already parsed */
+  }
+  let ageDays: number | undefined;
+  if (generatedAt) {
+    const t = Date.parse(generatedAt);
+    if (!Number.isNaN(t)) {
+      ageDays = Math.max(0, Math.floor((now().getTime() - t) / 86_400_000));
+    }
+  }
+  return { status: 'ok', doc: parsed.doc, schemaId: parsed.schemaId, generatedAt, ageDays };
+}

--- a/src/flow-cli.ts
+++ b/src/flow-cli.ts
@@ -82,6 +82,8 @@ export async function gatherModel(
     roots: resolveRoots(opts),
     specs: [...splitPaths(opts.specs, opts.cwd), ...policySpecs],
     stripUrlPrefixes: config.stripUrlPrefixes,
+    sources: config.sources,
+    sourcesBase: opts.cwd,
     ...(extra?.relativeTo !== undefined ? { relativeTo: extra.relativeTo } : {}),
   });
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -179,6 +179,10 @@ export const DXKIT_SKILLS = [
   // fix mode ships a deliberate breaking change the safe way (migration
   // + expiring accepted-risk allowlist entry), never a posture bypass.
   'dxkit-schema',
+  // dxkit-extensions: plug the repo's own extractors/inventories/sinks into
+  // dxkit as rung-2 declared artifacts or rung-3 external extensions; owns
+  // the authoring loop (extensions dev/init) and the trust-model explainer.
+  'dxkit-extensions',
   // dxkit-uninstall: cleanly remove all of dxkit from a repo, restoring the
   // pre-dxkit state (reverse each additive merge, delete created files),
   // dry-run first. Also captures optional, opt-in feedback via a prefilled

--- a/src/land-refresh.ts
+++ b/src/land-refresh.ts
@@ -1,0 +1,168 @@
+/**
+ * Landing a refresh commit on the default branch — the ONE tested home for
+ * what would otherwise be workflow bash, shared by every on-merge refresh
+ * surface that updates TRACKED files (flow contract snapshots, extension
+ * snapshots). Side-ref publishes are a different mechanism entirely
+ * (src/baseline/anchor-publish.ts); this module is for changes that must
+ * land in the default branch's tree because gates read them offline.
+ *
+ * Two modes (the flow-refresh semantics, generalized):
+ *   - `pr`: push a STANDING branch (force-updated in place — never a pile)
+ *     and open/update one PR. The review checkpoint sits where it matters;
+ *     PR creation degrades gracefully (no `gh` / not GitHub → the branch is
+ *     still pushed and the result says "open it manually").
+ *   - `push`: commit straight to the default branch with `[skip ci]` — zero
+ *     ceremony; a protected branch rejects it loudly (use `pr`).
+ *
+ * The caller owns everything domain-shaped: which paths, the substance
+ * check (so metadata churn never lands a commit), and the PR prose. This
+ * module owns only the git/gh mechanics, extracted verbatim from the flow
+ * lander so the two consumers cannot drift (Rule 2).
+ */
+import { execFileSync } from 'child_process';
+
+export type LandMode = 'pr' | 'push';
+
+export type Exec = (bin: string, args: readonly string[], opts?: { allowFail?: boolean }) => string;
+
+/** Real exec: capture stdout, tolerate failure only when asked. */
+export function makeExec(cwd: string): Exec {
+  return (bin, args, opts = {}) => {
+    try {
+      return execFileSync(bin, [...args], {
+        cwd,
+        encoding: 'utf8',
+        // Never hang a refresh on an interactive credential prompt; a bad
+        // remote fails fast and the caller surfaces it.
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+        timeout: 60_000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).toString();
+    } catch (e) {
+      if (opts.allowFail) return '';
+      throw e;
+    }
+  };
+}
+
+export interface LandRefreshOptions {
+  readonly cwd: string;
+  readonly mode: LandMode;
+  /** Git pathspecs the refresh may have touched (added + status-checked). */
+  readonly paths: readonly string[];
+  /** The standing refresh branch (`dxkit/<surface>-refresh`). */
+  readonly branchName: string;
+  readonly defaultBranch: string;
+  /** Commit subject; `[skip ci]` is appended by this module. */
+  readonly commitTitle: string;
+  readonly prTitle: string;
+  readonly prBody: string;
+  /**
+   * Substance check, run only when git sees a byte diff: return false to
+   * REVERT the paths and land nothing (a timestamp-only refresh must not
+   * commit on every merge). Default: any diff is substantive.
+   */
+  readonly isSubstantive?: () => boolean;
+  readonly identity?: { readonly name: string; readonly email: string };
+  readonly exec?: Exec;
+}
+
+export interface LandRefreshResult {
+  readonly outcome: 'clean' | 'pushed' | 'pr-opened' | 'pr-updated' | 'branch-pushed-no-pr';
+  readonly mode: LandMode;
+  readonly prUrl?: string;
+  readonly note?: string;
+}
+
+const BOT = { name: 'dxkit-bot', email: 'dxkit-bot@users.noreply.github.com' };
+
+export function landRefreshPaths(opts: LandRefreshOptions): LandRefreshResult {
+  const exec = opts.exec ?? makeExec(opts.cwd);
+  const identity = opts.identity ?? BOT;
+  const paths = [...opts.paths];
+
+  const status = exec('git', ['status', '--porcelain', '--', ...paths]).trim();
+  if (status === '') return { outcome: 'clean', mode: opts.mode };
+
+  if (opts.isSubstantive && !opts.isSubstantive()) {
+    exec('git', ['checkout', '--', ...paths], { allowFail: true });
+    return { outcome: 'clean', mode: opts.mode };
+  }
+
+  const commit = (message: string): void => {
+    exec('git', ['add', ...paths]);
+    exec('git', [
+      '-c',
+      `user.name=${identity.name}`,
+      '-c',
+      `user.email=${identity.email}`,
+      'commit',
+      '-m',
+      message,
+    ]);
+  };
+
+  if (opts.mode === 'push') {
+    commit(`${opts.commitTitle} [skip ci]`);
+    exec('git', ['push', 'origin', `HEAD:${opts.defaultBranch}`]);
+    return { outcome: 'pushed', mode: 'push' };
+  }
+
+  // PR mode: one standing branch, force-updated. On a LOCAL run, restore
+  // whatever the user had checked out afterwards (CI checkouts are detached /
+  // ephemeral and skip the restore) — landing a refresh must never leave a
+  // human stranded on the bot branch.
+  const priorRef = exec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { allowFail: true }).trim();
+  exec('git', ['checkout', '-B', opts.branchName]);
+  commit(`${opts.prTitle}\n\n[skip ci]`);
+  exec('git', ['push', '--force', 'origin', opts.branchName]);
+  if (priorRef && priorRef !== 'HEAD' && priorRef !== opts.branchName) {
+    exec('git', ['checkout', priorRef], { allowFail: true });
+  }
+
+  // The PR itself is best-effort: no gh / not GitHub → the branch still landed.
+  const existing = exec(
+    'gh',
+    ['pr', 'list', '--head', opts.branchName, '--state', 'open', '--json', 'url'],
+    { allowFail: true },
+  ).trim();
+  let parsed: Array<{ url: string }> = [];
+  try {
+    parsed = existing ? (JSON.parse(existing) as Array<{ url: string }>) : [];
+  } catch {
+    parsed = [];
+  }
+  if (parsed.length > 0) {
+    exec('gh', ['pr', 'edit', opts.branchName, '--title', opts.prTitle, '--body', opts.prBody], {
+      allowFail: true,
+    });
+    return { outcome: 'pr-updated', mode: 'pr', prUrl: parsed[0].url };
+  }
+  const created = exec(
+    'gh',
+    [
+      'pr',
+      'create',
+      '--head',
+      opts.branchName,
+      '--base',
+      opts.defaultBranch,
+      '--title',
+      opts.prTitle,
+      '--body',
+      opts.prBody,
+    ],
+    { allowFail: true },
+  ).trim();
+  if (created) {
+    const url = created.split('\n').pop() ?? '';
+    return { outcome: 'pr-opened', mode: 'pr', ...(url ? { prUrl: url } : {}) };
+  }
+  return {
+    outcome: 'branch-pushed-no-pr',
+    mode: 'pr',
+    note:
+      `Pushed '${opts.branchName}' but could not open the PR (no gh CLI / not GitHub / ` +
+      `no permission). Open it manually: ${opts.branchName} → ${opts.defaultBranch}.`,
+  };
+}

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -506,13 +506,28 @@ export function changedFilesTouchFlowSurface(
   changedFiles: readonly string[],
   packs: readonly LanguageSupport[],
   specPaths: readonly string[] = [],
+  /**
+   * Declared contract-artifact paths (`flow.sources[].path`) — exact paths
+   * or basename `*` globs. A PR that only edits a Postman collection or a
+   * pact MUST NOT skip the gate: the artifact IS flow surface.
+   */
+  sourcePatterns: readonly string[] = [],
 ): boolean {
   const exts = allFlowSourceExtensions(packs);
-  if (exts.length === 0) return false;
+  if (exts.length === 0 && specPaths.length === 0 && sourcePatterns.length === 0) return false;
   const specSet = new Set(specPaths.map((s) => s.replace(/\\/g, '/')));
+  const sourceRes = sourcePatterns.map((p) => {
+    const norm = p.replace(/\\/g, '/');
+    const escaped = norm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '[^/]*');
+    return new RegExp(`^${escaped}$`);
+  });
   return changedFiles.some((f) => {
     const norm = f.replace(/\\/g, '/');
-    return exts.some((e) => norm.endsWith(e)) || specSet.has(norm);
+    return (
+      exts.some((e) => norm.endsWith(e)) ||
+      specSet.has(norm) ||
+      sourceRes.some((re) => re.test(norm))
+    );
   });
 }
 

--- a/src/managed-artifacts.ts
+++ b/src/managed-artifacts.ts
@@ -50,6 +50,8 @@ import {
   installCiReportsRefresh,
   reportsRefreshEnabled,
   installCiFlowRefresh,
+  installCiExtensionsRefresh,
+  extensionsRefreshEnabled,
   flowRefreshEnabled,
   installCiGuardrails,
   installDevcontainer,
@@ -74,6 +76,7 @@ type PrimaryFlag =
   | 'withGraphRefresh'
   | 'withReportsRefresh'
   | 'withFlowRefresh'
+  | 'withExtensionsRefresh'
   | 'withClaudeLoop';
 
 /**
@@ -272,6 +275,19 @@ export const MANAGED_SHIP_SURFACES: readonly ManagedShipSurface[] = [
     detectPresent: (cwd) => existsRel(cwd, '.github/workflows/dxkit-reports-refresh.yml'),
   },
   {
+    // On-merge extension-snapshot refresh (keep committed extension
+    // snapshots current). Opt-in via --with-extensions-refresh, or
+    // automatically when a committed manifest declares refresh: on-merge;
+    // presence uninstall detection mirrors flow-refresh.
+    id: 'ci-extensions-refresh',
+    gate: { kind: 'flag', flag: 'withExtensionsRefresh' },
+    artifacts: () => ['.github/workflows/dxkit-extensions-refresh.yml'],
+    uninstallDetection: 'presence',
+    refreshOnUpdate: true,
+    install: (cwd, { force }) => installCiExtensionsRefresh(cwd, { force }),
+    detectPresent: (cwd) => existsRel(cwd, '.github/workflows/dxkit-extensions-refresh.yml'),
+  },
+  {
     // On-merge flow-contract refresh (task: keep committed served/consumed
     // snapshots current). Opt-in via policy flow.onMergeRefresh; presence
     // uninstall detection mirrors reports-refresh.
@@ -348,6 +364,7 @@ export function detectInstallFlags(cwd: string): ManifestInstallFlags {
     withGraphRefresh: false,
     withReportsRefresh: false,
     withFlowRefresh: false,
+    withExtensionsRefresh: false,
   };
   for (const surface of MANAGED_SHIP_SURFACES) {
     if (surface.gate.kind === 'flag' && surface.detectPresent) {
@@ -360,6 +377,7 @@ export function detectInstallFlags(cwd: string): ManifestInstallFlags {
   flags.withGraphRefresh = flags.withGraphRefresh || graphRefreshEnabled(cwd);
   flags.withReportsRefresh = flags.withReportsRefresh || reportsRefreshEnabled(cwd);
   flags.withFlowRefresh = flags.withFlowRefresh || flowRefreshEnabled(cwd);
+  flags.withExtensionsRefresh = flags.withExtensionsRefresh || extensionsRefreshEnabled(cwd);
   return flags;
 }
 

--- a/src/reports-cli.ts
+++ b/src/reports-cli.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { VERSION } from './constants';
 import { analyzeHealth } from './analyzers/health';
+import { gatherInventoryCounts } from './extensions/inventory';
 import {
   reportToHistoryEntry,
   publishReportSnapshot,
@@ -83,12 +84,18 @@ export async function runReportSnapshot(opts: ReportSnapshotOptions): Promise<nu
   const branch = gitLine(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']) || undefined;
   const date = opts.now ?? new Date().toISOString();
 
-  const entry = reportToHistoryEntry(report, {
-    sha,
-    date,
-    dxkitVersion: VERSION,
-    ...(branch ? { branch } : {}),
-  });
+  const inventory = gatherInventoryCounts(cwd);
+  const entry = {
+    ...reportToHistoryEntry(report, {
+      sha,
+      date,
+      dxkitVersion: VERSION,
+      ...(branch ? { branch } : {}),
+    }),
+    // Extension inventory counts ride the same history entry (additive
+    // field) so entity trends chart beside dimension scores.
+    ...(inventory ? { inventory } : {}),
+  };
   const artifacts = collectArtifacts(cwd);
 
   if (opts.dryRun) {

--- a/src/reports/history.ts
+++ b/src/reports/history.ts
@@ -45,6 +45,12 @@ export interface ReportHistoryEntry {
   readonly branch?: string;
   readonly scores: ReportScores;
   readonly findings?: ReportFindingCounts;
+  /** Extension inventory entity counts (extension name → entity kind →
+   *  count), captured from committed inventory.v1 snapshots at snapshot
+   *  time. Additive: absent for repos without inventory extensions, and
+   *  older dxkit readers ignore it. Counts only — the committed snapshot
+   *  (with git history) remains the per-entity store. */
+  readonly inventory?: Record<string, Record<string, number>>;
 }
 
 /** The score keys, in canonical display order — the ONE list every consumer
@@ -101,6 +107,9 @@ export function parseHistory(jsonl: string | null | undefined): ReportHistoryEnt
       scores,
       ...(o.findings && typeof o.findings === 'object'
         ? { findings: o.findings as ReportFindingCounts }
+        : {}),
+      ...(o.inventory && typeof o.inventory === 'object'
+        ? { inventory: o.inventory as Record<string, Record<string, number>> }
         : {}),
     };
     out.push(entry);

--- a/src/reports/render.ts
+++ b/src/reports/render.ts
@@ -78,6 +78,16 @@ export function renderHistoryMarkdown(
     );
   }
 
+  // Extension inventory counts (additive — rendered only when the latest
+  // entry carries them; repos without inventory extensions see nothing).
+  const invLines = inventoryDeltaLines(
+    entries,
+    (name, kind, count, delta) => `| ${name} | ${kind} | ${count} | ${delta || '—'} |`,
+  );
+  if (invLines.length > 0) {
+    lines.push('', '| Inventory | Kind | Count | Δ |', '| --- | --- | ---: | :--- |', ...invLines);
+  }
+
   // Compact recent trend (most-recent last), so the table reads left→right in time.
   const limit = opts.limit && opts.limit > 0 ? opts.limit : 10;
   const recent = entries.slice(-limit);
@@ -133,6 +143,46 @@ export function renderTrendText(
         recent.map((e) => `${e.date.slice(5, 10)} ${score(e.scores.overall)}`).join('  '),
     );
   }
+  // Extension inventory counts, one compact line per extension (invisible
+  // for repos without inventory extensions).
+  const latestInv = entries[entries.length - 1]?.inventory;
+  if (latestInv) {
+    const prevInv = [...entries.slice(0, -1)].reverse().find((e) => e.inventory)?.inventory;
+    for (const [name, counts] of Object.entries(latestInv)) {
+      const parts = Object.entries(counts)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([kind, count]) => {
+          const before = prevInv?.[name]?.[kind];
+          const d = before === undefined ? null : count - before;
+          return `${kind} ${count}${d ? ` (${d > 0 ? '+' : ''}${d})` : ''}`;
+        });
+      out.push(`  inventory ${name}: ${parts.join(' · ')}`);
+    }
+  }
   void cur;
+  return out;
+}
+
+/**
+ * Per-(extension, kind) inventory rows for the LATEST entry, with a delta
+ * against the most recent prior entry that carried inventory. Empty when the
+ * latest entry has none — inventory rendering is invisible to repos without
+ * inventory extensions.
+ */
+function inventoryDeltaLines(
+  entries: readonly ReportHistoryEntry[],
+  row: (name: string, kind: string, count: number, delta: string) => string,
+): string[] {
+  const latest = entries[entries.length - 1]?.inventory;
+  if (!latest) return [];
+  const prev = [...entries.slice(0, -1)].reverse().find((e) => e.inventory)?.inventory;
+  const out: string[] = [];
+  for (const [name, counts] of Object.entries(latest)) {
+    for (const [kind, count] of Object.entries(counts).sort(([a], [b]) => a.localeCompare(b))) {
+      const before = prev?.[name]?.[kind];
+      const d = before === undefined ? null : count - before;
+      out.push(row(name, kind, count, d ? `${d > 0 ? '+' : ''}${d}` : ''));
+    }
+  }
   return out;
 }

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -32,6 +32,7 @@ import {
 } from './baseline/modes';
 import { loadPolicyFromCwd } from './baseline/policy';
 import { readFlowConfig } from './analyzers/flow/config';
+import { discoverExtensions } from './extensions/manifest';
 import { mergeIntoPolicyFile } from './baseline/policy-write';
 import { detectEnforcement, type EnforcementState } from './enforcement';
 
@@ -835,6 +836,30 @@ export function installCiFlowRefresh(cwd: string, opts: InstallerOpts = {}): Shi
  *  the ONE flow-section reader (Rule 2), same as every other flow surface. */
 export function flowRefreshEnabled(cwd: string): boolean {
   return readFlowConfig(cwd).onMergeRefresh;
+}
+
+export function installCiExtensionsRefresh(
+  cwd: string,
+  opts: InstallerOpts = {},
+): ShipInstallResult {
+  const result = installWorkflow(cwd, 'dxkit-extensions-refresh.yml', opts, {
+    [CI_RUNTIME_SETUP_KEY]: renderCiRuntimeSetup(cwd),
+    __DXKIT_DEFAULT_BRANCH__: detectDefaultBranch(cwd),
+  });
+  if (result.installed.length > 0) {
+    result.notes.push(
+      'extensions-refresh workflow installed: after each merge it re-runs the committed ' +
+        'extension manifests and lands snapshot updates via one standing PR (a pure ' +
+        'timestamp restamp never lands a commit).',
+    );
+  }
+  return result;
+}
+
+/** Whether any committed extension declares an on-merge refresh — resolved
+ *  through the ONE manifest reader (Rule 2), same as every extension surface. */
+export function extensionsRefreshEnabled(cwd: string): boolean {
+  return discoverExtensions(cwd).extensions.some((e) => e.manifest.refresh === 'on-merge');
 }
 
 export function installCiDeepSastRefresh(cwd: string, opts: InstallerOpts = {}): ShipInstallResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,7 @@ export interface ManifestInstallFlags {
   /** Flow-refresh workflow (re-publish + land the contract snapshots on merge;
    *  opt-in via `.dxkit/policy.json:flow.onMergeRefresh: true`). */
   withFlowRefresh?: boolean;
+  withExtensionsRefresh?: boolean;
 }
 
 /** A dependency `vyuh-dxkit tools install` added to the repo on dxkit's behalf

--- a/test/extensions/contributions.test.ts
+++ b/test/extensions/contributions.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Wire validators + CONTRIBUTION_KINDS registry (extension SDK #11b).
+ *
+ * Three layers, mirroring the repo's registry discipline:
+ *  - validator precision: errors are field-precise and name the schema id
+ *    (the DX doctrine — the error message is the documentation);
+ *  - registry contract: every ContributionKind has exactly one entry, the
+ *    current schema id is covered by a reader, ids are unique;
+ *  - playbook: a synthetic kind injected into the registry parses through
+ *    the SAME dispatch — proof that adding a kind is one entry, no
+ *    consumer edits (mirror of recipe-playbook / producer-playbook).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { WIRE_SCHEMA_IDS } from '@vyuhlabs/dxkit-sdk';
+import type { ContributionKind } from '@vyuhlabs/dxkit-sdk';
+import {
+  CONTRIBUTION_KINDS,
+  contributionKindFor,
+  parseWireDoc,
+  parseWireDocText,
+  type ContributionKindDef,
+} from '../../src/extensions/contributions';
+
+const ALL_KINDS: ContributionKind[] = ['contract', 'inventory', 'findings', 'export'];
+
+describe('CONTRIBUTION_KINDS registry contract', () => {
+  it('covers every contribution kind exactly once', () => {
+    const kinds = CONTRIBUTION_KINDS.map((d) => d.kind).sort();
+    expect(kinds).toEqual([...ALL_KINDS].sort());
+  });
+
+  it('every entry reads its own current schema id', () => {
+    for (const def of CONTRIBUTION_KINDS) {
+      const reader = def.versions.find((v) => v.schemaId === def.currentSchemaId);
+      expect(reader, `${def.kind} must have a reader for ${def.currentSchemaId}`).toBeDefined();
+    }
+  });
+
+  it('every current schema id is a shipped WIRE_SCHEMA_IDS entry', () => {
+    for (const def of CONTRIBUTION_KINDS) {
+      expect(WIRE_SCHEMA_IDS).toContain(def.currentSchemaId);
+    }
+  });
+
+  it('snapshot path conventions are extension-name-scoped', () => {
+    for (const def of CONTRIBUTION_KINDS) {
+      const p = def.snapshotPathFor('ui-inventory');
+      expect(p).toContain('ui-inventory');
+      expect(p.endsWith('.json')).toBe(true);
+      expect(p.startsWith('.dxkit/')).toBe(true);
+    }
+  });
+});
+
+describe('parseWireDoc dispatch', () => {
+  it('accepts a minimal valid document per kind', () => {
+    const docs: Record<ContributionKind, unknown> = {
+      contract: { schema: 'contract.v1', consumed: [{ method: 'GET', url: '/api/things' }] },
+      inventory: {
+        schema: 'inventory.v1',
+        entities: [{ kind: 'screen', name: 'Checkout', fields: [{ name: 'total' }] }],
+      },
+      findings: {
+        schema: 'findings.v1',
+        findings: [
+          { rule: 'no-x', message: 'found x', severity: 'high', file: 'src/a.py', line: 3 },
+        ],
+      },
+      export: { schema: 'export.v1', delivered: true, detail: '3 rows to influx' },
+    };
+    for (const kind of ALL_KINDS) {
+      const r = parseWireDoc(kind, docs[kind]);
+      expect(r.ok, `${kind} should parse: ${JSON.stringify(r)}`).toBe(true);
+      if (r.ok) expect(r.schemaId).toBe(contributionKindFor(kind)?.currentSchemaId);
+    }
+  });
+
+  it('unknown kind names the known set', () => {
+    const r = parseWireDoc('telemetry', { schema: 'telemetry.v1' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors[0]).toContain("'contract' | 'inventory' | 'findings' | 'export'");
+  });
+
+  it('unknown schema id names the shipped ids and the current one', () => {
+    const r = parseWireDoc('contract', { schema: 'contract.v9' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors[0]).toContain("'contract.v1'");
+      expect(r.errors[0]).toContain("current: 'contract.v1'");
+    }
+  });
+
+  it('malformed JSON text is a disclosed validation failure, not a throw', () => {
+    const r = parseWireDocText('contract', '{not json');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors[0]).toMatch(/not valid JSON/);
+  });
+});
+
+describe('validator field precision (errors are the docs)', () => {
+  it('contract.v1: names the exact array index and field', () => {
+    const r = parseWireDoc('contract', {
+      schema: 'contract.v1',
+      consumed: [
+        { method: 'GET', url: '/ok' },
+        { method: 7, url: '' },
+      ],
+      served: [{ method: 'GET', path: '/x', line: 0 }],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors).toContainEqual(expect.stringContaining('consumed[1].method'));
+      expect(r.errors).toContainEqual(expect.stringContaining('consumed[1].url'));
+      expect(r.errors).toContainEqual(expect.stringContaining('served[0].line'));
+      for (const e of r.errors) expect(e.startsWith('contract.v1: ')).toBe(true);
+    }
+  });
+
+  it('inventory.v1: nested field paths are precise', () => {
+    const r = parseWireDoc('inventory', {
+      schema: 'inventory.v1',
+      entities: [
+        { kind: 'screen', name: 'A', fields: [{ name: 'ok' }, { type: 'str' }] },
+        { name: 'missing-kind' },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors).toContainEqual(expect.stringContaining('entities[0].fields[1].name'));
+      expect(r.errors).toContainEqual(expect.stringContaining('entities[1].kind'));
+    }
+  });
+
+  it('findings.v1: severity vocabulary is enforced with the allowed set in the message', () => {
+    const r = parseWireDoc('findings', {
+      schema: 'findings.v1',
+      findings: [{ rule: 'r', message: 'm', severity: 'urgent', file: 'a.ts' }],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors[0]).toContain('findings[0].severity');
+      expect(r.errors[0]).toContain("'critical' | 'high' | 'medium' | 'low'");
+    }
+  });
+
+  it('export.v1: missing delivered is loud', () => {
+    const r = parseWireDoc('export', { schema: 'export.v1' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors[0]).toContain('delivered');
+  });
+
+  it('unknown extra fields are tolerated (forward compatibility)', () => {
+    const r = parseWireDoc('contract', {
+      schema: 'contract.v1',
+      consumed: [{ method: 'GET', url: '/x', futureField: { anything: true } }],
+      vendorBlock: [1, 2, 3],
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('error volume is bounded (a huge malformed emit is a screenful, not a wall)', () => {
+    const entities = Array.from({ length: 500 }, () => ({}));
+    const r = parseWireDoc('inventory', { schema: 'inventory.v1', entities });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.length).toBeLessThanOrEqual(25);
+  });
+});
+
+describe('synthetic-kind playbook (the registry stays the dispatch)', () => {
+  it('an injected kind parses through the same entry point untouched', () => {
+    const synthetic: ContributionKindDef = {
+      kind: 'telemetry' as ContributionKind, // a kind core does not know
+      currentSchemaId: 'telemetry.v1',
+      versions: [
+        {
+          schemaId: 'telemetry.v1',
+          validate: (raw) =>
+            typeof (raw as Record<string, unknown>)?.['signal'] === 'string'
+              ? []
+              : ['telemetry.v1: signal is missing (required, non-empty string)'],
+          // Playbook-only shape; a real kind up-converts to its canonical doc.
+          upConvert: (raw) => raw as never,
+        },
+      ],
+      snapshotPathFor: (name) => `.dxkit/contrib/${name}.json`,
+    };
+    const registry = [...CONTRIBUTION_KINDS, synthetic];
+
+    const good = parseWireDoc('telemetry', { schema: 'telemetry.v1', signal: 'ok' }, registry);
+    expect(good.ok).toBe(true);
+
+    const bad = parseWireDoc('telemetry', { schema: 'telemetry.v1' }, registry);
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.errors[0]).toContain('signal');
+
+    // And the unknown-kind error now names the synthetic kind too — the
+    // "known kinds" list is registry-derived, not hardcoded.
+    const unknown = parseWireDoc('nope', {}, registry);
+    if (!unknown.ok) expect(unknown.errors[0]).toContain("'telemetry'");
+  });
+});

--- a/test/extensions/extension-findings.test.ts
+++ b/test/extensions/extension-findings.test.ts
@@ -126,7 +126,11 @@ describe('gatherExtensionFindings', () => {
 describe('the seam entry point folds extensions in', () => {
   it('gatherCustomCheckFindings returns extension findings with no checks configured', () => {
     writeExtension('perm-audit', 'block', [FINDING]);
-    const out = gatherCustomCheckFindings({ cwd: tmp, policy: DEFAULT_BROWNFIELD_POLICY, packs: [] });
+    const out = gatherCustomCheckFindings({
+      cwd: tmp,
+      policy: DEFAULT_BROWNFIELD_POLICY,
+      packs: [],
+    });
     expect(out).toHaveLength(1);
     expect(out[0].check).toBe('extension:perm-audit');
   });

--- a/test/extensions/extension-findings.test.ts
+++ b/test/extensions/extension-findings.test.ts
@@ -1,0 +1,161 @@
+/**
+ * findings.v1 → the custom-check seam (#11b lane 4b).
+ *
+ * Extension findings are the seam's third consumer: they enter through the
+ * ONE entry point (`gatherCustomCheckFindings`), so the baseline producer
+ * and the guardrail current scan see the identical set, and the located
+ * identity (check + file + lineWindow + rule) grandfathers pre-existing
+ * findings exactly as lint's does. Snapshot reads only — the gate stays
+ * offline; nothing here can execute an extension.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { gatherExtensionFindings } from '../../src/extensions/extension-findings';
+import { gatherCustomCheckFindings } from '../../src/analyzers/custom-checks/gather';
+import { DEFAULT_BROWNFIELD_POLICY } from '../../src/baseline/policy';
+import { identityFor } from '../../src/baseline/finding-identity';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-extf-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeExtension(
+  name: string,
+  gating: 'block' | 'warn' | 'off' | undefined,
+  findings: unknown[],
+): void {
+  const dir = path.join(tmp, '.dxkit/extensions', name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'extension.json'),
+    JSON.stringify({
+      schemaVersion: 1,
+      name,
+      contributes: 'findings',
+      run: { command: 'python3', args: ['x.py'] },
+      refresh: 'on-merge',
+      output: `.dxkit/contrib/${name}.json`,
+      ...(gating !== undefined ? { gating } : {}),
+    }),
+  );
+  const out = path.join(tmp, '.dxkit/contrib', `${name}.json`);
+  fs.mkdirSync(path.dirname(out), { recursive: true });
+  fs.writeFileSync(out, JSON.stringify({ schema: 'findings.v1', findings }));
+}
+
+const FINDING = {
+  rule: 'unguarded-permission',
+  message: 'screen lacks hasPermission()',
+  severity: 'high',
+  file: 'src/screens/Admin.jsx',
+  line: 12,
+};
+
+describe('gatherExtensionFindings', () => {
+  it('maps wire findings to located custom-check findings with gating', () => {
+    writeExtension('perm-audit', 'block', [FINDING]);
+    const out = gatherExtensionFindings(tmp);
+    expect(out).toEqual([
+      {
+        check: 'extension:perm-audit',
+        blocking: true,
+        file: 'src/screens/Admin.jsx',
+        line: 12,
+        rule: 'unguarded-permission',
+        message: '[high] screen lacks hasPermission()',
+      },
+    ]);
+  });
+
+  it("default gating is 'warn' (non-blocking); 'off' excludes the extension", () => {
+    writeExtension('warns', undefined, [FINDING]);
+    writeExtension('silent', 'off', [FINDING]);
+    const out = gatherExtensionFindings(tmp);
+    expect(out).toHaveLength(1);
+    expect(out[0].check).toBe('extension:warns');
+    expect(out[0].blocking).toBe(false);
+  });
+
+  it('a missing or invalid snapshot contributes nothing (doctor owns the disclosure)', () => {
+    const dir = path.join(tmp, '.dxkit/extensions/no-snap');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'extension.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        name: 'no-snap',
+        contributes: 'findings',
+        run: { command: 'python3' },
+        refresh: 'manual',
+        output: '.dxkit/contrib/no-snap.json',
+      }),
+    );
+    expect(gatherExtensionFindings(tmp)).toEqual([]);
+  });
+
+  it('non-findings extensions are ignored by this lane', () => {
+    const dir = path.join(tmp, '.dxkit/extensions/inv');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'extension.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        name: 'inv',
+        contributes: 'inventory',
+        run: { command: 'python3' },
+        refresh: 'manual',
+        output: '.dxkit/contrib/inv.json',
+      }),
+    );
+    fs.mkdirSync(path.join(tmp, '.dxkit/contrib'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.dxkit/contrib/inv.json'),
+      JSON.stringify({ schema: 'inventory.v1', entities: [] }),
+    );
+    expect(gatherExtensionFindings(tmp)).toEqual([]);
+  });
+});
+
+describe('the seam entry point folds extensions in', () => {
+  it('gatherCustomCheckFindings returns extension findings with no checks configured', () => {
+    writeExtension('perm-audit', 'block', [FINDING]);
+    const out = gatherCustomCheckFindings({ cwd: tmp, policy: DEFAULT_BROWNFIELD_POLICY, packs: [] });
+    expect(out).toHaveLength(1);
+    expect(out[0].check).toBe('extension:perm-audit');
+  });
+
+  it('located identity is stable across runs and distinct per rule', () => {
+    writeExtension('perm-audit', 'warn', [FINDING, { ...FINDING, rule: 'other-rule' }]);
+    const [a, b] = gatherExtensionFindings(tmp);
+    const idA = identityFor({
+      kind: 'custom-check',
+      check: a.check,
+      file: a.file,
+      line: a.line,
+      rule: a.rule,
+    });
+    const idA2 = identityFor({
+      kind: 'custom-check',
+      check: a.check,
+      file: a.file,
+      line: a.line,
+      rule: a.rule,
+    });
+    const idB = identityFor({
+      kind: 'custom-check',
+      check: b.check,
+      file: b.file,
+      line: b.line,
+      rule: b.rule,
+    });
+    expect(idA).toBe(idA2);
+    expect(idA).not.toBe(idB);
+  });
+});

--- a/test/extensions/extensions-cli.test.ts
+++ b/test/extensions/extensions-cli.test.ts
@@ -1,0 +1,164 @@
+/**
+ * `vyuh-dxkit extensions` CLI (#11b lane 5): init scaffolds a manifest that
+ * passes validation immediately, list surfaces snapshot health + manifest
+ * errors, dev/refresh run through the ONE runner (here with the real
+ * bounded exec against tiny node scripts — the cheapest real interpreter
+ * in this repo's test environment).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { runExtensionsCli } from '../../src/extensions-cli';
+import { discoverExtensions } from '../../src/extensions/manifest';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-ecli-'));
+  execFileSync('git', ['init', '-q'], { cwd: tmp });
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('extensions init', () => {
+  it('scaffolds a manifest + stub that pass discovery validation', () => {
+    const code = runExtensionsCli(tmp, 'init', 'ui-inventory', {
+      kind: 'inventory',
+      stub: true,
+    });
+    expect(code).toBe(0);
+    const { extensions, errors } = discoverExtensions(tmp);
+    expect(errors).toEqual([]);
+    expect(extensions).toHaveLength(1);
+    expect(extensions[0].manifest).toMatchObject({
+      name: 'ui-inventory',
+      contributes: 'inventory',
+      refresh: 'on-merge',
+      output: '.dxkit/contrib/ui-inventory.json',
+    });
+    expect(fs.existsSync(path.join(tmp, '.dxkit/extensions/ui-inventory/run.py'))).toBe(true);
+  });
+
+  it('findings kind gets the default warn gating in the scaffold', () => {
+    runExtensionsCli(tmp, 'init', 'perm-audit', {
+      kind: 'findings',
+      command: 'python3 tools/audit.py',
+    });
+    const { extensions } = discoverExtensions(tmp);
+    expect(extensions[0].manifest.gating).toBe('warn');
+    expect(extensions[0].manifest.run).toMatchObject({
+      command: 'python3',
+      args: ['tools/audit.py'],
+    });
+  });
+
+  it('rejects unknown kinds naming the registry set, and refuses to overwrite', () => {
+    expect(runExtensionsCli(tmp, 'init', 'x', { kind: 'telemetry', command: 'node x' })).toBe(1);
+    expect(runExtensionsCli(tmp, 'init', 'x', { kind: 'export', command: 'node x' })).toBe(0);
+    expect(runExtensionsCli(tmp, 'init', 'x', { kind: 'export', command: 'node x' })).toBe(1);
+  });
+});
+
+describe('extensions dev + refresh (real runner, node interpreter)', () => {
+  function writeNodeExtension(name: string, script: string): void {
+    const dir = path.join(tmp, '.dxkit/extensions', name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'extension.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        name,
+        contributes: 'inventory',
+        run: { command: 'node', args: [`.dxkit/extensions/${name}/run.js`], timeoutSeconds: 30 },
+        refresh: 'on-merge',
+        output: `.dxkit/contrib/${name}.json`,
+      }),
+    );
+    fs.writeFileSync(path.join(dir, 'run.js'), script);
+  }
+
+  it('dev: a valid emit reports ok and writes the stamped snapshot', () => {
+    writeNodeExtension(
+      'screens',
+      `process.stdout.write(JSON.stringify({
+         schema: 'inventory.v1',
+         entities: [{ kind: 'screen', name: 'Checkout' }],
+       }));`,
+    );
+    const code = runExtensionsCli(tmp, 'dev', 'screens', {});
+    expect(code).toBe(0);
+    const snap = JSON.parse(
+      fs.readFileSync(path.join(tmp, '.dxkit/contrib/screens.json'), 'utf8'),
+    ) as Record<string, unknown>;
+    expect(snap['schema']).toBe('inventory.v1');
+    expect(typeof snap['generatedAt']).toBe('string');
+  });
+
+  it('dev: an invalid emit exits 1 (field-precise errors are the loop)', () => {
+    writeNodeExtension(
+      'broken',
+      `process.stdout.write(JSON.stringify({ schema: 'inventory.v1', entities: [{ kind: 'k' }] }));`,
+    );
+    expect(runExtensionsCli(tmp, 'dev', 'broken', {})).toBe(1);
+  });
+
+  it('refresh: runs everything; list shows snapshot health', () => {
+    writeNodeExtension(
+      'screens',
+      `process.stdout.write(JSON.stringify({ schema: 'inventory.v1', entities: [] }));`,
+    );
+    expect(runExtensionsCli(tmp, 'refresh', undefined, {})).toBe(0);
+    expect(runExtensionsCli(tmp, 'list', undefined, {})).toBe(0);
+    expect(runExtensionsCli(tmp, 'refresh', 'nope', {})).toBe(1);
+  });
+
+  it('refresh --land with no substantive change lands nothing (restamp-only)', () => {
+    writeNodeExtension(
+      'screens',
+      `process.stdout.write(JSON.stringify({ schema: 'inventory.v1', entities: [] }));`,
+    );
+    // First refresh writes the snapshot; commit it so the second refresh's
+    // restamp is the only diff.
+    expect(runExtensionsCli(tmp, 'refresh', undefined, {})).toBe(0);
+    execFileSync('git', ['add', '-A'], { cwd: tmp });
+    execFileSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '-qm', 'snap'], {
+      cwd: tmp,
+    });
+    // --land push against a repo with no remote: the substance check must
+    // return false (generatedAt-only diff) BEFORE any push is attempted.
+    expect(runExtensionsCli(tmp, 'refresh', undefined, { land: 'push' })).toBe(0);
+    const status = execFileSync('git', ['status', '--porcelain'], {
+      cwd: tmp,
+      encoding: 'utf8',
+    }).trim();
+    expect(status).toBe('');
+  });
+});
+
+describe('onboarding integration (registry-derived probe + planner)', () => {
+  it('recommendExtensions + planFlowSources fire on undeclared artifacts, silent once declared', async () => {
+    const { recommendExtensions, planFlowSources } = await import('../../src/discovery/advisor');
+    fs.mkdirSync(path.join(tmp, 'pacts'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'pacts/web-api.json'), JSON.stringify({ interactions: [] }));
+    execFileSync('git', ['add', '-A'], { cwd: tmp });
+
+    const rec = recommendExtensions({ cwd: tmp });
+    expect(rec?.reason).toContain('pacts/web-api.json (pact)');
+    const plan = planFlowSources({ cwd: tmp });
+    expect(plan?.patch).toEqual({
+      flow: { sources: [{ kind: 'pact', path: 'pacts/web-api.json' }] },
+    });
+
+    // Declared → both go silent (a configured repo is never re-nagged).
+    fs.mkdirSync(path.join(tmp, '.dxkit'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.dxkit/policy.json'),
+      JSON.stringify({ flow: { sources: [{ kind: 'pact', path: 'pacts/web-api.json' }] } }),
+    );
+    expect(recommendExtensions({ cwd: tmp })).toBeNull();
+    expect(planFlowSources({ cwd: tmp })).toBeNull();
+  });
+});

--- a/test/extensions/inventory-trend.test.ts
+++ b/test/extensions/inventory-trend.test.ts
@@ -1,0 +1,109 @@
+/**
+ * inventory.v1 counts → the report-history trend (#11b lane 4c).
+ *
+ * The committed snapshot is the store (git history = the per-entity trend
+ * substrate); what rides report-history is the cheap aggregate: entity
+ * counts by kind, additive on the entry, invisible for repos without
+ * inventory extensions.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { gatherInventoryCounts } from '../../src/extensions/inventory';
+import { parseHistory, type ReportHistoryEntry } from '../../src/reports/history';
+import { renderHistoryMarkdown, renderTrendText } from '../../src/reports/render';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-inv-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeInventoryExtension(name: string, entities: unknown[]): void {
+  const dir = path.join(tmp, '.dxkit/extensions', name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'extension.json'),
+    JSON.stringify({
+      schemaVersion: 1,
+      name,
+      contributes: 'inventory',
+      run: { command: 'python3' },
+      refresh: 'on-merge',
+      output: `.dxkit/contrib/${name}.json`,
+    }),
+  );
+  const out = path.join(tmp, '.dxkit/contrib', `${name}.json`);
+  fs.mkdirSync(path.dirname(out), { recursive: true });
+  fs.writeFileSync(out, JSON.stringify({ schema: 'inventory.v1', entities }));
+}
+
+describe('gatherInventoryCounts', () => {
+  it('counts entities by kind per extension; undefined when none', () => {
+    expect(gatherInventoryCounts(tmp)).toBeUndefined();
+    writeInventoryExtension('ui-inventory', [
+      { kind: 'screen', name: 'A' },
+      { kind: 'screen', name: 'B' },
+      { kind: 'permission', name: 'admin.read' },
+    ]);
+    expect(gatherInventoryCounts(tmp)).toEqual({
+      'ui-inventory': { screen: 2, permission: 1 },
+    });
+  });
+});
+
+const SCORES = {
+  overall: 80,
+  security: 80,
+  quality: 80,
+  tests: 80,
+  documentation: 80,
+  maintainability: 80,
+  developerExperience: 80,
+};
+
+function entry(sha: string, inventory?: ReportHistoryEntry['inventory']): ReportHistoryEntry {
+  return {
+    sha,
+    date: '2026-07-11T00:00:00Z',
+    dxkitVersion: '3.5.0',
+    scores: SCORES,
+    ...(inventory ? { inventory } : {}),
+  };
+}
+
+describe('history entry + rendering', () => {
+  it('parseHistory round-trips the inventory field', () => {
+    const jsonl = [
+      JSON.stringify(entry('a'.repeat(40))),
+      JSON.stringify(entry('b'.repeat(40), { 'ui-inventory': { screen: 3 } })),
+    ].join('\n');
+    const parsed = parseHistory(jsonl);
+    expect(parsed[0].inventory).toBeUndefined();
+    expect(parsed[1].inventory).toEqual({ 'ui-inventory': { screen: 3 } });
+  });
+
+  it('renders counts with deltas vs the previous inventory-bearing entry', () => {
+    const entries = [
+      entry('a'.repeat(40), { 'ui-inventory': { screen: 210, permission: 890 } }),
+      entry('b'.repeat(40), { 'ui-inventory': { screen: 214, permission: 888 } }),
+    ];
+    const md = renderHistoryMarkdown(entries);
+    expect(md).toContain('| ui-inventory | screen | 214 | +4 |');
+    expect(md).toContain('| ui-inventory | permission | 888 | -2 |');
+    const text = renderTrendText(entries);
+    expect(text.join('\n')).toContain(
+      'inventory ui-inventory: permission 888 (-2) · screen 214 (+4)',
+    );
+  });
+
+  it('repos without inventory render nothing extra (zero bloat)', () => {
+    const entries = [entry('a'.repeat(40)), entry('b'.repeat(40))];
+    expect(renderHistoryMarkdown(entries)).not.toContain('Inventory');
+    expect(renderTrendText(entries).join('\n')).not.toContain('inventory');
+  });
+});

--- a/test/extensions/orchestrator.test.ts
+++ b/test/extensions/orchestrator.test.ts
@@ -195,6 +195,40 @@ describe('the ONE runner (policy matrix via injected exec)', () => {
   });
 });
 
+describe('export sinks (delivery payload + receipt)', () => {
+  it('the delivery document rides stdin and the receipt round-trips', () => {
+    writeManifest('influx-sink', {
+      schemaVersion: 1,
+      name: 'influx-sink',
+      contributes: 'export',
+      run: { command: 'python3', args: ['push.py'] },
+      refresh: 'manual',
+      output: '.dxkit/reports/export-influx-sink.json',
+    });
+    const r = discoverExtensions(tmp);
+    expect(r.errors).toEqual([]);
+    let seenDelivery: unknown;
+    const exec: CommandExec = (cmd) => {
+      seenDelivery = (JSON.parse(cmd.stdin ?? '{}') as { delivery?: unknown }).delivery;
+      return {
+        available: true,
+        code: 0,
+        output: JSON.stringify({ schema: 'export.v1', delivered: true, detail: '3 rows' }),
+      };
+    };
+    const out = runExtension(tmp, r.extensions[0], {
+      exec,
+      delivery: { overall: 81, sha: 'abc' },
+    });
+    expect(seenDelivery).toEqual({ overall: 81, sha: 'abc' });
+    expect(out.status).toBe('ok');
+    if (out.status === 'ok') {
+      expect(out.schemaId).toBe('export.v1');
+      expect(out.outputPath).toBe('.dxkit/reports/export-influx-sink.json');
+    }
+  });
+});
+
 describe('committed snapshots (the offline half)', () => {
   it('round-trips a runner-written snapshot with staleness age', () => {
     const exec: CommandExec = () => ({ available: true, code: 0, output: VALID_DOC });

--- a/test/extensions/orchestrator.test.ts
+++ b/test/extensions/orchestrator.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Extension orchestrator core: manifest discovery + the ONE runner +
+ * committed snapshots (#11b lane 2).
+ *
+ * The runner's policy matrix is exercised through an injected exec (the
+ * bounded-exec discipline — no real toolchain in unit tests): missing
+ * interpreter → skipped, timeout → skipped, non-zero exit → invalid,
+ * valid emit → ok + canonical stamped snapshot on disk. Manifest
+ * validation covers the three path-safety guards (argument injection,
+ * traversal, name aliasing) — the security posture is test-pinned, not
+ * prose.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { CommandExec } from '../../src/analyzers/tools/bounded-exec';
+import { discoverExtensions, type LoadedExtension } from '../../src/extensions/manifest';
+import { runExtension, type ExtensionStdinPayload } from '../../src/extensions/run';
+import { readExtensionSnapshot } from '../../src/extensions/snapshot';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-ext-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeManifest(name: string, manifest: Record<string, unknown>): void {
+  const dir = path.join(tmp, '.dxkit/extensions', name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'extension.json'), JSON.stringify(manifest, null, 2));
+}
+
+const GOOD = {
+  schemaVersion: 1,
+  name: 'ui-inventory',
+  contributes: 'inventory',
+  run: { command: 'python3', args: ['tools/extract.py'], timeoutSeconds: 60 },
+  refresh: 'on-merge',
+  output: '.dxkit/contrib/ui-inventory.json',
+};
+
+describe('manifest discovery', () => {
+  it('returns nothing quietly when no extensions dir exists', () => {
+    const r = discoverExtensions(tmp);
+    expect(r.extensions).toEqual([]);
+    expect(r.errors).toEqual([]);
+  });
+
+  it('loads a valid manifest with its committed config block', () => {
+    writeManifest('ui-inventory', { ...GOOD, config: { screensDir: 'src/screens' } });
+    const r = discoverExtensions(tmp);
+    expect(r.errors).toEqual([]);
+    expect(r.extensions).toHaveLength(1);
+    expect(r.extensions[0].manifest.name).toBe('ui-inventory');
+    expect(r.extensions[0].config).toEqual({ screensDir: 'src/screens' });
+    expect(r.extensions[0].dir).toBe('.dxkit/extensions/ui-inventory');
+  });
+
+  it('a broken manifest is reported and never hides healthy siblings', () => {
+    writeManifest('ui-inventory', GOOD);
+    writeManifest('broken', { schemaVersion: 1 });
+    const r = discoverExtensions(tmp);
+    expect(r.extensions).toHaveLength(1);
+    expect(r.errors.length).toBeGreaterThan(0);
+    expect(r.errors[0]).toContain('.dxkit/extensions/broken/extension.json');
+  });
+
+  it('rejects argument injection, path traversal, and name aliasing', () => {
+    writeManifest('inj', { ...GOOD, name: 'inj', run: { command: '--rm-rf' } });
+    writeManifest('trav', { ...GOOD, name: 'trav', output: '../../etc/cron.json' });
+    writeManifest('abs', { ...GOOD, name: 'abs', output: '/etc/cron.json' });
+    writeManifest('alias', { ...GOOD, name: 'other-name' });
+    const r = discoverExtensions(tmp);
+    expect(r.extensions).toEqual([]);
+    expect(r.errors).toContainEqual(expect.stringContaining('run.command'));
+    expect(r.errors.filter((e) => e.includes('output')).length).toBeGreaterThanOrEqual(2);
+    expect(r.errors).toContainEqual(
+      expect.stringContaining('must equal the extension directory name'),
+    );
+  });
+
+  it('rejects an unknown contribution kind naming the known set', () => {
+    writeManifest('bad-kind', { ...GOOD, name: 'bad-kind', contributes: 'telemetry' });
+    const r = discoverExtensions(tmp);
+    expect(r.errors[0]).toContain("'contract' | 'inventory' | 'findings' | 'export'");
+  });
+});
+
+function loaded(): LoadedExtension {
+  writeManifest('ui-inventory', { ...GOOD, config: { a: 1 } });
+  const r = discoverExtensions(tmp);
+  expect(r.errors).toEqual([]);
+  return r.extensions[0];
+}
+
+const VALID_DOC = JSON.stringify({
+  schema: 'inventory.v1',
+  entities: [{ kind: 'screen', name: 'Checkout' }],
+});
+
+describe('the ONE runner (policy matrix via injected exec)', () => {
+  it('missing interpreter → disclosed skip', () => {
+    const exec: CommandExec = () => ({ available: false, code: -1, output: '' });
+    const r = runExtension(tmp, loaded(), { exec });
+    expect(r).toEqual({ status: 'skipped', reason: "interpreter 'python3' not found" });
+  });
+
+  it('timeout → disclosed skip naming the budget', () => {
+    const exec: CommandExec = () => ({ available: true, timedOut: true, code: -1, output: '' });
+    const r = runExtension(tmp, loaded(), { exec });
+    expect(r.status).toBe('skipped');
+    if (r.status === 'skipped') expect(r.reason).toContain('60s');
+  });
+
+  it('non-zero exit → invalid with the output tail disclosed', () => {
+    const exec: CommandExec = () => ({ available: true, code: 3, output: 'Traceback: boom' });
+    const r = runExtension(tmp, loaded(), { exec });
+    expect(r.status).toBe('invalid');
+    if (r.status === 'invalid') {
+      expect(r.errors[0]).toContain('exited 3');
+      expect(r.errors[0]).toContain('boom');
+    }
+  });
+
+  it('stdin payload carries the config block and canonical repo facts', () => {
+    let seen: ExtensionStdinPayload | undefined;
+    const exec: CommandExec = (cmd) => {
+      seen = JSON.parse(cmd.stdin ?? '{}') as ExtensionStdinPayload;
+      return { available: true, code: 0, output: VALID_DOC };
+    };
+    runExtension(tmp, loaded(), {
+      exec,
+      excludeDirs: ['node_modules', 'dist'],
+      activeLanguages: ['python'],
+    });
+    expect(seen?.payloadVersion).toBe(1);
+    expect(seen?.extension).toEqual({ name: 'ui-inventory', contributes: 'inventory' });
+    expect(seen?.config).toEqual({ a: 1 });
+    expect(seen?.repo.excludeDirs).toEqual(['node_modules', 'dist']);
+    expect(seen?.repo.activeLanguages).toEqual(['python']);
+  });
+
+  it('valid stdout emit → ok + stamped canonical snapshot on disk', () => {
+    const exec: CommandExec = () => ({ available: true, code: 0, output: VALID_DOC });
+    const now = () => new Date('2026-07-11T12:00:00Z');
+    const r = runExtension(tmp, loaded(), { exec, now });
+    expect(r.status).toBe('ok');
+    const onDisk = JSON.parse(
+      fs.readFileSync(path.join(tmp, '.dxkit/contrib/ui-inventory.json'), 'utf-8'),
+    ) as Record<string, unknown>;
+    expect(onDisk['schema']).toBe('inventory.v1');
+    expect(onDisk['generatedAt']).toBe('2026-07-11T12:00:00.000Z');
+  });
+
+  it('output-file emit wins over stdout, and a stale file never counts as this run', () => {
+    const outAbs = path.join(tmp, '.dxkit/contrib/ui-inventory.json');
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, JSON.stringify({ schema: 'inventory.v1', entities: [] }));
+    // The exec does NOT rewrite the file → the runner must not read the
+    // stale pre-run file; with empty stdout the emit is missing.
+    const exec: CommandExec = () => ({ available: true, code: 0, output: '' });
+    const r = runExtension(tmp, loaded(), { exec });
+    expect(r.status).toBe('invalid');
+    if (r.status === 'invalid') expect(r.errors[0]).toContain('neither its output file');
+    // Now an exec that writes the file during the run:
+    const writingExec: CommandExec = () => {
+      fs.writeFileSync(
+        outAbs,
+        JSON.stringify({ schema: 'inventory.v1', entities: [{ kind: 'k', name: 'FromFile' }] }),
+      );
+      return { available: true, code: 0, output: VALID_DOC };
+    };
+    const r2 = runExtension(tmp, loaded(), { exec: writingExec });
+    expect(r2.status).toBe('ok');
+    if (r2.status === 'ok') {
+      expect(JSON.stringify(r2.doc)).toContain('FromFile');
+    }
+  });
+
+  it('invalid emit → the field-precise wire errors surface verbatim', () => {
+    const exec: CommandExec = () => ({
+      available: true,
+      code: 0,
+      output: JSON.stringify({ schema: 'inventory.v1', entities: [{ kind: 'screen' }] }),
+    });
+    const r = runExtension(tmp, loaded(), { exec });
+    expect(r.status).toBe('invalid');
+    if (r.status === 'invalid') {
+      expect(r.errors).toContainEqual(expect.stringContaining('entities[0].name'));
+    }
+  });
+});
+
+describe('committed snapshots (the offline half)', () => {
+  it('round-trips a runner-written snapshot with staleness age', () => {
+    const exec: CommandExec = () => ({ available: true, code: 0, output: VALID_DOC });
+    const ext = loaded();
+    runExtension(tmp, ext, { exec, now: () => new Date('2026-07-01T00:00:00Z') });
+    const snap = readExtensionSnapshot(tmp, ext, () => new Date('2026-07-11T00:00:00Z'));
+    expect(snap.status).toBe('ok');
+    if (snap.status === 'ok') {
+      expect(snap.schemaId).toBe('inventory.v1');
+      expect(snap.ageDays).toBe(10);
+    }
+  });
+
+  it('missing snapshot is a disclosed state naming the expected path', () => {
+    const snap = readExtensionSnapshot(tmp, loaded());
+    expect(snap).toEqual({ status: 'missing', outputPath: '.dxkit/contrib/ui-inventory.json' });
+  });
+
+  it('a hand-edited invalid snapshot is disclosed with wire errors', () => {
+    const ext = loaded();
+    const outAbs = path.join(tmp, ext.manifest.output);
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, JSON.stringify({ schema: 'inventory.v1' }));
+    const snap = readExtensionSnapshot(tmp, ext);
+    expect(snap.status).toBe('invalid');
+  });
+});

--- a/test/flow-config.test.ts
+++ b/test/flow-config.test.ts
@@ -25,6 +25,7 @@ describe('readFlowConfig', () => {
         mode: 'block',
         blockThreshold: 1,
         onMergeRefresh: false,
+        sources: [],
         refreshMode: 'pr',
       });
     } finally {
@@ -55,6 +56,27 @@ describe('readFlowConfig', () => {
     }
   });
 
+  it('reads flow.sources entries, dropping malformed ones (registry validates kinds later)', () => {
+    const dir = repoWith({
+      flow: {
+        sources: [
+          { kind: 'postman', path: 'col.json', side: 'consumed' },
+          { kind: 'har', path: 'session.har' },
+          { path: 'missing-kind.json' },
+          'not-an-object',
+        ],
+      },
+    });
+    try {
+      expect(readFlowConfig(dir).sources).toEqual([
+        { kind: 'postman', path: 'col.json', side: 'consumed' },
+        { kind: 'har', path: 'session.har' },
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('reads a full flow section', () => {
     const dir = repoWith({
       flow: {
@@ -71,6 +93,7 @@ describe('readFlowConfig', () => {
         mode: 'warn',
         blockThreshold: 0.5,
         onMergeRefresh: false,
+        sources: [],
         refreshMode: 'pr',
       });
     } finally {

--- a/test/flow-contract-sources.test.ts
+++ b/test/flow-contract-sources.test.ts
@@ -1,0 +1,238 @@
+/**
+ * CONTRACT_SOURCE_READERS — declared contract artifacts (#11b lane 3).
+ *
+ * Layers: per-reader parsing fixtures (each format's canonical shape and
+ * its failure modes), the registry contract, central-load behavior
+ * (side legality, glob expansion, external-URL disclosure, provenance),
+ * and the synthetic-reader playbook proving a new format is one registry
+ * entry (mirror of recipe-playbook — the check that the architecture
+ * stayed registry-driven).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  CONTRACT_SOURCE_READERS,
+  contractSourceReaderFor,
+  loadContractSources,
+  type ContractSourceReader,
+} from '../src/analyzers/flow/contract-sources';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-src-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function write(rel: string, content: unknown): void {
+  const abs = path.join(tmp, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, typeof content === 'string' ? content : JSON.stringify(content));
+}
+
+describe('registry contract', () => {
+  it('kinds are unique and defaultSide is always legal', () => {
+    const kinds = CONTRACT_SOURCE_READERS.map((r) => r.kind);
+    expect(new Set(kinds).size).toBe(kinds.length);
+    for (const r of CONTRACT_SOURCE_READERS) {
+      if (r.sides !== 'both') expect(r.defaultSide).toBe(r.sides);
+      expect(typeof r.sniff('anything')).toBe('boolean');
+    }
+  });
+
+  it('ships the five launch formats', () => {
+    expect(CONTRACT_SOURCE_READERS.map((r) => r.kind).sort()).toEqual([
+      'har',
+      'http',
+      'openapi',
+      'pact',
+      'postman',
+    ]);
+  });
+});
+
+describe('postman reader', () => {
+  it('walks nested folders and both url forms; {{vars}} become {var}', () => {
+    write('col.json', {
+      info: { name: 'c' },
+      item: [
+        {
+          name: 'folder',
+          item: [
+            { name: 'r1', request: { method: 'POST', url: '{{base}}/articles/{{slug}}' } },
+            { name: 'r2', request: { method: 'GET', url: { raw: '/tags' } } },
+          ],
+        },
+        { name: 'r3', request: { method: 'DELETE', url: { path: ['articles', ':id'] } } },
+      ],
+    });
+    const r = loadContractSources(tmp, [{ kind: 'postman', path: 'col.json' }], {});
+    expect(r.disclosures).toEqual([]);
+    const keys = r.calls.map((c) => `${c.method} ${c.path}`).sort();
+    expect(keys).toEqual(['DELETE /articles/{var}', 'GET /tags', 'POST /{var}/articles/{var}']);
+    expect(r.calls.every((c) => c.receiver === 'postman')).toBe(true);
+  });
+
+  it("side: 'served' reads the collection as the repo's own API", () => {
+    write('col.json', {
+      item: [{ request: { method: 'GET', url: '/things/:id' } }],
+    });
+    const r = loadContractSources(tmp, [{ kind: 'postman', path: 'col.json', side: 'served' }], {});
+    expect(r.calls).toEqual([]);
+    expect(r.routes).toHaveLength(1);
+    expect(r.routes[0]).toMatchObject({ method: 'GET', path: '/things/{var}', via: 'postman' });
+  });
+
+  it('a non-collection is a disclosed parse error', () => {
+    write('col.json', { nope: true });
+    const r = loadContractSources(tmp, [{ kind: 'postman', path: 'col.json' }], {});
+    expect(r.disclosures[0]).toContain('not a Postman collection');
+  });
+});
+
+describe('pact reader', () => {
+  it('interactions become consumed calls; served declaration is refused', () => {
+    write('pacts/web-api.json', {
+      consumer: { name: 'web' },
+      provider: { name: 'api' },
+      interactions: [
+        { description: 'list', request: { method: 'GET', path: '/articles' } },
+        { description: 'del', request: { method: 'DELETE', path: '/articles/1' } },
+      ],
+    });
+    const ok = loadContractSources(tmp, [{ kind: 'pact', path: 'pacts/web-api.json' }], {});
+    expect(ok.calls.map((c) => `${c.method} ${c.path}`)).toEqual([
+      'GET /articles',
+      'DELETE /articles/1',
+    ]);
+    const refused = loadContractSources(
+      tmp,
+      [{ kind: 'pact', path: 'pacts/web-api.json', side: 'served' }],
+      {},
+    );
+    expect(refused.routes).toEqual([]);
+    expect(refused.disclosures[0]).toContain("'consumed' side only");
+  });
+});
+
+describe('.http reader', () => {
+  it('parses request lines with REAL line numbers, ignoring comments/bodies', () => {
+    write(
+      'requests/checkout.http',
+      [
+        '### create',
+        'POST {{host}}/api/orders HTTP/1.1',
+        'Content-Type: application/json',
+        '',
+        '{"total": 1}',
+        '',
+        '### fetch',
+        'GET /api/orders/42',
+      ].join('\n'),
+    );
+    const r = loadContractSources(tmp, [{ kind: 'http', path: 'requests/*.http' }], {});
+    expect(r.calls).toHaveLength(2);
+    expect(r.calls[0]).toMatchObject({ method: 'POST', path: '/{var}/api/orders', line: 2 });
+    expect(r.calls[1]).toMatchObject({ method: 'GET', path: '/api/orders/42', line: 8 });
+  });
+
+  it('glob expansion is basename-only and misses are disclosed', () => {
+    write('requests/a.http', 'GET /a');
+    write('requests/b.http', 'GET /b');
+    write('requests/deep/c.http', 'GET /c');
+    const r = loadContractSources(tmp, [{ kind: 'http', path: 'requests/*.http' }], {});
+    expect(r.calls.map((c) => c.path).sort()).toEqual(['/a', '/b']);
+    const miss = loadContractSources(tmp, [{ kind: 'http', path: 'nowhere/*.http' }], {});
+    expect(miss.disclosures[0]).toContain("no file matches 'nowhere/*.http'");
+  });
+});
+
+describe('har reader', () => {
+  it('own-host entries join via stripUrlPrefixes; externals are counted, not silent', () => {
+    write('session.har', {
+      log: {
+        entries: [
+          { request: { method: 'GET', url: 'https://api.example.com/articles?page=2' } },
+          { request: { method: 'POST', url: 'https://api.example.com/articles' } },
+          { request: { method: 'GET', url: 'https://analytics.vendor.io/beacon' } },
+        ],
+      },
+    });
+    const r = loadContractSources(tmp, [{ kind: 'har', path: 'session.har' }], {
+      stripUrlPrefixes: ['https://api.example.com'],
+    });
+    expect(r.calls.map((c) => `${c.method} ${c.path}`)).toEqual([
+      'GET /articles',
+      'POST /articles',
+    ]);
+    expect(r.disclosures).toHaveLength(1);
+    expect(r.disclosures[0]).toContain('1 entry dropped');
+    expect(r.disclosures[0]).toContain('flow.stripUrlPrefixes');
+  });
+});
+
+describe('openapi registry entry', () => {
+  it('serves routes with via openapi through the same central load', () => {
+    write('api/openapi.json', {
+      openapi: '3.0.0',
+      paths: {
+        '/articles/{slug}': { get: { operationId: 'getArticle' }, parameters: [] },
+      },
+    });
+    const r = loadContractSources(tmp, [{ kind: 'openapi', path: 'api/openapi.json' }], {});
+    expect(r.routes).toHaveLength(1);
+    expect(r.routes[0]).toMatchObject({
+      method: 'GET',
+      path: '/articles/{var}',
+      handler: 'getArticle',
+      via: 'openapi',
+    });
+  });
+});
+
+describe('central-load discipline', () => {
+  it('unknown kind is a loud disclosure naming the known kinds', () => {
+    const r = loadContractSources(tmp, [{ kind: 'wsdl', path: 'x.wsdl' }], {});
+    expect(r.disclosures[0]).toContain("unknown kind 'wsdl'");
+    for (const k of ['openapi', 'postman', 'pact', 'http', 'har']) {
+      expect(r.disclosures[0]).toContain(`'${k}'`);
+    }
+  });
+
+  it('an invalid side value is disclosed and the entry skipped', () => {
+    write('col.json', { item: [] });
+    const r = loadContractSources(tmp, [{ kind: 'postman', path: 'col.json', side: 'both' }], {});
+    expect(r.disclosures[0]).toContain("side must be 'consumed' or 'served'");
+  });
+});
+
+describe('synthetic-reader playbook (formats stay registry entries)', () => {
+  it('an injected format flows through load, provenance, and the known-kind list', () => {
+    const wsdl: ContractSourceReader = {
+      kind: 'wsdl',
+      displayName: 'WSDL document',
+      sides: 'served',
+      defaultSide: 'served',
+      sniff: (p) => p.endsWith('.wsdl'),
+      parse: (_content, filePath) => ({
+        consumed: [],
+        served: [{ method: 'POST', path: '/soap/checkout', file: filePath, line: 0 }],
+        errors: [],
+      }),
+    };
+    const registry = [...CONTRACT_SOURCE_READERS, wsdl];
+    write('svc.wsdl', '<definitions/>');
+
+    const r = loadContractSources(tmp, [{ kind: 'wsdl', path: 'svc.wsdl' }], {}, registry);
+    expect(r.routes).toHaveLength(1);
+    expect(r.routes[0]).toMatchObject({ method: 'POST', path: '/soap/checkout', via: 'wsdl' });
+
+    expect(contractSourceReaderFor('wsdl', registry)).toBe(wsdl);
+    const unknown = loadContractSources(tmp, [{ kind: 'nope', path: 'x' }], {}, registry);
+    expect(unknown.disclosures[0]).toContain("'wsdl'");
+  });
+});

--- a/test/flow-gate-join-parity.test.ts
+++ b/test/flow-gate-join-parity.test.ts
@@ -130,6 +130,26 @@ const FIXTURES: { name: string; calls: Keyed[]; routes: Keyed[] }[] = [
     calls: ['POST /a', 'POST /b', 'GET /a'],
     routes: ['GET /a', 'ANY /b'],
   },
+  {
+    name: 'var routes resolve concrete calls (pact/HAR artifact paths)',
+    calls: ['/articles/1', '/articles/1/comments', '/typo/9/x'],
+    routes: ['/articles/{var}', '/articles/{var}/comments'],
+  },
+  {
+    name: 'var-route specificity: literals beat params, exact beats var',
+    calls: ['/a/b', '/a/c', 'GET /a/b/c'],
+    routes: ['/a/b', '/a/{var}', '/a/{var}/c'],
+  },
+  {
+    name: 'method-agnostic var route serves every verb on the shape',
+    calls: ['DELETE /users/42', 'PATCH /users/42/roles', 'GET /users'],
+    routes: ['ANY /users/{var}', 'ANY /users/{var}/roles'],
+  },
+  {
+    name: 'a var route never absorbs a different segment COUNT',
+    calls: ['/things/1/extra', '/things'],
+    routes: ['/things/{var}'],
+  },
 ];
 
 describe('gate ↔ join resolution parity (catch-all regression net)', () => {

--- a/test/flow-land.test.ts
+++ b/test/flow-land.test.ts
@@ -152,7 +152,7 @@ describe('landFlowRefresh (real git)', () => {
           if (args[1] === 'create') return 'https://github.com/o/r/pull/7\n';
           return '';
         }
-        return real(cmd, args);
+        return real(cmd, [...args]);
       },
     });
     expect(out.outcome).toBe('pr-opened');
@@ -171,7 +171,7 @@ describe('landFlowRefresh (real git)', () => {
           if (args[1] === 'list') return '[{"url":"https://github.com/o/r/pull/7"}]';
           return '';
         }
-        return real(cmd, args);
+        return real(cmd, [...args]);
       },
     });
     expect(out.outcome).toBe('pr-updated');

--- a/test/flow-sources-e2e.test.ts
+++ b/test/flow-sources-e2e.test.ts
@@ -1,0 +1,80 @@
+/**
+ * flow.sources end-to-end: declared artifacts join the flow model through
+ * the ONE canonical gather (`gatherRepoFlowModel` reads policy itself —
+ * Rule 2), disclosures ride the model, and the gate's incremental skip
+ * treats artifact paths as flow surface.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { gatherRepoFlowModel } from '../src/analyzers/flow/gather';
+import { changedFilesTouchFlowSurface } from '../src/languages';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-fsrc-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function write(rel: string, content: unknown): void {
+  const abs = path.join(tmp, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, typeof content === 'string' ? content : JSON.stringify(content));
+}
+
+describe('flow.sources through the canonical repo gather', () => {
+  it('a pact-declared call binds against a postman-served route', async () => {
+    write('.dxkit/policy.json', {
+      flow: {
+        sources: [
+          { kind: 'pact', path: 'pacts/web-api.json' },
+          { kind: 'postman', path: 'api-docs.json', side: 'served' },
+        ],
+      },
+    });
+    write('pacts/web-api.json', {
+      interactions: [
+        { request: { method: 'GET', path: '/articles/1' } },
+        { request: { method: 'GET', path: '/missing' } },
+      ],
+    });
+    write('api-docs.json', {
+      item: [{ request: { method: 'GET', url: '/articles/:id' } }],
+    });
+
+    const model = await gatherRepoFlowModel(tmp);
+    expect(model.calls).toHaveLength(2);
+    expect(model.routes).toHaveLength(1);
+    const bound = model.bindings.filter((b) => b.route !== null);
+    const unbound = model.bindings.filter((b) => b.route === null);
+    expect(bound).toHaveLength(1);
+    expect(bound[0].call.path).toBe('/articles/1');
+    expect(bound[0].route?.via).toBe('postman');
+    expect(unbound).toHaveLength(1);
+    expect(unbound[0].call.path).toBe('/missing');
+    expect(model.sourceDisclosures).toBeUndefined();
+  });
+
+  it('source problems are disclosed on the model, never thrown', async () => {
+    write('.dxkit/policy.json', {
+      flow: { sources: [{ kind: 'pact', path: 'pacts/nope.json' }] },
+    });
+    const model = await gatherRepoFlowModel(tmp);
+    expect(model.sourceDisclosures).toHaveLength(1);
+    expect(model.sourceDisclosures?.[0]).toContain("cannot read 'pacts/nope.json'");
+  });
+});
+
+describe('the incremental gate skip treats artifacts as flow surface', () => {
+  it('exact paths and basename globs match; unrelated files do not', () => {
+    const sources = ['pacts/web-api.json', 'requests/*.http'];
+    expect(changedFilesTouchFlowSurface(['pacts/web-api.json'], [], [], sources)).toBe(true);
+    expect(changedFilesTouchFlowSurface(['requests/checkout.http'], [], [], sources)).toBe(true);
+    expect(changedFilesTouchFlowSurface(['requests/deep/c.http'], [], [], sources)).toBe(false);
+    expect(changedFilesTouchFlowSurface(['README.md'], [], [], sources)).toBe(false);
+  });
+});

--- a/test/managed-artifacts-playbook.test.ts
+++ b/test/managed-artifacts-playbook.test.ts
@@ -39,6 +39,7 @@ const ALL_OFF: ManifestInstallFlags = {
   withGraphRefresh: false,
   withReportsRefresh: false,
   withFlowRefresh: false,
+  withExtensionsRefresh: false,
 };
 
 const SENTINEL_ARTIFACT = '.dxkit-synthetic-surface-sentinel';


### PR DESCRIPTION
## #11b — the extension runtime

Builds on the #11a freeze (merged). Eleven commits, each independently meaningful — recommend rebase-merge into `release/3.5`.

### Rung 2 — declared contract artifacts
- `CONTRACT_SOURCE_READERS` registry: openapi, postman, pact, `.http`/`.rest`, har — one module + one entry per format; synthetic-reader playbook + an arch tripwire confining format literals to the registry directory.
- `flow.sources` joins artifacts through the canonical gather, the two-ref gate (base side reads artifacts AT the ref — honest grandfathering), and the map CLI; artifact-only PRs no longer skip the gate.
- The join learned var-segment resolution (`/articles/{var}` covers a concrete `/articles/1`) symmetrically in both halves of the gate/join parity pair — artifact calls always carry concrete paths. Strictly recall-additive; four new parity fixtures. The shared normalizer learned the `{{var}}` mustache form.

### Rung 3 — the orchestrator
- `CONTRIBUTION_KINDS` registry + field-precise wire validators (errors are the docs; bounded; forward-tolerant; shipped versions read forever).
- Manifest discovery with test-pinned security guards (argument-injection, traversal, aliasing bans); the ONE arch-gated runner (stdin carries the committed config + canonical repo facts; fail-open on infrastructure); committed snapshots ARE the wire format with staleness disclosed — gates never execute extensions.
- Consumer wiring: findings.v1 gates net-new-only as the custom-check seam's third consumer (manifest `gating: block|warn|off`); inventory entity counts trend on report history (invisible for repos without extensions); export sinks receive the post-run report on stdin and return a validated receipt.

### The user surface
- `extensions` CLI: `list` (snapshot health), `refresh [--land pr|push]` (generatedAt-aware substance check — a restamp never lands a commit), `dev` (seconds-fast authoring loop), `init` (scaffold that passes validation immediately). Rule-16 registered + `dxkit-extensions` skill shipped on init.
- Onboarding integrated: doctor probe + deterministic `configure` planner discover undeclared artifacts via the reader registry's own sniff predicates and propose `flow.sources` entries.
- On-merge refresh workflow as a `MANAGED_SHIP_SURFACES` entry (auto-enabled when a manifest declares `refresh: "on-merge"`); landing mechanics extracted to one generic lander that flow's land.ts now delegates to (flow-land tests unchanged).

### Validation state
Full suite 3649 green; all gates pass; pre-push coverage above threshold. **This PR does NOT complete 3.5**: the lane-6 validation battery (the platform customer's real Python extractors as rung-3 extensions, mutation/FP-hunt on findings gating, e2e both base-ref modes, scale + 3.4-regression) and #11c remain before any release, per the standing hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Gics1xyFkuYmNvpE4mdfQ