### PR TITLE
feat(allowlist): the lapse projection — one home for what expires and what it will cost

### DIFF
--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -1094,6 +1094,30 @@ if [ -n "$ROGUE_COMMENT_FALLBACK" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# Rule 3: expiry day arithmetic lives in src/allowlist/file.ts only.
+# The class (4.3.1, the expiry cliff): "how many days until this lapses" was
+# computed in THREE places — auditAllowlist's buckets, a private daysUntil() in
+# the defer summary (which clamped negatives and read Date.now() directly), and
+# the guardrail's new lapse projection. Two consumers holding different shapes of
+# one concept (a full entry vs the bare expiresAt string) is the 2.30 setup, and
+# a surface that disagrees with doctor about the same date destroys trust in
+# both. daysUntilDate / daysUntilExpiry / SOON_TO_EXPIRE_DAYS are the one home;
+# test/allowlist-expiry-parity.test.ts is the semantic net that grep cannot be.
+ROGUE_EXPIRY_MATH=$(grep -rnE "expiresAt[^;]*(new Date\(|getTime\(\))|(new Date\(|getTime\(\))[^;]*expiresAt" src/ 2>/dev/null \
+  | grep -v "^src/allowlist/file.ts:" \
+  | grep -v "// expiry-daymath-ok" \
+  | grep -v -E ':[[:space:]]*(//|\*)')
+if [ -n "$ROGUE_EXPIRY_MATH" ]; then
+  echo "❌ Expiry day arithmetic outside the one home:"
+  echo "$ROGUE_EXPIRY_MATH"
+  echo "   → Use daysUntilDate(expiresAt, now) / daysUntilExpiry(entry, now) and"
+  echo "     SOON_TO_EXPIRE_DAYS from src/allowlist/file.ts, so every surface"
+  echo "     (doctor, allowlist audit, the guardrail lapse projection) reports"
+  echo "     the same countdown for the same date."
+  echo "   → Annotate '// expiry-daymath-ok' for justified exceptions (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
 # =============================================================================
 # Rule 12: Repo-explore graph queries flow through canonical entry points
 # (added 2026-05-26 with the 2.7 graph foundation).

--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -79,8 +79,10 @@ import { runCommentDefer } from './comment-defer';
 import {
   ALLOWLIST_FILENAME,
   ALL_MODES,
+  SOON_TO_EXPIRE_DAYS,
   addEntry,
   auditAllowlist,
+  daysUntilDate,
   emptyAllowlistFile,
   findEntry,
   isEntryActive,
@@ -506,10 +508,11 @@ export async function runAllowlistDefer(cwd: string, opts: AllowlistDeferOpts): 
   }
 }
 
-/** Whole days from today (UTC) to an ISO date — for the defer summary line. */
+/** Whole days from today (UTC) to an ISO date — for the defer summary line.
+ *  Delegates to the ONE day-math home; the clamp is display-only (a defer
+ *  window is always in the future, so it never fires in practice). */
 function daysUntil(iso: string): number {
-  const ms = new Date(`${iso}T00:00:00Z`).getTime() - Date.now();
-  return Math.max(0, Math.round(ms / 86_400_000));
+  return Math.max(0, daysUntilDate(iso));
 }
 
 // ─── list ─────────────────────────────────────────────────────────────────
@@ -619,7 +622,7 @@ export async function runAllowlistAudit(cwd: string, opts: AllowlistAuditOpts): 
   }
 
   const total = file.entries.length;
-  const horizon = opts.soonToExpireDays ?? 14;
+  const horizon = opts.soonToExpireDays ?? SOON_TO_EXPIRE_DAYS;
   logger.info(
     `Allowlist audit: ${total} entr${total === 1 ? 'y' : 'ies'} ` +
       `(mode=${file.mode}); soon-to-expire window=${horizon} days`,

--- a/src/allowlist/file.ts
+++ b/src/allowlist/file.ts
@@ -355,16 +355,47 @@ export function isEntryActive(entry: AllowlistEntry, now: Date = new Date()): bo
 }
 
 /**
+ * Days remaining until an ISO `YYYY-MM-DD` expiry date, counted in whole
+ * UTC days from today. Negative means already expired by that many days.
+ *
+ * THE one home for expiry day arithmetic (CLAUDE.md 2.30). Two consumers
+ * hold different shapes of the same concept — the audit path holds a full
+ * `AllowlistEntry`, while the guardrail's per-pair suppression holds only
+ * the `expiresAt` STRING (a lossy projection of the entry) — which is the
+ * exact setup where a second consumer re-derives the arithmetic slightly
+ * differently and the two surfaces disagree about the same date. Both route
+ * here: `daysUntilExpiry` for entries, this function directly for the
+ * projection. Pinned by `test/allowlist-expiry-parity.test.ts`.
+ */
+export function daysUntilDate(expiresAt: string, now: Date = new Date()): number {
+  const expiry = new Date(expiresAt + 'T00:00:00Z');
+  const today = new Date(now.toISOString().slice(0, 10) + 'T00:00:00Z');
+  const msPerDay = 24 * 60 * 60 * 1000;
+  return Math.round((expiry.getTime() - today.getTime()) / msPerDay);
+}
+
+/**
  * Days remaining until an entry expires, or `null` when it has no
  * expiry. Negative values mean already expired by that many days.
  */
 export function daysUntilExpiry(entry: AllowlistEntry, now: Date = new Date()): number | null {
   if (!entry.expiresAt) return null;
-  const expiry = new Date(entry.expiresAt + 'T00:00:00Z');
-  const today = new Date(now.toISOString().slice(0, 10) + 'T00:00:00Z');
-  const msPerDay = 24 * 60 * 60 * 1000;
-  return Math.round((expiry.getTime() - today.getTime()) / msPerDay);
+  return daysUntilDate(entry.expiresAt, now);
 }
