### PR TITLE
fix(allowlist): inline dxkit-allow annotations actually suppress + batch line-shift + raw-scan display (s24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Inline `dxkit-allow:` annotations now suppress the finding they sit on.**
+  An inline annotation was inserted into the source but never waived anything —
+  neither the scan report nor the guardrail — so the documented "annotate a test
+  fixture" path did nothing. Each annotation adjacent to a code/secret/config
+  finding is now resolved into an allowlist decision keyed on that finding's
+  fingerprint, so it suppresses exactly like a file-level entry, in both the
+  report and the gate. Works for gitleaks and grep-secrets findings, not only
+  semgrep.
+- **`allowlist add <file>:<line>` no longer strands later annotations.** The
+  inline insert now always appends to the finding's own line instead of adding a
+  line above it, so a second add in the same file — using line numbers from the
+  original scan — still lands on its real finding rather than one line off.
+- **The `vulnerabilities` scan shows what is allowlisted.** The terminal summary
+  now prints `(N allowlisted)` alongside the count and lists each secret with its
+  file, line, and suppression status, so an accepted test fixture is visible
+  instead of leaving a flat total that looks unchanged.
+
 ## [3.6.0] - 2026-07-12
 
 ### Changed

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -58,7 +58,13 @@ Rules for a scoped pass:
   writing docs is a dedicated loop — route to `dxkit-test` / `dxkit-docs`
   rather than half-doing it here.
 - **Verify within the scope.** Step [5] re-runs the scope's own report; the
-  scoped dimension should move and nothing else should regress (guardrail).
+  scoped dimension should move and nothing else should regress (guardrail). For a
+  SUPPRESSION (you allowlisted a finding — inline `dxkit-allow:` or file-level —
+  rather than fixing it), the raw count is unchanged BY DESIGN (raw-truth model):
+  verify instead that the finding now prints `(allowlisted: <category>)` in the
+  report and that the score moved, or confirm the gate impact with
+  `vyuh-dxkit guardrail check` (a suppressed finding drops out of the verdict and
+  is counted under "suppressed"). Do not expect the raw total to drop.
 
 Without a named scope, work the full **Priority order** below.
 

--- a/src/allowlist/annotate.ts
+++ b/src/allowlist/annotate.ts
@@ -55,7 +55,7 @@ export type CategorizedFinding = AnnotatableFinding & { readonly category: Findi
  * carry a stamped fingerprint, so they are annotatable — see the dep
  * wrapper below).
  */
-function kindForCategory(category: FindingCategory): IdentityKind {
+export function kindForCategory(category: FindingCategory): IdentityKind {
   switch (category) {
     case 'secret':
       return 'secret';

--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -304,7 +304,15 @@ async function runAddInline(args: {
     process.exit(1);
   }
 
-  const result = insertAnnotation(absPath, target.line, { category, reason }, lang);
+  // Force SAME-LINE insertion (append to the finding's own line) so the write
+  // never shifts subsequent line numbers. An above-line insert pushes every later
+  // line down by one, so a second `allowlist add <file>:<line>` in the same file —
+  // using line numbers from the pre-insert scan — would land one line off and
+  // suppress nothing (the s24 batch line-shift bug). Same-line never shifts, so
+  // sequential/batched adds all land on their real finding regardless of order.
+  const result = insertAnnotation(absPath, target.line, { category, reason }, lang, {
+    sameLineThreshold: Number.MAX_SAFE_INTEGER,
+  });
   logger.info(
     `Inserted ${result.position} allowlist annotation at ${target.file}:${result.annotationLine} ` +
       `(category=${category})`,

--- a/src/allowlist/inline-synth.ts
+++ b/src/allowlist/inline-synth.ts
@@ -1,0 +1,132 @@
+/**
+ * Inline `dxkit-allow:` annotations → synthesized allowlist entries.
+ *
+ * An inline annotation is an ALTERNATE SOURCE of an allowlist decision, not a
+ * second suppression mechanism (Rule 2). A committed `// dxkit-allow:test-fixture`
+ * comment adjacent to a finding is resolved here into an in-memory
+ * `AllowlistEntry` keyed on that finding's fingerprint, which the ONE
+ * fingerprint-based suppression core (`annotateByKind` on the report side,
+ * `allowlistSuppressionFor` on the gate side) then honors exactly like a
+ * file-level entry. The synthesized entries are EPHEMERAL — never written to
+ * `.dxkit/allowlist.json`; the annotation in the source IS the persistent record
+ * (and the stale-allow producer already tracks orphaned ones).
+ *
+ * Why synthesize rather than match by location in both consumers: the report
+ * annotator and the gate both already match findings against the loaded
+ * `AllowlistFile` by fingerprint. Turning an annotation into an entry keeps the
+ * "is this finding allowlisted?" decision in one place instead of adding a
+ * second, location-based predicate to two code paths.
+ *
+ * SECURITY: only INLINE-COMPATIBLE categories (`test-fixture` / `false-positive`)
+ * suppress inline — the same restriction the CLI enforces when WRITING an inline
+ * annotation. accepted-risk / deferred decisions must be file-level (auditable in
+ * one place). The annotation must sit exactly on (same-line) or immediately above
+ * (above-line) the finding, so a stray comment elsewhere can never waive a real
+ * credential. The source is the repo's own committed tree — the same trust
+ * boundary as the file-level allowlist.
+ */
+
+import type { InlineAllowlistOccurrence } from './gather';
+import type { AllowlistCategory } from './categories';
+import { INLINE_COMPATIBLE_CATEGORIES } from './categories';
+import type { AllowlistEntry, AllowlistFile } from './file';
+import { emptyAllowlistFile } from './file';
+import type { IdentityKind } from '../baseline/producers';
+
+/** The minimal finding shape the synth needs. `kind` is the durable identity
+ *  kind (the same discriminant the suppression core matches on) — the report
+ *  side maps its `FindingCategory` through `kindForCategory`, the gate reads it
+ *  off the baseline entry directly. `line` is 1-based; a finding with no
+ *  resolvable line can't be inline-covered and is skipped by the caller. */
+export interface InlineSynthFinding {
+  readonly file: string;
+  readonly line: number;
+  readonly fingerprint?: string;
+  readonly kind: IdentityKind;
+}
+
+/** Normalize a repo path for cross-source matching (occurrence paths come from
+ *  the source walker, finding paths from the scanners — strip a leading `./`
+ *  and normalize separators so the two align). */
+function normPath(p: string): string {
+  return p.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+/**
+ * The finding line an inline annotation COVERS: a same-line annotation at line L
+ * covers L; an above-line annotation at line L covers L+1 (the finding it sits
+ * above). The ONE coverage rule (Rule 2) — shared by the suppression synth AND
+ * the stale-allow producer, so "this annotation covers a finding" means the same
+ * thing to both (else the synth suppresses a finding while stale-allow reports the
+ * annotation orphaned — a net-new block from a working suppression).
+ */
+export function coveredLineFor(occ: Pick<InlineAllowlistOccurrence, 'line' | 'position'>): number {
+  return occ.position === 'above' ? occ.line + 1 : occ.line;
+}
+
+/**
+ * Map `${file}:${line}` → category for every line an inline annotation COVERS.
+ * Non-inline-compatible categories are dropped — they never suppress inline.
+ */
+export function inlineCoverage(
+  occurrences: readonly InlineAllowlistOccurrence[],
+): Map<string, AllowlistCategory> {
+  const cover = new Map<string, AllowlistCategory>();
+  for (const o of occurrences) {
+    if (!INLINE_COMPATIBLE_CATEGORIES.has(o.category as AllowlistCategory)) continue;
+    cover.set(`${normPath(o.file)}:${coveredLineFor(o)}`, o.category as AllowlistCategory);
+  }
+  return cover;
+}
+
+/**
+ * Synthesize ephemeral allowlist entries for every finding an inline annotation
+ * covers. Deterministic given `now`; deduped by fingerprint (one entry per
+ * distinct finding identity, even if multiple findings share a covered line).
+ */
+export function synthesizeInlineEntries(
+  occurrences: readonly InlineAllowlistOccurrence[],
+  findings: readonly InlineSynthFinding[],
+  now: Date = new Date(),
+): AllowlistEntry[] {
+  const cover = inlineCoverage(occurrences);
+  if (cover.size === 0) return [];
+  const out: AllowlistEntry[] = [];
+  const seen = new Set<string>();
+  const addedAt = now.toISOString();
+  for (const f of findings) {
+    if (!f.fingerprint || seen.has(f.fingerprint)) continue;
+    const category = cover.get(`${normPath(f.file)}:${f.line}`);
+    if (!category) continue;
+    seen.add(f.fingerprint);
+    out.push({
+      fingerprint: f.fingerprint,
+      kind: f.kind,
+      category,
+      reason: 'inline dxkit-allow annotation',
+      addedAt,
+    });
+  }
+  return out;
+}
+
+/**
+ * Return `base` augmented with the synthesized inline entries (deduped against
+ * existing fingerprints — a file-level entry wins, its category is authoritative).
+ * Returns `base` unchanged when there are no inline entries. Constructs a minimal
+ * allowlist when `base` is null but inline entries exist, so a repo with inline
+ * annotations and no `allowlist.json` still suppresses.
+ */
+export function augmentAllowlistWithInline(
+  base: AllowlistFile | null,
+  inlineEntries: readonly AllowlistEntry[],
+): AllowlistFile | null {
+  if (inlineEntries.length === 0) return base;
+  const scaffold = base ?? emptyAllowlistFile();
+  const existingFps = new Set(scaffold.entries.map((e) => e.fingerprint));
+  const merged = [
+    ...scaffold.entries,
+    ...inlineEntries.filter((e) => !existingFps.has(e.fingerprint)),
+  ];
+  return { ...scaffold, entries: merged };
+}

--- a/src/analyzers/security/aggregator.ts
+++ b/src/analyzers/security/aggregator.ts
@@ -70,8 +70,11 @@ import {
   annotateFindingsWithAllowlist,
   annotateDepFindingsWithAllowlist,
   allowlistLiftsScore,
+  kindForCategory,
 } from '../../allowlist/annotate';
 import type { AllowlistFile } from '../../allowlist/file';
+import { synthesizeInlineEntries, augmentAllowlistWithInline } from '../../allowlist/inline-synth';
+import type { InlineAllowlistOccurrence } from '../../allowlist/gather';
 
 // ─── Re-exports for consumer convenience ──────────────────────────────────
 
@@ -307,6 +310,13 @@ export interface SecurityAggregateInput {
    * lifts the score (`false-positive` / `test-fixture`). Absent/null →
    * `scoreable*` buckets equal the raw buckets. */
   allowlist?: AllowlistFile | null;
+  /** Inline `dxkit-allow:` annotations walked from the source tree by the
+   * caller (I/O stays out of this pure aggregate). Each annotation adjacent to
+   * a code/secret/config finding is resolved into an ephemeral allowlist entry
+   * keyed on that finding's fingerprint (`synthesizeInlineEntries`), so an
+   * inline suppression waives a finding exactly like a file-level entry — one
+   * suppression core, two sources (Rule 2). Absent/empty → file-level only. */
+  inlineAnnotations?: readonly InlineAllowlistOccurrence[];
 }
 
 /**
@@ -655,7 +665,24 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
     ...codeFindingsByCategory.code,
     ...codeFindingsByCategory.config,
   ];
-  annotateFindingsWithAllowlist(allCodeSideFindings, input.allowlist ?? null);
+  // Inline `dxkit-allow:` annotations are resolved to ephemeral entries keyed on
+  // each covered finding's fingerprint, then merged into the loaded allowlist —
+  // so inline and file-level suppressions flow through the ONE fingerprint-based
+  // annotator below (Rule 2). Fingerprints are already stamped on the findings by
+  // this point (the annotator matches on them too).
+  const effectiveAllowlist = augmentAllowlistWithInline(
+    input.allowlist ?? null,
+    synthesizeInlineEntries(
+      input.inlineAnnotations ?? [],
+      allCodeSideFindings.map((f) => ({
+        file: f.file,
+        line: f.line,
+        fingerprint: f.fingerprint,
+        kind: kindForCategory(f.category),
+      })),
+    ),
+  );
+  annotateFindingsWithAllowlist(allCodeSideFindings, effectiveAllowlist);
 
   const scoreableCodeBySeverity = emptyCounts();
   const scoreableSecretsBySeverity = emptyCounts();

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -28,6 +28,7 @@ import { SecurityFinding, DepVulnSummary, Severity } from './types';
 import { buildSecurityAggregate, type SecurityAggregate } from './aggregator';
 import { discoverNestedDepRoots, mergeDepVulnOutcomes } from './nested-dep-roots';
 import { loadAllowlist } from '../../allowlist/file';
+import { gatherInlineAllowlistAnnotations } from '../../allowlist/gather';
 import { defaultDispatcher } from '../dispatcher';
 import { allTlsBypassPatterns, detectActiveLanguages } from '../../languages';
 import {
@@ -683,5 +684,9 @@ export async function buildSecurityAggregateForHealth(
     // the analysis cache — see the same allowlist-adjusted scoreable
     // buckets and the same per-finding allowlist annotations.
     allowlist: loadAllowlist(cwd),
+    // Inline `dxkit-allow:` annotations, walked here (I/O) and resolved to
+    // ephemeral fingerprint entries inside the pure aggregate — so an inline
+    // suppression waives a finding exactly like a file-level one.
+    inlineAnnotations: gatherInlineAllowlistAnnotations(cwd),
   });
 }

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -82,6 +82,8 @@ import {
   type AllowlistDelta,
 } from '../allowlist/diff';
 import { findEntry, isEntryActive, loadAllowlist } from '../allowlist/file';
+import { gatherInlineAllowlistAnnotations } from '../allowlist/gather';
+import { synthesizeInlineEntries, augmentAllowlistWithInline } from '../allowlist/inline-synth';
 import type { AllowlistFile } from '../allowlist/file';
 import type { AllowlistCategory } from '../allowlist/categories';
 
@@ -631,7 +633,25 @@ export async function runGuardrailCheck(
   // this is what makes "I reviewed and accepted this finding" actually
   // suppress a net-new regression, not just annotate it. Null when no
   // allowlist file is present (the common case).
-  const allowlist = loadAllowlist(cwd);
+  // Load the file-level allowlist, then augment it with entries synthesized from
+  // inline `dxkit-allow:` annotations in the current tree — so an inline
+  // suppression on a NET-NEW finding waives its block exactly like a file-level
+  // entry (one suppression core, two sources — Rule 2). Only current-side findings
+  // with a resolvable file+line can be inline-covered; the synth mints an entry
+  // only when an annotation sits on/above that finding, keyed on its fingerprint.
+  const inlineSynthFindings = current.findings
+    .map((e) => {
+      const file = locatorFile(e);
+      const line = locatorLine(e);
+      return file !== undefined && line !== undefined
+        ? { file, line, fingerprint: e.id, kind: e.kind }
+        : null;
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null);
+  const allowlist = augmentAllowlistWithInline(
+    loadAllowlist(cwd),
+    synthesizeInlineEntries(gatherInlineAllowlistAnnotations(cwd), inlineSynthFindings),
+  );
   const now = new Date();
 
   const classifiedPairs: ClassifiedPair[] = [];

--- a/src/baseline/producers/stale-allow.ts
+++ b/src/baseline/producers/stale-allow.ts
@@ -47,6 +47,7 @@
 import { lineWindowFor } from '../../analyzers/tools/fingerprint';
 import type { SecurityAggregate } from '../../analyzers/security/aggregator';
 import type { InlineAllowlistOccurrence } from '../../allowlist/gather';
+import { coveredLineFor } from '../../allowlist/inline-synth';
 import { computeContentHashFromCommit } from '../content-hash';
 import { identityFor } from '../finding-identity';
 import type { RichBaselineEntry, StaleAllowIdentityInput } from '../types';
@@ -87,7 +88,11 @@ export function staleAllowToBaselineEntries(input: StaleAllowInput): RichBaselin
   const covered = buildCoveredLocations(input.aggregate);
   const out: RichBaselineEntry[] = [];
   for (const occ of input.annotations) {
-    const key = locationKey(occ.file, occ.line);
+    // Check the line the annotation COVERS (above-line → the finding below it),
+    // not the annotation's own line — the same coverage rule the suppression synth
+    // uses, so an annotation that legitimately suppresses a finding is never also
+    // reported orphaned (Rule 2).
+    const key = locationKey(occ.file, coveredLineFor(occ));
     if (covered.has(key)) continue; // active suppression — not stale
     const identityInput: StaleAllowIdentityInput = {
       kind: 'stale-allow',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1270,13 +1270,35 @@ export async function run(argv: string[]): Promise<void> {
       if (values.json) {
         await emitJson(stampSchema(report, 'vulnerabilities'));
       } else {
+        const { summarizeAllowlist } = await import('./allowlist/annotate');
         const s = report.summary.findings;
         const d = report.summary.dependencies;
+        // Live-vs-allowlisted split, so a headline count reflects suppression
+        // (raw count is unchanged — dxkit's raw-truth model — but the terminal
+        // now SAYS how many are accepted, instead of alarming with a flat total).
+        const split = summarizeAllowlist(report.findings);
+        const byCat = Object.entries(split.byCategory)
+          .map(([c, n]) => `${n} ${c}`)
+          .join(', ');
+        const allowSuffix =
+          split.allowlisted > 0
+            ? `  (${split.allowlisted} allowlisted${byCat ? `: ${byCat}` : ''})`
+            : '';
         console.log('');
         console.log(`  ${logger.bold('Code findings:')}`);
         console.log(
-          `    CRITICAL: ${s.critical}  HIGH: ${s.high}  MEDIUM: ${s.medium}  LOW: ${s.low}  Total: ${s.total}`,
+          `    CRITICAL: ${s.critical}  HIGH: ${s.high}  MEDIUM: ${s.medium}  LOW: ${s.low}  Total: ${s.total}${allowSuffix}`,
         );
+        // Enumerate secrets — the worklist a user needs to triage. Previously the
+        // terminal printed only counts and secrets were visible in `--json` alone.
+        const secrets = report.findings.filter((f) => f.category === 'secret');
+        if (secrets.length > 0) {
+          console.log(`  ${logger.bold(`Secrets (${secrets.length}):`)}`); // slop-ok: CLI report output, matches this block
+          for (const f of secrets) {
+            const tag = f.allowlisted ? ` (allowlisted: ${f.allowlistCategory})` : '';
+            console.log(`    [${f.severity}] ${f.rule}  ${f.file}:${f.line}${tag}`); // slop-ok: CLI report output
+          }
+        }
         if (d.tool) {
           console.log(`  ${logger.bold('Dependency vulns:')}`);
           console.log(`    ${d.critical}C ${d.high}H ${d.medium}M ${d.low}L (${d.total} total)`);

--- a/test/allowlist/inline-synth.test.ts
+++ b/test/allowlist/inline-synth.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import {
+  inlineCoverage,
+  synthesizeInlineEntries,
+  augmentAllowlistWithInline,
+  type InlineSynthFinding,
+} from '../../src/allowlist/inline-synth';
+import type { InlineAllowlistOccurrence } from '../../src/allowlist/gather';
+import { emptyAllowlistFile } from '../../src/allowlist/file';
+
+const NOW = new Date('2026-01-01T00:00:00.000Z');
+
+const occ = (
+  file: string,
+  line: number,
+  category: string,
+  position: 'above' | 'same-line',
+): InlineAllowlistOccurrence => ({ file, line, category, position });
+
+const finding = (file: string, line: number, fingerprint?: string): InlineSynthFinding => ({
+  file,
+  line,
+  fingerprint,
+  kind: 'secret',
+});
+
+describe('inlineCoverage', () => {
+  it('same-line annotation covers its own line; above covers the next line', () => {
+    const cov = inlineCoverage([
+      occ('src/a.ts', 5, 'test-fixture', 'same-line'),
+      occ('src/a.ts', 9, 'false-positive', 'above'),
+    ]);
+    expect(cov.get('src/a.ts:5')).toBe('test-fixture');
+    expect(cov.get('src/a.ts:10')).toBe('false-positive'); // above@9 covers 10
+    expect(cov.get('src/a.ts:9')).toBeUndefined();
+  });
+
+  it('drops categories that are not inline-compatible (accepted-risk is file-only)', () => {
+    const cov = inlineCoverage([occ('src/a.ts', 3, 'accepted-risk', 'same-line')]);
+    expect(cov.size).toBe(0);
+  });
+
+  it('normalizes a leading ./ so occurrence and finding paths align', () => {
+    const cov = inlineCoverage([occ('./src/a.ts', 4, 'test-fixture', 'same-line')]);
+    expect(cov.get('src/a.ts:4')).toBe('test-fixture');
+  });
+});
+
+describe('synthesizeInlineEntries', () => {
+  it('mints an entry for a finding an annotation covers, keyed on its fingerprint', () => {
+    const entries = synthesizeInlineEntries(
+      [occ('src/a.ts', 5, 'test-fixture', 'same-line')],
+      [finding('src/a.ts', 5, 'fp-abc')],
+      NOW,
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      fingerprint: 'fp-abc',
+      kind: 'secret',
+      category: 'test-fixture',
+      addedAt: NOW.toISOString(),
+    });
+  });
+
+  it('does NOT mint for a finding with no annotation at its line', () => {
+    const entries = synthesizeInlineEntries(
+      [occ('src/a.ts', 5, 'test-fixture', 'same-line')],
+      [finding('src/a.ts', 6, 'fp-xyz')],
+      NOW,
+    );
+    expect(entries).toHaveLength(0);
+  });
+
+  it('an above-line annotation suppresses the finding beneath it', () => {
+    const entries = synthesizeInlineEntries(
+      [occ('src/a.ts', 9, 'test-fixture', 'above')],
+      [finding('src/a.ts', 10, 'fp-below')],
+      NOW,
+    );
+    expect(entries.map((e) => e.fingerprint)).toEqual(['fp-below']);
+  });
+
+  it('skips findings without a fingerprint and dedupes repeats', () => {
+    const entries = synthesizeInlineEntries(
+      [occ('src/a.ts', 5, 'test-fixture', 'same-line')],
+      [
+        finding('src/a.ts', 5, undefined),
+        finding('src/a.ts', 5, 'dup'),
+        finding('src/a.ts', 5, 'dup'),
+      ],
+      NOW,
+    );
+    expect(entries.map((e) => e.fingerprint)).toEqual(['dup']);
+  });
+});
+
+describe('augmentAllowlistWithInline', () => {
+  it('returns base unchanged when there are no inline entries', () => {
+    const base = emptyAllowlistFile();
+    expect(augmentAllowlistWithInline(base, [])).toBe(base);
+    expect(augmentAllowlistWithInline(null, [])).toBeNull();
+  });
+
+  it('constructs a valid allowlist when base is null but inline entries exist', () => {
+    const synth = synthesizeInlineEntries(
+      [occ('src/a.ts', 5, 'test-fixture', 'same-line')],
+      [finding('src/a.ts', 5, 'fp-abc')],
+      NOW,
+    );
+    const out = augmentAllowlistWithInline(null, synth);
+    expect(out).not.toBeNull();
+    expect(out!.entries.map((e) => e.fingerprint)).toEqual(['fp-abc']);
+    expect(out!.schemaVersion).toBe(emptyAllowlistFile().schemaVersion);
+  });
+
+  it('a file-level entry wins over an inline entry with the same fingerprint', () => {
+    const base = {
+      ...emptyAllowlistFile(),
+      entries: [
+        {
+          fingerprint: 'fp-abc',
+          kind: 'secret' as const,
+          category: 'accepted-risk' as const,
+          addedAt: NOW.toISOString(),
+        },
+      ],
+    };
+    const synth = synthesizeInlineEntries(
+      [occ('src/a.ts', 5, 'test-fixture', 'same-line')],
+      [finding('src/a.ts', 5, 'fp-abc')],
+      NOW,
+    );
+    const out = augmentAllowlistWithInline(base, synth);
+    expect(out!.entries).toHaveLength(1);
+    expect(out!.entries[0].category).toBe('accepted-risk'); // file-level authoritative
+  });
+});

--- a/test/baseline/producers/stale-allow.test.ts
+++ b/test/baseline/producers/stale-allow.test.ts
@@ -177,4 +177,25 @@ describe('staleAllowToBaselineEntries', () => {
     });
     expect(a[0].id).toBe(b[0].id);
   });
+
+  it('an ABOVE-line annotation is NOT stale when the finding sits on the line it covers', () => {
+    // Annotation comment on line 2, finding on line 3 (the line the annotation
+    // covers). Historically this checked the annotation's OWN line and, when 2
+    // and 3 fell in different line-windows, wrongly reported the annotation
+    // orphaned — spawning a net-new stale-allow block from a working inline
+    // suppression. It must use the covered line (Rule 2: same rule as the synth).
+    const out = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 2, position: 'above' })],
+      aggregate: makeAggregate({ secrets: [makeFinding('src/a.ts', 3)] }),
+    });
+    expect(out).toHaveLength(0);
+  });
+
+  it('an ABOVE-line annotation IS stale when the covered line has no finding', () => {
+    const out = staleAllowToBaselineEntries({
+      annotations: [makeOccurrence({ file: 'src/a.ts', line: 2, position: 'above' })],
+      aggregate: makeAggregate({ secrets: [makeFinding('src/a.ts', 20)] }),
+    });
+    expect(out).toHaveLength(1);
+  });
 });

--- a/test/security-aggregator.test.ts
+++ b/test/security-aggregator.test.ts
@@ -102,6 +102,61 @@ describe('buildSecurityAggregate — empty case', () => {
   });
 });
 
+describe('buildSecurityAggregate — inline dxkit-allow annotations suppress (wiring net)', () => {
+  // The bug this pins (feedback s24): inline annotations had a working matcher
+  // (`findAnnotationAt`) that NOTHING called, so a documented suppression path did
+  // nothing. This test fails if the aggregator ever stops threading inline
+  // annotations through the synth — catching that whole "helper exists but is never
+  // wired" class, not just today's fix.
+  it('an inline annotation covering a finding marks it allowlisted (aggregator calls the synth)', () => {
+    const agg = buildSecurityAggregate({
+      ...emptyInput(),
+      secrets: {
+        findings: [
+          makeFinding({ category: 'secret', severity: 'critical', file: 'a.ts', line: 5 }),
+        ],
+        toolUsed: 'gitleaks',
+      },
+      inlineAnnotations: [
+        { file: 'a.ts', line: 5, category: 'test-fixture', position: 'same-line' },
+      ],
+    });
+    const secret = agg.findingsByCategory.secret[0];
+    expect(secret.allowlisted).toBe(true);
+    expect(secret.allowlistCategory).toBe('test-fixture');
+  });
+
+  it('a finding with no covering annotation stays live (no over-suppression)', () => {
+    const agg = buildSecurityAggregate({
+      ...emptyInput(),
+      secrets: {
+        findings: [
+          makeFinding({ category: 'secret', severity: 'critical', file: 'a.ts', line: 5 }),
+        ],
+        toolUsed: 'gitleaks',
+      },
+      inlineAnnotations: [
+        { file: 'a.ts', line: 99, category: 'test-fixture', position: 'same-line' },
+      ],
+    });
+    expect(agg.findingsByCategory.secret[0].allowlisted).toBeFalsy();
+  });
+
+  it('an above-line annotation waives the finding beneath it, across the aggregate', () => {
+    const agg = buildSecurityAggregate({
+      ...emptyInput(),
+      secrets: {
+        findings: [
+          makeFinding({ category: 'secret', severity: 'critical', file: 'a.ts', line: 6 }),
+        ],
+        toolUsed: 'gitleaks',
+      },
+      inlineAnnotations: [{ file: 'a.ts', line: 5, category: 'false-positive', position: 'above' }],
+    });
+    expect(agg.findingsByCategory.secret[0].allowlisted).toBe(true);
+  });
+});
+
 describe('buildSecurityAggregate — content-anchor threading', () => {
   // The anchor material is carried from the gather boundary onto the
   // emitted CodeFinding so the identity layer and producers can


### PR DESCRIPTION
Closes the genuinely-open items from dogfood feedback **s24** (Track 1 of the 3.7 solid-product work). The gate itself was already sound — this closes the inline-annotation and raw-scan-display surfaces.

## Fix (at root, Rule 2 — one suppression core, two sources)
- `src/allowlist/inline-synth.ts` resolves each inline `dxkit-allow:` annotation into an ephemeral allowlist entry keyed on the covered finding's fingerprint, merged into the loaded allowlist so inline + file-level suppression share the one fingerprint-based core — on the report side (aggregator) and the gate side (check). Works for gitleaks/grep-secrets, not just semgrep.
- Unified the coverage rule between the synth and the stale-allow producer (`coveredLineFor`), fixing a latent bug where a working suppression spawned a net-new stale-allow block.
- `allowlist add <file>:<line>` now appends same-line (never shifts subsequent lines).
- The `vulnerabilities` terminal prints `(N allowlisted)` and enumerates each secret with its status.
- dxkit-action skill verify step updated for the suppression case.

## Verification
- 27 targeted unit/regression tests incl. an aggregator wiring net (fails if the synth is ever un-wired) + full suite 3899 passing; build/lint/format/arch-check green.
- Verified end-to-end on real repos incl. a genuine 87K-LOC OSS repo: real finding annotated inline → suppressed; wrong-category + unannotated NOT suppressed (no over-suppression); committed + ref-based gate modes; CRLF; Python `#` annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfsSipNEgNZm7x23jGjyE9