### PR TITLE
3.6 follow-ups: publish verify window, registry-generated docs command table, js-yaml bump

### DIFF
--- a/.github/workflows/publish-dxkit-sdk.yml
+++ b/.github/workflows/publish-dxkit-sdk.yml
@@ -190,19 +190,20 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public "${{ steps.pack.outputs.tarball }}"
 
-      # Poll loop: up to 60 iterations × 3s = ~180s window. First-publish of
-      # a new scoped package commonly takes 30-90s for the CDN to propagate
-      # (learned on create-dxkit@0.1.0, whose publish registered as workflow
-      # "failure" on a short window even though it succeeded).
+      # Poll loop: up to 90 iterations × 10s = ~15min window. First-publish of
+      # a new scoped package can take several minutes for the registry to make
+      # the name readable — dxkit-sdk@0.1.0 itself took ~10 minutes and its
+      # publish registered as a workflow "failure" on the old ~180s window even
+      # though it succeeded (same lesson first learned on create-dxkit@0.1.0).
       - name: Verify npm shasum matches local tarball
         if: steps.ctx.outputs.skip != 'true'
         run: |
           VERSION="${{ steps.ctx.outputs.version }}"
           REMOTE_SHASUM=""
-          for i in $(seq 1 60); do
+          for i in $(seq 1 90); do
             REMOTE_SHASUM=$(npm view "@vyuhlabs/dxkit-sdk@${VERSION}" dist.shasum 2>/dev/null || true)
             if [ -n "$REMOTE_SHASUM" ]; then break; fi