+
+/**
+ * The window within which an expiry counts as "soon" — the default for BOTH
+ * the audit buckets (`auditAllowlist`) and the guardrail's lapse projection,
+ * so `doctor`'s "expiring soon" label and the check's warning can never
+ * disagree about which entries are in scope. 14 days: a typical sprint, long
+ * enough that a deferral's owner still has room to act.
+ *
+ * Callers may override per-invocation (`allowlist audit --soon-days`). That
+ * override is guardrail TUNING, not a posture knob — it refines a surface the
+ * repo already has, so it carries no discovery contract (same carve-out as
+ * `confidence` / `largeFileThreshold`).
+ */
+export const SOON_TO_EXPIRE_DAYS = 14;
 
 /** One entry in a soon-to-expire audit bucket, with the days
  *  remaining so callers can render time-to-expiry context. */
@@ -382,7 +413,7 @@ export interface SoonToExpire {
  *   The underlying suppression no longer applies on the next
  *   guardrail run.
  * - `soonToExpire` — entries whose `expiresAt` is within
- *   `soonToExpireDays` (default 14). Customer should review whether
+ *   `soonToExpireDays` (default `SOON_TO_EXPIRE_DAYS`). Customer should review whether
  *   the deferred work is still in plan and either fix the finding,
  *   extend the expiry, or remove the entry.
  * - `missingRationale` — entries with empty / whitespace-only
@@ -411,7 +442,8 @@ export interface AuditReport {
 export interface AuditOptions {
   readonly now?: Date;
   /** Window in days within which `expiresAt` is considered "soon."
-   *  Default 14 — chosen to match a typical sprint cadence. */
+   *  Defaults to `SOON_TO_EXPIRE_DAYS` (the shared constant, so this
+   *  bucket and the guardrail's lapse projection share one horizon). */
   readonly soonToExpireDays?: number;
   /** Set of fingerprints present in the current finding set (the
    *  union of every baseline entry's `id` plus its
@@ -423,7 +455,7 @@ export interface AuditOptions {
 
 export function auditAllowlist(file: AllowlistFile, options: AuditOptions = {}): AuditReport {
   const now = options.now ?? new Date();
-  const horizon = options.soonToExpireDays ?? 14;
+  const horizon = options.soonToExpireDays ?? SOON_TO_EXPIRE_DAYS;
   const expired: AllowlistEntry[] = [];
   const soonToExpire: SoonToExpire[] = [];
   const missingRationale: AllowlistEntry[] = [];

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -71,6 +71,8 @@ import { describeRecallDrift, diffRecall } from './recall';
 import type { RecallDrift } from './recall';
 import { collectAttributionGaps } from './attribution-gap';
 import type { AttributionGap } from './attribution-gap';
+import { collectExpiryProjection } from './expiry-projection';
+import type { ExpiryProjection } from './expiry-projection';
 import { evaluateFlowGateForGuardrail } from './flow-gate-check';
 import type { FlowGateOutcome } from './flow-gate-check';
 import { evaluateSchemaDriftGateForGuardrail } from './schema-drift-gate-check';
@@ -327,6 +329,16 @@ export interface GuardrailCheckResult {
    * mismatch gets. Empty on a healthy run. See `src/baseline/attribution-gap.ts`.
    */
   readonly attributionGaps: ReadonlyArray<AttributionGap>;
+  /**
+   * What this run's ACTIVE allowlist suppressions will do when their windows
+   * expire — how many will block, how many will warn, and how soon. REQUIRED so
+   * a new surface cannot render the check without the projection existing; it
+   * never affects the verdict or the exit code (expiry is already the forcing
+   * function, and blaming an author for someone else's lapsing deferral would be
+   * a false block). Empty `lapsing` on the overwhelming majority of runs, in
+   * which case renderers print nothing. See `src/baseline/expiry-projection.ts`.
+   */
+  readonly suppressionExpiry: ExpiryProjection;
   /** Allowlist entries added / removed between the baseline's
    *  commit SHA and the current working tree. Renderers (the PR
    *  comment markdown in particular) surface this so reviewers
@@ -989,6 +1001,20 @@ export async function runGuardrailCheck(
   // while one exists the run cannot render PASSED.
   const attributionGaps = collectAttributionGaps(filteredPairs, envelopeDrift.recallDrift);
 
+  // The lapse projection: what today's active suppressions will cost when their
+  // windows close. Reads the same pair set the verdict reads (post
+  // --changed-only filter) and the same `now` the suppression decision used, so
+  // a pair cannot be treated as suppressed here and lapsing on a different day.
+  // Disclosure only — it is deliberately absent from `blocks` / `warns` below.
+  const suppressionExpiry = collectExpiryProjection({
+    pairs: filteredPairs,
+    flowGate,
+    schemaDriftGate,
+    dupGate,
+    pairedGate,
+    now,
+  });
+
   return {
     mode,
     ...(baselinePath !== undefined ? { baselinePath } : {}),
@@ -1008,6 +1034,7 @@ export async function runGuardrailCheck(
     warns:
       baseWarns || flowGate.warns || schemaDriftGate.warns || dupGate.warns || pairedGate.warns,
     attributionGaps,
+    suppressionExpiry,
     allowlistDelta,
     refExcludedKinds,
     // Capture-deferral (Rule 20): classes the committed baseline could not

--- a/src/baseline/expiry-projection.ts
+++ b/src/baseline/expiry-projection.ts
@@ -1,0 +1,304 @@
+/**
+ * The lapse projection — what a check run's ACTIVE allowlist suppressions will
+ * do to this repo when their windows expire, computed in ONE place and carried
+ * on the result so every renderer says the same thing.
+ *
+ * # Why this exists (the class it closes)
+ *
+ * Two individually-correct mechanisms compose into a cliff. An allowlist entry
+ * deliberately holds its finding OUT of the baseline (`create.ts` excludes
+ * actively-suppressed findings, so an accepted finding can never grandfather
+ * itself in and defeat its own expiry), and the scheduled refresh is therefore
+ * structurally forbidden from absorbing it. So on the day a deferral lapses,
+ * every finding it was holding back returns AT ONCE — with no warning as the
+ * date approached and no decision surface at the lapse. Observed on a real
+ * repo: 21 findings deferred for six days, nothing remediated, and on expiry
+ * day 9 high dependency advisories blocked every open PR.
+ *
+ * The computation was already there and simply never delivered. `auditAllowlist`
+ * has computed `expired` + `soonToExpire` with `daysRemaining` since the
+ * allowlist shipped — but its only consumers were `doctor` and
+ * `allowlist audit`, two commands nobody runs on a normal day. The warning was
+ * written, correct, and invisible. This module puts it where every author and
+ * reviewer already looks: the guardrail check's own output.
+ *
+ * # What it adds over the audit buckets
+ *
+ * The audit answers "which entries expire soon" from the allowlist FILE alone —
+ * which is all it can see, so it cannot say what the lapse will COST. The check
+ * can: it holds each suppressed pair's classification and each gate finding's
+ * verdict, so it knows which lapses will BLOCK and which will merely warn. That
+ * is the consequence half of the concept, and it lives here.
+ *
+ * Read it as "if these lapsed today" — not a prophecy. The finding is
+ * re-classified on the run after the lapse, against that day's policy, recall
+ * state, and code. A finding that gets fixed in the meantime never returns at
+ * all. The projection is exact about today's tier rules and honest that the
+ * lapse date is the only thing it is predicting.
+ *
+ * # The contract
+ *
+ *   - The expiry horizon and the day arithmetic come from the ONE home,
+ *     `src/allowlist/file.ts` (`SOON_TO_EXPIRE_DAYS` / `daysUntilDate`) — the
+ *     same functions `auditAllowlist` uses, so `doctor`'s "next in Nd" label and
+ *     the check's warning can never disagree about the same date. Pinned by
+ *     `test/allowlist-expiry-parity.test.ts` (CLAUDE.md 2.30: two consumers
+ *     holding different shapes of one concept get a parity test, not just an
+ *     arch rule — the check side holds only the `expiresAt` STRING, a lossy
+ *     projection of the entry).
+ *   - EVERY suppression source is covered, not just the matcher pairs: the four
+ *     additive gates (flow, schema-drift, seam-dup, paired-change) each carry
+ *     their own `suppressed[]` with its own `expiresAt`, and a projection that
+ *     read pairs alone would warn about a lapsing dep-vuln while staying silent
+ *     about a lapsing flow breakage on the same day. One collector, five
+ *     sources.
+ *   - `GuardrailCheckResult.suppressionExpiry` is a REQUIRED field, so a new
+ *     surface cannot render the check without it being computed.
+ *   - It NEVER blocks and never changes a verdict. Expiry is already the forcing
+ *     function; this is disclosure, on the `GateFailure` discipline — a
+ *     fail-open surface stays fail-open, it just always says why.
+ */
+
+import { SOON_TO_EXPIRE_DAYS, daysUntilDate } from '../allowlist/file';
+
+/** Which surface a lapsing suppression came from. */
+export type LapseSource = 'finding' | 'flow' | 'schema-drift' | 'duplication' | 'paired-change';
+
+/** What the lapse would do, under today's tier rules. `info` is
+ *  disclosure-only — it neither blocks nor warns, so it never counts toward
+ *  the projection's totals. */
+export type LapseConsequence = 'block' | 'warn' | 'info';
+
+/** One active suppression whose window closes inside the horizon. */
+export interface LapsingSuppression {
+  readonly source: LapseSource;
+  /** The suppressed finding's fingerprint — the allowlist entry's key, so a
+   *  reader can go straight to the entry that defers it. */
+  readonly fingerprint: string;
+  /** The allowlist category the deferral was filed under. */
+  readonly category: string;
+  /** ISO `YYYY-MM-DD`. */
+  readonly expiresAt: string;
+  /** Whole UTC days from today, via the one day-math home. Always >= 0: an
+   *  already-expired entry does not suppress, so it cannot appear here. */
+  readonly daysRemaining: number;
+  readonly consequence: LapseConsequence;
+  /** Compact locator for the renderers — built here so all three surfaces
+   *  name the same finding the same way. */
+  readonly subject: string;
+}
+
+/** The whole projection for one check run. */
+export interface ExpiryProjection {
+  /** The horizon this projection used, echoed so a renderer can state the
+   *  window it is reporting over rather than assuming the default. */
+  readonly horizonDays: number;
+  /** Lapsing suppressions, soonest first, then blocks before warns (the most
+   *  actionable line reads first). */
+  readonly lapsing: ReadonlyArray<LapsingSuppression>;
+  /** How many would block. The number that makes this worth reading. */
+  readonly willBlock: number;
+  /** How many would warn. */
+  readonly willWarn: number;
+  /** Days until the soonest lapse; absent when nothing lapses in the horizon. */
+  readonly nextLapseDays?: number;
+}
+
+/** The minimal suppression shape every source shares — structural, so this
+ *  module imports no gate (they are all reached from `check.ts`, which imports
+ *  this). */
+interface SourceSuppression {
+  readonly fingerprint: string;
+  readonly category: string;
+  readonly expiresAt?: string;
+}
+
+/** The minimal pair shape the collector reads. Structural for the same reason
+ *  `attribution-gap.ts` is: `check.ts` imports this module. */
+interface LapseSourcePair {
+  readonly kind: string;
+  readonly classification: { readonly blocks: boolean; readonly warns: boolean };
+  readonly file?: string;
+  readonly line?: number;
+  readonly suppressedByAllowlist?: SourceSuppression;
+}
+
+/** The gate slices the collector reads — each gate's suppressions plus enough
+ *  of the underlying finding to name it and know its verdict. */
+interface LapseSourceGates {
+  readonly flowGate?: {
+    readonly suppressed?: ReadonlyArray<
+      SourceSuppression & {
+        readonly finding: {
+          readonly method: string;
+          readonly path: string;
+          readonly verdict: 'block' | 'warn';
+        };
+      }
+    >;
+  };
+  readonly schemaDriftGate?: {
+    readonly suppressed?: ReadonlyArray<
+      SourceSuppression & {
+        readonly finding: {
+          readonly changeClass: string;
+          readonly model: string;
+          readonly field: string | null;
+          readonly verdict: 'block' | 'warn' | 'info';
+        };
+      }
+    >;
+  };
+  readonly dupGate?: {
+    readonly suppressed?: ReadonlyArray<
+      SourceSuppression & {
+        readonly finding: {
+          readonly anchors: readonly [{ readonly symbol: string }, { readonly symbol: string }];
+        };
+      }
+    >;
+  };
+  readonly pairedGate?: {
+    readonly suppressed?: ReadonlyArray<
+      SourceSuppression & {
+        readonly finding: { readonly check: string; readonly blocking: boolean };
+      }
+    >;
+  };
+}
+
+export interface ExpiryProjectionInput extends LapseSourceGates {
+  readonly pairs: ReadonlyArray<LapseSourcePair>;
+  /** The check's clock — the SAME `now` the suppression decision used, so a
+   *  run cannot treat an entry as active and then compute its lapse against a
+   *  different day. */
+  readonly now: Date;
+  /** Override the horizon (guardrail tuning). Defaults to the shared
+   *  `SOON_TO_EXPIRE_DAYS`. */
+  readonly horizonDays?: number;
+}
+
+/**
+ * Collect every active suppression lapsing inside the horizon, across all five
+ * sources, with what the lapse would cost. Pure; ordering is stable (soonest
+ * first, blocks before warns, then by subject).
+ */
+export function collectExpiryProjection(input: ExpiryProjectionInput): ExpiryProjection {
+  const horizonDays = input.horizonDays ?? SOON_TO_EXPIRE_DAYS;
+  const lapsing: LapsingSuppression[] = [];
+
+  const consider = (
+    source: LapseSource,
+    s: SourceSuppression,
+    consequence: LapseConsequence,
+    subject: string,
+  ): void => {
+    // A non-expiring category (`false-positive`, `test-fixture`,
+    // `mitigated-externally`) never lapses, so it is not a decision waiting to
+    // happen — it stays out.
+    if (!s.expiresAt) return;
+    const daysRemaining = daysUntilDate(s.expiresAt, input.now);
+    if (daysRemaining < 0 || daysRemaining > horizonDays) return;
+    lapsing.push({
+      source,
+      fingerprint: s.fingerprint,
+      category: s.category,
+      expiresAt: s.expiresAt,
+      daysRemaining,
+      consequence,
+      subject,
+    });
+  };
+
+  for (const p of input.pairs) {
+    const s = p.suppressedByAllowlist;
+    if (!s) continue;
+    // Suppression is only consulted for a pair that blocks or warns, so one of
+    // the two holds. Read the classification rather than re-deriving the tier:
+    // it already folded in the policy's block rules and the custom-check
+    // `blocking: false` intent (CLAUDE.md 2.30 — no second tier table).
+    const consequence: LapseConsequence = p.classification.blocks ? 'block' : 'warn';
+    const where = p.file ? `${p.file}${p.line !== undefined ? `:${p.line}` : ''}` : undefined;
+    consider('finding', s, consequence, where ? `${p.kind} ${where}` : p.kind);
+  }
+
+  for (const s of input.flowGate?.suppressed ?? []) {
+    // The gate applies its posture (a `warn`-mode gate demotes every finding)
+    // BEFORE partitioning off the suppressions, so the verdict carried here is
+    // the effective one, not the pre-posture one.
+    consider('flow', s, s.finding.verdict, `${s.finding.method} ${s.finding.path}`);
+  }
+
+  for (const s of input.schemaDriftGate?.suppressed ?? []) {
+    const target = s.finding.field ? `${s.finding.model}.${s.finding.field}` : s.finding.model;
+    consider('schema-drift', s, s.finding.verdict, `${s.finding.changeClass} ${target}`);
+  }
+
+  for (const s of input.dupGate?.suppressed ?? []) {
+    // A lone duplicate never blocks — the seam gate is warn-tier by design.
+    const [a, b] = s.finding.anchors;
+    consider('duplication', s, 'warn', `${a.symbol} / ${b.symbol}`);
+  }
+
+  for (const s of input.pairedGate?.suppressed ?? []) {
+    consider('paired-change', s, s.finding.blocking ? 'block' : 'warn', s.finding.check);
+  }
+
+  const rank: Record<LapseConsequence, number> = { block: 0, warn: 1, info: 2 };
+  lapsing.sort(
+    (x, y) =>
+      x.daysRemaining - y.daysRemaining ||
+      rank[x.consequence] - rank[y.consequence] ||
+      x.subject.localeCompare(y.subject) ||
+      x.fingerprint.localeCompare(y.fingerprint),
+  );
+
+  const willBlock = lapsing.filter((l) => l.consequence === 'block').length;
+  const willWarn = lapsing.filter((l) => l.consequence === 'warn').length;
+  return {
+    horizonDays,
+    lapsing,
+    willBlock,
+    willWarn,
+    ...(lapsing.length > 0 ? { nextLapseDays: lapsing[0]!.daysRemaining } : {}),
+  };
+}
+
+/** One line for a lapsing suppression, shared by every renderer (Rule 2). */
+export function describeLapsingSuppression(l: LapsingSuppression): string {
+  const when = l.daysRemaining === 0 ? 'today' : `in ${l.daysRemaining}d`;
+  const effect =
+    l.consequence === 'block'
+      ? 'will BLOCK'
+      : l.consequence === 'warn'
+        ? 'will warn'
+        : 'disclosure';
+  return `${l.subject} — ${l.category} expires ${l.expiresAt} (${when}), ${effect}`;
+}
+
+/**
+ * The headline for a projection, or `undefined` when nothing lapses in the
+ * horizon (the renderers print nothing at all in that case — an empty section
+ * is noise on the overwhelming majority of runs).
+ */
+export function describeExpiryProjection(p: ExpiryProjection): string | undefined {
+  if (p.lapsing.length === 0) return undefined;
+  const n = p.lapsing.length;
+  const when = p.nextLapseDays === 0 ? 'today' : `in ${p.nextLapseDays}d`;
+  const consequence =
+    p.willBlock > 0
+      ? `${p.willBlock} will BLOCK` + (p.willWarn > 0 ? `, ${p.willWarn} will warn` : '')
+      : p.willWarn > 0
+        ? `${p.willWarn} will warn`
+        : 'none will block or warn';
+  return (
+    `${n} allowlist suppression${n === 1 ? '' : 's'} expire within ${p.horizonDays} days ` +
+    `(next ${when}); when they lapse, ${consequence}`
+  );
+}
+
+/** The remedy every projection shares — one string so the three renderers
+ *  agree. Never a block, so it reads as a choice, not an ultimatum. */
+export const EXPIRY_PROJECTION_REMEDY =
+  'fix the underlying findings before the window closes, or run ' +
+  '`vyuh-dxkit allowlist audit` to review and extend the ones still in plan';

--- a/test/allowlist-expiry-parity.test.ts
+++ b/test/allowlist-expiry-parity.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import {
+  auditAllowlist,
+  daysUntilDate,
+  daysUntilExpiry,
+  SOON_TO_EXPIRE_DAYS,
+  type AllowlistEntry,
+  type AllowlistFile,
+} from '../src/allowlist/file';
+import { allowlistSuppressionFor } from '../src/baseline/allowlist-match';
+import { collectExpiryProjection } from '../src/baseline/expiry-projection';
+import type { BaselineEntry } from '../src/baseline/types';
+import type { IdentityKind } from '../src/baseline/producers';
+
+/**
+ * PARITY: the allowlist audit's "expiring soon" buckets vs the guardrail
+ * check's lapse projection.
+ *
+ * One concept — "which suppressions are about to lapse, and in how many days" —
+ * with two consumers holding DIFFERENT shapes of it (CLAUDE.md 2.30). The audit
+ * side (`doctor`, `allowlist audit`) walks full `AllowlistEntry` objects. The
+ * check side walks per-finding suppressions that carry only the `expiresAt`
+ * STRING — a lossy projection of the entry — which is exactly the setup where
+ * the second consumer re-derives the arithmetic slightly differently (an
+ * off-by-one on the inclusive boundary, a local-vs-UTC day, a horizon default
+ * that drifted from 14) and the two surfaces start disagreeing about the same
+ * date. Grep cannot see that; only running both on shared fixtures can.
+ *
+ * So: build ONE fixture, drive BOTH consumers through their real entry points,
+ * and assert they agree on membership and on every day count.
+ */
+
+const NOW = new Date('2026-07-29T12:00:00Z');
+
+function entry(fingerprint: string, kind: IdentityKind, expiresAt?: string): AllowlistEntry {
+  return {
+    fingerprint,
+    kind,
+    category: expiresAt ? 'deferred' : 'false-positive',
+    reason: 'time-boxed pending dependency remediation',
+    addedBy: 'r@example.com',
+    addedAt: '2026-07-22',
+    ...(expiresAt ? { expiresAt } : {}),
+  } as AllowlistEntry;
+}
+
+function fileOf(entries: AllowlistEntry[]): AllowlistFile {
+  return { schemaVersion: 'dxkit-allowlist/v1', mode: 'full', entries };
+}
+
+function anchor(id: string, kind: IdentityKind): BaselineEntry {
+  return { id, kind } as unknown as BaselineEntry;
+}
+
+/**
+ * The check side, built the way `check.ts` builds it: resolve each finding's
+ * suppression through the real `allowlistSuppressionFor` (which is what drops
+ * the already-expired entries), then project. Anything the projection sees, it
+ * saw through the production path.
+ */
+function projectionFor(file: AllowlistFile, now: Date, horizonDays?: number) {
+  const pairs = file.entries.map((e) => {
+    const suppression = allowlistSuppressionFor(file, anchor(e.fingerprint, e.kind), now);
+    return {
+      kind: e.kind as string,
+      classification: { blocks: true, warns: false },
+      ...(suppression ? { suppressedByAllowlist: suppression } : {}),
+    };
+  });
+  return collectExpiryProjection({
+    pairs,
+    now,
+    ...(horizonDays !== undefined ? { horizonDays } : {}),
+  });
+}
+
+/** The audit side's soon-to-expire bucket, keyed for comparison. */
+function auditSoon(file: AllowlistFile, now: Date, soonToExpireDays?: number) {
+  const report = auditAllowlist(file, {
+    now,
+    ...(soonToExpireDays !== undefined ? { soonToExpireDays } : {}),
+  });
+  return new Map(report.soonToExpire.map((s) => [s.entry.fingerprint, s.daysRemaining]));
+}
+
+function projectionDays(file: AllowlistFile, now: Date, horizonDays?: number) {
+  return new Map(
+    projectionFor(file, now, horizonDays).lapsing.map((l) => [l.fingerprint, l.daysRemaining]),
+  );
+}
+
+// A fixture spanning every interesting position relative to the horizon and the
+// inclusive boundaries — modelled on the real incident (a batch deferred on
+// 07-22 with a six-day window) plus the edges that an independent
+// re-implementation gets wrong.
+const FIXTURE = fileOf([
+  entry('a000000000000000', 'dep-vuln', '2026-07-29'), // expires TODAY — still suppresses
+  entry('b000000000000000', 'dep-vuln', '2026-07-30'), // tomorrow
+  entry('c000000000000000', 'secret', '2026-08-05'), // inside the horizon
+  entry('d000000000000000', 'code', '2026-08-12'), // exactly ON the horizon (14d)
+  entry('e000000000000000', 'code', '2026-08-13'), // one day PAST the horizon
+  entry('f000000000000000', 'code', '2026-06-01'), // already expired
+  entry('0000000000000000', 'code'), // no expiry at all
+]);
+
+describe('allowlist expiry parity — audit buckets vs the check projection', () => {
+  it('agrees on membership and on every day count, at the default horizon', () => {
+    const audit = auditSoon(FIXTURE, NOW);
+    const projected = projectionDays(FIXTURE, NOW);
+
+    expect([...projected.keys()].sort()).toEqual([...audit.keys()].sort());
+    for (const [fingerprint, days] of audit) {
+      expect(projected.get(fingerprint)).toBe(days);
+    }
+    // Positive control: the fixture must actually exercise the horizon, or the
+    // assertion above passes on two empty sets.
+    expect(audit.size).toBe(4);
+    expect([...audit.keys()].sort()).toEqual([
+      'a000000000000000',
+      'b000000000000000',
+      'c000000000000000',
+      'd000000000000000',
+    ]);
+  });
+
+  it('agrees at a widened horizon — the override reaches both consumers', () => {
+    const audit = auditSoon(FIXTURE, NOW, 30);
+    const projected = projectionDays(FIXTURE, NOW, 30);
+    expect([...projected.keys()].sort()).toEqual([...audit.keys()].sort());
+    for (const [fingerprint, days] of audit) expect(projected.get(fingerprint)).toBe(days);
+    // The entry one day past the default horizon is now in scope on BOTH sides.
+    expect(audit.has('e000000000000000')).toBe(true);
+    expect(projected.has('e000000000000000')).toBe(true);
+  });
+
+  it('agrees at a narrowed horizon', () => {
+    const audit = auditSoon(FIXTURE, NOW, 1);
+    const projected = projectionDays(FIXTURE, NOW, 1);
+    expect([...projected.keys()].sort()).toEqual([...audit.keys()].sort());
+    expect(audit.size).toBe(2); // today + tomorrow only
+  });
+
+  it('shares one horizon default, so neither side can drift from 14', () => {
+    expect(SOON_TO_EXPIRE_DAYS).toBe(14);
+    expect(auditSoon(FIXTURE, NOW).size).toBe(auditSoon(FIXTURE, NOW, SOON_TO_EXPIRE_DAYS).size);
+    expect(projectionDays(FIXTURE, NOW).size).toBe(
+      projectionDays(FIXTURE, NOW, SOON_TO_EXPIRE_DAYS).size,
+    );
+  });
+
+  it('excludes the already-expired entry from BOTH sides, for the two different reasons', () => {
+    // Audit: it lands in `expired`, never in `soonToExpire`.
+    const report = auditAllowlist(FIXTURE, { now: NOW });
+    expect(report.expired.map((e) => e.fingerprint)).toEqual(['f000000000000000']);
+    expect(report.soonToExpire.map((s) => s.entry.fingerprint)).not.toContain('f000000000000000');
+    // Check: an expired entry does not suppress at all, so nothing reaches the
+    // projection. Same answer, arrived at honestly from each side's own data.
+    expect(projectionDays(FIXTURE, NOW).has('f000000000000000')).toBe(false);
+  });
+
+  it('excludes the never-expiring entry from both sides', () => {
+    expect(auditSoon(FIXTURE, NOW).has('0000000000000000')).toBe(false);
+    expect(projectionDays(FIXTURE, NOW).has('0000000000000000')).toBe(false);
+  });
+
+  it('routes both consumers through the one day-math home', () => {
+    // `daysUntilExpiry` (entry-shaped, the audit side) and `daysUntilDate`
+    // (string-shaped, the projection side) are the same arithmetic. If a future
+    // edit forks them, the membership assertions above still catch it — this
+    // just names the shared primitive.
+    for (const e of FIXTURE.entries) {
+      if (!e.expiresAt) continue;
+      expect(daysUntilExpiry(e, NOW)).toBe(daysUntilDate(e.expiresAt, NOW));
+    }
+    // Whole UTC days regardless of the wall-clock time inside the day: a late
+    // evening run and an early morning run must report the same countdown.
+    for (const at of ['2026-07-29T00:00:01Z', '2026-07-29T23:59:59Z']) {
+      expect(daysUntilDate('2026-08-05', new Date(at))).toBe(7);
+    }
+  });
+});

--- a/test/baseline/expiry-projection.test.ts
+++ b/test/baseline/expiry-projection.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collectExpiryProjection,
+  describeExpiryProjection,
+  describeLapsingSuppression,
+  EXPIRY_PROJECTION_REMEDY,
+} from '../../src/baseline/expiry-projection';
+import { SOON_TO_EXPIRE_DAYS } from '../../src/allowlist/file';
+
+/**
+ * The lapse projection — what active allowlist suppressions will do when their
+ * windows close. Unit coverage for the collector across all five suppression
+ * sources; `test/allowlist-expiry-parity.test.ts` pins it against the audit
+ * buckets (the Rule 2.30 net), and the renderer tests cover delivery.
+ */
+
+const NOW = new Date('2026-07-29T12:00:00Z');
+
+function pair(opts: {
+  kind: string;
+  blocks: boolean;
+  expiresAt?: string;
+  fingerprint?: string;
+  category?: string;
+  file?: string;
+  line?: number;
+}) {
+  const { kind, blocks, expiresAt, fingerprint = 'fp' + kind, category = 'deferred' } = opts;
+  return {
+    kind,
+    classification: { blocks, warns: !blocks },
+    ...(opts.file !== undefined ? { file: opts.file } : {}),
+    ...(opts.line !== undefined ? { line: opts.line } : {}),
+    suppressedByAllowlist: {
+      fingerprint,
+      category,
+      ...(expiresAt !== undefined ? { expiresAt } : {}),
+    },
+  };
+}
+
+describe('collectExpiryProjection', () => {
+  it('projects a blocking pair suppression with its days remaining and locator', () => {
+    const out = collectExpiryProjection({
+      pairs: [
+        pair({
+          kind: 'dep-vuln',
+          blocks: true,
+          expiresAt: '2026-08-03',
+          file: 'package-lock.json',
+          line: 12,
+        }),
+      ],
+      now: NOW,
+    });
+    expect(out.horizonDays).toBe(SOON_TO_EXPIRE_DAYS);
+    expect(out.willBlock).toBe(1);
+    expect(out.willWarn).toBe(0);
+    expect(out.nextLapseDays).toBe(5);
+    expect(out.lapsing[0]).toEqual({
+      source: 'finding',
+      fingerprint: 'fpdep-vuln',
+      category: 'deferred',
+      expiresAt: '2026-08-03',
+      daysRemaining: 5,
+      consequence: 'block',
+      subject: 'dep-vuln package-lock.json:12',
+    });
+  });
+
+  it('reads the tier off the classification rather than re-deriving it', () => {
+    // A `blocking: false` custom check warns even though its kind is otherwise
+    // block-class; the classification already folded that intent in.
+    const out = collectExpiryProjection({
+      pairs: [pair({ kind: 'custom-check', blocks: false, expiresAt: '2026-08-01' })],
+      now: NOW,
+    });
+    expect(out.lapsing[0]!.consequence).toBe('warn');
+    expect(out.willBlock).toBe(0);
+    expect(out.willWarn).toBe(1);
+  });
+
+  it('excludes a non-expiring suppression — it is not a decision waiting to happen', () => {
+    const out = collectExpiryProjection({
+      pairs: [pair({ kind: 'code', blocks: true, category: 'false-positive' })],
+      now: NOW,
+    });
+    expect(out.lapsing).toEqual([]);
+    expect(out.nextLapseDays).toBeUndefined();
+  });
+
+  it('excludes an expiry beyond the horizon, and honours an override', () => {
+    const far = [pair({ kind: 'code', blocks: true, expiresAt: '2026-08-20' })];
+    expect(collectExpiryProjection({ pairs: far, now: NOW }).lapsing).toEqual([]);
+    const wider = collectExpiryProjection({ pairs: far, now: NOW, horizonDays: 30 });
+    expect(wider.horizonDays).toBe(30);
+    expect(wider.lapsing).toHaveLength(1);
+    expect(wider.lapsing[0]!.daysRemaining).toBe(22);
+  });
+
+  it('includes an entry expiring today (expiry is inclusive, so it still suppresses)', () => {
+    const out = collectExpiryProjection({
+      pairs: [pair({ kind: 'secret', blocks: true, expiresAt: '2026-07-29' })],
+      now: NOW,
+    });
+    expect(out.lapsing[0]!.daysRemaining).toBe(0);
+    expect(describeLapsingSuppression(out.lapsing[0]!)).toContain('(today)');
+  });
+
+  it('covers all four additive gates, not just the matcher pairs', () => {
+    const out = collectExpiryProjection({
+      pairs: [],
+      now: NOW,
+      flowGate: {
+        suppressed: [
+          {
+            fingerprint: 'ff',
+            category: 'deferred',
+            expiresAt: '2026-08-02',
+            finding: { method: 'GET', path: '/api/orders', verdict: 'block' },
+          },
+        ],
+      },
+      schemaDriftGate: {
+        suppressed: [
+          {
+            fingerprint: 'sf',
+            category: 'deferred',
+            expiresAt: '2026-08-04',
+            finding: {
+              changeClass: 'field-removed',
+              model: 'Order',
+              field: 'total',
+              verdict: 'warn',
+            },
+          },
+          {
+            fingerprint: 'si',
+            category: 'deferred',
+            expiresAt: '2026-08-04',
+            finding: { changeClass: 'field-added', model: 'Order', field: null, verdict: 'info' },
+          },
+        ],
+      },
+      dupGate: {
+        suppressed: [
+          {
+            fingerprint: 'df',
+            category: 'deferred',
+            expiresAt: '2026-08-05',
+            finding: { anchors: [{ symbol: 'parseA' }, { symbol: 'parseB' }] },
+          },
+        ],
+      },
+      pairedGate: {
+        suppressed: [
+          {
+            fingerprint: 'pf',
+            category: 'deferred',
+            expiresAt: '2026-08-06',
+            finding: { check: 'model-requires-migration', blocking: true },
+          },
+        ],
+      },
+    });
+    expect(out.lapsing.map((l) => [l.source, l.subject, l.consequence])).toEqual([
+      ['flow', 'GET /api/orders', 'block'],
+      // Same lapse date: warn ranks ahead of disclosure-only info.
+      ['schema-drift', 'field-removed Order.total', 'warn'],
+      ['schema-drift', 'field-added Order', 'info'],
+      ['duplication', 'parseA / parseB', 'warn'],
+      ['paired-change', 'model-requires-migration', 'block'],
+    ]);
+    // `info` is disclosure-only: it appears in the list, counts toward neither.
+    expect(out.willBlock).toBe(2);
+    expect(out.willWarn).toBe(2);
+  });
+
+  it('orders soonest first, blocks before warns on the same day', () => {
+    const out = collectExpiryProjection({
+      pairs: [
+        pair({ kind: 'code', blocks: false, expiresAt: '2026-08-01', fingerprint: 'a' }),
+        pair({ kind: 'secret', blocks: true, expiresAt: '2026-08-01', fingerprint: 'b' }),
+        pair({ kind: 'dep-vuln', blocks: true, expiresAt: '2026-07-30', fingerprint: 'c' }),
+      ],
+      now: NOW,
+    });
+    expect(out.lapsing.map((l) => l.fingerprint)).toEqual(['c', 'b', 'a']);
+    expect(out.nextLapseDays).toBe(1);
+  });
+
+  it('is empty and silent on a run with no suppressions at all', () => {
+    const out = collectExpiryProjection({ pairs: [], now: NOW });
+    expect(out).toEqual({
+      horizonDays: SOON_TO_EXPIRE_DAYS,
+      lapsing: [],
+      willBlock: 0,
+      willWarn: 0,
+    });
+    expect(describeExpiryProjection(out)).toBeUndefined();
+  });
+});
+
+describe('describeExpiryProjection', () => {
+  it('leads with the block consequence and the soonest lapse', () => {
+    const out = collectExpiryProjection({
+      pairs: [
+        pair({ kind: 'dep-vuln', blocks: true, expiresAt: '2026-08-03', fingerprint: 'a' }),
+        pair({ kind: 'dep-vuln', blocks: true, expiresAt: '2026-08-04', fingerprint: 'b' }),
+        pair({ kind: 'code', blocks: false, expiresAt: '2026-08-05', fingerprint: 'c' }),
+      ],
+      now: NOW,
+    });
+    const line = describeExpiryProjection(out);
+    expect(line).toBe(
+      '3 allowlist suppressions expire within 14 days (next in 5d); ' +
+        'when they lapse, 2 will BLOCK, 1 will warn',
+    );
+    expect(EXPIRY_PROJECTION_REMEDY).toContain('allowlist audit');
+  });
+
+  it('says so plainly when nothing lapsing would block or warn', () => {
+    const out = collectExpiryProjection({
+      pairs: [],
+      now: NOW,
+      schemaDriftGate: {
+        suppressed: [
+          {
+            fingerprint: 'si',
+            category: 'deferred',
+            expiresAt: '2026-08-01',
+            finding: { changeClass: 'field-added', model: 'Order', field: null, verdict: 'info' },
+          },
+        ],
+      },
+    });
+    expect(describeExpiryProjection(out)).toContain('none will block or warn');
+  });
+});


### PR DESCRIPTION
**PR 1 of 4 in the 4.3.1 stack** (the allowlist expiry cliff). This one lands the *concept*; the delivery surfaces follow.

## The incident this closes

An innocent 16-file frontend PR on a real repo was blocked by 9 high dependency advisories nobody had introduced. Neither a dxkit bug nor an upgrade side effect — two individually-correct mechanisms compose into a cliff:

1. An allowlist entry deliberately holds its finding **out** of the baseline, so an accepted finding can never grandfather itself in and defeat its own expiry (gh #155).
2. The scheduled refresh is therefore structurally forbidden from absorbing it.

So a six-day deferral of 21 findings lapsed with nothing remediated, and all 21 came back at once — no warning as the date approached, no decision surface at the lapse.

**The warning already existed and was never delivered.** `auditAllowlist` has computed `expired` + `soonToExpire` with `daysRemaining` since the allowlist shipped. Its only consumers were `doctor` and `allowlist audit` — two commands nobody runs on a normal day. On the affected repo it would have fired from the moment the deferral was created.

## What's here

- **One home for expiry day arithmetic.** `daysUntilDate` + `SOON_TO_EXPIRE_DAYS` in `src/allowlist/file.ts`. The audit path holds a full `AllowlistEntry`; the guardrail's per-finding suppression holds only the `expiresAt` string — a lossy projection of the entry, which is the exact CLAUDE.md 2.30 setup where the second consumer re-derives the arithmetic and the two surfaces start disagreeing about the same date. Folded in the two duplicated \`?? 14\` horizon defaults, plus a **third implementation found while checking**: a private \`daysUntil\` in the \`allowlist defer\` summary that clamped negatives and read \`Date.now()\` directly.
- **`collectExpiryProjection`** (`src/baseline/expiry-projection.ts`) adds the half the audit structurally cannot see. The file alone says *which* entries expire soon; the check knows what the lapse will **cost**, because it holds each suppressed pair's classification and each gate finding's verdict. All **five** suppression sources are covered — pairs plus the four additive gates. A projection reading pairs alone would warn about a lapsing dep-vuln while staying silent about a lapsing flow breakage on the same day.
- **`GuardrailCheckResult.suppressionExpiry` is REQUIRED**, so a new surface cannot render the check without it existing. It never blocks and never touches the verdict — expiry is already the forcing function, and blaming an author for someone else's lapsing deferral would be a false block. Disclosure on the `GateFailure` discipline.
- The tier comes off `classification.blocks`, never a second tier table, so a `blocking: false` custom check projects as a warn exactly as it behaves.

Honest framing, stated in the module doc: read it as *"if these lapsed today"*. The finding is re-classified on the run after the lapse, and one that gets fixed in the meantime never returns at all.

## Enforcement (both nets, because grep cannot see a semantic divergence)

- `scripts/check-architecture.sh` Rule 3 (allowlist): bans expiry day arithmetic outside `file.ts`, annotation escape `// expiry-daymath-ok`. **Verified to bite** (probe file → exit 1; removed → exit 0).
- `test/allowlist-expiry-parity.test.ts`: runs **both** consumers on one fixture through their real entry points and asserts they agree on membership and on every day count — at the default, a widened, and a narrowed horizon, plus the inclusive boundaries (expires today, exactly on the horizon, one day past) and both exclusion reasons (already-expired vs never-expiring). Positive control asserts the fixture actually exercises the horizon, so the comparison cannot pass on two empty sets.

## Not a posture knob

`soonToExpireDays` is guardrail **tuning** — it refines a surface the repo already has rather than a capability it opts into — so it carries no discovery contract, same carve-out as `confidence` / `largeFileThreshold`. The posture-knob playbook is not expected to cover it.

## Gates run locally

| gate | result |
| --- | --- |
| `tsc --noEmit` (src + `typecheck:test`) | pass |
| `eslint . --max-warnings 0` | pass |
| `format:check` | pass |
| `check-architecture.sh` | pass (new rule verified to bite) |
| `check-slop.sh` / `check-cross-ecosystem-coverage.sh` | pass |
| `test:run` | **333 files / 5,046 tests pass** (+17) |
| self-guardrail `--mode ref-based --ref origin/main` | **PASSED** |

## Next in the stack

2. The three check renderers (console / JSON / markdown) — the actual delivery.
3. `allowlist defer` creation guard + comment-defer reciprocity.
4. The refresh-lane decision surface — designed first (it makes a managed workflow write, so Rule 15 + Rule 16 apply).

Version number for the release is still open (4.3.1 vs a minor — 4.4/4.5 are already claimed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)