### PR TITLE
fix(correctness+policy): pre-push floor honors the floor-debt envelope; graph.refresh settable

### DIFF
--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -29,6 +29,7 @@ stanzas).
 | `expiryNotice.enabled`              | [#expiry-notice](#expiry-notice)             |
 | `flow.mode`                         | [#flow-mode](#flow-mode)                     |
 | `flow.sources`                      | [#flow-sources](#flow-sources)               |
+| `graph.refresh`                     | [#graph-refresh](#graph-refresh)             |
 | `licenses.prohibited`               | [#prohibited-licenses](#prohibited-licenses) |
 | `lint.blocking`                     | [#lint-gate](#lint-gate)                     |
 | `lint.enabled`                      | [#lint-gate](#lint-gate)                     |
@@ -278,6 +279,18 @@ on; a notification that could not be posted must never fail a baseline capture.
 every merge — the score-over-time series `vyuh-dxkit metrics` renders.
 
 **Default and why.** Off; enabling installs a managed workflow (`update`).
+
+## Graph refresh
+
+**What it does.** The code-graph CI transport. Set to `cache`, `update`
+installs the managed `dxkit-graph-refresh` workflow, which rebuilds
+`graph.json` on a schedule and stores it in the Actions cache so gated
+runs skip the rebuild. `off` (or absent) means rebuild-on-demand.
+
+**Default and why.** Absent (rebuild-on-demand) — the transport changes no
+finding, only CI wall-clock, so nothing recommends it proactively. Set it
+with `vyuh-dxkit policy set graph.refresh cache` and run
+`vyuh-dxkit update` to install the workflow.
 
 ## Loop preset
 

--- a/src/analyzers/correctness/resolution-attribution.ts
+++ b/src/analyzers/correctness/resolution-attribution.ts
@@ -83,32 +83,70 @@ export function refutedResolutionSpecifiers(
   }
 }
 
+/** Check-level base evidence for the pre-push surface: (pack, label) rows
+ *  recorded FAILING in the committed baseline's floor-debt envelope, plus a
+ *  short provenance string for the disclosure. */
+export interface PrePushDebtEvidence {
+  readonly rows: readonly FloorBaseCheck[];
+  /** Where the evidence comes from (commit prefix or capture date). */
+  readonly captured: string;
+}
+
 /**
  * Route a blocking pre-push floor result through the ONE attribution
- * comparator (`attributeFloorFailures`), with the resolution check's base
- * side supplied by `refutedResolutionSpecifiers`. Checks with no base
- * evidence keep the surface's point-in-time semantics
- * (`absentMeans: 'net-new'` — a failing syntax or test check still blocks
- * exactly as before). Returns null when there is nothing to adjust (no
- * failing resolution check, no decisive base evidence) so the caller keeps
- * the original outcome byte-for-byte.
+ * comparator (`attributeFloorFailures`), with base evidence composed from
+ * BOTH cheap sources the hook can afford (no base worktree run):
+ *
+ *   - FINDING-level: `refutedResolutionSpecifiers` for the resolution
+ *     check — a specifier provably unresolvable at the merge base;
+ *   - CHECK-level: the committed baseline's floor-debt envelope (when the
+ *     caller supplies it) — a check recorded FAILING at baseline capture
+ *     was already red before this branch existed, so blocking the push on
+ *     it blames the developer for the repo's grandfathered debt. The
+ *     shipped class: the CI floor correctly reported the same failures as
+ *     pre-existing/unattributable while the local pre-push hook
+ *     hard-blocked them (bypassed with --no-verify — a gate that trains
+ *     bypassing). Check-level evidence cannot see ADDITIONAL failures
+ *     inside an already-red check; the note says so, and CI's two-sided
+ *     floor stays authoritative.
+ *
+ * Checks with NO base evidence keep the surface's point-in-time semantics
+ * (`absentMeans: 'net-new'` — a failing check with no record still blocks
+ * exactly as before). Returns null when there is nothing to adjust so the
+ * caller keeps the original outcome byte-for-byte.
  */
 export function attributePrePushResolution(
   cwd: string,
   baseSha: string,
   packs: readonly LanguageSupport[],
   result: CorrectnessFloorResult,
+  debt?: PrePushDebtEvidence | null,
 ): { blocks: boolean; note: string } | null {
   const failingResolution = result.checks.filter(
     (c) => c.status === 'fail' && c.label === IMPORT_RESOLUTION_LABEL && c.findings?.length,
   );
-  if (failingResolution.length === 0) return null;
 
   const baseRows: FloorBaseCheck[] = [];
+  const resolutionCovered = new Set<string>();
   for (const check of failingResolution) {
     const refuted = refutedResolutionSpecifiers(cwd, baseSha, packs, check.findings ?? []);
     if (refuted === null || refuted.length === 0) continue;
     baseRows.push({ pack: check.pack, label: check.label, status: 'fail', findings: refuted });
+    resolutionCovered.add(`${check.pack}\0${check.label}`);
+  }
+  // Floor-debt rows for FAILING checks not already covered by the stronger
+  // finding-level evidence (a debt row for the resolution check would erase
+  // its per-specifier attribution).
+  const debtDemoted: string[] = [];
+  for (const row of debt?.rows ?? []) {
+    const key = `${row.pack}\0${row.label}`;
+    if (resolutionCovered.has(key)) continue;
+    const failsNow = result.checks.some(
+      (c) => c.status === 'fail' && c.pack === row.pack && c.label === row.label,
+    );
+    if (!failsNow) continue;
+    baseRows.push({ pack: row.pack, label: row.label, status: 'fail' });
+    debtDemoted.push(`${row.pack} ${row.label}`);
   }
   if (baseRows.length === 0) return null;
 
@@ -117,6 +155,7 @@ export function attributePrePushResolution(
   const parts: string[] = [];
   for (const a of attributed) {
     if (a.check.label !== IMPORT_RESOLUTION_LABEL) continue;
+    if (!resolutionCovered.has(`${a.check.pack}\0${a.check.label}`)) continue;
     const refutedCount =
       (a.check.findings?.length ?? 0) -
       (a.attribution === 'net-new' ? (a.netNewFindings?.length ?? 0) : 0);
@@ -130,6 +169,14 @@ export function attributePrePushResolution(
     if (a.attribution === 'net-new' && a.netNewFindings?.length) {
       parts.push(`net-new unresolved import(s) BLOCK: ${a.netNewFindings.join(', ')}`);
     }
+  }
+  if (debtDemoted.length > 0) {
+    parts.push(
+      `${debtDemoted.join(', ')}: recorded failing in the committed baseline's floor-debt ` +
+        `envelope (${debt!.captured}) — pre-existing debt, not blocked at pre-push. ` +
+        `Check-level evidence cannot see additional failures inside an already-red check; ` +
+        `CI's two-sided floor is authoritative`,
+    );
   }
   return { blocks, note: parts.length > 0 ? ` [${parts.join('; ')}]` : '' };
 }

--- a/src/analyzers/correctness/surface-run.ts
+++ b/src/analyzers/correctness/surface-run.ts
@@ -49,9 +49,16 @@ import {
   type CorrectnessFloorResult,
 } from './run';
 import { attributeFloorFailures, type AttributedFloorFailure } from './attribution';
-import { attributePrePushResolution } from './resolution-attribution';
+import { attributePrePushResolution, type PrePushDebtEvidence } from './resolution-attribution';
 export { refutedResolutionSpecifiers } from './resolution-attribution';
 import { resolveCorrectnessSurface } from './surface';
+import {
+  DEFAULT_BASELINE_NAME,
+  pathForBaseline,
+  readBaselineFile,
+} from '../../baseline/baseline-file';
+import { loadAnchorFromBranch } from '../../baseline/anchor';
+import { readPolicySection } from '../../baseline/policy-text';
 
 /** The surfaces this runner serves (the loop-stop surface has its own runner). */
 export type RunnableSurface = 'pre-push' | 'ci';
@@ -215,10 +222,20 @@ export function runFloorForSurface(opts: RunFloorForSurfaceOptions): SurfaceFloo
       result,
     };
   }
-  // Pre-push resolution attribution (4.3.3): a blocking import-resolution
-  // failure is tested against sound base-side evidence before it may block.
+  // Pre-push attribution (4.3.3, extended 4.3.7): a blocking failure is
+  // tested against the cheap base evidence the hook can afford — sound
+  // per-specifier refutation for import-resolution, and the committed
+  // baseline's floor-debt envelope (check-level) for everything else — so
+  // the hook stops hard-blocking the repo's grandfathered debt that CI's
+  // two-sided floor correctly reports as pre-existing.
   if (surface === 'pre-push' && result.blocks && prePushBase) {
-    const adjusted = attributePrePushResolution(cwd, prePushBase, packs, result);
+    const adjusted = attributePrePushResolution(
+      cwd,
+      prePushBase,
+      packs,
+      result,
+      loadFloorDebtEvidence(cwd),
+    );
     if (adjusted) {
       return {
         surface,
@@ -240,6 +257,44 @@ export function runFloorForSurface(opts: RunFloorForSurfaceOptions): SurfaceFloo
     summary: describeCorrectnessFloor(result) + envSuffix,
     result,
   };
+}
+
+/**
+ * Check-level pre-push base evidence from the committed baseline's
+ * floor-debt envelope: the (pack, label) rows recorded FAILING at baseline
+ * capture. Reads the tree copy first, then the branch-transport anchor
+ * (read-only temp materialization) — the same precedence the guardrail
+ * uses. Null on any miss: no envelope, no baseline, unreadable — the
+ * surface then keeps its point-in-time semantics unchanged (fail toward
+ * blocking; the false-block prevention only engages on committed
+ * evidence).
+ */
+function loadFloorDebtEvidence(cwd: string): PrePushDebtEvidence | null {
+  try {
+    const baselinePath = pathForBaseline(cwd, DEFAULT_BASELINE_NAME);
+    let file: string | null = fs.existsSync(baselinePath) ? baselinePath : null;
+    if (!file) {
+      const section = readPolicySection(cwd, 'baseline') as
+        | Parameters<typeof loadAnchorFromBranch>[2]
+        | undefined;
+      file = loadAnchorFromBranch(cwd, baselinePath, section);
+    }
+    if (!file) return null;
+    const debt = readBaselineFile(file).floorDebt;
+    if (!debt) return null;
+    const rows = debt.checks
+      .filter((c) => c.status === 'fail')
+      .map((c) => ({ pack: c.pack, label: c.label, status: 'fail' as const }));
+    if (rows.length === 0) return null;
+    return {
+      rows,
+      captured: debt.capturedAtCommit
+        ? `captured at ${debt.capturedAtCommit.slice(0, 12)}`
+        : `captured ${debt.capturedAt}`,
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -184,6 +184,17 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
     anchor: 'reports-on-merge',
   },
   {
+    // Settable because dxkit's own guidance (docs + the learn assistant)
+    // points users at exactly this field — a knob the product recommends
+    // must be reachable through `policy set`, not a hand edit (the
+    // guidance/settability drift class). Still scaffold-exempt: it is a CI
+    // transport, not a posture.
+    path: 'graph.refresh',
+    summary: 'code-graph CI transport: "cache" installs the graph-refresh workflow on update',
+    anchor: 'graph-refresh',
+    enumValues: ['cache', 'off'],
+  },
+  {
     path: 'loop.preset',
     summary: 'what blocks an autonomous loop from declaring done',
     anchor: 'loop-preset',

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -325,10 +325,7 @@ export function buildPolicySchema(version: string): Schema {
       ),
       graph: obj(
         {
-          refresh: {
-            type: 'string',
-            description: 'Code-graph transport for CI (e.g. "cache"); set by init/update.',
-          },
+          refresh: stringProp('graph.refresh'),
         },
         'Code-graph plumbing.',
       ),

--- a/test/correctness-resolution-attribution.test.ts
+++ b/test/correctness-resolution-attribution.test.ts
@@ -200,3 +200,74 @@ describe('runFloorForSurface pre-push — resolution failures are attributed', (
     expect(outcome.blocks).toBe(true);
   });
 });
+
+describe('runFloorForSurface pre-push — floor-debt envelope demotes grandfathered checks (4.3.7)', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = makeRepo();
+    // The committed baseline's floor-debt envelope records the syntax check
+    // already FAILING at capture — the repo's grandfathered debt.
+    mkdirSync(join(dir, '.dxkit', 'baselines'), { recursive: true });
+    writeFileSync(
+      join(dir, '.dxkit', 'baselines', 'main.json'),
+      JSON.stringify({
+        schemaVersion: 'dxkit-baseline/v1',
+        name: 'main',
+        createdAt: '2026-08-01T00:00:00Z',
+        repo: {},
+        analysis: {},
+        tools: [],
+        findings: [],
+        floorDebt: {
+          capturedAtCommit: 'abcdef123456abcdef123456abcdef123456abcd',
+          capturedAt: '2026-08-01T00:00:00Z',
+          checks: [{ pack: 'synthetic', label: 'syntax', command: 'fake-syntax', status: 'fail' }],
+        },
+      }),
+    );
+  });
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('a check recorded failing in the envelope warns instead of hard-blocking the push', () => {
+    // The incident shape: CI's two-sided floor reported these failures as
+    // pre-existing/unattributable while the local pre-push hook hard-blocked
+    // them (bypassed with --no-verify — a gate that trains bypassing).
+    const outcome = runFloorForSurface({
+      surface: 'pre-push',
+      cwd: dir,
+      base: 'base-marker',
+      packs: [packWithResolution(unresolved('ghost-pkg'), { syntaxFails: true })],
+      exec: failSyntaxExec,
+    });
+    expect(outcome.ran).toBe(true);
+    expect(outcome.blocks).toBe(false);
+    expect(outcome.summary).toContain('floor-debt');
+    expect(outcome.summary).toContain('pre-existing debt, not blocked at pre-push');
+    expect(outcome.summary).toContain('abcdef123456');
+  });
+
+  it('a failing check ABSENT from the envelope still blocks (point-in-time kept)', () => {
+    const outcome = runFloorForSurface({
+      surface: 'pre-push',
+      cwd: dir,
+      base: 'base-marker',
+      packs: [
+        {
+          ...packWithResolution(unresolved(), { syntaxFails: true }),
+          correctness: {
+            ...(
+              packWithResolution(unresolved(), { syntaxFails: true }) as {
+                correctness: object;
+              }
+            ).correctness,
+            syntaxCheck: () => ({ label: 'other-syntax', bin: 'fake-syntax', args: [] }),
+            resolutionCheck: () => null,
+          },
+        } as unknown as LanguageSupport,
+      ],
+      exec: failSyntaxExec,
+    });
+    expect(outcome.blocks).toBe(true);
+  });
+});


### PR DESCRIPTION
WP6 of the 4.3.7 honesty release: two recommendation-vs-behavior parity gaps.

- **#3** Pre-push hard-blocked grandfathered debt that CI's two-sided floor correctly reported as pre-existing (the narrowed repro from the customer's PR runs). Pre-push now composes both cheap base-evidence tiers through the one comparator: finding-level specifier refutation (4.3.3) plus check-level rows from the committed baseline's floor-debt envelope. Disclosed limits; absent evidence keeps the point-in-time block; envelope loading is tree-then-anchor, read-only, fail-toward-blocking.
- **#2** `policy set graph.refresh cache` was refused while docs + the learn assistant point users at exactly that field (the customer update had to hand-edit policy.json). Now settable (enum `cache`/`off`) with a policy-guide section; scaffold-exempt and posture-exempt as before.

128 affected tests green (incl. two new incident-shaped floor-debt rows); local self-guardrail PASSED; guide tables regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)