-            sleep 3
+            sleep 10
           done
           LOCAL_SHASUM="${{ steps.pack.outputs.shasum }}"
           if [ -z "$REMOTE_SHASUM" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,19 +127,20 @@ jobs:
       # A mismatch means something replaced the tarball mid-publish or
       # the registry accepted a different file; bail loudly.
       #
-      # Poll loop: up to 60 iterations × 3s = ~180s window. First-publish
-      # of a new scoped package commonly takes 30-90s for the CDN to
-      # propagate; both 2.5.1 publishes registered as workflow "failure"
-      # on the old 6-iteration / 18s window even though the publish
-      # actually succeeded. Hence the wider tolerance.
+      # Poll loop: up to 90 iterations × 10s = ~15min window. Registry
+      # visibility after a publish is unbounded in practice: both 2.5.1
+      # publishes registered as workflow "failure" on an 18s window, and
+      # dxkit-sdk@0.1.0 (a first-ever name) took ~10 minutes to become
+      # readable. The wide window keeps a slow-but-successful publish from
+      # reading as a failed release.
       - name: Verify npm shasum matches local tarball
         run: |
           VERSION=$(node -p "require('./package.json').version")
           REMOTE_SHASUM=""
-          for i in $(seq 1 60); do
+          for i in $(seq 1 90); do
             REMOTE_SHASUM=$(npm view "@vyuhlabs/dxkit@${VERSION}" dist.shasum 2>/dev/null || true)
             if [ -n "$REMOTE_SHASUM" ]; then break; fi
-            sleep 3
+            sleep 10
           done
           LOCAL_SHASUM="${{ steps.pack.outputs.shasum }}"
           if [ -z "$REMOTE_SHASUM" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **The docs command table is generated from the capability registry.**
+  `docs/README.md`'s "What you can run" table is now rendered from the
+  Rule-16 command registry between marker comments (`npm run docs:commands`
+  rewrites it; a parity test pins the committed table against the
+  registry), so a new command cannot ship without its docs row. The
+  hand-maintained table had silently lost `tests`, `hooks`, `checks`, and
+  `demo` across waves — that drift class is closed. Each command's typical
+  runtime now lives on its registry descriptor.
+
+### Fixed
+
+- **Publish verification waits out slow npm visibility.** Both publish
+  workflows verify the registry shasum on a ~15-minute window (was ~3
+  minutes): a first-ever package name can take ~10 minutes to become
+  readable after publish, which made a successful release read as a
+  workflow failure.
+
 ## [3.5.0] - 2026-07-11
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,46 +45,56 @@ to re-activate manually: `vyuh-dxkit hooks activate`.
 
 ## What you can run
 
-Once dxkit + its tools are installed, here's the command surface:
+Once dxkit + its tools are installed, here's the command surface. This
+table is generated from the capability registry, so it is complete by
+construction; commands with a linked page have a full reference under
+`docs/commands/`.
 
-| Command                                                          | Question it answers                                                | Typical runtime                    |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------- |
-| [`health`](commands/health.md)                                   | "What's the overall shape of this codebase?"                       | 1-4 min                            |
-| [`vulnerabilities`](commands/vulnerabilities.md)                 | "What security issues are there?"                                  | 1-3 min                            |
-| [`test-gaps`](commands/test-gaps.md)                             | "Which untested files are riskiest?"                               | 30-90 sec                          |
-| [`quality`](commands/quality.md)                                 | "Where's the technical debt + duplication?"                        | 1-8 min (jscpd is the long-pole)   |
-| [`dev-report`](commands/dev-report.md)                           | "Who's working on what, where are the hot files?"                  | 5-30 sec                           |
-| [`licenses`](commands/licenses.md)                               | "What licenses are in my dependency tree?"                         | 30-60 sec                          |
-| [`bom`](commands/bom.md)                                         | "Full dependency × license × CVE × upgrade view"                   | 1-3 min                            |
-| [`coverage`](commands/coverage.md)                               | "Materialize real line-coverage data"                              | varies (runs your tests)           |
-| [`dashboard`](commands/dashboard.md)                             | "Single HTML view of everything I've run"                          | < 5 sec (renders existing reports) |
-| [`explore`](commands/explore.md)                                 | "What does this repo do / where does X live?"                      | < 5 sec (queries the graph)        |
-| [`context`](commands/context.md)                                 | "Token-budgeted structural slice for an LLM"                       | < 5 sec (queries the graph)        |
-| [`report`](commands/report.md)                                   | "Run all of the above in one shot" (+ `report history` trend)      | 5-30 min                           |
-| `metrics`                                                        | "What did the gate stop before merge, and how's the score trend?"  | < 5 sec                            |
-| `flow`                                                           | "Which client calls bind to which served routes?"                  | 5-30 sec                           |
-| `schema` / `schema diff`                                         | "What data models do we declare / does my change break one?"       | 5-30 sec                           |
-| `capabilities`                                                   | "What can dxkit do here, and what should this repo adopt?"         | < 5 sec                            |
-| `configure`                                                      | "Compute + apply the config this repo should have"                 | < 30 sec                           |
-| `ingest`                                                         | "Bring Snyk Code / CodeQL / SARIF findings into the gate"          | varies                             |
-| `extensions`                                                     | "Plug our own extractor/scanner/sink into dxkit" (4-rung ladder)   | seconds (`dev` loop)               |
-| `receipt`                                                        | "Emit the PR signals block (verdict + allowlist + score delta)"    | < 30 sec                           |
-| [`tools`](commands/tools.md)                                     | "What tools are detected / missing?"                               | < 5 sec                            |
-| [`doctor`](commands/doctor.md)                                   | "Why is X not working?"                                            | < 5 sec                            |
-| [`init`](commands/init.md)                                       | "Scaffold a new project with dxkit pre-configured"                 | 5-30 sec                           |
-| [`loop doctor` / `loop ledger`](commands/loop.md)                | "Run a safe autonomous coding loop behind the Stop-gate"           | < 5 sec                            |
-| [`update`](commands/update.md)                                   | "Re-generate scaffolded files, preserving customizations"          | 5-30 sec                           |
-| [`upgrade`](commands/upgrade.md)                                 | "Plan + execute a dxkit version upgrade (binary + scaffold)"       | 1-3 min                            |
-| `uninstall`                                                      | "Remove dxkit, restoring the exact pre-dxkit state (dry-run 1st)"  | < 30 sec                           |
-| [`to-xlsx`](commands/to-xlsx.md)                                 | "Convert a licenses/bom JSON report to 15-col XLSX"                | < 5 sec                            |
-| [`baseline create`](commands/baseline.md)                        | "Capture today's findings as a brownfield anchor"                  | 30s-2m                             |
-| [`baseline show`](commands/baseline.md)                          | "Inspect/filter the on-disk baseline"                              | < 1 sec                            |
-| [`guardrail check`](commands/guardrail.md)                       | "Block on net-new regressions vs. the baseline"                    | 30s-2m                             |
-| [`setup-branch-protection`](commands/setup-branch-protection.md) | "Mark `dxkit-guardrails` as required check on default branch"      | < 5 sec                            |
-| [`setup-prebuild`](commands/setup-prebuild.md)                   | "Configure Codespaces prebuild (cold-start ~7 min → ~30s)"         | < 5 sec                            |
-| [`allowlist`](commands/allowlist.md)                             | "Suppress a specific finding with typed reason + expiry"           | < 1 sec                            |
-| [`reviewers`](commands/reviewers.md)                             | "Who should review this change?" (active-owner model + CODEOWNERS) | < 5 sec                            |
-| [`issue`](commands/issue.md)                                     | "Open a pre-filled GitHub Issue against dxkit"                     | < 5 sec                            |
+<!-- dxkit:command-table:begin — generated from src/discovery/command-defs.ts by `npm run docs:commands`; do not edit by hand -->
+
+| Command                                                          | What it does                                                                     | Typical runtime                    |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------- |
+| [`health`](commands/health.md)                                   | Run the deterministic 6-dimension health analysis                                | 1-4 min                            |
+| [`vulnerabilities`](commands/vulnerabilities.md)                 | Run the deep security scan                                                       | 1-3 min                            |
+| [`test-gaps`](commands/test-gaps.md)                             | Analyze test coverage gaps                                                       | 30-90 sec                          |
+| `tests`                                                          | Select tests affected by a diff via the code graph                               | < 5 sec (queries the graph)        |
+| [`quality`](commands/quality.md)                                 | Code quality + slop detection                                                    | 1-8 min (jscpd is the long-pole)   |
+| [`dev-report`](commands/dev-report.md)                           | Developer activity analysis                                                      | 5-30 sec                           |
+| [`licenses`](commands/licenses.md)                               | Dependency license inventory                                                     | 30-60 sec                          |
+| [`bom`](commands/bom.md)                                         | Bill of Materials (licenses + vulnerabilities joined)                            | 1-3 min                            |
+| [`coverage`](commands/coverage.md)                               | Run per-pack test-with-coverage (materializes the artifact)                      | varies (runs your tests)           |
+| [`dashboard`](commands/dashboard.md)                             | Render .dxkit/reports/ into one HTML dashboard                                   | < 5 sec (renders existing reports) |
+| [`report`](commands/report.md)                                   | Full audit (report), or publish/read a score snapshot (report snapshot\|history) | 5-30 min                           |
+| `metrics`                                                        | Findings the gate stopped before merge + the score-over-time trend               | < 5 sec                            |
+| [`baseline`](commands/baseline.md)                               | Capture / publish / show per-finding baselines for the guardrail                 | 30 sec - 2 min                     |
+| [`guardrail`](commands/guardrail.md)                             | Diff current scan vs baseline; block on net-new regressions                      | 30 sec - 2 min                     |
+| `receipt`                                                        | Emit the PR "dxkit signals" block (verdict + allowlist + score delta)            | < 30 sec                           |
+| [`allowlist`](commands/allowlist.md)                             | Suppress / audit individual findings with typed reasons                          | < 1 sec                            |
+| `ingest`                                                         | Ingest external SAST (SARIF) findings as first-class                             | varies (reads engine SARIF)        |
+| [`loop`](commands/loop.md)                                       | Autonomous-loop utilities (doctor / ledger / snapshot)                           | < 5 sec                            |
+| [`checks`](commands/checks.md)                                   | List / dry-run your custom repo-invariant + lint gates                           | varies (runs your checks)          |
+| `extensions`                                                     | Plug your own extractors and sinks into dxkit (any language)                     | seconds (the `dev` loop)           |
+| `schema`                                                         | Data-model inventory + the schema drift gate                                     | 5-30 sec                           |
+| `flow`                                                           | UI→API integration mapping + the broken-integration gate                         | 5-30 sec                           |
+| [`explore`](commands/explore.md)                                 | Repo exploration via the code graph                                              | < 5 sec (queries the graph)        |
+| [`context`](commands/context.md)                                 | Slim structural code slice for a query (token-efficient)                         | < 5 sec (queries the graph)        |
+| [`reviewers`](commands/reviewers.md)                             | Suggest reviewers via the active-owner model                                     | < 5 sec                            |
+| `demo`                                                           | Offline, no-API demonstration walkthroughs                                       | 1-2 min (interactive walkthrough)  |
+| [`init`](commands/init.md)                                       | Install dxkit agent DX in this repo                                              | 5-30 sec                           |
+| [`update`](commands/update.md)                                   | Re-generate managed files (preserves your edits)                                 | 5-30 sec                           |
+| `uninstall`                                                      | Remove dxkit, restoring the exact pre-dxkit state                                | < 30 sec                           |
+| [`doctor`](commands/doctor.md)                                   | Verify setup — and recommend capabilities you are not using                      | < 5 sec                            |
+| `configure`                                                      | Compute + apply a deterministic config plan for this repo                        | < 30 sec                           |
+| `capabilities`                                                   | List every dxkit capability + what this repo should adopt                        | < 5 sec                            |
+| [`tools`](commands/tools.md)                                     | Show / install required analysis tools                                           | < 5 sec (list); install varies     |
+| `hooks`                                                          | Activate the dxkit git hooks (core.hooksPath)                                    | < 5 sec                            |
+| [`setup-branch-protection`](commands/setup-branch-protection.md) | Set up branch protection / required checks (dry-run by default)                  | < 5 sec                            |
+| [`setup-prebuild`](commands/setup-prebuild.md)                   | Set up the devcontainer prebuild workflow                                        | < 5 sec                            |
+| [`upgrade`](commands/upgrade.md)                                 | Plan / apply a dxkit version upgrade                                             | 1-3 min                            |
+| [`issue`](commands/issue.md)                                     | Open a pre-filled GitHub issue against dxkit                                     | < 5 sec                            |
+| [`to-xlsx`](commands/to-xlsx.md)                                 | Convert a dxkit JSON report to XLSX                                              | < 5 sec                            |
+
+<!-- dxkit:command-table:end -->
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2671,10 +2671,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test:changed": "vitest run --changed",
     "test:coverage": "npm run build && vitest run --coverage",
     "test:integration": "npm run build && vitest run --config vitest.integration.config.ts",
+    "docs:commands": "node scripts/generate-command-docs.js",
     "new-lang": "node scripts/scaffold-language.js",
     "dxkit:health": "npm run build && node dist/index.js health",
     "dxkit:guardrail": "npm run build && node dist/index.js guardrail check",

--- a/scripts/generate-command-docs.js
+++ b/scripts/generate-command-docs.js
@@ -15,7 +15,7 @@ const path = require('node:path');
 const root = path.join(__dirname, '..');
 const distModule = path.join(root, 'dist', 'discovery', 'docs-tables.js');
 if (!existsSync(distModule)) {
-  console.error('dist/discovery/docs-tables.js not found — run `npm run build` first.');
+  console.error('dist/discovery/docs-tables.js not found — run `npm run build` first.'); // slop-ok: build script
   process.exit(1);
 }
 

--- a/scripts/generate-command-docs.js
+++ b/scripts/generate-command-docs.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Rewrite the generated command table in docs/README.md from the capability
+ * registry (CLAUDE.md Rule 16). Run after changing src/discovery/command-defs.ts:
+ *
+ *   npm run build && npm run docs:commands
+ *
+ * test/docs-command-tables.test.ts pins the committed table against the
+ * registry, so forgetting this step fails CI with a pointer here.
+ */
+const { existsSync, readFileSync, writeFileSync } = require('node:fs');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const root = path.join(__dirname, '..');
+const distModule = path.join(root, 'dist', 'discovery', 'docs-tables.js');
+if (!existsSync(distModule)) {
+  console.error('dist/discovery/docs-tables.js not found — run `npm run build` first.');
+  process.exit(1);
+}
+
+const { renderDocsCommandTable, replaceDocsCommandTable } = require(distModule);
+
+const readme = path.join(root, 'docs', 'README.md');
+const hasDocPage = (id) => existsSync(path.join(root, 'docs', 'commands', `${id}.md`));
+const next = replaceDocsCommandTable(
+  readFileSync(readme, 'utf8'),
+  renderDocsCommandTable(hasDocPage),
+);
+writeFileSync(readme, next);
+
+// The docs tree is prettier-formatted; normalize table padding the same way
+// the pre-commit hook would so the generated file is committable as-is.
+execFileSync('npx', ['prettier', '--write', 'docs/README.md'], { cwd: root, stdio: 'inherit' });
+console.log('✓ docs/README.md command table regenerated from the capability registry');

--- a/scripts/generate-command-docs.js
+++ b/scripts/generate-command-docs.js
@@ -32,4 +32,4 @@ writeFileSync(readme, next);
 // The docs tree is prettier-formatted; normalize table padding the same way
 // the pre-commit hook would so the generated file is committable as-is.
 execFileSync('npx', ['prettier', '--write', 'docs/README.md'], { cwd: root, stdio: 'inherit' });
-console.log('✓ docs/README.md command table regenerated from the capability registry');
+console.log('✓ docs/README.md command table regenerated from the capability registry'); // slop-ok: build script

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -31,6 +31,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'setup',
     summary: 'Install dxkit agent DX in this repo',
+    typicalRuntime: '5-30 sec',
     docsBlurb:
       'Scaffold dxkit into a repo: agent skills, CLAUDE.md, and any opted-in hooks/CI/devcontainer.',
     skill: 'dxkit-init',
@@ -40,6 +41,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'setup',
     summary: 'Re-generate managed files (preserves your edits)',
+    typicalRuntime: '5-30 sec',
     docsBlurb:
       'Refresh dxkit-owned files to the current version, provenance-aware — never clobbers files you evolved.',
     skill: 'dxkit-update',
@@ -49,6 +51,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'setup',
     summary: 'Remove dxkit, restoring the exact pre-dxkit state',
+    typicalRuntime: '< 30 sec',
     docsBlurb:
       'Delete files dxkit created and surgically revert its additive merges. Dry-run by default; --yes applies.',
     skill: 'dxkit-uninstall',
@@ -58,6 +61,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'setup',
     summary: 'Verify setup — and recommend capabilities you are not using',
+    typicalRuntime: '< 5 sec',
     docsBlurb:
       'Check that dxkit is wired correctly, and advise on unused capabilities that fit this repo.',
   },
@@ -66,6 +70,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'setup',
     summary: 'Compute + apply a deterministic config plan for this repo',
+    typicalRuntime: '< 30 sec',
     docsBlurb:
       'Walk every capability the registry exposes and compute the config each should take from observable repo facts — a pure, reproducible plan (same repo → same plan). `--plan` shows it, `--apply` merge-writes it into .dxkit/policy.json without clobbering your edits. New capabilities join the plan automatically.',
     skill: 'dxkit-onboard',
@@ -76,6 +81,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'setup',
     summary: 'List every dxkit capability + what this repo should adopt',
+    typicalRuntime: '< 5 sec',
     docsBlurb:
       'The capability catalog — every command with its group, summary, and driving skill, plus repo-grounded recommendations. `--json` is the agent-queryable menu for configuring dxkit conversationally.',
     skill: 'dxkit-learn',
@@ -85,6 +91,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'setup',
     summary: 'Show / install required analysis tools',
+    typicalRuntime: '< 5 sec (list); install varies',
     docsBlurb:
       'Report the status of external analysis tools (semgrep, gitleaks, …) and install missing ones.',
   },
