### PR TITLE
3.7.2: bug cluster (allowlist-aware baseline, anchor push, config-drift, onboarding honesty + SDK bootstrap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.2] - 2026-07-14
+
+A reliability and honesty cluster from a real customer onboarding (a Windows-only
+.NET desktop repo, run from a Linux box with no .NET toolchain). Every fix lands
+at the platform level so its class cannot recur.
+
+### Fixed
+
+- **`baseline create` is now allowlist-aware (#155).** An allowlisted finding
+  that was also captured into the baseline used to sit there as `persisted`
+  forever: it never lifted from the score, and its allowlist expiry could never
+  re-expose it (a `persisted` finding never blocks). Baseline capture now holds
+  actively-allowlisted findings OUT of the baseline, so the allowlist (with its
+  expiry) is the single source of suppression: an active entry keeps a finding
+  suppressed today, and when it lapses the finding resurfaces as net-new on the
+  next check. `baseline create` reports the split (`N findings baselined, M
+  allowlisted, held out`).
+- **`baseline publish` no longer hangs mysteriously in GitHub Actions (#156).**
+  An anchor push that could not authenticate would block on a credential or SSH
+  prompt until a 60s timeout, then surface a raw `Command failed ... ETIMEDOUT`.
+  The push now disables both prompt paths (`GIT_TERMINAL_PROMPT=0` and SSH
+  `BatchMode=yes`) so it fails FAST, on a shorter surfaced timeout, with an
+  actionable reason that names the auth cause (grant `contents: write`; keep the
+  checkout's push credentials).
+- **The finish summary never over-claims coverage (#2 from onboarding).** When
+  the repo's own language toolchain is missing (so its lint, license, and
+  compile/test classes were not measured), `init` no longer prints an
+  unqualified "You're gated." It now reads "You're gated for what's measurable."
+  and names the missing toolchain, drawn from the same pack-driven signal
+  `doctor` reports.
+- **Remediation names the root prerequisite, not a loop (#1 from onboarding).**
+  When a scanner is unavailable because its toolchain (e.g. the .NET SDK) is
+  absent, the guidance points at installing the toolchain rather than looping on
+  `tools install`, whose own prerequisite is the missing thing.
+- **The .NET SDK bootstrap is non-sudo and version-aware (#4/#7 from
+  onboarding).** `tools install` used to run `apt install dotnet-sdk-8.0`, which
+  needs root (it dies with a raw dpkg-lock error on WSL and most dev machines)
+  and pins the wrong major. It now prefers Microsoft's per-user
+  `dotnet-install.sh --install-dir $HOME/.dotnet` and derives the SDK version
+  from the repo's detected target framework.
+- **dxkit's own `dotnet` calls run in invariant globalization mode (#8 from
+  onboarding).** On a minimal image without libicu, every `dotnet` invocation
+  FailFast-crashes with a cryptic ICU error. dxkit now sets
+  `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` for its analysis, floor, lint, and
+  install subprocesses (never overriding a value you set), so C# analysis works
+  without libicu or sudo.
+- **The default-branch fallback comes from GitHub, not the checked-out branch
+  (#3 from onboarding).** A repo inited on a feature branch whose local
+  `origin/HEAD` points at that branch could record it as the workflow's default.
+  The generated workflows now resolve the true default via `gh repo view` first.
+- **Config-drift no longer mislabels every unmatched finding, and the warning
+  wall collapses (#157).** After a dxkit upgrade or a `policy.json` edit, every
+  finding that did not match the baseline was stamped `CONFIG-DRIFT` even when a
+  truer cause applied, and each rendered as its own warning line. The classifier
+  now names the gate-just-enabled cause (a kind with no baseline entries is a
+  newly measured dimension, so its backlog reads as net-new) and the generic
+  drift reason no longer asserts "policy config changed" as the specific cause.
+  The console and PR-comment renderers collapse the drift group into one summary
+  line. The verdict is unchanged: net-new blocking-class findings still block.
+
+### Internal
+
+- New canonical seams keep each class fixed once: the effective allowlist has one
+  constructor (`resolveEffectiveAllowlist`) and one active-suppression predicate
+  (`allowlistSuppressionFor` / `partitionByActiveAllowlist`), shared by the
+  guardrail check, the security score, and baseline capture, with an
+  architecture-check banning the recipe from being re-inlined; the "is the
+  primary language's toolchain present" signal is one pack-driven function
+  (`assessLanguageToolchains`) read by both `doctor` and the finish arc; the
+  version-aware SDK bootstrap substitutes a detected-version placeholder in the
+  one install-command path. New tests: allowlist-aware capture (expiry,
+  non-expiring test-fixtures, wrong-kind guard), the anchor push failure
+  categorizer, the toolchain-coverage signal, the SDK-bootstrap substitution +
+  ICU env, and the config-drift precedence + wall collapse.
+
 ## [3.7.1] - 2026-07-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -759,6 +759,34 @@ if [ -n "$ROGUE_WORKTREE" ]; then
 fi
 
 # =============================================================================
+# Effective-allowlist discipline (3.7.2 / Rule 2): one construction, one predicate.
+# =============================================================================
+#
+# "What this repo currently suppresses" (file-level allowlist ∪ inline
+# `dxkit-allow:` annotations) is built in exactly ONE place —
+# `resolveEffectiveAllowlist` in `src/allowlist/effective.ts` — so every
+# finding-consumer (guardrail check, security score, `baseline create`) sees the
+# identical suppression set. gh #155 shipped because `baseline create` forgot the
+# allowlist entirely while the check + aggregator each re-inlined the same
+# `augmentAllowlistWithInline(loadAllowlist(...), synthesizeInlineEntries(...))`
+# recipe. Banning the raw augment call outside the constructor keeps the recipe
+# from being re-inlined into a new surface that then diverges (or forgets it).
+ROGUE_AUGMENT=$(grep -rnE "augmentAllowlistWithInline[[:space:]]*\(" src/ 2>/dev/null \
+  | grep -v "// effective-allowlist-ok" \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | grep -v "^src/allowlist/effective.ts:" \
+  | grep -v "^src/allowlist/inline-synth.ts:")
+if [ -n "$ROGUE_AUGMENT" ]; then
+  echo "❌ Effective-allowlist rule violation: augmentAllowlistWithInline() called outside"
+  echo "   src/allowlist/effective.ts:"
+  echo "$ROGUE_AUGMENT"
+  echo "   → Build the effective allowlist via resolveEffectiveAllowlist() so every"
+  echo "     finding-consumer (check, score, baseline create) shares one suppression set."
+  echo "   → Annotate '// effective-allowlist-ok' for justified exceptions (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# =============================================================================
 # Correctness floor (2.23): the liveness gate stays pack-driven.
 # =============================================================================
 #

--- a/src/allowlist/effective.ts
+++ b/src/allowlist/effective.ts
@@ -1,0 +1,96 @@
+/**
+ * The EFFECTIVE allowlist for a repo — the ONE construction of "what this repo
+ * currently suppresses" (CLAUDE.md Rule 2).
+ *
+ * "The effective allowlist" = the committed file-level `allowlist.json`
+ * augmented with ephemeral entries synthesized from inline `dxkit-allow:`
+ * annotations covering the current findings. Every finding-consuming surface
+ * needs it: the guardrail check (to waive a net-new block), the security
+ * aggregate/score (to lift accepted findings), and `baseline create` (to keep
+ * an allowlisted finding OUT of the grandfathered set — gh #155).
+ *
+ * Before this module each surface built the effective allowlist inline
+ * (`augmentAllowlistWithInline(loadAllowlist(cwd), synthesizeInlineEntries(...))`)
+ * — a copy-paste of the SAME three-call recipe — and `baseline create` simply
+ * forgot it, so an allowlisted finding grandfathered into the baseline as
+ * `persisted`: it never lifted from the score AND its allowlist expiry could
+ * never re-expose it (a `persisted` finding never blocks). Routing every
+ * surface through this one function is what makes a new finding-consumer
+ * unable to silently ignore the allowlist. The arch-check bans
+ * `augmentAllowlistWithInline(` outside this file so the recipe cannot be
+ * re-inlined.
+ */
+
+import type { IdentityKind } from '../baseline/producers';
+import type { AllowlistFile } from './file';
+import { loadAllowlist } from './file';
+import { gatherInlineAllowlistAnnotations, type InlineAllowlistOccurrence } from './gather';
+import { augmentAllowlistWithInline, synthesizeInlineEntries } from './inline-synth';
+
+/**
+ * The minimal finding shape the effective-allowlist construction needs. A
+ * finding with a resolvable `file` + `line` can be covered by an inline
+ * annotation sitting on/above it; one without still matters for file-level
+ * suppression (matched later by fingerprint + kind). `fingerprint` is the
+ * finding's durable identity (Rule 9).
+ */
+export interface AllowlistableFinding {
+  readonly fingerprint: string;
+  readonly kind: IdentityKind;
+  readonly file?: string;
+  readonly line?: number;
+}
+
+export interface EffectiveAllowlistInput {
+  /** Current findings — used only to know which findings an inline annotation
+   *  covers, so the synth can mint a fingerprint-keyed ephemeral entry. */
+  readonly findings: readonly AllowlistableFinding[];
+  /**
+   * Committed file-level allowlist. Pass it explicitly (the pure aggregator
+   * loads it once and threads it in so it does no I/O of its own); OMIT it to
+   * have this function `loadAllowlist(cwd)` — then `cwd` is required. `null`
+   * means "no file-level allowlist" and is distinct from omitted.
+   */
+  readonly base?: AllowlistFile | null;
+  /**
+   * Inline `dxkit-allow:` occurrences. Pass them when already gathered (the
+   * baseline producer context + the aggregator carry them); OMIT to gather
+   * from `cwd`.
+   */
+  readonly inlineAnnotations?: readonly InlineAllowlistOccurrence[];
+  /** Repo root. Required only when `base` or `inlineAnnotations` is omitted. */
+  readonly cwd?: string;
+}
+
+function requireCwd(input: EffectiveAllowlistInput, missing: string): string {
+  if (input.cwd === undefined) {
+    throw new Error(
+      `resolveEffectiveAllowlist: '${missing}' was omitted, so 'cwd' is required to derive it.`,
+    );
+  }
+  return input.cwd;
+}
+
+/**
+ * Build the effective allowlist (file-level ∪ inline). Returns `null` only when
+ * there is neither a file-level allowlist nor any inline suppression — the same
+ * "nothing to suppress" signal `loadAllowlist` returns, so callers keep their
+ * existing null-handling.
+ */
+export function resolveEffectiveAllowlist(input: EffectiveAllowlistInput): AllowlistFile | null {
+  const base = input.base !== undefined ? input.base : loadAllowlist(requireCwd(input, 'base'));
+  const annotations =
+    input.inlineAnnotations !== undefined
+      ? input.inlineAnnotations
+      : gatherInlineAllowlistAnnotations(requireCwd(input, 'inlineAnnotations'));
+
+  const synth = synthesizeInlineEntries(
+    annotations,
+    input.findings
+      .filter((f): f is AllowlistableFinding & { file: string; line: number } => {
+        return f.file !== undefined && f.line !== undefined;
+      })
+      .map((f) => ({ file: f.file, line: f.line, fingerprint: f.fingerprint, kind: f.kind })),
+  );
+  return augmentAllowlistWithInline(base, synth);
+}

--- a/src/analyzers/security/aggregator.ts
+++ b/src/analyzers/security/aggregator.ts
@@ -73,7 +73,7 @@ import {
   kindForCategory,
 } from '../../allowlist/annotate';
 import type { AllowlistFile } from '../../allowlist/file';
-import { synthesizeInlineEntries, augmentAllowlistWithInline } from '../../allowlist/inline-synth';
+import { resolveEffectiveAllowlist } from '../../allowlist/effective';
 import type { InlineAllowlistOccurrence } from '../../allowlist/gather';
 
 // ─── Re-exports for consumer convenience ──────────────────────────────────
@@ -670,18 +670,16 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
   // so inline and file-level suppressions flow through the ONE fingerprint-based
   // annotator below (Rule 2). Fingerprints are already stamped on the findings by
   // this point (the annotator matches on them too).
-  const effectiveAllowlist = augmentAllowlistWithInline(
-    input.allowlist ?? null,
-    synthesizeInlineEntries(
-      input.inlineAnnotations ?? [],
-      allCodeSideFindings.map((f) => ({
-        file: f.file,
-        line: f.line,
-        fingerprint: f.fingerprint,
-        kind: kindForCategory(f.category),
-      })),
-    ),
-  );
+  const effectiveAllowlist = resolveEffectiveAllowlist({
+    base: input.allowlist ?? null,
+    inlineAnnotations: input.inlineAnnotations ?? [],
+    findings: allCodeSideFindings.map((f) => ({
+      file: f.file,
+      line: f.line,
+      fingerprint: f.fingerprint,
+      kind: kindForCategory(f.category),
+    })),
+  });
   annotateFindingsWithAllowlist(allCodeSideFindings, effectiveAllowlist);
 
   const scoreableCodeBySeverity = emptyCounts();

--- a/src/analyzers/tools/install-exec.ts
+++ b/src/analyzers/tools/install-exec.ts
@@ -137,10 +137,30 @@ export function resolveInstallCommand(targetPath: string, toolName: string): Res
   // A node devDep tool (e.g. @vitest/coverage-v8) installs INTO the user's repo,
   // so its `npm install --save-dev …` must match the repo's PM — else it fails
   // the way create-dxkit did on a pnpm project. Isolated tools keep their npm cmd.
-  const command = def.nodePackage
+  let command = def.nodePackage
     ? pmAwareDevInstall(rawCmd, detectPackageManager(targetPath))
     : rawCmd;
+  // Version-aware SDK bootstrap: a tool whose install command carries a
+  // `__DOTNET_CHANNEL__` / `__DOTNET_MAJOR__` placeholder is filled from the
+  // repo's DETECTED runtime version (Rule 6 — the version is a language fact),
+  // so the installed SDK major matches the repo instead of a hardcoded one.
+  // Generic by placeholder, not a per-language branch: any future runtime
+  // bootstrap can reuse the same substitution.
+  command = substituteRuntimeVersion(command, targetPath);
   return { name: toolName, description: def.description, kind: 'run', command };
+}
+
+/**
+ * Fill `__DOTNET_CHANNEL__` (e.g. `9.0`) / `__DOTNET_MAJOR__` (e.g. `9`) in an
+ * install command from the repo's detected .NET version, falling back to `8.0`
+ * when the repo declares none. Only runs `detect` when a placeholder is present
+ * (the common non-.NET install pays nothing). Exported for unit coverage.
+ */
+export function substituteRuntimeVersion(command: string, targetPath: string): string {
+  if (!command.includes('__DOTNET_')) return command;
+  const version = detect(targetPath).versions.csharp ?? '8.0'; // e.g. '9.0'
+  const major = version.split('.')[0]; // e.g. '9'
+  return command.replace(/__DOTNET_CHANNEL__/g, version).replace(/__DOTNET_MAJOR__/g, major);
 }
 
 /** The outcome of running (or trying to run) one tool's install command. */

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -547,9 +547,18 @@ export function getInstallCommand(def: ToolDefinition): string {
  * `installDir/bin` to the probe set, so the result is discoverable.
  */
 export function getInstallEnv(cwd: string): Record<string, string> {
+  // Run any `dotnet` an install shells out to (e.g. `dotnet tool install
+  // --global nuget-license`) in invariant globalization mode, so it doesn't
+  // FailFast-crash on a minimal image with no libicu. Harmless for non-.NET
+  // installs; never overrides a value the user set in their own env.
+  const base: Record<string, string> =
+    process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT === undefined
+      ? { DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: '1' }
+      : {};
   const { installDir } = loadToolsConfig(cwd);
-  if (!installDir) return {};
+  if (!installDir) return base;
   return {
+    ...base,
     PIPX_BIN_DIR: installDir,
     npm_config_prefix: installDir,
     CARGO_INSTALL_ROOT: installDir,
@@ -920,10 +929,20 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     layer: 'language',
     binaries: ['dotnet'],
     versionCheck: 'dotnet --version',
+    // SDK bootstrap. Prefer Microsoft's NON-SUDO per-user installer
+    // (`dotnet-install.sh --install-dir $HOME/.dotnet` — the very location
+    // `getSystemPaths()` probes) over `apt install`, which needs root and dies
+    // with a raw dpkg-lock error on WSL / most dev machines / sudo-less CI. The
+    // `__DOTNET_CHANNEL__` / `__DOTNET_MAJOR__` placeholders are substituted from
+    // the repo's DETECTED .NET version at resolve time, so a .NET 9 repo gets a
+    // .NET 9 SDK — not a hardcoded 8.0. (Onboarding cluster: sudo-apt + wrong
+    // major shipped an auto-bootstrap that was broken on the common non-root box.)
     installCommands: {
-      macos: 'brew install dotnet-sdk',
-      linux: 'apt install dotnet-sdk-8.0',
-      windows: 'winget install Microsoft.DotNet.SDK.8',
+      macos:
+        'curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel __DOTNET_CHANNEL__ --install-dir "$HOME/.dotnet"',
+      linux:
+        'curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel __DOTNET_CHANNEL__ --install-dir "$HOME/.dotnet"',
+      windows: 'winget install Microsoft.DotNet.SDK.__DOTNET_MAJOR__',
     },
   },
   'nuget-license': {

--- a/src/baseline/allowlist-match.ts
+++ b/src/baseline/allowlist-match.ts
@@ -1,0 +1,136 @@
+/**
+ * Match a stored/produced `BaselineEntry` against the effective allowlist —
+ * the ONE predicate for "is this finding actively suppressed" (CLAUDE.md
+ * Rule 2), and the ONE partition of a finding set into live vs allowlisted.
+ *
+ * The suppression predicate lived in `check.ts` (the guardrail's only
+ * consumer). `baseline create` also needs it — an actively-allowlisted finding
+ * must be kept OUT of the captured baseline so it never grandfathers as
+ * `persisted` and its allowlist expiry stays load-bearing (gh #155). Rather
+ * than re-derive the fingerprint-candidate + expiry logic (the exact
+ * duplication that shipped the bug), both consumers import from here.
+ *
+ * It sits in the baseline layer, not `src/allowlist/`, because the predicate
+ * reasons over `BaselineEntry` shapes (sanitized vs rich, `absorbedFingerprints`)
+ * — and importing it here (rather than from `check.ts`) also breaks the
+ * `check.ts ⇄ create.ts` import cycle: `create.ts` needs the predicate but
+ * `check.ts` imports `gatherCurrentScan` from `create.ts`.
+ */
+
+import type { AllowlistCategory } from '../allowlist/categories';
+import type { AllowlistableFinding } from '../allowlist/effective';
+import { findEntry, isEntryActive } from '../allowlist/file';
+import type { AllowlistFile } from '../allowlist/file';
+import { entryToLocated } from './entry-to-located';
+import { isSanitized } from './sanitize';
+import type { BaselineEntry } from './types';
+
+/**
+ * Why a would-block finding didn't block: an active allowlist entry accepted
+ * it. Carries the audit fields a reviewer needs to judge the suppression at a
+ * glance (category + expiry), keyed by the matched fingerprint.
+ */
+export interface AllowlistSuppression {
+  readonly fingerprint: string;
+  readonly category: AllowlistCategory;
+  /** ISO `YYYY-MM-DD` expiry when the entry carries one; absent for
+   *  non-expiring categories. */
+  readonly expiresAt?: string;
+}
+
+/**
+ * The active allowlist entry that suppresses `anchorEntry`, or `undefined`.
+ * Matches on the entry's candidate fingerprints AND kind (ruling out an
+ * astronomically-unlikely cross-kind hash collision), and skips EXPIRED
+ * entries via `isEntryActive` — so a finding re-surfaces the moment its
+ * suppression window lapses. Non-expiring categories (`test-fixture`,
+ * `false-positive`, `mitigated-externally`) are always active.
+ */
+export function allowlistSuppressionFor(
+  allowlist: AllowlistFile,
+  anchorEntry: BaselineEntry,
+  now: Date,
+): AllowlistSuppression | undefined {
+  for (const fp of candidateFingerprints(anchorEntry)) {
+    const entry = findEntry(allowlist, fp);
+    if (!entry || entry.kind !== anchorEntry.kind) continue;
+    if (!isEntryActive(entry, now)) continue;
+    return {
+      fingerprint: entry.fingerprint,
+      category: entry.category,
+      ...(entry.expiresAt !== undefined ? { expiresAt: entry.expiresAt } : {}),
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Fingerprints an allowlist entry may match against for one finding: the
+ * representative `id` first (most direct), then any absorbed contributing
+ * fingerprints. Absorbed fingerprints live only on the rich secret/code/config
+ * variant — a sanitized entry carries id only.
+ */
+function candidateFingerprints(entry: BaselineEntry): string[] {
+  if (isSanitized(entry)) return [entry.id];
+  if (
+    (entry.kind === 'secret' || entry.kind === 'code' || entry.kind === 'config') &&
+    entry.absorbedFingerprints &&
+    entry.absorbedFingerprints.length > 0
+  ) {
+    return [entry.id, ...entry.absorbedFingerprints];
+  }
+  return [entry.id];
+}
+
+/**
+ * Project a `BaselineEntry` into the `AllowlistableFinding` shape
+ * `resolveEffectiveAllowlist` consumes, reusing the canonical entry→location
+ * mapping (`entryToLocated`) so there is no third locator implementation.
+ */
+export function entryToAllowlistable(entry: BaselineEntry): AllowlistableFinding {
+  const loc = entryToLocated(entry);
+  return {
+    fingerprint: loc.id,
+    kind: entry.kind,
+    ...(loc.file !== undefined ? { file: loc.file } : {}),
+    ...(loc.line !== undefined ? { line: loc.line } : {}),
+  };
+}
+
+/** A finding-set split by active-allowlist suppression. */
+export interface AllowlistPartition<T> {
+  /** Findings NO active entry suppresses — the set that grandfathers into a
+   *  baseline / contributes to the verdict. */
+  readonly live: T[];
+  /** Findings an active entry suppresses — kept out of the baseline; each
+   *  paired with its suppression for reporting the `allowlisted:M` split. */
+  readonly allowlisted: T[];
+  readonly suppressions: AllowlistSuppression[];
+}
+
+/**
+ * Partition `entries` into live vs actively-allowlisted. With no allowlist
+ * every entry is live. THE single place a finding set is filtered by the
+ * allowlist for capture — `baseline create` uses it so an allowlisted finding
+ * is never grandfathered as `persisted`.
+ */
+export function partitionByActiveAllowlist<T extends BaselineEntry>(
+  entries: readonly T[],
+  allowlist: AllowlistFile | null,
+  now: Date,
+): AllowlistPartition<T> {
+  if (!allowlist) return { live: [...entries], allowlisted: [], suppressions: [] };
+  const live: T[] = [];
+  const allowlisted: T[] = [];
+  const suppressions: AllowlistSuppression[] = [];
+  for (const e of entries) {
+    const s = allowlistSuppressionFor(allowlist, e, now);
+    if (s) {
+      allowlisted.push(e);
+      suppressions.push(s);
+    } else {
+      live.push(e);
+    }
+  }
+  return { live, allowlisted, suppressions };
+}

--- a/src/baseline/anchor-publish.ts
+++ b/src/baseline/anchor-publish.ts
@@ -65,6 +65,35 @@ export interface PublishResult {
 const DEFAULT_IDENTITY = { name: 'dxkit-bot', email: 'dxkit-bot@users.noreply.github.com' };
 
 /**
+ * Turn a failed `git push` into an ACTIONABLE reason (gh #156). A bare
+ * `push rejected: Command failed … ETIMEDOUT` reads as a mystery hang; the
+ * caller (and CI logs) need to know it was a stuck/denied AUTH handshake and
+ * what to check. A timeout after the prompt guards above almost always means
+ * the remote never authenticated (the CI token lacks `contents: write`, or the
+ * checkout didn't persist push credentials) rather than a slow network.
+ */
+export function describePushFailure(err: Error, timeoutMs: number): string {
+  const e = err as Error & { code?: string; signal?: string; killed?: boolean };
+  const timedOut =
+    e.code === 'ETIMEDOUT' ||
+    e.signal === 'SIGTERM' ||
+    e.killed === true ||
+    /ETIMEDOUT|timed out/i.test(err.message);
+  if (timedOut) {
+    return (
+      `push timed out after ${Math.round(timeoutMs / 1000)}s with no response — the remote did ` +
+      `not authenticate. In GitHub Actions ensure the job grants \`contents: write\` and the ` +
+      `checkout persists push credentials (actions/checkout with \`persist-credentials: true\`); ` +
+      `locally ensure your git credential helper / SSH key can push to origin.`
+    );
+  }
+  if (/denied|forbidden|403|not authorized|authentication failed/i.test(err.message)) {
+    return `push denied by the remote (authentication/permission): ${err.message}`;
+  }
+  return `push rejected: ${err.message}`;
+}
+
+/**
  * Read a single file's content from an arbitrary side ref (`origin/<ref>` then
  * `<ref>`), best-effort. Returns `null` when the ref/file is unreachable (not
  * created yet, offline, wrong ref). Never throws. This is the generalized read
@@ -129,10 +158,20 @@ function resolveTip(
 export function publishFilesToAnchorRef(opts: PublishToAnchorOptions): PublishResult {
   const { cwd, anchorRef } = opts;
   const identity = opts.identity ?? DEFAULT_IDENTITY;
-  const timeout = opts.timeoutMs ?? 60_000;
+  // A short, SURFACED bound: a small baseline push completes in seconds, so a
+  // stall is a stuck auth handshake, not slow transport. Kept low so a hang
+  // fails FAST with a clear reason instead of 60s of CI silence (gh #156).
+  const timeout = opts.timeoutMs ?? 30_000;
   const env = {
     ...process.env,
+    // BOTH prompt paths off so a push that would otherwise BLOCK on input fails
+    // fast instead of hanging until the timeout: HTTPS credential prompts
+    // (`GIT_TERMINAL_PROMPT=0`) AND SSH passphrase / host-key prompts
+    // (`BatchMode=yes`, mirroring remote-ref.ts). Without the SSH guard an
+    // unauthenticated push over an `ssh://` remote hangs — the "mystery hang"
+    // gh #156 reported in Actions.
     GIT_TERMINAL_PROMPT: '0',
+    GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes',
     GIT_AUTHOR_NAME: identity.name,
     GIT_AUTHOR_EMAIL: identity.email,
     GIT_COMMITTER_NAME: identity.name,
@@ -222,7 +261,7 @@ export function publishFilesToAnchorRef(opts: PublishToAnchorOptions): PublishRe
         git(pushArgs);
         return { pushed: true, commit };
       } catch (err) {
-        return { pushed: false, commit, reason: `push rejected: ${(err as Error).message}` };
+        return { pushed: false, commit, reason: describePushFailure(err as Error, timeout) };
       }
     };
 

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -196,7 +196,15 @@ export function renderConsole(result: GuardrailCheckResult): string {
   }
   if (warning.length > 0) {
     lines.push(logger.bold(`Warnings (${warning.length})`));
-    for (const p of warning) lines.push(...formatPairLines(p, '  '));
+    // Collapse the envelope-drift wall (gh #157): after a dxkit upgrade or a
+    // policy.json edit, dozens of unrelated findings all fall out as
+    // `config_drift` warnings. Rendering each as its own line buries the
+    // specific, actionable warnings under the wall — so print the drift group as
+    // ONE summary line and enumerate only the specific warnings.
+    const drift = warning.filter((p) => p.classification.status === 'config_drift');
+    const specific = warning.filter((p) => p.classification.status !== 'config_drift');
+    for (const p of specific) lines.push(...formatPairLines(p, '  '));
+    if (drift.length > 0) lines.push(...formatDriftWarningSummary(drift, '  '));
     lines.push('');
   }
   if (removed.length > 0) {
@@ -573,6 +581,33 @@ function formatPairLines(p: ClassifiedPair, indent: string): string[] {
     );
   }
   return out;
+}
+
+/**
+ * Collapse a group of `config_drift` warning pairs into ONE summary line (gh
+ * #157). The count is the headline; when some are the dimension-newly-measured
+ * case (a gate was just enabled), that truer cause is named so a reviewer looks
+ * in the right place instead of chasing "policy changed". Points at `--json` for
+ * the un-collapsed per-finding payload.
+ */
+export function formatDriftWarningSummary(
+  drift: ReadonlyArray<ClassifiedPair>,
+  indent: string,
+): string[] {
+  const gateEnabled = drift.filter((p) =>
+    p.classification.reasons.some((r) => r.code === 'dimension-newly-measured'),
+  ).length;
+  const n = drift.length;
+  const breakdown =
+    gateEnabled > 0
+      ? gateEnabled === n
+        ? ` (a gate/dimension was newly enabled — its pre-existing findings read as net-new)`
+        : ` (${gateEnabled} from a newly-enabled gate/dimension)`
+      : ` (a dxkit upgrade or policy/config change shifted the envelope)`;
+  return [
+    `${indent}${n} finding${n === 1 ? '' : 's'} unmatched after an envelope change${breakdown}.`,
+    `${indent}  · Not necessarily net-new — re-run with --json to inspect each, or re-capture the baseline if it is stale.`,
+  ];
 }
 
 function statusLabel(status: FindingStatus): string {
@@ -1104,13 +1139,43 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
   }
 
   if (warning.length > 0) {
+    // Collapse the envelope-drift wall (gh #157): the drift group becomes one
+    // summary line above the table, and only the specific warnings are tabled.
+    const driftWarn = warning.filter((p) => p.classification.status === 'config_drift');
+    const specificWarn = warning.filter((p) => p.classification.status !== 'config_drift');
+    if (driftWarn.length > 0) {
+      const gateEnabled = driftWarn.filter((p) =>
+        p.classification.reasons.some((r) => r.code === 'dimension-newly-measured'),
+      ).length;
+      const cause =
+        gateEnabled > 0
+          ? gateEnabled === driftWarn.length
+            ? 'a gate/dimension was newly enabled, so its pre-existing findings read as net-new'
+            : `${gateEnabled} are from a newly-enabled gate/dimension`
+          : 'a dxkit upgrade or policy/config change shifted the envelope';
+      lines.push(
+        `> **${driftWarn.length} finding${driftWarn.length === 1 ? '' : 's'} unmatched after an ` +
+          `envelope change** — ${cause}. Not necessarily net-new; inspect each with \`--json\` ` +
+          `or re-capture the baseline if it is stale.`,
+      );
+      lines.push('');
+    }
     lines.push('<details>');
     lines.push(`<summary>Warnings (${warning.length})</summary>`);
     lines.push('');
-    lines.push('| Status | Kind | Severity | Location | Fingerprint | Reason |');
-    lines.push('|---|---|---|---|---|---|');
-    for (const p of warning) lines.push(markdownPairRow(p));
-    lines.push('');
+    if (specificWarn.length > 0) {
+      lines.push('| Status | Kind | Severity | Location | Fingerprint | Reason |');
+      lines.push('|---|---|---|---|---|---|');
+      for (const p of specificWarn) lines.push(markdownPairRow(p));
+      lines.push('');
+    }
+    if (driftWarn.length > 0) {
+      lines.push(
+        `_${driftWarn.length} envelope-drift warning${driftWarn.length === 1 ? '' : 's'} collapsed ` +
+          `above; see \`--json\` for each._`,
+      );
+      lines.push('');
+    }
     lines.push('</details>');
     lines.push('');
   }

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -636,6 +636,11 @@ export async function runGuardrailCheck(
   });
 
   const priorById = indexById(baseline.findings);
+  // The set of finding KINDS the baseline captured. A current finding whose kind
+  // is absent here means the dimension was newly measured (a gate just enabled),
+  // which the classifier names as a truer cause than generic `config_drift`
+  // (gh #157). Reason-only — does not change the verdict.
+  const baselineKinds = new Set(baseline.findings.map((e) => e.kind));
   const currentById = indexById(current.findings);
   const severityByCurrentId = buildSeverityIndex(current.aggregate);
   const maliciousByCurrentId = buildMaliciousIndex(current.aggregate);
@@ -709,6 +714,10 @@ export async function runGuardrailCheck(
     // re-label a net-new finding on a new file). Non-empty changed-line set = the
     // file is in the diff (a brand-new file has all its lines added).
     const fileChangedInDiff = file !== undefined && (linesChangedFor(file)?.size ?? 0) > 0;
+    // Dimension newly measured: the baseline held no findings of this kind, so
+    // this one is unmatched because the gate/dimension was just enabled — a
+    // truer reason than generic config_drift (gh #157). Reason-only.
+    const kindAbsentFromBaseline = pair.status === 'added' && !baselineKinds.has(anchorEntry.kind);
 
     const malicious =
       pair.currentId !== undefined && maliciousByCurrentId.has(pair.currentId) ? true : undefined;
@@ -719,6 +728,7 @@ export async function runGuardrailCheck(
       ...(scannerVersionDiffers ? { scannerVersionDiffers: true } : {}),
       ...(configDiffers ? { configDiffers: true } : {}),
       ...(fileChangedInDiff ? { fileChangedInDiff: true } : {}),
+      ...(kindAbsentFromBaseline ? { kindAbsentFromBaseline: true } : {}),
       ...(overlapsChangedLines !== undefined ? { overlapsChangedLines } : {}),
       ...(malicious ? { malicious } : {}),
     };

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -84,11 +84,12 @@ import {
   resolveAllowlistDeltaBase,
   type AllowlistDelta,
 } from '../allowlist/diff';
-import { findEntry, isEntryActive, loadAllowlist } from '../allowlist/file';
-import { gatherInlineAllowlistAnnotations } from '../allowlist/gather';
-import { synthesizeInlineEntries, augmentAllowlistWithInline } from '../allowlist/inline-synth';
-import type { AllowlistFile } from '../allowlist/file';
-import type { AllowlistCategory } from '../allowlist/categories';
+import { resolveEffectiveAllowlist } from '../allowlist/effective';
+import {
+  allowlistSuppressionFor,
+  entryToAllowlistable,
+  type AllowlistSuppression,
+} from './allowlist-match';
 
 export interface RunGuardrailCheckOptions {
   /** Repo root being checked. Caller should pass an absolute path. */
@@ -234,20 +235,6 @@ export interface ClassifiedPair {
    *  dropping the finding. Expired entries never populate this — the
    *  finding re-blocks and the stale entry is surfaced for pruning. */
   readonly suppressedByAllowlist?: AllowlistSuppression;
-}
-
-/**
- * Why a would-block finding didn't block: an active allowlist entry
- * accepted it. Carries the audit fields a reviewer needs to judge the
- * suppression at a glance (category + expiry), keyed by the matched
- * fingerprint.
- */
-export interface AllowlistSuppression {
-  readonly fingerprint: string;
-  readonly category: AllowlistCategory;
-  /** ISO `YYYY-MM-DD` expiry when the entry carries one; absent for
-   *  non-expiring categories. */
-  readonly expiresAt?: string;
 }
 
 export interface EnvelopeDrift {
@@ -678,25 +665,15 @@ export async function runGuardrailCheck(
   // this is what makes "I reviewed and accepted this finding" actually
   // suppress a net-new regression, not just annotate it. Null when no
   // allowlist file is present (the common case).
-  // Load the file-level allowlist, then augment it with entries synthesized from
-  // inline `dxkit-allow:` annotations in the current tree — so an inline
-  // suppression on a NET-NEW finding waives its block exactly like a file-level
-  // entry (one suppression core, two sources — Rule 2). Only current-side findings
-  // with a resolvable file+line can be inline-covered; the synth mints an entry
-  // only when an annotation sits on/above that finding, keyed on its fingerprint.
-  const inlineSynthFindings = current.findings
-    .map((e) => {
-      const file = locatorFile(e);
-      const line = locatorLine(e);
-      return file !== undefined && line !== undefined
-        ? { file, line, fingerprint: e.id, kind: e.kind }
-        : null;
-    })
-    .filter((x): x is NonNullable<typeof x> => x !== null);
-  const allowlist = augmentAllowlistWithInline(
-    loadAllowlist(cwd),
-    synthesizeInlineEntries(gatherInlineAllowlistAnnotations(cwd), inlineSynthFindings),
-  );
+  // The effective allowlist (file-level ∪ inline `dxkit-allow:` annotations),
+  // resolved through the ONE canonical constructor so the guardrail, the
+  // security score, and `baseline create` all see the identical suppression set
+  // (Rule 2). An inline suppression on a NET-NEW finding waives its block
+  // exactly like a file-level entry.
+  const allowlist = resolveEffectiveAllowlist({
+    cwd,
+    findings: current.findings.map(entryToAllowlistable),
+  });
   const now = new Date();
 
   const classifiedPairs: ClassifiedPair[] = [];
@@ -1186,42 +1163,6 @@ function pairBlocks(p: ClassifiedPair): boolean {
  * fingerprint branches are exercised directly here so the (expensive)
  * integration test only has to prove the verdict wiring flips.
  */
-export function allowlistSuppressionFor(
-  allowlist: AllowlistFile,
-  anchorEntry: BaselineEntry,
-  now: Date,
-): AllowlistSuppression | undefined {
-  for (const fp of candidateFingerprints(anchorEntry)) {
-    const entry = findEntry(allowlist, fp);
-    if (!entry || entry.kind !== anchorEntry.kind) continue;
-    if (!isEntryActive(entry, now)) continue;
-    return {
-      fingerprint: entry.fingerprint,
-      category: entry.category,
-      ...(entry.expiresAt !== undefined ? { expiresAt: entry.expiresAt } : {}),
-    };
-  }
-  return undefined;
-}
-
-/**
- * Fingerprints an allowlist entry may match against for one finding:
- * the representative `id` first (most direct), then any absorbed
- * contributing fingerprints. Absorbed fingerprints live only on the
- * rich secret/code/config variant — a sanitized entry carries id only.
- */
-function candidateFingerprints(entry: BaselineEntry): string[] {
-  if (isSanitized(entry)) return [entry.id];
-  if (
-    (entry.kind === 'secret' || entry.kind === 'code' || entry.kind === 'config') &&
-    entry.absorbedFingerprints &&
-    entry.absorbedFingerprints.length > 0
-  ) {
-    return [entry.id, ...entry.absorbedFingerprints];
-  }
-  return [entry.id];
-}
-
 function keepUnderChangedOnly(p: ClassifiedPair): boolean {
   if (p.file === undefined || p.line === undefined) return true;
   const isNewSide =

--- a/src/baseline/classify.ts
+++ b/src/baseline/classify.ts
@@ -40,6 +40,13 @@ export interface ClassifyContext {
    *  re-label a net-new finding on a brand-new file as "config changed between
    *  runs". */
   readonly fileChangedInDiff?: boolean;
+  /** True when the finding's KIND had ZERO entries in the baseline — the
+   *  dimension was newly measured (e.g. `lint.enabled` was just turned on, so the
+   *  repo's whole pre-existing lint backlog appears net-new against a baseline
+   *  that had no lint dimension). Under envelope drift this is a MORE specific,
+   *  truer explanation than the generic `config_drift` label, so the reason names
+   *  it. Does NOT change the verdict — the status stays `config_drift`. */
+  readonly kindAbsentFromBaseline?: boolean;
   /** True when the underlying source file's lines overlap lines
    *  changed by the current diff. Used by `newSevereQualityIssueIn
    *  ChangedFiles` and similar rules; absent context is treated as
@@ -109,10 +116,29 @@ export function classify(
       // #19 reported: a net-new finding on a brand-new file labelled config_drift
       // because policy.json was edited alongside it).
       status = 'config_drift';
-      reasons.push({
-        code: 'config-drift',
-        detail: 'suppression or policy config changed between runs',
-      });
+      // `configDiffers` is a REPO-WIDE envelope signal (a dxkit-version /
+      // toolchain / policy / config hash change) — true for every finding in the
+      // run, so a bare "config changed" reason over-claims a specific cause it
+      // can't actually attribute. Name the truer per-finding cause when we have
+      // one: a kind with no baseline entries is a newly-enabled gate/dimension
+      // (its whole pre-existing backlog reads as net-new), not a policy edit.
+      // Verdict is unchanged either way — only the reason string differs.
+      reasons.push(
+        context.kindAbsentFromBaseline
+          ? {
+              code: 'dimension-newly-measured',
+              detail:
+                "this finding's kind had no baseline entries — a gate or dimension was " +
+                'newly enabled, so pre-existing findings appear net-new (not a policy change)',
+            }
+          : {
+              code: 'config-drift',
+              detail:
+                'unmatched after an envelope change (dxkit version / toolchain / policy / ' +
+                'config hash differs) — inspect per-finding with --json, or re-capture if the ' +
+                'baseline is stale',
+            },
+      );
     } else if (
       context.kind &&
       policy.addedRequiresChangedLines.includes(context.kind) &&

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -50,6 +50,8 @@ import type { ProducerContext } from './producers';
 import { resolveSalt } from '../analyzers/tools/salt';
 import type { SaltMode } from '../analyzers/tools/salt';
 import { sanitizeFile } from './sanitize';
+import { resolveEffectiveAllowlist } from '../allowlist/effective';
+import { entryToAllowlistable, partitionByActiveAllowlist } from './allowlist-match';
 import type { RichBaselineEntry } from './types';
 import { CURRENT_IDENTITY_SCHEME } from './types';
 import type { SecurityAggregate } from '../analyzers/security/aggregator';
@@ -89,6 +91,16 @@ export interface CreateBaselineResult {
   readonly mode: ResolvedMode;
   readonly path?: string;
   readonly file?: BaselineFile;
+  /** How the captured findings split between what was baselined (`live`) and
+   *  what an active allowlist entry suppressed and held OUT of the baseline
+   *  (`allowlisted`, gh #155). Absent for `ref-based` mode (no file written).
+   *  `byCategory` breaks the held-out count down by suppression category so the
+   *  CLI can report an honest `N findings baselined (M allowlisted)` line. */
+  readonly allowlistSplit?: {
+    readonly live: number;
+    readonly allowlisted: number;
+    readonly byCategory: Readonly<Record<string, number>>;
+  };
 }
 
 /** Hash used for baseline-envelope metadata fields (policy, ignore,
@@ -381,6 +393,30 @@ export async function createBaseline(
 
   const scan = await gatherCurrentScan({ cwd, verbose: options.verbose });
 
+  // Exclude actively-allowlisted findings from the captured set so a
+  // reviewed-and-accepted finding never grandfathers into the baseline as
+  // `persisted` (gh #155). Grandfathering an allowlisted finding double-
+  // suppresses it AND defeats its expiry — a `persisted` finding never blocks,
+  // so an accepted-risk entry that later lapsed would silently stay suppressed.
+  // Held OUT of the baseline, the allowlist (with its expiry) is the single
+  // source of suppression: an active entry keeps the finding suppressed today,
+  // and when it lapses the finding resurfaces as net-new on the next check.
+  // Resolved through the ONE effective-allowlist constructor + the ONE active-
+  // suppression predicate, so create sees the identical suppression set the
+  // guardrail check and the security score do (Rule 2).
+  const effectiveAllowlist = resolveEffectiveAllowlist({
+    cwd,
+    findings: scan.findings.map(entryToAllowlistable),
+    inlineAnnotations: scan.producerCtx.inlineAllowlistAnnotations,
+  });
+  const { live, suppressions } = partitionByActiveAllowlist(
+    scan.findings,
+    effectiveAllowlist,
+    new Date(),
+  );
+  const byCategory: Record<string, number> = {};
+  for (const s of suppressions) byCategory[s.category] = (byCategory[s.category] ?? 0) + 1;
+
   const richFile: BaselineFile = {
     schemaVersion: BASELINE_SCHEMA_VERSION,
     name,
@@ -391,10 +427,15 @@ export async function createBaseline(
     saltMode: scan.saltMode,
     identityScheme: CURRENT_IDENTITY_SCHEME,
     coverage: scan.coverage,
-    findings: scan.findings,
+    findings: live,
   };
 
   const file = mode.mode === 'committed-sanitized' ? sanitizeFile(richFile) : richFile;
   writeBaselineFile(filePath, file);
-  return { mode, path: filePath, file };
+  return {
+    mode,
+    path: filePath,
+    file,
+    allowlistSplit: { live: live.length, allowlisted: suppressions.length, byCategory },
+  };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -911,6 +911,7 @@ export async function run(argv: string[]): Promise<void> {
             baselineMode: null,
             surfaces: gateSurfaces,
             incompleteScanners: [],
+            languageToolchainGaps: [],
             elapsedMs: 0,
           };
       // "ready in Ns" reflects the WHOLE init (detect + generate + arm + arc),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2447,8 +2447,21 @@ export async function run(argv: string[]): Promise<void> {
           } else if (result.path && result.file) {
             const rel = path.relative(targetPath, result.path);
             const tag = result.mode.mode === 'committed-sanitized' ? ' (sanitized)' : '';
+            // Honest split: allowlisted findings are held OUT of the baseline
+            // (gh #155), so name how many were suppressed and why rather than
+            // letting the headline count silently absorb them.
+            const split = result.allowlistSplit;
+            let allowlistNote = '';
+            if (split && split.allowlisted > 0) {
+              const byCat = Object.entries(split.byCategory)
+                .map(([cat, n]) => `${n} ${cat}`)
+                .join(', ');
+              allowlistNote = ` — ${split.allowlisted} allowlisted, held out of the baseline${
+                byCat ? ` (${byCat})` : ''
+              }`;
+            }
             logger.success(
-              `Wrote ${rel}${tag} — ${result.file.findings.length} findings, salt: ${result.file.saltMode} (${elapsed}s)`,
+              `Wrote ${rel}${tag} — ${result.file.findings.length} findings baselined${allowlistNote}, salt: ${result.file.saltMode} (${elapsed}s)`,
             );
           }
         } catch (err) {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -4,6 +4,7 @@ import { execSync } from 'child_process';
 import { commandExists } from './analyzers/tools/runner';
 import { Manifest } from './types';
 import { activeLanguagesFromStack } from './languages';
+import { assessLanguageToolchains } from './languages/toolchain-coverage';
 import { dxkitCli } from './self-invocation';
 import * as logger from './logger';
 import { resolveBaselineMode } from './baseline/modes';
@@ -473,9 +474,15 @@ function runDxChecks(cwd: string, manifest: Manifest | null, hasManifest: boolea
   }
 
   if (manifest?.config?.languages) {
-    for (const lang of activeLanguagesFromStack(manifest.config)) {
+    // Route through the ONE pack-driven toolchain signal the init finish arc
+    // also reads (Rule 2), so doctor and the finish summary can never disagree
+    // on whether the primary language's depth is measured.
+    const active = activeLanguagesFromStack(manifest.config);
+    const gaps = new Map(assessLanguageToolchains(active).map((g) => [g.language, g]));
+    for (const lang of active) {
+      const missing = new Set(gaps.get(lang.id)?.missingBinaries ?? []);
       for (const bin of lang.cliBinaries ?? []) {
-        const ok = commandAvailable(bin);
+        const ok = !missing.has(bin);
         checks.push({
           label: bin,
           ok,

--- a/src/init-arc.ts
+++ b/src/init-arc.ts
@@ -20,6 +20,7 @@ import * as logger from './logger';
 import { dxkitCli } from './self-invocation';
 import type { BaselineMode } from './baseline/modes';
 import type { BaselineEntry } from './baseline/types';
+import type { LanguageToolchainGap } from './languages/toolchain-coverage';
 
 /** A coarse grouping of grandfathered findings — the emotional payoff line
  *  ("3 secrets · 12 dependency CVEs · 32 code patterns") the user sees as their
@@ -82,6 +83,11 @@ export interface InitClosingState {
   readonly surfaces: readonly string[];
   /** Scanner classes still missing at baseline time (coverage gap to teach). */
   readonly incompleteScanners: readonly string[];
+  /** Active language packs whose OWN toolchain is absent from PATH, so their
+   *  deep classes (lint / license / correctness floor) were UNMEASURED. When
+   *  non-empty the "gated" claim is QUALIFIED — never presented as full coverage
+   *  (the dpl-studio class). Empty on the common fully-provisioned path. */
+  readonly languageToolchainGaps: readonly LanguageToolchainGap[];
   readonly elapsedMs: number;
 }
 
@@ -164,6 +170,29 @@ export function buildInitClosing(state: InitClosingState): InitClosing {
     // Gated (surfaces armed) but no baseline count — a fail-soft skip.
     body.push('Your gates are armed. Capture a baseline to set the grandfathered floor:');
     body.push(`  ${dxkitCli('baseline create')}`);
+  }
+
+  // Honesty gate: when an ACTIVE language pack's OWN toolchain is missing, its
+  // deep classes (lint / license / the compile-and-test correctness floor) were
+  // NOT measured — so we must NOT present this as full coverage, and the
+  // remediation must name the ROOT prerequisite (install the toolchain), never
+  // loop the user back to `tools install` (whose own prerequisite is the very
+  // thing that's missing). This is the dpl-studio class: a pure-C# repo
+  // baselined with no `dotnet` on PATH, headlined "You're gated ✓".
+  const gaps = state.languageToolchainGaps;
+  if (gaps.length > 0) {
+    const langWord = gaps.length === 1 ? gaps[0].displayName : `${gaps.length} languages`;
+    const toolchains = gaps
+      .map((g) => `${g.displayName} (\`${g.missingBinaries.join('`, `')}\`)`)
+      .join('; ');
+    const caution =
+      `${langWord}'s toolchain isn't on PATH (${toolchains}), so its deeper checks ` +
+      `— lint, license, and the compile/test floor — were NOT measured. The ` +
+      `language-agnostic classes (secrets, dependency CVEs, SAST, duplication) ARE ` +
+      `gated. Install the toolchain (or use the generated devcontainer), then re-run ` +
+      `\`${dxkitCli('tools install')}\` and \`${dxkitCli('baseline create --force')}\` for full coverage.`;
+    // Qualified headline — measured what it could, honest about the rest.
+    return { headline: "You're gated for what's measurable.", ready, body, caution, actions };
   }
 
   const caution =
@@ -269,6 +298,13 @@ async function runFinishingArc(
   const { missingScanners } = await import('./baseline/coverage');
   const incompleteScanners = missingScanners(gatherScanCoverage(cwd)).map((m) => m.tool);
 
+  // The pack-driven "is the primary language's toolchain present" signal — the
+  // SAME one doctor reports — so the finish arc can't over-claim coverage when
+  // the repo's own language depth is unmeasured (gh onboarding honesty class).
+  const { detectActiveLanguages } = await import('./languages');
+  const { assessLanguageToolchains } = await import('./languages/toolchain-coverage');
+  const languageToolchainGaps = assessLanguageToolchains(detectActiveLanguages(cwd));
+
   const bl = logger.startSpinner('Capturing baseline');
   // The first baseline scans the whole tree (SAST + deps + coverage), which is
   // minutes on a large repo — say so, so a long-running spinner never reads as
@@ -329,6 +365,7 @@ async function runFinishingArc(
     baselineMode,
     surfaces: opts.surfaces,
     incompleteScanners,
+    languageToolchainGaps,
     elapsedMs: Date.now() - started,
   };
 }

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -44,6 +44,23 @@ import type {
 import type { LanguageSupport, LintSeverity } from './types';
 import type { LintGateProvider } from './capabilities/lint-gate';
 
+/**
+ * Run dxkit's OWN `dotnet` subprocesses (build / format / test for ANALYSIS,
+ * the correctness floor, and the Roslyn lint gate) in invariant globalization
+ * mode. A minimal WSL / container / CI image often lacks libicu, where every
+ * `dotnet` invocation FailFast-crashes with a cryptic "Couldn't find a valid
+ * ICU package installed" — and dxkit's analysis needs no culture-specific
+ * globalization, so invariant mode is the correct, sudo-free unblock. Set once
+ * in this process's env (inherited by every dotnet child dxkit spawns — the
+ * `run()` calls here AND the `{bin:'dotnet'}` commands the floor/lint runner
+ * executes), and NEVER overrides a value the user set themselves.
+ */
+function ensureDotnetInvariant(): void {
+  if (process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT === undefined) {
+    process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = '1';
+  }
+}
+
 function dirHasMatching(dir: string, regex: RegExp): boolean {
   try {
     return fs.readdirSync(dir).some((name) => regex.test(name));
@@ -723,6 +740,7 @@ async function runDotnetVulnerablePath(cwd: string): Promise<DepVulnGatherOutcom
       reason: 'dotnet SDK not installed (osv-scanner path covers this case)',
     };
   }
+  ensureDotnetInvariant();
 
   const vulnRaw = run(
     `${dotnet.path} list package --vulnerable --include-transitive --format json`,
@@ -1009,6 +1027,7 @@ function gatherCsharpLintResult(cwd: string): LintGatherOutcome {
   if (!dotnet.available) {
     return { kind: 'unavailable', reason: 'not installed' };
   }
+  ensureDotnetInvariant();
 
   const buildRaw = run('dotnet build --no-incremental --nologo -clp:NoSummary 2>&1', cwd, 180000);
   if (buildRaw !== '' && !/\): error \w+:|error (MSB|NETSDK)\d+/.test(buildRaw)) {
@@ -1503,11 +1522,13 @@ function csharpIsTestProject(cwd: string, relProj: string): boolean {
 const csharpCorrectnessProvider: CorrectnessProvider = {
   syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
     if (!csharpHasBuildTarget(ctx.cwd)) return null;
+    ensureDotnetInvariant();
     return { label: 'build', bin: 'dotnet', args: ['build', '--nologo'] };
   },
 
   affectedTests(ctx: CorrectnessContext): CorrectnessCommand | null {
     if (!csharpHasBuildTarget(ctx.cwd)) return null;
+    ensureDotnetInvariant();
     const undeterminable = ctx.changedFiles.length === 0;
     const changedCs = ctx.changedFiles.filter((f) => f.endsWith('.cs'));
     if (ctx.scope === 'affected' && !undeterminable) {
@@ -1544,6 +1565,7 @@ export const CSHARP_MSBUILD_WARNING_PARSE =
  */
 const csharpLintGateProvider: LintGateProvider = {
   lintCommand() {
+    ensureDotnetInvariant();
     return {
       bin: 'dotnet',
       args: ['build', '--nologo', '-clp:NoSummary'],

--- a/src/languages/toolchain-coverage.ts
+++ b/src/languages/toolchain-coverage.ts
@@ -1,0 +1,61 @@
+/**
+ * "Is the repo's OWN language toolchain present?" — the ONE pack-driven signal
+ * (Rule 2 + Rule 6) behind an honest coverage claim.
+ *
+ * A language pack's deep analysis (its lint gate, license inventory, and the
+ * `dotnet build` / `go build` correctness floor) needs the pack's toolchain
+ * binary on PATH. When it is absent, those classes are UNMEASURED — captured as
+ * a silent gap, not a clean scan. The dpl-studio onboarding surfaced the cost:
+ * a pure-C# repo baselined with NO `dotnet` on PATH, yet the finish arc printed
+ * an unqualified "You're gated ✓" and pointed remediation at `tools install`
+ * (which can't install the SDK either — a loop). doctor already reported the
+ * gap honestly via each pack's `cliBinaries`; the finish arc reduced it to a
+ * one-line footnote because it had no shared signal to read.
+ *
+ * This module is that shared signal: doctor's per-language toolchain check AND
+ * the init finish-arc honesty both resolve it here, so a partial baseline can
+ * never be presented as full coverage on one surface while the other tells the
+ * truth. Purely PATH-derived (`commandExists`) so it is cheap and side-effect
+ * free.
+ */
+
+import { commandExists } from '../analyzers/tools/runner';
+import type { LanguageSupport } from './types';
+
+/** One active language pack whose toolchain is (partly) absent from PATH. */
+export interface LanguageToolchainGap {
+  /** Pack id (e.g. `csharp`). */
+  readonly language: string;
+  /** Human label for messaging (e.g. `C#`). */
+  readonly displayName: string;
+  /** The pack's `cliBinaries` that are NOT resolvable on PATH — the toolchain
+   *  drivers whose absence makes the pack's deep classes unmeasured. */
+  readonly missingBinaries: readonly string[];
+}
+
+/**
+ * For each active pack, the `cliBinaries` missing from PATH. A pack with no
+ * `cliBinaries`, or all present, contributes nothing. Deterministic order
+ * (input order); the caller decides how loudly to surface it.
+ */
+export function assessLanguageToolchains(
+  activeLanguages: readonly LanguageSupport[],
+): LanguageToolchainGap[] {
+  const gaps: LanguageToolchainGap[] = [];
+  for (const lang of activeLanguages) {
+    const missing = (lang.cliBinaries ?? []).filter((bin) => !commandExists(bin));
+    if (missing.length > 0) {
+      gaps.push({ language: lang.id, displayName: lang.displayName, missingBinaries: missing });
+    }
+  }
+  return gaps;
+}
+
+/**
+ * Whether an active pack's toolchain is missing — the boolean that disqualifies
+ * an unqualified "You're gated ✓". True iff at least one active pack has an
+ * absent `cliBinary`.
+ */
+export function primaryLanguageUnmeasured(gaps: readonly LanguageToolchainGap[]): boolean {
+  return gaps.length > 0;
+}

--- a/src/setup-gh.ts
+++ b/src/setup-gh.ts
@@ -90,6 +90,18 @@ export function resolveOwnerRepo(cwd: string): OwnerRepo {
  * repos may still default to `master` etc.
  */
 export function resolveDefaultBranch(cwd: string): string {
+  return defaultBranchViaGh(cwd) ?? 'main';
+}
+
+/**
+ * The repo's TRUE default branch per GitHub (`gh repo view --json
+ * defaultBranchRef`), or `null` when gh is unavailable / not authenticated /
+ * the repo isn't on GitHub. The ONE gh default-branch probe (Rule 2) — the
+ * authoritative source, above any local git heuristic: a clone's
+ * `origin/HEAD` can point at a feature branch (the dpl-studio case), so a
+ * workflow inited there would otherwise record the wrong default.
+ */
+export function defaultBranchViaGh(cwd: string): string | null {
   try {
     const out = execSync('gh repo view --json defaultBranchRef', {
       cwd,
@@ -99,9 +111,9 @@ export function resolveDefaultBranch(cwd: string): string {
     const parsed = JSON.parse(out) as { defaultBranchRef?: { name?: string } };
     if (parsed.defaultBranchRef?.name) return parsed.defaultBranchRef.name;
   } catch {
-    /* fall through to fallback */
+    /* gh absent / unauthenticated / not a GitHub repo */
   }
-  return 'main';
+  return null;
 }
 
 /**

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -16,6 +16,7 @@ import { execFileSync } from 'child_process';
 import { makeExecutable, serializePreservingJson } from './files';
 import { activateHooks } from './hooks-cli';
 import { detect } from './detect';
+import { defaultBranchViaGh } from './setup-gh';
 import {
   buildDevcontainerExtensions,
   buildDevcontainerFeatures,
@@ -43,16 +44,22 @@ import { detectEnforcement, type EnforcementState } from './enforcement';
  * substitute *some* sensible branch and let the consumer edit the
  * workflow than refuse to install when git state is incomplete.
  *
- *   1. `git symbolic-ref refs/remotes/origin/HEAD` (set whenever the
+ *   1. `gh repo view --json defaultBranchRef` — the TRUE GitHub default,
+ *      above any local heuristic. A clone's `origin/HEAD` can point at a
+ *      feature branch (a repo inited on `feature/x` would otherwise record
+ *      `feature/x` as the workflow's default); gh is authoritative.
+ *   2. `git symbolic-ref refs/remotes/origin/HEAD` (set whenever the
  *      repo was cloned from a remote with a default-branch HEAD)
- *   2. `git rev-parse --verify <name>` against `main` / `master` /
+ *   3. `git rev-parse --verify <name>` against `main` / `master` /
  *      `trunk` / `develop` — the four conventions that cover ~all
  *      real repos
- *   3. The current branch (`git branch --show-current`) — the best
+ *   4. The current branch (`git branch --show-current`) — the best
  *      guess in a freshly-`git init`'d repo that hasn't been pushed
- *   4. Fallback to `'main'` — the GitHub default-branch default
+ *   5. Fallback to `'main'` — the GitHub default-branch default
  */
 export function detectDefaultBranch(cwd: string): string {
+  const viaGh = defaultBranchViaGh(cwd);
+  if (viaGh) return viaGh;
   try {
     const ref = execFileSync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
       cwd,

--- a/test/allowlist/effective.test.ts
+++ b/test/allowlist/effective.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { resolveEffectiveAllowlist } from '../../src/allowlist/effective';
+import {
+  entryToAllowlistable,
+  partitionByActiveAllowlist,
+} from '../../src/baseline/allowlist-match';
+import type { AllowlistEntry, AllowlistFile } from '../../src/allowlist/file';
+import type { InlineAllowlistOccurrence } from '../../src/allowlist/gather';
+import type { BaselineEntry } from '../../src/baseline/types';
+import type { IdentityKind } from '../../src/baseline/producers';
+
+/**
+ * Seam-level coverage for the ONE effective-allowlist construction
+ * (`resolveEffectiveAllowlist`) and the ONE finding-set partition
+ * (`partitionByActiveAllowlist`) — the platform pieces every finding-consumer
+ * (guardrail check, security score, `baseline create`) now share so an
+ * allowlisted finding can't be honored on one surface and ignored on another
+ * (gh #155).
+ */
+
+const NOW = new Date('2026-06-08T12:00:00Z');
+
+function fileWith(entries: AllowlistEntry[]): AllowlistFile {
+  return { schemaVersion: 'dxkit-allowlist/v1', mode: 'full', entries };
+}
+
+function entry(
+  over: Partial<AllowlistEntry> & { fingerprint: string; kind: IdentityKind },
+): AllowlistEntry {
+  return {
+    category: 'false-positive',
+    reason: 'x',
+    addedBy: 'test',
+    addedAt: '2020-01-01',
+    ...over,
+  } as AllowlistEntry;
+}
+
+function anchor(id: string, kind: IdentityKind): BaselineEntry {
+  return { id, kind } as unknown as BaselineEntry;
+}
+
+describe('resolveEffectiveAllowlist', () => {
+  it('returns the file-level base unchanged when there are no inline annotations', () => {
+    const base = fileWith([entry({ fingerprint: 'aaaa', kind: 'secret' })]);
+    const out = resolveEffectiveAllowlist({ base, inlineAnnotations: [], findings: [] });
+    expect(out).toEqual(base);
+  });
+
+  it('returns null when there is neither a file-level allowlist nor inline suppression', () => {
+    const out = resolveEffectiveAllowlist({ base: null, inlineAnnotations: [], findings: [] });
+    expect(out).toBeNull();
+  });
+
+  it('synthesizes an inline entry that suppresses a covered finding (no file-level allowlist)', () => {
+    const occ: InlineAllowlistOccurrence = {
+      file: 'src/a.ts',
+      line: 10,
+      category: 'test-fixture',
+      position: 'same-line',
+    };
+    const out = resolveEffectiveAllowlist({
+      base: null,
+      inlineAnnotations: [occ],
+      findings: [{ fingerprint: 'ffff', kind: 'secret', file: 'src/a.ts', line: 10 }],
+    });
+    expect(out).not.toBeNull();
+    expect(out!.entries.some((e) => e.fingerprint === 'ffff')).toBe(true);
+  });
+
+  it('requires cwd when base is omitted', () => {
+    expect(() => resolveEffectiveAllowlist({ findings: [], inlineAnnotations: [] })).toThrow(
+      /'base' was omitted, so 'cwd' is required/,
+    );
+  });
+
+  it('requires cwd when inlineAnnotations is omitted', () => {
+    expect(() => resolveEffectiveAllowlist({ findings: [], base: null })).toThrow(
+      /'inlineAnnotations' was omitted, so 'cwd' is required/,
+    );
+  });
+});
+
+describe('partitionByActiveAllowlist', () => {
+  it('treats every finding as live when there is no allowlist', () => {
+    const findings = [anchor('a', 'secret'), anchor('b', 'code')];
+    const out = partitionByActiveAllowlist(findings, null, NOW);
+    expect(out.live).toHaveLength(2);
+    expect(out.allowlisted).toHaveLength(0);
+  });
+
+  it('splits live vs actively-allowlisted and records the suppression', () => {
+    const allowlist = fileWith([entry({ fingerprint: 'a', kind: 'secret' })]);
+    const out = partitionByActiveAllowlist(
+      [anchor('a', 'secret'), anchor('b', 'code')],
+      allowlist,
+      NOW,
+    );
+    expect(out.allowlisted.map((e) => e.id)).toEqual(['a']);
+    expect(out.live.map((e) => e.id)).toEqual(['b']);
+    expect(out.suppressions).toHaveLength(1);
+    expect(out.suppressions[0].category).toBe('false-positive');
+  });
+
+  it('does NOT suppress via an expired entry (finding stays live)', () => {
+    const allowlist = fileWith([
+      entry({
+        fingerprint: 'a',
+        kind: 'secret',
+        category: 'accepted-risk',
+        expiresAt: '2020-06-01',
+      }),
+    ]);
+    const out = partitionByActiveAllowlist([anchor('a', 'secret')], allowlist, NOW);
+    expect(out.live.map((e) => e.id)).toEqual(['a']);
+    expect(out.allowlisted).toHaveLength(0);
+  });
+});
+
+describe('entryToAllowlistable', () => {
+  it('projects a located baseline entry into the allowlistable shape', () => {
+    const e = {
+      id: 'deadbeef',
+      kind: 'secret',
+      file: 'src/x.ts',
+      line: 42,
+      tool: 'gitleaks',
+      rule: 'generic',
+    } as unknown as BaselineEntry;
+    expect(entryToAllowlistable(e)).toEqual({
+      fingerprint: 'deadbeef',
+      kind: 'secret',
+      file: 'src/x.ts',
+      line: 42,
+    });
+  });
+});

--- a/test/baseline/allowlist-suppression.test.ts
+++ b/test/baseline/allowlist-suppression.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { allowlistSuppressionFor } from '../../src/baseline/check';
+import { allowlistSuppressionFor } from '../../src/baseline/allowlist-match';
 import type { AllowlistFile, AllowlistEntry } from '../../src/allowlist/file';
 import type { BaselineEntry } from '../../src/baseline/types';
 import type { IdentityKind } from '../../src/baseline/producers';

--- a/test/baseline/anchor-publish.test.ts
+++ b/test/baseline/anchor-publish.test.ts
@@ -3,7 +3,11 @@ import { execFileSync } from 'child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { publishFilesToAnchorRef, readFromAnchorRef } from '../../src/baseline/anchor-publish';
+import {
+  describePushFailure,
+  publishFilesToAnchorRef,
+  readFromAnchorRef,
+} from '../../src/baseline/anchor-publish';
 
 /**
  * Real-git tests for the shared anchor writer/reader. A local bare repo stands
@@ -212,5 +216,52 @@ describe('publishFilesToAnchorRef', () => {
 
   it('readFromAnchorRef returns null for an unreachable ref', () => {
     expect(readFromAnchorRef(repo, 'never-created', 'x')).toBeNull();
+  });
+
+  it('fails FAST with a surfaced reason when origin is unreachable — never hangs (gh #156)', () => {
+    // Point origin at a path that is not a git repo. With the terminal-prompt +
+    // SSH BatchMode guards, the push errors immediately instead of blocking on a
+    // credential prompt, and the reason is surfaced (not a silent 60s stall).
+    git(repo, 'remote', 'set-url', 'origin', join(tmpdir(), 'dxkit-nonexistent-remote-xyz'));
+    const start = Date.now();
+    const res = publishFilesToAnchorRef({
+      cwd: repo,
+      anchorRef: ANCHOR,
+      files: [{ path: 'x', content: 'y' }],
+      baseParent: false,
+      message: 'm',
+      timeoutMs: 10_000,
+    });
+    expect(res.pushed).toBe(false);
+    expect(res.reason).toBeTruthy();
+    expect(res.reason).not.toBe('no change');
+    // Fast-fail: nowhere near the timeout.
+    expect(Date.now() - start).toBeLessThan(9_000);
+  });
+});
+
+describe('describePushFailure (gh #156 categorization)', () => {
+  it('categorizes a timeout as a stuck auth handshake with an actionable hint', () => {
+    const err = Object.assign(new Error('spawnSync git ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    const reason = describePushFailure(err, 30_000);
+    expect(reason).toMatch(/timed out after 30s/);
+    expect(reason).toMatch(/contents: write/);
+    expect(reason).toMatch(/persist-credentials/);
+  });
+
+  it('categorizes a SIGTERM-killed push (timeout kill) as a timeout too', () => {
+    const err = Object.assign(new Error('Command failed'), { signal: 'SIGTERM', killed: true });
+    expect(describePushFailure(err, 15_000)).toMatch(/timed out after 15s/);
+  });
+
+  it('categorizes a permission denial distinctly', () => {
+    const err = new Error('remote: Permission to org/repo denied to token. fatal: 403');
+    expect(describePushFailure(err, 30_000)).toMatch(/push denied by the remote/);
+  });
+
+  it('falls through to a plain rejection for a non-fast-forward (so the retry still bites)', () => {
+    const err = new Error('Updates were rejected because the remote contains work you do not have');
+    const reason = describePushFailure(err, 30_000);
+    expect(reason.startsWith('push rejected')).toBe(true);
   });
 });

--- a/test/baseline/create.test.ts
+++ b/test/baseline/create.test.ts
@@ -223,4 +223,127 @@ describe('createBaseline (integration)', () => {
       expect(result.file).toBeUndefined();
     });
   });
+
+  // ─── gh #155: baseline create is allowlist-aware ──────────────────────────
+  //
+  // An actively-allowlisted finding must be held OUT of the captured baseline
+  // (not grandfathered as `persisted`), and that exclusion must honor the
+  // allowlist's expiry — an expired entry suppresses nothing, so its finding
+  // baselines normally and resurfaces as net-new the moment the window lapses.
+  describe('allowlist-aware capture (gh #155)', () => {
+    /** Write a `.dxkit/allowlist.json` directly (bypasses the write-path
+     *  validation so a deliberately-expired fixture entry is allowed). */
+    function writeAllowlist(cwd: string, entries: Array<Record<string, unknown>>): void {
+      mkdirSync(join(cwd, '.dxkit'), { recursive: true });
+      writeFileSync(
+        join(cwd, '.dxkit', 'allowlist.json'),
+        JSON.stringify({ schemaVersion: 'dxkit-allowlist/v1', mode: 'full', entries }, null, 2) +
+          '\n',
+      );
+    }
+
+    /** Commit the stale + large-file fixture and return the two findings' ids. */
+    async function captureFixtureIds(cwd: string): Promise<{ large: string; stale: string }> {
+      writeFileSync(join(cwd, 'leftover.bak'), 'old\n');
+      const bigLines: string[] = [];
+      for (let i = 0; i < 600; i++) bigLines.push(`const v${i} = ${i};`);
+      writeFileSync(join(cwd, 'huge.ts'), bigLines.join('\n') + '\n');
+      execFileSync('git', ['add', '.'], { cwd });
+      execFileSync('git', ['commit', '-q', '-m', 'fixture content'], { cwd });
+
+      const file = expectFile(await createBaseline({ cwd }));
+      const large = file.findings.find((f) => f.kind === 'large-file');
+      const stale = file.findings.find((f) => f.kind === 'stale-file');
+      if (!large || !stale) throw new Error('fixture did not produce both findings');
+      return { large: large.id, stale: stale.id };
+    }
+
+    it('holds an actively-allowlisted finding out of the baseline + reports the split', async () => {
+      const ids = await captureFixtureIds(dir);
+      // Baseline WITHOUT an allowlist: both findings captured, nothing held out.
+      const before = await createBaseline({ cwd: dir, force: true });
+      expect(before.allowlistSplit?.allowlisted).toBe(0);
+      expect(expectFile(before).findings.some((f) => f.id === ids.large)).toBe(true);
+
+      // Allowlist the large-file finding (false-positive → non-expiring).
+      writeAllowlist(dir, [
+        {
+          fingerprint: ids.large,
+          kind: 'large-file',
+          category: 'false-positive',
+          reason: 'reviewed: generated file',
+          addedBy: 'test',
+          addedAt: '2020-01-01',
+        },
+      ]);
+
+      const after = await createBaseline({ cwd: dir, force: true });
+      const file = expectFile(after);
+      // The allowlisted finding is NOT in the baseline; the stale one still is.
+      expect(file.findings.some((f) => f.id === ids.large)).toBe(false);
+      expect(file.findings.some((f) => f.id === ids.stale)).toBe(true);
+      // The split is reported honestly for the CLI headline.
+      expect(after.allowlistSplit?.allowlisted).toBe(1);
+      expect(after.allowlistSplit?.byCategory).toEqual({ 'false-positive': 1 });
+      expect(after.allowlistSplit?.live).toBe(file.findings.length);
+    });
+
+    it('an EXPIRED allowlist entry suppresses nothing — the finding baselines normally', async () => {
+      const ids = await captureFixtureIds(dir);
+      // accepted-risk with a PAST expiry → inactive → must NOT hold the finding out.
+      writeAllowlist(dir, [
+        {
+          fingerprint: ids.large,
+          kind: 'large-file',
+          category: 'accepted-risk',
+          reason: 'was deferred, window lapsed',
+          addedBy: 'test',
+          addedAt: '2020-01-01',
+          expiresAt: '2020-06-01',
+        },
+      ]);
+
+      const after = await createBaseline({ cwd: dir, force: true });
+      const file = expectFile(after);
+      expect(file.findings.some((f) => f.id === ids.large)).toBe(true);
+      expect(after.allowlistSplit?.allowlisted).toBe(0);
+    });
+
+    it('a FUTURE-dated accepted-risk entry is active and held out', async () => {
+      const ids = await captureFixtureIds(dir);
+      writeAllowlist(dir, [
+        {
+          fingerprint: ids.large,
+          kind: 'large-file',
+          category: 'accepted-risk',
+          reason: 'accepted for this quarter',
+          addedBy: 'test',
+          addedAt: '2020-01-01',
+          expiresAt: '2999-01-01',
+        },
+      ]);
+
+      const after = await createBaseline({ cwd: dir, force: true });
+      expect(expectFile(after).findings.some((f) => f.id === ids.large)).toBe(false);
+      expect(after.allowlistSplit?.allowlisted).toBe(1);
+    });
+
+    it('a wrong-kind allowlist entry does NOT suppress (fingerprint alone is insufficient)', async () => {
+      const ids = await captureFixtureIds(dir);
+      // Same fingerprint but kind `secret` — must not match the large-file finding.
+      writeAllowlist(dir, [
+        {
+          fingerprint: ids.large,
+          kind: 'secret',
+          category: 'false-positive',
+          reason: 'wrong kind',
+          addedBy: 'test',
+          addedAt: '2020-01-01',
+        },
+      ]);
+      const after = await createBaseline({ cwd: dir, force: true });
+      expect(expectFile(after).findings.some((f) => f.id === ids.large)).toBe(true);
+      expect(after.allowlistSplit?.allowlisted).toBe(0);
+    });
+  });
 });

--- a/test/baseline/drift-warning-collapse.test.ts
+++ b/test/baseline/drift-warning-collapse.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { formatDriftWarningSummary } from '../../src/baseline/check-renderers';
+import type { ClassifiedPair } from '../../src/baseline/check';
+
+/**
+ * gh #157: the envelope-drift warning WALL collapses to ONE summary line, and
+ * names the truer gate-just-enabled cause when it applies — so a policy.json
+ * edit or a dxkit upgrade doesn't bury the specific warnings under dozens of
+ * `config_drift` lines.
+ */
+
+function driftPair(reasonCode: string): ClassifiedPair {
+  return {
+    classification: {
+      status: 'config_drift',
+      reasons: [{ code: reasonCode, detail: 'x' }],
+      blocks: false,
+      warns: true,
+    },
+  } as unknown as ClassifiedPair;
+}
+
+describe('formatDriftWarningSummary', () => {
+  it('collapses N drift warnings into a single summary line with the count', () => {
+    const out = formatDriftWarningSummary(
+      [driftPair('config-drift'), driftPair('config-drift'), driftPair('config-drift')],
+      '  ',
+    );
+    // One headline line + one guidance line — NOT one line per finding.
+    expect(out).toHaveLength(2);
+    expect(out[0]).toContain('3 findings unmatched after an envelope change');
+    expect(out[1]).toContain('--json');
+  });
+
+  it('names the gate-just-enabled cause when every drift finding is a new dimension', () => {
+    const out = formatDriftWarningSummary(
+      [driftPair('dimension-newly-measured'), driftPair('dimension-newly-measured')],
+      '  ',
+    );
+    expect(out[0]).toMatch(/gate\/dimension was newly enabled/);
+  });
+
+  it('reports a partial gate-enabled breakdown when mixed with generic drift', () => {
+    const out = formatDriftWarningSummary(
+      [driftPair('dimension-newly-measured'), driftPair('config-drift')],
+      '  ',
+    );
+    expect(out[0]).toContain('2 findings');
+    expect(out[0]).toMatch(/1 from a newly-enabled gate\/dimension/);
+  });
+
+  it('falls back to the generic envelope-change cause when none are gate-enabled', () => {
+    const out = formatDriftWarningSummary([driftPair('config-drift')], '  ');
+    expect(out[0]).toMatch(/dxkit upgrade or policy\/config change/);
+    expect(out[0]).toContain('1 finding unmatched');
+  });
+});

--- a/test/baseline/policy.test.ts
+++ b/test/baseline/policy.test.ts
@@ -89,6 +89,42 @@ describe('classify — drift context reclassifies added', () => {
     expect(result.status).toBe('config_drift');
   });
 
+  it('names the gate-just-enabled cause over generic config_drift (gh #157)', () => {
+    // The kind had no baseline entries → a gate/dimension was newly enabled, so
+    // its whole pre-existing backlog reads as net-new. That is a truer reason
+    // than "policy config changed" — but the VERDICT must be unchanged.
+    const ctx: ClassifyContext = { configDiffers: true, kindAbsentFromBaseline: true };
+    const result = classify(pair('added'), DEFAULT_BROWNFIELD_POLICY, ctx);
+    expect(result.status).toBe('config_drift'); // verdict-bearing status unchanged
+    expect(result.warns).toBe(true);
+    expect(result.reasons.some((r) => r.code === 'dimension-newly-measured')).toBe(true);
+    // The misleading generic reason is NOT emitted for this case.
+    expect(result.reasons.some((r) => r.code === 'config-drift')).toBe(false);
+  });
+
+  it('generic config_drift reason no longer over-claims a specific cause (gh #157)', () => {
+    const ctx: ClassifyContext = { configDiffers: true, kindAbsentFromBaseline: false };
+    const result = classify(pair('added'), DEFAULT_BROWNFIELD_POLICY, ctx);
+    expect(result.reasons.some((r) => r.code === 'config-drift')).toBe(true);
+    const drift = result.reasons.find((r) => r.code === 'config-drift');
+    // No longer asserts "suppression or policy config changed" as THE cause.
+    expect(drift?.detail).not.toContain('suppression or policy config changed');
+    expect(drift?.detail).toContain('envelope change');
+  });
+
+  it('gate-just-enabled does NOT weaken a net-new secret block (verdict preserved, gh #157)', () => {
+    // A secret whose kind was absent from the baseline + config drift: the reason
+    // is refined, but the block-rule must still fire (config_drift is block-rule
+    // eligible), so the net-new secret still blocks.
+    const ctx: ClassifyContext = {
+      configDiffers: true,
+      kindAbsentFromBaseline: true,
+      kind: 'secret',
+    };
+    const result = classify(pair('added'), DEFAULT_BROWNFIELD_POLICY, ctx);
+    expect(result.blocks).toBe(true);
+  });
+
   it('does not reclassify persisted on drift signals', () => {
     const ctx: ClassifyContext = { scannerVersionDiffers: true };
     const result = classify(pair('persisted'), DEFAULT_BROWNFIELD_POLICY, ctx);

--- a/test/cross-platform-detect.test.ts
+++ b/test/cross-platform-detect.test.ts
@@ -154,16 +154,29 @@ describe('loadToolsConfig (.dxkit/tools.json)', () => {
 
 describe('getInstallEnv', () => {
   let cwd: string;
+  let savedIcu: string | undefined;
   beforeEach(() => {
     cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-installenv-'));
     clearToolsConfigCache();
+    // getInstallEnv adds the .NET ICU-invariant flag only when the user hasn't
+    // set it — control it explicitly so the assertions are deterministic
+    // regardless of test ordering / the ambient CI env.
+    savedIcu = process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT;
+    delete process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT;
   });
   afterEach(() => {
+    if (savedIcu === undefined) delete process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT;
+    else process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = savedIcu;
     fs.rmSync(cwd, { recursive: true, force: true });
     clearToolsConfigCache();
   });
 
-  it('is empty when no installDir is configured', () => {
+  it('carries only the .NET ICU-invariant flag when no installDir is configured', () => {
+    expect(getInstallEnv(cwd)).toEqual({ DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: '1' });
+  });
+
+  it('does not add the ICU flag when the user already set it', () => {
+    process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = '0';
     expect(getInstallEnv(cwd)).toEqual({});
   });
 
@@ -173,6 +186,7 @@ describe('getInstallEnv', () => {
     fs.writeFileSync(p, JSON.stringify({ installDir: '/custom/tools' }));
     clearToolsConfigCache();
     expect(getInstallEnv(cwd)).toEqual({
+      DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: '1',
       PIPX_BIN_DIR: '/custom/tools',
       npm_config_prefix: '/custom/tools',
       CARGO_INSTALL_ROOT: '/custom/tools',

--- a/test/init-arc.test.ts
+++ b/test/init-arc.test.ts
@@ -16,6 +16,7 @@ const base: InitClosingState = {
   baselineMode: 'committed-full',
   surfaces: ['pre-push hook', 'CI guardrail'],
   incompleteScanners: [],
+  languageToolchainGaps: [],
   elapsedMs: 48_000,
 };
 
@@ -135,6 +136,50 @@ describe('buildInitClosing', () => {
     expect(c.caution).toContain('tools install');
     // No coverage gap → no caution.
     expect(buildInitClosing({ ...base, baselineFindings: 12 }).caution).toBeNull();
+  });
+
+  it('QUALIFIES the headline when an active language toolchain is unmeasured (honesty class)', () => {
+    const c = buildInitClosing({
+      ...base,
+      baselineFindings: 3747,
+      // The dpl-studio shape: a pure-C# repo baselined with no `dotnet` on PATH.
+      incompleteScanners: ['dotnet-format', 'nuget-license'],
+      languageToolchainGaps: [
+        { language: 'csharp', displayName: 'C#', missingBinaries: ['dotnet'] },
+      ],
+    });
+    // NOT an unqualified "You're gated ✓".
+    expect(c.headline).toBe("You're gated for what's measurable.");
+    expect(c.caution).not.toBeNull();
+    // Names the toolchain + the root prerequisite, and is explicit that the deep
+    // classes were NOT measured (never presented as full coverage).
+    expect(c.caution).toContain('C#');
+    expect(c.caution).toContain('dotnet');
+    expect(c.caution).toMatch(/not.*measured|weren't measured|NOT measured/i);
+    // Actionable + root-pointed: re-run baseline after installing the toolchain,
+    // not a bare loop back to `tools install`.
+    expect(c.caution).toContain('baseline create');
+  });
+
+  it('a missing language toolchain takes precedence over the generic scanner caution', () => {
+    const withGap = buildInitClosing({
+      ...base,
+      baselineFindings: 10,
+      incompleteScanners: ['dotnet-format'],
+      languageToolchainGaps: [
+        { language: 'csharp', displayName: 'C#', missingBinaries: ['dotnet'] },
+      ],
+    });
+    // Full coverage NOT claimed.
+    expect(withGap.headline).not.toBe("You're gated.");
+    // A generic optional-scanner gap (no language toolchain missing) still reads
+    // as fully gated with the lighter caution.
+    const optionalOnly = buildInitClosing({
+      ...base,
+      baselineFindings: 10,
+      incompleteScanners: ['gitleaks'],
+    });
+    expect(optionalOnly.headline).toBe("You're gated.");
   });
 
   it('time-to-verdict is humanized across ranges', () => {

--- a/test/languages/toolchain-coverage.test.ts
+++ b/test/languages/toolchain-coverage.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assessLanguageToolchains,
+  primaryLanguageUnmeasured,
+} from '../../src/languages/toolchain-coverage';
+import type { LanguageSupport } from '../../src/languages/types';
+
+/**
+ * The pack-driven "is the primary language toolchain present" signal — the ONE
+ * source doctor's per-language check and the init finish-arc honesty both read,
+ * so a partial baseline can't be presented as full coverage on one surface
+ * while the other tells the truth (the dpl-studio onboarding class).
+ */
+
+function pack(id: string, displayName: string, cliBinaries?: string[]): LanguageSupport {
+  return { id, displayName, cliBinaries } as unknown as LanguageSupport;
+}
+
+describe('assessLanguageToolchains', () => {
+  it('reports a gap when an active pack cliBinary is absent from PATH', () => {
+    // A binary that cannot exist on PATH → guaranteed gap.
+    const gaps = assessLanguageToolchains([pack('csharp', 'C#', ['dxkit-nonexistent-binary-xyz'])]);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0]).toMatchObject({
+      language: 'csharp',
+      displayName: 'C#',
+      missingBinaries: ['dxkit-nonexistent-binary-xyz'],
+    });
+    expect(primaryLanguageUnmeasured(gaps)).toBe(true);
+  });
+
+  it('reports no gap for a pack whose toolchain resolves (node is always present in CI)', () => {
+    const gaps = assessLanguageToolchains([pack('typescript', 'TypeScript', ['node'])]);
+    expect(gaps).toHaveLength(0);
+    expect(primaryLanguageUnmeasured(gaps)).toBe(false);
+  });
+
+  it('ignores packs that declare no cliBinaries', () => {
+    expect(assessLanguageToolchains([pack('x', 'X', undefined)])).toHaveLength(0);
+    expect(assessLanguageToolchains([pack('x', 'X', [])])).toHaveLength(0);
+  });
+
+  it('only reports the binaries that are actually missing', () => {
+    const gaps = assessLanguageToolchains([
+      pack('mixed', 'Mixed', ['node', 'dxkit-nonexistent-binary-xyz']),
+    ]);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].missingBinaries).toEqual(['dxkit-nonexistent-binary-xyz']);
+  });
+});

--- a/test/tools-sdk-bootstrap.test.ts
+++ b/test/tools-sdk-bootstrap.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { substituteRuntimeVersion } from '../src/analyzers/tools/install-exec';
+import { getInstallEnv, TOOL_DEFS } from '../src/analyzers/tools/tool-registry';
+
+/**
+ * 3.7.2 SDK-bootstrap execution cluster: the C# SDK bootstrap is NON-SUDO and
+ * VERSION-AWARE (#4/#7), and dxkit's own dotnet subprocesses run in invariant
+ * globalization mode so a libicu-less image doesn't crash them (#8).
+ */
+
+describe('substituteRuntimeVersion (#4 version-aware SDK bootstrap)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-sdk-boot-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('is a no-op for a command with no runtime placeholder', () => {
+    const cmd = 'brew install cloc';
+    expect(substituteRuntimeVersion(cmd, dir)).toBe(cmd);
+  });
+
+  it('fills the .NET channel + major from the repo-detected version', () => {
+    writeFileSync(
+      join(dir, 'App.csproj'),
+      '<Project><PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup></Project>\n',
+    );
+    const out = substituteRuntimeVersion(
+      'dotnet-install.sh --channel __DOTNET_CHANNEL__ ; winget ...SDK.__DOTNET_MAJOR__',
+      dir,
+    );
+    expect(out).toContain('--channel 9.0');
+    expect(out).toContain('SDK.9');
+    expect(out).not.toContain('__DOTNET_');
+  });
+
+  it('falls back to 8.0 when the repo declares no .NET version', () => {
+    const out = substituteRuntimeVersion('--channel __DOTNET_CHANNEL__', dir);
+    expect(out).toBe('--channel 8.0');
+  });
+});
+
+describe('dotnet-format install command (#7 non-sudo bootstrap)', () => {
+  it('uses the non-sudo dotnet-install.sh, never a sudo apt', () => {
+    const cmds = TOOL_DEFS['dotnet-format'].installCommands;
+    expect(cmds.linux).toContain('dotnet-install.sh');
+    expect(cmds.linux).toContain('$HOME/.dotnet');
+    expect(cmds.linux).not.toMatch(/\bapt\b|\bsudo\b/);
+    // Version-aware, not a hardcoded major.
+    expect(cmds.linux).toContain('__DOTNET_CHANNEL__');
+    expect(cmds.linux).not.toContain('dotnet-sdk-8.0');
+  });
+});
+
+describe('getInstallEnv (#8 ICU invariant for dotnet installs)', () => {
+  let dir: string;
+  let saved: string | undefined;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-icu-env-'));
+    saved = process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT;
+    delete process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT;
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT;
+    else process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = saved;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('sets the invariant flag so `dotnet tool install` does not ICU-crash', () => {
+    expect(getInstallEnv(dir).DOTNET_SYSTEM_GLOBALIZATION_INVARIANT).toBe('1');
+  });
+
+  it('never overrides a value the user already set', () => {
+    process.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = '0';
+    expect(getInstallEnv(dir).DOTNET_SYSTEM_GLOBALIZATION_INVARIANT).toBeUndefined();
+  });
+});


### PR DESCRIPTION
A reliability and honesty cluster surfaced by a real customer onboarding (a Windows-only .NET desktop repo, run from a Linux box with no .NET toolchain). Every fix lands at the platform level so its class cannot recur; the branch is 6 atomic commits (rebase-merge to preserve them).

Fixes #155, #156, #157.

## What's in it

- **`baseline create` is allowlist-aware (#155)** — actively-allowlisted findings are held OUT of the baseline (never grandfathered as `persisted`), so the allowlist + its expiry is the single source of suppression and an expired entry re-exposes the finding as net-new. One effective-allowlist constructor + one active-suppression predicate shared by check / score / capture; arch-check bans re-inlining the recipe.
- **Anchor push no longer hangs in Actions (#156)** — SSH `BatchMode=yes` + `GIT_TERMINAL_PROMPT=0` make an unauthenticated push fail fast, on a shorter surfaced timeout, with a categorized reason that names the auth cause.
- **Never over-claim coverage on init (onboarding #1/#2)** — when the repo's own language toolchain is absent, `init` reads "You're gated for what's measurable." and points remediation at the root prerequisite, not a `tools install` loop. One pack-driven signal shared with `doctor`.
- **Non-sudo, version-aware .NET SDK bootstrap + ICU-safe dotnet + gh default branch (onboarding #4/#7/#8/#3)** — `dotnet-install.sh --install-dir $HOME/.dotnet` at the repo's detected major; `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` on dxkit's dotnet subprocesses; default branch resolved via `gh repo view` first.
- **Config-drift precedence + collapse the warning wall (#157)** — the classifier names the gate-just-enabled cause instead of over-claiming `config_drift`, the generic reason stops asserting "policy config changed", and the console + PR renderers collapse the drift group into one line. Verdict unchanged (net-new blocking findings still block).

## Verification

- `npm run build`, `npm run test:run` (**4090 tests**), `check-architecture.sh`, lint, format all green.
- New tests: allowlist-aware capture (expiry / non-expiring test-fixtures / wrong-kind guard), the anchor push failure categorizer, the toolchain-coverage signal, the SDK-bootstrap substitution + ICU env, and config-drift precedence + wall collapse.
- The `dotnet`-dependent SDK-bootstrap paths (#4/#7/#8) are unit-tested here; end-to-end verification of the actual .NET install lands during release validation on WSL/dpl-studio (no .NET toolchain on the dev box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)