### PR TITLE
4.0.3: close the enforcement-boundary holes, verify the supply chain, unblock the rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ fix what the baseline grandfathered.
   Informational — always exits 0; the gates do the blocking, and they hold
   the ratchet: a fixed floor check regresses as net-new and blocks, no
   re-baseline needed.
+- **A failing build is loud in the PR, even when it is pre-existing.** The
+  diff-scoped CI floor never lets "warn" mean "a line in a green check's log":
+  one disclosure builder feeds the PR comment (a broken base branch gets an
+  explicit approver call-out — "approving merges onto a broken build" — with
+  reproduction commands and output), GitHub check annotations
+  (`::error` for net-new, `::warning` for pre-existing/unattributed), and the
+  workflow step summary. A green floor emits nothing.
 - **`baseline create` records the floor-debt envelope** (`floorDebt` on the
   baseline file): the full-scope correctness floor at capture time, bounded
   per-check, details included. Never consulted by the gate verdict (a failing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.3] - 2026-07-17
 
-Correctness and trust only — no new features. Closes the three
-enforcement-boundary holes an external audit verified against 4.0.2, plus the
-supply-chain gap and the defect cluster the first 16-repo org rollout surfaced.
+Correctness and trust. Closes the three enforcement-boundary holes an external
+audit verified against 4.0.2, plus the supply-chain gap and the defect cluster
+the first 16-repo org rollout surfaced. One deliberate addition completes the
+adoption arc those fixes enable: the committed floor-debt inventory + `debt`
+surface, so once the gates hold the line, cleanup agents can prioritize and
+fix what the baseline grandfathered.
+
+### Added
+
+- **`vyuh-dxkit debt [--json]` — the prioritized repair inventory for cleanup
+  agents.** One composed, agent-readable plan across both debt classes: the
+  correctness-floor debt (broken build / failing tests — live-run, with the
+  reproduction command and captured error output per failing check, and
+  provenance against the baseline's envelope: failing-since-baseline vs
+  new-since-baseline vs fixed) and the fingerprinted finding debt grouped by
+  severity. Ordered by the one hard dependency: fix the build first (nothing
+  else is measurable until it compiles), then tests, then findings.
+  Informational — always exits 0; the gates do the blocking, and they hold
+  the ratchet: a fixed floor check regresses as net-new and blocks, no
+  re-baseline needed.
+- **`baseline create` records the floor-debt envelope** (`floorDebt` on the
+  baseline file): the full-scope correctness floor at capture time, bounded
+  per-check, details included. Never consulted by the gate verdict (a failing
+  build is a signal, not a grandfatherable finding — Rule 15 intact), never
+  allowlistable. Opt out with `--no-floor` or `DXKIT_BASELINE_NO_FLOOR=1`;
+  `update`'s re-baseline refreshes it automatically. `doctor` recommends
+  `debt` when the committed baseline carries floor debt.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.3] - 2026-07-17
+
+Correctness and trust only — no new features. Closes the three
+enforcement-boundary holes an external audit verified against 4.0.2, plus the
+supply-chain gap and the defect cluster the first 16-repo org rollout surfaced.
+
+### Fixed
+
+- **An uncommitted edit that introduces a high/critical SAST finding now
+  BLOCKS.** The scan reads the working tree, but changed-line attribution
+  diffed committed history — at Stop time an agent's dirty edits sat outside
+  an empty diff, so net-new `code` findings demoted `added → uncertain` and
+  warned instead of blocking. Attribution now diffs base → working tree
+  (staged + unstaged + untracked; an untracked file attributes as all-lines),
+  through one canonical index beside `computeChangedFiles` so file-level and
+  line-level discovery can never diverge on diff basis again. A per-file
+  attribution failure now reads as UNKNOWN (no demotion), never as "nothing
+  changed".
+- **The `newHighReachableDependencyVulnerability` block rule actually fires.**
+  It was armed in both shipped presets and structurally dead twice over: the
+  guardrail gather never computed reachability, and the classifier context
+  never carried it. Reachability is now annotated on the guardrail path from
+  the imports gather (one annotation entry point shared with the standalone
+  scan), threaded into classification, and the rule→evidence mapping is a
+  compile-enforced table — a future block rule cannot land without declaring
+  which analyzers produce its evidence.
+- **The loop Stop-gate verdict cache is environment-complete.** It keyed on
+  tree bytes alone, so a scanner/policy/dxkit upgrade on an unchanged tree
+  replayed a stale ALLOW. The key now carries an environment signature (dxkit
+  + node versions, resolved loop policy/preset/modes, the postflight test
+  command, and a spawn-free stamp of every registry tool's resolved binary),
+  and loop activation clears the cache so a session never replays a verdict
+  minted by a previous one. Legacy cache entries never match (miss, re-scan).
+- **`stale-file` findings no longer come from `node_modules/`.** The hygiene
+  glob matched tracked files anywhere, so a repo with a committed
+  node_modules saw `*.orig`/`*.log` under it flagged as net-new on its
+  onboarding PR. The discovery now consults the one canonical exclusion
+  source; pinned by an analysis-fixture case both directions.
+- **The CI correctness floor is diff-scoped: only NET-NEW compile/test
+  failures block a PR.** A repo with a pre-existing red suite can now adopt
+  dxkit without the onboarding PR being walled off — while a PR that bundles
+  a real breakage still blocks (the base was green). Failures also present at
+  the merge-base warn by name; a failure whose base side could not be
+  observed is disclosed as unattributed and never blocked. One comparator
+  serves both the loop Stop-gate and CI, with the absent-from-base policy an
+  explicit declared argument. Pushes to the default branch (no base) keep the
+  point-in-time liveness verdict.
+- **Environment failures on Android/Gradle repos read as environment, not
+  broken code.** Catalog-based Android projects (the `com.android` literal
+  only in `gradle/libs.versions.toml`) are now detected, so the JVM floor
+  declines them as designed; an unspawnable command (`gradlew` committed
+  without the executable bit) is a disclosed fail-open skip carrying its
+  one-line remedy instead of a 0.2-second "compile failed" with empty
+  output; and a failing floor check always prints its command and output (or
+  says explicitly that there was none).
+
+### Security
+
+- **Every executed tool download is now sha256-verified, fail-closed.**
+  gitleaks, osv-scanner, pmd, detekt, ktlint, the dotnet-install script
+  (now pinned to an immutable dotnet/install-scripts commit instead of the
+  mutable dot.net URL), and CodeQL (now pinned to a bundle tag with the
+  release's published checksums; previously `releases/latest`, unpinned and
+  unverifiable) all route through one verified-fetch primitive that refuses
+  a mismatched artifact. An architecture gate bans any new unverified
+  download in the registry. ktlint's installer also stops using sudo.
+
+### Documentation
+
+- SECURITY.md supported versions corrected to 4.x; "every stop" claims scoped
+  to unattended-loop stops; the floor's capability stated precisely (runs the
+  checks it can establish, reports unavailable ones explicitly); the
+  benchmark's preset caveat now sits beside the 0/16 headline.
+
 ## [4.0.2] - 2026-07-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,19 @@ Every external tool (cloc, gitleaks, semgrep, graphify, jscpd, ruff, etc.) MUST 
 
 Builtins (grep, find, wc, git, node) are exempt — they're always available.
 
+**Executed downloads are checksum-verified (4.0.3 / T2.1).** Any network
+artifact an install command fetches goes through
+`dxkit_fetch <url> <sha256> <dest>` — defined ONCE in
+`src/analyzers/tools/install-exec.ts` (the single install executor prepends
+it), with the pinned hash declared in the registry beside the URL. It fails
+CLOSED on mismatch. The arch-check bans a raw curl/wget-with-URL in
+`tool-registry.ts` and an `Invoke-WebRequest` without a `Get-FileHash` check
+(annotate `// unverified-download-ok` for a justified exception);
+`test/tool-registry-version-pins.test.ts` pins that every `dxkit_fetch` call
+carries a 64-hex sha and that no unverified fetch exists in any install
+command. Bumping a tool version means re-pinning its hash (prefer the
+publisher's published checksum file where one exists — gitleaks, codeql).
+
 **CI tool discoverability is registry-derived, never a hardcoded PATH.** The
 places a tool binary can live are declared once — `getSystemPaths()` plus each
 tool's `probePaths` in the registry — and `findTool` probes them. The CI PATH
@@ -77,6 +90,35 @@ ${path}` keys, which discards catch-all structure — so it did exact membership
   leading `{var}` has no anchor → warn, not block);
 - benign secret / env conventions → `isPlaceholderSecret` / `isExampleEnvFile`
   (Rule 5's benign module), consulted by BOTH secret detectors.
+- what the working tree CHANGED vs a base → `computeChangedFiles` +
+  `createChangedLineIndex`, BOTH in `src/baseline/changed-files.ts`, both
+  diffing base → WORKING TREE (staged + unstaged + untracked; an untracked
+  file attributes as all-lines). The 4.0.3 T1.1 class: line attribution
+  lived in check.ts and diffed committed HEAD while the scan read the dirty
+  tree, so every finding an agent's uncommitted edit introduced demoted
+  `added→uncertain` and warned instead of blocking. Parity pinned in
+  `test/baseline/changed-files.test.ts` (a file the file-level sibling
+  reports changed must carry line attribution). Attribution failure reads
+  as UNKNOWN (no demotion), never as "nothing changed".
+- a block rule's required EVIDENCE (which analyzers must gather for it to
+  fire) → `BLOCK_RULE_EVIDENCE` in `src/baseline/gather-scope.ts`, typed
+  `Record<keyof BrownfieldBlockRules, ...>` so a new rule without an
+  evidence declaration fails to COMPILE; `scopeForPolicy` derives from it.
+  The 4.0.3 T1.2 class: `newHighReachableDependencyVulnerability` was armed
+  in both presets and structurally dead — the scope if-chain never pulled in
+  the imports gather its evidence needed, and the check path never threaded
+  `reachable`. Reachability itself is ONE entry point
+  (`annotateReachability` in `tools/reachability.ts`), consumed by both the
+  standalone enriched scan and the guardrail/health path.
+- is a floor FAILURE the change's fault → `attributeFloorFailures` in
+  `src/analyzers/correctness/attribution.ts` (base pass → net-new BLOCKS;
+  base fail → pre-existing warns; base unobserved → unattributed, disclosed,
+  never blocked — Rule 19 applied to the floor). BOTH consumers route
+  through it: the loop Stop-gate (`netNewFloorFailures` is a thin wrapper)
+  and the two-sided CI floor (`attributeCiFloorOutcome`). The one honest
+  policy difference — what an ABSENT base check means — is a declared
+  argument (`absentMeans`), never a second comparator. Parity pinned in
+  `test/correctness-attribution.test.ts`.
 - what dxkit OWNS vs what the user owns, for a managed file → the manifest's
   `provenance` (`created`/`overwritten`/`skipped`) + `hash`. BOTH the update
   write path (`decideUpdateDisposition` in `src/update-disposition.ts`, consumed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 before the edit, and a deterministic stop-gate before the loop can finish.**
 
 It maps the relevant code, callers, dependencies, and blast radius before the
-agent edits. At stop time it checks compilation, affected tests, and the
+agent edits. When an unattended loop tries to stop, it runs the compilation
+and affected-test checks it can establish in that environment — anything it
+cannot run is reported explicitly, never silently passed — plus the
 configured detector-backed policy, and blocks if the change introduced a
 prohibited regression.
 
@@ -139,9 +141,10 @@ steps:
 2. **Baseline.** `baseline create` records today's findings with durable
    fingerprints, so pre-existing issues stay visible and auditable without
    blocking the work.
-3. **Gate.** On every stop attempt, a Claude Code Stop hook reruns the
-   guardrail against that baseline: compilation, affected tests, and the
-   configured detector-backed policy.
+3. **Gate.** On every unattended-loop stop attempt, a Claude Code Stop hook
+   reruns the guardrail against that baseline: the compilation and
+   affected-test checks it can establish (unavailable ones are reported,
+   not silently passed), and the configured detector-backed policy.
 4. **Repair.** If the change introduced a finding, the stop is blocked and the
    exact finding comes back to the agent while it still holds the task
    context. The loop finishes only when the change is clean.
@@ -164,7 +167,8 @@ more than all debt.
 The one-liner above is the default: it adds dxkit as a devDependency, installs
 the Claude Code Stop hook, provisions scanners, and captures the baseline.
 Everything is additive, preserving your existing `.claude` settings. Then run Claude Code
-as you normally would; the Stop-gate fires on every stop.
+as you normally would; the Stop-gate fires on every stop of an unattended loop
+(interactive sessions are not gated — review and the CI guardrail cover those).
 
 ```bash
 npx vyuh-dxkit loop doctor            # verify the wiring
@@ -268,7 +272,7 @@ tries to declare done.
 
 | Loop Stop-gate need                                         | dxkit | Cloud or CI scanners                   |
 | ----------------------------------------------------------- | ----- | -------------------------------------- |
-| Runs locally on every stop, in seconds                      | yes   | usually CI or cloud cadence            |
+| Runs locally on every unattended-loop stop, in seconds      | yes   | usually CI or cloud cadence            |
 | Deterministic verdict, no model in the gate                 | yes   | varies (some add an LLM judge)         |
 | Grandfathers existing debt                                  | yes   | tool-dependent                         |
 | Feeds the exact block reason back to the warm agent session | yes   | usually a human-facing dashboard or PR |
@@ -362,7 +366,7 @@ secret-task premium pointed the same way but was weak (mean +19%, median
 slightly negative), so we lean on the robust test-gap result.) So the gate is not
 just safer than deferring, it is plausibly cheaper too.
 
-**And the gate is fast enough to run on every stop.** dxkit scopes the
+**And the gate is fast enough to run on every unattended-loop stop.** dxkit scopes the
 Stop-gate scan to the active preset's blockable finding kinds and re-scans only
 the changed files, reusing cached results for everything unchanged. The verdict
 is identical to a full scan; the cost is seconds per stop, not minutes, even on

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,8 @@ backports — please upgrade.
 
 | Version | Supported        |
 | ------- | ---------------- |
-| 3.x.y   | ✅ Latest minor  |
-| < 3.0   | ❌ Not supported |
+| 4.x.y   | ✅ Latest minor  |
+| < 4.0   | ❌ Not supported |
 
 ## Reporting a Vulnerability
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ construction; commands with a linked page have a full reference under
 | [`dashboard`](commands/dashboard.md)                             | Render .dxkit/reports/ into one HTML dashboard                                    | < 5 sec (renders existing reports) |
 | [`report`](commands/report.md)                                   | Full audit (report), or publish/read a score snapshot (report snapshot\|history)  | 5-30 min                           |
 | `metrics`                                                        | Findings the gate stopped before merge + the score-over-time trend                | < 5 sec                            |
+| `debt`                                                           | The prioritized repair inventory: floor debt + finding debt                       | varies (runs your compile + tests) |
 | [`baseline`](commands/baseline.md)                               | Capture / publish / show per-finding baselines for the guardrail                  | 30 sec - 2 min                     |
 | [`guardrail`](commands/guardrail.md)                             | Diff current scan vs baseline; block on net-new regressions                       | 30 sec - 2 min                     |
 | `receipt`                                                        | Emit the PR "dxkit signals" block (verdict + allowlist + score delta)             | < 30 sec                           |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -21,7 +21,11 @@ still present.
 - A prompt-only self-check still left it in 9 of 16 runs.
 - With dxkit's Stop-gate, we observed 0 of 16 escapes.
 
-Each figure is n=16 per arm, from 8 repetitions on each of two tasks.
+Each figure is n=16 per arm, from 8 repetitions on each of two tasks. Read the
+0/16 with its preset caveat: one of the two seeded tasks (the test-gap) is
+gated only by the opt-in `full-debt` preset — the product default,
+`security-only`, gates the secret task's class but not that one. The result is
+also observed, not proven-zero.
 
 The dxkit arm did not discover a new class of bugs. On every stop it re-ran a
 deterministic net-new guardrail, blocked any stop that left debt in the tree,
@@ -193,7 +197,9 @@ does not?
 
 **Headline.** Observed escapes: vanilla **11/16 (69%)**, checklist (prompt-only)
 **9/16 (56%)**, dxkit **0/16**. The dxkit arm blocked, the model repaired the
-specific finding, and the loop re-stopped clean.
+specific finding, and the loop re-stopped clean. (Caveat, stated with the
+number: the test-gap half of the 0/16 is gated by the opt-in `full-debt`
+preset, not the `security-only` default.)
 
 **Method.** `bench-loop.mjs`, four arms, two seeded traps (a test-gap and a
 secret), 8 reps each, Sonnet 4.6, with an identical post-hoc guardrail measuring
@@ -294,7 +300,7 @@ agent's stop decision.
 
 | What a loop's Stop-gate needs            | dxkit                               | Cloud scanners (Snyk Code, SonarQube) |
 | ---------------------------------------- | ----------------------------------- | ------------------------------------- |
-| Fires on every stop, in seconds, locally | yes: no LLM cost, offline, instant  | no: cloud round-trip, CI/PR cadence   |
+| Fires on every unattended-loop stop, in seconds, locally | yes: no LLM cost, offline, instant  | no: cloud round-trip, CI/PR cadence   |
 | Offline, with no egress and no auth      | yes: local and deterministic        | no: upload-to-cloud, server-side gate |
 | Feedback the model can act on            | yes: a block decision plus a reason | no: dashboards and PR comments        |
 | Reproducible identity offline            | yes: content-anchored               | partial: "new code" defined on server |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -298,12 +298,12 @@ The difference is one of architecture and tempo, not detection. Cloud scanners
 are detection engines on a CI cadence, and they were never built to sit inside an
 agent's stop decision.
 
-| What a loop's Stop-gate needs            | dxkit                               | Cloud scanners (Snyk Code, SonarQube) |
-| ---------------------------------------- | ----------------------------------- | ------------------------------------- |
+| What a loop's Stop-gate needs                            | dxkit                               | Cloud scanners (Snyk Code, SonarQube) |
+| -------------------------------------------------------- | ----------------------------------- | ------------------------------------- |
 | Fires on every unattended-loop stop, in seconds, locally | yes: no LLM cost, offline, instant  | no: cloud round-trip, CI/PR cadence   |
-| Offline, with no egress and no auth      | yes: local and deterministic        | no: upload-to-cloud, server-side gate |
-| Feedback the model can act on            | yes: a block decision plus a reason | no: dashboards and PR comments        |
-| Reproducible identity offline            | yes: content-anchored               | partial: "new code" defined on server |
+| Offline, with no egress and no auth                      | yes: local and deterministic        | no: upload-to-cloud, server-side gate |
+| Feedback the model can act on                            | yes: a block decision plus a reason | no: dashboards and PR comments        |
+| Reproducible identity offline                            | yes: content-anchored               | partial: "new code" defined on server |
 
 A note on what not to claim, so that the comparison holds up. Do not say cloud
 scanners cannot detect net-new findings, because SonarQube has a new-code quality

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1863,6 +1863,34 @@ if [ -n "$TEMPLATE_BARE_NPM" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# =============================================================================
+# T2.1 (4.0.3): every EXECUTED tool download is checksum-verified.
+#
+# Class: an install command that pipes a network artifact straight into
+# tar/bash/the filesystem executes whatever the network returned. The registry
+# is the ONE home of executed install commands; every download in it goes
+# through `dxkit_fetch <url> <sha256> <dest>` (defined + prepended by the ONE
+# executor, install-exec.ts), which fails CLOSED on hash mismatch. A raw
+# curl/wget with a URL in the registry is a new unverified download path.
+# Windows commands use package managers (winget/scoop) or carry an inline
+# Get-FileHash check — an Invoke-WebRequest without one fails too.
+REGISTRY_RAW_DL=$(grep -nE "(curl|wget)[^']*https?://" src/analyzers/tools/tool-registry.ts 2>/dev/null \
+  | grep -v "dxkit_fetch" | grep -v "// unverified-download-ok")
+if [ -n "$REGISTRY_RAW_DL" ]; then
+  echo "❌ Supply-chain violation: unverified download in the tool registry:"
+  echo "$REGISTRY_RAW_DL"
+  echo "   → Route it through dxkit_fetch <url> <sha256> <dest> with a pinned hash."
+  echo "   → Annotate '// unverified-download-ok' for a justified exception."
+  ERRORS=$((ERRORS + 1))
+fi
+REGISTRY_RAW_PS_DL=$(grep -n "Invoke-WebRequest" src/analyzers/tools/tool-registry.ts 2>/dev/null \
+  | grep -v "Get-FileHash" | grep -v "// unverified-download-ok")
+if [ -n "$REGISTRY_RAW_PS_DL" ]; then
+  echo "❌ Supply-chain violation: Invoke-WebRequest without a Get-FileHash check in the tool registry:"
+  echo "$REGISTRY_RAW_PS_DL"
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ $ERRORS -gt 0 ]; then
   echo ""
   echo "Architecture checks failed. See CLAUDE.md for rules."

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1589,8 +1589,8 @@ fi
 # existence, synthetic-injection — live in test/discovery-playbook.test.ts.)
 RULE16_CLI_CASES=$(grep -oE "^    case '[a-z][a-z-]*':" src/cli.ts | sed -E "s/^    case '([a-z-]+)':/\1/" | sort -u)
 RULE16_REG_TOKENS=$( { \
-  grep -oE "id: '[a-z][a-z-]*'" src/discovery/command-defs.ts | sed -E "s/id: '([a-z-]+)'/\1/"; \
-  grep -oE "aliases: \[[^]]*\]" src/discovery/command-defs.ts | grep -oE "'[a-z-]+'" | tr -d "'"; \
+  grep -hoE "id: '[a-z][a-z-]*'" src/discovery/command-defs.ts src/discovery/command-defs-internal.ts | sed -E "s/id: '([a-z-]+)'/\1/"; \
+  grep -hoE "aliases: \[[^]]*\]" src/discovery/command-defs.ts src/discovery/command-defs-internal.ts | grep -oE "'[a-z-]+'" | tr -d "'"; \
 } | sort -u)
 RULE16_UNREGISTERED=$(comm -23 <(printf '%s\n' "$RULE16_CLI_CASES") <(printf '%s\n' "$RULE16_REG_TOKENS"))
 RULE16_ORPHANED=$(comm -13 <(printf '%s\n' "$RULE16_CLI_CASES") <(printf '%s\n' "$RULE16_REG_TOKENS"))

--- a/src-templates/.claude/skills/dxkit-action/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-action/SKILL.md
@@ -7,6 +7,34 @@ description: Read a dxkit report and execute fixes — prioritize findings by se
 
 This skill takes a dxkit report and drives the fix loop with the user. Reach for it after `dxkit-reports` has surfaced concrete findings.
 
