### PR TITLE
feat(init): world-class zero-question finishing arc

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -99,7 +99,13 @@ jobs:
           # for the pre-commit hook (default-off), --with-pr-review
           # for the AI PR-review workflow (default-off). The smoke
           # asserts they install correctly when opted in.
-          ./node_modules/.bin/vyuh-dxkit init --full --yes \
+          #
+          # --no-finish: this job tests baseline + guardrail MECHANICS as
+          # discrete steps below, so init must NOT run its finishing arc
+          # (which would provision scanners + pre-create the baseline in a
+          # bare toolchain-free runner). It keeps the "Capture baseline"
+          # step the unit under test.
+          ./node_modules/.bin/vyuh-dxkit init --full --yes --no-finish \
             --with-precommit-hook \
             --with-pr-review
 
@@ -171,7 +177,9 @@ jobs:
           git init -q
           npm init -y >/dev/null
           npm install --save-dev "${{ steps.pack-sdk.outputs.tarball }}" "${{ steps.pack.outputs.tarball }}" --silent
-          ./node_modules/.bin/vyuh-dxkit init --full --yes
+          # --no-finish: this dir only asserts default-off ship surfaces, no
+          # baseline/guardrail — skip the arc so it stays fast + toolchain-free.
+          ./node_modules/.bin/vyuh-dxkit init --full --yes --no-finish
           if [ -f .githooks/pre-commit ]; then
             echo "::error::pre-commit hook should NOT install without --with-precommit-hook"
             exit 1

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1547,6 +1547,25 @@ if [ -n "$FROZEN_REDECL$FROZEN_REIMPL" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# ── init finishing-arc guard ──────────────────────────────────────────────
+# `init --full` / `--claude-loop` / `--with-hooks` / `--with-ci` now runs the
+# finishing arc: REAL scanner installs + a baseline scan. Inside a test or CI
+# workflow that isn't specifically exercising the arc, that pollutes the runner
+# (installed tools flip skipIf-gated integration tests from skip→run) and burns
+# minutes. Such invocations MUST pass --no-finish. Annotate '# init-arc-ok' /
+# '// init-arc-ok' on the line for a test that genuinely drives the arc.
+INIT_ARC=$(grep -rnE "('init',[^)]*'(--full|--claude-loop|--with-hooks|--with-ci|--with-precommit-hook)'|(vyuh-dxkit|index\.js.?) init [^\`]*(--full|--claude-loop|--with-hooks|--with-ci))" test/ .github/ 2>/dev/null \
+  | grep -v -- "--no-finish" \
+  | grep -vE "expect\(|toContain|toEqual|not\.to|name: |init-arc-ok" || true)
+if [ -n "$INIT_ARC" ]; then
+  echo "❌ init finishing-arc guard: a test/workflow runs init with a baseline-consuming"
+  echo "   flag but no --no-finish (the arc installs real scanners + scans a baseline,"
+  echo "   polluting the runner + flipping skipIf-gated integration tests):"
+  echo "$INIT_ARC"
+  echo "   → Add --no-finish, or annotate '# init-arc-ok' if the test drives the arc."
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ $ERRORS -gt 0 ]; then
   echo ""
   echo "Architecture checks failed. See CLAUDE.md for rules."

--- a/src/analyzers/tools/install-exec.ts
+++ b/src/analyzers/tools/install-exec.ts
@@ -1,0 +1,238 @@
+/**
+ * Tool install EXECUTION — the ONE code path that resolves a tool's install
+ * command, runs it, verifies the binary landed, and records a project-local
+ * devDependency (Rule 2). Split out of `tools-cli.ts` so both the interactive
+ * installer (which renders its own prompts + summary) and the init finishing
+ * arc's quiet `installMissingTools()` core drive the same execution primitive
+ * without duplicating command construction.
+ *
+ * Pure of any CLI chrome: nothing here prints via the logger. The interactive
+ * surface in `tools-cli.ts` renders the outcomes; the quiet core emits progress
+ * through an optional `onEvent` observer.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { detect } from '../../detect';
+import { DetectedStack, type Manifest } from '../../types';
+import { serializePreservingJson } from '../../files';
+import { detectPackageManager, pmAwareDevInstall } from '../../package-manager';
+import {
+  TOOL_DEFS,
+  findTool,
+  getInstallCommand,
+  getInstallEnv,
+  buildRequiredTools,
+  exportToolPathsToGithubEnv,
+  ToolStatus,
+} from './tool-registry';
+
+export interface ToolsInstallOptions {
+  toolName?: string;
+  all?: boolean;
+}
+
+/**
+ * Decide which tool names to consider for install given the options.
+ * Pure function — does not touch the filesystem; testable in isolation.
+ *
+ * - toolName set: just that one (returns [] if name is unknown — caller
+ *   surfaces an error)
+ * - all: every key in TOOL_DEFS, sorted for stable output
+ * - default: tools required for the current-project stack
+ */
+export function selectToolNames(
+  languages: DetectedStack['languages'],
+  options: ToolsInstallOptions = {},
+): string[] {
+  if (options.toolName) {
+    return TOOL_DEFS[options.toolName] ? [options.toolName] : [];
+  }
+  if (options.all) {
+    return Object.keys(TOOL_DEFS).sort();
+  }
+  return buildRequiredTools(languages).map((r) => r.name);
+}
+
+/**
+ * Append a dxkit-installed node devDependency to the install manifest so
+ * `vyuh-dxkit uninstall` can remove it. No-op when the repo has no manifest
+ * (dxkit wasn't init'd there) or the entry is already recorded. Best-effort:
+ * a manifest write failure never fails the install.
+ */
+export function recordToolDep(cwd: string, pkg: string): void {
+  const manifestPath = path.join(cwd, '.vyuh-dxkit.json');
+  try {
+    const raw = fs.readFileSync(manifestPath, 'utf-8');
+    const manifest = JSON.parse(raw) as Manifest;
+    // Normalize to the {package, ecosystem} shape, dropping any legacy `install`
+    // string an older dxkit persisted here. Every executed/rendered install is
+    // already PM-aware; the stored npm-flavored text (`npm install --save-dev …`)
+    // was misleading canonical JSON on a non-npm repo and is derivable from
+    // {package, ecosystem} anyway. Re-run of `tools install` cleans a legacy file.
+    const normalized = (manifest.toolDeps ?? []).map((d) => ({
+      package: d.package,
+      ecosystem: 'node' as const,
+    }));
+    if (!normalized.some((d) => d.package === pkg)) {
+      normalized.push({ package: pkg, ecosystem: 'node' });
+    }
+    manifest.toolDeps = normalized;
+    fs.writeFileSync(manifestPath, serializePreservingJson(raw, manifest), 'utf-8');
+  } catch {
+    // no manifest / unreadable / unwritable → nothing to record, never fatal
+  }
+}
+
+function runInstallCmd(
+  cmd: string,
+  envOverlay?: Record<string, string>,
+  quiet = false,
+): { success: boolean; message: string } {
+  try {
+    // Pick a shell that exists on the platform. On POSIX use bash so
+    // multi-command scripts (`&&`, `||`, `;`) work; on Windows omit the
+    // option so Node uses the default cmd.exe (the hardcoded `/bin/bash`
+    // path doesn't exist there, which made every `tools install` fail
+    // outright).
+    const shell = process.platform === 'win32' ? undefined : '/bin/bash';
+    // Quiet mode (the init finishing arc): capture the child's output instead
+    // of inheriting it, so a package manager's install noise doesn't bleed
+    // through the step UI. On failure the captured text becomes the message.
+    execSync(cmd, {
+      shell,
+      stdio: quiet ? ['ignore', 'pipe', 'pipe'] : ['inherit', 'inherit', 'inherit'],
+      timeout: 600000, // 10 min for downloads
+      env: envOverlay ? { ...process.env, ...envOverlay } : process.env,
+    });
+    return { success: true, message: 'installed' };
+  } catch (err: unknown) {
+    const e = err as { message?: string };
+    return { success: false, message: e.message || 'unknown error' };
+  }
+}
+
+/** The install command dxkit would run for a tool, resolved PM-aware. */
+export interface ResolvedInstall {
+  readonly name: string;
+  readonly description: string;
+  /** 'builtin' → nothing to install; 'none' → no install command; 'run' → execute `command`. */
+  readonly kind: 'builtin' | 'none' | 'run';
+  readonly command?: string;
+}
+
+/**
+ * Resolve the install command for one tool WITHOUT running it. Shared by the
+ * interactive installer (which prints it before prompting) and the quiet core
+ * — the PM-aware command string is built in exactly one place (Rule 2).
+ */
+export function resolveInstallCommand(targetPath: string, toolName: string): ResolvedInstall {
+  const def = TOOL_DEFS[toolName];
+  if (!def) return { name: toolName, description: '', kind: 'none' };
+  const rawCmd = getInstallCommand(def);
+  if (rawCmd === 'builtin' || rawCmd === 'builtin (npm)' || rawCmd === 'builtin (dotnet SDK)') {
+    return { name: toolName, description: def.description, kind: 'builtin' };
+  }
+  // A node devDep tool (e.g. @vitest/coverage-v8) installs INTO the user's repo,
+  // so its `npm install --save-dev …` must match the repo's PM — else it fails
+  // the way create-dxkit did on a pnpm project. Isolated tools keep their npm cmd.
+  const command = def.nodePackage
+    ? pmAwareDevInstall(rawCmd, detectPackageManager(targetPath))
+    : rawCmd;
+  return { name: toolName, description: def.description, kind: 'run', command };
+}
+
+/** The outcome of running (or trying to run) one tool's install command. */
+export interface OneToolResult {
+  readonly status: 'installed' | 'skipped' | 'failed';
+  readonly detail?: string;
+}
+
+/**
+ * Execute one tool's resolved install command, verify the binary landed, and
+ * record a project-local devDep so `uninstall` owns it. The ONE place install
+ * execution + verification + dep-recording lives — both the interactive
+ * installer and the quiet init-arc core call this (Rule 2).
+ */
+export function execInstall(
+  targetPath: string,
+  resolved: ResolvedInstall,
+  opts: { quiet?: boolean } = {},
+): OneToolResult {
+  if (resolved.kind === 'none') return { status: 'skipped', detail: 'no install command' };
+  if (resolved.kind === 'builtin') return { status: 'skipped', detail: 'builtin' };
+  const def = TOOL_DEFS[resolved.name]!;
+  const result = runInstallCmd(resolved.command!, getInstallEnv(targetPath), opts.quiet);
+  if (!result.success) return { status: 'failed', detail: result.message };
+  // An install command can legitimately exit 0 without producing the binary —
+  // e.g. the vitest-coverage guard no-ops when vitest isn't a target dep. Treat
+  // "exit 0 + tool still missing" as a skip, not a failure.
+  const recheck = findTool(def, targetPath);
+  if (!recheck.available) {
+    return {
+      status: 'skipped',
+      detail: 'install command exited 0 without producing the binary (likely a guarded no-op)',
+    };
+  }
+  // A project-local node devDep landed in the user's package.json on dxkit's
+  // behalf — record it so uninstall OWNS it (the "exact pre-dxkit state" promise).
+  if (def.nodePackage) recordToolDep(targetPath, def.nodePackage);
+  return { status: 'installed', detail: recheck.source };
+}
+
+/** A tool-install progress event for the quiet core's optional observer. */
+export interface ToolInstallEvent {
+  readonly name: string;
+  readonly phase: 'installing' | 'installed' | 'skipped' | 'failed';
+  readonly detail?: string;
+}
+
+/** The structured result of a non-interactive install-missing pass. */
+export interface ToolInstallOutcome {
+  readonly installed: readonly string[];
+  readonly skipped: ReadonlyArray<{ name: string; reason: string }>;
+  readonly failed: ReadonlyArray<{ name: string; reason: string }>;
+  /** Applicable tools already available (nothing to do). */
+  readonly alreadyPresent: readonly string[];
+  /** Tools n/a for this stack (skipped by the applicability gate). */
+  readonly notApplicable: readonly string[];
+}
+
+/**
+ * Install every MISSING applicable tool non-interactively and return a
+ * structured outcome — the quiet core the init finishing-arc drives so it can
+ * render its own progress UI. No logger chrome; emits progress via `onEvent`.
+ * Reuses the ONE selection + exec path the interactive installer uses (Rule 2).
+ */
+export async function installMissingTools(
+  targetPath: string,
+  options: ToolsInstallOptions & { onEvent?: (e: ToolInstallEvent) => void } = {},
+): Promise<ToolInstallOutcome> {
+  const stack = detect(targetPath);
+  const names = selectToolNames(stack.languages, options);
+  const statuses = names
+    .map((n) => (TOOL_DEFS[n] ? findTool(TOOL_DEFS[n]!, targetPath) : null))
+    .filter((s): s is ToolStatus => s !== null);
+  const missing = statuses.filter((s) => !s.available && s.source !== 'n/a');
+  const alreadyPresent = statuses.filter((s) => s.available).map((s) => s.name);
+  const notApplicable = statuses.filter((s) => s.source === 'n/a').map((s) => s.name);
+
+  const installed: string[] = [];
+  const skipped: { name: string; reason: string }[] = [];
+  const failed: { name: string; reason: string }[] = [];
+
+  for (const s of missing) {
+    options.onEvent?.({ name: s.name, phase: 'installing' });
+    const resolved = resolveInstallCommand(targetPath, s.name);
+    const r = execInstall(targetPath, resolved, { quiet: true });
+    options.onEvent?.({ name: s.name, phase: r.status, detail: r.detail });
+    if (r.status === 'installed') installed.push(s.name);
+    else if (r.status === 'failed') failed.push({ name: s.name, reason: r.detail ?? 'error' });
+    else skipped.push({ name: s.name, reason: r.detail ?? 'skipped' });
+  }
+
+  // Make every tool bin dir discoverable by name in later CI steps. No-op off CI.
+  exportToolPathsToGithubEnv();
+  return { installed, skipped, failed, alreadyPresent, notApplicable };
+}

