### PR TITLE
feat(ingest): fail open on engine infrastructure failure when a snapshot exists

### DIFF
--- a/src-templates/.claude/skills/dxkit-ingest/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-ingest/SKILL.md
@@ -94,6 +94,14 @@ Ingested findings flow through the same aggregate as native findings, so they ap
 
 Add a scheduled refresh (mirrors `dxkit-baseline-refresh`): a CI job with the `SNYK_TOKEN` secret runs `ingest --from-snyk` and commits the updated snapshot. The bundled `--with-deep-sast-refresh` workflow (`workflow_dispatch`) does exactly this; its `method` input picks `api` (Enterprise, quota-free) or `cli` (free/team, one test per run). The ingested findings are a point-in-time snapshot of the engine's last scan — re-ingest after the engine re-scans.
 
+### When the refresh itself fails
+
+The gate never calls the engine live — it reads the committed snapshot — so an engine failure cannot block a PR. The refresh degrades accordingly:
+
+- **Infrastructure failure** (quota exhausted, rate limit, auth, network) with a prior snapshot on disk: the run prints `refresh skipped: <engine> — <reason>`, keeps the snapshot, and **exits 0**. The gate keeps enforcing against the last good snapshot. Fix the engine access (top up the quota, rotate the token) and re-run ingest; nothing else is wrong.
+- **Genuine failure** (bad config, malformed engine output), or an infra failure with **no** prior snapshot to fall back to: **exits 1** — this needs fixing, not waiting out.
+- A snapshot that keeps aging because the refresh is chronically failing open shows up in `doctor` as `external <engine> snapshot fresh (Nd old)` failing past 30 days, with the repair command. If a user asks why deep-SAST findings look outdated, run `doctor` and look for that check.
+
 ## Hand-offs
 
 - To fix the ingested findings → `dxkit-action` (it reads them like any code finding).

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -14,6 +14,8 @@ import { detectEnforcement } from './enforcement';
 import { detectInstalledRefreshTransport, detectDefaultBranch } from './ship-installers';
 import { detectPackageManager, addDevCommand } from './package-manager';
 import { loadAllowlist, auditAllowlist } from './allowlist/file';
+import { snapshotEngines, readSnapshot } from './ingest/snapshot';
+import { EXTERNAL_SNAPSHOT_STALE_DAYS, snapshotAgeDays } from './ingest/engine-failure';
 import { diagnoseFlow, type FlowDiagnosis } from './analyzers/flow/diagnose';
 import { gatherRecommendations, type CommandRecommendation } from './discovery/commands';
 
@@ -895,6 +897,44 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
         tier: 'operational',
       });
     }
+  }
+
+  // 8. External deep-SAST snapshot freshness. The ingest refresh fails
+  // OPEN on infrastructure (quota / rate limit / auth / network): it
+  // keeps the committed snapshot and exits 0, so a chronically-broken
+  // refresh never reds a pipeline — this check is where that breakage
+  // becomes visible instead. Only emits when snapshots exist.
+  const now = new Date();
+  for (const engine of snapshotEngines(cwd)) {
+    const snap = readSnapshot(cwd, engine);
+    if (!snap) continue;
+    const age = snapshotAgeDays(snap.generatedAt, now);
+    if (age === null) continue;
+    const fresh = age <= EXTERNAL_SNAPSHOT_STALE_DAYS;
+    const refreshCommand =
+      engine === 'snyk-code'
+        ? dxkitCli('ingest --from-snyk')
+        : engine === 'codeql'
+          ? dxkitCli('ingest --codeql')
+          : undefined;
+    checks.push({
+      label: `external ${engine} snapshot fresh (${age}d old)`,
+      ok: fresh,
+      tier: 'operational',
+      ...(fresh
+        ? {}
+        : {
+            fix: {
+              hint:
+                `The committed ${engine} snapshot is ${age} days old (threshold: ` +
+                `${EXTERNAL_SNAPSHOT_STALE_DAYS}d). The gate is still using it, but its findings no ` +
+                `longer reflect the current code. The refresh may be failing open on an ` +
+                `infrastructure problem (quota / rate limit / auth) — check the ` +
+                `dxkit-deep-sast-refresh workflow logs, fix the engine access, and re-run ingest.`,
+              ...(refreshCommand ? { command: refreshCommand } : {}),
+            },
+          }),
+    });
   }
 
   return checks;

