### PR TITLE
release: 4.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.3] - 2026-07-30
+
+### Fixed
+
+- **The pre-push floor no longer blocks on pre-existing phantom imports.**
+  A branch that touches a dependency manifest escalates the floor's
+  import-resolution check to the whole tree — correct, since a lockfile
+  change alters module resolution everywhere. But the pre-push surface had
+  no way to tell a failure the change caused from debt the repository
+  already carried, so a chore branch bumping one unrelated lockfile entry
+  could hard-block on imports that were never declared in any manifest at
+  the merge base either. Pre-push now checks each unresolved specifier
+  against the base's own manifests and source: one that was provably
+  already unresolvable there (absent from every base manifest, already
+  imported in base source) is disclosed as pre-existing and warns. Every
+  uncertain case still blocks — a specifier the base lockfile provided
+  transitively (the genuine un-hoisting class), a newly added import, or
+  an unreadable base.
+- Drift lines no longer render an empty recorded value as a truncated
+  arrow ("… → "); it now reads `(empty)`, distinct from `(absent)`.
+
 ## [4.3.2] - 2026-07-30
 
 The honesty patch. Three fixes that share one shape: a correct mechanism was

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.3.2",
+      "version": "4.3.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",


### PR DESCRIPTION
## 4.3.3 — the pre-push floor patch

Version bump + changelog. Content already on main via #206:

- Pre-push attributes import-resolution failures: a specifier provably already unresolvable at the merge base (absent from every base manifest, already imported in base source) warns as pre-existing instead of blocking; every uncertain case still blocks.
- Drift lines render an empty recorded value as `(empty)` instead of a bare trailing arrow.

After this merges: verify main's tree, then `gh release create v4.3.3 --target <full sha>`. Then downstream repos then update to 4.3.3.

Local gates: build, lint, format, arch check, `npm pack --dry-run`, slop on the committed range, self-guardrail exit 0 (read from `--json`, not a grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)