### PR TITLE
fix(gate): fail-open guardrail gates report WHY they didn't run (3.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.1] - 2026-07-13
+
+### Fixed
+
+- **Fail-open guardrail gates now say WHY they didn't run, instead of erroring
+  silently.** A gate that could not evaluate (an unreachable base ref, an
+  unparseable tree, a plugin throw) returned `skipped: "error"` with no reason in
+  the human output, the `--json`, or stderr — a diagnosability black hole. The
+  flow gate, the model-schema drift gate, and the seam/duplicate gate now each
+  capture the failing step and a clean message and surface it in all three
+  renderers (console, JSON `error`, and the PR markdown), while staying fail-open
+  (the gate still does not block the build). Set `DXKIT_DEBUG=1` for the full
+  stack. This unblocks confirming the flow gate agrees with `doctor` before
+  moving `flow.mode` from `warn` to `block`.
+
+### Internal
+
+- Fixed at the platform level so the class cannot recur: the three additive gates
+  share one fail-open diagnostic contract (`src/baseline/gate-failopen.ts`); the
+  `skip(mode, 'error', failure)` overload makes a silent error a compile error; an
+  architecture-check rule bans a bare `} catch {` in `*-gate-check.ts`; and
+  `test/baseline/gate-failopen.test.ts` drives each gate into its catch and
+  asserts a populated failure plus that the renderers surface it.
+
 ## [3.7.0] - 2026-07-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,23 @@ ${path}` keys, which discards catch-all structure — so it did exact membership
   MERGES into (`.gitignore`, `package.json`, `.claude/settings.json`,
   `CLAUDE.md`) are reverted by `src/uninstall/reversals.ts`, a separate
   centralized mechanism — a merge-only surface carries an empty `artifacts` list.
