### PR TITLE
WP5 (core): remediate per-task matrix, observability, evidence, spend controls

### DIFF
--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -21,6 +21,14 @@ name: dxkit remediate
 # Enabled by `.dxkit/policy.json:remediate.enabled: true` + `vyuh-dxkit update`.
 # Budget, tasks, model tier, and salvage policy are read from the committed
 # policy by the CLI itself — this workflow carries no tuning of its own.
+#
+# STRUCTURE: one MATRIX JOB PER TASK, each on its own checkout. The serial
+# shape this replaces coupled the tasks through one tree — a single failed
+# task's unlanded work starved every task after it, and the whole lane was
+# one monolithic log. The matrix kills the coupling structurally: per-task
+# status on the run page, per-task logs/summaries, per-task retry, parallel
+# wall-clock. The task list comes from `remediate plan --json` (the one
+# config reader, spend-ceiling applied) — never a shell parse of policy.
 
 on:
   schedule:
@@ -32,9 +40,69 @@ permissions:
   pull-requests: write
 
 jobs:
-  remediate:
-    name: dxkit-remediate
+  plan:
+    name: dxkit-remediate-plan
     runs-on: ubuntu-latest
+    outputs:
+      tasks: ${{ steps.plan.outputs.tasks }}
+      any: ${{ steps.plan.outputs.any }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: __DXKIT_DEFAULT_BRANCH__
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install dependencies + dxkit
+        run: |
+          corepack enable >/dev/null 2>&1 || true
+          if [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile
+          elif [ -f yarn.lock ]; then
+            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
+          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
+            npm install -g bun >/dev/null 2>&1 || true
+            bun install --frozen-lockfile
+          elif [ -f package-lock.json ]; then
+            npm ci || npm ci --legacy-peer-deps
+          elif [ -f package.json ]; then
+            npm install || npm install --legacy-peer-deps
+          else
+            npm install -g @vyuhlabs/dxkit
+          fi
+
+      - name: Compute the task matrix
+        id: plan
+        run: |
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi
+          "$DXKIT" remediate plan --json > remediate-plan.json
+          node - <<'EOF'
+          const fs = require('fs');
+          const p = JSON.parse(fs.readFileSync('remediate-plan.json', 'utf8'));
+          const tasks = p.matrixTasks ?? [];
+          const out = process.env.GITHUB_OUTPUT;
+          fs.appendFileSync(out, `tasks=${JSON.stringify(tasks)}\n`);
+          fs.appendFileSync(out, `any=${tasks.length > 0 ? 'true' : 'false'}\n`);
+          const deferred = p.deferredBySpendCeiling ?? [];
+          if (deferred.length > 0) {
+            console.log(`::notice title=remediate spend ceiling::deferred to the next firing: ${deferred.join(', ')}`);
+          }
+          console.log('matrix:', JSON.stringify(tasks));
+          EOF
+
+  remediate:
+    name: dxkit-remediate (${{ matrix.task }})
+    needs: plan
+    if: needs.plan.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      # One task's failure must never cancel (or starve) its siblings — the
+      # exact coupling the matrix exists to kill.
+      fail-fast: false
+      matrix:
+        task: ${{ fromJSON(needs.plan.outputs.tasks) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -102,15 +170,39 @@ __DXKIT_CI_RUNTIME_SETUP__
           git config user.name "__DXKIT_BOT_NAME__"
           git config user.email "__DXKIT_BOT_EMAIL__"
 
-      # ONE invocation runs every policy-configured task: the CLI reads the
-      # task list through the one config reader (never a shell parse of
-      # policy JSON), opens one standing PR per task, writes each ledger to
-      # the step summary itself, and exits non-zero when any task did not
-      # end clean — a truthful failure, never a silent skip.
-      - name: Run the remediation lane
+      # ONE task per job (this matrix row's own checkout): the CLI verifies
+      # inside the frame, opens the task's standing PR, writes the ledger to
+      # THIS job's step summary, streams per-phase log groups + heartbeats,
+      # and exits non-zero when the task did not end clean — a truthful
+      # per-task failure, visible on the run page without opening logs.
+      - name: Run task ${{ matrix.task }}
         env:
           GH_TOKEN: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
 __DXKIT_REMEDIATE_CREDENTIAL_ENV__
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi
-          "$DXKIT" remediate configured --land pr
+          "$DXKIT" remediate --task "${{ matrix.task }}" --land pr
+
+      # A BLOCKED / failed attempt's diff must survive the ephemeral runner:
+      # the runner writes a machine-readable attempt record; when nothing
+      # landed but commits exist, format-patch them into a run artifact so
+      # "stays local for inspection" means something a human can download.
+      - name: Collect the attempt diff (evidence when nothing landed)
+        if: always()
+        run: |
+          REC=".dxkit/cache/remediate-${{ matrix.task }}.json"
+          if [ -f "$REC" ]; then
+            RANGE=$(node -e "const r=require('./' + process.argv[1]); if (!r.landed && r.baseHead && r.head && r.baseHead !== r.head) console.log(r.baseHead + '..' + r.head);" "$REC")
+            if [ -n "$RANGE" ]; then
+              git format-patch --stdout "$RANGE" > remediate-attempt.patch
+              echo "wrote remediate-attempt.patch for $RANGE"
+            fi
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: remediate-${{ matrix.task }}-attempt
+          path: remediate-attempt.patch
+          if-no-files-found: ignore
+          retention-days: 14

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -284,6 +284,27 @@ export function buildPolicySchema(version: string): Schema {
             },
             'Which agent runs, at which capability tier, under which caps.',
           ),
+          taskBudgets: {
+            type: 'object',
+            description:
+              'Per-task budget overrides merged over agent.budget (e.g. give fix-build ' +
+              'more headroom than fix-lint). Keys are task ids; values are partial ' +
+              '{maxTurns, maxMinutes, maxUsd}.',
+            additionalProperties: {
+              type: 'object',
+              properties: {
+                maxTurns: { type: 'number' },
+                maxMinutes: { type: 'number' },
+                maxUsd: { type: 'number' },
+              },
+            },
+          },
+          maxSpendPerRun: {
+            type: 'number',
+            description:
+              'Run-level USD ceiling across the per-task matrix (0/absent = none). Tasks ' +
+              'beyond it are deferred to the next firing, in order, and disclosed.',
+          },
         },
         'Agentic remediation: a scheduled agent inside the verified frame.',
       ),

--- a/src/lanes/heartbeat.ts
+++ b/src/lanes/heartbeat.ts
@@ -1,0 +1,73 @@
+/**
+ * Lane progress reporting — the heartbeat that makes "working" observable
+ * from a CI job log (the core observability requirement from the first
+ * production remediate run: one monolithic step, 35+ minutes in-progress,
+ * zero streamed output — indistinguishable from a hang).
+ *
+ * Under GitHub Actions each phase opens a `::group::` (collapsible per-phase
+ * logs) and a timer prints an elapsed-time heartbeat line inside the current
+ * phase every interval. Outside Actions the group markers degrade to plain
+ * phase lines; the heartbeat still prints (a local 30-minute run is just as
+ * opaque). Everything goes to STDERR unbuffered, so it streams regardless of
+ * stdout buffering.
+ */
+
+const HEARTBEAT_INTERVAL_MS = 60_000;
+
+export interface PhaseReporter {
+  /** Enter a phase: closes the previous group, opens a new one, resets the
+   *  phase clock. */
+  phase(name: string): void;
+  /** Stop the heartbeat and close any open group. Always call in finally. */
+  stop(): void;
+}
+
+function inActions(): boolean {
+  return process.env.GITHUB_ACTIONS === 'true';
+}
+
+function minutes(sinceMs: number): string {
+  return `${Math.round((Date.now() - sinceMs) / 60_000)}m`;
+}
+
+/**
+ * Create a reporter for one labeled run (e.g. a remediate task). Injectable
+ * write/now for tests.
+ */
+export function startPhaseReporter(
+  label: string,
+  io?: {
+    readonly write?: (line: string) => void;
+    readonly intervalMs?: number;
+  },
+): PhaseReporter {
+  const write = io?.write ?? ((line: string) => process.stderr.write(line + '\n'));
+  const intervalMs = io?.intervalMs ?? HEARTBEAT_INTERVAL_MS;
+  let current: string | undefined;
+  let phaseStart = Date.now();
+  const runStart = Date.now();
+
+  const timer = setInterval(() => {
+    if (current === undefined) return;
+    write(
+      `[${label}] still running: ${current} (${minutes(phaseStart)} in phase, ${minutes(runStart)} total)`,
+    );
+  }, intervalMs);
+  // Never hold the process open for a heartbeat.
+  timer.unref?.();
+
+  return {
+    phase(name: string) {
+      if (current !== undefined && inActions()) write('::endgroup::');
+      current = name;
+      phaseStart = Date.now();
+      if (inActions()) write(`::group::[${label}] ${name}`);
+      else write(`[${label}] phase: ${name}`);
+    },
+    stop() {
+      clearInterval(timer);
+      if (current !== undefined && inActions()) write('::endgroup::');
+      current = undefined;
+    },
+  };
+}

--- a/src/lanes/verify.ts
+++ b/src/lanes/verify.ts
@@ -41,7 +41,15 @@ export interface GuardrailGateResult {
   /** True only when the check ran and its canonical exit derivation is
    *  clean — the enforcement answer, never re-derived from the word. */
   readonly passesGate: boolean;
+  /** Compact descriptions of the findings that blocked (capped) — evidence
+   *  for a lane whose work will not land, so a BLOCKED attempt on an
+   *  ephemeral runner is inspectable from the ledger alone (the
+   *  uninspectable-attempt defect). Absent when nothing blocked. */
+  readonly blocking?: readonly string[];
 }
+
+/** Cap on the per-lane blocking-finding list — evidence, not a full report. */
+const BLOCKING_SUMMARY_CAP = 10;
 
 /**
  * Run the guardrail for a lane. Late-imports the check module (heavy; the
@@ -56,8 +64,26 @@ export async function guardrailVerdictFor(
   try {
     const { runGuardrailCheck } = await import('../baseline/check');
     const { verdictCounts } = await import('../baseline/check-renderers');
-    const counts = verdictCounts(await runGuardrailCheck({ cwd, trust }));
-    return { verdict: counts.verdict, ran: true, passesGate: counts.exitCode === 0 };
+    const result = await runGuardrailCheck({ cwd, trust });
+    const counts = verdictCounts(result);
+    // Name what blocked (capped): a lane's BLOCKED verdict must be
+    // inspectable from its ledger — "the guardrail did not pass" with no
+    // findings is a diagnosability black hole on an ephemeral runner.
+    const blockingPairs = result.pairs.filter(
+      (p) => p.classification.blocks && p.suppressedByAllowlist === undefined,
+    );
+    const blocking = blockingPairs
+      .slice(0, BLOCKING_SUMMARY_CAP)
+      .map((p) => `[${p.kind}] ${p.locator ?? p.file ?? '(no locator)'}`);
+    if (blockingPairs.length > BLOCKING_SUMMARY_CAP) {
+      blocking.push(`… and ${blockingPairs.length - BLOCKING_SUMMARY_CAP} more`);
+    }
+    return {
+      verdict: counts.verdict,
+      ran: true,
+      passesGate: counts.exitCode === 0,
+      ...(blocking.length > 0 ? { blocking } : {}),
+    };
   } catch (e) {
     return {
       verdict: `unavailable (${e instanceof Error ? e.message : String(e)})`,

--- a/src/remediate/cli.ts
+++ b/src/remediate/cli.ts
@@ -22,108 +22,27 @@
  * The local CLI is the trusted boundary (bump-lane doctrine).
  */
 import * as fs from 'fs';
+import * as path from 'path';
 import { execFileSync } from 'child_process';
 import * as logger from '../logger';
 import { trustedLocalContext } from '../analysis-trust';
 import { detectDefaultBranch } from '../ship-installers';
-import { resolveRemediateConfig, type RemediateConfig } from './config';
-import { resolveModelSetting } from './driver';
-import { AGENT_DRIVERS, driverById } from './registry';
+import { startPhaseReporter } from '../lanes/heartbeat';
+import {
+  budgetForTask,
+  resolveRemediateConfig,
+  tasksWithinSpendCeiling,
+  type RemediateConfig,
+} from './config';
+import { driverById } from './registry';
 import { REMEDIATE_TASKS, remediateTaskById } from './tasks';
 import { runRemediateTask, type RemediateResult } from './run';
 import { landRemediateHead, remediateBranchFor } from './land';
 import { appendLaneEvent, LANE_LEDGER_SCHEMA_VERSION } from '../lanes/ledger';
 
-export interface RemediatePlanOptions {
-  readonly json?: boolean;
-}
-
-/** `remediate plan` — the resolution chain, computed not narrated. */
-export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): void {
-  const config = resolveRemediateConfig(cwd);
-  const driver = driverById(config.agent.driver);
-
-  const rows = config.tasks.map((taskId) => {
-    const task = remediateTaskById(taskId)!;
-    const choice = driver ? resolveModelSetting(driver, config.agent.model, task.tier) : undefined;
-    return {
-      task: taskId,
-      tier: task.tier,
-      tierWhy: task.tierWhy,
-      model: choice?.native ?? null,
-      modelSource: choice?.source ?? null,
-      warning: choice?.warning ?? null,
-    };
-  });
-
-  const availability = driver ? driver.available(cwd) : undefined;
-
-  if (opts.json) {
-    process.stdout.write(
-      JSON.stringify(
-        {
-          schema: 'remediate-plan.v1',
-          enabled: config.enabled,
-          driver: config.agent.driver,
-          driverKnown: !!driver,
-          driverAvailable: availability ? availability.ok : null,
-          model: config.agent.model,
-          budget: config.agent.budget,
-          salvage: config.salvage,
-          schedule: config.schedule,
-          tasks: rows,
-          unknownTasks: config.unknownTasks,
-          unenforceableCaps: driver
-            ? [
-                ...(driver.budgetSupport.turns ? [] : ['maxTurns']),
-                ...(driver.budgetSupport.cost ? [] : ['maxUsd']),
-              ]
-            : [],
-        },
-        null,
-        2,
-      ) + '\n',
-    );
-    return;
-  }
-
-  logger.header('dxkit remediate plan');
-  if (!driver) {
-    logger.fail(
-      `unknown agent driver '${config.agent.driver}' — known drivers: ` +
-        AGENT_DRIVERS.map((d) => d.id).join(', '),
-    );
-    process.exitCode = 1;
-    return;
-  }
-  logger.info(
-    `driver: ${driver.id}` +
-      (availability && !availability.ok ? ` (NOT available here: ${availability.reason})` : ''),
-  );
-  logger.info(
-    `budget: ${config.agent.budget.maxTurns} turns, ${config.agent.budget.maxMinutes} min, ` +
-      `$${config.agent.budget.maxUsd} — salvage: ${config.salvage}`,
-  );
-  if (!driver.budgetSupport.turns) logger.warn(`maxTurns is not enforceable by ${driver.id}`);
-  if (!driver.budgetSupport.cost) logger.warn(`maxUsd is not enforceable by ${driver.id}`);
-  logger.info(`schedule (managed workflow): ${config.schedule}`);
-  if (!config.enabled) {
-    logger.dim('remediate.enabled is not set — the scheduled workflow is off; local runs work.');
-  }
-  for (const row of rows) {
-    const source =
-      row.modelSource === 'auto-tier'
-        ? `auto: ${row.tier} tier (${row.tierWhy})`
-        : row.modelSource === 'pinned-tier'
-          ? `tier pinned by policy`
-          : `pinned by policy`;
-    logger.info(`  ${row.task} → ${row.model} (${source})`);
-    if (row.warning) logger.warn(`    ${row.warning}`);
-  }
-  for (const unknown of config.unknownTasks) {
-    logger.warn(`  unknown task in policy (ignored): '${unknown}'`);
-  }
-}
+// `remediate plan` lives in `./plan-cli` (module-size split); re-exported so
+// consumers keep one import surface.
+export { runRemediatePlan, type RemediatePlanOptions } from './plan-cli';
 
 export interface TaskRun {
   readonly result: RemediateResult;
@@ -157,24 +76,39 @@ async function executeTask(
   taskId: string,
   land: 'pr' | 'none',
 ): Promise<TaskRun> {
-  const result = await runRemediateTask({
-    cwd,
-    trust: trustedLocalContext(),
-    taskId,
-    config,
-    // CI injects the driver's credential env explicitly; locally the driver's
-    // own default applies (claude-code: subscription mode).
-    agentEnv: collectCredentialEnv(config.agent.driver),
-  });
+  // Per-task budget: the override-merged budget rides a task-scoped config
+  // copy, so the runner's enforcement + ledger see the effective caps.
+  const task = remediateTaskById(taskId);
+  const taskConfig: RemediateConfig = task
+    ? { ...config, agent: { ...config.agent, budget: budgetForTask(config, task.id) } }
+    : config;
+  // Phase reporter: per-phase log groups + a 60s heartbeat so a long agent
+  // or verify phase reads as "working", never as hung.
+  const reporter = startPhaseReporter(`remediate:${taskId}`);
+  let result: RemediateResult;
+  try {
+    result = await runRemediateTask({
+      cwd,
+      trust: trustedLocalContext(),
+      taskId,
+      config: taskConfig,
+      // CI injects the driver's credential env explicitly; locally the driver's
+      // own default applies (claude-code: subscription mode).
+      agentEnv: collectCredentialEnv(config.agent.driver),
+      onPhase: (phase) => reporter.phase(phase),
+    });
+  } finally {
+    reporter.stop();
+  }
 
   const draftSalvage = result.outcome === 'budget-exhausted' && config.salvage === 'draft-pr';
   const landEligible = result.outcome === 'verified' || draftSalvage;
   if (land !== 'pr' || !landEligible) {
-    return {
+    return finalizeTaskRun(cwd, taskId, {
       result,
       landed: false,
       clean: result.outcome === 'verified' || result.outcome === 'no-op',
-    };
+    });
   }
 
   // Landing guard (the standing branch is built from HEAD): a named
@@ -182,7 +116,7 @@ async function executeTask(
   const defaultBranch = detectDefaultBranch(cwd);
   const branch = currentBranch(cwd);
   if (branch !== 'HEAD' && branch !== defaultBranch) {
-    return {
+    return finalizeTaskRun(cwd, taskId, {
       result,
       landed: false,
       clean: false,
@@ -190,7 +124,7 @@ async function executeTask(
         `not landed: HEAD is on '${branch}', not '${defaultBranch}' — landing pushes HEAD ` +
         `to the standing branch, so run from '${defaultBranch}' (or let the scheduled ` +
         `workflow land it).`,
-    };
+    });
   }
 
   // The delivery-ledger event rides the PR's own diff (committed by the
@@ -217,12 +151,40 @@ async function executeTask(
     draft: draftSalvage,
     ledgerPath,
   });
-  return {
+  return finalizeTaskRun(cwd, taskId, {
     result,
     ...(landResult.prUrl ? { prUrl: landResult.prUrl } : {}),
     landed: true,
     clean: result.outcome === 'verified' || draftSalvage,
-  };
+  });
+}
+
+/**
+ * Every executeTask exit funnels through here: write the machine-readable
+ * attempt record (the workflow's artifact step reads it to upload the diff
+ * of a blocked/failed attempt — evidence must survive the ephemeral runner)
+ * and, under Actions, annotate a not-landed attempt so it is visible from
+ * the run page without opening logs.
+ */
+function finalizeTaskRun(cwd: string, taskId: string, run: TaskRun): TaskRun {
+  try {
+    const dir = path.join(cwd, '.dxkit', 'cache');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `remediate-${taskId}.json`),
+      JSON.stringify(taskRunJson(run), null, 2) + '\n',
+      'utf8',
+    );
+  } catch {
+    // the record is evidence plumbing, never a failure
+  }
+  if (process.env.GITHUB_ACTIONS === 'true' && !run.clean) {
+    const first = (run.result.note ?? run.result.outcome).split('\n')[0];
+    process.stdout.write(
+      `::warning title=remediate ${taskId} did not land::${run.result.outcome}: ${first}\n`,
+    );
+  }
+  return run;
 }
 
 /** Append a ledger to the GitHub Actions step summary when running in CI. */
