### PR TITLE
feat(baseline): multi-environment baseline composition (Rule 20, design §3.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1316,6 +1316,21 @@ install` loop for an ambient SDK), never a silent skip and never a spawn
   the parity test (`test/execution/placement.test.ts`): off-primary-placed ⇔
   wrong-host-skipped, both directions — the Rule 2.30 semantic-divergence
   net.
+- **Composed** across environments (design §3.4 — the hidden enabler): ONE
+  committed baseline assembled from captures in different environments,
+  sound because finding identity is environment-independent (Rule 9). The
+  primitives live in `src/baseline/fragment.ts`: `captureFragment` (a placed
+  host's slice — its checks' findings + recall, via the seam's ONE producer
+  map and ONE recall formula) and `mergeFragment` (check-scoped ownership:
+  the fragment REPLACES its declared checks' entries + recall keys, touches
+  nothing else, and REFUSES a scheme/epoch mismatch with the remedy named).
+  The refresh workflow's per-host capture jobs + merge step are rendered
+  from the placement plan (`renderFragmentOrchestration`; template partials,
+  empty slots on a host-agnostic repo). Paired honesty fix: an
+  env-unrunnable check contributes NO recall inputs (`observableSpecs` in
+  the seam) — unobserved reads as ABSENT, never as "comparable and clean"
+  (the lie that would flag a whole pre-existing backlog as net-new on the
+  first host-side check).
 
 **Bad**: a capability that shells a build with no `execution` declaration (it
 won't compile); a `process.platform` read in an analyzer; an inline

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
@@ -31,8 +31,10 @@ permissions:
   contents: write
 
 jobs:
+__DXKIT_FRAGMENT_CAPTURE_JOBS__
   refresh:
     runs-on: ubuntu-latest
+__DXKIT_REFRESH_NEEDS__
     steps:
       - uses: actions/checkout@v6
         with:
@@ -86,6 +88,7 @@ __DXKIT_CI_RUNTIME_SETUP__
             DXKIT=vyuh-dxkit
           fi
           "${DXKIT}" baseline create --force
+__DXKIT_FRAGMENT_MERGE_STEPS__
 
       - name: Publish anchor to the unprotected side branch
         # No token env needed: the side-ref push authenticates with the credential

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
@@ -26,8 +26,10 @@ permissions:
   contents: read
 
 jobs:
+__DXKIT_FRAGMENT_CAPTURE_JOBS__
   refresh:
     runs-on: ubuntu-latest
+__DXKIT_REFRESH_NEEDS__
     steps:
       - uses: actions/checkout@v6
         with:
@@ -81,6 +83,7 @@ __DXKIT_CI_RUNTIME_SETUP__
             DXKIT=vyuh-dxkit
           fi
           "${DXKIT}" baseline create --force
+__DXKIT_FRAGMENT_MERGE_STEPS__
 
       - name: Store anchor in the Actions cache
         uses: actions/cache/save@v4

--- a/src-templates/.github/workflows/dxkit-baseline-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh.yml
@@ -22,8 +22,10 @@ permissions:
   contents: write
 
 jobs:
+__DXKIT_FRAGMENT_CAPTURE_JOBS__
   refresh:
     runs-on: ubuntu-latest
+__DXKIT_REFRESH_NEEDS__
     # Don't re-run on our own auto-commit (defensive — paths-ignore
     # above already filters the common case).
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
@@ -82,6 +84,7 @@ __DXKIT_CI_RUNTIME_SETUP__
             DXKIT=vyuh-dxkit
           fi
           "${DXKIT}" baseline create --force
+__DXKIT_FRAGMENT_MERGE_STEPS__
 
       - name: Commit and push refreshed baseline
         run: |

--- a/src-templates/.github/workflows/partials/fragment-capture-job.yml
+++ b/src-templates/.github/workflows/partials/fragment-capture-job.yml
@@ -1,0 +1,40 @@
+# PARTIAL — one per-host baseline-fragment capture job, rendered by
+# installCiBaselineRefresh into the refresh workflow's __DXKIT_FRAGMENT_CAPTURE_JOBS__
+# slot when the placement plan routes lint gates to this host (CLAUDE.md Rule 20,
+# design §3.4). Never installed standalone.
+  capture-__DXKIT_GATE_HOST__:
+    runs-on: __DXKIT_GATE_RUNNER__
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+__DXKIT_FRAGMENT_HOST_SETUP__
+      - name: Install dxkit
+        shell: bash
+        run: |
+          if [ -f package.json ]; then
+            npm install --no-save @vyuhlabs/dxkit >/dev/null 2>&1 || npm install -g @vyuhlabs/dxkit
+          else
+            npm install -g @vyuhlabs/dxkit
+          fi
+
+      # This host's slice of the baseline: the checks the primary runner
+      # cannot observe (their declared execution requirement needs this host).
+      - name: Capture baseline fragment (__DXKIT_FRAGMENT_CHECKS__)
+        shell: bash
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            DXKIT=./node_modules/.bin/vyuh-dxkit
+          else
+            DXKIT=vyuh-dxkit
+          fi
+          "${DXKIT}" baseline fragment --checks __DXKIT_FRAGMENT_CHECKS__ --out dxkit-fragment-__DXKIT_GATE_HOST__.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dxkit-fragment-__DXKIT_GATE_HOST__
+          path: dxkit-fragment-__DXKIT_GATE_HOST__.json

--- a/src-templates/.github/workflows/partials/fragment-merge-steps.yml
+++ b/src-templates/.github/workflows/partials/fragment-merge-steps.yml
@@ -1,0 +1,21 @@
+# PARTIAL — merge steps rendered into the refresh job's
+# __DXKIT_FRAGMENT_MERGE_STEPS__ slot (after `baseline create`, before the
+# commit) when host capture jobs exist. Never installed standalone.
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dxkit-fragment-*
+          merge-multiple: true
+
+      # Fold each host's slice into the freshly-recomputed baseline. The
+      # fragments' finding ids are environment-independent (Rule 9), which is
+      # what makes one committed baseline composable across runners. A
+      # scheme/epoch mismatch refuses (exit 1) rather than poisoning the
+      # baseline — capture and merge must run the same dxkit version.
+      - name: Merge host-captured baseline fragments
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
+            DXKIT=./node_modules/.bin/vyuh-dxkit
+          else
+            DXKIT=vyuh-dxkit
+          fi
+          "${DXKIT}" baseline merge-fragment dxkit-fragment-*.json

--- a/src/analyzers/custom-checks/gather.ts
+++ b/src/analyzers/custom-checks/gather.ts
@@ -19,6 +19,7 @@ import type { BrownfieldPolicy } from '../../baseline/policy';
 import { lintGateSpecs, normalizeCustomChecks } from './config';
 import { runCustomChecks } from './run';
 import type { CommandExec } from '../tools/bounded-exec';
+import { currentEnvironment, unmetRequirement, type ExecutionEnvironment } from '../../execution';
 import {
   extensionRecallInputs,
   gatherExtensionFindings,
@@ -38,6 +39,30 @@ export interface GatherCustomChecksOptions {
   readonly timeoutMs?: number;
   /** Injected for tests; defaults to real PATH resolution + execFileSync. */
   readonly exec?: CommandExec;
+  /** Injected for tests; defaults to the real local host + toolchain probes. */
+  readonly env?: ExecutionEnvironment;
+  /**
+   * Scope the gather to these check names — the fragment capture's slice
+   * (Rule 20 / design §3.4). When set, ONLY the named checks run, and
+   * committed extension findings are NOT appended (a scoped host capture owns
+   * its checks; extension snapshots are the primary capture's to read).
+   * Undefined = the full seam, exactly as before.
+   */
+  readonly onlyChecks?: readonly string[];
+}
+
+/**
+ * The specs whose declared execution requirement THIS environment satisfies
+ * (Rule 20) — the ONE observability filter shared by the recall derivation
+ * below and the fragment capture (`src/baseline/fragment.ts`). A spec with no
+ * declaration (a user check) always passes: dxkit cannot know what `make
+ * lint` needs and does not invent a requirement.
+ */
+export function observableSpecs(
+  specs: readonly CustomCheckSpec[],
+  env: ExecutionEnvironment,
+): CustomCheckSpec[] {
+  return specs.filter((s) => !s.execution || unmetRequirement(s.execution, env) === null);
 }
 
 /** Resolve the full spec set (user checks + built-in lint) for a repo. Pure
@@ -76,8 +101,28 @@ export function resolveCustomCheckSpecs(opts: GatherCustomChecksOptions): Custom
  * the ones that find nothing.
  */
 export function customCheckRecallInputs(opts: GatherCustomChecksOptions): Record<string, string> {
+  // Rule 20 honesty: a check this environment CANNOT run contributes no
+  // recall inputs — it was not observed, and claiming its recall would
+  // fabricate comparability (the exact proxy Rule 19 exists to kill). The
+  // latent lie this closes: a baseline captured on linux recorded
+  // `lint:csharp/...` inputs (config hashes need no dotnet) while the runner
+  // env-skipped the check, so a later windows gate read "comparable, zero
+  // grandfathered findings" and flagged the repo's ENTIRE pre-existing lint
+  // backlog as net-new. Unobserved must read as ABSENT, which the recall
+  // diff already treats as "cannot attribute" — the honest answer.
+  const env = opts.env ?? currentEnvironment();
+  return {
+    ...recallInputsForSpecs(observableSpecs(resolveCustomCheckSpecs(opts), env)),
+    ...extensionRecallInputs(opts.cwd),
+  };
+}
+
+/** The per-spec recall derivation, factored so the fragment capture
+ *  (`src/baseline/fragment.ts`) reuses the ONE formula for the checks it
+ *  observed on its host (Rule 2 — a second derivation would drift). */
+export function recallInputsForSpecs(specs: readonly CustomCheckSpec[]): Record<string, string> {
   const inputs: Record<string, string> = {};
-  for (const spec of resolveCustomCheckSpecs(opts)) {
+  for (const spec of specs) {
     inputs[`${spec.name}/cmd`] = normalizeCommandForRecall(spec.command.bin, spec.command.args);
     inputs[`${spec.name}/parse`] =
       spec.parse.mode === 'regex'
@@ -93,7 +138,7 @@ export function customCheckRecallInputs(opts: GatherCustomChecksOptions): Record
       inputs[`${spec.name}/${key}`] = value;
     }
   }
-  return { ...inputs, ...extensionRecallInputs(opts.cwd) };
+  return inputs;
 }
 
 /**
@@ -152,7 +197,8 @@ function hashText(text: string): string {
 export function gatherCustomCheckFindings(
   opts: GatherCustomChecksOptions,
 ): readonly CustomCheckFinding[] {
-  const specs = resolveCustomCheckSpecs(opts);
+  const all = resolveCustomCheckSpecs(opts);
+  const specs = opts.onlyChecks ? all.filter((s) => opts.onlyChecks!.includes(s.name)) : all;
   const commandFindings =
     specs.length === 0
       ? []
@@ -161,7 +207,9 @@ export function gatherCustomCheckFindings(
           specs,
           ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
           ...(opts.exec !== undefined ? { exec: opts.exec } : {}),
+          ...(opts.env !== undefined ? { env: opts.env } : {}),
         }).findings;
+  if (opts.onlyChecks) return commandFindings;
   // The seam's third consumer (after user checks + pack lint): findings
   // committed by findings-kind EXTENSIONS. Snapshot reads only — nothing
   // executes here (extensions run at refresh time; gates stay offline) —

--- a/src/baseline/fragment.ts
+++ b/src/baseline/fragment.ts
@@ -1,0 +1,197 @@
+/**
+ * Multi-environment baseline composition (CLAUDE.md Rule 20, design §3.4 —
+ * the hidden enabler): ONE committed baseline assembled from findings
+ * captured in DIFFERENT environments. Sound because finding identity is
+ * environment-independent by design (Rule 9) — the same finding gets the same
+ * id regardless of which runner produced it.
+ *
+ * A FRAGMENT is a partial capture from a placed host: the `custom-check`
+ * findings (and their recall inputs) for the checks that host can observe and
+ * the primary cannot — the `lint:csharp` backlog captured on the windows
+ * runner. The MERGE folds fragments into the committed baseline by
+ * observation unit (the check name): the fragment OWNS its declared checks —
+ * their prior entries and recall keys are replaced wholesale, everything else
+ * is untouched. Never append-only (stale entries would grandfather fixed
+ * findings forever) and never whole-kind (the primary's own lint checks live
+ * in the same kind).
+ *
+ * Composition guards are load-bearing: a fragment minted under a different
+ * identity scheme or recall epoch is NOT comparable, and merging it would
+ * poison the baseline with ids the guardrail can never match — refused with
+ * the remedy named, never silently accepted (the Rule 19 discipline).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { BaselineFile } from './baseline-file';
+import { CURRENT_IDENTITY_SCHEME, type BaselineEntry, type IdentitySchemeVersion } from './types';
+import { RECALL_EPOCHS, type RecallMap } from './recall';
+import { customCheckFindingsToBaselineEntries } from './producers/custom-checks';
+import {
+  gatherCustomCheckFindings,
+  observableSpecs,
+  recallInputsForSpecs,
+  resolveCustomCheckSpecs,
+  type GatherCustomChecksOptions,
+} from '../analyzers/custom-checks/gather';
+// exec-requirement-ok: the fragment capture is a deliberate Rule 20 consumer —
+// it derives its default observation scope ("what can THIS host see that the
+// primary cannot") from the same predicate the runners and resolver use.
+import { currentEnvironment, hostOf, unmetRequirement, type ExecutionHost } from '../execution';
+
+export const FRAGMENT_SCHEMA = 'dxkit-baseline-fragment.v1' as const;
+
+export interface BaselineFragment {
+  readonly schema: typeof FRAGMENT_SCHEMA;
+  readonly capturedAt: string;
+  /** Host that captured this fragment (provenance for diagnostics). */
+  readonly host: ExecutionHost;
+  /** Scheme + epoch the fragment was minted under — the comparability
+   *  guards the merge enforces. */
+  readonly identityScheme: IdentitySchemeVersion;
+  readonly customCheckEpoch: number;
+  /** The observation scope: check names this fragment FULLY observed. The
+   *  merge replaces exactly these checks' entries + recall keys. */
+  readonly checks: readonly string[];
+  /** `custom-check` entries for the observed checks. */
+  readonly findings: readonly BaselineEntry[];
+  /** Recall inputs for the observed checks (`<check>/...` namespaced), from
+   *  the ONE seam derivation (`recallInputsForSpecs`). */
+  readonly recallInputs: Readonly<Record<string, string>>;
+}
+
+export interface CaptureFragmentOptions extends GatherCustomChecksOptions {
+  /** Explicit check names to capture. Default: the checks THIS host can
+   *  observe that the primary (linux) host cannot — i.e. exactly the slice
+   *  the placement plan routed here. */
+  readonly checks?: readonly string[];
+}
+
+/**
+ * Capture a baseline fragment on the current host. Runs ONLY the selected
+ * checks (a windows capture job must not re-run eslint), maps their findings
+ * through the one custom-check producer, and derives their recall through the
+ * one seam formula — a fragment is byte-compatible with what a full capture
+ * on this host would have recorded for these checks.
+ */
+export function captureFragment(opts: CaptureFragmentOptions): BaselineFragment {
+  const env = opts.env ?? currentEnvironment();
+  const all = resolveCustomCheckSpecs(opts);
+  const selected = opts.checks
+    ? all.filter((s) => opts.checks!.includes(s.name))
+    : // Default: observable HERE, not observable on the primary host — the
+      // placement plan's slice, derived from the same declarations.
+      observableSpecs(all, env).filter(
+        (s) =>
+          s.execution &&
+          unmetRequirement(s.execution, { host: 'linux', hasToolchain: () => true }) !== null,
+      );
+
+  // Through the seam's ONE entry point, scoped to the selected checks — a
+  // fragment's findings are byte-compatible with what a full capture on this
+  // host would have recorded for them (the arch-check custom-check rule).
+  const findings =
+    selected.length === 0
+      ? []
+      : gatherCustomCheckFindings({ ...opts, env, onlyChecks: selected.map((s) => s.name) });
+
+  return {
+    schema: FRAGMENT_SCHEMA,
+    capturedAt: new Date().toISOString(),
+    host: hostOf(),
+    identityScheme: CURRENT_IDENTITY_SCHEME,
+    customCheckEpoch: RECALL_EPOCHS['custom-check'],
+    checks: selected.map((s) => s.name),
+    findings: customCheckFindingsToBaselineEntries(findings),
+    recallInputs: recallInputsForSpecs(selected),
+  };
+}
+
+/** Refusal error with the remedy in the message — callers surface it verbatim. */
+export class FragmentMergeError extends Error {}
+
+/**
+ * Fold a fragment into a baseline. Pure — the caller decides where the result
+ * is written (the refresh workflow commits it via the existing anchor path).
+ *
+ * Ownership semantics: for every check the fragment declares, ALL prior
+ * `custom-check` entries with that check name and ALL `<check>/…` recall keys
+ * are replaced by the fragment's. Other checks, other kinds, and the
+ * envelope are untouched.
+ */
+export function mergeFragment(baseline: BaselineFile, fragment: BaselineFragment): BaselineFile {
+  if (fragment.schema !== FRAGMENT_SCHEMA) {
+    throw new FragmentMergeError(
+      `Unknown fragment schema '${String((fragment as { schema?: string }).schema)}' — ` +
+        `re-capture the fragment with this dxkit version.`,
+    );
+  }
+  const baselineScheme = baseline.identityScheme ?? 'v1';
+  if (fragment.identityScheme !== baselineScheme) {
+    throw new FragmentMergeError(
+      `Fragment identity scheme '${fragment.identityScheme}' does not match the baseline's ` +
+        `'${baselineScheme}' — the ids would never line up. Remedy: upgrade the baseline first ` +
+        `(vyuh-dxkit update migrates it), then re-capture the fragment.`,
+    );
+  }
+  if (fragment.customCheckEpoch !== RECALL_EPOCHS['custom-check']) {
+    throw new FragmentMergeError(
+      `Fragment custom-check recall epoch ${fragment.customCheckEpoch} does not match this ` +
+        `dxkit's epoch ${RECALL_EPOCHS['custom-check']} — capture and merge must run the same ` +
+        `dxkit version. Remedy: re-capture the fragment with the version doing the merge.`,
+    );
+  }
+  const owned = new Set(fragment.checks);
+  // `'check' in f` narrows past sanitized entries (a sanitized baseline keeps
+  // ids only) — a sanitized custom-check entry without its check name cannot
+  // be attributed to the fragment's scope, so it is conservatively KEPT.
+  const kept = baseline.findings.filter(
+    (f) => !(f.kind === 'custom-check' && 'check' in f && owned.has(f.check)),
+  );
+
+  const slot = baseline.recall?.['custom-check'];
+  const keptInputs = Object.fromEntries(
+    Object.entries(slot?.inputs ?? {}).filter(([key]) => !owned.has(key.split('/')[0])),
+  );
+  const recall: RecallMap = {
+    ...(baseline.recall ?? {}),
+    'custom-check': {
+      epoch: fragment.customCheckEpoch,
+      inputs: { ...keptInputs, ...fragment.recallInputs },
+    },
+  };
+
+  return { ...baseline, recall, findings: [...kept, ...fragment.findings] };
+}
+
+/** Write a fragment (pretty JSON, mkdir -p). */
+export function writeFragment(filePath: string, fragment: BaselineFragment): void {
+  fs.mkdirSync(path.dirname(path.resolve(filePath)), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(fragment, null, 2) + '\n', 'utf8');
+}
+
+/** Read + shape-check a fragment file. Throws `FragmentMergeError` with the
+ *  remedy on anything unrecognizable — a merge must never guess. */
+export function readFragment(filePath: string): BaselineFragment {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    throw new FragmentMergeError(`Cannot read fragment ${filePath}: ${(err as Error).message}`);
+  }
+  const f = parsed as BaselineFragment;
+  if (
+    !f ||
+    f.schema !== FRAGMENT_SCHEMA ||
+    !Array.isArray(f.checks) ||
+    !Array.isArray(f.findings) ||
+    typeof f.identityScheme !== 'string' ||
+    typeof f.customCheckEpoch !== 'number'
+  ) {
+    throw new FragmentMergeError(
+      `${filePath} is not a dxkit baseline fragment (expected schema '${FRAGMENT_SCHEMA}').`,
+    );
+  }
+  return f;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -436,6 +436,7 @@ export async function run(argv: string[]): Promise<void> {
       ref: { type: 'string' },
       surface: { type: 'string' },
       packs: { type: 'string' },
+      checks: { type: 'string' },
       correctness: { type: 'boolean' },
       'no-correctness': { type: 'boolean' },
       'keep-baselines': { type: 'boolean', default: false },
@@ -2571,11 +2572,77 @@ export async function run(argv: string[]): Promise<void> {
         }
         break;
       }
