### PR TITLE
fix(ci-templates): survive a peer-conflicted repo, and say why when the gate cannot run

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -285,9 +285,14 @@ jobs:
             echo "::error::fixture is no longer peer-conflicted — a bare 'npm ci' succeeded, so this step cannot catch the regression it exists for. Fix the fixture."
             exit 1
           fi
-          if ! npm ci 2>&1 | grep -q "code ERESOLVE"; then
+          # Capture first, then match. Under `set -o pipefail` a
+          # `npm ci | grep -q` pipeline returns npm's non-zero exit, not grep's,
+          # so the match result would be unreadable and this check would fire on
+          # a CORRECT fixture.
+          ci_out=$(npm ci 2>&1 || true)
+          if ! printf '%s' "$ci_out" | grep -q "code ERESOLVE"; then
             echo "::error::fixture fails for the WRONG reason (expected code ERESOLVE — a peer conflict). This guard would not prove the fix:"
-            npm ci 2>&1 | head -5
+            printf '%s\n' "$ci_out" | head -5
             exit 1
           fi
           echo "✓ fixture confirmed peer-conflicted (bare 'npm ci' fails with ERESOLVE)"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -237,6 +237,84 @@ jobs:
           fi
           echo "Guardrail passed on clean state as expected."
 
+      # 4.0.1 class-fix. Every shipped workflow template carried a bare `npm ci`,
+      # so a repo whose tree only resolves under --legacy-peer-deps died at the
+      # install step and the guardrail never ran — the check we ask customers to
+      # make REQUIRED was red on their first PR. Nothing caught it: no test
+      # EXECUTES a generated workflow, and the fixture above is a package.json with
+      # no dependencies at all, so `npm ci` there cannot fail. This runs the REAL
+      # rendered step against a REAL conflicting tree, in the order a real
+      # onboarding hits it (the repo's own install, then the dxkit devDep, then
+      # init) — that order matters, because it is what keeps package.json and the
+      # lockfile in sync. A desynced lockfile fails `npm ci` with EUSAGE for an
+      # unrelated reason and would make this guard test nothing.
+      - name: Generated workflow's install step survives a peer-conflicted tree
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/dxkit-peer
+          cd /tmp/dxkit-peer
+          git init -q -b main
+          git config user.email "smoke@example.com"
+          git config user.name "smoke"
+          # eslint 10 at the root against a config that peer-requires eslint 8:
+          # the real shape that broke. npm rejects this tree without
+          # --legacy-peer-deps, while the repo itself installs and ships fine.
+          cat > package.json <<'EOF'
+          {
+            "name": "dxkit-peer-conflict",
+            "version": "0.0.0",
+            "private": true,
+            "devDependencies": {
+              "eslint": "^10.0.0",
+              "@loopback/eslint-config": "^16.0.1"
+            }
+          }
+          EOF
+          mkdir -p src && echo 'export const x = 1;' > src/index.ts
+          npm install --legacy-peer-deps --silent
+          git add -A && git commit -q -m "init"
+          npm install --save-dev --legacy-peer-deps --silent \
+            "${{ steps.pack-sdk.outputs.tarball }}" "${{ steps.pack.outputs.tarball }}"
+          ./node_modules/.bin/vyuh-dxkit init --full --yes --no-finish
+
+          # The fixture must actually BE conflicted, or this guard rots into a
+          # vacuous pass. Assert the negative first, and assert the RIGHT negative:
+          # ERESOLVE (a peer conflict) and not EUSAGE (a desynced lockfile).
+          rm -rf node_modules
+          if npm ci >/dev/null 2>&1; then
+            echo "::error::fixture is no longer peer-conflicted — a bare 'npm ci' succeeded, so this step cannot catch the regression it exists for. Fix the fixture."
+            exit 1
+          fi
+          if ! npm ci 2>&1 | grep -q "code ERESOLVE"; then
+            echo "::error::fixture fails for the WRONG reason (expected code ERESOLVE — a peer conflict). This guard would not prove the fix:"
+            npm ci 2>&1 | head -5
+            exit 1
+          fi
+          echo "✓ fixture confirmed peer-conflicted (bare 'npm ci' fails with ERESOLVE)"
+
+          # Execute the install step exactly as the generated workflow ships it.
+          node -e "
+            const yaml = require('${{ github.workspace }}/node_modules/js-yaml');
+            const fs = require('fs');
+            const wf = yaml.load(fs.readFileSync('.github/workflows/dxkit-guardrails.yml', 'utf8'));
+            const steps = Object.values(wf.jobs)[0].steps;
+            const step = steps.find(s => s.name && s.name.startsWith('Install dependencies'));
+            if (!step) { console.error('no install step in the rendered workflow'); process.exit(1); }
+            fs.writeFileSync('/tmp/rendered-install-step.sh', step.run);
+          "
+          echo "==> running the rendered install step:"
+          cat /tmp/rendered-install-step.sh
+          rm -rf node_modules
+          if ! bash -e /tmp/rendered-install-step.sh; then
+            echo "::error::the generated dxkit-guardrails.yml install step FAILED on a peer-conflicted repo — this is the 4.0.0 defect (a bare npm ci). The guardrail would never run, and the required check would be red on the customer's first PR."
+            exit 1
+          fi
+          test -x node_modules/.bin/vyuh-dxkit || {
+            echo "::error::install step exited 0 but dxkit is not resolvable — the guardrail still could not run."
+            exit 1
+          }
+          echo "✓ generated workflow's install step survived a peer-conflicted tree"
+
   devcontainer-smoke:
     name: devcontainer build + post-create
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1] - 2026-07-17
+
+### Fixed
+
+- **The generated CI workflows no longer die on a peer-conflicted repo.** Every
+  shipped workflow template installed the project's node dependencies with a bare
+  `npm ci`. A repo whose tree only resolves under `--legacy-peer-deps` (a
+  pre-existing peer conflict its own install already tolerates) failed at the
+  install step, so the guardrail never ran and `dxkit-guardrails` — the check dxkit
+  asks you to make required — was red on the very first PR. All nine templates now
+  fall back: `npm ci || npm ci --legacy-peer-deps` (and the `npm install` pair when
+  there is no lockfile). `npm ci` installs the lockfile's tree either way and the
+  flag only skips the peer check that rejects it, so the audited tree is still the
+  tree the repo ships; a re-resolving fallback would fabricate a different tree and
+  is deliberately not used.
+
+- **A guardrail that could not run now says so.** The PR-comment step ran
+  `cat guardrail-report.md` unguarded under `if: always()`, so when an earlier step
+  failed the job surfaced `cat: guardrail-report.md: No such file or directory` —
+  burying the real cause several steps up. It now posts an explicit "did not run"
+  comment naming that the PR was not gated and that this is not a finding in the
+  change, and emits a `::error::` pointing at the failing step. Same discipline as
+  `GateFailure` (3.7.1): a gate that cannot run stays fail-open, it just always says
+  why.
+
+### Added
+
+- **A generated workflow is now executed against a peer-conflicted repo in CI**
+  (`smoke.yml`). The defect above shipped because nothing ever ran a generated
+  workflow — the existing smoke fixture is a `package.json` with no dependencies, so
+  its `npm ci` cannot fail, and dxkit's own repo has a clean tree. The new guard
+  builds a genuinely conflicted fixture, asserts it fails for the *right* reason
+  (`ERESOLVE`, not a desynced lockfile), then extracts and executes the rendered
+  install step. This is the generated-artifact analog of the fixture-repo analysis
+  harness (CLAUDE.md 2.30).
+
+- **Architecture rule: no bare `npm ci` / `npm install` in a shipped CI template.**
+  `scripts/check-architecture.sh` fails on one, naming the file and line. The
+  concept lived in three code paths and `.devcontainer/post-create.sh` had already
+  learned the fallback while the workflow templates had not — CLAUDE.md Rule 2.30,
+  caught by prose and never by a check.
+
 ## [4.0.0] - 2026-07-17
 
 The execution-environment platform (CLAUDE.md Rule 20). dxkit already modeled

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1829,6 +1829,40 @@ if [ -n "$RULE20_PREDICATE" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# Generated-workflow dependency-install rule (4.0.1 class-fix): a shipped CI
+# template installs the repo's node deps with a peer-conflict fallback, never a
+# bare `npm ci` / `npm install`.
+#
+# What this prevents:
+#   A repo whose tree only resolves under --legacy-peer-deps (a pre-existing peer
+#   conflict its own install already tolerates) dies at the generated workflow's
+#   install step, so the guardrail never runs and the check we ask customers to
+#   make REQUIRED is red on their very first PR. That shipped in 4.0.0: all nine
+#   workflow templates carried a bare `npm ci`, while .devcontainer/post-create.sh
+#   had ALREADY learned the fallback. One concept, three code paths, two of them
+#   wrong (CLAUDE.md Rule 2.30). Nothing caught it because no test executes a
+#   generated workflow, and the smoke fixture is a package.json with no deps.
+#
+# Canonical form:
+#   npm ci || npm ci --legacy-peer-deps            (lockfile present)
+#   npm install || npm install --legacy-peer-deps  (no lockfile)
+#   `npm ci` installs the LOCKFILE's tree either way and the flag only skips the
+#   peer check that rejects it, so the audited tree stays the tree the repo ships.
+#   Falling back to a RE-RESOLVING `npm install` is NOT valid here: it fabricates a
+#   different tree, and the dep audit then reports phantom vulns and misses real
+#   ones (the reason the install step uses the repo's own PM in the first place).
+TEMPLATE_BARE_NPM=$(grep -rn -E '^[[:space:]]*npm (ci|install)[[:space:]]*$' \
+  src-templates/.github/workflows/ 2>/dev/null \
+  | grep -v "# bare-npm-ok")
+if [ -n "$TEMPLATE_BARE_NPM" ]; then
+  echo "❌ Generated-workflow install violation: bare 'npm ci'/'npm install' in a shipped CI template:"
+  echo "$TEMPLATE_BARE_NPM"
+  echo "   → Use 'npm ci || npm ci --legacy-peer-deps' (or the npm install pair)."
+  echo "   → A peer-conflicted repo must not fail the gate at the install step."
+  echo "   → Annotate '# bare-npm-ok' for a justified exception."
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ $ERRORS -gt 0 ]; then
   echo ""
   echo "Architecture checks failed. See CLAUDE.md for rules."

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
@@ -58,9 +58,15 @@ __DXKIT_CI_RUNTIME_SETUP__
             npm install -g bun >/dev/null 2>&1 || true
             bun install --frozen-lockfile
           elif [ -f package-lock.json ]; then