--- a/src/analyzers/tools/timing.ts
+++ b/src/analyzers/tools/timing.ts
@@ -19,7 +19,13 @@
  * advisories) can land in 2.4.8.
  */
 
+import * as logger from '../../logger';
+
 function startLine(name: string): void {
+  // Honor a surface that has muted ordinary output (e.g. the init finishing
+  // arc, which reuses the scan pipeline but drives its own step UI) — otherwise
+  // these per-phase lines bleed through it.
+  if (logger.isQuiet()) return;
   // Indent to match the rest of the CLI's stderr framing (logger.info
   // uses the same "  → " prefix). Stays on stderr in all modes so it
   // never pollutes `--json` stdout.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -409,6 +409,10 @@ export async function run(argv: string[]): Promise<void> {
       // --flow forces it on (warn posture); --no-flow suppresses it.
       flow: { type: 'boolean', default: false },
       'no-flow': { type: 'boolean', default: false },
+      // The init finishing arc (tools install + baseline create) runs by
+      // default when a gate surface was armed or --yes was given; --no-finish
+      // opts out (arm the surfaces, let the user capture the baseline later).
+      'no-finish': { type: 'boolean', default: false },
       // setup-branch-protection flags
       branch: { type: 'string' },
       'require-reviews': { type: 'string' },
@@ -512,23 +516,28 @@ export async function run(argv: string[]): Promise<void> {
 
   switch (command) {
     case 'init': {
-      logger.header('vyuh-dxkit init');
+      const initStarted = Date.now();
+      logger.header('Setting up dxkit');
 
-      logger.info('Detecting stack...');
+      const detectStep = logger.startSpinner('Reading your stack');
       const detected = detect(cwd);
       const langs = Object.entries(detected.languages)
         .filter(([, v]) => v)
         .map(([k]) => k);
-
-      if (langs.length === 0) {
-        logger.warn('No languages detected. Generating with minimal config.');
-      } else {
-        logger.success(`Languages: ${langs.join(', ')}`);
+      {
+        // Surface the interesting facts as one aligned recap line: languages,
+        // framework, test runner — the "dxkit understands my repo" moment.
+        const facts = [
+          langs.length ? langs.join(', ') : null,
+          detected.framework,
+          detected.testRunner ? detected.testRunner.framework : null,
+        ].filter(Boolean);
+        if (langs.length === 0) {
+          detectStep.warn('no languages detected — minimal config');
+        } else {
+          detectStep.succeed(facts.join(' · '));
+        }
       }
-      if (detected.framework) logger.success(`Framework: ${detected.framework}`);
-      if (detected.testRunner)
-        logger.success(`Tests: ${detected.testRunner.framework} (${detected.testRunner.command})`);
-      console.log(''); // slop-ok
 
       const promptOpts = {
         yes: !!(values.yes || values.detect),
@@ -556,6 +565,7 @@ export async function run(argv: string[]): Promise<void> {
       const wantClaudeLoop = !!values['claude-loop'];
       const wantDxkitAgents =
         !!values.full || !!values['with-dxkit-agents'] || wantClaudeLoop || !!values.flow;
+      const genStep = logger.startSpinner('Wiring agent context');
       const result = await generate(
         cwd,
         config,
@@ -564,6 +574,17 @@ export async function run(argv: string[]): Promise<void> {
         !!values['no-scan'],
         wantDxkitAgents,
       );
+      {
+        const skills = result.created.filter((f) => f.includes('.claude/skills/')).length;
+        const facts = [
+          skills ? `${skills} skill${skills === 1 ? '' : 's'}` : null,
+          result.created.length ? `${result.created.length} files` : null,
+          result.skipped.length ? `${result.skipped.length} kept` : null,
+        ]
+          .filter(Boolean)
+          .join(' · ');
+        genStep.succeed(facts || 'context ready');
+      }
 
       // Phase Ship installers (additive). `--full` implies every flag
       // so a one-command setup gets the full 2.5.0 ship surface.
@@ -758,30 +779,37 @@ export async function run(argv: string[]): Promise<void> {
         result: installIgnoreFiles(cwd, { force: !!values.force }),
       });
 
-      // Summary
-      console.log('');
-      logger.header('Summary');
-      if (result.created.length) logger.success(`Created: ${result.created.length} files`);
-      if (result.skipped.length)
-        logger.warn(`Skipped: ${result.skipped.length} files (already exist)`);
-      if (result.overwritten.length) logger.info(`Overwritten: ${result.overwritten.length} files`);
+      // The armed enforcement surfaces, as human labels — drives both the
+      // recap step and the closing's `gated` state. Derived from the same
+      // want* flags the installers keyed on (not re-parsed from labels).
+      const gateSurfaces: string[] = [];
+      if (wantHooks) gateSurfaces.push('pre-push hook');
+      if (wantPrecommitHook) gateSurfaces.push('pre-commit hook');
+      if (wantCi) gateSurfaces.push('CI guardrail');
+      if (wantClaudeLoop) gateSurfaces.push('Stop-gate');
+      const flowInstalled = shipResults.some(
+        (s) => s.label === 'Flow integration gate' && s.result.installed.length > 0,
+      );
+      if (flowInstalled) gateSurfaces.push('flow gate');
 
-      for (const { label, result: r } of shipResults) {
-        if (r.installed.length) {
-          logger.success(`${label}: installed ${r.installed.length} file(s)`);
-          for (const f of r.installed) logger.dim(`    ${f}`);
-        }
-        if (r.sidecars.length) {
-          logger.warn(
-            `${label}: ${r.sidecars.length} sidecar(s) written (existing files preserved)`,
-          );
-          for (const f of r.sidecars) logger.dim(`    ${f}`);
-        }
-        if (r.skipped.length) {
-          logger.dim(`${label}: ${r.skipped.length} file(s) skipped (already present)`);
-        }
-        for (const note of r.notes) logger.info(note);
+      // Recap the armed surfaces as ONE step (the verbose per-file list is
+      // gated behind --verbose for the rare debugging case). Notes surface the
+      // facts that matter: sidecars written, and the flow-gate posture.
+      const armStep = logger.startSpinner('Arming the gates');
+      const installedFiles = shipResults.reduce((n, s) => n + s.result.installed.length, 0);
+      const sidecars = shipResults.reduce((n, s) => n + s.result.sidecars.length, 0);
+      if (values.verbose) {
+        for (const { label, result: r } of shipResults)
+          for (const f of r.installed) armStep.note(`${label}: ${f}`);
       }
+      if (sidecars > 0)
+        armStep.note(`${sidecars} sidecar(s) written — your existing files were preserved`);
+      const flowNote = shipResults.find((s) => s.label === 'Flow integration gate')?.result
+        .notes[0];
+      if (flowNote) armStep.note(flowNote);
+      if (gateSurfaces.length > 0) armStep.succeed(gateSurfaces.join(' · '));
+      else if (installedFiles > 0) armStep.succeed(`${installedFiles} files`);
+      else armStep.succeed('nothing to arm');
 
       // Stamp the install-flag set into the manifest so `vyuh-dxkit
       // update` knows exactly which surfaces to refresh later instead
@@ -815,39 +843,42 @@ export async function run(argv: string[]): Promise<void> {
         withExtensionsRefresh: !!values['with-extensions-refresh'] || extensionsRefreshEnabled(cwd),
       });
 
-      console.log('');
-      logger.info('Manifest written to .vyuh-dxkit.json');
+      logger.dim('Manifest written to .vyuh-dxkit.json');
 
       // Stealth mode: gitignore only files we just created
       if (values.stealth) {
         enableStealthMode(cwd, result.created);
       }
 
-      console.log('');
-      logger.success('Done! Claude Code now has full project context.');
-
-      // D150 fix: baseline-create is the most actionable next step
-      // when ship surfaces (hooks / CI / etc.) landed — surface it
-      // prominently rather than buried under a wall of dim hints.
-      // Without a baseline, the hooks + CI workflows fail-fast on
-      // every push ("no baseline found"), making the customer think
-      // dxkit is broken right after they installed it.
-      if (shipResults.length > 0) {
-        console.log(''); // slop-ok
-        // Sequence matters: `baseline create` refuses to write an incomplete
-        // baseline when a scanner is missing (e.g. the coverage tool), so point
-        // at `tools install` FIRST — otherwise the very next step init suggests
-        // fails, right after install.
-        logger.info(
-          `Next: run \`${dxkitCli('tools install')}\`, then \`${dxkitCli('baseline create')}\` to capture today's state.`,
-        );
-        logger.dim('   (tools install provisions the scanners baseline needs; without a baseline,');
-        logger.dim('    your pre-push hook + CI guardrail have nothing to diff against)');
-      }
-
-      console.log(''); // slop-ok
-      logger.dim('  Other commands: `vyuh-dxkit doctor` (verify), `vyuh-dxkit update` (refresh),');
-      logger.dim('    `vyuh-dxkit upgrade` (move to a newer dxkit version)');
+      // The FINISHING arc — the step that makes `init` actually FINISH. It
+      // provisions the scanners a baseline needs, then captures today's
+      // baseline (visibility-resolved per Rule 11, non-interactive, fail-soft),
+      // so the surfaces we just armed have something to diff against on the
+      // very next push. Runs when a gate surface was armed (those surfaces are
+      // inert without a baseline) or the user asked for a hands-off setup
+      // (--yes); `--no-finish` opts out; a context-only install skips it.
+      const { finishSetup, buildInitClosing, renderInitClosing } = await import('./init-arc');
+      // Finish only when a BASELINE-CONSUMING gate was armed — the pre-push
+      // hook, CI guardrail, or Stop-gate are the surfaces that are inert (and
+      // fail-fast with "no baseline") without one. A context-only install
+      // (--dx-only) or a flow-warn-only bare `init` needs no baseline, so the
+      // arc doesn't waste a scan there; `--no-finish` opts out explicitly.
+      const baselineGates = wantHooks || wantCi || wantClaudeLoop;
+      const wantFinish = !values['no-finish'] && baselineGates;
+      let closingState = wantFinish
+        ? await finishSetup({ cwd, surfaces: gateSurfaces, force: !!values.force })
+        : {
+            gated: baselineGates,
+            baselineFindings: null,
+            baselineMode: null,
+            surfaces: gateSurfaces,
+            incompleteScanners: [],
+            elapsedMs: 0,
+          };
+      // "ready in Ns" reflects the WHOLE init (detect + generate + arm + arc),
+      // not just the tail.
+      closingState = { ...closingState, elapsedMs: Date.now() - initStarted };
+      renderInitClosing(buildInitClosing(closingState));
       break;
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -539,6 +539,34 @@ export async function run(argv: string[]): Promise<void> {
         }
       }
 
+      // If dxkit is already installed here at an OLDER version, the user almost
+      // certainly wants `update` (refresh the managed files to this CLI's
+      // templates), not a fresh re-init. Surface that prominently — but still
+      // continue, since `init --claude-loop` on an adopted repo is a legit
+      // "add a surface" flow. A same-version re-run just says so.
+      try {
+        const manifestFile = path.join(cwd, '.vyuh-dxkit.json');
+        if (fs.existsSync(manifestFile)) {
+          const installed = (JSON.parse(fs.readFileSync(manifestFile, 'utf-8'))?.version ??
+            null) as string | null;
+          const { classifyDelta } = await import('./upgrade');
+          const delta = classifyDelta(installed, VERSION);
+          if (delta === 'major' || delta === 'minor' || delta === 'patch') {
+            logger.warn(
+              `dxkit ${installed} is already installed here — you're running ${VERSION}.`,
+            );
+            logger.dim(
+              `  To refresh it to ${VERSION}, run \`${dxkitCli('update')}\` (no re-setup needed).`,
+            );
+            logger.dim('  Continuing will re-apply the current templates additively.');
+          } else if (delta === 'none' && installed) {
+            logger.dim(`dxkit ${installed} is already set up here — re-applying additively.`);
+          }
+        }
+      } catch {
+        /* unreadable manifest → treat as a fresh install */
+      }
+
       const promptOpts = {
         yes: !!(values.yes || values.detect),
         detect: !!values.detect,
@@ -566,14 +594,24 @@ export async function run(argv: string[]): Promise<void> {
       const wantDxkitAgents =
         !!values.full || !!values['with-dxkit-agents'] || wantClaudeLoop || !!values.flow;
       const genStep = logger.startSpinner('Wiring agent context');
-      const result = await generate(
-        cwd,
-        config,
-        finalMode,
-        !!values.force,
-        !!values['no-scan'],
-        wantDxkitAgents,
-      );
+      // Mute generate()'s own header + per-file lines (they'd otherwise leak
+      // through the step UI on a repo with files to merge, e.g. an existing
+      // CLAUDE.md/AGENTS.md); the step's summary conveys the counts. --verbose
+      // keeps the full file list for debugging.
+      const priorGenQuiet = values.verbose ? false : logger.setQuiet(true);
+      let result;
+      try {
+        result = await generate(
+          cwd,
+          config,
+          finalMode,
+          !!values.force,
+          !!values['no-scan'],
+          wantDxkitAgents,
+        );
+      } finally {
+        if (!values.verbose) logger.setQuiet(priorGenQuiet);
+      }
       {
         const skills = result.created.filter((f) => f.includes('.claude/skills/')).length;
         const facts = [

--- a/src/init-arc.ts
+++ b/src/init-arc.ts
@@ -1,0 +1,301 @@
+/**
+ * The init FINISHING arc — the step that makes `init` actually FINISH.
+ *
+ * `init --yes` already asks nothing; the friction was that it stopped early and
+ * printed two commands of homework (`tools install`, `baseline create`) instead
+ * of running them. This module runs that tail as a smooth, progress-rendered
+ * sequence: provision the scanners → capture today's baseline (visibility-
+ * resolved per Rule 11, non-interactive, FAIL-SOFT) → hand back a state the
+ * pure {@link buildInitClosing} turns into a single mental-model closing.
+ *
+ * Split in two on purpose:
+ *   - `finishSetup` does the IO and drives the spinner UI (not unit-tested);
+ *   - `buildFindingBreakdown` + `buildInitClosing` are PURE, so the
+ *     zero-question / one-closing-sentence / brownfield-mental-model contract
+ *     is assertable in a transcript test (mirror of `loop/demo.ts:buildNextSteps`,
+ *     the template the design doc names for every funnel closer).
+ */
+
+import * as logger from './logger';
+import { dxkitCli } from './self-invocation';
+import type { BaselineMode } from './baseline/modes';
+import type { BaselineEntry } from './baseline/types';
+
+/** A coarse grouping of grandfathered findings — the emotional payoff line
+ *  ("3 secrets · 12 dependency CVEs · 32 code patterns") the user sees as their
+ *  repo becomes gated. Kept deliberately coarse; the exact per-kind taxonomy
+ *  lives in the identity layer, this is a human summary. */
+export interface FindingBreakdown {
+  readonly secrets: number;
+  readonly deps: number;
+  readonly code: number;
+  readonly other: number;
+  readonly total: number;
+}
+
+/** Group baseline entries into the coarse human classes. Pure. */
+export function buildFindingBreakdown(findings: readonly BaselineEntry[]): FindingBreakdown {
+  let secrets = 0;
+  let deps = 0;
+  let code = 0;
+  let other = 0;
+  for (const f of findings) {
+    switch (f.kind) {
+      case 'secret':
+        secrets++;
+        break;
+      case 'dep-vuln':
+        deps++;
+        break;
+      case 'code':
+      case 'config':
+        code++;
+        break;
+      default:
+        other++;
+    }
+  }
+  return { secrets, deps, code, other, total: findings.length };
+}
+
+/** Render a breakdown as a `·`-separated human line, omitting zero classes. */
+export function formatBreakdown(b: FindingBreakdown): string {
+  const parts: string[] = [];
+  if (b.secrets) parts.push(`${b.secrets} secret${b.secrets === 1 ? '' : 's'}`);
+  if (b.deps) parts.push(`${b.deps} dependency CVE${b.deps === 1 ? '' : 's'}`);
+  if (b.code) parts.push(`${b.code} code pattern${b.code === 1 ? '' : 's'}`);
+  if (b.other) parts.push(`${b.other} other`);
+  return parts.join(' · ');
+}
+
+/** The state the pure closing builder consumes — everything it needs to teach
+ *  the brownfield mental model in one sentence, with zero homework commands. */
+export interface InitClosingState {
+  /** Did we arm gates AND establish a baseline (committed count or ref)? */
+  readonly gated: boolean;
+  /** Grandfathered finding count for committed modes; null for ref-based
+   *  (the ref itself is the baseline — there is no init-time count) or when
+   *  the baseline capture was skipped/failed. */
+  readonly baselineFindings: number | null;
+  readonly baselineMode: BaselineMode | null;
+  /** Human labels of the gate surfaces that were armed (for the recap line). */
+  readonly surfaces: readonly string[];
+  /** Scanner classes still missing at baseline time (coverage gap to teach). */
+  readonly incompleteScanners: readonly string[];
+  readonly elapsedMs: number;
+}
+
+/** One actionable next step: a label and the exact command to run. */
+export interface ClosingAction {
+  readonly label: string;
+  readonly command: string;
+}
+
+/** The structured closing — the renderer colors it; tests assert its fields. */
+export interface InitClosing {
+  readonly headline: string;
+  /** "ready in Ns" — the time-to-first-verdict stamp. */
+  readonly ready: string;
+  /** The mental-model body: at most a couple of short sentences. */
+  readonly body: readonly string[];
+  /** A single optional caution (incomplete scanner coverage). */
+  readonly caution: string | null;
+  readonly actions: readonly ClosingAction[];
+}
+
+function secondsLabel(ms: number): string {
+  const s = ms / 1000;
+  if (s < 1) return 'ready in under a second';
+  if (s < 90) return `ready in ${Math.round(s)}s`;
+  return `ready in ${Math.round(s / 60)}m ${Math.round(s % 60)}s`;
+}
+
+/**
+ * Build the closing from the finished-arc state. PURE — no IO, no `Date.now`.
+ *
+ * Contract (the design doc's DoD):
+ *   - teaches the brownfield mental model in ONE sentence;
+ *   - carries ZERO homework commands when gated (the tail already ran) — the
+ *     only command it may name is `tools install` to CLOSE a real coverage gap,
+ *     which is genuinely still needed;
+ *   - the two standing actions are always Verify (`doctor`) and Undo
+ *     (`uninstall`), so a first-timer always knows how to check and how to back out.
+ */
+export function buildInitClosing(state: InitClosingState): InitClosing {
+  const ready = secondsLabel(state.elapsedMs);
+  const actions: ClosingAction[] = [
+    { label: 'Verify', command: dxkitCli('doctor') },
+    { label: 'Undo', command: dxkitCli('uninstall') },
+  ];
+
+  // Not gated: a context-only install (dx-only, no gate surfaces). Sell the
+  // context win, and teach the ONE command that turns on the gate.
+  if (!state.gated) {
+    return {
+      headline: 'dxkit is set up.',
+      ready,
+      body: ['Claude Code now has full project context for this repo.'],
+      caution: null,
+      actions: [
+        { label: 'Gate it', command: dxkitCli('init --claude-loop') },
+        { label: 'Undo', command: dxkitCli('uninstall') },
+      ],
+    };
+  }
+
+  const body: string[] = [];
+  if (state.baselineMode === 'ref-based') {
+    // Public repo: the default branch IS the baseline; nothing was written.
+    body.push('Your default branch is the baseline — nothing was written to your tree.');
+    body.push('Anything a change ADDS from here is caught before it ships.');
+  } else if (state.baselineFindings !== null) {
+    const n = state.baselineFindings;
+    if (n === 0) {
+      body.push('Your repo is clean today — that clean state is now the floor.');
+      body.push('Anything a change ADDS from here is caught before it ships.');
+    } else {
+      body.push(
+        `${n} finding${n === 1 ? '' : 's'} today ${n === 1 ? 'is' : 'are'} grandfathered — ` +
+          `${n === 1 ? "it won't" : "they won't"} block you.`,
+      );
+      body.push('Anything a change ADDS from here is caught before it ships.');
+    }
+  } else {
+    // Gated (surfaces armed) but no baseline count — a fail-soft skip.
+    body.push('Your gates are armed. Capture a baseline to set the grandfathered floor:');
+    body.push(`  ${dxkitCli('baseline create')}`);
+  }
+
+  const caution =
+    state.incompleteScanners.length > 0
+      ? `${state.incompleteScanners.length} scanner class(es) weren't available ` +
+        `(${state.incompleteScanners.join(', ')}) — those finding types aren't gated yet. ` +
+        `Run \`${dxkitCli('tools install')}\` to complete coverage.`
+      : null;
+
+  return { headline: "You're gated.", ready, body, caution, actions };
+}
+
+/** Options for the finishing arc. */
+export interface FinishSetupOptions {
+  readonly cwd: string;
+  /** Human labels of the gate surfaces init just armed (for the closing recap). */
+  readonly surfaces: readonly string[];
+  /** Overwrite an existing baseline (the `--force` passthrough). */
+  readonly force?: boolean;
+}
+
+/**
+ * Run the finishing tail with live progress, and return the closing state.
+ *
+ * FAIL-SOFT throughout: a scanner that won't install, or a baseline capture
+ * that throws, degrades to a warned step — never an aborted init. A partly-set-up
+ * repo with armed gates is strictly better than an error at the finish line.
+ */
+export async function finishSetup(opts: FinishSetupOptions): Promise<InitClosingState> {
+  const started = Date.now();
+  const { cwd } = opts;
+
+  // Mute the reused installers/analyzers' ordinary logger output for the whole
+  // arc — they'd otherwise bleed progress chatter through our step UI. The
+  // spinner bypasses the mute, so the steps still render. Restored in `finally`.
+  const priorQuiet = logger.setQuiet(true);
+  try {
+    return await runFinishingArc(opts, cwd, started);
+  } finally {
+    logger.setQuiet(priorQuiet);
+  }
+}
+
+async function runFinishingArc(
+  opts: FinishSetupOptions,
+  cwd: string,
+  started: number,
+): Promise<InitClosingState> {
+  // 1) Provision the scanners the baseline needs. Running this FIRST is what
+  //    makes the baseline complete (and keeps its incomplete-capture prompt
+  //    unreachable — the design doc's key sequencing insight).
+  const { installMissingTools } = await import('./tools-cli');
+  const scan = logger.startSpinner('Installing scanners');
+  const tools = await installMissingTools(cwd, {
+    onEvent: (e) => {
+      if (e.phase === 'installing') scan.setLabel(`Installing ${e.name}`);
+    },
+  });
+  {
+    const present = tools.alreadyPresent.length;
+    if (tools.installed.length > 0) {
+      scan.note(`installed ${tools.installed.join(', ')}`);
+      scan.succeed(
+        `${tools.installed.length} installed${present ? ` · ${present} already present` : ''}`,
+      );
+    } else if (present > 0) {
+      scan.succeed(`${present} already present`);
+    } else {
+      scan.succeed('nothing to install');
+    }
+    for (const f of tools.failed) scan.note(`could not install ${f.name}: ${f.reason}`);
+  }
+
+  // 2) Capture today's baseline — visibility-resolved mode, non-interactive.
+  //    Calling createBaseline directly bypasses the CLI's incomplete-capture
+  //    prompt by construction (it captures whatever scanners are present), so
+  //    the arc never hangs; we surface the coverage gap as a note instead.
+  const { createBaseline, gatherScanCoverage } = await import('./baseline/create');
+  const { missingScanners } = await import('./baseline/coverage');
+  const incompleteScanners = missingScanners(gatherScanCoverage(cwd)).map((m) => m.tool);
+
+  const bl = logger.startSpinner('Capturing baseline');
+  let baselineFindings: number | null = null;
+  let baselineMode: BaselineMode | null = null;
+  try {
+    const result = await createBaseline({ cwd, force: !!opts.force });
+    baselineMode = result.mode.mode;
+    if (result.mode.mode === 'ref-based') {
+      bl.note('public repo → ref-based (nothing written to your tree)');
+      if (result.mode.ref) bl.note(`baseline is ${result.mode.ref}, compared on every check`);
+      bl.succeed('ref-based');
+    } else if (result.file) {
+      const b = buildFindingBreakdown(result.file.findings);
+      baselineFindings = b.total;
+      if (b.total > 0) bl.note(formatBreakdown(b));
+      const modeWord =
+        result.mode.mode === 'committed-sanitized' ? 'committed (sanitized)' : 'committed';
+      bl.note(`private repo → ${modeWord} baseline`);
+      if (incompleteScanners.length > 0) {
+        bl.note(`⚠ ${incompleteScanners.length} scanner class(es) not yet covered`);
+      }
+      bl.succeed(`${b.total} finding${b.total === 1 ? '' : 's'} grandfathered`);
+    } else {
+      bl.succeed('captured');
+    }
+  } catch (err) {
+    // Fail-soft: the gates are still armed; the user can capture a baseline
+    // themselves. Never abort init at the finish line.
+    bl.warn(`skipped — ${(err as Error).message}`);
+  }
+
+  return {
+    gated: opts.surfaces.length > 0,
+    baselineFindings,
+    baselineMode,
+    surfaces: opts.surfaces,
+    incompleteScanners,
+    elapsedMs: Date.now() - started,
+  };
+}
+
+/** Render a built closing to stdout (the init case's final output). */
+export function renderInitClosing(closing: InitClosing): void {
+  logger.header(`${closing.headline}  ✓   ${closing.ready}`);
+  for (const line of closing.body) logger.info(line);
+  if (closing.caution) {
+    console.log(''); // slop-ok: spacing before the caution
+    logger.warn(closing.caution);
+  }
+  console.log(''); // slop-ok: spacing before the actions
+  const width = Math.max(...closing.actions.map((a) => a.label.length));
+  for (const a of closing.actions) {
+    logger.dim(`${a.label.padEnd(width)}   ${a.command}`);
+  }
+}

--- a/src/init-arc.ts
+++ b/src/init-arc.ts
@@ -246,6 +246,11 @@ async function runFinishingArc(
   const incompleteScanners = missingScanners(gatherScanCoverage(cwd)).map((m) => m.tool);
 
   const bl = logger.startSpinner('Capturing baseline');
+  // The first baseline scans the whole tree (SAST + deps + coverage), which is
+  // minutes on a large repo — say so, so a long-running spinner never reads as
+  // a hang. (No-op'd visually for the fast already-gated path, which resolves
+  // before anyone reads it.)
+  bl.note('scanning your code for the grandfathered floor — the first run can take a few minutes');
   let baselineFindings: number | null = null;
   let baselineMode: BaselineMode | null = null;
   try {
@@ -270,9 +275,28 @@ async function runFinishingArc(
       bl.succeed('captured');
     }
   } catch (err) {
-    // Fail-soft: the gates are still armed; the user can capture a baseline
-    // themselves. Never abort init at the finish line.
-    bl.warn(`skipped — ${(err as Error).message}`);
+    const msg = (err as Error).message;
+    // Re-init on an already-adopted repo: a committed baseline exists, so
+    // createBaseline refuses. That's not a failure — the repo is already
+    // gated. Read the existing baseline and report its grandfathered floor.
+    const existing = msg.match(/already exists at (.+?\.json)/);
+    if (existing) {
+      try {
+        const { readBaselineFile } = await import('./baseline/baseline-file');
+        const b = buildFindingBreakdown(readBaselineFile(existing[1]).findings);
+        baselineFindings = b.total;
+        baselineMode = 'committed-full';
+        if (b.total > 0) bl.note(formatBreakdown(b));
+        bl.note('baseline already present — your repo is already gated');
+        bl.succeed(`${b.total} finding${b.total === 1 ? '' : 's'} already grandfathered`);
+      } catch {
+        bl.succeed('baseline already present');
+      }
+    } else {
+      // Fail-soft: the gates are still armed; the user can capture a baseline
+      // themselves. Never abort init at the finish line.
+      bl.warn(`skipped — ${msg}`);
+    }
   }
 
   return {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,17 +7,44 @@ const BOLD = '\x1b[1m';
 const RESET = '\x1b[0m';
 
 let jsonMode = false;
+let quiet = false;
 
 export function setJsonMode(enabled: boolean): void {
   jsonMode = enabled;
 }
 
-function write(line: string): void {
+/**
+ * Suppress the ordinary logger output (success / warn / info / dim / header)
+ * while a higher-level surface owns the screen — e.g. the init finishing arc,
+ * which drives its own spinner steps and doesn't want a reused analyzer's
+ * progress chatter bleeding through. The {@link Spinner} deliberately bypasses
+ * this, so step lines always render. Returns the prior value so a caller can
+ * restore it (use try/finally).
+ */
+export function setQuiet(enabled: boolean): boolean {
+  const prev = quiet;
+  quiet = enabled;
+  return prev;
+}
+
+/** Whether ordinary output is currently muted. Read by low-level progress
+ *  printers (e.g. the analyzer timing lines) so they honor the same scope. */
+export function isQuiet(): boolean {
+  return quiet;
+}
+
+/** The actual sink — respects JSON mode (stderr) but NOT quiet. Spinner-only. */
+function rawWrite(line: string): void {
   if (jsonMode) {
     process.stderr.write(line + '\n');
   } else {
     console.log(line); // slop-ok: logger's non-json stdout path
   }
+}
+
+function write(line: string): void {
+  if (quiet) return;
+  rawWrite(line);
 }
 
 export function header(text: string): void {
@@ -58,4 +85,102 @@ export function detected(label: string, value: string | boolean): void {
   } else {
     write(`  ${GREEN}✓${RESET} ${label}: ${CYAN}${value}${RESET}`);
   }
+}
+
+/**
+ * A live progress step. On a real TTY it animates a spinner on one line and
+ * can print interesting FACTS underneath it as they're discovered; on CI /
+ * a piped stdout / JSON mode it degrades to clean, static outcome lines (no
+ * animation, no cursor control) so logs stay readable and screenshot-stable.
+ *
+ * The label is padded to a fixed column so a stack of finalized steps reads as
+ * a table — the "world-class init" surface leans on this alignment.
+ */
+export interface Spinner {
+  /** Print an interesting fact under the step (dim, indented). Safe while spinning. */
+  note(text: string): void;
+  /** Update the live label (no effect once finalized). */
+  setLabel(text: string): void;
+  /** Finalize as success (✓). Optional dim summary shown in the fact column. */
+  succeed(summary?: string): void;
+  /** Finalize as a non-fatal warning (!). */
+  warn(summary?: string): void;
+  /** Finalize as failure (✗). */
+  fail(summary?: string): void;
+}
+
+const SPIN_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const LABEL_COL = 22; // fact column start — keep finalized steps aligned as a table
+
+/** Visible width of a label once ANSI codes are stripped (padding math). */
+function padLabel(label: string): string {
+  // eslint-disable-next-line no-control-regex
+  const bare = label.replace(/\x1b\[[0-9;]*m/g, '');
+  return bare.length >= LABEL_COL ? label : label + ' '.repeat(LABEL_COL - bare.length);
+}
+
+/**
+ * Start a live progress step. Returns a {@link Spinner} the caller finalizes
+ * with `succeed` / `warn` / `fail`. Animation runs only when stdout is an
+ * interactive TTY and we're not in JSON mode — otherwise this is a quiet
+ * primitive that prints one outcome line on finalize.
+ */
+export function startSpinner(label: string): Spinner {
+  const started = Date.now();
+  const animate = !jsonMode && !!process.stdout.isTTY;
+  let current = label;
+  let frame = 0;
+  let done = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const clearLine = (): void => {
+    if (animate) process.stdout.write('\r\x1b[K');
+  };
+  const draw = (): void => {
+    if (!animate || done) return;
+    process.stdout.write(`\r\x1b[K  ${CYAN}${SPIN_FRAMES[frame]}${RESET} ${current}`);
+    frame = (frame + 1) % SPIN_FRAMES.length;
+  };
+
+  if (animate) {
+    draw();
+    timer = setInterval(draw, 80);
+    if (typeof timer.unref === 'function') timer.unref();
+  }
+
+  const finalize = (mark: string, color: string, summary?: string): void => {
+    if (done) return;
+    done = true;
+    if (timer) clearInterval(timer);
+    clearLine();
+    const secs = (Date.now() - started) / 1000;
+    // Auto-append elapsed for genuinely slow steps so the "ready in Ns" story
+    // is visible per-step, but stay quiet on instant ones.
+    const timing = secs >= 0.8 ? `${DIM}(${secs.toFixed(1)}s)${RESET}` : '';
+    const tail = [summary ? `${DIM}${summary}${RESET}` : '', timing].filter(Boolean).join('  ');
+    // rawWrite: a step line renders even when the surface has muted ordinary
+    // logger output (the init arc mutes reused analyzers but keeps its steps).
+    rawWrite(`  ${color}${mark}${RESET} ${padLabel(current)}${tail ? ' ' + tail : ''}`);
+  };
+
+  return {
+    note(text: string): void {
+      clearLine();
+      rawWrite(`      ${DIM}${text}${RESET}`);
+      draw();
+    },
+    setLabel(text: string): void {
+      current = text;
+      draw();
+    },
+    succeed(summary?: string): void {
+      finalize('✓', GREEN, summary);
+    },
+    warn(summary?: string): void {
+      finalize('!', YELLOW, summary);
+    },
+    fail(summary?: string): void {
+      finalize('✗', RED, summary);
+    },
+  };
 }

--- a/src/tools-cli.ts
+++ b/src/tools-cli.ts
@@ -18,53 +18,42 @@
  * - `vyuh-dxkit tools install --yes` → install all missing, no prompts
  */
 import * as readline from 'readline/promises';
-import * as fs from 'fs';
-import * as path from 'path';
 import { dxkitCli } from './self-invocation';
 import { stdin, stdout } from 'process';
-import { execSync } from 'child_process';
 import { detect } from './detect';
-import { DetectedStack, type Manifest } from './types';
-import { serializePreservingJson } from './files';
-import { detectPackageManager, provisionCommand, pmAwareDevInstall } from './package-manager';
+import { detectPackageManager, provisionCommand } from './package-manager';
 import * as logger from './logger';
 import {
   TOOL_DEFS,
   findTool,
-  getInstallCommand,
-  getInstallEnv,
   checkAllTools,
-  buildRequiredTools,
   exportToolPathsToGithubEnv,
   ToolStatus,
 } from './analyzers/tools/tool-registry';
+import {
+  selectToolNames,
+  resolveInstallCommand,
+  execInstall,
+  type ToolsInstallOptions,
+} from './analyzers/tools/install-exec';
 
-export interface ToolsInstallOptions {
-  toolName?: string;
-  all?: boolean;
-}
-
-/**
- * Decide which tool names to consider for install given the options.
- * Pure function — does not touch the filesystem; testable in isolation.
- *
- * - toolName set: just that one (returns [] if name is unknown — caller
- *   surfaces an error)
- * - all: every key in TOOL_DEFS, sorted for stable output
- * - default: tools required for the current-project stack
- */
-export function selectToolNames(
-  languages: DetectedStack['languages'],
-  options: ToolsInstallOptions = {},
-): string[] {
-  if (options.toolName) {
-    return TOOL_DEFS[options.toolName] ? [options.toolName] : [];
-  }
-  if (options.all) {
-    return Object.keys(TOOL_DEFS).sort();
-  }
-  return buildRequiredTools(languages).map((r) => r.name);
-}
+// The install-EXECUTION surface lives in `install-exec.ts` (split out to keep
+// this file under the large-file budget); re-export it so existing importers
+// (init-arc, tests) keep one entry point (Rule 2 — one install code path).
+export {
+  selectToolNames,
+  recordToolDep,
+  resolveInstallCommand,
+  execInstall,
+  installMissingTools,
+} from './analyzers/tools/install-exec';
+export type {
+  ToolsInstallOptions,
+  ResolvedInstall,
+  OneToolResult,
+  ToolInstallEvent,
+  ToolInstallOutcome,
+} from './analyzers/tools/install-exec';
 
 const LAYER_ORDER: Record<string, number> = {
   universal: 1,
@@ -187,64 +176,10 @@ function showStatus(targetPath: string): ToolStatus[] {
   return statuses;
 }
 
-/**
- * Append a dxkit-installed node devDependency to the install manifest so
- * `vyuh-dxkit uninstall` can remove it. No-op when the repo has no manifest
- * (dxkit wasn't init'd there) or the entry is already recorded. Best-effort:
- * a manifest write failure never fails the install.
- */
-export function recordToolDep(cwd: string, pkg: string): void {
-  const manifestPath = path.join(cwd, '.vyuh-dxkit.json');
-  try {
-    const raw = fs.readFileSync(manifestPath, 'utf-8');
-    const manifest = JSON.parse(raw) as Manifest;
-    // Normalize to the {package, ecosystem} shape, dropping any legacy `install`
-    // string an older dxkit persisted here. Every executed/rendered install is
-    // already PM-aware; the stored npm-flavored text (`npm install --save-dev …`)
-    // was misleading canonical JSON on a non-npm repo and is derivable from
-    // {package, ecosystem} anyway. Re-run of `tools install` cleans a legacy file.
-    const normalized = (manifest.toolDeps ?? []).map((d) => ({
-      package: d.package,
-      ecosystem: 'node' as const,
-    }));
-    if (!normalized.some((d) => d.package === pkg)) {
-      normalized.push({ package: pkg, ecosystem: 'node' });
-    }
-    manifest.toolDeps = normalized;
-    fs.writeFileSync(manifestPath, serializePreservingJson(raw, manifest), 'utf-8');
-  } catch {
-    // no manifest / unreadable / unwritable → nothing to record, never fatal
-  }
-}
-
 async function confirm(rl: readline.Interface, question: string): Promise<boolean> {
   const answer = await rl.question(`  ${question} [Y/n]: `);
   if (!answer.trim()) return true;
   return answer.trim().toLowerCase().startsWith('y');
-}
-
-function runInstallCmd(
-  cmd: string,
-  envOverlay?: Record<string, string>,
-): { success: boolean; message: string } {
-  try {
-    // Pick a shell that exists on the platform. On POSIX use bash so
-    // multi-command scripts (`&&`, `||`, `;`) work; on Windows omit the
-    // option so Node uses the default cmd.exe (the hardcoded `/bin/bash`
-    // path doesn't exist there, which made every `tools install` fail
-    // outright).
-    const shell = process.platform === 'win32' ? undefined : '/bin/bash';
-    execSync(cmd, {
-      shell,
-      stdio: ['inherit', 'inherit', 'inherit'],
-      timeout: 600000, // 10 min for downloads
-      env: envOverlay ? { ...process.env, ...envOverlay } : process.env,
-    });
-    return { success: true, message: 'installed' };
-  } catch (err: unknown) {
-    const e = err as { message?: string };
-    return { success: false, message: e.message || 'unknown error' };
-  }
 }
 
 /** Interactive install of missing tools. */
@@ -323,27 +258,19 @@ async function runInstall(
 
   try {
     for (const s of missing) {
-      const def = TOOL_DEFS[s.name];
-      if (!def) {
+      const resolved = resolveInstallCommand(targetPath, s.name);
+      if (resolved.kind === 'none') {
         results.push({ name: s.name, status: 'skipped', msg: 'no install command' });
         continue;
       }
-      const rawCmd = getInstallCommand(def);
-      if (rawCmd === 'builtin' || rawCmd === 'builtin (npm)' || rawCmd === 'builtin (dotnet SDK)') {
+      if (resolved.kind === 'builtin') {
         results.push({ name: s.name, status: 'skipped', msg: 'builtin' });
         continue;
       }
-      // A node devDep tool (e.g. @vitest/coverage-v8) installs INTO the user's
-      // repo, so its `npm install --save-dev …` must match the repo's PM — else
-      // it fails the way create-dxkit did on a pnpm project. Tools installed
-      // into an isolated dxkit dir (no nodePackage) keep their npm command.
-      const cmd = def.nodePackage
-        ? pmAwareDevInstall(rawCmd, detectPackageManager(targetPath))
-        : rawCmd;
 
-      console.log('');
-      console.log(`  ${logger.bold(s.name)} — ${def.description}`);
-      logger.dim(`    ${cmd}`);
+      console.log(''); // slop-ok: interactive installer's own stdout framing
+      console.log(`  ${logger.bold(s.name)} — ${resolved.description}`); // slop-ok: interactive installer tool header
+      logger.dim(`    ${resolved.command}`);
 
       let shouldInstall = autoYes;
       if (!autoYes && rl) {
@@ -357,36 +284,19 @@ async function runInstall(
       }
 
       console.log('');
-      logger.info(`Running: ${cmd}`);
-      const result = runInstallCmd(cmd, getInstallEnv(targetPath));
-      if (result.success) {
-        // Verify install worked. An install command can legitimately
-        // exit 0 without producing the binary — e.g. the vitest-coverage
-        // guard no-ops when vitest isn't a target-repo dep. Treat
-        // "exit 0 + tool still missing" as a skip, not a failure: the
-        // script ran cleanly, we just didn't get the binary we wanted.
-        // Real install failures surface through the `result.success ===
-        // false` branch below (non-zero exit).
-        const recheck = findTool(def, targetPath);
-        if (recheck.available) {
-          results.push({ name: s.name, status: 'installed' });
-          // A project-local node devDep landed in the user's package.json on
-          // dxkit's behalf — record it so uninstall OWNS it (a dxkit-driven
-          // install dxkit then disowns breaks the "exact pre-dxkit state"
-          // promise). Global/isolated tools (no nodePackage) aren't recorded.
-          if (def.nodePackage) recordToolDep(targetPath, def.nodePackage);
-          logger.success(`${s.name} installed (${recheck.source})`);
-        } else {
-          results.push({
-            name: s.name,
-            status: 'skipped',
-            msg: 'install command exited 0 without producing the binary (likely a guarded no-op)',
-          });
-          logger.dim(`${s.name} skipped — install command exited cleanly without installing`);
-        }
+      logger.info(`Running: ${resolved.command}`);
+      // The command construction + exec + verify + dep-recording all live in
+      // execInstall (Rule 2) — the interactive path just renders its outcome.
+      const r = execInstall(targetPath, resolved);
+      if (r.status === 'installed') {
+        results.push({ name: s.name, status: 'installed' });
+        logger.success(`${s.name} installed (${r.detail})`);
+      } else if (r.status === 'failed') {
+        results.push({ name: s.name, status: 'failed', msg: r.detail });
+        logger.fail(`${s.name}: ${r.detail}`);
       } else {
-        results.push({ name: s.name, status: 'failed', msg: result.message });
-        logger.fail(`${s.name}: ${result.message}`);
+        results.push({ name: s.name, status: 'skipped', msg: r.detail });
+        logger.dim(`${s.name} skipped — ${r.detail}`);
       }
     }
   } finally {

--- a/test/cli-init.test.ts
+++ b/test/cli-init.test.ts
@@ -72,7 +72,16 @@ describe('cli init --full --yes (integration, full agent scaffold)', () => {
       JSON.stringify({ name: 'cli-init-test-full', version: '0.0.1' }, null, 2),
     );
     execFileSync('git', ['init', '-q'], { cwd: tmpDir });
-    execFileSync('node', [CLI, 'init', '--full', '--yes'], { cwd: tmpDir, stdio: 'pipe' });
+    // --no-finish: this suite asserts the generated template surface (AGENTS.md,
+    // CLAUDE.md, skills, settings.json), which `generate()` writes BEFORE the
+    // finishing arc. Without it, `init --full` would run the real arc —
+    // installing scanners into the runner (polluting later skipIf-gated
+    // integration tests) and scanning a baseline — neither of which this test
+    // exercises. Mirrors the smoke workflow's --no-finish.
+    execFileSync('node', [CLI, 'init', '--full', '--yes', '--no-finish'], {
+      cwd: tmpDir,
+      stdio: 'pipe',
+    });
   });
 
   afterAll(() => {

--- a/test/init-arc.test.ts
+++ b/test/init-arc.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildFindingBreakdown,
+  formatBreakdown,
+  buildInitClosing,
+  type InitClosingState,
+} from '../src/init-arc';
+import type { BaselineEntry } from '../src/baseline/types';
+
+/** Minimal baseline entries — only `kind` matters to the breakdown. */
+const entry = (kind: string): BaselineEntry => ({ kind }) as unknown as BaselineEntry;
+
+const base: InitClosingState = {
+  gated: true,
+  baselineFindings: 0,
+  baselineMode: 'committed-full',
+  surfaces: ['pre-push hook', 'CI guardrail'],
+  incompleteScanners: [],
+  elapsedMs: 48_000,
+};
+
+/** Assert no line poses a question to the user — the zero-question DoD. */
+function assertNoQuestions(lines: string[]): void {
+  for (const l of lines) expect(l).not.toContain('?');
+}
+
+describe('buildFindingBreakdown', () => {
+  it('groups by coarse human class and totals', () => {
+    const b = buildFindingBreakdown([
+      entry('secret'),
+      entry('secret'),
+      entry('dep-vuln'),
+      entry('code'),
+      entry('config'),
+      entry('coverage-gap'),
+    ]);
+    expect(b).toEqual({ secrets: 2, deps: 1, code: 2, other: 1, total: 6 });
+  });
+
+  it('is empty for no findings', () => {
+    expect(buildFindingBreakdown([])).toEqual({
+      secrets: 0,
+      deps: 0,
+      code: 0,
+      other: 0,
+      total: 0,
+    });
+  });
+});
+
+describe('formatBreakdown', () => {
+  it('omits zero classes and pluralizes', () => {
+    expect(formatBreakdown({ secrets: 1, deps: 0, code: 3, other: 0, total: 4 })).toBe(
+      '1 secret · 3 code patterns',
+    );
+  });
+  it('is empty when nothing to show', () => {
+    expect(formatBreakdown({ secrets: 0, deps: 0, code: 0, other: 0, total: 0 })).toBe('');
+  });
+});
+
+describe('buildInitClosing', () => {
+  it('gated + committed findings: grandfathers, teaches the ADD rule, zero homework', () => {
+    const c = buildInitClosing({ ...base, baselineFindings: 47 });
+    expect(c.headline).toBe("You're gated.");
+    expect(c.ready).toBe('ready in 48s');
+    const body = c.body.join(' ');
+    expect(body).toContain('47 findings');
+    expect(body).toContain('grandfathered');
+    expect(body.toLowerCase()).toContain('adds');
+    // No homework: the tail already ran, so it must NOT tell the user to run
+    // tools install / baseline create.
+    expect(body).not.toContain('baseline create');
+    expect(body).not.toContain('tools install');
+    // Standing actions are always Verify + Undo.
+    expect(c.actions.map((a) => a.label)).toEqual(['Verify', 'Undo']);
+    expect(c.actions[0].command).toContain('doctor');
+    expect(c.actions[1].command).toContain('uninstall');
+    assertNoQuestions([...c.body, c.headline, c.caution ?? '']);
+  });
+
+  it('singular grandfathered finding reads naturally', () => {
+    const c = buildInitClosing({ ...base, baselineFindings: 1 });
+    const body = c.body.join(' ');
+    expect(body).toContain('1 finding ');
+    expect(body).toContain("it won't");
+  });
+
+  it('clean repo (zero findings) sets the floor without a scary count', () => {
+    const c = buildInitClosing({ ...base, baselineFindings: 0 });
+    const body = c.body.join(' ');
+    expect(body.toLowerCase()).toContain('clean');
+    expect(body).not.toContain('0 findings');
+  });
+
+  it('ref-based mode: default branch is the baseline, nothing written, no count', () => {
+    const c = buildInitClosing({
+      ...base,
+      baselineMode: 'ref-based',
+      baselineFindings: null,
+    });
+    const body = c.body.join(' ');
+    expect(body.toLowerCase()).toContain('default branch');
+    expect(body.toLowerCase()).toContain('nothing was written');
+  });
+
+  it('fail-soft (armed, no baseline count): teaches the one baseline command', () => {
+    const c = buildInitClosing({ ...base, baselineFindings: null, baselineMode: null });
+    const body = c.body.join('\n');
+    expect(body).toContain('baseline create');
+  });
+
+  it('not gated: sells context and offers the ONE command that turns on the gate', () => {
+    const c = buildInitClosing({
+      ...base,
+      gated: false,
+      baselineFindings: null,
+      baselineMode: null,
+      surfaces: [],
+    });
+    expect(c.headline).toBe('dxkit is set up.');
+    expect(c.body.join(' ')).toContain('full project context');
+    expect(c.actions.map((a) => a.label)).toEqual(['Gate it', 'Undo']);
+    expect(c.actions[0].command).toContain('init');
+  });
+
+  it('incomplete scanner coverage becomes a single teaching caution (the only command)', () => {
+    const c = buildInitClosing({
+      ...base,
+      baselineFindings: 12,
+      incompleteScanners: ['osv-scanner', 'semgrep'],
+    });
+    expect(c.caution).not.toBeNull();
+    expect(c.caution).toContain('osv-scanner');
+    expect(c.caution).toContain('tools install');
+    // No coverage gap → no caution.
+    expect(buildInitClosing({ ...base, baselineFindings: 12 }).caution).toBeNull();
+  });
+
+  it('time-to-verdict is humanized across ranges', () => {
+    expect(buildInitClosing({ ...base, elapsedMs: 300 }).ready).toBe('ready in under a second');
+    expect(buildInitClosing({ ...base, elapsedMs: 12_000 }).ready).toBe('ready in 12s');
+    expect(buildInitClosing({ ...base, elapsedMs: 135_000 }).ready).toMatch(/ready in 2m \d+s/);
+  });
+});

--- a/test/lifecycle/roundtrip.test.ts
+++ b/test/lifecycle/roundtrip.test.ts
@@ -197,7 +197,7 @@ describe('load-bearing activation does not depend on a package-manager hook', ()
 
     // No package manager runs here — init must not defer the load-bearing
     // git-config write to a postinstall script that a given PM may skip.
-    cli(repo, 'init', '--with-hooks', '--yes');
+    cli(repo, 'init', '--with-hooks', '--yes', '--no-finish');
     const hooksPath = git(repo, 'config', '--local', '--get', 'core.hooksPath').trim();
     expect(hooksPath).toBe('.githooks');
   });
@@ -220,7 +220,7 @@ describe('update refreshes dxkit-owned files but never clobbers user files', () 
     git(repo, 'add', '-A');
     git(repo, 'commit', '-qm', 'pre-dxkit');
 
-    cli(repo, 'init', '--full', '--yes');
+    cli(repo, 'init', '--full', '--yes', '--no-finish');
 
     // Simulate an OLDER install: a dxkit skill sits at a stale version the user
     // never touched — on-disk content matches the manifest hash (dxkit owns it,
@@ -249,7 +249,7 @@ describe('update refreshes dxkit-owned files but never clobbers user files', () 
     git(repo, 'add', '-A');
     git(repo, 'commit', '-qm', 'pre-dxkit');
 
-    cli(repo, 'init', '--full', '--yes');
+    cli(repo, 'init', '--full', '--yes', '--no-finish');
 
     const wfAbs = join(repo, '.github/workflows/dxkit-guardrails.yml');
     expect(existsSync(wfAbs)).toBe(true);
@@ -273,7 +273,7 @@ describe('update refreshes dxkit-owned files but never clobbers user files', () 
     git(repo, 'add', '-A');
     git(repo, 'commit', '-qm', 'pre-dxkit brownfield');
 
-    cli(repo, 'init', '--full', '--yes'); // dxkit skips AGENTS.md → provenance 'skipped'
+    cli(repo, 'init', '--full', '--yes', '--no-finish'); // dxkit skips AGENTS.md → provenance 'skipped'
     cli(repo, 'update', '--force'); // the reported data-loss trigger
 
     expect(readFileSync(join(repo, 'AGENTS.md'), 'utf8')).toBe(agents);

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -203,7 +203,7 @@ describe('vyuh-dxkit update: end-to-end refresh', () => {
 
     // Simulate a 2.5.1-era full install — let dxkit's own init drop the
     // full scaffold here so we observe a realistic baseline.
-    runCli(tmp, ['init', '--full', '--yes']);
+    runCli(tmp, ['init', '--full', '--yes', '--no-finish']);
   });
 
   afterAll(() => {


### PR DESCRIPTION
## What

`init --yes` already asked nothing — the friction was that it **stopped early** and printed `tools install` + `baseline create` as homework instead of running them. Init now **finishes the arc**, rendered as a smooth, progress-lit sequence, and lands the user on a single mental-model closing.

**One command → detected, wired, armed, gated in ~10s** — animated demo: the recording is at `tmp/feature-req/assets/init/init-tty.gif`.

```
  ✓ Reading your stack     TypeScript · Next.js · vitest
  ✓ Wiring agent context   8 skills · CLAUDE.md
  ✓ Arming the gates       pre-push hook · CI guardrail · Stop-gate
  ✓ Installing scanners    3 installed · 6 already present
  ✓ Capturing baseline     47 findings grandfathered
       3 secrets · 12 dependency CVEs · 32 code patterns · committed baseline

  You're gated.  ✓   ready in 10s
  → 47 findings today are grandfathered — they won't block you.
  → Anything a change ADDS from here is caught before it ships.
  Verify   vyuh-dxkit doctor
  Undo     vyuh-dxkit uninstall
```

## How

- **`logger.startSpinner`** — TTY-aware animated step primitive (fact column, auto-elapsed) that degrades to clean static lines on CI / non-TTY / JSON. `setQuiet`/`isQuiet` let the arc mute reused analyzers while its steps keep rendering (spinner bypasses the mute; the analyzer `timing` lines honor the same scope).
- **`tools-cli`** — extracted `resolveInstallCommand` + `execInstall` + a quiet `installMissingTools()` core (**Rule 2** — the interactive installer now delegates to the same exec path; no duplicated command construction), with a quiet exec mode so PM install noise doesn't bleed through the UI.
- **`src/init-arc.ts`** — `finishSetup()` runs the tail (provision scanners → capture baseline, visibility-resolved per **Rule 11**, non-interactive, **fail-soft**), then a **pure, unit-tested** `buildInitClosing()` teaches the brownfield mental model in one sentence with **zero homework commands**. Runs only when a baseline-consuming gate (hooks/CI/Stop-gate) was armed; `--no-finish` opts out; a context-only install skips it.
- **init case** — phases render as steps surfacing the interesting facts + a time-to-first-verdict stamp.

## Notes

- Creates **no branches** — default baseline is committed-file (private) or ref-based (public); side-refs remain the opt-in anchor transport only.
- `--no-finish` and `--dx-only` paths verified (dx-only no longer wastes a scan).

## Gates

build ✓ · arch ✓ · slop ✓ · lint ✓ · format ✓ · **full suite 4046 passed** (+12 init-arc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)