### PR TITLE
Pre-push floor: pre-existing phantom imports warn, never block

### DIFF
--- a/src/analyzers/correctness/resolution-attribution.ts
+++ b/src/analyzers/correctness/resolution-attribution.ts
@@ -1,0 +1,135 @@
+/**
+ * Pre-push attribution for import-resolution failures (4.3.3) — a sound
+ * base-side answer WITHOUT a base worktree run, so the one hook surface that
+ * cannot afford a two-sided floor still obeys the floor's law: only a
+ * net-new failure blocks.
+ *
+ * The class this closes, observed live on a customer re-roll: a chore branch
+ * bumping one unrelated lockfile entry escalated the pre-push floor to full
+ * scope, and the repo's PRE-EXISTING phantom imports (specifiers imported by
+ * untouched files, declared in no manifest at the base either) hard-blocked
+ * the push — debt the change cannot have caused, blamed on the change.
+ */
+
+import { execFileSync } from 'child_process';
+
+import { dependencyManifestFilesIn } from '../../languages';
+import type { LanguageSupport } from '../../languages/types';
+import { IMPORT_RESOLUTION_LABEL, type CorrectnessFloorResult } from './run';
+import { attributeFloorFailures, type FloorBaseCheck } from './attribution';
+
+/**
+ * Sound base-side evidence for unresolved import specifiers, WITHOUT a base
+ * worktree run. A specifier could only have resolved at the merge base if
+ * some package by that name was installed there — and every install is
+ * recorded in a manifest/lockfile. So:
+ *
+ *   - the specifier appears in NO base manifest/lockfile blob (conservative
+ *     textual containment — a false "present" merely keeps the block), AND
+ *   - the base tree already carried the import (the QUOTED specifier appears
+ *     in base source — quoting excludes prose mentions, and a false "absent"
+ *     merely keeps the block)
+ *
+ *   ⇒ the specifier was ALREADY unresolvable at the base: pre-existing
+ *     phantom-dependency debt this change cannot have caused. Refuted.
+ *
+ * Everything else stays attributable (the un-hoist class the resolution
+ * check exists for: a specifier the base lockfile DID provide transitively
+ * reads as present and keeps blocking; a newly-added import of an undeclared
+ * package is absent from base source and keeps blocking). Every uncertainty
+ * lands on "keep blocking" — the refutation only fires when the base
+ * evidence is decisive. Returns null when the base side is unreadable (no
+ * refutation, behavior unchanged). Exported for tests.
+ */
+export function refutedResolutionSpecifiers(
+  cwd: string,
+  baseSha: string,
+  packs: readonly LanguageSupport[],
+  specifiers: readonly string[],
+): string[] | null {
+  if (specifiers.length === 0) return [];
+  const git = (args: string[]): string =>
+    execFileSync('git', args, { cwd, encoding: 'utf8', maxBuffer: 128 * 1024 * 1024 });
+  try {
+    const treeFiles = git(['ls-tree', '-r', '--name-only', baseSha]).split('\n').filter(Boolean);
+    const manifestPaths = dependencyManifestFilesIn(treeFiles, packs);
+    const manifestBlobs = manifestPaths.map((p) => {
+      try {
+        return git(['show', `${baseSha}:${p}`]);
+      } catch {
+        // An unreadable manifest blob makes base evidence non-decisive for
+        // every specifier — fail toward keeping the block.
+        throw new Error(`unreadable base manifest ${p}`);
+      }
+    });
+    const refuted: string[] = [];
+    for (const spec of specifiers) {
+      if (manifestBlobs.some((blob) => blob.includes(spec))) continue; // maybe provided at base
+      // Quoted-containment probe for the import existing at base. `git grep`
+      // exits 1 on no match — treated as "not imported at base" (keep block).
+      const importedAtBase = [`'${spec}'`, `"${spec}"`].some((needle) => {
+        try {
+          git(['grep', '-l', '--fixed-strings', needle, baseSha]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      if (importedAtBase) refuted.push(spec);
+    }
+    return refuted;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Route a blocking pre-push floor result through the ONE attribution
+ * comparator (`attributeFloorFailures`), with the resolution check's base
+ * side supplied by `refutedResolutionSpecifiers`. Checks with no base
+ * evidence keep the surface's point-in-time semantics
+ * (`absentMeans: 'net-new'` — a failing syntax or test check still blocks
+ * exactly as before). Returns null when there is nothing to adjust (no
+ * failing resolution check, no decisive base evidence) so the caller keeps
+ * the original outcome byte-for-byte.
+ */
+export function attributePrePushResolution(
+  cwd: string,
+  baseSha: string,
+  packs: readonly LanguageSupport[],
+  result: CorrectnessFloorResult,
+): { blocks: boolean; note: string } | null {
+  const failingResolution = result.checks.filter(
+    (c) => c.status === 'fail' && c.label === IMPORT_RESOLUTION_LABEL && c.findings?.length,
+  );
+  if (failingResolution.length === 0) return null;
+
+  const baseRows: FloorBaseCheck[] = [];
+  for (const check of failingResolution) {
+    const refuted = refutedResolutionSpecifiers(cwd, baseSha, packs, check.findings ?? []);
+    if (refuted === null || refuted.length === 0) continue;
+    baseRows.push({ pack: check.pack, label: check.label, status: 'fail', findings: refuted });
+  }
+  if (baseRows.length === 0) return null;
+
+  const attributed = attributeFloorFailures(result, baseRows, { absentMeans: 'net-new' });
+  const blocks = attributed.some((a) => a.attribution === 'net-new');
+  const parts: string[] = [];
+  for (const a of attributed) {
+    if (a.check.label !== IMPORT_RESOLUTION_LABEL) continue;
+    const refutedCount =
+      (a.check.findings?.length ?? 0) -
+      (a.attribution === 'net-new' ? (a.netNewFindings?.length ?? 0) : 0);
+    if (refutedCount > 0) {
+      parts.push(
+        `${refutedCount} unresolved import(s) are PRE-EXISTING — already unresolvable at the ` +
+          `merge base ${baseSha.slice(0, 12)} (absent from its manifests/lockfiles, already ` +
+          `imported there) — not blocked; declare or remove them`,
+      );
+    }
+    if (a.attribution === 'net-new' && a.netNewFindings?.length) {
+      parts.push(`net-new unresolved import(s) BLOCK: ${a.netNewFindings.join(', ')}`);
+    }
+  }
+  return { blocks, note: parts.length > 0 ? ` [${parts.join('; ')}]` : '' };
+}

--- a/src/analyzers/correctness/surface-run.ts
+++ b/src/analyzers/correctness/surface-run.ts
@@ -10,7 +10,13 @@
  *     keeps `git push` fast. Blocks the push when the affected tests don't pass.
  *     (It does not distinguish a pre-existing red test in a touched module from
  *     a newly-broken one — that distinction belongs to the two-sided surfaces.
- *     Bypass with `--no-verify`.)
+ *     Bypass with `--no-verify`. ONE exception, 4.3.3: import-resolution
+ *     failures ARE attributed here, because a sound base-side answer exists
+ *     without a base worktree run — see `refutedResolutionSpecifiers`. The
+ *     class this closes: a chore PR bumping an unrelated lockfile entry
+ *     escalated the floor to full scope and hard-blocked the push on the
+ *     repo's PRE-EXISTING phantom imports, debt the change cannot have
+ *     caused.)
  *   - `ci` — FULL scope, no timeout. DIFF-SCOPED (T2.3): when the current tree
  *     has failures and a merge-base is resolvable, the floor also runs at the
  *     base in a throwaway worktree and each failure is ATTRIBUTED through the
@@ -43,6 +49,8 @@ import {
   type CorrectnessFloorResult,
 } from './run';
 import { attributeFloorFailures, type AttributedFloorFailure } from './attribution';
+import { attributePrePushResolution } from './resolution-attribution';
+export { refutedResolutionSpecifiers } from './resolution-attribution';
 import { resolveCorrectnessSurface } from './surface';
 
 /** The surfaces this runner serves (the loop-stop surface has its own runner). */
@@ -165,12 +173,13 @@ export function runFloorForSurface(opts: RunFloorForSurfaceOptions): SurfaceFloo
   let scope: 'affected' | 'full' = 'full';
   let changedFiles: readonly string[] = [];
   let timeoutMs: number | undefined;
+  let prePushBase = '';
   if (surface === 'pre-push') {
     scope = 'affected';
-    const base = resolvePrePushBase(cwd, opts.base);
+    prePushBase = resolvePrePushBase(cwd, opts.base);
     // Empty changedFiles (base unresolved / diff undeterminable) → the packs
     // treat the scope as full, per the CorrectnessContext contract.
-    changedFiles = base ? (computeChangedFiles(cwd, base) ?? []) : [];
+    changedFiles = prePushBase ? (computeChangedFiles(cwd, prePushBase) ?? []) : [];
     timeoutMs = prePushTimeoutMs();
   }
   // ci: full scope, no timeout — the full suite runs to completion.
@@ -205,6 +214,22 @@ export function runFloorForSurface(opts: RunFloorForSurfaceOptions): SurfaceFloo
       summary: `correctness floor (${surface}): ${cause} — CI is the backstop${envSuffix}`,
       result,
     };
+  }
+  // Pre-push resolution attribution (4.3.3): a blocking import-resolution
+  // failure is tested against sound base-side evidence before it may block.
+  if (surface === 'pre-push' && result.blocks && prePushBase) {
+    const adjusted = attributePrePushResolution(cwd, prePushBase, packs, result);
+    if (adjusted) {
+      return {
+        surface,
+        enabled: true,
+        reason: res.reason,
+        ran: true,
+        blocks: adjusted.blocks,
+        summary: describeCorrectnessFloor(result) + envSuffix + adjusted.note,
+        result,
+      };
+    }
   }
   return {
     surface,

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -1138,9 +1138,12 @@ function formatDrift(drift: EnvelopeDrift): string[] {
   if (drift.ignoreHashChanged) out.push('.dxkit-ignore changed');
   if (drift.configHashChanged) out.push('.vyuh-dxkit.json changed');
   for (const d of drift.toolVersionDiffs) {
-    out.push(
-      `tool drift: ${d.tool} ${d.baselineVersion ?? '(absent)'} → ${d.currentVersion ?? '(absent)'}`,
-    );
+    // An EMPTY-string value is a real recorded value (e.g. `licenses.prohibited`
+    // with an empty list), distinct from `(absent)` — but rendered bare it
+    // reads as a truncated line ("… → "). Name it.
+    const show = (v: string | undefined): string =>
+      v === undefined ? '(absent)' : v === '' ? '(empty)' : v;
+    out.push(`tool drift: ${d.tool} ${show(d.baselineVersion)} → ${show(d.currentVersion)}`);
   }
   // Recall drift (CLAUDE.md Rule 19) — the load-bearing disclosure. A drifted
   // kind's net-new findings are NOT attributable to the diff, so they warn

--- a/src/baseline/recall.ts
+++ b/src/baseline/recall.ts
@@ -292,8 +292,12 @@ export function describeRecallDrift(drift: RecallDrift): string {
     case 'epoch':
       return `${drift.kind}: dxkit changed what it observes for this kind since the baseline was captured`;
     case 'inputs': {
+      // An empty-string value is a real recorded value (an empty list knob),
+      // distinct from `(absent)` — rendered bare it reads as truncation.
+      const show = (v: string | undefined): string =>
+        v === undefined ? '(absent)' : v === '' ? '(empty)' : v;
       const detail = drift.changed
-        .map((c) => `${c.input} ${c.before ?? '(absent)'} -> ${c.after ?? '(absent)'}`)
+        .map((c) => `${c.input} ${show(c.before)} -> ${show(c.after)}`)
         .join(', ');
       // D4b disclosure: dep-vuln recall keys on the AMBIENT scanner version
       // (e.g. the npm bundled with the local node), so an identical tree can

--- a/test/correctness-resolution-attribution.test.ts
+++ b/test/correctness-resolution-attribution.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Pre-push attribution for import-resolution failures (4.3.3).
+ *
+ * The class this closes, observed live on a customer re-roll: a chore branch
+ * bumping one unrelated lockfile entry escalated the pre-push floor to full
+ * scope, and the repo's PRE-EXISTING phantom imports (specifiers imported by
+ * untouched files and declared in no manifest at the base either) hard-blocked
+ * the push. The floor's own law — only a net-new failure blocks — was already
+ * enforced on the two-sided surfaces (CI, the loop); pre-push was point-in-
+ * time because a base worktree run is too expensive for a hook. The fix is a
+ * sound base answer WITHOUT a base run: a specifier could only have resolved
+ * at the merge base if some package by that name was installed there, and
+ * every install is recorded in a manifest/lockfile. Absent from every base
+ * manifest blob + already imported (quoted) in base source ⇒ already broken
+ * at base ⇒ pre-existing ⇒ warn, not block.
+ *
+ * Every uncertainty keeps the block: a specifier the base lockfile mentions
+ * (the genuine un-hoist class) blocks; a newly-added import (absent from base
+ * source) blocks; an unreadable base yields no refutation at all. Routed
+ * through the ONE comparator (`attributeFloorFailures`), never a second
+ * partition path.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import {
+  runFloorForSurface,
+  refutedResolutionSpecifiers,
+} from '../src/analyzers/correctness/surface-run';
+import type { CommandExec } from '../src/analyzers/correctness/run';
+import type { LanguageSupport } from '../src/languages/types';
+import type {
+  CorrectnessContext,
+  ResolutionCheckResult,
+} from '../src/languages/capabilities/correctness';
+
+function git(dir: string, args: string[]): string {
+  return execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+}
+
+/**
+ * Fixture: base commit with two quoted phantom imports ('ghost-pkg',
+ * 'left-pad'), a lockfile that mentions 'hoisted-pkg' (transitively provided
+ * at base) but neither phantom, then a HEAD commit that only touches the
+ * lockfile — the incident shape.
+ */
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-floor-attrib-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '1.0.0' }));
+  writeFileSync(
+    join(dir, 'package-lock.json'),
+    JSON.stringify({
+      name: 'fixture',
+      lockfileVersion: 3,
+      packages: { '': {}, 'node_modules/hoisted-pkg': { version: '1.0.0' } },
+    }),
+  );
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src', 'app.js'),
+    "const g = require('ghost-pkg');\nconst l = require('left-pad');\nmodule.exports = { g, l };\n",
+  );
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  git(dir, ['branch', 'base-marker']);
+  // The chore change: only the lockfile moves (an unrelated version bump).
+  writeFileSync(
+    join(dir, 'package-lock.json'),
+    JSON.stringify({
+      name: 'fixture',
+      lockfileVersion: 3,
+      packages: { '': {}, 'node_modules/hoisted-pkg': { version: '1.0.1' } },
+    }),
+  );
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '-q', '-m', 'chore: bump lockfile']);
+  return dir;
+}
+
+/** Synthetic pack: injected resolution verdict, exec-driven commands, and the
+ *  manifest patterns the base-probe filters the base tree with. */
+function packWithResolution(
+  resolution: ResolutionCheckResult,
+  opts: { syntaxFails?: boolean } = {},
+): LanguageSupport {
+  return {
+    id: 'synthetic',
+    depVulns: { manifestPatterns: ['package.json', 'package-lock.json'] },
+    correctness: {
+      execution: () => ({
+        hosts: ['any' as const],
+        toolchains: [],
+        needsBuild: false,
+        buildTarget: 'none' as const,
+        weight: 'cheap' as const,
+      }),
+      syntaxCheck: (_ctx: CorrectnessContext) =>
+        opts.syntaxFails ? { label: 'syntax', bin: 'fake-syntax', args: [] } : null,
+      affectedTests: () => null,
+      resolutionCheck: () => resolution,
+    },
+  } as unknown as LanguageSupport;
+}
+
+const passExec: CommandExec = () => ({ available: true, code: 0, output: '' });
+const failSyntaxExec: CommandExec = (c) =>
+  c.bin === 'fake-syntax'
+    ? { available: true, code: 1, output: 'syntax broken' }
+    : { available: true, code: 0, output: '' };
+
+const unresolved = (...specs: string[]): ResolutionCheckResult => ({
+  kind: 'unresolved',
+  unresolved: specs.map((s) => ({ specifier: s, file: 'src/app.js' })),
+});
+
+describe('refutedResolutionSpecifiers — the base probe', () => {
+  let dir: string;
+  let baseSha: string;
+  const packs = [packWithResolution({ kind: 'clean', checkedSpecifiers: 0 })];
+
+  beforeAll(() => {
+    dir = makeRepo();
+    baseSha = git(dir, ['rev-parse', 'base-marker']).trim();
+  });
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('refutes a phantom: absent from every base manifest, imported (quoted) at base', () => {
+    expect(refutedResolutionSpecifiers(dir, baseSha, packs, ['ghost-pkg', 'left-pad'])).toEqual([
+      'ghost-pkg',
+      'left-pad',
+    ]);
+  });
+
+  it('keeps a specifier the base lockfile mentions (the genuine un-hoist class blocks)', () => {
+    expect(refutedResolutionSpecifiers(dir, baseSha, packs, ['hoisted-pkg'])).toEqual([]);
+  });
+
+  it('keeps a newly-added import (absent from base source — the change introduced it)', () => {
+    expect(refutedResolutionSpecifiers(dir, baseSha, packs, ['new-ghost'])).toEqual([]);
+  });
+
+  it('yields no refutation at all when the base is unreadable', () => {
+    expect(refutedResolutionSpecifiers(dir, 'not-a-sha', packs, ['ghost-pkg'])).toBeNull();
+  });
+});
+
+describe('runFloorForSurface pre-push — resolution failures are attributed', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = makeRepo();
+  });
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  const run = (resolution: ResolutionCheckResult, exec: CommandExec, syntaxFails = false) =>
+    runFloorForSurface({
+      surface: 'pre-push',
+      cwd: dir,
+      base: 'base-marker',
+      packs: [packWithResolution(resolution, { syntaxFails })],
+      exec,
+    });
+
+  it('pre-existing phantoms warn instead of blocking, with the base named', () => {
+    const outcome = run(unresolved('ghost-pkg', 'left-pad'), passExec);
+    expect(outcome.ran).toBe(true);
+    expect(outcome.blocks).toBe(false);
+    expect(outcome.summary).toContain('PRE-EXISTING');
+    expect(outcome.summary).toContain('not blocked');
+  });
+
+  it('a net-new unresolved import still blocks, named, while the phantoms stay refuted', () => {
+    const outcome = run(unresolved('ghost-pkg', 'new-ghost'), passExec);
+    expect(outcome.blocks).toBe(true);
+    expect(outcome.summary).toContain('net-new unresolved import(s) BLOCK: new-ghost');
+    expect(outcome.summary).toContain('PRE-EXISTING');
+  });
+
+  it('another failing check keeps its point-in-time block even when resolution is refuted', () => {
+    const outcome = run(unresolved('ghost-pkg'), failSyntaxExec, true);
+    expect(outcome.blocks).toBe(true);
+  });
+
+  it('no resolvable base keeps the point-in-time verdict (no refutation invented)', () => {
+    const outcome = runFloorForSurface({
+      surface: 'pre-push',
+      cwd: dir,
+      base: 'no-such-ref',
+      packs: [packWithResolution(unresolved('ghost-pkg'))],
+      exec: passExec,
+    });
+    expect(outcome.blocks).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

The pre-push correctness floor now attributes import-resolution failures before blocking: a specifier that was already unresolvable at the merge base is disclosed as pre-existing and warns; only a net-new unresolved import blocks. Found live during a live rollout: a chore branch bumping one unrelated lockfile entry escalated the floor to full scope and hard-blocked the push on five pre-existing phantom imports the change could not have caused.

## How

Pre-push was deliberately point-in-time (a base worktree run is too expensive for a hook), so the fix is a sound base-side answer without a base run (`refutedResolutionSpecifiers`, new module `resolution-attribution.ts`): a specifier could only have resolved at the merge base if some package by that name was installed there, and every install is recorded in a manifest/lockfile. Absent from every base manifest blob AND already imported (quoted) in base source ⇒ already broken at base ⇒ refuted. The result routes through the ONE comparator (`attributeFloorFailures`) with a synthetic base row — never a second partition path — and every other failing check keeps the surface's point-in-time semantics exactly.

Every uncertainty keeps the block: a specifier the base lockfile mentions (the genuine un-hoist class the check exists for), a newly-added import (absent from base source), an unreadable base (no refutation at all). The two-sided surfaces (CI, loop) are untouched.

## Rider

An empty-string recall/tool value now renders `(empty)` instead of a bare trailing arrow — `licenses.prohibited (absent) → ` read as a truncated line on a live PR comment.

## Tests

`test/correctness-resolution-attribution.test.ts`: the probe all four ways (refuted phantom, base-lockfile-mentioned kept, newly-added kept, unreadable base → null) and the surface end-to-end (refuted-only unblocks with the base named; mixed blocks naming only the net-new specifier; a failing syntax check keeps blocking; no resolvable base keeps the point-in-time verdict).

Local gates: typecheck (src + test), lint, format, arch check, slop on the committed range, full suite (5,135), self-guardrail ref-based vs origin/main PASSED — after splitting the new logic into its own module when the self-guardrail flagged `surface-run.ts` crossing the large-file floor (fixed the finding, not the threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)