### PR TITLE
WP8: remediate dispatch campaigns (typed inputs, custom prompt, clamped spend)

### DIFF
--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -33,7 +33,43 @@ name: dxkit remediate
 on:
   schedule:
     - cron: '__DXKIT_REMEDIATE_CRON__'
-  workflow_dispatch: {}
+  # Dispatch campaigns (one-time runs with per-run overrides). The scheduled
+  # posture reads policy; a dispatch is an explicit, WRITE-GATED human action
+  # (GitHub only lets users with write access fire it), so it may select one
+  # task — including `custom` with a free-text prompt — and override budgets
+  # within the committed `remediate.maxDispatchBudget` ceiling. The prompt
+  # travels via ENV (never shell-interpolated) and is disclosed verbatim in
+  # the PR body; the work still lands only through the verified frame.
+  workflow_dispatch:
+    inputs:
+      task:
+        description: 'Run ONE task (blank = the scheduled set)'
+        type: choice
+        default: ''
+        options:
+          - ''
+__DXKIT_REMEDIATE_TASK_OPTIONS__
+          - custom
+      prompt:
+        description: 'Custom task prompt (task=custom only; disclosed verbatim in the PR)'
+        type: string
+        default: ''
+      max_usd:
+        description: 'Spend override in USD (blank = policy; clamped to remediate.maxDispatchBudget)'
+        type: string
+        default: ''
+      max_turns:
+        description: 'Turn-cap override (blank = policy)'
+        type: string
+        default: ''
+      max_minutes:
+        description: 'Wall-clock override in minutes (blank = policy)'
+        type: string
+        default: ''
+      model:
+        description: 'Model override (blank = policy)'
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -75,17 +111,24 @@ jobs:
 
       - name: Compute the task matrix
         id: plan
+        env:
+          # A dispatch that names a task runs EXACTLY that task (its choice
+          # list is rendered from the registry, so the value is a known id or
+          # `custom`); blank falls through to the scheduled, spend-ceilinged
+          # set from the plan.
+          DISPATCH_TASK: ${{ github.event.inputs.task || '' }}
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi
           "$DXKIT" remediate plan --json > remediate-plan.json
           node - <<'EOF'
           const fs = require('fs');
           const p = JSON.parse(fs.readFileSync('remediate-plan.json', 'utf8'));
-          const tasks = p.matrixTasks ?? [];
+          const dispatchTask = (process.env.DISPATCH_TASK || '').trim();
+          const tasks = dispatchTask ? [dispatchTask] : (p.matrixTasks ?? []);
           const out = process.env.GITHUB_OUTPUT;
           fs.appendFileSync(out, `tasks=${JSON.stringify(tasks)}\n`);
           fs.appendFileSync(out, `any=${tasks.length > 0 ? 'true' : 'false'}\n`);
-          const deferred = p.deferredBySpendCeiling ?? [];
+          const deferred = dispatchTask ? [] : (p.deferredBySpendCeiling ?? []);
           if (deferred.length > 0) {
             console.log(`::notice title=remediate spend ceiling::deferred to the next firing: ${deferred.join(', ')}`);
           }
@@ -178,6 +221,15 @@ __DXKIT_CI_RUNTIME_SETUP__
       - name: Run task ${{ matrix.task }}
         env:
           GH_TOKEN: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
+          # Dispatch-campaign inputs, transported via ENV only (the
+          # comment-defer pattern — free text never touches a shell line).
+          # Blank on scheduled runs; the CLI clamps budget overrides to the
+          # committed remediate.maxDispatchBudget and discloses every clamp.
+          DXKIT_CUSTOM_PROMPT: ${{ github.event.inputs.prompt || '' }}
+          DXKIT_DISPATCH_MAX_USD: ${{ github.event.inputs.max_usd || '' }}
+          DXKIT_DISPATCH_MAX_TURNS: ${{ github.event.inputs.max_turns || '' }}
+          DXKIT_DISPATCH_MAX_MINUTES: ${{ github.event.inputs.max_minutes || '' }}
+          DXKIT_DISPATCH_MODEL: ${{ github.event.inputs.model || '' }}
 __DXKIT_REMEDIATE_CREDENTIAL_ENV__
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -305,6 +305,12 @@ export function buildPolicySchema(version: string): Schema {
               'Run-level USD ceiling across the per-task matrix (0/absent = none). Tasks ' +
               'beyond it are deferred to the next firing, in order, and disclosed.',
           },
+          maxDispatchBudget: {
+            type: 'number',
+            description:
+              'The most a workflow_dispatch campaign may raise maxUsd to (0/absent = ' +
+              'dispatch can lower spend but never raise it beyond the policy cap).',
+          },
         },
         'Agentic remediation: a scheduled agent inside the verified frame.',
       ),

--- a/src/remediate/cli.ts
+++ b/src/remediate/cli.ts
@@ -34,6 +34,7 @@ import {
   tasksWithinSpendCeiling,
   type RemediateConfig,
 } from './config';