@@ -93,6 +100,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'setup',
     summary: 'Activate the dxkit git hooks (core.hooksPath)',
+    typicalRuntime: '< 5 sec',
     docsBlurb: 'Idempotently point git at .githooks so the pre-push guardrail runs on every push.',
     skill: 'dxkit-hooks',
   },
@@ -102,6 +110,7 @@ export const COMMANDS = [
     group: 'setup',
     aliases: ['protect'],
     summary: 'Set up branch protection / required checks (dry-run by default)',
+    typicalRuntime: '< 5 sec',
     docsBlurb:
       'Configure branch protection so the guardrail check is a required status, and add a ' +
       'deletion-protection ruleset for the dxkit anchor side branches. `protect` is the ' +
@@ -112,6 +121,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'setup',
     summary: 'Set up the devcontainer prebuild workflow',
+    typicalRuntime: '< 5 sec',
     docsBlurb: 'Install a GitHub Actions workflow that prebuilds the dxkit devcontainer image.',
   },
   {
@@ -119,6 +129,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'setup',
     summary: 'Plan / apply a dxkit version upgrade',
+    typicalRuntime: '1-3 min',
     docsBlurb:
       'Show a package-manager-aware upgrade plan for the dxkit devDependency and its transition steps.',
   },
@@ -127,6 +138,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'setup',
     summary: 'Open a pre-filled GitHub issue against dxkit',