-            npm ci
+            # A repo whose tree only resolves under --legacy-peer-deps (a peer
+            # conflict its own install already tolerates) must not fail the gate.
+            # `npm ci` installs the LOCKFILE's tree either way — the flag only
+            # skips the peer check that rejects it — so the audited tree is still
+            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+            # fallback here: it would fabricate a different tree.
+            npm ci || npm ci --legacy-peer-deps
           elif [ -f package.json ]; then
-            npm install
+            npm install || npm install --legacy-peer-deps
           else
             npm install -g @vyuhlabs/dxkit
           fi

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
@@ -53,9 +53,15 @@ __DXKIT_CI_RUNTIME_SETUP__
             npm install -g bun >/dev/null 2>&1 || true
             bun install --frozen-lockfile
           elif [ -f package-lock.json ]; then
-            npm ci
+            # A repo whose tree only resolves under --legacy-peer-deps (a peer
+            # conflict its own install already tolerates) must not fail the gate.
+            # `npm ci` installs the LOCKFILE's tree either way — the flag only
+            # skips the peer check that rejects it — so the audited tree is still
+            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+            # fallback here: it would fabricate a different tree.
+            npm ci || npm ci --legacy-peer-deps
           elif [ -f package.json ]; then
-            npm install
+            npm install || npm install --legacy-peer-deps
           else
             npm install -g @vyuhlabs/dxkit
           fi

