### PR TITLE
feat(allowlist): the expiry decision surface — reach the owner when no PR is open

### DIFF
--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -25,6 +25,7 @@ stanzas).
 | `depBump.allowMajor`                | [#dep-bump](#dep-bump)                       |
 | `depBump.enabled`                   | [#dep-bump](#dep-bump)                       |
 | `duplication.mode`                  | [#duplication-mode](#duplication-mode)       |
+| `expiryNotice.enabled`              | [#expiry-notice](#expiry-notice)             |
 | `flow.mode`                         | [#flow-mode](#flow-mode)                     |
 | `flow.sources`                      | [#flow-sources](#flow-sources)               |
 | `licenses.prohibited`               | [#prohibited-licenses](#prohibited-licenses) |
@@ -236,6 +237,39 @@ boring to merge.
 
 **Interactions.** What the bump lane cannot close (no fixed release,
 breaking-not-allowed) is exactly the [remediate lane's](#remediate) input.
+
+## Expiry notice
+
+**What it does.** While the scheduled baseline refresh is running anyway, it
+maintains ONE GitHub issue naming the allowlist suppressions whose windows
+close within the next 14 days: the finding, its kind, the severity the
+reviewer acknowledged, who accepted it (`addedBy`), the date, and the
+countdown. One issue, updated in place — and closed automatically once
+nothing is lapsing.
+
+**Default and why.** Off. `expiryNotice.enabled: true` + `vyuh-dxkit update`
+grants the refresh workflow `issues: write` and turns the lane on. It is the
+only dxkit lane that opens an issue on its own initiative, so it is never
+enabled for you.
+
+**When you would turn it on.** The [lapse projection](#new-advisories) already
+warns every author and reviewer on every guardrail check, which covers any
+week somebody opens a PR. Turn this on if your repo can go quiet for days at a
+time — that is the case where a deferral lapses with nobody watching and the
+next PR author inherits findings they never touched.
+
+**Tuning.** None. The horizon is the same 14 days
+[`allowlist audit`](../reference/cli.md) uses, so the issue and the check never
+disagree about which entries are in scope. If your
+[refresh cadence](#refresh-cadence) is slower than 14 days, the first notice
+can arrive late — the issue body says so rather than pretending otherwise.
+
+**Interactions.** It never gates: no verdict, no exit code, no block. The
+expiry remains the forcing function. Owners are NAMED from `addedBy`, never
+assigned — `addedBy` is an email address, and guessing a GitHub login from an
+email would put a stranger's name on someone else's deferral. If issues are
+disabled or the token lacks the permission, the refresh reports why and carries
+on; a notification that could not be posted must never fail a baseline capture.
 
 ## Reports on merge
 

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
@@ -28,7 +28,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
+__DXKIT_REFRESH_PERMISSIONS__
 
 jobs:
 __DXKIT_FRAGMENT_CAPTURE_JOBS__

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: read
+__DXKIT_REFRESH_PERMISSIONS__
 
 jobs:
 __DXKIT_FRAGMENT_CAPTURE_JOBS__

--- a/src-templates/.github/workflows/dxkit-baseline-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh.yml
@@ -19,7 +19,7 @@ on:
       - '.dxkit/baselines/**'
 
 permissions:
-  contents: write
+__DXKIT_REFRESH_PERMISSIONS__
 
 jobs:
 __DXKIT_FRAGMENT_CAPTURE_JOBS__

--- a/src/allowlist/file.ts
+++ b/src/allowlist/file.ts
@@ -333,6 +333,24 @@ export function removeEntry(file: AllowlistFile, fingerprint: string): Allowlist
 }
 
 /**
+ * `loadAllowlist` with the throw swallowed — null on absence OR on a malformed
+ * file. The fail-open sibling for advisory READERS (`doctor`'s hygiene check,
+ * the discovery probes): a broken allowlist must not take down a surface whose
+ * job is telling you things. Naming mirrors `loadGraph` / `tryLoadGraph`.
+ *
+ * Enforcing paths (the guardrail's suppression resolution) keep using
+ * `loadAllowlist` directly — there, a malformed file must surface, not silently
+ * read as "nothing is suppressed".
+ */
+export function tryLoadAllowlist(cwd: string): AllowlistFile | null {
+  try {
+    return loadAllowlist(cwd);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Whether the allowlist suppresses a given finding. Pure
  * fingerprint match. Expiry handling is layered on top by
  * `isEntryActive` (kept separate so the guardrail can distinguish

--- a/src/baseline/expiry-notice.ts
+++ b/src/baseline/expiry-notice.ts
@@ -1,0 +1,283 @@
+/**
+ * The expiry DECISION surface — one maintained GitHub issue naming the
+ * allowlist suppressions whose windows are about to close, who accepted each,
+ * and when.
+ *
+ * # The hole this closes (and the three it does not need to)
+ *
+ * By the time this runs, three surfaces already warn about an approaching lapse:
+ * the guardrail check's console section, its PR comment, and its JSON — every
+ * author and reviewer, on every run, for the whole window. What none of them can
+ * do is speak when NOBODY OPENS A PR. On the repo that produced this class the
+ * deferral was created on the 22nd, the repo went quiet, and the lapse landed on
+ * the 29th inside an unrelated 16-file frontend PR whose author had never seen
+ * the findings. The person who made the promise was never addressed again; the
+ * person who paid was whoever pushed next.
+ *
+ * So this surface exists for exactly one reason: to reach a named owner with no
+ * PR in play. It rides the scheduled refresh (which runs weekly AND on every
+ * merge to the default branch), so it needs no new workflow, no new managed
+ * artifact, and no new CLI verb.
+ *
+ * # What it claims, and what it refuses to claim
+ *
+ * Entry-shaped facts only: fingerprint, kind, category, the severity the
+ * reviewer ACKNOWLEDGED at accept time, `addedBy`, the date, the countdown. It
+ * does NOT say "2 of these will block" — that projection needs a classification
+ * pass the refresh does not run, and the check (which does run one) already
+ * makes the claim honestly. Each surface asserts only what it observed.
+ *
+ * # Load-bearing behaviours
+ *
+ *   - **One issue, found by marker.** `EXPIRY_NOTICE_MARKER` in the body is the
+ *     identity; the title is stable prose. Found → edit. Absent → create.
+ *   - **It closes itself.** Nothing lapsing inside the horizon ⇒ close the open
+ *     issue. This is not tidiness: an open issue that no longer describes
+ *     reality is precisely how a team learns to filter dxkit's issues, which
+ *     would silently disable every future notice. The self-close is why the
+ *     surface stays trustworthy.
+ *   - **Fail-OPEN, always disclosed.** Issues disabled, a token without
+ *     `issues: write`, no `gh` — every one of those yields a reported reason and
+ *     an unchanged exit. The refresh's contract is capturing the baseline; a
+ *     notification that could not be posted must never fail that job (the
+ *     `GateFailure` discipline).
+ *   - **It never gates.** No verdict, no exit code, no block. The expiry itself
+ *     is the forcing function; this only makes it visible earlier.
+ *   - **Owners are NAMED, never assigned.** `addedBy` is an email address, and
+ *     mapping an email to a GitHub login is a guess — a wrong assignment puts a
+ *     stranger's name on someone else's deferral. Naming cannot be wrong.
+ *
+ * # Horizon
+ *
+ * The trigger is the ONE shared horizon (`auditAllowlist`, 14 days), not a
+ * "before the next scheduled run" computation. A cron next-run calculator is
+ * real complexity, and the horizon dominates it for every cadence the product
+ * offers (`weekly` = 7d, `daily` = 1d, plus every push to the default branch).
+ * The one honest limitation — a custom cron slower than the horizon can deliver
+ * the first notice late — is stated in the issue body rather than hidden.
+ */
+
+import { auditAllowlist, loadAllowlist, SOON_TO_EXPIRE_DAYS } from '../allowlist/file';
+import type { SoonToExpire } from '../allowlist/file';
+import { dxkitCli } from '../self-invocation';
+import type { Exec } from '../land-refresh';
+
+/** Body marker that identifies dxkit's notice issue. The issue is found by this,
+ *  never by title matching, so retitling never orphans one. */
+export const EXPIRY_NOTICE_MARKER = '<!-- dxkit-expiry-notice -->';
+
+export type ExpiryNoticeOutcome =
+  /** The knob is off — nothing was looked at. */
+  | 'disabled'
+  /** Nothing expires inside the horizon and no issue was open. */
+  | 'nothing-to-report'
+  | 'issue-opened'
+  | 'issue-updated'
+  /** Nothing lapsing any more, so the open issue was closed. */
+  | 'issue-closed'
+  /** Could not talk to GitHub (no gh, no permission, issues disabled). */
+  | 'unavailable';
+
+export interface ExpiryNoticeResult {
+  readonly outcome: ExpiryNoticeOutcome;
+  /** How many suppressions lapse inside the horizon. */
+  readonly lapsing: number;
+  readonly issueUrl?: string;
+  /** Always populated: why this outcome, in one sentence a refresh log can
+   *  print verbatim. Never silent, whichever way it went. */
+  readonly note: string;
+}
+
+export interface ExpiryNoticeOptions {
+  readonly cwd: string;
+  readonly exec: Exec;
+  readonly now?: Date;
+  /** Horizon override; defaults to the shared constant. */
+  readonly horizonDays?: number;
+}
+
+const TITLE_PREFIX = 'dxkit: allowlist suppressions expiring';
+
+function titleFor(count: number): string {
+  return `${TITLE_PREFIX} (${count})`;
+}
+
+/**
+ * The issue body. Pure, so the wording is testable without touching GitHub, and
+ * so the same builder can be appended to the standing advisory-decision PR.
+ */
+export function expiryNoticeBody(
+  soon: ReadonlyArray<SoonToExpire>,
+  opts: { readonly horizonDays: number },
+): string {
+  const owners = [...new Set(soon.map((s) => s.entry.addedBy).filter(Boolean))];
+  const soonest = Math.min(...soon.map((s) => s.daysRemaining));
+  const lines: string[] = [
+    EXPIRY_NOTICE_MARKER,
+    '',
+    `**${soon.length} allowlist suppression${soon.length === 1 ? '' : 's'} lapse within ` +
+      `${opts.horizonDays} days** (soonest ${soonest === 0 ? 'today' : `in ${soonest} day${soonest === 1 ? '' : 's'}`}).`,
+    '',
+    'When a window closes, the finding it was holding back returns on the next guardrail run. ' +
+      'That is the deferral working as intended — but it should be a decision, not a surprise ' +
+      'sprung on whoever opens the next PR.',
+    '',
+    '| Finding | Kind | Accepted as | Accepted by | Expires | In |',
+    '|---|---|---|---|---|---|',
+  ];
+  for (const { entry, daysRemaining } of soon) {
+    lines.push(
+      `| \`${entry.fingerprint}\` | ${entry.kind} | ${entry.acknowledgedSeverity ?? entry.category} | ` +
+        `${entry.addedBy || '—'} | ${entry.expiresAt} | ${daysRemaining}d |`,
+    );
+  }
+  lines.push('');
+  const byDate = new Set(soon.map((s) => s.entry.expiresAt));
+  if (soon.length > 1 && byDate.size === 1) {
+    lines.push(
+      `All ${soon.length} share one expiry, so they return together on ` +
+        `${soon[0]!.entry.expiresAt} — not spread out.`,
+      '',
+    );
+  }
+  lines.push(
+    '**Two lanes.**',
+    '',
+    '1. **Fix them** before the date — then this issue closes itself on the next refresh.',
+    `2. **Renew deliberately** if the work genuinely needs longer: ` +
+      `\`${dxkitCli('allowlist defer')} --expires +7d\` re-dates the window, and tells you ` +
+      `whether anything in the repo can actually close it in that time.`,
+    '',
+    `Full list and rationales: \`${dxkitCli('allowlist audit')}\`.`,
+    '',
+    owners.length > 0
+      ? `Accepted by: ${owners.join(', ')} — named from each entry's \`addedBy\`, not assigned ` +
+          `(dxkit will not guess a GitHub login from an email address).`
+      : 'No `addedBy` recorded on these entries.',
+    '',
+    '---',
+    '',
+    `_Maintained by \`${dxkitCli('baseline refresh')}\` — one issue, updated in place, closed when ` +
+      `nothing is lapsing. It never blocks a build; the expiry is the forcing function. If your ` +
+      `refresh cadence is slower than ${opts.horizonDays} days, the first notice can arrive late._`,
+  );
+  return lines.join('\n');
+}
+
+/** The open notice issue's number + url, or null. Found by MARKER, not title. */
+function findOpenNotice(exec: Exec): { number: number; url: string } | null {
+  const raw = exec(
+    'gh',
+    ['issue', 'list', '--state', 'open', '--limit', '100', '--json', 'number,url,body'],
+    { allowFail: true },
+  ).trim();
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Array<{ number: number; url: string; body?: string }>;
+    const hit = parsed.find((i) => (i.body ?? '').includes(EXPIRY_NOTICE_MARKER));
+    return hit ? { number: hit.number, url: hit.url } : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create / update / close the one notice issue to match what the allowlist
+ * currently says. Idempotent: safe to run on every refresh, which is exactly
+ * what happens.
+ */
+export function syncExpiryNotice(opts: ExpiryNoticeOptions): ExpiryNoticeResult {
+  const horizonDays = opts.horizonDays ?? SOON_TO_EXPIRE_DAYS;
+  const now = opts.now ?? new Date();
+  const file = loadAllowlist(opts.cwd);
+  const soon = file
+    ? auditAllowlist(file, { now, soonToExpireDays: horizonDays }).soonToExpire
+    : [];
+
+  const existing = findOpenNotice(opts.exec);
+
+  if (soon.length === 0) {
+    if (!existing) {
+      return {
+        outcome: 'nothing-to-report',
+        lapsing: 0,
+        note: `No allowlist suppression expires within ${horizonDays} days.`,
+      };
+    }
+    // The self-close. A notice that outlives its facts teaches people to ignore
+    // the next one.
+    exec_close(opts.exec, existing.number);
+    return {
+      outcome: 'issue-closed',
+      lapsing: 0,
+      issueUrl: existing.url,
+      note:
+        `Nothing lapses within ${horizonDays} days any more — closed the expiry notice ` +
+        `(${existing.url}).`,
+    };
+  }
+
+  const body = expiryNoticeBody(soon, { horizonDays });
+  const title = titleFor(soon.length);
+
+  if (existing) {
+    const edited = opts.exec(
+      'gh',
+      ['issue', 'edit', String(existing.number), '--title', title, '--body', body],
+      { allowFail: true },
+    );
+    // `gh issue edit` prints the url on success and nothing on failure.
+    if (edited.trim() === '') {
+      return {
+        outcome: 'unavailable',
+        lapsing: soon.length,
+        issueUrl: existing.url,
+        note:
+          `${soon.length} suppression(s) lapse within ${horizonDays} days, but the notice issue ` +
+          `could not be updated (no permission / no gh). It is still open: ${existing.url}.`,
+      };
+    }
+    return {
+      outcome: 'issue-updated',
+      lapsing: soon.length,
+      issueUrl: existing.url,
+      note: `Updated the expiry notice: ${soon.length} suppression(s) lapse within ${horizonDays} days (${existing.url}).`,
+    };
+  }
+
+  const created = opts
+    .exec('gh', ['issue', 'create', '--title', title, '--body', body], { allowFail: true })
+    .trim();
+  const url = created.split('\n').filter(Boolean).pop() ?? '';
+  if (!url.startsWith('http')) {
+    return {
+      outcome: 'unavailable',
+      lapsing: soon.length,
+      note:
+        `${soon.length} suppression(s) lapse within ${horizonDays} days, but no issue could be ` +
+        `opened — issues may be disabled, or the workflow token lacks \`issues: write\` (grant it ` +
+        `by re-running \`${dxkitCli('update')}\` with \`expiryNotice.enabled\` set). The lapse ` +
+        `still surfaces on every guardrail check.`,
+    };
+  }
+  return {
+    outcome: 'issue-opened',
+    lapsing: soon.length,
+    issueUrl: url,
+    note: `Opened the expiry notice: ${soon.length} suppression(s) lapse within ${horizonDays} days (${url}).`,
+  };
+}
+
+function exec_close(exec: Exec, issueNumber: number): void {
+  exec(
+    'gh',
+    [
+      'issue',
+      'close',
+      String(issueNumber),
+      '--comment',
+      'Nothing is lapsing within the horizon any more — closing. dxkit reopens a fresh notice if that changes.',
+    ],
+    { allowFail: true },
+  );
+}

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -167,6 +167,11 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
     anchor: 'dep-bump',
   },
   {
+    path: 'expiryNotice.enabled',
+    summary: 'maintain one issue naming allowlist suppressions about to lapse',
+    anchor: 'expiry-notice',
+  },
+  {
     path: 'reports.onMerge',
     summary: 'publish report snapshots to the dxkit-reports ref on merge',
     anchor: 'reports-on-merge',
@@ -352,6 +357,23 @@ export const POLICY_STANZAS: readonly PolicyStanzaMeta[] = [
     anchor: 'dep-bump',
     example: () => ({ enabled: true }),
     followUp: ['Installs a managed workflow: run `vyuh-dxkit update` after enabling.'],
+  },
+  {
+    key: 'expiryNotice',
+    coversKnobs: ['expiryNotice.enabled'],
+    title: 'Expiring-suppression notice',
+    blurb: [
+      'A deferral is a promise with a date on it. The guardrail check already',
+      'warns every PR while the window is open — this covers the quiet week:',
+      'the scheduled refresh maintains ONE issue naming what lapses, who',
+      'accepted it, and when, and closes it once nothing is lapsing.',
+      'Never blocks; the expiry itself stays the forcing function.',
+    ],
+    anchor: 'expiry-notice',
+    example: () => ({ enabled: true }),
+    followUp: [
+      'Grants the refresh workflow `issues: write`: run `vyuh-dxkit update` after enabling.',
+    ],
   },
   {
     key: 'reports',

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -214,6 +214,12 @@ export function buildPolicySchema(version: string): Schema {
         },
         'Scheduled deterministic dependency-bump PRs.',
       ),
+      expiryNotice: obj(
+        {
+          enabled: boolProp('expiryNotice.enabled'),
+        },
+        'One maintained issue naming allowlist suppressions about to lapse.',
+      ),
       reports: obj(
         {
           onMerge: boolProp('reports.onMerge'),

--- a/src/baseline/policy.ts
+++ b/src/baseline/policy.ts
@@ -349,6 +349,21 @@ export interface BrownfieldPolicy {
    */
   readonly depBump?: { readonly enabled?: boolean; readonly allowMajor?: boolean };
   /**
+   * The expiry decision surface: while the scheduled refresh is running anyway,
+   * maintain ONE GitHub issue naming the allowlist suppressions whose windows
+   * close inside the shared horizon, who accepted each, and when. Opt-in,
+   * default OFF — it is the only dxkit lane that opens an issue on its own
+   * initiative, and enabling it grants the refresh workflow `issues: write`
+   * (run `vyuh-dxkit update` after flipping it so the workflow is re-rendered).
+   *
+   * The guardrail check already warns every author and reviewer during the
+   * window (the lapse projection). This closes the remaining hole: a repo where
+   * nobody opens a PR for a week gets no warning at all, and the person who
+   * accepted the deferral is never addressed. Never gates — the expiry itself
+   * remains the forcing function.
+   */
+  readonly expiryNotice?: { readonly enabled?: boolean };
+  /**
    * Recall-attribution tuning (Rule 19). Absent ⟹ `inputs: 'resolved'`.
    */
   readonly recall?: RecallPolicy;

--- a/src/baseline/refresh.ts
+++ b/src/baseline/refresh.ts
@@ -72,7 +72,8 @@ import {
 import { loadAllowlist } from '../allowlist/file';
 import { makeExec, openOrUpdateStandingPr, type LandRefreshResult } from '../land-refresh';
 import { internalGitPushArgs } from '../git-internal-push';
-import { detectDefaultBranch } from '../ship-installers';
+import { detectDefaultBranch, expiryNoticeEnabled } from '../ship-installers';
+import { syncExpiryNotice, type ExpiryNoticeResult } from './expiry-notice';
 
 /** The standing decision branch. ONE branch, force-updated — never a pile. */
 export const ADVISORY_DECISION_BRANCH = 'dxkit/advisory-decision';
@@ -92,6 +93,9 @@ export interface BaselineRefreshResult {
   readonly heldOut: ReadonlyArray<HeldOutAdvisory>;
   /** The decision-PR landing outcome; absent when nothing was held out. */
   readonly decision?: LandRefreshResult;
+  /** The expiry decision surface's outcome; absent when the knob is off (the
+   *  default) — so a repo that never opted in cannot tell the difference. */
+  readonly expiryNotice?: ExpiryNoticeResult;
   /** Why the advisory lane did / could not run — always populated so a refresh
    *  log never leaves the reader guessing (the GateFailure discipline). */
   readonly note: string;
@@ -275,10 +279,38 @@ export function decisionPrBody(
 }
 
 /**
- * The refresh orchestration. See the module docs for semantics; the return's
- * `note` always says what the advisory lane did (or why it could not run).
+ * The refresh orchestration: the advisory decision lane, then the expiry
+ * decision surface.
+ *
+ * The two are INDEPENDENT and both ride this one scheduled run. A suppression
+ * can be about to lapse whether or not this refresh held any advisory out, so
+ * the notice is synced on every path the advisory lane can take — including its
+ * early returns (ref-based mode, first capture, no prior baseline). Wiring it
+ * inside the lane would have made the notice a silent function of whether an
+ * unrelated feed happened to move that week.
  */
 export async function runBaselineRefresh(
+  opts: BaselineRefreshOptions,
+): Promise<BaselineRefreshResult> {
+  const result = await runAdvisoryDecisionLane(opts);
+  const cwd = path.resolve(opts.cwd);
+  // Opt-in, default off: it is the only dxkit lane that opens an issue on its
+  // own initiative, and it needs a permission the workflow only holds when the
+  // repo asked for it (`refreshPermissionsBlock`).
+  if (!expiryNoticeEnabled(cwd)) return result;
+  const expiryNotice = syncExpiryNotice({
+    cwd,
+    exec: opts.exec ?? makeExec(cwd),
+    ...(opts.now !== undefined ? { now: opts.now } : {}),
+  });
+  return { ...result, expiryNotice };
+}
+
+/**
+ * The advisory decision lane. See the module docs for semantics; the return's
+ * `note` always says what it did (or why it could not run).
+ */
+async function runAdvisoryDecisionLane(
   opts: BaselineRefreshOptions,
 ): Promise<BaselineRefreshResult> {
   const cwd = path.resolve(opts.cwd);

--- a/src/discovery/advisor.ts
+++ b/src/discovery/advisor.ts
@@ -13,6 +13,7 @@ import { FLOW_CONFIG_SCHEMA_VERSION } from '../analyzers/flow/config';
 import { SCHEMA_CONFIG_SCHEMA_VERSION } from '../analyzers/model-schema/config';
 import { DUPLICATION_CONFIG_SCHEMA_VERSION } from '../analyzers/duplication/config';
 import { readPolicyObjectSafe } from '../baseline/policy-text';
+import { tryLoadAllowlist } from '../allowlist/file';
 import { failingFloorDebt } from '../baseline/floor-debt';
 import {
   existsAt,
@@ -209,6 +210,36 @@ export function recommendDepBump(ctx: RecommendContext): Recommendation | null {
       `floor-verified PR (no agent involved). Preview with the command below; enable the ` +
       `scheduled lane with .dxkit/policy.json depBump.enabled: true + vyuh-dxkit update`,
     command: 'vyuh-dxkit deps bump',
+  };
+}
+
+/**
+ * Expiring-suppression notice: fires when the repo actually holds allowlist
+ * entries with expiry dates and the notice lane is not configured. Grounded in
+ * the committed allowlist — a repo with no time-boxed suppressions never hears
+ * about it, and one that decided (either way) stops hearing immediately.
+ *
+ * Deliberately keyed on "has expiring entries at all", not "has entries
+ * expiring within the horizon": the recommendation is about adopting a lane
+ * BEFORE the quiet week that needs it, and a probe that only fired inside the
+ * horizon would arrive at the same time as the problem.
+ */
+export function recommendExpiryNotice(ctx: RecommendContext): Recommendation | null {
+  const policy = readPolicyObjectSafe(ctx.cwd) as { expiryNotice?: unknown } | null;
+  if (policy && policy.expiryNotice !== undefined) return null;
+  // Through the ONE allowlist reader, not a raw JSON read: it validates the
+  // schema and merges the sanitized-mode reason sidecar, so a compliance-mode
+  // repo's entries are counted the same as a full-mode repo's.
+  const allowlist = tryLoadAllowlist(ctx.cwd);
+  const timeBoxed = (allowlist?.entries ?? []).filter((e) => e.expiresAt !== undefined).length;
+  if (timeBoxed === 0) return null;
+  return {
+    reason:
+      `${timeBoxed} allowlist suppression${timeBoxed === 1 ? ' is' : 's are'} time-boxed — the ` +
+      `guardrail check warns while a PR is open, but a quiet week ends with the lapse landing on ` +
+      `whoever pushes next. Set .dxkit/policy.json expiryNotice.enabled: true + vyuh-dxkit update ` +
+      `to have the scheduled refresh keep one issue naming what lapses and who accepted it`,
+    command: 'vyuh-dxkit allowlist audit',
   };
 }
 

--- a/src/discovery/command-defs-gate.ts
+++ b/src/discovery/command-defs-gate.ts
@@ -10,6 +10,7 @@ import {
   recommendChecks,
   recommendDebt,
   recommendDepBump,
+  recommendExpiryNotice,
   recommendRemediate,
   recommendExtensions,
   recommendLoopPreset,
@@ -80,6 +81,7 @@ export const GATE_COMMANDS = [
       'Accept a finding with a typed category + required reason + optional expiry; audit and prune ' +
       'entries. `defer` bulk-defers newly published dep-vuln advisories time-boxed (dep-vuln-only).',
     skill: 'dxkit-allowlist',
+    whenToRecommend: recommendExpiryNotice,
   },
   {
     id: 'ingest',

--- a/src/discovery/posture-knobs.ts
+++ b/src/discovery/posture-knobs.ts
@@ -144,6 +144,16 @@ export const POSTURE_KNOBS: readonly PostureKnob[] = [
       'a CI-performance transport (graph.json Actions-cache), not a gate/posture — rebuild-on-demand is the correct default and changes no finding, so there is no behavioral difference to recommend. Installed by init/update when set to "cache"; documented in policy.md.',
   },
   {
+    path: 'expiryNotice.enabled',
+    command: 'allowlist',
+    requiresPlan: false,
+    requiresRecommend: true,
+    note:
+      'enabling grants the managed refresh workflow `issues: write`, which configure’s ' +
+      'policy-only merge-write cannot place — so no planConfig; recommendExpiryNotice surfaces ' +
+      'the lane once the repo actually holds suppressions that expire.',
+  },
+  {
     path: 'depBump.enabled',
     command: 'deps',
     requiresPlan: false,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -14,7 +14,7 @@ import { loadPolicyFromCwd } from './baseline/policy';
 import { detectEnforcement } from './enforcement';
 import { detectInstalledRefreshTransport, detectDefaultBranch } from './ship-installers';
 import { detectPackageManager, addDevCommand } from './package-manager';
-import { loadAllowlist, auditAllowlist } from './allowlist/file';
+import { auditAllowlist, tryLoadAllowlist } from './allowlist/file';
 import { snapshotEngines, readSnapshot } from './ingest/snapshot';
 import { EXTERNAL_SNAPSHOT_STALE_DAYS, snapshotAgeDays } from './ingest/engine-failure';
 import { diagnoseFlow, type FlowDiagnosis } from './analyzers/flow/diagnose';
@@ -121,19 +121,6 @@ function nodeMajorVersion(): number {
 function safeLoadPolicy(cwd: string): ReturnType<typeof loadPolicyFromCwd> | null {
   try {
     return loadPolicyFromCwd(cwd);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Wrap `loadAllowlist` with a swallowing try/catch — a malformed
- * allowlist file must not break doctor. Returns null on absence or
- * parse failure; the expiry check simply doesn't emit in that case.
- */
-function safeLoadAllowlist(cwd: string): ReturnType<typeof loadAllowlist> {
-  try {
-    return loadAllowlist(cwd);
   } catch {
     return null;
   }
@@ -902,7 +889,7 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
   // nearing expiry needs a decision before it lapses. Surface both so
   // a reviewed-and-accepted finding doesn't silently turn back into a
   // blocker mid-sprint. Only emits when an allowlist actually exists.
-  const allowlistFile = safeLoadAllowlist(cwd);
+  const allowlistFile = tryLoadAllowlist(cwd);
   if (allowlistFile && allowlistFile.entries.length > 0) {
     const audit = auditAllowlist(allowlistFile);
     if (audit.expired.length > 0) {

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -901,6 +901,10 @@ export function installCiBaselineRefresh(
       // Policy-driven through the ONE normalizer; the 'tree' template has no
       // schedule (it refreshes per push), so the key is simply absent there.
       __DXKIT_REFRESH_CRON__: baselineRefreshCron({ baseline: readPolicyBaselineSection(cwd) }),
+      // The permission block, transport-derived + knob-derived (the expiry
+      // notice needs `issues: write`). Rendered from ONE helper so the workflow
+      // can never hold a permission the lane does not need, or lack one it does.
+      __DXKIT_REFRESH_PERMISSIONS__: refreshPermissionsBlock(cwd, plan.transport),
       [CI_RUNTIME_SETUP_KEY]: renderCiRuntimeSetup(cwd),
       // Multi-env capture (Rule 20 / design §3.4): per-host fragment jobs +
       // the merge before the commit. All three slots render empty on a repo
@@ -1103,6 +1107,33 @@ export function depBumpEnabled(cwd: string): boolean {
   } catch {
     return false;
   }
+}
+
+/** Whether the expiry decision surface is enabled in policy
+ *  (`expiryNotice.enabled: true`). Read here, beside its lane siblings, so the
+ *  refresh lane and the workflow's permission block resolve it from ONE place —
+ *  a lane that runs while the workflow lacks `issues: write` would fail-open
+ *  silently every week. */
+export function expiryNoticeEnabled(cwd: string): boolean {
+  try {
+    return loadPolicyFromCwd(cwd).expiryNotice?.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The refresh workflow's `permissions:` block. `contents` is the transport's
+ * own requirement (a tree/branch push needs write; the cache transport writes
+ * no git object at all), and `issues: write` is added ONLY when the expiry
+ * notice is enabled — so a repo that never opts in keeps a workflow
+ * byte-identical to the one it has today.
+ */
+export function refreshPermissionsBlock(cwd: string, transport: BaselineAnchor): string {
+  const contents = transport === 'cache' ? 'read' : 'write';
+  const lines = [`  contents: ${contents}`];
+  if (expiryNoticeEnabled(cwd)) lines.push('  issues: write');
+  return lines.join('\n');
 }
 
 export function installCiCommentDefer(cwd: string, opts: InstallerOpts = {}): ShipInstallResult {

--- a/test/baseline/expiry-notice.test.ts
+++ b/test/baseline/expiry-notice.test.ts
@@ -1,0 +1,293 @@
+/**
+ * The expiry DECISION surface — the one maintained issue that reaches a
+ * deferral's owner when no PR is open.
+ *
+ * The hole it closes is narrow and specific. Three surfaces already warn during
+ * the window (console / PR comment / JSON), so this is only about the quiet
+ * week: on the repo that produced this class, the deferral was created on the
+ * 22nd, the repo went quiet, and the lapse landed on the 29th inside an
+ * unrelated PR whose author had never seen the findings.
+ *
+ * Pinned here: create / update / **close** (the self-close is what keeps the
+ * surface trustworthy — an issue that outlives its facts teaches a team to
+ * filter dxkit's issues, which would disable every future notice), fail-open on
+ * every GitHub failure, the opt-in gate, and the permission block that must
+ * carry `issues: write` exactly when the lane is on.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  EXPIRY_NOTICE_MARKER,
+  expiryNoticeBody,
+  syncExpiryNotice,
+} from '../../src/baseline/expiry-notice';
+import { refreshPermissionsBlock, expiryNoticeEnabled } from '../../src/ship-installers';
+import { auditAllowlist, SOON_TO_EXPIRE_DAYS } from '../../src/allowlist/file';
+import type { AllowlistEntry, AllowlistFile } from '../../src/allowlist/file';
+import type { Exec } from '../../src/land-refresh';
+
+const NOW = new Date('2026-07-22T09:00:00Z');
+
+const tmps: string[] = [];
+function mkRepo(
+  opts: { policy?: Record<string, unknown>; allowlist?: AllowlistFile } = {},
+): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-expiry-notice-'));
+  tmps.push(d);
+  execFileSync('git', ['init', '-q'], { cwd: d });
+  fs.mkdirSync(path.join(d, '.dxkit'), { recursive: true });
+  if (opts.policy) {
+    fs.writeFileSync(path.join(d, '.dxkit', 'policy.json'), JSON.stringify(opts.policy, null, 2));
+  }
+  if (opts.allowlist) {
+    fs.writeFileSync(
+      path.join(d, '.dxkit', 'allowlist.json'),
+      JSON.stringify(opts.allowlist, null, 2),
+    );
+  }
+  return d;
+}
+afterEach(() => {
+  for (const d of tmps.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+function entry(fingerprint: string, expiresAt?: string, over: Partial<AllowlistEntry> = {}) {
+  return {
+    fingerprint,
+    kind: 'dep-vuln',
+    category: expiresAt ? 'deferred' : 'false-positive',
+    reason: 'time-boxed pending dependency remediation',
+    addedBy: 'jane@corp.example',
+    addedAt: '2026-07-22',
+    ...(expiresAt ? { expiresAt } : {}),
+    ...over,
+  } as AllowlistEntry;
+}
+
+function allowlistOf(entries: AllowlistEntry[]): AllowlistFile {
+  return { schemaVersion: 'dxkit-allowlist/v1', mode: 'full', entries };
+}
+
+/** A recording exec seam: canned stdout per `gh <sub> <verb>`, plus a log. */
+function fakeExec(responses: Record<string, string>): Exec & { calls: string[][] } {
+  const calls: string[][] = [];
+  const fn = ((bin: string, args: readonly string[]) => {
+    calls.push([bin, ...args]);
+    const key = `${args[0]} ${args[1]}`;
+    return responses[key] ?? '';
+  }) as Exec & { calls: string[][] };
+  fn.calls = calls;
+  return fn;
+}
+
+const LAPSING = allowlistOf([
+  entry('aaaa000000000001', '2026-07-28', { acknowledgedSeverity: 'high' }),
+  entry('aaaa000000000002', '2026-07-28', { acknowledgedSeverity: 'high' }),
+  entry('bbbb000000000001'), // never expires — must not appear
+]);
+
+describe('expiryNoticeBody', () => {
+  const soon = auditAllowlist(LAPSING, { now: NOW }).soonToExpire;
+
+  it('carries the marker, the countdown, and one row per lapsing entry', () => {
+    const body = expiryNoticeBody(soon, { horizonDays: SOON_TO_EXPIRE_DAYS });
+    expect(body.startsWith(EXPIRY_NOTICE_MARKER)).toBe(true);
+    expect(body).toContain('**2 allowlist suppressions lapse within 14 days**');
+    expect(body).toContain('in 6 days');
+    expect(body).toContain('`aaaa000000000001`');
+    expect(body).toContain('`aaaa000000000002`');
+    // The non-expiring entry is not a decision waiting to happen.
+    expect(body).not.toContain('bbbb000000000001');
+  });
+
+  it('states the batch-lapse property when one date covers them all', () => {
+    const body = expiryNoticeBody(soon, { horizonDays: SOON_TO_EXPIRE_DAYS });
+    expect(body).toContain('All 2 share one expiry, so they return together on 2026-07-28');
+  });
+
+  it('names owners and says explicitly that it will not assign', () => {
+    const body = expiryNoticeBody(soon, { horizonDays: SOON_TO_EXPIRE_DAYS });
+    expect(body).toContain('jane@corp.example');
+    expect(body).toContain('not assigned');
+    expect(body).toContain('will not guess a GitHub login');
+  });
+
+  it('offers both lanes and discloses the cadence limitation', () => {
+    const body = expiryNoticeBody(soon, { horizonDays: SOON_TO_EXPIRE_DAYS });
+    expect(body).toContain('Fix them');
+    expect(body).toContain('Renew deliberately');
+    expect(body).toContain('never blocks a build');
+    expect(body).toContain('slower than 14 days, the first notice can arrive late');
+  });
+
+  it('reports the acknowledged severity, which is a recorded fact rather than a re-derivation', () => {
+    const body = expiryNoticeBody(soon, { horizonDays: SOON_TO_EXPIRE_DAYS });
+    expect(body).toContain('| high |');
+    // It never claims a block/warn consequence — that needs a classification
+    // pass the refresh does not run; the guardrail check makes that claim.
+    expect(body).not.toContain('will BLOCK');
+  });
+});
+
+describe('syncExpiryNotice', () => {
+  it('opens one issue when suppressions are lapsing and none is open', () => {
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({
+      'issue list': '[]',
+      'issue create': 'https://github.com/acme/repo/issues/7\n',
+    });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('issue-opened');
+    expect(out.lapsing).toBe(2);
+    expect(out.issueUrl).toBe('https://github.com/acme/repo/issues/7');
+    expect(out.note).toContain('Opened the expiry notice');
+    const create = exec.calls.find((c) => c[1] === 'issue' && c[2] === 'create')!;
+    expect(create.join(' ')).toContain('dxkit: allowlist suppressions expiring (2)');
+  });
+
+  it('updates the SAME issue when one carries the marker (never a second one)', () => {
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({
+      'issue list': JSON.stringify([
+        { number: 3, url: 'https://github.com/acme/repo/issues/3', body: 'unrelated' },
+        {
+          number: 7,
+          url: 'https://github.com/acme/repo/issues/7',
+          body: `${EXPIRY_NOTICE_MARKER}\nstale text`,
+        },
+      ]),
+      'issue edit': 'https://github.com/acme/repo/issues/7\n',
+    });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('issue-updated');
+    expect(out.issueUrl).toBe('https://github.com/acme/repo/issues/7');
+    expect(exec.calls.some((c) => c[2] === 'create')).toBe(false);
+    const edit = exec.calls.find((c) => c[2] === 'edit')!;
+    expect(edit[3]).toBe('7');
+  });
+
+  it('CLOSES the open issue once nothing is lapsing — the self-close', () => {
+    const d = mkRepo({ allowlist: allowlistOf([entry('cccc000000000001', '2026-12-31')]) });
+    const exec = fakeExec({
+      'issue list': JSON.stringify([
+        {
+          number: 7,
+          url: 'https://github.com/acme/repo/issues/7',
+          body: `${EXPIRY_NOTICE_MARKER}\nold`,
+        },
+      ]),
+    });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('issue-closed');
+    expect(out.lapsing).toBe(0);
+    const close = exec.calls.find((c) => c[2] === 'close')!;
+    expect(close[3]).toBe('7');
+    expect(close.join(' ')).toContain('reopens a fresh notice');
+  });
+
+  it('stays silent when nothing is lapsing and no issue is open', () => {
+    const d = mkRepo({ allowlist: allowlistOf([entry('dddd000000000001')]) });
+    const exec = fakeExec({ 'issue list': '[]' });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('nothing-to-report');
+    expect(exec.calls.some((c) => c[2] === 'create' || c[2] === 'close')).toBe(false);
+  });
+
+  it('fails OPEN and says why when the issue cannot be created', () => {
+    // gh missing / issues disabled / token without `issues: write` — every one
+    // of those surfaces as empty stdout through the allowFail exec.
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({ 'issue list': '[]', 'issue create': '' });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('unavailable');
+    expect(out.lapsing).toBe(2);
+    expect(out.note).toContain('issues: write');
+    expect(out.note).toContain('still surfaces on every guardrail check');
+  });
+
+  it('fails OPEN when an existing issue cannot be edited, and keeps naming it', () => {
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({
+      'issue list': JSON.stringify([
+        { number: 7, url: 'https://github.com/acme/repo/issues/7', body: EXPIRY_NOTICE_MARKER },
+      ]),
+      'issue edit': '',
+    });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('unavailable');
+    expect(out.issueUrl).toBe('https://github.com/acme/repo/issues/7');
+  });
+
+  it('treats an unparseable issue list as "none open" rather than throwing', () => {
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({ 'issue list': 'not json', 'issue create': 'https://x/issues/1\n' });
+    expect(syncExpiryNotice({ cwd: d, exec, now: NOW }).outcome).toBe('issue-opened');
+  });
+
+  it('reports nothing to do on a repo with no allowlist at all', () => {
+    const d = mkRepo();
+    const exec = fakeExec({ 'issue list': '[]' });
+    expect(syncExpiryNotice({ cwd: d, exec, now: NOW }).outcome).toBe('nothing-to-report');
+  });
+});
+
+describe('the refresh lane runs the notice independently of the advisory lane', () => {
+  /** Policy that makes the advisory lane take its earliest no-op return. */
+  const REF_BASED = { baseline: { mode: 'ref-based' } };
+
+  it('syncs the notice even when the advisory lane no-ops entirely', async () => {
+    const { runBaselineRefresh } = await import('../../src/baseline/refresh');
+    const d = mkRepo({
+      policy: { ...REF_BASED, expiryNotice: { enabled: true } },
+      allowlist: LAPSING,
+    });
+    const exec = fakeExec({
+      'issue list': '[]',
+      'issue create': 'https://github.com/acme/repo/issues/9\n',
+    });
+    const result = await runBaselineRefresh({ cwd: d, exec, now: NOW });
+    // The advisory lane did nothing (ref-based has no committed baseline) …
+    expect(result.heldOut).toEqual([]);
+    expect(result.note).toContain('ref-based');
+    // … and the notice still fired. A suppression's expiry has nothing to do
+    // with whether an advisory feed moved this week.
+    expect(result.expiryNotice?.outcome).toBe('issue-opened');
+    expect(result.expiryNotice?.lapsing).toBe(2);
+  });
+
+  it('does not touch GitHub at all when the knob is off (the default)', async () => {
+    const { runBaselineRefresh } = await import('../../src/baseline/refresh');
+    const d = mkRepo({ policy: REF_BASED, allowlist: LAPSING });
+    const exec = fakeExec({ 'issue list': '[]' });
+    const result = await runBaselineRefresh({ cwd: d, exec, now: NOW });
+    expect(result.expiryNotice).toBeUndefined();
+    expect(exec.calls).toEqual([]);
+  });
+});
+
+describe('the opt-in gate and the workflow permission it implies', () => {
+  it('is off unless policy says otherwise', () => {
+    expect(expiryNoticeEnabled(mkRepo())).toBe(false);
+    expect(expiryNoticeEnabled(mkRepo({ policy: {} }))).toBe(false);
+    expect(expiryNoticeEnabled(mkRepo({ policy: { expiryNotice: { enabled: false } } }))).toBe(
+      false,
+    );
+    expect(expiryNoticeEnabled(mkRepo({ policy: { expiryNotice: { enabled: true } } }))).toBe(true);
+  });
+
+  it('grants issues: write ONLY when enabled, keeping every other repo byte-identical', () => {
+    const off = mkRepo();
+    expect(refreshPermissionsBlock(off, 'tree')).toBe('  contents: write');
+    expect(refreshPermissionsBlock(off, 'branch')).toBe('  contents: write');
+    // The cache transport writes no git object, so it never needed write.
+    expect(refreshPermissionsBlock(off, 'cache')).toBe('  contents: read');
+
+    const on = mkRepo({ policy: { expiryNotice: { enabled: true } } });
+    expect(refreshPermissionsBlock(on, 'tree')).toBe('  contents: write\n  issues: write');
+    expect(refreshPermissionsBlock(on, 'cache')).toBe('  contents: read\n  issues: write');
+  });
+});


### PR DESCRIPTION
**PR 4 of 4 in the 4.3.1 stack.** Stacked on #195 → #194 → #193. Designed before implemented, as planned.

## The last hole

PRs 1–3 warn every author and reviewer on every check, and warn the person creating a deferral at the keystroke. None of that speaks when **nobody opens a PR** — which is exactly what happened: deferred on the 22nd, repo quiet all week, and the lapse landed on the 29th inside an unrelated 16-file frontend PR whose author had never seen the findings. The person who made the promise was never addressed again.

So: while the scheduled refresh is running anyway, it maintains **one** GitHub issue naming the suppressions whose windows close inside the shared horizon, who accepted each, and when.

## What the design pass changed

The first sketch had a new workflow, a new managed artifact, and a new CLI verb. The survey found the scheduled lane **already exists** and already runs an idempotent decision surface, so this needs none of them — it rides `baseline refresh`, which runs weekly *and* on every merge to the default branch. No Rule 15 surface registration, no Rule 14 self-invocation entry.

Two options rejected on the record (full matrix in the design doc):

- **A standing PR whose merge renews the window.** No new permission needed, quite elegant — and wrong: it makes defer-forever a one-click merge, the exact failure this release exists to stop.
- **A job-summary line.** Free, and useless: nobody reads a scheduled job's summary. It is the `doctor` invisibility class one layer over, and shipping it would let us claim a delivery we did not achieve.

## Load-bearing behaviours

- **One issue, found by a body marker**, never by title — retitling cannot orphan it.
- **It closes itself** once nothing is lapsing. Not tidiness: an issue that outlives its facts is precisely how a team learns to filter dxkit's issues, which would silently disable every future notice.
- **Fail-open, always disclosed.** Issues disabled, a token without `issues: write`, no `gh` — each yields a reported reason and an unchanged exit. A notification that could not be posted must never fail a baseline capture.
- **It never gates.** The expiry remains the forcing function.
- **Owners are NAMED from `addedBy`, never assigned.** `addedBy` is an email; guessing a GitHub login from an email would put a stranger's name on someone else's deferral.
- **Entry-shaped claims only** (kind, acknowledged severity, owner, date, countdown). It does *not* project block-vs-warn — that needs a classification pass the refresh does not run, and the check already makes that claim honestly. Each surface asserts only what it observed.
- **One horizon**, the shared `SOON_TO_EXPIRE_DAYS` via `auditAllowlist` — not a cron next-run calculator. 14 days dominates every cadence the product offers. The one honest limitation (a custom cron slower than the horizon delivers the first notice late) is stated in the issue body rather than hidden.
- **Synced on every path the advisory lane can take**, including its early returns — a suppression's expiry has nothing to do with whether an advisory feed moved this week. Pinned with a test that drives the advisory lane to a full no-op and asserts the notice still fires.

## Opt-in, default off — and it announces itself

This is the only dxkit lane that opens an issue on its own initiative, and enabling it grants the refresh workflow `issues: write`. A repo that never opts in keeps a **byte-identical** workflow — pinned in both directions, and verified end-to-end on scratch repos:

```
# knob off (unchanged from today)        # knob on
permissions:                            permissions:
  contents: write                         contents: write
                                          issues: write
```

Discovery rides the 4.3.0 policy platform end to end. One metadata row produces all of it:

```jsonc
  // ── Expiring-suppression notice ──  policy-guide#expiry-notice
  // A deferral is a promise with a date on it. The guardrail check already
  // warns every PR while the window is open — this covers the quiet week:
  // the scheduled refresh maintains ONE issue naming what lapses, who
  // accepted it, and when, and closes it once nothing is lapsing.
  // Never blocks; the expiry itself stays the forcing function.
  // "expiryNotice": {
  //   "enabled": true, // maintain one issue naming allowlist suppressions about to lapse → policy-guide#expiry-notice
  // },
  // Grants the refresh workflow `issues: write`: run `vyuh-dxkit update` after enabling.
```

- generated **scaffold** stanza with its guide link (shown above, real output)
- **JSON-schema** description → editor hover text
- **knob-index** row in the policy guide, plus a full teaching section
- **`policy sync`** carries it into policy files that predate it — this is how already-onboarded repos learn it exists
- **`POSTURE_KNOBS`** + a grounded `doctor` probe that fires only once the repo actually holds time-boxed suppressions, so it reaches `doctor` and `capabilities --json`

## Two centralizations the gates caught, both real

- The doctor probe was reading `.dxkit/allowlist.json` raw — the arch gate's allowlist-IO rule bit correctly.
- `safeLoadAllowlist` was a private helper in `doctor.ts`; rather than copy it, it became the shared `tryLoadAllowlist` (the `loadGraph`/`tryLoadGraph` naming precedent), with enforcing paths deliberately still using the throwing `loadAllowlist` — a malformed allowlist must never read as "nothing is suppressed" in the guardrail.
- The policy-schema test caught the missing schema property before CI did.

## Gates run locally

| gate | result |
| --- | --- |
| `tsc --noEmit` (src + `typecheck:test`) | pass |
| `eslint . --max-warnings 0` | pass |
| `format:check` | pass |
| `check-architecture.sh` / `check-slop.sh` / `check-cross-ecosystem-coverage.sh` | pass |
| `test:run` | **336 files / 5,085 tests pass** (+20) |
| self-guardrail `--mode ref-based --ref origin/main` | **PASSED** |
| manual | scaffold stanza, `policy sync --apply`, `policy get`, `doctor` line, and both permission renderings verified on scratch repos |

## Still open for the release

The version number: 4.3.1 vs a minor. This PR adds a capability, which is minor-shaped, but 4.4 and 4.5 are already claimed by the flow arc and build topology, and 4.2.1 set the precedent that a patch can carry features here. Leaning 4.3.1. The CHANGELOG + version bump are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)