### PR TITLE
WP13: learn --serve — local grounded assistant, BYO key (#245)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -406,6 +406,9 @@ export async function run(argv: string[]): Promise<void> {
       xlsx: { type: 'boolean', default: false },
       filter: { type: 'string' },
       all: { type: 'boolean', default: false },
+      // learn: local assistant server + its port
+      serve: { type: 'boolean', default: false },
+      port: { type: 'string' },
       frontend: { type: 'string' },
       backend: { type: 'string' },
       specs: { type: 'string' },
@@ -3418,8 +3421,41 @@ export async function run(argv: string[]): Promise<void> {
 
     case 'learn': {
       const targetPath = resolveRepoPath(positionals[1]);
-      const { runLearn } = await import('./learn');
       logger.header('vyuh-dxkit learn');
+      if (values.serve) {
+        const { buildLearnBundle } = await import('./learn/bundle');
+        const { gatherLearnRepoStatus } = await import('./learn/repo-status');
+        const { startLearnServer } = await import('./learn/serve');
+        const { LLM_DRIVERS, envKeyFor } = await import('./learn/drivers');
+        const bundle = buildLearnBundle();
+        const status = await gatherLearnRepoStatus(targetPath);
+        const port = values.port ? parseInt(String(values.port), 10) : undefined;
+        const running = await startLearnServer(bundle, status, { port });
+        logger.success(`Learn assistant serving at ${running.url} (localhost only)`);
+        logger.dim(
+          status
+            ? 'Repo mode: live status + setup checklist + repo-grounded assistant.'
+            : 'Zero-context mode: the full guide + assistant, no repo needed.',
+        );
+        const withKey = LLM_DRIVERS.filter((d) => envKeyFor(d) !== null);
+        logger.dim(
+          withKey.length > 0
+            ? `API key detected in env for: ${withKey.map((d) => d.label).join(', ')}. It stays in this process.`
+            : 'No provider API key in the environment. Enter one in the page, or export e.g. ANTHROPIC_API_KEY and restart.',
+        );
+        logger.dim('Press Ctrl+C to stop.');
+        // Keep the process alive until interrupted.
+        await new Promise<void>((resolve) => {
+          process.once('SIGINT', () => {
+            void running.close().then(resolve);
+          });
+          process.once('SIGTERM', () => {
+            void running.close().then(resolve);
+          });
+        });
+        break;
+      }
+      const { runLearn } = await import('./learn');
       const result = await runLearn(targetPath, {
         out: values.output ? String(values.output) : undefined,
       });
@@ -3429,6 +3465,7 @@ export async function run(argv: string[]): Promise<void> {
           ? 'Includes live repo status + the read-only setup checklist. Open it in a browser.'
           : 'Capability guide (no repo detected here). Open it in a browser.',
       );
+      logger.dim('Add --serve for the local grounded assistant (BYO key).');
       break;
     }
 

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -355,7 +355,7 @@ export const COMMANDS = [
     summary: 'One offline HTML page: capabilities, docs, this repo’s status + setup',
     typicalRuntime: '< 10 sec',
     docsBlurb:
-      'Generate a self-contained HTML guide: every capability by tier, the mental-model docs, what dxkit verifies and what it cannot, plus (in a repo) live doctor status and a read-only setup checklist. Works in an empty directory too.',
+      'Generate a self-contained HTML guide: every capability by tier, the mental-model docs, what dxkit verifies and what it cannot, plus (in a repo) live doctor status and a read-only setup checklist. Works in an empty directory too. --serve adds a local grounded assistant (bring-your-own LLM key; localhost only).',
   },
   {
     id: 'context',

--- a/src/learn/drivers.ts
+++ b/src/learn/drivers.ts
@@ -1,0 +1,182 @@
+/**
+ * The LLM driver registry for the learn assistant (issue #245) — the ONE
+ * place provider facts live. Three drivers by design decision (2026-08-02):
+ * Anthropic (default), OpenAI, and an OpenAI-compatible custom endpoint that
+ * covers org proxies, Azure-style gateways, and local models without naming
+ * products. Each driver declares its key env var, endpoint, wire format, and
+ * a couple of SUGGESTED models plus a free-text override on the page — never
+ * an exhaustive model list (those go stale between releases).
+ *
+ * The page's model chooser renders FROM this registry (via /api/status), so
+ * adding a driver is one entry here and zero page edits.
+ */
+
+export interface LlmDriver {
+  readonly id: 'anthropic' | 'openai' | 'custom';
+  readonly label: string;
+  /** Env var the serve process auto-detects a key from. */
+  readonly keyEnv: string;
+  /** Fixed API base; null for the custom driver (user supplies it). */
+  readonly endpoint: string | null;
+  /** Which request/response shape the relay speaks. */
+  readonly wire: 'anthropic' | 'openai-chat';
+  /** Suggestions only — the page always offers a free-text model field. */
+  readonly suggestedModels: readonly string[];
+  readonly defaultModel: string;
+}
+
+export const LLM_DRIVERS: readonly LlmDriver[] = [
+  {
+    id: 'anthropic',
+    label: 'Anthropic (Claude)',
+    keyEnv: 'ANTHROPIC_API_KEY',
+    endpoint: 'https://api.anthropic.com',
+    wire: 'anthropic',
+    suggestedModels: ['claude-opus-5', 'claude-sonnet-5', 'claude-haiku-4-5'],
+    defaultModel: 'claude-opus-5',
+  },
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    keyEnv: 'OPENAI_API_KEY',
+    endpoint: 'https://api.openai.com/v1',
+    wire: 'openai-chat',
+    suggestedModels: ['gpt-5.1', 'gpt-5-mini'],
+    defaultModel: 'gpt-5.1',
+  },
+  {
+    id: 'custom',
+    label: 'OpenAI-compatible endpoint (org proxy, local model)',
+    keyEnv: 'DXKIT_LLM_API_KEY',
+    endpoint: null,
+    wire: 'openai-chat',
+    suggestedModels: [],
+    defaultModel: '',
+  },
+] as const;
+
+export function getDriver(id: string): LlmDriver | undefined {
+  return LLM_DRIVERS.find((d) => d.id === id);
+}
+
+/** Which env key (if any) the serve process can use for a driver. */
+export function envKeyFor(driver: LlmDriver): string | null {
+  const v = process.env[driver.keyEnv];
+  return v && v.trim().length > 0 ? v : null;
+}
+
+/** Optional env base URL for the custom driver. */
+export const CUSTOM_BASE_URL_ENV = 'DXKIT_LLM_BASE_URL';
+
+export interface RelayRequest {
+  driver: LlmDriver;
+  /** Free-text model wins over the driver default. */
+  model: string;
+  /** Full base URL for the custom driver (from form or env). */
+  baseUrl?: string;
+  apiKey: string;
+  system: string;
+  /** Prior turns + the current question, oldest first. */
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>;
+  timeoutMs?: number;
+}
+
+export interface RelayResult {
+  ok: boolean;
+  answer?: string;
+  /** Disclosed, key-free error description. */
+  error?: string;
+}
+
+/**
+ * Relay ONE question to the provider. Raw HTTP by design: this is a
+ * provider-neutral relay behind a driver registry, not a per-provider SDK
+ * integration, and dxkit keeps its dependency surface minimal. The fetch
+ * implementation is injectable for tests. The key is used for exactly this
+ * request and never logged, stored, or echoed.
+ */
+export async function relayAsk(
+  req: RelayRequest,
+  fetchFn: typeof fetch = fetch,
+): Promise<RelayResult> {
+  const timeout = req.timeoutMs ?? 60_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    if (req.driver.wire === 'anthropic') {
+      const res = await fetchFn(`${req.driver.endpoint}/v1/messages`, {
+        method: 'POST',
+        signal: controller.signal,
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': req.apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model: req.model,
+          max_tokens: 2048,
+          system: req.system,
+          messages: req.messages,
+        }),
+      });
+      if (!res.ok) {
+        return { ok: false, error: `provider returned HTTP ${res.status}: ${await safeBody(res)}` };
+      }
+      const data = (await res.json()) as {
+        stop_reason?: string;
+        content?: Array<{ type: string; text?: string }>;
+      };
+      if (data.stop_reason === 'refusal') {
+        return { ok: false, error: 'the provider declined this request (refusal)' };
+      }
+      const text = (data.content ?? [])
+        .filter((b) => b.type === 'text' && typeof b.text === 'string')
+        .map((b) => b.text)
+        .join('\n');
+      return text.length > 0 ? { ok: true, answer: text } : { ok: false, error: 'empty response' };
+    }
+
+    // openai-chat wire (openai + custom).
+    const base = req.driver.endpoint ?? req.baseUrl;
+    if (!base) return { ok: false, error: 'custom driver requires a base URL' };
+    const res = await fetchFn(`${base.replace(/\/$/, '')}/chat/completions`, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${req.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: req.model,
+        messages: [{ role: 'system', content: req.system }, ...req.messages],
+      }),
+    });
+    if (!res.ok) {
+      return { ok: false, error: `provider returned HTTP ${res.status}: ${await safeBody(res)}` };
+    }
+    const data = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const answer = data.choices?.[0]?.message?.content;
+    return typeof answer === 'string' && answer.length > 0
+      ? { ok: true, answer }
+      : { ok: false, error: 'empty response' };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: controller.signal.aborted ? `provider timed out after ${timeout}ms` : msg,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** First 200 chars of an error body, never throwing, never echoing headers. */
+async function safeBody(res: { text(): Promise<string> }): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 200);
+  } catch {
+    return '(unreadable body)';
+  }
+}

