### PR TITLE
WP11: tiered help + learn docs (#243)

### DIFF
--- a/docs/learn/how-dxkit-thinks.md
+++ b/docs/learn/how-dxkit-thinks.md
@@ -1,0 +1,110 @@
+# How dxkit thinks
+
+One page. If you read nothing else, read this.
+
+## The one-sentence model
+
+dxkit proves that a **change** introduced no new problems, without requiring
+the repository to be clean first.
+
+That sentence drives everything else. dxkit is not a linter that shouts about
+everything wrong in your repo. It is a gate that answers one question per
+change: "did THIS change make things worse?"
+
+## The four pieces
+
+```
+baseline  ->  gate  ->  allowlist  ->  lanes
+(what is)    (what's   (what we      (what keeps
+              new)      accept)       it current)
+```
+
+### 1. Baseline: a snapshot of what already exists
+
+`vyuh-dxkit baseline create` scans the repo and records a durable identity
+(a fingerprint) for every finding that already exists: secrets, vulnerable
+dependencies, static-analysis findings, coverage gaps, lint errors, and more.
+
+Existing findings are **grandfathered**. They do not block anyone. They are
+debt you already had, and dxkit never blames the next person to open a PR
+for it.
+
+### 2. The gate: only net-new blocks
+
+`vyuh-dxkit guardrail check` re-scans and diffs against the baseline using
+those fingerprints. A finding that moved lines, or lives in a renamed file,
+still matches its baseline entry. Only findings that are genuinely **new in
+this change** can block, and which kinds block is policy
+(`.dxkit/policy.json`), not hardcode.
+
+The verdicts:
+
+- **PASSED**: no net-new findings in any blocking category.
+- **PASSED with warnings**: net-new findings exist in warn-only categories
+  (for example test gaps under the default posture). Read them; nothing
+  blocks.
+- **BLOCKED** (exit 1): the change introduced at least one finding in a
+  blocking category. The output names each finding and the remedy paths.
+- **CANNOT GATE** (exit 1): dxkit could not honestly attribute the delta to
+  your change, and it refuses to guess in either direction. This is not an
+  error in your code. The output names exactly what broke the comparison
+  (for example a baseline captured with a different tool version, or a
+  baseline older than your merge-base) and the remedy.
+
+CANNOT GATE is the most important verdict to understand: dxkit would rather
+refuse to certify than certify something it cannot verify. A tool upgrade
+that reports new findings is never blamed on the developer who happened to
+open the next PR.
+
+### 3. Allowlist: accepted, on the record
+
+Not every finding should be fixed right now, and some are false positives.
+The allowlist is the typed escape hatch:
+
+- `vyuh-dxkit allowlist add` suppresses one finding with a required
+  **category** (false-positive, test-fixture, mitigated-externally,
+  accepted-risk, deferred) and a required **reason**. Every entry is
+  auditable.
+- `vyuh-dxkit allowlist defer` is the time-boxed form: the finding stops
+  blocking until the expiry date, then **re-blocks**. Deferral is a loan,
+  not a write-off.
+- `vyuh-dxkit allowlist audit` surfaces expired, soon-to-expire, and
+  reason-less entries.
+
+### 4. Lanes: scheduled work that keeps the system honest
+
+Lanes are scheduled GitHub Actions workflows dxkit can install:
+
+- **Baseline refresh** re-captures on a schedule. Newly published dependency
+  advisories are held OUT of the baseline and raised as a decision PR:
+  merging it defers the advisory for a time-boxed window; fixing means
+  upgrading the dependency instead.
+- **Dependency bump** proposes dependency upgrades as a PR.
+- **Remediation** runs budget-bounded agent tasks (fix the build, improve
+  tests, write docs). Anything an agent produces lands **only via a PR that
+  passes the same gate as a human change**. The PR discloses who dispatched
+  it, the exact prompt, the model, and the spend.
+
+No lane bypasses the gate. That is the point of the design: one gate, every
+producer of change goes through it, human or machine.
+
+## The honesty rules underneath
+
+Two disciplines explain most of dxkit's behavior when something looks odd:
+
+1. **A net-new claim requires ruling out every other cause.** A delta can
+   come from your change, from a tool upgrade, from a scanner that did not
+   run, or from dxkit itself changing what it can see. Only the first may
+   block. The others become disclosed warnings or a CANNOT GATE refusal,
+   never a silent pass and never a false block.
+2. **Unobserved never reads as clean.** If a scanner could not run, dxkit
+   says so in the output. "We did not look" and "we looked and found
+   nothing" are different statements, and dxkit never lets one masquerade
+   as the other.
+
+## Where to go next
+
+- The gate blocked your PR: `docs/learn/quickstart-developer.md`
+- You review PRs here: `docs/learn/quickstart-reviewer.md`
+- You are setting dxkit up: `docs/learn/quickstart-admin.md`
+- Every command: `vyuh-dxkit --help --all` or `vyuh-dxkit capabilities`

--- a/docs/learn/quickstart-admin.md
+++ b/docs/learn/quickstart-admin.md
@@ -1,0 +1,84 @@
+# Admin setup path
+
+For the person wiring dxkit into a repository and keeping it healthy.
+Every step here is idempotent and verifiable with `vyuh-dxkit doctor`.
+
+## 1. Install and configure
+
+```bash
+npm init @vyuhlabs/dxkit -- --yes     # or: vyuh-dxkit init on an existing install
+vyuh-dxkit configure --apply           # deterministic policy from repo facts
+vyuh-dxkit doctor                      # verify, and read its recommendations
+```
+
+`configure` derives policy from observable facts (repo visibility, stack,
+lockfiles) and is reproducible: same repo, same plan. `doctor` is the
+ongoing health check; run it after every step below until it is quiet.
+
+## 2. The baseline and its transport
+
+`init` captures the first baseline. Decide where it lives:
+
+- **Private repos** default to a committed baseline (`committed-full`).
+- **Public repos** default to `ref-based` (nothing sensitive committed).
+- Compliance-conscious private repos can opt into `committed-sanitized`.
+
+Install the **baseline refresh workflow** so the baseline stays current on
+the default branch and advisory decisions surface as PRs. A baseline
+captured once on a laptop and never refreshed goes stale, and stale
+baselines are the top cause of CANNOT GATE verdicts.
+
+## 3. Branch protection
+
+```bash
+vyuh-dxkit setup-branch-protection
+```
+
+Require the guardrail check on the default branch. dxkit reads BOTH classic
+branch protection and repository rulesets, so either mechanism works;
+`doctor` reports the effective protection either way.
+
+## 4. GitHub settings the lanes need
+
+Two settings decide whether the scheduled lanes can do their jobs:
+
+1. **Allow GitHub Actions to create and approve pull requests**
+   (repo or org Settings, Actions, General). Without it, the dep-bump and
+   remediation lanes can push branches but cannot open their PRs; the run
+   log will name this setting.
+2. **A bot token for lane pushes (recommended): `DXKIT_BOT_TOKEN`.**
+   Branches pushed with the default `GITHUB_TOKEN` do not trigger workflow
+   runs, so lane PRs arrive with no CI checks and cannot satisfy branch
+   protection. Set a fine-grained PAT (contents: write, pull requests:
+   write) as a repo secret named `DXKIT_BOT_TOKEN`; the lane workflows use
+   it automatically when present and fall back to `GITHUB_TOKEN` (degraded,
+   disclosed) when absent.
+
+## 5. Policy: what blocks here
+
+`.dxkit/policy.json` is the contract. The pieces admins actually tune:
+
+- **Preset** (for example `security-only`): which finding kinds block vs
+  warn. Start conservative; tighten once the team trusts the gate.
+- **Custom checks** (`checks[]`): repo commands run as first-class gate
+  citizens. These execute in CI, so PRs that edit them deserve
+  workflow-edit scrutiny.
+- **Agent lane budgets**: per-task spend, turn, and time caps for the
+  remediation lane, plus `remediate.maxSpendPerRun` and
+  `remediate.maxDispatchBudget` org ceilings.
+
+Every knob is discoverable: `vyuh-dxkit capabilities --json` is the
+machine-readable menu, and `doctor` proactively recommends unused
+capabilities that fit the repo.
+
+## 6. Verify end to end
+
+```bash
+vyuh-dxkit doctor          # wiring, credentials, protection, staleness
+vyuh-dxkit guardrail check # the gate itself, exit 0 on a clean tree
+```
+
+Then open a trivial PR and watch the verdict land. If anything surprises
+you, `doctor` first: it knows about missing tokens, missing workflows,
+stale baselines, and unprotected branches, and it prints the exact remedy
+for each.

--- a/docs/learn/quickstart-developer.md
+++ b/docs/learn/quickstart-developer.md
@@ -1,0 +1,81 @@
+# The gate blocked my PR. Now what?
+
+Three minutes, four situations. Find yours.
+
+First, read the verdict output (the CI job log, the PR comment, or run
+`vyuh-dxkit guardrail check` locally). It names each finding, its kind, its
+fingerprint, and why it gates. Everything below starts from that.
+
+## 1. The finding is real and mine
+
+Fix it and push. The gate compares your change against the baseline, so the
+moment the finding is gone from your branch, the gate passes. Nothing to
+clean up, nothing to ask anyone.
+
+This is the common case, and it is the whole product working as intended.
+
+## 2. It is a false positive
+
+Suppress it on the record, in your PR:
+
+```bash
+vyuh-dxkit allowlist add --fingerprint=<id> --kind=<kind> \
+  --category=false-positive --reason="<why this is not real>"
+```
+
+The fingerprint and kind are printed in the verdict output. The entry lands
+in `.dxkit/allowlist.json` in your PR, so the reviewer sees the suppression
+and the reason next to the change that needed it.
+
+If several findings share one reason, batch them:
+`--fingerprints=<id,id,...>` or pipe ids via `--from-stdin`.
+
+## 3. It is real, but not fixable in this PR
+
+Defer it, time-boxed:
+
+```bash
+vyuh-dxkit allowlist defer <fingerprint> \
+  --reason="<why later>" --expires=+14d
+```
+
+The finding stops blocking until the expiry, then **re-blocks**. Default
+expiry is 7 days. Deferral is visible to reviewers and auditable later
+(`vyuh-dxkit allowlist audit`), so use an honest reason.
+
+For a wave of blocking dependency advisories from the last check there is a
+bulk form: `vyuh-dxkit allowlist defer --from-last-check --reason="..."`.
+Other kinds are deliberately one-at-a-time.
+
+## 4. The verdict is CANNOT GATE
+
+Stop: this is not about your code. dxkit is telling you it cannot honestly
+decide what your change introduced, and it refuses to guess. The output
+names the exact cause and remedy. The common ones:
+
+- **The baseline is stale or predates your merge-base.** Remedy: whoever
+  maintains the repo re-captures (usually the baseline refresh workflow, or
+  `vyuh-dxkit baseline create`). Your PR re-gates cleanly afterward.
+- **A scanner version drifted** since the baseline was captured. Same
+  remedy: re-capture. Your change is not blamed for a tool upgrade.
+
+If you see CANNOT GATE repeatedly, tell your repo admin; the fix is on the
+repo side, not in your PR.
+
+## Local loop, before CI
+
+Run the same gate CI runs:
+
+```bash
+vyuh-dxkit guardrail check
+```
+
+Exit 0 means CI's gate will agree with you. If the repo has git hooks
+installed, pre-push already does this.
+
+## One rule
+
+Never "fix" a block by re-creating the baseline from your feature branch.
+That absorbs your net-new finding into the record for everyone. The
+baseline is maintained on the default branch by the refresh lane or the
+repo admin; your tools are the fix itself, the allowlist, and deferral.

--- a/docs/learn/quickstart-reviewer.md
+++ b/docs/learn/quickstart-reviewer.md
@@ -1,0 +1,61 @@
+# Reviewing with dxkit: guardrail output and lane PRs
+
+For people who review PRs in a dxkit-gated repo. Two things land in your
+review queue: human PRs carrying a guardrail verdict, and PRs opened by
+dxkit's own scheduled lanes.
+
+## Reading a guardrail verdict on a human PR
+
+- **PASSED**: the change introduced nothing in a blocking category. Existing
+  repo debt is not this author's problem; do not ask them to fix unrelated
+  findings the gate grandfathered.
+- **PASSED with warnings**: net-new findings in warn-only categories (for
+  example new test gaps under the default posture). Worth a comment if they
+  matter; the gate deliberately does not force them.
+- **BLOCKED**: the listed findings are net-new in this change. The author's
+  options are fix, allowlist with a category and reason, or a time-boxed
+  deferral. All three are visible in the diff.
+- **CANNOT GATE**: the comparison itself was invalid (stale baseline, tool
+  drift). Not the author's fault; the repo side re-captures. Do not merge a
+  gated repo on CANNOT GATE without knowing why.
+
+Things worth your attention as a reviewer:
+
+- **New allowlist entries** in the diff (`.dxkit/allowlist.json` or inline
+  `dxkit-allow:` annotations). The category and reason are the review
+  surface: is "false-positive" actually true? Is an `accepted-risk` entry
+  something this author may accept alone?
+- **Deferrals**: a defer entry is a loan with an expiry that will re-block.
+  Check the reason and the date are honest.
+- **Policy edits**: a PR that changes `.dxkit/policy.json:checks[].command`
+  executes in CI. Review it with the same scrutiny as a workflow edit.
+
+## Reviewing lane PRs
+
+dxkit's scheduled lanes open PRs of their own. Each type has a specific
+meaning for merge:
+
+- **Baseline refresh decision PR**: a newly published dependency advisory
+  was held OUT of the baseline. **Merging the PR defers the advisory for a
+  time-boxed window** (it re-blocks at expiry). Fixing means upgrading the
+  dependency instead, and closing this PR. The PR body states the deadline.
+- **Dependency bump PR**: a proposed upgrade, gated like any change. Review
+  the changelog delta and merge or close; there is no hidden semantics.
+- **Remediation PR**: produced by a budget-bounded agent task. The body
+  carries the envelope: who dispatched it, the exact prompt, the model, and
+  the spend. The change passed the same gate as a human PR, and for custom
+  prompts the body says explicitly that no automated score improved; your
+  review is the verification. Review the diff on its merits.
+
+One operational note: a lane PR pushed with the default workflow credential
+may show **no CI checks** (GitHub does not trigger workflows for it). The
+repo admin can configure a bot token to fix this; until then, close and ask
+for a re-run, or run the checks by hand. Never merge an unchecked lane PR
+into a protected branch on trust.
+
+## What you never need to do
+
+- Re-run scanners by hand to double-check the gate: the verdict is
+  deterministic and reproducible with `vyuh-dxkit guardrail check`.
+- Police pre-existing debt in someone's unrelated PR: the baseline exists
+  precisely so review can focus on the change.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from 'node:util';
-import { renderCommandIndex, suggestCommand } from './discovery/commands';
+import { renderCommandIndex, renderTieredIndex, suggestCommand } from './discovery/commands';
 import { suspectVendoredEntries } from './analyzers/tools/vendored-advisor';
 import { detect } from './detect';
 import { generate } from './generator';
@@ -145,7 +145,31 @@ function applyFailOnSeverity(
   }
 }
 
