### PR TITLE
The policy parity gate: policy.json is the interface, drift is unmergeable

### DIFF
--- a/src-templates/.githooks/pre-push
+++ b/src-templates/.githooks/pre-push
@@ -67,6 +67,13 @@ fi
 # or bypass everything with: git push --no-verify
 "${DXKIT}" floor check --surface pre-push
 
+# Policy ⇄ rendered-workflow parity (4.3.4): a .dxkit/policy.json edit that
+# leaves the managed workflows un-rendered would fail the same check on the
+# PR — catch it here, where the fix is one command:
+#   vyuh-dxkit policy render --apply   (then commit the re-rendered files)
+# The check snapshots, renders, diffs, and restores — your tree is untouched.
+"${DXKIT}" policy render --check
+
 BASELINE_NAME="${DXKIT_BASELINE_NAME:-main}"
 BASELINE_FILE=".dxkit/baselines/${BASELINE_NAME}.json"
 

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -211,6 +211,39 @@ __DXKIT_CI_RUNTIME_SETUP__
             echo "✓ dxkit guardrail passed — no net-new findings vs the baseline"
           fi
 
+      # Policy ⇄ rendered-workflow parity (4.3.4). The managed workflows are
+      # rendered FROM .dxkit/policy.json; a policy edit that lands without a
+      # re-render leaves the repo running yesterday's schedule while the file
+      # claims today's. `policy render --check` snapshots the managed files,
+      # re-renders through update's own lane, diffs, and restores — the tree
+      # is byte-identical afterwards, and rendering executes nothing from the
+      # repo, so this is safe on every PR including forks. On drift the diff
+      # lands in the PR comment and the job fails; the fix is ONE command
+      # (`npx vyuh-dxkit policy render --apply`), or the opt-in render bot
+      # commits it for you.
+      - name: Policy render parity
+        id: parity
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi
+          set +e
+          "$DXKIT" policy render --check > parity.txt 2>&1
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          if [ "$code" -ne 0 ]; then
+            {
+              printf '\n\n### Policy drift — managed workflows do not match .dxkit/policy.json\n\n'
+              printf 'A policy change is landing without the re-render of the workflows it gates. '
+              printf 'Run `npx vyuh-dxkit policy render --apply` and commit the result:\n\n'
+              printf '```diff\n'
+              cat parity.txt
+              printf '\n```\n'
+            } >> guardrail-report.md
+            echo "::error::policy drift: managed workflows do not match .dxkit/policy.json (diff in the PR comment)"
+            cat parity.txt
+          else
+            echo "managed workflows match the policy"
+          fi
+
       # Correctness floor (liveness) — full-scope: does the code compile + do
       # the tests pass? Runs after the finding gate. ADAPTIVE: if this repo
       # already runs its tests in its own CI workflow, this is a no-op here
@@ -351,4 +384,5 @@ __DXKIT_CI_RUNTIME_SETUP__
           fi
 
       - name: Fail if guardrail blocked
-        run: exit ${{ steps.guardrail.outputs.exit_code }}
+        # Either gate failing fails the job (sum is non-zero iff any is).
+        run: exit $(( ${{ steps.guardrail.outputs.exit_code }} + ${{ steps.parity.outputs.exit_code }} ))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1110,6 +1110,14 @@ export async function run(argv: string[]): Promise<void> {
         });
         break;
       }
