### PR TITLE
WP4: lane outcomes derive from land results; token parity across templates

### DIFF
--- a/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
@@ -87,6 +87,12 @@ __DXKIT_CI_RUNTIME_SETUP__
           done
 
       - name: Recompute baseline
+        # The refresh's own `gh` calls need auth: the advisory decision PR and
+        # the allowlist-expiry notice issue. Without GH_TOKEN here they run
+        # unauthenticated and fail silently (the per-template-drift class the
+        # lane-token parity test pins).
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
             DXKIT=./node_modules/.bin/vyuh-dxkit

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
@@ -82,6 +82,12 @@ __DXKIT_CI_RUNTIME_SETUP__
           done
 
       - name: Recompute baseline
+        # The refresh's own `gh` calls need auth: the advisory decision PR and
+        # the allowlist-expiry notice issue. Without GH_TOKEN here they run
+        # unauthenticated and fail silently (the per-template-drift class the
+        # lane-token parity test pins).
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
             DXKIT=./node_modules/.bin/vyuh-dxkit

--- a/src-templates/.github/workflows/dxkit-baseline-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh.yml
@@ -35,6 +35,18 @@ __DXKIT_REFRESH_NEEDS__
           fetch-depth: 0
           # `persist-credentials: true` (the default) leaves the
           # token in .git/config so the final `git push` reuses it.
+          # Optional bot PAT (DXKIT_BOT_TOKEN): pushes made with the default
+          # GITHUB_TOKEN never trigger workflow runs, so the advisory decision
+          # PR this lane can open would show no checks. Falls back cleanly.
+          token: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
+
+      - name: Disclose token mode
+        env:
+          DXKIT_BOT_TOKEN_SET: ${{ secrets.DXKIT_BOT_TOKEN != '' }}
+        run: |
+          if [ "${DXKIT_BOT_TOKEN_SET}" != "true" ]; then
+            echo "::notice title=lane PRs run no checks::This lane pushes with the default GITHUB_TOKEN, and GitHub never triggers workflows for such pushes - a PR it opens will show no checks. Set the DXKIT_BOT_TOKEN secret (a PAT with repo scope) to lift this."
+          fi
 
       - uses: actions/setup-node@v6
         with:
@@ -83,6 +95,13 @@ __DXKIT_CI_RUNTIME_SETUP__
           done
 
       - name: Recompute baseline
+        # The refresh's own `gh` calls need auth: the advisory decision PR and
+        # the allowlist-expiry notice issue. Without GH_TOKEN here they run
+        # unauthenticated and fail — the granted `issues: write` permission is
+        # useless to a step that never receives the token (the defect that let
+        # an in-horizon expiry produce zero issues, silently).
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
             DXKIT=./node_modules/.bin/vyuh-dxkit

--- a/src-templates/.github/workflows/dxkit-dep-bump.yml
+++ b/src-templates/.github/workflows/dxkit-dep-bump.yml
@@ -33,6 +33,20 @@ jobs:
         with:
           ref: __DXKIT_DEFAULT_BRANCH__
           fetch-depth: 0
+          # Optional bot PAT: a branch pushed with the default GITHUB_TOKEN
+          # never triggers workflow runs, so a lane-opened PR arrives with NO
+          # checks (uncheckable under branch protection). Set the
+          # DXKIT_BOT_TOKEN secret (a PAT with repo scope) to retire that
+          # degradation; absent, the lane still works and discloses it.
+          token: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
+
+      - name: Disclose token mode
+        env:
+          DXKIT_BOT_TOKEN_SET: ${{ secrets.DXKIT_BOT_TOKEN != '' }}
+        run: |
+          if [ "${DXKIT_BOT_TOKEN_SET}" != "true" ]; then
+            echo "::notice title=lane PRs run no checks::This lane pushes with the default GITHUB_TOKEN, and GitHub never triggers workflows for such pushes - the PR it opens will show no checks. Set the DXKIT_BOT_TOKEN secret (a PAT with repo scope) to lift this."
+          fi
 
       - uses: actions/setup-node@v6
         with:
@@ -79,7 +93,7 @@ __DXKIT_CI_RUNTIME_SETUP__
       # committed policy opts in.
       - name: Run the bump lane
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi
           EXTRA=""
