### PR TITLE
feat(init): optimize install to the repo + quick/comprehensive enforcement tiering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-07-13
+
 ### Added
 
+- **Zero-question `init` that finishes the setup in one command.** `vyuh-dxkit
+  init` (and `create-dxkit`) now completes the whole arc with no prompts: it
+  detects the stack, wires the agent context, arms the gates, installs the
+  scanner toolchain, optimizes the config to the repo, and captures today's
+  baseline — so the repository is gated on the very next change. It renders as a
+  live progress sequence and ends on a single mental-model closing (N findings
+  grandfathered; anything a change adds is caught) instead of a wall of homework
+  commands. `--no-finish` arms the gates but defers the tools-install + baseline;
+  re-running on an already-adopted repo detects an older installed version and
+  points at `vyuh-dxkit update`.
+- **`init` optimizes the config to the repo.** As part of the finish arc, `init`
+  runs the deterministic `configure` plan: it computes the config each capability
+  should take from observable repo facts (same repo yields the same plan) and
+  merge-writes it into `policy.json` without clobbering your edits — pinning
+  postures like `baseline.mode` and enabling the lint / schema / duplication
+  gates that fit the repo (mostly warn-tier, so it adds visibility, not new
+  blocks). Agents can drive the same assess-and-configure flow through the
+  `dxkit-onboard` skill (`capabilities` → `doctor` → `configure --apply`).
+- **`vyuh-dxkit evaluate` — a zero-write trial.** Replays your recent landings
+  through the guardrail gate so you can see what it would have blocked before you
+  commit to adopting it. Writes nothing to the repo; `--json` for the evidence
+  document. Driven by the `dxkit-evaluate` skill.
 - **`vyuh-dxkit describe` — a zero-write repo card + a shareable contract map.**
   A snapshot of what dxkit can see about a repo: its stack, its HTTP flow spine
   (routes served, calls made, how they bind), and its data models — with every
