### PR TITLE
fix(first-run): Windows-proof create-dxkit + un-404 every pre-install command

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,6 +28,50 @@ permissions:
   contents: read
 
 jobs:
+  # The FIRST command a new user runs (`npm init @vyuhlabs/dxkit`) must never
+  # break — and its worst shipped break was Windows-only: Node's
+  # CVE-2024-27980 fix makes a shell-less `.cmd` spawn throw EINVAL, so the
+  # old shim could never install on a current Windows Node, and no
+  # Linux-only job could see it — it surfaced in the field. This job runs
+  # the shim's unit + child-process integration suites on a real Windows
+  # Node, then performs the real first run: the PR's shim, launched by real
+  # npm (which sets `npm_execpath` exactly as `npm init` does), installing
+  # the published @vyuhlabs/dxkit into a fresh git repo.
+  first-run-windows:
+    name: windows first run (create-dxkit shim)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Shim unit + entry-point integration tests (real Windows spawn semantics)
+        run: npx vitest run test/create-dxkit.test.ts test/create-dxkit-entrypoint.test.ts
+
+      - name: Real first run in a fresh repo
+        shell: pwsh
+        run: |
+          $fixture = Join-Path $env:RUNNER_TEMP 'first-run'
+          New-Item -ItemType Directory -Path $fixture | Out-Null
+          Set-Location $fixture
+          git init -q -b main
+          git config user.email "smoke@example.com"
+          git config user.name "smoke"
+          # `npm exec --package <dir>` launches the PR's shim under real npm,
+          # with the same env (`npm_execpath` et al.) `npm init @vyuhlabs/dxkit`
+          # provides. `--dx-only` keeps the published init's work light (agent
+          # context only — no scanner provisioning on a bare runner).
+          npm exec --yes --package "$env:GITHUB_WORKSPACE\packages\create-dxkit" -- create-dxkit --dx-only --yes
+          if ($LASTEXITCODE -ne 0) { throw "create-dxkit exited $LASTEXITCODE" }
+          if (-not (Test-Path 'node_modules/@vyuhlabs/dxkit')) { throw 'dxkit was not installed into the fixture' }
+          $pkg = Get-Content package.json -Raw | ConvertFrom-Json
+          if (-not $pkg.devDependencies.'@vyuhlabs/dxkit') { throw 'dxkit devDependency was not declared' }
+
   pack-smoke:
     name: npm pack + init --full + baseline + guardrail
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.6] - 2026-07-23
+
+First-run reliability release: a field report showed that the very first
+commands our README and demo print could not complete on a current
+Windows Node. Ships alongside
+`@vyuhlabs/create-dxkit@0.4.0` (see below — the bootstrap shim carries the
+core fix).
+
+- **Demo hint no longer 404s pre-install.** The `demo loop-guardrail`
+  gitleaks hint invoked the CLI by BINARY name (`npx vyuh-dxkit tools
+  install`), which resolves only through an installed package — and the
+  demo's whole audience has not installed one yet, so the printed command
+  failed with npm E404. Pre-install surfaces now use the one-shot PACKAGE
+  form via the new `dxkitOneShotCli` helper in `src/self-invocation.ts`
+  (`npx -y @vyuhlabs/dxkit tools install`), the same form the demo command
+  itself uses.
+- **README funnel reordered: `npm init @vyuhlabs/dxkit` is the first
+  command.** The demo led the quick start, but on a fresh machine it
+  degrades to a labelled illustration (no gitleaks) and its follow-ups run
+  outside a repo; `init` provisions its own prerequisites and is
+  reversible. The demo stays as the explicit "see it without installing
+  anything" alternative.
+- **`exports` now exposes `./package.json`** so tooling (including the
+  bootstrap shim's bin resolution) can read package metadata through
+  `require.resolve`.
+- **New Windows first-run smoke job** (`smoke.yml:first-run-windows`): runs
+  the shim's unit + child-process integration suites on a real Windows
+  Node, then performs a real first run — the shim launched by real npm into
+  a fresh git fixture. The class this closes could not be seen by any
+  Linux-only job.
+
+### @vyuhlabs/create-dxkit 0.4.0
+
+- **Windows install fixed (the shipped first-run break).** Node's
+  CVE-2024-27980 fix (≥ 18.20.2 / 20.12.2 / 21.7.3) makes spawning a
+  `.cmd` with `shell: false` throw EINVAL — so the shim's
+  `spawnSync('npm.cmd', …)` could never install on a current Windows Node,
+  and the un-checked spawn error surfaced as a phantom "Peer-dep conflict
+  detected" with empty stderr. The shim now runs npm via
+  `process.execPath` on `npm_execpath` (the JS entry npm itself provides —
+  no shell, no `.cmd`, any OS), falls back to `shell: true` with quoted
+  args for other package managers on Windows, and never produces a
+  shell-less `.cmd` spawn (property-pinned in tests).
+- **Honest failure reporting.** A spawn-level failure (the PM never ran)
+  is now reported as exactly that — no fabricated peer-dep diagnosis, no
+  pointless retry, no pointer to an npm debug log that does not exist.
+- **The install-failure escape hatch no longer 404s.** It printed
+  `npx vyuh-dxkit init --full --yes` — the binary form, which resolves
+  only through the install that just failed. It now prints the package
+  form (`npx -y @vyuhlabs/dxkit init --full --yes`). The arch-check's
+  Rule 14 grep now covers `packages/create-dxkit/` so the binary form
+  cannot return there.
+- **Home-directory guard.** Running the bootstrap from the OS home
+  directory or a filesystem root is refused before anything is written —
+  previously it seeded a `package.json` into the user's home folder.
+- **Post-install `init` runs the installed bin directly** (`node
+  <resolved bin>`), immune to the Windows spawn class and to npx
+  resolution; falls back to a one-shot npx by package name.
+- **Entry-point integration suite** (`test/create-dxkit-entrypoint.test.ts`):
+  the real shim as a child process across refusal / happy path / ERESOLVE
+  retry / both-fail / spawn-failure branches, with npm stubbed through the
+  production `npm_execpath` mechanism.
+
 ## [4.1.5] - 2026-07-23
 
 The graph decision release: dxkit keeps graphify as its graph substrate —

--- a/README.md
+++ b/README.md
@@ -29,7 +29,28 @@ Likely affected tests               Exact repair reason
 </p>
 <p align="center"><sub>Recorded from a real run on a synthetic repository, shortened for readability. Blocked and repaired inside the same warm loop.</sub></p>
 
-### See the gate run in about 20 seconds
+## Start in one command
+
+From the root of the repository you want to gate:
+
+```bash
+npm init @vyuhlabs/dxkit -- --claude-loop --yes
+```
+
+That is the whole setup. dxkit reads your stack, wires the agent context, arms
+the gates, installs the scanners a baseline needs, and captures today's
+baseline, so the repository is gated on the very next change. No questions, no
+homework. Undo anytime with `npx vyuh-dxkit uninstall`.
+
+<p align="center">
+  <img src=".github/assets/init-quickstart.gif" width="760" alt="vyuh-dxkit init reads the stack, wires the agent context, arms the gates, installs scanners, captures the baseline, and reports the repository is gated in about ten seconds." />
+</p>
+
+Existing findings are grandfathered, not approved. Only what a change _adds_
+from here can block. Already have dxkit installed? `init` detects the version
+and points you at `npx vyuh-dxkit update` instead of re-running setup.
+
+### Want to see the gate first, without installing anything?
 
 ```bash
 npx -y @vyuhlabs/dxkit@latest demo loop-guardrail
@@ -87,25 +108,6 @@ What you can rely on:
   passed.
 
 ---
-
-## Start in one command
-
-```bash
-npm init @vyuhlabs/dxkit -- --claude-loop --yes
-```
-
-That is the whole setup. dxkit reads your stack, wires the agent context, arms
-the gates, installs the scanners a baseline needs, and captures today's
-baseline, so the repository is gated on the very next change. No questions, no
-homework. Undo anytime with `npx vyuh-dxkit uninstall`.
-
-<p align="center">
-  <img src=".github/assets/init-quickstart.gif" width="760" alt="vyuh-dxkit init reads the stack, wires the agent context, arms the gates, installs scanners, captures the baseline, and reports the repository is gated in about ten seconds." />
-</p>
-
-Existing findings are grandfathered, not approved. Only what a change _adds_
-from here can block. Already have dxkit installed? `init` detects the version
-and points you at `npx vyuh-dxkit update` instead of re-running setup.
 
 ## See your code the way an agent should
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.1.5",
+      "version": "4.1.6",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -4927,7 +4927,7 @@
     },
     "packages/create-dxkit": {
       "name": "@vyuhlabs/create-dxkit",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "bin": {
         "create-dxkit": "index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",
@@ -25,7 +25,8 @@
     ".": {
       "types": "./dist/lib.d.ts",
       "default": "./dist/lib.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/create-dxkit/README.md
+++ b/packages/create-dxkit/README.md
@@ -26,10 +26,12 @@ into one. Useful at the first-install moment — the highest-leverage UX touchpo
 
 ## What it does
 
-1. If the current directory has no `package.json`, seed a minimal one.
-2. Install `@vyuhlabs/dxkit` into `devDependencies` (retries with
+1. Refuse to run in a home directory or filesystem root (a project
+   directory is required — nothing is written on refusal).
+2. If the current directory has no `package.json`, seed a minimal one.
+3. Install `@vyuhlabs/dxkit` into `devDependencies` (retries with
    `--legacy-peer-deps` once if the initial install hits an ERESOLVE).
-3. Forward your args (or `--full --yes` if none) to `vyuh-dxkit init`.
+4. Forward your args (or `--full --yes` if none) to `vyuh-dxkit init`.
 
 After this runs, every dxkit subcommand is available via
 `./node_modules/.bin/vyuh-dxkit` or `npx vyuh-dxkit`.

--- a/packages/create-dxkit/index.js
+++ b/packages/create-dxkit/index.js
@@ -26,354 +26,40 @@
  * `shell: false` throw EINVAL — so the old `spawnSync('npm.cmd', …)`
  * approach could NEVER succeed on a current Node on Windows, and the
  * un-checked `.error` read as a phantom "peer-dep conflict" with empty
- * stderr (the shipped failure this rewrite fixes). The order of
- * preference now:
- *   - npm: spawn `process.execPath <npm_execpath> …` — npm always sets
- *     `npm_execpath` for scripts it launches (this shim runs via
- *     npm init/npx), and a plain JS entry needs no shell on any OS.
- *   - other PMs on Windows: `shell: true` with each arg quoted (the args
- *     are our own constants, quoted defensively anyway).
- *   - everything else: plain direct spawn.
- * The post-install `init` step spawns the freshly-installed package's
- * own bin JS via `process.execPath` — no npx, no `.cmd`, no shell.
+ * stderr (the shipped failure this rewrite fixes). `installSpawnPlan`
+ * in `lib.js` owns the safe plan; the post-install `init` step spawns
+ * the freshly-installed package's own bin JS via `process.execPath` —
+ * no npx, no `.cmd`, no shell.
  *
  * Zero runtime dependencies — keeps the install surface as narrow as
  * possible so a customer hitting this for the first time doesn't pull
  * a transitive that conflicts with their tree. That is also why the
- * package-manager detection is a small self-contained copy of
- * `src/package-manager.ts` rather than an import: this shim is a
+ * package-manager detection in `lib.js` is a small self-contained copy
+ * of `src/package-manager.ts` rather than an import: this shim is a
  * separate published package and cannot depend on the main one.
  */
 'use strict';
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
 const { spawnSync } = require('child_process');
-
-/** The package this bootstrap installs. */
-const PKG = '@vyuhlabs/dxkit';
-
-/**
- * The PRE-INSTALL escape hatch shown when the dev-dep install fails: a
- * one-shot npx invocation by PACKAGE name. It must NOT invoke the bare
- * `vyuh-dxkit` binary name — that resolves only through an installed
- * package, which is exactly what just failed, so it would 404 (the main
- * repo's Rule 14 class; this file is grepped by the same arch check).
- */
-const ONE_SHOT_INIT = `npx -y ${PKG} init --full --yes`;
-
-// ── Pure helpers (exported for unit tests) ──────────────────────────
-
-/**
- * The args we forward to `vyuh-dxkit init`. When the user passed
- * nothing, fall back to `--full --yes` — the "I just want everything"
- * default that matches the highest-leverage first-install case.
- */
-function resolveInitArgs(argv) {
-  const userArgs = argv.slice(2);
-  return userArgs.length > 0 ? userArgs : ['--full', '--yes'];
-}
-
-/**
- * Refuse to scaffold in a directory that is clearly not a project: the
- * user's home directory or a filesystem root. The demo's next-steps say
- * `cd <your-repo>` but users skim — running from `C:\Users\<name>` would
- * seed a package.json into their home folder and then install into it.
- * Returns a human-readable reason, or null when the cwd is acceptable.
- * Windows paths compare case-insensitively.
- */
-function refuseCwdReason(cwd, homeDir = os.homedir(), platform = process.platform) {
-  const norm = (p) => {
-    const r = path.resolve(p);
-    return platform === 'win32' ? r.toLowerCase() : r;
-  };
-  const c = norm(cwd);
-  if (homeDir && c === norm(homeDir)) {
-    return (
-      `This is your home directory (${path.resolve(cwd)}), not a project.\n` +
-      'cd into the repository you want to gate, then re-run this command.\n' +
-      'Nothing was written.'
-    );
-  }
-  if (c === norm(path.parse(c).root)) {
-    return (
-      `This is the filesystem root (${path.resolve(cwd)}), not a project.\n` +
-      'cd into the repository you want to gate, then re-run this command.\n' +
-      'Nothing was written.'
-    );
-  }
-  return null;
-}
-
-/**
- * Seed a minimal package.json when missing. `npm install --save-dev`
- * needs SOMETHING to write the entry into; without this, npm walks up
- * to the parent dir or refuses outright depending on version.
- *
- * Returns `{ seeded: true }` when we wrote a file, `{ seeded: false }`
- * when an existing package.json was already present.
- */
-function ensurePackageJson(cwd, fsMod = fs, pathMod = path) {
-  const pkgPath = pathMod.join(cwd, 'package.json');
-  if (fsMod.existsSync(pkgPath)) return { seeded: false };
-  const seeded = {
-    name:
-      pathMod
-        .basename(cwd)
-        .toLowerCase()
-        .replace(/[^a-z0-9-]/g, '-') || 'dxkit-project',
-    private: true,
-    version: '0.0.0',
-  };
-  fsMod.writeFileSync(pkgPath, JSON.stringify(seeded, null, 2) + '\n');
-  return { seeded: true };
-}
-
-/**
- * Detect the repo's package manager — lockfile first (it reflects what actually
- * provisioned node_modules), then the `packageManager` field (corepack), else
- * npm. Self-contained copy of `src/package-manager.ts:detectPackageManager`
- * (this shim can't import from the main package). `fsMod`/`pathMod` are
- * injectable for unit tests.
- */
-function detectPackageManager(cwd, fsMod = fs, pathMod = path) {
-  const has = (f) => fsMod.existsSync(pathMod.join(cwd, f));
-  if (has('pnpm-lock.yaml')) return 'pnpm';
-  if (has('yarn.lock')) return 'yarn';
-  if (has('bun.lockb') || has('bun.lock')) return 'bun';
-  if (has('package-lock.json')) return 'npm';
-  try {
-    const pkg = JSON.parse(fsMod.readFileSync(pathMod.join(cwd, 'package.json'), 'utf8'));
-    if (typeof pkg.packageManager === 'string') {
-      const name = pkg.packageManager.split('@')[0].trim();
-      if (name === 'pnpm' || name === 'yarn' || name === 'bun' || name === 'npm') return name;
-    }
-  } catch {
-    // no/invalid package.json → fall through to npm
-  }
-  return 'npm';
-}
-
-/** Platform-aware executable name for a package manager. The JS PMs ship as
- *  `.cmd` shims on Windows; bun ships as `bun.exe`. Only used on the
- *  `shell: true` Windows path — see `installSpawnPlan`. */
-function pmBin(pm, platform = process.platform) {
-  if (platform !== 'win32') return pm;
-  return pm === 'bun' ? 'bun.exe' : `${pm}.cmd`;
-}
-
-/** Quote one argument for a Windows `shell: true` spawn (cmd.exe). Our own
- *  install args are constants, but quote defensively — Node does NOT quote
- *  args it joins for a shell spawn. */
-function windowsQuoteArg(arg) {
-  if (/^[A-Za-z0-9_@/.:=+-]+$/.test(arg)) return arg;
-  return `"${arg.replace(/"/g, '""')}"`;
-}
-
-/**
- * How to actually spawn the package manager — the CVE-2024-27980-safe plan.
- *
- *   - npm with `npm_execpath` pointing at a JS entry (always true when this
- *     shim runs via npm init / npx): spawn node itself on that entry. No
- *     `.cmd`, no shell, works on every OS and every Node.
- *   - anything else on Windows: `shell: true` (spawning a `.cmd` with
- *     `shell: false` throws EINVAL on patched Node) with args pre-quoted.
- *   - anything else elsewhere: plain direct spawn.
- *
- * Returns `{ cmd, args, shell }` ready for spawnSync.
- */
-function installSpawnPlan(pm, pmArgs, env = process.env, platform = process.platform) {
-  const execpath = env.npm_execpath;
-  if (pm === 'npm' && typeof execpath === 'string' && /\.[cm]?js$/.test(execpath)) {
-    return { cmd: process.execPath, args: [execpath, ...pmArgs], shell: false };
-  }
-  if (platform === 'win32') {
-    return { cmd: pmBin(pm, platform), args: pmArgs.map(windowsQuoteArg), shell: true };
-  }
-  return { cmd: pm, args: pmArgs, shell: false };
-}
-
-/**
- * The args that add `@vyuhlabs/dxkit` as a devDependency with the given PM.
- * `--no-audit` (npm) suppresses the host project's vuln tally mid-install —
- * those numbers describe the customer's own deps, not anything dxkit added.
- */
-function installArgs(pm) {
-  switch (pm) {
-    case 'pnpm':
-      return ['add', '-D', PKG];
-    case 'yarn':
-      return ['add', '-D', PKG];
-    case 'bun':
-      return ['add', '-d', PKG];
-    default:
-      return ['install', '--save-dev', '--no-audit', PKG];
-  }
-}
-
-/**
- * Resolve the freshly-installed package's bin entry to a JS path we can
- * run with `process.execPath` — no npx, no `.cmd` shim, no shell, so the
- * init step cannot re-hit the Windows spawn class the install step just
- * avoided. Returns null when the package (or its bin) can't be resolved;
- * the caller falls back to a one-shot npx by package name.
- */
-function resolveInstalledBin(cwd, requireResolve = require.resolve, fsMod = fs) {
-  // Direct node_modules path FIRST: the install we just ran put the package
-  // at <cwd>/node_modules (a symlink under pnpm — fs reads through it), and
-  // this route is immune to the package's `exports` map, which does not have
-  // to expose `./package.json` for require.resolve subpath resolution.
-  const candidates = [path.join(cwd, 'node_modules', PKG, 'package.json')];
-  try {
-    candidates.push(requireResolve(`${PKG}/package.json`, { paths: [cwd] }));
-  } catch {
-    // exports-restricted or unresolvable — the direct path may still work
-  }
-  for (const pkgJsonPath of candidates) {
-    try {
-      const pkgJson = JSON.parse(fsMod.readFileSync(pkgJsonPath, 'utf8'));
-      const bin = pkgJson.bin && pkgJson.bin['vyuh-dxkit'];
-      if (typeof bin !== 'string') continue;
-      const binPath = path.resolve(path.dirname(pkgJsonPath), bin);
-      if (fsMod.existsSync(binPath)) return binPath;
-    } catch {
-      // unreadable candidate — try the next
-    }
-  }
-  return null;
-}
-
-/**
- * Persist `legacy-peer-deps=true` to `.npmrc` when the fallback install
- * had to be used. Without this, the customer's next `npm install` (any
- * `npm install <new-pkg>`) re-hits the same peer-dep ERESOLVE we just
- * worked around — only this time WE aren't in the loop to recover.
- *
- * Idempotent: skips if the line is already present. Append-or-create
- * — preserves any other settings the customer already had.
- */
-function persistLegacyPeerDeps(cwd, fsMod = fs, pathMod = path) {
-  const npmrcPath = pathMod.join(cwd, '.npmrc');
-  const line = 'legacy-peer-deps=true';
-  let existing = '';
-  if (fsMod.existsSync(npmrcPath)) {
-    existing = fsMod.readFileSync(npmrcPath, 'utf8');
-    if (existing.split('\n').some((l) => l.trim() === line)) {
-      return { changed: false, reason: 'already-present' };
-    }
-    if (existing.length > 0 && !existing.endsWith('\n')) existing += '\n';
-  }
-  fsMod.writeFileSync(npmrcPath, existing + line + '\n');
-  return { changed: true, reason: existing ? 'appended' : 'created' };
-}
-
-/**
- * Extract npm's "complete log of this run" debug-log path from captured
- * npm output. Modern npm routes ERESOLVE / registry / auth detail to a
- * `_logs/*-debug-0.log` file and emits only a one-line pointer to
- * stderr — so this path is where the real failure cause lives. Matches
- * both the new `npm error ...` and legacy `npm ERR! ...` prefixes, and
- * tolerates Windows paths.
- *
- * Returns the last match (npm prints the pointer last) or null.
- */
-function extractNpmLogPath(text) {
-  if (!text) return null;
-  const re = /complete log of this run can be found in:\s*(.+)$/gim;
-  let match;
-  let last = null;
-  while ((match = re.exec(text)) !== null) {
-    last = match[1].trim();
-  }
-  return last;
-}
-
-/**
- * Build the failure message shown when the install could not complete.
- *
- * Pure + exported so its content is unit-testable. Two distinct shapes:
- *
- *   - `spawnError` set: the package manager never RAN (spawn-level failure —
- *     EINVAL, ENOENT). Say exactly that; there is no npm log to point at and
- *     no peer-dep story to tell. The previous version read this case as a
- *     "peer-dep conflict" with empty stderr — a fabricated diagnosis that
- *     shipped and was caught in the field.
- *   - otherwise: the PM ran and exited non-zero. Surface whatever stderr we
- *     captured, ALWAYS point at the npm debug log when one is named, and
- *     list the real common causes.
- *
- * Both shapes end with the one-shot npx escape hatch, which needs no
- * successful `npm install` at all (package form — the binary form would
- * 404 in exactly this situation).
- *
- * @param {{ stderrChunks?: string[], pm?: string, spawnError?: Error }} opts
- */
-function formatInstallFailure(opts = {}) {
-  const stderrChunks = (opts.stderrChunks || []).filter((s) => s && s.length > 0);
-  const pm = opts.pm || 'npm';
-  const lines = [];
-
-  if (opts.spawnError) {
-    lines.push(
-      `Could not launch ${pm} at all (${opts.spawnError.code || opts.spawnError.message}).`,
-    );
-    lines.push(`${pm} never ran, so there is no install error to debug — the problem is`);
-    lines.push(`launching ${pm} from this environment (PATH, or a Node/npm installation issue).`);
-    lines.push('');
-  } else {
-    const combined = stderrChunks.join('\n');
-    if (combined.length > 0) {
-      lines.push(`${pm} reported:`);
-      lines.push(combined.trimEnd());
-      lines.push('');
-    }
-
-    // Only npm routes its failure detail to a `_logs/*-debug.log` and prints a
-    // "complete log of this run" pointer; the other PMs surface the cause on
-    // stderr directly (already shown above).
-    if (pm === 'npm') {
-      const logPath = extractNpmLogPath(combined);
-      if (logPath) {
-        lines.push(`Full npm error log: ${logPath}`);
-      } else {
-        lines.push(
-          'npm wrote the failure detail to its debug log — see the ' +
-            '"complete log of this run" path npm printed above, under ' +
-            'your npm cache `_logs/` directory.',
-        );
-      }
-      lines.push('');
-    }
-    lines.push(`Could not install ${PKG}. Common causes:`);
-    lines.push('  • a private-registry auth or proxy issue (check the log above),');
-    lines.push("  • an unresolved peer-dep conflict in this folder's package.json,");
-    lines.push('  • running in a wrapper directory rather than your actual project.');
-    lines.push('');
-  }
-  lines.push('You do NOT need this install to use dxkit. From your project root run:');
-  lines.push(`  ${ONE_SHOT_INIT}`);
-  lines.push(
-    'That scaffolds dxkit directly (the same step this bootstrap runs after ' +
-      'install) without adding it to package.json.',
-  );
-  return lines.join('\n');
-}
-
-module.exports = {
+const lib = require('./lib');
+const {
+  PKG,
+  ONE_SHOT_INIT,
   resolveInitArgs,
   refuseCwdReason,
   ensurePackageJson,
   detectPackageManager,
-  pmBin,
   windowsQuoteArg,
   installSpawnPlan,
   installArgs,
   resolveInstalledBin,
   persistLegacyPeerDeps,
-  extractNpmLogPath,
   formatInstallFailure,
-};
+} = lib;
+
+// Re-export the pure helpers so tests (and any tooling) can keep
+// requiring the package entry.
+module.exports = lib;
 
 // ── Entry point ─────────────────────────────────────────────────────
 

