### PR TITLE
fix(gate): malware blocks and net-new never passes silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,12 @@ allowed, and what was repaired after a block.
 Two presets decide what blocks a stop:
 
 ```text
-security-only  (default)  net-new secrets and critical or high vulnerabilities.
-                          Bounded, must-fix, cheap to gate.
-full-debt      (opt-in)   also gates net-new test gaps and maintainability
+security-only  (default)  blocks net-new secrets, critical and high code
+                          findings, critical dependency vulnerabilities, and
+                          known-malicious packages at any severity. Every
+                          other net-new finding warns; nothing net-new is
+                          ever silent. Bounded, must-fix, cheap to gate.
+full-debt      (opt-in)   also blocks net-new test gaps and maintainability
                           regressions. Repairs can be expensive.
 ```
 

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -42,6 +42,7 @@ tuning belongs here.
     "newHighSecurity": true,
     "newCriticalDependencyVulnerability": true,
     "newHighReachableDependencyVulnerability": true,
+    "newMaliciousDependency": true,
     "newUntestedChangedSource": true,
     "newSevereQualityIssueInChangedFiles": true
   },
@@ -191,15 +192,16 @@ shapes, and troubleshooting live in [`vyuh-dxkit checks`](../commands/checks.md)
 The block-rules object captures the "block on any net-new X regardless
 of confidence" policy lines. Set any flag to `false` to suppress.
 
-| Flag                                      | Meaning                                                             |
-| ----------------------------------------- | ------------------------------------------------------------------- |
-| `newSecret`                               | Block any newly-introduced secret (gitleaks finding)                |
-| `newCriticalSecurity`                     | Block newly-introduced critical-severity code findings              |
-| `newHighSecurity`                         | Block newly-introduced high-severity code findings                  |
-| `newCriticalDependencyVulnerability`      | Block newly-introduced critical dep-vuln advisories                 |
-| `newHighReachableDependencyVulnerability` | Block newly-introduced high-severity reachable dep-vulns            |
-| `newUntestedChangedSource`                | Block when an untested source file appears alongside changed code   |
-| `newSevereQualityIssueInChangedFiles`     | Block newly-introduced severe quality issues touching changed lines |
+| Flag                                      | Meaning                                                                                                                                                                                                                       |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `newSecret`                               | Block any newly-introduced secret (gitleaks finding)                                                                                                                                                                          |
+| `newCriticalSecurity`                     | Block newly-introduced critical-severity code findings                                                                                                                                                                        |
+| `newHighSecurity`                         | Block newly-introduced high-severity code findings                                                                                                                                                                            |
+| `newCriticalDependencyVulnerability`      | Block newly-introduced critical dep-vuln advisories                                                                                                                                                                           |
+| `newHighReachableDependencyVulnerability` | Block newly-introduced high-severity reachable dep-vulns                                                                                                                                                                      |
+| `newMaliciousDependency`                  | Block a newly-introduced dependency carrying a malicious-code advisory (OSV `MAL-*`, CWE-506 family, malware-titled GHSA) at ANY severity — install-time malware runs at install, so CVSS and reachability are the wrong lens |
+| `newUntestedChangedSource`                | Block when an untested source file appears alongside changed code                                                                                                                                                             |
+| `newSevereQualityIssueInChangedFiles`     | Block newly-introduced severe quality issues touching changed lines                                                                                                                                                           |
 
 ## Common customisations
 

--- a/src/analyzers/security/malicious.ts
+++ b/src/analyzers/security/malicious.ts
@@ -31,15 +31,28 @@
  * dependency, which is the costlier error.
  */
 
-/** CWE ids for the malicious-code family (CWE-506 "Embedded Malicious
- *  Code" and its children). Matched case-insensitively on the exact id. */
-const MALICIOUS_CWES = new Set([
-  'CWE-506', // Embedded Malicious Code
-  'CWE-507', // Trojan Horse
-  'CWE-510', // Trapdoor
-  'CWE-511', // Logic/Time Bomb
-  'CWE-512', // Spyware
-]);
+/**
+ * The CWE malicious-code family: CWE-506 "Embedded Malicious Code" and its
+ * children, which occupy the contiguous id range 506–512 (507 Trojan
+ * Horse, 508 Non-Replicating, 509 Replicating, 510 Trapdoor, 511
+ * Logic/Time Bomb, 512 Spyware). Checked as a RANGE so the family is
+ * complete by construction — a hand-picked set is exactly where a member
+ * gets forgotten (the first draft of this file missed 508/509).
+ *
+ * Maintenance posture: this subtree has been unchanged since CWE 1.0
+ * (2008), so the range is effectively static — and it is deliberately the
+ * SECONDARY signal. The signal that actually evolves (which packages are
+ * malicious) is ecosystem-maintained for us: OSV's `MAL-*` namespace,
+ * fed by OpenSSF's malicious-packages database and matched above by id.
+ * The CWE and title branches exist for feeds that carry no MAL id
+ * (GitHub advisories via npm audit, ingested SARIF), as defense in depth.
+ */
+function isMaliciousCwe(cwe: string): boolean {
+  const m = /^CWE-(\d+)$/i.exec(cwe.trim());
+  if (!m) return false;
+  const n = Number(m[1]);
+  return n >= 506 && n <= 512;
+}
 
 const MAL_NAMESPACE = /^MAL-\d{4}-\d+/i;
 
