### PR TITLE
4.1.3: --untrusted forwarding (P0) + newly-published-advisory attribution + allowlist defer (D4 phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.3] - 2026-07-22
+
+- **Security fix (P0): `--untrusted` now reaches every in-process plugin
+  load.** The trust tier promises that executable flow plugins never load
+  when the scanned source is attacker-controlled — the shipped PR workflow
+  runs `flow console --untrusted` against PR-head code. The boolean was
+  honored by the gate but silently dropped at three call sites: `flow
+  console` → the integration gate, `flow map` → the seam inventory (whose
+  dead-surface ladder gathers a flow model, and through it loads plugins),
+  and `evaluate` → the trial's seam-visibility lane. All three now forward
+  the posture, and a side-effect canary test (a fixture plugin that writes
+  a sentinel file at load) drives every `--untrusted` entry point in both
+  directions — untrusted must never fire it, trusted must (so the
+  untrusted assertion can never pass vacuously).
+- **Newly published advisories stop being blamed on the PR (D4 phase 1).**
+  The incident class (two live batches in 48h against one customer repo): a
+  committed-mode PR that touches no dependency manifest goes red as "N new
+  regressions" the day an advisory batch lands on an unchanged dependency.
+  An `added` dep-vuln on a diff that touched no dependency manifest of any
+  active pack — the same pack-declared `changedFilesTouchDependencyManifest`
+  the ref-based dep-audit skip trusts, parity-pinned — is now classified
+  `newly-published-advisory`: the report and PR comment state the findings
+  were published after baseline capture, not introduced by this PR, and
+  present both lanes (fix the vulnerability, or defer time-boxed). Gate
+  semantics are UNCHANGED in this release: the finding blocks exactly as
+  `added` does, including every armed block rule — what changed is
+  attribution honesty and the cost of the defer lane. (The policy tier knob
+  and base-branch-first surfacing ship next, as 4.1.4.)
+- **New: `vyuh-dxkit allowlist defer` — bulk, dep-vuln-only, time-boxed
+  deferral.** Productizes the incident bridge script: one command adds
+  `category=deferred` entries with a short shared expiry (default 7 days —
+  the expiry is the forcing function back into the fix lane) for either an
+  explicit fingerprint list or `--from-last-check` (the blocking dep-vulns
+  of the last same-tree guardrail run, read from the verdict cache, which
+  now carries the blocking-finding list). Structurally incapable of bulk
+  bypass: entries are minted `kind=dep-vuln` (suppression matches on kind),
+  and non-dep-vuln findings are refused loudly, never deferred.
+- **Fix: dep-vuln report rows show the advisory id, not the fingerprint.**
+  `describeEntryLocation` read `entry.id` — which on a baseline entry is the
+  finding FINGERPRINT — where the advisory id belongs, so a multi-advisory
+  package rendered as duplicate rows with contradictory severities and the
+  Location column repeated the Fingerprint column. Rows now read
+  `package@version · GHSA-…` (falling back to the fingerprint only on a
+  pre-advisoryId baseline).
+
 ## [4.1.2] - 2026-07-19
 
 - **Fix: the CI PR-comment step bounds its body to GitHub's 65,536-char

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.claude/skills/dxkit-allowlist/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-allowlist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dxkit-allowlist
-description: Manage the dxkit allowlist over its whole lifecycle — list, inspect, audit (including orphaned entries after a re-baseline), remove stale entries, prune expired ones, and export Snyk-originated suppressions to a .snyk policy. Use when the user says "review our allowlist", "what suppressions do we have", "this allowlist entry is stale", "remove this fingerprint", "the allowlist drifted after re-baselining", "audit our accepted-risk entries", or "push our Snyk ignores back to Snyk". For the fix-vs-suppress DECISION and adding a new entry, defer to dxkit-action.
+description: Manage the dxkit allowlist over its whole lifecycle — list, inspect, audit (including orphaned entries after a re-baseline), bulk-defer newly published dep-vuln advisories, remove stale entries, prune expired ones, and export Snyk-originated suppressions to a .snyk policy. Use when the user says "review our allowlist", "what suppressions do we have", "the guardrail blocked my PR for advisories published after the baseline", "defer these new CVEs", "this allowlist entry is stale", "remove this fingerprint", "the allowlist drifted after re-baselining", "audit our accepted-risk entries", or "push our Snyk ignores back to Snyk". For the fix-vs-suppress DECISION and adding a new individual entry, defer to dxkit-action.
 ---
 
 # dxkit-allowlist
@@ -59,6 +59,26 @@ npx vyuh-dxkit allowlist audit --against-baseline   # ALSO flag orphaned entries
 2. **Re-baselining churned the fingerprint** — semgrep is nondeterministic run-to-run, and cross-tool dedup can shift which tool's fingerprint represents a merged finding. The suppressed finding may still exist intermittently. Removing the entry would let it block a future PR.
 
 So treat the orphaned bucket as a **review queue**: confirm each finding is truly gone (re-run the analyzer and check the fingerprint is absent), *then* remove. Never script a bulk-remove of the orphaned set.
+
+## Defer newly published advisories — bulk, dep-vuln-only, time-boxed
+
+```bash
+npx vyuh-dxkit allowlist defer --from-last-check --reason="advisory batch YYYY-MM-DD, PR is time-sensitive"
+npx vyuh-dxkit allowlist defer <fp1> <fp2> … --reason="…" [--expires=+7d|YYYY-MM-DD]
+```
+
+The scenario: a PR that touches **no dependency manifest** goes red because new advisories were published to the feed *after* the baseline was captured. The guardrail labels these `NEWLY-PUBLISHED-ADVISORY` — not introduced by this PR — and the decision is **time-sensitivity**:
+
+- change is **not** time-sensitive → **fix the vulnerabilities** (upgrade/patch); that is what unblocks;
+- change **is** time-sensitive → `allowlist defer` clears the gate now with short-dated `deferred` entries (default expiry **7 days**, not the 90-day accepted-risk default). The expiry is the forcing function: the findings re-block when it lapses, so plan the dependency fix immediately.
+
+`--from-last-check` pulls the blocking dep-vulns from the last guardrail run on this exact tree (run `npx vyuh-dxkit guardrail check` locally first). Structural guarantees — this can never become a bulk bypass:
+
+- entries are minted `kind=dep-vuln`; suppression matches on kind, so a deferred fingerprint can never waive a secret, SAST, or any other finding;
+- non-dep-vuln blocking findings are refused and named, never deferred;
+- explicit fingerprints the last run reports as non-dep-vuln findings are refused loudly.
+
+Commit the updated `.dxkit/allowlist.json` **via the blocked PR itself** (or a dedicated PR when the base branch is push-protected) — once merged to the base, every other open PR clears on a check re-run, and remediation sweeps inherit the entries on their next clone. Do **not** refresh the baseline for this: the allowlist is the time-boxed instrument; a refresh would grandfather the advisories with no expiry pressure.
 
 ## Remove a single entry
 

--- a/src/allowlist/categories.ts
+++ b/src/allowlist/categories.ts
@@ -224,3 +224,20 @@ export function defaultExpiryDate(now: Date = new Date()): string {
   expires.setUTCDate(expires.getUTCDate() + DEFAULT_EXPIRY_DAYS);
   return expires.toISOString().slice(0, 10);
 }
+
+/**
+ * Default expiry window for `allowlist defer` — the bulk deferral of newly
+ * published dep-vuln advisories (D4). Deliberately SHORT: the expiry is the
+ * forcing function back into the fix lane, so a live advisory a time-sensitive
+ * change deferred re-blocks within days, not the 90-day accepted-risk horizon.
+ * Matches the window the incident bridge script shipped to customers.
+ */
+export const DEFER_ADVISORY_EXPIRY_DAYS = 7;
+
+/** ISO `YYYY-MM-DD` expiry `DEFER_ADVISORY_EXPIRY_DAYS` from `now` (UTC-
+ *  anchored like `defaultExpiryDate`; `now` injected for tests). */
+export function deferAdvisoryExpiryDate(now: Date = new Date()): string {
+  const expires = new Date(now);
+  expires.setUTCDate(expires.getUTCDate() + DEFER_ADVISORY_EXPIRY_DAYS);
+  return expires.toISOString().slice(0, 10);
+}

--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -17,6 +17,10 @@
  * - `list` — print every entry across the file-level allowlist.
  * Reads only; no mutation. Honors `--json` for structured output.
  *
+ * - `defer [<fp>…] [--from-last-check]` — bulk, dep-vuln-only,
+ * time-boxed deferral of newly published advisories (D4). Short
+ * default expiry; refuses every other finding kind.
+ *
  * - `show <fingerprint>` — print one entry's full detail. Falls
  * back to a "no entry found" message when the fingerprint isn't
  * present.
@@ -65,11 +69,13 @@ import {
   ALL_CATEGORIES,
   DEFAULT_EXPIRY_DAYS,
   INLINE_COMPATIBLE_CATEGORIES,
+  deferAdvisoryExpiryDate,
   defaultExpiryDate,
   isCategoryValidForKind,
   requiresExpiry,
   type AllowlistCategory,
 } from './categories';
