### PR TITLE
WP15: learn v2 — product UI, search, auto routing, full knowledge base + drift net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,13 @@ that keeps the class from recurring — plus the learn surface below.
   checklist with copy-paste remedies.
 - **The knowledge base is the whole documentation set, and it cannot
   drift.** The page ships the entire docs tree (command reference,
-  configuration and policy reference, benchmarks, the extension SDK) plus
-  the installed agent-skill and remediation-task catalogs, all searchable.
+  configuration and policy reference, benchmarks, the extension SDK), a
+  complete policy field reference generated from the policy schema
+  itself, the installed agent-skill catalog, and the remediation-task
+  catalog with each task's model-tier rationale and verification hinge —
+  all searchable. New guides cover operating the lanes (schedules,
+  one-off dispatch campaigns, budgets) and a step-by-step bot-token
+  setup for admins.
   A coverage test enforces that every command, policy knob, skill, task,
   and doc is in the bundle or declared-excluded with a reason — a feature
   or doc that skips the knowledge base fails CI.
@@ -43,9 +48,13 @@ that keeps the class from recurring — plus the learn surface below.
   your own LLM key: auto-detected from the environment (never sent to the
   browser) or entered in the page (held in tab memory, relayed per
   request, never stored). Three providers — Anthropic, OpenAI, any
-  OpenAI-compatible endpoint — with an **Auto** model choice that routes
-  each question deterministically between a fast tier and a deep tier and
-  discloses, under every answer, which model served and why. Repo
+  OpenAI-compatible endpoint — and the model chooser loads the LIVE model
+  list from the provider with your key (compiled-in suggestions remain
+  only as a labeled offline fallback, so the chooser is never a stale
+  snapshot). An **Auto** model choice routes each question
+  deterministically between a fast tier and a deep tier — resolved
+  against the live list, newest models win — and discloses, under every
+  answer, which model served and why. Repo
   grounding defaults to summaries and counts; finding-level detail sits
   behind a visible toggle, and the page states exactly what is sent —
   generated from the same assembly as the payload, so the disclosure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,20 +23,34 @@ that keeps the class from recurring — plus the learn surface below.
   three persona quickstarts (developer, reviewer, admin), and a
   capabilities-and-limits statement that says explicitly what dxkit
   verifies and what it cannot.
-- **`vyuh-dxkit learn`.** One self-contained offline HTML page — zero CDN
-  loads, zero scripts — with capability cards rendered from the registries,
-  the docs above, and (inside a repo) live doctor status plus a strictly
-  read-only "Set up this repo" checklist with copy-paste remedies. Works in
-  an empty directory: `npx @vyuhlabs/dxkit learn` needs no repo at all.
-- **`learn --serve`.** A localhost-only assistant grounded hard in that same
-  content plus the repo's live status. Bring your own LLM key: auto-detected
-  from the environment (never sent to the browser) or entered in the page
-  (held in tab memory, relayed per request, never stored). Three providers:
-  Anthropic, OpenAI, and any OpenAI-compatible endpoint. Repo grounding
-  defaults to summaries and counts; finding-level detail sits behind a
-  visible toggle, and the page states exactly what is sent — generated from
-  the same assembly as the payload, so the disclosure cannot drift. The
-  assistant explains and produces exact commands; it executes nothing.
+- **`vyuh-dxkit learn`.** One self-contained offline HTML page — every
+  asset inline, zero external requests, works from file:// — with a full
+  product UI: light and dark themes, a Ctrl+K search palette over
+  everything on the page, copy buttons on every command, and capability
+  cards rendered from the registries. Works in an empty directory:
+  `npx @vyuhlabs/dxkit learn` needs no repo at all. Inside a repo it adds
+  live doctor status plus a strictly read-only "Set up this repo"
+  checklist with copy-paste remedies.
+- **The knowledge base is the whole documentation set, and it cannot
+  drift.** The page ships the entire docs tree (command reference,
+  configuration and policy reference, benchmarks, the extension SDK) plus
+  the installed agent-skill and remediation-task catalogs, all searchable.
+  A coverage test enforces that every command, policy knob, skill, task,
+  and doc is in the bundle or declared-excluded with a reason — a feature
+  or doc that skips the knowledge base fails CI.
+- **`learn --serve`.** A localhost-only assistant in a dedicated panel,
+  grounded hard in that same content plus the repo's live status. Bring
+  your own LLM key: auto-detected from the environment (never sent to the
+  browser) or entered in the page (held in tab memory, relayed per
+  request, never stored). Three providers — Anthropic, OpenAI, any
+  OpenAI-compatible endpoint — with an **Auto** model choice that routes
+  each question deterministically between a fast tier and a deep tier and
+  discloses, under every answer, which model served and why. Repo
+  grounding defaults to summaries and counts; finding-level detail sits
+  behind a visible toggle, and the page states exactly what is sent —
+  generated from the same assembly as the payload, so the disclosure
+  cannot drift. The assistant explains and produces exact commands; it
+  executes nothing.
 - **Per-repo runbook.** Install/update generates `RUNBOOK.dxkit.md` at the
   repo root: what dxkit actually runs in this repo (gates, lane schedules),
   what to do when blocked, and the typed escape hatches — rendered from repo

--- a/docs/learn/capabilities-and-limits.md
+++ b/docs/learn/capabilities-and-limits.md
@@ -43,6 +43,19 @@ both directions, so you can decide what to rely on it for.
 - **The honesty of allowlist entries.** A false-positive category or a
   deferral reason is a human statement, on the record and auditable, but
   dxkit does not second-guess it.
+- **UI or screen testing.** dxkit does not drive browsers or screens and
+  does not generate end-to-end UI tests. Its testing surface is test-gap
+  analysis, affected-test selection, and the `improve-tests` remediation
+  task, which writes tests in the repo's own test framework.
+- **API collection generation.** dxkit maps UI-to-API integration (the
+  flow gate) and inventories served routes, but it does not generate or
+  maintain request-collection suites for external API tools. The route
+  inventory (`flow` / `describe`) is a sound input if you build those
+  elsewhere.
+- **Code migration.** Framework or platform migrations are not a dxkit
+  capability. A custom remediation campaign can attempt scoped migration
+  work, but it carries no score hinge: verification is compile + affected
+  tests + the guardrail + your review, and the PR says so.
 
 ## Standing limits worth knowing
 