@@ -87,5 +101,18 @@ __DXKIT_CI_RUNTIME_SETUP__
           AM=$("$DXKIT" policy get depBump.allowMajor --default false)
           if [ "$AM" = "true" ]; then EXTRA="--allow-major"; fi
           "$DXKIT" deps bump --apply --land pr $EXTRA --json > dep-bump.json
-          # Surface the outcome; a refused/floor-red lane already exited 1.
-          node -e "const r=require('./dep-bump.json');console.log('outcome:',r.outcome, r.land&&r.land.prUrl?r.land.prUrl:'')"
+          # Surface the REAL outcome + note; a refused/floor-red lane already
+          # exited 1. The outcome now derives from the land result, so a
+          # branch-pushed-no-pr (PR creation refused by repo settings) can
+          # never print as "landed" — it prints its remedy and annotates the
+          # run so the degradation is visible from the Actions list.
+          node - <<'EOF'
+          const r = require('./dep-bump.json');
+          const url = (r.land && r.land.prUrl) || '';
+          console.log('outcome:', r.outcome, url);
+          if (r.note) console.log('note:', r.note);
+          if (r.outcome === 'branch-pushed-no-pr') {
+            const msg = (r.note || 'branch pushed, PR creation failed - open it manually').replace(/\n/g, ' ');
+            console.log('::warning title=dep-bump PR not opened::' + msg);
+          }
+          EOF

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -40,6 +40,18 @@ jobs:
         with:
           ref: __DXKIT_DEFAULT_BRANCH__
           fetch-depth: 0
+          # Optional bot PAT (DXKIT_BOT_TOKEN): branches pushed with the
+          # default GITHUB_TOKEN never trigger workflow runs, so the lane's
+          # PRs would show no checks. Falls back to the default token.
+          token: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
+
+      - name: Disclose token mode
+        env:
+          DXKIT_BOT_TOKEN_SET: ${{ secrets.DXKIT_BOT_TOKEN != '' }}
+        run: |
+          if [ "${DXKIT_BOT_TOKEN_SET}" != "true" ]; then
+            echo "::notice title=lane PRs run no checks::This lane pushes with the default GITHUB_TOKEN, and GitHub never triggers workflows for such pushes - the PR it opens will show no checks. Set the DXKIT_BOT_TOKEN secret (a PAT with repo scope) to lift this."
+          fi
 
       - uses: actions/setup-node@v6
         with:
@@ -97,7 +109,7 @@ __DXKIT_CI_RUNTIME_SETUP__
       # end clean — a truthful failure, never a silent skip.
       - name: Run the remediation lane
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
 __DXKIT_REMEDIATE_CREDENTIAL_ENV__
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi

--- a/src/deps-bump/run.ts
+++ b/src/deps-bump/run.ts
@@ -56,11 +56,20 @@ export interface AppliedBump extends PlannedBump {
 }
 
 export interface DepsBumpResult {
-  /** 'planned' — dry run; 'applied' — bumps executed; 'landed' — PR
-   *  opened/updated; 'nothing-to-do' — empty plan; 'refused' — trust or
+  /** 'planned' — dry run; 'applied' — bumps executed; 'landed' — the PR
+   *  actually opened/updated; 'branch-pushed-no-pr' — the branch pushed but
+   *  PR creation failed (repo settings / gh error; the manual remedy is in
+   *  `note`); 'nothing-to-do' — empty plan; 'refused' — trust or
    *  environment refusal (disclosed in `note`); 'floor-red' — bumps applied
    *  but the floor failed, so nothing landed. */
-  readonly outcome: 'planned' | 'applied' | 'landed' | 'nothing-to-do' | 'refused' | 'floor-red';
+  readonly outcome:
+    | 'planned'
+    | 'applied'
+    | 'landed'
+    | 'branch-pushed-no-pr'
+    | 'nothing-to-do'
+    | 'refused'
+    | 'floor-red';
   readonly plan: BumpPlan;
   readonly applied: readonly AppliedBump[];
   readonly floor?: CorrectnessFloorResult;
@@ -378,5 +387,31 @@ export async function runDepsBump(opts: DepsBumpOptions): Promise<DepsBumpResult
     prTitle: 'dxkit: dependency security bumps',
     prBody: renderLedger(partial),
   });