+      if (subCommand === 'fragment') {
+        // Capture THIS host's slice of the baseline (Rule 20 / design §3.4):
+        // the custom-check findings + recall for the checks placed on this
+        // host — the generated per-host capture job's command. Default scope
+        // is exactly what the primary host cannot observe; --checks overrides.
+        const targetPath = resolveRepoPath(positionals[2]);
+        const { captureFragment, writeFragment } = await import('./baseline/fragment');
+        const { loadPolicyFromCwd } = await import('./baseline/policy');
+        const checks = (values.checks as string | undefined)
+          ?.split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        const fragment = captureFragment({
+          cwd: targetPath,
+          policy: loadPolicyFromCwd(targetPath),
+          ...(checks ? { checks } : {}),
+        });
+        const out = (values.out as string | undefined) ?? 'dxkit-baseline-fragment.json';
+        writeFragment(out, fragment);
+        logger.success(
+          `Captured ${fragment.findings.length} finding(s) for ${fragment.checks.length} ` +
+            `check(s) [${fragment.checks.join(', ') || 'none placed on this host'}] → ${out}`,
+        );
+        process.exit(0);
+        break;
+      }
+      if (subCommand === 'merge-fragment') {
+        // Fold host-captured fragments into the committed baseline — the
+        // refresh workflow's merge step before the anchor commit. Refuses
+        // (exit 1, remedy named) on a scheme/epoch mismatch rather than
+        // poisoning the baseline with incomparable ids.
+        const files = positionals.slice(2).filter((p) => p.endsWith('.json'));
+        if (files.length === 0) {
+          logger.fail('Usage: vyuh-dxkit baseline merge-fragment <fragment.json…> [--name main]');
+          process.exit(1);
+        }
+        const { mergeFragment, readFragment, FragmentMergeError } =
+          await import('./baseline/fragment');
+        const { pathForBaseline, readBaselineFile, writeBaselineFile } =
+          await import('./baseline/baseline-file');
+        const name = (values.name as string | undefined) ?? 'main';
+        const baselinePath = pathForBaseline(process.cwd(), name);
+        try {
+          let file = readBaselineFile(baselinePath);
+          for (const f of files) {
+            const fragment = readFragment(f);
+            file = mergeFragment(file, fragment);
+            logger.info(
+              `Merged ${fragment.findings.length} finding(s) from ${f} ` +
+                `(${fragment.host}: ${fragment.checks.join(', ')})`,
+            );
+          }
+          writeBaselineFile(baselinePath, file);
+          logger.success(`Baseline '${name}' updated with ${files.length} fragment(s).`);
+          process.exit(0);
+        } catch (err) {
+          if (err instanceof FragmentMergeError) {
+            logger.fail(err.message);
+            process.exit(1);
+          }
+          throw err;
+        }
+        break;
+      }
       logger.fail(
         `Unknown baseline subcommand: ${subCommand ?? '(missing)'}. ` +
           `Available: vyuh-dxkit baseline create [path] [--name <name>] [--force] · ` +
           `vyuh-dxkit baseline publish [path] · ` +
-          `vyuh-dxkit baseline show [path] [--name <name>] [--baseline <path>] [--kind <kind>] [--json]`,
+          `vyuh-dxkit baseline show [path] [--name <name>] [--baseline <path>] [--kind <kind>] [--json] · ` +
+          `vyuh-dxkit baseline fragment [path] [--checks <a,b>] [--out <file>] · ` +
+          `vyuh-dxkit baseline merge-fragment <fragment.json…> [--name <name>]`,
       );
       process.exit(1);
       break;

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -668,6 +668,78 @@ export function installCiHostGates(cwd: string, opts: InstallerOpts = {}): ShipI
   return result;
 }
 