--- a/src-templates/.github/workflows/dxkit-baseline-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh.yml
@@ -54,9 +54,15 @@ __DXKIT_CI_RUNTIME_SETUP__
             npm install -g bun >/dev/null 2>&1 || true
             bun install --frozen-lockfile
           elif [ -f package-lock.json ]; then
-            npm ci
+            # A repo whose tree only resolves under --legacy-peer-deps (a peer
+            # conflict its own install already tolerates) must not fail the gate.
+            # `npm ci` installs the LOCKFILE's tree either way — the flag only
+            # skips the peer check that rejects it — so the audited tree is still
+            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+            # fallback here: it would fabricate a different tree.
+            npm ci || npm ci --legacy-peer-deps
           elif [ -f package.json ]; then
-            npm install
+            npm install || npm install --legacy-peer-deps
           else
             npm install -g @vyuhlabs/dxkit
           fi

--- a/src-templates/.github/workflows/dxkit-deep-sast-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-deep-sast-refresh.yml
@@ -60,9 +60,12 @@ jobs:
       - name: Install dxkit
         run: |
           if [ -f package-lock.json ]; then
-            npm ci
+            # A peer-conflicted tree (one that only installs under
+            # --legacy-peer-deps) must not fail the refresh. `npm ci` installs the
+            # LOCKFILE's tree either way; the flag only skips the peer check.
+            npm ci || npm ci --legacy-peer-deps
           elif [ -f package.json ]; then
-            npm install
+            npm install || npm install --legacy-peer-deps
           else
             npm install -g @vyuhlabs/dxkit
           fi

