### PR TITLE
feat(baseline): pairedChecks ifAdded — norms about new artifacts fire on additions only

### DIFF
--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -201,6 +201,23 @@ you know; dxkit inferring them would recommend wrong pairings confidently.
 ]
 ```
 
+**Tuning.** For norms about NEW artifacts, use `ifAdded` instead of (or
+beside) `if`: it triggers only when the change ADDED a matching file, so
+editing an existing one never over-demands the companion. A rule needs at
+least one of `if` / `ifAdded`, plus `then`.
+
+```jsonc
+"pairedChecks": [
+  { "name": "component-needs-guide",
+    "ifAdded": ["src/components/**"], "then": ["docs/guides/**"],
+    "message": "a new component ships with a guide" }
+]
+```
+
+When the added-file set cannot be computed for a run, an `ifAdded` clause
+is not evaluated (it never fires blind) and the skip is disclosed in the
+gate output.
+
 ## Prohibited licenses
 
 **What it does.** Blocks a net-new dependency whose license matches a

--- a/src/analyzers/custom-checks/config.ts
+++ b/src/analyzers/custom-checks/config.ts
@@ -85,7 +85,13 @@ export function normalizeCustomChecks(
 /** A validated paired-change rule the gate evaluates. */
 export interface PairedCheckRule {
   readonly name: string;
+  /** Trigger globs over the CHANGED-path set (may be empty when the rule
+   *  triggers on additions only). */
   readonly ifGlobs: readonly string[];
+  /** Trigger globs over the ADDED-file set (created files; renames are not
+   *  additions) — the "new component ships with a guide" shape, where a
+   *  plain `if` would over-demand the companion on every edit. */
+  readonly ifAddedGlobs: readonly string[];
   readonly thenGlobs: readonly string[];
   readonly message?: string;
   readonly blocking: boolean;
@@ -121,10 +127,12 @@ export function normalizePairedChecks(
       continue;
     }
     const ifGlobs = normalizeGlobs(raw.if);
+    const ifAddedGlobs = normalizeGlobs(raw.ifAdded);
     const thenGlobs = normalizeGlobs(raw.then);
-    if (ifGlobs.length === 0 || thenGlobs.length === 0) {
+    if ((ifGlobs.length === 0 && ifAddedGlobs.length === 0) || thenGlobs.length === 0) {
       warnings.push(
-        `pairedChecks rule '${name}' needs at least one \`if\` and one \`then\` glob and was skipped`,
+        `pairedChecks rule '${name}' needs at least one trigger glob (\`if\` or \`ifAdded\`) ` +
+          `and one \`then\` glob and was skipped`,
       );
       continue;
     }
