### PR TITLE
fix(remediate): truthful agent outcomes — never-ran on API failure, agent-failed, auth + CLI provenance

### DIFF
--- a/docs/learn/operating-the-lanes.md
+++ b/docs/learn/operating-the-lanes.md
@@ -86,6 +86,14 @@ Read the task's job summary first — it names the outcome. The shapes:
   attempt-counted) can continue next run instead of starting over.
 - **Skipped: "an earlier task left unlanded work in the tree"** — task
   isolation working as designed; the skipped tasks run next time.
+- **`agent-never-ran`** — the agent CLI/API failed before any work
+  happened: an invalid or credit-exhausted `ANTHROPIC_API_KEY`, a missing
+  CLI, a bad flag. The job is red and the ledger names the provider's own
+  cause (for example `agent never ran: Credit balance is too low`) — fix
+  the key or credit on the provider side; no dxkit change is involved.
+- **`agent-failed`** — the run started, then ended in an error with no
+  committed change. The ledger carries the driver-reported cause and the
+  job log carries the agent's last output lines.
 - **Degraded credentials, disclosed in the log** — the run fell back to
   `GITHUB_TOKEN` (missing or expired `DXKIT_BOT_TOKEN`): the PR opens but
   gets no CI checks, or with the Actions PR-creation setting off, the

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -202,8 +202,10 @@ __DXKIT_CI_RUNTIME_SETUP__
             echo "$d" >> "$GITHUB_PATH"
           done
 
-      - name: Install the agent CLI
-        run: npm install -g @anthropic-ai/claude-code
+      # PINNED to the version the driver registry declares (an unattended
+      # lane must not float its executor; the envelope records the build).
+      - name: Install the agent CLI (pinned)
+        run: __DXKIT_REMEDIATE_AGENT_CLI_INSTALL__
 
       # A runner has no ambient git identity, and the AGENT's own commits
       # need one (the runner's sweep + ledger commits carry the bot identity

--- a/src/lanes/verification-render.ts
+++ b/src/lanes/verification-render.ts
@@ -17,7 +17,22 @@ export function renderFloorVerification(
   entryLabel: string,
 ): string[] {
   if (!floor) return ['Correctness floor: not run (dry run).', ''];
-  const attributed = attribution ?? [];
+  // A floor WITHOUT an attribution pass is the ENTRY snapshot (the run
+  // exited before any change existed to attribute — a no-op, a failed
+  // agent). Say what it is: rendering the attributed headline here once
+  // printed "not run (dry run)" for a floor that HAD run, and would print
+  // "passed" over a red entry floor. Pre-existing debt is disclosed as
+  // exactly that — it belongs to the repo, not to this run.
+  if (!attribution) {
+    const checks = floor.checks.map((c) => `- ${c.pack}/${c.label}: ${c.status}`).join('\n');
+    return [
+      `Correctness floor (entry snapshot — no change to attribute): ` +
+        `**${floor.blocks ? 'red (pre-existing debt, not caused by this run)' : 'green'}**`,
+      checks,
+      '',
+    ];
+  }
+  const attributed = attribution;
   const netNew = attributed.filter((a) => a.attribution === 'net-new');
   const preExisting = attributed.filter((a) => a.attribution === 'pre-existing');
   const unattributed = attributed.filter((a) => a.attribution === 'unattributed');

--- a/src/remediate/claude-code-driver.ts
+++ b/src/remediate/claude-code-driver.ts
@@ -8,9 +8,13 @@
  *     never an env var that happened to be exported in this shell;
  *   - tier → rolling CLI alias (`haiku`/`sonnet`/`opus`), never a dated
  *     model id, so a model-generation rollover needs no dxkit release;
- *   - "agent never ran" detection: a non-zero exit with zero turns means the
- *     CLI died before the agent started (auth, bad flag) — reported as its
- *     own outcome, never read downstream as "agent made no change";
+ *   - "agent never ran" detection, BOTH shapes: a non-zero exit with zero
+ *     turns (CLI died before the agent started — bad flag), and an API-level
+ *     failure with no work done (invalid key, exhausted credit — the CLI
+ *     reports `num_turns: 1` for the failed call itself, which defeated the
+ *     original zero-turns guard and shipped a green job over a dead agent).
+ *     Reported as its own outcome with the CLI's human-readable cause,
+ *     never read downstream as "agent made no change";
  *   - a wall-clock kill is salvage territory, not failure: work the agent
  *     already committed is finished work (the runner decides what to do
  *     with it).
@@ -96,6 +100,43 @@ interface ClaudeJsonResult {
    *  runs have reported neither `modelId` nor `model`, leaving the envelope
    *  at "concrete id not reported by driver"). */
   readonly modelUsage?: Record<string, unknown>;
+  /** Why the run terminated (`"api_error"` on an auth/credit failure). */
+  readonly terminal_reason?: string;
+  /** On a failed run this is the CLI's human-readable cause ("Credit
+   *  balance is too low"); on a successful run it is the agent's final
+   *  message. Read ONLY when the run failed. */
+  readonly result?: string;
+  /** TRAP — the CLI reports `subtype: "success"` even on a FAILED run
+   *  (observed on credit exhaustion, CLI 2.1.222). Never key on it. */
+  readonly subtype?: string;
+}
+
+/**
+ * Both observed API-level failure shapes — invalid key AND credit
+ * exhaustion — share this signature on CLI 2.1.222:
+ *
+ *     is_error: true, terminal_reason: "api_error", num_turns: 1,
+ *     total_cost_usd: 0, modelUsage: {}, exit 1  (subtype: "success"!)
+ *
+ * `num_turns: 1` is why a `!turns` guard can never catch it: the failed
+ * call itself counts as a turn.
+ */
+function apiLevelFailure(result: ClaudeJsonResult): boolean {
+  return result.is_error === true || result.terminal_reason === 'api_error';
+}
+
+/** Evidence real agent work happened: turns beyond the failed call itself,
+ *  or actual spend. Distinguishes "never ran" from "died mid-run". */
+function madeProgress(result: ClaudeJsonResult): boolean {
+  const turns = typeof result.num_turns === 'number' ? result.num_turns : 0;
+  const cost = typeof result.total_cost_usd === 'number' ? result.total_cost_usd : 0;
+  return turns > 1 || cost > 0;
+}
+
+/** The CLI's own human-readable failure cause, bounded for a ledger line. */
+function failureCause(result: ClaudeJsonResult, fallback: string): string {
+  const cause = typeof result.result === 'string' ? result.result.trim() : '';
+  return cause ? cause.slice(0, 300) : fallback;
 }
 
 /** The concrete model id(s) a result actually used, or undefined. Falls back
@@ -118,6 +159,9 @@ export function makeClaudeCodeDriver(exec: AgentExec = realAgentExec): AgentDriv
     id: 'claude-code',
     budgetSupport: { turns: true, cost: true },
     credentialEnv: ['ANTHROPIC_API_KEY'],
+    // The pinned executor the managed workflow installs. Bump deliberately
+    // (one line, one place) — never float `latest` under an unattended lane.
+    cli: { package: '@anthropic-ai/claude-code', version: '2.1.222' },
 
     resolveModel(tier: ModelTier): string {
       return TIER_ALIAS[tier];
@@ -156,6 +200,16 @@ export function makeClaudeCodeDriver(exec: AgentExec = realAgentExec): AgentDriv
       Object.assign(env, opts.env);
       env.DXKIT_LOOP_ACTIVE = '1'; // arm the Stop-gate: the loop verifies itself
 
+      // The executor's own build, for the envelope (run provenance). Best
+      // effort — an unparseable probe leaves the field absent, disclosed by
+      // the ledger, never a failure.
+      const versionProbe = exec('claude', ['--version'], {
+        cwd: opts.cwd,
+        env,
+        timeoutMs: 30_000,
+      });
+      const cliVersion = versionProbe.stdout.match(/(\d+\.\d+\.\d+)/)?.[1];
+
       const outcome = exec(
         'claude',
         [
@@ -173,9 +227,10 @@ export function makeClaudeCodeDriver(exec: AgentExec = realAgentExec): AgentDriv
       );
 
       const tail = (outcome.stderr || outcome.stdout).trim().split('\n').slice(-6).join('\n');
+      const provenance = cliVersion ? { cliVersion } : {};
 
       if (outcome.timedOut) {
-        return { completed: false, timedOut: true, transcriptTail: tail };
+        return { completed: false, timedOut: true, transcriptTail: tail, ...provenance };
       }
 
       let result: ClaudeJsonResult = {};
@@ -186,22 +241,50 @@ export function makeClaudeCodeDriver(exec: AgentExec = realAgentExec): AgentDriv
       }
 
       const turns = typeof result.num_turns === 'number' ? result.num_turns : undefined;
-      if (outcome.code !== 0 && !turns) {
+      // Never-ran, both shapes: the CLI died before the agent started
+      // (non-zero exit, zero turns) OR the API call itself failed with no
+      // work done (invalid key, exhausted credit — `num_turns: 1` there, so
+      // a turn-count guard alone can never catch it; this shipped a green
+      // job over a dead agent).
+      const apiFailed = apiLevelFailure(result);
+      if ((outcome.code !== 0 && !turns) || (apiFailed && !madeProgress(result))) {
+        const fallback = `claude exit ${outcome.code ?? 'null'}: ${tail || '(no stderr)'}`;
+        const detail = result.terminal_reason ? ` (${result.terminal_reason})` : '';
         return {
           completed: false,
           timedOut: false,
-          neverRan: { reason: `claude exit ${outcome.code ?? 'null'}: ${tail || '(no stderr)'}` },
+          neverRan: {
+            reason: apiFailed ? `${failureCause(result, fallback)}${detail}` : fallback,
+          },
           transcriptTail: tail,
+          ...provenance,
         };
       }
 
+      const completed = outcome.code === 0 && result.is_error !== true;
+      // An error AFTER real work: verification decides the committed work's
+      // fate; the failure itself is disclosed, and a no-diff errored run is
+      // a failure outcome downstream, never a benign no-op.
+      const failure =
+        !completed && (apiFailed || outcome.code !== 0)
+          ? {
+              failure: {
+                reason: apiFailed
+                  ? failureCause(result, `claude exit ${outcome.code ?? 'null'}`) +
+                    (result.terminal_reason ? ` (${result.terminal_reason})` : '')
+                  : `claude exit ${outcome.code ?? 'null'}`,
+              },
+            }
+          : {};
       return {
-        completed: outcome.code === 0 && result.is_error !== true,
+        completed,
         turns,
         costUsd: typeof result.total_cost_usd === 'number' ? result.total_cost_usd : undefined,
         resolvedModelId: resolvedModelFrom(result),
         timedOut: false,
         transcriptTail: tail,
+        ...provenance,
+        ...failure,
       };
     },
   };

--- a/src/remediate/cli.ts
+++ b/src/remediate/cli.ts
@@ -213,6 +213,19 @@ function finalizeTaskRun(cwd: string, taskId: string, run: TaskRun): TaskRun {
   } catch {
     // the record is evidence plumbing, never a failure
   }
+  if (!run.clean) {
+    // A non-clean outcome must be diagnosable from the run page: the agent
+    // phase group otherwise closes with ZERO output (the driver captures the
+    // CLI's streams), so the failure's own evidence — the driver-reported
+    // cause and the transcript tail — surfaces in the LOG here. Log only,
+    // never the ledger/PR body.
+    if (run.result.envelope?.failure) {
+      logger.warn(`driver-reported failure: ${run.result.envelope.failure}`);
+    }
+    if (run.result.transcriptTail) {
+      logger.warn(`agent transcript (last lines):\n${run.result.transcriptTail}`);
+    }
+  }
   if (process.env.GITHUB_ACTIONS === 'true' && !run.clean) {
     const first = (run.result.note ?? run.result.outcome).split('\n')[0];
     process.stdout.write(
@@ -260,6 +273,8 @@ function taskRunJson(run: TaskRun): Record<string, unknown> {
     // format-patches into a run artifact when nothing landed.
     baseHead: r.baseHead ?? null,
     head: r.head ?? null,
+    // Failure evidence (machine-readable record only — never the PR body).
+    transcriptTail: r.transcriptTail ?? null,
     ledger: r.ledger,
   };
 }

--- a/src/remediate/driver.ts
+++ b/src/remediate/driver.ts
@@ -46,12 +46,24 @@ export interface AgentRunResult {
   /** Concrete model id the run actually used, when the driver reports it —
    *  the ledger discloses absence ("not reported by driver"). */
   readonly resolvedModelId?: string;
