### PR TITLE
feat: dxkit evaluate — the zero-write trial

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,12 @@ allowed, and what was repaired after a block.
 Two presets decide what blocks a stop:
 
 ```text
-security-only  (default)  net-new secrets and critical or high vulnerabilities.
-                          Bounded, must-fix, cheap to gate.
-full-debt      (opt-in)   also gates net-new test gaps and maintainability
+security-only  (default)  blocks net-new secrets, critical and high code
+                          findings, critical dependency vulnerabilities, and
+                          known-malicious packages at any severity. Every
+                          other net-new finding warns; nothing net-new is
+                          ever silent. Bounded, must-fix, cheap to gate.
+full-debt      (opt-in)   also blocks net-new test gaps and maintainability
                           regressions. Repairs can be expensive.
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ construction; commands with a linked page have a full reference under
 | [`vulnerabilities`](commands/vulnerabilities.md)                 | Run the deep security scan                                                       | 1-3 min                            |
 | [`test-gaps`](commands/test-gaps.md)                             | Analyze test coverage gaps                                                       | 30-90 sec                          |
 | `tests`                                                          | Select tests affected by a diff via the code graph                               | < 5 sec (queries the graph)        |
+| `evaluate`                                                       | Zero-write trial: replay your recent landings through the gate                   | 30 sec - 1 min per landing         |
 | [`quality`](commands/quality.md)                                 | Code quality + slop detection                                                    | 1-8 min (jscpd is the long-pole)   |
 | [`dev-report`](commands/dev-report.md)                           | Developer activity analysis                                                      | 5-30 sec                           |
 | [`licenses`](commands/licenses.md)                               | Dependency license inventory                                                     | 30-60 sec                          |

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -42,6 +42,7 @@ tuning belongs here.
     "newHighSecurity": true,
     "newCriticalDependencyVulnerability": true,
     "newHighReachableDependencyVulnerability": true,
+    "newMaliciousDependency": true,
     "newUntestedChangedSource": true,
     "newSevereQualityIssueInChangedFiles": true
   },
@@ -191,15 +192,16 @@ shapes, and troubleshooting live in [`vyuh-dxkit checks`](../commands/checks.md)
 The block-rules object captures the "block on any net-new X regardless
 of confidence" policy lines. Set any flag to `false` to suppress.
 
-| Flag                                      | Meaning                                                             |
-| ----------------------------------------- | ------------------------------------------------------------------- |
-| `newSecret`                               | Block any newly-introduced secret (gitleaks finding)                |
-| `newCriticalSecurity`                     | Block newly-introduced critical-severity code findings              |
-| `newHighSecurity`                         | Block newly-introduced high-severity code findings                  |
-| `newCriticalDependencyVulnerability`      | Block newly-introduced critical dep-vuln advisories                 |
-| `newHighReachableDependencyVulnerability` | Block newly-introduced high-severity reachable dep-vulns            |
-| `newUntestedChangedSource`                | Block when an untested source file appears alongside changed code   |
-| `newSevereQualityIssueInChangedFiles`     | Block newly-introduced severe quality issues touching changed lines |
+| Flag                                      | Meaning                                                                                                                                                                                                                       |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `newSecret`                               | Block any newly-introduced secret (gitleaks finding)                                                                                                                                                                          |
+| `newCriticalSecurity`                     | Block newly-introduced critical-severity code findings                                                                                                                                                                        |
+| `newHighSecurity`                         | Block newly-introduced high-severity code findings                                                                                                                                                                            |
+| `newCriticalDependencyVulnerability`      | Block newly-introduced critical dep-vuln advisories                                                                                                                                                                           |
+| `newHighReachableDependencyVulnerability` | Block newly-introduced high-severity reachable dep-vulns                                                                                                                                                                      |
+| `newMaliciousDependency`                  | Block a newly-introduced dependency carrying a malicious-code advisory (OSV `MAL-*`, CWE-506 family, malware-titled GHSA) at ANY severity — install-time malware runs at install, so CVSS and reachability are the wrong lens |
+| `newUntestedChangedSource`                | Block when an untested source file appears alongside changed code                                                                                                                                                             |
+| `newSevereQualityIssueInChangedFiles`     | Block newly-introduced severe quality issues touching changed lines                                                                                                                                                           |
 
 ## Common customisations
 

--- a/src-templates/.claude/skills/dxkit-evaluate/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-evaluate/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: dxkit-evaluate
+description: Run dxkit's zero-write trial — replay a repo's recent merged changes through the deterministic gate and report what it would have blocked and what enabling dxkit costs, without writing anything to the repo. Use when the user asks "would dxkit help here", "try dxkit on this repo", "what would dxkit have caught", "is dxkit worth enabling", or wants to evaluate dxkit before installing it.
+---
+
+# dxkit-evaluate
+
+This skill answers the pre-adoption question honestly: **what would dxkit's
+gate have done on this repo's real history, and at what cost?** It runs the
+real guardrail — the same code path the installed Stop-gate and CI gate use —
+against historical ref pairs, in disposable temp worktrees. Nothing is
+written to the repo: no `.dxkit/`, no baseline, no hooks.
+
+## Running the trial
+
+The default replays the last 10 landings (merged PRs / squash commits) of the
+current branch:
+
+```bash
+vyuh-dxkit evaluate                      # last 10 landings, security-only posture
+vyuh-dxkit evaluate --last-prs 20        # more history
+vyuh-dxkit evaluate --preset full-debt   # also gate test gaps + quality regressions
+vyuh-dxkit evaluate --base origin/main~5 --head origin/main   # one explicit range
+vyuh-dxkit evaluate --json               # the versioned evidence document
+vyuh-dxkit evaluate --json --redact      # shareable: file paths + lines stripped
+```
+
+## Reading the result
+
+- **Blocked landings** list the exact net-new findings the gate would have
+  returned for repair. Dependency findings on old landings carry an
+  anachronism note (advisories are current-day) — say so when summarizing.
+- **A clean replay is a positive result, not an empty one**: it means the
+  repo's existing debt would be grandfathered and the gate would have stayed
+  out of the way. Present it that way — the gate's value is blocking the
+  regression that hasn't happened yet, and the trial just measured its
+  false-block behavior on real history.
+- **The costs section is measured, not modeled**: gate latency comes from
+  this trial on this machine, the interruption rate from the repo's own
+  history. Quote those numbers; do not invent others.
+- Some finding classes are structurally excluded from a ref-vs-ref replay
+  (duplication, test gaps, custom checks) — the output discloses this. Do
+  not claim the trial covered them.
+
+## Next steps to offer
+
+- Clean history and the user wants to see a block happen:
+  `npx -y @vyuhlabs/dxkit@latest demo loop-guardrail` (20 seconds, fixture
+  repo, their repo untouched).
+- Ready to enable: `npm init @vyuhlabs/dxkit -- --claude-loop --yes`, then
+  `vyuh-dxkit baseline create`. Everything is reversible via
+  `vyuh-dxkit uninstall`.

--- a/src/analyzers/security/malicious.ts
+++ b/src/analyzers/security/malicious.ts
@@ -31,15 +31,28 @@
  * dependency, which is the costlier error.
  */
 
-/** CWE ids for the malicious-code family (CWE-506 "Embedded Malicious
- *  Code" and its children). Matched case-insensitively on the exact id. */
-const MALICIOUS_CWES = new Set([
-  'CWE-506', // Embedded Malicious Code
-  'CWE-507', // Trojan Horse
-  'CWE-510', // Trapdoor
-  'CWE-511', // Logic/Time Bomb
-  'CWE-512', // Spyware
-]);
+/**
+ * The CWE malicious-code family: CWE-506 "Embedded Malicious Code" and its
+ * children, which occupy the contiguous id range 506–512 (507 Trojan
+ * Horse, 508 Non-Replicating, 509 Replicating, 510 Trapdoor, 511
+ * Logic/Time Bomb, 512 Spyware). Checked as a RANGE so the family is
+ * complete by construction — a hand-picked set is exactly where a member
+ * gets forgotten (the first draft of this file missed 508/509).
+ *
+ * Maintenance posture: this subtree has been unchanged since CWE 1.0
+ * (2008), so the range is effectively static — and it is deliberately the
+ * SECONDARY signal. The signal that actually evolves (which packages are
+ * malicious) is ecosystem-maintained for us: OSV's `MAL-*` namespace,
+ * fed by OpenSSF's malicious-packages database and matched above by id.
+ * The CWE and title branches exist for feeds that carry no MAL id
+ * (GitHub advisories via npm audit, ingested SARIF), as defense in depth.
+ */
+function isMaliciousCwe(cwe: string): boolean {
+  const m = /^CWE-(\d+)$/i.exec(cwe.trim());
+  if (!m) return false;
+  const n = Number(m[1]);
+  return n >= 506 && n <= 512;
+}
 
 const MAL_NAMESPACE = /^MAL-\d{4}-\d+/i;
 
@@ -57,7 +70,7 @@ export interface MaliciousAdvisorySignals {
 export function isMaliciousAdvisory(f: MaliciousAdvisorySignals): boolean {
   if (MAL_NAMESPACE.test(f.id)) return true;
   if (f.aliases?.some((a) => MAL_NAMESPACE.test(a))) return true;
-  if (f.cwes?.some((c) => MALICIOUS_CWES.has(c.toUpperCase()))) return true;
+  if (f.cwes?.some(isMaliciousCwe)) return true;
   if (f.summary && MALICIOUS_TEXT.test(f.summary)) return true;
   return false;
 }

--- a/src/analyzers/security/malicious.ts
+++ b/src/analyzers/security/malicious.ts
@@ -1,0 +1,63 @@
+/**
+ * Malicious-advisory classification — ONE source of truth (the mirror of
+ * `benign.ts` at the other end of the severity scale). A dependency
+ * advisory that reports the package itself as malware (a compromised
+ * release, a trojaned version, install-time malicious code) is a
+ * different class from a vulnerability: install-time malware executes at
+ * `npm install`, so "is the vulnerable function reachable from my code"
+ * is the wrong lens entirely, and CVSS often under-scores or omits it
+ * (OSV `MAL-*` entries frequently carry no score at all).
+ *
+ * The guardrail consults this predicate to drive the
+ * `newMaliciousDependency` block rule: a NET-NEW dependency carrying a
+ * malicious-code advisory blocks under every posture, including
+ * `security-only`, regardless of CVSS severity.
+ *
+ * Every branch is grounded in a real feed (verified against the July 2025
+ * eslint-config-prettier compromise, CVE-2025-54313):
+ *   - OSV's dedicated malicious-package namespace: id/alias `MAL-….`
+ *     (osv-scanner reports `MAL-2025-6022` for the incident).
+ *   - The CWE malicious-code family, which npm audit attaches
+ *     (`CWE-506` on the incident's GHSA advisory).
+ *   - The advisory-title conventions both ecosystems use: OSV's
+ *     "Malicious code in <pkg>" and GitHub's "… have embedded malicious
+ *     code".
+ *
+ * Bias: this predicate BLOCKS, so it is precision-biased — the text
+ * branch requires "malicious" adjacent to code/package/version, which a
+ * normal vulnerability description ("fails to sanitize malicious input")
+ * does not produce. A missed malware advisory still surfaces through the
+ * ordinary severity rules; a false positive here would block a clean
+ * dependency, which is the costlier error.
+ */
+
+/** CWE ids for the malicious-code family (CWE-506 "Embedded Malicious
+ *  Code" and its children). Matched case-insensitively on the exact id. */
+const MALICIOUS_CWES = new Set([
+  'CWE-506', // Embedded Malicious Code
+  'CWE-507', // Trojan Horse
+  'CWE-510', // Trapdoor
+  'CWE-511', // Logic/Time Bomb
+  'CWE-512', // Spyware
+]);
+
+const MAL_NAMESPACE = /^MAL-\d{4}-\d+/i;
+
+/** "Malicious code in x", "… have embedded malicious code",
+ *  "malicious version(s) of …" — never bare "malicious input". */
+const MALICIOUS_TEXT = /\bmalicious\s+(code|package|version)/i;
+
+export interface MaliciousAdvisorySignals {
+  readonly id: string;
+  readonly aliases?: readonly string[];
+  readonly summary?: string;
+  readonly cwes?: readonly string[];
+}
+
+export function isMaliciousAdvisory(f: MaliciousAdvisorySignals): boolean {
+  if (MAL_NAMESPACE.test(f.id)) return true;
+  if (f.aliases?.some((a) => MAL_NAMESPACE.test(a))) return true;
+  if (f.cwes?.some((c) => MALICIOUS_CWES.has(c.toUpperCase()))) return true;
+  if (f.summary && MALICIOUS_TEXT.test(f.summary)) return true;
+  return false;
+}

--- a/src/analyzers/tools/osv-scanner-deps.ts
+++ b/src/analyzers/tools/osv-scanner-deps.ts
@@ -32,6 +32,7 @@ import {
   resolveCvssScores,
   type OsvVuln,
 } from './osv';
+import { isMaliciousAdvisory } from '../security/malicious';
 import { fileExists, run } from './runner';
 import { findTool, TOOL_DEFS } from './tool-registry';
 import type {
@@ -225,9 +226,69 @@ export async function gatherOsvScannerDepVulnsResult(
     counts,
     findings,
   };
-  // G_v4_4 (2.4.7): `packId` is forwarded into `parseOsvScannerFindings`
-  // so each finding carries the producing pack, which `buildUpgradeCommand`
-  // dispatches on. Envelope-level `tool: 'osv-scanner'` stays as the
-  // tool-attribution string used in `toolsUsed`.
+  // `packId` is forwarded into `parseOsvScannerFindings` so each finding
+  // carries the producing pack, which `buildUpgradeCommand` dispatches on.
+  // Envelope-level `tool: 'osv-scanner'` stays as the tool-attribution
+  // string used in `toolsUsed`.
   return { kind: 'success', envelope };
+}
+
+/**
+ * Overlay the ecosystem-maintained malicious-package feed onto a native
+ * scanner's result — the canonical-source answer to malware detection.
+ *
+ * Several packs use a native Tier-1 scanner (npm audit, cargo-audit,
+ * govulncheck, `dotnet list --vulnerable`) whose advisory feed does NOT
+ * carry OSV's `MAL-*` malicious-package entries, fed by OpenSSF's
+ * malicious-packages database. Those packs run osv-scanner as a
+ * best-effort second source and merge JUST the malicious findings in via
+ * this helper, so the `newMaliciousDependency` gate rule rides the
+ * maintained database on every path — never a list dxkit maintains.
+ * (Packs whose canonical scanner already IS osv-scanner — java, kotlin,
+ * ruby — and pip-audit, which queries OSV natively, need no overlay.)
+ *
+ * Merge semantics, deliberately narrow:
+ *   - ONLY findings the canonical `isMaliciousAdvisory` predicate flags
+ *     are appended. Ordinary advisories both scanners see would
+ *     double-count, and the native scanner stays the richer source for
+ *     them (embedded CVSS, fix targets).
+ *   - A malicious finding already represented in the base (same package
+ *     with an overlapping advisory id or alias) is skipped.
+ *   - Counts are recomputed to include the appended findings, keeping
+ *     the envelope's counts consistent with its findings.
+ *
+ * Pure; callers treat the overlay as best-effort (an unavailable
+ * osv-scanner never degrades the native result — fail-open on
+ * infrastructure, per the gate's standing policy).
+ */
+export function mergeMaliciousOsvFindings(
+  base: DepVulnResult,
+  overlay: DepVulnResult,
+): DepVulnResult {
+  const overlayFindings = overlay.findings ?? [];
+  if (overlayFindings.length === 0) return base;
+
+  const seen = new Set<string>();
+  for (const f of base.findings ?? []) {
+    seen.add(`${f.package} ${f.id}`);
+    for (const a of f.aliases ?? []) seen.add(`${f.package} ${a}`);
+  }
+
+  const appended = overlayFindings.filter((f) => {
+    if (!isMaliciousAdvisory(f)) return false;
+    if (seen.has(`${f.package} ${f.id}`)) return false;
+    if ((f.aliases ?? []).some((a) => seen.has(`${f.package} ${a}`))) return false;
+    return true;
+  });
+  if (appended.length === 0) return base;
+
+  const counts = { ...base.counts };
+  for (const f of appended) {
+    if (f.severity in counts) counts[f.severity as keyof typeof counts] += 1;
+  }
+  return {
+    ...base,
+    counts,
+    findings: [...(base.findings ?? []), ...appended],
+  };
 }

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -40,6 +40,7 @@ import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { dxkitCli } from '../self-invocation';
+import { isMaliciousAdvisory } from '../analyzers/security/malicious';
 import { gatherCurrentScan } from './create';
 import type { CurrentScan } from './create';
 import {
@@ -603,6 +604,7 @@ export async function runGuardrailCheck(
   const priorById = indexById(baseline.findings);
   const currentById = indexById(current.findings);
   const severityByCurrentId = buildSeverityIndex(current.aggregate);
+  const maliciousByCurrentId = buildMaliciousIndex(current.aggregate);
   const envelopeDrift = diffEnvelopes(baseline, current);
 
   // Per-kind tool attribution drives the per-pair
@@ -666,6 +668,9 @@ export async function runGuardrailCheck(
     // file is in the diff (a brand-new file has all its lines added).
     const fileChangedInDiff = file !== undefined && (linesChangedFor(file)?.size ?? 0) > 0;
 
+    const malicious =
+      pair.currentId !== undefined && maliciousByCurrentId.has(pair.currentId) ? true : undefined;
+
     const context: ClassifyContext = {
       severity,
       kind: anchorEntry.kind,
@@ -673,6 +678,7 @@ export async function runGuardrailCheck(
       ...(configDiffers ? { configDiffers: true } : {}),
       ...(fileChangedInDiff ? { fileChangedInDiff: true } : {}),
       ...(overlapsChangedLines !== undefined ? { overlapsChangedLines } : {}),
+      ...(malicious ? { malicious } : {}),
     };
 
     // `classify` is kind-agnostic; fold in the custom-check block INTENT (a
@@ -846,6 +852,22 @@ function buildSeverityIndex(aggregate: SecurityAggregate): Map<FindingId, Findin
   }
   for (const f of aggregate.findingsByCategory.dependency) {
     if (f.fingerprint) out.set(f.fingerprint, f.severity);
+  }
+  return out;
+}
+
+/**
+ * Fingerprints of current-scan dependency findings whose advisory reports
+ * the package itself as malicious code — the `newMaliciousDependency`
+ * block rule's signal. Computed from the CURRENT side only: block rules
+ * fire on `added` pairs, which always carry a currentId, so the committed
+ * baseline needs no schema change. Classification comes from the one
+ * canonical predicate (`src/analyzers/security/malicious.ts`).
+ */
+function buildMaliciousIndex(aggregate: SecurityAggregate): Set<FindingId> {
+  const out = new Set<FindingId>();
+  for (const f of aggregate.findingsByCategory.dependency) {
+    if (f.fingerprint && isMaliciousAdvisory(f)) out.add(f.fingerprint);
   }
   return out;
 }

--- a/src/baseline/classify.ts
+++ b/src/baseline/classify.ts
@@ -47,6 +47,10 @@ export interface ClassifyContext {
   readonly overlapsChangedLines?: boolean;
   /** True when an `added` dep-vuln is on a reachable code path. */
   readonly reachable?: boolean;
+  /** True when an `added` dep-vuln's advisory reports the package itself
+   *  as malicious code (OSV `MAL-*`, CWE-506 family, malware-titled
+   *  advisory) — see `src/analyzers/security/malicious.ts`. */
+  readonly malicious?: boolean;
 }
 
 /** Verdict + reasoning for one classified pair. */
@@ -204,6 +208,13 @@ function evaluateBlockRules(
     context.reachable === true
   ) {
     return 'newHighReachableDependencyVulnerability';
+  }
+  // Malicious-code advisories block at ANY severity: install-time malware
+  // executes at install, so CVSS and reachability are the wrong lens. The
+  // `malicious` signal comes from the one canonical predicate
+  // (`src/analyzers/security/malicious.ts`) applied to the current scan.
+  if (rules.newMaliciousDependency && context.kind === 'dep-vuln' && context.malicious === true) {
+    return 'newMaliciousDependency';
   }
   if (
     rules.newUntestedChangedSource &&

--- a/src/baseline/gather-scope.ts
+++ b/src/baseline/gather-scope.ts
@@ -171,7 +171,11 @@ export function scopeForPolicy(policy: BrownfieldPolicy): GatherScope {
   const scope = { ...EMPTY_SCOPE };
   if (r.newSecret) scope.secrets = true;
   if (r.newCriticalSecurity || r.newHighSecurity) scope.codePatterns = true;
-  if (r.newCriticalDependencyVulnerability || r.newHighReachableDependencyVulnerability) {
+  if (
+    r.newCriticalDependencyVulnerability ||
+    r.newHighReachableDependencyVulnerability ||
+    r.newMaliciousDependency
+  ) {
     scope.depVulns = true;
   }
   if (r.newUntestedChangedSource) scope.testGaps = true;

--- a/src/baseline/policy.ts
+++ b/src/baseline/policy.ts
@@ -91,6 +91,13 @@ export interface BrownfieldBlockRules {
   readonly newCriticalDependencyVulnerability?: boolean;
   /** Block any newly-introduced high-severity reachable dep vuln. */
   readonly newHighReachableDependencyVulnerability?: boolean;
+  /** Block a newly-introduced dependency carrying a malicious-code
+   *  advisory (OSV `MAL-*`, the CWE-506 family, a malware-titled GHSA),
+   *  REGARDLESS of CVSS severity: install-time malware executes at
+   *  install, so severity scores and code-reachability are the wrong
+   *  lens. Classified by the one canonical predicate,
+   *  `src/analyzers/security/malicious.ts`. */
+  readonly newMaliciousDependency?: boolean;
   /** Block when an untested source file is added in a changed file. */
   readonly newUntestedChangedSource?: boolean;
   /** Block any newly-introduced severe quality issue in changed files. */
@@ -305,6 +312,7 @@ export const DEFAULT_BROWNFIELD_POLICY: BrownfieldPolicy = Object.freeze({
     newHighSecurity: true,
     newCriticalDependencyVulnerability: true,
     newHighReachableDependencyVulnerability: true,
+    newMaliciousDependency: true,
     newUntestedChangedSource: true,
     newSevereQualityIssueInChangedFiles: true,
   }),

--- a/src/baseline/presets.ts
+++ b/src/baseline/presets.ts
@@ -1,0 +1,141 @@
+/**
+ * Gate posture presets — the two shipped blocking postures, shared by the
+ * surfaces that inject a preset-scoped policy into the guardrail instead of
+ * (or on top of) the repo's committed `.dxkit/policy.json`.
+ *
+ * ──────────────────────────────────────────────────────────────────────
+ *  SCOPE: exactly two consumers read this table.
+ *    1. The loop Stop-gate, via `src/loop/policy.ts:resolveLoopPolicy` —
+ *       an unattended loop's posture, resolved from `loop.preset` /
+ *       `DXKIT_LOOP_PRESET`.
+ *    2. The zero-write trial, via `src/evaluate/run.ts` — `vyuh-dxkit
+ *       evaluate --preset <p>` replays history under a named posture on a
+ *       repo that may have no dxkit config at all.
+ *  The CI / PR guardrail (`vyuh-dxkit baseline check`) and `createBaseline`
+ *  resolve the shared `BrownfieldPolicy` directly via `resolvePolicy` and
+ *  never read a preset, so a preset changes how a loop or a trial blocks
+ *  WITHOUT silently downgrading a repo's CI posture.
+ * ──────────────────────────────────────────────────────────────────────
+ *
+ * Why a curated posture exists: in CI a guardrail block just fails a check
+ * a human then reads — blocking on every debt class (test-gap, quality) is
+ * fine. In a loop a block FEEDS THE MODEL a repair instruction, so blocking
+ * on open-ended debt makes the agent grind on it unattended. The default
+ * posture therefore blocks only on the unambiguous, must-fix security
+ * class; the open-ended debt classes are an explicit opt-in.
+ */
+import { type BrownfieldBlockRules, type BrownfieldPolicy } from './policy';
+import type { FindingStatus } from './types';
+import type { FlowGateMode } from '../analyzers/flow/config';
+import type { SchemaGateMode } from '../analyzers/model-schema/config';
+
+/**
+ * The two shipped postures.
+ *   - `security-only` (default): block only on net-new secrets + crit/high
+ *     security + crit/high reachable dependency vulns. test-gap + quality
+ *     are NOT blocked — they warn. Cost-bounded; safe to run unattended.
+ *   - `full-debt`: block on every net-new finding (adds test-gap +
+ *     quality). Exhaustive but can drive an open-ended repair; opt-in.
+ */
+export type LoopPreset = 'security-only' | 'full-debt';
+
+/** The cost-bounded default — the posture a loop or a trial gets unless the
+ *  caller explicitly opts into `full-debt`. */
+export const DEFAULT_LOOP_PRESET: LoopPreset = 'security-only';
+
+export function isLoopPreset(v: unknown): v is LoopPreset {
+  return v === 'security-only' || v === 'full-debt';
+}
+
+interface PresetDef {
+  /**
+   * Generic block list (statuses that fail regardless of kind).
+   * `security-only` leaves this EMPTY so a net-new test-gap / quality
+   * finding (status `added`) does not auto-block; blocking is driven
+   * entirely by the security `blockRules` below.
+   */
+  readonly block: ReadonlyArray<FindingStatus>;
+  /** Per-kind escalation rules (see `BrownfieldBlockRules`). */
+  readonly blockRules: BrownfieldBlockRules;
+  /**
+   * Posture for the flow integration gate. `security-only` WARNS on a
+   * net-new broken integration (like test-gap / quality — it isn't a
+   * security class, and a cross-repo integration false positive must never
+   * wedge an unattended run); `full-debt` BLOCKS on it. Both keep the
+   * gate's own confidence gating (only exact bindings can block even under
+   * `block`).
+   */
+  readonly flowMode: FlowGateMode;
+  /**
+   * Posture for the model-schema drift gate — same reasoning as `flowMode`.
+   * The guardrail applies it only when the repo has ENABLED the gate:
+   * schema defaults to off, and a preset never activates it.
+   */
+  readonly schemaMode: SchemaGateMode;
+}
+
+/** The security class: secrets, crit/high SAST, crit/high reachable dep
+ *  vulns. Shared by both presets — full-debt is this plus the debt rules. */
+const SECURITY_BLOCK_RULES: BrownfieldBlockRules = {
+  newSecret: true,
+  newCriticalSecurity: true,
+  newHighSecurity: true,
+  newCriticalDependencyVulnerability: true,
+  newHighReachableDependencyVulnerability: true,
+  // Open-ended debt — OFF in security-only (warn, never block).
+  newUntestedChangedSource: false,
+  newSevereQualityIssueInChangedFiles: false,
+};
+
+const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
+  'security-only': {
+    // Empty generic block list: nothing auto-blocks by status alone, so
+    // test-gap + quality net-new findings warn but never block.
+    // Blocking comes solely from SECURITY_BLOCK_RULES.
+    block: [],
+    blockRules: SECURITY_BLOCK_RULES,
+    flowMode: 'warn',
+    schemaMode: 'warn',
+  },
+  'full-debt': {
+    // Any net-new finding blocks (generic `added`), plus every escalation.
+    block: ['added'],
+    blockRules: {
+      ...SECURITY_BLOCK_RULES,
+      newUntestedChangedSource: true,
+      newSevereQualityIssueInChangedFiles: true,
+    },
+    flowMode: 'block',
+    schemaMode: 'block',
+  },
+});
+
+/** A preset applied to a base policy, plus the gate postures the preset
+ *  dictates. The shape both consumers hand to `runGuardrailCheck`. */
+export interface PresetPolicy {
+  readonly policy: BrownfieldPolicy;
+  readonly preset: LoopPreset;
+  readonly flowMode: FlowGateMode;
+  readonly schemaMode: SchemaGateMode;
+}
+
+/**
+ * Apply a preset to a base `BrownfieldPolicy`: the base's confidence
+ * thresholds, baseline mode, and drift handling are preserved; its `block`
+ * list + `blockRules` are REPLACED by the preset's. Pure — resolution of
+ * WHICH preset applies (env var, `loop.preset`, CLI flag) stays with the
+ * consumer.
+ */
+export function policyForPreset(preset: LoopPreset, base: BrownfieldPolicy): PresetPolicy {
+  const def = PRESETS[preset];
+  return {
+    preset,
+    flowMode: def.flowMode,
+    schemaMode: def.schemaMode,
+    policy: {
+      ...base,
+      block: def.block,
+      blockRules: def.blockRules,
+    },
+  };
+}

--- a/src/baseline/presets.ts
+++ b/src/baseline/presets.ts
@@ -72,6 +72,17 @@ interface PresetDef {
    * schema defaults to off, and a preset never activates it.
    */
   readonly schemaMode: SchemaGateMode;
+  /**
+   * Statuses ADDED to the base policy's warn list (union, never a
+   * replacement — the base's drift/uncertainty warns always survive).
+   * `security-only` adds `added` so a net-new finding its block rules do
+   * not escalate (a high dep vuln without a reachability signal, a
+   * quality issue) is still REPORTED as a warning instead of passing
+   * silently — the gap a real supply-chain-incident replay exposed.
+   * `full-debt` needs no addition: its generic block list already covers
+   * `added`.
+   */
+  readonly warn: ReadonlyArray<FindingStatus>;
 }
 
 /** The security class: secrets, crit/high SAST, crit/high reachable dep
@@ -82,6 +93,13 @@ const SECURITY_BLOCK_RULES: BrownfieldBlockRules = {
   newHighSecurity: true,
   newCriticalDependencyVulnerability: true,
   newHighReachableDependencyVulnerability: true,
+  // Malware is not "debt": a net-new dependency carrying a malicious-code
+  // advisory blocks under EVERY posture regardless of CVSS — install-time
+  // malware runs at install, so severity and reachability are the wrong
+  // lens. Added after a zero-write replay of the July 2025
+  // eslint-config-prettier compromise showed the default posture passing
+  // it silently.
+  newMaliciousDependency: true,
   // Open-ended debt — OFF in security-only (warn, never block).
   newUntestedChangedSource: false,
   newSevereQualityIssueInChangedFiles: false,
@@ -94,6 +112,10 @@ const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
     // Blocking comes solely from SECURITY_BLOCK_RULES.
     block: [],
     blockRules: SECURITY_BLOCK_RULES,
+    // Every net-new finding the rules don't escalate is still a warning —
+    // silence is reserved for pre-existing debt, never for something this
+    // change introduced.
+    warn: ['added'],
     flowMode: 'warn',
     schemaMode: 'warn',
   },
@@ -105,6 +127,7 @@ const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
       newUntestedChangedSource: true,
       newSevereQualityIssueInChangedFiles: true,
     },
+    warn: [],
     flowMode: 'block',
     schemaMode: 'block',
   },
@@ -136,6 +159,9 @@ export function policyForPreset(preset: LoopPreset, base: BrownfieldPolicy): Pre
       ...base,
       block: def.block,
       blockRules: def.blockRules,
+      // Union, never replacement: the base's drift/uncertainty warns
+      // survive; the preset can only ADD warn statuses (see PresetDef.warn).
+      warn: def.warn.length > 0 ? [...new Set([...base.warn, ...def.warn])] : base.warn,
     },
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -365,6 +365,13 @@ export async function run(argv: string[]): Promise<void> {
       'changed-only': { type: 'boolean', default: false },
       incremental: { type: 'boolean', default: false },
       untrusted: { type: 'boolean', default: false },
+      // evaluate: the zero-write trial (ref pair or last-N-landings replay).
+      // --base is shared with the reviewers flags below.
+      head: { type: 'string' },
+      'last-prs': { type: 'string' },
+      preset: { type: 'string' },
+      redact: { type: 'boolean', default: false },
+      'no-incremental': { type: 'boolean', default: false },
       baseline: { type: 'string' },
       policy: { type: 'string' },
       markdown: { type: 'boolean', default: false },
@@ -911,6 +918,23 @@ export async function run(argv: string[]): Promise<void> {
         logger.fail(receiptFailureHint(err as Error));
         process.exit(1);
       }
+      break;
+    }
+
+    case 'evaluate': {
+      const { runEvaluateCli } = await import('./evaluate-cli');
+      await runEvaluateCli(resolveRepoPath(positionals[1]), {
+        base: values.base as string | undefined,
+        head: values.head as string | undefined,
+        lastPrs: values['last-prs'] as string | undefined,
+        preset: values.preset as string | undefined,
+        json: !!values.json,
+        redact: !!values.redact,
+        untrusted: !!values.untrusted,
+        noIncremental: !!values['no-incremental'],
+        verbose: !!values.verbose,
+        out: values.output as string | undefined,
+      });
       break;
     }
 

--- a/src/discovery/advisor.ts
+++ b/src/discovery/advisor.ts
@@ -54,6 +54,19 @@ function dirHasEntries(dir: string): boolean {
   }
 }
 
+/** Recommend the zero-write trial where dxkit is NOT installed yet — the
+ *  pre-adoption step. Once the manifest exists the gate itself answers the
+ *  question the trial answers, so the probe goes silent. */
+export function recommendEvaluate(ctx: RecommendContext): Recommendation | null {
+  if (existsAt(ctx.cwd, '.vyuh-dxkit.json')) return null;
+  if (!existsAt(ctx.cwd, '.git')) return null;
+  return {
+    reason:
+      'dxkit is not installed here — the zero-write trial replays your recent landings through the gate without touching the repo',
+    command: 'vyuh-dxkit evaluate',
+  };
+}
+
 /** Recommend `baseline create` when dxkit is installed but has no baseline. */
 export function recommendBaseline(ctx: RecommendContext): Recommendation | null {
   // Only relevant once dxkit is installed (the manifest exists). Without a

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -8,6 +8,7 @@ import type { CapabilityDescriptor } from './command-types';
 import {
   recommendConfigure,
   recommendBaseline,
+  recommendEvaluate,
   recommendFlow,
   recommendSchema,
   recommendChecks,
@@ -184,6 +185,17 @@ export const COMMANDS = [
     docsBlurb:
       '`tests affected --diff <ref>` lists the test files a change reaches, computed from the call graph (beats module-graph selection in composition-root repos). Fails safe to the full suite when the graph is missing, stale, or unreliable for a changed language.',
     skill: 'dxkit-test',
+  },
+  {
+    id: 'evaluate',
+    audience: 'user',
+    group: 'assess',
+    summary: 'Zero-write trial: replay your recent landings through the gate',
+    typicalRuntime: '30 sec - 1 min per landing',
+    docsBlurb:
+      'What dxkit would have blocked on your last N merged changes, plus what enabling it costs (measured gate latency, interruption rate, setup) — computed in disposable worktrees, writing nothing to your repo.',
+    skill: 'dxkit-evaluate',
+    whenToRecommend: recommendEvaluate,
   },
   {
     id: 'quality',

--- a/src/evaluate-cli.ts
+++ b/src/evaluate-cli.ts
@@ -1,0 +1,75 @@
+/**
+ * `vyuh-dxkit evaluate` — the CLI shell over the zero-write trial. Thin by
+ * design (mirror of `receipt-cli.ts`): argument shaping, progress lines,
+ * output selection, exit codes. The trial itself is `src/evaluate/run.ts`;
+ * the verdicts come from the one guardrail path.
+ *
+ * Exit code is ALWAYS 0 on a completed trial, including one with blocked
+ * landings: evaluate is an advisory replay, not a gate. Scripts that want
+ * pass/fail read the JSON (`totals.blocked`) or run `guardrail check`.
+ */
+import { writeFileSync } from 'node:fs';
+import * as logger from './logger';
+import { isLoopPreset } from './baseline/presets';
+import { RefBaselineError } from './baseline/ref-baseline';
+import { runEvaluate } from './evaluate/run';
+import { redactEvidence } from './evaluate/redact';
+import { renderEvaluateText } from './evaluate/render';
+
+export interface EvaluateCliOptions {
+  readonly base?: string;
+  readonly head?: string;
+  readonly lastPrs?: string;
+  readonly preset?: string;
+  readonly json?: boolean;
+  readonly redact?: boolean;
+  readonly untrusted?: boolean;
+  readonly noIncremental?: boolean;
+  readonly verbose?: boolean;
+  /** Write the evidence JSON to this path (an explicit, user-requested
+   *  write — the repo itself still receives nothing). */
+  readonly out?: string;
+}
+
+export async function runEvaluateCli(cwd: string, opts: EvaluateCliOptions): Promise<void> {
+  if (opts.preset !== undefined && !isLoopPreset(opts.preset)) {
+    logger.fail(`Unknown --preset ${opts.preset}. Available: security-only (default), full-debt.`);
+    process.exit(1);
+  }
+  const lastLandings = opts.lastPrs !== undefined ? Number(opts.lastPrs) : undefined;
+  if (lastLandings !== undefined && (!Number.isInteger(lastLandings) || lastLandings < 1)) {
+    logger.fail(`--last-prs needs a positive integer, got ${opts.lastPrs}.`);
+    process.exit(1);
+  }
+
+  try {
+    const doc = await runEvaluate({
+      cwd,
+      base: opts.base,
+      head: opts.head,
+      lastLandings,
+      preset: opts.preset !== undefined && isLoopPreset(opts.preset) ? opts.preset : undefined,
+      incremental: opts.noIncremental ? false : undefined,
+      untrusted: opts.untrusted,
+      verbose: opts.verbose,
+      onProgress: (line) => logger.dim(line),
+    });
+    const output = opts.redact ? redactEvidence(doc) : doc;
+    if (opts.out) {
+      writeFileSync(opts.out, JSON.stringify(output, null, 2) + '\n');
+      logger.info(`Evidence written to ${opts.out}`);
+    }
+    if (opts.json) {
+      console.log(JSON.stringify(output, null, 2)); // slop-ok: the report body IS stdout
+    } else {
+      console.log(renderEvaluateText(output)); // slop-ok: the report body IS stdout
+    }
+  } catch (err) {
+    if (err instanceof RefBaselineError) {
+      logger.fail(err.message);
+      logger.dim(`  ${err.hint}`);
+      process.exit(1);
+    }
+    throw err;
+  }
+}

--- a/src/evaluate/evidence.ts
+++ b/src/evaluate/evidence.ts
@@ -1,0 +1,318 @@
+/**
+ * The evaluate evidence document — `dxkit.evaluate-evidence.v1`.
+ *
+ * The versioned, shareable record of a zero-write trial: per-landing gate
+ * verdicts plus everything an honest reader needs to weigh them — what was
+ * watched (scanners, preset), what was structurally excluded (ref-mode
+ * kinds), what could not be measured (missing dep scanner), and the
+ * anachronism caveat (advisory data is current-day; a historical landing
+ * can "block" on a CVE disclosed after it merged).
+ *
+ * Append-only discipline per `src/evidence/conventions.ts`: an
+ * incompatible shape change is a NEW schema id, and the v1 builder stays.
+ * The full per-landing guardrail payload (`dxkit.guardrail-check.v1`) is
+ * embedded verbatim — evaluate lifts summary fields out of it but never
+ * re-derives a verdict (one concept, one code path).
+ */
+import type { GuardrailCheckResult } from '../baseline/check';
+import { type GuardrailJsonPayload, renderJson } from '../baseline/check-renderers';
+import type { ScanCoverage } from '../baseline/coverage';
+import type { LoopPreset } from '../baseline/presets';
+import { type EvidenceEnvelope, evidenceEnvelope } from '../evidence/conventions';
+import type { LandingPair } from './pr-ranges';
+
+export const EVALUATE_EVIDENCE_SCHEMA = 'dxkit.evaluate-evidence.v1' as const;
+
+/** One landing (PR merge / squash / commit) replayed through the gate. */
+export interface EvaluateRunEvidence {
+  /** Display label: "#123" when a PR number was parsed, else short SHA. */
+  readonly label: string;
+  readonly baseSha: string;
+  readonly headSha: string;
+  readonly subject?: string;
+  readonly committedAt?: string;
+  readonly prNumber?: number;
+  /** The gate verdict, lifted from the embedded payload. */
+  readonly verdict: { readonly blocks: boolean; readonly warns: boolean };
+  /** Blocking pairs, lifted for summary rendering (allowlist-suppressed
+   *  pairs excluded — mirrors the payload's verdict). */
+  readonly blocking: ReadonlyArray<{
+    readonly kind: string;
+    readonly severity?: string;
+    readonly file?: string;
+    readonly line?: number;
+  }>;
+  readonly warningCount: number;
+  /** Kinds structurally excluded from a ref-vs-ref diff (duplication,
+   *  test-gap, custom-check, secret-hmac) with the head-side counts that
+   *  were dropped — the trial cannot demo gating these; say so. */
+  readonly refExcludedKinds: ReadonlyArray<{
+    readonly kind: string;
+    readonly currentCount: number;
+  }>;
+  /** Present when the dependency audit was requested but could not run —
+   *  a clean landing is then NOT a clean bill of dependency health. */
+  readonly depVulnsUnmeasured?: { readonly reason: string };
+  /** Scanner availability for the head-side gather. */
+  readonly coverage: ScanCoverage;
+  /** Exact tool versions on each side of the diff. */
+  readonly toolVersions: {
+    readonly base: Readonly<Record<string, string>>;
+    readonly head: Readonly<Record<string, string>>;
+  };
+  readonly matcher: { readonly gitAware: boolean; readonly degradedReason?: string };
+  /** The full versioned guardrail payload for this landing. Absent only
+   *  on an errored landing (see `error`). */
+  readonly guardrail?: GuardrailJsonPayload;
+  readonly durationMs: number;
+  /** Set when this landing could not be evaluated (unresolvable ref,
+   *  worktree failure). The trial continues with the other landings. */
+  readonly error?: { readonly message: string; readonly hint?: string };
+}
+
+export interface EvaluateEvidenceDoc extends EvidenceEnvelope {
+  readonly schema: typeof EVALUATE_EVIDENCE_SCHEMA;
+  readonly repo: { readonly branch: string; readonly ref: string };
+  readonly policy: {
+    readonly preset: LoopPreset;
+    /** Where the preset came from: an explicit flag or the default. */
+    readonly source: 'flag' | 'default';
+    /** Where the base policy came from: the repo's committed
+     *  `.dxkit/policy.json` or the compiled-in defaults. */
+    readonly base: 'repo-policy' | 'defaults';
+  };
+  readonly options: { readonly incremental: boolean; readonly untrusted: boolean };
+  /** The zero-write attestation: the trial created no files, refs, or
+   *  hooks in the repository. Pinned by `test/evaluate/zero-write.test.ts`. */
+  readonly zeroWrite: true;
+  readonly runs: ReadonlyArray<EvaluateRunEvidence>;
+  readonly totals: {
+    readonly landings: number;
+    readonly blocked: number;
+    readonly warned: number;
+    readonly clean: number;
+    readonly errored: number;
+  };
+  /** Honesty notes rendered with the results (dep-advisory anachronism,
+   *  ref-mode exclusions, redaction marker). */
+  readonly notes: ReadonlyArray<string>;
+  /** What enabling dxkit would cost on THIS repo — measured from the trial
+   *  itself wherever possible, static facts otherwise. Answers "the gate
+   *  would have blocked X, but at what price?" */
+  readonly costs: EvaluateCosts;
+}
+
+/**
+ * The adoption-cost card. Provenance discipline: `gateReplayMs` and
+ * `interruptions` are MEASURED by this trial on this repo; `setup.writes`
+ * is the static, versioned list of what `init` creates (all reversible via
+ * `uninstall`); `setup.missingScanners` is the trial's own tool probe.
+ * Anything modeled rather than measured goes in `notes`, never in a
+ * number field.
+ */
+export interface EvaluateCosts {
+  /** Wall-clock cost of one gate replay on this repo (the honest upper
+   *  bound for a per-PR CI gate run; the installed Stop-gate is typically
+   *  faster — verdict cache, preset-scoped gather). */
+  readonly gateReplayMs: {
+    readonly median: number;
+    readonly p95: number;
+    readonly max: number;
+  };
+  /** How often the gate would have interrupted this repo's recent history —
+   *  the friction number. Zero interruptions = the gate would have stayed
+   *  out of the way. */
+  readonly interruptions: {
+    readonly blockedLandings: number;
+    readonly landings: number;
+  };
+  /** Warning pairs across the replay: reported, never blocking. The
+   *  ongoing-noise indicator. */
+  readonly warnNoise: number;
+  readonly setup: {
+    /** Scanners the trial found missing on this machine — what
+     *  `tools install` would provision. */
+    readonly missingScanners: ReadonlyArray<string>;
+    /** What `init --claude-loop` writes (static; every entry reversible
+     *  with `uninstall`). */
+    readonly writes: ReadonlyArray<string>;
+  };
+  /** Derivation honesty for the numbers above. */
+  readonly notes: ReadonlyArray<string>;
+}
+
+/** The static list of what the default install writes. Kept here (not in
+ *  the renderer) so JSON consumers see the same facts as the text view. */
+export const INIT_WRITES: ReadonlyArray<string> = Object.freeze([
+  '.dxkit/ (policy, baseline)',
+  '.claude/settings.json Stop hook (merged additively)',
+  'devDependency @vyuhlabs/dxkit',
+  'AGENTS.md + agent skills (optional surfaces: git hooks, CI workflows, with --full)',
+]);
+
+function percentile(sorted: ReadonlyArray<number>, p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)];
+}
+
+export function buildCosts(runs: ReadonlyArray<EvaluateRunEvidence>): EvaluateCosts {
+  const evaluated = runs.filter((r) => !r.error);
+  const durations = evaluated.map((r) => r.durationMs).sort((a, b) => a - b);
+  const missing = new Set<string>();
+  for (const run of evaluated) {
+    for (const scanner of run.coverage.scanners) {
+      if (!scanner.available) missing.add(scanner.tool);
+    }
+  }
+  return {
+    gateReplayMs: {
+      median: percentile(durations, 50),
+      p95: percentile(durations, 95),
+      max: durations.length ? durations[durations.length - 1] : 0,
+    },
+    interruptions: {
+      blockedLandings: evaluated.filter((r) => r.verdict.blocks).length,
+      landings: evaluated.length,
+    },
+    warnNoise: evaluated.reduce((sum, r) => sum + r.warningCount, 0),
+    setup: {
+      missingScanners: [...missing].sort(),
+      writes: INIT_WRITES,
+    },
+    notes: [
+      'gateReplayMs is measured by this trial on this repo (both sides gathered per landing). ' +
+        'The installed Stop-gate is typically faster: it reuses the committed baseline and a verdict cache.',
+      'Creating the initial baseline costs roughly one full scan (the same order as one replayed landing).',
+      'Every install write is reversible: `vyuh-dxkit uninstall` restores the pre-dxkit state.',
+    ],
+  };
+}
+
+/** Everything `buildRunEvidence` needs besides the gate result. */
+export interface RunEvidenceMeta {
+  readonly pair: LandingPair;
+  readonly durationMs: number;
+}
+
+export function runLabel(pair: LandingPair): string {
+  return pair.prNumber !== undefined ? `#${pair.prNumber}` : pair.headSha.slice(0, 8);
+}
+
+/** Lift one landing's evidence out of a completed gate run. */
+export function buildRunEvidence(
+  result: GuardrailCheckResult,
+  meta: RunEvidenceMeta,
+): EvaluateRunEvidence {
+  const payload = renderJson(result);
+  const blocking = payload.pairs
+    .filter((p) => p.blocks && !p.suppressedByAllowlist)
+    .map((p) => ({ kind: p.kind, severity: p.severity, file: p.file, line: p.line }));
+  return {
+    label: runLabel(meta.pair),
+    baseSha: meta.pair.baseSha,
+    headSha: meta.pair.headSha,
+    subject: meta.pair.subject || undefined,
+    committedAt: meta.pair.committedAt || undefined,
+    prNumber: meta.pair.prNumber,
+    verdict: { blocks: payload.verdict.blocks, warns: payload.verdict.warns },
+    blocking,
+    warningCount: payload.summary.warning,
+    refExcludedKinds: result.refExcludedKinds,
+    depVulnsUnmeasured: result.depVulnsUnmeasured,
+    coverage: result.current.coverage,
+    toolVersions: { base: result.baseline.tools, head: result.current.tools },
+    matcher: {
+      gitAware: payload.matcher.gitAware,
+      degradedReason: payload.matcher.degradedReason,
+    },
+    guardrail: payload,
+    durationMs: meta.durationMs,
+  };
+}
+
+/** The evidence entry for a landing that could not be evaluated. */
+export function buildErrorEvidence(
+  pair: LandingPair,
+  durationMs: number,
+  error: { message: string; hint?: string },
+): EvaluateRunEvidence {
+  return {
+    label: runLabel(pair),
+    baseSha: pair.baseSha,
+    headSha: pair.headSha,
+    subject: pair.subject || undefined,
+    committedAt: pair.committedAt || undefined,
+    prNumber: pair.prNumber,
+    verdict: { blocks: false, warns: false },
+    blocking: [],
+    warningCount: 0,
+    refExcludedKinds: [],
+    coverage: { scanners: [] },
+    toolVersions: { base: {}, head: {} },
+    matcher: { gitAware: false },
+    durationMs,
+    error,
+  };
+}
+
+/** The dep-advisory anachronism disclosure, present whenever a historical
+ *  landing produced dependency-vulnerability findings. */
+export const ANACHRONISM_NOTE =
+  'Dependency advisories are current-day: a historical landing can show a block ' +
+  'for a CVE disclosed after it merged. The live gate never has this skew.';
+
+export function buildEvidenceDoc(input: {
+  readonly branch: string;
+  readonly ref: string;
+  readonly preset: LoopPreset;
+  readonly presetSource: 'flag' | 'default';
+  readonly policyBase: 'repo-policy' | 'defaults';
+  readonly incremental: boolean;
+  readonly untrusted: boolean;
+  readonly runs: ReadonlyArray<EvaluateRunEvidence>;
+}): EvaluateEvidenceDoc {
+  const evaluated = input.runs.filter((r) => !r.error);
+  const blocked = evaluated.filter((r) => r.verdict.blocks).length;
+  const warned = evaluated.filter((r) => !r.verdict.blocks && r.verdict.warns).length;
+  const notes: string[] = [];
+  // `secret-hmac` is an internal matcher-assist companion of the located
+  // `secret` kind (which IS gated here) — disclosing it would read as
+  // "secrets were not watched". It stays in each run's refExcludedKinds for
+  // fidelity but is never a user-facing exclusion.
+  const excluded = new Set(
+    evaluated
+      .flatMap((r) => r.refExcludedKinds.map((k) => k.kind))
+      .filter((k) => k !== 'secret-hmac'),
+  );
+  if (excluded.size > 0) {
+    notes.push(
+      `Not gated in this trial (ref-vs-ref replay cannot gather them comparably): ` +
+        `${[...excluded].sort().join(', ')}. The installed gate covers them in committed mode.`,
+    );
+  }
+  const hasDepFindings = evaluated.some((r) => r.blocking.some((b) => b.kind === 'dep-vuln'));
+  if (hasDepFindings) notes.push(ANACHRONISM_NOTE);
+  return {
+    ...evidenceEnvelope(EVALUATE_EVIDENCE_SCHEMA),
+    schema: EVALUATE_EVIDENCE_SCHEMA,
+    repo: { branch: input.branch, ref: input.ref },
+    policy: {
+      preset: input.preset,
+      source: input.presetSource,
+      base: input.policyBase,
+    },
+    options: { incremental: input.incremental, untrusted: input.untrusted },
+    zeroWrite: true,
+    runs: input.runs,
+    totals: {
+      landings: input.runs.length,
+      blocked,
+      warned,
+      clean: evaluated.length - blocked - warned,
+      errored: input.runs.length - evaluated.length,
+    },
+    notes,
+    costs: buildCosts(input.runs),
+  };
+}