+- how a fail-open guardrail gate reports its OWN failure → `captureGateFailure`
+  in `src/baseline/gate-failopen.ts`. The three additive gates (flow, schema-
+  drift, seam-dup) are deliberately fail-OPEN: a bad ref, an unparseable tree, a
+  plugin throw must NOT wedge the build, so each degrades to "did not gate". The
+  recurring shape (the shipped bug): each gate ended in a bare `} catch { return
+skip(mode, 'error'); }` that DISCARDED the error, and the renderers printed
+  nothing for a finding-less gate — so the flow gate erroring inside `guardrail
+check` was a diagnosability black hole (nothing in the human output, the
+  `--json`, or stderr), and it was invisible in dogfood because dxkit's own repo
+  runs `flow` off so the gate path was never exercised. Every gate now tracks the
+  `step` it is in, its catch routes through `captureGateFailure(step, err)`, and
+  the outcome carries a `GateFailure { step, message }` that ALL three renderers
+  surface (console / JSON `error` / markdown). The `skip(mode, 'error', failure)`
+  overload makes a silent `skip(mode, 'error')` a COMPILE error; the arch-check
+  bans a bare `} catch {` in `*-gate-check.ts`; `test/baseline/gate-failopen.test.ts`
+  drives each gate into its catch and asserts a populated `GateFailure` + that the
+  renderers show it. A fail-open gate stays fail-open — it just always says WHY.
 
 `scripts/check-architecture.sh` gates the first two (a second `git ls-files
 .env` or a config-less `gatherFlowModel` on a single-repo surface fails CI) and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1260,6 +1260,27 @@ if [ -n "$RULE_MODELGATHER" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# Fail-open gate diagnostics (the swallow class-fix): every additive guardrail
+# gate (flow / schema-drift / seam-dup) is fail-OPEN, but a bare `} catch {` that
+# discards the error and returns `skipped: 'error'` with no reason is a
+# diagnosability black hole (it shipped once — the flow gate erroring silently
+# inside `guardrail check`). A gate's catch MUST bind the error and route it
+# through captureGateFailure() in src/baseline/gate-failopen.ts so the outcome
+# carries the step + message. The `skip(mode, 'error')` overload enforces this at
+# compile time; this bans the silent shape at commit time as a second net.
+RULE_GATE_SWALLOW=$(grep -rnE "\}[[:space:]]*catch[[:space:]]*\{" src/baseline/ 2>/dev/null \
+  | grep -E 'gate-check\.ts:' \
+  | grep -v "// failopen-ok")
+if [ -n "$RULE_GATE_SWALLOW" ]; then
+  echo "❌ Fail-open swallow: a bare '} catch {' in a guardrail gate discards the error:"
+  echo "$RULE_GATE_SWALLOW"
+  echo "   → Bind the error ('} catch (err) {') and return"
+  echo "     skip(mode, 'error', captureGateFailure(step, err)) so the outcome says WHY."
+  echo "   → See src/baseline/gate-failopen.ts + test/baseline/gate-failopen.test.ts."
+  echo "   → Annotate '// failopen-ok' for a justified non-gate exception (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
 #   (b) the `schema` policy section has ONE reader/writer —
 #       src/analyzers/model-schema/config.ts. A second ad-hoc read of
 #       policy.json's schema block re-opens the split-config bug class the

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -34,6 +34,7 @@ import type { FlowGateOutcome } from './flow-gate-check';
 import { describeSchemaDrift } from '../analyzers/model-schema/gate';
 import type { SchemaDriftGateOutcome } from './schema-drift-gate-check';
 import type { DupGateOutcome } from './dup-gate-check';
+import type { GateFailure } from './gate-failopen';
 import {
   groupDuplicatesByAdded,
   type DuplicateFinding,
@@ -291,8 +292,33 @@ export function renderConsole(result: GuardrailCheckResult): string {
  * findings — a skipped or clean gate adds no noise. Blocking breakages are
  * grouped separately from warnings so the actionable set surfaces first.
  */
+/**
+ * A visible line for a fail-open gate that ERRORED — never silent. The gate
+ * degraded to "did not gate" (correct: a broken toolchain is not broken code),
+ * but it says WHERE (`error.step`) and WHY (`error.message`) instead of
+ * swallowing the throw. Closes the class where a gate erroring inside
+ * `guardrail check` produced a bare `skipped:"error"` with nothing in the human
+ * output, the JSON, or stderr. Accepts the minimal shared shape so all three
+ * gates render a failure identically (Rule 2). Empty for any non-error state.
+ */
+function formatGateFailure(
+  label: string,
+  gate: { skipped?: string; error?: GateFailure } | undefined,
+): string[] {
+  if (!gate || gate.skipped !== 'error') return [];
+  const at = gate.error?.step ? ` at ${gate.error.step}` : '';
+  const why = gate.error?.message ? `: ${gate.error.message}` : '';
+  return [
+    logger.bold(`⚠ ${label} gate did not run — error${at}${why}`),
+    '  (fail-open: this did not block the check; set DXKIT_DEBUG=1 for the stack)',
+    '',
+  ];
+}
+
 function formatFlowGate(flow: FlowGateOutcome | undefined): string[] {
   if (!flow) return [];
+  const failure = formatGateFailure('Flow', flow);
+  if (failure.length > 0) return failure;
   const suppressed = flow.suppressed ?? [];
   if (flow.findings.length === 0 && suppressed.length === 0) return [];
   const out: string[] = [];
@@ -355,6 +381,8 @@ function flowFingerprintLine(id: string): string {
  */
 function formatSchemaDriftGate(gate: SchemaDriftGateOutcome | undefined): string[] {
   if (!gate) return [];
+  const failure = formatGateFailure('Schema drift', gate);
+  if (failure.length > 0) return failure;
   const suppressed = gate.suppressed ?? [];
   if (gate.findings.length === 0 && suppressed.length === 0) return [];
   const out: string[] = [];
@@ -412,6 +440,8 @@ function schemaFingerprintLine(id: string): string {
  */
 function formatDupGate(gate: DupGateOutcome | undefined): string[] {
   if (!gate) return [];
+  const failure = formatGateFailure('Structural duplicate', gate);
+  if (failure.length > 0) return failure;
   const suppressed = gate.suppressed ?? [];
   if (gate.findings.length === 0 && suppressed.length === 0) return [];
   const out: string[] = [];
@@ -710,6 +740,9 @@ export interface GuardrailJsonPayload {
   readonly flowGate?: {
     readonly ran: boolean;
     readonly skipped?: string;
+    /** Present when `skipped === 'error'` — the step that threw + a clean
+     *  message. A fail-open error is disclosed, never a silent `skipped:"error"`. */
+    readonly error?: { readonly step: string; readonly message: string };
     readonly mode: string;
     readonly blocks: boolean;
     readonly warns: boolean;
@@ -742,6 +775,7 @@ export interface GuardrailJsonPayload {
   readonly schemaDriftGate?: {
     readonly ran: boolean;
     readonly skipped?: string;
+    readonly error?: { readonly step: string; readonly message: string };
     readonly mode: string;
     readonly blocks: boolean;
     readonly warns: boolean;
@@ -774,6 +808,7 @@ export interface GuardrailJsonPayload {
   readonly dupGate?: {
     readonly ran: boolean;
     readonly skipped?: string;
+    readonly error?: { readonly step: string; readonly message: string };
     readonly mode: string;
     readonly blocks: boolean;
     readonly warns: boolean;
@@ -882,6 +917,7 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
           flowGate: {
             ran: result.flowGate.ran,
             ...(result.flowGate.skipped !== undefined ? { skipped: result.flowGate.skipped } : {}),
+            ...(result.flowGate.error !== undefined ? { error: result.flowGate.error } : {}),
             mode: result.flowGate.mode,
             blocks: result.flowGate.blocks,
             warns: result.flowGate.warns,
@@ -914,6 +950,9 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
             ran: result.schemaDriftGate.ran,
             ...(result.schemaDriftGate.skipped !== undefined
               ? { skipped: result.schemaDriftGate.skipped }
+              : {}),
+            ...(result.schemaDriftGate.error !== undefined
+              ? { error: result.schemaDriftGate.error }
               : {}),
             mode: result.schemaDriftGate.mode,
             blocks: result.schemaDriftGate.blocks,
@@ -948,6 +987,7 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
           dupGate: {
             ran: result.dupGate.ran,
             ...(result.dupGate.skipped !== undefined ? { skipped: result.dupGate.skipped } : {}),
+            ...(result.dupGate.error !== undefined ? { error: result.dupGate.error } : {}),
             mode: result.dupGate.mode,
             blocks: result.dupGate.blocks,
             warns: result.dupGate.warns,
@@ -1118,8 +1158,22 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
  * top-level table (they fail the PR); warnings collapse into a `<details>`.
  * Silent when the gate produced no findings.
  */
+/** A markdown line for a fail-open gate that errored — the PR-comment mirror of
+ *  `formatGateFailure`. Never silent on an error; empty otherwise. */
+function markdownGateFailure(
+  label: string,
+  gate: { skipped?: string; error?: GateFailure } | undefined,
+): string[] {
+  if (!gate || gate.skipped !== 'error') return [];
+  const at = gate.error?.step ? ` at \`${gate.error.step}\`` : '';
+  const why = gate.error?.message ? `: ${escapeMd(gate.error.message)}` : '';
+  return [`> ⚠️ **${label} gate did not run** — error${at}${why} (fail-open; did not block).`, ''];
+}
+
 function markdownFlowGate(flow: FlowGateOutcome | undefined): string[] {
   if (!flow) return [];
+  const failure = markdownGateFailure('Flow', flow);
+  if (failure.length > 0) return failure;
   const suppressed = flow.suppressed ?? [];
   if (flow.findings.length === 0 && suppressed.length === 0) return [];
   const out: string[] = [];
@@ -1181,6 +1235,8 @@ function markdownFlowGate(flow: FlowGateOutcome | undefined): string[] {
  */
 function markdownSchemaDriftGate(gate: SchemaDriftGateOutcome | undefined): string[] {
   if (!gate) return [];
+  const failure = markdownGateFailure('Schema drift', gate);
+  if (failure.length > 0) return failure;
   const suppressed = gate.suppressed ?? [];
   if (gate.findings.length === 0 && suppressed.length === 0) return [];
   const out: string[] = [];
@@ -1257,6 +1313,8 @@ function markdownSchemaDriftGate(gate: SchemaDriftGateOutcome | undefined): stri
  *  single collapsed section names each twin, its similarity, and fingerprint. */
 function markdownDupGate(gate: DupGateOutcome | undefined): string[] {
   if (!gate) return [];
+  const failure = markdownGateFailure('Structural duplicate', gate);
+  if (failure.length > 0) return failure;
   const suppressed = gate.suppressed ?? [];
   if (gate.findings.length === 0 && suppressed.length === 0) return [];
   const out: string[] = [];

--- a/src/baseline/dup-gate-check.ts
+++ b/src/baseline/dup-gate-check.ts
@@ -39,6 +39,7 @@ import { readDuplicationConfig, type DuplicationGateMode } from '../analyzers/du
 import { allSourceExtensions } from '../languages';
 import { findEntry, isEntryActive } from '../allowlist/file';
 import type { AllowlistFile } from '../allowlist/file';
+import { captureGateFailure, type GateFailure } from './gate-failopen';
 
 /** Why the gate produced no verdict, when it didn't run. */
 export type DupGateSkip =
@@ -64,6 +65,9 @@ export interface DupGateOutcome {
   readonly ran: boolean;
   /** Populated when `ran` is false — the reason no verdict was produced. */
   readonly skipped?: DupGateSkip;
+  /** Populated when `skipped === 'error'` — the step that threw + a clean
+   *  message, so a fail-open error is never a silent black hole. */
+  readonly error?: GateFailure;
   /** The effective mode after the preset override (`block` / `warn` / `off`).
    *  `block` does NOT make a lone duplicate block — it authorizes seam
    *  convergence (downstream) to escalate a duplicate that is also reliably
@@ -81,7 +85,15 @@ export interface DupGateOutcome {
   readonly warns: boolean;
 }
 
-function skip(mode: DuplicationGateMode, reason: DupGateSkip): DupGateOutcome {
+// A fail-open 'error' skip MUST carry the captured failure — the overload makes
+// a silent `skip(mode, 'error')` a compile error (the swallow class).
+function skip(mode: DuplicationGateMode, reason: 'error', failure: GateFailure): DupGateOutcome;
+function skip(mode: DuplicationGateMode, reason: Exclude<DupGateSkip, 'error'>): DupGateOutcome;
+function skip(
+  mode: DuplicationGateMode,
+  reason: DupGateSkip,
+  failure?: GateFailure,
+): DupGateOutcome {
   return {
     ran: false,
     skipped: reason,
@@ -90,6 +102,7 @@ function skip(mode: DuplicationGateMode, reason: DupGateSkip): DupGateOutcome {
     suppressed: [],
     blocks: false,
     warns: false,
+    ...(failure ? { error: failure } : {}),
   };
 }
 
@@ -167,6 +180,8 @@ export async function evaluateDupGateForGuardrail(opts: {
   if (!opts.baseRef) return skip(gateMode, 'no-base-ref');
   const ref = opts.baseRef;
 
+  // The step the try body is in — carried into a fail-open error.
+  let step = 'changed-files';
   try {
     // Trigger-skip: a net-new duplicate requires a change to a source file.
     // A null changed-set = can't prove the diff is source-free → fall through
@@ -184,6 +199,7 @@ export async function evaluateDupGateForGuardrail(opts: {
 
     // HEAD side — duplicate findings from dxkit's own AST (no graph.json write;
     // the zero-write guarantee). Diff-scoped to pairs touching a changed file.
+    step = 'head-gather';
     const headFindings = await gatherDuplicates(cwd, {
       minScore: config.minScore,
       ...(focusFiles ? { focusFiles } : {}),
@@ -194,6 +210,7 @@ export async function evaluateDupGateForGuardrail(opts: {
 
     // Base side — the duplicate-pair ID set at the base ref, gathered from a
     // detached worktree (Rule 11). A pair present here is grandfathered.
+    step = 'base-worktree';
     const baseIds = await withRefWorktree({ cwd, ref }, async (wt) => {
       const baseFindings = await gatherDuplicates(wt, {
         minScore: config.minScore,
@@ -235,9 +252,10 @@ export async function evaluateDupGateForGuardrail(opts: {
       );
     }
     return { ran: true, mode: gateMode, findings: active, suppressed, blocks: false, warns };
-  } catch {
+  } catch (err) {
     // Fail-open: a ref that can't be checked out, an unparseable tree, a
-    // graphify error — none of these should fail the guardrail.
-    return skip(gateMode, 'error');
+    // graphify error — none of these should fail the guardrail. The gate did
+    // not run, but it says WHY rather than swallowing the throw.
+    return skip(gateMode, 'error', captureGateFailure(step, err));
   }
 }

--- a/src/baseline/flow-gate-check.ts
+++ b/src/baseline/flow-gate-check.ts
@@ -44,6 +44,7 @@ import { evaluateFlowGate, type BrokenIntegration } from '../analyzers/flow/gate
 import { readFlowConfig, type FlowGateMode } from '../analyzers/flow/config';
 import { findEntry, isEntryActive } from '../allowlist/file';
 import type { AllowlistFile } from '../allowlist/file';
+import { captureGateFailure, type GateFailure } from './gate-failopen';
 
 /** Why the gate produced no verdict, when it didn't run. */
 export type FlowGateSkip =
@@ -69,6 +70,9 @@ export interface FlowGateOutcome {
   readonly ran: boolean;
   /** Populated when `ran` is false — the reason no verdict was produced. */
   readonly skipped?: FlowGateSkip;
+  /** Populated when `skipped === 'error'` — the step that threw + a clean
+   *  message, so a fail-open error is never a silent black hole. */
+  readonly error?: GateFailure;
   /** The effective mode after the loop-seam override (block / warn / off). */
   readonly mode: FlowGateMode;
   /** Net-new broken integrations that count toward the verdict (active — NOT
@@ -93,7 +97,12 @@ export interface FlowGateOutcome {
  *  the snapshot metadata, so a clock-free placeholder keeps this pure. */
 const GATE_META = { schemaVersion: 1 as const, generatedAt: '' };
 
-function skip(mode: FlowGateMode, reason: FlowGateSkip): FlowGateOutcome {
+// A fail-open 'error' skip MUST carry the captured failure — the overload makes
+// a silent `skip(mode, 'error')` a compile error, so the swallow class cannot
+// return through this door again.
+function skip(mode: FlowGateMode, reason: 'error', failure: GateFailure): FlowGateOutcome;
+function skip(mode: FlowGateMode, reason: Exclude<FlowGateSkip, 'error'>): FlowGateOutcome;
+function skip(mode: FlowGateMode, reason: FlowGateSkip, failure?: GateFailure): FlowGateOutcome {
   return {
     ran: false,
     skipped: reason,
@@ -102,6 +111,7 @@ function skip(mode: FlowGateMode, reason: FlowGateSkip): FlowGateOutcome {
     suppressed: [],
     blocks: false,
     warns: false,
+    ...(failure ? { error: failure } : {}),
   };
 }
 
@@ -174,6 +184,9 @@ export async function evaluateFlowGateForGuardrail(opts: {
   if (!opts.baseRef) return skip(gateMode, 'no-base-ref');
   const ref = opts.baseRef;
 
+  // The step the try body is in — carried into a fail-open error so the reader
+  // knows WHERE the gate broke, not just that it did.
+  let step = 'changed-files';
   try {
     // Trigger-skip: a net-new broken integration requires a change to a client
     // call, a route, or a spec. When the diff touched none, there is nothing to
@@ -199,6 +212,7 @@ export async function evaluateFlowGateForGuardrail(opts: {
     // a PR that edits the plugin changes both sides' lens — intended, the
     // same rule the gate's policy config follows). Under --untrusted the
     // overlay is empty on both sides — symmetric degradation.
+    step = 'plugin-overlay';
     const overlay = loadFlowPluginOverlay(cwd, { untrusted: opts.untrusted });
     const overlayGather = {
       dialects: overlay.dialects,
@@ -208,6 +222,7 @@ export async function evaluateFlowGateForGuardrail(opts: {
 
     // HEAD side (the working tree). Served truth = live routes ∪ any committed
     // counterpart snapshot (split-repo case).
+    step = 'head-gather';
     const headModel = await gatherFlowModel({
       roots: [cwd],
       specs: config.specs.map((s) => path.resolve(cwd, s)),
@@ -226,6 +241,7 @@ export async function evaluateFlowGateForGuardrail(opts: {
     // Base side, gathered from a detached worktree at the ref (Rule 11). Read
     // ITS committed snapshot so the base served set reflects the counterpart as
     // it was at base — keeping the grandfathering diff honest.
+    step = 'base-worktree';
     const base = await withRefWorktree({ cwd, ref }, async (wt) => {
       const baseModel = await gatherFlowModel({
         roots: [wt],
@@ -251,6 +267,7 @@ export async function evaluateFlowGateForGuardrail(opts: {
     // from a call served by a repo we can't see. Skip rather than false-block.
     if (headServed.size === 0 && baseServed.size === 0) return skip(gateMode, 'no-served-truth');
 
+    step = 'evaluate';
     const found = evaluateFlowGate({
       headConsumed,
       baseConsumed: base.consumed,
@@ -289,11 +306,11 @@ export async function evaluateFlowGateForGuardrail(opts: {
       warns,
       ...(contractGeneratedAt ? { contractGeneratedAt } : {}),
     };
-  } catch {
+  } catch (err) {
     // Fail-open: a ref that can't be checked out, an unparseable tree, a git
-    // error — none of these should fail the guardrail. The gate simply did not
-    // run.
-    return skip(gateMode, 'error');
+    // error — none of these should fail the guardrail. The gate did not run, but
+    // it says WHY (the step + a clean message) rather than swallowing the throw.
+    return skip(gateMode, 'error', captureGateFailure(step, err));
   }
 }
 

--- a/src/baseline/gate-failopen.ts
+++ b/src/baseline/gate-failopen.ts
@@ -1,0 +1,73 @@
+/**
+ * The ONE fail-open diagnostic contract shared by every additive guardrail gate
+ * (flow, schema-drift, seam/dup — and any future sibling).
+ *
+ * These gates are deliberately fail-OPEN: a ref that can't be checked out, an
+ * unparseable tree, a plugin that throws at load — none should wedge the build,
+ * so the gate degrades to "did not gate" rather than an error. The class of bug
+ * this module exists to kill: a fail-open gate that catches its error in a bare
+ * `catch {}` and returns `skipped: 'error'` with NO captured reason, so a real
+ * throw becomes a diagnosability black hole (nothing in the human output, the
+ * `--json`, or stderr). It shipped once — the flow gate erroring silently inside
+ * `guardrail check` on a real repo while every direct flow surface ran clean —
+ * and it was invisible in dogfood because dxkit's own repo runs `flow` off, so
+ * the gate path was never exercised by the self-guardrail.
+ *
+ * The fix is structural, not a one-off log line: every gate's outcome carries an
+ * optional `error: GateFailure` (the step that threw + a clean message), the
+ * catch routes through `captureGateFailure`, and the renderers surface it. A
+ * fail-open gate stays fail-open — it just says WHY, always.
+ *
+ * See `test/baseline/gate-failopen.test.ts` (the cross-gate contract: an induced
+ * throw in each gate must yield a populated `GateFailure`) and the
+ * `check-architecture.sh` rule banning a bare `} catch {` in `*-gate-check.ts`.
+ */
+
+import { RefBaselineError } from './ref-baseline';
+
+/** Why a fail-open gate did not run, captured from the thrown error rather than
+ *  discarded. Attached to a gate outcome alongside `skipped: 'error'`. */
+export interface GateFailure {
+  /** The step that threw — a short, stable token (`'base-worktree'`,
+   *  `'head-gather'`, `'evaluate'`, …) so the reader knows WHERE it broke, not
+   *  just that it broke. */
+  readonly step: string;
+  /** A clean, human-readable message extracted from the thrown value. */
+  readonly message: string;
+}
+
+/** True when verbose gate diagnostics are requested (`DXKIT_DEBUG=1`). */
+function debugEnabled(): boolean {
+  return process.env.DXKIT_DEBUG === '1' || process.env.DXKIT_DEBUG === 'true';
+}
+
+/** Extract a clean one-line message from an arbitrary thrown value. Unwraps the
+ *  gates' own `RefBaselineError` (message + actionable hint), a plain `Error`,
+ *  or stringifies anything else. */
+function messageOf(err: unknown): string {
+  if (err instanceof RefBaselineError) {
+    return err.hint ? `${err.message} (${err.hint})` : err.message;
+  }
+  if (err instanceof Error) return err.message || err.name;
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+/**
+ * Turn a caught error into a `GateFailure` for a fail-open gate. Call this from
+ * the gate's catch, passing the `step` the try body was in when it threw. Under
+ * `DXKIT_DEBUG=1` the full stack is written to stderr so a swallowed throw is
+ * never truly lost; the returned failure is what the outcome carries and the
+ * renderers surface in normal runs.
+ */
+export function captureGateFailure(step: string, err: unknown): GateFailure {
+  if (debugEnabled()) {
+    const stack = err instanceof Error && err.stack ? err.stack : String(err);
+    process.stderr.write(`    [gate] fail-open at step '${step}':\n${stack}\n`);
+  }
+  return { step, message: messageOf(err) };
+}

--- a/src/baseline/schema-drift-gate-check.ts
+++ b/src/baseline/schema-drift-gate-check.ts
@@ -33,6 +33,7 @@ import { evaluateSchemaDriftGate, type SchemaDriftFinding } from '../analyzers/m
 import { readSchemaConfig, type SchemaGateMode } from '../analyzers/model-schema/config';
 import { findEntry, isEntryActive } from '../allowlist/file';
 import type { AllowlistFile } from '../allowlist/file';
+import { captureGateFailure, type GateFailure } from './gate-failopen';
 
 /** Why the gate produced no verdict, when it didn't run. */
 export type SchemaDriftGateSkip =
@@ -58,6 +59,9 @@ export interface SchemaDriftGateOutcome {
   readonly ran: boolean;
   /** Populated when `ran` is false — why no verdict was produced. */
   readonly skipped?: SchemaDriftGateSkip;
+  /** Populated when `skipped === 'error'` — the step that threw + a clean
+   *  message, so a fail-open error is never a silent black hole. */
+  readonly error?: GateFailure;
   /** The effective mode after the loop-seam override. */
   readonly mode: SchemaGateMode;
   /** Active findings (not allowlist-waived). `info` findings are disclosure
@@ -71,7 +75,18 @@ export interface SchemaDriftGateOutcome {
   readonly warns: boolean;
 }
 
-function skip(mode: SchemaGateMode, reason: SchemaDriftGateSkip): SchemaDriftGateOutcome {
+// A fail-open 'error' skip MUST carry the captured failure — the overload makes
+// a silent `skip(mode, 'error')` a compile error (the swallow class).
+function skip(mode: SchemaGateMode, reason: 'error', failure: GateFailure): SchemaDriftGateOutcome;
+function skip(
+  mode: SchemaGateMode,
+  reason: Exclude<SchemaDriftGateSkip, 'error'>,
+): SchemaDriftGateOutcome;
+function skip(
+  mode: SchemaGateMode,
+  reason: SchemaDriftGateSkip,
+  failure?: GateFailure,
+): SchemaDriftGateOutcome {
   return {
     ran: false,
     skipped: reason,
@@ -80,6 +95,7 @@ function skip(mode: SchemaGateMode, reason: SchemaDriftGateSkip): SchemaDriftGat
     suppressed: [],
     blocks: false,
     warns: false,
+    ...(failure ? { error: failure } : {}),
   };
 }
 
@@ -146,6 +162,8 @@ export async function evaluateSchemaDriftGateForGuardrail(opts: {
   if (!opts.baseRef) return skip(gateMode, 'no-base-ref');
   const ref = opts.baseRef;
 
+  // The step the try body is in — carried into a fail-open error.
+  let step = 'changed-files';
   try {
     // Trigger-skip: net-new drift requires a change to a model-capable
     // source file or a configured spec. Null changed-set = can't prove the
@@ -160,6 +178,7 @@ export async function evaluateSchemaDriftGateForGuardrail(opts: {
 
     // HEAD side (the working tree), repo-relative locators so display
     // metadata is environment-independent and the base side lines up.
+    step = 'head-gather';
     const headModels = await gatherModelSet({
       roots: [cwd],
       specs: config.specs.map((s) => path.resolve(cwd, s)),
@@ -169,6 +188,7 @@ export async function evaluateSchemaDriftGateForGuardrail(opts: {
     // Base side from a detached worktree at the ref (Rule 11), with the SAME
     // config — the HEAD checkout's policy governs both sides so a policy
     // edit in the PR cannot split the comparison.
+    step = 'base-worktree';
     const baseModels = await withRefWorktree({ cwd, ref }, async (wt) =>
       gatherModelSet({
         roots: [wt],
@@ -183,6 +203,7 @@ export async function evaluateSchemaDriftGateForGuardrail(opts: {
       return skip(gateMode, 'no-models');
     }
 
+    step = 'evaluate';
     const found = evaluateSchemaDriftGate({
       baseModels,
       headModels,
@@ -209,9 +230,9 @@ export async function evaluateSchemaDriftGateForGuardrail(opts: {
       );
     }
     return { ran: true, mode: gateMode, findings: active, suppressed, blocks, warns };
-  } catch {
-    // Fail-open: a ref that can't be checked out, a git error — the gate
-    // simply did not run.
-    return skip(gateMode, 'error');
+  } catch (err) {
+    // Fail-open: a ref that can't be checked out, a git error — the gate did
+    // not run, but it says WHY (step + clean message) rather than swallowing.
+    return skip(gateMode, 'error', captureGateFailure(step, err));
   }
 }

--- a/test/baseline/gate-failopen.test.ts
+++ b/test/baseline/gate-failopen.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The cross-gate fail-open CONTRACT (the won't-recur net for the swallow class).
+ *
+ * Every additive guardrail gate (flow, schema-drift, seam/dup) is fail-OPEN: a
+ * ref that can't be checked out, an unparseable tree, a plugin throw — none may
+ * wedge the build. The class of bug this pins: a gate that catches its error in
+ * a bare `catch {}` and returns `skipped: 'error'` with NO reason, so a real
+ * throw becomes a diagnosability black hole. It shipped once (the flow gate
+ * erroring silently inside `guardrail check` on a real repo) and was invisible
+ * in dogfood because dxkit's own repo runs `flow` off, so the gate path was
+ * never exercised.
+ *
+ * This drives EACH gate into its catch (a base ref that resolves to nothing
+ * checkoutable → the base-worktree step throws) and asserts the outcome carries
+ * `skipped: 'error'` AND a populated `error` (step + message). A future gate that
+ * reintroduces a silent catch — or a new gate that omits the failure capture —
+ * fails here. The type system is the first line (the `skip(mode, 'error')`
+ * overload requires the failure arg); this is the runtime backstop and the proof
+ * the renderers surface it.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { rmSync } from 'fs';
+import { evaluateFlowGateForGuardrail } from '../../src/baseline/flow-gate-check';
+import { evaluateSchemaDriftGateForGuardrail } from '../../src/baseline/schema-drift-gate-check';
+import { evaluateDupGateForGuardrail } from '../../src/baseline/dup-gate-check';
+import { captureGateFailure } from '../../src/baseline/gate-failopen';
+import { RefBaselineError } from '../../src/baseline/ref-baseline';
+import { createBaseline } from '../../src/baseline/create';
+import { runGuardrailCheck, type GuardrailCheckResult } from '../../src/baseline/check';
+import { renderConsole, renderJson, renderMarkdown } from '../../src/baseline/check-renderers';
+
+/** A ref that resolves to no checkoutable commit — forces the base-worktree
+ *  step of every gate to throw. */
+const UNREACHABLE_REF = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+function git(dir: string, args: string[]): void {
+  execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+}
+
+/** A monorepo with flow (call+route), a model, and a structural duplicate — so
+ *  every gate reaches its base-worktree step rather than an earlier content
+ *  skip. Committed on `main`. */
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-failopen-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'test']);
+  mkdirSync(join(dir, 'web'), { recursive: true });
+  mkdirSync(join(dir, 'api'), { recursive: true });
+  mkdirSync(join(dir, 'models'), { recursive: true });
+  mkdirSync(join(dir, '.dxkit'), { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '0.0.0' }));
+  // Enable all three opt-in gates so each reaches its evaluation path (schema +
+  // duplication default off; a mode override does not switch on an unconfigured
+  // capability, so the policy must turn them on).
+  writeFileSync(
+    join(dir, '.dxkit', 'policy.json'),
+    JSON.stringify({
+      flow: { mode: 'warn' },
+      schema: { mode: 'warn' },
+      duplication: { mode: 'warn' },
+    }),
+  );
+  // Flow surface: a client call + a served route.
+  writeFileSync(join(dir, 'web', 'List.tsx'), "axios.get('/articles');\n");
+  writeFileSync(join(dir, 'api', 'ctrl.ts'), "class C { @get('/articles') a() {} }\n");
+  // A declared model (schema surface).
+  writeFileSync(
+    join(dir, 'models', 'article.ts'),
+    '@model()\nexport class Article { @property() title: string; }\n',
+  );
+  // A structural duplicate: two functions with the same 3-callee set → the seam
+  // detector flags them, so the dup gate reaches its base-worktree step.
+  writeFileSync(join(dir, 'a.ts'), 'function alpha() { helperX(); helperY(); helperZ(); }\n');
+  writeFileSync(join(dir, 'b.ts'), 'function beta() { helperX(); helperY(); helperZ(); }\n');
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  return dir;
+}
+
+describe('gate fail-open contract — no silent swallow', () => {
+  it('captureGateFailure extracts a clean message and preserves the step', () => {
+    expect(captureGateFailure('base-worktree', new Error('boom'))).toEqual({
+      step: 'base-worktree',
+      message: 'boom',
+    });
+    // RefBaselineError folds its actionable hint into the message.
+    const ref = new RefBaselineError('cannot reach ref', 'run git fetch');
+    expect(captureGateFailure('head-gather', ref)).toEqual({
+      step: 'head-gather',
+      message: 'cannot reach ref (run git fetch)',
+    });
+    // A non-Error throw still yields a non-empty message.
+    expect(captureGateFailure('evaluate', 'raw string throw').message).toBe('raw string throw');
+  });
+
+  it('flow gate: an unreachable base ref errors WITH a reason, never silently', async () => {
+    const dir = makeRepo();
+    const out = await evaluateFlowGateForGuardrail({
+      cwd: dir,
+      baseRef: UNREACHABLE_REF,
+      modeOverride: 'warn',
+    });
+    expect(out.ran).toBe(false);
+    expect(out.skipped).toBe('error');
+    expect(out.error).toBeDefined();
+    expect(out.error!.step.length).toBeGreaterThan(0);
+    expect(out.error!.message.length).toBeGreaterThan(0);
+    // Fail-open: an errored gate never blocks or warns the build.
+    expect(out.blocks).toBe(false);
+    expect(out.warns).toBe(false);
+  });
+
+  it('schema-drift gate: an unreachable base ref errors WITH a reason', async () => {
+    const dir = makeRepo();
+    const out = await evaluateSchemaDriftGateForGuardrail({
+      cwd: dir,
+      baseRef: UNREACHABLE_REF,
+      modeOverride: 'warn',
+    });
+    expect(out.ran).toBe(false);
+    expect(out.skipped).toBe('error');
+    expect(out.error).toBeDefined();
+    expect(out.error!.step.length).toBeGreaterThan(0);
+    expect(out.error!.message.length).toBeGreaterThan(0);
+    expect(out.blocks).toBe(false);
+  });
+
+  it('dup gate: an unreachable base ref errors WITH a reason', async () => {
+    const dir = makeRepo();
+    const out = await evaluateDupGateForGuardrail({
+      cwd: dir,
+      baseRef: UNREACHABLE_REF,
+      modeOverride: 'warn',
+    });
+    expect(out.ran).toBe(false);
+    // The dup gate only reaches the base-worktree step when HEAD has a
+    // candidate duplicate; the fixture guarantees one.
+    expect(out.skipped).toBe('error');
+    expect(out.error).toBeDefined();
+    expect(out.error!.step.length).toBeGreaterThan(0);
+    expect(out.error!.message.length).toBeGreaterThan(0);
+    expect(out.blocks).toBe(false);
+  });
+});
+
+describe('renderers surface a fail-open gate error (never silent)', () => {
+  let base: GuardrailCheckResult;
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = makeRepo();
+    await createBaseline({ cwd: dir });
+    base = await runGuardrailCheck({ cwd: dir });
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const errored: GuardrailCheckResult['flowGate'] = {
+    ran: false,
+    skipped: 'error',
+    error: { step: 'base-worktree', message: 'could not check out base ref' },
+    mode: 'warn',
+    findings: [],
+    suppressed: [],
+    blocks: false,
+    warns: false,
+  };
+
+  it('console prints a visible line with the step and message', () => {
+    const out = renderConsole({ ...base, flowGate: errored });
+    expect(out).toContain('did not run');
+    expect(out).toContain('base-worktree');
+    expect(out).toContain('could not check out base ref');
+  });
+
+  it('json carries the structured error (not a bare skipped:"error")', () => {
+    const json = renderJson({ ...base, flowGate: errored });
+    expect(json.flowGate?.skipped).toBe('error');
+    expect(json.flowGate?.error).toEqual({
+      step: 'base-worktree',
+      message: 'could not check out base ref',
+    });
+  });
+
+  it('markdown prints a visible callout with the reason', () => {
+    const md = renderMarkdown({ ...base, flowGate: errored });
+    expect(md).toContain('did not run');
+    expect(md).toContain('could not check out base ref');
+  });
+});


### PR DESCRIPTION
## The bug (customer feedback, `feedback_log_v2.md`)

`guardrail check --json` returned `flowGate: { ran:false, skipped:"error", … }` with **no reason anywhere** — not in the human output, the `--json`, or stderr — while every *direct* flow surface (`doctor`, `flow map`, `flow console --diff`) ran clean. A gate that "errors" but says nothing is worse than one that fails loud, and it **blocked verifying the flow.mode `warn → block` revert** (#30): `doctor` shows the improved classification, but the gate's own flow step erroring means we can't confirm the gate agrees.

## Root cause + why this is a platform-level fix

All **three** additive fail-open gates — flow, model-schema-drift, seam/duplicate — shared the *identical* `} catch { return skip(mode, 'error'); }` swallow, and the renderers printed nothing for a finding-less gate. It was invisible in dogfood because **dxkit's own repo runs `flow` off**, so the self-guardrail never exercised the gate path. Fixing only flow would leave two siblings to reoffend, so this fixes the class:

- **New `src/baseline/gate-failopen.ts`** — the ONE fail-open diagnostic contract: `GateFailure { step, message }` + `captureGateFailure(step, err)` (unwraps `RefBaselineError`/`Error`, prints the stack under `DXKIT_DEBUG=1`).
- **All three gates** track the `step` they're in, route the catch through `captureGateFailure`, and carry `error?: GateFailure`. The `skip(mode, 'error', failure)` **overload makes a silent `skip(mode, 'error')` a compile error**.
- **All three renderers surface it** (console, JSON `error`, PR markdown) while the gate stays fail-open — it never blocks the build, it just always says WHY.

## Won't-recur nets

- `test/baseline/gate-failopen.test.ts` drives **each** gate into its catch and asserts a populated `GateFailure` + that the renderers show it.
- `scripts/check-architecture.sh` bans a bare `} catch {` in `*-gate-check.ts` (verified it bites).
- CLAUDE.md records the contract in the Rule-2 "one concept, one code path" family.

## Impact on #30

No separate code change — this **unblocks** it. The gate-vs-doctor matcher agreement was already fixed structurally (`servedMatch`/`buildServedMatcher`, pinned by `test/flow-gate-join-parity.test.ts`). The only blocker was the silent error. Now the next `guardrail check` either shows `flowGate.ran:true` (safe to flip `flow.mode`) or prints the exact `error.step` + message.

## Validation

- Reproduced the silent swallow first, then confirmed the fix.
- Full suite **4053 green** (280 files); typecheck (src + test), arch-check, lint, format all clean.

## Release

Bundles the **3.7.1** patch bump (`package.json` + lock + CHANGELOG). Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)