### PR TITLE
feat(guardrail): deliver the lapse projection — console, JSON, and the PR comment

### DIFF
--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -34,6 +34,12 @@ import type {
 } from './check';
 import { ATTRIBUTION_GAP_REMEDY, describeAttributionGap } from './attribution-gap';
 import type { AttributionGap } from './attribution-gap';
+import {
+  EXPIRY_PROJECTION_REMEDY,
+  describeExpiryProjection,
+  describeLapsingSuppression,
+} from './expiry-projection';
+import type { ExpiryProjection } from './expiry-projection';
 import { recallDriftRemedy, describeRecallDrift } from './recall';
 import type { BrownfieldPolicy } from './policy';
 import type { FindingStatus, MatchReason } from './types';
@@ -247,7 +253,11 @@ export function renderConsole(result: GuardrailCheckResult): string {
   // Provenance: what was compared against what. Inline so the user
   // can verify they're checking against the intended baseline.
   lines.push(logger.bold('Baseline'));
-  lines.push(`  Path:        ${result.baselinePath}`);
+  // Ref-based mode has no on-disk baseline; say so rather than stringifying the
+  // absent field into the literal word "undefined".
+  lines.push(
+    `  Path:        ${result.baselinePath ?? `(none — gathered from ${result.mode.ref ?? 'a git ref'})`}`,
+  );
   lines.push(`  Name:        ${result.baseline.name}`);
   lines.push(`  Captured:    ${result.baseline.createdAt}`);
   lines.push(
@@ -317,6 +327,9 @@ export function renderConsole(result: GuardrailCheckResult): string {
     for (const p of suppressed) lines.push(...formatPairLines(p, '  '));
     lines.push('');
   }
+  // The lapse projection, immediately after the list it is the consequence of.
+  // Silent when nothing expires inside the horizon, which is almost every run.
+  lines.push(...formatExpiryProjection(result.suppressionExpiry));
   if (warning.length > 0) {
     lines.push(logger.bold(`Warnings (${warning.length})`));
     // Collapse the envelope-drift wall (gh #157): after a dxkit upgrade or a
@@ -359,6 +372,15 @@ export function renderConsole(result: GuardrailCheckResult): string {
       `warning: ${warning.length}, persisted: ${persisted.length}, ` +
       `resolved: ${removed.length})`,
   );
+  // The lapse line belongs in the footer too: a reader who skims to the summary
+  // and stops must still see that today's PASS has an expiry date on it.
+  if (result.suppressionExpiry.lapsing.length > 0) {
+    const p = result.suppressionExpiry;
+    lines.push(
+      `  Expiring:    ${p.lapsing.length} suppression(s) within ${p.horizonDays}d ` +
+        `(next in ${p.nextLapseDays}d; ${p.willBlock} would block, ${p.willWarn} would warn)`,
+    );
+  }
   // A flow-gate line so the verdict banner's total (which counts flow findings)
   // reconciles with the summary. Without it, a repo whose only regressions are
   // flow breakages read "BLOCKED — 3 new regressions" over "Pairs: blocking: 0"
@@ -459,6 +481,32 @@ function formatGateFailure(
     '  (fail-open: this did not block the check; set DXKIT_DEBUG=1 for the stack)',
     '',
   ];
+}
+
+/**
+ * The lapse projection section. Prints nothing when no active suppression
+ * expires inside the horizon — the state of almost every run, and an empty
+ * "nothing expiring" section would be noise that trains readers to skip the
+ * area where the real warning eventually appears.
+ *
+ * Where the delivery gap was: the horizon computation has existed since the
+ * allowlist shipped, reachable only from `doctor` and `allowlist audit`. Every
+ * author and reviewer reads THIS output instead, which is why the warning goes
+ * here (see `src/baseline/expiry-projection.ts`).
+ */
+function formatExpiryProjection(projection: ExpiryProjection): string[] {
+  const headline = describeExpiryProjection(projection);
+  if (!headline) return [];
+  const out = [
+    logger.bold(
+      `${projection.willBlock > 0 ? '⚠ ' : ''}Suppressions expiring (${projection.lapsing.length})`,
+    ),
+    `  ${headline}`,
+  ];
+  for (const l of projection.lapsing) out.push(`  · ${describeLapsingSuppression(l)}`);
+  out.push(`  → ${EXPIRY_PROJECTION_REMEDY}`);
+  out.push('');
+  return out;
 }
 
 /**
@@ -1070,6 +1118,13 @@ export interface GuardrailJsonPayload {
    *  disarmed, how many findings, and which recall input moved. Empty on a
    *  healthy run. */
   readonly attributionGaps: ReadonlyArray<AttributionGap>;
+  /** What this run's ACTIVE allowlist suppressions will do when their windows
+   *  close: how many would block, how many would warn, and how soon. ALWAYS
+   *  present (`lapsing: []` when nothing expires inside the horizon), so an
+   *  agent can read it without probing for the field. Never affects
+   *  `verdict` — a lapse that has not happened yet is not a regression, and
+   *  the finding is re-classified on the run after it lapses. */
+  readonly suppressionExpiry: ExpiryProjection;
   /** Present when the dependency-vuln scan was requested but could not run —
    *  a pass is then NOT a clean bill of dependency health. */
   readonly depVulnsUnmeasured?: { readonly reason: string };
@@ -1305,6 +1360,7 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
       exitCode: counts.exitCode,
     },
     attributionGaps: result.attributionGaps,
+    suppressionExpiry: result.suppressionExpiry,
     ...(result.depVulnsUnmeasured ? { depVulnsUnmeasured: result.depVulnsUnmeasured } : {}),
     ...(result.deferredCapture && result.deferredCapture.length > 0
       ? { deferredCapture: result.deferredCapture }
@@ -1630,6 +1686,8 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     lines.push('');
   }
 
+  lines.push(...markdownExpiryProjection(result.suppressionExpiry));
+
   if (warning.length > 0) {
     // Collapse the envelope-drift wall (gh #157): the drift group becomes one
     // summary line above the table, and only the specific warnings are tabled.
@@ -1754,6 +1812,42 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
  * top-level table (they fail the PR); warnings collapse into a `<details>`.
  * Silent when the gate produced no findings.
  */
+/**
+ * The lapse projection for the PR comment — the surface that actually closes
+ * the delivery gap, since a reviewer reads this and nobody runs `doctor`.
+ *
+ * A lapse that will BLOCK gets a warning callout (it is about to become
+ * somebody's problem, and the somebody is whoever opens the next PR); a
+ * warn-only lapse gets an informational one. Detail collapses into `<details>`
+ * so a 21-entry deferral does not bury the findings above it. Silent when
+ * nothing expires inside the horizon.
+ */
+function markdownExpiryProjection(projection: ExpiryProjection): string[] {
+  const headline = describeExpiryProjection(projection);
+  if (!headline) return [];
+  const lines: string[] = [];
+  const icon = projection.willBlock > 0 ? '⚠️' : 'ℹ️';
+  lines.push(`> ${icon} **${escapeMd(headline)}**`);
+  lines.push(`> - Remedy: ${escapeMd(EXPIRY_PROJECTION_REMEDY)}`);
+  lines.push('');
+  lines.push('<details>');
+  lines.push(`<summary>Suppressions expiring (${projection.lapsing.length})</summary>`);
+  lines.push('');
+  lines.push('| Source | Finding | Category | Expires | In | On lapse |');
+  lines.push('|---|---|---|---|---|---|');
+  for (const l of projection.lapsing) {
+    const effect = l.consequence === 'block' ? '**blocks**' : l.consequence;
+    lines.push(
+      `| ${escapeMd(l.source)} | ${escapeMd(l.subject)} | ${escapeMd(l.category)} | ` +
+        `${escapeMd(l.expiresAt)} | ${l.daysRemaining}d | ${effect} |`,
+    );
+  }
+  lines.push('');
+  lines.push('</details>');
+  lines.push('');
+  return lines;
+}
+
 /** A markdown line for a fail-open gate that errored — the PR-comment mirror of
  *  `formatGateFailure`. Never silent on an error; empty otherwise. */
 function markdownGateFailure(

--- a/src/loop/demo.ts
+++ b/src/loop/demo.ts
@@ -20,6 +20,7 @@ import * as readline from 'readline';
 import { execFileSync, spawnSync } from 'child_process';
 import type { GuardrailJsonPayload } from '../baseline/check-renderers';
 import { GUARDRAIL_JSON_SCHEMA } from '../baseline/check-renderers';
+import { SOON_TO_EXPIRE_DAYS } from '../allowlist/file';
 import { buildRepairMessage } from './stop-gate';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
 import { dxkitCli, dxkitOneShotCli } from '../self-invocation';
@@ -51,6 +52,15 @@ function illustrativePayload(blocked: boolean): GuardrailJsonPayload {
     schema: GUARDRAIL_JSON_SCHEMA,
     verdict: { blocks: blocked, warns: false, refused: false, exitCode: blocked ? 1 : 0 },
     attributionGaps: [],
+    // The illustration has no allowlist, so nothing is deferred and nothing can
+    // lapse. Spelled out rather than omitted — the field is required so a real
+    // payload can never quietly lack it.
+    suppressionExpiry: {
+      horizonDays: SOON_TO_EXPIRE_DAYS,
+      lapsing: [],
+      willBlock: 0,
+      willWarn: 0,
+    },
     baseline: {
       name: 'main',
       createdAt: '2026-01-01T00:00:00.000Z',

--- a/test/baseline/expiry-projection-renderers.test.ts
+++ b/test/baseline/expiry-projection-renderers.test.ts
@@ -1,0 +1,192 @@
+/**
+ * DELIVERY: the lapse projection reaches all three check surfaces.
+ *
+ * The whole point of the projection is that the computation already existed and
+ * was never delivered — `auditAllowlist` has known which suppressions expire
+ * soon since the allowlist shipped, reachable only from `doctor` and
+ * `allowlist audit`, two commands nobody runs on a normal day. A projection
+ * computed onto the result and rendered by only ONE of the three surfaces would
+ * reproduce the same bug one layer in (the same discipline `GateFailure` is
+ * pinned by: console / JSON / markdown, or it did not ship).
+ *
+ * Both directions, because over-disclosure is its own failure: an empty
+ * projection must be SILENT on every surface. A "nothing expiring" section on
+ * every run trains readers to skip the exact area where the real warning
+ * eventually appears.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createBaseline } from '../../src/baseline/create';
+import { runGuardrailCheck, type GuardrailCheckResult } from '../../src/baseline/check';
+import { renderConsole, renderJson, renderMarkdown } from '../../src/baseline/check-renderers';
+import {
+  EXPIRY_PROJECTION_REMEDY,
+  type ExpiryProjection,
+} from '../../src/baseline/expiry-projection';
+import { SOON_TO_EXPIRE_DAYS } from '../../src/allowlist/file';
+import { trustedLocalContext } from '../../src/analysis-trust';
+
+function git(dir: string, args: string[]): void {
+  execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+}
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-expiry-render-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'test']);
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '0.0.0' }));
+  writeFileSync(join(dir, 'src', 'index.js'), 'module.exports = () => 1;\n');
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '-q', '-m', 'init']);
+  return dir;
+}
+
+/** A populated projection covering both consequence tiers and the whole
+ *  reporting range (lapses today, and lapses inside the horizon). */
+const LAPSING: ExpiryProjection = {
+  horizonDays: SOON_TO_EXPIRE_DAYS,
+  lapsing: [
+    {
+      source: 'finding',
+      fingerprint: 'aaaa111122223333',
+      category: 'deferred',
+      expiresAt: '2026-08-01',
+      daysRemaining: 3,
+      consequence: 'block',
+      subject: 'dep-vuln package-lock.json:1',
+    },
+    {
+      source: 'flow',
+      fingerprint: 'bbbb111122223333',
+      category: 'accepted-risk',
+      expiresAt: '2026-08-05',
+      daysRemaining: 7,
+      consequence: 'warn',
+      subject: 'GET /api/orders',
+    },
+  ],
+  willBlock: 1,
+  willWarn: 1,
+  nextLapseDays: 3,
+};
+
+describe('the lapse projection reaches every check surface', () => {
+  let base: GuardrailCheckResult;
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = makeRepo();
+    await createBaseline({ cwd: dir });
+    base = await runGuardrailCheck({ trust: trustedLocalContext(), cwd: dir });
+  }, 120_000);
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('a real run computes the projection (the field is not just a type)', () => {
+    // No allowlist in this repo, so nothing is suppressed and nothing can lapse
+    // — but the projection is still COMPUTED, with the shared horizon.
+    expect(base.suppressionExpiry).toBeDefined();
+    expect(base.suppressionExpiry.horizonDays).toBe(SOON_TO_EXPIRE_DAYS);
+    expect(base.suppressionExpiry.lapsing).toEqual([]);
+    expect(base.suppressionExpiry.willBlock).toBe(0);
+  });
+
+  it('is SILENT on all three surfaces when nothing expires', () => {
+    expect(renderConsole(base)).not.toContain('Suppressions expiring');
+    expect(renderConsole(base)).not.toContain('Expiring:');
+    expect(renderMarkdown(base)).not.toContain('Suppressions expiring');
+    // JSON always carries the field (an agent reads it without probing), but it
+    // says plainly that nothing is pending.
+    expect(renderJson(base).suppressionExpiry.lapsing).toEqual([]);
+  });
+
+  it('console names the count, the countdown, the consequence, and the remedy', () => {
+    const out = renderConsole({ ...base, suppressionExpiry: LAPSING });
+    expect(out).toContain('Suppressions expiring (2)');
+    expect(out).toContain('2 allowlist suppressions expire within 14 days');
+    expect(out).toContain('next in 3d');
+    expect(out).toContain('1 will BLOCK');
+    expect(out).toContain('dep-vuln package-lock.json:1');
+    expect(out).toContain('GET /api/orders');
+    expect(out).toContain(EXPIRY_PROJECTION_REMEDY.slice(0, 30));
+    // And the summary footer, for a reader who skims to the bottom and stops.
+    expect(out).toContain('Expiring:    2 suppression(s) within 14d');
+  });
+
+  it('console flags the block tier so a lapse that will break the build stands out', () => {
+    const warnOnly: ExpiryProjection = {
+      ...LAPSING,
+      lapsing: [LAPSING.lapsing[1]!],
+      willBlock: 0,
+      willWarn: 1,
+      nextLapseDays: 7,
+    };
+    expect(renderConsole({ ...base, suppressionExpiry: LAPSING })).toContain(
+      '⚠ Suppressions expiring',
+    );
+    expect(renderConsole({ ...base, suppressionExpiry: warnOnly })).toContain(
+      'Suppressions expiring (1)',
+    );
+    expect(renderConsole({ ...base, suppressionExpiry: warnOnly })).not.toContain(
+      '⚠ Suppressions expiring',
+    );
+  });
+
+  it('json carries the whole structure, unabridged', () => {
+    const json = renderJson({ ...base, suppressionExpiry: LAPSING });
+    expect(json.suppressionExpiry).toEqual(LAPSING);
+    // It must NOT leak into the verdict: a lapse that has not happened is not a
+    // regression, and this run passed.
+    expect(json.verdict.blocks).toBe(false);
+    expect(json.verdict.refused).toBe(false);
+    expect(json.verdict.exitCode).toBe(0);
+  });
+
+  it('markdown carries a callout plus a per-entry table', () => {
+    const md = renderMarkdown({ ...base, suppressionExpiry: LAPSING });
+    expect(md).toContain('⚠️');
+    expect(md).toContain('2 allowlist suppressions expire within 14 days');
+    expect(md).toContain('<summary>Suppressions expiring (2)</summary>');
+    expect(md).toContain('| Source | Finding | Category | Expires | In | On lapse |');
+    expect(md).toContain('dep-vuln package-lock.json:1');
+    expect(md).toContain('**blocks**');
+    expect(md).toContain('| 7d |');
+    // Disclosure, not a verdict change — the heading still reports the pass.
+    expect(md).toContain('## Guardrail: PASSED');
+  });
+
+  it('markdown drops to an informational icon when no lapse would block', () => {
+    const warnOnly: ExpiryProjection = {
+      ...LAPSING,
+      lapsing: [LAPSING.lapsing[1]!],
+      willBlock: 0,
+      willWarn: 1,
+      nextLapseDays: 7,
+    };
+    const md = renderMarkdown({ ...base, suppressionExpiry: warnOnly });
+    expect(md).toContain('ℹ️');
+    expect(md).toContain('1 will warn');
+    expect(md).not.toContain('**blocks**');
+  });
+
+  it('names the baseline path honestly in ref-based mode (no literal "undefined")', () => {
+    // The console printed `Path: undefined` whenever there was no on-disk
+    // baseline, which is every ref-based run.
+    const refBased = {
+      ...base,
+      baselinePath: undefined,
+      mode: { ...base.mode, mode: 'ref-based' as const, ref: 'origin/main' },
+    };
+    const out = renderConsole(refBased);
+    expect(out).not.toContain('Path:        undefined');
+    expect(out).toContain('origin/main');
+  });
+});


### PR DESCRIPTION
**PR 2 of 4 in the 4.3.1 stack.** Stacked on #193 — review that one first; this PR's diff is renderers only.

PR 1 computed what active allowlist suppressions will cost when their windows close. This is the half that closes the actual bug, because the delivery gap was never a missing computation: `auditAllowlist` has known which suppressions expire soon since the allowlist shipped, reachable only from `doctor` and `allowlist audit`. Nobody runs those. Everybody reads the check.

## All three surfaces, or it did not ship

| surface | what lands |
| --- | --- |
| **console** | `Suppressions expiring (N)` section right after the suppressed list it is the consequence of — headline, one line per entry, remedy. Plus a `Expiring:` summary footer line, so a reader who skims to the bottom and stops still learns today's PASS has an expiry date on it. A lapse that would BLOCK gets the `⚠` marker; warn-only does not. |
| **JSON** | `suppressionExpiry` always present, so an agent reads it without probing. Deliberately absent from `verdict`. |
| **markdown** | Callout (⚠️ when a lapse would block, ℹ️ otherwise) plus a collapsible per-entry table, so a 21-entry deferral cannot bury the findings above it. Verdict heading untouched. |

Every downstream consumer already funnels through these three (`receipt` → `renderMarkdown`, `evaluate` + the loop Stop-gate → `renderJson`), so there is no fourth surface re-deriving a summary.

## Silence is enforced in the other direction too

An empty projection prints **nothing** on any surface. A standing "nothing expiring" section on every run would train readers to skip the exact area where the real warning eventually appears. `test/baseline/expiry-projection-renderers.test.ts` pins both directions against a real `runGuardrailCheck` result, so a future surface that computes the projection and forgets to render it fails here.

The REQUIRED field earned its keep immediately: it caught the synthetic payload builder in `src/loop/demo.ts` at **compile** time.

## Also: the cosmetic fix noted during PR 1's review

The console printed `Path: undefined` on every ref-based run (there is no on-disk baseline in that mode). It now names what was actually compared against — verified in real output:

```
Baseline
  Path:        (none — gathered from origin/main)
```

## Two deliberate non-items

- **The loop Stop-gate's repair message stays silent about lapses.** It hands back net-new findings to *fix*; an approaching expiry is neither net-new nor the agent's to resolve, and surfacing it there would invite an agent to extend somebody else's deferral.
- **No new policy knob.** The horizon stays at the shared 14-day default, with the existing `allowlist audit --soon-days` override for ad-hoc widening. Adding a `soonToExpireDays` policy field would be guardrail tuning nobody asked for; if it turns out to be wanted, it is a one-line addition on top of the shared constant.

## Gates run locally

| gate | result |
| --- | --- |
| `tsc --noEmit` (src + `typecheck:test`) | pass |
| `eslint . --max-warnings 0` | pass |
| `format:check` | pass |
| `check-architecture.sh` / `check-slop.sh` / `check-cross-ecosystem-coverage.sh` | pass |
| `test:run` | **334 files / 5,054 tests pass** (+8) |
| self-guardrail `--mode ref-based --ref origin/main` | **PASSED** |

## Next in the stack

3. `allowlist defer` creation guard + comment-defer reciprocity.
4. The refresh-lane decision surface — designed first (managed workflow write, so Rule 15 + Rule 16 apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)