### PR TITLE
feat(seam-gate): structural-duplicate gate — catch copy-paste, not just tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Structural-duplicate (seam) gate — catches the copy-paste-instead-of-parameterize
+  pattern.** A new opt-in guardrail layer flags a net-new function that
+  structurally re-implements another: same helper set, same name shape, read from
+  the call graph — so it survives rename and reformat, where the existing
+  token-level duplicate signal (jscpd) does not. It is a two-ref relation like the
+  flow and schema gates: a duplicate present at the base ref is grandfathered, and
+  only a pair the change introduces is reported, so an upgrade never floods the
+  gate with pre-existing debt. A lone duplicate is always warn-tier (never blocks
+  on its own). Enable with `.dxkit/policy.json:duplication.mode` (`warn` /
+  `block`); it defaults to `off` because it builds the code graph. Findings carry
+  a durable `code-reimplementation` fingerprint and an allowlist escape hatch
+  (`--kind=code-reimplementation --category=false-positive`) for a sanctioned
+  by-design parallel. The finding is **directional** — it names which side the
+  change introduced (`added: <new> ≈ existing: <twin>`, and `"changed": true` on
+  the new anchor in JSON), so an agent knows exactly which copy to consolidate;
+  the `dxkit-action` skill carries a fix recipe for it. Highest signal on
+  backend / CLI / library code; on a framework-mediated frontend the call graph
+  is thin, so it finds little rather than false-flagging.
+
 ### Fixed
+
+- **Indexing an in-memory producer graph no longer throws.** The graph indexer
+  now tolerates a raw producer graph that carries no flow-overlay `endpoints`
+  layer, so a zero-write consumer (the seam gate) can query the graph in memory
+  without a disk round-trip.
 
 - **Inline `dxkit-allow:` annotations now suppress the finding they sit on.**
   An inline annotation was inserted into the source but never waived anything —

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -355,6 +355,51 @@ suppressed section. Under an autonomous loop the `security-only` preset
 demotes schema blocks to warnings; the preset never activates a gate the
 repo did not configure.
 
+## `duplication` — the structural-duplicate (seam) gate (opt-in)
+
+Flag a net-new function that structurally re-implements another — same helper
+set, same name shape, read from the **call graph** (so it survives rename and
+reformat, where the token-level [duplicate signal](../commands/quality.md) does
+not). This catches the copy-paste-instead-of-parameterize pattern (a CLI variant
+pasted from a handler, a `findByX` cloned into a `findByIdX`).
+
+```jsonc
+{
+  "duplication": {
+    "mode": "warn", // off (default) | warn | block
+    "minScore": 0.5, // structural similarity to report (0..1, default 0.5)
+  },
+}
+```
+
+- `off` (default) — the gate does not run. It builds the code graph (the
+  heaviest thing dxkit does), so — unlike the cheap flow gate — it is strictly
+  opt-in; a repo that never configured it never pays a graph build.
+- `warn` — a net-new structural duplicate surfaces as a warning.
+- `block` — a lone duplicate still only warns (the precision floor); `block`
+  authorizes seam **convergence** to escalate a duplicate that is _also_ a
+  reliably-dead surface. (Convergence ships in a follow-up; today `block`
+  behaves like `warn`.)
+
+Like the flow and schema gates, it is a **two-ref relation**: a duplicate
+present at the base ref is grandfathered, and only a pair the change introduces
+is reported — so enabling it, or upgrading dxkit, never floods the gate with a
+repo's pre-existing duplication. It is additive and fail-open: it runs only when
+the diff touches a source file, scopes the scan to pairs touching a changed
+file, and any infrastructure failure (graphify absent, an unparseable tree)
+means "did not gate", never a failed build. A sanctioned by-design parallel is
+accepted with `allowlist add --fingerprint=<id> --kind=code-reimplementation
+--category=false-positive`, which stays visible in the PR comment's suppressed
+section.
+
+Highest signal on backend / CLI / library code (a dense internal call graph); on
+a framework-mediated frontend the graph is thin, so it finds little rather than
+false-flagging. It catches structural copy-paste, not semantic re-derivation
+(two functions that reach the same end through _different_ helpers share no
+callee overlap — out of scope by construction). Under an autonomous loop the
+`security-only` preset keeps duplicates at warn; the preset never activates a
+gate the repo did not configure.
+
 ## `loop.preset` — loop-scoped posture (not read by CI)
 
 A repo running the [loop pack](../commands/loop.md) carries a separate

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -45,7 +45,7 @@ partitions that dimension and work **only** that worklist — prioritization
 |---|---|---|---|
 | "dependency / BOM vulnerabilities" | `npx vyuh-dxkit bom` (or `vulnerabilities --detailed`) | `dep-vuln` | upgrade-first; see "Dependency vulnerability" below |
 | "security" | `npx vyuh-dxkit vulnerabilities --detailed --graph-context` | code-SAST, secrets, dep-vuln | reachable findings first (the report orders them); secrets always top |
-| "code quality" | `npx vyuh-dxkit quality --detailed --graph-context` | duplication, slop, lint, complexity | see "Slop / code-pattern finding" below |
+| "code quality" | `npx vyuh-dxkit quality --detailed --graph-context` | duplication, code-reimplementation, slop, lint, complexity | see "Slop / code-pattern finding" + "Structural duplicate" below |
 | "tests" / "coverage" | `npx vyuh-dxkit test-gaps --detailed --graph-context` | test-gap | hand off to **dxkit-test** for a real test-writing push |
 | "documentation" | `npx vyuh-dxkit health --detailed` (Documentation) | doc-gap | hand off to **dxkit-docs** |
 
@@ -178,6 +178,51 @@ For a dedicated push to close many gaps / raise the Tests score — reading the 
 ```
 
 If the finding is a false positive, add `// slop-ok: <reason>` on the offending line (or `# slop-ok` for non-JS).
+
+### Structural duplicate (code-reimplementation)
+
+A `code-reimplementation` finding means your change added a function that
+structurally re-implements another one — same helper set, same name shape, read
+from the call graph. It's the copy-paste-instead-of-parameterize pattern (a CLI
+handler pasted from the HTTP one, a `findByX` cloned into `findByIdX`). It is
+distinct from the token-level `duplication` (jscpd) finding — this one survives
+rename/reformat because it reads structure, not text.
+
+The finding is a PAIR of anchors, and the guardrail tells you **which side your
+change introduced** — the console reads `added: <new> ≈ existing: <twin>`, and
+the JSON marks the new anchor with `"changed": true`. That's your direction:
+**the new side is what you fix; the existing side is what you consolidate
+toward.**
+
+```bash
+# 1. Read BOTH anchors from the guardrail output (or the JSON `dupGate.findings`).
+#    The `added` / `changed:true` side is the code your change introduced.
+# 2. Open both functions and confirm they really are the same routine (the score
+#    is a strong signal, not proof — a high score on genuinely-distinct logic is
+#    the case to allowlist, not fix).
+# 3. Consolidate:
+#      - Extract the shared body into ONE routine and have both call it, OR
+#      - if the two differ only by a value/branch, parameterize the existing one
+#        and delete the new copy (the usual right fix for a pasted variant).
+# 4. Verify the pair is gone:
+npx vyuh-dxkit guardrail check      # the code-reimplementation finding drops out
+```
+
+Prefer parameterizing the existing function over keeping two near-copies — that's
+the fix the finding is asking for. If the parallel is **deliberate** (a
+sanctioned by-design twin — two adapters that must stay structurally identical, a
+generated-then-specialized pair), allowlist it instead:
+
+```bash
+npx vyuh-dxkit allowlist add --fingerprint=<id> \
+    --kind=code-reimplementation --category=false-positive \
+    --reason="<why the parallel is intentional>"
+```
+
+The guardrail's block/warn message prints this exact command with the fingerprint
+filled in. Since a duplicate is warn-tier on its own, it won't fail the build —
+but leaving it un-consolidated is exactly the maintainability debt the gate
+exists to surface, so fix it unless the parallel is genuinely intended.
 
 ## Allowlisting (when fix is not viable)
 

--- a/src/allowlist/categories.ts
+++ b/src/allowlist/categories.ts
@@ -148,6 +148,11 @@ export const CATEGORIES_BY_KIND: Readonly<Record<IdentityKind, readonly Allowlis
   // false-positive covers a misread declaration; deferred parks a decision
   'model-schema-drift': ['false-positive', 'accepted-risk', 'deferred'],
 
+  // Structural duplicate: false-positive (a sanctioned by-design parallel — two
+  // per-pack gathers that legitimately share a call shape); otherwise
+  // accepted-risk (we know it's a duplicate and accept it) or deferred
+  'code-reimplementation': ['false-positive', 'accepted-risk', 'deferred'],
+
   // Stale-allow (orphaned inline allowlist annotation): never
   // allowlisted. The right response is always "remove the stale
   // annotation" — allowlisting the warning that an annotation is

--- a/src/allowlist/hint.ts
+++ b/src/allowlist/hint.ts
@@ -232,6 +232,14 @@ export function remediationFor(kind: BaselineEntry['kind']): string {
         'or — if the check fired spuriously — allowlist with category=false-positive ' +
         'or relax the check in policy.json.'
       );
+    case 'code-reimplementation':
+      return (
+        'This change added a function that structurally duplicates another (same ' +
+        'helpers, same name shape) — the copy-paste-instead-of-parameterize slop ' +
+        'pattern. Extract the shared logic into one routine both call, or — if the ' +
+        'parallel is deliberate (a sanctioned by-design twin) — allowlist with ' +
+        'category=false-positive.'
+      );
   }
 }
 
@@ -273,6 +281,9 @@ function entryLocator(entry: BaselineEntry): { file?: string; line?: number } {
     case 'secret-hmac':
     case 'dep-vuln':
     case 'duplication':
+    case 'code-reimplementation':
+      // A symmetric PAIR of anchors, no single canonical file:line → route to
+      // the `--fingerprint=<id>` CLI form, like duplication.
       return {};
   }
 }

