### PR TITLE
WP9: lane-credential discoverability + agent budget awareness

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -321,7 +321,38 @@ vyuh-dxkit issue --type=bug --about="..."
 
 See [`vyuh-dxkit issue`](commands/issue.md) for full details.
 
-## 8. Common pitfalls
+## 8. Lane credentials
+
+The scheduled lanes (baseline refresh, dep bump, remediate) use up to
+three credentials. Only the first is automatic:
+
+- **`GITHUB_TOKEN`** — provided by Actions automatically. Enough for
+  pushes and commits, but PRs opened with it **trigger no workflow
+  runs** (GitHub's robot-loop rule), so lane PRs arrive with no checks
+  — unmergeable under branch protection. The lanes disclose this on
+  every run until you set the next one.
+
+- **`DXKIT_BOT_TOKEN`** (recommended) — a Personal Access Token with
+  `repo` scope, added as a repo secret. Lane pushes made with it count
+  as real pushes, so lane PRs get their checks like any human PR.
+  `vyuh-dxkit doctor` flags its absence when a PR-opening lane is
+  installed:
+
+  ```bash
+  gh secret set DXKIT_BOT_TOKEN
+  ```
+
+- **The agent key** (remediate only) — e.g. `ANTHROPIC_API_KEY`, from
+  repo secrets. Use a scoped workspace key with a spend limit, never a
+  personal key. The runner enforces the budget caps; the key's own
+  limit is the backstop.
+
+One GitHub _setting_ matters too: "Allow GitHub Actions to create and
+approve pull requests" (Settings → Actions → General → Workflow
+permissions). Off means lanes can push branches but not open their
+PRs — the run says exactly this when it happens.
+
+## 9. Common pitfalls
 
 A handful of first-run issues account for most onboarding friction.
 Each is a two-line fix:

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -99,6 +99,29 @@ export interface DoctorReport {
   };
 }
 
+/**
+ * Is the DXKIT_BOT_TOKEN repo secret absent? Tri-state and fail-open:
+ * `true` only when `gh secret list` SUCCEEDED and the name is not there;
+ * `false` when present; `null` when unknowable (no gh, no admin scope,
+ * offline) — the caller stays silent on null, never a false alarm.
+ */
+function botTokenSecretAbsent(cwd: string): boolean | null {
+  try {
+    const out = execSync('gh secret list --json name --jq ".[].name"', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+    });
+    return !out
+      .split('\n')
+      .map((l) => l.trim())
+      .includes('DXKIT_BOT_TOKEN');
+  } catch {
+    return null;
+  }
+}
+
 function commandAvailable(cmd: string): boolean {
   // Cross-platform PATH resolution (honors %PATHEXT% on Windows). The
   // prior `which <cmd> 2>/dev/null` shell probe false-negatived every
@@ -929,6 +952,35 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
           },
         });
       }
+    }
+  }
+
+  // 6d. Lane-PR checks credential. A PR-opening lane (dep-bump / remediate)
+  // that pushes with the default GITHUB_TOKEN opens PRs that trigger NO
+  // workflow runs (GitHub's own robot-loop rule) — uncheckable under branch
+  // protection. The lanes disclose this per run, but a run notice is
+  // reactive; doctor is where setup gaps are FOUND. Advisory + fail-open:
+  // when `gh` can't list secrets (no admin scope, offline), stay silent —
+  // never a false alarm.
+  {
+    const prLaneInstalled = ['dxkit-dep-bump.yml', 'dxkit-remediate.yml'].some((f) =>
+      fs.existsSync(path.join(cwd, '.github', 'workflows', f)),
+    );
+    if (prLaneInstalled && botTokenSecretAbsent(cwd) === true) {
+      checks.push({
+        label: 'lane PRs will run no checks — DXKIT_BOT_TOKEN secret is not set',
+        ok: false,
+        tier: 'operational',
+        fix: {
+          hint:
+            'The dep-bump / remediate lanes push with the default GITHUB_TOKEN, and GitHub ' +
+            'never triggers workflows for such pushes — their PRs arrive with no checks ' +
+            '(unmergeable under branch protection). Create a PAT with repo scope and add it ' +
+            'as the DXKIT_BOT_TOKEN repo secret; the lanes pick it up automatically.',
+          command: 'gh secret set DXKIT_BOT_TOKEN',
+          skill: 'dxkit-fix',
+        },
+      });
     }
   }
 

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -265,9 +265,20 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   const baseHead = git.head();
 
   opts.onPhase?.('agent');