+import { readDispatchOverrides } from './dispatch';
 import { driverById } from './registry';
 import { REMEDIATE_TASKS, remediateTaskById } from './tasks';
 import { runRemediateTask, type RemediateResult } from './run';
@@ -78,10 +79,19 @@ async function executeTask(
 ): Promise<TaskRun> {
   // Per-task budget: the override-merged budget rides a task-scoped config
   // copy, so the runner's enforcement + ledger see the effective caps.
+  // Dispatch-campaign overrides (env-transported, clamped) layer on top —
+  // the runner receives the disclosure and folds it into the ledger.
   const task = remediateTaskById(taskId);
-  const taskConfig: RemediateConfig = task
-    ? { ...config, agent: { ...config.agent, budget: budgetForTask(config, task.id) } }
-    : config;
+  const policyBudget = task ? budgetForTask(config, task.id) : config.agent.budget;
+  const dispatch = readDispatchOverrides(process.env, policyBudget, config);
+  const taskConfig: RemediateConfig = {
+    ...config,
+    agent: {
+      ...config.agent,
+      budget: dispatch.any ? dispatch.budget : policyBudget,
+      ...(dispatch.model !== undefined ? { model: dispatch.model } : {}),
+    },
+  };
   // Phase reporter: per-phase log groups + a 60s heartbeat so a long agent
   // or verify phase reads as "working", never as hung.
   const reporter = startPhaseReporter(`remediate:${taskId}`);
@@ -96,6 +106,7 @@ async function executeTask(
       // own default applies (claude-code: subscription mode).
       agentEnv: collectCredentialEnv(config.agent.driver),
       onPhase: (phase) => reporter.phase(phase),
+      dispatch,
     });
   } finally {
     reporter.stop();

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -52,6 +52,12 @@ export interface RemediateConfig {
    *  one firing. Tasks beyond the ceiling are DEFERRED (disclosed), in
    *  declaration order — never silently dropped. */
   readonly maxSpendPerRun: number;
+  /** Dispatch-campaign USD ceiling (`remediate.maxDispatchBudget`, 0 =
+   *  undeclared): the most a workflow_dispatch override may raise `maxUsd`
+   *  to. Undeclared ⇒ dispatch can lower spend but never raise it beyond
+   *  the policy cap — spend authority grows only in committed policy,
+   *  never in a dispatch form field. */
+  readonly maxDispatchBudget: number;
 }
 
 /** The effective budget for one task: the per-task override merged over the
@@ -141,6 +147,12 @@ export function resolveRemediateConfig(cwd: string): RemediateConfig {
       Number.isFinite(raw.maxSpendPerRun) &&
       raw.maxSpendPerRun > 0
         ? raw.maxSpendPerRun
+        : 0,
+    maxDispatchBudget:
+      typeof raw.maxDispatchBudget === 'number' &&
+      Number.isFinite(raw.maxDispatchBudget) &&
+      raw.maxDispatchBudget > 0
+        ? raw.maxDispatchBudget
         : 0,
   };
 }

--- a/src/remediate/dispatch.ts
+++ b/src/remediate/dispatch.ts
@@ -1,0 +1,156 @@
+/**
+ * Dispatch-campaign inputs (E2/E3): a one-time, human-triggered remediate
+ * run with per-run overrides — task selection, budget, model, and (for the
+ * `custom` task) a free-text prompt.
+ *
+ * TRUST MODEL, stated once: the scheduled lane runs dxkit-authored prompts
+ * only. A dispatch campaign relaxes that for a WRITE-GATED surface — GitHub
+ * only lets users with write access fire workflow_dispatch — and the work
+ * still lands ONLY via a PR through the identical verified frame (entry
+ * snapshot, floor attribution, guardrail, sweep). The prompt is transported
+ * via ENV (the comment-defer pattern — never shell-interpolated, never
+ * argv), and the ledger/PR body disclose the dispatcher and the verbatim
+ * prompt so a reviewer sees exactly what was asked.
+ *
+ * Budget overrides are CLAMPED: maxUsd may never exceed
+ * `remediate.maxDispatchBudget` (when unset, the policy's own per-task cap
+ * is the ceiling — a dispatch without a declared ceiling can lower spend,
+ * never raise it). Every clamp is disclosed, never silent.
+ */
+import type { RemediateBudget, RemediateConfig } from './config';
+import { customDispatchTask, knownTaskIds, remediateTaskById, type RemediateTask } from './tasks';
+
+/** Env names — the one place they are spelled. The workflow maps its typed
+ *  dispatch inputs onto exactly these. */
+export const DISPATCH_ENV = {
+  maxUsd: 'DXKIT_DISPATCH_MAX_USD',
+  maxTurns: 'DXKIT_DISPATCH_MAX_TURNS',
+  maxMinutes: 'DXKIT_DISPATCH_MAX_MINUTES',
+  model: 'DXKIT_DISPATCH_MODEL',
+  customPrompt: 'DXKIT_CUSTOM_PROMPT',
+} as const;
+
+export interface DispatchOverrides {
+  /** Effective budget after overrides + clamping (absent field = policy). */
+  readonly budget: RemediateBudget;
+  /** Model override, when given (else the policy model applies). */
+  readonly model?: string;
+  /** The custom task's verbatim prompt (task `custom` only). */
+  readonly customPrompt?: string;
+  /** Who fired the dispatch (GITHUB_ACTOR) — ledger disclosure. */
+  readonly actor?: string;
+  /** Human-phrased clamp disclosures (empty = nothing clamped). */
+  readonly clamped: readonly string[];
+  /** True when any dispatch input was present at all. */
+  readonly any: boolean;
+}
+
+/**
+ * Resolve the task for a run, dispatch-aware (the runner's one entry).
+ * `custom` exists only for a dispatch carrying a prompt — it is not in the
+ * registry, so policy can never schedule it, and without a prompt it is a
+ * refusal, never an empty-prompt agent run. Also computes the disclosure
+ * that must ride EVERY result's ledger.
+ */
+export function resolveDispatchedTask(
+  taskId: string,
+  dispatch: DispatchOverrides | undefined,
+): {
+  readonly task?: RemediateTask;
+  readonly refusalNote?: string;
+  readonly disclosure?: NonNullable<RemediateResultDispatch>;
+} {
+  const task =
+    taskId === 'custom'
+      ? dispatch?.customPrompt
+        ? customDispatchTask(dispatch.customPrompt)
+        : undefined
+      : remediateTaskById(taskId);
+  if (!task) {
+    return {
+      refusalNote:
+        taskId === 'custom'
+          ? `refused: the custom task requires a prompt (the workflow_dispatch 'prompt' input, ` +
+            `transported via env) — none was provided.`
+          : `refused: unknown task '${taskId}' — known tasks: ${knownTaskIds().join(', ')}.`,
+    };
+  }
+  const disclosure =
+    dispatch && (dispatch.any || taskId === 'custom')
+      ? {
+          ...(dispatch.actor !== undefined ? { actor: dispatch.actor } : {}),
+          ...(taskId === 'custom' && dispatch.customPrompt !== undefined
+            ? { prompt: dispatch.customPrompt }
+            : {}),
+          clamped: dispatch.clamped,
+        }
+      : undefined;
+  return { task, ...(disclosure ? { disclosure } : {}) };
+}
+
+/** The result's dispatch-disclosure shape (mirrors `RemediateResult.dispatch`). */
+export type RemediateResultDispatch =
+  | {
+      readonly actor?: string;
+      readonly prompt?: string;
+      readonly clamped: readonly string[];
+    }
+  | undefined;
+
+function num(v: string | undefined): number | undefined {
+  if (v === undefined || v.trim() === '') return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
+ * Read the dispatch env against the policy budget for one task. Pure over
+ * its inputs; the CLI passes `process.env`.
+ */
+export function readDispatchOverrides(
+  env: Readonly<Record<string, string | undefined>>,
+  policyBudget: RemediateBudget,
+  config: Pick<RemediateConfig, 'maxDispatchBudget'>,
+): DispatchOverrides {
+  const clamped: string[] = [];
+  const reqUsd = num(env[DISPATCH_ENV.maxUsd]);
+  const reqTurns = num(env[DISPATCH_ENV.maxTurns]);
+  const reqMinutes = num(env[DISPATCH_ENV.maxMinutes]);
+  const model = env[DISPATCH_ENV.model]?.trim() || undefined;
+  const customPrompt = env[DISPATCH_ENV.customPrompt]?.trim() || undefined;
+
+  // The USD ceiling: an explicit maxDispatchBudget, else the policy's own
+  // cap (a dispatch may spend LESS than policy without any declaration, but
+  // raising spend requires the committed ceiling to say so).
+  const usdCeiling = config.maxDispatchBudget > 0 ? config.maxDispatchBudget : policyBudget.maxUsd;
+  let maxUsd = policyBudget.maxUsd;
+  if (reqUsd !== undefined) {
+    maxUsd = Math.min(reqUsd, usdCeiling);
+    if (maxUsd < reqUsd) {
+      clamped.push(
+        `maxUsd override $${reqUsd} clamped to $${maxUsd} ` +
+          (config.maxDispatchBudget > 0
+            ? '(remediate.maxDispatchBudget)'
+            : '(no remediate.maxDispatchBudget declared — dispatch may not raise spend beyond policy)'),
+      );
+    }
+  }
+
+  return {
+    budget: {
+      maxUsd,
+      maxTurns: reqTurns ?? policyBudget.maxTurns,
+      maxMinutes: reqMinutes ?? policyBudget.maxMinutes,
+    },
+    ...(model !== undefined ? { model } : {}),
+    ...(customPrompt !== undefined ? { customPrompt } : {}),
+    ...(env.GITHUB_ACTOR ? { actor: env.GITHUB_ACTOR } : {}),
+    clamped,
+    any:
+      reqUsd !== undefined ||
+      reqTurns !== undefined ||
+      reqMinutes !== undefined ||
+      model !== undefined ||
+      customPrompt !== undefined,
+  };
+}

--- a/src/remediate/git-ops.ts
+++ b/src/remediate/git-ops.ts
@@ -1,0 +1,55 @@
+/**
+ * The remediate runner's real git operations, split from `run.ts` for module
+ * size. The sweep NEVER names runtime paths in the add pathspec — git
+ * hard-errors on a pathspec matching only gitignored paths (the script's
+ * observed failure); stage everything, then un-stage runtime state.
+ */
+import { execFileSync } from 'child_process';
+import { BOT_IDENTITY } from '../land-refresh';
+import type { RemediateGit } from './run';
+
+export function realGit(cwd: string): RemediateGit {
+  const git = (args: string[]): string =>
+    execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  return {
+    head: () => git(['rev-parse', 'HEAD']),
+    sweepLeftovers() {
+      const status = git(['status', '--porcelain']);
+      const leftovers = status
+        .split('\n')
+        .filter(
+          (l) =>
+            l.trim() &&
+            !l.includes('.dxkit/loop') &&
+            !l.includes('.dxkit/cache') &&
+            !l.includes('.dxkit/reports'),
+        );
+      if (leftovers.length === 0) return undefined;
+      try {
+        git(['add', '-A']);
+        try {
+          git(['restore', '--staged', '--', '.dxkit/loop', '.dxkit/cache', '.dxkit/reports']);
+        } catch {
+          // nothing staged from runtime paths — fine
+        }
+        // Explicit bot identity (Rule 2: the one BOT_IDENTITY) — a CI
+        // runner has no ambient git identity, and the sweep must commit
+        // there or the whole lane reads as no-op.
+        git([
+          '-c',
+          `user.name=${BOT_IDENTITY.name}`,
+          '-c',
+          `user.email=${BOT_IDENTITY.email}`,
+          'commit',
+          '-q',
+          '-m',
+          'chore: commit remaining agent working state (swept by the runner — review closely)',
+        ]);
+        return undefined;
+      } catch (e) {
+        return e instanceof Error ? e.message.split('\n').slice(-1)[0] : String(e);
+      }
+    },
+    hasDiff: (baseHead: string) => git(['rev-list', '--count', `${baseHead}..HEAD`]) !== '0',
+  };
+}

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -56,6 +56,22 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
     lines.push('');
   }
 
+  if (r.dispatch) {
+    lines.push('### Dispatch campaign', '');
+    lines.push(
+      `- dispatched by: ${r.dispatch.actor ? `\`${r.dispatch.actor}\`` : 'not reported (no GITHUB_ACTOR)'}`,
+    );
+    for (const c of r.dispatch.clamped) lines.push(`- clamped: ${c}`);
+    if (r.dispatch.prompt !== undefined) {
+      lines.push(
+        '- no score hinge exists for a custom goal — verification is the floor + the ' +
+          'guardrail + the human reviewing this PR against the prompt below.',
+      );
+      lines.push('', 'Prompt (verbatim):', '', '```', r.dispatch.prompt, '```');
+    }
+    lines.push('');
+  }
+
   lines.push('### Verification', '');
   lines.push(...renderFloorVerification(r.floor, r.floorAttribution, 'the pre-agent entry run'));
   lines.push(...renderGuardrailVerdict(r.guardrailVerdict));

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -22,7 +22,6 @@
  * dxkit-authored prompts only. Landing (the standing PR) is composed by the
  * CLI/workflow layer on top of this runner's outcome.
  */
-import { execFileSync } from 'child_process';
 import type { AnalysisTrustContext } from '../analysis-trust';
 import { runCorrectnessFloor, type CorrectnessFloorResult } from '../analyzers/correctness/run';
 import {
@@ -33,10 +32,11 @@ import {
 import { detectActiveLanguages } from '../languages';
 import { renderRemediateLedger } from './ledger-render';
 import { guardrailVerdictFor, toFloorBaseChecks, type GuardrailGateResult } from '../lanes/verify';
-import { BOT_IDENTITY } from '../land-refresh';
 import { resolveModelSetting, type AgentDriver, type AgentRunResult } from './driver';
 import { AGENT_DRIVERS, knownDriverIds } from './registry';
-import { remediateTaskById, knownTaskIds, type RemediateTask } from './tasks';
+import type { RemediateTask } from './tasks';
+import { resolveDispatchedTask, type DispatchOverrides } from './dispatch';
+import { realGit } from './git-ops';
 import {
   evaluateScoreHinge,
   healthHingeScores,
@@ -93,6 +93,14 @@ export interface RemediateResult {
   /** HEAD before/after the agent — the commit range a lander pushes. */
   readonly baseHead?: string;
   readonly head?: string;
+  /** Dispatch-campaign disclosure (E3): who fired it, the verbatim custom
+   *  prompt (when the `custom` task ran), and any clamped overrides. In the
+   *  ledger = in the PR body, so the reviewer sees exactly what was asked. */
+  readonly dispatch?: {
+    readonly actor?: string;
+    readonly prompt?: string;
+    readonly clamped: readonly string[];
+  };
   /** The verification ledger — PR body / job summary markdown. */
   readonly ledger: string;
 }
@@ -104,55 +112,6 @@ export interface RemediateGit {
   sweepLeftovers(): string | undefined;
   /** Any commits in base..HEAD? */
   hasDiff(baseHead: string): boolean;
-}
-
-/** Real git ops. The sweep NEVER names runtime paths in the add pathspec —
- *  git hard-errors on a pathspec matching only gitignored paths (the script's
- *  observed failure); stage everything, then un-stage runtime state. */
-function realGit(cwd: string): RemediateGit {
-  const git = (args: string[]): string =>
-    execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
-  return {
-    head: () => git(['rev-parse', 'HEAD']),
-    sweepLeftovers() {
-      const status = git(['status', '--porcelain']);
-      const leftovers = status
-        .split('\n')
-        .filter(
-          (l) =>
-            l.trim() &&
-            !l.includes('.dxkit/loop') &&
-            !l.includes('.dxkit/cache') &&
-            !l.includes('.dxkit/reports'),
-        );
-      if (leftovers.length === 0) return undefined;
-      try {
-        git(['add', '-A']);
-        try {
-          git(['restore', '--staged', '--', '.dxkit/loop', '.dxkit/cache', '.dxkit/reports']);
-        } catch {
-          // nothing staged from runtime paths — fine
-        }
-        // Explicit bot identity (Rule 2: the one BOT_IDENTITY) — a CI
-        // runner has no ambient git identity, and the sweep must commit
-        // there or the whole lane reads as no-op.
-        git([
-          '-c',
-          `user.name=${BOT_IDENTITY.name}`,
-          '-c',
-          `user.email=${BOT_IDENTITY.email}`,
-          'commit',
-          '-q',
-          '-m',
-          'chore: commit remaining agent working state (swept by the runner — review closely)',
-        ]);
-        return undefined;
-      } catch (e) {
-        return e instanceof Error ? e.message.split('\n').slice(-1)[0] : String(e);
-      }
-    },
-    hasDiff: (baseHead: string) => git(['rev-list', '--count', `${baseHead}..HEAD`]) !== '0',
-  };
 }
 
 export interface RemediateRunOptions {
@@ -176,6 +135,10 @@ export interface RemediateRunOptions {
    *  log groups + heartbeats (a 35-minute silent step is indistinguishable
    *  from a hang; "working" must be observable from the job log). */
   readonly onPhase?: (phase: RemediatePhase) => void;
+  /** Dispatch-campaign overrides (E2/E3), read from env by the CLI layer.
+   *  Carries the custom task's prompt, the clamp disclosures, and the
+   *  dispatcher for the ledger. */
+  readonly dispatch?: DispatchOverrides;
 }
 
 /** The runner's observable phases, in order. */
@@ -192,10 +155,13 @@ export type RemediatePhase =
 export { renderRemediateLedger };
 
 export async function runRemediateTask(opts: RemediateRunOptions): Promise<RemediateResult> {
-  const finish = (r: Omit<RemediateResult, 'ledger'>): RemediateResult => ({
-    ...r,
-    ledger: renderRemediateLedger(r),
-  });
+  // Populated once the task resolves (a dispatch campaign's disclosure);
+  // folded into EVERY exit so no outcome can drop it from the ledger.
+  let dispatchDisclosure: Pick<RemediateResult, 'dispatch'> = {};
+  const finish = (r: Omit<RemediateResult, 'ledger' | 'dispatch'>): RemediateResult => {
+    const withDispatch = { ...dispatchDisclosure, ...r };
+    return { ...withDispatch, ledger: renderRemediateLedger(withDispatch) };
+  };
 
   // Trust boundary first: this runner spawns an agent against the tree.
   if (!opts.trust.repoExecutionAllowed) {
@@ -207,13 +173,15 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     });
   }
 
-  const task = remediateTaskById(opts.taskId);
-  if (!task) {
-    return finish({
-      outcome: 'refused',
-      note: `refused: unknown task '${opts.taskId}' — known tasks: ${knownTaskIds().join(', ')}.`,
-    });
+  // Task resolution + dispatch disclosure — one dispatch-aware entry
+  // (`resolveDispatchedTask`); the disclosure rides every result from here
+  // on (finish() folds it into the ledger).
+  const resolved = resolveDispatchedTask(opts.taskId, opts.dispatch);
+  if (!resolved.task) {
+    return finish({ outcome: 'refused', note: resolved.refusalNote });
   }
+  const task = resolved.task;
+  if (resolved.disclosure) dispatchDisclosure = { dispatch: resolved.disclosure };
 
   const drivers = opts.drivers ?? AGENT_DRIVERS;
   const driver = drivers.find((d) => d.id === opts.config.agent.driver);

--- a/src/remediate/tasks.ts
+++ b/src/remediate/tasks.ts
@@ -25,7 +25,12 @@ export type RemediateTaskId =
   | 'fix-vulns'
   | 'fix-lint'
   | 'improve-tests'
-  | 'write-docs';
+  | 'write-docs'
+  /** Dispatch-campaign only (E3): NOT in REMEDIATE_TASKS, so policy can
+   *  never schedule it — it exists solely for a write-gated
+   *  workflow_dispatch with an explicit prompt, built by
+   *  `customDispatchTask`. */
+  | 'custom';
 
 /** Health dimensions a score hinge may reference (the report's keys). */
 export type HingeDimension =
@@ -194,6 +199,26 @@ the Documentation score must END HIGHER than it started while Quality does
 not drop — cosmetic edits that move nothing are rejected, not landed.` + SHARED_RULES,
   },
 ];