-  return finish({ ...partial, outcome: 'landed', land });
+  return finish({
+    ...partial,
+    outcome: outcomeFromLand(land),
+    land,
+    ...(land.note !== undefined ? { note: land.note } : {}),
+  });
+}
+
+/**
+ * The lane's top-level outcome derives from the LAND result — ONE derivation,
+ * so the surface can never say "landed" over a disclosed non-delivery (the
+ * false-"landed" class: branch pushed, PR creation refused by the repo's
+ * Actions settings, job green, prUrl empty, remedy buried in unread JSON).
+ */
+function outcomeFromLand(land: LandRefreshResult): DepsBumpResult['outcome'] {
+  switch (land.outcome) {
+    case 'pr-opened':
+    case 'pr-updated':
+    case 'pushed':
+      return 'landed';
+    case 'branch-pushed-no-pr':
+      return 'branch-pushed-no-pr';
+    case 'clean':
+      // Nothing to commit after an apply — defensively "applied", never a
+      // delivery claim.
+      return 'applied';
+  }
 }

--- a/src/land-refresh.ts
+++ b/src/land-refresh.ts
@@ -202,6 +202,9 @@ export function openOrUpdateStandingPr(
     mode: 'pr',
     note:
       `Pushed '${opts.branchName}' but could not open the PR (no gh CLI / not GitHub / ` +
-      `no permission). Open it manually: ${opts.branchName} → ${opts.defaultBranch}.`,
+      `no permission). Under GitHub Actions the usual cause is the repo/org setting ` +
+      `"Allow GitHub Actions to create and approve pull requests" being off ` +
+      `(Settings > Actions > General > Workflow permissions). Open the PR manually ` +
+      `meanwhile: ${opts.branchName} -> ${opts.defaultBranch}.`,
   };
 }

--- a/test/deps-bump/run.test.ts
+++ b/test/deps-bump/run.test.ts
@@ -133,6 +133,36 @@ describe('runDepsBump', () => {
     }
   });
 
