### PR TITLE
fix(baseline): defer classes a capture environment can't observe (v4.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.2] - 2026-07-17
+
+### Fixed
+
+- **A baseline captured where a scanner couldn't run is no longer committed as if
+  it were whole.** When the machine running `init` / `baseline create` can't
+  observe a finding class — a package index too stale to install a pinned scanner
+  (a corporate mirror / offline proxy), or a host/toolchain not present here — that
+  class is now recorded as **deferred**, not fail-open-committed as measured.
+  Previously a partial capture was promoted to authoritative (`--yes` /
+  `--allow-incomplete` waved it through); on the first CI run, where the full
+  pinned toolchain does install, the recall mechanism then saw a toolchain mismatch
+  and demoted every affected security kind to warn-only — the gate read green while
+  enforcing nothing. Now the guardrail surfaces an honest arming banner ("baseline
+  COMPLETING ON CI — N classes not yet gating") instead of a silent pass, and the
+  existing baseline-refresh workflow completes the baseline on CI with the
+  guaranteed toolchain, clearing the state automatically. Completes CLAUDE.md
+  Rule 20 (execution environment) for the moment dxkit captures the baseline: the
+  new `assessCaptureDeferral` asks the one predicate "can this environment observe
+  the class?" before the baseline claims it did. The arming banner never changes
+  the exit code — deferred classes warn, they are never false-blocked.
+
+- **A stale-index install failure reads as one sentence, not a wall of pip errors.**
+  When a pinned Python scanner won't install because the package index can't reach
+  that version, dxkit now parses pip's `No matching distribution` / `from versions:`
+  output and says so plainly ("`semgrep 1.165.0` isn't in your package index —
+  newest it offers `1.99.0` — likely a mirror; dxkit captures this class on CI
+  instead"), rather than surfacing the raw error that reads as "the product is
+  broken". A non-pip failure keeps its raw text.
+
 ## [4.0.1] - 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead"), rather than surfacing the raw error that reads as "the product is
   broken". A non-pip failure keeps its raw text.
 
+- **A blocked anchor/report push no longer reddens the refresh job or vanishes
+  silently.** The two side-ref publishers had diverged: `baseline publish` exited
+  1 (turning the post-merge refresh red on a governed-org default branch for a
+  condition dxkit can't fix), while `report snapshot` emitted a buried warning and
+  exited 0 (so a ruleset that blocked the push produced no `dxkit-reports` ref with
+  no visible signal). Both now go through one announcer that FAILS OPEN — the
+  refresh job stays green, because the guardrail falls back to a live re-gather
+  when the anchor is absent — but is LOUD: a warning plus a GitHub Actions
+  `::warning::` annotation. When the cause is a repository/org ruleset (a `GH013`
+  rejection), the message names the exact remedy: exclude `refs/heads/dxkit-**`
+  from that ruleset, or add a bypass for the CI actor.
+
 ## [4.0.1] - 2026-07-17
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/analyzers/tools/install-diagnosis.ts
+++ b/src/analyzers/tools/install-diagnosis.ts
@@ -1,0 +1,84 @@
+/**
+ * Legibility for a failed tool install (CLAUDE.md Rule 20, problem C).
+ *
+ * When a pinned Python scanner won't install because the operator's package
+ * index is stale (a corporate PyPI mirror months behind, an offline proxy), pip
+ * emits a wall of "ERROR: Could not find a version that satisfies the
+ * requirement …" / "No matching distribution found …" text. Read raw, that
+ * looks like "the product is broken" — when the actual condition is "your index
+ * can't reach this version, so dxkit will capture this class on CI instead."
+ *
+ * This module turns pip's own output into ONE sentence that names the root
+ * cause and the remedy dxkit is already taking (defer to CI — the deferral
+ * partition records the class). It is a pure classifier over captured stderr; it
+ * returns null on anything that is not the stale-mirror signature, so a genuine
+ * failure is never masked. Biased toward a false NEGATIVE (say nothing) over a
+ * false POSITIVE (claim "behind a mirror" when the failure was something else).
+ */
+
+/** A recognized stale-mirror install failure. */
+export interface StaleIndexDiagnosis {
+  /** The package pip could not satisfy (e.g. `semgrep`). */
+  readonly pkg: string;
+  /** The pinned version requested, when the requirement carried one. */
+  readonly wanted?: string;
+  /** Newest version the index DID offer, parsed from pip's "from versions:"
+   *  list — present ⇒ the package exists but the pin is unreachable (a mirror);
+   *  absent / "none" ⇒ genuinely not in the index. */
+  readonly newestAvailable?: string;
+  /** The one legible sentence, ready to show in place of the raw wall. */
+  readonly message: string;
+}
+
+// pip prints, e.g.:
+//   ERROR: Could not find a version that satisfies the requirement semgrep==1.165.0
+//     (from versions: 1.96.0, 1.97.0, 1.99.0)
+//   ERROR: No matching distribution found for semgrep==1.165.0
+const NO_MATCH = /No matching distribution found for\s+([A-Za-z0-9._-]+)(?:==([0-9][^\s)]*))?/;
+const FROM_VERSIONS = /from versions:\s*([^)]*)/i;
+
+/**
+ * Classify a failed install's captured output. Returns the diagnosis when the
+ * output is pip's unsatisfiable-requirement signature, else null.
+ */
+export function diagnoseStaleIndex(output: string): StaleIndexDiagnosis | null {
+  if (!output) return null;
+  const m = NO_MATCH.exec(output);
+  if (!m) return null;
+  const pkg = m[1];
+  const wanted = m[2];
+
+  let newestAvailable: string | undefined;
+  const fv = FROM_VERSIONS.exec(output);
+  if (fv) {
+    const raw = fv[1].trim();
+    if (raw && raw.toLowerCase() !== 'none') {
+      // pip lists oldest→newest; the last entry is the newest the index offers.
+      const versions = raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      newestAvailable = versions[versions.length - 1];
+    }
+  }
+
+  const want = wanted ? `${pkg} ${wanted}` : pkg;
+  let message: string;
+  if (newestAvailable) {
+    message =
+      `${want} isn't in your package index (newest it offers: ${newestAvailable}) — you're ` +
+      `likely behind a mirror or an offline proxy. dxkit captures this class on CI instead, ` +
+      `where the toolchain is guaranteed. No action needed.`;
+  } else {
+    message =
+      `${want} isn't available from your package index — likely a mirror or offline proxy that ` +
+      `can't reach it. dxkit captures this class on CI instead, where the toolchain is ` +
+      `guaranteed. No action needed.`;
+  }
+  return {
+    pkg,
+    ...(wanted ? { wanted } : {}),
+    ...(newestAvailable ? { newestAvailable } : {}),
+    message,
+  };
+}

--- a/src/analyzers/tools/install-exec.ts
+++ b/src/analyzers/tools/install-exec.ts
@@ -18,6 +18,7 @@ import { detect } from '../../detect';
 import { DetectedStack, type Manifest } from '../../types';
 import { serializePreservingJson } from '../../files';
 import { detectPackageManager, pmAwareDevInstall } from '../../package-manager';
+import { diagnoseStaleIndex } from './install-diagnosis';
 import {
   TOOL_DEFS,
   findTool,
@@ -184,7 +185,14 @@ export function execInstall(
   if (resolved.kind === 'builtin') return { status: 'skipped', detail: 'builtin' };
   const def = TOOL_DEFS[resolved.name]!;
   const result = runInstallCmd(resolved.command!, getInstallEnv(targetPath), opts.quiet);
-  if (!result.success) return { status: 'failed', detail: result.message };
+  if (!result.success) {
+    // Problem C (Rule 20): a stale-mirror failure surfaces as pip's
+    // unsatisfiable-requirement wall. Replace it with one legible sentence
+    // naming the root cause + the remedy dxkit already takes (defer to CI).
+    // Only when the signature matches — a genuine failure keeps its raw text.
+    const stale = diagnoseStaleIndex(result.message);
+    return { status: 'failed', detail: stale ? stale.message : result.message };
+  }
   // An install command can legitimately exit 0 without producing the binary —
   // e.g. the vitest-coverage guard no-ops when vitest isn't a target dep. Treat
   // "exit 0 + tool still missing" as a skip, not a failure.

--- a/src/baseline/anchor-publish.ts
+++ b/src/baseline/anchor-publish.ts
@@ -29,6 +29,7 @@ import { execFileSync } from 'child_process';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import * as path from 'path';
+import * as logger from '../logger';
 import { internalGitPushArgs } from '../git-internal-push';
 
 export interface AnchorFile {
@@ -98,10 +99,49 @@ export function describePushFailure(err: Error, timeoutMs: number): string {
       `timeout points at a stuck network/transport or an unreachable remote rather than auth.`
     );
   }
+  if (
+    /GH013|rule violations|push declined|creations? (is|are|being) restricted|cannot create ref due to|protected branch/i.test(
+      err.message,
+    )
+  ) {
+    // A repository/organization RULESET blocks writing the side ref (restrict
+    // creations / block non-fast-forward). This is an environment fact, not a
+    // dxkit fault or a developer mistake — name the exact remedy. The dxkit-**
+    // side refs are internal anchors, not code branches, so the fix is to exempt
+    // them, never to weaken the rule for real branches.
+    return (
+      `push blocked by a repository/org ruleset — the remote restricts writing this side ref ` +
+      `(branch creation / non-fast-forward). Exclude 'refs/heads/dxkit-**' from that ruleset ` +
+      `(Settings → Rules, at the repo or org), or add a bypass for the CI actor. Gating is ` +
+      `unaffected: the guardrail falls back to a live re-gather when the anchor is absent.`
+    );
+  }
   if (/denied|forbidden|403|not authorized|authentication failed/i.test(err.message)) {
     return `push denied by the remote (authentication/permission): ${err.message}`;
   }
   return `push rejected: ${err.message}`;
+}
+
+/**
+ * The ONE way both side-ref publishers (`baseline publish` and `report
+ * snapshot`) announce a push that did NOT land — Rule 2 applied to the publish
+ * outcome, because the two handlers had diverged: baseline `fail`ed + exited 1
+ * (reddening the refresh job on an infra push-rejection — the exact false-red
+ * that read as "dxkit is broken" on a governed-org main), while reports emitted
+ * a buried `warn` and exited 0 (so a ruleset silently produced no reports ref).
+ *
+ * A rejected side-ref push is INFRASTRUCTURE (a ruleset, a permission, a stale
+ * network), never a code defect or a developer mistake, and the guardrail falls
+ * back to a live re-gather when the anchor is absent — so publishing FAILS OPEN:
+ * the refresh job stays green. But it is LOUD, never silent (the fail-open gate
+ * discipline — CLAUDE.md Rule 19/§3.7.1): a human `warn` plus a GitHub Actions
+ * `::warning::` annotation that surfaces in the run + PR-checks summary, carrying
+ * the reason and its remedy. Callers announce, then exit 0.
+ */
+export function announceAnchorNotPushed(anchorRef: string, reason: string | undefined): void {
+  const why = reason ?? 'unknown';
+  logger.warn(`Anchor '${anchorRef}' not published: ${why}`);
+  logger.ciAnnotate('warning', `dxkit could not publish the '${anchorRef}' side ref: ${why}`);
 }
 
 /**

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -69,6 +69,25 @@ export interface BaselineAnalysisMeta {
 }
 
 /**
+ * A finding class the capture environment could NOT observe, deferred to one
+ * that can (CI, with the guaranteed pinned toolchain). Recorded so a guardrail
+ * check on the capture window can be honest — "this class is completing on CI,
+ * not yet gating" — instead of reading an unobserved class as measured-and-clean
+ * (the incident: a partial baseline that drifted every class to warn-only).
+ * Populated by `assessCaptureDeferral`; consumed by the gate's arming banner.
+ * Absent / empty ⇒ the baseline is authoritative for every class.
+ */
+export interface DeferredCaptureClass {
+  /** Scanner tool name, or `<pack>:<capability>` — stable + machine-independent. */
+  readonly id: string;
+  /** Human label for the arming banner. */
+  readonly label: string;
+  /** Why the capture environment could not observe it. */
+  readonly reason: string;
+  readonly cause: 'scanner-missing' | 'unmet-requirement';
+}
+
+/**
  * The full on-disk envelope. Fields are ordered to match the order
  * the matcher reads them in: identity-related fields first, then
  * envelope metadata. Serialized via `JSON.stringify(file, null, 2)`
@@ -124,6 +143,15 @@ export interface BaselineFile {
    *  baselines written before this field existed omit it and are treated
    *  as the original `'v1'` scheme. */
   readonly identityScheme?: IdentitySchemeVersion;
+  /** Finding classes this capture environment could NOT observe, deferred to
+   *  one that can (CLAUDE.md Rule 20 applied to capture). Non-empty ⇒ the
+   *  baseline is INCOMPLETE by construction, honestly recorded rather than
+   *  fail-open-committed as if whole — a `--yes` capture on a machine with an
+   *  incomplete toolchain lands the deferred classes here, and the gate's
+   *  arming banner reads them instead of certifying a class that never ran.
+   *  Cleared once a complete environment (CI) re-captures the whole baseline.
+   *  Optional: a baseline captured somewhere that observed everything omits it. */
+  readonly deferred?: ReadonlyArray<DeferredCaptureClass>;
   /** Per-finding entries. Multiset — duplicates allowed (an
    *  identity appearing twice means two distinct occurrences). */
   readonly findings: ReadonlyArray<BaselineEntry>;

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -197,6 +197,30 @@ export function depVulnsUnmeasuredRemediation(reason: string): string {
   return 'The scanner is present but did not produce a result — investigate the reason above rather than reinstalling.';
 }
 
+/**
+ * The arming banner for a committed baseline captured with classes DEFERRED
+ * (CLAUDE.md Rule 20 — a stale mirror couldn't install a scanner, or a
+ * wrong-host build gate). One phrasing, shared by every renderer, so the
+ * boundary is stated once. The point: never certify a class that was never
+ * observed. Returns the note lines (no leading blank) or `[]` when nothing was
+ * deferred. `armed` is the count of classes NOT yet gating.
+ */
+export function deferredCaptureBannerLines(result: GuardrailCheckResult): string[] {
+  const deferred = result.deferredCapture ?? [];
+  if (deferred.length === 0) return [];
+  const labels = deferred.map((d) => d.label).join(', ');
+  return [
+    `Baseline COMPLETING ON CI — ${deferred.length} class${deferred.length === 1 ? '' : 'es'} ` +
+      `not yet gating (${labels}).`,
+    `These could not be captured in the environment that ran this baseline ` +
+      `(a scanner your package index couldn't reach, or a host/toolchain not present here). ` +
+      `CI captures them with the guaranteed pinned toolchain and refreshes the baseline anchor; ` +
+      `the gate is fully armed once that lands. A pass here does NOT yet verify these classes. ` +
+      `If this repo has no CI to complete on, capture them in the generated devcontainer ` +
+      `(a guaranteed-complete environment).`,
+  ];
+}
+
 export function renderConsole(result: GuardrailCheckResult): string {
   const lines: string[] = [];
 
@@ -366,6 +390,10 @@ export function renderConsole(result: GuardrailCheckResult): string {
         `artifacts (node_modules / coverage) absent at a bare git ref. Use ` +
         `committed-full mode to gate them.`,
     );
+  }
+  for (const line of deferredCaptureBannerLines(result)) {
+    lines.push('');
+    lines.push(`  ⚠ ${line}`);
   }
   if (result.blocks) {
     lines.push('');
@@ -895,6 +923,15 @@ export interface GuardrailJsonPayload {
   /** Present when the dependency-vuln scan was requested but could not run —
    *  a pass is then NOT a clean bill of dependency health. */
   readonly depVulnsUnmeasured?: { readonly reason: string };
+  /** Present when the committed baseline was captured with classes deferred to
+   *  CI (CLAUDE.md Rule 20). A pass does NOT yet verify these classes — they are
+   *  completing on CI. Absent on a complete capture and in ref-based mode. */
+  readonly deferredCapture?: ReadonlyArray<{
+    readonly id: string;
+    readonly label: string;
+    readonly reason: string;
+    readonly cause: 'scanner-missing' | 'unmet-requirement';
+  }>;
   readonly baseline: {
     /** Absent when the run used `ref-based` mode (no on-disk
      *  baseline file). */
@@ -1091,6 +1128,9 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
     },
     attributionGaps: result.attributionGaps,
     ...(result.depVulnsUnmeasured ? { depVulnsUnmeasured: result.depVulnsUnmeasured } : {}),
+    ...(result.deferredCapture && result.deferredCapture.length > 0
+      ? { deferredCapture: result.deferredCapture }
+      : {}),
     baseline: {
       ...(result.baselinePath !== undefined ? { path: result.baselinePath } : {}),
       name: result.baseline.name,
@@ -1334,6 +1374,14 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
         `Switch \`.dxkit/policy.json\` to \`committed-full\` to gate them.`,
     );
     lines.push('');
+  }
+
+  {
+    const banner = deferredCaptureBannerLines(result);
+    if (banner.length > 0) {
+      lines.push(`> ⚠️ **${banner[0]}** ${banner.slice(1).join(' ')}`);
+      lines.push('');
+    }
   }
 
   if (blocking.length > 0) {

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -51,7 +51,7 @@ import { isMaliciousAdvisory } from '../analyzers/security/malicious';
 import { gatherCurrentScan, scanToBaselineFile } from './create';
 import type { CurrentScan } from './create';
 import { DEFAULT_BASELINE_NAME, pathForBaseline, readBaselineFile } from './baseline-file';
-import type { BaselineFile } from './baseline-file';
+import type { BaselineFile, DeferredCaptureClass } from './baseline-file';
 import { diffCoverage } from './coverage';
 import type { CoverageDrift } from './coverage';
 import { entriesToLocated } from './entry-to-located';
@@ -323,6 +323,19 @@ export interface GuardrailCheckResult {
     readonly kind: BaselineEntry['kind'];
     readonly currentCount: number;
   }>;
+  /** Finding classes the committed baseline's capture environment could not
+   *  observe (CLAUDE.md Rule 20 applied to capture) — read from
+   *  `baseline.deferred`. Non-empty ⇒ the baseline is INCOMPLETE by
+   *  construction (a stale mirror couldn't install a scanner, a wrong-host
+   *  build gate), so the renderers surface an arming banner ("completing on CI
+   *  — not yet gating") rather than certifying a class that never ran. Does NOT
+   *  change the exit code: the deferred classes are demoted to warn by the
+   *  recall mechanism (Rule 19 — absent/divergent recall), never false-blocked;
+   *  this field only makes the incompleteness LOUD instead of silently green
+   *  (the incident: a partial baseline that read as fully gated). Empty/absent
+   *  in ref-based mode (no committed baseline to complete) and on a complete
+   *  capture. */
+  readonly deferredCapture?: ReadonlyArray<DeferredCaptureClass>;
   /** The flow integration-gate pass — an additive, fail-open layer that flags
    *  net-new UI→API breakage from a base↔HEAD contract diff. Runs in BOTH
    *  modes (the base commit is the resolved ref in ref-based mode, the
@@ -899,6 +912,12 @@ export async function runGuardrailCheck(
     attributionGaps,
     allowlistDelta,
     refExcludedKinds,
+    // Capture-deferral (Rule 20): classes the committed baseline could not
+    // observe at capture. Committed modes only — ref-based has no committed
+    // baseline to complete, so the "completing on CI" framing does not apply.
+    ...(mode.mode !== 'ref-based' && baseline.deferred && baseline.deferred.length > 0
+      ? { deferredCapture: baseline.deferred }
+      : {}),
     ...(flowGate.ran || flowGate.skipped !== 'no-base-ref' ? { flowGate } : {}),
     // Attach when the gate is configured on (ran, or skipped for a reason
     // worth disclosing); an off/no-base-ref skip stays out of the result so

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -40,7 +40,13 @@ import {
   pathForBaseline,
   writeBaselineFile,
 } from './baseline-file';
-import type { BaselineAnalysisMeta, BaselineFile, BaselineRepoState } from './baseline-file';
+import type {
+  BaselineAnalysisMeta,
+  BaselineFile,
+  BaselineRepoState,
+  DeferredCaptureClass,
+} from './baseline-file';
+import { assessCaptureDeferral } from './deferral';
 import { resolveBaselineMode } from './modes';
 import type { ResolvedMode } from './modes';
 import { DEFAULT_BROWNFIELD_POLICY, loadPolicyFromCwd } from './policy';
@@ -190,6 +196,13 @@ export interface CurrentScan {
   /** Scanner availability snapshot for the run — which finding-
    *  contributing tools were detected vs missing on this machine. */
   readonly coverage: ScanCoverage;
+  /** Finding classes this environment could NOT observe (CLAUDE.md Rule 20
+   *  applied to capture): a missing registry scanner (a stale mirror) or an
+   *  unmet host/toolchain requirement. Non-empty ⇒ the capture is partial by
+   *  construction — recorded honestly on the committed baseline so the gate's
+   *  arming banner reads it, rather than fail-open-committing a partial baseline
+   *  as if whole. */
+  readonly deferred: ReadonlyArray<DeferredCaptureClass>;
   /** Envelope metadata for the run. `toolchainHash` is already
    *  resolved from `tools`. */
   readonly analysisMeta: BaselineAnalysisMeta;
@@ -245,6 +258,10 @@ export function scanToBaselineFile(
     identityScheme: CURRENT_IDENTITY_SCHEME,
     recall: scan.recall,
     coverage: scan.coverage,
+    // Only when non-empty: a complete capture omits the field entirely (the
+    // authoritative shape), so a baseline captured where everything was
+    // observable diffs byte-clean against a pre-4.0.2 one.
+    ...(scan.deferred.length > 0 ? { deferred: scan.deferred } : {}),
     findings: opts.findings,
   };
 }
@@ -375,8 +392,11 @@ export async function gatherCurrentScan(options: {
 
   // Scanner availability for the active stack. Recorded on the baseline
   // so a later guardrail check can detect when a category was never
-  // scanned (tool missing) rather than scanned-and-clean.
-  const coverage = coverageFromToolStatuses(checkAllTools(analysisResult.stack.languages, cwd));
+  // scanned (tool missing) rather than scanned-and-clean. The same probed
+  // statuses feed the capture-deferral partition — no second probe.
+  const toolStatuses = checkAllTools(analysisResult.stack.languages, cwd);
+  const coverage = coverageFromToolStatuses(toolStatuses);
+  const { deferred } = assessCaptureDeferral(cwd, { statuses: toolStatuses });
 
   return {
     findings,
@@ -386,6 +406,7 @@ export async function gatherCurrentScan(options: {
     tools,
     recall,
     coverage,
+    deferred,
     analysisMeta,
     producerCtx,
   };

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -40,13 +40,8 @@ import {
   pathForBaseline,
   writeBaselineFile,
 } from './baseline-file';
-import type {
-  BaselineAnalysisMeta,
-  BaselineFile,
-  BaselineRepoState,
-  DeferredCaptureClass,
-} from './baseline-file';
-import { assessCaptureDeferral } from './deferral';
+import type { BaselineAnalysisMeta, BaselineFile, BaselineRepoState } from './baseline-file';
+import { assessCaptureDeferral, type DeferredCaptureClass } from './deferral';
 import { resolveBaselineMode } from './modes';
 import type { ResolvedMode } from './modes';
 import { DEFAULT_BROWNFIELD_POLICY, loadPolicyFromCwd } from './policy';
@@ -196,12 +191,8 @@ export interface CurrentScan {
   /** Scanner availability snapshot for the run — which finding-
    *  contributing tools were detected vs missing on this machine. */
   readonly coverage: ScanCoverage;
-  /** Finding classes this environment could NOT observe (CLAUDE.md Rule 20
-   *  applied to capture): a missing registry scanner (a stale mirror) or an
-   *  unmet host/toolchain requirement. Non-empty ⇒ the capture is partial by
-   *  construction — recorded honestly on the committed baseline so the gate's
-   *  arming banner reads it, rather than fail-open-committing a partial baseline
-   *  as if whole. */
+  /** Finding classes this environment could NOT observe (Rule 20 — see
+   *  `deferral.ts`). Non-empty ⇒ partial capture; persisted for the arming banner. */
   readonly deferred: ReadonlyArray<DeferredCaptureClass>;
   /** Envelope metadata for the run. `toolchainHash` is already
    *  resolved from `tools`. */
@@ -212,31 +203,19 @@ export interface CurrentScan {
 }
 
 /**
- * The ONE conversion from a freshly-gathered `CurrentScan` into a `BaselineFile`
- * (CLAUDE.md Rule 2 — one concept, one code path).
+ * The ONE conversion from a `CurrentScan` into a `BaselineFile` (CLAUDE.md
+ * Rule 2 — one concept, one code path). Both baseline paths use it: the
+ * committed write (`createBaseline`) and the ref-based prior side
+ * (`loadPriorSide` in `check.ts`). Centralized because the two hand-built
+ * constructions DIVERGED — `recall`/`coverage` landed on one and were silently
+ * omitted from the other (both optional, so it compiled), making ref-based mode
+ * read every kind as `absent-from-baseline` drift — the Rule 2.30 shape.
  *
- * Both baseline paths use it: `createBaseline` (the committed write) and the
- * ref-based prior side of the guardrail (`loadPriorSide` in `check.ts`). It is
- * centralized because the two hand-built constructions DIVERGED — `recall` and
- * `coverage` were added to the committed write and silently omitted from the
- * ref-based one (both are optional on `BaselineFile`, so the omission compiled).
- * The consequence was severe and invisible: ref-based mode (the public-repo
- * default, the loop Stop-gate, `evaluate`, the self-guardrail) compared against a
- * prior side with NO recall, so `diffRecall` read every kind as
- * `absent-from-baseline` and reported spurious "cannot attribute" drift on every
- * run — even though both sides were gathered by the same dxkit on the same
- * machine and their recall was, by construction, identical. That is exactly the
- * Rule 2.30 shape: one concept, two code paths, a field lands in one.
- *
- * Now a scan field is mapped in exactly ONE place, so a future addition cannot
- * reach only half the callers. `scripts/check-architecture.sh` bans a second
- * `schemaVersion: BASELINE_SCHEMA_VERSION` object construction outside this
- * function, and `test/baseline/scan-to-baseline.test.ts` asserts every
- * scan-derived field survives the conversion.
- *
- * `findings` is a parameter because the two callers legitimately differ: the
- * committed write persists the allowlist-filtered `live` set; the ref-based prior
- * side keeps the full gathered set. Everything else is scan-derived and shared.
+ * A scan field is now mapped in exactly ONE place. `check-architecture.sh` bans
+ * a second `schemaVersion: BASELINE_SCHEMA_VERSION` construction outside this
+ * function; `test/baseline/scan-to-baseline.test.ts` asserts every scan field
+ * survives. `findings` is a param: the committed write persists the
+ * allowlist-filtered `live` set, the ref-based side keeps the full gathered set.
  */
 export function scanToBaselineFile(
   scan: CurrentScan,
@@ -258,9 +237,7 @@ export function scanToBaselineFile(
     identityScheme: CURRENT_IDENTITY_SCHEME,
     recall: scan.recall,
     coverage: scan.coverage,
-    // Only when non-empty: a complete capture omits the field entirely (the
-    // authoritative shape), so a baseline captured where everything was
-    // observable diffs byte-clean against a pre-4.0.2 one.
+    // Omitted when empty — a complete capture keeps the pre-4.0.2 authoritative shape.
     ...(scan.deferred.length > 0 ? { deferred: scan.deferred } : {}),
     findings: opts.findings,
   };
@@ -390,10 +367,9 @@ export async function gatherCurrentScan(options: {
     toolchainHash: hashContent(JSON.stringify(tools)),
   };
 
-  // Scanner availability for the active stack. Recorded on the baseline
-  // so a later guardrail check can detect when a category was never
-  // scanned (tool missing) rather than scanned-and-clean. The same probed
-  // statuses feed the capture-deferral partition — no second probe.
+  // Scanner availability for the active stack (so a later check can tell "never
+  // scanned, tool missing" from "scanned and clean"). The same probed statuses
+  // feed the capture-deferral partition — no second probe.
   const toolStatuses = checkAllTools(analysisResult.stack.languages, cwd);
   const coverage = coverageFromToolStatuses(toolStatuses);
   const { deferred } = assessCaptureDeferral(cwd, { statuses: toolStatuses });

--- a/src/baseline/deferral.ts
+++ b/src/baseline/deferral.ts
@@ -1,0 +1,132 @@
+/**
+ * Capture-time deferral (CLAUDE.md Rule 20, applied to the baseline itself).
+ *
+ * A baseline is only sound if it is captured in an environment that can
+ * OBSERVE every finding class it claims to cover. The pre-4.0.2 capture path
+ * assumed the machine running `init` could see everything — false whenever a
+ * class's scanner cannot run here: a corporate PyPI mirror too stale to install
+ * the pinned Python scanners, or a windows-only build gate on a linux operator's
+ * laptop. When that assumption broke, the capture fail-opened and committed a
+ * PARTIAL baseline as if it were authoritative — and every unobserved class then
+ * drifted to warn-only on the first CI run, where the full toolchain DID install
+ * (Rule 19). The gate looked green while enforcing nothing.
+ *
+ * This module answers the one question the capture path must ask BEFORE writing:
+ * "which finding classes can this environment capture soundly, and which must be
+ * deferred to one that can?" It unifies the two independent signals that make a
+ * class unobservable here — deliberately, because they are architecturally
+ * distinct (see `requirement.ts`):
+ *
+ *   1. a REGISTRY SCANNER is missing (`source === 'missing'`) — gitleaks,
+ *      semgrep, pip-audit, jscpd… These are provisioned by `tools install`, so
+ *      "missing here" usually means the local machine couldn't fetch the pinned
+ *      version (a stale mirror / offline proxy). This is the incident's signal.
+ *   2. a capability's EXECUTION REQUIREMENT is unmet (`unmetRequirement`) — the
+ *      wrong host or a missing ambient toolchain (a `net*-windows` build on
+ *      linux, a missing .NET SDK). This is the Rule 20 host/toolchain signal.
+ *
+ * Both route to the same answer — defer this class to the environment that can
+ * observe it (CI, with the guaranteed pinned toolchain). The capture path records
+ * the deferral honestly on the baseline; it never fabricates a "measured and
+ * clean" record for a class it did not run.
+ */
+
+import * as path from 'path';
+
+import { detect } from '../detect';
+import { checkAllTools, type ToolStatus } from '../analyzers/tools/tool-registry';
+import { collectExecutionRequirements, detectActiveLanguages } from '../languages';
+// exec-requirement-ok: capture-time deferral is a deliberate Rule 20 consumer
+// (the "init honesty" case named in the arch-check) — it asks the ONE predicate
+// "can this environment observe the class?" before the baseline claims it did.
+import {
+  currentEnvironment,
+  describeUnmetRequirement,
+  unmetRequirement,
+  type CapabilityRequirement,
+  type ExecutionEnvironment,
+} from '../execution';
+import type { DeferredCaptureClass } from './baseline-file';
+
+export type { DeferredCaptureClass };
+
+export interface CaptureDeferral {
+  /** Classes that must be captured elsewhere (empty ⇒ this environment can
+   *  observe everything, and a locally-captured baseline is authoritative). */
+  readonly deferred: readonly DeferredCaptureClass[];
+}
+
+/** Baseline-contributing capabilities whose execution requirement can gate the
+ *  committed baseline. `correctness` is the liveness floor (never baselined —
+ *  Rule 15) and `lintGate` has its own per-host fragment path (Rule 20 §3.4),
+ *  so neither belongs in the capture-deferral partition. */
+const BASELINE_CONTRIBUTING_CAPABILITIES: ReadonlySet<CapabilityRequirement['capability']> =
+  new Set(['depVulns', 'deepSast']);
+
+export interface AssessCaptureDeferralOptions {
+  /** The environment to assess against. Default: the real local one. Injected
+   *  in tests to simulate a stale-mirror / wrong-host machine. */
+  readonly env?: ExecutionEnvironment;
+  /** Pre-probed tool statuses (init already computes these — pass them to avoid
+   *  a second probe). Default: `checkAllTools` for the detected stack. */
+  readonly statuses?: readonly ToolStatus[];
+  /** Capability execution requirements. Default: `collectExecutionRequirements`
+   *  for the detected packs. Injected in tests to exercise signal 2 without
+   *  constructing a windows-gated fixture. */
+  readonly requirements?: readonly CapabilityRequirement[];
+}
+
+/**
+ * Partition the repo's finding classes into observable-here vs deferred, for
+ * THIS environment. Pure w.r.t. the injected env + statuses (no hidden global
+ * state); the two default sources (`checkAllTools`, `currentEnvironment`) are
+ * the same ones `init` and the runners already use, so the answer matches what
+ * a full local capture would actually have observed.
+ */
+export function assessCaptureDeferral(
+  cwd: string,
+  opts: AssessCaptureDeferralOptions = {},
+): CaptureDeferral {
+  const resolved = path.resolve(cwd);
+  const stack = detect(resolved);
+  const env = opts.env ?? currentEnvironment();
+  const statuses = opts.statuses ?? checkAllTools(stack.languages, resolved);
+
+  const byId = new Map<string, DeferredCaptureClass>();
+
+  // Signal 1 — a registry scanner that would populate a class is missing here.
+  for (const s of statuses) {
+    if (s.source !== 'missing') continue; // 'n/a' means the class doesn't apply — not a gap
+    if (byId.has(s.name)) continue;
+    byId.set(s.name, {
+      id: s.name,
+      label: s.requirement.description ?? s.name,
+      reason:
+        `${s.name} is not available in this environment — likely a package index that ` +
+        `cannot reach the pinned version (a mirror or offline proxy). CI has the guaranteed ` +
+        `toolchain, so this class is captured there.`,
+      cause: 'scanner-missing',
+    });
+  }
+
+  // Signal 2 — a baseline-contributing capability's host/toolchain requirement
+  // is unmet here (the Rule 20 wrong-host / missing-SDK case).
+  const requirements =
+    opts.requirements ?? collectExecutionRequirements(resolved, detectActiveLanguages(resolved));
+  for (const req of requirements) {
+    if (!BASELINE_CONTRIBUTING_CAPABILITIES.has(req.capability)) continue;
+    const unmet = unmetRequirement(req.requirement, env);
+    if (unmet === null) continue;
+    const id = `${req.pack}:${req.capability}`;
+    if (byId.has(id)) continue;
+    byId.set(id, {
+      id,
+      label: `${req.capability} (${req.pack})`,
+      reason: describeUnmetRequirement(unmet, env.host),
+      cause: 'unmet-requirement',
+    });
+  }
+
+  const deferred = [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+  return { deferred };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2400,12 +2400,18 @@ export async function run(argv: string[]): Promise<void> {
           logger.warn(
             `${missing.length} scanner(s) not detected: ${missing.map((m) => m.tool).join(', ')}`,
           );
-          logger.dim('  Findings in these categories will NOT be captured in the baseline.');
           logger.dim(
-            '  Install with `' + dxkitCli('tools install') + '`, or if a tool IS installed but',
+            '  These classes are recorded as DEFERRED — captured on CI with the guaranteed',
           );
           logger.dim(
-            '  not detected, point dxkit at it via .dxkit/tools.json (ask Claude: "fix dxkit").',
+            '  toolchain, not committed as if measured here. The gate reads them honestly',
+          );
+          logger.dim('  ("completing on CI") until that first CI run lands.');
+          logger.dim(
+            '  Offline: install with `' + dxkitCli('tools install') + '`, or if a tool IS',
+          );
+          logger.dim(
+            '  installed but not detected, point dxkit at it via .dxkit/tools.json ("fix dxkit").',
           );
           // `--force` is an explicit "overwrite, non-interactive, I know
           // what I'm doing" signal — and the shipped baseline-refresh
@@ -2419,18 +2425,21 @@ export async function run(argv: string[]): Promise<void> {
           if (!proceedAnyway && interactive) {
             const readline = await import('node:readline/promises');
             const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-            const answer = (await rl.question('  Capture an INCOMPLETE baseline anyway? [y/N]: '))
+            const answer = (
+              await rl.question('  Capture now and defer these classes to CI? [Y/n]: ')
+            )
               .trim()
               .toLowerCase();
             rl.close();
-            if (!answer.startsWith('y')) {
+            if (answer.startsWith('n')) {
               logger.info('Aborted. Install the missing scanners, then re-run `baseline create`.');
               process.exit(1);
             }
           } else if (!proceedAnyway) {
             logger.fail(
-              'Refusing to write an incomplete baseline non-interactively. ' +
-                'Re-run with --allow-incomplete to proceed, or install the missing scanners.',
+              'Refusing to write a baseline with deferred classes non-interactively. ' +
+                'Re-run with --allow-incomplete to capture-and-defer (the deferred classes ' +
+                'complete on CI), or install the missing scanners first.',
             );
             process.exit(1);
           }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2536,10 +2536,15 @@ export async function run(argv: string[]): Promise<void> {
             `Anchor on '${outcome.anchorRef}' already matches .dxkit/baselines/ — nothing to publish.`,
           );
         } else {
-          // No origin / rejected push: in the refresh workflow this is a broken
-          // run, not a soft skip — fail loud so CI surfaces it.
-          logger.fail(`Anchor publish did not push: ${publish?.reason ?? 'unknown'}.`);
-          process.exit(1);
+          // Rejected / no-origin push: an INFRASTRUCTURE fact (a ruleset, a
+          // permission), not a broken run — and the guardrail falls back to a
+          // live re-gather when the anchor is absent. So FAIL OPEN (exit 0) but
+          // LOUD, via the ONE announcer both publishers share (Rule 2): a human
+          // warning + a GitHub Actions ::warning:: with the remedy. Exiting 1
+          // here reddened the refresh job on a governed-org main for a condition
+          // dxkit cannot fix and the developer did not cause.
+          const { announceAnchorNotPushed } = await import('./baseline/anchor-publish');
+          announceAnchorNotPushed(outcome.anchorRef ?? 'anchor', publish?.reason);
         }
         break;
       }

--- a/src/init-arc.ts
+++ b/src/init-arc.ts
@@ -198,15 +198,20 @@ export function buildInitClosing(state: InitClosingState): InitClosing {
 
   // Same honesty gate, one class over: a scanner that wasn't available at
   // capture time means the baseline is PARTIAL — those finding kinds were
-  // never measured, so they are not gated. An unqualified "You're gated."
-  // over that baseline is a confident answer where the honest output is a
-  // boundary (the same shape as the unprovisioned-toolchain case above).
+  // never measured here, so they are DEFERRED to an environment that can
+  // observe them (CI, with the guaranteed toolchain), not fail-open-committed
+  // as if gated. An unqualified "You're gated." over that baseline is a
+  // confident answer where the honest output is a boundary (the same shape as
+  // the unprovisioned-toolchain case above).
   if (state.incompleteScanners.length > 0) {
     const caution =
-      `${state.incompleteScanners.length} scanner class(es) weren't available ` +
-      `(${state.incompleteScanners.join(', ')}) — those finding types are NOT gated yet. ` +
-      `Run \`${dxkitCli('tools install')}\`, then \`${dxkitCli('baseline create --force')}\` ` +
-      `so the baseline covers them.`;
+      `${state.incompleteScanners.length} scanner class(es) weren't available here ` +
+      `(${state.incompleteScanners.join(', ')}) — likely a package index that can't reach the ` +
+      `pinned versions (a mirror / offline proxy). They are DEFERRED to CI, which captures them ` +
+      `with the guaranteed toolchain and completes the baseline automatically. Until that first ` +
+      `CI run lands, those classes are not yet gating — nothing else to do. ` +
+      `(Or, offline: \`${dxkitCli('tools install')}\` then \`${dxkitCli('baseline create --force')}\` ` +
+      `once the scanners resolve.)`;
     return { headline: "You're gated for what's measurable.", ready, body, caution, actions };
   }
 
@@ -335,8 +340,16 @@ async function runFinishingArc(
       const modeWord =
         result.mode.mode === 'committed-sanitized' ? 'committed (sanitized)' : 'committed';
       bl.note(`private repo → ${modeWord} baseline`);
-      if (incompleteScanners.length > 0) {
-        bl.note(`⚠ ${incompleteScanners.length} scanner class(es) not yet covered`);
+      // A class this environment could not observe (a scanner your package index
+      // couldn't reach, a wrong-host build gate) is recorded as DEFERRED, not
+      // fail-open-committed as if measured. It completes on CI with the
+      // guaranteed toolchain; the gate is honest ("completing on CI") until then.
+      const deferred = result.file.deferred ?? [];
+      if (deferred.length > 0) {
+        bl.note(
+          `→ ${deferred.length} class(es) deferred to CI: ${deferred.map((d) => d.label).join(', ')}`,
+        );
+        bl.note('  (captured on the first CI run with the guaranteed toolchain — nothing to do)');
       }
       bl.succeed(`${b.total} finding${b.total === 1 ? '' : 's'} grandfathered`);
     } else {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -67,6 +67,20 @@ export function fail(text: string): void {
   write(`  ${RED}✗${RESET} ${text}`);
 }
 
+/**
+ * Emit a GitHub Actions annotation — a `::warning::` / `::error::` / `::notice::`
+ * workflow command that surfaces in the run summary + PR checks UI, not just the
+ * raw log. No-op outside Actions (a bare `::warning::…` line is noise on a
+ * terminal). One line only: annotation commands cannot span newlines, so any
+ * embedded newline is flattened. Written straight to stdout (not `write`) so
+ * `--quiet` / JSON mode never suppress a CI-visible signal.
+ */
+export function ciAnnotate(level: 'warning' | 'error' | 'notice', message: string): void {
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    process.stdout.write(`::${level}::${message.replace(/\r?\n/g, ' ')}\n`);
+  }
+}
+
 export function info(text: string): void {
   write(`  ${CYAN}→${RESET} ${text}`);
 }

--- a/src/reports-cli.ts
+++ b/src/reports-cli.ts
@@ -23,6 +23,7 @@ import {
 import type { ReportHistoryEntry } from './reports/history';
 import { renderHistoryMarkdown } from './reports/render';
 import { loadPolicyFromCwd, type ReportsPolicy } from './baseline/policy';
+import { announceAnchorNotPushed } from './baseline/anchor-publish';
 import * as logger from './logger';
 
 /** The repo's `policy.json:reports` block (opt-in), via the one policy loader. */
@@ -112,7 +113,13 @@ export async function runReportSnapshot(opts: ReportSnapshotOptions): Promise<nu
   }
 
   const result = publishReportSnapshot({ cwd, anchorRef, entry, artifacts, retainHistory });
+  // A rejected publish is infrastructure, not a failure to red the job — but it
+  // must never be silent (the class that shipped: a ruleset blocked the push,
+  // the workflow went green, and no reports ref ever appeared). Announce it the
+  // ONE way both publishers do, in JSON and human mode alike.
+  const notPushed = !result.publish.pushed && result.publish.reason !== 'no change';
   if (opts.json) {
+    if (notPushed) announceAnchorNotPushed(result.anchorRef, result.publish.reason);
     process.stdout.write(
       JSON.stringify({
         pushed: result.publish.pushed,
@@ -133,7 +140,7 @@ export async function runReportSnapshot(opts: ReportSnapshotOptions): Promise<nu
   } else if (result.publish.reason === 'no change') {
     logger.info('No change since the last snapshot — nothing published.');
   } else {
-    logger.warn(`Snapshot not published: ${result.publish.reason ?? 'unknown'}.`);
+    announceAnchorNotPushed(result.anchorRef, result.publish.reason);
   }
   return 0;
 }

--- a/test/baseline/anchor-publish.test.ts
+++ b/test/baseline/anchor-publish.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execFileSync } from 'child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { existsSync, chmodSync } from 'fs';
 import {
+  announceAnchorNotPushed,
   describePushFailure,
   publishFilesToAnchorRef,
   readFromAnchorRef,
@@ -311,6 +312,55 @@ describe('describePushFailure (gh #156 categorization)', () => {
     const err = new Error('Updates were rejected because the remote contains work you do not have');
     const reason = describePushFailure(err, 30_000);
     expect(reason.startsWith('push rejected')).toBe(true);
+  });
+
+  it('names the remedy for a repository-ruleset rejection (GH013 — the customer incident)', () => {
+    const err = new Error(
+      'remote: error: GH013: Repository rule violations found for refs/heads/dxkit-baselines. ' +
+        'remote: - Cannot create ref due to creations being restricted.',
+    );
+    const reason = describePushFailure(err, 30_000);
+    // Not the raw wall, and not a generic "push rejected".
+    expect(reason).toMatch(/ruleset/i);
+    expect(reason).toContain('refs/heads/dxkit-**');
+    // Reassures that gating still works — the fail-open promise.
+    expect(reason).toMatch(/re-gather|unaffected/i);
+    expect(reason.startsWith('push rejected')).toBe(false);
+  });
+});
+
+describe('announceAnchorNotPushed — loud fail-open (baseline + reports share it)', () => {
+  const saved = process.env.GITHUB_ACTIONS;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.GITHUB_ACTIONS;
+    else process.env.GITHUB_ACTIONS = saved;
+  });
+
+  it('emits a ::warning:: annotation carrying the reason when running in Actions', () => {
+    process.env.GITHUB_ACTIONS = 'true';
+    const lines: string[] = [];
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      lines.push(String(chunk));
+      return true;
+    });
+    announceAnchorNotPushed('dxkit-reports', 'push blocked by a repository/org ruleset');
+    spy.mockRestore();
+    const annotation = lines.find((l) => l.startsWith('::warning::'));
+    expect(annotation).toBeDefined();
+    expect(annotation).toContain('dxkit-reports');
+    expect(annotation).toContain('ruleset');
+  });
+
+  it('is a no-op annotation outside Actions (no ::warning:: noise on a terminal)', () => {
+    delete process.env.GITHUB_ACTIONS;
+    const lines: string[] = [];
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      lines.push(String(chunk));
+      return true;
+    });
+    announceAnchorNotPushed('dxkit-baselines', 'no origin remote');
+    spy.mockRestore();
+    expect(lines.some((l) => l.startsWith('::warning::'))).toBe(false);
   });
 });
 

--- a/test/baseline/check.test.ts
+++ b/test/baseline/check.test.ts
@@ -96,6 +96,65 @@ describe('runGuardrailCheck (integration)', () => {
       expect(renderJson(base).depVulnsUnmeasured).toBeUndefined();
     });
 
+    it('arming banner surfaces a deferred capture without changing the verdict (Rule 20)', async () => {
+      await createBaseline({ cwd: dir });
+      const base = await runGuardrailCheck({ cwd: dir });
+      // A baseline captured where a scanner could not run (stale mirror) records
+      // the class as deferred; the gate reads it into `deferredCapture`.
+      const armed = {
+        ...base,
+        deferredCapture: [
+          {
+            id: 'semgrep',
+            label: 'Static analysis security scanner (SAST)',
+            reason: 'mirror',
+            cause: 'scanner-missing' as const,
+          },
+        ],
+      };
+      // Loud in every renderer — never a silent green pass over an unobserved class.
+      expect(renderConsole(armed)).toContain('COMPLETING ON CI');
+      expect(renderConsole(armed)).toContain('Static analysis security scanner (SAST)');
+      expect(renderMarkdown(armed)).toContain('COMPLETING ON CI');
+      expect(renderJson(armed).deferredCapture).toHaveLength(1);
+      // Orthogonal to the verdict: the deferred classes warn via recall, they do
+      // not force a block. Exit code is exactly what it was without the marker.
+      expect(renderJson(armed).verdict.exitCode).toBe(renderJson(base).verdict.exitCode);
+      // A complete capture shows nothing new.
+      expect(renderJson(base).deferredCapture).toBeUndefined();
+      expect(renderConsole(base)).not.toContain('COMPLETING ON CI');
+    });
+
+    it('reads a committed baseline’s deferred marker end-to-end, honestly, without blocking (Rule 20)', async () => {
+      const created = await createBaseline({ cwd: dir });
+      expect(created.path).toBeDefined();
+      // Simulate the incident: a capture that could not observe a class (a stale
+      // mirror couldn't install the scanner) lands a `deferred` record on the
+      // committed baseline instead of fail-open-committing it as measured.
+      const file = JSON.parse(readFileSync(created.path!, 'utf8'));
+      file.deferred = [
+        {
+          id: 'semgrep',
+          label: 'Static analysis security scanner (SAST)',
+          reason: 'behind a mirror',
+          cause: 'scanner-missing',
+        },
+      ];
+      writeFileSync(created.path!, JSON.stringify(file, null, 2));
+
+      const result = await runGuardrailCheck({ cwd: dir });
+      // The gate READS it from disk (not injected) — proves the whole wiring:
+      // baseline.deferred → result.deferredCapture → arming banner.
+      expect(result.deferredCapture).toHaveLength(1);
+      expect(result.deferredCapture![0].id).toBe('semgrep');
+      expect(renderConsole(result)).toContain('COMPLETING ON CI');
+      // Honest, NOT a false block: nothing net-new here, and the deferred class
+      // is disclosed rather than silently certified.
+      expect(result.blocks).toBe(false);
+      expect(renderJson(result).verdict.exitCode).toBe(0);
+      expect(renderJson(result).deferredCapture).toHaveLength(1);
+    });
+
     it('UNMEASURED remediation is reason-aware — absent vs present-but-unusable (#15)', async () => {
       await createBaseline({ cwd: dir });
       const base = await runGuardrailCheck({ cwd: dir });

--- a/test/baseline/check.test.ts
+++ b/test/baseline/check.test.ts
@@ -120,9 +120,13 @@ describe('runGuardrailCheck (integration)', () => {
       // Orthogonal to the verdict: the deferred classes warn via recall, they do
       // not force a block. Exit code is exactly what it was without the marker.
       expect(renderJson(armed).verdict.exitCode).toBe(renderJson(base).verdict.exitCode);
-      // A complete capture shows nothing new.
-      expect(renderJson(base).deferredCapture).toBeUndefined();
-      expect(renderConsole(base)).not.toContain('COMPLETING ON CI');
+      // A complete capture shows nothing new. `base` is NOT asserted directly —
+      // a scanner-poor runner (missing cloc etc.) legitimately defers classes, so
+      // its own deferredCapture is environment-dependent. Clear it explicitly to
+      // pin the complete-capture rendering deterministically.
+      const complete = { ...base, deferredCapture: undefined };
+      expect(renderJson(complete).deferredCapture).toBeUndefined();
+      expect(renderConsole(complete)).not.toContain('COMPLETING ON CI');
     });
 
     it('reads a committed baseline’s deferred marker end-to-end, honestly, without blocking (Rule 20)', async () => {

--- a/test/baseline/deferral.test.ts
+++ b/test/baseline/deferral.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Capture-time deferral partition (CLAUDE.md Rule 20, applied to the baseline).
+ *
+ * Pins both signals that make a finding class unobservable in the current
+ * environment — a missing registry scanner (the stale-mirror incident) and an
+ * unmet execution requirement (the wrong-host / missing-SDK case) — and the
+ * boundary that keeps non-baseline capabilities out of the partition.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { assessCaptureDeferral } from '../../src/baseline/deferral';
+import type { ToolStatus } from '../../src/analyzers/tools/tool-registry';
+import type { CapabilityRequirement, ExecutionEnvironment } from '../../src/execution';
+
+const tmpRepo = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-deferral-'));
+
+const linux: ExecutionEnvironment = { host: 'linux', hasToolchain: () => false };
+
+/** A ToolStatus with just the fields the partition reads. */
+const status = (
+  name: string,
+  source: ToolStatus['source'],
+  description = `${name} desc`,
+): ToolStatus =>
+  ({
+    name,
+    available: source !== 'missing' && source !== 'n/a',
+    path: null,
+    version: null,
+    source,
+    requirement: { description } as ToolStatus['requirement'],
+  }) as ToolStatus;
+
+const capReq = (
+  pack: string,
+  capability: CapabilityRequirement['capability'],
+  hosts: CapabilityRequirement['requirement']['hosts'],
+): CapabilityRequirement => ({
+  pack,
+  capability,
+  requirement: { hosts, toolchains: [], needsBuild: false, buildTarget: 'none', weight: 'cheap' },
+});
+
+describe('assessCaptureDeferral — capturable-here vs defer-to-CI', () => {
+  it('defers nothing when every scanner is present and every requirement is met', () => {
+    const repo = tmpRepo();
+    const { deferred } = assessCaptureDeferral(repo, {
+      env: linux,
+      statuses: [status('gitleaks', 'path'), status('semgrep', 'path')],
+      requirements: [capReq('typescript', 'depVulns', ['any'])],
+    });
+    expect(deferred).toEqual([]);
+  });
+
+  it('defers a missing scanner (the stale-mirror signal) with its tool description as the label', () => {
+    const repo = tmpRepo();
+    const { deferred } = assessCaptureDeferral(repo, {
+      env: linux,
+      statuses: [
+        status('gitleaks', 'path'),
+        status('semgrep', 'missing', 'Static analysis security scanner (SAST)'),
+      ],
+      requirements: [],
+    });
+    expect(deferred).toHaveLength(1);
+    expect(deferred[0]).toMatchObject({
+      id: 'semgrep',
+      label: 'Static analysis security scanner (SAST)',
+      cause: 'scanner-missing',
+    });
+    expect(deferred[0].reason).toMatch(/mirror|proxy|CI/i);
+  });
+
+  it('does NOT defer a not-applicable scanner (nothing to capture ≠ a gap)', () => {
+    const repo = tmpRepo();
+    const { deferred } = assessCaptureDeferral(repo, {
+      env: linux,
+      statuses: [status('pip-audit', 'n/a')],
+      requirements: [],
+    });
+    expect(deferred).toEqual([]);
+  });
+
+  it('defers a baseline-contributing capability whose host requirement is unmet', () => {
+    const repo = tmpRepo();
+    const { deferred } = assessCaptureDeferral(repo, {
+      env: linux,
+      statuses: [],
+      requirements: [capReq('csharp', 'depVulns', ['windows'])],
+    });
+    expect(deferred).toHaveLength(1);
+    expect(deferred[0]).toMatchObject({ id: 'csharp:depVulns', cause: 'unmet-requirement' });
+    expect(deferred[0].reason).toMatch(/windows/i);
+  });
+
+  it('does NOT defer non-baseline capabilities (correctness floor, lint fragment path)', () => {
+    const repo = tmpRepo();
+    const { deferred } = assessCaptureDeferral(repo, {
+      env: linux,
+      statuses: [],
+      requirements: [
+        capReq('csharp', 'correctness', ['windows']),
+        capReq('csharp', 'lintGate', ['windows']),
+      ],
+    });
+    expect(deferred).toEqual([]);
+  });
+
+  it('unions both signals, dedups by id, and sorts deterministically', () => {
+    const repo = tmpRepo();
+    const { deferred } = assessCaptureDeferral(repo, {
+      env: linux,
+      statuses: [status('semgrep', 'missing'), status('pip-audit', 'missing')],
+      requirements: [capReq('csharp', 'deepSast', ['windows'])],
+    });
+    expect(deferred.map((d) => d.id)).toEqual(['csharp:deepSast', 'pip-audit', 'semgrep']);
+  });
+});

--- a/test/baseline/scan-to-baseline.test.ts
+++ b/test/baseline/scan-to-baseline.test.ts
@@ -41,6 +41,9 @@ function fixtureScan(): CurrentScan {
     coverage: {
       tools: [{ tool: 'gitleaks', available: true }],
     } as unknown as CurrentScan['coverage'],
+    deferred: [
+      { id: 'semgrep', label: 'SAST', reason: 'mirror', cause: 'scanner-missing' },
+    ] as CurrentScan['deferred'],
     analysisMeta: {
       dxkitVersion: '3.8.0',
       toolchainHash: 'abc',
@@ -61,6 +64,18 @@ describe('scanToBaselineFile — every scan-derived field survives the conversio
     expect(file.coverage).toEqual(scan.coverage);
     expect(file.recall).toBeDefined();
     expect(file.coverage).toBeDefined();
+  });
+
+  it('carries the capture-deferral record (Rule 20 — the arming banner reads it)', () => {
+    const scan = fixtureScan();
+    const file = scanToBaselineFile(scan, { name: 'main', findings: scan.findings });
+    expect(file.deferred).toEqual(scan.deferred);
+  });
+
+  it('omits `deferred` entirely on a complete capture (authoritative shape)', () => {
+    const scan = { ...fixtureScan(), deferred: [] as CurrentScan['deferred'] };
+    const file = scanToBaselineFile(scan, { name: 'main', findings: scan.findings });
+    expect('deferred' in file).toBe(false);
   });
 
   it('carries every other scan-derived field verbatim', () => {
@@ -105,6 +120,7 @@ describe('scanToBaselineFile — every scan-derived field survives the conversio
       'identityScheme',
       'recall',
       'coverage',
+      'deferred',
       'findings',
     ] as const) {
       expect(file[key], `scanToBaselineFile dropped '${key}'`).toBeDefined();

--- a/test/init-arc.test.ts
+++ b/test/init-arc.test.ts
@@ -186,7 +186,10 @@ describe('buildInitClosing', () => {
       incompleteScanners: ['gitleaks'],
     });
     expect(scannerOnly.headline).toBe("You're gated for what's measurable.");
-    expect(scannerOnly.caution).toContain('NOT gated');
+    // The scanner gap is now DEFERRED to CI (captured with the guaranteed
+    // toolchain), not silently dropped — the caution says so and stays honest
+    // that the class is not yet gating.
+    expect(scannerOnly.caution).toMatch(/deferred|not yet gating/i);
   });
 
   it('claims the unqualified headline ONLY on full coverage', () => {

--- a/test/tools/install-diagnosis.test.ts
+++ b/test/tools/install-diagnosis.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Stale-index install diagnosis (CLAUDE.md Rule 20, problem C).
+ *
+ * Turns pip's unsatisfiable-requirement wall into one legible sentence naming
+ * the root cause (a mirror / offline proxy) and the remedy (defer to CI). Biased
+ * toward a false NEGATIVE — a non-pip failure keeps its raw text.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { diagnoseStaleIndex } from '../../src/analyzers/tools/install-diagnosis';
+
+describe('diagnoseStaleIndex', () => {
+  it('reads the pin + the newest available version and names the mirror cause', () => {
+    const out = [
+      'ERROR: Could not find a version that satisfies the requirement semgrep==1.165.0',
+      '  (from versions: 1.96.0, 1.97.0, 1.99.0)',
+      'ERROR: No matching distribution found for semgrep==1.165.0',
+    ].join('\n');
+    const d = diagnoseStaleIndex(out);
+    expect(d).not.toBeNull();
+    expect(d!.pkg).toBe('semgrep');
+    expect(d!.wanted).toBe('1.165.0');
+    expect(d!.newestAvailable).toBe('1.99.0');
+    expect(d!.message).toContain('1.99.0');
+    expect(d!.message).toMatch(/mirror|proxy/i);
+    expect(d!.message).toMatch(/CI/);
+    // Never a raw pip line.
+    expect(d!.message).not.toContain('No matching distribution');
+  });
+
+  it('handles a package genuinely absent from the index (no from-versions list)', () => {
+    const out = 'ERROR: No matching distribution found for pip-audit==2.10.1';
+    const d = diagnoseStaleIndex(out);
+    expect(d).not.toBeNull();
+    expect(d!.pkg).toBe('pip-audit');
+    expect(d!.wanted).toBe('2.10.1');
+    expect(d!.newestAvailable).toBeUndefined();
+    expect(d!.message).toMatch(/mirror|proxy/i);
+  });
+
+  it('treats "from versions: none" as genuinely absent (not a newest)', () => {
+    const out = [
+      'ERROR: Could not find a version that satisfies the requirement foopkg==1.0.0 (from versions: none)',
+      'ERROR: No matching distribution found for foopkg==1.0.0',
+    ].join('\n');
+    const d = diagnoseStaleIndex(out);
+    expect(d!.newestAvailable).toBeUndefined();
+  });
+
+  it('returns null on an unrelated failure (a real error keeps its raw text)', () => {
+    expect(diagnoseStaleIndex('bash: pip: command not found')).toBeNull();
+    expect(diagnoseStaleIndex('Connection timed out after 30000ms')).toBeNull();
+    expect(diagnoseStaleIndex('')).toBeNull();
+  });
+
+  it('handles a bare requirement with no pinned version', () => {
+    const d = diagnoseStaleIndex('ERROR: No matching distribution found for coverage');
+    expect(d).not.toBeNull();
+    expect(d!.pkg).toBe('coverage');
+    expect(d!.wanted).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What & why

A baseline captured where a scanner couldn't run — a package index too stale to install a pinned scanner (a corporate mirror / offline proxy), or a host/toolchain not present on the machine — was promoted to authoritative (`--yes` / `--allow-incomplete` waved it through) and committed **as if complete**. On the first CI run, where the full pinned toolchain *does* install, the recall mechanism (Rule 19) then saw a toolchain mismatch and demoted every affected security kind to warn-only: **the gate read green while enforcing nothing.** Silent under-enforcement, not a false block.

This completes **CLAUDE.md Rule 20** for the moment dxkit captures the baseline.

## The fix

- **`src/baseline/deferral.ts` — `assessCaptureDeferral`**: the one predicate "can this environment observe the class?", unifying the two architecturally-distinct signals — a missing registry scanner (the coverage signal; a stale mirror — `unmetRequirement` never sees this, scanners aren't toolchains) and an unmet execution requirement (host/toolchain).
- **`BaselineFile.deferred`**: the honest record, written by the one converter (`scanToBaselineFile`), omitted entirely on a complete capture.
- **Gate reads it** into `GuardrailCheckResult.deferredCapture` (committed modes only — ref-based has no committed baseline to complete). Every renderer surfaces an honest **arming banner** ("baseline COMPLETING ON CI — N classes not yet gating"). **Exit code unchanged**: deferred classes warn via recall, they are never false-blocked; the banner only makes the incompleteness loud instead of silently green. The existing `dxkit-baseline-refresh` workflow completes the baseline on CI with the guaranteed toolchain, clearing the state (a full re-capture defers nothing).
- **`init` / `baseline create` messaging** reframed from "INCOMPLETE baseline anyway?" (scary override) to routine "defer to CI".
- **`src/analyzers/tools/install-diagnosis.ts` — `diagnoseStaleIndex`**: turns pip's unsatisfiable-requirement wall into one legible "behind a mirror; captured on CI" sentence; wired into `execInstall`, biased to a false negative so a real failure keeps its raw text.

## Two deliberate scope decisions

1. **No fragment composition.** The shipped fragment primitives are `custom-check`-only, and the incident is a single-host case (ubuntu CI observes everything), so the existing refresh workflow's full re-capture completes it. Fragments stay reserved for genuine multi-host lint.
2. **Post-merge completion, not PR-commit-back.** The commit-back-to-a-PR path has governed-org ruleset behavior that can't be validated without a real constrained repo; shipping it unverified would break the "prove on a real repo" rule. The arming banner keeps the pre-merge window honest; that completion is a tracked follow-up.

## Testing

All CI gates pass locally (typecheck ×2, eslint, prettier, arch-check, docs-coverage, slop, cross-ecosystem, **full suite 4396/4396**). New/updated tests: partition (both signals + the non-baseline boundary), the pip classifier, deferral survives the one converter (omitted when empty), the arming banner renders without changing the verdict, and the gate reads a committed `deferred` marker **end-to-end**. Proven on the real compiled binary: a repo with a deferred baseline → `guardrail check` PASSES exit 0 with the banner + `--json deferredCapture`; a well-provisioned machine defers nothing.

## Reviewer note

The arming banner is exit-code-neutral by design (deferred classes warn via recall, never block). If a distinct exit signal for a deferred baseline is preferred, that's a deliberate policy call, easy to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)