### PR TITLE
C# lint is severity-tiered (Roslyn diagnostics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **C# lint is severity-tiered.** The quality lint capability now reads
+  Roslyn analyzer diagnostics from `dotnet build` (the same canonical
+  warning stream the lint gate parses): security analyzer families
+  (CA21xx/CA3xxx/CA5xxx) rank high, other CA rules and CS compiler warnings
+  medium, IDE style low — parity with ruff, ESLint, golangci-lint, and
+  clippy. Multi-targeted projects deduplicate per-TFM re-emissions, and the
+  build runs non-incrementally so an unchanged tree cannot zero its own
+  counts. Repos the SDK cannot build (legacy .NET Framework) keep the
+  previous formatter-based path. C# Code Quality scores may shift with the
+  richer signal.
+
 ### Fixed
 
 - **Large repos no longer lose flow/schema extraction partway through.**

--- a/README.md
+++ b/README.md
@@ -375,10 +375,12 @@ file-level resolver is a no-op. Downstream analyses that need an edge graph
 (reachability, import-graph test-gap credit) degrade to conservative
 defaults for those packs. Resolver support for these packs is planned.
 
-² C# uses `dotnet-format` for formatting violations only. A real
-severity-tiered C# linter (Roslyn analyzers or StyleCop) is planned.
-Today every C# formatting violation is counted at `low` tier
-so it does not inflate the Code Quality score.
+² C# lint is severity-tiered via the Roslyn analyzers (`dotnet build`
+diagnostics: security analyzer families rank high, design/compiler
+warnings medium, style low). A repo the SDK cannot build (legacy .NET
+Framework projects) falls back to `dotnet-format`, whose formatting
+violations count at `low` tier so they do not inflate the Code Quality
+score.
 
 </details>
 

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -41,7 +41,7 @@ import type {
   SeverityCounts,
   TestFrameworkResult,
 } from './capabilities/types';