+    typicalRuntime: '< 5 sec',
     docsBlurb:
       'Compose a typed feedback issue (false-positive / bug / feature-request / …); nothing submits until you confirm in the browser.',
   },
@@ -137,6 +149,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'assess',
     summary: 'Run the deterministic 6-dimension health analysis',
+    typicalRuntime: '1-4 min',
     docsBlurb:
       'Score Security, Code Quality, Tests, Docs, Maintainability, and Developer Experience with structured deductions.',
     skill: 'dxkit-reports',
@@ -147,6 +160,7 @@ export const COMMANDS = [
     group: 'assess',
     aliases: ['vuln'],
     summary: 'Run the deep security scan',
+    typicalRuntime: '1-3 min',
     docsBlurb:
       'Secrets, SAST, and dependency-vulnerability findings with CVSS scoring and remediation proposals.',
     skill: 'dxkit-reports',
@@ -156,6 +170,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'assess',
     summary: 'Analyze test coverage gaps',
+    typicalRuntime: '30-90 sec',
     docsBlurb:
       'Surface untested source files by risk tier, crediting coverage artifacts and import-graph reachability.',
     skill: 'dxkit-test',
@@ -165,6 +180,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'assess',
     summary: 'Select tests affected by a diff via the code graph',
+    typicalRuntime: '< 5 sec (queries the graph)',
     docsBlurb:
       '`tests affected --diff <ref>` lists the test files a change reaches, computed from the call graph (beats module-graph selection in composition-root repos). Fails safe to the full suite when the graph is missing, stale, or unreliable for a changed language.',
     skill: 'dxkit-test',
@@ -174,6 +190,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'assess',
     summary: 'Code quality + slop detection',
+    typicalRuntime: '1-8 min (jscpd is the long-pole)',
     docsBlurb:
       'Duplication, complexity, and AI-slop signals rolled into the Code Quality dimension.',
   },
