### PR TITLE
4.3.1: land the rest of the expiry-cliff stack (PRs 2-5) + the release commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,84 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.1] - 2026-07-29
+
+The expiry cliff. An allowlist deferral is a promise with a date on it, and
+dxkit already enforced the date — a lapsed suppression stops suppressing and
+the finding comes back. What it never did was tell anyone the date was
+coming. This release closes that end to end, and every part of it is
+disclosure: nothing here adds a new way to fail a build.
+
+### What went wrong
+
+Two individually-correct mechanisms compose into a cliff. An allowlist entry
+is deliberately held OUT of the baseline, so an accepted finding can never
+grandfather itself in and defeat its own expiry; the scheduled refresh is
+therefore forbidden from absorbing it. So when a batch of dependency
+advisories was deferred for six days with nothing available to fix them, all
+of them came back on the same morning — with no warning as the date
+approached, no decision surface at the lapse, and the cost landing on
+whoever opened the next pull request.
+
+The warning already existed, and was never delivered. `allowlist audit` has
+computed which entries expire soon, with days remaining, since the allowlist
+shipped. Its only consumers were `doctor` and the audit command itself — two
+things nobody runs on an ordinary day.
+
+### The guardrail check now says what a lapse will cost
+
+Every check reports the suppressions whose windows close within 14 days, how
+soon the nearest one is, and — because the check holds each finding's
+classification — how many will BLOCK versus warn when they lapse. It reads
+on all three surfaces: a console section, the pull-request comment, and a
+`suppressionExpiry` field in `--json` that is always present so an agent can
+read it without probing. All five suppression sources are covered, not just
+findings: the flow, schema-drift, seam-duplicate and paired-change gates
+each carry their own expiring suppressions.
+
+Nothing about it gates. A lapse that has not happened is not a regression,
+and blaming an author for somebody else's expiring deferral would be a false
+block. When nothing is expiring, every surface prints nothing at all.
+
+### Deferring now tells you whether the promise is keepable
+
+`allowlist defer` (and the `/dxkit defer` pull-request reply, from the same
+core) states the facts at the moment the window is chosen: that all N
+findings share one expiry and return together; that no automated remediation
+lane is enabled, so nothing in the repo will close them before the date;
+that a window shorter than the dep-bump lane's weekly cadence may shut
+before it runs once. Each fires only on its own condition. And an expiry
+already in the past is now refused outright rather than writing an entry
+that suppresses nothing while the finding keeps blocking.
+
+### Optional: one issue that reaches the owner when no PR is open
+
+New `expiryNotice.enabled` (default off). While the scheduled baseline
+refresh is running anyway, it maintains ONE GitHub issue naming the
+suppressions about to lapse, who accepted each, and when — and closes that
+issue once nothing is lapsing. It covers the case the per-check delivery
+cannot: a quiet week with no pull request open, where the lapse then
+surprises the next author.
+
+Enabling it grants the refresh workflow `issues: write`, so it is opt-in by
+construction; a repo that does not enable it keeps a byte-identical
+workflow. It never gates, it names owners without assigning anyone (an
+`addedBy` email is not a GitHub login, and a wrong assignment puts a
+stranger's name on someone else's deferral), and it fails open with a stated
+reason if issues are disabled or the token lacks the permission. Run
+`vyuh-dxkit policy sync --apply` to have the knob and its guide link appear
+in an existing policy file, then `vyuh-dxkit update` after enabling.
+
+### Internal
+
+Expiry day arithmetic and the 14-day horizon now have one home shared by
+every consumer, with a parity test asserting the audit buckets and the
+check's projection can never disagree about the same date, and an
+architecture rule keeping the arithmetic there. Three implementations of it
+existed before this release, one of which read the clock directly and
+clamped negatives. Also fixed: the console printed `Path: undefined` on
+every ref-based run.
+
 ## [4.3.0] - 2026-07-29
 
 The policy platform and the agentic remediation lane, in one release. The

