### PR TITLE
feat(allowlist): the deferral creation guard — say at the keystroke whether the promise is keepable

### DIFF
--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -469,11 +469,15 @@ export async function runAllowlistDefer(cwd: string, opts: AllowlistDeferOpts): 
     logger.fail(result.message);
     process.exit(1);
   }
-  const { added, alreadyPresent, leftBlocking, expiresAt, reason, targets } = result;
+  const { added, alreadyPresent, leftBlocking, expiresAt, reason, targets, advisories } = result;
 
   if (opts.json) {
     process.stdout.write(
-      JSON.stringify({ added, alreadyPresent, leftBlocking, expiresAt, reason }, null, 2) + '\n',
+      JSON.stringify(
+        { added, alreadyPresent, leftBlocking, expiresAt, reason, advisories },
+        null,
+        2,
+      ) + '\n',
     );
     return;
   }
@@ -497,6 +501,9 @@ export async function runAllowlistDefer(cwd: string, opts: AllowlistDeferOpts): 
       `  Commit .dxkit/allowlist.json (via your PR) — the expiry re-blocks these in ` +
         `${daysUntil(expiresAt)} day(s), so plan the dependency fix now.`,
     );
+    // The creation guard: what this window will and will not get you. Warned
+    // rather than info'd — these are the facts a caller most needs to have read.
+    for (const a of advisories) logger.warn(`  ${a}`);
   }
   if (alreadyPresent.length > 0) {
     logger.info(`Skipped ${alreadyPresent.length} fingerprint(s) already allowlisted.`);

--- a/src/allowlist/comment-defer.ts
+++ b/src/allowlist/comment-defer.ts
@@ -241,6 +241,14 @@ export function runCommentDeferCore(
       'The allowlist commit below re-runs the guardrail check. The expiry is the ' +
         'forcing function: these re-block when it lapses, so plan the dependency fix now.',
     );
+    // The creation guard, carried into the thread. The reviewers reading this PR
+    // are the people who will live with the deferral, and this is the only place
+    // they will see whether the window is keepable (Rule 2: the same advisories
+    // the local CLI prints, from the same core).
+    if (result.advisories.length > 0) {
+      lines.push('');
+      for (const a of result.advisories) lines.push(`> ⚠️ ${a}`);
+    }
   } else {
     lines.push(
       result.alreadyPresent.length > 0

--- a/src/allowlist/defer-core.ts
+++ b/src/allowlist/defer-core.ts
@@ -15,6 +15,7 @@ import { dxkitCli } from '../self-invocation';
 import { readVerdictForTree } from '../baseline/verdict-cache';
 import {
   addEntry,
+  daysUntilDate,
   emptyAllowlistFile,
   findEntry,
   loadAllowlist,
@@ -23,7 +24,8 @@ import {
   type AllowlistEntry,
   type AllowlistMode,
 } from './file';
-import { deferAdvisoryExpiryDate } from './categories';
+import { DEFER_ADVISORY_EXPIRY_DAYS, deferAdvisoryExpiryDate } from './categories';
+import { deferAdvisories } from './defer-guard';
 
 export interface DeferRequest {
   /** Explicit fingerprints (deduped by the core). */
@@ -44,6 +46,12 @@ export interface DeferOutcome {
   readonly ok: true;
   readonly added: readonly string[];
   readonly alreadyPresent: readonly string[];
+  /** Creation-time advisories about the window just chosen (how many findings
+   *  share it, whether any lane could close them, whether it shuts before the
+   *  lane's next run). Facts, never a veto — see `defer-guard.ts`. Empty when
+   *  there is nothing worth saying, and empty when nothing was written. BOTH
+   *  front-ends render these; a new front-end inherits them from the core. */
+  readonly advisories: readonly string[];
   /** Non-dep-vuln blockers `--from-last-check` refused to touch, as
    *  `"<kind> <locator>"` strings. */
   readonly leftBlocking: readonly string[];
@@ -91,6 +99,18 @@ export function executeDefer(cwd: string, req: DeferRequest, now = new Date()): 
   if (expiresAt === null) {
     return refuse(
       `--expires must be ISO date YYYY-MM-DD or relative +Nd; got ${JSON.stringify(req.expires)}`,
+    );
+  }
+  // A window that already closed writes an entry that suppresses NOTHING: the
+  // matcher skips an expired entry, so the finding keeps blocking while the
+  // allowlist claims it was accepted. Refusing is the honest answer — silently
+  // writing a dead entry fails the caller's actual intent.
+  const windowDays = daysUntilDate(expiresAt, now);
+  if (windowDays < 0) {
+    return refuse(
+      `--expires ${expiresAt} is already in the past (${-windowDays} day(s) ago), so the entry ` +
+        `would suppress nothing and the findings would keep blocking. Pass a future date, ` +
+        `or \`--expires +${DEFER_ADVISORY_EXPIRY_DAYS}d\`.`,
     );
   }
 
@@ -194,5 +214,10 @@ export function executeDefer(cwd: string, req: DeferRequest, now = new Date()): 
 
   if (added.length > 0) saveAllowlist(cwd, { ...file, mode: req.mode });
 
-  return { ok: true, added, alreadyPresent, leftBlocking, expiresAt, reason, targets };
+  // Advisories describe the window that was just written, so they are computed
+  // only when something WAS written — an all-already-present run chose no window.
+  const advisories =
+    added.length > 0 ? deferAdvisories(cwd, { count: added.length, expiresAt, now }) : [];
+
+  return { ok: true, added, alreadyPresent, leftBlocking, expiresAt, reason, targets, advisories };
 }

--- a/src/allowlist/defer-guard.ts
+++ b/src/allowlist/defer-guard.ts
@@ -1,0 +1,113 @@
+/**
+ * The creation-time guard on a deferral — the advisories a caller sees at the
+ * moment they time-box a finding, decided ONCE for both front-ends.
+ *
+ * # Why this exists
+ *
+ * A deferral is a promise: "we will fix this before <date>." The expiry is the
+ * forcing function, and it works — a lapsed entry stops suppressing and the
+ * finding returns. What the product never said is whether the promise was
+ * KEEPABLE. On the repo that produced this class, an engineer deferred 21
+ * dependency advisories for six days with no remediation lane enabled: nothing
+ * in that repo was ever going to fix 9 packages in six days, and every one of
+ * the 21 came back on the same morning and blocked every open PR.
+ *
+ * None of that needed predicting. All of it was knowable at the keystroke: how
+ * many findings, how long the window, whether any lane exists that could close
+ * them, and the fact that one shared expiry means the whole batch returns
+ * together. So the guard states those facts when they matter and stays quiet
+ * when they don't.
+ *
+ * # What it deliberately is NOT
+ *
+ * It never blocks a deferral and never adjusts the window. Time-boxing a
+ * finding is a legitimate engineering decision and the human making it knows
+ * things dxkit does not (a fix already in review, a vendor patch landing
+ * Thursday). The guard's job is to make the decision INFORMED, not to overrule
+ * it — so every advisory is a fact plus its consequence, never a veto and never
+ * a nag. The one hard refusal lives in the core, not here: an expiry already in
+ * the past creates an entry that suppresses NOTHING, which silently fails the
+ * caller's actual intent.
+ *
+ * Both front-ends render these (Rule 2): `allowlist defer` prints them, and the
+ * `/dxkit defer` PR reply carries them into the thread where the reviewers who
+ * will live with the deferral can read them. The guard is consulted from the ONE
+ * defer core, so a third front-end inherits it for free.
+ */
+
+import { depBumpEnabled, remediateEnabled } from '../ship-installers';
+import { daysUntilDate } from './file';
+import { DEFER_ADVISORY_EXPIRY_DAYS } from './categories';
+
+export interface DeferGuardInput {
+  /** How many findings this deferral covers. */
+  readonly count: number;
+  /** The shared ISO `YYYY-MM-DD` expiry being written. */
+  readonly expiresAt: string;
+  readonly now: Date;
+}
+
+/**
+ * Whether this repo has any automated lane that could close a deferred
+ * dependency finding before its window shuts. Both probes are read from their
+ * declared homes rather than re-reading policy here — `doctor` recommends these
+ * same lanes, and a second policy read is how the two surfaces start
+ * disagreeing about whether a repo is covered.
+ *
+ * Both probes swallow a read failure and answer `false`, so an unreadable policy
+ * reads as "no lane". That is the conservative direction for this advisory: a
+ * lane dxkit cannot see is a lane that will not run on its behalf, and the
+ * advice (plan the work, or check the lane config) is right either way.
+ */
+function laneCoverage(cwd: string): { readonly depBump: boolean; readonly remediate: boolean } {
+  return { depBump: depBumpEnabled(cwd), remediate: remediateEnabled(cwd) };
+}
+
+/**
+ * The advisories for a deferral about to be written. Empty when there is
+ * nothing worth saying. Ordered most-consequential first.
+ */
+export function deferAdvisories(cwd: string, input: DeferGuardInput): string[] {
+  const windowDays = daysUntilDate(input.expiresAt, input.now);
+  const out: string[] = [];
+
+  // The batch-lapse property. One shared expiry is the whole point of a bulk
+  // defer, and also the thing that makes the return a wall rather than a
+  // trickle — say so while the window is still being chosen.
+  if (input.count > 1) {
+    out.push(
+      `All ${input.count} findings share one expiry, so they return together on ` +
+        `${input.expiresAt} — not spread out.`,
+    );
+  }
+
+  if (windowDays === 0) {
+    out.push(
+      'The window closes TODAY: the expiry is inclusive, so these are suppressed ' +
+        'for the rest of today and re-block tomorrow. Pass `--expires +Nd` for a ' +
+        'window you can actually work in.',
+    );
+  }
+
+  const lanes = laneCoverage(cwd);
+  if (!lanes.depBump && !lanes.remediate) {
+    out.push(
+      `No automated remediation lane is enabled in this repo, so nothing here will ` +
+        `close ${input.count === 1 ? 'this' : 'these'} before ${input.expiresAt} — ` +
+        `whoever opens a PR that day inherits ${input.count === 1 ? 'it' : 'them'}. ` +
+        `Either plan the work now, or enable a lane: \`depBump.enabled\` for the ` +
+        `deterministic version-bump lane (fixable dependency findings, no agent), ` +
+        `\`remediate.enabled\` for the agentic one.`,
+    );
+  } else if (lanes.depBump && !lanes.remediate && windowDays < DEFER_ADVISORY_EXPIRY_DAYS) {
+    // The bump lane is scheduled weekly by its managed workflow, so a window
+    // shorter than its cadence may shut before the lane has run even once.
+    out.push(
+      `The dep-bump lane runs weekly, so a ${windowDays}-day window may close before ` +
+        `its next run. Give it at least one cycle (\`--expires +${DEFER_ADVISORY_EXPIRY_DAYS}d\`) ` +
+        `or expect to renew.`,
+    );
+  }
+
+  return out;
+}

--- a/test/allowlist/defer-guard.test.ts
+++ b/test/allowlist/defer-guard.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The deferral creation guard — the advisories a caller gets at the moment they
+ * time-box a finding, and the one hard refusal.
+ *
+ * The class: a deferral is a promise ("we will fix this before <date>") and
+ * nothing ever said whether the promise was keepable. On the repo that produced
+ * this, 21 dependency advisories were deferred for six days with no remediation
+ * lane enabled; all 21 returned on the same morning and blocked every open PR.
+ * Every fact needed to see that coming was available at the keystroke.
+ *
+ * Pinned here: each advisory fires on its own condition, stays silent when the
+ * condition does not hold (an advisory that always fires is an advisory nobody
+ * reads), and reaches BOTH front-ends from the one core — the local CLI and the
+ * `/dxkit defer` PR reply.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { executeDefer } from '../../src/allowlist/defer-core';
+import { deferAdvisories } from '../../src/allowlist/defer-guard';
+import { runCommentDeferCore } from '../../src/allowlist/comment-defer';
+import { loadAllowlist } from '../../src/allowlist/file';
+import { DEFER_ADVISORY_EXPIRY_DAYS } from '../../src/allowlist/categories';
+import { writeVerdict } from '../../src/baseline/verdict-cache';
+import type { CachedBlockingFinding } from '../../src/baseline/verdict-cache';
+import type { BrownfieldPolicy } from '../../src/baseline/policy';
+
+const NOW = new Date('2026-07-22T09:00:00Z');
+
+const tmps: string[] = [];
+function mkRepo(policy?: Record<string, unknown>): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-defer-guard-'));
+  tmps.push(d);
+  execFileSync('git', ['init', '-q'], { cwd: d });
+  execFileSync('git', ['config', 'user.email', 'dev@example.com'], { cwd: d });
+  execFileSync('git', ['config', 'user.name', 'dev'], { cwd: d });
+  fs.writeFileSync(path.join(d, 'app.js'), 'const x = 1;\n');
+  if (policy) {
+    fs.mkdirSync(path.join(d, '.dxkit'), { recursive: true });
+    fs.writeFileSync(path.join(d, '.dxkit', 'policy.json'), JSON.stringify(policy, null, 2));
+  }
+  execFileSync('git', ['add', '-A'], { cwd: d });
+  execFileSync('git', ['commit', '-qm', 'init'], { cwd: d });
+  return d;
+}
+afterEach(() => {
+  for (const d of tmps.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const DEP_A: CachedBlockingFinding = {
+  fingerprint: 'aaaa000000000001',
+  kind: 'dep-vuln',
+  status: 'newly_published_advisory',
+  severity: 'high',
+  locator: 'fast-uri@3.1.2 · GHSA-aaaa-bbbb-cccc',
+};
+const DEP_B: CachedBlockingFinding = {
+  fingerprint: 'aaaa000000000002',
+  kind: 'dep-vuln',
+  status: 'newly_published_advisory',
+  severity: 'medium',
+  locator: 'svgo@1.3.2 · GHSA-dddd-eeee-ffff',
+};
+
+function seedVerdict(cwd: string, blockingFindings: CachedBlockingFinding[]): void {
+  writeVerdict(cwd, {} as unknown as BrownfieldPolicy, {
+    blocks: blockingFindings.length > 0,
+    warns: false,
+    blockingCount: blockingFindings.length,
+    unattributableCount: 0,
+    warningCount: 0,
+    markdown: '## dxkit signals',
+    ranAt: NOW.toISOString(),
+    blockingFindings,
+  });
+}
+
+describe('deferAdvisories', () => {
+  it('names the batch-lapse property when more than one finding shares the window', () => {
+    const d = mkRepo();
+    const out = deferAdvisories(d, { count: 21, expiresAt: '2026-07-28', now: NOW });
+    expect(out.some((a) => a.includes('All 21 findings share one expiry'))).toBe(true);
+    expect(out.some((a) => a.includes('2026-07-28'))).toBe(true);
+  });
+
+  it('stays quiet about batching for a single finding', () => {
+    const d = mkRepo();
+    const out = deferAdvisories(d, { count: 1, expiresAt: '2026-07-28', now: NOW });
+    expect(out.some((a) => a.includes('share one expiry'))).toBe(false);
+  });
+
+  it('warns when no remediation lane exists to close the findings', () => {
+    const d = mkRepo();
+    const out = deferAdvisories(d, { count: 9, expiresAt: '2026-07-28', now: NOW });
+    const lane = out.find((a) => a.includes('No automated remediation lane'));
+    expect(lane).toBeDefined();
+    // States the consequence and both escape hatches, not just the fact.
+    expect(lane).toContain('whoever opens a PR that day inherits them');
+    expect(lane).toContain('depBump.enabled');
+    expect(lane).toContain('remediate.enabled');
+  });
+
+  it('goes silent about lanes once the bump lane is enabled with a full cycle of room', () => {
+    const d = mkRepo({ depBump: { enabled: true } });
+    const out = deferAdvisories(d, { count: 9, expiresAt: '2026-08-05', now: NOW });
+    expect(out.some((a) => a.includes('No automated remediation lane'))).toBe(false);
+    expect(out.some((a) => a.includes('runs weekly'))).toBe(false);
+  });
+
+  it('warns when the window shuts before the weekly bump lane can run', () => {
+    const d = mkRepo({ depBump: { enabled: true } });
+    const out = deferAdvisories(d, { count: 9, expiresAt: '2026-07-25', now: NOW });
+    const cadence = out.find((a) => a.includes('runs weekly'));
+    expect(cadence).toBeDefined();
+    expect(cadence).toContain('3-day window');
+    expect(cadence).toContain(`+${DEFER_ADVISORY_EXPIRY_DAYS}d`);
+  });
+
+  it('warns that a same-day window is over tomorrow', () => {
+    const d = mkRepo({ remediate: { enabled: true } });
+    const out = deferAdvisories(d, { count: 1, expiresAt: '2026-07-22', now: NOW });
+    expect(out.some((a) => a.includes('closes TODAY'))).toBe(true);
+  });
+
+  it('says nothing at all when the deferral is unremarkable', () => {
+    const d = mkRepo({ remediate: { enabled: true } });
+    expect(deferAdvisories(d, { count: 1, expiresAt: '2026-08-05', now: NOW })).toEqual([]);
+  });
+});
+
+describe('executeDefer — the past-expiry refusal', () => {
+  it('refuses a window that already closed rather than writing a dead entry', () => {
+    const d = mkRepo();
+    seedVerdict(d, [DEP_A]);
+    const result = executeDefer(
+      d,
+      {
+        fingerprints: [DEP_A.fingerprint],
+        reason: 'backdated by mistake',
+        expires: '2026-07-01',
+        addedBy: 'dev@example.com',
+        mode: 'full',
+      },
+      NOW,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('already in the past');
+      expect(result.message).toContain('would suppress nothing');
+    }
+    // And nothing was written — the caller's intent failed loudly, not quietly.
+    expect(loadAllowlist(d)).toBeNull();
+  });
+
+  it('accepts a window closing today (the expiry is inclusive, so it still suppresses)', () => {
+    const d = mkRepo();
+    seedVerdict(d, [DEP_A]);
+    const result = executeDefer(
+      d,
+      {
+        fingerprints: [DEP_A.fingerprint],
+        reason: 'fix lands this afternoon',
+        expires: '2026-07-22',
+        addedBy: 'dev@example.com',
+        mode: 'full',
+      },
+      NOW,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.advisories.some((a) => a.includes('closes TODAY'))).toBe(true);
+  });
+});
+
+describe('both front-ends carry the advisories (one core, one set of facts)', () => {
+  it('the core attaches them to a successful defer, and only when something was written', () => {
+    const d = mkRepo();
+    seedVerdict(d, [DEP_A, DEP_B]);
+    const first = executeDefer(
+      d,
+      { fromLastCheck: true, reason: 'advisory batch', addedBy: 'dev@example.com', mode: 'full' },
+      NOW,
+    );
+    expect(first.ok).toBe(true);
+    if (first.ok) {
+      expect(first.added).toHaveLength(2);
+      expect(first.advisories.some((a) => a.includes('share one expiry'))).toBe(true);
+      expect(first.advisories.some((a) => a.includes('No automated remediation lane'))).toBe(true);
+    }
+    // A re-run writes nothing, so it chose no window and says nothing about one.
+    // Explicit fingerprints, not --from-last-check: the verdict cache is
+    // tree-scoped, and the allowlist write above already changed the tree.
+    const second = executeDefer(
+      d,
+      {
+        fingerprints: [DEP_A.fingerprint, DEP_B.fingerprint],
+        reason: 'advisory batch',
+        addedBy: 'dev@example.com',
+        mode: 'full',
+      },
+      NOW,
+    );
+    expect(second.ok).toBe(true);
+    if (second.ok) {
+      expect(second.added).toEqual([]);
+      expect(second.advisories).toEqual([]);
+    }
+  });
+
+  it('the PR reply carries them into the thread the reviewers read', () => {
+    const d = mkRepo();
+    seedVerdict(d, [DEP_A, DEP_B]);
+    const payload = runCommentDeferCore(
+      d,
+      {
+        DXKIT_COMMENT_BODY: '/dxkit defer --new-advisories --reason="advisory batch"',
+        DXKIT_COMMENT_AUTHOR: 'reviewer',
+        DXKIT_COMMENT_PR: '377',
+      },
+      NOW,
+    );
+    expect(payload.action).toBe('deferred');
+    expect(payload.replyMarkdown).toContain('No automated remediation lane');
+    expect(payload.replyMarkdown).toContain('share one expiry');
+  });
+});


### PR DESCRIPTION
**PR 3 of 4 in the 4.3.1 stack.** Stacked on #194 (which is stacked on #193) — this PR's own diff is the allowlist defer path.

A deferral is a promise: *"we will fix this before `<date>`."* The expiry is the forcing function and it works. What the product never said is whether the promise was **keepable**. On the repo that produced this class, an engineer deferred 21 dependency advisories for six days with no remediation lane enabled. Nothing in that repo was ever going to fix 9 packages in six days, and all 21 came back on the same morning and blocked every open PR.

None of that needed predicting — all of it was knowable at the keystroke.

## The advisories

| fires when | says |
| --- | --- |
| more than one finding | all N share one expiry, so they return **together** on that date, not spread out — the shape of the wall, while the window is still being chosen |
| no lane enabled | nothing here will close these before the date, and whoever opens a PR that day inherits them; names both escape hatches (`depBump.enabled` deterministic, `remediate.enabled` agentic) |
| bump lane on, window < a cycle | the lane runs weekly, so the window may shut before it has run even once |
| window closes today | suppressed for the rest of today, re-blocks tomorrow |

Each fires on its own condition and **goes silent when it does not hold**. An advisory that always fires is an advisory nobody reads, so the silent cases are pinned as hard as the firing ones (including a fully unremarkable deferral, which produces an empty list).

## Centralization

The guard lives beside the **one** defer core and is consulted *from* it, so both front-ends inherit the same facts: `allowlist defer` prints them, and the `/dxkit defer` PR reply carries them into the thread where the reviewers who will live with the deferral read them. A third front-end gets them for free. The two lane probes come from their declared homes (`depBumpEnabled` / `remediateEnabled`) rather than a fresh policy read — `doctor` recommends these same lanes, and a second read is how two surfaces start disagreeing about whether a repo is covered.

## It never blocks

Time-boxing a finding is a legitimate engineering decision, and the human making it knows things dxkit does not (a fix already in review, a vendor patch landing Thursday). Every advisory is a fact plus its consequence — never a veto, never a nag.

**One hard refusal**, in the core rather than the guard: an expiry already in the past writes an entry that suppresses **nothing** (the matcher skips an expired entry), so the finding keeps blocking while the allowlist claims it was accepted. That silently fails the caller's intent, so it is refused with the fix named. No existing test or workflow backdates an expiry.

## A scope reallocation worth flagging

The 4.3.1 plan listed "comment-defer reciprocity — the bot that accepted the deferral comments on the same thread *before it lapses*" as part of this PR. Half of it belongs here and shipped: the accepting reply now carries the keepability facts, so the thread records them at acceptance time. The *pre-lapse follow-up* is inherently a **scheduled** action — something has to wake up days later and revisit the thread — so it belongs to PR 4's refresh-lane decision surface, which is the scheduled context and already needs to know the PR it is speaking about. Flagging rather than quietly dropping it.

## Gates run locally

| gate | result |
| --- | --- |
| `tsc --noEmit` (src + `typecheck:test`) | pass |
| `eslint . --max-warnings 0` | pass |
| `format:check` | pass |
| `check-architecture.sh` / `check-slop.sh` | pass |
| `test:run` | **335 files / 5,065 tests pass** (+11) |
| self-guardrail `--mode ref-based --ref origin/main` | **PASSED** |

## Next

PR 4 — the refresh-lane decision surface, designed before implemented (it makes a managed workflow write, so Rule 15 + Rule 16 apply, and it carries the pre-lapse notification above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)