### PR TITLE
WP7: test-file-degradation catch-22 (#233)

### DIFF
--- a/src/allowlist/categories.ts
+++ b/src/allowlist/categories.ts
@@ -126,7 +126,12 @@ export const CATEGORIES_BY_KIND: Readonly<Record<IdentityKind, readonly Allowlis
   // only accepted-risk or deferred
   'coverage-gap': ['accepted-risk', 'deferred'],
   'test-gap': ['accepted-risk', 'deferred'],
-  'test-file-degradation': ['accepted-risk', 'deferred'],
+  // Degradation CAN be a scanner misfire (gh #233: a shared-helpers module
+  // in a tests tree misread as a degraded test). The heuristic exemptions
+  // reduce the class, but a kind whose detector can misfire must let the
+  // typed-suppression system say "not real" — the real-exposure categories
+  // carry expiry and score weight, which is the wrong shape for a misfire.
+  'test-file-degradation': ['false-positive', 'accepted-risk', 'deferred'],
 
   // Whole-file findings: false-positive (file IS not actually large /
   // stale / god when reviewed); otherwise accepted-risk or deferred

--- a/src/analyzers/tests/gather.ts
+++ b/src/analyzers/tests/gather.ts
@@ -63,24 +63,76 @@ export function isFixtureSupportPath(relPath: string): boolean {
   return FIXTURE_SUPPORT_DIR.test(relPath.replace(/\\/g, '/'));
 }
 
+/** Tool-recognized test-INFRASTRUCTURE basenames: files a test runner
+ *  collects by design that can never contain collected tests, so "contains
+ *  no tests" is their correct state, not degradation. `conftest.py` is
+ *  pytest's own support surface (gh #233 — it was flagged as a degraded
+ *  test file, closing a catch-22 around extracting shared test helpers).
+ *  Curated cross-ecosystem, like FIXTURE_SUPPORT_DIR above; grow it (or
+ *  promote to a pack-declared field) as new runners join. */
+const TEST_SUPPORT_BASENAMES = new Set(['conftest.py']);
+
+/** Escape a module name for embedding in a RegExp. */
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * A testless module in a tests tree that a SIBLING active test imports is
+ * shared test-support code (builders, fixtures-as-code), not a degraded
+ * test file (gh #233): "extract the duplicated builders to a helper" is
+ * the standard refactor the duplication gate itself pushes toward, and
+ * flagging the helper as degradation closed a catch-22 around it. The
+ * import evidence is a per-language module reference to the file's
+ * basename (python `from helpers import …` / JS `from './helpers'`).
+ */
+function isImportedByActiveSibling(modName: string, activeContents: readonly string[]): boolean {
+  const mod = escapeRe(modName);
+  // Python: `import helpers`, `from helpers import x`, `from tests.helpers import x`,
+  // `from .helpers import x`.
+  const py = new RegExp(`(^|\\n)\\s*(from|import)\\s+[\\w.]*\\b${mod}\\b`);
+  // JS/TS: `from './helpers'`, `require('../helpers')`, extension optional.
+  const js = new RegExp(`(from\\s+|require\\()\\s*['"][^'"]*[/.]${mod}(\\.[cm]?[jt]sx?)?['"]`);
+  return activeContents.some((c) => py.test(c) || js.test(c));
+}
+
 export function gatherTestFiles(cwd: string): TestFile[] {
   // Walker computes test-files as (includeTests:true SET) MINUS
   // (includeTests:false SET). Test-pattern derivation is pack-driven
   // via `allTestFilePatterns()`, so adding a new pack auto-extends.
   const allFiles = new Set(walkSourceFiles(cwd, { includeTests: true }));
   const nonTestFiles = new Set(walkSourceFiles(cwd));
-  const testFiles: TestFile[] = [];
+  const candidates: Array<TestFile & { readonly content: string }> = [];
   for (const p of allFiles) {
     if (nonTestFiles.has(p)) continue;
     if (isFixtureSupportPath(p)) continue; // fixtures/mocks/snapshots are support, not tests
+    if (TEST_SUPPORT_BASENAMES.has(path.basename(p))) continue; // runner infrastructure, not a test
     const fullPath = path.join(cwd, p);
-    testFiles.push({
+    let content = '';
+    try {
+      content = fs.readFileSync(fullPath, 'utf-8');
+    } catch {
+      // unreadable → classifyTestFile re-reads and degrades to 'empty'
+    }
+    candidates.push({
       path: p,
       status: classifyTestFile(fullPath),
       framework: detectTestFramework(fullPath),
+      content,
     });
   }
-  return testFiles;
+  // Second pass: a NON-active candidate imported by an active sibling is
+  // shared support code — excluded like the fixture dirs above, so it never
+  // mints a degradation finding (and never a new status value: exclusion,
+  // not reclassification, keeps finding identity untouched).
+  const activeContents = candidates.filter((c) => c.status === 'active').map((c) => c.content);
+  return candidates
+    .filter((c) => {
+      if (c.status === 'active') return true;
+      const modName = path.basename(c.path).replace(/\.[^.]+$/, '');
+      return !isImportedByActiveSibling(modName, activeContents);
+    })
+    .map(({ path: p, status, framework }) => ({ path: p, status, framework }));
 }
 
 function classifyTestFile(fullPath: string): TestFile['status'] {

--- a/test/allowlist/categories.test.ts
+++ b/test/allowlist/categories.test.ts
@@ -76,10 +76,17 @@ describe('allowlist categories', () => {
     expect(CATEGORIES_BY_KIND['stale-allow']).toEqual([]);
   });
 
-  it('coverage-gap / test-gap / test-file-degradation are accepted-risk + deferred only', () => {
+  it('coverage-gap / test-gap are accepted-risk + deferred only', () => {
     expect(CATEGORIES_BY_KIND['coverage-gap']).toEqual(['accepted-risk', 'deferred']);
     expect(CATEGORIES_BY_KIND['test-gap']).toEqual(['accepted-risk', 'deferred']);
-    expect(CATEGORIES_BY_KIND['test-file-degradation']).toEqual(['accepted-risk', 'deferred']);
+  });
+
+  it('test-file-degradation additionally permits false-positive (gh #233 — its detector can misfire)', () => {
+    expect(CATEGORIES_BY_KIND['test-file-degradation']).toEqual([
+      'false-positive',
+      'accepted-risk',
+      'deferred',
+    ]);
   });
 
   it('hygiene is accepted-risk + deferred only', () => {

--- a/test/gather-tests.test.ts
+++ b/test/gather-tests.test.ts
@@ -220,3 +220,44 @@ describe('matchTestsToSource', () => {
     expect(sources[0].hasMatchingTest).toBe(false);
   });
 });
+
+describe('test-support exemptions (gh #233 — the extract-helpers catch-22)', () => {
+  it('conftest.py never appears as a (degraded) test file — pytest infrastructure', () => {
+    writeFile('tests/test_math.py', 'def test_add():\n  assert 1 + 1 == 2\n');
+    writeFile(
+      'tests/conftest.py',
+      'import pytest\n\n@pytest.fixture\ndef costs():\n    return {"a": 1}\n',
+    );
+    const files = gatherTestFiles(tmp);
+    expect(files.map((f) => f.path)).toEqual(['tests/test_math.py']);
+  });
+
+  it('a testless helpers module IMPORTED by a sibling active test is support, not degradation', () => {
+    writeFile(
+      'tests/test_policy.py',
+      'from helpers import make_costs\n\ndef test_policy():\n  assert make_costs()["a"] == 1\n',
+    );
+    writeFile('tests/helpers.py', 'def make_costs():\n    return {"a": 1}\n');
+    const files = gatherTestFiles(tmp);
+    expect(files.map((f) => f.path).sort()).toEqual(['tests/test_policy.py']);
+  });
+
+  it('a JS test-tree helper imported via a relative path is support too', () => {
+    writeFile(
+      'test/render.test.ts',
+      'import { build } from "./builders";\ndescribe("r", () => { it("x", () => { expect(build()).toBeTruthy(); }); });',
+    );
+    writeFile('test/builders.ts', 'export const build = () => ({ ok: true });\n');
+    const files = gatherTestFiles(tmp);
+    expect(files.map((f) => f.path)).toEqual(['test/render.test.ts']);
+  });
+
+  it('an UNREFERENCED testless file in the tests tree still reads as degraded (the over-skip guard)', () => {
+    writeFile('tests/test_math.py', 'def test_add():\n  assert 1 + 1 == 2\n');
+    writeFile('tests/test_orphan.py', 'def build():\n    return 1\n');
+    const files = gatherTestFiles(tmp);
+    const orphan = files.find((f) => f.path === 'tests/test_orphan.py');
+    expect(orphan).toBeDefined();
+    expect(orphan!.status).not.toBe('active');
+  });
+});


### PR DESCRIPTION
Part of the 4.3.6 release train (target: `release/4.3.6`). Scoped from #233, filed today during the collection window.

## Root cause

The degradation detector treated every testless file matched by test patterns as a degraded test, with no concept of test SUPPORT code — while the duplication gate pushes exactly toward extracting shared helpers, and the kind's category matrix offered no honest "not real" suppression. All three exits from the standard refactor were blocked.

## Changes

- **conftest.py exemption**: excluded from test-file discovery as runner infrastructure (same mechanism as the existing fixtures/mocks/testdata exclusion).
- **Imported-by-sibling support detection**: a testless module in a tests tree that an active sibling test imports (python/JS module-reference shapes) is support code — excluded, not reclassified, so finding identity is untouched. Over-skip guard pinned: an unreferenced testless file still reads as degraded.
- **Category matrix**: `test-file-degradation` now admits `false-positive` (a kind whose detector can misfire must be suppressible as a misfire; the real-exposure categories carry expiry + score weight — the wrong shape).

## Validation

Full local sweep green (345 files / 5216 tests, arch, slop, self-guardrail); the repro shapes from the issue are the new test fixtures.

Closes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)