@@ -132,6 +140,7 @@ export function normalizePairedChecks(
     rules.push({
       name,
       ifGlobs,
+      ifAddedGlobs,
       thenGlobs,
       ...(typeof raw.message === 'string' && raw.message.trim()
         ? { message: raw.message.trim() }
@@ -142,7 +151,9 @@ export function normalizePairedChecks(
   return { rules, warnings };
 }
 
-function normalizeGlobs(value: PairedCheckConfig['if'] | undefined): readonly string[] {
+function normalizeGlobs(
+  value: PairedCheckConfig['if'] | PairedCheckConfig['ifAdded'] | undefined,
+): readonly string[] {
   const list = typeof value === 'string' ? [value] : Array.isArray(value) ? value : [];
   return list
     .filter((g): g is string => typeof g === 'string')

--- a/src/baseline/paired-gate-check.ts
+++ b/src/baseline/paired-gate-check.ts
@@ -27,7 +27,7 @@
  * waives it (the per-finding escape hatch, ideally `deferred` with an expiry).
  */
 
-import { computeChangedPaths } from './changed-files';
+import { computeAddedFiles, computeChangedPaths } from './changed-files';
 import { computePairedChangeFingerprint } from '../analyzers/tools/fingerprint-contract';
 import { globToRegex } from '../analyzers/tools/suppressions';
 import { normalizePairedChecks, type PairedCheckRule } from '../analyzers/custom-checks/config';
@@ -121,15 +121,28 @@ function skip(
   };
 }
 
-/** Evaluate one rule against the changed-path set. Pure. */
+/**
+ * Evaluate one rule against the changed-path set (and, for `ifAdded`
+ * clauses, the ADDED-file set). Pure.
+ *
+ * `addedPaths === null` means the added set could not be computed — an
+ * `ifAdded` clause is then NOT evaluated (bias toward the false negative:
+ * firing would treat every changed path as potentially added and
+ * over-demand the companion). The caller discloses the skip per rule.
+ */
 export function evaluatePairedRule(
   rule: PairedCheckRule,
   changedPaths: readonly string[],
+  addedPaths: readonly string[] | null,
 ): PairedChangeFinding | null {
   const ifRes = rule.ifGlobs.map(globToRegex);
+  const ifAddedRes = rule.ifAddedGlobs.map(globToRegex);
   const thenRes = rule.thenGlobs.map(globToRegex);
   const ifMatched = changedPaths.filter((p) => ifRes.some((re) => re.test(p)));
-  if (ifMatched.length === 0) return null;
+  const ifAddedMatched =
+    addedPaths === null ? [] : addedPaths.filter((p) => ifAddedRes.some((re) => re.test(p)));
+  const triggered = [...ifMatched, ...ifAddedMatched.filter((p) => !ifMatched.includes(p))];
+  if (triggered.length === 0) return null;
   const thenTouched = changedPaths.some((p) => thenRes.some((re) => re.test(p)));
   if (thenTouched) return null;
   return {
@@ -137,7 +150,7 @@ export function evaluatePairedRule(
     check: rule.name,
     blocking: rule.blocking,
     ...(rule.message !== undefined ? { message: rule.message } : {}),
-    ifMatched: ifMatched.slice(0, MAX_IF_MATCHED_SAMPLE),
+    ifMatched: triggered.slice(0, MAX_IF_MATCHED_SAMPLE),
     thenGlobs: rule.thenGlobs,
   };
 }
@@ -189,6 +202,9 @@ export function evaluatePairedGateForGuardrail(opts: {
   readonly now?: Date;
   readonly verbose?: boolean;
   readonly changedPathsProvider?: (cwd: string, base: string) => ReadonlyArray<string> | null;
+  /** Injected for tests; defaults to the ONE added-file projection
+   *  (`computeAddedFiles` — the same base->working-tree diff concept). */
+  readonly addedPathsProvider?: (cwd: string, base: string) => ReadonlySet<string> | null;
 }): PairedGateOutcome {
   const cwd = opts.cwd;
   let step = 'policy-read';
@@ -205,10 +221,32 @@ export function evaluatePairedGateForGuardrail(opts: {
     // a declared rule silently skipped would be the invisible-gate class, so
     // the skip is disclosed on the outcome.
     if (changedPaths === null) return skip('no-changed-set', warnings);
+    // The ADDED-file projection, computed only when some rule declares an
+    // `ifAdded` clause. `null` = unknown; the clause is then not evaluated
+    // (false-negative bias) and the skip is disclosed per rule below.
+    const needsAdded = rules.some((r) => r.ifAddedGlobs.length > 0);
+    const addedSet = needsAdded
+      ? (opts.addedPathsProvider ?? ((c: string, b: string) => computeAddedFiles(c, b)))(
+          cwd,
+          opts.baseRef,
+        )
+      : null;
+    const addedPaths = addedSet === null ? null : [...addedSet];
+    const evalWarnings = [...warnings];
+    if (needsAdded && addedPaths === null) {
+      for (const r of rules) {
+        if (r.ifAddedGlobs.length > 0) {
+          evalWarnings.push(
+            `rule '${r.name}': the added-file set could not be computed, so its \`ifAdded\` ` +
+              `clause was not evaluated this run (never fired blind)`,
+          );
+        }
+      }
+    }
 
     step = 'evaluate-rules';
     const violations = rules
-      .map((rule) => evaluatePairedRule(rule, changedPaths))
+      .map((rule) => evaluatePairedRule(rule, changedPaths, addedPaths))
       .filter((f): f is PairedChangeFinding => f !== null);
 
     const { active, suppressed } = partitionByAllowlist(
@@ -223,7 +261,7 @@ export function evaluatePairedGateForGuardrail(opts: {
         `    [paired] ${active.length} paired-change violation(s) — ${blocks ? 'blocking' : 'warning'}\n`,
       );
     }
-    return { ran: true, warnings, findings: active, suppressed, blocks, warns };
+    return { ran: true, warnings: evalWarnings, findings: active, suppressed, blocks, warns };
   } catch (err) {
     // Fail-open: a git failure, an unreadable policy — the gate did not run,
     // but it says WHY rather than swallowing the throw.

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -190,6 +190,14 @@ export function buildPolicySchema(version: string): Schema {
               items: { type: 'string' },
               description: 'Globs that trigger the rule when the change touches them.',
             },
+            ifAdded: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'Globs that trigger the rule only when the change ADDED a matching file ' +
+                '(created; renames excluded) — for norms about new artifacts, e.g. a new ' +
+                'component must ship with a guide. A rule needs `if` and/or `ifAdded`.',
+            },
             then: {
               type: 'array',
               items: { type: 'string' },

--- a/src/baseline/policy-sections.ts
+++ b/src/baseline/policy-sections.ts
@@ -34,8 +34,14 @@ import type { FindingSeverity } from './types';
 export interface PairedCheckConfig {
   /** Stable rule name — the finding's whole identity (Rule 9). Required. */
   readonly name?: string;
-  /** Glob(s) selecting the trigger surface. Required, at least one. */
+  /** Glob(s) selecting the trigger surface among CHANGED paths (edits,
+   *  additions, deletions). A rule needs `if` and/or `ifAdded`. */
   readonly if?: string | readonly string[];
+  /** Glob(s) selecting the trigger surface among files the change ADDED
+   *  (created; renames are not additions). For norms about NEW artifacts —
+   *  "a new component ships with a guide" — where a plain `if` would
+   *  over-demand the companion on every EDIT of an existing file. */
+  readonly ifAdded?: string | readonly string[];
   /** Glob(s) selecting the required companion surface. Required, at least one. */
   readonly then?: string | readonly string[];
   /** Human-facing explanation rendered with a violation. */

--- a/src/checks-cli.ts
+++ b/src/checks-cli.ts
@@ -89,6 +89,7 @@ function listChecks(
       pairedChecks: pairedRules.map((r) => ({
         name: r.name,
         if: r.ifGlobs,
+        ifAdded: r.ifAddedGlobs,
         then: r.thenGlobs,
         blocking: r.blocking,
         ...(r.message !== undefined ? { message: r.message } : {}),
@@ -129,7 +130,11 @@ function renderPairedGroup(rules: readonly PairedCheckRule[]): void {
   for (const r of rules) {
     const intent = r.blocking ? 'blocking' : 'warn-only';
     logger.dim(`  ${r.name.padEnd(22)} ${intent} · paired-change`);
-    logger.dim(`    if ${r.ifGlobs.join(', ')}  ⇒  then ${r.thenGlobs.join(', ')}`);
+    const triggers = [
+      ...(r.ifGlobs.length ? [`if ${r.ifGlobs.join(', ')}`] : []),
+      ...(r.ifAddedGlobs.length ? [`ifAdded ${r.ifAddedGlobs.join(', ')}`] : []),
+    ].join(' | ');
+    logger.dim(`    ${triggers}  ⇒  then ${r.thenGlobs.join(', ')}`);
     if (r.message) logger.dim(`    ↳ ${r.message}`);
   }
 }

--- a/test/baseline/paired-gate-check.test.ts
+++ b/test/baseline/paired-gate-check.test.ts
@@ -62,7 +62,7 @@ describe('evaluatePairedRule — the pure per-rule predicate', () => {
   const rule = rules[0];
 
   it('fires when if is touched and then is not', () => {
-    const f = evaluatePairedRule(rule, ['src/models/user.ts', 'README.md']);
+    const f = evaluatePairedRule(rule, ['src/models/user.ts', 'README.md'], []);
     expect(f).not.toBeNull();
     expect(f!.check).toBe('model-needs-migration');
     expect(f!.blocking).toBe(true);
@@ -71,18 +71,74 @@ describe('evaluatePairedRule — the pure per-rule predicate', () => {
   });
 
   it('is silent when the companion change is present', () => {
-    expect(evaluatePairedRule(rule, ['src/models/user.ts', 'migrations/0042_user.sql'])).toBeNull();
+    expect(
+      evaluatePairedRule(rule, ['src/models/user.ts', 'migrations/0042_user.sql'], []),
+    ).toBeNull();
   });
 
   it('is silent when the trigger surface is untouched', () => {
-    expect(evaluatePairedRule(rule, ['src/routes/user.ts'])).toBeNull();
+    expect(evaluatePairedRule(rule, ['src/routes/user.ts'], [])).toBeNull();
   });
 
   it('matches ** across directory levels and caps the evidence sample', () => {
     const paths = Array.from({ length: 9 }, (_, i) => `src/models/nested/deep/m${i}.ts`);
-    const f = evaluatePairedRule(rule, paths);
+    const f = evaluatePairedRule(rule, paths, []);
     expect(f).not.toBeNull();
     expect(f!.ifMatched.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('evaluatePairedRule — the ifAdded trigger (norms about NEW artifacts)', () => {
+  const { rules } = normalizePairedChecks([
+    {
+      name: 'component-needs-guide',
+      ifAdded: 'src/components/**',
+      then: 'docs/guides/**',
+      message: 'a new component ships with a guide',
+    },
+  ]);
+  const rule = rules[0];
+
+  it('fires when a matching file was ADDED and the companion is untouched', () => {
+    const f = evaluatePairedRule(
+      rule,
+      ['src/components/NewThing.tsx'],
+      ['src/components/NewThing.tsx'],
+    );
+    expect(f).not.toBeNull();
+    expect(f!.check).toBe('component-needs-guide');
+    expect(f!.ifMatched).toEqual(['src/components/NewThing.tsx']);
+  });
+
+  it('does NOT fire on an EDIT of an existing component (the over-demand class)', () => {
+    // The changed set contains the component, the added set does not — an
+    // edit must not demand a new guide.
+    expect(evaluatePairedRule(rule, ['src/components/OldThing.tsx'], [])).toBeNull();
+  });
+
+  it('is satisfied by a companion change like any other rule', () => {
+    expect(
+      evaluatePairedRule(
+        rule,
+        ['src/components/NewThing.tsx', 'docs/guides/new-thing.md'],
+        ['src/components/NewThing.tsx'],
+      ),
+    ).toBeNull();
+  });
+
+  it('an UNKNOWN added set never fires the clause (false-negative bias)', () => {
+    expect(evaluatePairedRule(rule, ['src/components/NewThing.tsx'], null)).toBeNull();
+  });
+
+  it('a rule may declare both if and ifAdded — either triggers', () => {
+    const both = normalizePairedChecks([
+      { name: 'either', if: 'api/**', ifAdded: 'src/components/**', then: 'docs/**' },
+    ]).rules[0];
+    expect(evaluatePairedRule(both, ['api/users.ts'], [])).not.toBeNull();
+    expect(
+      evaluatePairedRule(both, ['src/components/X.tsx'], ['src/components/X.tsx']),
+    ).not.toBeNull();
+    expect(evaluatePairedRule(both, ['unrelated.md'], [])).toBeNull();
   });
 });
 
@@ -218,6 +274,58 @@ describe('evaluatePairedGateForGuardrail — fail-open, always says why', () => 
       });
       expect(out.findings).toHaveLength(1);
       expect(out.blocks).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('evaluatePairedGateForGuardrail — the ifAdded clause end to end', () => {
+  const ADDED_RULE = {
+    name: 'component-needs-guide',
+    ifAdded: 'src/components/**',
+    then: 'docs/guides/**',
+  };
+
+  it('fires through the gate when the added set matches', () => {
+    const dir = repoWith({ pairedChecks: [ADDED_RULE] });
+    try {
+      const out = evaluatePairedGateForGuardrail({
+        cwd: dir,
+        baseRef: 'HEAD',
+        changedPathsProvider: () => ['src/components/NewThing.tsx'],
+        addedPathsProvider: () => new Set(['src/components/NewThing.tsx']),
+      });
+      expect(out.ran).toBe(true);
+      expect(out.findings).toHaveLength(1);
+      expect(out.blocks).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('an edit-only diff does not fire, and an UNKNOWN added set discloses the unevaluated clause', () => {
+    const dir = repoWith({ pairedChecks: [ADDED_RULE] });
+    try {
+      const edit = evaluatePairedGateForGuardrail({
+        cwd: dir,
+        baseRef: 'HEAD',
+        changedPathsProvider: () => ['src/components/OldThing.tsx'],
+        addedPathsProvider: () => new Set(),
+      });
+      expect(edit.ran).toBe(true);
+      expect(edit.findings).toHaveLength(0);
+
+      const unknown = evaluatePairedGateForGuardrail({
+        cwd: dir,
+        baseRef: 'HEAD',
+        changedPathsProvider: () => ['src/components/NewThing.tsx'],
+        addedPathsProvider: () => null,
+      });
+      expect(unknown.ran).toBe(true);
+      expect(unknown.findings).toHaveLength(0);
+      expect(unknown.warnings.join(' ')).toContain('ifAdded');
+      expect(unknown.warnings.join(' ')).toContain('never fired blind');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
WP8, pulled into 4.3.7 on request: item #5 — the added-only paired-check trigger (the "new component ships with a guide" norm, without over-demanding the guide on every edit).

- `ifAdded` globs beside/instead of `if`; triggers only on files the change ADDED (rename-aware, via the one `computeAddedFiles` projection landed with WP5).
- Unknown added set: the clause never fires blind and the skip is disclosed per rule.
- The gate stays pure (git metadata only — every surface, fork PRs, ref-based mode).
- Schema, policy guide (worked example), and `checks list` rendering updated.

21 gate tests green (+ schema/guide/kb drift nets, 113 total); local self-guardrail PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)