### PR TITLE
An unobserved check's baseline findings read not-observed, never resolved

### DIFF
--- a/src/analyzers/custom-checks/gather.ts
+++ b/src/analyzers/custom-checks/gather.ts
@@ -24,7 +24,7 @@ import {
   extensionRecallInputs,
   gatherExtensionFindings,
 } from '../../extensions/extension-findings';
-import type { CustomCheckFinding, CustomCheckSpec } from './types';
+import type { CustomCheckFinding, CustomCheckSpec, UnobservedCheck } from './types';
 import type { AnalysisTrustContext } from '../../analysis-trust';
 
 export interface GatherCustomChecksOptions {
@@ -207,11 +207,38 @@ function hashText(text: string): string {
 export function gatherCustomCheckFindings(
   opts: GatherCustomChecksOptions,
 ): readonly CustomCheckFinding[] {
+  return gatherCustomChecks(opts).findings;
+}
+
+/** Findings PLUS what the run could not observe. The findings side is exactly
+ *  `gatherCustomCheckFindings`; `unobserved` carries every configured check
+ *  whose command produced no finding set this run (a `skipped-*` status). The
+ *  guardrail check reads it to keep the removed-direction attribution honest
+ *  (an unobserved check's baseline findings are `not_observed`, not
+ *  "resolved") — before this, the runner's skip statuses died right here and
+ *  no downstream surface could tell "clean" from "never looked". */
+export interface CustomCheckGatherResult {
+  readonly findings: readonly CustomCheckFinding[];
+  readonly unobserved: readonly UnobservedCheck[];
+}
+
+/**
+ * The seam's observation record for one run, as the guardrail consumes it.
+ * `gathered: false` means the gather never ran at all (scoped out), so NO
+ * configured check was observed; `gathered: true` carries the individual
+ * checks whose commands skipped. Both shapes answer the question the
+ * removed-direction attribution asks: "did this run actually look?"
+ */
+export type CustomChecksUnobserved =
+  | { readonly gathered: false; readonly reason: string }
+  | { readonly gathered: true; readonly checks: readonly UnobservedCheck[] };
+
+export function gatherCustomChecks(opts: GatherCustomChecksOptions): CustomCheckGatherResult {
   const all = resolveCustomCheckSpecs(opts);
   const specs = opts.onlyChecks ? all.filter((s) => opts.onlyChecks!.includes(s.name)) : all;
-  const commandFindings =
+  const run =
     specs.length === 0
-      ? []
+      ? undefined
       : runCustomChecks({
           cwd: opts.cwd,
           trust: opts.trust,
@@ -219,13 +246,24 @@ export function gatherCustomCheckFindings(
           ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
           ...(opts.exec !== undefined ? { exec: opts.exec } : {}),
           ...(opts.env !== undefined ? { env: opts.env } : {}),
-        }).findings;
-  if (opts.onlyChecks) return commandFindings;
+        });
+  const commandFindings = run?.findings ?? [];
+  const unobserved = (run?.results ?? [])
+    .filter((r) => r.status !== 'pass' && r.status !== 'fail')
+    .map((r) => ({
+      name: r.name,
+      status: r.status,
+      ...(r.reason !== undefined ? { reason: r.reason } : {}),
+    }));
+  if (opts.onlyChecks) return { findings: commandFindings, unobserved };
   // The seam's third consumer (after user checks + pack lint): findings
   // committed by findings-kind EXTENSIONS. Snapshot reads only — nothing
   // executes here (extensions run at refresh time; gates stay offline) —
   // and both the baseline producer and the guardrail current scan reach
   // extension findings through THIS one entry point, so the two sides
   // always see the identical set (Rule 2).
-  return [...commandFindings, ...gatherExtensionFindings(opts.cwd)];
+  return {
+    findings: [...commandFindings, ...gatherExtensionFindings(opts.cwd)],
+    unobserved,
+  };
 }

--- a/src/analyzers/custom-checks/types.ts
+++ b/src/analyzers/custom-checks/types.ts
@@ -171,6 +171,43 @@ export interface CustomCheckResult {
   readonly reason?: string;
 }
 
+/**
+ * A check the current run did NOT observe: it was configured, but its command
+ * never produced a finding set (any `skipped-*` status). The guardrail check
+ * consumes this to keep Rule 19's law in the REMOVED direction — an unobserved
+ * check's baseline findings reclassify `not_observed`, never `removed`
+ * ("resolved"): absence of observation is UNKNOWN, not absence.
+ */
+export interface UnobservedCheck {
+  readonly name: string;
+  readonly status: CustomCheckStatus;
+  /** The runner's structured reason, when it carries one (environment /
+   *  unavailable skips). */
+  readonly reason?: string;
+}
+
+/**
+ * The ONE human phrasing of a check skip, shared by the classifier's reason
+ * chain and every renderer's disclosure line (Rule 2 — two phrasings of one
+ * skip would drift).
+ */
+export function describeCheckSkip(check: UnobservedCheck): string {
+  switch (check.status) {
+    case 'skipped-untrusted':
+      return 'skipped (untrusted tree — repo-declared commands do not execute on third-party content)';
+    case 'skipped-environment':
+      return `skipped (environment: ${check.reason ?? 'declared execution requirement unmet here'})`;
+    case 'skipped-unavailable':
+      return `skipped (unavailable: ${check.reason ?? 'its tool did not resolve'})`;
+    case 'skipped-timeout':
+      return 'skipped (timed out)';
+    case 'skipped-overflow':
+      return 'skipped (output outran the capture buffer)';
+    default:
+      return `skipped (${check.status})`;
+  }
+}
+
 /** Aggregate result across every configured check. */
 export interface CustomChecksRunResult {
   /** True when at least one check actually executed (not all skipped). */

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -31,6 +31,7 @@ import type {
   ClassifiedPair,
   EnvelopeDrift,
   GuardrailCheckResult,
+  NotObservedDisclosure,
 } from './check';
 import { ATTRIBUTION_GAP_REMEDY, describeAttributionGap } from './attribution-gap';
 import type { AttributionGap } from './attribution-gap';
@@ -356,6 +357,11 @@ export function renderConsole(result: GuardrailCheckResult): string {
     for (const p of removed) lines.push(...formatPairLines(p, '  '));
     lines.push('');
   }
+  // Not-observed disclosure (Rule 19's REMOVED direction): baseline findings
+  // the current side never re-verified. One aggregate line per unobserved
+  // check — never a per-finding table (the whole point is that a repo-scale
+  // backlog must not render as 18k "resolved" rows or 18k anything-rows).
+  lines.push(...formatNotObserved(result.notObserved));
 
   lines.push(...formatFlowGate(result.flowGate));
   lines.push(...formatSchemaDriftGate(result.schemaDriftGate));
@@ -370,7 +376,9 @@ export function renderConsole(result: GuardrailCheckResult): string {
       `suppressed: ${suppressed.length}, ` +
       (unattributable.length > 0 ? `unattributable: ${unattributable.length}, ` : '') +
       `warning: ${warning.length}, persisted: ${persisted.length}, ` +
-      `resolved: ${removed.length})`,
+      `resolved: ${removed.length}` +
+      (notObservedPairCount(result) > 0 ? `, not observed: ${notObservedPairCount(result)}` : '') +
+      `)`,
   );
   // The lapse line belongs in the footer too: a reader who skims to the summary
   // and stops must still see that today's PASS has an expiry date on it.
@@ -494,6 +502,33 @@ function formatGateFailure(
  * author and reviewer reads THIS output instead, which is why the warning goes
  * here (see `src/baseline/expiry-projection.ts`).
  */
+/** Total pairs classified `not_observed` — the summary-footer count. Derived
+ *  from the disclosures (which the check computed from the same pair set), so
+ *  the footer and the section agree by construction. */
+function notObservedPairCount(result: GuardrailCheckResult): number {
+  return result.notObserved.reduce((n, d) => n + d.count, 0);
+}
+
+/**
+ * The not-observed disclosure block, shared in structure by the console and
+ * markdown renderers: one line per unobserved check, aggregate counts only.
+ * A silent skip is the class this section exists to kill — but so is a 18k-row
+ * table, so it deliberately never enumerates findings.
+ */
+function formatNotObserved(disclosures: ReadonlyArray<NotObservedDisclosure>): string[] {
+  if (disclosures.length === 0) return [];
+  const total = disclosures.reduce((n, d) => n + d.count, 0);
+  const out = [logger.bold(`⚠ Not re-verified this run (${total})`)];
+  for (const d of disclosures) {
+    out.push(
+      `  ${d.kind} ${d.reason} — ${d.count} baseline finding${d.count === 1 ? '' : 's'} ` +
+        `not re-verified this run (reported as not observed, never as resolved)`,
+    );
+  }
+  out.push('');
+  return out;
+}
+
 function formatExpiryProjection(projection: ExpiryProjection): string[] {
   const headline = describeExpiryProjection(projection);
   if (!headline) return [];
@@ -1031,6 +1066,8 @@ function statusLabel(status: FindingStatus): string {
       return 'UNCERTAIN';
     case 'fixed':
       return 'FIXED';
+    case 'not_observed':
+      return 'NOT-OBSERVED';
   }
 }
 
@@ -1091,6 +1128,12 @@ function formatDrift(drift: EnvelopeDrift): string[] {
   return out;
 }
 
+/** Markdown Resolved-table row cap. The count in the summary line is exact;
+ *  the table shows a sample so a batch cleanup cannot push the comment past
+ *  GitHub's 65,536-byte limit (a real PR comment hit 60,143 bytes of mostly
+ *  this table). */
+const MAX_RESOLVED_ROWS = 100;
+
 // ─── JSON renderer ────────────────────────────────────────────────────────
 
 export const GUARDRAIL_JSON_SCHEMA = 'dxkit.guardrail-check.v1' as const;
@@ -1125,6 +1168,12 @@ export interface GuardrailJsonPayload {
    *  `verdict` — a lapse that has not happened yet is not a regression, and
    *  the finding is re-classified on the run after it lapses. */
   readonly suppressionExpiry: ExpiryProjection;
+  /** Baseline findings the current side never re-verified, per unobserved
+   *  check (aggregate counts, never per-finding rows). ALWAYS present
+   *  (`[]` when everything was observed) so an agent can tell "nothing
+   *  unobserved" from "nobody said". Their pairs carry status
+   *  `not_observed` — excluded from `summary.resolved`. */
+  readonly notObserved: ReadonlyArray<NotObservedDisclosure>;
   /** Present when the dependency-vuln scan was requested but could not run —
    *  a pass is then NOT a clean bill of dependency health. */
   readonly depVulnsUnmeasured?: { readonly reason: string };
@@ -1186,6 +1235,8 @@ export interface GuardrailJsonPayload {
     readonly warning: number;
     readonly persisted: number;
     readonly resolved: number;
+    /** Pairs classified `not_observed` — see the top-level `notObserved`. */
+    readonly notObserved: number;
   };
   readonly pairs: ReadonlyArray<{
     readonly status: FindingStatus;
@@ -1361,6 +1412,10 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
     },
     attributionGaps: result.attributionGaps,
     suppressionExpiry: result.suppressionExpiry,
+    // Baseline findings the current side never re-verified (per unobserved
+    // check, aggregate counts). Always present — an agent reading the JSON
+    // must be able to tell "nothing unobserved" from "nobody said".
+    notObserved: result.notObserved,
     ...(result.depVulnsUnmeasured ? { depVulnsUnmeasured: result.depVulnsUnmeasured } : {}),
     ...(result.deferredCapture && result.deferredCapture.length > 0
       ? { deferredCapture: result.deferredCapture }
@@ -1406,6 +1461,7 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
       warning,
       persisted,
       resolved,
+      notObserved: notObservedPairCount(result),
     },
     pairs: result.pairs.map((p) => ({
       status: p.classification.status,
@@ -1629,6 +1685,27 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     lines.push('');
   }
 
+  // Rule 19's REMOVED direction: what this run never looked at, said loudly in
+  // the PR comment — one aggregate line per unobserved check. The class this
+  // kills: an untrusted run skipped lint and the comment reported the repo's
+  // entire 18,406-finding backlog as "Resolved".
+  if (result.notObserved.length > 0) {
+    const total = result.notObserved.reduce((n, d) => n + d.count, 0);
+    lines.push(
+      `> ⚠️ **${total} baseline finding${total === 1 ? '' : 's'} not re-verified this run** — ` +
+        `their check did not execute here, so they are reported as *not observed*, ` +
+        `never as resolved. A pass does **not** re-verify them; trusted surfaces ` +
+        `(the default-branch refresh, pre-push, a local run) remain the backstop.`,
+    );
+    for (const d of result.notObserved) {
+      lines.push(
+        `> - ${escapeMd(d.kind)} ${escapeMd(d.reason)} — ${d.count} ` +
+          `finding${d.count === 1 ? '' : 's'}`,
+      );
+    }
+    lines.push('');
+  }
+
   if (result.refExcludedKinds.length > 0) {
     const detail = result.refExcludedKinds.map((e) => `${e.currentCount} ${e.kind}`).join(', ');
     lines.push(
@@ -1763,8 +1840,16 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     lines.push('');
     lines.push('| Kind | Location |');
     lines.push('|---|---|');
-    for (const p of resolved) {
+    // Row cap: GitHub truncates comments at 65,536 bytes, and a large resolved
+    // set (a batch cleanup, a re-baseline) once produced a 60k-byte table that
+    // crowded out the verdict. The count above is exact; the rows are a sample.
+    for (const p of resolved.slice(0, MAX_RESOLVED_ROWS)) {
       lines.push(`| ${escapeMd(p.kind)} | ${escapeMd(locatorProse(p) || '—')} |`);
+    }
+    if (resolved.length > MAX_RESOLVED_ROWS) {
+      lines.push(
+        `| … | ${resolved.length - MAX_RESOLVED_ROWS} more — full list in the job log or \`--json\` |`,
+      );
     }
     lines.push('');
     lines.push('</details>');

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -49,6 +49,7 @@ import { dxkitCli } from '../self-invocation';
 import { isMaliciousAdvisory } from '../analyzers/security/malicious';
 import { gatherCurrentScan, scanToBaselineFile } from './create';
 import type { CurrentScan } from './create';
+import { describeCheckSkip } from '../analyzers/custom-checks/types';
 import { DEFAULT_BASELINE_NAME, pathForBaseline, readBaselineFile } from './baseline-file';
 import type { BaselineFile, DeferredCaptureClass } from './baseline-file';
 import { diffCoverage } from './coverage';
@@ -295,6 +296,49 @@ export interface AnchorSourceDisclosure {
   readonly note: string;
 }
 
+/**
+ * One unobserved slice of the baseline: a check (or a scoped-out gather) the
+ * current run never executed, with how many committed baseline findings that
+ * leaves un-re-verified. The aggregate the renderers print INSTEAD of listing
+ * the pairs — see `GuardrailCheckResult.notObserved`.
+ */
+export interface NotObservedDisclosure {
+  /** Finding kind of the unobserved entries (today always `custom-check`). */
+  readonly kind: BaselineEntry['kind'];
+  /** The shared human phrasing of why (embeds the check name), identical to
+   *  the per-pair reason detail — one phrasing, both surfaces. */
+  readonly reason: string;
+  /** Baseline findings not re-verified under this reason. */
+  readonly count: number;
+}
+
+/**
+ * Group `not_observed` pairs by their reason. Pure; reads the prior-side entry
+ * through the SAME reason function the classifier consumed, so a disclosure
+ * can never disagree with the pair statuses it summarizes. Sorted by count
+ * (largest first) for stable rendering.
+ */
+export function collectNotObservedDisclosures(
+  pairs: ReadonlyArray<ClassifiedPair>,
+  priorById: ReadonlyMap<FindingId, BaselineEntry>,
+  reasonFor: (entry: BaselineEntry) => string | undefined,
+): NotObservedDisclosure[] {
+  const byReason = new Map<string, { kind: BaselineEntry['kind']; count: number }>();
+  for (const p of pairs) {
+    if (p.classification.status !== 'not_observed' || p.pair.priorId === undefined) continue;
+    const entry = priorById.get(p.pair.priorId);
+    if (!entry) continue;
+    const reason = reasonFor(entry);
+    if (reason === undefined) continue;
+    const agg = byReason.get(reason) ?? { kind: entry.kind, count: 0 };
+    agg.count += 1;
+    byReason.set(reason, agg);
+  }
+  return [...byReason.entries()]
+    .map(([reason, { kind, count }]) => ({ kind, reason, count }))
+    .sort((a, b) => b.count - a.count || a.reason.localeCompare(b.reason));
+}
+
 export interface GuardrailCheckResult {
   /** Pre-resolved baseline mode (which path produced `baseline`).
    *  Carries the audit trail (CLI / policy / auto-detect) so the
@@ -339,6 +383,18 @@ export interface GuardrailCheckResult {
    * which case renderers print nothing. See `src/baseline/expiry-projection.ts`.
    */
   readonly suppressionExpiry: ExpiryProjection;
+  /**
+   * Baseline findings the CURRENT side never re-verified, aggregated per
+   * unobserved check (Rule 19's REMOVED direction, 4.3.2). Their pairs are
+   * classified `not_observed` — excluded from the resolved tally and from
+   * per-finding tables — and every renderer prints one disclosure line per
+   * entry here ("check X skipped (untrusted tree) — N baseline findings not
+   * re-verified this run"). REQUIRED so a renderer cannot be written without
+   * deciding what to do with it; empty on the overwhelming majority of runs.
+   * Never affects the verdict: an unobserved backlog is neither the
+   * developer's regression nor their fix.
+   */
+  readonly notObserved: ReadonlyArray<NotObservedDisclosure>;
   /** Allowlist entries added / removed between the baseline's
    *  commit SHA and the current working tree. Renderers (the PR
    *  comment markdown in particular) surface this so reviewers
@@ -800,6 +856,30 @@ export async function runGuardrailCheck(
   });
   const now = new Date();
 
+  // Removed-direction attribution (Rule 19, 4.3.2): the ONE answer to "did the
+  // current side actually observe this prior entry's check?". A `removed` pair
+  // whose check the run never observed (skipped: untrusted tree / unmet
+  // environment / unavailable tool / timeout — or the whole gather scoped out)
+  // reclassifies `not_observed` instead of rendering "resolved". The shipped
+  // class: an --untrusted PR check skipped lint, diffed a baseline holding the
+  // repo's 18,406-finding lint backlog against a current side holding zero,
+  // and reported all of it as Resolved with no disclosure.
+  const ccUnobserved = current.customChecksUnobserved;
+  const unobservedByCheck = ccUnobserved.gathered
+    ? new Map(ccUnobserved.checks.map((c) => [c.name, describeCheckSkip(c)]))
+    : undefined;
+  const notObservedReasonFor = (entry: BaselineEntry): string | undefined => {
+    if (entry.kind !== 'custom-check') return undefined;
+    if (!ccUnobserved.gathered) return ccUnobserved.reason;
+    // A sanitized entry carries no check name, and per-check skip attribution
+    // needs one — it stays `removed` (bias toward the false negative, the
+    // benign-module discipline: never suppress a real resolution claim we
+    // cannot disprove). The whole-gather branch above still covers it.
+    if (!('check' in entry)) return undefined;
+    const skip = unobservedByCheck!.get(entry.check);
+    return skip !== undefined ? `check "${entry.check}" ${skip}` : undefined;
+  };
+
   const classifiedPairs: ClassifiedPair[] = [];
   let blocks = false;
   let warns = false;
@@ -847,6 +927,10 @@ export async function runGuardrailCheck(
     const reachable =
       pair.currentId !== undefined && reachableByCurrentId.has(pair.currentId) ? true : undefined;
 
+    // Only a `removed` pair can be a not-observed candidate: an unobserved
+    // check produces no current findings, so no other pair status exists.
+    const notObserved = pair.status === 'removed' ? notObservedReasonFor(anchorEntry) : undefined;
+
     const context: ClassifyContext = {
       severity,
       kind: anchorEntry.kind,
@@ -859,6 +943,7 @@ export async function runGuardrailCheck(
       ...(overlapsChangedLines !== undefined ? { overlapsChangedLines } : {}),
       ...(malicious ? { malicious } : {}),
       ...(reachable ? { reachable } : {}),
+      ...(notObserved !== undefined ? { notObserved } : {}),
       // Only asked for added dep-vuln pairs, so a run with none never pays the
       // git diff (and other kinds never see the flag).
       ...(anchorEntry.kind === 'dep-vuln' && pair.status === 'added' && manifestUntouched()
@@ -1001,6 +1086,20 @@ export async function runGuardrailCheck(
   // while one exists the run cannot render PASSED.
   const attributionGaps = collectAttributionGaps(filteredPairs, envelopeDrift.recallDrift);
 
+  // Aggregate the not-observed pairs into per-reason disclosures for the
+  // renderers. Aggregate ON PURPOSE: a repo-scale lint backlog is tens of
+  // thousands of entries, and listing them (the "Resolved (18406)" table this
+  // fixes) is both a lie and a comment-size failure — the honest output is one
+  // line per unobserved check with its count. Computed from the SAME pair set
+  // the verdict reads (post --changed-only filter), through the same reason
+  // function the classifier consumed, so the counts and phrasing agree by
+  // construction.
+  const notObservedDisclosures = collectNotObservedDisclosures(
+    filteredPairs,
+    priorById,
+    notObservedReasonFor,
+  );
+
   // The lapse projection: what today's active suppressions will cost when their
   // windows close. Reads the same pair set the verdict reads (post
   // --changed-only filter) and the same `now` the suppression decision used, so
@@ -1035,6 +1134,7 @@ export async function runGuardrailCheck(
       baseWarns || flowGate.warns || schemaDriftGate.warns || dupGate.warns || pairedGate.warns,
     attributionGaps,
     suppressionExpiry,
+    notObserved: notObservedDisclosures,
     allowlistDelta,
     refExcludedKinds,
     // Capture-deferral (Rule 20): classes the committed baseline could not

--- a/src/baseline/classify.ts
+++ b/src/baseline/classify.ts
@@ -77,6 +77,18 @@ export interface ClassifyContext {
   readonly manifestUntouched?: boolean;
   /** True when an `added` dep-vuln is on a reachable code path. */
   readonly reachable?: boolean;
+  /**
+   * Set (to the human-phrased cause) when the CURRENT side never observed
+   * this finding's check/kind — its command skipped (untrusted tree, unmet
+   * environment, unavailable tool, timeout) or its gather was scoped out.
+   * Reclassifies a matcher-`removed` pair as `not_observed` instead of
+   * letting it render "resolved": Rule 19's law applied to the REMOVED
+   * direction — a delta may be attributed (even a flattering attribution)
+   * only when every other cause is ruled out, and "dxkit did not look" is
+   * cause #2. Only read for `removed` pairs; an unobserved kind produces no
+   * current findings, so no other status can carry it.
+   */
+  readonly notObserved?: string;
   /** True when an `added` dep-vuln's advisory reports the package itself
    *  as malicious code (OSV `MAL-*`, CWE-506 family, malware-titled
    *  advisory) — see `src/analyzers/security/malicious.ts`. */
@@ -139,6 +151,19 @@ export function classify(
   let status: FindingStatus = pair.status;
   const reasons: MatchReason[] = [...pair.reasons];
   let unattributableBlockRule: string | undefined;
+
+  // Removed-direction attribution (Rule 19, 4.3.2): a `removed` pair whose
+  // check/kind the current side never observed is UNKNOWN, not "resolved".
+  // Epistemic status with a fixed verdict — it can never block or warn, no
+  // matter what a policy's block/warn lists say (a policy cannot make
+  // "dxkit did not look" gate), so it returns before the membership steps.
+  if (status === 'removed' && context.notObserved !== undefined) {
+    reasons.push({
+      code: 'not-observed',
+      detail: `${context.notObserved} — this baseline finding was not re-verified this run; not observed is not resolved`,
+    });
+    return { status: 'not_observed', blocks: false, warns: false, reasons };
+  }
 
   // Step 2: drift context can reclassify 'added'.
   if (status === 'added') {

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -42,10 +42,9 @@ import { assessCaptureDeferral, type DeferredCaptureClass } from './deferral';
 import { resolveBaselineMode } from './modes';
 import type { ResolvedMode } from './modes';
 import { loadPolicyFromCwd, prohibitedLicensePatterns } from './policy';
-import {
-  customCheckRecallInputs,
-  gatherCustomCheckFindings,
-} from '../analyzers/custom-checks/gather';
+import { customCheckRecallInputs, gatherCustomChecks } from '../analyzers/custom-checks/gather';
+import type { CustomChecksUnobserved } from '../analyzers/custom-checks/gather';
+export type { CustomChecksUnobserved };
 import { PRODUCERS, runProducers, runRecallContexts } from './producers';
 import type { ProducerContext } from './producers';
 import { recallInputsUnion } from './recall';
@@ -148,6 +147,13 @@ export interface CurrentScan {
   /** Finding classes this environment could NOT observe (Rule 20 — see
    *  `deferral.ts`). Non-empty ⇒ partial capture; persisted for the arming banner. */
   readonly deferred: ReadonlyArray<DeferredCaptureClass>;
+  /** What the custom-check seam could NOT observe on THIS run (Rule 19's
+   *  REMOVED direction — see `CustomChecksUnobserved` in the seam's
+   *  `gather.ts`). The guardrail reclassifies the unobserved checks' baseline
+   *  findings `not_observed` instead of minting `removed` ("resolved"). A run
+   *  property, never persisted (capture-side unobservation is carried by
+   *  absent recall + `deferred`). */
+  readonly customChecksUnobserved: CustomChecksUnobserved;
   /** Envelope metadata for the run. `toolchainHash` is already
    *  resolved from `tools`. */
   readonly analysisMeta: BaselineAnalysisMeta;
@@ -299,9 +305,16 @@ export async function gatherCurrentScan(options: {
   // policy can't block on (the loop Stop-gate's fast path), matching the other
   // producer inputs.
   const policy = loadPolicyFromCwd(cwd);
-  const customCheckFindings = scope.customChecks
-    ? gatherCustomCheckFindings({ cwd, policy, trust: options.trust })
-    : [];
+  const customCheckGather = scope.customChecks
+    ? gatherCustomChecks({ cwd, policy, trust: options.trust })
+    : undefined;
+  const customCheckFindings = customCheckGather?.findings ?? [];
+  const customChecksUnobserved: CustomChecksUnobserved = customCheckGather
+    ? { gathered: true, checks: customCheckGather.unobserved }
+    : {
+        gathered: false,
+        reason: 'custom checks were not gathered this run (outside the gather scope)',
+      };
   // Recall inputs are resolved even when the scope skipped the RUN: the kind's
   // context describes what the checks WOULD see, and a scope that can't block
   // on custom checks still records honest metadata. Pure string work + a
@@ -362,6 +375,7 @@ export async function gatherCurrentScan(options: {
     recall,
     coverage,
     deferred,
+    customChecksUnobserved,
     analysisMeta,
     producerCtx,
   };

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -887,6 +887,16 @@ export type FindingStatus =
    *  `added` for policy membership and block rules), it just stops blaming the
    *  PR and names the defer lane. */
   | 'newly_published_advisory'
+  /** A matcher-`removed` pair whose kind the CURRENT side never actually
+   *  observed (its check skipped: untrusted tree / unmet environment /
+   *  unavailable tool / timeout / scoped out). Rule 19 in the REMOVED
+   *  direction: "you fixed this" is an attribution claim too, and cause #2
+   *  (dxkit did not fully observe the current side) has not been ruled out —
+   *  so the pair is neither "resolved" nor a regression, it is UNKNOWN.
+   *  Epistemic status: never blocks, never warns, never counted as resolved;
+   *  renderers disclose it in aggregate ("N baseline findings not re-verified
+   *  this run"), never as 18k table rows. */
+  | 'not_observed'
   | 'probable_existing'
   | 'uncertain';
 

--- a/src/loop/demo.ts
+++ b/src/loop/demo.ts
@@ -52,6 +52,7 @@ function illustrativePayload(blocked: boolean): GuardrailJsonPayload {
     schema: GUARDRAIL_JSON_SCHEMA,
     verdict: { blocks: blocked, warns: false, refused: false, exitCode: blocked ? 1 : 0 },
     attributionGaps: [],
+    notObserved: [],
     // The illustration has no allowlist, so nothing is deferred and nothing can
     // lapse. Spelled out rather than omitted — the field is required so a real
     // payload can never quietly lack it.
@@ -111,6 +112,7 @@ function illustrativePayload(blocked: boolean): GuardrailJsonPayload {
       warning: 0,
       persisted: 184,
       resolved: 0,
+      notObserved: 0,
     },
     pairs,
   };

--- a/test/baseline/not-observed.test.ts
+++ b/test/baseline/not-observed.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Removal attribution (Rule 19's REMOVED direction, 4.3.2).
+ *
+ * The shipped class: a PR guardrail ran `--untrusted`, the custom-check
+ * runner correctly skipped every repo-declared command (Rule 17's trust
+ * boundary), and the diff then compared a baseline holding the repo's
+ * 18,406-finding lint backlog against a current side holding zero — minting
+ * every entry `removed` and rendering "Resolved (18406)" on a PR that fixed
+ * none of it, with zero disclosure. "You fixed N findings" is an attribution
+ * claim, and its actual cause was Rule 19's cause #2: dxkit did not observe
+ * the current side. Every link in that chain was individually correct; the
+ * lie lived between the runner's skip statuses and the renderers.
+ *
+ * Pinned here, both directions:
+ *   - an unobserved check's baseline findings classify `not_observed` (never
+ *     `removed`, never counted as resolved, never blocking), and ALL THREE
+ *     renderers disclose the aggregate — one line per unobserved check, never
+ *     a per-finding table;
+ *   - a trusted run keeps full behavior (persisted pairs, empty disclosures,
+ *     silent renderers) — over-disclosure trains readers to skip the section;
+ *   - the markdown Resolved table is row-capped regardless (the same incident
+ *     brushed GitHub's 65,536-byte comment limit at 60,143 bytes).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { createBaseline } from '../../src/baseline/create';
+import {
+  runGuardrailCheck,
+  collectNotObservedDisclosures,
+  type ClassifiedPair,
+  type GuardrailCheckResult,
+} from '../../src/baseline/check';
+import {
+  renderConsole,
+  renderJson,
+  renderMarkdown,
+  verdictCounts,
+} from '../../src/baseline/check-renderers';
+import { classify } from '../../src/baseline/classify';
+import { DEFAULT_BROWNFIELD_POLICY } from '../../src/baseline/policy';
+import type { BaselineEntry, FindingStatus, MatchPair } from '../../src/baseline/types';
+import { trustedLocalContext, untrustedContentContext } from '../../src/analysis-trust';
+
+// ─── classify: the reclassification is fixed-verdict ───────────────────────
+
+function removedPair(): MatchPair {
+  return { priorId: 'aaaa111122223333', status: 'removed', confidence: 1, reasons: [] };
+}
+
+describe('classify — removed + notObserved', () => {
+  it('reclassifies a removed pair to not_observed with the reason on the chain', () => {
+    const result = classify(removedPair(), DEFAULT_BROWNFIELD_POLICY, {
+      kind: 'custom-check',
+      notObserved: 'check "web-lint" skipped (untrusted tree)',
+    });
+    expect(result.status).toBe('not_observed');
+    expect(result.blocks).toBe(false);
+    expect(result.warns).toBe(false);
+    const reason = result.reasons.find((r) => r.code === 'not-observed');
+    expect(reason?.detail).toContain('web-lint');
+    expect(reason?.detail).toContain('not observed is not resolved');
+  });
+
+  it('can never block or warn, even under a policy that lists the status', () => {
+    const hostile = {
+      ...DEFAULT_BROWNFIELD_POLICY,
+      block: ['added', 'not_observed'] as ReadonlyArray<FindingStatus>,
+      warn: ['not_observed'] as ReadonlyArray<FindingStatus>,
+    };
+    const result = classify(removedPair(), hostile, {
+      kind: 'custom-check',
+      notObserved: 'check "web-lint" skipped (untrusted tree)',
+    });
+    expect(result.status).toBe('not_observed');
+    expect(result.blocks).toBe(false);
+    expect(result.warns).toBe(false);
+  });
+
+  it('leaves a removed pair without the context untouched (a real resolution stays resolved)', () => {
+    const result = classify(removedPair(), DEFAULT_BROWNFIELD_POLICY, { kind: 'custom-check' });
+    expect(result.status).toBe('removed');
+  });
+
+  it('never fires for non-removed statuses', () => {
+    const persisted: MatchPair = {
+      priorId: 'a',
+      currentId: 'a',
+      status: 'persisted',
+      confidence: 1,
+      reasons: [],
+    };
+    const result = classify(persisted, DEFAULT_BROWNFIELD_POLICY, {
+      kind: 'custom-check',
+      notObserved: 'check "web-lint" skipped (untrusted tree)',
+    });
+    expect(result.status).toBe('persisted');
+  });
+});
+
+// ─── the disclosure collector ──────────────────────────────────────────────
+
+describe('collectNotObservedDisclosures', () => {
+  function ccPair(priorId: string, status: FindingStatus): ClassifiedPair {
+    return {
+      pair: { priorId, status: 'removed', confidence: 1, reasons: [] },
+      classification: { status, blocks: false, warns: false, reasons: [] },
+      kind: 'custom-check',
+    };
+  }
+
+  it('groups by reason with counts, sorted largest first', () => {
+    const entries = new Map<string, BaselineEntry>([
+      ['p1', { id: 'p1', kind: 'custom-check', check: 'web-lint', blocking: false }],
+      ['p2', { id: 'p2', kind: 'custom-check', check: 'web-lint', blocking: false }],
+      ['p3', { id: 'p3', kind: 'custom-check', check: 'seam', blocking: true }],
+      ['p4', { id: 'p4', kind: 'custom-check', check: 'observed-one', blocking: true }],
+    ]);
+    const reasons = new Map<string, string>([
+      ['web-lint', 'check "web-lint" skipped (untrusted tree)'],
+      ['seam', 'check "seam" skipped (timed out)'],
+    ]);
+    const disclosures = collectNotObservedDisclosures(
+      [
+        ccPair('p1', 'not_observed'),
+        ccPair('p2', 'not_observed'),
+        ccPair('p3', 'not_observed'),
+        ccPair('p4', 'removed'), // observed check, really resolved — excluded
+      ],
+      entries,
+      (e) => (e.kind === 'custom-check' && 'check' in e ? reasons.get(e.check) : undefined),
+    );
+    expect(disclosures).toEqual([
+      { kind: 'custom-check', reason: 'check "web-lint" skipped (untrusted tree)', count: 2 },
+      { kind: 'custom-check', reason: 'check "seam" skipped (timed out)', count: 1 },
+    ]);
+  });
+
+  it('is empty when nothing was unobserved', () => {
+    expect(collectNotObservedDisclosures([], new Map(), () => undefined)).toEqual([]);
+  });
+});
+
+// ─── end-to-end: the shipped incident, in miniature ────────────────────────
+
+describe('an untrusted check over a custom-check baseline (integration)', () => {
+  let dir: string;
+  let trusted: GuardrailCheckResult;
+  let untrusted: GuardrailCheckResult;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-not-observed-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+    writeFileSync(join(dir, 'README.md'), '# fixture\n');
+    // A miniature lint backlog: a check whose command always reports the same
+    // two located findings, parsed by regex — the web-client shape at 1/9203
+    // scale.
+    writeFileSync(
+      join(dir, 'lint.cjs'),
+      'console.log("src/a.js:1: no-unused-vars broken");\n' +
+        'console.log("src/b.js:2: eqeqeq broken");\n' +
+        'process.exit(1);\n',
+    );
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(
+      join(dir, '.dxkit', 'policy.json'),
+      JSON.stringify({
+        checks: [
+          {
+            name: 'fake-lint',
+            command: ['node', 'lint.cjs'],
+            blocking: false,
+            parse: { regex: '^(?<file>[^:]+):(?<line>\\d+): (?<rule>\\S+) (?<message>.*)$' },
+          },
+        ],
+      }),
+    );
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: dir });
+
+    // Trusted capture: the check RUNS, its two findings land in the baseline.
+    await createBaseline({ cwd: dir });
+    trusted = await runGuardrailCheck({ trust: trustedLocalContext(), cwd: dir });
+    untrusted = await runGuardrailCheck({ trust: untrustedContentContext(), cwd: dir });
+  }, 240_000);
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('the trusted control: pairs persist, nothing is unobserved, renderers stay silent', () => {
+    const cc = trusted.pairs.filter((p) => p.kind === 'custom-check');
+    expect(cc.length).toBe(2);
+    for (const p of cc) expect(p.classification.status).toBe('persisted');
+    expect(trusted.notObserved).toEqual([]);
+    expect(renderConsole(trusted)).not.toContain('Not re-verified');
+    expect(renderMarkdown(trusted)).not.toContain('not re-verified');
+    expect(renderJson(trusted).summary.notObserved).toBe(0);
+  });
+
+  it('untrusted: zero removed custom-check pairs — the backlog is not_observed, not "resolved"', () => {
+    const cc = untrusted.pairs.filter((p) => p.kind === 'custom-check');
+    expect(cc.length).toBe(2);
+    for (const p of cc) {
+      expect(p.classification.status).toBe('not_observed');
+      expect(p.classification.blocks).toBe(false);
+      expect(p.classification.warns).toBe(false);
+    }
+    expect(cc.filter((p) => p.classification.status === ('removed' as FindingStatus))).toEqual([]);
+  });
+
+  it('the aggregate disclosure names the check, the cause, and the count', () => {
+    expect(untrusted.notObserved.length).toBe(1);
+    const d = untrusted.notObserved[0];
+    expect(d.kind).toBe('custom-check');
+    expect(d.count).toBe(2);
+    expect(d.reason).toContain('fake-lint');
+    expect(d.reason).toContain('untrusted');
+  });
+
+  it('the verdict is unchanged: an unobserved backlog neither blocks nor resolves', () => {
+    const counts = verdictCounts(untrusted);
+    expect(counts.exitCode).toBe(0);
+    expect(counts.resolved).toBe(0);
+  });
+
+  it('console disclosure: one aggregate line, no per-finding table, no Resolved section', () => {
+    const out = renderConsole(untrusted);
+    expect(out).toContain('Not re-verified this run (2)');
+    expect(out).toContain('fake-lint');
+    expect(out).toContain('not observed, never as resolved');
+    expect(out).not.toContain('Resolved (2)');
+  });
+
+  it('JSON disclosure: always-present field + summary counts', () => {
+    const json = renderJson(untrusted);
+    expect(json.summary.resolved).toBe(0);
+    expect(json.summary.notObserved).toBe(2);
+    expect(json.notObserved.length).toBe(1);
+    expect(json.notObserved[0].count).toBe(2);
+    // The pairs keep their per-finding statuses for machine consumers.
+    expect(json.pairs.filter((p) => p.status === 'not_observed').length).toBe(2);
+  });
+
+  it('markdown disclosure: the PR comment says what was not looked at', () => {
+    const md = renderMarkdown(untrusted);
+    expect(md).toContain('not re-verified this run');
+    expect(md).toContain('fake-lint');
+    expect(md).not.toContain('Resolved (2)');
+  });
+});
+
+// ─── the markdown Resolved row cap ─────────────────────────────────────────
+
+describe('markdown Resolved table row cap', () => {
+  it('caps rows and points at the full list (the 65,536-byte comment class)', async () => {
+    // A synthetic result with a large genuinely-resolved set. Base fields come
+    // from a minimal real run so the renderer sees a well-formed result.
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-resolved-cap-'));
+    try {
+      execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir });
+      execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+      writeFileSync(join(dir, 'README.md'), '# fixture\n');
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: dir });
+      await createBaseline({ cwd: dir });
+      const base = await runGuardrailCheck({ trust: trustedLocalContext(), cwd: dir });
+
+      const resolvedPairs: ClassifiedPair[] = Array.from({ length: 150 }, (_, i) => ({
+        pair: { priorId: `prior-${i}`, status: 'removed', confidence: 1, reasons: [] },
+        classification: { status: 'removed', blocks: false, warns: false, reasons: [] },
+        kind: 'custom-check',
+        file: `src/file-${i}.js`,
+        line: 1,
+        locator: `src/file-${i}.js:1`,
+      }));
+      const md = renderMarkdown({ ...base, pairs: [...base.pairs, ...resolvedPairs] });
+      expect(md).toContain('Resolved (150)');
+      // 100 sample rows plus the pointer to the rest — never all 150.
+      expect(md).toContain('src/file-99.js:1');
+      expect(md).not.toContain('src/file-100.js:1');
+      expect(md).toContain('50 more — full list in the job log or `--json`');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 240_000);
+});

--- a/test/baseline/not-observed.test.ts
+++ b/test/baseline/not-observed.test.ts
@@ -164,8 +164,10 @@ describe('an untrusted check over a custom-check baseline (integration)', () => 
     // scale.
     writeFileSync(
       join(dir, 'lint.cjs'),
-      'console.log("src/a.js:1: no-unused-vars broken");\n' +
-        'console.log("src/b.js:2: eqeqeq broken");\n' +
+      // Fixture CONTENT, not test logging: the fake linter's stdout IS the
+      // console.log output the regex parse extracts findings from.
+      'console.log("src/a.js:1: no-unused-vars broken");\n' + // slop-ok
+        'console.log("src/b.js:2: eqeqeq broken");\n' + // slop-ok
         'process.exit(1);\n',
     );
     mkdirSync(join(dir, '.dxkit'), { recursive: true });

--- a/test/baseline/scan-to-baseline.test.ts
+++ b/test/baseline/scan-to-baseline.test.ts
@@ -44,6 +44,10 @@ function fixtureScan(): CurrentScan {
     deferred: [
       { id: 'semgrep', label: 'SAST', reason: 'mirror', cause: 'scanner-missing' },
     ] as CurrentScan['deferred'],
+    // Run property (which checks THIS run observed), deliberately not
+    // persisted to the baseline file — capture-side unobservation is carried
+    // by absent recall + `deferred`.
+    customChecksUnobserved: { gathered: true, checks: [] },
     analysisMeta: {
       dxkitVersion: '3.8.0',
       toolchainHash: 'abc',


### PR DESCRIPTION
## What

When the current side of a guardrail check never observed a custom check (its command skipped: untrusted tree, unmet environment, unavailable tool, timeout, output overflow, or the whole gather was scoped out), its baseline findings no longer mint `removed` ("Resolved"). They classify as the new epistemic status `not_observed`, all three renderers disclose the aggregate, and the markdown Resolved table is row-capped.

## Why

The attribution law ("a delta may be attributed only when every other cause is ruled out") was enforced for the ADDED direction only. In the REMOVED direction, an untrusted PR run skipped lint, diffed a baseline holding a repo's entire 18,406-finding lint backlog against a current side holding zero, and reported all of it as Resolved on a PR that fixed nothing, with zero disclosure, in a comment brushing GitHub's 65,536-byte limit. Every link in that chain was individually correct; the runner's skip statuses simply died between the runner and the renderers. "You fixed N findings" is an attribution claim too, and its actual cause was that dxkit did not look.

## How

- `gatherCustomChecks` (the seam's one entry point) now surfaces per-check skip outcomes alongside findings; `gatherCustomCheckFindings` stays as a thin wrapper for existing callers.
- `CurrentScan.customChecksUnobserved` carries the observation record: either the whole gather was scoped out, or the individual checks that skipped. A run property, never persisted to the baseline file (capture-side unobservation is already carried by absent recall + `deferred`).
- The classifier reclassifies a matcher-`removed` pair whose check went unobserved to `not_observed`, with the shared skip phrasing on its reason chain. Fixed verdict: it can never block or warn, even if a policy lists the status, and it is excluded from every resolved tally.
- `GuardrailCheckResult.notObserved` is a REQUIRED field (same discipline as `attributionGaps`): aggregate disclosures, one per unobserved check, computed through the same reason function the classifier consumed so the counts and phrasing agree by construction.
- Console, JSON, and markdown all disclose ("check X skipped (untrusted tree) — N baseline findings not re-verified this run (reported as not observed, never as resolved)"). Aggregate lines only, never a per-finding table: an 18k-row table is the other half of the incident.
- The markdown Resolved table is capped at 100 sample rows regardless (exact count stays in the summary; pointer to the job log for the rest).

## Deliberate edges

- Trusted runs are pinned unchanged: persisted pairs, empty disclosures, silent renderers. Over-disclosure trains readers to skip the section.
- A genuinely resolved finding (its check ran and no longer reports it) still reads `removed`.
- Sanitized baseline entries carry no check name, so per-check skip attribution stays out for them (bias toward the false negative); the scoped-out-gather branch still covers them.
- Verdict-neutral: an unobserved backlog is neither the developer's regression nor their fix. Net-new gating on unobserved kinds at PR time is restored separately by the fork-keyed trust change (#200); the coverage-parity matrix net comes next.

## Tests

`test/baseline/not-observed.test.ts`: the classifier both directions (including a hostile policy listing `not_observed` in block/warn), the disclosure collector, the incident end-to-end at 1/9203 scale (trusted capture, then an untrusted check over the same tree), all three renderer disclosures plus the trusted-silence control, and the row cap.

Local gates: typecheck (src + test), lint, format, arch check, slop check, full suite (5,101), and `guardrail check --mode ref-based --ref origin/main` PASSED — after slimming `create.ts` back under the large-file threshold, which the self-guardrail itself flagged on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)