--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -25,6 +25,7 @@ stanzas).
 | `depBump.allowMajor`                | [#dep-bump](#dep-bump)                       |
 | `depBump.enabled`                   | [#dep-bump](#dep-bump)                       |
 | `duplication.mode`                  | [#duplication-mode](#duplication-mode)       |
+| `expiryNotice.enabled`              | [#expiry-notice](#expiry-notice)             |
 | `flow.mode`                         | [#flow-mode](#flow-mode)                     |
 | `flow.sources`                      | [#flow-sources](#flow-sources)               |
 | `licenses.prohibited`               | [#prohibited-licenses](#prohibited-licenses) |
@@ -236,6 +237,39 @@ boring to merge.
 
 **Interactions.** What the bump lane cannot close (no fixed release,
 breaking-not-allowed) is exactly the [remediate lane's](#remediate) input.
+
+## Expiry notice
+
+**What it does.** While the scheduled baseline refresh is running anyway, it
+maintains ONE GitHub issue naming the allowlist suppressions whose windows
+close within the next 14 days: the finding, its kind, the severity the
+reviewer acknowledged, who accepted it (`addedBy`), the date, and the
+countdown. One issue, updated in place — and closed automatically once
+nothing is lapsing.
+
+**Default and why.** Off. `expiryNotice.enabled: true` + `vyuh-dxkit update`
+grants the refresh workflow `issues: write` and turns the lane on. It is the
+only dxkit lane that opens an issue on its own initiative, so it is never
+enabled for you.
+
+**When you would turn it on.** The [lapse projection](#new-advisories) already
+warns every author and reviewer on every guardrail check, which covers any
+week somebody opens a PR. Turn this on if your repo can go quiet for days at a
+time — that is the case where a deferral lapses with nobody watching and the
+next PR author inherits findings they never touched.
+
+**Tuning.** None. The horizon is the same 14 days
+[`allowlist audit`](../reference/cli.md) uses, so the issue and the check never
+disagree about which entries are in scope. If your
+[refresh cadence](#refresh-cadence) is slower than 14 days, the first notice
+can arrive late — the issue body says so rather than pretending otherwise.
+
+**Interactions.** It never gates: no verdict, no exit code, no block. The
+expiry remains the forcing function. Owners are NAMED from `addedBy`, never
+assigned — `addedBy` is an email address, and guessing a GitHub login from an
+email would put a stranger's name on someone else's deferral. If issues are
+disabled or the token lacks the permission, the refresh reports why and carries
+on; a notification that could not be posted must never fail a baseline capture.
 
 ## Reports on merge
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
@@ -28,7 +28,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
+__DXKIT_REFRESH_PERMISSIONS__
 
 jobs:
 __DXKIT_FRAGMENT_CAPTURE_JOBS__

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: read
+__DXKIT_REFRESH_PERMISSIONS__
 
 jobs:
 __DXKIT_FRAGMENT_CAPTURE_JOBS__

--- a/src-templates/.github/workflows/dxkit-baseline-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh.yml
@@ -19,7 +19,7 @@ on:
       - '.dxkit/baselines/**'
 
 permissions:
-  contents: write
+__DXKIT_REFRESH_PERMISSIONS__
 
 jobs:
 __DXKIT_FRAGMENT_CAPTURE_JOBS__

--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -469,11 +469,15 @@ export async function runAllowlistDefer(cwd: string, opts: AllowlistDeferOpts): 
     logger.fail(result.message);
     process.exit(1);
   }
-  const { added, alreadyPresent, leftBlocking, expiresAt, reason, targets } = result;
+  const { added, alreadyPresent, leftBlocking, expiresAt, reason, targets, advisories } = result;
 
   if (opts.json) {
     process.stdout.write(
-      JSON.stringify({ added, alreadyPresent, leftBlocking, expiresAt, reason }, null, 2) + '\n',
+      JSON.stringify(
+        { added, alreadyPresent, leftBlocking, expiresAt, reason, advisories },
+        null,
+        2,
+      ) + '\n',
     );
     return;
   }
@@ -497,6 +501,9 @@ export async function runAllowlistDefer(cwd: string, opts: AllowlistDeferOpts): 
       `  Commit .dxkit/allowlist.json (via your PR) — the expiry re-blocks these in ` +
         `${daysUntil(expiresAt)} day(s), so plan the dependency fix now.`,
     );
+    // The creation guard: what this window will and will not get you. Warned
+    // rather than info'd — these are the facts a caller most needs to have read.
+    for (const a of advisories) logger.warn(`  ${a}`);
   }
   if (alreadyPresent.length > 0) {
     logger.info(`Skipped ${alreadyPresent.length} fingerprint(s) already allowlisted.`);

--- a/src/allowlist/comment-defer.ts
+++ b/src/allowlist/comment-defer.ts
@@ -241,6 +241,14 @@ export function runCommentDeferCore(
       'The allowlist commit below re-runs the guardrail check. The expiry is the ' +
         'forcing function: these re-block when it lapses, so plan the dependency fix now.',
     );
+    // The creation guard, carried into the thread. The reviewers reading this PR
+    // are the people who will live with the deferral, and this is the only place
+    // they will see whether the window is keepable (Rule 2: the same advisories
+    // the local CLI prints, from the same core).
+    if (result.advisories.length > 0) {
+      lines.push('');
+      for (const a of result.advisories) lines.push(`> ⚠️ ${a}`);
+    }
   } else {
     lines.push(
       result.alreadyPresent.length > 0

--- a/src/allowlist/defer-core.ts
+++ b/src/allowlist/defer-core.ts
@@ -15,6 +15,7 @@ import { dxkitCli } from '../self-invocation';
 import { readVerdictForTree } from '../baseline/verdict-cache';
 import {
   addEntry,
+  daysUntilDate,
   emptyAllowlistFile,
   findEntry,
   loadAllowlist,
@@ -23,7 +24,8 @@ import {
   type AllowlistEntry,
   type AllowlistMode,
 } from './file';
-import { deferAdvisoryExpiryDate } from './categories';
+import { DEFER_ADVISORY_EXPIRY_DAYS, deferAdvisoryExpiryDate } from './categories';
+import { deferAdvisories } from './defer-guard';
 
 export interface DeferRequest {
   /** Explicit fingerprints (deduped by the core). */
@@ -44,6 +46,12 @@ export interface DeferOutcome {
   readonly ok: true;
   readonly added: readonly string[];
   readonly alreadyPresent: readonly string[];
+  /** Creation-time advisories about the window just chosen (how many findings
+   *  share it, whether any lane could close them, whether it shuts before the
+   *  lane's next run). Facts, never a veto — see `defer-guard.ts`. Empty when
+   *  there is nothing worth saying, and empty when nothing was written. BOTH
+   *  front-ends render these; a new front-end inherits them from the core. */
+  readonly advisories: readonly string[];
   /** Non-dep-vuln blockers `--from-last-check` refused to touch, as
    *  `"<kind> <locator>"` strings. */
   readonly leftBlocking: readonly string[];
@@ -91,6 +99,18 @@ export function executeDefer(cwd: string, req: DeferRequest, now = new Date()): 
   if (expiresAt === null) {
     return refuse(
       `--expires must be ISO date YYYY-MM-DD or relative +Nd; got ${JSON.stringify(req.expires)}`,
+    );
+  }
+  // A window that already closed writes an entry that suppresses NOTHING: the
+  // matcher skips an expired entry, so the finding keeps blocking while the
+  // allowlist claims it was accepted. Refusing is the honest answer — silently
+  // writing a dead entry fails the caller's actual intent.
+  const windowDays = daysUntilDate(expiresAt, now);
+  if (windowDays < 0) {
+    return refuse(
+      `--expires ${expiresAt} is already in the past (${-windowDays} day(s) ago), so the entry ` +
+        `would suppress nothing and the findings would keep blocking. Pass a future date, ` +
+        `or \`--expires +${DEFER_ADVISORY_EXPIRY_DAYS}d\`.`,
     );
   }
 
@@ -194,5 +214,10 @@ export function executeDefer(cwd: string, req: DeferRequest, now = new Date()): 
 
   if (added.length > 0) saveAllowlist(cwd, { ...file, mode: req.mode });
 
-  return { ok: true, added, alreadyPresent, leftBlocking, expiresAt, reason, targets };
+  // Advisories describe the window that was just written, so they are computed
+  // only when something WAS written — an all-already-present run chose no window.
+  const advisories =
+    added.length > 0 ? deferAdvisories(cwd, { count: added.length, expiresAt, now }) : [];
+
+  return { ok: true, added, alreadyPresent, leftBlocking, expiresAt, reason, targets, advisories };
 }

--- a/src/allowlist/defer-guard.ts
+++ b/src/allowlist/defer-guard.ts
@@ -1,0 +1,113 @@
+/**
+ * The creation-time guard on a deferral — the advisories a caller sees at the
+ * moment they time-box a finding, decided ONCE for both front-ends.
+ *
+ * # Why this exists
+ *
+ * A deferral is a promise: "we will fix this before <date>." The expiry is the
+ * forcing function, and it works — a lapsed entry stops suppressing and the
+ * finding returns. What the product never said is whether the promise was
+ * KEEPABLE. On the repo that produced this class, an engineer deferred 21
+ * dependency advisories for six days with no remediation lane enabled: nothing
+ * in that repo was ever going to fix 9 packages in six days, and every one of
+ * the 21 came back on the same morning and blocked every open PR.
+ *
+ * None of that needed predicting. All of it was knowable at the keystroke: how
+ * many findings, how long the window, whether any lane exists that could close
+ * them, and the fact that one shared expiry means the whole batch returns
+ * together. So the guard states those facts when they matter and stays quiet
+ * when they don't.
+ *
+ * # What it deliberately is NOT
+ *
+ * It never blocks a deferral and never adjusts the window. Time-boxing a
+ * finding is a legitimate engineering decision and the human making it knows
+ * things dxkit does not (a fix already in review, a vendor patch landing
+ * Thursday). The guard's job is to make the decision INFORMED, not to overrule
+ * it — so every advisory is a fact plus its consequence, never a veto and never
+ * a nag. The one hard refusal lives in the core, not here: an expiry already in
+ * the past creates an entry that suppresses NOTHING, which silently fails the
+ * caller's actual intent.
+ *
+ * Both front-ends render these (Rule 2): `allowlist defer` prints them, and the
+ * `/dxkit defer` PR reply carries them into the thread where the reviewers who
+ * will live with the deferral can read them. The guard is consulted from the ONE
+ * defer core, so a third front-end inherits it for free.
+ */
+
+import { depBumpEnabled, remediateEnabled } from '../ship-installers';
+import { daysUntilDate } from './file';
+import { DEFER_ADVISORY_EXPIRY_DAYS } from './categories';
+
+export interface DeferGuardInput {
+  /** How many findings this deferral covers. */
+  readonly count: number;
+  /** The shared ISO `YYYY-MM-DD` expiry being written. */
+  readonly expiresAt: string;
+  readonly now: Date;
+}
+
+/**
+ * Whether this repo has any automated lane that could close a deferred
+ * dependency finding before its window shuts. Both probes are read from their
+ * declared homes rather than re-reading policy here — `doctor` recommends these
+ * same lanes, and a second policy read is how the two surfaces start
+ * disagreeing about whether a repo is covered.
+ *
+ * Both probes swallow a read failure and answer `false`, so an unreadable policy
+ * reads as "no lane". That is the conservative direction for this advisory: a
+ * lane dxkit cannot see is a lane that will not run on its behalf, and the
+ * advice (plan the work, or check the lane config) is right either way.
+ */
+function laneCoverage(cwd: string): { readonly depBump: boolean; readonly remediate: boolean } {
+  return { depBump: depBumpEnabled(cwd), remediate: remediateEnabled(cwd) };
+}
+
+/**
+ * The advisories for a deferral about to be written. Empty when there is
+ * nothing worth saying. Ordered most-consequential first.
+ */
+export function deferAdvisories(cwd: string, input: DeferGuardInput): string[] {
+  const windowDays = daysUntilDate(input.expiresAt, input.now);
+  const out: string[] = [];
+
+  // The batch-lapse property. One shared expiry is the whole point of a bulk
+  // defer, and also the thing that makes the return a wall rather than a
+  // trickle — say so while the window is still being chosen.
+  if (input.count > 1) {
+    out.push(
+      `All ${input.count} findings share one expiry, so they return together on ` +
+        `${input.expiresAt} — not spread out.`,
+    );
+  }
+
+  if (windowDays === 0) {
+    out.push(
+      'The window closes TODAY: the expiry is inclusive, so these are suppressed ' +
+        'for the rest of today and re-block tomorrow. Pass `--expires +Nd` for a ' +
+        'window you can actually work in.',
+    );
+  }
+
+  const lanes = laneCoverage(cwd);
+  if (!lanes.depBump && !lanes.remediate) {
+    out.push(
+      `No automated remediation lane is enabled in this repo, so nothing here will ` +
+        `close ${input.count === 1 ? 'this' : 'these'} before ${input.expiresAt} — ` +
+        `whoever opens a PR that day inherits ${input.count === 1 ? 'it' : 'them'}. ` +
+        `Either plan the work now, or enable a lane: \`depBump.enabled\` for the ` +
+        `deterministic version-bump lane (fixable dependency findings, no agent), ` +
+        `\`remediate.enabled\` for the agentic one.`,
+    );
+  } else if (lanes.depBump && !lanes.remediate && windowDays < DEFER_ADVISORY_EXPIRY_DAYS) {
+    // The bump lane is scheduled weekly by its managed workflow, so a window
+    // shorter than its cadence may shut before the lane has run even once.
+    out.push(
+      `The dep-bump lane runs weekly, so a ${windowDays}-day window may close before ` +
+        `its next run. Give it at least one cycle (\`--expires +${DEFER_ADVISORY_EXPIRY_DAYS}d\`) ` +
+        `or expect to renew.`,
+    );
+  }
+
+  return out;
+}

--- a/src/allowlist/file.ts
+++ b/src/allowlist/file.ts
@@ -333,6 +333,24 @@ export function removeEntry(file: AllowlistFile, fingerprint: string): Allowlist
 }
 
 /**
+ * `loadAllowlist` with the throw swallowed — null on absence OR on a malformed
+ * file. The fail-open sibling for advisory READERS (`doctor`'s hygiene check,
+ * the discovery probes): a broken allowlist must not take down a surface whose
+ * job is telling you things. Naming mirrors `loadGraph` / `tryLoadGraph`.
+ *
+ * Enforcing paths (the guardrail's suppression resolution) keep using
+ * `loadAllowlist` directly — there, a malformed file must surface, not silently
+ * read as "nothing is suppressed".
+ */
+export function tryLoadAllowlist(cwd: string): AllowlistFile | null {
+  try {
+    return loadAllowlist(cwd);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Whether the allowlist suppresses a given finding. Pure
  * fingerprint match. Expiry handling is layered on top by
  * `isEntryActive` (kept separate so the guardrail can distinguish

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -34,6 +34,12 @@ import type {
 } from './check';
 import { ATTRIBUTION_GAP_REMEDY, describeAttributionGap } from './attribution-gap';
 import type { AttributionGap } from './attribution-gap';
+import {
+  EXPIRY_PROJECTION_REMEDY,
+  describeExpiryProjection,
+  describeLapsingSuppression,
+} from './expiry-projection';
+import type { ExpiryProjection } from './expiry-projection';
 import { recallDriftRemedy, describeRecallDrift } from './recall';
 import type { BrownfieldPolicy } from './policy';
 import type { FindingStatus, MatchReason } from './types';
@@ -247,7 +253,11 @@ export function renderConsole(result: GuardrailCheckResult): string {
   // Provenance: what was compared against what. Inline so the user
   // can verify they're checking against the intended baseline.
   lines.push(logger.bold('Baseline'));
-  lines.push(`  Path:        ${result.baselinePath}`);
+  // Ref-based mode has no on-disk baseline; say so rather than stringifying the
+  // absent field into the literal word "undefined".
+  lines.push(
+    `  Path:        ${result.baselinePath ?? `(none — gathered from ${result.mode.ref ?? 'a git ref'})`}`,
+  );
   lines.push(`  Name:        ${result.baseline.name}`);
   lines.push(`  Captured:    ${result.baseline.createdAt}`);
   lines.push(
@@ -317,6 +327,9 @@ export function renderConsole(result: GuardrailCheckResult): string {
     for (const p of suppressed) lines.push(...formatPairLines(p, '  '));
     lines.push('');
   }
+  // The lapse projection, immediately after the list it is the consequence of.
+  // Silent when nothing expires inside the horizon, which is almost every run.
+  lines.push(...formatExpiryProjection(result.suppressionExpiry));
   if (warning.length > 0) {
     lines.push(logger.bold(`Warnings (${warning.length})`));
     // Collapse the envelope-drift wall (gh #157): after a dxkit upgrade or a
@@ -359,6 +372,15 @@ export function renderConsole(result: GuardrailCheckResult): string {
       `warning: ${warning.length}, persisted: ${persisted.length}, ` +
       `resolved: ${removed.length})`,
   );
+  // The lapse line belongs in the footer too: a reader who skims to the summary
+  // and stops must still see that today's PASS has an expiry date on it.
+  if (result.suppressionExpiry.lapsing.length > 0) {
+    const p = result.suppressionExpiry;
+    lines.push(
+      `  Expiring:    ${p.lapsing.length} suppression(s) within ${p.horizonDays}d ` +
+        `(next in ${p.nextLapseDays}d; ${p.willBlock} would block, ${p.willWarn} would warn)`,
+    );
+  }
   // A flow-gate line so the verdict banner's total (which counts flow findings)
   // reconciles with the summary. Without it, a repo whose only regressions are
   // flow breakages read "BLOCKED — 3 new regressions" over "Pairs: blocking: 0"
@@ -459,6 +481,32 @@ function formatGateFailure(
     '  (fail-open: this did not block the check; set DXKIT_DEBUG=1 for the stack)',
     '',
   ];
+}
+
+/**
+ * The lapse projection section. Prints nothing when no active suppression
+ * expires inside the horizon — the state of almost every run, and an empty
+ * "nothing expiring" section would be noise that trains readers to skip the
+ * area where the real warning eventually appears.
+ *
+ * Where the delivery gap was: the horizon computation has existed since the
+ * allowlist shipped, reachable only from `doctor` and `allowlist audit`. Every
+ * author and reviewer reads THIS output instead, which is why the warning goes
+ * here (see `src/baseline/expiry-projection.ts`).
+ */
+function formatExpiryProjection(projection: ExpiryProjection): string[] {
+  const headline = describeExpiryProjection(projection);
+  if (!headline) return [];
+  const out = [
+    logger.bold(
+      `${projection.willBlock > 0 ? '⚠ ' : ''}Suppressions expiring (${projection.lapsing.length})`,
+    ),
+    `  ${headline}`,
+  ];
+  for (const l of projection.lapsing) out.push(`  · ${describeLapsingSuppression(l)}`);
+  out.push(`  → ${EXPIRY_PROJECTION_REMEDY}`);
+  out.push('');
+  return out;
 }
 
 /**
@@ -1070,6 +1118,13 @@ export interface GuardrailJsonPayload {
    *  disarmed, how many findings, and which recall input moved. Empty on a
    *  healthy run. */
   readonly attributionGaps: ReadonlyArray<AttributionGap>;
+  /** What this run's ACTIVE allowlist suppressions will do when their windows
+   *  close: how many would block, how many would warn, and how soon. ALWAYS
+   *  present (`lapsing: []` when nothing expires inside the horizon), so an
+   *  agent can read it without probing for the field. Never affects
+   *  `verdict` — a lapse that has not happened yet is not a regression, and
+   *  the finding is re-classified on the run after it lapses. */
+  readonly suppressionExpiry: ExpiryProjection;
   /** Present when the dependency-vuln scan was requested but could not run —
    *  a pass is then NOT a clean bill of dependency health. */
   readonly depVulnsUnmeasured?: { readonly reason: string };
@@ -1305,6 +1360,7 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
       exitCode: counts.exitCode,
     },
     attributionGaps: result.attributionGaps,
+    suppressionExpiry: result.suppressionExpiry,
     ...(result.depVulnsUnmeasured ? { depVulnsUnmeasured: result.depVulnsUnmeasured } : {}),
     ...(result.deferredCapture && result.deferredCapture.length > 0
       ? { deferredCapture: result.deferredCapture }
@@ -1630,6 +1686,8 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     lines.push('');
   }
 
+  lines.push(...markdownExpiryProjection(result.suppressionExpiry));
+
   if (warning.length > 0) {
     // Collapse the envelope-drift wall (gh #157): the drift group becomes one
     // summary line above the table, and only the specific warnings are tabled.
@@ -1754,6 +1812,42 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
  * top-level table (they fail the PR); warnings collapse into a `<details>`.
  * Silent when the gate produced no findings.
  */
+/**
+ * The lapse projection for the PR comment — the surface that actually closes
+ * the delivery gap, since a reviewer reads this and nobody runs `doctor`.
+ *
+ * A lapse that will BLOCK gets a warning callout (it is about to become
+ * somebody's problem, and the somebody is whoever opens the next PR); a
+ * warn-only lapse gets an informational one. Detail collapses into `<details>`
+ * so a 21-entry deferral does not bury the findings above it. Silent when
+ * nothing expires inside the horizon.
+ */
+function markdownExpiryProjection(projection: ExpiryProjection): string[] {
+  const headline = describeExpiryProjection(projection);
+  if (!headline) return [];
+  const lines: string[] = [];
+  const icon = projection.willBlock > 0 ? '⚠️' : 'ℹ️';
+  lines.push(`> ${icon} **${escapeMd(headline)}**`);
+  lines.push(`> - Remedy: ${escapeMd(EXPIRY_PROJECTION_REMEDY)}`);
+  lines.push('');
+  lines.push('<details>');
+  lines.push(`<summary>Suppressions expiring (${projection.lapsing.length})</summary>`);
+  lines.push('');
+  lines.push('| Source | Finding | Category | Expires | In | On lapse |');
+  lines.push('|---|---|---|---|---|---|');
+  for (const l of projection.lapsing) {
+    const effect = l.consequence === 'block' ? '**blocks**' : l.consequence;
+    lines.push(
+      `| ${escapeMd(l.source)} | ${escapeMd(l.subject)} | ${escapeMd(l.category)} | ` +
+        `${escapeMd(l.expiresAt)} | ${l.daysRemaining}d | ${effect} |`,
+    );
+  }
+  lines.push('');
+  lines.push('</details>');
+  lines.push('');
+  return lines;
+}
+
 /** A markdown line for a fail-open gate that errored — the PR-comment mirror of
  *  `formatGateFailure`. Never silent on an error; empty otherwise. */
 function markdownGateFailure(

--- a/src/baseline/expiry-notice.ts
+++ b/src/baseline/expiry-notice.ts
@@ -1,0 +1,283 @@
+/**
+ * The expiry DECISION surface — one maintained GitHub issue naming the
+ * allowlist suppressions whose windows are about to close, who accepted each,
+ * and when.
+ *
+ * # The hole this closes (and the three it does not need to)
+ *
+ * By the time this runs, three surfaces already warn about an approaching lapse:
+ * the guardrail check's console section, its PR comment, and its JSON — every
+ * author and reviewer, on every run, for the whole window. What none of them can
+ * do is speak when NOBODY OPENS A PR. On the repo that produced this class the
+ * deferral was created on the 22nd, the repo went quiet, and the lapse landed on
+ * the 29th inside an unrelated 16-file frontend PR whose author had never seen
+ * the findings. The person who made the promise was never addressed again; the
+ * person who paid was whoever pushed next.
+ *
+ * So this surface exists for exactly one reason: to reach a named owner with no
+ * PR in play. It rides the scheduled refresh (which runs weekly AND on every
+ * merge to the default branch), so it needs no new workflow, no new managed
+ * artifact, and no new CLI verb.
+ *
+ * # What it claims, and what it refuses to claim
+ *
+ * Entry-shaped facts only: fingerprint, kind, category, the severity the
+ * reviewer ACKNOWLEDGED at accept time, `addedBy`, the date, the countdown. It
+ * does NOT say "2 of these will block" — that projection needs a classification
+ * pass the refresh does not run, and the check (which does run one) already
+ * makes the claim honestly. Each surface asserts only what it observed.
+ *
+ * # Load-bearing behaviours
+ *
+ *   - **One issue, found by marker.** `EXPIRY_NOTICE_MARKER` in the body is the
+ *     identity; the title is stable prose. Found → edit. Absent → create.
+ *   - **It closes itself.** Nothing lapsing inside the horizon ⇒ close the open
+ *     issue. This is not tidiness: an open issue that no longer describes
+ *     reality is precisely how a team learns to filter dxkit's issues, which
+ *     would silently disable every future notice. The self-close is why the
+ *     surface stays trustworthy.
+ *   - **Fail-OPEN, always disclosed.** Issues disabled, a token without
+ *     `issues: write`, no `gh` — every one of those yields a reported reason and
+ *     an unchanged exit. The refresh's contract is capturing the baseline; a
+ *     notification that could not be posted must never fail that job (the
+ *     `GateFailure` discipline).
+ *   - **It never gates.** No verdict, no exit code, no block. The expiry itself
+ *     is the forcing function; this only makes it visible earlier.
+ *   - **Owners are NAMED, never assigned.** `addedBy` is an email address, and
+ *     mapping an email to a GitHub login is a guess — a wrong assignment puts a
+ *     stranger's name on someone else's deferral. Naming cannot be wrong.
+ *
+ * # Horizon
+ *
+ * The trigger is the ONE shared horizon (`auditAllowlist`, 14 days), not a
+ * "before the next scheduled run" computation. A cron next-run calculator is
+ * real complexity, and the horizon dominates it for every cadence the product
+ * offers (`weekly` = 7d, `daily` = 1d, plus every push to the default branch).
+ * The one honest limitation — a custom cron slower than the horizon can deliver
+ * the first notice late — is stated in the issue body rather than hidden.
+ */
+
+import { auditAllowlist, loadAllowlist, SOON_TO_EXPIRE_DAYS } from '../allowlist/file';
+import type { SoonToExpire } from '../allowlist/file';
+import { dxkitCli } from '../self-invocation';
+import type { Exec } from '../land-refresh';
+
+/** Body marker that identifies dxkit's notice issue. The issue is found by this,
+ *  never by title matching, so retitling never orphans one. */
+export const EXPIRY_NOTICE_MARKER = '<!-- dxkit-expiry-notice -->';
+
+export type ExpiryNoticeOutcome =
+  /** The knob is off — nothing was looked at. */
+  | 'disabled'
+  /** Nothing expires inside the horizon and no issue was open. */
+  | 'nothing-to-report'
+  | 'issue-opened'
+  | 'issue-updated'
+  /** Nothing lapsing any more, so the open issue was closed. */
+  | 'issue-closed'
+  /** Could not talk to GitHub (no gh, no permission, issues disabled). */
+  | 'unavailable';
+
+export interface ExpiryNoticeResult {
+  readonly outcome: ExpiryNoticeOutcome;
+  /** How many suppressions lapse inside the horizon. */
+  readonly lapsing: number;
+  readonly issueUrl?: string;
+  /** Always populated: why this outcome, in one sentence a refresh log can
+   *  print verbatim. Never silent, whichever way it went. */
+  readonly note: string;
+}
+
+export interface ExpiryNoticeOptions {
+  readonly cwd: string;
+  readonly exec: Exec;
+  readonly now?: Date;
+  /** Horizon override; defaults to the shared constant. */
+  readonly horizonDays?: number;
+}
+
+const TITLE_PREFIX = 'dxkit: allowlist suppressions expiring';
+
+function titleFor(count: number): string {
+  return `${TITLE_PREFIX} (${count})`;
+}
+
+/**
+ * The issue body. Pure, so the wording is testable without touching GitHub, and
+ * so the same builder can be appended to the standing advisory-decision PR.
+ */
+export function expiryNoticeBody(
+  soon: ReadonlyArray<SoonToExpire>,
+  opts: { readonly horizonDays: number },
+): string {
+  const owners = [...new Set(soon.map((s) => s.entry.addedBy).filter(Boolean))];
+  const soonest = Math.min(...soon.map((s) => s.daysRemaining));
+  const lines: string[] = [
+    EXPIRY_NOTICE_MARKER,
+    '',
+    `**${soon.length} allowlist suppression${soon.length === 1 ? '' : 's'} lapse within ` +
+      `${opts.horizonDays} days** (soonest ${soonest === 0 ? 'today' : `in ${soonest} day${soonest === 1 ? '' : 's'}`}).`,
+    '',
+    'When a window closes, the finding it was holding back returns on the next guardrail run. ' +
+      'That is the deferral working as intended — but it should be a decision, not a surprise ' +
+      'sprung on whoever opens the next PR.',
+    '',
+    '| Finding | Kind | Accepted as | Accepted by | Expires | In |',
+    '|---|---|---|---|---|---|',
+  ];
+  for (const { entry, daysRemaining } of soon) {
+    lines.push(
+      `| \`${entry.fingerprint}\` | ${entry.kind} | ${entry.acknowledgedSeverity ?? entry.category} | ` +
+        `${entry.addedBy || '—'} | ${entry.expiresAt} | ${daysRemaining}d |`,
+    );
+  }
+  lines.push('');
+  const byDate = new Set(soon.map((s) => s.entry.expiresAt));
+  if (soon.length > 1 && byDate.size === 1) {
+    lines.push(
+      `All ${soon.length} share one expiry, so they return together on ` +
+        `${soon[0]!.entry.expiresAt} — not spread out.`,
+      '',
+    );
+  }
+  lines.push(
+    '**Two lanes.**',
+    '',
+    '1. **Fix them** before the date — then this issue closes itself on the next refresh.',
+    `2. **Renew deliberately** if the work genuinely needs longer: ` +
+      `\`${dxkitCli('allowlist defer')} --expires +7d\` re-dates the window, and tells you ` +
+      `whether anything in the repo can actually close it in that time.`,
+    '',
+    `Full list and rationales: \`${dxkitCli('allowlist audit')}\`.`,
+    '',
+    owners.length > 0
+      ? `Accepted by: ${owners.join(', ')} — named from each entry's \`addedBy\`, not assigned ` +
+          `(dxkit will not guess a GitHub login from an email address).`
+      : 'No `addedBy` recorded on these entries.',
+    '',
+    '---',
+    '',
+    `_Maintained by \`${dxkitCli('baseline refresh')}\` — one issue, updated in place, closed when ` +
+      `nothing is lapsing. It never blocks a build; the expiry is the forcing function. If your ` +
+      `refresh cadence is slower than ${opts.horizonDays} days, the first notice can arrive late._`,
+  );
+  return lines.join('\n');
+}
+
+/** The open notice issue's number + url, or null. Found by MARKER, not title. */
+function findOpenNotice(exec: Exec): { number: number; url: string } | null {
+  const raw = exec(
+    'gh',
+    ['issue', 'list', '--state', 'open', '--limit', '100', '--json', 'number,url,body'],
+    { allowFail: true },
+  ).trim();
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Array<{ number: number; url: string; body?: string }>;
+    const hit = parsed.find((i) => (i.body ?? '').includes(EXPIRY_NOTICE_MARKER));
+    return hit ? { number: hit.number, url: hit.url } : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create / update / close the one notice issue to match what the allowlist
+ * currently says. Idempotent: safe to run on every refresh, which is exactly
+ * what happens.
+ */
+export function syncExpiryNotice(opts: ExpiryNoticeOptions): ExpiryNoticeResult {
+  const horizonDays = opts.horizonDays ?? SOON_TO_EXPIRE_DAYS;
+  const now = opts.now ?? new Date();
+  const file = loadAllowlist(opts.cwd);
+  const soon = file
+    ? auditAllowlist(file, { now, soonToExpireDays: horizonDays }).soonToExpire
+    : [];
+
+  const existing = findOpenNotice(opts.exec);
+
+  if (soon.length === 0) {
+    if (!existing) {
+      return {
+        outcome: 'nothing-to-report',
+        lapsing: 0,
+        note: `No allowlist suppression expires within ${horizonDays} days.`,
+      };
+    }
+    // The self-close. A notice that outlives its facts teaches people to ignore
+    // the next one.
+    exec_close(opts.exec, existing.number);
+    return {
+      outcome: 'issue-closed',
+      lapsing: 0,
+      issueUrl: existing.url,
+      note:
+        `Nothing lapses within ${horizonDays} days any more — closed the expiry notice ` +
+        `(${existing.url}).`,
+    };
+  }
+
+  const body = expiryNoticeBody(soon, { horizonDays });
+  const title = titleFor(soon.length);
+
+  if (existing) {
+    const edited = opts.exec(
+      'gh',
+      ['issue', 'edit', String(existing.number), '--title', title, '--body', body],
+      { allowFail: true },
+    );
+    // `gh issue edit` prints the url on success and nothing on failure.
+    if (edited.trim() === '') {
+      return {
+        outcome: 'unavailable',
+        lapsing: soon.length,
+        issueUrl: existing.url,
+        note:
+          `${soon.length} suppression(s) lapse within ${horizonDays} days, but the notice issue ` +
+          `could not be updated (no permission / no gh). It is still open: ${existing.url}.`,
+      };
+    }
+    return {
+      outcome: 'issue-updated',
+      lapsing: soon.length,
+      issueUrl: existing.url,
+      note: `Updated the expiry notice: ${soon.length} suppression(s) lapse within ${horizonDays} days (${existing.url}).`,
+    };
+  }
+
+  const created = opts
+    .exec('gh', ['issue', 'create', '--title', title, '--body', body], { allowFail: true })
+    .trim();
+  const url = created.split('\n').filter(Boolean).pop() ?? '';
+  if (!url.startsWith('http')) {
+    return {
+      outcome: 'unavailable',
+      lapsing: soon.length,
+      note:
+        `${soon.length} suppression(s) lapse within ${horizonDays} days, but no issue could be ` +
+        `opened — issues may be disabled, or the workflow token lacks \`issues: write\` (grant it ` +
+        `by re-running \`${dxkitCli('update')}\` with \`expiryNotice.enabled\` set). The lapse ` +
+        `still surfaces on every guardrail check.`,
+    };
+  }
+  return {
+    outcome: 'issue-opened',
+    lapsing: soon.length,
+    issueUrl: url,
+    note: `Opened the expiry notice: ${soon.length} suppression(s) lapse within ${horizonDays} days (${url}).`,
+  };
+}
+
+function exec_close(exec: Exec, issueNumber: number): void {
+  exec(
+    'gh',
+    [
+      'issue',
+      'close',
+      String(issueNumber),
+      '--comment',
+      'Nothing is lapsing within the horizon any more — closing. dxkit reopens a fresh notice if that changes.',
+    ],
+    { allowFail: true },
+  );
+}

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -167,6 +167,11 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
     anchor: 'dep-bump',
   },
   {
+    path: 'expiryNotice.enabled',
+    summary: 'maintain one issue naming allowlist suppressions about to lapse',
+    anchor: 'expiry-notice',
+  },
+  {
     path: 'reports.onMerge',
     summary: 'publish report snapshots to the dxkit-reports ref on merge',
     anchor: 'reports-on-merge',
@@ -352,6 +357,23 @@ export const POLICY_STANZAS: readonly PolicyStanzaMeta[] = [
     anchor: 'dep-bump',
     example: () => ({ enabled: true }),
     followUp: ['Installs a managed workflow: run `vyuh-dxkit update` after enabling.'],
+  },
+  {
+    key: 'expiryNotice',
+    coversKnobs: ['expiryNotice.enabled'],
+    title: 'Expiring-suppression notice',
+    blurb: [
+      'A deferral is a promise with a date on it. The guardrail check already',
+      'warns every PR while the window is open — this covers the quiet week:',
+      'the scheduled refresh maintains ONE issue naming what lapses, who',
+      'accepted it, and when, and closes it once nothing is lapsing.',
+      'Never blocks; the expiry itself stays the forcing function.',
+    ],
+    anchor: 'expiry-notice',
+    example: () => ({ enabled: true }),
+    followUp: [
+      'Grants the refresh workflow `issues: write`: run `vyuh-dxkit update` after enabling.',
+    ],
   },
   {
     key: 'reports',

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -214,6 +214,12 @@ export function buildPolicySchema(version: string): Schema {
         },
         'Scheduled deterministic dependency-bump PRs.',
       ),
+      expiryNotice: obj(
+        {
+          enabled: boolProp('expiryNotice.enabled'),
+        },
+        'One maintained issue naming allowlist suppressions about to lapse.',
+      ),
       reports: obj(
         {
           onMerge: boolProp('reports.onMerge'),

--- a/src/baseline/policy.ts
+++ b/src/baseline/policy.ts
@@ -349,6 +349,21 @@ export interface BrownfieldPolicy {
    */
   readonly depBump?: { readonly enabled?: boolean; readonly allowMajor?: boolean };
   /**
+   * The expiry decision surface: while the scheduled refresh is running anyway,
+   * maintain ONE GitHub issue naming the allowlist suppressions whose windows
+   * close inside the shared horizon, who accepted each, and when. Opt-in,
+   * default OFF — it is the only dxkit lane that opens an issue on its own
+   * initiative, and enabling it grants the refresh workflow `issues: write`
+   * (run `vyuh-dxkit update` after flipping it so the workflow is re-rendered).
+   *
+   * The guardrail check already warns every author and reviewer during the
+   * window (the lapse projection). This closes the remaining hole: a repo where
+   * nobody opens a PR for a week gets no warning at all, and the person who
+   * accepted the deferral is never addressed. Never gates — the expiry itself
+   * remains the forcing function.
+   */
+  readonly expiryNotice?: { readonly enabled?: boolean };
+  /**
    * Recall-attribution tuning (Rule 19). Absent ⟹ `inputs: 'resolved'`.
    */
   readonly recall?: RecallPolicy;

--- a/src/baseline/refresh.ts
+++ b/src/baseline/refresh.ts
@@ -72,7 +72,8 @@ import {
 import { loadAllowlist } from '../allowlist/file';
 import { makeExec, openOrUpdateStandingPr, type LandRefreshResult } from '../land-refresh';
 import { internalGitPushArgs } from '../git-internal-push';
-import { detectDefaultBranch } from '../ship-installers';
+import { detectDefaultBranch, expiryNoticeEnabled } from '../ship-installers';
+import { syncExpiryNotice, type ExpiryNoticeResult } from './expiry-notice';
 
 /** The standing decision branch. ONE branch, force-updated — never a pile. */
 export const ADVISORY_DECISION_BRANCH = 'dxkit/advisory-decision';
@@ -92,6 +93,9 @@ export interface BaselineRefreshResult {
   readonly heldOut: ReadonlyArray<HeldOutAdvisory>;
   /** The decision-PR landing outcome; absent when nothing was held out. */
   readonly decision?: LandRefreshResult;
+  /** The expiry decision surface's outcome; absent when the knob is off (the
+   *  default) — so a repo that never opted in cannot tell the difference. */
+  readonly expiryNotice?: ExpiryNoticeResult;
   /** Why the advisory lane did / could not run — always populated so a refresh
    *  log never leaves the reader guessing (the GateFailure discipline). */
   readonly note: string;
@@ -275,10 +279,38 @@ export function decisionPrBody(
 }
 
 /**
- * The refresh orchestration. See the module docs for semantics; the return's
- * `note` always says what the advisory lane did (or why it could not run).
+ * The refresh orchestration: the advisory decision lane, then the expiry
+ * decision surface.
+ *
+ * The two are INDEPENDENT and both ride this one scheduled run. A suppression
+ * can be about to lapse whether or not this refresh held any advisory out, so
+ * the notice is synced on every path the advisory lane can take — including its
+ * early returns (ref-based mode, first capture, no prior baseline). Wiring it
+ * inside the lane would have made the notice a silent function of whether an
+ * unrelated feed happened to move that week.
  */
 export async function runBaselineRefresh(
+  opts: BaselineRefreshOptions,
+): Promise<BaselineRefreshResult> {
+  const result = await runAdvisoryDecisionLane(opts);
+  const cwd = path.resolve(opts.cwd);
+  // Opt-in, default off: it is the only dxkit lane that opens an issue on its
+  // own initiative, and it needs a permission the workflow only holds when the
+  // repo asked for it (`refreshPermissionsBlock`).
+  if (!expiryNoticeEnabled(cwd)) return result;
+  const expiryNotice = syncExpiryNotice({
+    cwd,
+    exec: opts.exec ?? makeExec(cwd),
+    ...(opts.now !== undefined ? { now: opts.now } : {}),
+  });
+  return { ...result, expiryNotice };
+}
+
+/**
+ * The advisory decision lane. See the module docs for semantics; the return's
+ * `note` always says what it did (or why it could not run).
+ */
+async function runAdvisoryDecisionLane(
   opts: BaselineRefreshOptions,
 ): Promise<BaselineRefreshResult> {
   const cwd = path.resolve(opts.cwd);

--- a/src/discovery/advisor.ts
+++ b/src/discovery/advisor.ts
@@ -13,6 +13,7 @@ import { FLOW_CONFIG_SCHEMA_VERSION } from '../analyzers/flow/config';
 import { SCHEMA_CONFIG_SCHEMA_VERSION } from '../analyzers/model-schema/config';
 import { DUPLICATION_CONFIG_SCHEMA_VERSION } from '../analyzers/duplication/config';
 import { readPolicyObjectSafe } from '../baseline/policy-text';
+import { tryLoadAllowlist } from '../allowlist/file';
 import { failingFloorDebt } from '../baseline/floor-debt';
 import {
   existsAt,
@@ -209,6 +210,36 @@ export function recommendDepBump(ctx: RecommendContext): Recommendation | null {
       `floor-verified PR (no agent involved). Preview with the command below; enable the ` +
       `scheduled lane with .dxkit/policy.json depBump.enabled: true + vyuh-dxkit update`,
     command: 'vyuh-dxkit deps bump',
+  };
+}
+
+/**
+ * Expiring-suppression notice: fires when the repo actually holds allowlist
+ * entries with expiry dates and the notice lane is not configured. Grounded in
+ * the committed allowlist — a repo with no time-boxed suppressions never hears
+ * about it, and one that decided (either way) stops hearing immediately.
+ *
+ * Deliberately keyed on "has expiring entries at all", not "has entries
+ * expiring within the horizon": the recommendation is about adopting a lane
+ * BEFORE the quiet week that needs it, and a probe that only fired inside the
+ * horizon would arrive at the same time as the problem.
+ */
+export function recommendExpiryNotice(ctx: RecommendContext): Recommendation | null {
+  const policy = readPolicyObjectSafe(ctx.cwd) as { expiryNotice?: unknown } | null;
+  if (policy && policy.expiryNotice !== undefined) return null;
+  // Through the ONE allowlist reader, not a raw JSON read: it validates the
+  // schema and merges the sanitized-mode reason sidecar, so a compliance-mode
+  // repo's entries are counted the same as a full-mode repo's.
+  const allowlist = tryLoadAllowlist(ctx.cwd);
+  const timeBoxed = (allowlist?.entries ?? []).filter((e) => e.expiresAt !== undefined).length;
+  if (timeBoxed === 0) return null;
+  return {
+    reason:
+      `${timeBoxed} allowlist suppression${timeBoxed === 1 ? ' is' : 's are'} time-boxed — the ` +
+      `guardrail check warns while a PR is open, but a quiet week ends with the lapse landing on ` +
+      `whoever pushes next. Set .dxkit/policy.json expiryNotice.enabled: true + vyuh-dxkit update ` +
+      `to have the scheduled refresh keep one issue naming what lapses and who accepted it`,
+    command: 'vyuh-dxkit allowlist audit',
   };
 }
 

--- a/src/discovery/command-defs-gate.ts
+++ b/src/discovery/command-defs-gate.ts
@@ -10,6 +10,7 @@ import {
   recommendChecks,
   recommendDebt,
   recommendDepBump,
+  recommendExpiryNotice,
   recommendRemediate,
   recommendExtensions,
   recommendLoopPreset,
@@ -80,6 +81,7 @@ export const GATE_COMMANDS = [
       'Accept a finding with a typed category + required reason + optional expiry; audit and prune ' +
       'entries. `defer` bulk-defers newly published dep-vuln advisories time-boxed (dep-vuln-only).',
     skill: 'dxkit-allowlist',
+    whenToRecommend: recommendExpiryNotice,
   },
   {
     id: 'ingest',

--- a/src/discovery/posture-knobs.ts
+++ b/src/discovery/posture-knobs.ts
@@ -144,6 +144,16 @@ export const POSTURE_KNOBS: readonly PostureKnob[] = [
       'a CI-performance transport (graph.json Actions-cache), not a gate/posture — rebuild-on-demand is the correct default and changes no finding, so there is no behavioral difference to recommend. Installed by init/update when set to "cache"; documented in policy.md.',
   },
   {
+    path: 'expiryNotice.enabled',
+    command: 'allowlist',
+    requiresPlan: false,
+    requiresRecommend: true,
+    note:
+      'enabling grants the managed refresh workflow `issues: write`, which configure’s ' +
+      'policy-only merge-write cannot place — so no planConfig; recommendExpiryNotice surfaces ' +
+      'the lane once the repo actually holds suppressions that expire.',
+  },
+  {
     path: 'depBump.enabled',
     command: 'deps',
     requiresPlan: false,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -14,7 +14,7 @@ import { loadPolicyFromCwd } from './baseline/policy';
 import { detectEnforcement } from './enforcement';
 import { detectInstalledRefreshTransport, detectDefaultBranch } from './ship-installers';
 import { detectPackageManager, addDevCommand } from './package-manager';
-import { loadAllowlist, auditAllowlist } from './allowlist/file';
+import { auditAllowlist, tryLoadAllowlist } from './allowlist/file';
 import { snapshotEngines, readSnapshot } from './ingest/snapshot';
 import { EXTERNAL_SNAPSHOT_STALE_DAYS, snapshotAgeDays } from './ingest/engine-failure';
 import { diagnoseFlow, type FlowDiagnosis } from './analyzers/flow/diagnose';
@@ -121,19 +121,6 @@ function nodeMajorVersion(): number {
 function safeLoadPolicy(cwd: string): ReturnType<typeof loadPolicyFromCwd> | null {
   try {
     return loadPolicyFromCwd(cwd);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Wrap `loadAllowlist` with a swallowing try/catch — a malformed
- * allowlist file must not break doctor. Returns null on absence or
- * parse failure; the expiry check simply doesn't emit in that case.
- */
-function safeLoadAllowlist(cwd: string): ReturnType<typeof loadAllowlist> {
-  try {
-    return loadAllowlist(cwd);
   } catch {
     return null;
   }
@@ -902,7 +889,7 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
   // nearing expiry needs a decision before it lapses. Surface both so
   // a reviewed-and-accepted finding doesn't silently turn back into a
   // blocker mid-sprint. Only emits when an allowlist actually exists.
-  const allowlistFile = safeLoadAllowlist(cwd);
+  const allowlistFile = tryLoadAllowlist(cwd);
   if (allowlistFile && allowlistFile.entries.length > 0) {
     const audit = auditAllowlist(allowlistFile);
     if (audit.expired.length > 0) {

--- a/src/loop/demo.ts
+++ b/src/loop/demo.ts
@@ -20,6 +20,7 @@ import * as readline from 'readline';
 import { execFileSync, spawnSync } from 'child_process';
 import type { GuardrailJsonPayload } from '../baseline/check-renderers';
 import { GUARDRAIL_JSON_SCHEMA } from '../baseline/check-renderers';
+import { SOON_TO_EXPIRE_DAYS } from '../allowlist/file';
 import { buildRepairMessage } from './stop-gate';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
 import { dxkitCli, dxkitOneShotCli } from '../self-invocation';
@@ -51,6 +52,15 @@ function illustrativePayload(blocked: boolean): GuardrailJsonPayload {
     schema: GUARDRAIL_JSON_SCHEMA,
     verdict: { blocks: blocked, warns: false, refused: false, exitCode: blocked ? 1 : 0 },
     attributionGaps: [],
+    // The illustration has no allowlist, so nothing is deferred and nothing can
+    // lapse. Spelled out rather than omitted — the field is required so a real
+    // payload can never quietly lack it.
+    suppressionExpiry: {
+      horizonDays: SOON_TO_EXPIRE_DAYS,
+      lapsing: [],
+      willBlock: 0,
+      willWarn: 0,
+    },
     baseline: {
       name: 'main',
       createdAt: '2026-01-01T00:00:00.000Z',

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -901,6 +901,10 @@ export function installCiBaselineRefresh(
       // Policy-driven through the ONE normalizer; the 'tree' template has no
       // schedule (it refreshes per push), so the key is simply absent there.
       __DXKIT_REFRESH_CRON__: baselineRefreshCron({ baseline: readPolicyBaselineSection(cwd) }),
+      // The permission block, transport-derived + knob-derived (the expiry
+      // notice needs `issues: write`). Rendered from ONE helper so the workflow
+      // can never hold a permission the lane does not need, or lack one it does.
+      __DXKIT_REFRESH_PERMISSIONS__: refreshPermissionsBlock(cwd, plan.transport),
       [CI_RUNTIME_SETUP_KEY]: renderCiRuntimeSetup(cwd),
       // Multi-env capture (Rule 20 / design §3.4): per-host fragment jobs +
       // the merge before the commit. All three slots render empty on a repo
@@ -1103,6 +1107,33 @@ export function depBumpEnabled(cwd: string): boolean {
   } catch {
     return false;
   }
+}
+
+/** Whether the expiry decision surface is enabled in policy
+ *  (`expiryNotice.enabled: true`). Read here, beside its lane siblings, so the
+ *  refresh lane and the workflow's permission block resolve it from ONE place —
+ *  a lane that runs while the workflow lacks `issues: write` would fail-open
+ *  silently every week. */
+export function expiryNoticeEnabled(cwd: string): boolean {
+  try {
+    return loadPolicyFromCwd(cwd).expiryNotice?.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The refresh workflow's `permissions:` block. `contents` is the transport's
+ * own requirement (a tree/branch push needs write; the cache transport writes
+ * no git object at all), and `issues: write` is added ONLY when the expiry
+ * notice is enabled — so a repo that never opts in keeps a workflow
+ * byte-identical to the one it has today.
+ */
+export function refreshPermissionsBlock(cwd: string, transport: BaselineAnchor): string {
+  const contents = transport === 'cache' ? 'read' : 'write';
+  const lines = [`  contents: ${contents}`];
+  if (expiryNoticeEnabled(cwd)) lines.push('  issues: write');
+  return lines.join('\n');
 }
 
 export function installCiCommentDefer(cwd: string, opts: InstallerOpts = {}): ShipInstallResult {

--- a/test/allowlist/defer-guard.test.ts
+++ b/test/allowlist/defer-guard.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The deferral creation guard — the advisories a caller gets at the moment they
+ * time-box a finding, and the one hard refusal.
+ *
+ * The class: a deferral is a promise ("we will fix this before <date>") and
+ * nothing ever said whether the promise was keepable. On the repo that produced
+ * this, 21 dependency advisories were deferred for six days with no remediation
+ * lane enabled; all 21 returned on the same morning and blocked every open PR.
+ * Every fact needed to see that coming was available at the keystroke.
+ *
+ * Pinned here: each advisory fires on its own condition, stays silent when the
+ * condition does not hold (an advisory that always fires is an advisory nobody
+ * reads), and reaches BOTH front-ends from the one core — the local CLI and the
+ * `/dxkit defer` PR reply.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { executeDefer } from '../../src/allowlist/defer-core';
+import { deferAdvisories } from '../../src/allowlist/defer-guard';
+import { runCommentDeferCore } from '../../src/allowlist/comment-defer';
+import { loadAllowlist } from '../../src/allowlist/file';
+import { DEFER_ADVISORY_EXPIRY_DAYS } from '../../src/allowlist/categories';
+import { writeVerdict } from '../../src/baseline/verdict-cache';
+import type { CachedBlockingFinding } from '../../src/baseline/verdict-cache';
+import type { BrownfieldPolicy } from '../../src/baseline/policy';
+
+const NOW = new Date('2026-07-22T09:00:00Z');
+
+const tmps: string[] = [];
+function mkRepo(policy?: Record<string, unknown>): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-defer-guard-'));
+  tmps.push(d);
+  execFileSync('git', ['init', '-q'], { cwd: d });
+  execFileSync('git', ['config', 'user.email', 'dev@example.com'], { cwd: d });
+  execFileSync('git', ['config', 'user.name', 'dev'], { cwd: d });
+  fs.writeFileSync(path.join(d, 'app.js'), 'const x = 1;\n');
+  if (policy) {
+    fs.mkdirSync(path.join(d, '.dxkit'), { recursive: true });
+    fs.writeFileSync(path.join(d, '.dxkit', 'policy.json'), JSON.stringify(policy, null, 2));
+  }
+  execFileSync('git', ['add', '-A'], { cwd: d });
+  execFileSync('git', ['commit', '-qm', 'init'], { cwd: d });
+  return d;
+}
+afterEach(() => {
+  for (const d of tmps.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const DEP_A: CachedBlockingFinding = {
+  fingerprint: 'aaaa000000000001',
+  kind: 'dep-vuln',
+  status: 'newly_published_advisory',
+  severity: 'high',
+  locator: 'fast-uri@3.1.2 · GHSA-aaaa-bbbb-cccc',
+};
+const DEP_B: CachedBlockingFinding = {
+  fingerprint: 'aaaa000000000002',
+  kind: 'dep-vuln',
+  status: 'newly_published_advisory',
+  severity: 'medium',
+  locator: 'svgo@1.3.2 · GHSA-dddd-eeee-ffff',
+};
+
+function seedVerdict(cwd: string, blockingFindings: CachedBlockingFinding[]): void {
+  writeVerdict(cwd, {} as unknown as BrownfieldPolicy, {
+    blocks: blockingFindings.length > 0,
+    warns: false,
+    blockingCount: blockingFindings.length,
+    unattributableCount: 0,
+    warningCount: 0,
+    markdown: '## dxkit signals',
+    ranAt: NOW.toISOString(),
+    blockingFindings,
+  });
+}
+
+describe('deferAdvisories', () => {
+  it('names the batch-lapse property when more than one finding shares the window', () => {
+    const d = mkRepo();
+    const out = deferAdvisories(d, { count: 21, expiresAt: '2026-07-28', now: NOW });
+    expect(out.some((a) => a.includes('All 21 findings share one expiry'))).toBe(true);
+    expect(out.some((a) => a.includes('2026-07-28'))).toBe(true);
+  });
+
+  it('stays quiet about batching for a single finding', () => {
+    const d = mkRepo();
+    const out = deferAdvisories(d, { count: 1, expiresAt: '2026-07-28', now: NOW });
+    expect(out.some((a) => a.includes('share one expiry'))).toBe(false);
+  });
+
+  it('warns when no remediation lane exists to close the findings', () => {
+    const d = mkRepo();
+    const out = deferAdvisories(d, { count: 9, expiresAt: '2026-07-28', now: NOW });
+    const lane = out.find((a) => a.includes('No automated remediation lane'));
+    expect(lane).toBeDefined();
+    // States the consequence and both escape hatches, not just the fact.
+    expect(lane).toContain('whoever opens a PR that day inherits them');
+    expect(lane).toContain('depBump.enabled');
+    expect(lane).toContain('remediate.enabled');
+  });
+
+  it('goes silent about lanes once the bump lane is enabled with a full cycle of room', () => {
+    const d = mkRepo({ depBump: { enabled: true } });
+    const out = deferAdvisories(d, { count: 9, expiresAt: '2026-08-05', now: NOW });
+    expect(out.some((a) => a.includes('No automated remediation lane'))).toBe(false);
+    expect(out.some((a) => a.includes('runs weekly'))).toBe(false);
+  });
+
+  it('warns when the window shuts before the weekly bump lane can run', () => {
+    const d = mkRepo({ depBump: { enabled: true } });
+    const out = deferAdvisories(d, { count: 9, expiresAt: '2026-07-25', now: NOW });
+    const cadence = out.find((a) => a.includes('runs weekly'));
+    expect(cadence).toBeDefined();
+    expect(cadence).toContain('3-day window');
+    expect(cadence).toContain(`+${DEFER_ADVISORY_EXPIRY_DAYS}d`);
+  });
+
+  it('warns that a same-day window is over tomorrow', () => {
+    const d = mkRepo({ remediate: { enabled: true } });
+    const out = deferAdvisories(d, { count: 1, expiresAt: '2026-07-22', now: NOW });
+    expect(out.some((a) => a.includes('closes TODAY'))).toBe(true);
+  });
+
+  it('says nothing at all when the deferral is unremarkable', () => {
+    const d = mkRepo({ remediate: { enabled: true } });
+    expect(deferAdvisories(d, { count: 1, expiresAt: '2026-08-05', now: NOW })).toEqual([]);
+  });
+});
+
+describe('executeDefer — the past-expiry refusal', () => {
+  it('refuses a window that already closed rather than writing a dead entry', () => {
+    const d = mkRepo();
+    seedVerdict(d, [DEP_A]);
+    const result = executeDefer(
+      d,
+      {
+        fingerprints: [DEP_A.fingerprint],
+        reason: 'backdated by mistake',
+        expires: '2026-07-01',
+        addedBy: 'dev@example.com',
+        mode: 'full',
+      },
+      NOW,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('already in the past');
+      expect(result.message).toContain('would suppress nothing');
+    }
+    // And nothing was written — the caller's intent failed loudly, not quietly.
+    expect(loadAllowlist(d)).toBeNull();
+  });
+
+  it('accepts a window closing today (the expiry is inclusive, so it still suppresses)', () => {
+    const d = mkRepo();
+    seedVerdict(d, [DEP_A]);
+    const result = executeDefer(
+      d,
+      {
+        fingerprints: [DEP_A.fingerprint],
+        reason: 'fix lands this afternoon',
+        expires: '2026-07-22',
+        addedBy: 'dev@example.com',
+        mode: 'full',
+      },
+      NOW,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.advisories.some((a) => a.includes('closes TODAY'))).toBe(true);
+  });
+});
+
+describe('both front-ends carry the advisories (one core, one set of facts)', () => {
+  it('the core attaches them to a successful defer, and only when something was written', () => {
+    const d = mkRepo();
+    seedVerdict(d, [DEP_A, DEP_B]);
+    const first = executeDefer(
+      d,
+      { fromLastCheck: true, reason: 'advisory batch', addedBy: 'dev@example.com', mode: 'full' },
+      NOW,
+    );
+    expect(first.ok).toBe(true);
+    if (first.ok) {
+      expect(first.added).toHaveLength(2);
+      expect(first.advisories.some((a) => a.includes('share one expiry'))).toBe(true);
+      expect(first.advisories.some((a) => a.includes('No automated remediation lane'))).toBe(true);
+    }
+    // A re-run writes nothing, so it chose no window and says nothing about one.
+    // Explicit fingerprints, not --from-last-check: the verdict cache is
+    // tree-scoped, and the allowlist write above already changed the tree.
+    const second = executeDefer(
+      d,
+      {
+        fingerprints: [DEP_A.fingerprint, DEP_B.fingerprint],
+        reason: 'advisory batch',
+        addedBy: 'dev@example.com',
+        mode: 'full',
+      },
+      NOW,
+    );
+    expect(second.ok).toBe(true);
+    if (second.ok) {
+      expect(second.added).toEqual([]);
+      expect(second.advisories).toEqual([]);
+    }
+  });
+
+  it('the PR reply carries them into the thread the reviewers read', () => {
+    const d = mkRepo();
+    seedVerdict(d, [DEP_A, DEP_B]);
+    const payload = runCommentDeferCore(
+      d,
+      {
+        DXKIT_COMMENT_BODY: '/dxkit defer --new-advisories --reason="advisory batch"',
+        DXKIT_COMMENT_AUTHOR: 'reviewer',
+        DXKIT_COMMENT_PR: '377',
+      },
+      NOW,
+    );
+    expect(payload.action).toBe('deferred');
+    expect(payload.replyMarkdown).toContain('No automated remediation lane');
+    expect(payload.replyMarkdown).toContain('share one expiry');
+  });
+});

--- a/test/baseline/expiry-notice.test.ts
+++ b/test/baseline/expiry-notice.test.ts
@@ -1,0 +1,293 @@
+/**
+ * The expiry DECISION surface — the one maintained issue that reaches a
+ * deferral's owner when no PR is open.
+ *
+ * The hole it closes is narrow and specific. Three surfaces already warn during
+ * the window (console / PR comment / JSON), so this is only about the quiet
+ * week: on the repo that produced this class, the deferral was created on the
+ * 22nd, the repo went quiet, and the lapse landed on the 29th inside an
+ * unrelated PR whose author had never seen the findings.
+ *
+ * Pinned here: create / update / **close** (the self-close is what keeps the
+ * surface trustworthy — an issue that outlives its facts teaches a team to
+ * filter dxkit's issues, which would disable every future notice), fail-open on
+ * every GitHub failure, the opt-in gate, and the permission block that must
+ * carry `issues: write` exactly when the lane is on.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  EXPIRY_NOTICE_MARKER,
+  expiryNoticeBody,
+  syncExpiryNotice,
+} from '../../src/baseline/expiry-notice';
+import { refreshPermissionsBlock, expiryNoticeEnabled } from '../../src/ship-installers';
+import { auditAllowlist, SOON_TO_EXPIRE_DAYS } from '../../src/allowlist/file';
+import type { AllowlistEntry, AllowlistFile } from '../../src/allowlist/file';
+import type { Exec } from '../../src/land-refresh';
+
+const NOW = new Date('2026-07-22T09:00:00Z');
+
+const tmps: string[] = [];
+function mkRepo(
+  opts: { policy?: Record<string, unknown>; allowlist?: AllowlistFile } = {},
+): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-expiry-notice-'));
+  tmps.push(d);
+  execFileSync('git', ['init', '-q'], { cwd: d });
+  fs.mkdirSync(path.join(d, '.dxkit'), { recursive: true });
+  if (opts.policy) {
+    fs.writeFileSync(path.join(d, '.dxkit', 'policy.json'), JSON.stringify(opts.policy, null, 2));
+  }
+  if (opts.allowlist) {
+    fs.writeFileSync(
+      path.join(d, '.dxkit', 'allowlist.json'),
+      JSON.stringify(opts.allowlist, null, 2),
+    );
+  }
+  return d;
+}
+afterEach(() => {
+  for (const d of tmps.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+function entry(fingerprint: string, expiresAt?: string, over: Partial<AllowlistEntry> = {}) {
+  return {
+    fingerprint,
+    kind: 'dep-vuln',
+    category: expiresAt ? 'deferred' : 'false-positive',
+    reason: 'time-boxed pending dependency remediation',
+    addedBy: 'jane@corp.example',
+    addedAt: '2026-07-22',
+    ...(expiresAt ? { expiresAt } : {}),
+    ...over,
+  } as AllowlistEntry;
+}
+
+function allowlistOf(entries: AllowlistEntry[]): AllowlistFile {
+  return { schemaVersion: 'dxkit-allowlist/v1', mode: 'full', entries };
+}
+
+/** A recording exec seam: canned stdout per `gh <sub> <verb>`, plus a log. */
+function fakeExec(responses: Record<string, string>): Exec & { calls: string[][] } {
+  const calls: string[][] = [];
+  const fn = ((bin: string, args: readonly string[]) => {
+    calls.push([bin, ...args]);
+    const key = `${args[0]} ${args[1]}`;
+    return responses[key] ?? '';
+  }) as Exec & { calls: string[][] };
+  fn.calls = calls;
+  return fn;
+}
+
+const LAPSING = allowlistOf([
+  entry('aaaa000000000001', '2026-07-28', { acknowledgedSeverity: 'high' }),
+  entry('aaaa000000000002', '2026-07-28', { acknowledgedSeverity: 'high' }),
+  entry('bbbb000000000001'), // never expires — must not appear
+]);
+
+describe('expiryNoticeBody', () => {
+  const soon = auditAllowlist(LAPSING, { now: NOW }).soonToExpire;
+
+  it('carries the marker, the countdown, and one row per lapsing entry', () => {
+    const body = expiryNoticeBody(soon, { horizonDays: SOON_TO_EXPIRE_DAYS });
+    expect(body.startsWith(EXPIRY_NOTICE_MARKER)).toBe(true);
+    expect(body).toContain('**2 allowlist suppressions lapse within 14 days**');
+    expect(body).toContain('in 6 days');
+    expect(body).toContain('`aaaa000000000001`');
+    expect(body).toContain('`aaaa000000000002`');
+    // The non-expiring entry is not a decision waiting to happen.
+    expect(body).not.toContain('bbbb000000000001');
+  });
+
+  it('states the batch-lapse property when one date covers them all', () => {
+    const body = expiryNoticeBody(soon, { horizonDays: SOON_TO_EXPIRE_DAYS });
+    expect(body).toContain('All 2 share one expiry, so they return together on 2026-07-28');
+  });
+
+  it('names owners and says explicitly that it will not assign', () => {
+    const body = expiryNoticeBody(soon, { horizonDays: SOON_TO_EXPIRE_DAYS });
+    expect(body).toContain('jane@corp.example');
+    expect(body).toContain('not assigned');
+    expect(body).toContain('will not guess a GitHub login');
+  });
+
+  it('offers both lanes and discloses the cadence limitation', () => {
+    const body = expiryNoticeBody(soon, { horizonDays: SOON_TO_EXPIRE_DAYS });
+    expect(body).toContain('Fix them');
+    expect(body).toContain('Renew deliberately');
+    expect(body).toContain('never blocks a build');
+    expect(body).toContain('slower than 14 days, the first notice can arrive late');
+  });
+
+  it('reports the acknowledged severity, which is a recorded fact rather than a re-derivation', () => {
+    const body = expiryNoticeBody(soon, { horizonDays: SOON_TO_EXPIRE_DAYS });
+    expect(body).toContain('| high |');
+    // It never claims a block/warn consequence — that needs a classification
+    // pass the refresh does not run; the guardrail check makes that claim.
+    expect(body).not.toContain('will BLOCK');
+  });
+});
+
+describe('syncExpiryNotice', () => {
+  it('opens one issue when suppressions are lapsing and none is open', () => {
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({
+      'issue list': '[]',
+      'issue create': 'https://github.com/acme/repo/issues/7\n',
+    });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('issue-opened');
+    expect(out.lapsing).toBe(2);
+    expect(out.issueUrl).toBe('https://github.com/acme/repo/issues/7');
+    expect(out.note).toContain('Opened the expiry notice');
+    const create = exec.calls.find((c) => c[1] === 'issue' && c[2] === 'create')!;
+    expect(create.join(' ')).toContain('dxkit: allowlist suppressions expiring (2)');
+  });
+
+  it('updates the SAME issue when one carries the marker (never a second one)', () => {
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({
+      'issue list': JSON.stringify([
+        { number: 3, url: 'https://github.com/acme/repo/issues/3', body: 'unrelated' },
+        {
+          number: 7,
+          url: 'https://github.com/acme/repo/issues/7',
+          body: `${EXPIRY_NOTICE_MARKER}\nstale text`,
+        },
+      ]),
+      'issue edit': 'https://github.com/acme/repo/issues/7\n',
+    });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('issue-updated');
+    expect(out.issueUrl).toBe('https://github.com/acme/repo/issues/7');
+    expect(exec.calls.some((c) => c[2] === 'create')).toBe(false);
+    const edit = exec.calls.find((c) => c[2] === 'edit')!;
+    expect(edit[3]).toBe('7');
+  });
+
+  it('CLOSES the open issue once nothing is lapsing — the self-close', () => {
+    const d = mkRepo({ allowlist: allowlistOf([entry('cccc000000000001', '2026-12-31')]) });
+    const exec = fakeExec({
+      'issue list': JSON.stringify([
+        {
+          number: 7,
+          url: 'https://github.com/acme/repo/issues/7',
+          body: `${EXPIRY_NOTICE_MARKER}\nold`,
+        },
+      ]),
+    });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('issue-closed');
+    expect(out.lapsing).toBe(0);
+    const close = exec.calls.find((c) => c[2] === 'close')!;
+    expect(close[3]).toBe('7');
+    expect(close.join(' ')).toContain('reopens a fresh notice');
+  });
+
+  it('stays silent when nothing is lapsing and no issue is open', () => {
+    const d = mkRepo({ allowlist: allowlistOf([entry('dddd000000000001')]) });
+    const exec = fakeExec({ 'issue list': '[]' });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('nothing-to-report');
+    expect(exec.calls.some((c) => c[2] === 'create' || c[2] === 'close')).toBe(false);
+  });
+
+  it('fails OPEN and says why when the issue cannot be created', () => {
+    // gh missing / issues disabled / token without `issues: write` — every one
+    // of those surfaces as empty stdout through the allowFail exec.
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({ 'issue list': '[]', 'issue create': '' });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('unavailable');
+    expect(out.lapsing).toBe(2);
+    expect(out.note).toContain('issues: write');
+    expect(out.note).toContain('still surfaces on every guardrail check');
+  });
+
+  it('fails OPEN when an existing issue cannot be edited, and keeps naming it', () => {
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({
+      'issue list': JSON.stringify([
+        { number: 7, url: 'https://github.com/acme/repo/issues/7', body: EXPIRY_NOTICE_MARKER },
+      ]),
+      'issue edit': '',
+    });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW });
+    expect(out.outcome).toBe('unavailable');
+    expect(out.issueUrl).toBe('https://github.com/acme/repo/issues/7');
+  });
+
+  it('treats an unparseable issue list as "none open" rather than throwing', () => {
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({ 'issue list': 'not json', 'issue create': 'https://x/issues/1\n' });
+    expect(syncExpiryNotice({ cwd: d, exec, now: NOW }).outcome).toBe('issue-opened');
+  });
+
+  it('reports nothing to do on a repo with no allowlist at all', () => {
+    const d = mkRepo();
+    const exec = fakeExec({ 'issue list': '[]' });
+    expect(syncExpiryNotice({ cwd: d, exec, now: NOW }).outcome).toBe('nothing-to-report');
+  });
+});
+
+describe('the refresh lane runs the notice independently of the advisory lane', () => {
+  /** Policy that makes the advisory lane take its earliest no-op return. */
+  const REF_BASED = { baseline: { mode: 'ref-based' } };
+
+  it('syncs the notice even when the advisory lane no-ops entirely', async () => {
+    const { runBaselineRefresh } = await import('../../src/baseline/refresh');
+    const d = mkRepo({
+      policy: { ...REF_BASED, expiryNotice: { enabled: true } },
+      allowlist: LAPSING,
+    });
+    const exec = fakeExec({
+      'issue list': '[]',
+      'issue create': 'https://github.com/acme/repo/issues/9\n',
+    });
+    const result = await runBaselineRefresh({ cwd: d, exec, now: NOW });
+    // The advisory lane did nothing (ref-based has no committed baseline) …
+    expect(result.heldOut).toEqual([]);
+    expect(result.note).toContain('ref-based');
+    // … and the notice still fired. A suppression's expiry has nothing to do
+    // with whether an advisory feed moved this week.
+    expect(result.expiryNotice?.outcome).toBe('issue-opened');
+    expect(result.expiryNotice?.lapsing).toBe(2);
+  });
+
+  it('does not touch GitHub at all when the knob is off (the default)', async () => {
+    const { runBaselineRefresh } = await import('../../src/baseline/refresh');
+    const d = mkRepo({ policy: REF_BASED, allowlist: LAPSING });
+    const exec = fakeExec({ 'issue list': '[]' });
+    const result = await runBaselineRefresh({ cwd: d, exec, now: NOW });
+    expect(result.expiryNotice).toBeUndefined();
+    expect(exec.calls).toEqual([]);
+  });
+});
+
+describe('the opt-in gate and the workflow permission it implies', () => {
+  it('is off unless policy says otherwise', () => {
+    expect(expiryNoticeEnabled(mkRepo())).toBe(false);
+    expect(expiryNoticeEnabled(mkRepo({ policy: {} }))).toBe(false);
+    expect(expiryNoticeEnabled(mkRepo({ policy: { expiryNotice: { enabled: false } } }))).toBe(
+      false,
+    );
+    expect(expiryNoticeEnabled(mkRepo({ policy: { expiryNotice: { enabled: true } } }))).toBe(true);
+  });
+
+  it('grants issues: write ONLY when enabled, keeping every other repo byte-identical', () => {
+    const off = mkRepo();
+    expect(refreshPermissionsBlock(off, 'tree')).toBe('  contents: write');
+    expect(refreshPermissionsBlock(off, 'branch')).toBe('  contents: write');
+    // The cache transport writes no git object, so it never needed write.
+    expect(refreshPermissionsBlock(off, 'cache')).toBe('  contents: read');
+
+    const on = mkRepo({ policy: { expiryNotice: { enabled: true } } });
+    expect(refreshPermissionsBlock(on, 'tree')).toBe('  contents: write\n  issues: write');
+    expect(refreshPermissionsBlock(on, 'cache')).toBe('  contents: read\n  issues: write');
+  });
+});

--- a/test/baseline/expiry-projection-renderers.test.ts
+++ b/test/baseline/expiry-projection-renderers.test.ts
@@ -1,0 +1,192 @@
+/**
+ * DELIVERY: the lapse projection reaches all three check surfaces.
+ *
+ * The whole point of the projection is that the computation already existed and
+ * was never delivered — `auditAllowlist` has known which suppressions expire
+ * soon since the allowlist shipped, reachable only from `doctor` and
+ * `allowlist audit`, two commands nobody runs on a normal day. A projection
+ * computed onto the result and rendered by only ONE of the three surfaces would
+ * reproduce the same bug one layer in (the same discipline `GateFailure` is
+ * pinned by: console / JSON / markdown, or it did not ship).
+ *
+ * Both directions, because over-disclosure is its own failure: an empty
+ * projection must be SILENT on every surface. A "nothing expiring" section on
+ * every run trains readers to skip the exact area where the real warning
+ * eventually appears.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createBaseline } from '../../src/baseline/create';
+import { runGuardrailCheck, type GuardrailCheckResult } from '../../src/baseline/check';
+import { renderConsole, renderJson, renderMarkdown } from '../../src/baseline/check-renderers';
+import {
+  EXPIRY_PROJECTION_REMEDY,
+  type ExpiryProjection,
+} from '../../src/baseline/expiry-projection';
+import { SOON_TO_EXPIRE_DAYS } from '../../src/allowlist/file';
+import { trustedLocalContext } from '../../src/analysis-trust';
+
+function git(dir: string, args: string[]): void {
+  execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+}
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-expiry-render-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'test']);
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '0.0.0' }));
+  writeFileSync(join(dir, 'src', 'index.js'), 'module.exports = () => 1;\n');
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '-q', '-m', 'init']);
+  return dir;
+}
+
+/** A populated projection covering both consequence tiers and the whole
+ *  reporting range (lapses today, and lapses inside the horizon). */
+const LAPSING: ExpiryProjection = {
+  horizonDays: SOON_TO_EXPIRE_DAYS,
+  lapsing: [
+    {
+      source: 'finding',
+      fingerprint: 'aaaa111122223333',
+      category: 'deferred',
+      expiresAt: '2026-08-01',
+      daysRemaining: 3,
+      consequence: 'block',
+      subject: 'dep-vuln package-lock.json:1',
+    },
+    {
+      source: 'flow',
+      fingerprint: 'bbbb111122223333',
+      category: 'accepted-risk',
+      expiresAt: '2026-08-05',
+      daysRemaining: 7,
+      consequence: 'warn',
+      subject: 'GET /api/orders',
+    },
+  ],
+  willBlock: 1,
+  willWarn: 1,
+  nextLapseDays: 3,
+};
+
+describe('the lapse projection reaches every check surface', () => {
+  let base: GuardrailCheckResult;
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = makeRepo();
+    await createBaseline({ cwd: dir });
+    base = await runGuardrailCheck({ trust: trustedLocalContext(), cwd: dir });
+  }, 120_000);
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('a real run computes the projection (the field is not just a type)', () => {
+    // No allowlist in this repo, so nothing is suppressed and nothing can lapse
+    // — but the projection is still COMPUTED, with the shared horizon.
+    expect(base.suppressionExpiry).toBeDefined();
+    expect(base.suppressionExpiry.horizonDays).toBe(SOON_TO_EXPIRE_DAYS);
+    expect(base.suppressionExpiry.lapsing).toEqual([]);
+    expect(base.suppressionExpiry.willBlock).toBe(0);
+  });
+
+  it('is SILENT on all three surfaces when nothing expires', () => {
+    expect(renderConsole(base)).not.toContain('Suppressions expiring');
+    expect(renderConsole(base)).not.toContain('Expiring:');
+    expect(renderMarkdown(base)).not.toContain('Suppressions expiring');
+    // JSON always carries the field (an agent reads it without probing), but it
+    // says plainly that nothing is pending.
+    expect(renderJson(base).suppressionExpiry.lapsing).toEqual([]);
+  });
+
+  it('console names the count, the countdown, the consequence, and the remedy', () => {
+    const out = renderConsole({ ...base, suppressionExpiry: LAPSING });
+    expect(out).toContain('Suppressions expiring (2)');
+    expect(out).toContain('2 allowlist suppressions expire within 14 days');
+    expect(out).toContain('next in 3d');
+    expect(out).toContain('1 will BLOCK');
+    expect(out).toContain('dep-vuln package-lock.json:1');
+    expect(out).toContain('GET /api/orders');
+    expect(out).toContain(EXPIRY_PROJECTION_REMEDY.slice(0, 30));
+    // And the summary footer, for a reader who skims to the bottom and stops.
+    expect(out).toContain('Expiring:    2 suppression(s) within 14d');
+  });
+
+  it('console flags the block tier so a lapse that will break the build stands out', () => {
+    const warnOnly: ExpiryProjection = {
+      ...LAPSING,
+      lapsing: [LAPSING.lapsing[1]!],
+      willBlock: 0,
+      willWarn: 1,
+      nextLapseDays: 7,
+    };
+    expect(renderConsole({ ...base, suppressionExpiry: LAPSING })).toContain(
+      '⚠ Suppressions expiring',
+    );
+    expect(renderConsole({ ...base, suppressionExpiry: warnOnly })).toContain(
+      'Suppressions expiring (1)',
+    );
+    expect(renderConsole({ ...base, suppressionExpiry: warnOnly })).not.toContain(
+      '⚠ Suppressions expiring',
+    );
+  });
+
+  it('json carries the whole structure, unabridged', () => {
+    const json = renderJson({ ...base, suppressionExpiry: LAPSING });
+    expect(json.suppressionExpiry).toEqual(LAPSING);
+    // It must NOT leak into the verdict: a lapse that has not happened is not a
+    // regression, and this run passed.
+    expect(json.verdict.blocks).toBe(false);
+    expect(json.verdict.refused).toBe(false);
+    expect(json.verdict.exitCode).toBe(0);
+  });
+
+  it('markdown carries a callout plus a per-entry table', () => {
+    const md = renderMarkdown({ ...base, suppressionExpiry: LAPSING });
+    expect(md).toContain('⚠️');
+    expect(md).toContain('2 allowlist suppressions expire within 14 days');
+    expect(md).toContain('<summary>Suppressions expiring (2)</summary>');
+    expect(md).toContain('| Source | Finding | Category | Expires | In | On lapse |');
+    expect(md).toContain('dep-vuln package-lock.json:1');
+    expect(md).toContain('**blocks**');
+    expect(md).toContain('| 7d |');
+    // Disclosure, not a verdict change — the heading still reports the pass.
+    expect(md).toContain('## Guardrail: PASSED');
+  });
+
+  it('markdown drops to an informational icon when no lapse would block', () => {
+    const warnOnly: ExpiryProjection = {
+      ...LAPSING,
+      lapsing: [LAPSING.lapsing[1]!],
+      willBlock: 0,
+      willWarn: 1,
+      nextLapseDays: 7,
+    };
+    const md = renderMarkdown({ ...base, suppressionExpiry: warnOnly });
+    expect(md).toContain('ℹ️');
+    expect(md).toContain('1 will warn');
+    expect(md).not.toContain('**blocks**');
+  });
+
+  it('names the baseline path honestly in ref-based mode (no literal "undefined")', () => {
+    // The console printed `Path: undefined` whenever there was no on-disk
+    // baseline, which is every ref-based run.
+    const refBased = {
+      ...base,
+      baselinePath: undefined,
+      mode: { ...base.mode, mode: 'ref-based' as const, ref: 'origin/main' },
+    };
+    const out = renderConsole(refBased);
+    expect(out).not.toContain('Path:        undefined');
+    expect(out).toContain('origin/main');
+  });
+});


### PR DESCRIPTION
## Why this PR exists

The five-PR stack was merged, but only **#193 reached `main`**. #194–#197 each merged into their own *feature-branch* base rather than into `main` (that is what a stacked PR does when its parent lands first without GitHub retargeting it), and those branches were then deleted on merge. So `main` currently has the lapse projection and nothing else:

| PR | content | on `main`? |
| --- | --- | --- |
| #193 | the lapse projection (`src/baseline/expiry-projection.ts`) | ✅ landed |
| #194 | the three renderers | ❌ merged into `feat/431-expiry-projection` |
| #195 | the deferral creation guard | ❌ merged into `feat/431-expiry-render` |
| #196 | the expiry decision surface | ❌ merged into `feat/431-defer-guard` |
| #197 | `release: 4.3.1` | ❌ merged into `feat/431-expiry-notice` |

Nothing was lost — every commit survived in local branches. This PR carries the four remaining commits, rebased onto the current `main`.

## What it is, exactly

`git rebase origin/main` over the old stack tip. Git recognised #193's commit as already applied (`skipped previously applied commit 4930407`) and replayed the other four. **The resulting tree is byte-identical to the tip CI validated on #197** — `git diff <old-tip> <new-tip>` is empty. So this is the same reviewed content, not a re-do.

Commits, unchanged from the individually-reviewed ones:

```
787b91b release: 4.3.1
53e9f7c feat(allowlist): the expiry decision surface — reach the owner when no PR is open
a5a0e43 feat(allowlist): the deferral creation guard — say at the keystroke whether the promise is keepable
03efdd2 feat(guardrail): deliver the lapse projection — console, JSON, and the PR comment
```

**Merge with "Rebase and merge"** so all four land as distinct commits — each is independently meaningful (three features + the release commit), which is exactly the case CLAUDE.md's release procedure says to rebase rather than squash.

## Gates re-run locally on the rebased branch

| gate | result |
| --- | --- |
| `tsc --noEmit` (src + `typecheck:test`) | pass |
| `eslint . --max-warnings 0` | pass |
| `format:check` | pass |
| `check-architecture.sh` / `check-slop.sh` / `check-cross-ecosystem-coverage.sh` | pass |
| `test:run` | **336 files / 5,085 tests pass** |
| self-guardrail `--mode ref-based --ref origin/main` | **PASSED** |

## After this merges

`main` carries `4.3.1` in `package.json`, and the release fires from a GitHub Release created against the full `main` SHA once CI is green there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)