+
+/**
+ * The dispatch-campaign task (E3): a one-time, write-gated run with a
+ * human-supplied prompt. The SHARED_RULES ground rules are appended exactly
+ * as for registry tasks (the baseline-refresh ban and the leave-the-tree-
+ * clean rule are non-negotiable regardless of who wrote the goal). No score
+ * hinge exists for an arbitrary goal — the runner's ledger disclosure says
+ * so, and verification is the floor + guardrail + the human reviewing the
+ * PR that carries the verbatim prompt.
+ */
+export function customDispatchTask(prompt: string): RemediateTask {
+  return {
+    id: 'custom',
+    summary: 'one-time dispatch campaign (custom prompt)',
+    tier: 'standard',
+    tierWhy: 'human-dispatched; pin agent.model (or the dispatch model input) to change',
+    verify: 'guardrail',
+    prompt: prompt + SHARED_RULES,
+  };
+}
 
 const byId = new Map(REMEDIATE_TASKS.map((t) => [t.id, t]));
 

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -39,6 +39,7 @@ import { cronFromCadence, DEFAULT_DEPBUMP_CRON } from './baseline/policy-section
 import { BOT_IDENTITY } from './land-refresh';
 import { resolveRemediateConfig } from './remediate/config';
 import { driverById } from './remediate/registry';