--- a/src-templates/.github/workflows/dxkit-extensions-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-extensions-refresh.yml
@@ -55,9 +55,15 @@ __DXKIT_CI_RUNTIME_SETUP__
             npm install -g bun >/dev/null 2>&1 || true
             bun install --frozen-lockfile
           elif [ -f package-lock.json ]; then
-            npm ci
+            # A repo whose tree only resolves under --legacy-peer-deps (a peer
+            # conflict its own install already tolerates) must not fail the gate.
+            # `npm ci` installs the LOCKFILE's tree either way — the flag only
+            # skips the peer check that rejects it — so the audited tree is still
+            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+            # fallback here: it would fabricate a different tree.
+            npm ci || npm ci --legacy-peer-deps
           elif [ -f package.json ]; then
-            npm install
+            npm install || npm install --legacy-peer-deps
           else
             npm install -g @vyuhlabs/dxkit
           fi

--- a/src-templates/.github/workflows/dxkit-flow-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-flow-refresh.yml
@@ -58,9 +58,15 @@ __DXKIT_CI_RUNTIME_SETUP__
             npm install -g bun >/dev/null 2>&1 || true
             bun install --frozen-lockfile
           elif [ -f package-lock.json ]; then
-            npm ci
+            # A repo whose tree only resolves under --legacy-peer-deps (a peer
+            # conflict its own install already tolerates) must not fail the gate.
+            # `npm ci` installs the LOCKFILE's tree either way — the flag only
+            # skips the peer check that rejects it — so the audited tree is still
+            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+            # fallback here: it would fabricate a different tree.
+            npm ci || npm ci --legacy-peer-deps
           elif [ -f package.json ]; then
-            npm install
+            npm install || npm install --legacy-peer-deps
           else
             npm install -g @vyuhlabs/dxkit
           fi

--- a/src-templates/.github/workflows/dxkit-graph-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-graph-refresh.yml
@@ -51,9 +51,15 @@ __DXKIT_CI_RUNTIME_SETUP__
             npm install -g bun >/dev/null 2>&1 || true
             bun install --frozen-lockfile
           elif [ -f package-lock.json ]; then
-            npm ci
+            # A repo whose tree only resolves under --legacy-peer-deps (a peer
+            # conflict its own install already tolerates) must not fail the gate.
+            # `npm ci` installs the LOCKFILE's tree either way — the flag only
+            # skips the peer check that rejects it — so the audited tree is still
+            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+            # fallback here: it would fabricate a different tree.
+            npm ci || npm ci --legacy-peer-deps
           elif [ -f package.json ]; then
-            npm install
+            npm install || npm install --legacy-peer-deps
           else
             npm install -g @vyuhlabs/dxkit
           fi

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -61,9 +61,15 @@ __DXKIT_CI_RUNTIME_SETUP__
             npm install -g bun >/dev/null 2>&1 || true
             bun install --frozen-lockfile
           elif [ -f package-lock.json ]; then
-            npm ci
+            # A repo whose tree only resolves under --legacy-peer-deps (a peer
+            # conflict its own install already tolerates) must not fail the gate.
+            # `npm ci` installs the LOCKFILE's tree either way — the flag only
+            # skips the peer check that rejects it — so the audited tree is still
+            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+            # fallback here: it would fabricate a different tree.
+            npm ci || npm ci --legacy-peer-deps
           elif [ -f package.json ]; then
-            npm install
+            npm install || npm install --legacy-peer-deps
           else
             npm install -g @vyuhlabs/dxkit
           fi
@@ -230,10 +236,26 @@ __DXKIT_CI_RUNTIME_SETUP__
           # Find a previous dxkit-guardrails comment by marker so we
           # update in place rather than appending a new one per push.
           MARKER='<!-- dxkit-guardrails -->'
-          {
-            printf '%s\n' "$MARKER"
-            cat guardrail-report.md
-          } > comment.md
+          # The report exists only if the guardrail actually RAN. When an earlier
+          # step fails (dependency install, toolchain setup), this step still runs
+          # under `if: always()`, and a bare `cat` would turn that into a
+          # `No such file` error that buries the real cause several steps up. A gate
+          # that could not run says so, and names where to look.
+          if [ ! -f guardrail-report.md ]; then
+            {
+              printf '%s\n' "$MARKER"
+              printf '### dxkit guardrails: did not run\n\n'
+              printf 'A step before the guardrail failed, so this PR was **not** gated.\n'
+              printf 'This is not a finding in your change.\n\n'
+              printf 'See the failing step in this job log.\n'
+            } > comment.md
+            echo "::error::dxkit guardrail did not run: an earlier step failed, so this PR was NOT gated. See the failing step in this job."
+          else
+            {
+              printf '%s\n' "$MARKER"
+              cat guardrail-report.md
+            } > comment.md
+          fi
           # Link the flow console artifact + a short reviewer checklist when this
           # PR touched an integration. Both self-skip on a PR with no UI→API
           # surface, so a non-integration change adds nothing.