+import { readVerdictForTree } from '../baseline/verdict-cache';
 import {
   ALLOWLIST_FILENAME,
   ALL_MODES,
@@ -94,6 +100,7 @@ import { insertAnnotation } from './inline';
 /** Subcommands recognized under `vyuh-dxkit allowlist`. */
 export const ALLOWLIST_SUBCOMMANDS = [
   'add',
+  'defer',
   'list',
   'show',
   'audit',
@@ -180,6 +187,9 @@ export async function runAllowlist(
   subcommand: string | undefined,
   args: {
     positionalAfter?: string;
+    /** ALL positionals after the subcommand — `defer` takes a repeated
+     *  fingerprint list. Falls back to `[positionalAfter]` when absent. */
+    positionalsAfter?: readonly string[];
     values: Record<string, unknown>;
   },
 ): Promise<void> {
@@ -203,6 +213,16 @@ export async function runAllowlist(
         acknowledgedSeverity: args.values['acknowledged-severity'] as string | undefined,
         addedBy: args.values['added-by'] as string | undefined,
         mode: args.values.mode as AllowlistMode | undefined,
+      });
+    case 'defer':
+      return runAllowlistDefer(cwd, {
+        fingerprints: args.positionalsAfter ?? (args.positionalAfter ? [args.positionalAfter] : []),
+        fromLastCheck: !!args.values['from-last-check'],
+        reason: args.values.reason as string | undefined,
+        expires: args.values.expires as string | undefined,
+        addedBy: args.values['added-by'] as string | undefined,
+        mode: args.values.mode as AllowlistMode | undefined,
+        json: !!args.values.json,
       });
     case 'list':
       return runAllowlistList(cwd, { json: !!args.values.json });
@@ -389,6 +409,212 @@ async function runAddFileLevel(args: {
     `Added allowlist entry for fingerprint ${fingerprint} (kind=${kind}, category=${category})` +
       (expiresAt ? `, expires ${expiresAt}` : ''),
   );
+}
+
+// ─── defer ────────────────────────────────────────────────────────────────
+
+export interface AllowlistDeferOpts {
+  /** Explicit fingerprints (positional, repeated). */
+  readonly fingerprints?: readonly string[];
+  /** Pull the blocking dep-vulns from the last same-tree guardrail run's
+   *  verdict cache. */
+  readonly fromLastCheck?: boolean;
+  readonly reason?: string;
+  /** ISO `YYYY-MM-DD`, or relative `+Nd`. Default: `+7d`
+   *  (`DEFER_ADVISORY_EXPIRY_DAYS`). */
+  readonly expires?: string;
+  readonly addedBy?: string;
+  readonly mode?: AllowlistMode;
+  readonly json?: boolean;
+}
+
+/**
+ * `vyuh-dxkit allowlist defer` — bulk, dep-vuln-only, time-boxed deferral of
+ * newly published advisories (D4). Productizes the incident bridge script:
+ * one command adds `category=deferred` entries with a SHORT shared expiry for
+ * either an explicit fingerprint list or the blocking dep-vulns of the last
+ * same-tree guardrail run (`--from-last-check`).
+ *
+ * Deliberately narrow so it can never become a bulk bypass:
+ *   - every entry is minted `kind=dep-vuln` — suppression matches on kind, so
+ *     a deferred fingerprint can never waive a secret / SAST / any other
+ *     finding even if someone pastes the wrong id;
+ *   - `--from-last-check` defers ONLY dep-vuln findings and names anything it
+ *     left blocking; an explicit fingerprint the cache shows as a non-dep-vuln
+ *     finding is refused loudly;
+ *   - the expiry is required-by-category and defaults SHORT
+ *     (`DEFER_ADVISORY_EXPIRY_DAYS` days) — the window is the forcing
+ *     function back into the fix lane.
+ */
+export async function runAllowlistDefer(cwd: string, opts: AllowlistDeferOpts): Promise<void> {
+  const reason = (opts.reason ?? '').trim();
+  if (!reason) {
+    logger.fail('--reason is required (non-empty rationale string)');
+    process.exit(1);
+  }
+  const expiresAt = resolveDeferExpiry(opts.expires);
+
+  const explicit = [...new Set((opts.fingerprints ?? []).map((f) => f.trim()).filter(Boolean))];
+  if (explicit.length === 0 && !opts.fromLastCheck) {
+    logger.fail(
+      'Nothing to defer. Pass fingerprints (vyuh-dxkit allowlist defer <fp> [<fp>…]) ' +
+        'or --from-last-check to defer the blocking dep-vulns of the last guardrail run.',
+    );
+    process.exit(1);
+  }
+
+  // The last same-tree run's blocking findings — the source for
+  // --from-last-check, and the kind cross-check for explicit fingerprints.
+  const cached = readVerdictForTree(cwd);
+  const cachedBlocking = cached?.blockingFindings;
+
+  const targets = new Map<string, { locator?: string; severity?: string }>();
+  const leftBlocking: string[] = [];
+  if (opts.fromLastCheck) {
+    if (!cachedBlocking) {
+      logger.fail(
+        cached
+          ? 'The cached verdict has no finding list (written by an older dxkit). ' +
+              `Re-run \`${dxkitCli('guardrail check')}\` on this tree, then retry.`
+          : 'No cached guardrail verdict for this tree. Run ' +
+              `\`${dxkitCli('guardrail check')}\` first (same tree, no edits in between), then retry.`,
+      );
+      process.exit(1);
+    }
+    for (const f of cachedBlocking) {
+      if (f.kind === 'dep-vuln') {
+        targets.set(f.fingerprint, {
+          ...(f.locator !== undefined ? { locator: f.locator } : {}),
+          ...(f.severity !== undefined ? { severity: f.severity } : {}),
+        });
+      } else {
+        leftBlocking.push(`${f.kind} ${f.locator ?? f.fingerprint}`);
+      }
+    }
+    if (targets.size === 0 && explicit.length === 0) {
+      logger.fail(
+        leftBlocking.length > 0
+          ? `The last run's blocking findings are not dep-vulns — defer refuses to touch them ` +
+              `(${leftBlocking.join('; ')}). Fix them, or review each with ` +
+              `\`${dxkitCli('allowlist add')}\` individually.`
+          : 'The last guardrail run had no blocking findings — nothing to defer.',
+      );
+      process.exit(1);
+    }
+  }
+  for (const fp of explicit) {
+    // Cross-check against the cache when we have it: a fingerprint the last
+    // run shows as a NON-dep-vuln finding must not be bulk-deferred.
+    const known = cachedBlocking?.find((f) => f.fingerprint === fp);
+    if (known && known.kind !== 'dep-vuln') {
+      logger.fail(
+        `Refusing to defer ${fp}: the last guardrail run reports it as a ${known.kind} finding ` +
+          `(${known.locator ?? 'no locator'}), and \`allowlist defer\` is dep-vuln-only. ` +
+          `Review it individually with \`${dxkitCli('allowlist add')}\`.`,
+      );
+      process.exit(1);
+    }
+    if (!targets.has(fp)) {
+      targets.set(fp, {
+        ...(known?.locator !== undefined ? { locator: known.locator } : {}),
+        ...(known?.severity !== undefined ? { severity: known.severity } : {}),
+      });
+    }
+  }
+
+  const addedBy = opts.addedBy?.trim() || resolveGitUserEmail(cwd);
+  if (!addedBy) {
+    logger.fail(`--added-by is required (or set git config user.email so it can be inferred)`);
+    process.exit(1);
+  }
+  const addedAt = todayISO();
+  const mode = resolveMode(cwd, opts.mode);
+  let file = loadAllowlist(cwd) ?? emptyAllowlistFile(mode);
+
+  const added: string[] = [];
+  const alreadyPresent: string[] = [];
+  for (const [fingerprint] of targets) {
+    if (findEntry(file, fingerprint)) {
+      alreadyPresent.push(fingerprint);
+      continue;
+    }
+    const entry: AllowlistEntry = {
+      fingerprint,
+      kind: 'dep-vuln',
+      category: 'deferred',
+      reason,
+      addedBy,
+      addedAt,
+      expiresAt,
+    };
+    const validationErrors = validateAllowlistEntry(entry, mode);
+    if (validationErrors.length > 0) {
+      logger.fail(`allowlist entry for ${fingerprint} failed validation:`);
+      for (const e of validationErrors) logger.fail(` - ${e.field}: ${e.message}`);
+      process.exit(1);
+    }
+    file = addEntry(file, entry);
+    added.push(fingerprint);
+  }
+
+  if (added.length > 0) saveAllowlist(cwd, { ...file, mode });
+
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify({ added, alreadyPresent, leftBlocking, expiresAt, reason }, null, 2) + '\n',
+    );
+    return;
+  }
+
+  if (added.length === 0) {
+    logger.info(
+      alreadyPresent.length > 0
+        ? `All ${alreadyPresent.length} fingerprint(s) already have allowlist entries — nothing written.`
+        : 'Nothing to defer.',
+    );
+  } else {
+    logger.success(
+      `Deferred ${added.length} dep-vuln finding${added.length === 1 ? '' : 's'} ` +
+        `(category=deferred, expires ${expiresAt}).`,
+    );
+    for (const fp of added) {
+      const meta = targets.get(fp);
+      logger.info(`  ${fp}${meta?.locator ? `  ${meta.locator}` : ''}`);
+    }
+    logger.info(
+      `  Commit .dxkit/allowlist.json (via your PR) — the expiry re-blocks these in ` +
+        `${daysUntil(expiresAt)} day(s), so plan the dependency fix now.`,
+    );
+  }
+  if (alreadyPresent.length > 0) {
+    logger.info(`Skipped ${alreadyPresent.length} fingerprint(s) already allowlisted.`);
+  }
+  if (leftBlocking.length > 0) {
+    logger.warn(
+      `Left blocking (not dep-vulns — defer refuses to touch them): ${leftBlocking.join('; ')}`,
+    );
+  }
+}
+
+/** Parse `--expires` for defer: ISO `YYYY-MM-DD` or relative `+Nd`; default
+ *  the short advisory window. */
+function resolveDeferExpiry(raw: string | undefined): string {
+  if (raw === undefined) return deferAdvisoryExpiryDate();
+  const rel = raw.match(/^\+(\d+)d$/);
+  if (rel) {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() + parseInt(rel[1], 10));
+    return d.toISOString().slice(0, 10);
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+  logger.fail(`--expires must be ISO date YYYY-MM-DD or relative +Nd; got ${JSON.stringify(raw)}`);
+  process.exit(1);
+}
+
+/** Whole days from today (UTC) to an ISO date — for the defer summary line. */
+function daysUntil(iso: string): number {
+  const ms = new Date(`${iso}T00:00:00Z`).getTime() - Date.now();
+  return Math.max(0, Math.round(ms / 86_400_000));
 }
 
 // ─── list ─────────────────────────────────────────────────────────────────