@@ -57,7 +70,7 @@ export interface MaliciousAdvisorySignals {
 export function isMaliciousAdvisory(f: MaliciousAdvisorySignals): boolean {
   if (MAL_NAMESPACE.test(f.id)) return true;
   if (f.aliases?.some((a) => MAL_NAMESPACE.test(a))) return true;
-  if (f.cwes?.some((c) => MALICIOUS_CWES.has(c.toUpperCase()))) return true;
+  if (f.cwes?.some(isMaliciousCwe)) return true;
   if (f.summary && MALICIOUS_TEXT.test(f.summary)) return true;
   return false;
 }

--- a/src/analyzers/security/malicious.ts
+++ b/src/analyzers/security/malicious.ts
@@ -1,0 +1,63 @@
+/**
+ * Malicious-advisory classification — ONE source of truth (the mirror of
+ * `benign.ts` at the other end of the severity scale). A dependency
+ * advisory that reports the package itself as malware (a compromised
+ * release, a trojaned version, install-time malicious code) is a
+ * different class from a vulnerability: install-time malware executes at
+ * `npm install`, so "is the vulnerable function reachable from my code"
+ * is the wrong lens entirely, and CVSS often under-scores or omits it
+ * (OSV `MAL-*` entries frequently carry no score at all).
+ *
+ * The guardrail consults this predicate to drive the
+ * `newMaliciousDependency` block rule: a NET-NEW dependency carrying a
+ * malicious-code advisory blocks under every posture, including
+ * `security-only`, regardless of CVSS severity.
+ *
+ * Every branch is grounded in a real feed (verified against the July 2025
+ * eslint-config-prettier compromise, CVE-2025-54313):
+ *   - OSV's dedicated malicious-package namespace: id/alias `MAL-….`
+ *     (osv-scanner reports `MAL-2025-6022` for the incident).
+ *   - The CWE malicious-code family, which npm audit attaches
+ *     (`CWE-506` on the incident's GHSA advisory).
+ *   - The advisory-title conventions both ecosystems use: OSV's
+ *     "Malicious code in <pkg>" and GitHub's "… have embedded malicious
+ *     code".
+ *
+ * Bias: this predicate BLOCKS, so it is precision-biased — the text
+ * branch requires "malicious" adjacent to code/package/version, which a
+ * normal vulnerability description ("fails to sanitize malicious input")
+ * does not produce. A missed malware advisory still surfaces through the
+ * ordinary severity rules; a false positive here would block a clean
+ * dependency, which is the costlier error.
+ */
+
+/** CWE ids for the malicious-code family (CWE-506 "Embedded Malicious
+ *  Code" and its children). Matched case-insensitively on the exact id. */
+const MALICIOUS_CWES = new Set([
+  'CWE-506', // Embedded Malicious Code
+  'CWE-507', // Trojan Horse
+  'CWE-510', // Trapdoor
+  'CWE-511', // Logic/Time Bomb
+  'CWE-512', // Spyware
+]);
+
+const MAL_NAMESPACE = /^MAL-\d{4}-\d+/i;
+
+/** "Malicious code in x", "… have embedded malicious code",
+ *  "malicious version(s) of …" — never bare "malicious input". */
+const MALICIOUS_TEXT = /\bmalicious\s+(code|package|version)/i;
+
+export interface MaliciousAdvisorySignals {
+  readonly id: string;
+  readonly aliases?: readonly string[];
+  readonly summary?: string;
+  readonly cwes?: readonly string[];
+}
+
+export function isMaliciousAdvisory(f: MaliciousAdvisorySignals): boolean {
+  if (MAL_NAMESPACE.test(f.id)) return true;
+  if (f.aliases?.some((a) => MAL_NAMESPACE.test(a))) return true;
+  if (f.cwes?.some((c) => MALICIOUS_CWES.has(c.toUpperCase()))) return true;
+  if (f.summary && MALICIOUS_TEXT.test(f.summary)) return true;
+  return false;
+}

--- a/src/analyzers/tools/osv-scanner-deps.ts
+++ b/src/analyzers/tools/osv-scanner-deps.ts
@@ -32,6 +32,7 @@ import {
   resolveCvssScores,
   type OsvVuln,
 } from './osv';
+import { isMaliciousAdvisory } from '../security/malicious';
 import { fileExists, run } from './runner';
 import { findTool, TOOL_DEFS } from './tool-registry';
 import type {
@@ -225,9 +226,69 @@ export async function gatherOsvScannerDepVulnsResult(
     counts,
     findings,
   };
-  // G_v4_4 (2.4.7): `packId` is forwarded into `parseOsvScannerFindings`
-  // so each finding carries the producing pack, which `buildUpgradeCommand`
-  // dispatches on. Envelope-level `tool: 'osv-scanner'` stays as the
-  // tool-attribution string used in `toolsUsed`.
+  // `packId` is forwarded into `parseOsvScannerFindings` so each finding
+  // carries the producing pack, which `buildUpgradeCommand` dispatches on.
+  // Envelope-level `tool: 'osv-scanner'` stays as the tool-attribution
+  // string used in `toolsUsed`.
   return { kind: 'success', envelope };
+}
+
+/**
+ * Overlay the ecosystem-maintained malicious-package feed onto a native
+ * scanner's result — the canonical-source answer to malware detection.
+ *
+ * Several packs use a native Tier-1 scanner (npm audit, cargo-audit,
+ * govulncheck, `dotnet list --vulnerable`) whose advisory feed does NOT
+ * carry OSV's `MAL-*` malicious-package entries, fed by OpenSSF's
+ * malicious-packages database. Those packs run osv-scanner as a
+ * best-effort second source and merge JUST the malicious findings in via
+ * this helper, so the `newMaliciousDependency` gate rule rides the
+ * maintained database on every path — never a list dxkit maintains.
+ * (Packs whose canonical scanner already IS osv-scanner — java, kotlin,
+ * ruby — and pip-audit, which queries OSV natively, need no overlay.)
+ *
+ * Merge semantics, deliberately narrow:
+ *   - ONLY findings the canonical `isMaliciousAdvisory` predicate flags
+ *     are appended. Ordinary advisories both scanners see would
+ *     double-count, and the native scanner stays the richer source for
+ *     them (embedded CVSS, fix targets).
+ *   - A malicious finding already represented in the base (same package
+ *     with an overlapping advisory id or alias) is skipped.
+ *   - Counts are recomputed to include the appended findings, keeping
+ *     the envelope's counts consistent with its findings.
+ *
+ * Pure; callers treat the overlay as best-effort (an unavailable
+ * osv-scanner never degrades the native result — fail-open on
+ * infrastructure, per the gate's standing policy).
+ */
+export function mergeMaliciousOsvFindings(
+  base: DepVulnResult,
+  overlay: DepVulnResult,
+): DepVulnResult {
+  const overlayFindings = overlay.findings ?? [];
+  if (overlayFindings.length === 0) return base;
+
+  const seen = new Set<string>();
+  for (const f of base.findings ?? []) {
+    seen.add(`${f.package} ${f.id}`);
+    for (const a of f.aliases ?? []) seen.add(`${f.package} ${a}`);
+  }
+
+  const appended = overlayFindings.filter((f) => {
+    if (!isMaliciousAdvisory(f)) return false;
+    if (seen.has(`${f.package} ${f.id}`)) return false;
+    if ((f.aliases ?? []).some((a) => seen.has(`${f.package} ${a}`))) return false;
+    return true;
+  });
+  if (appended.length === 0) return base;
+
+  const counts = { ...base.counts };
+  for (const f of appended) {
+    if (f.severity in counts) counts[f.severity as keyof typeof counts] += 1;
+  }
+  return {
+    ...base,
+    counts,
+    findings: [...(base.findings ?? []), ...appended],
+  };
 }

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -40,6 +40,7 @@ import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { dxkitCli } from '../self-invocation';
+import { isMaliciousAdvisory } from '../analyzers/security/malicious';
 import { gatherCurrentScan } from './create';
 import type { CurrentScan } from './create';
 import {
@@ -603,6 +604,7 @@ export async function runGuardrailCheck(
   const priorById = indexById(baseline.findings);
   const currentById = indexById(current.findings);
   const severityByCurrentId = buildSeverityIndex(current.aggregate);
+  const maliciousByCurrentId = buildMaliciousIndex(current.aggregate);
   const envelopeDrift = diffEnvelopes(baseline, current);
 
   // Per-kind tool attribution drives the per-pair
@@ -666,6 +668,9 @@ export async function runGuardrailCheck(
     // file is in the diff (a brand-new file has all its lines added).
     const fileChangedInDiff = file !== undefined && (linesChangedFor(file)?.size ?? 0) > 0;
 
+    const malicious =
+      pair.currentId !== undefined && maliciousByCurrentId.has(pair.currentId) ? true : undefined;
+
     const context: ClassifyContext = {
       severity,
       kind: anchorEntry.kind,
@@ -673,6 +678,7 @@ export async function runGuardrailCheck(
       ...(configDiffers ? { configDiffers: true } : {}),
       ...(fileChangedInDiff ? { fileChangedInDiff: true } : {}),
       ...(overlapsChangedLines !== undefined ? { overlapsChangedLines } : {}),
+      ...(malicious ? { malicious } : {}),
     };
 
     // `classify` is kind-agnostic; fold in the custom-check block INTENT (a
@@ -846,6 +852,22 @@ function buildSeverityIndex(aggregate: SecurityAggregate): Map<FindingId, Findin
   }
   for (const f of aggregate.findingsByCategory.dependency) {
     if (f.fingerprint) out.set(f.fingerprint, f.severity);
+  }
+  return out;
+}
+
+/**
+ * Fingerprints of current-scan dependency findings whose advisory reports
+ * the package itself as malicious code — the `newMaliciousDependency`
+ * block rule's signal. Computed from the CURRENT side only: block rules
+ * fire on `added` pairs, which always carry a currentId, so the committed
+ * baseline needs no schema change. Classification comes from the one
+ * canonical predicate (`src/analyzers/security/malicious.ts`).
+ */
+function buildMaliciousIndex(aggregate: SecurityAggregate): Set<FindingId> {
+  const out = new Set<FindingId>();
+  for (const f of aggregate.findingsByCategory.dependency) {
+    if (f.fingerprint && isMaliciousAdvisory(f)) out.add(f.fingerprint);
   }
   return out;
 }

--- a/src/baseline/classify.ts
+++ b/src/baseline/classify.ts
@@ -47,6 +47,10 @@ export interface ClassifyContext {
   readonly overlapsChangedLines?: boolean;
   /** True when an `added` dep-vuln is on a reachable code path. */
   readonly reachable?: boolean;
+  /** True when an `added` dep-vuln's advisory reports the package itself
+   *  as malicious code (OSV `MAL-*`, CWE-506 family, malware-titled
+   *  advisory) — see `src/analyzers/security/malicious.ts`. */
+  readonly malicious?: boolean;
 }
 
 /** Verdict + reasoning for one classified pair. */
@@ -204,6 +208,13 @@ function evaluateBlockRules(
     context.reachable === true
   ) {
     return 'newHighReachableDependencyVulnerability';
+  }
+  // Malicious-code advisories block at ANY severity: install-time malware
+  // executes at install, so CVSS and reachability are the wrong lens. The
+  // `malicious` signal comes from the one canonical predicate
+  // (`src/analyzers/security/malicious.ts`) applied to the current scan.
+  if (rules.newMaliciousDependency && context.kind === 'dep-vuln' && context.malicious === true) {
+    return 'newMaliciousDependency';
   }
   if (
     rules.newUntestedChangedSource &&

--- a/src/baseline/gather-scope.ts
+++ b/src/baseline/gather-scope.ts
@@ -171,7 +171,11 @@ export function scopeForPolicy(policy: BrownfieldPolicy): GatherScope {
   const scope = { ...EMPTY_SCOPE };
   if (r.newSecret) scope.secrets = true;
   if (r.newCriticalSecurity || r.newHighSecurity) scope.codePatterns = true;
-  if (r.newCriticalDependencyVulnerability || r.newHighReachableDependencyVulnerability) {
+  if (
+    r.newCriticalDependencyVulnerability ||
+    r.newHighReachableDependencyVulnerability ||
+    r.newMaliciousDependency
+  ) {
     scope.depVulns = true;
   }
   if (r.newUntestedChangedSource) scope.testGaps = true;

--- a/src/baseline/policy.ts
+++ b/src/baseline/policy.ts
@@ -91,6 +91,13 @@ export interface BrownfieldBlockRules {
   readonly newCriticalDependencyVulnerability?: boolean;
   /** Block any newly-introduced high-severity reachable dep vuln. */
   readonly newHighReachableDependencyVulnerability?: boolean;
+  /** Block a newly-introduced dependency carrying a malicious-code
+   *  advisory (OSV `MAL-*`, the CWE-506 family, a malware-titled GHSA),
+   *  REGARDLESS of CVSS severity: install-time malware executes at
+   *  install, so severity scores and code-reachability are the wrong
+   *  lens. Classified by the one canonical predicate,
+   *  `src/analyzers/security/malicious.ts`. */
+  readonly newMaliciousDependency?: boolean;
   /** Block when an untested source file is added in a changed file. */
   readonly newUntestedChangedSource?: boolean;
   /** Block any newly-introduced severe quality issue in changed files. */
@@ -305,6 +312,7 @@ export const DEFAULT_BROWNFIELD_POLICY: BrownfieldPolicy = Object.freeze({
     newHighSecurity: true,
     newCriticalDependencyVulnerability: true,
     newHighReachableDependencyVulnerability: true,
+    newMaliciousDependency: true,
     newUntestedChangedSource: true,
     newSevereQualityIssueInChangedFiles: true,
   }),

--- a/src/baseline/presets.ts
+++ b/src/baseline/presets.ts
@@ -72,6 +72,17 @@ interface PresetDef {
    * schema defaults to off, and a preset never activates it.
    */
   readonly schemaMode: SchemaGateMode;
+  /**
+   * Statuses ADDED to the base policy's warn list (union, never a
+   * replacement — the base's drift/uncertainty warns always survive).
+   * `security-only` adds `added` so a net-new finding its block rules do
+   * not escalate (a high dep vuln without a reachability signal, a
+   * quality issue) is still REPORTED as a warning instead of passing
+   * silently — the gap a real supply-chain-incident replay exposed.
+   * `full-debt` needs no addition: its generic block list already covers
+   * `added`.
+   */
+  readonly warn: ReadonlyArray<FindingStatus>;
 }
 
 /** The security class: secrets, crit/high SAST, crit/high reachable dep
@@ -82,6 +93,13 @@ const SECURITY_BLOCK_RULES: BrownfieldBlockRules = {
   newHighSecurity: true,
   newCriticalDependencyVulnerability: true,
   newHighReachableDependencyVulnerability: true,
+  // Malware is not "debt": a net-new dependency carrying a malicious-code
+  // advisory blocks under EVERY posture regardless of CVSS — install-time
+  // malware runs at install, so severity and reachability are the wrong
+  // lens. Added after a zero-write replay of the July 2025
+  // eslint-config-prettier compromise showed the default posture passing
+  // it silently.
+  newMaliciousDependency: true,
   // Open-ended debt — OFF in security-only (warn, never block).
   newUntestedChangedSource: false,
   newSevereQualityIssueInChangedFiles: false,
@@ -94,6 +112,10 @@ const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
     // Blocking comes solely from SECURITY_BLOCK_RULES.
     block: [],
     blockRules: SECURITY_BLOCK_RULES,
+    // Every net-new finding the rules don't escalate is still a warning —
+    // silence is reserved for pre-existing debt, never for something this
+    // change introduced.
+    warn: ['added'],
     flowMode: 'warn',
     schemaMode: 'warn',
   },
@@ -105,6 +127,7 @@ const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
       newUntestedChangedSource: true,
       newSevereQualityIssueInChangedFiles: true,
     },
+    warn: [],
     flowMode: 'block',
     schemaMode: 'block',
   },
@@ -136,6 +159,9 @@ export function policyForPreset(preset: LoopPreset, base: BrownfieldPolicy): Pre
       ...base,
       block: def.block,
       blockRules: def.blockRules,
+      // Union, never replacement: the base's drift/uncertainty warns
+      // survive; the preset can only ADD warn statuses (see PresetDef.warn).
+      warn: def.warn.length > 0 ? [...new Set([...base.warn, ...def.warn])] : base.warn,
     },
   };
 }

--- a/src/languages/capabilities/types.ts
+++ b/src/languages/capabilities/types.ts
@@ -150,6 +150,11 @@ export interface DepVulnFinding {
   aliases?: string[];
   summary?: string;
   references?: string[];
+  /** CWE ids the advisory carries (e.g. `['CWE-506']`). Drives the
+   *  malicious-code classification (`isMaliciousAdvisory`) — CWE-506
+   *  "Embedded Malicious Code" and family are the deterministic malware
+   *  signal npm audit attaches. Additive metadata, never identity. */
+  cwes?: string[];
 
   // Top-level (direct) manifest dep(s) this advisory rolls up to.
   // `['axios']` when the vulnerable package is itself a direct dep.

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -11,7 +11,10 @@ import {
   enrichWithUpgradePlans,
   gatherOsvScannerFixPlans,
 } from '../analyzers/tools/osv-scanner-fix';
-import { gatherOsvScannerDepVulnsResult } from '../analyzers/tools/osv-scanner-deps';
+import {
+  gatherOsvScannerDepVulnsResult,
+  mergeMaliciousOsvFindings,
+} from '../analyzers/tools/osv-scanner-deps';
 import { detectLockfile } from '../package-manager';
 import { fileExists, run, runJSON } from '../analyzers/tools/runner';
 import { walkPaths } from '../analyzers/tools/walk-paths';
@@ -363,7 +366,26 @@ async function gatherTsDepVulnsResult(
     return gatherOsvScannerDepVulnsResult(cwd, 'typescript', 'npm', [lock.lockfile]);
   }
 
-  return gatherTsDepVulnsViaNpmAudit(cwd, opts);
+  // npm lockfile: npm audit stays the canonical source (richest feed —
+  // embedded CVSS, fix targets), and osv-scanner joins BEST-EFFORT for the
+  // one signal npm audit's advisory feed structurally lacks: OSV `MAL-*`
+  // malicious-package entries from OpenSSF's ecosystem-maintained database.
+  // Without the overlay, the malicious-package gate rule on the npm path
+  // depends on fallback signals (the CWE-506 family, advisory titles)
+  // instead of the canonical source. An unavailable or failing osv-scanner
+  // never degrades the npm-audit result (fail-open on infrastructure).
+  const audit = await gatherTsDepVulnsViaNpmAudit(cwd, opts);
+  if (audit.kind !== 'success') return audit;
+  try {
+    const overlay = await gatherOsvScannerDepVulnsResult(cwd, 'typescript', 'npm', [lock.lockfile]);
+    if (overlay.kind !== 'success') return audit;
+    return {
+      kind: 'success',
+      envelope: mergeMaliciousOsvFindings(audit.envelope, overlay.envelope),
+    };
+  } catch {
+    return audit;
+  }
 }
 
 /**

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -469,6 +469,7 @@ async function gatherTsDepVulnsViaNpmAudit(
           if (ghsa) finding.aliases = [ghsa];
           if (v.title) finding.summary = v.title;
           if (v.url) finding.references = [v.url];
+          if (v.cwe && v.cwe.length > 0) finding.cwes = v.cwe;
           const parents = topLevelIndex.get(advisoryPkg);
           if (parents && parents.length > 0) finding.topLevelDep = parents;
           findings.push(finding);

--- a/test/baseline/gather-scope.test.ts
+++ b/test/baseline/gather-scope.test.ts
@@ -25,7 +25,7 @@ import { gatherCurrentScan } from '../../src/baseline/create';
  */
 
 /** A `security-only`-shaped policy: empty generic block list, security
- *  block-rules only. Mirrors `src/loop/policy.ts`'s preset. */
+ *  block-rules only. Mirrors `src/baseline/presets.ts`'s preset. */
 const SECURITY_ONLY: BrownfieldPolicy = {
   ...DEFAULT_BROWNFIELD_POLICY,
   block: [],
@@ -35,6 +35,7 @@ const SECURITY_ONLY: BrownfieldPolicy = {
     newHighSecurity: true,
     newCriticalDependencyVulnerability: true,
     newHighReachableDependencyVulnerability: true,
+    newMaliciousDependency: true,
     newUntestedChangedSource: false,
     newSevereQualityIssueInChangedFiles: false,
   },
@@ -109,6 +110,7 @@ describe('scopeForPolicy', () => {
       'newHighSecurity',
       'newCriticalDependencyVulnerability',
       'newHighReachableDependencyVulnerability',
+      'newMaliciousDependency',
       'newUntestedChangedSource',
       'newSevereQualityIssueInChangedFiles',
     ] as const;
@@ -122,6 +124,7 @@ describe('scopeForPolicy', () => {
           newHighSecurity: false,
           newCriticalDependencyVulnerability: false,
           newHighReachableDependencyVulnerability: false,
+          newMaliciousDependency: false,
           newUntestedChangedSource: false,
           newSevereQualityIssueInChangedFiles: false,
           [rule]: true,

--- a/test/baseline/policy.test.ts
+++ b/test/baseline/policy.test.ts
@@ -182,6 +182,31 @@ describe('classify — block-rule overrides', () => {
     expect(result2.reasons.some((r) => r.code === 'block-rule')).toBe(false);
   });
 
+  it('blocks a new malicious dependency at ANY severity (the supply-chain rule)', () => {
+    // The July 2025 eslint-config-prettier compromise shipped as severity
+    // HIGH — below the critical rule, unreachable by the reachability rule
+    // (never populated on the check path). The malicious rule fires on the
+    // advisory class alone.
+    for (const severity of ['high', 'medium', 'low'] as const) {
+      const ctx: ClassifyContext = { kind: 'dep-vuln', severity, malicious: true };
+      const result = classify(pair('added'), DEFAULT_BROWNFIELD_POLICY, ctx);
+      expect(result.blocks).toBe(true);
+      expect(result.reasons.some((r) => r.detail.includes('newMaliciousDependency'))).toBe(true);
+    }
+  });
+
+  it('the malicious rule never fires for non-malicious dep-vulns or persisted pairs', () => {
+    const nonMalicious: ClassifyContext = { kind: 'dep-vuln', severity: 'high' };
+    const r1 = classify(pair('added'), DEFAULT_BROWNFIELD_POLICY, nonMalicious);
+    expect(r1.reasons.some((r) => r.detail.includes('newMaliciousDependency'))).toBe(false);
+
+    // Baseline-relative: a grandfathered malicious advisory (already in the
+    // baseline) is debt to pay down, not a net-new block.
+    const persisted: ClassifyContext = { kind: 'dep-vuln', severity: 'high', malicious: true };
+    const r2 = classify(pair('persisted'), DEFAULT_BROWNFIELD_POLICY, persisted);
+    expect(r2.blocks).toBe(false);
+  });
+
   it('blocks a new untested file overlapping changed lines', () => {
     const ctx: ClassifyContext = {
       kind: 'test-gap',

--- a/test/loop/policy.test.ts
+++ b/test/loop/policy.test.ts
@@ -82,6 +82,19 @@ describe('loop policy presets', () => {
     expect(policy.blockRules.newHighSecurity).toBe(true);
     expect(policy.blockRules.newCriticalDependencyVulnerability).toBe(true);
     expect(policy.blockRules.newHighReachableDependencyVulnerability).toBe(true);
+    // Malware blocks under every posture regardless of CVSS.
+    expect(policy.blockRules.newMaliciousDependency).toBe(true);
+  });
+
+  it('security-only WARNS on net-new findings its rules do not escalate (never silent)', () => {
+    const { policy } = resolveLoopPolicy(repo);
+    // The supply-chain-replay gap: an added finding outside the block rules
+    // (a high dep vuln without a reachability signal, a quality issue) must
+    // surface as a warning, not vanish.
+    expect(policy.warn).toContain('added');
+    // The base drift/uncertainty warns survive the union.
+    expect(policy.warn).toContain('tooling_drift');
+    expect(policy.warn).toContain('uncertain');
   });
 
   it('full-debt blocks every net-new finding incl. test-gap + quality', () => {
@@ -91,8 +104,11 @@ describe('loop policy presets', () => {
     expect(policy.block).toEqual(['added']);
     expect(policy.blockRules.newUntestedChangedSource).toBe(true);
     expect(policy.blockRules.newSevereQualityIssueInChangedFiles).toBe(true);
+    expect(policy.blockRules.newMaliciousDependency).toBe(true);
     // Full-debt blocks integration breakage too.
     expect(flowMode).toBe('block');
+    // No warn addition needed: the generic block list already covers `added`.
+    expect(policy.warn).not.toContain('added');
   });
 
   it('reads loop.preset from .dxkit/policy.json', () => {

--- a/test/osv-malicious-overlay.test.ts
+++ b/test/osv-malicious-overlay.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { mergeMaliciousOsvFindings } from '../src/analyzers/tools/osv-scanner-deps';
+import type { DepVulnFinding, DepVulnResult } from '../src/languages/capabilities/types';
+
+/**
+ * The malicious-overlay merge: osv-scanner's MAL-* feed (OpenSSF's
+ * ecosystem-maintained malicious-packages database) joins a native
+ * scanner's result, appending ONLY malicious findings not already
+ * represented. Shapes mirror the July 2025 eslint-config-prettier
+ * incident the overlay exists for.
+ */
+function finding(over: Partial<DepVulnFinding>): DepVulnFinding {
+  return {
+    id: 'GHSA-a',
+    package: 'pkg',
+    tool: 'npm-audit',
+    severity: 'high',
+    ...over,
+  } as DepVulnFinding;
+}
+
+function envelope(
+  findings: DepVulnFinding[],
+  counts?: Partial<DepVulnResult['counts']>,
+): DepVulnResult {
+  return {
+    schemaVersion: 1,
+    tool: 'npm-audit',
+    enrichment: null,
+    counts: { critical: 0, high: 0, medium: 0, low: 0, ...counts },
+    findings,
+  };
+}
+
+describe('mergeMaliciousOsvFindings', () => {
+  it('appends a MAL finding the native scanner cannot see, and bumps counts', () => {
+    const base = envelope(
+      [finding({ id: 'GHSA-f29h-pxvx-f335', package: 'eslint-config-prettier' })],
+      { high: 1 },
+    );
+    const overlay = envelope([
+      finding({
+        id: 'MAL-2025-6022',
+        package: 'eslint-config-prettier',
+        tool: 'osv-scanner',
+        severity: 'medium',
+        summary: 'Malicious code in eslint-config-prettier (npm)',
+      }),
+    ]);
+    const merged = mergeMaliciousOsvFindings(base, overlay);
+    expect(merged.findings).toHaveLength(2);
+    expect(merged.findings?.[1].id).toBe('MAL-2025-6022');
+    expect(merged.counts).toEqual({ critical: 0, high: 1, medium: 1, low: 0 });
+    // The native envelope stays the attribution base.
+    expect(merged.tool).toBe('npm-audit');
+  });
+
+  it('never appends ordinary advisories (the native scanner is the richer source)', () => {
+    const base = envelope([], {});
+    const overlay = envelope([
+      finding({ id: 'GHSA-ordinary', summary: 'Prototype pollution in pkg' }),
+    ]);
+    expect(mergeMaliciousOsvFindings(base, overlay)).toBe(base);
+  });
+
+  it('skips a malicious finding already represented by id or alias on the same package', () => {
+    const base = envelope(
+      [finding({ id: 'GHSA-f29h-pxvx-f335', package: 'p', aliases: ['MAL-2025-6022'] })],
+      { high: 1 },
+    );
+    const overlay = envelope([
+      finding({
+        id: 'MAL-2025-6022',
+        package: 'p',
+        summary: 'Malicious code in p (npm)',
+      }),
+    ]);
+    expect(mergeMaliciousOsvFindings(base, overlay)).toBe(base);
+  });
+
+  it('the same advisory on a DIFFERENT package is not deduped away', () => {
+    const base = envelope(
+      [finding({ id: 'MAL-2025-1', package: 'other', summary: 'Malicious code in other (npm)' })],
+      { high: 1 },
+    );
+    const overlay = envelope([
+      finding({ id: 'MAL-2025-1', package: 'target', summary: 'Malicious code in target (npm)' }),
+    ]);
+    expect(mergeMaliciousOsvFindings(base, overlay).findings).toHaveLength(2);
+  });
+
+  it('returns the base untouched for an empty overlay', () => {
+    const base = envelope([finding({})], { high: 1 });
+    expect(mergeMaliciousOsvFindings(base, envelope([]))).toBe(base);
+  });
+});

--- a/test/security-malicious.test.ts
+++ b/test/security-malicious.test.ts
@@ -32,6 +32,14 @@ describe('isMaliciousAdvisory', () => {
       }),
     ).toBe(true);
     expect(isMaliciousAdvisory({ id: 'GHSA-a', cwes: ['cwe-507'] })).toBe(true);
+    // The whole 506–512 family, complete by construction (the first draft
+    // of the predicate hand-picked members and missed 508/509).
+    for (const n of [506, 507, 508, 509, 510, 511, 512]) {
+      expect(isMaliciousAdvisory({ id: 'GHSA-x', cwes: [`CWE-${n}`] })).toBe(true);
+    }
+    // Range boundaries: neighbors are NOT malicious-code CWEs.
+    expect(isMaliciousAdvisory({ id: 'GHSA-y', cwes: ['CWE-505'] })).toBe(false);
+    expect(isMaliciousAdvisory({ id: 'GHSA-z', cwes: ['CWE-513'] })).toBe(false);
   });
 
   it('flags the malware title conventions without CWE or MAL id', () => {

--- a/test/security-malicious.test.ts
+++ b/test/security-malicious.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { isMaliciousAdvisory } from '../src/analyzers/security/malicious';
+
+/**
+ * The canonical malicious-advisory predicate, pinned against the REAL feed
+ * shapes captured from the July 2025 eslint-config-prettier compromise
+ * (CVE-2025-54313) — the incident whose silent pass through security-only
+ * motivated the `newMaliciousDependency` rule. Each positive row is a
+ * verbatim shape one of the scanners actually emitted.
+ */
+describe('isMaliciousAdvisory', () => {
+  it('flags the OSV malicious-package namespace by id (osv-scanner feed)', () => {
+    expect(
+      isMaliciousAdvisory({
+        id: 'MAL-2025-6022',
+        summary: 'Malicious code in eslint-config-prettier (npm)',
+      }),
+    ).toBe(true);
+  });
+
+  it('flags a MAL alias even when the primary id is a GHSA', () => {
+    expect(isMaliciousAdvisory({ id: 'GHSA-xxxx-yyyy-zzzz', aliases: ['MAL-2025-1'] })).toBe(true);
+  });
+
+  it('flags the CWE-506 malicious-code family (npm-audit feed)', () => {
+    expect(
+      isMaliciousAdvisory({
+        id: 'GHSA-f29h-pxvx-f335',
+        cwes: ['CWE-506'],
+        summary:
+          'eslint-config-prettier, eslint-plugin-prettier, synckit, @pkgr/core, napi-postinstall have embedded malicious code',
+      }),
+    ).toBe(true);
+    expect(isMaliciousAdvisory({ id: 'GHSA-a', cwes: ['cwe-507'] })).toBe(true);
+  });
+
+  it('flags the malware title conventions without CWE or MAL id', () => {
+    // GitHub's convention.
+    expect(
+      isMaliciousAdvisory({
+        id: 'GHSA-b',
+        summary: 'some-pkg versions have embedded malicious code',
+      }),
+    ).toBe(true);
+    // OSV's convention.
+    expect(isMaliciousAdvisory({ id: 'GHSA-c', summary: 'Malicious code in left-pad (npm)' })).toBe(
+      true,
+    );
+    expect(
+      isMaliciousAdvisory({ id: 'GHSA-d', summary: 'Malicious versions of foo published' }),
+    ).toBe(true);
+  });
+
+  it('does NOT flag ordinary vulnerabilities, including ones that mention malicious input', () => {
+    expect(
+      isMaliciousAdvisory({
+        id: 'GHSA-e',
+        cwes: ['CWE-79'],
+        summary: 'foo fails to sanitize malicious input, allowing XSS',
+      }),
+    ).toBe(false);
+    expect(
+      isMaliciousAdvisory({
+        id: 'CVE-2024-12345',
+        summary: 'Prototype pollution in bar',
+      }),
+    ).toBe(false);
+    expect(isMaliciousAdvisory({ id: 'RUSTSEC-2024-0001' })).toBe(false);
+    // "MALFORMED" must not match the MAL- namespace.
+    expect(isMaliciousAdvisory({ id: 'MALFORMED-2024-1' })).toBe(false);
+  });
+});


### PR DESCRIPTION
Third PR of the 3.7 train. **Stacked on #140** (branched from `feat/evaluate` because the validation instrument is `evaluate` itself) — after #140 merges, retarget this to `release/3.7`.

## The finding

A zero-write replay of the real July 2025 `eslint-config-prettier@10.1.7` compromise (CVE-2025-54313) through `evaluate` showed the default `security-only` posture passing actual install-time malware with **no block and no warning**: the advisory is HIGH (below the critical rule), the high-reachable rule needs a reachability signal the check path never populates, and `added` was not in the warn list. This applies to the loop Stop-gate, which runs the same preset machinery. Evidence: `tmp/launch/evidence-hunts/incident-analyze-css.json` (local).

## The fix (approved posture: warn-for-added + malicious-class rule)

1. **`newMaliciousDependency` block rule** — a net-new dependency carrying a malicious-code advisory blocks at ANY severity, under every posture. One canonical predicate (`src/analyzers/security/malicious.ts`), each branch grounded in a real feed from the incident: OSV `MAL-*` ids, the CWE-506 family (npm audit attaches it; the TS provider now threads `cwe` → `DepVulnFinding.cwes`, additive), and both ecosystems' malware title conventions. Precision-biased: "fails to sanitize malicious input" does not match. Wired through policy defaults, both presets, `scopeForPolicy`, and the classifier (`malicious` context from the current scan only — no baseline schema change).
2. **security-only warns on unmatched net-new** — the preset unions `added` into the warn list (base drift/uncertainty warns survive). Nothing net-new is ever silent; blocking behavior unchanged except for malware.

## Validation

- Real incident replays now block under security-only on BOTH scanner paths: npm-audit (analyze-css — CWE-506/title) and osv-scanner (grafana/opensearch-datasource — `MAL-2025-6022` at severity *medium*, proving the any-severity design necessary).
- Precision regression: 5-landing fastify recheck stays block-free; one new warning = two genuinely net-new medium code findings a PR added — disclosed instead of silent, which is the point.
- Full suite: 3,882 tests pass (54 new/extended: predicate rows pinned to the real captured feeds, classifier rules incl. persisted-malicious-never-blocks, preset warn union, the gather-scope no-silent-skip matrix extended to the new rule). Arch/slop/ecosystem gates green. README + policy docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAAbsZKvrqDjB1Xuqb7zxg