### PR TITLE
depBump.schedule: the dep-bump lane's frequency is a policy knob

### DIFF
--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -24,6 +24,7 @@ stanzas).
 | `checks`                            | [#custom-checks](#custom-checks)             |
 | `depBump.allowMajor`                | [#dep-bump](#dep-bump)                       |
 | `depBump.enabled`                   | [#dep-bump](#dep-bump)                       |
+| `depBump.schedule`                  | [#dep-bump](#dep-bump)                       |
 | `duplication.mode`                  | [#duplication-mode](#duplication-mode)       |
 | `expiryNotice.enabled`              | [#expiry-notice](#expiry-notice)             |
 | `flow.mode`                         | [#flow-mode](#flow-mode)                     |

--- a/src-templates/.github/workflows/dxkit-dep-bump.yml
+++ b/src-templates/.github/workflows/dxkit-dep-bump.yml
@@ -14,7 +14,10 @@ name: dxkit dep bump
 
 on:
   schedule:
-    - cron: '0 7 * * 1'
+    # Rendered from `.dxkit/policy.json:depBump.schedule` (weekly | daily | a
+    # 5-field cron). Absent = Monday 07:00 UTC. Change the policy knob and run
+    # `vyuh-dxkit update` — do not edit this line (update re-renders it).
+    - cron: '__DXKIT_DEPBUMP_CRON__'
   workflow_dispatch: {}
 
 permissions:

--- a/src/baseline/policy-checks.ts
+++ b/src/baseline/policy-checks.ts
@@ -1,0 +1,64 @@
+/**
+ * The custom-check seam's POLICY types (`checks[]` + `lint`), split from
+ * `policy.ts` at the large-file bar. `policy.ts` re-exports both, so every
+ * existing consumer import keeps working — one definition, one home
+ * (CLAUDE.md Rule 17 owns the runtime seam; these are its declarations).
+ */
+
+/**
+ * One user-declared custom check in `.dxkit/policy.json:checks`. dxkit runs it
+ * as a first-class gate citizen alongside its own scanners: it executes the
+ * command, fingerprints each failure as a `custom-check` finding, and gates on
+ * NET-NEW failures (a pre-existing failure is grandfathered) uniformly across
+ * pre-push / CI / the loop Stop-gate. dxkit becomes the gate runner for ALL of a
+ * repo's invariants, not just its own scanners.
+ *
+ * SECURITY: the command is executed. It comes ONLY from the repo's own committed
+ * policy.json — the same trust boundary as the repo's npm scripts / CI config.
+ * dxkit never runs a check from a CLI flag or any untrusted source.
+ *
+ * Schema example:
+ *
+ *   {
+ *     "checks": [
+ *       { "name": "check:seam", "command": "npm run check:seam" },
+ *       { "name": "licenses", "command": ["make", "check-licenses"], "blocking": false },
+ *       {
+ *         "name": "custom-lint",
+ *         "command": "npx eslint . -f unix",
+ *         "parse": { "regex": "^(?<file>[^:]+):(?<line>\\d+):\\d+:\\s+(?<message>.*?)\\s+\\[(?<rule>[^\\]]+)\\]$" }
+ *       }
+ *     ]
+ *   }
+ */
+export interface CustomCheckConfig {
+  /** Stable label — becomes the finding's durable identity key. `lint:*` is
+   *  reserved for pack-declared built-in lint. */
+  readonly name: string;
+  /** The command: a single string (whitespace-split; no shell — for a pipeline
+   *  use a script) or an argv array. */
+  readonly command: string | readonly string[];
+  /** Net-new failure blocks (default true) or only warns (false). */
+  readonly blocking?: boolean;
+  /** Exit code meaning "pass" (default 0). */
+  readonly expectedExit?: number;
+  /** Output→findings extraction. `'exit'` (default): one binary finding per
+   *  failure. `{ regex }`: one located finding per matching line, via named
+   *  `(?<file>)(?<line>)(?<rule>)(?<message>)` capture groups. */
+  readonly parse?: 'exit' | { readonly regex: string };
+}
+
+/**
+ * `.dxkit/policy.json:lint` — opt-in gating on pack-declared built-in lint
+ * (`LanguageSupport.lint`). Off by default: a lint gate is noisy on a repo that
+ * hasn't opted in, so it ships dormant. When enabled, dxkit synthesizes a
+ * `lint:<pack>` custom check per active language pack, running through the SAME
+ * runner as user checks (lint is a consumer of the custom-check seam, not a
+ * parallel path).
+ */
+export interface LintPolicy {
+  /** Turn on pack-declared lint gating (default false). */
+  readonly enabled?: boolean;
+  /** Net-new lint findings block (default false — warn only). */
+  readonly blocking?: boolean;
+}

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -167,6 +167,13 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
     anchor: 'dep-bump',
   },
   {
+    // Same open shape as baseline.refreshCadence / remediate.schedule: named
+    // cadences OR a cron. Absent = the lane's own Monday 07:00 UTC default.
+    path: 'depBump.schedule',
+    summary: 'cadence: weekly, daily, or a 5-field cron line',
+    anchor: 'dep-bump',
+  },
+  {
     path: 'expiryNotice.enabled',
     summary: 'maintain one issue naming allowlist suppressions about to lapse',
     anchor: 'expiry-notice',

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -211,6 +211,7 @@ export function buildPolicySchema(version: string): Schema {
         {
           enabled: boolProp('depBump.enabled'),
           allowMajor: boolProp('depBump.allowMajor'),
+          schedule: stringProp('depBump.schedule'),
         },
         'Scheduled deterministic dependency-bump PRs.',
       ),

--- a/src/baseline/policy-sections.ts
+++ b/src/baseline/policy-sections.ts
@@ -124,14 +124,24 @@ export function baselineRefreshCron(policy: {
  * 5-field cron, or the weekly default. One grammar, so "weekly" means the
  * same thing on every surface that schedules anything.
  */
-export function cronFromCadence(declared: string | undefined): string {
-  if (typeof declared !== 'string') return DEFAULT_BASELINE_REFRESH_CRON;
+export function cronFromCadence(
+  declared: string | undefined,
+  fallback: string = DEFAULT_BASELINE_REFRESH_CRON,
+): string {
+  if (typeof declared !== 'string') return fallback;
   const trimmed = declared.trim();
   const named = NAMED_REFRESH_CADENCES[trimmed];
   if (named) return named;
   if (CRON_RE.test(trimmed)) return trimmed;
-  return DEFAULT_BASELINE_REFRESH_CRON;
+  return fallback;
 }
+
+/** The dep-bump lane's default: weekly, Monday 07:00 UTC — an hour after the
+ *  refresh/remediate default so the lanes do not pile onto one runner window.
+ *  A declared `depBump.schedule` goes through the ONE cadence grammar above
+ *  (note "weekly" is the shared Mon 06:00 — the 07:00 offset is the ABSENT
+ *  default, not a named cadence). */
+export const DEFAULT_DEPBUMP_CRON = '0 7 * * 1';
 
 /** `licenses.*` block in `.dxkit/policy.json`. */
 export interface LicensesPolicy {

--- a/src/baseline/policy.ts
+++ b/src/baseline/policy.ts
@@ -25,6 +25,9 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+
+import type { CustomCheckConfig, LintPolicy } from './policy-checks';
+export type { CustomCheckConfig, LintPolicy } from './policy-checks';
 import { readPolicyRoot } from './policy-text';
 import type { BaselineMode, BaselineAnchor } from './modes';
 import type { FindingSeverity, FindingStatus } from './types';
@@ -133,64 +136,6 @@ export interface BrownfieldBlockRules {
    *  minted `license` finding IS a prohibited-license match (the inventory
    *  itself never becomes findings), so the rule needs no severity tier. */
   readonly newProhibitedLicense?: boolean;
-}
-
-/**
- * One user-declared custom check in `.dxkit/policy.json:checks`. dxkit runs it
- * as a first-class gate citizen alongside its own scanners: it executes the
- * command, fingerprints each failure as a `custom-check` finding, and gates on
- * NET-NEW failures (a pre-existing failure is grandfathered) uniformly across
- * pre-push / CI / the loop Stop-gate. dxkit becomes the gate runner for ALL of a
- * repo's invariants, not just its own scanners.
- *
- * SECURITY: the command is executed. It comes ONLY from the repo's own committed
- * policy.json — the same trust boundary as the repo's npm scripts / CI config.
- * dxkit never runs a check from a CLI flag or any untrusted source.
- *
- * Schema example:
- *
- *   {
- *     "checks": [
- *       { "name": "check:seam", "command": "npm run check:seam" },
- *       { "name": "licenses", "command": ["make", "check-licenses"], "blocking": false },
- *       {
- *         "name": "custom-lint",
- *         "command": "npx eslint . -f unix",
- *         "parse": { "regex": "^(?<file>[^:]+):(?<line>\\d+):\\d+:\\s+(?<message>.*?)\\s+\\[(?<rule>[^\\]]+)\\]$" }
- *       }
- *     ]
- *   }
- */
-export interface CustomCheckConfig {
-  /** Stable label — becomes the finding's durable identity key. `lint:*` is
-   *  reserved for pack-declared built-in lint. */
-  readonly name: string;
-  /** The command: a single string (whitespace-split; no shell — for a pipeline
-   *  use a script) or an argv array. */
-  readonly command: string | readonly string[];
-  /** Net-new failure blocks (default true) or only warns (false). */
-  readonly blocking?: boolean;
-  /** Exit code meaning "pass" (default 0). */
-  readonly expectedExit?: number;
-  /** Output→findings extraction. `'exit'` (default): one binary finding per
-   *  failure. `{ regex }`: one located finding per matching line, via named
-   *  `(?<file>)(?<line>)(?<rule>)(?<message>)` capture groups. */
-  readonly parse?: 'exit' | { readonly regex: string };
-}
-
-/**
- * `.dxkit/policy.json:lint` — opt-in gating on pack-declared built-in lint
- * (`LanguageSupport.lint`). Off by default: a lint gate is noisy on a repo that
- * hasn't opted in, so it ships dormant. When enabled, dxkit synthesizes a
- * `lint:<pack>` custom check per active language pack, running through the SAME
- * runner as user checks (lint is a consumer of the custom-check seam, not a
- * parallel path).
- */
-export interface LintPolicy {
-  /** Turn on pack-declared lint gating (default false). */
-  readonly enabled?: boolean;
-  /** Net-new lint findings block (default false — warn only). */
-  readonly blocking?: boolean;
 }
 
 /**

--- a/src/baseline/policy.ts
+++ b/src/baseline/policy.ts
@@ -347,7 +347,14 @@ export interface BrownfieldPolicy {
    * major bumps (default false — majors stay a human decision, disclosed in
    * the skip list). Opt-in, default off.
    */
-  readonly depBump?: { readonly enabled?: boolean; readonly allowMajor?: boolean };
+  readonly depBump?: {
+    readonly enabled?: boolean;
+    readonly allowMajor?: boolean;
+    /** Cadence for the scheduled lane — the shared grammar (`weekly`, `daily`,
+     *  or a strict 5-field cron). Absent ⇒ the lane's own default (Monday
+     *  07:00 UTC, an hour after the refresh/remediate default). */
+    readonly schedule?: string;
+  };
   /**
    * The expiry decision surface: while the scheduled refresh is running anyway,
    * maintain ONE GitHub issue naming the allowlist suppressions whose windows

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -35,7 +35,7 @@ import {
   type BaselineAnchor,
 } from './baseline/modes';
 import { baselineRefreshCron, loadPolicyFromCwd } from './baseline/policy';
-import { cronFromCadence } from './baseline/policy-sections';
+import { cronFromCadence, DEFAULT_DEPBUMP_CRON } from './baseline/policy-sections';
 import { BOT_IDENTITY } from './land-refresh';
 import { resolveRemediateConfig } from './remediate/config';
 import { driverById } from './remediate/registry';
@@ -1087,13 +1087,20 @@ export function installCiDepBump(cwd: string, opts: InstallerOpts = {}): ShipIns
   const result = installWorkflow(cwd, 'dxkit-dep-bump.yml', opts, {
     [CI_RUNTIME_SETUP_KEY]: renderCiRuntimeSetup(cwd),
     __DXKIT_DEFAULT_BRANCH__: detectDefaultBranch(cwd),
+    // The one cadence grammar; the lane's own Mon 07:00 default when the knob
+    // is absent (offset from the refresh/remediate 06:00 so lanes don't pile).
+    __DXKIT_DEPBUMP_CRON__: cronFromCadence(
+      loadPolicyFromCwd(cwd).depBump?.schedule,
+      DEFAULT_DEPBUMP_CRON,
+    ),
   });
   if (result.installed.length > 0) {
     result.notes.push(
-      'dep-bump workflow installed: weekly, it turns the fixable subset of dependency ' +
-        'vulnerabilities into one standing PR (dxkit/dep-bump) — bumps from the scanners’ ' +
-        'own fix versions, verified by the correctness floor + guardrail before opening. ' +
-        'Majors are skipped unless depBump.allowMajor.',
+      'dep-bump workflow installed: on its schedule (depBump.schedule; default weekly, ' +
+        'Monday 07:00 UTC) it turns the fixable subset of dependency vulnerabilities into ' +
+        'one standing PR (dxkit/dep-bump) — bumps from the scanners’ own fix versions, ' +
+        'verified by the correctness floor + guardrail before opening. Majors are skipped ' +
+        'unless depBump.allowMajor.',
     );
   }
   return result;

--- a/test/ship-installers.test.ts
+++ b/test/ship-installers.test.ts
@@ -356,6 +356,29 @@ describe('installCiGuardrails + installCiBaselineRefresh', () => {
     // Branch + PR mechanics live in the CLI (shared lander), never the YAML.
     expect(content).toContain('deps bump --apply --land pr');
     expect(content).not.toContain('git checkout -B');
+    // Absent knob → the lane's own default (Mon 07:00, offset from the
+    // refresh/remediate 06:00).
+    expect(content).toContain("cron: '0 7 * * 1'");
+  });
+
+  it('renders depBump.schedule through the one cadence grammar (4.3.4)', () => {
+    fs.mkdirSync(path.join(tmp, '.dxkit'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.dxkit', 'policy.json'),
+      JSON.stringify({ depBump: { enabled: true, schedule: 'daily' } }),
+    );
+    installCiDepBump(tmp, { force: true });
+    const content = fs.readFileSync(path.join(tmp, '.github/workflows/dxkit-dep-bump.yml'), 'utf8');
+    expect(content).toContain("cron: '0 6 * * *'");
+    // A malformed value falls back to the lane default, never an invalid YAML.
+    fs.writeFileSync(
+      path.join(tmp, '.dxkit', 'policy.json'),
+      JSON.stringify({ depBump: { enabled: true, schedule: 'whenever; rm -rf' } }),
+    );
+    installCiDepBump(tmp, { force: true });
+    const again = fs.readFileSync(path.join(tmp, '.github/workflows/dxkit-dep-bump.yml'), 'utf8');
+    expect(again).toContain("cron: '0 7 * * 1'");
+    expect(again).not.toContain('rm -rf');
   });
 
   it('renders the default weekly cron into a scheduled refresh transport', () => {


### PR DESCRIPTION
## What

The dep-bump lane was the one scheduled lane whose frequency wasn't policy-tunable — a hardcoded Monday 07:00 UTC cron, while baseline refresh and remediate both speak the shared cadence grammar. `depBump.schedule` closes that: `"weekly"`, `"daily"`, or a strict 5-field cron, rendered into the workflow by `vyuh-dxkit update` exactly like its siblings. Absent keeps the lane's own Mon 07:00 default (deliberately offset from the 06:00 siblings).

Wired through every knob surface: the policy type, the JSON schema (hover text), the metadata row (teaching stanza + knob-index + policy-guide, re-rendered), and the template placeholder. A malformed value falls back to the lane default through the one strict grammar — never invalid YAML, never interpolated text (pinned, including an injection-shaped value).

First PR of the 4.3.4 operability set (next: `policy set` with automatic workflow refresh, schedule drift detection, and a `jobs` command).

Local gates: typecheck (src + test), lint, format, arch, slop on the committed range, full suite (5,137 — including the re-rendered policy guide), self-guardrail exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)