--- a/docs/learn/extending-dxkit.md
+++ b/docs/learn/extending-dxkit.md
@@ -1,0 +1,101 @@
+# Extending dxkit: the SDK and the effort ladder
+
+dxkit's core owns the language-agnostic machinery: routes, models,
+dependencies, findings, gates. Everything app-specific or org-specific is an
+extension, and `@vyuhlabs/dxkit-sdk` is the frozen surface extensions build
+against. This page is the short version; the full reference lives in
+`docs/extension-sdk.md`.
+
+## When should you extend at all?
+
+Reach for an extension when dxkit's stock analysis cannot see something your
+org's code makes true by convention:
+
+- your HTTP client is a wrapper (`fetchJson`, `api.call`) the flow mapper
+  does not recognize, so UI-to-API calls read as unresolved;
+- a contract artifact already exists (an OpenAPI file, a route manifest from
+  your framework's build) and dxkit should trust it instead of re-deriving;
+- an in-house scanner or audit script produces findings you want gated like
+  native ones, with grandfathering and allowlists;
+- an org convention ("every handler declares its auth level") deserves a
+  first-class check.
+
+If none of these apply, you do not need the SDK. Custom checks in
+`.dxkit/policy.json` (a command plus a regex over its output) already make
+any repo command a gate citizen.
+
+## The effort ladder: land on the lowest rung
+
+Every capability lands on the lowest rung that can express it. Most teams
+never leave rungs 1 and 2.
+
+1. **A policy key.** Examples: `flow.stripUrlPrefixes`, custom `checks[]`,
+   paired-change rules. You write JSON, nothing runs.
+2. **A path to an artifact you already have.** Point `flow.sources` at an
+   OpenAPI file or a route manifest your build already emits. dxkit reads
+   it; nothing of yours runs.
+3. **A manifest pointing at your existing script.** Your script emits one of
+   the versioned wire documents (`contract.v1`, `inventory.v1`,
+   `findings.v1`, `export.v1`); dxkit runs it at refresh time, validates the
+   output, and commits the snapshot. Developers and the per-commit gate read
+   the committed snapshot, so your script's toolchain is needed only where
+   refresh runs.
+4. **A TypeScript plugin.** Mostly a data table, loaded in-process. This is
+   where wrapper dialects and custom contract readers live.
+
+## A worked rung-4 example: teach the flow mapper your HTTP wrapper
+
+Your frontend calls `fetchJson('/api/orders')` and dxkit's flow map shows
+unresolved calls. The fix is a committed plugin that contributes a dialect
+entry to the TypeScript pack:
+
+```jsonc
+// .dxkit/extensions/acme-dialect/extension.json
+{ "schemaVersion": 1, "name": "acme-dialect", "plugin": { "module": "plugin.js" } }
+```
+
+```js
+// .dxkit/extensions/acme-dialect/plugin.js
+module.exports = {
+  name: 'acme-dialect',
+  sdkMajor: 0,
+  httpFlowDialect: {
+    pack: 'typescript',
+    clientMethodCallees: { methods: ['fetchJson'] },
+    methodAliases: { fetchjson: 'GET' },
+  },
+};
+```
+
+Scaffold with `vyuh-dxkit extensions init <name> --plugin`, iterate with
+`vyuh-dxkit extensions dev <name>`, and commit the result. From then on the
+flow map, the doctor diagnosis, and the integration gate all understand the
+wrapper, on every machine, with no per-developer setup.
+
+## The rules that keep extensions honest
+
+- **One normalizer.** URL and method normalization is the SDK's
+  (`normalizePath`, `normalizeMethod`); extensions never replicate it, and
+  wire URLs are re-normalized at ingest, so an extension cannot drift from
+  the gate's idea of a route.
+- **dxkit computes identity.** Extensions emit findings; the aggregator
+  fingerprints them. An extension that hashed its own identities would opt
+  out of baseline migration, so the SDK simply does not expose it.
+- **Committed code, reviewed like CI config.** A rung-4 plugin runs
+  in-process on trusted surfaces only, never under `--untrusted`, and a
+  plugin built against a different SDK major is refused at load with both
+  versions named. Review a PR that edits a plugin the way you review a PR
+  that edits a workflow.
+- **Additive-only freeze.** Everything the SDK exports is contract, pinned
+  by a surface-freeze test; shipped wire versions are read forever. A
+  committed snapshot is never stranded by a dxkit upgrade.
+
+## Choosing your rung, quickly
+
+| You have...                                   | Use                              |
+| --------------------------------------------- | -------------------------------- |
+| a convention expressible as configuration     | rung 1: a policy key             |
+| an artifact your build already produces       | rung 2: `flow.sources`           |
+| a script that can print JSON                  | rung 3: manifest + wire document |
+| a wrapper/dialect the parsers should learn    | rung 4: plugin (data table)      |
+| findings from an external SAST engine (SARIF) | `vyuh-dxkit ingest`, not the SDK |

--- a/docs/learn/operating-the-lanes.md
+++ b/docs/learn/operating-the-lanes.md
@@ -1,0 +1,77 @@
+# Operating the lanes: schedules, campaigns, and budgets
+
+For whoever owns dxkit's scheduled automation in a repo. Everything here is
+observable in GitHub Actions and lands only via pull requests through the
+same gate as a human change.
+
+## The three lane families
+
+- **Baseline refresh** re-captures findings on a cadence and raises newly
+  published dependency advisories as a decision PR: merging it defers the
+  advisory for a time-boxed window (it re-blocks at expiry); fixing means
+  upgrading the dependency and closing the PR.
+- **Dependency bump** proposes upgrades as ordinary PRs.
+- **Remediation** runs budget-bounded agent tasks. Each task's outcome is
+  re-verifiable without reading prose: the correctness floor and the
+  guardrail always run, and score-hinged tasks must additionally move their
+  target dimension above the pristine-tree entry score or nothing lands.
+
+The task catalog (what each task does, its model tier and why, and what its
+outcome hinges on) is on the Remediation tasks page of this guide, rendered
+from the same registry the lane executes.
+
+## Scheduled runs vs one-off campaigns
+
+**Scheduled** is the recurring posture: the tasks enabled in
+`.dxkit/policy.json` run on the workflow's cron, under the policy's
+per-task budgets.
+
+**Dispatch campaigns** are one-time runs from the GitHub Actions UI: open
+the remediation workflow, press _Run workflow_, and the typed form offers:
+
+- **task**: one task from the catalog, or `custom` with a free-text prompt
+  (the prompt is transported via environment, never shell-interpolated, and
+  is disclosed verbatim in the PR body);
+- **spend / turn / minute overrides**: blank means policy; every value is
+  clamped by the `remediate.maxDispatchBudget` org ceiling.
+
+A custom prompt carries no score hinge, and the PR says so explicitly:
+verification is the floor + the guardrail + your review. Dispatching is
+write-access-gated by GitHub itself.
+
+## Budgets, in one place
+
+- Per-task caps (spend, turns, minutes) live in policy
+  (`remediate.agent.budget`, per-task overrides in `remediate.taskBudgets`).
+- `remediate.maxSpendPerRun` caps a whole scheduled run;
+  `remediate.maxDispatchBudget` caps any one-off campaign.
+- A task that hits its cap is "budget-bounded, not finished": nothing lands
+  unless the frame verifies, and the attempt is disclosed in the run.
+- With `remediate.resume` enabled, a salvaged attempt can continue in a
+  later run (draft-PR salvage only, attempt-counted, capped).
+
+## What a failed attempt looks like
+
+The frame holding is the feature: if the agent's work does not verify, the
+run is red, nothing merges, and the blocked attempt's diff is uploaded as a
+run artifact for inspection. The other tasks in a matrix run are isolated
+(own checkout each) and keep going.
+
+## Credentials the lanes need
+
+Two GitHub settings decide whether lanes can do their jobs — both are
+covered step by step in the admin quickstart, and `vyuh-dxkit doctor`
+checks them:
+
+1. "Allow GitHub Actions to create and approve pull requests" (repo or org
+   Actions settings) — without it a lane pushes its branch and cannot open
+   the PR.
+2. The `DXKIT_BOT_TOKEN` secret — without it, lane PRs trigger no CI
+   checks and cannot satisfy branch protection.
+
+## Watching a run
+
+Every lane streams per-phase progress with heartbeats in the Actions log
+(a long silent phase means look at the last heartbeat line, not that it
+hung), and remediation runs use one job per task so each task has its own
+status, log, and retry button.

--- a/docs/learn/quickstart-admin.md
+++ b/docs/learn/quickstart-admin.md
@@ -49,10 +49,29 @@ Two settings decide whether the scheduled lanes can do their jobs:
 2. **A bot token for lane pushes (recommended): `DXKIT_BOT_TOKEN`.**
    Branches pushed with the default `GITHUB_TOKEN` do not trigger workflow
    runs, so lane PRs arrive with no CI checks and cannot satisfy branch
-   protection. Set a fine-grained PAT (contents: write, pull requests:
-   write) as a repo secret named `DXKIT_BOT_TOKEN`; the lane workflows use
-   it automatically when present and fall back to `GITHUB_TOKEN` (degraded,
-   disclosed) when absent.
+   protection. Create the token step by step:
+   1. GitHub → your profile → **Settings** → **Developer settings** →
+      **Personal access tokens** → **Fine-grained tokens** → _Generate new
+      token_. (Prefer a dedicated bot/service account over a personal one,
+      so lane PRs are not attributed to a person and survive offboarding.)
+   2. **Resource owner**: your organization. **Repository access**: only
+      the repositories dxkit's lanes run in.
+   3. **Permissions** (repository): `Contents` → Read and write,
+      `Pull requests` → Read and write. Nothing else.
+   4. **Expiration**: pick a real date and put the rotation on your
+      calendar; an expired token degrades lanes back to `GITHUB_TOKEN`
+      (disclosed in the run log, but easy to miss).
+   5. If your org requires fine-grained token approval, have an org admin
+      approve it (Settings → Personal access tokens in the org).
+   6. Store it as the repo secret and verify:
+
+      ```bash
+      gh secret set DXKIT_BOT_TOKEN     # paste the token when prompted
+      vyuh-dxkit doctor                 # the lane-credential check goes quiet
+      ```
+
+   The lane workflows use it automatically when present and fall back to
+   `GITHUB_TOKEN` (degraded, disclosed) when absent.
 
 ## 5. Policy: what blocks here
 

--- a/docs/learn/quickstart-developer.md
+++ b/docs/learn/quickstart-developer.md
@@ -47,6 +47,18 @@ For a wave of blocking dependency advisories from the last check there is a
 bulk form: `vyuh-dxkit allowlist defer --from-last-check --reason="..."`.
 Other kinds are deliberately one-at-a-time.
 
+**Straight from the PR conversation**: when the repo has the comment-defer
+workflow installed, anyone with write access can defer without leaving
+GitHub by commenting on the PR:
+
+```text
+/dxkit defer <fingerprint> --expires=+14d --reason="tracked in the payments epic"
+```
+
+The workflow applies the same time-boxed deferral the CLI does and commits
+it to the PR branch, so the reviewer sees it like any other change. The
+fingerprint is in the guardrail's PR comment.
+
 ## 4. The verdict is CANNOT GATE
 
 Stop: this is not about your code. dxkit is telling you it cannot honestly

--- a/scripts/copy-learn-docs.js
+++ b/scripts/copy-learn-docs.js
@@ -1,26 +1,41 @@
 #!/usr/bin/env node
 /**
- * Copy the curated learn docs (docs/learn/*.md) into dist/learn/docs/ so the
- * published package renders the learn page with NO repo checkout and no
- * network (the zero-context path). Runs after tsc in `npm run build`;
- * `src/learn/bundle.ts:learnDocsDir()` prefers this packaged copy and falls
- * back to docs/learn/ when running from source.
+ * Package the learn knowledge base into dist/ so the published package
+ * renders the full learn page with NO repo checkout and no network (the
+ * zero-context path):
+ *   - docs/learn/*.md        → dist/learn/docs/      (curated narratives)
+ *   - docs/** (everything)   → dist/learn/docs-ref/  (the reference shelf)
+ * Runs after tsc in `npm run build`; `src/learn/bundle.ts` prefers the
+ * packaged copies and falls back to docs/ when running from source.
  */
 const fs = require('fs');
 const path = require('path');
 
-const SRC = path.join(__dirname, '..', 'docs', 'learn');
-const DEST = path.join(__dirname, '..', 'dist', 'learn', 'docs');
+const DOCS = path.join(__dirname, '..', 'docs');
+const DEST_LEARN = path.join(__dirname, '..', 'dist', 'learn', 'docs');
+const DEST_REF = path.join(__dirname, '..', 'dist', 'learn', 'docs-ref');
 
-if (!fs.existsSync(SRC)) {
-  console.log('Warning: docs/learn/ not found; learn page will render packaging stubs.'); // slop-ok
+if (!fs.existsSync(DOCS)) {
+  console.log('Warning: docs/ not found; learn page will render packaging stubs.'); // slop-ok
   process.exit(0);
 }
-fs.mkdirSync(DEST, { recursive: true });
+
 let count = 0;
-for (const f of fs.readdirSync(SRC)) {
-  if (!f.endsWith('.md')) continue;
-  fs.copyFileSync(path.join(SRC, f), path.join(DEST, f));
-  count++;
+function copyTree(src, dest, skip) {
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    if (skip && skip(entry.name)) continue;
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyTree(s, d, null);
+    } else if (entry.name.endsWith('.md')) {
+      fs.mkdirSync(path.dirname(d), { recursive: true });
+      fs.copyFileSync(s, d);
+      count++;
+    }
+  }
 }
-console.log(`Copied ${count} learn docs to dist/learn/docs/`); // slop-ok
+
+copyTree(path.join(DOCS, 'learn'), DEST_LEARN, null);
+copyTree(DOCS, DEST_REF, (name) => name === 'learn');
+console.log(`Packaged ${count} learn/reference docs into dist/learn/`); // slop-ok

--- a/src/learn/bundle.ts
+++ b/src/learn/bundle.ts
@@ -1,21 +1,32 @@
 /**
- * The learn bundle — the ONE content assembly both the learn page and (next)
- * the `--serve` assistant grounding read (Rule 2.30: one concept, one code
- * path; the page and the assistant can never drift from each other).
+ * The learn bundle — the ONE content assembly the learn page, the search
+ * index, and the `--serve` assistant grounding all read (Rule 2.30: one
+ * concept, one code path; the page and the assistant can never drift from
+ * each other).
  *
- * Two content sources, by design (issue #244):
- *   - GENERATED: capability + knob facts come from the live registries
- *     (`COMMANDS`, `POSTURE_KNOBS`) compiled into this package — they cannot
- *     drift from the product;
- *   - CURATED: the narrative docs under `docs/learn/` (mental model, persona
- *     quickstarts, the capabilities-and-limits statement), copied into
- *     `dist/learn/docs/` at build time so the bundle works with NO repo, no
- *     git, and no network (the zero-context path is first-class).
+ * Three content classes, each with its own drift net
+ * (`test/learn/kb-coverage.test.ts`):
+ *
+ *   1. GENERATED from live registries compiled into this package — the
+ *      command catalog (`COMMANDS`), posture knobs (`POSTURE_KNOBS`), the
+ *      remediation task registry (`REMEDIATE_TASKS`), and the agent skills
+ *      dxkit installs (enumerated from the packaged templates). Cannot
+ *      drift from the product by construction.
+ *   2. The REFERENCE SHELF: the repo's entire `docs/` tree, shipped
+ *      verbatim (packaged at build). Every doc is either in the bundle or
+ *      in `KB_EXCLUDED` with a reason — a new doc that skips the KB fails
+ *      the coverage test.
+ *   3. CURATED learn narratives (`docs/learn/`), the guided reading path.
+ *
+ * All of it works with NO repo, no git, and no network (the zero-context
+ * path is first-class).
  */
 import * as fs from 'fs';
 import * as path from 'path';
 import { CORE_COMMAND_IDS, GROUP_LABELS, GROUP_ORDER, userCommands } from '../discovery/commands';
 import { POSTURE_KNOBS } from '../discovery/posture-knobs';
+import { REMEDIATE_TASKS } from '../remediate/tasks';
+import { templatesDir } from '../ship-installers';
 import { VERSION } from '../constants';
 
 export interface LearnDoc {
@@ -23,6 +34,18 @@ export interface LearnDoc {
   /** First `# ` heading of the file. */
   title: string;
   markdown: string;
+}
+
+export interface ReferenceDoc {
+  /** docs/-relative POSIX path, e.g. `configuration/policy.md`. */
+  relPath: string;
+  /** Display group on the page (Commands / Configuration / Benchmarks / Guides). */
+  group: string;
+  title: string;
+  markdown: string;
+  /** Whether this doc is included in the assistant's grounding (the page and
+   *  search always carry everything; grounding is size-budgeted). */
+  grounded: boolean;
 }
 
 export interface LearnCapability {
@@ -43,6 +66,17 @@ export interface LearnKnob {
   note?: string;
 }
 
+export interface LearnSkill {
+  name: string;
+  description: string;
+}
+
+export interface LearnTask {
+  id: string;
+  summary: string;
+  tier: string;
+}
+
 export interface LearnBundle {
   version: string;
   /** Core tier first (registry order), then the remaining user-facing
@@ -50,6 +84,9 @@ export interface LearnBundle {
   capabilities: LearnCapability[];
   knobs: LearnKnob[];
   docs: LearnDoc[];
+  reference: ReferenceDoc[];
+  skills: LearnSkill[];
+  tasks: LearnTask[];
 }
 
 /** Display order of the curated docs on the page. */
@@ -59,17 +96,60 @@ const DOC_SLUGS = [
   'quickstart-developer',
   'quickstart-reviewer',
   'quickstart-admin',
+  'extending-dxkit',
 ] as const;
 
 /**
- * Locate the curated docs: the packaged copy next to the compiled module
- * (`dist/learn/docs/`, written by the build), falling back to the repo's
- * `docs/learn/` when running from source (tests, tsx).
+ * docs/-relative paths deliberately NOT in the bundle, each with a reason —
+ * the `DEFERRED_KINDS` discipline: an exclusion is a declared decision,
+ * never a silent omission. The coverage test enforces that every doc on
+ * disk is bundled or listed here (and that listed paths actually exist).
+ */
+export const KB_EXCLUDED: ReadonlyArray<{ relPath: string; reason: string }> = [
+  {
+    relPath: 'MIGRATING-TO-2.4.7-SCORING.md',
+    reason: 'historical one-time migration note for a 2.x upgrade; not current-product knowledge',
+  },
+];
+
+/** Which reference docs join the assistant grounding (size-budgeted: the
+ *  command pages duplicate the registry blurbs and the deep benchmark pages
+ *  are large; both stay page+search-only). */
+function isGrounded(relPath: string): boolean {
+  if (relPath.startsWith('configuration/')) return true;
+  return ['getting-started.md', 'why-dxkit.md', 'extension-sdk.md', 'benchmarks.md'].includes(
+    relPath,
+  );
+}
+
+function referenceGroup(relPath: string): string {
+  if (relPath.startsWith('commands/')) return 'Command reference';
+  if (relPath.startsWith('configuration/')) return 'Configuration reference';
+  if (relPath.startsWith('benchmarks/') || relPath === 'benchmarks.md') return 'Benchmarks';
+  return 'Guides';
+}
+
+/**
+ * Locate the packaged content: the compiled copy next to this module
+ * (`dist/learn/docs`, written by the build), falling back to the repo tree
+ * when running from source (tests, tsx).
  */
 export function learnDocsDir(): string {
   const packaged = path.join(__dirname, 'docs');
   if (fs.existsSync(packaged)) return packaged;
   return path.join(__dirname, '..', '..', 'docs', 'learn');
+}
+
+/** The packaged reference shelf (`dist/learn/docs-ref`), or the repo docs/. */
+export function referenceDocsDir(): string {
+  const packaged = path.join(__dirname, 'docs-ref');
+  if (fs.existsSync(packaged)) return packaged;
+  return path.join(__dirname, '..', '..', 'docs');
+}
+
+function titleOf(markdown: string, fallback: string): string {
+  const h1 = markdown.match(/^#\s+(.+)$/m);
+  return h1 ? h1[1].trim() : fallback;
 }
 
 function loadDocs(): LearnDoc[] {
@@ -85,10 +165,81 @@ function loadDocs(): LearnDoc[] {
       // than a broken page, and let the bundle test catch it in CI.
       markdown = `# ${slug}\n\nThis document was not packaged with this build.`;
     }
-    const h1 = markdown.match(/^#\s+(.+)$/m);
-    docs.push({ slug, title: h1 ? h1[1].trim() : slug, markdown });
+    docs.push({ slug, title: titleOf(markdown, slug), markdown });
   }
   return docs;
+}
+
+/** Recursive .md listing of a docs tree, as sorted docs/-relative POSIX paths. */
+export function listDocsTree(root: string): string[] {
+  const out: string[] = [];
+  const walk = (rel: string): void => {
+    const abs = path.join(root, rel);
+    for (const entry of fs.readdirSync(abs, { withFileTypes: true })) {
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) walk(childRel);
+      else if (entry.name.endsWith('.md')) out.push(childRel);
+    }
+  };
+  try {
+    walk('');
+  } catch {
+    return [];
+  }
+  return out.sort();
+}
+
+const EXCLUDED_SET = new Set(KB_EXCLUDED.map((e) => e.relPath));
+
+function loadReference(): ReferenceDoc[] {
+  const root = referenceDocsDir();
+  const out: ReferenceDoc[] = [];
+  for (const relPath of listDocsTree(root)) {
+    // The curated learn docs are class 3, loaded separately; the generated
+    // README command table is a projection of the registry (class 1).
+    if (relPath.startsWith('learn/') || relPath === 'README.md') continue;
+    if (EXCLUDED_SET.has(relPath)) continue;
+    let markdown: string;
+    try {
+      markdown = fs.readFileSync(path.join(root, relPath), 'utf-8');
+    } catch {
+      continue;
+    }
+    out.push({
+      relPath,
+      group: referenceGroup(relPath),
+      title: titleOf(markdown, relPath),
+      markdown,
+      grounded: isGrounded(relPath),
+    });
+  }
+  return out;
+}
+
+/** The agent skills dxkit installs, enumerated from the packaged templates —
+ *  a registry read, never a hand-maintained list. */
+function loadSkills(): LearnSkill[] {
+  const dir = path.join(templatesDir(), '.claude', 'skills');
+  const out: LearnSkill[] = [];
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir).sort();
+  } catch {
+    return [];
+  }
+  for (const name of entries) {
+    const skillMd = path.join(dir, name, 'SKILL.md');
+    let description = '';
+    try {
+      const raw = fs.readFileSync(skillMd, 'utf-8');
+      const m = raw.match(/^description:\s*(.+)$/m);
+      description = m ? m[1].trim().replace(/^["']|["']$/g, '') : '';
+    } catch {
+      continue;
+    }
+    out.push({ name, description });
+  }
+  return out;
 }
 
 export function buildLearnBundle(): LearnBundle {
@@ -131,5 +282,35 @@ export function buildLearnBundle(): LearnBundle {
     capabilities: caps,
     knobs: POSTURE_KNOBS.map((k) => ({ path: k.path, command: k.command, note: k.note })),
     docs: loadDocs(),
+    reference: loadReference(),
+    skills: loadSkills(),
+    tasks: REMEDIATE_TASKS.map((t) => ({ id: t.id, summary: t.summary, tier: String(t.tier) })),
   };
 }
+
+/**
+ * The KB coverage checker — PURE so the drift net can synthetic-inject
+ * (mirror of the registry playbooks): given the docs on disk and the bundle,
+ * report anything that is neither bundled nor declared-excluded, plus any
+ * declared exclusion that no longer exists.
+ */
+export function checkKbCoverage(
+  docsOnDisk: readonly string[],
+  bundledRelPaths: readonly string[],
+  curatedSlugs: readonly string[],
+  excluded: ReadonlyArray<{ relPath: string; reason: string }> = KB_EXCLUDED,
+): { uncovered: string[]; staleExclusions: string[]; reasonless: string[] } {
+  const bundled = new Set(bundledRelPaths);
+  const curated = new Set(curatedSlugs.map((s) => `learn/${s}.md`));
+  const excludedSet = new Set(excluded.map((e) => e.relPath));
+  const uncovered = docsOnDisk.filter(
+    (p) => p !== 'README.md' && !bundled.has(p) && !curated.has(p) && !excludedSet.has(p),
+  );
+  const onDisk = new Set(docsOnDisk);
+  const staleExclusions = excluded.map((e) => e.relPath).filter((p) => !onDisk.has(p));
+  const reasonless = excluded.filter((e) => e.reason.trim().length < 10).map((e) => e.relPath);
+  return { uncovered, staleExclusions, reasonless };
+}
+
+/** The curated slugs, exported for the coverage test. */
+export const CURATED_DOC_SLUGS: readonly string[] = DOC_SLUGS;

--- a/src/learn/bundle.ts
+++ b/src/learn/bundle.ts
@@ -75,6 +75,20 @@ export interface LearnTask {
   id: string;
   summary: string;
   tier: string;
+  tierWhy: string;
+  /** Which verification the outcome hinges on (floor vs guardrail). */
+  verify: string;
+  /** Human line for the score hinge, when the task declares one. */
+  hinge?: string;
+}
+
+export interface LearnPolicyField {
+  /** Dotted path, e.g. `remediate.maxDispatchBudget`. */
+  path: string;
+  type: string;
+  description: string;
+  default?: string;
+  enum?: string[];
 }
 
 export interface LearnBundle {
@@ -87,6 +101,10 @@ export interface LearnBundle {
   reference: ReferenceDoc[];
   skills: LearnSkill[];
   tasks: LearnTask[];
+  /** EVERY policy field, flattened from the generated policy.schema.json —
+   *  the same schema the policy file validates against, so this reference
+   *  cannot drift from what the product accepts. */
+  policyFields: LearnPolicyField[];
 }
 
 /** Display order of the curated docs on the page. */
@@ -96,6 +114,7 @@ const DOC_SLUGS = [
   'quickstart-developer',
   'quickstart-reviewer',
   'quickstart-admin',
+  'operating-the-lanes',
   'extending-dxkit',
 ] as const;
 
@@ -138,6 +157,53 @@ export function learnDocsDir(): string {
   const packaged = path.join(__dirname, 'docs');
   if (fs.existsSync(packaged)) return packaged;
   return path.join(__dirname, '..', '..', 'docs', 'learn');
+}
+
+/** The generated policy schema shipped at the package root. */
+function policySchemaPath(): string {
+  return path.join(__dirname, '..', '..', 'policy.schema.json');
+}
+
+interface SchemaNode {
+  type?: string | string[];
+  description?: string;
+  default?: unknown;
+  enum?: unknown[];
+  properties?: Record<string, SchemaNode>;
+  items?: SchemaNode;
+  additionalProperties?: SchemaNode | boolean;
+}
+
+function flattenSchema(node: SchemaNode, prefix: string, out: LearnPolicyField[]): void {
+  for (const [key, child] of Object.entries(node.properties ?? {})) {
+    const p = prefix ? `${prefix}.${key}` : key;
+    const type = Array.isArray(child.type) ? child.type.join('|') : (child.type ?? 'object');
+    out.push({
+      path: p,
+      type,
+      description: child.description ?? '',
+      default: child.default === undefined ? undefined : JSON.stringify(child.default),
+      enum: Array.isArray(child.enum) ? child.enum.map((e) => String(e)) : undefined,
+    });
+    if (child.properties) flattenSchema(child, p, out);
+    if (child.items?.properties) flattenSchema(child.items, `${p}[]`, out);
+    if (typeof child.additionalProperties === 'object' && child.additionalProperties.properties) {
+      flattenSchema(child.additionalProperties, `${p}.<name>`, out);
+    }
+  }
+}
+
+function loadPolicyFields(): LearnPolicyField[] {
+  try {
+    // policy-text-ok: this is policy.schema.json (the generated JSON-Schema
+    // artifact, strict JSON by construction), not a user's JSONC policy file.
+    const schema = JSON.parse(fs.readFileSync(policySchemaPath(), 'utf-8')) as SchemaNode; // policy-text-ok
+    const out: LearnPolicyField[] = [];
+    flattenSchema(schema, '', out);
+    return out;
+  } catch {
+    return [];
+  }
 }
 
 /** The packaged reference shelf (`dist/learn/docs-ref`), or the repo docs/. */
@@ -284,7 +350,17 @@ export function buildLearnBundle(): LearnBundle {
     docs: loadDocs(),
     reference: loadReference(),
     skills: loadSkills(),
-    tasks: REMEDIATE_TASKS.map((t) => ({ id: t.id, summary: t.summary, tier: String(t.tier) })),
+    tasks: REMEDIATE_TASKS.map((t) => ({
+      id: t.id,
+      summary: t.summary,
+      tier: String(t.tier),
+      tierWhy: t.tierWhy,
+      verify: t.verify,
+      hinge: t.scoreHinge
+        ? `must raise the ${t.scoreHinge.improve} score above the pristine-tree entry score (holding ${t.scoreHinge.holdSteady.join(', ') || 'nothing else'} steady) or nothing lands`
+        : undefined,
+    })),
+    policyFields: loadPolicyFields(),
   };
 }
 

--- a/src/learn/drivers.ts
+++ b/src/learn/drivers.ts
@@ -63,6 +63,101 @@ export const LLM_DRIVERS: readonly LlmDriver[] = [
   },
 ] as const;
 
+export interface ProviderModel {
+  id: string;
+  /** Epoch seconds when the provider created the model, when reported. */
+  created?: number;
+}
+
+export interface ListModelsResult {
+  ok: boolean;
+  models?: ProviderModel[];
+  error?: string;
+}
+
+/**
+ * Fetch the LIVE model list from the provider with the user's own key — the
+ * fix for hardcoded suggestion lists going stale (they are training-data
+ * snapshots; the provider is the source of truth). Fail-open: any error
+ * returns { ok: false } and the caller falls back to the driver's
+ * suggestions, LABELED as possibly outdated.
+ */
+export async function listModels(
+  req: { driver: LlmDriver; apiKey: string; baseUrl?: string; timeoutMs?: number },
+  fetchFn: typeof fetch = fetch,
+): Promise<ListModelsResult> {
+  const timeout = req.timeoutMs ?? 15_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    if (req.driver.wire === 'anthropic') {
+      const res = await fetchFn(`${req.driver.endpoint}/v1/models?limit=100`, {
+        signal: controller.signal,
+        headers: { 'x-api-key': req.apiKey, 'anthropic-version': '2023-06-01' },
+      });
+      if (!res.ok) return { ok: false, error: `provider returned HTTP ${res.status}` };
+      const data = (await res.json()) as {
+        data?: Array<{ id?: string; created_at?: string }>;
+      };
+      const models = (data.data ?? [])
+        .filter((m) => typeof m.id === 'string')
+        .map((m) => ({
+          id: m.id as string,
+          created: m.created_at ? Math.floor(Date.parse(m.created_at) / 1000) : undefined,
+        }));
+      return models.length > 0 ? { ok: true, models } : { ok: false, error: 'empty model list' };
+    }
+    const base = req.driver.endpoint ?? req.baseUrl;
+    if (!base) return { ok: false, error: 'custom driver requires a base URL' };
+    const res = await fetchFn(`${base.replace(/\/$/, '')}/models`, {
+      signal: controller.signal,
+      headers: { authorization: `Bearer ${req.apiKey}` },
+    });
+    if (!res.ok) return { ok: false, error: `provider returned HTTP ${res.status}` };
+    const data = (await res.json()) as { data?: Array<{ id?: string; created?: number }> };
+    const models = (data.data ?? [])
+      .filter((m) => typeof m.id === 'string')
+      .map((m) => ({ id: m.id as string, created: m.created }));
+    return models.length > 0 ? { ok: true, models } : { ok: false, error: 'empty model list' };
+  } catch (err) {
+    return {
+      ok: false,
+      error: controller.signal.aborted ? 'model list timed out' : String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolve the Auto tiers against a LIVE model list: deep = the newest
+ * flagship-shaped id, fast = the newest small-tier id — falling back to the
+ * driver's compiled-in tiers when the pattern finds nothing. Deterministic
+ * given the same list (sorted by created desc, then id desc).
+ */
+export function resolveRouting(
+  driver: LlmDriver,
+  models: readonly ProviderModel[] | undefined,
+): { fast: string; deep: string } | undefined {
+  if (!driver.routing) return undefined;
+  if (!models || models.length === 0) return driver.routing;
+  const sorted = [...models].sort(
+    (a, b) => (b.created ?? 0) - (a.created ?? 0) || b.id.localeCompare(a.id),
+  );
+  const ids = sorted.map((m) => m.id);
+  let deep: string | undefined;
+  let fast: string | undefined;
+  if (driver.wire === 'anthropic') {
+    deep = ids.find((id) => /^claude-opus-/.test(id));
+    fast = ids.find((id) => /^claude-haiku-/.test(id));
+  } else {
+    // Flagship: gpt-N[.M] with no size/date suffix; small tier: -mini/-nano.
+    deep = ids.find((id) => /^gpt-\d+(\.\d+)?$/.test(id));
+    fast = ids.find((id) => /^gpt-\d+(\.\d+)?-(mini|nano)$/.test(id));
+  }
+  return { fast: fast ?? driver.routing.fast, deep: deep ?? driver.routing.deep };
+}
+
 /** The sentinel the page sends when the model choice is "Auto". */
 export const AUTO_MODEL = 'auto';
 
@@ -83,9 +178,10 @@ export interface RouteDecision {
 export function routeModel(
   driver: LlmDriver,
   question: string,
-  opts: { detail?: boolean; historyLength?: number } = {},
+  opts: { detail?: boolean; historyLength?: number; routing?: { fast: string; deep: string } } = {},
 ): RouteDecision {
-  if (!driver.routing) {
+  const routing = opts.routing ?? driver.routing;
+  if (!routing) {
     return {
       model: driver.defaultModel,
       tier: 'deep',
@@ -106,9 +202,9 @@ export function routeModel(
   }
   if ((opts.historyLength ?? 0) >= 6) deepReasons.push('deep follow-up chain');
   if (deepReasons.length > 0) {
-    return { model: driver.routing.deep, tier: 'deep', reason: deepReasons[0] };
+    return { model: routing.deep, tier: 'deep', reason: deepReasons[0] };
   }
-  return { model: driver.routing.fast, tier: 'fast', reason: 'quick lookup' };
+  return { model: routing.fast, tier: 'fast', reason: 'quick lookup' };
 }
 
 export function getDriver(id: string): LlmDriver | undefined {

--- a/src/learn/drivers.ts
+++ b/src/learn/drivers.ts
@@ -23,6 +23,12 @@ export interface LlmDriver {
   /** Suggestions only — the page always offers a free-text model field. */
   readonly suggestedModels: readonly string[];
   readonly defaultModel: string;
+  /**
+   * Auto-routing tiers (the "Auto" model choice): quick lookups go to `fast`,
+   * reasoning-shaped questions to `deep`. Routing never crosses providers
+   * (keys differ); a driver without tiers always serves its default model.
+   */
+  readonly routing?: { readonly fast: string; readonly deep: string };
 }
 
 export const LLM_DRIVERS: readonly LlmDriver[] = [
@@ -34,6 +40,7 @@ export const LLM_DRIVERS: readonly LlmDriver[] = [
     wire: 'anthropic',
     suggestedModels: ['claude-opus-5', 'claude-sonnet-5', 'claude-haiku-4-5'],
     defaultModel: 'claude-opus-5',
+    routing: { fast: 'claude-haiku-4-5', deep: 'claude-opus-5' },
   },
   {
     id: 'openai',
@@ -41,8 +48,9 @@ export const LLM_DRIVERS: readonly LlmDriver[] = [
     keyEnv: 'OPENAI_API_KEY',
     endpoint: 'https://api.openai.com/v1',
     wire: 'openai-chat',
-    suggestedModels: ['gpt-5.1', 'gpt-5-mini'],
+    suggestedModels: ['gpt-5.1', 'gpt-5-mini', 'gpt-5-nano'],
     defaultModel: 'gpt-5.1',
+    routing: { fast: 'gpt-5-mini', deep: 'gpt-5.1' },
   },
   {
     id: 'custom',
@@ -54,6 +62,54 @@ export const LLM_DRIVERS: readonly LlmDriver[] = [
     defaultModel: '',
   },
 ] as const;
+
+/** The sentinel the page sends when the model choice is "Auto". */
+export const AUTO_MODEL = 'auto';
+
+export interface RouteDecision {
+  model: string;
+  tier: 'fast' | 'deep';
+  /** One human-readable clause, DISCLOSED under the answer — the routing is
+   *  deterministic and the user always sees which model served and why. */
+  reason: string;
+}
+
+/**
+ * Deterministic per-question routing for the "Auto" model choice. Pure and
+ * pinned by test: reasoning-shaped questions (why/how/design/debug...), long
+ * or multi-part questions, deep follow-up chains, and detail-grounded asks go
+ * to the deep tier; short lookups go to the fast tier.
+ */
+export function routeModel(
+  driver: LlmDriver,
+  question: string,
+  opts: { detail?: boolean; historyLength?: number } = {},
+): RouteDecision {
+  if (!driver.routing) {
+    return {
+      model: driver.defaultModel,
+      tier: 'deep',
+      reason: 'single-model provider (no routing tiers)',
+    };
+  }
+  const q = question.trim();
+  const deepReasons: string[] = [];
+  if (opts.detail) deepReasons.push('finding-level grounding is on');
+  if (q.length > 240) deepReasons.push('long question');
+  if ((q.match(/\?/g) ?? []).length >= 2) deepReasons.push('multi-part question');
+  if (
+    /\b(why|how (do|should|can|would)|explain|design|architect|compare|trade-?offs?|debug|root cause|investigate|plan|migrate|strategy|convince|justify)\b/i.test(
+      q,
+    )
+  ) {
+    deepReasons.push('reasoning-shaped question');
+  }
+  if ((opts.historyLength ?? 0) >= 6) deepReasons.push('deep follow-up chain');
+  if (deepReasons.length > 0) {
+    return { model: driver.routing.deep, tier: 'deep', reason: deepReasons[0] };
+  }
+  return { model: driver.routing.fast, tier: 'fast', reason: 'quick lookup' };
+}
 
 export function getDriver(id: string): LlmDriver | undefined {
   return LLM_DRIVERS.find((d) => d.id === id);

--- a/src/learn/grounding.ts
+++ b/src/learn/grounding.ts
@@ -29,7 +29,8 @@ const ASSISTANT_CHARTER = `You are the dxkit learn assistant, running locally ne
 Answer ONLY from the grounding below — the registry digest, the docs, and (when present) this repo's status.
 When the answer is an action, produce the EXACT command to run, or the sentence to tell a coding agent.
 You execute nothing and cannot change anything; the one configuration write path is 'vyuh-dxkit configure --apply', which you may quote but the user runs.
-If the grounding does not answer a question, say so plainly and point to 'vyuh-dxkit doctor' or the docs; never invent capabilities or flags.`;
+Your knowledge is version-locked: you know exactly the capabilities of the dxkit version named below (the one installed here), generated from its own registries — never speculate about newer or older versions.
+If the grounding does not answer a question, say so plainly, suggest 'vyuh-dxkit doctor' or the reference shelf, and point the user to the public repository (github.com/vyuh-labs/dxkit) or 'vyuh-dxkit issue' to report the documentation gap; never invent capabilities or flags.`;
 
 export function assembleGrounding(
   bundle: LearnBundle,
@@ -50,8 +51,17 @@ export function assembleGrounding(
   );
   parts.push(`## Capability registry (dxkit v${bundle.version})\n${capLines.join('\n')}`);
   parts.push(`## Policy knobs\n${knobLines.join('\n')}`);
+  if (bundle.policyFields.length > 0) {
+    const fieldLines = bundle.policyFields.map(
+      (f) =>
+        `- ${f.path} (${f.type}${f.default !== undefined ? `, default ${f.default}` : ''}${f.enum ? `, one of: ${f.enum.join('|')}` : ''}): ${f.description || '(no description)'}`,
+    );
+    parts.push(
+      `## Policy field reference (every field .dxkit/policy.json accepts)\n${fieldLines.join('\n')}`,
+    );
+  }
   disclosure.push(
-    `The capability registry: every command name + description, and policy knob names (product facts, no repo data).`,
+    `The capability registry: every command name + description, policy knob names, and the full policy field reference (product facts, no repo data).`,
   );
 
   // 2. The curated docs + the grounded slice of the reference shelf — all
@@ -71,7 +81,14 @@ export function assembleGrounding(
   }
   if (bundle.tasks.length > 0) {
     parts.push(
-      `## Remediation lane tasks\n${bundle.tasks.map((t) => `- ${t.id} (${t.tier} tier): ${t.summary}`).join('\n')}`,
+      `## Remediation lane tasks\n${bundle.tasks
+        .map(
+          (t) =>
+            `- ${t.id} (${t.tier} tier — ${t.tierWhy}): ${t.summary} Verified by the ${t.verify}${t.hinge ? `; score hinge: ${t.hinge}` : ''}.`,
+        )
+        .join(
+          '\n',
+        )}\nTasks run on the scheduled lane, or as one-off dispatch campaigns from the Actions UI (workflow_dispatch inputs: task, custom prompt, spend/turn/minute overrides — clamped by remediate.maxDispatchBudget). Everything lands only via a PR through the gate.`,
     );
   }
   disclosure.push(
@@ -116,6 +133,9 @@ export function assembleGrounding(
         }
       }
     }
+    if (detail && status.rawPolicyText) {
+      s.push(`full committed policy.json:\n${status.rawPolicyText}`);
+    }
     if (detail && status.lastVerdict?.blockingFindings?.length) {
       for (const f of status.lastVerdict.blockingFindings) {
         s.push(`  blocking finding: kind=${f.kind}, fingerprint=${f.fingerprint}`);
@@ -124,7 +144,7 @@ export function assembleGrounding(
     parts.push(`## This repo (live status)\n${s.join('\n')}`);
     disclosure.push(
       detail
-        ? `This repo's status IN DETAIL: policy summary, baseline counts, the last verdict, each failing doctor check with its remedy, and blocking-finding fingerprints. (Detail toggle is ON.)`
+        ? `This repo's status IN DETAIL: the full committed policy.json, baseline counts, the last verdict, each failing doctor check with its remedy, and blocking-finding fingerprints. (Detail toggle is ON.)`
         : `This repo's status as SUMMARIES ONLY: policy summary, baseline entry counts, the last verdict word, and doctor pass/fail counts. No file paths, no finding contents, no check labels. (Turn on the detail toggle to include failing checks + remedies.)`,
     );
   } else {

--- a/src/learn/grounding.ts
+++ b/src/learn/grounding.ts
@@ -54,11 +54,29 @@ export function assembleGrounding(
     `The capability registry: every command name + description, and policy knob names (product facts, no repo data).`,
   );
 
-  // 2. The curated docs — also product facts.
+  // 2. The curated docs + the grounded slice of the reference shelf — all
+  // product facts shipped with the package (never repo data). The command
+  // pages and deep benchmark chapters stay page/search-only for size; the
+  // registry digest above covers every command.
   for (const d of bundle.docs) {
     parts.push(`## Doc: ${d.title}\n${d.markdown}`);
   }
-  disclosure.push(`The built-in docs (mental model, quickstarts, capabilities-and-limits).`);
+  for (const r of bundle.reference.filter((x) => x.grounded)) {
+    parts.push(`## Reference: ${r.title} (docs/${r.relPath})\n${r.markdown}`);
+  }
+  if (bundle.skills.length > 0) {
+    parts.push(
+      `## Agent skills dxkit installs\n${bundle.skills.map((s) => `- ${s.name}: ${s.description}`).join('\n')}`,
+    );
+  }
+  if (bundle.tasks.length > 0) {
+    parts.push(
+      `## Remediation lane tasks\n${bundle.tasks.map((t) => `- ${t.id} (${t.tier} tier): ${t.summary}`).join('\n')}`,
+    );
+  }
+  disclosure.push(
+    `The built-in docs: mental model, quickstarts, capabilities-and-limits, extending dxkit, the configuration reference, getting started, benchmarks overview, plus the installed agent-skill and remediation-task catalogs.`,
+  );
 
   // 3. Repo status — ONLY in repo mode, summaries by default.
   if (status) {

--- a/src/learn/markdown.ts
+++ b/src/learn/markdown.ts
@@ -112,6 +112,36 @@ export function markdownToHtml(md: string): string {
       continue;
     }
 
+    // Pipe tables (GitHub style): a header row, a separator row, body rows.
+    // The reference docs (benchmarks, extension SDK) use them heavily.
+    if (
+      /^\|.*\|\s*$/.test(line) &&
+      i + 1 < lines.length &&
+      /^\|[\s:|-]+\|\s*$/.test(lines[i + 1])
+    ) {
+      flushPara();
+      const splitRow = (l: string): string[] =>
+        l
+          .trim()
+          .replace(/^\|/, '')
+          .replace(/\|$/, '')
+          .split('|')
+          .map((c) => c.trim());
+      const header = splitRow(line);
+      i += 2; // skip header + separator
+      const rows: string[][] = [];
+      while (i < lines.length && /^\|.*\|\s*$/.test(lines[i])) {
+        rows.push(splitRow(lines[i]));
+        i++;
+      }
+      const th = header.map((h) => `<th>${renderInline(escapeHtml(h))}</th>`).join('');
+      const trs = rows
+        .map((r) => `<tr>${r.map((c) => `<td>${renderInline(escapeHtml(c))}</td>`).join('')}</tr>`)
+        .join('');
+      out.push(`<table><thead><tr>${th}</tr></thead><tbody>${trs}</tbody></table>`);
+      continue;
+    }
+
     // Blockquote (flat).
     if (/^>\s?/.test(line)) {
       flushPara();

--- a/src/learn/page-css.ts
+++ b/src/learn/page-css.ts
@@ -138,6 +138,9 @@ pre:hover .copybtn, .fix:hover .copybtn { opacity:1; }
 .list-plain li { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:10px 14px; font-size:12.5px; }
 .list-plain li b { color:var(--text); font-weight:650; }
 .list-plain li .tier { float:right; font-size:10px; color:var(--muted); background:var(--raise); border-radius:12px; padding:1px 8px; }
+.task-why { font-size:11px; color:var(--muted); }
+.models-note { font-size:11px; color:var(--muted); }
+.models-note.live { color:var(--ok); }
 
 /* search palette */
 .palette-overlay { position:fixed; inset:0; z-index:60; background:rgba(0,0,0,.35); display:none;

--- a/src/learn/page-css.ts
+++ b/src/learn/page-css.ts
@@ -1,0 +1,207 @@
+/**
+ * The learn page's design system — every token and component style, inline
+ * (the page loads nothing external). Split from render.ts for module size;
+ * render.ts remains the one assembler.
+ */
+
+export const CSS = `
+:root {
+  --bg:#f7f7f8; --surface:#ffffff; --card:#ffffff; --raise:#f1f1f3;
+  --border:#e4e4e7; --border-strong:#d4d4d8;
+  --text:#18181b; --text-2:#3f3f46; --muted:#71717a;
+  --accent:#2563eb; --accent-soft:#eff4ff; --on-accent:#ffffff;
+  --ok:#16a34a; --warn:#d97706; --bad:#dc2626;
+  --shadow:0 1px 2px rgba(0,0,0,.05), 0 8px 24px rgba(0,0,0,.06);
+  --shadow-lg:0 12px 40px rgba(0,0,0,.18);
+  --radius:10px;
+}
+[data-theme="dark"] {
+  --bg:#0b0b0d; --surface:#131316; --card:#17171b; --raise:#1e1e23;
+  --border:#26262c; --border-strong:#34343c;
+  --text:#f4f4f5; --text-2:#d4d4d8; --muted:#9d9da8;
+  --accent:#4f83ff; --accent-soft:#182236; --on-accent:#ffffff;
+  --ok:#4ade80; --warn:#fbbf24; --bad:#f87171;
+  --shadow:0 1px 2px rgba(0,0,0,.4), 0 8px 24px rgba(0,0,0,.35);
+  --shadow-lg:0 12px 48px rgba(0,0,0,.6);
+}
+* { margin:0; padding:0; box-sizing:border-box; }
+html { scroll-behavior:smooth; scroll-padding-top:76px; }
+body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  background:var(--bg); color:var(--text-2); font-size:15px; line-height:1.65; }
+code, pre, kbd { font-family:ui-monospace,'SF Mono','Cascadia Code',Consolas,monospace; }
+
+/* topbar */
+.topbar { position:fixed; inset:0 0 auto 0; height:56px; z-index:40; display:flex; align-items:center;
+  gap:14px; padding:0 18px; background:color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter:blur(10px); border-bottom:1px solid var(--border); }
+.brand { display:flex; align-items:baseline; gap:8px; font-weight:700; color:var(--text); font-size:15.5px; white-space:nowrap; }
+.brand .v { font-weight:500; font-size:11.5px; color:var(--muted); }
+.brand .mode { font-size:10.5px; font-weight:600; letter-spacing:.4px; text-transform:uppercase;
+  color:var(--accent); background:var(--accent-soft); border-radius:20px; padding:2px 9px; }
+.searchbtn { flex:1; max-width:440px; display:flex; align-items:center; gap:8px; height:34px;
+  padding:0 12px; background:var(--raise); border:1px solid var(--border); border-radius:8px;
+  color:var(--muted); font-size:13px; cursor:pointer; }
+.searchbtn:hover { border-color:var(--border-strong); }
+.searchbtn kbd { margin-left:auto; font-size:10.5px; background:var(--surface); border:1px solid var(--border);
+  border-radius:4px; padding:1px 6px; color:var(--muted); }
+.topbar .spacer { flex:1; }
+.tbtn { display:flex; align-items:center; gap:7px; height:34px; padding:0 13px; border-radius:8px;
+  border:1px solid var(--border); background:var(--surface); color:var(--text-2); font-size:13px;
+  cursor:pointer; font-family:inherit; white-space:nowrap; }
+.tbtn:hover { background:var(--raise); }
+.tbtn.primary { background:var(--accent); border-color:var(--accent); color:var(--on-accent); font-weight:600; }
+.tbtn.primary:hover { filter:brightness(1.08); }
+
+/* layout */
+.layout { display:flex; padding-top:56px; min-height:100vh; }
+.sidebar { width:248px; flex-shrink:0; position:sticky; top:56px; height:calc(100vh - 56px);
+  overflow-y:auto; padding:18px 10px 40px 14px; border-right:1px solid var(--border); }
+.nav-label { font-size:10.5px; font-weight:600; text-transform:uppercase; letter-spacing:.8px;
+  color:var(--muted); padding:16px 10px 5px; }
+.sidebar a { display:block; color:var(--text-2); text-decoration:none; font-size:13px;
+  padding:5.5px 10px; border-radius:7px; border-left:2px solid transparent; }
+.sidebar a:hover { background:var(--raise); color:var(--text); }
+.sidebar a.active { color:var(--accent); background:var(--accent-soft); border-left-color:var(--accent); font-weight:500; }
+.main { flex:1; min-width:0; padding:30px 40px 100px; max-width:1020px; }
+
+/* sections */
+h2.section { font-size:21px; font-weight:700; color:var(--text); margin:44px 0 6px; letter-spacing:-.01em; }
+h2.section:first-child { margin-top:0; }
+.section-sub { color:var(--muted); font-size:13.5px; margin-bottom:18px; }
+.cards { display:grid; grid-template-columns:repeat(auto-fill,minmax(290px,1fr)); gap:14px; }
+.card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius);
+  padding:15px 17px; transition:border-color .12s ease; }
+.card:hover { border-color:var(--border-strong); }
+.card .cmd { font-size:14px; color:var(--accent); font-weight:650; font-family:ui-monospace,'SF Mono',Consolas,monospace; }
+.card .aliases { font-size:11px; color:var(--muted); margin-left:5px; }
+.card .runtime { float:right; font-size:10.5px; color:var(--muted); background:var(--raise);
+  padding:2px 9px; border-radius:20px; }
+.card p { font-size:13px; line-height:1.6; margin-top:8px; color:var(--text-2); }
+.card .knobs { margin-top:9px; font-size:11.5px; color:var(--muted); }
+.card .knobs code { color:var(--warn); background:var(--raise); padding:1px 5px; border-radius:4px; font-size:11px; }
+
+/* docs */
+.doc { background:var(--card); border:1px solid var(--border); border-radius:var(--radius);
+  padding:26px 30px; margin-bottom:20px; }
+.doc h1 { font-size:23px; font-weight:750; color:var(--text); margin-bottom:14px; letter-spacing:-.015em; }
+.doc h2 { font-size:17.5px; font-weight:700; color:var(--text); margin:26px 0 9px; }
+.doc h3 { font-size:15px; font-weight:650; color:var(--text); margin:18px 0 6px; }
+.doc h4 { font-size:13.5px; font-weight:650; color:var(--text); margin:14px 0 5px; }
+.doc p, .doc li { font-size:14px; line-height:1.7; }
+.doc p { margin-bottom:11px; }
+.doc ul, .doc ol { padding-left:24px; margin-bottom:13px; }
+.doc li { margin-bottom:3px; }
+.doc pre { position:relative; background:var(--raise); border:1px solid var(--border); border-radius:8px;
+  padding:13px 15px; font-size:12.5px; overflow-x:auto; margin:11px 0 15px; line-height:1.55; }
+.doc code { background:var(--raise); padding:1.5px 6px; border-radius:5px; font-size:12.5px; color:var(--text); }
+.doc pre code { background:none; padding:0; }
+.doc a { color:var(--accent); text-decoration:none; }
+.doc a:hover { text-decoration:underline; }
+.doc strong { color:var(--text); font-weight:650; }
+.doc blockquote { border-left:3px solid var(--accent); padding:2px 0 2px 14px; color:var(--muted); margin-bottom:11px; }
+
+/* copy button */
+.copybtn { position:absolute; top:7px; right:7px; border:1px solid var(--border); background:var(--surface);
+  color:var(--muted); font-size:10.5px; border-radius:6px; padding:3px 9px; cursor:pointer; opacity:0;
+  transition:opacity .12s ease; font-family:inherit; }
+pre:hover .copybtn, .fix:hover .copybtn { opacity:1; }
+.copybtn.done { color:var(--ok); border-color:var(--ok); opacity:1; }
+
+/* repo status */
+.pill-row { display:flex; flex-wrap:wrap; gap:8px; margin:10px 0 18px; }
+.pill { font-size:12px; background:var(--card); border:1px solid var(--border);
+  border-radius:20px; padding:4px 13px; color:var(--text-2); }
+.status-line { display:flex; gap:10px; align-items:baseline; padding:9px 13px; border-radius:8px; font-size:13.5px; }
+.status-line.fail { background:var(--card); border:1px solid var(--border); margin-bottom:9px; display:block; }
+.badge-ok { color:var(--ok); } .badge-fail { color:var(--bad); } .badge-warn { color:var(--warn); }
+.fix { position:relative; font-size:12.5px; color:var(--muted); margin:5px 0 3px 22px; line-height:1.55; }
+.fix code { background:var(--raise); border:1px solid var(--border); padding:2.5px 8px;
+  border-radius:6px; color:var(--accent); user-select:all; font-size:12px; }
+.note { font-size:13px; color:var(--muted); background:var(--card); border:1px solid var(--border);
+  border-radius:var(--radius); padding:12px 16px; margin:10px 0; line-height:1.65; }
+
+/* tables (docs + reference) */
+.doc table, .ref-doc table { border-collapse:collapse; margin:12px 0 16px; font-size:12.5px; width:100%; display:block; overflow-x:auto; }
+.doc th, .ref-doc th { text-align:left; font-weight:650; color:var(--text); border-bottom:2px solid var(--border-strong);
+  padding:7px 12px 7px 0; }
+.doc td, .ref-doc td { border-bottom:1px solid var(--border); padding:7px 12px 7px 0; vertical-align:top; }
+
+/* reference shelf */
+.ref-group { margin-bottom:10px; }
+.ref-group > summary { cursor:pointer; font-size:14.5px; font-weight:650; color:var(--text);
+  padding:11px 15px; background:var(--card); border:1px solid var(--border); border-radius:var(--radius); }
+.ref-group[open] > summary { border-radius:var(--radius) var(--radius) 0 0; }
+.ref-doc { border:1px solid var(--border); border-top:none; padding:4px 15px; }
+.ref-doc > summary { cursor:pointer; font-size:13px; color:var(--text-2); padding:8px 4px; }
+.ref-doc .doc { border:none; padding:8px 12px 16px; margin:0; }
+.list-plain { list-style:none; display:grid; grid-template-columns:repeat(auto-fill,minmax(290px,1fr)); gap:10px; }
+.list-plain li { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:10px 14px; font-size:12.5px; }
+.list-plain li b { color:var(--text); font-weight:650; }
+.list-plain li .tier { float:right; font-size:10px; color:var(--muted); background:var(--raise); border-radius:12px; padding:1px 8px; }
+
+/* search palette */
+.palette-overlay { position:fixed; inset:0; z-index:60; background:rgba(0,0,0,.35); display:none;
+  align-items:flex-start; justify-content:center; padding-top:12vh; }
+.palette-overlay.open { display:flex; }
+.palette { width:min(620px, 92vw); background:var(--surface); border:1px solid var(--border-strong);
+  border-radius:14px; box-shadow:var(--shadow-lg); overflow:hidden; }
+.palette input { width:100%; border:none; outline:none; background:transparent; color:var(--text);
+  font-size:15px; padding:16px 18px; border-bottom:1px solid var(--border); font-family:inherit; }
+.palette-results { max-height:46vh; overflow-y:auto; padding:6px; }
+.presult { display:block; width:100%; text-align:left; background:none; border:none; cursor:pointer;
+  border-radius:8px; padding:9px 12px; font-family:inherit; }
+.presult:hover, .presult.sel { background:var(--accent-soft); }
+.presult .rt { font-size:13.5px; color:var(--text); font-weight:550; }
+.presult .rk { font-size:10px; font-weight:650; text-transform:uppercase; letter-spacing:.5px;
+  color:var(--accent); margin-right:8px; }
+.presult .rs { font-size:12px; color:var(--muted); margin-top:1px; overflow:hidden; text-overflow:ellipsis;
+  white-space:nowrap; }
+.palette-empty { padding:18px; font-size:13px; color:var(--muted); text-align:center; }
+
+/* assistant panel */
+.assistant-fab { position:fixed; right:22px; bottom:22px; z-index:45; height:46px; padding:0 19px;
+  border-radius:24px; border:none; background:var(--accent); color:var(--on-accent); font-size:13.5px;
+  font-weight:650; cursor:pointer; box-shadow:var(--shadow-lg); display:flex; align-items:center; gap:8px;
+  font-family:inherit; }
+.assistant-panel { position:fixed; top:56px; right:0; bottom:0; width:min(430px, 100vw); z-index:50;
+  background:var(--surface); border-left:1px solid var(--border); display:flex; flex-direction:column;
+  transform:translateX(105%); transition:transform .22s ease; box-shadow:var(--shadow-lg); }
+.assistant-panel.open { transform:translateX(0); }
+.ap-head { display:flex; align-items:center; gap:10px; padding:13px 16px; border-bottom:1px solid var(--border); }
+.ap-head .t { font-weight:700; color:var(--text); font-size:14.5px; }
+.ap-head .sub { font-size:11px; color:var(--muted); }
+.ap-head .close { margin-left:auto; border:none; background:none; color:var(--muted); font-size:17px; cursor:pointer; }
+.ap-config { padding:11px 16px; border-bottom:1px solid var(--border); display:flex; flex-direction:column; gap:8px; }
+.ap-row { display:flex; gap:8px; align-items:center; flex-wrap:wrap; font-size:12px; color:var(--muted); }
+.ap-row label { display:flex; gap:6px; align-items:center; }
+.ap-row select, .ap-row input[type=text], .ap-row input[type=password] { background:var(--raise); color:var(--text);
+  border:1px solid var(--border); border-radius:7px; padding:5.5px 9px; font-size:12.5px; font-family:inherit; }
+.ap-row select { max-width:180px; }
+#key-env-note { font-size:11.5px; color:var(--ok); }
+.ap-disclosure summary { font-size:11.5px; color:var(--muted); cursor:pointer; }
+.ap-disclosure ul { padding:6px 0 0 18px; font-size:11.5px; color:var(--muted); }
+.ap-chat { flex:1; overflow-y:auto; padding:16px; display:flex; flex-direction:column; gap:12px; }
+.ap-empty { margin:auto; text-align:center; color:var(--muted); font-size:13px; max-width:280px; line-height:1.7; }
+.msg { max-width:92%; border-radius:12px; padding:10px 13px; font-size:13.5px; line-height:1.6; }
+.msg.user { background:var(--accent); color:var(--on-accent); align-self:flex-end; white-space:pre-wrap; }
+.msg.assistant { background:var(--card); border:1px solid var(--border); align-self:flex-start; color:var(--text-2); }
+.msg.assistant pre { background:var(--raise); border:1px solid var(--border); border-radius:7px; padding:9px 11px;
+  overflow-x:auto; font-size:11.5px; margin:8px 0; }
+.msg.assistant code { background:var(--raise); padding:1px 5px; border-radius:4px; font-size:12px; }
+.msg.assistant p { margin:0 0 8px; } .msg.assistant p:last-child { margin-bottom:0; }
+.msg.assistant ul, .msg.assistant ol { padding-left:19px; margin:4px 0 8px; }
+.msg.assistant h1, .msg.assistant h2, .msg.assistant h3 { font-size:13.5px; color:var(--text); margin:8px 0 4px; }
+.msg-meta { font-size:10.5px; color:var(--muted); align-self:flex-start; margin:-7px 0 0 4px; }
+.typing { display:inline-flex; gap:4px; padding:4px 2px; }
+.typing i { width:6px; height:6px; border-radius:50%; background:var(--muted); animation:tp 1s infinite; }
+.typing i:nth-child(2) { animation-delay:.15s; } .typing i:nth-child(3) { animation-delay:.3s; }
+@keyframes tp { 0%,60%,100% { opacity:.25; } 30% { opacity:1; } }
+.ap-input { display:flex; gap:9px; padding:13px 16px; border-top:1px solid var(--border); align-items:flex-end; }
+.ap-input textarea { flex:1; resize:none; background:var(--raise); color:var(--text); border:1px solid var(--border);
+  border-radius:10px; padding:9px 12px; font-size:13.5px; font-family:inherit; line-height:1.5; max-height:130px; }
+.ap-input button { height:38px; padding:0 17px; border:none; border-radius:9px; background:var(--accent);
+  color:var(--on-accent); font-weight:650; font-size:13px; cursor:pointer; font-family:inherit; }
+.ap-error { color:var(--bad); font-size:12px; padding:0 16px 10px; }
+
+@media (max-width: 900px) { .sidebar { display:none; } .main { padding:24px 18px 90px; } }
+`;

--- a/src/learn/page-css.ts
+++ b/src/learn/page-css.ts
@@ -203,5 +203,48 @@ pre:hover .copybtn, .fix:hover .copybtn { opacity:1; }
   color:var(--on-accent); font-weight:650; font-size:13px; cursor:pointer; font-family:inherit; }
 .ap-error { color:var(--bad); font-size:12px; padding:0 16px 10px; }
 
+/* SPA views (wiki mode): with JS, exactly one view is visible */
+body.spa .view { display:none; }
+body.spa .view.active { display:block; animation:viewin .14s ease; }
+@keyframes viewin { from { opacity:.4; transform:translateY(4px); } to { opacity:1; transform:none; } }
+
+/* hero */
+.hero { padding:34px 34px 30px; background:linear-gradient(135deg, var(--accent-soft), var(--card));
+  border:1px solid var(--border); border-radius:14px; margin-bottom:28px; }
+.hero h1 { font-size:27px; font-weight:750; color:var(--text); letter-spacing:-.02em; margin-bottom:10px; }
+.hero p { font-size:14.5px; max-width:640px; margin-bottom:18px; }
+.hero-actions { display:flex; gap:10px; flex-wrap:wrap; }
+.hero-actions .tbtn { text-decoration:none; height:38px; display:inline-flex; }
+
+/* breadcrumbs + prev/next */
+.crumbs { font-size:12px; color:var(--muted); margin-bottom:14px; min-height:16px; }
+.crumbs a { color:var(--muted); text-decoration:none; }
+.crumbs a:hover { color:var(--accent); }
+.crumbs .sep { margin:0 7px; opacity:.6; }
+.crumbs .here { color:var(--text); font-weight:550; }
+.pagenav { display:flex; justify-content:space-between; gap:12px; margin-top:44px; }
+.pagenav a { flex:1; max-width:46%; text-decoration:none; border:1px solid var(--border); background:var(--card);
+  border-radius:10px; padding:12px 16px; }
+.pagenav a:hover { border-color:var(--accent); }
+.pagenav .dir { font-size:10.5px; text-transform:uppercase; letter-spacing:.6px; color:var(--muted); }
+.pagenav .pt { font-size:13.5px; color:var(--accent); font-weight:550; margin-top:2px; }
+.pagenav a.next { text-align:right; margin-left:auto; }
+
+/* per-page TOC rail */
+.toc { width:200px; flex-shrink:0; position:sticky; top:56px; height:calc(100vh - 56px);
+  overflow-y:auto; padding:26px 16px 40px 6px; display:none; }
+.toc .toc-label { font-size:10.5px; font-weight:600; text-transform:uppercase; letter-spacing:.8px;
+  color:var(--muted); margin-bottom:8px; }
+.toc a { display:block; font-size:12px; color:var(--muted); text-decoration:none; padding:3.5px 0 3.5px 10px;
+  border-left:2px solid var(--border); }
+.toc a:hover { color:var(--accent); }
+.toc a.h3 { padding-left:22px; }
+@media (min-width: 1240px) { .toc { display:block; } }
+
+/* reference index */
+.ref-index-group { font-size:14px; font-weight:650; color:var(--text); margin:22px 0 10px; }
+.ref-card { display:block; text-decoration:none; }
+.ref-card:hover { border-color:var(--accent); }
+
 @media (max-width: 900px) { .sidebar { display:none; } .main { padding:24px 18px 90px; } }
 `;

--- a/src/learn/page-js.ts
+++ b/src/learn/page-js.ts
@@ -1,0 +1,280 @@
+/**
+ * The learn page's inline scripts, split from render.ts for module size.
+ * Both are plain-string constants embedded verbatim into the page:
+ *   - PAGE_JS runs in BOTH modes and performs ZERO network requests
+ *     (theme, Ctrl+K search over the embedded index, copy buttons, nav);
+ *   - ASSISTANT_JS is serve-mode only and talks ONLY to same-origin
+ *     /api/ paths. Pinned by test/learn/serve.test.ts.
+ */
+
+export /** Base page behavior: theme, search palette, copy buttons, active nav.
+ *  Runs in BOTH modes; performs zero network requests. Plain string concat
+ *  only (no template placeholders) so the embedded source stays literal. */
+const BASE_JS = `
+(function () {
+  'use strict';
+  function el(id) { return document.getElementById(id); }
+
+  /* theme */
+  var stored = null;
+  try { stored = localStorage.getItem('dxkit-theme'); } catch (e) {}
+  var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  function applyTheme(t) {
+    document.documentElement.setAttribute('data-theme', t);
+    var b = el('theme-toggle');
+    if (b) b.textContent = t === 'dark' ? '☀' : '☾';
+  }
+  applyTheme(stored || (prefersDark ? 'dark' : 'light'));
+  el('theme-toggle').addEventListener('click', function () {
+    var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    try { localStorage.setItem('dxkit-theme', next); } catch (e) {}
+    applyTheme(next);
+  });
+
+  /* copy buttons */
+  var targets = document.querySelectorAll('.doc pre, .fix');
+  targets.forEach(function (t) {
+    var codeText = t.classList.contains('fix')
+      ? (t.querySelector('code') ? t.querySelector('code').textContent : '')
+      : t.textContent;
+    if (!codeText || !codeText.trim()) return;
+    var b = document.createElement('button');
+    b.className = 'copybtn'; b.type = 'button'; b.textContent = 'copy';
+    b.addEventListener('click', function () {
+      var done = function () { b.textContent = 'copied'; b.classList.add('done');
+        setTimeout(function () { b.textContent = 'copy'; b.classList.remove('done'); }, 1400); };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(codeText.trim()).then(done, done);
+      } else { done(); }
+    });
+    t.appendChild(b);
+  });
+
+  /* active nav */
+  var links = Array.prototype.slice.call(document.querySelectorAll('.sidebar a[href^="#"]'));
+  var byId = {};
+  links.forEach(function (a) { byId[a.getAttribute('href').slice(1)] = a; });
+  var observed = Object.keys(byId).map(function (id) { return document.getElementById(id); }).filter(Boolean);
+  if ('IntersectionObserver' in window && observed.length) {
+    var active = null;
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (en.isIntersecting) {
+          if (active) active.classList.remove('active');
+          active = byId[en.target.id];
+          if (active) active.classList.add('active');
+        }
+      });
+    }, { rootMargin: '-20% 0px -70% 0px' });
+    observed.forEach(function (s) { io.observe(s); });
+  }
+
+  /* search palette */
+  var indexEl = el('search-index');
+  var INDEX = indexEl ? JSON.parse(indexEl.textContent) : [];
+  var overlay = el('palette-overlay'); var input = el('palette-input');
+  var results = el('palette-results'); var sel = 0; var shown = [];
+  function openPalette() { overlay.classList.add('open'); input.value = ''; render(''); input.focus(); }
+  function closePalette() { overlay.classList.remove('open'); }
+  function render(q) {
+    var ql = q.trim().toLowerCase(); sel = 0;
+    shown = !ql ? INDEX.slice(0, 10) : INDEX
+      .map(function (e) {
+        var t = e.t.toLowerCase(); var s = (e.s || '').toLowerCase();
+        var score = t === ql ? 0 : t.indexOf(ql) === 0 ? 1 : t.indexOf(ql) >= 0 ? 2 : s.indexOf(ql) >= 0 ? 3 : -1;
+        return { e: e, score: score };
+      })
+      .filter(function (r) { return r.score >= 0; })
+      .sort(function (a, b) { return a.score - b.score; })
+      .slice(0, 12)
+      .map(function (r) { return r.e; });
+    results.replaceChildren();
+    if (!shown.length) {
+      var d = document.createElement('div'); d.className = 'palette-empty';
+      d.textContent = 'No matches.'; results.appendChild(d); return;
+    }
+    shown.forEach(function (e, i) {
+      var b = document.createElement('button');
+      b.className = 'presult' + (i === sel ? ' sel' : ''); b.type = 'button';
+      var t = document.createElement('div'); t.className = 'rt';
+      var k = document.createElement('span'); k.className = 'rk'; k.textContent = e.k;
+      t.appendChild(k); t.appendChild(document.createTextNode(e.t));
+      var s = document.createElement('div'); s.className = 'rs'; s.textContent = e.s || '';
+      b.appendChild(t); b.appendChild(s);
+      b.addEventListener('click', function () { go(e); });
+      results.appendChild(b);
+    });
+  }
+  function go(e) {
+    closePalette();
+    /* open every ancestor <details> so anchors inside the reference shelf land visibly */
+    var target = document.getElementById(e.a.slice(1));
+    var p = target;
+    while (p) { if (p.tagName === 'DETAILS') p.open = true; p = p.parentElement; }
+    location.hash = e.a;
+    if (target) target.scrollIntoView({ block: 'start' });
+  }
+  el('searchbtn').addEventListener('click', openPalette);
+  overlay.addEventListener('click', function (ev) { if (ev.target === overlay) closePalette(); });
+  input.addEventListener('input', function () { render(input.value); });
+  input.addEventListener('keydown', function (ev) {
+    if (ev.key === 'ArrowDown' || ev.key === 'ArrowUp') {
+      ev.preventDefault();
+      sel = Math.max(0, Math.min(shown.length - 1, sel + (ev.key === 'ArrowDown' ? 1 : -1)));
+      Array.prototype.forEach.call(results.children, function (c, i) { c.classList.toggle('sel', i === sel); });
+    } else if (ev.key === 'Enter' && shown[sel]) { go(shown[sel]); }
+    else if (ev.key === 'Escape') { closePalette(); }
+  });
+  document.addEventListener('keydown', function (ev) {
+    if ((ev.ctrlKey || ev.metaKey) && ev.key.toLowerCase() === 'k') { ev.preventDefault(); openPalette(); }
+  });
+})();
+`;
+
+export /** Assistant behavior (serve mode only): same-origin localhost fetch only. */
+const ASSISTANT_JS = `
+(function () {
+  'use strict';
+  function el(id) { return document.getElementById(id); }
+  var state = { drivers: [], history: [] };
+  var CUSTOM_SENTINEL = '__custom__';
+
+  /* panel open/close */
+  function openPanel() { el('apanel').classList.add('open'); el('q').focus(); }
+  function closePanel() { el('apanel').classList.remove('open'); }
+  el('fab').addEventListener('click', openPanel);
+  el('assistant-open').addEventListener('click', openPanel);
+  el('ap-close').addEventListener('click', closePanel);
+  document.addEventListener('keydown', function (ev) {
+    if ((ev.ctrlKey || ev.metaKey) && ev.key === '/') { ev.preventDefault();
+      el('apanel').classList.contains('open') ? closePanel() : openPanel(); }
+  });
+
+  function refreshStatus() {
+    var detail = el('detail').checked ? '1' : '0';
+    return fetch('/api/status?detail=' + detail).then(function (r) { return r.json(); }).then(function (s) {
+      state.drivers = s.drivers;
+      if (s.repoMode) el('detail-row').hidden = false;
+      var drv = el('drv');
+      if (drv.options.length === 0) {
+        s.drivers.forEach(function (d) {
+          var o = document.createElement('option');
+          o.value = d.id; o.textContent = d.label + (d.envKeyPresent ? ' · key in env' : '');
+          drv.appendChild(o);
+        });
+      }
+      var ul = el('disclosure');
+      ul.replaceChildren();
+      s.disclosure.forEach(function (line) {
+        var li = document.createElement('li'); li.textContent = line; ul.appendChild(li);
+      });
+      syncDriver();
+    });
+  }
+  function currentDriver() {
+    var id = el('drv').value;
+    for (var i = 0; i < state.drivers.length; i++) if (state.drivers[i].id === id) return state.drivers[i];
+    return null;
+  }
+  function syncDriver() {
+    var d = currentDriver(); if (!d) return;
+    el('baseurl-row').hidden = !d.needsBaseUrl;
+    var ms = el('model-select');
+    ms.replaceChildren();
+    if (d.routing) {
+      var auto = document.createElement('option');
+      auto.value = 'auto';
+      auto.textContent = 'Auto — ' + d.routing.fast + ' ↔ ' + d.routing.deep;
+      ms.appendChild(auto);
+    }
+    d.suggestedModels.forEach(function (m) {
+      var o = document.createElement('option'); o.value = m; o.textContent = m; ms.appendChild(o);
+    });
+    var custom = document.createElement('option');
+    custom.value = CUSTOM_SENTINEL; custom.textContent = 'Other model…';
+    ms.appendChild(custom);
+    ms.value = d.routing ? 'auto' : (d.suggestedModels[0] || CUSTOM_SENTINEL);
+    el('model-custom').hidden = ms.value !== CUSTOM_SENTINEL;
+    el('key-env-note').hidden = !d.envKeyPresent;
+    el('key-input-label').hidden = d.envKeyPresent;
+    el('key-env-name').textContent = d.keyEnv;
+  }
+  function chosenModel() {
+    var v = el('model-select').value;
+    if (v === CUSTOM_SENTINEL) return el('model-custom').value.trim();
+    return v;
+  }
+
+  function addMsg(role, node) {
+    var empty = el('chat-empty'); if (empty) empty.remove();
+    var div = document.createElement('div');
+    div.className = 'msg ' + role;
+    if (typeof node === 'string') div.textContent = node; else div.appendChild(node);
+    el('chat').appendChild(div);
+    div.scrollIntoView({ block: 'end' });
+    return div;
+  }
+  function addMeta(text) {
+    var m = document.createElement('div'); m.className = 'msg-meta'; m.textContent = text;
+    el('chat').appendChild(m);
+  }
+  function typingNode() {
+    var t = document.createElement('span'); t.className = 'typing';
+    for (var i = 0; i < 3; i++) t.appendChild(document.createElement('i'));
+    return t;
+  }
+
+  function ask() {
+    var q = el('q').value.trim(); if (!q) return;
+    el('ask-error').textContent = ''; el('q').value = ''; autoGrow();
+    addMsg('user', q);
+    var pending = addMsg('assistant', typingNode());
+    fetch('/api/ask', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        driverId: el('drv').value,
+        model: chosenModel(),
+        baseUrl: el('baseurl').value.trim(),
+        browserKey: el('key').value,
+        detail: el('detail').checked,
+        question: q,
+        history: state.history
+      })
+    }).then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+      .then(function (res) {
+        if (!res.ok) {
+          pending.remove();
+          el('ask-error').textContent = res.body.error || 'request failed';
+          return;
+        }
+        pending.replaceChildren();
+        /* answerHtml is rendered server-side by dxkit's pinned markdown
+           renderer, which escapes all input — safe to inject. */
+        pending.innerHTML = res.body.answerHtml || '';
+        if (!res.body.answerHtml) pending.textContent = res.body.answer;
+        var meta = 'served by ' + res.body.servedModel +
+          (res.body.routed ? ' · auto-routed: ' + res.body.routeReason : '') +
+          ' · key: ' + res.body.keySource;
+        addMeta(meta);
+        state.history.push({ role: 'user', content: q });
+        state.history.push({ role: 'assistant', content: res.body.answer });
+      })
+      .catch(function (e) { pending.remove(); el('ask-error').textContent = String(e); });
+  }
+  function autoGrow() {
+    var t = el('q'); t.style.height = 'auto'; t.style.height = Math.min(t.scrollHeight, 130) + 'px';
+  }
+  el('ask').addEventListener('click', ask);
+  el('q').addEventListener('keydown', function (ev) {
+    if (ev.key === 'Enter' && !ev.shiftKey) { ev.preventDefault(); ask(); }
+  });
+  el('q').addEventListener('input', autoGrow);
+  el('model-select').addEventListener('change', function () {
+    el('model-custom').hidden = el('model-select').value !== CUSTOM_SENTINEL;
+  });
+  el('drv').addEventListener('change', syncDriver);
+  el('detail').addEventListener('change', refreshStatus);
+  refreshStatus();
+})();
+`;

--- a/src/learn/page-js.ts
+++ b/src/learn/page-js.ts
@@ -50,24 +50,90 @@ const BASE_JS = `
     t.appendChild(b);
   });
 
-  /* active nav */
+  /* ── wiki router: one view at a time, driven by location.hash ── */
+  var views = Array.prototype.slice.call(document.querySelectorAll('.view'));
   var links = Array.prototype.slice.call(document.querySelectorAll('.sidebar a[href^="#"]'));
-  var byId = {};
-  links.forEach(function (a) { byId[a.getAttribute('href').slice(1)] = a; });
-  var observed = Object.keys(byId).map(function (id) { return document.getElementById(id); }).filter(Boolean);
-  if ('IntersectionObserver' in window && observed.length) {
-    var active = null;
-    var io = new IntersectionObserver(function (entries) {
-      entries.forEach(function (en) {
-        if (en.isIntersecting) {
-          if (active) active.classList.remove('active');
-          active = byId[en.target.id];
-          if (active) active.classList.add('active');
-        }
-      });
-    }, { rootMargin: '-20% 0px -70% 0px' });
-    observed.forEach(function (s) { io.observe(s); });
+  document.body.classList.add('spa');
+  function viewFor(id) {
+    var target = document.getElementById(id);
+    if (!target) return null;
+    return target.classList.contains('view') ? target : (target.closest ? target.closest('.view') : null);
   }
+  function buildToc(v) {
+    var toc = el('toc'); if (!toc) return;
+    toc.replaceChildren();
+    var heads = v.querySelectorAll('h2[id], h3[id], h2.section');
+    if (heads.length < 2) return;
+    var label = document.createElement('div'); label.className = 'toc-label'; label.textContent = 'On this page';
+    toc.appendChild(label);
+    Array.prototype.forEach.call(heads, function (h, idx) {
+      if (!h.id) h.id = 'sec-' + v.id + '-' + idx;
+      var a = document.createElement('a');
+      a.href = '#' + h.id;
+      a.textContent = h.textContent;
+      if (h.tagName === 'H3') a.className = 'h3';
+      toc.appendChild(a);
+    });
+  }
+  function buildCrumbs(v) {
+    var c = el('crumbs'); if (!c) return;
+    c.replaceChildren();
+    var home = document.createElement('a'); home.href = '#core'; home.textContent = 'dxkit learn';
+    c.appendChild(home);
+    var crumb = v.getAttribute('data-crumb');
+    if (crumb === 'Reference') {
+      var sep0 = document.createElement('span'); sep0.className = 'sep'; sep0.textContent = '/';
+      var refA = document.createElement('a'); refA.href = '#reference'; refA.textContent = 'Reference';
+      c.appendChild(sep0); c.appendChild(refA);
+    } else if (crumb) {
+      var sep1 = document.createElement('span'); sep1.className = 'sep'; sep1.textContent = '/';
+      var g = document.createElement('span'); g.textContent = crumb;
+      c.appendChild(sep1); c.appendChild(g);
+    }
+    var sep2 = document.createElement('span'); sep2.className = 'sep'; sep2.textContent = '/';
+    var here = document.createElement('span'); here.className = 'here';
+    here.textContent = v.getAttribute('data-title') || v.id;
+    c.appendChild(sep2); c.appendChild(here);
+  }
+  function buildPagenav(v) {
+    var pn = el('pagenav'); if (!pn) return;
+    pn.replaceChildren();
+    var i = views.indexOf(v);
+    function mk(dirText, cls, target) {
+      var a = document.createElement('a'); a.className = cls; a.href = '#' + target.id;
+      var d = document.createElement('div'); d.className = 'dir'; d.textContent = dirText;
+      var t = document.createElement('div'); t.className = 'pt';
+      t.textContent = target.getAttribute('data-title') || target.id;
+      a.appendChild(d); a.appendChild(t); return a;
+    }
+    if (i > 0) pn.appendChild(mk('Previous', 'prev', views[i - 1]));
+    if (i >= 0 && i < views.length - 1) pn.appendChild(mk('Next', 'next', views[i + 1]));
+  }
+  var activeView = null;
+  function showView(v, scrollTargetId) {
+    if (!v) v = views[0];
+    if (activeView) activeView.classList.remove('active');
+    activeView = v;
+    v.classList.add('active');
+    links.forEach(function (a) {
+      var lv = viewFor(a.getAttribute('href').slice(1));
+      a.classList.toggle('active', lv === v);
+    });
+    buildToc(v); buildCrumbs(v); buildPagenav(v);
+    if (scrollTargetId && scrollTargetId !== v.id) {
+      var t = document.getElementById(scrollTargetId);
+      if (t) { t.scrollIntoView({ block: 'start' }); return; }
+    }
+    window.scrollTo(0, 0);
+  }
+  function route() {
+    var id = (location.hash || '#').slice(1);
+    if (!id) { showView(views[0]); return; }
+    var v = viewFor(id);
+    if (v) showView(v, id);
+  }
+  window.addEventListener('hashchange', route);
+  route();
 
   /* search palette */
   var indexEl = el('search-index');
@@ -107,12 +173,8 @@ const BASE_JS = `
   }
   function go(e) {
     closePalette();
-    /* open every ancestor <details> so anchors inside the reference shelf land visibly */
-    var target = document.getElementById(e.a.slice(1));
-    var p = target;
-    while (p) { if (p.tagName === 'DETAILS') p.open = true; p = p.parentElement; }
-    location.hash = e.a;
-    if (target) target.scrollIntoView({ block: 'start' });
+    if (location.hash === e.a) { route(); return; }
+    location.hash = e.a; /* the router shows the containing view */
   }
   el('searchbtn').addEventListener('click', openPalette);
   overlay.addEventListener('click', function (ev) { if (ev.target === overlay) closePalette(); });

--- a/src/learn/page-js.ts
+++ b/src/learn/page-js.ts
@@ -238,28 +238,56 @@ const ASSISTANT_JS = `
     for (var i = 0; i < state.drivers.length; i++) if (state.drivers[i].id === id) return state.drivers[i];
     return null;
   }
-  function syncDriver() {
-    var d = currentDriver(); if (!d) return;
-    el('baseurl-row').hidden = !d.needsBaseUrl;
+  function fillModels(d, payload) {
     var ms = el('model-select');
+    var keep = ms.value;
     ms.replaceChildren();
-    if (d.routing) {
+    var routing = payload.routing || d.routing;
+    if (routing) {
       var auto = document.createElement('option');
       auto.value = 'auto';
-      auto.textContent = 'Auto — ' + d.routing.fast + ' ↔ ' + d.routing.deep;
+      auto.textContent = 'Auto — ' + routing.fast + ' ↔ ' + routing.deep;
       ms.appendChild(auto);
     }
-    d.suggestedModels.forEach(function (m) {
+    (payload.models || []).slice(0, 30).forEach(function (m) {
       var o = document.createElement('option'); o.value = m; o.textContent = m; ms.appendChild(o);
     });
     var custom = document.createElement('option');
     custom.value = CUSTOM_SENTINEL; custom.textContent = 'Other model…';
     ms.appendChild(custom);
-    ms.value = d.routing ? 'auto' : (d.suggestedModels[0] || CUSTOM_SENTINEL);
+    ms.value = keep && Array.prototype.some.call(ms.options, function (o) { return o.value === keep; })
+      ? keep : (routing ? 'auto' : ((payload.models || [])[0] || CUSTOM_SENTINEL));
     el('model-custom').hidden = ms.value !== CUSTOM_SENTINEL;
+    var note = el('models-note');
+    if (note) {
+      note.textContent = payload.note || '';
+      note.classList.toggle('live', !!payload.live);
+    }
+  }
+  function loadModels() {
+    var d = currentDriver(); if (!d) return;
+    fetch('/api/models', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        driverId: d.id,
+        browserKey: el('key').value,
+        baseUrl: el('baseurl').value.trim()
+      })
+    }).then(function (r) { return r.json(); })
+      .then(function (p) { fillModels(d, p); })
+      .catch(function () { fillModels(d, { models: d.suggestedModels, routing: d.routing,
+        note: 'suggestions from this dxkit release — may be outdated' }); });
+  }
+  function syncDriver() {
+    var d = currentDriver(); if (!d) return;
+    el('baseurl-row').hidden = !d.needsBaseUrl;
+    fillModels(d, { models: d.suggestedModels, routing: d.routing, live: false,
+      note: 'suggestions from this dxkit release — may be outdated; a key loads the live list' });
     el('key-env-note').hidden = !d.envKeyPresent;
     el('key-input-label').hidden = d.envKeyPresent;
     el('key-env-name').textContent = d.keyEnv;
+    loadModels();
   }
   function chosenModel() {
     var v = el('model-select').value;
@@ -335,7 +363,9 @@ const ASSISTANT_JS = `
   el('model-select').addEventListener('change', function () {
     el('model-custom').hidden = el('model-select').value !== CUSTOM_SENTINEL;
   });
-  el('drv').addEventListener('change', syncDriver);
+  el('drv').addEventListener('change', function () { el('model-select').value = ''; syncDriver(); });
+  el('key').addEventListener('change', loadModels);
+  el('baseurl').addEventListener('change', loadModels);
   el('detail').addEventListener('change', refreshStatus);
   refreshStatus();
 })();

--- a/src/learn/render.ts
+++ b/src/learn/render.ts
@@ -117,12 +117,12 @@ function capCard(c: LearnCapability, knobs: LearnBundle['knobs']): string {
 }
 
 function docSection(d: LearnDoc): string {
-  return `<section id="doc-${escapeHtml(d.slug)}"><div class="doc">${markdownToHtml(d.markdown)}</div></section>`;
+  return `<section class="view" id="doc-${escapeHtml(d.slug)}" data-title="${escapeHtml(d.title)}" data-crumb="Guide"><div class="doc">${markdownToHtml(d.markdown)}</div></section>`;
 }
 
-function statusSection(status: LearnRepoStatus): string {
+function repoStatusView(status: LearnRepoStatus): string {
   const parts: string[] = [];
-  parts.push(`<h2 class="section" id="repo-status">This repo</h2>`);
+  parts.push(`<h2 class="section">This repo</h2>`);
   if (!status.installed) {
     parts.push(
       `<div class="note">dxkit is not installed in this repository yet. The zero-question path: <code>npm init @vyuhlabs/dxkit -- --yes</code>, then <code>vyuh-dxkit doctor</code>.</div>`,
@@ -150,43 +150,46 @@ function statusSection(status: LearnRepoStatus): string {
       `<div class="status-line"><span class="${cls}">●</span> last guardrail verdict: <strong>${word}</strong>${v.blockingCount ? ` (${v.blockingCount} blocking)` : ''}${v.warningCount ? `, ${v.warningCount} warnings` : ''} <span style="color:var(--muted)">(${escapeHtml(v.ranAt.slice(0, 16))})</span></div>`,
     );
   }
+  return `<section class="view" id="repo-status" data-title="This repo" data-crumb="This repo">${parts.join('\n')}</section>`;
+}
 
+function setupView(status: LearnRepoStatus): string {
   const doctor = status.doctor;
-  if (doctor) {
-    parts.push(`<h2 class="section" id="setup-panel">Set up this repo</h2>
+  if (!doctor) return '';
+  const parts: string[] = [];
+  parts.push(`<h2 class="section">Set up this repo</h2>
       <p class="section-sub">Live requirements check (doctor). Everything here is read-only: copy the command, or tell your agent the sentence. The one write path is <code>vyuh-dxkit configure --apply</code>.</p>`);
-    const failing = doctor.checks.filter((c) => !c.ok);
-    const passing = doctor.checks.filter((c) => c.ok);
-    if (failing.length === 0) {
-      parts.push(
-        `<div class="status-line"><span class="badge-ok">●</span> all ${passing.length} doctor checks pass</div>`,
-      );
-    }
-    for (const c of failing) {
-      parts.push(`<div class="status-line fail"><div>
+  const failing = doctor.checks.filter((c) => !c.ok);
+  const passing = doctor.checks.filter((c) => c.ok);
+  if (failing.length === 0) {
+    parts.push(
+      `<div class="status-line"><span class="badge-ok">●</span> all ${passing.length} doctor checks pass</div>`,
+    );
+  }
+  for (const c of failing) {
+    parts.push(`<div class="status-line fail"><div>
         <span class="badge-fail">✗</span> ${escapeHtml(c.label)}
         ${c.fix ? `<div class="fix">${escapeHtml(c.fix.hint)}</div>` : ''}
         ${c.fix?.command ? `<div class="fix"><code>${escapeHtml(c.fix.command)}</code></div>` : ''}
       </div></div>`);
-    }
-    if (doctor.recommendations?.length) {
-      parts.push(
-        `<p class="section-sub" style="margin-top:14px">Doctor also recommends for this repo:</p>`,
-      );
-      for (const r of doctor.recommendations) {
-        parts.push(`<div class="status-line fail"><div>
+  }
+  if (doctor.recommendations?.length) {
+    parts.push(
+      `<p class="section-sub" style="margin-top:14px">Doctor also recommends for this repo:</p>`,
+    );
+    for (const r of doctor.recommendations) {
+      parts.push(`<div class="status-line fail"><div>
           <span class="badge-warn">→</span> <strong>${escapeHtml(r.id)}</strong>: ${escapeHtml(r.recommendation.reason)}
           <div class="fix"><code>${escapeHtml(r.recommendation.command)}</code></div>
         </div></div>`);
-      }
-    }
-    if (passing.length > 0 && failing.length > 0) {
-      parts.push(
-        `<div class="status-line" style="margin-top:8px"><span class="badge-ok">●</span> ${passing.length} other checks pass</div>`,
-      );
     }
   }
-  return parts.join('\n');
+  if (passing.length > 0 && failing.length > 0) {
+    parts.push(
+      `<div class="status-line" style="margin-top:8px"><span class="badge-ok">●</span> ${passing.length} other checks pass</div>`,
+    );
+  }
+  return `<section class="view" id="setup-panel" data-title="Set up this repo" data-crumb="This repo">${parts.join('\n')}</section>`;
 }
 
 /* ─────────────────────────── assistant panel (serve) ─────────────────────────── */
@@ -273,54 +276,80 @@ export function renderLearnHtml(
   }
 
   const body: string[] = [];
-  for (const d of bundle.docs) body.push(docSection(d));
-  body.push(`<h2 class="section" id="core">Start here</h2>
+
+  // Home / "Start here" view: hero + the core capability cards.
+  body.push(`<section class="view" id="core" data-title="Start here" data-crumb="">
+    <div class="hero">
+      <h1>Understand dxkit in one sitting</h1>
+      <p>dxkit gates <strong>changes</strong>, not repositories: existing debt is grandfathered, only net-new problems block. Everything on this page ships with the package and works offline${opts.serve ? ' — and the assistant on the right answers from exactly this content' : ''}.</p>
+      <div class="hero-actions">
+        <a class="tbtn primary" href="#doc-how-dxkit-thinks">Read the mental model</a>
+        <a class="tbtn" href="#reference">Browse the reference (${bundle.reference.length} pages)</a>
+      </div>
+    </div>
+    <h2 class="section">Start here</h2>
     <p class="section-sub">The five commands most repos live in.</p>
-    <div class="cards">${core.map((c) => capCard(c, bundle.knobs)).join('\n')}</div>`);
+    <div class="cards">${core.map((c) => capCard(c, bundle.knobs)).join('\n')}</div>
+  </section>`);
+
+  for (const d of bundle.docs) body.push(docSection(d));
+
   for (const g of groups) {
     const caps = more.filter((c) => c.groupLabel === g);
-    body.push(`<h2 class="section" id="group-${slugify(g)}">${escapeHtml(g)}</h2>
-      <div class="cards">${caps.map((c) => capCard(c, bundle.knobs)).join('\n')}</div>`);
+    body.push(`<section class="view" id="group-${slugify(g)}" data-title="${escapeHtml(g)}" data-crumb="Capabilities">
+      <h2 class="section">${escapeHtml(g)}</h2>
+      <div class="cards">${caps.map((c) => capCard(c, bundle.knobs)).join('\n')}</div></section>`);
   }
   if (bundle.skills.length > 0) {
-    body.push(`<h2 class="section" id="skills">Agent skills</h2>
+    body.push(`<section class="view" id="skills" data-title="Agent skills" data-crumb="Knowledge base">
+      <h2 class="section">Agent skills</h2>
       <p class="section-sub">Installed into <code>.claude/skills/</code> by init so a coding agent drives each capability conversationally.</p>
       <ul class="list-plain">${bundle.skills
         .map((s) => `<li><b>${escapeHtml(s.name)}</b><br>${escapeHtml(s.description)}</li>`)
-        .join('')}</ul>`);
+        .join('')}</ul></section>`);
   }
   if (bundle.tasks.length > 0) {
-    body.push(`<h2 class="section" id="tasks">Remediation lane tasks</h2>
+    body.push(`<section class="view" id="tasks" data-title="Remediation lane tasks" data-crumb="Knowledge base">
+      <h2 class="section">Remediation lane tasks</h2>
       <p class="section-sub">What the scheduled remediation lane (and one-off dispatch campaigns) can run. Every task lands only via a PR through the same gate.</p>
       <ul class="list-plain">${bundle.tasks
         .map(
           (t) =>
             `<li><span class="tier">${escapeHtml(t.tier)}</span><b>${escapeHtml(t.id)}</b><br>${escapeHtml(t.summary)}</li>`,
         )
-        .join('')}</ul>`);
+        .join('')}</ul></section>`);
   }
   if (bundle.reference.length > 0) {
     const refGroups = [...new Set(bundle.reference.map((r) => r.group))];
-    const parts: string[] = [
-      `<h2 class="section" id="reference">Reference</h2>
-       <p class="section-sub">The full documentation shelf, shipped with the package — ${bundle.reference.length} pages, all searchable (Ctrl+K).</p>`,
-    ];
-    for (const g of refGroups) {
-      const docs = bundle.reference.filter((r) => r.group === g);
-      parts.push(`<details class="ref-group"><summary>${escapeHtml(g)} (${docs.length})</summary>
-        ${docs
+    // The reference INDEX view: a wiki-style listing, one card per page.
+    body.push(`<section class="view" id="reference" data-title="Reference" data-crumb="Knowledge base">
+      <h2 class="section">Reference</h2>
+      <p class="section-sub">The full documentation shelf, shipped with the package — ${bundle.reference.length} pages, all searchable (Ctrl+K).</p>
+      ${refGroups
+        .map(
+          (g) => `<h3 class="ref-index-group">${escapeHtml(g)}</h3>
+        <div class="cards">${bundle.reference
+          .filter((r) => r.group === g)
           .map(
-            (r) => `<details class="ref-doc" id="ref-${slugify(r.relPath)}">
-          <summary>${escapeHtml(r.title)} <span style="color:var(--muted)">· docs/${escapeHtml(r.relPath)}</span></summary>
-          <div class="doc">${markdownToHtml(r.markdown)}</div>
-        </details>`,
+            (r) => `<a class="card ref-card" href="#ref-${slugify(r.relPath)}">
+              <span class="cmd">${escapeHtml(r.title)}</span>
+              <p>docs/${escapeHtml(r.relPath)}</p></a>`,
           )
-          .join('\n')}
-      </details>`);
+          .join('')}</div>`,
+        )
+        .join('\n')}
+    </section>`);
+    // One view per reference page (wiki page-per-topic).
+    for (const r of bundle.reference) {
+      body.push(`<section class="view" id="ref-${slugify(r.relPath)}" data-title="${escapeHtml(r.title)}" data-crumb="Reference">
+        <p class="section-sub"><a href="#reference">← Reference</a> · docs/${escapeHtml(r.relPath)}</p>
+        <div class="doc">${markdownToHtml(r.markdown)}</div></section>`);
     }
-    body.push(parts.join('\n'));
   }
-  if (status) body.push(statusSection(status));
+  if (status) {
+    body.push(repoStatusView(status));
+    body.push(setupView(status));
+  }
 
   const searchIndexJson = JSON.stringify(buildSearchIndex(bundle, status)).replace(/</g, '\\u003c');
 
@@ -347,9 +376,12 @@ export function renderLearnHtml(
   ${nav.join('\n  ')}
 </nav>
 <main class="main">
+<div class="crumbs" id="crumbs"></div>
 ${body.join('\n')}
+<div class="pagenav" id="pagenav"></div>
 ${opts.generatedAt ? `<p class="section-sub" style="margin-top:44px">Generated ${escapeHtml(opts.generatedAt)} · fully self-contained page: no external requests, works offline.</p>` : ''}
 </main>
+<aside class="toc" id="toc" aria-label="On this page"></aside>
 </div>
 <div class="palette-overlay" id="palette-overlay">
   <div class="palette">

--- a/src/learn/render.ts
+++ b/src/learn/render.ts
@@ -1,100 +1,109 @@
 /**
- * The learn page renderer — ONE self-contained HTML document (issue #244).
+ * The learn page renderer — ONE self-contained HTML document (issues #244,
+ * #245, plus the UI modernization pass).
  *
- * Hard constraints, all load-bearing:
- *   - ZERO external loads: no CDN scripts, no fonts, no images. Inline CSS
- *     only, no JavaScript at all in this (read-only) increment. The page
- *     must open from file:// on an offline machine.
- *   - STRICTLY read-only: every "enable X" renders the exact command to run
- *     (or the sentence to tell your agent); the one write path
- *     (`configure --apply`) stays canonical and is only ever QUOTED here.
- *   - Repo-derived strings are escaped at the boundary; the curated docs go
- *     through the pinned markdown subset renderer.
+ * Hard constraints, all load-bearing and pinned by test:
+ *   - ZERO external loads: no CDN, no fonts, no remote images, no fetch to
+ *     anywhere but the page's own localhost origin (serve mode only). The
+ *     static file opens from file:// on an offline machine, fully working.
+ *   - All JavaScript is INLINE and self-contained. The static page's script
+ *     performs no network requests at all (search, theme, copy, nav
+ *     highlighting are pure client-side over embedded data).
+ *   - STRICTLY read-only: every "enable X" renders the exact command; the
+ *     one write path (`configure --apply`) is only ever QUOTED.
+ *   - Repo-derived strings are escaped at the boundary; docs go through the
+ *     pinned markdown subset renderer; assistant answers are rendered
+ *     server-side by that SAME renderer (never a client-side engine).
+ *
+ * Theme: light + dark via design tokens; default follows
+ * prefers-color-scheme, the toggle persists to localStorage.
  */
 import type { LearnBundle, LearnCapability, LearnDoc } from './bundle';
 import type { LearnRepoStatus } from './repo-status';
 import { escapeHtml, markdownToHtml, slugify } from './markdown';
+import { CSS } from './page-css';
+import { BASE_JS, ASSISTANT_JS } from './page-js';
 
-const CSS = `
-:root {
-  --bg-primary:#0d1117; --bg-secondary:#161b22; --bg-card:#1c2129;
-  --bg-tertiary:#21262d; --border:#30363d; --text-primary:#e6edf3;
-  --text-secondary:#c9d1d9; --text-muted:#8b949e; --accent-blue:#58a6ff;
-  --accent-green:#3fb950; --accent-red:#f85149; --accent-amber:#d29922;
+/* ─────────────────────────── search index ─────────────────────────── */
+
+interface SearchEntry {
+  /** Display title. */
+  t: string;
+  /** Kind label shown in the palette. */
+  k: string;
+  /** Anchor (#...) to jump to. */
+  a: string;
+  /** Snippet searched + shown. */
+  s: string;
 }
-* { margin:0; padding:0; box-sizing:border-box; }
-body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
-  background:var(--bg-primary); color:var(--text-secondary); display:flex; min-height:100vh; }
-code, pre { font-family:'SF Mono','Fira Code',Consolas,monospace; }
-.sidebar { width:250px; background:var(--bg-secondary); border-right:1px solid var(--border);
-  padding:20px 14px; position:sticky; top:0; align-self:flex-start; height:100vh; overflow-y:auto; flex-shrink:0; }
-.sidebar h1 { font-size:16px; color:var(--text-primary); padding:0 8px 4px; }
-.sidebar .version { font-size:11px; color:var(--text-muted); padding:0 8px 14px; }
-.sidebar a { display:block; color:var(--text-secondary); text-decoration:none; font-size:13px;
-  padding:6px 8px; border-radius:6px; }
-.sidebar a:hover { background:var(--bg-tertiary); color:var(--text-primary); }
-.nav-label { font-size:10px; text-transform:uppercase; letter-spacing:.8px;
-  color:var(--text-muted); padding:14px 8px 4px; }
-.main { flex:1; padding:32px 40px 80px; max-width:980px; }
-h2.section { font-size:20px; color:var(--text-primary); margin:36px 0 6px; padding-bottom:8px;
-  border-bottom:1px solid var(--border); }
-.section-sub { color:var(--text-muted); font-size:13px; margin-bottom:16px; }
-.cards { display:grid; grid-template-columns:repeat(auto-fill,minmax(280px,1fr)); gap:12px; }
-.card { background:var(--bg-card); border:1px solid var(--border); border-radius:10px; padding:14px 16px; }
-.card .cmd { font-size:14px; color:var(--accent-blue); font-weight:600; }
-.card .aliases { font-size:11px; color:var(--text-muted); }
-.card .runtime { float:right; font-size:11px; color:var(--text-muted); background:var(--bg-tertiary);
-  padding:2px 8px; border-radius:10px; }
-.card p { font-size:12.5px; line-height:1.55; margin-top:8px; }
-.card .knobs { margin-top:8px; font-size:11.5px; color:var(--text-muted); }
-.card .knobs code { color:var(--accent-amber); }
-.doc { background:var(--bg-card); border:1px solid var(--border); border-radius:10px;
-  padding:22px 26px; margin-bottom:18px; }
-.doc h1 { font-size:21px; color:var(--text-primary); margin-bottom:12px; }
-.doc h2 { font-size:17px; color:var(--text-primary); margin:22px 0 8px; }
-.doc h3 { font-size:14.5px; color:var(--text-primary); margin:16px 0 6px; }
-.doc h4 { font-size:13px; color:var(--text-primary); margin:12px 0 4px; }
-.doc p, .doc li { font-size:13.5px; line-height:1.65; }
-.doc p { margin-bottom:10px; }
-.doc ul, .doc ol { padding-left:22px; margin-bottom:12px; }
-.doc pre { background:var(--bg-primary); border:1px solid var(--border); border-radius:8px;
-  padding:12px 14px; font-size:12.5px; overflow-x:auto; margin:10px 0 14px; line-height:1.5; }
-.doc code { background:var(--bg-tertiary); padding:1px 5px; border-radius:4px; font-size:12px; }
-.doc pre code { background:none; padding:0; }
-.doc a { color:var(--accent-blue); text-decoration:none; }
-.doc strong { color:var(--text-primary); }
-.doc blockquote { border-left:3px solid var(--border); padding-left:14px; color:var(--text-muted); margin-bottom:10px; }
-.status-line { display:flex; gap:10px; align-items:baseline; padding:8px 12px; border-radius:8px; font-size:13px; }
-.status-line.ok { color:var(--text-secondary); }
-.status-line.fail { background:var(--bg-card); border:1px solid var(--border); margin-bottom:8px; }
-.badge-ok { color:var(--accent-green); }
-.badge-fail { color:var(--accent-red); }
-.badge-warn { color:var(--accent-amber); }
-.fix { font-size:12.5px; color:var(--text-muted); margin:4px 0 2px 24px; line-height:1.55; }
-.fix code { background:var(--bg-primary); border:1px solid var(--border); padding:2px 7px;
-  border-radius:5px; color:var(--accent-blue); user-select:all; }
-.pill-row { display:flex; flex-wrap:wrap; gap:8px; margin:10px 0 16px; }
-.pill { font-size:12px; background:var(--bg-card); border:1px solid var(--border);
-  border-radius:14px; padding:4px 12px; color:var(--text-secondary); }
-.note { font-size:12.5px; color:var(--text-muted); background:var(--bg-card);
-  border:1px solid var(--border); border-radius:8px; padding:10px 14px; margin:10px 0; line-height:1.6; }
-.ask-row { display:flex; gap:12px; align-items:center; margin:8px 0; flex-wrap:wrap; }
-.ask-row label { font-size:12.5px; color:var(--text-muted); display:flex; gap:6px; align-items:center; }
-.ask-row input, .ask-row select, .ask-row textarea { background:var(--bg-primary); color:var(--text-primary);
-  border:1px solid var(--border); border-radius:6px; padding:6px 9px; font-size:12.5px; font-family:inherit; }
-.ask-row textarea { flex:1; min-width:260px; }
-.ask-row button { background:var(--accent-blue); color:#fff; border:none; border-radius:6px;
-  padding:8px 18px; font-size:13px; cursor:pointer; }
-#chat { margin:12px 0; display:flex; flex-direction:column; gap:8px; }
-.chat-msg { padding:9px 12px; border-radius:8px; font-size:13px; line-height:1.6; white-space:pre-wrap; }
-.chat-user { background:var(--bg-tertiary); align-self:flex-end; max-width:85%; }
-.chat-assistant { background:var(--bg-primary); border:1px solid var(--border); max-width:95%; }
-#ask-error { font-size:12.5px; margin-top:6px; }
-`;
+
+function buildSearchIndex(bundle: LearnBundle, status: LearnRepoStatus | null): SearchEntry[] {
+  const out: SearchEntry[] = [];
+  for (const c of bundle.capabilities) {
+    out.push({
+      t: c.id,
+      k: c.tier === 'core' ? 'core command' : 'command',
+      a: `#cap-${c.id}`,
+      s: c.docsBlurb ?? c.summary,
+    });
+  }
+  for (const kn of bundle.knobs) {
+    out.push({
+      t: kn.path,
+      k: 'policy knob',
+      a: `#cap-${kn.command}`,
+      s: kn.note ?? `configured via ${kn.command}`,
+    });
+  }
+  for (const d of bundle.docs) {
+    out.push({ t: d.title, k: 'doc', a: `#doc-${d.slug}`, s: firstProse(d.markdown) });
+    for (const line of d.markdown.split('\n')) {
+      const h = line.match(/^##\s+(.+)$/);
+      if (h) out.push({ t: h[1], k: 'doc section', a: `#${slugify(h[1])}`, s: d.title });
+    }
+  }
+  for (const r of bundle.reference) {
+    out.push({
+      t: r.title,
+      k: 'reference',
+      a: `#ref-${slugify(r.relPath)}`,
+      s: `docs/${r.relPath}`,
+    });
+  }
+  for (const s of bundle.skills) {
+    out.push({ t: s.name, k: 'agent skill', a: '#skills', s: s.description.slice(0, 160) });
+  }
+  for (const t of bundle.tasks) {
+    out.push({ t: t.id, k: 'remediation task', a: '#tasks', s: t.summary });
+  }
+  if (status?.doctor) {
+    for (const c of status.doctor.checks.filter((x) => !x.ok)) {
+      out.push({
+        t: c.label,
+        k: 'setup item',
+        a: '#setup-panel',
+        s: c.fix?.hint ?? 'failing doctor check',
+      });
+    }
+  }
+  return out;
+}
+
+function firstProse(md: string): string {
+  for (const line of md.split('\n')) {
+    const l = line.trim();
+    if (l.length > 0 && !l.startsWith('#') && !l.startsWith('```') && !l.startsWith('<!--')) {
+      return l.slice(0, 160);
+    }
+  }
+  return '';
+}
+
+/* ─────────────────────────── sections ─────────────────────────── */
 
 function capCard(c: LearnCapability, knobs: LearnBundle['knobs']): string {
   const own = knobs.filter((k) => k.command === c.id);
-  return `<div class="card">
+  return `<div class="card" id="cap-${escapeHtml(c.id)}">
     ${c.typicalRuntime ? `<span class="runtime">${escapeHtml(c.typicalRuntime)}</span>` : ''}
     <span class="cmd">${escapeHtml(c.id)}</span>
     ${c.aliases?.length ? `<span class="aliases">(${c.aliases.map(escapeHtml).join(', ')})</span>` : ''}
@@ -122,7 +131,7 @@ function statusSection(status: LearnRepoStatus): string {
   if (status.policy) {
     const p = status.policy;
     parts.push(`<div class="pill-row">
-      ${p.preset ? `<span class="pill">preset: ${escapeHtml(p.preset)}</span>` : ''}
+      ${p.preset ? `<span class="pill">preset: <strong>${escapeHtml(p.preset)}</strong></span>` : ''}
       <span class="pill">custom checks: ${p.checksCount}</span>
       <span class="pill">pack lint gate: ${p.lintEnabled ? 'on' : 'off'}</span>
       ${p.lanes.map((l) => `<span class="pill">lane: ${escapeHtml(l)}</span>`).join('')}
@@ -130,7 +139,7 @@ function statusSection(status: LearnRepoStatus): string {
   }
   for (const b of status.baselines) {
     parts.push(
-      `<div class="status-line ok"><span class="badge-ok">●</span> baseline <code>${escapeHtml(b.name)}</code>: ${b.entryCount} grandfathered findings${b.capturedAt ? `, captured ${escapeHtml(b.capturedAt.slice(0, 10))}` : ''}</div>`,
+      `<div class="status-line"><span class="badge-ok">●</span> baseline <code>${escapeHtml(b.name)}</code>: ${b.entryCount} grandfathered findings${b.capturedAt ? `, captured ${escapeHtml(b.capturedAt.slice(0, 10))}` : ''}</div>`,
     );
   }
   if (status.lastVerdict) {
@@ -138,19 +147,19 @@ function statusSection(status: LearnRepoStatus): string {
     const word = v.unattributableCount > 0 ? 'CANNOT GATE' : v.blocks ? 'BLOCKED' : 'PASSED';
     const cls = word === 'PASSED' ? 'badge-ok' : 'badge-fail';
     parts.push(
-      `<div class="status-line ok"><span class="${cls}">●</span> last guardrail verdict: ${word}${v.blockingCount ? ` (${v.blockingCount} blocking)` : ''}${v.warningCount ? `, ${v.warningCount} warnings` : ''} <span style="color:var(--text-muted)">(${escapeHtml(v.ranAt.slice(0, 16))})</span></div>`,
+      `<div class="status-line"><span class="${cls}">●</span> last guardrail verdict: <strong>${word}</strong>${v.blockingCount ? ` (${v.blockingCount} blocking)` : ''}${v.warningCount ? `, ${v.warningCount} warnings` : ''} <span style="color:var(--muted)">(${escapeHtml(v.ranAt.slice(0, 16))})</span></div>`,
     );
   }
 
   const doctor = status.doctor;
   if (doctor) {
     parts.push(`<h2 class="section" id="setup-panel">Set up this repo</h2>
-      <p class="section-sub">Live requirements check (doctor). Every item is read-only here: copy the command, or tell your agent the sentence. The one write path is <code>vyuh-dxkit configure --apply</code>.</p>`);
+      <p class="section-sub">Live requirements check (doctor). Everything here is read-only: copy the command, or tell your agent the sentence. The one write path is <code>vyuh-dxkit configure --apply</code>.</p>`);
     const failing = doctor.checks.filter((c) => !c.ok);
     const passing = doctor.checks.filter((c) => c.ok);
     if (failing.length === 0) {
       parts.push(
-        `<div class="status-line ok"><span class="badge-ok">●</span> all ${passing.length} doctor checks pass</div>`,
+        `<div class="status-line"><span class="badge-ok">●</span> all ${passing.length} doctor checks pass</div>`,
       );
     }
     for (const c of failing) {
@@ -173,150 +182,67 @@ function statusSection(status: LearnRepoStatus): string {
     }
     if (passing.length > 0 && failing.length > 0) {
       parts.push(
-        `<div class="status-line ok" style="margin-top:8px"><span class="badge-ok">●</span> ${passing.length} other checks pass</div>`,
+        `<div class="status-line" style="margin-top:8px"><span class="badge-ok">●</span> ${passing.length} other checks pass</div>`,
       );
     }
   }
   return parts.join('\n');
 }
 
+/* ─────────────────────────── assistant panel (serve) ─────────────────────────── */
+
+function assistantPanel(): string {
+  return `
+<button class="assistant-fab" id="fab">✦ Ask dxkit <kbd style="opacity:.7;font-size:10px">Ctrl+/</kbd></button>
+<aside class="assistant-panel" id="apanel" aria-label="dxkit assistant">
+  <div class="ap-head">
+    <span class="t">✦ dxkit assistant</span>
+    <span class="sub">bring-your-own-key · local relay · executes nothing</span>
+    <button class="close" id="ap-close" title="Close">✕</button>
+  </div>
+  <div class="ap-config">
+    <div class="ap-row">
+      <label>Provider <select id="drv"></select></label>
+      <label>Model <select id="model-select"></select></label>
+      <input type="text" id="model-custom" placeholder="model id" hidden>
+    </div>
+    <div class="ap-row" id="baseurl-row" hidden>
+      <label>Base URL <input type="text" id="baseurl" placeholder="https://your-endpoint/v1"></label>
+    </div>
+    <div class="ap-row" id="key-row">
+      <span id="key-env-note" hidden>Key from your terminal env (<code id="key-env-name"></code>) — it never reaches this page.</span>
+      <label id="key-input-label">API key <input type="password" id="key" placeholder="stays in this tab's memory only"></label>
+    </div>
+    <div class="ap-row" id="detail-row" hidden>
+      <label><input type="checkbox" id="detail"> Include finding-level detail (off = summaries and counts only)</label>
+    </div>
+    <details class="ap-disclosure" id="sent-note"><summary>Exactly what is sent with each question</summary><ul id="disclosure"></ul></details>
+  </div>
+  <div class="ap-chat" id="chat">
+    <div class="ap-empty" id="chat-empty">Ask anything about dxkit${''} or this repo.<br><br>“Why is my PR blocked?”<br>“What should we adopt next?”<br>“How do I defer a finding?”</div>
+  </div>
+  <div class="ap-error" id="ask-error"></div>
+  <div class="ap-input">
+    <textarea id="q" rows="1" placeholder="Ask… (Enter to send, Shift+Enter for a new line)"></textarea>
+    <button id="ask">Send</button>
+  </div>
+</aside>`;
+}
+
+/* ─────────────────────────── page assembly ─────────────────────────── */
+
 export interface RenderLearnOptions {
   /** ISO timestamp shown in the footer; omit for a deterministic page. */
   generatedAt?: string;
-  /**
-   * Serve mode (`learn --serve`): adds the assistant panel + its inline
-   * script, which talks ONLY to same-origin localhost endpoints. The static
-   * file mode stays entirely script-free — that page must open from file://
-   * offline, and its tests pin the absence of any <script>.
-   */
+  /** Serve mode: adds the assistant panel + its script (same-origin only). */
   serve?: boolean;
 }
 
-/** The assistant panel + inline JS for serve mode. No external loads; all
- *  repo/provider strings are inserted via textContent, never innerHTML. */
-function assistantSection(): string {
-  return `<h2 class="section" id="assistant">Ask the assistant</h2>
-<p class="section-sub">Grounded in this page's content${''} and answered by YOUR provider with YOUR key (bring-your-own-key). dxkit relays your question from this machine directly to the provider; nothing is stored.</p>
-<div class="doc" id="assistant-panel">
-  <div class="ask-row">
-    <label>Provider <select id="drv"></select></label>
-    <label>Model <input id="model" list="model-suggestions" placeholder="model id"><datalist id="model-suggestions"></datalist></label>
-  </div>
-  <div class="ask-row" id="baseurl-row" hidden>
-    <label>Base URL <input id="baseurl" placeholder="https://your-endpoint/v1"></label>
-  </div>
-  <div class="ask-row" id="key-row">
-    <span id="key-env-note" hidden>Using the API key from your terminal environment (<code id="key-env-name"></code>). It never reaches this page.</span>
-    <label id="key-input-label">API key <input id="key" type="password" placeholder="pasted key stays in this tab's memory only"></label>
-  </div>
-  <div class="ask-row" id="detail-row" hidden>
-    <label><input type="checkbox" id="detail"> Include finding-level detail from this repo (off = summaries and counts only)</label>
-  </div>
-  <details class="note" id="sent-note"><summary>Exactly what is sent with each question</summary><ul id="disclosure"></ul></details>
-  <div id="chat"></div>
-  <div class="ask-row">
-    <textarea id="q" rows="3" placeholder="e.g. Why is my PR blocked? What should this repo adopt next?"></textarea>
-    <button id="ask">Ask</button>
-  </div>
-  <div id="ask-error" class="badge-fail"></div>
-</div>
-<script>
-(function () {
-  'use strict';
-  var state = { drivers: [] };
-  function el(id) { return document.getElementById(id); }
-  function refreshStatus() {
-    var detail = el('detail').checked ? '1' : '0';
-    return fetch('/api/status?detail=' + detail).then(function (r) { return r.json(); }).then(function (s) {
-      state.drivers = s.drivers;
-      if (s.repoMode) el('detail-row').hidden = false;
-      var drv = el('drv');
-      if (drv.options.length === 0) {
-        s.drivers.forEach(function (d) {
-          var o = document.createElement('option');
-          o.value = d.id; o.textContent = d.label + (d.envKeyPresent ? ' (key found in env)' : '');
-          drv.appendChild(o);
-        });
-      }
-      var ul = el('disclosure');
-      ul.replaceChildren();
-      s.disclosure.forEach(function (line) {
-        var li = document.createElement('li');
-        li.textContent = line;
-        ul.appendChild(li);
-      });
-      syncDriver();
-    });
-  }
-  function currentDriver() {
-    var id = el('drv').value;
-    for (var i = 0; i < state.drivers.length; i++) if (state.drivers[i].id === id) return state.drivers[i];
-    return null;
-  }
-  function syncDriver() {
-    var d = currentDriver();
-    if (!d) return;
-    el('baseurl-row').hidden = !d.needsBaseUrl;
-    var dl = el('model-suggestions');
-    dl.replaceChildren();
-    d.suggestedModels.forEach(function (m) {
-      var o = document.createElement('option');
-      o.value = m;
-      dl.appendChild(o);
-    });
-    if (!el('model').value) el('model').value = d.defaultModel;
-    el('key-env-note').hidden = !d.envKeyPresent;
-    el('key-input-label').hidden = d.envKeyPresent;
-    el('key-env-name').textContent = d.keyEnv;
-  }
-  function addMsg(role, text) {
-    var div = document.createElement('div');
-    div.className = 'chat-msg chat-' + role;
-    div.textContent = text;
-    el('chat').appendChild(div);
-    div.scrollIntoView();
-    return div;
-  }
-  var history = [];
-  function ask() {
-    var q = el('q').value.trim();
-    if (!q) return;
-    el('ask-error').textContent = '';
-    el('q').value = '';
-    addMsg('user', q);
-    var pending = addMsg('assistant', '…');
-    fetch('/api/ask', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        driverId: el('drv').value,
-        model: el('model').value.trim(),
-        baseUrl: el('baseurl').value.trim(),
-        browserKey: el('key').value,
-        detail: el('detail').checked,
-        question: q,
-        history: history
-      })
-    }).then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
-      .then(function (res) {
-        if (!res.ok) {
-          pending.textContent = '';
-          el('ask-error').textContent = res.body.error || 'request failed';
-          return;
-        }
-        pending.textContent = res.body.answer;
-        history.push({ role: 'user', content: q });
-        history.push({ role: 'assistant', content: res.body.answer });
-      })
-      .catch(function (e) { pending.textContent = ''; el('ask-error').textContent = String(e); });
-  }
-  el('ask').addEventListener('click', ask);
-  el('drv').addEventListener('change', function () { el('model').value = ''; syncDriver(); });
-  el('detail').addEventListener('change', refreshStatus);
-  refreshStatus();
-})();
-</script>`;
-}
+const FAVICON =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="7" fill="#2563eb"/><text x="16" y="22" font-size="16" font-family="monospace" font-weight="bold" fill="#fff" text-anchor="middle">dx</text></svg>`,
+  );
 
 export function renderLearnHtml(
   bundle: LearnBundle,
@@ -335,6 +261,11 @@ export function renderLearnHtml(
   nav.push(`<div class="nav-label">Capabilities</div>`);
   nav.push(`<a href="#core">Start here</a>`);
   for (const g of groups) nav.push(`<a href="#group-${slugify(g)}">${escapeHtml(g)}</a>`);
+  nav.push(`<div class="nav-label">Knowledge base</div>`);
+  if (bundle.skills.length > 0) nav.push(`<a href="#skills">Agent skills</a>`);
+  if (bundle.tasks.length > 0) nav.push(`<a href="#tasks">Remediation tasks</a>`);
+  if (bundle.reference.length > 0)
+    nav.push(`<a href="#reference">Reference (${bundle.reference.length} pages)</a>`);
   if (status) {
     nav.push(`<div class="nav-label">This repo</div>`);
     nav.push(`<a href="#repo-status">Status</a>`);
@@ -343,7 +274,6 @@ export function renderLearnHtml(
 
   const body: string[] = [];
   for (const d of bundle.docs) body.push(docSection(d));
-
   body.push(`<h2 class="section" id="core">Start here</h2>
     <p class="section-sub">The five commands most repos live in.</p>
     <div class="cards">${core.map((c) => capCard(c, bundle.knobs)).join('\n')}</div>`);
@@ -352,12 +282,47 @@ export function renderLearnHtml(
     body.push(`<h2 class="section" id="group-${slugify(g)}">${escapeHtml(g)}</h2>
       <div class="cards">${caps.map((c) => capCard(c, bundle.knobs)).join('\n')}</div>`);
   }
-  if (status) body.push(statusSection(status));
-  if (opts.serve) {
-    nav.push(`<div class="nav-label">Assistant</div>`);
-    nav.push(`<a href="#assistant">Ask the assistant</a>`);
-    body.push(assistantSection());
+  if (bundle.skills.length > 0) {
+    body.push(`<h2 class="section" id="skills">Agent skills</h2>
+      <p class="section-sub">Installed into <code>.claude/skills/</code> by init so a coding agent drives each capability conversationally.</p>
+      <ul class="list-plain">${bundle.skills
+        .map((s) => `<li><b>${escapeHtml(s.name)}</b><br>${escapeHtml(s.description)}</li>`)
+        .join('')}</ul>`);
   }
+  if (bundle.tasks.length > 0) {
+    body.push(`<h2 class="section" id="tasks">Remediation lane tasks</h2>
+      <p class="section-sub">What the scheduled remediation lane (and one-off dispatch campaigns) can run. Every task lands only via a PR through the same gate.</p>
+      <ul class="list-plain">${bundle.tasks
+        .map(
+          (t) =>
+            `<li><span class="tier">${escapeHtml(t.tier)}</span><b>${escapeHtml(t.id)}</b><br>${escapeHtml(t.summary)}</li>`,
+        )
+        .join('')}</ul>`);
+  }
+  if (bundle.reference.length > 0) {
+    const refGroups = [...new Set(bundle.reference.map((r) => r.group))];
+    const parts: string[] = [
+      `<h2 class="section" id="reference">Reference</h2>
+       <p class="section-sub">The full documentation shelf, shipped with the package — ${bundle.reference.length} pages, all searchable (Ctrl+K).</p>`,
+    ];
+    for (const g of refGroups) {
+      const docs = bundle.reference.filter((r) => r.group === g);
+      parts.push(`<details class="ref-group"><summary>${escapeHtml(g)} (${docs.length})</summary>
+        ${docs
+          .map(
+            (r) => `<details class="ref-doc" id="ref-${slugify(r.relPath)}">
+          <summary>${escapeHtml(r.title)} <span style="color:var(--muted)">· docs/${escapeHtml(r.relPath)}</span></summary>
+          <div class="doc">${markdownToHtml(r.markdown)}</div>
+        </details>`,
+          )
+          .join('\n')}
+      </details>`);
+    }
+    body.push(parts.join('\n'));
+  }
+  if (status) body.push(statusSection(status));
+
+  const searchIndexJson = JSON.stringify(buildSearchIndex(bundle, status)).replace(/</g, '\\u003c');
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -365,18 +330,37 @@ export function renderLearnHtml(
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>dxkit learn</title>
+<link rel="icon" href="${FAVICON}">
 <style>${CSS}</style>
 </head>
 <body>
+<header class="topbar">
+  <span class="brand">dxkit <span class="v">v${escapeHtml(bundle.version)}</span>
+    <span class="mode">${status ? 'repo mode' : 'guide'}</span></span>
+  <button class="searchbtn" id="searchbtn" type="button">🔍 Search capabilities, docs, setup…<kbd>Ctrl K</kbd></button>
+  <span class="spacer"></span>
+  ${opts.serve ? `<button class="tbtn primary" id="assistant-open" type="button">✦ Ask dxkit</button>` : ''}
+  <button class="tbtn" id="theme-toggle" type="button" title="Toggle theme">☾</button>
+</header>
+<div class="layout">
 <nav class="sidebar">
-  <h1>dxkit learn</h1>
-  <div class="version">v${escapeHtml(bundle.version)}${status ? ' · with repo status' : ' · capability guide'}</div>
   ${nav.join('\n  ')}
 </nav>
 <main class="main">
 ${body.join('\n')}
-${opts.generatedAt ? `<p class="section-sub" style="margin-top:40px">Generated ${escapeHtml(opts.generatedAt)} · fully offline page: no scripts, no external loads.</p>` : ''}
+${opts.generatedAt ? `<p class="section-sub" style="margin-top:44px">Generated ${escapeHtml(opts.generatedAt)} · fully self-contained page: no external requests, works offline.</p>` : ''}
 </main>
+</div>
+<div class="palette-overlay" id="palette-overlay">
+  <div class="palette">
+    <input id="palette-input" type="text" placeholder="Search capabilities, docs, policy knobs…" autocomplete="off">
+    <div class="palette-results" id="palette-results"></div>
+  </div>
+</div>
+${opts.serve ? assistantPanel() : ''}
+<script type="application/json" id="search-index">${searchIndexJson}</script>
+<script>${BASE_JS}</script>
+${opts.serve ? `<script>${ASSISTANT_JS}</script>` : ''}
 </body>
 </html>
 `;

--- a/src/learn/render.ts
+++ b/src/learn/render.ts
@@ -62,6 +62,14 @@ function buildSearchIndex(bundle: LearnBundle, status: LearnRepoStatus | null): 
       if (h) out.push({ t: h[1], k: 'doc section', a: `#${slugify(h[1])}`, s: d.title });
     }
   }
+  for (const f of bundle.policyFields) {
+    out.push({
+      t: f.path,
+      k: 'policy field',
+      a: '#policy-reference',
+      s: f.description.slice(0, 160),
+    });
+  }
   for (const r of bundle.reference) {
     out.push({
       t: r.title,
@@ -219,7 +227,15 @@ function assistantPanel(): string {
     <div class="ap-row" id="detail-row" hidden>
       <label><input type="checkbox" id="detail"> Include finding-level detail (off = summaries and counts only)</label>
     </div>
+    <div class="ap-row"><span id="models-note" class="models-note"></span></div>
     <details class="ap-disclosure" id="sent-note"><summary>Exactly what is sent with each question</summary><ul id="disclosure"></ul></details>
+    <details class="ap-disclosure"><summary>How this assistant works</summary>
+      <ul>
+        <li>It answers from a fixed knowledge pack: this dxkit version's own registries (every command and policy field), the shipped docs, and — in a repo — this repo's dxkit status (policy, doctor results, baselines, last verdict), gathered when the server started.</li>
+        <li>It does NOT read your source code, does not browse the internet or GitHub, and cannot run anything. Its knowledge is version-locked to the installed dxkit.</li>
+        <li>Your question + the grounding go directly from this machine to the provider you chose, with your key. dxkit stores nothing.</li>
+      </ul>
+    </details>
   </div>
   <div class="ap-chat" id="chat">
     <div class="ap-empty" id="chat-empty">Ask anything about dxkit${''} or this repo.<br><br>“Why is my PR blocked?”<br>“What should we adopt next?”<br>“How do I defer a finding?”</div>
@@ -265,6 +281,8 @@ export function renderLearnHtml(
   nav.push(`<a href="#core">Start here</a>`);
   for (const g of groups) nav.push(`<a href="#group-${slugify(g)}">${escapeHtml(g)}</a>`);
   nav.push(`<div class="nav-label">Knowledge base</div>`);
+  if (bundle.policyFields.length > 0)
+    nav.push(`<a href="#policy-reference">Policy fields (${bundle.policyFields.length})</a>`);
   if (bundle.skills.length > 0) nav.push(`<a href="#skills">Agent skills</a>`);
   if (bundle.tasks.length > 0) nav.push(`<a href="#tasks">Remediation tasks</a>`);
   if (bundle.reference.length > 0)
@@ -315,9 +333,23 @@ export function renderLearnHtml(
       <ul class="list-plain">${bundle.tasks
         .map(
           (t) =>
-            `<li><span class="tier">${escapeHtml(t.tier)}</span><b>${escapeHtml(t.id)}</b><br>${escapeHtml(t.summary)}</li>`,
+            `<li><span class="tier">${escapeHtml(t.tier)} · ${escapeHtml(t.verify)}</span><b>${escapeHtml(t.id)}</b><br>${escapeHtml(t.summary)}<br><span class="task-why">Model tier: ${escapeHtml(t.tierWhy)}${t.hinge ? `<br>Score hinge: ${escapeHtml(t.hinge)}` : ''}</span></li>`,
         )
-        .join('')}</ul></section>`);
+        .join('')}</ul>
+      <div class="note">Run tasks two ways: the <strong>scheduled lane</strong> (cron, the tasks enabled in policy), or a <strong>one-off dispatch campaign</strong> from the GitHub Actions UI (Run workflow → pick a task or <code>custom</code> with a free-text prompt, plus spend/turn/minute overrides — clamped by <code>remediate.maxDispatchBudget</code>). Either way, work lands ONLY via a pull request through the same gate, with the dispatcher, prompt, model, and spend disclosed in the PR body.</div></section>`);
+  }
+  if (bundle.policyFields.length > 0) {
+    const rows = bundle.policyFields
+      .map(
+        (f) =>
+          `<tr><td><code>${escapeHtml(f.path)}</code></td><td>${escapeHtml(f.type)}${f.enum ? `<br><span class="task-why">${f.enum.map(escapeHtml).join(' | ')}</span>` : ''}</td><td>${f.default !== undefined ? `<code>${escapeHtml(f.default)}</code>` : ''}</td><td>${escapeHtml(f.description)}</td></tr>`,
+      )
+      .join('');
+    body.push(`<section class="view" id="policy-reference" data-title="Policy field reference" data-crumb="Knowledge base">
+      <h2 class="section">Policy field reference</h2>
+      <p class="section-sub">Every field <code>.dxkit/policy.json</code> accepts — ${bundle.policyFields.length} fields, generated from the same schema the file validates against, so this table cannot drift from the product. See also the narrative <a href="#ref-${slugify('configuration/policy-guide.md')}">policy guide</a>.</p>
+      <div class="doc"><table><thead><tr><th>Field</th><th>Type</th><th>Default</th><th>What it does</th></tr></thead><tbody>${rows}</tbody></table></div>
+    </section>`);
   }
   if (bundle.reference.length > 0) {
     const refGroups = [...new Set(bundle.reference.map((r) => r.group))];

--- a/src/learn/repo-status.ts
+++ b/src/learn/repo-status.ts
@@ -17,7 +17,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { runDoctor, type DoctorReport } from '../doctor';
 import { readVerdictForTree, type CachedVerdict } from '../baseline/verdict-cache';
-import { readPolicyObjectSafe } from '../baseline/policy-text';
+import { readPolicyObjectSafe, readPolicyRoot } from '../baseline/policy-text';
 import { readBaselineFile } from '../baseline/baseline-file';
 
 export interface LearnRepoStatus {
@@ -38,6 +38,9 @@ export interface LearnRepoStatus {
   baselines: Array<{ name: string; capturedAt?: string; entryCount: number }>;
   /** The last same-tree guardrail verdict, when cached. */
   lastVerdict: CachedVerdict | null;
+  /** The committed policy file, verbatim — sent to the provider ONLY under
+   *  the explicit detail toggle (it can carry custom check commands). */
+  rawPolicyText?: string;
 }
 
 /** Which lane workflows are installed (filename presence, read-only). */
@@ -113,6 +116,11 @@ export async function gatherLearnRepoStatus(cwd: string): Promise<LearnRepoStatu
     lastVerdict = null;
   }
 
+  // The ONE policy reader again (Rule 2.30): readPolicyRoot returns the raw
+  // text alongside the parsed root, so no second file read exists.
+  const policyRead = readPolicyRoot(path.join(cwd, '.dxkit', 'policy.json'));
+  const rawPolicyText = policyRead.status === 'ok' ? policyRead.text.slice(0, 20_000) : undefined;
+
   return {
     cwd,
     installed,
@@ -120,5 +128,6 @@ export async function gatherLearnRepoStatus(cwd: string): Promise<LearnRepoStatu
     policy: readPolicySummary(cwd),
     baselines: readBaselineSummaries(cwd),
     lastVerdict,
+    rawPolicyText,
   };
 }

--- a/src/learn/serve.ts
+++ b/src/learn/serve.ts
@@ -23,8 +23,11 @@ import {
   LLM_DRIVERS,
   envKeyFor,
   getDriver,
+  listModels,
   relayAsk,
+  resolveRouting,
   routeModel,
+  type ProviderModel,
 } from './drivers';
 import { markdownToHtml } from './markdown';
 
@@ -40,6 +43,12 @@ export interface ServeOptions {
   port?: number;
   /** Injectable for tests. */
   fetchFn?: typeof fetch;
+}
+
+interface ModelsBody {
+  driverId?: string;
+  browserKey?: string;
+  baseUrl?: string;
 }
 
 interface AskBody {
@@ -109,6 +118,10 @@ export async function startLearnServer(
   opts: ServeOptions = {},
 ): Promise<LearnServer> {
   const fetchFn = opts.fetchFn ?? fetch;
+  // Live model lists per driver(+base URL), fetched with the user's key so
+  // the chooser is never a stale hardcoded snapshot. Session-scoped cache;
+  // the compiled-in suggestions remain the labeled offline fallback.
+  const modelCache = new Map<string, ProviderModel[]>();
   const html = renderLearnHtml(bundle, status, {
     generatedAt: new Date().toISOString(),
     serve: true,
@@ -125,6 +138,62 @@ export async function startLearnServer(
       if (req.method === 'GET' && url.startsWith('/api/status')) {
         const detail = new URL(url, 'http://localhost').searchParams.get('detail') === '1';
         json(res, 200, buildStatusPayload(bundle, status, detail));
+        return;
+      }
+      if (req.method === 'POST' && url === '/api/models') {
+        const raw = await readBody(req);
+        if (raw === null) {
+          json(res, 413, { error: 'request body too large' });
+          return;
+        }
+        let body: ModelsBody;
+        try {
+          body = JSON.parse(raw) as ModelsBody;
+        } catch {
+          json(res, 400, { error: 'invalid JSON' });
+          return;
+        }
+        const driver = getDriver(body.driverId ?? '');
+        if (!driver) {
+          json(res, 400, { error: `unknown driver: ${body.driverId ?? '(none)'}` });
+          return;
+        }
+        const baseUrl =
+          (body.baseUrl ?? '').trim() || process.env[CUSTOM_BASE_URL_ENV] || undefined;
+        const apiKey = envKeyFor(driver) ?? (body.browserKey ?? '').trim();
+        const cacheKey = `${driver.id}|${baseUrl ?? ''}`;
+        const fallback = {
+          live: false,
+          models: driver.suggestedModels,
+          routing: driver.routing ?? null,
+          note: 'suggestions from this dxkit release — may be outdated; enter a key to load the live list from the provider',
+        };
+        if (apiKey.length === 0) {
+          json(res, 200, fallback);
+          return;
+        }
+        let models = modelCache.get(cacheKey);
+        if (!models) {
+          const listed = await listModels({ driver, apiKey, baseUrl }, fetchFn);
+          if (!listed.ok || !listed.models) {
+            json(res, 200, {
+              ...fallback,
+              note: `${fallback.note} (live fetch failed: ${listed.error})`,
+            });
+            return;
+          }
+          models = listed.models;
+          modelCache.set(cacheKey, models);
+        }
+        const sorted = [...models].sort(
+          (a, b) => (b.created ?? 0) - (a.created ?? 0) || b.id.localeCompare(a.id),
+        );
+        json(res, 200, {
+          live: true,
+          models: sorted.map((m) => m.id),
+          routing: resolveRouting(driver, models) ?? null,
+          note: 'live list from the provider, fetched with your key',
+        });
         return;
       }
       if (req.method === 'POST' && url === '/api/ask') {
@@ -172,9 +241,19 @@ export async function startLearnServer(
         // driver's fast/deep tiers; an explicit model always wins. The
         // decision is returned and shown under the answer — never silent.
         const requested = (body.model ?? '').trim();
+        const routeBaseUrl =
+          (body.baseUrl ?? '').trim() || process.env[CUSTOM_BASE_URL_ENV] || undefined;
+        const liveRouting = resolveRouting(
+          driver,
+          modelCache.get(`${driver.id}|${routeBaseUrl ?? ''}`),
+        );
         const route =
           requested.length === 0 || requested === AUTO_MODEL
-            ? routeModel(driver, question, { detail: !!body.detail, historyLength: history.length })
+            ? routeModel(driver, question, {
+                detail: !!body.detail,
+                historyLength: history.length,
+                routing: liveRouting,
+              })
             : null;
         const result = await relayAsk(
           {

--- a/src/learn/serve.ts
+++ b/src/learn/serve.ts
@@ -17,7 +17,16 @@ import type { LearnBundle } from './bundle';
 import type { LearnRepoStatus } from './repo-status';
 import { renderLearnHtml } from './render';
 import { assembleGrounding } from './grounding';
-import { CUSTOM_BASE_URL_ENV, LLM_DRIVERS, envKeyFor, getDriver, relayAsk } from './drivers';
+import {
+  AUTO_MODEL,
+  CUSTOM_BASE_URL_ENV,
+  LLM_DRIVERS,
+  envKeyFor,
+  getDriver,
+  relayAsk,
+  routeModel,
+} from './drivers';
+import { markdownToHtml } from './markdown';
 
 const MAX_BODY_BYTES = 256 * 1024;
 
@@ -84,6 +93,7 @@ export function buildStatusPayload(
       needsBaseUrl: d.endpoint === null,
       suggestedModels: d.suggestedModels,
       defaultModel: d.defaultModel,
+      routing: d.routing ?? null,
       // Presence only — the key itself never crosses to the browser.
       envKeyPresent: envKeyFor(d) !== null,
     })),
@@ -158,10 +168,18 @@ export async function startLearnServer(
               )
               .slice(-20)
           : [];
+        // "Auto" (or an empty model) routes deterministically between the
+        // driver's fast/deep tiers; an explicit model always wins. The
+        // decision is returned and shown under the answer — never silent.
+        const requested = (body.model ?? '').trim();
+        const route =
+          requested.length === 0 || requested === AUTO_MODEL
+            ? routeModel(driver, question, { detail: !!body.detail, historyLength: history.length })
+            : null;
         const result = await relayAsk(
           {
             driver,
-            model: (body.model ?? '').trim() || driver.defaultModel,
+            model: route ? route.model : requested,
             baseUrl: (body.baseUrl ?? '').trim() || process.env[CUSTOM_BASE_URL_ENV] || undefined,
             apiKey,
             system: grounding.system,
@@ -173,7 +191,18 @@ export async function startLearnServer(
           json(res, 502, { error: result.error });
           return;
         }
-        json(res, 200, { answer: result.answer, keySource: envKeyFor(driver) ? 'env' : 'browser' });
+        json(res, 200, {
+          answer: result.answer,
+          // Rendered through the ONE pinned markdown subset renderer (it
+          // escapes everything), so the page can show formatted answers
+          // without a client-side markdown engine.
+          answerHtml: markdownToHtml(result.answer ?? ''),
+          servedModel: route ? route.model : requested || driver.defaultModel,
+          routed: route !== null,
+          routeTier: route?.tier,
+          routeReason: route?.reason,
+          keySource: envKeyFor(driver) ? 'env' : 'browser',
+        });
         return;
       }
       json(res, 404, { error: 'not found' });

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -160,7 +160,9 @@ function emptyResult(): ShipInstallResult {
   return { installed: [], skipped: [], sidecars: [], notes: [] };
 }
 
-function templatesDir(): string {
+/** The ONE packaged-templates locator (also consumed by the learn bundle's
+ *  skills inventory — never a second `../templates` join elsewhere). */
+export function templatesDir(): string {
   return path.join(__dirname, '..', 'templates');
 }
 

--- a/test/learn/kb-coverage.test.ts
+++ b/test/learn/kb-coverage.test.ts
@@ -69,6 +69,25 @@ describe('KB coverage — generated class (registries reach every surface)', () 
     }
   });
 
+  it('every policy schema field is in the bundle, the page, and the grounding', () => {
+    const schema = JSON.parse(
+      fs.readFileSync(path.join(REPO_ROOT, 'policy.schema.json'), 'utf-8'),
+    ) as { properties?: Record<string, unknown> };
+    expect(bundle.policyFields.length).toBeGreaterThan(40);
+    // Every top-level schema property appears as a field path root.
+    for (const top of Object.keys(schema.properties ?? {})) {
+      expect(
+        bundle.policyFields.some((f) => f.path === top || f.path.startsWith(`${top}.`)),
+        `schema field ${top} missing from bundle`,
+      ).toBe(true);
+    }
+    for (const f of bundle.policyFields) {
+      expect(grounding.system, `grounding missing policy field ${f.path}`).toContain(f.path);
+    }
+    expect(html).toContain('Policy field reference');
+    expect(html).toContain('"k":"policy field"');
+  });
+
   it('every remediation task is in the bundle, the page, and the grounding', () => {
     expect(REMEDIATE_TASKS.length).toBeGreaterThan(3);
     for (const t of REMEDIATE_TASKS) {
@@ -149,5 +168,26 @@ describe('KB content — the previously-missing narratives exist', () => {
     expect(html).toContain('Remediation lane tasks');
     expect(html).toContain('Agent skills');
     expect(KB_EXCLUDED.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it('the admin path walks bot-token creation; lanes guide covers campaigns + budgets', () => {
+    const admin = bundle.docs.find((d) => d.slug === 'quickstart-admin')!;
+    expect(admin.markdown).toContain('Fine-grained tokens');
+    expect(admin.markdown).toContain('gh secret set DXKIT_BOT_TOKEN');
+    const lanes = bundle.docs.find((d) => d.slug === 'operating-the-lanes')!;
+    expect(lanes.markdown).toContain('maxDispatchBudget');
+    expect(lanes.markdown).toContain('Run workflow');
+    expect(grounding.system).toContain('maxDispatchBudget');
+  });
+
+  it('task detail (tier reason + verification hinge) reaches the page and grounding', () => {
+    const hinged = bundle.tasks.find((t) => t.hinge);
+    expect(hinged, 'expected at least one score-hinged task').toBeDefined();
+    expect(html).toContain('Score hinge:');
+    expect(grounding.system).toContain('score hinge');
+    for (const t of bundle.tasks) {
+      expect(t.tierWhy.length).toBeGreaterThan(0);
+      expect(['floor', 'guardrail']).toContain(t.verify);
+    }
   });
 });

--- a/test/learn/kb-coverage.test.ts
+++ b/test/learn/kb-coverage.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The KB drift net (the "how do we make sure this knowledge base doesn't
+ * drift?" answer, made mechanical):
+ *
+ *   - GENERATED class: every user-facing command, every posture knob, every
+ *     installed agent skill, and every remediation task MUST appear in the
+ *     bundle (and therefore on the page, in search, and in the assistant's
+ *     grounding source).
+ *   - REFERENCE class: every .md under docs/ is either bundled or declared
+ *     in KB_EXCLUDED with a real reason; a stale exclusion fails too.
+ *   - SYNTHETIC INJECTION: the checker itself is proven to bite (mirror of
+ *     the registry playbooks) — a new doc that skips the KB is flagged.
+ */
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  buildLearnBundle,
+  checkKbCoverage,
+  listDocsTree,
+  CURATED_DOC_SLUGS,
+  KB_EXCLUDED,
+} from '../../src/learn/bundle';
+import { assembleGrounding } from '../../src/learn/grounding';
+import { renderLearnHtml } from '../../src/learn/render';
+import { userCommands } from '../../src/discovery/commands';
+import { POSTURE_KNOBS } from '../../src/discovery/posture-knobs';
+import { REMEDIATE_TASKS } from '../../src/remediate/tasks';
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const bundle = buildLearnBundle();
+const html = renderLearnHtml(bundle, null, { serve: true });
+const grounding = assembleGrounding(bundle, null);
+
+describe('KB coverage — generated class (registries reach every surface)', () => {
+  it('every user-facing command is in the bundle, the page, and the grounding', () => {
+    for (const c of userCommands()) {
+      expect(
+        bundle.capabilities.some((x) => x.id === c.id),
+        `bundle missing command ${c.id}`,
+      ).toBe(true);
+      expect(html, `page missing command ${c.id}`).toContain(`cap-${c.id}`);
+      expect(grounding.system, `grounding missing command ${c.id}`).toContain(`- ${c.id} [`);
+    }
+  });
+
+  it('every posture knob is in the bundle and the grounding', () => {
+    for (const k of POSTURE_KNOBS) {
+      expect(
+        bundle.knobs.some((x) => x.path === k.path),
+        `knob ${k.path}`,
+      ).toBe(true);
+      expect(grounding.system).toContain(k.path);
+    }
+  });
+
+  it('every installed agent skill is in the bundle, the page, and the grounding', () => {
+    const skillsDir = path.join(REPO_ROOT, 'templates', '.claude', 'skills');
+    const onDisk = fs.readdirSync(skillsDir).sort();
+    expect(onDisk.length).toBeGreaterThan(10);
+    for (const name of onDisk) {
+      expect(
+        bundle.skills.some((s) => s.name === name),
+        `skill ${name} missing`,
+      ).toBe(true);
+      expect(html).toContain(name);
+      expect(grounding.system).toContain(name);
+    }
+  });
+
+  it('every remediation task is in the bundle, the page, and the grounding', () => {
+    expect(REMEDIATE_TASKS.length).toBeGreaterThan(3);
+    for (const t of REMEDIATE_TASKS) {
+      expect(
+        bundle.tasks.some((x) => x.id === t.id),
+        `task ${t.id} missing`,
+      ).toBe(true);
+      expect(html).toContain(t.id);
+      expect(grounding.system).toContain(t.id);
+    }
+  });
+});
+
+describe('KB coverage — reference class (docs/ tree, bundled or declared-excluded)', () => {
+  it('every doc on disk is bundled or excluded-with-reason; no stale exclusions', () => {
+    const docsOnDisk = listDocsTree(path.join(REPO_ROOT, 'docs'));
+    expect(docsOnDisk.length).toBeGreaterThan(40);
+    const result = checkKbCoverage(
+      docsOnDisk,
+      bundle.reference.map((r) => r.relPath),
+      CURATED_DOC_SLUGS,
+    );
+    expect(result.uncovered, `docs missing from the KB: ${result.uncovered.join(', ')}`).toEqual(
+      [],
+    );
+    expect(result.staleExclusions, 'KB_EXCLUDED names docs that no longer exist').toEqual([]);
+    expect(result.reasonless, 'KB_EXCLUDED entries need real reasons').toEqual([]);
+  });
+
+  it('the reference shelf is rendered and searchable', () => {
+    expect(bundle.reference.length).toBeGreaterThan(40);
+    // Spot-pin the surfaces the KB was originally missing.
+    for (const rel of [
+      'configuration/policy.md',
+      'configuration/policy-guide.md',
+      'commands/guardrail.md',
+      'commands/explore.md',
+      'commands/report.md',
+      'benchmarks.md',
+      'extension-sdk.md',
+    ]) {
+      expect(
+        bundle.reference.some((r) => r.relPath === rel),
+        `reference missing ${rel}`,
+      ).toBe(true);
+      expect(html).toContain(`ref-${rel.replace(/[^a-z0-9\s-]/gi, '').toLowerCase()}`.slice(0, 12));
+    }
+    // The search index carries reference entries.
+    expect(html).toContain('"k":"reference"');
+    expect(html).toContain('"k":"agent skill"');
+    expect(html).toContain('"k":"remediation task"');
+  });
+
+  it('the grounded slice includes the configuration reference and benchmarks overview', () => {
+    for (const rel of ['configuration/policy.md', 'benchmarks.md', 'getting-started.md']) {
+      expect(bundle.reference.find((r) => r.relPath === rel)?.grounded, rel).toBe(true);
+    }
+    expect(grounding.system).toContain('Reference: ');
+  });
+
+  it('SYNTHETIC INJECTION: the checker flags a doc that skips the KB', () => {
+    const result = checkKbCoverage(
+      ['synthetic/new-feature-guide.md'],
+      bundle.reference.map((r) => r.relPath),
+      CURATED_DOC_SLUGS,
+    );
+    expect(result.uncovered).toContain('synthetic/new-feature-guide.md');
+    // And an exclusion with a throwaway reason is itself flagged.
+    const reasonless = checkKbCoverage(['x.md'], [], [], [{ relPath: 'x.md', reason: 'n/a' }]);
+    expect(reasonless.reasonless).toContain('x.md');
+  });
+});
+
+describe('KB content — the previously-missing narratives exist', () => {
+  it('the developer path covers comment-defer, and lanes/graph/skills content is present', () => {
+    const dev = bundle.docs.find((d) => d.slug === 'quickstart-developer')!;
+    expect(dev.markdown).toContain('/dxkit defer');
+    expect(html).toContain('Remediation lane tasks');
+    expect(html).toContain('Agent skills');
+    expect(KB_EXCLUDED.length).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/test/learn/learn.test.ts
+++ b/test/learn/learn.test.ts
@@ -77,6 +77,14 @@ describe('learn page — self-contained + zero-context', () => {
     expect(html).toContain('palette-input');
     expect(html).toContain('theme-toggle');
     expect(html).toContain('search-index');
+    // Wiki mode: routed views (page-per-topic), hash router, crumbs, TOC,
+    // prev/next — with graceful no-JS fallback (views hidden only under .spa).
+    expect((html.match(/class="view"/g) ?? []).length).toBeGreaterThan(20);
+    expect(html).toContain('hashchange');
+    expect(html).toContain('id="crumbs"');
+    expect(html).toContain('id="pagenav"');
+    expect(html).toContain('id="toc"');
+    expect(html).toContain('body.spa .view');
     expect(html).not.toContain('id="apanel"');
     // No repo section without a repo.
     expect(html).not.toContain('Set up this repo');

--- a/test/learn/learn.test.ts
+++ b/test/learn/learn.test.ts
@@ -39,7 +39,7 @@ describe('learn bundle — registry-driven, cannot drift', () => {
     }
   });
 
-  it('carries every posture knob and all five curated docs with real titles', () => {
+  it('carries every posture knob and all six curated docs with real titles', () => {
     expect(bundle.knobs.length).toBe(POSTURE_KNOBS.length);
     expect(bundle.docs.map((d) => d.slug)).toEqual([
       'how-dxkit-thinks',
@@ -47,6 +47,7 @@ describe('learn bundle — registry-driven, cannot drift', () => {
       'quickstart-developer',
       'quickstart-reviewer',
       'quickstart-admin',
+      'extending-dxkit',
     ]);
     for (const d of bundle.docs) {
       expect(d.title, `${d.slug} packaging stub leaked`).not.toBe(d.slug);
@@ -58,16 +59,25 @@ describe('learn bundle — registry-driven, cannot drift', () => {
 describe('learn page — self-contained + zero-context', () => {
   const bundle = buildLearnBundle();
 
-  it('zero-repo render: full guide, no scripts, no external loads', () => {
+  it('zero-repo render: full guide, self-contained, zero external loads, no network JS', () => {
     const html = renderLearnHtml(bundle, null);
     for (const id of CORE_COMMAND_IDS) expect(html).toContain(`>${id}</span>`);
     expect(html).toContain('What dxkit verifies, and what it cannot');
     expect(html).toContain('How dxkit thinks');
-    // Self-containment: no JS at all in this increment, no remote fetches.
-    expect(html).not.toContain('<script');
-    expect(html).not.toMatch(/<(link|img|iframe)\b/);
+    // Self-containment: inline assets only — no CDN scripts, no remote
+    // styles/fonts/images, no imports. The favicon is a data: URI.
     expect(html).not.toMatch(/src=["']https?:/);
+    expect(html).not.toMatch(/<link[^>]+href=["']https?:/);
+    expect(html).not.toMatch(/<(img|iframe)\b/);
     expect(html).not.toMatch(/@import/);
+    // The STATIC page's script performs zero network requests (search,
+    // theme, copy, nav are pure client-side over embedded data).
+    expect(html).not.toMatch(/fetch\(/);
+    // Search + theme are present in both modes; the assistant is serve-only.
+    expect(html).toContain('palette-input');
+    expect(html).toContain('theme-toggle');
+    expect(html).toContain('search-index');
+    expect(html).not.toContain('id="apanel"');
     // No repo section without a repo.
     expect(html).not.toContain('Set up this repo');
   });
@@ -82,7 +92,7 @@ describe('learn page — self-contained + zero-context', () => {
     expect(result.repoMode).toBe(false);
     expect(result.outputPath).toBe(path.join(dir, 'dxkit-learn.html'));
     const html = fs.readFileSync(result.outputPath, 'utf-8');
-    expect(html).toContain('capability guide');
+    expect(html).toContain('class="mode">guide<');
     expect(html).toContain('guardrail');
   });
 });
@@ -156,18 +166,19 @@ describe('learn page — repo mode renders doctor as a read-only setup panel', (
     expect(html).toContain('18928 grandfathered findings');
   });
 
-  it('escapes repo-derived strings and stays script-free', () => {
+  it('escapes repo-derived strings at the render boundary', () => {
     const html = renderLearnHtml(bundle, syntheticStatus());
     expect(html).not.toContain('<script>alert(1)');
     expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
-    expect(html).not.toContain('<script');
   });
 
-  it('is read-only: the one write path is only ever quoted', () => {
+  it('is read-only: the one write path is only ever quoted, and static-mode JS never fetches', () => {
     const html = renderLearnHtml(bundle, syntheticStatus());
     expect(html).toContain('configure --apply');
-    // No forms, no buttons, no JS handlers anywhere on the page.
-    expect(html).not.toMatch(/<(form|button|input)\b/);
+    // No forms, no inline JS handlers; the static page's script makes zero
+    // network requests (theme/search/copy/nav only).
+    expect(html).not.toMatch(/<form\b/);
     expect(html).not.toMatch(/on(click|submit|load)=/);
+    expect(html).not.toMatch(/fetch\(/);
   });
 });

--- a/test/learn/learn.test.ts
+++ b/test/learn/learn.test.ts
@@ -39,7 +39,7 @@ describe('learn bundle — registry-driven, cannot drift', () => {
     }
   });
 
-  it('carries every posture knob and all six curated docs with real titles', () => {
+  it('carries every posture knob and all seven curated docs with real titles', () => {
     expect(bundle.knobs.length).toBe(POSTURE_KNOBS.length);
     expect(bundle.docs.map((d) => d.slug)).toEqual([
       'how-dxkit-thinks',
@@ -47,6 +47,7 @@ describe('learn bundle — registry-driven, cannot drift', () => {
       'quickstart-developer',
       'quickstart-reviewer',
       'quickstart-admin',
+      'operating-the-lanes',
       'extending-dxkit',
     ]);
     for (const d of bundle.docs) {

--- a/test/learn/markdown.test.ts
+++ b/test/learn/markdown.test.ts
@@ -49,6 +49,15 @@ describe('learn markdown renderer — the pinned subset', () => {
     expect(html).not.toContain('<a href="javascript:');
   });
 
+  it('renders pipe tables (header + separator + body), cells inline-formatted', () => {
+    const html = markdownToHtml(
+      '| Rung | You write |\n| ---- | --------- |\n| 1 | a `key` |\n| 2 | **bold** |',
+    );
+    expect(html).toContain('<table><thead><tr><th>Rung</th><th>You write</th></tr></thead>');
+    expect(html).toContain('<td>1</td><td>a <code>key</code></td>');
+    expect(html).toContain('<td><strong>bold</strong></td>');
+  });
+
   it('escapes raw HTML everywhere', () => {
     const html = markdownToHtml('<script>alert(1)</script>\n\n> a <b>quote</b>');
     expect(html).not.toContain('<script>');
@@ -73,7 +82,7 @@ describe('learn markdown renderer — the pinned subset', () => {
       const renderedHeadings = (html.match(/<h[1-4] /g) ?? []).length;
       expect(renderedHeadings, `${f}: headings dropped`).toBe(headingCount);
       expect(html, `${f}: unescaped angle bracket`).not.toMatch(
-        /<(?!\/?(h[1-4]|p|ul|ol|li|pre|code|strong|a|blockquote)\b)[a-z]/i,
+        /<(?!\/?(h[1-4]|p|ul|ol|li|pre|code|strong|a|blockquote|table|thead|tbody|tr|th|td)\b)[a-z]/i,
       );
     }
   });

--- a/test/learn/serve.test.ts
+++ b/test/learn/serve.test.ts
@@ -13,7 +13,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildLearnBundle } from '../../src/learn/bundle';
 import { renderLearnHtml } from '../../src/learn/render';
 import { assembleGrounding } from '../../src/learn/grounding';
-import { LLM_DRIVERS, relayAsk, getDriver, routeModel } from '../../src/learn/drivers';
+import {
+  LLM_DRIVERS,
+  relayAsk,
+  getDriver,
+  routeModel,
+  listModels,
+  resolveRouting,
+} from '../../src/learn/drivers';
 import { startLearnServer, buildStatusPayload } from '../../src/learn/serve';
 import type { LearnRepoStatus } from '../../src/learn/repo-status';
 
@@ -352,6 +359,106 @@ describe('render — static mode never fetches, serve mode stays self-contained'
     for (const f of fetches) expect(f.startsWith('/api/')).toBe(true);
     // Fetches with computed URLs stay same-origin too (string-concat on /api/).
     expect(html).not.toMatch(/fetch\((['"])https?:/);
+  });
+});
+
+describe('live model lists — the provider is the source of truth, suggestions are labeled fallback', () => {
+  const bundle = buildLearnBundle();
+
+  it('listModels speaks both wire formats', async () => {
+    const seen: string[] = [];
+    const fetchFn = (async (url: unknown, init: unknown) => {
+      seen.push(String(url));
+      const headers = (init as { headers: Record<string, string> }).headers;
+      if (String(url).includes('api.anthropic.com')) {
+        expect(headers['x-api-key']).toBe('your-key');
+        return new Response(
+          JSON.stringify({ data: [{ id: 'claude-future-9', created_at: '2027-01-01T00:00:00Z' }] }),
+          { status: 200 },
+        );
+      }
+      expect(headers.authorization).toBe('Bearer your-key');
+      return new Response(JSON.stringify({ data: [{ id: 'gpt-9.9', created: 1800000000 }] }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+    const a = await listModels({ driver: getDriver('anthropic')!, apiKey: 'your-key' }, fetchFn);
+    expect(a.ok).toBe(true);
+    expect(a.models![0].id).toBe('claude-future-9');
+    const o = await listModels({ driver: getDriver('openai')!, apiKey: 'your-key' }, fetchFn);
+    expect(o.ok).toBe(true);
+    expect(o.models![0].id).toBe('gpt-9.9');
+    expect(seen[0]).toContain('/v1/models');
+    expect(seen[1]).toBe('https://api.openai.com/v1/models');
+  });
+
+  it('resolveRouting picks the NEWEST flagship/small tier from a live list (never stale)', () => {
+    const openai = getDriver('openai')!;
+    const live = resolveRouting(openai, [
+      { id: 'gpt-5.1', created: 100 },
+      { id: 'gpt-5.6', created: 500 },
+      { id: 'gpt-5.6-mini', created: 500 },
+      { id: 'gpt-5.6-audio-preview', created: 600 },
+      { id: 'gpt-5-mini', created: 50 },
+    ]);
+    expect(live).toEqual({ fast: 'gpt-5.6-mini', deep: 'gpt-5.6' });
+    // Empty/absent list → compiled-in fallback tiers.
+    expect(resolveRouting(openai, undefined)).toEqual(openai.routing);
+    // Pattern miss on a weird list → fallback per tier.
+    expect(resolveRouting(openai, [{ id: 'whisper-1' }])).toEqual(openai.routing);
+  });
+
+  it('/api/models: no key → labeled fallback suggestions; with key → live list + resolved routing', async () => {
+    const fetchFn = (async (url: unknown) =>
+      String(url).endsWith('/models')
+        ? new Response(
+            JSON.stringify({
+              data: [
+                { id: 'gpt-5.6', created: 500 },
+                { id: 'gpt-5.6-mini', created: 500 },
+              ],
+            }),
+            { status: 200 },
+          )
+        : new Response(JSON.stringify({ choices: [{ message: { content: 'ok' } }] }), {
+            status: 200,
+          })) as typeof fetch;
+    const s = await startLearnServer(bundle, null, { fetchFn });
+    try {
+      const noKey = (await (
+        await fetch(`${s.url}api/models`, {
+          method: 'POST',
+          body: JSON.stringify({ driverId: 'openai' }),
+        })
+      ).json()) as { live: boolean; models: string[]; note: string };
+      expect(noKey.live).toBe(false);
+      expect(noKey.note).toContain('may be outdated');
+      const live = (await (
+        await fetch(`${s.url}api/models`, {
+          method: 'POST',
+          body: JSON.stringify({ driverId: 'openai', browserKey: 'your-key' }),
+        })
+      ).json()) as { live: boolean; models: string[]; routing: { fast: string; deep: string } };
+      expect(live.live).toBe(true);
+      expect(live.models).toContain('gpt-5.6');
+      expect(live.routing).toEqual({ fast: 'gpt-5.6-mini', deep: 'gpt-5.6' });
+      // Auto asks now route on the LIVE tiers (cache shared with /api/ask).
+      const ask = (await (
+        await fetch(`${s.url}api/ask`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            driverId: 'openai',
+            model: 'auto',
+            question: 'what is a baseline?',
+            browserKey: 'your-key',
+          }),
+        })
+      ).json()) as { servedModel: string };
+      expect(ask.servedModel).toBe('gpt-5.6-mini');
+    } finally {
+      await s.close();
+    }
   });
 });
 

--- a/test/learn/serve.test.ts
+++ b/test/learn/serve.test.ts
@@ -13,7 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildLearnBundle } from '../../src/learn/bundle';
 import { renderLearnHtml } from '../../src/learn/render';
 import { assembleGrounding } from '../../src/learn/grounding';
-import { LLM_DRIVERS, relayAsk, getDriver } from '../../src/learn/drivers';
+import { LLM_DRIVERS, relayAsk, getDriver, routeModel } from '../../src/learn/drivers';
 import { startLearnServer, buildStatusPayload } from '../../src/learn/serve';
 import type { LearnRepoStatus } from '../../src/learn/repo-status';
 
@@ -235,10 +235,12 @@ describe('serve — localhost only, key hygiene, graceful no-key degrade', () =>
       const addr = s.server.address();
       expect(typeof addr === 'object' && addr ? addr.address : '').toBe('127.0.0.1');
       const html = await (await fetch(s.url)).text();
-      expect(html).toContain('Ask the assistant');
+      expect(html).toContain('dxkit assistant');
+      expect(html).toContain('assistant-panel');
       expect(html).toContain('<script>');
       expect(html).not.toMatch(/src=["']https?:/);
-      expect(html).not.toMatch(/<(link|img|iframe)\b/);
+      expect(html).not.toMatch(/<link[^>]+href=["']https?:/);
+      expect(html).not.toMatch(/<(img|iframe)\b/);
     } finally {
       await s.close();
     }
@@ -328,20 +330,117 @@ describe('serve — localhost only, key hygiene, graceful no-key degrade', () =>
   });
 });
 
-describe('render — file mode stays script-free, serve mode stays self-contained', () => {
+describe('render — static mode never fetches, serve mode stays self-contained', () => {
   const bundle = buildLearnBundle();
 
-  it('static file mode has no script even with serve-capable code present', () => {
+  it('static file mode has no assistant and its JS makes no network requests', () => {
     const html = renderLearnHtml(bundle, null, {});
-    expect(html).not.toContain('<script');
-    expect(html).not.toContain('Ask the assistant');
+    expect(html).not.toContain('id="apanel"');
+    expect(html).not.toMatch(/fetch\(/);
+    expect(html).toContain('palette-input');
   });
 
   it('serve mode adds the panel + script but still no external loads', () => {
     const html = renderLearnHtml(bundle, null, { serve: true });
-    expect(html).toContain('Ask the assistant');
+    expect(html).toContain('dxkit assistant');
     expect(html).toContain('bring-your-own-key');
     expect(html).not.toMatch(/src=["']https?:/);
     expect(html).not.toMatch(/@import/);
+    // The serve page's JS talks ONLY to same-origin /api/* paths.
+    const fetches = [...html.matchAll(/fetch\((['"])([^'"]+)\1/g)].map((m) => m[2]);
+    expect(fetches.length).toBeGreaterThan(0);
+    for (const f of fetches) expect(f.startsWith('/api/')).toBe(true);
+    // Fetches with computed URLs stay same-origin too (string-concat on /api/).
+    expect(html).not.toMatch(/fetch\((['"])https?:/);
+  });
+});
+
+describe('auto model routing — deterministic, disclosed', () => {
+  const bundle = buildLearnBundle();
+  const anthropic = getDriver('anthropic')!;
+
+  it('routes quick lookups to the fast tier and reasoning to the deep tier', () => {
+    expect(routeModel(anthropic, 'what is a baseline?')).toMatchObject({
+      model: 'claude-haiku-4-5',
+      tier: 'fast',
+    });
+    expect(routeModel(anthropic, 'why is my PR blocked and how do I fix it?')).toMatchObject({
+      model: 'claude-opus-5',
+      tier: 'deep',
+      reason: 'reasoning-shaped question',
+    });
+    expect(routeModel(anthropic, 'list gates', { detail: true }).tier).toBe('deep');
+    expect(routeModel(anthropic, 'and then?', { historyLength: 8 }).tier).toBe('deep');
+    expect(routeModel(getDriver('custom')!, 'anything').reason).toContain('single-model');
+  });
+
+  it('serve: model "auto" routes and the response discloses the decision', async () => {
+    let seenModel = '';
+    const fetchFn = (async (_url: unknown, init: unknown) => {
+      seenModel = JSON.parse(String((init as RequestInit).body)).model;
+      return new Response(
+        JSON.stringify({ stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok `x`' }] }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+    const s = await startLearnServer(bundle, null, { fetchFn });
+    try {
+      const res = await fetch(`${s.url}api/ask`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          driverId: 'anthropic',
+          model: 'auto',
+          question: 'what is a baseline?',
+          browserKey: 'your-key',
+        }),
+      });
+      const body = (await res.json()) as {
+        routed: boolean;
+        servedModel: string;
+        routeTier: string;
+        routeReason: string;
+        answerHtml: string;
+      };
+      expect(seenModel).toBe('claude-haiku-4-5');
+      expect(body.routed).toBe(true);
+      expect(body.servedModel).toBe('claude-haiku-4-5');
+      expect(body.routeTier).toBe('fast');
+      expect(body.routeReason.length).toBeGreaterThan(0);
+      // Answers come back rendered by the ONE pinned markdown renderer.
+      expect(body.answerHtml).toContain('<code>x</code>');
+    } finally {
+      await s.close();
+    }
+  });
+
+  it('an explicit model always wins over routing', async () => {
+    let seenModel = '';
+    const fetchFn = (async (_url: unknown, init: unknown) => {
+      seenModel = JSON.parse(String((init as RequestInit).body)).model;
+      return new Response(
+        JSON.stringify({ stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }] }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+    const s = await startLearnServer(bundle, null, { fetchFn });
+    try {
+      const res = await fetch(`${s.url}api/ask`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          driverId: 'anthropic',
+          model: 'claude-sonnet-5',
+          question: 'why why why?',
+          browserKey: 'your-key',
+        }),
+      });
+      const body = (await res.json()) as { routed: boolean; servedModel: string };
+      expect(seenModel).toBe('claude-sonnet-5');
+      expect(body.routed).toBe(false);
+      expect(body.servedModel).toBe('claude-sonnet-5');
+    } finally {
+      await s.close();
+    }
   });
 });


### PR DESCRIPTION
Part of the 4.3.6 release train (#240). User-directed expansion during the acceptance review.

- **Product UI**: design system (light/dark, topbar, refined cards), Ctrl+K search palette over everything, copy buttons, assistant promoted to a dedicated side panel (chat bubbles, Enter-to-send, markdown answers via the ONE server-side renderer). Static page stays fully self-contained (zero external requests, no network JS — pinned); serve JS is same-origin-only (pinned).
- **Auto model routing**: "Auto" default routes per question between fast (claude-haiku-4-5 / gpt-5-mini) and deep (claude-opus-5 / gpt-5.1) tiers — deterministic, pinned by test, and DISCLOSED under every answer (served model + reason). Explicit model always wins. Suggestion lists widened.
- **Knowledge base completeness**: the bundle now ships the ENTIRE docs/ tree (48 reference pages: command/configuration/policy reference, 7 benchmark chapters, extension SDK), the 25 installed agent skills, and the 5 remediation tasks — closing the policy/workflows/remediate/graph/reports/skills/benchmarks gap. New curated extending-dxkit doc; developer quickstart now covers /dxkit defer PR comments. Markdown renderer gains pipe tables.
- **Drift net**: test/learn/kb-coverage.test.ts — every command, knob, skill, task, and doc must reach the bundle/page/grounding, or be declared-excluded with a reason (synthetic-injection-guarded).
- Dogfood note: the self-guardrail BLOCKED the first commit (render.ts crossed the large-file threshold) — fixed by extracting page-css.ts + page-js.ts, the designed remedy.
- Local sweep ALL GREEN (354 files / 5308 tests, self-guardrail PASSED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)