-import type { LanguageSupport } from './types';
+import type { LanguageSupport, LintSeverity } from './types';
 import type { LintGateProvider } from './capabilities/lint-gate';
 
 function dirHasMatching(dir: string, regex: RegExp): boolean {
@@ -950,18 +950,76 @@ const csharpDepVulnsProvider: DepVulnsProvider = {
 };
 
 /**
+ * Severity tier for a Roslyn/MSBuild diagnostic code. The security-relevant
+ * analyzer families rank high — CA21xx (the security category: SQL-injection
+ * review and friends), CA3xxx (injection), CA5xxx (crypto). Other CA
+ * design/usage rules, CS compiler warnings, and SYSLIB obsoletions are
+ * medium; IDE style rules and formatter codes (WHITESPACE, FINALNEWLINE)
+ * are low. Non-string input short-circuits to 'low' (the mapLintSeverity
+ * contract — real tool output occasionally omits the code).
+ */
+export function mapRoslynSeverity(code: string | null | undefined): LintSeverity {
+  if (typeof code !== 'string') return 'low';
+  const c = code.toUpperCase();
+  if (/^CA(21|3|5)\d+/.test(c)) return 'high';
+  if (/^(CA|CS|SYSLIB)\d+/.test(c)) return 'medium';
+  return 'low';
+}
+
+/**
+ * Tiered counts from a `dotnet build` output stream — one diagnostic per
+ * canonical warning line (the same shape the lint gate parses), deduplicated
+ * by (file, line, rule) because a multi-targeted project re-emits every
+ * diagnostic once per TFM. Exported for the parse-contract tests.
+ */
+export function countRoslynWarnings(raw: string): LintResult['counts'] {
+  const counts = { critical: 0, high: 0, medium: 0, low: 0 };
+  const re = new RegExp(CSHARP_MSBUILD_WARNING_PARSE);
+  const seen = new Set<string>();
+  for (const lineText of raw.split('\n')) {
+    const m = re.exec(lineText.trim());
+    if (!m?.groups) continue;
+    const key = `${m.groups.file}(${m.groups.line}):${m.groups.rule}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    counts[mapRoslynSeverity(m.groups.rule)]++;
+  }
+  return counts;
+}
+
+/**
  * Single source of truth for the csharp pack's lint gathering.
  * Consumed by `csharpLintProvider` (capability dispatcher).
  *
- * dotnet-format is a formatter, not a tiered linter — it emits binary
- * pass/fail per file. Violations are formatting issues (indentation,
- * spacing), not correctness. This helper reports them at `low` tier so
- * they don't inflate the Quality/Slop score.
+ * The real C# linter is the compiler: Roslyn analyzers ride `dotnet build`,
+ * emitting `File.cs(l,c): warning CAxxxx: …` lines — the same canonical
+ * stream the lint gate parses — which tier through `mapRoslynSeverity`.
+ * `--no-incremental` is load-bearing: an incremental build skips up-to-date
+ * projects and RE-EMITS NOTHING, which would zero the counts on every
+ * second scan of an unchanged tree.
+ *
+ * A repo `dotnet build` cannot compile (legacy .NET Framework projects,
+ * broken trees — any `error` diagnostic means the warning stream is
+ * partial and untrustworthy) falls back to the formatter path: dotnet-format
+ * violations are formatting issues, not correctness, reported at `low` tier
+ * so they don't inflate the Quality/Slop score.
  */
 function gatherCsharpLintResult(cwd: string): LintGatherOutcome {
   const dotnet = findTool(TOOL_DEFS['dotnet-format'], cwd);
   if (!dotnet.available) {
     return { kind: 'unavailable', reason: 'not installed' };
+  }
+
+  const buildRaw = run('dotnet build --no-incremental --nologo -clp:NoSummary 2>&1', cwd, 180000);
+  if (buildRaw !== '' && !/\): error \w+:|error (MSB|NETSDK)\d+/.test(buildRaw)) {
+    return {
+      kind: 'success',
+      envelope: {
+        schemaVersion: 1,
+        tool: 'roslyn-analyzers',
+        counts: countRoslynWarnings(buildRaw),
+      },
+    };
   }
 
   const exitCode = runExitCode('dotnet format --verify-no-changes', cwd, 120000);
@@ -1804,16 +1862,10 @@ export const csharp: LanguageSupport = {
     licenses: csharpLicensesProvider,
   },
 
-  // mapLintSeverity intentionally omitted: dotnet-format is a formatter,
-  // not a tiered linter. It emits binary pass/fail per file and doesn't
-  // expose per-rule codes that could be categorized into
-  // critical/high/medium/low. Matching the parity of ruff (Python),
-  // ESLint (TypeScript), golangci-lint (Go), and clippy (Rust) would
-  // require integrating a different tool — parsing `dotnet build
-  // --verbosity quiet` output for CS*/CA*/IDE* diagnostic codes and
-  // mapping each to a tier. That's deferred until a C# test project
-  // is available to validate the integration; see architecture-redesign
-  // plan for the capability-based approach this will live in.
+  // Roslyn diagnostic codes tier through the same map the lint capability
+  // uses — CS*/CA*/IDE* codes from `dotnet build`, security analyzer
+  // families ranked high. Parity with ruff/ESLint/golangci-lint/clippy.
+  mapLintSeverity: mapRoslynSeverity,
 
   permissions: [
     'Bash(dotnet test:*)',

--- a/test/csharp-tiered-lint.test.ts
+++ b/test/csharp-tiered-lint.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The tiered C# lint capability: Roslyn diagnostics from `dotnet build`
+ * output tier through `mapRoslynSeverity`, counted by `countRoslynWarnings`
+ * with multi-TFM deduplication. The parse regex itself is pinned by the
+ * lint-gate format contract (lint-formats.test.ts); this file pins the
+ * severity map and the counting semantics the quality capability adds on
+ * top. (The live `dotnet build` path is exercised by the cross-ecosystem
+ * CI matrix, which provisions the SDK.)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { countRoslynWarnings, mapRoslynSeverity } from '../src/languages/csharp';
+
+describe('mapRoslynSeverity', () => {
+  it('ranks the security analyzer families high', () => {
+    expect(mapRoslynSeverity('CA2100')).toBe('high'); // SQL injection review
+    expect(mapRoslynSeverity('CA3001')).toBe('high'); // injection
+    expect(mapRoslynSeverity('CA5350')).toBe('high'); // weak crypto
+  });
+
+  it('ranks design/usage rules, compiler warnings, and obsoletions medium', () => {
+    expect(mapRoslynSeverity('CA1822')).toBe('medium'); // design
+    expect(mapRoslynSeverity('CS0618')).toBe('medium'); // obsolete member
+    expect(mapRoslynSeverity('CS8602')).toBe('medium'); // possible null deref
+    expect(mapRoslynSeverity('SYSLIB0014')).toBe('medium');
+  });
+
+  it('ranks style + formatter codes low, and survives junk input', () => {
+    expect(mapRoslynSeverity('IDE0055')).toBe('low');
+    expect(mapRoslynSeverity('WHITESPACE')).toBe('low');
+    expect(mapRoslynSeverity(null)).toBe('low');
+    expect(mapRoslynSeverity(undefined)).toBe('low');
+    expect(mapRoslynSeverity('')).toBe('low');
+  });
+});
+
+describe('countRoslynWarnings', () => {
+  const BUILD_OUTPUT = [
+    '  Determining projects to restore...',
+    '  All projects are up-to-date for restore.',
+    'Services/UserService.cs(42,13): warning CA2100: Review SQL query for vulnerabilities [/repo/App.csproj]',
+    'Controllers/HomeController.cs(12,5): warning CA1822: Member does not access instance data [/repo/App.csproj]',
+    'Controllers/HomeController.cs(30,9): warning CS0618: Method is obsolete [/repo/App.csproj]',
+    'Program.cs(3,1): warning IDE0055: Fix formatting [/repo/App.csproj]',
+    '  App -> /repo/bin/Debug/net8.0/App.dll',
+  ].join('\n');
+
+  it('tiers each diagnostic and ignores non-warning lines', () => {
+    expect(countRoslynWarnings(BUILD_OUTPUT)).toEqual({
+      critical: 0,
+      high: 1,
+      medium: 2,
+      low: 1,
+    });
+  });
+
+  it('deduplicates multi-TFM re-emissions of the same diagnostic', () => {
+    const multiTfm = [
+      'A.cs(1,1): warning CA1822: msg [/repo/App.csproj::TargetFramework=net8.0]',
+      'A.cs(1,1): warning CA1822: msg [/repo/App.csproj::TargetFramework=net9.0]',
+      'A.cs(2,1): warning CA1822: msg [/repo/App.csproj::TargetFramework=net9.0]',
+    ].join('\n');
+    expect(countRoslynWarnings(multiTfm)).toEqual({ critical: 0, high: 0, medium: 2, low: 0 });
+  });
+
+  it('a clean build counts nothing', () => {
+    expect(
+      countRoslynWarnings('  Determining projects to restore...\n  App -> /repo/bin/App.dll'),
+    ).toEqual({ critical: 0, high: 0, medium: 0, low: 0 });
+  });
+});

--- a/test/fixtures/benchmarks/csharp-multi/ProjectA/BadLint.cs
+++ b/test/fixtures/benchmarks/csharp-multi/ProjectA/BadLint.cs
@@ -1,10 +1,16 @@
-// Deliberate dotnet-format violation. Phase 10i.0.2: per-language
-// lint fixture (multi-project variant). The body uses 3-space
-// indentation; .NET defaults to 4 spaces, so `dotnet format
-// --verify-no-changes` exits non-zero on this file.
-namespace ProjectA;
+// Deliberate lint violations for the per-language matrix. The unused local
+// is a guaranteed compiler diagnostic (CS0219) — the tiered lint capability
+// reads Roslyn warnings from `dotnet build`, so the fixture must carry an
+// analyzer-visible defect, not just formatting. The 3-space indentation
+// stays for the formatter FALLBACK path (legacy repos the SDK cannot
+// build), which `dotnet format --verify-no-changes` still flags.
+namespace Dxkit.Benchmark;
 
 public static class BadLint
 {
-   public static int Value => 42;
+   public static int Value()
+   {
+      int unused = 1;
+      return 42;
+   }
 }

--- a/test/fixtures/benchmarks/csharp/BadLint.cs
+++ b/test/fixtures/benchmarks/csharp/BadLint.cs
@@ -1,10 +1,16 @@
-// Deliberate dotnet-format violation. Phase 10i.0.2: per-language
-// lint fixture. The body uses 3-space indentation; .NET defaults to
-// 4 spaces, so `dotnet format --verify-no-changes` exits non-zero
-// and reports the file as needing reformatting.
+// Deliberate lint violations for the per-language matrix. The unused local
+// is a guaranteed compiler diagnostic (CS0219) — the tiered lint capability
+// reads Roslyn warnings from `dotnet build`, so the fixture must carry an
+// analyzer-visible defect, not just formatting. The 3-space indentation
+// stays for the formatter FALLBACK path (legacy repos the SDK cannot
+// build), which `dotnet format --verify-no-changes` still flags.
 namespace Dxkit.Benchmark;
 
 public static class BadLint
 {
-   public static int Value => 42;
+   public static int Value()
+   {
+      int unused = 1;
+      return 42;
+   }
 }

--- a/test/integration/cross-ecosystem.test.ts
+++ b/test/integration/cross-ecosystem.test.ts
@@ -136,7 +136,7 @@ const BENCHMARK_LANGUAGES: readonly BenchmarkLanguage[] = [
     name: 'C# (single)',
     dir: 'csharp',
     secret: { file: 'Secrets.cs' },
-    lint: { file: 'BadLint.cs', expectedTool: 'dotnet-format', requires: 'dotnet' },
+    lint: { file: 'BadLint.cs', expectedTool: 'roslyn-analyzers', requires: 'dotnet' },
     dup: { file: 'Duplications.cs' },
     untested: { file: 'UntestedModule.cs' },
   },
@@ -146,7 +146,7 @@ const BENCHMARK_LANGUAGES: readonly BenchmarkLanguage[] = [
     secret: { file: path.join('ProjectA', 'Secrets.cs') },
     lint: {
       file: path.join('ProjectA', 'BadLint.cs'),
-      expectedTool: 'dotnet-format',
+      expectedTool: 'roslyn-analyzers',
       requires: 'dotnet',
     },
     dup: { file: path.join('ProjectA', 'Duplications.cs') },

--- a/test/integration/cross-ecosystem.test.ts
+++ b/test/integration/cross-ecosystem.test.ts
@@ -88,6 +88,7 @@ interface BenchmarkLanguage {
       | 'eslint'
       | 'golangci-lint'
       | 'clippy'
+      | 'roslyn-analyzers'
       | 'dotnet-format'
       | 'detekt'
       | 'pmd'


### PR DESCRIPTION
Closes the README's long-standing footnote: the C# quality lint capability upgrades from formatting-only `dotnet-format` counts to tiered Roslyn analyzer diagnostics, reusing the exact canonical warning parse the lint gate already ships.

- **Tiering**: security analyzer families (CA21xx/CA3xxx/CA5xxx) → high; other CA rules + CS compiler warnings + SYSLIB → medium; IDE/style/formatter codes → low. `mapRoslynSeverity` joins the pack contract (parity with ruff/ESLint/golangci-lint/clippy).
- **Correctness details**: `--no-incremental` (an incremental build re-emits nothing on an unchanged tree — counts would self-zero on the second scan); per-TFM deduplication for multi-targeted projects; any build *error* (legacy .NET Framework, broken tree) means the warning stream is partial, so the gather falls back to the previous formatter path unchanged.
- **Score note**: C# Code Quality scores may shift with the richer signal (CHANGELOG'd). Gate identity is untouched — this is the score capability, not the finding pipeline.
- **Validation**: severity map + counting semantics pinned by unit tests; the parse regex was already pinned by the lint-gate format contract; the live `dotnet build` path is exercised by the cross-ecosystem CI matrix (this sandbox has no SDK). README footnote + CHANGELOG updated in-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Avc94RYCbx9ivvQP1oZunX