### PR TITLE
release: 4.3.8 — the deliver-layer hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,86 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.8] - 2026-08-08
+
+The deliver-layer hotfix. Four live remediation-lane runs surfaced four
+defects, and in every one the agent's work was verified sound — the frame
+around it then lost, discarded, or misattributed that work. Each fix lands
+at the root of its class with the regression pinned by tests: the layer
+that classifies, attributes, lands, and salvages an agent run now holds
+itself to the same honesty contract the run itself is held to.
+
+### Fixed
+
+- **A finding on a modified line no longer misattributes as net-new
+  (#271).** A modified line is a -/+ replacement hunk with no line-map
+  image, so a located finding sitting on one split into removed + added —
+  and the added side blocked as a "new" finding the developer never
+  introduced. Any bulk formatter or codemod tripped this (observed: a
+  lint fix that resolved thousands of findings, blocked on rows that had
+  merely been restyled). The git-aware matcher gains a modified-hunk
+  endpoint pass: an unmatched prior finding inside a replacement hunk's
+  old span pairs with an unmatched current finding of the same rule
+  inside the same hunk's new span, and only when that pairing is
+  unambiguous — exactly one candidate on each side. Ambiguity stays
+  split, pure deletions and additions never pair, and the new
+  `git-hunk-pair` reason carries confidence below the line-survived tier,
+  so the pairing can soften a verdict but never hide a genuinely new
+  finding.
+- **A wall-clock kill is classified by the deadline, not the exit
+  encoding (#272).** The agent CLI traps the timeout SIGTERM and exits
+  143 gracefully, which read as a plain failed exit, fell into the
+  "agent never ran" branch, and returned before the leftover sweep — a
+  30-minute run's stranded work discarded, salvage never engaged, and the
+  reason line blaming an unrelated stderr warning. The exec now measures
+  its own elapsed time and classifies a kill-shaped death at or past the
+  deadline as a timeout, whatever the encoding; a natural failure exit
+  before the deadline is never reclassified. And one layer out, the
+  runner no longer honors a never-ran claim before looking at the tree:
+  the sweep runs first, and a claim contradicted by committed work or
+  uncommittable leftovers demotes to a disclosed failure — verification
+  decides the work's fate, because a future CLI can always invent a new
+  exit encoding, and the tree cannot lie.
+- **A refused landing push is a disclosed outcome, and evidence precedes
+  delivery (#273).** A push refused by repository rules or token
+  permissions crashed the frame after verification: no attempt record,
+  no ledger rendered, an empty evidence artifact. The attempt record —
+  with the commit range the patch-artifact fallback reads — is now
+  written before the push and flipped on success, and a landing failure
+  becomes a `landingBlocked` outcome carrying git's own words, with the
+  remedy named when the refusal is rules-shaped (grant the token the
+  permission, add a ruleset bypass, or keep the task away from the
+  restricted paths). The ledger, record, and step summary render as
+  usual: a refused push loses the delivery, never the evidence.
+- **A custom dispatch task honors the salvage policy (#274).** The
+  executor re-derived task facts from a registry lookup that is
+  deliberately empty for `custom`, so salvage hard-fell to `discard` —
+  overriding both an explicit `draft-pr` policy and `auto` — and a
+  verified, guardrail-passed docs run was thrown away. Both derivations
+  now route the raw id through the one resolvers, which already handle
+  `custom` (open-ended, so `auto` salvages as a draft PR). Resume for
+  custom is now a deliberate, disclosed unavailability (a later dispatch
+  may carry a different prompt than the salvaged attempt), never a
+  silent guard.
+
+- **Every agent prompt now explicitly bans `.github/` writes.** The
+  ground rules said "do not touch CI/workflow files", but issue and PR
+  templates under `.github/` do not read as CI files to an agent — one
+  wrote them, and the refused push cost the whole run. The ban is now
+  explicit in every task prompt, including the custom dispatch task, with
+  a write-the-proposal-in-notes escape hatch. Prompt-level constraints of
+  this shape were validated live: the one run that carried the ban
+  complied fully and verified end-to-end.
+
+### Internal
+
+- The remediate executor is split out of the CLI module and gains
+  injection seams plus executor-level tests — this wiring layer between
+  the runner and the lander is where two of the four defects sat with
+  zero coverage. The salvage-threading, pre-push-record, and
+  landing-refusal behaviors are each pinned at exactly the layer that
+  shipped them.
+
 ## [4.3.7] - 2026-08-06
 
 The honesty release: one class of defect, fixed across every surface it

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.3.7",
+      "version": "4.3.8",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, a deterministic stop-gate that blocks net-new detector-backed regressions, and autonomous remediation lanes whose work lands only through that same gate. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src/baseline/git-aware-match.ts
+++ b/src/baseline/git-aware-match.ts
@@ -66,6 +66,14 @@ const LINE_FUZZ_RANGE = 2;
  *  a content-hash pair demotes to `'uncertain'`; for critical
  *  findings (threshold 0.75), it passes through cleanly. */
 const CONFIDENCE_CONTENT_HASH = 0.8;
+/** Confidence assigned to a modified-hunk endpoint pair (#271): the
+ *  line itself changed, so there is no line-map image and no byte
+ *  identity — the evidence is the hunk STRUCTURE plus an unambiguous
+ *  same-rule 1:1 within it. Below git-line-fuzz (the line survived
+ *  there; here it was rewritten), so low-severity pairs demote to
+ *  `'uncertain'` under the default thresholds while the pairing still
+ *  prevents the false net-new BLOCK that split pairs produced. */
+const CONFIDENCE_HUNK_PAIR = 0.85;
 
 /**
  * Per-finding identity plus the locator info needed to query git.
@@ -135,24 +143,8 @@ export function mapLineThroughDiff(opts: {
   if (!oldFile || !newFile) {
     throw new Error('mapLineThroughDiff requires `file` or both `oldFile` + `newFile`');
   }
-  let diff: string;
-  try {
-    diff = execFileSync(
-      'git',
-      [
-        'diff',
-        '--unified=0',
-        '--no-color',
-        '--find-renames',
-        opts.baseSha,
-        opts.headSha,
-        '--',
-        oldFile,
-        ...(newFile !== oldFile ? [newFile] : []),
-      ],
-      { cwd: opts.cwd, encoding: 'utf8' },
-    );
-  } catch {
+  const diff = fetchFileDiff(opts.cwd, opts.baseSha, opts.headSha, oldFile, newFile);
+  if (diff === null) {
     // File missing in one revision, git not available, sha unreachable — any
     // of these defeats the mapping. Caller treats null as "unmatched."
     return null;
@@ -162,6 +154,60 @@ export function mapLineThroughDiff(opts: {
     return opts.baseLine;
   }
   return walkHunks(diff, opts.baseLine);
+}
+
+/** The ONE per-file diff fetch both the line mapper and the hunk-pair pass
+ *  read (`--unified=0`, rename-aware). Null when git cannot produce it. */
+function fetchFileDiff(
+  cwd: string,
+  baseSha: string,
+  headSha: string,
+  oldFile: string,
+  newFile: string,
+): string | null {
+  try {
+    return execFileSync(
+      'git',
+      [
+        'diff',
+        '--unified=0',
+        '--no-color',
+        '--find-renames',
+        baseSha,
+        headSha,
+        '--',
+        oldFile,
+        ...(newFile !== oldFile ? [newFile] : []),
+      ],
+      { cwd, encoding: 'utf8' },
+    );
+  } catch {
+    return null;
+  }
+}
+
+interface HunkSpan {
+  readonly oldStart: number;
+  readonly oldCount: number;
+  readonly newStart: number;
+  readonly newCount: number;
+}
+
+/** All `@@ -A,B +C,D @@` spans of a `--unified=0` diff, in order. Pure
+ *  function over the diff text (the same header grammar `walkHunks` walks). */
+function parseHunkSpans(diff: string): HunkSpan[] {
+  const hunkRe = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/gm;
+  const spans: HunkSpan[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = hunkRe.exec(diff)) !== null) {
+    spans.push({
+      oldStart: parseInt(match[1], 10),
+      oldCount: match[2] !== undefined ? parseInt(match[2], 10) : 1,
+      newStart: parseInt(match[3], 10),
+      newCount: match[4] !== undefined ? parseInt(match[4], 10) : 1,
+    });
+  }
+  return spans;
 }
 
 /**
@@ -222,6 +268,13 @@ function walkHunks(diff: string, baseLine: number): number | null {
  *      policy's per-severity thresholds naturally tune whether to
  *      trust this layer.
  *
+ *   1.75. Modified-hunk endpoint pairing (#271): a prior finding ON a
+ *      line the diff modified (a -/+ replacement hunk — no line-map
+ *      image, no surviving context bytes) pairs with a current finding
+ *      of the same rule inside the same hunk's new span, conservative
+ *      1:1 (an ambiguous bucket stays split). Confidence 0.85 — below
+ *      git-line-fuzz: the line was rewritten, not moved.
+ *
  *   2. Multiset exact-identity diff over whatever remains. Catches:
  *        - findings without a file-line locator (dep-vuln, license,
  *          symbol-based coverage-gap, duplication)
@@ -249,10 +302,12 @@ export function gitAwareMatch(
   const pairs: MatchPair[] = [];
   const priorMatched = new Set<LocatedIdentity>();
   const currentMatched = new Set<LocatedIdentity>();
+  // Shared by Pass 1, 1b, and the hunk-pair pass below.
+  const renames = reachability.ok
+    ? readRenameMap(opts.cwd, opts.baseSha, headSha)
+    : new Map<string, string>();
 
   if (reachability.ok) {
-    const renames = readRenameMap(opts.cwd, opts.baseSha, headSha);
-
     // Index current findings by (file, rule, line). One key holds at
     // most one entry — the multiset diff in pass 2 picks up any
     // collisions left after location pairing.
@@ -437,6 +492,109 @@ export function gitAwareMatch(
           },
         ],
       });
+    }
+  }
+
+  // Pass 1.75 — modified-hunk endpoint pairing (#271). A located finding ON
+  // a line the diff MODIFIED cannot relocate through the line map: a
+  // modified line is a -/+ hunk pair with no image, so Pass 1 maps it to
+  // null and the finding splits into removed + added — and the added side
+  // false-blocks as net-new (Rule 19 cause #4, "the finding MOVED", read as
+  // cause #1, "the developer introduced it"). Bites any bulk formatter or
+  // codemod. Content hashes don't reach it either: the surrounding bytes
+  // changed by definition. Here the two endpoints re-pair through the hunk
+  // STRUCTURE: an unmatched prior finding inside a hunk's replaced span
+  // pairs with an unmatched current finding of the SAME rule inside the
+  // SAME hunk's new span — and ONLY when the pairing is unambiguous
+  // (exactly one candidate on each side of that hunk+rule bucket). An
+  // ambiguous or unmatched candidate stays split: bias hard toward false
+  // NEGATIVE on the pairing, never invent a match. Pure deletions
+  // (newCount 0) never pair — there is nothing on the other side.
+  if (reachability.ok) {
+    const priorsByFile = new Map<string, LocatedIdentity[]>();
+    for (const p of prior) {
+      if (priorMatched.has(p)) continue;
+      if (!p.file || p.line === undefined || !p.rule) continue;
+      const bucket = priorsByFile.get(p.file);
+      if (bucket) bucket.push(p);
+      else priorsByFile.set(p.file, [p]);
+    }
+    const currentsByFile = new Map<string, LocatedIdentity[]>();
+    for (const c of current) {
+      if (currentMatched.has(c)) continue;
+      if (!c.file || c.line === undefined || !c.rule) continue;
+      const bucket = currentsByFile.get(c.file);
+      if (bucket) bucket.push(c);
+      else currentsByFile.set(c.file, [c]);
+    }
+    for (const [file, priors] of priorsByFile) {
+      const effectivePath = renames.get(file) ?? file;
+      const pathChanged = effectivePath !== file;
+      const currents = currentsByFile.get(effectivePath);
+      if (!currents || currents.length === 0) continue;
+      const diff = fetchFileDiff(opts.cwd, opts.baseSha, headSha, file, effectivePath);
+      if (!diff || !diff.trim()) continue;
+      // Replacement hunks only: a -/+ pair with both sides non-empty.
+      const hunks = parseHunkSpans(diff).filter((h) => h.oldCount > 0 && h.newCount > 0);
+      if (hunks.length === 0) continue;
+
+      const bucketKey = (hunkIdx: number, rule: string): string => `${hunkIdx}\0${rule}`;
+      const priorBuckets = new Map<string, LocatedIdentity[]>();
+      for (const p of priors) {
+        const idx = hunks.findIndex(
+          (h) => p.line! >= h.oldStart && p.line! <= h.oldStart + h.oldCount - 1,
+        );
+        if (idx === -1) continue;
+        const key = bucketKey(idx, p.rule!);
+        const bucket = priorBuckets.get(key);
+        if (bucket) bucket.push(p);
+        else priorBuckets.set(key, [p]);
+      }
+      if (priorBuckets.size === 0) continue;
+      const currentBuckets = new Map<string, LocatedIdentity[]>();
+      for (const c of currents) {
+        const idx = hunks.findIndex(
+          (h) => c.line! >= h.newStart && c.line! <= h.newStart + h.newCount - 1,
+        );
+        if (idx === -1) continue;
+        const key = bucketKey(idx, c.rule!);
+        const bucket = currentBuckets.get(key);
+        if (bucket) bucket.push(c);
+        else currentBuckets.set(key, [c]);
+      }
+
+      for (const [key, ps] of priorBuckets) {
+        const cs = currentBuckets.get(key);
+        // The conservative 1:1: a singleton on BOTH sides, or no pair.
+        if (!cs || ps.length !== 1 || cs.length !== 1) continue;
+        const p = ps[0];
+        const c = cs[0];
+        priorMatched.add(p);
+        currentMatched.add(c);
+        const reasons: MatchReason[] = [
+          {
+            code: 'git-hunk-pair',
+            detail:
+              `finding sits on a MODIFIED line: git pairs ${p.file}:${p.line} with ` +
+              `${c.file}:${c.line} through the same replacement hunk (same rule, ` +
+              `unambiguous 1:1) — a modified line has no line-map image, so without ` +
+              `this pass the pair reads as removed+added`,
+          },
+        ];
+        if (pathChanged) {
+          reasons.unshift({
+            code: 'git-rename',
+            detail: `file renamed: ${file} → ${effectivePath}`,
+          });
+        }
+        pairs.push({
+          priorId: p.id,
+          currentId: c.id,
+          status: pathChanged ? 'relocated' : 'persisted',
+          confidence: CONFIDENCE_HUNK_PAIR,
+          reasons,
+        });
+      }
     }
   }
 

--- a/src/remediate/claude-code-driver.ts
+++ b/src/remediate/claude-code-driver.ts
@@ -49,6 +49,22 @@ const MAX_CAPTURE = 16 * 1024 * 1024;
  * Real spawn. A timeout kill surfaces as `timedOut`, distinct from a
  * non-zero exit; captured output rides the error object either way.
  *
+ * Timeout classification is DEADLINE-FIRST, not signal-encoding-first
+ * (#272): the deadline is this exec's own fact, so it measures elapsed
+ * time itself and classifies a kill-shaped death at/past the deadline as
+ * `timedOut` — corroborated by any of the encodings a SIGTERM produces:
+ *
+ *   - signal-death: the child died to the signal (`signal: 'SIGTERM'`,
+ *     no exit status) — the only encoding the original predicate knew;
+ *   - graceful-catch: the child traps SIGTERM and exits 128+15=143
+ *     (observed on claude CLI 2.1.222) — `status: 143`, `signal: null`,
+ *     and no result JSON, which made the run read as "agent never ran"
+ *     and discard 30 minutes of stranded work before the sweep.
+ *
+ * A natural non-zero exit before the deadline is never a timeout, and a
+ * real failure exit (e.g. 1) is never reclassified even when the race
+ * lands it past the deadline — biased toward false NEGATIVE.
+ *
  * DECLARED EXCEPTION to the bounded-exec seam (Rule 2 discipline: an
  * exception is stated, never silent): `makeCommandExec` merges stdout and
  * stderr into one stream, but this driver's never-ran taxonomy REQUIRES
@@ -58,6 +74,7 @@ const MAX_CAPTURE = 16 * 1024 * 1024;
  * agent spawn keeps its own exec with the same timeout-kill semantics.
  */
 export const realAgentExec: AgentExec = (bin, args, opts) => {
+  const startedAt = Date.now();
   try {
     const stdout = execFileSync(bin, args as string[], {
       cwd: opts.cwd,
@@ -75,11 +92,17 @@ export const realAgentExec: AgentExec = (bin, args, opts) => {
       stdout?: string;
       stderr?: string;
     };
+    const status = typeof e.status === 'number' ? e.status : null;
+    const signalDeath = e.signal === 'SIGTERM' && status === null;
+    // Kill-shaped: died to a signal (no status), or exited with the
+    // SIGTERM convention code. A plain failure exit is not kill-shaped.
+    const killShaped = signalDeath || e.signal === 'SIGTERM' || status === 143 || status === null;
+    const pastDeadline = Date.now() - startedAt >= opts.timeoutMs;
     return {
-      code: typeof e.status === 'number' ? e.status : null,
+      code: status,
       stdout: e.stdout ?? '',
       stderr: e.stderr ?? String(e.message ?? ''),
-      timedOut: e.signal === 'SIGTERM' && typeof e.status !== 'number',
+      timedOut: signalDeath || (pastDeadline && killShaped),
     };
   }
 };

--- a/src/remediate/cli.ts
+++ b/src/remediate/cli.ts
@@ -22,267 +22,23 @@
  * The local CLI is the trusted boundary (bump-lane doctrine).
  */
 import * as fs from 'fs';
-import * as path from 'path';
-import { execFileSync } from 'child_process';
 import * as logger from '../logger';
-import { trustedLocalContext } from '../analysis-trust';
-import { detectDefaultBranch } from '../ship-installers';
-import { startPhaseReporter } from '../lanes/heartbeat';
-import { runCorrectnessFloor, type CorrectnessFloorResult } from '../analyzers/correctness/run';
-import { detectActiveLanguages } from '../languages';
-import { prepareResume, type ResumeDecision } from './resume';
-import {
-  budgetForTask,
-  resolveRemediateConfig,
-  salvageForTask,
-  tasksWithinSpendCeiling,
-  type RemediateConfig,
-} from './config';
-import { readDispatchOverrides } from './dispatch';
-import { driverById } from './registry';
-import { REMEDIATE_TASKS, remediateTaskById } from './tasks';
-import { runRemediateTask, type RemediateResult } from './run';
-import { landRemediateHead, remediateBranchFor } from './land';
-import { appendLaneEvent, LANE_LEDGER_SCHEMA_VERSION } from '../lanes/ledger';
+import { resolveRemediateConfig, tasksWithinSpendCeiling } from './config';
+import { REMEDIATE_TASKS } from './tasks';
 
-// `remediate plan` lives in `./plan-cli` and the configured sequencing loop
-// in `./configured-loop` (module-size splits); re-exported so consumers keep
-// one import surface.
+// The executor (run one task + land it) lives in `./execute`, `remediate
+// plan` in `./plan-cli`, and the configured sequencing loop in
+// `./configured-loop` (module-size splits); all re-exported so consumers
+// keep one import surface.
 export { runRemediatePlan, type RemediatePlanOptions } from './plan-cli';
 export {
   runConfiguredLoop,
   type ConfiguredLoopOps,
   type ConfiguredLoopResult,
 } from './configured-loop';
+export { executeTask, taskRunJson, type ExecutorSeams, type TaskRun } from './execute';
 import { headCommit, resetHardTo, runConfiguredLoop } from './configured-loop';
-
-export interface TaskRun {
-  readonly result: RemediateResult;
-  readonly prUrl?: string;
-  /** Why a land-eligible outcome was NOT landed (the branch guard). */
-  readonly landRefused?: string;
-  /** The landing ran (branch pushed, PR opened/updated). */
-  readonly landed: boolean;
-  /** Truthful per-task success: verified/no-op, or a landed salvage draft. */
-  readonly clean: boolean;
-}
-
-/** Current branch name, or 'HEAD' for a detached (CI) checkout. */
-function currentBranch(cwd: string): string {
-  try {
-    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
-  } catch {
-    return 'HEAD';
-  }
-}
-
-/** Run one task through the runner and (optionally) land it — the ONE
- *  executor `--task` and `configured` both use. */
-async function executeTask(
-  cwd: string,
-  config: RemediateConfig,
-  taskId: string,
-  land: 'pr' | 'none',
-): Promise<TaskRun> {
-  // Per-task budget: the override-merged budget rides a task-scoped config
-  // copy, so the runner's enforcement + ledger see the effective caps.
-  // Dispatch-campaign overrides (env-transported, clamped) layer on top —
-  // the runner receives the disclosure and folds it into the ledger.
-  // Both derivations take the RAW id string — never `task ? … : fallback`.
-  // 'custom' is deliberately outside the registry, so a registry-lookup
-  // guard here is a second, weaker derivation of the same concept the
-  // resolvers already own (the #274 class: it forced salvage to 'discard'
-  // on a verified custom run, overriding explicit policy).
-  const policyBudget = budgetForTask(config, taskId);
-  const dispatch = readDispatchOverrides(process.env, policyBudget, config);
-  // The concrete salvage decision for THIS task (the one resolver: explicit
-  // policy wins, 'auto' follows the task's completion shape) — threaded into
-  // the runner's config so the ledger note and the landing below agree.
-  const salvage = salvageForTask(config, taskId);
-  const taskConfig: RemediateConfig = {
-    ...config,
-    salvage,
-    agent: {
-      ...config.agent,
-      budget: dispatch.any ? dispatch.budget : policyBudget,
-      ...(dispatch.model !== undefined ? { model: dispatch.model } : {}),
-    },
-  };
-  // Resume-from-salvage (opt-in, remediate.resume): the entry floor is
-  // captured FIRST on the pristine tree, THEN the salvage branch is checked
-  // out — attribution stays anchored to the original base, so a broken
-  // partial reads NET-NEW and can never grandfather its own breakage.
-  let entryFloor: CorrectnessFloorResult | undefined;
-  let resume: ResumeDecision = { resumed: false };
-  if (land === 'pr' && config.resume && taskId === 'custom') {
-    // DELIBERATE, not a registry-lookup accident: a custom dispatch carries a
-    // human-supplied prompt, and a later dispatch may carry a DIFFERENT one —
-    // resuming would continue a prior attempt's goal under this run's prompt
-    // and ledger. Disclosed here, never a silent guard (#274's second half).
-    logger.warn(
-      'resume: unavailable for custom dispatch tasks — a later dispatch may carry a ' +
-        'different prompt than the salvaged attempt; starting fresh.',
-    );
-  }
-  if (land === 'pr' && config.resume && taskId !== 'custom' && remediateTaskById(taskId)) {
-    // (salvage above is the task-resolved decision — resume needs draft-pr)
-    entryFloor = runCorrectnessFloor({
-      cwd,
-      changedFiles: [],
-      scope: 'full',
-      packs: detectActiveLanguages(cwd),
-    });
-    resume = prepareResume(cwd, taskId, { resume: config.resume, salvage });
-    if (resume.note) logger.warn(`resume: ${resume.note}`);
-    if (resume.resumed) {
-      logger.info(`resuming budget-bounded attempt #${resume.attempt} from the salvage branch`);
-    }
-  }
-  const reporter = startPhaseReporter(`remediate:${taskId}`);
-  let result: RemediateResult;
-  try {
-    result = await runRemediateTask({
-      cwd,
-      trust: trustedLocalContext(),
-      taskId,
-      config: taskConfig,
-      // CI injects the driver's credential env explicitly; locally the driver's
-      // own default applies (claude-code: subscription mode).
-      agentEnv: collectCredentialEnv(config.agent.driver),
-      onPhase: (phase) => reporter.phase(phase),
-      dispatch,
-      ...(entryFloor !== undefined ? { entryFloor } : {}),
-      ...(resume.resumed && resume.attempt !== undefined
-        ? {
-            resume: {
-              attempt: resume.attempt,
-              ...(resume.blockingContext ? { blockingContext: resume.blockingContext } : {}),
-            },
-          }
-        : {}),
-    });
-  } finally {
-    reporter.stop();
-  }
-
-  const draftSalvage = result.outcome === 'budget-exhausted' && salvage === 'draft-pr';
-  // Guardrail-red under draft-pr salvage: the BLOCKED attempt is pushed as a
-  // RED draft — its own required guardrail check keeps it unmergeable, so
-  // "nothing merges" holds while the work + blocking findings survive the
-  // ephemeral runner and the next run can RESUME from them (guardrail-red
-  // was the outcome where the most valuable partial work died). Only a
-  // RAN-and-blocked verdict qualifies; an unrunnable guardrail never pushes.
-  const blockedSalvage = result.outcome === 'guardrail-red' && salvage === 'draft-pr';
-  const landEligible = result.outcome === 'verified' || draftSalvage || blockedSalvage;
-  if (land !== 'pr' || !landEligible) {
-    return finalizeTaskRun(cwd, taskId, {
-      result,
-      landed: false,
-      clean: result.outcome === 'verified' || result.outcome === 'no-op',
-    });
-  }
-
-  // Landing guard (the standing branch is built from HEAD): a named
-  // non-default branch would push unrelated commits into the standing PR.
-  const defaultBranch = detectDefaultBranch(cwd);
-  const branch = currentBranch(cwd);
-  if (branch !== 'HEAD' && branch !== defaultBranch) {
-    return finalizeTaskRun(cwd, taskId, {
-      result,
-      landed: false,
-      clean: false,
-      landRefused:
-        `not landed: HEAD is on '${branch}', not '${defaultBranch}' — landing pushes HEAD ` +
-        `to the standing branch, so run from '${defaultBranch}' (or let the scheduled ` +
-        `workflow land it).`,
-    });
-  }
-
-  // The delivery-ledger event rides the PR's own diff (committed by the
-  // lander, pushed with the work) — delivered means MERGED, never "PR opened".
-  const ledgerPath = appendLaneEvent(cwd, {
-    schema_version: LANE_LEDGER_SCHEMA_VERSION,
-    timestamp: new Date().toISOString(),
-    lane: 'remediate',
-    task: taskId,
-    outcome: 'landed',
-    ...(draftSalvage || blockedSalvage ? { partial: true } : {}),
-    ...(blockedSalvage ? { blocked: true } : {}),
-    ...(result.envelope?.costUsd !== undefined ? { costUsd: result.envelope.costUsd } : {}),
-    ...(result.envelope?.resolvedModelId
-      ? { resolvedModelId: result.envelope.resolvedModelId }
-      : {}),
-    ...(result.envelope ? { driver: result.envelope.driver } : {}),
-  });
-  const landResult = landRemediateHead({
-    cwd,
-    taskId,
-    defaultBranch,
-    prTitle:
-      `dxkit remediate: ${taskId}` +
-      (blockedSalvage
-        ? ' (blocked: guardrail-red — do not merge)'
-        : draftSalvage
-          ? ' (partial, budget-bounded)'
-          : ''),
-    prBody: result.ledger,
-    draft: draftSalvage || blockedSalvage,
-    ledgerPath,
-  });
-  return finalizeTaskRun(cwd, taskId, {
-    result,
-    ...(landResult.prUrl ? { prUrl: landResult.prUrl } : {}),
-    landed: true,
-    // A blocked salvage is NOT clean: the draft exists for inspection and
-    // resume, but the task did not end well — the job stays red.
-    clean: result.outcome === 'verified' || draftSalvage,
-  });
-}
-
-/**
- * Every executeTask exit funnels through here: write the machine-readable
- * attempt record (the workflow's artifact step reads it to upload the diff
- * of a blocked/failed attempt — evidence must survive the ephemeral runner)
- * and, under Actions, annotate a not-landed attempt so it is visible from
- * the run page without opening logs.
- */
-function finalizeTaskRun(cwd: string, taskId: string, run: TaskRun): TaskRun {
-  try {
-    const dir = path.join(cwd, '.dxkit', 'cache');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, `remediate-${taskId}.json`),
-      JSON.stringify(taskRunJson(run), null, 2) + '\n',
-      'utf8',
-    );
-  } catch {
-    // the record is evidence plumbing, never a failure
-  }
-  if (!run.clean) {
-    // A non-clean outcome must be diagnosable from the run page: the agent
-    // phase group otherwise closes with ZERO output (the driver captures the
-    // CLI's streams), so the failure's own evidence — the driver-reported
-    // cause and the transcript tail — surfaces in the LOG here. Log only,
-    // never the ledger/PR body.
-    if (run.result.envelope?.failure) {
-      logger.warn(`driver-reported failure: ${run.result.envelope.failure}`);
-    }
-    if (run.result.transcriptTail) {
-      logger.warn(`agent transcript (last lines):\n${run.result.transcriptTail}`);
-    }
-  }
-  if (process.env.GITHUB_ACTIONS === 'true' && !run.clean) {
-    const first = (run.result.note ?? run.result.outcome).split('\n')[0];
-    process.stdout.write(
-      `::warning title=remediate ${taskId} did not land::${run.result.outcome}: ${first}\n`,
-    );
-  }
-  return run;
-}
+import { executeTask, taskRunJson, type TaskRun } from './execute';
 
 /** Append a ledger to the GitHub Actions step summary when running in CI. */
 function appendStepSummary(ledger: string): void {
@@ -300,32 +56,10 @@ function reportTaskRun(run: TaskRun, json: boolean): void {
   logger.info(`outcome: ${run.result.outcome}`);
   if (run.result.note) logger.info(run.result.note);
   if (run.landRefused) logger.warn(run.landRefused);
+  if (run.landingBlocked) logger.warn(run.landingBlocked);
   if (run.prUrl) logger.success(`standing PR: ${run.prUrl}`);
   console.log(''); // slop-ok
   process.stdout.write(run.result.ledger + '\n');
-}
-
-function taskRunJson(run: TaskRun): Record<string, unknown> {
-  const r = run.result;
-  return {
-    outcome: r.outcome,
-    task: r.task ?? null,
-    note: r.note ?? null,
-    partial: r.partial ?? false,
-    envelope: r.envelope ?? null,
-    guardrailVerdict: r.guardrailVerdict ?? null,
-    branch: r.task ? remediateBranchFor(r.task) : null,
-    prUrl: run.prUrl ?? null,
-    landRefused: run.landRefused ?? null,
-    landed: run.landed,
-    // The commit range of the attempt — what the workflow's evidence step
-    // format-patches into a run artifact when nothing landed.
-    baseHead: r.baseHead ?? null,
-    head: r.head ?? null,
-    // Failure evidence (machine-readable record only — never the PR body).
-    transcriptTail: r.transcriptTail ?? null,
-    ledger: r.ledger,
-  };
 }
 
 export interface RemediateOptions {
@@ -417,19 +151,6 @@ export async function runRemediateConfigured(
     );
   }
   if (outcome.failed) process.exitCode = 1;
-}
-
-/** Credentials the configured driver declares, read from THIS process env
- *  (CI: injected by the workflow from repo secrets). Only declared names are
- *  forwarded — never the whole environment. */
-function collectCredentialEnv(driverId: string): Record<string, string> {
-  const driver = driverById(driverId);
-  const out: Record<string, string> = {};
-  for (const name of driver?.credentialEnv ?? []) {
-    const value = process.env[name];
-    if (value) out[name] = value;
-  }
-  return out;
 }
 
 /** Known task ids for the CLI usage line. */

--- a/src/remediate/cli.ts
+++ b/src/remediate/cli.ts
@@ -92,13 +92,17 @@ async function executeTask(
   // copy, so the runner's enforcement + ledger see the effective caps.
   // Dispatch-campaign overrides (env-transported, clamped) layer on top —
   // the runner receives the disclosure and folds it into the ledger.
-  const task = remediateTaskById(taskId);
-  const policyBudget = task ? budgetForTask(config, task.id) : config.agent.budget;
+  // Both derivations take the RAW id string — never `task ? … : fallback`.
+  // 'custom' is deliberately outside the registry, so a registry-lookup
+  // guard here is a second, weaker derivation of the same concept the
+  // resolvers already own (the #274 class: it forced salvage to 'discard'
+  // on a verified custom run, overriding explicit policy).
+  const policyBudget = budgetForTask(config, taskId);
   const dispatch = readDispatchOverrides(process.env, policyBudget, config);
   // The concrete salvage decision for THIS task (the one resolver: explicit
   // policy wins, 'auto' follows the task's completion shape) — threaded into
   // the runner's config so the ledger note and the landing below agree.
-  const salvage = task ? salvageForTask(config, task) : 'discard';
+  const salvage = salvageForTask(config, taskId);
   const taskConfig: RemediateConfig = {
     ...config,
     salvage,
@@ -114,15 +118,25 @@ async function executeTask(
   // partial reads NET-NEW and can never grandfather its own breakage.
   let entryFloor: CorrectnessFloorResult | undefined;
   let resume: ResumeDecision = { resumed: false };
-  if (land === 'pr' && task && config.resume) {
-    // (salvage below is the task-resolved decision — resume needs draft-pr)
+  if (land === 'pr' && config.resume && taskId === 'custom') {
+    // DELIBERATE, not a registry-lookup accident: a custom dispatch carries a
+    // human-supplied prompt, and a later dispatch may carry a DIFFERENT one —
+    // resuming would continue a prior attempt's goal under this run's prompt
+    // and ledger. Disclosed here, never a silent guard (#274's second half).
+    logger.warn(
+      'resume: unavailable for custom dispatch tasks — a later dispatch may carry a ' +
+        'different prompt than the salvaged attempt; starting fresh.',
+    );
+  }
+  if (land === 'pr' && config.resume && taskId !== 'custom' && remediateTaskById(taskId)) {
+    // (salvage above is the task-resolved decision — resume needs draft-pr)
     entryFloor = runCorrectnessFloor({
       cwd,
       changedFiles: [],
       scope: 'full',
       packs: detectActiveLanguages(cwd),
     });
-    resume = prepareResume(cwd, task.id, { resume: config.resume, salvage });
+    resume = prepareResume(cwd, taskId, { resume: config.resume, salvage });
     if (resume.note) logger.warn(`resume: ${resume.note}`);
     if (resume.resumed) {
       logger.info(`resuming budget-bounded attempt #${resume.attempt} from the salvage branch`);

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -86,7 +86,14 @@ export interface RemediateConfig {
  */
 export function salvageForTask(
   config: Pick<RemediateConfig, 'salvage'>,
-  task: Pick<RemediateTask, 'completion'> | RemediateTaskId,
+  // Accepts the resolved task OR its raw id string. The string arm exists so
+  // callers that hold only an id (the CLI executor, where 'custom' is
+  // deliberately outside the registry) route through THIS resolver instead of
+  // re-deriving from a registry lookup — the lookup-returns-undefined path is
+  // exactly how the executor's second derivation forced 'discard' on a
+  // verified custom run (#274). An id that resolves to nothing and is not
+  // 'custom' reads as bounded → discard (conservative).
+  task: Pick<RemediateTask, 'completion'> | string,
 ): 'discard' | 'draft-pr' {
   if (config.salvage !== 'auto') return config.salvage;
   const shape =
@@ -100,9 +107,12 @@ export function salvageForTask(
 
 /** The effective budget for one task: the per-task override merged over the
  *  shared agent budget — the ONE derivation every surface (runner, plan,
- *  matrix trim) reads. */
-export function budgetForTask(config: RemediateConfig, taskId: RemediateTaskId): RemediateBudget {
-  const override = config.taskBudgets[taskId] ?? {};
+ *  matrix trim) reads. Accepts a raw id string so the executor never branches
+ *  on "is this a registry task" to pick a budget: an id with no override slot
+ *  ('custom', or a typo the runner will refuse anyway) gets the shared agent
+ *  budget. */
+export function budgetForTask(config: RemediateConfig, taskId: string): RemediateBudget {
+  const override = config.taskBudgets[taskId as RemediateTaskId] ?? {};
   return {
     maxTurns: positiveNumber(override.maxTurns, config.agent.budget.maxTurns),
     maxMinutes: positiveNumber(override.maxMinutes, config.agent.budget.maxMinutes),

--- a/src/remediate/execute.ts
+++ b/src/remediate/execute.ts
@@ -1,0 +1,366 @@
+/**
+ * The remediate task executor — run ONE task through the verified-frame
+ * runner and (optionally) land it. Split from `cli.ts` for module size (the
+ * plan-cli / configured-loop precedent); the CLI re-exports everything, so
+ * consumers keep one import surface.
+ *
+ * This is the wiring layer BETWEEN the runner and the lander, and it is
+ * where two live deliver-layer defects sat with zero coverage (#273 landing
+ * crash, #274 salvage bypass) — hence the injection seams: the runner and
+ * the lander are each unit-tested through their own seams, but the wiring
+ * between them was untestable without spawning a real agent.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import * as logger from '../logger';
+import { trustedLocalContext } from '../analysis-trust';
+import { detectDefaultBranch } from '../ship-installers';
+import { startPhaseReporter } from '../lanes/heartbeat';
+import { runCorrectnessFloor, type CorrectnessFloorResult } from '../analyzers/correctness/run';
+import { detectActiveLanguages } from '../languages';
+import { prepareResume, type ResumeDecision } from './resume';
+import { budgetForTask, salvageForTask, type RemediateConfig } from './config';
+import { readDispatchOverrides } from './dispatch';
+import { driverById } from './registry';
+import { remediateTaskById } from './tasks';
+import { runRemediateTask, type RemediateResult } from './run';
+import { landRemediateHead, remediateBranchFor } from './land';
+import { appendLaneEvent, LANE_LEDGER_SCHEMA_VERSION } from '../lanes/ledger';
+
+export interface TaskRun {
+  readonly result: RemediateResult;
+  readonly prUrl?: string;
+  /** Why a land-eligible outcome was NOT landed (the branch guard). */
+  readonly landRefused?: string;
+  /** The landing itself FAILED (push refused by rules/permissions, PR
+   *  creation failed): the disclosed cause + remedy. The attempt record
+   *  and ledger still render — a refused push loses the delivery, never
+   *  the evidence (#273). */
+  readonly landingBlocked?: string;
+  /** The landing ran (branch pushed, PR opened/updated). */
+  readonly landed: boolean;
+  /** Truthful per-task success: verified/no-op, or a landed salvage draft. */
+  readonly clean: boolean;
+}
+
+/**
+ * Phrase a landing failure for the record + job log: the git/gh output is
+ * the evidence, and a rules/permissions-shaped refusal names the remedy —
+ * the class exists on every GitHub repo (a GITHUB_TOKEN push touching
+ * workflow files is refused without the `workflows` permission), not only
+ * where a push ruleset restricts paths.
+ */
+function describeLandingFailure(err: unknown): string {
+  const e = err as { message?: string; stderr?: string | Buffer };
+  const stderr = (e.stderr ?? '').toString().trim();
+  const message = (e.message ?? String(err)).split('\n')[0];
+  const evidence = stderr ? `${message}\n${stderr}` : message;
+  const rulesShaped =
+    /\b403\b|GH006|GH013|protected branch|ruleset|refusing to allow|permission/i.test(evidence);
+  const remedy = rulesShaped
+    ? '\nThis looks like a repository-rules or token-permissions refusal. Remedies: grant ' +
+      'the workflow token the permission the push needs (e.g. the `workflows` permission ' +
+      'for workflow-file changes), add a ruleset bypass for the bot, or keep the task ' +
+      'away from the restricted paths (a prompt-level constraint like "do not touch ' +
+      '.github/" holds in practice).'
+    : '';
+  return (
+    `the landing push/PR was refused — the verified work did NOT land, but the attempt ` +
+    `record and ledger carry the evidence (branch state left for inspection).\n${evidence}${remedy}`
+  );
+}
+
+/** Current branch name, or 'HEAD' for a detached (CI) checkout. */
+function currentBranch(cwd: string): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return 'HEAD';
+  }
+}
+
+/** Injection seams for the executor — tests only; production callers pass
+ *  nothing (see the module doc for why they exist). */
+export interface ExecutorSeams {
+  readonly runTask?: typeof runRemediateTask;
+  readonly landHead?: typeof landRemediateHead;
+  readonly branch?: (cwd: string) => string;
+  readonly defaultBranch?: (cwd: string) => string;
+}
+
+/** Run one task through the runner and (optionally) land it — the ONE
+ *  executor `--task` and `configured` both use. */
+export async function executeTask(
+  cwd: string,
+  config: RemediateConfig,
+  taskId: string,
+  land: 'pr' | 'none',
+  seams: ExecutorSeams = {},
+): Promise<TaskRun> {
+  // Per-task budget: the override-merged budget rides a task-scoped config
+  // copy, so the runner's enforcement + ledger see the effective caps.
+  // Dispatch-campaign overrides (env-transported, clamped) layer on top —
+  // the runner receives the disclosure and folds it into the ledger.
+  // Both derivations take the RAW id string — never `task ? … : fallback`.
+  // 'custom' is deliberately outside the registry, so a registry-lookup
+  // guard here is a second, weaker derivation of the same concept the
+  // resolvers already own (the #274 class: it forced salvage to 'discard'
+  // on a verified custom run, overriding explicit policy).
+  const policyBudget = budgetForTask(config, taskId);
+  const dispatch = readDispatchOverrides(process.env, policyBudget, config);
+  // The concrete salvage decision for THIS task (the one resolver: explicit
+  // policy wins, 'auto' follows the task's completion shape) — threaded into
+  // the runner's config so the ledger note and the landing below agree.
+  const salvage = salvageForTask(config, taskId);
+  const taskConfig: RemediateConfig = {
+    ...config,
+    salvage,
+    agent: {
+      ...config.agent,
+      budget: dispatch.any ? dispatch.budget : policyBudget,
+      ...(dispatch.model !== undefined ? { model: dispatch.model } : {}),
+    },
+  };
+  // Resume-from-salvage (opt-in, remediate.resume): the entry floor is
+  // captured FIRST on the pristine tree, THEN the salvage branch is checked
+  // out — attribution stays anchored to the original base, so a broken
+  // partial reads NET-NEW and can never grandfather its own breakage.
+  let entryFloor: CorrectnessFloorResult | undefined;
+  let resume: ResumeDecision = { resumed: false };
+  if (land === 'pr' && config.resume && taskId === 'custom') {
+    // DELIBERATE, not a registry-lookup accident: a custom dispatch carries a
+    // human-supplied prompt, and a later dispatch may carry a DIFFERENT one —
+    // resuming would continue a prior attempt's goal under this run's prompt
+    // and ledger. Disclosed here, never a silent guard (#274's second half).
+    logger.warn(
+      'resume: unavailable for custom dispatch tasks — a later dispatch may carry a ' +
+        'different prompt than the salvaged attempt; starting fresh.',
+    );
+  }
+  if (land === 'pr' && config.resume && taskId !== 'custom' && remediateTaskById(taskId)) {
+    // (salvage above is the task-resolved decision — resume needs draft-pr)
+    entryFloor = runCorrectnessFloor({
+      cwd,
+      changedFiles: [],
+      scope: 'full',
+      packs: detectActiveLanguages(cwd),
+    });
+    resume = prepareResume(cwd, taskId, { resume: config.resume, salvage });
+    if (resume.note) logger.warn(`resume: ${resume.note}`);
+    if (resume.resumed) {
+      logger.info(`resuming budget-bounded attempt #${resume.attempt} from the salvage branch`);
+    }
+  }
+  const reporter = startPhaseReporter(`remediate:${taskId}`);
+  let result: RemediateResult;
+  try {
+    result = await (seams.runTask ?? runRemediateTask)({
+      cwd,
+      trust: trustedLocalContext(),
+      taskId,
+      config: taskConfig,
+      // CI injects the driver's credential env explicitly; locally the driver's
+      // own default applies (claude-code: subscription mode).
+      agentEnv: collectCredentialEnv(config.agent.driver),
+      onPhase: (phase) => reporter.phase(phase),
+      dispatch,
+      ...(entryFloor !== undefined ? { entryFloor } : {}),
+      ...(resume.resumed && resume.attempt !== undefined
+        ? {
+            resume: {
+              attempt: resume.attempt,
+              ...(resume.blockingContext ? { blockingContext: resume.blockingContext } : {}),
+            },
+          }
+        : {}),
+    });
+  } finally {
+    reporter.stop();
+  }
+
+  const draftSalvage = result.outcome === 'budget-exhausted' && salvage === 'draft-pr';
+  // Guardrail-red under draft-pr salvage: the BLOCKED attempt is pushed as a
+  // RED draft — its own required guardrail check keeps it unmergeable, so
+  // "nothing merges" holds while the work + blocking findings survive the
+  // ephemeral runner and the next run can RESUME from them (guardrail-red
+  // was the outcome where the most valuable partial work died). Only a
+  // RAN-and-blocked verdict qualifies; an unrunnable guardrail never pushes.
+  const blockedSalvage = result.outcome === 'guardrail-red' && salvage === 'draft-pr';
+  const landEligible = result.outcome === 'verified' || draftSalvage || blockedSalvage;
+  if (land !== 'pr' || !landEligible) {
+    return finalizeTaskRun(cwd, taskId, {
+      result,
+      landed: false,
+      clean: result.outcome === 'verified' || result.outcome === 'no-op',
+    });
+  }
+
+  // Landing guard (the standing branch is built from HEAD): a named
+  // non-default branch would push unrelated commits into the standing PR.
+  const defaultBranch = (seams.defaultBranch ?? detectDefaultBranch)(cwd);
+  const branch = (seams.branch ?? currentBranch)(cwd);
+  if (branch !== 'HEAD' && branch !== defaultBranch) {
+    return finalizeTaskRun(cwd, taskId, {
+      result,
+      landed: false,
+      clean: false,
+      landRefused:
+        `not landed: HEAD is on '${branch}', not '${defaultBranch}' — landing pushes HEAD ` +
+        `to the standing branch, so run from '${defaultBranch}' (or let the scheduled ` +
+        `workflow land it).`,
+    });
+  }
+
+  // The delivery-ledger event rides the PR's own diff (committed by the
+  // lander, pushed with the work) — delivered means MERGED, never "PR opened".
+  const ledgerPath = appendLaneEvent(cwd, {
+    schema_version: LANE_LEDGER_SCHEMA_VERSION,
+    timestamp: new Date().toISOString(),
+    lane: 'remediate',
+    task: taskId,
+    outcome: 'landed',
+    ...(draftSalvage || blockedSalvage ? { partial: true } : {}),
+    ...(blockedSalvage ? { blocked: true } : {}),
+    ...(result.envelope?.costUsd !== undefined ? { costUsd: result.envelope.costUsd } : {}),
+    ...(result.envelope?.resolvedModelId
+      ? { resolvedModelId: result.envelope.resolvedModelId }
+      : {}),
+    ...(result.envelope ? { driver: result.envelope.driver } : {}),
+  });
+  // Evidence BEFORE delivery (#273): the attempt record — with the commit
+  // range the workflow's patch-artifact fallback needs — is written before
+  // the push, landed:false, and flipped by the finalize below on success. A
+  // refused push (ruleset, token permissions) must lose the delivery, never
+  // the 18 minutes of verified evidence: the crash-shaped alternative left
+  // no record, no ledger, and an empty patch artifact.
+  writeAttemptRecord(cwd, taskId, { result, landed: false, clean: false });
+  let landResult: ReturnType<typeof landRemediateHead>;
+  try {
+    landResult = (seams.landHead ?? landRemediateHead)({
+      cwd,
+      taskId,
+      defaultBranch,
+      prTitle:
+        `dxkit remediate: ${taskId}` +
+        (blockedSalvage
+          ? ' (blocked: guardrail-red — do not merge)'
+          : draftSalvage
+            ? ' (partial, budget-bounded)'
+            : ''),
+      prBody: result.ledger,
+      draft: draftSalvage || blockedSalvage,
+      ledgerPath,
+    });
+  } catch (err) {
+    // A landing failure is a DISCLOSED outcome, never a crash: the ledger,
+    // record, and step summary all render as usual — the GateFailure
+    // discipline applied to the land layer.
+    return finalizeTaskRun(cwd, taskId, {
+      result,
+      landed: false,
+      clean: false,
+      landingBlocked: describeLandingFailure(err),
+    });
+  }
+  return finalizeTaskRun(cwd, taskId, {
+    result,
+    ...(landResult.prUrl ? { prUrl: landResult.prUrl } : {}),
+    landed: true,
+    // A blocked salvage is NOT clean: the draft exists for inspection and
+    // resume, but the task did not end well — the job stays red.
+    clean: result.outcome === 'verified' || draftSalvage,
+  });
+}
+
+/**
+ * Every executeTask exit funnels through here: write the machine-readable
+ * attempt record (the workflow's artifact step reads it to upload the diff
+ * of a blocked/failed attempt — evidence must survive the ephemeral runner)
+ * and, under Actions, annotate a not-landed attempt so it is visible from
+ * the run page without opening logs.
+ */
+function finalizeTaskRun(cwd: string, taskId: string, run: TaskRun): TaskRun {
+  writeAttemptRecord(cwd, taskId, run);
+  if (run.landingBlocked) {
+    logger.warn(run.landingBlocked);
+  }
+  if (!run.clean) {
+    // A non-clean outcome must be diagnosable from the run page: the agent
+    // phase group otherwise closes with ZERO output (the driver captures the
+    // CLI's streams), so the failure's own evidence — the driver-reported
+    // cause and the transcript tail — surfaces in the LOG here. Log only,
+    // never the ledger/PR body.
+    if (run.result.envelope?.failure) {
+      logger.warn(`driver-reported failure: ${run.result.envelope.failure}`);
+    }
+    if (run.result.transcriptTail) {
+      logger.warn(`agent transcript (last lines):\n${run.result.transcriptTail}`);
+    }
+  }
+  if (process.env.GITHUB_ACTIONS === 'true' && !run.clean) {
+    const first = (run.landingBlocked ?? run.result.note ?? run.result.outcome).split('\n')[0];
+    process.stdout.write(
+      `::warning title=remediate ${taskId} did not land::${run.result.outcome}: ${first}\n`,
+    );
+  }
+  return run;
+}
+
+/** The machine-readable attempt record — written pre-push (landed:false)
+ *  AND at every finalize, so the evidence exists no matter where the
+ *  landing dies. Best-effort plumbing, never a failure. */
+function writeAttemptRecord(cwd: string, taskId: string, run: TaskRun): void {
+  try {
+    const dir = path.join(cwd, '.dxkit', 'cache');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `remediate-${taskId}.json`),
+      JSON.stringify(taskRunJson(run), null, 2) + '\n',
+      'utf8',
+    );
+  } catch {
+    // the record is evidence plumbing, never a failure
+  }
+}
+
+export function taskRunJson(run: TaskRun): Record<string, unknown> {
+  const r = run.result;
+  return {
+    outcome: r.outcome,
+    task: r.task ?? null,
+    note: r.note ?? null,
+    partial: r.partial ?? false,
+    envelope: r.envelope ?? null,
+    guardrailVerdict: r.guardrailVerdict ?? null,
+    branch: r.task ? remediateBranchFor(r.task) : null,
+    prUrl: run.prUrl ?? null,
+    landRefused: run.landRefused ?? null,
+    landingBlocked: run.landingBlocked ?? null,
+    landed: run.landed,
+    // The commit range of the attempt — what the workflow's evidence step
+    // format-patches into a run artifact when nothing landed.
+    baseHead: r.baseHead ?? null,
+    head: r.head ?? null,
+    // Failure evidence (machine-readable record only — never the PR body).
+    transcriptTail: r.transcriptTail ?? null,
+    ledger: r.ledger,
+  };
+}
+
+/** Credentials the configured driver declares, read from THIS process env
+ *  (CI: injected by the workflow from repo secrets). Only declared names are
+ *  forwarded — never the whole environment. */
+function collectCredentialEnv(driverId: string): Record<string, string> {
+  const driver = driverById(driverId);
+  const out: Record<string, string> = {};
+  for (const name of driver?.credentialEnv ?? []) {
+    const value = process.env[name];
+    if (value) out[name] = value;
+  }
+  return out;
+}

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -211,7 +211,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     env: opts.agentEnv ?? {},
   });
 
-  const envelope: AgentEnvelope = {
+  let envelope: AgentEnvelope = {
     ...envelopeBase,
     ...(agentResult.resolvedModelId ? { resolvedModelId: agentResult.resolvedModelId } : {}),
     ...(agentResult.cliVersion ? { cliVersion: agentResult.cliVersion } : {}),
@@ -225,20 +225,14 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     ? { transcriptTail: agentResult.transcriptTail }
     : {};
 
-  if (agentResult.neverRan) {
-    return finish({
-      outcome: 'agent-never-ran',
-      task: task.id,
-      envelope,
-      floor: entryFloor,
-      ...evidenceTail,
-      note: `agent never ran: ${agentResult.neverRan.reason}`,
-    });
-  }
-
   // Sweep uncommitted leftovers into a loudly-labeled commit — work the
   // budget kill stranded mid-edit is still evidence, and a dirty tree must
-  // never leak into the landing layer unreviewed.
+  // never leak into the landing layer unreviewed. The sweep runs BEFORE the
+  // driver's never-ran claim is honored: a classification must never decide
+  // the fate of evidence it has not looked at (#272 — a wall-clock kill the
+  // driver misread as "never ran" returned early here and discarded 30
+  // minutes of stranded work). A genuinely never-ran agent leaves nothing
+  // to sweep, so this is a no-op on that path.
   opts.onPhase?.('sweep');
   const sweepError = git.sweepLeftovers();
   // Drop attempt-introduced runtime artifacts (regenerable scan state the
@@ -247,6 +241,33 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // must not carry `.dxkit/reports/*` into its PR. Disclosed below.
   const scrubbed = git.scrubRuntimeArtifacts(baseHead);
   const hasDiff = git.hasDiff(baseHead);
+
+  if (agentResult.neverRan) {
+    // The tree is the arbiter of "ran": commits past baseHead, or leftovers
+    // the sweep touched, are work — and work means the agent RAN, whatever
+    // the driver's classification concluded (a future CLI can always invent
+    // a new exit encoding; the tree cannot lie). Uncontradicted, the claim
+    // stands; contradicted, the claim is demoted to a disclosed failure and
+    // verification decides the work's fate — the lane's law applied to the
+    // driver's own report.
+    if (!hasDiff && !sweepError) {
+      return finish({
+        outcome: 'agent-never-ran',
+        task: task.id,
+        envelope,
+        floor: entryFloor,
+        ...evidenceTail,
+        note: `agent never ran: ${agentResult.neverRan.reason}`,
+      });
+    }
+    envelope = {
+      ...envelope,
+      failure:
+        `driver classified the run as "agent never ran" (${agentResult.neverRan.reason}), ` +
+        `but the tree carries work from this attempt — the claim is contradicted by ` +
+        `evidence, so verification decides the work's fate`,
+    };
+  }
 
   // Reported spend exceeding the (advisory) cap is an honest post-hoc claim
   // — "the run overran maxUsd" — for any driver that at least REPORTS cost.

--- a/src/remediate/tasks.ts
+++ b/src/remediate/tasks.ts
@@ -103,6 +103,12 @@ export const SHARED_RULES = `
 Ground rules (non-negotiable):
 - Work ONLY on this task. Do not fix unrelated debt, do not refactor beyond
   what the task needs, do not touch CI/workflow files.
+- Never create or edit ANYTHING under the .github/ directory — not
+  workflows, not issue/PR templates, not configs. Repository rules and
+  token permissions commonly refuse bot pushes touching those paths, and a
+  refused push means NONE of your work lands. If the task seems to need a
+  .github/ change, write the proposal in
+  docs/DXKIT-REMEDIATION-NOTES.md instead.
 - NEVER run \`vyuh-dxkit baseline create\` or edit \`.dxkit/baselines/\` — the
   gate must attribute your work honestly, and refreshing the baseline to
   clear a block is forbidden.

--- a/test/baseline/git-aware-match.test.ts
+++ b/test/baseline/git-aware-match.test.ts
@@ -546,3 +546,156 @@ describe('gitAwareMatch', () => {
     expect(pair.reasons[0].detail).toContain('a.ts:4');
   });
 });
+
+describe('gitAwareMatch — modified-hunk endpoint pairing (#271)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeRepo();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function findingAt(file: string, line: number, rule = 'quotes'): LocatedIdentity {
+    return {
+      id: identityFor({ kind: 'code', tool: 'eslint', rule, file, line }),
+      file,
+      line,
+      rule,
+    };
+  }
+
+  /** Base: ten lines, a lint finding on line 10. Head: three lines deleted
+   *  above AND the finding line itself rewritten (the quote-fix shape from
+   *  the live incident) — so the finding lands on line 7 with new content.
+   *  No line-map image (the line was modified), no content-hash (the bytes
+   *  changed): only the hunk structure can re-pair the endpoints. */
+  function writeBaseAndModifiedHead(): { base: string; head: string } {
+    writeFileSync(
+      join(dir, 'a.ts'),
+      lines(
+        'line-1',
+        'line-2',
+        'line-3',
+        'line-4',
+        'line-5',
+        'line-6',
+        'line-7',
+        'line-8',
+        'line-9',
+        'const s = "double";',
+      ),
+    );
+    const base = commit(dir, 'initial');
+    writeFileSync(
+      join(dir, 'a.ts'),
+      lines('line-1', 'line-5', 'line-6', 'line-7', 'line-8', 'line-9', "const s = 'single';"),
+    );
+    const head = commit(dir, 'delete three lines, fix the quotes');
+    return { base, head };
+  }
+
+  it('pairs a finding on a MODIFIED line through the replacement hunk (the live class)', () => {
+    const { base, head } = writeBaseAndModifiedHead();
+    const prior = [findingAt('a.ts', 10)];
+    const current = [findingAt('a.ts', 7)];
+    expect(prior[0].id).not.toBe(current[0].id); // buckets differ — pass 2 cannot save this
+
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+    const [pair] = result.pairs;
+    expect(pair.status).toBe('persisted');
+    expect(pair.confidence).toBe(0.85); // below git-line-fuzz: rewritten, not moved
+    expect(pair.reasons[0].code).toBe('git-hunk-pair');
+    expect(pair.reasons[0].detail).toContain('a.ts:10');
+    expect(pair.reasons[0].detail).toContain('a.ts:7');
+  });
+
+  it('the live shape end-to-end: unmodified lines relocate git-line-exact WHILE the modified line hunk-pairs', () => {
+    const { base, head } = writeBaseAndModifiedHead();
+    // line 9 ('line-9') survives untouched: maps 9 → 6 through the deletion.
+    const prior = [findingAt('a.ts', 10), findingAt('a.ts', 9, 'no-console')];
+    const current = [findingAt('a.ts', 7), findingAt('a.ts', 6, 'no-console')];
+
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+    const codes = result.pairs.map((p) => p.reasons[0].code).sort();
+    expect(codes).toEqual(['git-hunk-pair', 'git-line-exact']);
+  });
+
+  it('an AMBIGUOUS bucket (two same-rule candidates in one hunk) stays split — never invent a match', () => {
+    writeFileSync(
+      join(dir, 'a.ts'),
+      lines(
+        'line-1',
+        'line-2',
+        'line-3',
+        'line-4',
+        'line-5',
+        'line-6',
+        'line-7',
+        'line-8',
+        'line-9',
+        'const a = "x";',
+        'const b = "y";',
+      ),
+    );
+    const base = commit(dir, 'initial');
+    writeFileSync(
+      join(dir, 'a.ts'),
+      lines(
+        'line-1',
+        'line-5',
+        'line-6',
+        'line-7',
+        'line-8',
+        'line-9',
+        "const a = 'x';",
+        "const b = 'y';",
+      ),
+    );
+    const head = commit(dir, 'delete three lines, fix both quote lines');
+
+    // Two same-rule findings inside ONE replacement hunk on each side: a
+    // 1:1 pairing would be a guess (which prior is which current?), so the
+    // pass must refuse — the pairs stay removed+added (false-negative bias).
+    const prior = [findingAt('a.ts', 10), findingAt('a.ts', 11)];
+    const current = [findingAt('a.ts', 7), findingAt('a.ts', 8)];
+    for (const p of prior) for (const c of current) expect(p.id).not.toBe(c.id);
+
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+    expect(result.removed.length).toBe(2);
+    expect(result.added.length).toBe(2);
+    expect(result.pairs.every((p) => p.reasons[0]?.code !== 'git-hunk-pair')).toBe(true);
+  });
+
+  it('different rules in one hunk never cross-pair', () => {
+    const { base, head } = writeBaseAndModifiedHead();
+    const prior = [findingAt('a.ts', 10, 'quotes')];
+    const current = [findingAt('a.ts', 7, 'semi')];
+
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+    expect(result.removed.length).toBe(1);
+    expect(result.added.length).toBe(1);
+  });
+
+  it('a pure deletion never pairs with an unrelated addition elsewhere in the file', () => {
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'const gone = "x";', 'three', 'four', 'five'));
+    const base = commit(dir, 'initial');
+    writeFileSync(join(dir, 'a.ts'), lines('one', 'three', 'four', 'five', 'const fresh = "y";'));
+    const head = commit(dir, 'delete line 2, append a NEW finding line');
+
+    // The deletion hunk has no new span (newCount 0) and the addition hunk
+    // has no old span (oldCount 0): neither is a replacement, so the removed
+    // finding and the genuinely new finding must NOT pair — pairing them
+    // would grandfather a real net-new finding.
+    const prior = [findingAt('a.ts', 2)];
+    const current = [findingAt('a.ts', 5)];
+    const result = gitAwareMatch(prior, current, { cwd: dir, baseSha: base, headSha: head });
+    expect(result.removed.length).toBe(1);
+    expect(result.added.length).toBe(1);
+    expect(result.pairs.every((p) => p.reasons[0]?.code !== 'git-hunk-pair')).toBe(true);
+  });
+});

--- a/test/remediate/config-budgets.test.ts
+++ b/test/remediate/config-budgets.test.ts
@@ -3,7 +3,7 @@
  * ceiling (the org guard for the per-task matrix, where a failing task no
  * longer starves siblings and every task may spend its own cap).
  */
-import { REMEDIATE_TASKS } from '../../src/remediate/tasks';
+import { customDispatchTask, REMEDIATE_TASKS } from '../../src/remediate/tasks';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -55,6 +55,13 @@ describe('budgetForTask', () => {
     });
     // A task with no override gets the shared budget untouched.
     expect(budgetForTask(config, 'fix-vulns')).toEqual(DEFAULT_REMEDIATE_BUDGET);
+  });
+
+  it('accepts a raw id string: custom (outside the registry) gets the shared budget', () => {
+    // The executor holds only the id string — it must not branch on "is this
+    // a registry task" to pick a budget (#274's sibling derivation).
+    expect(budgetForTask(cfg({}), 'custom')).toEqual(DEFAULT_REMEDIATE_BUDGET);
+    expect(budgetForTask(cfg({}), 'no-such-task')).toEqual(DEFAULT_REMEDIATE_BUDGET);
   });
 });
 
@@ -130,6 +137,38 @@ describe('salvageForTask — the one salvage resolver (task-shape defaults)', ()
   it('an explicit policy value overrides every task', () => {
     expect(salvageForTask({ salvage: 'discard' }, 'write-docs')).toBe('discard');
     expect(salvageForTask({ salvage: 'draft-pr' }, 'fix-build')).toBe('draft-pr');
+  });
+
+  it('custom honors explicit policy and auto — never a structural discard (#274)', () => {
+    // The live class: a registry-lookup guard in the CLI executor forced
+    // 'discard' for custom, overriding BOTH an explicit draft-pr policy and
+    // 'auto' — a verified, guardrail-PASSED docs run was thrown away.
+    expect(salvageForTask({ salvage: 'draft-pr' }, 'custom')).toBe('draft-pr');
+    expect(salvageForTask(auto, 'custom')).toBe('draft-pr');
+    expect(salvageForTask({ salvage: 'discard' }, 'custom')).toBe('discard');
+  });
+
+  it('PARITY: the id-string arm and the resolved-task arm agree for every task', () => {
+    // The CLI executor passes the raw id string; the runner passes the
+    // resolved task object. Both hit this one resolver — this pins that the
+    // two call shapes cannot diverge (the Rule 2.30 net for #274).
+    const policies = [
+      { salvage: 'auto' },
+      { salvage: 'draft-pr' },
+      { salvage: 'discard' },
+    ] as const;
+    for (const policy of policies) {
+      for (const t of REMEDIATE_TASKS) {
+        expect(salvageForTask(policy, t.id)).toBe(salvageForTask(policy, t));
+      }
+      expect(salvageForTask(policy, 'custom')).toBe(
+        salvageForTask(policy, customDispatchTask('any prompt')),
+      );
+    }
+  });
+
+  it('an unknown id string (typo — the runner will refuse it) reads bounded → discard', () => {
+    expect(salvageForTask(auto, 'no-such-task')).toBe('discard');
   });
 
   it('every registered task declares its completion shape', () => {

--- a/test/remediate/driver.test.ts
+++ b/test/remediate/driver.test.ts
@@ -11,7 +11,12 @@ import {
   type AgentExec,
 } from '../../src/remediate/claude-code-driver';
 import { AGENT_DRIVERS, driverById, knownDriverIds } from '../../src/remediate/registry';
-import { REMEDIATE_TASKS, remediateTaskById, SHARED_RULES } from '../../src/remediate/tasks';
+import {
+  customDispatchTask,
+  REMEDIATE_TASKS,
+  remediateTaskById,
+  SHARED_RULES,
+} from '../../src/remediate/tasks';
 
 /**
  * The driver seam is the "other agents later" promise: these tests pin the
@@ -129,6 +134,22 @@ describe('task registry', () => {
     expect(SHARED_RULES).toContain('docs/DXKIT-REMEDIATION-NOTES.md');
     expect(remediateTaskById('fix-lint')?.tier).toBe('light');
     expect(remediateTaskById('unknown-task')).toBeUndefined();
+  });
+
+  it('every prompt bans .github/ writes — registry tasks AND the custom dispatch task', () => {
+    // Validated live twice, in both directions: a write-docs agent wrote
+    // .github/ templates and the landing push was refused by a path ruleset
+    // (all work lost pre-#273); a custom run with an in-prompt ban complied
+    // fully and verified end-to-end. Prompt-level constraint is the
+    // mitigation with an evidence base — the learned restricted-paths layer
+    // is the 4.3.8 root treatment.
+    for (const t of REMEDIATE_TASKS) {
+      expect(t.prompt).toContain('.github/');
+      expect(t.prompt).toContain('Never create or edit ANYTHING under');
+    }
+    expect(customDispatchTask('write some docs').prompt).toContain(
+      'Never create or edit ANYTHING under',
+    );
   });
 });
 

--- a/test/remediate/driver.test.ts
+++ b/test/remediate/driver.test.ts
@@ -5,7 +5,11 @@ import {
   type AgentDriver,
   type ModelTier,
 } from '../../src/remediate/driver';
-import { makeClaudeCodeDriver, type AgentExec } from '../../src/remediate/claude-code-driver';
+import {
+  makeClaudeCodeDriver,
+  realAgentExec,
+  type AgentExec,
+} from '../../src/remediate/claude-code-driver';
 import { AGENT_DRIVERS, driverById, knownDriverIds } from '../../src/remediate/registry';
 import { REMEDIATE_TASKS, remediateTaskById, SHARED_RULES } from '../../src/remediate/tasks';
 
@@ -253,5 +257,45 @@ describe('claude-code driver (exec injected)', () => {
     expect(r.neverRan).toBeUndefined();
     expect(r.completed).toBe(false);
     expect(r.turns).toBe(9);
+  });
+});
+
+describe('realAgentExec — deadline-first timeout classification (#272)', () => {
+  // Real child processes, deliberately: the classification lives in the REAL
+  // exec (the injected-exec tests above bypass it by design), and the two
+  // SIGTERM encodings can only be produced by an actual kill.
+
+  it('signal-death: a child killed by the timeout SIGTERM is timedOut', () => {
+    const r = realAgentExec('sleep', ['2'], { cwd: '/tmp', env: {}, timeoutMs: 250 });
+    expect(r.timedOut).toBe(true);
+    expect(r.code).toBeNull();
+  });
+
+  it('graceful-catch: a child that traps SIGTERM and exits 143 is timedOut, never never-ran-shaped', () => {
+    // The claude CLI (2.1.222) traps SIGTERM and exits 143 with no result
+    // JSON — signal null, status 143. The signal-only predicate read this as
+    // a plain failed exit, which fell into the never-ran branch downstream
+    // and discarded the stranded work. The background+wait shape matters:
+    // bash defers traps until the foreground command exits, and the orphaned
+    // sleep must not hold our pipes open.
+    const r = realAgentExec(
+      'bash',
+      ['-c', 'trap "exit 143" TERM; sleep 2 >/dev/null 2>&1 & wait'],
+      { cwd: '/tmp', env: {}, timeoutMs: 250 },
+    );
+    expect(r.timedOut).toBe(true);
+    expect(r.code).toBe(143);
+  });
+
+  it('a natural failure exit before the deadline is NEVER a timeout (false-negative bias)', () => {
+    const r = realAgentExec('bash', ['-c', 'exit 7'], { cwd: '/tmp', env: {}, timeoutMs: 5000 });
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(7);
+  });
+
+  it('a clean exit is a clean exit', () => {
+    const r = realAgentExec('bash', ['-c', 'echo ok'], { cwd: '/tmp', env: {}, timeoutMs: 5000 });
+    expect(r).toMatchObject({ code: 0, timedOut: false });
+    expect(r.stdout).toContain('ok');
   });
 });

--- a/test/remediate/executor-landing.test.ts
+++ b/test/remediate/executor-landing.test.ts
@@ -1,0 +1,220 @@
+/**
+ * The executor's landing layer (#273) — pinned through the executor seams.
+ *
+ * The live class: a push ruleset refused the landing push (403/GH006 on a
+ * `.github/**` path restriction) and the frame CRASHED — no attempt record
+ * (never written), no ledger rendered, the workflow's evidence artifact
+ * empty, 18 minutes of verified work lost. The class exists on every GitHub
+ * repo (GITHUB_TOKEN refuses `.github/workflows/**` pushes without the
+ * `workflows` permission), not only where a ruleset restricts paths.
+ *
+ * Two invariants, both directions:
+ *   - evidence BEFORE delivery: the attempt record (with the commit range
+ *     the patch-artifact fallback reads) exists before the push runs;
+ *   - a landing failure is a DISCLOSED outcome (cause + remedy when it is
+ *     rules/permissions-shaped), never a crash.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { executeTask, type ExecutorSeams } from '../../src/remediate/cli';
+import { DEFAULT_REMEDIATE_BUDGET, type RemediateConfig } from '../../src/remediate/config';
+import type { RemediateResult } from '../../src/remediate/run';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+function tempRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-exec-'));
+  dirs.push(dir);
+  return dir;
+}
+
+function config(salvage: RemediateConfig['salvage'] = 'discard'): RemediateConfig {
+  return {
+    enabled: true,
+    tasks: ['write-docs'],
+    unknownTasks: [],
+    schedule: 'weekly',
+    salvage,
+    agent: { driver: 'claude-code', model: 'auto', budget: DEFAULT_REMEDIATE_BUDGET },
+    taskBudgets: {},
+    maxSpendPerRun: 0,
+    maxDispatchBudget: 0,
+    resume: false,
+  };
+}
+
+function verifiedResult(): RemediateResult {
+  return {
+    outcome: 'verified',
+    task: 'write-docs',
+    ledger: 'THE VERIFICATION LEDGER',
+    baseHead: 'aaaa1111',
+    head: 'bbbb2222',
+  };
+}
+
+/** The ruleset refusal git actually prints (web-client's "Push to Path
+ *  block" ruleset, trimmed) — stderr rides the thrown exec error. */
+const RULESET_STDERR =
+  'remote: error: GH013: Repository rule violations found for refs/heads/dxkit/remediate-write-docs.\n' +
+  'remote: - Push to Path block\n' +
+  "remote:   Paths must not match: '.github/**/*'\n" +
+  '! [remote rejected] HEAD -> dxkit/remediate-write-docs (push declined due to repository rule violations)';
+
+function seams(overrides: Partial<ExecutorSeams> = {}): ExecutorSeams {
+  return {
+    runTask: async () => verifiedResult(),
+    branch: () => 'main',
+    defaultBranch: () => 'main',
+    landHead: () => ({
+      outcome: 'pr-opened' as const,
+      mode: 'pr' as const,
+      prUrl: 'https://example.test/pr/1',
+    }),
+    ...overrides,
+  };
+}
+
+function readRecord(cwd: string): Record<string, unknown> {
+  return JSON.parse(
+    fs.readFileSync(path.join(cwd, '.dxkit', 'cache', 'remediate-write-docs.json'), 'utf8'),
+  ) as Record<string, unknown>;
+}
+
+describe('executeTask landing layer (#273)', () => {
+  it('a rules-shaped push refusal is a DISCLOSED outcome with the git stderr and the remedy', async () => {
+    const cwd = tempRepo();
+    const run = await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        landHead: () => {
+          throw Object.assign(new Error('git push exited 1'), { stderr: RULESET_STDERR });
+        },
+      }),
+    );
+    expect(run.landed).toBe(false);
+    expect(run.clean).toBe(false);
+    // The evidence: git's own words, not a paraphrase.
+    expect(run.landingBlocked).toContain('GH013');
+    expect(run.landingBlocked).toContain('Push to Path block');
+    // The remedy, named (rules/permissions-shaped refusal).
+    expect(run.landingBlocked).toContain('ruleset bypass');
+    expect(run.landingBlocked).toContain('workflows');
+    // The ledger survived — the runner's result is intact for the step summary.
+    expect(run.result.ledger).toBe('THE VERIFICATION LEDGER');
+  });
+
+  it('the attempt record exists BEFORE the push, with the commit range (evidence before delivery)', async () => {
+    const cwd = tempRepo();
+    let recordAtPushTime: Record<string, unknown> | undefined;
+    await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        landHead: () => {
+          recordAtPushTime = readRecord(cwd);
+          throw Object.assign(new Error('git push exited 1'), { stderr: RULESET_STDERR });
+        },
+      }),
+    );
+    // The pre-push record already carries what the patch-artifact fallback
+    // needs — the crash-shaped alternative left it unwritten.
+    expect(recordAtPushTime).toBeDefined();
+    expect(recordAtPushTime!.landed).toBe(false);
+    expect(recordAtPushTime!.baseHead).toBe('aaaa1111');
+    expect(recordAtPushTime!.head).toBe('bbbb2222');
+    // And the final record discloses the refusal.
+    const final = readRecord(cwd);
+    expect(final.landed).toBe(false);
+    expect(String(final.landingBlocked)).toContain('GH013');
+  });
+
+  it('a non-rules failure is disclosed WITHOUT inventing a rules remedy', async () => {
+    const cwd = tempRepo();
+    const run = await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        landHead: () => {
+          throw new Error('fatal: unable to access remote: Could not resolve host');
+        },
+      }),
+    );
+    expect(run.landingBlocked).toContain('Could not resolve host');
+    expect(run.landingBlocked).not.toContain('Remedies');
+  });
+
+  it('a successful landing flips the record to landed:true with the PR url', async () => {
+    const cwd = tempRepo();
+    const run = await executeTask(cwd, config(), 'write-docs', 'pr', seams());
+    expect(run.landed).toBe(true);
+    expect(run.clean).toBe(true);
+    expect(run.prUrl).toBe('https://example.test/pr/1');
+    const record = readRecord(cwd);
+    expect(record.landed).toBe(true);
+    expect(record.prUrl).toBe('https://example.test/pr/1');
+  });
+
+  it("custom's salvage decision reaches the runner AND lands as a draft (#274, executor level)", async () => {
+    // The live bug sat exactly here: the executor's registry-lookup guard
+    // baked 'discard' into the runner's config for 'custom' before the one
+    // resolver ever saw it. Now pinned at the wiring layer: under
+    // salvage 'auto', custom resolves open-ended → draft-pr, the runner
+    // receives that decision, and a budget-exhausted custom outcome lands
+    // as a DRAFT instead of being thrown away.
+    const cwd = tempRepo();
+    let salvageSeenByRunner: string | undefined;
+    let draftSeenByLander: boolean | undefined;
+    const run = await executeTask(
+      cwd,
+      config('auto'),
+      'custom',
+      'pr',
+      seams({
+        runTask: async (opts) => {
+          salvageSeenByRunner = opts.config.salvage;
+          return {
+            outcome: 'budget-exhausted',
+            task: 'custom',
+            ledger: 'THE VERIFICATION LEDGER',
+            baseHead: 'aaaa1111',
+            head: 'bbbb2222',
+          };
+        },
+        landHead: (opts) => {
+          draftSeenByLander = opts.draft;
+          return { outcome: 'pr-opened', mode: 'pr', prUrl: 'https://example.test/pr/2' };
+        },
+      }),
+    );
+    expect(salvageSeenByRunner).toBe('draft-pr');
+    expect(draftSeenByLander).toBe(true);
+    expect(run.landed).toBe(true);
+    expect(run.clean).toBe(true); // a landed budget-bounded draft is the clean outcome
+  });
+
+  it('the branch guard still refuses a feature-branch landing (unchanged behavior)', async () => {
+    const cwd = tempRepo();
+    const run = await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({ branch: () => 'feat/x' }),
+    );
+    expect(run.landed).toBe(false);
+    expect(run.landRefused).toContain("HEAD is on 'feat/x'");
+    expect(run.landingBlocked).toBeUndefined();
+  });
+});

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -268,8 +268,13 @@ describe('runner: an errored no-diff run is agent-failed, never a benign no-op',
   });
 
   it('agent-never-ran carries the entry floor too (the ledger names pre-existing debt)', async () => {
+    // diff: false — a genuinely never-ran agent leaves a clean tree; a
+    // never-ran claim over a tree WITH work is the #272 contradiction case
+    // (pinned in run.test.ts) and no longer returns this outcome.
     const r = await runRemediateTask(
-      base(fakeDriver({ completed: false, neverRan: { reason: 'Credit balance is too low' } })),
+      base(fakeDriver({ completed: false, neverRan: { reason: 'Credit balance is too low' } }), {
+        git: fakeGit({ diff: false }),
+      }),
     );
     expect(r.outcome).toBe('agent-never-ran');
     expect(r.note).toContain('agent never ran: Credit balance is too low');

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -151,9 +151,55 @@ describe('refusal + infra arms (each truthful and distinct)', () => {
       completed: false,
       neverRan: { reason: 'claude exit 1: bad auth' },
     });
-    const r = await runRemediateTask(base(driver));
+    // A genuinely never-ran agent leaves a clean tree — the claim stands.
+    const r = await runRemediateTask(base(driver, { git: fakeGit({ diff: false }) }));
     expect(r.outcome).toBe('agent-never-ran');
     expect(r.note).toContain('bad auth');
+  });
+
+  it('the sweep runs BEFORE a never-ran claim is honored (#272: evidence first)', async () => {
+    let swept = false;
+    const git: RemediateGit = {
+      head: () => 'base0000',
+      sweepLeftovers: () => {
+        swept = true;
+        return undefined;
+      },
+      scrubRuntimeArtifacts: () => [],
+      hasDiff: () => false,
+    };
+    const driver = fakeDriver({ completed: false, neverRan: { reason: 'exit 143' } });
+    const r = await runRemediateTask(base(driver, { git }));
+    expect(r.outcome).toBe('agent-never-ran');
+    expect(swept).toBe(true);
+  });
+
+  it('a never-ran claim CONTRADICTED by committed work is demoted — verification decides (#272)', async () => {
+    // The live class: a wall-clock-killed run the driver misread as "never
+    // ran" returned early and discarded 30 minutes of committed work. The
+    // tree is the arbiter: work means the agent ran, whatever the driver's
+    // exit-encoding taxonomy concluded. The claim demotes to a disclosed
+    // failure and the verified frame decides the work's fate.
+    const driver = fakeDriver({
+      completed: false,
+      neverRan: { reason: 'claude exit 143: (no stderr)' },
+    });
+    const r = await runRemediateTask(base(driver, { git: fakeGit({ diff: true }) }));
+    expect(r.outcome).not.toBe('agent-never-ran');
+    expect(r.outcome).toBe('verified'); // green floor + PASSED guardrail in `base`
+    expect(r.envelope?.failure).toContain('contradicted');
+    expect(r.ledger).toBeTruthy();
+  });
+
+  it('a never-ran claim with UNCOMMITTABLE leftovers is also contradicted — nothing is discarded silently', async () => {
+    const driver = fakeDriver({ completed: false, neverRan: { reason: 'exit 143' } });
+    const r = await runRemediateTask(
+      base(driver, { git: fakeGit({ diff: false, sweepError: 'index locked' }) }),
+    );
+    // The sweep-failed arm (agent left uncommitted work it could not commit)
+    // reports the evidence rather than the driver's claim.
+    expect(r.note).toContain('uncommitted work');
+    expect(r.envelope?.failure).toContain('contradicted');
   });
 });
 


