### PR TITLE
fix(renderers): collapse the tooling-drift wall to one summary block per kind

### DIFF
--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -273,8 +273,16 @@ export function renderConsole(result: GuardrailCheckResult): string {
     // specific, actionable warnings under the wall — so print the drift group as
     // ONE summary line and enumerate only the specific warnings.
     const drift = warning.filter((p) => p.classification.status === 'config_drift');
-    const specific = warning.filter((p) => p.classification.status !== 'config_drift');
+    // The tooling-drift wall (VERIFY-39 F-6) is the same disease one status
+    // over: on a pre-Rule-19 baseline the whole backlog demotes at once
+    // (18,396 blocks on a real repo). One summary block per kind instead.
+    const toolingDrift = warning.filter((p) => p.classification.status === 'tooling_drift');
+    const specific = warning.filter(
+      (p) =>
+        p.classification.status !== 'config_drift' && p.classification.status !== 'tooling_drift',
+    );
     for (const p of specific) lines.push(...formatPairLines(p, '  '));
+    if (toolingDrift.length > 0) lines.push(...formatToolingDriftSummary(toolingDrift, '  '));
     if (drift.length > 0) lines.push(...formatDriftWarningSummary(drift, '  '));
     lines.push('');
   }
@@ -714,6 +722,49 @@ function formatPairLines(p: ClassifiedPair, indent: string): string[] {
  * in the right place instead of chasing "policy changed". Points at `--json` for
  * the un-collapsed per-finding payload.
  */
+/**
+ * Collapse `tooling_drift` warning pairs into ONE summary block per KIND
+ * (VERIFY-39 F-6). On a brownfield repo whose baseline predates the current
+ * recall context — a dxkit upgrade, a plugin bump, lint newly enabled — the
+ * ENTIRE backlog demotes to tooling-drift at once: a real repo produced
+ * 18,396 four-line drift blocks (73,665 lines of console output) that buried
+ * the one unattributable block-rule finding driving the verdict. Every block
+ * said the same cause and the same remedy, so itemizing them adds nothing a
+ * reader can act on. One block per kind carries everything actionable: the
+ * count, the shared cause, one exemplar, and the pointer at `--json` for the
+ * full per-finding payload (which is NOT collapsed). Sibling of the
+ * `config_drift` collapse above (gh #157) — same disease, one status over.
+ */
+export function formatToolingDriftSummary(
+  drift: ReadonlyArray<ClassifiedPair>,
+  indent: string,
+): string[] {
+  const byKind = new Map<string, ClassifiedPair[]>();
+  for (const p of drift) {
+    const list = byKind.get(p.kind) ?? [];
+    list.push(p);
+    byKind.set(p.kind, list);
+  }
+  const out: string[] = [];
+  for (const [kind, pairs] of byKind) {
+    const n = pairs.length;
+    const cause =
+      pairs[0].classification.reasons.find((r) => r.code === 'tooling-drift')?.detail ??
+      'what dxkit can see for this kind changed between runs';
+    out.push(
+      `${indent}${n} ${kind} finding${n === 1 ? '' : 's'} demoted to TOOLING-DRIFT — ${cause}`,
+    );
+    const exemplar = pairs[0];
+    const where = locatorProse(exemplar);
+    if (where) out.push(`${indent}  · e.g. ${where}`);
+  }
+  out.push(
+    `${indent}  · Not attributable to this diff, so these warn and never block. ` +
+      `Re-run with --json for the full per-finding list; re-baseline (from CI) to restore attribution.`,
+  );
+  return out;
+}
+
 export function formatDriftWarningSummary(
   drift: ReadonlyArray<ClassifiedPair>,
   indent: string,
@@ -1326,7 +1377,26 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     // Collapse the envelope-drift wall (gh #157): the drift group becomes one
     // summary line above the table, and only the specific warnings are tabled.
     const driftWarn = warning.filter((p) => p.classification.status === 'config_drift');
-    const specificWarn = warning.filter((p) => p.classification.status !== 'config_drift');
+    // Tooling drift collapses per KIND (VERIFY-39 F-6) — a brownfield upgrade
+    // demotes the whole backlog at once, and a PR body must not carry an
+    // 18k-row warnings table.
+    const toolingDriftWarn = warning.filter((p) => p.classification.status === 'tooling_drift');
+    const specificWarn = warning.filter(
+      (p) =>
+        p.classification.status !== 'config_drift' && p.classification.status !== 'tooling_drift',
+    );
+    if (toolingDriftWarn.length > 0) {
+      const byKind = new Map<string, number>();
+      for (const p of toolingDriftWarn) byKind.set(p.kind, (byKind.get(p.kind) ?? 0) + 1);
+      const perKind = [...byKind.entries()].map(([k, n]) => `${n} ${k}`).join(', ');
+      lines.push(
+        `> **${toolingDriftWarn.length} finding${toolingDriftWarn.length === 1 ? '' : 's'} demoted ` +
+          `to TOOLING-DRIFT** (${perKind}) — what dxkit can see for these kinds changed between ` +
+          `the baseline and this scan, so they cannot be attributed to this diff. They warn and ` +
+          `never block; see \`--json\` for each, and re-baseline (from CI) to restore attribution.`,
+      );
+      lines.push('');
+    }
     if (driftWarn.length > 0) {
       const gateEnabled = driftWarn.filter((p) =>
         p.classification.reasons.some((r) => r.code === 'dimension-newly-measured'),
@@ -1353,11 +1423,11 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
       for (const p of specificWarn) lines.push(markdownPairRow(p));
       lines.push('');
     }
-    if (driftWarn.length > 0) {
-      lines.push(
-        `_${driftWarn.length} envelope-drift warning${driftWarn.length === 1 ? '' : 's'} collapsed ` +
-          `above; see \`--json\` for each._`,
-      );
+    if (driftWarn.length > 0 || toolingDriftWarn.length > 0) {
+      const parts: string[] = [];
+      if (toolingDriftWarn.length > 0) parts.push(`${toolingDriftWarn.length} tooling-drift`);
+      if (driftWarn.length > 0) parts.push(`${driftWarn.length} envelope-drift`);
+      lines.push(`_${parts.join(' + ')} warning(s) collapsed above; see \`--json\` for each._`);
       lines.push('');
     }
     lines.push('</details>');

--- a/test/baseline/drift-warning-collapse.test.ts
+++ b/test/baseline/drift-warning-collapse.test.ts
@@ -55,3 +55,68 @@ describe('formatDriftWarningSummary', () => {
     expect(out[0]).toContain('1 finding unmatched');
   });
 });
+
+/**
+ * VERIFY-39 F-6: the TOOLING-drift wall collapses to one summary block per
+ * KIND. On a pre-Rule-19 baseline the entire backlog demotes at once — a real
+ * repo produced 18,396 four-line drift blocks (73,665 console lines) that
+ * buried the verdict. Same disease as gh #157, one status over.
+ */
+
+import { formatToolingDriftSummary } from '../../src/baseline/check-renderers';
+
+function toolingPair(kind: string, file: string, line: number, detail?: string): ClassifiedPair {
+  return {
+    kind,
+    file,
+    line,
+    locator: `${file}:${line}`,
+    classification: {
+      status: 'tooling_drift',
+      reasons: [
+        { code: 'no-prior-match', detail: 'identity fingerprint not present in the baseline' },
+        {
+          code: 'tooling-drift',
+          detail: detail ?? 'the baseline predates recall attribution',
+        },
+      ],
+      blocks: false,
+      warns: true,
+    },
+  } as unknown as ClassifiedPair;
+}
+
+describe('formatToolingDriftSummary (F-6)', () => {
+  it('collapses N same-kind drift findings into ONE block: count + cause + exemplar + remedy', () => {
+    const pairs = Array.from({ length: 500 }, (_, i) =>
+      toolingPair('custom-check', `src/f${i}.ts`, i + 1),
+    );
+    const out = formatToolingDriftSummary(pairs, '  ');
+    // Bounded output regardless of finding count — the whole point.
+    expect(out.length).toBeLessThanOrEqual(3);
+    expect(out[0]).toContain('500 custom-check findings demoted to TOOLING-DRIFT');
+    expect(out[0]).toContain('the baseline predates recall attribution');
+    expect(out[1]).toContain('e.g. src/f0.ts:1');
+    expect(out[out.length - 1]).toContain('--json');
+    expect(out[out.length - 1]).toContain('re-baseline');
+  });
+
+  it('groups per kind — each kind gets its own count, cause, and exemplar', () => {
+    const out = formatToolingDriftSummary(
+      [
+        toolingPair('custom-check', 'a.ts', 1),
+        toolingPair('custom-check', 'b.ts', 2),
+        toolingPair('dep-vuln', 'package.json', 1, 'osv-scanner version changed'),
+      ],
+      '  ',
+    );
+    expect(out.join('\n')).toContain('2 custom-check findings');
+    expect(out.join('\n')).toContain('1 dep-vuln finding');
+    expect(out.join('\n')).toContain('osv-scanner version changed');
+  });
+
+  it('singular form for one finding', () => {
+    const out = formatToolingDriftSummary([toolingPair('secret', 'x.env', 3)], '  ');
+    expect(out[0]).toContain('1 secret finding demoted');
+  });
+});


### PR DESCRIPTION
## What & why

VERIFY-39 F-6: on a brownfield repo whose baseline predates the current recall context, the whole backlog demotes to tooling-drift at once and the console itemized every finding — 18,396 four-line blocks (73,665 lines) on a real customer repo, burying the CANNOT GATE verdict. The console now renders one summary block per KIND (count, shared cause, one exemplar, `--json` pointer + re-baseline remedy) and the PR-body markdown gets the matching per-kind blockquote. Sibling of the gh #157 config-drift collapse, one status over; `--json` is unchanged. Re-proven on the repo that surfaced it: the same guardrail run now emits **90 lines** with an identical verdict.

## Changes

### Fixes
- **renderers:** collapse the tooling-drift wall to one summary block per kind

## dxkit signals

## Guardrail: PASSED

No changes from baseline (83 pairs checked).

> ℹ️ ref-based mode does not gate **5 secret-hmac, 0 duplication, 0 test-gap, 0 custom-check** — these depend on build artifacts (`node_modules` / coverage) not present at a bare git ref. Switch `.dxkit/policy.json` to `committed-full` to gate them.

> ⚠️ **Flow gate is configured but did not run** — `no-served-truth`: no served-side truth is available (no committed served.json and no monorepo route set) — publish one via 'flow publish' (or set 'flow.mode: off') or this gate will never evaluate

### Envelope drift

- coverage drift: eslint was NOT available when the baseline was captured but is now — that category was never baselined, so its findings may surface as new
- coverage drift: vitest-coverage was NOT available when the baseline was captured but is now — that category was never baselined, so its findings may surface as new

---

_Baseline_: `main` @ 02f5e40f · _Mode_: `ref-based` (ref: `origin/main`) · _Current_: a97ce840 · _Matcher_: git-aware · _dxkit_: 3.9.0-rc.3

<!-- dxkit receipt: fresh verdict @ 2026-07-16T15:35:17.317Z -->

## Suggested reviewers

_No git history or CODEOWNERS for the touched files — no reviewer signal._

## Reviewer checklist

- [ ] Change matches the description; scope is not broader than stated
- [ ] Exported/public API change preserves backward compatibility (callers updated, or the break is intended + noted)
- [ ] No secrets, keys, or tokens in the diff

<!-- dxkit pr: computed against `origin/main` -->


🤖 Generated with [Claude Code](https://claude.com/claude-code)