+## Cleaning the BASELINE (grandfathered debt): start from `debt`
+
+For a whole-baseline cleanup pass — the deployment where the gates are armed
+and your job is to burn down what they grandfathered — start from the composed
+inventory instead of a single report:
+
+```bash
+npx vyuh-dxkit debt --json
+```
+
+It returns one priority-ordered plan across BOTH debt classes:
+
+- **Correctness-floor debt** (broken build, failing tests) — live-run, with
+  the reproduction command and captured error output per failing check, and
+  provenance vs the baseline's `floorDebt` envelope (`failing since baseline`
+  = the debt you're here to fix; `new since baseline` = the gate's business,
+  it already blocks). **Fix the build first** — until it compiles, nothing
+  else is reliably measurable.
+- **Finding debt** (secrets, CVEs, SAST, lint backlog) — fingerprinted
+  baseline entries grouped by severity; drive each group with the scoped
+  action loop below.
+
+The command is informational and always exits 0 — the gates do the blocking,
+and they also hold the ratchet: once you fix a floor check, any regression is
+net-new and blocks automatically. No re-baselining is needed for floor fixes;
+finding fixes surface as `removed` on the next check and leave the baseline
+on the next re-capture.
+
 ## The action loop
 
 ```

--- a/src-templates/.github/workflows/dxkit-gate-host.yml
+++ b/src-templates/.github/workflows/dxkit-gate-host.yml
@@ -30,6 +30,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history: the diff-scoped floor resolves the merge-base and
+          # runs the base side in a worktree (a shallow clone breaks both).
+          fetch-depth: 0
 
       - uses: actions/setup-node@v6
         with:
@@ -58,4 +62,4 @@ __DXKIT_GATE_HOST_SETUP__
           else
             DXKIT=vyuh-dxkit
           fi
-          "${DXKIT}" floor check --surface ci --correctness --packs __DXKIT_GATE_PACKS__
+          "${DXKIT}" floor check --surface ci --correctness --packs __DXKIT_GATE_PACKS__ ${GITHUB_BASE_REF:+--base "origin/${GITHUB_BASE_REF}"}

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -191,6 +191,12 @@ __DXKIT_CI_RUNTIME_SETUP__
       # and a failing check is attributed against the merge-base — only a
       # NET-NEW failure blocks; a repo's pre-existing broken build/tests warn
       # by name instead of walling off the PR (the onboarding-PR class).
+      #
+      # A failing floor is never quiet: --report-md appends a loud disclosure
+      # section to the report the next step posts as the PR COMMENT (a
+      # pre-existing broken base branch is called out to approvers in the
+      # conversation, not buried in a green check's log), and the CLI also
+      # emits check annotations + a step-summary section under Actions.
       - name: Correctness floor (compile + tests)
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
@@ -198,7 +204,7 @@ __DXKIT_CI_RUNTIME_SETUP__
           else
             DXKIT=vyuh-dxkit
           fi
-          "${DXKIT}" floor check --surface ci ${GITHUB_BASE_REF:+--base "origin/${GITHUB_BASE_REF}"}
+          "${DXKIT}" floor check --surface ci --report-md guardrail-report.md ${GITHUB_BASE_REF:+--base "origin/${GITHUB_BASE_REF}"}
 
       # Interactive flow console (design §E) — a self-contained HTML artifact
       # scoped to THIS PR: the UI→API map + a browser-side request runner for the

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -186,6 +186,11 @@ __DXKIT_CI_RUNTIME_SETUP__
       # floor is most meaningful on JS/TS repos and on repos with no test-CI;
       # your own test job is the place for full-language coverage. Tune via
       # .dxkit/policy.json correctness.surfaces.ci or DXKIT_FLOOR_CI.
+      #
+      # On a PR the floor is DIFF-SCOPED: --base hands it the target branch,
+      # and a failing check is attributed against the merge-base — only a
+      # NET-NEW failure blocks; a repo's pre-existing broken build/tests warn
+      # by name instead of walling off the PR (the onboarding-PR class).
       - name: Correctness floor (compile + tests)
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
@@ -193,7 +198,7 @@ __DXKIT_CI_RUNTIME_SETUP__
           else
             DXKIT=vyuh-dxkit
           fi
-          "${DXKIT}" floor check --surface ci
+          "${DXKIT}" floor check --surface ci ${GITHUB_BASE_REF:+--base "origin/${GITHUB_BASE_REF}"}
 
       # Interactive flow console (design §E) — a self-contained HTML artifact
       # scoped to THIS PR: the UI→API map + a browser-side request runner for the

--- a/src/analyzers/correctness/attribution.ts
+++ b/src/analyzers/correctness/attribution.ts
@@ -1,0 +1,82 @@
+/**
+ * Floor-failure ATTRIBUTION — the ONE comparator that decides whether a
+ * failing correctness check is the change's fault (T2.3, Rule 2.30).
+ *
+ * Two surfaces diff a floor run against a "before" side and must agree:
+ *
+ *   - the loop Stop-gate, against its ENTRY SNAPSHOT (`src/loop/floor-state.ts`,
+ *     captured on the pristine tree at activation, same environment);
+ *   - the CI floor, against a MERGE-BASE worktree run (a different tree,
+ *     same runner) — so an onboarding PR is not blocked by the repo's own
+ *     pre-existing broken build, while a PR that bundles a breakage with the
+ *     dxkit install still blocks (base green, PR red).
+ *
+ * Per current-side FAILURE, against the base side:
+ *   - base `pass`     → `net-new`      — the change broke it. BLOCKS.
+ *   - base `fail`     → `pre-existing` — grandfathered debt. Warns, named.
+ *   - base `skipped`  → `unattributed` — dxkit could not OBSERVE the base
+ *     side for this check (toolchain missing in the worktree, deps not
+ *     provisioned). Blaming the developer would violate the Rule 19 law
+ *     (rule out every other cause before attributing), so it warns with the
+ *     reason disclosed, never blocks.
+ *   - absent from base → `absentMeans`, declared by the caller, because the
+ *     two base sides genuinely differ: the loop's snapshot deliberately DROPS
+ *     skipped checks (same environment — a check that newly runs and fails
+ *     was enabled by the change, so absent ⇒ `net-new`, failing toward
+ *     blocking); a cross-tree CI base run keeps its skips, and a check absent
+ *     there means the base run itself was incomplete ⇒ `unattributed`.
+ *
+ * An explicit option, not two functions — so the policy difference is a
+ * declared argument at each call site instead of a semantic fork in a second
+ * comparator (the divergence class the flow gate-vs-join bug shipped from).
+ */
+import type { CorrectnessCheckResult, CorrectnessFloorResult } from './run';
+
+/** The durable identity of one floor check across runs. */
+export function checkKey(pack: string, label: string): string {
+  return `${pack}:${label}`;
+}
+
+/** One base-side check, statuses collapsed to what attribution needs. */
+export interface FloorBaseCheck {
+  readonly pack: string;
+  readonly label: string;
+  readonly status: 'pass' | 'fail' | 'skipped';
+}
+
+export type FloorAttribution = 'net-new' | 'pre-existing' | 'unattributed';
+
+export interface AttributedFloorFailure {
+  readonly check: CorrectnessCheckResult;
+  readonly attribution: FloorAttribution;
+}
+
+/**
+ * Attribute every current-side FAILURE against the base side. `base === null`
+ * means no base side exists at all — every failure takes `absentMeans`
+ * (loop: no snapshot → fail toward blocking; CI: base run crashed → cannot
+ * attribute, disclosed).
+ */
+export function attributeFloorFailures(
+  current: CorrectnessFloorResult,
+  base: readonly FloorBaseCheck[] | null,
+  opts: { readonly absentMeans: 'net-new' | 'unattributed' },
+): AttributedFloorFailure[] {
+  const byKey = new Map<string, FloorBaseCheck['status']>();
+  for (const c of base ?? []) byKey.set(checkKey(c.pack, c.label), c.status);
+  const out: AttributedFloorFailure[] = [];
+  for (const check of current.checks) {
+    if (check.status !== 'fail') continue;
+    const baseStatus = byKey.get(checkKey(check.pack, check.label));
+    const attribution: FloorAttribution =
+      baseStatus === 'fail'
+        ? 'pre-existing'
+        : baseStatus === 'pass'
+          ? 'net-new'
+          : baseStatus === 'skipped'
+            ? 'unattributed'
+            : opts.absentMeans;
+    out.push({ check, attribution });
+  }
+  return out;
+}

--- a/src/analyzers/correctness/floor-disclosure.ts
+++ b/src/analyzers/correctness/floor-disclosure.ts
@@ -1,0 +1,148 @@
+/**
+ * Floor DISCLOSURE — making a failing build impossible to miss in a PR.
+ *
+ * The diff-scoped CI floor (T2.3) deliberately does not BLOCK on a
+ * pre-existing broken build — but "warn" must not mean "a line in a green
+ * check's log nobody opens". A reviewer approving a PR onto a broken base
+ * branch should be unable to claim they didn't know. So one disclosure
+ * builder feeds every surface reviewers actually look at:
+ *
+ *   - the PR COMMENT (the guardrail workflow appends
+ *     `floorDisclosureMarkdown` to the report it posts — reviewers read
+ *     the conversation);
+ *   - CHECK ANNOTATIONS (`githubAnnotations` → `::error`/`::warning`
+ *     workflow commands, surfaced in the Checks tab and the Files view);
+ *   - the RUN'S STEP SUMMARY (same markdown, on the workflow run page).
+ *
+ * Three tiers, same vocabulary as the attribution lattice:
+ *   net-new       → 🛑 error  — this PR broke it (the gate already blocks).
+ *   pre-existing  → ⚠️ warning — the BASE BRANCH is broken; not this PR's
+ *                   fault and not blocking, but approvers are told, loudly,
+ *                   that they are merging onto a broken build.
+ *   unattributed  → ⚠️ warning — failing now, base side unobservable.
+ * A point-in-time failure (no base resolvable) gets the error tier: the
+ * check is red anyway; the annotation says why without opening the log.
+ *
+ * Returns null / [] when there is nothing to shout about — a green floor
+ * stays silent.
+ */
+import { dxkitCli } from '../../self-invocation';
+import type { SurfaceFloorOutcome } from './surface-run';
+import type { AttributedFloorFailure } from './attribution';
+import type { CorrectnessCheckResult } from './run';
+
+function repro(c: CorrectnessCheckResult): string {
+  return [c.bin, ...(c.args ?? [])].filter(Boolean).join(' ');
+}
+
+function mdCheck(c: CorrectnessCheckResult): string[] {
+  const lines = [`- **${c.pack} ${c.label}** — repro: \`${repro(c)}\``];
+  if (c.output) {
+    lines.push('  <details><summary>output</summary>');
+    lines.push('');
+    lines.push('  ```');
+    for (const l of c.output.split('\n').slice(-15)) lines.push(`  ${l}`);
+    lines.push('  ```');
+    lines.push('  </details>');
+  }
+  return lines;
+}
+
+function tiers(outcome: SurfaceFloorOutcome): {
+  netNew: CorrectnessCheckResult[];
+  preExisting: CorrectnessCheckResult[];
+  unattributed: CorrectnessCheckResult[];
+  pointInTime: CorrectnessCheckResult[];
+} {
+  const a = outcome.attributed;
+  const pick = (t: AttributedFloorFailure['attribution']) =>
+    (a ?? []).filter((x) => x.attribution === t).map((x) => x.check);
+  return {
+    netNew: a ? pick('net-new') : [],
+    preExisting: a ? pick('pre-existing') : [],
+    unattributed: a ? pick('unattributed') : [],
+    // No attribution ran (green, disabled, or no base resolvable): any
+    // failure is a point-in-time red — still worth a legible annotation.
+    pointInTime: a ? [] : (outcome.result?.checks ?? []).filter((c) => c.status === 'fail'),
+  };
+}
+
+/** Markdown block for the PR comment + step summary; null when green. */
+export function floorDisclosureMarkdown(outcome: SurfaceFloorOutcome): string | null {
+  const { netNew, preExisting, unattributed, pointInTime } = tiers(outcome);
+  if (!netNew.length && !preExisting.length && !unattributed.length && !pointInTime.length) {
+    return null;
+  }
+  const lines: string[] = [];
+  if (netNew.length > 0) {
+    lines.push('## 🛑 Correctness floor: this PR breaks the build/tests (net-new — BLOCKING)');
+    lines.push('');
+    for (const c of netNew) lines.push(...mdCheck(c));
+    lines.push('');
+  }
+  if (pointInTime.length > 0) {
+    lines.push(
+      '## 🛑 Correctness floor: build/tests failing (no merge-base to attribute against — BLOCKING)',
+    );
+    lines.push('');
+    for (const c of pointInTime) lines.push(...mdCheck(c));
+    lines.push('');
+  }
+  if (preExisting.length > 0) {
+    lines.push(
+      '## ⚠️ THE BASE BRANCH BUILD/TESTS ARE BROKEN (pre-existing — not caused by this PR, not blocking)',
+    );
+    lines.push('');
+    lines.push(
+      '> **Approvers, read this before approving:** these failures exist on the base branch itself. ' +
+        'This PR did not cause them and is not blocked by them — but merging means merging onto a ' +
+        'broken build. Approve only if you accept that, and make sure someone owns the fix: ' +
+        `\`${dxkitCli('debt')}\` prints the prioritized repair inventory.`,
+    );
+    lines.push('');
+    for (const c of preExisting) lines.push(...mdCheck(c));
+    lines.push('');
+  }
+  if (unattributed.length > 0) {
+    lines.push(
+      '## ⚠️ Floor failures dxkit could not attribute (base side unobservable — not blocking)',
+    );
+    lines.push('');
+    lines.push(
+      '> These checks fail on this PR, but the merge-base run could not observe them ' +
+        '(toolchain/deps unavailable in the base worktree), so dxkit refuses to blame either side. ' +
+        'Review advised.',
+    );
+    lines.push('');
+    for (const c of unattributed) lines.push(...mdCheck(c));
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+/** One-line GitHub workflow-command annotations (Checks tab + Files view). */
+export function githubAnnotations(outcome: SurfaceFloorOutcome): string[] {
+  const { netNew, preExisting, unattributed, pointInTime } = tiers(outcome);
+  const out: string[] = [];
+  for (const c of netNew) {
+    out.push(
+      `::error title=dxkit floor — this PR breaks the build/tests::${c.pack} ${c.label} is a NET-NEW failure (passes on the base branch). Repro: ${repro(c)}`,
+    );
+  }
+  for (const c of pointInTime) {
+    out.push(
+      `::error title=dxkit floor — build/tests failing::${c.pack} ${c.label} failed. Repro: ${repro(c)}`,
+    );
+  }
+  for (const c of preExisting) {
+    out.push(
+      `::warning title=dxkit floor — the BASE BRANCH is broken::${c.pack} ${c.label} fails on the base branch too. Not caused by this PR and not blocking — but approving merges onto a broken build. Inventory the debt: ${dxkitCli('debt')}`,
+    );
+  }
+  for (const c of unattributed) {
+    out.push(
+      `::warning title=dxkit floor — unattributed failure::${c.pack} ${c.label} fails here and the base side could not be observed. Review advised.`,
+    );
+  }
+  return out;
+}

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -65,6 +65,10 @@ export interface CorrectnessCheckResult {
   readonly pack: LanguageId;
   readonly label: string;
   readonly bin: string;
+  /** Full argv (excluding the bin) — with `bin`, the reproduction command
+   *  an agent runs to see the failure itself. Absent on requirement-level
+   *  skips (no command was built). */
+  readonly args?: readonly string[];
   readonly status: CorrectnessStatus;
   /** Captured output tail on `fail` (for the block message), or the
    *  disclosed reason on `skipped-unavailable` (missing binary / wrapper
@@ -131,6 +135,7 @@ export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessF
           pack: id,
           label: cmd.label,
           bin: cmd.bin,
+          args: cmd.args,
           status: 'skipped-unavailable',
           // WHY it was unavailable (not-on-PATH vs present-but-not-executable
           // vs spawn errno) — carried so every surface can disclose the skip
@@ -142,14 +147,26 @@ export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessF
       if (outcome.timedOut) {
         // Exceeded the budget — fail-OPEN. The run didn't finish, so it says
         // nothing about correctness; CI (unbounded) is the backstop.
-        checks.push({ pack: id, label: cmd.label, bin: cmd.bin, status: 'skipped-timeout' });
+        checks.push({
+          pack: id,
+          label: cmd.label,
+          bin: cmd.bin,
+          args: cmd.args,
+          status: 'skipped-timeout',
+        });
         continue;
       }
       if (outcome.overflowed) {
         // Output outran the capture buffer — fail-OPEN, same reasoning as the
         // timeout above. The floor BLOCKS, so it must only block on a failure it
         // actually read; a fragment is not evidence of a broken build.
-        checks.push({ pack: id, label: cmd.label, bin: cmd.bin, status: 'skipped-overflow' });
+        checks.push({
+          pack: id,
+          label: cmd.label,
+          bin: cmd.bin,
+          args: cmd.args,
+          status: 'skipped-overflow',
+        });
         continue;
       }
       if (outcome.code !== 0) {
@@ -164,6 +181,7 @@ export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessF
             pack: id,
             label: cmd.label,
             bin: cmd.bin,
+            args: cmd.args,
             status: 'skipped-environment',
             unmet: { kind: 'unhealthy-toolchain', ...envFailure },
           });
@@ -174,6 +192,7 @@ export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessF
         pack: id,
         label: cmd.label,
         bin: cmd.bin,
+        args: cmd.args,
         status: outcome.code === 0 ? 'pass' : 'fail',
         // DISPLAY only — `tail` belongs here, at the renderer boundary, not in the
         // capture primitive where a parser could mistake it for the whole stream.

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -66,7 +66,9 @@ export interface CorrectnessCheckResult {
   readonly label: string;
   readonly bin: string;
   readonly status: CorrectnessStatus;
-  /** Captured output tail — present only on `fail`, for the block message. */
+  /** Captured output tail on `fail` (for the block message), or the
+   *  disclosed reason on `skipped-unavailable` (missing binary / wrapper
+   *  not executable — carries the remedy). */
   readonly output?: string;
   /** Present only on `skipped-environment` — the structured unmet-requirement
    *  reason (phrase via `describeUnmetRequirement`). */
@@ -125,7 +127,16 @@ export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessF
       if (cmd === null) continue; // pack declined this check for this change
       const outcome = exec(cmd, opts.cwd);
       if (!outcome.available) {
-        checks.push({ pack: id, label: cmd.label, bin: cmd.bin, status: 'skipped-unavailable' });
+        checks.push({
+          pack: id,
+          label: cmd.label,
+          bin: cmd.bin,
+          status: 'skipped-unavailable',
+          // WHY it was unavailable (not-on-PATH vs present-but-not-executable
+          // vs spawn errno) — carried so every surface can disclose the skip
+          // with its remedy instead of silently thinning the floor (Rule 20).
+          ...(outcome.output ? { output: outcome.output } : {}),
+        });
         continue;
       }
       if (outcome.timedOut) {
@@ -190,10 +201,18 @@ export function describeCorrectnessFloor(result: CorrectnessFloorResult): string
  *  and the root remedy — never a silent skip (Rule 20). The floor always runs
  *  on the local host, so the local host selects the install hints. */
 export function describeEnvironmentSkips(result: CorrectnessFloorResult): string[] {
-  return result.checks
-    .filter((c) => c.status === 'skipped-environment' && c.unmet)
-    .map(
-      (c) =>
-        `${c.pack} floor not measurable in this environment: ${describeUnmetRequirement(c.unmet as UnmetRequirement, hostOf())}`,
-    );
+  return [
+    ...result.checks
+      .filter((c) => c.status === 'skipped-environment' && c.unmet)
+      .map(
+        (c) =>
+          `${c.pack} floor not measurable in this environment: ${describeUnmetRequirement(c.unmet as UnmetRequirement, hostOf())}`,
+      ),
+    // Unavailable-with-a-reason is the same disclosure obligation: a check
+    // that could not even spawn (binary missing / wrapper not executable)
+    // must be named with its remedy, never silently thin the floor.
+    ...result.checks
+      .filter((c) => c.status === 'skipped-unavailable' && c.output)
+      .map((c) => `${c.pack} ${c.label} skipped: ${c.output}`),
+  ];
 }

--- a/src/analyzers/correctness/surface-run.ts
+++ b/src/analyzers/correctness/surface-run.ts
@@ -296,8 +296,7 @@ export async function attributeCiFloorOutcome(
       : baseResult.checks.map((c) => ({
           pack: c.pack as string,
           label: c.label,
-          status:
-            c.status === 'pass' || c.status === 'fail' ? c.status : ('skipped' as const),
+          status: c.status === 'pass' || c.status === 'fail' ? c.status : ('skipped' as const),
         }));
   const attributed = attributeFloorFailures(outcome.result, baseChecks, {
     absentMeans: 'unattributed',
@@ -326,7 +325,9 @@ export async function attributeCiFloorOutcome(
   if (unattributed.length > 0) {
     parts.push(
       `${unattributed.length} failure(s) could not be attributed (the base side did not run that check — ${
-        baseResult === null ? 'base floor run failed' : 'toolchain/deps unavailable in the base worktree'
+        baseResult === null
+          ? 'base floor run failed'
+          : 'toolchain/deps unavailable in the base worktree'
       }); not blocked, review advised: ${unattributed
         .map((a) => `${a.check.pack} ${a.check.label}`)
         .join(', ')}`,

--- a/src/analyzers/correctness/surface-run.ts
+++ b/src/analyzers/correctness/surface-run.ts
@@ -2,21 +2,25 @@
  * Run the correctness floor for a NON-loop surface (`pre-push` / `ci`).
  *
  * The loop Stop-gate has its own runner (`src/loop/stop-gate.ts`) because it
- * diffs against a cheap entry snapshot to block only on NET-NEW failures. The
- * pre-push and CI surfaces are point-in-time LIVENESS gates instead: they run
- * the floor at the current tree and are fail-CLOSED on the surface's scope.
- * There is no net-new diffing here (that would cost a base-ref worktree run on
- * every push / PR); the entry-snapshot trick is the loop's alone.
+ * diffs against a cheap entry snapshot to block only on NET-NEW failures.
  *
  *   - `pre-push` — AFFECTED scope, changed files computed vs the merge-base with
  *     the integration branch. Runs on the developer's machine where the
  *     toolchain is present, so the floor is meaningful; a per-command timeout
  *     keeps `git push` fast. Blocks the push when the affected tests don't pass.
  *     (It does not distinguish a pre-existing red test in a touched module from
- *     a newly-broken one — that distinction is the loop Stop-gate's job. Bypass
- *     with `--no-verify`.)
- *   - `ci` — FULL scope, no timeout (the full suite is expected to run). The
- *     backstop.
+ *     a newly-broken one — that distinction belongs to the two-sided surfaces.
+ *     Bypass with `--no-verify`.)
+ *   - `ci` — FULL scope, no timeout. DIFF-SCOPED (T2.3): when the current tree
+ *     has failures and a merge-base is resolvable, the floor also runs at the
+ *     base in a throwaway worktree and each failure is ATTRIBUTED through the
+ *     ONE comparator the loop uses (`attributeFloorFailures`): only NET-NEW
+ *     failures block (a PR bundling a breakage with, say, a dxkit install
+ *     still blocks — base green, PR red), pre-existing debt warns by name,
+ *     and a failure whose base side could not be observed is `unattributed`
+ *     (disclosed, never blocked — the Rule 19 law applied to the floor). The
+ *     base side only runs when the current side FAILED, so a green PR pays
+ *     nothing.
  *
  * Both surfaces are ADAPTIVE (`resolveCorrectnessSurface`): when the repo
  * already runs its tests in its own CI, the floor defaults to opt-in here, so
@@ -24,8 +28,10 @@
  */
 
 import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 
-import { detectActiveLanguages } from '../../languages';
+import { detectActiveLanguages, changedFilesTouchDependencyManifest } from '../../languages';
 import type { LanguageSupport } from '../../languages/types';
 import { computeChangedFiles } from '../../baseline/changed-files';
 import {
@@ -35,6 +41,7 @@ import {
   type CommandExec,
   type CorrectnessFloorResult,
 } from './run';
+import { attributeFloorFailures, type AttributedFloorFailure } from './attribution';
 import { resolveCorrectnessSurface } from './surface';
 
 /** The surfaces this runner serves (the loop-stop surface has its own runner). */
@@ -53,6 +60,10 @@ export interface SurfaceFloorOutcome {
   /** One-line human summary for CLI / hook output. */
   readonly summary: string;
   readonly result?: CorrectnessFloorResult;
+  /** Present after a two-sided ci run (T2.3): every current failure with its
+   *  attribution vs the merge-base. Renderers print net-new with full output
+   *  and the non-blocking tiers by name. */
+  readonly attributed?: readonly AttributedFloorFailure[];
 }
 
 /** Best-effort git stdout for a fixed arg vector; '' on any failure. */
@@ -199,5 +210,133 @@ export function runFloorForSurface(opts: RunFloorForSurfaceOptions): SurfaceFloo
     blocks: result.blocks,
     summary: describeCorrectnessFloor(result) + envSuffix,
     result,
+  };
+}
+
+/**
+ * Provision a base-ref worktree well enough for the floor to run (best
+ * effort). Ecosystems with user-level caches (Gradle/Maven, go, cargo, pip)
+ * just work in a fresh worktree; node needs node_modules. When the diff
+ * touched NO dependency manifest (pack-declared patterns — Rule 6), the
+ * current tree's install IS the base's install, so a symlink is sound. When
+ * manifests changed (or the changed set is unknowable) we provision nothing —
+ * affected checks then skip on the base side and their failures come back
+ * `unattributed` (disclosed, non-blocking) rather than resting on a tree the
+ * base never had.
+ */
+function provisionBaseWorktree(
+  cwd: string,
+  worktree: string,
+  baseSha: string,
+  packs: readonly LanguageSupport[],
+): void {
+  const changed = computeChangedFiles(cwd, baseSha);
+  if (changed === null || changedFilesTouchDependencyManifest(changed, packs)) return;
+  const src = path.join(cwd, 'node_modules');
+  const dst = path.join(worktree, 'node_modules');
+  try {
+    if (fs.existsSync(src) && !fs.existsSync(dst)) fs.symlinkSync(src, dst, 'dir');
+  } catch {
+    /* best-effort — an unprovisioned base side degrades to `unattributed` */
+  }
+}
+
+/**
+ * Two-sided attribution for a BLOCKING ci floor outcome (T2.3): run the floor
+ * at the merge-base in a throwaway worktree and re-derive `blocks` from the
+ * ONE comparator — only failures the base side PASSED (net-new) block. Called
+ * only when the current side failed, so a green PR never pays the base run.
+ *
+ * Fail-open discipline: an unresolvable base keeps the point-in-time verdict
+ * (blocking — push-to-default-branch runs have no base and stay the liveness
+ * backstop); a base-side crash attributes every failure `unattributed`
+ * (non-blocking, disclosed) — the developer is never blamed on evidence dxkit
+ * does not have.
+ */
+export async function attributeCiFloorOutcome(
+  outcome: SurfaceFloorOutcome,
+  opts: {
+    readonly cwd: string;
+    readonly base?: string;
+    /** Injected for tests; default real exec / worktree pack detection. */
+    readonly exec?: CommandExec;
+    readonly packs?: readonly LanguageSupport[];
+  },
+): Promise<SurfaceFloorOutcome> {
+  if (outcome.surface !== 'ci' || !outcome.blocks || !outcome.result) return outcome;
+  const baseSha = resolvePrePushBase(opts.cwd, opts.base);
+  if (!baseSha) {
+    return {
+      ...outcome,
+      summary: `${outcome.summary} [no merge-base resolvable — point-in-time verdict]`,
+    };
+  }
+
+  let baseResult: CorrectnessFloorResult | null = null;
+  try {
+    const { withRefWorktree } = await import('../../baseline/ref-baseline');
+    baseResult = await withRefWorktree({ cwd: opts.cwd, ref: baseSha }, async (wt) => {
+      const packs = (opts.packs ?? detectActiveLanguages(wt)).filter((p) => p.correctness);
+      provisionBaseWorktree(opts.cwd, wt, baseSha, packs);
+      return runCorrectnessFloor({
+        cwd: wt,
+        changedFiles: [],
+        scope: 'full',
+        packs,
+        exec: opts.exec,
+      });
+    });
+  } catch {
+    baseResult = null; // base side unobservable → every failure unattributed
+  }
+
+  const baseChecks =
+    baseResult === null
+      ? null
+      : baseResult.checks.map((c) => ({
+          pack: c.pack as string,
+          label: c.label,
+          status:
+            c.status === 'pass' || c.status === 'fail' ? c.status : ('skipped' as const),
+        }));
+  const attributed = attributeFloorFailures(outcome.result, baseChecks, {
+    absentMeans: 'unattributed',
+  });
+  const netNew = attributed.filter((a) => a.attribution === 'net-new');
+  const preExisting = attributed.filter((a) => a.attribution === 'pre-existing');
+  const unattributed = attributed.filter((a) => a.attribution === 'unattributed');
+
+  const parts: string[] = [];
+  if (netNew.length > 0) {
+    parts.push(
+      `correctness floor: ${netNew.length} NET-NEW failure(s) vs ${baseSha.slice(0, 12)} — ${netNew
+        .map((a) => `${a.check.pack} ${a.check.label}`)
+        .join(', ')}`,
+    );
+  } else {
+    parts.push(`correctness floor: no net-new failure vs ${baseSha.slice(0, 12)}`);
+  }
+  if (preExisting.length > 0) {
+    parts.push(
+      `${preExisting.length} pre-existing failure(s) also present at the base (not blocked): ${preExisting
+        .map((a) => `${a.check.pack} ${a.check.label}`)
+        .join(', ')}`,
+    );
+  }
+  if (unattributed.length > 0) {
+    parts.push(
+      `${unattributed.length} failure(s) could not be attributed (the base side did not run that check — ${
+        baseResult === null ? 'base floor run failed' : 'toolchain/deps unavailable in the base worktree'
+      }); not blocked, review advised: ${unattributed
+        .map((a) => `${a.check.pack} ${a.check.label}`)
+        .join(', ')}`,
+    );
+  }
+
+  return {
+    ...outcome,
+    blocks: netNew.length > 0,
+    summary: parts.join(' | '),
+    attributed,
   };
 }

--- a/src/analyzers/health.ts
+++ b/src/analyzers/health.ts
@@ -27,6 +27,7 @@ import { gatherPackageJsonMetrics } from './tools/package-json';
 import { gatherHygieneMarkers, gatherCommentRatio } from './quality/gather';
 import { timed, timedAsync } from './tools/timing';
 import { defaultDispatcher } from './dispatcher';
+import { annotateReachability } from './tools/reachability';
 import {
   CODE_PATTERNS,
   COVERAGE,
@@ -627,6 +628,15 @@ async function gatherCapabilityReport(
     available: licensesWithAvail.available,
     unavailableReason: licensesWithAvail.unavailableReason,
   };
+
+  // Dep-vuln reachability for the guardrail path (T1.2). The enriched
+  // standalone scan annotates inside gatherDepVulns; this path reuses
+  // the imports envelope the scope.imports gather above already
+  // produced — same ONE annotation entry point (Rule 2), no second
+  // IMPORTS dispatch. Without this the `newHighReachableDependencyVulnerability`
+  // block rule was structurally dead on the check path: `f.reachable`
+  // was never computed, so the classifier's evidence never existed.
+  annotateReachability(depVulnsWithAvail.envelope?.findings ?? [], imports);
 
   // G_v4_8 (C1.3): build the canonical aggregate from everything we
   // just gathered, plus the two security finders not represented in

--- a/src/analyzers/quality/gather.ts
+++ b/src/analyzers/quality/gather.ts
@@ -13,6 +13,7 @@
  *   grep      → hygiene markers (TODO, FIXME, HACK, console.log)
  */
 import { run } from '../tools/runner';
+import { isExcludedPath } from '../tools/exclusions';
 import { findTool, TOOL_DEFS } from '../tools/tool-registry';
 import { gatherClocMetrics } from '../tools/cloc';
 import { walkSourceFiles, countLineMatches } from '../tools/walk-source-files';
@@ -190,12 +191,23 @@ export function gatherHygieneMarkers(cwd: string): {
   staleFiles: string[];
   mixedLanguages: boolean;
 } {
-  // Stale files: vim swap, backup, temp files tracked in git
+  // Stale files: vim swap, backup, temp files tracked in git. The glob
+  // pathspecs match tracked files ANYWHERE in the tree — including a
+  // committed/vendored node_modules — so the list is filtered through the
+  // ONE exclusion predicate (Rule 4). The shipped bug: a repo with
+  // node_modules in git got `node_modules/**/*.orig` flagged as net-new
+  // stale files the developer never touched (the baseline's install tree
+  // differed from CI's).
   const staleRaw = run(
     `git ls-files '*.swp' '*.swo' '*.bak' '*.orig' '*.tmp' '*.log' '*.pyc'`,
     cwd,
   );
-  const staleFiles = staleRaw ? staleRaw.split('\n').filter((l) => l.trim()) : [];
+  const staleFiles = staleRaw
+    ? staleRaw
+        .split('\n')
+        .filter((l) => l.trim())
+        .filter((rel) => !isExcludedPath(cwd, rel))
+    : [];
 
   // Mixed languages: .js files alongside .ts in same source directories (not config files at root)
   const jsInSrc = run(

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -15,7 +15,7 @@ import { enrichEpss, extractCveId } from '../tools/epss';
 import { spanHash, stampFingerprints } from '../tools/fingerprint';
 import { enrichKev } from '../tools/kev';
 import { resolveAliases } from '../tools/osv';
-import { buildReachablePackageSet, markReachable } from '../tools/reachability';
+import { annotateReachability } from '../tools/reachability';
 import { scoreFindings } from '../tools/risk-score';
 import { resolveTransitiveUpgradePlans } from '../tools/upgrade-plan-resolver';
 import { externalToSecurityFindings } from '../../ingest/normalize';
@@ -508,10 +508,7 @@ export async function gatherDepVulns(cwd: string): Promise<DepVulnSummary> {
     const importsProviders = providersFor(IMPORTS);
     if (importsProviders.length > 0) {
       const importsEnvelope = await defaultDispatcher.gather(cwd, IMPORTS, importsProviders);
-      if (importsEnvelope && importsEnvelope.extracted.size > 0) {
-        const reachable = buildReachablePackageSet(importsEnvelope);
-        markReachable(findings, reachable);
-      }
+      annotateReachability(findings, importsEnvelope);
     }
 
     // Cross-pack upgrade-plan resolver (Phase 10h.6.4). Runs after

--- a/src/analyzers/tools/bounded-exec.ts
+++ b/src/analyzers/tools/bounded-exec.ts
@@ -52,15 +52,45 @@ export interface RunnableCommand {
  * be wrongly treated as missing and the check skipped (fail-open on a tool that
  * IS present) — so this keeps the fail-open gate honest.
  */
-export function binaryAvailable(bin: string): boolean {
+export function binaryAvailable(bin: string, cwd?: string): boolean {
   if (bin.includes('/') || bin.includes(path.sep)) {
+    // A relative bin (`./gradlew`) is relative to the COMMAND's cwd, not
+    // dxkit's process cwd — the two differ under the Stop-gate and any
+    // multi-repo caller.
+    const resolved = cwd ? path.resolve(cwd, bin) : bin;
     try {
-      return fs.statSync(bin).isFile();
+      if (!fs.statSync(resolved).isFile()) return false;
+      // Present but not RUNNABLE is not available: a committed wrapper
+      // script without the executable bit (`git add gradlew` from Windows)
+      // spawns EACCES in ~0ms, which used to read as "compile failed" with
+      // empty output — an environment problem reported as broken code.
+      fs.accessSync(resolved, fs.constants.X_OK);
+      return true;
     } catch {
       return false;
     }
   }
   return commandExists(bin);
+}
+
+/**
+ * WHY a bin is unavailable, for disclosure (never a silent skip — Rule 20).
+ * Distinguishes the actionable case: the file exists but is not executable,
+ * which has a one-line repo-side remedy.
+ */
+export function explainUnavailable(bin: string, cwd?: string): string {
+  if (bin.includes('/') || bin.includes(path.sep)) {
+    const resolved = cwd ? path.resolve(cwd, bin) : bin;
+    try {
+      if (fs.statSync(resolved).isFile()) {
+        return `${bin} exists but is not executable — restore the executable bit (chmod +x ${bin}; committed to git: git update-index --chmod=+x ${bin})`;
+      }
+    } catch {
+      /* fall through */
+    }
+    return `${bin} not found`;
+  }
+  return `${bin} is not on PATH`;
 }
 
 /** Outcome of running one command:
@@ -104,7 +134,9 @@ const OUTPUT_TAIL = 4000; // display cap — applied by RENDERERS, never at capt
  */
 export function makeCommandExec(timeoutMs?: number): CommandExec {
   return (cmd, cwd) => {
-    if (!binaryAvailable(cmd.bin)) return { available: false, code: -1, output: '' };
+    if (!binaryAvailable(cmd.bin, cwd)) {
+      return { available: false, code: -1, output: explainUnavailable(cmd.bin, cwd) };
+    }
     try {
       const out = execFileSync(cmd.bin, [...cmd.args], {
         cwd,
@@ -139,9 +171,27 @@ export function makeCommandExec(timeoutMs?: number): CommandExec {
       if (err.code === 'ENOBUFS') {
         return { available: true, overflowed: true, code: -1, output: combined };
       }
-      // A non-numeric status (spawn error, non-timeout signal) is treated as a
-      // failure with code 1 — the binary existed (binaryAvailable passed) but the
-      // run broke.
+      // A spawn-level errno (EACCES / ENOENT / EPERM / ENOTDIR — status is not
+      // a number, no signal, and the child produced no output) means the
+      // command never RAN. That is infrastructure, not broken code: fail-OPEN
+      // as unavailable, with the errno named so the skip is disclosed. Without
+      // this, a non-executable ./gradlew "failed the compile" in 0.2s with
+      // empty output on a real onboarding gate.
+      if (
+        typeof err.status !== 'number' &&
+        !err.signal &&
+        typeof err.code === 'string' &&
+        combined === ''
+      ) {
+        return {
+          available: false,
+          code: -1,
+          output: `${err.code}: ${cmd.bin} could not be executed — ${explainUnavailable(cmd.bin, cwd)}`,
+        };
+      }
+      // A non-numeric status otherwise (non-timeout signal) is treated as a
+      // failure with code 1 — the binary existed (binaryAvailable passed), the
+      // run started, and it broke.
       return {
         available: true,
         code: typeof err.status === 'number' ? err.status : 1,

--- a/src/analyzers/tools/install-exec.ts
+++ b/src/analyzers/tools/install-exec.ts
@@ -86,6 +86,38 @@ export function recordToolDep(cwd: string, pkg: string): void {
   }
 }
 
+/**
+ * The ONE verified-download primitive (T2.1). Install commands never raw
+ * `curl | tar`; they call `dxkit_fetch <url> <sha256> <dest>`, which
+ * downloads to a temp file, verifies the sha256 against the registry-pinned
+ * value, and only then moves the artifact into place. FAIL CLOSED: a
+ * mismatch deletes the download and exits non-zero with both hashes named —
+ * a tampered or substituted artifact is never executed or extracted. The
+ * function is prepended to any install command that references it, so the
+ * pinned hash lives in ONE place per artifact (the tool registry) and the
+ * verification logic lives here.
+ */
+export const DXKIT_FETCH_PREAMBLE = `dxkit_fetch() {
+  _dxkit_url="$1"; _dxkit_sha="$2"; _dxkit_dest="$3"
+  _dxkit_tmp="$(mktemp)" || return 1
+  if ! curl -sSfL "$_dxkit_url" -o "$_dxkit_tmp"; then
+    echo "dxkit: download failed: $_dxkit_url" >&2; rm -f "$_dxkit_tmp"; return 1
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    _dxkit_got="$(sha256sum "$_dxkit_tmp" | awk '{print $1}')"
+  else
+    _dxkit_got="$(shasum -a 256 "$_dxkit_tmp" | awk '{print $1}')"
+  fi
+  if [ "$_dxkit_got" != "$_dxkit_sha" ]; then
+    echo "dxkit: checksum mismatch for $_dxkit_url" >&2
+    echo "  expected: $_dxkit_sha" >&2
+    echo "  got:      $_dxkit_got" >&2
+    echo "  refusing to install an artifact that does not match the pinned hash." >&2
+    rm -f "$_dxkit_tmp"; return 1
+  fi
+  mv "$_dxkit_tmp" "$_dxkit_dest"
+}`;
+
 function runInstallCmd(
   cmd: string,
   envOverlay?: Record<string, string>,
@@ -98,6 +130,12 @@ function runInstallCmd(
     // path doesn't exist there, which made every `tools install` fail
     // outright).
     const shell = process.platform === 'win32' ? undefined : '/bin/bash';
+    // Checksum-verified downloads: define the fetch helper for commands
+    // that use it. POSIX-shell only; Windows commands go through package
+    // managers (winget/scoop) or carry their own PowerShell verification.
+    if (cmd.includes('dxkit_fetch ') && process.platform !== 'win32') {
+      cmd = `${DXKIT_FETCH_PREAMBLE}\n${cmd}`;
+    }
     // Quiet mode (the init finishing arc): capture the child's output instead
     // of inheriting it, so a package manager's install noise doesn't bleed
     // through the step UI. On failure the captured text becomes the message.

--- a/src/analyzers/tools/reachability.ts
+++ b/src/analyzers/tools/reachability.ts
@@ -100,3 +100,21 @@ export function markReachable(findings: DepVulnFinding[], reachable: ReadonlySet
     f.reachable = reachable.has(f.package);
   }
 }
+
+/**
+ * The ONE reachability-annotation entry point (Rule 2): given an
+ * already-gathered IMPORTS envelope, mark every finding. Consumed by
+ * BOTH the standalone enriched scan (`gatherDepVulns`, which dispatches
+ * IMPORTS itself) and the guardrail/health path (which reuses the
+ * envelope its own scope.imports gather produced). An absent or empty
+ * envelope leaves `reachable` UNSET on every finding — "reachability
+ * unknown", never mass-`false` (an unknown must not disarm the
+ * high-reachable block rule's evidence, nor fabricate it).
+ */
+export function annotateReachability(
+  findings: DepVulnFinding[],
+  imports: ImportsResult | null | undefined,
+): void {
+  if (!imports || imports.extracted.size === 0) return;
+  markReachable(findings, buildReachablePackageSet(imports));
+}

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -1214,7 +1214,7 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
       linux:
         'mkdir -p "$HOME/.cache/dxkit" && t="$(mktemp)" && dxkit_fetch https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.26.1/codeql-bundle-linux64.tar.gz 38eca75ea296a6c48c52aff942b0678f06d3367140a5aa18caf80176943422ba "$t" && tar xzf "$t" -C "$HOME/.cache/dxkit" && rm -f "$t" && mkdir -p "$HOME/.local/bin" && ln -sf "$HOME/.cache/dxkit/codeql/codeql" "$HOME/.local/bin/codeql"',
       windows:
-        'powershell -Command "New-Item -ItemType Directory -Force $HOME/.cache/dxkit; Invoke-WebRequest -Uri https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.26.1/codeql-bundle-win64.tar.gz -OutFile $env:TEMP/codeql.tar.gz; if ((Get-FileHash -Algorithm SHA256 $env:TEMP/codeql.tar.gz).Hash -ne \'CA630F02E0BCF4F35F5C39159E82A794F1F598FF8DF51F32BA1D20A9BFD75CBB\') { Remove-Item $env:TEMP/codeql.tar.gz; throw \'dxkit: checksum mismatch for codeql-bundle-win64.tar.gz — refusing to install\' }; tar xz -C $HOME/.cache/dxkit -f $env:TEMP/codeql.tar.gz"',
+        "powershell -Command \"New-Item -ItemType Directory -Force $HOME/.cache/dxkit; Invoke-WebRequest -Uri https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.26.1/codeql-bundle-win64.tar.gz -OutFile $env:TEMP/codeql.tar.gz; if ((Get-FileHash -Algorithm SHA256 $env:TEMP/codeql.tar.gz).Hash -ne 'CA630F02E0BCF4F35F5C39159E82A794F1F598FF8DF51F32BA1D20A9BFD75CBB') { Remove-Item $env:TEMP/codeql.tar.gz; throw 'dxkit: checksum mismatch for codeql-bundle-win64.tar.gz — refusing to install' }; tar xz -C $HOME/.cache/dxkit -f $env:TEMP/codeql.tar.gz\"",
     },
   },
 };

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -609,9 +609,10 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     versionCheck: 'gitleaks version',
     installCommands: {
       macos: 'brew install gitleaks',
-      // Install to ~/.local/bin (user path, no sudo)
+      // Install to ~/.local/bin (user path, no sudo). sha256 pinned from the
+      // publisher's gitleaks_8.24.0_checksums.txt (T2.1 — verified download).
       linux:
-        'mkdir -p ~/.local/bin && curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.24.0/gitleaks_8.24.0_linux_x64.tar.gz | tar xz -C ~/.local/bin gitleaks && chmod +x ~/.local/bin/gitleaks',
+        'mkdir -p ~/.local/bin && t="$(mktemp)" && dxkit_fetch https://github.com/gitleaks/gitleaks/releases/download/v8.24.0/gitleaks_8.24.0_linux_x64.tar.gz cb49b7de5ee986510fe8666ca0273a6cc15eb82571f2f14832c9e8920751f3a4 "$t" && tar xzf "$t" -C ~/.local/bin gitleaks && rm -f "$t" && chmod +x ~/.local/bin/gitleaks',
       windows: 'scoop install gitleaks',
     },
   },
@@ -750,11 +751,11 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
       macos:
         'brew install osv-scanner || ' +
         '(mkdir -p ~/.local/bin && ' +
-        'curl -sSfL https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_darwin_amd64 -o ~/.local/bin/osv-scanner && ' +
+        'dxkit_fetch https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_darwin_amd64 b8a80a9f14ca4c0cd0fc2d351b28f740da9e6a5b18385ac9f9d083360b5b504e ~/.local/bin/osv-scanner && ' +
         'chmod +x ~/.local/bin/osv-scanner)',
       linux:
         'mkdir -p ~/.local/bin && ' +
-        'curl -sSfL https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64 -o ~/.local/bin/osv-scanner && ' +
+        'dxkit_fetch https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64 bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc ~/.local/bin/osv-scanner && ' +
         'chmod +x ~/.local/bin/osv-scanner',
       windows: 'scoop install osv-scanner',
     },
@@ -945,11 +946,15 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     // the repo's DETECTED .NET version at resolve time, so a .NET 9 repo gets a
     // .NET 9 SDK — not a hardcoded 8.0. (Onboarding cluster: sudo-apt + wrong
     // major shipped an auto-bootstrap that was broken on the common non-root box.)
+    // The installer SCRIPT is fetched from a PINNED dotnet/install-scripts
+    // commit and sha256-verified before bash sees it (T2.1): the mutable
+    // https://dot.net/v1/ URL piped straight to bash was the sharpest
+    // supply-chain edge in the registry. Bumping = new commit + new hash.
     installCommands: {
       macos:
-        'curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel __DOTNET_CHANNEL__ --install-dir "$HOME/.dotnet"',
+        't="$(mktemp)" && dxkit_fetch https://raw.githubusercontent.com/dotnet/install-scripts/da3ce11ba63f3dbb0fb835d41bda2665d5c48e84/src/dotnet-install.sh 082f7685e156738a1b2e2ed8381a621870d4ce8e8c59278034556f05c186eb2e "$t" && bash "$t" --channel __DOTNET_CHANNEL__ --install-dir "$HOME/.dotnet"; r=$?; rm -f "$t"; exit $r',
       linux:
-        'curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel __DOTNET_CHANNEL__ --install-dir "$HOME/.dotnet"',
+        't="$(mktemp)" && dxkit_fetch https://raw.githubusercontent.com/dotnet/install-scripts/da3ce11ba63f3dbb0fb835d41bda2665d5c48e84/src/dotnet-install.sh 082f7685e156738a1b2e2ed8381a621870d4ce8e8c59278034556f05c186eb2e "$t" && bash "$t" --channel __DOTNET_CHANNEL__ --install-dir "$HOME/.dotnet"; r=$?; rm -f "$t"; exit $r',
       windows: 'winget install Microsoft.DotNet.SDK.__DOTNET_MAJOR__',
     },
   },
@@ -993,7 +998,7 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     installCommands: {
       macos: 'brew install pmd',
       linux:
-        'mkdir -p ~/.local/share/pmd ~/.local/bin && curl -sSfL -o /tmp/pmd.zip "https://github.com/pmd/pmd/releases/download/pmd_releases%2F7.24.0/pmd-dist-7.24.0-bin.zip" && unzip -q -o /tmp/pmd.zip -d ~/.local/share/pmd && chmod +x ~/.local/share/pmd/pmd-bin-7.24.0/bin/pmd && ln -sf ~/.local/share/pmd/pmd-bin-7.24.0/bin/pmd ~/.local/bin/pmd',
+        'mkdir -p ~/.local/share/pmd ~/.local/bin && t="$(mktemp)" && dxkit_fetch "https://github.com/pmd/pmd/releases/download/pmd_releases%2F7.24.0/pmd-dist-7.24.0-bin.zip" 110934b36d39c19094d1b77386931978093f238f2c2f1851748822b69c7367ac "$t" && unzip -q -o "$t" -d ~/.local/share/pmd && rm -f "$t" && chmod +x ~/.local/share/pmd/pmd-bin-7.24.0/bin/pmd && ln -sf ~/.local/share/pmd/pmd-bin-7.24.0/bin/pmd ~/.local/bin/pmd',
       windows: 'scoop install pmd',
     },
   },
@@ -1019,7 +1024,7 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     installCommands: {
       macos: 'brew install detekt',
       linux:
-        'mkdir -p ~/.local/share/detekt ~/.local/bin && curl -sSfL -o /tmp/detekt-cli.zip https://github.com/detekt/detekt/releases/download/v1.23.6/detekt-cli-1.23.6.zip && unzip -q -o /tmp/detekt-cli.zip -d ~/.local/share/detekt && chmod +x ~/.local/share/detekt/detekt-cli-1.23.6/bin/detekt-cli && ln -sf ~/.local/share/detekt/detekt-cli-1.23.6/bin/detekt-cli ~/.local/bin/detekt-cli && ln -sf ~/.local/share/detekt/detekt-cli-1.23.6/bin/detekt-cli ~/.local/bin/detekt',
+        'mkdir -p ~/.local/share/detekt ~/.local/bin && t="$(mktemp)" && dxkit_fetch https://github.com/detekt/detekt/releases/download/v1.23.6/detekt-cli-1.23.6.zip 6b4d41865b58baaff5ff931726b637cc3c2434f4c4f89b900b5829016d244abd "$t" && unzip -q -o "$t" -d ~/.local/share/detekt && rm -f "$t" && chmod +x ~/.local/share/detekt/detekt-cli-1.23.6/bin/detekt-cli && ln -sf ~/.local/share/detekt/detekt-cli-1.23.6/bin/detekt-cli ~/.local/bin/detekt-cli && ln -sf ~/.local/share/detekt/detekt-cli-1.23.6/bin/detekt-cli ~/.local/bin/detekt',
       windows: 'scoop install detekt',
     },
   },
@@ -1125,8 +1130,10 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     // their own version (mirrors detekt, ktlint's sibling Kotlin linter).
     installCommands: {
       macos: 'brew install ktlint',
+      // Verified download to ~/.local/bin — no sudo (the old command moved
+      // it to /usr/local/bin with sudo, which dies on sudo-less CI anyway).
       linux:
-        'curl -sSLO https://github.com/pinterest/ktlint/releases/download/1.5.0/ktlint && chmod a+x ktlint && sudo mv ktlint /usr/local/bin/',
+        'mkdir -p ~/.local/bin && dxkit_fetch https://github.com/pinterest/ktlint/releases/download/1.5.0/ktlint a16be01dcc480aab2f55f444b620142152f66e31564b3b9376506d624c28a2ad ~/.local/bin/ktlint && chmod a+x ~/.local/bin/ktlint',
       windows: 'scoop install ktlint',
     },
   },
@@ -1198,12 +1205,16 @@ export const TOOL_DEFS: Record<string, ToolDefinition> = {
     installCommands: {
       // Download the CodeQL bundle (CLI + precompiled query packs) into
       // the dxkit cache and symlink the launcher onto the user path.
+      // Pinned to codeql-bundle-v2.26.1 with publisher-issued sha256s
+      // (the release's *.checksum.txt assets) — the old `releases/latest`
+      // URL was both unpinned AND unverifiable (T2.1). Bumping = new tag
+      // + the three new published checksums.
       macos:
-        'mkdir -p "$HOME/.cache/dxkit" && curl -sSfL https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-osx64.tar.gz | tar xz -C "$HOME/.cache/dxkit" && mkdir -p "$HOME/.local/bin" && ln -sf "$HOME/.cache/dxkit/codeql/codeql" "$HOME/.local/bin/codeql"',
+        'mkdir -p "$HOME/.cache/dxkit" && t="$(mktemp)" && dxkit_fetch https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.26.1/codeql-bundle-osx64.tar.gz 49a4514336f1c155d8c54eb94c2445ff1ea7b4ff0bb61af5b3749d9a82fb27f9 "$t" && tar xzf "$t" -C "$HOME/.cache/dxkit" && rm -f "$t" && mkdir -p "$HOME/.local/bin" && ln -sf "$HOME/.cache/dxkit/codeql/codeql" "$HOME/.local/bin/codeql"',
       linux:
-        'mkdir -p "$HOME/.cache/dxkit" && curl -sSfL https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-linux64.tar.gz | tar xz -C "$HOME/.cache/dxkit" && mkdir -p "$HOME/.local/bin" && ln -sf "$HOME/.cache/dxkit/codeql/codeql" "$HOME/.local/bin/codeql"',
+        'mkdir -p "$HOME/.cache/dxkit" && t="$(mktemp)" && dxkit_fetch https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.26.1/codeql-bundle-linux64.tar.gz 38eca75ea296a6c48c52aff942b0678f06d3367140a5aa18caf80176943422ba "$t" && tar xzf "$t" -C "$HOME/.cache/dxkit" && rm -f "$t" && mkdir -p "$HOME/.local/bin" && ln -sf "$HOME/.cache/dxkit/codeql/codeql" "$HOME/.local/bin/codeql"',
       windows:
-        'powershell -Command "New-Item -ItemType Directory -Force $HOME/.cache/dxkit; Invoke-WebRequest -Uri https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-win64.tar.gz -OutFile $env:TEMP/codeql.tar.gz; tar xz -C $HOME/.cache/dxkit -f $env:TEMP/codeql.tar.gz"',
+        'powershell -Command "New-Item -ItemType Directory -Force $HOME/.cache/dxkit; Invoke-WebRequest -Uri https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.26.1/codeql-bundle-win64.tar.gz -OutFile $env:TEMP/codeql.tar.gz; if ((Get-FileHash -Algorithm SHA256 $env:TEMP/codeql.tar.gz).Hash -ne \'CA630F02E0BCF4F35F5C39159E82A794F1F598FF8DF51F32BA1D20A9BFD75CBB\') { Remove-Item $env:TEMP/codeql.tar.gz; throw \'dxkit: checksum mismatch for codeql-bundle-win64.tar.gz — refusing to install\' }; tar xz -C $HOME/.cache/dxkit -f $env:TEMP/codeql.tar.gz"',
     },
   },
 };

--- a/src/analyzers/tools/tool-registry.ts
+++ b/src/analyzers/tools/tool-registry.ts
@@ -379,7 +379,14 @@ function findGraphifyPython(cwd: string): string | null {
  * Find a tool across multiple installation methods.
  * Returns the first matching absolute path, or null.
  */
-export function findTool(def: ToolDefinition, cwd?: string): ToolStatus {
+/** Options for `findTool`. `skipVersion` suppresses the `--version`
+ *  subprocess so pure path-probing callers (the Stop-gate's environment
+ *  signature stats the resolved binary instead) stay spawn-free. */
+export interface FindToolOptions {
+  readonly skipVersion?: boolean;
+}
+
+export function findTool(def: ToolDefinition, cwd?: string, opts?: FindToolOptions): ToolStatus {
   // Applicability gate runs first. Non-applicable tools (e.g.
   // vitest-coverage on a mocha repo) get an explicit "n/a" status so
   // they never inflate the missing-count.
@@ -425,7 +432,7 @@ export function findTool(def: ToolDefinition, cwd?: string): ToolStatus {
   // Node packages without a CLI binary (e.g. vitest plugins):
   if (def.nodePackage && cwd) {
     const pkgPath = findNodePackage(def.nodePackage, cwd);
-    if (pkgPath) return makeStatus(def, pkgPath, 'probe');
+    if (pkgPath) return makeStatus(def, pkgPath, 'probe', opts);
     // Nothing more to check — the package has no binary.
     return {
       name: def.name,
@@ -440,7 +447,7 @@ export function findTool(def: ToolDefinition, cwd?: string): ToolStatus {
   // Ruby gems without a CLI binary (e.g. SimpleCov):
   if (def.gemPackage) {
     const gemPath = findGemPackage(def.gemPackage);
-    if (gemPath) return makeStatus(def, gemPath, 'probe');
+    if (gemPath) return makeStatus(def, gemPath, 'probe', opts);
     return {
       name: def.name,
       available: false,
@@ -455,30 +462,30 @@ export function findTool(def: ToolDefinition, cwd?: string): ToolStatus {
     // 0. Project-local node_modules (for language tools)
     if (cwd && def.layer === 'language' && def.for === 'node') {
       const localResult = findInProjectNodeModules(binary, cwd);
-      if (localResult) return makeStatus(def, localResult, 'probe');
+      if (localResult) return makeStatus(def, localResult, 'probe', opts);
     }
 
     // 1. PATH
     const pathResult = findInPath(binary);
-    if (pathResult) return makeStatus(def, pathResult, 'path');
+    if (pathResult) return makeStatus(def, pathResult, 'path', opts);
 
     // 2. brew
     const brewResult = findInBrew(binary);
-    if (brewResult) return makeStatus(def, brewResult, 'brew');
+    if (brewResult) return makeStatus(def, brewResult, 'brew', opts);
 
     // 3. npm global
     const npmResult = findInNpmGlobal(binary);
-    if (npmResult) return makeStatus(def, npmResult, 'npm-g');
+    if (npmResult) return makeStatus(def, npmResult, 'npm-g', opts);
 
     // 4. pipx
     const pipxResult = findInPipx(binary);
-    if (pipxResult) return makeStatus(def, pipxResult, 'pipx');
+    if (pipxResult) return makeStatus(def, pipxResult, 'pipx', opts);
 
     // 4b. gem-installed binaries (ruby toolchain — system + --user-install
     // bin dirs discovered via `gem env`). Mirrors the pipx step for the
     // Ruby ecosystem.
     const gemResult = findInGemBin(binary);
-    if (gemResult) return makeStatus(def, gemResult, 'probe');
+    if (gemResult) return makeStatus(def, gemResult, 'probe', opts);
 
     // 5. System probe paths (includes cargo/go/graphify venv) plus any
     //    user-configured `.dxkit/tools.json:probePaths` — lets dxkit find
@@ -489,7 +496,7 @@ export function findTool(def: ToolDefinition, cwd?: string): ToolStatus {
       let source: ToolStatus['source'] = 'probe';
       if (probeResult.includes('/.cargo/')) source = 'cargo';
       else if (probeResult.includes('/go/bin/')) source = 'go';
-      return makeStatus(def, probeResult, source);
+      return makeStatus(def, probeResult, source, opts);
     }
   }
 
@@ -507,8 +514,9 @@ function makeStatus(
   def: ToolDefinition,
   binPath: string,
   source: ToolStatus['source'],
+  opts?: FindToolOptions,
 ): ToolStatus {
-  const version = def.versionCheck ? quickRun(def.versionCheck) : null;
+  const version = def.versionCheck && !opts?.skipVersion ? quickRun(def.versionCheck) : null;
   return {
     name: def.name,
     available: true,

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -27,6 +27,7 @@ import type { BaselineEntry, IdentitySchemeVersion } from './types';
 import type { SaltMode } from '../analyzers/tools/salt';
 import type { ScanCoverage } from './coverage';
 import type { RecallMap } from './recall';
+import type { FloorDebt } from './floor-debt';
 
 /** Banner stamped on every baseline file. Bump when the on-disk
  *  shape changes incompatibly so readers can refuse old / new files
@@ -152,6 +153,18 @@ export interface BaselineFile {
    *  Cleared once a complete environment (CI) re-captures the whole baseline.
    *  Optional: a baseline captured somewhere that observed everything omits it. */
   readonly deferred?: ReadonlyArray<DeferredCaptureClass>;
+  /** The correctness-floor state at capture time — the committed inventory
+   *  of pre-existing build/test debt (per check: reproduction command,
+   *  status, the actual error output). INFORMATIONAL ONLY: a failing floor
+   *  check is a signal, not a finding (Rule 15) — this envelope is never
+   *  read by the guardrail verdict, cannot be allowlisted, and does not
+   *  gate. It exists so cleanup agents can PRIORITIZE and fix the baseline
+   *  debt (`vyuh-dxkit debt`), with live floor runs as ground truth.
+   *  Optional: omitted when no active pack provides a floor, when capture
+   *  was skipped (`--no-floor` / DXKIT_BASELINE_NO_FLOOR=1), or on
+   *  baselines written before the field existed. Do NOT bump the schema
+   *  version for it — same graceful-degrade contract as `recall`. */
+  readonly floorDebt?: FloorDebt;
   /** Per-finding entries. Multiset — duplicates allowed (an
    *  identity appearing twice means two distinct occurrences). */
   readonly findings: ReadonlyArray<BaselineEntry>;

--- a/src/baseline/changed-files.ts
+++ b/src/baseline/changed-files.ts
@@ -61,3 +61,77 @@ export function computeChangedFiles(cwd: string, baseSha: string): ReadonlyArray
     return null; // any failure → full scan (safe default)
   }
 }
+
+/**
+ * Line-granularity sibling of `computeChangedFiles` — the ONE changed-line
+ * attribution the guardrail consults. Both live in this module because they
+ * are two projections of one concept ("what did the working tree change vs
+ * the base?") and MUST share a diff basis: base → WORKING TREE. The scan
+ * reads the working tree, so attribution that diffed committed HEAD instead
+ * demoted every finding an agent's uncommitted edit introduced (the 4.0.3
+ * T1.1 hole).
+ *
+ * Per file, `linesFor` answers one of:
+ *   - a set of working-tree line numbers changed vs base (tracked file);
+ *   - `'all'` — the file is untracked, so every line is new;
+ *   - `null` — attribution failed for this file. Callers must treat `null`
+ *     as UNKNOWN (do not demote), never as "nothing changed": under-reporting
+ *     here is a false negative in a safety gate.
+ */
+export interface ChangedLineIndex {
+  linesFor(file: string): ReadonlySet<number> | 'all' | null;
+}
+
+export function createChangedLineIndex(cwd: string, baseSha: string): ChangedLineIndex | null {
+  if (!baseSha) return null;
+  let untracked: Set<string>;
+  try {
+    untracked = new Set(gitLines(cwd, ['ls-files', '--others', '--exclude-standard']));
+  } catch {
+    return null; // attribution unavailable everywhere → callers see unknown
+  }
+  const cache = new Map<string, ReadonlySet<number> | 'all' | null>();
+  return {
+    linesFor(file: string) {
+      let hit = cache.get(file);
+      if (hit === undefined) {
+        hit = untracked.has(file) ? 'all' : readChangedLineSet(cwd, baseSha, file);
+        cache.set(file, hit);
+      }
+      return hit;
+    },
+  };
+}
+
+/**
+ * Working-tree line numbers modified since `baseSha` for `file`, from
+ * `git diff --unified=0` hunk headers (new-side `+start,count`). One-sided
+ * diff: base → working tree, staged + unstaged. Returns `null` on git
+ * failure (unknown, per the ChangedLineIndex contract).
+ */
+function readChangedLineSet(cwd: string, baseSha: string, file: string): Set<number> | null {
+  let diff: string;
+  try {
+    diff = execFileSync(
+      'git',
+      ['diff', '--unified=0', '--no-color', '--find-renames', baseSha, '--', file],
+      { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+    );
+  } catch {
+    return null;
+  }
+  const out = new Set<number>();
+  if (!diff.trim()) return out;
+  const hunkRe = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/gm;
+  let match: RegExpExecArray | null;
+  while ((match = hunkRe.exec(diff)) !== null) {
+    const newStart = parseInt(match[1], 10);
+    const newCount = match[2] !== undefined ? parseInt(match[2], 10) : 1;
+    if (newCount === 0) {
+      // Pure-deletion hunk on the new side — no new-side lines.
+      continue;
+    }
+    for (let i = 0; i < newCount; i++) out.add(newStart + i);
+  }
+  return out;
+}

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -451,7 +451,9 @@ export function partitionForRefBasedDiff<T extends { readonly kind: BaselineEntr
   };
 }
 
-const KIND_DEFAULT_SEVERITY: Readonly<Record<BaselineEntry['kind'], FindingSeverity>> =
+/** Canonical per-kind default severity (exported for the debt inventory —
+ *  the one severity table, never a second copy). */
+export const KIND_DEFAULT_SEVERITY: Readonly<Record<BaselineEntry['kind'], FindingSeverity>> =
   Object.freeze({
     secret: 'high',
     code: 'medium',

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -43,7 +43,6 @@
  * producer side was fixed.
  */
 
-import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { dxkitCli } from '../self-invocation';
@@ -66,7 +65,7 @@ import type { ClassifyContext, ClassifyResult } from './classify';
 import { hydrateAnchorFromBranch, loadAnchorFromBranch } from './anchor';
 import { gatherFromRef } from './ref-baseline';
 import { type GatherScope, FULL_SCOPE, scopeForPolicy, scopeForRefBasedDiff } from './gather-scope';
-import { computeChangedFiles } from './changed-files';
+import { computeChangedFiles, createChangedLineIndex } from './changed-files';
 import { changedFilesTouchDependencyManifest, detectActiveLanguages } from '../languages';
 import { describeRecallDrift, diffRecall } from './recall';
 import type { RecallDrift } from './recall';
@@ -694,17 +693,14 @@ export async function runGuardrailCheck(
   // hardcoded `buildToolsByKind` silently exclude every kind but five.
   const driftByKind = new Map(envelopeDrift.recallDrift.map((d) => [d.kind, d]));
 
-  const changedLineCache = new Map<string, Set<number>>();
-  const headSha = readHeadSha(cwd);
+  // Changed-line attribution vs the WORKING TREE (canonical index — the
+  // line-granularity sibling of computeChangedFiles, same diff basis). The
+  // scan reads the working tree, so attribution must too: diffing committed
+  // HEAD instead demoted every finding an uncommitted edit introduced.
   const baseSha = baseline.repo.commitSha;
-  const linesChangedFor = (file: string): Set<number> | undefined => {
-    if (!baseSha || !headSha) return undefined;
-    let cached = changedLineCache.get(file);
-    if (cached) return cached;
-    cached = readChangedLineSet(cwd, baseSha, headSha, file);
-    changedLineCache.set(file, cached);
-    return cached;
-  };
+  const changedLineIndex = createChangedLineIndex(cwd, baseSha);
+  const linesChangedFor = (file: string): ReadonlySet<number> | 'all' | null =>
+    changedLineIndex ? changedLineIndex.linesFor(file) : null;
 
   // Load the per-finding allowlist once. An active (unexpired) entry
   // whose fingerprint matches a would-block finding waives the block —
@@ -738,9 +734,13 @@ export async function runGuardrailCheck(
     const file = locatorFile(anchorEntry);
     const line = locatorLine(anchorEntry);
     const locator = describeEntryLocation(anchorEntry);
+    // `null` (attribution unavailable) maps to `undefined` — UNKNOWN must not
+    // demote (classify only demotes on a strict `false`). An untracked file
+    // ('all') overlaps at every line: the whole file is this change's work.
+    const changedInFile = file !== undefined ? linesChangedFor(file) : null;
     const overlapsChangedLines =
-      file !== undefined && line !== undefined && line > 0
-        ? (linesChangedFor(file)?.has(line) ?? false)
+      file !== undefined && line !== undefined && line > 0 && changedInFile !== null
+        ? changedInFile === 'all' || changedInFile.has(line)
         : undefined;
 
     const kindDrift = pair.status === 'added' ? driftByKind.get(anchorEntry.kind) : undefined;
@@ -753,7 +753,8 @@ export async function runGuardrailCheck(
     // so it outranks config_drift (a coincident policy.json edit must not
     // re-label a net-new finding on a new file). Non-empty changed-line set = the
     // file is in the diff (a brand-new file has all its lines added).
-    const fileChangedInDiff = file !== undefined && (linesChangedFor(file)?.size ?? 0) > 0;
+    const fileChangedInDiff =
+      changedInFile !== null && (changedInFile === 'all' || changedInFile.size > 0);
     // Dimension newly measured: the baseline held no findings of this kind, so
     // this one is unmatched because the gate/dimension was just enabled — a
     // truer reason than generic config_drift (gh #157). Reason-only.
@@ -1206,55 +1207,6 @@ function keepUnderChangedOnly(p: ClassifiedPair): boolean {
     p.classification.status === 'newly_detected';
   if (!isNewSide) return true;
   return p.overlapsChangedLines === true;
-}
-
-function readHeadSha(cwd: string): string {
-  try {
-    return execFileSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' }).trim();
-  } catch {
-    return '';
-  }
-}
-
-/**
- * Compute the set of HEAD-side line numbers modified between
- * `baseSha` and `headSha` for `file`. Used by the per-pair
- * `overlapsChangedLines` signal: a current-side finding at line N
- * overlaps the diff iff N is in this set.
- *
- * Walks `git diff --unified=0` hunks. Returns an empty set on any
- * failure (file missing in either revision, git unavailable, etc.).
- */
-function readChangedLineSet(
-  cwd: string,
-  baseSha: string,
-  headSha: string,
-  file: string,
-): Set<number> {
-  const out = new Set<number>();
-  let diff: string;
-  try {
-    diff = execFileSync(
-      'git',
-      ['diff', '--unified=0', '--no-color', '--find-renames', baseSha, headSha, '--', file],
-      { cwd, encoding: 'utf8' },
-    );
-  } catch {
-    return out;
-  }
-  if (!diff.trim()) return out;
-  const hunkRe = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/gm;
-  let match: RegExpExecArray | null;
-  while ((match = hunkRe.exec(diff)) !== null) {
-    const newStart = parseInt(match[1], 10);
-    const newCount = match[2] !== undefined ? parseInt(match[2], 10) : 1;
-    if (newCount === 0) {
-      // Pure-deletion hunk on the new side — no new-side lines.
-      continue;
-    }
-    for (let i = 0; i < newCount; i++) out.add(newStart + i);
-  }
-  return out;
 }
 
 /**

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -682,6 +682,7 @@ export async function runGuardrailCheck(
   const currentById = indexById(current.findings);
   const severityByCurrentId = buildSeverityIndex(current.aggregate);
   const maliciousByCurrentId = buildMaliciousIndex(current.aggregate);
+  const reachableByCurrentId = buildReachableIndex(current.aggregate);
   const envelopeDrift = diffEnvelopes(baseline, current);
 
   // Per-kind recall attribution (Rule 19) drives the per-pair `recallDrifted`
@@ -762,6 +763,8 @@ export async function runGuardrailCheck(
 
     const malicious =
       pair.currentId !== undefined && maliciousByCurrentId.has(pair.currentId) ? true : undefined;
+    const reachable =
+      pair.currentId !== undefined && reachableByCurrentId.has(pair.currentId) ? true : undefined;
 
     const context: ClassifyContext = {
       severity,
@@ -774,6 +777,7 @@ export async function runGuardrailCheck(
       ...(kindAbsentFromBaseline ? { kindAbsentFromBaseline: true } : {}),
       ...(overlapsChangedLines !== undefined ? { overlapsChangedLines } : {}),
       ...(malicious ? { malicious } : {}),
+      ...(reachable ? { reachable } : {}),
     };
 
     // `classify` is kind-agnostic; fold in the custom-check block INTENT (a
@@ -995,6 +999,25 @@ function buildMaliciousIndex(aggregate: SecurityAggregate): Set<FindingId> {
   const out = new Set<FindingId>();
   for (const f of aggregate.findingsByCategory.dependency) {
     if (f.fingerprint && isMaliciousAdvisory(f)) out.add(f.fingerprint);
+  }
+  return out;
+}
+
+/**
+ * Fingerprints of current-scan dependency findings the import graph marks
+ * REACHABLE — the `newHighReachableDependencyVulnerability` block rule's
+ * evidence. Mirror of `buildMaliciousIndex` (current side only, same
+ * rationale). `f.reachable` is annotated by the ONE entry point
+ * (`annotateReachability`) on both the standalone and the guardrail
+ * gather paths; when reachability was not computed (no imports gathered)
+ * the field is unset and the index stays empty — the rule then simply
+ * has no evidence, it never fabricates `false` or `true` (T1.2).
+ * Exported for the rule-liveness test.
+ */
+export function buildReachableIndex(aggregate: SecurityAggregate): Set<FindingId> {
+  const out = new Set<FindingId>();
+  for (const f of aggregate.findingsByCategory.dependency) {
+    if (f.fingerprint && f.reachable === true) out.add(f.fingerprint);
   }
   return out;
 }

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -61,6 +61,7 @@ import { entryToAllowlistable, partitionByActiveAllowlist } from './allowlist-ma
 import type { RichBaselineEntry } from './types';
 import { CURRENT_IDENTITY_SCHEME } from './types';
 import type { SecurityAggregate } from '../analyzers/security/aggregator';
+import { captureFloorDebt, type FloorDebt } from './floor-debt';
 
 export interface CreateBaselineOptions {
   /** Repo root to baseline. Caller should pass an absolute path. */
@@ -87,6 +88,13 @@ export interface CreateBaselineOptions {
   /** Explicit CLI flag value for the ref (`--ref=<R>`). Only
    *  consulted when the resolved mode is `ref-based`. */
   readonly cliRef?: string;
+  /** Capture the correctness-floor debt envelope (compile + tests, full
+   *  scope, bounded per-check). Default ON — cleanup agents rely on the
+   *  envelope existing — with two opt-outs: pass `false` (the `--no-floor`
+   *  flag) or set DXKIT_BASELINE_NO_FLOOR=1 (the test suite does, so
+   *  hundreds of fixture baselines don't each run a floor pass). An
+   *  explicit option always wins over the env. */
+  readonly floor?: boolean;
 }
 
 /** Outcome of `createBaseline`. `path` and `file` are absent when
@@ -224,6 +232,11 @@ export function scanToBaselineFile(
     readonly findings: ReadonlyArray<RichBaselineEntry>;
     /** Injectable for deterministic tests; defaults to now. */
     readonly createdAt?: string;
+    /** Floor-debt envelope (informational — Rule 15; never gates). Only the
+     *  committed write supplies it: the ref-based prior side runs in a
+     *  throwaway worktree where the floor would mostly skip-unavailable,
+     *  and the guardrail never reads the envelope anyway. */
+    readonly floorDebt?: FloorDebt;
   },
 ): BaselineFile {
   return {
@@ -239,6 +252,7 @@ export function scanToBaselineFile(
     coverage: scan.coverage,
     // Omitted when empty — a complete capture keeps the pre-4.0.2 authoritative shape.
     ...(scan.deferred.length > 0 ? { deferred: scan.deferred } : {}),
+    ...(opts.floorDebt ? { floorDebt: opts.floorDebt } : {}),
     findings: opts.findings,
   };
 }
@@ -477,7 +491,13 @@ export async function createBaseline(
   const byCategory: Record<string, number> = {};
   for (const s of suppressions) byCategory[s.category] = (byCategory[s.category] ?? 0) + 1;
 
-  const richFile = scanToBaselineFile(scan, { name, findings: live });
+  // Floor-debt inventory (T2.3 follow-through): record the pre-existing
+  // build/test state WITH details so cleanup agents can prioritize and fix
+  // it (`vyuh-dxkit debt`). Bounded; never gates; explicit option beats env.
+  const captureFloor = options.floor ?? process.env.DXKIT_BASELINE_NO_FLOOR !== '1';
+  const floorDebt = captureFloor ? (captureFloorDebt(cwd) ?? undefined) : undefined;
+
+  const richFile = scanToBaselineFile(scan, { name, findings: live, floorDebt });
 
   const file = mode.mode === 'committed-sanitized' ? sanitizeFile(richFile) : richFile;
   writeBaselineFile(filePath, file);

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -19,8 +19,6 @@
  * registering a producer there, never an edit here.
  */
 
-import { execFileSync } from 'child_process';
-import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { gatherAnalysisResultBody } from '../analyzers/health';
@@ -31,7 +29,6 @@ import { checkAllTools } from '../analyzers/tools/tool-registry';
 import { detect } from '../detect';
 import { coverageFromToolStatuses } from './coverage';
 import type { ScanCoverage } from './coverage';
-import { VERSION as DXKIT_VERSION } from '../constants';
 import { clearToolVersionCache } from './tool-versions';
 export { clearToolVersionCache };
 import {
@@ -44,7 +41,7 @@ import type { BaselineAnalysisMeta, BaselineFile, BaselineRepoState } from './ba
 import { assessCaptureDeferral, type DeferredCaptureClass } from './deferral';
 import { resolveBaselineMode } from './modes';
 import type { ResolvedMode } from './modes';
-import { DEFAULT_BROWNFIELD_POLICY, loadPolicyFromCwd } from './policy';
+import { loadPolicyFromCwd } from './policy';
 import {
   customCheckRecallInputs,
   gatherCustomCheckFindings,
@@ -62,6 +59,7 @@ import type { RichBaselineEntry } from './types';
 import { CURRENT_IDENTITY_SCHEME } from './types';
 import type { SecurityAggregate } from '../analyzers/security/aggregator';
 import { captureFloorDebt, type FloorDebt } from './floor-debt';
+import { hashContent, readRepoState, buildAnalysisMeta } from './envelope-meta';
 
 export interface CreateBaselineOptions {
   /** Repo root to baseline. Caller should pass an absolute path. */
@@ -115,59 +113,6 @@ export interface CreateBaselineResult {
     readonly allowlisted: number;
     readonly byCategory: Readonly<Record<string, number>>;
   };
-}
-
-/** Hash used for baseline-envelope metadata fields (policy, ignore,
- *  toolchain, config). Distinct concern from finding-identity
- *  fingerprints — these never enter the matcher's identity space. */
-function hashContent(content: string): string {
-  return createHash('sha1').update(content).digest('hex').slice(0, 16); // fingerprint-helper-ok: envelope-metadata hash, not finding identity
-}
-
-/**
- * Read a small file's text content with the canonical "absent → ''"
- * convention. Treating absent files as the empty string keeps the
- * downstream metadata hash stable across runs where the file is
- * still missing.
- */
-function readOptionalFile(filePath: string): string {
-  try {
-    return fs.readFileSync(filePath, 'utf8');
-  } catch {
-    return '';
-  }
-}
-
-/** Resolve the absolute commit SHA + branch name of the working tree.
- *  Empty strings when the directory isn't a git repo — the rest of
- *  the orchestrator works fine, only the git-aware matcher loses its
- *  diff anchor on a future check. */
-function readRepoState(cwd: string): { commitSha: string; branch: string } {
-  const run = (...args: string[]): string => {
-    try {
-      return execFileSync('git', args, {
-        cwd,
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe'],
-      }).trim();
-    } catch {
-      return '';
-    }
-  };
-  return {
-    commitSha: run('rev-parse', 'HEAD'),
-    branch: run('rev-parse', '--abbrev-ref', 'HEAD'),
-  };
-}
-
-/** Build the analysis-environment hash bundle from the live repo. */
-function buildAnalysisMeta(cwd: string): BaselineAnalysisMeta {
-  const policyHash = hashContent(JSON.stringify(DEFAULT_BROWNFIELD_POLICY));
-  const ignoreHash = hashContent(readOptionalFile(path.join(cwd, '.dxkit-ignore')));
-  const configHash = hashContent(readOptionalFile(path.join(cwd, '.vyuh-dxkit.json')));
-  // toolchainHash is filled in by `createBaseline` once the
-  // per-tool version map has been resolved (depends on the gather).
-  return { dxkitVersion: DXKIT_VERSION, policyHash, ignoreHash, toolchainHash: '', configHash };
 }
 
 /**

--- a/src/baseline/envelope-meta.ts
+++ b/src/baseline/envelope-meta.ts
@@ -1,0 +1,70 @@
+/**
+ * Baseline ENVELOPE metadata — the repo/analysis-environment facts stamped
+ * on every `BaselineFile` (`repo.commitSha`/`branch`, the policy / ignore /
+ * config / toolchain hashes). Split from `create.ts` (which orchestrates
+ * the capture) so the envelope derivation is one small cohesive unit.
+ *
+ * These hashes are a distinct concern from finding-identity fingerprints
+ * (Rule 9): they never enter the matcher's identity space — they exist so
+ * the guardrail can tell "the environment moved" apart from "the developer
+ * changed something".
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { createHash } from 'crypto';
+import { execFileSync } from 'child_process';
+import { VERSION as DXKIT_VERSION } from '../constants';
+import { DEFAULT_BROWNFIELD_POLICY } from './policy';
+import type { BaselineAnalysisMeta } from './baseline-file';
+
+/** Hash used for baseline-envelope metadata fields (policy, ignore,
+ *  toolchain, config). */
+export function hashContent(content: string): string {
+  return createHash('sha1').update(content).digest('hex').slice(0, 16); // fingerprint-helper-ok: envelope-metadata hash, not finding identity
+}
+
+/**
+ * Read a small file's text content with the canonical "absent → ''"
+ * convention. Treating absent files as the empty string keeps the
+ * downstream metadata hash stable across runs where the file is
+ * still missing.
+ */
+function readOptionalFile(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+/** Resolve the absolute commit SHA + branch name of the working tree.
+ *  Empty strings when the directory isn't a git repo — the rest of
+ *  the orchestrator works fine, only the git-aware matcher loses its
+ *  diff anchor on a future check. */
+export function readRepoState(cwd: string): { commitSha: string; branch: string } {
+  const run = (...args: string[]): string => {
+    try {
+      return execFileSync('git', args, {
+        cwd,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).trim();
+    } catch {
+      return '';
+    }
+  };
+  return {
+    commitSha: run('rev-parse', 'HEAD'),
+    branch: run('rev-parse', '--abbrev-ref', 'HEAD'),
+  };
+}
+
+/** Build the analysis-environment hash bundle from the live repo.
+ *  `toolchainHash` is filled in by `createBaseline` once the per-tool
+ *  version map has been resolved (depends on the gather). */
+export function buildAnalysisMeta(cwd: string): BaselineAnalysisMeta {
+  const policyHash = hashContent(JSON.stringify(DEFAULT_BROWNFIELD_POLICY));
+  const ignoreHash = hashContent(readOptionalFile(path.join(cwd, '.dxkit-ignore')));
+  const configHash = hashContent(readOptionalFile(path.join(cwd, '.vyuh-dxkit.json')));
+  return { dxkitVersion: DXKIT_VERSION, policyHash, ignoreHash, toolchainHash: '', configHash };
+}

--- a/src/baseline/floor-debt.ts
+++ b/src/baseline/floor-debt.ts
@@ -1,0 +1,120 @@
+/**
+ * Floor DEBT — the committed, agent-readable inventory of the repo's
+ * pre-existing correctness-floor state (broken build, failing tests),
+ * captured at baseline time.
+ *
+ * # What this is, and deliberately is not
+ *
+ * A failing floor check is a pass/fail SIGNAL, not a finding (CLAUDE.md
+ * Rule 15): it carries no fingerprint, enters no matcher, and can never be
+ * allowlisted — you don't grandfather a syntax error by identity, you fix
+ * it. This envelope does not change that. It exists for the OTHER half of
+ * the adoption story: once the gates are armed and regressions are blocked,
+ * a cleanup agent needs a durable, detailed record of the debt it should
+ * burn down — WHICH checks were failing when the baseline was captured,
+ * with the reproduction command and the actual compiler/test output, not
+ * just "kotlin compile failed".
+ *
+ * The envelope is informational: the guardrail verdict never reads it. The
+ * gate's own comparison base is always LIVE (the loop's entry snapshot, the
+ * CI floor's merge-base run), because stored build errors go stale the
+ * moment anything changes. Consumers are told the same: `vyuh-dxkit debt`
+ * re-runs the floor for ground truth and uses this envelope for provenance
+ * ("failing since the baseline was captured") and prioritization.
+ *
+ * Capture is BOUNDED (a generous per-check budget) so `baseline create`
+ * cannot hang on a pathological suite; a check that exceeds it records
+ * honestly as `skipped-timeout`, never as pass or fail.
+ */
+import { execFileSync } from 'child_process';
+import { detectActiveLanguages } from '../languages';
+import type { LanguageSupport } from '../languages/types';
+import {
+  runCorrectnessFloor,
+  type CommandExec,
+  type CorrectnessStatus,
+} from '../analyzers/correctness/run';
+import { describeUnmetRequirement, hostOf } from '../execution';
+
+/** Per-check budget for baseline-time capture. Generous — this is a one-time
+ *  inventory pass, not a hook — but bounded, so a capture can never hang. */
+const BASELINE_FLOOR_TIMEOUT_MS = 600_000;
+
+/** One floor check as recorded in the baseline envelope. */
+export interface FloorDebtCheck {
+  readonly pack: string;
+  readonly label: string;
+  /** The reproduction command (bin + args) an agent runs to see the
+   *  failure itself. Empty for requirement-level skips. */
+  readonly command: string;
+  readonly status: CorrectnessStatus;
+  /** Captured output tail on `fail` (the actual compiler/test errors), or
+   *  the disclosed reason on an unavailable skip. */
+  readonly output?: string;
+  /** Human-phrased environment boundary on `skipped-environment` — what is
+   *  needed and where the check would run (Rule 20 disclosure). */
+  readonly unmet?: string;
+}
+
+/** The committed floor-debt envelope on a BaselineFile. */
+export interface FloorDebt {
+  readonly capturedAtCommit: string | null;
+  readonly capturedAt: string;
+  readonly checks: ReadonlyArray<FloorDebtCheck>;
+}
+
+/** The failing subset — the debt itself. */
+export function failingFloorDebt(debt: FloorDebt): ReadonlyArray<FloorDebtCheck> {
+  return debt.checks.filter((c) => c.status === 'fail');
+}
+
+/**
+ * Run the full-scope floor and record it as a debt envelope. Returns null
+ * when no active pack provides a floor (the envelope is then omitted — a
+ * repo with no floor has no floor debt, which is different from "all
+ * green"). `exec`/`packs`/`now` are injectable for tests.
+ */
+export function captureFloorDebt(
+  cwd: string,
+  opts: {
+    readonly exec?: CommandExec;
+    readonly packs?: readonly LanguageSupport[];
+    readonly timeoutMs?: number;
+    readonly now?: () => Date;
+  } = {},
+): FloorDebt | null {
+  const packs = (opts.packs ?? detectActiveLanguages(cwd)).filter((p) => p.correctness);
+  if (packs.length === 0) return null;
+  const result = runCorrectnessFloor({
+    cwd,
+    changedFiles: [],
+    scope: 'full',
+    packs,
+    timeoutMs: opts.timeoutMs ?? BASELINE_FLOOR_TIMEOUT_MS,
+    exec: opts.exec,
+  });
+  const host = hostOf();
+  const checks: FloorDebtCheck[] = result.checks.map((c) => ({
+    pack: c.pack as string,
+    label: c.label,
+    command: [c.bin, ...(c.args ?? [])].filter(Boolean).join(' '),
+    status: c.status,
+    ...(c.output !== undefined ? { output: c.output } : {}),
+    ...(c.unmet !== undefined ? { unmet: describeUnmetRequirement(c.unmet, host) } : {}),
+  }));
+  let capturedAtCommit: string | null = null;
+  try {
+    capturedAtCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    /* no commit / not a repo — informational field stays null */
+  }
+  return {
+    capturedAtCommit,
+    capturedAt: (opts.now?.() ?? new Date()).toISOString(),
+    checks,
+  };
+}

--- a/src/baseline/gather-scope.ts
+++ b/src/baseline/gather-scope.ts
@@ -39,7 +39,7 @@
  * gain the matching analyzer here or a real finding could be skipped — the
  * scope contract test pins this.
  */
-import type { BrownfieldPolicy } from './policy';
+import type { BrownfieldPolicy, BrownfieldBlockRules } from './policy';
 
 /**
  * One boolean per skippable analyzer. `true` = run it. The names mirror the
@@ -141,28 +141,6 @@ export function scopeSignature(s: GatherScope): string {
     .join('+');
 }
 
-/**
- * Derive the minimal gather scope a policy needs.
- *
- * The verdict can only be changed by a kind the policy BLOCKS, so the scope
- * tracks `evaluateBlockRules` (in `./policy.ts`) one-to-one:
- *
- *   newSecret                              → secrets
- *   newCriticalSecurity / newHighSecurity  → codePatterns
- *   newCritical/HighReachableDependency…   → depVulns
- *   newUntestedChangedSource               → testGaps
- *   newSevereQualityIssueInChangedFiles    → codePatterns + hygiene
- *
- * A non-empty `policy.block` list (statuses that block regardless of kind,
- * e.g. `full-debt`'s `['added']`) means any kind can block, so we cannot
- * skip anything → `FULL_SCOPE`.
- *
- * NB: `newHighReachableDependencyVulnerability` needs reachability, which the
- * guardrail's classifier never populates today (`context.reachable` is unset
- * on the check path), so it cannot actually fire — but we still scope in
- * `depVulns` for it so the mapping stays a faithful, future-proof mirror of
- * the rule table rather than relying on that downstream gap.
- */
 /** The finding kinds a ref-based diff structurally excludes, mapped to the
  *  scope flags of the analyzers that produce them. `secret-hmac` is absent
  *  deliberately: it is a companion output of the secrets analyzer, which
@@ -206,25 +184,59 @@ export function scopeForRefBasedDiff(scope: GatherScope): {
   return { scope: Object.freeze(next), skippedKinds: skipped };
 }
 
+/**
+ * The evidence each block rule needs, declared once (T1.2 class fix).
+ *
+ * A block rule is only alive when EVERY analyzer producing its evidence
+ * actually runs. The shipped bug: `newHighReachableDependencyVulnerability`
+ * was armed in both presets, scoped in `depVulns` — and was still
+ * structurally dead, because its reachability evidence comes from the
+ * IMPORTS gather, which the hand-maintained if-chain here never pulled in
+ * (and the check path never threaded). The rule table and the scope
+ * mapping were two projections of one concept in two places (Rule 2.30).
+ *
+ * This table is the ONE declaration. `scopeForPolicy` derives from it, and
+ * the `Record` over `keyof BrownfieldBlockRules` makes omission a COMPILE
+ * error: a new block rule cannot land without declaring which analyzers
+ * produce its evidence. `test/baseline/gather-scope.test.ts` additionally
+ * pins per-rule scope derivation both directions (armed ⇒ scoped,
+ * un-armed ⇒ not scoped).
+ */
+export const BLOCK_RULE_EVIDENCE: Record<
+  keyof BrownfieldBlockRules,
+  ReadonlyArray<keyof GatherScope>
+> = Object.freeze({
+  newSecret: ['secrets'],
+  newCriticalSecurity: ['codePatterns'],
+  newHighSecurity: ['codePatterns'],
+  newCriticalDependencyVulnerability: ['depVulns'],
+  // Reachability evidence = the import graph. Without `imports` the
+  // classifier can never see `reachable === true` and the rule is dead.
+  newHighReachableDependencyVulnerability: ['depVulns', 'imports'],
+  newMaliciousDependency: ['depVulns'],
+  newUntestedChangedSource: ['testGaps'],
+  newSevereQualityIssueInChangedFiles: ['codePatterns', 'hygiene'],
+});
+
+/**
+ * Derive the minimal gather scope a policy needs.
+ *
+ * The verdict can only be changed by a kind the policy BLOCKS, so the scope
+ * is the union of `BLOCK_RULE_EVIDENCE[rule]` over the armed rules.
+ *
+ * A non-empty `policy.block` list (statuses that block regardless of kind,
+ * e.g. `full-debt`'s `['added']`) means any kind can block, so we cannot
+ * skip anything → `FULL_SCOPE`.
+ */
 export function scopeForPolicy(policy: BrownfieldPolicy): GatherScope {
   // Any status-based block applies across all kinds — nothing is safe to skip.
   if (policy.block.length > 0) return FULL_SCOPE;
 
   const r = policy.blockRules;
   const scope = { ...EMPTY_SCOPE };
-  if (r.newSecret) scope.secrets = true;
-  if (r.newCriticalSecurity || r.newHighSecurity) scope.codePatterns = true;
-  if (
-    r.newCriticalDependencyVulnerability ||
-    r.newHighReachableDependencyVulnerability ||
-    r.newMaliciousDependency
-  ) {
-    scope.depVulns = true;
-  }
-  if (r.newUntestedChangedSource) scope.testGaps = true;
-  if (r.newSevereQualityIssueInChangedFiles) {
-    scope.codePatterns = true;
-    scope.hygiene = true;
+  for (const rule of Object.keys(BLOCK_RULE_EVIDENCE) as Array<keyof BrownfieldBlockRules>) {
+    if (!r[rule]) continue;
+    for (const flag of BLOCK_RULE_EVIDENCE[rule]) scope[flag] = true;
   }
   // Custom checks gate via their own per-check `blocking` flag, not a status in
   // `policy.block`, so scope them in whenever the repo configured any — else the

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2895,7 +2895,13 @@ export async function run(argv: string[]): Promise<void> {
         if (outcome.blocks) {
           logger.fail(outcome.summary);
           for (const c of outcome.result?.checks.filter((c) => c.status === 'fail') ?? []) {
-            if (c.output) process.stdout.write(`\n[${c.pack} ${c.label}]\n${c.output}\n`);
+            // Never a bare label: a failure with no captured output is itself
+            // load-bearing information (the command produced nothing before
+            // exiting non-zero) — say so instead of printing nothing, which
+            // made a real onboarding gate failure undiagnosable from CI logs.
+            process.stdout.write(
+              `\n[${c.pack} ${c.label}] (${c.bin})\n${c.output || '(the command exited non-zero without producing any output)'}\n`,
+            );
           }
         } else {
           logger.success(outcome.summary);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -440,6 +440,7 @@ export async function run(argv: string[]): Promise<void> {
       correctness: { type: 'boolean' },
       'no-correctness': { type: 'boolean' },
       'no-floor': { type: 'boolean' },
+      'report-md': { type: 'string' },
       'keep-baselines': { type: 'boolean', default: false },
       'remove-devdep': { type: 'boolean', default: false },
       'no-feedback': { type: 'boolean', default: false },
@@ -2911,6 +2912,35 @@ export async function run(argv: string[]): Promise<void> {
           cwd: targetPath,
           base: values.base as string | undefined,
         });
+      }
+      // LOUD DISCLOSURE (never silent-in-a-log): a failing floor — even a
+      // pre-existing, non-blocking one — must reach the surfaces reviewers
+      // actually look at. One builder feeds all three: the PR comment (the
+      // workflow passes --report-md with the report file it posts), GitHub
+      // check annotations, and the run's step summary. A green floor emits
+      // nothing.
+      {
+        const { floorDisclosureMarkdown, githubAnnotations } =
+          await import('./analyzers/correctness/floor-disclosure');
+        const noise = floorDisclosureMarkdown(outcome);
+        const reportMd = values['report-md'] as string | undefined;
+        if (noise && reportMd) {
+          try {
+            fs.appendFileSync(reportMd, `\n${noise}\n`, 'utf8');
+          } catch {
+            /* best-effort: the annotations + summary below still fire */
+          }
+        }
+        if (process.env.GITHUB_ACTIONS === 'true') {
+          for (const a of githubAnnotations(outcome)) process.stdout.write(`${a}\n`);
+          if (noise && process.env.GITHUB_STEP_SUMMARY) {
+            try {
+              fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n${noise}\n`, 'utf8');
+            } catch {
+              /* best-effort */
+            }
+          }
+        }
       }
       if (values.json) {
         await emitJson({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2875,13 +2875,25 @@ export async function run(argv: string[]): Promise<void> {
         ?.split(',')
         .map((s) => s.trim())
         .filter(Boolean);
-      const outcome = runFloorForSurface({
+      let outcome = runFloorForSurface({
         surface: surfaceRaw,
         cwd: targetPath,
         base: values.base as string | undefined,
         flag,
         packIds,
       });
+      // Diff-scope the CI floor (T2.3): a failing ci run is attributed
+      // against the merge-base before it may block — pre-existing debt
+      // (an onboarding PR on a repo whose tests were already red) warns by
+      // name; only net-new failures block. Runs ONLY when the current side
+      // failed, so a green PR pays nothing extra.
+      if (surfaceRaw === 'ci' && outcome.blocks) {
+        const { attributeCiFloorOutcome } = await import('./analyzers/correctness/surface-run');
+        outcome = await attributeCiFloorOutcome(outcome, {
+          cwd: targetPath,
+          base: values.base as string | undefined,
+        });
+      }
       if (values.json) {
         await emitJson({
           surface: outcome.surface,
@@ -2890,11 +2902,30 @@ export async function run(argv: string[]): Promise<void> {
           blocks: outcome.blocks,
           reason: outcome.reason,
           checks: outcome.result?.checks ?? [],
+          ...(outcome.attributed
+            ? {
+                attribution: outcome.attributed.map((a) => ({
+                  pack: a.check.pack,
+                  label: a.check.label,
+                  attribution: a.attribution,
+                })),
+              }
+            : {}),
         });
       } else {
+        // With attribution, only NET-NEW failures print with full output —
+        // pre-existing/unattributed tiers are already named in the summary.
+        const failing =
+          outcome.attributed !== undefined
+            ? outcome.attributed.filter((a) => a.attribution === 'net-new').map((a) => a.check)
+            : (outcome.result?.checks.filter((c) => c.status === 'fail') ?? []);
         if (outcome.blocks) {
           logger.fail(outcome.summary);
-          for (const c of outcome.result?.checks.filter((c) => c.status === 'fail') ?? []) {
+        } else {
+          logger.success(outcome.summary);
+        }
+        if (outcome.blocks || outcome.attributed !== undefined) {
+          for (const c of failing) {
             // Never a bare label: a failure with no captured output is itself
             // load-bearing information (the command produced nothing before
             // exiting non-zero) — say so instead of printing nothing, which
@@ -2903,8 +2934,6 @@ export async function run(argv: string[]): Promise<void> {
               `\n[${c.pack} ${c.label}] (${c.bin})\n${c.output || '(the command exited non-zero without producing any output)'}\n`,
             );
           }
-        } else {
-          logger.success(outcome.summary);
         }
       }
       process.exit(outcome.blocks ? 1 : 0);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -439,6 +439,7 @@ export async function run(argv: string[]): Promise<void> {
       checks: { type: 'string' },
       correctness: { type: 'boolean' },
       'no-correctness': { type: 'boolean' },
+      'no-floor': { type: 'boolean' },
       'keep-baselines': { type: 'boolean', default: false },
       'remove-devdep': { type: 'boolean', default: false },
       'no-feedback': { type: 'boolean', default: false },
@@ -2464,6 +2465,8 @@ export async function run(argv: string[]): Promise<void> {
             verbose: !!values.verbose,
             cliMode: cliMode ?? undefined,
             cliRef: values.ref as string | undefined,
+            // --no-floor skips the floor-debt inventory (compile + tests).
+            ...(values['no-floor'] ? { floor: false } : {}),
           });
           const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
           logger.info(`Baseline ${result.mode.explanation}`);
@@ -2845,6 +2848,21 @@ export async function run(argv: string[]): Promise<void> {
         logger.dim(`  ${url}`);
         logger.dim('  (skip with --no-feedback)');
       }
+      process.exit(0);
+      break;
+    }
+
+    case 'debt': {
+      // The composed repair inventory for cleanup agents: live floor state
+      // (with baseline provenance) + fingerprinted finding debt, ordered by
+      // the one hard dependency (build → tests → findings by severity).
+      // Informational — always exits 0; the gates do the blocking.
+      const targetPath = resolveRepoPath(positionals[1]);
+      const { runDebtCli } = await import('./debt-cli');
+      await runDebtCli(targetPath, {
+        json: !!values.json,
+        name: values.name as string | undefined,
+      });
       process.exit(0);
       break;
     }

--- a/src/debt-cli.ts
+++ b/src/debt-cli.ts
@@ -1,0 +1,243 @@
+/**
+ * `vyuh-dxkit debt` — the one repair inventory a cleanup agent reads.
+ *
+ * The adoption arc this serves: arm the gates (regressions now block), then
+ * deploy agents to burn the BASELINE down — and "the baseline" is two
+ * different kinds of debt with two different homes:
+ *
+ *   - CORRECTNESS-FLOOR debt (broken build, failing tests). Never a
+ *     fingerprinted finding (Rule 15 — you fix a syntax error, you don't
+ *     grandfather it), so its ground truth is a LIVE floor run. The
+ *     baseline's `floorDebt` envelope supplies provenance: which failures
+ *     were already failing at capture ("baseline debt") vs appeared since
+ *     (the gate's business, but named here too so nothing hides).
+ *   - FINDING debt (secrets, CVEs, SAST, lint backlog…), fingerprinted in
+ *     the committed baseline file, ranked by severity.
+ *
+ * The output ends with a SUGGESTED ORDER, built on one hard dependency:
+ * while the build is broken, nothing else is reliably measurable — fix
+ * compilation first, then tests, then findings by severity. Environment-
+ * unobservable checks are listed with their remedy, never silently absent
+ * (Rule 20).
+ *
+ * Informational, never a gate: exit code is always 0. Composes existing
+ * canonical machinery only — `captureFloorDebt` (the same capture the
+ * baseline write uses), `checkKey` (the one floor-check identity), the
+ * baseline reader, and the canonical per-kind severity table.
+ */
+import * as fs from 'fs';
+import * as logger from './logger';
+import { pathForBaseline, readBaselineFile, type BaselineFile } from './baseline/baseline-file';
+import { captureFloorDebt, failingFloorDebt, type FloorDebt } from './baseline/floor-debt';
+import { checkKey } from './analyzers/correctness/attribution';
+import { KIND_DEFAULT_SEVERITY, describeEntryLocation } from './baseline/check';
+import type { BaselineEntry, FindingSeverity } from './baseline/types';
+
+const SEVERITY_RANK: Readonly<Record<FindingSeverity, number>> = Object.freeze({
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+});
+
+/** One live floor failure with its baseline provenance. */
+export interface DebtFloorFailure {
+  readonly pack: string;
+  readonly label: string;
+  readonly command: string;
+  readonly output?: string;
+  /** 'baseline' — already failing when the baseline was captured (the debt
+   *  to clean); 'new' — failing now but not then (the gate's business);
+   *  'unknown' — no baseline envelope to compare against. */
+  readonly sinceBaseline: 'baseline' | 'new' | 'unknown';
+}
+
+export interface DebtFindingGroup {
+  readonly kind: string;
+  readonly severity: FindingSeverity;
+  readonly count: number;
+  /** Up to three sample entries so an agent can orient without the file. */
+  readonly samples: ReadonlyArray<{ fingerprint: string; locator: string }>;
+}
+
+export interface DebtReport {
+  readonly schema: 'dxkit.debt.v1';
+  readonly baselinePresent: boolean;
+  readonly floor: {
+    readonly live: FloorDebt | null;
+    readonly baseline: FloorDebt | null;
+    readonly failures: ReadonlyArray<DebtFloorFailure>;
+    readonly fixedSinceBaseline: ReadonlyArray<string>;
+    readonly unobservable: ReadonlyArray<string>;
+  };
+  readonly findings: {
+    readonly total: number;
+    readonly groups: ReadonlyArray<DebtFindingGroup>;
+  };
+  readonly plan: ReadonlyArray<string>;
+}
+
+/** Build the composed debt report. Pure of process I/O; injectable floor
+ *  capture for tests. */
+export function buildDebtReport(
+  cwd: string,
+  opts: {
+    readonly name?: string;
+    readonly liveFloor?: (cwd: string) => FloorDebt | null;
+  } = {},
+): DebtReport {
+  const name = opts.name ?? 'main';
+  let baseline: BaselineFile | null = null;
+  try {
+    if (fs.existsSync(pathForBaseline(cwd, name))) {
+      baseline = readBaselineFile(pathForBaseline(cwd, name));
+    }
+  } catch {
+    baseline = null; // unreadable baseline → report proceeds without it
+  }
+
+  const live = (opts.liveFloor ?? captureFloorDebt)(cwd);
+  const storedFloor = baseline?.floorDebt ?? null;
+  const storedByKey = new Map(
+    (storedFloor?.checks ?? []).map((c) => [checkKey(c.pack, c.label), c.status]),
+  );
+
+  const failures: DebtFloorFailure[] = (live ? failingFloorDebt(live) : []).map((c) => {
+    const stored = storedByKey.get(checkKey(c.pack, c.label));
+    return {
+      pack: c.pack,
+      label: c.label,
+      command: c.command,
+      ...(c.output !== undefined ? { output: c.output } : {}),
+      sinceBaseline: storedFloor === null ? 'unknown' : stored === 'fail' ? 'baseline' : 'new',
+    };
+  });
+  const liveByKey = new Map((live?.checks ?? []).map((c) => [checkKey(c.pack, c.label), c]));
+  const fixedSinceBaseline = (storedFloor ? failingFloorDebt(storedFloor) : [])
+    .filter((c) => {
+      const now = liveByKey.get(checkKey(c.pack, c.label));
+      return now !== undefined && now.status === 'pass';
+    })
+    .map((c) => `${c.pack} ${c.label}`);
+  const unobservable = (live?.checks ?? [])
+    .filter((c) => c.status.startsWith('skipped') && (c.unmet || c.output))
+    .map((c) => `${c.pack} ${c.label}: ${c.unmet ?? c.output ?? ''}`);
+
+  const byKind = new Map<string, BaselineEntry[]>();
+  for (const e of baseline?.findings ?? []) {
+    const arr = byKind.get(e.kind) ?? [];
+    arr.push(e);
+    byKind.set(e.kind, arr);
+  }
+  const groups: DebtFindingGroup[] = [...byKind.entries()]
+    .map(([kind, entries]) => ({
+      kind,
+      severity: KIND_DEFAULT_SEVERITY[kind as BaselineEntry['kind']] ?? 'medium',
+      count: entries.length,
+      samples: entries.slice(0, 3).map((e) => ({
+        fingerprint: e.id,
+        locator: describeEntryLocation(e) || e.kind,
+      })),
+    }))
+    .sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity] || b.count - a.count);
+
+  // The one hard dependency the ordering encodes: a broken build makes
+  // everything downstream unmeasurable — fix it before anything else.
+  const plan: string[] = [];
+  const buildFailures = failures.filter((f) => !/test/i.test(f.label));
+  const testFailures = failures.filter((f) => /test/i.test(f.label));
+  if (buildFailures.length > 0) {
+    plan.push(
+      `Fix the build first — nothing else is reliably measurable until it compiles: ${buildFailures
+        .map((f) => `${f.pack} ${f.label} (${f.command})`)
+        .join('; ')}`,
+    );
+  }
+  if (testFailures.length > 0) {
+    plan.push(
+      `Fix the failing tests: ${testFailures
+        .map((f) => `${f.pack} ${f.label} (${f.command})`)
+        .join('; ')}`,
+    );
+  }
+  for (const g of groups) {
+    plan.push(
+      `Burn down ${g.count} ${g.kind} finding(s) (${g.severity}) — fingerprints in the baseline file`,
+    );
+  }
+  if (unobservable.length > 0) {
+    plan.push(
+      `Unmeasurable here (install the toolchain or rely on CI): ${unobservable.join('; ')}`,
+    );
+  }
+  if (plan.length === 0)
+    plan.push('No recorded debt — the floor is green and the baseline is empty.');
+
+  return {
+    schema: 'dxkit.debt.v1',
+    baselinePresent: baseline !== null,
+    floor: { live, baseline: storedFloor, failures, fixedSinceBaseline, unobservable },
+    findings: { total: baseline?.findings.length ?? 0, groups },
+    plan,
+  };
+}
+
+/** Console rendering of a debt report. */
+export function renderDebtConsole(report: DebtReport): string {
+  const lines: string[] = [];
+  lines.push('Repair inventory (informational — never gates; exit is always 0)');
+  lines.push('');
+  lines.push('CORRECTNESS FLOOR');
+  if (report.floor.live === null) {
+    lines.push('  no active language pack provides a floor');
+  } else if (report.floor.failures.length === 0) {
+    lines.push('  all measurable checks pass');
+  } else {
+    for (const f of report.floor.failures) {
+      const tag =
+        f.sinceBaseline === 'baseline'
+          ? 'failing since the baseline was captured'
+          : f.sinceBaseline === 'new'
+            ? 'NEW since the baseline (the gate blocks this as net-new)'
+            : 'no baseline envelope to compare against';
+      lines.push(`  ✗ ${f.pack} ${f.label} — ${tag}`);
+      lines.push(`      repro: ${f.command}`);
+      if (f.output) {
+        for (const l of f.output.split('\n').slice(-8)) lines.push(`      ${l}`);
+      }
+    }
+  }
+  if (report.floor.fixedSinceBaseline.length > 0) {
+    lines.push(`  fixed since baseline: ${report.floor.fixedSinceBaseline.join(', ')}`);
+  }
+  for (const u of report.floor.unobservable) lines.push(`  ~ ${u}`);
+  lines.push('');
+  lines.push(`FINDING DEBT (${report.findings.total} baselined finding(s))`);
+  for (const g of report.findings.groups) {
+    lines.push(`  ${g.severity.padEnd(8)} ${g.kind.padEnd(22)} ${g.count}`);
+  }
+  if (report.findings.groups.length === 0) {
+    lines.push(
+      report.baselinePresent
+        ? '  none — the baseline is clean'
+        : '  no baseline file — run `vyuh-dxkit baseline create` first',
+    );
+  }
+  lines.push('');
+  lines.push('SUGGESTED ORDER');
+  report.plan.forEach((p, i) => lines.push(`  ${i + 1}. ${p}`));
+  return lines.join('\n');
+}
+
+/** CLI entry: render (or emit JSON) and always exit 0 — a report, not a gate. */
+export async function runDebtCli(
+  cwd: string,
+  opts: { readonly json?: boolean; readonly name?: string },
+): Promise<void> {
+  const report = buildDebtReport(cwd, { name: opts.name });
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+  } else {
+    logger.info(renderDebtConsole(report));
+  }
+}

--- a/src/discovery/advisor.ts
+++ b/src/discovery/advisor.ts
@@ -135,6 +135,25 @@ export function recommendChecks(ctx: RecommendContext): Recommendation | null {
   };
 }
 
+/**
+ * Debt inventory: fires when the committed baseline carries recorded
+ * correctness-floor debt (a broken build / failing tests were grandfathered
+ * at capture). The gates keep the debt from growing; this points at the
+ * surface that inventories it for a cleanup pass. Reads the envelope only —
+ * never re-runs the floor (doctor stays fast).
+ */
+export function recommendDebt(ctx: RecommendContext): Recommendation | null {
+  const parsed = readJsonSafe(path.join(ctx.cwd, '.dxkit', 'baselines', 'main.json')) as {
+    floorDebt?: { checks?: Array<{ status?: string }> };
+  } | null;
+  const failing = (parsed?.floorDebt?.checks ?? []).filter((c) => c.status === 'fail').length;
+  if (failing === 0) return null; // no baseline / no envelope / all green
+  return {
+    reason: `the baseline grandfathered ${failing} failing correctness check(s) (broken build / failing tests) — inventory and burn the debt down while the gates hold the line`,
+    command: 'vyuh-dxkit debt',
+  };
+}
+
 // ─── Deterministic config planners (`vyuh-dxkit configure`) ──────────────────
 // Each is a PURE function of observable repo facts — same repo, same plan, every
 // run and every environment. That reproducibility is the whole point: the config

--- a/src/discovery/command-defs-internal.ts
+++ b/src/discovery/command-defs-internal.ts
@@ -1,0 +1,28 @@
+/** The INTERNAL-audience partition of the command registry (Rule 16):
+ *  machine-invoked plumbing — hook bodies, floor commands. Registered so
+ *  nothing is invisible ("internal" is a DECLARED status, not an
+ *  omission), but exempt from the user-facing discovery fields. Split
+ *  from `command-defs.ts` by audience; spread into `COMMANDS` there, so
+ *  the one registry (and the literal `CommandId` union) is unchanged. */
+import type { CapabilityDescriptor } from './command-types';
+
+export const INTERNAL_COMMANDS = [
+  {
+    id: 'context-hook',
+    audience: 'internal',
+    group: 'internal',
+    summary: 'Claude Code PreToolUse hook body (graph context injection)',
+  },
+  {
+    id: 'hook',
+    audience: 'internal',
+    group: 'internal',
+    summary: 'Claude Code lifecycle-hook bodies for the loop pack (stop-gate)',
+  },
+  {
+    id: 'floor',
+    audience: 'internal',
+    group: 'internal',
+    summary: 'Correctness-floor plumbing (snapshot / check) for the loop + hooks',
+  },
+] as const satisfies readonly CapabilityDescriptor[];

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -18,6 +18,7 @@ import {
   planLintGate,
   planLoopPreset,
   recommendExtensions,
+  recommendDebt,
   planFlowSources,
 } from './advisor';
 
@@ -350,6 +351,21 @@ export const COMMANDS = [
     skill: 'dxkit-loop',
     whenToRecommend: recommendLoopPreset,
     planConfig: planLoopPreset,
+  },
+  {
+    id: 'debt',
+    audience: 'user',
+    group: 'assess',
+    summary: 'The prioritized repair inventory: floor debt + finding debt',
+    typicalRuntime: 'varies (runs your compile + tests)',
+    docsBlurb:
+      'One agent-readable inventory of everything the baseline grandfathered: the correctness-floor ' +
+      'debt (broken build / failing tests, with reproduction commands and captured error output, ' +
+      'live-run and diffed against the baseline envelope) plus the fingerprinted finding debt by ' +
+      'severity — ordered into a repair plan (build first, then tests, then findings). ' +
+      'Informational: it never gates.',
+    skill: 'dxkit-action',
+    whenToRecommend: recommendDebt,
   },
   {
     id: 'checks',

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -1,6 +1,7 @@
 /** THE command registry data (CLAUDE.md Rule 16) — one descriptor per top-level
  *  CLI command; `commands.ts` re-exports `COMMANDS` + `CommandId` + helpers. */
 import type { CapabilityDescriptor } from './command-types';
+import { INTERNAL_COMMANDS } from './command-defs-internal';
 import {
   recommendConfigure,
   recommendBaseline,
@@ -482,25 +483,7 @@ export const COMMANDS = [
     docsBlurb: 'Render a dxkit JSON report into a 15-column spreadsheet for sharing.',
   },
 
-  // ── Internal (machine-invoked; registered, not user-facing) ────────────
-  {
-    id: 'context-hook',
-    audience: 'internal',
-    group: 'internal',
-    summary: 'Claude Code PreToolUse hook body (graph context injection)',
-  },
-  {
-    id: 'hook',
-    audience: 'internal',
-    group: 'internal',
-    summary: 'Claude Code lifecycle-hook bodies for the loop pack (stop-gate)',
-  },
-  {
-    id: 'floor',
-    audience: 'internal',
-    group: 'internal',
-    summary: 'Correctness-floor plumbing (snapshot / check) for the loop + hooks',
-  },
+  ...INTERNAL_COMMANDS, // machine-invoked partition — command-defs-internal.ts
   {
     id: 'demo',
     audience: 'user',

--- a/src/languages/jvm-build.ts
+++ b/src/languages/jvm-build.ts
@@ -102,12 +102,29 @@ function isJvmBuildFile(rel: string): boolean {
  * file. Exported so both JVM packs share the one detector.
  */
 export function isAndroidGradleBuild(cwd: string): boolean {
-  for (const rel of [
+  // Root build files (classpath / plugins-block declarations), the version
+  // catalog (modern projects reference the plugin as
+  // `alias(libs.plugins.android.application)` in build files and the
+  // `com.android.application` literal lives ONLY in gradle/libs.versions.toml
+  // — the shape that shipped a false floor run on a real Android repo), and
+  // first-level module build files (`app/build.gradle.kts` declaring the
+  // plugin id directly).
+  const candidates = [
     'build.gradle.kts',
     'build.gradle',
     'settings.gradle.kts',
     'settings.gradle',
-  ]) {
+    'gradle/libs.versions.toml',
+  ];
+  try {
+    for (const entry of fs.readdirSync(cwd, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      candidates.push(`${entry.name}/build.gradle.kts`, `${entry.name}/build.gradle`);
+    }
+  } catch {
+    /* unreadable cwd → root candidates only */
+  }
+  for (const rel of candidates) {
     if (!fileExists(cwd, rel)) continue;
     try {
       if (fs.readFileSync(path.join(cwd, rel), 'utf-8').includes('com.android')) return true;

--- a/src/loop/floor-gate.ts
+++ b/src/loop/floor-gate.ts
@@ -22,6 +22,7 @@ import {
 } from '../analyzers/correctness/run';
 import { resolveCorrectnessSurface } from '../analyzers/correctness/surface';
 import { readFloorBaseline, writeFloorBaseline, netNewFloorFailures } from './floor-state';
+import { clearStateCache } from './gate-cache';
 import { type CheckStatus } from './ledger';
 
 /**
@@ -161,6 +162,10 @@ export function buildFloorGate(repoDir: string): FloorGateOutcome | null {
  * reporting, or null when no active pack provides a floor. Best-effort write.
  */
 export function captureFloorSnapshot(repoDir: string): CorrectnessFloorResult | null {
+  // A new loop session must never replay a previous session's verdict:
+  // activation clears the Stop-gate verdict cache regardless of whether a
+  // floor is available below (T1.3 session-scope belt).
+  clearStateCache(repoDir);
   const packs = detectActiveLanguages(repoDir).filter((p) => p.correctness);
   if (packs.length === 0) return null;
   const result = runCorrectnessFloor({

--- a/src/loop/floor-state.ts
+++ b/src/loop/floor-state.ts
@@ -31,6 +31,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { LEDGER_DIR } from './ledger';
 import type { CorrectnessCheckResult, CorrectnessFloorResult } from '../analyzers/correctness/run';
+import { attributeFloorFailures } from '../analyzers/correctness/attribution';
 
 /** File under `.dxkit/loop/` holding the entry snapshot. */
 export const FLOOR_BASELINE_FILE = 'floor-baseline.json';
@@ -52,10 +53,10 @@ export interface FloorBaseline {
   readonly checks: readonly FloorCheckState[];
 }
 
-/** Stable per-check identity used to diff a Stop against the entry snapshot. */
-export function checkKey(pack: string, label: string): string {
-  return `${pack}:${label}`;
-}
+/** Stable per-check identity used to diff a Stop against the entry snapshot.
+ *  Re-exported from the canonical attribution module (T2.3) so the loop and
+ *  the CI floor share ONE key scheme. */
+export { checkKey } from '../analyzers/correctness/attribution';
 
 function floorBaselinePath(cwd: string): string {
   return path.join(cwd, LEDGER_DIR, FLOOR_BASELINE_FILE);
@@ -119,12 +120,15 @@ export function netNewFloorFailures(
   current: CorrectnessFloorResult,
   baseline: FloorBaseline | null,
 ): CorrectnessCheckResult[] {
-  const alreadyFailing = new Set(
-    (baseline?.checks ?? [])
-      .filter((c) => c.status === 'fail')
-      .map((c) => checkKey(c.pack, c.label)),
-  );
-  return current.checks.filter(
-    (c) => c.status === 'fail' && !alreadyFailing.has(checkKey(c.pack, c.label)),
-  );
+  // ONE comparator with the CI floor (attributeFloorFailures — T2.3).
+  // `absentMeans: 'net-new'` is the loop's declared policy: the snapshot is
+  // captured in the SAME environment, and skipped checks are deliberately
+  // dropped from it, so a check absent from the snapshot that fails now was
+  // enabled by the change — fail toward blocking. A cross-tree CI base run
+  // declares 'unattributed' instead; the difference is an argument, never a
+  // second comparator.
+  const base = baseline === null ? null : baseline.checks;
+  return attributeFloorFailures(current, base, { absentMeans: 'net-new' })
+    .filter((a) => a.attribution === 'net-new')
+    .map((a) => a.check);
 }

--- a/src/loop/gate-cache.ts
+++ b/src/loop/gate-cache.ts
@@ -14,6 +14,9 @@ import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { LEDGER_DIR } from './ledger';
+import { VERSION } from '../constants';
+import { TOOL_DEFS, findTool } from '../analyzers/tools/tool-registry';
+import { resolveLoopTestCommand } from './policy';
 
 /** Permission modes that mean "running unattended", so the gate
  *  auto-activates. `bypassPermissions` is what `--dangerously-skip-permissions`
@@ -125,11 +128,85 @@ export function workingTreeSignature(repoDir: string): string | null {
   return createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 32);
 }
 
-/** Cached verdict keyed on a working-tree signature. Only the
- *  tree-deterministic outcomes (allow / block-model) are cached;
- *  operator/preflight failures are environment-dependent and re-tried. */
+/**
+ * A signature of everything OUTSIDE the tree that can change the verdict
+ * (T1.3). The tree signature proves the CODE is identical; a replay is
+ * only sound when the OBSERVER is identical too — the same dxkit, the
+ * same policy/posture, the same postflight test command, and the same
+ * scanner binaries. Keying on tree bytes alone replayed a stale ALLOW
+ * after a scanner or toolchain upgrade between sessions — exactly the
+ * drift class Rule 19 exists to catch, never consulted here.
+ *
+ * Inputs, all cheap and scan-free (computable on the fast path):
+ *   - dxkit's own version + the node runtime;
+ *   - the resolved loop policy + preset + gate modes (caller-supplied,
+ *     already resolved by the Stop-gate before the cache is consulted);
+ *   - the resolved postflight test command;
+ *   - a stamp (path + size + mtime) of every registry tool's RESOLVED
+ *     binary. Iterates the WHOLE registry rather than a per-kind tool
+ *     table (the table is the exact shape Rule 19 bans — it drifts).
+ *     Over-invalidation is the safe direction: a stamp change on an
+ *     irrelevant tool costs one re-scan; a missed change replays a
+ *     stale verdict. `skipVersion` keeps the probe spawn-free.
+ *
+ * Known residual (documented, accepted): an ecosystem toolchain upgrade
+ * (JDK, dotnet SDK) that changes a floor outcome on an identical tree is
+ * not stamped; CI remains the backstop, and the entry snapshot is
+ * re-captured at each loop activation.
+ */
+export function environmentSignature(
+  repoDir: string,
+  inputs: { readonly preset: string; readonly policy: unknown; readonly modes?: unknown },
+  toolStamps?: ReadonlyArray<string>,
+): string {
+  const parts: string[] = [
+    `dxkit:${VERSION}`,
+    `node:${process.version}`,
+    `preset:${inputs.preset}`,
+    `policy:${JSON.stringify(inputs.policy)}`,
+    `modes:${JSON.stringify(inputs.modes ?? null)}`,
+    `test-cmd:${resolveLoopTestCommand(repoDir) ?? ''}`,
+    ...(toolStamps ?? registryToolStamps(repoDir)),
+  ];
+  return createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 32);
+}
+
+/** One deterministic stamp per registry tool: resolved binary identity
+ *  (path + size + mtime) or 'missing'. Sorted by tool name. Exported for
+ *  the cache tests. */
+export function registryToolStamps(repoDir: string): string[] {
+  const stamps: string[] = [];
+  for (const def of Object.values(TOOL_DEFS)) {
+    let stamp = `tool:${def.name}:missing`;
+    try {
+      const status = findTool(def, repoDir, { skipVersion: true });
+      if (status.available && status.path) {
+        try {
+          const st = fs.statSync(status.path);
+          stamp = `tool:${def.name}:${status.path}:${st.size}:${Math.floor(st.mtimeMs)}`;
+        } catch {
+          stamp = `tool:${def.name}:${status.path}:unstattable`;
+        }
+      } else if (status.source === 'n/a') {
+        stamp = `tool:${def.name}:n/a`;
+      }
+    } catch {
+      /* keep 'missing' — a probe failure must not break the gate */
+    }
+    stamps.push(stamp);
+  }
+  return stamps.sort();
+}
+
+/** Cached verdict keyed on a working-tree signature AND an environment
+ *  signature. Only the tree-deterministic outcomes (allow / block-model)
+ *  are cached; operator/preflight failures are environment-dependent and
+ *  re-tried. Entries written before the environment key existed carry no
+ *  `envSignature` and therefore never match — a legacy entry is a MISS,
+ *  never a replay (fail toward re-scanning). */
 export interface StopGateStateCache {
   readonly signature: string;
+  readonly envSignature?: string;
   readonly outcome: 'allow' | 'block-model';
   readonly message: string;
   readonly netNew: number;
@@ -160,5 +237,19 @@ export function writeStateCache(repoDir: string, cache: StopGateStateCache): voi
     fs.writeFileSync(path.join(dir, STATE_FILE), JSON.stringify(cache, null, 2) + '\n', 'utf8');
   } catch {
     /* best-effort: a cache write must never break the gate */
+  }
+}
+
+/** Drop any cached verdict. Called at loop ACTIVATION (`loop snapshot`)
+ *  so a new session never replays a verdict minted by a previous one —
+ *  the session-scope belt on top of the environment signature's
+ *  suspenders (the signature covers scanners + policy + dxkit itself;
+ *  this covers everything it cannot see, e.g. an ecosystem toolchain
+ *  upgrade between sessions). */
+export function clearStateCache(repoDir: string): void {
+  try {
+    fs.rmSync(path.join(repoDir, LEDGER_DIR, STATE_FILE), { force: true });
+  } catch {
+    /* best-effort */
   }
 }

--- a/src/loop/stop-gate-io.ts
+++ b/src/loop/stop-gate-io.ts
@@ -1,0 +1,64 @@
+/**
+ * Stop-gate I/O — the hook-boundary plumbing split from `stop-gate.ts` so
+ * the gate module stays the DECISION logic: reading the Claude Code Stop
+ * payload from stdin, and running the operator-configured postflight test
+ * command. Both are pure of gate policy.
+ */
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import { resolveLoopTestCommand } from './policy';
+import type { CheckStatus } from './ledger';
+
+/** Subset of the Claude Code Stop-hook stdin payload we consume. */
+export interface StopHookPayload {
+  readonly session_id?: string;
+  readonly cwd?: string;
+  readonly stop_hook_active?: boolean;
+  readonly agent_id?: string;
+  readonly agent_type?: string;
+  /**
+   * Active permission mode, when Claude Code includes it
+   * (`default` | `plan` | `acceptEdits` | `auto` | `dontAsk` |
+   * `bypassPermissions`). `bypassPermissions` is the canonical
+   * unattended/headless mode (`--dangerously-skip-permissions` /
+   * `--permission-mode bypassPermissions`), so it auto-activates the gate.
+   * Not guaranteed present on every event, so the env / sentinel remain the
+   * reliable override for guaranteed gating.
+   */
+  readonly permission_mode?: string;
+}
+
+/** Read and parse the stdin hook payload; {} on any problem. */
+export function readStdinPayload(): StopHookPayload {
+  let raw = '';
+  try {
+    raw = fs.readFileSync(0, 'utf8');
+  } catch {
+    return {};
+  }
+  if (!raw.trim()) return {};
+  try {
+    return JSON.parse(raw) as StopHookPayload;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Optional configured test command (DXKIT_LOOP_TEST_COMMAND). Runs only
+ * after the guardrail passes. Returns the status plus a short failure
+ * tail to surface in the block message. `not_configured` when unset.
+ */
+export function runConfiguredTests(repoDir: string): { status: CheckStatus; tail: string } {
+  const cmd = resolveLoopTestCommand(repoDir);
+  if (!cmd || !cmd.trim()) return { status: 'not_configured', tail: '' };
+  try {
+    execSync(cmd, { cwd: repoDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    return { status: 'pass', tail: '' };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string };
+    const out = `${e.stdout ?? ''}${e.stderr ?? ''}`.trim();
+    const tail = out.split('\n').slice(-15).join('\n');
+    return { status: 'fail', tail };
+  }
+}

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -38,7 +38,6 @@ import {
   type CheckStatus,
   type LedgerEvent,
 } from './ledger';
-import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { dxkitCli } from '../self-invocation';
@@ -55,26 +54,7 @@ import {
   floorLedgerStatuses,
   type FloorGateOutcome,
 } from './floor-gate';
-import { resolveLoopTestCommand } from './policy';
-
-/** Subset of the Claude Code Stop-hook stdin payload we consume. */
-interface StopHookPayload {
-  readonly session_id?: string;
-  readonly cwd?: string;
-  readonly stop_hook_active?: boolean;
-  readonly agent_id?: string;
-  readonly agent_type?: string;
-  /**
-   * Active permission mode, when Claude Code includes it
-   * (`default` | `plan` | `acceptEdits` | `auto` | `dontAsk` |
-   * `bypassPermissions`). `bypassPermissions` is the canonical
-   * unattended/headless mode (`--dangerously-skip-permissions` /
-   * `--permission-mode bypassPermissions`), so it auto-activates the gate.
-   * Not guaranteed present on every event, so the env / sentinel remain the
-   * reliable override for guaranteed gating.
-   */
-  readonly permission_mode?: string;
-}
+import { readStdinPayload, runConfiguredTests, type StopHookPayload } from './stop-gate-io';
 
 /** What the gate decided, before any process I/O. */
 export interface StopGateDecision {
@@ -85,41 +65,6 @@ export interface StopGateDecision {
   readonly message: string;
   /** Ledger event recorded for this decision. */
   readonly event: LedgerEvent;
-}
-
-/** Read and parse the stdin hook payload; {} on any problem. */
-function readStdinPayload(): StopHookPayload {
-  let raw = '';
-  try {
-    raw = fs.readFileSync(0, 'utf8');
-  } catch {
-    return {};
-  }
-  if (!raw.trim()) return {};
-  try {
-    return JSON.parse(raw) as StopHookPayload;
-  } catch {
-    return {};
-  }
-}
-
-/**
- * Optional configured test command (DXKIT_LOOP_TEST_COMMAND). Runs only
- * after the guardrail passes. Returns the status plus a short failure
- * tail to surface in the block message. `not_configured` when unset.
- */
-function runConfiguredTests(repoDir: string): { status: CheckStatus; tail: string } {
-  const cmd = resolveLoopTestCommand(repoDir);
-  if (!cmd || !cmd.trim()) return { status: 'not_configured', tail: '' };
-  try {
-    execSync(cmd, { cwd: repoDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
-    return { status: 'pass', tail: '' };
-  } catch (err) {
-    const e = err as { stdout?: string; stderr?: string };
-    const out = `${e.stdout ?? ''}${e.stderr ?? ''}`.trim();
-    const tail = out.split('\n').slice(-15).join('\n');
-    return { status: 'fail', tail };
-  }
 }
 
 /**

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -45,6 +45,7 @@ import { dxkitCli } from '../self-invocation';
 import {
   loopGateActive,
   workingTreeSignature,
+  environmentSignature,
   readStateCache,
   writeStateCache,
 } from './gate-cache';
@@ -380,13 +381,19 @@ export async function runStopGate(cwd: string): Promise<void> {
   // only ever a genuinely-identical tree and the cache can never skip a
   // real net-new finding. Bypass with DXKIT_LOOP_NO_CACHE=1.
   const signature = process.env.DXKIT_LOOP_NO_CACHE === '1' ? null : workingTreeSignature(repoDir);
+  // The environment half of the cache key (T1.3): same tree + DIFFERENT
+  // observer (dxkit / policy / test command / scanner binaries) must MISS,
+  // or a scanner upgrade between sessions replays a stale ALLOW.
+  const envSignature = signature
+    ? environmentSignature(repoDir, { preset, policy, modes: { flowMode, schemaMode, duplicationMode } })
+    : null;
   const agentFields = {
     ...(payload.agent_id ? { agent_id: payload.agent_id } : {}),
     ...(payload.agent_type ? { agent_type: payload.agent_type } : {}),
   };
-  if (signature) {
+  if (signature && envSignature) {
     const cached = readStateCache(repoDir);
-    if (cached && cached.signature === signature) {
+    if (cached && cached.signature === signature && cached.envSignature === envSignature) {
       const event = buildLedgerEvent(repoDir, {
         session_id: payload.session_id || '',
         ...agentFields,
@@ -462,9 +469,14 @@ export async function runStopGate(cwd: string): Promise<void> {
   // an unchanged tree replays it instead of re-gathering. Only the
   // tree-deterministic outcomes are cached; an operator/preflight failure
   // is environment-dependent and must be re-tried.
-  if (signature && (decision.outcome === 'allow' || decision.outcome === 'block-model')) {
+  if (
+    signature &&
+    envSignature &&
+    (decision.outcome === 'allow' || decision.outcome === 'block-model')
+  ) {
     writeStateCache(repoDir, {
       signature,
+      envSignature,
       outcome: decision.outcome,
       message: decision.message,
       netNew: decision.event.net_new_findings,

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -385,7 +385,11 @@ export async function runStopGate(cwd: string): Promise<void> {
   // observer (dxkit / policy / test command / scanner binaries) must MISS,
   // or a scanner upgrade between sessions replays a stale ALLOW.
   const envSignature = signature
-    ? environmentSignature(repoDir, { preset, policy, modes: { flowMode, schemaMode, duplicationMode } })
+    ? environmentSignature(repoDir, {
+        preset,
+        policy,
+        modes: { flowMode, schemaMode, duplicationMode },
+      })
     : null;
   const agentFields = {
     ...(payload.agent_id ? { agent_id: payload.agent_id } : {}),

--- a/test/baseline/changed-files.test.ts
+++ b/test/baseline/changed-files.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from 'child_process';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { computeChangedFiles } from '../../src/baseline/changed-files';
+import { computeChangedFiles, createChangedLineIndex } from '../../src/baseline/changed-files';
 
 /**
  * `computeChangedFiles` is the safety core of incremental scanning (opt 3):
@@ -91,6 +91,92 @@ describe('computeChangedFiles', () => {
       expect(computeChangedFiles(plain, 'HEAD')).toBeNull();
     } finally {
       rmSync(plain, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('createChangedLineIndex (line-granularity sibling — same working-tree basis)', () => {
+  let repo: string;
+  let base: string;
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'dxkit-changed-lines-'));
+    git(repo, ['init', '-q', '-b', 'main']);
+    git(repo, ['config', 'user.email', 't@t.co']);
+    git(repo, ['config', 'user.name', 't']);
+    mkdirSync(join(repo, 'src'), { recursive: true });
+    writeFileSync(join(repo, 'src', 'a.ts'), 'line one\nline two\nline three\n');
+    base = commitAll(repo, 'base');
+  });
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('attributes an UNCOMMITTED (unstaged) edit — the T1.1 hole', () => {
+    // At Stop time an agent's edits are dirty. Attribution that diffed
+    // committed HEAD saw an empty diff here and demoted the finding.
+    writeFileSync(join(repo, 'src', 'a.ts'), 'line one\nEDITED two\nline three\n');
+    const idx = createChangedLineIndex(repo, base);
+    expect(idx).not.toBeNull();
+    const lines = idx!.linesFor('src/a.ts');
+    expect(lines).not.toBe('all');
+    expect(lines).not.toBeNull();
+    expect([...(lines as ReadonlySet<number>)]).toEqual([2]);
+  });
+
+  it('attributes a staged-but-uncommitted edit', () => {
+    writeFileSync(join(repo, 'src', 'a.ts'), 'line one\nline two\nline three\nline four\n');
+    git(repo, ['add', 'src/a.ts']);
+    const idx = createChangedLineIndex(repo, base)!;
+    expect([...(idx.linesFor('src/a.ts') as ReadonlySet<number>)]).toEqual([4]);
+  });
+
+  it('attributes a committed edit (HEAD ahead of base)', () => {
+    writeFileSync(join(repo, 'src', 'a.ts'), 'CHANGED one\nline two\nline three\n');
+    commitAll(repo, 'later');
+    const idx = createChangedLineIndex(repo, base)!;
+    expect([...(idx.linesFor('src/a.ts') as ReadonlySet<number>)]).toEqual([1]);
+  });
+
+  it("reports 'all' for an untracked file — every line is this change's work", () => {
+    writeFileSync(join(repo, 'src', 'new.ts'), 'brand\nnew\nfile\n');
+    const idx = createChangedLineIndex(repo, base)!;
+    expect(idx.linesFor('src/new.ts')).toBe('all');
+  });
+
+  it('reports an empty set for an unchanged file', () => {
+    const idx = createChangedLineIndex(repo, base)!;
+    const lines = idx.linesFor('src/a.ts');
+    expect(lines).not.toBe('all');
+    expect((lines as ReadonlySet<number>).size).toBe(0);
+  });
+
+  it('returns null (unknown-everywhere) for an empty base', () => {
+    expect(createChangedLineIndex(repo, '')).toBeNull();
+  });
+
+  it('reports null (unknown) for a file when the base SHA is unreachable — never an empty set', () => {
+    // An unreadable diff must read as CANNOT-ATTRIBUTE (no demotion), not as
+    // "nothing changed" (silent demotion of a real finding).
+    const idx = createChangedLineIndex(repo, '0000000000000000000000000000000000000000')!;
+    expect(idx.linesFor('src/a.ts')).toBeNull();
+  });
+
+  it('PARITY: every file computeChangedFiles reports has non-empty line attribution', () => {
+    // The Rule 2.30 net: file-level and line-level discovery are two
+    // projections of one concept and must agree. A file the file-level
+    // sibling calls "changed" whose line attribution comes back empty
+    // means the two paths diverged on diff basis again.
+    writeFileSync(join(repo, 'src', 'a.ts'), 'line one\nEDITED two\nline three\n'); // unstaged
+    writeFileSync(join(repo, 'src', 'b.ts'), 'staged\n'); // staged new content
+    git(repo, ['add', 'src/b.ts']);
+    writeFileSync(join(repo, 'src', 'c.ts'), 'untracked\n'); // untracked
+    const files = computeChangedFiles(repo, base)!;
+    expect(files.length).toBeGreaterThanOrEqual(3);
+    const idx = createChangedLineIndex(repo, base)!;
+    for (const file of files) {
+      const lines = idx.linesFor(file);
+      const attributed = lines === 'all' || (lines !== null && lines.size > 0);
+      expect(attributed, `no line attribution for changed file ${file}`).toBe(true);
     }
   });
 });

--- a/test/baseline/check.test.ts
+++ b/test/baseline/check.test.ts
@@ -240,6 +240,132 @@ describe('runGuardrailCheck (integration)', () => {
       expect(viaPath.baseline.name).toBe('main');
     }, 300_000);
 
+    it('an UNCOMMITTED edit introducing a high code finding BLOCKS (T1.1 — dirty-tree attribution)', async () => {
+      // The 4.0.3 T1.1 hole: at Stop time an agent's edits are dirty. The
+      // scan reads the working tree, but changed-line attribution diffed
+      // committed history — so a net-new high/critical `code` finding in an
+      // uncommitted edit had `overlapsChangedLines=false`, demoted
+      // `added → uncertain`, and WARNED instead of blocking. Every other
+      // fixture in this file commits its edits, which is exactly why the
+      // hole shipped. This one does not commit.
+      //
+      // The `code` finding is minted through the ingest path (Rule 13) so
+      // the test is scanner-independent: CI installs no semgrep. The
+      // engine snapshot exists at baseline time (empty) so engine
+      // provenance is identical on both sides — no recall drift in play.
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'handler.js'), 'const a = 1;\nconst b = 2;\nconst c = 3;\n');
+      mkdirSync(join(dir, '.dxkit', 'external'), { recursive: true });
+      const emptySnapshot = {
+        schemaVersion: 1,
+        engine: 'sarif',
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        findings: [],
+      };
+      writeFileSync(
+        join(dir, '.dxkit', 'external', 'sarif.json'),
+        JSON.stringify(emptySnapshot, null, 2) + '\n',
+      );
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-q', '-m', 'source + empty engine snapshot'], { cwd: dir });
+
+      await createBaseline({ cwd: dir });
+
+      // The agent's dirty edit: line 2 changes, and the refreshed engine
+      // snapshot reports a HIGH finding on that line. NOTHING is committed.
+      writeFileSync(
+        join(dir, 'src', 'handler.js'),
+        'const a = 1;\nconst b = eval(userInput);\nconst c = 3;\n',
+      );
+      writeFileSync(
+        join(dir, '.dxkit', 'external', 'sarif.json'),
+        JSON.stringify(
+          {
+            ...emptySnapshot,
+            findings: [
+              {
+                engine: 'sarif',
+                severity: 'high',
+                category: 'code',
+                cwe: 'CWE-95',
+                rule: 'js/eval-injection',
+                title: 'Eval of user-controlled input',
+                file: 'src/handler.js',
+                line: 2,
+              },
+            ],
+          },
+          null,
+          2,
+        ) + '\n',
+      );
+
+      const result = await runGuardrailCheck({ cwd: dir });
+      const codeAdds = result.pairs.filter(
+        (p) => p.kind === 'code' && p.classification.status === 'added',
+      );
+      expect(codeAdds).toHaveLength(1);
+      // The uncommitted line IS this change's work — attribution must see it.
+      expect(codeAdds[0].overlapsChangedLines).toBe(true);
+      expect(codeAdds[0].classification.blocks).toBe(true);
+      expect(result.blocks).toBe(true);
+    }, 300_000);
+
+    it('a finding in an UNTRACKED new file BLOCKS (T1.1 — untracked = all lines changed)', async () => {
+      // Same hole, second shape: `git diff <base>` never mentions an
+      // untracked file, so a finding in a brand-new uncommitted file
+      // slipped the same way. Untracked files attribute as 'all'.
+      mkdirSync(join(dir, '.dxkit', 'external'), { recursive: true });
+      const emptySnapshot = {
+        schemaVersion: 1,
+        engine: 'sarif',
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        findings: [],
+      };
+      writeFileSync(
+        join(dir, '.dxkit', 'external', 'sarif.json'),
+        JSON.stringify(emptySnapshot, null, 2) + '\n',
+      );
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-q', '-m', 'empty engine snapshot'], { cwd: dir });
+
+      await createBaseline({ cwd: dir });
+
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'brand-new.js'), 'const x = eval(input);\n'); // untracked
+      writeFileSync(
+        join(dir, '.dxkit', 'external', 'sarif.json'),
+        JSON.stringify(
+          {
+            ...emptySnapshot,
+            findings: [
+              {
+                engine: 'sarif',
+                severity: 'critical',
+                category: 'code',
+                cwe: 'CWE-95',
+                rule: 'js/eval-injection',
+                title: 'Eval of user-controlled input',
+                file: 'src/brand-new.js',
+                line: 1,
+              },
+            ],
+          },
+          null,
+          2,
+        ) + '\n',
+      );
+
+      const result = await runGuardrailCheck({ cwd: dir });
+      const codeAdds = result.pairs.filter(
+        (p) => p.kind === 'code' && p.classification.status === 'added',
+      );
+      expect(codeAdds).toHaveLength(1);
+      expect(codeAdds[0].overlapsChangedLines).toBe(true);
+      expect(codeAdds[0].classification.blocks).toBe(true);
+      expect(result.blocks).toBe(true);
+    }, 300_000);
+
     it('surfaces allowlist additions in the markdown PR-comment section', async () => {
       // Baseline-time: no .dxkit/allowlist.json file
       await createBaseline({ cwd: dir });

--- a/test/baseline/floor-debt.test.ts
+++ b/test/baseline/floor-debt.test.ts
@@ -90,7 +90,8 @@ describe('createBaseline floor-debt wiring', () => {
           name: 'fixture',
           version: '1.0.0',
           scripts: {
-            typecheck: 'node -e "console.error(\'TS9999: fixture broken\');process.exit(1)"',
+            // The fixture's fake compiler writing to ITS stderr — not a stray console. // slop-ok
+            typecheck: 'node -e "console.error(\'TS9999: fixture broken\');process.exit(1)"', // slop-ok
           },
         },
         null,

--- a/test/baseline/floor-debt.test.ts
+++ b/test/baseline/floor-debt.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The floor-debt envelope (T2.3 follow-through): the committed inventory of
+ * pre-existing build/test debt, captured at baseline time so cleanup agents
+ * can prioritize and fix it. Informational — Rule 15 intact: no fingerprint,
+ * no matcher, never a gate input. These tests pin capture fidelity (details
+ * survive: reproduction command + error output), the create-time wiring
+ * (default ON, env kill-switch, explicit option beats env), and the
+ * read-path round-trip.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { captureFloorDebt, failingFloorDebt } from '../../src/baseline/floor-debt';
+import { createBaseline } from '../../src/baseline/create';
+import { readBaselineFile, pathForBaseline } from '../../src/baseline/baseline-file';
+import type { CommandExec } from '../../src/analyzers/correctness/run';
+import type { LanguageSupport } from '../../src/languages/types';
+
+function syntheticPack(id: string): LanguageSupport {
+  return {
+    id,
+    correctness: {
+      execution: () => ({
+        hosts: ['any' as const],
+        toolchains: [],
+        needsBuild: false,
+        buildTarget: 'none' as const,
+        weight: 'cheap' as const,
+      }),
+      syntaxCheck: () => ({ label: 'compile', bin: 'fake-cc', args: ['--strict', 'src/'] }),
+      affectedTests: () => ({ label: 'tests', bin: 'fake-test', args: ['run'] }),
+    },
+  } as unknown as LanguageSupport;
+}
+
+describe('captureFloorDebt', () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'dxkit-floordebt-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 't@t.co'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: repo });
+    writeFileSync(join(repo, 'README.md'), '# fixture\n');
+    execFileSync('git', ['add', '-A'], { cwd: repo });
+    execFileSync('git', ['commit', '-qm', 'seed'], { cwd: repo });
+  });
+  afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+  it('records failing checks WITH the reproduction command and error output', () => {
+    const exec: CommandExec = (cmd) =>
+      cmd.bin === 'fake-cc'
+        ? { available: true, code: 2, output: 'src/app.x:14: error: broken widget\n' }
+        : { available: true, code: 0, output: '' };
+    const debt = captureFloorDebt(repo, { exec, packs: [syntheticPack('ts')] });
+    expect(debt).not.toBeNull();
+    const failing = failingFloorDebt(debt!);
+    expect(failing).toHaveLength(1);
+    // The two things a cleanup agent needs: HOW to reproduce, WHAT broke.
+    expect(failing[0].command).toBe('fake-cc --strict src/');
+    expect(failing[0].output).toContain('error: broken widget');
+    // Provenance is stamped.
+    expect(debt!.capturedAtCommit).toMatch(/^[0-9a-f]{40}$/);
+    expect(debt!.capturedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    // The passing sibling is recorded too — 'all green' must be
+    // distinguishable from 'never measured'.
+    expect(debt!.checks.map((c) => c.status).sort()).toEqual(['fail', 'pass']);
+  });
+
+  it('returns null when no active pack provides a floor (envelope omitted, not empty-green)', () => {
+    expect(captureFloorDebt(repo, { packs: [] })).toBeNull();
+  });
+});
+
+describe('createBaseline floor-debt wiring', () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'dxkit-floordebt-create-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 't@t.co'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: repo });
+    // A ts-pack repo whose typecheck script fails fast with real output —
+    // the cheapest honest "pre-existing broken build". Pack detection needs
+    // a real source file, not just a package.json.
+    writeFileSync(
+      join(repo, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'fixture',
+          version: '1.0.0',
+          scripts: {
+            typecheck: 'node -e "console.error(\'TS9999: fixture broken\');process.exit(1)"',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    mkdirSync(join(repo, 'src'), { recursive: true });
+    writeFileSync(join(repo, 'src', 'index.ts'), 'export const x = 1;\n');
+    execFileSync('git', ['add', '-A'], { cwd: repo });
+    execFileSync('git', ['commit', '-qm', 'seed'], { cwd: repo });
+  });
+  afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+  it('explicit floor:true captures the envelope (beats the suite env kill-switch) and it round-trips', async () => {
+    // The suite sets DXKIT_BASELINE_NO_FLOOR=1 globally; an explicit option
+    // must win, or the product default would be untestable.
+    const created = await createBaseline({ cwd: repo, floor: true });
+    expect(created.path).toBeTruthy();
+    const file = readBaselineFile(pathForBaseline(repo, 'main'));
+    expect(file.floorDebt).toBeDefined();
+    const failing = failingFloorDebt(file.floorDebt!);
+    expect(failing.length).toBeGreaterThanOrEqual(1);
+    const typecheck = failing.find((c) => /typecheck|compile/i.test(c.label));
+    expect(typecheck, 'the broken typecheck script must be recorded as debt').toBeDefined();
+    expect(typecheck!.output).toContain('TS9999: fixture broken');
+    expect(typecheck!.command.length).toBeGreaterThan(0);
+  }, 120_000);
+
+  it('the env kill-switch (suite default) omits the envelope; --no-floor maps to floor:false', async () => {
+    const created = await createBaseline({ cwd: repo }); // env says no-floor
+    expect(created.path).toBeTruthy();
+    const file = readBaselineFile(pathForBaseline(repo, 'main'));
+    expect(file.floorDebt).toBeUndefined();
+
+    rmSync(pathForBaseline(repo, 'main'), { force: true });
+    const explicit = await createBaseline({ cwd: repo, floor: false, force: true });
+    expect(explicit.path).toBeTruthy();
+    expect(readBaselineFile(pathForBaseline(repo, 'main')).floorDebt).toBeUndefined();
+  }, 120_000);
+});

--- a/test/baseline/gather-scope.test.ts
+++ b/test/baseline/gather-scope.test.ts
@@ -10,9 +10,10 @@ import {
   isFullScope,
   isEmptyScope,
   FULL_SCOPE,
+  BLOCK_RULE_EVIDENCE,
   type GatherScope,
 } from '../../src/baseline/gather-scope';
-import type { BrownfieldPolicy } from '../../src/baseline/policy';
+import type { BrownfieldPolicy, BrownfieldBlockRules } from '../../src/baseline/policy';
 import { DEFAULT_BROWNFIELD_POLICY } from '../../src/baseline/policy';
 import { resolveLoopPolicy } from '../../src/loop/policy';
 import { gatherCurrentScan } from '../../src/baseline/create';
@@ -69,13 +70,16 @@ describe('scopeForPolicy', () => {
     expect(s.secrets).toBe(true); // newSecret
     expect(s.codePatterns).toBe(true); // newCritical/HighSecurity
     expect(s.depVulns).toBe(true); // newCritical/HighReachableDependency
+    // Reachability EVIDENCE for the high-reachable rule (T1.2): the armed
+    // rule needs the import graph or it is structurally dead — the shipped
+    // bug was this flag staying false while the rule was armed.
+    expect(s.imports).toBe(true);
     // Everything a security-only posture can never block on is skipped.
     expect(s.structural).toBe(false);
     expect(s.duplication).toBe(false);
     expect(s.lint).toBe(false);
     expect(s.coverage).toBe(false);
     expect(s.licenses).toBe(false);
-    expect(s.imports).toBe(false);
     expect(s.testFramework).toBe(false);
     expect(s.cloc).toBe(false);
     expect(s.testGaps).toBe(false);
@@ -119,42 +123,45 @@ describe('scopeForPolicy', () => {
   });
 
   /**
-   * SAFETY CONTRACT: every block rule that can fire MUST pull at least one
-   * analyzer into scope. If a future rule is added to `evaluateBlockRules`
-   * without a matching scope branch, a security-only-style posture would
-   * silently skip the analyzer that feeds it — a missed-finding bug. This
-   * asserts each rule, toggled alone, yields a non-empty scope.
+   * SAFETY CONTRACT (rule liveness, both directions): the declarative
+   * evidence table is the ONE rule→analyzer mapping, and `scopeForPolicy`
+   * must track it exactly. For every block rule, armed alone:
+   *   - every analyzer in its declared evidence set is scoped IN (a
+   *     missing analyzer = the rule is structurally dead, the T1.2 bug);
+   *   - no analyzer outside the set is scoped in (over-gathering erodes
+   *     the loop's speed contract and hides derivation drift).
+   * The table itself is a `Record` over `keyof BrownfieldBlockRules`, so
+   * a NEW rule that omits its evidence declaration fails to compile; this
+   * test closes the remaining runtime half of the loop. Also asserts no
+   * rule declares an empty evidence set.
    */
-  it('every block rule individually yields a non-empty scope (no silent skips)', () => {
-    const rules = [
-      'newSecret',
-      'newCriticalSecurity',
-      'newHighSecurity',
-      'newCriticalDependencyVulnerability',
-      'newHighReachableDependencyVulnerability',
-      'newMaliciousDependency',
-      'newUntestedChangedSource',
-      'newSevereQualityIssueInChangedFiles',
-    ] as const;
-    for (const rule of rules) {
+  it('every block rule scopes in EXACTLY its declared evidence analyzers', () => {
+    const allOff: Record<keyof BrownfieldBlockRules, boolean> = {
+      newSecret: false,
+      newCriticalSecurity: false,
+      newHighSecurity: false,
+      newCriticalDependencyVulnerability: false,
+      newHighReachableDependencyVulnerability: false,
+      newMaliciousDependency: false,
+      newUntestedChangedSource: false,
+      newSevereQualityIssueInChangedFiles: false,
+    };
+    for (const rule of Object.keys(BLOCK_RULE_EVIDENCE) as Array<keyof BrownfieldBlockRules>) {
+      const evidence = BLOCK_RULE_EVIDENCE[rule];
+      expect(evidence.length, `rule ${rule} must declare evidence analyzers`).toBeGreaterThan(0);
       const policy: BrownfieldPolicy = {
         ...DEFAULT_BROWNFIELD_POLICY,
         block: [],
-        blockRules: {
-          newSecret: false,
-          newCriticalSecurity: false,
-          newHighSecurity: false,
-          newCriticalDependencyVulnerability: false,
-          newHighReachableDependencyVulnerability: false,
-          newMaliciousDependency: false,
-          newUntestedChangedSource: false,
-          newSevereQualityIssueInChangedFiles: false,
-          [rule]: true,
-        },
+        checks: [],
+        blockRules: { ...allOff, [rule]: true },
       };
-      expect(isEmptyScope(scopeForPolicy(policy)), `rule ${rule} must scope in an analyzer`).toBe(
-        false,
-      );
+      const s = scopeForPolicy(policy);
+      for (const flag of Object.keys(s) as Array<keyof GatherScope>) {
+        // customChecks is driven by policy.checks/lint, not block rules.
+        if (flag === 'customChecks') continue;
+        const expected = evidence.includes(flag);
+        expect(s[flag], `rule ${rule}: scope.${flag} should be ${expected}`).toBe(expected);
+      }
     }
   });
 });

--- a/test/baseline/policy.test.ts
+++ b/test/baseline/policy.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { DEFAULT_BROWNFIELD_POLICY } from '../../src/baseline/policy';
 import { classify, classifyAll } from '../../src/baseline/classify';
 import { verdictWordFrom } from '../../src/baseline/check-renderers';
+import { buildReachableIndex } from '../../src/baseline/check';
 import type { BrownfieldPolicy } from '../../src/baseline/policy';
 import type { ClassifyContext } from '../../src/baseline/classify';
 import type { MatchPair } from '../../src/baseline/types';
@@ -276,10 +277,51 @@ describe('classify — block-rule overrides', () => {
     expect(result2.reasons.some((r) => r.code === 'block-rule')).toBe(false);
   });
 
+  it('rule liveness: the reachable index feeds the exact context the high-reachable rule reads (T1.2)', () => {
+    // The evidence CHAIN, not just the classifier: aggregate finding with
+    // `reachable: true` → buildReachableIndex membership → the
+    // `reachable: true` context field → the armed rule fires under the
+    // security-only shape (empty `block` list, so the generic 'added'
+    // block cannot mask a dead rule — the exact configuration the rule
+    // was structurally dead under when it shipped).
+    const aggregate = {
+      findingsByCategory: {
+        dependency: [
+          { fingerprint: 'aaaa111122223333', package: 'axios', reachable: true },
+          { fingerprint: 'bbbb111122223333', package: 'inert', reachable: false },
+          { package: 'no-fingerprint', reachable: true },
+        ],
+      },
+    } as unknown as Parameters<typeof buildReachableIndex>[0];
+    const index = buildReachableIndex(aggregate);
+    expect(index.has('aaaa111122223333')).toBe(true);
+    expect(index.has('bbbb111122223333')).toBe(false);
+    expect(index.size).toBe(1);
+
+    const securityOnly: BrownfieldPolicy = { ...DEFAULT_BROWNFIELD_POLICY, block: [], warn: [] };
+    const fire = classify(pair('added'), securityOnly, {
+      kind: 'dep-vuln',
+      severity: 'high',
+      reachable: index.has('aaaa111122223333') || undefined,
+    });
+    expect(fire.blocks).toBe(true);
+    expect(
+      fire.reasons.some((r) => r.detail.includes('newHighReachableDependencyVulnerability')),
+    ).toBe(true);
+    // Without the evidence the rule must NOT fire under the same shape.
+    const noEvidence = classify(pair('added'), securityOnly, {
+      kind: 'dep-vuln',
+      severity: 'high',
+    });
+    expect(
+      noEvidence.reasons.some((r) => r.detail.includes('newHighReachableDependencyVulnerability')),
+    ).toBe(false);
+  });
+
   it('blocks a new malicious dependency at ANY severity (the supply-chain rule)', () => {
     // The July 2025 eslint-config-prettier compromise shipped as severity
-    // HIGH — below the critical rule, unreachable by the reachability rule
-    // (never populated on the check path). The malicious rule fires on the
+    // HIGH — below the critical rule, and independent of reachability (a
+    // malicious dep executes at install). The malicious rule fires on the
     // advisory class alone.
     for (const severity of ['high', 'medium', 'low'] as const) {
       const ctx: ClassifyContext = { kind: 'dep-vuln', severity, malicious: true };

--- a/test/correctness-attribution.test.ts
+++ b/test/correctness-attribution.test.ts
@@ -1,0 +1,260 @@
+/**
+ * The ONE floor-failure comparator (T2.3): the loop Stop-gate and the
+ * diff-scoped CI floor both attribute failures through
+ * `attributeFloorFailures`, with the absent-from-base policy a DECLARED
+ * argument. These tests pin the attribution lattice, the loop wrapper's
+ * unchanged semantics (parity — the Rule 2.30 net for two consumers of one
+ * concept), and the two-sided CI outcome end-to-end on a real git repo with
+ * injected execution.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  attributeFloorFailures,
+  checkKey,
+  type FloorBaseCheck,
+} from '../src/analyzers/correctness/attribution';
+import { netNewFloorFailures, type FloorBaseline } from '../src/loop/floor-state';
+import {
+  runFloorForSurface,
+  attributeCiFloorOutcome,
+} from '../src/analyzers/correctness/surface-run';
+import type {
+  CorrectnessFloorResult,
+  CorrectnessCheckResult,
+  CommandExec,
+} from '../src/analyzers/correctness/run';
+import type { LanguageSupport } from '../src/languages/types';
+
+function fail(pack: string, label: string): CorrectnessCheckResult {
+  return { pack: pack as CorrectnessCheckResult['pack'], label, bin: 'x', status: 'fail' };
+}
+function pass(pack: string, label: string): CorrectnessCheckResult {
+  return { pack: pack as CorrectnessCheckResult['pack'], label, bin: 'x', status: 'pass' };
+}
+function result(checks: CorrectnessCheckResult[]): CorrectnessFloorResult {
+  return { ran: true, checks, blocks: checks.some((c) => c.status === 'fail') };
+}
+
+describe('attributeFloorFailures (the lattice)', () => {
+  const base: FloorBaseCheck[] = [
+    { pack: 'ts', label: 'typecheck', status: 'pass' },
+    { pack: 'ts', label: 'affected-tests', status: 'fail' },
+    { pack: 'kotlin', label: 'compile', status: 'skipped' },
+  ];
+
+  it('base pass → net-new; base fail → pre-existing; base skipped → unattributed', () => {
+    const current = result([
+      fail('ts', 'typecheck'),
+      fail('ts', 'affected-tests'),
+      fail('kotlin', 'compile'),
+    ]);
+    const out = attributeFloorFailures(current, base, { absentMeans: 'unattributed' });
+    const byKey = new Map(out.map((a) => [checkKey(a.check.pack, a.check.label), a.attribution]));
+    expect(byKey.get('ts:typecheck')).toBe('net-new');
+    expect(byKey.get('ts:affected-tests')).toBe('pre-existing');
+    expect(byKey.get('kotlin:compile')).toBe('unattributed');
+  });
+
+  it('absent from base takes the DECLARED policy — both modes', () => {
+    const current = result([fail('go', 'build')]);
+    expect(attributeFloorFailures(current, base, { absentMeans: 'net-new' })[0].attribution).toBe(
+      'net-new',
+    );
+    expect(
+      attributeFloorFailures(current, base, { absentMeans: 'unattributed' })[0].attribution,
+    ).toBe('unattributed');
+  });
+
+  it('a null base attributes EVERY failure via absentMeans', () => {
+    const current = result([fail('ts', 'typecheck')]);
+    expect(attributeFloorFailures(current, null, { absentMeans: 'net-new' })[0].attribution).toBe(
+      'net-new',
+    );
+    expect(
+      attributeFloorFailures(current, null, { absentMeans: 'unattributed' })[0].attribution,
+    ).toBe('unattributed');
+  });
+
+  it('passing/skipped current checks are never attributed (failures only)', () => {
+    const current = result([pass('ts', 'typecheck'), fail('ts', 'affected-tests')]);
+    const out = attributeFloorFailures(current, base, { absentMeans: 'net-new' });
+    expect(out).toHaveLength(1);
+    expect(out[0].check.label).toBe('affected-tests');
+  });
+});
+
+describe('PARITY: the loop wrapper preserves its exact semantics through the one comparator', () => {
+  it('netNewFloorFailures ≡ attributeFloorFailures(..., net-new filter) on shared fixtures', () => {
+    const snapshot: FloorBaseline = {
+      capturedAtCommit: 'abc',
+      checks: [
+        { pack: 'ts', label: 'typecheck', status: 'pass' },
+        { pack: 'ts', label: 'affected-tests', status: 'fail' },
+      ],
+    };
+    const scenarios: CorrectnessFloorResult[] = [
+      result([fail('ts', 'typecheck')]), // base pass → net-new
+      result([fail('ts', 'affected-tests')]), // base fail → grandfathered
+      result([fail('go', 'build')]), // absent → net-new (loop policy)
+      result([pass('ts', 'typecheck'), fail('ts', 'affected-tests'), fail('kotlin', 'compile')]),
+    ];
+    for (const current of scenarios) {
+      const viaWrapper = netNewFloorFailures(current, snapshot).map((c) =>
+        checkKey(c.pack, c.label),
+      );
+      const viaComparator = attributeFloorFailures(current, snapshot.checks, {
+        absentMeans: 'net-new',
+      })
+        .filter((a) => a.attribution === 'net-new')
+        .map((a) => checkKey(a.check.pack, a.check.label));
+      expect(viaWrapper).toEqual(viaComparator);
+    }
+    // Null snapshot: every failure net-new (fails toward blocking) — both paths.
+    const current = result([fail('ts', 'typecheck')]);
+    expect(netNewFloorFailures(current, null)).toHaveLength(1);
+  });
+});
+
+describe('attributeCiFloorOutcome (two-sided CI floor, real git worktree)', () => {
+  let repo: string;
+  let baseSha: string;
+
+  /** A synthetic pack whose single check's verdict is decided by the tree
+   *  content the exec sees — so the base worktree genuinely differs. */
+  function syntheticPack(): LanguageSupport {
+    return {
+      id: 'ts',
+      correctness: {
+        execution: () => ({
+          hosts: ['any' as const],
+          toolchains: [],
+          needsBuild: false,
+          buildTarget: 'none' as const,
+          weight: 'cheap' as const,
+        }),
+        syntaxCheck: () => ({ label: 'typecheck', bin: 'check-marker', args: [] }),
+        affectedTests: () => null,
+      },
+    } as unknown as LanguageSupport;
+  }
+
+  /** exec that reads marker.txt in the RUN CWD: 'broken' → fail, else pass.
+   *  This is what makes the base worktree (old content) and the current tree
+   *  (new content) produce different verdicts through the same command. */
+  const contentExec: CommandExec = (_cmd, cwd) => {
+    try {
+      const marker = readFileSync(join(cwd, 'marker.txt'), 'utf8');
+      return marker.includes('broken')
+        ? { available: true, code: 1, output: 'marker says broken' }
+        : { available: true, code: 0, output: '' };
+    } catch {
+      return { available: false, code: -1, output: 'marker missing' };
+    }
+  };
+
+  function git(args: string[]): void {
+    execFileSync('git', args, { cwd: repo, stdio: ['ignore', 'pipe', 'pipe'] });
+  }
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'dxkit-twosided-'));
+    git(['init', '-q', '-b', 'main']);
+    git(['config', 'user.email', 't@t.co']);
+    git(['config', 'user.name', 't']);
+  });
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  async function runTwoSided(baseMarker: string, headMarker: string) {
+    writeFileSync(join(repo, 'marker.txt'), baseMarker);
+    git(['add', '-A']);
+    git(['commit', '-qm', 'base']);
+    baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim();
+    writeFileSync(join(repo, 'marker.txt'), headMarker);
+    writeFileSync(join(repo, 'feature.txt'), 'the PR change\n'); // head always differs from base
+    git(['add', '-A']);
+    git(['commit', '-qm', 'head']);
+
+    const outcome = runFloorForSurface({
+      surface: 'ci',
+      cwd: repo,
+      flag: true,
+      exec: contentExec,
+      packs: [syntheticPack()],
+      resolveEnabled: () => ({ enabled: true, reason: 'test' }),
+    });
+    return attributeCiFloorOutcome(outcome, {
+      cwd: repo,
+      base: baseSha,
+      exec: contentExec,
+      packs: [syntheticPack()],
+    });
+  }
+
+  it('PRE-EXISTING: base red + head red → warns by name, does NOT block (the onboarding-PR class)', async () => {
+    const out = await runTwoSided('broken\n', 'broken\n');
+    expect(out.blocks).toBe(false);
+    expect(out.attributed?.[0].attribution).toBe('pre-existing');
+    expect(out.summary).toContain('pre-existing');
+    expect(out.summary).toContain('not blocked');
+  }, 60_000);
+
+  it('NET-NEW: base green + head red → still BLOCKS (a bundled breakage cannot ride in)', async () => {
+    const out = await runTwoSided('fine\n', 'broken\n');
+    expect(out.blocks).toBe(true);
+    expect(out.attributed?.[0].attribution).toBe('net-new');
+    expect(out.summary).toContain('NET-NEW');
+  }, 60_000);
+
+  it('UNATTRIBUTED: base side could not run the check → disclosed, not blocked (Rule 19)', async () => {
+    // Base commit has NO marker file → the exec reports unavailable on the
+    // base side → skipped there → the head failure cannot be attributed.
+    writeFileSync(join(repo, 'other.txt'), 'seed\n');
+    git(['add', '-A']);
+    git(['commit', '-qm', 'base without marker']);
+    baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim();
+    writeFileSync(join(repo, 'marker.txt'), 'broken\n');
+    git(['add', '-A']);
+    git(['commit', '-qm', 'head adds broken marker']);
+
+    const outcome = runFloorForSurface({
+      surface: 'ci',
+      cwd: repo,
+      flag: true,
+      exec: contentExec,
+      packs: [syntheticPack()],
+      resolveEnabled: () => ({ enabled: true, reason: 'test' }),
+    });
+    const out = await attributeCiFloorOutcome(outcome, {
+      cwd: repo,
+      base: baseSha,
+      exec: contentExec,
+      packs: [syntheticPack()],
+    });
+    expect(out.blocks).toBe(false);
+    expect(out.attributed?.[0].attribution).toBe('unattributed');
+    expect(out.summary).toContain('could not be attributed');
+  }, 60_000);
+
+  it('a non-blocking outcome returns unchanged (a green PR never pays the base run)', async () => {
+    writeFileSync(join(repo, 'marker.txt'), 'fine\n');
+    git(['add', '-A']);
+    git(['commit', '-qm', 'green']);
+    const outcome = runFloorForSurface({
+      surface: 'ci',
+      cwd: repo,
+      flag: true,
+      exec: contentExec,
+      packs: [syntheticPack()],
+      resolveEnabled: () => ({ enabled: true, reason: 'test' }),
+    });
+    expect(outcome.blocks).toBe(false);
+    const out = await attributeCiFloorOutcome(outcome, { cwd: repo, exec: contentExec });
+    expect(out).toBe(outcome);
+  }, 60_000);
+});

--- a/test/correctness-floor-disclosure.test.ts
+++ b/test/correctness-floor-disclosure.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Floor disclosure — a failing build must be impossible to miss in a PR,
+ * even (especially) when it is pre-existing and therefore NOT blocking.
+ * Pins the tier vocabulary across both outputs (PR-comment markdown and
+ * GitHub check annotations), the approver call-out for a broken base
+ * branch, the reproduction commands, and silence on a green floor.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  floorDisclosureMarkdown,
+  githubAnnotations,
+} from '../src/analyzers/correctness/floor-disclosure';
+import type { SurfaceFloorOutcome } from '../src/analyzers/correctness/surface-run';
+import type { CorrectnessCheckResult } from '../src/analyzers/correctness/run';
+
+function check(
+  pack: string,
+  label: string,
+  status: CorrectnessCheckResult['status'],
+  output?: string,
+): CorrectnessCheckResult {
+  return {
+    pack: pack as CorrectnessCheckResult['pack'],
+    label,
+    bin: 'runner',
+    args: ['--flag'],
+    status,
+    ...(output ? { output } : {}),
+  };
+}
+
+function outcome(partial: Partial<SurfaceFloorOutcome>): SurfaceFloorOutcome {
+  return {
+    surface: 'ci',
+    enabled: true,
+    reason: 'test',
+    ran: true,
+    blocks: false,
+    summary: '',
+    ...partial,
+  } as SurfaceFloorOutcome;
+}
+
+describe('floorDisclosureMarkdown', () => {
+  it('is silent on a green floor', () => {
+    const o = outcome({
+      result: { ran: true, blocks: false, checks: [check('ts', 'typecheck', 'pass')] },
+    });
+    expect(floorDisclosureMarkdown(o)).toBeNull();
+    expect(githubAnnotations(o)).toEqual([]);
+  });
+
+  it('pre-existing failures get the LOUD approver call-out, with repro + output', () => {
+    const failing = check('ts', 'affected-tests', 'fail', '3 tests failed');
+    const o = outcome({
+      result: { ran: true, blocks: true, checks: [failing] },
+      blocks: false, // attributed away — not blocking
+      attributed: [{ check: failing, attribution: 'pre-existing' }],
+    });
+    const md = floorDisclosureMarkdown(o)!;
+    expect(md).toContain('BASE BRANCH BUILD/TESTS ARE BROKEN');
+    expect(md).toContain('Approvers, read this before approving');
+    expect(md).toContain('merging onto a broken build');
+    expect(md).toContain('vyuh-dxkit debt');
+    expect(md).toContain('`runner --flag`');
+    expect(md).toContain('3 tests failed');
+    const ann = githubAnnotations(o);
+    expect(ann).toHaveLength(1);
+    expect(ann[0]).toMatch(/^::warning /);
+    expect(ann[0]).toContain('BASE BRANCH is broken');
+  });
+
+  it('net-new failures get the error tier in both outputs', () => {
+    const failing = check('ts', 'typecheck', 'fail', 'error TS2304');
+    const o = outcome({
+      result: { ran: true, blocks: true, checks: [failing] },
+      blocks: true,
+      attributed: [{ check: failing, attribution: 'net-new' }],
+    });
+    const md = floorDisclosureMarkdown(o)!;
+    expect(md).toContain('this PR breaks the build/tests');
+    expect(md).toContain('BLOCKING');
+    const ann = githubAnnotations(o);
+    expect(ann[0]).toMatch(/^::error /);
+    expect(ann[0]).toContain('NET-NEW');
+  });
+
+  it('unattributed failures are disclosed as warnings, never blamed', () => {
+    const failing = check('kotlin', 'compile', 'fail');
+    const o = outcome({
+      result: { ran: true, blocks: true, checks: [failing] },
+      blocks: false,
+      attributed: [{ check: failing, attribution: 'unattributed' }],
+    });
+    expect(floorDisclosureMarkdown(o)).toContain('could not attribute');
+    expect(githubAnnotations(o)[0]).toMatch(/^::warning /);
+  });
+
+  it('a point-in-time failure (no attribution ran) still gets an error annotation', () => {
+    const failing = check('go', 'compile', 'fail', 'syntax error');
+    const o = outcome({
+      result: { ran: true, blocks: true, checks: [failing] },
+      blocks: true,
+      // no `attributed` — push to the default branch / no base resolvable
+    });
+    expect(floorDisclosureMarkdown(o)).toContain('no merge-base to attribute against');
+    expect(githubAnnotations(o)[0]).toMatch(/^::error /);
+  });
+
+  it('all three tiers coexist in one report, blocking tiers first', () => {
+    const a = check('ts', 'typecheck', 'fail');
+    const b = check('ts', 'affected-tests', 'fail');
+    const c = check('kotlin', 'compile', 'fail');
+    const o = outcome({
+      result: { ran: true, blocks: true, checks: [a, b, c] },
+      blocks: true,
+      attributed: [
+        { check: a, attribution: 'net-new' },
+        { check: b, attribution: 'pre-existing' },
+        { check: c, attribution: 'unattributed' },
+      ],
+    });
+    const md = floorDisclosureMarkdown(o)!;
+    const netNewAt = md.indexOf('this PR breaks');
+    const preAt = md.indexOf('BASE BRANCH');
+    const unAt = md.indexOf('could not attribute');
+    expect(netNewAt).toBeGreaterThanOrEqual(0);
+    expect(preAt).toBeGreaterThan(netNewAt);
+    expect(unAt).toBeGreaterThan(preAt);
+    expect(githubAnnotations(o)).toHaveLength(3);
+  });
+});

--- a/test/correctness-run.test.ts
+++ b/test/correctness-run.test.ts
@@ -86,6 +86,45 @@ describe('runCorrectnessFloor', () => {
     expect(r.checks[0].status).toBe('skipped-unavailable');
   });
 
+  it('an unavailable skip CARRIES its reason, and the disclosure surfaces it (T2.4)', async () => {
+    // The android-oculus class: ./gradlew committed without the exec bit
+    // spawned EACCES in 0.2s and read as "kotlin compile failed" with EMPTY
+    // output — an environment problem reported as broken code, undiagnosable
+    // from the gate log. The exec now reports it unavailable WITH the remedy;
+    // the runner must carry that through and the skip disclosure must name it.
+    const reason =
+      './gradlew exists but is not executable — restore the executable bit (chmod +x ./gradlew; committed to git: git update-index --chmod=+x ./gradlew)';
+    const exec: CommandExec = () => ({ available: false, code: -1, output: reason });
+    const r = runCorrectnessFloor({
+      ...base,
+      packs: [pack('kotlin', cmd('compile', './gradlew'), cmd('affected-tests', './gradlew'))],
+      exec,
+    });
+    expect(r.blocks).toBe(false); // infrastructure, never a block
+    expect(r.checks.every((c) => c.status === 'skipped-unavailable')).toBe(true);
+    expect(r.checks[0].output).toBe(reason);
+    const { describeEnvironmentSkips } = await import('../src/analyzers/correctness/run');
+    const lines = describeEnvironmentSkips(r);
+    expect(lines.some((l) => l.includes('not executable'))).toBe(true);
+  });
+
+  it('makeCommandExec: a path-like bin WITHOUT the exec bit is unavailable, resolved vs the command cwd', async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import('fs');
+    const { join } = await import('path');
+    const { tmpdir } = await import('os');
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-noexec-'));
+    try {
+      writeFileSync(join(dir, 'wrapper'), '#!/bin/sh\necho hi\n'); // mode 644
+      const exec = makeCommandExec();
+      const out = exec({ bin: './wrapper', args: [] }, dir);
+      expect(out.available).toBe(false);
+      expect(out.output).toContain('not executable');
+      expect(out.output).toContain('git update-index --chmod=+x');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('fail-OPEN: a timed-out command is skipped, not failed (a slow suite is not a broken one)', () => {
     const exec: CommandExec = (c) =>
       c.bin === 'vitest'

--- a/test/correctness-run.test.ts
+++ b/test/correctness-run.test.ts
@@ -87,7 +87,7 @@ describe('runCorrectnessFloor', () => {
   });
 
   it('an unavailable skip CARRIES its reason, and the disclosure surfaces it (T2.4)', async () => {
-    // The android-oculus class: ./gradlew committed without the exec bit
+    // The rollout class: ./gradlew committed without the exec bit
     // spawned EACCES in 0.2s and read as "kotlin compile failed" with EMPTY
     // output — an environment problem reported as broken code, undiagnosable
     // from the gate log. The exec now reports it unavailable WITH the remedy;

--- a/test/debt-cli.test.ts
+++ b/test/debt-cli.test.ts
@@ -1,0 +1,138 @@
+/**
+ * `vyuh-dxkit debt` — the composed repair inventory for cleanup agents.
+ * Pins the composition rules: baseline provenance per live floor failure
+ * (failing-since-baseline vs new-since-baseline), fixed-since-baseline
+ * credit, severity-ordered finding groups, and the plan's one hard
+ * dependency (build before tests before findings). All floor input is
+ * injected — the command's own live-run plumbing is `captureFloorDebt`,
+ * covered in test/baseline/floor-debt.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { buildDebtReport, renderDebtConsole } from '../src/debt-cli';
+import type { FloorDebt } from '../src/baseline/floor-debt';
+
+const LIVE: FloorDebt = {
+  capturedAtCommit: 'live',
+  capturedAt: '2026-07-17T00:00:00.000Z',
+  checks: [
+    {
+      pack: 'ts',
+      label: 'typecheck',
+      command: 'npx tsc --noEmit',
+      status: 'fail',
+      output: 'error TS2304: Cannot find name',
+    },
+    {
+      pack: 'ts',
+      label: 'affected-tests',
+      command: 'vitest run',
+      status: 'fail',
+      output: '3 failed',
+    },
+    { pack: 'go', label: 'compile', command: 'go build ./...', status: 'pass' },
+    {
+      pack: 'kotlin',
+      label: 'compile',
+      command: './gradlew testClasses',
+      status: 'skipped-environment',
+      unmet: 'needs the jdk toolchain',
+    },
+  ],
+};
+
+function writeBaseline(dir: string, floorDebt: object | undefined, findings: object[]): void {
+  mkdirSync(join(dir, '.dxkit', 'baselines'), { recursive: true });
+  writeFileSync(
+    join(dir, '.dxkit', 'baselines', 'main.json'),
+    JSON.stringify({
+      schemaVersion: 'dxkit-baseline/v1',
+      name: 'main',
+      createdAt: '2026-07-16T00:00:00.000Z',
+      repo: { commitSha: 'base', branch: 'main', dirty: false },
+      analysis: { dxkitVersion: 'test', toolchainHash: 'x' },
+      tools: {},
+      saltMode: 'none',
+      findings,
+      ...(floorDebt ? { floorDebt } : {}),
+    }),
+  );
+}
+
+describe('buildDebtReport', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-debt-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('classifies live failures by baseline provenance and credits fixes', () => {
+    writeBaseline(
+      dir,
+      {
+        capturedAtCommit: 'base',
+        capturedAt: '2026-07-16T00:00:00.000Z',
+        checks: [
+          { pack: 'ts', label: 'typecheck', command: 'npx tsc --noEmit', status: 'fail' },
+          { pack: 'ts', label: 'affected-tests', command: 'vitest run', status: 'pass' },
+          { pack: 'go', label: 'compile', command: 'go build ./...', status: 'fail' },
+        ],
+      },
+      [],
+    );
+    const r = buildDebtReport(dir, { liveFloor: () => LIVE });
+    const byLabel = new Map(r.floor.failures.map((f) => [`${f.pack}:${f.label}`, f]));
+    // Failing at baseline AND now → the debt this surface exists for.
+    expect(byLabel.get('ts:typecheck')?.sinceBaseline).toBe('baseline');
+    // Passing at baseline, failing now → the gate's business, but named.
+    expect(byLabel.get('ts:affected-tests')?.sinceBaseline).toBe('new');
+    // Failing at baseline, passing now → credited.
+    expect(r.floor.fixedSinceBaseline).toEqual(['go compile']);
+    // Environment boundary disclosed, never silently absent (Rule 20).
+    expect(r.floor.unobservable.some((u) => u.includes('jdk'))).toBe(true);
+  });
+
+  it('no baseline envelope → provenance is unknown, never fabricated', () => {
+    writeBaseline(dir, undefined, []);
+    const r = buildDebtReport(dir, { liveFloor: () => LIVE });
+    expect(r.floor.failures.every((f) => f.sinceBaseline === 'unknown')).toBe(true);
+  });
+
+  it('groups findings by severity rank and orders the plan build → tests → findings', () => {
+    writeBaseline(dir, undefined, [
+      { id: 'aaaa000000000001', kind: 'stale-file', file: 'x.bak', suffix: 'bak' },
+      { id: 'aaaa000000000002', kind: 'secret', file: 'src/cfg.ts' },
+      { id: 'aaaa000000000003', kind: 'secret', file: 'src/env.ts' },
+      { id: 'aaaa000000000004', kind: 'dep-vuln', package: 'adm-zip', version: '0.5.17' },
+    ]);
+    const r = buildDebtReport(dir, { liveFloor: () => LIVE });
+    expect(r.findings.total).toBe(4);
+    // secret (high) before dep-vuln (medium) before stale-file (low).
+    expect(r.findings.groups.map((g) => g.kind)).toEqual(['secret', 'dep-vuln', 'stale-file']);
+    expect(r.findings.groups[0].count).toBe(2);
+    expect(r.findings.groups[0].samples[0].fingerprint).toBe('aaaa000000000002');
+    // The one hard dependency: build first, then tests, then findings.
+    expect(r.plan[0]).toContain('Fix the build first');
+    expect(r.plan[0]).toContain('npx tsc --noEmit');
+    expect(r.plan[1]).toContain('failing tests');
+    expect(r.plan[2]).toContain('secret');
+  });
+
+  it('renders a console report with repro commands and the suggested order', () => {
+    writeBaseline(dir, undefined, []);
+    const out = renderDebtConsole(buildDebtReport(dir, { liveFloor: () => LIVE }));
+    expect(out).toContain('never gates');
+    expect(out).toContain('repro: npx tsc --noEmit');
+    expect(out).toContain('SUGGESTED ORDER');
+  });
+
+  it('no baseline file at all still inventories the live floor and says what is missing', () => {
+    const r = buildDebtReport(dir, { liveFloor: () => LIVE });
+    expect(r.baselinePresent).toBe(false);
+    expect(r.floor.failures.length).toBeGreaterThan(0);
+    const out = renderDebtConsole(r);
+    expect(out).toContain('baseline create');
+  });
+});

--- a/test/fixtures-analysis.test.ts
+++ b/test/fixtures-analysis.test.ts
@@ -27,6 +27,7 @@ import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { gatherFileFindings } from '../src/analyzers/security/gather';
 import { gatherGrepSecretsResult } from '../src/analyzers/tools/grep-secrets';
+import { gatherHygieneMarkers } from '../src/analyzers/quality/gather';
 import { gatherRepoFlowModel } from '../src/analyzers/flow/gather';
 import { gatherRepoModelSet } from '../src/analyzers/model-schema/gather';
 import { summarize } from '../src/analyzers/flow/model';
@@ -43,6 +44,11 @@ const FIXTURES = join(__dirname, 'fixtures', 'analysis');
 const MATERIALIZE: Array<{ marker: string; target: string }> = [
   { marker: 'env.example', target: '.env.example' },
   { marker: 'dxkit-policy.json', target: '.dxkit/policy.json' },
+  // Stale-suffix targets are committed under marker names for TWO reasons:
+  // node_modules/ is gitignored repo-wide, and a tracked `*.orig` would be
+  // flagged by dxkit's own self-guardrail hygiene scan.
+  { marker: 'nm-lookup-orig.marker', target: 'node_modules/cldr/dist/lookup.js.orig' },
+  { marker: 'src-legacy-orig.marker', target: 'src/legacy.js.orig' },
 ];
 
 /** Copy a fixture into a throwaway git repo (env-in-git needs tracked files). */
@@ -126,6 +132,17 @@ describe('analysis fixtures — language-agnostic invariants (every stack)', () 
       expect(result!.suppressedCount).toBeGreaterThanOrEqual(1);
     });
   }
+
+  it('ts-webapp: a tracked .orig under node_modules is NOT a stale file; one in src/ IS (T2.2)', () => {
+    // The rollout bug: a repo with node_modules committed to git got
+    // `node_modules/**/*.orig` flagged as net-new stale files (its baseline
+    // install tree differed from CI's `npm ci` tree). Stale-file discovery
+    // must consult the ONE exclusion source (Rule 4). The src/ control pins
+    // that the filter is exclusion-scoped, not suffix-dead.
+    const { staleFiles } = gatherHygieneMarkers(staged['ts-webapp']);
+    expect(staleFiles.some((f) => f.startsWith('node_modules/'))).toBe(false);
+    expect(staleFiles).toContain('src/legacy.js.orig');
+  });
 });
 
 describe('analysis fixtures — model-schema extraction (marker-based, every stack)', () => {

--- a/test/fixtures/analysis/ts-webapp/nm-lookup-orig.marker
+++ b/test/fixtures/analysis/ts-webapp/nm-lookup-orig.marker
@@ -1,0 +1,1 @@
+// pre-existing editor backup inside a vendored node_modules — NOT a finding

--- a/test/fixtures/analysis/ts-webapp/src-legacy-orig.marker
+++ b/test/fixtures/analysis/ts-webapp/src-legacy-orig.marker
@@ -1,0 +1,1 @@
+// a real tracked editor backup in source — IS a finding

--- a/test/jvm-build-android.test.ts
+++ b/test/jvm-build-android.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Android-Gradle detection (`isAndroidGradleBuild`) — the JVM packs'
+ * correctness-floor `declineWhen`. If this misses, the kotlin/java floor
+ * runs plain `gradlew testClasses` on an Android repo and fails on
+ * variant-specific tasks (or worse, on infrastructure) — the T2.4 rollout
+ * bug: a modern catalog-based repo carries the `com.android` literal ONLY
+ * in gradle/libs.versions.toml (`alias(libs.plugins.android.application)`
+ * in build files), which the root-build-file sniff never saw.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { isAndroidGradleBuild } from '../src/languages/jvm-build';
+
+const dirs: string[] = [];
+function repo(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-android-'));
+  dirs.push(dir);
+  for (const [rel, content] of Object.entries(files)) {
+    mkdirSync(join(dir, rel, '..'), { recursive: true });
+    writeFileSync(join(dir, rel), content);
+  }
+  return dir;
+}
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe('isAndroidGradleBuild', () => {
+  it('detects the classic shape: com.android classpath in the root build file', () => {
+    const dir = repo({
+      'build.gradle':
+        'buildscript { dependencies { classpath "com.android.tools.build:gradle:8.0.0" } }\n',
+    });
+    expect(isAndroidGradleBuild(dir)).toBe(true);
+  });
+
+  it('detects the VERSION-CATALOG shape — com.android only in libs.versions.toml (the shipped miss)', () => {
+    const dir = repo({
+      'build.gradle.kts': 'plugins { alias(libs.plugins.android.application) apply false }\n',
+      'settings.gradle.kts': 'rootProject.name = "app"\ninclude(":app")\n',
+      'gradle/libs.versions.toml':
+        '[plugins]\nandroid-application = { id = "com.android.application", version.ref = "agp" }\n',
+    });
+    expect(isAndroidGradleBuild(dir)).toBe(true);
+  });
+
+  it('detects a first-level module declaring the plugin id directly', () => {
+    const dir = repo({
+      'settings.gradle.kts': 'include(":app")\n',
+      'app/build.gradle.kts': 'plugins { id("com.android.application") }\n',
+    });
+    expect(isAndroidGradleBuild(dir)).toBe(true);
+  });
+
+  it('stays FALSE for a plain (non-Android) Gradle build — the floor must keep running there', () => {
+    const dir = repo({
+      'build.gradle.kts': 'plugins { kotlin("jvm") version "2.0.0" }\n',
+      'settings.gradle.kts': 'rootProject.name = "svc"\n',
+      'gradle/libs.versions.toml': '[versions]\nkotlin = "2.0.0"\n',
+      'app/build.gradle.kts': 'plugins { application }\n',
+    });
+    expect(isAndroidGradleBuild(dir)).toBe(false);
+  });
+});

--- a/test/loop/stop-gate-cache.test.ts
+++ b/test/loop/stop-gate-cache.test.ts
@@ -5,8 +5,11 @@ import { tmpdir } from 'os';
 import * as path from 'path';
 import {
   workingTreeSignature,
+  environmentSignature,
+  registryToolStamps,
   readStateCache,
   writeStateCache,
+  clearStateCache,
   loopGateActive,
   type StopGateStateCache,
 } from '../../src/loop/gate-cache';
@@ -140,6 +143,110 @@ describe('verdict cache read/write', () => {
       JSON.stringify({ signature: 'x', outcome: 'block-operator' }),
     );
     expect(readStateCache(repo)).toBeNull();
+  });
+
+  it('a LEGACY entry (no envSignature) can never match a computed environment key', () => {
+    // Entries written before T1.3 carry no envSignature. The Stop-gate
+    // requires `cached.envSignature === envSignature` (a real string), so
+    // a legacy entry is a MISS — the gate re-scans rather than replaying a
+    // verdict minted under an unknown environment.
+    const legacy = {
+      signature: 'tree-sig',
+      outcome: 'allow',
+      message: '',
+      netNew: 0,
+      baselineFindings: 3,
+    };
+    const dir = path.join(repo, '.dxkit', 'loop');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'last-state.json'), JSON.stringify(legacy));
+    const cached = readStateCache(repo);
+    expect(cached).not.toBeNull();
+    const envSig = environmentSignature(repo, { preset: 'security-only', policy: {} }, ['t:x']);
+    expect(cached!.envSignature === envSig).toBe(false);
+  });
+
+  it('clearStateCache removes the verdict (loop activation = session scope)', () => {
+    const c: StopGateStateCache = {
+      signature: 'abc',
+      envSignature: 'env',
+      outcome: 'allow',
+      message: '',
+      netNew: 0,
+      baselineFindings: 1,
+    };
+    writeStateCache(repo, c);
+    expect(readStateCache(repo)).not.toBeNull();
+    clearStateCache(repo);
+    expect(readStateCache(repo)).toBeNull();
+  });
+});
+
+describe('environmentSignature (the observer half of the cache key — T1.3)', () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+    delete process.env.DXKIT_LOOP_TEST_COMMAND;
+  });
+
+  const inputs = { preset: 'security-only', policy: { block: [] }, modes: { flowMode: 'off' } };
+  const stamps = ['tool:gitleaks:/usr/bin/gitleaks:100:1'];
+
+  it('is deterministic for identical inputs', () => {
+    expect(environmentSignature(repo, inputs, stamps)).toBe(
+      environmentSignature(repo, inputs, stamps),
+    );
+  });
+
+  it('changes when the policy changes', () => {
+    const other = { ...inputs, policy: { block: ['added'] } };
+    expect(environmentSignature(repo, other, stamps)).not.toBe(
+      environmentSignature(repo, inputs, stamps),
+    );
+  });
+
+  it('changes when the preset changes', () => {
+    const other = { ...inputs, preset: 'full-debt' };
+    expect(environmentSignature(repo, other, stamps)).not.toBe(
+      environmentSignature(repo, inputs, stamps),
+    );
+  });
+
+  it('changes when a gate mode changes', () => {
+    const other = { ...inputs, modes: { flowMode: 'block' } };
+    expect(environmentSignature(repo, other, stamps)).not.toBe(
+      environmentSignature(repo, inputs, stamps),
+    );
+  });
+
+  it('changes when the resolved postflight test command changes', () => {
+    const before = environmentSignature(repo, inputs, stamps);
+    process.env.DXKIT_LOOP_TEST_COMMAND = 'npm run test:special';
+    expect(environmentSignature(repo, inputs, stamps)).not.toBe(before);
+  });
+
+  it('changes when a scanner binary stamp changes (the stale-ALLOW replay hole)', () => {
+    // A byte-identical tree with an upgraded scanner MUST miss: the old
+    // key replayed the previous verdict and the drift Rule 19 exists to
+    // catch was never consulted.
+    const upgraded = ['tool:gitleaks:/usr/bin/gitleaks:200:2'];
+    expect(environmentSignature(repo, inputs, upgraded)).not.toBe(
+      environmentSignature(repo, inputs, stamps),
+    );
+  });
+
+  it('registryToolStamps is deterministic, sorted, and covers the whole registry', () => {
+    const a = registryToolStamps(repo);
+    const b = registryToolStamps(repo);
+    expect(a).toEqual(b);
+    expect(a).toEqual([...a].sort());
+    // One stamp per registry tool — the probe iterates ALL of TOOL_DEFS
+    // (no per-kind tool table; over-invalidation is the safe direction).
+    expect(a.length).toBeGreaterThan(10);
+    for (const s of a) expect(s.startsWith('tool:')).toBe(true);
   });
 });
 

--- a/test/reachability.test.ts
+++ b/test/reachability.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  annotateReachability,
   buildReachablePackageSet,
   markReachable,
   specifierToPackage,
@@ -99,5 +100,41 @@ describe('markReachable', () => {
     expect(fs[0].reachable).toBe(true);
     expect(fs[1].reachable).toBe(true);
     expect(fs[2].reachable).toBe(false);
+  });
+});
+
+describe('annotateReachability (the ONE entry point both gather paths consume — T1.2)', () => {
+  function finding(pkg: string): DepVulnFinding {
+    return { id: 'CVE-1', package: pkg, tool: 'test', severity: 'high' };
+  }
+  function imports(specsByFile: Record<string, string[]>): ImportsResult {
+    const extracted = new Map<string, ReadonlyArray<string>>();
+    for (const [f, s] of Object.entries(specsByFile)) extracted.set(f, s);
+    return {
+      schemaVersion: 1,
+      tool: 'test',
+      sourceExtensions: ['.ts'],
+      extracted,
+      edges: new Map(),
+    };
+  }
+
+  it('marks findings from a populated envelope', () => {
+    const fs = [finding('axios'), finding('inert')];
+    annotateReachability(fs, imports({ 'src/a.ts': ['axios'] }));
+    expect(fs[0].reachable).toBe(true);
+    expect(fs[1].reachable).toBe(false);
+  });
+
+  it('a null envelope leaves reachable UNSET — unknown, never mass-false', () => {
+    const fs = [finding('axios')];
+    annotateReachability(fs, null);
+    expect(fs[0].reachable).toBeUndefined();
+  });
+
+  it('an empty envelope (no files parsed) leaves reachable UNSET', () => {
+    const fs = [finding('axios')];
+    annotateReachability(fs, imports({}));
+    expect(fs[0].reachable).toBeUndefined();
   });
 });

--- a/test/tool-registry-version-pins.test.ts
+++ b/test/tool-registry-version-pins.test.ts
@@ -53,6 +53,10 @@ const PINNED_TOOLS: Record<string, string> = {
   'golangci-lint': '@v1.64.8',
   govulncheck: '@v1.3.0',
   'go-licenses': '@v1.6.0',
+  // T2.1 (4.0.3): previously KNOWN_UNPINNED on `releases/latest`, which was
+  // both unpinned AND unverifiable. Now pinned to a bundle tag with the
+  // release's published sha256 checksums verified at install time.
+  codeql: 'codeql-bundle-v2.26.1',
 };
 
 /**
@@ -67,9 +71,6 @@ const PINNED_TOOLS: Record<string, string> = {
  *   - `snyk` — a SaaS CLI that authenticates against Snyk's backend and
  *     self-manages client/server compatibility. Pinning an old client
  *     risks server-side deprecation breaking it; let it float.
- *   - `codeql` — a GitHub-managed bundle paired with versioned query
- *     packs; the CLI and packs must stay in lockstep, so GitHub's
- *     channel owns the version, not dxkit.
  *   - `cloc` — a stable line-counter on a non-semver npm tag
  *     (`2.6.0-cloc`); lowest-risk output schema in the registry, and the
  *     odd version string makes a clean pin fragile for negligible gain.
@@ -77,7 +78,7 @@ const PINNED_TOOLS: Record<string, string> = {
  * Moving a tool here into PINNED_TOOLS (with a tested version) is the
  * closure step for any future backlog entry.
  */
-const KNOWN_UNPINNED = ['eslint', 'vitest-coverage', 'snyk', 'codeql', 'cloc'];
+const KNOWN_UNPINNED = ['eslint', 'vitest-coverage', 'snyk', 'cloc'];
 
 /**
  * Tools installed through a system / language package manager that owns its
@@ -158,4 +159,80 @@ describe('tool-registry version pins', () => {
     const stale = [...counts.keys()].filter((n) => !registry.has(n));
     expect(stale, `bucketed tools no longer in the registry: ${stale.join(', ')}`).toEqual([]);
   });
+});
+
+describe('tool-registry download verification (T2.1 supply chain)', () => {
+  const allCommands: Array<{ name: string; cmd: string }> = [];
+  for (const [name, def] of Object.entries(TOOL_DEFS)) {
+    for (const cmd of Object.values(def.installCommands ?? {})) {
+      if (typeof cmd === 'string' && cmd.length > 0) allCommands.push({ name, cmd });
+    }
+  }
+
+  it('every dxkit_fetch call carries a 64-hex sha256 argument', () => {
+    // dxkit_fetch <url> <sha256> <dest> — a call missing the hash (or with a
+    // truncated one) would verify nothing while LOOKING verified.
+    const calls = allCommands.filter(({ cmd }) => cmd.includes('dxkit_fetch '));
+    expect(calls.length).toBeGreaterThanOrEqual(7); // gitleaks, osv×2, dotnet×2, pmd, detekt, ktlint, codeql×2
+    for (const { name, cmd } of calls) {
+      for (const m of cmd.matchAll(/dxkit_fetch\s+(\S+)\s+(\S+)\s+/g)) {
+        expect(m[1], `${name}: dxkit_fetch first arg should be a URL`).toMatch(/^["']?https:\/\//);
+        expect(m[2], `${name}: dxkit_fetch second arg must be a sha256: ${cmd}`).toMatch(
+          /^[0-9a-f]{64}$/,
+        );
+      }
+    }
+  });
+
+  it('no unverified network download remains in any install command', () => {
+    // Runtime mirror of the arch-check rule: a raw curl/wget with a URL is a
+    // new unverified download path; an Invoke-WebRequest must be paired with
+    // a Get-FileHash comparison in the same command.
+    for (const { name, cmd } of allCommands) {
+      const rawFetch = /(curl|wget)\s[^|]*https?:\/\//.test(cmd);
+      expect(rawFetch, `${name}: unverified curl/wget download: ${cmd}`).toBe(false);
+      if (cmd.includes('Invoke-WebRequest')) {
+        expect(cmd, `${name}: Invoke-WebRequest without Get-FileHash: ${cmd}`).toContain(
+          'Get-FileHash',
+        );
+      }
+    }
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'dxkit_fetch verifies and fails CLOSED on mismatch (functional)',
+    async () => {
+      const { DXKIT_FETCH_PREAMBLE } = await import('../src/analyzers/tools/install-exec');
+      const { execSync } = await import('child_process');
+      const { mkdtempSync, writeFileSync, existsSync, rmSync } = await import('fs');
+      const { createHash } = await import('crypto');
+      const { join } = await import('path');
+      const { tmpdir } = await import('os');
+      const dir = mkdtempSync(join(tmpdir(), 'dxkit-fetch-'));
+      try {
+        const src = join(dir, 'artifact.bin');
+        writeFileSync(src, 'artifact-bytes\n');
+        const sha = createHash('sha256').update('artifact-bytes\n').digest('hex');
+        const good = join(dir, 'good.out');
+        const bad = join(dir, 'bad.out');
+        // Correct hash → artifact lands at dest.
+        execSync(`${DXKIT_FETCH_PREAMBLE}\ndxkit_fetch "file://${src}" ${sha} "${good}"`, {
+          shell: '/bin/bash',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        expect(existsSync(good)).toBe(true);
+        // Wrong hash → non-zero exit AND no artifact at dest (fail closed).
+        const wrong = '0'.repeat(64);
+        expect(() =>
+          execSync(`${DXKIT_FETCH_PREAMBLE}\ndxkit_fetch "file://${src}" ${wrong} "${bad}"`, {
+            shell: '/bin/bash',
+            stdio: ['ignore', 'pipe', 'pipe'],
+          }),
+        ).toThrow();
+        expect(existsSync(bad)).toBe(false);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/test/vitest-setup.ts
+++ b/test/vitest-setup.ts
@@ -1,0 +1,13 @@
+/**
+ * Suite-wide environment defaults.
+ *
+ * DXKIT_BASELINE_NO_FLOOR: `createBaseline` captures the floor-debt
+ * envelope (a full compile + test pass) by DEFAULT in the product — but the
+ * suite calls `createBaseline` on hundreds of throwaway fixture repos, and
+ * paying a floor run per fixture would add minutes of pure noise (fixtures
+ * have no real toolchain to measure). The env opt-out keeps the suite fast;
+ * the capture path itself is exercised explicitly by
+ * `test/baseline/floor-debt.test.ts`, which passes `floor: true` (an
+ * explicit option always beats the env).
+ */
+process.env.DXKIT_BASELINE_NO_FLOOR = '1';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     // the integration suite as a separate step (`.github/workflows/
     // ci.yml`) so PRs still validate it.
     include: ['test/**/*.test.ts'],
+    setupFiles: ['test/vitest-setup.ts'],
     exclude: [
       'node_modules/**',
       'dist/**',

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   },
   test: {
     include: ['test/integration/**/*.test.ts'],
+    setupFiles: ['test/vitest-setup.ts'],
     exclude: ['node_modules/**', 'dist/**'],
     testTimeout: 120000,
   },


### PR DESCRIPTION
4.0.3 — correctness and trust. Closes the three enforcement-boundary holes the external audit verified against 4.0.2, the supply-chain gap, and the defect cluster the first real multi-repo rollout surfaced. Every fix lands as a class fix through one canonical path, with an enforcement net (arch-check rule, compile-enforced table, or parity/playbook test) and a test reproducing the exact shipped bug. Rebase-merge: one commit per item, each independently meaningful.

## Commits (one per plan item)

- **T1.1** `fix(guardrail)`: changed-line attribution diffs base → WORKING TREE via one canonical index beside `computeChangedFiles` — an uncommitted or untracked high/crit finding now blocks. Orchestration tests leave their edits uncommitted (every prior fixture committed them — why this shipped) and mint `code` findings via the ingest path so CI needs no semgrep.
- **T1.2** `fix(guardrail)`: the high-reachable dep-vuln rule fires. Reachability annotated on the guardrail gather (one entry point), threaded into classification, and `BLOCK_RULE_EVIDENCE` makes rule→evidence a compile-enforced declaration.
- **T1.3** `fix(loop)`: Stop-gate cache key gains an environment signature (dxkit/node versions, policy+preset+modes, test command, spawn-free whole-registry binary stamps) + activation clears the cache. Legacy entries never replay.
- **T2.1** `feat(security)`: every executed download is sha256-verified fail-closed via one `dxkit_fetch` primitive; codeql pinned to a bundle tag with publisher checksums; dotnet-install pinned to an immutable commit; arch-check bans unverified fetches (verified to bite); live-proven against the real gitleaks release.
- **T2.2** `fix(quality)`: stale-file discovery honors the canonical exclusions (the committed-node_modules class), pinned by an analysis-fixture case both directions.
- **T2.4** `fix(floor)`: catalog-based Android detection (the `com.android`-only-in-libs.versions.toml shape); unspawnable commands (a wrapper committed without the exec bit → EACCES in 0.2s) are disclosed fail-open skips with the remedy, never "compile failed" with empty output; and a failing floor check always prints its command and output (or says explicitly that there was none).
- **T2.3** `feat(floor)`: the CI floor is diff-scoped through ONE comparator shared with the loop — base pass → net-new BLOCKS (bundled breakage still caught), base fail → pre-existing warns by name, base unobserved → unattributed + disclosed (Rule 19). Green PRs pay nothing.
- **T2.5** `docs(trust)`: SECURITY.md → 4.x, "every stop" claims scoped to unattended loops, floor claim stated precisely, benchmark preset caveat beside the 0/16 headline. GitHub Discussions enabled.
- `chore(release)`: 4.0.3 bump + CHANGELOG + CLAUDE.md rule codification.

## Gates

typecheck, typecheck:test, eslint, prettier, architecture, cross-ecosystem coverage, docs coverage, slop, build, full suite (302 files / 4,451 tests) — all green locally.

## DoD: the 4.0.3 tarball against all 10 open rollout PRs (external org, anonymized)

| Repo (by stack) | 4.0.2 gate | 4.0.3 tarball | Why |
| --- | --- | --- | --- |
| node lib A | green | **GREEN** | no regression |
| node lib B | green | **GREEN** | no regression |
| docs site | green | **GREEN** | no regression |
| python service | green | **GREEN** | no regression |
| android app A | RED | **GREEN** | T2.4 (catalog Android detection; floor declines as designed) |
| android app B | RED | **GREEN** | T2.4 |
| node service A | RED | **GREEN** | T2.2 (committed-node_modules stale-file) |
| web client A | RED | **GREEN** | T2.3 (pre-existing test failures attributed, warned, not blocked) |
| web client B | RED | **GREEN** | T2.3 |
| backend service | green | RED — **true positive** | the revived T1.2 rule caught a real high-severity, import-reachable dep-vuln advisory published after their baseline capture. Needs triage on their side (bump / allowlist / re-baseline via `update`), not a dxkit fix. |

## Added after review discussion: the floor-debt inventory (`debt`)

The adoption arc the gate fixes enable — arm the gates, then deploy agents to clean the baseline, including fixing the build — needed a durable, detailed surface for the correctness-floor debt the gates grandfather:

- **`baseline create` now records a `floorDebt` envelope** on the baseline file: every floor check at capture time with its reproduction command and captured error output (bounded per-check; opt out with `--no-floor`). Rule 15 intact — informational only, never a gate input, never allowlistable; no schema bump.
- **`vyuh-dxkit debt [--json]`**: the composed repair inventory — live floor state with baseline provenance (failing-since-baseline / new / fixed), finding debt by severity, and a priority-ordered plan (build first, then tests, then findings; unmeasurable checks disclosed with their remedy). Always exits 0; the gates hold the ratchet.
- Registered per Rule 16 (descriptor, doctor recommendation when the baseline carries floor debt, and the dxkit-action skill gains the baseline-cleanup playbook). Proven end-to-end on a broken-build fixture through the real CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Also added: a failing build is LOUD in the PR, even when pre-existing

"Warn" must never mean "a line in a green check's log". One disclosure builder now feeds the PR comment (a broken base branch gets an explicit approver call-out — *"approving merges onto a broken build"* — with repro commands + output), GitHub check annotations (`::error` net-new / `::warning` pre-existing + unattributed), and the workflow step summary. Green floors stay silent. Proven end-to-end on a broken-base fixture under a simulated Actions environment.
