### PR TITLE
fix(remediate): wall-clock kill classified by deadline, not signal encoding (#272)

### DIFF
--- a/src/remediate/claude-code-driver.ts
+++ b/src/remediate/claude-code-driver.ts
@@ -49,6 +49,22 @@ const MAX_CAPTURE = 16 * 1024 * 1024;
  * Real spawn. A timeout kill surfaces as `timedOut`, distinct from a
  * non-zero exit; captured output rides the error object either way.
  *
+ * Timeout classification is DEADLINE-FIRST, not signal-encoding-first
+ * (#272): the deadline is this exec's own fact, so it measures elapsed
+ * time itself and classifies a kill-shaped death at/past the deadline as
+ * `timedOut` — corroborated by any of the encodings a SIGTERM produces:
+ *
+ *   - signal-death: the child died to the signal (`signal: 'SIGTERM'`,
+ *     no exit status) — the only encoding the original predicate knew;
+ *   - graceful-catch: the child traps SIGTERM and exits 128+15=143
+ *     (observed on claude CLI 2.1.222) — `status: 143`, `signal: null`,
+ *     and no result JSON, which made the run read as "agent never ran"
+ *     and discard 30 minutes of stranded work before the sweep.
+ *
+ * A natural non-zero exit before the deadline is never a timeout, and a
+ * real failure exit (e.g. 1) is never reclassified even when the race
+ * lands it past the deadline — biased toward false NEGATIVE.
+ *
  * DECLARED EXCEPTION to the bounded-exec seam (Rule 2 discipline: an
  * exception is stated, never silent): `makeCommandExec` merges stdout and
  * stderr into one stream, but this driver's never-ran taxonomy REQUIRES
@@ -58,6 +74,7 @@ const MAX_CAPTURE = 16 * 1024 * 1024;
  * agent spawn keeps its own exec with the same timeout-kill semantics.
  */
 export const realAgentExec: AgentExec = (bin, args, opts) => {
+  const startedAt = Date.now();
   try {
     const stdout = execFileSync(bin, args as string[], {
       cwd: opts.cwd,
@@ -75,11 +92,17 @@ export const realAgentExec: AgentExec = (bin, args, opts) => {
       stdout?: string;
       stderr?: string;
     };
+    const status = typeof e.status === 'number' ? e.status : null;
+    const signalDeath = e.signal === 'SIGTERM' && status === null;
+    // Kill-shaped: died to a signal (no status), or exited with the
+    // SIGTERM convention code. A plain failure exit is not kill-shaped.
+    const killShaped = signalDeath || e.signal === 'SIGTERM' || status === 143 || status === null;
+    const pastDeadline = Date.now() - startedAt >= opts.timeoutMs;
     return {
-      code: typeof e.status === 'number' ? e.status : null,
+      code: status,
       stdout: e.stdout ?? '',
       stderr: e.stderr ?? String(e.message ?? ''),
-      timedOut: e.signal === 'SIGTERM' && typeof e.status !== 'number',
+      timedOut: signalDeath || (pastDeadline && killShaped),
     };
   }
 };

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -211,7 +211,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     env: opts.agentEnv ?? {},
   });
 
-  const envelope: AgentEnvelope = {
+  let envelope: AgentEnvelope = {
     ...envelopeBase,
     ...(agentResult.resolvedModelId ? { resolvedModelId: agentResult.resolvedModelId } : {}),
     ...(agentResult.cliVersion ? { cliVersion: agentResult.cliVersion } : {}),
@@ -225,20 +225,14 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     ? { transcriptTail: agentResult.transcriptTail }
     : {};
 
-  if (agentResult.neverRan) {
-    return finish({
-      outcome: 'agent-never-ran',
-      task: task.id,
-      envelope,
-      floor: entryFloor,
-      ...evidenceTail,
-      note: `agent never ran: ${agentResult.neverRan.reason}`,
-    });
-  }
-
   // Sweep uncommitted leftovers into a loudly-labeled commit — work the
   // budget kill stranded mid-edit is still evidence, and a dirty tree must
-  // never leak into the landing layer unreviewed.
+  // never leak into the landing layer unreviewed. The sweep runs BEFORE the
+  // driver's never-ran claim is honored: a classification must never decide
+  // the fate of evidence it has not looked at (#272 — a wall-clock kill the
+  // driver misread as "never ran" returned early here and discarded 30
+  // minutes of stranded work). A genuinely never-ran agent leaves nothing
+  // to sweep, so this is a no-op on that path.
   opts.onPhase?.('sweep');
   const sweepError = git.sweepLeftovers();
   // Drop attempt-introduced runtime artifacts (regenerable scan state the
@@ -247,6 +241,33 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // must not carry `.dxkit/reports/*` into its PR. Disclosed below.
   const scrubbed = git.scrubRuntimeArtifacts(baseHead);
   const hasDiff = git.hasDiff(baseHead);
+
+  if (agentResult.neverRan) {
+    // The tree is the arbiter of "ran": commits past baseHead, or leftovers
+    // the sweep touched, are work — and work means the agent RAN, whatever
+    // the driver's classification concluded (a future CLI can always invent
+    // a new exit encoding; the tree cannot lie). Uncontradicted, the claim
+    // stands; contradicted, the claim is demoted to a disclosed failure and
+    // verification decides the work's fate — the lane's law applied to the
+    // driver's own report.
+    if (!hasDiff && !sweepError) {
+      return finish({
+        outcome: 'agent-never-ran',
+        task: task.id,
+        envelope,
+        floor: entryFloor,
+        ...evidenceTail,
+        note: `agent never ran: ${agentResult.neverRan.reason}`,
+      });
+    }
+    envelope = {
+      ...envelope,
+      failure:
+        `driver classified the run as "agent never ran" (${agentResult.neverRan.reason}), ` +
+        `but the tree carries work from this attempt — the claim is contradicted by ` +
+        `evidence, so verification decides the work's fate`,
+    };
+  }
 
   // Reported spend exceeding the (advisory) cap is an honest post-hoc claim
   // — "the run overran maxUsd" — for any driver that at least REPORTS cost.

--- a/test/remediate/driver.test.ts
+++ b/test/remediate/driver.test.ts
@@ -5,7 +5,11 @@ import {
   type AgentDriver,
   type ModelTier,
 } from '../../src/remediate/driver';
-import { makeClaudeCodeDriver, type AgentExec } from '../../src/remediate/claude-code-driver';
+import {
+  makeClaudeCodeDriver,
+  realAgentExec,
+  type AgentExec,
+} from '../../src/remediate/claude-code-driver';
 import { AGENT_DRIVERS, driverById, knownDriverIds } from '../../src/remediate/registry';
 import { REMEDIATE_TASKS, remediateTaskById, SHARED_RULES } from '../../src/remediate/tasks';
 
@@ -253,5 +257,45 @@ describe('claude-code driver (exec injected)', () => {
     expect(r.neverRan).toBeUndefined();
     expect(r.completed).toBe(false);
     expect(r.turns).toBe(9);
+  });
+});
+
+describe('realAgentExec — deadline-first timeout classification (#272)', () => {
+  // Real child processes, deliberately: the classification lives in the REAL
+  // exec (the injected-exec tests above bypass it by design), and the two
+  // SIGTERM encodings can only be produced by an actual kill.
+
+  it('signal-death: a child killed by the timeout SIGTERM is timedOut', () => {
+    const r = realAgentExec('sleep', ['2'], { cwd: '/tmp', env: {}, timeoutMs: 250 });
+    expect(r.timedOut).toBe(true);
+    expect(r.code).toBeNull();
+  });
+
+  it('graceful-catch: a child that traps SIGTERM and exits 143 is timedOut, never never-ran-shaped', () => {
+    // The claude CLI (2.1.222) traps SIGTERM and exits 143 with no result
+    // JSON — signal null, status 143. The signal-only predicate read this as
+    // a plain failed exit, which fell into the never-ran branch downstream
+    // and discarded the stranded work. The background+wait shape matters:
+    // bash defers traps until the foreground command exits, and the orphaned
+    // sleep must not hold our pipes open.
+    const r = realAgentExec(
+      'bash',
+      ['-c', 'trap "exit 143" TERM; sleep 2 >/dev/null 2>&1 & wait'],
+      { cwd: '/tmp', env: {}, timeoutMs: 250 },
+    );
+    expect(r.timedOut).toBe(true);
+    expect(r.code).toBe(143);
+  });
+
+  it('a natural failure exit before the deadline is NEVER a timeout (false-negative bias)', () => {
+    const r = realAgentExec('bash', ['-c', 'exit 7'], { cwd: '/tmp', env: {}, timeoutMs: 5000 });
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(7);
+  });
+
+  it('a clean exit is a clean exit', () => {
+    const r = realAgentExec('bash', ['-c', 'echo ok'], { cwd: '/tmp', env: {}, timeoutMs: 5000 });
+    expect(r).toMatchObject({ code: 0, timedOut: false });
+    expect(r.stdout).toContain('ok');
   });
 });

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -268,8 +268,13 @@ describe('runner: an errored no-diff run is agent-failed, never a benign no-op',
   });
 
   it('agent-never-ran carries the entry floor too (the ledger names pre-existing debt)', async () => {
+    // diff: false — a genuinely never-ran agent leaves a clean tree; a
+    // never-ran claim over a tree WITH work is the #272 contradiction case
+    // (pinned in run.test.ts) and no longer returns this outcome.
     const r = await runRemediateTask(
-      base(fakeDriver({ completed: false, neverRan: { reason: 'Credit balance is too low' } })),
+      base(fakeDriver({ completed: false, neverRan: { reason: 'Credit balance is too low' } }), {
+        git: fakeGit({ diff: false }),
+      }),
     );
     expect(r.outcome).toBe('agent-never-ran');
     expect(r.note).toContain('agent never ran: Credit balance is too low');

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -151,9 +151,55 @@ describe('refusal + infra arms (each truthful and distinct)', () => {
       completed: false,
       neverRan: { reason: 'claude exit 1: bad auth' },
     });
-    const r = await runRemediateTask(base(driver));
+    // A genuinely never-ran agent leaves a clean tree — the claim stands.
+    const r = await runRemediateTask(base(driver, { git: fakeGit({ diff: false }) }));
     expect(r.outcome).toBe('agent-never-ran');
     expect(r.note).toContain('bad auth');
+  });
+
+  it('the sweep runs BEFORE a never-ran claim is honored (#272: evidence first)', async () => {
+    let swept = false;
+    const git: RemediateGit = {
+      head: () => 'base0000',
+      sweepLeftovers: () => {
+        swept = true;
+        return undefined;
+      },
+      scrubRuntimeArtifacts: () => [],
+      hasDiff: () => false,
+    };
+    const driver = fakeDriver({ completed: false, neverRan: { reason: 'exit 143' } });
+    const r = await runRemediateTask(base(driver, { git }));
+    expect(r.outcome).toBe('agent-never-ran');
+    expect(swept).toBe(true);
+  });
+
+  it('a never-ran claim CONTRADICTED by committed work is demoted — verification decides (#272)', async () => {
+    // The live class: a wall-clock-killed run the driver misread as "never
+    // ran" returned early and discarded 30 minutes of committed work. The
+    // tree is the arbiter: work means the agent ran, whatever the driver's
+    // exit-encoding taxonomy concluded. The claim demotes to a disclosed
+    // failure and the verified frame decides the work's fate.
+    const driver = fakeDriver({
+      completed: false,
+      neverRan: { reason: 'claude exit 143: (no stderr)' },
+    });
+    const r = await runRemediateTask(base(driver, { git: fakeGit({ diff: true }) }));
+    expect(r.outcome).not.toBe('agent-never-ran');
+    expect(r.outcome).toBe('verified'); // green floor + PASSED guardrail in `base`
+    expect(r.envelope?.failure).toContain('contradicted');
+    expect(r.ledger).toBeTruthy();
+  });
+
+  it('a never-ran claim with UNCOMMITTABLE leftovers is also contradicted — nothing is discarded silently', async () => {
+    const driver = fakeDriver({ completed: false, neverRan: { reason: 'exit 143' } });
+    const r = await runRemediateTask(
+      base(driver, { git: fakeGit({ diff: false, sweepError: 'index locked' }) }),
+    );
+    // The sweep-failed arm (agent left uncommitted work it could not commit)
+    // reports the evidence rather than the driver's claim.
+    expect(r.note).toContain('uncommitted work');
+    expect(r.envelope?.failure).toContain('contradicted');
   });
 });
 


