### PR TITLE
The write-docs remediation task: documentation work verified by the score

### DIFF
--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -339,6 +339,7 @@ declared capability tier.
 | `fix-vulns`     | `standard` | cross-file reasoning; majors can require real code changes    |
 | `fix-lint`      | `light`    | mechanical, pattern-per-finding work                          |
 | `improve-tests` | `standard` | design judgment about behavior worth pinning, not boilerplate |
+| `write-docs`    | `standard` | grounded technical writing over real code, not boilerplate    |
 
 <!-- END GENERATED: remediate-task-tiers -->
 

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -37,6 +37,13 @@ import { BOT_IDENTITY } from '../land-refresh';
 import { resolveModelSetting, type AgentDriver, type AgentRunResult } from './driver';
 import { AGENT_DRIVERS, knownDriverIds } from './registry';
 import { remediateTaskById, knownTaskIds, type RemediateTask } from './tasks';
+import {
+  evaluateScoreHinge,
+  healthHingeScores,
+  renderScoreHinge,
+  type HingeEvidence,
+  type HingeScores,
+} from './score-hinge';
 import type { RemediateConfig } from './config';
 
 export type RemediateOutcome =
@@ -44,6 +51,7 @@ export type RemediateOutcome =
   | 'no-op' // agent ran, no diff (nothing to fix)
   | 'floor-red' // diff breaks the net-new floor — never lands
   | 'guardrail-red' // guardrail blocked, refused, or could not run — never lands
+  | 'score-red' // the task's score hinge did not hold (goal not met) — never lands
   | 'budget-exhausted' // a cap hit; partial diff (salvage policy decides its fate)
   | 'agent-never-ran' // CLI/auth/env failure — infra, not a code outcome
   | 'sweep-failed' // agent committed work but leftovers could not be swept
