### PR TITLE
fix(update): a policy-enabled lane installs on the next update, not the one after

### DIFF
--- a/src/managed-artifacts-detect.ts
+++ b/src/managed-artifacts-detect.ts
@@ -70,15 +70,54 @@ export function detectInstallFlags(cwd: string): ManifestInstallFlags {
       flags[surface.gate.flag] = surface.detectPresent(cwd);
     }
   }
-  // Graph-refresh is opt-in via policy, so a repo that set `graph.refresh:
-  // "cache"` but hasn't installed the workflow yet must still be treated as
-  // enabled — otherwise `update` would never lay it down. Presence OR policy.
-  flags.withGraphRefresh = flags.withGraphRefresh || graphRefreshEnabled(cwd);
-  flags.withReportsRefresh = flags.withReportsRefresh || reportsRefreshEnabled(cwd);
-  flags.withFlowRefresh = flags.withFlowRefresh || flowRefreshEnabled(cwd);
-  flags.withExtensionsRefresh = flags.withExtensionsRefresh || extensionsRefreshEnabled(cwd);
-  flags.withCommentDefer = flags.withCommentDefer || commentCommandsEnabled(cwd);
-  flags.withDepBump = flags.withDepBump || depBumpEnabled(cwd);
-  flags.withRemediate = flags.withRemediate || remediateEnabled(cwd);
+  return applyPolicyDerivedFlags(cwd, flags);
+}
+
+/**
+ * OR the POLICY-DERIVED surface enables over whatever flags the caller already
+ * has. THE one home for "policy switched this surface on" (Rule 2), consumed by
+ * BOTH flag sources: `detectInstallFlags` (presence-derived) and `update`'s
+ * `resolveInstallFlags` (manifest-derived).
+ *
+ * # The class this closes
+ *
+ * These surfaces are opt-in through policy, so a repo that set
+ * `depBump.enabled: true` but has not installed the workflow yet MUST read as
+ * enabled — otherwise `update` never lays it down. That OR was applied only on
+ * the presence-derived path, and `resolveInstallFlags` returns the MANIFEST's
+ * recorded flags verbatim whenever it has them (every modern install), so the
+ * derivation was unreachable in the exact case it exists for: a flag absent
+ * from an older manifest's record reads as `undefined` → falsy → skipped.
+ *
+ * The shipped consequence, found while dogfooding a fleet rollout: enable a lane
+ * in policy, run `vyuh-dxkit update`, and the knob is ON with no workflow behind
+ * it — the silent no-op Rule 15's registry exists to prevent, reintroduced one
+ * layer up by a second source of truth for the same question. Two sources, the
+ * stale one winning, no error: CLAUDE.md 2.30's semantic-divergence shape.
+ *
+ * Deliberately one-directional (OR, never AND): policy can only turn a surface
+ * ON here. Turning one off is `uninstall`'s job, which reads provenance — an
+ * update must never delete a workflow because a knob flipped.
+ */
+export function applyPolicyDerivedFlags(
+  cwd: string,
+  flags: ManifestInstallFlags,
+): ManifestInstallFlags {
+  // Assign only where policy says YES, so a repo that enabled nothing gets a
+  // byte-identical flag set back. Writing `false` into every slot would work
+  // for update, but it would also silently rewrite the shape every other
+  // consumer (and the manifest self-migration) sees.
+  const enables: ReadonlyArray<[keyof ManifestInstallFlags, (cwd: string) => boolean]> = [
+    ['withGraphRefresh', graphRefreshEnabled],
+    ['withReportsRefresh', reportsRefreshEnabled],
+    ['withFlowRefresh', flowRefreshEnabled],
+    ['withExtensionsRefresh', extensionsRefreshEnabled],
+    ['withCommentDefer', commentCommandsEnabled],
+    ['withDepBump', depBumpEnabled],
+    ['withRemediate', remediateEnabled],
+  ];
+  for (const [flag, enabled] of enables) {
+    if (!flags[flag] && enabled(cwd)) flags[flag] = true;
+  }
   return flags;
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -5,6 +5,7 @@ import { detect } from './detect';
 import { generate } from './generator';
 import { ShipInstallResult } from './ship-installers';
 import { detectInstallFlags, refreshManagedSurfaces } from './managed-artifacts';
+import { applyPolicyDerivedFlags } from './managed-artifacts-detect';
 import * as logger from './logger';
 import { detectStaleRecall, detectStaleScheme, migrateIdentity } from './baseline/migrate';
 import { createBaseline, gatherScanCoverage } from './baseline/create';
@@ -42,7 +43,19 @@ export function resolveInstallFlags(
   cwd: string,
 ): { flags: InstallFlags; source: 'manifest' | 'workspace-derived' } {
   if (manifest.installFlags) {
-    return { flags: manifest.installFlags, source: 'manifest' };
+    // The manifest records what LANDED at install time; policy records what the
+    // repo has since opted INTO. Both are real, so both are read — the recorded
+    // flags are the base and the policy-derived enables are OR'd over them
+    // through the one derivation (`applyPolicyDerivedFlags`).
+    //
+    // Returning the record verbatim is what made a policy flip a silent no-op:
+    // a lane enabled after init has no entry in the record, `undefined` reads as
+    // off, and `update` skipped the surface forever. Copy first — the manifest
+    // object is not ours to mutate.
+    return {
+      flags: applyPolicyDerivedFlags(cwd, { ...manifest.installFlags }),
+      source: 'manifest',
+    };
   }
   return { flags: detectInstallFlags(cwd), source: 'workspace-derived' };
 }

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -174,6 +174,53 @@ describe('resolveInstallFlags + writeInstallFlags: manifest persistence', () => 
     expect(out.flags).toEqual(flags);
   });
 
