### PR TITLE
fix(honesty): qualify the init headline over a partial baseline; reset analysis memos per build

### DIFF
--- a/src/analyzers/analysis-memos.ts
+++ b/src/analyzers/analysis-memos.ts
@@ -1,0 +1,38 @@
+/**
+ * The ONE "a fresh analysis is starting" reset for process-lifetime,
+ * per-cwd memo caches.
+ *
+ * `walkSourceFiles`, `walkPaths`, `exclusions`, the gitleaks-outcome
+ * cache, and the capability dispatcher all memoize per cwd for the
+ * lifetime of the process, to dedupe work WITHIN one analysis. Their
+ * clear seams existed but were called nowhere in `src/` — so when one
+ * process scanned the SAME cwd twice with the tree changed in between
+ * (a baseline create followed by a current scan in one process), the
+ * second scan reused the first's stale walk and read an EMPTY tree: no
+ * source, so no secrets, no test-gap, nothing. Latent in the CLI (each
+ * command is its own process) but live in integration tests and any
+ * future daemon / watch / in-process re-scan.
+ *
+ * The root fix is scoping, not more call sites: every analysis entry
+ * point funnels through `gatherAnalysisResultBody`, which calls this
+ * ONCE at the top — dedup still works within a build, a changed tree
+ * re-walks across builds, and no caller has to remember to clear.
+ * (Concurrent builds of different cwds clearing each other's memos
+ * would only cost a redundant re-walk, never a wrong result — and all
+ * multi-cwd flows today are sequential awaits.)
+ */
+import { clearWalkCache } from './tools/walk-source-files';
+import { clearWalkPathsCache } from './tools/walk-paths';
+import { clearExclusionsCache } from './tools/exclusions';
+import { clearGitleaksOutcomeCache } from './tools/gitleaks';
+import { defaultDispatcher } from './dispatcher';
+
+/** Reset every process-lifetime analysis memo. Called at the start of
+ *  each fresh analysis build; safe (only costs a re-walk) anywhere else. */
+export function resetAnalysisMemos(): void {
+  clearWalkCache();
+  clearWalkPathsCache();
+  clearExclusionsCache();
+  clearGitleaksOutcomeCache();
+  defaultDispatcher.clearCache();
+}

--- a/src/analyzers/health.ts
+++ b/src/analyzers/health.ts
@@ -51,6 +51,7 @@ import { scoreDxDimension } from './dx/shallow';
 import { computeOverall } from '../scoring';
 import { ScoreInput } from './types';
 import { type GatherScope, FULL_SCOPE } from '../baseline/gather-scope';