-function printUsage(): void {
+/**
+ * Tiered help (issue #243): the default screen shows the five core commands +
+ * a collapsed line per group; `--help --all` prints the full grouped index and
+ * the complete flag reference. Presentation only — both views render from the
+ * one command registry (CLAUDE.md Rule 16).
+ */
+function printUsage(all = false): void {
+  if (!all) {
+    console.log(`
+  ${logger.bold('vyuh-dxkit')} v${VERSION} — a deterministic stop condition + code-graph context layer for AI coding agents
+
+${renderTieredIndex().join('\n')}
+  ${logger.bold('Learn:')}
+    docs/learn/how-dxkit-thinks.md         The mental model (baseline, gate, allowlist, lanes)
+    docs/learn/quickstart-developer.md     "The gate blocked my PR": what to do
+    docs/learn/quickstart-reviewer.md      Reading guardrail comments + lane PRs
+    docs/learn/quickstart-admin.md         Setup path: secrets, branch protection, policy
+
+  ${logger.bold('Examples:')}
+    ${dxkitCli('init')}                  # Interactive
+    ${dxkitCli('doctor')}                # Verify setup + get recommendations
+    ${dxkitCli('guardrail check')}       # Gate the current change
+`);
+    return;
+  }
   console.log(`
   ${logger.bold('vyuh-dxkit')} v${VERSION} — a deterministic stop condition + code-graph context layer for AI coding agents
 
@@ -534,7 +558,7 @@ export async function run(argv: string[]): Promise<void> {
   });
 
   if (values.help) {
-    printUsage();
+    printUsage(!!values.all);
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,6 +153,7 @@ function applyFailOnSeverity(
  */
 function printUsage(all = false): void {
   if (!all) {
+    // slop-ok — help output IS the product surface here, same as the full view below.
     console.log(`
   ${logger.bold('vyuh-dxkit')} v${VERSION} — a deterministic stop condition + code-graph context layer for AI coding agents
 

--- a/src/discovery/commands.ts
+++ b/src/discovery/commands.ts
@@ -106,6 +106,42 @@ export const GROUP_ORDER: Array<Exclude<CommandGroup, 'internal'>> = [
 ];
 
 /**
+ * The core tier: the commands a new user meets first (issue #243). This is
+ * PRESENTATION metadata only — a display ordering over the registry, never a
+ * second registry. Every id here must resolve via `getCommand` (pinned by
+ * `test/discovery-playbook.test.ts`); the descriptors themselves are untouched.
+ */
+export const CORE_COMMAND_IDS = ['init', 'guardrail', 'baseline', 'allowlist', 'doctor'] as const;
+
+/**
+ * The tiered help index (issue #243): the five core commands with their
+ * summaries, then every remaining user-facing command collapsed to one line
+ * per group, so the first screen a new user sees is five commands, not ~40.
+ * The full grouped index stays available via `renderCommandIndex`
+ * (`vyuh-dxkit --help --all`).
+ */
+export function renderTieredIndex(): string[] {
+  const lines: string[] = [];
+  lines.push('  Start here');
+  for (const id of CORE_COMMAND_IDS) {
+    const c = getCommand(id);
+    if (!c) continue;
+    lines.push(`    ${c.id.padEnd(28)} ${c.summary}`);
+  }
+  lines.push('');
+  lines.push("  Everything else (run 'vyuh-dxkit --help --all' for the full reference)");
+  for (const group of GROUP_ORDER) {
+    const rest = userCommands().filter(
+      (c) => c.group === group && !(CORE_COMMAND_IDS as readonly string[]).includes(c.id),
+    );
+    if (rest.length === 0) continue;
+    lines.push(`    ${GROUP_LABELS[group].padEnd(12)} ${rest.map((c) => c.id).join(', ')}`);
+  }
+  lines.push('');
+  return lines;
+}
+
+/**
  * A grouped, one-line-per-command index of the user-facing commands.
  * Drives the unknown-command hint today; the top-level `--help` index next.
  */

--- a/test/discovery-playbook.test.ts
+++ b/test/discovery-playbook.test.ts
@@ -28,6 +28,8 @@ import {
   userCommands,
   suggestCommand,
   renderCommandIndex,
+  renderTieredIndex,
+  CORE_COMMAND_IDS,
   gatherRecommendations,
   type CapabilityDescriptor,
 } from '../src/discovery/commands';
@@ -133,6 +135,43 @@ describe('capability registry — lookup + discovery helpers', () => {
     const text = renderCommandIndex().join('\n');
     for (const c of userCommands()) {
       expect(text, `help index missing ${c.id}`).toContain(c.id);
+    }
+  });
+});
+
+describe('tiered help (issue #243) — presentation over the one registry', () => {
+  it('every core id resolves in the registry and is user-facing', () => {
+    for (const id of CORE_COMMAND_IDS) {
+      const c = getCommand(id);
+      expect(c, `core id ${id} not registered`).toBeDefined();
+      expect(c?.audience, `core id ${id} must be user-facing`).toBe('user');
+    }
+  });
+
+  it('the tiered index shows core summaries and still names every other user command', () => {
+    const text = renderTieredIndex().join('\n');
+    for (const id of CORE_COMMAND_IDS) {
+      const c = getCommand(id)!;
+      expect(text, `tiered index missing core ${id}`).toContain(c.summary);
+    }
+    // Collapse, never hide: every non-core user command's id is present.
+    for (const c of userCommands()) {
+      expect(text, `tiered index dropped ${c.id}`).toContain(c.id);
+    }
+    // The expansion path is named, so the tier is never a dead end.
+    expect(text).toContain('--help --all');
+  });
+
+  it('the learn docs referenced by the tiered help exist and are non-trivial', () => {
+    for (const f of [
+      'how-dxkit-thinks.md',
+      'quickstart-developer.md',
+      'quickstart-reviewer.md',
+      'quickstart-admin.md',
+    ]) {
+      const p = path.join(REPO_ROOT, 'docs', 'learn', f);
+      expect(fs.existsSync(p), `docs/learn/${f} missing`).toBe(true);
+      expect(fs.readFileSync(p, 'utf-8').length).toBeGreaterThan(500);
     }
   });
 });


### PR DESCRIPTION
Part of the 4.3.6 release train (#240). Closes #243.

- Default `--help` shows the five core commands + collapsed groups; `--help --all` keeps the full reference. Both views render from the one command registry (Rule 16); `CORE_COMMAND_IDS` is presentation metadata pinned by the discovery playbook.
- `docs/learn/`: how-dxkit-thinks.md + developer/reviewer/admin quickstarts. Curated narrative content; also the bundle source for the upcoming `learn` command.
- Local sweep ALL GREEN (349 files / 5253 tests, self-guardrail vs origin/main clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)