### PR TITLE
fix(anchor): internal side-ref push skips the pre-push hook (#156, 3.7.4)

### DIFF
--- a/.github/workflows/anchor-auth-smoke.yml
+++ b/.github/workflows/anchor-auth-smoke.yml
@@ -1,15 +1,15 @@
 name: anchor push auth smoke
 
-# REAL end-to-end proof (gh #156) that dxkit's side-ref writer authenticates its
-# push in GitHub Actions from the CI token alone. The unit tests mock the git
-# exec, so they cannot catch "the auth mechanism does not actually work against
-# real GitHub" — the failure mode that shipped the 3.1.0 regression. This job
-# hits real GitHub auth.
+# REAL end-to-end proof (gh #156) that dxkit's side-ref writer does NOT fire the
+# repo's pre-push hook. The actual root cause of #156 was NOT auth: the internal
+# `git push` ran in a checkout where `core.hooksPath=.githooks` was active, so it
+# fired dxkit's own guardrail check as a pre-push hook and got SIGTERM'd mid-run
+# under the exec timeout → ETIMEDOUT (misread as an auth failure for four builds).
+# The fix is `--no-verify` on the internal push.
 #
-# Key: `persist-credentials: false` removes the ambient credential
-# actions/checkout would otherwise leave in .git/config, so the push can ONLY
-# succeed if `publishFilesToAnchorRef` authenticates itself from GITHUB_TOKEN —
-# reproducing the exact condition the plumbing writer failed under.
+# The smoke is self-contained (a throwaway local repo with a blocking pre-push
+# hook — no token, no remote), so it proves the fix in the real CI OS/git
+# environment without depending on repo push policy.
 
 on:
   pull_request:
@@ -20,17 +20,13 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          # Deliberately NO persisted credential — the whole point is to prove
-          # the push authenticates without it (the regression condition).
-          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -39,24 +35,7 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      # Control: with no token in the env, the push MUST fail. If it somehow
-      # succeeds, the smoke is not exercising auth and the positive case proves
-      # nothing — so this failing is required.
-      - name: control — push must fail without a token
-        run: node scripts/anchor-auth-smoke.mjs expect-fail
-
-      # The fix: with the token exposed, the primitive authenticates the push to
-      # a throwaway side ref (then deletes it).
-      - name: fix — the CI token authenticates the push
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: node scripts/anchor-auth-smoke.mjs expect-pass
-
-      # Belt-and-suspenders cleanup in case the script's own delete was skipped.
-      - name: cleanup throwaway ref
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" \
-            --delete "ci-anchor-auth-smoke-${{ github.run_id }}" 2>/dev/null || true
+      # The internal side-ref push must publish while a blocking pre-push hook is
+      # wired — proving it runs with `--no-verify` and never fires the hook.
+      - name: internal push skips the pre-push hook
+        run: node scripts/anchor-auth-smoke.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.4] - 2026-07-14
+
+### Fixed
+
+- **After-merge refresh workflows publish their side-ref push in CI — the real
+  root cause of #156 (3.7.1–3.7.3 fixed a phantom).** The 30s `ETIMEDOUT` on the
+  anchor push was **never** an auth problem. The internal side-ref push runs
+  `git push` in the checkout, where `core.hooksPath=.githooks` is active whenever
+  dxkit is installed with git hooks — so the push fired the repo's **own
+  `pre-push` guardrail hook** (`vyuh-dxkit guardrail check`) as a side effect of a
+  machine refresh. Under the bounded exec timeout that hook was SIGTERM'd mid-run
+  → `ETIMEDOUT`, which `describePushFailure` mislabeled as "the remote did not
+  authenticate" — the one mislabel that sent three prior releases chasing a
+  non-existent credential bug (fetch always worked because fetch fires no hook; a
+  developer's bash `git push` worked because it has no exec timeout to kill the
+  hook). The fix is one flag: dxkit's internal machine pushes now run
+  `git push --no-verify`, so they never run the repo's pre-push gate against a bot
+  commit. This fixes **both** side-ref publishers (baseline branch-anchor refresh
+  and reports snapshot — one shared writer) and is verified end-to-end on a real
+  hook-active repo.
+- **Reverted the 3.7.3 credential machinery.** It was built on the misdiagnosis:
+  the ambient checkout credential always authenticated fine, so the injected
+  `http.<host>.extraheader` / token handling and the `GITHUB_TOKEN` env in the
+  generated refresh workflows are removed. `describePushFailure` no longer asserts
+  auth from a bare timeout.
+
+### Changed
+
+- **Every dxkit-internal `git push` is guarded at the class level.** A second
+  latent site (the flow/reports `--land push` mode in `src/land-refresh.ts`)
+  carried the identical bug. All internal machine pushes now build their argv
+  through one constructor, `internalGitPushArgs` (`src/git-internal-push.ts`),
+  which always emits `--no-verify`; `scripts/check-architecture.sh` bans a raw
+  `['push', …]` git argv anywhere in `src/` outside that helper, so a future
+  internal push cannot silently reintroduce the class. Real-git regression tests
+  (a genuinely blocking `pre-push` hook that the push must skip) cover both
+  consumers.
+
 ## [3.7.3] - 2026-07-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "3.7.3",
+      "version": "3.7.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/anchor-auth-smoke.mjs
+++ b/scripts/anchor-auth-smoke.mjs
@@ -1,110 +1,97 @@
 /**
- * REAL end-to-end proof that `publishFilesToAnchorRef` authenticates a side-ref
- * push in GitHub Actions using ONLY the CI token.
+ * REAL end-to-end proof that `publishFilesToAnchorRef`'s side-ref push does NOT
+ * fire the repo's `pre-push` hook (gh #156 — the actual root cause).
  *
- * The unit/seam tests mock the git exec, so they prove the push CARRIES the auth
- * header but not that the header actually AUTHENTICATES — the exact gap that let
- * the 3.1.0 regression (gh #156) ship green. This script closes it: the workflow
- * checks out with `persist-credentials: false`, so there is NO ambient
- * credential to fall back on, and the push can only succeed if the primitive
- * authenticates itself from the token.
+ * The regression: dxkit's internal machine push ran a plain `git push` in a
+ * checkout where `core.hooksPath=.githooks` is active, so it fired dxkit's OWN
+ * guardrail check as a pre-push hook; under the `execFileSync` timeout that hook
+ * was SIGTERM'd mid-run → ETIMEDOUT, which four debug builds misread as an auth
+ * failure. The fix is `--no-verify` on the internal push.
  *
- *   node scripts/anchor-auth-smoke.mjs expect-pass   # GITHUB_TOKEN set → must push
- *   node scripts/anchor-auth-smoke.mjs expect-fail   # no token → must NOT push (control)
+ * This smoke is self-contained (a throwaway local repo — no token, no remote):
+ * it wires a `pre-push` hook that BLOCKS any ordinary push (writes a sentinel +
+ * exits 1), proves the hook really blocks a normal push, then asserts the
+ * primitive still publishes (hook skipped) and the sentinel was never written.
+ *
+ *   node scripts/anchor-auth-smoke.mjs
  */
 import { execFileSync } from 'child_process';
