### PR TITLE
chore(release): 4.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.4] - 2026-07-18
+
+The debt-surface UX pass and the v2 audit's extension trust + safety cluster.
+
+### Added
+
+- **`vyuh-dxkit debt --stored`** reads the baseline's recorded floor-debt
+  envelope instantly (no compile/test run), labeled with capture provenance
+  and staleness; live mode announces up front that it runs the build.
+  `baseline create` now says when it recorded failing correctness checks as
+  grandfathered floor debt, and `guardrail check` output carries one
+  informational floor-debt line when the baseline holds failing checks — a
+  PASSED gate on a repo with a broken build stays honest. The dxkit-action
+  skill routes baseline-cleanup asks ("clean up the baseline", "fix the build
+  the baseline grandfathered") and documents the `debt`-driven playbook.
+
 ### Security
 
 - **The plugin-trust boundary is now ACTIVE on the shipped PR workflow.** The

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",


### PR DESCRIPTION
Version bump + CHANGELOG date for 4.0.4 (PRs #180 + #181, both merged). Squash-merge, then I'll tag + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)