### PR TITLE
feat(pr): compute a reviewable PR body from the branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`vyuh-dxkit pr` — a computed, reviewable PR body.** The deterministic core of
+  the `dxkit-pr` skill: it reads the branch's real commits + diff for
+  `base..HEAD` and computes the parts that used to drift when hand-assembled — the
+  title (dominant conventional-commit type + scope), the Changes section bucketed
+  by commit type, the dxkit signals block (the receipt: verdict + allowlist
+  delta), suggested reviewers (the active-owner model), a **diff-derived reviewer
+  checklist** (a registry of pure fact → row rules: a supply-chain row only when a
+  dependency manifest moved, a migration row only when a migration moved, a tests
+  row when source changed without a test, a CI-scrutiny row when a workflow/hook
+  moved), and a **Structural review** section that surfaces functions the change
+  adds which structurally match existing code — the seam signal as a warn-tier
+  reviewer prompt ("added X matches existing Y — confirm intentional or
+  consolidate"), never a block. The author writes only "What & why". Prints
+  markdown or `--json`; reads git + the cache-backed guardrail and writes nothing
+  — it never opens the PR. This lands the structural-duplicate lane's value into
+  the review loop: `receipt` and `reviewers` gained reusable non-printing cores
+  (`buildReceipt` / `computeReviewers`) that `pr` composes (Rule 2).
+
 ### Changed
 
 - **Structural-duplicate (seam) signal re-sourced from dxkit's own AST, with

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,48 +52,49 @@ construction; commands with a linked page have a full reference under
 
 <!-- dxkit:command-table:begin — generated from src/discovery/command-defs.ts by `npm run docs:commands`; do not edit by hand -->
 
-| Command                                                          | What it does                                                                     | Typical runtime                    |
-| ---------------------------------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------- |
-| [`health`](commands/health.md)                                   | Run the deterministic 6-dimension health analysis                                | 1-4 min                            |
-| [`vulnerabilities`](commands/vulnerabilities.md)                 | Run the deep security scan                                                       | 1-3 min                            |
-| [`test-gaps`](commands/test-gaps.md)                             | Analyze test coverage gaps                                                       | 30-90 sec                          |
-| `tests`                                                          | Select tests affected by a diff via the code graph                               | < 5 sec (queries the graph)        |
-| `evaluate`                                                       | Zero-write trial: replay your recent landings through the gate                   | 30 sec - 1 min per landing         |
-| [`quality`](commands/quality.md)                                 | Code quality + slop detection                                                    | 1-8 min (jscpd is the long-pole)   |
-| [`dev-report`](commands/dev-report.md)                           | Developer activity analysis                                                      | 5-30 sec                           |
-| [`licenses`](commands/licenses.md)                               | Dependency license inventory                                                     | 30-60 sec                          |
-| [`bom`](commands/bom.md)                                         | Bill of Materials (licenses + vulnerabilities joined)                            | 1-3 min                            |
-| [`coverage`](commands/coverage.md)                               | Run per-pack test-with-coverage (materializes the artifact)                      | varies (runs your tests)           |
-| [`dashboard`](commands/dashboard.md)                             | Render .dxkit/reports/ into one HTML dashboard                                   | < 5 sec (renders existing reports) |
-| [`report`](commands/report.md)                                   | Full audit (report), or publish/read a score snapshot (report snapshot\|history) | 5-30 min                           |
-| `metrics`                                                        | Findings the gate stopped before merge + the score-over-time trend               | < 5 sec                            |
-| [`baseline`](commands/baseline.md)                               | Capture / publish / show per-finding baselines for the guardrail                 | 30 sec - 2 min                     |
-| [`guardrail`](commands/guardrail.md)                             | Diff current scan vs baseline; block on net-new regressions                      | 30 sec - 2 min                     |
-| `receipt`                                                        | Emit the PR "dxkit signals" block (verdict + allowlist + score delta)            | < 30 sec                           |
-| [`allowlist`](commands/allowlist.md)                             | Suppress / audit individual findings with typed reasons                          | < 1 sec                            |
-| `ingest`                                                         | Ingest external SAST (SARIF) findings as first-class                             | varies (reads engine SARIF)        |
-| [`loop`](commands/loop.md)                                       | Autonomous-loop utilities (doctor / ledger / snapshot)                           | < 5 sec                            |
-| [`checks`](commands/checks.md)                                   | List / dry-run your custom repo-invariant + lint gates                           | varies (runs your checks)          |
-| `extensions`                                                     | Plug your own extractors and sinks into dxkit (any language)                     | seconds (the `dev` loop)           |
-| `schema`                                                         | Data-model inventory + the schema drift gate                                     | 5-30 sec                           |
-| `flow`                                                           | UI→API integration mapping + the broken-integration gate                         | 5-30 sec                           |
-| [`explore`](commands/explore.md)                                 | Repo exploration via the code graph                                              | < 5 sec (queries the graph)        |
-| [`context`](commands/context.md)                                 | Slim structural code slice for a query (token-efficient)                         | < 5 sec (queries the graph)        |
-| [`reviewers`](commands/reviewers.md)                             | Suggest reviewers via the active-owner model                                     | < 5 sec                            |
-| `demo`                                                           | Offline, no-API demonstration walkthroughs                                       | 1-2 min (interactive walkthrough)  |
-| [`init`](commands/init.md)                                       | Install dxkit agent DX in this repo                                              | 5-30 sec                           |
-| [`update`](commands/update.md)                                   | Re-generate managed files (preserves your edits)                                 | 5-30 sec                           |
-| `uninstall`                                                      | Remove dxkit, restoring the exact pre-dxkit state                                | < 30 sec                           |
-| [`doctor`](commands/doctor.md)                                   | Verify setup — and recommend capabilities you are not using                      | < 5 sec                            |
-| `configure`                                                      | Compute + apply a deterministic config plan for this repo                        | < 30 sec                           |
-| `capabilities`                                                   | List every dxkit capability + what this repo should adopt                        | < 5 sec                            |
-| [`tools`](commands/tools.md)                                     | Show / install required analysis tools                                           | < 5 sec (list); install varies     |
-| `hooks`                                                          | Activate the dxkit git hooks (core.hooksPath)                                    | < 5 sec                            |
-| [`setup-branch-protection`](commands/setup-branch-protection.md) | Set up branch protection / required checks (dry-run by default)                  | < 5 sec                            |
-| [`setup-prebuild`](commands/setup-prebuild.md)                   | Set up the devcontainer prebuild workflow                                        | < 5 sec                            |
-| [`upgrade`](commands/upgrade.md)                                 | Plan / apply a dxkit version upgrade                                             | 1-3 min                            |
-| [`issue`](commands/issue.md)                                     | Open a pre-filled GitHub issue against dxkit                                     | < 5 sec                            |
-| [`to-xlsx`](commands/to-xlsx.md)                                 | Convert a dxkit JSON report to XLSX                                              | < 5 sec                            |
+| Command                                                          | What it does                                                                      | Typical runtime                    |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------- |
+| [`health`](commands/health.md)                                   | Run the deterministic 6-dimension health analysis                                 | 1-4 min                            |
+| [`vulnerabilities`](commands/vulnerabilities.md)                 | Run the deep security scan                                                        | 1-3 min                            |
+| [`test-gaps`](commands/test-gaps.md)                             | Analyze test coverage gaps                                                        | 30-90 sec                          |
+| `tests`                                                          | Select tests affected by a diff via the code graph                                | < 5 sec (queries the graph)        |
+| `evaluate`                                                       | Zero-write trial: replay your recent landings through the gate                    | 30 sec - 1 min per landing         |
+| [`quality`](commands/quality.md)                                 | Code quality + slop detection                                                     | 1-8 min (jscpd is the long-pole)   |
+| [`dev-report`](commands/dev-report.md)                           | Developer activity analysis                                                       | 5-30 sec                           |
+| [`licenses`](commands/licenses.md)                               | Dependency license inventory                                                      | 30-60 sec                          |
+| [`bom`](commands/bom.md)                                         | Bill of Materials (licenses + vulnerabilities joined)                             | 1-3 min                            |
+| [`coverage`](commands/coverage.md)                               | Run per-pack test-with-coverage (materializes the artifact)                       | varies (runs your tests)           |
+| [`dashboard`](commands/dashboard.md)                             | Render .dxkit/reports/ into one HTML dashboard                                    | < 5 sec (renders existing reports) |
+| [`report`](commands/report.md)                                   | Full audit (report), or publish/read a score snapshot (report snapshot\|history)  | 5-30 min                           |
+| `metrics`                                                        | Findings the gate stopped before merge + the score-over-time trend                | < 5 sec                            |
+| [`baseline`](commands/baseline.md)                               | Capture / publish / show per-finding baselines for the guardrail                  | 30 sec - 2 min                     |
+| [`guardrail`](commands/guardrail.md)                             | Diff current scan vs baseline; block on net-new regressions                       | 30 sec - 2 min                     |
+| `receipt`                                                        | Emit the PR "dxkit signals" block (verdict + allowlist + score delta)             | < 30 sec                           |
+| `pr`                                                             | Compute a reviewable PR body from the branch (title, changes, signals, checklist) | < 30 sec (longer with --since)     |
+| [`allowlist`](commands/allowlist.md)                             | Suppress / audit individual findings with typed reasons                           | < 1 sec                            |
+| `ingest`                                                         | Ingest external SAST (SARIF) findings as first-class                              | varies (reads engine SARIF)        |
+| [`loop`](commands/loop.md)                                       | Autonomous-loop utilities (doctor / ledger / snapshot)                            | < 5 sec                            |
+| [`checks`](commands/checks.md)                                   | List / dry-run your custom repo-invariant + lint gates                            | varies (runs your checks)          |
+| `extensions`                                                     | Plug your own extractors and sinks into dxkit (any language)                      | seconds (the `dev` loop)           |
+| `schema`                                                         | Data-model inventory + the schema drift gate                                      | 5-30 sec                           |
+| `flow`                                                           | UI→API integration mapping + the broken-integration gate                          | 5-30 sec                           |
+| [`explore`](commands/explore.md)                                 | Repo exploration via the code graph                                               | < 5 sec (queries the graph)        |
+| [`context`](commands/context.md)                                 | Slim structural code slice for a query (token-efficient)                          | < 5 sec (queries the graph)        |
+| [`reviewers`](commands/reviewers.md)                             | Suggest reviewers via the active-owner model                                      | < 5 sec                            |
+| `demo`                                                           | Offline, no-API demonstration walkthroughs                                        | 1-2 min (interactive walkthrough)  |
+| [`init`](commands/init.md)                                       | Install dxkit agent DX in this repo                                               | 5-30 sec                           |
+| [`update`](commands/update.md)                                   | Re-generate managed files (preserves your edits)                                  | 5-30 sec                           |
+| `uninstall`                                                      | Remove dxkit, restoring the exact pre-dxkit state                                 | < 30 sec                           |
+| [`doctor`](commands/doctor.md)                                   | Verify setup — and recommend capabilities you are not using                       | < 5 sec                            |
+| `configure`                                                      | Compute + apply a deterministic config plan for this repo                         | < 30 sec                           |
+| `capabilities`                                                   | List every dxkit capability + what this repo should adopt                         | < 5 sec                            |
+| [`tools`](commands/tools.md)                                     | Show / install required analysis tools                                            | < 5 sec (list); install varies     |
+| `hooks`                                                          | Activate the dxkit git hooks (core.hooksPath)                                     | < 5 sec                            |
+| [`setup-branch-protection`](commands/setup-branch-protection.md) | Set up branch protection / required checks (dry-run by default)                   | < 5 sec                            |
+| [`setup-prebuild`](commands/setup-prebuild.md)                   | Set up the devcontainer prebuild workflow                                         | < 5 sec                            |
+| [`upgrade`](commands/upgrade.md)                                 | Plan / apply a dxkit version upgrade                                              | 1-3 min                            |
+| [`issue`](commands/issue.md)                                     | Open a pre-filled GitHub issue against dxkit                                      | < 5 sec                            |
+| [`to-xlsx`](commands/to-xlsx.md)                                 | Convert a dxkit JSON report to XLSX                                               | < 5 sec                            |
 
 <!-- dxkit:command-table:end -->
 

--- a/src-templates/.claude/skills/dxkit-pr/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-pr/SKILL.md
@@ -19,132 +19,88 @@ otherwise have to reconstruct by hand.
 ## The PR loop
 
 ```
-[1] Survey      → branch vs base: commits, diff stat, files touched
-[2] Classify    → features / fixes / refactors / docs / findings closed
-[3] Signals     → guardrail verdict + allowlist activity + score deltas
-[4] Draft       → title + body grounded in [1]–[3] + a reviewer checklist
-[5] Confirm     → show the user the draft; open with `gh pr create` on yes
+[1] Compute     → `vyuh-dxkit pr` builds the body from the real commits + diff
+[2] Narrate     → you write only "What & why"; tailor the computed checklist
+[3] Confirm     → show the user the draft; open with `gh pr create` on yes
 ```
 
-Don't skip [5]. A PR is outward-facing — show the draft and get a yes before
+The heavy lifting is one command. `vyuh-dxkit pr` reads `base..HEAD` and emits a
+ready-to-review body with the parts that used to drift when hand-assembled:
+
+- a **title** from the dominant conventional-commit type + scope,
+- a **Changes** section bucketed by commit type (Features / Fixes / Refactors / …),
+- the **dxkit signals** block (the receipt: guardrail verdict + allowlist delta),
+- **suggested reviewers** (the active-owner model, blended with CODEOWNERS),
+- a **diff-derived reviewer checklist** (a supply-chain row only when a manifest
+  moved, a migration row only when a migration moved, a tests row when source
+  changed without a test, …), and
+- a **Structural review** section: functions this change adds that structurally
+  match existing code — the seam signal as a reviewer prompt, not a block.
+
+Everything there is computed from the branch, so the body can't misrepresent the
+change. Your job is the narrative ("What & why") and pruning/tailoring the
+checklist to the actual change.
+
+```bash
+vyuh-dxkit pr --base <base-branch>              # markdown body on stdout
+vyuh-dxkit pr --base <base-branch> --since <base-branch>   # + health-score movement
+vyuh-dxkit pr --base <base-branch> --json       # every computed field, to parse
+```
+
+`--since <ref>` adds the per-dimension score-movement table (it runs a base-ref
+analysis, so omit it if you only need the verdict + checklist). `--no-seams`
+skips the structural-duplicate pass. The command reads git + the (cache-backed)
+guardrail and writes nothing — it never opens the PR.
+
+Don't skip [3]. A PR is outward-facing — show the draft and get a yes before
 opening it.
 
-## [1] Survey — read the branch, don't guess
+## [1] Compute — run the command, read what it produced
 
 ```bash
 git fetch origin
-BASE=origin/main                      # or the repo's default branch
-git log --oneline $BASE..HEAD         # every commit on this branch
-git diff --stat $BASE...HEAD          # files + churn
-git diff $BASE...HEAD                 # the actual change, when you need detail
+vyuh-dxkit pr --base origin/main --since origin/main    # or the repo's default branch
 ```
 
-Read the commit messages first — on a well-kept branch they already narrate the
-work. Use the diff to verify and fill gaps, not to re-derive everything.
+The body it prints is the draft's skeleton. Skim the diff (`git diff --stat
+$BASE...HEAD`) to confirm the computed classification matches what you know you
+changed — the command reads commit *subjects*, so a poorly-titled commit lands in
+the `Other` bucket, and that's your cue to describe it in the narrative.
 
-## [2] Classify — group the change for a reviewer
+Two computed sections are load-bearing and you should read them, not just paste:
 
-Sort the commits/diff into the buckets a reviewer cares about:
+- **dxkit signals** — the guardrail verdict + allowlist delta. If it's BLOCKED,
+  the PR isn't ready: hand off to `dxkit-action` to fix the net-new findings
+  first. The block reuses the session verdict cache, so it's the same result the
+  pre-push hook produced moments ago, not a fresh scan.
+- **Structural review** — functions this change adds that structurally match
+  existing code. This is advisory (warn-tier, never a block): for each one,
+  either confirm in the narrative that the parallel is intentional, or consolidate
+  before opening. It's exactly the "you copied an existing function" signal a
+  human reviewer would otherwise have to notice by eye.
 
-- **Features** — new capability, with the entry point / surface it adds.
-- **Fixes** — bugs or findings closed (name the finding if it came from a dxkit
-  report: rule, file, severity).
-- **Refactors** — behavior-preserving structure changes (flag these — they're
-  where "looks big, reads safe" lives).
-- **Docs / tests / chore** — supporting changes.
+Reviewers come from the **active-owner model** (recency-weighted git history,
+bots + departed devs filtered, author excluded, blended with CODEOWNERS). Honor
+its caveats: a `busFactor: 1` line is a real single-point-of-failure to call out;
+a `note` (owners inactive / no signal) means don't invent a reviewer. It renders
+`@handle`s, never emails, and you can pass them to `gh pr create --reviewer`.
 
-Lead the body with the *why* (the problem) and the *what* (the approach), then
-the bucketed change list. Keep it proportional — a one-commit fix gets a short
-body; a multi-commit feature gets sections.
+## [2] Narrate + tailor — the only hand-written parts
 
-## [3] Signals — one command, computed not narrated
+The command leaves one placeholder: `## What & why`. Write the problem this
+solves and the approach, in 1–3 sentences — proportional to the change (a
+one-commit fix gets a line; a multi-commit feature gets a short paragraph).
+Refine the suggested **title** if the computed one is generic (it's the dominant
+commit type + the headline commit's subject; make it specific and imperative).
 
-The signals block (guardrail verdict, allowlist delta, score movement) is a
-COMMAND, not something you hand-assemble: `vyuh-dxkit receipt`. It emits
-ready-to-paste markdown, so the PR body can never misrepresent gate state, and
-it **reuses the verdict cache** — a feature session normally ran the gate against
-this exact HEAD moments ago (dxkit-feature verify, the pre-push hook), so
-`receipt` replays that result instead of paying a third ~25s scan. It re-runs
-only when the tree actually changed since the last gather.
+Then **tailor the computed checklist** to the actual change — the rules are
+diff-derived (a supply-chain row appears only when a manifest moved, a migration
+row only when a migration moved), but you know things the diff can't show: drop a
+row that doesn't apply, add a specific one (a config flag to set, a caller to
+re-test from the blast radius, a manual step to run). A targeted checklist guides
+the review; a generic one is noise.
 
-```bash
-npx vyuh-dxkit receipt --since <base-branch>    # verdict + allowlist delta + score movement
-```
-
-- `--since <ref>` adds the health-score movement vs the base branch (it runs a
-  base-ref analysis, so omit it if you only need the verdict + allowlist — that
-  part is always cached and instant).
-- `--json` if you want to parse it; `--refresh` forces a fresh gather (rarely
-  needed — the cache already misses on any real tree change).
-
-Paste `receipt`'s output straight into the body under `## dxkit signals`. It
-already contains:
-
-- **Guardrail verdict** — PASS, or BLOCKED with the net-new findings named.
-- **Allowlist delta** — any suppression added on this branch, with category +
-  reason + expiry, called out for explicit review (suppressions are the
-  highest-trust thing a reviewer approves).
-- **Score movement** — the per-dimension base→head table (only with `--since`).
-
-Because the block is computed, you don't transcribe numbers by hand — that's
-what used to let a PR body drift from the real gate state. `receipt` is
-informational (it never fails the command); `guardrail check` remains the gate.
-
-### Suggested reviewers
-
-```bash
-npx vyuh-dxkit reviewers --base <base-branch> --json
-```
-
-This ranks reviewers by the **active-owner model** — recency-weighted git
-history on the touched files, with bots and departed contributors filtered, the
-PR author excluded, blended with `CODEOWNERS`. Better signal than the platform's
-naive last-touch suggestion. Surface the top few in the body with the *why*
-("@alice — owns 3/4 touched files, active"), and you can pass them to
-`gh pr create --reviewer`. Honor the output's caveats: if it returns a
-`busFactor: 1`, note the single-point-of-failure; if it returns a `note`
-(original authors inactive / no signal), say so rather than inventing a
-reviewer. Renders `@handle`s, never emails.
-
-## [4] Draft — title, body, reviewer checklist
-
-**Title** — imperative, scoped, specific. `feat(auth): add refresh-token
-rotation`, not `Updates`. Match the repo's existing PR/commit convention
-(check `git log` on the base branch).
-
-**Body** — structure:
-
-```markdown
-## What & why
-<the problem this solves, in 1–3 sentences>
-
-## Changes
-- **Feature:** …
-- **Fix:** … (closes <finding/issue>)
-- **Refactor:** … (behavior-preserving)
-
-<!-- ## dxkit signals — paste `vyuh-dxkit receipt --since <base>` output here.
-     It already renders the verdict, allowlist delta, and score-movement table. -->
-
-## Suggested reviewers
-- @alice — owns 3/4 touched files, active · @bob — CODEOWNERS
-  (or the `note` when there's no active-owner signal)
-
-## Reviewer checklist
-- [ ] Change matches the description; scope isn't broader than stated
-- [ ] <feature>: behavior verified (how to exercise it)
-- [ ] Refactors are behavior-preserving (no silent semantic change)
-- [ ] New/changed code is tested; test gaps addressed or noted
-- [ ] Any allowlist suppression is justified (category + reason + expiry)
-- [ ] No secrets/keys/tokens in the diff
-- [ ] Docs updated if behavior or interfaces changed
-```
-
-Tailor the checklist to the *actual* change — drop rows that don't apply, add
-specific ones (a migration step, a config flag to set, a caller to re-test from
-the blast radius). A generic checklist is noise; a targeted one guides the review.
-
-## [5] Confirm + open
+## [3] Confirm + open
 
 Show the user the full draft (title + body) and confirm. On yes:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -178,6 +178,12 @@ ${renderCommandIndex().join('\n')}
                                  (recency-weighted git history, bots + departed devs
                                  filtered, excludes the author) blended with CODEOWNERS,
                                  with a bus-factor signal. Names + @handles, never emails.
+    vyuh-dxkit pr [path] [--base <ref>] [--since <ref>] [--no-seams] [--json]
+                                 Compute a reviewable PR body from the branch's real commits +
+                                 diff: title, bucketed Changes, the dxkit signals block (receipt),
+                                 suggested reviewers, a diff-derived reviewer checklist, and the
+                                 structural-duplicate seam prompts. Leaves only "What & why" for
+                                 the author. Prints markdown (or --json); never opens a PR.
     vyuh-dxkit to-xlsx <json>    Convert a dxkit JSON report to 15-col XLSX
     vyuh-dxkit tools [path]      Show required analysis tools status
     vyuh-dxkit tools install     Interactively install missing tools
@@ -447,6 +453,8 @@ export async function run(argv: string[]): Promise<void> {
       // report snapshot flag: retain the most recent N history entries
       retain: { type: 'string' },
       substring: { type: 'boolean', default: false },
+      // pr: skip the structural-duplicate seam pass
+      'no-seams': { type: 'boolean', default: false },
       // reviewers flags
       staged: { type: 'boolean', default: false },
       base: { type: 'string' },
@@ -935,6 +943,18 @@ export async function run(argv: string[]): Promise<void> {
         verbose: !!values.verbose,
         out: values.output as string | undefined,
       });
+      break;
+    }
+
+    case 'pr': {
+      const { runPr } = await import('./pr/run');
+      const body = await runPr(resolveRepoPath(positionals[1]), {
+        base: values.base as string | undefined,
+        since: values.since as string | undefined,
+        json: !!values.json,
+        noSeams: !!values['no-seams'],
+      });
+      process.stdout.write(body + '\n'); // slop-ok
       break;
     }
 

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -319,6 +319,16 @@ export const COMMANDS = [
     skill: 'dxkit-pr',
   },
   {
+    id: 'pr',
+    audience: 'user',
+    group: 'gate',
+    summary: 'Compute a reviewable PR body from the branch (title, changes, signals, checklist)',
+    typicalRuntime: '< 30 sec (longer with --since)',
+    docsBlurb:
+      'The deterministic core of the dxkit-pr skill: reads the branch commits + diff and computes the title, bucketed Changes, the receipt signals block, suggested reviewers, a diff-derived reviewer checklist, and the structural-duplicate seam prompts — leaving only "What & why" for the author. Prints markdown or --json; never opens the PR.',
+    skill: 'dxkit-pr',
+  },
+  {
     id: 'allowlist',
     audience: 'user',
     group: 'gate',
@@ -362,7 +372,6 @@ export const COMMANDS = [
     whenToRecommend: recommendChecks,
     planConfig: planLintGate,
   },
-
   {
     id: 'extensions',
     audience: 'user',

--- a/src/pr/checklist.ts
+++ b/src/pr/checklist.ts
@@ -1,0 +1,128 @@
+/**
+ * The reviewer-checklist engine for `vyuh-dxkit pr`: a registry of pure
+ * fact → row rules. Each rule inspects the diff facts and, when it applies,
+ * contributes one checklist row targeted at what THIS change actually touched —
+ * a migration row only when a migration moved, a supply-chain row only when a
+ * dependency manifest moved. A generic checklist is noise; a diff-derived one
+ * guides the review.
+ *
+ * `deriveFacts` is pure (structured diff inputs → `DiffFacts`), so the whole
+ * checklist is testable without git. The rows are stable and deterministic.
+ */
+import type { LanguageSupport } from '../languages/types';
+import { changedFilesTouchDependencyManifest } from '../languages/index';
+import { isTestSourceFile } from '../analyzers/tools/walk-source-files';
+
+/** Structured, git-free inputs the facts are derived from. */
+export interface DiffInputs {
+  /** Repo-relative paths changed in `base..HEAD`. */
+  readonly changedFiles: readonly string[];
+  /** Lines ADDED by the diff (the `+` side, prefix stripped) — scanned for
+   *  intrinsic markers (an inline allowlist annotation, an `export`). Kept small
+   *  by the caller (added lines only, not the whole file). */
+  readonly addedLines: readonly string[];
+  /** Active language packs (for pack-driven dependency-manifest matching). */
+  readonly packs: readonly LanguageSupport[];
+}
+
+/** The boolean facts the checklist rules switch on. */
+export interface DiffFacts {
+  readonly allowlistTouched: boolean;
+  readonly dependencyTouched: boolean;
+  readonly migrationTouched: boolean;
+  readonly publicApiChanged: boolean;
+  readonly sourceChanged: boolean;
+  readonly testChanged: boolean;
+  readonly ciOrHookTouched: boolean;
+}
+
+const SOURCE_EXT = /\.(ts|tsx|js|jsx|mjs|cjs|py|go|rs|cs|kt|java|rb)$/;
+const MIGRATION = /(^|\/)(migrations?|db\/migrate)\//i;
+const SCHEMA_FILE = /(schema\.prisma|\.sql|schema\.rb|\/schema\/)/i;
+const CI_OR_HOOK = /(^|\/)(\.github\/workflows\/|\.githooks\/|\.husky\/)/;
+const ALLOWLIST_FILE = /(^|\/)\.dxkit\/allowlist/;
+const INLINE_ALLOW = /dxkit-allow[:=]/;
+// A public-surface signal: an added or removed top-level `export` (JS/TS),
+// `func`/`pub fn`/`public` export shapes are covered coarsely by the language
+// packs elsewhere; here we key on the most common exported-symbol markers.
+const EXPORTED_SYMBOL = /\bexport\b|\bpublic\s|\bpub\s+(fn|struct|enum|trait)\b/;
+
+/** Derive the boolean diff facts. Pure. */
+export function deriveFacts(input: DiffInputs): DiffFacts {
+  const { changedFiles, addedLines, packs } = input;
+  const isSource = (f: string): boolean => SOURCE_EXT.test(f);
+
+  const sourceFiles = changedFiles.filter((f) => isSource(f) && !isTestSourceFile(f));
+  const testFiles = changedFiles.filter((f) => isTestSourceFile(f));
+
+  return {
+    allowlistTouched:
+      changedFiles.some((f) => ALLOWLIST_FILE.test(f)) ||
+      addedLines.some((l) => INLINE_ALLOW.test(l)),
+    dependencyTouched: packs.length > 0 && changedFilesTouchDependencyManifest(changedFiles, packs),
+    migrationTouched: changedFiles.some((f) => MIGRATION.test(f) || SCHEMA_FILE.test(f)),
+    publicApiChanged: sourceFiles.length > 0 && addedLines.some((l) => EXPORTED_SYMBOL.test(l)),
+    sourceChanged: sourceFiles.length > 0,
+    testChanged: testFiles.length > 0,
+    ciOrHookTouched: changedFiles.some((f) => CI_OR_HOOK.test(f)),
+  };
+}
+
+interface ChecklistRule {
+  readonly id: string;
+  readonly when: (f: DiffFacts) => boolean;
+  readonly row: string;
+}
+
+/**
+ * The rule registry. Always-on rows (scope, secrets) anchor every review; the
+ * rest are fact-gated so they appear only when the change touches that surface.
+ * Order here is the render order.
+ */
+export const CHECKLIST_RULES: readonly ChecklistRule[] = [
+  {
+    id: 'scope',
+    when: () => true,
+    row: 'Change matches the description; scope is not broader than stated',
+  },
+  {
+    id: 'allowlist',
+    when: (f) => f.allowlistTouched,
+    row: 'Each allowlist suppression is justified (category + reason + expiry) — the highest-trust thing to approve',
+  },
+  {
+    id: 'dependency',
+    when: (f) => f.dependencyTouched,
+    row: 'Supply chain: review added/updated dependencies (new packages, version bumps, lockfile churn)',
+  },
+  {
+    id: 'migration',
+    when: (f) => f.migrationTouched,
+    row: 'Data-model / migration change is reversible and backward-compatible with in-flight data',
+  },
+  {
+    id: 'public-api',
+    when: (f) => f.publicApiChanged,
+    row: 'Exported/public API change preserves backward compatibility (callers updated, or the break is intended + noted)',
+  },
+  {
+    id: 'tests',
+    when: (f) => f.sourceChanged && !f.testChanged,
+    row: 'Source changed without a matching test change — add tests or note why the gap is acceptable',
+  },
+  {
+    id: 'ci-security',
+    when: (f) => f.ciOrHookTouched,
+    row: 'CI workflow / git-hook change reviewed with pipeline-level scrutiny (it runs with repository privileges)',
+  },
+  {
+    id: 'secrets',
+    when: () => true,
+    row: 'No secrets, keys, or tokens in the diff',
+  },
+];
+
+/** The checklist rows that apply to this diff, in registry order. */
+export function buildChecklist(facts: DiffFacts): string[] {
+  return CHECKLIST_RULES.filter((r) => r.when(facts)).map((r) => r.row);
+}

--- a/src/pr/commits.ts
+++ b/src/pr/commits.ts
@@ -1,0 +1,177 @@
+/**
+ * Conventional-commit parsing for `vyuh-dxkit pr` — turns the branch's commit
+ * log into the two things a PR body needs computed rather than improvised: a
+ * suggested title (the dominant commit type + scope) and the "Changes" section
+ * bucketed by type.
+ *
+ * Pure and git-free: the caller hands in the raw `git log` subjects for
+ * `base..HEAD`; every function here is a deterministic transform over that list.
+ * A subject that isn't conventional-commit shaped is still kept (as an
+ * `other`-typed commit) so nothing is silently dropped.
+ */
+
+/** The conventional-commit types we recognize, in headline priority order — the
+ *  dominant-type tiebreak walks this list, so a branch mixing a feat and a
+ *  chore titles as the feat. `other` catches non-conventional subjects. */
+export const COMMIT_TYPES = [
+  'feat',
+  'fix',
+  'perf',
+  'refactor',
+  'docs',
+  'test',
+  'build',
+  'ci',
+  'style',
+  'chore',
+  'revert',
+  'other',
+] as const;
+export type CommitType = (typeof COMMIT_TYPES)[number];
+
+export interface ParsedCommit {
+  readonly type: CommitType;
+  /** The `(scope)` when present, else undefined. */
+  readonly scope?: string;
+  /** The subject line with the `type(scope): ` prefix stripped. */
+  readonly subject: string;
+  /** Whether the commit marked a breaking change (`!` or `BREAKING`). */
+  readonly breaking: boolean;
+  /** The original subject, verbatim. */
+  readonly raw: string;
+}
+
+const CONVENTIONAL = /^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/;
+
+/** Parse one `git log --format=%s` subject into a ParsedCommit. A subject that
+ *  doesn't match the conventional-commit grammar becomes `type: 'other'` with
+ *  the whole line as its subject — kept, never dropped. */
+export function parseCommitSubject(raw: string): ParsedCommit {
+  const m = CONVENTIONAL.exec(raw.trim());
+  if (!m) {
+    return { type: 'other', subject: raw.trim(), breaking: /BREAKING[ -]CHANGE/.test(raw), raw };
+  }
+  const [, typeRaw, scope, bang, subject] = m;
+  const type = (COMMIT_TYPES as readonly string[]).includes(typeRaw.toLowerCase())
+    ? (typeRaw.toLowerCase() as CommitType)
+    : 'other';
+  return {
+    type,
+    ...(scope ? { scope } : {}),
+    subject: subject.trim(),
+    breaking: bang === '!' || /BREAKING[ -]CHANGE/.test(raw),
+    raw,
+  };
+}
+
+/** Parse a list of subjects (newest-first from `git log`). */
+export function parseCommits(subjects: readonly string[]): ParsedCommit[] {
+  return subjects
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(parseCommitSubject);
+}
+
+/** The display bucket a commit type rolls up into for the "Changes" section. */
+export const TYPE_BUCKET: Record<CommitType, string> = {
+  feat: 'Features',
+  fix: 'Fixes',
+  perf: 'Refactors',
+  refactor: 'Refactors',
+  docs: 'Docs',
+  test: 'Tests',
+  build: 'Chore',
+  ci: 'Chore',
+  style: 'Chore',
+  chore: 'Chore',
+  revert: 'Fixes',
+  other: 'Other',
+};
+
+/** Bucket order in the rendered "Changes" section. */
+const BUCKET_ORDER = ['Features', 'Fixes', 'Refactors', 'Docs', 'Tests', 'Chore', 'Other'];
+
+export interface ChangeBucket {
+  readonly label: string;
+  readonly commits: readonly ParsedCommit[];
+}
+
+/** Group commits into display buckets, dropping empty buckets, in a stable
+ *  reviewer-facing order (Features first). */
+export function bucketCommits(commits: readonly ParsedCommit[]): ChangeBucket[] {
+  const byBucket = new Map<string, ParsedCommit[]>();
+  for (const c of commits) {
+    const b = TYPE_BUCKET[c.type];
+    (byBucket.get(b) ?? byBucket.set(b, []).get(b)!).push(c);
+  }
+  return BUCKET_ORDER.filter((b) => byBucket.has(b)).map((label) => ({
+    label,
+    commits: byBucket.get(label)!,
+  }));
+}
+
+/**
+ * The dominant commit type — the highest-priority type present, weighted by
+ * count. We pick the type with the most commits; ties break by `COMMIT_TYPES`
+ * priority (feat over fix over chore). `other`-only branches return `other`.
+ */
+export function dominantType(commits: readonly ParsedCommit[]): CommitType {
+  if (commits.length === 0) return 'other';
+  const counts = new Map<CommitType, number>();
+  for (const c of commits) counts.set(c.type, (counts.get(c.type) ?? 0) + 1);
+  let best: CommitType = 'other';
+  let bestCount = -1;
+  for (const t of COMMIT_TYPES) {
+    const n = counts.get(t) ?? 0;
+    // Strictly-greater keeps the first (highest-priority) type on a tie.
+    if (n > bestCount) {
+      best = t;
+      bestCount = n;
+    }
+  }
+  return best;
+}
+
+/** The most common scope among commits of the given type (undefined when none
+ *  carry a scope). Ties break toward the first-seen scope for determinism. */
+export function dominantScope(
+  commits: readonly ParsedCommit[],
+  type: CommitType,
+): string | undefined {
+  const counts = new Map<string, number>();
+  const order: string[] = [];
+  for (const c of commits) {
+    if (c.type !== type || !c.scope) continue;
+    if (!counts.has(c.scope)) order.push(c.scope);
+    counts.set(c.scope, (counts.get(c.scope) ?? 0) + 1);
+  }
+  let best: string | undefined;
+  let bestCount = 0;
+  for (const s of order) {
+    const n = counts.get(s)!;
+    if (n > bestCount) {
+      best = s;
+      bestCount = n;
+    }
+  }
+  return best;
+}
+
+/**
+ * A suggested PR title, computed from the commits. A single-commit branch uses
+ * that commit's subject verbatim (already the canonical shape). A multi-commit
+ * branch synthesizes `type(scope): <subject-of-the-headline-commit>` — the
+ * headline being the first commit of the dominant type (so it reads as a real
+ * change, not a count). Falls back to a bare type prefix when nothing usable is
+ * present. The title is a SUGGESTION the author refines — never invented detail.
+ */
+export function suggestTitle(commits: readonly ParsedCommit[]): string {
+  if (commits.length === 0) return '';
+  if (commits.length === 1) return commits[0].raw.trim();
+  const type = dominantType(commits);
+  const scope = dominantScope(commits, type);
+  const headline = commits.find((c) => c.type === type) ?? commits[0];
+  const prefix = scope ? `${type}(${scope})` : type;
+  const bang = commits.some((c) => c.breaking) ? '!' : '';
+  return `${prefix}${bang}: ${headline.subject}`;
+}

--- a/src/pr/render.ts
+++ b/src/pr/render.ts
@@ -1,0 +1,163 @@
+/**
+ * Assemble the `vyuh-dxkit pr` output — a ready-to-review PR body computed from
+ * the branch's commits, the receipt, the reviewer model, the diff-derived
+ * checklist, and the structural-duplicate seam prompts. Pure: takes the already-
+ * computed `PrData` and emits markdown (or the JSON projection). The one thing
+ * NOT computed is the "What & why" narrative — the author writes that; the
+ * command leaves a labelled placeholder so the body is otherwise complete.
+ */
+import type { ChangeBucket } from './commits';
+import type { DuplicateGroup } from '../analyzers/duplication/findings';
+import type { ReviewersResult } from '../reviewers-cli';
+
+export interface PrData {
+  /** Suggested title (single-commit verbatim, else `type(scope): headline`). */
+  readonly title: string;
+  /** Changes bucketed by commit type (Features / Fixes / …). */
+  readonly buckets: readonly ChangeBucket[];
+  /** The receipt markdown block (verdict + allowlist [+ score]) — null when the
+   *  receipt could not be produced (no baseline, etc.). */
+  readonly receiptMarkdown: string | null;
+  /** Ranked reviewer suggestions — null when no changed files / no signal. */
+  readonly reviewers: ReviewersResult | null;
+  /** Structural-duplicate prompts the diff introduced (verified tier, grouped). */
+  readonly seams: readonly DuplicateGroup[];
+  /** The diff-derived reviewer-checklist rows. */
+  readonly checklist: readonly string[];
+  /** The base ref the body was computed against (for provenance). */
+  readonly base: string;
+}
+
+function anchorLabel(a: { symbol: string; file: string }): string {
+  return `\`${a.symbol}\` (${a.file})`;
+}
+
+/** One structural-drift prompt per added function: the added function and every
+ *  existing function it structurally matches, phrased as a reviewer question. */
+function renderSeamPrompts(seams: readonly DuplicateGroup[]): string[] {
+  if (seams.length === 0) return [];
+  const lines = [
+    '## Structural review (dxkit)',
+    '',
+    `dxkit found ${seams.length} function${seams.length === 1 ? '' : 's'} this change adds or edits ` +
+      `that structurally match existing code. Not a block — confirm each parallel is intentional, ` +
+      `or consolidate:`,
+    '',
+  ];
+  for (const g of seams) {
+    const twins = g.twins
+      .map((t) => `${anchorLabel(t.anchor)} (${Math.round(t.score * 100)}% similar)`)
+      .join(', ');
+    lines.push(`- [ ] ${anchorLabel(g.added)} matches ${twins}`);
+  }
+  return lines;
+}
+
+function renderChanges(buckets: readonly ChangeBucket[]): string[] {
+  if (buckets.length === 0) return [];
+  const lines = ['## Changes', ''];
+  for (const b of buckets) {
+    lines.push(`### ${b.label}`);
+    for (const c of b.commits) {
+      const scope = c.scope ? `**${c.scope}:** ` : '';
+      const breaking = c.breaking ? ' ⚠️ breaking' : '';
+      lines.push(`- ${scope}${c.subject}${breaking}`);
+    }
+    lines.push('');
+  }
+  return lines;
+}
+
+function renderReviewers(reviewers: ReviewersResult): string[] {
+  const lines = ['## Suggested reviewers', ''];
+  if (reviewers.reviewers.length === 0) {
+    lines.push(
+      reviewers.note ? `_${reviewers.note}_` : '_No active-owner signal for the touched files._',
+    );
+    return lines;
+  }
+  for (const r of reviewers.reviewers) {
+    const who = r.handle ? `@${r.handle}` : r.name;
+    const tag = r.isCodeowner ? ' [CODEOWNERS]' : '';
+    lines.push(`- ${who}${tag} — ${r.reason}`);
+  }
+  if (reviewers.busFactor === 1) {
+    lines.push(
+      '',
+      '_Bus factor 1: a single active owner covers these files — consider spreading knowledge._',
+    );
+  }
+  if (reviewers.note) lines.push('', `_${reviewers.note}_`);
+  return lines;
+}
+
+/** Render the full PR body as markdown. */
+export function renderPrBody(data: PrData): string {
+  const parts: string[] = [];
+  parts.push(`# ${data.title || '<title>'}`, '');
+  parts.push(
+    '## What & why',
+    '',
+    '<!-- Describe the problem this solves and the approach, in 1–3 sentences. -->',
+    '',
+  );
+
+  parts.push(...renderChanges(data.buckets));
+
+  if (data.receiptMarkdown) {
+    parts.push('## dxkit signals', '', data.receiptMarkdown.trimEnd(), '');
+  }
+
+  if (data.reviewers) parts.push(...renderReviewers(data.reviewers), '');
+
+  const seamLines = renderSeamPrompts(data.seams);
+  if (seamLines.length > 0) parts.push(...seamLines, '');
+
+  parts.push('## Reviewer checklist', '');
+  for (const row of data.checklist) parts.push(`- [ ] ${row}`);
+
+  parts.push('', `<!-- dxkit pr: computed against \`${data.base}\` -->`);
+  return parts.join('\n');
+}
+
+/** The JSON projection — every computed field, for programmatic consumers. */
+export function renderPrJson(data: PrData): unknown {
+  return {
+    schema: 'pr.v1',
+    base: data.base,
+    title: data.title,
+    changes: data.buckets.map((b) => ({
+      bucket: b.label,
+      commits: b.commits.map((c) => ({
+        type: c.type,
+        ...(c.scope ? { scope: c.scope } : {}),
+        subject: c.subject,
+        breaking: c.breaking,
+      })),
+    })),
+    reviewers: data.reviewers
+      ? {
+          suggestions: data.reviewers.reviewers.map((r) => ({
+            name: r.name,
+            ...(r.handle ? { handle: r.handle } : {}),
+            isCodeowner: r.isCodeowner,
+            reason: r.reason,
+          })),
+          busFactor: data.reviewers.busFactor,
+          ...(data.reviewers.note ? { note: data.reviewers.note } : {}),
+        }
+      : null,
+    structuralDuplicates: data.seams.map((g) => ({
+      added: { symbol: g.added.symbol, file: g.added.file },
+      topScore: g.topScore,
+      twins: g.twins.map((t) => ({
+        symbol: t.anchor.symbol,
+        file: t.anchor.file,
+        score: t.score,
+        id: t.id,
+      })),
+    })),
+    checklist: data.checklist,
+    markdown: renderPrBody(data),
+  };
+}

--- a/src/pr/run.ts
+++ b/src/pr/run.ts
@@ -1,0 +1,109 @@
+/**
+ * `vyuh-dxkit pr` — compute a reviewable PR body from the branch, not a template.
+ *
+ * The command is the deterministic core of the dxkit-pr skill: it reads the real
+ * commits + diff for `base..HEAD` and computes the title, the bucketed Changes
+ * section, the dxkit signals block (via the receipt), the suggested reviewers
+ * (active-owner model), a diff-derived reviewer checklist, and the structural-
+ * duplicate seam prompts — leaving only the "What & why" narrative for the
+ * author. Every embedded signal comes from its canonical source (Rule 2): the
+ * receipt from `buildReceipt`, reviewers from `computeReviewers`, duplicates from
+ * dxkit's AST detector.
+ *
+ * Zero side effects beyond reading git + the (cache-backed) guardrail; it never
+ * opens a PR — that's an explicit `gh pr create` the author runs after review.
+ */
+import { execFileSync } from 'child_process';
+import { detectActiveLanguages } from '../languages/index';
+import { buildReceipt } from '../receipt-cli';
+import { computeReviewers } from '../reviewers-cli';
+import { parseCommits, bucketCommits, suggestTitle } from './commits';
+import { deriveFacts, buildChecklist } from './checklist';
+import { gatherPrSeams } from './seams';
+import { renderPrBody, renderPrJson, type PrData } from './render';
+
+export interface PrOptions {
+  readonly base?: string;
+  /** Add health-score movement vs the base ref to the signals block (a base-ref
+   *  analysis — omit for verdict + allowlist only, which is cache-instant). */
+  readonly since?: string;
+  readonly json?: boolean;
+  /** Skip the structural-duplicate seam pass (the AST gather). */
+  readonly noSeams?: boolean;
+}
+
+function git(args: readonly string[], cwd: string): string {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      maxBuffer: 64 * 1024 * 1024,
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Resolve the base ref: explicit flag, else the remote default branch, else
+ *  `origin/main`. */
+function resolveBase(cwd: string, explicit: string | undefined): string {
+  if (explicit) return explicit;
+  const remoteHead = git(['rev-parse', '--abbrev-ref', 'origin/HEAD'], cwd);
+  return remoteHead || 'origin/main';
+}
+
+/** Repo-relative files changed in `base...HEAD` (merge-base three-dot). */
+function changedFiles(cwd: string, base: string): string[] {
+  const out = git(['diff', '--name-only', `${base}...HEAD`], cwd);
+  return out.split('\n').filter(Boolean);
+}
+
+/** The lines the diff ADDED (the `+` side, prefix stripped), skipping the
+ *  `+++` file headers. Used only for intrinsic marker detection. */
+function addedLines(cwd: string, base: string): string[] {
+  const diff = git(['diff', '--unified=0', `${base}...HEAD`], cwd);
+  const out: string[] = [];
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+') && !line.startsWith('+++')) out.push(line.slice(1));
+  }
+  return out;
+}
+
+export async function runPr(cwd: string, opts: PrOptions = {}): Promise<string> {
+  const base = resolveBase(cwd, opts.base);
+
+  const subjects = git(['log', '--format=%s', `${base}..HEAD`], cwd)
+    .split('\n')
+    .filter(Boolean);
+  const commits = parseCommits(subjects);
+
+  const files = changedFiles(cwd, base);
+  const packs = detectActiveLanguages(cwd);
+  const facts = deriveFacts({ changedFiles: files, addedLines: addedLines(cwd, base), packs });
+
+  // The receipt needs a baseline; fail-open to no signals block if it can't run.
+  let receiptMarkdown: string | null = null;
+  try {
+    receiptMarkdown = (await buildReceipt(cwd, { ...(opts.since ? { since: opts.since } : {}) }))
+      .markdown;
+  } catch {
+    receiptMarkdown = null;
+  }
+
+  const reviewers = computeReviewers(cwd, { base });
+
+  const seams = opts.noSeams ? [] : await gatherPrSeams(cwd, new Set(files));
+
+  const data: PrData = {
+    title: suggestTitle(commits),
+    buckets: bucketCommits(commits),
+    receiptMarkdown,
+    reviewers,
+    seams,
+    checklist: buildChecklist(facts),
+    base,
+  };
+
+  return opts.json ? JSON.stringify(renderPrJson(data), null, 2) : renderPrBody(data);
+}

--- a/src/pr/seams.ts
+++ b/src/pr/seams.ts
@@ -1,0 +1,50 @@
+/**
+ * The seam lane for `vyuh-dxkit pr` — the structural-duplicate signal rendered
+ * as a reviewer prompt rather than a block. It surfaces where a function the PR
+ * ADDED or CHANGED structurally re-implements an existing one, so the reviewer
+ * can confirm the parallel is intentional (or ask for consolidation). This is
+ * the warn-tier, advisory form of the seam gate: "make gradual structural drift
+ * visible to the reviewer" (the data-backed decision — a lone duplicate warns,
+ * it does not block).
+ *
+ * Diff-scoped and VERIFIED-tier only (score ≥ `VERIFIED_DUP_MIN_SCORE`), grouped
+ * one-per-added-function to avoid review fatigue: one added function that copies
+ * N existing reads as ONE prompt with N twins. Reuses dxkit's AST duplicate
+ * detector (`gatherDuplicateFindings`) and the shared grouping — no parallel
+ * pipeline (Rule 2). Fail-open: any failure yields no prompts.
+ */
+import { VERIFIED_DUP_MIN_SCORE } from '../analyzers/duplication/detect';
+import {
+  gatherDuplicateFindings,
+  groupDuplicatesByAdded,
+  type DuplicateGroup,
+} from '../analyzers/duplication/findings';
+
+/**
+ * Gather the diff-scoped, verified structural duplicates a PR introduces,
+ * grouped by the added function. `root` is the absolute repo root (the HEAD
+ * tree); `changedFiles` is the repo-relative set the diff touched — a pair is
+ * only surfaced when it touches a changed file, and the changed side is marked
+ * so the group's `added` is the function the PR is responsible for.
+ *
+ * Independent of `duplication.mode` (the block gate) — this is the visibility
+ * lane, always computed so the reviewer sees the drift even on a repo that never
+ * armed the gate.
+ */
+export async function gatherPrSeams(
+  root: string,
+  changedFiles: ReadonlySet<string>,
+): Promise<DuplicateGroup[]> {
+  if (changedFiles.size === 0) return [];
+  const findings = await gatherDuplicateFindings(root, {
+    minScore: VERIFIED_DUP_MIN_SCORE,
+    focusFiles: changedFiles,
+  });
+  // Mark which anchor the diff introduced (its file is in the changed set), so
+  // the grouping picks the added side as the thing to consolidate.
+  const directional = findings.map((f) => ({
+    ...f,
+    changed: [changedFiles.has(f.anchors[0].file), changedFiles.has(f.anchors[1].file)] as const,
+  }));
+  return groupDuplicatesByAdded(directional);
+}

--- a/src/receipt-cli.ts
+++ b/src/receipt-cli.ts
@@ -29,7 +29,7 @@ export interface ReceiptOptions {
   readonly refresh?: boolean;
 }
 
-interface VerdictView {
+export interface VerdictView {
   readonly markdown: string;
   readonly blocks: boolean;
   readonly warns: boolean;
@@ -46,7 +46,7 @@ interface DimDelta {
   readonly head: number;
   readonly delta: number;
 }
-interface ScoreMovement {
+export interface ScoreMovement {
   readonly ref: string;
   readonly overall: DimDelta;
   readonly dimensions: readonly DimDelta[];
@@ -70,10 +70,31 @@ type HealthDims = {
   developerExperience: DimensionScore;
 };
 
-export async function runReceipt(cwd: string, opts: ReceiptOptions = {}): Promise<void> {
+/** The computed receipt — the verdict view, optional score movement, and the
+ *  ready-to-paste markdown block. Shared by `runReceipt` (prints it) and
+ *  `vyuh-dxkit pr` (embeds the markdown in the PR body) — Rule 2, one source
+ *  for the "dxkit signals" block. */
+export interface Receipt {
+  readonly verdict: VerdictView;
+  readonly movement: ScoreMovement | null;
+  readonly markdown: string;
+}
+
+/**
+ * Compute the receipt without printing: the guardrail verdict (from the session
+ * verdict cache when fresh, else a fresh gather), the optional health-score
+ * movement vs `since`, and the assembled markdown block. The one place the block
+ * is produced — callers render or embed it.
+ */
+export async function buildReceipt(cwd: string, opts: ReceiptOptions = {}): Promise<Receipt> {
   const policy = loadPolicyFromCwd(cwd);
   const verdict = await resolveVerdict(cwd, policy, !!opts.refresh);
   const movement = opts.since ? await computeScoreMovement(cwd, opts.since) : null;
+  return { verdict, movement, markdown: assembleMarkdown(verdict, movement, opts.since) };
+}
+
+export async function runReceipt(cwd: string, opts: ReceiptOptions = {}): Promise<void> {
+  const { verdict, movement, markdown } = await buildReceipt(cwd, opts);
 
   if (opts.json) {
     process.stdout.write(
@@ -88,7 +109,7 @@ export async function runReceipt(cwd: string, opts: ReceiptOptions = {}): Promis
           cached: verdict.cached,
           ranAt: verdict.ranAt,
           scoreMovement: movement,
-          markdown: assembleMarkdown(verdict, movement, opts.since),
+          markdown,
         },
         null,
         2,
@@ -99,7 +120,7 @@ export async function runReceipt(cwd: string, opts: ReceiptOptions = {}): Promis
 
   // Default output is pure, ready-to-paste markdown on stdout (no console
   // chrome), mirroring `guardrail check --markdown`.
-  process.stdout.write(assembleMarkdown(verdict, movement, opts.since) + '\n'); // slop-ok
+  process.stdout.write(markdown + '\n'); // slop-ok
 }
 
 /** Reuse a fresh cached verdict, else run the guardrail and cache the result. */

--- a/src/reviewers-cli.ts
+++ b/src/reviewers-cli.ts
@@ -227,12 +227,16 @@ function readCodeowners(cwd: string): CodeownersRule[] {
   return [];
 }
 
-export function runReviewers(cwd: string, opts: ReviewersOptions): void {
+/**
+ * Compute the reviewer suggestions without printing — the IO gather (touched
+ * files, ownership, CODEOWNERS) plus the pure `buildSuggestions` ranking. Both
+ * `runReviewers` (prints) and `vyuh-dxkit pr` (embeds the list) call this, so the
+ * active-owner model has one entry point (Rule 2). Returns null when no changed
+ * files are detected.
+ */
+export function computeReviewers(cwd: string, opts: ReviewersOptions): ReviewersResult | null {
   const files = touchedFiles(cwd, opts);
-  if (files.length === 0) {
-    logger.info('No changed files detected (pass --base <ref> or --staged). Nothing to suggest.');
-    return;
-  }
+  if (files.length === 0) return null;
 
   // Exclude the change author from suggestions (never review your own PR).
   const authorEmail = gitOut('git config --get user.email', cwd);
@@ -245,13 +249,22 @@ export function runReviewers(cwd: string, opts: ReviewersOptions): void {
   const coOwners: string[] = [];
   for (const f of files) coOwners.push(...matchCodeowners(rules, f));
 
-  const result: ReviewersResult = {
+  return {
     ...buildSuggestions(ownership, {
       ...(opts.limit !== undefined ? { limit: opts.limit } : {}),
       codeowners: coOwners,
     }),
     touchedFiles: files,
   };
+}
+
+export function runReviewers(cwd: string, opts: ReviewersOptions): void {
+  const result = computeReviewers(cwd, opts);
+  if (!result) {
+    logger.info('No changed files detected (pass --base <ref> or --staged). Nothing to suggest.');
+    return;
+  }
+  const files = result.touchedFiles;
 
   if (opts.json) {
     process.stdout.write(JSON.stringify(result, null, 2) + '\n');

--- a/test/pr/checklist.test.ts
+++ b/test/pr/checklist.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { deriveFacts, buildChecklist, CHECKLIST_RULES } from '../../src/pr/checklist';
+import type { LanguageSupport } from '../../src/languages/types';
+
+// A minimal fake pack: `allDependencyManifestPatterns` reads only
+// `capabilities.depVulns.manifestPatterns`, so this is enough to exercise the
+// pack-driven dependency fact without pulling a full LanguageSupport.
+const fakePack = {
+  capabilities: { depVulns: { manifestPatterns: ['package.json', 'package-lock.json'] } },
+} as unknown as LanguageSupport;
+
+function facts(changedFiles: string[], addedLines: string[] = [], packs = [fakePack]) {
+  return deriveFacts({ changedFiles, addedLines, packs });
+}
+
+describe('deriveFacts', () => {
+  it('flags an allowlist file change and an inline annotation', () => {
+    expect(facts(['.dxkit/allowlist.json']).allowlistTouched).toBe(true);
+    expect(
+      facts(['src/a.ts'], ['  const k = secret; // dxkit-allow: secret']).allowlistTouched,
+    ).toBe(true);
+    expect(facts(['src/a.ts'], ['const x = 1']).allowlistTouched).toBe(false);
+  });
+
+  it('flags a dependency-manifest change via the pack patterns', () => {
+    expect(facts(['package.json']).dependencyTouched).toBe(true);
+    expect(facts(['src/a.ts']).dependencyTouched).toBe(false);
+  });
+
+  it('does not flag a dependency change with no active packs', () => {
+    expect(facts(['package.json'], [], []).dependencyTouched).toBe(false);
+  });
+
+  it('flags a migration / schema change', () => {
+    expect(facts(['db/migrations/001_init.ts']).migrationTouched).toBe(true);
+    expect(facts(['prisma/schema.prisma']).migrationTouched).toBe(true);
+    expect(facts(['api/migrate/0002.sql']).migrationTouched).toBe(true);
+    expect(facts(['src/a.ts']).migrationTouched).toBe(false);
+  });
+
+  it('flags a public-API change only when a source file added an export', () => {
+    expect(facts(['src/a.ts'], ['export function foo() {}']).publicApiChanged).toBe(true);
+    expect(facts(['src/a.ts'], ['const internal = 1']).publicApiChanged).toBe(false);
+    // an export line with no source file changed does not count
+    expect(facts(['README.md'], ['export function foo() {}']).publicApiChanged).toBe(false);
+  });
+
+  it('distinguishes source-changed from test-changed', () => {
+    const f1 = facts(['src/a.ts']);
+    expect(f1.sourceChanged).toBe(true);
+    expect(f1.testChanged).toBe(false);
+
+    const f2 = facts(['src/a.ts', 'test/a.test.ts']);
+    expect(f2.sourceChanged).toBe(true);
+    expect(f2.testChanged).toBe(true);
+  });
+
+  it('flags a CI workflow / git hook change', () => {
+    expect(facts(['.github/workflows/ci.yml']).ciOrHookTouched).toBe(true);
+    expect(facts(['.githooks/pre-push']).ciOrHookTouched).toBe(true);
+    expect(facts(['.husky/pre-commit']).ciOrHookTouched).toBe(true);
+    expect(facts(['src/a.ts']).ciOrHookTouched).toBe(false);
+  });
+});
+
+describe('buildChecklist', () => {
+  it('always includes the scope + secrets rows', () => {
+    const rows = buildChecklist(facts(['README.md']));
+    expect(rows.some((r) => /scope is not broader/.test(r))).toBe(true);
+    expect(rows.some((r) => /No secrets/.test(r))).toBe(true);
+  });
+
+  it('adds a tests row for source changed without a matching test change', () => {
+    const rows = buildChecklist(facts(['src/a.ts']));
+    expect(rows.some((r) => /Source changed without a matching test/.test(r))).toBe(true);
+  });
+
+  it('drops the tests row when a test moved with the source', () => {
+    const rows = buildChecklist(facts(['src/a.ts', 'test/a.test.ts']));
+    expect(rows.some((r) => /Source changed without a matching test/.test(r))).toBe(false);
+  });
+
+  it('adds supply-chain + migration + CI rows only when the diff touches them', () => {
+    const rows = buildChecklist(
+      facts(['package.json', 'db/migrations/1.sql', '.github/workflows/ci.yml']),
+    );
+    expect(rows.some((r) => /Supply chain/.test(r))).toBe(true);
+    expect(rows.some((r) => /reversible and backward-compatible/.test(r))).toBe(true);
+    expect(rows.some((r) => /pipeline-level scrutiny/.test(r))).toBe(true);
+  });
+
+  it('renders rows in registry order', () => {
+    const rows = buildChecklist(facts(['package.json']));
+    const scopeIdx = rows.findIndex((r) => /scope is not broader/.test(r));
+    const depIdx = rows.findIndex((r) => /Supply chain/.test(r));
+    const secretsIdx = rows.findIndex((r) => /No secrets/.test(r));
+    expect(scopeIdx).toBeLessThan(depIdx);
+    expect(depIdx).toBeLessThan(secretsIdx);
+  });
+
+  it('every rule id is unique', () => {
+    const ids = CHECKLIST_RULES.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/test/pr/commits.test.ts
+++ b/test/pr/commits.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseCommitSubject,
+  parseCommits,
+  bucketCommits,
+  dominantType,
+  dominantScope,
+  suggestTitle,
+} from '../../src/pr/commits';
+
+describe('parseCommitSubject', () => {
+  it('parses a conventional commit with scope', () => {
+    const c = parseCommitSubject('feat(auth): add refresh-token rotation');
+    expect(c.type).toBe('feat');
+    expect(c.scope).toBe('auth');
+    expect(c.subject).toBe('add refresh-token rotation');
+    expect(c.breaking).toBe(false);
+  });
+
+  it('parses without a scope', () => {
+    const c = parseCommitSubject('fix: handle empty diff');
+    expect(c.type).toBe('fix');
+    expect(c.scope).toBeUndefined();
+    expect(c.subject).toBe('handle empty diff');
+  });
+
+  it('flags a breaking change via bang', () => {
+    const c = parseCommitSubject('feat(api)!: drop v1 endpoints');
+    expect(c.breaking).toBe(true);
+    expect(c.scope).toBe('api');
+  });
+
+  it('flags a breaking change via BREAKING CHANGE footer text', () => {
+    expect(parseCommitSubject('feat: x BREAKING CHANGE later').breaking).toBe(true);
+  });
+
+  it('keeps a non-conventional subject as type other, never dropped', () => {
+    const c = parseCommitSubject('Merge branch main into feature');
+    expect(c.type).toBe('other');
+    expect(c.subject).toBe('Merge branch main into feature');
+  });
+
+  it('maps an unknown type token to other', () => {
+    expect(parseCommitSubject('wip(x): scratch').type).toBe('other');
+  });
+});
+
+describe('dominantType', () => {
+  it('picks the type with the most commits', () => {
+    const commits = parseCommits(['fix: a', 'fix: b', 'feat: c']);
+    expect(dominantType(commits)).toBe('fix');
+  });
+
+  it('breaks a count tie by headline priority (feat over fix)', () => {
+    const commits = parseCommits(['fix: a', 'feat: b']);
+    expect(dominantType(commits)).toBe('feat');
+  });
+
+  it('returns other for an empty list', () => {
+    expect(dominantType([])).toBe('other');
+  });
+});
+
+describe('dominantScope', () => {
+  it('picks the most common scope among the given type', () => {
+    const commits = parseCommits(['feat(pr): a', 'feat(pr): b', 'feat(flow): c', 'fix(x): d']);
+    expect(dominantScope(commits, 'feat')).toBe('pr');
+  });
+
+  it('returns undefined when no commit of that type carries a scope', () => {
+    expect(dominantScope(parseCommits(['feat: a']), 'feat')).toBeUndefined();
+  });
+});
+
+describe('bucketCommits', () => {
+  it('groups into ordered display buckets, dropping empties', () => {
+    const buckets = bucketCommits(
+      parseCommits(['feat: a', 'fix: b', 'refactor: c', 'perf: d', 'chore: e', 'docs: f']),
+    );
+    const labels = buckets.map((b) => b.label);
+    expect(labels).toEqual(['Features', 'Fixes', 'Refactors', 'Docs', 'Chore']);
+    // perf rolls into Refactors alongside refactor
+    expect(buckets.find((b) => b.label === 'Refactors')!.commits).toHaveLength(2);
+  });
+});
+
+describe('suggestTitle', () => {
+  it('uses a single commit verbatim', () => {
+    expect(suggestTitle(parseCommits(['feat(auth): add rotation']))).toBe(
+      'feat(auth): add rotation',
+    );
+  });
+
+  it('synthesizes type(scope): headline for a multi-commit branch', () => {
+    const title = suggestTitle(
+      parseCommits(['feat(pr): reviewer surface', 'feat(pr): checklist engine', 'test: cover it']),
+    );
+    expect(title).toBe('feat(pr): reviewer surface');
+  });
+
+  it('adds a breaking bang when any commit is breaking', () => {
+    const title = suggestTitle(parseCommits(['feat(api)!: drop v1', 'test: cover']));
+    expect(title.startsWith('feat(api)!:')).toBe(true);
+  });
+
+  it('returns empty for no commits', () => {
+    expect(suggestTitle([])).toBe('');
+  });
+});

--- a/test/pr/render.test.ts
+++ b/test/pr/render.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { renderPrBody, renderPrJson, type PrData } from '../../src/pr/render';
+import { parseCommits, bucketCommits } from '../../src/pr/commits';
+import type { DuplicateGroup } from '../../src/analyzers/duplication/findings';
+import type { ReviewersResult } from '../../src/reviewers-cli';
+
+const reviewers: ReviewersResult = {
+  touchedFiles: ['src/a.ts'],
+  reviewers: [
+    {
+      name: 'Alice',
+      handle: 'alice',
+      active: true,
+      isCodeowner: false,
+      reason: 'owns 2/2 files',
+      score: 9,
+    },
+    {
+      name: '@team/core',
+      handle: 'team/core',
+      active: true,
+      isCodeowner: true,
+      reason: 'listed in CODEOWNERS',
+      score: Infinity,
+    },
+  ],
+  busFactor: 2,
+};
+
+const seams: DuplicateGroup[] = [
+  {
+    added: { symbol: 'createLeagueButton', file: 'src/ui/league.tsx', line: 10 },
+    twins: [
+      {
+        anchor: { symbol: 'createDivisionButton', file: 'src/ui/division.tsx', line: 8 },
+        score: 0.96,
+        id: 'abc123',
+        bothAdded: false,
+      },
+    ],
+    topScore: 0.96,
+  },
+];
+
+function baseData(overrides: Partial<PrData> = {}): PrData {
+  return {
+    title: 'feat(pr): reviewer surface',
+    buckets: bucketCommits(parseCommits(['feat(pr): reviewer surface', 'test: cover it'])),
+    receiptMarkdown: '## Guardrail: PASSED\n\nNo net-new findings.',
+    reviewers,
+    seams,
+    checklist: ['Change matches the description', 'No secrets, keys, or tokens in the diff'],
+    base: 'origin/main',
+    ...overrides,
+  };
+}
+
+describe('renderPrBody', () => {
+  it('renders every section in order', () => {
+    const body = renderPrBody(baseData());
+    expect(body).toContain('# feat(pr): reviewer surface');
+    expect(body).toContain('## What & why');
+    expect(body).toContain('## Changes');
+    expect(body).toContain('### Features');
+    expect(body).toContain('## dxkit signals');
+    expect(body).toContain('## Guardrail: PASSED');
+    expect(body).toContain('## Suggested reviewers');
+    expect(body).toContain('@alice');
+    expect(body).toContain('[CODEOWNERS]');
+    expect(body).toContain('## Structural review (dxkit)');
+    expect(body).toContain('`createLeagueButton`');
+    expect(body).toContain('96% similar');
+    expect(body).toContain('## Reviewer checklist');
+    expect(body).toContain('- [ ] No secrets');
+    expect(body).toContain('computed against `origin/main`');
+  });
+
+  it('falls back to <title> when no title computed', () => {
+    expect(renderPrBody(baseData({ title: '' }))).toContain('# <title>');
+  });
+
+  it('omits the signals section when the receipt could not run', () => {
+    const body = renderPrBody(baseData({ receiptMarkdown: null }));
+    expect(body).not.toContain('## dxkit signals');
+  });
+
+  it('omits the structural-review section when there are no seams', () => {
+    const body = renderPrBody(baseData({ seams: [] }));
+    expect(body).not.toContain('## Structural review');
+  });
+
+  it('surfaces a bus-factor-1 warning', () => {
+    const solo: ReviewersResult = { ...reviewers, busFactor: 1 };
+    expect(renderPrBody(baseData({ reviewers: solo }))).toContain('Bus factor 1');
+  });
+
+  it('shows the note when reviewers has no suggestions', () => {
+    const none: ReviewersResult = {
+      touchedFiles: [],
+      reviewers: [],
+      busFactor: 0,
+      note: 'No signal',
+    };
+    expect(renderPrBody(baseData({ reviewers: none }))).toContain('No signal');
+  });
+});
+
+describe('renderPrJson', () => {
+  it('projects the computed fields with the schema tag', () => {
+    const json = renderPrJson(baseData()) as Record<string, unknown>;
+    expect(json.schema).toBe('pr.v1');
+    expect(json.title).toBe('feat(pr): reviewer surface');
+    expect((json.structuralDuplicates as unknown[]).length).toBe(1);
+    expect((json.checklist as unknown[]).length).toBe(2);
+    expect(typeof json.markdown).toBe('string');
+  });
+});

--- a/test/pr/seams.test.ts
+++ b/test/pr/seams.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { gatherPrSeams } from '../../src/pr/seams';
+
+describe('gatherPrSeams', () => {
+  it('short-circuits to no prompts when nothing changed (never touches the tree)', async () => {
+    expect(await gatherPrSeams('/nonexistent', new Set())).toEqual([]);
+  });
+
+  it('fails open on an unreadable tree', async () => {
+    // A path with changed files but no analyzable tree yields no prompts, never throws.
+    expect(await gatherPrSeams('/nonexistent', new Set(['src/a.ts']))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What & why

The `dxkit-pr` skill produced a good PR body but *improvised* the parts that
matter most for review — the title, the change classification, the reviewer
checklist. Improvised means drift: a body can quietly misrepresent what the
change actually did. This adds **`vyuh-dxkit pr`**, the deterministic core the
skill now drives, so those parts are **computed from the branch**, not narrated.

It also cashes in the seam-detector work (3.7 Track 2): the structural-duplicate
signal — decided to be **warn, not block** — needed a home, and the reviewer PR
surface is it. `pr` renders "this change adds a function that structurally
matches existing code" as a reviewer prompt, turning a warn-tier signal into an
actionable review question without blocking.

## Changes

### Features
- **pr:** `vyuh-dxkit pr [path] [--base <ref>] [--since <ref>] [--no-seams] [--json]`
  computes a full PR body from `base..HEAD`:
  - **title** — dominant conventional-commit type + scope (single-commit branches
    verbatim);
  - **Changes** — commits bucketed by type (Features / Fixes / Refactors / …);
  - **dxkit signals** — the receipt (guardrail verdict + allowlist delta [+ score
    with `--since`]);
  - **suggested reviewers** — the active-owner model, blended with CODEOWNERS;
  - **reviewer checklist** — a registry of pure fact → row rules (a supply-chain
    row only when a manifest moved, a migration row only when a migration moved, a
    tests row when source changed without a test, a CI-scrutiny row when a
    workflow/hook moved);
  - **Structural review** — diff-scoped, verified-tier structural duplicates the
    change introduces, grouped one-per-added-function, as a warn-tier reviewer
    prompt. The author writes only "What & why".

### Refactors
- **receipt / reviewers:** extracted reusable non-printing cores (`buildReceipt`,
  `computeReviewers`) that both the existing commands and `pr` compose — Rule 2,
  one source per embedded signal.

### Docs
- `dxkit-pr` skill rewritten to drive the command (Compute → Narrate → Confirm).
- Rule 16 `CapabilityDescriptor` registered; `docs/README.md` command table +
  CHANGELOG + CLI usage updated. Normalized a stray separator in the command
  registry so the file stays under the large-file threshold.

## How it was validated

- **Unit:** 40 new tests (commits / checklist / render / seams) — conventional-commit
  parsing, the fact→row registry, body assembly, fail-open seams. Full suite green
  (4020 tests).
- **End-to-end, this branch:** `pr` renders the title, bucketed Changes, the live
  guardrail verdict, an honest reviewer note, and the diff-derived checklist.
- **Seam lane, real copy-paste:** on a scratch repo where HEAD adds a near-identical
  `getLeagues` copy of `getDivisions`, `pr` flags exactly `getLeagues matches
  getDivisions (100% similar)`, directionally correct (added side named first).
- Build / lint / format / arch / slop / cross-ecosystem all green.

## Reviewer checklist
- [ ] `pr` output reads as a body a reviewer would want (skim the description above)
- [ ] The receipt embed reflects the *configured* gate (policy baseline), not `--base`
      — intentional: it mirrors what CI actually enforces
- [ ] Structural-review section is advisory only — never sets a failing exit code
- [ ] No secrets/keys in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfM2bbuQNkkXjpr8zJJZSG