@@ -182,6 +199,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'assess',
     summary: 'Developer activity analysis',
+    typicalRuntime: '5-30 sec',
     docsBlurb: 'Recency-weighted git activity: active owners, bus-factor, and contribution shape.',
   },
   {
@@ -189,6 +207,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'assess',
     summary: 'Dependency license inventory',
+    typicalRuntime: '30-60 sec',
     docsBlurb: 'Enumerate dependency licenses and attribution for the dependency tree.',
   },
   {
@@ -196,6 +215,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'assess',
     summary: 'Bill of Materials (licenses + vulnerabilities joined)',
+    typicalRuntime: '1-3 min',
     docsBlurb: 'Join the license inventory with the vulnerability scan into one dependency BOM.',
   },
   {
@@ -203,6 +223,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'assess',
     summary: 'Run per-pack test-with-coverage (materializes the artifact)',
+    typicalRuntime: 'varies (runs your tests)',
     docsBlurb:
       'Side-effecting: run each active pack’s coverage command so health/test-gaps read line-level truth.',
   },
@@ -211,6 +232,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'assess',
     summary: 'Render .dxkit/reports/ into one HTML dashboard',
+    typicalRuntime: '< 5 sec (renders existing reports)',
     docsBlurb: 'Combine the generated reports into a single browsable HTML dashboard.',
     skill: 'dxkit-reports',
   },
@@ -219,6 +241,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'assess',
     summary: 'Full audit (report), or publish/read a score snapshot (report snapshot|history)',
+    typicalRuntime: '5-30 min',
     docsBlurb:
       'One command to run all analyzers and render the dashboard — the full-audit entry point. ' +
       '`report snapshot` publishes a per-merge score snapshot to the dxkit-reports ref; ' +
@@ -232,6 +255,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'assess',
     summary: 'Findings the gate stopped before merge + the score-over-time trend',
+    typicalRuntime: '< 5 sec',
     docsBlurb:
       'The champion ROI report, computed not narrated: net-new findings the guardrail intercepted before they reached the base branch, per week and by category, from the append-only loop ledger. Interceptions are the ungameable number; --since <ref|date> scopes the window. Also surfaces the score-over-time trend (how each dimension moved) from the dxkit-reports snapshots when on-merge reports are enabled.',
     skill: 'dxkit-reports',
@@ -243,6 +267,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'gate',
     summary: 'Capture / publish / show per-finding baselines for the guardrail',
+    typicalRuntime: '30 sec - 2 min',
     docsBlurb:
       'Record per-finding identities the guardrail check diffs against to gate net-new ' +
       'regressions. `baseline publish` pushes the captured anchor to the side branch on the ' +