+  /**
+   * The silent-no-op class, found while dogfooding a fleet rollout: a lane is
+   * opted into via POLICY after init, so the manifest's recorded flags have no
+   * entry for it. Returning that record verbatim made `undefined` read as off,
+   * and `update` skipped the surface — the knob was on with no workflow behind
+   * it, forever. Both sources are real, so both are read; the policy-derived
+   * enables OR over the record through the one derivation.
+   */
+  it('resolveInstallFlags ORs policy-enabled lanes over the manifest record', () => {
+    const policyRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-policy-lane-'));
+    try {
+      fs.mkdirSync(path.join(policyRepo, '.dxkit'), { recursive: true });
+      fs.writeFileSync(
+        path.join(policyRepo, '.dxkit', 'policy.json'),
+        JSON.stringify({ depBump: { enabled: true }, remediate: { enabled: true } }),
+      );
+      // A record written before either lane existed — no entry for them at all.
+      const manifest = { ...baseManifest, installFlags: { ...allOff, withCiGuardrails: true } };
+      const out = resolveInstallFlags(manifest, policyRepo);
+      expect(out.source).toBe('manifest');
+      expect(out.flags.withDepBump).toBe(true);
+      expect(out.flags.withRemediate).toBe(true);
+      // The record still wins for everything policy says nothing about.
+      expect(out.flags.withCiGuardrails).toBe(true);
+      expect(out.flags.withDevcontainer).toBe(false);
+    } finally {
+      fs.rmSync(policyRepo, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves the manifest record untouched when policy enables nothing', () => {
+    // The other direction: no policy file at all must not invent surfaces, and
+    // the caller's manifest object must not be mutated in place.
+    const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-no-policy-'));
+    try {
+      const record = { ...allOff, withHooks: true };
+      const manifest = { ...baseManifest, installFlags: record };
+      const out = resolveInstallFlags(manifest, bare);
+      expect(out.flags.withDepBump).toBeFalsy();
+      expect(out.flags.withRemediate).toBeFalsy();
+      expect(out.flags.withHooks).toBe(true);
+      expect(manifest.installFlags).toEqual(record);
+    } finally {
+      fs.rmSync(bare, { recursive: true, force: true });
+    }
+  });
+
   it('resolveInstallFlags falls back to workspace detection on legacy manifests', () => {
     const legacy = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-legacy-manifest-'));
     try {


### PR DESCRIPTION
**This commit was meant to be in #198 but missed the merge** — GitHub merged the head it had recorded (`787b91b`, the release commit) and my push landed just after that snapshot, so `main` has 4.3.1 without the fix. Same commit, cherry-picked onto current `main`, unchanged.

**Please merge this before the v4.3.1 release** — `package.json` already says 4.3.1, so the tag will be cut from the tip that includes this.

## The bug

Found by dogfooding the fleet rollout against the 4.3.1 build: enable `depBump` (or `remediate`, or `newAdvisories.commentCommands`) in policy, run `vyuh-dxkit update`, and the knob is **on with no workflow behind it**. Every policy-gated managed surface was affected, on every repo whose manifest was written by a modern dxkit — which is every install since 2.5.2.

Two sources of truth for one question:

- `detectInstallFlags` ORs the policy-derived enables over its presence probes. Correct, and the whole reason that derivation exists: *a repo that set the knob but has not installed the workflow yet must read as enabled, or update never lays it down.*
- `resolveInstallFlags` returns `manifest.installFlags` **verbatim** whenever the manifest has them. So the derivation was unreachable in exactly the case it was written for: a lane enabled after init has no entry in that record, `undefined` reads as falsy, the surface is skipped forever.

No error, no note — the silent no-op Rule 15's registry exists to prevent, reintroduced one layer up. CLAUDE.md 2.30's semantic-divergence shape: two projections of one concept, the stale one winning, nothing to grep for.

## The fix

One home for the derivation (`applyPolicyDerivedFlags`), routed by **both** flag sources: the manifest record is the base, policy enables OR over it.

- **One-directional.** Policy can only turn a surface *on* here. Turning one off is uninstall's job (it reads provenance); an update must never delete a workflow because a knob flipped.
- **Assigns only where policy says yes**, so a repo that enabled nothing gets a byte-identical flag set back rather than a rewritten shape.
- **No in-place mutation** of the caller's manifest object.

## Verified

On a scratch repo with a modern manifest, using the 4.3.1 build:

| | before | after |
| --- | --- | --- |
| lanes installed by **one** `update` after the policy flip | none | all three |
| lanes installed by a **second** `update` | all three (the first having clobbered the record) | n/a |

Surface list now reads `… withCommentDefer, withDepBump, withRemediate` on the first run. Pinned both directions in `test/update.test.ts`: policy-enabled lanes reach the flags, and a repo with no policy keeps its record untouched.

## Gates

`tsc` (src + test), `eslint --max-warnings 0`, `format:check`, `check-architecture.sh`, `update` + lifecycle suites (25 tests), self-guardrail ref-based → **PASSED**. Full suite was green on this same commit in #198 at 5,087 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)