+import { resetAnalysisMemos } from './analysis-memos';
 
 /** Default values for all HealthMetrics fields. */
 export function defaultMetrics(): HealthMetrics {
@@ -198,6 +199,12 @@ export async function gatherAnalysisResultBody(
 ): Promise<AnalysisResultBody> {
   const verbose = !!options.verbose;
   const scope = options.scope ?? FULL_SCOPE;
+
+  // A fresh analysis is starting: reset the process-lifetime per-cwd
+  // memos (walks, exclusions, gitleaks outcome, dispatcher) so a tree
+  // that changed since a PRIOR in-process analysis is re-walked instead
+  // of read as the stale (possibly empty) snapshot the memos hold.
+  resetAnalysisMemos();
 
   // Step 1: Detect stack
   const stack = timed('detect', verbose, () => detect(repoPath));

--- a/src/init-arc.ts
+++ b/src/init-arc.ts
@@ -196,14 +196,21 @@ export function buildInitClosing(state: InitClosingState): InitClosing {
     return { headline: "You're gated for what's measurable.", ready, body, caution, actions };
   }
 
-  const caution =
-    state.incompleteScanners.length > 0
-      ? `${state.incompleteScanners.length} scanner class(es) weren't available ` +
-        `(${state.incompleteScanners.join(', ')}) — those finding types aren't gated yet. ` +
-        `Run \`${dxkitCli('tools install')}\` to complete coverage.`
-      : null;
+  // Same honesty gate, one class over: a scanner that wasn't available at
+  // capture time means the baseline is PARTIAL — those finding kinds were
+  // never measured, so they are not gated. An unqualified "You're gated."
+  // over that baseline is a confident answer where the honest output is a
+  // boundary (the same shape as the unprovisioned-toolchain case above).
+  if (state.incompleteScanners.length > 0) {
+    const caution =
+      `${state.incompleteScanners.length} scanner class(es) weren't available ` +
+      `(${state.incompleteScanners.join(', ')}) — those finding types are NOT gated yet. ` +
+      `Run \`${dxkitCli('tools install')}\`, then \`${dxkitCli('baseline create --force')}\` ` +
+      `so the baseline covers them.`;
+    return { headline: "You're gated for what's measurable.", ready, body, caution, actions };
+  }
 
-  return { headline: "You're gated.", ready, body, caution, actions };
+  return { headline: "You're gated.", ready, body, caution: null, actions };
 }
 
 /** Options for the finishing arc. */

--- a/test/analysis-memos.test.ts
+++ b/test/analysis-memos.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The fresh-analysis memo reset (`resetAnalysisMemos`).
+ *
+ * The walk/exclusion/gitleaks/dispatcher memos are process-lifetime and
+ * keyed by cwd, which is correct WITHIN one analysis and wrong across
+ * two: a process that scans the same cwd twice with the tree changed in
+ * between must not read the first scan's snapshot (the latent class: a
+ * baseline create followed by a current scan in one process saw an
+ * empty tree — no source, no secrets, no test-gap). The root fix scopes
+ * the memos to one analysis by resetting them at the ONE entry seam
+ * (`gatherAnalysisResultBody`); this test pins the reset itself, and
+ * `test/baseline/attribution-gap.test.ts` (which re-scans a changed cwd
+ * in-process with NO ad-hoc clears) pins that the seam actually runs it.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { resetAnalysisMemos } from '../src/analyzers/analysis-memos';
+import { walkSourceFiles } from '../src/analyzers/tools/walk-source-files';
+import { walkPaths } from '../src/analyzers/tools/walk-paths';
+
+describe('resetAnalysisMemos', () => {
+  it('a changed tree is re-walked after reset (and NOT before — the memo is real)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-memos-'));
+    try {
+      execSync('git init -q', { cwd: tmp });
+      fs.writeFileSync(path.join(tmp, 'a.ts'), 'export const a = 1;\n');
+
+      // Warm BOTH memos on the 1-file tree.
+      expect(walkSourceFiles(tmp, { extensions: ['.ts'] })).toHaveLength(1);
+      expect(walkPaths(tmp, { extensions: ['.ts'] })).toHaveLength(1);
+
+      fs.writeFileSync(path.join(tmp, 'b.ts'), 'export const b = 2;\n');
+
+      // Without a reset the memo replays the stale walk — this assertion is
+      // what makes the reset non-optional (if the cache disappeared, the
+      // reset would be dead code and this would fail).
+      expect(walkSourceFiles(tmp, { extensions: ['.ts'] })).toHaveLength(1);
+      expect(walkPaths(tmp, { extensions: ['.ts'] })).toHaveLength(1);
+
+      resetAnalysisMemos();
+
+      expect(walkSourceFiles(tmp, { extensions: ['.ts'] })).toHaveLength(2);
+      expect(walkPaths(tmp, { extensions: ['.ts'] })).toHaveLength(2);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/baseline/attribution-gap.test.ts
+++ b/test/baseline/attribution-gap.test.ts
@@ -38,8 +38,6 @@ import { verdictWordFrom, verdictCounts } from '../../src/baseline/check-rendere
 import { renderConsole, renderJson, renderMarkdown } from '../../src/baseline/check-renderers';
 import { createBaseline } from '../../src/baseline/create';
 import { runGuardrailCheck } from '../../src/baseline/check';
-import { clearGitleaksOutcomeCache } from '../../src/analyzers/tools/gitleaks';
-import { defaultDispatcher } from '../../src/analyzers/dispatcher';
 import { findTool, TOOL_DEFS } from '../../src/analyzers/tools/tool-registry';
 
 // The two end-to-end tests below drive a REAL secret scan of a fixture repo, so
@@ -182,12 +180,10 @@ function addSecret(dir: string): void {
   );
   execFileSync('git', ['add', '.'], { cwd: dir });
   execFileSync('git', ['commit', '-q', '-m', 'add config'], { cwd: dir });
-  // Both per-process gather memos are keyed by cwd only (fine for one-shot
-  // CLI runs, where a process never re-scans a changed tree); this test
-  // re-scans the SAME cwd after changing the tree, so drop them or the check
-  // replays the pre-secret capability outcome.
-  clearGitleaksOutcomeCache();
-  defaultDispatcher.clearCache();
+  // No ad-hoc memo clears needed: every fresh analysis resets the
+  // process-lifetime per-cwd memos itself (resetAnalysisMemos at
+  // gatherAnalysisResultBody), so an in-process re-scan of a changed
+  // tree sees the new state. This test relying on that IS the coverage.
 }
 
 describe('runGuardrailCheck — a net-new secret under absent recall CANNOT pass (BLOCKER-1)', () => {

--- a/test/init-arc.test.ts
+++ b/test/init-arc.test.ts
@@ -173,14 +173,26 @@ describe('buildInitClosing', () => {
     });
     // Full coverage NOT claimed.
     expect(withGap.headline).not.toBe("You're gated.");
-    // A generic optional-scanner gap (no language toolchain missing) still reads
-    // as fully gated with the lighter caution.
-    const optionalOnly = buildInitClosing({
+    // The toolchain caution (the root prerequisite) is the one shown; the
+    // generic scanner caution would name tools install first.
+    expect(withGap.caution).toContain('toolchain');
+    // A scanner gap alone (no language toolchain missing) is ALSO a partial
+    // baseline — a missing gitleaks means secrets were never measured — so
+    // the headline is qualified there too (3.9: never print an unqualified
+    // "You're gated." over a partial baseline).
+    const scannerOnly = buildInitClosing({
       ...base,
       baselineFindings: 10,
       incompleteScanners: ['gitleaks'],
     });
-    expect(optionalOnly.headline).toBe("You're gated.");
+    expect(scannerOnly.headline).toBe("You're gated for what's measurable.");
+    expect(scannerOnly.caution).toContain('NOT gated');
+  });
+
+  it('claims the unqualified headline ONLY on full coverage', () => {
+    const full = buildInitClosing({ ...base, baselineFindings: 10 });
+    expect(full.headline).toBe("You're gated.");
+    expect(full.caution).toBeNull();
   });
 
   it('time-to-verdict is humanized across ranges', () => {


### PR DESCRIPTION
## What & why

Two 3.9 fold-ins, both the uncertainty-at-extraction class. (1) Onboarding honesty: a baseline captured while a scanner class was unavailable (no gitleaks → secrets never measured) still headlined an unqualified "You're gated." — it now gets the same qualified "You're gated for what's measurable." the toolchain-gap case already earned, with the remedy naming `tools install` then `baseline create --force`. (2) Walk-cache staleness root fix: the process-lifetime per-cwd memos (walks, exclusions, gitleaks outcome, dispatcher) had clear seams called nowhere in src/, so an in-process re-scan of a changed tree read a stale (possibly empty) snapshot; one `resetAnalysisMemos()` now runs at the one analysis entry seam (`gatherAnalysisResultBody`), and the ad-hoc clears in `attribution-gap.test.ts` are deleted — that test re-scanning a changed cwd with no clears is the integration coverage.

## Changes

### Fixes
- **honesty:** qualify the init headline over a partial baseline; reset analysis memos per build

## dxkit signals

## Guardrail: PASSED

No changes from baseline (83 pairs checked).

> ℹ️ ref-based mode does not gate **5 secret-hmac, 0 duplication, 0 test-gap, 0 custom-check** — these depend on build artifacts (`node_modules` / coverage) not present at a bare git ref. Switch `.dxkit/policy.json` to `committed-full` to gate them.

> ⚠️ **Flow gate is configured but did not run** — `no-served-truth`: no served-side truth is available (no committed served.json and no monorepo route set) — publish one via 'flow publish' (or set 'flow.mode: off') or this gate will never evaluate

### Envelope drift

- coverage drift: eslint was NOT available when the baseline was captured but is now — that category was never baselined, so its findings may surface as new
- coverage drift: vitest-coverage was NOT available when the baseline was captured but is now — that category was never baselined, so its findings may surface as new

---

_Baseline_: `main` @ 02f5e40f · _Mode_: `ref-based` (ref: `origin/main`) · _Current_: af111e66 · _Matcher_: git-aware · _dxkit_: 3.8.0

<!-- dxkit receipt: fresh verdict @ 2026-07-16T14:10:08.678Z -->

## Suggested reviewers

_No git history or CODEOWNERS for the touched files — no reviewer signal._

## Reviewer checklist

- [ ] Change matches the description; scope is not broader than stated
- [ ] Exported/public API change preserves backward compatibility (callers updated, or the break is intended + noted)
- [ ] No secrets, keys, or tokens in the diff

<!-- dxkit pr: computed against `origin/main` -->


🤖 Generated with [Claude Code](https://claude.com/claude-code)