+  /** The agent CLI build that executed the run, when the driver can probe it
+   *  — the executor is part of the run's provenance (Rule 19 cause #5: "the
+   *  TOOL changed" must be visible, so the envelope names the build). */
+  readonly cliVersion?: string;
   /** Wall-clock cap hit: the runner salvages committed work, the outcome
    *  taxonomy says the task was cut short. */
   readonly timedOut: boolean;
-  /** CLI died before the agent ran (auth, bad flag) — a distinct infra
-   *  outcome (`agent-never-ran`), never read as "agent made no change". */
+  /** CLI died before the agent ran (auth, credit, bad flag) — a distinct
+   *  infra outcome (`agent-never-ran`), never read as "agent made no
+   *  change". The reason carries the CLI's own human-readable cause when it
+   *  reports one ("Credit balance is too low"), so the ledger names what a
+   *  maintainer must actually fix. */
   readonly neverRan?: { readonly reason: string };
+  /** The run ended in a driver/API error AFTER real work started — distinct
+   *  from neverRan (no work happened) and timedOut (salvage territory). The
+   *  runner verifies whatever was committed and DISCLOSES this; a no-diff
+   *  errored run is a failure outcome, never a benign no-op. */
+  readonly failure?: { readonly reason: string };
   /** For the failure taxonomy only — never rendered into a PR body. */
   readonly transcriptTail: string;
 }
@@ -77,6 +89,17 @@ export interface AgentDriver {
    * new driver never means hand-editing the template.
    */
   readonly credentialEnv: readonly string[];
+  /**
+   * The installable agent CLI, PINNED — the managed workflow renders its
+   * install step FROM this declaration (Rule 15: registry-driven, never a
+   * hand-edited template line). An unattended lane must not float its
+   * executor: a CLI release changing behavior under a byte-identical dxkit
+   * is Rule 19 cause #5 ("the TOOL changed"), so the version is explicit
+   * and bumping it is a deliberate one-line driver change. `null` declares
+   * a driver with no installable CLI (it manages its own runtime) — a
+   * stated fact, never an omission.
+   */
+  readonly cli: { readonly package: string; readonly version: string } | null;
   available(cwd: string): { readonly ok: true } | { readonly ok: false; readonly reason: string };
   run(opts: AgentRunOptions): Promise<AgentRunResult>;
 }

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -28,7 +28,10 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
         : e.modelSource === 'pinned-tier'
           ? 'tier pinned by policy'
           : 'pinned by policy';
-    lines.push(`- driver: \`${e.driver}\``);
+    lines.push(
+      `- driver: \`${e.driver}\`` +
+        (e.cliVersion ? ` — agent CLI ${e.cliVersion}` : ' — agent CLI version not reported'),
+    );
     lines.push(
       `- model: \`${e.model}\` (${modelWhy})` +
         (e.resolvedModelId
@@ -36,11 +39,23 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
           : ' — concrete id not reported by driver'),
     );
     if (e.modelWarning) lines.push(`- model warning: ${e.modelWarning}`);
