### PR TITLE
Key the PR tree-trust boundary on fork-ness, not the pull_request event

### DIFF
--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -129,6 +129,38 @@ __DXKIT_CI_RUNTIME_SETUP__
           restore-keys: |
             dxkit-graph-
 
+      # Tree-trust decision, made ONCE and read by every step that analyzes
+      # the checked-out source (guardrail check, flow console).
+      #
+      # S-05 (4.0.4) keyed this on the pull_request event: every PR ran with
+      # the plugin-trust boundary active, which also disabled repo-declared
+      # custom-check/lint commands — so net-new lint errors silently stopped
+      # gating at PR time (4.3.2). The boundary is now keyed on FORK-ness,
+      # the same line GitHub's own secrets model draws:
+      #   - a FORK head is third-party input → --untrusted. Executable
+      #     flow/extension plugins and repo-declared check commands are
+      #     disabled (disclosed, not silent); plugin-derived routes still
+      #     reach the gate through the committed served.json snapshot,
+      #     produced by trusted default-branch runs.
+      #   - a SAME-REPO head was pushed by someone with write access, whose
+      #     code already executes in this repo's other PR workflows (test
+      #     jobs run the repo's own scripts). Running its committed check
+      #     commands here adds no new surface, and keeps lint/custom-check
+      #     gating LIVE at PR time.
+      # A missing head repo (deleted fork) compares unequal → untrusted.
+      # Fail closed.
+      - name: Resolve tree trust
+        id: trust
+        env:
+          DXKIT_PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          UNTRUSTED=""
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && [ "${DXKIT_PR_HEAD_REPO}" != "${GITHUB_REPOSITORY}" ]; then
+            echo "fork PR head (${DXKIT_PR_HEAD_REPO:-unknown}) — analyzing as untrusted content"
+            UNTRUSTED="--untrusted"
+          fi
+          echo "flag=$UNTRUSTED" >> "$GITHUB_OUTPUT"
+
       # Capture the markdown report regardless of exit code so we can
       # post it as a PR comment even when the guardrail blocks.
       - name: Run guardrail check
@@ -163,13 +195,8 @@ __DXKIT_CI_RUNTIME_SETUP__
             EXTRA="--mode ref-based --ref origin/${DXKIT_PR_BASE:-$DEFAULT_BRANCH}"
           fi
           set +e
-          # S-05 (4.0.4): a pull_request head is third-party input — run with
-          # the plugin-trust boundary ACTIVE. Executable flow/extension
-          # plugins are disabled (disclosed, not silent); plugin-derived
-          # routes still reach the gate through the committed served.json
-          # snapshot, which was produced from trusted default-branch runs.
-          UNTRUSTED=""
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then UNTRUSTED="--untrusted"; fi
+          # Trust boundary decided once in the 'Resolve tree trust' step above.
+          UNTRUSTED="${{ steps.trust.outputs.flag }}"
           "${DXKIT}" guardrail check $EXTRA $UNTRUSTED --markdown > guardrail-report.md
           code=$?
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
@@ -220,7 +247,11 @@ __DXKIT_CI_RUNTIME_SETUP__
       # Self-skips (produces nothing to upload) on a repo with no UI→API surface.
       - name: Generate flow console
         id: console
-        if: always()
+        # always() so the console still generates when the gate BLOCKED — but
+        # never without a resolved trust decision: if the trust step did not
+        # run (an earlier step failed), its empty output would read as
+        # trusted, which on a fork PR is fail-open. Skip instead.
+        if: always() && steps.trust.outcome == 'success'
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
             DXKIT=./node_modules/.bin/vyuh-dxkit
@@ -228,8 +259,8 @@ __DXKIT_CI_RUNTIME_SETUP__
             DXKIT=vyuh-dxkit
           fi
           set +e
-          UNTRUSTED=""
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then UNTRUSTED="--untrusted"; fi
+          # Trust boundary decided once in the 'Resolve tree trust' step above.
+          UNTRUSTED="${{ steps.trust.outputs.flag }}"
           "${DXKIT}" flow console $UNTRUSTED --diff "${{ github.event.pull_request.base.sha }}" \
             --out flow-console.html --json > console.json 2>/dev/null
           set -e