@@ -79,6 +87,10 @@ export interface RemediateResult {
   readonly floor?: CorrectnessFloorResult;
   readonly floorAttribution?: readonly AttributedFloorFailure[];
   readonly guardrailVerdict?: string;
+  /** Score-hinge evidence (tasks that declare one): the entry vs post-agent
+   *  dimension scores the land decision was made on. Present on success AND
+   *  failure — the ledger shows the delta either way. */
+  readonly scoreHinge?: HingeEvidence;
   /** HEAD before/after the agent — the commit range a lander pushes. */
   readonly baseHead?: string;
   readonly head?: string;
@@ -158,6 +170,9 @@ export interface RemediateRunOptions {
   readonly git?: RemediateGit;
   readonly runFloor?: () => CorrectnessFloorResult;
   readonly runGuardrail?: () => Promise<GuardrailGateResult>;
+  /** Injected for tests: replaces the health-score probe behind a task's
+   *  score hinge. */
+  readonly hingeScores?: (hinge: NonNullable<RemediateTask['scoreHinge']>) => Promise<HingeScores>;
 }
 
 /** The remediate verification ledger — deterministic, identifier-free. */
@@ -203,6 +218,7 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
   lines.push('### Verification', '');
   lines.push(...renderFloorVerification(r.floor, r.floorAttribution, 'the pre-agent entry run'));
   lines.push(...renderGuardrailVerdict(r.guardrailVerdict));
+  if (r.scoreHinge) lines.push(renderScoreHinge(r.scoreHinge));
   lines.push(
     "_Agentic lane inside the verified frame: the agent's own claim of success is never " +
       'trusted — the entry-attributed floor and the guardrail ran before anything lands, ' +
@@ -293,6 +309,12 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // comparator — a repo already red at entry keeps its debt disclosed, never
   // weaponized against the agent's change.
   const entryFloor = runFloor();
+  // Entry side of the task's score hinge (when it declares one) — computed on
+  // the same pristine tree the entry floor snapshots.
+  const hingeProbe =
+    opts.hingeScores ??
+    ((h: NonNullable<RemediateTask['scoreHinge']>) => healthHingeScores(opts.cwd, opts.trust, h));
+  const entryScores = task.scoreHinge ? await hingeProbe(task.scoreHinge) : undefined;
   const baseHead = git.head();
 
   const agentResult: AgentRunResult = await driver.run({
@@ -430,6 +452,26 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
         : `the guardrail could not run (${guardrail.verdict}) — nothing lands. An ` +
           'agent-authored diff is never pushed unverified.',
     });
+  }
+
+  // The score hinge — the task's GOAL as a deterministic land condition. It
+  // gates salvage too: a partial docs diff that moves nothing is noise, not
+  // salvageable work.
+  if (task.scoreHinge && entryScores) {
+    const verdict = evaluateScoreHinge(
+      task.scoreHinge,
+      entryScores,
+      await hingeProbe(task.scoreHinge),
+    );
+    if (!verdict.ok) {
+      return finish({
+        outcome: 'score-red',
+        ...common,
+        scoreHinge: verdict.evidence,
+        note: verdict.note,
+      });
+    }
+    (common as { scoreHinge?: typeof verdict.evidence }).scoreHinge = verdict.evidence;
   }
 
   if (partial) {

--- a/src/remediate/score-hinge.ts
+++ b/src/remediate/score-hinge.ts
@@ -1,0 +1,98 @@
+/**
+ * The remediation score hinge (4.3.4) — a task's GOAL as a deterministic
+ * land condition, split from `run.ts` at the large-file bar.
+ *
+ * The lane's law is that a task ships only when "done" is re-verifiable
+ * without reading prose. For work whose whole point is a health dimension
+ * moving (docs), the floor and guardrail are necessary but prove nothing
+ * about the goal — so a task may declare a hinge: the `improve` dimension's
+ * score must end STRICTLY higher than the pristine-tree entry score, and
+ * every `holdSteady` dimension must not drop. Both sides are computed by the
+ * same deterministic scorer in the same environment, so the DELTA is fair
+ * even where absolute scores are degraded (a missing scanner degrades entry
+ * and after equally).
+ */
+
+import type { AnalysisTrustContext } from '../analysis-trust';
+import type { RemediateTask } from './tasks';
+
+type Hinge = NonNullable<RemediateTask['scoreHinge']>;
+
+/** Entry/after snapshot for a score hinge: the improve dimension's score plus
+ *  the holdSteady dimensions' scores, index-aligned with the declaration. */
+export interface HingeScores {
+  readonly improve: number;
+  readonly holds: readonly number[];
+}
+
+export interface HingeEvidence {
+  readonly dimension: string;
+  readonly before: number;
+  readonly after: number;
+  readonly holds: readonly { dimension: string; before: number; after: number }[];
+}
+
+export type HingeVerdict =
+  | { readonly ok: true; readonly evidence: HingeEvidence }
+  | { readonly ok: false; readonly evidence: HingeEvidence; readonly note: string };
+
+/** Default hinge probe: the deterministic health scorer. */
+export async function healthHingeScores(
+  cwd: string,
+  trust: AnalysisTrustContext,
+  hinge: Hinge,
+): Promise<HingeScores> {
+  const { analyzeHealth } = await import('../analyzers/health');
+  // The lane runs on the maintainers' own default branch — the same trust
+  // the agent itself ran under.
+  const report = await analyzeHealth(cwd, { trust });
+  return {
+    improve: report.dimensions[hinge.improve].score,
+    holds: hinge.holdSteady.map((d) => report.dimensions[d].score),
+  };
+}
+
+/** Pure hinge evaluation — one place decides what "goal met" means. */
+export function evaluateScoreHinge(
+  hinge: Hinge,
+  entry: HingeScores,
+  after: HingeScores,
+): HingeVerdict {
+  const evidence: HingeEvidence = {
+    dimension: hinge.improve,
+    before: entry.improve,
+    after: after.improve,
+    holds: hinge.holdSteady.map((d, i) => ({
+      dimension: d,
+      before: entry.holds[i],
+      after: after.holds[i],
+    })),
+  };
+  const improved = evidence.after > evidence.before;
+  const held = evidence.holds.every((h) => h.after >= h.before);
+  if (improved && held) return { ok: true, evidence };
+  return {
+    ok: false,
+    evidence,
+    note: !improved
+      ? `the ${evidence.dimension} score did not improve (${evidence.before} -> ` +
+        `${evidence.after}) — the task's goal is part of the verified frame, so ` +
+        `nothing lands. Cosmetic churn is rejected, not shipped.`
+      : `a held dimension dropped (${evidence.holds
+          .filter((h) => h.after < h.before)
+          .map((h) => `${h.dimension} ${h.before} -> ${h.after}`)
+          .join(', ')}) — improving one score by degrading another never lands.`,
+  };
+}
+
+/** The hinge's ledger line — evidence rendered one way everywhere. */
+export function renderScoreHinge(h: HingeEvidence): string {
+  const arrow = (b: number, a: number): string =>
+    `${b} -> ${a}${a > b ? ' ✓' : a < b ? ' ✗' : ' ='}`;
+  return (
+    `- score hinge: **${h.dimension}** ${arrow(h.before, h.after)}` +
+    (h.holds.length > 0
+      ? ` (held: ${h.holds.map((x) => `${x.dimension} ${arrow(x.before, x.after)}`).join(', ')})`
+      : '')
+  );
+}

--- a/src/remediate/tasks.ts
+++ b/src/remediate/tasks.ts
@@ -20,7 +20,21 @@ function dxkitInRepo(subcommand: string): string {
   return `\`./node_modules/.bin/vyuh-dxkit ${subcommand}\` (fall back to \`${dxkitCli(subcommand)}\`)`;
 }
 
-export type RemediateTaskId = 'fix-build' | 'fix-vulns' | 'fix-lint' | 'improve-tests';
+export type RemediateTaskId =
+  | 'fix-build'
+  | 'fix-vulns'
+  | 'fix-lint'
+  | 'improve-tests'
+  | 'write-docs';
+
+/** Health dimensions a score hinge may reference (the report's keys). */
+export type HingeDimension =
+  | 'testing'
+  | 'quality'
+  | 'documentation'
+  | 'security'
+  | 'maintainability'
+  | 'developerExperience';
 
 export interface RemediateTask {
   readonly id: RemediateTaskId;
@@ -35,6 +49,23 @@ export interface RemediateTask {
   /** Which verification the outcome hinges on (both always run; this names
    *  the primary signal for the ledger). */
   readonly verify: 'floor' | 'guardrail';
+  /**
+   * OPTIONAL deterministic score hinge (4.3.4). The lane's law is that a task
+   * ships only when "done" is re-verifiable without reading prose — and for
+   * work whose whole point is a dimension moving (docs), the floor and
+   * guardrail are necessary but prove nothing about the goal. A hinge makes
+   * the goal itself part of the verified frame: the `improve` dimension's
+   * score must END STRICTLY HIGHER than the pristine-tree entry score, and
+   * every `holdSteady` dimension must not drop — else the outcome is
+   * `score-red` and nothing lands. Both sides are computed by the same
+   * deterministic scorer in the same environment, so the delta is fair even
+   * where absolute scores are degraded (a missing scanner degrades both
+   * sides equally).
+   */
+  readonly scoreHinge?: {
+    readonly improve: HingeDimension;
+    readonly holdSteady: readonly HingeDimension[];
+  };
 }
 
 /** Ground rules appended to every task prompt — the non-negotiables. */
@@ -130,6 +161,27 @@ give the empty/broken suites real tests or delete them with the reason in the
 commit message. Every test you add must pass, and the suite must run clean
 before you finish (\`vyuh-dxkit debt\` floor section stays clean). Do NOT lower
 coverage thresholds or edit test configuration to inflate numbers.` + SHARED_RULES,
+  },
+  {
+    id: 'write-docs',
+    summary: 'write the documentation the repo is missing, verified by the score',
+    tier: 'standard',
+    tierWhy: 'grounded technical writing over real code, not boilerplate',
+    verify: 'guardrail',
+    scoreHinge: { improve: 'documentation', holdSteady: ['quality'] },
+    prompt:
+      `Run ${dxkitInRepo('health --json')} and read the Documentation dimension's
+deductions — they name exactly what is missing (README sections, docstring
+coverage, architecture notes). Work the largest deductions first. READ the
+real code before documenting it, then write documentation that is TRUE of
+this codebase: a README whose commands and layout match reality, docstrings
+that say what a function does and WHY it exists (never a restatement of the
+signature), architecture notes grounded in the actual module structure. No
+filler prose and no generated-sounding padding — the Quality dimension's
+slop metrics are part of your verification, and vague boilerplate fails it.
+Never document behavior you have not read. Verification is deterministic:
+the Documentation score must END HIGHER than it started while Quality does
+not drop — cosmetic edits that move nothing are rejected, not landed.` + SHARED_RULES,
   },
 ];
 

--- a/test/remediate/driver.test.ts
+++ b/test/remediate/driver.test.ts
@@ -77,12 +77,13 @@ describe('resolveModelSetting (the three accepted shapes)', () => {
 });
 
 describe('task registry', () => {
-  it('declares four v1 tasks, each with a tier + rationale + verify signal', () => {
+  it('declares the task set, each with a tier + rationale + verify signal', () => {
     expect(REMEDIATE_TASKS.map((t) => t.id).sort()).toEqual([
       'fix-build',
       'fix-lint',
       'fix-vulns',
       'improve-tests',
+      'write-docs',
     ]);
     for (const t of REMEDIATE_TASKS) {
       expect(MODEL_TIERS).toContain(t.tier);

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -401,3 +401,69 @@ describe('resolveRemediateConfig (conservative normalization)', () => {
     }
   });
 });
+
+// ─── the score hinge (write-docs, 4.3.4) ────────────────────────────────────
+
+describe('the score hinge — the task goal as a land condition', () => {
+  const hingeBase = (
+    driver: AgentDriver,
+    scores: { entry: [number, number]; after: [number, number] },
+  ) => {
+    let call = 0;
+    return base(driver, {
+      taskId: 'write-docs',
+      config: { ...config(), tasks: ['write-docs' as const] },
+      hingeScores: async () => {
+        const [improve, hold] = call++ === 0 ? scores.entry : scores.after;
+        return { improve, holds: [hold] };
+      },
+    });
+  };
+
+  it('an improved dimension with holds intact lands, evidence in the ledger', async () => {
+    const r = await runRemediateTask(
+      hingeBase(fakeDriver({}), { entry: [42, 70], after: [55, 70] }),
+    );
+    expect(r.outcome).toBe('verified');
+    expect(r.scoreHinge).toEqual({
+      dimension: 'documentation',
+      before: 42,
+      after: 55,
+      holds: [{ dimension: 'quality', before: 70, after: 70 }],
+    });
+    expect(r.ledger).toContain('score hinge');
+    expect(r.ledger).toContain('42 -> 55');
+  });
+
+  it('a score that does not move is score-red — cosmetic churn never lands', async () => {
+    const r = await runRemediateTask(
+      hingeBase(fakeDriver({}), { entry: [42, 70], after: [42, 70] }),
+    );
+    expect(r.outcome).toBe('score-red');
+    expect(r.note).toContain('did not improve');
+    expect(r.note).toContain('42 -> 42');
+  });
+
+  it('improving the goal by degrading a held dimension is score-red', async () => {
+    const r = await runRemediateTask(
+      hingeBase(fakeDriver({}), { entry: [42, 70], after: [60, 61] }),
+    );
+    expect(r.outcome).toBe('score-red');
+    expect(r.note).toContain('quality 70 -> 61');
+  });
+
+  it('tasks without a hinge never pay the probe', async () => {
+    let probed = 0;
+    const r = await runRemediateTask(
+      base(fakeDriver({}), {
+        hingeScores: async () => {
+          probed++;
+          return { improve: 0, holds: [] };
+        },
+      }),
+    );
+    expect(r.outcome).toBe('verified');
+    expect(probed).toBe(0);
+    expect(r.scoreHinge).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

The fifth remediation task — and the answer to "can a job write docs?" done honestly. The lane's law is that a task ships only when "done" is deterministically re-verifiable, and prose quality isn't. But dxkit already computes the deterministic signals docs work needs: the **Documentation dimension score** and the **Quality dimension** (which carries the slop metrics). So `write-docs` ships with the lane's first **score hinge**:

> the Documentation score must end **strictly higher** than the pristine-tree entry score, while Quality does **not drop** — else the outcome is the new `score-red` and nothing lands.

- The hinge is a declared task field (`scoreHinge: { improve, holdSteady }`), evaluated inside the verified frame after the floor and guardrail both pass; it gates salvage too (a partial docs diff that moves nothing is noise, not salvageable work).
- Both sides are computed by the same deterministic scorer in the same environment, so the delta is fair even where absolute scores are degraded (a missing scanner degrades entry and after equally).
- Evidence (`before → after`, per held dimension) lands in the ledger on success *and* failure; tasks without a hinge never pay the probe.
- The prompt is grounded the way `improve-tests` is: read the dimension's actual deductions, read the real code, write docs that are true of it — with the verification spelled out so the agent knows cosmetic churn is rejected.

Enabling it is one policy edit (post-4.3.4: `policy set` — or add `"write-docs"` to `remediate.tasks`).

Fifth PR of the 4.3.4 set; independent of #208–#211.

## Tests

`test/remediate/run.test.ts`: improve+hold lands with ledger evidence; a flat score is `score-red`; improving the goal by degrading a held dimension is `score-red`; no-hinge tasks skip the probe entirely. Task-set pin updated in `driver.test.ts`.

Local gates: the one sweep (build → typecheck → lint → format → arch → slop CI-style → full suite → self-guardrail) ALL GREEN; push gated on its exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)