--- a/packages/create-dxkit/index.js
+++ b/packages/create-dxkit/index.js
@@ -3,19 +3,39 @@
  * @vyuhlabs/create-dxkit — `npm init @vyuhlabs/dxkit` entry point.
  *
  * Collapses the two-step first install — `npm install --save-dev
- * @vyuhlabs/dxkit && npx vyuh-dxkit init` — into a single command. npm
+ * @vyuhlabs/dxkit`, then the CLI's `init` — into a single command. npm
  * resolves `npm init @scope/name` to `npx @scope/create-name`, so this
  * shim runs in the customer's cwd with their command-line args.
  *
  * Responsibilities, in order:
- *   1. Seed a minimal `package.json` if the cwd doesn't have one
+ *   1. Refuse to run in a home directory or filesystem root — a user
+ *      who skipped the `cd <your-repo>` step would otherwise get a
+ *      package.json seeded into their home folder (shipped once, found
+ *      in the field).
+ *   2. Seed a minimal `package.json` if the cwd doesn't have one
  *      (else the dev-dep install would write to the global one).
- *   2. Detect the repo's package manager from its lockfile (pnpm / yarn
+ *   3. Detect the repo's package manager from its lockfile (pnpm / yarn
  *      / bun / npm) and add `@vyuhlabs/dxkit` as a devDependency with
  *      THAT PM — running `npm install` in a pnpm repo crashes npm. On an
- *      npm peer-dep ERESOLVE, retry once with `--legacy-peer-deps`.
- *   3. Forward the user's args (or `--full --yes` if none) to
+ *      npm install failure, retry once with `--legacy-peer-deps`.
+ *   4. Forward the user's args (or `--full --yes` if none) to
  *      `vyuh-dxkit init`.
+ *
+ * Windows spawning (load-bearing): Node's CVE-2024-27980 fix (18.20.2 /
+ * 20.12.2 / 21.7.3, April 2024) makes spawning a `.cmd`/`.bat` with
+ * `shell: false` throw EINVAL — so the old `spawnSync('npm.cmd', …)`
+ * approach could NEVER succeed on a current Node on Windows, and the
+ * un-checked `.error` read as a phantom "peer-dep conflict" with empty
+ * stderr (the shipped failure this rewrite fixes). The order of
+ * preference now:
+ *   - npm: spawn `process.execPath <npm_execpath> …` — npm always sets
+ *     `npm_execpath` for scripts it launches (this shim runs via
+ *     npm init/npx), and a plain JS entry needs no shell on any OS.
+ *   - other PMs on Windows: `shell: true` with each arg quoted (the args
+ *     are our own constants, quoted defensively anyway).
+ *   - everything else: plain direct spawn.
+ * The post-install `init` step spawns the freshly-installed package's
+ * own bin JS via `process.execPath` — no npx, no `.cmd`, no shell.
  *
  * Zero runtime dependencies — keeps the install surface as narrow as
  * possible so a customer hitting this for the first time doesn't pull
@@ -27,11 +47,21 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
 /** The package this bootstrap installs. */
 const PKG = '@vyuhlabs/dxkit';
+
+/**
+ * The PRE-INSTALL escape hatch shown when the dev-dep install fails: a
+ * one-shot npx invocation by PACKAGE name. It must NOT invoke the bare
+ * `vyuh-dxkit` binary name — that resolves only through an installed
+ * package, which is exactly what just failed, so it would 404 (the main
+ * repo's Rule 14 class; this file is grepped by the same arch check).
+ */
+const ONE_SHOT_INIT = `npx -y ${PKG} init --full --yes`;
 
 // ── Pure helpers (exported for unit tests) ──────────────────────────
 
@@ -43,6 +73,37 @@ const PKG = '@vyuhlabs/dxkit';
 function resolveInitArgs(argv) {
   const userArgs = argv.slice(2);
   return userArgs.length > 0 ? userArgs : ['--full', '--yes'];
+}
+
+/**
+ * Refuse to scaffold in a directory that is clearly not a project: the
+ * user's home directory or a filesystem root. The demo's next-steps say
+ * `cd <your-repo>` but users skim — running from `C:\Users\<name>` would
+ * seed a package.json into their home folder and then install into it.
+ * Returns a human-readable reason, or null when the cwd is acceptable.
+ * Windows paths compare case-insensitively.
+ */
+function refuseCwdReason(cwd, homeDir = os.homedir(), platform = process.platform) {
+  const norm = (p) => {
+    const r = path.resolve(p);
+    return platform === 'win32' ? r.toLowerCase() : r;
+  };
+  const c = norm(cwd);
+  if (homeDir && c === norm(homeDir)) {
+    return (
+      `This is your home directory (${path.resolve(cwd)}), not a project.\n` +
+      'cd into the repository you want to gate, then re-run this command.\n' +
+      'Nothing was written.'
+    );
+  }
+  if (c === norm(path.parse(c).root)) {
+    return (
+      `This is the filesystem root (${path.resolve(cwd)}), not a project.\n` +
+      'cd into the repository you want to gate, then re-run this command.\n' +
+      'Nothing was written.'
+    );
+  }
+  return null;
 }
 
 /**
@@ -67,14 +128,6 @@ function ensurePackageJson(cwd, fsMod = fs, pathMod = path) {
   };
   fsMod.writeFileSync(pkgPath, JSON.stringify(seeded, null, 2) + '\n');
   return { seeded: true };
-}
-
-/** Platform-aware `npm` / `npx` binary names — npm/npx ship as .cmd on Windows. */
-function npmBin(platform = process.platform) {
-  return platform === 'win32' ? 'npm.cmd' : 'npm';
-}
-function npxBin(platform = process.platform) {
-  return platform === 'win32' ? 'npx.cmd' : 'npx';
 }
 
 /**
@@ -103,10 +156,42 @@ function detectPackageManager(cwd, fsMod = fs, pathMod = path) {
 }
 
 /** Platform-aware executable name for a package manager. The JS PMs ship as
- *  `.cmd` shims on Windows; bun ships as `bun.exe`. */
+ *  `.cmd` shims on Windows; bun ships as `bun.exe`. Only used on the
+ *  `shell: true` Windows path — see `installSpawnPlan`. */
 function pmBin(pm, platform = process.platform) {
   if (platform !== 'win32') return pm;
   return pm === 'bun' ? 'bun.exe' : `${pm}.cmd`;
+}
+
+/** Quote one argument for a Windows `shell: true` spawn (cmd.exe). Our own
+ *  install args are constants, but quote defensively — Node does NOT quote
+ *  args it joins for a shell spawn. */
+function windowsQuoteArg(arg) {
+  if (/^[A-Za-z0-9_@/.:=+-]+$/.test(arg)) return arg;
+  return `"${arg.replace(/"/g, '""')}"`;
+}
+
+/**
+ * How to actually spawn the package manager — the CVE-2024-27980-safe plan.
+ *
+ *   - npm with `npm_execpath` pointing at a JS entry (always true when this
+ *     shim runs via npm init / npx): spawn node itself on that entry. No
+ *     `.cmd`, no shell, works on every OS and every Node.
+ *   - anything else on Windows: `shell: true` (spawning a `.cmd` with
+ *     `shell: false` throws EINVAL on patched Node) with args pre-quoted.
+ *   - anything else elsewhere: plain direct spawn.
+ *
+ * Returns `{ cmd, args, shell }` ready for spawnSync.
+ */
+function installSpawnPlan(pm, pmArgs, env = process.env, platform = process.platform) {
+  const execpath = env.npm_execpath;
+  if (pm === 'npm' && typeof execpath === 'string' && /\.[cm]?js$/.test(execpath)) {
+    return { cmd: process.execPath, args: [execpath, ...pmArgs], shell: false };
+  }
+  if (platform === 'win32') {
+    return { cmd: pmBin(pm, platform), args: pmArgs.map(windowsQuoteArg), shell: true };
+  }
+  return { cmd: pm, args: pmArgs, shell: false };
 }
 
 /**
@@ -125,6 +210,38 @@ function installArgs(pm) {
     default:
       return ['install', '--save-dev', '--no-audit', PKG];
   }
+}
+
+/**
+ * Resolve the freshly-installed package's bin entry to a JS path we can
+ * run with `process.execPath` — no npx, no `.cmd` shim, no shell, so the
+ * init step cannot re-hit the Windows spawn class the install step just
+ * avoided. Returns null when the package (or its bin) can't be resolved;
+ * the caller falls back to a one-shot npx by package name.
+ */
+function resolveInstalledBin(cwd, requireResolve = require.resolve, fsMod = fs) {
+  // Direct node_modules path FIRST: the install we just ran put the package
+  // at <cwd>/node_modules (a symlink under pnpm — fs reads through it), and
+  // this route is immune to the package's `exports` map, which does not have
+  // to expose `./package.json` for require.resolve subpath resolution.
+  const candidates = [path.join(cwd, 'node_modules', PKG, 'package.json')];
+  try {
+    candidates.push(requireResolve(`${PKG}/package.json`, { paths: [cwd] }));
+  } catch {
+    // exports-restricted or unresolvable — the direct path may still work
+  }
+  for (const pkgJsonPath of candidates) {
+    try {
+      const pkgJson = JSON.parse(fsMod.readFileSync(pkgJsonPath, 'utf8'));
+      const bin = pkgJson.bin && pkgJson.bin['vyuh-dxkit'];
+      if (typeof bin !== 'string') continue;
+      const binPath = path.resolve(path.dirname(pkgJsonPath), bin);
+      if (fsMod.existsSync(binPath)) return binPath;
+    } catch {
+      // unreadable candidate — try the next
+    }
+  }
+  return null;
 }
 
 /**
@@ -173,53 +290,69 @@ function extractNpmLogPath(text) {
 }
 
 /**
- * Build the failure message shown when BOTH install attempts fail.
+ * Build the failure message shown when the install could not complete.
  *
- * Pure + exported so its content is unit-testable. The screenshotted
- * customer failure showed "Resolve the npm error above" with nothing
- * above — because the captured stderr was empty (npm put the detail in
- * its log file). This message never claims the error is "above": it
- * surfaces whatever stderr we captured, ALWAYS points at the npm debug
- * log when one is named, and offers the npx-init escape hatch that
- * doesn't need a successful `npm install` at all.
+ * Pure + exported so its content is unit-testable. Two distinct shapes:
  *
- * @param {{ stderrChunks?: string[], pm?: string }} opts
+ *   - `spawnError` set: the package manager never RAN (spawn-level failure —
+ *     EINVAL, ENOENT). Say exactly that; there is no npm log to point at and
+ *     no peer-dep story to tell. The previous version read this case as a
+ *     "peer-dep conflict" with empty stderr — a fabricated diagnosis that
+ *     shipped and was caught in the field.
+ *   - otherwise: the PM ran and exited non-zero. Surface whatever stderr we
+ *     captured, ALWAYS point at the npm debug log when one is named, and
+ *     list the real common causes.
+ *
+ * Both shapes end with the one-shot npx escape hatch, which needs no
+ * successful `npm install` at all (package form — the binary form would
+ * 404 in exactly this situation).
+ *
+ * @param {{ stderrChunks?: string[], pm?: string, spawnError?: Error }} opts
  */
 function formatInstallFailure(opts = {}) {
   const stderrChunks = (opts.stderrChunks || []).filter((s) => s && s.length > 0);
   const pm = opts.pm || 'npm';
   const lines = [];
 
-  const combined = stderrChunks.join('\n');
-  if (combined.length > 0) {
-    lines.push(`${pm} reported:`);
-    lines.push(combined.trimEnd());
+  if (opts.spawnError) {
+    lines.push(
+      `Could not launch ${pm} at all (${opts.spawnError.code || opts.spawnError.message}).`,
+    );
+    lines.push(`${pm} never ran, so there is no install error to debug — the problem is`);
+    lines.push(`launching ${pm} from this environment (PATH, or a Node/npm installation issue).`);
     lines.push('');
-  }
-
-  // Only npm routes its failure detail to a `_logs/*-debug.log` and prints a
-  // "complete log of this run" pointer; the other PMs surface the cause on
-  // stderr directly (already shown above).
-  if (pm === 'npm') {
-    const logPath = extractNpmLogPath(combined);
-    if (logPath) {
-      lines.push(`Full npm error log: ${logPath}`);
-    } else {
-      lines.push(
-        'npm wrote the failure detail to its debug log — see the ' +
-          '"complete log of this run" path npm printed above, under ' +
-          'your npm cache `_logs/` directory.',
-      );
+  } else {
+    const combined = stderrChunks.join('\n');
+    if (combined.length > 0) {
+      lines.push(`${pm} reported:`);
+      lines.push(combined.trimEnd());
+      lines.push('');
     }
+
+    // Only npm routes its failure detail to a `_logs/*-debug.log` and prints a
+    // "complete log of this run" pointer; the other PMs surface the cause on
+    // stderr directly (already shown above).
+    if (pm === 'npm') {
+      const logPath = extractNpmLogPath(combined);
+      if (logPath) {
+        lines.push(`Full npm error log: ${logPath}`);
+      } else {
+        lines.push(
+          'npm wrote the failure detail to its debug log — see the ' +
+            '"complete log of this run" path npm printed above, under ' +
+            'your npm cache `_logs/` directory.',
+        );
+      }
+      lines.push('');
+    }
+    lines.push(`Could not install ${PKG}. Common causes:`);
+    lines.push('  • a private-registry auth or proxy issue (check the log above),');
+    lines.push("  • an unresolved peer-dep conflict in this folder's package.json,");
+    lines.push('  • running in a wrapper directory rather than your actual project.');
     lines.push('');
   }
-  lines.push('Could not install @vyuhlabs/dxkit. Common causes:');
-  lines.push('  • a private-registry auth or proxy issue (check the log above),');
-  lines.push("  • an unresolved peer-dep conflict in this folder's package.json,");
-  lines.push('  • running in a wrapper directory rather than your actual project.');
-  lines.push('');
   lines.push('You do NOT need this install to use dxkit. From your project root run:');
-  lines.push('  npx vyuh-dxkit init --full --yes');
+  lines.push(`  ${ONE_SHOT_INIT}`);
   lines.push(
     'That scaffolds dxkit directly (the same step this bootstrap runs after ' +
       'install) without adding it to package.json.',
@@ -229,12 +362,14 @@ function formatInstallFailure(opts = {}) {
 
 module.exports = {
   resolveInitArgs,
+  refuseCwdReason,
   ensurePackageJson,
-  npmBin,
-  npxBin,
   detectPackageManager,
   pmBin,
+  windowsQuoteArg,
+  installSpawnPlan,
   installArgs,
+  resolveInstalledBin,
   persistLegacyPeerDeps,
   extractNpmLogPath,
   formatInstallFailure,
@@ -246,20 +381,25 @@ if (require.main === module) {
   const cwd = process.cwd();
   const initArgs = resolveInitArgs(process.argv);
 
+  const refusal = refuseCwdReason(cwd);
+  if (refusal) {
+    process.stderr.write('\n' + refusal + '\n');
+    process.exit(1);
+  }
+
   const seedResult = ensurePackageJson(cwd);
   if (seedResult.seeded) {
     console.log(`Seeded minimal package.json in ${cwd}.`); // slop-ok
   }
 
-  function run(cmd, args) {
-    return spawnSync(cmd, args, { stdio: 'inherit', shell: false }).status;
-  }
-
   // Quiet variant: streams stdout (so the customer sees progress) but
-  // captures stderr. Used for attempt 1 so npm's multi-line ERESOLVE
-  // wall doesn't print on screen before the fallback retry succeeds.
-  function runCaptureStderr(cmd, args) {
-    return spawnSync(cmd, args, { stdio: ['inherit', 'inherit', 'pipe'], shell: false });
+  // captures stderr. Used for the install attempts so npm's multi-line
+  // ERESOLVE wall doesn't print on screen before the fallback retry succeeds.
+  function runCaptureStderr(plan) {
+    return spawnSync(plan.cmd, plan.args, {
+      stdio: ['inherit', 'inherit', 'pipe'],
+      shell: plan.shell,
+    });
   }
 
   // Detect the repo's package manager from its lockfile and install with THAT
@@ -273,21 +413,35 @@ if (require.main === module) {
   // Attempt 1: strict resolution. On a clean tree this works in one shot; on a
   // non-trivial npm repo there's often a peer-dep mismatch (eslint 8↔10, react
   // cross-pkg, etc.) that fails here — hence the legacy-peer-deps retry below.
-  const attempt1 = runCaptureStderr(pmBin(pm), addArgs);
+  const attempt1 = runCaptureStderr(installSpawnPlan(pm, addArgs));
   let rc = attempt1.status;
   let usedLegacy = false;
   let attempt2 = null;
+
+  if (attempt1.error) {
+    // The PM never ran (spawn-level failure). Retrying would EINVAL/ENOENT
+    // identically — bail with the honest cause instead of a peer-dep guess.
+    process.stderr.write('\n' + formatInstallFailure({ pm, spawnError: attempt1.error }) + '\n');
+    process.exit(1);
+  }
 
   // The `--legacy-peer-deps` retry is npm-specific — pnpm / yarn / bun are
   // lenient on peer deps by default, so a failure there is a real error, not a
   // strictness knob to relax.
   if (rc !== 0 && pm === 'npm') {
-    console.log('Peer-dep conflict detected. Retrying with --legacy-peer-deps...'); // slop-ok
+    // We don't know yet WHY npm failed (the detail is in its debug log) —
+    // peer-dep strictness is just the most common recoverable cause, so try
+    // the relaxed mode once before reporting.
+    console.log(`npm install failed (exit ${rc}). Retrying with --legacy-peer-deps...`); // slop-ok
     // Capture stderr here too, so a second failure surfaces the real cause
     // (including the npm debug-log path) rather than an empty error wall.
-    attempt2 = runCaptureStderr(pmBin(pm), [...addArgs, '--legacy-peer-deps']);
+    attempt2 = runCaptureStderr(installSpawnPlan(pm, [...addArgs, '--legacy-peer-deps']));
     rc = attempt2.status;
     usedLegacy = true;
+    if (attempt2.error) {
+      process.stderr.write('\n' + formatInstallFailure({ pm, spawnError: attempt2.error }) + '\n');
+      process.exit(1);
+    }
   }
 
   if (rc !== 0) {
@@ -317,6 +471,48 @@ if (require.main === module) {
   }
 
   console.log(`Running: vyuh-dxkit init ${initArgs.join(' ')}`); // slop-ok
-  const initRc = run(npxBin(), ['vyuh-dxkit', 'init', ...initArgs]);
-  process.exit(initRc ?? 0);
+  // Run the freshly-installed CLI's bin JS with node directly — immune to
+  // the Windows `.cmd`+`shell:false` EINVAL class and needs no npx
+  // resolution. Fall back to one-shot npx BY PACKAGE NAME (never the bare
+  // binary name, which only resolves through an install).
+  const binJs = resolveInstalledBin(cwd);
+  let initResult;
+  if (binJs) {
+    initResult = spawnSync(process.execPath, [binJs, 'init', ...initArgs], {
+      stdio: 'inherit',
+      shell: false,
+    });
+  } else {
+    const plan = installSpawnPlan('npm', [], process.env, process.platform);
+    const npxViaNode = plan.cmd === process.execPath;
+    initResult = npxViaNode
+      ? spawnSync(
+          process.execPath,
+          [
+            plan.args[0],
+            'exec',
+            '--yes',
+            '--package',
+            PKG,
+            '--',
+            'vyuh-dxkit',
+            'init',
+            ...initArgs,
+          ],
+          { stdio: 'inherit', shell: false },
+        )
+      : spawnSync(
+          'npx',
+          ['-y', '--package', PKG, 'vyuh-dxkit', 'init', ...initArgs].map(windowsQuoteArg),
+          { stdio: 'inherit', shell: process.platform === 'win32' },
+        );
+  }
+  if (initResult.error) {
+    process.stderr.write(
+      `\nCould not launch vyuh-dxkit init (${initResult.error.code || initResult.error.message}).\n` +
+        `The install itself succeeded — finish setup from your project root with:\n  ${ONE_SHOT_INIT}\n`,
+    );
+    process.exit(1);
+  }
+  process.exit(initResult.status ?? 0);
 }

--- a/packages/create-dxkit/lib.js
+++ b/packages/create-dxkit/lib.js
@@ -12,7 +12,6 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { spawnSync } = require('child_process');
 
 /** The package this bootstrap installs. */
 const PKG = '@vyuhlabs/dxkit';

--- a/packages/create-dxkit/lib.js
+++ b/packages/create-dxkit/lib.js
@@ -1,0 +1,341 @@
+/**
+ * @vyuhlabs/create-dxkit — pure helpers for the bootstrap shim.
+ *
+ * Everything here is side-effect-free (or filesystem-injectable) and
+ * unit-tested via `test/create-dxkit.test.ts`; the entry-point
+ * orchestration lives in `index.js`, integration-tested as a child
+ * process via `test/create-dxkit-entrypoint.test.ts`. Zero runtime
+ * dependencies — see the rationale in `index.js`.
+ */
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+/** The package this bootstrap installs. */
+const PKG = '@vyuhlabs/dxkit';
+
+/**
+ * The PRE-INSTALL escape hatch shown when the dev-dep install fails: a
+ * one-shot npx invocation by PACKAGE name. It must NOT invoke the bare
+ * `vyuh-dxkit` binary name — that resolves only through an installed
+ * package, which is exactly what just failed, so it would 404 (the main
+ * repo's Rule 14 class; this file is grepped by the same arch check).
+ */
+const ONE_SHOT_INIT = `npx -y ${PKG} init --full --yes`;
+
+// ── Pure helpers (exported for unit tests) ──────────────────────────
+
+/**
+ * The args we forward to `vyuh-dxkit init`. When the user passed
+ * nothing, fall back to `--full --yes` — the "I just want everything"
+ * default that matches the highest-leverage first-install case.
+ */
+function resolveInitArgs(argv) {
+  const userArgs = argv.slice(2);
+  return userArgs.length > 0 ? userArgs : ['--full', '--yes'];
+}
+
+/**
+ * Refuse to scaffold in a directory that is clearly not a project: the
+ * user's home directory or a filesystem root. The demo's next-steps say
+ * `cd <your-repo>` but users skim — running from `C:\Users\<name>` would
+ * seed a package.json into their home folder and then install into it.
+ * Returns a human-readable reason, or null when the cwd is acceptable.
+ * Windows paths compare case-insensitively.
+ */
+function refuseCwdReason(cwd, homeDir = os.homedir(), platform = process.platform) {
+  const norm = (p) => {
+    const r = path.resolve(p);
+    return platform === 'win32' ? r.toLowerCase() : r;
+  };
+  const c = norm(cwd);
+  if (homeDir && c === norm(homeDir)) {
+    return (
+      `This is your home directory (${path.resolve(cwd)}), not a project.\n` +
+      'cd into the repository you want to gate, then re-run this command.\n' +
+      'Nothing was written.'
+    );
+  }
+  if (c === norm(path.parse(c).root)) {
+    return (
+      `This is the filesystem root (${path.resolve(cwd)}), not a project.\n` +
+      'cd into the repository you want to gate, then re-run this command.\n' +
+      'Nothing was written.'
+    );
+  }
+  return null;
+}
+
+/**
+ * Seed a minimal package.json when missing. `npm install --save-dev`
+ * needs SOMETHING to write the entry into; without this, npm walks up
+ * to the parent dir or refuses outright depending on version.
+ *
+ * Returns `{ seeded: true }` when we wrote a file, `{ seeded: false }`
+ * when an existing package.json was already present.
+ */
+function ensurePackageJson(cwd, fsMod = fs, pathMod = path) {
+  const pkgPath = pathMod.join(cwd, 'package.json');
+  if (fsMod.existsSync(pkgPath)) return { seeded: false };
+  const seeded = {
+    name:
+      pathMod
+        .basename(cwd)
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, '-') || 'dxkit-project',
+    private: true,
+    version: '0.0.0',
+  };
+  fsMod.writeFileSync(pkgPath, JSON.stringify(seeded, null, 2) + '\n');
+  return { seeded: true };
+}
+
+/**
+ * Detect the repo's package manager — lockfile first (it reflects what actually
+ * provisioned node_modules), then the `packageManager` field (corepack), else
+ * npm. Self-contained copy of `src/package-manager.ts:detectPackageManager`
+ * (this shim can't import from the main package). `fsMod`/`pathMod` are
+ * injectable for unit tests.
+ */
+function detectPackageManager(cwd, fsMod = fs, pathMod = path) {
+  const has = (f) => fsMod.existsSync(pathMod.join(cwd, f));
+  if (has('pnpm-lock.yaml')) return 'pnpm';
+  if (has('yarn.lock')) return 'yarn';
+  if (has('bun.lockb') || has('bun.lock')) return 'bun';
+  if (has('package-lock.json')) return 'npm';
+  try {
+    const pkg = JSON.parse(fsMod.readFileSync(pathMod.join(cwd, 'package.json'), 'utf8'));
+    if (typeof pkg.packageManager === 'string') {
+      const name = pkg.packageManager.split('@')[0].trim();
+      if (name === 'pnpm' || name === 'yarn' || name === 'bun' || name === 'npm') return name;
+    }
+  } catch {
+    // no/invalid package.json → fall through to npm
+  }
+  return 'npm';
+}
+
+/** Platform-aware executable name for a package manager. The JS PMs ship as
+ *  `.cmd` shims on Windows; bun ships as `bun.exe`. Only used on the
+ *  `shell: true` Windows path — see `installSpawnPlan`. */
+function pmBin(pm, platform = process.platform) {
+  if (platform !== 'win32') return pm;
+  return pm === 'bun' ? 'bun.exe' : `${pm}.cmd`;
+}
+
+/** Quote one argument for a Windows `shell: true` spawn (cmd.exe). Our own
+ *  install args are constants, but quote defensively — Node does NOT quote
+ *  args it joins for a shell spawn. */
+function windowsQuoteArg(arg) {
+  if (/^[A-Za-z0-9_@/.:=+-]+$/.test(arg)) return arg;
+  return `"${arg.replace(/"/g, '""')}"`;
+}
+
+/**
+ * How to actually spawn the package manager — the CVE-2024-27980-safe plan.
+ *
+ *   - npm with `npm_execpath` pointing at a JS entry (always true when this
+ *     shim runs via npm init / npx): spawn node itself on that entry. No
+ *     `.cmd`, no shell, works on every OS and every Node.
+ *   - anything else on Windows: `shell: true` (spawning a `.cmd` with
+ *     `shell: false` throws EINVAL on patched Node) with args pre-quoted.
+ *   - anything else elsewhere: plain direct spawn.
+ *
+ * Returns `{ cmd, args, shell }` ready for spawnSync.
+ */
+function installSpawnPlan(pm, pmArgs, env = process.env, platform = process.platform) {
+  const execpath = env.npm_execpath;
+  if (pm === 'npm' && typeof execpath === 'string' && /\.[cm]?js$/.test(execpath)) {
+    return { cmd: process.execPath, args: [execpath, ...pmArgs], shell: false };
+  }
+  if (platform === 'win32') {
+    return { cmd: pmBin(pm, platform), args: pmArgs.map(windowsQuoteArg), shell: true };
+  }
+  return { cmd: pm, args: pmArgs, shell: false };
+}
+
+/**
+ * The args that add `@vyuhlabs/dxkit` as a devDependency with the given PM.
+ * `--no-audit` (npm) suppresses the host project's vuln tally mid-install —
+ * those numbers describe the customer's own deps, not anything dxkit added.
+ */
+function installArgs(pm) {
+  switch (pm) {
+    case 'pnpm':
+      return ['add', '-D', PKG];
+    case 'yarn':
+      return ['add', '-D', PKG];
+    case 'bun':
+      return ['add', '-d', PKG];
+    default:
+      return ['install', '--save-dev', '--no-audit', PKG];
+  }
+}
+
+/**
+ * Resolve the freshly-installed package's bin entry to a JS path we can
+ * run with `process.execPath` — no npx, no `.cmd` shim, no shell, so the
+ * init step cannot re-hit the Windows spawn class the install step just
+ * avoided. Returns null when the package (or its bin) can't be resolved;
+ * the caller falls back to a one-shot npx by package name.
+ */
+function resolveInstalledBin(cwd, requireResolve = require.resolve, fsMod = fs) {
+  // Direct node_modules path FIRST: the install we just ran put the package
+  // at <cwd>/node_modules (a symlink under pnpm — fs reads through it), and
+  // this route is immune to the package's `exports` map, which does not have
+  // to expose `./package.json` for require.resolve subpath resolution.
+  const candidates = [path.join(cwd, 'node_modules', PKG, 'package.json')];
+  try {
+    candidates.push(requireResolve(`${PKG}/package.json`, { paths: [cwd] }));
+  } catch {
+    // exports-restricted or unresolvable — the direct path may still work
+  }
+  for (const pkgJsonPath of candidates) {
+    try {
+      const pkgJson = JSON.parse(fsMod.readFileSync(pkgJsonPath, 'utf8'));
+      const bin = pkgJson.bin && pkgJson.bin['vyuh-dxkit'];
+      if (typeof bin !== 'string') continue;
+      const binPath = path.resolve(path.dirname(pkgJsonPath), bin);
+      if (fsMod.existsSync(binPath)) return binPath;
+    } catch {
+      // unreadable candidate — try the next
+    }
+  }
+  return null;
+}
+
+/**
+ * Persist `legacy-peer-deps=true` to `.npmrc` when the fallback install
+ * had to be used. Without this, the customer's next `npm install` (any
+ * `npm install <new-pkg>`) re-hits the same peer-dep ERESOLVE we just
+ * worked around — only this time WE aren't in the loop to recover.
+ *
+ * Idempotent: skips if the line is already present. Append-or-create
+ * — preserves any other settings the customer already had.
+ */
+function persistLegacyPeerDeps(cwd, fsMod = fs, pathMod = path) {
+  const npmrcPath = pathMod.join(cwd, '.npmrc');
+  const line = 'legacy-peer-deps=true';
+  let existing = '';
+  if (fsMod.existsSync(npmrcPath)) {
+    existing = fsMod.readFileSync(npmrcPath, 'utf8');
+    if (existing.split('\n').some((l) => l.trim() === line)) {
+      return { changed: false, reason: 'already-present' };
+    }
+    if (existing.length > 0 && !existing.endsWith('\n')) existing += '\n';
+  }
+  fsMod.writeFileSync(npmrcPath, existing + line + '\n');
+  return { changed: true, reason: existing ? 'appended' : 'created' };
+}
+
+/**
+ * Extract npm's "complete log of this run" debug-log path from captured
+ * npm output. Modern npm routes ERESOLVE / registry / auth detail to a
+ * `_logs/*-debug-0.log` file and emits only a one-line pointer to
+ * stderr — so this path is where the real failure cause lives. Matches
+ * both the new `npm error ...` and legacy `npm ERR! ...` prefixes, and
+ * tolerates Windows paths.
+ *
+ * Returns the last match (npm prints the pointer last) or null.
+ */
+function extractNpmLogPath(text) {
+  if (!text) return null;
+  const re = /complete log of this run can be found in:\s*(.+)$/gim;
+  let match;
+  let last = null;
+  while ((match = re.exec(text)) !== null) {
+    last = match[1].trim();
+  }
+  return last;
+}
+
+/**
+ * Build the failure message shown when the install could not complete.
+ *
+ * Pure + exported so its content is unit-testable. Two distinct shapes:
+ *
+ *   - `spawnError` set: the package manager never RAN (spawn-level failure —
+ *     EINVAL, ENOENT). Say exactly that; there is no npm log to point at and
+ *     no peer-dep story to tell. The previous version read this case as a
+ *     "peer-dep conflict" with empty stderr — a fabricated diagnosis that
+ *     shipped and was caught in the field.
+ *   - otherwise: the PM ran and exited non-zero. Surface whatever stderr we
+ *     captured, ALWAYS point at the npm debug log when one is named, and
+ *     list the real common causes.
+ *
+ * Both shapes end with the one-shot npx escape hatch, which needs no
+ * successful `npm install` at all (package form — the binary form would
+ * 404 in exactly this situation).
+ *
+ * @param {{ stderrChunks?: string[], pm?: string, spawnError?: Error }} opts
+ */
+function formatInstallFailure(opts = {}) {
+  const stderrChunks = (opts.stderrChunks || []).filter((s) => s && s.length > 0);
+  const pm = opts.pm || 'npm';
+  const lines = [];
+
+  if (opts.spawnError) {
+    lines.push(
+      `Could not launch ${pm} at all (${opts.spawnError.code || opts.spawnError.message}).`,
+    );
+    lines.push(`${pm} never ran, so there is no install error to debug — the problem is`);
+    lines.push(`launching ${pm} from this environment (PATH, or a Node/npm installation issue).`);
+    lines.push('');
+  } else {
+    const combined = stderrChunks.join('\n');
+    if (combined.length > 0) {
+      lines.push(`${pm} reported:`);
+      lines.push(combined.trimEnd());
+      lines.push('');
+    }
+
+    // Only npm routes its failure detail to a `_logs/*-debug.log` and prints a
+    // "complete log of this run" pointer; the other PMs surface the cause on
+    // stderr directly (already shown above).
+    if (pm === 'npm') {
+      const logPath = extractNpmLogPath(combined);
+      if (logPath) {
+        lines.push(`Full npm error log: ${logPath}`);
+      } else {
+        lines.push(
+          'npm wrote the failure detail to its debug log — see the ' +
+            '"complete log of this run" path npm printed above, under ' +
+            'your npm cache `_logs/` directory.',
+        );
+      }
+      lines.push('');
+    }
+    lines.push(`Could not install ${PKG}. Common causes:`);
+    lines.push('  • a private-registry auth or proxy issue (check the log above),');
+    lines.push("  • an unresolved peer-dep conflict in this folder's package.json,");
+    lines.push('  • running in a wrapper directory rather than your actual project.');
+    lines.push('');
+  }
+  lines.push('You do NOT need this install to use dxkit. From your project root run:');
+  lines.push(`  ${ONE_SHOT_INIT}`);
+  lines.push(
+    'That scaffolds dxkit directly (the same step this bootstrap runs after ' +
+      'install) without adding it to package.json.',
+  );
+  return lines.join('\n');
+}
+
+module.exports = {
+  PKG,
+  ONE_SHOT_INIT,
+  resolveInitArgs,
+  refuseCwdReason,
+  ensurePackageJson,
+  detectPackageManager,
+  pmBin,
+  windowsQuoteArg,
+  installSpawnPlan,
+  installArgs,
+  resolveInstalledBin,
+  persistLegacyPeerDeps,
+  extractNpmLogPath,
+  formatInstallFailure,
+};

--- a/packages/create-dxkit/package.json
+++ b/packages/create-dxkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/create-dxkit",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "One-command bootstrap for @vyuhlabs/dxkit. Detects your package manager (pnpm/yarn/bun/npm) to add it as a devDependency, then runs `vyuh-dxkit init`.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/packages/create-dxkit/package.json
+++ b/packages/create-dxkit/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "index.js",
+    "lib.js",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1502,6 +1502,25 @@ if [ -n "$RULE14_SELFINVOKE" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# Rule 14, pre-install variant: the create-dxkit bootstrap shim runs BEFORE
+# any dxkit install exists, so a binary-name invocation (`npx vyuh-dxkit`)
+# 404s by construction there — the exact remedy string a Windows customer
+# hit in its install-failure text. Pre-install surfaces use the PACKAGE
+# form (`npx -y @vyuhlabs/dxkit …` / dxkitOneShotCli). The shim is a
+# separate zero-dep package, so it can't import the helper — this grep is
+# its net. Scoped to .js (the code whose strings print in a pre-install
+# context); the package README describes POST-install usage, where the
+# binary form is correct.
+RULE14_CREATE_DXKIT=$(grep -rn --include="*.js" "npx vyuh-dxkit" packages/create-dxkit/ 2>/dev/null \
+  | grep -v "// self-invocation-ok")
+if [ -n "$RULE14_CREATE_DXKIT" ]; then
+  echo "❌ Rule 14 violation: binary-form 'npx vyuh-dxkit' in create-dxkit (pre-install"
+  echo "   context — it 404s there; vyuh-dxkit is a binary name, not a package):"
+  echo "$RULE14_CREATE_DXKIT"
+  echo "   → Use the package form: npx -y @vyuhlabs/dxkit <subcommand>"
+  ERRORS=$((ERRORS + 1))
+fi
+
 # AST tree-lifecycle rule (wave-3 class-fix): repo-scale parsing goes through
 # the scoped withParsedFile(path, fn), never a raw parseFile loop.
 #

--- a/src/loop/demo.ts
+++ b/src/loop/demo.ts
@@ -22,7 +22,7 @@ import type { GuardrailJsonPayload } from '../baseline/check-renderers';
 import { GUARDRAIL_JSON_SCHEMA } from '../baseline/check-renderers';
 import { buildRepairMessage } from './stop-gate';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
-import { dxkitCli } from '../self-invocation';
+import { dxkitCli, dxkitOneShotCli } from '../self-invocation';
 import * as logger from '../logger';
 
 type DemoPair = GuardrailJsonPayload['pairs'][number];
@@ -291,8 +291,11 @@ function printIllustration(reason: 'no-gitleaks' | 'sandbox-failed'): void {
   const { blockMessage } = renderLoopGuardrailDemo();
   if (reason === 'no-gitleaks') {
     logger.warn('gitleaks not installed — showing an illustration, not a real scan.');
+    // One-shot PACKAGE form, not `dxkitCli`: the demo itself runs via one-shot
+    // npx, so the viewer has no dxkit install for a binary-name invocation to
+    // resolve — it would 404 here (the class Rule 14 exists for).
     logger.dim(
-      `  Install it (\`${dxkitCli('tools install')}\`) and re-run to scan a real sandbox.`,
+      `  Install it (\`${dxkitOneShotCli('tools install')}\`) and re-run to scan a real sandbox.`,
     );
   } else {
     logger.warn('Could not run the sandbox scan here — showing an illustration instead.');

--- a/src/self-invocation.ts
+++ b/src/self-invocation.ts
@@ -45,6 +45,22 @@ export function dxkitCli(subcommand = ''): string {
 }
 
 /**
+ * The PRE-INSTALL form: a one-shot npx invocation by PACKAGE name, for
+ * surfaces shown to a user who has NOT installed dxkit anywhere (the demo's
+ * own hints, bootstrap-failure remedies). `dxkitCli` resolves a binary and
+ * therefore 404s in that context — `vyuh-dxkit` is a binary name, not a
+ * package. This is the form the README's demo command itself uses, so it is
+ * guaranteed to work wherever the user already got this far.
+ */
+export const DXKIT_ONE_SHOT_CLI = 'npx -y @vyuhlabs/dxkit';
+
+/** Build a pre-install one-shot invocation string.
+ *  `dxkitOneShotCli('tools install')` → `'npx -y @vyuhlabs/dxkit tools install'`. */
+export function dxkitOneShotCli(subcommand = ''): string {
+  return subcommand ? `${DXKIT_ONE_SHOT_CLI} ${subcommand}` : DXKIT_ONE_SHOT_CLI;
+}
+
+/**
  * The cwd-anchored form for a `.claude/settings.json` hook command
  * (`context-hook`, the loop Stop-gate). A Claude Code hook runs with the
  * AGENT'S current working directory, which can be any subdirectory the

--- a/test/create-dxkit-entrypoint.test.ts
+++ b/test/create-dxkit-entrypoint.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Integration tests for the `@vyuhlabs/create-dxkit` ENTRY POINT — the
+ * first command a new user runs (`npm init @vyuhlabs/dxkit`).
+ *
+ * The pure-helper suite (`create-dxkit.test.ts`) pins decision logic; it
+ * structurally CANNOT catch orchestration bugs in the `require.main`
+ * block — the shipped Windows EINVAL first-run failure lived
+ * exactly there (an un-checked `spawnSync(...).error` read as a phantom
+ * "peer-dep conflict"). So this suite runs the REAL shim as a child
+ * process against fixture directories, driving every branch:
+ *
+ *   - home-directory refusal (nothing written, exit 1)
+ *   - happy path (fake npm ok → init bin invoked with forwarded args)
+ *   - ERESOLVE retry (fails strict, succeeds with --legacy-peer-deps,
+ *     persists .npmrc)
+ *   - both installs fail (escape hatch by PACKAGE name, debug-log pointer)
+ *   - PM spawn failure (honest "never ran" message, no peer-dep story)
+ *
+ * npm itself is stubbed via `npm_execpath` — the same mechanism the shim
+ * uses in production (npm always sets it for processes it launches), so
+ * the spawn path exercised here IS the production path, on every OS
+ * including Windows (this file runs in the windows first-run smoke job).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const ENTRY = path.resolve(__dirname, '..', 'packages', 'create-dxkit', 'index.js');
+
+let tmp: string;
+let fixture: string; // the "project" cwd
+let stubs: string; // fake npm + logs live here, outside the project
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'create-dxkit-e2e-'));
+  fixture = path.join(tmp, 'project');
+  stubs = path.join(tmp, 'stubs');
+  fs.mkdirSync(fixture, { recursive: true });
+  fs.mkdirSync(stubs, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/**
+ * A scriptable fake npm, pointed at via `npm_execpath`. Behavior comes
+ * from FAKE_NPM_MODE:
+ *   ok               → append argv to FAKE_NPM_LOG, exit 0
+ *   fail-then-ok     → exit 1 with ERESOLVE stderr unless argv contains
+ *                      --legacy-peer-deps (then exit 0)
+ *   fail             → always exit 1, stderr carries a debug-log pointer
+ * Must end in .cjs/.js so the shim's execpath sniff accepts it.
+ */
+function writeFakeNpm(): string {
+  const stubPath = path.join(stubs, 'fake-npm.cjs');
+  fs.writeFileSync(
+    stubPath,
+    `
+const fs = require('fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_NPM_LOG, JSON.stringify(args) + '\\n');
+const mode = process.env.FAKE_NPM_MODE || 'ok';
+if (mode === 'ok') process.exit(0);
+if (mode === 'fail-then-ok') {
+  if (args.includes('--legacy-peer-deps')) process.exit(0);
+  process.stderr.write('npm error code ERESOLVE\\nnpm error peer dep conflict\\n');
+  process.exit(1);
+}
+process.stderr.write(
+  'npm error code E403\\n' +
+  'npm error A complete log of this run can be found in: /fake/_logs/2026-07-23-debug-0.log\\n');
+process.exit(1);
+`,
+  );
+  return stubPath;
+}
+
+/** Plant a fake installed @vyuhlabs/dxkit whose bin records its argv.
+ *  `withExports` mirrors the real package: an exports map that does NOT
+ *  expose ./package.json (the shape that breaks require.resolve subpath
+ *  resolution — the direct-path route must still find the bin). */
+function plantInstalledDxkit(withExports = true): string {
+  const pkgDir = path.join(fixture, 'node_modules', '@vyuhlabs', 'dxkit');
+  fs.mkdirSync(path.join(pkgDir, 'dist'), { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({
+      name: '@vyuhlabs/dxkit',
+      version: '0.0.0-test',
+      bin: { 'vyuh-dxkit': './dist/index.js' },
+      ...(withExports ? { exports: { '.': './dist/index.js' } } : {}),
+    }),
+  );
+  fs.writeFileSync(
+    path.join(pkgDir, 'dist', 'index.js'),
+    `require('fs').appendFileSync(process.env.FAKE_INIT_LOG, JSON.stringify(process.argv.slice(2)) + '\\n');\n`,
+  );
+  return pkgDir;
+}
+
+interface RunOpts {
+  args?: string[];
+  cwd?: string;
+  mode?: string;
+  home?: string;
+  extraEnv?: Record<string, string | undefined>;
+}
+
+function runShim(opts: RunOpts = {}) {
+  const npmLog = path.join(stubs, 'npm-calls.log');
+  const initLog = path.join(stubs, 'init-calls.log');
+  const result = spawnSync(process.execPath, [ENTRY, ...(opts.args ?? [])], {
+    cwd: opts.cwd ?? fixture,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      npm_execpath: writeFakeNpm(),
+      FAKE_NPM_MODE: opts.mode ?? 'ok',
+      FAKE_NPM_LOG: npmLog,
+      FAKE_INIT_LOG: initLog,
+      // Cover both the POSIX and Windows homedir sources.
+      HOME: opts.home ?? path.join(tmp, 'not-home'),
+      USERPROFILE: opts.home ?? path.join(tmp, 'not-home'),
+      ...(opts.extraEnv ?? {}),
+    },
+  });
+  const readLog = (p: string): string[][] =>
+    fs.existsSync(p)
+      ? fs
+          .readFileSync(p, 'utf8')
+          .trim()
+          .split('\n')
+          .filter(Boolean)
+          .map((l) => JSON.parse(l) as string[])
+      : [];
+  return { ...result, npmCalls: readLog(npmLog), initCalls: readLog(initLog) };
+}
+
+describe('create-dxkit entry point (child-process integration)', () => {
+  it('refuses to run in the home directory and writes NOTHING', () => {
+    const home = path.join(tmp, 'home');
+    fs.mkdirSync(home);
+    const r = runShim({ cwd: home, home });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('home directory');
+    expect(r.stderr).toContain('cd into the repository');
+    // The refusal must come BEFORE the package.json seed — the shipped
+    // failure left a stray package.json in the user's home folder.
+    expect(fs.existsSync(path.join(home, 'package.json'))).toBe(false);
+    expect(r.npmCalls).toHaveLength(0);
+  });
+
+  it('happy path: seeds package.json, installs via npm_execpath, runs init with default args', () => {
+    plantInstalledDxkit();
+    const r = runShim();
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(path.join(fixture, 'package.json'))).toBe(true);
+    expect(r.npmCalls).toHaveLength(1);
+    expect(r.npmCalls[0]).toEqual(['install', '--save-dev', '--no-audit', '@vyuhlabs/dxkit']);
+    expect(r.initCalls).toHaveLength(1);
+    expect(r.initCalls[0]).toEqual(['init', '--full', '--yes']);
+  });
+
+  it('forwards user args to init verbatim', () => {
+    plantInstalledDxkit();
+    const r = runShim({ args: ['--claude-loop', '--yes'] });
+    expect(r.status).toBe(0);
+    expect(r.initCalls[0]).toEqual(['init', '--claude-loop', '--yes']);
+  });
+
+  it('finds the installed bin even when the package exports map hides ./package.json', () => {
+    // The real @vyuhlabs/dxkit has an exports map without "./package.json";
+    // a require.resolve-only lookup would throw ERR_PACKAGE_PATH_NOT_EXPORTED
+    // and silently fall back. The direct node_modules path must win.
+    plantInstalledDxkit(true);
+    const r = runShim();
+    expect(r.status).toBe(0);
+    expect(r.initCalls).toHaveLength(1);
+  });
+
+  it('ERESOLVE: retries with --legacy-peer-deps, persists .npmrc, still runs init', () => {
+    plantInstalledDxkit();
+    const r = runShim({ mode: 'fail-then-ok' });
+    expect(r.status).toBe(0);
+    expect(r.npmCalls).toHaveLength(2);
+    expect(r.npmCalls[1]).toContain('--legacy-peer-deps');
+    expect(fs.readFileSync(path.join(fixture, '.npmrc'), 'utf8')).toContain(
+      'legacy-peer-deps=true',
+    );
+    expect(r.initCalls).toHaveLength(1);
+    // The retry line no longer asserts a diagnosis npm never made.
+    expect(r.stdout).not.toMatch(/Peer-dep conflict detected/);
+  });
+
+  it('both installs fail: names the debug log, offers the PACKAGE-form escape hatch, exit 1', () => {
+    const r = runShim({ mode: 'fail' });
+    expect(r.status).toBe(1);
+    expect(r.npmCalls).toHaveLength(2); // strict + legacy retry
+    expect(r.stderr).toContain('Full npm error log: /fake/_logs/2026-07-23-debug-0.log');
+    expect(r.stderr).toContain('npx -y @vyuhlabs/dxkit init --full --yes');
+    expect(r.stderr).not.toMatch(/npx vyuh-dxkit/); // the 404 form, banned
+    expect(r.initCalls).toHaveLength(0);
+  });
+
+  it('PM spawn failure: says npm never ran — no phantom peer-dep diagnosis, no pointless retry', () => {
+    // Strip npm_execpath so the shim must spawn `npm` from PATH — and give it
+    // a PATH with no npm. The spawn itself errors (ENOENT), the class that
+    // used to be misreported as "Peer-dep conflict detected" with empty
+    // stderr. Skipped on win32: shell:true resolution fails differently there
+    // (cmd.exe reports through exit code, covered by the both-fail case).
+    if (process.platform === 'win32') return;
+    const emptyBin = path.join(tmp, 'empty-bin');
+    fs.mkdirSync(emptyBin);
+    const r = runShim({
+      extraEnv: { npm_execpath: undefined, PATH: emptyBin },
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('Could not launch npm at all');
+    expect(r.stderr).toContain('npm never ran');
+    expect(r.stderr).not.toMatch(/peer-dep/i);
+    expect(r.stderr).toContain('npx -y @vyuhlabs/dxkit init --full --yes');
+  });
+
+  it('respects an existing package.json (no reseed) and skips install when dxkit already declared', () => {
+    // Already-declared dxkit still goes through npm (npm dedupes fast); the
+    // shim's job is only to never CLOBBER the manifest.
+    const manifest = JSON.stringify({ name: 'my-app', version: '1.0.0' }, null, 2);
+    fs.writeFileSync(path.join(fixture, 'package.json'), manifest);
+    plantInstalledDxkit();
+    const r = runShim();
+    expect(r.status).toBe(0);
+    const after = JSON.parse(fs.readFileSync(path.join(fixture, 'package.json'), 'utf8'));
+    expect(after.name).toBe('my-app');
+  });
+});

--- a/test/create-dxkit-entrypoint.test.ts
+++ b/test/create-dxkit-entrypoint.test.ts
@@ -112,11 +112,19 @@ interface RunOpts {
 function runShim(opts: RunOpts = {}) {
   const npmLog = path.join(stubs, 'npm-calls.log');
   const initLog = path.join(stubs, 'init-calls.log');
+  // Strip EVERY case variant of npm_execpath from the inherited env before
+  // injecting the stub. On Windows the child's env lookup is case-insensitive
+  // and an UPPERCASE variant (present in GitHub's Windows runner env) shadows
+  // a lowercase override — verified empirically: the first CI run of this
+  // suite silently drove REAL registry npm through the shim for 6 minutes.
+  const inherited = Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => k.toLowerCase() !== 'npm_execpath'),
+  );
   const result = spawnSync(process.execPath, [ENTRY, ...(opts.args ?? [])], {
     cwd: opts.cwd ?? fixture,
     encoding: 'utf8',
     env: {
-      ...process.env,
+      ...inherited,
       npm_execpath: writeFakeNpm(),
       FAKE_NPM_MODE: opts.mode ?? 'ok',
       FAKE_NPM_LOG: npmLog,
@@ -136,7 +144,10 @@ function runShim(opts: RunOpts = {}) {
           .filter(Boolean)
           .map((l) => JSON.parse(l) as string[])
       : [];
-  return { ...result, npmCalls: readLog(npmLog), initCalls: readLog(initLog) };
+  // `trace` rides along on every assertion so a CI-only failure shows what
+  // the child actually printed instead of a bare length mismatch.
+  const trace = `shim stdout:\n${result.stdout}\nshim stderr:\n${result.stderr}`;
+  return { ...result, npmCalls: readLog(npmLog), initCalls: readLog(initLog), trace };
 }
 
 describe('create-dxkit entry point (child-process integration)', () => {
@@ -144,30 +155,30 @@ describe('create-dxkit entry point (child-process integration)', () => {
     const home = path.join(tmp, 'home');
     fs.mkdirSync(home);
     const r = runShim({ cwd: home, home });
-    expect(r.status).toBe(1);
+    expect(r.status, r.trace).toBe(1);
     expect(r.stderr).toContain('home directory');
     expect(r.stderr).toContain('cd into the repository');
     // The refusal must come BEFORE the package.json seed — the shipped
     // failure left a stray package.json in the user's home folder.
     expect(fs.existsSync(path.join(home, 'package.json'))).toBe(false);
-    expect(r.npmCalls).toHaveLength(0);
+    expect(r.npmCalls, r.trace).toHaveLength(0);
   });
 
   it('happy path: seeds package.json, installs via npm_execpath, runs init with default args', () => {
     plantInstalledDxkit();
     const r = runShim();
-    expect(r.status).toBe(0);
+    expect(r.status, r.trace).toBe(0);
     expect(fs.existsSync(path.join(fixture, 'package.json'))).toBe(true);
-    expect(r.npmCalls).toHaveLength(1);
+    expect(r.npmCalls, r.trace).toHaveLength(1);
     expect(r.npmCalls[0]).toEqual(['install', '--save-dev', '--no-audit', '@vyuhlabs/dxkit']);
-    expect(r.initCalls).toHaveLength(1);
+    expect(r.initCalls, r.trace).toHaveLength(1);
     expect(r.initCalls[0]).toEqual(['init', '--full', '--yes']);
   });
 
   it('forwards user args to init verbatim', () => {
     plantInstalledDxkit();
     const r = runShim({ args: ['--claude-loop', '--yes'] });
-    expect(r.status).toBe(0);
+    expect(r.status, r.trace).toBe(0);
     expect(r.initCalls[0]).toEqual(['init', '--claude-loop', '--yes']);
   });
 
@@ -177,32 +188,32 @@ describe('create-dxkit entry point (child-process integration)', () => {
     // and silently fall back. The direct node_modules path must win.
     plantInstalledDxkit(true);
     const r = runShim();
-    expect(r.status).toBe(0);
-    expect(r.initCalls).toHaveLength(1);
+    expect(r.status, r.trace).toBe(0);
+    expect(r.initCalls, r.trace).toHaveLength(1);
   });
 
   it('ERESOLVE: retries with --legacy-peer-deps, persists .npmrc, still runs init', () => {
     plantInstalledDxkit();
     const r = runShim({ mode: 'fail-then-ok' });
-    expect(r.status).toBe(0);
-    expect(r.npmCalls).toHaveLength(2);
+    expect(r.status, r.trace).toBe(0);
+    expect(r.npmCalls, r.trace).toHaveLength(2);
     expect(r.npmCalls[1]).toContain('--legacy-peer-deps');
     expect(fs.readFileSync(path.join(fixture, '.npmrc'), 'utf8')).toContain(
       'legacy-peer-deps=true',
     );
-    expect(r.initCalls).toHaveLength(1);
+    expect(r.initCalls, r.trace).toHaveLength(1);
     // The retry line no longer asserts a diagnosis npm never made.
     expect(r.stdout).not.toMatch(/Peer-dep conflict detected/);
   });
 
   it('both installs fail: names the debug log, offers the PACKAGE-form escape hatch, exit 1', () => {
     const r = runShim({ mode: 'fail' });
-    expect(r.status).toBe(1);
-    expect(r.npmCalls).toHaveLength(2); // strict + legacy retry
+    expect(r.status, r.trace).toBe(1);
+    expect(r.npmCalls, r.trace).toHaveLength(2); // strict + legacy retry
     expect(r.stderr).toContain('Full npm error log: /fake/_logs/2026-07-23-debug-0.log');
     expect(r.stderr).toContain('npx -y @vyuhlabs/dxkit init --full --yes');
     expect(r.stderr).not.toMatch(/npx vyuh-dxkit/); // the 404 form, banned
-    expect(r.initCalls).toHaveLength(0);
+    expect(r.initCalls, r.trace).toHaveLength(0);
   });
 
   it('PM spawn failure: says npm never ran — no phantom peer-dep diagnosis, no pointless retry', () => {
@@ -217,7 +228,7 @@ describe('create-dxkit entry point (child-process integration)', () => {
     const r = runShim({
       extraEnv: { npm_execpath: undefined, PATH: emptyBin },
     });
-    expect(r.status).toBe(1);
+    expect(r.status, r.trace).toBe(1);
     expect(r.stderr).toContain('Could not launch npm at all');
     expect(r.stderr).toContain('npm never ran');
     expect(r.stderr).not.toMatch(/peer-dep/i);
@@ -231,7 +242,7 @@ describe('create-dxkit entry point (child-process integration)', () => {
     fs.writeFileSync(path.join(fixture, 'package.json'), manifest);
     plantInstalledDxkit();
     const r = runShim();
-    expect(r.status).toBe(0);
+    expect(r.status, r.trace).toBe(0);
     const after = JSON.parse(fs.readFileSync(path.join(fixture, 'package.json'), 'utf8'));
     expect(after.name).toBe('my-app');
   });

--- a/test/create-dxkit.test.ts
+++ b/test/create-dxkit.test.ts
@@ -1,11 +1,12 @@
 /**
- * Unit tests for the `@vyuhlabs/create-dxkit` shim's pure helpers.
+ * Unit tests for the `@vyuhlabs/create-dxkit` shim's pure helpers:
+ * arg routing, cwd refusal, package.json seeding, PM detection, the
+ * CVE-2024-27980-safe spawn plan, bin resolution, and failure text.
  *
- * The shim itself shells out to `npm install` and `npx vyuh-dxkit
- * init` — those legs aren't unit-testable without network/install
- * machinery. The decision logic (arg routing, package.json seeding,
- * platform-aware binary names) lives in three exported helpers and
- * IS unit-testable; that's what this file covers.
+ * The shim's ORCHESTRATION (the `require.main` block) is covered by
+ * `create-dxkit-entrypoint.test.ts`, which runs the real entry point
+ * as a child process — the layer where the shipped Windows first-run
+ * break lived and where pure-helper tests are structurally blind.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
@@ -17,19 +18,34 @@ import * as path from 'path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const shim = require('../packages/create-dxkit/index.js') as {
   resolveInitArgs: (argv: string[]) => string[];
+  refuseCwdReason: (cwd: string, homeDir?: string, platform?: NodeJS.Platform) => string | null;
   ensurePackageJson: (cwd: string, fsMod?: typeof fs, pathMod?: typeof path) => { seeded: boolean };
-  npmBin: (platform?: NodeJS.Platform) => string;
-  npxBin: (platform?: NodeJS.Platform) => string;
   persistLegacyPeerDeps: (
     cwd: string,
     fsMod?: typeof fs,
     pathMod?: typeof path,
   ) => { changed: boolean; reason: string };
   extractNpmLogPath: (text: string | null | undefined) => string | null;
-  formatInstallFailure: (opts?: { stderrChunks?: string[]; pm?: string }) => string;
+  formatInstallFailure: (opts?: {
+    stderrChunks?: string[];
+    pm?: string;
+    spawnError?: Error & { code?: string };
+  }) => string;
   detectPackageManager: (cwd: string, fsMod?: typeof fs, pathMod?: typeof path) => string;
   pmBin: (pm: string, platform?: NodeJS.Platform) => string;
+  windowsQuoteArg: (arg: string) => string;
+  installSpawnPlan: (
+    pm: string,
+    pmArgs: string[],
+    env?: Record<string, string | undefined>,
+    platform?: NodeJS.Platform,
+  ) => { cmd: string; args: string[]; shell: boolean };
   installArgs: (pm: string) => string[];
+  resolveInstalledBin: (
+    cwd: string,
+    requireResolve?: (id: string, opts?: { paths: string[] }) => string,
+    fsMod?: typeof fs,
+  ) => string | null;
 };
 
 let tmp: string;
@@ -176,10 +192,27 @@ describe('extractNpmLogPath', () => {
 });
 
 describe('formatInstallFailure', () => {
-  it('never says "above" and always offers the npx-init escape hatch', () => {
+  it('never says "above" and always offers the one-shot npx escape hatch BY PACKAGE NAME', () => {
     const msg = shim.formatInstallFailure({ stderrChunks: [] });
     expect(msg).not.toMatch(/error above/i);
-    expect(msg).toContain('npx vyuh-dxkit init --full --yes');
+    // The remedy fires precisely when no dxkit install exists, so the binary
+    // form (`npx vyuh-dxkit …`) would 404 — the package form must be shown.
+    // The previous version of this test PINNED the 404ing string; the break
+    // was caught in the field.
+    expect(msg).toContain('npx -y @vyuhlabs/dxkit init --full --yes');
+    expect(msg).not.toMatch(/npx vyuh-dxkit/);
+  });
+
+  it('spawn-level failure: says the PM never ran, skips the peer-dep story, keeps the escape hatch', () => {
+    const err = Object.assign(new Error('spawnSync npm.cmd EINVAL'), { code: 'EINVAL' });
+    const msg = shim.formatInstallFailure({ pm: 'npm', spawnError: err });
+    expect(msg).toContain('Could not launch npm at all (EINVAL)');
+    expect(msg).toContain('npm never ran');
+    // No fabricated diagnosis: the install-cause list and debug-log pointer
+    // describe an npm run that never happened.
+    expect(msg).not.toMatch(/peer-dep/i);
+    expect(msg).not.toMatch(/debug log/i);
+    expect(msg).toContain('npx -y @vyuhlabs/dxkit init --full --yes');
   });
 
   it('surfaces captured npm stderr when present', () => {
@@ -214,20 +247,113 @@ describe('formatInstallFailure', () => {
   });
 });
 
-describe('npmBin / npxBin', () => {
-  it('returns plain names on linux', () => {
-    expect(shim.npmBin('linux')).toBe('npm');
-    expect(shim.npxBin('linux')).toBe('npx');
+describe('refuseCwdReason', () => {
+  it('refuses the home directory', () => {
+    const reason = shim.refuseCwdReason('/home/admin', '/home/admin', 'linux');
+    expect(reason).toContain('home directory');
+    expect(reason).toContain('Nothing was written');
   });
 
-  it('returns .cmd-suffixed names on win32', () => {
-    expect(shim.npmBin('win32')).toBe('npm.cmd');
-    expect(shim.npxBin('win32')).toBe('npx.cmd');
+  it('refuses the home directory case-insensitively on win32', () => {
+    const reason = shim.refuseCwdReason('C:\\Users\\Admin', 'c:\\users\\admin', 'win32');
+    expect(reason).toContain('home directory');
   });
 
-  it('returns plain names on darwin', () => {
-    expect(shim.npmBin('darwin')).toBe('npm');
-    expect(shim.npxBin('darwin')).toBe('npx');
+  it('refuses a filesystem root', () => {
+    const reason = shim.refuseCwdReason('/', '/home/admin', 'linux');
+    expect(reason).toContain('filesystem root');
+  });
+
+  it('accepts an ordinary project directory', () => {
+    expect(shim.refuseCwdReason(tmp, '/home/admin', 'linux')).toBeNull();
+    expect(
+      shim.refuseCwdReason('C:\\Users\\Admin\\my-app', 'C:\\Users\\Admin', 'win32'),
+    ).toBeNull();
+  });
+});
+
+describe('installSpawnPlan (the CVE-2024-27980 net)', () => {
+  // Spawning a `.cmd` with `shell: false` throws EINVAL on Node ≥ 18.20.2 /
+  // 20.12.2 / 21.7.3 — the plan must never produce that combination.
+  const npmEnv = { npm_execpath: '/usr/lib/node_modules/npm/bin/npm-cli.js' };
+
+  it('npm with npm_execpath: runs node on npm-cli.js directly — no shell, no .cmd, any OS', () => {
+    for (const platform of ['linux', 'win32', 'darwin'] as const) {
+      const plan = shim.installSpawnPlan('npm', ['install', 'x'], npmEnv, platform);
+      expect(plan.cmd).toBe(process.execPath);
+      expect(plan.args).toEqual([npmEnv.npm_execpath, 'install', 'x']);
+      expect(plan.shell).toBe(false);
+    }
+  });
+
+  it('non-npm PM on win32: .cmd via shell (the only EINVAL-safe way to run a .cmd)', () => {
+    const plan = shim.installSpawnPlan('pnpm', ['add', '-D', 'x'], {}, 'win32');
+    expect(plan.cmd).toBe('pnpm.cmd');
+    expect(plan.shell).toBe(true);
+  });
+
+  it('npm WITHOUT npm_execpath on win32 still avoids shell-less .cmd', () => {
+    const plan = shim.installSpawnPlan('npm', ['install'], {}, 'win32');
+    expect(plan.cmd).toBe('npm.cmd');
+    expect(plan.shell).toBe(true);
+  });
+
+  it('posix without npm_execpath: plain direct spawn', () => {
+    const plan = shim.installSpawnPlan('pnpm', ['add', '-D', 'x'], {}, 'linux');
+    expect(plan).toEqual({ cmd: 'pnpm', args: ['add', '-D', 'x'], shell: false });
+  });
+
+  it('never yields a .cmd command with shell: false, across PMs and platforms', () => {
+    for (const pm of ['npm', 'pnpm', 'yarn', 'bun']) {
+      for (const platform of ['linux', 'win32', 'darwin'] as const) {
+        for (const env of [{}, npmEnv]) {
+          const plan = shim.installSpawnPlan(pm, ['x'], env, platform);
+          if (/\.(cmd|bat)$/i.test(plan.cmd)) expect(plan.shell).toBe(true);
+        }
+      }
+    }
+  });
+});
+
+describe('windowsQuoteArg', () => {
+  it('leaves simple args untouched', () => {
+    expect(shim.windowsQuoteArg('--save-dev')).toBe('--save-dev');
+    expect(shim.windowsQuoteArg('@vyuhlabs/dxkit')).toBe('@vyuhlabs/dxkit');
+  });
+
+  it('quotes args with spaces or shell metacharacters', () => {
+    expect(shim.windowsQuoteArg('a b')).toBe('"a b"');
+    expect(shim.windowsQuoteArg('a&b')).toBe('"a&b"');
+    expect(shim.windowsQuoteArg('a"b')).toBe('"a""b"');
+  });
+});
+
+describe('resolveInstalledBin', () => {
+  it('resolves the installed package bin to an absolute JS path', () => {
+    const pkgDir = path.join(tmp, 'node_modules', '@vyuhlabs', 'dxkit');
+    fs.mkdirSync(path.join(pkgDir, 'dist'), { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({ name: '@vyuhlabs/dxkit', bin: { 'vyuh-dxkit': './dist/index.js' } }),
+    );
+    fs.writeFileSync(path.join(pkgDir, 'dist', 'index.js'), '');
+    const bin = shim.resolveInstalledBin(tmp);
+    expect(bin).toBe(path.join(pkgDir, 'dist', 'index.js'));
+  });
+
+  it('returns null when the package is not installed', () => {
+    expect(shim.resolveInstalledBin(tmp)).toBeNull();
+  });
+
+  it('returns null when the bin entry is missing or its file does not exist', () => {
+    const pkgDir = path.join(tmp, 'node_modules', '@vyuhlabs', 'dxkit');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({ name: '@vyuhlabs/dxkit', bin: { 'vyuh-dxkit': './dist/index.js' } }),
+    );
+    // bin declared but dist/index.js absent
+    expect(shim.resolveInstalledBin(tmp)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What broke (field report, Windows/pwsh)

A new user followed our own printed instructions and hit three shipped defects in sequence:

1. **The demo's gitleaks hint 404s.** `demo loop-guardrail` printed `npx vyuh-dxkit tools install` — the BINARY form, which resolves only through an installed package. The demo's whole audience runs it via one-shot npx with nothing installed, so the printed command fails with npm E404 (Rule 14 class, pre-install context).
2. **`npm init @vyuhlabs/dxkit` can never succeed on a current Windows Node.** Node's CVE-2024-27980 fix (≥ 18.20.2 / 20.12.2 / 21.7.3) makes spawning a `.cmd` with `shell: false` throw EINVAL. The shim's `spawnSync('npm.cmd', …)` hit that on every run; the un-checked `.error` was misread as a phantom "Peer-dep conflict detected" with empty stderr, and `formatInstallFailure` pointed at an npm debug log that npm (never having run) never wrote.
3. **The failure text's escape hatch was itself the 404**: `npx vyuh-dxkit init --full --yes`, shown precisely when no install exists. The unit suite had PINNED this broken string.

Plus: run from a home directory, the shim seeded a `package.json` there.

## The fix

**create-dxkit 0.4.0**
- CVE-2024-27980-safe spawn plan: npm runs via `process.execPath` on `npm_execpath` (the JS entry npm itself provides — no shell, no `.cmd`, any OS); other PMs on Windows use `shell: true` with quoted args; property test pins that no plan ever yields a shell-less `.cmd` spawn.
- Spawn-level failure (`.error`) is reported honestly — "npm never ran" — with no fabricated peer-dep diagnosis and no pointless retry.
- Post-install `init` runs the installed package's bin JS directly (`node <resolved bin>`); direct `node_modules` path first because the real package's `exports` map hides `./package.json` from `require.resolve` (fixture would have passed while production failed).
- Home-directory / filesystem-root refusal before anything is written.
- Escape hatch is now the package form: `npx -y @vyuhlabs/dxkit init --full --yes`.

**dxkit 4.1.6**
- New `dxkitOneShotCli` in `src/self-invocation.ts` (the pre-install sibling of `dxkitCli`); the demo hint uses it.
- `exports` now exposes `./package.json`.
- README funnel reordered: `npm init @vyuhlabs/dxkit -- --claude-loop --yes` is the first command; the demo is the explicit "see it without installing anything" alternative (on a fresh machine the demo degrades to an illustration — gitleaks missing — while `init` provisions its own scanners).

## The nets (so this class cannot ship again)

- **`test/create-dxkit-entrypoint.test.ts`** — the real shim as a child process across every branch: home-dir refusal (nothing written), happy path, arg forwarding, ERESOLVE retry + `.npmrc` persist, both-fail (package-form remedy, debug-log pointer), spawn-failure honesty, exports-restricted bin resolution. npm stubbed through the production `npm_execpath` mechanism.
- **`smoke.yml:first-run-windows`** — both suites on a real Windows Node, then a real first run: the PR's shim launched by real npm (`npm exec --package`, which sets `npm_execpath` exactly as `npm init` does) installing published dxkit into a fresh git fixture. The shipped class was invisible to every Linux job.
- **arch-check Rule 14 extended** to `packages/create-dxkit/*.js` — the binary-form invocation cannot return to a pre-install surface.

All gates green locally: typecheck (src+test), lint, format, arch, slop, cross-ecosystem, docs coverage, `npm pack --dry-run`, full suite (4,663 tests). The interim workaround (`npx -y @vyuhlabs/dxkit init --claude-loop --yes`) was verified end-to-end against published 4.1.5 in a fresh repo before being handed out.

Release notes: `CHANGELOG.md` 4.1.6 + create-dxkit 0.4.0 section. Publish order after merge: `create-dxkit@v0.4.0` tag/release first (its own lane), then `v4.1.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
