### PR TITLE
WP17: tier-1 repo profile — graph shape, debt shape, ranked actions in learn

### DIFF
--- a/src/explore/queries.ts
+++ b/src/explore/queries.ts
@@ -235,6 +235,79 @@ export function hotFilesQuery(graph: Graph, limit = 20): HotFileResult[] {
   return results.slice(0, limit);
 }
 
+// ─── Whole-graph profile (learn repo intelligence, tier 1) ───────────────────
+
+/** One hub row in a `graphProfile` result: a callable symbol many other
+ *  symbols call into. */
+export interface GraphProfileHub {
+  label: string;
+  sourceFile: string;
+  callsIn: number;
+  callsOut: number;
+}
+
+/** Bounded whole-graph summary for profile-style consumers (the learn
+ *  page's repo grounding). Counts + a small hub list — never the graph
+ *  itself. */
+export interface GraphProfile {
+  /** Callable symbols (function + method nodes). */
+  functionCount: number;
+  /** Distinct source files any node was declared in. */
+  fileCount: number;
+  /** `calls` edges in the graph. */
+  callEdgeCount: number;
+  /** Top callable symbols by call fan-in, descending. */
+  hubs: GraphProfileHub[];
+}
+
+/**
+ * Whole-graph profile: counts plus the top-N hub functions by call
+ * fan-in. The learn assistant's "what shape is this codebase?" answer —
+ * deliberately bounded (top-N, counts only) so a profile consumer never
+ * walks the graph itself (Rule 12).
+ */
+export function graphProfile(graph: Graph, hubLimit = 8): GraphProfile {
+  const files = new Set<string>();
+  let functionCount = 0;
+  let callEdgeCount = 0;
+  const callable: Array<{ node: GraphNode; callsIn: number; callsOut: number }> = [];
+
+  for (const node of graph.nodes) {
+    if (node.sourceFile) files.add(node.sourceFile);
+    for (const e of graph.edgesFromNode.get(node.id) ?? []) {
+      if (e.relation === 'calls') callEdgeCount++;
+    }
+    if (node.kind !== 'function' && node.kind !== 'method') continue;
+    functionCount++;
+    let callsIn = 0;
+    let callsOut = 0;
+    for (const e of graph.edgesToNode.get(node.id) ?? []) {
+      if (e.relation === 'calls') callsIn++;
+    }
+    for (const e of graph.edgesFromNode.get(node.id) ?? []) {
+      if (e.relation === 'calls') callsOut++;
+    }
+    callable.push({ node, callsIn, callsOut });
+  }
+
+  callable.sort((a, b) => {
+    if (b.callsIn !== a.callsIn) return b.callsIn - a.callsIn;
+    return a.node.label.localeCompare(b.node.label);
+  });
+
+  return {
+    functionCount,
+    fileCount: files.size,
+    callEdgeCount,
+    hubs: callable.slice(0, hubLimit).map((c) => ({
+      label: c.node.label,
+      sourceFile: c.node.sourceFile,
+      callsIn: c.callsIn,
+      callsOut: c.callsOut,
+    })),
+  };
+}
+
 /**
  * One row of `vyuh-dxkit explore communities` output. A community is
  * a Louvain-clustered grouping of nodes; the dominant source dir +

--- a/src/learn/grounding.ts
+++ b/src/learn/grounding.ts
@@ -123,6 +123,71 @@ export function assembleGrounding(
         );
       }
     }
+    // Repo profile (tier-1 repo intelligence). Every derived fact carries
+    // its freshness stamp; every absent artifact carries the exact enable
+    // command — the assistant points, never pretends. Counts and
+    // product-phrased strings sit in the summary tier; hub SYMBOL NAMES +
+    // file paths are repo content and stay behind the detail toggle.
+    const profile = status.profile;
+    if (profile) {
+      if (profile.graph) {
+        const g = profile.graph;
+        s.push(
+          `code graph: ${g.functionCount} functions across ${g.fileCount} files, ${g.callEdgeCount} call edges${g.refreshedAt ? `, refreshed ${g.refreshedAt.slice(0, 10)}` : ''}${g.stale ? ` — STALE (older than two weeks); refresh with 'vyuh-dxkit describe'` : ''}`,
+        );
+        if (detail && g.hubs.length > 0) {
+          s.push(`  top hub functions by callers:`);
+          for (const h of g.hubs) {
+            s.push(
+              `    ${h.label} (${h.sourceFile}): ${h.callsIn} callers, ${h.callsOut} calls out`,
+            );
+          }
+        }
+      } else {
+        s.push(
+          `code graph: not set up — enable with 'vyuh-dxkit describe' (one-off) or the graph.refresh policy field (kept fresh in CI); point-query answers need it`,
+        );
+      }
+      if (profile.debt) {
+        const d = profile.debt;
+        const kinds = Object.entries(d.byKind)
+          .sort((a, b) => b[1] - a[1])
+          .map(([k, n]) => `${k}=${n}`)
+          .join(', ');
+        const sevs = Object.entries(d.bySeverity)
+          .sort((a, b) => b[1] - a[1])
+          .map(([k, n]) => `${k}=${n}`)
+          .join(', ');
+        s.push(
+          `grandfathered debt shape: ${d.total} findings by kind (${kinds}); by severity (${sevs})`,
+        );
+        if (d.floorFailing.length > 0) {
+          s.push(
+            `  failing floor checks (pre-existing, grandfathered): ${d.floorFailing.map((c) => `${c.pack}: ${c.label}`).join('; ')}`,
+          );
+        }
+        s.push(`  full prioritized inventory: 'vyuh-dxkit debt'`);
+      } else {
+        s.push(
+          `grandfathered debt shape: no committed baseline to read — repos in ref-based mode gate against a git ref instead; 'vyuh-dxkit baseline create' writes one`,
+        );
+      }
+      if (profile.health) {
+        const h = profile.health;
+        s.push(
+          `health report${h.analyzedAt ? ` of ${h.analyzedAt.slice(0, 10)}` : ''}: overall ${h.overallScore}/100 (${h.rating}) — re-run 'vyuh-dxkit health' for current`,
+        );
+        for (const a of h.topActions) {
+          s.push(
+            `  top action [${a.dimension}]${a.upliftIfFixed ? ` (+${a.upliftIfFixed} if fixed)` : ''}: ${a.reason}`,
+          );
+        }
+      } else {
+        s.push(
+          `no health report artifact — run 'vyuh-dxkit health' to get ranked improvement actions`,
+        );
+      }
+    }
     if (status.doctor) {
       const failing = status.doctor.checks.filter((c) => !c.ok && !c.advisory);
       s.push(
@@ -158,8 +223,8 @@ export function assembleGrounding(
     parts.push(`## This repo (live status)\n${s.join('\n')}`);
     disclosure.push(
       detail
-        ? `This repo's status IN DETAIL: the full committed policy.json, baseline counts, the last verdict, each failing doctor check with its remedy, and blocking-finding fingerprints. (Detail toggle is ON.)`
-        : `This repo's status as SUMMARIES: policy summary, baseline entry counts, the last verdict word, doctor pass/fail counts with failing-check LABELS, and the installed dxkit workflow list (names, triggers, schedules). No file paths, no finding contents, no remedies. (Turn on the detail toggle to include remedies, recommendations, and the full policy file.)`,
+        ? `This repo's status IN DETAIL: the full committed policy.json, baseline counts, the last verdict, each failing doctor check with its remedy, blocking-finding fingerprints, and the repo profile including hub function names with their file paths. (Detail toggle is ON.)`
+        : `This repo's status as SUMMARIES: policy summary, baseline entry counts, the last verdict word, doctor pass/fail counts with failing-check LABELS, the installed dxkit workflow list (names, triggers, schedules), and the repo profile as COUNTS with freshness dates (graph size, debt by kind and severity, health score with its ranked action reasons). No file paths, no symbol names, no finding contents, no remedies. (Turn on the detail toggle to include remedies, recommendations, hub function names, and the full policy file.)`,
     );
   } else {
     disclosure.push(`No repo data at all — this is the zero-context guide.`);

--- a/src/learn/render.ts
+++ b/src/learn/render.ts
@@ -239,9 +239,14 @@ function starterChips(hasRepo: boolean): string {
     'What will the remediation lane cost us, and how is spend capped?',
     'The gate blocked my PR. What are my options?',
   ];
+  // Chips only promise what the current tier answers (tier-1 profile:
+  // debt shape, ranked actions, graph freshness — all artifact reads).
   const repo = [
     'What is set up in this repo, and what is missing?',
     'What does our policy enforce right now?',
+    'What does our debt look like?',
+    'What should we improve first?',
+    'Is the code graph set up and fresh here?',
   ];
   const chips = hasRepo ? [...repo, ...shared] : shared;
   return `<div class="chips" id="chips">${chips

--- a/src/learn/repo-status.ts
+++ b/src/learn/repo-status.ts
@@ -19,7 +19,10 @@ import { runDoctor, type DoctorReport } from '../doctor';
 import { readVerdictForTree, type CachedVerdict } from '../baseline/verdict-cache';
 import { readPolicyObjectSafe, readPolicyRoot } from '../baseline/policy-text';
 import { readBaselineFile } from '../baseline/baseline-file';
+import { failingFloorDebt } from '../baseline/floor-debt';
 import { collectJobs } from '../jobs-cli';
+import { tryLoadGraph, GRAPH_REPORT_PATH } from '../explore/load';
+import { graphProfile, type GraphProfileHub } from '../explore/queries';
 
 export interface LearnRepoStatus {
   cwd: string;
@@ -53,7 +56,57 @@ export interface LearnRepoStatus {
   /** The committed policy file, verbatim — sent to the provider ONLY under
    *  the explicit detail toggle (it can carry custom check commands). */
   rawPolicyText?: string;