+import { knownTaskIds } from './remediate/tasks';
 import { readFlowConfig } from './analyzers/flow/config';
 import { discoverExtensions } from './extensions/manifest';
 import { mergeIntoPolicyFile } from './baseline/policy-write';
@@ -1074,11 +1075,18 @@ export function installCiRemediate(cwd: string, opts: InstallerOpts = {}): ShipI
   const credentialLines = (driver?.credentialEnv ?? [])
     .map((name) => `          ${name}: \${{ secrets.${name} }}`)
     .join('\n');
+  // The dispatch form's task choices are RENDERED from the registry — a
+  // hand-listed option set in the template would be the README-matrix drift
+  // class (`custom` is appended by the template itself).
+  const taskOptionLines = knownTaskIds()
+    .map((id) => `          - ${id}`)
+    .join('\n');
   const result = installWorkflow(cwd, 'dxkit-remediate.yml', opts, {
     [CI_RUNTIME_SETUP_KEY]: renderCiRuntimeSetup(cwd),
     __DXKIT_DEFAULT_BRANCH__: resolveDefaultBranch(cwd),
     __DXKIT_REMEDIATE_CRON__: cronFromCadence(config.schedule),
     __DXKIT_REMEDIATE_CREDENTIAL_ENV__: credentialLines,
+    __DXKIT_REMEDIATE_TASK_OPTIONS__: taskOptionLines,
     __DXKIT_BOT_NAME__: BOT_IDENTITY.name,
     __DXKIT_BOT_EMAIL__: BOT_IDENTITY.email,
   });

