### PR TITLE
WP6: CLI/docs backlog (version, empty-state, context-hook relevance, pitfalls, hello-world)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,7 @@ construction; commands with a linked page have a full reference under
 | [`setup-prebuild`](commands/setup-prebuild.md)                   | Set up the devcontainer prebuild workflow                                                               | < 5 sec                                                         |
 | [`upgrade`](commands/upgrade.md)                                 | Plan / apply a dxkit version upgrade                                                                    | 1-3 min                                                         |
 | [`issue`](commands/issue.md)                                     | Open a pre-filled GitHub issue against dxkit                                                            | < 5 sec                                                         |
+| `version`                                                        | Print the dxkit, Node, and platform versions                                                            | < 1 sec                                                         |
 | [`to-xlsx`](commands/to-xlsx.md)                                 | Convert a dxkit JSON report to XLSX                                                                     | < 5 sec                                                         |
 
 <!-- dxkit:command-table:end -->

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -321,6 +321,40 @@ vyuh-dxkit issue --type=bug --about="..."
 
 See [`vyuh-dxkit issue`](commands/issue.md) for full details.
 
+## 8. Common pitfalls
+
+A handful of first-run issues account for most onboarding friction.
+Each is a two-line fix:
+
+- **Bare `vyuh-dxkit` hits a stale global install.** A previously
+  installed global `vyuh-dxkit` can shadow the repo-local one, so you
+  run an old version without noticing. Fix: use `npx vyuh-dxkit` (or
+  `./node_modules/.bin/vyuh-dxkit`) everywhere; `vyuh-dxkit version`
+  tells you which one answered.
+
+- **`git add .dxkit/` after install misses half the files.** The
+  install also writes `.claude/`, `.githooks/`, workflow files, and
+  merges into `.gitignore`/`package.json`. Fix: `git add .` — the
+  scaffolded `.gitignore` keeps that safe.
+
+- **The pre-push hook times out on slow connections.** GitHub's SSH
+  connection can idle out while a long guardrail check runs, and the
+  push then fails without a clear message. Fix:
+  `GIT_SSH_COMMAND='ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=20' git push`.
+
+- **`gh repo view` fails on private orgs.** Without `gh` auth to your
+  org, the visibility probe reads "Could not resolve to a Repository"
+  and baseline-mode auto-pick degrades. Fix: `gh auth login` with an
+  account that can read the repo, or pin `baseline.mode` in
+  `.dxkit/policy.json` to skip the probe.
+
+- **Baselines belong to CI, not your laptop.** A locally captured
+  committed baseline bakes your machine's scanner versions into the
+  anchor, and every PR gate then risks TOOLING-DRIFT noise against
+  CI's toolchain. Fix: install the refresh lane
+  (`init --with-baseline-refresh`) and let CI capture; `doctor` flags
+  a local anchor.
+
 ## What's next
 
 - **Deep SAST** — dxkit's bundled scanner is intraprocedural and misses

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,69 @@
+# dxkit hello-world
+
+The smallest possible repo that demonstrates dxkit's full closed loop:
+**score → baseline → gate**. Zero dependencies; the whole walkthrough runs
+in under a minute.
+
+## 1. Make it a standalone repo
+
+dxkit anchors to a git repository, so copy this directory out and init:
+
+```bash
+cp -r examples/hello-world /tmp/hello-world && cd /tmp/hello-world
+git init -b main && git add . && git commit -m "hello world"
+```
+
+## 2. Install dxkit
+
+```bash
+npm init @vyuhlabs/dxkit -- --yes
+git add . && git commit -m "add dxkit"
+```
+
+## 3. Score it
+
+```bash
+npx vyuh-dxkit health
+```
+
+Six dimensions, each with structured deductions. A repo this small scores
+oddly in places (one file, two tests) — the point is seeing the shape of
+the output, not the number.
+
+## 4. Capture the baseline
+
+```bash
+npx vyuh-dxkit baseline create --mode=committed-full
+git add .dxkit && git commit -m "baseline"
+```
+
+This records the repo's current findings as the accepted state. There is
+deliberately no pre-captured baseline checked into this example: a
+baseline is a **capture of your environment**, not an artifact you copy —
+a copied one goes stale against your scanner versions and reads as drift.
+
+## 5. Trip the gate
+
+Introduce a "leak" and watch the guardrail block it (the token is
+generated on your machine — this guide deliberately contains no
+secret-shaped string itself):
+
+```bash
+cat >> src/greet.js <<EOF
+const apiKey = 'sk-demo-$(openssl rand -hex 16)';
+EOF
+npx vyuh-dxkit guardrail check
+```
+
+The check exits non-zero and names the net-new finding with its
+fingerprint. Revert (`git checkout src/greet.js`) and the same check
+passes: nothing net-new against the baseline.
+
+## What you just saw
+
+- `health` — the deterministic score (same repo, same number).
+- `baseline create` — today's state becomes the accepted floor.
+- `guardrail check` — only **net-new** findings block; the pre-existing
+  state never does.
+
+From here, the real setup guide: [docs/getting-started.md](../../docs/getting-started.md).

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dxkit-hello-world",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Minimal end-to-end dxkit walkthrough: score, baseline, gate.",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/examples/hello-world/src/greet.js
+++ b/examples/hello-world/src/greet.js
@@ -1,0 +1,10 @@
+/**
+ * Compose a greeting. Deliberately tiny: the example exists to demonstrate
+ * the dxkit loop (score, baseline, gate), not the code.
+ */
+export function greet(name) {
+  if (typeof name !== 'string' || name.trim() === '') {
+    throw new TypeError('name must be a non-empty string');
+  }
+  return `Hello, ${name.trim()}!`;
+}