@@ -255,6 +280,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'gate',
     summary: 'Diff current scan vs baseline; block on net-new regressions',
+    typicalRuntime: '30 sec - 2 min',
     docsBlurb:
       'The brownfield gate: fail on findings introduced by a change, grandfathering pre-existing debt.',
     skill: 'dxkit-action',
@@ -264,6 +290,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'gate',
     summary: 'Emit the PR "dxkit signals" block (verdict + allowlist + score delta)',
+    typicalRuntime: '< 30 sec',
     docsBlurb:
       'The ready-to-paste PR signals block, computed not narrated: the guardrail verdict, the allowlist delta, and (with --since) health-score movement vs the base ref. Reuses the session verdict cache so it never re-runs an unchanged scan.',
     skill: 'dxkit-pr',
@@ -273,6 +300,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'gate',
     summary: 'Suppress / audit individual findings with typed reasons',
+    typicalRuntime: '< 1 sec',
     docsBlurb:
       'Accept a finding with a typed category + required reason + optional expiry; audit and prune entries.',
     skill: 'dxkit-allowlist',
@@ -282,6 +310,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'gate',
     summary: 'Ingest external SAST (SARIF) findings as first-class',
+    typicalRuntime: 'varies (reads engine SARIF)',
     docsBlurb:
       'Pull CodeQL / Snyk / Semgrep-Pro SARIF into dxkit so external findings share one fingerprint + gate.',
     skill: 'dxkit-ingest',
@@ -291,6 +320,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'gate',
     summary: 'Autonomous-loop utilities (doctor / ledger / snapshot)',
+    typicalRuntime: '< 5 sec',
     docsBlurb:
       'Inspect and verify the autonomous-loop Stop-gate wiring, its ledger, and the correctness-floor snapshot.',
     skill: 'dxkit-loop',
@@ -301,6 +331,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'gate',
     summary: 'List / dry-run your custom repo-invariant + lint gates',
+    typicalRuntime: 'varies (runs your checks)',
     docsBlurb:
       'Declare repo invariants (a project rule, a lint gate) as first-class gate citizens: the guardrail fingerprints their failures and blocks only net-new ones, grandfathering pre-existing debt. `checks list` shows what is configured; `checks run` dry-runs them.',
     skill: 'dxkit-checks',
@@ -313,6 +344,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'gate',
     summary: 'Plug your own extractors and sinks into dxkit (any language)',
+    typicalRuntime: 'seconds (the `dev` loop)',
     docsBlurb:
       'Declare an extension — a manifest pointing at your existing script — and dxkit runs it at ' +
       'refresh time, validates its emitted contract/inventory/findings/export document, and routes ' +
@@ -333,6 +365,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'gate',
     summary: 'Data-model inventory + the schema drift gate',
+    typicalRuntime: '5-30 sec',
     docsBlurb:
       'Extract every declared data model (ORM entities, tagged structs, spec schemas) and ' +
       'gate breaking changes — a removed field, a changed type, an optional field made ' +
@@ -348,6 +381,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'integrate',
     summary: 'UI→API integration mapping + the broken-integration gate',
+    typicalRuntime: '5-30 sec',
     docsBlurb:
       'Map client calls to served endpoints and gate changes that break a UI→API contract across ' +
       'repos. `flow publish --land` refreshes + lands the committed contract snapshots (the ' +
@@ -364,6 +398,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'explore',
     summary: 'Repo exploration via the code graph',
+    typicalRuntime: '< 5 sec (queries the graph)',
     docsBlurb:
       'Query the graphify artifact: hot-files, entry-points, communities, api-surface, per-file/feature context.',
   },
@@ -372,6 +407,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'explore',
     summary: 'Slim structural code slice for a query (token-efficient)',
+    typicalRuntime: '< 5 sec (queries the graph)',
     docsBlurb:
       'Budget-bounded structural context for a query — a compact codebase slice for an LLM.',
   },
@@ -380,6 +416,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'explore',
     summary: 'Suggest reviewers via the active-owner model',
+    typicalRuntime: '< 5 sec',
     docsBlurb:
       'Rank reviewers by recency-weighted ownership of the touched files, blended with CODEOWNERS, with a bus-factor signal.',
   },
@@ -390,6 +427,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'export',
     summary: 'Convert a dxkit JSON report to XLSX',
+    typicalRuntime: '< 5 sec',
     docsBlurb: 'Render a dxkit JSON report into a 15-column spreadsheet for sharing.',
   },
 
@@ -417,6 +455,7 @@ export const COMMANDS = [
     audience: 'user',
     group: 'explore',
     summary: 'Offline, no-API demonstration walkthroughs',
+    typicalRuntime: '1-2 min (interactive walkthrough)',
     docsBlurb:
       'Run a self-contained walkthrough (default: the loop-guardrail demo) with no network or API key.',
   },

