### PR TITLE
fix(defer): three user-facing descriptions still said dep-vuln-only

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -245,12 +245,14 @@ ${renderCommandIndex().join('\n')}
                                  form writes to .dxkit/allowlist.json.
     vyuh-dxkit allowlist defer [<fingerprint>…] [--from-last-check] --reason=<text>
                                [--expires=<YYYY-MM-DD|+Nd>]
-                                 Bulk, dep-vuln-only, time-boxed deferral of newly
-                                 published advisories (category=deferred, default
+                                 Time-boxed deferral (category=deferred, default
                                  expiry +7d — the expiry re-blocks, forcing the fix
-                                 lane). --from-last-check pulls the blocking dep-vulns
-                                 from the last same-tree guardrail run; other kinds are
-                                 refused, never bulk-deferred.
+                                 lane). Explicit fingerprints defer ANY blocking
+                                 finding, kind-stamped from the last verdict.
+                                 --from-last-check is the bulk form: it pulls only
+                                 the blocking dep-vulns of the last same-tree
+                                 guardrail run; other kinds are never bulk-deferred
+                                 (defer them one fingerprint at a time, on purpose).
     vyuh-dxkit allowlist list | show <fingerprint> | audit | prune [--dry-run] [--json]
                                  Review / audit / clean the allowlist. audit surfaces
                                  expired + soon-to-expire (within 14 days) + missing-

--- a/src/discovery/command-defs-gate.ts
+++ b/src/discovery/command-defs-gate.ts
@@ -79,7 +79,8 @@ export const GATE_COMMANDS = [
     typicalRuntime: '< 1 sec',
     docsBlurb:
       'Accept a finding with a typed category + required reason + optional expiry; audit and prune ' +
-      'entries. `defer` bulk-defers newly published dep-vuln advisories time-boxed (dep-vuln-only).',
+      'entries. `defer` time-boxes any blocking finding by fingerprint; its bulk form ' +
+      '(`--from-last-check`) is scoped to newly published dep-vuln advisories.',
     skill: 'dxkit-allowlist',
     whenToRecommend: recommendExpiryNotice,
   },

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -1171,8 +1171,9 @@ export function installCiCommentDefer(cwd: string, opts: InstallerOpts = {}): Sh
   if (result.installed.length > 0) {
     result.notes.push(
       'comment-commands workflow installed: a reviewer with write access can defer ' +
-        'newly published advisories from the PR conversation (`/dxkit defer …`) — ' +
-        'time-boxed, dep-vuln-only, committed to the PR branch with the commenter attributed.',
+        'any blocking finding from the PR conversation (`/dxkit defer <fingerprint>…`; ' +
+        '`--new-advisories` bulk-defers newly published dependency advisories) — ' +
+        'time-boxed, committed to the PR branch with the commenter attributed.',
     );
   }
   return result;


### PR DESCRIPTION
Explicit-fingerprint defer has accepted **any blocking finding kind** since 4.3.2 (kind-stamped from the verdict cache); only the `--from-last-check` / `--new-advisories` bulk form is deliberately scoped to newly published dependency advisories. Three user-facing descriptions still claimed the old dep-vuln-only scope:

- the comment-commands install note (`ship-installers.ts`) — seen by every operator running `update`
- the `allowlist defer` CLI help (`cli.ts`)
- the `allowlist` capability blurb (`command-defs-gate.ts`)

Docs-only in effect: behavior is unchanged, the words now match it. The generated docs table needed no regen (it renders summaries, not blurbs).

Sweep: all gates green locally (5,171 tests; self-guardrail ref-based PASSED).

Squash merge is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Fv5umBGtS1iD257uJGenu