--- a/examples/hello-world/test/greet.test.js
+++ b/examples/hello-world/test/greet.test.js
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { greet } from '../src/greet.js';
+
+test('greets a trimmed name', () => {
+  assert.equal(greet('  Ada '), 'Hello, Ada!');
+});
+
+test('rejects an empty name', () => {
+  assert.throws(() => greet('   '), TypeError);
+});

--- a/src/allowlist/cli.ts
+++ b/src/allowlist/cli.ts
@@ -601,7 +601,12 @@ export async function runAllowlistList(cwd: string, opts: AllowlistListOpts): Pr
   }
 
   if (!file || file.entries.length === 0) {
-    logger.info(`No allowlist entries. Run \`${dxkitCli('allowlist add')}\` to create one.`);
+    logger.info('No allowlist entries yet.');
+    logger.info(
+      'When a guardrail check blocks a finding you want to accept, its block message ' +
+        `gives you the exact \`${dxkitCli('allowlist add')}\` command to paste.`,
+    );
+    logger.dim('Guide: https://github.com/vyuh-labs/dxkit/blob/main/docs/commands/allowlist.md');
     return;
   }
   logger.info(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3342,6 +3342,15 @@ export async function run(argv: string[]): Promise<void> {
       break;
     }
 
+    case 'version': {
+      // The `npm version` / `gh version` convention (#51): the triage header
+      // for any report. Mirrors what `issue` collects for diagnostics.
+      console.log(`vyuh-dxkit ${VERSION}`); // slop-ok — version output
+      console.log(`node ${process.version}`); // slop-ok — version output
+      console.log(`${process.platform} ${process.arch}`); // slop-ok — version output
+      break;
+    }
+
     case 'issue': {
       const { runIssueSubmit } = await import('./issue-cli');
       await runIssueSubmit(cwd, {

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -157,6 +157,15 @@ export const COMMANDS = [
     docsBlurb:
       'Compose a typed feedback issue (false-positive / bug / feature-request / …); nothing submits until you confirm in the browser.',
   },
+  {
+    id: 'version',
+    audience: 'user',
+    group: 'setup',
+    summary: 'Print the dxkit, Node, and platform versions',
+    typicalRuntime: '< 1 sec',
+    docsBlurb:
+      'The `npm version`/`gh version` convention: dxkit version, Node version, and platform in one line each — the triage header for any report.',
+  },
   // ── Assess ─────────────────────────────────────────────────────────────
   {
     id: 'health',

--- a/src/explore/context-hook.ts
+++ b/src/explore/context-hook.ts
@@ -215,30 +215,42 @@ export function parseBashForTarget(
   graph: Graph,
   cwd: string,
 ): HookTarget | undefined {
-  if (!/\b(grep|egrep|fgrep|rg|ag|ack)\b/.test(command)) return undefined;
-
-  // First clause only — ignore everything past a pipe/`&&`/`;` so a
-  // downstream command's args don't masquerade as search paths.
-  const head = command.split(/\||&&|;/)[0];
-  const tokens = head.split(/\s+/).filter(Boolean).map(stripQuotes);
-
   const binaries = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
 
-  // 1. A concrete file argument that exists in the graph wins — that's
-  //    the file the agent is looking at, structural map is most useful.
-  for (const tok of tokens) {
-    if (tok.startsWith('-') || binaries.has(tok)) continue;
-    const rel = toRepoRelative(tok, cwd);
-    if (graph.nodesByFile.has(rel)) return { kind: 'file', file: rel };
-  }
+  // Parse the CLAUSE that actually runs the search tool, not the first
+  // clause of a command that merely contains one somewhere. The shipped
+  // false-positive class: `ls src | grep x` matched the whole-command
+  // regex, the head clause (`ls src`) was parsed, and `ls` itself became a
+  // symbol-search pattern — injecting an unrelated symbol table into a
+  // trivial navigation command. Now a clause qualifies only when a search
+  // binary is one of ITS tokens, and extraction starts AFTER that binary.
+  for (const clause of command.split(/\||&&|;/)) {
+    const tokens = clause.split(/\s+/).filter(Boolean).map(stripQuotes);
+    const binIndex = tokens.findIndex((t) => binaries.has(t));
+    if (binIndex === -1) continue;
+    const args = tokens.slice(binIndex + 1);
 
-  // 2. Else the first plausible search term → symbol match. Skip flags,
-  //    the binary, redirections, and path-ish/dir tokens.
-  for (const tok of tokens) {
-    if (tok.startsWith('-') || binaries.has(tok)) continue;
-    if (/[/<>|*]/.test(tok) || tok.includes('..')) continue;
-    if (tok.length < 2) continue;
-    return { kind: 'pattern', pattern: tok };
+    // 1. A concrete file argument that exists in the graph wins — that's
+    //    the file the agent is looking at, structural map is most useful.
+    for (const tok of args) {
+      if (tok.startsWith('-')) continue;
+      const rel = toRepoRelative(tok, cwd);
+      if (graph.nodesByFile.has(rel)) return { kind: 'file', file: rel };
+    }
+
+    // 2. Else the first plausible search term → symbol match. Skip flags,
+    //    redirections, path-ish/dir tokens, and anything too short or too
+    //    un-identifier-like to resolve into the graph meaningfully — a
+    //    weak pattern substring-matching random symbols trains the agent
+    //    to skim past the hook (the relevance floor).
+    for (const tok of args) {
+      if (tok.startsWith('-')) continue;
+      if (/[/<>|*]/.test(tok) || tok.includes('..')) continue;
+      if (tok.length < 3) continue;
+      if (!/^[A-Za-z_$][\w$.-]*$/.test(tok)) continue;
+      return { kind: 'pattern', pattern: tok };
+    }
+    return undefined; // a search clause with no usable target — no-op
   }
   return undefined;
 }

--- a/test/explore/context-hook.test.ts
+++ b/test/explore/context-hook.test.ts
@@ -249,6 +249,30 @@ describe('parseBashForTarget', () => {
     expect(parseBashForTarget('npm run build', graph, cwd)).toBeUndefined();
     expect(parseBashForTarget('ls -la src/', graph, cwd)).toBeUndefined();
   });
+
+  it('a navigation command piped INTO grep parses the grep clause, never the ls clause', () => {
+    // The shipped false-positive: `ls src | grep …` matched the whole-command
+    // regex, the head clause was parsed, and `ls` itself became a symbol
+    // pattern — injecting an unrelated symbol table on a trivial command.
+    expect(parseBashForTarget('ls -la src | grep -i readme', graph, cwd)).toEqual({
+      kind: 'pattern',
+      pattern: 'readme',
+    });
+    // A filter term too weak to resolve meaningfully stays a no-op.
+    expect(parseBashForTarget('ls | grep x', graph, cwd)).toBeUndefined();
+  });
+
+  it('parses the search clause wherever it sits in a compound command', () => {
+    expect(parseBashForTarget('echo start && grep sendFile src/', graph, cwd)).toEqual({
+      kind: 'pattern',
+      pattern: 'sendFile',
+    });
+  });
+
+  it('relevance floor: short or non-identifier patterns never fire', () => {
+    expect(parseBashForTarget('grep ls src/', graph, cwd)).toBeUndefined();
+    expect(parseBashForTarget('grep "a b c" src/', graph, cwd)).toBeUndefined();
+  });
 });
 
 describe('formatFileContext', () => {


### PR DESCRIPTION
Part of the 4.3.6 release train (target: `release/4.3.6`).

- **`vyuh-dxkit version`** (#51): npm-version convention output, registered in the capability registry; the docs command table regenerates from the registry (its parity test enforced exactly that).
- **allowlist empty state** (#52): explanation + guide link instead of a bare one-liner.
- **Context-hook relevance floor** (#225): the Bash parser targets the clause that actually runs the search binary — `ls … | grep …` no longer turns `ls` into a symbol pattern; weak/non-identifier patterns never fire. Both directions pinned in tests (the real search term still fires).
- **getting-started "Common pitfalls"** (#50): the five recurring first-run breaks with two-line fixes.
- **examples/hello-world** (#49): zero-dep score → baseline → gate walkthrough, runnable in under a minute. Deliberately no pre-captured baseline (a committed baseline artifact goes stale against scanner versions and reads as drift — the README says so); the gate-trip demo generates its token on the reader's machine so this repo contains no secret-shaped string.

## Validation

Full local sweep green (345 files / 5214 tests, arch, slop, self-guardrail); the example's own test suite runs clean under `node --test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)