### PR TITLE
perf(gate): ref-based mode stops gathering what its diff discards

### DIFF
--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -63,7 +63,7 @@ import type { BrownfieldPolicy, BaselineSection } from './policy';
 import type { ClassifyContext, ClassifyResult } from './classify';
 import { hydrateAnchorFromBranch, loadAnchorFromBranch } from './anchor';
 import { gatherFromRef } from './ref-baseline';
-import { type GatherScope, FULL_SCOPE, scopeForPolicy } from './gather-scope';
+import { type GatherScope, FULL_SCOPE, scopeForPolicy, scopeForRefBasedDiff } from './gather-scope';
 import { computeChangedFiles } from './changed-files';
 import { changedFilesTouchDependencyManifest, detectActiveLanguages } from '../languages';
 import { evaluateFlowGateForGuardrail } from './flow-gate-check';
@@ -516,6 +516,19 @@ export async function runGuardrailCheck(
     }
   }
 
+  // Ref-based mode structurally discards the REF_UNRELIABLE kinds from the
+  // diff (see partitionForRefBasedDiff), so don't pay to gather them on
+  // either side — under full-debt this was minutes of jscpd + coverage +
+  // check-runner per run for output that got thrown away. The skipped
+  // kinds are recorded so the "not gated in ref-based mode" disclosure
+  // survives the optimization.
+  let refScopeSkippedKinds: ReadonlyArray<BaselineEntry['kind']> = [];
+  if (mode.mode === 'ref-based') {
+    const adjusted = scopeForRefBasedDiff(gatherScope);
+    gatherScope = adjusted.scope;
+    refScopeSkippedKinds = adjusted.skippedKinds;
+  }
+
   // Load the prior side. Committed modes read from the baseline
   // file on disk; ref-based mode recomputes prior state by checking
   // out a git ref into a temporary worktree. Both paths produce a