@@ -49,6 +73,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Two-tier enforcement: quick at pre-push, comprehensive in CI.** The pre-push
+  hook now runs the correctness floor scoped to the change (does it compile, do
+  the affected tests pass?) plus the findings guardrail scanned `--incremental`
+  (scoped to the change, so the check scales with the PR's size, not the whole
+  repo's). CI stays comprehensive: the full-scope findings guardrail plus the
+  full-suite correctness floor. The floor is fail-open on a missing toolchain, so
+  the push boundary never hard-fails on un-installed tools — CI is the backstop.
 - **Structural-duplicate (seam) signal re-sourced from dxkit's own AST, with
   IDF-weighted scoring.** A rigor pass on real agent-authored repos found the
   graph-based detector produced confident false positives on framework-heavy code:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.githooks/pre-push
+++ b/src-templates/.githooks/pre-push
@@ -1,11 +1,17 @@
 #!/usr/bin/env sh
 #
-# dxkit pre-push hook — full guardrail check against the baseline.
+# dxkit pre-push hook — QUICK tier of a two-tier gate.
 #
-# Runs the full `vyuh-dxkit guardrail check` (no --changed-only),
-# so every regression introduced since the baseline blocks the push.
-# Slower than pre-commit, but the push boundary is the last point
-# we can stop bad code from leaving the developer's machine.
+# Enforcement is tiered so the push boundary stays fast while CI stays
+# comprehensive:
+#   - pre-push (here) = QUICK: the correctness floor scoped to the change
+#     (does it compile + do the affected tests pass?) followed by the
+#     findings guardrail scanned INCREMENTALLY (scoped to the change), so
+#     the check scales with the PR's size, not the whole repo's.
+#   - CI (dxkit-guardrails.yml) = COMPREHENSIVE: the full-scope findings
+#     guardrail plus the full-suite correctness floor.
+# The push boundary is the last point we can stop bad code from leaving
+# the developer's machine, so it blocks; but it does the cheap version.
 #
 # Install:
 #   git config core.hooksPath .githooks
@@ -70,4 +76,7 @@ if [ ! -f "${BASELINE_FILE}" ]; then
   exit 0
 fi
 
-"${DXKIT}" guardrail check --name "${BASELINE_NAME}"
+# Findings guardrail, scanned INCREMENTALLY — scoped to the change so the
+# check scales with the PR's size, not the whole repo's. CI runs the
+# full-scope guardrail as the comprehensive backstop.
+"${DXKIT}" guardrail check --name "${BASELINE_NAME}" --incremental

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -180,7 +180,7 @@ __DXKIT_CI_RUNTIME_SETUP__
       # floor is most meaningful on JS/TS repos and on repos with no test-CI;
       # your own test job is the place for full-language coverage. Tune via
       # .dxkit/policy.json correctness.surfaces.ci or DXKIT_FLOOR_CI.
-      - name: Run correctness floor
+      - name: Correctness floor (compile + tests)
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
             DXKIT=./node_modules/.bin/vyuh-dxkit

--- a/src/init-arc.ts
+++ b/src/init-arc.ts
@@ -237,7 +237,31 @@ async function runFinishingArc(
     for (const f of tools.failed) scan.note(`could not install ${f.name}: ${f.reason}`);
   }
 
-  // 2) Capture today's baseline — visibility-resolved mode, non-interactive.
+  // 2) Optimize the config for THIS repo. `gatherConfigPlan` computes the
+  //    deterministic per-capability plan from observable repo facts (same repo →
+  //    same plan) and `applyConfigPlan` merge-writes it into policy.json without
+  //    clobbering user edits. This turns a minimal-default install into a
+  //    repo-optimized one — it enables the lint / schema / duplication gates that
+  //    fit the repo (mostly warn-tier, so it adds visibility, not new blocks) and
+  //    PINS postures like baseline.mode. Runs BEFORE the baseline so baseline.mode
+  //    is pinned before capture. Fail-soft.
+  const cfg = logger.startSpinner('Optimizing config for this repo');
+  try {
+    const { gatherConfigPlan } = await import('./discovery/commands');
+    const { applyConfigPlan } = await import('./configure-cli');
+    const plan = gatherConfigPlan(cwd);
+    if (plan.length > 0) {
+      for (const item of plan) cfg.note(`${item.section} → ${item.summary}`);
+      applyConfigPlan(cwd, plan);
+      cfg.succeed(`${plan.length} setting${plan.length === 1 ? '' : 's'} tuned to this repo`);
+    } else {
+      cfg.succeed('already optimal');
+    }
+  } catch (err) {
+    cfg.warn(`skipped — ${(err as Error).message}`);
+  }
+
+  // 3) Capture today's baseline — visibility-resolved mode, non-interactive.
   //    Calling createBaseline directly bypasses the CLI's incomplete-capture
   //    prompt by construction (it captures whatever scanners are present), so
   //    the arc never hangs; we surface the coverage gap as a note instead.


### PR DESCRIPTION
## (a) Optimize the install to the repo

`init`'s finishing arc now runs the deterministic **`configure`** plan (between provisioning scanners and capturing the baseline): it computes the config each capability should take from **observable repo facts** (`gatherConfigPlan` → `applyConfigPlan`, same repo → same plan) and merge-writes it into `policy.json` without clobbering user edits.

This turns a **minimal-default** install into a **repo-optimized** one:
- **Enables the gates that fit** the repo — lint / schema / duplication — mostly **warn-tier**, so it adds *visibility, not new blocks*.
- **Pins postures** like `baseline.mode` (deterministic across dev + CI instead of re-resolved each run).

Runs **before** the baseline (so `baseline.mode` is pinned before capture), renders as an "Optimizing config for this repo" step, and is fail-soft. Validated on a real repo → `baseline.mode: committed-full` + `lint: { enabled: true, blocking: false }`.

## (b) Quick pre-push / comprehensive PR

Two-tier enforcement:
- **pre-push (quick):** correctness floor scoped to the change (**compile + affected tests**) + findings guardrail `--incremental` (scoped to the change, scales with PR size not repo size).
- **CI/PR (comprehensive):** full-scope findings guardrail + full-suite correctness floor.

The correctness floor was already wired at pre-push + CI; this PR adds `--incremental` to the pre-push findings scan (the actual "quick" enabler) and documents the tiering accurately. The floor is **fail-open** on a missing toolchain (validated), so pre-push can't hard-fail when tools aren't installed — CI is the backstop.

## Why now
Both directly sharpen the imminent customer installs: the install lands optimally configured, and the enforcement is fast locally / thorough in CI. Additive + low-risk (no skills-lifecycle changes).

## Gates
Full suite **4046 passed** · build / lint / format / arch / slop green · floor fail-open validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)