+  it('a land that could NOT open its PR is never reported "landed" (branch-pushed-no-pr)', async () => {
+    // The false-"landed" class: the lander pushed the branch, PR creation was
+    // refused (Actions settings), yet the lane stamped outcome "landed" with
+    // an empty prUrl and the remedy buried in unread JSON. The outcome must
+    // derive from the land result — one derivation.
+    const dir = repoWithManifest({ dependencies: { axios: '^1.7.0' } });
+    try {
+      const r = await runDepsBump({
+        cwd: dir,
+        trust: trustedLocalContext(),
+        apply: true,
+        land: 'pr',
+        gather,
+        execBump: () => ({ ok: true, output: '' }),
+        runFloor: () => GREEN_FLOOR,
+        runGuardrail: async () => 'PASSED',
+        landPaths: () => ({
+          outcome: 'branch-pushed-no-pr',
+          mode: 'pr',
+          note: "Pushed 'dxkit/dep-bump' but could not open the PR",
+        }),
+      });
+      expect(r.outcome).toBe('branch-pushed-no-pr');
+      expect(r.note).toContain('could not open the PR');
+      expect(r.land?.prUrl).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('a NET-NEW floor failure (entry green → after red) lands NOTHING — outcome floor-red', async () => {
     const dir = repoWithManifest({ dependencies: { axios: '^1.7.0' } });
     const landed: unknown[] = [];

--- a/test/templates-lane-tokens.test.ts
+++ b/test/templates-lane-tokens.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Lane-template TOKEN parity — the net for the per-template-drift class: the
+ * dep-bump template exported GH_TOKEN while the baseline-refresh template did
+ * not, so the refresh's gh calls (expiry-notice issue, advisory decision PR)
+ * ran unauthenticated and failed silently for a full horizon. Templates are
+ * hand-maintained files with no compiler; parity lives here.
+ *
+ * Two invariants over EVERY workflow template:
+ *   1. any step that shells `gh` — directly or through a gh-shelling dxkit
+ *      lane command — carries GH_TOKEN in its env;
+ *   2. the PR-opening lane templates route their push credential + GH_TOKEN
+ *      through the optional DXKIT_BOT_TOKEN (falling back to github.token),
+ *      because a branch pushed with the default token never triggers workflow
+ *      runs and the lane's PRs would show no checks.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const WORKFLOWS = path.join(__dirname, '..', 'src-templates', '.github', 'workflows');
+
+/** dxkit lane subcommands that shell `gh` internally (PR/issue creation). A
+ *  template invoking one of these needs GH_TOKEN exactly like a literal `gh`
+ *  call. Test-side list, updated when a lane gains gh calls — the assertion
+ *  below fails loudly when a NEW template ships a bare `gh` either way. */
+const GH_SHELLING_COMMANDS = ['baseline refresh', 'deps bump', 'remediate configured'];
+
+interface Step {
+  readonly file: string;
+  readonly header: string;
+  readonly body: string;
+}
+
+/** Split a workflow template into step blocks (6-space `- name:` / `- uses:`
+ *  items). Regex-based on purpose: the templates carry `__DXKIT_*__`
+ *  placeholders that break YAML parsers. */
+function stepsOf(file: string, content: string): Step[] {
+  const out: Step[] = [];
+  const re = /\n {6}- (?:name|uses):[^\n]*/g;
+  const starts: number[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) starts.push(m.index);
+  for (let i = 0; i < starts.length; i++) {
+    const from = starts[i];
+    const to = i + 1 < starts.length ? starts[i + 1] : content.length;
+    const block = content.slice(from, to);
+    out.push({ file, header: block.split('\n')[1] ?? '', body: block });
+  }
+  return out;
+}
+
+function templates(): Array<{ file: string; content: string }> {
+  return fs
+    .readdirSync(WORKFLOWS)
+    .filter((f) => f.endsWith('.yml'))
+    .map((file) => ({ file, content: fs.readFileSync(path.join(WORKFLOWS, file), 'utf8') }));
+}
+
+function shellsGh(step: Step): boolean {
+  // A literal gh invocation in a run block, or a gh-shelling lane command.
+  if (/\bgh (api|pr|issue|repo|run|workflow)\b/.test(step.body)) return true;
+  return GH_SHELLING_COMMANDS.some((c) => step.body.includes(c));
+}
+
+describe('workflow-template token parity', () => {
+  it('every gh-shelling step in every template carries GH_TOKEN', () => {
+    const offenders: string[] = [];
+    for (const { file, content } of templates()) {
+      for (const step of stepsOf(file, content)) {
+        if (!shellsGh(step)) continue;
+        if (!step.body.includes('GH_TOKEN')) {
+          offenders.push(`${file}: ${step.header.trim() || '(unnamed step)'}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `steps shelling gh without GH_TOKEN (unauthenticated gh fails silently in CI):\n` +
+        offenders.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('PR-opening lane templates route credentials through the DXKIT_BOT_TOKEN fallback', () => {
+    const PR_LANES = ['dxkit-dep-bump.yml', 'dxkit-remediate.yml', 'dxkit-baseline-refresh.yml'];
+    for (const file of PR_LANES) {
+      const content = fs.readFileSync(path.join(WORKFLOWS, file), 'utf8');
+      expect(content, `${file} must use the DXKIT_BOT_TOKEN fallback`).toContain(
+        'secrets.DXKIT_BOT_TOKEN || github.token',
+      );
+      // The degraded default is disclosed, not silent.
+      expect(content, `${file} must disclose the default-token degradation`).toContain(
+        'DXKIT_BOT_TOKEN_SET',
+      );
+    }
+  });
+});


### PR DESCRIPTION
Part of the 4.3.6 release train (target: `release/4.3.6`).

## Root cause

Two flavors of one class: hand-maintained lane templates drift (GH_TOKEN present in one, missing in its siblings), and the dep-bump lane stamped its top-level outcome independently of the land result it summarizes.

## Changes

- **Honest outcome**: `runDepsBump` derives the outcome from the land result via one derivation — `branch-pushed-no-pr` (with the remedy note) instead of a false "landed"; the workflow prints outcome + note and emits a `::warning::` annotation.
- **Root-cause naming**: the no-PR note names the "Allow GitHub Actions to create and approve pull requests" setting with its settings path; the onboard script preflights it (advisory).
- **DXKIT_BOT_TOKEN fallback** on the PR-opening lanes (dep-bump, remediate, baseline-refresh): retires the GitHub semantics gap where default-token pushes trigger no workflow runs, leaving lane PRs uncheckable under branch protection. Default remains github.token with a disclosed run notice.
- **Class net — template token parity test**: every gh-shelling step in every template must carry GH_TOKEN. **On its first run it caught two latent instances**: the branch- and cache-transport refresh template variants had the same missing-token bug the tree variant was fixed for. Both fixed here.

Note: the tree-variant refresh template's GH_TOKEN hunk is intentionally identical to WP2 (#234) so the branches merge cleanly in either order.

## Validation

Full local sweep green (344 files / 5198 tests, self-guardrail, arch, slop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)