-import { publishFilesToAnchorRef, ciCredentialedUrl } from '../dist/baseline/anchor-publish.js';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, chmodSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { publishFilesToAnchorRef } from '../dist/baseline/anchor-publish.js';
 
-const mode = process.argv[2];
-if (mode !== 'expect-pass' && mode !== 'expect-fail') {
-  console.error('usage: anchor-auth-smoke.mjs expect-pass|expect-fail');
-  process.exit(2);
-}
+const git = (cwd, ...args) => execFileSync('git', args, { cwd, encoding: 'utf8' });
 
-const cwd = process.cwd();
-const runId = process.env.GITHUB_RUN_ID ?? `local-${process.pid}`;
-// A NON-`dxkit-*` ref name so dxkit's own anchor-branch ruleset (scoped to
-// `dxkit-*`) does not reject/delay the throwaway push — that policy rejection is
-// a property of THIS repo, not the fix, and it muddied the auth signal.
-const ref = `ci-anchor-auth-smoke-${runId}`;
+const base = mkdtempSync(join(tmpdir(), 'dxkit-hook-smoke-'));
+const bare = join(base, 'origin.git');
+const repo = join(base, 'checkout');
+const hooks = join(base, 'hooks');
+const sentinel = join(base, 'hook-fired');
+let failed = false;
+try {
+  git(base, 'init', '-q', '--bare', '-b', 'main', bare);
+  mkdirSync(repo);
+  git(repo, 'init', '-q', '-b', 'main');
+  git(repo, 'config', 'user.email', 'smoke@dxkit');
+  git(repo, 'config', 'user.name', 'smoke');
+  writeFileSync(join(repo, 'README.md'), '# smoke\n');
+  git(repo, 'add', '.');
+  git(repo, 'commit', '-q', '-m', 'init');
+  git(repo, 'remote', 'add', 'origin', bare);
+  git(repo, 'push', '-q', 'origin', 'main');
 
-const res = publishFilesToAnchorRef({
-  cwd,
-  anchorRef: ref,
-  files: [{ path: 'auth-smoke.txt', content: `run ${runId}\n` }],
-  message: 'ci: anchor auth smoke',
-  // Accumulate mode → a NON-force push to create the ref (this repo's ruleset
-  // blocks force-pushes; a plain branch-create is allowed, giving a clean
-  // pushed:true). The auth mechanism is identical for both modes.
-  baseParent: true,
-  timeoutMs: 25_000,
-});
-console.log('publish result:', JSON.stringify(res));
+  // A pre-push hook that BLOCKS any ordinary push — the stand-in for dxkit's own
+  // guardrail pre-push hook that caused the #156 timeout.
+  mkdirSync(hooks);
+  const hook = join(hooks, 'pre-push');
+  writeFileSync(hook, `#!/bin/sh\necho blocked > "${sentinel}"\nexit 1\n`);
+  chmodSync(hook, 0o755);
+  git(repo, 'config', 'core.hooksPath', hooks);
 
-/** Delete the throwaway ref, authenticating the same way the primitive does. */
-function cleanup() {
+  // Sanity: an ORDINARY push MUST be blocked by the hook, or the test is meaningless.
+  let ordinaryBlocked = false;
   try {
-    const originUrl = execFileSync('git', ['remote', 'get-url', 'origin'], {
-      cwd,
-      encoding: 'utf8',
-    }).trim();
-    const target = ciCredentialedUrl(originUrl, process.env) ?? 'origin';
-    execFileSync('git', ['push', target, '--delete', ref], { cwd, stdio: 'ignore' });
-    console.log(`cleaned up ${ref}`);
+    execFileSync('git', ['push', 'origin', 'HEAD:refs/heads/ordinary-probe'], {
+      cwd: repo,
+      stdio: 'ignore',
+    });
   } catch {
-    console.log(`could not delete ${ref} (best-effort)`);
+    ordinaryBlocked = true;
+  }
+  if (!ordinaryBlocked) {
+    console.error('SMOKE SETUP FAIL: the pre-push hook did not block an ordinary push.');
+    process.exit(1);
+  }
+  if (existsSync(sentinel)) rmSync(sentinel); // reset before the real assertion
+
+  // The primitive publish must SUCCEED (hook skipped via --no-verify) ...
+  const res = publishFilesToAnchorRef({
+    cwd: repo,
+    anchorRef: 'dxkit-baselines',
+    files: [{ path: 'baselines/main.json', content: '{}\n' }],
+    message: 'smoke: hook-skip',
+    baseParent: false,
+  });
+  if (!res.pushed) {
+    console.error(`FAIL: the primitive push did not succeed (hook not skipped?): ${res.reason}`);
+    failed = true;
+  }
+  // ... and the pre-push hook must NOT have fired.
+  if (existsSync(sentinel)) {
+    console.error('FAIL: the pre-push hook FIRED during the internal push (missing --no-verify).');
+    failed = true;
+  }
+  if (!failed) {
+    console.log(
+      'PASS: the internal side-ref push skipped the pre-push hook and published (gh #156).',
+    );
+  }
+} finally {
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
   }
 }
