### PR TITLE
4.0.4: activate the extension trust + safety boundaries (v2-audit cluster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **The plugin-trust boundary is now ACTIVE on the shipped PR workflow.** The
+  generated guardrail workflow passes `--untrusted` on `pull_request` events
+  (gate and flow console), so executable flow/extension plugins from a PR head
+  never run — the boundary existed but nothing turned it on. Plugin-derived
+  routes still reach the gate via the committed `served.json` produced from
+  trusted default-branch runs. The `flow` view commands (`map` / `trace` /
+  `extract` / `console`) accept `--untrusted` directly.
+- **Extension output can no longer target a user file.** `output` must live
+  under `.dxkit/` (convention: `.dxkit/contrib/<name>.json`) — previously
+  `package.json` was a legal target and the runner deleted it before every
+  run. ⚠ Tightening: an extension writing elsewhere now fails validation with
+  the migration path in the message; every shipped example already complied.
+  The runner also RESTORES the last-known-good snapshot when a refresh fails
+  or times out, and persists new snapshots atomically.
+
+### Fixed
+
+- **`refresh: manual` finally means manual.** The generated on-merge workflow
+  now runs `extensions refresh --scheduled on-merge`, so extensions declaring
+  `refresh: manual` are skipped there (previously the unfiltered refresh ran
+  everything). An explicit operator `extensions refresh` still runs all.
+- **Wire `file` locators are validated as the contract always claimed.**
+  `contract.v1` / `inventory.v1` / `findings.v1` reject absolute, traversal,
+  drive-prefixed, and non-POSIX paths with field-precise errors — they feed
+  finding identity, and a silent violation corrupted fingerprints. ⚠
+  Tightening for extensions that emitted non-canonical paths.
+- Extension-SDK docs no longer call the rung-4 plugin path "sandboxed" — it
+  is in-process and trust-tier-gated, not OS-sandboxed.
+
 ## [4.0.3] - 2026-07-17
 
 Correctness and trust. Closes the three enforcement-boundary holes an external

--- a/docs/extension-sdk.md
+++ b/docs/extension-sdk.md
@@ -19,7 +19,7 @@ never leave rungs 1 and 2.
 | 1    | a `.dxkit/policy.json` key                  | no                           |
 | 2    | a path to an artifact you already have      | no                           |
 | 3    | a manifest pointing at your existing script | your script, at refresh time |
-| 4    | a TypeScript plugin (mostly a data table)   | sandboxed, in-process        |
+| 4    | a TypeScript plugin (mostly a data table)   | in-process, NOT OS-sandboxed |
 
 ## What is frozen
 

--- a/src-templates/.github/workflows/dxkit-extensions-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-extensions-refresh.yml
@@ -81,4 +81,6 @@ __DXKIT_CI_RUNTIME_SETUP__
           # Runs every committed extension manifest and lands the snapshot
           # delta — execution/validation/landing logic lives in the tested
           # CLI, never in this workflow's bash.
-          "${DXKIT}" extensions refresh --land pr
+          # --scheduled on-merge: only extensions that DECLARED the on-merge
+          # trigger run here; `refresh: manual` extensions are skipped (S-14).
+          "${DXKIT}" extensions refresh --scheduled on-merge --land pr

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -164,7 +164,14 @@ __DXKIT_CI_RUNTIME_SETUP__
             EXTRA="--mode ref-based --ref origin/${DXKIT_PR_BASE:-$DEFAULT_BRANCH}"
           fi
           set +e
-          "${DXKIT}" guardrail check $EXTRA --markdown > guardrail-report.md
+          # S-05 (4.0.4): a pull_request head is third-party input — run with
+          # the plugin-trust boundary ACTIVE. Executable flow/extension
+          # plugins are disabled (disclosed, not silent); plugin-derived
+          # routes still reach the gate through the committed served.json
+          # snapshot, which was produced from trusted default-branch runs.
+          UNTRUSTED=""
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then UNTRUSTED="--untrusted"; fi
+          "${DXKIT}" guardrail check $EXTRA $UNTRUSTED --markdown > guardrail-report.md
           code=$?
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           # Surface WHY it blocked in the job log itself (not only the PR
@@ -222,7 +229,9 @@ __DXKIT_CI_RUNTIME_SETUP__
             DXKIT=vyuh-dxkit
           fi
           set +e
-          "${DXKIT}" flow console --diff "${{ github.event.pull_request.base.sha }}" \
+          UNTRUSTED=""
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then UNTRUSTED="--untrusted"; fi
+          "${DXKIT}" flow console $UNTRUSTED --diff "${{ github.event.pull_request.base.sha }}" \
             --out flow-console.html --json > console.json 2>/dev/null
           set -e
           eps=$(node -e "try{const j=require('./console.json');process.stdout.write(String((j.shownEndpoints||0)+(j.broken||0)))}catch(e){process.stdout.write('0')}" 2>/dev/null || echo 0)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -981,6 +981,7 @@ export async function run(argv: string[]): Promise<void> {
         stub: !!values.stub,
         plugin: !!values.plugin,
         land: values.land as string | undefined,
+        scheduled: values.scheduled as string | undefined,
       });
       break;
     }
