### PR TITLE
fix(remediate): custom task honors the salvage policy (#274)

### DIFF
--- a/src/remediate/cli.ts
+++ b/src/remediate/cli.ts
@@ -92,13 +92,17 @@ async function executeTask(
   // copy, so the runner's enforcement + ledger see the effective caps.
   // Dispatch-campaign overrides (env-transported, clamped) layer on top —
   // the runner receives the disclosure and folds it into the ledger.
-  const task = remediateTaskById(taskId);
-  const policyBudget = task ? budgetForTask(config, task.id) : config.agent.budget;
+  // Both derivations take the RAW id string — never `task ? … : fallback`.
+  // 'custom' is deliberately outside the registry, so a registry-lookup
+  // guard here is a second, weaker derivation of the same concept the
+  // resolvers already own (the #274 class: it forced salvage to 'discard'
+  // on a verified custom run, overriding explicit policy).
+  const policyBudget = budgetForTask(config, taskId);
   const dispatch = readDispatchOverrides(process.env, policyBudget, config);
   // The concrete salvage decision for THIS task (the one resolver: explicit
   // policy wins, 'auto' follows the task's completion shape) — threaded into
   // the runner's config so the ledger note and the landing below agree.
-  const salvage = task ? salvageForTask(config, task) : 'discard';
+  const salvage = salvageForTask(config, taskId);
   const taskConfig: RemediateConfig = {
     ...config,
     salvage,
@@ -114,15 +118,25 @@ async function executeTask(
   // partial reads NET-NEW and can never grandfather its own breakage.
   let entryFloor: CorrectnessFloorResult | undefined;
   let resume: ResumeDecision = { resumed: false };
-  if (land === 'pr' && task && config.resume) {
-    // (salvage below is the task-resolved decision — resume needs draft-pr)
+  if (land === 'pr' && config.resume && taskId === 'custom') {
+    // DELIBERATE, not a registry-lookup accident: a custom dispatch carries a
+    // human-supplied prompt, and a later dispatch may carry a DIFFERENT one —
+    // resuming would continue a prior attempt's goal under this run's prompt
+    // and ledger. Disclosed here, never a silent guard (#274's second half).
+    logger.warn(
+      'resume: unavailable for custom dispatch tasks — a later dispatch may carry a ' +
+        'different prompt than the salvaged attempt; starting fresh.',
+    );
+  }
+  if (land === 'pr' && config.resume && taskId !== 'custom' && remediateTaskById(taskId)) {
+    // (salvage above is the task-resolved decision — resume needs draft-pr)
     entryFloor = runCorrectnessFloor({
       cwd,
       changedFiles: [],
       scope: 'full',
       packs: detectActiveLanguages(cwd),
     });
-    resume = prepareResume(cwd, task.id, { resume: config.resume, salvage });
+    resume = prepareResume(cwd, taskId, { resume: config.resume, salvage });
     if (resume.note) logger.warn(`resume: ${resume.note}`);
     if (resume.resumed) {
       logger.info(`resuming budget-bounded attempt #${resume.attempt} from the salvage branch`);

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -86,7 +86,14 @@ export interface RemediateConfig {
  */
 export function salvageForTask(
   config: Pick<RemediateConfig, 'salvage'>,
-  task: Pick<RemediateTask, 'completion'> | RemediateTaskId,
+  // Accepts the resolved task OR its raw id string. The string arm exists so
+  // callers that hold only an id (the CLI executor, where 'custom' is
+  // deliberately outside the registry) route through THIS resolver instead of
+  // re-deriving from a registry lookup — the lookup-returns-undefined path is
+  // exactly how the executor's second derivation forced 'discard' on a
+  // verified custom run (#274). An id that resolves to nothing and is not
+  // 'custom' reads as bounded → discard (conservative).
+  task: Pick<RemediateTask, 'completion'> | string,
 ): 'discard' | 'draft-pr' {
   if (config.salvage !== 'auto') return config.salvage;
   const shape =
@@ -100,9 +107,12 @@ export function salvageForTask(
 
 /** The effective budget for one task: the per-task override merged over the
  *  shared agent budget — the ONE derivation every surface (runner, plan,
- *  matrix trim) reads. */
-export function budgetForTask(config: RemediateConfig, taskId: RemediateTaskId): RemediateBudget {
-  const override = config.taskBudgets[taskId] ?? {};
+ *  matrix trim) reads. Accepts a raw id string so the executor never branches
+ *  on "is this a registry task" to pick a budget: an id with no override slot
+ *  ('custom', or a typo the runner will refuse anyway) gets the shared agent
+ *  budget. */
+export function budgetForTask(config: RemediateConfig, taskId: string): RemediateBudget {
+  const override = config.taskBudgets[taskId as RemediateTaskId] ?? {};
   return {
     maxTurns: positiveNumber(override.maxTurns, config.agent.budget.maxTurns),
     maxMinutes: positiveNumber(override.maxMinutes, config.agent.budget.maxMinutes),

--- a/test/remediate/config-budgets.test.ts
+++ b/test/remediate/config-budgets.test.ts
@@ -3,7 +3,7 @@
  * ceiling (the org guard for the per-task matrix, where a failing task no
  * longer starves siblings and every task may spend its own cap).
  */
-import { REMEDIATE_TASKS } from '../../src/remediate/tasks';
+import { customDispatchTask, REMEDIATE_TASKS } from '../../src/remediate/tasks';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -55,6 +55,13 @@ describe('budgetForTask', () => {
     });
     // A task with no override gets the shared budget untouched.
     expect(budgetForTask(config, 'fix-vulns')).toEqual(DEFAULT_REMEDIATE_BUDGET);
+  });
+
+  it('accepts a raw id string: custom (outside the registry) gets the shared budget', () => {
+    // The executor holds only the id string — it must not branch on "is this
+    // a registry task" to pick a budget (#274's sibling derivation).
+    expect(budgetForTask(cfg({}), 'custom')).toEqual(DEFAULT_REMEDIATE_BUDGET);
+    expect(budgetForTask(cfg({}), 'no-such-task')).toEqual(DEFAULT_REMEDIATE_BUDGET);
   });
 });
 
@@ -130,6 +137,38 @@ describe('salvageForTask — the one salvage resolver (task-shape defaults)', ()
   it('an explicit policy value overrides every task', () => {
     expect(salvageForTask({ salvage: 'discard' }, 'write-docs')).toBe('discard');
     expect(salvageForTask({ salvage: 'draft-pr' }, 'fix-build')).toBe('draft-pr');
+  });
+
+  it('custom honors explicit policy and auto — never a structural discard (#274)', () => {
+    // The live class: a registry-lookup guard in the CLI executor forced
+    // 'discard' for custom, overriding BOTH an explicit draft-pr policy and
+    // 'auto' — a verified, guardrail-PASSED docs run was thrown away.
+    expect(salvageForTask({ salvage: 'draft-pr' }, 'custom')).toBe('draft-pr');
+    expect(salvageForTask(auto, 'custom')).toBe('draft-pr');
+    expect(salvageForTask({ salvage: 'discard' }, 'custom')).toBe('discard');
+  });
+
+  it('PARITY: the id-string arm and the resolved-task arm agree for every task', () => {
+    // The CLI executor passes the raw id string; the runner passes the
+    // resolved task object. Both hit this one resolver — this pins that the
+    // two call shapes cannot diverge (the Rule 2.30 net for #274).
+    const policies = [
+      { salvage: 'auto' },
+      { salvage: 'draft-pr' },
+      { salvage: 'discard' },
+    ] as const;
+    for (const policy of policies) {
+      for (const t of REMEDIATE_TASKS) {
+        expect(salvageForTask(policy, t.id)).toBe(salvageForTask(policy, t));
+      }
+      expect(salvageForTask(policy, 'custom')).toBe(
+        salvageForTask(policy, customDispatchTask('any prompt')),
+      );
+    }
+  });
+
+  it('an unknown id string (typo — the runner will refuse it) reads bounded → discard', () => {
+    expect(salvageForTask(auto, 'no-such-task')).toBe('discard');
   });
 
   it('every registered task declares its completion shape', () => {


### PR DESCRIPTION
One of four 4.3.7.1 deliver-layer fixes (umbrella: #270).

**Defect (#274)**: `executeTask` re-derived task facts from `remediateTaskById(taskId)`, which is deliberately `undefined` for `custom` (dispatch-only, outside the registry). The guard `task ? salvageForTask(...) : 'discard'` therefore forced `salvage: discard` for every custom dispatch, overriding both an explicit `draft-pr` policy and `auto` — and the wrong value was baked into the task-scoped config, so the runner's correct resolver inherited it as explicit policy. Observed live: a verified, guardrail-PASSED custom docs run discarded. The same guard silently disabled resume for custom.

**Fix**: both derivations now pass the raw id string through the one resolvers — `salvageForTask` / `budgetForTask` — which already handle `custom` (open-ended → draft-pr under auto) and unknown ids (bounded → discard, and the runner refuses them anyway). No `task ? … : fallback` branch remains. Resume-for-custom is now a deliberate, disclosed decision: unavailable (a later dispatch may carry a different prompt than the salvaged attempt), warned in the job log instead of silently guarded.

**Tests**: custom under explicit draft-pr / auto / explicit discard each asserted; budget for custom/unknown ids; and a parity pin — the id-string arm and the resolved-task arm of `salvageForTask` agree for every task under every policy, so the executor and runner cannot diverge again (the Rule 2.30 net).

Gates run locally: full suite (5,430), typecheck:test, lint, format, architecture, slop, self-guardrail ref-based vs origin/main (PASSED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)