### PR TITLE
fix(remediate): spend truth — advisory maxUsd disclosed, dispatch turn clamp closes the spend back door

### DIFF
--- a/docs/commands/remediate.md
+++ b/docs/commands/remediate.md
@@ -50,15 +50,25 @@ campaigns (below) and can never be scheduled from policy.
 ## Budgets (from `.dxkit/policy.json`)
 
 - `remediate.agent.budget`: `maxTurns` (default 80), `maxMinutes` (30),
-  `maxUsd` (5). Caps are enforced by the runner, not the agent's
-  self-report; a cap the driver cannot enforce is disclosed in the ledger.
+  `maxUsd` (5). What each cap can actually DO depends on the driver and is
+  declared per dimension (`enforced` / `reported` / `none`) and disclosed
+  in the ledger. For `claude-code`: `maxTurns` and `maxMinutes` are
+  enforced; **`maxUsd` is advisory** — the CLI reports spend only after
+  the run and cannot stop mid-run on cost, so real spend is bounded by
+  the turn cap and wall clock (an overrun is disclosed and the attempt
+  marked partial).
 - `remediate.taskBudgets.<id>`: per-task overrides merged over the shared
   budget.
 - `remediate.maxSpendPerRun` (0 = no ceiling): run-level USD ceiling;
   tasks beyond it are deferred to the next firing, in declaration order,
