### PR TITLE
feat(execution): ExecutionRequirement as the third pack-declared dimension (Rule 20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1244,6 +1244,85 @@ to write, and a naive grep matched that COMMENT and passed a dormant scaffold as
 if it probed. A test that passes because of a code comment reports coverage that
 does not exist.
 
+### 20. Execution environment is pack-declared, predicate-resolved (4.0)
+
+dxkit models language and capability as first-class, pack-declared dimensions;
+the third is **where a capability can execute**. The pre-4.0 model implicitly
+assumed "the machine driving the analysis can build and scan the repo" — false
+for any stack needing a provisioned build environment (the dpl-studio class: a
+`net9.0-windows` WinForms build needs Windows + the .NET SDK + a chosen
+solution; it recurs harder for Swift/iOS, Android, C/C++). When it broke,
+capabilities either fail-open skipped invisibly or misread an environment
+problem as a code finding. The platform makes the requirement explicit:
+
+- **Declared** per capability, per pack (Rule 6): `execution(cwd):
+ExecutionRequirement { hosts, toolchains, needsBuild, buildTarget, weight }`
+  is REQUIRED on `CorrectnessProvider`, `LintGateProvider`, `DepVulnsProvider`
+  (a deliberate frozen-in-place addition, pinned by the freeze test) and
+  `DeepSastSupport`. The declaration is PURE and REPO-INTRINSIC — it reads
+  repo files only (a `.csproj` TFM, the build system present), never PATH,
+  never `process.platform` — deterministic with no machine-specific values
+  (the Rule 19 recall-inputs discipline). Where the truth is repo-dependent
+  it is DERIVED: csharp narrows `hosts` to `['windows']` from a
+  `net*-windows` TFM / WinForms/WPF opt-in.
+- **Toolchains vs tools — the boundary line**: `toolchains` names AMBIENT
+  SDKs/runtimes the ecosystem owns (dotnet-sdk, jdk, go…), registered once in
+  `src/execution/toolchains.ts:TOOLCHAIN_DEFS` (per-host non-privileged
+  install + health checks; `ToolchainId` is derived from the registry, so an
+  unregistered reference fails to compile). Registry TOOLS (gitleaks, ruff,
+  osv-scanner…) stay in `TOOL_DEFS` / `findTool` (Rule 1) and are NEVER
+  declared as toolchains. If `tools install` can provision it, it is a tool;
+  if the repo's ecosystem provisions it, it is a toolchain.
+- **Resolved** by the ONE predicate `unmetRequirement(req, env)` in
+  `src/execution/requirement.ts`, comparing the repo-intrinsic requirement
+  against the host-intrinsic environment (`currentEnvironment()` — the one
+  home of host detection). Every "can this run here?" question routes through
+  it; the placement resolver (the increment that routes capabilities to
+  ubuntu/windows/macos CI jobs) composes on the same predicate.
+- **Consumed** BEFORE execution, and every unmet requirement is DISCLOSED:
+  the correctness runner and the custom-check runner emit
+  `skipped-environment` with the structured reason (phrased once, by
+  `describeUnmetRequirement` — what is needed and where it would run), never
+  a silent skip and never a spawn that fails in a way that reads as a code
+  finding (the half-provisioned-SDK class). Fail-open stays fail-open, it
+  just always says why — the `GateFailure` discipline.
+
+**Bad**: a capability that shells a build with no `execution` declaration (it
+won't compile); a `process.platform` read in an analyzer; an inline
+`winget install …` string in a consumer; a second "can this run here?"
+predicate; declaring `osv-scanner` as a toolchain; a requirement that probes
+PATH or embeds a machine path.
+
+**Good**: `unmetRequirement(provider.execution(cwd), env)` in a runner;
+`csharpBuildExecution(cwd)` deriving hosts from TFMs; a new pack registering
+its SDK in `TOOLCHAIN_DEFS` and referencing the id.
+
+#### Execution-environment enforcement
+
+1. **Compile**: `execution` is required on all four capability contracts; a
+   pack that omits it does not build. `ToolchainId` is a closed union derived
+   from `TOOLCHAIN_DEFS`.
+2. **`scripts/check-architecture.sh` Rule 20**: (a) no new `process.platform`
+   outside `src/execution/` + the frozen pre-Rule-20 allowlist (annotate
+   `// exec-host-ok`); (b) no inline toolchain install literals outside the
+   two registries; (c) `unmetRequirement(` consumed only by its known
+   consumers (annotate `// exec-requirement-ok` and extend the allowlist
+   deliberately). All three verified to bite.
+3. **`test/languages-contract.test.ts`**: per pack × declaring capability —
+   well-formed requirement, every toolchain id resolves in `TOOLCHAIN_DEFS`,
+   deterministic + total + machine-independent, and the **cliBinaries parity**
+   (doctor's toolchain-coverage projection may not drift from the
+   declarations — Rule 2.30's two-projections shape, pinned).
+4. **`test/recipe-playbook.test.ts`**: the synthetic pack declares a
+   distinctive windows-only gate requirement; the playbook asserts it flows
+   pack → spec → runner, and that the runner honors it in BOTH directions
+   (unmet ⇒ disclosed skip decided before the spawn; met ⇒ executes — the
+   over-skip regression is the dangerous one).
+5. **`test/execution/execution-platform.test.ts`**: the predicate both
+   directions, the C# TFM host derivation, and the declaration-less user
+   check keeping the plain fail-open path (dxkit never invents a requirement
+   it cannot know).
+
 ## Release procedure
 
 **Every release goes through the CI pipeline. No exceptions.** Local

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1756,6 +1756,78 @@ if [ -n "$INIT_ARC" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# ── Rule 20: execution environment is pack-declared, predicate-resolved ────
+# The third pack-declared dimension (alongside language + capability): every
+# "can this capability run here?" question routes through the ONE predicate
+# `unmetRequirement` (src/execution/requirement.ts) over pack-declared
+# `ExecutionRequirement`s. The class this kills: scattered point checks and
+# implicit "the driver's machine can run everything" assumptions (the
+# dpl-studio Windows-only .NET onboarding).
+#
+# 20a: no NEW `process.platform` reads outside the environment model. Host
+# detection is one concept; a per-consumer point check is how the implicit
+# assumption survived unexamined. The allowlist below FREEZES the pre-Rule-20
+# call sites (each is a display/exec-mechanics concern, migrated
+# opportunistically); new files consult `hostOf()` / `currentEnvironment()`.
+# Annotate '// exec-host-ok' for a justified exception.
+RULE20_PLATFORM=""
+for f in $(grep -rlE "process\.platform" src --include='*.ts' 2>/dev/null); do
+  case "$f" in
+    src/execution/*) continue ;;
+    src/self-invocation.ts | src/doctor.ts | src/cli.ts | src/issue-cli.ts) continue ;;
+    src/analyzers/tools/runner.ts | src/analyzers/tools/install-exec.ts | src/analyzers/tools/tool-registry.ts) continue ;;
+  esac
+  grep -q "// exec-host-ok" "$f" && continue
+  RULE20_PLATFORM="$RULE20_PLATFORM $f"
+done
+if [ -n "$RULE20_PLATFORM" ]; then
+  echo "❌ Rule 20a violation: process.platform read outside the execution-environment model:"
+  for f in $RULE20_PLATFORM; do echo "     $f"; done
+  echo "   → Consult hostOf() / currentEnvironment() from src/execution/ instead — host"
+  echo "     detection is one concept (a scattered point check is how the implicit"
+  echo "     'this machine can run everything' assumption ships). Annotate"
+  echo "     '// exec-host-ok' for a justified exception."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# 20b: toolchain install commands live in the toolchain registry (per-host,
+# non-privileged default, health checks) or TOOL_DEFS — never inline in a
+# consumer. An inline install string is the "'scoop' is not recognized" class:
+# unroutable, host-blind, and invisible to the provisioning increment.
+RULE20_INSTALL=$(grep -rlnE "winget install|dotnet-install|sh\.rustup\.rs|apt-get install" src --include='*.ts' 2>/dev/null \
+  | grep -v "src/execution/toolchains.ts" \
+  | grep -v "src/analyzers/tools/tool-registry.ts" || true)
+if [ -n "$RULE20_INSTALL" ]; then
+  echo "❌ Rule 20b violation: inline toolchain install command outside the registries:"
+  echo "$RULE20_INSTALL"
+  echo "   → Declare it in src/execution/toolchains.ts (ambient toolchain) or"
+  echo "     TOOL_DEFS.installCommands (registry tool) and reference it."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# 20c: the satisfaction predicate has ONE home and known consumers. A second
+# "can this run here?" implementation (or ad-hoc host/toolchain gating in an
+# analyzer) is the semantic-divergence variant of Rule 2.30 — the gate and the
+# disclosure would drift. Annotate '// exec-requirement-ok' for a justified
+# new consumer (a placement resolver, doctor, init honesty).
+RULE20_PREDICATE=""
+for f in $(grep -rlE "unmetRequirement\(" src --include='*.ts' 2>/dev/null); do
+  case "$f" in
+    src/execution/*) continue ;;
+    src/analyzers/correctness/*) continue ;;
+    src/analyzers/custom-checks/*) continue ;;
+  esac
+  grep -q "// exec-requirement-ok" "$f" && continue
+  RULE20_PREDICATE="$RULE20_PREDICATE $f"
+done
+if [ -n "$RULE20_PREDICATE" ]; then
+  echo "❌ Rule 20c violation: unmetRequirement() consumed outside its known consumers:"
+  for f in $RULE20_PREDICATE; do echo "     $f"; done
+  echo "   → New consumers are deliberate: annotate '// exec-requirement-ok' on the file"
+  echo "     and extend this allowlist in the same PR (CLAUDE.md Rule 20)."
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ $ERRORS -gt 0 ]; then
   echo ""
   echo "Architecture checks failed. See CLAUDE.md for rules."

--- a/scripts/scaffold-language.js
+++ b/scripts/scaffold-language.js
@@ -322,6 +322,12 @@ export const ${id}: LanguageSupport = {
   // ref-based dep-audit skip needs it to tell whether a PR touched this pack's
   // dependencies (CLAUDE.md Rule 6).
   //
+  // It must ALSO declare \`execution(cwd)\` (Rule 20): a lockfile-reading
+  // audit via a registry tool needs nothing ({ hosts: ['any'], toolchains: [],
+  // needsBuild: false, buildTarget: 'none', weight: 'cheap' }); an audit that
+  // drives the ecosystem's own toolchain (npm audit → 'node', govulncheck →
+  // 'go' + needsBuild) declares it.
+  //
   // ALSO declare \`lockfilePatterns\` when the ecosystem has a lockfile (or a
   // manifest that independently resolves, like go.mod / requirements.txt):
   // exact basenames marking an INDEPENDENT dependency-resolution root. The
@@ -433,6 +439,27 @@ export const ${id}: LanguageSupport = {
   // with CI's full scope as the backstop). See typescript.ts / python.ts, and
   // jvm-build.ts for a shared multi-build-system provider.
   correctness: {
+    // REQUIRED(${id}) — Rule 20: what the floor NEEDS from the environment
+    // that runs it. PURE and REPO-INTRINSIC (read repo files only — never
+    // PATH, never process.platform; the contract test rejects
+    // non-determinism). The dormant floor below runs nothing, so the empty
+    // requirement is accurate NOW — when you fill in real commands, declare
+    // their truth: the ambient toolchain (a ToolchainId from
+    // src/execution/toolchains.ts — register it there if new), needsBuild
+    // for compiled stacks, and hosts narrowed when the BUILD is OS-locked
+    // (csharp derives hosts from the repo's TFMs — the worked example).
+    execution(_cwd) {
+      // TODO(${id}): declare the floor's real requirement, e.g.
+      //   return { hosts: ['any'], toolchains: ['${id}'], needsBuild: true,
+      //            buildTarget: 'discovered', weight: 'build' };
+      return {
+        hosts: ['any'],
+        toolchains: [],
+        needsBuild: false,
+        buildTarget: 'none',
+        weight: 'cheap',
+      };
+    },
     syntaxCheck(_ctx) {
       // TODO(${id}): compile/typecheck the change, e.g.
       //   return { label: 'compile', bin: '${id}', args: ['build'] };
@@ -456,6 +483,20 @@ export const ${id}: LanguageSupport = {
   // Java checkstyle), leave it dormant — users gate their linter via a
   // .dxkit/policy.json \`checks\` entry.
   lintGate: {
+    // Rule 20 (same contract as correctness.execution above): the dormant
+    // gate needs nothing; declare the real requirement with the real command
+    // (a JVM-jar linter needs 'jdk'; a build-stream gate like MSBuild needs
+    // the SDK + needsBuild + TFM-derived hosts — see csharp.ts).
+    execution(_cwd) {
+      // TODO(${id}): update alongside lintCommand.
+      return {
+        hosts: ['any'],
+        toolchains: [],
+        needsBuild: false,
+        buildTarget: 'none',
+        weight: 'cheap',
+      };
+    },
     lintCommand(_ctx) {
       // TODO(${id}): resolve the linter (findTool(TOOL_DEFS.<tool>, ctx.cwd)) and
       // return { bin, args, parse, expectedExit }; or return null (dormant).

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -18,6 +18,13 @@
 import { activeCorrectnessProviders } from '../../languages';
 import type { LanguageId, LanguageSupport } from '../../languages/types';
 import type { CorrectnessScope } from '../../languages/capabilities/correctness';
+import {
+  currentEnvironment,
+  describeUnmetRequirement,
+  unmetRequirement,
+  type ExecutionEnvironment,
+  type UnmetRequirement,
+} from '../../execution';
 // The spawn + timeout + fail-open exec primitive is shared with the custom-check
 // gate runner — one code path (Rule 2). Re-exported so existing callers (and
 // tests) keep importing `CommandExec` / `makeCommandExec` from here.
@@ -42,6 +49,14 @@ export type CorrectnessStatus =
    *  (This previously coded as `fail` and blocked — infrastructure failing closed,
    *  contrary to this module's own stated policy.) */
   | 'skipped-overflow'
+  /** The pack's declared `ExecutionRequirement` (Rule 20) is unmet here —
+   *  wrong host / missing ambient toolchain. Fail-OPEN like the other
+   *  infrastructure skips, but DISCLOSED: `unmet` carries the structured
+   *  reason so every surface can say WHERE the floor would run instead of
+   *  silently reporting nothing (the dpl-studio class). Checked BEFORE exec,
+   *  so a `dotnet build` of a Windows-only target never runs on Linux just to
+   *  fail in a way that reads as broken code. */
+  | 'skipped-environment'
   | 'skipped-none';
 
 export interface CorrectnessCheckResult {
@@ -51,6 +66,9 @@ export interface CorrectnessCheckResult {
   readonly status: CorrectnessStatus;
   /** Captured output tail — present only on `fail`, for the block message. */
   readonly output?: string;
+  /** Present only on `skipped-environment` — the structured unmet-requirement
+   *  reason (phrase via `describeUnmetRequirement`). */
+  readonly unmet?: UnmetRequirement;
 }
 
 export interface CorrectnessFloorResult {
@@ -73,6 +91,8 @@ export interface CorrectnessFloorOptions {
   readonly timeoutMs?: number;
   /** Injected for tests; defaults to real PATH resolution + execFileSync. */
   readonly exec?: CommandExec;
+  /** Injected for tests; defaults to the real local host + toolchain probes. */
+  readonly env?: ExecutionEnvironment;
 }
 
 /**
@@ -83,10 +103,20 @@ export interface CorrectnessFloorOptions {
  */
 export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessFloorResult {
   const exec = opts.exec ?? makeCommandExec(opts.timeoutMs);
+  const env = opts.env ?? currentEnvironment();
   const ctx = { cwd: opts.cwd, changedFiles: opts.changedFiles, scope: opts.scope };
   const checks: CorrectnessCheckResult[] = [];
 
   for (const { id, provider } of activeCorrectnessProviders(opts.packs)) {
+    // Rule 20: consult the pack's declared requirement BEFORE executing. An
+    // unmet environment is a disclosed boundary — running anyway would either
+    // fail-open invisibly (missing toolchain) or, worse, fail in a way that
+    // reads as broken code (a Windows-only build target on a Linux host).
+    const unmet = unmetRequirement(provider.execution(opts.cwd), env);
+    if (unmet !== null) {
+      checks.push({ pack: id, label: 'floor', bin: '', status: 'skipped-environment', unmet });
+      continue;
+    }
     const commands = [provider.syntaxCheck(ctx), provider.affectedTests(ctx)];
     for (const cmd of commands) {
       if (cmd === null) continue; // pack declined this check for this change
@@ -131,4 +161,17 @@ export function describeCorrectnessFloor(result: CorrectnessFloorResult): string
   if (failed.length === 0) return 'correctness floor: all checks passed';
   const which = failed.map((c) => `${c.pack} ${c.label}`).join(', ');
   return `correctness floor: ${failed.length} check(s) failed — ${which}`;
+}
+
+/** The environment-boundary disclosures in a floor result, one line per pack
+ *  (empty when none). Shared by every surface that renders a floor run, so a
+ *  capability that cannot run HERE is always named, with where it would run —
+ *  never a silent skip (Rule 20). */
+export function describeEnvironmentSkips(result: CorrectnessFloorResult): string[] {
+  return result.checks
+    .filter((c) => c.status === 'skipped-environment' && c.unmet)
+    .map(
+      (c) =>
+        `${c.pack} floor not measurable in this environment: ${describeUnmetRequirement(c.unmet as UnmetRequirement)}`,
+    );
 }

--- a/src/analyzers/correctness/surface-run.ts
+++ b/src/analyzers/correctness/surface-run.ts
@@ -31,6 +31,7 @@ import { computeChangedFiles } from '../../baseline/changed-files';
 import {
   runCorrectnessFloor,
   describeCorrectnessFloor,
+  describeEnvironmentSkips,
   type CommandExec,
   type CorrectnessFloorResult,
 } from './run';
@@ -164,14 +165,24 @@ export function runFloorForSurface(opts: RunFloorForSurfaceOptions): SurfaceFloo
     timeoutMs,
     exec: opts.exec,
   });
+  // A declared environment boundary is disclosed on every outcome — a floor
+  // that cannot run HERE names where it would run, never skips silently
+  // (Rule 20). Appended to the summary so hooks/CI logs carry it verbatim.
+  const envSkips = describeEnvironmentSkips(result);
+  const envSuffix = envSkips.length > 0 ? ` [${envSkips.join('; ')}]` : '';
   if (!result.ran) {
+    const cause =
+      envSkips.length > 0
+        ? 'not measurable in this environment'
+        : 'all checks skipped (toolchain not present)';
     return {
       surface,
       enabled: true,
       reason: res.reason,
       ran: false,
       blocks: false,
-      summary: `correctness floor (${surface}): all checks skipped (toolchain not present) — CI is the backstop`,
+      summary: `correctness floor (${surface}): ${cause} — CI is the backstop${envSuffix}`,
+      result,
     };
   }
   return {
@@ -180,7 +191,7 @@ export function runFloorForSurface(opts: RunFloorForSurfaceOptions): SurfaceFloo
     reason: res.reason,
     ran: true,
     blocks: result.blocks,
-    summary: describeCorrectnessFloor(result),
+    summary: describeCorrectnessFloor(result) + envSuffix,
     result,
   };
 }

--- a/src/analyzers/custom-checks/config.ts
+++ b/src/analyzers/custom-checks/config.ts
@@ -19,6 +19,7 @@ import type {
   RecallInputMode,
 } from '../../languages/capabilities/lint-gate';
 import { activeLintGateProviders } from '../../languages';
+import type { ExecutionRequirement } from '../../execution';
 import type { CustomCheckCommand, CustomCheckParse, CustomCheckSpec } from './types';
 
 /** The reserved prefix for pack-declared built-in lint checks. */
@@ -133,9 +134,31 @@ export function lintGateSpecs(
       // a reason to attribute less confidently, not to stop linting. An empty
       // set degrades to command-only recall, which is the pre-Rule-19 behavior.
       recallInputs: safeRecallInputs(id, provider, { ...ctx, mode }),
+      // What this gate NEEDS from the environment (Rule 20) — the runner
+      // consults it before spawning. Same fail-soft posture as recallInputs:
+      // a throwing declaration must not take the gate down; absence degrades
+      // to the plain fail-open missing-binary path.
+      ...safeExecution(id, provider, ctx.cwd),
     });
   }
   return specs;
+}
+
+function safeExecution(
+  id: string,
+  provider: { execution(cwd: string): ExecutionRequirement },
+  cwd: string,
+): { execution: ExecutionRequirement } | Record<string, never> {
+  try {
+    return { execution: provider.execution(cwd) };
+  } catch (err) {
+    if (process.env.DXKIT_DEBUG === '1') {
+      process.stderr.write(
+        `    [lint-gate] pack '${id}' execution threw: ${(err as Error)?.message ?? String(err)}\n`,
+      );
+    }
+    return {};
+  }
 }
 
 function safeRecallInputs(

--- a/src/analyzers/custom-checks/run.ts
+++ b/src/analyzers/custom-checks/run.ts
@@ -25,6 +25,12 @@
  */
 
 import { makeCommandExec, tail, type CommandExec } from '../tools/bounded-exec';
+import {
+  currentEnvironment,
+  describeUnmetRequirement,
+  unmetRequirement,
+  type ExecutionEnvironment,
+} from '../../execution';
 import { binaryFinding, parseLocated, parseStructuredLocated } from './parse';
 import type {
   CustomCheckFinding,
@@ -43,6 +49,8 @@ export interface RunCustomChecksOptions {
   readonly timeoutMs?: number;
   /** Injected for tests; defaults to real PATH resolution + execFileSync. */
   readonly exec?: CommandExec;
+  /** Injected for tests; defaults to the real local host + toolchain probes. */
+  readonly env?: ExecutionEnvironment;
 }
 
 /**
@@ -51,10 +59,27 @@ export interface RunCustomChecksOptions {
  */
 export function runCustomChecks(opts: RunCustomChecksOptions): CustomChecksRunResult {
   const exec = opts.exec ?? makeCommandExec(opts.timeoutMs);
+  const env = opts.env ?? currentEnvironment();
   const results: CustomCheckResult[] = [];
   const findings: CustomCheckFinding[] = [];
 
   for (const spec of opts.specs) {
+    // Rule 20: a check with a declared execution requirement is checked
+    // against the environment BEFORE spawning — an unrunnable command must
+    // not execute just to fail in a way the parser reads as a finding (the
+    // half-provisioned-SDK class), and the skip is disclosed, never silent.
+    if (spec.execution) {
+      const unmet = unmetRequirement(spec.execution, env);
+      if (unmet !== null) {
+        results.push({
+          name: spec.name,
+          status: 'skipped-environment',
+          findings: [],
+          reason: describeUnmetRequirement(unmet),
+        });
+        continue;
+      }
+    }
     const outcome = exec(spec.command, opts.cwd);
     if (!outcome.available) {
       results.push({ name: spec.name, status: 'skipped-unavailable', findings: [] });

--- a/src/analyzers/custom-checks/types.ts
+++ b/src/analyzers/custom-checks/types.ts
@@ -17,6 +17,7 @@
  */
 
 import type { RawLocatedFinding } from '../../languages/capabilities/lint-gate';
+import type { ExecutionRequirement } from '../../execution';
 
 /** The binary + args a check runs. `bin` is resolved on PATH by the shared
  *  `bounded-exec` primitive (a missing binary is fail-OPEN — skipped, not
@@ -93,6 +94,19 @@ export interface CustomCheckSpec {
    * (Rule 9).
    */
   readonly recallInputs?: Readonly<Record<string, string>>;
+  /**
+   * What this check NEEDS from the environment that runs it (Rule 20).
+   * Populated for pack-declared lint from `LintGateProvider.execution` — the
+   * runner consults it BEFORE spawning, so an unrunnable gate (a Windows-only
+   * `dotnet build` on a Linux host) is a disclosed `skipped-environment`
+   * boundary, never a spawn that fails in a way that reads as a finding.
+   *
+   * Absent for user-declared checks, mirroring `recallInputs`: dxkit cannot
+   * resolve what `make lint` needs, and inventing an answer would be worse
+   * than admitting the limit — such a check keeps the plain fail-open
+   * missing-binary path.
+   */
+  readonly execution?: ExecutionRequirement;
 }
 
 /** A single failure extracted from a check's output. Maps 1:1 to a
@@ -118,13 +132,23 @@ export type CustomCheckStatus =
    *  Fail-OPEN (never a block): a finding count parsed from a fragment is fiction,
    *  and it would slide between runs, so the baseline and the guardrail would
    *  disagree about what is net-new. */
-  | 'skipped-overflow';
+  | 'skipped-overflow'
+  /** The check's declared `ExecutionRequirement` (Rule 20) is unmet here —
+   *  wrong host / missing ambient toolchain. Fail-OPEN like the other skips
+   *  but DISCLOSED via `reason`, and decided BEFORE the spawn: an unrunnable
+   *  `dotnet build` must not execute just to fail in a way the parser would
+   *  surface as a binary finding (the half-provisioned-SDK class). */
+  | 'skipped-environment';
 
 /** Per-check outcome. `findings` is non-empty only on `fail`. */
 export interface CustomCheckResult {
   readonly name: string;
   readonly status: CustomCheckStatus;
   readonly findings: readonly CustomCheckFinding[];
+  /** Present on `skipped-environment`: the human-phrased unmet-requirement
+   *  boundary (from `describeUnmetRequirement`) — what is needed and where
+   *  the check would run instead. */
+  readonly reason?: string;
 }
 
 /** Aggregate result across every configured check. */

--- a/src/checks-cli.ts
+++ b/src/checks-cli.ts
@@ -148,6 +148,7 @@ function runChecksDryRun(
         name: r.name,
         status: r.status,
         findings: r.findings.length,
+        ...(r.reason ? { reason: r.reason } : {}),
       })),
       findings: result.findings,
       warnings,
@@ -162,6 +163,9 @@ function runChecksDryRun(
     const line = `  ${r.name.padEnd(22)} ${r.status}${r.findings.length ? ` (${r.findings.length})` : ''}`;
     if (r.status === 'fail') logger.warn(line);
     else logger.dim(line);
+    // An environment boundary is always disclosed with its remedy/placement
+    // (Rule 20) — a check that cannot run HERE never skips silently.
+    if (r.reason) logger.dim(`    ↳ ${r.reason}`);
   }
   console.log(''); // slop-ok
   logger.info(describeCustomChecks(result));

--- a/src/execution/environment.ts
+++ b/src/execution/environment.ts
@@ -1,0 +1,44 @@
+/**
+ * The AVAILABILITY side of the execution-environment model: what THIS machine
+ * is (host OS) and has (toolchains). The requirement side is repo-intrinsic
+ * and lives in `requirement.ts`; `unmetRequirement` compares the two.
+ *
+ * This module is the ONE place host detection lives (arch-check enforced —
+ * new `process.platform` reads outside the pre-existing allowlist fail CI).
+ * Point checks scattered per consumer are exactly how the implicit
+ * "the driver's machine can run everything" assumption survived unexamined.
+ */
+
+import { toolchainPresent, type ToolchainId } from './toolchains';
+import type { ExecutionEnvironment, ExecutionHost } from './requirement';
+
+/** Map a Node platform id to an execution host. Non-win/mac POSIX platforms
+ *  (the BSDs, AIX) are treated as linux — the POSIX approximation is right
+ *  for every placement decision dxkit makes (toolchain availability, CI
+ *  runner selection), and GitHub-hosted runners offer exactly these three. */
+export function hostOf(platform: NodeJS.Platform = process.platform): ExecutionHost {
+  if (platform === 'win32') return 'windows';
+  if (platform === 'darwin') return 'macos';
+  return 'linux';
+}
+
+/**
+ * The local environment, with toolchain probes memoized for the lifetime of
+ * the returned object. Callers hold one instance per run (a runner probes the
+ * same toolchain for several packs); nothing is cached module-globally, so a
+ * toolchain installed between runs is seen by the next run — the walk-cache
+ * staleness class stays closed.
+ */
+export function currentEnvironment(): ExecutionEnvironment {
+  const probed = new Map<ToolchainId, boolean>();
+  return {
+    host: hostOf(),
+    hasToolchain(id: ToolchainId): boolean {
+      const hit = probed.get(id);
+      if (hit !== undefined) return hit;
+      const present = toolchainPresent(id);
+      probed.set(id, present);
+      return present;
+    },
+  };
+}

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -1,0 +1,29 @@
+/**
+ * The execution-environment platform (CLAUDE.md Rule 20) — barrel.
+ *
+ * Requirement (repo-intrinsic, pack-declared) vs environment (host-intrinsic),
+ * compared by the ONE predicate `unmetRequirement`. The toolchain registry
+ * declares per-host provisioning for the ambient SDKs requirements name.
+ */
+
+export {
+  unmetRequirement,
+  describeUnmetRequirement,
+  type ExecutionHost,
+  type HostRequirement,
+  type ExecutionRequirement,
+  type ExecutionRequirementFor,
+  type ExecutionEnvironment,
+  type UnmetRequirement,
+} from './requirement';
+
+export { currentEnvironment, hostOf } from './environment';
+
+export {
+  TOOLCHAIN_DEFS,
+  toolchainPresent,
+  toolchainInstallHint,
+  type ToolchainId,
+  type ToolchainDef,
+  type ToolchainHealthCheck,
+} from './toolchains';

--- a/src/execution/requirement.ts
+++ b/src/execution/requirement.ts
@@ -1,0 +1,156 @@
+/**
+ * The execution-environment REQUIREMENT model — the third pack-declared
+ * dimension alongside language and capability (CLAUDE.md Rule 20).
+ *
+ * dxkit's original model implicitly assumed "the machine driving the analysis
+ * can also build and scan the repo". That is false for any stack that needs a
+ * specific provisioned environment (a `net9.0-windows` WinForms build needs
+ * Windows + the .NET SDK + a chosen solution; a Swift scheme needs macOS +
+ * Xcode). When the assumption broke, capabilities either silently fail-open
+ * skipped (an invisible coverage gap) or misread an environment problem as a
+ * code finding. The fix is to make the requirement EXPLICIT: every capability
+ * that executes repo-facing commands declares what it needs, and every
+ * "can this run here?" question is answered by the ONE predicate in this
+ * module — never by a scattered `process.platform` check or a bare
+ * binary-missing skip.
+ *
+ * Two separated concerns, deliberately:
+ *   - a REQUIREMENT is repo-intrinsic — a pure function of the repository's
+ *     contents (its TFMs, its build system), never of the current machine.
+ *     Declaring it must be deterministic and environment-independent, the same
+ *     discipline recall inputs follow (Rule 19): a requirement that embeds a
+ *     machine fact would read differently on every host and poison placement.
+ *   - AVAILABILITY is host-intrinsic — what this machine is and has
+ *     (`src/execution/environment.ts`).
+ * `unmetRequirement` compares the two. The placement resolver (the 4.0
+ * increment that routes capabilities to CI jobs) composes on the same
+ * predicate; local runners use it today to disclose an environment boundary
+ * instead of skipping silently.
+ */
+
+import type { ToolchainId } from './toolchains';
+
+/** An operating-system host a capability can execute on. */
+export type ExecutionHost = 'linux' | 'macos' | 'windows';
+
+/** A host constraint: a concrete host, or `'any'` (no OS constraint). */
+export type HostRequirement = ExecutionHost | 'any';
+
+/**
+ * What a capability needs from the environment that runs it.
+ *
+ * `toolchains` names AMBIENT toolchains (SDKs / runtimes the ecosystem owns:
+ * the .NET SDK, a JDK, the Go distribution) — the things `vyuh-dxkit tools
+ * install` deliberately does NOT manage. Registry TOOLS (gitleaks, ruff,
+ * osv-scanner…) are NOT listed here: their detection and provisioning already
+ * flow through `findTool` / the tool registry (Rule 1), and a missing tool is
+ * the runners' existing fail-open path. The boundary line: if `tools install`
+ * can provision it, it is a tool; if the repo's ecosystem provisions it, it is
+ * a toolchain and belongs in this declaration.
+ */
+export interface ExecutionRequirement {
+  /** Hosts that can run this capability. Non-empty; `['any']` means no OS
+   *  constraint. Repo-derived where the truth is repo-dependent (a
+   *  `net9.0-windows` TFM narrows the C# build to `['windows']`). */
+  readonly hosts: readonly HostRequirement[];
+  /** Ambient toolchains required (see the tool/toolchain boundary above).
+   *  Every id must resolve in `TOOLCHAIN_DEFS` — contract-tested. */
+  readonly toolchains: readonly ToolchainId[];
+  /** The capability must COMPILE the project, so it needs the complete build
+   *  environment (restored packages, generated sources, the works) — not just
+   *  the toolchain binary on PATH. */
+  readonly needsBuild: boolean;
+  /**
+   * How the build/run target is resolved:
+   *   - `'none'`       — no target concept (a linter over files, a lockfile scan).
+   *   - `'discovered'` — the toolchain/pack can find the target itself
+   *                      (a root `.sln`, Cargo's workspace, Go's `./...`).
+   *   - `'configured'` — ambiguous without user configuration (the 29-`.sln`
+   *                      repo with no root solution).
+   */
+  readonly buildTarget: 'none' | 'discovered' | 'configured';
+  /** Placement cost: `'cheap'` runs in seconds without touching the project's
+   *  own build (a file scan, a lockfile audit); `'build'` runs the project's
+   *  toolchain over the tree (compile, test suite, CodeQL DB). */
+  readonly weight: 'cheap' | 'build';
+}
+
+/** A requirement builder: pure, deterministic, repo-intrinsic. Reads repo
+ *  files only — NEVER the current machine (no PATH probes, no
+ *  `process.platform`); availability is `environment.ts`'s side of the line. */
+export type ExecutionRequirementFor = (cwd: string) => ExecutionRequirement;
+
+/** The environment surface `unmetRequirement` reads. `currentEnvironment`
+ *  (environment.ts) produces the real one; tests and the future placement
+ *  resolver (which reasons about REMOTE environments: the ubuntu / windows /
+ *  macos CI runners) construct their own. */
+export interface ExecutionEnvironment {
+  readonly host: ExecutionHost;
+  hasToolchain(id: ToolchainId): boolean;
+}
+
+/**
+ * Why a requirement is not satisfied here. Structured so renderers can phrase
+ * it and the placement resolver can route on it — never a prose-only reason.
+ *
+ * `unhealthy-toolchain` is reserved for the provisioning increment (a toolchain
+ * present but failing its registry health check — the half-provisioned-SDK
+ * class); this increment mints only the first two kinds.
+ */
+export type UnmetRequirement =
+  | {
+      readonly kind: 'wrong-host';
+      readonly requiredHosts: readonly ExecutionHost[];
+      readonly currentHost: ExecutionHost;
+    }
+  | { readonly kind: 'missing-toolchain'; readonly toolchains: readonly ToolchainId[] }
+  | {
+      readonly kind: 'unhealthy-toolchain';
+      readonly toolchain: ToolchainId;
+      readonly problem: string;
+    };
+
+/**
+ * THE satisfaction predicate — every "can this capability run in this
+ * environment?" decision routes through here (arch-check enforced). Returns
+ * `null` when satisfied, else the first (most fundamental) unmet dimension:
+ * the wrong OS makes toolchain presence irrelevant, so host is checked first.
+ */
+export function unmetRequirement(
+  req: ExecutionRequirement,
+  env: ExecutionEnvironment,
+): UnmetRequirement | null {
+  if (!req.hosts.includes('any') && !req.hosts.includes(env.host)) {
+    return {
+      kind: 'wrong-host',
+      requiredHosts: req.hosts.filter((h): h is ExecutionHost => h !== 'any'),
+      currentHost: env.host,
+    };
+  }
+  const missing = req.toolchains.filter((t) => !env.hasToolchain(t));
+  if (missing.length > 0) return { kind: 'missing-toolchain', toolchains: missing };
+  return null;
+}
+
+/**
+ * One human line for an unmet requirement — shared by every renderer so the
+ * boundary is phrased once. Says WHERE the capability can run, not just that
+ * it can't run here: the point of the model is that "not here" is a routing
+ * fact, not a dead end.
+ */
+export function describeUnmetRequirement(unmet: UnmetRequirement): string {
+  switch (unmet.kind) {
+    case 'wrong-host':
+      return (
+        `needs ${unmet.requiredHosts.join(' or ')} (this environment is ${unmet.currentHost}) — ` +
+        `runs where that host is available (e.g. a ${unmet.requiredHosts[0]} CI job)`
+      );
+    case 'missing-toolchain':
+      return (
+        `needs the ${unmet.toolchains.join(', ')} toolchain${unmet.toolchains.length > 1 ? 's' : ''} — ` +
+        `not present in this environment`
+      );
+    case 'unhealthy-toolchain':
+      return `the ${unmet.toolchain} toolchain is present but not usable here: ${unmet.problem}`;
+  }
+}

--- a/src/execution/toolchains.ts
+++ b/src/execution/toolchains.ts
@@ -1,0 +1,194 @@
+/**
+ * The toolchain-provisioning registry — ambient SDKs / runtimes that
+ * capabilities may require (`ExecutionRequirement.toolchains`), declared once
+ * with per-host installation and health facts (CLAUDE.md Rule 20).
+ *
+ * This is the toolchain sibling of the TOOL registry (Rule 1): `TOOL_DEFS`
+ * owns scanners dxkit can install itself (`tools install`); `TOOLCHAIN_DEFS`
+ * owns the ecosystems' own SDKs, which dxkit never installs unasked — it
+ * DETECTS them, NAMES the per-host install when one is missing, and (in the
+ * placement increment) routes the capability to an environment that has them.
+ * The boundary: if `tools install` can provision it, it is a tool; if the
+ * repo's ecosystem provisions it, it is a toolchain.
+ *
+ * Install commands prefer a NON-PRIVILEGED default per host (the
+ * `dotnet-install.sh --install-dir $HOME/.dotnet` class — the same paths
+ * `getSystemPaths()` already probes), and `fallback` is a URL that works when
+ * no package manager does. Never surface a raw "command not recognized" from
+ * a package manager the host doesn't have — name the remedy from THIS
+ * registry.
+ *
+ * `healthChecks` declares the present-but-unusable class (dotnet on a
+ * libicu-less Linux). This increment declares them; the provisioning
+ * increment executes them and mints `unhealthy-toolchain` boundaries.
+ */
+
+import { commandExists } from '../analyzers/tools/runner';
+import type { ExecutionHost } from './requirement';
+
+/** A declared way a present toolchain can still be unusable, with the probe
+ *  a later increment runs and the remedy to name when it fails. */
+export interface ToolchainHealthCheck {
+  readonly id: string;
+  /** What breaks when the check fails (human line). */
+  readonly problem: string;
+  /** The actionable remedy — a command or a setting, never a bare error. */
+  readonly remedy: string;
+}
+
+export interface ToolchainDef {
+  readonly id: string;
+  readonly displayName: string;
+  /** Binaries whose PATH presence means "this toolchain is available".
+   *  First match wins; multiple entries cover per-host naming (python3 vs
+   *  python). Probed via the canonical `commandExists` PATH walk — the same
+   *  probe doctor's toolchain coverage uses, so the two surfaces cannot
+   *  disagree about presence. */
+  readonly binaries: readonly string[];
+  /** Per-host install command (non-privileged default where one exists) and
+   *  a fallback URL for hosts where no one-liner is honest. */
+  readonly install: Partial<Record<ExecutionHost, string>> & { readonly fallback: string };
+  readonly healthChecks?: readonly ToolchainHealthCheck[];
+}
+
+/**
+ * The registry. `ToolchainId` is derived from it, so a pack declaring an
+ * unregistered toolchain fails to COMPILE — the same closed-union discipline
+ * `LanguageId` follows.
+ */
+export const TOOLCHAIN_DEFS = {
+  node: {
+    id: 'node',
+    displayName: 'Node.js',
+    binaries: ['node'],
+    install: {
+      linux:
+        'curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash && nvm install --lts',
+      macos: 'brew install node',
+      windows: 'winget install OpenJS.NodeJS.LTS',
+      fallback: 'https://nodejs.org/en/download',
+    },
+  },
+  python: {
+    id: 'python',
+    displayName: 'Python',
+    binaries: ['python3', 'python'],
+    install: {
+      linux: 'sudo apt-get install -y python3 python3-pip # or your distro equivalent',
+      macos: 'brew install python',
+      windows: 'winget install Python.Python.3.12',
+      fallback: 'https://www.python.org/downloads/',
+    },
+  },
+  go: {
+    id: 'go',
+    displayName: 'Go',
+    binaries: ['go'],
+    install: {
+      // Non-sudo default: the tarball into a user-owned toolchain dir (the
+      // path the 3.9 evaluation provisioned by hand and getSystemPaths probes
+      // via PATH).
+      linux:
+        'curl -fsSL https://go.dev/dl/go1.22.5.linux-amd64.tar.gz | tar -C $HOME/.local/toolchains -xz && export PATH="$HOME/.local/toolchains/go/bin:$PATH"',
+      macos: 'brew install go',
+      windows: 'winget install GoLang.Go',
+      fallback: 'https://go.dev/dl/',
+    },
+  },
+  rust: {
+    id: 'rust',
+    displayName: 'Rust',
+    binaries: ['cargo', 'rustc'],
+    install: {
+      linux: 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y',
+      macos: 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y',
+      windows: 'winget install Rustlang.Rustup',
+      fallback: 'https://rustup.rs',
+    },
+  },
+  'dotnet-sdk': {
+    id: 'dotnet-sdk',
+    displayName: '.NET SDK',
+    binaries: ['dotnet'],
+    install: {
+      // Microsoft's recommended non-sudo path — installs to $HOME/.dotnet,
+      // which getSystemPaths() already probes. Never `apt`/`scoop` first: the
+      // class that shipped a raw "'scoop' is not recognized".
+      linux:
+        'curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --install-dir $HOME/.dotnet && export PATH="$HOME/.dotnet:$PATH"',
+      macos: 'brew install dotnet-sdk',
+      windows: 'winget install Microsoft.DotNet.SDK.9',
+      fallback: 'https://dot.net/v1/dotnet-install.sh',
+    },
+    healthChecks: [
+      {
+        id: 'libicu',
+        problem: 'dotnet aborts at startup on Linux hosts without libicu (globalization support)',
+        remedy:
+          'install libicu (e.g. `sudo apt-get install -y libicu-dev`) or set DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
+      },
+    ],
+  },
+  jdk: {
+    id: 'jdk',
+    displayName: 'JDK',
+    binaries: ['java'],
+    install: {
+      linux:
+        'curl -fsSL https://api.adoptium.net/v3/binary/latest/21/ga/linux/x64/jdk/hotspot/normal/eclipse | tar -C $HOME/.local/toolchains -xz',
+      macos: 'brew install openjdk@21',
+      windows: 'winget install Microsoft.OpenJDK.21',
+      fallback: 'https://adoptium.net/temurin/releases/',
+    },
+  },
+  maven: {
+    id: 'maven',
+    displayName: 'Maven',
+    binaries: ['mvn'],
+    install: {
+      linux: 'sudo apt-get install -y maven # or use the repo-committed ./mvnw wrapper',
+      macos: 'brew install maven',
+      windows: 'winget install Apache.Maven',
+      fallback: 'https://maven.apache.org/install.html',
+    },
+  },
+  gradle: {
+    id: 'gradle',
+    displayName: 'Gradle',
+    binaries: ['gradle'],
+    install: {
+      linux: 'sudo apt-get install -y gradle # or use the repo-committed ./gradlew wrapper',
+      macos: 'brew install gradle',
+      windows: 'winget install Gradle.Gradle',
+      fallback: 'https://gradle.org/install/',
+    },
+  },
+  ruby: {
+    id: 'ruby',
+    displayName: 'Ruby',
+    binaries: ['ruby'],
+    install: {
+      linux: 'sudo apt-get install -y ruby-full # or rbenv for a user-local install',
+      macos: 'brew install ruby',
+      windows: 'winget install RubyInstallerTeam.Ruby.3.2',
+      fallback: 'https://www.ruby-lang.org/en/documentation/installation/',
+    },
+  },
+} as const satisfies Record<string, ToolchainDef>;
+
+/** Closed union of registered toolchains — derived, never hand-maintained. */
+export type ToolchainId = keyof typeof TOOLCHAIN_DEFS;
+
+/** Is this toolchain present here? PATH-derived via the ONE canonical probe
+ *  (`commandExists`), so this module, doctor, and the toolchain-coverage
+ *  signal all answer presence identically. */
+export function toolchainPresent(id: ToolchainId): boolean {
+  return TOOLCHAIN_DEFS[id].binaries.some((bin) => commandExists(bin));
+}
+
+/** The install command for a toolchain on a host — the actionable remedy line
+ *  renderers surface instead of a raw "not recognized" error. */
+export function toolchainInstallHint(id: ToolchainId, host: ExecutionHost): string {
+  const def = TOOLCHAIN_DEFS[id];
+  return def.install[host] ?? def.install.fallback;
+}

--- a/src/languages/capabilities/correctness.ts
+++ b/src/languages/capabilities/correctness.ts
@@ -39,6 +39,8 @@ export interface CorrectnessCommand {
   readonly args: readonly string[];
 }
 
+import type { ExecutionRequirement } from '../../execution';
+
 /**
  * A pack's correctness-floor provider. Both methods are pure command builders —
  * they inspect the repo + changed files and return the command to run (or
@@ -54,4 +56,22 @@ export interface CorrectnessProvider {
    *  CI's `full` scope as the backstop. Returns `null` when nothing relevant
    *  changed, or when the pack has no test command at all. */
   affectedTests(ctx: CorrectnessContext): CorrectnessCommand | null;
+  /**
+   * What the floor NEEDS from the environment that runs it (CLAUDE.md Rule 20):
+   * host OS, ambient toolchains, whether it builds the project, how its target
+   * resolves. REQUIRED — the pre-declaration model implicitly assumed
+   * `{ hosts: any, toolchains: [], needsBuild: false }` for every floor, which
+   * was wrong on every axis for compiled stacks (`dotnet build` of a
+   * `net9.0-windows` target on a Linux driver). The runner consults this
+   * BEFORE executing, so an unrunnable floor is a disclosed environment
+   * boundary, never a silent binary-missing skip; the placement resolver
+   * routes on the same declaration.
+   *
+   * Pure and repo-intrinsic: reads repo files only (a `.csproj` TFM, the build
+   * system present), NEVER the current machine — availability is the
+   * environment model's side of the line. Deterministic across calls with no
+   * machine-specific values, the same contract-tested discipline as
+   * `recallInputs` (Rule 19).
+   */
+  execution(cwd: string): ExecutionRequirement;
 }

--- a/src/languages/capabilities/lint-gate.ts
+++ b/src/languages/capabilities/lint-gate.ts
@@ -106,11 +106,29 @@ export interface LintGateRecallContext extends LintGateContext {
   readonly mode: RecallInputMode;
 }
 
+import type { ExecutionRequirement } from '../../execution';
+
 /** A pack's lint-gate provider. Pure command builder — it resolves the linter
  *  and returns the command (or `null` to skip); execution + fail-open policy
  *  live in the custom-check runner (a pack never shells out itself). */
 export interface LintGateProvider {
   lintCommand(ctx: LintGateContext): LintGateCommand | null;
+
+  /**
+   * What the gate NEEDS from the environment that runs it (CLAUDE.md Rule 20).
+   * REQUIRED. Most linters are host-agnostic and cheap; the exception is the
+   * class that shipped as a defect — the C# gate reads Roslyn warnings out of
+   * `dotnet build`, which needs the .NET SDK, a build, and (for a
+   * `net*-windows` target) a Windows host. Declaring the truth lets the
+   * custom-check runner disclose an environment boundary instead of a silent
+   * skip, and lets the placement resolver put the gate where it can run.
+   * A dormant gate (`lintCommand` returns null unconditionally) declares the
+   * empty requirement — nothing runs, so nothing is needed.
+   *
+   * Pure and repo-intrinsic (repo files only, never the current machine);
+   * deterministic — same discipline as `recallInputs` below.
+   */
+  execution(cwd: string): ExecutionRequirement;
 
   /**
    * What determines what THIS pack's linter can see, beyond its command

--- a/src/languages/capabilities/provider.ts
+++ b/src/languages/capabilities/provider.ts
@@ -17,6 +17,7 @@ import type {
   LintGatherOutcome,
   LintResult,
 } from './types';
+import type { ExecutionRequirement } from '../../execution';
 
 /**
  * Outcome of a side-effecting `runTests()` invocation (D021).
@@ -116,6 +117,19 @@ export interface DepVulnGatherOptions {
 
 export interface DepVulnsProvider extends CapabilityProvider<DepVulnResult> {
   gatherOutcome(cwd: string, opts?: DepVulnGatherOptions): Promise<DepVulnGatherOutcome>;
+  /**
+   * What the audit NEEDS from the environment that runs it (CLAUDE.md
+   * Rule 20). REQUIRED. Registry tools (osv-scanner, pip-audit) are NOT
+   * declared here — `findTool` owns their lifecycle (Rule 1); this names the
+   * AMBIENT toolchains the audit shells beyond them: `npm audit` needs node,
+   * `govulncheck` needs the Go toolchain for call analysis, while a pure
+   * lockfile scan (osv-scanner on Gemfile.lock / a Maven tree) needs none.
+   *
+   * Pure and repo-intrinsic; deterministic. Field addition is a deliberate
+   * change to the frozen-in-place pack contract — pinned alongside
+   * `manifestPatterns` in `test/sdk-surface-freeze.test.ts`.
+   */
+  execution(cwd: string): ExecutionRequirement;
   /**
    * Filenames / patterns that identify this pack's dependency manifests and
    * lockfiles (e.g. `package.json`, `package-lock.json`, `*.csproj`,

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -44,6 +44,7 @@ import type {
 import type { LanguageSupport, LintSeverity } from './types';
 import type { LintGateProvider } from './capabilities/lint-gate';
 import { hashFileInput } from './capabilities/recall-inputs';
+import type { ExecutionRequirement } from '../execution';
 
 /**
  * Run dxkit's OWN `dotnet` subprocesses (build / format / test for ANALYSIS,
@@ -949,6 +950,18 @@ function hasCsharpProject(cwd: string): boolean {
 
 const csharpDepVulnsProvider: DepVulnsProvider = {
   source: 'csharp',
+  // Host-agnostic BY DESIGN, unlike the build-based C# capabilities: the
+  // osv-scanner half (a registry tool — Rule 1) reads committed
+  // packages.lock.json / PackageReference entries with no dotnet and no
+  // build, precisely so dependency auditing works where the Windows build
+  // cannot run. The dotnet half enriches when present; it is not required.
+  execution: (): ExecutionRequirement => ({
+    hosts: ['any'],
+    toolchains: [],
+    needsBuild: false,
+    buildTarget: 'none',
+    weight: 'cheap',
+  }),
   manifestPatterns: [
     '*.csproj',
     '*.sln',
@@ -1507,6 +1520,45 @@ function csharpIsTestProject(cwd: string, relProj: string): boolean {
 }
 
 /**
+ * Does any project in this repo target Windows? A `net*-windows` TFM (or an
+ * explicit WinForms/WPF opt-in) makes the BUILD Windows-only — `dotnet build`
+ * of such a target on Linux/macOS fails on missing Windows Desktop reference
+ * packs. This is the repo fact that narrows every build-based C# capability's
+ * host requirement (Rule 20): the dpl-studio class, where a Linux driver
+ * could never produce the build half of the gate and nothing said so.
+ */
+function csharpTargetsWindows(cwd: string): boolean {
+  for (const csproj of walkPaths(cwd, { extensions: ['.csproj'] })) {
+    const content = readRepoFile(cwd, csproj);
+    if (
+      /<TargetFrameworks?>[^<]*-windows/i.test(content) ||
+      /<UseWindowsForms>\s*true/i.test(content) ||
+      /<UseWPF>\s*true/i.test(content)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * The execution requirement every BUILD-based C# capability shares (floor,
+ * Roslyn lint gate, CodeQL extraction): the .NET SDK, a project build, hosts
+ * narrowed to Windows when the repo targets it, and a build target that is
+ * `discovered` only when `dotnet` can auto-resolve one (a root `.sln` /
+ * `.csproj`) — the 29-solutions-no-root repo is `configured`.
+ */
+function csharpBuildExecution(cwd: string): ExecutionRequirement {
+  return {
+    hosts: csharpTargetsWindows(cwd) ? ['windows'] : ['any'],
+    toolchains: ['dotnet-sdk'],
+    needsBuild: true,
+    buildTarget: csharpHasBuildTarget(cwd) ? 'discovered' : 'configured',
+    weight: 'build',
+  };
+}
+
+/**
  * The C# correctness floor.
  *
  * syntaxCheck: `dotnet build` — compiles the solution/project `dotnet`
@@ -1521,6 +1573,8 @@ function csharpIsTestProject(cwd: string, relProj: string): boolean {
  * isn't cheaply resolvable. A change touching no `.cs` on the fast surface skips.
  */
 const csharpCorrectnessProvider: CorrectnessProvider = {
+  execution: csharpBuildExecution,
+
   syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
     if (!csharpHasBuildTarget(ctx.cwd)) return null;
     ensureDotnetInvariant();
@@ -1565,6 +1619,11 @@ export const CSHARP_MSBUILD_WARNING_PARSE =
  * `dotnet format --verify-no-changes`.)
  */
 const csharpLintGateProvider: LintGateProvider = {
+  // The gate reads Roslyn analyzer warnings out of `dotnet build` — it is a
+  // BUILD, with everything that implies (SDK, host, target). The
+  // pre-declaration model implicitly claimed `{ hosts: any, toolchains: [],
+  // needsBuild: false }` here, which was wrong on every axis.
+  execution: csharpBuildExecution,
   lintCommand() {
     ensureDotnetInvariant();
     return {
@@ -1896,7 +1955,7 @@ export const csharp: LanguageSupport = {
   // p/csharp semgrep ruleset is sparse — skip until it matures.
   semgrepRulesets: [],
   // CodeQL `csharp` extractor needs a build; Snyk Code supports C#.
-  deepSast: { codeqlLanguage: 'csharp', codeqlBuildRequired: true, snykCode: true },
+  deepSast: { codeqlLanguage: 'csharp', snykCode: true, execution: csharpBuildExecution },
 
   correctness: csharpCorrectnessProvider,
   lintGate: csharpLintGateProvider,

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -24,6 +24,7 @@ import type {
   CorrectnessContext,
   CorrectnessProvider,
 } from './capabilities/correctness';
+import type { ExecutionRequirement } from '../execution';
 import type {
   CoverageResult,
   DepVulnFinding,
@@ -454,6 +455,9 @@ async function gatherGoDepVulnsResult(cwd: string): Promise<DepVulnGatherOutcome
 
 const goDepVulnsProvider: DepVulnsProvider = {
   source: 'go',
+  // govulncheck's call analysis compiles the module — the audit is only as
+  // available as the Go build environment.
+  execution: () => GO_BUILD_EXECUTION,
   manifestPatterns: ['go.mod', 'go.sum'],
   // Every go.mod is an independent module root (multi-module repos).
   lockfilePatterns: ['go.mod'],
@@ -919,7 +923,20 @@ function goChangedPackages(changedFiles: readonly string[]): string[] {
  * false-blocks. (Package-level rung — Go has no per-test impact selection; a
  * change to a package whose DEPENDENTS have tests is caught at full/CI scope.)
  */
+/** Rule 20: Go's floor, lint gate, and vuln audit all compile packages (go
+ *  build / golangci-lint's type-check / govulncheck's call analysis), so each
+ *  needs the Go toolchain + a build; `./...` discovers the target itself. */
+const GO_BUILD_EXECUTION: ExecutionRequirement = {
+  hosts: ['any'],
+  toolchains: ['go'],
+  needsBuild: true,
+  buildTarget: 'discovered',
+  weight: 'build',
+};
+
 const goCorrectnessProvider: CorrectnessProvider = {
+  execution: () => GO_BUILD_EXECUTION,
+
   syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
     if (!fileExists(ctx.cwd, 'go.mod')) return null; // not a module
     // No `commandExists('go')` gate here — the runner fail-opens on a missing
@@ -977,6 +994,9 @@ export function parseGolangciJson(output: string): RawLocatedFinding[] {
 }
 
 const goLintGateProvider: LintGateProvider = {
+  // golangci-lint type-checks the packages it lints — it needs the Go
+  // toolchain and a loadable build, not just its own binary.
+  execution: () => GO_BUILD_EXECUTION,
   lintCommand(ctx) {
     const gl = findTool(TOOL_DEFS['golangci-lint'], ctx.cwd);
     if (!gl.available || !gl.path) return null;
@@ -1184,7 +1204,12 @@ export const go: LanguageSupport = {
   tools: ['golangci-lint', 'govulncheck', 'go-licenses'],
   semgrepRulesets: ['p/gosec'],
   // CodeQL `go` extractor needs a build (autobuild); Snyk Code supports Go.
-  deepSast: { codeqlLanguage: 'go', codeqlBuildRequired: true, snykCode: true },
+  deepSast: {
+    codeqlLanguage: 'go',
+    snykCode: true,
+    // CodeQL's Go extractor builds the module to trace it.
+    execution: () => GO_BUILD_EXECUTION,
+  },
 
   correctness: goCorrectnessProvider,
   lintGate: goLintGateProvider,

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -8,7 +8,8 @@ import { gatherOsvScannerDepVulnsResult } from '../analyzers/tools/osv-scanner-d
 import { fileExists, run } from '../analyzers/tools/runner';
 import { runTestsWithCoverage } from '../analyzers/tools/run-tests-helper';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
-import { isAndroidGradleBuild, jvmCorrectnessProvider } from './jvm-build';
+import { isAndroidGradleBuild, jvmBuildExecution, jvmCorrectnessProvider } from './jvm-build';
+import type { ExecutionRequirement } from '../execution';
 import type {
   CapabilityProvider,
   DepVulnsProvider,
@@ -400,6 +401,15 @@ const JAVA_DEP_MANIFESTS = ['gradle.lockfile', 'pom.xml', 'gradle/verification-m
 
 const javaDepVulnsProvider: DepVulnsProvider = {
   source: 'java',
+  // osv-scanner (a registry tool — Rule 1) reads the Maven/Gradle manifests
+  // directly; no build, no ambient toolchain.
+  execution: (): ExecutionRequirement => ({
+    hosts: ['any'],
+    toolchains: [],
+    needsBuild: false,
+    buildTarget: 'none',
+    weight: 'cheap',
+  }),
   // osv-scanner audits JAVA_DEP_MANIFESTS; the build scripts carry the actual
   // dependency declarations, so include them for the incremental skip check.
   manifestPatterns: [
@@ -719,7 +729,7 @@ export const java: LanguageSupport = {
   // Semgrep ships a Java ruleset under p/java.
   semgrepRulesets: ['p/java'],
   // CodeQL `java` extractor needs a build; Snyk Code supports Java.
-  deepSast: { codeqlLanguage: 'java', codeqlBuildRequired: true, snykCode: true },
+  deepSast: { codeqlLanguage: 'java', snykCode: true, execution: jvmBuildExecution },
 
   correctness: javaCorrectnessProvider,
   // Lint gate: DORMANT. Java linters (checkstyle/PMD/SpotBugs) run via the build
@@ -730,7 +740,19 @@ export const java: LanguageSupport = {
   // whose recall could drift. An empty input set is the accurate answer here,
   // not a stub — when a real command is pinned, its versions + config land
   // alongside it.
-  lintGate: { lintCommand: () => null, recallInputs: () => ({}) },
+  lintGate: {
+    lintCommand: () => null,
+    recallInputs: () => ({}),
+    // Dormant gate: nothing runs, so nothing is required — the empty
+    // requirement is the accurate answer, mirroring the empty recall inputs.
+    execution: () => ({
+      hosts: ['any'],
+      toolchains: [],
+      needsBuild: false,
+      buildTarget: 'none',
+      weight: 'cheap',
+    }),
+  },
 
   capabilities: {
     imports: javaImportsProvider,

--- a/src/languages/jvm-build.ts
+++ b/src/languages/jvm-build.ts
@@ -36,6 +36,7 @@ import type {
   CorrectnessContext,
   CorrectnessProvider,
 } from './capabilities/correctness';
+import type { ExecutionRequirement, ToolchainId } from '../execution';
 
 type JvmBuildSystem = 'maven' | 'gradle';
 
@@ -196,6 +197,28 @@ function testCommandForModules(build: JvmBuild, mods: readonly string[]): Correc
   return { label: 'affected-tests', bin: build.bin, args: tasks };
 }
 
+/**
+ * The JVM build execution requirement (Rule 20), shared by both JVM packs and
+ * every build-based JVM capability (floor, deep SAST). Repo-intrinsic: the
+ * toolchain list names the build system the REPO uses — and a committed
+ * wrapper (`mvnw` / `gradlew`) provisions its own build tool, so only the JDK
+ * remains ambient in that case. Compile + tests are a build with a
+ * module-discovered target.
+ */
+export function jvmBuildExecution(cwd: string): ExecutionRequirement {
+  const toolchains: ToolchainId[] = ['jdk'];
+  const build = detectJvmBuild(cwd);
+  if (build?.system === 'maven' && !fileExists(cwd, 'mvnw')) toolchains.push('maven');
+  if (build?.system === 'gradle' && !fileExists(cwd, 'gradlew')) toolchains.push('gradle');
+  return {
+    hosts: ['any'],
+    toolchains,
+    needsBuild: true,
+    buildTarget: 'discovered',
+    weight: 'build',
+  };
+}
+
 export interface JvmCorrectnessOptions {
   /** Extensions that count as a relevant source change (`.java`, `.kt`/`.kts`). */
   readonly sourceExtensions: readonly string[];
@@ -214,6 +237,8 @@ export function jvmCorrectnessProvider(opts: JvmCorrectnessOptions): Correctness
   const isSource = (f: string): boolean => opts.sourceExtensions.some((e) => f.endsWith(e));
 
   return {
+    execution: jvmBuildExecution,
+
     syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
       if (opts.declineWhen?.(ctx.cwd)) return null;
       const build = detectJvmBuild(ctx.cwd);

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -9,7 +9,8 @@ import { walkSourceFiles } from '../analyzers/tools/walk-source-files';
 import { fileExists, run } from '../analyzers/tools/runner';
 import { runTestsWithCoverage } from '../analyzers/tools/run-tests-helper';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
-import { isAndroidGradleBuild, jvmCorrectnessProvider } from './jvm-build';
+import { isAndroidGradleBuild, jvmBuildExecution, jvmCorrectnessProvider } from './jvm-build';
+import type { ExecutionRequirement } from '../execution';
 import type {
   CapabilityProvider,
   DepVulnsProvider,
@@ -287,6 +288,15 @@ const KOTLIN_DEP_MANIFESTS = ['gradle.lockfile', 'pom.xml', 'gradle/verification
 
 const kotlinDepVulnsProvider: DepVulnsProvider = {
   source: 'kotlin',
+  // osv-scanner (a registry tool — Rule 1) reads the Gradle manifests
+  // directly; no build, no ambient toolchain.
+  execution: (): ExecutionRequirement => ({
+    hosts: ['any'],
+    toolchains: [],
+    needsBuild: false,
+    buildTarget: 'none',
+    weight: 'cheap',
+  }),
   // The osv-scanner audit keys off KOTLIN_DEP_MANIFESTS, but a Gradle
   // dependency change shows up in the build scripts too — include them so the
   // incremental skip never misses a dep edit.
@@ -480,6 +490,15 @@ export function parseKtlintJson(output: string): RawLocatedFinding[] {
  * exits non-zero on violations.
  */
 const kotlinLintGateProvider: LintGateProvider = {
+  // ktlint is a registry tool (Rule 1) but ships as a JVM executable — the
+  // JDK is the ambient runtime it needs. No build: it lints source directly.
+  execution: (): ExecutionRequirement => ({
+    hosts: ['any'],
+    toolchains: ['jdk'],
+    needsBuild: false,
+    buildTarget: 'none',
+    weight: 'cheap',
+  }),
   lintCommand(ctx) {
     const ktlint = findTool(TOOL_DEFS.ktlint, ctx.cwd);
     if (!ktlint.available || !ktlint.path) return null;
@@ -770,9 +789,9 @@ export const kotlin: LanguageSupport = {
   // there; Snyk Code supports Kotlin.
   deepSast: {
     codeqlLanguage: 'java',
-    codeqlBuildRequired: true,
     codeqlBeta: true,
     snykCode: true,
+    execution: jvmBuildExecution,
   },
 
   correctness: kotlinCorrectnessProvider,
@@ -797,7 +816,11 @@ export const kotlin: LanguageSupport = {
 
   permissions: ['Bash(./gradlew:*)', 'Bash(gradle:*)', 'Bash(detekt:*)'],
   ruleFile: 'kotlin.md',
-  cliBinaries: ['gradle', 'detekt'],
+  // `java` — the ambient JVM every Kotlin capability ultimately runs on
+  // (Gradle and ktlint are both JVM executables); its absence is the pack's
+  // deepest toolchain gap, and doctor must report it (Rule 20 parity: every
+  // declared execution toolchain surfaces through cliBinaries).
+  cliBinaries: ['java', 'gradle', 'detekt'],
   ciSetup: {
     // Kotlin/JVM runs on the JDK; shares `actions/setup-java` with the Java pack
     // (deduped by `uses` in allCiSetupSteps, so a Java+Kotlin repo sets it up once).

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -22,6 +22,7 @@ import type {
   CorrectnessContext,
   CorrectnessProvider,
 } from './capabilities/correctness';
+import type { ExecutionRequirement } from '../execution';
 import type {
   CoverageResult,
   DepVulnFinding,
@@ -535,6 +536,15 @@ async function gatherPyDepVulnsResult(
 
 const pyDepVulnsProvider: DepVulnsProvider = {
   source: 'python',
+  // pip-audit is a registry tool, but it drives the repo's Python environment
+  // (project mode resolves via the PEP 517 backend) — the runtime is ambient.
+  execution: (): ExecutionRequirement => ({
+    hosts: ['any'],
+    toolchains: ['python'],
+    needsBuild: false,
+    buildTarget: 'none',
+    weight: 'cheap',
+  }),
   manifestPatterns: [
     'pyproject.toml',
     'setup.py',
@@ -928,6 +938,16 @@ function isPyTestFile(rel: string): boolean {
  * CI. (Documented ceiling; testmon-based per-test selection is a future upgrade.)
  */
 const pyCorrectnessProvider: CorrectnessProvider = {
+  // Rule 20: host-agnostic, needs the Python runtime; py_compile + pytest run
+  // the project's own code — 'build' weight without a compiled-build env.
+  execution: (): ExecutionRequirement => ({
+    hosts: ['any'],
+    toolchains: ['python'],
+    needsBuild: false,
+    buildTarget: 'none',
+    weight: 'build',
+  }),
+
   syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
     const changedPy = ctx.changedFiles.filter((f) => f.endsWith('.py'));
     if (changedPy.length === 0) return null; // full-scope backstop is the pytest import
@@ -985,6 +1005,15 @@ export function parseRuffJson(output: string): RawLocatedFinding[] {
 }
 
 const pyLintGateProvider: LintGateProvider = {
+  // ruff is a standalone registry tool (Rule 1 owns its provisioning), so the
+  // gate itself has no ambient-toolchain requirement.
+  execution: (): ExecutionRequirement => ({
+    hosts: ['any'],
+    toolchains: [],
+    needsBuild: false,
+    buildTarget: 'none',
+    weight: 'cheap',
+  }),
   lintCommand(ctx) {
     const ruff = findTool(TOOL_DEFS.ruff, ctx.cwd);
     if (!ruff.available || !ruff.path) return null;
@@ -1455,7 +1484,18 @@ export const python: LanguageSupport = {
   tools: ['ruff', 'pip-audit', 'coverage-py', 'pip-licenses'],
   semgrepRulesets: ['p/python'],
   // CodeQL `python` extractor (no build); Snyk Code supports Python.
-  deepSast: { codeqlLanguage: 'python', snykCode: true },
+  deepSast: {
+    codeqlLanguage: 'python',
+    snykCode: true,
+    // Source extractor: no build, no ambient toolchain.
+    execution: () => ({
+      hosts: ['any'],
+      toolchains: [],
+      needsBuild: false,
+      buildTarget: 'none',
+      weight: 'build',
+    }),
+  },
 
   correctness: pyCorrectnessProvider,
   lintGate: pyLintGateProvider,

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -18,6 +18,7 @@ import type {
   CorrectnessContext,
   CorrectnessProvider,
 } from './capabilities/correctness';
+import type { ExecutionRequirement } from '../execution';
 import type {
   CoverageResult,
   ImportsResult,
@@ -654,6 +655,15 @@ const RUBY_DEP_MANIFESTS = ['Gemfile.lock'];
 
 const rubyDepVulnsProvider: DepVulnsProvider = {
   source: 'ruby',
+  // osv-scanner (a registry tool — Rule 1) reads the committed Gemfile.lock;
+  // no build, no ambient toolchain.
+  execution: (): ExecutionRequirement => ({
+    hosts: ['any'],
+    toolchains: [],
+    needsBuild: false,
+    buildTarget: 'none',
+    weight: 'cheap',
+  }),
   // osv-scanner audits Gemfile.lock; Gemfile / *.gemspec carry the dependency
   // declarations, so include them for the incremental skip check.
   manifestPatterns: [...RUBY_DEP_MANIFESTS, 'Gemfile', '*.gemspec'],
@@ -700,6 +710,16 @@ function isRubyTestFile(rel: string): boolean {
  * CI's full scope is the backstop).
  */
 const rubyCorrectnessProvider: CorrectnessProvider = {
+  // Rule 20: host-agnostic, needs the Ruby runtime; the floor runs the
+  // project's own specs — 'build' weight without a compiled-build env.
+  execution: (): ExecutionRequirement => ({
+    hosts: ['any'],
+    toolchains: ['ruby'],
+    needsBuild: false,
+    buildTarget: 'none',
+    weight: 'build',
+  }),
+
   syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
     const changedRb = ctx.changedFiles.filter((f) => f.endsWith('.rb'));
     if (changedRb.length === 0) return null;
@@ -780,6 +800,14 @@ export function parseRubocopJson(output: string): RawLocatedFinding[] {
 }
 
 const rubyLintGateProvider: LintGateProvider = {
+  // rubocop is a Ruby gem — the Ruby runtime is its ambient toolchain.
+  execution: (): ExecutionRequirement => ({
+    hosts: ['any'],
+    toolchains: ['ruby'],
+    needsBuild: false,
+    buildTarget: 'none',
+    weight: 'cheap',
+  }),
   lintCommand(ctx) {
     const rubocop = findTool(TOOL_DEFS.rubocop, ctx.cwd);
     if (!rubocop.available || !rubocop.path) return null;
@@ -958,7 +986,18 @@ export const ruby: LanguageSupport = {
 
   semgrepRulesets: ['p/ruby'],
   // CodeQL `ruby` extractor (no build); Snyk Code supports Ruby.
-  deepSast: { codeqlLanguage: 'ruby', snykCode: true },
+  deepSast: {
+    codeqlLanguage: 'ruby',
+    snykCode: true,
+    // Source extractor: no build, no ambient toolchain.
+    execution: () => ({
+      hosts: ['any'],
+      toolchains: [],
+      needsBuild: false,
+      buildTarget: 'none',
+      weight: 'build',
+    }),
+  },
 
   correctness: rubyCorrectnessProvider,
   lintGate: rubyLintGateProvider,

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -20,6 +20,7 @@ import type {
   CorrectnessContext,
   CorrectnessProvider,
 } from './capabilities/correctness';
+import type { ExecutionRequirement } from '../execution';
 import type {
   CoverageResult,
   DepVulnFinding,
@@ -480,6 +481,16 @@ async function gatherRustDepVulnsResult(cwd: string): Promise<DepVulnGatherOutco
 
 const rustDepVulnsProvider: DepVulnsProvider = {
   source: 'rust',
+  // cargo-audit reads the committed Cargo.lock directly (a registry tool —
+  // Rule 1); the `cargo metadata` top-level attribution is best-effort enrich,
+  // so the Rust toolchain is not a requirement of the audit itself.
+  execution: (): ExecutionRequirement => ({
+    hosts: ['any'],
+    toolchains: [],
+    needsBuild: false,
+    buildTarget: 'none',
+    weight: 'cheap',
+  }),
   manifestPatterns: ['Cargo.toml', 'Cargo.lock'],
   // A workspace member has no own Cargo.lock; a nested one marks an
   // independent crate the root audit cannot see.
@@ -915,7 +926,19 @@ function rustChangedCrates(cwd: string, changedFiles: readonly string[]): string
  * (Crate-level rung, like Go's package-level: a change whose DEPENDENTS live in
  * another crate is caught at full/CI scope, not the affected surface.)
  */
+/** Rule 20: cargo check/test/clippy all compile the crate graph — the Rust
+ *  toolchain + a build; Cargo discovers the workspace target itself. */
+const RUST_BUILD_EXECUTION: ExecutionRequirement = {
+  hosts: ['any'],
+  toolchains: ['rust'],
+  needsBuild: true,
+  buildTarget: 'discovered',
+  weight: 'build',
+};
+
 const rustCorrectnessProvider: CorrectnessProvider = {
+  execution: () => RUST_BUILD_EXECUTION,
+
   syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
     if (!fileExists(ctx.cwd, 'Cargo.toml')) return null; // not a cargo project
     return { label: 'check', bin: 'cargo', args: ['check'] };
@@ -999,6 +1022,8 @@ export function parseClippyJson(output: string): RawLocatedFinding[] {
  * a default rustup install, the common case when a Rust team opts into linting.
  */
 const rustLintGateProvider: LintGateProvider = {
+  // `cargo clippy` compiles what it lints — same requirement as the floor.
+  execution: () => RUST_BUILD_EXECUTION,
   lintCommand() {
     return {
       bin: 'cargo',
@@ -1133,7 +1158,19 @@ export const rust: LanguageSupport = {
   semgrepRulesets: [],
   // CodeQL `rust` extractor is beta (no build). Snyk Code has no Rust
   // support today, so leave snykCode unset.
-  deepSast: { codeqlLanguage: 'rust', codeqlBeta: true },
+  deepSast: {
+    codeqlLanguage: 'rust',
+    codeqlBeta: true,
+    // The beta Rust extractor is build-less but resolves the crate graph via
+    // cargo metadata — the toolchain is required, a compiled build is not.
+    execution: () => ({
+      hosts: ['any'],
+      toolchains: ['rust'],
+      needsBuild: false,
+      buildTarget: 'discovered',
+      weight: 'build',
+    }),
+  },
 
   correctness: rustCorrectnessProvider,
   lintGate: rustLintGateProvider,

--- a/src/languages/toolchain-coverage.ts
+++ b/src/languages/toolchain-coverage.ts
@@ -17,6 +17,18 @@
  * never be presented as full coverage on one surface while the other tells the
  * truth. Purely PATH-derived (`commandExists`) so it is cheap and side-effect
  * free.
+ *
+ * Relationship to the execution-environment model (Rule 20): `cliBinaries` is
+ * the PATH-probe PROJECTION of the richer per-capability
+ * `ExecutionRequirement` declarations — it covers toolchain drivers AND
+ * registry tools doctor should name, while the requirement model carries
+ * hosts/needsBuild/buildTarget for placement. Two projections of one concept
+ * is the Rule 2.30 drift shape, so the contract test pins their parity: every
+ * toolchain a pack's capabilities declare must surface one of its binaries in
+ * that pack's `cliBinaries` (and both sides probe presence through the ONE
+ * `commandExists`). Full convergence — this module deriving from the
+ * declarations — lands with the placement resolver, which replaces the
+ * boolean "unmeasured" with "unmeasured HERE, runs THERE".
  */
 
 import { commandExists } from '../analyzers/tools/runner';

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -1,4 +1,5 @@
 import type { LanguageId } from '../types';
+import type { ExecutionRequirement } from '../execution';
 import type {
   CapabilityProvider,
   DepVulnsProvider,
@@ -175,16 +176,24 @@ export interface DeepSastSupport {
   /** CodeQL query suite; defaults to the language's security-extended
    *  suite when omitted. */
   codeqlQuerySuite?: string;
-  /** CodeQL DB creation requires building the project (compiled
-   *  languages: Java/Kotlin/C#/Go). Source extractors (JS/TS, Python,
-   *  Ruby) leave this false. */
-  codeqlBuildRequired?: boolean;
   /** CodeQL extractor maturity is beta for this pack (Kotlin via the
    *  java extractor; Rust) — surfaced so callers can warn. */
   codeqlBeta?: boolean;
   /** Snyk Code (SAST) supports this language, so `ingest --from-snyk`
    *  is expected to return findings for it. */
   snykCode?: boolean;
+  /**
+   * What a deep-SAST run NEEDS from the environment (CLAUDE.md Rule 20):
+   * compiled languages need the toolchain + a project build for CodeQL DB
+   * creation (`execution(cwd).needsBuild` — this field REPLACED the old
+   * boolean `codeqlBuildRequired`, which was the same fact under a second
+   * name: one concept, one code path); source extractors need neither.
+   * Hosts follow the build (a `net*-windows` target extracts on Windows).
+   *
+   * REQUIRED, pure, repo-intrinsic, deterministic — the same discipline as
+   * the other capability `execution` declarations.
+   */
+  execution(cwd: string): ExecutionRequirement;
 }
 
 // The descriptor interfaces below moved to @vyuhlabs/dxkit-sdk (the frozen

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -34,6 +34,7 @@ import type {
   CorrectnessContext,
   CorrectnessProvider,
 } from './capabilities/correctness';
+import type { ExecutionRequirement } from '../execution';
 import type {
   CoverageResult,
   DepVulnFinding,
@@ -549,6 +550,9 @@ async function gatherTsDepVulnsViaNpmAudit(
 
 const tsDepVulnsProvider: DepVulnsProvider = {
   source: 'typescript',
+  // `npm audit` shells npm (node); the osv-scanner path is a registry tool
+  // (Rule 1) and is deliberately NOT a toolchain here.
+  execution: () => TS_TOOLING_EXECUTION,
   manifestPatterns: [
     'package.json',
     'package-lock.json',
@@ -1226,6 +1230,17 @@ function tsTypecheckScript(cwd: string): string | null {
   }
 }
 
+/** Rule 20: the TS/JS tooling is host-agnostic and needs only Node — the
+ *  runtime dxkit itself runs on, so the requirement is trivially satisfiable
+ *  wherever dxkit runs. Declared anyway: the model is total, never assumed. */
+const TS_TOOLING_EXECUTION: ExecutionRequirement = {
+  hosts: ['any'],
+  toolchains: ['node'],
+  needsBuild: false,
+  buildTarget: 'none',
+  weight: 'cheap',
+};
+
 /**
  * The TS/JS correctness floor. `npx --no-install <tool>` is the portable
  * invocation — npx resolves the project-local `.bin` shim cross-platform (a
@@ -1233,6 +1248,10 @@ function tsTypecheckScript(cwd: string): string | null {
  * and `--no-install` guarantees it never reaches the network.
  */
 const tsCorrectnessProvider: CorrectnessProvider = {
+  // The floor runs the project's compiler pass + test suite — 'build' weight,
+  // though no compiled-output environment is needed (needsBuild false).
+  execution: () => ({ ...TS_TOOLING_EXECUTION, weight: 'build' }),
+
   syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
     // Prefer the project's own typecheck script — it carries their exact
     // compiler flags and project-references, the same command their CI runs.
@@ -1334,6 +1353,7 @@ export function parseEslintJson(output: string): RawLocatedFinding[] {
 }
 
 const tsLintGateProvider: LintGateProvider = {
+  execution: () => TS_TOOLING_EXECUTION,
   lintCommand(ctx) {
     if (!hasLocalBin(ctx.cwd, 'eslint')) return null;
     return {
@@ -1981,7 +2001,19 @@ export const typescript: LanguageSupport = {
   semgrepRulesets: ['p/javascript', 'p/typescript'],
   // CodeQL's `javascript` extractor covers both JS and TS in one DB,
   // no build needed. Snyk Code supports JS/TS.
-  deepSast: { codeqlLanguage: 'javascript', snykCode: true },
+  deepSast: {
+    codeqlLanguage: 'javascript',
+    snykCode: true,
+    // Source extractor: no build, no toolchain (codeql itself is a registry
+    // tool). 'build' weight — a DB build + analyze is minutes, never cheap.
+    execution: () => ({
+      hosts: ['any'],
+      toolchains: [],
+      needsBuild: false,
+      buildTarget: 'none',
+      weight: 'build',
+    }),
+  },
 
   correctness: tsCorrectnessProvider,
   lintGate: tsLintGateProvider,

--- a/test/correctness-run.test.ts
+++ b/test/correctness-run.test.ts
@@ -26,6 +26,15 @@ function pack(
   return {
     id,
     correctness: {
+      // Satisfiable everywhere (Rule 20) — these tests exercise the exec
+      // policy, not the environment gate (that lives in test/execution/).
+      execution: () => ({
+        hosts: ['any' as const],
+        toolchains: [],
+        needsBuild: false,
+        buildTarget: 'none' as const,
+        weight: 'cheap' as const,
+      }),
       syntaxCheck: (_ctx: CorrectnessContext) => syntax,
       affectedTests: (_ctx: CorrectnessContext) => affected,
     },

--- a/test/correctness-surface-run.test.ts
+++ b/test/correctness-surface-run.test.ts
@@ -15,6 +15,15 @@ function fakePack(): LanguageSupport {
   return {
     id: 'typescript', // any real LanguageId; only `correctness` is exercised
     correctness: {
+      // Satisfiable everywhere (Rule 20) — these tests exercise surface
+      // resolution + exec policy, not the environment gate.
+      execution: () => ({
+        hosts: ['any' as const],
+        toolchains: [],
+        needsBuild: false,
+        buildTarget: 'none' as const,
+        weight: 'cheap' as const,
+      }),
       syntaxCheck: () => cmd('compile'),
       affectedTests: () => cmd('affected-tests'),
     },
@@ -117,6 +126,13 @@ describe('runFloorForSurface — scope selection', () => {
     const scopePack = {
       id: 'typescript',
       correctness: {
+        execution: () => ({
+          hosts: ['any' as const],
+          toolchains: [],
+          needsBuild: false,
+          buildTarget: 'none' as const,
+          weight: 'cheap' as const,
+        }),
         syntaxCheck: () => null,
         affectedTests: (ctx: { scope: string }) => ({
           label: 'affected-tests',
@@ -144,6 +160,13 @@ describe('runFloorForSurface — scope selection', () => {
     const scopePack = {
       id: 'typescript',
       correctness: {
+        execution: () => ({
+          hosts: ['any' as const],
+          toolchains: [],
+          needsBuild: false,
+          buildTarget: 'none' as const,
+          weight: 'cheap' as const,
+        }),
         syntaxCheck: () => null,
         affectedTests: (ctx: { scope: string }) => ({
           label: 'affected-tests',

--- a/test/execution/execution-platform.test.ts
+++ b/test/execution/execution-platform.test.ts
@@ -1,0 +1,254 @@
+/**
+ * The execution-environment platform (CLAUDE.md Rule 20) — unit layer.
+ *
+ * Pins the ONE satisfaction predicate both directions, the host mapping, the
+ * repo-derived C# host narrowing (the dpl-studio class), and the runners'
+ * pre-spawn environment consultation. The registry-driven flow (synthetic
+ * pack → spec → runner) lives in `test/recipe-playbook.test.ts`; the per-pack
+ * declaration contract lives in `test/languages-contract.test.ts`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  describeUnmetRequirement,
+  hostOf,
+  toolchainInstallHint,
+  TOOLCHAIN_DEFS,
+  unmetRequirement,
+  type ExecutionEnvironment,
+  type ExecutionRequirement,
+} from '../../src/execution';
+import { csharp } from '../../src/languages/csharp';
+import { runCorrectnessFloor, describeEnvironmentSkips } from '../../src/analyzers/correctness/run';
+import { runCustomChecks } from '../../src/analyzers/custom-checks/run';
+import type { LanguageSupport } from '../../src/languages/types';
+
+const env = (host: 'linux' | 'macos' | 'windows', toolchains: string[]): ExecutionEnvironment => ({
+  host,
+  hasToolchain: (id) => toolchains.includes(id),
+});
+
+const req = (over: Partial<ExecutionRequirement>): ExecutionRequirement => ({
+  hosts: ['any'],
+  toolchains: [],
+  needsBuild: false,
+  buildTarget: 'none',
+  weight: 'cheap',
+  ...over,
+});
+
+describe('unmetRequirement — the one satisfaction predicate', () => {
+  it('an unconstrained requirement is satisfied anywhere', () => {
+    expect(unmetRequirement(req({}), env('linux', []))).toBeNull();
+    expect(unmetRequirement(req({}), env('windows', []))).toBeNull();
+  });
+
+  it('a concrete host requirement is satisfied only on that host', () => {
+    const windowsOnly = req({ hosts: ['windows'] });
+    expect(unmetRequirement(windowsOnly, env('windows', []))).toBeNull();
+    expect(unmetRequirement(windowsOnly, env('linux', []))).toEqual({
+      kind: 'wrong-host',
+      requiredHosts: ['windows'],
+      currentHost: 'linux',
+    });
+  });
+
+  it("'any' alongside a concrete host means no constraint", () => {
+    expect(unmetRequirement(req({ hosts: ['windows', 'any'] }), env('linux', []))).toBeNull();
+  });
+
+  it('missing toolchains are reported together, present ones are not', () => {
+    const needs = req({ toolchains: ['dotnet-sdk', 'node'] });
+    expect(unmetRequirement(needs, env('linux', ['dotnet-sdk', 'node']))).toBeNull();
+    expect(unmetRequirement(needs, env('linux', ['node']))).toEqual({
+      kind: 'missing-toolchain',
+      toolchains: ['dotnet-sdk'],
+    });
+  });
+
+  it('the wrong host is reported before toolchains (more fundamental)', () => {
+    const both = req({ hosts: ['windows'], toolchains: ['dotnet-sdk'] });
+    expect(unmetRequirement(both, env('linux', []))?.kind).toBe('wrong-host');
+  });
+
+  it('descriptions name the need AND where it runs — never a bare error', () => {
+    const wrongHost = describeUnmetRequirement({
+      kind: 'wrong-host',
+      requiredHosts: ['windows'],
+      currentHost: 'linux',
+    });
+    expect(wrongHost).toContain('windows');
+    expect(wrongHost).toContain('linux');
+    expect(wrongHost).toContain('CI job');
+    expect(
+      describeUnmetRequirement({ kind: 'missing-toolchain', toolchains: ['dotnet-sdk'] }),
+    ).toContain('dotnet-sdk');
+  });
+});
+
+describe('environment model', () => {
+  it('hostOf maps node platforms to execution hosts (POSIX → linux)', () => {
+    expect(hostOf('win32')).toBe('windows');
+    expect(hostOf('darwin')).toBe('macos');
+    expect(hostOf('linux')).toBe('linux');
+    expect(hostOf('freebsd')).toBe('linux');
+  });
+
+  it('every toolchain declares binaries, a fallback install, and per-host hints', () => {
+    for (const def of Object.values(TOOLCHAIN_DEFS)) {
+      expect(def.binaries.length).toBeGreaterThan(0);
+      expect(def.install.fallback).toMatch(/^https?:\/\//);
+      // The hint never comes back empty — an unknown host gets the fallback
+      // URL, so a raw "'<pm>' is not recognized" is unconstructible from here.
+      for (const host of ['linux', 'macos', 'windows'] as const) {
+        expect(toolchainInstallHint(def.id as keyof typeof TOOLCHAIN_DEFS, host)).toBeTruthy();
+      }
+    }
+  });
+});
+
+describe('csharp host narrowing (the dpl-studio class)', () => {
+  function csprojRepo(csprojContent: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-exec-csharp-'));
+    fs.writeFileSync(path.join(dir, 'App.csproj'), csprojContent);
+    return dir;
+  }
+
+  const project = (props: string) =>
+    `<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup>${props}</PropertyGroup></Project>`;
+
+  it('a net*-windows TFM narrows every build-based capability to windows', () => {
+    const dir = csprojRepo(project('<TargetFramework>net9.0-windows</TargetFramework>'));
+    try {
+      for (const r of [
+        csharp.correctness.execution(dir),
+        csharp.lintGate!.execution(dir),
+        csharp.deepSast!.execution(dir),
+      ]) {
+        expect(r.hosts).toEqual(['windows']);
+        expect(r.needsBuild).toBe(true);
+        expect(r.toolchains).toContain('dotnet-sdk');
+      }
+      // A root .csproj is a target dotnet can discover itself.
+      expect(csharp.correctness.execution(dir).buildTarget).toBe('discovered');
+      // The dependency audit stays host-agnostic BY DESIGN — the osv half
+      // reads manifests without dotnet, so auditing works where the Windows
+      // build cannot run.
+      expect(csharp.capabilities!.depVulns!.execution(dir).hosts).toEqual(['any']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('an explicit WinForms/WPF opt-in narrows to windows too', () => {
+    const dir = csprojRepo(
+      project('<TargetFramework>net48</TargetFramework><UseWindowsForms>true</UseWindowsForms>'),
+    );
+    try {
+      expect(csharp.correctness.execution(dir).hosts).toEqual(['windows']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a cross-platform TFM stays host-agnostic', () => {
+    const dir = csprojRepo(project('<TargetFramework>net9.0</TargetFramework>'));
+    try {
+      expect(csharp.correctness.execution(dir).hosts).toEqual(['any']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('no discoverable root target reads as configured', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-exec-csharp-'));
+    try {
+      fs.mkdirSync(path.join(dir, 'src'));
+      fs.writeFileSync(
+        path.join(dir, 'src', 'App.csproj'),
+        project('<TargetFramework>net9.0</TargetFramework>'),
+      );
+      expect(csharp.correctness.execution(dir).buildTarget).toBe('configured');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('correctness runner honors declarations (Rule 20, both directions)', () => {
+  const windowsPack = {
+    id: 'winonly',
+    displayName: 'WinOnly (synthetic)',
+    correctness: {
+      execution: () => req({ hosts: ['windows'], needsBuild: true, weight: 'build' }),
+      syntaxCheck: () => ({ label: 'build', bin: 'winbuild', args: [] }),
+      affectedTests: () => null,
+    },
+  } as unknown as LanguageSupport;
+
+  it('an unmet requirement is a disclosed skip, decided BEFORE the spawn', () => {
+    const exec = vi.fn(() => ({ available: true, code: 0, output: '' }));
+    const result = runCorrectnessFloor({
+      cwd: '/nonexistent-repo',
+      changedFiles: [],
+      scope: 'full',
+      packs: [windowsPack],
+      exec,
+      env: env('linux', []),
+    });
+    expect(exec).not.toHaveBeenCalled();
+    expect(result.ran).toBe(false);
+    expect(result.blocks).toBe(false);
+    expect(result.checks[0].status).toBe('skipped-environment');
+    expect(result.checks[0].unmet?.kind).toBe('wrong-host');
+    const skips = describeEnvironmentSkips(result);
+    expect(skips).toHaveLength(1);
+    expect(skips[0]).toContain('winonly');
+    expect(skips[0]).toContain('windows');
+  });
+
+  it('a satisfied requirement executes normally (no over-skip)', () => {
+    const exec = vi.fn(() => ({ available: true, code: 0, output: '' }));
+    const result = runCorrectnessFloor({
+      cwd: '/nonexistent-repo',
+      changedFiles: [],
+      scope: 'full',
+      packs: [windowsPack],
+      exec,
+      env: env('windows', []),
+    });
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(result.ran).toBe(true);
+    expect(result.checks[0].status).toBe('pass');
+    expect(describeEnvironmentSkips(result)).toEqual([]);
+  });
+});
+
+describe('custom-check runner: declaration-less checks keep the plain path', () => {
+  it('a user check (no execution declared) is never environment-skipped', () => {
+    const exec = vi.fn(() => ({ available: true, code: 0, output: '' }));
+    const result = runCustomChecks({
+      cwd: '/nonexistent-repo',
+      specs: [
+        {
+          name: 'user-check',
+          command: { bin: 'make', args: ['lint'] },
+          blocking: true,
+          expectedExit: 0,
+          parse: { mode: 'exit' },
+        },
+      ],
+      exec,
+      // An environment that satisfies nothing — must not matter without a
+      // declaration: dxkit cannot know what `make lint` needs, and inventing
+      // a requirement would be worse than admitting the limit.
+      env: env('linux', []),
+    });
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(result.results[0].status).toBe('pass');
+  });
+});

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { LANGUAGES, getLanguage, detectActiveLanguages } from '../src/languages';
 import type { LanguageId, LanguageSupport } from '../src/languages';
 import { TOOL_DEFS } from '../src/analyzers/tools/tool-registry';
+import { TOOLCHAIN_DEFS } from '../src/execution';
 import { grammarShape } from '../src/ast/grammar-shape';
 import { modelShapeForGrammar } from '../src/ast/grammar-model-shape';
 
@@ -438,6 +440,107 @@ describe.each(LANGUAGES as LanguageSupport[])('language contract: $id', (lang) =
         }
       }
     }
+  });
+
+  // Rule 20 (4.0): every capability that executes repo-facing commands
+  // declares what it NEEDS from the environment that runs it. The
+  // pre-declaration model implicitly assumed `{ hosts: any, toolchains: [],
+  // needsBuild: false }` everywhere — wrong on every axis for the C# build
+  // gates (the dpl-studio class). This block makes the declaration total,
+  // well-formed, repo-intrinsic, and non-divergent from doctor's toolchain
+  // probe (the cliBinaries parity — two projections of one concept, Rule 2.30).
+  describe('execution requirements (Rule 20)', () => {
+    /** Every (capability, requirement) pair this pack declares at `cwd`. */
+    function declaredRequirements(cwd: string): Array<{ capability: string; req: unknown }> {
+      const out: Array<{ capability: string; req: unknown }> = [];
+      out.push({ capability: 'correctness', req: lang.correctness.execution(cwd) });
+      if (lang.lintGate) out.push({ capability: 'lintGate', req: lang.lintGate.execution(cwd) });
+      const dep = lang.capabilities?.depVulns;
+      if (dep) out.push({ capability: 'depVulns', req: dep.execution(cwd) });
+      if (lang.deepSast) {
+        out.push({ capability: 'deepSast', req: lang.deepSast.execution(cwd) });
+      }
+      return out;
+    }
+
+    const HOSTS = ['linux', 'macos', 'windows', 'any'];
+
+    it('every declaring capability returns a well-formed requirement', () => {
+      for (const { capability, req } of declaredRequirements(process.cwd())) {
+        const r = req as {
+          hosts: unknown;
+          toolchains: unknown;
+          needsBuild: unknown;
+          buildTarget: unknown;
+          weight: unknown;
+        };
+        const label = `${lang.id}.${capability}`;
+        expect(Array.isArray(r.hosts) && r.hosts.length > 0, `${label}: hosts non-empty`).toBe(
+          true,
+        );
+        for (const h of r.hosts as unknown[]) {
+          expect(HOSTS, `${label}: unknown host '${String(h)}'`).toContain(h);
+        }
+        expect(Array.isArray(r.toolchains), `${label}: toolchains is an array`).toBe(true);
+        for (const t of r.toolchains as unknown[]) {
+          // Every referenced toolchain must resolve in the ONE provisioning
+          // registry — an unregistered id would make the requirement
+          // unroutable and its install hint unanswerable.
+          expect(
+            Object.keys(TOOLCHAIN_DEFS),
+            `${label}: toolchain '${String(t)}' not in TOOLCHAIN_DEFS`,
+          ).toContain(t);
+        }
+        expect(typeof r.needsBuild, `${label}: needsBuild is boolean`).toBe('boolean');
+        expect(['none', 'discovered', 'configured'], `${label}: buildTarget`).toContain(
+          r.buildTarget,
+        );
+        expect(['cheap', 'build'], `${label}: weight`).toContain(r.weight);
+      }
+    });
+
+    it('requirements are deterministic, total, and repo-intrinsic', () => {
+      // Deterministic: same repo → byte-identical answer (a requirement that
+      // wobbles would flap placement and disclosures).
+      expect(declaredRequirements(process.cwd())).toEqual(declaredRequirements(process.cwd()));
+      // Total: an empty/alien cwd must still answer, never throw — the
+      // declaration is consulted before anything about the repo is known good.
+      const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-exec-contract-'));
+      try {
+        expect(() => declaredRequirements(empty)).not.toThrow();
+        // Repo-intrinsic, machine-independent: nothing machine-specific may
+        // leak into the declaration (the Rule 19 recall-inputs discipline —
+        // an absolute path would make the same repo read differently per host).
+        const serialized = JSON.stringify(declaredRequirements(empty));
+        expect(serialized).not.toContain(os.homedir());
+        expect(serialized).not.toContain(empty);
+      } finally {
+        fs.rmSync(empty, { recursive: true, force: true });
+      }
+    });
+
+    // The cliBinaries parity net: doctor's toolchain-coverage signal reads
+    // `cliBinaries` (the PATH projection) while placement reads the
+    // requirement declarations. Two projections of one concept drift unless
+    // pinned (Rule 2.30) — every declared toolchain must surface at least one
+    // of its registry binaries in the pack's cliBinaries, so a toolchain gap
+    // placement would route on is never invisible to doctor.
+    it('declared toolchains surface through cliBinaries (doctor parity)', () => {
+      const declared = new Set(
+        declaredRequirements(process.cwd()).flatMap(
+          ({ req }) => (req as { toolchains: readonly string[] }).toolchains,
+        ),
+      );
+      for (const id of declared) {
+        const def = TOOLCHAIN_DEFS[id as keyof typeof TOOLCHAIN_DEFS];
+        expect(
+          def.binaries.some((b) => (lang.cliBinaries ?? []).includes(b)),
+          `${lang.id}: toolchain '${id}' declares binaries [${def.binaries.join(', ')}] but ` +
+            `none appear in cliBinaries [${(lang.cliBinaries ?? []).join(', ')}] — doctor ` +
+            `would never report the gap placement routes on`,
+        ).toBe(true);
+      }
+    });
   });
 
   // Rule 19: a pack that gates lint must also declare what makes its linter SEE

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -70,6 +70,7 @@ import {
 } from '../src/languages';
 import { runCorrectnessFloor } from '../src/analyzers/correctness/run';
 import { lintGateSpecs } from '../src/analyzers/custom-checks/config';
+import { runCustomChecks } from '../src/analyzers/custom-checks/run';
 import { customCheckRecallInputs } from '../src/analyzers/custom-checks/gather';
 import type { BrownfieldPolicy } from '../src/baseline/policy';
 import { deriveFileRoutePath } from '../src/analyzers/flow/file-routes';
@@ -195,6 +196,15 @@ const mockPlaybookPack = {
   correctness: {
     syntaxCheck: () => ({ label: 'playbook-typecheck', bin: 'playbookc-mock', args: ['--check'] }),
     affectedTests: () => ({ label: 'playbook-tests', bin: 'playbookc-mock', args: ['test'] }),
+    // Rule 20: satisfiable everywhere, so the floor-pickup assertion above
+    // keeps exercising the dispatch path on any test host.
+    execution: () => ({
+      hosts: ['any' as const],
+      toolchains: [],
+      needsBuild: false,
+      buildTarget: 'none' as const,
+      weight: 'cheap' as const,
+    }),
   },
   // Lint-GATE contribution (custom-check flagship). Distinctive bin/parse so the
   // assertion verifies the synthetic pack's provider flows through
@@ -233,6 +243,19 @@ const mockPlaybookPack = {
       'playbook-linter': ctx.mode === 'locked' ? '^9.0.0' : '9.4.2',
       'playbook-plugin-mock': '2.1.0',
     }),
+    // Rule 20: a DISTINCTIVE, unsatisfiable-on-CI requirement (windows-only
+    // build gate — the csharp shape) so the assertions below can prove the
+    // declaration flows pack → spec → runner and that the runner honors it in
+    // BOTH directions. Without this, `execution` could silently cease being
+    // pack-driven behind `safeExecution`'s fail-soft catch — the same
+    // invisibility recallInputs had pre-Rule-19.
+    execution: () => ({
+      hosts: ['windows' as const],
+      toolchains: [],
+      needsBuild: true,
+      buildTarget: 'configured' as const,
+      weight: 'build' as const,
+    }),
   },
   detect: vi.fn(() => false),
   tools: [],
@@ -259,6 +282,14 @@ const mockPlaybookPack = {
       async gatherOutcome() {
         return { kind: 'no-manifest', reason: 'mock' };
       },
+      // Rule 20: lockfile-scan shape — no ambient toolchain, no build.
+      execution: () => ({
+        hosts: ['any' as const],
+        toolchains: [],
+        needsBuild: false,
+        buildTarget: 'none' as const,
+        weight: 'cheap' as const,
+      }),
     },
   },
   permissions: ['Bash(mock-playbook-permission:*)'],
@@ -513,6 +544,61 @@ describe('recipe playbook — synthetic pack', () => {
     expect(locked.find((s) => s.name === 'lint:playbook')?.recallInputs).toMatchObject({
       'playbook-linter': '^9.0.0',
     });
+  });
+
+  // Rule 20: the execution-environment declaration must be pack-driven the same
+  // way the command and recall inputs are. `lintGateSpecs` reads it behind
+  // `safeExecution`'s fail-soft catch, so a pack that silently stopped
+  // declaring would look exactly like a pack with no requirement — this proves
+  // the synthetic pack's declaration ARRIVES on the spec.
+  it('lintGateSpecs carries the mock pack execution requirement onto the spec (Rule 20)', () => {
+    const specs = lintGateSpecs(
+      [...LANGUAGES],
+      { cwd: '/nonexistent-repo', changedFiles: [] },
+      { enabled: true },
+    );
+    expect(specs.find((s) => s.name === 'lint:playbook')?.execution).toEqual({
+      hosts: ['windows'],
+      toolchains: [],
+      needsBuild: true,
+      buildTarget: 'configured',
+      weight: 'build',
+    });
+  });
+
+  // Rule 20, both directions. Unsatisfied: the runner must NOT spawn the
+  // windows-only gate on a linux environment — it discloses a
+  // `skipped-environment` boundary naming the host. Satisfied: the same spec
+  // on a windows environment must execute normally. The second direction is
+  // the more dangerous regression (a gate that silently stops running while
+  // everything stays green), mirroring the recall playbook's over-drift guard.
+  it('runCustomChecks honors the mock pack requirement in both directions (Rule 20)', () => {
+    const specs = lintGateSpecs(
+      [...LANGUAGES],
+      { cwd: '/nonexistent-repo', changedFiles: [] },
+      { enabled: true },
+    ).filter((s) => s.name === 'lint:playbook');
+    expect(specs).toHaveLength(1);
+
+    const exec = vi.fn(() => ({ available: true, code: 0, output: '' }));
+    const onLinux = runCustomChecks({
+      cwd: '/nonexistent-repo',
+      specs,
+      exec,
+      env: { host: 'linux', hasToolchain: () => true },
+    });
+    expect(onLinux.results[0].status).toBe('skipped-environment');
+    expect(onLinux.results[0].reason).toContain('windows');
+    expect(exec).not.toHaveBeenCalled(); // decided BEFORE the spawn
+
+    const onWindows = runCustomChecks({
+      cwd: '/nonexistent-repo',
+      specs,
+      exec,
+      env: { host: 'windows', hasToolchain: () => true },
+    });
+    expect(onWindows.results[0].status).toBe('pass');
+    expect(exec).toHaveBeenCalledTimes(1);
   });
 
   it('the seam namespaces the mock pack inputs into the custom-check kind (Rule 19)', () => {

--- a/test/sdk-surface-freeze.test.ts
+++ b/test/sdk-surface-freeze.test.ts
@@ -98,6 +98,7 @@ import type {
   DepVulnsProvider,
 } from '../src/languages/capabilities/provider';
 import type { DepVulnGatherOutcome } from '../src/languages/capabilities/types';
+import type { ExecutionRequirement } from '../src/execution';
 
 /**
  * The frozen runtime export set. Additive-only: append (with a changelog
@@ -243,4 +244,9 @@ export type DepVulnsProviderFrozenInPlace = [
   Expect<Equal<DepVulnsProvider['lockfilePatterns'], readonly string[] | undefined>>,
   Expect<Equal<ReturnType<DepVulnsProvider['gatherOutcome']>, Promise<DepVulnGatherOutcome>>>,
   Expect<Equal<Parameters<DepVulnsProvider['gatherOutcome']>[1], DepVulnGatherOptions | undefined>>,
+  // 4.0 (Rule 20): the execution-environment declaration joined the pack
+  // contract — a deliberate frozen-in-place field addition (all implementers
+  // are in-tree packs; extensions contribute dep findings via findings.v1 and
+  // never implement this interface).
+  Expect<Equal<ReturnType<DepVulnsProvider['execution']>, ExecutionRequirement>>,
 ];


### PR DESCRIPTION
## What this is

The first increment of the 4.0 execution-environment platform (ROADMAP section "Execution-environment platform"; design doc `tmp/feature-req/DESIGN-execution-environment-platform.md` sections 3.1 and 3.2). Execution environment becomes the third pack-declared dimension, alongside language and capability, and the full drift-proof enforcement net ships in the same PR as the contract.

dxkit's pre-4.0 model implicitly assumed the machine driving the analysis can also build and scan the repo. That is false for any stack needing a provisioned build environment: the dpl-studio class (Windows-only `net9.0-windows` WinForms), recurring harder for Swift/iOS, Android, and C/C++. When the assumption broke, capabilities either fail-open skipped invisibly (a silent coverage gap) or executed anyway and misread an environment problem as a code finding (the 3.9 eval's F-14: a `dotnet build` on a half-provisioned SDK read as a lint failure).

## What changed

### The platform module: `src/execution/`
- `requirement.ts` defines `ExecutionRequirement { hosts, toolchains, needsBuild, buildTarget, weight }`, the ONE satisfaction predicate `unmetRequirement(req, env)`, and the ONE phrasing helper `describeUnmetRequirement`. Requirements are repo-intrinsic: pure functions of repo contents, never of the machine (the Rule 19 recall-inputs discipline). Availability is the environment's side of the line.
- `environment.ts` is the one home of host detection (`hostOf`, `currentEnvironment` with per-run memoized toolchain probes; nothing cached module-globally).
- `toolchains.ts` adds `TOOLCHAIN_DEFS`, the provisioning registry for ambient SDKs (node, python, go, rust, dotnet-sdk, jdk, maven, gradle, ruby): per-host non-privileged installs (dotnet via `dotnet-install.sh --install-dir $HOME/.dotnet`, never a raw scoop/apt failure) plus declared health checks (dotnet/libicu). `ToolchainId` is derived from the registry, so an unregistered reference fails to compile. The boundary line: if `tools install` can provision it, it is a TOOL (Rule 1, `TOOL_DEFS`); if the repo's ecosystem provisions it, it is a TOOLCHAIN and lives here. **No change to the OSS default tool stack, and no new default engines.**

### The contract: `execution(cwd)` REQUIRED on every executing capability
- Added to `CorrectnessProvider`, `LintGateProvider`, `DepVulnsProvider` (a deliberate frozen-in-place field addition, pinned in `test/sdk-surface-freeze.test.ts`; all implementers are in-tree, and extensions contribute via findings.v1 without ever implementing it) and `DeepSastSupport`.
- `DeepSastSupport.codeqlBuildRequired` is folded into `execution().needsBuild` and deleted. It was the same fact under a second name (declared on 4 packs, read by nothing), a Rule 2.30 drift seed.

### All 8 packs declare truthfully
- csharp is the worked example of repo-derived truth: `csharpBuildExecution(cwd)` narrows `hosts` to `['windows']` from a `net*-windows` TFM or a WinForms/WPF opt-in, requires `dotnet-sdk` plus a build, and reports `buildTarget: 'configured'` when no root target is discoverable (the 29-`.sln` repo). Its dep audit stays `hosts: ['any']` by design: the osv half reads committed lockfiles without dotnet.
- go/rust floors and gates declare `needsBuild: true` (go vet, golangci-lint, clippy, and govulncheck all compile what they analyze). The JVM packs share `jvmBuildExecution` in `jvm-build.ts` (Rule 2), which omits maven/gradle when the repo commits a wrapper. TS/Python/Ruby declare their runtimes. Dormant gates declare the empty requirement: nothing runs, so nothing is needed.
- kotlin's `cliBinaries` gains `java`. The parity net (below) surfaced that doctor never checked the JVM that every kotlin capability runs on.

### First consumers: disclosed boundaries instead of silent skips
- `runCorrectnessFloor` and `runCustomChecks` consult the declaration BEFORE spawning: unmet means a new `skipped-environment` status carrying the structured reason. Fail-open stays fail-open; it just always says why, and where the capability would run instead (the `GateFailure` discipline).
- The pre-spawn check is the first half of the F-14 class fix: an unrunnable `dotnet build` no longer executes just to fail in a way that reads as a finding. (The present-but-unhealthy half, health-check probes minting `unhealthy-toolchain`, lands with the provisioning increment; the reason kind is already in the type.)
- Surfaces: the floor's pre-push/CI summary and `checks run` (human and `--json`) render the boundary. User-declared checks keep the plain fail-open path: dxkit cannot know what `make lint` needs and does not invent it.

### The enforcement net (same PR as the contract, per the standing directive)
1. Compile-time: required fields everywhere; `ToolchainId` closed union; the `new-lang` scaffold wires an honest TODO-marked stub.
2. `check-architecture.sh` Rule 20, all three verified to bite: (a) no new `process.platform` outside `src/execution/` plus the frozen legacy allowlist; (b) no inline toolchain-install literals outside the two registries; (c) `unmetRequirement(` consumed only by known consumers.
3. `test/languages-contract.test.ts`: per pack and capability, the requirement is well-formed, every toolchain id resolves, the declaration is deterministic, total, and machine-independent, and the cliBinaries parity holds (doctor's toolchain-coverage projection cannot drift from the declarations).
4. `test/recipe-playbook.test.ts`: the synthetic pack declares a distinctive windows-only gate; asserted pack to spec to runner, and the runner honored in BOTH directions (unmet: disclosed skip decided before the spawn; met: executes. The over-skip regression is the dangerous one).
5. `test/execution/execution-platform.test.ts`: the predicate in both directions, C# TFM host derivation on fixture repos, and declaration-less user checks unaffected.
6. CLAUDE.md Rule 20 codifies the discipline.

## What this does NOT do (later increments of the 4.0 train)
- No placement resolver or multi-job workflow generation (design sections 3.3 and 4); the resolver composes on `unmetRequirement` over remote environments.
- No `tools install` rerouting through `TOOLCHAIN_DEFS`, and no live health-check probes yet (section 3.2 consumers).
- No multi-env baseline capture (sections 3.4 and 6.6).
- `toolchain-coverage.ts` still reads `cliBinaries`, documented as the PATH projection of this concept and pinned non-divergent by the parity test; full convergence lands with the resolver.

## Verification
`npm run typecheck`, `typecheck:test`, `lint`, `format:check`, `test:run` (full suite green), `check-architecture.sh` (new rules bite-verified with throwaway violations), `check-slop.sh`, `check-cross-ecosystem-coverage.sh`, `check-docs-coverage.sh`, `npm run build`, and `npm pack --dry-run`: all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
