### PR TITLE
The coverage-parity matrix net: every kind x surface observes or discloses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,20 @@ ${path}` keys, which discards catch-all structure — so it did exact membership
   `test/baseline/changed-files.test.ts` (a file the file-level sibling
   reports changed must carry line attribution). Attribution failure reads
   as UNKNOWN (no demotion), never as "nothing changed".
+- whether the CURRENT side of a guardrail diff actually OBSERVED a kind
+  (Rule 19's REMOVED direction, 4.3.2 — "you fixed 18,406 findings" is an
+  attribution claim too, and an unobserved current side cannot back it) →
+  for `custom-check`, the seam's own record (`CustomChecksUnobserved` from
+  `gatherCustomChecks`, which sees per-check runtime skips); for every other
+  kind, `kindNotObservedReason` in `check.ts`, reading the typed
+  `KIND_OBSERVATION_SCOPE` table (`gather-scope.ts` — a new kind without an
+  observation declaration fails to COMPILE) + the aggregate's per-source
+  provenance (what actually RAN — never a kind↔tool table). Unobserved ⇒ the
+  pair classifies `not_observed` (fixed verdict, never "resolved"), and the
+  REQUIRED `GuardrailCheckResult.notObserved` disclosures reach all three
+  renderers. The matrix net `test/baseline/coverage-parity.test.ts` pins the
+  invariant per kind × surface: observed, or the output says why not —
+  injection-guarded so the net itself is proven to bite.
 - a block rule's required EVIDENCE (which analyzers must gather for it to
   fire) → `BLOCK_RULE_EVIDENCE` in `src/baseline/gather-scope.ts`, typed
   `Record<keyof BrownfieldBlockRules, ...>` so a new rule without an

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -65,7 +65,13 @@ import type { BrownfieldPolicy, BaselineSection } from './policy';
 import type { ClassifyContext, ClassifyResult } from './classify';
 import { hydrateAnchorFromBranch, loadAnchorFromBranch } from './anchor';
 import { gatherFromRef } from './ref-baseline';
-import { type GatherScope, FULL_SCOPE, scopeForPolicy, scopeForRefBasedDiff } from './gather-scope';
+import {
+  type GatherScope,
+  FULL_SCOPE,
+  KIND_OBSERVATION_SCOPE,
+  scopeForPolicy,
+  scopeForRefBasedDiff,
+} from './gather-scope';
 import { computeChangedFiles, createChangedLineIndex } from './changed-files';
 import { changedFilesTouchDependencyManifest, detectActiveLanguages } from '../languages';
 import { describeRecallDrift, diffRecall } from './recall';
@@ -310,6 +316,47 @@ export interface NotObservedDisclosure {
   readonly reason: string;
   /** Baseline findings not re-verified under this reason. */
   readonly count: number;
+}
+
+/**
+ * Was a NON-custom-check kind observed by this run? Pure — the ONE answer the
+ * removed-direction attribution reads for scope- and scanner-level causes
+ * (`custom-check` has its own richer record at the seam, `CustomChecksUnobserved`).
+ *
+ * Committed modes only: a ref-based diff gathers BOTH sides in this same
+ * environment, so an un-run scanner produces zero findings on each and no
+ * removed pair exists to mislabel (and the structurally-excluded kinds carry
+ * their own `refExcludedKinds` disclosure).
+ *
+ * Two causes, in order:
+ *   1. the kind's gather was scoped out (`KIND_OBSERVATION_SCOPE`);
+ *   2. the gather was requested but its scanner did not run — read from the
+ *      aggregate's per-source provenance, the same signal `depVulnsUnmeasured`
+ *      trusts (never a kind↔tool table; provenance says what actually ran).
+ */
+export function kindNotObservedReason(
+  kind: BaselineEntry['kind'],
+  ctx: {
+    readonly mode: ResolvedMode['mode'];
+    readonly scope: GatherScope;
+    readonly provenance: SecurityAggregate['provenance'];
+  },
+): string | undefined {
+  if (ctx.mode === 'ref-based') return undefined;
+  const offFlag = KIND_OBSERVATION_SCOPE[kind].find((flag) => !ctx.scope[flag]);
+  if (offFlag !== undefined) {
+    return `not gathered this run (the ${offFlag} gather is outside this run's scope)`;
+  }
+  if ((kind === 'secret' || kind === 'secret-hmac') && !ctx.provenance.secrets.ran) {
+    return 'not observed this run (no secret scanner ran)';
+  }
+  if (kind === 'code' && !ctx.provenance.codePatterns.ran) {
+    return 'not observed this run (the code-pattern scanner did not run)';
+  }
+  if (kind === 'dep-vuln' && !ctx.provenance.depVulns.available) {
+    return 'not observed this run (the dependency scanner could not run)';
+  }
+  return undefined;
 }
 
 /**
@@ -869,15 +916,23 @@ export async function runGuardrailCheck(
     ? new Map(ccUnobserved.checks.map((c) => [c.name, describeCheckSkip(c)]))
     : undefined;
   const notObservedReasonFor = (entry: BaselineEntry): string | undefined => {
-    if (entry.kind !== 'custom-check') return undefined;
-    if (!ccUnobserved.gathered) return ccUnobserved.reason;
-    // A sanitized entry carries no check name, and per-check skip attribution
-    // needs one — it stays `removed` (bias toward the false negative, the
-    // benign-module discipline: never suppress a real resolution claim we
-    // cannot disprove). The whole-gather branch above still covers it.
-    if (!('check' in entry)) return undefined;
-    const skip = unobservedByCheck!.get(entry.check);
-    return skip !== undefined ? `check "${entry.check}" ${skip}` : undefined;
+    if (entry.kind === 'custom-check') {
+      // The seam records its own observation (scope-skip AND per-check
+      // runtime skips) — the one source for this kind.
+      if (!ccUnobserved.gathered) return ccUnobserved.reason;
+      // A sanitized entry carries no check name, and per-check skip attribution
+      // needs one — it stays `removed` (bias toward the false negative, the
+      // benign-module discipline: never suppress a real resolution claim we
+      // cannot disprove). The whole-gather branch above still covers it.
+      if (!('check' in entry)) return undefined;
+      const skip = unobservedByCheck!.get(entry.check);
+      return skip !== undefined ? `check "${entry.check}" ${skip}` : undefined;
+    }
+    return kindNotObservedReason(entry.kind, {
+      mode: mode.mode,
+      scope,
+      provenance: current.aggregate.provenance,
+    });
   };
 
   const classifiedPairs: ClassifiedPair[] = [];

--- a/src/baseline/gather-scope.ts
+++ b/src/baseline/gather-scope.ts
@@ -40,6 +40,7 @@
  * scope contract test pins this.
  */
 import type { BrownfieldPolicy, BrownfieldBlockRules } from './policy';
