### PR TITLE
WP2: baseline provenance consulted, not just recorded

### DIFF
--- a/src-templates/.github/workflows/dxkit-baseline-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh.yml
@@ -83,6 +83,13 @@ __DXKIT_CI_RUNTIME_SETUP__
           done
 
       - name: Recompute baseline
+        # The refresh's own `gh` calls need auth: the advisory decision PR and
+        # the allowlist-expiry notice issue. Without GH_TOKEN here they run
+        # unauthenticated and fail — the granted `issues: write` permission is
+        # useless to a step that never receives the token (the defect that let
+        # an in-horizon expiry produce zero issues, silently).
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
             DXKIT=./node_modules/.bin/vyuh-dxkit

--- a/src/baseline/attribution-gap.ts
+++ b/src/baseline/attribution-gap.ts
@@ -112,8 +112,23 @@ export function describeAttributionGap(gap: AttributionGap): string {
   );
 }
 
-/** The remedy every gap shares — one string so the three renderers agree. The
- *  gate stays refused (exit 1, never PASSED) until attribution is restored. */
-export const ATTRIBUTION_GAP_REMEDY =
-  'run `vyuh-dxkit update` (migrates + re-baselines) or `vyuh-dxkit baseline create --force` ' +
-  'to restore attribution; the guardrail refuses to pass until then';
+/** The remedy every gap shares — one derivation so the three renderers agree.
+ *  The gate stays refused (exit 1, never PASSED) until attribution is
+ *  restored. Workflow-aware (the provenance discipline): a repo with the CI
+ *  refresh lane is pointed at it, never at the local `--force` anti-pattern. */
+export function attributionGapRemedy(refreshLaneInstalled?: boolean): string {
+  if (refreshLaneInstalled) {
+    return (
+      'dispatch the baseline-refresh workflow (workflow_dispatch) or merge to the default ' +
+      'branch to re-capture the anchor from CI and restore attribution; the guardrail ' +
+      'refuses to pass until then'
+    );
+  }
+  return (
+    'run `vyuh-dxkit update` (migrates + re-baselines) or `vyuh-dxkit baseline create --force` ' +
+    'to restore attribution; the guardrail refuses to pass until then'
+  );
+}
+
+/** Back-compat constant (no-refresh-lane wording). */
+export const ATTRIBUTION_GAP_REMEDY = attributionGapRemedy();

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -33,7 +33,7 @@ import type {
   GuardrailCheckResult,
   NotObservedDisclosure,
 } from './check';