### PR DESCRIPTION
One of four 4.3.7.1 deliver-layer fixes (umbrella: #270).

**Defect (#272)**: `realAgentExec` detected timeout only via signal-death (`signal === 'SIGTERM' && no exit status`). claude CLI 2.1.222 catches SIGTERM and exits **143** gracefully with no result JSON → `timedOut: false` → the never-ran branch (`code !== 0 && !turns`) → and the runner's never-ran short-circuit returned **before** `sweepLeftovers`, so the stranded 30-minute run's work was discarded and salvage never engaged. Observed live: fix-lint attempt 2, the reason line blamed an unrelated workspace-trust stderr notice.

**Fix, at the root**:
1. **Deadline-first classification in the exec**: it measures its own elapsed time; a kill-shaped death (SIGTERM in either encoding — signal-death or exit 143 — or a signal-with-no-status) at/past the deadline is `timedOut`. A natural failure exit before the deadline is never reclassified (false-negative bias). With `timedOut: true` the existing sweep → scrub → salvage machinery engages as designed.
2. **Evidence over classification in the runner** (future-proof half): the sweep now runs **before** the never-ran claim is honored. A claim contradicted by committed work or uncommittable leftovers demotes to a disclosed failure and the verified frame decides the work's fate — a future CLI can invent a new exit encoding; the tree cannot lie. A genuine never-ran (clean tree) is unchanged.

**Tests**: real-process exec tests for both SIGTERM encodings + false-negative bias + clean exit; runner pins for sweep-before-classification, both contradiction shapes, and the untouched genuine never-ran arm. One existing fixture corrected (a never-ran claim over a diff-carrying tree is now, by design, the contradiction case).

Gates run locally: full suite (5,433), typecheck:test, lint, format, architecture, slop, self-guardrail ref-based vs origin/main (PASSED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)