--- a/src-templates/.github/workflows/dxkit-reports-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-reports-refresh.yml
@@ -52,9 +52,15 @@ __DXKIT_CI_RUNTIME_SETUP__
             npm install -g bun >/dev/null 2>&1 || true
             bun install --frozen-lockfile
           elif [ -f package-lock.json ]; then
-            npm ci
+            # A repo whose tree only resolves under --legacy-peer-deps (a peer
+            # conflict its own install already tolerates) must not fail the gate.
+            # `npm ci` installs the LOCKFILE's tree either way — the flag only
+            # skips the peer check that rejects it — so the audited tree is still
+            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+            # fallback here: it would fabricate a different tree.
+            npm ci || npm ci --legacy-peer-deps
           elif [ -f package.json ]; then
-            npm install
+            npm install || npm install --legacy-peer-deps
           else
             npm install -g @vyuhlabs/dxkit
           fi


### PR DESCRIPTION
## What broke

A real onboarding installed dxkit 4.0.0 cleanly and then its first PR went red on `dxkit-guardrails` in 32s.

Every shipped workflow template installs the project's node deps with a bare `npm ci`. The repo has a pre-existing peer conflict (root `eslint@^10` vs `@loopback/eslint-config` peer-requiring `eslint@^8.57.1`) that its own install tolerates with `--legacy-peer-deps`. Under `bash -e`, `npm ci` exits 1 with `code ERESOLVE`, the guardrail step is skipped, and the check we ask customers to make **required** is red on their very first PR.

It was also undiagnosable. The PR-comment step runs under `if: always()` and did a bare `cat guardrail-report.md`, so the surfaced error was `cat: guardrail-report.md: No such file or directory` — pointing nowhere near the npm failure two steps up.

## The fix

`npm ci || npm ci --legacy-peer-deps` across all nine templates (plus the `npm install` pair when there's no lockfile).

The flag is safe for audit fidelity here, which is why this and not the devcontainer's ladder: `npm ci` installs the **lockfile's** tree either way and `--legacy-peer-deps` only skips the peer *check* that rejects it. A re-resolving fallback (`npm ci || npm install`) would fabricate a different tree — exactly what the step's own comment says it exists to avoid — so it's deliberately not used.

A gate that can't run now says so: an explicit "did not run" PR comment stating the PR was **not** gated and that this is not a finding in the change, plus an `::error::` naming the failing step. Same discipline as `GateFailure` (3.7.1).

## Why nothing caught it

**Rule 2.30, again.** Three code paths for one concept, and `.devcontainer/post-create.sh` had *already* learned the fallback while the templates hadn't.

**And no test has ever executed a generated workflow.** Nine test files reference `dxkit-guardrails`; every one asserts the file is written / refreshed / removed / correctly substituted. `smoke.yml` renders it then calls the CLI directly. Our own repo deliberately runs a hand-written self-guardrail. The smoke fixture is a `package.json` with no dependencies, so its `npm ci` *cannot* fail. Three independent blind spots.

## The nets

1. **`check-architecture.sh`** fails on a bare `npm ci`/`npm install` in a shipped template, naming file and line. Verified to bite both directions (regressed a template → exit 1 with the exact line; restored → exit 0).
2. **`smoke.yml` executes the rendered install step** against a genuinely conflicted fixture, and asserts the fixture fails for the *right* reason (`ERESOLVE`, not a desynced lockfile) so it can't rot into a vacuous pass. The generated-artifact analog of the fixture-repo analysis harness.

## Verification

End-to-end against the customer's exact shape, locally:

- fixture reproduces: bare `npm ci` → exit 1, `code ERESOLVE`
- rendered step from the fixed template → **exit 0**, deps installed, dxkit resolvable
- an earlier draft of the *test* failed for the wrong reason (`EUSAGE`, desynced lockfile) and was rewritten to mirror the real onboarding order — that's now asserted explicitly

All gates green locally: typecheck, typecheck:test, lint, format:check, architecture, cross-ecosystem, docs-coverage, slop, `npm pack --dry-run`, and **4381/4381** tests.

## Rollout

Ships as 4.0.1. The onboarding script needs no code change (its own `--legacy-peer-deps` fallback worked); its version default moves to 4.0.1. The customer's existing PR is superseded rather than adopted — see the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)