### PR TITLE
4.1.1: CI never provisions Swift from the pbxproj SWIFT_VERSION language mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- **Fix: CI never provisions Swift from the pbxproj `SWIFT_VERSION`.** Both
+  real iOS repos in the 4.1.0 org rollout had their `dxkit-guardrails` job
+  404 in `swift-actions/setup-swift`: the generated workflow pinned
+  `swift-version: '5.0'`, taken from the Xcode project's `SWIFT_VERSION` —
+  which is a source-compatibility MODE (modern projects still say 5.0), not
+  an installable toolchain. `CiSetupSupport` gains an optional
+  `detectToolchainVersion`; `allCiSetupSteps` substitutes it in preference
+  to `detectVersion`, and the swift pack routes only `.swift-version` pins
+  and `Package.swift` tools-version through it. An Xcode-only repo keeps the
+  declared modern default; `detectVersion` still reports the dialect.
+
 ## [4.1.0] - 2026-07-19
 
 - **PHP language pack** (10th pack). Detection (`composer.json` + a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.1.1] - 2026-07-19
 
 - **Fix: CI never provisions Swift from the pbxproj `SWIFT_VERSION`.** Both
   real iOS repos in the 4.1.0 org rollout had their `dxkit-guardrails` job

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -383,7 +383,12 @@ export function allCiSetupSteps(flags: DetectedStack['languages'], cwd?: string)
   const byUses = new Map<string, { step: CiSetupStep; detected: boolean }>();
   const order: string[] = [];
   for (const l of activeLanguagesFromFlags(flags)) {
-    const detected = cwd !== undefined ? l.detectVersion?.(cwd) : undefined;
+    // Provisioning consumes the PROVISIONABLE version: a pack whose detected
+    // version can name a mere language dialect (swift's pbxproj
+    // SWIFT_VERSION) declares detectToolchainVersion to keep that signal out
+    // of CI setup — see CiSetupSupport.
+    const detected =
+      cwd !== undefined ? (l.ciSetup?.detectToolchainVersion ?? l.detectVersion)?.(cwd) : undefined;
     for (const step of l.ciSetup?.steps ?? []) {
       const substituted =
         step.versionInput && detected

--- a/src/languages/swift.ts
+++ b/src/languages/swift.ts
@@ -591,6 +591,22 @@ const swiftCorrectnessProvider: CorrectnessProvider = {
  *  Xcode-shaped repo has — verified on a real iOS repo whose root carries
  *  neither manifest). */
 function detectSwiftVersion(cwd: string): string | undefined {
+  const toolchain = detectSwiftToolchainVersion(cwd);
+  if (toolchain) return toolchain;
+  for (const rel of walkPaths(cwd, { extensions: [], basenames: ['project.pbxproj'] })) {
+    const m = readRepoFile(cwd, rel).match(/SWIFT_VERSION\s*=\s*(\d+(?:\.\d+)?)/);
+    if (m) return m[1].includes('.') ? m[1] : `${m[1]}.0`;
+  }
+  return undefined;
+}
+
+/** The PROVISIONABLE slice of the above — only sources that name a real
+ *  installable toolchain (`.swift-version` pin, tools-version floor). The
+ *  pbxproj `SWIFT_VERSION` is deliberately excluded: it is Xcode's
+ *  source-compatibility MODE (modern projects still say 5.0), and feeding it
+ *  to setup-swift 404'd the guardrail job on both real iOS repos in the 4.1.0
+ *  org rollout — no "swift 5.0" toolchain exists for current runners. */
+function detectSwiftToolchainVersion(cwd: string): string | undefined {
   const pin = readRepoFile(cwd, '.swift-version').trim();
   const pinMatch = pin.match(/^(\d+\.\d+(?:\.\d+)?)/);
   if (pinMatch) return pinMatch[1];
@@ -598,10 +614,6 @@ function detectSwiftVersion(cwd: string): string | undefined {
     /\/\/\s*swift-tools-version\s*:\s*(\d+\.\d+)/,
   );
   if (tools) return tools[1];
-  for (const rel of walkPaths(cwd, { extensions: [], basenames: ['project.pbxproj'] })) {
-    const m = readRepoFile(cwd, rel).match(/SWIFT_VERSION\s*=\s*(\d+(?:\.\d+)?)/);
-    if (m) return m[1].includes('.') ? m[1] : `${m[1]}.0`;
-  }
   return undefined;
 }
 
@@ -739,6 +751,9 @@ export const swift: LanguageSupport = {
         versionInput: 'swift-version',
       },
     ],
+    // Provisioning must never see the pbxproj SWIFT_VERSION language mode —
+    // an Xcode-only repo keeps the declared 6.1 default above.
+    detectToolchainVersion: detectSwiftToolchainVersion,
   },
   defaultVersion: '6.1',
   detectVersion: detectSwiftVersion,

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -70,6 +70,19 @@ export interface CiSetupStep {
 /** A pack's CI runtime setup — the ordered steps unioned into the workflow. */
 export interface CiSetupSupport {
   readonly steps: ReadonlyArray<CiSetupStep>;
+  /**
+   * The toolchain version CI can PROVISION for this repo, when it differs
+   * from `detectVersion`'s answer. `allCiSetupSteps` substitutes
+   * `detectToolchainVersion?.(cwd) ?? detectVersion?.(cwd)` into
+   * `versionInput` — declare this when the pack's detected version includes
+   * signals that name a LANGUAGE DIALECT rather than an installable
+   * toolchain. The shipped class: swift's `detectVersion` reads the Xcode
+   * project's `SWIFT_VERSION` (a source-compatibility MODE — modern projects
+   * still say `5.0`), and feeding it to `swift-actions/setup-swift` 404s the
+   * org's guardrail job because no such toolchain exists for the runner.
+   * Return undefined to leave the step's declared default untouched.
+   */
+  readonly detectToolchainVersion?: (cwd: string) => string | undefined;
 }
 
 export interface ArchitecturalShape {

--- a/test/ci-setup.test.ts
+++ b/test/ci-setup.test.ts
@@ -7,10 +7,11 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { allCiSetupSteps } from '../src/languages';
+import { swift } from '../src/languages/swift';
 import { installCiGuardrails } from '../src/ship-installers';
 import type { DetectedStack } from '../src/types';
 
@@ -54,6 +55,35 @@ describe('allCiSetupSteps — pack-driven CI runtime setup', () => {
     const steps = allCiSetupSteps(flags({ typescript: true, go: true }));
     expect(steps.some((s) => s.uses === 'actions/setup-go@v5')).toBe(true);
     expect(steps.some((s) => s.uses.includes('setup-node'))).toBe(false);
+  });
+
+  it('swift: provisioning never sees the pbxproj SWIFT_VERSION language mode (4.1.0 rollout bug)', () => {
+    // The shipped class: both real iOS repos' pbxproj said SWIFT_VERSION =
+    // 5.0 (Xcode's source-compat MODE), the workflow rendered
+    // `swift-version: '5.0'`, and setup-swift 404'd the guardrail job — no
+    // such toolchain exists for current runners.
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-swift-ci-'));
+    try {
+      const proj = join(dir, 'App.xcodeproj');
+      mkdirSync(proj, { recursive: true });
+      writeFileSync(join(proj, 'project.pbxproj'), 'SWIFT_VERSION = 5.0;\n');
+      const step = allCiSetupSteps(flags({ swift: true }), dir).find((s) =>
+        s.uses.startsWith('swift-actions/setup-swift'),
+      )!;
+      // Reporting still sees the dialect; provisioning keeps the declared
+      // default.
+      expect(swift.detectVersion!(dir)).toBe('5.0');
+      expect(step.with!['swift-version']).toBe('6.1');
+
+      // A REAL toolchain pin (.swift-version) IS substituted.
+      writeFileSync(join(dir, '.swift-version'), '6.0.3\n');
+      const pinned = allCiSetupSteps(flags({ swift: true }), dir).find((s) =>
+        s.uses.startsWith('swift-actions/setup-swift'),
+      )!;
+      expect(pinned.with!['swift-version']).toBe('6.0.3');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## The 4.1.0 org rollout's one red check, fixed

Both real iOS repos onboarded in the 4.1.0 rollout had their `dxkit-guardrails` job fail in `swift-actions/setup-swift` with a 404: the generated workflow pinned `swift-version: '5.0'`, taken from the Xcode project's `SWIFT_VERSION` build setting — which is a source-compatibility MODE (modern projects still declare 5.0), not an installable toolchain. The macos host gates on the same PRs passed; only the ubuntu provisioning step was poisoned.

Rule 2.30 shape: two consumers of one detected version wanted different concepts. Reporting wants the dialect; CI provisioning wants an installable toolchain. `CiSetupSupport` gains an optional `detectToolchainVersion`, `allCiSetupSteps` prefers it over `detectVersion`, and the swift pack routes only `.swift-version` pins and `Package.swift` tools-version through it — the pbxproj signal stays reporting-only. Pinned both directions in `test/ci-setup.test.ts`.

Includes the 4.1.1 version bump + CHANGELOG. After merge + release, the two affected org repos get re-onboarded at 4.1.1 (superseding their 4.1.0 PRs) so their generated workflows carry the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)