### PR TITLE
fix(remediate): ground-rules ban on .github/ writes

### DIFF
--- a/src/remediate/tasks.ts
+++ b/src/remediate/tasks.ts
@@ -103,6 +103,12 @@ export const SHARED_RULES = `
 Ground rules (non-negotiable):
 - Work ONLY on this task. Do not fix unrelated debt, do not refactor beyond
   what the task needs, do not touch CI/workflow files.
+- Never create or edit ANYTHING under the .github/ directory — not
+  workflows, not issue/PR templates, not configs. Repository rules and
+  token permissions commonly refuse bot pushes touching those paths, and a
+  refused push means NONE of your work lands. If the task seems to need a
+  .github/ change, write the proposal in
+  docs/DXKIT-REMEDIATION-NOTES.md instead.
 - NEVER run \`vyuh-dxkit baseline create\` or edit \`.dxkit/baselines/\` — the
   gate must attribute your work honestly, and refreshing the baseline to
   clear a block is forbidden.

--- a/test/remediate/driver.test.ts
+++ b/test/remediate/driver.test.ts
@@ -11,7 +11,12 @@ import {
   type AgentExec,
 } from '../../src/remediate/claude-code-driver';
 import { AGENT_DRIVERS, driverById, knownDriverIds } from '../../src/remediate/registry';
-import { REMEDIATE_TASKS, remediateTaskById, SHARED_RULES } from '../../src/remediate/tasks';
+import {
+  customDispatchTask,
+  REMEDIATE_TASKS,
+  remediateTaskById,
+  SHARED_RULES,
+} from '../../src/remediate/tasks';
 
 /**
  * The driver seam is the "other agents later" promise: these tests pin the
@@ -129,6 +134,22 @@ describe('task registry', () => {
     expect(SHARED_RULES).toContain('docs/DXKIT-REMEDIATION-NOTES.md');
     expect(remediateTaskById('fix-lint')?.tier).toBe('light');
     expect(remediateTaskById('unknown-task')).toBeUndefined();
+  });
+
+  it('every prompt bans .github/ writes — registry tasks AND the custom dispatch task', () => {
+    // Validated live twice, in both directions: a write-docs agent wrote
+    // .github/ templates and the landing push was refused by a path ruleset
+    // (all work lost pre-#273); a custom run with an in-prompt ban complied
+    // fully and verified end-to-end. Prompt-level constraint is the
+    // mitigation with an evidence base — the learned restricted-paths layer
+    // is the 4.3.8 root treatment.
+    for (const t of REMEDIATE_TASKS) {
+      expect(t.prompt).toContain('.github/');
+      expect(t.prompt).toContain('Never create or edit ANYTHING under');
+    }
+    expect(customDispatchTask('write some docs').prompt).toContain(
+      'Never create or edit ANYTHING under',
+    );
   });
 });
 


### PR DESCRIPTION
Canary-hardening slice for 4.3.8 (follows #275/#276/#277/#278; umbrella #270).

**Why**: validated live in both directions — the write-docs agent wrote `.github/` templates and the landing push was refused by a path ruleset (all work lost, pre-#273); the custom docs run with an in-prompt ban complied fully and verified end-to-end. `SHARED_RULES` already said "do not touch CI/workflow files", but issue/PR templates and configs under `.github/` don't read as CI files to an agent. The ban is now explicit in every task prompt (registry tasks and the custom dispatch task — pinned by test), with the write-the-proposal-in-notes escape hatch.

This is the prompt-level slice with a live evidence base; the learned restricted-paths + sweep-scrub root treatment stays 4.3.8 scope (#270).

Gates run locally: full suite (5,444), typecheck:test, lint, format, architecture, slop, self-guardrail ref-based vs origin/main (PASSED, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)