+  /** The bounded repo profile (tier-1 repo intelligence): cheap artifact
+   *  reads with freshness stamps, computed once at gather time. Each field
+   *  is null when its artifact is absent — the renderer/grounding then
+   *  carries the exact enable command instead (never silence). */
+  profile: LearnRepoProfile;
 }
+
+/** Tier-1 repo profile. Everything here is an ARTIFACT read (graph.json,
+ *  the committed baseline, the newest health report) — learn never runs an
+ *  analyzer (serve start stays fast and strictly read-only). */
+export interface LearnRepoProfile {
+  /** Code-graph shape + freshness. Null = graph not set up. */
+  graph: {
+    functionCount: number;
+    fileCount: number;
+    callEdgeCount: number;
+    /** Top hub functions by call fan-in. Symbol names + file paths are
+     *  repo content: grounding sends them only under the detail toggle. */
+    hubs: GraphProfileHub[];
+    /** Artifact mtime, ISO. Absent when unreadable. */
+    refreshedAt?: string;
+    /** Older than STALE_GRAPH_DAYS — the grounding states the refresh
+     *  command alongside the numbers. */
+    stale: boolean;
+  } | null;
+  /** Grandfathered-debt shape from the committed baseline(s) plus the
+   *  failing floor checks. Null = no baseline. */
+  debt: {
+    total: number;
+    byKind: Record<string, number>;
+    /** Counts by observed severity; entries without one land in
+     *  'unrated' (pre-4.2 baselines disclose the fallback). */
+    bySeverity: Record<string, number>;
+    /** Failing floor checks (pack + label only — product-phrased). */
+    floorFailing: Array<{ pack: string; label: string }>;
+  } | null;
+  /** The newest committed health report's headline + ranked actions.
+   *  Null = no health report artifact. */
+  health: {
+    overallScore: number;
+    rating: string;
+    /** The report's own timestamp — always stated next to derived facts. */
+    analyzedAt?: string;
+    /** Best action per dimension, ranked by uplift, capped. Reasons are
+     *  product-phrased scoring strings (same class as doctor labels). */
+    topActions: Array<{ dimension: string; reason: string; upliftIfFixed?: number }>;
+  } | null;
+}
+
+/** A graph artifact older than this reads as stale (design 2026-08-03). */
+const STALE_GRAPH_DAYS = 14;
 
 /** Which lane workflows are installed (filename presence, read-only). */
 function installedLanes(cwd: string): string[] {
@@ -84,25 +137,112 @@ function readPolicySummary(cwd: string): LearnRepoStatus['policy'] {
   };
 }
 
