### PR TITLE
fix(4.0-eval): close the five VERIFY-40 med+ findings from the rc.1 tarball eval

### DIFF
--- a/src/analyzers/custom-checks/config.ts
+++ b/src/analyzers/custom-checks/config.ts
@@ -117,7 +117,26 @@ export function lintGateSpecs(
   const specs: CustomCheckSpec[] = [];
   for (const { id, provider } of activeLintGateProviders(packs)) {
     const cmd = provider.lintCommand(ctx);
-    if (cmd === null) continue;
+    if (cmd === null) {
+      // The pack's linter is not resolvable here (findTool missed, no local
+      // bin). Pre-F-9 the spec simply didn't exist and a policy-ENABLED gate
+      // went silent; now it exists as a disclosed stub the runner reports as
+      // `skipped-unavailable` (never spawned — the sentinel bin is
+      // unexecutable by construction) and the recall derivation ignores
+      // (unobserved reads as absent).
+      specs.push({
+        name: `${LINT_CHECK_PREFIX}${id}`,
+        command: { bin: 'dxkit-lint-unavailable', args: [] },
+        blocking,
+        expectedExit: 0,
+        parse: { mode: 'exit' },
+        unavailable:
+          `the ${id} pack's linter is not installed or resolvable in this environment — ` +
+          `run \`vyuh-dxkit tools install\` (inventory: \`vyuh-dxkit tools list\`)`,
+        ...safeExecution(id, provider, ctx.cwd),
+      });
+      continue;
+    }
     specs.push({
       name: `${LINT_CHECK_PREFIX}${id}`,
       command: { bin: cmd.bin, args: cmd.args },

--- a/src/analyzers/custom-checks/gather.ts
+++ b/src/analyzers/custom-checks/gather.ts
@@ -123,6 +123,10 @@ export function customCheckRecallInputs(opts: GatherCustomChecksOptions): Record
 export function recallInputsForSpecs(specs: readonly CustomCheckSpec[]): Record<string, string> {
   const inputs: Record<string, string> = {};
   for (const spec of specs) {
+    // A declared-but-unresolvable gate (F-9 stub) was NOT observed — claiming
+    // its recall would fabricate comparability, the same lie the env filter
+    // above this function exists to kill. Unobserved reads as absent.
+    if (spec.unavailable) continue;
     inputs[`${spec.name}/cmd`] = normalizeCommandForRecall(spec.command.bin, spec.command.args);
     inputs[`${spec.name}/parse`] =
       spec.parse.mode === 'regex'

--- a/src/analyzers/custom-checks/run.ts
+++ b/src/analyzers/custom-checks/run.ts
@@ -81,6 +81,20 @@ export function runCustomChecks(opts: RunCustomChecksOptions): CustomChecksRunRe
         continue;
       }
     }
+    // A declared check whose tool is unresolvable (the pack's lintCommand
+    // returned null) is disclosed, never spawned and never silent — the user
+    // enabled this gate in policy and deserves to know why it isn't gating
+    // (VERIFY-40 F-9). After the env check: a wrong host is the more
+    // fundamental boundary and its remedy supersedes "install the linter".
+    if (spec.unavailable) {
+      results.push({
+        name: spec.name,
+        status: 'skipped-unavailable',
+        findings: [],
+        reason: spec.unavailable,
+      });
+      continue;
+    }
     const outcome = exec(spec.command, opts.cwd);
     if (!outcome.available) {
       results.push({ name: spec.name, status: 'skipped-unavailable', findings: [] });

--- a/src/analyzers/custom-checks/types.ts
+++ b/src/analyzers/custom-checks/types.ts
@@ -107,6 +107,17 @@ export interface CustomCheckSpec {
    * missing-binary path.
    */
   readonly execution?: ExecutionRequirement;
+  /**
+   * Present when the check is DECLARED (policy-enabled lint) but its tool is
+   * not resolvable here — the pack's `lintCommand` returned null. The runner
+   * discloses it as `skipped-unavailable` with this reason BEFORE any spawn,
+   * and the recall derivation contributes NOTHING for it (unobserved reads as
+   * absent). Without this marker the spec simply didn't exist, and a user who
+   * set `lint.enabled: true` saw total silence about why nothing gated
+   * (VERIFY-40 F-9). The stub's `command` is a sentinel that is never
+   * executed.
+   */
+  readonly unavailable?: string;
 }
 
 /** A single failure extracted from a check's output. Maps 1:1 to a
@@ -145,9 +156,11 @@ export interface CustomCheckResult {
   readonly name: string;
   readonly status: CustomCheckStatus;
   readonly findings: readonly CustomCheckFinding[];
-  /** Present on `skipped-environment`: the human-phrased unmet-requirement
-   *  boundary (from `describeUnmetRequirement`) — what is needed and where
-   *  the check would run instead. */
+  /** Present on `skipped-environment` (the human-phrased unmet-requirement
+   *  boundary from `describeUnmetRequirement` — what is needed and where the
+   *  check would run instead) and on a declared-but-unresolvable
+   *  `skipped-unavailable` (the spec's `unavailable` reason — which tool is
+   *  missing and the install remedy). */
   readonly reason?: string;
 }
 

--- a/src/analyzers/tools/osv-scanner-deps.ts
+++ b/src/analyzers/tools/osv-scanner-deps.ts
@@ -33,7 +33,7 @@ import {
   type OsvVuln,
 } from './osv';
 import { isMaliciousAdvisory } from '../security/malicious';
-import { fileExists, run } from './runner';
+import { fileExists, runWithExit } from './runner';
 import { findTool, TOOL_DEFS } from './tool-registry';
 import type {
   DepVulnFinding,
@@ -172,9 +172,13 @@ export function parseOsvScannerFindings(
  *     before pom.xml; ruby: Gemfile.lock).
  *
  * `scan source --lockfile <path>` is the v2.x form. JSON output to
- * stdout. Exit code is non-zero when findings exist — we ignore the
- * exit code and parse the JSON regardless (run() already swallows
- * non-zero exits cleanly via execSync's catch).
+ * stdout. Exit codes disambiguate completeness (VERIFY-40 F-7): 0 = clean,
+ * 1 = vulnerabilities found — BOTH mean the scan finished and its output is
+ * the whole observation. Anything else means the scan itself errored
+ * (network/API degradation, bad input) and any JSON on stdout may be a
+ * PARTIAL result — recording it as complete writes a baseline that
+ * under-observes and false-blocks the next check, so those exits are
+ * `unavailable` (disclosed), never parsed.
  *
  * CVSS alias-fallback: osv-scanner ships CVSS vectors when present,
  * but advisory data quality varies by ecosystem — some carry only
@@ -206,7 +210,20 @@ export async function gatherOsvScannerDepVulnsResult(
     return { kind: 'unavailable', reason: 'osv-scanner not installed' };
   }
 
-  const raw = run(`${scanner.path} scan source --lockfile ${manifest} --format json`, cwd, 180000);
+  const { code, stdout: raw } = runWithExit(
+    `${scanner.path} scan source --lockfile ${manifest} --format json`,
+    cwd,
+    180000,
+  );
+  if (code !== 0 && code !== 1) {
+    return {
+      kind: 'unavailable',
+      reason:
+        `osv-scanner exited ${code ?? 'without a code (timeout/spawn failure)'} — the scan ` +
+        `errored, so its output may be partial and was discarded rather than recorded as a ` +
+        `complete observation`,
+    };
+  }
   if (!raw) return { kind: 'unavailable', reason: 'osv-scanner produced no output' };
 
   const { counts, findings, vulnsForCvss } = parseOsvScannerFindings(raw, ecosystem, packId);

--- a/src/analyzers/tools/runner.ts
+++ b/src/analyzers/tools/runner.ts
@@ -84,6 +84,39 @@ export function run(cmd: string, cwd: string, timeoutMs = 30000): string {
 }
 
 /**
+ * Like `run`, but the caller sees the EXIT CODE alongside stdout. For tools
+ * whose non-zero exits are ambiguous: osv-scanner exits 1 both meaning
+ * "vulnerabilities found" (output complete) and >1 when the scan itself
+ * errored (network/API degradation) — possibly after emitting PARTIAL JSON.
+ * `run()` returns that partial stdout indistinguishably from success, which
+ * let a degraded scan write a 1-of-14-findings baseline that then false-
+ * blocked the next check 13 times (VERIFY-40 F-7). `code` is null when the
+ * process never yielded one (spawn failure / timeout).
+ */
+export function runWithExit(
+  cmd: string,
+  cwd: string,
+  timeoutMs = 30000,
+): { code: number | null; stdout: string } {
+  try {
+    const stdout = execSync(cmd, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: timeoutMs,
+      maxBuffer: 64 * 1024 * 1024,
+    }).trim();
+    return { code: 0, stdout };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; status?: number | null };
+    return {
+      code: typeof e.status === 'number' ? e.status : null,
+      stdout: typeof e.stdout === 'string' ? e.stdout.trim() : '',
+    };
+  }
+}
+
+/**
  * Run a binary directly (NO shell) and return stdout, or '' on failure.
  *
  * Synchronous sibling of `runDetached` for single-binary tools that must

--- a/src/baseline/anchor.ts
+++ b/src/baseline/anchor.ts
@@ -120,6 +120,55 @@ export interface AnchorBranchStatus {
   branchExists: boolean;
 }
 
+/**
+ * The dangerous anchor↔local divergence, pure over the two parsed baseline
+ * payloads (VERIFY-40 F-6): update's migration lanes rewrite the LOCAL file,
+ * but the branch-transport guardrail reads the ANCHOR — a migrated local over
+ * a pre-migration anchor means every check still drifts (or CANNOT GATE)
+ * while `update` and this file both look done. Only the migration-shaped
+ * divergences alarm; ordinary content lag (CI refreshed the anchor after a
+ * merge, the local copy is older) is normal and stays quiet.
+ */
+export function anchorStalenessFromContents(
+  anchor: { identityScheme?: unknown; recall?: unknown } | null,
+  local: { identityScheme?: unknown; recall?: unknown } | null,
+): string | null {
+  if (anchor == null || local == null) return null;
+  if (local.identityScheme && anchor.identityScheme !== local.identityScheme) {
+    return (
+      `the anchor branch holds identity scheme '${String(anchor.identityScheme ?? 'pre-v2')}' ` +
+      `while the local baseline is '${String(local.identityScheme)}'`
+    );
+  }
+  if (local.recall != null && anchor.recall == null) {
+    return 'the anchor branch predates recall attribution while the local baseline carries it';
+  }
+  return null;
+}
+
+/**
+ * IO wrapper over `anchorStalenessFromContents`: reads the side-branch anchor
+ * (when the transport is `branch` and the branch is reachable) and the local
+ * baseline file. `null` on any unreadable side — the presence probe above
+ * covers absence; this probe only speaks when it can actually compare.
+ */
+export function anchorStalenessProblem(
+  cwd: string,
+  baselinePath: string,
+  section: BaselineSection | undefined,
+): string | null {
+  try {
+    const tmp = loadAnchorFromBranch(cwd, baselinePath, section);
+    if (tmp == null || !fs.existsSync(baselinePath)) return null;
+    return anchorStalenessFromContents(
+      JSON.parse(fs.readFileSync(tmp, 'utf8')),
+      JSON.parse(fs.readFileSync(baselinePath, 'utf8')),
+    );
+  } catch {
+    return null;
+  }
+}
+
 /** Outcome of a `baseline publish`. `ok:false` carries `error` (wrong
  *  transport / nothing captured); a transport failure (no origin, rejected
  *  push) surfaces on `publish.reason` with `ok:true` left false-ish only via

--- a/src/baseline/fragment.ts
+++ b/src/baseline/fragment.ts
@@ -38,7 +38,13 @@ import {
 // exec-requirement-ok: the fragment capture is a deliberate Rule 20 consumer —
 // it derives its default observation scope ("what can THIS host see that the
 // primary cannot") from the same predicate the runners and resolver use.
-import { currentEnvironment, hostOf, unmetRequirement, type ExecutionHost } from '../execution';
+import {
+  currentEnvironment,
+  describeUnmetRequirement,
+  hostOf,
+  unmetRequirement,
+  type ExecutionHost,
+} from '../execution';
 
 export const FRAGMENT_SCHEMA = 'dxkit-baseline-fragment.v1' as const;
 
@@ -78,15 +84,59 @@ export interface CaptureFragmentOptions extends GatherCustomChecksOptions {
 export function captureFragment(opts: CaptureFragmentOptions): BaselineFragment {
   const env = opts.env ?? currentEnvironment();
   const all = resolveCustomCheckSpecs(opts);
-  const selected = opts.checks
-    ? all.filter((s) => opts.checks!.includes(s.name))
-    : // Default: observable HERE, not observable on the primary host — the
-      // placement plan's slice, derived from the same declarations.
-      observableSpecs(all, env).filter(
-        (s) =>
-          s.execution &&
-          unmetRequirement(s.execution, { host: 'linux', hasToolchain: () => true }) !== null,
+  let selected;
+  if (opts.checks) {
+    // Explicit scope. A fragment OWNS its declared checks on merge (their
+    // prior entries + recall keys are replaced wholesale), so a check this
+    // environment cannot observe MUST refuse — writing `findings: []` +
+    // recall inputs for a check that never ran claims "comparable and clean",
+    // erases the check's real backlog, and flags it all net-new on the next
+    // honest capture. Unobserved reads as ABSENT, never as clean (the same
+    // invariant `observableSpecs` enforces on the default path and the
+    // baseline producer).
+    const byName = new Map(all.map((s) => [s.name, s] as const));
+    const unknown = opts.checks.filter((n) => !byName.has(n));
+    if (unknown.length > 0) {
+      throw new FragmentCaptureError(
+        `unknown check(s): ${unknown.join(', ')} — not in this repo's resolved check set ` +
+          `(see \`vyuh-dxkit checks list\`)`,
       );
+    }
+    selected = opts.checks.map((n) => byName.get(n)!);
+    const unobservable = selected
+      .map((s) => ({ s, unmet: s.execution ? unmetRequirement(s.execution, env) : null }))
+      .filter((x) => x.unmet !== null);
+    if (unobservable.length > 0) {
+      throw new FragmentCaptureError(
+        `cannot capture in this environment: ` +
+          unobservable
+            .map((x) => `${x.s.name} — ${describeUnmetRequirement(x.unmet!, env.host)}`)
+            .join('; ') +
+          `. Run this capture where the check's declared requirement is met ` +
+          `(the generated capture-<host> refresh job).`,
+      );
+    }
+    // Same refusal for a declared-but-unresolvable linter (the F-9 stub):
+    // the check did not run, so a fragment owning it would merge as
+    // "comparable and clean" and erase its real backlog.
+    const unavailable = selected.filter((s) => s.unavailable);
+    if (unavailable.length > 0) {
+      throw new FragmentCaptureError(
+        `cannot capture: ` + unavailable.map((s) => `${s.name} — ${s.unavailable}`).join('; '),
+      );
+    }
+  } else {
+    // Default: observable HERE, not observable on the primary host — the
+    // placement plan's slice, derived from the same declarations. An
+    // unresolvable-linter stub is excluded the same way an env-unmet check
+    // is: this host did not observe it, so the fragment must not own it.
+    selected = observableSpecs(all, env).filter(
+      (s) =>
+        !s.unavailable &&
+        s.execution &&
+        unmetRequirement(s.execution, { host: 'linux', hasToolchain: () => true }) !== null,
+    );
+  }
 
   // Through the seam's ONE entry point, scoped to the selected checks — a
   // fragment's findings are byte-compatible with what a full capture on this
@@ -107,6 +157,10 @@ export function captureFragment(opts: CaptureFragmentOptions): BaselineFragment 
     recallInputs: recallInputsForSpecs(selected),
   };
 }
+
+/** Capture-side refusal (unknown / environment-unobservable check) with the
+ *  remedy in the message — callers surface it verbatim and exit non-zero. */
+export class FragmentCaptureError extends Error {}
 
 /** Refusal error with the remedy in the message — callers surface it verbatim. */
 export class FragmentMergeError extends Error {}

--- a/src/checks-cli.ts
+++ b/src/checks-cli.ts
@@ -110,6 +110,14 @@ function renderGroup(title: string, specs: readonly CustomCheckSpec[]): void {
   console.log(''); // slop-ok
   logger.info(title);
   for (const s of specs) {
+    if (s.unavailable) {
+      // A policy-enabled gate whose linter isn't resolvable here — declared,
+      // disclosed, never silent (VERIFY-40 F-9). The sentinel command is an
+      // implementation detail, not something a user should see or run.
+      logger.dim(`  ${s.name.padEnd(22)} unavailable`);
+      logger.dim(`    ↳ ${s.unavailable}`);
+      continue;
+    }
     const intent = s.blocking ? 'blocking' : 'warn-only';
     const shape = s.parse.mode === 'exit' ? 'binary' : 'located';
     logger.dim(`  ${s.name.padEnd(22)} ${intent} · ${shape}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2578,17 +2578,30 @@ export async function run(argv: string[]): Promise<void> {
         // host — the generated per-host capture job's command. Default scope
         // is exactly what the primary host cannot observe; --checks overrides.
         const targetPath = resolveRepoPath(positionals[2]);
-        const { captureFragment, writeFragment } = await import('./baseline/fragment');
+        const { captureFragment, writeFragment, FragmentCaptureError } =
+          await import('./baseline/fragment');
         const { loadPolicyFromCwd } = await import('./baseline/policy');
         const checks = (values.checks as string | undefined)
           ?.split(',')
           .map((s) => s.trim())
           .filter(Boolean);
-        const fragment = captureFragment({
-          cwd: targetPath,
-          policy: loadPolicyFromCwd(targetPath),
-          ...(checks ? { checks } : {}),
-        });
+        let fragment;
+        try {
+          fragment = captureFragment({
+            cwd: targetPath,
+            policy: loadPolicyFromCwd(targetPath),
+            ...(checks ? { checks } : {}),
+          });
+        } catch (err) {
+          // A refused capture (unknown check / this environment cannot
+          // observe it) must exit non-zero — a poisoned fragment that merges
+          // "clean" erases the check's real backlog (VERIFY-40 F-12).
+          if (err instanceof FragmentCaptureError) {
+            logger.fail(err.message);
+            process.exit(1);
+          }
+          throw err;
+        }
         const out = (values.out as string | undefined) ?? 'dxkit-baseline-fragment.json';
         writeFragment(out, fragment);
         logger.success(

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -9,7 +9,7 @@ import { hostOf, toolchainForBinary, toolchainInstallHint, type ToolchainId } fr
 import { dxkitCli } from './self-invocation';
 import * as logger from './logger';
 import { resolveBaselineMode } from './baseline/modes';
-import { anchorBranchStatus } from './baseline/anchor';
+import { anchorBranchStatus, anchorStalenessProblem } from './baseline/anchor';
 import { loadPolicyFromCwd } from './baseline/policy';
 import { detectEnforcement } from './enforcement';
 import { detectInstalledRefreshTransport, detectDefaultBranch } from './ship-installers';
@@ -544,6 +544,34 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
             },
           }),
     });
+    // 0b. Anchor CONTENT staleness (VERIFY-40 F-6). Presence is not enough:
+    // update's migration lanes rewrite the LOCAL baseline while the guardrail
+    // reads the ANCHOR — a migrated local over a pre-migration anchor keeps
+    // every check drifting while everything above reports green. Only the
+    // migration-shaped divergences alarm (scheme / recall-presence); ordinary
+    // content lag stays quiet.
+    if (anchorStatus.branchExists) {
+      const staleness = anchorStalenessProblem(
+        cwd,
+        path.join(cwd, '.dxkit', 'baselines', 'main.json'),
+        safeLoadPolicy(cwd)?.baseline,
+      );
+      checks.push({
+        label: `baseline anchor branch current (${anchorStatus.anchorRef})`,
+        ok: staleness === null,
+        tier: 'operational',
+        ...(staleness === null
+          ? {}
+          : {
+              fix: {
+                hint:
+                  `${staleness}. The guardrail hydrates its baseline from the anchor branch, ` +
+                  `so the local migration is inert until published.`,
+                command: dxkitCli('baseline publish'),
+              },
+            }),
+      });
+    }
   }
 
   // 1. Hooks active. Two independent conditions must BOTH hold for the

--- a/src/execution/toolchains.ts
+++ b/src/execution/toolchains.ts
@@ -148,6 +148,26 @@ export const TOOLCHAIN_DEFS = {
       windows: 'winget install Rustlang.Rustup',
       fallback: 'https://rustup.rs',
     },
+    // rustc alone is not enough: linking needs the platform C toolchain, and
+    // cargo refuses a crate graph pinned to a newer rustc. Both fail before
+    // any of the user's code is judged — environment, not findings
+    // (VERIFY-40 F-10: `linker cc not found` minted a lint finding AND
+    // failed the correctness floor on pristine code).
+    environmentFailurePatterns: [
+      {
+        id: 'rust-no-linker',
+        pattern: 'linker `[^`]+` not found',
+        problem: 'rustc cannot link: no platform C toolchain/linker on this host',
+        remedy:
+          'install the platform C toolchain (linux: `sudo apt-get install -y build-essential`; macos: `xcode-select --install`; windows: the Visual Studio Build Tools)',
+      },
+      {
+        id: 'rust-too-old',
+        pattern: 'requires rustc \\d|rustc [\\d.]+ is not supported',
+        problem: 'a dependency requires a newer rustc than installed',
+        remedy: 'upgrade the toolchain: `rustup update stable`',
+      },
+    ],
   },
   'dotnet-sdk': {
     id: 'dotnet-sdk',

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -10,7 +10,7 @@ import {
 } from '../analyzers/tools/nuget-package-reference';
 import { resolveCvssScores } from '../analyzers/tools/osv';
 import { parseOsvScannerFindings } from '../analyzers/tools/osv-scanner-deps';
-import { fileExists, run, runExitCode } from '../analyzers/tools/runner';
+import { fileExists, run, runExitCode, runWithExit } from '../analyzers/tools/runner';
 import { runTestsWithCoverage } from '../analyzers/tools/run-tests-helper';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
 import { walkPaths } from '../analyzers/tools/walk-paths';
@@ -605,11 +605,25 @@ async function gatherDirectPackageReferenceFallback(
   const adhocPath = path.join(adhocDir, 'packages.lock.json');
   try {
     fs.writeFileSync(adhocPath, buildNugetAdhocLockfile(entries));
-    const raw = run(
+    // Exit-aware (VERIFY-40 F-7): 0/1 = complete scan (clean / vulns found);
+    // anything else = the scan errored and its JSON may be PARTIAL — a
+    // degraded OSV response once wrote a 1-of-14 baseline here that
+    // false-blocked the next check 13 times. Partial is disclosed
+    // unavailable, never recorded as a complete observation.
+    const { code, stdout: raw } = runWithExit(
       `${scanner.path} scan source --lockfile=${adhocPath} --format json`,
       cwd,
       180000,
     );
+    if (code !== 0 && code !== 1) {
+      return {
+        kind: 'unavailable',
+        reason:
+          `${dotnetFailureReason}; osv-scanner exited ` +
+          `${code ?? 'without a code (timeout/spawn failure)'} on the D025f fallback — the ` +
+          `scan errored, so its output may be partial and was discarded`,
+      };
+    }
     if (!raw) {
       return {
         kind: 'unavailable',
@@ -697,7 +711,21 @@ async function gatherRealLockfilePath(
   }
 
   const lockfileFlags = lockfiles.map((f) => `--lockfile=${f}`).join(' ');
-  const raw = run(`${scanner.path} scan source ${lockfileFlags} --format json`, cwd, 180000);
+  // Exit-aware for the same reason as the D025f fallback (VERIFY-40 F-7).
+  const { code, stdout: raw } = runWithExit(
+    `${scanner.path} scan source ${lockfileFlags} --format json`,
+    cwd,
+    180000,
+  );
+  if (code !== 0 && code !== 1) {
+    return {
+      kind: 'unavailable',
+      reason:
+        `osv-scanner exited ${code ?? 'without a code (timeout/spawn failure)'} on ` +
+        `${lockfiles.length} packages.lock.json file(s) — the scan errored, so its output ` +
+        `may be partial and was discarded`,
+    };
+  }
   if (!raw) {
     return {
       kind: 'unavailable',

--- a/src/update.ts
+++ b/src/update.ts
@@ -9,6 +9,8 @@ import * as logger from './logger';
 import { detectStaleRecall, detectStaleScheme, migrateIdentity } from './baseline/migrate';
 import { createBaseline, gatherScanCoverage } from './baseline/create';
 import { missingScanners } from './baseline/coverage';
+import { loadPolicyFromCwd } from './baseline/policy';
+import { resolveAnchorTransport } from './baseline/modes';
 import { dxkitCli } from './self-invocation';
 
 /**
@@ -265,7 +267,7 @@ async function refreshRecallIfStale(cwd: string): Promise<void> {
     const result = await createBaseline({ cwd, force: true });
     if (result.path) {
       logger.success('Baseline re-captured on the current recall contract.');
-      logger.dim('  → Commit .dxkit/baselines to finish the refresh.');
+      logger.dim(baselineFinishingStep(cwd));
     }
   } catch (err) {
     logger.warn(
@@ -274,6 +276,36 @@ async function refreshRecallIfStale(cwd: string): Promise<void> {
         'affected kinds warn instead of blocking.',
     );
   }
+}
+
+/**
+ * The finishing step after the migration lanes rewrite the local baseline,
+ * phrased for the repo's anchor transport (VERIFY-40 F-6). On `branch`
+ * transport the guardrail hydrates the anchor from the side branch, so
+ * committing the local file changes NOTHING the gate reads — the migration is
+ * inert until `baseline publish` lands it. The transport comes from the SAME
+ * resolver the check uses (Rule 11), so the hint and the read cannot
+ * disagree.
+ */
+function baselineFinishingStep(cwd: string, alsoAllowlist = false): string {
+  try {
+    const transport = resolveAnchorTransport({
+      mode: 'committed-full', // both migration lanes only run over a committed baseline file
+      policyAnchor: loadPolicyFromCwd(cwd).baseline?.anchor,
+    });
+    if (transport === 'branch') {
+      return (
+        `  → Run \`${dxkitCli('baseline publish')}\` to land it on the anchor branch the ` +
+        `guardrail reads${alsoAllowlist ? ', and commit .dxkit/allowlist.json' : ''} — ` +
+        `committing the file alone does not update the anchor.`
+      );
+    }
+  } catch {
+    /* unreadable policy — fall through to the tree-transport hint */
+  }
+  return alsoAllowlist
+    ? '  → Commit .dxkit/baselines + .dxkit/allowlist.json to finish the migration.'
+    : '  → Commit .dxkit/baselines to finish the refresh.';
 }
 
 /**
@@ -313,7 +345,7 @@ async function migrateIdentityIfStale(cwd: string): Promise<void> {
         logger.dim(`  ${e.fingerprint}  ${e.kind}/${e.category}`);
       }
     }
-    logger.dim('  → Commit .dxkit/baselines + .dxkit/allowlist.json to finish the migration.');
+    logger.dim(baselineFinishingStep(cwd, true));
   } catch (err) {
     logger.warn(
       `Identity migration could not complete: ${(err as Error).message}. ` +

--- a/test/baseline/anchor-publish.test.ts
+++ b/test/baseline/anchor-publish.test.ts
@@ -9,6 +9,7 @@ import {
   publishFilesToAnchorRef,
   readFromAnchorRef,
 } from '../../src/baseline/anchor-publish';
+import { anchorStalenessFromContents } from '../../src/baseline/anchor';
 
 /**
  * Real-git tests for the shared anchor writer/reader. A local bare repo stands
@@ -371,5 +372,38 @@ describe('publishFilesToAnchorRef — the push always runs --no-verify (gh #156)
     const push = spy.pushCall();
     expect(push).toContain('--no-verify');
     expect(push).toContain('origin');
+  });
+});
+
+describe('anchorStalenessFromContents (VERIFY-40 F-6 — migrated local over stale anchor)', () => {
+  it('scheme divergence alarms with both schemes named', () => {
+    const problem = anchorStalenessFromContents(
+      { identityScheme: undefined, recall: undefined },
+      { identityScheme: 'v2', recall: {} },
+    );
+    expect(problem).toContain("'pre-v2'");
+    expect(problem).toContain("'v2'");
+  });
+
+  it('anchor without recall while local carries it alarms', () => {
+    const problem = anchorStalenessFromContents(
+      { identityScheme: 'v2' },
+      { identityScheme: 'v2', recall: { secret: { epoch: 1, inputs: {} } } },
+    );
+    expect(problem).toContain('predates recall attribution');
+  });
+
+  it('ordinary content lag stays quiet (same scheme, both have recall)', () => {
+    expect(
+      anchorStalenessFromContents(
+        { identityScheme: 'v2', recall: {} },
+        { identityScheme: 'v2', recall: {} },
+      ),
+    ).toBeNull();
+  });
+
+  it('an unreadable side never alarms (fail-open — the presence probe covers absence)', () => {
+    expect(anchorStalenessFromContents(null, { identityScheme: 'v2' })).toBeNull();
+    expect(anchorStalenessFromContents({ identityScheme: 'v2' }, null)).toBeNull();
   });
 });

--- a/test/baseline/fragment.test.ts
+++ b/test/baseline/fragment.test.ts
@@ -15,6 +15,7 @@ import {
   mergeFragment,
   readFragment,
   writeFragment,
+  FragmentCaptureError,
   FragmentMergeError,
   FRAGMENT_SCHEMA,
   type BaselineFragment,
@@ -104,6 +105,79 @@ describe('captureFragment', () => {
       );
       expect(fragment.identityScheme).toBe(CURRENT_IDENTITY_SCHEME);
       expect(fragment.customCheckEpoch).toBe(RECALL_EPOCHS['custom-check']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('REFUSES an explicit check this environment cannot observe (VERIFY-40 F-12)', () => {
+    // The poisoned-fragment lie: `--checks lint:csharp` on linux (the check
+    // needs windows, it never ran) must refuse — a fragment with findings:[]
+    // + recall inputs claims "comparable and clean", erases the check's real
+    // backlog on merge, and flags it all net-new on the next honest capture.
+    // Same failure mode when the generated capture job's toolchain setup
+    // fails transiently, so the refusal is load-bearing, not flag hygiene.
+    const dir = winformsRepo();
+    try {
+      expect(() =>
+        captureFragment({
+          cwd: dir,
+          policy: LINT_ON,
+          packs: [csharp],
+          env: envOf('linux'),
+          checks: ['lint:csharp'],
+        }),
+      ).toThrow(FragmentCaptureError);
+      try {
+        captureFragment({
+          cwd: dir,
+          policy: LINT_ON,
+          packs: [csharp],
+          env: envOf('linux'),
+          checks: ['lint:csharp'],
+        });
+      } catch (err) {
+        // The refusal names the check, the unmet requirement, and the remedy.
+        const msg = (err as Error).message;
+        expect(msg).toContain('lint:csharp');
+        expect(msg).toContain('windows');
+        expect(msg).toContain('capture-<host>');
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('REFUSES an unknown explicit check (a typo must not silently own nothing)', () => {
+    const dir = winformsRepo();
+    try {
+      expect(() =>
+        captureFragment({
+          cwd: dir,
+          policy: LINT_ON,
+          packs: [csharp],
+          env: envOf('windows'),
+          checks: ['lint:chsarp'],
+        }),
+      ).toThrow(FragmentCaptureError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('an explicit check that IS observable here still captures', () => {
+    const dir = winformsRepo();
+    try {
+      const fragment = captureFragment({
+        cwd: dir,
+        policy: LINT_ON,
+        packs: [csharp],
+        env: envOf('windows'),
+        checks: ['lint:csharp'],
+        exec: () => ({ available: true, code: 0, output: '' }),
+      });
+      expect(fragment.checks).toEqual(['lint:csharp']);
+      expect(fragment.recallInputs['lint:csharp/cmd']).toBeTruthy();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/custom-checks/config.test.ts
+++ b/test/custom-checks/config.test.ts
@@ -3,7 +3,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { normalizeCustomChecks } from '../../src/analyzers/custom-checks/config';
+import { lintGateSpecs, normalizeCustomChecks } from '../../src/analyzers/custom-checks/config';
+import { recallInputsForSpecs } from '../../src/analyzers/custom-checks/gather';
 import { resolvePolicy } from '../../src/baseline/policy';
 import type { CustomCheckConfig } from '../../src/baseline/policy';
 
@@ -119,5 +120,40 @@ describe('resolvePolicy — checks/lint passthrough', () => {
     const cwd = withPolicy({ mode: 'brownfield' });
     expect(resolvePolicy(undefined, cwd).largeFileThreshold).toBeUndefined();
     fs.rmSync(cwd, { recursive: true, force: true });
+  });
+});
+
+describe('lintGateSpecs — unresolvable linter becomes a disclosed stub (VERIFY-40 F-9)', () => {
+  const nullPack = {
+    id: 'ruby',
+    lintGate: {
+      execution: () => ({
+        hosts: ['any'],
+        toolchains: ['ruby'],
+        needsBuild: false,
+        buildTarget: 'none',
+        weight: 'cheap',
+      }),
+      lintCommand: () => null,
+      recallInputs: () => ({ rubocop: '9.9.9' }),
+    },
+  } as unknown as import('../../src/languages/types').LanguageSupport;
+
+  it('a policy-enabled gate whose lintCommand returns null still exists, marked unavailable', () => {
+    const specs = lintGateSpecs([nullPack], { cwd: '/repo', changedFiles: [] }, { enabled: true });
+    expect(specs).toHaveLength(1);
+    expect(specs[0].name).toBe('lint:ruby');
+    expect(specs[0].unavailable).toContain('tools install');
+    // The sentinel command must be unexecutable by construction.
+    expect(specs[0].command.bin).toBe('dxkit-lint-unavailable');
+  });
+
+  it('the stub contributes NO recall inputs (unobserved reads as absent)', () => {
+    const specs = lintGateSpecs([nullPack], { cwd: '/repo', changedFiles: [] }, { enabled: true });
+    expect(recallInputsForSpecs(specs)).toEqual({});
+  });
+
+  it('lint disabled still yields nothing (the stub only exists for an ENABLED gate)', () => {
+    expect(lintGateSpecs([nullPack], { cwd: '/repo', changedFiles: [] }, undefined)).toEqual([]);
   });
 });

--- a/test/custom-checks/run.test.ts
+++ b/test/custom-checks/run.test.ts
@@ -197,3 +197,45 @@ describe('parseLocated — dedupe + malformed regex', () => {
     expect(found[0].message).toMatch(/invalid parse regex/);
   });
 });
+
+describe('declared-but-unresolvable lint gate (VERIFY-40 F-9 — disclosed, never silent)', () => {
+  const stub = spec({
+    name: 'lint:ruby',
+    command: { bin: 'dxkit-lint-unavailable', args: [] },
+    unavailable: "the ruby pack's linter is not installed or resolvable in this environment",
+  });
+
+  it('the runner discloses skipped-unavailable with the reason, without spawning', () => {
+    let spawned = 0;
+    const counting: CommandExec = () => {
+      spawned++;
+      return { available: true, code: 0, output: '' };
+    };
+    const r = runCustomChecks({ cwd: CWD, specs: [stub], exec: counting });
+    expect(r.results[0].status).toBe('skipped-unavailable');
+    expect(r.results[0].reason).toContain('not installed');
+    expect(r.findings).toEqual([]);
+    expect(spawned).toBe(0);
+  });
+
+  it('an unmet environment supersedes the unavailable reason (wrong host first)', () => {
+    const winOnly = spec({
+      name: 'lint:csharp',
+      unavailable: 'linter missing',
+      execution: {
+        hosts: ['windows'],
+        toolchains: [],
+        needsBuild: false,
+        buildTarget: 'none',
+        weight: 'cheap',
+      },
+    });
+    const r = runCustomChecks({
+      cwd: CWD,
+      specs: [winOnly],
+      exec: pass,
+      env: { host: 'linux', hasToolchain: () => true },
+    });
+    expect(r.results[0].status).toBe('skipped-environment');
+  });
+});

--- a/test/execution/execution-platform.test.ts
+++ b/test/execution/execution-platform.test.ts
@@ -337,6 +337,27 @@ describe('classifyEnvironmentFailure (the F-14 post-failure tier)', () => {
     expect(classifyEnvironmentFailure(['dotnet-sdk'], '')).toBeNull();
   });
 
+  it('rust: a missing platform linker is environment, not a finding (VERIFY-40 F-10)', () => {
+    // The exact output cargo emitted on the axum eval repo: rustc present,
+    // no C toolchain — every build script fails before the user's code is
+    // judged. Pre-fix this minted a lint finding AND failed the floor.
+    const CC_MISSING = 'error: linker `cc` not found\n  = note: No such file or directory';
+    const hit = classifyEnvironmentFailure(['rust'], CC_MISSING);
+    expect(hit?.toolchain).toBe('rust');
+    expect(hit?.problem).toContain('linker');
+    expect(hit?.remedy).toContain('build-essential');
+    // windows spelling of the same boundary
+    expect(classifyEnvironmentFailure(['rust'], 'error: linker `link.exe` not found')).toBeTruthy();
+    // crate pinned to a newer rustc
+    expect(
+      classifyEnvironmentFailure(['rust'], 'package `foo v1.0.0` requires rustc 1.99 or newer'),
+    ).toBeTruthy();
+    // a real rust compile error is never reclassified
+    expect(
+      classifyEnvironmentFailure(['rust'], 'error[E0308]: mismatched types\n --> src/main.rs:3:5'),
+    ).toBeNull();
+  });
+
   it('missing-toolchain descriptions name the per-host install (root remedy)', () => {
     const line = describeUnmetRequirement(
       { kind: 'missing-toolchain', toolchains: ['dotnet-sdk'] },

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseJsonStream, runDetached } from '../src/analyzers/tools/runner';
+import { parseJsonStream, runDetached, runWithExit } from '../src/analyzers/tools/runner';
 
 describe('parseJsonStream', () => {
   it('parses concatenated single-line objects', () => {
@@ -121,5 +121,31 @@ describe('runDetached — process group lifecycle (10k.1.5c regression)', () => 
       { cwd: process.cwd(), timeoutMs: 5000 },
     );
     expect(outcome.stdout).toBe('$HOME and *');
+  });
+});
+
+describe('runWithExit (exit-aware run — the F-7 completeness disambiguator)', () => {
+  it('a clean exit returns code 0 with stdout', () => {
+    const r = runWithExit('node -e "process.stdout.write(String(7))"', process.cwd(), 10000);
+    expect(r).toEqual({ code: 0, stdout: '7' });
+  });
+
+  it('a non-zero exit surfaces BOTH the code and the partial stdout', () => {
+    // osv-scanner\'s hazard shape: JSON on stdout, then the process errors.
+    // run() returns that stdout indistinguishably from success; runWithExit
+    // lets the caller see the scan errored and refuse the partial output.
+    const r = runWithExit(
+      'node -e "process.stdout.write(\'partial\'); process.exit(3)"',
+      process.cwd(),
+      10000,
+    );
+    expect(r.code).toBe(3);
+    expect(r.stdout).toBe('partial');
+  });
+
+  it('a spawn failure yields code null and empty stdout', () => {
+    const r = runWithExit('definitely-not-a-binary-xyz', process.cwd(), 10000);
+    expect(r.code === null || r.code !== 0).toBe(true);
+    expect(r.stdout).toBe('');
   });
 });


### PR DESCRIPTION
## What & why

The 4.0.0-rc.1 tarball eval (`tmp/verify/VERIFY-40.md`, 11 real repos + the F-14 classifier probes) proved the platform end-to-end — dpl-studio's windows gate generates, boundaries disclose with remedies, migration lanes carry 2.9.1/3.7.x/3.8 installs, 18,417 lint parity holds, identity stable at 3,747 — and surfaced **1 HIGH + 4 MED defects, all in the honesty perimeter the platform itself defines**. This PR closes all five, each re-proven live on the repo that surfaced it.

## The five findings → fixes

| id | sev | defect | fix |
|---|---|---|---|
| F-12 | HIGH | `baseline fragment --checks X` on a host where X cannot run exits 0 and writes `findings: []` + full recall inputs — merging erases X's real backlog and stamps it "comparable and clean" (the #173 lie, re-opened in the new primitive; reachable in CI when the capture job's toolchain setup fails) | `captureFragment` REFUSES unknown / env-unobservable explicit checks (`FragmentCaptureError`, exit 1, unmet requirement + remedy named); default scope excludes unavailable stubs |
| F-10 | MED | axum with rustc but no C compiler: ``linker `cc` not found`` minted a lint FINDING and failed the floor — the F-14 class, un-closed for rust (no `environmentFailurePatterns`) | rust signatures added (missing linker, requires-newer-rustc); both runners now disclose the boundary + remedy |
| F-9 | MED | `lint.enabled: true` + linter tool missing = total silence (`lintCommand → null` deleted the spec before the 4.0 disclosure machinery could see it) | disclosed stub spec (`unavailable`): runner reports `skipped-unavailable` + tools-install remedy pre-spawn; `checks list` renders it; recall skips it; fragments refuse it; env boundary supersedes it |
| F-6 | MED | on branch anchor transport, update's migration re-captures only the LOCAL baseline; the gate reads the stale ANCHOR → every kind drifts, second update goes quiet, doctor says "branch present ✓" | migration lanes phrase the finishing step from the SAME transport resolver the check uses (`baseline publish` on branch); doctor gained "anchor branch current" (alarms only on migration-shaped divergence) |
| F-7 | MED | a network-degraded osv-scanner run emitted PARTIAL JSON and exited non-zero; `run()` returned it indistinguishably from success → a 1-of-14 baseline that false-blocked the next check 13× | exit-aware `runWithExit`; all three osv-scanner sites accept only exits 0/1 (complete scan), disclose anything else as `unavailable` |

## Live re-proof (post-fix, on the eval repos)

- dpl-studio: wrong-host fragment now `✗ cannot capture in this environment: lint:csharp — needs windows…`, exit 1, no file written
- axum: lint = `skipped-environment` + build-essential remedy; floor = "not measurable in this environment — CI is the backstop" (was `✗ 1 check(s) failed`)
- rails: `checks run` discloses the boundary (env supersedes the stub, as designed)
- gcs-web: both doctor anchor probes green on the healthy anchor (no false alarm)

## Gates

tsc · typecheck:test · eslint · prettier · arch-check · slop · cross-ecosystem · docs-coverage · `npm pack --dry-run` all green locally; full suite **4,381/4,381** (16 new pins). F-8 + F-11 (low) logged to ROADMAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
