### PR TITLE
fix(detect): no-language message names the true cause (empty branch vs unsupported stack)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -608,7 +608,13 @@ export async function run(argv: string[]): Promise<void> {
           detected.testRunner ? detected.testRunner.framework : null,
         ].filter(Boolean);
         if (langs.length === 0) {
-          detectStep.warn('no languages detected — minimal config');
+          // The truthful cause, not the flat message: an empty branch and an
+          // unsupported stack are different problems with different remedies
+          // (the live class: a Unity repo whose default branch held 4 files
+          // read as "unsupported" while 2,000+ C# files sat on other
+          // branches).
+          const { explainNoLanguages } = await import('./detect');
+          detectStep.warn(explainNoLanguages(cwd));
         } else {
           detectStep.succeed(facts.join(' · '));
         }

--- a/src/describe/run.ts
+++ b/src/describe/run.ts
@@ -75,7 +75,14 @@ export async function runDescribe(
   readBundle: () => string | undefined = readVisNetworkBundle,
 ): Promise<DescribeResult> {
   const input = await gatherDescribeInput(cwd);
-  const card = buildRepoCard(input);
+  let card = buildRepoCard(input);
+  if (card.stack.languages.length === 0) {
+    // "unknown stack" hides two different truths (an empty branch vs an
+    // unsupported stack) — append the ONE explainer's checkable cause to the
+    // honesty notes (Rule 2: same explainer init's detect step prints).
+    const { explainNoLanguages } = await import('../detect');
+    card = { ...card, notes: [...card.notes, explainNoLanguages(cwd)] };
+  }
 
   if (opts.json && !opts.html) {
     return { stdout: JSON.stringify(card, null, 2), wrotePath: null, zeroWrite: true };

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import { execFileSync } from 'child_process';
 import * as path from 'path';
 import { DetectedStack, ToolRequirement } from './types';
 import { buildRequiredTools } from './analyzers/tools/tool-registry';
@@ -286,6 +287,83 @@ function detectFramework(cwd: string): string | undefined {
 // and the `vyuh-dxkit tools` subcommand read from the same source of truth.
 function detectRequiredTools(languages: DetectedStack['languages']): ToolRequirement[] {
   return buildRequiredTools(languages);
+}
+
+/**
+ * Why did detection find NO languages here? Two different truths hid under
+ * one message (the class found live on a Unity repo whose default branch
+ * held four files while 2,000+ C# files lived on other branches — "no
+ * supported languages detected" read as "your stack is unsupported" when
+ * the stack IS supported and the branch was simply empty):
+ *
+ *   - the checked-out branch is (nearly) EMPTY — say the file count and,
+ *     when other branches exist, suggest onboarding the one that carries
+ *     the code;
+ *   - source IS present but no pack claims its extensions — name what was
+ *     seen, so "unsupported" is a checkable claim, not a shrug.
+ *
+ * One explainer, consumed by every surface that reports the empty result
+ * (init's detect step, describe's honesty notes). Best-effort git probes;
+ * any failure degrades to the generic message, never a throw.
+ */
+export function explainNoLanguages(cwd: string): string {
+  try {
+    const git = (args: string[]): string =>
+      execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    const files = git(['ls-files']).split('\n').filter(Boolean);
+    const branch = (() => {
+      try {
+        return git(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+      } catch {
+        return 'HEAD';
+      }
+    })();
+    const branchCount = (() => {
+      try {
+        return git(['branch', '-a', '--format=%(refname:short)']).split('\n').filter(Boolean)
+          .length;
+      } catch {
+        return 0;
+      }
+    })();
+
+    if (files.length <= 10) {
+      const hint =
+        branchCount > 1
+          ? ` This repo has ${branchCount} branches — if the code lives on another branch, ` +
+            `check that one out and run dxkit there (the guardrail diffs against the branch ` +
+            `it is installed on).`
+          : '';
+      return (
+        `no source on the checked-out branch — '${branch}' holds only ${files.length} ` +
+        `file(s), so there is nothing to detect a language from (this is NOT a claim that ` +
+        `your stack is unsupported).${hint}`
+      );
+    }
+
+    // Source exists but no pack matched: name what was seen so the claim is
+    // checkable.
+    const histogram = new Map<string, number>();
+    for (const f of files) {
+      const dot = f.lastIndexOf('.');
+      if (dot <= 0 || f.lastIndexOf('/') > dot) continue;
+      const ext = f.slice(dot);
+      histogram.set(ext, (histogram.get(ext) ?? 0) + 1);
+    }
+    const top = [...histogram.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([ext, n]) => `${ext}×${n}`)
+      .join(', ');
+    return (
+      `no supported language among ${files.length} files on '${branch}'` +
+      (top ? ` (most common extensions: ${top})` : '') +
+      ` — if one of these is your stack, a language pack for it does not exist yet ` +
+      `(see docs/configuration/language-packs.md).`
+    );
+  } catch {
+    return 'no languages detected — minimal config';
+  }
 }
 
 export function detect(cwd: string): DetectedStack {

--- a/test/detect.test.ts
+++ b/test/detect.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
-import { detect } from '../src/detect';
+import { execFileSync } from 'child_process';
+import { detect, explainNoLanguages } from '../src/detect';
 
 const FIX = (name: string) => path.join(__dirname, 'fixtures', name);
 
@@ -134,5 +137,58 @@ describe('detect()', () => {
     it('returns no test runner', () => {
       expect(stack.testRunner).toBeUndefined();
     });
+  });
+});
+
+describe('explainNoLanguages — two truths, two messages (the empty-branch class)', () => {
+  function repo(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-nolang-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 't@t'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: dir });
+    return dir;
+  }
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  it('an (almost) empty branch says so and points at other branches — never "unsupported"', () => {
+    const dir = repo();
+    dirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'README.md'), '# scaffold');
+    execFileSync('git', ['add', '-A'], { cwd: dir });
+    execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'x'], {
+      cwd: dir,
+    });
+    execFileSync('git', ['branch', 'working'], { cwd: dir });
+    execFileSync('git', ['branch', 'development'], { cwd: dir });
+    const msg = explainNoLanguages(dir);
+    expect(msg).toContain('no source on the checked-out branch');
+    expect(msg).toContain("'main'");
+    expect(msg).toContain('NOT a claim that your stack is unsupported');
+    expect(msg).toContain('3 branches');
+  });
+
+  it('unsupported source names what was seen (checkable, not a shrug)', () => {
+    const dir = repo();
+    dirs.push(dir);
+    for (let i = 0; i < 15; i++) {
+      fs.writeFileSync(path.join(dir, `mod${i}.zig`), `const x = ${i};`);
+    }
+    execFileSync('git', ['add', '-A'], { cwd: dir });
+    execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'x'], {
+      cwd: dir,
+    });
+    const msg = explainNoLanguages(dir);
+    expect(msg).toContain('no supported language among 15 files');
+    expect(msg).toContain('.zig');
+    expect(msg).toContain('language pack');
+  });
+
+  it('a non-git directory degrades to the generic message, never a throw', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-nolang-plain-'));
+    dirs.push(dir);
+    expect(explainNoLanguages(dir)).toContain('no languages detected');
   });
 });


### PR DESCRIPTION
WP7, pulled into 4.3.7 on request: item #18 — the message-conflation defect found on a real onboarding.

"No supported languages detected" hid two different truths: an (almost) empty checked-out branch, and genuinely unsupported source. One explainer now names the actual cause with checkable facts (file count + branch hint, or an extension histogram + language-pack pointer), consumed by both init's detect step and describe's honesty notes. Fail-open to the old generic line on any git failure.

Both arms verified live on fixture repos; 24 detect tests green; arch/lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)