### PR DESCRIPTION
The 4.3.7.1 hotfix, shipping as **4.3.8** (semver has no four-part versions — npm and publish.yml's preflight both reject `4.3.7.1`; the planned agent-capability release #270 renumbers accordingly).

Four live remediation-lane runs surfaced four defects. In every one the agent's work was verified sound — the frame around it then lost, discarded, or misattributed that work. Each fix lands at the root with its class pinned by tests:

- **#271** (PR #278): a located finding on a MODIFIED line split into removed+added and false-blocked as net-new. New git-aware matcher pass `git-hunk-pair`: conservative 1:1 same-rule pairing inside replacement hunks (ambiguity stays split, deletions never pair), confidence below the line-survived tier.
- **#272** (PR #276): a wall-clock kill the CLI turned into a graceful exit 143 was misclassified as agent-never-ran and its work discarded pre-sweep. Deadline-first timeout classification in the exec, plus evidence-over-classification in the runner: the sweep runs before a never-ran claim is honored, and a contradicted claim demotes to a disclosed failure.
- **#273** (PR #277): a rules/permissions-refused landing push crashed the frame and lost the evidence. The attempt record now precedes the push; a landing failure is a disclosed `landingBlocked` outcome carrying git's stderr + the remedy. The executor gained injection seams + tests (the zero-coverage layer where two of the four defects sat).
- **#274** (PR #275): the custom dispatch task's salvage hard-fell to discard via a registry-lookup guard, overriding explicit committed policy. Both derivations route the raw id through the one resolvers; parity-pinned.
- **Prompt hardening** (PR #279): explicit `.github/` write ban in every agent prompt — the mitigation validated live in both directions.
- **Release prep** (PR #280): version 4.3.8 + changelog.

Every PR merged on green CI; the full gate sweep (suite 5,449, typecheck:test, lint, format, architecture, slop, self-guardrail ref-based vs origin/main) ran locally on the combined tree before the prep push.

After merge + green CI on main: `gh release create v4.3.8 --target <full main sha>` fires publish.yml. Canary validation on the live lane repo follows before any fleet movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)