--- a/src/learn/grounding.ts
+++ b/src/learn/grounding.ts
@@ -1,0 +1,122 @@
+/**
+ * Assistant grounding for `learn --serve` (issue #245).
+ *
+ * ONE function assembles BOTH the system prompt the provider receives AND the
+ * human-readable disclosure of exactly what is being sent — from the same
+ * walk over the same data (Rule 2.30). The page's "what is sent" statement
+ * can therefore never drift from the payload: if a section is added to the
+ * prompt, its disclosure line is added in the same place or it doesn't ship.
+ *
+ * Privacy design (user decision, 2026-08-02): BYO key means grounding goes
+ * to the USER'S chosen provider. Default is SUMMARIES AND COUNTS only (the
+ * sanitized-baseline ethos). Finding-level detail (doctor check labels with
+ * remedies, blocking-finding fingerprints) is behind an explicit visible
+ * toggle. The assistant explains and produces exact commands; it executes
+ * nothing — the one write path (`configure --apply`) is only ever quoted.
+ */
+import type { LearnBundle } from './bundle';
+import type { LearnRepoStatus } from './repo-status';
+
+export interface GroundingResult {
+  system: string;
+  /** One line per thing included — rendered verbatim on the page. */
+  disclosure: string[];
+  repoMode: boolean;
+  detail: boolean;
+}
+
+const ASSISTANT_CHARTER = `You are the dxkit learn assistant, running locally next to the user's terminal.
+Answer ONLY from the grounding below — the registry digest, the docs, and (when present) this repo's status.
+When the answer is an action, produce the EXACT command to run, or the sentence to tell a coding agent.
+You execute nothing and cannot change anything; the one configuration write path is 'vyuh-dxkit configure --apply', which you may quote but the user runs.
+If the grounding does not answer a question, say so plainly and point to 'vyuh-dxkit doctor' or the docs; never invent capabilities or flags.`;
+
+export function assembleGrounding(
+  bundle: LearnBundle,
+  status: LearnRepoStatus | null,
+  opts: { detail?: boolean } = {},
+): GroundingResult {
+  const detail = !!opts.detail && status !== null;
+  const parts: string[] = [ASSISTANT_CHARTER];
+  const disclosure: string[] = [];
+
+  // 1. The registry digest — compiled-in product facts, no repo data.
+  const capLines = bundle.capabilities.map(
+    (c) =>
+      `- ${c.id} [${c.groupLabel}${c.tier === 'core' ? ', core' : ''}]: ${c.docsBlurb ?? c.summary}`,
+  );
+  const knobLines = bundle.knobs.map(
+    (k) => `- ${k.path} (command: ${k.command})${k.note ? ` — ${k.note}` : ''}`,
+  );
+  parts.push(`## Capability registry (dxkit v${bundle.version})\n${capLines.join('\n')}`);
+  parts.push(`## Policy knobs\n${knobLines.join('\n')}`);
+  disclosure.push(
+    `The capability registry: every command name + description, and policy knob names (product facts, no repo data).`,
+  );
+
+  // 2. The curated docs — also product facts.
+  for (const d of bundle.docs) {
+    parts.push(`## Doc: ${d.title}\n${d.markdown}`);
+  }
+  disclosure.push(`The built-in docs (mental model, quickstarts, capabilities-and-limits).`);
+
+  // 3. Repo status — ONLY in repo mode, summaries by default.
+  if (status) {
+    const s: string[] = [];
+    s.push(`dxkit installed: ${status.installed ? 'yes' : 'no'}`);
+    if (status.policy) {
+      s.push(
+        `policy: preset=${status.policy.preset ?? '(none)'}, custom checks=${status.policy.checksCount}, lint gate=${status.policy.lintEnabled ? 'on' : 'off'}, lanes=[${status.policy.lanes.join(', ') || 'none'}]`,
+      );
+    }
+    for (const b of status.baselines) {
+      s.push(
+        `baseline '${b.name}': ${b.entryCount} grandfathered findings${b.capturedAt ? `, captured ${b.capturedAt.slice(0, 10)}` : ''}`,
+      );
+    }
+    if (status.lastVerdict) {
+      const v = status.lastVerdict;
+      s.push(
+        `last guardrail verdict: ${v.unattributableCount > 0 ? 'CANNOT GATE' : v.blocks ? 'BLOCKED' : 'PASSED'} (${v.blockingCount} blocking, ${v.warningCount} warnings, at ${v.ranAt})`,
+      );
+    }
+    if (status.doctor) {
+      const failing = status.doctor.checks.filter((c) => !c.ok);
+      s.push(
+        `doctor: ${status.doctor.checks.length - failing.length} checks pass, ${failing.length} failing`,
+      );
+      if (detail) {
+        for (const c of failing) {
+          s.push(
+            `  failing: ${c.label}${c.fix ? ` — remedy: ${c.fix.command ?? c.fix.hint}` : ''}`,
+          );
+        }
+        for (const r of status.doctor.recommendations ?? []) {
+          s.push(
+            `  recommended: ${r.id} — ${r.recommendation.reason} (${r.recommendation.command})`,
+          );
+        }
+      }
+    }
+    if (detail && status.lastVerdict?.blockingFindings?.length) {
+      for (const f of status.lastVerdict.blockingFindings) {
+        s.push(`  blocking finding: kind=${f.kind}, fingerprint=${f.fingerprint}`);
+      }
+    }
+    parts.push(`## This repo (live status)\n${s.join('\n')}`);
+    disclosure.push(
+      detail
+        ? `This repo's status IN DETAIL: policy summary, baseline counts, the last verdict, each failing doctor check with its remedy, and blocking-finding fingerprints. (Detail toggle is ON.)`
+        : `This repo's status as SUMMARIES ONLY: policy summary, baseline entry counts, the last verdict word, and doctor pass/fail counts. No file paths, no finding contents, no check labels. (Turn on the detail toggle to include failing checks + remedies.)`,
+    );
+  } else {
+    disclosure.push(`No repo data at all — this is the zero-context guide.`);
+  }
+
+  disclosure.push(`Your question and the visible chat history.`);
+  disclosure.push(
+    `Sent DIRECTLY from this machine to the provider you chose. dxkit runs no server of its own and stores nothing.`,
+  );
+
+  return { system: parts.join('\n\n'), disclosure, repoMode: status !== null, detail };
+}