--- a/src/analyzers/duplication/config.ts
+++ b/src/analyzers/duplication/config.ts
@@ -1,0 +1,76 @@
+/**
+ * Structural-duplicate (seam) gate configuration, read from
+ * `.dxkit/policy.json:duplication` — the single reader of that section (Rule 2,
+ * the flow/schema-config discipline). Every duplicate-seam surface — the
+ * two-ref gate, `evaluate`, doctor's probe — resolves its config here.
+ *
+ * All fields are optional in the file; a missing / malformed policy yields the
+ * defaults (fail-open), never a throw. The default MODE is `off`: the gate runs
+ * a graph build, which is the heaviest thing dxkit does, so — like the schema
+ * gate and UNLIKE the cheap flow gate — it is strictly opt-in. A repo that never
+ * configured it spawns no graphify. `evaluate` forces it on to demonstrate the
+ * signal on a trial run; a repo promotes it to `warn` (and, via convergence,
+ * effectively `block`) when it wants the gate live.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { DUP_DEFAULT_MIN_SCORE } from '../../explore/queries';
+
+/** How the guardrail treats a net-new structural duplicate.
+ *   - `block`: enables seam CONVERGENCE to escalate a duplicate that is ALSO a
+ *     reliably-dead surface to a build failure. A lone duplicate never blocks —
+ *     tier-3's precision floor is warn (the anti-slop proof).
+ *   - `warn`: every net-new duplicate warns, never fails a build.
+ *   - `off` (default): the gate does not run at all (no graph build). */
+export type DuplicationGateMode = 'block' | 'warn' | 'off';
+
+export interface DuplicationConfig {
+  /** Guardrail posture for a net-new structural duplicate. */
+  readonly mode: DuplicationGateMode;
+  /** Blended structural-similarity at/above which a pair is reported. Default
+   *  `DUP_DEFAULT_MIN_SCORE` — the proof's precision floor. Raising it trades
+   *  recall for precision on a noisy repo. */
+  readonly minScore: number;
+}
+
+const DEFAULTS: DuplicationConfig = {
+  mode: 'off',
+  minScore: DUP_DEFAULT_MIN_SCORE,
+};
+
+/** Current schema version of the committed `.dxkit/policy.json:duplication`
+ *  block. Stamped on write so a future restructure is detectable/migratable
+ *  (a versionless block reads as v1 — every field optional-with-default). */
+export const DUPLICATION_CONFIG_SCHEMA_VERSION = 1;
+
+interface RawDuplication {
+  mode?: unknown;
+  minScore?: unknown;
+}
+
+function isMode(v: unknown): v is DuplicationGateMode {
+  return v === 'block' || v === 'warn' || v === 'off';
+}
+
+function rawSection(cwd: string): RawDuplication | undefined {
+  try {
+    const text = fs.readFileSync(path.join(cwd, '.dxkit', 'policy.json'), 'utf8');
+    return (JSON.parse(text) as { duplication?: RawDuplication })?.duplication;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read the `duplication` section of `.dxkit/policy.json`. Fail-open — a
+ *  read/parse error or an absent block returns the defaults (gate off). */
+export function readDuplicationConfig(cwd: string): DuplicationConfig {
+  const raw = rawSection(cwd) ?? {};
+  return {
+    mode: isMode(raw.mode) ? raw.mode : DEFAULTS.mode,
+    minScore:
+      typeof raw.minScore === 'number' && raw.minScore > 0 && raw.minScore <= 1
+        ? raw.minScore
+        : DEFAULTS.minScore,
+  };
+}

--- a/src/analyzers/tools/fingerprint.ts
+++ b/src/analyzers/tools/fingerprint.ts
@@ -423,6 +423,46 @@ export function computeModelSchemaDriftFingerprint(
   );
 }
 
+// ─── Code-reimplementation identity (the seam gate, Rule 9) ───────────────────
+
+/**
+ * Tool-independent canonical rule for a structural-duplicate finding. Every
+ * code-reimplementation pair shares this constant — the finding is intrinsic
+ * ("these two functions are the same routine written twice"), never a per-tool
+ * classification.
+ */
+export const CODE_REIMPLEMENTATION_CANONICAL_RULE = 'canonical:code-reimplementation';
+
+/** One duplicate anchor's dxkit-derived coordinates. */
+export interface DuplicateAnchorLike {
+  readonly file: string;
+  readonly symbol: string;
+  readonly line: number;
+}
+
+/**
+ * Symmetric-by-construction identity for a structural-duplicate PAIR. The two
+ * anchors are sorted into a canonical order (by file, then line-window, then
+ * symbol) before hashing, so a pair reported as `(A,B)` and one reported as
+ * `(B,A)` produce the same identity. Each anchor's line is bucketed into the
+ * shared 3-line window so a small reformat doesn't churn identity. All inputs
+ * are dxkit-derived — the graph node's file/symbol/line, never a tool's
+ * captured span (Rule 9), so a committed allowlist entry keeps matching when the
+ * scan moves to CI.
+ */
+export function computeCodeReimplementationFingerprint(
+  anchorA: DuplicateAnchorLike,
+  anchorB: DuplicateAnchorLike,
+): string {
+  const key = (a: DuplicateAnchorLike) => `${a.file}\0${lineWindowFor(a.line)}\0${a.symbol}`;
+  const [first, second] = [key(anchorA), key(anchorB)].sort();
+  return computeContentFingerprint(
+    CODE_REIMPLEMENTATION_CANONICAL_RULE,
+    '',
+    `${first}\0\0${second}`,
+  );
+}
+
 // ─── Secret HMAC primitive ───────────────────────────────────────────────────
 
 /**

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -33,6 +33,8 @@ import { describeBrokenIntegration } from '../analyzers/flow/gate';
 import type { FlowGateOutcome } from './flow-gate-check';
 import { describeSchemaDrift } from '../analyzers/model-schema/gate';
 import type { SchemaDriftGateOutcome } from './schema-drift-gate-check';
+import type { DupGateOutcome } from './dup-gate-check';
+import type { DuplicateFinding } from '../explore/duplication';
 
 // ─── Shared verdict predicates ────────────────────────────────────────────
 
@@ -83,9 +85,13 @@ function extraGateTallies(result: GuardrailCheckResult): { block: number; warn: 
     ...(result.flowGate?.findings ?? []),
     ...(result.schemaDriftGate?.findings ?? []),
   ];
+  // Seam-gate duplicates are always warn-tier (no per-finding verdict field);
+  // fold their count into the warn tally so the banner reconciles with the
+  // summary — the same "one report, one story" discipline as the gates above.
+  const dupWarns = result.dupGate?.findings.length ?? 0;
   return {
     block: findings.filter((f) => f.verdict === 'block').length,
-    warn: findings.filter((f) => f.verdict === 'warn').length,
+    warn: findings.filter((f) => f.verdict === 'warn').length + dupWarns,
   };
 }
 
@@ -194,6 +200,7 @@ export function renderConsole(result: GuardrailCheckResult): string {
 
   lines.push(...formatFlowGate(result.flowGate));
   lines.push(...formatSchemaDriftGate(result.schemaDriftGate));
+  lines.push(...formatDupGate(result.dupGate));
 
   // Always show a summary footer — sets expectations for what
   // happens next (exit code, what to read on a fail).
@@ -228,6 +235,16 @@ export function renderConsole(result: GuardrailCheckResult): string {
     lines.push(
       `  Schema:      ${schemaFindings.length + schemaSuppressed.length} ` +
         `(blocking: ${sBlock}, warning: ${sWarn}, info: ${sInfo}, suppressed: ${schemaSuppressed.length})`,
+    );
+  }
+  // Same reconciliation line for the structural-duplicate (seam) gate. All
+  // warn-tier (a lone duplicate never blocks), so the count folds into warnings.
+  const dupFindings = result.dupGate?.findings ?? [];
+  const dupSuppressed = result.dupGate?.suppressed ?? [];
+  if (dupFindings.length > 0 || dupSuppressed.length > 0) {
+    lines.push(
+      `  Seam:        ${dupFindings.length + dupSuppressed.length} ` +
+        `(warning: ${dupFindings.length}, suppressed: ${dupSuppressed.length})`,
     );
   }
   lines.push(
@@ -376,6 +393,64 @@ function schemaFingerprintLine(id: string): string {
   return (
     `    · fingerprint: ${id}  (accept if intentional: allowlist add ` +
     `--fingerprint=${id} --kind=model-schema-drift --category=accepted-risk --reason="<why>")`
+  );
+}
+
+/**
+ * Console lines for the structural-duplicate (seam) gate. Silent unless the
+ * gate produced findings. All warn-tier (a lone duplicate never blocks), so the
+ * one section names the twin, the similarity score, and the accept command.
+ */
+function formatDupGate(gate: DupGateOutcome | undefined): string[] {
+  if (!gate) return [];
+  const suppressed = gate.suppressed ?? [];
+  if (gate.findings.length === 0 && suppressed.length === 0) return [];
+  const out: string[] = [];
+  if (gate.findings.length > 0) {
+    out.push(logger.bold(`Structural duplicate — warning (${gate.findings.length})`));
+    for (const f of gate.findings) {
+      out.push(`  ${describeDuplicate(f)}`);
+      out.push(dupFingerprintLine(f.id));
+    }
+    out.push('');
+  }
+  if (suppressed.length > 0) {
+    out.push(logger.bold(`Structural duplicate — suppressed by allowlist (${suppressed.length})`));
+    for (const s of suppressed) {
+      const exp = s.expiresAt ? `, expires ${s.expiresAt}` : '';
+      out.push(`  ${describeDuplicate(s.finding)}`);
+      out.push(`    · allowlisted: ${s.category}${exp} (waived from the verdict)`);
+    }
+    out.push('');
+  }
+  return out;
+}
+
+/** One-line description of a structural-duplicate pair. When the gate marked
+ *  which side the change introduced, the new side is named FIRST and labelled —
+ *  so the fix is directional ("you added A, consolidate with existing B"). */
+function describeDuplicate(f: DuplicateFinding): string {
+  const [a, b] = f.anchors;
+  const loc = (x: DuplicateFinding['anchors'][number]) => `${x.symbol} @ ${x.file}:${x.line}`;
+  const sim = `(similarity ${f.score.toFixed(2)})`;
+  if (f.changed) {
+    const [aNew, bNew] = f.changed;
+    // One side new, one pre-existing → name the new (added) side first.
+    if (aNew && !bNew) return `added: ${loc(a)}  ≈  existing: ${loc(b)}  ${sim}`;
+    if (bNew && !aNew) return `added: ${loc(b)}  ≈  existing: ${loc(a)}  ${sim}`;
+    // Both sides in the change → the whole duplicate was introduced here.
+    if (aNew && bNew) return `both added: ${loc(a)}  ≈  ${loc(b)}  ${sim}`;
+  }
+  return `${loc(a)}  ≈  ${loc(b)}  ${sim}`;
+}
+
+/** The duplicate fingerprint line + the concrete accept command. A sanctioned
+ *  by-design parallel is accepted as false-positive (the same category flow
+ *  uses for a cross-repo consumer the scan can't see). */
+function dupFingerprintLine(id: string): string {
+  return (
+    `    · fingerprint: ${id}  (accept if by-design: allowlist add ` +
+    `--fingerprint=${id} --kind=code-reimplementation --category=false-positive --reason="<why>")`
   );
 }
 
@@ -649,6 +724,33 @@ export interface GuardrailJsonPayload {
       readonly expiresAt?: string;
     }>;
   };
+  /** The structural-duplicate (seam) gate — net-new code-reimplementation pairs
+   *  from the base↔HEAD diff. Absent when the gate is off (the default — it
+   *  builds the code graph) or no base commit was resolvable. All warn-tier. */
+  readonly dupGate?: {
+    readonly ran: boolean;
+    readonly skipped?: string;
+    readonly mode: string;
+    readonly blocks: boolean;
+    readonly warns: boolean;
+    readonly findings: ReadonlyArray<{
+      readonly id: string;
+      readonly score: number;
+      readonly anchors: ReadonlyArray<{
+        readonly file: string;
+        readonly symbol: string;
+        readonly line: number;
+        /** True when this anchor's file was touched by the change — the side the
+         *  diff introduced (the one to consolidate). Absent on an unscoped run. */
+        readonly changed?: boolean;
+      }>;
+    }>;
+    readonly suppressed: ReadonlyArray<{
+      readonly id: string;
+      readonly category: string;
+      readonly expiresAt?: string;
+    }>;
+  };
 }
 
 export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
@@ -797,6 +899,32 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
           },
         }
       : {}),
+    ...(result.dupGate !== undefined
+      ? {
+          dupGate: {
+            ran: result.dupGate.ran,
+            ...(result.dupGate.skipped !== undefined ? { skipped: result.dupGate.skipped } : {}),
+            mode: result.dupGate.mode,
+            blocks: result.dupGate.blocks,
+            warns: result.dupGate.warns,
+            findings: result.dupGate.findings.map((f) => ({
+              id: f.id,
+              score: f.score,
+              anchors: f.anchors.map((a, idx) => ({
+                file: a.file,
+                symbol: a.symbol,
+                line: a.line,
+                ...(f.changed ? { changed: f.changed[idx] } : {}),
+              })),
+            })),
+            suppressed: (result.dupGate.suppressed ?? []).map((s) => ({
+              id: s.finding.id,
+              category: s.category,
+              ...(s.expiresAt !== undefined ? { expiresAt: s.expiresAt } : {}),
+            })),
+          },
+        }
+      : {}),
   };
 }
 
@@ -865,6 +993,7 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
 
   lines.push(...markdownFlowGate(result.flowGate));
   lines.push(...markdownSchemaDriftGate(result.schemaDriftGate));