@@ -1299,7 +1300,14 @@ export async function run(argv: string[]): Promise<void> {
       // `flow` / `flow map` → the traceability map (writes the graph overlay).
       if (subCommand === undefined || subCommand === 'map') {
         const { runFlowMap } = await import('./flow-cli');
-        await runFlowMap({ cwd, frontend, backend, specs, json: !!values.json });
+        await runFlowMap({
+          cwd,
+          frontend,
+          backend,
+          specs,
+          json: !!values.json,
+          untrusted: !!values.untrusted,
+        });
         break;
       }
       // `flow trace "<METHOD> <path>"` → one endpoint's full trace.
@@ -1310,7 +1318,15 @@ export async function run(argv: string[]): Promise<void> {
           process.exit(1);
         }
         const { runFlowTrace } = await import('./flow-cli');
-        await runFlowTrace({ cwd, frontend, backend, specs, json: !!values.json, target });
+        await runFlowTrace({
+          cwd,
+          frontend,
+          backend,
+          specs,
+          json: !!values.json,
+          untrusted: !!values.untrusted,
+          target,
+        });
         break;
       }
       // `flow extract` → the parity CSVs.
@@ -1323,6 +1339,7 @@ export async function run(argv: string[]): Promise<void> {
           specs,
           out: values.out as string | undefined,
           json: !!values.json,
+          untrusted: !!values.untrusted,
         });
         break;
       }
@@ -1339,6 +1356,7 @@ export async function run(argv: string[]): Promise<void> {
           out: values.out as string | undefined,
           noGate: !!values['no-gate'],
           json: !!values.json,
+          untrusted: !!values.untrusted,
         });
         break;
       }

