### PR TITLE
Ref-based mode never diffs the synthetic prior side's coverage

### DIFF
--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -857,7 +857,7 @@ export async function runGuardrailCheck(
   const severityByCurrentId = buildSeverityIndex(current.aggregate);
   const maliciousByCurrentId = buildMaliciousIndex(current.aggregate);
   const reachableByCurrentId = buildReachableIndex(current.aggregate);
-  const envelopeDrift = diffEnvelopes(baseline, current);
+  const envelopeDrift = diffEnvelopes(baseline, current, mode.mode);
 
   // Per-kind recall attribution (Rule 19) drives the per-pair `recallDrifted`
   // signal. A pair is in drift only when the inputs that determine ITS kind
@@ -1319,7 +1319,11 @@ export function buildReachableIndex(aggregate: SecurityAggregate): Set<FindingId
   return out;
 }
 
-function diffEnvelopes(baseline: BaselineFile, current: CurrentScan): EnvelopeDrift {
+function diffEnvelopes(
+  baseline: BaselineFile,
+  current: CurrentScan,
+  mode: ResolvedMode['mode'],
+): EnvelopeDrift {
   const toolVersionDiffs: Array<{
     tool: string;
     baselineVersion: string | undefined;
@@ -1355,7 +1359,16 @@ function diffEnvelopes(baseline: BaselineFile, current: CurrentScan): EnvelopeDr
     toolVersionDiffs,
     recallDrift,
     ...(baseline.capturedIn ? { baselineCapturedIn: baseline.capturedIn } : {}),
-    coverageDrift: diffCoverage(baseline.coverage, current.coverage),
+    // Ref-based mode: the prior side is a fresh gather in a bare worktree,
+    // so its "coverage" records artifact-dependent tools (a node_modules
+    // linter, the coverage report) as missing BY CONSTRUCTION — not as a
+    // fact about any capture. Diffing that against the real tree produced a
+    // guaranteed-noise warning ("eslint was NOT available at baseline …
+    // findings may surface as new") for categories the ref-based diff
+    // ALREADY excludes and discloses (REF_UNRELIABLE_KINDS). Committed
+    // modes keep the diff — there it is load-bearing (a baseline captured
+    // without gitleaks genuinely never baselined secrets).
+    coverageDrift: mode === 'ref-based' ? [] : diffCoverage(baseline.coverage, current.coverage),
   };
 }
 

--- a/test/baseline/coverage-parity.test.ts
+++ b/test/baseline/coverage-parity.test.ts
@@ -203,6 +203,11 @@ describe('coverage-parity matrix — every kind × surface observes or discloses
   it('ref-based: custom-check answers via refExcludedKinds; large-file diffs normally', () => {
     const r = cells.refBased;
     expect(r.refExcludedKinds.some((e) => e.kind === 'custom-check')).toBe(true);
+    // The synthetic prior side's "coverage" is a property of the bare
+    // worktree, not of any capture — never diffed in ref-based mode (the
+    // guaranteed-noise "eslint was NOT available at baseline" class; the
+    // excluded kinds already carry their own disclosure above).
+    expect(r.envelopeDrift.coverageDrift).toEqual([]);
     expect(r.pairs.filter((p) => p.kind === 'custom-check')).toEqual([]);
     const lf = r.pairs.filter((p) => p.kind === 'large-file');
     expect(lf.length).toBeGreaterThan(0);


### PR DESCRIPTION
## What

Removes the guaranteed-noise envelope warning on every ref-based PR comment:

> coverage drift: eslint was NOT available when the baseline was captured but is now — that category was never baselined, so its findings may surface as new

## Why it was wrong there

In ref-based mode the "baseline" is a fresh gather in a bare worktree — no `node_modules`, no coverage artifact — so tools resolved through them read *missing by construction*, not as a fact about any capture. The categories they feed (lint, test-gap) are already structurally excluded from the ref-based diff with their own disclosure, so "findings may surface as new" is impossible in this mode: the line was a double-report of a disclosed exclusion with scarier wording. Committed modes keep the diff untouched — there it is load-bearing (a baseline captured without gitleaks genuinely never baselined secrets, and the warning is the honest disclosure of that).

Pinned in the coverage-parity matrix's ref-based cell; verified live — the self-guardrail's own output no longer carries the two noise lines.

Rider for 4.3.4, raised from reading the guardrail comments on this repo's own PRs.

Local gates: the one sweep ALL GREEN (5,164 tests, self-guardrail exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)