--- a/src/analyzers/convergence/dead-surface-gather.ts
+++ b/src/analyzers/convergence/dead-surface-gather.ts
@@ -242,7 +242,13 @@ function stripHandler(handler: string): string {
  */
 export async function gatherDeadSurfaces(
   cwd: string,
-  opts: { readonly dupFindings?: readonly DuplicateFinding[]; readonly graph?: Graph } = {},
+  opts: {
+    readonly dupFindings?: readonly DuplicateFinding[];
+    readonly graph?: Graph;
+    /** Trust posture, forwarded to diagnoseFlow's model gather so plugins
+     *  never load on an untrusted tree (N-TRUST-01). */
+    readonly untrusted?: boolean;
+  } = {},
 ): Promise<DeadSurfaceResult> {
   const empty: DeadSurfaceResult = {
     surfaces: [],
@@ -251,7 +257,9 @@ export async function gatherDeadSurfaces(
   };
   let diag: FlowDiagnosis | null;
   try {
-    diag = await diagnoseFlow(cwd);
+    diag = await diagnoseFlow(cwd, {
+      ...(opts.untrusted !== undefined ? { untrusted: opts.untrusted } : {}),
+    });
   } catch {
     return empty;
   }

--- a/src/analyzers/convergence/inventory.ts
+++ b/src/analyzers/convergence/inventory.ts
@@ -52,7 +52,16 @@ const EMPTY: SeamInventory = {
  * and only builds fresh when no fresh artifact is present (e.g. a git worktree at
  * a ref, where evaluate always builds).
  */
-export async function gatherSeamInventory(cwd: string): Promise<SeamInventory> {
+export async function gatherSeamInventory(
+  cwd: string,
+  opts: {
+    /** Attacker-controlled-source posture: threaded to the dead-surface
+     *  ladder's flow gather so executable flow plugins never load
+     *  (N-TRUST-01 — the trust tier must survive every hop, not just the
+     *  surface that received the flag). */
+    readonly untrusted?: boolean;
+  } = {},
+): Promise<SeamInventory> {
   try {
     // Resolve to an ABSOLUTE path: graphify's subprocess resolves its target
     // from its own working directory, so a relative `cwd` silently yields "no
@@ -70,6 +79,7 @@ export async function gatherSeamInventory(cwd: string): Promise<SeamInventory> {
     const dead = await gatherDeadSurfaces(root, {
       dupFindings: duplicates,
       ...(graph ? { graph } : {}),
+      ...(opts.untrusted !== undefined ? { untrusted: opts.untrusted } : {}),
     });
     const converged = convergeSeams(dead.surfaces, duplicates);
     return { duplicates, dead, converged };

--- a/src/analyzers/flow/diagnose.ts
+++ b/src/analyzers/flow/diagnose.ts
@@ -242,12 +242,23 @@ function resolveConnection(cwd: string, model: FlowModel): { rung: ConnectionRun
  * section) when no flow-capable pack is active, when extraction finds nothing,
  * or on any error.
  */
-export async function diagnoseFlow(cwd: string): Promise<FlowDiagnosis | null> {
+export async function diagnoseFlow(
+  cwd: string,
+  opts: {
+    /** Attacker-controlled-source posture, forwarded to the model gather so
+     *  executable flow plugins never load through the diagnose path
+     *  (N-TRUST-01: the seam-inventory chain reaches here from surfaces that
+     *  accept --untrusted). */
+    readonly untrusted?: boolean;
+  } = {},
+): Promise<FlowDiagnosis | null> {
   if (allFlowSourceExtensions(detectActiveLanguages(cwd)).length === 0) return null;
 
   let model: FlowModel;
   try {
-    model = await gatherSystemFlowModel(cwd);
+    model = await gatherSystemFlowModel(cwd, {
+      ...(opts.untrusted !== undefined ? { untrusted: opts.untrusted } : {}),
+    });
   } catch {
     return null;
   }

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -32,6 +32,7 @@ import type { AttributionGap } from './attribution-gap';
 import { RECALL_DRIFT_REMEDY, describeRecallDrift } from './recall';
 import type { BrownfieldPolicy } from './policy';
 import type { FindingStatus, MatchReason } from './types';
+import { DEFER_ADVISORY_EXPIRY_DAYS } from '../allowlist/categories';
 import { describeBrokenIntegration } from '../analyzers/flow/gate';
 import type { FlowGateOutcome } from './flow-gate-check';
 import { describeSchemaDrift } from '../analyzers/model-schema/gate';
@@ -275,6 +276,7 @@ export function renderConsole(result: GuardrailCheckResult): string {
   if (blocking.length > 0) {
     lines.push(logger.bold(`Blocking (${blocking.length})`));
     for (const p of blocking) lines.push(...formatPairLines(p, '  '));
+    lines.push(...newlyPublishedAdvisoryNote(blocking, '  '));
     lines.push('');
   }
   if (unattributable.length > 0) {
@@ -831,6 +833,53 @@ export function formatDriftWarningSummary(
   ];
 }
 
+/**
+ * The honest-attribution note under a blocking list that contains newly
+ * published advisories (D4): states the PR did not cause them and names both
+ * lanes as one-command remedies. Empty when none are present. Exported for
+ * unit testing (the `formatDriftWarningSummary` pattern).
+ */
+export function newlyPublishedAdvisoryNote(
+  blocking: ReadonlyArray<ClassifiedPair>,
+  indent: string,
+): string[] {
+  const advisories = blocking.filter((p) => p.classification.status === 'newly_published_advisory');
+  if (advisories.length === 0) return [];
+  return [
+    `${indent}${advisories.length} of the blocking finding${blocking.length === 1 ? '' : 's'} ` +
+      `${advisories.length === 1 ? 'is a newly published advisory' : 'are newly published advisories'} — ` +
+      `not introduced by this PR (no dependency manifest changed; published after baseline capture).`,
+    `${indent}  · fix lane: upgrade/patch the dependency — that is what unblocks`,
+    `${indent}  · defer lane (time-sensitive change): vyuh-dxkit allowlist defer --from-last-check --reason="…" ` +
+      `(time-boxed; expires in ${DEFER_ADVISORY_EXPIRY_DAYS} days by default)`,
+  ];
+}
+
+/** Markdown sibling of `newlyPublishedAdvisoryNote` — the blockquote above the
+ *  blocking table. Exported for unit testing. */
+export function markdownNewlyPublishedAdvisoryNote(
+  blocking: ReadonlyArray<ClassifiedPair>,
+): string[] {
+  const advisories = blocking.filter((p) => p.classification.status === 'newly_published_advisory');
+  if (advisories.length === 0) return [];
+  const head =
+    advisories.length === blocking.length
+      ? advisories.length === 1
+        ? 'This blocking finding is a newly published advisory'
+        : `All ${advisories.length} blocking findings are newly published advisories`
+      : `${advisories.length} of these ${blocking.length} blocking findings ` +
+        `${advisories.length === 1 ? 'is a newly published advisory' : 'are newly published advisories'}`;
+  return [
+    `> **${head}** — ` +
+      `not introduced by this PR: the diff touches no dependency manifest, so they were ` +
+      `published to the advisory feed after the baseline was captured. Two lanes: **fix** the ` +
+      `vulnerabilities (that is what unblocks), or **defer time-boxed** when the change is ` +
+      'time-sensitive: `vyuh-dxkit allowlist defer --from-last-check --reason="…"` (expires in ' +
+      `${DEFER_ADVISORY_EXPIRY_DAYS} days by default — the expiry forces the fix lane).`,
+    '',
+  ];
+}
+
 function statusLabel(status: FindingStatus): string {
   switch (status) {
     case 'added':
@@ -845,6 +894,8 @@ function statusLabel(status: FindingStatus): string {
       return 'TOOLING-DRIFT';
     case 'config_drift':
       return 'CONFIG-DRIFT';
+    case 'newly_published_advisory':
+      return 'NEWLY-PUBLISHED-ADVISORY';
     case 'newly_detected':
       return 'NEWLY-DETECTED';
     case 'probable_existing':
@@ -1405,6 +1456,7 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
   if (blocking.length > 0) {
     lines.push('### Blocking findings');
     lines.push('');
+    lines.push(...markdownNewlyPublishedAdvisoryNote(blocking));
     lines.push('| Status | Kind | Severity | Location | Fingerprint | Reason |');
     lines.push('|---|---|---|---|---|---|');
     for (const p of blocking) lines.push(markdownPairRow(p));

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -705,6 +705,28 @@ export async function runGuardrailCheck(
   const linesChangedFor = (file: string): ReadonlySet<number> | 'all' | null =>
     changedLineIndex ? changedLineIndex.linesFor(file) : null;
 
+  // D4: the manifest-untouched discriminator for `added` dep-vulns. A net-new
+  // dependency vulnerability requires a manifest/lockfile change; when the diff
+  // (baseline anchor → working tree, the same basis as the changed-line index)
+  // touched none, the advisory was published AFTER baseline capture and the
+  // classifier relabels the pair `newly_published_advisory` — attribution
+  // honesty only, the verdict is unchanged. Consumes the ONE pack-declared
+  // `changedFilesTouchDependencyManifest` — the same helper the ref-based
+  // incremental dep-audit skip trusts (Rule 2.30 parity, pinned by
+  // test/baseline/advisory-attribution.test.ts). Memoized: one `git diff` per
+  // run, and only when an added dep-vuln pair actually asks. `null` changed
+  // files (attribution unavailable) reads as UNKNOWN → no relabel.
+  let manifestUntouchedMemo: boolean | undefined;
+  const manifestUntouched = (): boolean => {
+    if (manifestUntouchedMemo === undefined) {
+      const changed = baseSha ? computeChangedFiles(cwd, baseSha) : null;
+      manifestUntouchedMemo =
+        changed !== null &&
+        !changedFilesTouchDependencyManifest(changed, detectActiveLanguages(cwd));
+    }
+    return manifestUntouchedMemo;
+  };
+
   // Load the per-finding allowlist once. An active (unexpired) entry
   // whose fingerprint matches a would-block finding waives the block —
   // this is what makes "I reviewed and accepted this finding" actually
@@ -780,6 +802,11 @@ export async function runGuardrailCheck(
       ...(overlapsChangedLines !== undefined ? { overlapsChangedLines } : {}),
       ...(malicious ? { malicious } : {}),
       ...(reachable ? { reachable } : {}),
+      // Only asked for added dep-vuln pairs, so a run with none never pays the
+      // git diff (and other kinds never see the flag).
+      ...(anchorEntry.kind === 'dep-vuln' && pair.status === 'added' && manifestUntouched()
+        ? { manifestUntouched: true }
+        : {}),
     };
 
     // `classify` is kind-agnostic; fold in the custom-check block INTENT (a
@@ -1075,7 +1102,14 @@ function diffEnvelopes(baseline: BaselineFile, current: CurrentScan): EnvelopeDr
 export function describeEntryLocation(entry: BaselineEntry): string {
   if (!isSanitized(entry) && entry.kind === 'dep-vuln') {
     const ver = entry.installedVersion ? `@${entry.installedVersion}` : '';
-    const adv = entry.id ? ` · ${entry.id}` : '';
+    // The ADVISORY id, not `entry.id` (the fingerprint — a naming collision:
+    // `DepVulnIdentityInput.id` means advisory id, `BaselineEntry.id` means
+    // finding id). Reading the fingerprint made ten same-package rows repeat
+    // the Fingerprint column and read as duplicates with contradictory
+    // severities (severity is per-advisory). Fallback covers pre-advisoryId
+    // baselines.
+    const advisoryId = entry.advisoryId ?? entry.id;
+    const adv = advisoryId ? ` · ${advisoryId}` : '';
     return `${entry.package}${ver}${adv}`;
   }
   if (!isSanitized(entry) && entry.kind === 'custom-check') {
@@ -1197,10 +1231,11 @@ function locatorLine(entry: BaselineEntry): number | undefined {
  * Whether a classified pair contributes a BLOCK to the verdict. Folds
  * the classifier's verdict together with allowlist suppression: a pair
  * the classifier would block but an active allowlist entry accepted
- * does not block. Single chokepoint so the main verdict and the
- * post-`--changed-only` re-derivation can't drift.
+ * does not block. Single chokepoint so the main verdict, the
+ * post-`--changed-only` re-derivation, and the verdict cache's
+ * blocking-finding projection can't drift. Exported for the cache.
  */
-function pairBlocks(p: ClassifiedPair): boolean {
+export function pairBlocks(p: ClassifiedPair): boolean {
   return p.classification.blocks && p.suppressedByAllowlist === undefined;
 }
 

--- a/src/baseline/classify.ts
+++ b/src/baseline/classify.ts
@@ -65,6 +65,15 @@ export interface ClassifyContext {
    *  ChangedFiles` and similar rules; absent context is treated as
    *  "we don't know, assume outside changed lines." */
   readonly overlapsChangedLines?: boolean;
+  /** True when the diff (baseline anchor → working tree) touched NO dependency
+   *  manifest of any active pack. For an `added` dep-vuln this rules the
+   *  developer out as the delta's cause — the dependency set is unchanged, so
+   *  the advisory was published to the feed after baseline capture (D4). The
+   *  discriminator is the ONE `changedFilesTouchDependencyManifest` — the same
+   *  helper the ref-based incremental dep-audit skip trusts (Rule 2.30 parity).
+   *  Absent (changed files unknowable) ⇒ no relabel: the evidence is missing,
+   *  so the finding keeps its `added` attribution. */
+  readonly manifestUntouched?: boolean;
   /** True when an `added` dep-vuln is on a reachable code path. */
   readonly reachable?: boolean;
   /** True when an `added` dep-vuln's advisory reports the package itself
@@ -160,6 +169,26 @@ export function classify(
             `baseline is re-captured`,
         });
       }
+    } else if (context.kind === 'dep-vuln' && context.manifestUntouched) {
+      // D4: the PR changed no dependency manifest, so the dependency set is
+      // identical to the baseline's — the developer cannot be the cause of an
+      // added dep-vuln. The one input that moved is the advisory FEED
+      // (published after baseline capture). Recall is genuinely clean here
+      // (Rule 19's recallDrifted branch above wins when it isn't), so this is
+      // its own status — never "regression", never `tooling_drift`. The
+      // VERDICT is unchanged (phase 1): block rules and policy membership
+      // treat it exactly as `added` — a live high/critical advisory must not
+      // silently ride in — but the report stops blaming the PR and names the
+      // two lanes (fix the vuln, or short-dated `allowlist defer`).
+      status = 'newly_published_advisory';
+      reasons.push({
+        code: 'newly-published-advisory',
+        detail:
+          'not introduced by this PR — the diff touches no dependency manifest, so this ' +
+          'advisory was published after the baseline was captured. Fix the vulnerability to ' +
+          'unblock, or defer time-boxed: vyuh-dxkit allowlist defer --from-last-check ' +
+          '--reason="…"',
+      });
     } else if (context.configDiffers && !context.fileChangedInDiff) {
       // Config drift only explains a finding that appeared WITHOUT a code
       // change (e.g. a path the policy newly un-ignored). A finding on a file
@@ -235,9 +264,14 @@ export function classify(
     });
   }
 
-  // Step 5: policy block/warn membership.
-  const blocks = blockRuleHit !== null || policy.block.includes(status);
-  const warns = policy.warn.includes(status);
+  // Step 5: policy block/warn membership. `newly_published_advisory` is an
+  // attribution RELABEL of `added` (D4 phase 1: gate semantics unchanged), so
+  // membership is evaluated as `added` — every policy that blocks added
+  // dep-vulns today keeps blocking them, whatever its lists say, without each
+  // committed policy.json needing to learn the new status.
+  const membershipStatus: FindingStatus = status === 'newly_published_advisory' ? 'added' : status;
+  const blocks = blockRuleHit !== null || policy.block.includes(membershipStatus);
+  const warns = policy.warn.includes(membershipStatus);
 
   return {
     status,
@@ -275,7 +309,11 @@ function evaluateBlockRules(
   rules: BrownfieldBlockRules,
   context: ClassifyContext,
 ): string | null {
-  if (status !== 'added' && status !== 'config_drift') return null;
+  // `newly_published_advisory` fires block rules exactly as `added` — the
+  // relabel changes attribution (who is blamed), never the floor (D4 phase 1).
+  if (status !== 'added' && status !== 'config_drift' && status !== 'newly_published_advisory') {
+    return null;
+  }
   if (rules.newSecret && context.kind === 'secret') return 'newSecret';
   if (rules.newCriticalSecurity && context.kind === 'code' && context.severity === 'critical') {
     return 'newCriticalSecurity';

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -803,6 +803,14 @@ export type FindingStatus =
   | 'newly_detected'
   | 'tooling_drift'
   | 'config_drift'
+  /** An `added` dep-vuln on a diff that touched NO dependency manifest of any
+   *  active pack: the dependency set is identical on both sides, so the delta's
+   *  cause is the advisory FEED moving after baseline capture — never the
+   *  developer (D4, Rule 19 cause-5 in its data-vintage variant). Attribution
+   *  relabel only: it gates exactly as `added` does (the classifier maps it to
+   *  `added` for policy membership and block rules), it just stops blaming the
+   *  PR and names the defer lane. */
+  | 'newly_published_advisory'
   | 'probable_existing'
   | 'uncertain';
 

--- a/src/baseline/verdict-cache.ts
+++ b/src/baseline/verdict-cache.ts
@@ -24,8 +24,48 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { workingTreeSignature } from '../loop/gate-cache';
 import type { BrownfieldPolicy } from './policy';
+import { pairBlocks, type ClassifiedPair } from './check';
 
 const CACHE_REL = path.join('.dxkit', 'cache', 'verdict.json');
+
+/**
+ * One live blocking finding, projected for replay consumers. `allowlist defer
+ * --from-last-check` reads this list to bulk-defer newly published dep-vuln
+ * advisories without hand-copying fingerprints; the `kind` is what lets it
+ * refuse to defer anything that isn't a dep-vuln.
+ */
+export interface CachedBlockingFinding {
+  readonly fingerprint: string;
+  readonly kind: string;
+  readonly status: string;
+  readonly severity?: string;
+  /** Human descriptor (`package@version · advisory-id` for dep-vulns). */
+  readonly locator?: string;
+}
+
+/**
+ * Project a check result's LIVE blocking pairs (via the one `pairBlocks`
+ * chokepoint — suppressed pairs excluded) into the cacheable shape. Pairs
+ * without a current-side fingerprint are dropped: they cannot be allowlisted.
+ */
+export function cacheBlockingFindings(
+  pairs: ReadonlyArray<ClassifiedPair>,
+): CachedBlockingFinding[] {
+  const out: CachedBlockingFinding[] = [];
+  for (const p of pairs) {
+    if (!pairBlocks(p)) continue;
+    const fingerprint = p.pair.currentId ?? p.pair.priorId;
+    if (!fingerprint) continue;
+    out.push({
+      fingerprint,
+      kind: p.kind,
+      status: p.classification.status,
+      ...(p.severity !== undefined ? { severity: p.severity } : {}),
+      ...(p.locator !== undefined ? { locator: p.locator } : {}),
+    });
+  }
+  return out;
+}
 
 /** A replayable verdict. Stores the rendered signals markdown + the summary
  *  fields a `--json` consumer needs, keyed on the tree signature + policy hash
@@ -49,6 +89,11 @@ export interface CachedVerdict {
   readonly markdown: string;
   /** ISO timestamp of the run this verdict came from. */
   readonly ranAt: string;
+  /** The live blocking findings (fingerprint + kind + status), so
+   *  `allowlist defer --from-last-check` can bulk-defer dep-vuln advisories
+   *  from the last same-tree run. Optional: a cache written by an older dxkit
+   *  lacks it — defer then asks for a re-run rather than guessing. */
+  readonly blockingFindings?: ReadonlyArray<CachedBlockingFinding>;
 }
 
 /** Stable hash of the resolved policy — the block/warn severity routing that
@@ -81,6 +126,29 @@ export function readFreshVerdict(cwd: string, policy: BrownfieldPolicy): CachedV
   if (typeof parsed.unattributableCount !== 'number') return null;
   if (parsed.signature !== sig) return null; // tree moved
   if (parsed.policyHash !== policyHash(policy)) return null; // policy changed
+  return parsed;
+}
+
+/**
+ * The cached verdict for the CURRENT tree, ignoring the policy hash — for
+ * consumers that need the last run's FINDING LIST rather than a replayable
+ * verdict (`allowlist defer --from-last-check`). The tree-signature check
+ * still applies: a fingerprint list from a different tree could defer findings
+ * that no longer exist (or miss ones that do), so a moved tree reads as "no
+ * cache — re-run the check". A policy edit, by contrast, changes which
+ * findings BLOCK but not what the findings ARE; requiring a policy match here
+ * would force a pointless re-gather before every defer. Never throws.
+ */
+export function readVerdictForTree(cwd: string): CachedVerdict | null {
+  const sig = workingTreeSignature(cwd);
+  if (!sig) return null;
+  let parsed: CachedVerdict;
+  try {
+    parsed = JSON.parse(fs.readFileSync(path.join(cwd, CACHE_REL), 'utf8')) as CachedVerdict;
+  } catch {
+    return null;
+  }
+  if (typeof parsed.signature !== 'string' || parsed.signature !== sig) return null;
   return parsed;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -235,6 +235,14 @@ ${renderCommandIndex().join('\n')}
                                  accepted-risk / deferred) and required reason. Inline
                                  form inserts a dxkit-allow: annotation; file-level
                                  form writes to .dxkit/allowlist.json.
+    vyuh-dxkit allowlist defer [<fingerprint>…] [--from-last-check] --reason=<text>
+                               [--expires=<YYYY-MM-DD|+Nd>]
+                                 Bulk, dep-vuln-only, time-boxed deferral of newly
+                                 published advisories (category=deferred, default
+                                 expiry +7d — the expiry re-blocks, forcing the fix
+                                 lane). --from-last-check pulls the blocking dep-vulns
+                                 from the last same-tree guardrail run; other kinds are
+                                 refused, never bulk-deferred.
     vyuh-dxkit allowlist list | show <fingerprint> | audit | prune [--dry-run] [--json]
                                  Review / audit / clean the allowlist. audit surfaces
                                  expired + soon-to-expire (within 14 days) + missing-
@@ -425,11 +433,12 @@ export async function run(argv: string[]): Promise<void> {
       target: { type: 'string' },
       'dry-run': { type: 'boolean', default: false },
       plan: { type: 'boolean', default: false },
-      // allowlist flags (allowlist add | list | show | audit | prune | remove | export)
+      // allowlist flags (allowlist add | defer | list | show | audit | prune | remove | export)
       category: { type: 'string' },
       reason: { type: 'string' },
       fingerprint: { type: 'string' },
       expires: { type: 'string' },
+      'from-last-check': { type: 'boolean', default: false },
       'acknowledged-severity': { type: 'string' },
       'added-by': { type: 'string' },
       mode: { type: 'string' },
@@ -2733,7 +2742,7 @@ export async function run(argv: string[]): Promise<void> {
       const { runGuardrailCheck } = await import('./baseline/check');
       const { renderConsole, renderJson, renderMarkdown, verdictCounts } =
         await import('./baseline/check-renderers');
-      const { writeVerdict } = await import('./baseline/verdict-cache');
+      const { cacheBlockingFindings, writeVerdict } = await import('./baseline/verdict-cache');
       const { parseBaselineMode } = await import('./baseline/modes');
       const cliModeRaw = values.mode as string | undefined;
       const cliMode = cliModeRaw !== undefined ? parseBaselineMode(cliModeRaw) : undefined;
@@ -2778,6 +2787,7 @@ export async function run(argv: string[]): Promise<void> {
           warningCount: counts.warning,
           markdown: renderMarkdown(result),
           ranAt: new Date().toISOString(),
+          blockingFindings: cacheBlockingFindings(result.pairs),
         });
         const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
         if (values.json) {
@@ -3079,10 +3089,12 @@ export async function run(argv: string[]): Promise<void> {
 
     case 'allowlist': {
       const { runAllowlist } = await import('./allowlist/cli');
-      // positionals[1] = subcommand (add | list | show | audit | prune | remove | export)
+      // positionals[1] = subcommand (add | defer | list | show | audit | prune | remove | export)
       // positionals[2] = optional target (file:line for add; fingerprint for show / remove)
+      // positionals[2..] = repeated fingerprints for defer
       await runAllowlist(cwd, positionals[1], {
         positionalAfter: positionals[2],
+        positionalsAfter: positionals.slice(2),
         values: values as Record<string, unknown>,
       });
       break;

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -328,7 +328,8 @@ export const COMMANDS = [
     summary: 'Suppress / audit individual findings with typed reasons',
     typicalRuntime: '< 1 sec',
     docsBlurb:
-      'Accept a finding with a typed category + required reason + optional expiry; audit and prune entries.',
+      'Accept a finding with a typed category + required reason + optional expiry; audit and prune ' +
+      'entries. `defer` bulk-defers newly published dep-vuln advisories time-boxed (dep-vuln-only).',
     skill: 'dxkit-allowlist',
   },
   {

--- a/src/evaluate/run.ts
+++ b/src/evaluate/run.ts
@@ -190,7 +190,7 @@ export async function runEvaluate(opts: EvaluateOptions): Promise<EvaluateEviden
   // that has not enabled those gates. Runs in a disposable worktree at the head
   // (zero-write, the same spine as the per-landing checks); fail-open — a head
   // that can't be analyzed simply omits the lane.
-  const seams = await gatherTrialSeams(cwd, pairs[0]?.pair.headSha);
+  const seams = await gatherTrialSeams(cwd, pairs[0]?.pair.headSha, untrusted);
 
   return buildEvidenceDoc({
     branch: currentBranch(cwd),
@@ -211,11 +211,14 @@ export async function runEvaluate(opts: EvaluateOptions): Promise<EvaluateEviden
 async function gatherTrialSeams(
   cwd: string,
   headSha: string | undefined,
+  untrusted: boolean,
 ): Promise<SeamVisibility | undefined> {
   if (!headSha) return undefined;
   try {
     return await withRefWorktree({ cwd, ref: headSha }, async (wt) =>
-      seamVisibilityFrom(await gatherSeamInventory(wt)),
+      // The trial's trust posture reaches the seam lane too — the gate runs
+      // untrusted but this lane also gathers from the same head (N-TRUST-01).
+      seamVisibilityFrom(await gatherSeamInventory(wt, { untrusted })),
     );
   } catch {
     return undefined;

--- a/src/flow-cli.ts
+++ b/src/flow-cli.ts
@@ -168,7 +168,9 @@ export async function runFlowMap(opts: FlowViewOptions): Promise<void> {
   // ladder over served-but-unconsumed routes. Zero-write; gathered once (the ONE
   // seam-inventory orchestration, shared with `evaluate`) and used by both the
   // console + JSON surfaces.
-  const inv = await gatherSeamInventory(opts.cwd);
+  const inv = await gatherSeamInventory(opts.cwd, {
+    ...(opts.untrusted !== undefined ? { untrusted: opts.untrusted } : {}),
+  });
 
   if (opts.json) {
     emitJson({
@@ -371,6 +373,10 @@ export async function runFlowConsole(opts: FlowConsoleOptions): Promise<void> {
         cwd: opts.cwd,
         baseRef: opts.diff,
         allowlist: loadAllowlist(opts.cwd),
+        // The console's trust tier must reach the gate's in-process plugin
+        // load — dropping it here was N-TRUST-01 (the shipped PR workflow
+        // runs `flow console --untrusted` against PR-head source).
+        ...(opts.untrusted !== undefined ? { untrusted: opts.untrusted } : {}),
       });
       if (outcome.ran) {
         for (const f of outcome.findings) {

--- a/src/receipt-cli.ts
+++ b/src/receipt-cli.ts
@@ -18,7 +18,7 @@
  * it never sets a failing exit code; `guardrail check` is the gate.
  */
 import { loadPolicyFromCwd } from './baseline/policy';
-import { readFreshVerdict, writeVerdict } from './baseline/verdict-cache';
+import { cacheBlockingFindings, readFreshVerdict, writeVerdict } from './baseline/verdict-cache';
 import type { DimensionScore } from './analyzers/types';
 
 export interface ReceiptOptions {
@@ -166,6 +166,7 @@ async function resolveVerdict(
     warningCount: counts.warning,
     markdown,
     ranAt,
+    blockingFindings: cacheBlockingFindings(result.pairs),
   });
   return {
     markdown,

--- a/test/allowlist/defer.test.ts
+++ b/test/allowlist/defer.test.ts
@@ -1,0 +1,204 @@
+/**
+ * `vyuh-dxkit allowlist defer` — the bulk, dep-vuln-only, time-boxed deferral
+ * of newly published advisories (D4 phase 1). Productizes the incident bridge
+ * script (web-client #375/#376): one command, short shared expiry, and a hard
+ * structural guarantee that it can never bulk-defer a real regression — every
+ * entry is minted `kind=dep-vuln` (suppression matches on kind), non-dep-vuln
+ * findings are refused, and `--from-last-check` only ever reads dep-vulns out
+ * of the cached verdict.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { runAllowlistDefer } from '../../src/allowlist/cli';
+import { loadAllowlist } from '../../src/allowlist/file';
+import { DEFER_ADVISORY_EXPIRY_DAYS } from '../../src/allowlist/categories';
+import { writeVerdict } from '../../src/baseline/verdict-cache';
+import type { CachedBlockingFinding } from '../../src/baseline/verdict-cache';
+import type { BrownfieldPolicy } from '../../src/baseline/policy';
+
+const tmps: string[] = [];
+function mkRepo(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-defer-'));
+  tmps.push(d);
+  execFileSync('git', ['init', '-q'], { cwd: d });
+  execFileSync('git', ['config', 'user.email', 'dev@example.com'], { cwd: d });
+  execFileSync('git', ['config', 'user.name', 'dev'], { cwd: d });
+  fs.writeFileSync(path.join(d, 'app.js'), 'const x = 1;\n');
+  execFileSync('git', ['add', '-A'], { cwd: d });
+  execFileSync('git', ['commit', '-qm', 'init'], { cwd: d });
+  return d;
+}
+afterEach(() => {
+  for (const d of tmps.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function mockExit() {
+  return vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    throw new Error(`process.exit(${code ?? 0})`);
+  });
+}
+
+const POLICY = {} as unknown as BrownfieldPolicy;
+
+function seedVerdict(cwd: string, blockingFindings: CachedBlockingFinding[]): void {
+  writeVerdict(cwd, POLICY, {
+    blocks: blockingFindings.length > 0,
+    warns: false,
+    blockingCount: blockingFindings.length,
+    unattributableCount: 0,
+    warningCount: 0,
+    markdown: '## dxkit signals',
+    ranAt: '2026-07-22T00:00:00.000Z',
+    blockingFindings,
+  });
+}
+
+const DEP_A: CachedBlockingFinding = {
+  fingerprint: 'aaaa000000000001',
+  kind: 'dep-vuln',
+  status: 'newly_published_advisory',
+  severity: 'high',
+  locator: 'fast-uri@3.1.2 · GHSA-aaaa-bbbb-cccc',
+};
+const DEP_B: CachedBlockingFinding = {
+  fingerprint: 'aaaa000000000002',
+  kind: 'dep-vuln',
+  status: 'newly_published_advisory',
+  severity: 'medium',
+  locator: 'svgo@1.3.2 · GHSA-dddd-eeee-ffff',
+};
+const SECRET: CachedBlockingFinding = {
+  fingerprint: 'bbbb000000000001',
+  kind: 'secret',
+  status: 'added',
+  severity: 'critical',
+  locator: 'src/config.js:12',
+};
+
+describe('allowlist defer --from-last-check', () => {
+  it('defers the cached blocking dep-vulns with the short default expiry, and ONLY those', async () => {
+    const d = mkRepo();
+    seedVerdict(d, [DEP_A, DEP_B, SECRET]);
+    await runAllowlistDefer(d, { fromLastCheck: true, reason: 'advisory batch 2026-07-22' });
+
+    const file = loadAllowlist(d);
+    expect(file?.entries.map((e) => e.fingerprint).sort()).toEqual([
+      DEP_A.fingerprint,
+      DEP_B.fingerprint,
+    ]);
+    for (const e of file!.entries) {
+      expect(e.kind).toBe('dep-vuln');
+      expect(e.category).toBe('deferred');
+      expect(e.reason).toBe('advisory batch 2026-07-22');
+      expect(e.addedBy).toBe('dev@example.com');
+      // Short window — the forcing function, not the 90-day accepted-risk default.
+      const days = Math.round(
+        (new Date(`${e.expiresAt}T00:00:00Z`).getTime() - Date.now()) / 86_400_000,
+      );
+      expect(days).toBeGreaterThanOrEqual(DEFER_ADVISORY_EXPIRY_DAYS - 1);
+      expect(days).toBeLessThanOrEqual(DEFER_ADVISORY_EXPIRY_DAYS);
+    }
+    // The secret is untouched — left blocking, never bulk-deferred.
+    expect(file!.entries.some((e) => e.fingerprint === SECRET.fingerprint)).toBe(false);
+  });
+
+  it('is idempotent — already-present fingerprints are skipped, not duplicated', async () => {
+    const d = mkRepo();
+    seedVerdict(d, [DEP_A]);
+    await runAllowlistDefer(d, { fromLastCheck: true, reason: 'first' });
+    // The allowlist write changed the tree, so re-seed for the second run.
+    seedVerdict(d, [DEP_A, DEP_B]);
+    await runAllowlistDefer(d, { fromLastCheck: true, reason: 'second' });
+
+    const file = loadAllowlist(d);
+    expect(file?.entries).toHaveLength(2);
+    expect(file?.entries.find((e) => e.fingerprint === DEP_A.fingerprint)?.reason).toBe('first');
+  });
+
+  it('refuses when no cached verdict exists for this tree, naming the remedy', async () => {
+    const d = mkRepo();
+    const exit = mockExit();
+    await expect(runAllowlistDefer(d, { fromLastCheck: true, reason: 'x' })).rejects.toThrow(
+      'process.exit(1)',
+    );
+    exit.mockRestore();
+    expect(loadAllowlist(d)).toBeNull();
+  });
+
+  it('refuses a STALE cache (tree moved since the check) — findings must match this tree', async () => {
+    const d = mkRepo();
+    seedVerdict(d, [DEP_A]);
+    fs.appendFileSync(path.join(d, 'app.js'), 'const y = 2;\n');
+    const exit = mockExit();
+    await expect(runAllowlistDefer(d, { fromLastCheck: true, reason: 'x' })).rejects.toThrow(
+      'process.exit(1)',
+    );
+    exit.mockRestore();
+  });
+
+  it('refuses when the only blocking findings are non-dep-vuln (never a bulk bypass)', async () => {
+    const d = mkRepo();
+    seedVerdict(d, [SECRET]);
+    const exit = mockExit();
+    await expect(runAllowlistDefer(d, { fromLastCheck: true, reason: 'x' })).rejects.toThrow(
+      'process.exit(1)',
+    );
+    exit.mockRestore();
+    expect(loadAllowlist(d)).toBeNull();
+  });
+});
+
+describe('allowlist defer <fingerprint>…', () => {
+  it('defers an explicit fingerprint list as dep-vuln/deferred entries', async () => {
+    const d = mkRepo();
+    await runAllowlistDefer(d, {
+      fingerprints: ['cccc000000000001', 'cccc000000000002', 'cccc000000000001'],
+      reason: 'GHSA batch, PR is time-sensitive',
+      expires: '+3d',
+    });
+    const file = loadAllowlist(d);
+    // Deduped.
+    expect(file?.entries).toHaveLength(2);
+    const expected = new Date();
+    expected.setUTCDate(expected.getUTCDate() + 3);
+    expect(file?.entries[0].expiresAt).toBe(expected.toISOString().slice(0, 10));
+    expect(file?.entries.every((e) => e.kind === 'dep-vuln' && e.category === 'deferred')).toBe(
+      true,
+    );
+  });
+
+  it('refuses an explicit fingerprint the last run reports as a non-dep-vuln finding', async () => {
+    const d = mkRepo();
+    seedVerdict(d, [SECRET]);
+    const exit = mockExit();
+    await expect(
+      runAllowlistDefer(d, { fingerprints: [SECRET.fingerprint], reason: 'x' }),
+    ).rejects.toThrow('process.exit(1)');
+    exit.mockRestore();
+    expect(loadAllowlist(d)).toBeNull();
+  });
+
+  it('requires a reason and at least one source', async () => {
+    const d = mkRepo();
+    const exit = mockExit();
+    await expect(runAllowlistDefer(d, { fingerprints: ['aaaa000000000001'] })).rejects.toThrow(
+      'process.exit(1)',
+    );
+    await expect(runAllowlistDefer(d, { reason: 'x' })).rejects.toThrow('process.exit(1)');
+    exit.mockRestore();
+  });
+
+  it('rejects a malformed --expires', async () => {
+    const d = mkRepo();
+    const exit = mockExit();
+    await expect(
+      runAllowlistDefer(d, { fingerprints: ['aaaa000000000001'], reason: 'x', expires: 'soon' }),
+    ).rejects.toThrow('process.exit(1)');
+    exit.mockRestore();
+  });
+});

--- a/test/baseline/advisory-attribution.test.ts
+++ b/test/baseline/advisory-attribution.test.ts
@@ -1,0 +1,241 @@
+/**
+ * D4 phase 1 — the `newly_published_advisory` classification (4.1.3).
+ *
+ * The incident class: a committed-mode repo's PR that touches NO dependency
+ * manifest gets hard-blocked as "N new regressions" the day an advisory batch
+ * lands on any unchanged dependency (web-client #375, then #376 48h later).
+ * Recall is genuinely clean (same scanner, same version), so Rule 19 rightly
+ * stays silent — the one input that moved is the advisory FEED. The fix is
+ * attribution honesty with gate semantics UNCHANGED: the finding still blocks
+ * exactly as `added` does (a live high/critical advisory must not ride in),
+ * but the status stops blaming the PR and the output names both lanes.
+ *
+ * Parity discipline (Rule 2.30): the classifier's discriminator and the
+ * ref-based incremental dep-audit skip consume the ONE pack-declared
+ * `changedFilesTouchDependencyManifest` — pinned here behaviorally (the
+ * helper's verdict drives the relabel decision on shared fixtures) and at the
+ * source level (check.ts holds no second manifest matcher).
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { classify } from '../../src/baseline/classify';
+import type { ClassifyContext } from '../../src/baseline/classify';
+import { DEFAULT_BROWNFIELD_POLICY } from '../../src/baseline/policy';
+import type { BrownfieldPolicy } from '../../src/baseline/policy';
+import type { MatchPair } from '../../src/baseline/types';
+import { changedFilesTouchDependencyManifest, getLanguage } from '../../src/languages';
+import {
+  markdownNewlyPublishedAdvisoryNote,
+  newlyPublishedAdvisoryNote,
+} from '../../src/baseline/check-renderers';
+import type { ClassifiedPair } from '../../src/baseline/check';
+
+const addedPair: MatchPair = {
+  currentId: 'dep0000000000000a',
+  status: 'added',
+  confidence: 1,
+  reasons: [{ code: 'no-prior-match', detail: 'not in baseline' }],
+};
+
+function ctx(extra: Partial<ClassifyContext>): ClassifyContext {
+  return { kind: 'dep-vuln', severity: 'high', ...extra };
+}
+
+describe('classify — newly_published_advisory (D4 phase 1)', () => {
+  it('relabels an added dep-vuln on a manifest-untouched diff, with the honest reason', () => {
+    const out = classify(addedPair, DEFAULT_BROWNFIELD_POLICY, ctx({ manifestUntouched: true }));
+    expect(out.status).toBe('newly_published_advisory');
+    const reason = out.reasons.find((r) => r.code === 'newly-published-advisory');
+    expect(reason).toBeDefined();
+    expect(reason!.detail).toContain('not introduced by this PR');
+    expect(reason!.detail).toContain('allowlist defer');
+  });
+
+  it('gate semantics are UNCHANGED: it blocks exactly as added does (policy membership)', () => {
+    // Default policy blocks 'added' by membership; the relabel must not open
+    // a bypass for severities no block rule covers.
+    const medium = classify(
+      addedPair,
+      DEFAULT_BROWNFIELD_POLICY,
+      ctx({ severity: 'medium', manifestUntouched: true }),
+    );
+    const asAdded = classify(addedPair, DEFAULT_BROWNFIELD_POLICY, ctx({ severity: 'medium' }));
+    expect(medium.status).toBe('newly_published_advisory');
+    expect(medium.blocks).toBe(asAdded.blocks);
+    expect(medium.warns).toBe(asAdded.warns);
+  });
+
+  it('armed block rules still fire through the relabel (critical, high+reachable, malicious)', () => {
+    const critical = classify(
+      addedPair,
+      DEFAULT_BROWNFIELD_POLICY,
+      ctx({ severity: 'critical', manifestUntouched: true }),
+    );
+    expect(critical.blocks).toBe(true);
+    expect(
+      critical.reasons.some((r) => r.detail.includes('newCriticalDependencyVulnerability')),
+    ).toBe(true);
+
+    const reachable = classify(
+      addedPair,
+      DEFAULT_BROWNFIELD_POLICY,
+      ctx({ severity: 'high', reachable: true, manifestUntouched: true }),
+    );
+    expect(reachable.blocks).toBe(true);
+    expect(
+      reachable.reasons.some((r) => r.detail.includes('newHighReachableDependencyVulnerability')),
+    ).toBe(true);
+
+    const malicious = classify(
+      addedPair,
+      DEFAULT_BROWNFIELD_POLICY,
+      ctx({ severity: 'low', malicious: true, manifestUntouched: true }),
+    );
+    expect(malicious.blocks).toBe(true);
+    expect(malicious.reasons.some((r) => r.detail.includes('newMaliciousDependency'))).toBe(true);
+  });
+
+  it('a warn-only policy keeps warning (relabel never escalates)', () => {
+    const warnOnly: BrownfieldPolicy = {
+      ...DEFAULT_BROWNFIELD_POLICY,
+      block: [],
+      warn: ['added'],
+      blockRules: {
+        ...DEFAULT_BROWNFIELD_POLICY.blockRules,
+        newCriticalDependencyVulnerability: false,
+        newHighReachableDependencyVulnerability: false,
+        newMaliciousDependency: false,
+      },
+    };
+    const out = classify(addedPair, warnOnly, ctx({ severity: 'medium', manifestUntouched: true }));
+    expect(out.status).toBe('newly_published_advisory');
+    expect(out.blocks).toBe(false);
+    expect(out.warns).toBe(true);
+  });
+
+  it('absent evidence means NO relabel — an added dep-vuln stays added', () => {
+    // `manifestUntouched` absent = changed files unknowable; the classifier
+    // must not claim an attribution it has no evidence for (Rule 19).
+    const out = classify(addedPair, DEFAULT_BROWNFIELD_POLICY, ctx({}));
+    expect(out.status).toBe('added');
+  });
+
+  it('a manifest-TOUCHING diff keeps full added semantics', () => {
+    const out = classify(addedPair, DEFAULT_BROWNFIELD_POLICY, ctx({ manifestUntouched: false }));
+    expect(out.status).toBe('added');
+  });
+
+  it('only dep-vulns relabel — other kinds ignore the flag', () => {
+    const out = classify(addedPair, DEFAULT_BROWNFIELD_POLICY, {
+      kind: 'secret',
+      severity: 'critical',
+      manifestUntouched: true,
+    });
+    expect(out.status).toBe('added');
+  });
+
+  it('recall drift outranks the relabel (D4b stays a disclosed drift, not an advisory claim)', () => {
+    // When the scanner itself moved (sandbox npm 10.8.2 vs baseline 10.9.8),
+    // the data-vintage claim is not clean — Rule 19's tooling_drift branch
+    // keeps priority, including its unattributable-block-rule refusal tier.
+    const out = classify(
+      addedPair,
+      DEFAULT_BROWNFIELD_POLICY,
+      ctx({ severity: 'critical', recallDrifted: true, manifestUntouched: true }),
+    );
+    expect(out.status).toBe('tooling_drift');
+    expect(out.unattributableBlockRule).toBe('newCriticalDependencyVulnerability');
+  });
+});
+
+describe('renderers — the honest attribution note (both surfaces)', () => {
+  function blockingPair(status: string, kind = 'dep-vuln'): ClassifiedPair {
+    return {
+      kind,
+      locator: 'axios@1.16.1 · GHSA-h67p-54hq-rp68',
+      classification: { status, blocks: true, warns: false, reasons: [] },
+      pair: addedPair,
+      severity: 'high',
+    } as unknown as ClassifiedPair;
+  }
+
+  it('console: names the two lanes and states the PR did not cause the findings', () => {
+    const lines = newlyPublishedAdvisoryNote(
+      [blockingPair('newly_published_advisory'), blockingPair('added', 'secret')],
+      '  ',
+    );
+    expect(lines.join('\n')).toContain('not introduced by this PR');
+    expect(lines.join('\n')).toContain('allowlist defer --from-last-check');
+    expect(lines.join('\n')).toContain('fix lane');
+  });
+
+  it('markdown: the blockquote above the blocking table, with both lanes', () => {
+    const md = markdownNewlyPublishedAdvisoryNote([
+      blockingPair('newly_published_advisory'),
+      blockingPair('newly_published_advisory'),
+    ]).join('\n');
+    expect(md).toContain('All 2 blocking findings are newly published advisories');
+    expect(md).toContain('not introduced by this PR');
+    expect(md).toContain('allowlist defer --from-last-check');
+  });
+
+  it('silent when no blocking pair carries the status', () => {
+    expect(newlyPublishedAdvisoryNote([blockingPair('added')], '  ')).toEqual([]);
+    expect(markdownNewlyPublishedAdvisoryNote([blockingPair('added')])).toEqual([]);
+  });
+});
+
+describe('discriminator parity with the ref-based dep-audit skip (Rule 2.30)', () => {
+  const ts = getLanguage('typescript')!;
+
+  // Shared fixtures: the SAME changed-file sets, judged by the ONE helper.
+  const fixtures: ReadonlyArray<{ files: string[]; touches: boolean }> = [
+    { files: ['src/app.ts', 'README.md'], touches: false },
+    { files: ['package.json'], touches: true },
+    { files: ['package-lock.json'], touches: true },
+    { files: ['services/api/pnpm-lock.yaml'], touches: true },
+    { files: ['docs/guide.md'], touches: false },
+  ];
+
+  it('the helper verdict drives BOTH consumers identically on shared fixtures', () => {
+    for (const f of fixtures) {
+      const touches = changedFilesTouchDependencyManifest(f.files, [ts]);
+      expect(touches).toBe(f.touches);
+
+      // Consumer 1 — the ref-based incremental skip: audits are skipped
+      // exactly when the diff touches no manifest.
+      const skipFires = !touches;
+
+      // Consumer 2 — the classifier discriminator: an added dep-vuln relabels
+      // exactly when the diff touches no manifest.
+      const out = classify(
+        addedPair,
+        DEFAULT_BROWNFIELD_POLICY,
+        ctx({ manifestUntouched: !touches }),
+      );
+      const relabels = out.status === 'newly_published_advisory';
+
+      // Parity: the two consumers may never disagree about the diff's
+      // dependency-relevance. (If the skip fires, the audit never runs and no
+      // added dep-vuln can exist ref-based — so a finding that DOES appear, in
+      // committed mode, must carry the honest relabel.)
+      expect(relabels).toBe(skipFires);
+    }
+  });
+
+  it('check.ts consumes the ONE helper for both the skip and the discriminator (source pin)', () => {
+    // Strip comments first (the languages-contract lesson: a grep that
+    // matches a comment reports coverage that does not exist).
+    const src = fs
+      .readFileSync(path.join(__dirname, '..', '..', 'src', 'baseline', 'check.ts'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '');
+    const calls = src.match(/changedFilesTouchDependencyManifest\(/g) ?? [];
+    // Exactly two consumers: the ref-based skip and the D4 discriminator.
+    expect(calls.length).toBe(2);
+    // And no second manifest-pattern matcher smuggled in beside the helper.
+    expect(src).not.toMatch(/matchesManifestPattern\(/);
+    expect(src).not.toMatch(/allDependencyManifestPatterns\(/);
+  });
+});

--- a/test/baseline/finding-locator.test.ts
+++ b/test/baseline/finding-locator.test.ts
@@ -11,26 +11,42 @@ import type { BaselineEntry } from '../../src/baseline/types';
 import type { ClassifyResult } from '../../src/baseline/classify';
 
 describe('describeEntryLocation', () => {
-  it('dep-vuln → package@version · advisory-id (the fix for Location: —)', () => {
+  it('dep-vuln → package@version · ADVISORY id, never the fingerprint (D4c)', () => {
+    // On a real BaselineEntry `id` is the FINDING fingerprint — the naming
+    // collision that shipped ten same-package rows repeating the Fingerprint
+    // column and reading as duplicates with contradictory severities. The
+    // locator must show `advisoryId`.
     const entry = {
       kind: 'dep-vuln',
-      fingerprint: 'abcd000000000000',
+      id: 'abcd000000000000',
       package: 'dompurify',
       installedVersion: '3.2.7',
-      id: 'GHSA-76mc-f452-cxcm',
+      advisoryId: 'GHSA-76mc-f452-cxcm',
     } as unknown as BaselineEntry;
-    expect(describeEntryLocation(entry)).toBe('dompurify@3.2.7 · GHSA-76mc-f452-cxcm');
+    const loc = describeEntryLocation(entry);
+    expect(loc).toBe('dompurify@3.2.7 · GHSA-76mc-f452-cxcm');
+    expect(loc).not.toContain('abcd000000000000');
   });
 
   it('dep-vuln with no installed version → package · advisory-id', () => {
     const entry = {
       kind: 'dep-vuln',
-      fingerprint: 'abcd000000000000',
+      id: 'abcd000000000000',
       package: 'uuid',
       installedVersion: undefined,
-      id: 'GHSA-w5hq-g745-h8pq',
+      advisoryId: 'GHSA-w5hq-g745-h8pq',
     } as unknown as BaselineEntry;
     expect(describeEntryLocation(entry)).toBe('uuid · GHSA-w5hq-g745-h8pq');
+  });
+
+  it('dep-vuln from a pre-advisoryId baseline falls back to the entry id', () => {
+    const entry = {
+      kind: 'dep-vuln',
+      id: 'abcd000000000000',
+      package: 'axios',
+      installedVersion: '1.16.1',
+    } as unknown as BaselineEntry;
+    expect(describeEntryLocation(entry)).toBe('axios@1.16.1 · abcd000000000000');
   });
 
   it('located kinds still render file:line', () => {

--- a/test/flow-untrusted-canary.test.ts
+++ b/test/flow-untrusted-canary.test.ts
@@ -1,0 +1,164 @@
+/**
+ * N-TRUST-01 side-effect canary (4.1.3). The `--untrusted` trust tier promises
+ * that executable flow plugins NEVER load when the scanned source is
+ * attacker-controlled — the shipped PR workflow runs `flow console --untrusted`
+ * against PR-head code, so a dropped flag means PR-head JavaScript executes on
+ * the CI runner. The audit found the boolean forwarded at some call sites and
+ * silently dropped at others (console → gate, map → seam inventory, evaluate →
+ * seam visibility).
+ *
+ * The canary: a fixture plugin whose module body writes a sentinel file OUTSIDE
+ * the repo at load time. Each user-facing `--untrusted` entry point runs twice —
+ * untrusted first (the sentinel must NOT appear), then trusted (the sentinel
+ * MUST appear, proving the canary actually covers that entry's plugin-load path
+ * and the untrusted assertion is not vacuous).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SDK_MAJOR } from '@vyuhlabs/dxkit-sdk';
+import { runFlowConsole, runFlowExtract, runFlowMap } from '../src/flow-cli';
+import { gatherSeamInventory } from '../src/analyzers/convergence/inventory';
+import { runEvaluate } from '../src/evaluate/run';
+
+let repo: string;
+let sentinelDir: string;
+let sentinel: string;
+
+beforeEach(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-canary-repo-'));
+  sentinelDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-canary-out-'));
+  sentinel = path.join(sentinelDir, 'PLUGIN_FIRED');
+});
+afterEach(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+  fs.rmSync(sentinelDir, { recursive: true, force: true });
+});
+
+function write(rel: string, content: unknown): void {
+  const abs = path.join(repo, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, typeof content === 'string' ? content : JSON.stringify(content));
+}
+
+/** The canary plugin: side-effect at LOAD (module body), then a valid dialect
+ *  definition. The sentinel path is absolute + out-of-tree so a load from a
+ *  detached git worktree (the gate's base side, evaluate's head) still lands
+ *  where the test can see it. */
+function writeCanaryPlugin(): void {
+  write('.dxkit/extensions/canary/extension.json', {
+    schemaVersion: 1,
+    name: 'canary',
+    plugin: { module: 'plugin.js' },
+  });
+  write(
+    '.dxkit/extensions/canary/plugin.js',
+    `require('fs').writeFileSync(${JSON.stringify(sentinel)}, 'fired');\n` +
+      `module.exports = {\n` +
+      `  name: 'canary',\n` +
+      `  sdkMajor: ${SDK_MAJOR},\n` +
+      `  httpFlowDialect: {\n` +
+      `    pack: 'typescript',\n` +
+      `    clientMethodCallees: { methods: ['fetchJson'] },\n` +
+      `    methodAliases: { fetchjson: 'GET' },\n` +
+      `  },\n` +
+      `};\n`,
+  );
+}
+
+/** The stack markers that make the repo DETECT as TypeScript — diagnoseFlow
+ *  (the seam-inventory chain) bails before any plugin load when no
+ *  flow-capable pack is active, which would make the positive controls
+ *  vacuous. */
+function writeStackMarkers(): void {
+  write('package.json', { name: 'canary-fixture', version: '1.0.0' });
+  write('tsconfig.json', { compilerOptions: { strict: true } });
+}
+
+function fired(): boolean {
+  return fs.existsSync(sentinel);
+}
+function resetSentinel(): void {
+  fs.rmSync(sentinel, { force: true });
+}
+
+function git(...args: string[]): void {
+  execFileSync('git', args, { cwd: repo, stdio: 'ignore' });
+}
+
+/** A minimal TS repo with the canary plugin COMMITTED (so worktrees at a ref
+ *  carry it) and one flow-surface change on top for diff-scoped surfaces. */
+function setupGitRepo(): void {
+  writeStackMarkers();
+  write('src/app.ts', `export async function load() { return api.fetchJson('/articles/1'); }\n`);
+  writeCanaryPlugin();
+  git('init', '-q');
+  git('config', 'user.email', 't@t.co');
+  git('config', 'user.name', 't');
+  git('add', '-A');
+  git('commit', '-qm', 'base');
+  write('src/app.ts', `export async function load() { return api.fetchJson('/articles/2'); }\n`);
+  git('add', '-A');
+  git('commit', '-qm', 'head');
+}
+
+describe('the plugin canary never fires through an --untrusted entry', () => {
+  it('flow map (model gather + seam inventory)', async () => {
+    write('src/app.ts', `export async function load() { return api.fetchJson('/a'); }\n`);
+    writeCanaryPlugin();
+
+    await runFlowMap({ cwd: repo, json: true, untrusted: true });
+    expect(fired()).toBe(false);
+
+    // Positive control: the same entry, trusted, DOES load the plugin — the
+    // untrusted assertion above is not vacuous.
+    await runFlowMap({ cwd: repo, json: true, untrusted: false });
+    expect(fired()).toBe(true);
+  }, 120_000);
+
+  it('flow extract', async () => {
+    write('src/app.ts', `export async function load() { return api.fetchJson('/a'); }\n`);
+    writeCanaryPlugin();
+
+    await runFlowExtract({ cwd: repo, json: true, untrusted: true });
+    expect(fired()).toBe(false);
+
+    await runFlowExtract({ cwd: repo, json: true, untrusted: false });
+    expect(fired()).toBe(true);
+  }, 120_000);
+
+  it('flow console --diff (the gate path — the shipped PR workflow entry)', async () => {
+    setupGitRepo();
+
+    await runFlowConsole({ cwd: repo, json: true, diff: 'HEAD~1', untrusted: true });
+    expect(fired()).toBe(false);
+
+    await runFlowConsole({ cwd: repo, json: true, diff: 'HEAD~1', untrusted: false });
+    expect(fired()).toBe(true);
+  }, 120_000);
+
+  it('gatherSeamInventory (the one seam orchestration both flow map and evaluate share)', async () => {
+    writeStackMarkers();
+    write('src/app.ts', `export async function load() { return api.fetchJson('/a'); }\n`);
+    writeCanaryPlugin();
+
+    await gatherSeamInventory(repo, { untrusted: true });
+    expect(fired()).toBe(false);
+
+    await gatherSeamInventory(repo);
+    expect(fired()).toBe(true);
+  }, 120_000);
+
+  it('evaluate (the trial seam-visibility lane)', async () => {
+    setupGitRepo();
+
+    await runEvaluate({ cwd: repo, base: 'HEAD~1', head: 'HEAD', untrusted: true });
+    expect(fired()).toBe(false);
+
+    resetSentinel();
+    await runEvaluate({ cwd: repo, base: 'HEAD~1', head: 'HEAD', untrusted: false });
+    expect(fired()).toBe(true);
+  }, 300_000);
+});


### PR DESCRIPTION
## What & why

4.1.3 hotfix: the P0 `--untrusted` trust-context escape (N-TRUST-01) plus D4 phase 1, the advisory-feed false-block relief a production incident (two live advisory batches against one repo in 48 hours) forced forward. Gate semantics are unchanged in this release; what changes is attribution honesty, the cost of the defer lane, and a closed plugin-execution hole on the CI path.

## Changes

**P0: `--untrusted` reaches every in-process plugin load** (`84f7d8e`)
- `flow console` forwards the flag to the integration gate; `flow map` forwards it into the seam inventory; `evaluate` forwards it into the trial's seam-visibility lane. The seam chain (`gatherSeamInventory` -> `gatherDeadSurfaces` -> `diagnoseFlow`) threads the posture down to the one overlay loader.
- Side-effect canary test: a fixture plugin writes a sentinel at load; every `--untrusted` entry runs both ways (untrusted never fires it, trusted must, so no assertion can pass vacuously).

**D4 phase 1: newly published advisories stop being blamed on the PR** (`5edce60`)
- An `added` dep-vuln on a diff that touched no dependency manifest of any active pack classifies as `newly_published_advisory`. Discriminator = the one `changedFilesTouchDependencyManifest` the ref-based skip already trusts (Rule 2.30, parity-pinned both behaviorally and at source level). Verdict evaluates exactly as `added` (block rules included); recall drift keeps priority; absent evidence means no relabel.
- Both renderers state the findings were published after baseline capture, not introduced by this PR, and present the two lanes (fix, or defer time-boxed).
- New `vyuh-dxkit allowlist defer`: bulk, dep-vuln-only, time-boxed (default expiry 7 days). Explicit fingerprints or `--from-last-check` via the verdict cache (which now carries the blocking-finding list). Structurally incapable of bulk bypass: entries minted `kind=dep-vuln`, other kinds refused loudly. Retires `defer_new_advisories.py`.
- D4c: dep-vuln rows show the advisory id (`package@version - GHSA-...`) instead of repeating the fingerprint.
- Skill (`dxkit-allowlist`) + capability catalog updated with the defer lane.

## Verification

- Full local gate parity with CI: build, typecheck, typecheck:test, lint, format, arch-check, slop, cross-ecosystem, docs-coverage, `npm pack --dry-run`, full suite (308 files / 4,621 tests, all green; 37 new tests).
- Canary positive controls caught two vacuous fixtures during development (diagnoseFlow bailed before plugin load on an undetected stack), which is exactly the failure mode they exist for.

## Merge strategy

Rebase merge: three independently meaningful commits (P0 fix, D4 phase 1, release bump).

Next: 4.1.4 (D4 complete: tier posture knob, refresh-as-decision-PR, D4d anchor-precedence verify) before 2026-07-28, when the affected repo's 21 deferred allowlist entries expire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