-
-/**
- * The fix is about AUTHENTICATION, so that is what we assert — independent of
- * the repo's write policy. With no ambient credential, a push that fails to
- * AUTHENTICATE looks like "could not read Username" / "terminal prompts
- * disabled" / a timeout; a push that AUTHENTICATED and was then rejected by repo
- * policy (e.g. this repo restricts creating an arbitrary branch) looks like
- * "failed to push some refs" — the token clearly got past auth. The control
- * (no token) must land in the FIRST bucket; the fix (token) must NOT.
- */
-// A genuine auth failure is ALWAYS fast here — with terminal prompts disabled,
-// a missing/bad credential fails immediately with "could not read Username" /
-// "Authentication failed" / a 401-403, never a hang. A TIMEOUT therefore is NOT
-// an auth failure: it only happens after auth succeeds and the server holds a
-// policy-blocked push. So `timed out` is deliberately NOT in this set.
-const AUTH_FAILED =
-  /could not read Username|terminal prompts disabled|Authentication failed|fatal: could not read|40[13]|Invalid username or (password|token)/i;
-
-if (mode === 'expect-pass') {
-  if (res.pushed) {
-    cleanup();
-    console.log(
-      'PASS: the CI token authenticated + the side-ref push succeeded (no ambient credential).',
-    );
-  } else if (AUTH_FAILED.test(res.reason ?? '')) {
-    console.error(`FAIL: the token did NOT authenticate the push: ${res.reason}`);
-    process.exit(1);
-  } else {
-    // Authenticated, then rejected by repo policy (this repo blocks the throwaway
-    // branch) — the auth mechanism (the whole point of #156) is proven.
-    console.log(
-      `PASS: the CI token AUTHENTICATED the push (rejected only by repo policy): ${res.reason}`,
-    );
-  }
-} else {
-  if (res.pushed) {
-    cleanup();
-    console.error(
-      'FAIL: the push succeeded WITHOUT a token — the smoke is not exercising auth ' +
-        '(persist-credentials leaked a credential?). This control must fail to be meaningful.',
-    );
-    process.exit(1);
-  }
-  if (!AUTH_FAILED.test(res.reason ?? '')) {
-    console.error(
-      `FAIL (control): expected an AUTH failure without a token, got a non-auth reason: ${res.reason}`,
-    );
-    process.exit(1);
-  }
-  console.log(
-    `PASS (control): the push correctly failed to AUTHENTICATE without a token: ${res.reason}`,
-  );
-}
+process.exit(failed ? 1 : 0);

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -759,6 +759,31 @@ if [ -n "$ROGUE_WORKTREE" ]; then
 fi
 
 # =============================================================================
+# Internal-push discipline (gh #156 / Rule 2): every dxkit machine push carries
+# `--no-verify`, built by exactly ONE constructor.
+# =============================================================================
+#
+# A dxkit-internal `git push` (side-ref anchors, refresh lands) is a MACHINE
+# push, never a gated developer push — it must NOT fire the repo's own pre-push
+# guardrail hook (dxkit installs `core.hooksPath=.githooks`), or under the
+# bounded exec timeout the hook is SIGTERM'd mid-run → ETIMEDOUT (gh #156, four
+# debug builds misread it as auth). The `--no-verify` flag is guaranteed by
+# `internalGitPushArgs` in `src/git-internal-push.ts`; a raw `['push', …]` git
+# argv anywhere else could silently drop it and reintroduce the class.
+ROGUE_PUSH=$(grep -rnE "\[[[:space:]]*['\"]push['\"]" src/ 2>/dev/null \
+  | grep -v "// internal-push-ok" \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | grep -v "^src/git-internal-push.ts:")
+if [ -n "$ROGUE_PUSH" ]; then
+  echo "❌ Internal-push rule violation: a raw 'git push' argv outside src/git-internal-push.ts:"
+  echo "$ROGUE_PUSH"
+  echo "   → Build the argv with internalGitPushArgs() from src/git-internal-push.ts"
+  echo "     (it guarantees --no-verify so the machine push never fires the pre-push hook, gh #156)."
+  echo "   → Annotate '// internal-push-ok' for a justified exception (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# =============================================================================
 # Effective-allowlist discipline (3.7.2 / Rule 2): one construction, one predicate.
 # =============================================================================
 #

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
@@ -88,14 +88,10 @@ __DXKIT_CI_RUNTIME_SETUP__
           "${DXKIT}" baseline create --force
 
       - name: Publish anchor to the unprotected side branch
-        env:
-          # Expose the workflow token so `baseline publish` can authenticate the
-          # side-ref push. The publish uses dxkit's plumbing side-ref writer (no
-          # checkout), which does not reliably reuse the credential
-          # actions/checkout persists — so it reads GITHUB_TOKEN and authenticates
-          # the push itself (a scoped http.extraheader). Without this the push
-          # hangs/rejects with no auth (dxkit #156, a regression since 3.1.0).
-          GITHUB_TOKEN: ${{ github.token }}
+        # No token env needed: the side-ref push authenticates with the credential
+        # actions/checkout already persists (`contents: write` above + the default
+        # `persist-credentials: true`). The internal push runs with `--no-verify`
+        # so it never fires this repo's own pre-push guardrail hook (dxkit #156).
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
             DXKIT=./node_modules/.bin/vyuh-dxkit

--- a/src-templates/.github/workflows/dxkit-reports-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-reports-refresh.yml
@@ -68,13 +68,10 @@ __DXKIT_CI_RUNTIME_SETUP__
           fi
 
       - name: Generate reports + publish the snapshot
-        env:
-          # Expose the workflow token so `report snapshot` can authenticate the
-          # side-ref push. It uses dxkit's plumbing side-ref writer (no checkout),
-          # which reads GITHUB_TOKEN and authenticates the push itself (a scoped
-          # http.extraheader) rather than relying on the persisted checkout cred
-          # (dxkit #156 — the same regression the baseline refresh hit since 3.1.0).
-          GITHUB_TOKEN: ${{ github.token }}
+        # No token env needed: the side-ref push authenticates with the credential
+        # actions/checkout already persists (`contents: write` above + the default
+        # `persist-credentials: true`). The internal push runs with `--no-verify`
+        # so it never fires this repo's own pre-push guardrail hook (dxkit #156).
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
             DXKIT=./node_modules/.bin/vyuh-dxkit