--- a/src/extensions-cli.ts
+++ b/src/extensions-cli.ts
@@ -61,6 +61,12 @@ export interface ExtensionsOptions {
   /** refresh: land the snapshot changes ('pr' = standing PR, 'push' = direct
    *  [skip ci] commit). Omitted → refresh writes the working tree only. */
   readonly land?: string;
+  /** refresh: run only extensions whose manifest declares this `refresh`
+   *  trigger (e.g. 'on-merge'). The generated on-merge workflow passes it,
+   *  so `refresh: manual` finally MEANS manual (S-14) — previously the
+   *  unfiltered refresh ran every extension. Omitted → all (explicit
+   *  operator invocation keeps its run-everything semantics). */
+  readonly scheduled?: string;
   /** init: contribution kind. */
   readonly kind?: string;
   /** init: the run command line (first token = interpreter, rest = args). */
@@ -284,10 +290,19 @@ export async function runExtensionsCli(
     }
 
     case 'refresh': {
-      const chosen = target ? extensions.filter((e) => e.manifest.name === target) : extensions;
+      let chosen = target ? extensions.filter((e) => e.manifest.name === target) : extensions;
       if (target && chosen.length === 0) {
         logger.fail(`No extension named '${target}' under ${EXTENSIONS_DIR}/.`);
         return 1;
+      }
+      if (opts.scheduled) {
+        const skipped = chosen.filter((e) => e.manifest.refresh !== opts.scheduled);
+        chosen = chosen.filter((e) => e.manifest.refresh === opts.scheduled);
+        for (const e of skipped) {
+          logger.info(
+            `  ${e.manifest.name}: refresh '${e.manifest.refresh}' — skipped by --scheduled ${opts.scheduled}`,
+          );
+        }
       }
       logger.header('vyuh-dxkit extensions refresh');
       for (const e of errors) logger.fail(`  ${e}`);

--- a/src/extensions/contributions/validate.ts
+++ b/src/extensions/contributions/validate.ts
@@ -80,6 +80,60 @@ function checkOptionalString(
   }
 }
 
+/**
+ * Why a `file` value is NOT a repo-relative POSIX path, or null when it is
+ * (S-15 / 4.0.4). The wire contract PROMISES repo-relative POSIX locators —
+ * they feed finding identity (Rule 9) and topology evidence — but the
+ * validators accepted any string, so absolute paths, traversal, drive
+ * prefixes, and backslashes could enter fingerprints (the exact class the
+ * 3.8 parseLocated boundary closed for linters). A protocol invariant is
+ * VALIDATED at the boundary, never assumed.
+ */
+function fileLocatorError(v: string): string | null {
+  if (v.includes('\0')) return 'must not contain NUL bytes';
+  if (v.startsWith('/') || v.startsWith('\\'))
+    return 'must be repo-relative (got an absolute path)';
+  if (/^[A-Za-z]:/.test(v)) return 'must be repo-relative (got a drive-prefixed path)';
+  if (v.includes('\\')) return 'must use POSIX separators (got a backslash)';
+  const segs = v.split('/');
+  if (segs.some((seg) => seg === '..')) return "must not traverse ('..' segment)";
+  if (segs.some((seg) => seg === ''))
+    return 'must not contain empty segments (leading/double slash)';
+  return null;
+}
+
+/** `file` locator, required: non-empty string AND a valid repo-relative
+ *  POSIX path. */
+function checkRequiredFile(
+  sink: ErrorSink,
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+): void {
+  checkRequiredString(sink, obj, key, path);
+  const v = obj[key];
+  if (typeof v === 'string' && v.length > 0) {
+    const err = fileLocatorError(v);
+    if (err) sink.add(`${path}.${key}`, `${err} (got ${JSON.stringify(v)})`);
+  }
+}
+
+/** `file` locator, optional: absent fine; present must be a valid
+ *  repo-relative POSIX path. */
+function checkOptionalFile(
+  sink: ErrorSink,
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+): void {
+  checkOptionalString(sink, obj, key, path);
+  const v = obj[key];
+  if (typeof v === 'string') {
+    const err = fileLocatorError(v);
+    if (err) sink.add(`${path}.${key}`, `${err} (got ${JSON.stringify(v)})`);
+  }
+}
+
 /** Optional 1-based line number: absent fine; present must be a positive integer. */
 function checkOptionalLine(
   sink: ErrorSink,
@@ -173,7 +227,7 @@ export function validateContractV1(raw: unknown): string[] {
   checkOptionalArray(sink, raw, 'consumed', '', (item, p) => {
     checkRequiredString(sink, item, 'method', p);
     checkRequiredString(sink, item, 'url', p);
-    checkOptionalString(sink, item, 'file', p);
+    checkOptionalFile(sink, item, 'file', p);
     checkOptionalLine(sink, item, 'line', p);
     checkOptionalMeta(sink, item, p);
   });
@@ -181,13 +235,13 @@ export function validateContractV1(raw: unknown): string[] {
     checkRequiredString(sink, item, 'method', p);
     checkRequiredString(sink, item, 'path', p);
     checkOptionalString(sink, item, 'handler', p);
-    checkOptionalString(sink, item, 'file', p);
+    checkOptionalFile(sink, item, 'file', p);
     checkOptionalLine(sink, item, 'line', p);
     checkOptionalMeta(sink, item, p);
   });
   checkOptionalArray(sink, raw, 'dynamicCalls', '', (item, p) => {
     checkRequiredString(sink, item, 'receiver', p);
-    checkOptionalString(sink, item, 'file', p);
+    checkOptionalFile(sink, item, 'file', p);
     checkOptionalLine(sink, item, 'line', p);
   });
   return sink.errors;
@@ -201,7 +255,7 @@ export function validateInventoryV1(raw: unknown): string[] {
   checkRequiredArray(sink, raw, 'entities', '', (entity, p) => {
     checkRequiredString(sink, entity, 'kind', p);
     checkRequiredString(sink, entity, 'name', p);
-    checkOptionalString(sink, entity, 'file', p);
+    checkOptionalFile(sink, entity, 'file', p);
     checkOptionalLine(sink, entity, 'line', p);
     checkOptionalMeta(sink, entity, p);
     checkOptionalArray(sink, entity, 'fields', `${p}.`, (field, fp) => {
@@ -230,7 +284,7 @@ export function validateFindingsV1(raw: unknown): string[] {
   checkRequiredArray(sink, raw, 'findings', '', (finding, p) => {
     checkRequiredString(sink, finding, 'rule', p);
     checkRequiredString(sink, finding, 'message', p);
-    checkRequiredString(sink, finding, 'file', p);
+    checkRequiredFile(sink, finding, 'file', p);
     const sev = finding['severity'];
     if (typeof sev !== 'string' || !WIRE_SEVERITIES.has(sev)) {
       sink.add(

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -204,6 +204,17 @@ function validateManifest(raw: unknown, dirName: string, at: string): string[] {
         'output',
         'must be a repo-relative .json path (no absolute paths, no "..", no leading "-")',
       );
+    } else if (!output.startsWith('.dxkit/')) {
+      // S-06 (4.0.4): the runner OWNS the output file (it may replace it on
+      // every refresh), so it must never be a user file — `package.json`
+      // used to be a legal target and was deleted before each run. dxkit
+      // state lives under `.dxkit/`; the convention is
+      // `.dxkit/contrib/<name>.json`. Every shipped example and fixture
+      // already used it, so the tightening is compat-safe in practice.
+      add(
+        'output',
+        `must live under .dxkit/ (dxkit owns and replaces this file; use .dxkit/contrib/<name>.json) — got ${JSON.stringify(output)}`,
+      );
     }
   } else if (plugin !== undefined) {
     for (const [field, value] of [

--- a/src/extensions/run.ts
+++ b/src/extensions/run.ts
@@ -236,13 +236,33 @@ function runCommandProducer(
   };
 
   const outputAbs = path.join(cwd, manifest.output);
-  // Remove a stale output first so "file exists after the run" means the
-  // RUN produced it, not a previous invocation.
+  // S-06: hold the last-known-good snapshot in memory before clearing the
+  // output (existence-after-run must mean THIS run wrote it), and RESTORE
+  // it on any non-ok outcome — a failed or skipped refresh never destroys
+  // the prior evidence. Combined with the manifest constraint (output must
+  // live under .dxkit/), the runner can no longer delete a user file.
+  let prior: string | null = null;
+  try {
+    prior = fs.readFileSync(outputAbs, 'utf-8');
+  } catch {
+    prior = null; // absent before the run
+  }
   try {
     fs.rmSync(outputAbs, { force: true });
   } catch {
     /* a locked stale file surfaces below as an invalid/missing emit */
   }
+  const finish = (r: ExtensionRunOutcome): ExtensionRunOutcome => {
+    if (r.status !== 'ok' && prior !== null) {
+      try {
+        fs.mkdirSync(path.dirname(outputAbs), { recursive: true });
+        fs.writeFileSync(outputAbs, prior);
+      } catch {
+        /* restoration is best-effort; the failure itself is already reported */
+      }
+    }
+    return r;
+  };
 
   const outcome = exec(
     {
@@ -254,21 +274,21 @@ function runCommandProducer(
   );
 
   if (!outcome.available) {
-    return { status: 'skipped', reason: `interpreter '${manifest.run.command}' not found` };
+    return finish({ status: 'skipped', reason: `interpreter '${manifest.run.command}' not found` });
   }
   if (outcome.timedOut) {
-    return {
+    return finish({
       status: 'skipped',
       reason: `timed out after ${manifest.run.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS}s`,
-    };
+    });
   }
   if (outcome.code !== 0) {
-    return {
+    return finish({
       status: 'invalid',
       errors: [
         `extension exited ${outcome.code}${outcome.output ? ` — output tail: ${outcome.output.slice(-800)}` : ''}`,
       ],
-    };
+    });
   }
 
   // Prefer the output file the extension wrote; fall back to stdout.
@@ -279,17 +299,17 @@ function runCommandProducer(
     text = outcome.output.trim().length > 0 ? outcome.output : null;
   }
   if (text === null) {
-    return {
+    return finish({
       status: 'invalid',
       errors: [
         `extension exited 0 but wrote neither its output file (${manifest.output}) nor a document on stdout`,
       ],
-    };
+    });
   }
 
   const parsed = parseWireDocText(manifest.contributes, text);
-  if (!parsed.ok) return { status: 'invalid', errors: parsed.errors };
-  return persistSnapshot(cwd, manifest.output, parsed.doc, parsed.schemaId, opts.now);
+  if (!parsed.ok) return finish({ status: 'invalid', errors: parsed.errors });
+  return finish(persistSnapshot(cwd, manifest.output, parsed.doc, parsed.schemaId, opts.now));
 }
 
 /**
@@ -309,6 +329,11 @@ function persistSnapshot(
   const stamped = { ...(doc as unknown as Record<string, unknown>) };
   stamped['generatedAt'] = (now?.() ?? new Date()).toISOString();
   fs.mkdirSync(path.dirname(outputAbs), { recursive: true });
-  fs.writeFileSync(outputAbs, `${JSON.stringify(stamped, null, 2)}\n`);
+  // Atomic replace (S-06): the VALIDATED document is written to a temp
+  // sibling and renamed over the target, so a crash or invalid emit can
+  // never leave a half-written snapshot where the last-known-good was.
+  const tmp = `${outputAbs}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, `${JSON.stringify(stamped, null, 2)}\n`);
+  fs.renameSync(tmp, outputAbs);
   return { status: 'ok', doc, schemaId, outputPath };
 }

--- a/src/flow-cli.ts
+++ b/src/flow-cli.ts
@@ -27,14 +27,8 @@ import { loadAllowlist } from './allowlist/file';
 import { readVisNetworkBundle } from './dashboard/vendor';
 import { readDxkitVersion } from './issue-cli';
 
-export interface FlowExtractOptions {
-  readonly cwd: string;
-  readonly frontend?: string;
-  readonly backend?: string;
-  /** Comma-separated OpenAPI spec paths (served side, unioned with static). */
-  readonly specs?: string;
+export interface FlowExtractOptions extends FlowViewOptions {
   readonly out?: string;
-  readonly json?: boolean;
 }
 
 /** Shared options for the graph-backed `flow` / `flow trace` views. */
@@ -44,6 +38,11 @@ export interface FlowViewOptions {
   readonly backend?: string;
   readonly specs?: string;
   readonly json?: boolean;
+  /** Treat the scanned source as attacker-controlled: executable flow
+   *  plugins are NOT loaded (disclosed, not silent — the same trust tier
+   *  the guardrail's --untrusted uses). The shipped PR workflow passes
+   *  this on pull_request events (S-05). */
+  readonly untrusted?: boolean;
 }
 
 /**
@@ -79,11 +78,12 @@ function resolveRoots(opts: { cwd: string; frontend?: string; backend?: string }
 function gatherOptions(
   opts: FlowViewOptions,
   extra?: { relativeTo?: string },
-): { roots: string[]; extraSpecs: string[]; relativeTo?: string } {
+): { roots: string[]; extraSpecs: string[]; relativeTo?: string; untrusted?: boolean } {
   return {
     roots: resolveRoots(opts),
     extraSpecs: splitPaths(opts.specs, opts.cwd),
     ...(extra?.relativeTo !== undefined ? { relativeTo: extra.relativeTo } : {}),
+    ...(opts.untrusted !== undefined ? { untrusted: opts.untrusted } : {}),
   };
 }
 

--- a/test/extensions/contributions.test.ts
+++ b/test/extensions/contributions.test.ts
@@ -21,6 +21,11 @@ import {
   parseWireDocText,
   type ContributionKindDef,
 } from '../../src/extensions/contributions';
+import {
+  validateContractV1,
+  validateInventoryV1,
+  validateFindingsV1,
+} from '../../src/extensions/contributions/validate';
 
 const ALL_KINDS: ContributionKind[] = ['contract', 'inventory', 'findings', 'export'];
 
@@ -164,6 +169,44 @@ describe('validator field precision (errors are the docs)', () => {
     const r = parseWireDoc('inventory', { schema: 'inventory.v1', entities });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.errors.length).toBeLessThanOrEqual(25);
+  });
+});
+
+describe('wire file locators are validated repo-relative POSIX (S-15)', () => {
+  const bad = [
+    ['/etc/passwd', 'absolute'],
+    ['..\u002fescape.ts', 'traversal'],
+    ['C:\\repo\\x.ts', 'drive-prefixed'],
+    ['src//x.ts', 'empty segment'],
+  ] as const;
+  it('findings.v1 rejects non-canonical file locators (they feed identity — Rule 9)', () => {
+    for (const [file] of bad) {
+      const errors = validateFindingsV1({
+        schema: 'findings.v1',
+        findings: [{ rule: 'r', message: 'm', file, severity: 'high' }],
+      });
+      expect(errors.length, `should reject ${JSON.stringify(file)}`).toBeGreaterThan(0);
+    }
+    expect(
+      validateFindingsV1({
+        schema: 'findings.v1',
+        findings: [{ rule: 'r', message: 'm', file: 'src/app.ts', severity: 'high' }],
+      }),
+    ).toEqual([]);
+  });
+  it('contract.v1 + inventory.v1 reject them on their optional file fields too', () => {
+    expect(
+      validateContractV1({
+        schema: 'contract.v1',
+        consumed: [{ method: 'GET', url: '/x', file: '/abs/path.ts' }],
+      }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      validateInventoryV1({
+        schema: 'inventory.v1',
+        entities: [{ kind: 'screen', name: 'A', file: '../outside.ts' }],
+      }).length,
+    ).toBeGreaterThan(0);
   });
 });
 

--- a/test/extensions/extensions-cli.test.ts
+++ b/test/extensions/extensions-cli.test.ts
@@ -218,3 +218,45 @@ describe('extensions init --plugin (rung 4)', () => {
     expect(await runExtensionsCli(tmp, 'list', undefined, { json: true })).toBe(0);
   });
 });
+
+describe('refresh --scheduled honors the manifest trigger (S-14)', () => {
+  function manifest(name: string, refresh: string): void {
+    const dir = path.join(tmp, '.dxkit/extensions', name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'extension.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        name,
+        contributes: 'inventory',
+        // node -e writing a valid doc to stdout — runs anywhere the suite runs.
+        run: {
+          command: 'node',
+          args: ['-e', 'console.log(JSON.stringify({schema:"inventory.v1",entities:[]}))'], // slop-ok: the fixture extension's own emit
+        },
+        refresh,
+        output: `.dxkit/contrib/${name}.json`,
+      }),
+    );
+  }
+
+  it('runs only on-merge extensions; manual ones are skipped and produce no snapshot', async () => {
+    manifest('auto-ext', 'on-merge');
+    manifest('manual-ext', 'manual');
+    const code = await runExtensionsCli(tmp, 'refresh', undefined, { scheduled: 'on-merge' });
+    expect(code).toBe(0);
+    expect(fs.existsSync(path.join(tmp, '.dxkit/contrib/auto-ext.json'))).toBe(true);
+    // The manual extension must NOT have run — that was the shipped bug:
+    // the generated on-merge workflow refreshed everything.
+    expect(fs.existsSync(path.join(tmp, '.dxkit/contrib/manual-ext.json'))).toBe(false);
+  });
+
+  it('an unfiltered explicit refresh still runs everything (operator semantics unchanged)', async () => {
+    manifest('auto-ext', 'on-merge');
+    manifest('manual-ext', 'manual');
+    const code = await runExtensionsCli(tmp, 'refresh', undefined, {});
+    expect(code).toBe(0);
+    expect(fs.existsSync(path.join(tmp, '.dxkit/contrib/auto-ext.json'))).toBe(true);
+    expect(fs.existsSync(path.join(tmp, '.dxkit/contrib/manual-ext.json'))).toBe(true);
+  });
+});

--- a/test/extensions/orchestrator.test.ts
+++ b/test/extensions/orchestrator.test.ts
@@ -94,6 +94,28 @@ describe('manifest discovery', () => {
   });
 });
 
+describe('output-path safety (S-06 — the runner owns the file it replaces)', () => {
+  it('rejects an output outside .dxkit/ — package.json used to be a legal target', () => {
+    writeManifest('grabby', { ...GOOD, name: 'grabby', output: 'package.json' });
+    const r = discoverExtensions(tmp);
+    expect(r.extensions).toEqual([]);
+    expect(r.errors.join('\n')).toContain('.dxkit/');
+  });
+
+  it('rejects a nested non-dxkit json target too', () => {
+    writeManifest('grabby2', { ...GOOD, name: 'grabby2', output: 'src/config.json' });
+    const r = discoverExtensions(tmp);
+    expect(r.extensions).toEqual([]);
+  });
+
+  it('accepts the .dxkit/contrib convention', () => {
+    writeManifest('fine', { ...GOOD, name: 'fine', output: '.dxkit/contrib/fine.json' });
+    const r = discoverExtensions(tmp);
+    expect(r.errors).toEqual([]);
+    expect(r.extensions).toHaveLength(1);
+  });
+});
+
 describe('rung-4 plugin manifests', () => {
   const PLUGIN_GATHER = {
     schemaVersion: 1,
@@ -262,6 +284,28 @@ describe('the ONE runner (policy matrix via injected exec)', () => {
     if (r2.status === 'ok') {
       expect(JSON.stringify(r2.doc)).toContain('FromFile');
     }
+  });
+
+  it('a FAILED refresh restores the last-known-good snapshot (S-06 — never destroy evidence)', async () => {
+    const outAbs = path.join(tmp, '.dxkit/contrib/ui-inventory.json');
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    const good = JSON.stringify({ schema: 'inventory.v1', entities: [], generatedAt: 'x' });
+    fs.writeFileSync(outAbs, good);
+    // The run fails outright — the prior snapshot must come back.
+    const exec: CommandExec = () => ({ available: true, code: 1, output: 'boom' });
+    const r = await runExtension(tmp, loaded(), { exec });
+    expect(r.status).toBe('invalid');
+    expect(fs.readFileSync(outAbs, 'utf-8')).toBe(good);
+    // A timeout (skip) restores too.
+    const execTimeout: CommandExec = () => ({
+      available: true,
+      timedOut: true,
+      code: -1,
+      output: '',
+    });
+    const r2 = await runExtension(tmp, loaded(), { exec: execTimeout });
+    expect(r2.status).toBe('skipped');
+    expect(fs.readFileSync(outAbs, 'utf-8')).toBe(good);
   });
 
   it('invalid emit → the field-precise wire errors surface verbatim', async () => {


### PR DESCRIPTION
The v2 audit's verified P0/P1 extension findings, as one patch-shaped cluster. The theme: every boundary already existed — nothing had turned it on.

- **S-05**: the shipped PR workflow passes `--untrusted` on `pull_request` events (guardrail + flow console); flow view commands accept and thread the flag. Fails open (evidence narrows), never toward a false block — committed snapshots carry plugin-derived routes from trusted runs.
- **S-06**: extension `output` constrained to `.dxkit/` (⚠ tightening; every shipped example already complied — `package.json` was previously a legal target the runner deleted before each run). Failed refreshes restore the last-known-good snapshot; persists are atomic.
- **S-14**: `extensions refresh --scheduled on-merge` in the generated workflow — `refresh: manual` finally means manual. Unfiltered operator runs unchanged.
- **S-15**: wire `file` locators validated as repo-relative POSIX (⚠ tightening; they feed finding identity and the contract always claimed this).
- **S-11**: docs stop calling the rung-4 plugin path 'sandboxed'.

Full suite 303 files / 4,465 tests green; all static gates pass; slop run post-commit. Squash-merge alongside #180 for 4.0.4 (release bump comes after both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)