+import type { BaselineEntry } from './types';
 
 /**
  * One boolean per skippable analyzer. `true` = run it. The names mirror the
@@ -142,11 +143,78 @@ export function scopeSignature(s: GatherScope): string {
     .join('+');
 }
 
+/**
+ * Which scope flags a finding KIND's observation depends on — the ONE mapping
+ * from "this gather was skipped" to "these baseline kinds were not observed"
+ * (Rule 19's REMOVED direction, 4.3.2 — the coverage-parity net's spine).
+ *
+ * The class this closes: a committed-mode run with a partial scope produced
+ * zero findings of a scoped-out kind, so every baseline entry of that kind
+ * minted `removed` ("resolved") with no disclosure — the same lie the
+ * untrusted custom-check skip told, one seam over. The check consults this
+ * table to reclassify those pairs `not_observed` instead.
+ *
+ * Typed `Record` over the full kind union, so a NEW kind cannot land without
+ * declaring its observation dependencies (compile error — the
+ * `BLOCK_RULE_EVIDENCE` discipline). An empty array means the kind is
+ * observed on every run: Layer-0 metrics (`large-file` reads the unscoped
+ * generic gather), intrinsic scans (`config`), plain file reads
+ * (`stale-allow`), gate-minted kinds whose own gates carry their disclosure
+ * (`flow-binding`, `model-schema-drift`, `paired-change`,
+ * `code-reimplementation`), and kinds no producer contributes yet
+ * (`DEFERRED_KINDS`). `custom-check` is deliberately `[]` here too: the seam
+ * records its own observation (`CustomChecksUnobserved`, which also carries
+ * per-check runtime skips this table cannot see) — a second scope-derived
+ * answer for it would be the two-projections drift class.
+ */
+export const KIND_OBSERVATION_SCOPE: Record<
+  BaselineEntry['kind'],
+  ReadonlyArray<keyof GatherScope>
+> = Object.freeze({
+  secret: ['secrets'],
+  // Companion of the located `secret` — same gather, same observation.
+  'secret-hmac': ['secrets'],
+  // Partial on purpose: the cheap intrinsic scans (tls-bypass, file findings)
+  // always run, so some `code` findings survive a skipped semgrep. Marking the
+  // whole kind unobserved when semgrep is off withholds resolution claims —
+  // the safe direction (never suppress a real finding; suppressing a
+  // resolution CLAIM is the bias this platform prefers).
+  code: ['codePatterns'],
+  config: [],
+  'dep-vuln': ['depVulns'],
+  duplication: ['duplication'],
+  'coverage-gap': [],
+  'test-gap': ['testGaps'],
+  hygiene: [],
+  'test-file-degradation': ['testGaps'],
+  'god-file': [],
+  'stale-file': ['hygiene'],
+  'large-file': [],
+  'stale-allow': [],
+  'flow-binding': [],
+  'model-schema-drift': [],
+  'code-reimplementation': [],
+  'custom-check': [],
+  'paired-change': [],
+  license: ['licenses'],
+});
+
 /** The finding kinds a ref-based diff structurally excludes, mapped to the
  *  scope flags of the analyzers that produce them. `secret-hmac` is absent
  *  deliberately: it is a companion output of the secrets analyzer, which
  *  must still run for the located `secret` kind. */
 export type RefSkippableKind = 'duplication' | 'test-gap' | 'custom-check' | 'license';
