### PR TITLE
WP1: uv-workspace correctness (import floor, pip-audit parse, test association)

### DIFF
--- a/src/analyzers/tools/runner.ts
+++ b/src/analyzers/tools/runner.ts
@@ -54,6 +54,42 @@ export function parseJsonStream(raw: string): unknown[] {
   return out;
 }
 
+/**
+ * Extract the first complete JSON document (`{...}` or `[...]`) from output
+ * that may carry a non-JSON prefix or suffix — the tool-banner class: a
+ * wrapper (uv's "The virtual environment ..." notice) prints on STDOUT ahead
+ * of the tool's JSON, and a byte-0 `JSON.parse` dies on the banner. Walks
+ * balanced brackets string-aware (same discipline as `parseJsonStream`, plus
+ * top-level arrays). Returns the JSON slice, or null when no balanced
+ * document exists — callers fall back to their existing parse-error path.
+ */
+export function extractJsonPayload(raw: string): string | null {
+  const start = raw.search(/[{[]/);
+  if (start < 0) return null;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < raw.length; i++) {
+    const ch = raw[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (ch === '\\') escape = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{' || ch === '[') depth++;
+    else if (ch === '}' || ch === ']') {
+      depth--;
+      if (depth === 0) return raw.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
 /** Run a command and return stdout. Returns empty string on failure. */
 export function run(cmd: string, cwd: string, timeoutMs = 30000): string {
   try {

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import { type Coverage, type FileCoverage, round1, toRelative } from '../analyzers/tools/coverage';
 import { enrichOsv, resolveCvssScores } from '../analyzers/tools/osv';
-import { commandExists, fileExists, run } from '../analyzers/tools/runner';
+import { commandExists, extractJsonPayload, fileExists, run } from '../analyzers/tools/runner';
 import { walkPaths } from '../analyzers/tools/walk-paths';
 import { UNIVERSAL_TEST_DIR_PATTERNS } from './test-dir-patterns';
 import { walkSourceFiles } from '../analyzers/tools/walk-source-files';
@@ -403,7 +403,12 @@ async function gatherPyDepVulnsResult(
   if (!raw) return { kind: 'unavailable', reason: 'pip-audit produced no output' };
 
   try {
-    const data = JSON.parse(raw) as PipAuditReport;
+    // pip-audit's JSON can arrive with a non-JSON stdout prefix when spawned
+    // through a wrapper (uv's virtual-environment notice) — parse the first
+    // balanced document, not byte 0. A payload-less output still lands in
+    // the catch below as a disclosed parse error (UNMEASURED), never a
+    // silent zero-vulns read.
+    const data = JSON.parse(extractJsonPayload(raw) ?? raw) as PipAuditReport;
     const vulnIds: string[] = [];
     for (const dep of data.dependencies || []) {
       for (const v of dep.vulns || []) {
@@ -767,6 +772,34 @@ export function pySourceRoots(cwd: string): string[] {
   const roots = [cwd];
   const srcDir = path.join(cwd, 'src');
   if (isDir(srcDir)) roots.push(srcDir);
+  // Nested project roots: a uv/poetry workspace member (or any nested
+  // sub-project) declares itself with its own pyproject.toml / setup.py /
+  // setup.cfg, and its packages live at the member root or its src/.
+  // Absolute imports of member packages must resolve against those roots —
+  // the uv-workspace class: `packages/acme-platform/src/acme` provides
+  // `acme`, whose name is derivable from NO manifest (distribution
+  // `acme-platform` != import `acme`). Discovery routes through the
+  // canonical walker: exclusion-aware (a .venv-internal pyproject never
+  // becomes a root) and depth-unlimited (G_v4_12).
+  const manifests = walkPaths(cwd, {
+    extensions: [],
+    basenames: ['pyproject.toml', 'setup.py', 'setup.cfg'],
+  });
+  const seen = new Set(roots);
+  for (const rel of manifests) {
+    const dir = path.dirname(rel);
+    if (dir === '.') continue; // repo root — already covered above
+    const abs = path.join(cwd, dir);
+    if (!seen.has(abs)) {
+      seen.add(abs);
+      roots.push(abs);
+    }
+    const memberSrc = path.join(abs, 'src');
+    if (!seen.has(memberSrc) && isDir(memberSrc)) {
+      seen.add(memberSrc);
+      roots.push(memberSrc);
+    }
+  }
   return roots;
 }
 

--- a/test/fixtures-analysis.test.ts
+++ b/test/fixtures-analysis.test.ts
@@ -86,6 +86,12 @@ const STACKS: Array<{ stack: string; flow?: { calls: number } }> = [
   { stack: 'csharp-svc', flow: { calls: 2 } },
   { stack: 'ruby-svc', flow: { calls: 2 } },
   { stack: 'rust-svc', flow: { calls: 2 } },
+  // No flow row: a uv-workspace monorepo (nested member with src/ layout,
+  // distribution name != import name, member-prefixed test basenames) — the
+  // environment shape the #219/#223 class was structurally blind to. The
+  // language-agnostic invariants run here like everywhere; the import-graph
+  // association is additionally pinned below.
+  { stack: 'python-uv' },
   // No flow row: the swift pack declares no httpFlow (iOS apps consume APIs
   // through URLSession wrappers a v1 descriptor can't resolve honestly).
   { stack: 'swift-app' },
@@ -261,6 +267,18 @@ describe('analysis fixtures — test-gap import-graph credits non-relative impor
     // Without `src/`-root awareness the absolute import would anchor at the
     // project root only, miss `src/authz/access.py`, and leave it a gap.
     expect([...reached]).toContain('src/authz/access.py');
+  });
+
+  it('python-uv: a workspace-member src-layout import from a member-prefixed test resolves', async () => {
+    // The #223 shape: `packages/acme-platform/tests/test_acme_platform_util.py`
+    // imports `acme.util` — the filename heuristic can never associate the
+    // prefixed basename with `util.py`, so without member-root awareness the
+    // module reads as untested and the phantom gap gets grandfathered.
+    const reached = await buildReachable(
+      ['packages/acme-platform/tests/test_acme_platform_util.py'],
+      staged['python-uv'],
+    );
+    expect([...reached]).toContain('packages/acme-platform/src/acme/util.py');
   });
 });
 

--- a/test/fixtures/analysis/python-uv/env.example
+++ b/test/fixtures/analysis/python-uv/env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://user:pass@localhost/db
+API_TOKEN=replace-me

--- a/test/fixtures/analysis/python-uv/packages/acme-platform/pyproject.toml
+++ b/test/fixtures/analysis/python-uv/packages/acme-platform/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "acme-platform"
+version = "0.1.0"
+requires-python = ">=3.12"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/acme"]

--- a/test/fixtures/analysis/python-uv/packages/acme-platform/src/acme/__init__.py
+++ b/test/fixtures/analysis/python-uv/packages/acme-platform/src/acme/__init__.py
@@ -1,0 +1,1 @@
+from acme.util import answer  # noqa: F401

--- a/test/fixtures/analysis/python-uv/packages/acme-platform/src/acme/util.py
+++ b/test/fixtures/analysis/python-uv/packages/acme-platform/src/acme/util.py
@@ -1,0 +1,2 @@
+def answer() -> int:
+    return 42

--- a/test/fixtures/analysis/python-uv/packages/acme-platform/tests/test_acme_platform_util.py
+++ b/test/fixtures/analysis/python-uv/packages/acme-platform/tests/test_acme_platform_util.py
@@ -1,0 +1,8 @@
+# The #223 shape: a member-PREFIXED test basename (pytest unique-basename
+# constraint in a workspace) that the filename heuristic cannot associate
+# with src/acme/util.py — only the import graph can.
+from acme.util import answer
+
+
+def test_answer() -> None:
+    assert answer() == 42

--- a/test/fixtures/analysis/python-uv/pyproject.toml
+++ b/test/fixtures/analysis/python-uv/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "example-workspace"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = ["acme-platform"]
+
+[tool.uv.workspace]
+members = ["packages/acme-platform"]
+
+[tool.uv.sources]
+acme-platform = { workspace = true }

--- a/test/fixtures/analysis/python-uv/seed.py
+++ b/test/fixtures/analysis/python-uv/seed.py
@@ -1,0 +1,2 @@
+DEMO_PASSWORD = "password"
+api_key = "your-api-key"

--- a/test/interpreted-resolution-checks.test.ts
+++ b/test/interpreted-resolution-checks.test.ts
@@ -65,6 +65,52 @@ describe('pyResolutionCheck', () => {
     expect(pyResolutionCheck(ctx(cwd)).kind).toBe('clean');
   });
 
+  it('uv-workspace: a member package resolves via its own src root (dist name != import name)', () => {
+    // The #219 shape: distribution `acme-platform` provides package `acme` —
+    // derivable from NO manifest name, installed editable (no literal
+    // site-packages dir). Both the member's SELF-import and a cross-member
+    // consumer must resolve against the member's src root.
+    const cwd = repo({
+      [`${SITE}/`]: '',
+      'pyproject.toml':
+        '[project]\nname = "example-workspace"\ndependencies = ["acme-platform"]\n\n' +
+        '[tool.uv.workspace]\nmembers = ["packages/acme-platform"]\n',
+      'packages/acme-platform/pyproject.toml': '[project]\nname = "acme-platform"\n',
+      'packages/acme-platform/src/acme/__init__.py': 'from acme.util import answer\n',
+      'packages/acme-platform/src/acme/util.py': 'def answer():\n    return 42\n',
+      'consumer/__init__.py': '',
+      'consumer/app.py': 'import acme\n',
+    });
+    expect(pyResolutionCheck(ctx(cwd)).kind).toBe('clean');
+  });
+
+  it('uv-workspace: a flat-layout member (no src/) resolves via the member root', () => {
+    const cwd = repo({
+      [`${SITE}/`]: '',
+      'pyproject.toml': '[project]\nname = "ws"\n\n[tool.uv.workspace]\nmembers = ["libs/tool"]\n',
+      'libs/tool/pyproject.toml': '[project]\nname = "tool-dist"\n',
+      'libs/tool/toolpkg/__init__.py': '# package\n',
+      'consumer/__init__.py': '',
+      'consumer/app.py': 'import toolpkg\n',
+    });
+    expect(pyResolutionCheck(ctx(cwd)).kind).toBe('clean');
+  });
+
+  it('uv-workspace: a genuinely missing import still flags (member roots do not over-suppress)', () => {
+    const cwd = repo({
+      [`${SITE}/`]: '',
+      'pyproject.toml':
+        '[project]\nname = "ws"\n\n[tool.uv.workspace]\nmembers = ["packages/acme-platform"]\n',
+      'packages/acme-platform/pyproject.toml': '[project]\nname = "acme-platform"\n',
+      'packages/acme-platform/src/acme/__init__.py': 'import ghostpkg\n',
+    });
+    const r = pyResolutionCheck(ctx(cwd));
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.unresolved.map((u) => u.specifier)).toEqual(['ghostpkg']);
+    }
+  });
+
   it('the known import↔dist aliases resolve on the declared side (yaml → pyyaml)', () => {
     const cwd = repo({
       [`${SITE}/`]: '',

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -1,5 +1,43 @@
 import { describe, it, expect } from 'vitest';
-import { parseJsonStream, runDetached, runWithExit } from '../src/analyzers/tools/runner';
+import {
+  extractJsonPayload,
+  parseJsonStream,
+  runDetached,
+  runWithExit,
+} from '../src/analyzers/tools/runner';
+
+describe('extractJsonPayload', () => {
+  it('strips a tool banner ahead of a JSON object (the uv stdout-notice class)', () => {
+    const raw = 'The virtual environment /repo/.venv is out of date\n{"dependencies": []}';
+    expect(extractJsonPayload(raw)).toBe('{"dependencies": []}');
+  });
+
+  it('strips a banner ahead of a top-level array', () => {
+    const raw = 'warning: something\n[{"name": "requests"}]';
+    expect(extractJsonPayload(raw)).toBe('[{"name": "requests"}]');
+  });
+
+  it('returns clean JSON unchanged', () => {
+    expect(extractJsonPayload('{"a": 1}')).toBe('{"a": 1}');
+  });
+
+  it('drops trailing noise after the document', () => {
+    expect(extractJsonPayload('{"a": 1}\nDone in 2.3s')).toBe('{"a": 1}');
+  });
+
+  it('honors brackets inside string literals', () => {
+    const raw = 'note\n{"msg": "a } brace and ] bracket", "n": 1}';
+    expect(JSON.parse(extractJsonPayload(raw)!)).toEqual({ msg: 'a } brace and ] bracket', n: 1 });
+  });
+
+  it('returns null when no JSON document exists (caller keeps its parse-error path)', () => {
+    expect(extractJsonPayload('The virtual environment is broken')).toBeNull();
+  });
+
+  it('returns null for an unterminated document rather than a truncated slice', () => {
+    expect(extractJsonPayload('{"a": [1, 2')).toBeNull();
+  });
+});
 
 describe('parseJsonStream', () => {
   it('parses concatenated single-line objects', () => {


### PR DESCRIPTION
Part of the 4.3.6 release train (target: `release/4.3.6`).

## Root cause

Three field defects with one shared root: the Python adapters assumed a pip/venv single-project layout. A uv workspace has nested members, editable installs, distribution names that differ from import names, wrapper banners on stdout, and member-prefixed test basenames.

## Changes

- **`pySourceRoots` is workspace-aware** (the one definition of the repo's Python source roots): nested project roots discovered via the canonical exclusion-aware walker. Three consumers heal through their existing code paths:
  - the import-resolution floor no longer flags a workspace member's own package (#219)
  - the imports capability resolves member-crossing edges
  - test-gap association credits member-prefixed tests through the import graph (#223)
- **`extractJsonPayload` in runner.ts**: pip-audit's JSON is parsed from the first balanced document, so a wrapper banner on stdout no longer produces "dependency audit UNMEASURED: parse error" (#220). Payload-less output still lands in the disclosed parse-error path.
- **Class net**: new `python-uv` fixture row in the analysis matrix + resolution-floor uv cases pinning both bias directions (resolves member packages; still flags a genuinely missing import).

## Validation

- Full suite: 343 files / 5184 tests green; full local sweep green (build, typecheck, lint, format, arch, slop, self-guardrail).
- Live repro from #219 rebuilt with uv 0.11.21: runtime import OK, floor reads `clean` (was `unresolved`).

Closes #219. Closes #220. Closes #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)