+  // Budget awareness: the agent is TOLD its caps so it lands work in
+  // mergeable increments instead of being surprised mid-edit by the kill —
+  // the difference between a salvageable 90% and a stranded one. Appended by
+  // the runner (the one place the effective budget is known), never baked
+  // into the task prompts.
+  const budgetNote =
+    `\nBudget for this run (runner-enforced): ~${budget.maxMinutes} minutes, ` +
+    `${budget.maxTurns} turns, $${budget.maxUsd}. Commit completed units as you go, and ` +
+    `reserve the final minutes to commit ALL remaining work and record where you stopped ` +
+    `in docs/DXKIT-REMEDIATION-NOTES.md — work committed before the cap survives; ` +
+    `uncommitted edits are swept into a single unlabeled-context commit.`;
   const agentResult: AgentRunResult = await driver.run({
     cwd: opts.cwd,
-    prompt: task.prompt,
+    prompt: task.prompt + budgetNote,
     budget: { maxTurns: budget.maxTurns, maxMinutes: budget.maxMinutes },
     model: choice.native,
     env: opts.agentEnv ?? {},

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -1096,7 +1096,10 @@ export function installCiRemediate(cwd: string, opts: InstallerOpts = {}): ShipI
         'inside the verified frame (entry-attributed floor + guardrail before any PR) and ' +
         `lands one standing PR per task. Set the ${
           driver?.credentialEnv.join(', ') || 'driver credential'
-        } repo secret (a scoped key with a spend limit) before the first run.`,
+        } repo secret (a scoped key with a spend limit) before the first run. ` +
+        'Recommended: also set a DXKIT_BOT_TOKEN secret (a PAT with repo scope) — PRs ' +
+        'opened with the default GITHUB_TOKEN trigger no workflow runs, so they arrive ' +
+        'with no checks. See docs/getting-started.md "Lane credentials".',
     );
   }
   return result;
@@ -1129,7 +1132,9 @@ export function installCiDepBump(cwd: string, opts: InstallerOpts = {}): ShipIns
         'Monday 07:00 UTC) it turns the fixable subset of dependency vulnerabilities into ' +
         'one standing PR (dxkit/dep-bump) — bumps from the scanners’ own fix versions, ' +
         'verified by the correctness floor + guardrail before opening. Majors are skipped ' +
-        'unless depBump.allowMajor.',
+        'unless depBump.allowMajor. Recommended: set a DXKIT_BOT_TOKEN secret (a PAT with ' +
+        'repo scope) so the lane PR runs checks — default-token pushes trigger no ' +
+        'workflows. See docs/getting-started.md "Lane credentials".',
     );
   }
   return result;

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -537,3 +537,13 @@ describe('WP5: fast-exit, phases, cap accounting, blocked evidence', () => {
     expect(r.ledger).toContain('the cap did enforce');
   });
 });
+
+describe('budget awareness (WP9)', () => {
+  it('the agent is told its caps and the commit-before-the-kill rule', async () => {
+    const driver = fakeDriver({});
+    await runRemediateTask(base(driver));
+    expect(driver.lastRun?.prompt).toContain('Budget for this run');
+    expect(driver.lastRun?.prompt).toContain(`${DEFAULT_REMEDIATE_BUDGET.maxMinutes} minutes`);
+    expect(driver.lastRun?.prompt).toContain('reserve the final minutes');
+  });
+});


### PR DESCRIPTION
Part of the 4.3.6 release train. Follow-up from review discussion: the DXKIT_BOT_TOKEN mechanism shipped in WP4/WP5 was only discoverable reactively (a notice in the run log).

- **doctor check**: PR-opening lane installed + secret absent → operational finding with `gh secret set DXKIT_BOT_TOKEN` as the fix. Fail-open tri-state probe (unreadable = silent, never a false alarm).
- **Install notes** recommend the token when the lane is installed; new **"Lane credentials"** docs section covers all three credentials + the Actions setting; onboard preflight prints the same recommendation.
- **Budget awareness**: the runner appends the effective caps + a commit-before-the-kill instruction to every agent prompt — a budget-bounded run now lands mergeable increments instead of stranding work.

Full local sweep green (348 files / 5241 tests, self-guardrail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)