--- a/test/guardrails-workflow-trust.test.ts
+++ b/test/guardrails-workflow-trust.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The tree-trust boundary in the shipped guardrails workflow is FORK-KEYED
+ * (4.3.2): `--untrusted` fires when the PR head repo differs from the base
+ * repo, not on every pull_request event. The event-keyed version (S-05,
+ * 4.0.4) silently disabled repo-declared custom-check/lint gating on EVERY
+ * PR — net-new lint errors stopped gating at PR time and nothing said so.
+ *
+ * This pins three things about the template:
+ *   1. the decision is computed ONCE (a 'Resolve tree trust' step) and every
+ *      analyzing step consumes its output — the two-independent-computations
+ *      shape is exactly the drift class Rule 2.30 exists for;
+ *   2. the condition is fork-keyed and fail-closed (a missing head repo
+ *      compares unequal → untrusted; a step skip skips the consumer);
+ *   3. the head-repo value reaches the shell via `env:` — never interpolated
+ *      into a run script line.
+ *
+ * The comment-defer workflow is deliberately NOT fork-keyed: it runs in a
+ * privileged issue_comment context (contents: write), is restricted to
+ * same-repo PRs, and its --untrusted cache-warming run only validates
+ * dep-vuln fingerprints — the boundary stays unconditional there.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const WORKFLOWS = join(__dirname, '..', 'src-templates', '.github', 'workflows');
+const guardrails = readFileSync(join(WORKFLOWS, 'dxkit-guardrails.yml'), 'utf8');
+const commentDefer = readFileSync(join(WORKFLOWS, 'dxkit-comment-defer.yml'), 'utf8');
+
+describe('guardrails workflow tree trust is fork-keyed and single-sourced', () => {
+  it('computes the --untrusted decision exactly once, in the trust step', () => {
+    expect(guardrails).toContain('- name: Resolve tree trust');
+    const assignments = guardrails.match(/UNTRUSTED="--untrusted"/g) ?? [];
+    expect(assignments).toHaveLength(1);
+  });
+
+  it('keys the boundary on fork-ness, not the pull_request event alone', () => {
+    expect(guardrails).toMatch(
+      /\[ "\$\{GITHUB_EVENT_NAME\}" = "pull_request" \] && \[ "\$\{DXKIT_PR_HEAD_REPO\}" != "\$\{GITHUB_REPOSITORY\}" \]/,
+    );
+    // The old event-only condition must not survive anywhere.
+    expect(guardrails).not.toMatch(/"pull_request" \]; then UNTRUSTED/);
+  });
+
+  it('every analyzing step consumes the one trust output (guardrail check + flow console)', () => {
+    const consumers =
+      guardrails.match(/UNTRUSTED="\$\{\{ steps\.trust\.outputs\.flag \}\}"/g) ?? [];
+    expect(consumers).toHaveLength(2);
+  });
+
+  it('the always()-guarded console step skips when trust was never resolved (fail closed)', () => {
+    expect(guardrails).toContain("if: always() && steps.trust.outcome == 'success'");
+  });
+
+  it('the head repo reaches the shell via env, never inline run interpolation', () => {
+    // The expression appears exactly once — as the env: value of the trust step.
+    const uses = guardrails.match(/github\.event\.pull_request\.head\.repo\.full_name/g) ?? [];
+    expect(uses).toHaveLength(1);
+    expect(guardrails).toContain(
+      'DXKIT_PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}',
+    );
+  });
+
+  it('comment-defer keeps its unconditional --untrusted (privileged context)', () => {
+    expect(commentDefer).toContain('--untrusted');
+  });
+});


### PR DESCRIPTION
## What

The shipped guardrails workflow decides tree trust once, in a new `Resolve tree trust` step, and passes `--untrusted` only when the PR head repo differs from the base repo. Previously every `pull_request` run was untrusted.

## Why

Since 4.2, the untrusted boundary correctly stopped repo-declared commands from executing on fork heads. But because it keyed on the event rather than the head, it also switched off custom-check/lint gating on every same-repo PR, and nothing disclosed that. On repos with lint gating enabled, net-new lint errors have not gated at PR time since 4.2; they gate only at pre-push and the loop Stop-gate. Nobody chose that per-repo; it fell out of the security fix.

## The security argument (a deliberate boundary decision)

- A same-repo PR head was pushed by someone with write access to the repo. That person's code already executes in the repo's other PR workflows (test jobs run the repo's own scripts and config on the PR head). Running the repo's committed check commands in the gate adds no new attack surface for that population.
- The fork boundary stays exactly as hard: a fork head is third-party input and runs with `--untrusted`, so executable flow/extension plugins and repo-declared check commands stay disabled there, disclosed rather than silent.
- This is the same line GitHub's own security model draws: fork PRs do not receive repo secrets; same-repo PRs do.
- Fail-closed edges: a deleted fork's missing head repo compares unequal and stays untrusted. The `always()`-guarded flow-console step now skips when the trust step never ran, because an empty step output would otherwise read as trusted.
- The comment-defer workflow keeps its unconditional `--untrusted`: it runs in a privileged `issue_comment` context with `contents: write`, and its cache-warming run only validates dep-vuln fingerprints, so nothing is lost by keeping the harder line there.

## One computation, pinned

The trust decision was previously computed independently in two steps (guardrail check and flow console). It is now computed once and both steps consume the step output. `test/guardrails-workflow-trust.test.ts` pins: exactly one `--untrusted` assignment, the fork-keyed condition, both consumers reading the one output, the fail-closed console guard, and that the head-repo value reaches the shell via `env:` only, never inline interpolation into a run script.

## Rollout

The workflow is a managed surface, so `vyuh-dxkit update` refreshes an unmodified installed copy on the next upgrade. No policy or CLI change; the `--untrusted` flag semantics are untouched.

Local gates: typecheck, lint, format, arch check, slop check, full suite (5,093), and `guardrail check --mode ref-based --ref origin/main` (PASSED) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)