--- a/src/discovery/command-types.ts
+++ b/src/discovery/command-types.ts
@@ -99,6 +99,12 @@ export interface CapabilityDescriptor {
   aliases?: readonly string[];
   /** A sentence for generated docs/README. Required for user-facing commands. */
   docsBlurb?: string;
+  /**
+   * What a run costs in wall-clock time (e.g. `'< 5 sec'`, `'1-4 min'`) —
+   * the "Typical runtime" column of the generated docs command table.
+   * Required for user-facing commands.
+   */
+  typicalRuntime?: string;
   /** Primary agent-facing skill basename under `.claude/skills/`, if any. */
   skill?: string;
   /**

--- a/src/discovery/docs-tables.ts
+++ b/src/discovery/docs-tables.ts
@@ -1,0 +1,64 @@
+/**
+ * Registry-generated docs command table (CLAUDE.md Rule 16 — generated docs
+ * are a discovery surface of the capability registry, same as the help index
+ * and the capability catalog).
+ *
+ * The "What you can run" table in `docs/README.md` is rendered from
+ * `COMMANDS`, between marker comments, so a new command cannot ship without
+ * its docs row — the drift class this closes: the hand-maintained table had
+ * silently lost `tests`, `hooks`, `checks`, and `demo` across waves.
+ *
+ * Writers: `npm run docs:commands` (scripts/generate-command-docs.js)
+ * rewrites the marked block. `test/docs-command-tables.test.ts` pins the
+ * committed block against this renderer, so an out-of-date table fails CI
+ * with a regenerate hint instead of shipping stale.
+ */
+import { GROUP_ORDER, userCommands } from './commands';
+import type { CapabilityDescriptor } from './command-types';
+
+/** Marker pair delimiting the generated block in docs/README.md. */
+export const DOCS_TABLE_BEGIN =
+  '<!-- dxkit:command-table:begin — generated from src/discovery/command-defs.ts by `npm run docs:commands`; do not edit by hand -->';
+export const DOCS_TABLE_END = '<!-- dxkit:command-table:end -->';
+
+/**
+ * Render the docs command table as markdown lines (no surrounding markers).
+ * `hasDocPage` is injected (fs probe in production, fixture in tests): a
+ * command with a page under `docs/commands/<id>.md` gets a linked name.
+ * Rows are ordered by the help-index group order, registry order within a
+ * group — one ordering everywhere.
+ */
+export function renderDocsCommandTable(
+  hasDocPage: (id: string) => boolean,
+  commands: readonly CapabilityDescriptor[] = userCommands(),
+): string[] {
+  // A literal `|` inside a cell (e.g. `report snapshot|history`) would split
+  // the markdown column — escape it.
+  const cell = (s: string) => s.replace(/\|/g, '\\|');
+  const lines: string[] = ['| Command | What it does | Typical runtime |', '| --- | --- | --- |'];
+  for (const group of GROUP_ORDER) {
+    for (const c of commands.filter((x) => x.group === group)) {
+      const name = hasDocPage(c.id) ? `[\`${c.id}\`](commands/${c.id}.md)` : `\`${c.id}\``;
+      lines.push(`| ${name} | ${cell(c.summary)} | ${cell(c.typicalRuntime ?? '')} |`);
+    }
+  }
+  return lines;
+}
+
+/**
+ * Replace the marked block inside a docs file's content with freshly
+ * rendered table lines. Throws loudly when the markers are missing or
+ * malformed — a silently-skipped rewrite is the drift this exists to stop.
+ */
+export function replaceDocsCommandTable(content: string, tableLines: string[]): string {
+  const begin = content.indexOf(DOCS_TABLE_BEGIN);
+  const end = content.indexOf(DOCS_TABLE_END);
+  if (begin === -1 || end === -1 || end < begin) {
+    throw new Error(
+      `docs command-table markers not found or out of order (expected "${DOCS_TABLE_BEGIN}" before "${DOCS_TABLE_END}")`,
+    );
+  }
+  const before = content.slice(0, begin);
+  const after = content.slice(end + DOCS_TABLE_END.length);
+  return `${before}${DOCS_TABLE_BEGIN}\n\n${tableLines.join('\n')}\n\n${DOCS_TABLE_END}${after}`;
+}

--- a/test/discovery-playbook.test.ts
+++ b/test/discovery-playbook.test.ts
@@ -70,11 +70,13 @@ describe('capability registry — Rule 16 parity (block-if-unregistered)', () =>
 });
 
 describe('capability registry — descriptor completeness', () => {
-  it('every user-facing command has group + summary + docsBlurb', () => {
+  it('every user-facing command has group + summary + docsBlurb + typicalRuntime', () => {
     for (const c of userCommands()) {
       expect(c.group, `${c.id}: group`).toBeTruthy();
       expect(c.summary.trim().length, `${c.id}: summary`).toBeGreaterThan(0);
       expect(c.docsBlurb?.trim().length ?? 0, `${c.id}: docsBlurb`).toBeGreaterThan(0);
+      // Feeds the generated docs command table's "Typical runtime" column.
+      expect(c.typicalRuntime?.trim().length ?? 0, `${c.id}: typicalRuntime`).toBeGreaterThan(0);
     }
   });
 

--- a/test/docs-command-tables.test.ts
+++ b/test/docs-command-tables.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The docs command table is a GENERATED discovery surface (CLAUDE.md
+ * Rule 16): docs/README.md's "What you can run" table must equal what the
+ * capability registry renders. This is the net for the drift class where a
+ * new command ships without its docs row (the hand-maintained table had
+ * silently lost `tests`, `hooks`, `checks`, and `demo` across waves) — an
+ * out-of-date table fails here with a regenerate hint instead of shipping.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { userCommands } from '../src/discovery/commands';
+import {
+  DOCS_TABLE_BEGIN,
+  DOCS_TABLE_END,
+  renderDocsCommandTable,
+  replaceDocsCommandTable,
+} from '../src/discovery/docs-tables';
+
+const ROOT = join(__dirname, '..');
+const README = join(ROOT, 'docs', 'README.md');
+const hasDocPage = (id: string) => existsSync(join(ROOT, 'docs', 'commands', `${id}.md`));
+
+/**
+ * Prettier pads table cells and dash rows; the renderer emits unpadded
+ * markdown. Collapse both to a canonical form so the comparison is about
+ * CONTENT, not column alignment.
+ */
+function normalize(block: string): string[] {
+  return block
+    .split('\n')
+    .map((l) =>
+      l
+        .replace(/-{3,}/g, '---')
+        .replace(/[ \t]+/g, ' ')
+        .trim(),
+    )
+    .filter((l) => l.length > 0);
+}
+
+describe('docs command table (registry-generated)', () => {
+  it('docs/README.md table matches the capability registry — if this fails, run: npm run build && npm run docs:commands', () => {
+    const content = readFileSync(README, 'utf8');
+    const begin = content.indexOf(DOCS_TABLE_BEGIN);
+    const end = content.indexOf(DOCS_TABLE_END);
+    expect(begin, 'begin marker present').toBeGreaterThanOrEqual(0);
+    expect(end, 'end marker after begin').toBeGreaterThan(begin);
+
+    const committed = content.slice(begin + DOCS_TABLE_BEGIN.length, end);
+    const rendered = renderDocsCommandTable(hasDocPage).join('\n');
+    expect(normalize(committed)).toEqual(normalize(rendered));
+  });
+
+  it('every user-facing command has a row; internal commands have none', () => {
+    const rendered = renderDocsCommandTable(hasDocPage).join('\n');
+    for (const c of userCommands()) {
+      expect(rendered, `row for ${c.id}`).toContain(`\`${c.id}\``);
+    }
+    for (const internal of ['context-hook', 'floor']) {
+      expect(rendered).not.toContain(`\`${internal}\``);
+    }
+  });
+
+  it('replaceDocsCommandTable throws loudly when markers are missing', () => {
+    expect(() => replaceDocsCommandTable('no markers here', ['| a |'])).toThrow(/markers/);
+  });
+
+  it('a synthetic command injected into the registry lands in the rendered table (the generator stays registry-driven)', () => {
+    const synthetic = {
+      id: 'synthetic-docs-probe',
+      audience: 'user',
+      group: 'assess',
+      summary: 'Synthetic docs-table probe',
+      docsBlurb: 'Never shipped — proves rendering iterates its registry argument.',
+      typicalRuntime: '< 1 sec',
+    } as const;
+    const rendered = renderDocsCommandTable(() => false, [...userCommands(), synthetic]).join('\n');
+    expect(rendered).toContain('`synthetic-docs-probe`');
+    expect(rendered).toContain('Synthetic docs-table probe');
+  });
+});


### PR DESCRIPTION
First PR of the 3.6 train (targets `release/3.6`). The two small follow-ups carried over from the 3.5 checkpoint, plus the open Dependabot alert.

## What's here

**1. Publish verification waits out slow npm visibility** (`ci`)
Both publish workflows verified the registry shasum on a ~180s poll. That window is calibrated to CDN propagation of an existing package, not first-publish name activation: dxkit-sdk@0.1.0 took ~10 minutes to become readable, so its successful publish registered as a workflow failure and had to be verified by hand. Both loops now poll 90 × 10s (~15 min).

**2. The docs command table is generated from the capability registry** (`feat`)
`docs/README.md`'s "What you can run" table was hand-maintained and drifted every wave — it had silently lost `tests`, `hooks`, `checks`, and `demo`. It now renders from the Rule-16 `COMMANDS` registry between marker comments:

- `typicalRuntime` joins the descriptor (required for user-facing commands via the completeness test) so the whole row is registry-owned;
- `npm run docs:commands` rewrites the block (prettier-normalized);
- `test/docs-command-tables.test.ts` pins the committed table against the renderer (padding-insensitive) — an out-of-date table fails CI with the regenerate hint — plus a synthetic-command injection proving the renderer stays registry-driven;
- cells escape literal pipes (the `report` summary contains `snapshot|history`, which split the column — caught while generating).

**3. Transitive js-yaml bump** (`chore`) — Dependabot alert #2, quadratic merge-key DoS, dev-scope via eslint. Lockfile-only, 4.1.1 → 4.3.0.

(Plus two one-line slop-gate annotations on the generator script, surfaced by the pre-push range check.)

## Validation

- Full suite 3707/3707 (245 files) including the new parity + injection tests
- Pushed through the full pre-push gate (typecheck, lint, prettier, arch-check, docs-coverage, range slop check, coverage 68.01%)
- Table regenerated and committed; `demo`, `tests`, `hooks`, `checks` now present

Recommend **rebase-merge** — commits are independently meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Avc94RYCbx9ivvQP1oZunX