### PR TITLE
test(gate): gate-vs-guardrail parity net (4.4.0 WP0)

### DIFF
--- a/test/gate/guardrail-parity.test.ts
+++ b/test/gate/guardrail-parity.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { rmSync } from 'fs';
+import {
+  buildCleanScenario,
+  buildNetNewSecretScenario,
+  buildPersistedCheckScenario,
+  guardrailCommittedSurface,
+  guardrailRefBasedSurface,
+  assertSurfacesAgree,
+  compareProjections,
+  projectGuardrailResult,
+  type BuiltScenario,
+  type GateSurface,
+  type VerdictProjection,
+} from './parity-harness';
+
+/**
+ * WP0 — the gate-vs-guardrail parity net (4.4.0).
+ *
+ * Freezes `runGuardrailCheck`'s verdict behavior over a shared scenario
+ * matrix BEFORE the engine extraction (WP1) and the `gate` surface (WP2)
+ * land. Two layers:
+ *
+ *   1. CHARACTERIZATION — each surface's projection over each scenario is
+ *      pinned with explicit expectations. The extraction must not move any
+ *      of these values; a diff here after WP1 means the refactor changed
+ *      behavior, not just structure.
+ *   2. PARITY MACHINERY — `compareProjections` / `assertSurfacesAgree` are
+ *      proven to BITE (injection-guarded): a surface that drifts in any
+ *      projected field fails loudly. WP2 adds the `gate` surface to the
+ *      same matrix and inherits a net already known to catch drift.
+ *
+ * Declared surface differences (committed grandfathers custom-checks;
+ * ref-based structurally excludes + discloses them) are characterized per
+ * surface, never papered over by comparing less.
+ *
+ * Runtime note: every projection is computed ONCE in beforeAll and shared
+ * across assertions (each full check runs every analyzer, ~10-20s).
+ */
+
+const HEAVY = 600_000;
+
+let savedSalt: string | undefined;
+const scenarios: BuiltScenario[] = [];
+
+beforeAll(() => {
+  savedSalt = process.env.DXKIT_BASELINE_SALT;
+  delete process.env.DXKIT_BASELINE_SALT;
+});
+
+afterAll(() => {
+  if (savedSalt === undefined) delete process.env.DXKIT_BASELINE_SALT;
+  else process.env.DXKIT_BASELINE_SALT = savedSalt;
+  for (const s of scenarios) rmSync(s.dir, { recursive: true, force: true });
+});
+
+/** A surface that replays a stored projection under a new name — used to
+ *  exercise the agreement machinery without re-running analyzers. */
+function replaySurface(name: string, projection: VerdictProjection): GateSurface {
+  return {
+    name,
+    run: () => Promise.resolve({ ...projection, surface: name }),
+  };
+}
+
+describe('scenario: clean (base == current)', () => {
+  let committed: VerdictProjection;
+  let committedAgain: VerdictProjection;
+  let refBased: VerdictProjection;
+
+  beforeAll(async () => {
+    const scenario = await buildCleanScenario();
+    scenarios.push(scenario);
+    committed = await guardrailCommittedSurface.run(scenario);
+    committedAgain = await guardrailCommittedSurface.run(scenario);
+    refBased = await guardrailRefBasedSurface.run(scenario);
+  }, HEAVY);
+
+  it('committed mode: PASSED, exit 0, nothing blocking', () => {
+    expect(committed.verdict).toMatch(/^PASSED/);
+    expect(committed.exitCode).toBe(0);
+    expect(committed.blocking).toEqual([]);
+    expect(committed.blockingCount).toBe(0);
+    expect(committed.unattributable).toBe(0);
+    expect(committed.refExcludedKinds).toEqual([]);
+  });
+
+  it('ref-based mode: PASSED, exit 0, exclusions disclosed not silent', () => {
+    expect(refBased.verdict).toMatch(/^PASSED/);
+    expect(refBased.exitCode).toBe(0);
+    expect(refBased.blocking).toEqual([]);
+    expect(refBased.unattributable).toBe(0);
+  });
+
+  it('is deterministic: the same surface run twice projects identically (P0-1 accept)', () => {
+    expect(compareProjections(committed, committedAgain)).toEqual([]);
+  });
+
+  it('assertSurfacesAgree passes for genuinely agreeing surfaces', async () => {
+    const scenario = scenarios.find((s) => s.name === 'clean')!;
+    const projections = await assertSurfacesAgree(scenario, [
+      replaySurface('surface-a', committed),
+      replaySurface('surface-b', committedAgain),
+    ]);
+    expect(projections).toHaveLength(2);
+  });
+});
+
+describe('scenario: net-new secret introduced after base', () => {
+  let committed: VerdictProjection;
+  let refBased: VerdictProjection;
+
+  beforeAll(async () => {
+    const scenario = await buildNetNewSecretScenario();
+    scenarios.push(scenario);
+    committed = await guardrailCommittedSurface.run(scenario);
+    refBased = await guardrailRefBasedSurface.run(scenario);
+  }, HEAVY);
+
+  it('committed mode: BLOCKED with the secret finding, exit 1', () => {
+    expect(committed.verdict).toBe('BLOCKED');
+    expect(committed.exitCode).toBe(1);
+    const secrets = committed.blocking.filter((f) => f.kind === 'secret');
+    expect(secrets.length).toBeGreaterThanOrEqual(1);
+    expect(secrets[0].file).toBe('config.ts');
+    expect(secrets[0].id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('ref-based mode: BLOCKED with the secret finding, exit 1', () => {
+    expect(refBased.verdict).toBe('BLOCKED');
+    expect(refBased.exitCode).toBe(1);
+    const secrets = refBased.blocking.filter((f) => f.kind === 'secret');
+    expect(secrets.length).toBeGreaterThanOrEqual(1);
+    expect(secrets[0].file).toBe('config.ts');
+  });
+
+  it('both surfaces mint the SAME durable identity for the same finding (Rule 9)', () => {
+    const committedSecret = committed.blocking.find((f) => f.kind === 'secret');
+    const refSecret = refBased.blocking.find((f) => f.kind === 'secret');
+    expect(committedSecret?.id).toBeDefined();
+    expect(committedSecret?.id).toBe(refSecret?.id);
+  });
+});
+
+describe('scenario: custom check failing at base and current', () => {
+  let committed: VerdictProjection;
+  let refBased: VerdictProjection;
+
+  beforeAll(async () => {
+    const scenario = await buildPersistedCheckScenario();
+    scenarios.push(scenario);
+    committed = await guardrailCommittedSurface.run(scenario);
+    refBased = await guardrailRefBasedSurface.run(scenario);
+  }, HEAVY);
+
+  it('committed mode: grandfathered — PASSED, nothing blocking', () => {
+    expect(committed.verdict).toMatch(/^PASSED/);
+    expect(committed.exitCode).toBe(0);
+    expect(committed.blocking).toEqual([]);
+  });
+
+  it('ref-based mode: custom-check excluded AND disclosed, never silently dropped', () => {
+    expect(refBased.verdict).toMatch(/^PASSED/);
+    expect(refBased.exitCode).toBe(0);
+    expect(refBased.refExcludedKinds.map((e) => e.kind)).toContain('custom-check');
+  });
+});
+
+describe('the parity machinery itself (injection-guarded)', () => {
+  // A hand-built projection so these tests run without analyzers.
+  const base: VerdictProjection = {
+    surface: 'a',
+    verdict: 'PASSED',
+    exitCode: 0,
+    blocking: [{ kind: 'secret', file: 'x.ts', id: 'deadbeefdeadbeef' }],
+    blockingCount: 1,
+    warningCount: 2,
+    unattributable: 0,
+    notObserved: [{ kind: 'custom-check', count: 3 }],
+    refExcludedKinds: [{ kind: 'custom-check', currentCount: 3 }],
+    gates: { flow: 'absent', schema: 'absent', dup: 'absent', paired: 'absent' },
+  };
+  const asB = (p: VerdictProjection): VerdictProjection => ({ ...p, surface: 'b' });
+
+  it('identical projections produce zero diffs', () => {
+    expect(compareProjections(base, asB(base))).toEqual([]);
+  });
+
+  it('flags a verdict mismatch by name', () => {
+    const diffs = compareProjections(base, asB({ ...base, verdict: 'BLOCKED', exitCode: 1 }));
+    expect(diffs.some((d) => d.startsWith('verdict:'))).toBe(true);
+    expect(diffs.some((d) => d.startsWith('exitCode:'))).toBe(true);
+  });
+
+  it('flags a dropped blocking finding', () => {
+    const diffs = compareProjections(base, asB({ ...base, blocking: [], blockingCount: 0 }));
+    expect(diffs.some((d) => d.startsWith('blocking:'))).toBe(true);
+  });
+
+  it('flags an identity mismatch even when counts agree', () => {
+    const mutated = asB({
+      ...base,
+      blocking: [{ kind: 'secret', file: 'x.ts', id: 'feedfacefeedface' }],
+    });
+    const diffs = compareProjections(base, mutated);
+    expect(diffs.some((d) => d.startsWith('blocking:'))).toBe(true);
+  });
+
+  it('flags a silently-dropped disclosure (notObserved / refExcludedKinds)', () => {
+    expect(
+      compareProjections(base, asB({ ...base, notObserved: [] })).some((d) =>
+        d.startsWith('notObserved:'),
+      ),
+    ).toBe(true);
+    expect(
+      compareProjections(base, asB({ ...base, refExcludedKinds: [] })).some((d) =>
+        d.startsWith('refExcludedKinds:'),
+      ),
+    ).toBe(true);
+  });
+
+  it('flags an additive-gate outcome drift', () => {
+    const diffs = compareProjections(
+      base,
+      asB({ ...base, gates: { ...base.gates, flow: 'blocks' } }),
+    );
+    expect(diffs.some((d) => d.startsWith('gates.flow:'))).toBe(true);
+  });
+
+  it('assertSurfacesAgree THROWS on a drifted surface, naming scenario and field', async () => {
+    const scenario: BuiltScenario = { name: 'synthetic', dir: '/nonexistent', baseRef: 'x' };
+    const drifted = replaySurface('drifted', {
+      ...base,
+      blocking: [],
+      blockingCount: 0,
+    });
+    await expect(
+      assertSurfacesAgree(scenario, [replaySurface('reference', base), drifted]),
+    ).rejects.toThrow(/parity violation on scenario 'synthetic'.*blocking/s);
+  });
+
+  it('projectGuardrailResult derives verdict/exit ONLY through verdictCounts', () => {
+    // Compile-time + shape guard: the projection function exists and its
+    // output carries exitCode 0|1 — the field every consumer must read
+    // instead of re-deriving from `blocks`. (The behavioral pin lives in
+    // attribution-gap.test.ts; this keeps the projection on that path.)
+    expect(typeof projectGuardrailResult).toBe('function');
+  });
+});

--- a/test/gate/parity-harness.ts
+++ b/test/gate/parity-harness.ts
@@ -1,0 +1,314 @@
+/**
+ * The gate-vs-guardrail parity harness (4.4.0 WP0).
+ *
+ * # Why this exists (written BEFORE the engine extraction, on purpose)
+ *
+ * 4.4.0 extracts the guardrail-check orchestration into one engine
+ * (`src/gate/engine.ts`) and adds a second consumer surface (`gate <dir>`).
+ * That is exactly the shape CLAUDE.md Rule 2.30 warns about: one concept
+ * (judge a subject against a prior under a policy) about to gain two
+ * consumers holding different data shapes. The only net that catches
+ * semantic divergence between them is a parity test that runs BOTH
+ * surfaces on shared fixtures and asserts they agree — so the net is
+ * written first, freezing today's `runGuardrailCheck` behavior as the
+ * reference, and the `gate` surface joins the SAME scenario matrix when
+ * it lands (WP2).
+ *
+ * # What a surface is
+ *
+ * A `GateSurface` turns a built scenario (a repo with a known base state
+ * and a known current state) into a `VerdictProjection` — the comparable
+ * core of a verdict: the verdict word + exit code (derived ONLY through
+ * `verdictCounts`, never `blocks ? 1 : 0`), the blocking finding set with
+ * durable identities, the disclosure surfaces (not-observed, ref-excluded
+ * kinds, attribution gaps), and the additive-gate outcomes. Two surfaces
+ * agree when `compareProjections` returns no diffs.
+ *
+ * Identity fields (`id`) are environment-independent by construction
+ * (Rule 9), which is what makes cross-surface comparison sound.
+ */
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createBaseline } from '../../src/baseline/create';
+import { runGuardrailCheck } from '../../src/baseline/check';
+import type { GuardrailCheckResult } from '../../src/baseline/check';
+import { verdictCounts } from '../../src/baseline/check-renderers';
+import { trustedLocalContext } from '../../src/analysis-trust';
+
+/** The tag every scenario stamps on its base state. Ref-shaped surfaces
+ *  (guardrail ref-based today, gate tree-baseline later) resolve the prior
+ *  from it; committed-mode surfaces have already captured a baseline file
+ *  at the same state. */
+export const PARITY_BASE_REF = 'parity-base';
+
+/** One finding that counts toward the verdict, projected to its durable,
+ *  surface-independent core. */
+export interface ProjectedFinding {
+  readonly kind: string;
+  readonly file?: string;
+  /** Canonical fingerprint (Rule 9) — the durable identity both surfaces
+   *  must mint identically for the same finding on the same tree. */
+  readonly id?: string;
+}
+
+/** The comparable core of one surface's verdict over one scenario. */
+export interface VerdictProjection {
+  readonly surface: string;
+  readonly verdict: string;
+  readonly exitCode: 0 | 1;
+  /** Pair-level blocking findings, sorted by (kind, file, id). Additive-gate
+   *  blocks are counted in `blockingCount` (via `verdictCounts`) and shown
+   *  per-gate in `gates`. */
+  readonly blocking: ReadonlyArray<ProjectedFinding>;
+  /** Total blocking tally exactly as the verdict layer counts it. */
+  readonly blockingCount: number;
+  readonly warningCount: number;
+  readonly unattributable: number;
+  /** Rule 19 removed-direction disclosures, projected to kind+count. */
+  readonly notObserved: ReadonlyArray<{ readonly kind: string; readonly count: number }>;
+  /** Kinds structurally excluded from a ref-based diff (with the dropped
+   *  current-side count) — a DECLARED difference between surfaces, so it is
+   *  part of the projection: a surface that silently drops a kind instead
+   *  of disclosing it must NOT compare equal to one that disclosed. */
+  readonly refExcludedKinds: ReadonlyArray<{
+    readonly kind: string;
+    readonly currentCount: number;
+  }>;
+  /** Additive-gate outcomes, one summary word per gate. */
+  readonly gates: {
+    readonly flow: string;
+    readonly schema: string;
+    readonly dup: string;
+    readonly paired: string;
+  };
+}
+
+/** Summarize an additive gate outcome into one comparable word. */
+function gateWord(
+  g: { ran?: boolean; skipped?: string; blocks?: boolean; warns?: boolean } | undefined,
+): string {
+  if (!g) return 'absent';
+  if (g.blocks) return 'blocks';
+  if (g.warns) return 'warns';
+  if (g.ran === false) return `skip:${g.skipped ?? 'unknown'}`;
+  return 'ran-clean';
+}
+
+/** Project a `GuardrailCheckResult` onto the comparable core. */
+export function projectGuardrailResult(
+  surface: string,
+  result: GuardrailCheckResult,
+): VerdictProjection {
+  const counts = verdictCounts(result);
+  const blocking = result.pairs
+    .filter((p) => p.classification.blocks)
+    .map((p) => ({
+      kind: p.kind as string,
+      file: p.file,
+      id: p.pair.currentId ?? p.pair.priorId,
+    }))
+    .sort(
+      (a, b) =>
+        a.kind.localeCompare(b.kind) ||
+        (a.file ?? '').localeCompare(b.file ?? '') ||
+        (a.id ?? '').localeCompare(b.id ?? ''),
+    );
+  return {
+    surface,
+    verdict: counts.verdict,
+    exitCode: counts.exitCode,
+    blocking,
+    blockingCount: counts.blocking,
+    warningCount: counts.warning,
+    unattributable: counts.unattributable,
+    notObserved: result.notObserved
+      .map((n) => ({ kind: n.kind as string, count: n.count }))
+      .sort((a, b) => a.kind.localeCompare(b.kind)),
+    refExcludedKinds: result.refExcludedKinds
+      .map((e) => ({ kind: e.kind as string, currentCount: e.currentCount }))
+      .sort((a, b) => a.kind.localeCompare(b.kind)),
+    gates: {
+      flow: gateWord(result.flowGate),
+      schema: gateWord(result.schemaDriftGate),
+      dup: gateWord(result.dupGate),
+      paired: gateWord(result.pairedGate),
+    },
+  };
+}
+
+/**
+ * Compare two projections field by field. Empty array = the surfaces agree.
+ * Each diff names the field and both values so a parity failure reads as a
+ * diagnosis, not a blob diff. The `surface` label itself is NOT compared.
+ */
+export function compareProjections(a: VerdictProjection, b: VerdictProjection): string[] {
+  const diffs: string[] = [];
+  const scalar = (field: string, av: unknown, bv: unknown) => {
+    if (av !== bv) diffs.push(`${field}: ${a.surface}=${String(av)} vs ${b.surface}=${String(bv)}`);
+  };
+  scalar('verdict', a.verdict, b.verdict);
+  scalar('exitCode', a.exitCode, b.exitCode);
+  scalar('blockingCount', a.blockingCount, b.blockingCount);
+  scalar('warningCount', a.warningCount, b.warningCount);
+  scalar('unattributable', a.unattributable, b.unattributable);
+  const list = (field: string, av: ReadonlyArray<unknown>, bv: ReadonlyArray<unknown>) => {
+    const as = JSON.stringify(av);
+    const bs = JSON.stringify(bv);
+    if (as !== bs) diffs.push(`${field}: ${a.surface}=${as} vs ${b.surface}=${bs}`);
+  };
+  list('blocking', a.blocking, b.blocking);
+  list('notObserved', a.notObserved, b.notObserved);
+  list('refExcludedKinds', a.refExcludedKinds, b.refExcludedKinds);
+  scalar('gates.flow', a.gates.flow, b.gates.flow);
+  scalar('gates.schema', a.gates.schema, b.gates.schema);
+  scalar('gates.dup', a.gates.dup, b.gates.dup);
+  scalar('gates.paired', a.gates.paired, b.gates.paired);
+  return diffs;
+}
+
+/** A built scenario: one repo whose base state is tagged `PARITY_BASE_REF`
+ *  (and captured as a committed baseline) and whose current state is HEAD. */
+export interface BuiltScenario {
+  readonly name: string;
+  readonly dir: string;
+  readonly baseRef: string;
+}
+
+/** One way of judging a scenario. `guardrail check` modes today; the
+ *  `gate` surface joins in WP2 with NO change to the scenario matrix. */
+export interface GateSurface {
+  readonly name: string;
+  run(scenario: BuiltScenario): Promise<VerdictProjection>;
+}
+
+/** Committed-full guardrail check — the baseline file captured at base. */
+export const guardrailCommittedSurface: GateSurface = {
+  name: 'guardrail-committed',
+  async run(scenario) {
+    const result = await runGuardrailCheck({ cwd: scenario.dir, trust: trustedLocalContext() });
+    return projectGuardrailResult(this.name, result);
+  },
+};
+
+/** Ref-based guardrail check — the prior gathered from the base tag. */
+export const guardrailRefBasedSurface: GateSurface = {
+  name: 'guardrail-ref-based',
+  async run(scenario) {
+    const result = await runGuardrailCheck({
+      cwd: scenario.dir,
+      trust: trustedLocalContext(),
+      cliMode: 'ref-based',
+      cliRef: scenario.baseRef,
+    });
+    return projectGuardrailResult(this.name, result);
+  },
+};
+
+/**
+ * Run every surface over the scenario and assert pairwise agreement.
+ * Throws with the full diff list on the first disagreement — the parity
+ * failure IS the test failure. Returns the projections so callers can
+ * additionally pin characterization expectations against them.
+ */
+export async function assertSurfacesAgree(
+  scenario: BuiltScenario,
+  surfaces: ReadonlyArray<GateSurface>,
+): Promise<VerdictProjection[]> {
+  const projections: VerdictProjection[] = [];
+  for (const surface of surfaces) {
+    projections.push(await surface.run(scenario));
+  }
+  for (let i = 1; i < projections.length; i++) {
+    const diffs = compareProjections(projections[0], projections[i]);
+    if (diffs.length > 0) {
+      throw new Error(
+        `parity violation on scenario '${scenario.name}' between ` +
+          `${projections[0].surface} and ${projections[i].surface}:\n  ${diffs.join('\n  ')}`,
+      );
+    }
+  }
+  return projections;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario builders. Each produces a temp git repo whose base state carries
+// BOTH prior representations (a committed baseline file AND the base tag),
+// so every surface judges the same (prior, current) pair.
+// ---------------------------------------------------------------------------
+
+function initRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-parity-'));
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+  return dir;
+}
+
+function commitAll(dir: string, message: string): void {
+  execFileSync('git', ['add', '.'], { cwd: dir });
+  execFileSync('git', ['commit', '-q', '-m', message], { cwd: dir });
+}
+
+async function sealBaseState(dir: string): Promise<void> {
+  // Capture the committed-mode prior FIRST, then commit the artifacts it
+  // wrote (.dxkit/baselines) so the tagged base tree is exactly the tree
+  // the baseline describes.
+  await createBaseline({ cwd: dir });
+  commitAll(dir, 'baseline capture');
+  execFileSync('git', ['tag', PARITY_BASE_REF], { cwd: dir });
+}
+
+/** Base == current, nothing seeded. Expected: PASSED everywhere. */
+export async function buildCleanScenario(): Promise<BuiltScenario> {
+  const dir = initRepo();
+  writeFileSync(join(dir, 'README.md'), '# parity fixture\n');
+  writeFileSync(join(dir, 'index.ts'), "export const greeting = 'hello';\n");
+  commitAll(dir, 'base');
+  await sealBaseState(dir);
+  return { name: 'clean', dir, baseRef: PARITY_BASE_REF };
+}
+
+/** A credential-shaped literal added AFTER the base state. Expected:
+ *  BLOCKED with one net-new secret finding under the default preset. */
+export async function buildNetNewSecretScenario(): Promise<BuiltScenario> {
+  const dir = initRepo();
+  writeFileSync(join(dir, 'README.md'), '# parity fixture\n');
+  writeFileSync(join(dir, 'index.ts'), "export const greeting = 'hello';\n");
+  commitAll(dir, 'base');
+  await sealBaseState(dir);
+  // Built at runtime so THIS repo's own guardrail never sees a credential
+  // literal in the harness source (same discipline as grep-secrets.test.ts).
+  const secretValue = ['hunter', '22', 'live', 'value'].join('-');
+  writeFileSync(
+    join(dir, 'config.ts'),
+    `const password = '${secretValue}';\nexport { password };\n`,
+  );
+  commitAll(dir, 'introduce credential');
+  return { name: 'net-new-secret', dir, baseRef: PARITY_BASE_REF };
+}
+
+/** A user custom check failing at base AND current. Expected: persisted
+ *  (grandfathered) in committed mode; structurally excluded + DISCLOSED in
+ *  ref-based mode (REF_UNRELIABLE_KINDS) — a declared surface difference,
+ *  characterized per surface rather than asserted identical. */
+export async function buildPersistedCheckScenario(): Promise<BuiltScenario> {
+  const dir = initRepo();
+  writeFileSync(join(dir, 'README.md'), '# parity fixture\n');
+  mkdirSync(join(dir, '.dxkit'), { recursive: true });
+  writeFileSync(
+    join(dir, '.dxkit', 'policy.json'),
+    JSON.stringify(
+      {
+        checks: [{ name: 'custom:always-fail', command: ['node', '-e', 'process.exit(1)'] }],
+      },
+      null,
+      2,
+    ),
+  );
+  commitAll(dir, 'base');
+  await sealBaseState(dir);
+  return { name: 'persisted-custom-check', dir, baseRef: PARITY_BASE_REF };
+}


### PR DESCRIPTION
## What

The characterization/parity harness for the 4.4.0 engine extraction, written BEFORE any extraction (the anti-drift discipline: a refactor that gives one concept two consumers needs its parity net first).

- `test/gate/parity-harness.ts` — `VerdictProjection` (the comparable core of a verdict: verdict word + exit code via `verdictCounts` only, blocking finding identities, notObserved / refExcludedKinds disclosures, additive-gate outcomes), `GateSurface` seam, `compareProjections` / `assertSurfacesAgree`, and three scenario builders (clean, net-new secret, persisted custom check) that seal a base state as BOTH a committed baseline and a git tag so every surface judges the same (prior, current) pair.
- `test/gate/guardrail-parity.test.ts` — freezes today's behavior per scenario × mode, pins determinism across two runs (the P0-1 acceptance property), pins that committed and ref-based mint the SAME durable identity for the same finding, and injection-guards the comparator (a drifted surface fails loudly, field-named).

## Why now

WP1 extracts `runGuardrailCheck` orchestration into `src/gate/engine.ts`; WP2 adds the `gate` surface as consumer #2 of the same matrix. This net is what makes both changes provable no-ops for the existing surface.

## Verification

Full suite 5,466 green, lint/format/arch/slop/cross-ecosystem green, self-guardrail ref-based vs origin/main PASSED exit 0 (unmasked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)