### PR TITLE
The lapse projection agrees with itself at n=1

### DIFF
--- a/src/baseline/expiry-projection.ts
+++ b/src/baseline/expiry-projection.ts
@@ -292,8 +292,9 @@ export function describeExpiryProjection(p: ExpiryProjection): string | undefine
         ? `${p.willWarn} will warn`
         : 'none will block or warn';
   return (
-    `${n} allowlist suppression${n === 1 ? '' : 's'} expire within ${p.horizonDays} days ` +
-    `(next ${when}); when they lapse, ${consequence}`
+    `${n} allowlist suppression${n === 1 ? '' : 's'} expire${n === 1 ? 's' : ''} within ` +
+    `${p.horizonDays} days (next ${when}); when ${n === 1 ? 'it lapses' : 'they lapse'}, ` +
+    consequence
   );
 }
 

--- a/test/baseline/expiry-projection.test.ts
+++ b/test/baseline/expiry-projection.test.ts
@@ -219,6 +219,17 @@ describe('describeExpiryProjection', () => {
     expect(EXPIRY_PROJECTION_REMEDY).toContain('allowlist audit');
   });
 
+  it('agrees with itself at n=1 (singular verb, singular pronoun)', () => {
+    const out = collectExpiryProjection({
+      pairs: [pair({ kind: 'dep-vuln', blocks: true, expiresAt: '2026-08-03', fingerprint: 'a' })],
+      now: NOW,
+    });
+    expect(describeExpiryProjection(out)).toBe(
+      '1 allowlist suppression expires within 14 days (next in 5d); ' +
+        'when it lapses, 1 will BLOCK',
+    );
+  });
+
   it('says so plainly when nothing lapsing would block or warn', () => {
     const out = collectExpiryProjection({
       pairs: [],


### PR DESCRIPTION
## What

The expiry-projection headline read "1 allowlist suppression expire within 14 days ... when they lapse" when exactly one suppression is lapsing. It now reads "1 allowlist suppression expires within 14 days ... when it lapses".

The headline comes from `describeExpiryProjection`, the one phrasing all three renderers (console, JSON consumers via the shared string, markdown) and the summary footer share, so the fix lands everywhere at once. A singular-case test pins both the verb and the pronoun.

Local gates: typecheck, lint, format, arch check, slop check, expiry test suites (36), and `guardrail check --mode ref-based --ref origin/main` PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)