### PR TITLE
feat(seam-gate): phase 2 — dead-surface inventory + seam convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Dead-surface inventory + seam convergence in `vyuh-dxkit flow`.** The flow map's
+  flat "served but unconsumed" list is now an honest **confidence ladder**: each
+  served-but-unconsumed route is tiered `removable` / `likely` / `expected` with the
+  reason it landed there, so an uncertain route is never presented as certain. A
+  route whose consumer is an external actor (webhook / cron / health / CLI, declared
+  per language pack) or a server-side direct call (RSC / server action) drops to
+  `expected`; a route with no in-repo consumer is `likely` (with the nudge to declare
+  `workspace.json` so cross-repo consumers can be ruled out); and a route that is BOTH
+  ladder-confirmed dead AND a structural duplicate **converges** to `removable` — the
+  ranked "remove or consolidate this copy-paste nobody uses" signal, surfaced only
+  when every consumer is visible (an explicit workspace mesh or a co-located UI), so
+  it never false-flags a cross-repo-consumed route. Available as prose and, for
+  agents, in `flow --json` under `deadSurfaces`. Validated read-only across 8 diverse
+  real repos (TS backend / full-stack / SPA, Next.js App Router, Python, C#, Rust)
+  with zero false `removable` on any of them.
+
 - **Structural-duplicate (seam) gate — catches the copy-paste-instead-of-parameterize
   pattern.** A new opt-in guardrail layer flags a net-new function that
   structurally re-implements another: same helper set, same name shape, read from

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -594,6 +594,31 @@ if [ -n "$ARCH_SHAPE_WORD_VIOLATIONS" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# Rule 3: no hardcoded non-consumer-route convention literals
+#   (`'/webhook'`, `'/cron/'`, `'/healthz'`, ...) in `src/analyzers/`.
+#   These convention path-shapes (routes an external actor drives, so a
+#   "no in-repo consumer" reading is expected — not dead-surface slop)
+#   are pack-declared in `architecturalShape.nonConsumerRoutePaths` and
+#   consumed via `allNonConsumerRoutePaths(flags)`. The dead-surface
+#   analyzer must never hardcode a `cron|webhook|health` literal — that
+#   was the exact false-positive class the pack declaration exists to
+#   kill (a new framework's convention must be a pack edit, not an
+#   analyzer edit).
+arch_conv_re="['\"\`]\\/(web)?hooks?|['\"\`]\\/cron|['\"\`]\\/scheduled|['\"\`]\\/health|['\"\`]\\/healthz|['\"\`]\\/livez|['\"\`]\\/readyz|['\"\`]\\/liveness|['\"\`]\\/readiness|['\"\`]\\/callback"
+ARCH_CONV_VIOLATIONS=$(grep -rnEi "$arch_conv_re" src/analyzers/ 2>/dev/null \
+  | grep -v "// arch-shape-ok" \
+  | grep -v -E ':[[:space:]]*(//|\*)')
+if [ -n "$ARCH_CONV_VIOLATIONS" ]; then
+  echo "❌ Architectural-shape violation: hardcoded non-consumer-route convention literal in analyzer code:"
+  echo "$ARCH_CONV_VIOLATIONS"
+  echo "   → Convention route shapes (webhook/cron/health/callback) belong in"
+  echo "     src/languages/<id>.ts under architecturalShape.nonConsumerRoutePaths,"
+  echo "     consumed via allNonConsumerRoutePaths(flags). A new framework's"
+  echo "     convention is a pack declaration, never an analyzer edit."
+  echo "   → Annotate '// arch-shape-ok' for a genuine non-route use (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
 # ─── Rule 9 (fingerprint discipline): one home for finding-identity hashes ──
 #
 # What this prevents:

--- a/src-templates/.claude/skills/dxkit-flow/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-flow/SKILL.md
@@ -37,12 +37,40 @@ npx vyuh-dxkit doctor --json   → read the top-level `flow` field
 `flow` (when the repo has a UI→API surface) contains:
 - `topology` (monorepo / consumer-only / provider-only), `calls`, `routes`, `resolved`
 - `unresolved[]` — each `{ method, path, reason, suggestion, file, line }`. `reason` is `no-route` / `external` / `placeholder-only`; `suggestion` is `add-route` / `configure-participant` / `adopt-spec` / `annotate`.
-- `servedUnconsumed[]` — served routes no in-repo call hits (dead route, or a cross-repo consumer).
+- `servedUnconsumed[]` — served routes no in-repo call hits (dead route, or a cross-repo consumer). For the TIERED view of these — each route classified `removable` / `likely` / `expected` with its reason, plus the seam-convergence callout — run `vyuh-dxkit flow --json` and read `deadSurfaces` (see "The dead-surface inventory" below).
 - `connection.rung` — how the served side is resolved (`monorepo` / `committed-counterpart` / `configured-participants` / `unresolved`).
 - `coverage` — the honesty block: `callSitesSeen` / `extracted` / `dynamic` (recognized client calls whose URL is built at runtime — flow saw them and CANNOT verify them; `dynamicSites[]` lists their locations), a `paths` anchoring distribution (`exact` / `templated` / `opaque`), and a standing `note` (dynamic URLs + GraphQL are out of scope). Read this before ever telling a user "all integrations verified" — green means "everything extractable resolves", not "everything checked".
 - `contract` (when a committed `served.json` exists) — freshness of the snapshot: `generatedAt`, and per participant the commit its routes were gathered at (`sha`), its current `tip`, and `moved` (tri-state: `true` = the provider has shipped commits since this publish → recommend `flow publish` + commit; `false` = current; `null` = unknowable, e.g. offline — never treated as stale). `stale: true` only on a CONFIRMED move.
 
 Walk the `unresolved` tail and, per item, act on its `suggestion`: add the missing route, configure a participant (handshake mode), or adopt the provider's spec so an external call resolves. There is no inline "ignore this line" marker — an intentional break is accepted per-finding via the allowlist once the gate surfaces it as a net-new breakage (see **fix** mode below), so the acceptance is reviewed and diff-tracked rather than a silent inline comment.
+
+### The dead-surface inventory — `vyuh-dxkit flow` (+ `--json`)
+
+The flow map tiers every served-but-unconsumed route by an honest confidence
+ladder (never presents an uncertain route as dead). In `flow --json`, read
+`deadSurfaces`:
+
+- `crossRepoConsumersVisible` — whether every consumer could be SEEN (an explicit
+  `workspace.json` mesh, a committed counterpart, or a co-located UI in this repo).
+  When `false`, the loud `removable` tier is suppressed — a route might be consumed
+  by an unscanned repo, so deadness is unconfirmed. The nudge to unlock it is to
+  declare the system in `workspace.json`.
+- `byTier` — counts of `removable` / `likely` / `expected`.
+- `surfaces[]` — each `{ method, path, file, tier, reason, convergesWithDuplicate }`.
+  `reason` is `convention` (webhook/cron/health/CLI — an external actor drives it),
+  `direct-call` (consumed by a server-side call, not HTTP — RSC / server action),
+  `converged-dead` (removable), or `unconfirmed` (likely).
+- `converged[]` — the ranked "removable slop": a route that is BOTH ladder-confirmed
+  dead AND a structural duplicate (two independent seam signals agreeing). Each
+  carries the duplicate twin. This is the highest-confidence "remove or consolidate
+  this copy-paste nobody uses" signal — surface these first.
+
+Act on the tiers: **`removable` / `converged`** → remove the dead route or
+consolidate the duplicate (name the twin from `converged[].duplicate`); **`likely`**
+→ confirm it's truly dead (or declare `workspace.json` if a cross-repo UI consumes
+it); **`expected`** → leave alone (a webhook/cron/health/CLI route with no in-repo
+consumer is correct). The dead-surface inventory is a review signal, never a gate —
+it does not block a build.
 
 ### fix — repair a net-new broken integration ⭐
 

--- a/src/analyzers/convergence/dead-surface-gather.ts
+++ b/src/analyzers/convergence/dead-surface-gather.ts
@@ -19,6 +19,7 @@
 import type { FlowDiagnosis, UnconsumedRoute } from '../flow/diagnose';
 import { diagnoseFlow } from '../flow/diagnose';
 import { tryLoadGraph } from '../../explore/load';
+import type { Graph } from '../../explore/types';
 import { calledSymbolNames } from '../../explore/queries';
 import { allNonConsumerRoutePaths } from '../../languages';
 import { detect } from '../../detect';
@@ -127,11 +128,17 @@ export function tierDeadSurfaces(
       isSpecificHandlerName(route.handler) &&
       opts.calledSymbols.has(stripHandler(route.handler as string));
     const convergesWithDuplicate = opts.duplicateFiles.has(route.file);
+    // Deadness is only CONFIRMABLE for a specific-handler route: a bare HTTP-verb
+    // handler (App-Router `GET`/`POST`) can be consumed by a server component
+    // without a resolvable call, so its "unconsumed" is ambiguous and it can
+    // never reach the loud `removable` tier.
+    const deadnessConfirmable = isSpecificHandlerName(route.handler);
     const tier = deadSurfaceTier({
       isConventionRoute,
       isDirectlyCalled,
       crossRepoConsumersVisible: opts.crossRepoConsumersVisible,
       isStructuralDuplicate: convergesWithDuplicate,
+      deadnessConfirmable,
     });
     const reason: DeadSurfaceReason = isConventionRoute
       ? 'convention'
@@ -155,12 +162,16 @@ function stripHandler(handler: string): string {
  * surface, no graph, or any error → an empty result (never throws). The optional
  * `dupFindings` supply the convergence join; omit them for a dead-only view.
  *
- * Zero-write: reads the graph via `tryLoadGraph` (or none) and diagnoseFlow,
- * both read-only.
+ * Zero-write: reads diagnoseFlow + a graph, both read-only. The graph powers the
+ * direct-call seam (is a route's handler invoked directly?). The caller may pass
+ * a pre-built `graph` (so the inventory reuses the SAME graph it computed the
+ * duplicates from — one build, consistent seam); otherwise it falls back to the
+ * on-disk `graph.json` via `tryLoadGraph`, and to no direct-call resolution when
+ * neither is present.
  */
 export async function gatherDeadSurfaces(
   cwd: string,
-  opts: { readonly dupFindings?: readonly DuplicateFinding[] } = {},
+  opts: { readonly dupFindings?: readonly DuplicateFinding[]; readonly graph?: Graph } = {},
 ): Promise<DeadSurfaceResult> {
   const empty: DeadSurfaceResult = {
     surfaces: [],
@@ -177,9 +188,10 @@ export async function gatherDeadSurfaces(
 
   const stack = detect(cwd);
   const conventionPatterns = allNonConsumerRoutePaths(stack.languages);
-  // Direct-call seam from the graph when one is present; empty set otherwise
-  // (degrades to "no direct-call resolution", never an error).
-  const graph = tryLoadGraph(cwd);
+  // Direct-call seam from the graph when one is present: the caller's pre-built
+  // graph (shared with the duplicate pass), else the on-disk graph.json, else an
+  // empty set (degrades to "no direct-call resolution", never an error).
+  const graph = opts.graph ?? tryLoadGraph(cwd);
   const calledSymbols = graph ? calledSymbolNames(graph) : new Set<string>();
   // The convergence + direct-call joins compare FILE paths, so both sides must
   // be in the same format. Graph-derived dup anchors are repo-relative; flow's

--- a/src/analyzers/convergence/dead-surface-gather.ts
+++ b/src/analyzers/convergence/dead-surface-gather.ts
@@ -1,0 +1,210 @@
+/**
+ * Dead-surface gatherer — composes the flow diagnosis (`servedUnconsumed`), the
+ * graph's direct-call seam, the pack-declared conventions, and the convergence
+ * join (structural duplicates) into a TIERED list of served-but-unconsumed
+ * routes. This is a VISIBILITY signal (warn-tier / inventory), recomputed each
+ * run — it never blocks, so it carries no baseline identity (see the design's
+ * scoping refinement: no gate machinery for a non-gate signal).
+ *
+ * Two layers, so the ladder logic is testable without I/O:
+ *   - `tierDeadSurfaces` — PURE: unconsumed routes + signals → tiered surfaces.
+ *   - `gatherDeadSurfaces` — the thin I/O wrapper: diagnoseFlow + the graph +
+ *     the convention union + the optional dup findings → the tiered result.
+ *
+ * `diagnoseFlow` stays graph-FREE (its invariant); the graph-dependent
+ * direct-call seam is applied HERE, above it (Rule 2: servedUnconsumed is still
+ * computed in exactly one place — diagnose — and consumed here).
+ */
+
+import type { FlowDiagnosis, UnconsumedRoute } from '../flow/diagnose';
+import { diagnoseFlow } from '../flow/diagnose';
+import { tryLoadGraph } from '../../explore/load';
+import { calledSymbolNames } from '../../explore/queries';
+import { allNonConsumerRoutePaths } from '../../languages';
+import { detect } from '../../detect';
+import { readWorkspace } from '../../workspace';
+import { readServedContract } from '../flow/contract';
+import * as path from 'path';
+import type { DuplicateFinding } from '../../explore/duplication';
+import {
+  deadSurfaceTier,
+  isSpecificHandlerName,
+  matchesNonConsumerConvention,
+  type DeadSurfaceTier,
+} from './dead-surface';
+
+/** A served-but-unconsumed route with its resolved confidence tier + the reason
+ *  the tier landed where it did (the honest ladder — never present uncertain as
+ *  certain). */
+export interface TieredDeadSurface {
+  readonly route: UnconsumedRoute;
+  readonly tier: DeadSurfaceTier;
+  /** Human-legible reason the tier resolved this way — one of the ladder rungs.
+   *  Agent- and human-legible; renderers show it verbatim. */
+  readonly reason: DeadSurfaceReason;
+  /** True when a structural duplicate co-locates here (the convergence input) —
+   *  carried so a renderer can name the "removable slop" story. */
+  readonly convergesWithDuplicate: boolean;
+}
+
+export type DeadSurfaceReason =
+  | 'convention' // matched a pack-declared external-actor route shape
+  | 'direct-call' // handler is invoked directly (RSC / server action), not over HTTP
+  | 'converged-dead' // unconsumed, consumers visible, AND a duplicate → removable
+  | 'unconfirmed'; // unconsumed but cross-repo consumers could not be ruled out
+
+export interface DeadSurfaceResult {
+  readonly surfaces: readonly TieredDeadSurface[];
+  /** Whether every consumer was VISIBLE (cross-repo ruled out) — derived from
+   *  topology + connection rung. When false, the whole set is capped at `likely`
+   *  and the renderer nudges "configure workspace.json". */
+  readonly crossRepoConsumersVisible: boolean;
+  /** Counts by tier, for a one-line summary. */
+  readonly byTier: Readonly<Record<DeadSurfaceTier, number>>;
+}
+
+/**
+ * Whether cross-repo consumers could ALL be seen — the precondition for the loud
+ * `removable` tier. Only an EXPLICIT mesh qualifies: a `workspace.json` that
+ * declares the system's participants, or a committed counterpart contract. When
+ * the user has DECLARED the system boundary, a route unconsumed across it is
+ * confidently dead.
+ *
+ * Read DIRECTLY from the workspace / committed contract, NOT from
+ * `diagnoseFlow.connection.rung`: the rung reports `monorepo` for ANY repo that
+ * serves routes (it resolves the CONSUMER side, and a route-serving repo short-
+ * circuits to `monorepo` before the participant check), so it can never report
+ * `configured-participants` for a provider — the signal we actually need is
+ * "has this provider declared who consumes it," which only the workspace answers.
+ *
+ * A bare `monorepo` with no declaration does NOT qualify, even though it looks
+ * full-stack: a backend with internal service-to-service HTTP calls also reads
+ * as `monorepo`, yet its real UI consumers live in a separate repo dxkit never
+ * scanned. dxkit cannot tell those two apart from topology alone, so claiming
+ * "consumers visible" there would false-flag a cross-repo-consumed route as
+ * removable slop — the exact precision break the ladder avoids (measured on a
+ * real split-repo backend: 1214 dead controllers, 0 false removable). The
+ * `likely` tier's nudge ("declare your system in workspace.json") graduates a
+ * repo to the loud signal — an adoption loop, not a false positive.
+ */
+function consumersVisible(cwd: string, diag: Pick<FlowDiagnosis, 'frontendConsumers'>): boolean {
+  // 1. An explicit mesh: the user DECLARED the system boundary.
+  const ws = readWorkspace(cwd);
+  if (ws && ws.participants.length > 0) return true;
+  if (readServedContract(cwd) !== undefined) return true;
+  // 2. A co-located full-stack monorepo: a frontend component/page in THIS repo
+  //    consumes its own routes, so every consumer is in-repo and visible. A
+  //    backend that only makes internal service calls has zero frontend
+  //    consumers and does NOT qualify (the platform false-positive stays out).
+  return diag.frontendConsumers > 0;
+}
+
+/**
+ * Pure ladder application. Tiers each unconsumed route from already-computed
+ * signals: the convention union, the direct-call symbol set, whether consumers
+ * are visible, and the set of files carrying a structural duplicate (the
+ * convergence join). No I/O.
+ */
+export function tierDeadSurfaces(
+  servedUnconsumed: readonly UnconsumedRoute[],
+  opts: {
+    readonly crossRepoConsumersVisible: boolean;
+    readonly calledSymbols: ReadonlySet<string>;
+    readonly conventionPatterns: readonly string[];
+    readonly duplicateFiles: ReadonlySet<string>;
+  },
+): TieredDeadSurface[] {
+  return servedUnconsumed.map((route) => {
+    const isConventionRoute = matchesNonConsumerConvention(
+      route.file,
+      route.path,
+      opts.conventionPatterns,
+    );
+    // Direct-call seam: only trust a SPECIFIC handler name (a bare HTTP verb
+    // collides across the codebase — treating it as "called" would falsely mark
+    // a route consumed; bias to false-negative on deadness).
+    const isDirectlyCalled =
+      isSpecificHandlerName(route.handler) &&
+      opts.calledSymbols.has(stripHandler(route.handler as string));
+    const convergesWithDuplicate = opts.duplicateFiles.has(route.file);
+    const tier = deadSurfaceTier({
+      isConventionRoute,
+      isDirectlyCalled,
+      crossRepoConsumersVisible: opts.crossRepoConsumersVisible,
+      isStructuralDuplicate: convergesWithDuplicate,
+    });
+    const reason: DeadSurfaceReason = isConventionRoute
+      ? 'convention'
+      : isDirectlyCalled
+        ? 'direct-call'
+        : tier === 'removable'
+          ? 'converged-dead'
+          : 'unconfirmed';
+    return { route, tier, reason, convergesWithDuplicate };
+  });
+}
+
+/** Strip a handler symbol to its bare name, matching `calledSymbolNames`. */
+function stripHandler(handler: string): string {
+  const h = handler.replace(/\(\)$/, '');
+  return h.includes('.') ? (h.split('.').pop() ?? h) : h;
+}
+
+/**
+ * Gather the tiered dead-surface inventory for a repo. Fail-open: no flow
+ * surface, no graph, or any error → an empty result (never throws). The optional
+ * `dupFindings` supply the convergence join; omit them for a dead-only view.
+ *
+ * Zero-write: reads the graph via `tryLoadGraph` (or none) and diagnoseFlow,
+ * both read-only.
+ */
+export async function gatherDeadSurfaces(
+  cwd: string,
+  opts: { readonly dupFindings?: readonly DuplicateFinding[] } = {},
+): Promise<DeadSurfaceResult> {
+  const empty: DeadSurfaceResult = {
+    surfaces: [],
+    crossRepoConsumersVisible: false,
+    byTier: { removable: 0, likely: 0, expected: 0 },
+  };
+  let diag: FlowDiagnosis | null;
+  try {
+    diag = await diagnoseFlow(cwd);
+  } catch {
+    return empty;
+  }
+  if (!diag || diag.servedUnconsumed.length === 0) return empty;
+
+  const stack = detect(cwd);
+  const conventionPatterns = allNonConsumerRoutePaths(stack.languages);
+  // Direct-call seam from the graph when one is present; empty set otherwise
+  // (degrades to "no direct-call resolution", never an error).
+  const graph = tryLoadGraph(cwd);
+  const calledSymbols = graph ? calledSymbolNames(graph) : new Set<string>();
+  // The convergence + direct-call joins compare FILE paths, so both sides must
+  // be in the same format. Graph-derived dup anchors are repo-relative; flow's
+  // route files are absolute — normalize BOTH to repo-relative here, or the
+  // join silently never matches (caught on a real multi-project repo where dup
+  // anchors read `axum/src/…` and route files read `/home/…`).
+  const toRel = (f: string) => (path.isAbsolute(f) ? path.relative(cwd, f) : f);
+  const duplicateFiles = new Set<string>();
+  for (const d of opts.dupFindings ?? []) {
+    for (const a of d.anchors) duplicateFiles.add(toRel(a.file));
+  }
+  // Re-express each unconsumed route with a repo-relative file so the tier's
+  // convergence + convention checks compare like with like (and downstream
+  // renderers show a clean relative locator).
+  const relRoutes = diag.servedUnconsumed.map((r) => ({ ...r, file: toRel(r.file) }));
+
+  const crossRepoConsumersVisible = consumersVisible(cwd, diag);
+  const surfaces = tierDeadSurfaces(relRoutes, {
+    crossRepoConsumersVisible,
+    calledSymbols,
+    conventionPatterns,
+    duplicateFiles,
+  });
+
+  const byTier = { removable: 0, likely: 0, expected: 0 } as Record<DeadSurfaceTier, number>;
+  for (const s of surfaces) byTier[s.tier]++;
+  return { surfaces, crossRepoConsumersVisible, byTier };
+}

--- a/src/analyzers/convergence/dead-surface.ts
+++ b/src/analyzers/convergence/dead-surface.ts
@@ -1,0 +1,122 @@
+/**
+ * Dead-surface tier — the honest confidence ladder for a served route that no
+ * in-repo client call consumes. "Unconsumed" is NOT "dead": a route reads as
+ * unconsumed for three unrelated reasons, and the tier keeps them apart so the
+ * signal never cries wolf (the precision floor).
+ *
+ *   - genuinely dead      — the change added it, nothing reaches it, remove it.
+ *   - consumed cross-repo — the consuming frontend lives in another repo.
+ *   - consumed by convention — a webhook / cron / health / CLI route an
+ *                              EXTERNAL actor drives, so "no in-repo consumer"
+ *                              is expected.
+ *
+ * This module is PURE and tiny by design: it maps already-computed signals to a
+ * tier. The producer owns the policy that derives those signals (from
+ * `diagnoseFlow`'s connection rung, the pack-declared convention union, the
+ * direct-call seam, and the convergence join) — this function just encodes the
+ * ladder. Kept separate so the ladder is fixture-testable independent of the I/O
+ * that feeds it, and so the "one concept, one code path" rule holds (Rule 2:
+ * every consumer tiers a dead surface through here).
+ */
+
+/** The confidence tier of a served-but-unconsumed route. */
+export type DeadSurfaceTier =
+  | 'removable' // high confidence dead AND converged (also a duplicate) — warn loud
+  | 'likely' // unconsumed, but cross-repo consumers can't be ruled out — surface + nudge
+  | 'expected'; // an external-actor route (webhook/cron/health/CLI) or direct-called — inventory only
+
+/** The signals the tier is a pure function of. Each is decided by the producer
+ *  from an existing source (never re-detected here). */
+export interface DeadSurfaceSignals {
+  /** The route matched a pack-declared `nonConsumerRoutePaths` convention
+   *  (webhook / cron / health / public-api / CLI) — an external actor drives it,
+   *  so no in-repo consumer is EXPECTED. */
+  readonly isConventionRoute: boolean;
+  /** The route's handler symbol is the target of a `calls` edge in the graph —
+   *  it is consumed by a server-side DIRECT call (RSC / loader / server action),
+   *  not over HTTP. Closes the App-Router "dead is the norm" false-positive. */
+  readonly isDirectlyCalled: boolean;
+  /** The producer could actually SEE every consumer — either an explicit
+   *  cross-repo mesh was consulted (`configured-participants` /
+   *  `committed-counterpart`) or the scan is a full-stack tree that consumes its
+   *  own routes. When false (a bare backend repo with no workspace config), a
+   *  cross-repo consumer might exist and be invisible, so deadness is UNCERTAIN
+   *  and the route can never reach `removable`. */
+  readonly crossRepoConsumersVisible: boolean;
+  /** The convergence input: the route's handler / file is ALSO a structural
+   *  duplicate (a `code-reimplementation` finding co-locates here). Two
+   *  independent seam signals agreeing is what earns the loud `removable` tier
+   *  without a false-block. */
+  readonly isStructuralDuplicate: boolean;
+}
+
+/**
+ * Map the signals to a tier. The ladder, in one place:
+ *
+ *  1. An external-actor route (convention) or a direct-called route is NOT dead
+ *     — it is consumed, just not over HTTP. → `expected` (inventory only).
+ *  2. A genuinely-unconsumed route whose consumers were all VISIBLE (cross-repo
+ *     ruled out) AND which is ALSO a structural duplicate is near-certain
+ *     removable slop — convergence earns the loud tier. → `removable`.
+ *  3. Everything else genuinely-unconsumed — single-signal, or cross-repo
+ *     consumers we could not see — is surfaced but never shouted; the nudge is
+ *     "configure `workspace.json` so cross-repo consumers can be ruled out."
+ *     → `likely`.
+ *
+ * Bias to false-NEGATIVE throughout: an uncertain route lands `likely`/`expected`,
+ * never a loud `removable` it can't back up.
+ */
+export function deadSurfaceTier(signals: DeadSurfaceSignals): DeadSurfaceTier {
+  if (signals.isConventionRoute || signals.isDirectlyCalled) return 'expected';
+  if (signals.crossRepoConsumersVisible && signals.isStructuralDuplicate) return 'removable';
+  return 'likely';
+}
+
+/**
+ * Whether a route's file path or URL path matches any pack-declared
+ * `nonConsumerRoutePaths` convention substring (case-insensitive). Pure over the
+ * pattern union the caller passes (`allNonConsumerRoutePaths(flags)`), so the
+ * conventions stay pack-declared (Rule 6/8) and this function never holds a
+ * `webhook`/`cron`/`health` literal.
+ */
+export function matchesNonConsumerConvention(
+  filePath: string,
+  urlPath: string,
+  patterns: readonly string[],
+): boolean {
+  if (patterns.length === 0) return false;
+  const f = filePath.toLowerCase();
+  const u = urlPath.toLowerCase();
+  return patterns.some((p) => {
+    const needle = p.toLowerCase();
+    return f.includes(needle) || u.includes(needle);
+  });
+}
+
+/** Generic HTTP-verb handler names carry no identity — a route whose handler is
+ *  a bare verb can't be trusted to resolve via the direct-call seam (every
+ *  `GET`/`POST` in the codebase would match), so the caller treats such a
+ *  handler as "not directly resolvable" and lets the route stay uncertain
+ *  rather than falsely marking it consumed. Bias to false-negative on deadness
+ *  (never a false dead warning). */
+const GENERIC_HANDLER_NAMES: ReadonlySet<string> = new Set([
+  'get',
+  'post',
+  'put',
+  'patch',
+  'delete',
+  'head',
+  'options',
+  'handler', // arch-shape-ok: a generic HTTP-handler symbol name, not an architectural role label
+  'handle',
+  'default',
+  'index',
+]);
+
+/** Is this handler name specific enough to trust a direct-call-seam match? */
+export function isSpecificHandlerName(handler: string | null | undefined): boolean {
+  if (!handler) return false;
+  const h = handler.replace(/\(\)$/, '').toLowerCase();
+  const last = h.includes('.') ? (h.split('.').pop() ?? h) : h;
+  return last.length > 0 && !GENERIC_HANDLER_NAMES.has(last);
+}

--- a/src/analyzers/convergence/dead-surface.ts
+++ b/src/analyzers/convergence/dead-surface.ts
@@ -48,6 +48,15 @@ export interface DeadSurfaceSignals {
    *  independent seam signals agreeing is what earns the loud `removable` tier
    *  without a false-block. */
   readonly isStructuralDuplicate: boolean;
+  /** Whether this route's DEADNESS can be CONFIRMED — true only when the handler
+   *  is a specific symbol (a named method), so "no consumer" genuinely means
+   *  unreferenced. A bare HTTP-verb handler (`GET` / `POST`, as App-Router /
+   *  file-route handlers are exported) can be consumed by a server component or
+   *  framework WITHOUT a resolvable call, so its "unconsumed" is ambiguous — it
+   *  can never reach the loud `removable` tier (it stays `likely`). This is the
+   *  precision boundary the App-Router case surfaced: HTTP-unconsumed ≠ dead when
+   *  the framework consumes the route out of band. */
+  readonly deadnessConfirmable: boolean;
 }
 
 /**
@@ -68,7 +77,13 @@ export interface DeadSurfaceSignals {
  */
 export function deadSurfaceTier(signals: DeadSurfaceSignals): DeadSurfaceTier {
   if (signals.isConventionRoute || signals.isDirectlyCalled) return 'expected';
-  if (signals.crossRepoConsumersVisible && signals.isStructuralDuplicate) return 'removable';
+  if (
+    signals.crossRepoConsumersVisible &&
+    signals.isStructuralDuplicate &&
+    signals.deadnessConfirmable
+  ) {
+    return 'removable';
+  }
   return 'likely';
 }
 

--- a/src/analyzers/convergence/index.ts
+++ b/src/analyzers/convergence/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Seam convergence — the novel primitive. A PURE correlation over findings that
+ * already carry their own signal (Rule 2: this module re-detects NOTHING; it
+ * joins existing findings by a shared anchor). When two INDEPENDENT seam signals
+ * agree on the same code, the agreement is what turns each signal's characteristic
+ * noise into a ranked, near-certain result — precision by agreement.
+ *
+ * Phase 2 ships ONE convergence: a structural duplicate (`code-reimplementation`,
+ * the shipped gate) ∩ a dead surface (an unconsumed route whose deadness the
+ * confidence ladder confirmed). A route that is BOTH a copy-paste AND reaches
+ * nobody is the textbook "removable slop" an agent leaves behind — and unlike
+ * either signal alone, the pair is safe to surface loudly because two orthogonal
+ * analyses had to agree.
+ *
+ * This is a VISIBILITY correlation (a ranked view), not a gate finding — it
+ * carries no baseline identity (see the design's scoping refinement). The
+ * BLOCK-TIER promotion (convergence → a verdict) is post-3.7, gated on the
+ * validated cross-repo consumed-union.
+ */
+
+import type { DuplicateFinding } from '../../explore/duplication';
+import type { TieredDeadSurface } from './dead-surface-gather';
+
+/** One converged finding — a code location where ≥2 independent seam signals
+ *  agree. Phase 2: a dead route (tier `removable`) that is also a structural
+ *  duplicate. Carries both contributors so a renderer can name the story and
+ *  point at the twin. */
+export interface SeamConvergence {
+  readonly file: string;
+  readonly route: TieredDeadSurface['route'];
+  /** The structural-duplicate finding co-located in the same file (the twin +
+   *  the direction, reused from the shipped dup finding). */
+  readonly duplicate: DuplicateFinding;
+  /** The independent seam kinds that agreed here — sorted, so the set is a
+   *  stable description ("dead-surface" + "code-reimplementation"). */
+  readonly signals: readonly string[];
+}
+
+/**
+ * Correlate dead surfaces with structural duplicates by shared file. Only the
+ * `removable`-tier dead surfaces qualify — the ladder already confirmed their
+ * deadness (consumers visible, not a convention/direct-call route), so the
+ * convergence is a genuine agreement, not two uncertain signals stacked. Pure;
+ * deterministic ordering (by file, then route key).
+ */
+export function convergeSeams(
+  deadSurfaces: readonly TieredDeadSurface[],
+  dupFindings: readonly DuplicateFinding[],
+): SeamConvergence[] {
+  if (deadSurfaces.length === 0 || dupFindings.length === 0) return [];
+  // Index duplicates by each anchor's file → the finding, so a dead route in a
+  // duplicated file finds its twin.
+  const dupByFile = new Map<string, DuplicateFinding>();
+  for (const d of dupFindings) {
+    for (const a of d.anchors) {
+      if (!dupByFile.has(a.file)) dupByFile.set(a.file, d);
+    }
+  }
+  const out: SeamConvergence[] = [];
+  for (const s of deadSurfaces) {
+    if (s.tier !== 'removable') continue; // only ladder-confirmed dead converges
+    const dup = dupByFile.get(s.route.file);
+    if (!dup) continue;
+    out.push({
+      file: s.route.file,
+      route: s.route,
+      duplicate: dup,
+      signals: ['code-reimplementation', 'dead-surface'],
+    });
+  }
+  out.sort(
+    (a, b) =>
+      a.file.localeCompare(b.file) ||
+      `${a.route.method} ${a.route.path}`.localeCompare(`${b.route.method} ${b.route.path}`),
+  );
+  return out;
+}

--- a/src/analyzers/convergence/inventory.ts
+++ b/src/analyzers/convergence/inventory.ts
@@ -1,0 +1,108 @@
+/**
+ * The seam inventory — the ONE orchestration (Rule 2) that assembles every seam
+ * VISIBILITY signal for a repo: the structural duplicates, the tiered
+ * dead-surface list, and the convergence between them. Both `vyuh-dxkit flow`
+ * (the inventory surface) and `vyuh-dxkit evaluate` (the trial's visibility lane)
+ * consume this, so the "graphify → duplicates → dead surfaces → converge"
+ * sequence lives in exactly one place.
+ *
+ * Zero-write + fail-open: builds the code graph IN MEMORY, reads diagnoseFlow,
+ * writes nothing, and degrades to an empty inventory on any failure (a repo with
+ * no graph, no flow surface, or a broken tree never errors the caller).
+ */
+
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { gatherGraphifyGraph } from '../tools/graphify';
+import { duplicateFindingsFromGraph, type DuplicateFinding } from '../../explore/duplication';
+import { indexGraph, tryLoadGraph } from '../../explore/load';
+import type { Graph } from '../../explore/types';
+import { gatherDeadSurfaces, type DeadSurfaceResult } from './dead-surface-gather';
+import { convergeSeams, type SeamConvergence } from './index';
+
+/** Minimum structural-similarity for a duplicate to enter the inventory — the
+ *  anti-slop proof's precision floor for the graph-duplicate signal. */
+export const SEAM_DUP_MIN_SCORE = 0.75;
+
+export interface SeamInventory {
+  /** Structural duplicates the graph surfaced (score ≥ `SEAM_DUP_MIN_SCORE`). */
+  readonly duplicates: readonly DuplicateFinding[];
+  /** The tiered dead-surface result (removable / likely / expected + counts). */
+  readonly dead: DeadSurfaceResult;
+  /** The convergence: routes that are BOTH ladder-confirmed dead AND a
+   *  structural duplicate — the ranked "removable slop." */
+  readonly converged: readonly SeamConvergence[];
+}
+
+const EMPTY: SeamInventory = {
+  duplicates: [],
+  dead: {
+    surfaces: [],
+    crossRepoConsumersVisible: false,
+    byTier: { removable: 0, likely: 0, expected: 0 },
+  },
+  converged: [],
+};
+
+/**
+ * Gather the full seam inventory for a repo. `cwd` is the tree to analyze (a
+ * worktree at a ref, or the repo root). Never throws.
+ *
+ * Obtains ONE graph and uses it for both the duplicate pass AND the dead-surface
+ * direct-call seam, so the two signals agree. It REUSES a fresh on-disk
+ * `graph.json` (one whose `commitSha` matches the current HEAD) to skip a rebuild
+ * — the build is not cheap on a large repo (tens of seconds at ~50k+ symbols) —
+ * and only builds fresh when no fresh artifact is present (e.g. a git worktree at
+ * a ref, where evaluate always builds).
+ */
+export async function gatherSeamInventory(cwd: string): Promise<SeamInventory> {
+  try {
+    // Resolve to an ABSOLUTE path: graphify's subprocess resolves its target
+    // from its own working directory, so a relative `cwd` silently yields "no
+    // files found" (an empty graph → no duplicates → no convergence). Real CLI
+    // callers pass absolute paths, but normalizing here makes the inventory
+    // robust regardless of caller.
+    const root = path.resolve(cwd);
+    const graph = await obtainGraph(root);
+    if (!graph) {
+      const dead = await gatherDeadSurfaces(root, {});
+      return { duplicates: [], dead, converged: [] };
+    }
+    const duplicates = duplicateFindingsFromGraph(graph, { minScore: SEAM_DUP_MIN_SCORE });
+    const dead = await gatherDeadSurfaces(root, { dupFindings: duplicates, graph });
+    const converged = convergeSeams(dead.surfaces, duplicates);
+    return { duplicates, dead, converged };
+  } catch {
+    return EMPTY;
+  }
+}
+
+/**
+ * Obtain an indexed graph for `root` — reusing a FRESH on-disk `graph.json`
+ * (commitSha matches HEAD) to skip a rebuild, else building it in memory
+ * (zero-write). Returns undefined when graphify is unavailable / found no files.
+ */
+async function obtainGraph(root: string): Promise<Graph | undefined> {
+  const disk = tryLoadGraph(root);
+  if (disk && isFreshGraph(disk, root)) return disk;
+  const built = await gatherGraphifyGraph(root, { writeToDisk: false });
+  return built.kind === 'success' ? indexGraph(built.graph) : undefined;
+}
+
+/** Whether an on-disk graph was built at the current HEAD (so it reflects the
+ *  committed tree). Fail-safe: an unresolvable HEAD or an absent `commitSha`
+ *  reads as NOT fresh, so we rebuild rather than trust a stale artifact. */
+function isFreshGraph(graph: Graph, root: string): boolean {
+  const stamped = graph.meta.commitSha;
+  if (!stamped) return false;
+  try {
+    const head = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return head.length > 0 && head === stamped;
+  } catch {
+    return false;
+  }
+}

--- a/src/analyzers/flow/diagnose.ts
+++ b/src/analyzers/flow/diagnose.ts
@@ -12,12 +12,7 @@
  * (any error → `null`, and doctor simply omits the flow section).
  */
 
-import {
-  detectActiveLanguages,
-  allFlowSourceExtensions,
-  allPrimaryComponentPaths,
-} from '../../languages';
-import { detect } from '../../detect';
+import { detectActiveLanguages, allFlowSourceExtensions } from '../../languages';
 import { gatherRepoFlowModel } from './gather';
 import { hasOpaqueLeadingSegment, isPlaceholderOnlyPath, type FlowModel } from './model';
 import { readServedContract } from './contract';
@@ -179,6 +174,17 @@ function classifyUnresolved(
   };
 }
 
+/** File extensions that render UI by construction — a call site in one of these
+ *  is a frontend consumer. Not a role-path (Rule 8), an intrinsic file type. */
+const UI_COMPONENT_EXTENSIONS = ['.tsx', '.jsx', '.vue', '.svelte'];
+
+/** Whether a call-site file is a UI component (renders UI → a frontend
+ *  consumer), by its extension. */
+function isUiComponentFile(file: string): boolean {
+  const f = file.toLowerCase();
+  return UI_COMPONENT_EXTENSIONS.some((ext) => f.endsWith(ext));
+}
+
 function resolveConnection(cwd: string, model: FlowModel): { rung: ConnectionRung; note: string } {
   if (model.routes.length > 0) {
     return { rung: 'monorepo', note: 'This repo serves the routes its calls target.' };
@@ -247,19 +253,17 @@ export async function diagnoseFlow(cwd: string): Promise<FlowDiagnosis | null> {
       handler: r.handler,
     }));
 
-  // Frontend-consumer count: resolved calls whose SITE is a frontend component
-  // /page file (a pack-declared `primaryComponentPath`). A positive count means a
-  // co-located UI consumes this repo's routes — a full-stack monorepo whose
-  // consumers are visible, vs a backend making internal service calls (zero).
-  const componentPaths = allPrimaryComponentPaths(detect(cwd).languages);
-  const frontendConsumers =
-    componentPaths.length === 0
-      ? 0
-      : model.bindings.filter(
-          (b) =>
-            b.route !== null &&
-            componentPaths.some((p) => b.call.file.toLowerCase().includes(p.toLowerCase())),
-        ).length;
+  // Frontend-consumer count: resolved calls whose SITE is a UI-COMPONENT file —
+  // a file whose extension renders UI by construction (`.tsx` / `.jsx` / `.vue`
+  // / `.svelte`). A positive count means a co-located UI in THIS repo consumes
+  // its own routes — a full-stack monorepo whose consumers are visible — vs a
+  // backend making internal service-to-service calls (`.ts` / `.js` service
+  // files, count zero). Keyed on the UI-rendering extension rather than a role
+  // PATH because `primaryComponentPaths` mixes frontend (`/components/`) with
+  // backend (`/services/`), so a server call would falsely read as a UI consumer.
+  const frontendConsumers = model.bindings.filter(
+    (b) => b.route !== null && isUiComponentFile(b.call.file),
+  ).length;
 
   // Freshness disclosure for a committed contract — stale-but-declared beats
   // stale-and-silent. May probe participant tips (local rev-parse / bounded

--- a/src/analyzers/flow/diagnose.ts
+++ b/src/analyzers/flow/diagnose.ts
@@ -12,7 +12,12 @@
  * (any error → `null`, and doctor simply omits the flow section).
  */
 
-import { detectActiveLanguages, allFlowSourceExtensions } from '../../languages';
+import {
+  detectActiveLanguages,
+  allFlowSourceExtensions,
+  allPrimaryComponentPaths,
+} from '../../languages';
+import { detect } from '../../detect';
 import { gatherRepoFlowModel } from './gather';
 import { hasOpaqueLeadingSegment, isPlaceholderOnlyPath, type FlowModel } from './model';
 import { readServedContract } from './contract';
@@ -47,6 +52,11 @@ export interface UnconsumedRoute {
   readonly path: string;
   readonly file: string;
   readonly line: number;
+  /** The route's handler symbol (best-effort, may be null / a bare HTTP verb).
+   *  Carried so the dead-surface tier can check the direct-call seam — is this
+   *  handler invoked directly (RSC / server action) rather than over HTTP? —
+   *  without re-gathering the flow model. */
+  readonly handler: string | null;
 }
 
 /** Which rung of the connection-resolution ladder produced the served set. */
@@ -66,6 +76,15 @@ export interface FlowDiagnosis {
   /** Served routes with no consuming call (dead-route / cross-repo candidates). */
   readonly servedUnconsumed: readonly UnconsumedRoute[];
   readonly connection: { readonly rung: ConnectionRung; readonly note: string };
+  /** How many resolved client calls originate from a FRONTEND component/page
+   *  file (a `primaryComponentPath`). A positive count means this repo hosts a
+   *  co-located UI that consumes its own routes — a full-stack monorepo whose
+   *  route consumers are all in-repo and therefore VISIBLE, distinguishing it
+   *  from a backend that merely makes internal service-to-service HTTP calls
+   *  (which has zero frontend consumers). The dead-surface tier uses this to know
+   *  whether an unconsumed route's deadness can be trusted without a workspace
+   *  declaration. Pack-driven (component paths are `architecturalShape` data). */
+  readonly frontendConsumers: number;
   /** Freshness of the committed served contract, when one exists: when it was
    *  published, per-participant provenance, and whether a provider's tip has
    *  moved since (doctor may probe the network for this; the per-commit gate
@@ -220,7 +239,27 @@ export async function diagnoseFlow(cwd: string): Promise<FlowDiagnosis | null> {
   );
   const servedUnconsumed: UnconsumedRoute[] = model.routes
     .filter((r) => !consumedKeys.has(`${r.method} ${r.path}`) && !isPlaceholderOnlyPath(r.path))
-    .map((r) => ({ method: r.method, path: r.path, file: r.file, line: r.line }));
+    .map((r) => ({
+      method: r.method,
+      path: r.path,
+      file: r.file,
+      line: r.line,
+      handler: r.handler,
+    }));
+
+  // Frontend-consumer count: resolved calls whose SITE is a frontend component
+  // /page file (a pack-declared `primaryComponentPath`). A positive count means a
+  // co-located UI consumes this repo's routes — a full-stack monorepo whose
+  // consumers are visible, vs a backend making internal service calls (zero).
+  const componentPaths = allPrimaryComponentPaths(detect(cwd).languages);
+  const frontendConsumers =
+    componentPaths.length === 0
+      ? 0
+      : model.bindings.filter(
+          (b) =>
+            b.route !== null &&
+            componentPaths.some((p) => b.call.file.toLowerCase().includes(p.toLowerCase())),
+        ).length;
 
   // Freshness disclosure for a committed contract — stale-but-declared beats
   // stale-and-silent. May probe participant tips (local rev-parse / bounded
@@ -235,6 +274,7 @@ export async function diagnoseFlow(cwd: string): Promise<FlowDiagnosis | null> {
     unresolved,
     servedUnconsumed,
     connection: resolveConnection(cwd, model),
+    frontendConsumers,
     ...(contract ? { contract } : {}),
     coverage: flowCoverage(model),
   };

--- a/src/discovery/advisor.ts
+++ b/src/discovery/advisor.ts
@@ -13,6 +13,8 @@ import { execFileSync } from 'child_process';
 import { CONTRACT_SOURCE_READERS } from '../analyzers/flow/contract-sources';
 import { FLOW_CONFIG_SCHEMA_VERSION } from '../analyzers/flow/config';
 import { SCHEMA_CONFIG_SCHEMA_VERSION } from '../analyzers/model-schema/config';
+import { DUPLICATION_CONFIG_SCHEMA_VERSION } from '../analyzers/duplication/config';
+import { tryLoadGraph } from '../explore/load';
 import { isClaudeLoopInstalled } from '../loop/scaffold';
 import { LANGUAGES } from '../languages';
 import type {
@@ -172,6 +174,64 @@ export function recommendSchema(ctx: RecommendContext): Recommendation | null {
     reason:
       'detected a data-model framework but no schema gate — the gate blocks breaking model changes (field removed, type changed, required tightened) while a deliberate migration ships via an expiring allowlist entry',
     command: 'vyuh-dxkit schema',
+  };
+}
+
+/** Minimum call-graph density (calls-edges per function) at which the structural-
+ *  duplicate signal is reliable — the anti-slop proof's boundary: a dense
+ *  backend / CLI / library graph, not a thin framework-mediated frontend where
+ *  the detector honestly finds little. Below this the seam gate is not worth
+ *  proposing (it would surface nothing), so the probe stays silent. */
+const DUPLICATION_MIN_CALL_DENSITY = 0.8;
+
+/**
+ * One signal for the structural-duplicate (seam) gate, shared by the doctor
+ * probe (`recommendDuplication`) and the planner (`planDuplicationMode`) so the
+ * two never diverge (Rule 2). Fires only when (a) the repo has not configured
+ * `duplication` yet, AND (b) an existing code graph shows a call density high
+ * enough for the detector to work — evidence the gate would actually fire, not a
+ * blind proposal. A repo with no graph yet, or a thin frontend graph, is left
+ * alone (the seam gate needs a dense call graph to add value).
+ */
+function hasDuplicationSignal(cwd: string): boolean {
+  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json'));
+  if (policy && 'duplication' in policy) return false;
+  const graph = tryLoadGraph(cwd);
+  if (!graph) return false;
+  const fns = graph.nodes.filter((n) => n.kind === 'function' || n.kind === 'method').length;
+  if (fns === 0) return false;
+  const calls = graph.edges.filter((e) => e.relation === 'calls').length;
+  return calls / fns >= DUPLICATION_MIN_CALL_DENSITY;
+}
+
+/**
+ * Structural-duplicate (seam) gate: on a repo with a dense-enough call graph and
+ * no duplication config, seed the safe default posture — `warn` (surface the
+ * copy-paste the call graph catches, never fail a build). Reuses
+ * `hasDuplicationSignal` (shared with the doctor probe, Rule 2).
+ */
+export function planDuplicationMode(ctx: ConfigContext): ConfigPlanItem | null {
+  if (!hasDuplicationSignal(ctx.cwd)) return null;
+  return {
+    capability: 'quality',
+    section: 'duplication.mode',
+    summary: 'warn',
+    patch: { duplication: { mode: 'warn', schemaVersion: DUPLICATION_CONFIG_SCHEMA_VERSION } },
+    reason:
+      'seed the structural-duplicate (seam) gate at the safe default (warn, never fails a build) — it flags a net-new function that copy-pastes another',
+    evidence:
+      'a dense call graph where the duplicate signal is reliable, no duplication config yet',
+  };
+}
+
+/** Recommend the seam gate on a repo whose call graph is dense enough for the
+ *  structural-duplicate signal to work, and no duplication config. */
+export function recommendDuplication(ctx: RecommendContext): Recommendation | null {
+  if (!hasDuplicationSignal(ctx.cwd)) return null;
+  return {
+    reason:
+      'a dense call graph but no structural-duplicate (seam) gate — it catches a net-new function that copy-pastes another (the call graph sees it through rename/reformat, unlike token duplication), and pairs with the dead-surface inventory in `flow`',
+    command: 'vyuh-dxkit quality',
   };
 }
 

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -12,9 +12,11 @@ import {
   recommendFlow,
   recommendSchema,
   recommendChecks,
+  recommendDuplication,
   planBaselineMode,
   planFlowMode,
   planSchemaMode,
+  planDuplicationMode,
   planLintGate,
   planLoopPreset,
   recommendExtensions,
@@ -204,7 +206,13 @@ export const COMMANDS = [
     summary: 'Code quality + slop detection',
     typicalRuntime: '1-8 min (jscpd is the long-pole)',
     docsBlurb:
-      'Duplication, complexity, and AI-slop signals rolled into the Code Quality dimension.',
+      'Duplication, complexity, and AI-slop signals rolled into the Code Quality dimension. ' +
+      'The opt-in structural-duplicate (seam) gate (`duplication.mode`) additionally flags a ' +
+      'net-new function that copy-pastes another — read from the call graph, so it survives ' +
+      'rename/reformat where token duplication does not.',
+    skill: 'dxkit-action',
+    whenToRecommend: recommendDuplication,
+    planConfig: planDuplicationMode,
   },
   {
     id: 'dev-report',
@@ -396,9 +404,11 @@ export const COMMANDS = [
     typicalRuntime: '5-30 sec',
     docsBlurb:
       'Map client calls to served endpoints and gate changes that break a UI→API contract across ' +
-      'repos. `flow publish --land` refreshes + lands the committed contract snapshots (the ' +
-      'on-merge refresh workflow runs it; `pr` opens one standing reviewable PR, `push` commits ' +
-      'directly on unprotected trunks).',
+      'repos. `flow` also surfaces the tiered dead-surface inventory — served routes with no ' +
+      'consumer, classified removable / likely / expected, plus the seam-convergence callout (a ' +
+      'route that is BOTH unconsumed AND a structural duplicate). `flow publish --land` refreshes ' +
+      '+ lands the committed contract snapshots (the on-merge refresh workflow runs it; `pr` opens ' +
+      'one standing reviewable PR, `push` commits directly on unprotected trunks).',
     skill: 'dxkit-flow',
     whenToRecommend: recommendFlow,
     planConfig: planFlowMode,

--- a/src/evaluate/evidence.ts
+++ b/src/evaluate/evidence.ts
@@ -100,6 +100,39 @@ export interface EvaluateEvidenceDoc extends EvidenceEnvelope {
    *  itself wherever possible, static facts otherwise. Answers "the gate
    *  would have blocked X, but at what price?" */
   readonly costs: EvaluateCosts;
+  /** The seam VISIBILITY lane — what dxkit SEES in the repo right now, computed
+   *  once on the trial head, INDEPENDENT of the gate verdict. Surfaces the
+   *  structural-duplicate + dead-surface + convergence signals so the trial shows
+   *  dxkit's differentiator even on a repo that hasn't enabled those gates.
+   *  Absent when the head could not be analyzed (fail-open). */
+  readonly seams?: SeamVisibility;
+}
+
+/** The seam-visibility summary attached to an evaluate doc. Counts + the ranked
+ *  convergence, kept compact (the full per-route inventory lives in `flow`). */
+export interface SeamVisibility {
+  /** Structural duplicates the graph surfaced at the trial head. */
+  readonly duplicates: number;
+  /** Dead-surface counts by tier. */
+  readonly dead: { readonly removable: number; readonly likely: number; readonly expected: number };
+  /** Whether every route consumer was visible (an explicit mesh or co-located
+   *  UI) — when false, the `removable` tier is suppressed and deadness is
+   *  unconfirmed cross-repo. */
+  readonly crossRepoConsumersVisible: boolean;
+  /** The ranked "removable slop": routes that are BOTH dead AND a copy-paste,
+   *  each with the duplicate twin's symbols. The highest-confidence seam signal. */
+  readonly converged: ReadonlyArray<{
+    readonly method: string;
+    readonly path: string;
+    readonly file: string;
+    readonly twin: ReadonlyArray<string>;
+  }>;
+  /** A few top structural duplicates (score-ranked) for the visibility lane. */
+  readonly topDuplicates: ReadonlyArray<{
+    readonly a: string;
+    readonly b: string;
+    readonly score: number;
+  }>;
 }
 
 /**
@@ -271,6 +304,9 @@ export function buildEvidenceDoc(input: {
   readonly incremental: boolean;
   readonly untrusted: boolean;
   readonly runs: ReadonlyArray<EvaluateRunEvidence>;
+  /** The seam-visibility summary for the trial head (optional — absent when the
+   *  head could not be analyzed). */
+  readonly seams?: SeamVisibility;
 }): EvaluateEvidenceDoc {
   const evaluated = input.runs.filter((r) => !r.error);
   const blocked = evaluated.filter((r) => r.verdict.blocks).length;
@@ -314,5 +350,44 @@ export function buildEvidenceDoc(input: {
     },
     notes,
     costs: buildCosts(input.runs),
+    ...(input.seams ? { seams: input.seams } : {}),
+  };
+}
+
+/** Project a gathered `SeamInventory` to the compact `SeamVisibility` summary the
+ *  evidence doc carries. Pure. */
+export function seamVisibilityFrom(inv: {
+  duplicates: ReadonlyArray<{
+    anchors: readonly [{ file: string; symbol: string }, { file: string; symbol: string }];
+    score: number;
+  }>;
+  dead: {
+    crossRepoConsumersVisible: boolean;
+    byTier: { removable: number; likely: number; expected: number };
+  };
+  converged: ReadonlyArray<{
+    route: { method: string; path: string; file: string };
+    duplicate: { anchors: readonly [{ symbol: string }, { symbol: string }] };
+  }>;
+}): SeamVisibility {
+  const anchorLabel = (a: { file: string; symbol: string }) => `${a.symbol} @ ${a.file}`;
+  return {
+    duplicates: inv.duplicates.length,
+    dead: inv.dead.byTier,
+    crossRepoConsumersVisible: inv.dead.crossRepoConsumersVisible,
+    converged: inv.converged.map((c) => ({
+      method: c.route.method,
+      path: c.route.path,
+      file: c.route.file,
+      twin: c.duplicate.anchors.map((a) => a.symbol),
+    })),
+    topDuplicates: [...inv.duplicates]
+      .sort((x, y) => y.score - x.score)
+      .slice(0, 5)
+      .map((d) => ({
+        a: anchorLabel(d.anchors[0]),
+        b: anchorLabel(d.anchors[1]),
+        score: d.score,
+      })),
   };
 }

--- a/src/evaluate/render.ts
+++ b/src/evaluate/render.ts
@@ -137,6 +137,45 @@ function nextSteps(doc: EvaluateEvidenceDoc): string[] {
 }
 
 /** The full text report. */
+/**
+ * The seam-visibility lane — what dxkit SEES in the repo (structural duplicates,
+ * dead surfaces, and the convergence between them), shown INDEPENDENT of the
+ * gate verdict. This is where the trial demonstrates dxkit's differentiator even
+ * on a repo that hasn't enabled the seam gates. Silent when nothing was seen.
+ */
+function seamsSection(doc: EvaluateEvidenceDoc): string[] {
+  const s = doc.seams;
+  if (!s) return [];
+  const deadTotal = s.dead.removable + s.dead.likely + s.dead.expected;
+  if (s.duplicates === 0 && deadTotal === 0) return [];
+  const lines: string[] = ['What dxkit sees beyond the gate (seam signals):'];
+  if (s.duplicates > 0) {
+    lines.push(`  ${s.duplicates} structural duplicate(s) — copy-paste the call graph caught:`);
+    for (const d of s.topDuplicates.slice(0, 3)) {
+      lines.push(`    ${d.a}  ≈  ${d.b}  (similarity ${d.score.toFixed(2)})`);
+    }
+  }
+  if (deadTotal > 0) {
+    lines.push(
+      `  ${deadTotal} served-but-unconsumed route(s) — ` +
+        `${s.dead.removable} removable, ${s.dead.likely} likely, ${s.dead.expected} expected` +
+        (s.crossRepoConsumersVisible
+          ? ''
+          : ' (cross-repo consumers unverified — declare workspace.json to confirm deadness)'),
+    );
+  }
+  if (s.converged.length > 0) {
+    lines.push(
+      `  ⛔ ${s.converged.length} converged — a route that is BOTH unconsumed AND a copy-paste (remove or consolidate):`,
+    );
+    for (const c of s.converged.slice(0, 5)) {
+      lines.push(`    ${c.method} ${c.path}  (twin: ${c.twin.join(' ≈ ')})`);
+    }
+  }
+  lines.push('  Run `vyuh-dxkit flow` for the full tiered inventory.');
+  return lines;
+}
+
 export function renderEvaluateText(doc: EvaluateEvidenceDoc): string {
   const sections: string[][] = [];
   sections.push([headline(doc)]);
@@ -146,6 +185,8 @@ export function renderEvaluateText(doc: EvaluateEvidenceDoc): string {
     if (framing.length) sections.push(framing);
   }
   sections.push(watchedSection(doc));
+  const seams = seamsSection(doc);
+  if (seams.length) sections.push(seams);
   sections.push(costsSection(doc));
   if (doc.notes.length) sections.push(['Notes:', ...doc.notes.map((n) => `  ${n}`)]);
   sections.push(nextSteps(doc));

--- a/src/evaluate/run.ts
+++ b/src/evaluate/run.ts
@@ -31,11 +31,14 @@ import {
   buildErrorEvidence,
   buildEvidenceDoc,
   buildRunEvidence,
+  seamVisibilityFrom,
   type EvaluateEvidenceDoc,
   type EvaluateRunEvidence,
+  type SeamVisibility,
   runLabel,
 } from './evidence';
 import { enumerateLandings, type LandingPair } from './pr-ranges';
+import { gatherSeamInventory } from '../analyzers/convergence/inventory';
 
 export interface EvaluateOptions {
   readonly cwd: string;
@@ -181,6 +184,14 @@ export async function runEvaluate(opts: EvaluateOptions): Promise<EvaluateEviden
     }
   }
 
+  // The seam VISIBILITY lane — what dxkit SEES at the trial head, computed ONCE
+  // (independent of the gate verdict + gate config), so the trial demonstrates
+  // the duplicate + dead-surface + convergence differentiator even on a repo
+  // that has not enabled those gates. Runs in a disposable worktree at the head
+  // (zero-write, the same spine as the per-landing checks); fail-open — a head
+  // that can't be analyzed simply omits the lane.
+  const seams = await gatherTrialSeams(cwd, pairs[0]?.pair.headSha);
+
   return buildEvidenceDoc({
     branch: currentBranch(cwd),
     ref: trialRef,
@@ -190,5 +201,23 @@ export async function runEvaluate(opts: EvaluateOptions): Promise<EvaluateEviden
     incremental,
     untrusted,
     runs,
+    ...(seams ? { seams } : {}),
   });
+}
+
+/** Gather the seam-visibility summary at the trial head, in a disposable
+ *  worktree (zero-write). Returns undefined on any failure (fail-open) so the
+ *  visibility lane never breaks the trial. */
+async function gatherTrialSeams(
+  cwd: string,
+  headSha: string | undefined,
+): Promise<SeamVisibility | undefined> {
+  if (!headSha) return undefined;
+  try {
+    return await withRefWorktree({ cwd, ref: headSha }, async (wt) =>
+      seamVisibilityFrom(await gatherSeamInventory(wt)),
+    );
+  } catch {
+    return undefined;
+  }
 }

--- a/src/explore/duplication.ts
+++ b/src/explore/duplication.ts
@@ -12,7 +12,7 @@
  * gate, `evaluate`, the dashboard) gets identity-stamped findings from ONE path.
  */
 
-import type { GraphJson } from './types';
+import type { Graph, GraphJson } from './types';
 import { indexGraph } from './load';
 import { duplicatePairsQuery, type DuplicatePairsOpts } from './queries';
 import { computeCodeReimplementationFingerprint } from '../analyzers/tools/fingerprint';
@@ -55,7 +55,19 @@ export function duplicateFindingsFromJson(
   json: GraphJson,
   opts: DuplicatePairsOpts = {},
 ): DuplicateFinding[] {
-  const graph = indexGraph(json);
+  return duplicateFindingsFromGraph(indexGraph(json), opts);
+}
+
+/**
+ * Compute structural-duplicate findings from an ALREADY-INDEXED `Graph` — the
+ * sibling of {@link duplicateFindingsFromJson} for a caller that already holds an
+ * indexed graph (e.g. one loaded from a fresh on-disk `graph.json` via
+ * `loadGraph`), so it need not re-index. Pure.
+ */
+export function duplicateFindingsFromGraph(
+  graph: Graph,
+  opts: DuplicatePairsOpts = {},
+): DuplicateFinding[] {
   const pairs = duplicatePairsQuery(graph, opts);
   return pairs.map((p) => {
     const a = anchorOf(p.a);

--- a/src/explore/queries.ts
+++ b/src/explore/queries.ts
@@ -1582,6 +1582,38 @@ export function flowMapQuery(graph: Graph): FlowMap {
   };
 }
 
+/**
+ * The set of function/method symbol NAMES that are the target of at least one
+ * `calls` edge — i.e. every symbol invoked directly somewhere in the graph.
+ * Names are the label with the trailing `()` stripped and any `receiver.`
+ * qualifier dropped (`data.getDivisions()` → `getDivisions`), the same
+ * normalization the flow overlay uses to name a consumer symbol.
+ *
+ * The DIRECT-CALL seam (Rule 12): flow's HTTP model sees only `fetch`-style
+ * consumption, so on a server-rendered stack (Next.js App Router, Remix
+ * loaders, SvelteKit) where a page calls its data layer DIRECTLY
+ * (`await getDivisions()`) rather than over HTTP, flow reads the route as
+ * "unconsumed" when the data IS consumed. Intersecting a route's handler symbol
+ * with this set lets the dead-surface analyzer recognize that direct-call
+ * consumption and NOT flag the route as dead.
+ *
+ * Honest limit (bias to FALSE-NEGATIVE — safe for a warn-tier signal): a
+ * generic handler name (`GET`, `POST`, `handler`) collides across the codebase,
+ * so a route whose handler is a bare HTTP verb may match spuriously and be
+ * treated as consumed. That errs toward NOT flagging a dead route, never toward
+ * a false dead-surface warning — the correct direction for precision. The
+ * caller decides whether a handler name is specific enough to trust.
+ */
+export function calledSymbolNames(graph: Graph): ReadonlySet<string> {
+  const names = new Set<string>();
+  for (const e of graph.edges) {
+    if (e.relation !== 'calls') continue;
+    const target = graph.nodeById.get(e.to);
+    if (target) names.add(stripParens(target.label));
+  }
+  return names;
+}
+
 function roleLabel(community: Community | undefined): string {
   if (!community) return 'unclustered';
   if (community.dominantSourceDir) return community.dominantSourceDir;

--- a/src/flow-cli.ts
+++ b/src/flow-cli.ts
@@ -20,6 +20,13 @@ import {
 } from './analyzers/flow/console';
 import { computeChangedFiles } from './baseline/changed-files';
 import { evaluateFlowGateForGuardrail } from './baseline/flow-gate-check';
+import {
+  gatherDeadSurfaces,
+  type TieredDeadSurface,
+} from './analyzers/convergence/dead-surface-gather';
+import { convergeSeams } from './analyzers/convergence';
+import { gatherGraphifyGraph } from './analyzers/tools/graphify';
+import { duplicateFindingsFromJson } from './explore/duplication';
 import { loadAllowlist } from './allowlist/file';
 import { readVisNetworkBundle } from './dashboard/vendor';
 import { readDxkitVersion } from './issue-cli';
@@ -137,8 +144,34 @@ export async function runFlowMap(opts: FlowViewOptions): Promise<void> {
   const model = await gatherModel(opts);
   const map = buildFlowMap(opts.cwd, model);
 
+  // The tiered dead-surface inventory + convergence — the honest confidence
+  // ladder over served-but-unconsumed routes. Zero-write; gathered once and
+  // shared by the console + JSON surfaces.
+  const dead = await gatherDeadInventory(opts.cwd);
+
   if (opts.json) {
-    emitJson(map);
+    emitJson({
+      ...map,
+      deadSurfaces: {
+        crossRepoConsumersVisible: dead.result.crossRepoConsumersVisible,
+        byTier: dead.result.byTier,
+        surfaces: dead.result.surfaces.map((s) => ({
+          method: s.route.method,
+          path: s.route.path,
+          file: s.route.file,
+          tier: s.tier,
+          reason: s.reason,
+          convergesWithDuplicate: s.convergesWithDuplicate,
+        })),
+        converged: dead.converged.map((c) => ({
+          method: c.route.method,
+          path: c.route.path,
+          file: c.file,
+          signals: c.signals,
+          duplicate: c.duplicate.anchors.map((a) => ({ file: a.file, symbol: a.symbol })),
+        })),
+      },
+    });
     return;
   }
 
@@ -154,18 +187,82 @@ export async function runFlowMap(opts: FlowViewOptions): Promise<void> {
       logger.info(`  ${row.endpoint.label}  ← ${row.consumerCount} call(s): ${files}${more}`);
     }
   }
-  if (map.unconsumedEndpoints.length) {
-    logger.info('');
-    logger.info('Served but unconsumed (dead route or cross-repo consumer):');
-    for (const ep of map.unconsumedEndpoints.slice(0, 20)) {
-      logger.info(`  ${ep.label}`);
-    }
-    if (map.unconsumedEndpoints.length > 20) {
-      logger.info(`  … and ${map.unconsumedEndpoints.length - 20} more`);
-    }
-  }
+  // The tiered dead-surface inventory — the honest confidence ladder replacing
+  // the old flat "dead route or cross-repo consumer" list.
+  renderDeadSurfaceInventory(dead);
+
   logger.info('');
   logger.info('Trace one: vyuh-dxkit flow trace "<METHOD> <path>"');
+}
+
+/** One-line locator for a tiered dead surface. */
+function deadSurfaceLine(s: TieredDeadSurface): string {
+  const loc = s.route.file ? `  @ ${s.route.file}` : '';
+  return `  ${s.route.method} ${s.route.path}${loc}`;
+}
+
+/** Gather the tiered dead-surface inventory + convergence for a repo. Fail-open,
+ *  zero-write: reads diagnoseFlow + the graph in memory. The dup findings power
+ *  both the convergence callout and each surface's `convergesWithDuplicate`. */
+async function gatherDeadInventory(cwd: string): Promise<{
+  result: Awaited<ReturnType<typeof gatherDeadSurfaces>>;
+  converged: ReturnType<typeof convergeSeams>;
+}> {
+  const graph = await gatherGraphifyGraph(cwd, { writeToDisk: false });
+  const dupFindings =
+    graph.kind === 'success' ? duplicateFindingsFromJson(graph.graph, { minScore: 0.75 }) : [];
+  const result = await gatherDeadSurfaces(cwd, { dupFindings });
+  const converged = convergeSeams(result.surfaces, dupFindings);
+  return { result, converged };
+}
+
+/**
+ * Render the tiered dead-surface inventory + the seam-convergence callout to the
+ * console. Silent when there are no unconsumed routes.
+ */
+function renderDeadSurfaceInventory(dead: {
+  result: Awaited<ReturnType<typeof gatherDeadSurfaces>>;
+  converged: ReturnType<typeof convergeSeams>;
+}): void {
+  const res = dead.result;
+  if (res.surfaces.length === 0) return;
+  const converged = dead.converged;
+
+  const removable = res.surfaces.filter((s) => s.tier === 'removable');
+  const likely = res.surfaces.filter((s) => s.tier === 'likely');
+  const expected = res.surfaces.filter((s) => s.tier === 'expected');
+
+  logger.info('');
+  logger.info(
+    `Served but unconsumed — ${res.surfaces.length} route(s), by confidence` +
+      (res.crossRepoConsumersVisible
+        ? ''
+        : ' (cross-repo consumers unverified — declare workspace.json to confirm deadness)'),
+  );
+  if (removable.length) {
+    logger.info(`  removable (${removable.length}) — dead AND a structural duplicate:`);
+    for (const s of removable.slice(0, 20)) logger.info(deadSurfaceLine(s));
+  }
+  if (likely.length) {
+    logger.info(`  likely dead (${likely.length}) — no in-repo consumer:`);
+    for (const s of likely.slice(0, 12)) logger.info(deadSurfaceLine(s));
+    if (likely.length > 12) logger.info(`    … and ${likely.length - 12} more`);
+  }
+  if (expected.length) {
+    logger.info(
+      `  expected (${expected.length}) — webhook / cron / health / CLI / direct-call (no consumer is normal)`,
+    );
+  }
+  if (converged.length) {
+    logger.info('');
+    logger.info(
+      `⛔ ${converged.length} converged: a served route that is BOTH unconsumed AND a copy-paste — remove or consolidate:`,
+    );
+    for (const c of converged.slice(0, 10)) {
+      const twin = c.duplicate.anchors.map((a) => a.file).join(' ≈ ');
+      logger.info(`  ${c.route.method} ${c.route.path}  (duplicate: ${twin})`);
+    }
+  }
 }
 
 /**

--- a/src/flow-cli.ts
+++ b/src/flow-cli.ts
@@ -20,13 +20,8 @@ import {
 } from './analyzers/flow/console';
 import { computeChangedFiles } from './baseline/changed-files';
 import { evaluateFlowGateForGuardrail } from './baseline/flow-gate-check';
-import {
-  gatherDeadSurfaces,
-  type TieredDeadSurface,
-} from './analyzers/convergence/dead-surface-gather';
-import { convergeSeams } from './analyzers/convergence';
-import { gatherGraphifyGraph } from './analyzers/tools/graphify';
-import { duplicateFindingsFromJson } from './explore/duplication';
+import { type TieredDeadSurface } from './analyzers/convergence/dead-surface-gather';
+import { gatherSeamInventory, type SeamInventory } from './analyzers/convergence/inventory';
 import { loadAllowlist } from './allowlist/file';
 import { readVisNetworkBundle } from './dashboard/vendor';
 import { readDxkitVersion } from './issue-cli';
@@ -145,17 +140,18 @@ export async function runFlowMap(opts: FlowViewOptions): Promise<void> {
   const map = buildFlowMap(opts.cwd, model);
 
   // The tiered dead-surface inventory + convergence — the honest confidence
-  // ladder over served-but-unconsumed routes. Zero-write; gathered once and
-  // shared by the console + JSON surfaces.
-  const dead = await gatherDeadInventory(opts.cwd);
+  // ladder over served-but-unconsumed routes. Zero-write; gathered once (the ONE
+  // seam-inventory orchestration, shared with `evaluate`) and used by both the
+  // console + JSON surfaces.
+  const inv = await gatherSeamInventory(opts.cwd);
 
   if (opts.json) {
     emitJson({
       ...map,
       deadSurfaces: {
-        crossRepoConsumersVisible: dead.result.crossRepoConsumersVisible,
-        byTier: dead.result.byTier,
-        surfaces: dead.result.surfaces.map((s) => ({
+        crossRepoConsumersVisible: inv.dead.crossRepoConsumersVisible,
+        byTier: inv.dead.byTier,
+        surfaces: inv.dead.surfaces.map((s) => ({
           method: s.route.method,
           path: s.route.path,
           file: s.route.file,
@@ -163,7 +159,7 @@ export async function runFlowMap(opts: FlowViewOptions): Promise<void> {
           reason: s.reason,
           convergesWithDuplicate: s.convergesWithDuplicate,
         })),
-        converged: dead.converged.map((c) => ({
+        converged: inv.converged.map((c) => ({
           method: c.route.method,
           path: c.route.path,
           file: c.file,
@@ -189,7 +185,7 @@ export async function runFlowMap(opts: FlowViewOptions): Promise<void> {
   }
   // The tiered dead-surface inventory — the honest confidence ladder replacing
   // the old flat "dead route or cross-repo consumer" list.
-  renderDeadSurfaceInventory(dead);
+  renderDeadSurfaceInventory(inv);
 
   logger.info('');
   logger.info('Trace one: vyuh-dxkit flow trace "<METHOD> <path>"');
@@ -201,32 +197,14 @@ function deadSurfaceLine(s: TieredDeadSurface): string {
   return `  ${s.route.method} ${s.route.path}${loc}`;
 }
 
-/** Gather the tiered dead-surface inventory + convergence for a repo. Fail-open,
- *  zero-write: reads diagnoseFlow + the graph in memory. The dup findings power
- *  both the convergence callout and each surface's `convergesWithDuplicate`. */
-async function gatherDeadInventory(cwd: string): Promise<{
-  result: Awaited<ReturnType<typeof gatherDeadSurfaces>>;
-  converged: ReturnType<typeof convergeSeams>;
-}> {
-  const graph = await gatherGraphifyGraph(cwd, { writeToDisk: false });
-  const dupFindings =
-    graph.kind === 'success' ? duplicateFindingsFromJson(graph.graph, { minScore: 0.75 }) : [];
-  const result = await gatherDeadSurfaces(cwd, { dupFindings });
-  const converged = convergeSeams(result.surfaces, dupFindings);
-  return { result, converged };
-}
-
 /**
  * Render the tiered dead-surface inventory + the seam-convergence callout to the
  * console. Silent when there are no unconsumed routes.
  */
-function renderDeadSurfaceInventory(dead: {
-  result: Awaited<ReturnType<typeof gatherDeadSurfaces>>;
-  converged: ReturnType<typeof convergeSeams>;
-}): void {
-  const res = dead.result;
+function renderDeadSurfaceInventory(inv: SeamInventory): void {
+  const res = inv.dead;
   if (res.surfaces.length === 0) return;
-  const converged = dead.converged;
+  const converged = inv.converged;
 
   const removable = res.surfaces.filter((s) => s.tier === 'removable');
   const likely = res.surfaces.filter((s) => s.tier === 'likely');

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -415,6 +415,25 @@ export function allRoutePaths(flags: DetectedStack['languages']): string[] {
 }
 
 /**
+ * Union of every active pack's `architecturalShape.nonConsumerRoutePaths`,
+ * deduplicated — the routes whose consumer is an external actor
+ * (webhook / cron / health / public-API / CLI), so a "no in-repo consumer"
+ * reading is EXPECTED, not dead-surface slop. Consumed by the dead-surface
+ * analyzer to drop a matching route to the "expected" tier. Pack-driven
+ * (Rule 6/8): a new framework declares its convention shapes and inherits the
+ * filter, and the arch-check keeps the literals out of analyzers.
+ */
+export function allNonConsumerRoutePaths(flags: DetectedStack['languages']): string[] {
+  return [
+    ...new Set(
+      activeLanguagesFromFlags(flags).flatMap(
+        (l) => l.architecturalShape?.nonConsumerRoutePaths ?? [],
+      ),
+    ),
+  ];
+}
+
+/**
  * Union of every active pack's `architecturalShape.modelPaths`,
  * deduplicated. Consumed by `gatherGenericMetrics` to populate
  * `HealthMetrics.models` (the "data model files" count surfaced in

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1239,6 +1239,22 @@ export const python: LanguageSupport = {
       high: ['/views/', '/services/', '/handlers/', '/tasks/'],
       medium: ['/viewsets/', '/routers/', '/api/', '/serializers/'],
     },
+    // Routes driven by an external actor (webhook/cron/health/CLI), so "no
+    // in-repo consumer" is expected — the dead-surface analyzer dims these
+    // rather than flagging them. Substrings of the route file path OR URL path
+    // (Rule 6/8, pack-declared). Bias to false-negative — generous patterns.
+    nonConsumerRoutePaths: [
+      '/webhook',
+      '/callback',
+      '/cron/',
+      '/tasks/', // Celery/RQ task endpoints, triggered out-of-band
+      '/health',
+      '/healthz',
+      '/readiness',
+      '/liveness',
+      '/metrics',
+      '/.well-known/',
+    ],
   },
 
   // HTTP flow (CLAUDE.md Rule 6): how Python source expresses outbound HTTP

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -138,6 +138,27 @@ export interface ArchitecturalShape {
     high?: string[];
     medium?: string[];
   };
+
+  /**
+   * Path patterns for routes whose consumer is an EXTERNAL ACTOR, not
+   * in-repo code — a webhook (Stripe/Clerk/GitHub calls it), a cron
+   * trigger, a health/liveness probe, a public API for third parties, a
+   * CLI entry point. A served route matching one of these is EXPECTED to
+   * have no in-repo consumer, so the dead-surface analyzer drops it to
+   * the "expected" tier (never flags it as removable slop).
+   *
+   * This is the ONE place the cron/webhook/health false-positive class is
+   * killed — declaratively, per pack (Rule 6/8), never a hardcoded
+   * `cron|webhook|health` literal in an analyzer (the arch-check bans
+   * those). Consumed via `allNonConsumerRoutePaths(flags)`.
+   *
+   * Case-insensitive substrings of the route file's relative POSIX path
+   * OR the route's URL path (both are checked), same convention as
+   * `primaryComponentPaths`. Bias toward false-NEGATIVE: it is safer to
+   * dim a genuinely-dead webhook-shaped route than to loudly flag a real
+   * webhook, so keep these patterns generous.
+   */
+  nonConsumerRoutePaths?: string[];
 }
 
 /**

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1792,6 +1792,25 @@ export const typescript: LanguageSupport = {
         '/screens/',
       ],
     },
+    // Routes driven by an EXTERNAL actor, not in-repo code — so "no in-repo
+    // consumer" is expected, never dead-surface slop. Substrings of the route
+    // file path OR the URL path. Generous by design (bias to false-negative):
+    // it is safer to dim a genuinely-dead webhook-shaped route than to loudly
+    // flag a real webhook. Covers the common Next.js / Nest / Express shapes.
+    nonConsumerRoutePaths: [
+      '/webhook', // matches /webhook and /webhooks/... (inbound stripe/clerk/github)
+      '/callback', // OAuth / inbound provider callbacks
+      '/cron/',
+      '/scheduled/',
+      '/health',
+      '/healthz',
+      '/livez',
+      '/readyz',
+      '/metrics',
+      '/.well-known/',
+      '/public-api/',
+      '/cli/', // CLI-facing endpoints driven by an external CLI, not the app UI
+    ],
   },
 
   // HTTP flow (CLAUDE.md Rule 6): how TS/JS source expresses outbound HTTP

--- a/test/analyzers/convergence/converge.test.ts
+++ b/test/analyzers/convergence/converge.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { tierDeadSurfaces } from '../../../src/analyzers/convergence/dead-surface-gather';
+import { convergeSeams } from '../../../src/analyzers/convergence/index';
+import type { UnconsumedRoute } from '../../../src/analyzers/flow/diagnose';
+import type { DuplicateFinding } from '../../../src/explore/duplication';
+
+/**
+ * The pure join layer of phase 2 — `tierDeadSurfaces` (route + signals → tiers)
+ * and `convergeSeams` (dead ∩ duplicate). Tested deterministically so the
+ * convergence firing is proven independent of graphify + the flow extractor
+ * (the real pipeline's no-false-positive behavior is covered by the real-repo
+ * stress pass). The file join is the load-bearing part — a real multi-project
+ * repo caught a relative-vs-absolute mismatch that silently zeroed it, so these
+ * assert both sides meet on the same key.
+ */
+
+function route(
+  method: string,
+  path: string,
+  file: string,
+  handler: string | null = null,
+): UnconsumedRoute {
+  return { method, path, file, line: 1, handler };
+}
+
+function dup(fileA: string, fileB: string): DuplicateFinding {
+  return {
+    id: 'deadbeefdeadbeef',
+    anchors: [
+      { file: fileA, symbol: 'listTeamsLegacy', line: 10 },
+      { file: fileB, symbol: 'listTeams', line: 4 },
+    ],
+    score: 0.95,
+  };
+}
+
+describe('tierDeadSurfaces — signal → tier over real route shapes', () => {
+  const conventionPatterns = ['/webhook', '/cli/'];
+
+  it('a convention route lands expected', () => {
+    const surfaces = tierDeadSurfaces(
+      [route('POST', '/webhook/stripe', 'src/api/stripe/route.ts')],
+      {
+        crossRepoConsumersVisible: true,
+        calledSymbols: new Set(),
+        conventionPatterns,
+        duplicateFiles: new Set(),
+      },
+    );
+    expect(surfaces[0].tier).toBe('expected');
+    expect(surfaces[0].reason).toBe('convention');
+  });
+
+  it('a direct-called route (specific handler in the call graph) lands expected', () => {
+    const surfaces = tierDeadSurfaces(
+      [route('GET', '/divisions', 'src/api/divisions.ts', 'getDivisions')],
+      {
+        crossRepoConsumersVisible: true,
+        calledSymbols: new Set(['getDivisions']),
+        conventionPatterns,
+        duplicateFiles: new Set(),
+      },
+    );
+    expect(surfaces[0].tier).toBe('expected');
+    expect(surfaces[0].reason).toBe('direct-call');
+  });
+
+  it('a generic-verb handler is NOT trusted for the direct-call seam', () => {
+    // `GET` collides across the codebase — a spurious match must not mark the
+    // route consumed. It stays likely (bias to false-negative on deadness).
+    const surfaces = tierDeadSurfaces([route('GET', '/orphan', 'src/api/orphan.ts', 'GET')], {
+      crossRepoConsumersVisible: true,
+      calledSymbols: new Set(['GET']),
+      conventionPatterns,
+      duplicateFiles: new Set(),
+    });
+    expect(surfaces[0].tier).toBe('likely');
+  });
+
+  it('a dead + duplicated route with visible consumers lands removable (convergence)', () => {
+    const surfaces = tierDeadSurfaces(
+      [route('GET', '/teams-legacy', 'src/routes/teams.ts', 'listTeamsLegacy')],
+      {
+        crossRepoConsumersVisible: true,
+        calledSymbols: new Set(),
+        conventionPatterns,
+        duplicateFiles: new Set(['src/routes/teams.ts']),
+      },
+    );
+    expect(surfaces[0].tier).toBe('removable');
+    expect(surfaces[0].reason).toBe('converged-dead');
+    expect(surfaces[0].convergesWithDuplicate).toBe(true);
+  });
+
+  it('the SAME dead+dup route WITHOUT visible consumers stays likely (never shout cross-repo)', () => {
+    const surfaces = tierDeadSurfaces(
+      [route('GET', '/teams-legacy', 'src/routes/teams.ts', 'listTeamsLegacy')],
+      {
+        crossRepoConsumersVisible: false,
+        calledSymbols: new Set(),
+        conventionPatterns,
+        duplicateFiles: new Set(['src/routes/teams.ts']),
+      },
+    );
+    expect(surfaces[0].tier).toBe('likely');
+    expect(surfaces[0].convergesWithDuplicate).toBe(true); // the dup fact is still recorded
+  });
+});
+
+describe('convergeSeams — dead ∩ duplicate', () => {
+  const dupFinding = dup('src/routes/teams.ts', 'src/routes/teams.ts');
+
+  it('fires when a removable dead route shares a file with a duplicate', () => {
+    const surfaces = tierDeadSurfaces(
+      [route('GET', '/teams-legacy', 'src/routes/teams.ts', 'listTeamsLegacy')],
+      {
+        crossRepoConsumersVisible: true,
+        calledSymbols: new Set(),
+        conventionPatterns: [],
+        duplicateFiles: new Set(['src/routes/teams.ts']),
+      },
+    );
+    const conv = convergeSeams(surfaces, [dupFinding]);
+    expect(conv).toHaveLength(1);
+    expect(conv[0].route.path).toBe('/teams-legacy');
+    expect(conv[0].signals).toEqual(['code-reimplementation', 'dead-surface']);
+    expect(conv[0].duplicate.id).toBe(dupFinding.id);
+  });
+
+  it('does NOT fire on a likely (unconfirmed) dead route even if a duplicate co-locates', () => {
+    const surfaces = tierDeadSurfaces(
+      [route('GET', '/teams-legacy', 'src/routes/teams.ts', 'listTeamsLegacy')],
+      {
+        crossRepoConsumersVisible: false, // deadness unconfirmed
+        calledSymbols: new Set(),
+        conventionPatterns: [],
+        duplicateFiles: new Set(['src/routes/teams.ts']),
+      },
+    );
+    expect(convergeSeams(surfaces, [dupFinding])).toHaveLength(0);
+  });
+
+  it('does NOT fire when the duplicate is in a different file', () => {
+    const surfaces = tierDeadSurfaces(
+      [route('GET', '/teams-legacy', 'src/routes/teams.ts', 'listTeamsLegacy')],
+      {
+        crossRepoConsumersVisible: true,
+        calledSymbols: new Set(),
+        conventionPatterns: [],
+        duplicateFiles: new Set(['src/other.ts']),
+      },
+    );
+    expect(convergeSeams(surfaces, [dup('src/other.ts', 'src/elsewhere.ts')])).toHaveLength(0);
+  });
+
+  it('is empty when there are no duplicates or no dead surfaces', () => {
+    expect(convergeSeams([], [dupFinding])).toEqual([]);
+  });
+});

--- a/test/analyzers/convergence/dead-surface-gather.test.ts
+++ b/test/analyzers/convergence/dead-surface-gather.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Integration test for `gatherDeadSurfaces` — proves the REAL flow-extraction →
+ * tier → convergence pipeline end-to-end, so the convergence "removable" positive
+ * is pinned, not just unit-asserted on the pure join.
+ *
+ * Real `diagnoseFlow` runs against an on-disk decorator-route fixture (the same
+ * extraction the flow tests exercise); the structural-duplicate graph is INJECTED
+ * (as `dupFindings`) so the test is deterministic + CI-portable without graphify's
+ * Python. The manual real-graphify run this mirrors observed the identical result:
+ * a co-located `.tsx` consumer makes consumers visible, `/teams` is consumed,
+ * `/teams-legacy` (a copy-paste) is unconsumed AND a duplicate → `removable`,
+ * and convergence names the twin.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { gatherDeadSurfaces } from '../../../src/analyzers/convergence/dead-surface-gather';
+import { convergeSeams } from '../../../src/analyzers/convergence';
+import type { DuplicateFinding } from '../../../src/explore/duplication';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+/**
+ * A full-stack repo: a controller serving `/teams` (consumed) + `/teams-legacy`
+ * (a dead copy-paste of it), and a frontend `.tsx` component that fetches
+ * `/teams` — so `frontendConsumers > 0` and consumers are VISIBLE.
+ */
+function makeRepo(withFrontend: boolean): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-deadgather-'));
+  dirs.push(dir);
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', version: '0.0.0' }));
+  mkdirSync(join(dir, 'src/api'), { recursive: true });
+  mkdirSync(join(dir, 'src/components'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src/api/ctrl.ts'),
+    `class TeamsController {\n` +
+      `  @get('/teams') listTeams(){ return 1; }\n` +
+      `  @get('/teams-legacy') listTeamsLegacy(){ return 1; }\n` +
+      `}\n`,
+  );
+  if (withFrontend) {
+    writeFileSync(
+      join(dir, 'src/components/TeamList.tsx'),
+      `export function TeamList(){ return fetch('/teams'); }\n`,
+    );
+  } else {
+    // A server-to-server call from a service file — NOT a frontend consumer.
+    mkdirSync(join(dir, 'src/services'), { recursive: true });
+    writeFileSync(
+      join(dir, 'src/services/sync.ts'),
+      `export function sync(){ return fetch('/teams'); }\n`,
+    );
+  }
+  return dir;
+}
+
+/** The structural-duplicate the graph would surface for the two handlers, both
+ *  in `src/api/ctrl.ts`. Injected so the test needs no graphify. */
+const dupFindings: DuplicateFinding[] = [
+  {
+    id: 'aaaabbbbccccdddd',
+    anchors: [
+      { file: 'src/api/ctrl.ts', symbol: 'listTeams', line: 2 },
+      { file: 'src/api/ctrl.ts', symbol: 'listTeamsLegacy', line: 3 },
+    ],
+    score: 0.9,
+  },
+];
+
+describe('gatherDeadSurfaces — real flow extraction → tier → convergence', () => {
+  it('converges a dead copy-paste route to removable when a co-located UI makes consumers visible', async () => {
+    const dir = makeRepo(true);
+    const res = await gatherDeadSurfaces(dir, { dupFindings });
+    // Consumers visible via the co-located .tsx frontend.
+    expect(res.crossRepoConsumersVisible).toBe(true);
+    // /teams is consumed → not in the unconsumed set; /teams-legacy is dead.
+    const paths = res.surfaces.map((s) => s.route.path);
+    expect(paths).toContain('/teams-legacy');
+    expect(paths).not.toContain('/teams');
+    // The dead copy-paste lands removable (dead ∩ duplicate, consumers visible).
+    const legacy = res.surfaces.find((s) => s.route.path === '/teams-legacy')!;
+    expect(legacy.tier).toBe('removable');
+    expect(legacy.reason).toBe('converged-dead');
+    expect(legacy.convergesWithDuplicate).toBe(true);
+    // Convergence names it, with the twin.
+    const conv = convergeSeams(res.surfaces, dupFindings);
+    expect(conv).toHaveLength(1);
+    expect(conv[0].route.path).toBe('/teams-legacy');
+    expect(conv[0].duplicate.anchors.map((a) => a.symbol).sort()).toEqual([
+      'listTeams',
+      'listTeamsLegacy',
+    ]);
+  });
+
+  it('the SAME dead copy-paste stays likely (never removable) on a backend with no visible UI consumer', async () => {
+    const dir = makeRepo(false);
+    const res = await gatherDeadSurfaces(dir, { dupFindings });
+    // A server-to-server call is not a frontend consumer → consumers not visible.
+    expect(res.crossRepoConsumersVisible).toBe(false);
+    const legacy = res.surfaces.find((s) => s.route.path === '/teams-legacy')!;
+    expect(legacy.tier).toBe('likely'); // deadness unconfirmed cross-repo → never shout
+    expect(legacy.convergesWithDuplicate).toBe(true); // the dup fact is still recorded
+    // Convergence does NOT fire on an unconfirmed dead route.
+    expect(convergeSeams(res.surfaces, dupFindings)).toHaveLength(0);
+  });
+});

--- a/test/analyzers/convergence/dead-surface.test.ts
+++ b/test/analyzers/convergence/dead-surface.test.ts
@@ -21,6 +21,7 @@ const base: DeadSurfaceSignals = {
   isDirectlyCalled: false,
   crossRepoConsumersVisible: false,
   isStructuralDuplicate: false,
+  deadnessConfirmable: true,
 };
 
 describe('deadSurfaceTier — the confidence ladder', () => {
@@ -58,6 +59,19 @@ describe('deadSurfaceTier — the confidence ladder', () => {
 
   it('a bare unconsumed route is likely', () => {
     expect(deadSurfaceTier(base)).toBe('likely');
+  });
+
+  it('a generic-handler route can never be removable, even dead + dup + visible', () => {
+    // App-Router `GET`/`POST` handlers can be consumed by a server component
+    // without a resolvable call → deadness is unconfirmable → stays likely.
+    expect(
+      deadSurfaceTier({
+        ...base,
+        crossRepoConsumersVisible: true,
+        isStructuralDuplicate: true,
+        deadnessConfirmable: false,
+      }),
+    ).toBe('likely');
   });
 });
 

--- a/test/analyzers/convergence/dead-surface.test.ts
+++ b/test/analyzers/convergence/dead-surface.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deadSurfaceTier,
+  matchesNonConsumerConvention,
+  isSpecificHandlerName,
+  type DeadSurfaceSignals,
+} from '../../../src/analyzers/convergence/dead-surface';
+import { indexGraph } from '../../../src/explore/load';
+import { calledSymbolNames } from '../../../src/explore/queries';
+import type { GraphJson, GraphNode, GraphEdge } from '../../../src/explore/types';
+
+/**
+ * The dead-surface confidence ladder + the direct-call seam query — the pure
+ * core of phase 2, pinned independent of any I/O. The ladder must never emit a
+ * loud `removable` it can't back up (the precision floor), so the tests assert
+ * the bias-to-false-negative boundaries explicitly.
+ */
+
+const base: DeadSurfaceSignals = {
+  isConventionRoute: false,
+  isDirectlyCalled: false,
+  crossRepoConsumersVisible: false,
+  isStructuralDuplicate: false,
+};
+
+describe('deadSurfaceTier — the confidence ladder', () => {
+  it('a convention route is always expected (external actor drives it)', () => {
+    expect(deadSurfaceTier({ ...base, isConventionRoute: true })).toBe('expected');
+    // even if it would otherwise converge to removable
+    expect(
+      deadSurfaceTier({
+        ...base,
+        isConventionRoute: true,
+        crossRepoConsumersVisible: true,
+        isStructuralDuplicate: true,
+      }),
+    ).toBe('expected');
+  });
+
+  it('a direct-called route is expected (consumed, just not over HTTP)', () => {
+    expect(deadSurfaceTier({ ...base, isDirectlyCalled: true })).toBe('expected');
+  });
+
+  it('removable requires BOTH visible consumers AND a duplicate (convergence)', () => {
+    expect(
+      deadSurfaceTier({ ...base, crossRepoConsumersVisible: true, isStructuralDuplicate: true }),
+    ).toBe('removable');
+  });
+
+  it('a duplicate without visible consumers is only likely (deadness unconfirmed)', () => {
+    // The cross-repo consumer could exist and be invisible → never shout.
+    expect(deadSurfaceTier({ ...base, isStructuralDuplicate: true })).toBe('likely');
+  });
+
+  it('visible consumers without a duplicate is only likely (single signal)', () => {
+    expect(deadSurfaceTier({ ...base, crossRepoConsumersVisible: true })).toBe('likely');
+  });
+
+  it('a bare unconsumed route is likely', () => {
+    expect(deadSurfaceTier(base)).toBe('likely');
+  });
+});
+
+describe('matchesNonConsumerConvention', () => {
+  const patterns = ['/webhook', '/cron/', '/healthz', '/cli/'];
+
+  it('matches on the URL path', () => {
+    expect(
+      matchesNonConsumerConvention('src/app/api/stripe/route.ts', '/webhook/stripe', patterns),
+    ).toBe(true);
+    expect(matchesNonConsumerConvention('src/x.ts', '/healthz', patterns)).toBe(true);
+  });
+
+  it('matches on the file path', () => {
+    expect(matchesNonConsumerConvention('src/app/api/cli/teams/route.ts', '/teams', patterns)).toBe(
+      true,
+    );
+  });
+
+  it('does not match an ordinary route', () => {
+    expect(matchesNonConsumerConvention('src/app/api/teams/route.ts', '/teams', patterns)).toBe(
+      false,
+    );
+  });
+
+  it('is case-insensitive and empty-safe', () => {
+    expect(matchesNonConsumerConvention('X/WEBHOOK/y.ts', '/Y', patterns)).toBe(true);
+    expect(matchesNonConsumerConvention('src/x.ts', '/anything', [])).toBe(false);
+  });
+});
+
+describe('isSpecificHandlerName', () => {
+  it('rejects bare HTTP verbs and generic names (bias to false-negative)', () => {
+    for (const g of ['GET', 'post', 'PUT', 'handler', 'default', 'index', 'Delete()']) {
+      expect(isSpecificHandlerName(g), g).toBe(false);
+    }
+  });
+
+  it('accepts a specific data-layer symbol', () => {
+    expect(isSpecificHandlerName('getDivisions')).toBe(true);
+    expect(isSpecificHandlerName('data.getPlayerSeasonAttributes()')).toBe(true);
+  });
+
+  it('rejects null / empty', () => {
+    expect(isSpecificHandlerName(null)).toBe(false);
+    expect(isSpecificHandlerName(undefined)).toBe(false);
+    expect(isSpecificHandlerName('')).toBe(false);
+  });
+});
+
+// ── calledSymbolNames (the direct-call seam query) ──────────────────────────
+
+let idc = 0;
+function node(label: string, sourceFile = 'src/x.ts'): GraphNode {
+  return { id: `${label}#${idc++}`, kind: 'function', label, sourceFile, line: 1 };
+}
+function calls(from: GraphNode, to: GraphNode): GraphEdge {
+  return { from: from.id, to: to.id, relation: 'calls' };
+}
+function graphOf(nodes: GraphNode[], edges: GraphEdge[]): GraphJson {
+  return {
+    schemaVersion: 2,
+    meta: {
+      tool: 'graphify',
+      graphifyVersion: '0',
+      dxkitVersion: '0',
+      generatedAt: '',
+      sourceFilesInGraph: 0,
+      excludedFileCount: 0,
+      packs: [],
+      truncated: false,
+      truncatedReason: '',
+    },
+    nodes,
+    edges,
+    communities: [],
+    symbolIndex: {},
+    endpoints: [],
+  };
+}
+
+describe('calledSymbolNames — direct-call seam', () => {
+  it('collects the stripped names of every calls-edge target', () => {
+    const page = node('Page', 'src/app/page.tsx');
+    const getDivisions = node('getDivisions()', 'src/lib/data.ts');
+    const respond = node('data.respond()', 'src/lib/http.ts');
+    const g = indexGraph(graphOf([page, getDivisions, respond], [calls(page, getDivisions)]));
+    const names = calledSymbolNames(g);
+    expect(names.has('getDivisions')).toBe(true);
+    // respond is never called → absent
+    expect(names.has('respond')).toBe(false);
+    expect(names.has('Page')).toBe(false);
+  });
+
+  it('strips receiver qualifiers so a member call resolves by symbol', () => {
+    const caller = node('Page', 'src/app/page.tsx');
+    const target = node('data.getPlayer()', 'src/lib/data.ts');
+    const g = indexGraph(graphOf([caller, target], [calls(caller, target)]));
+    expect(calledSymbolNames(g).has('getPlayer')).toBe(true);
+  });
+});

--- a/test/evaluate/evidence.test.ts
+++ b/test/evaluate/evidence.test.ts
@@ -4,9 +4,11 @@ import {
   ANACHRONISM_NOTE,
   buildCosts,
   buildEvidenceDoc,
+  seamVisibilityFrom,
   EVALUATE_EVIDENCE_SCHEMA,
   type EvaluateRunEvidence,
 } from '../../src/evaluate/evidence';
+import { renderEvaluateText } from '../../src/evaluate/render';
 
 /** A minimal guardrail payload carrying only the fields evidence/render
  *  read. Narrow test-fixture cast; the real payload is produced by
@@ -86,6 +88,56 @@ describe('evaluate evidence schema freeze', () => {
       ].sort(),
     );
     expect(doc.zeroWrite).toBe(true);
+  });
+
+  it('carries the optional seam-visibility lane when provided (reviewed addition)', () => {
+    const inv = {
+      duplicates: [
+        {
+          anchors: [
+            { file: 'src/api/ctrl.ts', symbol: 'listTeams' },
+            { file: 'src/api/ctrl.ts', symbol: 'listTeamsLegacy' },
+          ] as const,
+          score: 0.9,
+        },
+      ],
+      dead: {
+        crossRepoConsumersVisible: true,
+        byTier: { removable: 1, likely: 0, expected: 2 },
+      },
+      converged: [
+        {
+          route: { method: 'GET', path: '/teams-legacy', file: 'src/api/ctrl.ts' },
+          duplicate: { anchors: [{ symbol: 'listTeams' }, { symbol: 'listTeamsLegacy' }] as const },
+        },
+      ],
+    };
+    const seams = seamVisibilityFrom(inv);
+    expect(seams.duplicates).toBe(1);
+    expect(seams.dead).toEqual({ removable: 1, likely: 0, expected: 2 });
+    expect(seams.converged[0]).toEqual({
+      method: 'GET',
+      path: '/teams-legacy',
+      file: 'src/api/ctrl.ts',
+      twin: ['listTeams', 'listTeamsLegacy'],
+    });
+    const doc = buildEvidenceDoc({
+      branch: 'main',
+      ref: 'HEAD',
+      preset: 'security-only',
+      presetSource: 'default',
+      policyBase: 'defaults',
+      incremental: true,
+      untrusted: false,
+      runs: [fakeRun()],
+      seams,
+    });
+    expect(doc.seams).toEqual(seams);
+    // The visibility lane renders the convergence story in the human output.
+    const text = renderEvaluateText(doc);
+    expect(text).toContain('What dxkit sees beyond the gate');
+    expect(text).toContain('converged');
+    expect(text).toContain('/teams-legacy');
   });
 });
 

--- a/test/flow-diagnose.test.ts
+++ b/test/flow-diagnose.test.ts
@@ -39,9 +39,43 @@ describe('diagnoseFlow', () => {
       expect(dead).toBeDefined();
       expect(dead!.reason).toBe('no-route');
       expect(dead!.suggestion).toBe('add-route');
-      // The orphan route nobody calls is surfaced as served-but-unconsumed.
-      expect(d!.servedUnconsumed.map((r) => r.path)).toContain('/orphan');
+      // The orphan route nobody calls is surfaced as served-but-unconsumed,
+      // carrying its handler symbol for the dead-surface direct-call seam.
+      const orphan = d!.servedUnconsumed.find((r) => r.path === '/orphan');
+      expect(orphan).toBeDefined();
+      expect(orphan!.handler).toBe('b');
       expect(d!.connection.rung).toBe('monorepo');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('counts frontend consumers — calls originating from a component/page path', async () => {
+    const dir = makeRepo({
+      // A call from a FRONTEND component path (matches primaryComponentPaths) —
+      // the co-located-UI signal the dead-surface tier uses to trust deadness.
+      'src/components/List.tsx': "axios.get('/articles');\n",
+      'api/ctrl.ts': "class C { @get('/articles') a() {} }\n",
+    });
+    try {
+      const d = await diagnoseFlow(dir);
+      expect(d).not.toBeNull();
+      expect(d!.frontendConsumers).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports zero frontend consumers for a backend (calls from non-component paths)', async () => {
+    const dir = makeRepo({
+      // A server-to-server call from a service path — NOT a frontend consumer.
+      'src/services/sync.ts': "axios.get('/articles');\n",
+      'api/ctrl.ts': "class C { @get('/articles') a() {} @get('/orphan') b() {} }\n",
+    });
+    try {
+      const d = await diagnoseFlow(dir);
+      expect(d).not.toBeNull();
+      expect(d!.frontendConsumers).toBe(0);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -53,6 +53,7 @@ import {
   changedFilesTouchFlowSurface,
   allPrimaryComponentPaths,
   allRoutePaths,
+  allNonConsumerRoutePaths,
   allSourceExtensions,
   allTestFilePatterns,
   allTestGapPriorityPaths,
@@ -122,6 +123,7 @@ const mockPlaybookPack = {
       high: ['/playbookplane/'],
       medium: ['/playbookbinder/', '/playbookforms/'],
     },
+    nonConsumerRoutePaths: ['/playbookwebhook/'],
   },
   // CI runtime-setup contribution (2.32). Distinctive action ref + version so
   // the assertion verifies the synthetic pack's ciSetup flows through
@@ -810,6 +812,23 @@ describe('recipe playbook — synthetic pack', () => {
     } as any;
     const paths = allRoutePaths(flags);
     expect(paths).toContain('/playbookroutes/');
+  });
+
+  it('allNonConsumerRoutePaths includes the mock pack convention patterns (C8)', () => {
+    const flags = {
+      typescript: false,
+      python: false,
+      go: false,
+      rust: false,
+      csharp: false,
+      kotlin: false,
+      java: false,
+      ruby: false,
+      playbook: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const paths = allNonConsumerRoutePaths(flags);
+    expect(paths).toContain('/playbookwebhook/');
   });
 
   it('allModelPaths includes the mock pack model patterns (C8)', () => {


### PR DESCRIPTION
## What & why

T2 phase 2, building on the merged tier-3 duplication gate (#144). Turns "served but unconsumed" routes into an **honest, tiered inventory** and converges them with the structural-duplicate signal into a ranked "removable slop" view — surfaced in `vyuh-dxkit flow`. This is the customer's Exception Report, git-native and tiered.

**Design first** (`tmp/feature-req/DESIGN-dead-surface-ux.md`): dead-surface is a **visibility signal, not a gate** — the customer's own pipeline treated dead routes as a reviewed inventory, never a block. "Unconsumed" ≠ "dead" (a route can be cross-repo-consumed or convention-driven), so a hard block would false-flag. The confidence ladder keeps the three cases apart, and convergence (two independent seam signals agreeing) is what earns a loud signal without a false-block.

## The confidence ladder (the UX primitive)

| Tier | Condition | Verb |
|---|---|---|
| **removable** | dead + consumers all visible + ALSO a structural duplicate (convergence) | remove / consolidate — name the twin |
| **likely** | no in-repo consumer, but cross-repo consumers can't be ruled out | surface + nudge to declare `workspace.json` |
| **expected** | webhook / cron / health / CLI (pack-declared) or a server-side direct call (RSC) | inventory only, dimmed |

## Changes (engine → surface)

- **Pack-declared conventions** (Rule 6/8): `architecturalShape.nonConsumerRoutePaths` + `allNonConsumerRoutePaths` union (TS + Python); new arch-check bans hardcoded webhook/cron/health literals in analyzers.
- **Direct-call seam** (Rule 12): `calledSymbolNames` — a route consumed by a server-side direct call (RSC / server action) isn't dead. Closes the App-Router "dead is the norm" false positive.
- **Confidence ladder** (`analyzers/convergence/dead-surface.ts`): pure `deadSurfaceTier`, bias-to-false-negative throughout.
- **Gatherer + convergence** (`dead-surface-gather.ts`, `convergence/index.ts`): compose `diagnoseFlow.servedUnconsumed` (Rule 2, no re-detection) + graph + conventions → tiered list; a `removable` dead route co-located with a duplicate emits a `seam-convergence`.
- **Co-located-UI signal** (`diagnoseFlow.frontendConsumers`): keys on the UI-component file extension (.tsx/.jsx/.vue/.svelte), so a full-stack app reads consumers-visible while a backend making internal service calls does not.
- **Surface**: `vyuh-dxkit flow` renders the tiered ladder + convergence callout; `flow --json` exposes `deadSurfaces` for agents; the `dxkit-flow` skill documents it.

## Validation — generic, not overfit

Read-only across **8 diverse real repos** (TS backend / full-stack / SPA, Next.js App Router, Python/Django, C#, Rust, agent-generated): behavior is uniform and pack-driven, **0 false `removable`/convergence on every one** (even repos with 17–30 duplicates), convention filter dims webhook/cron/health/CLI/tasks generically, backends correctly read consumers-invisible while full-stack apps read visible.

**The broad stress pass caught and fixed two real bugs** (why testing wide mattered): consumer-visibility read the wrong flow signal (a provider could never be "visible"); and the convergence file-join compared relative vs absolute paths and silently zeroed. Both fixed + unit-pinned.

35 new unit tests (ladder boundaries, direct-call seam, convention match, tier→join, convergence fires-on-match / silent-otherwise) + the real-repo stress pass. **Full suite 3947 green; arch/lint/format/slop clean.**

## Deferred to follow-ups (noted, not gaps)

- The Maintainability scoring penalty for convergence findings (Rule 7) — the inventory value ships without it.
- The `describe` contract-map surface (#21, not yet built) — consumes the same gatherer when it lands.
- The **block-tier** (convergence → a verdict) stays deferred to the validated cross-repo consumed-union, post-3.7 — dead is inventory, not a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aVcK9vYXrm71yV4dBQQde