### PR TITLE
release: 4.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.5] - 2026-07-31
+
+A determinism fix for the parity gate that shipped in 4.3.4, found on its
+first production run.
+
+### The default branch is pinned, never re-probed
+
+- **Rendered workflows are now environment-independent.** The guardrail
+  workflow templates embed the repo's default branch. Before this release,
+  every render re-probed git for it — and a local checkout and a CI
+  checkout can legitimately disagree (a shallow single-branch CI clone sees
+  only the PR's branches). So `policy render --check` could report drift on
+  a repository whose default branch is not `main`, purely because the two
+  environments answered the probe differently. The branch is now **pinned
+  in the manifest at install time** (`defaultBranch`), and every render
+  reads the pin — the same discipline the baseline's recall contexts apply
+  to attribution inputs, applied to rendering.
+- **`update` backfills and heals the pin.** A manifest that predates the
+  pin gets it backfilled on the next `update`. If the pinned branch no
+  longer exists (renamed, or the repo moved to a new main branch), `update`
+  re-detects and re-pins, and says so. A pin whose branch still exists is
+  never second-guessed — switching your own checkout to a feature branch
+  does not move it.
+- **Guardrail runs no longer race their own comments.** The guardrails
+  workflow declares a per-PR concurrency group with `cancel-in-progress`,
+  so a force-push cannot leave a stale BLOCKED comment from a superseded
+  run as the last word on the PR.
+
 ## [4.3.4] - 2026-07-31
 
 The operability release. Configuring dxkit's jobs used to take two commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, and a deterministic stop-gate that blocks net-new detector-backed regressions before the loop can finish. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",


### PR DESCRIPTION
Version bump + CHANGELOG for 4.3.5 — the parity-gate determinism fix (pinned default branch, PR #216) plus per-PR guardrail-run concurrency.

Merge order: squash is fine (single release commit).

After merge: tag v4.3.5 from the merge commit and cut the GitHub Release to fire the publish pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Fv5umBGtS1iD257uJGenu