### PR TITLE
fix(baseline): scheme-mismatch remedy matches the migration state (anchor repos)

### DIFF
--- a/src/baseline/check.ts
+++ b/src/baseline/check.ts
@@ -316,6 +316,31 @@ export interface AnchorSourceDisclosure {
 }
 
 /**
+ * The scheme-mismatch remedy, state-aware (exported for tests). A repo whose
+ * LOCAL baseline is already current-scheme while the gate read a
+ * stale-scheme ANCHOR gets the real next step (`baseline publish`) —
+ * telling a user who just ran `update` to "run update" is a loop.
+ */
+export function schemeMismatchRemedy(
+  baselineScheme: string,
+  anchorSource: AnchorSourceDisclosure | undefined,
+  treeScheme: string | null,
+): string {
+  if (anchorSource?.used === 'anchor' && treeScheme === CURRENT_IDENTITY_SCHEME) {
+    return (
+      `The LOCAL baseline is already migrated to ${CURRENT_IDENTITY_SCHEME}, but this ` +
+      `gate reads the '${anchorSource.anchorRef}' anchor branch, which still holds ` +
+      `${baselineScheme}. Run \`${dxkitCli('baseline publish')}\` to land the migrated ` +
+      `baseline on the anchor (and commit .dxkit/allowlist.json).`
+    );
+  }
+  return (
+    `Run \`${dxkitCli('update')}\` to migrate the baseline + allowlist ` +
+    `automatically, or \`${dxkitCli('baseline create --force')}\` to re-anchor manually.`
+  );
+}
+
+/**
  * One unobserved slice of the baseline: a check (or a scoped-out gather) the
  * current run never executed, with how many committed baseline findings that
  * leaves un-re-verified. The aggregate the renderers print INSTEAD of listing
@@ -792,12 +817,26 @@ export async function runGuardrailCheck(
   if (mode.mode !== 'ref-based') {
     const baselineScheme = baseline.identityScheme ?? 'v1';
     if (baselineScheme !== CURRENT_IDENTITY_SCHEME) {
+      // The remedy must match the STATE (observed on the live migration
+      // test): on an anchor-transport repo, `update` migrates the LOCAL
+      // baseline but the gate reads the ANCHOR — telling a user who just
+      // ran update to "run update" is a loop. When the source was the
+      // anchor and the tree copy is already current-scheme, the real next
+      // step is `baseline publish`.
+      let treeScheme: string | null = null;
+      if (anchorSource?.used === 'anchor' && baselinePath && fs.existsSync(baselinePath)) {
+        try {
+          treeScheme = readBaselineFile(baselinePath).identityScheme ?? 'v1';
+        } catch {
+          /* unreadable tree copy — keep the generic remedy */
+        }
+      }
+      const remedy = schemeMismatchRemedy(baselineScheme, anchorSource, treeScheme);
       throw new Error(
         `Baseline "${baseline.name}" was captured under finding-identity scheme ` +
           `${baselineScheme}, but this dxkit mints ${CURRENT_IDENTITY_SCHEME}. The identity ` +
           `scheme changed between versions; diffing across schemes would flag every existing ` +
-          `finding as net-new. Run \`${dxkitCli('update')}\` to migrate the baseline + allowlist ` +
-          `automatically, or \`${dxkitCli('baseline create --force')}\` to re-anchor manually.`,
+          `finding as net-new. ${remedy}`,
       );
     }
   }

--- a/test/baseline/check.test.ts
+++ b/test/baseline/check.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs'
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { createBaseline } from '../../src/baseline/create';
-import { runGuardrailCheck } from '../../src/baseline/check';
+import { runGuardrailCheck, schemeMismatchRemedy } from '../../src/baseline/check';
 import { renderConsole, renderJson, renderMarkdown } from '../../src/baseline/check-renderers';
 import { computeFlowBindingFingerprint } from '../../src/analyzers/tools/fingerprint-contract';
 import { trustedLocalContext } from '../../src/analysis-trust';
@@ -840,4 +840,30 @@ describe('runGuardrailCheck — flow integration gate seam', () => {
     expect(result.flowGate?.findings.map((f) => f.path)).toContain('/dead');
     expect(result.blocks).toBe(true);
   }, 300_000);
+});
+
+describe('schemeMismatchRemedy — the remedy matches the migration STATE', () => {
+  it('anchor stale + local already migrated -> baseline publish (never a "run update" loop)', () => {
+    const remedy = schemeMismatchRemedy(
+      'v2',
+      { used: 'anchor', anchorRef: 'dxkit-baselines', note: 'x' },
+      CURRENT_IDENTITY_SCHEME,
+    );
+    expect(remedy).toContain('baseline publish');
+    expect(remedy).toContain('dxkit-baselines');
+    expect(remedy).toContain('already migrated');
+    expect(remedy).not.toContain('vyuh-dxkit update');
+  });
+
+  it('everything else keeps the generic update remedy', () => {
+    for (const [anchorSource, treeScheme] of [
+      [undefined, null],
+      [{ used: 'anchor', anchorRef: 'dxkit-baselines', note: 'x' }, 'v2'],
+      [{ used: 'tree-fallback', anchorRef: 'dxkit-baselines', note: 'x' }, CURRENT_IDENTITY_SCHEME],
+    ] as const) {
+      const remedy = schemeMismatchRemedy('v2', anchorSource as never, treeScheme as never);
+      expect(remedy).toContain('update');
+      expect(remedy).not.toContain('already migrated');
+    }
+  });
 });


### PR DESCRIPTION
WP9 — found by the thoroughness audit's live v2→v3 migration test on the customer clone (real 18.9k-finding artifacts).

`update` migrated the LOCAL baseline + allowlist to v3, but the gate reads the ANCHOR branch (still v2) and the refusal told the user to "run update" — a loop for someone who just did. The remedy is now state-aware: anchor-stale + local-already-migrated names the real next step (`baseline publish` + commit the allowlist). Pure helper, both arms unit-pinned, and verified live on the half-migrated clone (message now reads: "The LOCAL baseline is already migrated to v3, but this gate reads the 'dxkit-baselines' anchor branch, which still holds v2. Run `npx vyuh-dxkit baseline publish`…").

Also from the same audit, recorded as validation (no code): the migration lane itself worked on the real artifacts (re-baselined onto v3; allowlist migrated; the stale axios deferral correctly surfaced as prunable), and the live never-ran test against the real claude CLI (2.1.223, invalid key) produced the exact intended red outcome with the provider's cause, auth path, and CLI version disclosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)