+
+/** The gathers each ref-skippable kind rides on. `custom-check` names its
+ *  flag here (not in `KIND_OBSERVATION_SCOPE`, where the seam's own record
+ *  answers observation) because this map's job is turning OFF gathers, not
+ *  attributing observation. */
+const REF_SKIPPABLE_FLAGS: Record<RefSkippableKind, keyof GatherScope> = Object.freeze({
+  duplication: 'duplication',
+  'test-gap': 'testGaps',
+  'custom-check': 'customChecks',
+  license: 'licenses',
+});
 
 /**
  * Drop the analyzers whose finding kinds a ref-based diff throws away
@@ -169,21 +237,12 @@ export function scopeForRefBasedDiff(scope: GatherScope): {
 } {
   const skipped: RefSkippableKind[] = [];
   const next = { ...scope };
-  if (next.duplication) {
-    next.duplication = false;
-    skipped.push('duplication');
-  }
-  if (next.testGaps) {
-    next.testGaps = false;
-    skipped.push('test-gap');
-  }
-  if (next.customChecks) {
-    next.customChecks = false;
-    skipped.push('custom-check');
-  }
-  if (next.licenses) {
-    next.licenses = false;
-    skipped.push('license');
+  for (const kind of Object.keys(REF_SKIPPABLE_FLAGS) as RefSkippableKind[]) {
+    const flag = REF_SKIPPABLE_FLAGS[kind];
+    if (next[flag]) {
+      next[flag] = false;
+      skipped.push(kind);
+    }
   }
   if (skipped.length === 0) return { scope, skippedKinds: skipped };
   return { scope: Object.freeze(next), skippedKinds: skipped };

--- a/test/baseline/coverage-parity.test.ts
+++ b/test/baseline/coverage-parity.test.ts
@@ -70,11 +70,15 @@ function observationViolations(result: GuardrailCheckResult): string[] {
     const lieState =
       pairs.length === 0 || pairs.every((p) => p.classification.status === 'removed');
     if (!lieState) continue;
+    // Valid channels only. `deferredCapture` is deliberately NOT one: it
+    // discloses what the BASELINE could not capture, and a kind with baseline
+    // entries was by definition captured — so it can never explain that
+    // kind's removed pairs. (Accepting it masked the injection test on the
+    // scanner-less CI job, where every capture defers some class.)
     const disclosed =
       result.notObserved.some((d) => d.kind === kind) ||
       result.refExcludedKinds.some((e) => e.kind === kind) ||
       (kind === 'dep-vuln' && result.depVulnsUnmeasured !== undefined) ||
-      (result.deferredCapture ?? []).length > 0 ||
       result.envelopeDrift.recallDrift.some((d) => d.kind === kind);
     if (!disclosed) violations.push(kind);
   }

--- a/test/baseline/coverage-parity.test.ts
+++ b/test/baseline/coverage-parity.test.ts
@@ -1,0 +1,336 @@
+/**
+ * The coverage-parity matrix net (4.3.2 item 3 — the class-killer).
+ *
+ * The week's three defects shared one shape: a correct mechanism silently
+ * switching off a coverage path at a subsystem seam (trust×diff,
+ * manifest×policy, allowlist×refresh), with no disclosure. This net pins the
+ * invariant that kills the class:
+ *
+ * > For every finding kind × surface: either the kind is OBSERVED on that
+ * > surface, or the output SAYS why not.
+ *
+ * Surfaces are (mode, trust, scope) triples driven through the real
+ * `runGuardrailCheck` on one fixture repo whose baseline holds two kinds with
+ * different observation profiles:
+ *   - `custom-check` — observed only when the seam may spawn (trust) and the
+ *     gather is in scope; its observation record is `CustomChecksUnobserved`;
+ *   - `large-file` — read from the unscoped Layer-0 metrics, so observed on
+ *     EVERY surface (the control row: a disclosure for it would be
+ *     over-disclosure).
+ *
+ * The disclosure channels a cell may answer with: `notObserved` (the seam /
+ * kind-level record), `refExcludedKinds` (ref-based structural exclusion),
+ * `depVulnsUnmeasured`, `deferredCapture`, or per-kind recall drift. The
+ * scope- and scanner-level causes for native kinds (secret / code / dep-vuln
+ * / duplication / test-gap / stale-file / license) are covered at unit level
+ * through the pure `kindNotObservedReason` — an e2e secret cell would need a
+ * key-shaped literal in this file, which the self-guardrail would rightly
+ * flag as a net-new secret (the 4.3.0 lesson).
+ *
+ * A synthetic-injection tail proves the net BITES: a doctored result with the
+ * lie state (all pairs of a kind minted `removed`, disclosures stripped) must
+ * be flagged by the same helper every cell uses.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { createBaseline } from '../../src/baseline/create';
+import {
+  runGuardrailCheck,
+  kindNotObservedReason,
+  type GuardrailCheckResult,
+} from '../../src/baseline/check';
+import {
+  FULL_SCOPE,
+  KIND_OBSERVATION_SCOPE,
+  scopeForRefBasedDiff,
+} from '../../src/baseline/gather-scope';
+import type { BaselineEntry } from '../../src/baseline/types';
+import type { SecurityAggregate } from '../../src/analyzers/security/aggregator';
+import { trustedLocalContext, untrustedContentContext } from '../../src/analysis-trust';
+
+// ─── The one invariant every cell asserts ──────────────────────────────────
+
+/**
+ * Kinds in the lie state on this result: every pair of the kind reads
+ * `removed` ("resolved") — or the kind vanished from the diff entirely —
+ * while NO disclosure channel says why. Empty on an honest result. This is
+ * the net's single predicate; each matrix cell runs it, and the injection
+ * test proves it flags a doctored result.
+ */
+function observationViolations(result: GuardrailCheckResult): string[] {
+  const kinds = [...new Set(result.baseline.findings.map((e) => e.kind))];
+  const violations: string[] = [];
+  for (const kind of kinds) {
+    const pairs = result.pairs.filter((p) => p.kind === kind);
+    const lieState =
+      pairs.length === 0 || pairs.every((p) => p.classification.status === 'removed');
+    if (!lieState) continue;
+    const disclosed =
+      result.notObserved.some((d) => d.kind === kind) ||
+      result.refExcludedKinds.some((e) => e.kind === kind) ||
+      (kind === 'dep-vuln' && result.depVulnsUnmeasured !== undefined) ||
+      (result.deferredCapture ?? []).length > 0 ||
+      result.envelopeDrift.recallDrift.some((d) => d.kind === kind);
+    if (!disclosed) violations.push(kind);
+  }
+  return violations.sort();
+}
+
+// ─── The matrix (integration) ──────────────────────────────────────────────
+
+describe('coverage-parity matrix — every kind × surface observes or discloses', () => {
+  let dir: string;
+  let cells: Record<'trustedFull' | 'untrusted' | 'scoped' | 'refBased', GuardrailCheckResult>;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-coverage-parity-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+    writeFileSync(join(dir, 'README.md'), '# fixture\n');
+    // A file over the large-file threshold (500): the always-observed kind.
+    writeFileSync(
+      join(dir, 'big.js'),
+      Array.from({ length: 600 }, (_, i) => `const v${i} = ${i};`).join('\n') + '\n',
+    );
+    // A check with two located findings: the trust/scope-sensitive kind.
+    writeFileSync(
+      join(dir, 'lint.cjs'),
+      // Fixture CONTENT: the fake linter's stdout, parsed by the regex below.
+      'console.log("src/a.js:1: no-unused-vars broken");\n' + // slop-ok
+        'console.log("src/b.js:2: eqeqeq broken");\n' + // slop-ok
+        'process.exit(1);\n',
+    );
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(
+      join(dir, '.dxkit', 'policy.json'),
+      JSON.stringify({
+        checks: [
+          {
+            name: 'fake-lint',
+            command: ['node', 'lint.cjs'],
+            blocking: false,
+            parse: { regex: '^(?<file>[^:]+):(?<line>\\d+): (?<rule>\\S+) (?<message>.*)$' },
+          },
+        ],
+      }),
+    );
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: dir });
+
+    await createBaseline({ cwd: dir });
+    cells = {
+      trustedFull: await runGuardrailCheck({ trust: trustedLocalContext(), cwd: dir }),
+      untrusted: await runGuardrailCheck({ trust: untrustedContentContext(), cwd: dir }),
+      scoped: await runGuardrailCheck({
+        trust: trustedLocalContext(),
+        cwd: dir,
+        scope: { ...FULL_SCOPE, customChecks: false },
+      }),
+      refBased: await runGuardrailCheck({
+        trust: trustedLocalContext(),
+        cwd: dir,
+        cliMode: 'ref-based',
+        cliRef: 'HEAD',
+      }),
+    };
+  }, 300_000);
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('the fixture seeds both observation profiles', () => {
+    const kinds = new Set(cells.trustedFull.baseline.findings.map((e) => e.kind));
+    expect(kinds.has('custom-check')).toBe(true);
+    expect(kinds.has('large-file')).toBe(true);
+  });
+
+  it('no cell is in the lie state — the invariant holds on every surface', () => {
+    for (const [name, result] of Object.entries(cells)) {
+      expect({ cell: name, violations: observationViolations(result) }).toEqual({
+        cell: name,
+        violations: [],
+      });
+    }
+  });
+
+  it('trusted full-scope: everything observed, zero disclosures (no over-disclosure)', () => {
+    const r = cells.trustedFull;
+    for (const kind of ['custom-check', 'large-file'] as const) {
+      const pairs = r.pairs.filter((p) => p.kind === kind);
+      expect(pairs.length).toBeGreaterThan(0);
+      for (const p of pairs) expect(p.classification.status).toBe('persisted');
+    }
+    expect(r.notObserved).toEqual([]);
+    expect(r.refExcludedKinds).toEqual([]);
+  });
+
+  it('untrusted: custom-check answers via notObserved; large-file stays observed', () => {
+    const r = cells.untrusted;
+    const cc = r.pairs.filter((p) => p.kind === 'custom-check');
+    expect(cc.length).toBe(2);
+    for (const p of cc) expect(p.classification.status).toBe('not_observed');
+    expect(r.notObserved.some((d) => d.kind === 'custom-check' && d.count === 2)).toBe(true);
+    for (const p of r.pairs.filter((q) => q.kind === 'large-file')) {
+      expect(p.classification.status).toBe('persisted');
+    }
+  });
+
+  it('scoped-out gather: custom-check answers via notObserved with the scope reason', () => {
+    const r = cells.scoped;
+    const cc = r.pairs.filter((p) => p.kind === 'custom-check');
+    expect(cc.length).toBe(2);
+    for (const p of cc) expect(p.classification.status).toBe('not_observed');
+    const d = r.notObserved.find((x) => x.kind === 'custom-check');
+    expect(d?.count).toBe(2);
+    expect(d?.reason).toContain('outside the gather scope');
+    for (const p of r.pairs.filter((q) => q.kind === 'large-file')) {
+      expect(p.classification.status).toBe('persisted');
+    }
+  });
+
+  it('ref-based: custom-check answers via refExcludedKinds; large-file diffs normally', () => {
+    const r = cells.refBased;
+    expect(r.refExcludedKinds.some((e) => e.kind === 'custom-check')).toBe(true);
+    expect(r.pairs.filter((p) => p.kind === 'custom-check')).toEqual([]);
+    const lf = r.pairs.filter((p) => p.kind === 'large-file');
+    expect(lf.length).toBeGreaterThan(0);
+    for (const p of lf) expect(p.classification.status).toBe('persisted');
+  });
+
+  it('INJECTION: the net bites — the doctored lie state is flagged', () => {
+    const base = cells.untrusted;
+    const doctored: GuardrailCheckResult = {
+      ...base,
+      // Re-mint the unobserved pairs as `removed` and strip every disclosure —
+      // exactly the pre-4.3.2 output shape ("Resolved (18406)", silence).
+      pairs: base.pairs.map((p) =>
+        p.kind === 'custom-check'
+          ? { ...p, classification: { ...p.classification, status: 'removed' as const } }
+          : p,
+      ),
+      notObserved: [],
+    };
+    expect(observationViolations(doctored)).toEqual(['custom-check']);
+  });
+});
+
+// ─── kindNotObservedReason (unit — the scope- and scanner-level causes) ────
+
+const RAN_PROVENANCE: SecurityAggregate['provenance'] = {
+  secrets: { tool: 'gitleaks', ran: true },
+  codePatterns: { tool: 'semgrep', ran: true },
+  tlsBypass: { ran: true, patternCount: 0 },
+  fileFindings: { ran: true },
+  depVulns: { tool: 'osv-scanner', available: true, unavailableReason: '' },
+};
+
+describe('kindNotObservedReason', () => {
+  const committed = (
+    kind: BaselineEntry['kind'],
+    over: Partial<Parameters<typeof kindNotObservedReason>[1]>,
+  ) =>
+    kindNotObservedReason(kind, {
+      mode: 'committed-full',
+      scope: FULL_SCOPE,
+      provenance: RAN_PROVENANCE,
+      ...over,
+    });
+
+  it('is silent in ref-based mode — both sides gather in the same environment', () => {
+    for (const kind of ['secret', 'code', 'dep-vuln', 'duplication'] as const) {
+      expect(
+        kindNotObservedReason(kind, {
+          mode: 'ref-based',
+          scope: { ...FULL_SCOPE, secrets: false, duplication: false },
+          provenance: { ...RAN_PROVENANCE, secrets: { tool: null, ran: false } },
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it('names the scoped-out gather for each scope-dependent kind', () => {
+    const cases: Array<[BaselineEntry['kind'], keyof typeof FULL_SCOPE]> = [
+      ['secret', 'secrets'],
+      ['secret-hmac', 'secrets'],
+      ['code', 'codePatterns'],
+      ['dep-vuln', 'depVulns'],
+      ['duplication', 'duplication'],
+      ['test-gap', 'testGaps'],
+      ['test-file-degradation', 'testGaps'],
+      ['stale-file', 'hygiene'],
+      ['license', 'licenses'],
+    ];
+    for (const [kind, flag] of cases) {
+      const reason = committed(kind, { scope: { ...FULL_SCOPE, [flag]: false } });
+      expect(reason).toContain('outside this run');
+      expect(reason).toContain(flag);
+    }
+  });
+
+  it('reads scanner-did-not-run off the aggregate provenance', () => {
+    expect(
+      committed('secret', {
+        provenance: { ...RAN_PROVENANCE, secrets: { tool: null, ran: false } },
+      }),
+    ).toContain('no secret scanner ran');
+    expect(
+      committed('secret-hmac', {
+        provenance: { ...RAN_PROVENANCE, secrets: { tool: null, ran: false } },
+      }),
+    ).toContain('no secret scanner ran');
+    expect(
+      committed('code', {
+        provenance: { ...RAN_PROVENANCE, codePatterns: { tool: null, ran: false } },
+      }),
+    ).toContain('did not run');
+    expect(
+      committed('dep-vuln', {
+        provenance: {
+          ...RAN_PROVENANCE,
+          depVulns: { tool: null, available: false, unavailableReason: 'not installed' },
+        },
+      }),
+    ).toContain('could not run');
+  });
+
+  it('is silent when everything requested actually ran', () => {
+    for (const kind of Object.keys(KIND_OBSERVATION_SCOPE) as Array<BaselineEntry['kind']>) {
+      expect(committed(kind, {})).toBeUndefined();
+    }
+  });
+
+  it('always-observed kinds stay silent even under a minimal scope', () => {
+    const minimal = Object.fromEntries(
+      Object.keys(FULL_SCOPE).map((k) => [k, false]),
+    ) as unknown as typeof FULL_SCOPE;
+    for (const kind of ['large-file', 'config', 'stale-allow'] as const) {
+      expect(committed(kind, { scope: minimal })).toBeUndefined();
+    }
+  });
+});
+
+// ─── table consistency ─────────────────────────────────────────────────────
+
+describe('KIND_OBSERVATION_SCOPE stays consistent with its siblings', () => {
+  it('scopeForRefBasedDiff still skips exactly its four kinds', () => {
+    const { skippedKinds } = scopeForRefBasedDiff(FULL_SCOPE);
+    expect([...skippedKinds].sort()).toEqual([
+      'custom-check',
+      'duplication',
+      'license',
+      'test-gap',
+    ]);
+  });
+
+  it('custom-check declares no scope flags here — the seam record owns it', () => {
+    expect(KIND_OBSERVATION_SCOPE['custom-check']).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

The class-killer for this week's defect shape (a correct mechanism silently switching off a coverage path at a subsystem seam): a matrix net pinning one invariant — **for every finding kind × surface, either the kind is observed, or the output says why not** — plus fixes for the two remaining silent seams the net was designed to catch.

## The net

`test/baseline/coverage-parity.test.ts` drives the real `runGuardrailCheck` across four surfaces on one fixture (trusted full-scope / untrusted / scoped-out gather / ref-based), over a baseline holding two observation profiles: `custom-check` (trust- and scope-sensitive) and `large-file` (read from the unscoped Layer-0 gather, observed everywhere — the over-disclosure control). Every cell runs a single predicate: a kind whose pairs all read `removed` (or vanished from the diff) with no disclosure channel (`notObserved` / `refExcludedKinds` / `depVulnsUnmeasured` / `deferredCapture` / recall drift) is a violation. An injection tail re-mints a kind's pairs as `removed` and strips the disclosures — the exact pre-4.3.2 output shape — and proves the predicate flags it, the same discipline as the recipe/producer playbooks.

## The two seams it surfaced, fixed here

1. **Scoped-out gathers in committed mode.** A committed-mode run with a partial scope (`--incremental`'s policy-derived fast path, or an explicit scope) produced zero findings of each scoped-out kind, minting `removed` for that kind's whole baseline — the untrusted-lint lie one seam over. `KIND_OBSERVATION_SCOPE` (`gather-scope.ts`) is the one typed mapping from finding kind to the scope flags its observation rides on; a `Record` over the full kind union, so a new kind cannot land without declaring its observation dependencies (the `BLOCK_RULE_EVIDENCE` discipline). `scopeForRefBasedDiff` now derives from a shared per-kind map instead of a hand-maintained if-chain.

2. **Requested-but-did-not-run scanners.** A committed-mode run whose secret / code-pattern / dependency scanner did not run read the whole kind as resolved. `kindNotObservedReason` (`check.ts`, pure, unit-tested across all branches) consults the table and then the aggregate's per-source provenance — the same signal `depVulnsUnmeasured` already trusts, never a kind↔tool table.

Both route into the `not_observed` machinery from #201, so the pairs get the fixed-verdict epistemic status and the disclosures reach all three renderers with no new rendering code.

## Deliberate edges

- `custom-check` keeps its seam-owned observation record (it sees per-check runtime skips the scope table cannot); its table entry is deliberately empty — one source, pinned by test.
- Ref-based mode stays silent at the kind level: both sides gather in the same environment, so an un-run scanner is symmetric, and the structural exclusions already carry `refExcludedKinds`.
- Always-observed kinds (`large-file`, `config`, `stale-allow`, gate-minted and deferred kinds) declare empty dependencies; the trusted-full control cell pins zero disclosures on a fully-observed run.
- The `code` kind is marked partial on purpose: the intrinsic scans always run, so marking the kind unobserved when semgrep is off withholds resolution claims — the safe bias.
- No e2e secret cell: it would need a key-shaped literal in the test file, which the self-guardrail would rightly flag as a net-new secret. The scope/scanner branches for native kinds are unit-covered instead.

CLAUDE.md gains the observation bullet in the Rule 2.30 canonical-example list.

Local gates: typecheck (src + test), lint, format, arch check, slop check on the committed range vs main, full suite (5,122), and `guardrail check --mode ref-based --ref origin/main` PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)