### PR TITLE
fix(baseline): gate reporting truth — one entry per fingerprint, real repro paths, expiry notice cross-checks current findings

### DIFF
--- a/src/analyzers/correctness/floor-disclosure.ts
+++ b/src/analyzers/correctness/floor-disclosure.ts
@@ -31,12 +31,29 @@ import type { SurfaceFloorOutcome } from './surface-run';
 import type { AttributedFloorFailure } from './attribution';
 import type { CorrectnessCheckResult } from './run';
 
+/** The check's own reproduction command, or null for an IN-PROCESS check
+ *  (import-resolution runs no shell command — rendering its empty argv
+ *  printed a bare pair of backticks as the "repro"). */
+function reproCommand(c: CorrectnessCheckResult): string | null {
+  const cmd = [c.bin, ...(c.args ?? [])]
+    .filter((s) => typeof s === 'string' && s.trim())
+    .join(' ')
+    .trim();
+  return cmd || null;
+}
+
+/** One repro phrase for every surface: the check's command, or the
+ *  canonical CLI entry that re-runs in-process checks. */
 function repro(c: CorrectnessCheckResult): string {
-  return [c.bin, ...(c.args ?? [])].filter(Boolean).join(' ');
+  return reproCommand(c) ?? `${dxkitCli('floor check')} re-runs this in-process check`;
 }
 
 function mdCheck(c: CorrectnessCheckResult): string[] {
-  const lines = [`- **${c.pack} ${c.label}** — repro: \`${repro(c)}\``];
+  const cmd = reproCommand(c);
+  const lines = [
+    `- **${c.pack} ${c.label}** — ` +
+      (cmd ? `repro: \`${cmd}\`` : `repro: \`${dxkitCli('floor check')}\` (in-process check)`),
+  ];
   if (c.output) {
     lines.push('  <details><summary>output</summary>');
     lines.push('');

--- a/src/baseline/expiry-notice.ts
+++ b/src/baseline/expiry-notice.ts
@@ -94,6 +94,17 @@ export interface ExpiryNoticeOptions {
   readonly now?: Date;
   /** Horizon override; defaults to the shared constant. */
   readonly horizonDays?: number;
+  /**
+   * The freshly captured finding-id set, when the caller has one (the
+   * refresh just re-scanned). A lapsing entry whose fingerprint is ABSENT
+   * from it suppresses nothing any more — its finding was FIXED — so it is
+   * reported as prunable, never as a returning finding (the notice
+   * previously manufactured urgency about completed work: a "lapses in 2
+   * days, the finding returns" alarm for an advisory the repo had already
+   * fixed). `null`/absent = unknown (no fresh scan in hand) → every entry
+   * is treated as live, the fail-open direction.
+   */
+  readonly currentFindingIds?: ReadonlySet<string> | null;
 }
 
 const TITLE_PREFIX = 'dxkit: allowlist suppressions expiring';
@@ -108,7 +119,7 @@ function titleFor(count: number): string {
  */
 export function expiryNoticeBody(
   soon: ReadonlyArray<SoonToExpire>,
-  opts: { readonly horizonDays: number },
+  opts: { readonly horizonDays: number; readonly resolved?: ReadonlyArray<SoonToExpire> },
 ): string {
   const owners = [...new Set(soon.map((s) => s.entry.addedBy).filter(Boolean))];
   const soonest = Math.min(...soon.map((s) => s.daysRemaining));
@@ -139,6 +150,19 @@ export function expiryNoticeBody(
         `${soon[0]!.entry.expiresAt} — not spread out.`,
       '',
     );
+  }
+  if (opts.resolved && opts.resolved.length > 0) {
+    lines.push(
+      `**Already resolved (${opts.resolved.length}) — no finding returns when these lapse.** ` +
+        'The latest scan no longer contains the finding each of these suppressed (the work ' +
+        'was done), so the entry is stale bookkeeping, not a pending surprise. Remove at ' +
+        `leisure: \`${dxkitCli('allowlist remove')} --fingerprint <id>\` (or let \`${dxkitCli('allowlist prune')}\` sweep them once expired).`,
+      '',
+    );
+    for (const { entry } of opts.resolved) {
+      lines.push(`- \`${entry.fingerprint}\` (${entry.kind}, expires ${entry.expiresAt})`);
+    }
+    lines.push('');
   }
   lines.push(
     '**Two lanes.**',
@@ -190,9 +214,22 @@ export function syncExpiryNotice(opts: ExpiryNoticeOptions): ExpiryNoticeResult 
   const horizonDays = opts.horizonDays ?? SOON_TO_EXPIRE_DAYS;
   const now = opts.now ?? new Date();
   const file = loadAllowlist(opts.cwd);
-  const soon = file
+  const lapsing = file
     ? auditAllowlist(file, { now, soonToExpireDays: horizonDays }).soonToExpire
     : [];
+  // Cross-check lapsing entries against the freshest finding set when the
+  // caller has one: an entry whose finding no longer EXISTS suppresses
+  // nothing — nothing "returns" when it lapses. Alarm only about live
+  // findings; stale entries are reported as prunable. Unknown current set
+  // (no fresh scan) treats everything as live — fail-open.
+  const ids = opts.currentFindingIds ?? null;
+  const soon = ids ? lapsing.filter((s) => ids.has(s.entry.fingerprint)) : lapsing;
+  const resolved = ids ? lapsing.filter((s) => !ids.has(s.entry.fingerprint)) : [];
+  const resolvedNote =
+    resolved.length > 0
+      ? ` (${resolved.length} other lapsing entr${resolved.length === 1 ? 'y' : 'ies'} already ` +
+        `resolved — stale bookkeeping, prunable, no finding returns)`
+      : '';
 
   const existing = findOpenNotice(opts.exec);
 
@@ -201,7 +238,7 @@ export function syncExpiryNotice(opts: ExpiryNoticeOptions): ExpiryNoticeResult 
       return {
         outcome: 'nothing-to-report',
         lapsing: 0,
-        note: `No allowlist suppression expires within ${horizonDays} days.`,
+        note: `No live allowlist suppression expires within ${horizonDays} days.${resolvedNote}`,
       };
     }
     // The self-close. A notice that outlives its facts teaches people to ignore
@@ -212,12 +249,12 @@ export function syncExpiryNotice(opts: ExpiryNoticeOptions): ExpiryNoticeResult 
       lapsing: 0,
       issueUrl: existing.url,
       note:
-        `Nothing lapses within ${horizonDays} days any more — closed the expiry notice ` +
-        `(${existing.url}).`,
+        `Nothing live lapses within ${horizonDays} days any more — closed the expiry notice ` +
+        `(${existing.url}).${resolvedNote}`,
     };
   }
 
-  const body = expiryNoticeBody(soon, { horizonDays });
+  const body = expiryNoticeBody(soon, { horizonDays, resolved });
   const title = titleFor(soon.length);
 
   if (existing) {

--- a/src/baseline/floor-debt.ts
+++ b/src/baseline/floor-debt.ts
@@ -35,6 +35,7 @@ import {
   type CorrectnessStatus,
 } from '../analyzers/correctness/run';
 import { describeUnmetRequirement, hostOf } from '../execution';
+import { dxkitCli } from '../self-invocation';
 
 /** Per-check budget for baseline-time capture. Generous — this is a one-time
  *  inventory pass, not a hook — but bounded, so a capture can never hang. */
@@ -101,7 +102,12 @@ export function captureFloorDebt(
   const checks: FloorDebtCheck[] = result.checks.map((c) => ({
     pack: c.pack as string,
     label: c.label,
-    command: [c.bin, ...(c.args ?? [])].filter(Boolean).join(' '),
+    // In-process checks (import-resolution) have no argv — name the CLI
+    // entry that re-runs them instead of storing an empty command (rendered
+    // downstream as a bare "repro:" with nothing after it).
+    command:
+      [c.bin, ...(c.args ?? [])].filter(Boolean).join(' ').trim() ||
+      `${dxkitCli('floor check')} (in-process check)`,
     status: c.status,
     ...(c.output !== undefined ? { output: c.output } : {}),
     ...(c.unmet !== undefined ? { unmet: describeUnmetRequirement(c.unmet, host) } : {}),

--- a/src/baseline/producers/custom-checks.ts
+++ b/src/baseline/producers/custom-checks.ts
@@ -19,7 +19,16 @@ import type { RichBaselineEntry } from '../types';
 export function customCheckFindingsToBaselineEntries(
   findings: readonly CustomCheckFinding[],
 ): RichBaselineEntry[] {
-  return findings.map((f) => {
+  // ONE entry per identity. Located identity buckets lines into the shared
+  // 3-line window (Rule 9), so a linter reporting the same rule on adjacent
+  // lines mints the SAME fingerprint N times — and the multiset survived
+  // into the verdict: a real PR was reported as "206 new regressions" over
+  // 137 unique fingerprints (69 duplicate rows), inflating the headline by
+  // 50%. The fingerprint is the gate's unit (the allowlist waives by
+  // fingerprint), so it is the count's unit too; extra occurrences inside
+  // one window are disclosed on the entry, never counted as findings.
+  const byId = new Map<string, { entry: RichBaselineEntry; occurrences: number }>();
+  for (const f of findings) {
     const id = identityFor({
       kind: 'custom-check',
       check: f.check,
@@ -27,15 +36,28 @@ export function customCheckFindingsToBaselineEntries(
       ...(f.line !== undefined ? { line: f.line } : {}),
       ...(f.rule !== undefined ? { rule: f.rule } : {}),
     });
-    return {
-      id,
-      kind: 'custom-check' as const,
-      check: f.check,
-      blocking: f.blocking,
-      ...(f.file !== undefined ? { file: f.file } : {}),
-      ...(f.line !== undefined ? { line: f.line } : {}),
-      ...(f.rule !== undefined ? { rule: f.rule } : {}),
-      ...(f.message !== undefined ? { message: f.message } : {}),
-    };
-  });
+    const hit = byId.get(id);
+    if (hit) {
+      hit.occurrences += 1;
+      continue;
+    }
+    byId.set(id, {
+      occurrences: 1,
+      entry: {
+        id,
+        kind: 'custom-check' as const,
+        check: f.check,
+        blocking: f.blocking,
+        ...(f.file !== undefined ? { file: f.file } : {}),
+        ...(f.line !== undefined ? { line: f.line } : {}),
+        ...(f.rule !== undefined ? { rule: f.rule } : {}),
+        ...(f.message !== undefined ? { message: f.message } : {}),
+      },
+    });
+  }
+  return [...byId.values()].map(({ entry, occurrences }) =>
+    occurrences > 1 && 'message' in entry && entry.message !== undefined
+      ? { ...entry, message: `${entry.message} (${occurrences} occurrences in this line window)` }
+      : entry,
+  );
 }

--- a/src/baseline/refresh.ts
+++ b/src/baseline/refresh.ts
@@ -302,8 +302,26 @@ export async function runBaselineRefresh(
     cwd,
     exec: opts.exec ?? makeExec(cwd),
     ...(opts.now !== undefined ? { now: opts.now } : {}),
+    // The finding-id set from the baseline this refresh just captured, so a
+    // lapsing entry whose finding was FIXED reads as prunable bookkeeping,
+    // never as a returning finding (the false-alarm class: a "lapses in 2
+    // days" issue about an advisory the repo had already closed). Unreadable
+    // baseline → null → every entry treated live (fail-open).
+    currentFindingIds: freshFindingIds(cwd, opts.name ?? DEFAULT_BASELINE_NAME),
   });
   return { ...result, expiryNotice };
+}
+
+/** Finding ids from the freshest local baseline capture, or null when none
+ *  is readable (anchor-only repos without a tree file, first runs). */
+function freshFindingIds(cwd: string, name: string): ReadonlySet<string> | null {
+  try {
+    const file = readBaselineFile(pathForBaseline(cwd, name));
+    if (!file) return null;
+    return new Set(file.findings.map((f) => f.id));
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/test/baseline/custom-check-producer.test.ts
+++ b/test/baseline/custom-check-producer.test.ts
@@ -44,6 +44,42 @@ describe('customCheckFindingsToBaselineEntries (Rule 10 producer)', () => {
   it('empty in → empty out', () => {
     expect(customCheckFindingsToBaselineEntries([])).toEqual([]);
   });
+
+  it('ONE entry per identity: adjacent-line occurrences of one rule collapse (the inflated-headline class)', () => {
+    // Located identity buckets lines into the shared 3-line window, so a
+    // linter reporting the same rule on adjacent lines mints the SAME
+    // fingerprint N times. The multiset previously survived into the
+    // verdict: a real PR read "206 new regressions" over 137 unique
+    // fingerprints. The fingerprint is the gate's unit (the allowlist
+    // waives by fingerprint) — so it is the count's unit too.
+    const base = {
+      check: 'lint:typescript',
+      blocking: true,
+      file: 'src/a.ts',
+      rule: 'quotes',
+    };
+    const entries = customCheckFindingsToBaselineEntries([
+      { ...base, line: 9, message: 'use single quotes' },
+      { ...base, line: 10, message: 'use single quotes' }, // same 3-line window (9-11)
+      { ...base, line: 11, message: 'use single quotes' }, // same window
+      { ...base, line: 40, message: 'use single quotes' }, // different window
+    ]);
+    expect(entries).toHaveLength(2);
+    const ids = new Set(entries.map((e) => e.id));
+    expect(ids.size).toBe(2);
+    const collapsed = entries.find((e) => 'line' in e && e.line === 9)!;
+    if (collapsed.kind === 'custom-check') {
+      expect(collapsed.message).toContain('3 occurrences in this line window');
+    }
+  });
+
+  it('distinct rules in one window stay distinct findings', () => {
+    const entries = customCheckFindingsToBaselineEntries([
+      { check: 'lint:x', blocking: true, file: 'a.ts', line: 10, rule: 'quotes', message: 'q' },
+      { check: 'lint:x', blocking: true, file: 'a.ts', line: 10, rule: 'curly', message: 'c' },
+    ]);
+    expect(entries).toHaveLength(2);
+  });
 });
 
 describe('gatherCustomCheckFindings', () => {

--- a/test/baseline/expiry-notice.test.ts
+++ b/test/baseline/expiry-notice.test.ts
@@ -235,6 +235,60 @@ describe('syncExpiryNotice', () => {
   });
 });
 
+describe('the resolved cross-check (#15 — no alarm about completed work)', () => {
+  it('a lapsing entry whose finding is GONE from the current set is prunable, never a returning finding', () => {
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({
+      'issue list': '[]',
+      'issue create': 'https://github.com/acme/repo/issues/9\n',
+    });
+    // Only the first fingerprint still exists in the fresh scan.
+    const out = syncExpiryNotice({
+      cwd: d,
+      exec,
+      now: NOW,
+      currentFindingIds: new Set(['aaaa000000000001']),
+    });
+    expect(out.outcome).toBe('issue-opened');
+    expect(out.lapsing).toBe(1); // the live one only
+    const create = exec.calls.find((c) => c[1] === 'issue' && c[2] === 'create')!;
+    const body = create[create.indexOf('--body') + 1];
+    expect(body).toContain('aaaa000000000001');
+    expect(body).toContain('Already resolved (1)');
+    expect(body).toContain('aaaa000000000002');
+    expect(create.join(' ')).toContain('(1)'); // title counts LIVE entries only
+  });
+
+  it('all lapsing entries resolved -> nothing to report (and an open notice self-closes)', () => {
+    const d = mkRepo({ allowlist: LAPSING });
+    const noneLive = new Set(['unrelated-id']);
+    const quiet = syncExpiryNotice({
+      cwd: d,
+      exec: fakeExec({ 'issue list': '[]' }),
+      now: NOW,
+      currentFindingIds: noneLive,
+    });
+    expect(quiet.outcome).toBe('nothing-to-report');
+    expect(quiet.note).toContain('already resolved');
+
+    const exec = fakeExec({
+      'issue list': JSON.stringify([
+        { number: 7, url: 'https://x/7', body: `${EXPIRY_NOTICE_MARKER}` },
+      ]),
+    });
+    const closed = syncExpiryNotice({ cwd: d, exec, now: NOW, currentFindingIds: noneLive });
+    expect(closed.outcome).toBe('issue-closed');
+    expect(exec.calls.some((c) => c[2] === 'close')).toBe(true);
+  });
+
+  it('an UNKNOWN current set treats every entry as live (fail-open)', () => {
+    const d = mkRepo({ allowlist: LAPSING });
+    const exec = fakeExec({ 'issue list': '[]', 'issue create': 'https://x/9\n' });
+    const out = syncExpiryNotice({ cwd: d, exec, now: NOW, currentFindingIds: null });
+    expect(out.lapsing).toBe(2);
+  });
+});
+
 describe('the refresh lane runs the notice independently of the advisory lane', () => {
   /** Policy that makes the advisory lane take its earliest no-op return. */
   const REF_BASED = { baseline: { mode: 'ref-based' } };

--- a/test/correctness-floor-disclosure.test.ts
+++ b/test/correctness-floor-disclosure.test.ts
@@ -130,3 +130,26 @@ describe('floorDisclosureMarkdown', () => {
     expect(githubAnnotations(o)).toHaveLength(3);
   });
 });
+
+describe('command-less checks (in-process — the empty-backticks repro class)', () => {
+  it('names the CLI entry instead of rendering empty backticks', () => {
+    const inProcess: CorrectnessCheckResult = {
+      pack: 'typescript' as CorrectnessCheckResult['pack'],
+      label: 'import-resolution',
+      bin: '',
+      args: [],
+      status: 'fail',
+    };
+    const o = outcome({
+      result: { ran: true, blocks: false, checks: [inProcess] },
+      blocks: false,
+      attributed: [{ check: inProcess, attribution: 'net-new' }],
+    });
+    const md = floorDisclosureMarkdown(o)!;
+    expect(md).not.toContain('repro: ``');
+    expect(md).toContain('floor check');
+    expect(md).toContain('(in-process check)');
+    const ann = githubAnnotations(o)[0];
+    expect(ann).toContain('floor check re-runs this in-process check');
+  });
+});


### PR DESCRIPTION
WP4 of the 4.3.7 honesty release: the gate's account of magnitude and urgency now matches the facts.

- **#8** "206 new regressions" over 137 unique fingerprints: located custom-check identity buckets lines into the 3-line window, so one rule on adjacent lines minted the same fingerprint N times and the multiset survived into the verdict (69 duplicate rows, headline inflated 50%). The producer — the one path both sides use — now emits one entry per identity; extra in-window occurrences are disclosed on the message, never counted.
- **#9** Command-less floor checks (in-process import-resolution) rendered `repro: ` with empty backticks; the disclosure and the floor-debt envelope now name the canonical `floor check` CLI entry.
- **#15** The expiry notice warned "the finding returns in 2 days" about an advisory the repo had already fixed. The refresh now passes the freshly captured finding-id set: lapsing entries whose finding is gone are reported as prunable bookkeeping with the remedy, never as returning findings; title/count cover live entries only; unknown current set stays fail-open.

996 tests green across baseline+remediate suites; local self-guardrail PASSED; arch/lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)