--- a/src/learn/render.ts
+++ b/src/learn/render.ts
@@ -78,6 +78,18 @@ h2.section { font-size:20px; color:var(--text-primary); margin:36px 0 6px; paddi
   border-radius:14px; padding:4px 12px; color:var(--text-secondary); }
 .note { font-size:12.5px; color:var(--text-muted); background:var(--bg-card);
   border:1px solid var(--border); border-radius:8px; padding:10px 14px; margin:10px 0; line-height:1.6; }
+.ask-row { display:flex; gap:12px; align-items:center; margin:8px 0; flex-wrap:wrap; }
+.ask-row label { font-size:12.5px; color:var(--text-muted); display:flex; gap:6px; align-items:center; }
+.ask-row input, .ask-row select, .ask-row textarea { background:var(--bg-primary); color:var(--text-primary);
+  border:1px solid var(--border); border-radius:6px; padding:6px 9px; font-size:12.5px; font-family:inherit; }
+.ask-row textarea { flex:1; min-width:260px; }
+.ask-row button { background:var(--accent-blue); color:#fff; border:none; border-radius:6px;
+  padding:8px 18px; font-size:13px; cursor:pointer; }
+#chat { margin:12px 0; display:flex; flex-direction:column; gap:8px; }
+.chat-msg { padding:9px 12px; border-radius:8px; font-size:13px; line-height:1.6; white-space:pre-wrap; }
+.chat-user { background:var(--bg-tertiary); align-self:flex-end; max-width:85%; }
+.chat-assistant { background:var(--bg-primary); border:1px solid var(--border); max-width:95%; }
+#ask-error { font-size:12.5px; margin-top:6px; }
 `;
 
 function capCard(c: LearnCapability, knobs: LearnBundle['knobs']): string {
@@ -171,6 +183,139 @@ function statusSection(status: LearnRepoStatus): string {
 export interface RenderLearnOptions {
   /** ISO timestamp shown in the footer; omit for a deterministic page. */
   generatedAt?: string;
+  /**
+   * Serve mode (`learn --serve`): adds the assistant panel + its inline
+   * script, which talks ONLY to same-origin localhost endpoints. The static
+   * file mode stays entirely script-free — that page must open from file://
+   * offline, and its tests pin the absence of any <script>.
+   */
+  serve?: boolean;
+}
+
+/** The assistant panel + inline JS for serve mode. No external loads; all
+ *  repo/provider strings are inserted via textContent, never innerHTML. */
+function assistantSection(): string {
+  return `<h2 class="section" id="assistant">Ask the assistant</h2>
+<p class="section-sub">Grounded in this page's content${''} and answered by YOUR provider with YOUR key (bring-your-own-key). dxkit relays your question from this machine directly to the provider; nothing is stored.</p>
+<div class="doc" id="assistant-panel">
+  <div class="ask-row">
+    <label>Provider <select id="drv"></select></label>
+    <label>Model <input id="model" list="model-suggestions" placeholder="model id"><datalist id="model-suggestions"></datalist></label>
+  </div>
+  <div class="ask-row" id="baseurl-row" hidden>
+    <label>Base URL <input id="baseurl" placeholder="https://your-endpoint/v1"></label>
+  </div>
+  <div class="ask-row" id="key-row">
+    <span id="key-env-note" hidden>Using the API key from your terminal environment (<code id="key-env-name"></code>). It never reaches this page.</span>
+    <label id="key-input-label">API key <input id="key" type="password" placeholder="pasted key stays in this tab's memory only"></label>
+  </div>
+  <div class="ask-row" id="detail-row" hidden>
+    <label><input type="checkbox" id="detail"> Include finding-level detail from this repo (off = summaries and counts only)</label>
+  </div>
+  <details class="note" id="sent-note"><summary>Exactly what is sent with each question</summary><ul id="disclosure"></ul></details>
+  <div id="chat"></div>
+  <div class="ask-row">
+    <textarea id="q" rows="3" placeholder="e.g. Why is my PR blocked? What should this repo adopt next?"></textarea>
+    <button id="ask">Ask</button>
+  </div>
+  <div id="ask-error" class="badge-fail"></div>
+</div>
+<script>
+(function () {
+  'use strict';
+  var state = { drivers: [] };
+  function el(id) { return document.getElementById(id); }
+  function refreshStatus() {
+    var detail = el('detail').checked ? '1' : '0';
+    return fetch('/api/status?detail=' + detail).then(function (r) { return r.json(); }).then(function (s) {
+      state.drivers = s.drivers;
+      if (s.repoMode) el('detail-row').hidden = false;
+      var drv = el('drv');
+      if (drv.options.length === 0) {
+        s.drivers.forEach(function (d) {
+          var o = document.createElement('option');
+          o.value = d.id; o.textContent = d.label + (d.envKeyPresent ? ' (key found in env)' : '');
+          drv.appendChild(o);
+        });
+      }
+      var ul = el('disclosure');
+      ul.replaceChildren();
+      s.disclosure.forEach(function (line) {
+        var li = document.createElement('li');
+        li.textContent = line;
+        ul.appendChild(li);
+      });
+      syncDriver();
+    });
+  }
+  function currentDriver() {
+    var id = el('drv').value;
+    for (var i = 0; i < state.drivers.length; i++) if (state.drivers[i].id === id) return state.drivers[i];
+    return null;
+  }
+  function syncDriver() {
+    var d = currentDriver();
+    if (!d) return;
+    el('baseurl-row').hidden = !d.needsBaseUrl;
+    var dl = el('model-suggestions');
+    dl.replaceChildren();
+    d.suggestedModels.forEach(function (m) {
+      var o = document.createElement('option');
+      o.value = m;
+      dl.appendChild(o);
+    });
+    if (!el('model').value) el('model').value = d.defaultModel;
+    el('key-env-note').hidden = !d.envKeyPresent;
+    el('key-input-label').hidden = d.envKeyPresent;
+    el('key-env-name').textContent = d.keyEnv;
+  }
+  function addMsg(role, text) {
+    var div = document.createElement('div');
+    div.className = 'chat-msg chat-' + role;
+    div.textContent = text;
+    el('chat').appendChild(div);
+    div.scrollIntoView();
+    return div;
+  }
+  var history = [];
+  function ask() {
+    var q = el('q').value.trim();
+    if (!q) return;
+    el('ask-error').textContent = '';
+    el('q').value = '';
+    addMsg('user', q);
+    var pending = addMsg('assistant', '…');
+    fetch('/api/ask', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        driverId: el('drv').value,
+        model: el('model').value.trim(),
+        baseUrl: el('baseurl').value.trim(),
+        browserKey: el('key').value,
+        detail: el('detail').checked,
+        question: q,
+        history: history
+      })
+    }).then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+      .then(function (res) {
+        if (!res.ok) {
+          pending.textContent = '';
+          el('ask-error').textContent = res.body.error || 'request failed';
+          return;
+        }
+        pending.textContent = res.body.answer;
+        history.push({ role: 'user', content: q });
+        history.push({ role: 'assistant', content: res.body.answer });
+      })
+      .catch(function (e) { pending.textContent = ''; el('ask-error').textContent = String(e); });
+  }
+  el('ask').addEventListener('click', ask);
+  el('drv').addEventListener('change', function () { el('model').value = ''; syncDriver(); });
+  el('detail').addEventListener('change', refreshStatus);
+  refreshStatus();
+})();
+</script>`;
 }
 
 export function renderLearnHtml(
@@ -208,6 +353,11 @@ export function renderLearnHtml(
       <div class="cards">${caps.map((c) => capCard(c, bundle.knobs)).join('\n')}</div>`);
   }
   if (status) body.push(statusSection(status));