-function readBaselineSummaries(cwd: string): LearnRepoStatus['baselines'] {
+/** One pass over the committed baselines yields BOTH the per-file
+ *  summaries and the aggregate debt shape (no double read). */
+function readBaselines(cwd: string): {
+  summaries: LearnRepoStatus['baselines'];
+  debt: LearnRepoProfile['debt'];
+} {
   const dir = path.join(cwd, '.dxkit', 'baselines');
+  const summaries: LearnRepoStatus['baselines'] = [];
+  const byKind: Record<string, number> = {};
+  const bySeverity: Record<string, number> = {};
+  const floorFailing: Array<{ pack: string; label: string }> = [];
+  let total = 0;
+  let anyRead = false;
   try {
-    return fs
-      .readdirSync(dir)
-      .filter((f) => f.endsWith('.json'))
-      .map((f) => {
-        const name = f.replace(/\.json$/, '');
-        try {
-          // The one baseline reader (schema-validating) — never a second parse.
-          const file = readBaselineFile(path.join(dir, f));
-          return { name, capturedAt: file.createdAt, entryCount: file.findings.length };
-        } catch {
-          // Unreadable / other-schema file: shown as present with no detail.
-          return { name, entryCount: 0 };
+    for (const f of fs.readdirSync(dir).filter((x) => x.endsWith('.json'))) {
+      const name = f.replace(/\.json$/, '');
+      try {
+        // The one baseline reader (schema-validating) — never a second parse.
+        const file = readBaselineFile(path.join(dir, f));
+        summaries.push({ name, capturedAt: file.createdAt, entryCount: file.findings.length });
+        anyRead = true;
+        total += file.findings.length;
+        for (const entry of file.findings) {
+          byKind[entry.kind] = (byKind[entry.kind] ?? 0) + 1;
+          const sev = 'severity' in entry && entry.severity ? entry.severity : 'unrated';
+          bySeverity[sev] = (bySeverity[sev] ?? 0) + 1;
         }
-      });
+        if (file.floorDebt) {
+          for (const c of failingFloorDebt(file.floorDebt)) {
+            floorFailing.push({ pack: c.pack, label: c.label });
+          }
+        }
+      } catch {
+        // Unreadable / other-schema file: shown as present with no detail.
+        summaries.push({ name, entryCount: 0 });
+      }
+    }
   } catch {
-    return [];
+    return { summaries: [], debt: null };
+  }
+  return {
+    summaries,
+    debt: anyRead ? { total, byKind, bySeverity, floorFailing } : null,
+  };
+}
+
+/** Graph profile from the committed artifact via the canonical loader +
+ *  query (Rule 12). Null when the graph is not set up. */
+function readGraphProfile(cwd: string): LearnRepoProfile['graph'] {
+  const graph = tryLoadGraph(cwd);
+  if (!graph) return null;
+  const p = graphProfile(graph);
+  let refreshedAt: string | undefined;
+  let stale = false;
+  try {
+    const mtime = fs.statSync(path.join(cwd, GRAPH_REPORT_PATH)).mtime;
+    refreshedAt = mtime.toISOString();
+    stale = Date.now() - mtime.getTime() > STALE_GRAPH_DAYS * 24 * 60 * 60 * 1000;
+  } catch {
+    // Artifact readable via the loader but unstattable: no stamp, not stale.
+  }
+  return { ...p, ...(refreshedAt ? { refreshedAt } : {}), stale };
+}
+
+/** Headline + ranked actions from the NEWEST committed health report.
+ *  First reader of this artifact; date-named files sort lexically so the
+ *  newest is the last name. Fail-open: any shape surprise yields null. */
+function readHealthSummary(cwd: string): LearnRepoProfile['health'] {
+  const dir = path.join(cwd, '.dxkit', 'reports');
+  try {
+    const newest = fs
+      .readdirSync(dir)
+      .filter((f) => /^health-audit-\d{4}-\d{2}-\d{2}-detailed\.json$/.test(f))
+      .sort()
+      .pop();
+    if (!newest) return null;
+    const raw = JSON.parse(fs.readFileSync(path.join(dir, newest), 'utf-8')) as {
+      analyzedAt?: string;
+      summary?: { overallScore?: number; rating?: string };
+      dimensions?: Record<
+        string,
+        { topActions?: Array<{ reason?: string; upliftIfFixed?: number }> }
+      >;
+    };
+    if (typeof raw.summary?.overallScore !== 'number' || typeof raw.summary.rating !== 'string') {
+      return null;
+    }
+    const topActions: Array<{ dimension: string; reason: string; upliftIfFixed?: number }> = [];
+    for (const [dimension, dim] of Object.entries(raw.dimensions ?? {})) {
+      const best = dim.topActions?.[0];
+      if (!best || typeof best.reason !== 'string') continue;
+      topActions.push({
+        dimension,
+        reason: best.reason,
+        ...(typeof best.upliftIfFixed === 'number' ? { upliftIfFixed: best.upliftIfFixed } : {}),
+      });
+    }
+    topActions.sort((a, b) => (b.upliftIfFixed ?? 0) - (a.upliftIfFixed ?? 0));
+    return {
+      overallScore: raw.summary.overallScore,
+      rating: raw.summary.rating,
+      ...(typeof raw.analyzedAt === 'string' ? { analyzedAt: raw.analyzedAt } : {}),
+      topActions: topActions.slice(0, 6),
+    };
+  } catch {
+    return null;
   }
 }
 
@@ -146,14 +286,21 @@ export async function gatherLearnRepoStatus(cwd: string): Promise<LearnRepoStatu
     jobs = [];
   }
 
+  const { summaries, debt } = readBaselines(cwd);
+
   return {
     cwd,
     installed,
     doctor,
     policy: readPolicySummary(cwd),
-    baselines: readBaselineSummaries(cwd),
+    baselines: summaries,
     lastVerdict,
     jobs,
     rawPolicyText,
+    profile: {
+      graph: readGraphProfile(cwd),
+      debt,
+      health: readHealthSummary(cwd),
+    },
   };
 }

