### PR TITLE
configure --apply runs the post-write reconciliation

### DIFF
--- a/src/configure-cli.ts
+++ b/src/configure-cli.ts
@@ -26,6 +26,7 @@
 import * as logger from './logger';
 import { gatherConfigPlan, type ConfigPlanItem, type ConfigContext } from './discovery/commands';
 import { deepMergePolicy, mergeIntoPolicyFile } from './baseline/policy-write';
+import { resolvePolicyRender } from './policy-render';
 
 export interface ConfigureOptions {
   /** Write the plan into policy.json (default is plan-only, no write). */
@@ -121,10 +122,24 @@ function applyAndReport(
 ): void {
   const result = applyConfigPlan(cwd, plan);
 
+  // The knobs the plan just enabled may gate managed workflows. Rendering is
+  // the SAME post-write reconciliation `policy set` performs (Rule 2 — one
+  // renderer, update's own lane via `policy render`), so `configure --apply`
+  // never leaves a knob on with nothing serving it — the class the parity
+  // gate exists to catch must not be manufactured by dxkit's own onboarding
+  // path. No-op on repos without a dxkit install.
+  const render = result.changed ? resolvePolicyRender(cwd, 'apply') : undefined;
+
   if (opts.json) {
     process.stdout.write(
       JSON.stringify(
-        { schema: 'configure-apply.v1', changed: result.changed, sections: result.sections, plan },
+        {
+          schema: 'configure-apply.v1',
+          changed: result.changed,
+          sections: result.sections,
+          rendered: render?.drifted ?? [],
+          plan,
+        },
         null,
         2,
       ) + '\n',
@@ -146,6 +161,7 @@ function applyAndReport(
   for (const item of plan) logger.info(`  ✓ ${item.section} → ${item.summary}`);
   console.log(''); // slop-ok
   logger.info(`Wrote ${result.sections.length} section(s) into .dxkit/policy.json.`);
+  for (const rel of render?.drifted ?? []) logger.info(`  rendered ${rel}`);
   logger.dim('Commit it so every developer + CI share the same posture.');
 }
 

--- a/test/discovery/config-plan.test.ts
+++ b/test/discovery/config-plan.test.ts
@@ -25,6 +25,7 @@ import {
   type ConfigContext,
 } from '../../src/discovery/commands';
 import { applyConfigPlan, runConfigure } from '../../src/configure-cli';
+import { installCiBaselineRefresh } from '../../src/ship-installers';
 
 const tmps: string[] = [];
 function mkTmp(): string {
@@ -279,5 +280,29 @@ describe('configure check — the enforceable drift detector', () => {
     process.exitCode = 0;
     runConfigure(d, { check: true, json: true, probes: privateProbes });
     expect(process.exitCode).toBe(0);
+  });
+});
+
+describe('configure --apply renders the workflows the plan gates (4.3.4)', () => {
+  it('a changed apply runs the post-write reconciliation — no second update command', () => {
+    const d = mkTmp();
+    // An installed repo rendered under the weekly default, whose POLICY then
+    // moved to daily without a re-render (the hand-edit shape the parity
+    // gate exists for). The apply must leave the workflows reconciled, not
+    // tell the user to run update.
+    fs.writeFileSync(
+      path.join(d, '.vyuh-dxkit.json'),
+      JSON.stringify({ generatedAt: 'x', mode: 'full', files: [] }),
+    );
+    writePolicy(d, { baseline: { anchor: 'branch' } });
+    installCiBaselineRefresh(d, { policyAnchor: 'branch' });
+    const wf = path.join(d, '.github/workflows/dxkit-baseline-refresh.yml');
+    expect(fs.readFileSync(wf, 'utf8')).toContain("cron: '0 6 * * 1'");
+    // Policy edited by hand, workflows not re-rendered:
+    writePolicy(d, { baseline: { anchor: 'branch', refreshCadence: 'daily' } });
+
+    runConfigure(d, { apply: true, json: true, probes: privateProbes });
+
+    expect(fs.readFileSync(wf, 'utf8')).toContain("cron: '0 6 * * *'");
   });
 });


### PR DESCRIPTION
## What

The last policy-writing path with the old two-step gap: `configure --apply` merge-wrote `.dxkit/policy.json` and stopped, leaving any workflow-gating knob it enabled unserved until someone knew to run `update`. A changed apply now runs the one reconciliation primitive (`resolvePolicyRender(cwd, 'apply')` — update's own render lane, same as `policy set` and the parity gate) in the same command, naming the rendered files in the output and the `--json` payload. No-op on repos without a dxkit install.

With this, every dxkit-owned path that writes policy also renders: `policy set`, `configure --apply`, `update` itself — and the parity gate catches the one remaining writer (a human editor).

Final content PR of the 4.3.4 set.

## Tests

`test/discovery/config-plan.test.ts`: a policy that moved without a re-render is reconciled by the apply itself. The fixture deliberately honors the provenance rule — staleness is simulated on the policy side, because a hand-edited workflow is user divergence and must stay untouched (the first draft of the test broke that rule and failed correctly).

Local gates: the one sweep ALL GREEN (5,164 tests, self-guardrail exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)