### PR TITLE
feat(discovery): enforce config-knob discoverability (Track 3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Config-knob discovery coverage (the Rule 16 gap the seam gate exposed).** Rule
+  16's enforcement guaranteed a COMMAND was discoverable, but not that an opt-in
+  CONFIG KNOB it gates was reachable through `configure` (via `planConfig`) or
+  `doctor` / `capabilities` (via `whenToRecommend`) — so a new gate could ship with
+  a knob an onboarding agent never learns to enable. A new `POSTURE_KNOBS` registry
+  names every posture knob and declares which discovery probes its owning command
+  must carry; `test/discovery-posture-playbook.test.ts` (synthetic-injection-guarded)
+  turns that into a mechanical assertion so the class is auto-caught, not left to
+  human review. Closes the actual gaps found in the audit: `doctor` now recommends
+  pinning `loop.preset` when the Stop-gate is installed but the posture is unpinned,
+  and recommends `reports.onMerge` for a repo that gates but does not track the
+  score-over-time trend. `graph.refresh` (a CI-performance transport, not a gate) is
+  now documented in `policy.md` and recorded as a declared discovery exemption.
+
 - **Dead-surface inventory + seam convergence in `vyuh-dxkit flow`.** The flow map's
   flat "served but unconsumed" list is now an honest **confidence ladder**: each
   served-but-unconsumed route is tiered `removable` / `likely` / `expected` with the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -921,6 +921,24 @@ Mirror of Rule 15's managed-write gate, three escalating layers:
    the same empirical guard as `managed-artifacts-playbook.test.ts` /
    `recipe-playbook.test.ts`.
 
+The above gate COMMAND discoverability. But a command can be registered while an
+opt-in CONFIG KNOB it gates is discovery-invisible — `configure` never plans it
+(no `planConfig`) and `doctor` / `capabilities` never surface it (no
+`whenToRecommend`) — so an agent onboarding a repo via `capabilities --json`
+never enables the gate and `configure --apply` silently under-initializes the
+repo. That class shipped the seam gate's `duplication.mode` invisible until it
+was caught by hand. The **config-knob layer** closes it: every posture / opt-in
+knob is named in `src/discovery/posture-knobs.ts:POSTURE_KNOBS`, declaring per
+knob which probes its owning command MUST carry (`requiresPlan` /
+`requiresRecommend`), and `checkPostureKnobCoverage` turns that into a mechanical
+assertion pinned by `test/discovery-posture-playbook.test.ts` (synthetic-
+injection-guarded, mirror of the command playbook). A knob that deliberately
+carries no probe is a **declared exemption with a reason** (`exemptionReason` —
+same discipline as the `internal` audience and Rule 10's `DEFERRED_KINDS`), never
+a silent omission. Guardrail-TUNING fields (`confidence`, `blockRules`,
+`largeFileThreshold`) are not posture knobs — they refine an adopted gate, they
+are not a capability a repo opts into, so they carry no discovery contract.
+
 ### 17. Custom checks are one seam — user checks and lint share it
 
 A **custom check** is any repo command dxkit runs as a first-class gate

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -65,6 +65,7 @@ tuning belongs here.
 | `lint`                      | `object`       | Enable the pack-declared built-in lint gate. `{ enabled, blocking }`, both default `false`.                                                                                                                                                                                                                         |
 | `largeFileThreshold`        | `number`       | Line count above which a source file is flagged `large-file` (default `500`). Applied once at gather time, so it drives the guardrail `large-file` finding, the "files over N lines" count, and the Quality + Maintainability scores together. A non-positive / non-numeric value is ignored (falls back to `500`). |
 | `reports`                   | `object`       | Opt-in report snapshots on merge. See "Report snapshots on merge" below.                                                                                                                                                                                                                                            |
+| `graph`                     | `object`       | Code-graph freshness transport. `{ "refresh": "cache" \| "off" }` (default `off`). See "Code-graph refresh transport" below.                                                                                                                                                                                        |
 
 ## Baseline mode pinning
 
@@ -432,6 +433,28 @@ and block completion if they fail. Configure that command durably here:
 precedence, but an env var is the easiest part of the loop config to silently
 lose (per-shell, per-machine) — committing it to policy keeps it durable and
 reviewable. `vyuh-dxkit loop doctor` shows which source (if any) supplied it.
+
+## `graph.refresh` — code-graph refresh transport (CI performance)
+
+The code graph (`.dxkit/reports/graph.json`) backs `explore`, `context`, the
+affected-tests selector, and the structural-duplicate (seam) gate. By default it
+is rebuilt on demand by whichever consumer needs it — correct, but a cold rebuild
+on every CI run. Opt into caching it instead:
+
+```json
+{ "graph": { "refresh": "cache" } }
+```
+
+| Value           | Effect                                                                                                                                                                                                                       |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `off` (default) | rebuild on demand; a repo that never configured it never pays a build it does not use                                                                                                                                        |
+| `cache`         | `init`/`update` installs the `dxkit-graph-refresh` workflow, which rebuilds the graph on merge and stores it in the **Actions cache** (never git — no repo bloat) so the guardrail run restores it instead of a cold rebuild |
+
+This is a **performance transport, not a gate** — it changes no finding and no
+verdict, only how fast the graph is available in CI. Because there is no
+behavioral difference to surface, `doctor` / `configure` do not recommend it (it
+is a declared exemption in the posture-knob discovery registry); enable it here
+when cold graph builds are a CI cost you want to remove.
 
 ## Loading order
 

--- a/src/discovery/advisor-signals.ts
+++ b/src/discovery/advisor-signals.ts
@@ -1,0 +1,229 @@
+/**
+ * Shared signal predicates for the doctor probes + config planners in
+ * `./advisor`. Each `has*Signal` is the ONE implementation of "does this repo
+ * exhibit the condition capability X keys off" (Rule 2 — one concept, one code
+ * path), consumed by BOTH a `whenToRecommend` probe and a `planConfig` planner
+ * so the two can never diverge. Split out of `advisor.ts` to keep that module a
+ * cohesive set of probe/planner DECLARATIONS while their shared detection logic
+ * lives here. Leaf module — imports analyzer/pack facts, nothing in
+ * `./discovery` imports it back, so no registry↔probe cycle.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { CONTRACT_SOURCE_READERS } from '../analyzers/flow/contract-sources';
+import { tryLoadGraph } from '../explore/load';
+import { isClaudeLoopInstalled } from '../loop/scaffold';
+import { LANGUAGES } from '../languages';
+
+export function existsAt(...parts: string[]): boolean {
+  try {
+    return fs.existsSync(path.join(...parts));
+  } catch {
+    return false;
+  }
+}
+
+export function readJsonSafe(p: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+export function dirHasEntries(dir: string): boolean {
+  try {
+    return fs.readdirSync(dir).some((f) => !f.startsWith('.'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Does any pack-declared manifest signal match this repo? The ONE
+ * signal-matching implementation (Rule 2), shared by the flow and schema
+ * probes. `package.json` matches on dependency KEYS (a word-boundary text
+ * search would also hit versions/scripts); plain-text manifests
+ * (requirements.txt, pyproject.toml, go.mod…) match on word-boundary tokens
+ * — precise enough for a fail-open recommendation probe.
+ */
+function manifestSignalHit(
+  cwd: string,
+  signals: ReadonlyArray<{ manifest: string; anyOf: string[] }>,
+): boolean {
+  for (const signal of signals) {
+    if (signal.manifest === 'package.json') {
+      const pkg = readJsonSafe(path.join(cwd, signal.manifest));
+      if (!pkg) continue;
+      const deps = {
+        ...((pkg.dependencies as Record<string, unknown>) ?? {}),
+        ...((pkg.devDependencies as Record<string, unknown>) ?? {}),
+      };
+      if (signal.anyOf.some((f) => f in deps)) return true;
+    } else {
+      let text: string;
+      try {
+        text = fs.readFileSync(path.join(cwd, signal.manifest), 'utf8');
+      } catch {
+        continue;
+      }
+      const hit = signal.anyOf.some((f) =>
+        new RegExp(`\\b${f.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(text),
+      );
+      if (hit) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Signal: this repo has an HTTP framework a flow-capable pack declares but no
+ * flow setup yet — the case where flow's integration gate adds value. Shared
+ * by BOTH the doctor probe (`recommendFlow`) and the deterministic planner
+ * (`planFlowMode`) so the two never diverge (Rule 2 — one concept, one code
+ * path). The framework tokens are PACK-DECLARED (`httpFlow.flowSignals`,
+ * Rule 6) — pre-M6 this probe hardcoded a JS UI-framework list against
+ * package.json, so a pure FastAPI/Django repo was never recommended the
+ * capability its pack had just gained.
+ */
+export function hasFlowSignal(cwd: string): boolean {
+  // Already configured? workspace.json or a flow policy block means yes.
+  if (existsAt(cwd, '.dxkit', 'workspace.json')) return false;
+  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json'));
+  if (policy && 'flow' in policy) return false;
+  return manifestSignalHit(
+    cwd,
+    LANGUAGES.flatMap((p) => p.httpFlow?.flowSignals ?? []),
+  );
+}
+
+/**
+ * One signal function for the schema-gate capability, shared by the doctor
+ * probe (`recommendSchema`) and the planner (`planSchemaMode`) so the two
+ * never diverge (Rule 2). Tokens are PACK-DECLARED
+ * (`modelSchema.schemaSignals`, Rule 6). Silenced once a `schema` policy
+ * block exists — configured repos are never re-recommended.
+ */
+export function hasSchemaSignal(cwd: string): boolean {
+  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json'));
+  if (policy && 'schema' in policy) return false;
+  return manifestSignalHit(
+    cwd,
+    LANGUAGES.flatMap((p) => p.modelSchema?.schemaSignals ?? []),
+  );
+}
+
+/** Minimum call-graph density (calls-edges per function) at which the structural-
+ *  duplicate signal is reliable — the anti-slop proof's boundary: a dense
+ *  backend / CLI / library graph, not a thin framework-mediated frontend where
+ *  the detector honestly finds little. Below this the seam gate is not worth
+ *  proposing (it would surface nothing), so the probe stays silent. */
+const DUPLICATION_MIN_CALL_DENSITY = 0.8;
+
+/**
+ * One signal for the structural-duplicate (seam) gate, shared by the doctor
+ * probe (`recommendDuplication`) and the planner (`planDuplicationMode`) so the
+ * two never diverge (Rule 2). Fires only when (a) the repo has not configured
+ * `duplication` yet, AND (b) an existing code graph shows a call density high
+ * enough for the detector to work — evidence the gate would actually fire, not a
+ * blind proposal. A repo with no graph yet, or a thin frontend graph, is left
+ * alone (the seam gate needs a dense call graph to add value).
+ */
+export function hasDuplicationSignal(cwd: string): boolean {
+  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json'));
+  if (policy && 'duplication' in policy) return false;
+  const graph = tryLoadGraph(cwd);
+  if (!graph) return false;
+  const fns = graph.nodes.filter((n) => n.kind === 'function' || n.kind === 'method').length;
+  if (fns === 0) return false;
+  const calls = graph.edges.filter((e) => e.relation === 'calls').length;
+  return calls / fns >= DUPLICATION_MIN_CALL_DENSITY;
+}
+
+/**
+ * Signal: this repo runs a linter but has NOT wired it into dxkit's gate. Shared
+ * by the doctor probe (`recommendChecks`) and the deterministic planner
+ * (`planLintGate`) so they never diverge (Rule 2). Conservative: fires only on
+ * a concrete linter config / `lint` script, and goes silent the moment the
+ * `checks` / `lint` policy opts in.
+ */
+export function hasLintSignal(cwd: string): boolean {
+  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json')) ?? {};
+  // `.dxkit/policy.json` is flat (resolvePolicy spreads it at the top level),
+  // so `checks` / `lint` are top-level keys — mirror of the flow probe's
+  // `'flow' in policy`.
+  const checks = policy.checks;
+  const lint = policy.lint as Record<string, unknown> | undefined;
+  // Already opted in? (a declared check, or the lint gate enabled) → silent.
+  if (Array.isArray(checks) && checks.length > 0) return false;
+  if (lint?.enabled === true) return false;
+
+  // A concrete linter signal: a standalone lint config, or a package.json
+  // `lint` script. Kept conservative so this never nags a repo without one.
+  const lintConfigs = [
+    'eslint.config.js',
+    'eslint.config.mjs',
+    'eslint.config.cjs',
+    '.eslintrc.js',
+    '.eslintrc.cjs',
+    '.eslintrc.json',
+    '.eslintrc.yml',
+    '.eslintrc.yaml',
+    'ruff.toml',
+    '.ruff.toml',
+    '.rubocop.yml',
+    '.golangci.yml',
+    '.golangci.yaml',
+  ];
+  if (lintConfigs.some((f) => existsAt(cwd, f))) return true;
+  const pkg = readJsonSafe(path.join(cwd, 'package.json'));
+  const scripts = (pkg?.scripts as Record<string, unknown> | undefined) ?? {};
+  return typeof scripts.lint === 'string';
+}
+
+/**
+ * One signal for the declared-artifact capability, shared by the doctor probe
+ * (`recommendExtensions`) and the planner (`planFlowSources`) so they never
+ * diverge (Rule 2). Kinds and filename signals are REGISTRY-DERIVED (each
+ * reader's `sniff`) — no format literal lives here, so a new reader extends
+ * this probe automatically. Conservative: silent the moment ANY
+ * `flow.sources` entry exists (a configured repo is never re-nagged), scans
+ * the git-tracked list only (bounded), openapi excluded (`flow.specs` and
+ * the flow planner own specs).
+ */
+export function undeclaredContractArtifacts(cwd: string): Array<{ kind: string; path: string }> {
+  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json')) ?? {};
+  const flow = policy.flow as Record<string, unknown> | undefined;
+  const sources = flow?.sources;
+  if (Array.isArray(sources) && sources.length > 0) return [];
+  let files: string[];
+  try {
+    files = execFileSync('git', ['ls-files'], { cwd, encoding: 'utf8', timeout: 10_000 })
+      .split('\n')
+      .slice(0, 20_000);
+  } catch {
+    return [];
+  }
+  const readers = CONTRACT_SOURCE_READERS.filter((r) => r.kind !== 'openapi');
+  const out: Array<{ kind: string; path: string }> = [];
+  for (const f of files) {
+    if (out.length >= 10) break;
+    const reader = readers.find((r) => r.sniff(f));
+    if (reader) out.push({ kind: reader.kind, path: f });
+  }
+  return out;
+}
+
+/**
+ * Signal: the loop Stop-gate is installed but `loop.preset` is unpinned. Shared
+ * by the planner (`planLoopPreset`) and the doctor probe (`recommendLoopPreset`)
+ * so the two never diverge (Rule 2). Reuses the canonical Stop-hook detector
+ * (`isClaudeLoopInstalled`, Rule 2).
+ */
+export function loopStopGateNeedsPreset(cwd: string): boolean {
+  if (!isClaudeLoopInstalled(cwd)) return false;
+  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json')) ?? {};
+  const loop = policy.loop as Record<string, unknown> | undefined;
+  return !(loop && typeof loop.preset === 'string'); // true ⟹ unpinned
+}

--- a/src/discovery/advisor.ts
+++ b/src/discovery/advisor.ts
@@ -6,17 +6,22 @@
  * those descriptors. Kept out of `commands.ts` to hold each module to a
  * cohesive unit and to break the registry↔probe value-import cycle.
  */
-import * as fs from 'fs';
 import * as path from 'path';
 import { resolveBaselineMode } from '../baseline/modes';
-import { execFileSync } from 'child_process';
-import { CONTRACT_SOURCE_READERS } from '../analyzers/flow/contract-sources';
 import { FLOW_CONFIG_SCHEMA_VERSION } from '../analyzers/flow/config';
 import { SCHEMA_CONFIG_SCHEMA_VERSION } from '../analyzers/model-schema/config';
 import { DUPLICATION_CONFIG_SCHEMA_VERSION } from '../analyzers/duplication/config';
-import { tryLoadGraph } from '../explore/load';
-import { isClaudeLoopInstalled } from '../loop/scaffold';
-import { LANGUAGES } from '../languages';
+import {
+  existsAt,
+  readJsonSafe,
+  dirHasEntries,
+  hasFlowSignal,
+  hasSchemaSignal,
+  hasDuplicationSignal,
+  hasLintSignal,
+  undeclaredContractArtifacts,
+  loopStopGateNeedsPreset,
+} from './advisor-signals';
 import type {
   RecommendContext,
   Recommendation,
@@ -31,30 +36,8 @@ import type {
 // once the capability is in use, so `doctor` never nags about what's already
 // set up. New capabilities attach their own probe here as they land (the gate
 // runner's "you have ungated repo checks" probe is the marquee future case).
-
-function existsAt(...parts: string[]): boolean {
-  try {
-    return fs.existsSync(path.join(...parts));
-  } catch {
-    return false;
-  }
-}
-
-function readJsonSafe(p: string): Record<string, unknown> | null {
-  try {
-    return JSON.parse(fs.readFileSync(p, 'utf-8'));
-  } catch {
-    return null;
-  }
-}
-
-function dirHasEntries(dir: string): boolean {
-  try {
-    return fs.readdirSync(dir).some((f) => !f.startsWith('.'));
-  } catch {
-    return false;
-  }
-}
+// The shared `has*Signal` detectors live in `./advisor-signals` (Rule 2 —
+// consumed by both a probe and its planner).
 
 /** Recommend the zero-write trial where dxkit is NOT installed yet — the
  *  pre-adoption step. Once the manifest exists the gate itself answers the
@@ -82,80 +65,6 @@ export function recommendBaseline(ctx: RecommendContext): Recommendation | null 
   };
 }
 
-/**
- * Signal: this repo has an HTTP framework a flow-capable pack declares but no
- * flow setup yet — the case where flow's integration gate adds value. Shared
- * by BOTH the doctor probe (`recommendFlow`) and the deterministic planner
- * (`planFlowMode`) so the two never diverge (Rule 2 — one concept, one code
- * path). The framework tokens are PACK-DECLARED (`httpFlow.flowSignals`,
- * Rule 6) — pre-M6 this probe hardcoded a JS UI-framework list against
- * package.json, so a pure FastAPI/Django repo was never recommended the
- * capability its pack had just gained.
- */
-function hasFlowSignal(cwd: string): boolean {
-  // Already configured? workspace.json or a flow policy block means yes.
-  if (existsAt(cwd, '.dxkit', 'workspace.json')) return false;
-  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json'));
-  if (policy && 'flow' in policy) return false;
-  return manifestSignalHit(
-    cwd,
-    LANGUAGES.flatMap((p) => p.httpFlow?.flowSignals ?? []),
-  );
-}
-
-/**
- * Does any pack-declared manifest signal match this repo? The ONE
- * signal-matching implementation (Rule 2), shared by the flow and schema
- * probes. `package.json` matches on dependency KEYS (a word-boundary text
- * search would also hit versions/scripts); plain-text manifests
- * (requirements.txt, pyproject.toml, go.mod…) match on word-boundary tokens
- * — precise enough for a fail-open recommendation probe.
- */
-function manifestSignalHit(
-  cwd: string,
-  signals: ReadonlyArray<{ manifest: string; anyOf: string[] }>,
-): boolean {
-  for (const signal of signals) {
-    if (signal.manifest === 'package.json') {
-      const pkg = readJsonSafe(path.join(cwd, signal.manifest));
-      if (!pkg) continue;
-      const deps = {
-        ...((pkg.dependencies as Record<string, unknown>) ?? {}),
-        ...((pkg.devDependencies as Record<string, unknown>) ?? {}),
-      };
-      if (signal.anyOf.some((f) => f in deps)) return true;
-    } else {
-      let text: string;
-      try {
-        text = fs.readFileSync(path.join(cwd, signal.manifest), 'utf8');
-      } catch {
-        continue;
-      }
-      const hit = signal.anyOf.some((f) =>
-        new RegExp(`\\b${f.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(text),
-      );
-      if (hit) return true;
-    }
-  }
-  return false;
-}
-
-/**
- * One signal function for the schema-gate capability, shared by the doctor
- * probe (`recommendSchema`) and the planner (`planSchemaMode`) so the two
- * never diverge (Rule 2). Tokens are PACK-DECLARED
- * (`modelSchema.schemaSignals`, Rule 6). Silenced once a `schema` policy
- * block exists — configured repos are never re-recommended.
- */
-function hasSchemaSignal(cwd: string): boolean {
-  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json'));
-  if (policy && 'schema' in policy) return false;
-  return manifestSignalHit(
-    cwd,
-    LANGUAGES.flatMap((p) => p.modelSchema?.schemaSignals ?? []),
-  );
-}
-
 /** Recommend flow setup on a repo with an HTTP-framework signal and no flow config. */
 export function recommendFlow(ctx: RecommendContext): Recommendation | null {
   if (!hasFlowSignal(ctx.cwd)) return null;
@@ -175,33 +84,6 @@ export function recommendSchema(ctx: RecommendContext): Recommendation | null {
       'detected a data-model framework but no schema gate — the gate blocks breaking model changes (field removed, type changed, required tightened) while a deliberate migration ships via an expiring allowlist entry',
     command: 'vyuh-dxkit schema',
   };
-}
-
-/** Minimum call-graph density (calls-edges per function) at which the structural-
- *  duplicate signal is reliable — the anti-slop proof's boundary: a dense
- *  backend / CLI / library graph, not a thin framework-mediated frontend where
- *  the detector honestly finds little. Below this the seam gate is not worth
- *  proposing (it would surface nothing), so the probe stays silent. */
-const DUPLICATION_MIN_CALL_DENSITY = 0.8;
-
-/**
- * One signal for the structural-duplicate (seam) gate, shared by the doctor
- * probe (`recommendDuplication`) and the planner (`planDuplicationMode`) so the
- * two never diverge (Rule 2). Fires only when (a) the repo has not configured
- * `duplication` yet, AND (b) an existing code graph shows a call density high
- * enough for the detector to work — evidence the gate would actually fire, not a
- * blind proposal. A repo with no graph yet, or a thin frontend graph, is left
- * alone (the seam gate needs a dense call graph to add value).
- */
-function hasDuplicationSignal(cwd: string): boolean {
-  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json'));
-  if (policy && 'duplication' in policy) return false;
-  const graph = tryLoadGraph(cwd);
-  if (!graph) return false;
-  const fns = graph.nodes.filter((n) => n.kind === 'function' || n.kind === 'method').length;
-  if (fns === 0) return false;
-  const calls = graph.edges.filter((e) => e.relation === 'calls').length;
-  return calls / fns >= DUPLICATION_MIN_CALL_DENSITY;
 }
 
 /**
@@ -243,46 +125,6 @@ export function recommendDuplication(ctx: RecommendContext): Recommendation | nu
  * ask for it. Conservative: fires only on a concrete linter signal, and goes
  * silent once the policy opts in.
  */
-/**
- * Signal: this repo runs a linter but has NOT wired it into dxkit's gate. Shared
- * by the doctor probe (`recommendChecks`) and the deterministic planner
- * (`planLintGate`) so they never diverge (Rule 2). Conservative: fires only on
- * a concrete linter config / `lint` script, and goes silent the moment the
- * `checks` / `lint` policy opts in.
- */
-function hasLintSignal(cwd: string): boolean {
-  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json')) ?? {};
-  // `.dxkit/policy.json` is flat (resolvePolicy spreads it at the top level),
-  // so `checks` / `lint` are top-level keys — mirror of the flow probe's
-  // `'flow' in policy`.
-  const checks = policy.checks;
-  const lint = policy.lint as Record<string, unknown> | undefined;
-  // Already opted in? (a declared check, or the lint gate enabled) → silent.
-  if (Array.isArray(checks) && checks.length > 0) return false;
-  if (lint?.enabled === true) return false;
-
-  // A concrete linter signal: a standalone lint config, or a package.json
-  // `lint` script. Kept conservative so this never nags a repo without one.
-  const lintConfigs = [
-    'eslint.config.js',
-    'eslint.config.mjs',
-    'eslint.config.cjs',
-    '.eslintrc.js',
-    '.eslintrc.cjs',
-    '.eslintrc.json',
-    '.eslintrc.yml',
-    '.eslintrc.yaml',
-    'ruff.toml',
-    '.ruff.toml',
-    '.rubocop.yml',
-    '.golangci.yml',
-    '.golangci.yaml',
-  ];
-  if (lintConfigs.some((f) => existsAt(cwd, f))) return true;
-  const pkg = readJsonSafe(path.join(cwd, 'package.json'));
-  const scripts = (pkg?.scripts as Record<string, unknown> | undefined) ?? {};
-  return typeof scripts.lint === 'string';
-}
 
 export function recommendChecks(ctx: RecommendContext): Recommendation | null {
   if (!hasLintSignal(ctx.cwd)) return null;
@@ -370,39 +212,6 @@ export function planSchemaMode(ctx: ConfigContext): ConfigPlanItem | null {
   };
 }
 
-/**
- * One signal for the declared-artifact capability, shared by the doctor probe
- * (`recommendExtensions`) and the planner (`planFlowSources`) so they never
- * diverge (Rule 2). Kinds and filename signals are REGISTRY-DERIVED (each
- * reader's `sniff`) — no format literal lives here, so a new reader extends
- * this probe automatically. Conservative: silent the moment ANY
- * `flow.sources` entry exists (a configured repo is never re-nagged), scans
- * the git-tracked list only (bounded), openapi excluded (`flow.specs` and
- * the flow planner own specs).
- */
-function undeclaredContractArtifacts(cwd: string): Array<{ kind: string; path: string }> {
-  const policy = readJsonSafe(path.join(cwd, '.dxkit', 'policy.json')) ?? {};
-  const flow = policy.flow as Record<string, unknown> | undefined;
-  const sources = flow?.sources;
-  if (Array.isArray(sources) && sources.length > 0) return [];
-  let files: string[];
-  try {
-    files = execFileSync('git', ['ls-files'], { cwd, encoding: 'utf8', timeout: 10_000 })
-      .split('\n')
-      .slice(0, 20_000);
-  } catch {
-    return [];
-  }
-  const readers = CONTRACT_SOURCE_READERS.filter((r) => r.kind !== 'openapi');
-  const out: Array<{ kind: string; path: string }> = [];
-  for (const f of files) {
-    if (out.length >= 10) break;
-    const reader = readers.find((r) => r.sniff(f));
-    if (reader) out.push({ kind: reader.kind, path: f });
-  }
-  return out;
-}
-
 /** Recommend declaring contract artifacts the repo already has (a Postman
  *  collection, a pact, a HAR capture, .http files) — zero-code flow evidence. */
 export function recommendExtensions(ctx: RecommendContext): Recommendation | null {
@@ -461,14 +270,11 @@ export function planLintGate(ctx: ConfigContext): ConfigPlanItem | null {
 /**
  * Loop posture: if the Stop-gate is installed but `loop.preset` is unpinned,
  * pin the safe default (`security-only`). Rarely fires in practice — the loop
- * scaffold seeds the preset at install — so this is a safety net. Reuses the
- * canonical Stop-hook detector (`isClaudeLoopInstalled`, Rule 2).
+ * scaffold seeds the preset at install — so this is a safety net. Reuses
+ * `loopStopGateNeedsPreset` (shared with the doctor probe, Rule 2).
  */
 export function planLoopPreset(ctx: ConfigContext): ConfigPlanItem | null {
-  if (!isClaudeLoopInstalled(ctx.cwd)) return null;
-  const policy = readJsonSafe(path.join(ctx.cwd, '.dxkit', 'policy.json')) ?? {};
-  const loop = policy.loop as Record<string, unknown> | undefined;
-  if (loop && typeof loop.preset === 'string') return null; // already pinned
+  if (!loopStopGateNeedsPreset(ctx.cwd)) return null;
   return {
     capability: 'loop',
     section: 'loop.preset',
@@ -476,6 +282,41 @@ export function planLoopPreset(ctx: ConfigContext): ConfigPlanItem | null {
     patch: { loop: { preset: 'security-only' } },
     reason: 'pin the safe default loop posture (blocks net-new security, warns on debt)',
     evidence: 'loop Stop-gate installed, no preset pinned',
+  };
+}
+
+/** Recommend pinning `loop.preset` when the Stop-gate is installed but the
+ *  posture is unpinned — so `doctor` surfaces the same safety net `configure`
+ *  plans. Reuses `loopStopGateNeedsPreset` (Rule 2); silent once pinned. */
+export function recommendLoopPreset(ctx: RecommendContext): Recommendation | null {
+  if (!loopStopGateNeedsPreset(ctx.cwd)) return null;
+  return {
+    reason:
+      'the loop Stop-gate is installed but no `loop.preset` is pinned — pin the blocking posture so every unattended run gates identically (the safe default is security-only)',
+    command: 'vyuh-dxkit configure --plan',
+  };
+}
+
+/**
+ * Recommend on-merge report snapshots for a repo that is actively gating (dxkit
+ * installed + a baseline exists) but not publishing the score-over-time trend.
+ * Conservative: fires only once the repo is invested in the gate — so it nudges
+ * "also track the trend", never nags a fresh install — and goes silent the
+ * moment `reports.onMerge` is enabled. Recommend-only (no `planConfig`):
+ * enabling it installs the `dxkit-reports-refresh` workflow, a managed surface
+ * `configure`'s policy-only merge-write cannot place, so the driving command
+ * (`report`, via the dxkit-reports skill) owns turning it on.
+ */
+export function recommendReportsOnMerge(ctx: RecommendContext): Recommendation | null {
+  if (!existsAt(ctx.cwd, '.vyuh-dxkit.json')) return null;
+  if (!dirHasEntries(path.join(ctx.cwd, '.dxkit', 'baselines'))) return null;
+  const policy = readJsonSafe(path.join(ctx.cwd, '.dxkit', 'policy.json')) ?? {};
+  const reports = policy.reports as Record<string, unknown> | undefined;
+  if (reports?.onMerge === true) return null; // already publishing
+  return {
+    reason:
+      'you gate net-new findings but do not publish score snapshots on merge — enable reports.onMerge to track how each health dimension moves over time (the champion ROI trend)',
+    command: 'vyuh-dxkit report snapshot',
   };
 }
 

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -13,6 +13,8 @@ import {
   recommendSchema,
   recommendChecks,
   recommendDuplication,
+  recommendLoopPreset,
+  recommendReportsOnMerge,
   planBaselineMode,
   planFlowMode,
   planSchemaMode,
@@ -269,6 +271,7 @@ export const COMMANDS = [
       'block for a CI job summary or PR comment). Automate snapshots on merge with ' +
       '`policy.json:reports.onMerge` (the dxkit-reports-refresh workflow).',
     skill: 'dxkit-reports',
+    whenToRecommend: recommendReportsOnMerge,
   },
   {
     id: 'metrics',
@@ -344,6 +347,7 @@ export const COMMANDS = [
     docsBlurb:
       'Inspect and verify the autonomous-loop Stop-gate wiring, its ledger, and the correctness-floor snapshot.',
     skill: 'dxkit-loop',
+    whenToRecommend: recommendLoopPreset,
     planConfig: planLoopPreset,
   },
   {

--- a/src/discovery/posture-knobs.ts
+++ b/src/discovery/posture-knobs.ts
@@ -1,0 +1,164 @@
+/**
+ * The posture-knob discovery registry (CLAUDE.md Rule 16 — the config-knob
+ * layer). Rule 16's command-scoped enforcement (cli.ts ↔ COMMANDS parity +
+ * user-facing field completeness) guarantees a COMMAND is discoverable, but NOT
+ * that an opt-in CONFIG KNOB a command gates is reachable through the discovery
+ * surfaces — `configure` (via `planConfig`) and `doctor` / `capabilities` (via
+ * `whenToRecommend`). That gap shipped the seam gate's `duplication.mode`
+ * discovery-invisible until it was caught by hand (fixed in `b5a4db4`).
+ *
+ * A discovery-invisible knob is not a cosmetic miss: an agent onboarding a repo
+ * via `capabilities --json` never learns the gate exists, so `configure --apply`
+ * omits it and the repo is silently under-initialized — the exact failure the
+ * "five minutes to trust" funnel cannot afford.
+ *
+ * So this registry names every posture / opt-in knob and declares — per knob —
+ * which discovery probes its owning command MUST carry. `checkPostureKnobCoverage`
+ * turns that into a mechanical assertion (pinned by
+ * `test/discovery-posture-playbook.test.ts`, synthetic-injection-guarded), so a
+ * new gate cannot ship discovery-invisible on human DoD alone. A knob that
+ * deliberately carries no probe is a DECLARED exemption with a reason (mirror of
+ * Rule 16's `internal` audience and Rule 10's `DEFERRED_KINDS`), never a silent
+ * omission.
+ */
+import { userCommands } from './commands';
+import type { CapabilityDescriptor } from './command-types';
+
+/**
+ * One opt-in / posture config knob and the discovery contract its owning
+ * command must satisfy. `requiresPlan` / `requiresRecommend` say which probes
+ * are REQUIRED (a knob must be reachable through at least one surface, or carry
+ * an `exemptionReason`). `note` documents a deliberate partial choice (e.g. a
+ * knob recommend-able but not auto-plannable) — informational, not enforced.
+ */
+export interface PostureKnob {
+  /** The policy path the knob lives at (e.g. `duplication.mode`) — audit +
+   *  documentation anchor. */
+  readonly path: string;
+  /** The owning user-facing command id (must be a registered `user` command). */
+  readonly command: string;
+  /** Must the owning command expose a `planConfig` (reachable via `configure`)? */
+  readonly requiresPlan: boolean;
+  /** Must the owning command expose a `whenToRecommend` (surfaced by `doctor`
+   *  + `capabilities`)? */
+  readonly requiresRecommend: boolean;
+  /** REQUIRED when the knob requires neither probe: why it is a deliberate
+   *  exemption, not a discovery gap. */
+  readonly exemptionReason?: string;
+  /** Optional rationale for a partial contract (e.g. recommend-only, no plan). */
+  readonly note?: string;
+}
+
+/**
+ * THE registry. One entry per opt-in / posture knob. Guardrail-TUNING fields
+ * (`confidence`, `blockRules`, `addedRequiresChangedLines`, `largeFileThreshold`)
+ * are intentionally absent — they refine an already-adopted gate's behavior,
+ * they are not capabilities a repo opts INTO, so they carry no onboarding
+ * discovery contract.
+ */
+export const POSTURE_KNOBS: readonly PostureKnob[] = [
+  {
+    path: 'duplication.mode',
+    command: 'quality',
+    requiresPlan: true,
+    requiresRecommend: true,
+  },
+  { path: 'flow.mode', command: 'flow', requiresPlan: true, requiresRecommend: true },
+  { path: 'flow.sources', command: 'extensions', requiresPlan: true, requiresRecommend: true },
+  { path: 'schema.mode', command: 'schema', requiresPlan: true, requiresRecommend: true },
+  { path: 'lint', command: 'checks', requiresPlan: true, requiresRecommend: true },
+  {
+    path: 'checks',
+    command: 'checks',
+    requiresPlan: false,
+    requiresRecommend: true,
+    note: 'user invariants are repo-specific — dxkit cannot author a check command for the user, so no planConfig; recommendChecks surfaces wiring a detected linter into the gate.',
+  },
+  { path: 'baseline.mode', command: 'baseline', requiresPlan: true, requiresRecommend: true },
+  {
+    path: 'baseline.anchor',
+    command: 'baseline',
+    requiresPlan: false,
+    requiresRecommend: false,
+    exemptionReason:
+      'the anchor transport auto-derives from effective branch protection (classifyEnforcement) at publish time — not a user posture dxkit plans or recommends; documented under "Anchor transport" in policy.md.',
+  },
+  { path: 'loop.preset', command: 'loop', requiresPlan: true, requiresRecommend: true },
+  {
+    path: 'reports.onMerge',
+    command: 'report',
+    requiresPlan: false,
+    requiresRecommend: true,
+    note: 'enabling installs the dxkit-reports-refresh managed workflow, which configure’s policy-only merge-write cannot place — so no planConfig; recommendReportsOnMerge surfaces it once the repo is actively gating.',
+  },
+  {
+    path: 'graph.refresh',
+    command: 'update',
+    requiresPlan: false,
+    requiresRecommend: false,
+    exemptionReason:
+      'a CI-performance transport (graph.json Actions-cache), not a gate/posture — rebuild-on-demand is the correct default and changes no finding, so there is no behavioral difference to recommend. Installed by init/update when set to "cache"; documented in policy.md.',
+  },
+  {
+    path: 'deepSast',
+    command: 'ingest',
+    requiresPlan: false,
+    requiresRecommend: false,
+    exemptionReason:
+      'a manual pull requiring an external engine + token — dxkit never selects an engine or token for the user, so it is not an auto-plannable posture. The ingest command + dxkit-ingest skill own setup.',
+  },
+];
+
+/** A knob whose owning command does not satisfy its declared discovery contract. */
+export interface KnobCoverageGap {
+  readonly path: string;
+  readonly command: string;
+  readonly problem: string;
+}
+
+/**
+ * Assert every posture knob's owning command carries the probes the knob
+ * requires. Pure over its inputs (registry injectable for the synthetic-injection
+ * test). Returns the gaps; an empty array means full coverage.
+ */
+export function checkPostureKnobCoverage(
+  knobs: readonly PostureKnob[] = POSTURE_KNOBS,
+  registry: readonly CapabilityDescriptor[] = userCommands(),
+): KnobCoverageGap[] {
+  const gaps: KnobCoverageGap[] = [];
+  const byId = new Map(registry.map((c) => [c.id, c]));
+  for (const knob of knobs) {
+    const cmd = byId.get(knob.command);
+    if (!cmd) {
+      gaps.push({
+        path: knob.path,
+        command: knob.command,
+        problem: `owning command '${knob.command}' is not a registered user-facing command`,
+      });
+      continue;
+    }
+    if (knob.requiresPlan && !cmd.planConfig) {
+      gaps.push({
+        path: knob.path,
+        command: knob.command,
+        problem: `requires a planConfig probe (reachable via 'configure') but command '${knob.command}' has none`,
+      });
+    }
+    if (knob.requiresRecommend && !cmd.whenToRecommend) {
+      gaps.push({
+        path: knob.path,
+        command: knob.command,
+        problem: `requires a whenToRecommend probe (surfaced by 'doctor'/'capabilities') but command '${knob.command}' has none`,
+      });
+    }
+    if (!knob.requiresPlan && !knob.requiresRecommend && !knob.exemptionReason?.trim()) {
+      gaps.push({
+        path: knob.path,
+        command: knob.command,
+        problem:
+          'requires neither probe but declares no exemptionReason — a fully-exempt knob must justify why it is invisible, not omit silently',
+      });
+    }
+  }
+  return gaps;
+}

--- a/test/discovery-posture-playbook.test.ts
+++ b/test/discovery-posture-playbook.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The posture-knob playbook — enforcement for the config-knob layer of
+ * CLAUDE.md Rule 16. Mirror of `discovery-playbook.test.ts` (which gates
+ * COMMAND discoverability): the `POSTURE_KNOBS` registry names every opt-in
+ * config knob, and this test proves each knob's owning command carries the
+ * discovery probes the knob declares it needs — so a new gate cannot ship with
+ * a knob that `configure` never plans and `doctor`/`capabilities` never
+ * surface (the class that shipped the seam gate's `duplication.mode`
+ * discovery-invisible until it was caught by hand).
+ *
+ * It asserts:
+ *   - COVERAGE: every knob's owning command satisfies its declared contract
+ *     (`requiresPlan` ⟹ planConfig present; `requiresRecommend` ⟹
+ *     whenToRecommend present; fully-exempt ⟹ a reason);
+ *   - REGRESSION GUARDS: the three knobs this audit closed
+ *     (duplication.mode / loop.preset / reports.onMerge) are reachable;
+ *   - SYNTHETIC INJECTION: the coverage check actually bites — inject knobs
+ *     that violate each rule and assert each is flagged.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  POSTURE_KNOBS,
+  checkPostureKnobCoverage,
+  type PostureKnob,
+} from '../src/discovery/posture-knobs';
+import { getCommand, userCommands, type CapabilityDescriptor } from '../src/discovery/commands';
+
+describe('posture-knob registry — discovery coverage (Rule 16 config-knob layer)', () => {
+  it('every posture knob satisfies its declared discovery contract', () => {
+    const gaps = checkPostureKnobCoverage();
+    expect(
+      gaps,
+      `posture knobs missing their required discovery probes:\n${gaps
+        .map((g) => `  - ${g.path} (${g.command}): ${g.problem}`)
+        .join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('every knob names a registered user-facing owning command', () => {
+    for (const knob of POSTURE_KNOBS) {
+      const cmd = getCommand(knob.command);
+      expect(cmd, `${knob.path}: owning command '${knob.command}'`).toBeDefined();
+      expect(cmd?.audience, `${knob.path}: owning command audience`).toBe('user');
+    }
+  });
+
+  it('every fully-exempt knob declares a reason (no silent invisibility)', () => {
+    for (const knob of POSTURE_KNOBS) {
+      if (!knob.requiresPlan && !knob.requiresRecommend) {
+        expect(
+          knob.exemptionReason?.trim().length ?? 0,
+          `${knob.path}: exemptionReason`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('knob paths are unique', () => {
+    const seen = new Set<string>();
+    for (const knob of POSTURE_KNOBS) {
+      expect(seen.has(knob.path), `duplicate knob path: ${knob.path}`).toBe(false);
+      seen.add(knob.path);
+    }
+  });
+});
+
+describe('posture-knob registry — regression guards for the audit closes', () => {
+  const requiring = (path: string) => POSTURE_KNOBS.find((k) => k.path === path)!;
+
+  it('duplication.mode (the seam-gate class) is plan + recommend reachable', () => {
+    const knob = requiring('duplication.mode');
+    expect(knob.requiresPlan && knob.requiresRecommend).toBe(true);
+    const cmd = getCommand(knob.command)!;
+    expect(cmd.planConfig).toBeDefined();
+    expect(cmd.whenToRecommend).toBeDefined();
+  });
+
+  it('loop.preset now carries a whenToRecommend (gap closed)', () => {
+    const knob = requiring('loop.preset');
+    expect(knob.requiresRecommend).toBe(true);
+    expect(getCommand(knob.command)!.whenToRecommend).toBeDefined();
+  });
+
+  it('reports.onMerge now carries a whenToRecommend (gap closed)', () => {
+    const knob = requiring('reports.onMerge');
+    expect(knob.requiresRecommend).toBe(true);
+    expect(getCommand(knob.command)!.whenToRecommend).toBeDefined();
+  });
+});
+
+describe('posture-knob registry — SYNTHETIC INJECTION (the check bites)', () => {
+  // A user-facing command that carries NEITHER probe — the vehicle for the
+  // injections. `dashboard` is a pure renderer with no plan/recommend.
+  const probeless: CapabilityDescriptor = getCommand('dashboard')!;
+
+  it('flags a knob that requires a planConfig its command lacks', () => {
+    const injected: PostureKnob = {
+      path: 'synthetic.mode',
+      command: probeless.id,
+      requiresPlan: true,
+      requiresRecommend: false,
+    };
+    const gaps = checkPostureKnobCoverage([injected], userCommands());
+    expect(gaps.map((g) => g.path)).toContain('synthetic.mode');
+    expect(gaps[0].problem).toMatch(/planConfig/);
+  });
+
+  it('flags a knob that requires a whenToRecommend its command lacks', () => {
+    const injected: PostureKnob = {
+      path: 'synthetic.recommend',
+      command: probeless.id,
+      requiresPlan: false,
+      requiresRecommend: true,
+    };
+    const gaps = checkPostureKnobCoverage([injected], userCommands());
+    expect(gaps.map((g) => g.path)).toContain('synthetic.recommend');
+    expect(gaps[0].problem).toMatch(/whenToRecommend/);
+  });
+
+  it('flags a fully-exempt knob with no exemptionReason', () => {
+    const injected: PostureKnob = {
+      path: 'synthetic.exempt',
+      command: probeless.id,
+      requiresPlan: false,
+      requiresRecommend: false,
+    };
+    const gaps = checkPostureKnobCoverage([injected], userCommands());
+    expect(gaps.map((g) => g.path)).toContain('synthetic.exempt');
+    expect(gaps[0].problem).toMatch(/exemptionReason/);
+  });
+
+  it('flags a knob whose owning command is not registered', () => {
+    const injected: PostureKnob = {
+      path: 'synthetic.orphan',
+      command: 'no-such-command',
+      requiresPlan: false,
+      requiresRecommend: false,
+      exemptionReason: 'has a reason, but the command does not exist',
+    };
+    const gaps = checkPostureKnobCoverage([injected], userCommands());
+    expect(gaps.map((g) => g.path)).toContain('synthetic.orphan');
+    expect(gaps[0].problem).toMatch(/not a registered user-facing command/);
+  });
+
+  it('passes a well-formed injected knob (no false positive)', () => {
+    // `quality` carries both probes → a knob requiring both is satisfied.
+    const injected: PostureKnob = {
+      path: 'synthetic.ok',
+      command: 'quality',
+      requiresPlan: true,
+      requiresRecommend: true,
+    };
+    expect(checkPostureKnobCoverage([injected], userCommands())).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Track 3.0 — discovery-registry audit + auto-catch enforcement

Rule 16 guaranteed a **command** is discoverable, but not that an opt-in **config knob** it gates is reachable through the discovery surfaces — `configure` (via `planConfig`) and `doctor` / `capabilities` (via `whenToRecommend`). So a new gate could ship a knob an onboarding agent never learns to enable and `configure --apply` silently omits. That class shipped the seam gate's `duplication.mode` discovery-invisible until it was caught by hand (`b5a4db4`).

### Why this matters (the funnel)
The registry drives `configure` (the deterministic init engine), `capabilities --json` (the agent-facing menu an agent reads to set up an unfamiliar repo), and `doctor` (ongoing advisory). A discovery-invisible knob doesn't just miss a help line — it makes dxkit **silently under-initialize** the repo, which the "five minutes to trust" funnel can't afford.

### The audit (`tmp/feature-req/AUDIT-discovery-registry.md`)
7 knobs already fully covered. Gaps found + closed:
- **`loop.preset`** — had `planConfig`, no `whenToRecommend` → added `recommendLoopPreset` (shares its signal with the planner, Rule 2).
- **`reports.onMerge`** — no probe → added `recommendReportsOnMerge` (fires only once the repo is actively gating; recommend-only, since enabling installs a managed workflow `configure` can't place).
- **`graph.refresh`** — undocumented + no owner → documented in `policy.md`, recorded as a declared exemption (CI-perf transport, not a gate).
- **`deepSast`/ingest** — declared exemption (manual pull, not auto-plannable).

### The strengthening (auto-catch, not human-DoD)
- **`POSTURE_KNOBS` registry** (`src/discovery/posture-knobs.ts`) names every posture knob and declares which probes its owning command must carry. `checkPostureKnobCoverage` turns that into a mechanical assertion.
- **`test/discovery-posture-playbook.test.ts`** — coverage assertion + 3 regression guards + 5 synthetic-injection cases (mirror of the command playbook / `managed-artifacts-playbook`). A probe-less knob is a **declared exemption with a reason**, never a silent omission.
- Extracted the shared `has*Signal` predicates into `advisor-signals.ts` (keeps `advisor.ts` cohesive + under the size budget; Rule 2 single-source preserved).

### Validation
- Full suite **3964 green** (268 files); build / typecheck / typecheck:test / arch-check / eslint / prettier all clean.
- End-to-end on crafted fixtures: both new probes fire when relevant and go silent once configured.

Docs: CLAUDE.md Rule 16 enforcement section + CHANGELOG + policy.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4qmoW4EV9LfHsd5hwNsxh