### PR TITLE
4.1.4: D4 complete — advisory tier knob, base-branch decision PRs, anchor-transport fix (D4d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.4] - 2026-07-22
+
+D4 complete — the advisory-feed release (phase 2 of the class 4.1.3 opened).
+
+- **The advisory tier knob: `newAdvisories.blockSeverities`.** A dep-vuln
+  classified `newly-published-advisory` (the feed moved after baseline
+  capture; the diff touched no dependency manifest) now gates by an explicit
+  policy tier instead of the generic `added` semantics: default
+  critical + high BLOCK (a live advisory must not silently ride in),
+  medium + low WARN. Two invariants the tier cannot override: a
+  malicious-package advisory blocks at any severity, and an unknown severity
+  blocks (conservative). Registered with the full Rule 16 discovery
+  contract — a `POSTURE_KNOBS` entry plus a grounded doctor probe that
+  surfaces the knob only after a run has concretely blocked a newly
+  published advisory. One normalizer (`newAdvisoryBlockSeverities`) feeds
+  the classifier, the renderers, and the probe.
+- **Base-branch-first surfacing: `vyuh-dxkit baseline refresh`.** The
+  scheduled refresh workflows now run a capture WITH the advisory decision
+  lane instead of a bare `create --force`, which silently ABSORBED newly
+  published advisories into the fresh anchor (defer-forever, no expiry
+  pressure — the inverse failure of the false-block). New advisories —
+  detected against the prior effective baseline with the same
+  manifest-untouched discriminator the classifier trusts — are HELD OUT of
+  the refreshed baseline and raised as one standing base-branch decision PR
+  (`dxkit/advisory-decision`) carrying short-dated `deferred` allowlist
+  entries: merging IS the defer lane (7-day expiry, preserved across
+  re-raises so the window never quietly rolls), fixing the dependencies
+  instead obsoletes the PR. Dependency owners decide before feature PRs
+  fight the findings one at a time. Manifest-touching diffs absorb
+  normally; a first capture or an uncomputable diff degrades to a plain
+  refresh — every case disclosed, never silent.
+- **Fix (D4d): the `branch` anchor transport silently gated against a stale
+  tree copy.** Root-caused ON the incident repo during validation: a large
+  brownfield baseline (~19k findings, multi-MB JSON) blew the side-ref
+  reader's default 1MiB `execFileSync` buffer — `git show` died ENOBUFS with
+  empty stderr, the catch swallowed it, and the check silently used the
+  stale committed copy while the fresh anchor sat reachable in the checkout
+  (the exact #375 footer). Three coupled repairs: (1) the read carries a
+  256MiB buffer; (2) the reader fetches with an explicit refspec into a
+  private `refs/dxkit/` ref, so it also materializes on single-branch
+  clones and actions/checkout workspaces whose narrow fetch refspec never
+  mapped `origin/<anchorRef>` (a second, independent way to the same silent
+  fallback); (3) the check now DISCLOSES which file loaded — `anchorSource`
+  in the result and all three renderers: the side-branch anchor (the footer
+  SHA is then the anchor's), or a loud TREE FALLBACK warning naming the
+  possibly-stale copy. Precedence (anchor wins over the tree copy) is
+  pinned end-to-end; validated on the incident repo (the check now loads
+  the fresh anchor and the 21 live advisories classify + tier correctly).
+- **Disclosed (D4b, not fixed here):** dep-vuln recall keys on the
+  machine-local scanner version, so verdict flavor is machine-dependent on
+  an identical tree; the drift line now names the cause and the remedy
+  (align the local toolchain with repo CI, or run the check in CI). The
+  structural fix is CI-canonical baseline capture — strategy track.
+
 ## [4.1.3] - 2026-07-22
 
 - **Security fix (P0): `--untrusted` now reaches every in-process plugin

--- a/docs/commands/baseline.md
+++ b/docs/commands/baseline.md
@@ -181,11 +181,37 @@ git checkout release/2.5.x
 vyuh-dxkit baseline create --name release
 ```
 
+## `baseline refresh`
+
+The scheduled-refresh capture with the advisory decision lane. What the
+bundled refresh workflows run instead of a bare `create --force`:
+
+1. Re-captures the baseline (the same capture path as `create`).
+2. Diffs the fresh dep-vulns against the PRIOR effective baseline (side-branch
+   anchor first, tree copy second — the guardrail's own precedence). A fresh
+   dep-vuln absent from the prior baseline, on a tree whose diff since the
+   prior anchor touched **no dependency manifest**, is a **newly published
+   advisory** — the feed moved, not this repo.
+3. Holds those OUT of the written baseline (never silently grandfathered — a
+   silent absorption is defer-forever with no expiry pressure) and raises one
+   standing decision PR (`dxkit/advisory-decision`) carrying short-dated
+   `deferred` allowlist entries: **merge = defer time-boxed** (default 7-day
+   expiry — the forcing function back into the fix lane); **fix the
+   dependencies instead** and the next refresh absorbs the resolution. Until
+   one happens, the advisories classify as `newly_published_advisory` on
+   every check, gated by the
+   [`newAdvisories` tier](../configuration/policy.md#newadvisories--the-newly-published-advisory-tier).
+
+A diff that DID touch a dependency manifest absorbs new advisories normally (a
+dependency change legitimately brings its advisories as pre-existing debt), and
+a first capture or an uncomputable diff runs as a plain capture — each case is
+disclosed in the output, never silent.
+
 ## Refreshing the baseline
 
 The `--with-baseline-refresh` flag on `init` installs a GitHub Actions
-workflow that runs `baseline create --force` on every push to `main`,
-then stores the result per the anchor transport: on `tree` it
+workflow that runs [`baseline refresh`](#baseline-refresh) on every push
+to `main`, then stores the result per the anchor transport: on `tree` it
 auto-commits the updated file with `[skip ci]`; on `branch` it runs
 [`baseline publish`](#baseline-publish) to the unprotected side branch
 (no push to `main` at all). The next PR's

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -175,18 +175,19 @@ shapes, and troubleshooting live in [`vyuh-dxkit checks`](../commands/checks.md)
 
 ## Finding statuses
 
-| Status              | Meaning                                                                    |
-| ------------------- | -------------------------------------------------------------------------- |
-| `persisted`         | Same finding, same location — pre-existing debt                            |
-| `relocated`         | Same finding, moved (line drift, file rename)                              |
-| `removed`           | Was in baseline, no longer scanned                                         |
-| `fixed`             | Intentionally suppressed via comment/ignore                                |
-| `added`             | Net-new finding the developer just introduced                              |
-| `tooling_drift`     | New on disk but the scanner version / ruleset changed                      |
-| `config_drift`      | New on disk but `.dxkit-ignore` / dxkit config changed                     |
-| `newly_detected`    | New but envelope signals can't tell whether tooling or developer caused it |
-| `probable_existing` | Heuristic match below the confidence threshold                             |
-| `uncertain`         | Below every threshold; manual review                                       |
+| Status                     | Meaning                                                                                                                                                           |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `persisted`                | Same finding, same location — pre-existing debt                                                                                                                   |
+| `relocated`                | Same finding, moved (line drift, file rename)                                                                                                                     |
+| `removed`                  | Was in baseline, no longer scanned                                                                                                                                |
+| `fixed`                    | Intentionally suppressed via comment/ignore                                                                                                                       |
+| `added`                    | Net-new finding the developer just introduced                                                                                                                     |
+| `newly_published_advisory` | An added dep-vuln on a diff touching no dependency manifest — the advisory feed moved after baseline capture, not the PR. Gated by the `newAdvisories` tier below |
+| `tooling_drift`            | New on disk but the scanner version / ruleset changed                                                                                                             |
+| `config_drift`             | New on disk but `.dxkit-ignore` / dxkit config changed                                                                                                            |
+| `newly_detected`           | New but envelope signals can't tell whether tooling or developer caused it                                                                                        |
+| `probable_existing`        | Heuristic match below the confidence threshold                                                                                                                    |
+| `uncertain`                | Below every threshold; manual review                                                                                                                              |
 
 ## Block rules
 
@@ -203,6 +204,38 @@ of confidence" policy lines. Set any flag to `false` to suppress.
 | `newMaliciousDependency`                  | Block a newly-introduced dependency carrying a malicious-code advisory (OSV `MAL-*`, CWE-506 family, malware-titled GHSA) at ANY severity — install-time malware runs at install, so CVSS and reachability are the wrong lens |
 | `newUntestedChangedSource`                | Block when an untested source file appears alongside changed code                                                                                                                                                             |
 | `newSevereQualityIssueInChangedFiles`     | Block newly-introduced severe quality issues touching changed lines                                                                                                                                                           |
+
+## `newAdvisories` — the newly-published-advisory tier
+
+When the vulnerability feed publishes an advisory about a dependency the repo
+ALREADY had, every open PR that touched no dependency manifest would otherwise
+go red for something disclosure-dated after its branch point. Those findings
+classify as `newly_published_advisory` — the report states they were published
+after baseline capture, not introduced by the PR — and gate by this tier
+instead of the generic block list:
+
+```json
+{
+  "newAdvisories": {
+    "blockSeverities": ["critical", "high"]
+  }
+}
+```
+
+- Default (field absent): `critical` + `high` block; `medium` + `low` warn.
+- `"blockSeverities": []` — warn at every severity (visible pressure, no
+  hard block). A malicious-package advisory still blocks regardless of this
+  list — install-time malware is not tier-negotiable.
+- The two remedies render on every such finding: fix the dependency (that is
+  what unblocks), or defer time-boxed with
+  `vyuh-dxkit allowlist defer --from-last-check --reason="…"` (default expiry
+  7 days — the expiry is the forcing function back into the fix lane).
+- The scheduled refresh (`vyuh-dxkit baseline refresh`, run by the
+  `dxkit-baseline-refresh` workflow) surfaces these on the BASE branch first:
+  new advisories are held out of the refreshed baseline (never silently
+  grandfathered) and raised as one standing decision PR
+  (`dxkit/advisory-decision`) whose merge defers them time-boxed — dependency
+  owners decide before feature PRs fight the findings one at a time.
 
 ## Common customisations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1589,8 +1589,8 @@ fi
 # existence, synthetic-injection — live in test/discovery-playbook.test.ts.)
 RULE16_CLI_CASES=$(grep -oE "^    case '[a-z][a-z-]*':" src/cli.ts | sed -E "s/^    case '([a-z-]+)':/\1/" | sort -u)
 RULE16_REG_TOKENS=$( { \
-  grep -hoE "id: '[a-z][a-z-]*'" src/discovery/command-defs.ts src/discovery/command-defs-internal.ts | sed -E "s/id: '([a-z-]+)'/\1/"; \
-  grep -hoE "aliases: \[[^]]*\]" src/discovery/command-defs.ts src/discovery/command-defs-internal.ts | grep -oE "'[a-z-]+'" | tr -d "'"; \
+  grep -hoE "id: '[a-z][a-z-]*'" src/discovery/command-defs.ts src/discovery/command-defs-gate.ts src/discovery/command-defs-internal.ts | sed -E "s/id: '([a-z-]+)'/\1/"; \
+  grep -hoE "aliases: \[[^]]*\]" src/discovery/command-defs.ts src/discovery/command-defs-gate.ts src/discovery/command-defs-internal.ts | grep -oE "'[a-z-]+'" | tr -d "'"; \
 } | sort -u)
 RULE16_UNREGISTERED=$(comm -23 <(printf '%s\n' "$RULE16_CLI_CASES") <(printf '%s\n' "$RULE16_REG_TOKENS"))
 RULE16_ORPHANED=$(comm -13 <(printf '%s\n' "$RULE16_CLI_CASES") <(printf '%s\n' "$RULE16_REG_TOKENS"))

--- a/src-templates/.claude/skills/dxkit-allowlist/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-allowlist/SKILL.md
@@ -67,7 +67,7 @@ npx vyuh-dxkit allowlist defer --from-last-check --reason="advisory batch YYYY-M
 npx vyuh-dxkit allowlist defer <fp1> <fp2> … --reason="…" [--expires=+7d|YYYY-MM-DD]
 ```
 
-The scenario: a PR that touches **no dependency manifest** goes red because new advisories were published to the feed *after* the baseline was captured. The guardrail labels these `NEWLY-PUBLISHED-ADVISORY` — not introduced by this PR — and the decision is **time-sensitivity**:
+The scenario: a PR that touches **no dependency manifest** goes red because new advisories were published to the feed *after* the baseline was captured. The guardrail labels these `NEWLY-PUBLISHED-ADVISORY` — not introduced by this PR — and gates them by the policy tier (`newAdvisories.blockSeverities`, default: critical/high block, medium/low warn; malicious always blocks). The decision is **time-sensitivity**:
 
 - change is **not** time-sensitive → **fix the vulnerabilities** (upgrade/patch); that is what unblocks;
 - change **is** time-sensitive → `allowlist defer` clears the gate now with short-dated `deferred` entries (default expiry **7 days**, not the 90-day accepted-risk default). The expiry is the forcing function: the findings re-block when it lapses, so plan the dependency fix immediately.
@@ -79,6 +79,8 @@ The scenario: a PR that touches **no dependency manifest** goes red because new 
 - explicit fingerprints the last run reports as non-dep-vuln findings are refused loudly.
 
 Commit the updated `.dxkit/allowlist.json` **via the blocked PR itself** (or a dedicated PR when the base branch is push-protected) — once merged to the base, every other open PR clears on a check re-run, and remediation sweeps inherit the entries on their next clone. Do **not** refresh the baseline for this: the allowlist is the time-boxed instrument; a refresh would grandfather the advisories with no expiry pressure.
+
+**Base-branch-first (the well-configured path):** on repos with the scheduled refresh installed, `vyuh-dxkit baseline refresh` detects new advisories itself, holds them out of the baseline, and raises one standing decision PR (`dxkit/advisory-decision`) carrying exactly these deferred entries — merging it IS the defer lane, executed by the dependency owners before feature PRs ever fight the findings. The per-PR `defer` command above is the fallback for repos without the scheduled lane (or for an advisory batch that lands mid-decision).
 
 ## Remove a single entry
 

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
@@ -93,7 +93,12 @@ __DXKIT_CI_RUNTIME_SETUP__
           else
             DXKIT=vyuh-dxkit
           fi
-          "${DXKIT}" baseline create --force
+          # `baseline refresh` = capture + the D4 advisory decision lane: newly
+          # published dep-vuln advisories (feed moved, no manifest change) are
+          # HELD OUT of the baseline — never silently absorbed — and raised as
+          # the standing two-lane decision PR (merge = defer time-boxed; fix =
+          # upgrade the dependency instead).
+          "${DXKIT}" baseline refresh
 __DXKIT_FRAGMENT_MERGE_STEPS__
 
       - name: Publish anchor to the unprotected side branch

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
@@ -88,7 +88,12 @@ __DXKIT_CI_RUNTIME_SETUP__
           else
             DXKIT=vyuh-dxkit
           fi
-          "${DXKIT}" baseline create --force
+          # `baseline refresh` = capture + the D4 advisory decision lane: newly
+          # published dep-vuln advisories (feed moved, no manifest change) are
+          # HELD OUT of the baseline — never silently absorbed — and raised as
+          # the standing two-lane decision PR (merge = defer time-boxed; fix =
+          # upgrade the dependency instead).
+          "${DXKIT}" baseline refresh
 __DXKIT_FRAGMENT_MERGE_STEPS__
 
       - name: Store anchor in the Actions cache

--- a/src-templates/.github/workflows/dxkit-baseline-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh.yml
@@ -89,7 +89,12 @@ __DXKIT_CI_RUNTIME_SETUP__
           else
             DXKIT=vyuh-dxkit
           fi
-          "${DXKIT}" baseline create --force
+          # `baseline refresh` = capture + the D4 advisory decision lane: newly
+          # published dep-vuln advisories (feed moved, no manifest change) are
+          # HELD OUT of the baseline — never silently absorbed — and raised as
+          # the standing two-lane decision PR (merge = defer time-boxed; fix =
+          # upgrade the dependency instead).
+          "${DXKIT}" baseline refresh
 __DXKIT_FRAGMENT_MERGE_STEPS__
 
       - name: Commit and push refreshed baseline

--- a/src/baseline/anchor-publish.ts
+++ b/src/baseline/anchor-publish.ts
@@ -152,19 +152,37 @@ export function announceAnchorNotPushed(anchorRef: string, reason: string | unde
  * use — one reader of a side ref, one write path below.
  */
 export function readFromAnchorRef(cwd: string, anchorRef: string, relPath: string): string | null {
-  // Best-effort fetch so `origin/<ref>` exists locally (no-op offline / in CI
-  // where the checkout already fetched).
+  // Fetch with an EXPLICIT refspec into a private local ref (D4d). A bare
+  // `git fetch origin <ref>` only writes FETCH_HEAD when the clone's fetch
+  // refspec doesn't map the ref — single-branch clones and actions/checkout
+  // workspaces configure exactly such narrow refspecs — so `origin/<ref>`
+  // never materializes, `git show` fails on every candidate, and the caller
+  // silently falls back to the stale tree copy. The `+refs/heads/<ref>:<priv>`
+  // form materializes the ref regardless of the clone's refspec config; the
+  // private `refs/dxkit/` namespace never collides with user branches.
+  const privateRef = `refs/dxkit/anchor/${anchorRef}`;
   try {
-    execFileSync('git', ['fetch', '--depth=1', 'origin', anchorRef], { cwd, stdio: 'ignore' });
+    execFileSync(
+      'git',
+      ['fetch', '--depth=1', 'origin', `+refs/heads/${anchorRef}:${privateRef}`],
+      { cwd, stdio: 'ignore' },
+    );
   } catch {
-    /* offline / already present */
+    /* offline / no origin — fall through to whatever refs exist locally */
   }
-  for (const ref of [`origin/${anchorRef}`, anchorRef]) {
+  for (const ref of [privateRef, `origin/${anchorRef}`, anchorRef]) {
     try {
       return execFileSync('git', ['show', `${ref}:${relPath}`], {
         cwd,
         stdio: ['ignore', 'pipe', 'ignore'],
         encoding: 'utf8',
+        // D4d, the LIVE incident cause (found on the real repo): a large
+        // brownfield baseline (~19k findings ⇒ multi-MB JSON) blows
+        // execFileSync's default 1MiB maxBuffer — `git show` dies ENOBUFS
+        // with EMPTY stderr, the catch swallowed it, and the check silently
+        // gated against the stale tree copy while `origin/<anchorRef>` was
+        // sitting right there in the checkout.
+        maxBuffer: 256 * 1024 * 1024,
       });
     } catch {
       /* try next ref form */

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -26,7 +26,12 @@
  */
 
 import * as logger from '../logger';
-import type { ClassifiedPair, EnvelopeDrift, GuardrailCheckResult } from './check';
+import type {
+  AnchorSourceDisclosure,
+  ClassifiedPair,
+  EnvelopeDrift,
+  GuardrailCheckResult,
+} from './check';
 import { ATTRIBUTION_GAP_REMEDY, describeAttributionGap } from './attribution-gap';
 import type { AttributionGap } from './attribution-gap';
 import { RECALL_DRIFT_REMEDY, describeRecallDrift } from './recall';
@@ -240,6 +245,16 @@ export function renderConsole(result: GuardrailCheckResult): string {
     `  Commit:      ${shortSha(result.baseline.repo.commitSha)} (${result.baseline.repo.branch || 'detached'})`,
   );
   lines.push(`  Findings:    ${result.baseline.findings.length}`);
+  // D4d: under the `branch` anchor transport, say WHICH file actually loaded —
+  // an unreachable side branch silently gating against a stale tree copy was
+  // invisible in the incident output.
+  if (result.anchorSource) {
+    lines.push(
+      result.anchorSource.used === 'anchor'
+        ? `  Anchor:      side branch '${result.anchorSource.anchorRef}'`
+        : `  ⚠ Anchor:    TREE FALLBACK — ${result.anchorSource.note}`,
+    );
+  }
   const debtNote = floorDebtNotice(result.baseline);
   if (debtNote) lines.push(`  ${debtNote}`);
   lines.push('');
@@ -1010,6 +1025,9 @@ export interface GuardrailJsonPayload {
     readonly commitSha: string;
     readonly branch: string;
     readonly findingsCount: number;
+    /** D4d: under the `branch` anchor transport, which file actually loaded —
+     *  the side-branch anchor, or the tree copy as a disclosed fallback. */
+    readonly anchorSource?: AnchorSourceDisclosure;
     /** Resolved baseline mode (`committed-full` / `committed-
      *  sanitized` / `ref-based`) + its audit trail. Surfaced so
      *  agents + dashboards can see WHY the run picked a given
@@ -1207,6 +1225,7 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
       commitSha: result.baseline.repo.commitSha,
       branch: result.baseline.repo.branch,
       findingsCount: result.baseline.findings.length,
+      ...(result.anchorSource ? { anchorSource: result.anchorSource } : {}),
       mode: {
         value: result.mode.mode,
         source: result.mode.source,
@@ -1584,11 +1603,24 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     lines.push('');
   }
 
+  // D4d: an unreachable side-branch anchor silently gating against a stale
+  // tree copy must be loud in the PR comment, not only in the JSON.
+  if (result.anchorSource?.used === 'tree-fallback') {
+    lines.push('');
+    lines.push(`> ⚠️ **Baseline anchor fallback** — ${escapeMd(result.anchorSource.note)}`);
+    lines.push('');
+  }
+
   lines.push('---');
   lines.push('');
   lines.push(
-    `_Baseline_: \`${escapeMd(result.baseline.name)}\` @ ${shortSha(result.baseline.repo.commitSha)} · ` +
-      `_Mode_: \`${escapeMd(result.mode.mode)}\`${formatModeRef(result.mode)} · ` +
+    `_Baseline_: \`${escapeMd(result.baseline.name)}\` @ ${shortSha(result.baseline.repo.commitSha)}` +
+      (result.anchorSource
+        ? result.anchorSource.used === 'anchor'
+          ? ` (anchor: \`${escapeMd(result.anchorSource.anchorRef)}\`)`
+          : ' (tree fallback)'
+        : '') +
+      ` · _Mode_: \`${escapeMd(result.mode.mode)}\`${formatModeRef(result.mode)} · ` +
       `_Current_: ${shortSha(result.current.repoState.commitSha)} · ` +
       `_Matcher_: ${result.matchResult.gitAware ? 'git-aware' : 'degraded'} · ` +
       `_dxkit_: ${escapeMd(result.current.analysisMeta.dxkitVersion)}`,

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -56,7 +56,7 @@ import type { CoverageDrift } from './coverage';
 import { entriesToLocated } from './entry-to-located';
 import { gitAwareMatch } from './git-aware-match';
 import type { LocatedIdentity } from './git-aware-match';
-import { resolveBaselineMode } from './modes';
+import { DEFAULT_ANCHOR_REF, resolveBaselineMode } from './modes';
 import type { ResolvedMode } from './modes';
 import { resolvePolicy, loadPolicyFromCwd } from './policy';
 import { classify } from './classify';
@@ -271,11 +271,27 @@ export interface EnvelopeDrift {
   readonly coverageDrift: ReadonlyArray<CoverageDrift>;
 }
 
+/** How the committed prior side was obtained under the `branch` anchor
+ *  transport (D4d). `anchor` = read fresh from the side branch (the intended
+ *  path — the footer's baseline SHA is the anchor's). `tree-fallback` = the
+ *  side branch was unreachable and the check gated against the possibly-stale
+ *  tree copy. The fallback stays fail-open, but it is DISCLOSED: in the #375
+ *  incident nothing in the output said which file loaded, so an inert branch
+ *  transport was invisible (the GateFailure discipline — fail open, always say
+ *  why). */
+export interface AnchorSourceDisclosure {
+  readonly used: 'anchor' | 'tree-fallback';
+  readonly anchorRef: string;
+  readonly note: string;
+}
+
 export interface GuardrailCheckResult {
   /** Pre-resolved baseline mode (which path produced `baseline`).
    *  Carries the audit trail (CLI / policy / auto-detect) so the
    *  CLI surface can log WHY the mode was picked. */
   readonly mode: ResolvedMode;
+  /** Present only when the anchor transport is `branch` (D4d disclosure). */
+  readonly anchorSource?: AnchorSourceDisclosure;
   /** On-disk path of the baseline file, or undefined when mode is
    *  `ref-based` (the prior side was computed from a git ref, not
    *  read from a committed file). */
@@ -585,7 +601,7 @@ export async function runGuardrailCheck(
   // out a git ref into a temporary worktree. Both paths produce a
   // `BaselineFile`-shaped value so the matcher / classifier
   // downstream stay mode-agnostic.
-  const { baseline, baselinePath } = await loadPriorSide(
+  const { baseline, baselinePath, anchorSource } = await loadPriorSide(
     cwd,
     mode,
     options,
@@ -935,6 +951,7 @@ export async function runGuardrailCheck(
   return {
     mode,
     ...(baselinePath !== undefined ? { baselinePath } : {}),
+    ...(anchorSource !== undefined ? { anchorSource } : {}),
     baseline,
     current,
     matchResult,
@@ -1304,11 +1321,16 @@ async function loadPriorSide(
   options: RunGuardrailCheckOptions,
   incrementalFiles?: ReadonlyArray<string>,
   scope: GatherScope = FULL_SCOPE,
-): Promise<{ baseline: BaselineFile; baselinePath?: string }> {
+): Promise<{
+  baseline: BaselineFile;
+  baselinePath?: string;
+  anchorSource?: AnchorSourceDisclosure;
+}> {
   if (mode.mode !== 'ref-based') {
     const baselinePath =
       options.baselinePath ?? pathForBaseline(cwd, options.name ?? DEFAULT_BASELINE_NAME);
     const section = safeBaselineSection(cwd);
+    const anchorRef = section?.anchorRef ?? DEFAULT_ANCHOR_REF;
     // Scoped to the `branch` anchor transport: the source-of-truth anchor lives
     // on the side branch (the refresh only updates that, so a committed tree copy
     // goes stale). Read it from there — read-only, into a temp file — so a LOCAL
@@ -1320,7 +1342,15 @@ async function loadPriorSide(
     if (fromBranch) {
       // Keep `baselinePath` as the logical tree path for display; read the fresh
       // side-branch anchor from the temp file.
-      return { baseline: readBaselineFile(fromBranch), baselinePath };
+      return {
+        baseline: readBaselineFile(fromBranch),
+        baselinePath,
+        anchorSource: {
+          used: 'anchor',
+          anchorRef,
+          note: `baseline read from the '${anchorRef}' side branch (anchor transport)`,
+        },
+      };
     }
     if (!fs.existsSync(baselinePath)) {
       // No on-disk copy: materialize a `branch` anchor at the tree path if we can
@@ -1334,7 +1364,28 @@ async function loadPriorSide(
         );
       }
     }
-    return { baseline: readBaselineFile(baselinePath), baselinePath };
+    // D4d disclosure: with the `branch` transport, reaching this line means the
+    // side branch could NOT be read and the check gates against the tree copy —
+    // possibly stale (the refresh only updates the side branch). Fail-open, but
+    // never silent: the incident's footer cited the stale tree SHA with nothing
+    // saying the anchor read failed.
+    const anchorSource: AnchorSourceDisclosure | undefined =
+      section?.anchor === 'branch'
+        ? {
+            used: 'tree-fallback',
+            anchorRef,
+            note:
+              `anchor transport 'branch': the '${anchorRef}' side branch could not be read ` +
+              `(not created yet, offline, or unfetchable) — gating against the committed tree ` +
+              `copy, which may be STALE. If this repo's refresh publishes the anchor, ` +
+              `investigate with \`${dxkitCli('doctor')}\`.`,
+          }
+        : undefined;
+    return {
+      baseline: readBaselineFile(baselinePath),
+      baselinePath,
+      ...(anchorSource ? { anchorSource } : {}),
+    };
   }
 
   if (!mode.ref) {

--- a/src/baseline/classify.ts
+++ b/src/baseline/classify.ts
@@ -11,6 +11,7 @@ import {
   type BrownfieldPolicy,
   type BrownfieldBlockRules,
   DEFAULT_BROWNFIELD_POLICY,
+  newAdvisoryBlockSeverities,
 } from './policy';
 
 /**
@@ -176,10 +177,8 @@ export function classify(
       // (published after baseline capture). Recall is genuinely clean here
       // (Rule 19's recallDrifted branch above wins when it isn't), so this is
       // its own status — never "regression", never `tooling_drift`. The
-      // VERDICT is unchanged (phase 1): block rules and policy membership
-      // treat it exactly as `added` — a live high/critical advisory must not
-      // silently ride in — but the report stops blaming the PR and names the
-      // two lanes (fix the vuln, or short-dated `allowlist defer`).
+      // verdict is decided by the advisory TIER below (default: high/critical
+      // block, medium/low warn; malicious always blocks).
       status = 'newly_published_advisory';
       reasons.push({
         code: 'newly-published-advisory',
@@ -255,6 +254,43 @@ export function classify(
     }
   }
 
+  // D4 phase 2: the advisory TIER governs this status's verdict — not the
+  // generic block/warn membership, and not the block rules (both were the
+  // phase-1 bridge, which evaluated the status exactly as `added`). The tier
+  // is the repo's explicit posture for a class the developer did not cause:
+  // by default a live critical/high advisory still blocks (it must not ride
+  // in silently), medium/low warn. Two invariants: a malicious-package
+  // advisory blocks at ANY severity (install-time malware is not
+  // tier-negotiable), and an UNKNOWN severity blocks (conservative — never a
+  // silent pass on missing evidence).
+  if (status === 'newly_published_advisory') {
+    const tier = newAdvisoryBlockSeverities(policy);
+    const tierProse = tier.size > 0 ? [...tier].join('/') : 'none';
+    let blocks: boolean;
+    if (context.malicious === true) {
+      blocks = true;
+      reasons.push({
+        code: 'advisory-malicious',
+        detail:
+          'malicious-package advisory — blocks at any severity, tier-exempt ' +
+          '(install-time malware executes at install; CVSS is the wrong lens)',
+      });
+    } else {
+      blocks = context.severity === undefined || tier.has(context.severity);
+      reasons.push({
+        code: 'advisory-tier',
+        detail: blocks
+          ? `${context.severity ?? 'unknown-severity'} is in the advisory block tier ` +
+            `(newAdvisories.blockSeverities: ${tierProse}) — fix the dependency to unblock, ` +
+            `or defer time-boxed: vyuh-dxkit allowlist defer --from-last-check --reason="…"`
+          : `${context.severity} is below the advisory block tier ` +
+            `(newAdvisories.blockSeverities: ${tierProse}) — warning, not blocking; ` +
+            `the advisory is live, plan the dependency fix`,
+      });
+    }
+    return { status, blocks, warns: !blocks, reasons };
+  }
+
   // Step 4: block-rule overrides for newly-added findings.
   const blockRuleHit = evaluateBlockRules(status, policy.blockRules, context);
   if (blockRuleHit) {
@@ -264,14 +300,9 @@ export function classify(
     });
   }
 
-  // Step 5: policy block/warn membership. `newly_published_advisory` is an
-  // attribution RELABEL of `added` (D4 phase 1: gate semantics unchanged), so
-  // membership is evaluated as `added` — every policy that blocks added
-  // dep-vulns today keeps blocking them, whatever its lists say, without each
-  // committed policy.json needing to learn the new status.
-  const membershipStatus: FindingStatus = status === 'newly_published_advisory' ? 'added' : status;
-  const blocks = blockRuleHit !== null || policy.block.includes(membershipStatus);
-  const warns = policy.warn.includes(membershipStatus);
+  // Step 5: policy block/warn membership.
+  const blocks = blockRuleHit !== null || policy.block.includes(status);
+  const warns = policy.warn.includes(status);
 
   return {
     status,
@@ -309,11 +340,11 @@ function evaluateBlockRules(
   rules: BrownfieldBlockRules,
   context: ClassifyContext,
 ): string | null {
-  // `newly_published_advisory` fires block rules exactly as `added` — the
-  // relabel changes attribution (who is blamed), never the floor (D4 phase 1).
-  if (status !== 'added' && status !== 'config_drift' && status !== 'newly_published_advisory') {
-    return null;
-  }
+  // `newly_published_advisory` never reaches here — its verdict is governed by
+  // the advisory tier (see the early return in `classify`), which owns the
+  // malicious always-block invariant that `newMaliciousDependency` covers for
+  // ordinary `added` findings.
+  if (status !== 'added' && status !== 'config_drift') return null;
   if (rules.newSecret && context.kind === 'secret') return 'newSecret';
   if (rules.newCriticalSecurity && context.kind === 'code' && context.severity === 'critical') {
     return 'newCriticalSecurity';

--- a/src/baseline/policy.ts
+++ b/src/baseline/policy.ts
@@ -285,6 +285,17 @@ export interface BrownfieldPolicy {
    */
   readonly lint?: LintPolicy;
   /**
+   * Posture for dep-vulns classified `newly_published_advisory` (D4): the
+   * advisory feed moved after baseline capture and the diff touched no
+   * dependency manifest, so the finding is not the PR's fault — but a live
+   * advisory still must not silently ride in. This tier decides which
+   * severities BLOCK (the rest warn). Absent ⟹ the default
+   * (`DEFAULT_NEW_ADVISORY_BLOCK_SEVERITIES`: critical + high block,
+   * medium + low warn). Malicious-package advisories always block regardless
+   * — install-time malware is not tier-negotiable.
+   */
+  readonly newAdvisories?: NewAdvisoriesPolicy;
+  /**
    * Recall-attribution tuning (Rule 19). Absent ⟹ `inputs: 'resolved'`.
    */
   readonly recall?: RecallPolicy;
@@ -297,6 +308,42 @@ export interface BrownfieldPolicy {
    * because it's a CI-performance optimization, not a correctness gate.
    */
   readonly graph?: GraphSection;
+}
+
+/** `newAdvisories.*` block in `.dxkit/policy.json` (the D4 tier knob). */
+export interface NewAdvisoriesPolicy {
+  /** Severities that BLOCK when a dep-vuln is classified
+   *  `newly_published_advisory`. An explicit empty array is a legitimate
+   *  warn-everything posture. Unknown values are dropped by the ONE
+   *  normalizer `newAdvisoryBlockSeverities`. */
+  readonly blockSeverities?: ReadonlyArray<FindingSeverity>;
+}
+
+/** The default advisory block tier: a live high/critical advisory must not
+ *  silently ride in even though the PR did not cause it; medium/low warn —
+ *  visible pressure without a false hard-block. */
+export const DEFAULT_NEW_ADVISORY_BLOCK_SEVERITIES: ReadonlyArray<FindingSeverity> = Object.freeze([
+  'critical',
+  'high',
+]);
+
+const VALID_SEVERITIES: ReadonlyArray<FindingSeverity> = ['critical', 'high', 'medium', 'low'];
+
+/**
+ * The ONE normalizer of the advisory tier (Rule 2): the classifier, the
+ * renderers, and the doctor probe all read the effective block set through
+ * this. A missing/malformed field falls back to the default; a present array
+ * is filtered to known severities (an explicit `[]` means warn-everything —
+ * a deliberate posture, not an error).
+ */
+export function newAdvisoryBlockSeverities(
+  policy: Pick<BrownfieldPolicy, 'newAdvisories'>,
+): ReadonlySet<FindingSeverity> {
+  const declared = policy.newAdvisories?.blockSeverities;
+  if (!Array.isArray(declared)) return new Set(DEFAULT_NEW_ADVISORY_BLOCK_SEVERITIES);
+  return new Set(
+    declared.filter((s): s is FindingSeverity => (VALID_SEVERITIES as string[]).includes(s)),
+  );
 }
 
 /** `graph.*` block in `.dxkit/policy.json`. */

--- a/src/baseline/recall.ts
+++ b/src/baseline/recall.ts
@@ -293,7 +293,18 @@ export function describeRecallDrift(drift: RecallDrift): string {
       const detail = drift.changed
         .map((c) => `${c.input} ${c.before ?? '(absent)'} -> ${c.after ?? '(absent)'}`)
         .join(', ');
-      return `${drift.kind}: ${detail}`;
+      // D4b disclosure: dep-vuln recall keys on the AMBIENT scanner version
+      // (e.g. the npm bundled with the local node), so an identical tree can
+      // read comparable on one machine and drifted on another — the verdict
+      // flavor is machine-dependent until baselines are CI-canonically
+      // captured. Name the near-term operator remedy where it bites.
+      const machineHint =
+        drift.kind === 'dep-vuln'
+          ? ' (dep-vuln recall follows the machine-local scanner — a sandbox/laptop whose ' +
+            'toolchain differs from CI produces this on an unchanged tree; align the local ' +
+            'node/scanner version with the repo CI, or run the check in CI)'
+          : '';
+      return `${drift.kind}: ${detail}${machineHint}`;
     }
   }
 }

--- a/src/baseline/refresh.ts
+++ b/src/baseline/refresh.ts
@@ -1,0 +1,439 @@
+/**
+ * `vyuh-dxkit baseline refresh` — the scheduled-refresh capture with the D4
+ * advisory decision lane (4.1.4). Replaces the refresh workflows' bare
+ * `baseline create --force`, which silently ABSORBED newly published
+ * advisories into the fresh anchor: an advisory the feed disclosed after the
+ * previous capture would grandfather with no decision and no expiry pressure —
+ * defer-forever, the inverse failure of the false-block the classifier fixes.
+ *
+ * What it does instead:
+ *
+ *   1. Capture a fresh baseline (the existing `createBaseline` — one capture
+ *      path, this module never re-implements it).
+ *   2. Diff the fresh capture's dep-vulns against the PRIOR effective baseline
+ *      (side-branch anchor first, tree copy second — the same precedence the
+ *      guardrail check uses). A fresh dep-vuln absent from the prior baseline,
+ *      on a tree whose diff since the prior anchor touched NO dependency
+ *      manifest of any active pack, is a NEWLY PUBLISHED ADVISORY — the same
+ *      ONE discriminator (`changedFilesTouchDependencyManifest`) the
+ *      classifier and the ref-based skip trust (Rule 2.30).
+ *   3. HOLD those out of the written baseline — never absorbed silently — and
+ *      raise the two-lane decision as a standing base-branch PR
+ *      (`dxkit/advisory-decision`) whose content is short-dated `deferred`
+ *      allowlist entries:
+ *        - MERGE the PR  = defer, time-boxed (the expiry re-blocks — the
+ *          forcing function back into the fix lane);
+ *        - fix the dependencies instead and the next refresh absorbs the
+ *          resolution; the PR is updated/obsoleted automatically.
+ *      Until one of those happens the held-out advisories keep classifying as
+ *      `newly_published_advisory` on every check, gated by the tier knob —
+ *      dependency owners decide on the base branch before feature PRs fight
+ *      the findings one at a time.
+ *
+ * Evidence honesty (Rule 19 applied to the refresh): a prior baseline that
+ * cannot be loaded, or a changed-file set that cannot be computed, means the
+ * discriminator has NO evidence — the refresh then absorbs nothing specially
+ * and DISCLOSES why. A diff that DID touch a manifest absorbs normally (a
+ * dependency change legitimately brings its advisories with it as pre-existing
+ * debt — the standard refresh contract).
+ *
+ * Working-tree discipline: the decision branch is written with git PLUMBING
+ * (temp index, commit parented on HEAD, forced push to the standing branch) —
+ * the working tree and HEAD are never touched, so the workflow's later landing
+ * steps (anchor publish / tree commit) see exactly the tree they expect.
+ */
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { changedFilesTouchDependencyManifest, detectActiveLanguages } from '../languages';
+import { computeChangedFiles } from './changed-files';
+import { createBaseline } from './create';
+import {
+  DEFAULT_BASELINE_NAME,
+  pathForBaseline,
+  readBaselineFile,
+  writeBaselineFile,
+} from './baseline-file';
+import type { BaselineEntry } from './types';
+import type { BaselineFile } from './baseline-file';
+import { isSanitized } from './sanitize';
+import { loadAnchorFromBranch } from './anchor';
+import { readFromAnchorRef } from './anchor-publish';
+import { loadPolicyFromCwd, type BaselineSection } from './policy';
+import { resolveBaselineMode } from './modes';
+import { deferAdvisoryExpiryDate } from '../allowlist/categories';
+import {
+  ALLOWLIST_SCHEMA_VERSION,
+  type AllowlistEntry,
+  type AllowlistFile,
+} from '../allowlist/file';
+import { loadAllowlist } from '../allowlist/file';
+import { makeExec, openOrUpdateStandingPr, type LandRefreshResult } from '../land-refresh';
+import { internalGitPushArgs } from '../git-internal-push';
+import { detectDefaultBranch } from '../ship-installers';
+
+/** The standing decision branch. ONE branch, force-updated — never a pile. */
+export const ADVISORY_DECISION_BRANCH = 'dxkit/advisory-decision';
+
+/** One held-out newly published advisory, projected for the decision PR. */
+export interface HeldOutAdvisory {
+  readonly fingerprint: string;
+  readonly package: string;
+  readonly installedVersion?: string;
+  readonly advisoryId: string;
+}
+
+export interface BaselineRefreshResult {
+  /** The fresh capture's finding count (post hold-out). */
+  readonly findings: number;
+  /** Advisories held OUT of the refreshed baseline (empty on a quiet feed). */
+  readonly heldOut: ReadonlyArray<HeldOutAdvisory>;
+  /** The decision-PR landing outcome; absent when nothing was held out. */
+  readonly decision?: LandRefreshResult;
+  /** Why the advisory lane did / could not run — always populated so a refresh
+   *  log never leaves the reader guessing (the GateFailure discipline). */
+  readonly note: string;
+}
+
+export interface BaselineRefreshOptions {
+  readonly cwd: string;
+  readonly name?: string;
+  readonly verbose?: boolean;
+  /** Clock injection for deterministic tests. */
+  readonly now?: Date;
+  /** Exec injection for tests (PR mechanics). */
+  readonly exec?: ReturnType<typeof makeExec>;
+  /** TEST SEAM: replaces the `createBaseline` capture (the analyzers are not
+   *  what refresh tests exercise — the decision lane is). Production omits. */
+  readonly _capture?: (args: { cwd: string; name: string }) => Promise<void>;
+}
+
+/** Best-effort policy baseline section (mirrors check.ts's safe read). */
+function safeSection(cwd: string): BaselineSection | undefined {
+  try {
+    return loadPolicyFromCwd(cwd).baseline;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The PRIOR effective baseline: the side-branch anchor when the transport is
+ * `branch` and reachable, else the on-disk tree copy — the same precedence the
+ * guardrail check applies, so the refresh diffs against what the gate was
+ * actually using. MUST be read BEFORE the fresh capture overwrites the tree
+ * copy. Null when neither exists (first capture).
+ */
+function loadPriorBaseline(
+  cwd: string,
+  treePath: string,
+  section: BaselineSection | undefined,
+): BaselineFile | null {
+  try {
+    const fromBranch = loadAnchorFromBranch(cwd, treePath, section);
+    if (fromBranch) return readBaselineFile(fromBranch);
+  } catch {
+    /* fall through to the tree copy */
+  }
+  try {
+    if (fs.existsSync(treePath)) return readBaselineFile(treePath);
+  } catch {
+    /* unreadable tree copy — treat as absent */
+  }
+  return null;
+}
+
+function depVulnIds(file: BaselineFile): Set<string> {
+  const out = new Set<string>();
+  for (const f of file.findings) if (f.kind === 'dep-vuln') out.add(f.id);
+  return out;
+}
+
+function toHeldOut(entry: BaselineEntry): HeldOutAdvisory {
+  if (entry.kind !== 'dep-vuln') throw new Error('held-out projection is dep-vuln-only');
+  // A sanitized entry (committed-sanitized mode) strips package/advisory
+  // metadata — the fingerprint is all the identity that remains.
+  if (isSanitized(entry)) {
+    return { fingerprint: entry.id, package: '(sanitized)', advisoryId: entry.id };
+  }
+  return {
+    fingerprint: entry.id,
+    package: entry.package,
+    ...(entry.installedVersion !== undefined ? { installedVersion: entry.installedVersion } : {}),
+    advisoryId: entry.advisoryId ?? entry.id,
+  };
+}
+
+/**
+ * Existing deferred entries on the standing decision branch, so a re-raise
+ * (the branch is force-updated every refresh) preserves each advisory's
+ * ORIGINAL expiry — re-dating on every refresh would quietly turn the 7-day
+ * window into defer-forever, the exact failure the lane exists to prevent.
+ */
+function carryOverEntries(cwd: string): Map<string, AllowlistEntry> {
+  const out = new Map<string, AllowlistEntry>();
+  const raw = readFromAnchorRef(cwd, ADVISORY_DECISION_BRANCH, '.dxkit/allowlist.json');
+  if (!raw) return out;
+  try {
+    const file = JSON.parse(raw) as AllowlistFile;
+    for (const e of file.entries ?? []) {
+      if (e.kind === 'dep-vuln' && e.category === 'deferred') out.set(e.fingerprint, e);
+    }
+  } catch {
+    /* malformed standing content — regenerate from scratch */
+  }
+  return out;
+}
+
+/** Serialize an allowlist file exactly as `saveAllowlist` does (plain JSON,
+ *  the `full`-mode format — the decision lane never writes sanitized mode). */
+function serializeAllowlist(file: AllowlistFile): string {
+  return JSON.stringify(file, null, 2) + '\n';
+}
+
+/**
+ * Commit ONE file onto the standing decision branch, parented on the current
+ * HEAD (so the PR is mergeable into the default branch), using a temp index —
+ * the working tree and HEAD never move. Force-pushes the standing branch
+ * (latest-wins; it is machine-owned) through the one internal-push argv.
+ */
+function commitFileToDecisionBranch(
+  cwd: string,
+  relPath: string,
+  content: string,
+  message: string,
+): void {
+  const tmpIndex = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-decision-idx-')), 'idx');
+  const env = {
+    ...process.env,
+    GIT_INDEX_FILE: tmpIndex,
+    GIT_AUTHOR_NAME: 'dxkit-bot',
+    GIT_AUTHOR_EMAIL: 'dxkit-bot@users.noreply.github.com',
+    GIT_COMMITTER_NAME: 'dxkit-bot',
+    GIT_COMMITTER_EMAIL: 'dxkit-bot@users.noreply.github.com',
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes',
+  };
+  const git = (args: string[], input?: string): string =>
+    execFileSync('git', args, {
+      cwd,
+      env,
+      encoding: 'utf8',
+      timeout: 30_000,
+      ...(input !== undefined ? { input } : {}),
+      stdio: input !== undefined ? ['pipe', 'pipe', 'pipe'] : ['ignore', 'pipe', 'pipe'],
+    }).toString();
+
+  git(['read-tree', 'HEAD']);
+  const blob = git(['hash-object', '-w', '--stdin'], content).trim();
+  git(['update-index', '--add', '--cacheinfo', `100644,${blob},${relPath}`]);
+  const tree = git(['write-tree']).trim();
+  const commit = git(['commit-tree', tree, '-p', 'HEAD', '-m', message]).trim();
+  git(internalGitPushArgs(`${commit}:refs/heads/${ADVISORY_DECISION_BRANCH}`, { force: true }));
+}
+
+/** The decision PR's body: the advisory table + the two lanes, stated once. */
+export function decisionPrBody(
+  heldOut: ReadonlyArray<HeldOutAdvisory>,
+  entries: ReadonlyArray<AllowlistEntry>,
+): string {
+  const expiryByFp = new Map(entries.map((e) => [e.fingerprint, e.expiresAt ?? '—']));
+  const rows = heldOut
+    .map(
+      (a) =>
+        `| ${a.package}${a.installedVersion ? `@${a.installedVersion}` : ''} | ${a.advisoryId} | ` +
+        `\`${a.fingerprint}\` | ${expiryByFp.get(a.fingerprint) ?? '—'} |`,
+    )
+    .join('\n');
+  return [
+    `## ${heldOut.length} newly published advisor${heldOut.length === 1 ? 'y' : 'ies'} need a decision`,
+    '',
+    'The scheduled baseline refresh found dependency advisories published to the feed AFTER',
+    'the previous capture, on a tree whose diff touched no dependency manifest — nobody in',
+    'this repo introduced them. They were **held out of the refreshed baseline** (never',
+    'silently grandfathered), so they gate every PR by the advisory tier until this repo',
+    'decides:',
+    '',
+    '| Package | Advisory | Fingerprint | Defer expires |',
+    '|---|---|---|---|',
+    rows,
+    '',
+    '**Lane 1 — fix (preferred):** upgrade or patch the affected dependencies and merge that',
+    'change; the next refresh absorbs the resolution and this PR becomes obsolete.',
+    '',
+    '**Lane 2 — defer, time-boxed:** MERGE THIS PR. It adds `category=deferred` allowlist',
+    'entries that clear the gate now and EXPIRE on the dates above — the findings re-block',
+    'when the window lapses, which is the forcing function back into the fix lane.',
+    '',
+    'Closing this PR without fixing re-raises it on the next scheduled refresh — a live',
+    'advisory never goes silent.',
+    '',
+    '🤖 raised by `vyuh-dxkit baseline refresh` (the D4 advisory decision lane)',
+  ].join('\n');
+}
+
+/**
+ * The refresh orchestration. See the module docs for semantics; the return's
+ * `note` always says what the advisory lane did (or why it could not run).
+ */
+export async function runBaselineRefresh(
+  opts: BaselineRefreshOptions,
+): Promise<BaselineRefreshResult> {
+  const cwd = path.resolve(opts.cwd);
+  const name = opts.name ?? DEFAULT_BASELINE_NAME;
+  const treePath = pathForBaseline(cwd, name);
+  const section = safeSection(cwd);
+  const now = opts.now ?? new Date();
+
+  // Ref-based repos keep no committed baseline, so there is nothing to
+  // refresh — and the advisory class cannot arise there: the check re-gathers
+  // BOTH sides at the same moment, so a newly published advisory appears on
+  // each and matches as pre-existing, never as net-new. Graceful no-op with
+  // the explanation, not a "file not found" throw.
+  const mode = resolveBaselineMode({
+    cwd,
+    policyMode: section?.mode,
+    policyRef: section?.ref,
+  });
+  if (mode.mode === 'ref-based') {
+    return {
+      findings: 0,
+      heldOut: [],
+      note:
+        'ref-based baseline mode — no committed baseline to refresh, and newly published ' +
+        'advisories cannot false-block there (the check gathers both sides against the same ' +
+        'advisory feed). Nothing to do.',
+    };
+  }
+
+  // The prior EFFECTIVE baseline — read before the capture overwrites the tree.
+  const prior = loadPriorBaseline(cwd, treePath, section);
+
+  if (opts._capture) {
+    await opts._capture({ cwd, name });
+  } else {
+    await createBaseline({ cwd, name, force: true, verbose: opts.verbose });
+  }
+  const fresh = readBaselineFile(treePath);
+
+  if (!prior) {
+    return {
+      findings: fresh.findings.length,
+      heldOut: [],
+      note: 'first capture — no prior baseline to detect newly published advisories against',
+    };
+  }
+
+  // The ONE discriminator (Rule 2.30): the diff prior-anchor → working tree.
+  // No evidence (unreachable anchor commit) or a manifest-touching diff ⇒
+  // absorb normally, and say which.
+  const changed = prior.repo.commitSha ? computeChangedFiles(cwd, prior.repo.commitSha) : null;
+  if (changed === null) {
+    return {
+      findings: fresh.findings.length,
+      heldOut: [],
+      note:
+        `changed files vs the prior anchor (${prior.repo.commitSha.slice(0, 12) || 'unknown'}) ` +
+        'could not be computed — cannot attribute new dep-vulns to the feed, so nothing was ' +
+        'held out (absorbed as ordinary pre-existing debt)',
+    };
+  }
+  if (changedFilesTouchDependencyManifest(changed, detectActiveLanguages(cwd))) {
+    return {
+      findings: fresh.findings.length,
+      heldOut: [],
+      note:
+        'a dependency manifest changed since the prior anchor — new dep-vulns may come from ' +
+        'the dependency change itself, so the refresh absorbed them as ordinary pre-existing debt',
+    };
+  }
+
+  const priorIds = depVulnIds(prior);
+  const heldEntries = fresh.findings.filter((f) => f.kind === 'dep-vuln' && !priorIds.has(f.id));
+  if (heldEntries.length === 0) {
+    return {
+      findings: fresh.findings.length,
+      heldOut: [],
+      note: 'no newly published advisories since the prior capture',
+    };
+  }
+
+  // HOLD OUT: the refreshed baseline never grandfathers the new advisories.
+  const heldIds = new Set(heldEntries.map((f) => f.id));
+  const kept: BaselineFile = {
+    ...fresh,
+    findings: fresh.findings.filter((f) => !heldIds.has(f.id)),
+  };
+  writeBaselineFile(treePath, kept);
+  const heldOut = heldEntries.map(toHeldOut);
+
+  // The decision content: short-dated deferred entries, expiry preserved from
+  // the standing branch for advisories already awaiting a decision.
+  const carried = carryOverEntries(cwd);
+  const today = now.toISOString().slice(0, 10);
+  const decisionEntries: AllowlistEntry[] = heldOut.map((a) => {
+    const prev = carried.get(a.fingerprint);
+    if (prev) return prev;
+    return {
+      fingerprint: a.fingerprint,
+      kind: 'dep-vuln',
+      category: 'deferred',
+      reason:
+        `newly published advisory ${a.advisoryId} (${a.package}) detected by the scheduled ` +
+        `refresh on ${today} — merged as a time-boxed deferral; fix before expiry`,
+      addedBy: 'dxkit-refresh',
+      addedAt: today,
+      expiresAt: deferAdvisoryExpiryDate(now),
+    };
+  });
+
+  // Merge onto the DEFAULT BRANCH's current allowlist (the tree's), so the
+  // decision PR carries only the additive delta.
+  const existing = loadAllowlist(cwd);
+  const base: AllowlistFile = existing ?? {
+    schemaVersion: ALLOWLIST_SCHEMA_VERSION,
+    mode: 'full',
+    entries: [],
+  };
+  const present = new Set(base.entries.map((e) => e.fingerprint));
+  const merged: AllowlistFile = {
+    ...base,
+    entries: [...base.entries, ...decisionEntries.filter((e) => !present.has(e.fingerprint))],
+  };
+
+  let decision: LandRefreshResult;
+  const prTitle = `dxkit: ${heldOut.length} newly published advisor${heldOut.length === 1 ? 'y' : 'ies'} need a decision`;
+  try {
+    commitFileToDecisionBranch(
+      cwd,
+      '.dxkit/allowlist.json',
+      serializeAllowlist(merged),
+      `${prTitle}\n\n[skip ci]`,
+    );
+    decision = openOrUpdateStandingPr(opts.exec ?? makeExec(cwd), {
+      branchName: ADVISORY_DECISION_BRANCH,
+      defaultBranch: detectDefaultBranch(cwd),
+      prTitle,
+      prBody: decisionPrBody(heldOut, decisionEntries),
+    });
+  } catch (err) {
+    // Fail-open, never silent: the hold-out already protected the baseline;
+    // an unreachable remote only delays the decision surface.
+    decision = {
+      outcome: 'branch-pushed-no-pr',
+      mode: 'pr',
+      note: `could not land the decision branch: ${(err as Error).message}`,
+    };
+  }
+
+  return {
+    findings: kept.findings.length,
+    heldOut,
+    decision,
+    note:
+      `${heldOut.length} newly published advisor${heldOut.length === 1 ? 'y' : 'ies'} held out ` +
+      `of the refreshed baseline; decision raised on '${ADVISORY_DECISION_BRANCH}'`,
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -194,6 +194,13 @@ ${renderCommandIndex().join('\n')}
                                  (read later by guardrail check to gate new regressions).
                                  --mode=committed-full|committed-sanitized|ref-based picks
                                  the on-disk posture; default auto-selects from repo visibility.
+    vyuh-dxkit baseline refresh [path] [--name <n>] [--json]
+                                 The scheduled-refresh capture with the advisory
+                                 decision lane: re-capture, hold newly published
+                                 dep-vuln advisories OUT of the baseline (never
+                                 silently absorbed), and raise the two-lane decision
+                                 PR (merge = defer time-boxed; fix = upgrade instead).
+                                 What the refresh workflows run.
     vyuh-dxkit baseline publish [path]
                                  Publish .dxkit/baselines/ to the anchor side branch
                                  (baseline.anchor: 'branch' in .dxkit/policy.json) via
@@ -2564,6 +2571,44 @@ export async function run(argv: string[]): Promise<void> {
         }
         break;
       }
+      if (subCommand === 'refresh') {
+        // The scheduled-refresh capture with the D4 advisory decision lane:
+        // capture, hold newly published advisories OUT of the baseline, raise
+        // the two-lane decision PR. What the refresh workflows run instead of
+        // a bare `create --force` (which silently absorbed the advisories).
+        const targetPath = resolveRepoPath(positionals[2]);
+        const { runBaselineRefresh } = await import('./baseline/refresh');
+        logger.header('vyuh-dxkit baseline refresh');
+        try {
+          const result = await runBaselineRefresh({
+            cwd: targetPath,
+            name: values.name as string | undefined,
+            verbose: !!values.verbose,
+          });
+          if (values.json) {
+            await emitJson(result);
+            break;
+          }
+          logger.success(`Baseline refreshed — ${result.findings} finding(s).`);
+          logger.info(`  ${result.note}`);
+          if (result.heldOut.length > 0) {
+            for (const a of result.heldOut) {
+              logger.info(
+                `    ${a.package}${a.installedVersion ? `@${a.installedVersion}` : ''} · ${a.advisoryId}`,
+              );
+            }
+            if (result.decision?.prUrl) {
+              logger.info(`  Decision PR: ${result.decision.prUrl}`);
+            } else if (result.decision?.note) {
+              logger.warn(`  ${result.decision.note}`);
+            }
+          }
+        } catch (err) {
+          logger.fail((err as Error).message);
+          process.exit(1);
+        }
+        break;
+      }
       if (subCommand === 'publish') {
         const targetPath = resolveRepoPath(positionals[2]);
         const { publishBaselineAnchor } = await import('./baseline/anchor');
@@ -2719,6 +2764,7 @@ export async function run(argv: string[]): Promise<void> {
       logger.fail(
         `Unknown baseline subcommand: ${subCommand ?? '(missing)'}. ` +
           `Available: vyuh-dxkit baseline create [path] [--name <name>] [--force] · ` +
+          `vyuh-dxkit baseline refresh [path] [--name <name>] [--json] · ` +
           `vyuh-dxkit baseline publish [path] · ` +
           `vyuh-dxkit baseline show [path] [--name <name>] [--baseline <path>] [--kind <kind>] [--json] · ` +
           `vyuh-dxkit baseline fragment [path] [--checks <a,b>] [--out <file>] · ` +

--- a/src/discovery/advisor.ts
+++ b/src/discovery/advisor.ts
@@ -8,6 +8,7 @@
  */
 import * as path from 'path';
 import { resolveBaselineMode } from '../baseline/modes';
+import { readVerdictForTree } from '../baseline/verdict-cache';
 import { FLOW_CONFIG_SCHEMA_VERSION } from '../analyzers/flow/config';
 import { SCHEMA_CONFIG_SCHEMA_VERSION } from '../analyzers/model-schema/config';
 import { DUPLICATION_CONFIG_SCHEMA_VERSION } from '../analyzers/duplication/config';
@@ -132,6 +133,32 @@ export function recommendChecks(ctx: RecommendContext): Recommendation | null {
     reason:
       'this repo runs a linter but it is not a guardrail gate — enable the lint gate so net-new lint errors block (pre-existing debt is grandfathered)',
     command: 'vyuh-dxkit checks',
+  };
+}
+
+/**
+ * Recommend the advisory tier knob (`newAdvisories.blockSeverities`, D4) when
+ * the repo has CONCRETELY hit the class: the last same-tree guardrail run's
+ * cached verdict blocked at least one `newly_published_advisory` finding, and
+ * the policy has not set the knob. Grounded, not a blanket nag — a repo that
+ * never sees a post-baseline advisory batch never hears about the knob, and
+ * one that tuned it stops hearing immediately.
+ */
+export function recommendNewAdvisoryTier(ctx: RecommendContext): Recommendation | null {
+  const policy = readJsonSafe(path.join(ctx.cwd, '.dxkit', 'policy.json'));
+  if (policy && 'newAdvisories' in policy) return null;
+  const cached = readVerdictForTree(ctx.cwd);
+  const advisories = (cached?.blockingFindings ?? []).filter(
+    (f) => f.status === 'newly_published_advisory',
+  );
+  if (advisories.length === 0) return null;
+  return {
+    reason:
+      `the last guardrail run blocked ${advisories.length} newly published advisor` +
+      `${advisories.length === 1 ? 'y' : 'ies'} (not introduced by the change) — the tier knob ` +
+      `decides which severities block vs warn (default: critical/high block, medium/low warn); ` +
+      `set .dxkit/policy.json newAdvisories.blockSeverities to tune`,
+    command: 'vyuh-dxkit allowlist defer --from-last-check --reason="<why>"',
   };
 }
 

--- a/src/discovery/command-defs-gate.ts
+++ b/src/discovery/command-defs-gate.ts
@@ -1,0 +1,150 @@
+/** The GATE-group partition of the command registry (Rule 16): baseline /
+ *  guardrail / allowlist / checks / loop and their probes. Split from
+ *  `command-defs.ts` purely for file size (the registry grew past the
+ *  large-file floor); spread into `COMMANDS` there — same pattern as
+ *  `command-defs-internal.ts` — so the one registry and the literal
+ *  `CommandId` union are unchanged. */
+import type { CapabilityDescriptor } from './command-types';
+import {
+  recommendBaseline,
+  recommendChecks,
+  recommendDebt,
+  recommendExtensions,
+  recommendLoopPreset,
+  recommendNewAdvisoryTier,
+  planBaselineMode,
+  planFlowSources,
+  planLintGate,
+  planLoopPreset,
+} from './advisor';
+
+export const GATE_COMMANDS = [
+  {
+    id: 'baseline',
+    audience: 'user',
+    group: 'gate',
+    summary: 'Capture / publish / show per-finding baselines for the guardrail',
+    typicalRuntime: '30 sec - 2 min',
+    docsBlurb:
+      'Record per-finding identities the guardrail check diffs against to gate net-new ' +
+      'regressions. `baseline refresh` is the scheduled-refresh capture with the advisory ' +
+      'decision lane (new advisories held out + raised as a base-branch decision PR, never ' +
+      'silently absorbed); `baseline publish` pushes the captured anchor to the side branch on ' +
+      'the `branch` anchor transport.',
+    whenToRecommend: recommendBaseline,
+    planConfig: planBaselineMode,
+  },
+  {
+    id: 'guardrail',
+    audience: 'user',
+    group: 'gate',
+    summary: 'Diff current scan vs baseline; block on net-new regressions',
+    typicalRuntime: '30 sec - 2 min',
+    docsBlurb:
+      'The brownfield gate: fail on findings introduced by a change, grandfathering pre-existing ' +
+      'debt. Newly published advisories (dep-vulns the feed disclosed after baseline capture, on ' +
+      'a diff touching no manifest) gate by the `newAdvisories.blockSeverities` tier — default ' +
+      'critical/high block, medium/low warn.',
+    skill: 'dxkit-action',
+    whenToRecommend: recommendNewAdvisoryTier,
+  },
+  {
+    id: 'receipt',
+    audience: 'user',
+    group: 'gate',
+    summary: 'Emit the PR "dxkit signals" block (verdict + allowlist + score delta)',
+    typicalRuntime: '< 30 sec',
+    docsBlurb:
+      'The ready-to-paste PR signals block, computed not narrated: the guardrail verdict, the allowlist delta, and (with --since) health-score movement vs the base ref. Reuses the session verdict cache so it never re-runs an unchanged scan.',
+    skill: 'dxkit-pr',
+  },
+  {
+    id: 'pr',
+    audience: 'user',
+    group: 'gate',
+    summary: 'Compute a reviewable PR body from the branch (title, changes, signals, checklist)',
+    typicalRuntime: '< 30 sec (longer with --since)',
+    docsBlurb:
+      'The deterministic core of the dxkit-pr skill: reads the branch commits + diff and computes the title, bucketed Changes, the receipt signals block, suggested reviewers, a diff-derived reviewer checklist, and the structural-duplicate seam prompts — leaving only "What & why" for the author. Prints markdown or --json; never opens the PR.',
+    skill: 'dxkit-pr',
+  },
+  {
+    id: 'allowlist',
+    audience: 'user',
+    group: 'gate',
+    summary: 'Suppress / audit individual findings with typed reasons',
+    typicalRuntime: '< 1 sec',
+    docsBlurb:
+      'Accept a finding with a typed category + required reason + optional expiry; audit and prune ' +
+      'entries. `defer` bulk-defers newly published dep-vuln advisories time-boxed (dep-vuln-only).',
+    skill: 'dxkit-allowlist',
+  },
+  {
+    id: 'ingest',
+    audience: 'user',
+    group: 'gate',
+    summary: 'Ingest external SAST findings (Snyk / Sonar / CodeQL / SARIF) as first-class',
+    typicalRuntime: 'varies (reads engine API or SARIF)',
+    docsBlurb:
+      'Pull Snyk Code / SonarQube (API) or CodeQL / Semgrep-Pro (SARIF) findings into dxkit so external findings share one fingerprint + gate.',
+    skill: 'dxkit-ingest',
+  },
+  {
+    id: 'loop',
+    audience: 'user',
+    group: 'gate',
+    summary: 'Autonomous-loop utilities (doctor / ledger / snapshot)',
+    typicalRuntime: '< 5 sec',
+    docsBlurb:
+      'Inspect and verify the autonomous-loop Stop-gate wiring, its ledger, and the correctness-floor snapshot.',
+    skill: 'dxkit-loop',
+    whenToRecommend: recommendLoopPreset,
+    planConfig: planLoopPreset,
+  },
+  {
+    id: 'debt',
+    audience: 'user',
+    group: 'assess',
+    summary: 'The prioritized repair inventory: floor debt + finding debt',
+    typicalRuntime: 'varies (runs your compile + tests)',
+    docsBlurb:
+      'One agent-readable inventory of everything the baseline grandfathered: the correctness-floor ' +
+      'debt (broken build / failing tests, with reproduction commands and captured error output, ' +
+      'live-run and diffed against the baseline envelope) plus the fingerprinted finding debt by ' +
+      'severity — ordered into a repair plan (build first, then tests, then findings). ' +
+      'Informational: it never gates.',
+    skill: 'dxkit-action',
+    whenToRecommend: recommendDebt,
+  },
+  {
+    id: 'checks',
+    audience: 'user',
+    group: 'gate',
+    summary: 'List / dry-run your custom repo-invariant + lint gates',
+    typicalRuntime: 'varies (runs your checks)',
+    docsBlurb:
+      'Declare repo invariants (a project rule, a lint gate) as first-class gate citizens: the guardrail fingerprints their failures and blocks only net-new ones, grandfathering pre-existing debt. `checks list` shows what is configured; `checks run` dry-runs them.',
+    skill: 'dxkit-checks',
+    whenToRecommend: recommendChecks,
+    planConfig: planLintGate,
+  },
+  {
+    id: 'extensions',
+    audience: 'user',
+    group: 'gate',
+    summary: 'Plug your own extractors and sinks into dxkit (any language)',
+    typicalRuntime: 'seconds (the `dev` loop)',
+    docsBlurb:
+      'Declare an extension — a manifest pointing at your existing script — and dxkit runs it at ' +
+      'refresh time, validates its emitted contract/inventory/findings/export document, and routes ' +
+      'it through the same machines native output gets (the flow join, the report trend, the ' +
+      'net-new finding gate). `extensions dev <name>` is the seconds-fast authoring loop; ' +
+      '`extensions init` scaffolds a manifest that passes validation immediately, and ' +
+      '`extensions init --plugin` scaffolds a rung-4 TypeScript plugin (flow dialects, custom ' +
+      'artifact readers, URL rewrites, integration verifiers) — the dxkit-author-extension ' +
+      'skill writes either rung from a prose description.',
+    skill: 'dxkit-extensions',
+    whenToRecommend: recommendExtensions,
+    planConfig: planFlowSources,
+  },
+] as const satisfies readonly CapabilityDescriptor[];

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -2,25 +2,17 @@
  *  CLI command; `commands.ts` re-exports `COMMANDS` + `CommandId` + helpers. */
 import type { CapabilityDescriptor } from './command-types';
 import { INTERNAL_COMMANDS } from './command-defs-internal';
+import { GATE_COMMANDS } from './command-defs-gate';
 import {
   recommendConfigure,
-  recommendBaseline,
   recommendEvaluate,
   recommendFlow,
   recommendSchema,
-  recommendChecks,
   recommendDuplication,
-  recommendLoopPreset,
   recommendReportsOnMerge,
-  planBaselineMode,
   planFlowMode,
   planSchemaMode,
   planDuplicationMode,
-  planLintGate,
-  planLoopPreset,
-  recommendExtensions,
-  recommendDebt,
-  planFlowSources,
 } from './advisor';
 
 /** THE registry. One entry per command, in rough help-index order within each group. */
@@ -277,129 +269,8 @@ export const COMMANDS = [
       'The champion ROI report, computed not narrated: net-new findings the guardrail intercepted before they reached the base branch, per week and by category, from the append-only loop ledger. Interceptions are the ungameable number; --since <ref|date> scopes the window. Also surfaces the score-over-time trend (how each dimension moved) from the dxkit-reports snapshots when on-merge reports are enabled.',
     skill: 'dxkit-reports',
   },
-  // ── Gate ───────────────────────────────────────────────────────────────
-  {
-    id: 'baseline',
-    audience: 'user',
-    group: 'gate',
-    summary: 'Capture / publish / show per-finding baselines for the guardrail',
-    typicalRuntime: '30 sec - 2 min',
-    docsBlurb:
-      'Record per-finding identities the guardrail check diffs against to gate net-new ' +
-      'regressions. `baseline publish` pushes the captured anchor to the side branch on the ' +
-      '`branch` anchor transport — the one side-ref write path the refresh workflow runs.',
-    whenToRecommend: recommendBaseline,
-    planConfig: planBaselineMode,
-  },
-  {
-    id: 'guardrail',
-    audience: 'user',
-    group: 'gate',
-    summary: 'Diff current scan vs baseline; block on net-new regressions',
-    typicalRuntime: '30 sec - 2 min',
-    docsBlurb:
-      'The brownfield gate: fail on findings introduced by a change, grandfathering pre-existing debt.',
-    skill: 'dxkit-action',
-  },
-  {
-    id: 'receipt',
-    audience: 'user',
-    group: 'gate',
-    summary: 'Emit the PR "dxkit signals" block (verdict + allowlist + score delta)',
-    typicalRuntime: '< 30 sec',
-    docsBlurb:
-      'The ready-to-paste PR signals block, computed not narrated: the guardrail verdict, the allowlist delta, and (with --since) health-score movement vs the base ref. Reuses the session verdict cache so it never re-runs an unchanged scan.',
-    skill: 'dxkit-pr',
-  },
-  {
-    id: 'pr',
-    audience: 'user',
-    group: 'gate',
-    summary: 'Compute a reviewable PR body from the branch (title, changes, signals, checklist)',
-    typicalRuntime: '< 30 sec (longer with --since)',
-    docsBlurb:
-      'The deterministic core of the dxkit-pr skill: reads the branch commits + diff and computes the title, bucketed Changes, the receipt signals block, suggested reviewers, a diff-derived reviewer checklist, and the structural-duplicate seam prompts — leaving only "What & why" for the author. Prints markdown or --json; never opens the PR.',
-    skill: 'dxkit-pr',
-  },
-  {
-    id: 'allowlist',
-    audience: 'user',
-    group: 'gate',
-    summary: 'Suppress / audit individual findings with typed reasons',
-    typicalRuntime: '< 1 sec',
-    docsBlurb:
-      'Accept a finding with a typed category + required reason + optional expiry; audit and prune ' +
-      'entries. `defer` bulk-defers newly published dep-vuln advisories time-boxed (dep-vuln-only).',
-    skill: 'dxkit-allowlist',
-  },
-  {
-    id: 'ingest',
-    audience: 'user',
-    group: 'gate',
-    summary: 'Ingest external SAST findings (Snyk / Sonar / CodeQL / SARIF) as first-class',
-    typicalRuntime: 'varies (reads engine API or SARIF)',
-    docsBlurb:
-      'Pull Snyk Code / SonarQube (API) or CodeQL / Semgrep-Pro (SARIF) findings into dxkit so external findings share one fingerprint + gate.',
-    skill: 'dxkit-ingest',
-  },
-  {
-    id: 'loop',
-    audience: 'user',
-    group: 'gate',
-    summary: 'Autonomous-loop utilities (doctor / ledger / snapshot)',
-    typicalRuntime: '< 5 sec',
-    docsBlurb:
-      'Inspect and verify the autonomous-loop Stop-gate wiring, its ledger, and the correctness-floor snapshot.',
-    skill: 'dxkit-loop',
-    whenToRecommend: recommendLoopPreset,
-    planConfig: planLoopPreset,
-  },
-  {
-    id: 'debt',
-    audience: 'user',
-    group: 'assess',
-    summary: 'The prioritized repair inventory: floor debt + finding debt',
-    typicalRuntime: 'varies (runs your compile + tests)',
-    docsBlurb:
-      'One agent-readable inventory of everything the baseline grandfathered: the correctness-floor ' +
-      'debt (broken build / failing tests, with reproduction commands and captured error output, ' +
-      'live-run and diffed against the baseline envelope) plus the fingerprinted finding debt by ' +
-      'severity — ordered into a repair plan (build first, then tests, then findings). ' +
-      'Informational: it never gates.',
-    skill: 'dxkit-action',
-    whenToRecommend: recommendDebt,
-  },
-  {
-    id: 'checks',
-    audience: 'user',
-    group: 'gate',
-    summary: 'List / dry-run your custom repo-invariant + lint gates',
-    typicalRuntime: 'varies (runs your checks)',
-    docsBlurb:
-      'Declare repo invariants (a project rule, a lint gate) as first-class gate citizens: the guardrail fingerprints their failures and blocks only net-new ones, grandfathering pre-existing debt. `checks list` shows what is configured; `checks run` dry-runs them.',
-    skill: 'dxkit-checks',
-    whenToRecommend: recommendChecks,
-    planConfig: planLintGate,
-  },
-  {
-    id: 'extensions',
-    audience: 'user',
-    group: 'gate',
-    summary: 'Plug your own extractors and sinks into dxkit (any language)',
-    typicalRuntime: 'seconds (the `dev` loop)',
-    docsBlurb:
-      'Declare an extension — a manifest pointing at your existing script — and dxkit runs it at ' +
-      'refresh time, validates its emitted contract/inventory/findings/export document, and routes ' +
-      'it through the same machines native output gets (the flow join, the report trend, the ' +
-      'net-new finding gate). `extensions dev <name>` is the seconds-fast authoring loop; ' +
-      '`extensions init` scaffolds a manifest that passes validation immediately, and ' +
-      '`extensions init --plugin` scaffolds a rung-4 TypeScript plugin (flow dialects, custom ' +
-      'artifact readers, URL rewrites, integration verifiers) — the dxkit-author-extension ' +
-      'skill writes either rung from a prose description.',
-    skill: 'dxkit-extensions',
-    whenToRecommend: recommendExtensions,
-    planConfig: planFlowSources,
-  },
+  // ── Gate ── (partitioned by group for file size — command-defs-gate.ts)
+  ...GATE_COMMANDS,
   // ── Integrate ──────────────────────────────────────────────────────────
   {
     id: 'schema',

--- a/src/discovery/posture-knobs.ts
+++ b/src/discovery/posture-knobs.ts
@@ -85,6 +85,17 @@ export const POSTURE_KNOBS: readonly PostureKnob[] = [
   },
   { path: 'loop.preset', command: 'loop', requiresPlan: true, requiresRecommend: true },
   {
+    path: 'newAdvisories.blockSeverities',
+    command: 'guardrail',
+    requiresPlan: false,
+    requiresRecommend: true,
+    note:
+      'the default tier (critical/high block, medium/low warn) is right regardless of any ' +
+      'repo-observable fact, so a planConfig would only ever emit the default — no plan; ' +
+      'recommendNewAdvisoryTier surfaces the knob once a run has concretely blocked a newly ' +
+      'published advisory.',
+  },
+  {
     path: 'reports.onMerge',
     command: 'report',
     requiresPlan: false,

--- a/src/land-refresh.ts
+++ b/src/land-refresh.ts
@@ -124,7 +124,30 @@ export function landRefreshPaths(opts: LandRefreshOptions): LandRefreshResult {
     exec('git', ['checkout', priorRef], { allowFail: true });
   }
 
-  // The PR itself is best-effort: no gh / not GitHub → the branch still landed.
+  return openOrUpdateStandingPr(exec, {
+    branchName: opts.branchName,
+    defaultBranch: opts.defaultBranch,
+    prTitle: opts.prTitle,
+    prBody: opts.prBody,
+  });
+}
+
+/**
+ * Open (or update in place) the ONE standing PR for a refresh branch that has
+ * already been pushed. Best-effort: no `gh` / not GitHub / no permission → the
+ * branch still landed and the result says to open it manually. Extracted so
+ * every standing-PR surface (this lander's `pr` mode, the advisory decision
+ * lane) shares one implementation of the gh mechanics (Rule 2).
+ */
+export function openOrUpdateStandingPr(
+  exec: Exec,
+  opts: {
+    readonly branchName: string;
+    readonly defaultBranch: string;
+    readonly prTitle: string;
+    readonly prBody: string;
+  },
+): LandRefreshResult {
   const existing = exec(
     'gh',
     ['pr', 'list', '--head', opts.branchName, '--state', 'open', '--json', 'url'],

--- a/test/allowlist/defer.test.ts
+++ b/test/allowlist/defer.test.ts
@@ -1,7 +1,7 @@
 /**
  * `vyuh-dxkit allowlist defer` — the bulk, dep-vuln-only, time-boxed deferral
  * of newly published advisories (D4 phase 1). Productizes the incident bridge
- * script (web-client #375/#376): one command, short shared expiry, and a hard
+ * script shipped during the incident: one command, short shared expiry, and a hard
  * structural guarantee that it can never bulk-defer a real regression — every
  * entry is minted `kind=dep-vuln` (suppression matches on kind), non-dep-vuln
  * findings are refused, and `--from-last-check` only ever reads dep-vulns out

--- a/test/baseline/advisory-attribution.test.ts
+++ b/test/baseline/advisory-attribution.test.ts
@@ -3,7 +3,8 @@
  *
  * The incident class: a committed-mode repo's PR that touches NO dependency
  * manifest gets hard-blocked as "N new regressions" the day an advisory batch
- * lands on any unchanged dependency (web-client #375, then #376 48h later).
+ * lands on any unchanged dependency (seen live as two advisory batches in
+ * 48 hours against one production repo).
  * Recall is genuinely clean (same scanner, same version), so Rule 19 rightly
  * stays silent — the one input that moved is the advisory FEED. The fix is
  * attribution honesty with gate semantics UNCHANGED: the finding still blocks
@@ -21,7 +22,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { classify } from '../../src/baseline/classify';
 import type { ClassifyContext } from '../../src/baseline/classify';
-import { DEFAULT_BROWNFIELD_POLICY } from '../../src/baseline/policy';
+import { DEFAULT_BROWNFIELD_POLICY, newAdvisoryBlockSeverities } from '../../src/baseline/policy';
 import type { BrownfieldPolicy } from '../../src/baseline/policy';
 import type { MatchPair } from '../../src/baseline/types';
 import { changedFilesTouchDependencyManifest, getLanguage } from '../../src/languages';
@@ -52,66 +53,79 @@ describe('classify — newly_published_advisory (D4 phase 1)', () => {
     expect(reason!.detail).toContain('allowlist defer');
   });
 
-  it('gate semantics are UNCHANGED: it blocks exactly as added does (policy membership)', () => {
-    // Default policy blocks 'added' by membership; the relabel must not open
-    // a bypass for severities no block rule covers.
+  it('the default TIER: critical + high block, medium + low warn (D4 phase 2)', () => {
+    const verdicts = (['critical', 'high', 'medium', 'low'] as const).map((severity) => {
+      const out = classify(
+        addedPair,
+        DEFAULT_BROWNFIELD_POLICY,
+        ctx({ severity, manifestUntouched: true }),
+      );
+      expect(out.status).toBe('newly_published_advisory');
+      expect(out.warns).toBe(!out.blocks);
+      expect(out.reasons.some((r) => r.code === 'advisory-tier')).toBe(true);
+      return [severity, out.blocks] as const;
+    });
+    expect(verdicts).toEqual([
+      ['critical', true],
+      ['high', true],
+      ['medium', false],
+      ['low', false],
+    ]);
+  });
+
+  it('the tier is the authority: it overrides block/warn membership and block rules', () => {
+    // A repo that blocks everything as `added` still gets the tier verdict for
+    // this status — medium warns — because the tier IS the explicit posture
+    // for a class the developer did not cause.
+    const blockAll: BrownfieldPolicy = { ...DEFAULT_BROWNFIELD_POLICY, block: ['added'] };
     const medium = classify(
       addedPair,
-      DEFAULT_BROWNFIELD_POLICY,
+      blockAll,
       ctx({ severity: 'medium', manifestUntouched: true }),
     );
-    const asAdded = classify(addedPair, DEFAULT_BROWNFIELD_POLICY, ctx({ severity: 'medium' }));
-    expect(medium.status).toBe('newly_published_advisory');
-    expect(medium.blocks).toBe(asAdded.blocks);
-    expect(medium.warns).toBe(asAdded.warns);
+    expect(medium.blocks).toBe(false);
+    expect(medium.warns).toBe(true);
   });
 
-  it('armed block rules still fire through the relabel (critical, high+reachable, malicious)', () => {
-    const critical = classify(
-      addedPair,
-      DEFAULT_BROWNFIELD_POLICY,
-      ctx({ severity: 'critical', manifestUntouched: true }),
-    );
-    expect(critical.blocks).toBe(true);
+  it('a custom tier reshapes the verdict in both directions', () => {
+    const strict: BrownfieldPolicy = {
+      ...DEFAULT_BROWNFIELD_POLICY,
+      newAdvisories: { blockSeverities: ['critical', 'high', 'medium'] },
+    };
     expect(
-      critical.reasons.some((r) => r.detail.includes('newCriticalDependencyVulnerability')),
+      classify(addedPair, strict, ctx({ severity: 'medium', manifestUntouched: true })).blocks,
     ).toBe(true);
 
-    const reachable = classify(
-      addedPair,
-      DEFAULT_BROWNFIELD_POLICY,
-      ctx({ severity: 'high', reachable: true, manifestUntouched: true }),
-    );
-    expect(reachable.blocks).toBe(true);
-    expect(
-      reachable.reasons.some((r) => r.detail.includes('newHighReachableDependencyVulnerability')),
-    ).toBe(true);
+    const warnAll: BrownfieldPolicy = {
+      ...DEFAULT_BROWNFIELD_POLICY,
+      newAdvisories: { blockSeverities: [] },
+    };
+    const high = classify(addedPair, warnAll, ctx({ severity: 'high', manifestUntouched: true }));
+    expect(high.blocks).toBe(false);
+    expect(high.warns).toBe(true);
+  });
 
-    const malicious = classify(
+  it('malicious-package advisories block at ANY severity, tier-exempt', () => {
+    const warnAll: BrownfieldPolicy = {
+      ...DEFAULT_BROWNFIELD_POLICY,
+      newAdvisories: { blockSeverities: [] },
+    };
+    const out = classify(
       addedPair,
-      DEFAULT_BROWNFIELD_POLICY,
+      warnAll,
       ctx({ severity: 'low', malicious: true, manifestUntouched: true }),
     );
-    expect(malicious.blocks).toBe(true);
-    expect(malicious.reasons.some((r) => r.detail.includes('newMaliciousDependency'))).toBe(true);
+    expect(out.blocks).toBe(true);
+    expect(out.reasons.some((r) => r.code === 'advisory-malicious')).toBe(true);
   });
 
-  it('a warn-only policy keeps warning (relabel never escalates)', () => {
-    const warnOnly: BrownfieldPolicy = {
-      ...DEFAULT_BROWNFIELD_POLICY,
-      block: [],
-      warn: ['added'],
-      blockRules: {
-        ...DEFAULT_BROWNFIELD_POLICY.blockRules,
-        newCriticalDependencyVulnerability: false,
-        newHighReachableDependencyVulnerability: false,
-        newMaliciousDependency: false,
-      },
-    };
-    const out = classify(addedPair, warnOnly, ctx({ severity: 'medium', manifestUntouched: true }));
+  it('an UNKNOWN severity blocks (conservative — never a silent pass on missing evidence)', () => {
+    const out = classify(addedPair, DEFAULT_BROWNFIELD_POLICY, {
+      kind: 'dep-vuln',
+      manifestUntouched: true,
+    });
     expect(out.status).toBe('newly_published_advisory');
-    expect(out.blocks).toBe(false);
-    expect(out.warns).toBe(true);
+    expect(out.blocks).toBe(true);
   });
 
   it('absent evidence means NO relabel — an added dep-vuln stays added', () => {
@@ -146,6 +160,28 @@ describe('classify — newly_published_advisory (D4 phase 1)', () => {
     );
     expect(out.status).toBe('tooling_drift');
     expect(out.unattributableBlockRule).toBe('newCriticalDependencyVulnerability');
+  });
+});
+
+describe('newAdvisoryBlockSeverities — the ONE tier normalizer', () => {
+  it('absent/malformed → the default (critical + high)', () => {
+    expect([...newAdvisoryBlockSeverities({})].sort()).toEqual(['critical', 'high']);
+    expect([
+      ...newAdvisoryBlockSeverities({
+        newAdvisories: { blockSeverities: 'high' as unknown as ['high'] },
+      }),
+    ]).toEqual(['critical', 'high']);
+  });
+
+  it('an explicit empty array is warn-everything, not the default', () => {
+    expect(newAdvisoryBlockSeverities({ newAdvisories: { blockSeverities: [] } }).size).toBe(0);
+  });
+
+  it('unknown values are dropped, known ones kept', () => {
+    const tier = newAdvisoryBlockSeverities({
+      newAdvisories: { blockSeverities: ['critical', 'bogus'] as unknown as ['critical'] },
+    });
+    expect([...tier]).toEqual(['critical']);
   });
 });
 

--- a/test/baseline/anchor-hydrate-precedence.test.ts
+++ b/test/baseline/anchor-hydrate-precedence.test.ts
@@ -1,0 +1,168 @@
+/**
+ * D4d (4.1.4) — the `branch` anchor transport's hydrate precedence and its
+ * failure disclosure.
+ *
+ * The incident: a production repo's guardrail footer cited the STALE
+ * committed tree baseline while a fresher side-branch anchor existed — and
+ * nothing in the output said which file had loaded. Two pins close it:
+ *
+ * 1. The reader must materialize the side ref even on a clone whose fetch
+ *    refspec does not map it (single-branch clones and actions/checkout
+ *    workspaces): a bare `git fetch origin <ref>` only writes FETCH_HEAD
+ *    there, so `origin/<ref>` never resolves and the read silently failed.
+ *    The fix fetches with an explicit `+refs/heads/<ref>:refs/dxkit/anchor/…`
+ *    refspec.
+ * 2. When both an anchor and a tree copy exist, the ANCHOR wins (precedence),
+ *    and when the anchor is unreachable the fallback to the tree copy is
+ *    DISCLOSED (`anchorSource.used === 'tree-fallback'`) in the result and
+ *    every renderer — fail-open, never silent.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createBaseline } from '../../src/baseline/create';
+import { runGuardrailCheck } from '../../src/baseline/check';
+import { renderConsole, renderJson, renderMarkdown } from '../../src/baseline/check-renderers';
+import { readFromAnchorRef, publishFilesToAnchorRef } from '../../src/baseline/anchor-publish';
+import { loadAnchorFromBranch } from '../../src/baseline/anchor';
+
+const tmps: string[] = [];
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+/** A repo with a bare origin — the anchor side ref lives on the origin, the
+ *  clone reads it back, exactly the CI topology. */
+function makeRepoWithOrigin(): { repo: string; bare: string } {
+  const bare = mkdtempSync(join(tmpdir(), 'dxkit-anchorprec-bare-'));
+  const repo = mkdtempSync(join(tmpdir(), 'dxkit-anchorprec-'));
+  tmps.push(bare, repo);
+  git(bare, 'init', '-q', '--bare', '-b', 'main');
+  git(repo, 'init', '-q', '-b', 'main');
+  git(repo, 'config', 'user.email', 't@e.com');
+  git(repo, 'config', 'user.name', 't');
+  git(repo, 'config', 'commit.gpgsign', 'false');
+  writeFileSync(join(repo, 'README.md'), '# fixture\n');
+  git(repo, 'add', '.');
+  git(repo, 'commit', '-q', '-m', 'initial');
+  git(repo, 'remote', 'add', 'origin', bare);
+  git(repo, 'push', '-q', 'origin', 'main');
+  return { repo, bare };
+}
+
+afterEach(() => {
+  for (const d of tmps.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+let savedSalt: string | undefined;
+beforeAll(() => {
+  savedSalt = process.env.DXKIT_BASELINE_SALT;
+  delete process.env.DXKIT_BASELINE_SALT;
+});
+afterAll(() => {
+  if (savedSalt === undefined) delete process.env.DXKIT_BASELINE_SALT;
+  else process.env.DXKIT_BASELINE_SALT = savedSalt;
+});
+
+describe('readFromAnchorRef — narrow-refspec clones (the incident shape)', () => {
+  it('reads the side ref even when the clone fetch refspec does not map it', () => {
+    const { repo } = makeRepoWithOrigin();
+    publishFilesToAnchorRef({
+      cwd: repo,
+      anchorRef: 'dxkit-baselines',
+      files: [{ path: '.dxkit/baselines/main.json', content: '{"marker":"from-anchor"}' }],
+      message: 'anchor',
+      baseParent: false,
+    });
+    // The narrow refspec actions/checkout and single-branch clones configure:
+    // only main maps to a remote-tracking ref. Remove any refs the publish left
+    // locally so the read MUST go through its own fetch.
+    git(repo, 'config', 'remote.origin.fetch', '+refs/heads/main:refs/remotes/origin/main');
+    for (const ref of [
+      'refs/remotes/origin/dxkit-baselines',
+      'refs/heads/dxkit-baselines',
+      'refs/dxkit/anchor/dxkit-baselines',
+    ]) {
+      try {
+        git(repo, 'update-ref', '-d', ref);
+      } catch {
+        /* ref did not exist */
+      }
+    }
+    const content = readFromAnchorRef(repo, 'dxkit-baselines', '.dxkit/baselines/main.json');
+    expect(content).toContain('from-anchor');
+  });
+
+  it('loadAnchorFromBranch returns null for a non-branch transport (tree stays source of truth)', () => {
+    const { repo } = makeRepoWithOrigin();
+    expect(loadAnchorFromBranch(repo, join(repo, '.dxkit/baselines/main.json'), undefined)).toBe(
+      null,
+    );
+    expect(
+      loadAnchorFromBranch(repo, join(repo, '.dxkit/baselines/main.json'), { anchor: 'tree' }),
+    ).toBe(null);
+  });
+});
+
+describe('hydrate precedence + disclosure (integration)', () => {
+  it('anchor WINS over a stale tree copy, and the result says so', async () => {
+    const { repo } = makeRepoWithOrigin();
+    mkdirSync(join(repo, '.dxkit'), { recursive: true });
+    writeFileSync(
+      join(repo, '.dxkit', 'policy.json'),
+      JSON.stringify({ baseline: { mode: 'committed-full', anchor: 'branch' } }),
+    );
+    // Capture a baseline (writes the tree copy), publish it to the side branch,
+    // then STALE-IFY the tree copy by rewriting its commitSha marker.
+    await createBaseline({ cwd: repo });
+    const treePath = join(repo, '.dxkit', 'baselines', 'main.json');
+    const fresh = JSON.parse(readFileSync(treePath, 'utf8'));
+    publishFilesToAnchorRef({
+      cwd: repo,
+      anchorRef: 'dxkit-baselines',
+      files: [{ path: '.dxkit/baselines/main.json', content: JSON.stringify(fresh) }],
+      message: 'anchor',
+      baseParent: false,
+    });
+    const stale = { ...fresh, repo: { ...fresh.repo, commitSha: 'f'.repeat(40) } };
+    writeFileSync(treePath, JSON.stringify(stale));
+
+    const result = await runGuardrailCheck({ cwd: repo });
+    // The loaded baseline is the ANCHOR's (fresh commitSha), not the doctored
+    // tree copy — precedence pinned end-to-end, visible in the footer SHA.
+    expect(result.baseline.repo.commitSha).toBe(fresh.repo.commitSha);
+    expect(result.anchorSource).toMatchObject({ used: 'anchor', anchorRef: 'dxkit-baselines' });
+    expect(renderConsole(result)).toContain("side branch 'dxkit-baselines'");
+    expect(renderMarkdown(result)).toContain('anchor: `dxkit-baselines`');
+    expect(renderJson(result).baseline.anchorSource?.used).toBe('anchor');
+  }, 240_000);
+
+  it('an unreachable side branch falls back to the tree copy — DISCLOSED, never silent', async () => {
+    const { repo } = makeRepoWithOrigin();
+    mkdirSync(join(repo, '.dxkit'), { recursive: true });
+    writeFileSync(
+      join(repo, '.dxkit', 'policy.json'),
+      JSON.stringify({ baseline: { mode: 'committed-full', anchor: 'branch' } }),
+    );
+    // Tree copy exists; the side branch was never created (the incident's
+    // silent-fallback shape).
+    await createBaseline({ cwd: repo });
+
+    const result = await runGuardrailCheck({ cwd: repo });
+    expect(result.anchorSource?.used).toBe('tree-fallback');
+    expect(result.anchorSource?.note).toContain('may be STALE');
+    expect(renderConsole(result)).toContain('TREE FALLBACK');
+    expect(renderMarkdown(result)).toContain('Baseline anchor fallback');
+    expect(renderJson(result).baseline.anchorSource?.used).toBe('tree-fallback');
+  }, 240_000);
+
+  it('the tree transport carries NO anchor disclosure (nothing to disclose)', async () => {
+    const { repo } = makeRepoWithOrigin();
+    await createBaseline({ cwd: repo });
+    const result = await runGuardrailCheck({ cwd: repo });
+    expect(result.anchorSource).toBeUndefined();
+    expect(renderConsole(result)).not.toContain('TREE FALLBACK');
+  }, 240_000);
+});

--- a/test/baseline/refresh-decision.test.ts
+++ b/test/baseline/refresh-decision.test.ts
@@ -1,0 +1,286 @@
+/**
+ * `vyuh-dxkit baseline refresh` — the D4 advisory decision lane (4.1.4).
+ *
+ * The class both ways:
+ *   - ABSORPTION (the failure this closes): the old refresh (`create --force`)
+ *     silently grandfathered advisories the feed published after the previous
+ *     capture — no decision, no expiry pressure, defer-forever.
+ *   - FALSE HOLD-OUT (the over-trigger): a diff that DID change a dependency
+ *     manifest may legitimately bring new advisories with it — those absorb as
+ *     ordinary pre-existing debt, the standard refresh contract.
+ *
+ * The discriminator is the ONE `changedFilesTouchDependencyManifest` (Rule
+ * 2.30 — the same helper the classifier and the ref-based skip consume). The
+ * capture itself is injected (`_capture`) — these tests exercise the decision
+ * lane, not the analyzers. The decision branch is verified on a real bare
+ * origin: entries, expiry carry-over across re-raises, and zero working-tree /
+ * HEAD impact.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  ADVISORY_DECISION_BRANCH,
+  decisionPrBody,
+  runBaselineRefresh,
+} from '../../src/baseline/refresh';
+import { BASELINE_SCHEMA_VERSION, type BaselineFile } from '../../src/baseline/baseline-file';
+import type { AllowlistFile } from '../../src/allowlist/file';
+import { DEFER_ADVISORY_EXPIRY_DAYS } from '../../src/allowlist/categories';
+
+const tmps: string[] = [];
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function makeRepoWithOrigin(): { repo: string; bare: string } {
+  const bare = mk('dxkit-refresh-bare-');
+  const repo = mk('dxkit-refresh-');
+  git(bare, 'init', '-q', '--bare', '-b', 'main');
+  git(repo, 'init', '-q', '-b', 'main');
+  git(repo, 'config', 'user.email', 't@e.com');
+  git(repo, 'config', 'user.name', 't');
+  git(repo, 'config', 'commit.gpgsign', 'false');
+  fs.writeFileSync(path.join(repo, 'package.json'), JSON.stringify({ name: 'fx', version: '1' }));
+  fs.writeFileSync(path.join(repo, 'src.js'), 'const a = 1;\n');
+  git(repo, 'add', '.');
+  git(repo, 'commit', '-q', '-m', 'initial');
+  git(repo, 'remote', 'add', 'origin', bare);
+  git(repo, 'push', '-q', 'origin', 'main');
+  return { repo, bare };
+}
+
+function mk(prefix: string): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmps.push(d);
+  return d;
+}
+
+afterEach(() => {
+  for (const d of tmps.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+function depVuln(id: string, pkg: string, advisoryId: string) {
+  return { id, kind: 'dep-vuln' as const, package: pkg, installedVersion: '1.0.0', advisoryId };
+}
+
+function baselineFile(cwd: string, commitSha: string, findings: unknown[]): BaselineFile {
+  return {
+    schemaVersion: BASELINE_SCHEMA_VERSION,
+    name: 'main',
+    createdAt: '2026-07-20T00:00:00.000Z',
+    repo: { commitSha, branch: 'main', root: cwd },
+    analysis: {
+      dxkitVersion: 'test',
+      policyHash: '0'.repeat(16),
+      ignoreHash: '0'.repeat(16),
+      toolchainHash: '0'.repeat(16),
+      configHash: '0'.repeat(16),
+    },
+    tools: {},
+    saltMode: 'deterministic',
+    findings: findings as BaselineFile['findings'],
+  } as BaselineFile;
+}
+
+function writeTreeBaseline(repo: string, file: BaselineFile): string {
+  const p = path.join(repo, '.dxkit', 'baselines', 'main.json');
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(file));
+  return p;
+}
+
+/** A capture seam that writes `findings` as the fresh baseline. */
+function captureWriting(repo: string, findings: unknown[]) {
+  return async () => {
+    writeTreeBaseline(repo, baselineFile(repo, git(repo, 'rev-parse', 'HEAD').trim(), findings));
+  };
+}
+
+/** Commit a change so HEAD moves past the prior anchor. */
+function commitChange(repo: string, rel: string, content: string): void {
+  fs.writeFileSync(path.join(repo, rel), content);
+  git(repo, 'add', rel);
+  git(repo, 'commit', '-q', '-m', `change ${rel}`);
+}
+
+function decisionAllowlist(bare: string): AllowlistFile {
+  const raw = execFileSync('git', ['show', `${ADVISORY_DECISION_BRANCH}:.dxkit/allowlist.json`], {
+    cwd: bare,
+    encoding: 'utf8',
+  });
+  return JSON.parse(raw) as AllowlistFile;
+}
+
+describe('baseline refresh — the advisory decision lane', () => {
+  it('holds newly published advisories OUT of the baseline and raises the decision branch', async () => {
+    const { repo, bare } = makeRepoWithOrigin();
+    const priorSha = git(repo, 'rev-parse', 'HEAD').trim();
+    writeTreeBaseline(
+      repo,
+      baselineFile(repo, priorSha, [depVuln('a'.repeat(16), 'axios', 'GHSA-old')]),
+    );
+    // A NON-manifest change since the prior anchor — the feed, not the diff.
+    commitChange(repo, 'src.js', 'const a = 2;\n');
+
+    const result = await runBaselineRefresh({
+      cwd: repo,
+      _capture: captureWriting(repo, [
+        depVuln('a'.repeat(16), 'axios', 'GHSA-old'),
+        depVuln('b'.repeat(16), 'fast-uri', 'GHSA-new-1'),
+        depVuln('c'.repeat(16), 'svgo', 'GHSA-new-2'),
+      ]),
+    });
+
+    // Held out of the written baseline — never absorbed.
+    expect(result.heldOut.map((a) => a.advisoryId).sort()).toEqual(['GHSA-new-1', 'GHSA-new-2']);
+    const written = JSON.parse(
+      fs.readFileSync(path.join(repo, '.dxkit', 'baselines', 'main.json'), 'utf8'),
+    ) as BaselineFile;
+    expect(written.findings.map((f) => f.id)).toEqual(['a'.repeat(16)]);
+
+    // The decision branch landed on the origin, parented on HEAD (mergeable),
+    // carrying deferred entries with the short expiry.
+    const allow = decisionAllowlist(bare);
+    const fps = allow.entries.map((e) => e.fingerprint).sort();
+    expect(fps).toEqual(['b'.repeat(16), 'c'.repeat(16)]);
+    for (const e of allow.entries) {
+      expect(e).toMatchObject({ kind: 'dep-vuln', category: 'deferred', addedBy: 'dxkit-refresh' });
+      const days = Math.round(
+        (new Date(`${e.expiresAt}T00:00:00Z`).getTime() - Date.now()) / 86_400_000,
+      );
+      expect(days).toBeGreaterThanOrEqual(DEFER_ADVISORY_EXPIRY_DAYS - 1);
+      expect(days).toBeLessThanOrEqual(DEFER_ADVISORY_EXPIRY_DAYS);
+    }
+    const parent = execFileSync('git', ['rev-parse', `${ADVISORY_DECISION_BRANCH}^`], {
+      cwd: bare,
+      encoding: 'utf8',
+    }).trim();
+    expect(parent).toBe(git(repo, 'rev-parse', 'HEAD').trim());
+
+    // Zero working-tree / HEAD impact: no allowlist file appeared in the tree,
+    // HEAD did not move, the tree is clean apart from the baseline rewrite.
+    expect(fs.existsSync(path.join(repo, '.dxkit', 'allowlist.json'))).toBe(false);
+    expect(git(repo, 'rev-parse', '--abbrev-ref', 'HEAD').trim()).toBe('main');
+  }, 120_000);
+
+  it('a manifest-touching diff ABSORBS new advisories (the standard refresh contract)', async () => {
+    const { repo } = makeRepoWithOrigin();
+    const priorSha = git(repo, 'rev-parse', 'HEAD').trim();
+    writeTreeBaseline(repo, baselineFile(repo, priorSha, []));
+    commitChange(repo, 'package.json', JSON.stringify({ name: 'fx', version: '2' }));
+
+    const result = await runBaselineRefresh({
+      cwd: repo,
+      _capture: captureWriting(repo, [depVuln('d'.repeat(16), 'newdep', 'GHSA-x')]),
+    });
+    expect(result.heldOut).toEqual([]);
+    expect(result.note).toContain('dependency manifest changed');
+    const written = JSON.parse(
+      fs.readFileSync(path.join(repo, '.dxkit', 'baselines', 'main.json'), 'utf8'),
+    ) as BaselineFile;
+    expect(written.findings).toHaveLength(1);
+  }, 120_000);
+
+  it('re-raise preserves the ORIGINAL expiry (no rolling defer-forever)', async () => {
+    const { repo, bare } = makeRepoWithOrigin();
+    const priorSha = git(repo, 'rev-parse', 'HEAD').trim();
+    writeTreeBaseline(repo, baselineFile(repo, priorSha, []));
+    commitChange(repo, 'src.js', 'const a = 3;\n');
+
+    const firstNow = new Date();
+    await runBaselineRefresh({
+      cwd: repo,
+      now: firstNow,
+      _capture: captureWriting(repo, [depVuln('e'.repeat(16), 'immutable', 'GHSA-y')]),
+    });
+    const firstExpiry = decisionAllowlist(bare).entries[0].expiresAt;
+
+    // Three days later the refresh runs again; the advisory is still undecided
+    // (prior baseline unchanged on the tree — the decision PR is unmerged).
+    writeTreeBaseline(repo, baselineFile(repo, priorSha, []));
+    const laterNow = new Date(firstNow.getTime() + 3 * 86_400_000);
+    await runBaselineRefresh({
+      cwd: repo,
+      now: laterNow,
+      _capture: captureWriting(repo, [depVuln('e'.repeat(16), 'immutable', 'GHSA-y')]),
+    });
+    expect(decisionAllowlist(bare).entries[0].expiresAt).toBe(firstExpiry);
+  }, 120_000);
+
+  it('no prior baseline → plain capture, disclosed', async () => {
+    const { repo } = makeRepoWithOrigin();
+    const result = await runBaselineRefresh({
+      cwd: repo,
+      _capture: captureWriting(repo, [depVuln('f'.repeat(16), 'axios', 'GHSA-z')]),
+    });
+    expect(result.heldOut).toEqual([]);
+    expect(result.note).toContain('first capture');
+  }, 120_000);
+
+  it('ref-based mode is a graceful, explained no-op (the class cannot arise there)', async () => {
+    const { repo } = makeRepoWithOrigin();
+    fs.mkdirSync(path.join(repo, '.dxkit'), { recursive: true });
+    fs.writeFileSync(
+      path.join(repo, '.dxkit', 'policy.json'),
+      JSON.stringify({ baseline: { mode: 'ref-based', ref: 'origin/main' } }),
+    );
+    const result = await runBaselineRefresh({
+      cwd: repo,
+      _capture: async () => {
+        throw new Error('capture must not run in ref-based mode');
+      },
+    });
+    expect(result.heldOut).toEqual([]);
+    expect(result.note).toContain('ref-based');
+    expect(result.note).toContain('Nothing to do');
+  }, 60_000);
+
+  it('a quiet feed refreshes normally with a note', async () => {
+    const { repo } = makeRepoWithOrigin();
+    const priorSha = git(repo, 'rev-parse', 'HEAD').trim();
+    const same = [depVuln('a'.repeat(16), 'axios', 'GHSA-old')];
+    writeTreeBaseline(repo, baselineFile(repo, priorSha, same));
+    commitChange(repo, 'src.js', 'const a = 4;\n');
+    const result = await runBaselineRefresh({
+      cwd: repo,
+      _capture: captureWriting(repo, same),
+    });
+    expect(result.heldOut).toEqual([]);
+    expect(result.note).toContain('no newly published advisories');
+  }, 120_000);
+});
+
+describe('decisionPrBody', () => {
+  it('names both lanes and every advisory', () => {
+    const body = decisionPrBody(
+      [
+        {
+          fingerprint: 'b'.repeat(16),
+          package: 'fast-uri',
+          installedVersion: '3.1.2',
+          advisoryId: 'GHSA-new-1',
+        },
+      ],
+      [
+        {
+          fingerprint: 'b'.repeat(16),
+          kind: 'dep-vuln',
+          category: 'deferred',
+          reason: 'r',
+          addedBy: 'dxkit-refresh',
+          addedAt: '2026-07-22',
+          expiresAt: '2026-07-29',
+        },
+      ],
+    );
+    expect(body).toContain('fast-uri@3.1.2');
+    expect(body).toContain('GHSA-new-1');
+    expect(body).toContain('2026-07-29');
+    expect(body).toContain('Lane 1 — fix');
+    expect(body).toContain('Lane 2 — defer');
+    expect(body).toContain('held out of the refreshed baseline');
+  });
+});


### PR DESCRIPTION
## What & why

4.1.4 — D4 complete, the advisory-feed release. Hard deadline context: the affected repo's 21 deferred allowlist entries expire 2026-07-28; this release puts machinery under that expiry. Three workstreams, all validated against a full local mirror of the incident repo (zero external effect — pushes landed on a local bare).

## Changes

**D4d: the branch anchor transport actually reads the anchor** (`5a5890f`)
- Root-caused ON the incident repo: a ~19k-finding baseline blows `execFileSync`'s default 1MiB buffer — `git show` dies ENOBUFS with empty stderr, silently falling back to the stale tree copy (the exact stale SHA the incident footer cited). Fixed with a 256MiB buffer + an explicit-refspec fetch into a private `refs/dxkit/` ref (covers narrow-refspec clones, the second independent path to the same silent fallback).
- The check now discloses which file loaded (`anchorSource`) in all three renderers — anchor, or a loud TREE FALLBACK warning. Precedence + both failure paths pinned in `test/baseline/anchor-hydrate-precedence.test.ts`.
- Validated: the mirror check now loads the fresh anchor commit the incident should have used.

**The tier knob** (`8dbb7a8`)
- `newAdvisories.blockSeverities` governs `newly_published_advisory` verdicts: default critical/high block, medium/low warn; malicious always blocks; unknown severity blocks; `[]` = deliberate warn-everything. One normalizer feeds classifier, renderers, and probe.
- Full Rule 16 contract: POSTURE_KNOBS entry + a grounded doctor probe (fires only after a run concretely blocked a newly published advisory, via the verdict cache). Registry gate-group split into `command-defs-gate.ts` to clear the large-file floor properly.
- Validated: the mirror's 21 live advisories classify with 5 highs blocking, 16 mediums warning.

**Base-branch-first surfacing** (`f31a0ab`)
- New `vyuh-dxkit baseline refresh` (all three refresh workflow templates now call it; existing repos pick it up via `update`'s managed-surface refresh): capture + hold newly published advisories OUT of the baseline (never silently absorbed) + one standing decision PR (`dxkit/advisory-decision`) carrying 7-day deferred entries. Merge = defer (expiry preserved across re-raises); fix = the PR obsoletes. First-capture / uncomputable-diff / manifest-touched / ref-based cases each degrade with the reason disclosed.
- Validated: the mirror refresh held out the exact live batch (21 advisories) and parented the decision branch on the default-branch head with correct entries.

**D4b** disclosed (not fixed): the dep-vuln recall-drift line now names the machine-dependence cause and the operator remedy. Real fix (CI-canonical capture) stays on the strategy track.

## Verification

Full local gate parity: build, typecheck, typecheck:test, lint, format, arch-check, slop, cross-ecosystem, docs-coverage, `npm pack --dry-run`, full suite (310 files / 4,638 tests). Real-repo validation on the incident mirror as above — which is also where the ENOBUFS root cause was found; the unit suite alone would have shipped only the refspec fix.

## Merge strategy

Rebase merge: four independently meaningful commits (D4d fix, tier knob, decision lane, release bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