+/**
+ * Multi-environment baseline capture (Rule 20, design §3.4/§6.6): the refresh
+ * workflow's per-host fragment-capture jobs + merge steps, rendered from the
+ * placement plan. A host job earns a capture job only when a LINT GATE is
+ * placed on it (the floor is a pass/fail signal, never baselined) and lint
+ * gating is enabled — otherwise every slot renders empty and the refresh
+ * workflow stays byte-identical to its single-job form.
+ */
+export function renderFragmentOrchestration(cwd: string): {
+  captureJobs: string;
+  needs: string;
+  mergeSteps: string;
+} {
+  const empty = { captureJobs: '', needs: '', mergeSteps: '' };
+  let lintEnabled = false;
+  try {
+    lintEnabled = loadPolicyFromCwd(cwd)?.lint?.enabled === true;
+  } catch {
+    return empty; // fail-open: orchestration is additive
+  }
+  if (!lintEnabled) return empty;
+
+  const plan = repoPlacementPlan(cwd);
+  const lintHosts = plan.hostJobs
+    .map((j) => ({
+      host: j.host,
+      runner: j.runner,
+      lintPacks: j.capabilities.filter((c) => c.capability === 'lintGate').map((c) => c.pack),
+    }))
+    .filter((j) => j.lintPacks.length > 0);
+  if (lintHosts.length === 0) return empty;
+
+  const partial = (name: string): string =>
+    fs
+      .readFileSync(path.join(templatesDir(), '.github', 'workflows', 'partials', name), 'utf8')
+      // Strip the partial's own header comment (lines before the first
+      // non-comment content) — it documents the TEMPLATE, not the render.
+      .replace(/^(#[^\n]*\n)+/, '');
+
+  const jobs = lintHosts.map((j) => {
+    // The check names for this host's placed lint gates (`lint:<pack>` is the
+    // seam's reserved naming — LINT_CHECK_PREFIX).
+    const checks = j.lintPacks.map((p) => `lint:${p}`).join(',');
+    let setup = '';
+    try {
+      const flags = { ...detect(cwd).languages };
+      for (const id of Object.keys(flags) as (keyof typeof flags)[]) {
+        if (!j.lintPacks.includes(id)) flags[id] = false;
+      }
+      const steps = allCiSetupSteps(flags, cwd);
+      setup = steps.length === 0 ? '' : steps.map(renderCiSetupStep).join('\n') + '\n';
+    } catch {
+      setup = '';
+    }
+    return partial('fragment-capture-job.yml')
+      .split('__DXKIT_GATE_HOST__')
+      .join(j.host)
+      .split('__DXKIT_GATE_RUNNER__')
+      .join(j.runner)
+      .split('__DXKIT_FRAGMENT_CHECKS__')
+      .join(checks)
+      .split('__DXKIT_FRAGMENT_HOST_SETUP__\n')
+      .join(setup);
+  });
+
+  return {
+    captureJobs: jobs.join('\n'),
+    needs: `    needs: [${lintHosts.map((j) => `capture-${j.host}`).join(', ')}]\n`,
+    mergeSteps: partial('fragment-merge-steps.yml'),
+  };
+}
+
 /** Combine two ship results — local helper for multi-file installers. */
 function mergeShipResults(a: ShipInstallResult, b: ShipInstallResult): ShipInstallResult {
   return {
@@ -813,6 +885,7 @@ export function installCiBaselineRefresh(
   const installedTransport = detectInstalledRefreshTransport(cwd);
   const migrating = installedTransport !== null && installedTransport !== plan.transport;
   const effectiveOpts = migrating ? { ...opts, force: true } : opts;
+  const fragments = renderFragmentOrchestration(cwd);
   const result = installWorkflow(
     cwd,
     REFRESH_TEMPLATE_BY_TRANSPORT[plan.transport],
@@ -821,9 +894,20 @@ export function installCiBaselineRefresh(
       __DXKIT_DEFAULT_BRANCH__: defaultBranch,
       __DXKIT_ANCHOR_REF__: plan.anchorRef,
       [CI_RUNTIME_SETUP_KEY]: renderCiRuntimeSetup(cwd),
+      // Multi-env capture (Rule 20 / design §3.4): per-host fragment jobs +
+      // the merge before the commit. All three slots render empty on a repo
+      // whose lint the primary runner fully observes.
+      ['__DXKIT_FRAGMENT_CAPTURE_JOBS__\n']: fragments.captureJobs,
+      ['__DXKIT_REFRESH_NEEDS__\n']: fragments.needs,
+      ['__DXKIT_FRAGMENT_MERGE_STEPS__\n']: fragments.mergeSteps,
     },
     REFRESH_WORKFLOW_DEST,
   );
+  if (fragments.captureJobs && result.installed.length > 0) {
+    result.notes.push(
+      'Baseline refresh captures host fragments (multi-env baseline) — merged before the anchor commit.',
+    );
+  }
   // Record a resolved 'branch' transport in the policy so the guardrail READER
   // activates: `loadAnchorFromBranch` gates on `policy.baseline.anchor ===
   // 'branch'`, so an enforcement-derived transport that lives only in the

--- a/test/baseline/fragment.test.ts
+++ b/test/baseline/fragment.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Multi-environment baseline composition (CLAUDE.md Rule 20, design §3.4 —
+ * 4.0 increment 4): check-level recall honesty, fragment capture, the
+ * kind/check-scoped merge with its comparability guards, and the generated
+ * refresh-workflow orchestration.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  captureFragment,
+  mergeFragment,
+  readFragment,
+  writeFragment,
+  FragmentMergeError,
+  FRAGMENT_SCHEMA,
+  type BaselineFragment,
+} from '../../src/baseline/fragment';
+import { customCheckRecallInputs } from '../../src/analyzers/custom-checks/gather';
+import { RECALL_EPOCHS } from '../../src/baseline/recall';
+import { CURRENT_IDENTITY_SCHEME } from '../../src/baseline/types';
+import { BASELINE_SCHEMA_VERSION, type BaselineFile } from '../../src/baseline/baseline-file';
+import type { BrownfieldPolicy } from '../../src/baseline/policy';
+import { csharp } from '../../src/languages/csharp';
+import { typescript } from '../../src/languages/typescript';
+import { renderFragmentOrchestration } from '../../src/ship-installers';
+import type { ExecutionEnvironment } from '../../src/execution';
+
+const LINT_ON = { lint: { enabled: true } } as unknown as BrownfieldPolicy;
+
+function winformsRepo(withPolicy = false): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-fragment-'));
+  fs.writeFileSync(
+    path.join(dir, 'App.csproj'),
+    '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><TargetFramework>net9.0-windows</TargetFramework></PropertyGroup></Project>',
+  );
+  fs.writeFileSync(path.join(dir, 'Main.cs'), 'class P { static void Main() {} }');
+  if (withPolicy) {
+    fs.mkdirSync(path.join(dir, '.dxkit'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, '.dxkit', 'policy.json'),
+      JSON.stringify({ lint: { enabled: true } }),
+    );
+  }
+  return dir;
+}
+
+const envOf = (host: 'linux' | 'windows'): ExecutionEnvironment => ({
+  host,
+  hasToolchain: () => true,
+});
+
+describe('check-level recall honesty (the unobserved-check lie, closed)', () => {
+  it('an env-unrunnable check contributes NO recall inputs; a runnable one does', () => {
+    const dir = winformsRepo();
+    try {
+      const base = { cwd: dir, policy: LINT_ON, packs: [csharp] };
+      const onLinux = customCheckRecallInputs({ ...base, env: envOf('linux') });
+      // The windows-only gate was NOT observed here — claiming its recall
+      // would read as "comparable, zero findings" and flag the whole
+      // pre-existing backlog as net-new on the first windows-side check.
+      expect(Object.keys(onLinux).filter((k) => k.startsWith('lint:csharp/'))).toEqual([]);
+      const onWindows = customCheckRecallInputs({ ...base, env: envOf('windows') });
+      expect(onWindows['lint:csharp/cmd']).toBeTruthy();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('captureFragment', () => {
+  it('captures exactly the primary-unobservable slice, with findings + recall', () => {
+    const dir = winformsRepo();
+    try {
+      const fragment = captureFragment({
+        cwd: dir,
+        policy: LINT_ON,
+        packs: [csharp, typescript],
+        env: envOf('windows'),
+        // MSBuild emits warnings on exit 0 — the regex parse reads them anyway.
+        exec: () => ({
+          available: true,
+          code: 0,
+          output: [
+            'Main.cs(10,5): warning CA1051: Do not declare visible instance fields [App.csproj]',
+            'Main.cs(20,5): warning CA2007: Consider ConfigureAwait [App.csproj]',
+          ].join('\n'),
+        }),
+      });
+      // Default scope: the windows-only csharp gate, never the host-agnostic
+      // eslint gate (the primary already observes it).
+      expect(fragment.checks).toEqual(['lint:csharp']);
+      expect(fragment.findings).toHaveLength(2);
+      for (const f of fragment.findings) {
+        expect(f.kind).toBe('custom-check');
+        expect(f.id).toMatch(/^[0-9a-f]{16}$/);
+      }
+      expect(fragment.recallInputs['lint:csharp/cmd']).toBeTruthy();
+      expect(Object.keys(fragment.recallInputs).every((k) => k.startsWith('lint:csharp/'))).toBe(
+        true,
+      );
+      expect(fragment.identityScheme).toBe(CURRENT_IDENTITY_SCHEME);
+      expect(fragment.customCheckEpoch).toBe(RECALL_EPOCHS['custom-check']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('round-trips through write + read', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-fragment-'));
+    try {
+      const fragment: BaselineFragment = {
+        schema: FRAGMENT_SCHEMA,
+        capturedAt: '2026-01-01T00:00:00.000Z',
+        host: 'windows',
+        identityScheme: CURRENT_IDENTITY_SCHEME,
+        customCheckEpoch: RECALL_EPOCHS['custom-check'],
+        checks: ['lint:csharp'],
+        findings: [],
+        recallInputs: {},
+      };
+      const p = path.join(dir, 'f.json');
+      writeFragment(p, fragment);
+      expect(readFragment(p)).toEqual(fragment);
+      fs.writeFileSync(p, '{"schema":"nope"}');
+      expect(() => readFragment(p)).toThrow(FragmentMergeError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('mergeFragment (check-scoped ownership, comparability guards)', () => {
+  const baseline: BaselineFile = {
+    schemaVersion: BASELINE_SCHEMA_VERSION, // baseline-file-construction-ok: hand-built fixture
+    name: 'main',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    repo: { headSha: 'x', branch: 'main', dirty: false },
+    analysis: {
+      dxkitVersion: '4.0.0',
+      policyHash: '',
+      ignoreHash: '',
+      toolchainHash: '',
+      configHash: '',
+    },
+    tools: {},
+    saltMode: 'none',
+    identityScheme: CURRENT_IDENTITY_SCHEME,
+    recall: {
+      'custom-check': {
+        epoch: RECALL_EPOCHS['custom-check'],
+        inputs: { 'lint:csharp/cmd': 'stale', 'lint:typescript/cmd': 'keep-me' },
+      },
+    },
+    findings: [
+      { id: 'aaaaaaaaaaaaaaaa', kind: 'custom-check', check: 'lint:csharp', blocking: false },
+      { id: 'bbbbbbbbbbbbbbbb', kind: 'custom-check', check: 'lint:typescript', blocking: false },
+      {
+        id: 'cccccccccccccccc',
+        kind: 'secret',
+        tool: 'gitleaks',
+        rule: 'generic',
+        file: 'a.ts',
+        line: 1,
+      },
+    ],
+  } as unknown as BaselineFile;
+
+  const fragment: BaselineFragment = {
+    schema: FRAGMENT_SCHEMA,
+    capturedAt: '2026-01-02T00:00:00.000Z',
+    host: 'windows',
+    identityScheme: CURRENT_IDENTITY_SCHEME,
+    customCheckEpoch: RECALL_EPOCHS['custom-check'],
+    checks: ['lint:csharp'],
+    findings: [
+      { id: 'dddddddddddddddd', kind: 'custom-check', check: 'lint:csharp', blocking: false },
+      { id: 'eeeeeeeeeeeeeeee', kind: 'custom-check', check: 'lint:csharp', blocking: false },
+    ],
+    recallInputs: { 'lint:csharp/cmd': 'fresh', 'lint:csharp/config': 'hash' },
+  };
+
+  it('replaces exactly the owned checks — entries and recall keys — and nothing else', () => {
+    const merged = mergeFragment(baseline, fragment);
+    const ids = merged.findings.map((f) => f.id).sort();
+    expect(ids).toEqual([
+      'bbbbbbbbbbbbbbbb',
+      'cccccccccccccccc',
+      'dddddddddddddddd',
+      'eeeeeeeeeeeeeeee',
+    ]);
+    expect(merged.recall?.['custom-check']?.inputs).toEqual({
+      'lint:typescript/cmd': 'keep-me',
+      'lint:csharp/cmd': 'fresh',
+      'lint:csharp/config': 'hash',
+    });
+    // Envelope untouched.
+    expect(merged.name).toBe('main');
+    expect(merged.identityScheme).toBe(CURRENT_IDENTITY_SCHEME);
+  });
+
+  it('is idempotent (re-merging the same fragment changes nothing)', () => {
+    const once = mergeFragment(baseline, fragment);
+    const twice = mergeFragment(once, fragment);
+    expect(twice.findings.map((f) => f.id).sort()).toEqual(once.findings.map((f) => f.id).sort());
+    expect(twice.recall).toEqual(once.recall);
+  });
+
+  it('refuses an identity-scheme mismatch with the remedy named', () => {
+    const alien = { ...fragment, identityScheme: 'v1' as const };
+    expect(() => mergeFragment(baseline, alien)).toThrow(FragmentMergeError);
+    expect(() => mergeFragment(baseline, alien)).toThrow(/update migrates/);
+  });
+
+  it('refuses a recall-epoch mismatch (capture and merge must share a dxkit)', () => {
+    const stale = { ...fragment, customCheckEpoch: RECALL_EPOCHS['custom-check'] + 1 };
+    expect(() => mergeFragment(baseline, stale)).toThrow(/epoch/);
+  });
+});
+
+describe('refresh-workflow fragment orchestration (generated)', () => {
+  it('renders a windows capture job + needs + merge steps for a placed lint gate', () => {
+    const dir = winformsRepo(true);
+    try {
+      const r = renderFragmentOrchestration(dir);
+      expect(r.captureJobs).toContain('capture-windows:');
+      expect(r.captureJobs).toContain('runs-on: windows-latest');
+      expect(r.captureJobs).toContain('--checks lint:csharp');
+      expect(r.captureJobs).toContain('upload-artifact');
+      expect(r.captureJobs).toContain('actions/setup-dotnet');
+      expect(r.needs).toContain('needs: [capture-windows]');
+      expect(r.mergeSteps).toContain('merge-fragment');
+      // The generator lesson holds here too: setup actions only.
+      expect(r.captureJobs).not.toMatch(/Visual Studio.{0,4}\d{4}/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('renders nothing when lint gating is off, or when nothing is placed off-primary', () => {
+    const noPolicy = winformsRepo(false);
+    const tsOnly = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-fragment-'));
+    try {
+      expect(renderFragmentOrchestration(noPolicy)).toEqual({
+        captureJobs: '',
+        needs: '',
+        mergeSteps: '',
+      });
+      fs.writeFileSync(path.join(tsOnly, 'package.json'), '{"name":"x"}');
+      fs.mkdirSync(path.join(tsOnly, '.dxkit'));
+      fs.writeFileSync(path.join(tsOnly, '.dxkit', 'policy.json'), '{"lint":{"enabled":true}}');
+      expect(renderFragmentOrchestration(tsOnly).captureJobs).toBe('');
+    } finally {
+      fs.rmSync(noPolicy, { recursive: true, force: true });
+      fs.rmSync(tsOnly, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -609,6 +609,10 @@ describe('recipe playbook — synthetic pack', () => {
       cwd: '/nonexistent-repo',
       packs: [...LANGUAGES],
       policy: { lint: { enabled: true } } as unknown as BrownfieldPolicy,
+      // The mock gate is windows-only (Rule 20); recall honesty excludes
+      // unobservable checks, so observe from a satisfying environment — the
+      // exclusion direction is pinned in test/baseline/fragment.test.ts.
+      env: { host: 'windows', hasToolchain: () => true },
     });
     expect(inputs['lint:playbook/playbook-plugin-mock']).toBe('2.1.0');
     expect(inputs['lint:playbook/cmd']).toBe('playbook-lint-mock --gate --format json');


### PR DESCRIPTION
## What this is

Increment 4 of the 4.0 execution-environment train (stacks on #170/#171/#172), the last platform brick: **multi-environment baseline capture** (design 3.4 and 6.6). One committed baseline, assembled from captures in different environments, composed on the environment-independent finding fingerprints (Rule 9) that were built for exactly this and never used for it. This is what makes the dpl-studio target UX real: onboard from any machine, CI captures the complete baseline across the placed environments, commit via the anchor. One person, one flow, no hand-off.

It also fixes a latent honesty bug this design surfaced: a baseline captured on linux recorded `lint:csharp/...` recall inputs (config hashes need no dotnet) while the runner env-skipped the check itself. A later windows-side gate would read "comparable recall, zero grandfathered findings" and flag the repo's ENTIRE pre-existing lint backlog as net-new: the same class as the 3.8 B1 blocker, one layer down.

## What changed

### Check-level recall honesty (the unobserved-check lie, closed)
- `customCheckRecallInputs` now derives from `observableSpecs`: a check whose declared execution requirement this environment cannot satisfy contributes NO recall inputs. Unobserved reads as ABSENT, which the recall diff already treats as "cannot attribute", never as "comparable and clean". User checks (no declaration) keep the existing behavior: dxkit does not invent requirements it cannot know.

### The fragment primitive (`src/baseline/fragment.ts`)
- `captureFragment`: a placed host's slice of the baseline. Default scope is derived from the declarations (observable HERE, not observable on the primary host: exactly the placement plan's slice); findings flow through the seam's ONE gather entry point (`gatherCustomCheckFindings` gains an `onlyChecks` scope: the arch-check's custom-check rule forced this routing, and it is load-bearing: a fragment is byte-compatible with a full capture for its checks) and recall through the ONE formula (`recallInputsForSpecs`).
- `mergeFragment`: check-scoped ownership. The fragment REPLACES its declared checks' entries and recall keys and touches nothing else (never append-only, never whole-kind). Comparability guards REFUSE with the remedy named: identity-scheme mismatch (upgrade the baseline first) and recall-epoch mismatch (capture and merge must run the same dxkit). Idempotent.
- CLI: `baseline fragment [--checks a,b] [--out file]` and `baseline merge-fragment <files...> [--name main]`.

### Generated refresh-workflow orchestration
- All three baseline-refresh transport templates gain three render slots (capture jobs, `needs`, merge steps), all empty on a host-agnostic repo (byte-identical single-job workflow).
- `renderFragmentOrchestration` (from the placement plan, template partials): when a lint gate is placed on a non-primary host and lint gating is enabled, the refresh workflow gains a `capture-<host>` job (checkout, placed packs' `ciSetup`, `baseline fragment`, upload-artifact) and the primary refresh job gains `needs` + download + `merge-fragment` before the anchor commit. Setup actions only, same pinned discipline as the host gates.

## Verification
9 new fragment tests (recall honesty both directions, capture scope, merge ownership + idempotence + both refusal guards, round-trip, orchestration rendering both directions) plus the recipe-playbook seam test updated to observe from a satisfying environment (its windows-only mock gate is now correctly unobservable on linux: the fix biting). Full local gate ladder green.

## After this PR
The 4.0 platform is functionally complete: declare (170), diagnose (171), place and generate (172), compose (this). Next: the DoD: tarball eval on the external-repo fleet + gcs-web + fixtures into VERIFY-40, fix everything found, then onboard the repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