+  if (opts.serve) {
+    nav.push(`<div class="nav-label">Assistant</div>`);
+    nav.push(`<a href="#assistant">Ask the assistant</a>`);
+    body.push(assistantSection());
+  }
 
   return `<!DOCTYPE html>
 <html lang="en">

--- a/src/learn/serve.ts
+++ b/src/learn/serve.ts
@@ -1,0 +1,201 @@
+/**
+ * `vyuh-dxkit learn --serve` — the localhost assistant server (issue #245).
+ *
+ * Security posture, all load-bearing:
+ *   - binds 127.0.0.1 ONLY — never reachable from the network;
+ *   - READ-ONLY + relay: it serves the page, reports status, and relays one
+ *     question at a time to the user's chosen provider. No mutation
+ *     endpoint exists (the setup wizard is deliberately deferred, #247);
+ *   - key handling: an env key (per-driver) stays in the process and is
+ *     never sent to the browser; a browser-entered key is held in browser
+ *     memory only, arrives per-request in the POST body, is used for
+ *     exactly that provider call, and is never logged, stored, or echoed;
+ *   - body size is capped and JSON is parsed defensively.
+ */
+import * as http from 'http';
+import type { LearnBundle } from './bundle';
+import type { LearnRepoStatus } from './repo-status';
+import { renderLearnHtml } from './render';
+import { assembleGrounding } from './grounding';
+import { CUSTOM_BASE_URL_ENV, LLM_DRIVERS, envKeyFor, getDriver, relayAsk } from './drivers';
+
+const MAX_BODY_BYTES = 256 * 1024;
+
+export interface LearnServer {
+  server: http.Server;
+  url: string;
+  close: () => Promise<void>;
+}
+
+export interface ServeOptions {
+  port?: number;
+  /** Injectable for tests. */
+  fetchFn?: typeof fetch;
+}
+
+interface AskBody {
+  driverId?: string;
+  model?: string;
+  baseUrl?: string;
+  browserKey?: string;
+  detail?: boolean;
+  question?: string;
+  history?: Array<{ role: 'user' | 'assistant'; content: string }>;
+}
+
+function json(res: http.ServerResponse, code: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(code, { 'content-type': 'application/json; charset=utf-8' });
+  res.end(payload);
+}
+
+function readBody(req: http.IncomingMessage): Promise<string | null> {
+  return new Promise((resolve) => {
+    let size = 0;
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => {
+      size += c.length;
+      if (size > MAX_BODY_BYTES) {
+        resolve(null);
+        req.destroy();
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    req.on('error', () => resolve(null));
+  });
+}
+
+/** The status payload the page's JS renders its chooser + disclosure from. */
+export function buildStatusPayload(
+  bundle: LearnBundle,
+  status: LearnRepoStatus | null,
+  detail: boolean,
+): unknown {
+  const grounding = assembleGrounding(bundle, status, { detail });
+  return {
+    version: bundle.version,
+    repoMode: status !== null,
+    drivers: LLM_DRIVERS.map((d) => ({
+      id: d.id,
+      label: d.label,
+      keyEnv: d.keyEnv,
+      needsBaseUrl: d.endpoint === null,
+      suggestedModels: d.suggestedModels,
+      defaultModel: d.defaultModel,
+      // Presence only — the key itself never crosses to the browser.
+      envKeyPresent: envKeyFor(d) !== null,
+    })),
+    envBaseUrlPresent: !!process.env[CUSTOM_BASE_URL_ENV],
+    disclosure: grounding.disclosure,
+    detail,
+  };
+}
+
+export async function startLearnServer(
+  bundle: LearnBundle,
+  status: LearnRepoStatus | null,
+  opts: ServeOptions = {},
+): Promise<LearnServer> {
+  const fetchFn = opts.fetchFn ?? fetch;
+  const html = renderLearnHtml(bundle, status, {
+    generatedAt: new Date().toISOString(),
+    serve: true,
+  });
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const url = req.url ?? '/';
+      if (req.method === 'GET' && (url === '/' || url === '/index.html')) {
+        res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+        res.end(html);
+        return;
+      }
+      if (req.method === 'GET' && url.startsWith('/api/status')) {
+        const detail = new URL(url, 'http://localhost').searchParams.get('detail') === '1';
+        json(res, 200, buildStatusPayload(bundle, status, detail));
+        return;
+      }
+      if (req.method === 'POST' && url === '/api/ask') {
+        const raw = await readBody(req);
+        if (raw === null) {
+          json(res, 413, { error: 'request body too large' });
+          return;
+        }
+        let body: AskBody;
+        try {
+          body = JSON.parse(raw) as AskBody;
+        } catch {
+          json(res, 400, { error: 'invalid JSON' });
+          return;
+        }
+        const driver = getDriver(body.driverId ?? '');
+        if (!driver) {
+          json(res, 400, { error: `unknown driver: ${body.driverId ?? '(none)'}` });
+          return;
+        }
+        const question = (body.question ?? '').trim();
+        if (question.length === 0) {
+          json(res, 400, { error: 'empty question' });
+          return;
+        }
+        // Key precedence: env key first (never leaves the process), else the
+        // browser-entered key for this one request.
+        const apiKey = envKeyFor(driver) ?? (body.browserKey ?? '').trim();
+        if (apiKey.length === 0) {
+          json(res, 400, {
+            error: `no API key: set ${driver.keyEnv} in the terminal before --serve, or enter a key in the page`,
+          });
+          return;
+        }
+        const grounding = assembleGrounding(bundle, status, { detail: !!body.detail });
+        const history = Array.isArray(body.history)
+          ? body.history
+              .filter(
+                (m) =>
+                  (m.role === 'user' || m.role === 'assistant') && typeof m.content === 'string',
+              )
+              .slice(-20)
+          : [];
+        const result = await relayAsk(
+          {
+            driver,
+            model: (body.model ?? '').trim() || driver.defaultModel,
+            baseUrl: (body.baseUrl ?? '').trim() || process.env[CUSTOM_BASE_URL_ENV] || undefined,
+            apiKey,
+            system: grounding.system,
+            messages: [...history, { role: 'user', content: question }],
+          },
+          fetchFn,
+        );
+        if (!result.ok) {
+          json(res, 502, { error: result.error });
+          return;
+        }
+        json(res, 200, { answer: result.answer, keySource: envKeyFor(driver) ? 'env' : 'browser' });
+        return;
+      }
+      json(res, 404, { error: 'not found' });
+    })().catch(() => {
+      try {
+        json(res, 500, { error: 'internal error' });
+      } catch {
+        // Response already closed.
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    // 127.0.0.1 only — the whole security model depends on this bind.
+    server.listen(opts.port ?? 0, '127.0.0.1', () => resolve());
+  });
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  return {
+    server,
+    url: `http://127.0.0.1:${port}/`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}