-import { ATTRIBUTION_GAP_REMEDY, describeAttributionGap } from './attribution-gap';
+import { attributionGapRemedy, describeAttributionGap } from './attribution-gap';
 import type { AttributionGap } from './attribution-gap';
 import {
   EXPIRY_PROJECTION_REMEDY,
@@ -44,6 +44,7 @@ import type { ExpiryProjection } from './expiry-projection';
 import { recallDriftRemedy, describeRecallDrift } from './recall';
 import type { BrownfieldPolicy } from './policy';
 import type { FindingStatus, MatchReason } from './types';
+import { describeBaselineSuspect } from './provenance';
 import { DEFER_ADVISORY_EXPIRY_DAYS } from '../allowlist/categories';
 import { failingFloorDebt } from './floor-debt';
 import { describeBrokenIntegration } from '../analyzers/flow/gate';
@@ -320,7 +321,7 @@ export function renderConsole(result: GuardrailCheckResult): string {
     for (const gap of result.attributionGaps) {
       lines.push(`  · ${describeAttributionGap(gap)}`);
     }
-    lines.push(`  · ${ATTRIBUTION_GAP_REMEDY}`);
+    lines.push(`  · ${attributionGapRemedy(result.envelopeDrift.refreshLaneInstalled)}`);
     lines.push('');
   }
   if (suppressed.length > 0) {
@@ -433,6 +434,12 @@ export function renderConsole(result: GuardrailCheckResult): string {
   const counts = verdictCounts(result);
   lines.push(`  Verdict:     ${counts.verdict}`);
   lines.push(`  Exit code:   ${counts.exitCode}`);
+  // The stale-anchor reframe (#222) — printed WITH the verdict so a reader
+  // never acts on a confident BLOCKED without seeing that the anchor, not the
+  // change, is the likely cause.
+  if (result.baselineSuspect) {
+    lines.push(`  ⚠ ${describeBaselineSuspect(result.baselineSuspect)}`);
+  }
   if (result.depVulnsUnmeasured) {
     lines.push('');
     lines.push(
@@ -1155,7 +1162,7 @@ function formatDrift(drift: EnvelopeDrift): string[] {
   }
   if (drift.recallDrift.length > 0) {
     out.push(
-      `${drift.recallDrift.length} kind(s) not attributable — ${recallDriftRemedy(drift.baselineCapturedIn)}`,
+      `${drift.recallDrift.length} kind(s) not attributable — ${recallDriftRemedy(drift.baselineCapturedIn, drift.refreshLaneInstalled)}`,
     );
   }
   for (const d of drift.coverageDrift) {
@@ -1689,6 +1696,12 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
   const counts = verdictCounts(result);
   lines.push(`## Guardrail: ${counts.verdict}`);
   lines.push('');
+  if (result.baselineSuspect) {
+    // The stale-anchor reframe (#222), directly under the heading — a PR
+    // reader must see it before triaging the finding tables.
+    lines.push(`> ⚠️ ${escapeMd(describeBaselineSuspect(result.baselineSuspect))}`);
+    lines.push('');
+  }
   const extra = extraGateTallies(result);
   lines.push(
     summarySentence(
@@ -1709,7 +1722,9 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     for (const gap of result.attributionGaps) {
       lines.push(`> - ${escapeMd(describeAttributionGap(gap))}`);
     }
-    lines.push(`> - Remedy: ${escapeMd(ATTRIBUTION_GAP_REMEDY)}`);
+    lines.push(
+      `> - Remedy: ${escapeMd(attributionGapRemedy(result.envelopeDrift.refreshLaneInstalled))}`,
+    );
     lines.push('');
     if (unattributable.length > 0) {
       lines.push('### Unattributable findings');

--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -96,6 +96,12 @@ import type { FlowGateMode } from '../analyzers/flow/config';
 import { isSanitized } from './sanitize';
 import type { BaselineEntry, FindingId, FindingSeverity, MatchPair, MatchResult } from './types';
 import { CURRENT_IDENTITY_SCHEME } from './types';
+import {
+  refreshWorkflowInstalled,
+  detectBaselineSuspect,
+  readBaselineProvenance,
+} from './provenance';
+import type { BaselineSuspect } from './provenance';
 import type { SecurityAggregate } from '../analyzers/security/aggregator';
 import {
   computeAllowlistDelta,
@@ -281,6 +287,11 @@ export interface EnvelopeDrift {
    *  root fix is the CI-canonical re-capture; renderers lead there instead of
    *  a local `--force`. Absent on pre-4.2 baselines (unknown provenance). */
   readonly baselineCapturedIn?: 'ci' | 'local';
+  /** Whether the CI baseline-refresh workflow is installed (the provenance
+   *  module's one probe). Drives the drift/attribution-gap REMEDY: a repo
+   *  with the lane is pointed at a CI re-capture, never at the local
+   *  `--force` anti-pattern the docs warn about. */
+  readonly refreshLaneInstalled?: boolean;
   /** Scanners whose availability flipped between baseline capture and
    *  this check. A tool missing at baseline but present now means the
    *  baseline never covered that category — its findings surface as new
@@ -421,6 +432,11 @@ export interface GuardrailCheckResult {
    * mismatch gets. Empty on a healthy run. See `src/baseline/attribution-gap.ts`.
    */
   readonly attributionGaps: ReadonlyArray<AttributionGap>;
+  /** Present when the ADDED-finding pattern matches the stale-anchor
+   *  signature (most net-new findings in files the diff never touched —
+   *  #222). Disclosure only: reframes a mechanically-correct BLOCKED as
+   *  "baseline suspect" with the workflow-aware re-anchor remedy. */
+  readonly baselineSuspect?: BaselineSuspect;
   /**
    * What this run's ACTIVE allowlist suppressions will do when their windows
    * expire — how many will block, how many will warn, and how soon. REQUIRED so
@@ -857,7 +873,7 @@ export async function runGuardrailCheck(
   const severityByCurrentId = buildSeverityIndex(current.aggregate);
   const maliciousByCurrentId = buildMaliciousIndex(current.aggregate);
   const reachableByCurrentId = buildReachableIndex(current.aggregate);
-  const envelopeDrift = diffEnvelopes(baseline, current, mode.mode);
+  const envelopeDrift = diffEnvelopes(baseline, current, mode.mode, refreshWorkflowInstalled(cwd));
 
   // Per-kind recall attribution (Rule 19) drives the per-pair `recallDrifted`
   // signal. A pair is in drift only when the inputs that determine ITS kind
@@ -1153,6 +1169,26 @@ export async function runGuardrailCheck(
   // while one exists the run cannot render PASSED.
   const attributionGaps = collectAttributionGaps(filteredPairs, envelopeDrift.recallDrift);
 
+  // Baseline-suspect staleness disclosure (#222): a large share of ADDED
+  // findings in files the diff never touched is a stale-anchor signature (the
+  // baseline predates the base branch's recent history), not developer fault.
+  // Committed modes only — ref-based re-gathers the prior side at the PR's own
+  // base, so there is no stale-anchor concept. Disclosure only: the verdict is
+  // mechanically correct either way; this reframes it and names the honest
+  // remedy (workflow-aware via the provenance module).
+  const baselineSuspect =
+    mode.mode !== 'ref-based'
+      ? detectBaselineSuspect({
+          addedFiles: filteredPairs
+            .filter((p) => p.classification.status === 'added' && p.file !== undefined)
+            .map((p) => p.file!),
+          changedFiles: baseline.repo.commitSha
+            ? computeChangedFiles(cwd, baseline.repo.commitSha)
+            : null,
+          provenance: readBaselineProvenance(cwd, baseline),
+        })
+      : null;
+
   // Aggregate the not-observed pairs into per-reason disclosures for the
   // renderers. Aggregate ON PURPOSE: a repo-scale lint backlog is tens of
   // thousands of entries, and listing them (the "Resolved (18406)" table this
@@ -1200,6 +1236,7 @@ export async function runGuardrailCheck(
     warns:
       baseWarns || flowGate.warns || schemaDriftGate.warns || dupGate.warns || pairedGate.warns,
     attributionGaps,
+    ...(baselineSuspect ? { baselineSuspect } : {}),
     suppressionExpiry,
     notObserved: notObservedDisclosures,
     allowlistDelta,
@@ -1323,6 +1360,7 @@ function diffEnvelopes(
   baseline: BaselineFile,
   current: CurrentScan,
   mode: ResolvedMode['mode'],
+  refreshLaneInstalled?: boolean,
 ): EnvelopeDrift {
   const toolVersionDiffs: Array<{
     tool: string;
@@ -1359,6 +1397,7 @@ function diffEnvelopes(
     toolVersionDiffs,
     recallDrift,
     ...(baseline.capturedIn ? { baselineCapturedIn: baseline.capturedIn } : {}),
+    ...(refreshLaneInstalled !== undefined ? { refreshLaneInstalled } : {}),
     // Ref-based mode: the prior side is a fresh gather in a bare worktree,
     // so its "coverage" records artifact-dependent tools (a node_modules
     // linter, the coverage report) as missing BY CONSTRUCTION — not as a

--- a/src/baseline/provenance.ts
+++ b/src/baseline/provenance.ts
@@ -1,0 +1,122 @@
+/**
+ * Baseline PROVENANCE — the ONE place that answers "where did this repo's
+ * committed baseline come from, and is it still a sound anchor?" (Rule 2.30
+ * applied to baseline freshness: `capturedIn`, `createdAt`, and the CI
+ * refresh lane's presence were all RECORDED, but no consumer read them — so
+ * the guardrail issued a confident BLOCKED over a stale anchor, doctor
+ * scored a local-anchor repo healthy, and the drift remediation recommended
+ * the documented anti-pattern.)
+ *
+ * Consumers, all through this module:
+ *   - `recallDriftRemedy` (the guardrail's envelope-drift copy) — recommends
+ *     the CI refresh lane when it exists, `--force` only when it does not;
+ *   - doctor's local-anchor check — a `capturedIn: local` committed baseline
+ *     with no refresh workflow is the exact combination getting-started.md
+ *     warns about;
+ *   - the guardrail's baseline-suspect staleness disclosure (`check.ts`) —
+ *     a delta wave in files the diff never touched is a stale-anchor
+ *     signature, not developer fault.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Repo-relative path of the CI baseline-refresh workflow. The canonical
+ * declaration lives on the `ci-baseline-refresh` managed surface
+ * (`src/managed-artifacts.ts`); duplicated here as a constant (NOT a runtime
+ * import — that would pull the whole ship-installer graph into every
+ * guardrail run) and pinned against the registry by
+ * `test/baseline/provenance.test.ts`.
+ */
+export const REFRESH_WORKFLOW_RELPATH = '.github/workflows/dxkit-baseline-refresh.yml';
+
+/** Is the CI baseline-refresh lane installed in this repo? */
+export function refreshWorkflowInstalled(cwd: string): boolean {
+  try {
+    return fs.existsSync(path.join(cwd, REFRESH_WORKFLOW_RELPATH));
+  } catch {
+    return false;
+  }
+}
+
+/** The provenance facts a consumer branches on. */
+export interface BaselineProvenance {
+  /** Where the committed baseline was captured (absent on pre-provenance
+   *  baselines — treated as unknown, never assumed CI). */
+  readonly capturedIn?: 'ci' | 'local';
+  /** ISO capture timestamp from the baseline file. */
+  readonly createdAt?: string;
+  /** Whether the CI refresh lane exists — decides which re-baseline remedy
+   *  is honest to recommend. */
+  readonly refreshWorkflowInstalled: boolean;
+}
+
+export function readBaselineProvenance(
+  cwd: string,
+  baseline?: { readonly capturedIn?: 'ci' | 'local'; readonly createdAt?: string },
+): BaselineProvenance {
+  return {
+    ...(baseline?.capturedIn !== undefined ? { capturedIn: baseline.capturedIn } : {}),
+    ...(baseline?.createdAt !== undefined ? { createdAt: baseline.createdAt } : {}),
+    refreshWorkflowInstalled: refreshWorkflowInstalled(cwd),
+  };
+}
+
+/**
+ * The staleness signature (#222): a large share of ADDED findings living in
+ * files the diff under review never touched. Mechanically each finding has no
+ * baseline match, but the truer cause is an anchor that predates the base
+ * branch's recent history — the developer did not introduce a wave of
+ * findings into files they never edited. Pure; thresholds deliberately
+ * conservative (a disclosure, never a gating change).
+ */
+export interface BaselineSuspect {
+  /** Added findings in files the diff did not touch. */
+  readonly untouchedAdded: number;
+  /** Total added findings considered. */
+  readonly totalAdded: number;
+  /** The baseline's capture timestamp, for the disclosure line. */
+  readonly createdAt?: string;
+  /** Human remedy — re-baseline deliberately on the base branch. */
+  readonly remedy: string;
+}
+
+/** Minimum added findings before the signature is even evaluated — small
+ *  deltas are triaged by hand and need no meta-disclosure. */
+const SUSPECT_MIN_ADDED = 8;
+/** Fraction of added findings outside the diff at/above which the anchor is
+ *  suspect. */
+const SUSPECT_MIN_FRACTION = 0.6;
+
+/** Shared phrasing (Rule 2) — console, markdown, and the receipt agree. */
+export function describeBaselineSuspect(s: BaselineSuspect): string {
+  const anchor = s.createdAt ? ` (anchor captured ${s.createdAt.slice(0, 10)})` : '';
+  return (
+    `baseline suspect: ${s.untouchedAdded} of ${s.totalAdded} net-new findings are in files ` +
+    `this change does not touch${anchor} — likely a stale anchor, not this change; ${s.remedy}`
+  );
+}
+
+export function detectBaselineSuspect(args: {
+  /** Files (repo-relative) of each ADDED-status finding, one per finding. */
+  readonly addedFiles: readonly string[];
+  /** The diff's changed-file set; null/undefined = unknowable → no claim. */
+  readonly changedFiles: readonly string[] | null | undefined;
+  readonly provenance: BaselineProvenance;
+}): BaselineSuspect | null {
+  const { addedFiles, changedFiles, provenance } = args;
+  if (!changedFiles) return null; // cannot attribute either way — say nothing
+  if (addedFiles.length < SUSPECT_MIN_ADDED) return null;
+  const changed = new Set(changedFiles);
+  const untouched = addedFiles.filter((f) => !changed.has(f)).length;
+  if (untouched / addedFiles.length < SUSPECT_MIN_FRACTION) return null;
+  const remedy = provenance.refreshWorkflowInstalled
+    ? 'dispatch the baseline-refresh workflow (or merge to the default branch) to re-anchor from CI'
+    : 'run `vyuh-dxkit baseline create --force` on the base branch to re-anchor deliberately';
+  return {
+    untouchedAdded: untouched,
+    totalAdded: addedFiles.length,
+    ...(provenance.createdAt !== undefined ? { createdAt: provenance.createdAt } : {}),
+    remedy,
+  };
+}

--- a/src/baseline/recall.ts
+++ b/src/baseline/recall.ts
@@ -324,7 +324,24 @@ export function describeRecallDrift(drift: RecallDrift): string {
  * local `--force` (which would just stamp THIS machine's environment) is the
  * fallback, not the headline.
  */
-export function recallDriftRemedy(capturedIn?: 'ci' | 'local'): string {
+export function recallDriftRemedy(
+  capturedIn?: 'ci' | 'local',
+  refreshLaneInstalled?: boolean,
+): string {
+  // A repo WITH the CI refresh lane must be pointed at it, never at a local
+  // `--force`: baselines are captured CI-side by design (stable scanner
+  // versions), and a local force-capture bakes this machine's toolchain into
+  // the committed anchor — the exact cause of the NEXT round of envelope
+  // drift. In an agent-heavy workflow the remediation copy IS the policy, so
+  // recommending the anti-pattern trains the loop to reintroduce the problem.
+  if (refreshLaneInstalled) {
+    return (
+      'the CI baseline-refresh lane is installed — dispatch it (workflow_dispatch) or ' +
+      'merge to the default branch to re-capture the anchor canonically. Avoid a local ' +
+      "`vyuh-dxkit baseline create --force`: it bakes this machine's toolchain into the " +
+      'committed baseline. These findings warn instead of blocking until then'
+    );
+  }
   if (capturedIn === 'local') {
     return (
       'this baseline was captured on a developer machine — the CI refresh surface ' +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2679,6 +2679,20 @@ export async function run(argv: string[]): Promise<void> {
               logger.warn(`  ${result.decision.note}`);
             }
           }
+          // The expiry-notice lane's outcome is part of the refresh's contract
+          // ("fail-open, always disclosed") — an `unavailable` that never
+          // reaches the log is how a granted-permission/no-token workflow
+          // miss stayed invisible for a full horizon. `note` is always
+          // populated, whichever way it went.
+          if (result.expiryNotice && result.expiryNotice.outcome !== 'disabled') {
+            const n = result.expiryNotice;
+            const url = n.issueUrl ? ` — ${n.issueUrl}` : '';
+            if (n.outcome === 'unavailable') {
+              logger.warn(`  Expiry notice: ${n.note}`);
+            } else {
+              logger.info(`  Expiry notice: ${n.note}${url}`);
+            }
+          }
         } catch (err) {
           logger.fail((err as Error).message);
           process.exit(1);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -10,6 +10,8 @@ import { dxkitCli } from './self-invocation';
 import * as logger from './logger';
 import { resolveBaselineMode } from './baseline/modes';
 import { anchorBranchStatus, anchorStalenessProblem } from './baseline/anchor';
+import { readBaselineFile } from './baseline/baseline-file';
+import { refreshWorkflowInstalled } from './baseline/provenance';
 import { loadPolicyFromCwd } from './baseline/policy';
 import { detectEnforcement } from './enforcement';
 import { detectInstalledRefreshTransport, resolveDefaultBranch } from './ship-installers';
@@ -562,6 +564,52 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
     }
   }
 
+  // 0c. Baseline capture provenance (#224). A committed baseline captured
+  // LOCALLY, with no CI refresh workflow installed, is the exact combination
+  // getting-started.md warns about: the anchor bakes the developer machine's
+  // scanner versions in, so every PR gate risks tooling-drift noise against
+  // CI's toolchain. Both facts are already recorded — the baseline's
+  // `capturedIn` and the workflow's presence — this check just reads them
+  // (the provenance module, one probe).
+  {
+    const baselineFile = path.join(cwd, '.dxkit', 'baselines', 'main.json');
+    if (fs.existsSync(baselineFile)) {
+      let capturedIn: 'ci' | 'local' | undefined;
+      try {
+        capturedIn = readBaselineFile(baselineFile).capturedIn;
+      } catch {
+        /* unreadable baseline is covered by other checks */
+      }
+      if (capturedIn === 'local') {
+        const laneInstalled = refreshWorkflowInstalled(cwd);
+        checks.push({
+          label: laneInstalled
+            ? 'committed baseline was captured locally (CI refresh lane installed — supersede it)'
+            : 'committed baseline was captured locally and no CI refresh workflow is installed',
+          ok: false,
+          tier: 'operational',
+          fix: laneInstalled
+            ? {
+                hint:
+                  'The committed anchor was captured on a developer machine; the CI refresh ' +
+                  'lane exists, so dispatch it (workflow_dispatch) or merge to the default ' +
+                  'branch — the CI capture supersedes the local anchor and retires the ' +
+                  'tooling-drift risk.',
+                skill: 'dxkit-fix',
+              }
+            : {
+                hint:
+                  "A locally captured anchor bakes this machine's scanner versions into the " +
+                  "committed baseline — expect TOOLING-DRIFT noise whenever CI's versions " +
+                  'differ. Install the CI refresh lane so captures happen where the gate runs.',
+                command: dxkitCli('init --with-baseline-refresh'),
+                skill: 'dxkit-fix',
+              },
+        });
+      }
+    }
+  }
+
   // 1. Hooks active. Two independent conditions must BOTH hold for the
   // pre-push guardrail to actually fire: `core.hooksPath` set to
   // `.githooks` AND the hook file carrying the executable bit. Git
@@ -813,7 +861,7 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
       // answer never fails the check — dxkit can't read protection when gh is
       // absent/unauthenticated or the token lacks repo read scope.
       checks.push({
-        label: `guardrail enforcement on '${enf.branch}' — not verified (gh unavailable or lacks repo read access)`,
+        label: `guardrail enforcement on '${enf.branch}' — not verified (${enf.unverifiedReason ?? 'gh unavailable or lacks repo read access'})`,
         ok: true,
         tier: 'operational',
       });

--- a/src/enforcement.ts
+++ b/src/enforcement.ts
@@ -94,6 +94,11 @@ export interface EnforcementReads {
   readonly rules: EffectiveRule[];
   /** Did the ruleset read succeed? */
   readonly rulesKnown: boolean;
+  /** The classic-protection read's failure, when it failed non-definitively.
+   *  Lets the classifier tell a Free-plan 403 ("Upgrade to Pro" on private
+   *  repos — the API refuses the read regardless of token scope) apart from
+   *  a missing/underscoped gh, so doctor names the true enforcement gap. */
+  readonly classicError?: { readonly httpStatus?: number; readonly message: string };
 }
 
 export interface EnforcementState {
@@ -121,6 +126,11 @@ export interface EnforcementState {
    *  true, `protect` must not create a conflicting classic rule — the guardrail
    *  belongs in the ruleset. */
   readonly rulesetGoverned: boolean;
+  /** Populated when `probed` is false: the specific reason no definitive
+   *  answer exists, phrased for doctor. Distinguishes the GitHub Free-plan
+   *  403 on private repos (protection unsupported/unreadable at this plan)
+   *  from "gh unavailable or lacks repo read access". */
+  readonly unverifiedReason?: string;
 }
 
 /** Rule types that reject a direct push (mirror of classic requiresChecks ||
@@ -184,6 +194,7 @@ export function classifyEnforcement(
       guardrailRequired: false,
       guardrailContextLegacyOnly: false,
       rulesetGoverned: false,
+      unverifiedReason: 'gh unavailable or lacks repo read access',
     };
   }
   const directPushBlocked =
@@ -197,6 +208,25 @@ export function classifyEnforcement(
   const bothRead = reads.classicKnown && reads.rulesKnown;
   const probed = sawProtection || bothRead;
 
+  // When no definitive answer exists, say WHY — the Free-plan 403 on a
+  // private repo means "this plan cannot have (or expose) required checks
+  // here", a materially different enforcement gap than a missing gh.
+  let unverifiedReason: string | undefined;
+  if (!probed) {
+    const err = reads.classicError;
+    if (err && err.httpStatus === 403 && /upgrade to/i.test(err.message)) {
+      unverifiedReason =
+        "GitHub returned 403 'Upgrade to Pro' — this plan does not support branch " +
+        'protection on private repos, so required checks cannot be verified (or enforced) here';
+    } else if (err) {
+      unverifiedReason = `branch-protection read failed${
+        err.httpStatus ? ` (HTTP ${err.httpStatus})` : ''
+      } — gh may lack repo read access`;
+    } else {
+      unverifiedReason = 'gh unavailable or lacks repo read access';
+    }
+  }
+
   return {
     branch,
     probed,
@@ -204,6 +234,7 @@ export function classifyEnforcement(
     guardrailRequired,
     guardrailContextLegacyOnly,
     rulesetGoverned,
+    ...(unverifiedReason !== undefined ? { unverifiedReason } : {}),
   };
 }
 
@@ -227,6 +258,7 @@ export function probeEnforcementReads(cwd: string, branch: string): EnforcementR
 
   let classic: ClassicProtection | null = null;
   let classicKnown = false;
+  let classicError: { httpStatus?: number; message: string } | undefined;
   try {
     classic = ghApi(`repos/{owner}/{repo}/branches/${branch}/protection`, {
       cwd,
@@ -235,8 +267,15 @@ export function probeEnforcementReads(cwd: string, branch: string): EnforcementR
     classicKnown = true;
   } catch (e) {
     // 404 = no classic protection rule (definitive). Anything else (403 without
-    // admin scope, network) leaves classic unknown.
+    // admin scope, the Free-plan private-repo refusal, network) leaves classic
+    // unknown — captured so the classifier can name the reason.
     if (e instanceof GhError && e.httpStatus === 404) classicKnown = true;
+    else if (e instanceof GhError) {
+      classicError = {
+        ...(e.httpStatus !== undefined ? { httpStatus: e.httpStatus } : {}),
+        message: e.message,
+      };
+    }
   }
 
   let rules: EffectiveRule[] = [];
@@ -257,7 +296,13 @@ export function probeEnforcementReads(cwd: string, branch: string): EnforcementR
   if (!classicKnown && !rulesKnown) {
     throw new GhError('could not read branch protection (classic or ruleset)');
   }
-  return { classic, classicKnown, rules, rulesKnown };
+  return {
+    classic,
+    classicKnown,
+    rules,
+    rulesKnown,
+    ...(classicError !== undefined ? { classicError } : {}),
+  };
 }
 
 /**

--- a/test/baseline-anchor.test.ts
+++ b/test/baseline-anchor.test.ts
@@ -122,6 +122,46 @@ describe('classifyEnforcement', () => {
     expect(s.directPushBlocked).toBe(false);
     expect(s.guardrailRequired).toBe(false);
     expect(s.rulesetGoverned).toBe(false);
+    expect(s.unverifiedReason).toContain('gh unavailable');
+  });
+
+  it("the Free-plan 403 ('Upgrade to Pro') is named as a plan gap, not a gh problem", () => {
+    // A private repo on GitHub Free 403s the classic-protection read with an
+    // upgrade message regardless of token scope — the true enforcement gap is
+    // "this plan cannot require checks here", which doctor must say instead
+    // of the misleading "gh unavailable or lacks repo read access".
+    const s = classifyEnforcement(
+      'main',
+      reads({
+        classicKnown: false,
+        classicError: {
+          httpStatus: 403,
+          message: 'Upgrade to GitHub Pro or make this repository public to enable this feature.',
+        },
+      }),
+    );
+    expect(s.probed).toBe(false);
+    expect(s.unverifiedReason).toContain('Upgrade to Pro');
+    expect(s.unverifiedReason).toContain('plan');
+    expect(s.unverifiedReason).not.toContain('gh unavailable');
+  });
+
+  it('an other-403 read failure names the HTTP status and the scope hypothesis', () => {
+    const s = classifyEnforcement(
+      'main',
+      reads({
+        classicKnown: false,
+        classicError: { httpStatus: 403, message: 'Resource not accessible by integration' },
+      }),
+    );
+    expect(s.probed).toBe(false);
+    expect(s.unverifiedReason).toContain('HTTP 403');
+  });
+
+  it('a definitive answer carries no unverifiedReason', () => {
+    const s = classifyEnforcement('main', reads({}));
+    expect(s.probed).toBe(true);
+    expect(s.unverifiedReason).toBeUndefined();
   });
   it('both mechanisms read, neither protects → confidently unprotected', () => {
     const s = classifyEnforcement('main', reads({}));

--- a/test/baseline/provenance.test.ts
+++ b/test/baseline/provenance.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The baseline-provenance module (#222 / #224 / #227 + defects A/B class):
+ * one place answers "where did the baseline come from, and is it still a
+ * sound anchor?", consumed by the drift remedies, doctor, and the guardrail's
+ * baseline-suspect disclosure.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  REFRESH_WORKFLOW_RELPATH,
+  refreshWorkflowInstalled,
+  readBaselineProvenance,
+  detectBaselineSuspect,
+  describeBaselineSuspect,
+} from '../../src/baseline/provenance';
+import { MANAGED_SHIP_SURFACES } from '../../src/managed-artifacts';
+import { attributionGapRemedy } from '../../src/baseline/attribution-gap';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+function tmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-provenance-'));
+  dirs.push(d);
+  return d;
+}
+
+describe('refresh-workflow path parity (Rule 2.30)', () => {
+  it('the provenance constant matches the ci-baseline-refresh managed surface', () => {
+    // The path is declared canonically on the managed surface; the provenance
+    // module duplicates it as a constant (a runtime import would pull the
+    // ship-installer graph into every guardrail run). This pin is what makes
+    // the duplication safe: they cannot drift silently.
+    const surface = MANAGED_SHIP_SURFACES.find((s) => s.id === 'ci-baseline-refresh');
+    expect(surface).toBeDefined();
+    expect(surface!.artifacts({} as never)).toContain(REFRESH_WORKFLOW_RELPATH);
+  });
+
+  it('detects presence/absence of the workflow file', () => {
+    const cwd = tmp();
+    expect(refreshWorkflowInstalled(cwd)).toBe(false);
+    fs.mkdirSync(path.join(cwd, '.github', 'workflows'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, REFRESH_WORKFLOW_RELPATH), 'name: refresh\n');
+    expect(refreshWorkflowInstalled(cwd)).toBe(true);
+    expect(readBaselineProvenance(cwd, { capturedIn: 'local' })).toMatchObject({
+      capturedIn: 'local',
+      refreshWorkflowInstalled: true,
+    });
+  });
+});
+
+describe('detectBaselineSuspect (#222 — the stale-anchor signature)', () => {
+  const provenance = { refreshWorkflowInstalled: false, createdAt: '2026-07-01T00:00:00Z' };
+  const files = (n: number, prefix: string) =>
+    Array.from({ length: n }, (_, i) => `${prefix}/f${i}.ts`);
+
+  it('fires when most added findings live in files the diff never touched', () => {
+    const s = detectBaselineSuspect({
+      addedFiles: [...files(9, 'untouched'), 'touched/a.ts'],
+      changedFiles: ['touched/a.ts'],
+      provenance,
+    });
+    expect(s).not.toBeNull();
+    expect(s!.untouchedAdded).toBe(9);
+    expect(s!.totalAdded).toBe(10);
+    expect(s!.remedy).toContain('baseline create --force'); // no lane installed
+    const text = describeBaselineSuspect(s!);
+    expect(text).toContain('9 of 10');
+    expect(text).toContain('2026-07-01');
+  });
+
+  it('recommends the CI refresh lane when it is installed', () => {
+    const s = detectBaselineSuspect({
+      addedFiles: files(10, 'untouched'),
+      changedFiles: ['touched/a.ts'],
+      provenance: { ...provenance, refreshWorkflowInstalled: true },
+    });
+    expect(s!.remedy).toContain('baseline-refresh workflow');
+    expect(s!.remedy).not.toContain('--force');
+  });
+
+  it('stays silent on small deltas (hand-triaged, no meta-disclosure)', () => {
+    expect(
+      detectBaselineSuspect({
+        addedFiles: files(5, 'untouched'),
+        changedFiles: ['touched/a.ts'],
+        provenance,
+      }),
+    ).toBeNull();
+  });
+
+  it('stays silent when the added findings mostly sit in the diff (developer-introduced)', () => {
+    const touched = files(8, 'touched');
+    expect(
+      detectBaselineSuspect({
+        addedFiles: [...touched, 'untouched/x.ts'],
+        changedFiles: touched,
+        provenance,
+      }),
+    ).toBeNull();
+  });
+
+  it('makes no claim when the changed set is unknowable', () => {
+    expect(
+      detectBaselineSuspect({ addedFiles: files(20, 'u'), changedFiles: null, provenance }),
+    ).toBeNull();
+  });
+});
+
+describe('attributionGapRemedy (workflow-aware)', () => {
+  it('points at the refresh workflow when installed, never a local --force', () => {
+    const withLane = attributionGapRemedy(true);
+    expect(withLane).toContain('baseline-refresh workflow');
+    expect(withLane).not.toContain('--force');
+    // Without the lane, the existing remedy is unchanged.
+    expect(attributionGapRemedy(false)).toContain('baseline create --force');
+    expect(attributionGapRemedy()).toContain('baseline create --force');
+  });
+});
+
+describe('refresh workflow template carries GH_TOKEN on the recompute step (defect class: per-template drift)', () => {
+  it('the recompute step exports GH_TOKEN so syncExpiryNotice / the decision PR can call gh', () => {
+    const template = fs.readFileSync(
+      path.join(
+        __dirname,
+        '..',
+        '..',
+        'src-templates',
+        '.github',
+        'workflows',
+        'dxkit-baseline-refresh.yml',
+      ),
+      'utf8',
+    );
+    const recompute = template.slice(template.indexOf('- name: Recompute baseline'));
+    const step = recompute.slice(0, recompute.indexOf('- name:', 10));
+    expect(step).toContain('GH_TOKEN');
+  });
+});

--- a/test/baseline/recall.test.ts
+++ b/test/baseline/recall.test.ts
@@ -223,4 +223,20 @@ describe('recallDriftRemedy (4.2 CI-canonical capture)', () => {
       expect(recallDriftRemedy(p)).not.toContain('developer machine');
     }
   });
+
+  it('a repo WITH the CI refresh lane is pointed at the workflow, never at a local --force', async () => {
+    // The remediation copy IS the policy in an agent workflow — recommending a
+    // local `--force` in a repo whose baselines are CI-captured trains the
+    // loop to bake a developer toolchain into the anchor (the drift cause).
+    const { recallDriftRemedy } = await import('../../src/baseline/recall');
+    for (const p of ['ci', 'local', undefined] as const) {
+      const remedy = recallDriftRemedy(p, true);
+      expect(remedy).toContain('baseline-refresh');
+      expect(remedy).toContain('workflow_dispatch');
+      // --force may be NAMED only as the thing to avoid.
+      expect(remedy).toContain('Avoid a local');
+    }
+    // Without the lane, behavior is unchanged.
+    expect(recallDriftRemedy('ci', false)).toContain('baseline create --force');
+  });
 });


### PR DESCRIPTION
Part of the 4.3.6 release train (target: `release/4.3.6`).

## Root cause

The baseline records `capturedIn` and `createdAt`, and the CI refresh workflow's presence is a stat call — but no consumer read them. So the guardrail issued a confident BLOCKED over a stale anchor, doctor scored a local-anchor repo 6/7, and the drift remediation recommended the local `--force` the docs call an anti-pattern.

## Changes

- **New `src/baseline/provenance.ts`** — the one module answering "where did the baseline come from, and is it still a sound anchor?". Workflow path pinned against the `ci-baseline-refresh` managed surface by a parity test.
- **Baseline-suspect disclosure (#222)**: most net-new findings in files the diff never touched reframes the verdict ("baseline suspect: M of N net-new findings are in files this change does not touch") with a workflow-aware re-anchor remedy. Disclosure only; conservative thresholds; unknown changed set makes no claim. Rendered in console summary + markdown heading.
- **Workflow-aware remedies (#227)**: `recallDriftRemedy` and `attributionGapRemedy` point a repo with the CI refresh lane at workflow_dispatch / merge — never at a local `--force`.
- **doctor (#224)**: flags a locally captured committed baseline (lane installed → supersede from CI; absent → install the lane). Also distinguishes the GitHub Free-plan 403 ("Upgrade to Pro") from "gh unavailable" via the enforcement classifier's `unverifiedReason`.
- **Expiry-notice render (field defect)**: `baseline refresh` now prints `result.expiryNotice` — the silent-render gap that hid the next item for a full horizon.
- **Refresh template GH_TOKEN (field defect)**: the recompute step exports `GH_TOKEN` so `syncExpiryNotice` and the advisory decision PR can call `gh`; the template is the only lane template that lacked it. Pinned by test (the full cross-template parity net lands in WP4).

## Validation

Full local sweep green (build, typecheck, lint, format, arch, slop, 344 files / 5184 tests, self-guardrail).

Closes #222. Closes #224. Closes #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)