--- a/src/baseline/anchor-publish.ts
+++ b/src/baseline/anchor-publish.ts
@@ -29,6 +29,7 @@ import { execFileSync } from 'child_process';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import * as path from 'path';
+import { internalGitPushArgs } from '../git-internal-push';
 
 export interface AnchorFile {
   /** Repo-relative path on the side ref (POSIX separators). */
@@ -55,8 +56,7 @@ export interface PublishToAnchorOptions {
   readonly timeoutMs?: number;
   /** Test seam: override the git executor. Production leaves this undefined and
    *  runs `git` via `execFileSync`; a test injects a spy to assert the exact
-   *  argv (e.g. the CI-auth extraheader reaches the push) without a real remote.
-   *  Receives the FULL argv including any prepended auth `-c …` config. */
+   *  argv (e.g. the push carries `--no-verify`) without a real remote. */
   readonly _exec?: (args: string[], input?: string) => string;
 }
 
@@ -70,41 +70,19 @@ export interface PublishResult {
 const DEFAULT_IDENTITY = { name: 'dxkit-bot', email: 'dxkit-bot@users.noreply.github.com' };
 
 /**
- * A credentialed HTTPS push URL for `originUrl` using the CI token, or `null`
- * when none applies. The load-bearing fix for the after-merge refresh regression
- * (gh #156): the 2.x refresh ran an inline `git push` inside the checkout, so it
- * reused the credential `actions/checkout` persists; when 3.1.0 moved the
- * refresh to this shared side-ref writer, the plumbing push stopped reusing that
- * ambient credential and hung → ETIMEDOUT with no auth. So when the workflow
- * exposes the CI token in the env (`GITHUB_TOKEN` / `GH_TOKEN` — GitHub Actions
- * only puts it there when the step maps `${{ github.token }}`), the writer
- * points `origin` at a token-credentialed URL for the operation (the mechanism
- * proven to authenticate in real Actions; an `http.extraheader` override did
- * NOT take — the real-CI smoke caught that).
+ * Turn a failed `git push` into an ACTIONABLE reason. A bare `push rejected:
+ * Command failed … ETIMEDOUT` reads as a mystery hang; the caller (and CI logs)
+ * need to know what stalled.
  *
- * HTTPS only — an SSH origin authenticates by key (BatchMode handles the no-key
- * case). Any credentials already in the URL are stripped first. No token →
- * `null`, and the push falls back to the ambient credential (local dev: the
- * user's credential helper / SSH agent), so nothing changes off-CI.
- */
-export function ciCredentialedUrl(
-  originUrl: string,
-  env: NodeJS.ProcessEnv = process.env,
-): string | null {
-  const token = env.GITHUB_TOKEN || env.GH_TOKEN;
-  if (!token) return null;
-  const m = /^https:\/\/(?:[^@/]*@)?(.+)$/.exec(originUrl); // strip any existing creds
-  if (!m) return null; // ssh:// or git@host:… — token URL does not apply
-  return `https://x-access-token:${token}@${m[1]}`;
-}
-
-/**
- * Turn a failed `git push` into an ACTIONABLE reason (gh #156). A bare
- * `push rejected: Command failed … ETIMEDOUT` reads as a mystery hang; the
- * caller (and CI logs) need to know it was a stuck/denied AUTH handshake and
- * what to check. A timeout after the prompt guards above almost always means
- * the remote never authenticated (the CI token lacks `contents: write`, or the
- * checkout didn't persist push credentials) rather than a slow network.
+ * gh #156 — the load-bearing lesson: DO NOT assert "auth" from a bare timeout.
+ * The original message here declared "the remote did not authenticate" on any
+ * timeout, and that single mislabel sent four debug builds chasing a
+ * non-existent credential bug. The REAL cause of the timeout was that the
+ * internal side-ref push fired the repo's own `pre-push` hook (dxkit's guardrail
+ * check), which ran past the `execFileSync` timeout and got SIGTERM'd
+ * mid-hook → ETIMEDOUT. That is now fixed at the source (the push runs with
+ * `--no-verify`, below), so a timeout here is a genuine transport/network stall,
+ * not auth and not a hook.
  */
 export function describePushFailure(err: Error, timeoutMs: number): string {
   const e = err as Error & { code?: string; signal?: string; killed?: boolean };
@@ -115,10 +93,9 @@ export function describePushFailure(err: Error, timeoutMs: number): string {
     /ETIMEDOUT|timed out/i.test(err.message);
   if (timedOut) {
     return (
-      `push timed out after ${Math.round(timeoutMs / 1000)}s with no response — the remote did ` +
-      `not authenticate. In GitHub Actions ensure the job grants \`contents: write\` and the ` +
-      `checkout persists push credentials (actions/checkout with \`persist-credentials: true\`); ` +
-      `locally ensure your git credential helper / SSH key can push to origin.`
+      `push did not complete within ${Math.round(timeoutMs / 1000)}s. The internal side-ref ` +
+      `push runs with \`--no-verify\` (so a project pre-push hook is not the cause); a persistent ` +
+      `timeout points at a stuck network/transport or an unreachable remote rather than auth.`
     );
   }
   if (/denied|forbidden|403|not authorized|authentication failed/i.test(err.message)) {
@@ -200,7 +177,7 @@ export function publishFilesToAnchorRef(opts: PublishToAnchorOptions): PublishRe
   // stall is a stuck auth handshake, not slow transport. Kept low so a hang
   // fails FAST with a clear reason instead of 60s of CI silence (gh #156).
   const timeout = opts.timeoutMs ?? 30_000;
-  const env = {
+  const env: NodeJS.ProcessEnv = {
     ...process.env,
     // BOTH prompt paths off so a push that would otherwise BLOCK on input fails
     // fast instead of hanging until the timeout: HTTPS credential prompts
@@ -226,17 +203,38 @@ export function publishFilesToAnchorRef(opts: PublishToAnchorOptions): PublishRe
       ...(input !== undefined ? { input } : {}),
       stdio: input !== undefined ? ['pipe', 'pipe', 'pipe'] : ['ignore', 'pipe', 'pipe'],
     }).toString();
-  // CI auth (gh #156): the plumbing writer does not reliably reuse the
-  // credential actions/checkout persists. When the env carries a CI token we
-  // point the NETWORK commands (fetch / ls-remote / push) DIRECTLY at a
-  // token-credentialed URL — the exact form a raw `git ls-remote` proves
-  // authenticates in Actions (a `set-url origin` rewrite or an
-  // `http.extraheader` override did NOT take — the real-CI smoke caught both).
-  // `credential.helper=` is disabled alongside so no ambient helper can hang the
-  // handshake. Off-CI (no token) `netRemote` stays `origin` and nothing changes.
-  const authPrefix: string[] = [];
+  // Auth is the ambient credential of `cwd` — in CI the one actions/checkout
+  // persists (`http.<host>.extraheader`); locally the git credential helper /
+  // SSH agent. We inject NOTHING: the whole gh #156 saga was a misdiagnosis
+  // (see `describePushFailure`) — a plain plumbing push always authenticated
+  // fine; the 30s "timeout" was the internal push firing the repo's own
+  // `pre-push` guardrail hook and getting SIGTERM'd mid-hook. The real fix is
+  // `--no-verify` on the push (below), not any credential handling.
   const exec = opts._exec ?? realExec;
-  const git = (args: string[], input?: string): string => exec([...authPrefix, ...args], input);
+  // Diagnosability (gh #156): with DXKIT_DEBUG set, trace every git command and
+  // how long it took, so a stall shows exactly which command hung (this is what
+  // finally surfaced the pre-push hook as the cause). Any embedded credential in
+  // a URL is masked.
+  const debugOn = !!env.DXKIT_DEBUG;
+  const mask = (s: string): string =>
+    s.replace(/x-access-token:[^@]+@/g, 'x-access-token:***@').replace(/(:\/\/)[^@/]+@/g, '$1***@');
+  const dbg = (msg: string): void => {
+    if (debugOn) process.stderr.write(`[dxkit-anchor] ${mask(msg)}\n`);
+  };
+  const git = (args: string[], input?: string): string => {
+    if (!debugOn) return exec(args, input);
+    const started = Date.now();
+    try {
+      const out = exec(args, input);
+      dbg(`git ${args.join(' ')}  (${Date.now() - started}ms)`);
+      return out;
+    } catch (err) {
+      dbg(
+        `git ${args.join(' ')}  FAILED after ${Date.now() - started}ms: ${(err as Error).message}`,
+      );
+      throw err;
+    }
+  };
 
   try {
     // Confirm a remote exists — no origin ⇒ nothing to publish to.
@@ -246,12 +244,7 @@ export function publishFilesToAnchorRef(opts: PublishToAnchorOptions): PublishRe
     } catch {
       return { pushed: false, commit: null, reason: 'no origin remote' };
     }
-    const credUrl = ciCredentialedUrl(originUrl, env);
-    // The remote for every NETWORK op below: the credentialed URL in CI, else
-    // `origin`. Fetching by URL does not update `origin/<ref>` on its own, so the
-    // fetch below carries an explicit refspec that does (resolveTip reads it).
-    const netRemote = credUrl ?? 'origin';
-    if (credUrl) authPrefix.push('-c', 'credential.helper=');
+    dbg(`origin=${mask(originUrl)} · push=ambient-credential · hook=skipped (--no-verify)`);
 
     const buildAndPush = (): PublishResult => {
       const baseParent = opts.baseParent !== false;
@@ -260,15 +253,9 @@ export function publishFilesToAnchorRef(opts: PublishToAnchorOptions): PublishRe
       // `origin/<ref>` on every git version, and this also picks up a
       // concurrent merge's advance before we build. Both modes need it:
       // accumulate bases the commit on it, replace-all compares against it for
-      // the no-change skip below. Explicit refspec so a URL fetch updates
-      // `origin/<ref>` too.
+      // the no-change skip below.
       try {
-        git([
-          'fetch',
-          '--depth=1',
-          netRemote,
-          `+refs/heads/${anchorRef}:refs/remotes/origin/${anchorRef}`,
-        ]);
+        git(['fetch', '--depth=1', 'origin', anchorRef]);
       } catch {
         /* first publish (ref absent) / offline — resolveTip returns null */
       }
@@ -306,7 +293,7 @@ export function publishFilesToAnchorRef(opts: PublishToAnchorOptions): PublishRe
       if (
         remoteTip &&
         tree === remoteTip.tree &&
-        remoteRefExists(git, netRemote, anchorRef) !== false
+        remoteRefExists(git, 'origin', anchorRef) !== false
       ) {
         return { pushed: false, commit: null, reason: 'no change' };
       }
@@ -314,17 +301,18 @@ export function publishFilesToAnchorRef(opts: PublishToAnchorOptions): PublishRe
       if (tip) commitArgs.push('-p', tip.commit);
       const commit = git(commitArgs).trim();
 
-      // Accumulate: a plain (fast-forward) push; a concurrent-merge rejection is
-      // retried once below. Replace-all (`baseParent:false`, latest-wins like the
-      // baseline anchor): a parentless commit is non-fast-forward by design, so
-      // force-overwrite the ref.
       const pushRefspec = `${commit}:refs/heads/${anchorRef}`;
-      const pushArgs =
-        baseParent === false
-          ? ['push', '--force', netRemote, pushRefspec]
-          : ['push', netRemote, pushRefspec];
+      // The push routes through `internalGitPushArgs` — the ONE constructor that
+      // guarantees `--no-verify` (gh #156: this is a machine push of a dxkit-owned
+      // side ref; running the repo's pre-push guardrail hook here is what caused
+      // the ETIMEDOUT the fix chased as auth for four builds). Accumulate: plain
+      // fast-forward push (a concurrent-merge rejection is retried once below).
+      // Replace-all (`baseParent:false`, latest-wins): a parentless commit is
+      // non-fast-forward by design, so force-overwrite.
+      const pushArgs = internalGitPushArgs(pushRefspec, { force: baseParent === false });
       try {
         git(pushArgs);
+        dbg('push succeeded (ambient credential, hook skipped)');
         return { pushed: true, commit };
       } catch (err) {
         return { pushed: false, commit, reason: describePushFailure(err as Error, timeout) };
@@ -336,12 +324,7 @@ export function publishFilesToAnchorRef(opts: PublishToAnchorOptions): PublishRe
     // the commit onto the new tip once.
     if (!result.pushed && result.reason?.startsWith('push rejected') && opts.baseParent !== false) {
       try {
-        git([
-          'fetch',
-          '--depth=1',
-          netRemote,
-          `+refs/heads/${anchorRef}:refs/remotes/origin/${anchorRef}`,
-        ]);
+        git(['fetch', '--depth=1', 'origin', anchorRef]);
       } catch {
         /* offline — the retry will just fail again, returning the rejection */
       }

--- a/src/git-internal-push.ts
+++ b/src/git-internal-push.ts
@@ -1,0 +1,38 @@
+/**
+ * The ONE constructor for a dxkit-INTERNAL (machine) `git push` argv.
+ *
+ * Every push dxkit performs ITSELF — side-ref anchors (`baseline publish` /
+ * `report snapshot` via `src/baseline/anchor-publish.ts`) and refresh lands (flow
+ * contract / extension snapshots via `src/land-refresh.ts`) — is a MACHINE
+ * operation, never a gated developer push. It therefore MUST carry `--no-verify`.
+ *
+ * Why (gh #156, load-bearing): an internal push runs `git` in a checkout where
+ * `core.hooksPath=.githooks` is active whenever dxkit is installed with git
+ * hooks. Without `--no-verify` the push fires the repo's OWN `pre-push` hook —
+ * dxkit's `guardrail check` — as a side effect of a machine refresh. Under the
+ * bounded exec timeout every internal push wraps that in, the hook is SIGTERM'd
+ * mid-run → ETIMEDOUT. That timeout was misread as "the remote did not
+ * authenticate" and cost four debug builds chasing a non-existent auth bug; the
+ * push never even reached the network. Skipping the hook is the fix, and it's
+ * also just correct: dxkit must not run a developer's pre-push gate against its
+ * own bot commits.
+ *
+ * A developer's own `git push` stays fully gated — that push is the human's and
+ * does NOT go through dxkit. dxkit gates its own machine pushes never.
+ *
+ * `scripts/check-architecture.sh` bans a raw `['push', …]` git argv anywhere in
+ * `src/` except this module, so a future internal push cannot silently drop the
+ * flag and reintroduce the class.
+ */
+export function internalGitPushArgs(
+  refspec: string,
+  opts: { readonly force?: boolean; readonly remote?: string } = {},
+): string[] {
+  return [
+    'push',
+    '--no-verify',
+    ...(opts.force ? ['--force'] : []),
+    opts.remote ?? 'origin',
+    refspec,
+  ];
+}

--- a/src/land-refresh.ts
+++ b/src/land-refresh.ts
@@ -20,6 +20,7 @@
  * lander so the two consumers cannot drift (Rule 2).
  */
 import { execFileSync } from 'child_process';
+import { internalGitPushArgs } from './git-internal-push';
 
 export type LandMode = 'pr' | 'push';
 
@@ -104,7 +105,9 @@ export function landRefreshPaths(opts: LandRefreshOptions): LandRefreshResult {
 
   if (opts.mode === 'push') {
     commit(`${opts.commitTitle} [skip ci]`);
-    exec('git', ['push', 'origin', `HEAD:${opts.defaultBranch}`]);
+    // Internal machine push → `--no-verify` (gh #156): must not fire the repo's
+    // own pre-push guardrail hook against a bot refresh commit.
+    exec('git', internalGitPushArgs(`HEAD:${opts.defaultBranch}`));
     return { outcome: 'pushed', mode: 'push' };
   }
 
@@ -115,7 +118,8 @@ export function landRefreshPaths(opts: LandRefreshOptions): LandRefreshResult {
   const priorRef = exec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { allowFail: true }).trim();
   exec('git', ['checkout', '-B', opts.branchName]);
   commit(`${opts.prTitle}\n\n[skip ci]`);
-  exec('git', ['push', '--force', 'origin', opts.branchName]);
+  // Internal machine push → `--no-verify` (gh #156), same reason as the push mode.
+  exec('git', internalGitPushArgs(opts.branchName, { force: true }));
   if (priorRef && priorRef !== 'HEAD' && priorRef !== opts.branchName) {
     exec('git', ['checkout', priorRef], { allowFail: true });
   }

--- a/test/baseline/anchor-publish.test.ts
+++ b/test/baseline/anchor-publish.test.ts
@@ -3,8 +3,8 @@ import { execFileSync } from 'child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { existsSync, chmodSync } from 'fs';
 import {
-  ciCredentialedUrl,
   describePushFailure,
   publishFilesToAnchorRef,
   readFromAnchorRef,
@@ -18,11 +18,6 @@ import {
  * touching the checkout's working tree or index (verified via `git status`).
  */
 const ANCHOR = 'dxkit-reports';
-
-// A placeholder token spelled indirectly so dxkit's OWN secret scanner does not
-// flag these fixtures as a real credential (no `x-access-token:<literal>@…` in
-// source). The value is irrelevant — only that it flows through the auth logic.
-const FAKE_TOKEN = ['fake', 'token'].join('-');
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).toString();
@@ -244,20 +239,66 @@ describe('publishFilesToAnchorRef', () => {
     // Fast-fail: nowhere near the timeout.
     expect(Date.now() - start).toBeLessThan(9_000);
   });
+
+  it('publishes even when a repo pre-push hook would block the push — runs --no-verify (gh #156)', () => {
+    // THE root-cause regression test. dxkit's internal side-ref push is a machine
+    // push; when dxkit is installed with git hooks, `core.hooksPath` is active in
+    // the checkout, so a plain `git push` fires the repo's pre-push hook (dxkit's
+    // own guardrail check) — which, under the exec timeout, got SIGTERM'd mid-run
+    // → ETIMEDOUT, the "hang" #156 chased as an auth failure for four builds.
+    // Wire a pre-push hook that BLOCKS any ordinary push, then assert the
+    // primitive still publishes (it passes --no-verify) and the hook never fired.
+    const hooks = mkdtempSync(join(tmpdir(), 'dxkit-anchor-hooks-'));
+    const sentinel = join(hooks, 'fired');
+    const hook = join(hooks, 'pre-push');
+    writeFileSync(hook, `#!/bin/sh\necho fired > "${sentinel}"\nexit 1\n`);
+    chmodSync(hook, 0o755);
+    git(repo, 'config', 'core.hooksPath', hooks);
+    try {
+      // Sanity: an ordinary push MUST be blocked by the hook (else the test is moot).
+      let ordinaryBlocked = false;
+      try {
+        git(repo, 'push', 'origin', 'HEAD:refs/heads/ordinary-probe');
+      } catch {
+        ordinaryBlocked = true;
+      }
+      expect(ordinaryBlocked).toBe(true);
+      if (existsSync(sentinel)) rmSync(sentinel); // reset before the real assertion
+
+      const res = publishFilesToAnchorRef({
+        cwd: repo,
+        anchorRef: ANCHOR,
+        files: [{ path: 'baselines/main.json', content: '{}\n' }],
+        baseParent: false,
+        message: 'refresh under a blocking pre-push hook',
+      });
+      // Skipped the hook → the push landed ...
+      expect(res.pushed).toBe(true);
+      // ... and the pre-push hook never fired.
+      expect(existsSync(sentinel)).toBe(false);
+      expect(readFromAnchorRef(repo, ANCHOR, 'baselines/main.json')).toBe('{}\n');
+    } finally {
+      git(repo, 'config', '--unset', 'core.hooksPath');
+      rmSync(hooks, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('describePushFailure (gh #156 categorization)', () => {
-  it('categorizes a timeout as a stuck auth handshake with an actionable hint', () => {
+  it('does NOT assert auth for a bare timeout — the mislabel that cost four builds', () => {
     const err = Object.assign(new Error('spawnSync git ETIMEDOUT'), { code: 'ETIMEDOUT' });
     const reason = describePushFailure(err, 30_000);
-    expect(reason).toMatch(/timed out after 30s/);
-    expect(reason).toMatch(/contents: write/);
-    expect(reason).toMatch(/persist-credentials/);
+    expect(reason).toMatch(/did not complete within 30s/);
+    expect(reason).toMatch(/--no-verify/);
+    // The old message asserted the remote "did not authenticate" — the exact
+    // mislabel that sent four debug builds chasing a non-existent auth bug.
+    expect(reason).not.toMatch(/did not authenticate/i);
+    expect(reason).not.toMatch(/persist-credentials/);
   });
 
   it('categorizes a SIGTERM-killed push (timeout kill) as a timeout too', () => {
     const err = Object.assign(new Error('Command failed'), { signal: 'SIGTERM', killed: true });
-    expect(describePushFailure(err, 15_000)).toMatch(/timed out after 15s/);
+    expect(describePushFailure(err, 15_000)).toMatch(/did not complete within 15s/);
   });
 
   it('categorizes a permission denial distinctly', () => {
@@ -272,62 +313,21 @@ describe('describePushFailure (gh #156 categorization)', () => {
   });
 });
 
-describe('ciCredentialedUrl (gh #156 — CI token push auth)', () => {
-  const TOKEN = FAKE_TOKEN;
-
-  it('builds a token-credentialed URL for an HTTPS origin when a token is present', () => {
-    expect(ciCredentialedUrl('https://github.com/acme/widgets.git', { GITHUB_TOKEN: TOKEN })).toBe(
-      `https://x-access-token:${TOKEN}@github.com/acme/widgets.git`,
-    );
-  });
-
-  it('preserves the actual host (GitHub Enterprise)', () => {
-    expect(
-      ciCredentialedUrl('https://ghe.corp.example/acme/widgets.git', { GH_TOKEN: TOKEN }),
-    ).toBe(`https://x-access-token:${TOKEN}@ghe.corp.example/acme/widgets.git`);
-  });
-
-  it('strips any credentials already in the origin URL', () => {
-    expect(
-      ciCredentialedUrl('https://old@github.com/acme/widgets.git', { GITHUB_TOKEN: TOKEN }),
-    ).toBe(`https://x-access-token:${TOKEN}@github.com/acme/widgets.git`);
-  });
-
-  it('returns null when no token is in the env (falls back to ambient creds)', () => {
-    expect(ciCredentialedUrl('https://github.com/acme/widgets.git', {})).toBeNull();
-  });
-
-  it('returns null for an SSH origin (token URL does not apply)', () => {
-    expect(
-      ciCredentialedUrl('git@github.com:acme/widgets.git', { GITHUB_TOKEN: TOKEN }),
-    ).toBeNull();
-    expect(
-      ciCredentialedUrl('ssh://git@github.com/acme/widgets.git', { GH_TOKEN: TOKEN }),
-    ).toBeNull();
-  });
-});
-
 /**
- * End-to-end auth wiring through the primitive, via the injected exec seam — no
- * real remote needed. Proves the primitive points `origin` at the credentialed
- * URL for the operation (then restores it), and does NOT for the no-token / SSH
- * cases. The REAL auth (that the URL actually authenticates GitHub) is proven by
- * `.github/workflows/anchor-auth-smoke.yml` — a mock cannot cover that.
+ * Seam test (injected git exec, no real remote): every side-ref push carries
+ * `--no-verify` so the internal machine push never fires the repo's pre-push
+ * hook (gh #156). Both modes — replace-all (force) and accumulate — are covered.
+ * The REAL end-to-end proof (that --no-verify actually skips a live hook) is the
+ * real-git test above plus `.github/workflows/anchor-auth-smoke.yml`.
  */
-describe('publishFilesToAnchorRef — origin gets the credentialed URL for CI auth (gh #156)', () => {
-  /** A git spy that records every invocation and returns canned output so the
-   *  writer completes a full replace-all publish without a real remote. `remote
-   *  get-url` reports `originUrl`; `rev-parse` throws so `resolveTip` sees an
-   *  absent ref (first-publish path). */
+describe('publishFilesToAnchorRef — the push always runs --no-verify (gh #156)', () => {
   function gitSpy(originUrl: string) {
     const calls: string[][] = [];
     const exec = (args: string[]): string => {
       calls.push(args);
-      let i = 0;
-      while (args[i] === '-c') i += 2; // skip a prepended `-c credential.helper=`
-      switch (args[i]) {
+      switch (args[0]) {
         case 'remote':
-          return args[i + 1] === 'get-url' ? originUrl + '\n' : '';
+          return args[1] === 'get-url' ? originUrl + '\n' : '';
         case 'rev-parse':
           throw new Error('unknown revision'); // resolveTip → null (first publish)
         case 'hash-object':
@@ -338,60 +338,38 @@ describe('publishFilesToAnchorRef — origin gets the credentialed URL for CI au
           return '';
       }
     };
-    return { calls, exec };
+    return { calls, exec, pushCall: () => calls.find((c) => c.includes('push')) ?? [] };
   }
 
-  const pushCall = (calls: string[][]) => calls.find((c) => c.includes('push')) ?? [];
-
-  let saved: { gh?: string; ghp?: string };
-  beforeEach(() => {
-    saved = { gh: process.env.GITHUB_TOKEN, ghp: process.env.GH_TOKEN };
-    delete process.env.GITHUB_TOKEN;
-    delete process.env.GH_TOKEN;
-  });
-  afterEach(() => {
-    if (saved.gh === undefined) delete process.env.GITHUB_TOKEN;
-    else process.env.GITHUB_TOKEN = saved.gh;
-    if (saved.ghp === undefined) delete process.env.GH_TOKEN;
-    else process.env.GH_TOKEN = saved.ghp;
-  });
-
-  const publish = (exec: (a: string[], i?: string) => string) =>
-    publishFilesToAnchorRef({
+  it('replace-all (baseParent:false) force-pushes with --no-verify', () => {
+    const spy = gitSpy('https://github.com/acme/widgets.git');
+    const res = publishFilesToAnchorRef({
       cwd: '/tmp/x',
       anchorRef: 'dxkit-baselines',
       files: [{ path: 'baselines/main.json', content: '{}' }],
       message: 'refresh',
       baseParent: false,
-      _exec: exec,
+      _exec: spy.exec,
     });
-
-  it('pushes DIRECTLY to the credentialed URL when HTTPS + GITHUB_TOKEN', () => {
-    process.env.GITHUB_TOKEN = FAKE_TOKEN;
-    const { calls, exec } = gitSpy('https://github.com/acme/widgets.git');
-    expect(publish(exec).pushed).toBe(true);
-    const push = pushCall(calls);
-    // The push targets the credentialed URL itself (the proven raw form), NOT
-    // the bare `origin`, and disables any ambient credential helper.
-    expect(push).toContain(`https://x-access-token:${FAKE_TOKEN}@github.com/acme/widgets.git`);
-    expect(push).not.toContain('origin');
-    expect(push.slice(0, 2)).toEqual(['-c', 'credential.helper=']);
+    expect(res.pushed).toBe(true);
+    const push = spy.pushCall();
+    expect(push).toContain('--no-verify');
+    expect(push).toContain('--force');
+    expect(push).toContain('origin');
   });
 
-  it('pushes to `origin` (ambient creds) when no token is present', () => {
-    const { calls, exec } = gitSpy('https://github.com/acme/widgets.git');
-    expect(publish(exec).pushed).toBe(true);
-    const push = pushCall(calls);
+  it('accumulate (default) pushes with --no-verify', () => {
+    const spy = gitSpy('https://github.com/acme/widgets.git');
+    const res = publishFilesToAnchorRef({
+      cwd: '/tmp/x',
+      anchorRef: 'dxkit-reports',
+      files: [{ path: 'report-history.jsonl', content: '{}\n' }],
+      message: 'snapshot',
+      _exec: spy.exec,
+    });
+    expect(res.pushed).toBe(true);
+    const push = spy.pushCall();
+    expect(push).toContain('--no-verify');
     expect(push).toContain('origin');
-    expect(push).not.toContain('-c');
-  });
-
-  it('pushes to `origin` for an SSH origin even with a token set (token URL n/a)', () => {
-    process.env.GITHUB_TOKEN = FAKE_TOKEN;
-    const { calls, exec } = gitSpy('git@github.com:acme/widgets.git');
-    expect(publish(exec).pushed).toBe(true);
-    const push = pushCall(calls);
-    expect(push).toContain('origin');
-    expect(push).not.toContain('-c');
   });
 });

--- a/test/flow-land.test.ts
+++ b/test/flow-land.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'child_process';
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -118,6 +118,38 @@ describe('landFlowRefresh (real git)', () => {
     const log = git(bare, 'log', '-1', '--format=%s', 'main');
     expect(log).toContain('[skip ci]');
     expect(git(bare, 'show', 'main:.dxkit/flow/served.json')).toContain('"/new"');
+  });
+
+  it('push mode runs --no-verify — a blocking pre-push hook does not stop the land (gh #156)', () => {
+    // The SECOND internal-push consumer (land-refresh). Same class as the anchor
+    // writer: a machine push must not fire the repo's pre-push guardrail hook.
+    // Wire a hook that BLOCKS any ordinary push, then assert the land still pushes.
+    const hooks = mkdtempSync(join(tmpdir(), 'dxkit-land-hooks-'));
+    const sentinel = join(hooks, 'fired');
+    const hook = join(hooks, 'pre-push');
+    writeFileSync(hook, `#!/bin/sh\necho fired > "${sentinel}"\nexit 1\n`);
+    chmodSync(hook, 0o755);
+    git(repo, 'config', 'core.hooksPath', hooks);
+    try {
+      let blocked = false;
+      try {
+        git(repo, 'push', 'origin', 'HEAD:refs/heads/ordinary-probe');
+      } catch {
+        blocked = true;
+      }
+      expect(blocked).toBe(true); // the hook really blocks a normal push
+      if (existsSync(sentinel)) rmSync(sentinel);
+
+      const before = contract(['GET /a']);
+      writeSnapshot(['GET /a', 'POST /new']);
+      const out = landFlowRefresh({ cwd: repo, mode: 'push', before, defaultBranch: 'main' });
+      expect(out.outcome).toBe('pushed'); // landed despite the blocking hook
+      expect(existsSync(sentinel)).toBe(false); // the hook never fired (--no-verify)
+      expect(git(bare, 'show', 'main:.dxkit/flow/served.json')).toContain('"/new"');
+    } finally {
+      git(repo, 'config', '--unset', 'core.hooksPath');
+      rmSync(hooks, { recursive: true, force: true });
+    }
   });
 
   it('pr mode pushes the standing branch and degrades gracefully without gh', () => {

--- a/test/git-internal-push.test.ts
+++ b/test/git-internal-push.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { internalGitPushArgs } from '../src/git-internal-push';
+
+/**
+ * The one constructor for a dxkit-internal machine push (gh #156). Its whole job
+ * is to GUARANTEE `--no-verify` so the push never fires the repo's pre-push
+ * guardrail hook. The arch-check bans a raw `['push', …]` git argv elsewhere, so
+ * this is the single place the flag can be present or absent — pin it hard.
+ */
+describe('internalGitPushArgs (gh #156 — --no-verify is guaranteed)', () => {
+  it('always emits --no-verify, immediately after push', () => {
+    const args = internalGitPushArgs('HEAD:refs/heads/main');
+    expect(args.slice(0, 2)).toEqual(['push', '--no-verify']);
+    expect(args).toEqual(['push', '--no-verify', 'origin', 'HEAD:refs/heads/main']);
+  });
+
+  it('adds --force for a replace-all / non-fast-forward push, still with --no-verify', () => {
+    expect(internalGitPushArgs('sha:refs/heads/dxkit-baselines', { force: true })).toEqual([
+      'push',
+      '--no-verify',
+      '--force',
+      'origin',
+      'sha:refs/heads/dxkit-baselines',
+    ]);
+  });
+
+  it('honors a custom remote', () => {
+    expect(internalGitPushArgs('feature', { remote: 'upstream' })).toEqual([
+      'push',
+      '--no-verify',
+      'upstream',
+      'feature',
+    ]);
+  });
+
+  it('--no-verify is present in EVERY shape (force × remote matrix)', () => {
+    for (const force of [true, false]) {
+      for (const remote of [undefined, 'origin', 'upstream']) {
+        const args = internalGitPushArgs('ref', { force, ...(remote ? { remote } : {}) });
+        expect(args[0]).toBe('push');
+        expect(args).toContain('--no-verify');
+      }
+    }
+  });
+});


### PR DESCRIPTION
## The real root cause of #156

The 30s `ETIMEDOUT` on the anchor/refresh push was **never auth**. `baseline publish` / `report snapshot` run `git push` in the checkout where `core.hooksPath=.githooks` is active whenever dxkit is installed with git hooks — so the push fired dxkit's **own `pre-push` guardrail hook** as a side effect of a machine refresh. Under the bounded exec timeout that hook was SIGTERM'd mid-run → `ETIMEDOUT`, which `describePushFailure` mislabeled as "the remote did not authenticate" — the one mislabel that sent 3.7.1–3.7.3 chasing a phantom credential bug.

- Fetch always worked → fetch fires no hook.
- A developer's bash `git push` worked → no exec timeout to kill the hook.
- Every auth strategy failed identically → none reached the network.

## The fix (one flag)

dxkit's internal machine pushes run `git push --no-verify` — they must not run the repo's pre-push gate against a bot commit. **Verified end-to-end on a real hook-active repo (gcs-web baseline refresh is green).** Fixes both side-ref publishers (baseline branch-anchor refresh + reports snapshot) via the one shared writer.

## Reverts the 3.7.3 credential machinery

Built on the misdiagnosis — the ambient checkout credential always authenticated. Removes the injected token extraheader, the `GITHUB_TOKEN` env in the generated refresh workflows, and the "did not authenticate" timeout mislabel.

## Class-level guard (root, not just the symptom)

A second latent site — the flow/reports `--land push` mode in `src/land-refresh.ts` — carried the identical bug. Now:

- **One constructor** `internalGitPushArgs` (`src/git-internal-push.ts`) always emits `--no-verify`; both consumers route through it.
- **Arch gate** — `check-architecture.sh` bans a raw `['push', …]` git argv in `src/` outside the helper (verified it fails on a rogue push).
- **Regression tests** — a genuinely blocking `pre-push` hook the push must skip, one per consumer, plus the constructor matrix and the corrected `describePushFailure` test.

## Verification

- gcs-web baseline refresh workflow: **green** (real hook-active repo)
- Full suite: **4099 passing**, arch exit 0, lint 0, prettier clean

Closes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)