--- a/test/learn/serve.test.ts
+++ b/test/learn/serve.test.ts
@@ -1,0 +1,347 @@
+/**
+ * `learn --serve` contract (issue #245):
+ *   - the driver registry is well-formed (three drivers, decision 2026-08-02);
+ *   - the relay speaks each wire format correctly and never echoes the key;
+ *   - grounding: summaries by default, finding detail ONLY behind the toggle,
+ *     and the disclosure derives from the SAME assembly as the payload;
+ *   - the server binds localhost only, degrades without a key to a clear
+ *     remedy (never an exception), and the assistant page stays free of
+ *     external loads.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildLearnBundle } from '../../src/learn/bundle';
+import { renderLearnHtml } from '../../src/learn/render';
+import { assembleGrounding } from '../../src/learn/grounding';
+import { LLM_DRIVERS, relayAsk, getDriver } from '../../src/learn/drivers';
+import { startLearnServer, buildStatusPayload } from '../../src/learn/serve';
+import type { LearnRepoStatus } from '../../src/learn/repo-status';
+
+const KEY_ENVS = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'DXKIT_LLM_API_KEY', 'DXKIT_LLM_BASE_URL'];
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of KEY_ENVS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+afterEach(() => {
+  for (const k of KEY_ENVS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+function repoStatus(): LearnRepoStatus {
+  return {
+    cwd: '/repo',
+    installed: true,
+    doctor: {
+      schema: 'doctor.v1',
+      generatedAt: 'x',
+      cwd: '/repo',
+      checks: [
+        { label: 'git', ok: true, tier: 'reports' },
+        {
+          label: 'SECRET-SHAPED failing label',
+          ok: false,
+          tier: 'operational',
+          fix: { hint: 'do the thing', command: 'vyuh-dxkit fix-it' },
+        },
+      ],
+      recommendations: [
+        {
+          id: 'baseline',
+          recommendation: { reason: 'no baseline', command: 'vyuh-dxkit baseline create' },
+        },
+      ],
+      summary: {
+        reports: { pass: 1, fail: 0, status: 'ok' },
+        dx: { pass: 0, fail: 0, status: 'ok' },
+        operational: { pass: 0, fail: 1, status: 'fail' },
+        fixable: [],
+      },
+    },
+    policy: { preset: 'security-only', checksCount: 1, lintEnabled: false, lanes: [] },
+    baselines: [{ name: 'main', capturedAt: '2026-08-01T00:00:00Z', entryCount: 42 }],
+    lastVerdict: {
+      signature: 's',
+      policyHash: 'p',
+      blocks: true,
+      warns: false,
+      blockingCount: 2,
+      unattributableCount: 0,
+      warningCount: 0,
+      markdown: '',
+      ranAt: '2026-08-01T12:00:00Z',
+      blockingFindings: [{ fingerprint: 'fp-123', kind: 'dep-vuln', status: 'added' }],
+    },
+  };
+}
+
+describe('driver registry — decision-locked shape', () => {
+  it('ships exactly anthropic (default) + openai + custom, all well-formed', () => {
+    expect(LLM_DRIVERS.map((d) => d.id)).toEqual(['anthropic', 'openai', 'custom']);
+    for (const d of LLM_DRIVERS) {
+      expect(d.keyEnv.length).toBeGreaterThan(0);
+      expect(['anthropic', 'openai-chat']).toContain(d.wire);
+      if (d.id === 'custom') {
+        expect(d.endpoint).toBeNull();
+        expect(d.suggestedModels).toEqual([]);
+      } else {
+        expect(d.endpoint).toMatch(/^https:\/\//);
+        expect(d.suggestedModels.length).toBeGreaterThan(0);
+        expect(d.defaultModel.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('relay — wire formats, key hygiene', () => {
+  it('anthropic wire: /v1/messages, key + version headers, system + messages, text joined', async () => {
+    let seen: { url: string; init: RequestInit } | null = null;
+    const fetchFn = (async (url: unknown, init: unknown) => {
+      seen = { url: String(url), init: init as RequestInit };
+      return new Response(
+        JSON.stringify({
+          stop_reason: 'end_turn',
+          content: [
+            { type: 'text', text: 'hello' },
+            { type: 'text', text: 'world' },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+    const result = await relayAsk(
+      {
+        driver: getDriver('anthropic')!,
+        model: 'claude-opus-5',
+        apiKey: 'your-unit-key-123',
+        system: 'SYSTEM-PROMPT',
+        messages: [{ role: 'user', content: 'q' }],
+      },
+      fetchFn,
+    );
+    expect(result).toEqual({ ok: true, answer: 'hello\nworld' });
+    expect(seen!.url).toBe('https://api.anthropic.com/v1/messages');
+    const headers = seen!.init.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('your-unit-key-123');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    const body = JSON.parse(String(seen!.init.body));
+    expect(body.system).toBe('SYSTEM-PROMPT');
+    expect(body.messages).toEqual([{ role: 'user', content: 'q' }]);
+  });
+
+  it('anthropic wire: a refusal is a disclosed error, not an empty answer', async () => {
+    const fetchFn = (async () =>
+      new Response(JSON.stringify({ stop_reason: 'refusal', content: [] }), {
+        status: 200,
+      })) as typeof fetch;
+    const result = await relayAsk(
+      {
+        driver: getDriver('anthropic')!,
+        model: 'm',
+        apiKey: 'k',
+        system: 's',
+        messages: [{ role: 'user', content: 'q' }],
+      },
+      fetchFn,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('refusal');
+  });
+
+  it('openai wire: bearer auth, chat/completions, system message first', async () => {
+    let seen: { url: string; init: RequestInit } | null = null;
+    const fetchFn = (async (url: unknown, init: unknown) => {
+      seen = { url: String(url), init: init as RequestInit };
+      return new Response(JSON.stringify({ choices: [{ message: { content: 'answer' } }] }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+    const result = await relayAsk(
+      {
+        driver: getDriver('openai')!,
+        model: 'gpt-5.1',
+        apiKey: 'your-unit-key-oai',
+        system: 'SYS',
+        messages: [{ role: 'user', content: 'q' }],
+      },
+      fetchFn,
+    );
+    expect(result).toEqual({ ok: true, answer: 'answer' });
+    expect(seen!.url).toBe('https://api.openai.com/v1/chat/completions');
+    const headers = seen!.init.headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer your-unit-key-oai');
+    const body = JSON.parse(String(seen!.init.body));
+    expect(body.messages[0]).toEqual({ role: 'system', content: 'SYS' });
+  });
+
+  it('custom driver without a base URL is a disclosed error', async () => {
+    const result = await relayAsk(
+      {
+        driver: getDriver('custom')!,
+        model: 'local-model',
+        apiKey: 'k',
+        system: 's',
+        messages: [{ role: 'user', content: 'q' }],
+      },
+      (async () => new Response('{}')) as typeof fetch,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('base URL');
+  });
+});
+
+describe('grounding — summaries by default, detail behind the toggle, disclosure = payload', () => {
+  const bundle = buildLearnBundle();
+
+  it('zero-context grounding has product facts only and says so', () => {
+    const g = assembleGrounding(bundle, null);
+    expect(g.repoMode).toBe(false);
+    expect(g.system).toContain('guardrail');
+    expect(g.system).toContain('How dxkit thinks');
+    expect(g.disclosure.join(' ')).toContain('No repo data');
+  });
+
+  it('repo default: counts only — no failing labels, no fingerprints; disclosure says summaries', () => {
+    const g = assembleGrounding(bundle, repoStatus(), { detail: false });
+    expect(g.detail).toBe(false);
+    expect(g.system).toContain('1 failing');
+    expect(g.system).not.toContain('SECRET-SHAPED failing label');
+    expect(g.system).not.toContain('fp-123');
+    expect(g.disclosure.join(' ')).toContain('SUMMARIES ONLY');
+  });
+
+  it('detail toggle: labels + remedies + fingerprints appear, and the disclosure says so', () => {
+    const g = assembleGrounding(bundle, repoStatus(), { detail: true });
+    expect(g.detail).toBe(true);
+    expect(g.system).toContain('SECRET-SHAPED failing label');
+    expect(g.system).toContain('vyuh-dxkit fix-it');
+    expect(g.system).toContain('fp-123');
+    expect(g.disclosure.join(' ')).toContain('IN DETAIL');
+  });
+});
+
+describe('serve — localhost only, key hygiene, graceful no-key degrade', () => {
+  const bundle = buildLearnBundle();
+
+  it('binds 127.0.0.1, serves the assistant page with zero external loads', async () => {
+    const s = await startLearnServer(bundle, null, {});
+    try {
+      expect(s.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
+      const addr = s.server.address();
+      expect(typeof addr === 'object' && addr ? addr.address : '').toBe('127.0.0.1');
+      const html = await (await fetch(s.url)).text();
+      expect(html).toContain('Ask the assistant');
+      expect(html).toContain('<script>');
+      expect(html).not.toMatch(/src=["']https?:/);
+      expect(html).not.toMatch(/<(link|img|iframe)\b/);
+    } finally {
+      await s.close();
+    }
+  });
+
+  it('/api/status exposes driver metadata + disclosure but never key material', async () => {
+    process.env.ANTHROPIC_API_KEY = 'your-env-unit-key';
+    const s = await startLearnServer(bundle, null, {});
+    try {
+      const raw = await (await fetch(`${s.url}api/status`)).text();
+      expect(raw).not.toContain('your-env-unit-key');
+      const status = JSON.parse(raw);
+      const anthropic = status.drivers.find((d: { id: string }) => d.id === 'anthropic');
+      expect(anthropic.envKeyPresent).toBe(true);
+      expect(status.disclosure.length).toBeGreaterThan(0);
+    } finally {
+      await s.close();
+    }
+  });
+
+  it('no key anywhere: /api/ask degrades to a 400 naming the env var, never a crash', async () => {
+    const s = await startLearnServer(bundle, null, {});
+    try {
+      const res = await fetch(`${s.url}api/ask`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ driverId: 'anthropic', question: 'hi' }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain('ANTHROPIC_API_KEY');
+    } finally {
+      await s.close();
+    }
+  });
+
+  it('browser key is relayed to the provider and never echoed in the response', async () => {
+    let seenKey = '';
+    const fetchFn = (async (_url: unknown, init: unknown) => {
+      seenKey = (init as { headers: Record<string, string> }).headers['x-api-key'];
+      return new Response(
+        JSON.stringify({ stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }] }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+    const s = await startLearnServer(bundle, null, { fetchFn });
+    try {
+      const res = await fetch(`${s.url}api/ask`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          driverId: 'anthropic',
+          question: 'hi',
+          browserKey: 'your-browser-unit-key',
+        }),
+      });
+      expect(res.status).toBe(200);
+      const raw = JSON.stringify(await res.json());
+      expect(seenKey).toBe('your-browser-unit-key');
+      expect(raw).not.toContain('your-browser-unit-key');
+      expect(raw).toContain('"keySource":"browser"');
+    } finally {
+      await s.close();
+    }
+  });
+
+  it('unknown driver and invalid JSON are 400s', async () => {
+    const s = await startLearnServer(bundle, null, {});
+    try {
+      const r1 = await fetch(`${s.url}api/ask`, {
+        method: 'POST',
+        body: JSON.stringify({ driverId: 'nope', question: 'x' }),
+      });
+      expect(r1.status).toBe(400);
+      const r2 = await fetch(`${s.url}api/ask`, { method: 'POST', body: '{not json' });
+      expect(r2.status).toBe(400);
+    } finally {
+      await s.close();
+    }
+  });
+
+  it('status payload detail flag round-trips through the one grounding assembly', () => {
+    const off = buildStatusPayload(bundle, repoStatus(), false) as { disclosure: string[] };
+    const on = buildStatusPayload(bundle, repoStatus(), true) as { disclosure: string[] };
+    expect(off.disclosure.join(' ')).toContain('SUMMARIES ONLY');
+    expect(on.disclosure.join(' ')).toContain('IN DETAIL');
+  });
+});
+
+describe('render — file mode stays script-free, serve mode stays self-contained', () => {
+  const bundle = buildLearnBundle();
+
+  it('static file mode has no script even with serve-capable code present', () => {
+    const html = renderLearnHtml(bundle, null, {});
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('Ask the assistant');
+  });
+
+  it('serve mode adds the panel + script but still no external loads', () => {
+    const html = renderLearnHtml(bundle, null, { serve: true });
+    expect(html).toContain('Ask the assistant');
+    expect(html).toContain('bring-your-own-key');
+    expect(html).not.toMatch(/src=["']https?:/);
+    expect(html).not.toMatch(/@import/);
+  });
+});


### PR DESCRIPTION
Part of the 4.3.6 release train (#240). Closes #245. Builds on WP12.

- Localhost-only server (127.0.0.1 bind pinned by test): serves the learn page with an assistant chat panel, `GET /api/status`, `POST /api/ask`. No mutation endpoint (wizard deferred to #247).
- Driver registry (design decision): Anthropic default + OpenAI + OpenAI-compatible custom endpoint; suggested models + free-text override; chooser rendered from the registry via /api/status.
- Key flow: env auto-detect (key never sent to the browser) AND in-browser form (tab memory only, relayed per-request, never logged/stored/echoed — pinned by test).
- Privacy: repo grounding defaults to summaries/counts; failing-check labels + remedies + blocking fingerprints only behind the visible detail toggle. The page's "exactly what is sent" list derives from the SAME assembly as the provider payload (one code path) — pinned in both directions.
- Static-file page remains 100% script-free; serve page's inline JS is same-origin only.
- Dogfood note: the self-guardrail BLOCKED this branch's first commit — the secret scanner flagged `sk-*`-shaped test fixture keys as net-new secrets. Fixed by using `your-*` placeholder-convention fixtures (the benign module's designed path), not by allowlisting.
- Local sweep ALL GREEN (352 files / 5286 tests, self-guardrail PASSED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)