### PR TITLE
fix(remediate): salvage/resume truth — task-shape defaults, durable attempt counter, blocked-attempt salvage, runtime-artifact scrub

### DIFF
--- a/docs/commands/remediate.md
+++ b/docs/commands/remediate.md
@@ -72,13 +72,29 @@ campaigns (below) and can never be scheduled from policy.
 
 ## Salvage and resume
 
-`remediate.salvage` defaults to `discard`: a partial diff from a
-budget-killed run is dropped. With `draft-pr`, the partial lands as a
-draft PR marked partial. With `remediate.resume: true` (opt-in), the next
-run continues from that salvage branch instead of starting over, up to 2
-attempts per branch before falling back to a fresh run. The entry floor
-still snapshots the pristine default tree first, so a broken partial
-reads as net-new and can never grandfather its own breakage.
+`remediate.salvage` defaults to `auto`: the decision follows each task's
+declared completion shape. Open-ended tasks (`write-docs`,
+`improve-tests`) have no completion test — the agent stops when a cap
+cuts it off, never because it is done — so `discard` would throw away
+their verified, gate-passing work every run; they default to `draft-pr`.
+Bounded tasks (`fix-build`, `fix-vulns`, `fix-lint`) can genuinely
+finish, so they keep the conservative `discard`. Pin `discard` or
+`draft-pr` in policy to override every task.
+
+Under `draft-pr`, a budget-cut partial lands as a draft PR marked
+partial, and a guardrail-BLOCKED attempt lands as a red draft titled "do
+not merge" — its own required guardrail check keeps it unmergeable, so
+nothing merges while the work and the exact blocking findings survive
+the ephemeral runner. An unrunnable guardrail never pushes anything.
+
+With `remediate.resume: true` (opt-in), the next run continues from that
+salvage branch instead of starting over, up to 2 attempts per branch
+before falling back to a fresh run (the attempt counter is pushed with
+the branch, so a no-op resume still consumes an attempt). A resumed
+attempt after a guardrail block gets the prior blocking findings in its
+prompt, so it starts from "close these", not from scratch. The entry
+floor still snapshots the pristine default tree first, so a broken
+partial reads as net-new and can never grandfather its own breakage.
 
 ## Dispatch campaigns
 

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -207,9 +207,11 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
   },
   {
     path: 'remediate.salvage',
-    summary: 'fate of budget-cut partial work',
+    summary:
+      'fate of partial/blocked work: auto (default — per task shape: open-ended tasks ' +
+      'draft-pr, bounded tasks discard), or pin one value for every task',
     anchor: 'remediate-salvage',
-    enumValues: ['discard', 'draft-pr'],
+    enumValues: ['auto', 'discard', 'draft-pr'],
   },
   {
     path: 'remediate.agent.driver',

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -316,9 +316,10 @@ export function buildPolicySchema(version: string): Schema {
           resume: {
             type: 'boolean',
             description:
-              'Opt-in: continue a prior budget-bounded attempt from its draft-PR salvage ' +
-              'branch instead of starting over (requires salvage: "draft-pr"; capped ' +
-              'resumes; entry floor stays anchored to the pristine base).',
+              'Opt-in: continue a prior budget-bounded or guardrail-blocked attempt from its ' +
+              'draft-PR salvage branch instead of starting over (requires the effective ' +
+              'per-task salvage to be draft-pr; capped resumes with a durable attempt ' +
+              'counter; entry floor stays anchored to the pristine base).',
           },
         },
         'Agentic remediation: a scheduled agent inside the verified frame.',

--- a/src/lanes/ledger.ts
+++ b/src/lanes/ledger.ts
@@ -40,6 +40,10 @@ export interface LaneEvent {
    *  budget-bounded draft that a reviewer chose to merge anyway. */
   readonly outcome: 'landed';
   readonly partial?: boolean;
+  /** The draft was pushed BLOCKED (guardrail-red salvage): unmergeable until
+   *  its findings are fixed — if this event ever reaches the default branch,
+   *  a human resolved them first. */
+  readonly blocked?: boolean;
   readonly findingsClosed?: readonly LaneFindingsClosed[];
   readonly costUsd?: number;
   readonly resolvedModelId?: string;

--- a/src/remediate/cli.ts
+++ b/src/remediate/cli.ts
@@ -34,6 +34,7 @@ import { prepareResume, type ResumeDecision } from './resume';
 import {
   budgetForTask,
   resolveRemediateConfig,
+  salvageForTask,
   tasksWithinSpendCeiling,
   type RemediateConfig,
 } from './config';
@@ -87,8 +88,13 @@ async function executeTask(
   const task = remediateTaskById(taskId);
   const policyBudget = task ? budgetForTask(config, task.id) : config.agent.budget;
   const dispatch = readDispatchOverrides(process.env, policyBudget, config);
+  // The concrete salvage decision for THIS task (the one resolver: explicit
+  // policy wins, 'auto' follows the task's completion shape) — threaded into
+  // the runner's config so the ledger note and the landing below agree.
+  const salvage = task ? salvageForTask(config, task) : 'discard';
   const taskConfig: RemediateConfig = {
     ...config,
+    salvage,
     agent: {
       ...config.agent,
       budget: dispatch.any ? dispatch.budget : policyBudget,
@@ -102,13 +108,14 @@ async function executeTask(
   let entryFloor: CorrectnessFloorResult | undefined;
   let resume: ResumeDecision = { resumed: false };
   if (land === 'pr' && task && config.resume) {
+    // (salvage below is the task-resolved decision — resume needs draft-pr)
     entryFloor = runCorrectnessFloor({
       cwd,
       changedFiles: [],
       scope: 'full',
       packs: detectActiveLanguages(cwd),
     });
-    resume = prepareResume(cwd, task.id, config);
+    resume = prepareResume(cwd, task.id, { resume: config.resume, salvage });
     if (resume.note) logger.warn(`resume: ${resume.note}`);
     if (resume.resumed) {
       logger.info(`resuming budget-bounded attempt #${resume.attempt} from the salvage branch`);
@@ -129,15 +136,27 @@ async function executeTask(
       dispatch,
       ...(entryFloor !== undefined ? { entryFloor } : {}),
       ...(resume.resumed && resume.attempt !== undefined
-        ? { resume: { attempt: resume.attempt } }
+        ? {
+            resume: {
+              attempt: resume.attempt,
+              ...(resume.blockingContext ? { blockingContext: resume.blockingContext } : {}),
+            },
+          }
         : {}),
     });
   } finally {
     reporter.stop();
   }
 
-  const draftSalvage = result.outcome === 'budget-exhausted' && config.salvage === 'draft-pr';
-  const landEligible = result.outcome === 'verified' || draftSalvage;
+  const draftSalvage = result.outcome === 'budget-exhausted' && salvage === 'draft-pr';
+  // Guardrail-red under draft-pr salvage: the BLOCKED attempt is pushed as a
+  // RED draft — its own required guardrail check keeps it unmergeable, so
+  // "nothing merges" holds while the work + blocking findings survive the
+  // ephemeral runner and the next run can RESUME from them (guardrail-red
+  // was the outcome where the most valuable partial work died). Only a
+  // RAN-and-blocked verdict qualifies; an unrunnable guardrail never pushes.
+  const blockedSalvage = result.outcome === 'guardrail-red' && salvage === 'draft-pr';
+  const landEligible = result.outcome === 'verified' || draftSalvage || blockedSalvage;
   if (land !== 'pr' || !landEligible) {
     return finalizeTaskRun(cwd, taskId, {
       result,
@@ -170,7 +189,8 @@ async function executeTask(
     lane: 'remediate',
     task: taskId,
     outcome: 'landed',
-    ...(draftSalvage ? { partial: true } : {}),
+    ...(draftSalvage || blockedSalvage ? { partial: true } : {}),
+    ...(blockedSalvage ? { blocked: true } : {}),
     ...(result.envelope?.costUsd !== undefined ? { costUsd: result.envelope.costUsd } : {}),
     ...(result.envelope?.resolvedModelId
       ? { resolvedModelId: result.envelope.resolvedModelId }
@@ -181,15 +201,23 @@ async function executeTask(
     cwd,
     taskId,
     defaultBranch,
-    prTitle: `dxkit remediate: ${taskId}${draftSalvage ? ' (partial, budget-bounded)' : ''}`,
+    prTitle:
+      `dxkit remediate: ${taskId}` +
+      (blockedSalvage
+        ? ' (blocked: guardrail-red — do not merge)'
+        : draftSalvage
+          ? ' (partial, budget-bounded)'
+          : ''),
     prBody: result.ledger,
-    draft: draftSalvage,
+    draft: draftSalvage || blockedSalvage,
     ledgerPath,
   });
   return finalizeTaskRun(cwd, taskId, {
     result,
     ...(landResult.prUrl ? { prUrl: landResult.prUrl } : {}),
     landed: true,
+    // A blocked salvage is NOT clean: the draft exists for inspection and
+    // resume, but the task did not end well — the job stays red.
     clean: result.outcome === 'verified' || draftSalvage,
   });
 }

--- a/src/remediate/cli.ts
+++ b/src/remediate/cli.ts
@@ -45,9 +45,16 @@ import { runRemediateTask, type RemediateResult } from './run';
 import { landRemediateHead, remediateBranchFor } from './land';
 import { appendLaneEvent, LANE_LEDGER_SCHEMA_VERSION } from '../lanes/ledger';
 
-// `remediate plan` lives in `./plan-cli` (module-size split); re-exported so
-// consumers keep one import surface.
+// `remediate plan` lives in `./plan-cli` and the configured sequencing loop
+// in `./configured-loop` (module-size splits); re-exported so consumers keep
+// one import surface.
 export { runRemediatePlan, type RemediatePlanOptions } from './plan-cli';
+export {
+  runConfiguredLoop,
+  type ConfiguredLoopOps,
+  type ConfiguredLoopResult,
+} from './configured-loop';
+import { headCommit, resetHardTo, runConfiguredLoop } from './configured-loop';
 
 export interface TaskRun {
   readonly result: RemediateResult;
@@ -334,71 +341,6 @@ export interface RemediateConfiguredOptions {
   readonly json?: boolean;
 }
 
-/** The seams the configured loop drives — injectable so the sequencing
- *  POLICY is unit-testable without git or an agent. */
-export interface ConfiguredLoopOps {
-  execute(taskId: string): Promise<TaskRun>;
-  /** Current commit, or null when unreadable. */
-  head(): string | null;
-  /** Hard-reset the tree to a commit; false on failure. */
-  resetTo(head: string): boolean;
-  report(taskId: string, run: TaskRun): void;
-}
-
-export interface ConfiguredLoopResult {
-  readonly runs: ReadonlyArray<{ readonly taskId: string; readonly run: TaskRun }>;
-  /** Tasks NOT run because an earlier task left unlanded work in the tree
-   *  (or a reset failed) — disclosed, never silent. */
-  readonly skipped: readonly string[];
-  readonly failed: boolean;
-}
-
-/**
- * The sequencing policy of `remediate configured` (X-1): tasks share one
- * tree, so isolation between them is explicit —
- *
- *   - after a LANDED task, the tree resets to the initial head (the work
- *     lives on the pushed standing branch), so the next task's PR carries
- *     ONLY its own diff;
- *   - a task that left UNLANDED work in the tree (floor-red, guardrail-red,
- *     a discarded partial, a refused landing) STOPS the loop: resetting
- *     would destroy the work the ledger promises stays for inspection, and
- *     running the next task on a polluted tree would stack diffs into its
- *     PR. The remaining tasks are named as skipped; the next scheduled run
- *     picks them up on a fresh checkout.
- */
-export async function runConfiguredLoop(
-  tasks: readonly string[],
-  ops: ConfiguredLoopOps,
-): Promise<ConfiguredLoopResult> {
-  const initialHead = ops.head();
-  const runs: Array<{ taskId: string; run: TaskRun }> = [];
-  let skipped: string[] = [];
-  let failed = false;
-
-  for (let i = 0; i < tasks.length; i++) {
-    const taskId = tasks[i];
-    const run = await ops.execute(taskId);
-    ops.report(taskId, run);
-    runs.push({ taskId, run });
-    if (!run.clean) failed = true;
-
-    const moved = initialHead !== null && ops.head() !== initialHead;
-    if (!moved) continue;
-
-    const remaining = tasks.slice(i + 1);
-    if (run.landed) {
-      if (ops.resetTo(initialHead!)) continue;
-      skipped = remaining; // a failed reset means a polluted tree — stop
-      failed = true;
-      break;
-    }
-    skipped = remaining;
-    break;
-  }
-  return { runs, skipped, failed };
-}
-
 /**
  * `remediate configured` — every policy-configured task through the one
  * executor, sequenced by `runConfiguredLoop`. The managed workflow calls
@@ -461,34 +403,6 @@ export async function runRemediateConfigured(
     );
   }
   if (outcome.failed) process.exitCode = 1;
-}
-
-/** Current commit sha, or null when unreadable. */
-function headCommit(cwd: string): string | null {
-  try {
-    return execFileSync('git', ['rev-parse', 'HEAD'], {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
-  } catch {
-    return null;
-  }
-}
-
-/** Hard-reset to a commit (used only after a LANDED task — the work is on
- *  the pushed standing branch). False on failure. */
-function resetHardTo(cwd: string, head: string): boolean {
-  try {
-    execFileSync('git', ['reset', '--hard', head], {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /** Credentials the configured driver declares, read from THIS process env

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -168,7 +168,8 @@ export function resolveRemediateConfig(cwd: string): RemediateConfig {
     tasks: tasks.length > 0 ? tasks : (['fix-vulns'] as const),
     unknownTasks,
     schedule: typeof raw.schedule === 'string' && raw.schedule.trim() ? raw.schedule : 'weekly',
-    salvage: raw.salvage === 'draft-pr' ? 'draft-pr' : raw.salvage === 'discard' ? 'discard' : 'auto',
+    salvage:
+      raw.salvage === 'draft-pr' ? 'draft-pr' : raw.salvage === 'discard' ? 'discard' : 'auto',
     agent: {
       driver:
         typeof agent.driver === 'string' && agent.driver.trim() ? agent.driver : 'claude-code',

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -5,8 +5,9 @@
  *   - `budget` is required-with-defaults: an enabled block with no budget
  *     gets the conservative caps below, echoed in the ledger — never an
  *     unbounded run (the stranded-spend scar);
- *   - `salvage` defaults to `discard`: a partial diff from a budget-killed
- *     run is dropped unless the repo opts into draft PRs;
+ *   - `salvage` defaults to `auto`: the decision follows each task's
+ *     declared completion shape (open-ended → draft-pr, bounded → discard;
+ *     see `salvageForTask`) unless policy pins one value for every task;
  *   - unknown task ids are RETAINED in `unknownTasks` (disclosed by the
  *     caller, never silently dropped — a typo must not read as "nothing to
  *     do");
@@ -14,7 +15,7 @@
  *     workflow injects them from repo secrets.
  */
 import { readPolicySection } from '../baseline/policy-text';
-import { knownTaskIds, type RemediateTaskId } from './tasks';
+import { knownTaskIds, remediateTaskById, type RemediateTask, type RemediateTaskId } from './tasks';
 
 export interface RemediateBudget {
   readonly maxTurns: number;
@@ -35,7 +36,14 @@ export interface RemediateConfig {
   readonly unknownTasks: readonly string[];
   /** Cadence for the managed workflow (the cadence-knob grammar). */
   readonly schedule: string;
-  readonly salvage: 'discard' | 'draft-pr';
+  /**
+   * The salvage POSTURE as configured. `'auto'` (the default when policy
+   * says nothing) resolves PER TASK from its declared completion shape —
+   * see `salvageForTask`. An explicit `'discard'` / `'draft-pr'` overrides
+   * every task. Consumers of a concrete decision go through
+   * `salvageForTask`, never this raw field.
+   */
+  readonly salvage: 'discard' | 'draft-pr' | 'auto';
   readonly agent: {
     readonly driver: string;
     /** 'auto' | a tier name | a driver-native id (resolved per task). */
@@ -65,6 +73,29 @@ export interface RemediateConfig {
    *  partial can never grandfather its own breakage. Hard cap of
    *  MAX_RESUME_ATTEMPTS per branch (resume.ts). */
   readonly resume: boolean;
+}
+
+/**
+ * The effective salvage decision for ONE task — the single resolver every
+ * consumer reads (the CLI's land eligibility, the runner's disposition
+ * note, resume eligibility). An explicit policy setting wins; `'auto'`
+ * follows the task's declared completion shape: open-ended tasks (docs,
+ * tests — no completion test, every outcome is budget-bounded) default to
+ * `draft-pr` so their verified work is never structurally discarded;
+ * bounded tasks keep the conservative `discard`.
+ */
+export function salvageForTask(
+  config: Pick<RemediateConfig, 'salvage'>,
+  task: Pick<RemediateTask, 'completion'> | RemediateTaskId,
+): 'discard' | 'draft-pr' {
+  if (config.salvage !== 'auto') return config.salvage;
+  const shape =
+    typeof task === 'string'
+      ? // 'custom' lives outside the registry (dispatch-only) and has no
+        // completion test — open-ended by construction.
+        (remediateTaskById(task)?.completion ?? (task === 'custom' ? 'open-ended' : 'bounded'))
+      : task.completion;
+  return shape === 'open-ended' ? 'draft-pr' : 'discard';
 }
 
 /** The effective budget for one task: the per-task override merged over the
@@ -137,7 +168,7 @@ export function resolveRemediateConfig(cwd: string): RemediateConfig {
     tasks: tasks.length > 0 ? tasks : (['fix-vulns'] as const),
     unknownTasks,
     schedule: typeof raw.schedule === 'string' && raw.schedule.trim() ? raw.schedule : 'weekly',
-    salvage: raw.salvage === 'draft-pr' ? 'draft-pr' : 'discard',
+    salvage: raw.salvage === 'draft-pr' ? 'draft-pr' : raw.salvage === 'discard' ? 'discard' : 'auto',
     agent: {
       driver:
         typeof agent.driver === 'string' && agent.driver.trim() ? agent.driver : 'claude-code',

--- a/src/remediate/configured-loop.ts
+++ b/src/remediate/configured-loop.ts
@@ -1,0 +1,101 @@
+/**
+ * The configured-run SEQUENCING LOOP (X-1) + its git seams — pure policy,
+ * injectable, unit-tested without git or an agent. Split from `cli.ts`
+ * purely for module size (the plan-cli precedent); `cli.ts` re-exports the
+ * loop, so consumers keep one import surface.
+ */
+import { execFileSync } from 'child_process';
+import type { TaskRun } from './cli';
+
+/** The seams the configured loop drives — injectable so the sequencing
+ *  POLICY is unit-testable without git or an agent. */
+export interface ConfiguredLoopOps {
+  execute(taskId: string): Promise<TaskRun>;
+  /** Current commit, or null when unreadable. */
+  head(): string | null;
+  /** Hard-reset the tree to a commit; false on failure. */
+  resetTo(head: string): boolean;
+  report(taskId: string, run: TaskRun): void;
+}
+
+export interface ConfiguredLoopResult {
+  readonly runs: ReadonlyArray<{ readonly taskId: string; readonly run: TaskRun }>;
+  /** Tasks NOT run because an earlier task left unlanded work in the tree
+   *  (or a reset failed) — disclosed, never silent. */
+  readonly skipped: readonly string[];
+  readonly failed: boolean;
+}
+
+/**
+ * The sequencing policy of `remediate configured` (X-1): tasks share one
+ * tree, so isolation between them is explicit —
+ *
+ *   - after a LANDED task, the tree resets to the initial head (the work
+ *     lives on the pushed standing branch), so the next task's PR carries
+ *     ONLY its own diff;
+ *   - a task that left UNLANDED work in the tree (floor-red, guardrail-red,
+ *     a discarded partial, a refused landing) STOPS the loop: resetting
+ *     would destroy the work the ledger promises stays for inspection, and
+ *     running the next task on a polluted tree would stack diffs into its
+ *     PR. The remaining tasks are named as skipped; the next scheduled run
+ *     picks them up on a fresh checkout.
+ */
+export async function runConfiguredLoop(
+  tasks: readonly string[],
+  ops: ConfiguredLoopOps,
+): Promise<ConfiguredLoopResult> {
+  const initialHead = ops.head();
+  const runs: Array<{ taskId: string; run: TaskRun }> = [];
+  let skipped: string[] = [];
+  let failed = false;
+
+  for (let i = 0; i < tasks.length; i++) {
+    const taskId = tasks[i];
+    const run = await ops.execute(taskId);
+    ops.report(taskId, run);
+    runs.push({ taskId, run });
+    if (!run.clean) failed = true;
+
+    const moved = initialHead !== null && ops.head() !== initialHead;
+    if (!moved) continue;
+
+    const remaining = tasks.slice(i + 1);
+    if (run.landed) {
+      if (ops.resetTo(initialHead!)) continue;
+      skipped = remaining; // a failed reset means a polluted tree — stop
+      failed = true;
+      break;
+    }
+    skipped = remaining;
+    break;
+  }
+  return { runs, skipped, failed };
+}
+
+/** Current commit sha, or null when unreadable. */
+export function headCommit(cwd: string): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Hard-reset to a commit (used only after a LANDED task — the work is on
+ *  the pushed standing branch). False on failure. */
+export function resetHardTo(cwd: string, head: string): boolean {
+  try {
+    execFileSync('git', ['reset', '--hard', head], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/remediate/git-ops.ts
+++ b/src/remediate/git-ops.ts
@@ -6,7 +6,11 @@
  */
 import { execFileSync } from 'child_process';
 import { BOT_IDENTITY } from '../land-refresh';
+import { DXKIT_RUNTIME_ARTIFACT_PATHS, isRuntimeArtifactPath } from '../runtime-artifacts';
 import type { RemediateGit } from './run';
+
+/** Runtime paths as pathspecs for staged-restore (strip trailing slash). */
+const RUNTIME_PATHSPECS = DXKIT_RUNTIME_ARTIFACT_PATHS.map((p) => p.replace(/\/$/, ''));
 
 export function realGit(cwd: string): RemediateGit {
   const git = (args: string[]): string =>
@@ -17,18 +21,12 @@ export function realGit(cwd: string): RemediateGit {
       const status = git(['status', '--porcelain']);
       const leftovers = status
         .split('\n')
-        .filter(
-          (l) =>
-            l.trim() &&
-            !l.includes('.dxkit/loop') &&
-            !l.includes('.dxkit/cache') &&
-            !l.includes('.dxkit/reports'),
-        );
+        .filter((l) => l.trim() && !isRuntimeArtifactPath(l.slice(3).trim()));
       if (leftovers.length === 0) return undefined;
       try {
         git(['add', '-A']);
         try {
-          git(['restore', '--staged', '--', '.dxkit/loop', '.dxkit/cache', '.dxkit/reports']);
+          git(['restore', '--staged', '--', ...RUNTIME_PATHSPECS]);
         } catch {
           // nothing staged from runtime paths — fine
         }
@@ -50,6 +48,42 @@ export function realGit(cwd: string): RemediateGit {
         return e instanceof Error ? e.message.split('\n').slice(-1)[0] : String(e);
       }
     },
-    hasDiff: (baseHead: string) => git(['rev-list', '--count', `${baseHead}..HEAD`]) !== '0',
+    scrubRuntimeArtifacts(baseHead: string) {
+      // The sweep keeps runtime state out of ITS commit, but the AGENT
+      // commits as it goes and can commit scan output it generated mid-run
+      // (observed live: a salvage draft carrying .dxkit/reports/* +
+      // .dxkit/cache/*). Drop from the attempt every runtime-artifact path
+      // that did NOT exist at the base — a repo that deliberately tracks
+      // reports keeps them; only artifacts this attempt introduced are
+      // regenerable noise. Fail-open: a scrub error leaves the attempt
+      // as-is (the guardrail still gates it).
+      try {
+        const changed = git(['diff', '--name-only', baseHead, 'HEAD']).split('\n').filter(Boolean);
+        const baseTracked = new Set(
+          git(['ls-tree', '-r', '--name-only', baseHead]).split('\n').filter(Boolean),
+        );
+        const scrub = changed.filter((f) => isRuntimeArtifactPath(f) && !baseTracked.has(f));
+        if (scrub.length === 0) return [];
+        git(['rm', '-r', '-q', '--cached', '--ignore-unmatch', '--', ...scrub]);
+        git([
+          '-c',
+          `user.name=${BOT_IDENTITY.name}`,
+          '-c',
+          `user.email=${BOT_IDENTITY.email}`,
+          'commit',
+          '-q',
+          '-m',
+          'chore: drop dxkit runtime artifacts from the attempt (regenerable scan state)',
+        ]);
+        return scrub;
+      } catch {
+        return [];
+      }
+    },
+    // CONTENT diff, not commit count: a resume's empty marker commit (or an
+    // attempt whose only content was scrubbed runtime state) has commits but
+    // changes nothing — reporting it as a diff would verify and land
+    // nothing-shaped work.
+    hasDiff: (baseHead: string) => git(['diff', '--name-only', baseHead, 'HEAD']) !== '',
   };
 }

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -80,6 +80,16 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
     );
   }
 
+  if (r.scrubbedArtifacts && r.scrubbedArtifacts.length > 0) {
+    lines.push(
+      `Dropped from the attempt (regenerable dxkit scan state the agent committed mid-run — ` +
+        `never part of the delivery): ${r.scrubbedArtifacts.length} path(s): ` +
+        r.scrubbedArtifacts.slice(0, 8).join(', ') +
+        (r.scrubbedArtifacts.length > 8 ? ', …' : ''),
+      '',
+    );
+  }
+
   if (r.dispatch) {
     lines.push('### Dispatch campaign', '');
     lines.push(

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -92,6 +92,9 @@ export interface RemediateResult {
    *  non-clean outcome (the run page must be diagnosable without reading
    *  source). Never rendered into the ledger / PR body. */
   readonly transcriptTail?: string;
+  /** dxkit runtime-artifact paths dropped from the attempt (regenerable
+   *  scan state the agent committed mid-run) — disclosed in the ledger. */
+  readonly scrubbedArtifacts?: readonly string[];
   /** The verification ledger — PR body / job summary markdown. */
   readonly ledger: string;
 }
@@ -101,7 +104,13 @@ export interface RemediateGit {
   /** Commit uncommitted leftovers (excluding dxkit runtime state); returns
    *  an error string when the sweep commit failed. */
   sweepLeftovers(): string | undefined;
-  /** Any commits in base..HEAD? */
+  /** Drop attempt-introduced dxkit runtime artifacts (regenerable scan
+   *  state the AGENT committed mid-run) from the landing; returns the
+   *  scrubbed paths (disclosed). Paths tracked at base are never touched.
+   *  Fail-open: an error returns [] and the attempt lands as-is. */
+  scrubRuntimeArtifacts(baseHead: string): readonly string[];
+  /** Any CONTENT change in base..HEAD? (Commit count is the wrong
+   *  question: a resume marker is an empty commit.) */
   hasDiff(baseHead: string): boolean;
 }
 
@@ -134,8 +143,10 @@ export interface RemediateRunOptions {
    *  default tree BEFORE checking out a salvage branch, so attribution stays
    *  anchored to the original base — a broken partial reads NET-NEW. */
   readonly entryFloor?: CorrectnessFloorResult;
-  /** Present when this run continues a prior budget-bounded attempt. */
-  readonly resume?: { readonly attempt: number };
+  /** Present when this run continues a prior budget-bounded attempt. The
+   *  optional blockingContext is the prior attempt's guardrail findings
+   *  (from its draft-PR ledger) — appended to the prompt, never the ledger. */
+  readonly resume?: { readonly attempt: number; readonly blockingContext?: string };
 }
 
 /** The runner's observable phases, in order. */

--- a/src/remediate/resume.ts
+++ b/src/remediate/resume.ts
@@ -48,9 +48,28 @@ export interface ResumeDecision {
   readonly resumed: boolean;
   /** 1-based resume attempt number (marker commits + 1). */
   readonly attempt?: number;
+  /** The prior attempt's blocking findings (extracted from the open draft
+   *  PR's ledger body, bounded) — carried into the resumed prompt so
+   *  attempt N+1 starts from "close these findings", not from scratch. */
+  readonly blockingContext?: string;
   /** Why no resume happened, when the knob is ON but nothing resumed —
    *  disclosed by the caller, never silent. Absent when the knob is off. */
   readonly note?: string;
+}
+
+/** Extract the ledger's "Blocking findings" list from a PR body, bounded —
+ *  the durable record of WHY the prior attempt was blocked. */
+export function extractBlockingContext(body: string | undefined): string | undefined {
+  if (!body) return undefined;
+  const idx = body.indexOf('Blocking findings:');
+  if (idx === -1) return undefined;
+  const section = body
+    .slice(idx)
+    .split('\n')
+    .slice(1)
+    .filter((l) => l.trim().startsWith('- '));
+  if (section.length === 0) return undefined;
+  return section.join('\n').slice(0, 1500);
 }
 
 /**
@@ -76,12 +95,25 @@ export function prepareResume(
   const branch = remediateBranchFor(taskId);
   try {
     // An OPEN PR for the standing branch is the resume anchor — a merged or
-    // closed one means the work was decided on; start fresh.
-    const prJson = run('gh', ['pr', 'list', '--head', branch, '--state', 'open', '--json', 'url']);
-    const open = JSON.parse(prJson || '[]') as unknown[];
+    // closed one means the work was decided on; start fresh. The body is the
+    // prior attempt's ledger: its "Blocking findings" list (a guardrail-red
+    // salvage) is carried into the resumed prompt so attempt N+1 starts from
+    // "close these findings", not from scratch.
+    const prJson = run('gh', [
+      'pr',
+      'list',
+      '--head',
+      branch,
+      '--state',
+      'open',
+      '--json',
+      'url,body',
+    ]);
+    const open = JSON.parse(prJson || '[]') as Array<{ body?: string }>;
     if (!Array.isArray(open) || open.length === 0) {
       return { resumed: false, note: `no open draft PR for '${branch}' — fresh run` };
     }
+    const blockingContext = extractBlockingContext(open[0]?.body);
     run('git', ['fetch', 'origin', branch]);
     // Count prior resume markers on the salvage head (bounded to the branch's
     // own history vs the current default tree).
@@ -112,7 +144,28 @@ export function prepareResume(
       '-m',
       `${RESUME_MARKER} [skip ci]`,
     ]);
-    return { resumed: true, attempt: prior + 1 };
+    // Push the marker IMMEDIATELY — the attempt counter must advance even
+    // when this attempt lands nothing. The counter previously lived only in
+    // commits the lander force-pushed on success, so a doomed branch whose
+    // resumes kept no-oping counted "attempt #1" forever and re-spent its
+    // budget every scheduled firing (MAX_RESUME_ATTEMPTS was unreachable —
+    // observed live across three runs). At this point HEAD is provably
+    // FETCH_HEAD + one empty marker commit, so the push carries ZERO agent
+    // content — the never-push-unverified law is untouched.
+    let note: string | undefined;
+    try {
+      run('git', ['push', 'origin', `HEAD:refs/heads/${branch}`]);
+    } catch (e) {
+      note =
+        `attempt marker could not be pushed (${e instanceof Error ? e.message.split('\n')[0] : String(e)}) — ` +
+        `the ${MAX_RESUME_ATTEMPTS}-attempt cap may not engage across runs until a landing pushes`;
+    }
+    return {
+      resumed: true,
+      attempt: prior + 1,
+      ...(blockingContext ? { blockingContext } : {}),
+      ...(note ? { note } : {}),
+    };
   } catch (e) {
     return {
       resumed: false,
@@ -121,11 +174,17 @@ export function prepareResume(
   }
 }
 
-/** The continuation instruction appended to the task prompt on a resume. */
-export function resumePromptNote(attempt: number): string {
+/** The continuation instruction appended to the task prompt on a resume.
+ *  When the prior attempt was BLOCKED, its findings ride along so this
+ *  attempt starts from "close these", not from scratch. */
+export function resumePromptNote(attempt: number, blockingContext?: string): string {
   return (
     `\nRESUMED ATTEMPT #${attempt}: a previous budget-bounded run already committed real ` +
     `work on this branch. Read docs/DXKIT-REMEDIATION-NOTES.md and the recent git log ` +
-    `FIRST, then CONTINUE from where it stopped — do not redo or rewrite completed work.`
+    `FIRST, then CONTINUE from where it stopped — do not redo or rewrite completed work.` +
+    (blockingContext
+      ? `\nThe previous attempt was BLOCKED by the guardrail on exactly these findings — ` +
+        `resolving them is this attempt's FIRST priority:\n${blockingContext}`
+      : '')
   );
 }

--- a/src/remediate/resume.ts
+++ b/src/remediate/resume.ts
@@ -22,6 +22,7 @@
  */
 import { execFileSync } from 'child_process';
 import { BOT_IDENTITY } from '../land-refresh';
+import { internalGitPushArgs } from '../git-internal-push';
 import { remediateBranchFor } from './land';
 import type { RemediateConfig } from './config';
 
@@ -154,7 +155,7 @@ export function prepareResume(
     // content — the never-push-unverified law is untouched.
     let note: string | undefined;
     try {
-      run('git', ['push', 'origin', `HEAD:refs/heads/${branch}`]);
+      run('git', internalGitPushArgs(`HEAD:refs/heads/${branch}`));
     } catch (e) {
       note =
         `attempt marker could not be pushed (${e instanceof Error ? e.message.split('\n')[0] : String(e)}) — ` +

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -34,6 +34,7 @@ import { resolveDispatchedTask } from './dispatch';
 import { resumePromptNote } from './resume';
 import { realGit } from './git-ops';
 import { evaluateScoreHinge, healthHingeScores } from './score-hinge';
+import { salvageForTask } from './config';
 import type { AgentEnvelope, RemediateResult, RemediateRunOptions } from './outcome';
 
 // The outcome vocabulary lives in `./outcome` and the ledger renderer in
@@ -56,7 +57,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   const finish = (r: Omit<RemediateResult, 'ledger' | 'dispatch' | 'resume'>): RemediateResult => {
     const withDispatch = {
       ...dispatchDisclosure,
-      ...(opts.resume ? { resume: opts.resume } : {}),
+      ...(opts.resume ? { resume: { attempt: opts.resume.attempt } } : {}),
       ...r,
     };
     return { ...withDispatch, ledger: renderRemediateLedger(withDispatch) };
@@ -104,6 +105,10 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
 
   const choice = resolveModelSetting(driver, opts.config.agent.model, task.tier);
   const budget = opts.config.agent.budget;
+  // The ONE salvage resolver (config.ts): explicit policy wins; 'auto'
+  // follows the task's declared completion shape. The CLI's land decision
+  // reads the same function, so the note here and the landing agree.
+  const effectiveSalvage = salvageForTask(opts.config, task);
   // A cap below 'enforced' is a DISCLOSED limitation, phrased by what the
   // driver CAN do. Claiming an unenforced cap as a cap is the $14.71 class:
   // maxUsd read post-hoc while max_turns silently governed real spend.
@@ -195,7 +200,9 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     `reserve the final minutes to commit ALL remaining work and record where you stopped ` +
     `in docs/DXKIT-REMEDIATION-NOTES.md — work committed before the cap survives; ` +
     `uncommitted edits are swept into a single unlabeled-context commit.`;
-  const resumeNote = opts.resume ? resumePromptNote(opts.resume.attempt) : '';
+  const resumeNote = opts.resume
+    ? resumePromptNote(opts.resume.attempt, opts.resume.blockingContext)
+    : '';
   const agentResult: AgentRunResult = await driver.run({
     cwd: opts.cwd,
     prompt: task.prompt + budgetNote + resumeNote,
@@ -234,6 +241,11 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // never leak into the landing layer unreviewed.
   opts.onPhase?.('sweep');
   const sweepError = git.sweepLeftovers();
+  // Drop attempt-introduced runtime artifacts (regenerable scan state the
+  // agent committed mid-run) BEFORE the diff question — an attempt whose
+  // only content was scan output must read as a no-op, and a real attempt
+  // must not carry `.dxkit/reports/*` into its PR. Disclosed below.
+  const scrubbed = git.scrubRuntimeArtifacts(baseHead);
   const hasDiff = git.hasDiff(baseHead);
 
   // Reported spend exceeding the (advisory) cap is an honest post-hoc claim
@@ -313,8 +325,13 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
       envelope,
       floor: entryFloor,
       ...evidenceTail,
+      ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
       ...(partial ? { partial } : {}),
-      note: 'agent ran and produced no committed change.',
+      note:
+        scrubbed.length > 0
+          ? 'agent ran and produced no committed change beyond regenerable dxkit scan state ' +
+            '(dropped, disclosed below).'
+          : 'agent ran and produced no committed change.',
       baseHead,
       head: git.head(),
     });
@@ -346,6 +363,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     baseHead,
     head: git.head(),
     ...evidenceTail,
+    ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
     ...(partial ? { partial } : {}),
   };
 
@@ -374,16 +392,30 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
       guardrail.blocking && guardrail.blocking.length > 0
         ? `\n\nBlocking findings:\n${guardrail.blocking.map((b) => `- ${b}`).join('\n')}`
         : '';
+    // Salvage disposition for a RAN-and-BLOCKED verdict: under draft-pr
+    // salvage the blocked attempt may be pushed as a RED draft (its own
+    // required guardrail check keeps it unmergeable), so the work and the
+    // exact blocking reasons survive the ephemeral runner and the next run
+    // can RESUME from them instead of starting over — guardrail-red is
+    // where the most valuable partial work used to die. An UNRUNNABLE
+    // guardrail stays absolute: an unverified diff is never pushed.
+    const salvageNote =
+      guardrail.ran && effectiveSalvage === 'draft-pr'
+        ? ' Salvage policy: draft-pr — the BLOCKED attempt may be pushed as a red DRAFT ' +
+          '(unmergeable while the guardrail check is red) so the next run can resume from it.'
+        : '';
     return finish({
       outcome: 'guardrail-red',
       ...common,
       note:
         (guardrail.ran
-          ? `the guardrail did not pass (${guardrail.verdict}) — nothing lands. The attempt ` +
+          ? `the guardrail did not pass (${guardrail.verdict}) — nothing merges. The attempt ` +
             'diff is uploaded as a run artifact when this ran under Actions; locally the ' +
             'branch stays for inspection.'
           : `the guardrail could not run (${guardrail.verdict}) — nothing lands. An ` +
-            'agent-authored diff is never pushed unverified.') + evidence,
+            'agent-authored diff is never pushed unverified.') +
+        salvageNote +
+        evidence,
     });
   }
 
@@ -409,7 +441,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
 
   if (partial) {
     const salvage =
-      opts.config.salvage === 'draft-pr'
+      effectiveSalvage === 'draft-pr'
         ? 'salvage policy: draft-pr — the verified partial work may land as a DRAFT.'
         : 'salvage policy: discard — the partial work is not landed (branch left for inspection).';
     return finish({

--- a/src/remediate/tasks.ts
+++ b/src/remediate/tasks.ts
@@ -55,6 +55,22 @@ export interface RemediateTask {
    *  the primary signal for the ledger). */
   readonly verify: 'floor' | 'guardrail';
   /**
+   * The task's completion SHAPE — it decides the default salvage posture
+   * (`salvageForTask`), because the two shapes need opposite defaults:
+   *
+   *   - `'bounded'` — a binary completion test exists (floor green,
+   *     findings closed). The agent can FINISH, so `verified` is reachable
+   *     and discarding a rare budget-cut partial is a defensible default.
+   *   - `'open-ended'` — a score hinge, no completion test. There is always
+   *     more to document/test, so the agent never stops because it is DONE;
+   *     it stops because a cap cut it off. Every outcome is
+   *     `budget-exhausted`, so `salvage: discard` GUARANTEES its verified,
+   *     gate-passing work is thrown away every run (observed live: 454
+   *     verified doc lines, guardrail PASSED, discarded). Open-ended tasks
+   *     therefore default to `draft-pr` salvage.
+   */
+  readonly completion: 'bounded' | 'open-ended';
+  /**
    * $0 deterministic fast-exit: when the ENTRY floor (already captured on
    * the pristine tree before any agent spawns) is green, this task has
    * nothing to fix — return `no-op` without spawning the agent. Only
@@ -110,6 +126,7 @@ export const REMEDIATE_TASKS: readonly RemediateTask[] = [
     tier: 'standard',
     tierWhy: 'real diagnosis + repair across build config and test code',
     verify: 'floor',
+    completion: 'bounded',
     skipWhenEntryFloorGreen: true,
     prompt:
       `Run ${dxkitInRepo('debt --json')}.
@@ -127,6 +144,7 @@ message. When you believe you are done, re-run the failing commands and then
     tier: 'standard',
     tierWhy: 'cross-file reasoning; majors can require real code changes',
     verify: 'guardrail',
+    completion: 'bounded',
     prompt:
       `Run \`./node_modules/.bin/vyuh-dxkit debt --json\` and \`vyuh-dxkit vulnerabilities\`.
 Your task is the dependency-vulnerability findings: upgrade or patch the
@@ -149,6 +167,7 @@ in docs/DXKIT-REMEDIATION-NOTES.md so the reviewer sees what was compared.` + SH
     tier: 'light',
     tierWhy: 'mechanical, pattern-per-finding work',
     verify: 'guardrail',
+    completion: 'bounded',
     prompt:
       `Run \`./node_modules/.bin/vyuh-dxkit debt --json\` (fall back to \`npx
 vyuh-dxkit debt --json\`) and review the custom-check (lint) findings — the
@@ -166,6 +185,7 @@ is a bug, not a cleanup.` + SHARED_RULES,
     tier: 'standard',
     tierWhy: 'design judgment about behavior worth pinning, not boilerplate',
     verify: 'floor',
+    completion: 'open-ended',
     prompt:
       `Run ${dxkitInRepo('test-gaps --json')}. Work the CRITICAL bucket top-down, then
 HIGH as budget allows: for each listed file, READ it first, then write tests
@@ -183,6 +203,7 @@ coverage thresholds or edit test configuration to inflate numbers.` + SHARED_RUL
     tier: 'standard',
     tierWhy: 'grounded technical writing over real code, not boilerplate',
     verify: 'guardrail',
+    completion: 'open-ended',
     scoreHinge: { improve: 'documentation', holdSteady: ['quality'] },
     prompt:
       `Run ${dxkitInRepo('health --json')} and read the Documentation dimension's
@@ -216,6 +237,7 @@ export function customDispatchTask(prompt: string): RemediateTask {
     tier: 'standard',
     tierWhy: 'human-dispatched; pin agent.model (or the dispatch model input) to change',
     verify: 'guardrail',
+    completion: 'open-ended',
     prompt: prompt + SHARED_RULES,
   };
 }

--- a/src/runtime-artifacts.ts
+++ b/src/runtime-artifacts.ts
@@ -1,0 +1,29 @@
+/**
+ * dxkit's RUNTIME-OUTPUT paths — regenerable analyzer state that must never
+ * ride a delivery commit. ONE list (Rule 2), in a leaf module (no imports)
+ * so every consumer can reach it without a cycle:
+ *
+ *   - `installIgnoreFiles` (ship-installers): the `.gitignore` block init
+ *     seeds;
+ *   - the remediate runner's leftover sweep + runtime-artifact scrub
+ *     (`remediate/git-ops.ts`): a repo onboarded WITHOUT the ignore block
+ *     (or whose agent committed scan output it generated mid-run) otherwise
+ *     ships `.dxkit/reports/*` inside a remediation PR — observed live on a
+ *     salvage draft.
+ *
+ * Directory entries end with `/`; file entries are exact paths.
+ */
+export const DXKIT_RUNTIME_ARTIFACT_PATHS: readonly string[] = [
+  '.dxkit/reports/',
+  '.dxkit/dashboard.html',
+  '.dxkit/cache/',
+  '.dxkit/loop/',
+  'graphify-out/',
+];
+
+/** Is a repo-relative POSIX path one of dxkit's runtime artifacts? */
+export function isRuntimeArtifactPath(rel: string): boolean {
+  return DXKIT_RUNTIME_ARTIFACT_PATHS.some((p) =>
+    p.endsWith('/') ? rel.startsWith(p) : rel === p,
+  );
+}

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -45,6 +45,7 @@ import { readFlowConfig } from './analyzers/flow/config';
 import { discoverExtensions } from './extensions/manifest';
 import { mergeIntoPolicyFile } from './baseline/policy-write';
 import { detectEnforcement, type EnforcementState } from './enforcement';
+import { DXKIT_RUNTIME_ARTIFACT_PATHS } from './runtime-artifacts';
 
 /**
  * Detect the consumer repo's default branch so workflow templates
@@ -1274,13 +1275,10 @@ export function installPrReview(cwd: string, opts: InstallerOpts = {}): ShipInst
 }
 
 export const GITIGNORE_HEADER = '# dxkit — runtime outputs (analyzer reports + dashboard)';
-export const GITIGNORE_ENTRIES = [
-  '.dxkit/reports/',
-  '.dxkit/dashboard.html',
-  '.dxkit/cache/',
-  '.dxkit/loop/',
-  'graphify-out/',
-];
+// Derived from the ONE runtime-artifact list (Rule 2) — the remediate
+// runner's sweep/scrub reads the same paths, so what init gitignores and
+// what the lane refuses to land can never drift apart.
+export const GITIGNORE_ENTRIES = [...DXKIT_RUNTIME_ARTIFACT_PATHS];
 
 /**
  * Seed `.gitignore` with dxkit's runtime-output paths and write a

--- a/test/remediate/config-budgets.test.ts
+++ b/test/remediate/config-budgets.test.ts
@@ -3,6 +3,7 @@
  * ceiling (the org guard for the per-task matrix, where a failing task no
  * longer starves siblings and every task may spend its own cap).
  */
+import { REMEDIATE_TASKS } from '../../src/remediate/tasks';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -10,6 +11,7 @@ import * as path from 'path';
 import {
   budgetForTask,
   resolveRemediateConfig,
+  salvageForTask,
   tasksWithinSpendCeiling,
   DEFAULT_REMEDIATE_BUDGET,
   type RemediateConfig,
@@ -107,5 +109,37 @@ describe('resolveRemediateConfig parsing', () => {
     const config = resolveRemediateConfig(dir);
     expect(config.maxSpendPerRun).toBe(0);
     expect(config.taskBudgets).toEqual({});
+  });
+});
+
+describe('salvageForTask — the one salvage resolver (task-shape defaults)', () => {
+  const auto = { salvage: 'auto' as const };
+
+  it('auto follows the task completion shape: open-ended draft-pr, bounded discard', () => {
+    // Open-ended tasks never finish (no completion test) — discard would
+    // structurally throw away their verified work every run (observed live:
+    // 454 verified doc lines, guardrail PASSED, discarded).
+    expect(salvageForTask(auto, 'write-docs')).toBe('draft-pr');
+    expect(salvageForTask(auto, 'improve-tests')).toBe('draft-pr');
+    expect(salvageForTask(auto, 'custom')).toBe('draft-pr');
+    expect(salvageForTask(auto, 'fix-build')).toBe('discard');
+    expect(salvageForTask(auto, 'fix-vulns')).toBe('discard');
+    expect(salvageForTask(auto, 'fix-lint')).toBe('discard');
+  });
+
+  it('an explicit policy value overrides every task', () => {
+    expect(salvageForTask({ salvage: 'discard' }, 'write-docs')).toBe('discard');
+    expect(salvageForTask({ salvage: 'draft-pr' }, 'fix-build')).toBe('draft-pr');
+  });
+
+  it('every registered task declares its completion shape', () => {
+    for (const t of REMEDIATE_TASKS) {
+      expect(['bounded', 'open-ended']).toContain(t.completion);
+    }
+    // Fast-exit tasks are bounded by construction: skipWhenEntryFloorGreen
+    // IS a completion test.
+    for (const t of REMEDIATE_TASKS) {
+      if (t.skipWhenEntryFloorGreen) expect(t.completion).toBe('bounded');
+    }
   });
 });

--- a/test/remediate/dispatch.test.ts
+++ b/test/remediate/dispatch.test.ts
@@ -131,6 +131,7 @@ function fakeGit(): RemediateGit {
   return {
     head: () => head,
     sweepLeftovers: () => undefined,
+    scrubRuntimeArtifacts: () => [],
     hasDiff: () => {
       head = 'head1111';
       return true;

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -183,6 +183,7 @@ function fakeGit(opts: { diff?: boolean } = {}): RemediateGit {
   return {
     head: () => 'base0000',
     sweepLeftovers: () => undefined,
+    scrubRuntimeArtifacts: () => [],
     hasDiff: () => !!opts.diff,
   };
 }

--- a/test/remediate/git-ops.test.ts
+++ b/test/remediate/git-ops.test.ts
@@ -58,7 +58,7 @@ describe('scrubRuntimeArtifacts', () => {
 
     const ops = realGit(repo);
     const scrubbed = ops.scrubRuntimeArtifacts(base);
-    expect(scrubbed.sort()).toEqual([
+    expect([...scrubbed].sort()).toEqual([
       '.dxkit/cache/analysis-result-1.json',
       '.dxkit/reports/health-audit-1.json',
     ]);

--- a/test/remediate/git-ops.test.ts
+++ b/test/remediate/git-ops.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The runner's real git operations: the runtime-artifact scrub (an agent
+ * that commits dxkit scan output mid-run must not ship it in a remediation
+ * PR — observed live on a salvage draft), and the content-based diff
+ * question (a resume's empty marker commit is not a diff).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { realGit } from '../../src/remediate/git-ops';
+import { DXKIT_RUNTIME_ARTIFACT_PATHS, isRuntimeArtifactPath } from '../../src/runtime-artifacts';
+import { GITIGNORE_ENTRIES } from '../../src/ship-installers';
+
+let repo: string;
+
+function git(...args: string[]): string {
+  return execFileSync('git', args, { cwd: repo, encoding: 'utf8' }).trim();
+}
+
+function commitAll(msg: string): void {
+  git('add', '-A');
+  git('-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '-q', '-m', msg);
+}
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), 'dxkit-git-ops-'));
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo });
+  writeFileSync(join(repo, 'src.js'), 'module.exports = 1;\n');
+  commitAll('base');
+});
+
+afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+describe('the ONE runtime-artifact list', () => {
+  it('the gitignore block and the scrub read the same paths (Rule 2)', () => {
+    expect(GITIGNORE_ENTRIES).toEqual([...DXKIT_RUNTIME_ARTIFACT_PATHS]);
+    expect(isRuntimeArtifactPath('.dxkit/reports/health-audit-1.json')).toBe(true);
+    expect(isRuntimeArtifactPath('.dxkit/cache/analysis-result-2.json')).toBe(true);
+    expect(isRuntimeArtifactPath('.dxkit/dashboard.html')).toBe(true);
+    // The guardrail anchor stays tracked — never a runtime artifact.
+    expect(isRuntimeArtifactPath('.dxkit/baselines/main.json')).toBe(false);
+    expect(isRuntimeArtifactPath('.dxkit/policy.json')).toBe(false);
+  });
+});
+
+describe('scrubRuntimeArtifacts', () => {
+  it('drops attempt-introduced scan state, keeps real work, and reports what it dropped', () => {
+    const base = git('rev-parse', 'HEAD');
+    // The "agent" commits real work AND scan output it generated mid-run.
+    mkdirSync(join(repo, '.dxkit', 'reports'), { recursive: true });
+    mkdirSync(join(repo, '.dxkit', 'cache'), { recursive: true });
+    writeFileSync(join(repo, 'src.js'), 'module.exports = 2;\n');
+    writeFileSync(join(repo, '.dxkit', 'reports', 'health-audit-1.json'), '{}');
+    writeFileSync(join(repo, '.dxkit', 'cache', 'analysis-result-1.json'), '{}');
+    commitAll('agent work + scan noise');
+
+    const ops = realGit(repo);
+    const scrubbed = ops.scrubRuntimeArtifacts(base);
+    expect(scrubbed.sort()).toEqual([
+      '.dxkit/cache/analysis-result-1.json',
+      '.dxkit/reports/health-audit-1.json',
+    ]);
+    const changed = git('diff', '--name-only', base, 'HEAD').split('\n');
+    expect(changed).toEqual(['src.js']);
+    expect(ops.hasDiff(base)).toBe(true);
+  });
+
+  it('never touches runtime paths the repo tracked at BASE (a deliberate choice is respected)', () => {
+    mkdirSync(join(repo, '.dxkit', 'reports'), { recursive: true });
+    writeFileSync(join(repo, '.dxkit', 'reports', 'kept.md'), 'v1');
+    commitAll('repo tracks its reports on purpose');
+    const base = git('rev-parse', 'HEAD');
+
+    writeFileSync(join(repo, '.dxkit', 'reports', 'kept.md'), 'v2');
+    commitAll('agent updates the tracked report');
+
+    const ops = realGit(repo);
+    expect(ops.scrubRuntimeArtifacts(base)).toEqual([]);
+    expect(git('diff', '--name-only', base, 'HEAD')).toBe('.dxkit/reports/kept.md');
+  });
+
+  it('an attempt whose ONLY content was scan state reads as no diff afterward', () => {
+    const base = git('rev-parse', 'HEAD');
+    mkdirSync(join(repo, '.dxkit', 'reports'), { recursive: true });
+    writeFileSync(join(repo, '.dxkit', 'reports', 'only-noise.json'), '{}');
+    commitAll('agent produced only scan output');
+
+    const ops = realGit(repo);
+    expect(ops.scrubRuntimeArtifacts(base).length).toBe(1);
+    expect(ops.hasDiff(base)).toBe(false);
+  });
+});
+
+describe('hasDiff is a CONTENT question', () => {
+  it('an empty marker commit is not a diff (the resume counter is bookkeeping, not work)', () => {
+    const base = git('rev-parse', 'HEAD');
+    git('-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '--allow-empty', '-q', '-m', 'marker');
+    const ops = realGit(repo);
+    expect(ops.hasDiff(base)).toBe(false);
+    writeFileSync(join(repo, 'src.js'), 'module.exports = 3;\n');
+    commitAll('real change');
+    expect(ops.hasDiff(base)).toBe(true);
+  });
+});

--- a/test/remediate/git-ops.test.ts
+++ b/test/remediate/git-ops.test.ts
@@ -96,7 +96,17 @@ describe('scrubRuntimeArtifacts', () => {
 describe('hasDiff is a CONTENT question', () => {
   it('an empty marker commit is not a diff (the resume counter is bookkeeping, not work)', () => {
     const base = git('rev-parse', 'HEAD');
-    git('-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '--allow-empty', '-q', '-m', 'marker');
+    git(
+      '-c',
+      'user.name=t',
+      '-c',
+      'user.email=t@t',
+      'commit',
+      '--allow-empty',
+      '-q',
+      '-m',
+      'marker',
+    );
     const ops = realGit(repo);
     expect(ops.hasDiff(base)).toBe(false);
     writeFileSync(join(repo, 'src.js'), 'module.exports = 3;\n');

--- a/test/remediate/resume.test.ts
+++ b/test/remediate/resume.test.ts
@@ -18,16 +18,29 @@ import { DEFAULT_REMEDIATE_BUDGET } from '../../src/remediate/config';
 import type { AnalysisTrustContext } from '../../src/analysis-trust';
 import type { CorrectnessFloorResult } from '../../src/analyzers/correctness/run';
 
-function fakeExec(opts: { openPr?: boolean; markers?: number; failFetch?: boolean }): {
+function fakeExec(opts: {
+  openPr?: boolean;
+  markers?: number;
+  failFetch?: boolean;
+  failPush?: boolean;
+  prBody?: string;
+}): {
   exec: ResumeExec;
   calls: string[][];
 } {
   const calls: string[][] = [];
   const exec: ResumeExec = (bin, args) => {
     calls.push([bin, ...args]);
-    if (bin === 'gh') return opts.openPr ? '[{"url":"https://x/pr/1"}]' : '[]';
+    if (bin === 'gh') {
+      if (!opts.openPr) return '[]';
+      return JSON.stringify([{ url: 'https://x/pr/1', body: opts.prBody ?? '' }]);
+    }
     if (bin === 'git' && args[0] === 'fetch') {
       if (opts.failFetch) throw new Error('fetch failed');
+      return '';
+    }
+    if (bin === 'git' && args[0] === 'push') {
+      if (opts.failPush) throw new Error('push rejected');
       return '';
     }
     if (bin === 'git' && args[0] === 'rev-list') return String(opts.markers ?? 0);
@@ -75,6 +88,40 @@ describe('prepareResume — the eligibility ladder', () => {
     expect(commit!.join(' ')).toContain('--allow-empty');
   });
 
+  it('the attempt marker is PUSHED immediately — a no-op resume still consumes an attempt', () => {
+    // Observed live: the marker only reached the remote when a landing
+    // force-pushed, so runs 2 and 3 both announced attempt #1 and the
+    // MAX_RESUME_ATTEMPTS cap was unreachable — a doomed branch resumed
+    // (and spent) forever.
+    const { exec, calls } = fakeExec({ openPr: true, markers: 0 });
+    const d = prepareResume('/repo', 'fix-build', ON, exec);
+    expect(d.resumed).toBe(true);
+    const push = calls.find((c) => c[0] === 'git' && c[1] === 'push');
+    expect(push).toBeDefined();
+    expect(push!.join(' ')).toContain('HEAD:refs/heads/');
+    // The push happens AFTER the marker commit — it carries the counter.
+    const commitIdx = calls.findIndex((c) => c[0] === 'git' && c.includes('commit'));
+    expect(calls.indexOf(push!)).toBeGreaterThan(commitIdx);
+  });
+
+  it('a failed marker push still resumes, with the cap risk disclosed', () => {
+    const { exec } = fakeExec({ openPr: true, markers: 0, failPush: true });
+    const d = prepareResume('/repo', 'fix-build', ON, exec);
+    expect(d.resumed).toBe(true);
+    expect(d.note).toContain('attempt marker could not be pushed');
+  });
+
+  it('carries the prior attempt blocking findings from the draft-PR ledger into the decision', () => {
+    const body = 'ledger...\n\nBlocking findings:\n- [dep-vuln] form-data GHSA-1\n- [test-gap] src/x.js\n\nrest';
+    const { exec } = fakeExec({ openPr: true, markers: 0, prBody: body });
+    const d = prepareResume('/repo', 'fix-build', ON, exec);
+    expect(d.resumed).toBe(true);
+    expect(d.blockingContext).toContain('form-data GHSA-1');
+    expect(d.blockingContext).toContain('src/x.js');
+    // and it reaches the resumed prompt
+    expect(resumePromptNote(d.attempt!, d.blockingContext)).toContain('BLOCKED by the guardrail');
+  });
+
   it('any git/gh failure → fresh run, never a throw', () => {
     const { exec } = fakeExec({ openPr: true, failFetch: true });
     const d = prepareResume('/repo', 'fix-build', ON, exec);
@@ -98,6 +145,7 @@ function fakeGit(): RemediateGit {
   return {
     head: () => head,
     sweepLeftovers: () => undefined,
+    scrubRuntimeArtifacts: () => [],
     hasDiff: () => {
       head = 'salvage01';
       return true;

--- a/test/remediate/resume.test.ts
+++ b/test/remediate/resume.test.ts
@@ -112,7 +112,8 @@ describe('prepareResume — the eligibility ladder', () => {
   });
 
   it('carries the prior attempt blocking findings from the draft-PR ledger into the decision', () => {
-    const body = 'ledger...\n\nBlocking findings:\n- [dep-vuln] form-data GHSA-1\n- [test-gap] src/x.js\n\nrest';
+    const body =
+      'ledger...\n\nBlocking findings:\n- [dep-vuln] form-data GHSA-1\n- [test-gap] src/x.js\n\nrest';
     const { exec } = fakeExec({ openPr: true, markers: 0, prBody: body });
     const d = prepareResume('/repo', 'fix-build', ON, exec);
     expect(d.resumed).toBe(true);

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -41,6 +41,7 @@ function fakeGit(opts: { diff?: boolean; sweepError?: string } = {}): RemediateG
   return {
     head: () => head,
     sweepLeftovers: () => opts.sweepError,
+    scrubRuntimeArtifacts: () => [],
     hasDiff: () => {
       if (opts.diff) head = 'head1111';
       return !!opts.diff;
@@ -204,7 +205,7 @@ describe('the verified frame (the agent is never trusted)', () => {
     );
     expect(r.outcome).toBe('guardrail-red');
     expect(r.note).toContain('BLOCKED');
-    expect(r.note).toContain('nothing lands');
+    expect(r.note).toContain('nothing merges');
   });
 
   it('guardrail-red: an UNRUNNABLE guardrail fails closed for the agent lane', async () => {
@@ -358,7 +359,10 @@ describe('resolveRemediateConfig (conservative normalization)', () => {
         model: 'auto',
         budget: { maxTurns: 80, maxMinutes: 30, maxUsd: 5 },
       });
-      expect(c.salvage).toBe('discard');
+      // 'auto' resolves per task shape via salvageForTask (open-ended →
+      // draft-pr, bounded → discard); the raw default is the posture, not
+      // a concrete decision.
+      expect(c.salvage).toBe('auto');
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }


### PR DESCRIPTION
WP3 of the 4.3.7 honesty release: the lane's disposal of real work now matches what the knobs claim.

- **#28** Tasks declare their completion shape (`bounded` / `open-ended`) in the registry. `remediate.salvage` defaults to `auto`, resolved per task through the one `salvageForTask` resolver: open-ended tasks (write-docs, improve-tests, custom) default to `draft-pr` — under `discard` their verified, guardrail-PASSING work was structurally thrown away every run (observed live: 454 doc lines, gate green, discarded). Bounded tasks keep `discard`. Explicit policy still pins every task.
- **#26** The resume attempt counter is now durable: the marker commit is pushed immediately after creation (HEAD is provably base + one empty commit — zero agent content, the never-push-unverified law untouched), so a no-op resume consumes an attempt and `MAX_RESUME_ATTEMPTS` actually engages (previously a doomed branch resumed attempt #1 forever, re-spending its budget every firing — proven live over three runs). `hasDiff` is now a content question, so a marker-only resume truthfully reads no-op.
- **#20** Under `draft-pr` salvage, a RAN-and-BLOCKED guardrail attempt lands as a **red draft titled "do not merge"** — its own required guardrail check keeps it unmergeable, the lane ledger event carries `blocked: true`, the job stays red, and the next resume carries the exact blocking findings into the prompt ("close these" instead of starting over). An unrunnable guardrail still never pushes anything.
- **#27** Runtime-artifact paths live in one leaf module (`src/runtime-artifacts.ts`) consumed by both the `.gitignore` seed and the runner's new scrub: attempt-introduced `.dxkit/reports`/`.dxkit/cache` etc. are dropped from the landing (base-tracked paths respected) and disclosed in the ledger.

Also: cli.ts's sequencing loop extracted to `configured-loop.ts` (large-file gate — the dogfood catch), and the marker push routes through `internalGitPushArgs` (a second arch-gate catch).

Remediate suite 132 green incl. new real-repo `git-ops.test.ts`; local self-guardrail PASSED; arch/lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)