-  and named.
-- `remediate.maxDispatchBudget` (0 = undeclared): the most a dispatch
-  override may raise `maxUsd` to.
+  and named. `remediate plan` prints the per-run projection (the sum of
+  the matrix tasks' caps) either way — each matrix task is its own
+  invocation with its own cap, so one firing may spend the sum.
+- `remediate.maxDispatchBudget` (0 = undeclared): the dispatch spend
+  authority. It clamps the `max_usd` override AND the `max_turns`
+  override (proportionally against the policy budget) — turns govern real
+  spend when the driver cannot enforce cost mid-run, so an unclamped turn
+  override would be a back door around the ceiling.
 
 ## Salvage and resume
 

--- a/docs/learn/operating-the-lanes.md
+++ b/docs/learn/operating-the-lanes.md
@@ -52,11 +52,20 @@ write-access-gated by GitHub itself.
 
 ## Estimating spend
 
-The caps are hard, so the worst case is arithmetic, not a prediction:
+The worst case is arithmetic, but be precise about which caps are hard:
+`maxTurns` and `maxMinutes` are enforced by the runner/CLI; **`maxUsd` is
+advisory for the claude-code driver** (spend is reported after the run,
+not stopped mid-run — the ledger says so). Real spend is bounded by the
+turn cap, so the projection uses observed cost-per-turn, and dispatch
+turn overrides are clamped against `remediate.maxDispatchBudget` so a
+one-off campaign cannot silently raise the ceiling.
 
-> worst-case monthly spend = enabled tasks × runs per month × per-task cap
-> (default $5), additionally capped by `remediate.maxSpendPerRun` each run.
+> worst-case monthly spend ≈ enabled tasks × runs per month × per-task
+> cap (default $5, turn-bounded), additionally capped by
+> `remediate.maxSpendPerRun` each run.
 
+`remediate plan` prints the per-run projection (the sum of the matrix
+tasks' caps — each matrix task is its own invocation with its own cap).
 Example: 3 enabled tasks on the default weekly schedule, default caps:
 3 × 4 × $5 = $60/month ceiling. Real runs usually land far below their cap
 (a typical fix task spends $1–3), and every PR body discloses the actual

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -59,7 +59,7 @@ __DXKIT_REMEDIATE_TASK_OPTIONS__
         type: string
         default: ''
       max_turns:
-        description: 'Turn-cap override (blank = policy)'
+        description: 'Turn-cap override (blank = policy; clamped against remediate.maxDispatchBudget — turns govern real spend)'
         type: string
         default: ''
       max_minutes:

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -308,8 +308,10 @@ export function buildPolicySchema(version: string): Schema {
           maxDispatchBudget: {
             type: 'number',
             description:
-              'The most a workflow_dispatch campaign may raise maxUsd to (0/absent = ' +
-              'dispatch can lower spend but never raise it beyond the policy cap).',
+              'The dispatch spend authority: the most a workflow_dispatch campaign may raise ' +
+              'maxUsd to, and the same authority clamps max_turns proportionally (turns govern ' +
+              'real spend when the driver cannot enforce cost mid-run). 0/absent = dispatch ' +
+              'can lower budgets but never raise them beyond the policy caps.',
           },
           resume: {
             type: 'boolean',

--- a/src/remediate/claude-code-driver.ts
+++ b/src/remediate/claude-code-driver.ts
@@ -157,7 +157,13 @@ const TIER_ALIAS: Record<ModelTier, string> = {
 export function makeClaudeCodeDriver(exec: AgentExec = realAgentExec): AgentDriver {
   return {
     id: 'claude-code',
-    budgetSupport: { turns: true, cost: true },
+    // The honest declaration: `--max-turns` genuinely stops the run; cost is
+    // only REPORTED in the closing JSON — the CLI cannot stop mid-run on
+    // spend, so maxUsd is a post-hoc classification, never an enforcement
+    // (the $14.71-against-$5 incident). The dispatch layer clamps max_turns
+    // against the committed spend authority because turns are the lever
+    // that actually bounds spend here.
+    budgetSupport: { turns: 'enforced', cost: 'reported' },
     credentialEnv: ['ANTHROPIC_API_KEY'],
     // The pinned executor the managed workflow installs. Bump deliberately
     // (one line, one place) — never float `latest` under an unattended lane.

--- a/src/remediate/dispatch.ts
+++ b/src/remediate/dispatch.ts
@@ -15,7 +15,10 @@
  * Budget overrides are CLAMPED: maxUsd may never exceed
  * `remediate.maxDispatchBudget` (when unset, the policy's own per-task cap
  * is the ceiling — a dispatch without a declared ceiling can lower spend,
- * never raise it). Every clamp is disclosed, never silent.
+ * never raise it), and max_turns is clamped against the SAME spend
+ * authority — turns govern real spend when the driver cannot enforce
+ * maxUsd mid-run, so an unclamped turn override was a back door around the
+ * ceiling. Every clamp is disclosed, never silent.
  */
 import type { RemediateBudget, RemediateConfig } from './config';
 import { customDispatchTask, knownTaskIds, remediateTaskById, type RemediateTask } from './tasks';
@@ -136,10 +139,41 @@ export function readDispatchOverrides(
     }
   }
 
+  // TURNS are clamped against the SAME committed spend authority. maxUsd is
+  // advisory for a driver that only reports cost post-hoc, so the turn cap
+  // is the lever that actually bounds real spend — an unclamped max_turns
+  // was a back door around the ceiling ($14.71 spent against a $5 cap: the
+  // dispatch raised turns 80 → 200 and the "clamped" USD cap never
+  // enforced). A dispatch may lower turns freely; raising them beyond
+  // policy scales with the declared spend authority (usdCeiling / policy
+  // maxUsd), so with no maxDispatchBudget declared, turns cannot rise at
+  // all — the documented "spend authority grows only in committed policy"
+  // now holds for the lever that matters.
+  const turnsCeiling = Math.max(
+    policyBudget.maxTurns,
+    Math.floor(policyBudget.maxTurns * (usdCeiling / policyBudget.maxUsd)),
+  );
+  let maxTurns = policyBudget.maxTurns;
+  if (reqTurns !== undefined) {
+    maxTurns = Math.min(reqTurns, turnsCeiling);
+    if (maxTurns < reqTurns) {
+      clamped.push(
+        `max_turns override ${reqTurns} clamped to ${maxTurns} — turns govern real spend ` +
+          `when the driver cannot enforce maxUsd mid-run, so raising them beyond policy ` +
+          `(${policyBudget.maxTurns}) requires spend authority from ` +
+          `remediate.maxDispatchBudget (committed policy, ${
+            config.maxDispatchBudget > 0
+              ? `$${config.maxDispatchBudget} declared — allows up to ${turnsCeiling} turns`
+              : 'not declared'
+          })`,
+      );
+    }
+  }
+
   return {
     budget: {
       maxUsd,
-      maxTurns: reqTurns ?? policyBudget.maxTurns,
+      maxTurns,
       maxMinutes: reqMinutes ?? policyBudget.maxMinutes,
     },
     ...(model !== undefined ? { model } : {}),

--- a/src/remediate/driver.ts
+++ b/src/remediate/driver.ts
@@ -19,6 +19,9 @@
 /** dxkit's own capability tiers — driver-neutral, task-registry vocabulary. */
 export type ModelTier = 'light' | 'standard' | 'deep';
 
+/** What a driver can do about a budget cap — see `AgentDriver.budgetSupport`. */
+export type BudgetCapability = 'enforced' | 'reported' | 'none';
+
 export const MODEL_TIERS: readonly ModelTier[] = ['light', 'standard', 'deep'];
 
 export function isModelTier(v: unknown): v is ModelTier {
@@ -77,12 +80,27 @@ export interface AgentDriver {
    */
   resolveModel(tier: ModelTier): string;
   /**
-   * Which budget dimensions this driver can enforce/report. An undeclared
-   * dimension becomes a DISCLOSED limitation in the ledger ("maxUsd not
-   * enforceable by <driver>; wall-clock cap applied"), never a silent no-op.
-   * maxMinutes is always runner-enforced, so it is not declared here.
+   * Per budget dimension, what the driver can actually DO about the cap —
+   * three-valued because "reports it afterward" is not "enforces it", and
+   * conflating them shipped a $14.71 spend against a $5 cap:
+   *
+   *   - `'enforced'`  — the driver stops the run at the cap (claude-code's
+   *     `--max-turns`);
+   *   - `'reported'`  — the driver only reports the dimension after the run;
+   *     the cap is applied POST-HOC (an overrun marks the attempt partial
+   *     and is disclosed) and the ledger says so plainly;
+   *   - `'none'`      — neither enforced nor reported.
+   *
+   * Anything below `'enforced'` becomes a DISCLOSED limitation in the
+   * ledger, never a silent no-op, and the dispatch layer clamps the levers
+   * that DO bound the dimension (raising `max_turns` raises real spend, so
+   * turns are clamped against the committed spend authority). maxMinutes is
+   * always runner-enforced, so it is not declared here.
    */
-  readonly budgetSupport: { readonly turns: boolean; readonly cost: boolean };
+  readonly budgetSupport: {
+    readonly turns: BudgetCapability;
+    readonly cost: BudgetCapability;
+  };
   /**
    * Env var NAMES the driver needs (e.g. ['ANTHROPIC_API_KEY']). The managed
    * workflow template renders its secret wiring FROM this declaration, so a

--- a/src/remediate/plan-cli.ts
+++ b/src/remediate/plan-cli.ts
@@ -37,6 +37,15 @@ export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): 
   // The run-level spend ceiling, applied here so the WORKFLOW's matrix reads
   // the trimmed list from the plan (one derivation) instead of re-deriving it.
   const ceiling = tasksWithinSpendCeiling(config);
+  // The disclosed per-RUN spend projection (the undisclosed-4x class): each
+  // matrix task is its own invocation with its own maxUsd, so one firing may
+  // spend the SUM — a ceiling multiplication the serial shape's coupling
+  // used to hide. Derived from the same per-task budgets the runner
+  // enforces, and shown whether or not maxSpendPerRun caps it.
+  const projectedMaxSpendUsd = ceiling.run.reduce(
+    (sum, taskId) => sum + budgetForTask(config, taskId).maxUsd,
+    0,
+  );
 
   if (opts.json) {
     process.stdout.write(
@@ -57,11 +66,20 @@ export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): 
           matrixTasks: ceiling.run,
           deferredBySpendCeiling: ceiling.deferred,
           maxSpendPerRun: config.maxSpendPerRun,
+          /** What one firing may spend: Σ of the matrix tasks' per-task
+           *  maxUsd (each matrix job is its own invocation with its own
+           *  cap). Advisory where the driver only reports cost — see
+           *  budgetSupport. */
+          projectedMaxSpendUsd,
           unknownTasks: config.unknownTasks,
+          /** Per-dimension driver capability: 'enforced' | 'reported' |
+           *  'none'. A dimension below 'enforced' also appears in
+           *  unenforceableCaps. */
+          budgetSupport: driver ? driver.budgetSupport : null,
           unenforceableCaps: driver
             ? [
-                ...(driver.budgetSupport.turns ? [] : ['maxTurns']),
-                ...(driver.budgetSupport.cost ? [] : ['maxUsd']),
+                ...(driver.budgetSupport.turns === 'enforced' ? [] : ['maxTurns']),
+                ...(driver.budgetSupport.cost === 'enforced' ? [] : ['maxUsd']),
               ]
             : [],
         },
@@ -89,8 +107,24 @@ export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): 
     `budget: ${config.agent.budget.maxTurns} turns, ${config.agent.budget.maxMinutes} min, ` +
       `$${config.agent.budget.maxUsd} — salvage: ${config.salvage}`,
   );
-  if (!driver.budgetSupport.turns) logger.warn(`maxTurns is not enforceable by ${driver.id}`);
-  if (!driver.budgetSupport.cost) logger.warn(`maxUsd is not enforceable by ${driver.id}`);
+  if (driver.budgetSupport.turns !== 'enforced') {
+    logger.warn(`maxTurns is not enforceable by ${driver.id}`);
+  }
+  if (driver.budgetSupport.cost === 'none') {
+    logger.warn(`maxUsd is not enforceable by ${driver.id} (no spend reporting)`);
+  } else if (driver.budgetSupport.cost === 'reported') {
+    logger.warn(
+      `maxUsd is ADVISORY for ${driver.id} (cost is reported after the run, not enforced ` +
+        `mid-run) — the enforced turn cap and wall clock bound real spend`,
+    );
+  }
+  logger.info(
+    `per-run spend projection: up to $${projectedMaxSpendUsd} across ${ceiling.run.length} ` +
+      `task(s) in one firing` +
+      (config.maxSpendPerRun > 0
+        ? ` (maxSpendPerRun: $${config.maxSpendPerRun})`
+        : ' (no remediate.maxSpendPerRun ceiling declared)'),
+  );
   logger.info(`schedule (managed workflow): ${config.schedule}`);
   if (!config.enabled) {
     logger.dim('remediate.enabled is not set — the scheduled workflow is off; local runs work.');

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -104,15 +104,25 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
 
   const choice = resolveModelSetting(driver, opts.config.agent.model, task.tier);
   const budget = opts.config.agent.budget;
+  // A cap below 'enforced' is a DISCLOSED limitation, phrased by what the
+  // driver CAN do. Claiming an unenforced cap as a cap is the $14.71 class:
+  // maxUsd read post-hoc while max_turns silently governed real spend.
   const unenforceableCaps: string[] = [];
-  if (!driver.budgetSupport.turns) {
+  if (driver.budgetSupport.turns !== 'enforced') {
     unenforceableCaps.push(
       `maxTurns is not enforceable by ${driver.id}; the wall-clock cap (${budget.maxMinutes} min) applies`,
     );
   }
-  if (!driver.budgetSupport.cost) {
+  if (driver.budgetSupport.cost === 'none') {
     unenforceableCaps.push(
       `maxUsd is not enforceable by ${driver.id} (no spend reporting); the wall-clock cap applies`,
+    );
+  } else if (driver.budgetSupport.cost === 'reported') {
+    unenforceableCaps.push(
+      `maxUsd ($${budget.maxUsd}) is ADVISORY for ${driver.id}: the CLI reports spend only ` +
+        `after the run and cannot stop mid-run on cost. Real spend is bounded by the ` +
+        `enforced turn cap (${budget.maxTurns}) and the wall clock (${budget.maxMinutes} min); ` +
+        `an overrun is disclosed and the attempt marked partial`,
     );
   }
 
@@ -226,16 +236,18 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   const sweepError = git.sweepLeftovers();
   const hasDiff = git.hasDiff(baseHead);
 
+  // Reported spend exceeding the (advisory) cap is an honest post-hoc claim
+  // — "the run overran maxUsd" — for any driver that at least REPORTS cost.
   const overUsd =
-    driver.budgetSupport.cost &&
+    driver.budgetSupport.cost !== 'none' &&
     agentResult.costUsd !== undefined &&
     agentResult.costUsd > budget.maxUsd;
-  // A cap dxkit cannot enforce is a cap dxkit may not claim was HIT — the
-  // same refusal the cost clause makes. A driver that reports turns without
-  // enforcing them would otherwise mislabel a natural completion as
-  // budget-exhausted while the envelope discloses the cap as unenforceable.
+  // A cap dxkit cannot enforce is a cap dxkit may not claim was HIT — a
+  // driver that merely reports turns without enforcing them would mislabel
+  // a natural completion as budget-exhausted while the envelope discloses
+  // the cap as unenforceable.
   const overTurns =
-    driver.budgetSupport.turns &&
+    driver.budgetSupport.turns === 'enforced' &&
     agentResult.turns !== undefined &&
     agentResult.turns >= budget.maxTurns;
   const partial = agentResult.timedOut || overUsd || overTurns;

--- a/test/remediate/dispatch.test.ts
+++ b/test/remediate/dispatch.test.ts
@@ -65,12 +65,49 @@ describe('readDispatchOverrides', () => {
       BUDGET,
       { maxDispatchBudget: 0 },
     );
-    expect(d.budget.maxTurns).toBe(120);
+    // 120 turns exceeds policy (80) with no declared spend authority — the
+    // turn clamp holds (turns govern real spend; see the clamp tests below).
+    expect(d.budget.maxTurns).toBe(BUDGET.maxTurns);
     expect(d.budget.maxMinutes).toBe(BUDGET.maxMinutes); // junk ignored
     expect(d.model).toBe('sonnet-tier');
     expect(d.customPrompt).toContain('docstring');
     expect(d.actor).toBe('octocat');
     expect(d.any).toBe(true);
+  });
+});
+
+describe('the turn clamp (the $14.71 back door)', () => {
+  it('without a declared ceiling, dispatch can LOWER turns but never raise them', () => {
+    const lower = readDispatchOverrides({ [DISPATCH_ENV.maxTurns]: '20' }, BUDGET, {
+      maxDispatchBudget: 0,
+    });
+    expect(lower.budget.maxTurns).toBe(20);
+    expect(lower.clamped).toEqual([]);
+
+    // The incident dispatch: max_turns=200 against 80-turn/$5 policy. The
+    // old passthrough made turns an unclamped back door around the spend
+    // ceiling ($14.71 actually spent against the "clamped" $5 cap).
+    const raise = readDispatchOverrides({ [DISPATCH_ENV.maxTurns]: '200' }, BUDGET, {
+      maxDispatchBudget: 0,
+    });
+    expect(raise.budget.maxTurns).toBe(BUDGET.maxTurns);
+    expect(raise.clamped[0]).toContain('max_turns override 200 clamped to 80');
+    expect(raise.clamped[0]).toContain('maxDispatchBudget');
+  });
+
+  it('declared spend authority raises the turn ceiling proportionally', () => {
+    // $15 authority over a $5 policy cap = 3x → up to 240 turns.
+    const within = readDispatchOverrides({ [DISPATCH_ENV.maxTurns]: '200' }, BUDGET, {
+      maxDispatchBudget: 15,
+    });
+    expect(within.budget.maxTurns).toBe(200);
+    expect(within.clamped).toEqual([]);
+
+    const beyond = readDispatchOverrides({ [DISPATCH_ENV.maxTurns]: '500' }, BUDGET, {
+      maxDispatchBudget: 15,
+    });
+    expect(beyond.budget.maxTurns).toBe(240);
+    expect(beyond.clamped[0]).toContain('clamped to 240');
   });
 });
 
@@ -104,7 +141,7 @@ function fakeGit(): RemediateGit {
 function fakeDriver(): AgentDriver & { lastRun?: Parameters<AgentDriver['run']>[0] } {
   const driver: AgentDriver & { lastRun?: Parameters<AgentDriver['run']>[0] } = {
     id: 'fake-agent',
-    budgetSupport: { turns: true, cost: true },
+    budgetSupport: { turns: 'enforced', cost: 'reported' },
     credentialEnv: [],
     cli: null,
     resolveModel: (tier) => `fake-${tier}`,

--- a/test/remediate/driver.test.ts
+++ b/test/remediate/driver.test.ts
@@ -37,8 +37,10 @@ describe('driver registry contract', () => {
         // rolling aliases, never dated snapshot ids (the deprecation rule)
         expect(native).not.toMatch(/\d{8}/);
       }
-      expect(typeof driver.budgetSupport.turns).toBe('boolean');
-      expect(typeof driver.budgetSupport.cost).toBe('boolean');
+      // Three-valued capability per dimension — 'reported' is not 'enforced'
+      // (conflating them shipped a $14.71 spend against a $5 cap).
+      expect(['enforced', 'reported', 'none']).toContain(driver.budgetSupport.turns);
+      expect(['enforced', 'reported', 'none']).toContain(driver.budgetSupport.cost);
       expect(Array.isArray(driver.credentialEnv)).toBe(true);
       // The executor declaration: an exact pinned version (an unattended
       // lane never floats its CLI) or an explicit null — never absent.
@@ -50,6 +52,16 @@ describe('driver registry contract', () => {
     const cli = driverById('claude-code')!.cli;
     expect(cli?.package).toBe('@anthropic-ai/claude-code');
     expect(cli?.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('claude-code declares cost as REPORTED, never enforced (the honest cap)', () => {
+    // The CLI cannot stop mid-run on spend; declaring cost 'enforced' here
+    // is the $14.71-against-$5 class. Flipping this to 'enforced' requires
+    // an actual mid-run enforcement mechanism in the driver.
+    expect(driverById('claude-code')!.budgetSupport).toEqual({
+      turns: 'enforced',
+      cost: 'reported',
+    });
   });
 });
 

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -190,7 +190,7 @@ function fakeGit(opts: { diff?: boolean } = {}): RemediateGit {
 function fakeDriver(result: Partial<AgentRunResult>): AgentDriver {
   return {
     id: 'fake-agent',
-    budgetSupport: { turns: true, cost: true },
+    budgetSupport: { turns: 'enforced', cost: 'reported' },
     credentialEnv: ['FAKE_KEY'],
     cli: null,
     resolveModel: (tier) => `fake-${tier}`,

--- a/test/remediate/resume.test.ts
+++ b/test/remediate/resume.test.ts
@@ -108,7 +108,7 @@ function fakeGit(): RemediateGit {
 function fakeDriver(): AgentDriver & { lastRun?: Parameters<AgentDriver['run']>[0] } {
   const driver: AgentDriver & { lastRun?: Parameters<AgentDriver['run']>[0] } = {
     id: 'fake-agent',
-    budgetSupport: { turns: true, cost: true },
+    budgetSupport: { turns: 'enforced', cost: 'reported' },
     credentialEnv: [],
     cli: null,
     resolveModel: (tier) => `fake-${tier}`,

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -54,7 +54,7 @@ function fakeDriver(
 ): AgentDriver & { lastRun?: Parameters<AgentDriver['run']>[0] } {
   const driver: AgentDriver & { lastRun?: Parameters<AgentDriver['run']>[0] } = {
     id: 'fake-agent',
-    budgetSupport: { turns: true, cost: true },
+    budgetSupport: { turns: 'enforced', cost: 'reported' },
     credentialEnv: ['FAKE_KEY'],
     cli: null,
     resolveModel: (tier) => `fake-${tier}`,
@@ -257,7 +257,7 @@ describe('the budget envelope (runner-enforced, disclosed)', () => {
   });
 
   it('a driver that cannot enforce a cap yields a DISCLOSED limitation, never silence', async () => {
-    const driver = fakeDriver({ costUsd: 99 }, { budgetSupport: { turns: false, cost: false } });
+    const driver = fakeDriver({ costUsd: 99 }, { budgetSupport: { turns: 'none', cost: 'none' } });
     const r = await runRemediateTask(base(driver));
     // cost unsupported → the runner does NOT enforce maxUsd from a number the
     // driver cannot vouch for; both limitations are disclosed in the envelope
@@ -274,7 +274,7 @@ describe('the budget envelope (runner-enforced, disclosed)', () => {
     // and discards verified work under the default salvage policy.
     const driver = fakeDriver(
       { turns: DEFAULT_REMEDIATE_BUDGET.maxTurns },
-      { budgetSupport: { turns: false, cost: true } },
+      { budgetSupport: { turns: 'reported', cost: 'reported' } },
     );
     const r = await runRemediateTask(base(driver));
     expect(r.outcome).toBe('verified');


### PR DESCRIPTION
WP2 of the 4.3.7 honesty release: the real-money defect.

**Observed live:** a dispatch with `max_turns=200` spent $14.71 against a $5 cap on the customer's account. `maxUsd` was read after the run (never enforced), and `max_turns` passed through unclamped — the lever that actually governs spend had no relationship to the committed spend authority.

- `budgetSupport` is now three-valued per dimension (`enforced` / `reported` / `none`); claude-code honestly declares `cost: 'reported'`, pinned by a contract test.
- The ledger discloses an advisory cap plainly; a cap is only claimed HIT when the driver can vouch for the dimension.
- Dispatch `max_turns` is clamped against the same spend authority as `max_usd` (proportional to `remediate.maxDispatchBudget`; no ceiling declared → turns cannot rise). The incident dispatch now clamps 200 → 80 with the reason named.
- `remediate plan` prints the per-run spend projection (Σ matrix task caps — the matrix redesign silently multiplied the ceiling ~4x) in human output and plan JSON.
- Docs stop claiming "the caps are hard".

Incremental cost streaming investigated and deliberately not built (the CLI reports cost only at close; a mid-run estimate needs a maintained price table — a Rule 19 cause-#5 drift surface). The turn clamp + honest declaration close the hole without it.

Full remediate + learn suites green (205 tests), arch/lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)