### PR TITLE
chore(release): 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.6.0] - 2026-07-12
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "A deterministic stop condition and code-graph context layer for AI coding agents: gives agents a code graph to make changes, then blocks only net-new detector-backed regressions at the stop boundary, with no model in the gate.",
   "license": "MIT",
   "author": "Vyuh Labs",


### PR DESCRIPTION
The version bump for the 3.6 train: package.json/lock → 3.6.0, CHANGELOG's Unreleased section dated 2026-07-12, command docs regenerated from the capability registry (no drift — parity test green).

Release-contract sweep: the internal ledger has **zero open rows** (every wave-2/3 item is fixed or accepted-with-docs). SDK 0.2.0's bump is already on this branch history (wave 2) and auto-publishes when it reaches main — before the v3.6.0 tag, per the structural ordering.

After this merges: the final `release/3.6` → `main` PR, then tag → Release → publish → npm verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Avc94RYCbx9ivvQP1oZunX