--- a/src/evaluate/pr-ranges.ts
+++ b/src/evaluate/pr-ranges.ts
@@ -1,0 +1,73 @@
+/**
+ * Landing enumeration for the zero-write trial: the last N first-parent
+ * commits of a branch, each paired with its first parent — the "what did
+ * this landing change" ref pair the trial replays through the gate.
+ *
+ * First-parent (not `--merges`) so every merge strategy yields pairs:
+ *   - merge commits: (parent1, merge) is exactly the PR's cumulative diff;
+ *   - squash merges: the squash commit IS the PR, paired with its parent;
+ *   - rebase merges: each landed commit becomes its own pair (a coarser
+ *     but honest unit — there is no PR boundary in the history).
+ * PR numbers are best-effort parsed from the subject line ("Merge pull
+ * request #N" and the squash suffix "(#N)") so the trial stays offline —
+ * no `gh` dependency, no network.
+ */
+import { execFileSync } from 'node:child_process';
+
+export interface LandingPair {
+  /** The landing commit (merge / squash / rebase-landed commit). */
+  readonly headSha: string;
+  /** Its first parent — the tree the landing changed. */
+  readonly baseSha: string;
+  /** Commit subject line, for display. */
+  readonly subject: string;
+  /** Commit timestamp (ISO-8601). */
+  readonly committedAt: string;
+  /** Best-effort PR number parsed from the subject; absent when the
+   *  subject carries no recognizable marker. */
+  readonly prNumber?: number;
+}
+
+const MERGE_SUBJECT = /^Merge pull request #(\d+)/;
+const SQUASH_SUFFIX = /\(#(\d+)\)\s*$/;
+
+/** Parse a PR number out of a commit subject, if one is recognizable. */
+export function prNumberFromSubject(subject: string): number | undefined {
+  const merge = MERGE_SUBJECT.exec(subject);
+  if (merge) return Number(merge[1]);
+  const squash = SQUASH_SUFFIX.exec(subject);
+  if (squash) return Number(squash[1]);
+  return undefined;
+}
+
+/**
+ * The last `count` first-parent landings of `ref` (default `HEAD`),
+ * newest first. Root commits (no parent) are skipped — there is no base
+ * side to diff against. Throws on git failure (not a repo, unknown ref);
+ * the CLI surfaces the message.
+ */
+export function enumerateLandings(cwd: string, count: number, ref: string = 'HEAD'): LandingPair[] {
+  // %x1f (unit separator) cannot appear in a subject; %x1e separates records.
+  const out = execFileSync(
+    'git',
+    ['log', '--first-parent', `-n`, String(count), '--format=%H%x1f%P%x1f%cI%x1f%s%x1e', ref],
+    { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  const pairs: LandingPair[] = [];
+  for (const record of out.split('\x1e')) {
+    const line = record.trim();
+    if (!line) continue;
+    const [sha, parents, committedAt, subject] = line.split('\x1f');
+    if (!sha || !parents) continue; // root commit or malformed record
+    const firstParent = parents.split(' ')[0];
+    if (!firstParent) continue;
+    pairs.push({
+      headSha: sha,
+      baseSha: firstParent,
+      subject: subject ?? '',
+      committedAt: committedAt ?? '',
+      prNumber: prNumberFromSubject(subject ?? ''),
+    });
+  }
+  return pairs;
+}

--- a/src/evaluate/redact.ts
+++ b/src/evaluate/redact.ts
@@ -1,0 +1,52 @@
+/**
+ * Redaction for shareable evidence — `evaluate --redact`.
+ *
+ * The pipeline already guarantees no raw secret VALUES reach the evidence
+ * (secret producers store salted HMACs only). What redaction removes is
+ * repo-internal STRUCTURE a user may not want in a pasted/shared document:
+ * file paths, line numbers, and finding locators. Kinds, severities,
+ * verdicts, counts, timings, and coverage stay — the shareable story is
+ * "what the gate decided and what it cost", not "where our code lives".
+ *
+ * Pure and lossy by design: a redacted doc says so in `notes`, and the
+ * un-redacted original is never mutated.
+ */
+import type { GuardrailJsonPayload } from '../baseline/check-renderers';
+import type { EvaluateEvidenceDoc, EvaluateRunEvidence } from './evidence';
+
+const REDACTION_NOTE =
+  'Redacted for sharing: file paths, line numbers, and locators removed. ' +
+  'Kinds, severities, verdicts, and timings are unchanged.';
+
+function redactPayload(payload: GuardrailJsonPayload): GuardrailJsonPayload {
+  return {
+    ...payload,
+    pairs: payload.pairs.map((p) => ({ ...p, file: undefined, line: undefined })),
+    flowGate: payload.flowGate && {
+      ...payload.flowGate,
+      findings: payload.flowGate.findings.map((f) => ({ ...f, file: '', line: 0 })),
+      suppressed: payload.flowGate.suppressed.map((f) => ({ ...f, file: '', line: 0 })),
+    },
+    schemaDriftGate: payload.schemaDriftGate && {
+      ...payload.schemaDriftGate,
+      findings: payload.schemaDriftGate.findings.map((f) => ({ ...f, file: '', line: 0 })),
+      suppressed: payload.schemaDriftGate.suppressed.map((f) => ({ ...f, file: '', line: 0 })),
+    },
+  };
+}
+
+function redactRun(run: EvaluateRunEvidence): EvaluateRunEvidence {
+  return {
+    ...run,
+    blocking: run.blocking.map((b) => ({ kind: b.kind, severity: b.severity })),
+    guardrail: run.guardrail && redactPayload(run.guardrail),
+  };
+}
+
+export function redactEvidence(doc: EvaluateEvidenceDoc): EvaluateEvidenceDoc {
+  return {
+    ...doc,
+    runs: doc.runs.map(redactRun),
+    notes: [...doc.notes, REDACTION_NOTE],
+  };
+}

--- a/src/evaluate/render.ts
+++ b/src/evaluate/render.ts
@@ -1,0 +1,154 @@
+/**
+ * Text rendering for the zero-write trial. Pure functions returning plain
+ * strings (no ANSI, no I/O) so the funnel copy is unit-testable — the
+ * `buildNextSteps` discipline from the demo command applied to evaluate.
+ *
+ * The empty result is a first-class outcome, not an empty screen: a clean
+ * replay renders the trust framing (existing debt grandfathered, the gate
+ * would have stayed out of the way), what was WATCHED, what it would COST,
+ * and the next step — because on a well-maintained repo, clean is the
+ * common case and it has to carry the story.
+ */
+import type { EvaluateEvidenceDoc, EvaluateRunEvidence } from './evidence';
+
+function seconds(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/** Group identical kind+severity findings: "secret high ×2, dep-vuln critical". */
+function summarizeBlocking(blocking: EvaluateRunEvidence['blocking']): string {
+  const counts = new Map<string, number>();
+  for (const b of blocking) {
+    const key = b.severity ? `${b.kind} ${b.severity}` : b.kind;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([key, n]) => (n > 1 ? `${key} ×${n}` : key)).join(', ');
+}
+
+function landingLine(run: EvaluateRunEvidence): string {
+  const subject = run.subject ? `  ${run.subject.slice(0, 64)}` : '';
+  if (run.error) return `  error    ${run.label}${subject}\n           ${run.error.message}`;
+  if (run.verdict.blocks) {
+    return `  BLOCKED  ${run.label}${subject}\n           net-new: ${summarizeBlocking(run.blocking)}`;
+  }
+  if (run.verdict.warns) return `  warned   ${run.label}${subject}`;
+  return `  clean    ${run.label}${subject}`;
+}
+
+/** The headline sentence — the first thing a reader (or a screenshot) sees. */
+export function headline(doc: EvaluateEvidenceDoc): string {
+  const { blocked, landings, errored } = doc.totals;
+  const evaluated = landings - errored;
+  const unit = doc.repo.ref === 'HEAD' ? 'landings' : 'range';
+  if (doc.repo.ref !== 'HEAD') {
+    return blocked > 0
+      ? `dxkit would have blocked this ${unit}.`
+      : `dxkit would not have blocked this ${unit}.`;
+  }
+  return blocked > 0
+    ? `dxkit would have blocked ${blocked} of your last ${evaluated} landings.`
+    : `None of your last ${evaluated} landings would have been blocked.`;
+}
+
+/** The trust framing for a clean replay — the common case on a
+ *  well-maintained repo, and the false-block story: the gate would have
+ *  stayed out of the way. */
+function cleanFraming(doc: EvaluateEvidenceDoc): string[] {
+  const latest = doc.runs.find((r) => !r.error && r.guardrail);
+  const lines: string[] = [];
+  if (latest?.guardrail) {
+    const existing = latest.guardrail.baseline.findingsCount;
+    if (existing > 0) {
+      lines.push(
+        `Your repo carries ${existing} pre-existing findings in the gated classes — all ` +
+          `grandfathered. The gate blocks only what a change adds, and your recent ` +
+          `changes added nothing it blocks on.`,
+      );
+    } else {
+      lines.push(
+        `No pre-existing findings in the gated classes, and no landing added one — ` +
+          `the gate would have stayed silent throughout.`,
+      );
+    }
+  }
+  return lines;
+}
+
+function watchedSection(doc: EvaluateEvidenceDoc): string[] {
+  const lines: string[] = [`Watched (preset: ${doc.policy.preset}):`];
+  const latest = doc.runs.find((r) => !r.error);
+  if (latest) {
+    const available = latest.coverage.scanners.filter((s) => s.available).map((s) => s.tool);
+    const missing = latest.coverage.scanners.filter((s) => !s.available).map((s) => s.tool);
+    if (available.length) lines.push(`  scanners ran: ${available.join(', ')}`);
+    if (missing.length) {
+      lines.push(
+        `  scanners missing on this machine (their classes were NOT watched): ${missing.join(', ')}`,
+      );
+    }
+    if (latest.depVulnsUnmeasured) {
+      lines.push(`  dependency audit could not run: ${latest.depVulnsUnmeasured.reason}`);
+    }
+  }
+  return lines;
+}
+
+function costsSection(doc: EvaluateEvidenceDoc): string[] {
+  const c = doc.costs;
+  const lines: string[] = ['What enabling dxkit costs on this repo (measured by this trial):'];
+  if (c.gateReplayMs.median > 0) {
+    lines.push(
+      `  gate run: ${seconds(c.gateReplayMs.median)} median, ${seconds(c.gateReplayMs.p95)} p95 ` +
+        `per change (the installed Stop-gate is typically faster — it reuses the baseline ` +
+        `and a verdict cache)`,
+    );
+  }
+  const unit = c.interruptions.landings === 1 ? 'landing' : 'landings';
+  lines.push(
+    c.interruptions.blockedLandings === 0
+      ? `  interruptions: none across the ${c.interruptions.landings} evaluated ${unit}`
+      : `  interruptions: ${c.interruptions.blockedLandings} of the ` +
+          `${c.interruptions.landings} evaluated ${unit} would have paused for a repair`,
+  );
+  if (c.warnNoise > 0) {
+    lines.push(`  warnings (reported, never blocking): ${c.warnNoise} across the replay`);
+  }
+  if (c.setup.missingScanners.length > 0) {
+    lines.push(`  setup: \`tools install\` would provision ${c.setup.missingScanners.join(', ')}`);
+  }
+  lines.push(`  install writes: ${c.setup.writes.join('; ')}`);
+  lines.push('  everything is reversible: `vyuh-dxkit uninstall` restores the pre-dxkit state');
+  return lines;
+}
+
+function nextSteps(doc: EvaluateEvidenceDoc): string[] {
+  const lines: string[] = ['Next:'];
+  if (doc.totals.blocked === 0) {
+    lines.push(
+      '  see a real block → repair → clean cycle in ~20s (fixture repo, yours untouched):',
+      '    npx -y @vyuhlabs/dxkit@latest demo loop-guardrail',
+    );
+  }
+  lines.push(
+    '  arm the gate for real (one command, reversible):',
+    '    npm init @vyuhlabs/dxkit -- --claude-loop --yes',
+  );
+  return lines;
+}
+
+/** The full text report. */
+export function renderEvaluateText(doc: EvaluateEvidenceDoc): string {
+  const sections: string[][] = [];
+  sections.push([headline(doc)]);
+  sections.push(doc.runs.map(landingLine));
+  if (doc.totals.blocked === 0) {
+    const framing = cleanFraming(doc);
+    if (framing.length) sections.push(framing);
+  }
+  sections.push(watchedSection(doc));
+  sections.push(costsSection(doc));
+  if (doc.notes.length) sections.push(['Notes:', ...doc.notes.map((n) => `  ${n}`)]);
+  sections.push(nextSteps(doc));
+  sections.push(['Nothing was written to your repo.']);
+  return sections.map((s) => s.join('\n')).join('\n\n');
+}

--- a/src/evaluate/run.ts
+++ b/src/evaluate/run.ts
@@ -1,0 +1,193 @@
+/**
+ * The zero-write trial runner — `vyuh-dxkit evaluate`.
+ *
+ * Replays the guardrail gate over historical ref pairs (a single
+ * `--base`/`--head` pair, or the last N landings of the current branch)
+ * and reports what the gate WOULD have blocked — without writing anything
+ * to the repository: no `.dxkit/`, no baseline file, no refs, no hooks.
+ *
+ * The zero-write guarantee is structural, not best-effort: the gate NEVER
+ * runs with the user's repo as its working directory. Each landing's head
+ * side is checked out into a disposable `withRefWorktree` temp dir and the
+ * guardrail runs from there (`cliMode: 'ref-based'` diffing against the
+ * landing's base), so every cache the pipeline writes (`.dxkit/cache/…`)
+ * lands in the temp worktree and is torn down with it. Pinned by
+ * `test/evaluate/zero-write.test.ts`.
+ *
+ * Everything here is composition of existing gate machinery — the trial
+ * must never fork a verdict path (one concept, one code path): the diff is
+ * `runGuardrailCheck`, the posture is `policyForPreset`, the checkout is
+ * `withRefWorktree`.
+ */
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import * as path from 'node:path';
+import { runGuardrailCheck } from '../baseline/check';
+import { scopeForPolicy } from '../baseline/gather-scope';
+import { DEFAULT_POLICY_FILENAME, resolvePolicy } from '../baseline/policy';
+import { DEFAULT_LOOP_PRESET, type LoopPreset, policyForPreset } from '../baseline/presets';
+import { RefBaselineError, resolveRefToSha, withRefWorktree } from '../baseline/ref-baseline';
+import {
+  buildErrorEvidence,
+  buildEvidenceDoc,
+  buildRunEvidence,
+  type EvaluateEvidenceDoc,
+  type EvaluateRunEvidence,
+  runLabel,
+} from './evidence';
+import { enumerateLandings, type LandingPair } from './pr-ranges';
+
+export interface EvaluateOptions {
+  readonly cwd: string;
+  /** Single-pair mode: replay exactly this base→head diff. */
+  readonly base?: string;
+  readonly head?: string;
+  /** History mode: replay the last N landings of `ref` (default HEAD).
+   *  Used when `base`/`head` are not given; defaults to 10. */
+  readonly lastLandings?: number;
+  readonly preset?: LoopPreset;
+  /** Incremental scanning (changed-files-scoped semgrep, manifest-gated
+   *  dep audit) — the same soundness argument as the CI ref-based gate.
+   *  Default true; `--no-incremental` opts out for a full-tree replay. */
+  readonly incremental?: boolean;
+  readonly untrusted?: boolean;
+  readonly verbose?: boolean;
+  /** Per-landing progress line, wired to stderr by the CLI. */
+  readonly onProgress?: (line: string) => void;
+}
+
+/** A ref pair the trial will replay, resolved to SHAs up front so an
+ *  unresolvable ref fails fast with a targeted message. */
+interface ResolvedPair {
+  readonly pair: LandingPair;
+}
+
+function currentBranch(cwd: string): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return '(unknown)';
+  }
+}
+
+/** A raw 40-hex ref renders friendlier shortened; named refs stay verbatim. */
+function displayRef(ref: string): string {
+  return /^[0-9a-f]{40}$/.test(ref) ? ref.slice(0, 8) : ref;
+}
+
+function resolveExplicitPair(cwd: string, base: string, head: string): ResolvedPair {
+  const baseSha = resolveRefToSha(cwd, base);
+  if (!baseSha) throw new RefBaselineError(`Cannot resolve --base ${base}.`, fetchHint(base));
+  const headSha = resolveRefToSha(cwd, head);
+  if (!headSha) throw new RefBaselineError(`Cannot resolve --head ${head}.`, fetchHint(head));
+  return {
+    pair: {
+      baseSha,
+      headSha,
+      subject: `${displayRef(base)}..${displayRef(head)}`,
+      committedAt: '',
+      prNumber: undefined,
+    },
+  };
+}
+
+function fetchHint(ref: string): string {
+  return `Run \`git fetch origin\` (or \`git fetch --unshallow\` on a shallow clone) so ${ref} is reachable locally.`;
+}
+
+/**
+ * Run the trial. Per-landing failures do not abort the run — they become
+ * `error` rows in the evidence so a 20-landing replay with one unreadable
+ * ref still reports the other 19.
+ */
+export async function runEvaluate(opts: EvaluateOptions): Promise<EvaluateEvidenceDoc> {
+  const cwd = path.resolve(opts.cwd);
+  const preset = opts.preset ?? DEFAULT_LOOP_PRESET;
+  const presetSource: 'flag' | 'default' = opts.preset ? 'flag' : 'default';
+  const incremental = opts.incremental ?? true;
+  const untrusted = opts.untrusted ?? false;
+
+  // The base policy is the repo's committed policy when one exists (the
+  // user's current intent), else the compiled-in defaults — so the trial
+  // works on a repo with no dxkit install at all. The preset then replaces
+  // the blocking posture, exactly as the loop Stop-gate does.
+  const hasRepoPolicy = existsSync(path.join(cwd, DEFAULT_POLICY_FILENAME));
+  const applied = policyForPreset(preset, resolvePolicy(undefined, cwd));
+  // Scope the gather exactly the way the Stop-gate does for this policy —
+  // the replay measures the gate the user would actually run, and a
+  // security-only trial skips the analyzers it can never block on.
+  const scope = scopeForPolicy(applied.policy);
+
+  let pairs: ResolvedPair[];
+  let trialRef: string;
+  if (opts.base || opts.head) {
+    if (!opts.base || !opts.head) {
+      throw new RefBaselineError(
+        'evaluate needs both --base and --head (or neither, for the last-landings replay).',
+        'Example: vyuh-dxkit evaluate --base origin/main~5 --head origin/main',
+      );
+    }
+    pairs = [resolveExplicitPair(cwd, opts.base, opts.head)];
+    trialRef = `${displayRef(opts.base)}..${displayRef(opts.head)}`;
+  } else {
+    const count = opts.lastLandings ?? 10;
+    const landings = enumerateLandings(cwd, count);
+    if (landings.length === 0) {
+      throw new RefBaselineError(
+        'No landings found to replay: the current branch has no first-parent history with a base side.',
+        'Point evaluate at a branch with merged history, or pass an explicit --base/--head pair.',
+      );
+    }
+    pairs = landings.map((pair) => ({ pair }));
+    trialRef = 'HEAD';
+  }
+
+  const runs: EvaluateRunEvidence[] = [];
+  for (const { pair } of pairs) {
+    const started = Date.now();
+    opts.onProgress?.(`evaluating ${runLabel(pair)} (${pair.headSha.slice(0, 8)})…`);
+    try {
+      // The head side gets its own disposable worktree; the gate runs FROM
+      // that worktree, never from the user's repo (the zero-write spine).
+      // Worktrees share the object DB, so the base SHA resolves inside it.
+      const result = await withRefWorktree({ cwd, ref: pair.headSha }, (headWorktree) =>
+        runGuardrailCheck({
+          cwd: headWorktree,
+          cliMode: 'ref-based',
+          cliRef: pair.baseSha,
+          policy: applied.policy,
+          flowMode: applied.flowMode,
+          schemaMode: applied.schemaMode,
+          scope,
+          incremental,
+          untrusted,
+          verbose: opts.verbose,
+        }),
+      );
+      runs.push(buildRunEvidence(result, { pair, durationMs: Date.now() - started }));
+    } catch (err) {
+      const e = err as Error & { hint?: string };
+      runs.push(
+        buildErrorEvidence(pair, Date.now() - started, {
+          message: e.message,
+          hint: e.hint,
+        }),
+      );
+    }
+  }
+
+  return buildEvidenceDoc({
+    branch: currentBranch(cwd),
+    ref: trialRef,
+    preset,
+    presetSource,
+    policyBase: hasRepoPolicy ? 'repo-policy' : 'defaults',
+    incremental,
+    untrusted,
+    runs,
+  });
+}

--- a/src/evidence/conventions.ts
+++ b/src/evidence/conventions.ts
@@ -1,0 +1,58 @@
+/**
+ * Evidence conventions — the shared vocabulary for dxkit's zero-write
+ * evidence documents (`vyuh-dxkit evaluate`, `vyuh-dxkit describe`, and any
+ * future trial/report surface that emits a shareable, versioned artifact).
+ *
+ * One module so the vocabulary cannot fork (the one-concept rule): every
+ * evidence schema id is registered here APPEND-ONLY, every doc carries the
+ * same envelope fields, and the epistemic-label enum has exactly one
+ * definition. `test/evidence/conventions-freeze.test.ts` pins the registry
+ * and the label set the same way the SDK wire-schema ids are pinned — a
+ * shipped schema id is never removed or renamed; an incompatible shape
+ * change is a NEW id (`…v2`) and readers up-convert at ingest.
+ */
+import { VERSION as DXKIT_VERSION } from '../constants';
+
+/**
+ * Registered evidence schema ids. APPEND-ONLY: removing or renaming an
+ * entry breaks every consumer that version-gates on `doc.schema` — add a
+ * `…v2` alongside instead and keep the v1 reader.
+ */
+export const EVIDENCE_SCHEMA_IDS = ['dxkit.evaluate-evidence.v1'] as const;
+
+export type EvidenceSchemaId = (typeof EVIDENCE_SCHEMA_IDS)[number];
+
+/**
+ * How a fact in an evidence document is known. The honesty vocabulary
+ * shared by every evidence surface (the repo card labels every field with
+ * one of these; evaluate uses them for disclosure notes):
+ *   - `observed`: dxkit parsed the source / ran the tool itself.
+ *   - `derived`: taken from an artifact the repo declared (a spec, a
+ *     committed contract) — trusted, but dxkit did not see the source.
+ *   - `inferred`: heuristic, carries a confidence; may be wrong.
+ *   - `unknown`: dxkit knows the fact exists but cannot resolve it
+ *     (a dynamic call, a missing scanner, an unreachable participant).
+ */
+export const EPISTEMIC_LABELS = ['observed', 'derived', 'inferred', 'unknown'] as const;
+
+export type EpistemicLabel = (typeof EPISTEMIC_LABELS)[number];
+
+/**
+ * The envelope every evidence document opens with. `schema` first so
+ * downstream tooling can version-gate before reading further fields.
+ */
+export interface EvidenceEnvelope {
+  readonly schema: EvidenceSchemaId;
+  /** ISO-8601 timestamp of the run that produced the document. */
+  readonly generatedAt: string;
+  readonly dxkitVersion: string;
+}
+
+/** Build the envelope for a new evidence document. */
+export function evidenceEnvelope(schema: EvidenceSchemaId): EvidenceEnvelope {
+  return {
+    schema,
+    generatedAt: new Date().toISOString(),
+    dxkitVersion: DXKIT_VERSION,
+  };
+}

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -197,6 +197,11 @@ export const DXKIT_SKILLS = [
   // failures and blocks only net-new ones (pre-existing debt grandfathered).
   // Drives `vyuh-dxkit checks` + the policy.json:checks/lint config. Rule 17.
   'dxkit-checks',
+  // dxkit-evaluate: the zero-write trial. Replays recent landings through
+  // the gate in disposable worktrees and reports what would have blocked
+  // plus what enabling dxkit costs — the honest pre-adoption answer, and
+  // useful post-install for "would the gate have caught this range".
+  'dxkit-evaluate',
 ] as const;
 
 interface GenerateResult {

--- a/src/languages/capabilities/types.ts
+++ b/src/languages/capabilities/types.ts
@@ -150,6 +150,11 @@ export interface DepVulnFinding {
   aliases?: string[];
   summary?: string;
   references?: string[];
+  /** CWE ids the advisory carries (e.g. `['CWE-506']`). Drives the
+   *  malicious-code classification (`isMaliciousAdvisory`) — CWE-506
+   *  "Embedded Malicious Code" and family are the deterministic malware
+   *  signal npm audit attaches. Additive metadata, never identity. */
+  cwes?: string[];
 
   // Top-level (direct) manifest dep(s) this advisory rolls up to.
   // `['axios']` when the vulnerable package is itself a direct dep.

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -11,7 +11,10 @@ import {
   enrichWithUpgradePlans,
   gatherOsvScannerFixPlans,
 } from '../analyzers/tools/osv-scanner-fix';
-import { gatherOsvScannerDepVulnsResult } from '../analyzers/tools/osv-scanner-deps';
+import {
+  gatherOsvScannerDepVulnsResult,
+  mergeMaliciousOsvFindings,
+} from '../analyzers/tools/osv-scanner-deps';
 import { detectLockfile } from '../package-manager';
 import { fileExists, run, runJSON } from '../analyzers/tools/runner';
 import { walkPaths } from '../analyzers/tools/walk-paths';
@@ -363,7 +366,26 @@ async function gatherTsDepVulnsResult(
     return gatherOsvScannerDepVulnsResult(cwd, 'typescript', 'npm', [lock.lockfile]);
   }
 
-  return gatherTsDepVulnsViaNpmAudit(cwd, opts);
+  // npm lockfile: npm audit stays the canonical source (richest feed —
+  // embedded CVSS, fix targets), and osv-scanner joins BEST-EFFORT for the
+  // one signal npm audit's advisory feed structurally lacks: OSV `MAL-*`
+  // malicious-package entries from OpenSSF's ecosystem-maintained database.
+  // Without the overlay, the malicious-package gate rule on the npm path
+  // depends on fallback signals (the CWE-506 family, advisory titles)
+  // instead of the canonical source. An unavailable or failing osv-scanner
+  // never degrades the npm-audit result (fail-open on infrastructure).
+  const audit = await gatherTsDepVulnsViaNpmAudit(cwd, opts);
+  if (audit.kind !== 'success') return audit;
+  try {
+    const overlay = await gatherOsvScannerDepVulnsResult(cwd, 'typescript', 'npm', [lock.lockfile]);
+    if (overlay.kind !== 'success') return audit;
+    return {
+      kind: 'success',
+      envelope: mergeMaliciousOsvFindings(audit.envelope, overlay.envelope),
+    };
+  } catch {
+    return audit;
+  }
 }
 
 /**

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -469,6 +469,7 @@ async function gatherTsDepVulnsViaNpmAudit(
           if (ghsa) finding.aliases = [ghsa];
           if (v.title) finding.summary = v.title;
           if (v.url) finding.references = [v.url];
+          if (v.cwe && v.cwe.length > 0) finding.cwes = v.cwe;
           const parents = topLevelIndex.get(advisoryPkg);
           if (parents && parents.length > 0) finding.topLevelDep = parents;
           findings.push(finding);

--- a/src/loop/policy.ts
+++ b/src/loop/policy.ts
@@ -1,115 +1,33 @@
 /**
- * Loop policy presets — a curated blocking posture scoped to autonomous
- * coding loops ONLY.
+ * Loop policy resolution — how an autonomous loop picks its blocking
+ * posture. The preset TABLE itself (what each posture blocks) lives in
+ * `src/baseline/presets.ts`, shared with the zero-write trial
+ * (`vyuh-dxkit evaluate`); this module owns the loop-scoped RESOLUTION:
+ * which preset is active for a repo's unattended loop, read from
+ * `DXKIT_LOOP_PRESET` / `.dxkit/policy.json:loop.preset`.
  *
- * ──────────────────────────────────────────────────────────────────────
- *  SCOPE: this layer is read by exactly one consumer — the Stop-gate
- *  (`src/loop/stop-gate.ts`). The CI / PR guardrail (`vyuh-dxkit baseline
- *  check`) and `createBaseline` resolve the shared `BrownfieldPolicy`
- *  directly via `resolvePolicy` and NEVER read `loop.preset`. So setting a
- *  preset changes how an unattended loop blocks WITHOUT silently
- *  downgrading a repo's CI posture. The `loop.*` namespace in
- *  `.dxkit/policy.json` and the `Loop`-prefixed names here both signal
- *  that boundary.
- * ──────────────────────────────────────────────────────────────────────
- *
- * Why a loop-only posture exists: in CI a guardrail block just fails a
- * check a human then reads — blocking on every debt class (test-gap,
- * quality) is fine. In a loop a block instead FEEDS THE MODEL a repair
- * instruction, so blocking on open-ended debt makes the agent grind on it
- * unattended (writing tests / refactoring until the gap closes), which is
- * expensive and unbounded. The default loop posture therefore blocks only
- * on the unambiguous, must-fix security class; the open-ended debt classes
- * are an explicit opt-in.
+ * The `loop.*` namespace in `.dxkit/policy.json` and the `Loop`-prefixed
+ * names signal the boundary: the CI / PR guardrail (`vyuh-dxkit baseline
+ * check`) and `createBaseline` resolve the shared `BrownfieldPolicy`
+ * directly via `resolvePolicy` and NEVER read `loop.preset`, so setting a
+ * preset changes how an unattended loop blocks WITHOUT silently
+ * downgrading a repo's CI posture.
  */
 import * as fs from 'fs';
 import * as path from 'path';
+import { type BrownfieldPolicy, DEFAULT_POLICY_FILENAME, resolvePolicy } from '../baseline/policy';
 import {
-  type BrownfieldBlockRules,
-  type BrownfieldPolicy,
-  DEFAULT_POLICY_FILENAME,
-  resolvePolicy,
-} from '../baseline/policy';
-import type { FindingStatus } from '../baseline/types';
+  DEFAULT_LOOP_PRESET,
+  isLoopPreset,
+  type LoopPreset,
+  policyForPreset,
+} from '../baseline/presets';
 import type { FlowGateMode } from '../analyzers/flow/config';
 import type { SchemaGateMode } from '../analyzers/model-schema/config';
 
-/**
- * The two shipped loop postures.
- *   - `security-only` (default): block only on net-new secrets + crit/high
- *     security + crit/high reachable dependency vulns. test-gap + quality
- *     are NOT blocked — they warn. Cost-bounded; safe to run unattended.
- *   - `full-debt`: block on every net-new finding (adds test-gap +
- *     quality). Exhaustive but can drive an open-ended repair; opt-in.
- */
-export type LoopPreset = 'security-only' | 'full-debt';
-
-/** The cost-bounded default — the posture an unattended loop gets unless
- *  the repo explicitly opts into `full-debt`. */
-export const DEFAULT_LOOP_PRESET: LoopPreset = 'security-only';
-
-interface PresetDef {
-  /**
-   * Generic block list (statuses that fail regardless of kind).
-   * `security-only` leaves this EMPTY so a net-new test-gap / quality
-   * finding (status `added`) does not auto-block; blocking is driven
-   * entirely by the security `blockRules` below.
-   */
-  readonly block: ReadonlyArray<FindingStatus>;
-  /** Per-kind escalation rules (see `BrownfieldBlockRules`). */
-  readonly blockRules: BrownfieldBlockRules;
-  /**
-   * Posture for the flow integration gate. `security-only` WARNS on a net-new
-   * broken integration (like test-gap / quality — it isn't a security class,
-   * and a cross-repo integration false positive must never wedge an unattended
-   * loop); `full-debt` BLOCKS on it. Both keep the gate's own confidence gating
-   * (only exact bindings can block even under `block`).
-   */
-  readonly flowMode: FlowGateMode;
-  /**
-   * Posture for the model-schema drift gate — same reasoning as `flowMode`
-   * (a contract-drift false positive must never wedge an unattended loop).
-   * The guardrail applies it only when the repo has ENABLED the gate:
-   * schema defaults to off, and a loop preset never activates it.
-   */
-  readonly schemaMode: SchemaGateMode;
-}
-
-/** The security class: secrets, crit/high SAST, crit/high reachable dep
- *  vulns. Shared by both presets — full-debt is this plus the debt rules. */
-const SECURITY_BLOCK_RULES: BrownfieldBlockRules = {
-  newSecret: true,
-  newCriticalSecurity: true,
-  newHighSecurity: true,
-  newCriticalDependencyVulnerability: true,
-  newHighReachableDependencyVulnerability: true,
-  // Open-ended debt — OFF in security-only (warn, never block in a loop).
-  newUntestedChangedSource: false,
-  newSevereQualityIssueInChangedFiles: false,
-};
-
-const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
-  'security-only': {
-    // Empty generic block list: nothing auto-blocks by status alone, so
-    // test-gap + quality net-new findings warn but never block the loop.
-    // Blocking comes solely from SECURITY_BLOCK_RULES.
-    block: [],
-    blockRules: SECURITY_BLOCK_RULES,
-    flowMode: 'warn',
-    schemaMode: 'warn',
-  },
-  'full-debt': {
-    // Any net-new finding blocks (generic `added`), plus every escalation.
-    block: ['added'],
-    blockRules: {
-      ...SECURITY_BLOCK_RULES,
-      newUntestedChangedSource: true,
-      newSevereQualityIssueInChangedFiles: true,
-    },
-    flowMode: 'block',
-    schemaMode: 'block',
-  },
-});
+// Re-exported so existing consumers (stop-gate, scaffold, doctor, CLI) keep
+// one import site for the loop posture vocabulary.
+export { DEFAULT_LOOP_PRESET, type LoopPreset } from '../baseline/presets';
 
 /** Resolved loop posture: the policy the Stop-gate hands to the guardrail,
  *  plus the preset name that produced it (recorded in the ledger) and the
@@ -119,10 +37,6 @@ export interface ResolvedLoopPolicy {
   readonly preset: LoopPreset;
   readonly flowMode: FlowGateMode;
   readonly schemaMode: SchemaGateMode;
-}
-
-function isLoopPreset(v: unknown): v is LoopPreset {
-  return v === 'security-only' || v === 'full-debt';
 }
 
 /**
@@ -193,15 +107,11 @@ export function resolveLoopTestCommand(cwd: string): string | undefined {
 export function resolveLoopPolicy(cwd: string): ResolvedLoopPolicy {
   const base = resolvePolicy(undefined, cwd);
   const preset = resolveLoopPreset(cwd);
-  const def = PRESETS[preset];
+  const applied = policyForPreset(preset, base);
   return {
     preset,
-    flowMode: def.flowMode,
-    schemaMode: def.schemaMode,
-    policy: {
-      ...base,
-      block: def.block,
-      blockRules: def.blockRules,
-    },
+    flowMode: applied.flowMode,
+    schemaMode: applied.schemaMode,
+    policy: applied.policy,
   };
 }

--- a/test/baseline/gather-scope.test.ts
+++ b/test/baseline/gather-scope.test.ts
@@ -25,7 +25,7 @@ import { gatherCurrentScan } from '../../src/baseline/create';
  */
 
 /** A `security-only`-shaped policy: empty generic block list, security
- *  block-rules only. Mirrors `src/loop/policy.ts`'s preset. */
+ *  block-rules only. Mirrors `src/baseline/presets.ts`'s preset. */
 const SECURITY_ONLY: BrownfieldPolicy = {
   ...DEFAULT_BROWNFIELD_POLICY,
   block: [],
@@ -35,6 +35,7 @@ const SECURITY_ONLY: BrownfieldPolicy = {
     newHighSecurity: true,
     newCriticalDependencyVulnerability: true,
     newHighReachableDependencyVulnerability: true,
+    newMaliciousDependency: true,
     newUntestedChangedSource: false,
     newSevereQualityIssueInChangedFiles: false,
   },
@@ -109,6 +110,7 @@ describe('scopeForPolicy', () => {
       'newHighSecurity',
       'newCriticalDependencyVulnerability',
       'newHighReachableDependencyVulnerability',
+      'newMaliciousDependency',
       'newUntestedChangedSource',
       'newSevereQualityIssueInChangedFiles',
     ] as const;
@@ -122,6 +124,7 @@ describe('scopeForPolicy', () => {
           newHighSecurity: false,
           newCriticalDependencyVulnerability: false,
           newHighReachableDependencyVulnerability: false,
+          newMaliciousDependency: false,
           newUntestedChangedSource: false,
           newSevereQualityIssueInChangedFiles: false,
           [rule]: true,

--- a/test/baseline/policy.test.ts
+++ b/test/baseline/policy.test.ts
@@ -182,6 +182,31 @@ describe('classify — block-rule overrides', () => {
     expect(result2.reasons.some((r) => r.code === 'block-rule')).toBe(false);
   });
 
+  it('blocks a new malicious dependency at ANY severity (the supply-chain rule)', () => {
+    // The July 2025 eslint-config-prettier compromise shipped as severity
+    // HIGH — below the critical rule, unreachable by the reachability rule
+    // (never populated on the check path). The malicious rule fires on the
+    // advisory class alone.
+    for (const severity of ['high', 'medium', 'low'] as const) {
+      const ctx: ClassifyContext = { kind: 'dep-vuln', severity, malicious: true };
+      const result = classify(pair('added'), DEFAULT_BROWNFIELD_POLICY, ctx);
+      expect(result.blocks).toBe(true);
+      expect(result.reasons.some((r) => r.detail.includes('newMaliciousDependency'))).toBe(true);
+    }
+  });
+
+  it('the malicious rule never fires for non-malicious dep-vulns or persisted pairs', () => {
+    const nonMalicious: ClassifyContext = { kind: 'dep-vuln', severity: 'high' };
+    const r1 = classify(pair('added'), DEFAULT_BROWNFIELD_POLICY, nonMalicious);
+    expect(r1.reasons.some((r) => r.detail.includes('newMaliciousDependency'))).toBe(false);
+
+    // Baseline-relative: a grandfathered malicious advisory (already in the
+    // baseline) is debt to pay down, not a net-new block.
+    const persisted: ClassifyContext = { kind: 'dep-vuln', severity: 'high', malicious: true };
+    const r2 = classify(pair('persisted'), DEFAULT_BROWNFIELD_POLICY, persisted);
+    expect(r2.blocks).toBe(false);
+  });
+
   it('blocks a new untested file overlapping changed lines', () => {
     const ctx: ClassifyContext = {
       kind: 'test-gap',

--- a/test/evaluate/evidence.test.ts
+++ b/test/evaluate/evidence.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import type { GuardrailJsonPayload } from '../../src/baseline/check-renderers';
+import {
+  ANACHRONISM_NOTE,
+  buildCosts,
+  buildEvidenceDoc,
+  EVALUATE_EVIDENCE_SCHEMA,
+  type EvaluateRunEvidence,
+} from '../../src/evaluate/evidence';
+
+/** A minimal guardrail payload carrying only the fields evidence/render
+ *  read. Narrow test-fixture cast; the real payload is produced by
+ *  `renderJson` and exercised by the zero-write integration test. */
+export function fakePayload(findingsCount: number): GuardrailJsonPayload {
+  return {
+    schema: 'dxkit.guardrail-check.v1',
+    verdict: { blocks: false, warns: false, exitCode: 0 },
+    baseline: {
+      name: 'main',
+      createdAt: '2026-07-12T00:00:00Z',
+      commitSha: 'a'.repeat(40),
+      branch: 'main',
+      findingsCount,
+      mode: { value: 'ref-based', source: 'cli', explanation: 'test' },
+    },
+    current: { commitSha: 'b'.repeat(40), branch: 'main', findingsCount },
+    matcher: { gitAware: true },
+    envelopeDrift: {},
+    policy: { mode: 'strict', block: [], warn: [], confidence: {}, blockRules: {} },
+    summary: { pairs: 0, blocking: 0, suppressed: 0, warning: 0, persisted: 0, resolved: 0 },
+    pairs: [],
+  } as unknown as GuardrailJsonPayload;
+}
+
+export function fakeRun(over: Partial<EvaluateRunEvidence> = {}): EvaluateRunEvidence {
+  return {
+    label: '#1',
+    baseSha: 'a'.repeat(40),
+    headSha: 'b'.repeat(40),
+    verdict: { blocks: false, warns: false },
+    blocking: [],
+    warningCount: 0,
+    refExcludedKinds: [],
+    coverage: { scanners: [{ tool: 'gitleaks', available: true, source: 'path' }] },
+    toolVersions: { base: {}, head: {} },
+    matcher: { gitAware: true },
+    guardrail: fakePayload(3),
+    durationMs: 1000,
+    ...over,
+  };
+}
+
+function docWith(runs: EvaluateRunEvidence[]) {
+  return buildEvidenceDoc({
+    branch: 'main',
+    ref: 'HEAD',
+    preset: 'security-only',
+    presetSource: 'default',
+    policyBase: 'defaults',
+    incremental: true,
+    untrusted: false,
+    runs,
+  });
+}
+
+describe('evaluate evidence schema freeze', () => {
+  it('pins the schema id', () => {
+    expect(EVALUATE_EVIDENCE_SCHEMA).toBe('dxkit.evaluate-evidence.v1');
+  });
+
+  it('pins the v1 top-level field set (additions require review; removals require a v2)', () => {
+    const doc = docWith([fakeRun()]);
+    expect(Object.keys(doc).sort()).toEqual(
+      [
+        'schema',
+        'generatedAt',
+        'dxkitVersion',
+        'repo',
+        'policy',
+        'options',
+        'zeroWrite',
+        'runs',
+        'totals',
+        'notes',
+        'costs',
+      ].sort(),
+    );
+    expect(doc.zeroWrite).toBe(true);
+  });
+});
+
+describe('buildEvidenceDoc', () => {
+  it('computes totals across clean, warned, blocked, and errored landings', () => {
+    const doc = docWith([
+      fakeRun(),
+      fakeRun({ verdict: { blocks: false, warns: true }, warningCount: 2 }),
+      fakeRun({
+        verdict: { blocks: true, warns: false },
+        blocking: [{ kind: 'secret' }],
+      }),
+      fakeRun({ error: { message: 'unreachable ref' } }),
+    ]);
+    expect(doc.totals).toEqual({ landings: 4, blocked: 1, warned: 1, clean: 1, errored: 1 });
+  });
+
+  it('discloses ref-excluded kinds and the dep-advisory anachronism only when they apply', () => {
+    const clean = docWith([fakeRun()]);
+    expect(clean.notes).toHaveLength(0);
+
+    const disclosed = docWith([
+      fakeRun({
+        verdict: { blocks: true, warns: false },
+        blocking: [{ kind: 'dep-vuln', severity: 'critical' }],
+        refExcludedKinds: [{ kind: 'test-gap', currentCount: 4 }],
+      }),
+    ]);
+    expect(disclosed.notes.some((n) => n.includes('test-gap'))).toBe(true);
+    expect(disclosed.notes).toContain(ANACHRONISM_NOTE);
+  });
+
+  it('never discloses the internal secret-hmac companion as an unwatched class', () => {
+    const doc = docWith([
+      fakeRun({ refExcludedKinds: [{ kind: 'secret-hmac', currentCount: 2 }] }),
+    ]);
+    expect(doc.notes).toHaveLength(0);
+    // Fidelity preserved in the per-run data.
+    expect(doc.runs[0].refExcludedKinds[0].kind).toBe('secret-hmac');
+  });
+});
+
+describe('buildCosts', () => {
+  it('measures latency percentiles, interruption rate, warn noise, and missing scanners', () => {
+    const costs = buildCosts([
+      fakeRun({ durationMs: 1000 }),
+      fakeRun({ durationMs: 2000, warningCount: 3 }),
+      fakeRun({
+        durationMs: 9000,
+        verdict: { blocks: true, warns: false },
+        coverage: {
+          scanners: [
+            { tool: 'gitleaks', available: true, source: 'path' },
+            { tool: 'semgrep', available: false, source: 'missing' },
+          ],
+        },
+      }),
+      fakeRun({ durationMs: 50, error: { message: 'x' } }), // excluded from stats
+    ]);
+    expect(costs.gateReplayMs.median).toBe(2000);
+    expect(costs.gateReplayMs.max).toBe(9000);
+    expect(costs.interruptions).toEqual({ blockedLandings: 1, landings: 3 });
+    expect(costs.warnNoise).toBe(3);
+    expect(costs.setup.missingScanners).toEqual(['semgrep']);
+    expect(costs.setup.writes.length).toBeGreaterThan(0);
+  });
+});

--- a/test/evaluate/pr-ranges.test.ts
+++ b/test/evaluate/pr-ranges.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { enumerateLandings, prNumberFromSubject } from '../../src/evaluate/pr-ranges';
+
+const tmps: string[] = [];
+function mkRepo(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-evalranges-'));
+  tmps.push(d);
+  git(d, 'init', '-q', '-b', 'main');
+  git(d, 'config', 'user.email', 't@t.co');
+  git(d, 'config', 'user.name', 't');
+  return d;
+}
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
+}
+function commit(cwd: string, file: string, content: string, subject: string): string {
+  fs.writeFileSync(path.join(cwd, file), content);
+  git(cwd, 'add', '-A');
+  git(cwd, 'commit', '-qm', subject);
+  return git(cwd, 'rev-parse', 'HEAD');
+}
+afterEach(() => {
+  for (const d of tmps.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+describe('prNumberFromSubject', () => {
+  it('parses merge-commit and squash-suffix markers, and nothing else', () => {
+    expect(prNumberFromSubject('Merge pull request #42 from org/feat')).toBe(42);
+    expect(prNumberFromSubject('feat: add the gate (#137)')).toBe(137);
+    expect(prNumberFromSubject('feat: mention (#7) mid-subject')).toBeUndefined();
+    expect(prNumberFromSubject('plain subject')).toBeUndefined();
+  });
+});
+
+describe('enumerateLandings', () => {
+  it('pairs each first-parent landing with its base across merge strategies', () => {
+    const d = mkRepo();
+    const root = commit(d, 'a.txt', '1', 'root');
+    const squash = commit(d, 'a.txt', '2', 'feat: squash-landed change (#12)');
+    // A real merge: branch from the squash commit, then merge back.
+    git(d, 'checkout', '-q', '-b', 'feat');
+    const featTip = commit(d, 'b.txt', 'x', 'feat work');
+    git(d, 'checkout', '-q', 'main');
+    git(d, 'merge', '--no-ff', '-q', '-m', 'Merge pull request #13 from org/feat', 'feat');
+    const mergeSha = git(d, 'rev-parse', 'HEAD');
+
+    const landings = enumerateLandings(d, 10);
+    // Newest first: the merge, the squash, then the root (skipped: no parent).
+    expect(landings).toHaveLength(2);
+    expect(landings[0]).toMatchObject({
+      headSha: mergeSha,
+      baseSha: squash,
+      prNumber: 13,
+    });
+    expect(landings[1]).toMatchObject({ headSha: squash, baseSha: root, prNumber: 12 });
+    // First-parent discipline: the merge's base is main's tip, never the branch tip.
+    expect(landings[0].baseSha).not.toBe(featTip);
+  });
+
+  it('honors the count limit', () => {
+    const d = mkRepo();
+    commit(d, 'a.txt', '1', 'root');
+    commit(d, 'a.txt', '2', 'second');
+    commit(d, 'a.txt', '3', 'third');
+    expect(enumerateLandings(d, 1)).toHaveLength(1);
+  });
+
+  it('throws on a non-repo so the CLI can surface the message', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-evalranges-'));
+    tmps.push(d);
+    expect(() => enumerateLandings(d, 5)).toThrow();
+  });
+});

--- a/test/evaluate/render.test.ts
+++ b/test/evaluate/render.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { buildEvidenceDoc, type EvaluateRunEvidence } from '../../src/evaluate/evidence';
+import { redactEvidence } from '../../src/evaluate/redact';
+import { headline, renderEvaluateText } from '../../src/evaluate/render';
+import { fakePayload, fakeRun } from './evidence.test';
+
+function docWith(runs: EvaluateRunEvidence[], ref = 'HEAD') {
+  return buildEvidenceDoc({
+    branch: 'main',
+    ref,
+    preset: 'security-only',
+    presetSource: 'default',
+    policyBase: 'defaults',
+    incremental: true,
+    untrusted: false,
+    runs,
+  });
+}
+
+describe('renderEvaluateText — the clean replay is a first-class result', () => {
+  it('carries the trust framing, the watched summary, the costs, and the demo handoff', () => {
+    const doc = docWith([fakeRun(), fakeRun({ label: '#2' })]);
+    const text = renderEvaluateText(doc);
+    expect(text).toContain('None of your last 2 landings would have been blocked.');
+    // Grandfathered framing from the base-side findings count (fakePayload: 3).
+    expect(text).toContain('3 pre-existing findings');
+    expect(text).toContain('grandfathered');
+    // Watched honesty.
+    expect(text).toContain('scanners ran: gitleaks');
+    // Costs are measured, present, and reversibility is stated.
+    expect(text).toContain('What enabling dxkit costs');
+    expect(text).toContain('interruptions: none across the 2 evaluated landings');
+    expect(text).toContain('uninstall');
+    // The clean path hands off to the seeded demo, then init.
+    expect(text).toContain('demo loop-guardrail');
+    expect(text).toContain('npm init @vyuhlabs/dxkit');
+    // The zero-write line closes every report.
+    expect(text.trim().endsWith('Nothing was written to your repo.')).toBe(true);
+  });
+
+  it('renders blocked landings with their net-new kinds and skips the demo handoff', () => {
+    const doc = docWith([
+      fakeRun({
+        label: '#7',
+        subject: 'feat: add auth',
+        verdict: { blocks: true, warns: false },
+        blocking: [
+          { kind: 'secret', severity: 'high' },
+          { kind: 'secret', severity: 'high' },
+          { kind: 'dep-vuln', severity: 'critical' },
+        ],
+      }),
+      fakeRun({ label: '#8' }),
+    ]);
+    const text = renderEvaluateText(doc);
+    expect(text).toContain('dxkit would have blocked 1 of your last 2 landings.');
+    expect(text).toContain('BLOCKED  #7');
+    expect(text).toContain('net-new: secret high ×2, dep-vuln critical');
+    expect(text).not.toContain('demo loop-guardrail');
+    expect(text).toContain('Nothing was written to your repo.');
+  });
+
+  it('reports missing scanners as unwatched classes, not silently', () => {
+    const doc = docWith([
+      fakeRun({
+        coverage: {
+          scanners: [
+            { tool: 'gitleaks', available: false, source: 'missing' },
+            { tool: 'semgrep', available: true, source: 'path' },
+          ],
+        },
+      }),
+    ]);
+    expect(renderEvaluateText(doc)).toContain('scanners missing on this machine');
+  });
+
+  it('headline handles the explicit-range mode', () => {
+    const doc = docWith([fakeRun()], 'origin/main~5..origin/main');
+    expect(headline(doc)).toBe('dxkit would not have blocked this range.');
+  });
+});
+
+describe('redactEvidence', () => {
+  it('strips file/line from blocking entries and the embedded payload, and says so', () => {
+    const payload = fakePayload(1);
+    const run = fakeRun({
+      verdict: { blocks: true, warns: false },
+      blocking: [{ kind: 'secret', file: 'src/config.ts', line: 12 }],
+      guardrail: {
+        ...payload,
+        pairs: [
+          {
+            status: 'added',
+            blocks: true,
+            warns: false,
+            confidence: 1,
+            kind: 'secret',
+            file: 'src/config.ts',
+            line: 12,
+            reasons: [],
+          },
+        ],
+      } as typeof payload,
+    });
+    const redacted = redactEvidence(docWith([run]));
+    const r = redacted.runs[0];
+    expect(r.blocking[0]).toEqual({ kind: 'secret', severity: undefined });
+    expect(r.guardrail?.pairs[0].file).toBeUndefined();
+    expect(r.guardrail?.pairs[0].line).toBeUndefined();
+    expect(r.guardrail?.pairs[0].kind).toBe('secret'); // signal preserved
+    expect(redacted.notes.some((n) => n.includes('Redacted for sharing'))).toBe(true);
+  });
+});

--- a/test/evaluate/zero-write.test.ts
+++ b/test/evaluate/zero-write.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto'; // fingerprint-helper-ok: tree snapshotting for the zero-write proof, not finding identity
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runEvaluate } from '../../src/evaluate/run';
+
+/**
+ * THE zero-write proof: `evaluate` runs the real guardrail over a real ref
+ * pair and the target repository is byte-identical afterwards — no
+ * `.dxkit/`, no caches, no refs, no config. This is the structural
+ * guarantee the funnel copy states ("nothing was written to your repo"),
+ * pinned as an invariant rather than trusted as a code-review property.
+ *
+ * The test runs the full gather pipeline in disposable worktrees; missing
+ * scanners on the host degrade to coverage entries (fail-open), which is
+ * itself part of what the evidence must record honestly.
+ */
+
+const tmps: string[] = [];
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
+}
+function mkRepo(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-evalzw-'));
+  tmps.push(d);
+  git(d, 'init', '-q', '-b', 'main');
+  git(d, 'config', 'user.email', 't@t.co');
+  git(d, 'config', 'user.name', 't');
+  return d;
+}
+function commit(cwd: string, files: Record<string, string>, subject: string): string {
+  for (const [rel, content] of Object.entries(files)) {
+    const p = path.join(cwd, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content);
+  }
+  git(cwd, 'add', '-A');
+  git(cwd, 'commit', '-qm', subject);
+  return git(cwd, 'rev-parse', 'HEAD');
+}
+afterEach(() => {
+  for (const d of tmps.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+/** Every path under `dir` (files AND directories, including dotfiles) with
+ *  a content hash for files — the complete on-disk state. */
+function snapshotTree(dir: string): Map<string, string> {
+  const out = new Map<string, string>();
+  const walk = (rel: string) => {
+    const abs = path.join(dir, rel);
+    for (const entry of fs.readdirSync(abs, { withFileTypes: true })) {
+      const childRel = rel ? path.join(rel, entry.name) : entry.name;
+      if (entry.isDirectory()) {
+        out.set(childRel + '/', 'dir');
+        walk(childRel);
+      } else if (entry.isFile()) {
+        out.set(
+          childRel,
+          createHash('sha256')
+            .update(fs.readFileSync(path.join(dir, childRel)))
+            .digest('hex'),
+        );
+      }
+    }
+  };
+  walk('');
+  return out;
+}
+
+describe('evaluate zero-write invariant', () => {
+  it(
+    'leaves the target repo byte-identical and reports the replay honestly',
+    { timeout: 300_000 },
+    async () => {
+      const d = mkRepo();
+      const base = commit(
+        d,
+        {
+          'package.json': '{"name":"zw-fixture","version":"1.0.0"}\n',
+          'src/a.js': 'const a = 1;\nmodule.exports = a;\n',
+        },
+        'root',
+      );
+      const head = commit(
+        d,
+        { 'src/b.js': 'const b = 2;\nmodule.exports = b;\n' },
+        'feat: add b (#5)',
+      );
+
+      const before = snapshotTree(d);
+      const gitStateBefore =
+        git(d, 'for-each-ref') + '\n' + git(d, 'status', '--porcelain=v1', '-uall');
+
+      const doc = await runEvaluate({ cwd: d, base, head });
+
+      const after = snapshotTree(d);
+      const gitStateAfter =
+        git(d, 'for-each-ref') + '\n' + git(d, 'status', '--porcelain=v1', '-uall');
+
+      // The attestation the output makes, proven byte-for-byte.
+      expect(Object.fromEntries(after)).toEqual(Object.fromEntries(before));
+      expect(gitStateAfter).toBe(gitStateBefore);
+      expect(fs.existsSync(path.join(d, '.dxkit'))).toBe(false);
+
+      // The evidence is honest about what happened.
+      expect(doc.schema).toBe('dxkit.evaluate-evidence.v1');
+      expect(doc.zeroWrite).toBe(true);
+      expect(doc.totals.landings).toBe(1);
+      expect(doc.totals.errored).toBe(0);
+      const run = doc.runs[0];
+      expect(run.baseSha).toBe(base);
+      expect(run.headSha).toBe(head);
+      expect(run.guardrail?.schema).toBe('dxkit.guardrail-check.v1');
+      expect(run.coverage.scanners.length).toBeGreaterThan(0);
+      expect(run.durationMs).toBeGreaterThan(0);
+    },
+  );
+
+  it(
+    'last-landings mode replays history and survives an unresolvable landing',
+    { timeout: 300_000 },
+    async () => {
+      const d = mkRepo();
+      commit(d, { 'package.json': '{"name":"zw-fixture2","version":"1.0.0"}\n' }, 'root');
+      commit(d, { 'src/a.js': 'const a = 1;\nmodule.exports = a;\n' }, 'feat: a (#1)');
+      commit(d, { 'src/a.js': 'const a = 2;\nmodule.exports = a;\n' }, 'feat: bump a (#2)');
+
+      const before = snapshotTree(d);
+      const doc = await runEvaluate({ cwd: d, lastLandings: 5 });
+      expect(Object.fromEntries(snapshotTree(d))).toEqual(Object.fromEntries(before));
+
+      // Root has no base side → 2 replayable landings.
+      expect(doc.totals.landings).toBe(2);
+      expect(doc.runs.map((r) => r.label)).toEqual(['#2', '#1']);
+      expect(doc.costs.interruptions.landings).toBe(doc.totals.landings - doc.totals.errored);
+    },
+  );
+});

--- a/test/evidence/conventions-freeze.test.ts
+++ b/test/evidence/conventions-freeze.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EPISTEMIC_LABELS,
+  EVIDENCE_SCHEMA_IDS,
+  evidenceEnvelope,
+} from '../../src/evidence/conventions';
+
+/**
+ * Freeze net for the shared evidence vocabulary (mirror of the SDK
+ * wire-schema pin): schema ids are append-only and the epistemic-label set
+ * has exactly one definition. A failing assertion here means a shipped
+ * contract changed — add a new id / label alongside, never remove or
+ * rename one.
+ */
+describe('evidence conventions freeze', () => {
+  it('pins the evidence schema-id registry (append-only)', () => {
+    const frozen = ['dxkit.evaluate-evidence.v1'];
+    // Every previously shipped id must still be present, in order.
+    expect(EVIDENCE_SCHEMA_IDS.slice(0, frozen.length)).toEqual(frozen);
+  });
+
+  it('pins the epistemic-label set exactly', () => {
+    expect([...EPISTEMIC_LABELS]).toEqual(['observed', 'derived', 'inferred', 'unknown']);
+  });
+
+  it('stamps a well-formed envelope', () => {
+    const env = evidenceEnvelope('dxkit.evaluate-evidence.v1');
+    expect(env.schema).toBe('dxkit.evaluate-evidence.v1');
+    expect(new Date(env.generatedAt).toString()).not.toBe('Invalid Date');
+    expect(env.dxkitVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/test/loop/policy.test.ts
+++ b/test/loop/policy.test.ts
@@ -82,6 +82,19 @@ describe('loop policy presets', () => {
     expect(policy.blockRules.newHighSecurity).toBe(true);
     expect(policy.blockRules.newCriticalDependencyVulnerability).toBe(true);
     expect(policy.blockRules.newHighReachableDependencyVulnerability).toBe(true);
+    // Malware blocks under every posture regardless of CVSS.
+    expect(policy.blockRules.newMaliciousDependency).toBe(true);
+  });
+
+  it('security-only WARNS on net-new findings its rules do not escalate (never silent)', () => {
+    const { policy } = resolveLoopPolicy(repo);
+    // The supply-chain-replay gap: an added finding outside the block rules
+    // (a high dep vuln without a reachability signal, a quality issue) must
+    // surface as a warning, not vanish.
+    expect(policy.warn).toContain('added');
+    // The base drift/uncertainty warns survive the union.
+    expect(policy.warn).toContain('tooling_drift');
+    expect(policy.warn).toContain('uncertain');
   });
 
   it('full-debt blocks every net-new finding incl. test-gap + quality', () => {
@@ -91,8 +104,11 @@ describe('loop policy presets', () => {
     expect(policy.block).toEqual(['added']);
     expect(policy.blockRules.newUntestedChangedSource).toBe(true);
     expect(policy.blockRules.newSevereQualityIssueInChangedFiles).toBe(true);
+    expect(policy.blockRules.newMaliciousDependency).toBe(true);
     // Full-debt blocks integration breakage too.
     expect(flowMode).toBe('block');
+    // No warn addition needed: the generic block list already covers `added`.
+    expect(policy.warn).not.toContain('added');
   });
 
   it('reads loop.preset from .dxkit/policy.json', () => {

--- a/test/osv-malicious-overlay.test.ts
+++ b/test/osv-malicious-overlay.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { mergeMaliciousOsvFindings } from '../src/analyzers/tools/osv-scanner-deps';
+import type { DepVulnFinding, DepVulnResult } from '../src/languages/capabilities/types';
+
+/**
+ * The malicious-overlay merge: osv-scanner's MAL-* feed (OpenSSF's
+ * ecosystem-maintained malicious-packages database) joins a native
+ * scanner's result, appending ONLY malicious findings not already
+ * represented. Shapes mirror the July 2025 eslint-config-prettier
+ * incident the overlay exists for.
+ */
+function finding(over: Partial<DepVulnFinding>): DepVulnFinding {
+  return {
+    id: 'GHSA-a',
+    package: 'pkg',
+    tool: 'npm-audit',
+    severity: 'high',
+    ...over,
+  } as DepVulnFinding;
+}
+
+function envelope(
+  findings: DepVulnFinding[],
+  counts?: Partial<DepVulnResult['counts']>,
+): DepVulnResult {
+  return {
+    schemaVersion: 1,
+    tool: 'npm-audit',
+    enrichment: null,
+    counts: { critical: 0, high: 0, medium: 0, low: 0, ...counts },
+    findings,
+  };
+}
+
+describe('mergeMaliciousOsvFindings', () => {
+  it('appends a MAL finding the native scanner cannot see, and bumps counts', () => {
+    const base = envelope(
+      [finding({ id: 'GHSA-f29h-pxvx-f335', package: 'eslint-config-prettier' })],
+      { high: 1 },
+    );
+    const overlay = envelope([
+      finding({
+        id: 'MAL-2025-6022',
+        package: 'eslint-config-prettier',
+        tool: 'osv-scanner',
+        severity: 'medium',
+        summary: 'Malicious code in eslint-config-prettier (npm)',
+      }),
+    ]);
+    const merged = mergeMaliciousOsvFindings(base, overlay);
+    expect(merged.findings).toHaveLength(2);
+    expect(merged.findings?.[1].id).toBe('MAL-2025-6022');
+    expect(merged.counts).toEqual({ critical: 0, high: 1, medium: 1, low: 0 });
+    // The native envelope stays the attribution base.
+    expect(merged.tool).toBe('npm-audit');
+  });
+
+  it('never appends ordinary advisories (the native scanner is the richer source)', () => {
+    const base = envelope([], {});
+    const overlay = envelope([
+      finding({ id: 'GHSA-ordinary', summary: 'Prototype pollution in pkg' }),
+    ]);
+    expect(mergeMaliciousOsvFindings(base, overlay)).toBe(base);
+  });
+
+  it('skips a malicious finding already represented by id or alias on the same package', () => {
+    const base = envelope(
+      [finding({ id: 'GHSA-f29h-pxvx-f335', package: 'p', aliases: ['MAL-2025-6022'] })],
+      { high: 1 },
+    );
+    const overlay = envelope([
+      finding({
+        id: 'MAL-2025-6022',
+        package: 'p',
+        summary: 'Malicious code in p (npm)',
+      }),
+    ]);
+    expect(mergeMaliciousOsvFindings(base, overlay)).toBe(base);
+  });
+
+  it('the same advisory on a DIFFERENT package is not deduped away', () => {
+    const base = envelope(
+      [finding({ id: 'MAL-2025-1', package: 'other', summary: 'Malicious code in other (npm)' })],
+      { high: 1 },
+    );
+    const overlay = envelope([
+      finding({ id: 'MAL-2025-1', package: 'target', summary: 'Malicious code in target (npm)' }),
+    ]);
+    expect(mergeMaliciousOsvFindings(base, overlay).findings).toHaveLength(2);
+  });
+
+  it('returns the base untouched for an empty overlay', () => {
+    const base = envelope([finding({})], { high: 1 });
+    expect(mergeMaliciousOsvFindings(base, envelope([]))).toBe(base);
+  });
+});

--- a/test/security-malicious.test.ts
+++ b/test/security-malicious.test.ts
@@ -32,6 +32,14 @@ describe('isMaliciousAdvisory', () => {
       }),
     ).toBe(true);
     expect(isMaliciousAdvisory({ id: 'GHSA-a', cwes: ['cwe-507'] })).toBe(true);
+    // The whole 506–512 family, complete by construction (the first draft
+    // of the predicate hand-picked members and missed 508/509).
+    for (const n of [506, 507, 508, 509, 510, 511, 512]) {
+      expect(isMaliciousAdvisory({ id: 'GHSA-x', cwes: [`CWE-${n}`] })).toBe(true);
+    }
+    // Range boundaries: neighbors are NOT malicious-code CWEs.
+    expect(isMaliciousAdvisory({ id: 'GHSA-y', cwes: ['CWE-505'] })).toBe(false);
+    expect(isMaliciousAdvisory({ id: 'GHSA-z', cwes: ['CWE-513'] })).toBe(false);
   });
 
   it('flags the malware title conventions without CWE or MAL id', () => {

--- a/test/security-malicious.test.ts
+++ b/test/security-malicious.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { isMaliciousAdvisory } from '../src/analyzers/security/malicious';
+
+/**
+ * The canonical malicious-advisory predicate, pinned against the REAL feed
+ * shapes captured from the July 2025 eslint-config-prettier compromise
+ * (CVE-2025-54313) — the incident whose silent pass through security-only
+ * motivated the `newMaliciousDependency` rule. Each positive row is a
+ * verbatim shape one of the scanners actually emitted.
+ */
+describe('isMaliciousAdvisory', () => {
+  it('flags the OSV malicious-package namespace by id (osv-scanner feed)', () => {
+    expect(
+      isMaliciousAdvisory({
+        id: 'MAL-2025-6022',
+        summary: 'Malicious code in eslint-config-prettier (npm)',
+      }),
+    ).toBe(true);
+  });
+
+  it('flags a MAL alias even when the primary id is a GHSA', () => {
+    expect(isMaliciousAdvisory({ id: 'GHSA-xxxx-yyyy-zzzz', aliases: ['MAL-2025-1'] })).toBe(true);
+  });
+
+  it('flags the CWE-506 malicious-code family (npm-audit feed)', () => {
+    expect(
+      isMaliciousAdvisory({
+        id: 'GHSA-f29h-pxvx-f335',
+        cwes: ['CWE-506'],
+        summary:
+          'eslint-config-prettier, eslint-plugin-prettier, synckit, @pkgr/core, napi-postinstall have embedded malicious code',
+      }),
+    ).toBe(true);
+    expect(isMaliciousAdvisory({ id: 'GHSA-a', cwes: ['cwe-507'] })).toBe(true);
+  });
+
+  it('flags the malware title conventions without CWE or MAL id', () => {
+    // GitHub's convention.
+    expect(
+      isMaliciousAdvisory({
+        id: 'GHSA-b',
+        summary: 'some-pkg versions have embedded malicious code',
+      }),
+    ).toBe(true);
+    // OSV's convention.
+    expect(isMaliciousAdvisory({ id: 'GHSA-c', summary: 'Malicious code in left-pad (npm)' })).toBe(
+      true,
+    );
+    expect(
+      isMaliciousAdvisory({ id: 'GHSA-d', summary: 'Malicious versions of foo published' }),
+    ).toBe(true);
+  });
+
+  it('does NOT flag ordinary vulnerabilities, including ones that mention malicious input', () => {
+    expect(
+      isMaliciousAdvisory({
+        id: 'GHSA-e',
+        cwes: ['CWE-79'],
+        summary: 'foo fails to sanitize malicious input, allowing XSS',
+      }),
+    ).toBe(false);
+    expect(
+      isMaliciousAdvisory({
+        id: 'CVE-2024-12345',
+        summary: 'Prototype pollution in bar',
+      }),
+    ).toBe(false);
+    expect(isMaliciousAdvisory({ id: 'RUSTSEC-2024-0001' })).toBe(false);
+    // "MALFORMED" must not match the MAL- namespace.
+    expect(isMaliciousAdvisory({ id: 'MALFORMED-2024-1' })).toBe(false);
+  });
+});


### PR DESCRIPTION
Second PR of the 3.7 train (targets `release/3.7`). Board item: the funnel's entry point and the demo-maker.

## What

`vyuh-dxkit evaluate` — replay a repo's recent landings (or an explicit `--base`/`--head` pair) through the real guardrail and report what it would have blocked, and what enabling dxkit costs, **writing nothing to the repo**.

```
vyuh-dxkit evaluate                    # last 10 landings, security-only
vyuh-dxkit evaluate --last-prs 20 --preset full-debt
vyuh-dxkit evaluate --base origin/main~5 --head origin/main
vyuh-dxkit evaluate --json --redact    # shareable evidence document
```

Design doc: tmp/feature-req/DESIGN-evaluate-zero-write.md (local). Highlights:

- **Zero-write is structural and pinned.** The gate never runs from the user's repo: each landing's head is checked out via `withRefWorktree` and the guardrail runs there in ref-based mode, so every cache dies with the temp dir. `test/evaluate/zero-write.test.ts` hashes the full tree (plus refs and status) before/after a real replay and asserts byte-identity.
- **One concept, one code path.** The verdict is `runGuardrailCheck`; the posture is the preset table, extracted to `src/baseline/presets.ts` (scope note rewritten for its two consumers: Stop-gate, trial); the gather scope is `scopeForPolicy`, exactly as the Stop-gate passes it. Evaluate never re-derives a verdict.
- **Versioned evidence.** `dxkit.evaluate-evidence.v1`, built on the new `src/evidence/conventions.ts` (append-only schema-id registry + the epistemic-label enum the upcoming repo card shares), freeze-tested. Embeds each landing's `dxkit.guardrail-check.v1` payload verbatim; lifts the honesty fields beside the verdicts (coverage, ref-mode exclusions, unmeasured dep audits, both sides' tool versions, the dep-advisory anachronism note).
- **The costs card answers "blocked, but at what price?"** — measured, not modeled: gate-latency percentiles from this trial on this repo, the interruption rate from the repo's own history, missing scanners from the tool probe, the static list of what init writes, and the reversibility line.
- **The clean replay is a first-class result** (the field-reported failure mode of a value demo on a well-maintained repo): grandfathered-count trust framing, the watched summary, and the seeded-demo handoff — pinned by renderer tests.
- Rule 16: descriptor (`assess` group) + `whenToRecommend` probe (fires on uninitialized repos) + `dxkit-evaluate` skill + regenerated docs table.

## Validation

- Full suite: 3,874 tests pass; arch, slop, and cross-ecosystem gates green.
- Real repos: dxkit's own history (3 landings, clean, 17.0s median replay) and a fastify clone (5 landings clean at 12.9s median; a seeded credential pair correctly blocked under both presets; `git status` and tree hashes identical throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAAbsZKvrqDjB1Xuqb7zxg