@@ -582,11 +595,21 @@ export async function runGuardrailCheck(
   // In ref-based mode the prior side came from a detached worktree that
   // can't gather the build-artifact-dependent kinds; drop them from both
   // sides so the diff stays symmetric (see partitionForRefBasedDiff).
-  const { diffablePrior, diffableCurrent, refExcludedKinds } = partitionForRefBasedDiff(
+  const partitioned = partitionForRefBasedDiff(
     baseline.findings,
     current.findings,
     mode.mode === 'ref-based',
   );
+  const { diffablePrior, diffableCurrent } = partitioned;
+  // Union in the kinds whose analyzers were scope-skipped up front: their
+  // gathers never ran, so the partition saw no findings to record, but the
+  // disclosure ("not gated in ref-based mode") must still surface.
+  const refExcludedKinds: GuardrailCheckResult['refExcludedKinds'] = [
+    ...partitioned.refExcludedKinds,
+    ...refScopeSkippedKinds
+      .filter((k) => !partitioned.refExcludedKinds.some((e) => e.kind === k))
+      .map((kind) => ({ kind, currentCount: 0 })),
+  ];
 
   const priorLocated: ReadonlyArray<LocatedIdentity> = entriesToLocated(diffablePrior);
   const currentLocated: ReadonlyArray<LocatedIdentity> = entriesToLocated(diffableCurrent);

--- a/src/baseline/gather-scope.ts
+++ b/src/baseline/gather-scope.ts
@@ -163,6 +163,49 @@ export function scopeSignature(s: GatherScope): string {
  * `depVulns` for it so the mapping stays a faithful, future-proof mirror of
  * the rule table rather than relying on that downstream gap.
  */
+/** The finding kinds a ref-based diff structurally excludes, mapped to the
+ *  scope flags of the analyzers that produce them. `secret-hmac` is absent
+ *  deliberately: it is a companion output of the secrets analyzer, which
+ *  must still run for the located `secret` kind. */
+export type RefSkippableKind = 'duplication' | 'test-gap' | 'custom-check';
+
+/**
+ * Drop the analyzers whose finding kinds a ref-based diff throws away
+ * (`REF_UNRELIABLE_KINDS` in check.ts: duplication, test-gap,
+ * custom-check). Gathering them in ref-based mode pays the jscpd /
+ * coverage / check-runner cost on BOTH sides for findings
+ * `partitionForRefBasedDiff` then discards — found by stress-running the
+ * zero-write trial under full-debt, where the discarded gathers dominated
+ * the per-landing cost (the same waste applied to ref-based CI runs and
+ * full-debt loop gates).
+ *
+ * Returns the adjusted scope plus the kinds whose analyzers were skipped,
+ * so the caller still DISCLOSES the exclusion — the honest "not gated in
+ * ref-based mode" note must not disappear just because the thrown-away
+ * gather stopped being paid for. Pure.
+ */
+export function scopeForRefBasedDiff(scope: GatherScope): {
+  readonly scope: GatherScope;
+  readonly skippedKinds: ReadonlyArray<RefSkippableKind>;
+} {
+  const skipped: RefSkippableKind[] = [];
+  const next = { ...scope };
+  if (next.duplication) {
+    next.duplication = false;
+    skipped.push('duplication');
+  }
+  if (next.testGaps) {
+    next.testGaps = false;
+    skipped.push('test-gap');
+  }
+  if (next.customChecks) {
+    next.customChecks = false;
+    skipped.push('custom-check');
+  }
+  if (skipped.length === 0) return { scope, skippedKinds: skipped };
+  return { scope: Object.freeze(next), skippedKinds: skipped };
+}
+
 export function scopeForPolicy(policy: BrownfieldPolicy): GatherScope {
   // Any status-based block applies across all kinds — nothing is safe to skip.
   if (policy.block.length > 0) return FULL_SCOPE;

--- a/test/baseline/gather-scope.test.ts
+++ b/test/baseline/gather-scope.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   scopeForPolicy,
+  scopeForRefBasedDiff,
   scopeSignature,
   isFullScope,
   isEmptyScope,
@@ -40,6 +41,27 @@ const SECURITY_ONLY: BrownfieldPolicy = {
     newSevereQualityIssueInChangedFiles: false,
   },
 };
+
+describe('scopeForRefBasedDiff', () => {
+  it('clears exactly the analyzers whose kinds a ref diff discards, and names them', () => {
+    const { scope, skippedKinds } = scopeForRefBasedDiff(FULL_SCOPE);
+    expect(scope.duplication).toBe(false);
+    expect(scope.testGaps).toBe(false);
+    expect(scope.customChecks).toBe(false);
+    // The secrets analyzer stays on: secret-hmac is its companion output
+    // and the located `secret` kind still gates.
+    expect(scope.secrets).toBe(true);
+    expect(scope.codePatterns).toBe(true);
+    expect(scope.depVulns).toBe(true);
+    expect([...skippedKinds].sort()).toEqual(['custom-check', 'duplication', 'test-gap']);
+  });
+
+  it('is a no-op on a scope that never enabled the discarded analyzers', () => {
+    const { scope, skippedKinds } = scopeForRefBasedDiff(scopeForPolicy(SECURITY_ONLY));
+    expect(skippedKinds).toEqual([]);
+    expect(scope).toEqual(scopeForPolicy(SECURITY_ONLY));
+  });
+});
 
 describe('scopeForPolicy', () => {
   it('security-only enables ONLY the analyzers feeding its blockable kinds', () => {


### PR DESCRIPTION
The orphaned commit from #141 — it was pushed to the branch minutes after the rebase-merge and never landed. Cherry-picked clean onto the train.

Under full-debt, a ref-based run resolved to a full gather scope, paying jscpd, the test-gap analyzer, and the custom-check runner on both sides of every diff — then `partitionForRefBasedDiff` discarded all of those findings, because ref-based mode structurally cannot gate them. Minutes per run of thrown-away work on every ref-based CI guardrail and full-debt loop gate (found when a full-debt trial replay sat on one repo for most of an hour; post-fix the same replay finished in ~4 minutes).

`scopeForRefBasedDiff` (pure, gather-scope.ts) clears exactly the analyzers whose kinds the ref diff discards; the secrets analyzer stays on (secret-hmac is its companion output, the located secret kind still gates); the skipped kinds are recorded so the "not gated in ref-based mode" disclosure survives the optimization. Unit-tested; full suite was green with this commit on the original branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)