+    // Under subscription auth a reported cost is a NOTIONAL API-equivalent,
+    // not billed spend — printing it as "spend" makes a benchmark table read
+    // as a bill (and a $0 lane look free when it is quota).
+    const spendLabel = e.auth === 'subscription' ? 'API-equivalent cost' : 'spend';
     lines.push(
-      `- spend: ${e.costUsd !== undefined ? `$${e.costUsd.toFixed(2)}` : 'not reported'} over ` +
+      `- auth: ${
+        e.auth === 'subscription'
+          ? 'subscription (stored login — costs shown are API-equivalents, not billed spend)'
+          : 'api-key (billed API spend)'
+      }`,
+    );
+    lines.push(
+      `- ${spendLabel}: ${e.costUsd !== undefined ? `$${e.costUsd.toFixed(2)}` : 'not reported'} over ` +
         `${e.turns !== undefined ? `${e.turns} turns` : 'an unreported turn count'} ` +
         `(caps: ${e.budget.maxTurns} turns, ${e.budget.maxMinutes} min, $${e.budget.maxUsd})`,
     );
+    if (e.failure) lines.push(`- driver-reported failure: ${e.failure}`);
     if (e.turns !== undefined && e.turns > e.budget.maxTurns) {
       // The 81-vs-80 confusion: the driver's reported count can exceed the
       // cap it enforced (its accounting includes the closing turn). Say so —

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -1,0 +1,148 @@
+/**
+ * The remediate outcome vocabulary — the runner's result/option shapes and
+ * the outcome taxonomy every surface (CLI, ledger, workflow, landers) speaks.
+ * Split from `run.ts` purely for module size (the ledger-render precedent);
+ * the runner re-exports everything, so consumers keep one import surface.
+ */
+import type { AnalysisTrustContext } from '../analysis-trust';
+import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
+import type { AttributedFloorFailure } from '../analyzers/correctness/attribution';
+import type { GuardrailGateResult } from '../lanes/verify';
+import type { AgentDriver } from './driver';
+import type { RemediateTask } from './tasks';
+import type { DispatchOverrides } from './dispatch';
+import type { HingeEvidence, HingeScores } from './score-hinge';
+import type { RemediateConfig } from './config';
+
+export type RemediateOutcome =
+  | 'verified' // diff produced, floor net-new-clean, guardrail PASSED — ready to land
+  | 'no-op' // agent ran TO COMPLETION, no diff (nothing to fix)
+  | 'floor-red' // diff breaks the net-new floor — never lands
+  | 'guardrail-red' // guardrail blocked, refused, or could not run — never lands
+  | 'score-red' // the task's score hinge did not hold (goal not met) — never lands
+  | 'budget-exhausted' // a cap hit; partial diff (salvage policy decides its fate)
+  | 'agent-never-ran' // CLI/auth/env failure — infra, not a code outcome
+  | 'agent-failed' // the run errored after starting and produced no committed change
+  | 'sweep-failed' // agent committed work but leftovers could not be swept
+  | 'refused'; // trust/config refusal, disclosed
+
+export interface AgentEnvelope {
+  readonly driver: string;
+  /** Driver-native model argument + how it was chosen (ledger disclosure). */
+  readonly model: string;
+  readonly modelSource: 'auto-tier' | 'pinned-tier' | 'pinned-native';
+  readonly modelWarning?: string;
+  /** Concrete id the run reported, or absent ("not reported by driver"). */
+  readonly resolvedModelId?: string;
+  /** The agent CLI build that executed the run (run provenance), when the
+   *  driver could probe it. */
+  readonly cliVersion?: string;
+  /**
+   * Which auth path the run used: `api-key` = the runner injected a declared
+   * credential (billed API spend); `subscription` = no credential injected,
+   * the CLI's own stored login applied. Under subscription auth a reported
+   * cost is a NOTIONAL API-equivalent, not billed spend — the ledger labels
+   * it so a benchmark table never reads as a bill.
+   */
+  readonly auth: 'api-key' | 'subscription';
+  readonly turns?: number;
+  readonly costUsd?: number;
+  /** Driver-reported failure (an error after the run started) — disclosed
+   *  even when committed work verifies clean. */
+  readonly failure?: string;
+  readonly budget: {
+    readonly maxTurns: number;
+    readonly maxMinutes: number;
+    readonly maxUsd: number;
+  };
+  /** Caps the driver cannot enforce — disclosed, never silent. */
+  readonly unenforceableCaps: readonly string[];
+}
+
+export interface RemediateResult {
+  readonly outcome: RemediateOutcome;
+  readonly task?: RemediateTask['id'];
+  readonly note?: string;
+  readonly envelope?: AgentEnvelope;
+  /** True when the run was cut short (wall-clock or turn cap) — the ledger
+   *  must say the task was budget-bounded, not finished. */
+  readonly partial?: boolean;
+  readonly floor?: CorrectnessFloorResult;
+  readonly floorAttribution?: readonly AttributedFloorFailure[];
+  readonly guardrailVerdict?: string;
+  /** Score-hinge evidence (tasks that declare one): the entry vs post-agent
+   *  dimension scores the land decision was made on. Present on success AND
+   *  failure — the ledger shows the delta either way. */
+  readonly scoreHinge?: HingeEvidence;
+  /** HEAD before/after the agent — the commit range a lander pushes. */
+  readonly baseHead?: string;
+  readonly head?: string;
+  /** Dispatch-campaign disclosure (E3): who fired it, the verbatim custom
+   *  prompt (when the `custom` task ran), and any clamped overrides. In the
+   *  ledger = in the PR body, so the reviewer sees exactly what was asked. */
+  readonly dispatch?: {
+    readonly actor?: string;
+    readonly prompt?: string;
+    readonly clamped: readonly string[];
+  };
+  /** Present when this run CONTINUED a prior budget-bounded attempt
+   *  (resume-from-salvage) — disclosed in the ledger/PR body. */
+  readonly resume?: { readonly attempt: number };
+  /** The last lines of the agent's captured output — JOB-LOG evidence for a
+   *  non-clean outcome (the run page must be diagnosable without reading
+   *  source). Never rendered into the ledger / PR body. */
+  readonly transcriptTail?: string;
+  /** The verification ledger — PR body / job summary markdown. */
+  readonly ledger: string;
+}
+
+export interface RemediateGit {
+  head(): string;
+  /** Commit uncommitted leftovers (excluding dxkit runtime state); returns
+   *  an error string when the sweep commit failed. */
+  sweepLeftovers(): string | undefined;
+  /** Any commits in base..HEAD? */
+  hasDiff(baseHead: string): boolean;
+}
+
+export interface RemediateRunOptions {
+  readonly cwd: string;
+  /** REQUIRED typed trust context — the runner executes an agent CLI. */
+  readonly trust: AnalysisTrustContext;
+  readonly taskId: string;
+  readonly config: RemediateConfig;
+  /** Credentials for the driver (CI: from repo secrets). Local default is
+   *  empty — the claude-code driver then runs subscription-mode. */
+  readonly agentEnv?: Readonly<Record<string, string>>;
+  /** Injected for tests. */
+  readonly drivers?: readonly AgentDriver[];
+  readonly git?: RemediateGit;
+  readonly runFloor?: () => CorrectnessFloorResult;
+  readonly runGuardrail?: () => Promise<GuardrailGateResult>;
+  /** Injected for tests: replaces the health-score probe behind a task's
+   *  score hinge. */
+  readonly hingeScores?: (hinge: NonNullable<RemediateTask['scoreHinge']>) => Promise<HingeScores>;
+  /** Progress hook — called as each phase begins so the CLI layer can emit
+   *  log groups + heartbeats (a 35-minute silent step is indistinguishable
+   *  from a hang; "working" must be observable from the job log). */
+  readonly onPhase?: (phase: RemediatePhase) => void;
+  /** Dispatch-campaign overrides (E2/E3), read from env by the CLI layer.
+   *  Carries the custom task's prompt, the clamp disclosures, and the
+   *  dispatcher for the ledger. */
+  readonly dispatch?: DispatchOverrides;
+  /** Pre-captured entry floor (resume path): the CLI snapshots the PRISTINE
+   *  default tree BEFORE checking out a salvage branch, so attribution stays
+   *  anchored to the original base — a broken partial reads NET-NEW. */
+  readonly entryFloor?: CorrectnessFloorResult;
+  /** Present when this run continues a prior budget-bounded attempt. */
+  readonly resume?: { readonly attempt: number };
+}
+
+/** The runner's observable phases, in order. */
+export type RemediatePhase =
+  | 'entry-floor'
+  | 'agent'
+  | 'sweep'
+  | 'verify-floor'
+  | 'guardrail'
+  | 'score-hinge';

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -48,12 +48,13 @@ import type { RemediateConfig } from './config';
 
 export type RemediateOutcome =
   | 'verified' // diff produced, floor net-new-clean, guardrail PASSED — ready to land
-  | 'no-op' // agent ran, no diff (nothing to fix)
+  | 'no-op' // agent ran TO COMPLETION, no diff (nothing to fix)
   | 'floor-red' // diff breaks the net-new floor — never lands
   | 'guardrail-red' // guardrail blocked, refused, or could not run — never lands
   | 'score-red' // the task's score hinge did not hold (goal not met) — never lands
   | 'budget-exhausted' // a cap hit; partial diff (salvage policy decides its fate)
   | 'agent-never-ran' // CLI/auth/env failure — infra, not a code outcome
+  | 'agent-failed' // the run errored after starting and produced no committed change
   | 'sweep-failed' // agent committed work but leftovers could not be swept
   | 'refused'; // trust/config refusal, disclosed
 
@@ -65,8 +66,22 @@ export interface AgentEnvelope {
   readonly modelWarning?: string;
   /** Concrete id the run reported, or absent ("not reported by driver"). */
   readonly resolvedModelId?: string;
+  /** The agent CLI build that executed the run (run provenance), when the
+   *  driver could probe it. */
+  readonly cliVersion?: string;
+  /**
+   * Which auth path the run used: `api-key` = the runner injected a declared
+   * credential (billed API spend); `subscription` = no credential injected,
+   * the CLI's own stored login applied. Under subscription auth a reported
+   * cost is a NOTIONAL API-equivalent, not billed spend — the ledger labels
+   * it so a benchmark table never reads as a bill.
+   */
+  readonly auth: 'api-key' | 'subscription';
   readonly turns?: number;
   readonly costUsd?: number;
+  /** Driver-reported failure (an error after the run started) — disclosed
+   *  even when committed work verifies clean. */
+  readonly failure?: string;
   readonly budget: {
     readonly maxTurns: number;
     readonly maxMinutes: number;
@@ -105,6 +120,10 @@ export interface RemediateResult {
   /** Present when this run CONTINUED a prior budget-bounded attempt
    *  (resume-from-salvage) — disclosed in the ledger/PR body. */
   readonly resume?: { readonly attempt: number };
+  /** The last lines of the agent's captured output — JOB-LOG evidence for a
+   *  non-clean outcome (the run page must be diagnosable without reading
+   *  source). Never rendered into the ledger / PR body. */
+  readonly transcriptTail?: string;
   /** The verification ledger — PR body / job summary markdown. */
   readonly ledger: string;
 }
@@ -231,11 +250,19 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     );
   }
 
+  // Auth-path disclosure (driver-generic): a declared credential the runner
+  // actually injected = billed API spend; none = the CLI's stored login
+  // (subscription), whose reported costs are notional API-equivalents.
+  const auth: AgentEnvelope['auth'] = driver.credentialEnv.some((name) => opts.agentEnv?.[name])
+    ? 'api-key'
+    : 'subscription';
+
   const envelopeBase = {
     driver: driver.id,
     model: choice.native,
     modelSource: choice.source,
     ...(choice.warning ? { modelWarning: choice.warning } : {}),
+    auth,
     budget,
     unenforceableCaps,
   };
@@ -304,15 +331,24 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   const envelope: AgentEnvelope = {
     ...envelopeBase,
     ...(agentResult.resolvedModelId ? { resolvedModelId: agentResult.resolvedModelId } : {}),
+    ...(agentResult.cliVersion ? { cliVersion: agentResult.cliVersion } : {}),
     ...(agentResult.turns !== undefined ? { turns: agentResult.turns } : {}),
     ...(agentResult.costUsd !== undefined ? { costUsd: agentResult.costUsd } : {}),
+    ...(agentResult.failure ? { failure: agentResult.failure.reason } : {}),
   };
+  // Job-log evidence for every post-run exit (never rendered into the
+  // ledger): a non-clean outcome must be diagnosable from the run page.
+  const evidenceTail = agentResult.transcriptTail
+    ? { transcriptTail: agentResult.transcriptTail }
+    : {};
 
   if (agentResult.neverRan) {
     return finish({
       outcome: 'agent-never-ran',
       task: task.id,
       envelope,
+      floor: entryFloor,
+      ...evidenceTail,
       note: `agent never ran: ${agentResult.neverRan.reason}`,
     });
   }
@@ -348,6 +384,8 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
         outcome: 'agent-never-ran',
         task: task.id,
         envelope,
+        floor: entryFloor,
+        ...evidenceTail,
         note: `agent left uncommitted work the sweep could not commit: ${sweepError}`,
       });
     }