--- a/test/remediate/config-budgets.test.ts
+++ b/test/remediate/config-budgets.test.ts
@@ -37,6 +37,7 @@ function cfg(partial: Partial<RemediateConfig>): RemediateConfig {
     agent: { driver: 'claude-code', model: 'auto', budget: DEFAULT_REMEDIATE_BUDGET },
     taskBudgets: {},
     maxSpendPerRun: 0,
+    maxDispatchBudget: 0,
     ...partial,
   };
 }

--- a/test/remediate/dispatch.test.ts
+++ b/test/remediate/dispatch.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Dispatch campaigns (E2/E3): env-transported overrides with clamped spend,
+ * and the custom task's trust mechanics — refused without a prompt, ground
+ * rules appended, dispatcher + verbatim prompt + no-hinge disclosure in the
+ * ledger.
+ */
+import { describe, it, expect } from 'vitest';
+import { DISPATCH_ENV, readDispatchOverrides } from '../../src/remediate/dispatch';
+import { customDispatchTask, SHARED_RULES } from '../../src/remediate/tasks';
+import { runRemediateTask, type RemediateGit } from '../../src/remediate/run';
+import type { AgentDriver, AgentRunResult } from '../../src/remediate/driver';
+import type { RemediateConfig } from '../../src/remediate/config';
+import { DEFAULT_REMEDIATE_BUDGET } from '../../src/remediate/config';
+import type { AnalysisTrustContext } from '../../src/analysis-trust';
+import type { CorrectnessFloorResult } from '../../src/analyzers/correctness/run';
+
+const BUDGET = DEFAULT_REMEDIATE_BUDGET; // 80 turns / 30 min / $5
+
+describe('readDispatchOverrides', () => {
+  it('no env → policy budget, nothing clamped, any=false', () => {
+    const d = readDispatchOverrides({}, BUDGET, { maxDispatchBudget: 0 });
+    expect(d.any).toBe(false);
+    expect(d.budget).toEqual(BUDGET);
+    expect(d.clamped).toEqual([]);
+  });
+
+  it('without a declared ceiling, dispatch can LOWER spend but never raise it', () => {
+    const lower = readDispatchOverrides({ [DISPATCH_ENV.maxUsd]: '2' }, BUDGET, {
+      maxDispatchBudget: 0,
+    });
+    expect(lower.budget.maxUsd).toBe(2);
+    expect(lower.clamped).toEqual([]);
+
+    const raise = readDispatchOverrides({ [DISPATCH_ENV.maxUsd]: '50' }, BUDGET, {
+      maxDispatchBudget: 0,
+    });
+    expect(raise.budget.maxUsd).toBe(BUDGET.maxUsd);
+    expect(raise.clamped[0]).toContain('clamped');
+    expect(raise.clamped[0]).toContain('maxDispatchBudget');
+  });
+
+  it('a declared ceiling authorizes raising spend up to it, clamping beyond', () => {
+    const within = readDispatchOverrides({ [DISPATCH_ENV.maxUsd]: '15' }, BUDGET, {
+      maxDispatchBudget: 20,
+    });
+    expect(within.budget.maxUsd).toBe(15);
+    expect(within.clamped).toEqual([]);
+
+    const beyond = readDispatchOverrides({ [DISPATCH_ENV.maxUsd]: '25' }, BUDGET, {
+      maxDispatchBudget: 20,
+    });
+    expect(beyond.budget.maxUsd).toBe(20);
+    expect(beyond.clamped[0]).toContain('$20');
+  });
+
+  it('turns/minutes/model/prompt/actor flow through; junk numbers are ignored', () => {
+    const d = readDispatchOverrides(
+      {
+        [DISPATCH_ENV.maxTurns]: '120',
+        [DISPATCH_ENV.maxMinutes]: 'lots',
+        [DISPATCH_ENV.model]: 'sonnet-tier',
+        [DISPATCH_ENV.customPrompt]: 'Increase docstring coverage in src/api.',
+        GITHUB_ACTOR: 'octocat',
+      },
+      BUDGET,
+      { maxDispatchBudget: 0 },
+    );
+    expect(d.budget.maxTurns).toBe(120);
+    expect(d.budget.maxMinutes).toBe(BUDGET.maxMinutes); // junk ignored
+    expect(d.model).toBe('sonnet-tier');
+    expect(d.customPrompt).toContain('docstring');
+    expect(d.actor).toBe('octocat');
+    expect(d.any).toBe(true);
+  });
+});
+
+describe('customDispatchTask', () => {
+  it('appends the non-negotiable ground rules to the human prompt', () => {
+    const t = customDispatchTask('Do the thing.');
+    expect(t.id).toBe('custom');
+    expect(t.prompt.startsWith('Do the thing.')).toBe(true);
+    expect(t.prompt).toContain(SHARED_RULES.trim().slice(0, 40));
+    expect(t.scoreHinge).toBeUndefined();
+  });
+});
+
+// ─── The custom task through the runner (trust mechanics) ────────────────────
+
+const TRUSTED = { repoExecutionAllowed: true, source: 'local-workspace' } as AnalysisTrustContext;
+const GREEN_FLOOR: CorrectnessFloorResult = { ran: true, checks: [], blocks: false };
+
+function fakeGit(): RemediateGit {
+  let head = 'base0000';
+  return {
+    head: () => head,
+    sweepLeftovers: () => undefined,
+    hasDiff: () => {
+      head = 'head1111';
+      return true;
+    },
+  };
+}
+
+function fakeDriver(): AgentDriver & { lastRun?: Parameters<AgentDriver['run']>[0] } {
+  const driver: AgentDriver & { lastRun?: Parameters<AgentDriver['run']>[0] } = {
+    id: 'fake-agent',
+    budgetSupport: { turns: true, cost: true },
+    credentialEnv: [],
+    resolveModel: (tier) => `fake-${tier}`,
+    available: () => ({ ok: true }),
+    run: async (opts) => {
+      driver.lastRun = opts;
+      return { completed: true, timedOut: false, transcriptTail: '' } as AgentRunResult;
+    },
+  };
+  return driver;
+}
+
+function config(): RemediateConfig {
+  return {
+    enabled: true,
+    tasks: ['fix-vulns'],
+    unknownTasks: [],
+    schedule: 'weekly',
+    salvage: 'discard',
+    agent: { driver: 'fake-agent', model: 'auto', budget: DEFAULT_REMEDIATE_BUDGET },
+    taskBudgets: {},
+    maxSpendPerRun: 0,
+    maxDispatchBudget: 0,
+  };
+}
+
+describe('runRemediateTask — the custom dispatch task', () => {
+  it('REFUSES custom without a prompt (never an empty-prompt agent run)', async () => {
+    const driver = fakeDriver();
+    const r = await runRemediateTask({
+      cwd: '/tmp/fake',
+      trust: TRUSTED,
+      taskId: 'custom',
+      config: config(),
+      drivers: [driver],
+      git: fakeGit(),
+      runFloor: () => GREEN_FLOOR,
+      runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+    });
+    expect(r.outcome).toBe('refused');
+    expect(r.note).toContain('prompt');
+    expect(driver.lastRun).toBeUndefined();
+  });
+
+  it('runs with the prompt + ground rules, and the ledger discloses actor, verbatim prompt, no-hinge', async () => {
+    const driver = fakeDriver();
+    const r = await runRemediateTask({
+      cwd: '/tmp/fake',
+      trust: TRUSTED,
+      taskId: 'custom',
+      config: config(),
+      drivers: [driver],
+      git: fakeGit(),
+      runFloor: () => GREEN_FLOOR,
+      runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+      dispatch: {
+        budget: DEFAULT_REMEDIATE_BUDGET,
+        customPrompt: 'Raise docstring coverage in src/api only.',
+        actor: 'octocat',
+        clamped: ['maxUsd override $50 clamped to $5 (no remediate.maxDispatchBudget declared)'],
+        any: true,
+      },
+    });
+    expect(r.outcome).toBe('verified');
+    // The agent got the prompt WITH the non-negotiables appended.
+    expect(driver.lastRun?.prompt).toContain('Raise docstring coverage');
+    expect(driver.lastRun?.prompt).toContain('NEVER run');
+    // The ledger (= the PR body) carries the full disclosure.
+    expect(r.ledger).toContain('Dispatch campaign');
+    expect(r.ledger).toContain('octocat');
+    expect(r.ledger).toContain('Raise docstring coverage in src/api only.');
+    expect(r.ledger).toContain('no score hinge');
+    expect(r.ledger).toContain('clamped');
+  });
+});

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -90,6 +90,7 @@ function config(
     },
     taskBudgets: {},
     maxSpendPerRun: 0,
