### PR TITLE
4.1.2: an unrestored .NET tree can no longer mint a comparable-and-clean dep baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.2] - 2026-07-19
+
+- **Fix: the CI PR-comment step bounds its body to GitHub's 65,536-char
+  limit.** A very large repo's PASSED guardrail failed its job anyway —
+  the full report blew the comment cap and the post errored. The step now
+  truncates at a line boundary with a link to the job log's full report.
+- **Fix: an unrestored .NET tree can no longer produce a "comparable and
+  clean" dependency baseline.** Caught live in the 4.1.0 org rollout: a
+  repo's install-time baseline held 1 dep-vuln while CI found 16 more and
+  BLOCKED them as the PR's own — pre-existing vulnerabilities blamed on
+  whoever opened the next PR (the exact false-block class Rule 19 exists
+  to kill). Two coupled defects: (1) `dotnet list package --vulnerable`
+  on an unrestored tree exits 0 with per-project `No assets file` errors
+  inside the JSON, and the parser read that as ran-and-clean — the dotnet
+  half now returns a disclosed `unavailable` (run `dotnet restore` for
+  the full transitive audit) and drops out of provenance honestly;
+  (2) the `dotnet-vulnerable` recall input was silently dropped as a
+  non-registry `unknown`, so two scans with different observable surfaces
+  compared "comparable" — toolchain-backed scanner names now resolve
+  through the registry def that gates their availability
+  (`TOOLCHAIN_BACKED_TOOLS`), so the presence difference drifts the kind
+  and demotes the delta to a disclosed warning instead of a block. Both
+  directions pinned; proven on the affected repo (unrestored → honest
+  osv-only; restored → 16 findings with `dotnet-vulnerable: <sdk>` in the
+  recall inputs).
+
 ## [4.1.1] - 2026-07-19
 
 - **Fix: CI never provisions Swift from the pbxproj `SWIFT_VERSION`.** Both

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -293,6 +293,22 @@ __DXKIT_CI_RUNTIME_SETUP__
               printf -- '- [ ] Consuming UI handles error + empty responses, not just the happy path\n'
             } >> comment.md
           fi
+          # GitHub caps issue comments at 65,536 characters, and an oversized
+          # body fails this WHOLE job even after a PASSED gate (seen live on a
+          # repo with a 23k-finding baseline). Keep the top of the report — the
+          # verdict and summary lead it — cut at a line boundary, and point at
+          # the job log for the rest. Bytes ≥ characters, so a byte cap is
+          # safely conservative.
+          MAX_BYTES=60000
+          if [ "$(wc -c < comment.md)" -gt "$MAX_BYTES" ]; then
+            head -c "$MAX_BYTES" comment.md | sed '$d' > comment.trunc
+            {
+              printf '\n\n---\n'
+              printf '⚠️ **Report truncated** to fit GitHub'"'"'s comment size limit — the full report is in this run'"'"'s job log: %s/%s/actions/runs/%s\n' \
+                "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}"
+            } >> comment.trunc
+            mv comment.trunc comment.md
+          fi
           existing=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
             | head -n1)

--- a/src/baseline/tool-versions.ts
+++ b/src/baseline/tool-versions.ts
@@ -50,6 +50,23 @@ export function buildToolsMap(
 const IN_PROCESS_TOOLS: ReadonlySet<string> = new Set(['tls-bypass-registry', 'grep-secrets']);
 
 /**
+ * Scanner names backed by an AMBIENT TOOLCHAIN rather than a registry
+ * binary, mapped to the TOOL_DEFS key that gates their availability (the
+ * same `findTool` probe the gather itself makes). Without this map the
+ * name shortens to no registry key, resolves `unknown`, and is DROPPED
+ * from recall inputs — but unlike a builtin (`git`, `find`), an
+ * ambient-toolchain scanner's presence VARIES by environment, and that
+ * presence is exactly the discriminating signal Rule 19 needs. The
+ * shipped class: `dotnet-vulnerable` ran in CI (restored tree, 16
+ * findings) and not at capture (no dotnet, 1 finding), both recall
+ * contexts read `{osv-scanner}`, the sets compared "comparable", and 9
+ * pre-existing NuGet vulns false-blocked as the PR's.
+ */
+const TOOLCHAIN_BACKED_TOOLS: Readonly<Record<string, string>> = {
+  'dotnet-vulnerable': 'dotnet-format',
+};
+
+/**
  * Per-process cache of resolved tool versions, keyed by `${name}::${cwd}`.
  *
  * Why this exists: `findTool` spawns an `execFileSync` subprocess to
@@ -87,7 +104,8 @@ function resolveToolVersion(name: string, cwd: string): string {
 
 function resolveToolVersionUncached(name: string, cwd: string): string {
   if (IN_PROCESS_TOOLS.has(name)) return `dxkit-${DXKIT_VERSION}`;
-  const parts = name.split('-');
+  const backing = TOOLCHAIN_BACKED_TOOLS[name];
+  const parts = (backing ?? name).split('-');
   for (let i = parts.length; i > 0; i--) {
     const candidate = parts.slice(0, i).join('-');
     const def = TOOL_DEFS[candidate];

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -192,6 +192,14 @@ interface DotnetVulnerableReport {
     path?: string;
     frameworks?: DotnetFramework[];
   }>;
+  /** Per-project errors dotnet emits INSIDE the JSON (exit stays 0) — the
+   *  load-bearing one: `No assets file was found ... Please run restore`
+   *  on every unrestored project. */
+  problems?: Array<{
+    project?: string;
+    level?: string;
+    text?: string;
+  }>;
 }
 
 /**
@@ -262,9 +270,18 @@ function extractGhsaIdFromUrl(url: string | undefined): string | null {
  * matches Python's venv-missing behavior: degrade gracefully rather
  * than invent false parents.
  */