@@ -355,6 +393,8 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
       outcome: 'sweep-failed',
       task: task.id,
       envelope,
+      floor: entryFloor,
+      ...evidenceTail,
       ...(partial ? { partial } : {}),
       note:
         `the agent committed work, but the runner could not sweep its remaining uncommitted ` +
@@ -366,10 +406,35 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   }
 
   if (!hasDiff) {
+    // A benign no-op requires the agent's run to have ENDED CLEAN. An
+    // errored run with no diff is a failure — reporting it as "nothing to
+    // fix" is the green-job-over-a-dead-agent class, one guard further out
+    // than the driver's never-ran taxonomy (defense in depth: any driver
+    // that misses its own failure shape still cannot produce a green no-op
+    // here). A budget-cut run (timedOut / cap hit) stays a no-op with the
+    // `partial` flag: "ran out of budget before committing anything" is a
+    // true statement the ledger already makes.
+    if (!agentResult.completed && !partial) {
+      return finish({
+        outcome: 'agent-failed',
+        task: task.id,
+        envelope,
+        floor: entryFloor,
+        ...evidenceTail,
+        note:
+          `the agent run ended in an error and produced no committed change` +
+          `${agentResult.failure ? `: ${agentResult.failure.reason}` : ''}. ` +
+          'Nothing to verify; nothing lands.',
+        baseHead,
+        head: git.head(),
+      });
+    }
     return finish({
       outcome: 'no-op',
       task: task.id,
       envelope,
+      floor: entryFloor,
+      ...evidenceTail,
       ...(partial ? { partial } : {}),
       note: 'agent ran and produced no committed change.',
       baseHead,
@@ -402,6 +467,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     guardrailVerdict: guardrail.verdict,
     baseHead,
     head: git.head(),
+    ...evidenceTail,
     ...(partial ? { partial } : {}),
   };
 

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -22,165 +22,31 @@
  * dxkit-authored prompts only. Landing (the standing PR) is composed by the
  * CLI/workflow layer on top of this runner's outcome.
  */
-import type { AnalysisTrustContext } from '../analysis-trust';
-import { runCorrectnessFloor, type CorrectnessFloorResult } from '../analyzers/correctness/run';
-import {
-  attributeFloorFailures,
-  type AttributedFloorFailure,
-  type FloorBaseCheck,
-} from '../analyzers/correctness/attribution';
+import { runCorrectnessFloor } from '../analyzers/correctness/run';
+import { attributeFloorFailures, type FloorBaseCheck } from '../analyzers/correctness/attribution';
 import { detectActiveLanguages } from '../languages';
 import { renderRemediateLedger } from './ledger-render';
-import { guardrailVerdictFor, toFloorBaseChecks, type GuardrailGateResult } from '../lanes/verify';
-import { resolveModelSetting, type AgentDriver, type AgentRunResult } from './driver';
+import { guardrailVerdictFor, toFloorBaseChecks } from '../lanes/verify';
+import { resolveModelSetting, type AgentRunResult } from './driver';
 import { AGENT_DRIVERS, knownDriverIds } from './registry';
 import type { RemediateTask } from './tasks';
-import { resolveDispatchedTask, type DispatchOverrides } from './dispatch';
+import { resolveDispatchedTask } from './dispatch';
 import { resumePromptNote } from './resume';
 import { realGit } from './git-ops';
-import {
-  evaluateScoreHinge,
-  healthHingeScores,
-  type HingeEvidence,
-  type HingeScores,
-} from './score-hinge';
-import type { RemediateConfig } from './config';
+import { evaluateScoreHinge, healthHingeScores } from './score-hinge';
+import type { AgentEnvelope, RemediateResult, RemediateRunOptions } from './outcome';
 
-export type RemediateOutcome =
-  | 'verified' // diff produced, floor net-new-clean, guardrail PASSED — ready to land
-  | 'no-op' // agent ran TO COMPLETION, no diff (nothing to fix)
-  | 'floor-red' // diff breaks the net-new floor — never lands
-  | 'guardrail-red' // guardrail blocked, refused, or could not run — never lands
-  | 'score-red' // the task's score hinge did not hold (goal not met) — never lands
-  | 'budget-exhausted' // a cap hit; partial diff (salvage policy decides its fate)
-  | 'agent-never-ran' // CLI/auth/env failure — infra, not a code outcome
-  | 'agent-failed' // the run errored after starting and produced no committed change
-  | 'sweep-failed' // agent committed work but leftovers could not be swept
-  | 'refused'; // trust/config refusal, disclosed
-
-export interface AgentEnvelope {
-  readonly driver: string;
-  /** Driver-native model argument + how it was chosen (ledger disclosure). */
-  readonly model: string;
-  readonly modelSource: 'auto-tier' | 'pinned-tier' | 'pinned-native';
-  readonly modelWarning?: string;
-  /** Concrete id the run reported, or absent ("not reported by driver"). */
-  readonly resolvedModelId?: string;
-  /** The agent CLI build that executed the run (run provenance), when the
-   *  driver could probe it. */
-  readonly cliVersion?: string;
-  /**
-   * Which auth path the run used: `api-key` = the runner injected a declared
-   * credential (billed API spend); `subscription` = no credential injected,
-   * the CLI's own stored login applied. Under subscription auth a reported
-   * cost is a NOTIONAL API-equivalent, not billed spend — the ledger labels
-   * it so a benchmark table never reads as a bill.
-   */
-  readonly auth: 'api-key' | 'subscription';
-  readonly turns?: number;
-  readonly costUsd?: number;
-  /** Driver-reported failure (an error after the run started) — disclosed
-   *  even when committed work verifies clean. */
-  readonly failure?: string;
-  readonly budget: {
-    readonly maxTurns: number;
-    readonly maxMinutes: number;
-    readonly maxUsd: number;
-  };
-  /** Caps the driver cannot enforce — disclosed, never silent. */
-  readonly unenforceableCaps: readonly string[];
-}
-
-export interface RemediateResult {
-  readonly outcome: RemediateOutcome;
-  readonly task?: RemediateTask['id'];
-  readonly note?: string;
-  readonly envelope?: AgentEnvelope;
-  /** True when the run was cut short (wall-clock or turn cap) — the ledger
-   *  must say the task was budget-bounded, not finished. */
-  readonly partial?: boolean;
-  readonly floor?: CorrectnessFloorResult;
-  readonly floorAttribution?: readonly AttributedFloorFailure[];
-  readonly guardrailVerdict?: string;
-  /** Score-hinge evidence (tasks that declare one): the entry vs post-agent
-   *  dimension scores the land decision was made on. Present on success AND
-   *  failure — the ledger shows the delta either way. */
-  readonly scoreHinge?: HingeEvidence;
-  /** HEAD before/after the agent — the commit range a lander pushes. */
-  readonly baseHead?: string;
-  readonly head?: string;
-  /** Dispatch-campaign disclosure (E3): who fired it, the verbatim custom
-   *  prompt (when the `custom` task ran), and any clamped overrides. In the
-   *  ledger = in the PR body, so the reviewer sees exactly what was asked. */
-  readonly dispatch?: {
-    readonly actor?: string;
-    readonly prompt?: string;
-    readonly clamped: readonly string[];
-  };
-  /** Present when this run CONTINUED a prior budget-bounded attempt
-   *  (resume-from-salvage) — disclosed in the ledger/PR body. */
-  readonly resume?: { readonly attempt: number };
-  /** The last lines of the agent's captured output — JOB-LOG evidence for a
-   *  non-clean outcome (the run page must be diagnosable without reading
-   *  source). Never rendered into the ledger / PR body. */
-  readonly transcriptTail?: string;
-  /** The verification ledger — PR body / job summary markdown. */
-  readonly ledger: string;
-}
-
-export interface RemediateGit {
-  head(): string;
-  /** Commit uncommitted leftovers (excluding dxkit runtime state); returns
-   *  an error string when the sweep commit failed. */
-  sweepLeftovers(): string | undefined;
-  /** Any commits in base..HEAD? */
-  hasDiff(baseHead: string): boolean;
-}
-
-export interface RemediateRunOptions {
-  readonly cwd: string;
-  /** REQUIRED typed trust context — the runner executes an agent CLI. */
-  readonly trust: AnalysisTrustContext;
-  readonly taskId: string;
-  readonly config: RemediateConfig;
-  /** Credentials for the driver (CI: from repo secrets). Local default is
-   *  empty — the claude-code driver then runs subscription-mode. */
-  readonly agentEnv?: Readonly<Record<string, string>>;
-  /** Injected for tests. */
-  readonly drivers?: readonly AgentDriver[];
-  readonly git?: RemediateGit;
-  readonly runFloor?: () => CorrectnessFloorResult;
-  readonly runGuardrail?: () => Promise<GuardrailGateResult>;
-  /** Injected for tests: replaces the health-score probe behind a task's
-   *  score hinge. */
-  readonly hingeScores?: (hinge: NonNullable<RemediateTask['scoreHinge']>) => Promise<HingeScores>;
-  /** Progress hook — called as each phase begins so the CLI layer can emit
-   *  log groups + heartbeats (a 35-minute silent step is indistinguishable
-   *  from a hang; "working" must be observable from the job log). */
-  readonly onPhase?: (phase: RemediatePhase) => void;
-  /** Dispatch-campaign overrides (E2/E3), read from env by the CLI layer.
-   *  Carries the custom task's prompt, the clamp disclosures, and the
-   *  dispatcher for the ledger. */
-  readonly dispatch?: DispatchOverrides;
-  /** Pre-captured entry floor (resume path): the CLI snapshots the PRISTINE
-   *  default tree BEFORE checking out a salvage branch, so attribution stays
-   *  anchored to the original base — a broken partial reads NET-NEW. */
-  readonly entryFloor?: CorrectnessFloorResult;
-  /** Present when this run continues a prior budget-bounded attempt. */
-  readonly resume?: { readonly attempt: number };
-}
-
-/** The runner's observable phases, in order. */
-export type RemediatePhase =
-  | 'entry-floor'
-  | 'agent'
-  | 'sweep'
-  | 'verify-floor'
-  | 'guardrail'
-  | 'score-hinge';
-
-// The ledger renderer lives in `./ledger-render` (module-size split);
-// re-exported so consumers keep one import surface.
+// The outcome vocabulary lives in `./outcome` and the ledger renderer in
+// `./ledger-render` (module-size splits); both are re-exported so consumers
+// keep one import surface.
+export type {
+  AgentEnvelope,
+  RemediateGit,
+  RemediateOutcome,
+  RemediatePhase,
+  RemediateResult,
+  RemediateRunOptions,
+} from './outcome';
 export { renderRemediateLedger };
 
 export async function runRemediateTask(opts: RemediateRunOptions): Promise<RemediateResult> {

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -1084,12 +1084,20 @@ export function installCiRemediate(cwd: string, opts: InstallerOpts = {}): ShipI
   const taskOptionLines = knownTaskIds()
     .map((id) => `          - ${id}`)
     .join('\n');
+  // The agent CLI install is rendered from the driver's PINNED declaration
+  // (Rule 15): an unattended lane must not float its executor, and bumping
+  // the CLI is a one-line driver change, never a template edit. A driver
+  // with no installable CLI (cli: null) renders a disclosed no-op.
+  const agentCliInstall = driver?.cli
+    ? `npm install -g ${driver.cli.package}@${driver.cli.version}`
+    : `echo "driver '${config.agent.driver}' declares no installable CLI"`;
   const result = installWorkflow(cwd, 'dxkit-remediate.yml', opts, {
     [CI_RUNTIME_SETUP_KEY]: renderCiRuntimeSetup(cwd),
     __DXKIT_DEFAULT_BRANCH__: resolveDefaultBranch(cwd),
     __DXKIT_REMEDIATE_CRON__: cronFromCadence(config.schedule),
     __DXKIT_REMEDIATE_CREDENTIAL_ENV__: credentialLines,
     __DXKIT_REMEDIATE_TASK_OPTIONS__: taskOptionLines,
+    __DXKIT_REMEDIATE_AGENT_CLI_INSTALL__: agentCliInstall,
     __DXKIT_BOT_NAME__: BOT_IDENTITY.name,
     __DXKIT_BOT_EMAIL__: BOT_IDENTITY.email,
   });

--- a/test/remediate/dispatch.test.ts
+++ b/test/remediate/dispatch.test.ts
@@ -106,6 +106,7 @@ function fakeDriver(): AgentDriver & { lastRun?: Parameters<AgentDriver['run']>[
     id: 'fake-agent',
     budgetSupport: { turns: true, cost: true },
     credentialEnv: [],
+    cli: null,
     resolveModel: (tier) => `fake-${tier}`,
     available: () => ({ ok: true }),
     run: async (opts) => {

--- a/test/remediate/driver.test.ts
+++ b/test/remediate/driver.test.ts
@@ -40,8 +40,17 @@ describe('driver registry contract', () => {
       expect(typeof driver.budgetSupport.turns).toBe('boolean');
       expect(typeof driver.budgetSupport.cost).toBe('boolean');
       expect(Array.isArray(driver.credentialEnv)).toBe(true);
+      // The executor declaration: an exact pinned version (an unattended
+      // lane never floats its CLI) or an explicit null — never absent.
+      expect(driver.cli === null || /^\d+\.\d+\.\d+$/.test(driver.cli.version)).toBe(true);
     });
   }
+
+  it('claude-code pins its installable CLI (the workflow renders from this)', () => {
+    const cli = driverById('claude-code')!.cli;
+    expect(cli?.package).toBe('@anthropic-ai/claude-code');
+    expect(cli?.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
 });
 
 describe('resolveModelSetting (the three accepted shapes)', () => {

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect } from 'vitest';
+import { makeClaudeCodeDriver, type AgentExec } from '../../src/remediate/claude-code-driver';
+import { runRemediateTask, type RemediateGit } from '../../src/remediate/run';
+import { renderRemediateLedger } from '../../src/remediate/ledger-render';
+import { renderFloorVerification } from '../../src/lanes/verification-render';
+import type { AgentDriver, AgentRunResult } from '../../src/remediate/driver';
+import type { RemediateConfig } from '../../src/remediate/config';
+import { DEFAULT_REMEDIATE_BUDGET } from '../../src/remediate/config';
+import type { CorrectnessFloorResult } from '../../src/analyzers/correctness/run';
+import type { AnalysisTrustContext } from '../../src/analysis-trust';
+
+/**
+ * The agent failure taxonomy — the honesty contract between a run and its
+ * ledger. Pins the production class where an agent that could not
+ * authenticate reported a green no-op: the claude CLI reports `num_turns: 1`
+ * for the failed API call itself, defeating a zero-turns guard, and the
+ * no-diff branch never consulted `completed`. Every arm here is a shape
+ * OBSERVED live (invalid key, exhausted credit — byte-identical signatures
+ * on CLI 2.1.222) or the guard one layer out (the runner's own completed
+ * gate, for any future driver that misses its own failure shape).
+ */
+
+/** The observed credit-exhaustion result (CLI 2.1.222) — verbatim shape,
+ *  including the `subtype: "success"` trap on a FAILED run. */
+const CREDIT_EXHAUSTED = {
+  is_error: true,
+  num_turns: 1,
+  total_cost_usd: 0,
+  terminal_reason: 'api_error',
+  modelUsage: {},
+  result: 'Credit balance is too low',
+  subtype: 'success',
+};
+
+/** Exec fixture that answers the version probe and the agent run
+ *  separately — the driver calls both through the one injected seam. */
+function execWith(run: {
+  code?: number | null;
+  stdout?: string;
+  stderr?: string;
+  timedOut?: boolean;
+  version?: string;
+}): AgentExec {
+  return (bin, args) => {
+    expect(bin).toBe('claude');
+    if (args.includes('--version')) {
+      return {
+        code: 0,
+        stdout: run.version ?? '2.1.222 (Claude Code)',
+        stderr: '',
+        timedOut: false,
+      };
+    }
+    return {
+      code: run.code ?? 0,
+      stdout: run.stdout ?? '',
+      stderr: run.stderr ?? '',
+      timedOut: run.timedOut ?? false,
+    };
+  };
+}
+
+const budget = { maxTurns: 80, maxMinutes: 30 };
+const runOpts = { cwd: '/tmp', prompt: 'p', budget, model: 'sonnet', env: {} };
+
+describe('claude-code driver: API-level failure is never-ran, with the human cause', () => {
+  it('credit exhaustion (the live signature, num_turns: 1) is never-ran naming the cause', async () => {
+    const d = makeClaudeCodeDriver(execWith({ code: 1, stdout: JSON.stringify(CREDIT_EXHAUSTED) }));
+    const r = await d.run(runOpts);
+    expect(r.neverRan?.reason).toContain('Credit balance is too low');
+    expect(r.neverRan?.reason).toContain('api_error');
+    expect(r.completed).toBe(false);
+  });
+
+  it('an invalid key (same signature, different cause string) is never-ran', async () => {
+    const d = makeClaudeCodeDriver(
+      execWith({
+        code: 1,
+        stdout: JSON.stringify({ ...CREDIT_EXHAUSTED, result: 'Invalid API key provided' }),
+      }),
+    );
+    const r = await d.run(runOpts);
+    expect(r.neverRan?.reason).toContain('Invalid API key');
+  });
+
+  it('never keys on subtype ("success" is present on a FAILED run)', async () => {
+    // The signature already carries subtype: 'success'; a regression that
+    // trusts it would classify this run as completed.
+    const d = makeClaudeCodeDriver(execWith({ code: 1, stdout: JSON.stringify(CREDIT_EXHAUSTED) }));
+    const r = await d.run(runOpts);
+    expect(r.completed).toBe(false);
+    expect(r.neverRan).toBeDefined();
+  });
+
+  it('is_error with exit 0 and no progress is still never-ran (exit code is not the signal)', async () => {
+    const d = makeClaudeCodeDriver(execWith({ code: 0, stdout: JSON.stringify(CREDIT_EXHAUSTED) }));
+    const r = await d.run(runOpts);
+    expect(r.neverRan).toBeDefined();
+  });
+
+  it('an api_error AFTER real work is a failed run with the cause, never never-ran', async () => {
+    const d = makeClaudeCodeDriver(
+      execWith({
+        code: 1,
+        stdout: JSON.stringify({
+          is_error: true,
+          terminal_reason: 'api_error',
+          num_turns: 41,
+          total_cost_usd: 2.53,
+          result: 'Credit balance is too low',
+          modelUsage: { 'claude-sonnet-5': {} },
+        }),
+      }),
+    );
+    const r = await d.run(runOpts);
+    expect(r.neverRan).toBeUndefined();
+    expect(r.completed).toBe(false);
+    expect(r.failure?.reason).toContain('Credit balance is too low');
+    expect(r.turns).toBe(41);
+    expect(r.costUsd).toBe(2.53);
+  });
+
+  it('a plain non-zero exit after real turns reports the exit as the failure', async () => {
+    const d = makeClaudeCodeDriver(execWith({ code: 1, stdout: '{"num_turns": 9}' }));
+    const r = await d.run(runOpts);
+    expect(r.neverRan).toBeUndefined();
+    expect(r.failure?.reason).toBe('claude exit 1');
+  });
+
+  it('a successful run never reads the result field (the agent final message) as a failure', async () => {
+    const d = makeClaudeCodeDriver(
+      execWith({
+        code: 0,
+        stdout: JSON.stringify({
+          is_error: false,
+          num_turns: 12,
+          total_cost_usd: 0.4,
+          result: 'I fixed the build by declaring the missing packages.',
+        }),
+      }),
+    );
+    const r = await d.run(runOpts);
+    expect(r.completed).toBe(true);
+    expect(r.failure).toBeUndefined();
+    expect(r.neverRan).toBeUndefined();
+  });
+
+  it('probes and reports the agent CLI build (run provenance)', async () => {
+    const d = makeClaudeCodeDriver(
+      execWith({ code: 0, stdout: '{"num_turns": 2}', version: '2.1.222 (Claude Code)' }),
+    );
+    const r = await d.run(runOpts);
+    expect(r.cliVersion).toBe('2.1.222');
+  });
+
+  it('an unparseable version probe leaves the field absent, never fails the run', async () => {
+    const d = makeClaudeCodeDriver(
+      execWith({ code: 0, stdout: '{"num_turns": 2}', version: 'garbage' }),
+    );
+    const r = await d.run(runOpts);
+    expect(r.cliVersion).toBeUndefined();
+    expect(r.turns).toBe(2);
+  });
+});
+
+// ── The runner's own guard (driver-independent) ─────────────────────────────
+
+const TRUSTED: AnalysisTrustContext = {
+  repoExecutionAllowed: true,
+  source: 'local-workspace',
+} as AnalysisTrustContext;
+
+const GREEN_FLOOR: CorrectnessFloorResult = { ran: true, checks: [], blocks: false };
+const RED_FLOOR: CorrectnessFloorResult = {
+  ran: true,
+  checks: [
+    { pack: 'typescript', label: 'import-resolution', bin: 'node', status: 'fail' },
+  ] as never,
+  blocks: true,
+};
+
+function fakeGit(opts: { diff?: boolean } = {}): RemediateGit {
+  return {
+    head: () => 'base0000',
+    sweepLeftovers: () => undefined,
+    hasDiff: () => !!opts.diff,
+  };
+}
+
+function fakeDriver(result: Partial<AgentRunResult>): AgentDriver {
+  return {
+    id: 'fake-agent',
+    budgetSupport: { turns: true, cost: true },
+    credentialEnv: ['FAKE_KEY'],
+    cli: null,
+    resolveModel: (tier) => `fake-${tier}`,
+    available: () => ({ ok: true }),
+    run: async () => ({ completed: true, timedOut: false, transcriptTail: '', ...result }),
+  };
+}
+
+function config(): RemediateConfig {
+  return {
+    enabled: true,
+    tasks: ['fix-vulns'],
+    unknownTasks: [],
+    schedule: 'weekly',
+    salvage: 'discard',
+    agent: { driver: 'fake-agent', model: 'auto', budget: DEFAULT_REMEDIATE_BUDGET },
+    taskBudgets: {},
+    maxSpendPerRun: 0,
+    maxDispatchBudget: 0,
+    resume: false,
+  };
+}
+
+function base(driver: AgentDriver, extra: Partial<Parameters<typeof runRemediateTask>[0]> = {}) {
+  return {
+    cwd: '/tmp/fake',
+    trust: TRUSTED,
+    taskId: 'fix-vulns',
+    config: config(),
+    drivers: [driver],
+    git: fakeGit({ diff: true }),
+    runFloor: () => RED_FLOOR,
+    runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+    ...extra,
+  };
+}
+
+describe('runner: an errored no-diff run is agent-failed, never a benign no-op', () => {
+  it('completed: false with no diff is agent-failed, naming the driver cause', async () => {
+    const r = await runRemediateTask(
+      base(
+        fakeDriver({
+          completed: false,
+          failure: { reason: 'Credit balance is too low (api_error)' },
+          transcriptTail: 'API Error: 400',
+        }),
+        { git: fakeGit({ diff: false }) },
+      ),
+    );
+    expect(r.outcome).toBe('agent-failed');
+    expect(r.note).toContain('Credit balance is too low');
+    expect(r.transcriptTail).toBe('API Error: 400');
+    // The entry floor rides the result — "not run (dry run)" was FALSE here
+    // (the floor ran; it is why the agent spawned).
+    expect(r.floor).toBe(RED_FLOOR);
+    expect(r.ledger).toContain('entry snapshot');
+    expect(r.ledger).not.toContain('dry run');
+  });
+
+  it('a budget-cut no-diff run stays a no-op with the partial flag (a true statement)', async () => {
+    const r = await runRemediateTask(
+      base(fakeDriver({ completed: false, timedOut: true }), { git: fakeGit({ diff: false }) }),
+    );
+    expect(r.outcome).toBe('no-op');
+    expect(r.partial).toBe(true);
+  });
+
+  it('a clean no-diff run is a no-op and carries the entry floor', async () => {
+    const r = await runRemediateTask(
+      base(fakeDriver({ completed: true }), { git: fakeGit({ diff: false }) }),
+    );
+    expect(r.outcome).toBe('no-op');
+    expect(r.floor).toBe(RED_FLOOR);
+  });
+
+  it('agent-never-ran carries the entry floor too (the ledger names pre-existing debt)', async () => {
+    const r = await runRemediateTask(
+      base(fakeDriver({ completed: false, neverRan: { reason: 'Credit balance is too low' } })),
+    );
+    expect(r.outcome).toBe('agent-never-ran');
+    expect(r.note).toContain('agent never ran: Credit balance is too low');
+    expect(r.floor).toBe(RED_FLOOR);
+  });
+
+  it('an errored run WITH committed work still verifies, and the failure is disclosed', async () => {
+    const r = await runRemediateTask(
+      base(
+        fakeDriver({
+          completed: false,
+          failure: { reason: 'claude exit 1' },
+          turns: 30,
+          costUsd: 1.1,
+        }),
+        { runFloor: () => GREEN_FLOOR },
+      ),
+    );
+    // Verification decides the committed work's fate — here it passes.
+    expect(r.outcome).toBe('verified');
+    expect(r.envelope?.failure).toBe('claude exit 1');
+    expect(r.ledger).toContain('driver-reported failure: claude exit 1');
+  });
+});
+
+describe('runner: auth-path disclosure (#24)', () => {
+  it('an injected declared credential is api-key; none is subscription', async () => {
+    const withKey = await runRemediateTask(base(fakeDriver({}), { agentEnv: { FAKE_KEY: 'k' } }));
+    expect(withKey.envelope?.auth).toBe('api-key');
+    expect(withKey.ledger).toContain('api-key (billed API spend)');
+
+    const without = await runRemediateTask(base(fakeDriver({})));
+    expect(without.envelope?.auth).toBe('subscription');
+  });
+
+  it('subscription costs are labeled API-equivalent, never spend', async () => {
+    const r = await runRemediateTask(base(fakeDriver({ turns: 4, costUsd: 0.08 })));
+    expect(r.ledger).toContain('API-equivalent cost: $0.08');
+    expect(r.ledger).toContain('not billed spend');
+    expect(r.ledger).not.toMatch(/- spend:/);
+  });
+
+  it('api-key costs stay labeled spend', async () => {
+    const r = await runRemediateTask(
+      base(fakeDriver({ turns: 4, costUsd: 0.08 }), { agentEnv: { FAKE_KEY: 'k' } }),
+    );
+    expect(r.ledger).toContain('- spend: $0.08');
+  });
+});
+
+describe('envelope provenance (#13)', () => {
+  it('the agent CLI build reaches the envelope and the ledger; absence is disclosed', async () => {
+    const withVersion = await runRemediateTask(base(fakeDriver({ cliVersion: '2.1.222' })));
+    expect(withVersion.envelope?.cliVersion).toBe('2.1.222');
+    expect(withVersion.ledger).toContain('agent CLI 2.1.222');
+
+    const without = await runRemediateTask(base(fakeDriver({})));
+    expect(without.ledger).toContain('agent CLI version not reported');
+  });
+
+  it('the transcript tail never reaches the ledger (job-log evidence only)', async () => {
+    const r = await runRemediateTask(
+      base(
+        fakeDriver({
+          completed: false,
+          failure: { reason: 'x' },
+          transcriptTail: 'SECRET-TAIL-MARKER',
+        }),
+        {
+          git: fakeGit({ diff: false }),
+        },
+      ),
+    );
+    expect(r.transcriptTail).toBe('SECRET-TAIL-MARKER');
+    expect(r.ledger).not.toContain('SECRET-TAIL-MARKER');
+  });
+});
+
+describe('renderFloorVerification: the entry-snapshot arm (#11)', () => {
+  it('a red entry floor with no attribution renders as pre-existing debt, never "passed"', () => {
+    const lines = renderFloorVerification(RED_FLOOR, undefined, 'the pre-agent entry run');
+    const text = lines.join('\n');
+    expect(text).toContain('entry snapshot');
+    expect(text).toContain('red (pre-existing debt');
+    expect(text).not.toContain('**passed**');
+    expect(text).toContain('typescript/import-resolution: fail');
+  });
+
+  it('a green entry floor renders green', () => {
+    const text = renderFloorVerification(GREEN_FLOOR, undefined, 'x').join('\n');
+    expect(text).toContain('**green**');
+  });
+
+  it('an absent floor still renders the dry-run line (plan paths)', () => {
+    expect(renderFloorVerification(undefined, undefined, 'x')[0]).toContain('not run (dry run)');
+  });
+
+  it('an attributed floor keeps the attributed headline', () => {
+    const text = renderFloorVerification(GREEN_FLOOR, [], 'the pre-agent entry run').join('\n');
+    expect(text).toContain('attributed vs the pre-agent entry run');
+    expect(text).toContain('**passed**');
+  });
+});
+
+describe('ledger: the failure ledger is complete without leaking evidence', () => {
+  it('renders driver failure + auth + CLI build in one envelope', () => {
+    const ledger = renderRemediateLedger({
+      outcome: 'agent-failed',
+      task: 'fix-build',
+      note: 'the agent run ended in an error and produced no committed change: Credit balance is too low.',
+      envelope: {
+        driver: 'claude-code',
+        model: 'sonnet',
+        modelSource: 'auto-tier',
+        auth: 'api-key',
+        cliVersion: '2.1.222',
+        failure: 'Credit balance is too low (api_error)',
+        turns: 1,
+        costUsd: 0,
+        budget: { maxTurns: 80, maxMinutes: 30, maxUsd: 5 },
+        unenforceableCaps: [],
+      },
+    });
+    expect(ledger).toContain('outcome: **agent-failed**');
+    expect(ledger).toContain('Credit balance is too low');
+    expect(ledger).toContain('agent CLI 2.1.222');
+    expect(ledger).toContain('api-key (billed API spend)');
+  });
+});

--- a/test/remediate/resume.test.ts
+++ b/test/remediate/resume.test.ts
@@ -110,6 +110,7 @@ function fakeDriver(): AgentDriver & { lastRun?: Parameters<AgentDriver['run']>[
     id: 'fake-agent',
     budgetSupport: { turns: true, cost: true },
     credentialEnv: [],
+    cli: null,
     resolveModel: (tier) => `fake-${tier}`,
     available: () => ({ ok: true }),
     run: async (opts) => {

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -56,6 +56,7 @@ function fakeDriver(
     id: 'fake-agent',
     budgetSupport: { turns: true, cost: true },
     credentialEnv: ['FAKE_KEY'],
+    cli: null,
     resolveModel: (tier) => `fake-${tier}`,
     available: () => ({ ok: true }),
     run: async (opts) => {

--- a/test/remediate/surface.test.ts
+++ b/test/remediate/surface.test.ts
@@ -48,6 +48,10 @@ describe('installCiRemediate (the managed workflow)', () => {
     // no unrendered substitution keys survive
     expect(text).not.toContain('__DXKIT_REMEDIATE_CREDENTIAL_ENV__');
     expect(text).not.toContain('__DXKIT_REMEDIATE_CRON__');
+    expect(text).not.toContain('__DXKIT_REMEDIATE_AGENT_CLI_INSTALL__');
+    // The agent CLI install is PINNED from the driver's declaration — an
+    // unattended lane must not float its executor (Rule 19 cause #5).
+    expect(text).toContain(`npm install -g ${claude.cli!.package}@${claude.cli!.version}`);
   });
 
   it('renders the git-identity step from the ONE bot identity (a runner has none ambient)', () => {


### PR DESCRIPTION
WP1 of the 4.3.7 honesty release: the agent lane's account of a run now matches what happened.

**The class this closes (observed live):** a remediate dispatch went green in 5 minutes having done nothing — the API key could not authenticate, the claude CLI reported the failed call as `num_turns: 1`, the zero-turns guard never fired, and the no-diff branch reported a benign no-op.

- **Driver:** never-ran now catches both observed shapes (CLI died pre-run AND an API-level failure with no work done — invalid key and credit exhaustion share one signature on CLI 2.1.222). The reason carries the provider's own human cause, so the ledger reads `agent never ran: Credit balance is too low`. `subtype` is documented as a trap and never consulted. An error after real work is a disclosed `failure`; the CLI build is probed and reported (`cliVersion`).
- **Runner (defense in depth):** the no-diff branch requires `completed` — an errored no-diff run is the new red `agent-failed` outcome, so any future driver that misses its own failure shape still cannot produce a green no-op. Every post-run exit carries the entry floor; the shared renderer gained an entry-snapshot arm that never prints "passed" over a red entry floor.
- **Disclosure:** envelope names the auth path (api-key vs subscription); subscription costs are labeled API-equivalent, never spend. Transcript tail + driver cause surface in the job log (never the PR body) on non-clean outcomes.
- **Template:** the agent CLI install is pinned, rendered from the driver's new required `cli` declaration (registry-driven).

Tests: new `test/remediate/failure-taxonomy.test.ts` pins the live credit-exhaustion signature verbatim; driver/surface contract rows extended. Full suite green locally (357 files / 5,373 tests), arch + slop + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)