--- a/src/ingest-cli.ts
+++ b/src/ingest-cli.ts
@@ -27,6 +27,7 @@ import { fetchSnykCodeFindings } from './ingest/snyk-api';
 import { runSnykCodeTest } from './ingest/snyk-cli';
 import { runCodeql, type CodeqlTarget } from './ingest/codeql';
 import { readDeepSastConfig } from './ingest/config';
+import { resolveEngineFailure, failureMessage } from './ingest/engine-failure';
 import { loadSnykEnv } from './ingest/env-file';
 import { writeSnapshot } from './ingest/snapshot';
 import { detectActiveLanguages } from './languages/index';
@@ -105,8 +106,7 @@ async function ingestFromCodeql(cwd: string, opts: IngestOptions): Promise<void>
   try {
     findings = await runCodeql({ cwd, targets, onLog: (m) => logger.dim(`  ${m}`) });
   } catch (err) {
-    logger.warn(`CodeQL run failed: ${(err as Error).message}`);
-    process.exitCode = 1;
+    reportEngineFailure(cwd, 'codeql', err, 'CodeQL run failed');
     return;
   }
   writeAndReport(cwd, 'codeql', findings, opts);
@@ -133,6 +133,38 @@ function ingestFromSarif(cwd: string, opts: IngestOptions): void {
  *  only entitlement. We fall back to the CLI (Snyk Code product) path. */
 export function isNotEntitled(message: string): boolean {
   return /\b403\b/.test(message) || /not entitled/i.test(message) || /api access/i.test(message);
+}
+
+/**
+ * The ONE engine-failure exit policy (every engine catch routes here).
+ * Infrastructure failure (quota / rate limit / auth / network) with a
+ * prior committed snapshot → keep the snapshot, disclose the skip,
+ * exit 0: the gate reads the committed snapshot, never a live engine,
+ * so a red refresh the team learns to ignore is strictly worse than a
+ * stale-but-present snapshot. Anything else stays exit 1.
+ */
+function reportEngineFailure(cwd: string, engine: string, err: unknown, what: string): void {
+  const disposition = resolveEngineFailure(cwd, engine, failureMessage(err));
+  if (disposition.action === 'degrade') {
+    logger.warn(`refresh skipped: ${engine} — ${disposition.reason}`);
+    logger.dim(
+      '  This is an infrastructure failure (quota / rate limit / auth / network), not a code problem.',
+    );
+    logger.dim(
+      `  The gate continues on the committed snapshot from ${disposition.snapshotGeneratedAt}. ` +
+        'Fix the engine access and re-run ingest to refresh it.',
+    );
+    return;
+  }
+  logger.warn(`${what}: ${disposition.reason}`);
+  if (disposition.infra) {
+    logger.dim(
+      // Display string naming the path for the user, not snapshot access.
+      `  This looks like an infrastructure failure, but no prior .dxkit/external/${engine}.json ` + // ingest-snapshot-ok
+        'snapshot exists to fall back to — fix the engine access (token / quota / network) and retry.',
+    );
+  }
+  process.exitCode = 1;
 }
 
 async function ingestFromSnyk(cwd: string, opts: IngestOptions): Promise<void> {
@@ -210,8 +242,7 @@ async function ingestFromSnyk(cwd: string, opts: IngestOptions): Promise<void> {
       await ingestViaSnykCli(cwd, opts, orgId);
       return;
     }
-    logger.warn(`Snyk read failed: ${message}`);
-    process.exitCode = 1;
+    reportEngineFailure(cwd, 'snyk-code', err, 'Snyk read failed');
     return;
   }
   writeAndReport(cwd, 'snyk-code', findings, opts);
@@ -228,8 +259,7 @@ async function ingestViaSnykCli(
   try {
     findings = await runSnykCodeTest({ cwd, org: orgId, onLog: (m) => logger.dim(`  ${m}`) });
   } catch (err) {
-    logger.warn(`Snyk Code test failed: ${(err as Error).message}`);
-    process.exitCode = 1;
+    reportEngineFailure(cwd, 'snyk-code', err, 'Snyk Code test failed');
     return;
   }
   writeAndReport(cwd, 'snyk-code', findings, opts);

--- a/src/ingest/engine-failure.ts
+++ b/src/ingest/engine-failure.ts
@@ -1,0 +1,129 @@
+/**
+ * Graceful engine-failure degradation.
+ *
+ * The ingest CLI refreshes `.dxkit/external/<engine>.json`. The GATE
+ * never calls an engine live — it reads the committed snapshot — so an
+ * engine failure can never block a PR. What it CAN do is red the
+ * refresh job, and a quota / rate-limit / auth / network failure is
+ * infrastructure, not a code problem: a red check the team learns to
+ * ignore is worse than a stale-but-present snapshot.
+ *
+ * Policy — the same fail-open-on-infrastructure stance as the
+ * correctness floor (Rule 15) and custom checks (Rule 17): when the
+ * failure is infrastructure AND a prior snapshot exists, keep the
+ * snapshot, disclose the skip, and exit 0. A GENUINE failure (bad
+ * config, malformed output, a real analysis error) — or an infra
+ * failure with NO snapshot to fall back to — still exits 1 so it gets
+ * fixed. Fail-open is never silent (the GateFailure discipline): the
+ * skip names the engine, the reason, and the snapshot date the gate
+ * continues on, and `doctor` surfaces a chronically stale snapshot so
+ * a permanently-broken refresh cannot hide behind the fail-open.
+ */
+import { readSnapshot } from './snapshot';
+
+/**
+ * True when an engine error message describes an infrastructure
+ * failure — quota exhaustion, rate limiting, auth, or network — rather
+ * than a genuine analysis/configuration failure. Sibling of
+ * `isNotEntitled` (ingest-cli), which handles the one 403 that has a
+ * better remedy than degrading (the REST→CLI plan fallback).
+ *
+ * Bias: moderate breadth is safe here because misclassifying a genuine
+ * failure as infra degrades to a stale snapshot that doctor's
+ * staleness check surfaces, while the reverse (infra read as genuine)
+ * re-introduces the red-pipeline failure mode this exists to fix.
+ */
+export function isEngineInfraFailure(message: string): boolean {
+  return (
+    // Quota / plan limits (Snyk: "You have used your limit of private tests").
+    /\bquota\b/i.test(message) ||
+    /rate.?limit/i.test(message) ||
+    /(used your|reached the|exceeded (the|your)|over the) .{0,20}limit/i.test(message) ||
+    /limit (of|reached|exceeded)/i.test(message) ||
+    // HTTP auth / throttling / upstream-availability status codes.
+    /\b(401|403|429|502|503|504)\b/.test(message) ||
+    /unauthori[sz]ed|forbidden|invalid token|expired token|authentication/i.test(message) ||
+    /too many requests|service unavailable|temporarily unavailable|bad gateway/i.test(message) ||
+    // Network-level failures (Node errno codes + generic timeouts).
+    // `fetch failed` is undici's blanket message for a connection-level
+    // failure (the errno hides in err.cause — see failureMessage below);
+    // an HTTP-level error resolves with a status instead, so the bare
+    // message is reliably network.
+    /\b(ETIMEDOUT|ECONNREFUSED|ECONNRESET|ENOTFOUND|EAI_AGAIN|ENETUNREACH|EHOSTUNREACH)\b/.test(
+      message,
+    ) ||
+    /\btimed? ?out\b/i.test(message) ||
+    /fetch failed/i.test(message) ||
+    /network (error|failure|issue)/i.test(message)
+  );
+}
+
+/**
+ * An error's message with its `cause` chain unwrapped. Node's fetch
+ * (undici) reports every connection failure as a bare `fetch failed`
+ * TypeError with the real errno (ECONNREFUSED, ENOTFOUND, …) on
+ * err.cause — without unwrapping, the classifier can't see it and the
+ * disclosure tells the user nothing actionable.
+ */
+export function failureMessage(err: unknown): string {
+  const parts: string[] = [];
+  let cur: unknown = err;
+  for (let depth = 0; depth < 5 && cur instanceof Error; depth++) {
+    if (cur.message) parts.push(cur.message);
+    cur = cur.cause;
+  }
+  if (parts.length === 0) parts.push(String(err));
+  return parts.join(': ');
+}
+
+/** What the ingest CLI should do about an engine failure. */
+export type EngineFailureDisposition =
+  | {
+      /** Infra failure with a prior snapshot: keep it, disclose, exit 0. */
+      action: 'degrade';
+      reason: string;
+      /** `generatedAt` of the snapshot the gate continues on. */
+      snapshotGeneratedAt: string;
+    }
+  | {
+      /** Genuine failure, or infra with nothing to fall back to: exit 1. */
+      action: 'fail';
+      reason: string;
+      /** True when the failure IS infra but no prior snapshot exists —
+       *  the renderer says so, since the remedy differs (fix the quota/
+       *  token, don't debug the engine config). */
+      infra: boolean;
+    };
+
+/**
+ * Classify an engine failure against the committed snapshot state.
+ * Pure decision given (message, snapshot-on-disk); the caller renders
+ * and sets the exit code.
+ */
+export function resolveEngineFailure(
+  cwd: string,
+  engine: string,
+  message: string,
+): EngineFailureDisposition {
+  if (!isEngineInfraFailure(message)) return { action: 'fail', reason: message, infra: false };
+  const prior = readSnapshot(cwd, engine);
+  if (!prior) return { action: 'fail', reason: message, infra: true };
+  return { action: 'degrade', reason: message, snapshotGeneratedAt: prior.generatedAt };
+}
+
+/**
+ * Doctor's staleness threshold for `.dxkit/external/<engine>.json`.
+ * The managed refresh cadence is weekly; 30 days ≈ four missed
+ * refreshes — enough to mean "the refresh is broken, not just skipped
+ * once", without flagging repos that refresh manually each month.
+ */
+export const EXTERNAL_SNAPSHOT_STALE_DAYS = 30;
+
+/** Whole days between a snapshot's `generatedAt` and `now`; null when
+ *  the timestamp is missing/unparseable (doctor then skips the check
+ *  rather than false-alarm on a hand-edited snapshot). */
+export function snapshotAgeDays(generatedAt: string, now: Date): number | null {
+  const then = Date.parse(generatedAt);
+  if (Number.isNaN(then)) return null;
+  return Math.floor((now.getTime() - then) / (24 * 60 * 60 * 1000));
+}

--- a/src/ingest/snapshot.ts
+++ b/src/ingest/snapshot.ts
@@ -32,8 +32,26 @@ export interface ExternalSnapshot {
 }
 
 /** Absolute path to an engine's snapshot file. */
-function snapshotPath(cwd: string, engine: SourceEngine): string {
+function snapshotPath(cwd: string, engine: string): string {
   return path.join(cwd, EXTERNAL_DIR, `${engine}.json`);
+}
+
+/**
+ * Read one engine's snapshot. Fail-open: missing, unreadable, or
+ * malformed → null. Consumers: the ingest CLI's graceful-degradation
+ * path ("does a prior snapshot exist to fall back to?") and doctor's
+ * staleness check (accepts the string engine names `snapshotEngines`
+ * lists from disk, hence the wider param type).
+ */
+export function readSnapshot(cwd: string, engine: string): ExternalSnapshot | null {
+  try {
+    const raw = fs.readFileSync(snapshotPath(cwd, engine), 'utf-8');
+    const snap = JSON.parse(raw) as ExternalSnapshot;
+    if (!Array.isArray(snap.findings) || typeof snap.generatedAt !== 'string') return null;
+    return snap;
+  } catch {
+    return null;
+  }
 }
 
 /** Write (overwrite) an engine's snapshot. Creates `.dxkit/external/`

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -383,3 +383,60 @@ describe('doctor --json: structured output', () => {
     expect(r.stdout).not.toContain('━━━');
   });
 });
+
+describe('doctor: external snapshot staleness (3.9 graceful degradation)', () => {
+  let tmp: string;
+
+  function writeExternalSnapshot(engine: string, generatedAt: string): void {
+    const dir = path.join(tmp, '.dxkit', 'external');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `${engine}.json`),
+      JSON.stringify({ schemaVersion: 1, engine, generatedAt, findings: [] }, null, 2),
+    );
+  }
+
+  beforeAll(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-doctor-external-'));
+    execSync('git init -q', { cwd: tmp });
+  });
+
+  afterAll(() => {
+    if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('flags a stale external snapshot with a fix hint (the fail-open backstop)', () => {
+    // The ingest refresh fails OPEN on quota/auth/network — doctor is
+    // the only place a chronically-broken refresh becomes visible.
+    writeExternalSnapshot('snyk-code', '2020-01-01T00:00:00.000Z');
+    const r = runDoctor(tmp, ['--json']);
+    const report = JSON.parse(r.stdout);
+    const check = report.checks.find((c: { label: string }) =>
+      c.label.startsWith('external snyk-code snapshot'),
+    );
+    expect(check).toBeDefined();
+    expect(check.ok).toBe(false);
+    expect(check.fix.hint).toContain('failing open');
+    expect(check.fix.command).toContain('ingest --from-snyk');
+  });
+
+  it('passes on a fresh external snapshot', () => {
+    writeExternalSnapshot('snyk-code', new Date().toISOString());
+    const r = runDoctor(tmp, ['--json']);
+    const report = JSON.parse(r.stdout);
+    const check = report.checks.find((c: { label: string }) =>
+      c.label.startsWith('external snyk-code snapshot'),
+    );
+    expect(check).toBeDefined();
+    expect(check.ok).toBe(true);
+    expect(check.fix).toBeUndefined();
+  });
+
+  it('emits nothing when no external snapshots exist', () => {
+    fs.rmSync(path.join(tmp, '.dxkit', 'external'), { recursive: true, force: true });
+    const r = runDoctor(tmp, ['--json']);
+    const report = JSON.parse(r.stdout);
+    const check = report.checks.find((c: { label: string }) => c.label.startsWith('external '));
+    expect(check).toBeUndefined();
+  });
+});

--- a/test/ingest/engine-failure.test.ts
+++ b/test/ingest/engine-failure.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Graceful engine-failure degradation (3.9).
+ *
+ * The refresh (`vyuh-dxkit ingest`) must bite BOTH ways:
+ * - an INFRASTRUCTURE failure (quota / rate limit / auth / network)
+ *   with a prior committed snapshot keeps the snapshot and exits 0 —
+ *   the dpl-studio lesson ("used your limit of private tests" redding
+ *   the refresh CI while the gate was fine);
+ * - a GENUINE failure, or an infra failure with NO snapshot to fall
+ *   back to, still exits 1 so it gets fixed.
+ *
+ * Plus doctor's other half of the policy: `snapshotAgeDays` feeds the
+ * staleness check that makes a chronically fail-open refresh visible.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  isEngineInfraFailure,
+  resolveEngineFailure,
+  failureMessage,
+  snapshotAgeDays,
+  EXTERNAL_SNAPSHOT_STALE_DAYS,
+} from '../../src/ingest/engine-failure';
+import { writeSnapshot, readSnapshot } from '../../src/ingest/snapshot';
+import { runIngest } from '../../src/ingest-cli';
+import { fetchSnykCodeFindings } from '../../src/ingest/snyk-api';
+
+vi.mock('../../src/ingest/snyk-api', () => ({
+  fetchSnykCodeFindings: vi.fn(),
+}));
+
+function tmpRepo(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-engine-failure-'));
+}
+
+function seedSnapshot(cwd: string, generatedAt = '2026-07-01T00:00:00.000Z'): void {
+  writeSnapshot(cwd, {
+    schemaVersion: 1,
+    engine: 'snyk-code',
+    generatedAt,
+    findings: [],
+  });
+}
+
+// ─── isEngineInfraFailure ───────────────────────────────────────────────────
+
+describe('isEngineInfraFailure', () => {
+  it.each([
+    // The real dpl-studio quota message, as the Snyk CLI wrapper surfaces it.
+    'Snyk CLI produced no SARIF (exit 2): You have used your limit of private tests',
+    'quota exceeded for this billing period',
+    'Rate limit exceeded, retry after 60s',
+    '429 Too Many Requests',
+    '401 Unauthorized',
+    'Snyk API error: 502 Bad Gateway',
+    '503 Service Unavailable',
+    'request to https://api.snyk.io failed, reason: connect ETIMEDOUT 1.2.3.4:443',
+    'getaddrinfo ENOTFOUND api.snyk.io',
+    'socket connection timed out',
+    'network error while fetching results',
+    'invalid token provided',
+    // undici's blanket connection-failure message (real errno on err.cause).
+    'fetch failed',
+  ])('classifies infra: %s', (msg) => {
+    expect(isEngineInfraFailure(msg)).toBe(true);
+  });
+
+  it.each([
+    'Unexpected token < in JSON at position 0',
+    'Snyk CLI produced no SARIF (exit 2)',
+    'CodeQL database creation failed: 14 compilation errors',
+    'unexpected response schema: missing data[].attributes',
+    'ENOENT: no such file or directory',
+  ])('classifies genuine (not infra): %s', (msg) => {
+    expect(isEngineInfraFailure(msg)).toBe(false);
+  });
+});
+
+// ─── resolveEngineFailure ───────────────────────────────────────────────────
+
+describe('resolveEngineFailure', () => {
+  it('degrades on an infra failure when a prior snapshot exists', () => {
+    const cwd = tmpRepo();
+    try {
+      seedSnapshot(cwd);
+      const d = resolveEngineFailure(cwd, 'snyk-code', 'You have used your limit of private tests');
+      expect(d).toEqual({
+        action: 'degrade',
+        reason: 'You have used your limit of private tests',
+        snapshotGeneratedAt: '2026-07-01T00:00:00.000Z',
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails (infra flagged) on an infra failure with NO prior snapshot', () => {
+    const cwd = tmpRepo();
+    try {
+      const d = resolveEngineFailure(cwd, 'snyk-code', '429 Too Many Requests');
+      expect(d).toEqual({ action: 'fail', reason: '429 Too Many Requests', infra: true });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails on a genuine error even when a snapshot exists', () => {
+    const cwd = tmpRepo();
+    try {
+      seedSnapshot(cwd);
+      const d = resolveEngineFailure(cwd, 'snyk-code', 'unexpected response schema');
+      expect(d).toEqual({ action: 'fail', reason: 'unexpected response schema', infra: false });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('degrades per ENGINE — another engine’s snapshot is not a fallback', () => {
+    const cwd = tmpRepo();
+    try {
+      seedSnapshot(cwd); // snyk-code only
+      const d = resolveEngineFailure(cwd, 'codeql', 'connect ETIMEDOUT 1.2.3.4:443');
+      expect(d.action).toBe('fail');
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── failureMessage (cause unwrap — the undici `fetch failed` shape) ────────
+
+describe('failureMessage', () => {
+  it('unwraps the cause chain so the errno reaches the classifier + disclosure', () => {
+    // Node fetch throws TypeError('fetch failed') with the real network
+    // errno on err.cause — observed live against a dead endpoint.
+    const cause = new Error('connect ECONNREFUSED 127.0.0.1:9');
+    const err = new TypeError('fetch failed', { cause });
+    expect(failureMessage(err)).toBe('fetch failed: connect ECONNREFUSED 127.0.0.1:9');
+    expect(isEngineInfraFailure(failureMessage(err))).toBe(true);
+  });
+
+  it('handles a plain error and a non-Error throw', () => {
+    expect(failureMessage(new Error('boom'))).toBe('boom');
+    expect(failureMessage('string throw')).toBe('string throw');
+  });
+});
+
+// ─── readSnapshot (fail-open single-engine reader) ──────────────────────────
+
+describe('readSnapshot', () => {
+  it('round-trips a written snapshot', () => {
+    const cwd = tmpRepo();
+    try {
+      seedSnapshot(cwd, '2026-06-15T12:00:00.000Z');
+      const snap = readSnapshot(cwd, 'snyk-code');
+      expect(snap?.generatedAt).toBe('2026-06-15T12:00:00.000Z');
+      expect(snap?.engine).toBe('snyk-code');
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null on a missing snapshot / dir', () => {
+    const cwd = tmpRepo();
+    try {
+      expect(readSnapshot(cwd, 'snyk-code')).toBeNull();
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null on malformed JSON and on a snapshot missing generatedAt', () => {
+    const cwd = tmpRepo();
+    try {
+      const dir = path.join(cwd, '.dxkit', 'external');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'snyk-code.json'), 'not json');
+      expect(readSnapshot(cwd, 'snyk-code')).toBeNull();
+      fs.writeFileSync(path.join(dir, 'snyk-code.json'), JSON.stringify({ findings: [] }));
+      expect(readSnapshot(cwd, 'snyk-code')).toBeNull();
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── snapshotAgeDays (doctor’s staleness half of the policy) ────────────────
+
+describe('snapshotAgeDays', () => {
+  const now = new Date('2026-07-16T00:00:00.000Z');
+
+  it('computes whole days', () => {
+    expect(snapshotAgeDays('2026-07-15T00:00:00.000Z', now)).toBe(1);
+    expect(snapshotAgeDays('2026-07-15T12:00:00.000Z', now)).toBe(0);
+    expect(snapshotAgeDays('2026-06-01T00:00:00.000Z', now)).toBe(45);
+  });
+
+  it('returns null on an unparseable timestamp', () => {
+    expect(snapshotAgeDays('not-a-date', now)).toBeNull();
+  });
+
+  it('threshold spans multiple missed weekly refreshes', () => {
+    // Cadence-derived sanity pin, not a magic-number tautology: the
+    // managed refresh is weekly, and the threshold must mean "broken,
+    // not skipped once".
+    expect(EXTERNAL_SNAPSHOT_STALE_DAYS).toBeGreaterThanOrEqual(21);
+  });
+});
+
+// ─── runIngest exit-code behavior (the bite test) ───────────────────────────
+
+describe('runIngest engine-failure exit codes', () => {
+  const fetchMock = vi.mocked(fetchSnykCodeFindings);
+  let cwd: string;
+  const savedExitCode = process.exitCode;
+  const savedEnv = {
+    SNYK_TOKEN: process.env.SNYK_TOKEN,
+    SNYK_ORG_ID: process.env.SNYK_ORG_ID,
+    SNYK_PROJECT_ID: process.env.SNYK_PROJECT_ID,
+  };
+
+  beforeEach(() => {
+    cwd = tmpRepo();
+    process.exitCode = undefined;
+    process.env.SNYK_TOKEN = 'test-token';
+    process.env.SNYK_ORG_ID = 'test-org';
+    process.env.SNYK_PROJECT_ID = 'test-project';
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+    process.exitCode = savedExitCode;
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  function ingest(): Promise<void> {
+    return runIngest(cwd, {
+      fromSnyk: true,
+      noEnvFile: true,
+      generatedAt: '2026-07-16T00:00:00.000Z',
+    });
+  }
+
+  it('exits 0 and keeps the snapshot on an infra failure with a prior snapshot', async () => {
+    seedSnapshot(cwd);
+    fetchMock.mockRejectedValue(new Error('connect ETIMEDOUT 1.2.3.4:443'));
+    await ingest();
+    expect(process.exitCode ?? 0).toBe(0);
+    // The prior snapshot is untouched — the gate keeps reading it.
+    expect(readSnapshot(cwd, 'snyk-code')?.generatedAt).toBe('2026-07-01T00:00:00.000Z');
+  });
+
+  it('exits 1 on an infra failure with no prior snapshot', async () => {
+    fetchMock.mockRejectedValue(new Error('connect ETIMEDOUT 1.2.3.4:443'));
+    await ingest();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('exits 1 on a genuine failure even with a prior snapshot', async () => {
+    seedSnapshot(cwd);
+    fetchMock.mockRejectedValue(new Error('unexpected response schema: missing data'));
+    await ingest();
+    expect(process.exitCode).toBe(1);
+    // …and never clobbers the snapshot on the way down.
+    expect(readSnapshot(cwd, 'snyk-code')?.generatedAt).toBe('2026-07-01T00:00:00.000Z');
+  });
+});

--- a/test/ingest/engine-failure.test.ts
+++ b/test/ingest/engine-failure.test.ts
@@ -224,7 +224,9 @@ describe('runIngest engine-failure exit codes', () => {
   beforeEach(() => {
     cwd = tmpRepo();
     process.exitCode = undefined;
-    process.env.SNYK_TOKEN = 'test-token';
+    // A `your-…` value is one of benign.ts's placeholder conventions, so
+    // dxkit's own secret gate reads it as a fixture, not a leak.
+    process.env.SNYK_TOKEN = 'your-snyk-token';
     process.env.SNYK_ORG_ID = 'test-org';
     process.env.SNYK_PROJECT_ID = 'test-project';
     fetchMock.mockReset();


### PR DESCRIPTION
## What & why

A quota, rate-limit, auth, or network failure in the deep-SAST refresh is infrastructure, not a code problem, and the gate never calls an engine live (it reads the committed `.dxkit/external/` snapshot), so hard-exiting 1 only reds the refresh CI until the team learns to ignore it (the shipped case: dpl-studio's Snyk "used your limit of private tests"). One classifier + one shared handler now route every engine catch: infra failure with a prior snapshot keeps the snapshot, discloses the skip, and exits 0; a genuine failure, or infra with no snapshot to fall back to, still exits 1. Doctor grows an external-snapshot staleness check (30d) so a chronically fail-open refresh stays visible. Live-verified against a dead endpoint, which caught undici's bare `fetch failed` hiding the real errno on `err.cause`; `failureMessage()` unwraps the cause chain so the classifier and the disclosure both see it.

## Changes

### Features
- **ingest:** fail open on engine infrastructure failure when a snapshot exists

### Tests
- **ingest:** use a placeholder-convention token so the secret gate reads it as a fixture

## dxkit signals

## Guardrail: PASSED

No changes from baseline (83 pairs checked).

> ℹ️ ref-based mode does not gate **5 secret-hmac, 0 duplication, 0 test-gap, 0 custom-check** — these depend on build artifacts (`node_modules` / coverage) not present at a bare git ref. Switch `.dxkit/policy.json` to `committed-full` to gate them.

> ⚠️ **Flow gate is configured but did not run** — `no-served-truth`: no served-side truth is available (no committed served.json and no monorepo route set) — publish one via 'flow publish' (or set 'flow.mode: off') or this gate will never evaluate

### Envelope drift

- coverage drift: eslint was NOT available when the baseline was captured but is now — that category was never baselined, so its findings may surface as new
- coverage drift: vitest-coverage was NOT available when the baseline was captured but is now — that category was never baselined, so its findings may surface as new

---

_Baseline_: `main` @ 02f5e40f · _Mode_: `ref-based` (ref: `origin/main`) · _Current_: cfaba334 · _Matcher_: git-aware · _dxkit_: 3.8.0

<!-- dxkit receipt: fresh verdict @ 2026-07-16T12:53:24.789Z -->

## Suggested reviewers

_No git history or CODEOWNERS for the touched files — no reviewer signal._

## Reviewer checklist

- [ ] Change matches the description; scope is not broader than stated
- [ ] Exported/public API change preserves backward compatibility (callers updated, or the break is intended + noted)
- [ ] No secrets, keys, or tokens in the diff

<!-- dxkit pr: computed against `origin/main` -->


🤖 Generated with [Claude Code](https://claude.com/claude-code)