+      if (sub === 'render') {
+        const { runPolicyRender } = await import('./policy-render');
+        runPolicyRender(process.cwd(), {
+          mode: values.apply ? 'apply' : 'check',
+          json: !!values.json,
+        });
+        break;
+      }
       if (sub === 'sync') {
         const { runPolicySync, scaffoldCtxFor } = await import('./policy-sync');
         const { VERSION } = await import('./constants');
@@ -1122,7 +1130,7 @@ export async function run(argv: string[]): Promise<void> {
       }
       logger.fail(
         'usage: vyuh-dxkit policy get <dotted.path> [--default <value>] | ' +
-          'policy set <dotted.path> <value> | policy sync [--apply]',
+          'policy set <dotted.path> <value> | policy render [--apply] | policy sync [--apply]',
       );
       process.exitCode = 1;
       break;

--- a/src/policy-render.ts
+++ b/src/policy-render.ts
@@ -1,0 +1,221 @@
+/**
+ * `vyuh-dxkit policy render [--check|--apply]` — the reconciliation primitive
+ * behind "policy.json is the interface" (4.3.4).
+ *
+ * The managed workflows are RENDERED from the committed policy; a policy edit
+ * that lands without a re-render leaves the repo running yesterday's
+ * schedule while the file claims today's. This command is the ONE primitive
+ * every reconciliation surface calls:
+ *
+ *   - `--check` (CI parity gate, pre-push hook): render in memory-safe
+ *     fashion — snapshot the managed artifacts, run update's OWN refresh
+ *     lane, diff, RESTORE — and exit 1 with a per-file unified diff when
+ *     anything drifts. The working tree is byte-identical afterwards, so it
+ *     is safe on a dirty tree and inside hooks.
+ *   - `--apply` (the fix, local or the opt-in render-bot workflow): run the
+ *     same refresh and keep the result.
+ *
+ * The render path is update's `refreshManagedSurfaces` (Rule 2 — a second
+ * renderer would drift from update's provenance rules); flags resolve
+ * through `resolveInstallFlags`, so a policy-enabled lane renders its
+ * workflow exactly as `update` would. Rendering executes NOTHING from the
+ * repo: policy values reach the templates only through their strict
+ * validators (the cadence grammar's cron allowlist, branch-name detection),
+ * so `--check` is safe on any tree, including untrusted ones.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+import * as logger from './logger';
+import { dxkitCli } from './self-invocation';
+import { refreshManagedSurfaces, managedGatedArtifacts } from './managed-artifacts';
+import { resolveInstallFlags } from './update';
+import type { Manifest } from './types';
+
+export interface PolicyRenderOptions {
+  readonly mode: 'check' | 'apply';
+  readonly json?: boolean;
+}
+
+export interface PolicyRenderOutcome {
+  readonly ok: boolean;
+  /** True when nothing drifted (check) / nothing needed writing (apply). */
+  readonly clean: boolean;
+  readonly message: string;
+  /** Repo-relative managed files whose rendered content differs from disk. */
+  readonly drifted: readonly string[];
+  /** Unified diffs per drifted file (check mode; capped for PR comments). */
+  readonly diffs: readonly string[];
+}
+
+/** Max diff lines carried per file — the PR comment needs the shape of the
+ *  change, not an unbounded wall (the 65,536-byte comment limit again). */
+const MAX_DIFF_LINES_PER_FILE = 60;
+
+function readOrNull(p: string): Buffer | null {
+  try {
+    return fs.readFileSync(p);
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort unified diff via `git diff --no-index` (repo-state-free);
+ *  falls back to a plain marker when git is unavailable. */
+function unifiedDiff(
+  cwd: string,
+  rel: string,
+  before: Buffer | null,
+  after: Buffer | null,
+): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-render-'));
+  try {
+    const a = path.join(tmp, 'a');
+    const b = path.join(tmp, 'b');
+    fs.writeFileSync(a, before ?? Buffer.alloc(0));
+    fs.writeFileSync(b, after ?? Buffer.alloc(0));
+    try {
+      execFileSync('git', ['diff', '--no-index', '--', a, b], { encoding: 'utf8' });
+      return ''; // identical (git exits 0)
+    } catch (err) {
+      const out = (err as { stdout?: string }).stdout ?? '';
+      const lines = out
+        .split('\n')
+        // Strip the temp-path headers; keep hunks.
+        .filter((l) => !l.startsWith('diff --git') && !l.startsWith('index '))
+        .map((l) =>
+          l.startsWith('--- ') ? `--- ${rel}` : l.startsWith('+++ ') ? `+++ ${rel}` : l,
+        );
+      const capped =
+        lines.length > MAX_DIFF_LINES_PER_FILE
+          ? [
+              ...lines.slice(0, MAX_DIFF_LINES_PER_FILE),
+              `… (${lines.length - MAX_DIFF_LINES_PER_FILE} more lines)`,
+            ]
+          : lines;
+      return capped.join('\n');
+    }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Pure-ish core (writes are snapshot-restored in check mode). Exported for
+ * tests and the render-bot workflow.
+ */
+export function resolvePolicyRender(cwd: string, mode: 'check' | 'apply'): PolicyRenderOutcome {
+  const manifestPath = path.join(cwd, '.vyuh-dxkit.json');
+  if (!fs.existsSync(manifestPath)) {
+    // Nothing dxkit-managed to render: a policy-only checkout is clean by
+    // definition (the parity gate must pass on repos without an install).
+    return {
+      ok: true,
+      clean: true,
+      message: 'no dxkit install here (.vyuh-dxkit.json absent) — nothing to render',
+      drifted: [],
+      diffs: [],
+    };
+  }
+  let manifest: Manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as Manifest;
+  } catch {
+    return {
+      ok: false,
+      clean: false,
+      message: '.vyuh-dxkit.json is unreadable — run `' + dxkitCli('update') + '` to repair',
+      drifted: [],
+      diffs: [],
+    };
+  }
+
+  const { flags } = resolveInstallFlags(manifest, cwd);
+  // Snapshot every artifact a managed surface could touch, so check mode can
+  // restore byte-for-byte (safe on a dirty tree, safe in a hook).
+  const candidates = [...new Set(managedGatedArtifacts(flags))];
+  const snapshot = new Map<string, Buffer | null>(
+    candidates.map((rel) => [rel, readOrNull(path.join(cwd, rel))]),
+  );
+
+  // A hand-modified managed file makes the refresh emit a SIDECAR rather than
+  // overwrite (update's provenance rule) — that is deliberate user divergence,
+  // not drift, so the canonical file compares equal and the gate passes. The
+  // sidecars written during a CHECK are cleaned up below (they are
+  // regenerable dxkit output; the check must leave the tree as it found it).
+  const sidecarsWritten: string[] = [];
+  refreshManagedSurfaces(cwd, { force: false, flags }, (r) => {
+    sidecarsWritten.push(...r.sidecars);
+  });
+
+  const drifted: string[] = [];
+  const diffs: string[] = [];
+  for (const rel of candidates) {
+    const before = snapshot.get(rel) ?? null;
+    const after = readOrNull(path.join(cwd, rel));
+    const same =
+      (before === null && after === null) ||
+      (before !== null && after !== null && before.equals(after));
+    if (same) continue;
+    drifted.push(rel);
+    if (mode === 'check') diffs.push(unifiedDiff(cwd, rel, before, after));
+  }
+
+  if (mode === 'check') {
+    // Restore: the check must leave the tree untouched, drift or not.
+    for (const rel of drifted) {
+      const before = snapshot.get(rel) ?? null;
+      const abs = path.join(cwd, rel);
+      if (before === null) fs.rmSync(abs, { force: true });
+      else fs.writeFileSync(abs, before);
+    }
+    for (const rel of new Set(sidecarsWritten)) {
+      fs.rmSync(path.join(cwd, rel), { force: true, recursive: true });
+    }
+  }
+
+  if (drifted.length === 0) {
+    return {
+      ok: true,
+      clean: true,
+      message:
+        mode === 'check'
+          ? 'managed files match the policy — nothing drifts'
+          : 'managed files already match the policy — nothing written',
+      drifted: [],
+      diffs: [],
+    };
+  }
+  return {
+    ok: mode === 'apply',
+    clean: false,
+    message:
+      mode === 'check'
+        ? `${drifted.length} managed file(s) drift from .dxkit/policy.json — ` +
+          `run \`${dxkitCli('policy render --apply')}\` (or \`${dxkitCli('update')}\`) and commit the result`
+        : `re-rendered ${drifted.length} managed file(s) from the policy`,
+    drifted,
+    diffs,
+  };
+}
+
+export function runPolicyRender(cwd: string, opts: PolicyRenderOptions): void {
+  const out = resolvePolicyRender(cwd, opts.mode);
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify(
+        { clean: out.clean, drifted: out.drifted, message: out.message, diffs: out.diffs },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    (out.ok ? (out.clean ? logger.success : logger.success) : logger.fail)(out.message);
+    for (const rel of out.drifted) logger.info(`  ${rel}`);
+    for (const d of out.diffs) if (d) process.stdout.write(d + '\n');
+  }
+  if (!out.ok) process.exitCode = 1;
+}

--- a/test/policy-render.test.ts
+++ b/test/policy-render.test.ts
@@ -1,0 +1,113 @@
+/**
+ * `policy render` — the reconciliation primitive behind "policy.json is the
+ * interface" (4.3.4). The managed workflows are rendered FROM the committed
+ * policy; this command is what the CI parity gate, the pre-push hook, and the
+ * opt-in render bot all call. Pins, both directions:
+ *
+ *   - `--check` detects a policy edit whose workflows were not re-rendered,
+ *     names the files, carries a diff — and leaves the tree BYTE-IDENTICAL
+ *     (safe on dirty trees and inside hooks), including cleaning up any
+ *     sidecars the refresh emitted along the way;
+ *   - `--apply` is the one-command fix;
+ *   - a repo without a dxkit install is clean by definition (the gate must
+ *     pass there);
+ *   - a hand-modified managed file is deliberate divergence, NOT drift — the
+ *     provenance rule that keeps update from clobbering it keeps this check
+ *     from flagging it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { resolvePolicyRender } from '../src/policy-render';
+import { installCiBaselineRefresh } from '../src/ship-installers';
+
+let repo: string;
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), 'dxkit-policy-render-'));
+  mkdirSync(join(repo, '.dxkit'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+function installRefreshSurface(cadence?: string): void {
+  writeFileSync(
+    join(repo, '.dxkit', 'policy.json'),
+    JSON.stringify({
+      baseline: { anchor: 'branch', ...(cadence ? { refreshCadence: cadence } : {}) },
+    }),
+  );
+  writeFileSync(
+    join(repo, '.vyuh-dxkit.json'),
+    JSON.stringify({ generatedAt: 'x', mode: 'full', files: [] }),
+  );
+  installCiBaselineRefresh(repo, { policyAnchor: 'branch' });
+  // Settle the full managed set (ignore files etc.) the way a real install
+  // does, so each scenario starts from a rendered-clean state.
+  resolvePolicyRender(repo, 'apply');
+}
+
+const REFRESH_YML = '.github/workflows/dxkit-baseline-refresh.yml';
+
+describe('resolvePolicyRender', () => {
+  it('a repo without a dxkit install is clean by definition', () => {
+    const out = resolvePolicyRender(repo, 'check');
+    expect(out).toMatchObject({ ok: true, clean: true, drifted: [] });
+  });
+
+  it('freshly rendered files check clean', () => {
+    installRefreshSurface();
+    const out = resolvePolicyRender(repo, 'check');
+    expect(out.clean).toBe(true);
+    expect(out.drifted).toEqual([]);
+  });
+
+  it('a policy edit without a re-render drifts — named, diffed, and the tree untouched', () => {
+    installRefreshSurface();
+    const before = readFileSync(join(repo, REFRESH_YML), 'utf8');
+    expect(before).toContain("cron: '0 6 * * 1'");
+    // The hand edit the parity gate exists for: cadence changed, no render.
+    writeFileSync(
+      join(repo, '.dxkit', 'policy.json'),
+      JSON.stringify({ baseline: { anchor: 'branch', refreshCadence: 'daily' } }),
+    );
+
+    const out = resolvePolicyRender(repo, 'check');
+    expect(out.ok).toBe(false);
+    expect(out.clean).toBe(false);
+    expect(out.drifted).toContain(REFRESH_YML);
+    expect(out.diffs.join('\n')).toContain('0 6 * * *');
+    expect(out.message).toContain('policy render --apply');
+    // Byte-identical restore — the load-bearing hook-safety property.
+    expect(readFileSync(join(repo, REFRESH_YML), 'utf8')).toBe(before);
+  });
+
+  it('--apply is the one-command fix; the follow-up check is clean', () => {
+    installRefreshSurface();
+    writeFileSync(
+      join(repo, '.dxkit', 'policy.json'),
+      JSON.stringify({ baseline: { anchor: 'branch', refreshCadence: 'daily' } }),
+    );
+    const applied = resolvePolicyRender(repo, 'apply');
+    expect(applied.ok).toBe(true);
+    expect(applied.drifted).toContain(REFRESH_YML);
+    expect(readFileSync(join(repo, REFRESH_YML), 'utf8')).toContain("cron: '0 6 * * *'");
+    expect(resolvePolicyRender(repo, 'check').clean).toBe(true);
+  });
+
+  it('a hand-modified managed file is deliberate divergence, not drift — and sidecars are cleaned', () => {
+    installRefreshSurface();
+    // The user rewrote the workflow their way; provenance says never clobber.
+    writeFileSync(join(repo, REFRESH_YML), 'name: my own refresh\non: {}\n');
+    const out = resolvePolicyRender(repo, 'check');
+    expect(out.clean).toBe(true);
+    expect(readFileSync(join(repo, REFRESH_YML), 'utf8')).toContain('my own refresh');
+    // Any sidecar the refresh emitted during the check was cleaned up.
+    expect(existsSync(join(repo, `${REFRESH_YML}.dxkit`))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

The reconciliation model behind "configure everything by editing one file". Managed workflows are rendered *from* `.dxkit/policy.json`; this PR makes a policy edit that lands without its re-render impossible to merge silently:

- **`vyuh-dxkit policy render --check|--apply`** — the one reconciliation primitive (new `src/policy-render.ts`). Check mode snapshots the managed artifacts, runs update's *own* refresh lane (never a second renderer — the provenance rules protecting user-edited files apply identically), diffs, and restores byte-identically. Safe on dirty trees, inside hooks, and on any PR including forks: rendering executes nothing from the repo — policy values reach templates only through their strict validators. Apply mode is the one-command fix.
- **The guardrails workflow gains a "Policy render parity" step**: on drift, the per-file unified diff lands in the PR comment (capped per file for the comment-size limit) and the job fails.
- **The pre-push hook mirrors the check**, where the fix costs the least.

## Deliberate semantics

- A **hand-modified** managed file is deliberate divergence, not drift — the same provenance rule that keeps `update` from clobbering it keeps this gate from flagging it (sidecars emitted during a check are cleaned up).
- A repo **without a dxkit install** is clean by definition.
- The check leaves the tree **byte-identical**, drift or not — the property that makes it hook-safe.

Third PR of the 4.3.4 operability set; independent of #208/#209 (trivial adjacent-line overlap with #209 in `cli.ts` at worst). The opt-in render-bot workflow (a `DXKIT_RENDER_TOKEN` fine-grained PAT lets CI commit the re-render to same-repo PR branches — the default Actions token cannot touch workflow files) comes as the next PR.

## Tests

`test/policy-render.test.ts`, both directions: drift detected + named + diffed + tree untouched; apply fixes and the follow-up check is clean; clean stays silent; no-install passes; user-diverged files never flag.

Local gates: typecheck (src + test), lint, format, arch, slop on the committed range, full suite green, self-guardrail exit 0 — commit and push structurally gated on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)