-export function parseDotnetVulnerableOutput(
-  raw: string,
-): { counts: SeverityCounts; findings: DepVulnFinding[] } | null {
+export function parseDotnetVulnerableOutput(raw: string): {
+  counts: SeverityCounts;
+  findings: DepVulnFinding[];
+  /** Projects the report says it could NOT observe (`No assets file was
+   *  found ... Please run restore`, level error). Non-empty means this
+   *  output is a PARTIAL view of the dependency tree — the caller must
+   *  refuse to read it as ran-and-clean (the unrestored-tree class, caught live on a real org repo: an
+   *  unrestored tree parsed as 0 findings, the baseline read
+   *  "comparable", and CI's restored scan false-blocked 9 pre-existing
+   *  vulns as the PR's). */
+  unrestoredProjects: string[];
+} | null {
   let data: DotnetVulnerableReport;
   try {
     data = JSON.parse(raw) as DotnetVulnerableReport;
@@ -322,7 +339,16 @@ export function parseDotnetVulnerableOutput(
       }
     }
   }
-  return { counts: { critical, high, medium, low }, findings };
+  const unrestoredProjects = (data.problems ?? [])
+    .filter(
+      (p) =>
+        p.level === 'error' &&
+        typeof p.text === 'string' &&
+        /no assets file was found|please run restore/i.test(p.text),
+    )
+    .map((p) => p.project ?? '(unknown project)');
+
+  return { counts: { critical, high, medium, low }, findings, unrestoredProjects };
 }
 
 /**
@@ -788,6 +814,22 @@ async function runDotnetVulnerablePath(cwd: string): Promise<DepVulnGatherOutcom
   const parsed = parseDotnetVulnerableOutput(vulnRaw);
   if (!parsed) {
     return { kind: 'unavailable', reason: 'dotnet list package output failed JSON parse' };
+  }
+
+  // An unrestored project makes this half's view PARTIAL — reading it as
+  // ran-and-clean is the false-clean class (proven live: an unrestored
+  // tree reported 1 finding where the restored tree reports 16, and the
+  // committed baseline then false-blocked CI's true findings as net-new).
+  // Unavailable is honest: this half drops out of provenance, so Rule 19
+  // sees the environments differ instead of "comparable and clean". The
+  // osv half still covers committed lockfiles / direct references.
+  if (parsed.unrestoredProjects.length > 0) {
+    return {
+      kind: 'unavailable',
+      reason:
+        `dotnet list package could not observe ${parsed.unrestoredProjects.length} unrestored ` +
+        'project(s) (no assets file) — run `dotnet restore` for the full transitive audit',
+    };
   }
 
   const { counts, findings } = parsed;

--- a/test/baseline/producers-contract.test.ts
+++ b/test/baseline/producers-contract.test.ts
@@ -267,3 +267,20 @@ describe('producer recall-context contract (Rule 19)', () => {
     }
   });
 });
+
+describe('toolchain-backed scanner names survive recall-input resolution (Rule 19)', () => {
+  it('dotnet-vulnerable is never dropped as unknown — its presence is the discriminating signal', async () => {
+    // The unrestored-tree class (caught live on a real org repo): the dotnet half of the C# dep audit ran in CI
+    // (restored tree) and not at capture, but `resolveToolInputs` dropped
+    // the name as a non-registry `unknown` on BOTH sides — so two scans
+    // with different observable surfaces compared "comparable" and CI's
+    // pre-existing findings false-blocked as net-new. The name resolves
+    // through the registry def that gates the scanner's availability
+    // (`dotnet-format` — the same findTool probe the gather makes), so it
+    // can never fall out of the input set while the scanner ran.
+    const { resolveToolInputs } = await import('../../src/baseline/producers/recall-inputs');
+    const inputs = resolveToolInputs(['dotnet-vulnerable'], process.cwd());
+    expect(Object.keys(inputs)).toContain('dotnet-vulnerable');
+    expect(inputs['dotnet-vulnerable']).not.toBe('unknown');
+  });
+});

--- a/test/languages-csharp-depvulns.test.ts
+++ b/test/languages-csharp-depvulns.test.ts
@@ -211,6 +211,50 @@ describe('parseDotnetVulnerableOutput', () => {
     expect(parsed.findings).toHaveLength(4);
   });
 
+  it('surfaces unrestored projects from the problems array — never a silent clean (the unrestored-tree class)', () => {
+    // Shape captured live from `dotnet list package --vulnerable
+    // --include-transitive --format json` on an unrestored tree: exit 0,
+    // zero packages, and a per-project error INSIDE the JSON. Reading
+    // this as ran-and-clean is the false-clean that made a committed
+    // baseline "comparable" with CI's restored scan and false-blocked 9
+    // pre-existing vulns as a PR's own.
+    const raw = JSON.stringify({
+      version: 1,
+      parameters: '--vulnerable --include-transitive',
+      problems: [
+        {
+          project: '/repo/App.Web/App.Web.csproj',
+          level: 'error',
+          text: 'No assets file was found for `/repo/App.Web/App.Web.csproj`. Please run restore before running this command.',
+        },
+        {
+          project: '/repo/App.Core/App.Core.csproj',
+          level: 'error',
+          text: 'No assets file was found for `/repo/App.Core/App.Core.csproj`. Please run restore before running this command.',
+        },
+        // A non-restore warning must NOT count as unobserved.
+        { project: '/repo/App.Web/App.Web.csproj', level: 'warning', text: 'some other notice' },
+      ],
+      projects: [
+        { path: '/repo/App.Web/App.Web.csproj' },
+        { path: '/repo/App.Core/App.Core.csproj' },
+      ],
+    });
+    const parsed = parseDotnetVulnerableOutput(raw)!;
+    expect(parsed.findings).toEqual([]);
+    expect(parsed.unrestoredProjects).toEqual([
+      '/repo/App.Web/App.Web.csproj',
+      '/repo/App.Core/App.Core.csproj',
+    ]);
+  });
+
+  it('a fully-restored report carries no unrestored projects', () => {
+    const raw = JSON.stringify({
+      projects: [{ frameworks: [{ topLevelPackages: [] }] }],
+    });
+    expect(parseDotnetVulnerableOutput(raw)!.unrestoredProjects).toEqual([]);
+  });
+
   it('handles empty vulnerabilities array as zero findings', () => {
     const raw = JSON.stringify({
       projects: [


### PR DESCRIPTION
## The rollout's one unexplained red, root-caused and fixed

A repo onboarded in the 4.1.0 rollout had its guardrail block 15 pre-existing NuGet vulnerabilities as the PR's own: the install-time baseline held 1 dep-vuln, CI held 16. Reproduced live on the affected repo — two coupled defects:

1. **False-clean**: `dotnet list package --vulnerable` on an unrestored tree exits 0 with per-project `No assets file was found … Please run restore` errors *inside* the JSON; the parser ignored `problems[]` and read the empty report as ran-and-clean. The dotnet half now returns a disclosed `unavailable` and drops out of provenance honestly (the osv half still covers committed lockfiles / direct references).
2. **Rule 19 blind spot**: the `dotnet-vulnerable` recall input was dropped as a non-registry `unknown` on both sides, so a scan that ran the dotnet half and one that couldn't compared "comparable". The drop rationale assumed non-registry names are constants — but an ambient-toolchain scanner's *presence* varies by environment and is precisely the discriminating signal. Toolchain-backed scanner names now resolve through the registry def that gates their availability (`TOOLCHAIN_BACKED_TOOLS`), so the surface difference drifts the kind and demotes the delta to a disclosed warning — never a block on the developer.

Also folded in (rollout-found defect #3): **the CI PR-comment step now bounds its body to GitHub's 65,536-character limit** — a 23k-finding repo's guardrail PASSED and the job then failed anyway because the full report blew the comment cap. The step truncates at a line boundary and links the job log's full report.

Proven both directions on the real repo: unrestored → `osv-scanner-nuget-direct` only, 1 finding, no false-clean; restored → both halves, 16 findings, recall inputs carry `dotnet-vulnerable: 9.0.315`. Suite 4,593 + all gates + self-guardrail green. Includes the 4.1.2 bump + CHANGELOG.

After merge + release: re-onboard the affected repo at 4.1.2 (supersedes its 4.1.0 PR) — its CI then discloses the capture/CI surface difference as drift, and the post-merge baseline refresh makes the sides comparable for good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