@@ -258,6 +220,11 @@ function taskRunJson(run: TaskRun): Record<string, unknown> {
     branch: r.task ? remediateBranchFor(r.task) : null,
     prUrl: run.prUrl ?? null,
     landRefused: run.landRefused ?? null,
+    landed: run.landed,
+    // The commit range of the attempt — what the workflow's evidence step
+    // format-patches into a run artifact when nothing landed.
+    baseHead: r.baseHead ?? null,
+    head: r.head ?? null,
     ledger: r.ledger,
   };
 }
@@ -372,7 +339,17 @@ export async function runRemediateConfigured(
     logger.warn(`unknown task in policy (ignored): '${unknown}'`);
   }
 
-  const outcome = await runConfiguredLoop(config.tasks, {
+  // The same spend ceiling the matrix reads from `plan --json` — the serial
+  // path (local runs, pre-matrix installs) must not outspend the parallel one.
+  const ceiling = tasksWithinSpendCeiling(config);
+  if (ceiling.deferred.length > 0) {
+    logger.warn(
+      `spend ceiling ($${config.maxSpendPerRun}/run): deferring ${ceiling.deferred.join(', ')} ` +
+        'to the next firing.',
+    );
+  }
+
+  const outcome = await runConfiguredLoop(ceiling.run, {
     execute: (taskId) => executeTask(cwd, config, taskId, land),
     head: () => headCommit(cwd),
     resetTo: (head) => resetHardTo(cwd, head),

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -42,6 +42,51 @@ export interface RemediateConfig {
     readonly model: string;
     readonly budget: RemediateBudget;
   };
+  /** Per-task budget overrides (`remediate.taskBudgets.<id>`), merged over
+   *  `agent.budget` by `budgetForTask`. Lets a repo give fix-build more
+   *  headroom than fix-lint without raising every task's cap. */
+  readonly taskBudgets: Readonly<Partial<Record<RemediateTaskId, Partial<RemediateBudget>>>>;
+  /** Run-level USD ceiling (`remediate.maxSpendPerRun`, 0 = no ceiling): the
+   *  org guard for the per-task matrix, where a failing task no longer
+   *  starves its siblings and every enabled task may spend its own cap in
+   *  one firing. Tasks beyond the ceiling are DEFERRED (disclosed), in
+   *  declaration order — never silently dropped. */
+  readonly maxSpendPerRun: number;
+}
+
+/** The effective budget for one task: the per-task override merged over the
+ *  shared agent budget — the ONE derivation every surface (runner, plan,
+ *  matrix trim) reads. */
+export function budgetForTask(config: RemediateConfig, taskId: RemediateTaskId): RemediateBudget {
+  const override = config.taskBudgets[taskId] ?? {};
+  return {
+    maxTurns: positiveNumber(override.maxTurns, config.agent.budget.maxTurns),
+    maxMinutes: positiveNumber(override.maxMinutes, config.agent.budget.maxMinutes),
+    maxUsd: positiveNumber(override.maxUsd, config.agent.budget.maxUsd),
+  };
+}
+
+/** Apply the run-level spend ceiling: tasks whose cumulative per-task maxUsd
+ *  fits run now; the rest are deferred to the next firing (deterministic —
+ *  declaration order). No ceiling → everything runs. */
+export function tasksWithinSpendCeiling(config: RemediateConfig): {
+  readonly run: readonly RemediateTaskId[];
+  readonly deferred: readonly RemediateTaskId[];
+} {
+  if (config.maxSpendPerRun <= 0) return { run: config.tasks, deferred: [] };
+  const run: RemediateTaskId[] = [];
+  const deferred: RemediateTaskId[] = [];
+  let spend = 0;
+  for (const taskId of config.tasks) {
+    const usd = budgetForTask(config, taskId).maxUsd;
+    if (spend + usd <= config.maxSpendPerRun) {
+      spend += usd;
+      run.push(taskId);
+    } else {
+      deferred.push(taskId);
+    }
+  }
+  return { run, deferred };
 }
 
 function positiveNumber(v: unknown, fallback: number): number {
@@ -61,6 +106,19 @@ export function resolveRemediateConfig(cwd: string): RemediateConfig {
   const tasks = rawTasks.filter((t): t is RemediateTaskId => known.has(t));
   const unknownTasks = rawTasks.filter((t) => !known.has(t));
 
+  const rawTaskBudgets = (raw.taskBudgets ?? {}) as Record<string, unknown>;
+  const taskBudgets: Partial<Record<RemediateTaskId, Partial<RemediateBudget>>> = {};
+  for (const [id, value] of Object.entries(rawTaskBudgets)) {
+    if (!known.has(id) || typeof value !== 'object' || value === null) continue;
+    const v = value as Record<string, unknown>;
+    const override: Partial<RemediateBudget> = {
+      ...(typeof v.maxTurns === 'number' && v.maxTurns > 0 ? { maxTurns: v.maxTurns } : {}),
+      ...(typeof v.maxMinutes === 'number' && v.maxMinutes > 0 ? { maxMinutes: v.maxMinutes } : {}),
+      ...(typeof v.maxUsd === 'number' && v.maxUsd > 0 ? { maxUsd: v.maxUsd } : {}),
+    };
+    if (Object.keys(override).length > 0) taskBudgets[id as RemediateTaskId] = override;
+  }
+
   return {
     enabled: raw.enabled === true,
     tasks: tasks.length > 0 ? tasks : (['fix-vulns'] as const),
@@ -77,5 +135,12 @@ export function resolveRemediateConfig(cwd: string): RemediateConfig {
         maxUsd: positiveNumber(budget.maxUsd, DEFAULT_REMEDIATE_BUDGET.maxUsd),
       },
     },
+    taskBudgets,
+    maxSpendPerRun:
+      typeof raw.maxSpendPerRun === 'number' &&
+      Number.isFinite(raw.maxSpendPerRun) &&
+      raw.maxSpendPerRun > 0
+        ? raw.maxSpendPerRun
+        : 0,
   };
 }

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -1,0 +1,69 @@
+/**
+ * The remediate verification ledger — deterministic, identifier-free
+ * markdown (the PR body / job step summary). Split from the runner
+ * (`run.ts`) purely for module size; the runner is its only producer. The
+ * type dependency is type-only, so there is no runtime cycle.
+ */
+import { renderFloorVerification, renderGuardrailVerdict } from '../lanes/verification-render';
+import { renderScoreHinge } from './score-hinge';
+import type { RemediateResult } from './run';
+
+export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): string {
+  const lines: string[] = ['## dxkit agentic remediation', ''];
+  lines.push(`Task: **${r.task ?? '(none)'}** — outcome: **${r.outcome}**`);
+  if (r.partial)
+    lines.push(
+      '',
+      'Budget-bounded, not finished: the work below is real and verified, but the task was cut short.',
+    );
+  if (r.note) lines.push('', r.note);
+  lines.push('');
+
+  if (r.envelope) {
+    const e = r.envelope;
+    lines.push('### Agent envelope', '');
+    const modelWhy =
+      e.modelSource === 'auto-tier'
+        ? 'auto tier'
+        : e.modelSource === 'pinned-tier'
+          ? 'tier pinned by policy'
+          : 'pinned by policy';
+    lines.push(`- driver: \`${e.driver}\``);
+    lines.push(
+      `- model: \`${e.model}\` (${modelWhy})` +
+        (e.resolvedModelId
+          ? ` — ran as \`${e.resolvedModelId}\``
+          : ' — concrete id not reported by driver'),
+    );
+    if (e.modelWarning) lines.push(`- model warning: ${e.modelWarning}`);
+    lines.push(
+      `- spend: ${e.costUsd !== undefined ? `$${e.costUsd.toFixed(2)}` : 'not reported'} over ` +
+        `${e.turns !== undefined ? `${e.turns} turns` : 'an unreported turn count'} ` +
+        `(caps: ${e.budget.maxTurns} turns, ${e.budget.maxMinutes} min, $${e.budget.maxUsd})`,
+    );
+    if (e.turns !== undefined && e.turns > e.budget.maxTurns) {
+      // The 81-vs-80 confusion: the driver's reported count can exceed the
+      // cap it enforced (its accounting includes the closing turn). Say so —
+      // an over-cap count otherwise reads as broken enforcement.
+      lines.push(
+        `- note: the driver reported ${e.turns} turns against its ${e.budget.maxTurns}-turn ` +
+          `cap — the driver's own count includes the run's closing turn; the cap did enforce.`,
+      );
+    }
+    for (const cap of e.unenforceableCaps) {
+      lines.push(`- disclosed limitation: ${cap}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('### Verification', '');
+  lines.push(...renderFloorVerification(r.floor, r.floorAttribution, 'the pre-agent entry run'));
+  lines.push(...renderGuardrailVerdict(r.guardrailVerdict));
+  if (r.scoreHinge) lines.push(renderScoreHinge(r.scoreHinge));
+  lines.push(
+    "_Agentic lane inside the verified frame: the agent's own claim of success is never " +
+      'trusted — the entry-attributed floor and the guardrail ran before anything lands, ' +
+      'and everything not verified is named above._',
+  );
+  return lines.join('\n');
+}

--- a/src/remediate/plan-cli.ts
+++ b/src/remediate/plan-cli.ts
@@ -1,0 +1,117 @@
+/**
+ * `vyuh-dxkit remediate plan` — the dry-run resolution chain (no key, no
+ * spend): per enabled task, task -> tier -> driver-native model, the
+ * effective per-task budget, and the spend-ceiling-trimmed matrix the
+ * managed workflow reads. Split from `cli.ts` purely for module size.
+ */
+import * as logger from '../logger';
+import { budgetForTask, resolveRemediateConfig, tasksWithinSpendCeiling } from './config';
+import { resolveModelSetting } from './driver';
+import { AGENT_DRIVERS, driverById } from './registry';
+import { remediateTaskById } from './tasks';
+
+export interface RemediatePlanOptions {
+  readonly json?: boolean;
+}
+
+/** `remediate plan` — the resolution chain, computed not narrated. */
+export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): void {
+  const config = resolveRemediateConfig(cwd);
+  const driver = driverById(config.agent.driver);
+
+  const rows = config.tasks.map((taskId) => {
+    const task = remediateTaskById(taskId)!;
+    const choice = driver ? resolveModelSetting(driver, config.agent.model, task.tier) : undefined;
+    return {
+      task: taskId,
+      tier: task.tier,
+      tierWhy: task.tierWhy,
+      model: choice?.native ?? null,
+      modelSource: choice?.source ?? null,
+      warning: choice?.warning ?? null,
+      budget: budgetForTask(config, task.id),
+    };
+  });
+
+  const availability = driver ? driver.available(cwd) : undefined;
+  // The run-level spend ceiling, applied here so the WORKFLOW's matrix reads
+  // the trimmed list from the plan (one derivation) instead of re-deriving it.
+  const ceiling = tasksWithinSpendCeiling(config);
+
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          schema: 'remediate-plan.v1',
+          enabled: config.enabled,
+          driver: config.agent.driver,
+          driverKnown: !!driver,
+          driverAvailable: availability ? availability.ok : null,
+          model: config.agent.model,
+          budget: config.agent.budget,
+          salvage: config.salvage,
+          schedule: config.schedule,
+          tasks: rows,
+          /** The per-task workflow matrix: enabled tasks within the run's
+           *  spend ceiling, in declaration order. */
+          matrixTasks: ceiling.run,
+          deferredBySpendCeiling: ceiling.deferred,
+          maxSpendPerRun: config.maxSpendPerRun,
+          unknownTasks: config.unknownTasks,
+          unenforceableCaps: driver
+            ? [
+                ...(driver.budgetSupport.turns ? [] : ['maxTurns']),
+                ...(driver.budgetSupport.cost ? [] : ['maxUsd']),
+              ]
+            : [],
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return;
+  }
+
+  logger.header('dxkit remediate plan');
+  if (!driver) {
+    logger.fail(
+      `unknown agent driver '${config.agent.driver}' — known drivers: ` +
+        AGENT_DRIVERS.map((d) => d.id).join(', '),
+    );
+    process.exitCode = 1;
+    return;
+  }
+  logger.info(
+    `driver: ${driver.id}` +
+      (availability && !availability.ok ? ` (NOT available here: ${availability.reason})` : ''),
+  );
+  logger.info(
+    `budget: ${config.agent.budget.maxTurns} turns, ${config.agent.budget.maxMinutes} min, ` +
+      `$${config.agent.budget.maxUsd} — salvage: ${config.salvage}`,
+  );
+  if (!driver.budgetSupport.turns) logger.warn(`maxTurns is not enforceable by ${driver.id}`);
+  if (!driver.budgetSupport.cost) logger.warn(`maxUsd is not enforceable by ${driver.id}`);
+  logger.info(`schedule (managed workflow): ${config.schedule}`);
+  if (!config.enabled) {
+    logger.dim('remediate.enabled is not set — the scheduled workflow is off; local runs work.');
+  }
+  for (const row of rows) {
+    const source =
+      row.modelSource === 'auto-tier'
+        ? `auto: ${row.tier} tier (${row.tierWhy})`
+        : row.modelSource === 'pinned-tier'
+          ? `tier pinned by policy`
+          : `pinned by policy`;
+    logger.info(`  ${row.task} → ${row.model} (${source})`);
+    if (row.warning) logger.warn(`    ${row.warning}`);
+  }
+  for (const unknown of config.unknownTasks) {
+    logger.warn(`  unknown task in policy (ignored): '${unknown}'`);
+  }
+  if (ceiling.deferred.length > 0) {
+    logger.warn(
+      `  spend ceiling ($${config.maxSpendPerRun}/run): ${ceiling.deferred.join(', ')} ` +
+        'deferred to the next firing (disclosed, never dropped).',
+    );
+  }
+}

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -31,7 +31,7 @@ import {
   type FloorBaseCheck,
 } from '../analyzers/correctness/attribution';
 import { detectActiveLanguages } from '../languages';
-import { renderFloorVerification, renderGuardrailVerdict } from '../lanes/verification-render';
+import { renderRemediateLedger } from './ledger-render';
 import { guardrailVerdictFor, toFloorBaseChecks, type GuardrailGateResult } from '../lanes/verify';
 import { BOT_IDENTITY } from '../land-refresh';
 import { resolveModelSetting, type AgentDriver, type AgentRunResult } from './driver';
@@ -40,7 +40,6 @@ import { remediateTaskById, knownTaskIds, type RemediateTask } from './tasks';
 import {
   evaluateScoreHinge,
   healthHingeScores,
-  renderScoreHinge,
   type HingeEvidence,
   type HingeScores,
 } from './score-hinge';
@@ -173,59 +172,24 @@ export interface RemediateRunOptions {
   /** Injected for tests: replaces the health-score probe behind a task's
    *  score hinge. */
   readonly hingeScores?: (hinge: NonNullable<RemediateTask['scoreHinge']>) => Promise<HingeScores>;
+  /** Progress hook — called as each phase begins so the CLI layer can emit
+   *  log groups + heartbeats (a 35-minute silent step is indistinguishable
+   *  from a hang; "working" must be observable from the job log). */
+  readonly onPhase?: (phase: RemediatePhase) => void;
 }
 
-/** The remediate verification ledger — deterministic, identifier-free. */
-export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): string {
-  const lines: string[] = ['## dxkit agentic remediation', ''];
-  lines.push(`Task: **${r.task ?? '(none)'}** — outcome: **${r.outcome}**`);
-  if (r.partial)
-    lines.push(
-      '',
-      'Budget-bounded, not finished: the work below is real and verified, but the task was cut short.',
-    );
-  if (r.note) lines.push('', r.note);
-  lines.push('');
+/** The runner's observable phases, in order. */
+export type RemediatePhase =
+  | 'entry-floor'
+  | 'agent'
+  | 'sweep'
+  | 'verify-floor'
+  | 'guardrail'
+  | 'score-hinge';
 
-  if (r.envelope) {
-    const e = r.envelope;
-    lines.push('### Agent envelope', '');
-    const modelWhy =
-      e.modelSource === 'auto-tier'
-        ? 'auto tier'
-        : e.modelSource === 'pinned-tier'
-          ? 'tier pinned by policy'
-          : 'pinned by policy';
-    lines.push(`- driver: \`${e.driver}\``);
-    lines.push(
-      `- model: \`${e.model}\` (${modelWhy})` +
-        (e.resolvedModelId
-          ? ` — ran as \`${e.resolvedModelId}\``
-          : ' — concrete id not reported by driver'),
-    );
-    if (e.modelWarning) lines.push(`- model warning: ${e.modelWarning}`);
-    lines.push(
-      `- spend: ${e.costUsd !== undefined ? `$${e.costUsd.toFixed(2)}` : 'not reported'} over ` +
-        `${e.turns !== undefined ? `${e.turns} turns` : 'an unreported turn count'} ` +
-        `(caps: ${e.budget.maxTurns} turns, ${e.budget.maxMinutes} min, $${e.budget.maxUsd})`,
-    );
-    for (const cap of e.unenforceableCaps) {
-      lines.push(`- disclosed limitation: ${cap}`);
-    }
-    lines.push('');
-  }
-
-  lines.push('### Verification', '');
-  lines.push(...renderFloorVerification(r.floor, r.floorAttribution, 'the pre-agent entry run'));
-  lines.push(...renderGuardrailVerdict(r.guardrailVerdict));
-  if (r.scoreHinge) lines.push(renderScoreHinge(r.scoreHinge));
-  lines.push(
-    "_Agentic lane inside the verified frame: the agent's own claim of success is never " +
-      'trusted — the entry-attributed floor and the guardrail ran before anything lands, ' +
-      'and everything not verified is named above._',
-  );
-  return lines.join('\n');
-}
+// The ledger renderer lives in `./ledger-render` (module-size split);
+// re-exported so consumers keep one import surface.
+export { renderRemediateLedger };
 
 export async function runRemediateTask(opts: RemediateRunOptions): Promise<RemediateResult> {
   const finish = (r: Omit<RemediateResult, 'ledger'>): RemediateResult => ({
@@ -308,7 +272,22 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // Entry snapshot on the pristine tree: the base side of the attribution
   // comparator — a repo already red at entry keeps its debt disclosed, never
   // weaponized against the agent's change.
+  opts.onPhase?.('entry-floor');
   const entryFloor = runFloor();
+
+  // $0 deterministic fast-exit (per-task opt-in): a floor-goal task with a
+  // GREEN entry floor has nothing to fix — return no-op BEFORE any agent
+  // spawns, so a scheduled firing on a healthy repo costs nothing.
+  if (task.skipWhenEntryFloorGreen && !entryFloor.blocks) {
+    return finish({
+      outcome: 'no-op',
+      task: task.id,
+      floor: entryFloor,
+      note:
+        'nothing to do: the entry correctness floor is green, and this task exists to fix ' +
+        'floor debt — no agent was spawned ($0).',
+    });
+  }
   // Entry side of the task's score hinge (when it declares one) — computed on
   // the same pristine tree the entry floor snapshots.
   const hingeProbe =
@@ -317,6 +296,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   const entryScores = task.scoreHinge ? await hingeProbe(task.scoreHinge) : undefined;
   const baseHead = git.head();
 
+  opts.onPhase?.('agent');
   const agentResult: AgentRunResult = await driver.run({
     cwd: opts.cwd,
     prompt: task.prompt,
@@ -344,6 +324,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // Sweep uncommitted leftovers into a loudly-labeled commit — work the
   // budget kill stranded mid-edit is still evidence, and a dirty tree must
   // never leak into the landing layer unreviewed.
+  opts.onPhase?.('sweep');
   const sweepError = git.sweepLeftovers();
   const hasDiff = git.hasDiff(baseHead);
 
@@ -402,6 +383,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
 
   // Verify: floor at full scope attributed vs entry (through the ONE
   // base-check projection, shared with the bump lane), then the guardrail.
+  opts.onPhase?.('verify-floor');
   const floor = runFloor();
   const baseChecks: FloorBaseCheck[] = toFloorBaseChecks(entryFloor);
   const floorAttribution = attributeFloorFailures(floor, baseChecks, {
@@ -411,6 +393,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   });
   const netNewFloorRed = floorAttribution.some((a) => a.attribution === 'net-new');
 
+  opts.onPhase?.('guardrail');
   const guardrail = opts.runGuardrail
     ? await opts.runGuardrail()
     : await guardrailVerdictFor(opts.cwd, opts.trust);
@@ -443,14 +426,24 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // BLOCKED verdict, the CANNOT-GATE refusal tier, and an unrunnable check
   // all land nothing; the ledger says which it was.
   if (!guardrail.ran || !guardrail.passesGate) {
+    // Name the blocking findings in the ledger: on an ephemeral runner the
+    // diff evaporates with the job, so "did not pass" with no evidence made
+    // a BLOCKED attempt uninspectable (the workflow additionally uploads the
+    // attempt diff as a run artifact).
+    const evidence =
+      guardrail.blocking && guardrail.blocking.length > 0
+        ? `\n\nBlocking findings:\n${guardrail.blocking.map((b) => `- ${b}`).join('\n')}`
+        : '';
     return finish({
       outcome: 'guardrail-red',
       ...common,
-      note: guardrail.ran
-        ? `the guardrail did not pass (${guardrail.verdict}) — nothing lands. The agent's ` +
-          'change (including any swept working state) stays local for inspection.'
-        : `the guardrail could not run (${guardrail.verdict}) — nothing lands. An ` +
-          'agent-authored diff is never pushed unverified.',
+      note:
+        (guardrail.ran
+          ? `the guardrail did not pass (${guardrail.verdict}) — nothing lands. The attempt ` +
+            'diff is uploaded as a run artifact when this ran under Actions; locally the ' +
+            'branch stays for inspection.'
+          : `the guardrail could not run (${guardrail.verdict}) — nothing lands. An ` +
+            'agent-authored diff is never pushed unverified.') + evidence,
     });
   }
 

--- a/src/remediate/tasks.ts
+++ b/src/remediate/tasks.ts
@@ -50,6 +50,15 @@ export interface RemediateTask {
    *  the primary signal for the ledger). */
   readonly verify: 'floor' | 'guardrail';
   /**
+   * $0 deterministic fast-exit: when the ENTRY floor (already captured on
+   * the pristine tree before any agent spawns) is green, this task has
+   * nothing to fix — return `no-op` without spawning the agent. Only
+   * meaningful for tasks whose whole goal IS the floor (fix-build); tasks
+   * whose goal lives elsewhere (docs, tests, vulns) must not skip on a
+   * green floor.
+   */
+  readonly skipWhenEntryFloorGreen?: boolean;
+  /**
    * OPTIONAL deterministic score hinge (4.3.4). The lane's law is that a task
    * ships only when "done" is re-verifiable without reading prose — and for
    * work whose whole point is a dimension moving (docs), the floor and
@@ -96,6 +105,7 @@ export const REMEDIATE_TASKS: readonly RemediateTask[] = [
     tier: 'standard',
     tierWhy: 'real diagnosis + repair across build config and test code',
     verify: 'floor',
+    skipWhenEntryFloorGreen: true,
     prompt:
       `Run ${dxkitInRepo('debt --json')}.
 Your task is the CORRECTNESS FLOOR section only: make the failing checks pass.

--- a/test/lanes/heartbeat.test.ts
+++ b/test/lanes/heartbeat.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The lane heartbeat: phases become log groups (under Actions) and a timer
+ * makes long phases observably "working" rather than hung.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { startPhaseReporter } from '../../src/lanes/heartbeat';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+});
+
+describe('startPhaseReporter', () => {
+  it('emits ::group:: markers per phase under Actions and closes them', () => {
+    vi.stubEnv('GITHUB_ACTIONS', 'true');
+    const lines: string[] = [];
+    const r = startPhaseReporter('remediate:fix-build', { write: (l) => lines.push(l) });
+    r.phase('entry-floor');
+    r.phase('agent');
+    r.stop();
+    expect(lines).toEqual([
+      '::group::[remediate:fix-build] entry-floor',
+      '::endgroup::',
+      '::group::[remediate:fix-build] agent',
+      '::endgroup::',
+    ]);
+  });
+
+  it('degrades to plain phase lines outside Actions', () => {
+    vi.stubEnv('GITHUB_ACTIONS', '');
+    const lines: string[] = [];
+    const r = startPhaseReporter('remediate:x', { write: (l) => lines.push(l) });
+    r.phase('agent');
+    r.stop();
+    expect(lines).toEqual(['[remediate:x] phase: agent']);
+  });
+
+  it('prints a heartbeat inside a long phase, and stops with stop()', () => {
+    vi.stubEnv('GITHUB_ACTIONS', '');
+    vi.useFakeTimers();
+    const lines: string[] = [];
+    const r = startPhaseReporter('remediate:x', { write: (l) => lines.push(l), intervalMs: 1000 });
+    r.phase('agent');
+    vi.advanceTimersByTime(2500);
+    const beats = lines.filter((l) => l.includes('still running'));
+    expect(beats.length).toBe(2);
+    expect(beats[0]).toContain('agent');
+    r.stop();
+    vi.advanceTimersByTime(5000);
+    expect(lines.filter((l) => l.includes('still running')).length).toBe(2);
+  });
+});

--- a/test/remediate/config-budgets.test.ts
+++ b/test/remediate/config-budgets.test.ts
@@ -1,0 +1,109 @@
+/**
+ * WP5 config surface: per-task budget overrides + the run-level spend
+ * ceiling (the org guard for the per-task matrix, where a failing task no
+ * longer starves siblings and every task may spend its own cap).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  budgetForTask,
+  resolveRemediateConfig,
+  tasksWithinSpendCeiling,
+  DEFAULT_REMEDIATE_BUDGET,
+  type RemediateConfig,
+} from '../../src/remediate/config';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+function repoWithPolicy(remediate: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-remcfg-'));
+  dirs.push(dir);
+  fs.mkdirSync(path.join(dir, '.dxkit'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.dxkit', 'policy.json'), JSON.stringify({ remediate }));
+  return dir;
+}
+
+function cfg(partial: Partial<RemediateConfig>): RemediateConfig {
+  return {
+    enabled: true,
+    tasks: ['fix-build', 'fix-vulns', 'write-docs'],
+    unknownTasks: [],
+    schedule: 'weekly',
+    salvage: 'discard',
+    agent: { driver: 'claude-code', model: 'auto', budget: DEFAULT_REMEDIATE_BUDGET },
+    taskBudgets: {},
+    maxSpendPerRun: 0,
+    ...partial,
+  };
+}
+
+describe('budgetForTask', () => {
+  it('merges the per-task override over the shared budget, field by field', () => {
+    const config = cfg({ taskBudgets: { 'fix-build': { maxUsd: 12, maxMinutes: 60 } } });
+    expect(budgetForTask(config, 'fix-build')).toEqual({
+      maxTurns: DEFAULT_REMEDIATE_BUDGET.maxTurns,
+      maxMinutes: 60,
+      maxUsd: 12,
+    });
+    // A task with no override gets the shared budget untouched.
+    expect(budgetForTask(config, 'fix-vulns')).toEqual(DEFAULT_REMEDIATE_BUDGET);
+  });
+});
+
+describe('tasksWithinSpendCeiling', () => {
+  it('no ceiling → every enabled task runs', () => {
+    const { run, deferred } = tasksWithinSpendCeiling(cfg({}));
+    expect(run).toEqual(['fix-build', 'fix-vulns', 'write-docs']);
+    expect(deferred).toEqual([]);
+  });
+
+  it('defers tasks beyond the ceiling in declaration order, never dropping them', () => {
+    // Default maxUsd is 5 per task; a $12 ceiling fits two.
+    const { run, deferred } = tasksWithinSpendCeiling(cfg({ maxSpendPerRun: 12 }));
+    expect(run).toEqual(['fix-build', 'fix-vulns']);
+    expect(deferred).toEqual(['write-docs']);
+  });
+
+  it('per-task overrides count at their overridden cost', () => {
+    const config = cfg({
+      maxSpendPerRun: 12,
+      taskBudgets: { 'fix-build': { maxUsd: 10 } },
+    });
+    const { run, deferred } = tasksWithinSpendCeiling(config);
+    // fix-build (10) fits; fix-vulns (5) would exceed 12 → deferred, and the
+    // walk stays in order (no knapsack cleverness — determinism wins).
+    expect(run).toEqual(['fix-build']);
+    expect(deferred).toEqual(['fix-vulns', 'write-docs']);
+  });
+});
+
+describe('resolveRemediateConfig parsing', () => {
+  it('reads taskBudgets + maxSpendPerRun; ignores unknown tasks and junk values', () => {
+    const dir = repoWithPolicy({
+      enabled: true,
+      tasks: ['fix-build', 'fix-vulns'],
+      maxSpendPerRun: 15,
+      taskBudgets: {
+        'fix-build': { maxUsd: 10, maxTurns: -3 },
+        'no-such-task': { maxUsd: 99 },
+        'fix-vulns': 'not-an-object',
+      },
+    });
+    const config = resolveRemediateConfig(dir);
+    expect(config.maxSpendPerRun).toBe(15);
+    expect(config.taskBudgets).toEqual({ 'fix-build': { maxUsd: 10 } });
+    expect(budgetForTask(config, 'fix-build').maxUsd).toBe(10);
+    expect(budgetForTask(config, 'fix-build').maxTurns).toBe(DEFAULT_REMEDIATE_BUDGET.maxTurns);
+  });
+
+  it('absent knobs keep the pre-WP5 shape (no ceiling, no overrides)', () => {
+    const dir = repoWithPolicy({ enabled: true });
+    const config = resolveRemediateConfig(dir);
+    expect(config.maxSpendPerRun).toBe(0);
+    expect(config.taskBudgets).toEqual({});
+  });
+});

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -88,6 +88,8 @@ function config(
       budget: DEFAULT_REMEDIATE_BUDGET,
       ...partial,
     },
+    taskBudgets: {},
+    maxSpendPerRun: 0,
   };
 }
 
@@ -465,5 +467,72 @@ describe('the score hinge — the task goal as a land condition', () => {
     expect(r.outcome).toBe('verified');
     expect(probed).toBe(0);
     expect(r.scoreHinge).toBeUndefined();
+  });
+});
+
+describe('WP5: fast-exit, phases, cap accounting, blocked evidence', () => {
+  it('fix-build with a GREEN entry floor is a $0 no-op — no agent spawns', async () => {
+    const driver = fakeDriver({});
+    let spawned = false;
+    driver.run = async () => {
+      spawned = true;
+      return { completed: true, timedOut: false, transcriptTail: '' };
+    };
+    const r = await runRemediateTask(
+      base(driver, { taskId: 'fix-build', runFloor: () => GREEN_FLOOR }),
+    );
+    expect(r.outcome).toBe('no-op');
+    expect(spawned).toBe(false);
+    expect(r.note).toContain('no agent was spawned');
+  });
+
+  it('fix-build with a RED entry floor still runs the agent (the over-skip guard)', async () => {
+    const driver = fakeDriver({});
+    let spawned = false;
+    const origRun = driver.run.bind(driver);
+    driver.run = async (o) => {
+      spawned = true;
+      return origRun(o);
+    };
+    const floors = [RED_FLOOR, RED_FLOOR];
+    const r = await runRemediateTask(
+      base(driver, { taskId: 'fix-build', runFloor: () => floors.shift() ?? RED_FLOOR }),
+    );
+    expect(spawned).toBe(true);
+    // Pre-existing failure on both sides — disclosed, not weaponized.
+    expect(r.outcome).toBe('verified');
+  });
+
+  it('reports phases in order through onPhase', async () => {
+    const phases: string[] = [];
+    const r = await runRemediateTask(base(fakeDriver({}), { onPhase: (p) => phases.push(p) }));
+    expect(r.outcome).toBe('verified');
+    expect(phases).toEqual(['entry-floor', 'agent', 'sweep', 'verify-floor', 'guardrail']);
+  });
+
+  it('a guardrail-red ledger names the blocking findings (evidence survives the runner)', async () => {
+    const r = await runRemediateTask(
+      base(fakeDriver({}), {
+        runGuardrail: async () => ({
+          verdict: 'BLOCKED',
+          ran: true,
+          passesGate: false,
+          blocking: ['[secret] src/config.ts:12', '[dep-vuln] axios@1.6.0 · GHSA-xxxx'],
+        }),
+      }),
+    );
+    expect(r.outcome).toBe('guardrail-red');
+    expect(r.note).toContain('Blocking findings:');
+    expect(r.note).toContain('[secret] src/config.ts:12');
+    expect(r.ledger).toContain('[dep-vuln] axios@1.6.0');
+  });
+
+  it('a driver turn count one over the cap is explained, not left reading as broken enforcement', async () => {
+    const r = await runRemediateTask(
+      base(fakeDriver({ turns: DEFAULT_REMEDIATE_BUDGET.maxTurns + 1, costUsd: 3.12 })),
+    );
+    expect(r.outcome).toBe('budget-exhausted');
+    expect(r.ledger).toContain("includes the run's closing turn");
+    expect(r.ledger).toContain('the cap did enforce');
   });
 });

--- a/test/templates-lane-tokens.test.ts
+++ b/test/templates-lane-tokens.test.ts
@@ -23,7 +23,12 @@ const WORKFLOWS = path.join(__dirname, '..', 'src-templates', '.github', 'workfl
  *  template invoking one of these needs GH_TOKEN exactly like a literal `gh`
  *  call. Test-side list, updated when a lane gains gh calls — the assertion
  *  below fails loudly when a NEW template ships a bare `gh` either way. */
-const GH_SHELLING_COMMANDS = ['baseline refresh', 'deps bump', 'remediate configured'];
+const GH_SHELLING_COMMANDS = [
+  'baseline refresh',
+  'deps bump',
+  'remediate configured',
+  'remediate --task',
+];
 
 interface Step {
   readonly file: string;


### PR DESCRIPTION
Part of the 4.3.6 release train (target: `release/4.3.6`). Core half of the remediate redesign; the dispatch-campaign surface (typed workflow inputs incl. a custom prompt) follows as a separate PR on top.

## Root causes (from the first production run)

Serial task coupling through one shared tree (one failed task starved all four siblings), and evidence/progress trapped inside the runner (35+ silent minutes; a BLOCKED attempt's diff evaporating with the runner).

## Changes

- **Per-task matrix**: a `plan` job reads the task list from `remediate plan --json` (the one config reader; never a shell parse) and fans out one job per task, each with its own checkout, `fail-fast: false`. Kills the starvation structurally; per-task status/logs/summaries/retry come free. The serial `remediate configured` stays for local use with the same spend ceiling.
- **$0 fast-exit**: `fix-build` with a green entry floor returns `no-op` before any agent spawns.
- **Spend controls**: `remediate.maxSpendPerRun` (run-level ceiling; overflow deferred in order, disclosed) and `remediate.taskBudgets` (per-task overrides via one derivation, `budgetForTask`). Policy schema updated.
- **Observability**: runner phase hook → Actions log groups + a 60s heartbeat (`src/lanes/heartbeat.ts`); non-clean outcomes annotate the run page.
- **Blocked-attempt evidence**: the guardrail gate result now names blocking findings (capped) in the ledger, and the workflow uploads an unlanded attempt's commits as a `format-patch` run artifact.
- **Cap accounting**: the 81-vs-80 turn confusion is explained in the ledger (driver counts the closing turn; the cap did enforce).

## Dogfood note

dxkit's own self-guardrail BLOCKED the first version of this change — two net-new large-file findings on `run.ts`/`cli.ts`. Fixed by extracting `ledger-render.ts` and `plan-cli.ts`, not by allowlisting.

## Validation

Full local sweep green (347 files / 5225 tests, arch, slop, self-guardrail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)