--- a/src/learn/showcase.ts
+++ b/src/learn/showcase.ts
@@ -153,7 +153,20 @@ export interface RepoHomeStatus {
     ranAt: string;
   } | null;
   jobs?: Array<{ name: string; nextRunUtc?: string }>;
+  /** Tier-1 repo profile projection (repo-status.ts owns the reads). */
+  profile?: {
+    graph: {
+      functionCount: number;
+      fileCount: number;
+      refreshedAt?: string;
+      stale: boolean;
+    } | null;
+    debt: { bySeverity: Record<string, number> } | null;
+  };
 }
+
+/** Canonical severity display order for the debt shape. */
+const SEVERITY_ORDER = ['critical', 'high', 'medium', 'low', 'unrated'];
 
 function esc(s: string): string {
   return s
@@ -186,10 +199,14 @@ export function renderRepoHome(status: RepoHomeStatus, opts: { serve: boolean })
     ? `<div class="stat"><div class="stat-n ${verdictWord === 'PASSED' ? 'ok' : 'bad'}">${verdictWord}</div><div class="stat-s">last guardrail verdict (${esc(v.ranAt.slice(0, 10))})${v.blockingCount ? ` · ${v.blockingCount} blocking` : ''}${v.warningCount ? ` · ${v.warningCount} warnings` : ''}</div></div>`
     : `<div class="stat"><div class="stat-n">—</div><div class="stat-s">no cached verdict yet · run <code>vyuh-dxkit guardrail check</code></div></div>`;
 
-  // Tile 2: the baseline.
+  // Tile 2: the baseline, with the debt's severity shape when known.
   const b = status.baselines[0];
+  const bySev = status.profile?.debt?.bySeverity ?? {};
+  const sevShape = SEVERITY_ORDER.filter((k) => (bySev[k] ?? 0) > 0)
+    .map((k) => `${bySev[k]} ${k}`)
+    .join(' · ');
   const baselineTile = b
-    ? `<div class="stat"><div class="stat-n">${b.entryCount}</div><div class="stat-s">grandfathered findings in baseline <code>${esc(b.name)}</code>${b.capturedAt ? `, captured ${esc(b.capturedAt.slice(0, 10))}` : ''}</div></div>`
+    ? `<div class="stat"><div class="stat-n">${b.entryCount}</div><div class="stat-s">grandfathered findings in baseline <code>${esc(b.name)}</code>${b.capturedAt ? `, captured ${esc(b.capturedAt.slice(0, 10))}` : ''}${sevShape ? ` · ${esc(sevShape)}` : ''}</div></div>`
     : `<div class="stat"><div class="stat-n">—</div><div class="stat-s">no committed baseline · <code>vyuh-dxkit baseline create</code> (or the refresh lane)</div></div>`;
 
   // Tile 3: automation.
@@ -200,7 +217,13 @@ export function renderRepoHome(status: RepoHomeStatus, opts: { serve: boolean })
     .sort()[0];
   const autoTile = `<div class="stat"><div class="stat-n">${jobs.length}</div><div class="stat-s">dxkit workflows installed${nextRun ? ` · next scheduled run ${esc(nextRun)} UTC` : ''}</div></div>`;
 
-  // Tile 4: setup health (advisory items are advice, not gaps).
+  // Tile 4: the map (tier-1 profile; freshness always stated).
+  const g = status.profile?.graph;
+  const graphTile = g
+    ? `<div class="stat"><div class="stat-n">${g.functionCount.toLocaleString('en-US')}</div><div class="stat-s">functions in the code graph, ${g.fileCount.toLocaleString('en-US')} files${g.refreshedAt ? ` · refreshed ${esc(g.refreshedAt.slice(0, 10))}` : ''}${g.stale ? ` · STALE — <code>vyuh-dxkit describe</code>` : ''}</div></div>`
+    : `<div class="stat"><div class="stat-n">—</div><div class="stat-s">code graph not set up · <code>vyuh-dxkit describe</code></div></div>`;
+
+  // Tile 5: setup health (advisory items are advice, not gaps).
   const failing = (status.doctor?.checks ?? []).filter((c) => !c.ok && !c.advisory);
   const setupTile =
     failing.length === 0
@@ -233,7 +256,7 @@ export function renderRepoHome(status: RepoHomeStatus, opts: { serve: boolean })
       </div>
       ${notInstalled}
     </div>
-    <div class="stats">${verdictTile}${baselineTile}${autoTile}${setupTile}</div>
+    <div class="stats">${verdictTile}${baselineTile}${autoTile}${graphTile}${setupTile}</div>
     ${attention}</section>`;
 }
 

--- a/test/explore/queries.test.ts
+++ b/test/explore/queries.test.ts
@@ -22,6 +22,7 @@ import {
   featureQuery,
   fileSummaryQuery,
   findingContextQuery,
+  graphProfile,
   hotFilesQuery,
   nodesInFile,
 } from '../../src/explore/queries';
@@ -622,5 +623,31 @@ describe('findingContextQuery', () => {
     it('returns undefined for a file absent from the graph', () => {
       expect(enclosingSymbolFor(FC, 'src/nowhere.ts', 12)).toBeUndefined();
     });
+  });
+});
+
+describe('graphProfile', () => {
+  it('counts callables/files/call-edges and ranks hubs by fan-in', () => {
+    const p = graphProfile(G);
+    expect(p.functionCount).toBe(3);
+    expect(p.fileCount).toBe(3);
+    expect(p.callEdgeCount).toBe(3);
+    // logger has 2 callers, helper 1, main 0 — descending, label tiebreak.
+    expect(p.hubs.map((h) => h.label)).toEqual(['logger()', 'helper()', 'main()']);
+    expect(p.hubs[0]).toEqual({
+      label: 'logger()',
+      sourceFile: 'src/c.ts',
+      callsIn: 2,
+      callsOut: 0,
+    });
+    expect(p.hubs[1].callsOut).toBe(1); // helper -> logger
+  });
+
+  it('honors hubLimit and excludes module/class nodes from callables', () => {
+    const p = graphProfile(G, 1);
+    expect(p.hubs).toHaveLength(1);
+    expect(p.hubs[0].label).toBe('logger()');
+    // Module nodes counted in files but never as functions/hubs.
+    expect(p.functionCount).toBe(3);
   });
 });

--- a/test/learn/learn.test.ts
+++ b/test/learn/learn.test.ts
@@ -170,6 +170,23 @@ describe('learn page — repo mode renders doctor as a read-only setup panel', (
           dispatchable: false,
         },
       ],
+      profile: {
+        graph: {
+          functionCount: 2253,
+          fileCount: 310,
+          callEdgeCount: 9800,
+          hubs: [],
+          refreshedAt: '2026-08-01T06:00:00.000Z',
+          stale: false,
+        },
+        debt: {
+          total: 18928,
+          byKind: { code: 18925, secret: 3 },
+          bySeverity: { high: 3, medium: 68, unrated: 18857 },
+          floorFailing: [],
+        },
+        health: null,
+      },
     };
   }
 
@@ -180,6 +197,10 @@ describe('learn page — repo mode renders doctor as a read-only setup panel', (
     expect(repo.slice(firstView, firstView + 120)).toContain('id="home"');
     expect(repo).toContain('grandfathered findings in baseline');
     expect(repo).toContain('dxkit workflows installed');
+    // Tier-1 profile tiles: graph size + freshness, debt severity shape.
+    expect(repo).toContain('functions in the code graph');
+    expect(repo).toContain('refreshed 2026-08-01');
+    expect(repo).toContain('3 high · 68 medium');
     // Static repo page carries no serve-only ask button.
     expect(repo).not.toContain('id="home-ask"');
     // Zero-context: no home view, the showcase is first.

--- a/test/learn/serve.test.ts
+++ b/test/learn/serve.test.ts
@@ -93,6 +93,32 @@ function repoStatus(): LearnRepoStatus {
         dispatchable: true,
       },
     ],
+    profile: {
+      graph: {
+        functionCount: 2253,
+        fileCount: 310,
+        callEdgeCount: 9800,
+        hubs: [
+          { label: 'secretHubFunction', sourceFile: 'src/deep/hub.ts', callsIn: 41, callsOut: 3 },
+        ],
+        refreshedAt: '2026-08-01T06:00:00.000Z',
+        stale: false,
+      },
+      debt: {
+        total: 42,
+        byKind: { 'dep-vuln': 30, secret: 2, code: 10 },
+        bySeverity: { high: 3, medium: 29, unrated: 10 },
+        floorFailing: [{ pack: 'typescript', label: 'tsc --noEmit' }],
+      },
+      health: {
+        overallScore: 50,
+        rating: 'C',
+        analyzedAt: '2026-08-01T00:00:00Z',
+        topActions: [
+          { dimension: 'testing', reason: 'no coverage data available', upliftIfFixed: 35 },
+        ],
+      },
+    },
   };
 }
 
@@ -258,6 +284,44 @@ describe('grounding — summaries by default, detail behind the toggle, disclosu
     expect(g.system).toContain('vyuh-dxkit fix-it');
     expect(g.system).toContain('fp-123');
     expect(g.disclosure.join(' ')).toContain('IN DETAIL');
+  });
+
+  it('repo profile: counts + freshness ride the summary tier; hub symbol names stay behind detail', () => {
+    const g = assembleGrounding(bundle, repoStatus(), { detail: false });
+    // Graph shape, debt shape, health headline: counts + product-phrased
+    // strings, each with its freshness stamp.
+    expect(g.system).toContain('2253 functions');
+    expect(g.system).toContain('refreshed 2026-08-01');
+    expect(g.system).toContain('dep-vuln=30');
+    expect(g.system).toContain('high=3');
+    expect(g.system).toContain('overall 50/100 (C)');
+    expect(g.system).toContain('no coverage data available');
+    expect(g.system).toContain('tsc --noEmit');
+    // Hub SYMBOL NAMES + their file paths are repo content: detail only.
+    expect(g.system).not.toContain('secretHubFunction');
+    expect(g.system).not.toContain('src/deep/hub.ts');
+    expect(g.disclosure.join(' ')).toContain('COUNTS');
+    const gd = assembleGrounding(bundle, repoStatus(), { detail: true });
+    expect(gd.system).toContain('secretHubFunction');
+    expect(gd.system).toContain('src/deep/hub.ts');
+  });
+
+  it('absent profile artifacts carry the exact enable command; a stale graph names the refresh', () => {
+    const absent = repoStatus();
+    absent.profile = { graph: null, debt: null, health: null };
+    const g = assembleGrounding(bundle, absent, { detail: false });
+    expect(g.system).toContain('code graph: not set up');
+    expect(g.system).toContain('vyuh-dxkit describe');
+    expect(g.system).toContain("run 'vyuh-dxkit health'");
+    expect(g.system).toContain('no committed baseline to read');
+
+    const staleSt = repoStatus();
+    staleSt.profile = {
+      ...staleSt.profile,
+      graph: { ...staleSt.profile.graph!, stale: true },
+    };
+    const gs = assembleGrounding(bundle, staleSt, { detail: false });
+    expect(gs.system).toContain('STALE');
   });
 });
 


### PR DESCRIPTION
Part of the 4.3.6 release train (#240), stacked on #253 (retarget to release/4.3.6 after it merges). Design + decisions: the repo-intelligence working doc (tier 1; tier 2 is issue #254).

The learn page and assistant gain a bounded tier-1 repo profile, KB-in-sync by construction: computed at gather time from committed artifacts only (learn reads artifacts, never runs analyzers), every derived fact stamped with its freshness, every absent artifact answered with the exact enable command.

- **graphProfile** joins the canonical query module (Rule 12): callable counts, file count, call-edge count, top hub functions by fan-in.
- **LearnRepoProfile** on repo-status: graph shape + artifact-mtime freshness (14-day staleness threshold), debt by kind and severity plus failing floor checks from the committed baseline in one read pass, headline + best-action-per-dimension from the newest health report (first reader of that artifact; fail-open on any shape surprise).
- **Grounding** (one-assembly rule): counts, freshness stamps, and product-phrased strings ride the summary tier; hub symbol names + file paths are repo content and stay behind the detail toggle; disclosure updated in lockstep.
- **Home dashboard**: graph tile (size + refreshed date + stale pointer) and the debt severity shape on the baseline tile. Three new repo chips, promising only what this tier answers.
- **Deviation from the design doc**: dev-activity moved to tier 2 — no dev-report artifact writer exists to read; the tool loop's bounded git blame covers it.

Tests: graphProfile unit pins on the shared fixture graph, summary/detail tier pins, absent-artifact pointer pins (graph/debt/health), stale-graph pin, home-tile pins. Learn + explore suites green (270 tests); live smoke on a real repo returns real graph/health data and the correct absent-baseline pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)