+    maxDispatchBudget: 0,
   };
 }
 

--- a/test/remediate/surface.test.ts
+++ b/test/remediate/surface.test.ts
@@ -59,8 +59,9 @@ describe('installCiRemediate (the managed workflow)', () => {
     expect(text).not.toContain('__DXKIT_BOT_NAME__');
     // the runner-side machine commits carry the same identity explicitly
     const land = readFileSync(join(__dirname, '../../src/remediate/land.ts'), 'utf8');
-    const run = readFileSync(join(__dirname, '../../src/remediate/run.ts'), 'utf8');
-    for (const src of [land, run]) {
+    // The runner's git ops live in git-ops.ts (module-size split from run.ts).
+    const gitOps = readFileSync(join(__dirname, '../../src/remediate/git-ops.ts'), 'utf8');
+    for (const src of [land, gitOps]) {
       expect(src).toContain('BOT_IDENTITY.name');
       expect(src).toContain('BOT_IDENTITY.email');
     }


### PR DESCRIPTION
Part of the 4.3.6 release train (target: `release/4.3.6`). The second half of the remediate redesign (the enhancement requests for one-off, UI-configurable runs including a custom prompt).

## Design

Two products, one engine: the schedule is recurring posture read from policy; a **dispatch campaign** is a one-time, write-gated human action with per-run overrides — running through the identical verified frame (entry snapshot, floor attribution, guardrail, sweep) and landing only via PR.

- **Typed `workflow_dispatch` inputs**: task choice (options rendered from the task registry by the installer — never hand-listed — plus `custom`), free-text prompt, spend/turns/minutes overrides, model override. Blank = policy.
- **Env transport only** for every input (the comment-defer pattern): free text never touches a shell line.
- **`custom` task**: dispatch-only (not in the registry, so policy can never schedule it); refused without a prompt; the non-negotiable ground rules are appended exactly as for registry tasks.
- **Spend authority stays in committed policy**: overrides clamp to `remediate.maxDispatchBudget`; undeclared means a dispatch can lower spend but never raise it. Every clamp disclosed.
- **Full disclosure in the PR body**: dispatcher, verbatim prompt, clamps, and the explicit statement that a custom goal has no score hinge (verification = floor + guardrail + human review).

## Dogfood note

The self-guardrail blocked the oversized intermediate `run.ts` again — fixed by extracting `git-ops.ts` + moving dispatch resolution into `dispatch.ts`.

## Validation

Full local sweep green (348 files / 5232 tests, arch, slop, self-guardrail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)