+  lines.push(...markdownDupGate(result.dupGate));
 
   if (suppressed.length > 0) {
     lines.push('<details>');
@@ -1071,6 +1200,66 @@ function markdownSchemaDriftGate(gate: SchemaDriftGateOutcome | undefined): stri
         `| ${escapeMd(subject(f))} | ${escapeMd(f.changeClass)} | ` +
           `${escapeMd(`${f.file}:${f.line}`)} | ${escapeMd(s.category)} | ` +
           `${escapeMd(s.expiresAt ?? '—')} |`,
+      );
+    }
+    out.push('');
+    out.push('</details>');
+    out.push('');
+  }
+  return out;
+}
+
+/** Markdown for the structural-duplicate (seam) gate. All warn-tier, so a
+ *  single collapsed section names each twin, its similarity, and fingerprint. */
+function markdownDupGate(gate: DupGateOutcome | undefined): string[] {
+  if (!gate) return [];
+  const suppressed = gate.suppressed ?? [];
+  if (gate.findings.length === 0 && suppressed.length === 0) return [];
+  const out: string[] = [];
+  const loc = (x: DuplicateFinding['anchors'][number]) =>
+    `${escapeMd(x.symbol)} @ ${escapeMd(`${x.file}:${x.line}`)}`;
+  const pairCell = (f: DuplicateFinding): string => {
+    const [a, b] = f.anchors;
+    if (f.changed) {
+      const [aNew, bNew] = f.changed;
+      if (aNew && !bNew) return `**added** ${loc(a)} ≈ existing ${loc(b)}`;
+      if (bNew && !aNew) return `**added** ${loc(b)} ≈ existing ${loc(a)}`;
+    }
+    return `${loc(a)} ≈ ${loc(b)}`;
+  };
+  if (gate.findings.length > 0) {
+    out.push('<details>');
+    out.push(`<summary>Structural duplicates (${gate.findings.length})</summary>`);
+    out.push('');
+    out.push(
+      '_A net-new function that structurally duplicates another (same helpers, ' +
+        'same name shape). Extract the shared routine, or accept a by-design ' +
+        'parallel with `allowlist add --fingerprint=<id> --kind=code-reimplementation ' +
+        '--category=false-positive`._',
+    );
+    out.push('');
+    out.push('| Duplicate pair | Similarity | Fingerprint |');
+    out.push('|---|---|---|');
+    for (const f of gate.findings) {
+      out.push(`| ${pairCell(f)} | ${f.score.toFixed(2)} | \`${escapeMd(f.id)}\` |`);
+    }
+    out.push('');
+    out.push('</details>');
+    out.push('');
+  }
+  if (suppressed.length > 0) {
+    out.push('<details>');
+    out.push(
+      `<summary>Structural duplicates suppressed by allowlist (${suppressed.length})</summary>`,
+    );
+    out.push('');
+    out.push('These would warn, but an active allowlist entry accepted them.');
+    out.push('');
+    out.push('| Duplicate pair | Category | Expires |');
+    out.push('|---|---|---|');
+    for (const s of suppressed) {
+      out.push(
+        `| ${pairCell(s.finding)} | ${escapeMd(s.category)} | ${escapeMd(s.expiresAt ?? '—')} |`,
       );
     }
     out.push('');

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -70,6 +70,9 @@ import { evaluateFlowGateForGuardrail } from './flow-gate-check';
 import type { FlowGateOutcome } from './flow-gate-check';
 import { evaluateSchemaDriftGateForGuardrail } from './schema-drift-gate-check';
 import type { SchemaDriftGateOutcome } from './schema-drift-gate-check';
+import { evaluateDupGateForGuardrail } from './dup-gate-check';
+import type { DupGateOutcome } from './dup-gate-check';
+import type { DuplicationGateMode } from '../analyzers/duplication/config';
 import type { SchemaGateMode } from '../analyzers/model-schema/config';
 import type { FlowGateMode } from '../analyzers/flow/config';
 import { isSanitized } from './sanitize';
@@ -183,6 +186,13 @@ export interface RunGuardrailCheckOptions {
    * repo did not configure.
    */
   readonly schemaMode?: SchemaGateMode;
+  /**
+   * Loop-seam override for the structural-duplicate (seam) gate's posture,
+   * mirroring `schemaMode`: the seam gate defaults to OFF (opt-in — it builds
+   * the code graph), so the override softens/hardens an enabled gate but never
+   * activates one the repo did not configure.
+   */
+  readonly duplicationMode?: DuplicationGateMode;
 }
 
 /**
@@ -313,6 +323,12 @@ export interface GuardrailCheckResult {
    *  Opt-in (`.dxkit/policy.json:schema.mode`, default off); `undefined`
    *  when off or when no base commit is resolvable. */
   readonly schemaDriftGate?: SchemaDriftGateOutcome;
+  /** The structural-duplicate (seam) gate pass — additive + fail-open like the
+   *  flow gate, diffing the duplicate-pair set across the same base↔HEAD pair.
+   *  Opt-in (`.dxkit/policy.json:duplication.mode`, default off — it builds the
+   *  code graph); `undefined` when off or when no base commit is resolvable. A
+   *  lone duplicate only ever warns; convergence (downstream) can escalate. */
+  readonly dupGate?: DupGateOutcome;
   /** Set when the CURRENT dependency-vulnerability scan could not run — the
    *  scanner was absent / timed out / failed — AND the scan was actually
    *  REQUESTED this run (not incrementally skipped because no manifest changed,
@@ -441,6 +457,12 @@ const KIND_DEFAULT_SEVERITY: Readonly<Record<BaselineEntry['kind'], FindingSever
     // additive/info classes never reach the guardrail as findings, so this
     // default speaks only for the breaking ones.
     'model-schema-drift': 'high',
+    // A structural code-reimplementation (two functions the graph shows to be
+    // the same routine written twice). Low severity — it is a maintainability /
+    // slop signal surfaced warn-tier, not a correctness or security defect; its
+    // block confidence comes only from seam CONVERGENCE (dup ∩ reliably-dead),
+    // never from this default alone.
+    'code-reimplementation': 'low',
     // A custom-check / lint failure. Severity is a neutral default — a custom
     // check's block intent is user/pack-declared (`entry.blocking`), NOT
     // severity-derived, so severity only feeds the confidence-threshold logic
@@ -825,6 +847,18 @@ export async function runGuardrailCheck(
     ...(options.verbose !== undefined ? { verbose: options.verbose } : {}),
   });
 
+  // The structural-duplicate (seam) gate — same additive, fail-open shape,
+  // sharing the base-commit resolution, allowlist, and clock. Opt-in: with no
+  // `duplication` policy block it skips as 'off' at zero cost (no graph build).
+  const dupGate = await evaluateDupGateForGuardrail({
+    cwd,
+    ...(flowBaseRef ? { baseRef: flowBaseRef } : {}),
+    allowlist,
+    now,
+    ...(options.duplicationMode !== undefined ? { modeOverride: options.duplicationMode } : {}),
+    ...(options.verbose !== undefined ? { verbose: options.verbose } : {}),
+  });
+
   const baseBlocks = options.changedOnly ? filteredBlocks : blocks;
   const baseWarns = options.changedOnly ? filteredWarns : warns;
 
@@ -837,8 +871,8 @@ export async function runGuardrailCheck(
     pairs: filteredPairs,
     envelopeDrift,
     policy,
-    blocks: baseBlocks || flowGate.blocks || schemaDriftGate.blocks,
-    warns: baseWarns || flowGate.warns || schemaDriftGate.warns,
+    blocks: baseBlocks || flowGate.blocks || schemaDriftGate.blocks || dupGate.blocks,
+    warns: baseWarns || flowGate.warns || schemaDriftGate.warns || dupGate.warns,
     allowlistDelta,
     refExcludedKinds,
     ...(flowGate.ran || flowGate.skipped !== 'no-base-ref' ? { flowGate } : {}),
@@ -848,6 +882,12 @@ export async function runGuardrailCheck(
     ...(schemaDriftGate.ran ||
     (schemaDriftGate.skipped !== 'off' && schemaDriftGate.skipped !== 'no-base-ref')
       ? { schemaDriftGate }
+      : {}),
+    // Attach when the seam gate is configured on (ran, or skipped for a reason
+    // worth disclosing); an off/no-base-ref skip stays out so unconfigured
+    // repos see nothing new.
+    ...(dupGate.ran || (dupGate.skipped !== 'off' && dupGate.skipped !== 'no-base-ref')
+      ? { dupGate }
       : {}),
     // Fail-loud: a dep scan that was REQUESTED but could not run must not read as
     // a clean "no net-new dep vulns" — surface it. Incrementally-skipped scans

--- a/src/baseline/dup-gate-check.ts
+++ b/src/baseline/dup-gate-check.ts
@@ -1,0 +1,248 @@
+/**
+ * The structural-duplicate (seam) gate pass for the guardrail check — an
+ * ADDITIVE, fail-open layer over `runGuardrailCheck`, the third sibling of the
+ * flow integration gate and the model-schema drift gate.
+ *
+ * It answers "did this diff ADD a structural code-reimplementation?" — a
+ * function the call graph shows to be the same routine written twice, the
+ * textbook agent copy-paste. Like flow-binding and model-schema-drift, a
+ * duplicate is a two-ref RELATION: the gate gathers the duplicate-pair set at
+ * base AND head and mints only the pairs the diff INTRODUCES (a pair present at
+ * the base ref is grandfathered). That is why `code-reimplementation` is a
+ * DEFERRED baseline kind minted here, not a full-scan producer — so an upgrade
+ * adds no backlog to flood the gate.
+ *
+ * Cost discipline (this gate builds the code graph, the heaviest thing dxkit
+ * does — unlike the cheap flow/schema gathers):
+ *   - OPT-IN. `.dxkit/policy.json:duplication.mode` defaults to `off`; a repo
+ *     that never configured it never pays a graph build (mirror of the schema
+ *     gate — a preset softens/hardens but never activates).
+ *   - Trigger-skip when the diff touched no source file.
+ *   - Diff-SCOPE the HEAD scan to pairs that touch a changed file, and build the
+ *     BASE graph ONLY when the HEAD side produced candidates. A change with no
+ *     candidate duplicate pays exactly one (HEAD) graph build, never two.
+ *   - Zero-write: the graph is taken from the producer IN MEMORY
+ *     (`gatherGraphifyGraph({ writeToDisk: false })`) and indexed in-process, so
+ *     the gate writes no `graph.json` (the `evaluate` zero-write guarantee).
+ *
+ * Every failure path degrades to "did not gate": no base ref, an unparseable
+ * tree, graphify not installed — all yield an empty, non-blocking outcome. The
+ * gate NEVER blocks on its own: a lone duplicate is warn-tier (the anti-slop
+ * proof's precision floor). Block confidence comes only from seam CONVERGENCE
+ * (duplicate ∩ reliably-dead surface), computed downstream at the verdict stage.
+ */
+
+import { computeChangedFiles } from './changed-files';
+import { withRefWorktree } from './ref-baseline';
+import { gatherGraphifyGraph, type GraphGatherOutcome } from '../analyzers/tools/graphify';
+import { duplicateFindingsFromJson, type DuplicateFinding } from '../explore/duplication';
+import { readDuplicationConfig, type DuplicationGateMode } from '../analyzers/duplication/config';
+import { allSourceExtensions } from '../languages';
+import { findEntry, isEntryActive } from '../allowlist/file';
+import type { AllowlistFile } from '../allowlist/file';
+
+/** Why the gate produced no verdict, when it didn't run. */
+export type DupGateSkip =
+  | 'off' // policy `duplication.mode: off` (the default — the gate is opt-in)
+  | 'no-base-ref' // no base commit resolvable (no ref, no baseline anchor SHA)
+  | 'no-source-change' // the diff touched no source file — no duplicate possible
+  | 'no-graph' // graphify unavailable / failed on the HEAD tree (fail-open)
+  | 'no-candidates' // HEAD produced no diff-scoped duplicate — nothing to gate
+  | 'error'; // any failure — fail-open
+
+/** A net-new duplicate an active allowlist entry waived from the verdict.
+ *  Mirrors the flow gate's `FlowGateSuppression`: still surfaced for audit,
+ *  excluded from `warns`. */
+export interface DupGateSuppression {
+  readonly finding: DuplicateFinding;
+  readonly fingerprint: string;
+  readonly category: string;
+  readonly expiresAt?: string;
+}
+
+/** Outcome of the seam gate pass, folded additively into the guardrail verdict. */
+export interface DupGateOutcome {
+  /** True when the gate actually evaluated a base↔HEAD comparison. */
+  readonly ran: boolean;
+  /** Populated when `ran` is false — the reason no verdict was produced. */
+  readonly skipped?: DupGateSkip;
+  /** The effective mode after the preset override (`block` / `warn` / `off`).
+   *  `block` does NOT make a lone duplicate block — it authorizes seam
+   *  convergence (downstream) to escalate a duplicate that is also reliably
+   *  dead. A lone duplicate is always warn-tier. */
+  readonly mode: DuplicationGateMode;
+  /** Net-new structural duplicates that count toward the verdict (active — NOT
+   *  waived by an allowlist entry). Always warn-tier here. */
+  readonly findings: readonly DuplicateFinding[];
+  /** Net-new duplicates an active allowlist entry accepted — surfaced for
+   *  audit, excluded from `warns`. */
+  readonly suppressed: readonly DupGateSuppression[];
+  /** Always false for a lone duplicate — the gate never blocks on its own. */
+  readonly blocks: boolean;
+  /** True when at least one active net-new duplicate warns. */
+  readonly warns: boolean;
+}
+
+function skip(mode: DuplicationGateMode, reason: DupGateSkip): DupGateOutcome {
+  return {
+    ran: false,
+    skipped: reason,
+    mode,
+    findings: [],
+    suppressed: [],
+    blocks: false,
+    warns: false,
+  };
+}
+
+/**
+ * Partition net-new duplicates into active (count toward the verdict) and
+ * allowlist-suppressed. A `code-reimplementation` allowlist entry whose
+ * fingerprint matches a finding's id, is the right kind, and is unexpired waives
+ * it — the per-finding escape hatch for a sanctioned by-design parallel, exactly
+ * like the flow gate's flow-binding suppression.
+ */
+function partitionByAllowlist(
+  findings: readonly DuplicateFinding[],
+  allowlist: AllowlistFile | null | undefined,
+  now: Date,
+): { active: DuplicateFinding[]; suppressed: DupGateSuppression[] } {
+  if (!allowlist) return { active: [...findings], suppressed: [] };
+  const active: DuplicateFinding[] = [];
+  const suppressed: DupGateSuppression[] = [];
+  for (const f of findings) {
+    const entry = findEntry(allowlist, f.id);
+    if (entry && entry.kind === 'code-reimplementation' && isEntryActive(entry, now)) {
+      suppressed.push({
+        finding: f,
+        fingerprint: entry.fingerprint,
+        category: entry.category,
+        ...(entry.expiresAt !== undefined ? { expiresAt: entry.expiresAt } : {}),
+      });
+    } else {
+      active.push(f);
+    }
+  }
+  return { active, suppressed };
+}
+
+/**
+ * Run the seam gate for a guardrail check. Never throws — a caller ORs the
+ * returned `warns` into the overall verdict and attaches the outcome for
+ * rendering + downstream convergence.
+ *
+ * @param baseRef the base commit to diff HEAD against (resolved ref in ref-based
+ *   mode, or the committed baseline's anchor SHA in committed mode). Absent →
+ *   the gate skips.
+ * @param modeOverride the preset's posture — softens/hardens an ENABLED gate,
+ *   never activates one (the schema-gate discipline).
+ * @param allowlist an active `code-reimplementation` entry matching a finding
+ *   waives it (the per-finding escape hatch). Omit / null for no suppression.
+ * @param now the clock for allowlist-expiry checks (passed for testability).
+ */
+export async function evaluateDupGateForGuardrail(opts: {
+  readonly cwd: string;
+  readonly baseRef?: string;
+  readonly modeOverride?: DuplicationGateMode;
+  readonly verbose?: boolean;
+  readonly allowlist?: AllowlistFile | null;
+  readonly now?: Date;
+  /** Graph provider, injected for tests. Defaults to the real graphify gather
+   *  (in-memory, no disk write). Called once for HEAD (`dir === cwd`) and once
+   *  for the base ref (`dir === the worktree`). */
+  readonly gatherGraph?: (
+    dir: string,
+    opts: { writeToDisk?: boolean },
+  ) => Promise<GraphGatherOutcome>;
+}): Promise<DupGateOutcome> {
+  const cwd = opts.cwd;
+  const gatherGraph = opts.gatherGraph ?? gatherGraphifyGraph;
+  const config = readDuplicationConfig(cwd);
+  // The override softens/hardens an ENABLED gate; it never activates one (like
+  // schema, unlike flow's default-block) — the graph build is too heavy to
+  // switch on for a repo that never configured it.
+  const gateMode: DuplicationGateMode =
+    config.mode === 'off' ? 'off' : (opts.modeOverride ?? config.mode);
+
+  if (gateMode === 'off') return skip(gateMode, 'off');
+  if (!opts.baseRef) return skip(gateMode, 'no-base-ref');
+  const ref = opts.baseRef;
+
+  try {
+    // Trigger-skip: a net-new duplicate requires a change to a source file.
+    // A null changed-set = can't prove the diff is source-free → fall through
+    // and run unscoped (safe default), the flow/schema-gate discipline.
+    const changed = computeChangedFiles(cwd, ref);
+    const exts = allSourceExtensions();
+    // Diff-scope: only score HEAD pairs that touch a changed SOURCE file. When
+    // the changed set is unknown (null), run unscoped — correct, just slower.
+    const focusFiles = changed
+      ? new Set(changed.filter((f) => exts.some((e) => f.endsWith(e))))
+      : undefined;
+    if (focusFiles && focusFiles.size === 0) {
+      return skip(gateMode, 'no-source-change');
+    }
+
+    // HEAD side — the working tree's graph, taken IN MEMORY from the producer
+    // (no graph.json write; the zero-write guarantee).
+    const headOut = await gatherGraph(cwd, { writeToDisk: false });
+    if (headOut.kind !== 'success') return skip(gateMode, 'no-graph');
+    const headFindings = duplicateFindingsFromJson(headOut.graph, {
+      minScore: config.minScore,
+      ...(focusFiles ? { focusFiles } : {}),
+    });
+    // No diff-scoped duplicate on the HEAD side → nothing to gate. Skip WITHOUT
+    // building the base graph — the primary cost guard (one build, not two).
+    if (headFindings.length === 0) return skip(gateMode, 'no-candidates');
+
+    // Base side — the duplicate-pair ID set at the base ref, gathered from a
+    // detached worktree (Rule 11). A pair present here is grandfathered.
+    const baseIds = await withRefWorktree({ cwd, ref }, async (wt) => {
+      const baseOut = await gatherGraph(wt, { writeToDisk: false });
+      if (baseOut.kind !== 'success') return new Set<string>();
+      const baseFindings = duplicateFindingsFromJson(baseOut.graph, {
+        minScore: config.minScore,
+        ...(focusFiles ? { focusFiles } : {}),
+      });
+      return new Set(baseFindings.map((f) => f.id));
+    });
+
+    // Net-new = a HEAD duplicate whose identity is not present at base.
+    // Mark which anchor(s) the change INTRODUCED (file in the changed set) so the
+    // remediation is directional — "you added A, which duplicates existing B" —
+    // instead of a symmetric pair the agent must disambiguate itself.
+    const netNew = headFindings
+      .filter((f) => !baseIds.has(f.id))
+      .map((f) =>
+        focusFiles
+          ? {
+              ...f,
+              changed: [
+                focusFiles.has(f.anchors[0].file),
+                focusFiles.has(f.anchors[1].file),
+              ] as const,
+            }
+          : f,
+      );
+
+    const { active, suppressed } = partitionByAllowlist(
+      netNew,
+      opts.allowlist,
+      opts.now ?? new Date(),
+    );
+    // A lone duplicate is ALWAYS warn-tier — the gate never blocks on its own.
+    // Block confidence is earned only by seam convergence, downstream.
+    const warns = active.length > 0;
+
+    if (opts.verbose && active.length > 0) {
+      process.stderr.write(
+        `    [seam] ${active.length} net-new structural duplicate(s) — warning\n`,
+      );
+    }
+    return { ran: true, mode: gateMode, findings: active, suppressed, blocks: false, warns };
+  } catch {
+    // Fail-open: a ref that can't be checked out, an unparseable tree, a
+    // graphify error — none of these should fail the guardrail.
+    return skip(gateMode, 'error');
+  }
+}

--- a/src/baseline/entry-to-located.ts
+++ b/src/baseline/entry-to-located.ts
@@ -157,6 +157,27 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
       // pure rename; the `${method} ${path}` join key is the rule discriminator
       // so two distinct bindings in one renamed file don't cross-pair.
       return { id: entry.id, file: entry.file, rule: `${entry.method} ${entry.path}` };
+    case 'code-reimplementation': {
+      // Line-window-bucketed identity over a symmetric anchor pair. The gate
+      // mints and matches these by fingerprint itself (two-ref relation), so
+      // this projection serves show/report tooling: locate at the canonical
+      // first anchor (by file, then line, then symbol — the same order the
+      // fingerprint sorts) with the symbol as the rule discriminator.
+      const [first] = [...entry.anchors].sort((x, y) =>
+        x.file !== y.file
+          ? x.file < y.file
+            ? -1
+            : 1
+          : x.line !== y.line
+            ? x.line - y.line
+            : x.symbol < y.symbol
+              ? -1
+              : x.symbol > y.symbol
+                ? 1
+                : 0,
+      );
+      return { id: entry.id, file: first.file, line: first.line, rule: `dup:${first.symbol}` };
+    }
     case 'model-schema-drift':
       // LOCATION-free identity ((model, field, changeClass)) → whole-file
       // display locator; the identity triple is the rule discriminator. The

--- a/src/baseline/finding-identity.ts
+++ b/src/baseline/finding-identity.ts
@@ -15,6 +15,7 @@ import { createHash } from 'crypto';
 import {
   canonicalRuleFor,
   computeCodeFingerprint,
+  computeCodeReimplementationFingerprint,
   computeContentFingerprint,
   computeFingerprint,
   computeFingerprintV1,
@@ -140,6 +141,11 @@ export function identityFor(
       // finding, so identity survives line AND file moves and a follow-up
       // tweak to the same field keeps one allowlist decision (Rule 9).
       return computeModelSchemaDriftFingerprint(input.model, input.field, input.changeClass);
+    case 'code-reimplementation':
+      // Version-independent. Symmetric over the two dxkit-derived function
+      // anchors (each line-window-bucketed) — a pair survives reformat/rename
+      // and `(A,B)` == `(B,A)`. Never a tool-captured span (Rule 9).
+      return computeCodeReimplementationFingerprint(input.anchors[0], input.anchors[1]);
     case 'custom-check':
       // Version-independent. Two shapes: a LOCATED finding (a linter's
       // per-line diagnostic) hashes (check, file, lineWindow, rule) — the

--- a/src/baseline/migrate.ts
+++ b/src/baseline/migrate.ts
@@ -127,6 +127,9 @@ export function baselineEntryToIdentityInput(entry: BaselineEntry): IdentityInpu
         field: e.field,
         changeClass: e.changeClass,
       };
+    case 'code-reimplementation':
+      // `score` is display metadata; identity is the anchor pair.
+      return { kind: 'code-reimplementation', anchors: e.anchors };
     case 'custom-check':
       // `blocking` + `message` are display/verdict metadata on the entry, never
       // identity inputs (Rule 9). File/line/rule reconstruct the located variant;

--- a/src/baseline/presets.ts
+++ b/src/baseline/presets.ts
@@ -28,6 +28,7 @@ import { type BrownfieldBlockRules, type BrownfieldPolicy } from './policy';
 import type { FindingStatus } from './types';
 import type { FlowGateMode } from '../analyzers/flow/config';
 import type { SchemaGateMode } from '../analyzers/model-schema/config';
+import type { DuplicationGateMode } from '../analyzers/duplication/config';
 
 /**
  * The two shipped postures.
@@ -72,6 +73,14 @@ interface PresetDef {
    * schema defaults to off, and a preset never activates it.
    */
   readonly schemaMode: SchemaGateMode;
+  /**
+   * Posture for the structural-duplicate (seam) gate — same opt-in reasoning
+   * as `schemaMode`: the gate defaults to off (it builds the code graph), and a
+   * preset only softens/hardens an already-enabled gate. `security-only` WARNS
+   * (a duplicate is a maintainability signal, never a security class, and must
+   * not wedge an unattended run); `full-debt` authorizes convergence to BLOCK.
+   */
+  readonly duplicationMode: DuplicationGateMode;
   /**
    * Statuses ADDED to the base policy's warn list (union, never a
    * replacement — the base's drift/uncertainty warns always survive).
@@ -118,6 +127,7 @@ const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
     warn: ['added'],
     flowMode: 'warn',
     schemaMode: 'warn',
+    duplicationMode: 'warn',
   },
   'full-debt': {
     // Any net-new finding blocks (generic `added`), plus every escalation.
@@ -130,6 +140,7 @@ const PRESETS: Readonly<Record<LoopPreset, PresetDef>> = Object.freeze({
     warn: [],
     flowMode: 'block',
     schemaMode: 'block',
+    duplicationMode: 'block',
   },
 });
 
@@ -140,6 +151,7 @@ export interface PresetPolicy {
   readonly preset: LoopPreset;
   readonly flowMode: FlowGateMode;
   readonly schemaMode: SchemaGateMode;
+  readonly duplicationMode: DuplicationGateMode;
 }
 
 /**
@@ -155,6 +167,7 @@ export function policyForPreset(preset: LoopPreset, base: BrownfieldPolicy): Pre
     preset,
     flowMode: def.flowMode,
     schemaMode: def.schemaMode,
+    duplicationMode: def.duplicationMode,
     policy: {
       ...base,
       block: def.block,

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -206,6 +206,17 @@ export const DEFERRED_KINDS: Readonly<
       'Substitute: none needed — the gate is the complete producer for this kind.',
     landingPhase: 'model-schema drift gate (ships with the kind)',
   },
+  'code-reimplementation': {
+    reason:
+      'a structural-duplicate PAIR is a two-ref RELATION, not a standing finding: ' +
+      'the seam gate gathers the duplicate-pair set at base AND head and mints only ' +
+      'the pairs the diff INTRODUCES (a pair present at the base ref is grandfathered), ' +
+      'mirror of flow-binding / model-schema-drift. A full-scan producer would FLOOD ' +
+      'the gate on upgrade — an older baseline has zero entries of this kind, so every ' +
+      'pre-existing duplicate would read net-new. Substitute: none — the gate is the ' +
+      'complete producer for this kind.',
+    landingPhase: 'seam gate (ships with the kind)',
+  },
 });
 
 // ─── Producer module wrappers ─────────────────────────────────────────────

--- a/src/baseline/show.ts
+++ b/src/baseline/show.ts
@@ -218,6 +218,10 @@ function describeEntry(entry: BaselineEntry): string {
       return `${entry.method} ${entry.path}  ← ${entry.file}:${entry.line}`;
     case 'model-schema-drift':
       return `${entry.model}${entry.field ? '.' + entry.field : ''}  [${entry.changeClass}]  ${entry.file}:${entry.line}`;
+    case 'code-reimplementation': {
+      const [a, b] = entry.anchors;
+      return `${a.symbol} @ ${a.file}:${a.line}  ≈  ${b.symbol} @ ${b.file}:${b.line}  [dup ${entry.score.toFixed(2)}]`;
+    }
     case 'custom-check':
       return entry.file !== undefined
         ? `${entry.file}:${entry.line ?? '?'}  [${entry.check}${entry.rule ? '/' + entry.rule : ''}]`

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -125,6 +125,7 @@ export type IdentityInput =
   | StaleAllowIdentityInput
   | FlowBindingIdentityInput
   | ModelSchemaDriftIdentityInput
+  | CodeReimplementationIdentityInput
   | CustomCheckIdentityInput;
 
 /**
@@ -418,6 +419,38 @@ export interface FlowBindingIdentityInput {
 }
 
 /**
+ * One anchor of a structural-duplicate pair — a function/method dxkit's own
+ * graph pass identified. All three fields are dxkit-derived (Rule 9): the
+ * repo-relative `file`, the `symbol` label, and the `line` (bucketed into the
+ * shared 3-line window at hash time so a small reformat doesn't churn identity).
+ * No tool-captured text.
+ */
+export interface DuplicateAnchor {
+  readonly file: string;
+  readonly symbol: string;
+  readonly line: number;
+}
+
+/**
+ * A structural code-reimplementation — two functions the call graph shows to be
+ * the same routine written twice (same helper set, same name tokens). A SIBLING
+ * of the token-level `duplication` kind (jscpd), not a replacement: this signal
+ * is graph-derived and survives rename/reformat, where jscpd's line-block signal
+ * does not. Minted by the two-ref seam gate (a pair present at the base ref is
+ * grandfathered), never by a full-scan baseline producer — so an upgrade adds no
+ * backlog to flood the gate (`DEFERRED_KINDS`, the flow-binding precedent).
+ *
+ * Identity hashes the two anchors sorted into a canonical order (so the pair is
+ * symmetric — `(A,B)` and `(B,A)` share one identity) — all inputs dxkit-derived
+ * and tool-/environment-independent.
+ */
+export interface CodeReimplementationIdentityInput {
+  readonly kind: 'code-reimplementation';
+  /** The two duplicate function anchors. Sorted canonically before hashing. */
+  readonly anchors: readonly [DuplicateAnchor, DuplicateAnchor];
+}
+
+/**
  * A schema-drift finding — one detected change to a declared data model, the
  * unit the model-schema drift gate mints and the allowlist waives. Identity
  * is exactly the triple `(model, field, changeClass)` — LOCATION-FREE by
@@ -600,6 +633,17 @@ export type BaselineEntry =
     }
   | {
       id: FindingId;
+      kind: 'code-reimplementation';
+      /** The two duplicate function anchors — all identity inputs, stored so
+       * identity is recomputable from the entry alone (the migration contract).
+       * The blended similarity score is display metadata, never hashed. */
+      anchors: readonly [DuplicateAnchor, DuplicateAnchor];
+      /** Blended structural-similarity score in [0,1] at mint time — display
+       * metadata only (identity is the anchor pair). Lets renderers rank. */
+      score: number;
+    }
+  | {
+      id: FindingId;
       kind: 'custom-check';
       /** The check's stable label — the durable identity key (Rule 9). */
       check: string;
@@ -671,6 +715,7 @@ export interface SanitizedBaselineEntry {
     | 'stale-allow'
     | 'flow-binding'
     | 'model-schema-drift'
+    | 'code-reimplementation'
     | 'custom-check';
   readonly sanitized: true;
 }

--- a/src/evaluate/run.ts
+++ b/src/evaluate/run.ts
@@ -162,6 +162,7 @@ export async function runEvaluate(opts: EvaluateOptions): Promise<EvaluateEviden
           policy: applied.policy,
           flowMode: applied.flowMode,
           schemaMode: applied.schemaMode,
+          duplicationMode: applied.duplicationMode,
           scope,
           incremental,
           untrusted,

--- a/src/explore/duplication.ts
+++ b/src/explore/duplication.ts
@@ -1,0 +1,69 @@
+/**
+ * Graph-derived structural-duplicate findings — the explore-layer adapter that
+ * turns a code graph into `code-reimplementation` findings (CLAUDE.md Rule 12:
+ * graph access is confined to `src/explore/`, so this load+query+map lives here,
+ * never in the baseline gate or an analyzer).
+ *
+ * The detection itself is `duplicatePairsQuery` in `./queries.ts` (the one place
+ * graph traversal lives). This module composes it with graph indexing and the
+ * canonical fingerprint helper (Rule 9 — via the direct
+ * `computeCodeReimplementationFingerprint`, NOT `identityFor`, exactly as the
+ * flow gate mints its `flow-binding` ids), so every consumer (the two-ref seam
+ * gate, `evaluate`, the dashboard) gets identity-stamped findings from ONE path.
+ */
+
+import type { GraphJson } from './types';
+import { indexGraph } from './load';
+import { duplicatePairsQuery, type DuplicatePairsOpts } from './queries';
+import { computeCodeReimplementationFingerprint } from '../analyzers/tools/fingerprint';
+import type { DuplicateAnchor } from '../baseline/types';
+
+/**
+ * One structural-duplicate finding: a symmetric pair of function anchors the
+ * call graph shows to be the same routine written twice, its durable identity,
+ * and the blended similarity score that produced it. The identity + anchors are
+ * the same shape the `code-reimplementation` baseline entry stores.
+ */
+export interface DuplicateFinding {
+  /** Durable identity — `computeCodeReimplementationFingerprint` over the sorted
+   *  anchor pair (Rule 9, tool-/environment-independent). */
+  readonly id: string;
+  /** The two duplicate function anchors (dxkit-derived: file, symbol, line). */
+  readonly anchors: readonly [DuplicateAnchor, DuplicateAnchor];
+  /** Blended structural-similarity score in [0,1] — display/ranking metadata. */
+  readonly score: number;
+  /** Per-anchor flag: `true` when this anchor's file was touched by the change
+   *  under evaluation — i.e. the side the diff INTRODUCED (the thing to
+   *  consolidate), as opposed to a pre-existing twin. Set by the two-ref gate
+   *  from its changed-file set; absent for a whole-repo query where "new" has no
+   *  meaning. Display/remediation metadata only, never hashed. */
+  readonly changed?: readonly [boolean, boolean];
+}
+
+/** A graph node's dxkit-derived anchor coordinates. */
+function anchorOf(node: { sourceFile: string; label: string; line?: number }): DuplicateAnchor {
+  return { file: node.sourceFile, symbol: node.label, line: node.line ?? 0 };
+}
+
+/**
+ * Compute structural-duplicate findings from an in-memory `GraphJson`. Pure —
+ * no I/O; the caller supplies the graph (obtained from the producer
+ * `gatherGraphifyGraph`, never a disk read here). Returns findings sorted by
+ * descending similarity, each carrying a stable identity.
+ */
+export function duplicateFindingsFromJson(
+  json: GraphJson,
+  opts: DuplicatePairsOpts = {},
+): DuplicateFinding[] {
+  const graph = indexGraph(json);
+  const pairs = duplicatePairsQuery(graph, opts);
+  return pairs.map((p) => {
+    const a = anchorOf(p.a);
+    const b = anchorOf(p.b);
+    return {
+      id: computeCodeReimplementationFingerprint(a, b),
+      anchors: [a, b] as const,
+      score: p.score,
+    };
+  });
+}

--- a/src/explore/load.ts
+++ b/src/explore/load.ts
@@ -141,7 +141,17 @@ function validateAndUpgrade(absPath: string, raw: unknown): GraphJson {
   return { ...(raw as GraphJson), endpoints: endpoints as HttpEndpointNode[] };
 }
 
-function indexGraph(json: GraphJson): Graph {
+/**
+ * Build the in-memory `Graph` (convenience indices) from an ALREADY-VALIDATED
+ * `GraphJson`. The pure, in-memory sibling of {@link loadGraph}: `loadGraph`
+ * reads + JSON-parses + validates the disk artifact and then calls this;
+ * consumers that already hold a `GraphJson` from the PRODUCER
+ * (`gatherGraphifyGraph`, in-memory, never touching disk) index it here without
+ * a disk round-trip — so a zero-write gate can query the graph without writing
+ * `graph.json`. JSON.parse + validation stay in `loadGraph` (Rule 12); this only
+ * builds maps, so it is safe to expose and use from within `src/explore/`.
+ */
+export function indexGraph(json: GraphJson): Graph {
   const nodeById = new Map<string, GraphNode>();
   for (const n of json.nodes) nodeById.set(n.id, n);
 
@@ -172,13 +182,21 @@ function indexGraph(json: GraphJson): Graph {
 
   const endpointById = new Map<string, HttpEndpointNode>();
   const endpointByKey = new Map<string, HttpEndpointNode>();
-  for (const ep of json.endpoints) {
+  // The disk loader guarantees `endpoints` (validateAndUpgrade defaults it to
+  // []), but the RAW producer graph from `gatherGraphifyGraph` — indexed
+  // in-memory by the zero-write seam gate — carries only the structural
+  // node/edge layers; the flow overlay is added at disk-write. Default to [] so
+  // indexing a producer graph never throws (the flow overlay is not needed for
+  // structural queries like duplicate detection).
+  const endpoints = json.endpoints ?? [];
+  for (const ep of endpoints) {
     endpointById.set(ep.id, ep);
     endpointByKey.set(`${ep.method} ${ep.path}`, ep);
   }
 
   return {
     ...json,
+    endpoints,
     nodeById,
     edgesFromNode,
     edgesToNode,

--- a/src/explore/queries.ts
+++ b/src/explore/queries.ts
@@ -1667,3 +1667,179 @@ function suggestionsFor(graph: Graph, kw: string): Array<{ key: string; hits: nu
   suggestions.sort((a, b) => b.hits - a.hits || a.key.localeCompare(b.key));
   return suggestions.slice(0, 5);
 }
+
+// ─── Structural duplicate detection (tier-3 code-reimplementation) ────────────
+//
+// A GRAPH-level duplicate signal, distinct from jscpd's token-level
+// `duplication` (which is line-block copy-paste and churns on rename/reformat).
+// This reads the call graph: two functions that call the SAME set of helpers
+// and carry the same name tokens are almost certainly the same routine written
+// twice — the textbook agent copy-paste ("needed a variant, pasted the handler
+// instead of parameterizing"). It survives rename and reformat because its
+// signal is who-you-call, not how-your-lines-read.
+//
+// The scoring is the validated Exp-B formula (see the anti-slop proof): a
+// callee-set Jaccard (the reliable structural spine) blended with a name-token
+// Jaccard, with caller-set overlap as a tiebreak. `MIN_CALLEES` is a
+// structural-signal floor — a function that calls almost nothing has no
+// fingerprint and would match everything spuriously. Only pairs that share at
+// least one callee are ever scored (an inverted index over shared callees keeps
+// this near-linear, not O(n²)).
+//
+// Claim boundary (honest): this needs a dense internal call graph (backends /
+// CLIs / libraries, ≥~1 call/fn). On framework-mediated frontends the signal is
+// thin — low recall, NOT false positives. It catches structural copy-paste, not
+// semantic re-derivation (two functions that call DIFFERENT helpers to the same
+// end have near-zero callee overlap — out of scope by construction).
+
+/** Default blend weight on callee-set overlap (the reliable structural spine). */
+const DUP_W_CALLEE = 0.6;
+/** Default blend weight on name-token overlap. */
+const DUP_W_NAME = 0.4;
+/** A function calling fewer than this many distinct helpers has no structural
+ *  fingerprint — excluded so it can't spuriously match everything. */
+export const DUP_MIN_CALLEES = 3;
+/** Default report threshold: pairs scoring below this are not surfaced. */
+export const DUP_DEFAULT_MIN_SCORE = 0.5;
+
+/** One candidate duplicate pair: two function/method nodes that appear to be
+ *  re-implementations of each other, with the component similarity scores that
+ *  produced the verdict. `score = DUP_W_CALLEE·calleeJaccard + DUP_W_NAME·nameJaccard`. */
+export interface DuplicatePair {
+  readonly a: GraphNode;
+  readonly b: GraphNode;
+  readonly score: number;
+  readonly calleeJaccard: number;
+  readonly nameJaccard: number;
+  readonly callerJaccard: number;
+}
+
+export interface DuplicatePairsOpts {
+  /** Structural-signal floor (default `DUP_MIN_CALLEES`). */
+  readonly minCallees?: number;
+  /** Report threshold on the blended score (default `DUP_DEFAULT_MIN_SCORE`). */
+  readonly minScore?: number;
+  /** Exclude test/spec files from BOTH sides (default true). Test scaffolding is
+   *  legitimately repetitive; including it is the only false-positive class the
+   *  proof observed on human-reviewed code. Uses the pack-declared test-file
+   *  patterns (`isTestSourceFile`), never a hardcoded regex (Rule 6). */
+  readonly excludeTests?: boolean;
+  /** When present, a pair is only emitted if AT LEAST ONE side's source file is
+   *  in this set. This is the gate's diff-scoping ("what did THIS change
+   *  duplicate?") pushed into the query so large graphs never score the full
+   *  O(pairs) cross-product — only pairs touching a changed file. */
+  readonly focusFiles?: ReadonlySet<string>;
+}
+
+/** Split a symbol label into lowercased identifier tokens (camelCase / snake /
+ *  dotted), dropping single-char noise. `getDivisions()` → {get, divisions}. */
+function tokenizeLabel(label: string): Set<string> {
+  const base = label.replace(/\(.*$/, '');
+  return new Set(
+    base
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .replace(/[_\-.]/g, ' ')
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((t) => t.length > 1),
+  );
+}
+
+/** Jaccard overlap of two sets — |A∩B| / |A∪B|. Zero when both are empty. */
+function jaccard(a: ReadonlySet<string>, b: ReadonlySet<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  let inter = 0;
+  const [small, big] = a.size <= b.size ? [a, b] : [b, a];
+  for (const x of small) if (big.has(x)) inter++;
+  return inter / (a.size + b.size - inter);
+}
+
+interface DupFeature {
+  readonly node: GraphNode;
+  readonly callees: Set<string>;
+  readonly callers: Set<string>;
+  readonly tokens: Set<string>;
+}
+
+/** Build the per-function feature vectors (callee set, caller set, name tokens)
+ *  for every function/method with enough callees to carry a signal. */
+function buildDupFeatures(
+  graph: Graph,
+  minCallees: number,
+  excludeTests: boolean,
+): Map<string, DupFeature> {
+  const feats = new Map<string, DupFeature>();
+  for (const node of graph.nodes) {
+    if (node.kind !== 'function' && node.kind !== 'method') continue;
+    if (excludeTests && isTestSourceFile(node.sourceFile)) continue;
+    const callees = new Set<string>();
+    for (const e of graph.edgesFromNode.get(node.id) ?? []) {
+      if (e.relation === 'calls') callees.add(e.to);
+    }
+    if (callees.size < minCallees) continue;
+    const callers = new Set<string>();
+    for (const e of graph.edgesToNode.get(node.id) ?? []) {
+      if (e.relation === 'calls') callers.add(e.from);
+    }
+    feats.set(node.id, { node, callees, callers, tokens: tokenizeLabel(node.label) });
+  }
+  return feats;
+}
+
+/**
+ * Rank candidate structural-duplicate pairs across the call graph. Pure,
+ * deterministic, near-linear (inverted index over shared callees). Returns
+ * pairs sorted by descending score, then caller-overlap tiebreak.
+ *
+ * Traversal lives ONLY here (Rule 12); the duplication analyzer + the two-ref
+ * gate consume this and never re-walk edges.
+ */
+export function duplicatePairsQuery(graph: Graph, opts: DuplicatePairsOpts = {}): DuplicatePair[] {
+  const minCallees = opts.minCallees ?? DUP_MIN_CALLEES;
+  const minScore = opts.minScore ?? DUP_DEFAULT_MIN_SCORE;
+  const excludeTests = opts.excludeTests ?? true;
+  const focus = opts.focusFiles;
+  const feats = buildDupFeatures(graph, minCallees, excludeTests);
+
+  // Inverted index calleeId → [fnId,…] so we only ever score pairs that share
+  // at least one callee — the rest have Jaccard 0 and can't clear the floor.
+  const inv = new Map<string, string[]>();
+  for (const [id, f] of feats) {
+    for (const c of f.callees) {
+      const bucket = inv.get(c);
+      if (bucket) bucket.push(id);
+      else inv.set(c, [id]);
+    }
+  }
+
+  const seen = new Set<string>();
+  const pairs: DuplicatePair[] = [];
+  for (const ids of inv.values()) {
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        const [x, y] = ids[i] < ids[j] ? [ids[i], ids[j]] : [ids[j], ids[i]];
+        const key = `${x}\0${y}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const fa = feats.get(x)!;
+        const fb = feats.get(y)!;
+        // Diff-scope: at least one side must touch a changed file, when scoped.
+        if (focus && !focus.has(fa.node.sourceFile) && !focus.has(fb.node.sourceFile)) continue;
+        const calleeJaccard = jaccard(fa.callees, fb.callees);
+        const nameJaccard = jaccard(fa.tokens, fb.tokens);
+        const score = DUP_W_CALLEE * calleeJaccard + DUP_W_NAME * nameJaccard;
+        if (score < minScore) continue;
+        pairs.push({
+          a: fa.node,
+          b: fb.node,
+          score,
+          calleeJaccard,
+          nameJaccard,
+          callerJaccard: jaccard(fa.callers, fb.callers),
+        });
+      }
+    }
+  }
+  pairs.sort((p, q) => q.score - p.score || q.callerJaccard - p.callerJaccard);
+  return pairs;
+}

--- a/src/loop/policy.ts
+++ b/src/loop/policy.ts
@@ -24,6 +24,7 @@ import {
 } from '../baseline/presets';
 import type { FlowGateMode } from '../analyzers/flow/config';
 import type { SchemaGateMode } from '../analyzers/model-schema/config';
+import type { DuplicationGateMode } from '../analyzers/duplication/config';
 
 // Re-exported so existing consumers (stop-gate, scaffold, doctor, CLI) keep
 // one import site for the loop posture vocabulary.
@@ -37,6 +38,7 @@ export interface ResolvedLoopPolicy {
   readonly preset: LoopPreset;
   readonly flowMode: FlowGateMode;
   readonly schemaMode: SchemaGateMode;
+  readonly duplicationMode: DuplicationGateMode;
 }
 
 /**
@@ -112,6 +114,7 @@ export function resolveLoopPolicy(cwd: string): ResolvedLoopPolicy {
     preset,
     flowMode: applied.flowMode,
     schemaMode: applied.schemaMode,
+    duplicationMode: applied.duplicationMode,
     policy: applied.policy,
   };
 }

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -330,7 +330,7 @@ export async function runStopGate(cwd: string): Promise<void> {
   // Resolve the loop-scoped posture ONCE (preset → policy). This is the
   // only place the loop preset is read; the CI guardrail never sees it.
   const { resolveLoopPolicy } = await import('./policy');
-  const { policy, preset, flowMode, schemaMode } = resolveLoopPolicy(repoDir);
+  const { policy, preset, flowMode, schemaMode, duplicationMode } = resolveLoopPolicy(repoDir);
 
   // ── Fast path: replay the last verdict when the working tree is
   // byte-identical to what was last gathered (a no-change stop — an
@@ -394,6 +394,7 @@ export async function runStopGate(cwd: string): Promise<void> {
       incremental: true,
       flowMode,
       schemaMode,
+      duplicationMode,
     });
     const json = renderJson(result);
     // Persist the full machine-readable verdict so the model (and a human)

--- a/test/allowlist/hint.test.ts
+++ b/test/allowlist/hint.test.ts
@@ -83,6 +83,15 @@ const ENTRIES: Record<BaselineEntry['kind'], BaselineEntry> = {
     line: 5,
     rule: 'no-unused-vars',
   },
+  'code-reimplementation': {
+    id: FP,
+    kind: 'code-reimplementation',
+    anchors: [
+      { file: 'src/api/divisions.ts', symbol: 'GET', line: 10 },
+      { file: 'src/api/cli/divisions.ts', symbol: 'GET', line: 12 },
+    ],
+    score: 1.0,
+  },
 };
 
 const ALL_KINDS = Object.keys(ENTRIES) as BaselineEntry['kind'][];

--- a/test/baseline/dup-gate-check.test.ts
+++ b/test/baseline/dup-gate-check.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Integration tests for src/baseline/dup-gate-check.ts — the additive,
+ * fail-open structural-duplicate (seam) gate over a real ref-based comparison.
+ *
+ * The graph provider is INJECTED (the graphify gather is heavy + needs Python),
+ * so these tests pin the two-ref gate LOGIC deterministically: opt-in gating,
+ * trigger-skip, net-new grandfathering against the base ref, diff-scoping,
+ * allowlist suppression, and fail-open — over a genuine `git` worktree, without
+ * ever invoking graphify. The detector itself is pinned separately in
+ * test/explore/duplicate-pairs-query.test.ts.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { evaluateDupGateForGuardrail } from '../../src/baseline/dup-gate-check';
+import type { GraphGatherOutcome } from '../../src/analyzers/tools/graphify';
+import type { GraphJson, GraphNode, GraphEdge } from '../../src/explore/types';
+import { computeCodeReimplementationFingerprint } from '../../src/analyzers/tools/fingerprint';
+import type { AllowlistFile } from '../../src/allowlist/file';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function git(dir: string, args: string[]): void {
+  execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+}
+
+let idc = 0;
+function fn(label: string, sourceFile: string, line = 1): GraphNode {
+  return { id: `${sourceFile}#${label}#${idc++}`, kind: 'function', label, sourceFile, line };
+}
+function helper(name: string): GraphNode {
+  return {
+    id: `lib#${name}#${idc++}`,
+    kind: 'function',
+    label: name,
+    sourceFile: 'src/lib.ts',
+    line: 1,
+  };
+}
+function graphOf(nodes: GraphNode[], edges: GraphEdge[]): GraphJson {
+  return {
+    schemaVersion: 2,
+    meta: {
+      tool: 'graphify',
+      graphifyVersion: '0',
+      dxkitVersion: '0',
+      generatedAt: '',
+      sourceFilesInGraph: 0,
+      excludedFileCount: 0,
+      packs: [],
+      truncated: false,
+      truncatedReason: '',
+    },
+    nodes,
+    edges,
+    communities: [],
+    symbolIndex: {},
+    endpoints: [],
+  };
+}
+
+/** A copy-paste pair: `a` and `b` both call the same 3 helpers by the same
+ *  name → callee-Jaccard 1.0, name-Jaccard 1.0, score 1.0. */
+function pairGraph(fileA: string, fileB: string): GraphJson {
+  const h = ['query', 'requireUser', 'respond'].map(helper);
+  const a = fn('GET', fileA, 10);
+  const b = fn('GET', fileB, 12);
+  const edges = h.flatMap((x) => [
+    { from: a.id, to: x.id, relation: 'calls' as const },
+    { from: b.id, to: x.id, relation: 'calls' as const },
+  ]);
+  return graphOf([...h, a, b], edges);
+}
+
+const EMPTY = graphOf([], []);
+function ok(g: GraphJson): GraphGatherOutcome {
+  return { kind: 'success', graph: g };
+}
+
+/** A repo with the seam gate enabled (mode warn), a source file touched by the
+ *  HEAD change, committed on `main` as the base. */
+function makeRepo(mode: 'warn' | 'block' | 'off' = 'warn'): { dir: string; baseSha: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-dupgate-'));
+  dirs.push(dir);
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'test']);
+  mkdirSync(join(dir, '.dxkit'), { recursive: true });
+  writeFileSync(join(dir, '.dxkit', 'policy.json'), JSON.stringify({ duplication: { mode } }));
+  mkdirSync(join(dir, 'src', 'api', 'cli'), { recursive: true });
+  writeFileSync(join(dir, 'src', 'api', 'divisions.ts'), 'export const GET = () => {};\n');
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  const baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir }).toString().trim();
+  // The PR change: add a new source file (a CLI variant), so the diff touches source.
+  writeFileSync(join(dir, 'src', 'api', 'cli', 'divisions.ts'), 'export const GET = () => {};\n');
+  return { dir, baseSha };
+}
+
+/** Inject a provider that returns `head` for the working tree (cwd) and `base`
+ *  for anything else (the ref worktree). */
+function provider(head: GraphGatherOutcome, base: GraphGatherOutcome, cwd: string) {
+  return async (dir: string): Promise<GraphGatherOutcome> => (dir === cwd ? head : base);
+}
+
+describe('evaluateDupGateForGuardrail — two-ref seam gate', () => {
+  it('skips at zero cost when policy mode is off (no graph build)', async () => {
+    const { dir, baseSha } = makeRepo('off');
+    let called = false;
+    const out = await evaluateDupGateForGuardrail({
+      cwd: dir,
+      baseRef: baseSha,
+      gatherGraph: async () => {
+        called = true;
+        return ok(EMPTY);
+      },
+    });
+    expect(out.skipped).toBe('off');
+    expect(called).toBe(false);
+  });
+
+  it('flags a NET-NEW duplicate the diff introduced (absent at base)', async () => {
+    const { dir, baseSha } = makeRepo('warn');
+    const head = pairGraph('src/api/divisions.ts', 'src/api/cli/divisions.ts');
+    const out = await evaluateDupGateForGuardrail({
+      cwd: dir,
+      baseRef: baseSha,
+      // Base had only the original handler, no duplicate.
+      gatherGraph: provider(ok(head), ok(EMPTY), dir),
+    });
+    expect(out.ran).toBe(true);
+    expect(out.warns).toBe(true);
+    expect(out.blocks).toBe(false); // a lone duplicate never blocks
+    expect(out.findings).toHaveLength(1);
+    expect(out.mode).toBe('warn');
+    // The gate marks WHICH anchor the change introduced (the added CLI variant),
+    // so remediation is directional. The base file is not in the changed set.
+    const f = out.findings[0];
+    expect(f.changed).toBeDefined();
+    const changedAnchor = f.anchors.find((_, i) => f.changed![i]);
+    const unchangedAnchor = f.anchors.find((_, i) => !f.changed![i]);
+    expect(changedAnchor?.file).toBe('src/api/cli/divisions.ts');
+    expect(unchangedAnchor?.file).toBe('src/api/divisions.ts');
+  });
+
+  it('GRANDFATHERS a duplicate present at BOTH refs (never blocks pre-existing debt)', async () => {
+    const { dir, baseSha } = makeRepo('warn');
+    // The SAME duplicate exists at head AND base → not net-new.
+    const g = pairGraph('src/api/divisions.ts', 'src/api/cli/divisions.ts');
+    const out = await evaluateDupGateForGuardrail({
+      cwd: dir,
+      baseRef: baseSha,
+      gatherGraph: provider(ok(g), ok(g), dir),
+    });
+    expect(out.warns).toBe(false);
+    expect(out.findings).toHaveLength(0);
+    // It RAN the base comparison and grandfathered the pre-existing pair —
+    // not a skip, just zero net-new.
+    expect(out.ran).toBe(true);
+    expect(out.skipped).toBeUndefined();
+  });
+
+  it('never builds the base graph when HEAD has no candidate (the cost guard)', async () => {
+    const { dir, baseSha } = makeRepo('warn');
+    let baseBuilt = false;
+    const out = await evaluateDupGateForGuardrail({
+      cwd: dir,
+      baseRef: baseSha,
+      gatherGraph: async (d: string) => {
+        if (d !== dir) baseBuilt = true;
+        return ok(EMPTY); // HEAD has no duplicate
+      },
+    });
+    expect(out.skipped).toBe('no-candidates');
+    expect(baseBuilt).toBe(false);
+  });
+
+  it('fail-opens (skips, never throws) when graphify is unavailable on HEAD', async () => {
+    const { dir, baseSha } = makeRepo('warn');
+    const out = await evaluateDupGateForGuardrail({
+      cwd: dir,
+      baseRef: baseSha,
+      gatherGraph: async () => ({ kind: 'unavailable', reason: 'not installed' }),
+    });
+    expect(out.skipped).toBe('no-graph');
+    expect(out.blocks).toBe(false);
+  });
+
+  it('an active code-reimplementation allowlist entry waives the finding', async () => {
+    const { dir, baseSha } = makeRepo('warn');
+    const head = pairGraph('src/api/divisions.ts', 'src/api/cli/divisions.ts');
+    // Recompute the finding id the gate will mint (canonical sorted anchors).
+    const id = computeCodeReimplementationFingerprint(
+      { file: 'src/api/divisions.ts', symbol: 'GET', line: 10 },
+      { file: 'src/api/cli/divisions.ts', symbol: 'GET', line: 12 },
+    );
+    const allowlist: AllowlistFile = {
+      version: 1,
+      entries: [
+        {
+          fingerprint: id,
+          kind: 'code-reimplementation',
+          category: 'false-positive',
+          reason: 'sanctioned parallel',
+          addedAt: '2026-01-01T00:00:00Z',
+        },
+      ],
+    } as unknown as AllowlistFile;
+    const out = await evaluateDupGateForGuardrail({
+      cwd: dir,
+      baseRef: baseSha,
+      allowlist,
+      gatherGraph: provider(ok(head), ok(EMPTY), dir),
+    });
+    expect(out.warns).toBe(false);
+    expect(out.findings).toHaveLength(0);
+    expect(out.suppressed).toHaveLength(1);
+    expect(out.suppressed[0].fingerprint).toBe(id);
+  });
+});

--- a/test/baseline/finding-identity.test.ts
+++ b/test/baseline/finding-identity.test.ts
@@ -919,6 +919,83 @@ const FIXTURES: ReadonlyArray<IdentityFixture> = [
     },
     expected: 'changed',
   },
+
+  // ─── code-reimplementation (4) ────────────────────────────────────────
+  {
+    name: 'code-reimplementation/clean — same anchor pair',
+    prior: {
+      kind: 'code-reimplementation',
+      anchors: [
+        { file: 'src/api/cli/divisions/route.ts', symbol: 'GET', line: 12 },
+        { file: 'src/api/divisions/route.ts', symbol: 'GET', line: 8 },
+      ],
+    },
+    current: {
+      kind: 'code-reimplementation',
+      anchors: [
+        { file: 'src/api/cli/divisions/route.ts', symbol: 'GET', line: 12 },
+        { file: 'src/api/divisions/route.ts', symbol: 'GET', line: 8 },
+      ],
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'code-reimplementation/symmetric — (A,B) equals (B,A)',
+    // The two anchors are order-independent: reporting the pair reversed must
+    // resolve to the same identity.
+    prior: {
+      kind: 'code-reimplementation',
+      anchors: [
+        { file: 'src/api/divisions/route.ts', symbol: 'GET', line: 8 },
+        { file: 'src/api/cli/divisions/route.ts', symbol: 'GET', line: 12 },
+      ],
+    },
+    current: {
+      kind: 'code-reimplementation',
+      anchors: [
+        { file: 'src/api/cli/divisions/route.ts', symbol: 'GET', line: 12 },
+        { file: 'src/api/divisions/route.ts', symbol: 'GET', line: 8 },
+      ],
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'code-reimplementation/small line drift absorbed by the window',
+    // A one-line reformat inside the shared 3-line window keeps identity stable.
+    prior: {
+      kind: 'code-reimplementation',
+      anchors: [
+        { file: 'src/api/cli/divisions/route.ts', symbol: 'GET', line: 12 },
+        { file: 'src/api/divisions/route.ts', symbol: 'GET', line: 8 },
+      ],
+    },
+    current: {
+      kind: 'code-reimplementation',
+      anchors: [
+        { file: 'src/api/cli/divisions/route.ts', symbol: 'GET', line: 13 },
+        { file: 'src/api/divisions/route.ts', symbol: 'GET', line: 6 },
+      ],
+    },
+    expected: 'persisted',
+  },
+  {
+    name: 'code-reimplementation/different partner symbol → identity changes',
+    prior: {
+      kind: 'code-reimplementation',
+      anchors: [
+        { file: 'src/api/cli/divisions/route.ts', symbol: 'GET', line: 12 },
+        { file: 'src/api/divisions/route.ts', symbol: 'GET', line: 8 },
+      ],
+    },
+    current: {
+      kind: 'code-reimplementation',
+      anchors: [
+        { file: 'src/api/cli/divisions/route.ts', symbol: 'GET', line: 12 },
+        { file: 'src/api/leagues/route.ts', symbol: 'GET', line: 8 },
+      ],
+    },
+    expected: 'changed',
+  },
 ];
 
 describe('identityFor — per-kind deterministic identity', () => {
@@ -1138,6 +1215,7 @@ const EXPECTED_KINDS = [
   'stale-allow',
   'flow-binding',
   'model-schema-drift',
+  'code-reimplementation',
   'custom-check',
 ] as const;
 

--- a/test/baseline/producers-contract.test.ts
+++ b/test/baseline/producers-contract.test.ts
@@ -59,6 +59,7 @@ const ALL_KINDS: ReadonlyArray<IdentityKind> = [
   'stale-allow',
   'flow-binding',
   'model-schema-drift',
+  'code-reimplementation',
   'custom-check',
 ];
 

--- a/test/explore/duplicate-pairs-query.test.ts
+++ b/test/explore/duplicate-pairs-query.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { indexGraph } from '../../src/explore/load';
+import {
+  duplicatePairsQuery,
+  DUP_MIN_CALLEES,
+  DUP_DEFAULT_MIN_SCORE,
+} from '../../src/explore/queries';
+import type { GraphJson, GraphNode, GraphEdge } from '../../src/explore/types';
+
+/**
+ * Structural-duplicate detector (tier-3 `code-reimplementation`) — unit tests
+ * over synthetic graphs, so the behavior is pinned independently of graphify.
+ * Mirrors the validated Exp-B detector: callee/name Jaccard, the MIN_CALLEES
+ * structural floor, test-file exclusion, and the diff-scope focus set.
+ */
+
+let idc = 0;
+function fn(label: string, sourceFile: string, line = 1): GraphNode {
+  return { id: `${sourceFile}#${label}#${idc++}`, kind: 'function', label, sourceFile, line };
+}
+function helper(sourceFile: string, name: string): GraphNode {
+  return {
+    id: `${sourceFile}#${name}#${idc++}`,
+    kind: 'function',
+    label: name,
+    sourceFile,
+    line: 1,
+  };
+}
+function calls(from: GraphNode, to: GraphNode): GraphEdge {
+  return { from: from.id, to: to.id, relation: 'calls' };
+}
+
+function build(nodes: GraphNode[], edges: GraphEdge[]): GraphJson {
+  return {
+    schemaVersion: 2,
+    meta: {
+      tool: 'graphify',
+      graphifyVersion: '0',
+      dxkitVersion: '0',
+      generatedAt: '',
+      sourceFilesInGraph: 0,
+      excludedFileCount: 0,
+      packs: [],
+      truncated: false,
+      truncatedReason: '',
+    },
+    nodes,
+    edges,
+    communities: [],
+    symbolIndex: {},
+    endpoints: [],
+  };
+}
+
+/** Two functions that call the SAME three helpers with the SAME name → a
+ *  textbook copy-paste (callee-Jaccard 1.0, name-Jaccard 1.0). */
+function copyPasteGraph(): GraphJson {
+  const h1 = helper('src/lib/db.ts', 'query');
+  const h2 = helper('src/lib/auth.ts', 'requireUser');
+  const h3 = helper('src/lib/http.ts', 'respond');
+  const a = fn('GET', 'src/api/divisions/route.ts', 10);
+  const b = fn('GET', 'src/api/cli/divisions/route.ts', 12);
+  const edges = [h1, h2, h3].flatMap((h) => [calls(a, h), calls(b, h)]);
+  return build([h1, h2, h3, a, b], edges);
+}
+
+describe('duplicatePairsQuery — structural duplicate detection', () => {
+  it('flags two functions with identical callee sets + names at score 1.0', () => {
+    const g = indexGraph(copyPasteGraph());
+    const pairs = duplicatePairsQuery(g);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].score).toBeCloseTo(1.0, 5);
+    expect(pairs[0].calleeJaccard).toBeCloseTo(1.0, 5);
+    const files = [pairs[0].a.sourceFile, pairs[0].b.sourceFile].sort();
+    expect(files).toEqual(['src/api/cli/divisions/route.ts', 'src/api/divisions/route.ts']);
+  });
+
+  it('excludes functions below the MIN_CALLEES structural floor', () => {
+    // Same names, but each calls only 2 helpers (< DUP_MIN_CALLEES=3) → no signal.
+    expect(DUP_MIN_CALLEES).toBe(3);
+    const h1 = helper('src/lib/db.ts', 'query');
+    const h2 = helper('src/lib/http.ts', 'respond');
+    const a = fn('GET', 'src/api/a/route.ts');
+    const b = fn('GET', 'src/api/b/route.ts');
+    const g = indexGraph(
+      build(
+        [h1, h2, a, b],
+        [h1, h2].flatMap((h) => [calls(a, h), calls(b, h)]),
+      ),
+    );
+    expect(duplicatePairsQuery(g)).toHaveLength(0);
+  });
+
+  it('does not flag two functions that call DIFFERENT helpers (semantic re-derivation is out of scope)', () => {
+    const ha = ['a1', 'a2', 'a3'].map((n) => helper('src/lib/a.ts', n));
+    const hb = ['b1', 'b2', 'b3'].map((n) => helper('src/lib/b.ts', n));
+    const a = fn('doThing', 'src/x.ts');
+    const b = fn('doThing', 'src/y.ts');
+    const edges = [...ha.map((h) => calls(a, h)), ...hb.map((h) => calls(b, h))];
+    const g = indexGraph(build([...ha, ...hb, a, b], edges));
+    // Zero callee overlap → never scored (inverted index only pairs shared callees).
+    expect(duplicatePairsQuery(g)).toHaveLength(0);
+  });
+
+  it('excludes test files from both sides by default', () => {
+    const h = ['h1', 'h2', 'h3'].map((n) => helper('src/lib.ts', n));
+    const a = fn('setup', 'src/api/route.ts');
+    const b = fn('setup', 'test/api/route.test.ts');
+    const edges = h.flatMap((x) => [calls(a, x), calls(b, x)]);
+    const g = indexGraph(build([...h, a, b], edges));
+    // Default excludeTests → the test-file side is dropped, so no pair remains.
+    expect(duplicatePairsQuery(g)).toHaveLength(0);
+    // Opt back in → the pair appears.
+    expect(duplicatePairsQuery(g, { excludeTests: false })).toHaveLength(1);
+  });
+
+  it('diff-scopes to pairs touching a focus file', () => {
+    const g = copyPasteGraph();
+    const graph = indexGraph(g);
+    // Focus on a file NEITHER side touches → dropped.
+    expect(duplicatePairsQuery(graph, { focusFiles: new Set(['src/unrelated.ts']) })).toHaveLength(
+      0,
+    );
+    // Focus on one side's file → kept.
+    expect(
+      duplicatePairsQuery(graph, { focusFiles: new Set(['src/api/cli/divisions/route.ts']) }),
+    ).toHaveLength(1);
+  });
+
+  it('honors the minScore threshold', () => {
+    // Partial overlap: share 2 of 3 callees, different names → score < 1.0.
+    const shared = ['s1', 's2'].map((n) => helper('src/lib.ts', n));
+    const onlyA = helper('src/lib.ts', 'a-only');
+    const onlyB = helper('src/lib.ts', 'b-only');
+    const a = fn('alpha', 'src/a.ts');
+    const b = fn('beta', 'src/b.ts');
+    const edges = [
+      ...shared.flatMap((h) => [calls(a, h), calls(b, h)]),
+      calls(a, onlyA),
+      calls(b, onlyB),
+    ];
+    const g = indexGraph(build([...shared, onlyA, onlyB, a, b], edges));
+    const all = duplicatePairsQuery(g, { minScore: 0 });
+    expect(all).toHaveLength(1);
+    // callee-Jaccard = 2/4 = 0.5; name-Jaccard = 0 → score = 0.6*0.5 = 0.3.
+    expect(all[0].score).toBeCloseTo(0.3, 5);
+    // Default threshold (0.5) drops it.
+    expect(DUP_DEFAULT_MIN_SCORE).toBe(0.5);
+    expect(duplicatePairsQuery(g)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What & why

T2 phase 1 — the first of the seam gates. A graph-derived duplicate signal that flags a **net-new function structurally re-implementing another** (same helper set, same name shape, read from the call graph). It survives rename/reformat where jscpd's token-level `duplication` does not — a **sibling** kind, not a replacement. This is the copy-paste-instead-of-parameterize pattern agents produce (a CLI variant pasted from a handler, a `findByX` cloned into `findByIdX`).

Scoped as **phase 1** deliberately: this proven tier-3 signal ships first; the block-tier differentiator (dead-surface + seam-convergence + scoring) is phase 2, stacking on this.

## Changes

- **Detector** — a pure query in `explore/queries.ts` (Rule 12): callee/name Jaccard, a `MIN_CALLEES` structural floor, inverted-index pairing, pack-declared test-file exclusion, a diff-scope focus set.
- **Identity** — new `code-reimplementation` `IdentityKind` (Rule 9): symmetric fingerprint over two dxkit-derived anchors; a `DEFERRED_KIND` (gate-minted two-ref relation, no full-scan producer → no upgrade flood); fixture rows in the identity contract.
- **Gate** (`src/baseline/dup-gate-check.ts`) — gathers the duplicate set at base + head and mints only net-new pairs (a duplicate at base is grandfathered), mirroring the flow/schema gates. **Opt-in** (`.dxkit/policy.json:duplication.mode`, default off — it builds the code graph), **zero-write** (indexes the producer graph in memory), diff-scoped, and builds the base graph only when HEAD has a candidate. Fail-open throughout. Lone duplicates are always **warn-tier** (the anti-slop proof's precision floor); block is reserved for convergence.
- **Directional & agent-fixable** — the finding names which side the change introduced (`added: <new> ≈ existing: <twin>`, `"changed": true` in JSON), and the `dxkit-action` skill carries a fix recipe.
- Folds into the guardrail verdict + console/markdown/json renderers + loop preset posture. Allowlist waiver via `--kind=code-reimplementation --category=false-positive`. Docs in `policy.md`; CHANGELOG entry.

## Validation

Read-only across an `external-repos/` matrix: **0 pairs** on a thin frontend SPA (honest negative), genuine controller / keyboard-handler copy-paste on TS and C# backends, query scaling to **65k functions in ~1.46s**. Real-graphify end-to-end: net-new detected, pre-existing grandfathered (even when its file is edited), non-source skipped. **Full suite 3920 green; build/lint/format/arch/slop/cross-ecosystem clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aVcK9vYXrm71yV4dBQQde