### PR TITLE
feat(gate): fresh + tree-baseline priors, tree subjects, prior-class dispatch (4.4.0 WP2a)

### DIFF
--- a/.dxkit/allowlist.json
+++ b/.dxkit/allowlist.json
@@ -428,6 +428,14 @@
       "addedBy": "siddarth.ch1990@gmail.com",
       "addedAt": "2026-07-19",
       "expiresAt": "2026-10-17"
+    },
+    {
+      "fingerprint": "b464ed123cea6f77",
+      "kind": "secret",
+      "category": "false-positive",
+      "reason": "the KIND_DEFAULT_SEVERITY table's severity word for the secret kind (moved from check.ts to gate/observation.ts in the 4.4.0 engine split) — a record key named 'secret' with the value 'high', matched by the generic hardcoded-secret pattern; not a credential",
+      "addedBy": "siddarth.ch1990@gmail.com",
+      "addedAt": "2026-08-08"
     }
   ],
   "identityScheme": "v2"

--- a/src/analyzers/tools/salt.ts
+++ b/src/analyzers/tools/salt.ts
@@ -42,8 +42,16 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 /** Resolution path that produced the salt. Stamped on every baseline
- * file so the guardrail check knows what the matcher needs. */
-export type SaltMode = 'env-var' | 'file' | 'deterministic';
+ * file so the guardrail check knows what the matcher needs.
+ * `'unavailable'` is the DECLARED no-salt state (4.4.0 WP2): a bare
+ * tree with no git root, no salt file, no env var — the scan proceeds
+ * (a gate on a generated package must not demand git), the located
+ * `secret` kind still gates in full, and only the salt-dependent
+ * `secret-hmac` companions are skipped, recorded on the envelope
+ * rather than silently absent. `resolveSalt` never returns it (hard
+ * error preserved for baseline commands); only
+ * `resolveSaltOrUnavailable` does. */
+export type SaltMode = 'env-var' | 'file' | 'deterministic' | 'unavailable';
 
 export interface ResolvedSalt {
   readonly mode: SaltMode;
@@ -96,6 +104,22 @@ export function resolveSalt(cwd: string): ResolvedSalt {
       'Cannot derive a baseline salt: not a git repository (or no root commit reachable). ' +
         'Set DXKIT_BASELINE_SALT or initialize a git repo before running baseline commands.',
     );
+  }
+}
+
+/**
+ * Fail-open sibling of `resolveSalt` for the SCAN path (4.4.0 WP2):
+ * returns the declared `'unavailable'` state instead of throwing, so a
+ * gate over a bare tree can run. Callers that REQUIRE a salt (the
+ * committed `baseline create` write — its HMAC companions must be
+ * re-derivable at check time) assert on the mode and surface
+ * `resolveSalt`'s original error; the one message lives there.
+ */
+export function resolveSaltOrUnavailable(cwd: string): ResolvedSalt {
+  try {
+    return resolveSalt(cwd);
+  } catch {
+    return { mode: 'unavailable', salt: '' };
   }
 }
 

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -26,6 +26,7 @@
  */
 
 import * as logger from '../logger';
+import type { BaselineMode } from './modes';
 import type {
   AnchorSourceDisclosure,
   ClassifiedPair,
@@ -1262,12 +1263,14 @@ export interface GuardrailJsonPayload {
     /** D4d: under the `branch` anchor transport, which file actually loaded —
      *  the side-branch anchor, or the tree copy as a disclosed fallback. */
     readonly anchorSource?: AnchorSourceDisclosure;
-    /** Resolved baseline mode (`committed-full` / `committed-
-     *  sanitized` / `ref-based`) + its audit trail. Surfaced so
+    /** Resolved prior mode (committed / ref-based / the gate-only
+     *  fresh + tree-baseline priors) + its audit trail. Surfaced so
      *  agents + dashboards can see WHY the run picked a given
-     *  posture without re-deriving from policy + visibility. */
+     *  posture without re-deriving from policy + visibility. Typed off
+     *  the ONE mode union in modes.ts — never a re-listed literal set
+     *  (the pre-4.4.0 shape silently excluded new modes). */
     readonly mode: {
-      readonly value: 'committed-full' | 'committed-sanitized' | 'ref-based';
+      readonly value: BaselineMode;
       readonly source: string;
       readonly explanation: string;
       readonly ref?: string;

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -49,7 +49,7 @@ import { PRODUCERS, runProducers, runRecallContexts } from './producers';
 import type { ProducerContext } from './producers';
 import { recallInputsUnion } from './recall';
 import type { RecallMap } from './recall';
-import { resolveSalt } from '../analyzers/tools/salt';
+import { resolveSalt, resolveSaltOrUnavailable } from '../analyzers/tools/salt';
 import type { SaltMode } from '../analyzers/tools/salt';
 import { sanitizeFile } from './sanitize';
 import { resolveEffectiveAllowlist } from '../allowlist/effective';
@@ -281,11 +281,12 @@ export async function gatherCurrentScan(options: {
     root: cwd,
   };
 
-  // Salt resolves once; threaded into every producer that needs to
-  // compute HMACs. The mode lands on the baseline file so the
-  // matcher can re-derive the same salt at check time (or warn when
-  // it can't).
-  const { mode: saltMode, salt } = resolveSalt(cwd);
+  // Salt resolves once; threaded into every HMAC-computing producer, mode
+  // stamped on the file. Fail-open (4.4.0 WP2): a gate over a bare tree has
+  // no git root, so the scan proceeds under the DECLARED `unavailable` mode
+  // — located secrets still gate in full; only the HMAC companions are
+  // skipped. `createBaseline` re-asserts a real salt below.
+  const { mode: saltMode, salt } = resolveSaltOrUnavailable(cwd);
 
   // Build the producer context once. Every analyzer's gather runs
   // here (or earlier inside readOrBuildAnalysisResult) so producers
@@ -435,6 +436,10 @@ export async function createBaseline(
     // surface a clear "ref-based mode active; no file written" log.
     return { mode };
   }
+
+  // A COMMITTED baseline needs a re-derivable salt (its HMAC companions must
+  // compute identically at check time) — the write path keeps the hard error.
+  resolveSalt(cwd);
 
   const filePath = pathForBaseline(cwd, name);
   if (!options.force && fs.existsSync(filePath)) {

--- a/src/baseline/modes.ts
+++ b/src/baseline/modes.ts
@@ -70,19 +70,79 @@ import { execSync } from 'child_process';
 import { detectRepoVisibility } from './visibility';
 import type { RepoVisibility } from './visibility';
 
-/** The three modes. Keep this union ordered the same way as
- *  `BASELINE_MODES` (declared below) so help text + arch checks
- *  match. */
-export type BaselineMode = 'committed-full' | 'committed-sanitized' | 'ref-based';
+/** The five modes. The first three are the REPO modes a guardrail can
+ *  resolve (CLI flag / policy / visibility default — keep them ordered
+ *  the same way as `BASELINE_MODES` below so help text + arch checks
+ *  match). The last two are GATE-ONLY priors (4.4.0 WP2), constructed
+ *  exclusively by `resolveGateMode` for the `gate` surface:
+ *
+ *   - **`fresh`** — the empty prior. Everything in the subject tree is
+ *     net-new BY CONSTRUCTION and the verdict says so; Rule 19's drift
+ *     machinery is inapplicable-by-construction (the prior envelope IS
+ *     the current envelope), never disabled.
+ *   - **`tree-baseline`** — the prior is a full gather of a supplied
+ *     directory (`ResolvedMode.baselineDir`): the generated-vs-edited
+ *     diff (H2). Shares the ref-based arm's gather + projection.
+ */
+export type BaselineMode =
+  | 'committed-full'
+  | 'committed-sanitized'
+  | 'ref-based'
+  | 'fresh'
+  | 'tree-baseline';
 
-/** Canonical enumeration of the mode strings. Consumers wanting to
- *  iterate every mode (CLI flag validation, help text, doctor)
- *  import this rather than re-listing the union members. */
+/** Canonical enumeration of the REPO mode strings — the modes a
+ *  guardrail surface may select via `--mode` / `baseline.mode` policy.
+ *  Consumers wanting to iterate them (CLI flag validation, help text,
+ *  doctor, the policy schema enum) import this rather than re-listing
+ *  the union members. The gate-only priors are deliberately NOT here:
+ *  a repo policy cannot pin `fresh`, and `guardrail check --mode=fresh`
+ *  is a flag error — they exist only through `resolveGateMode`. */
 export const BASELINE_MODES: ReadonlyArray<BaselineMode> = Object.freeze([
   'committed-full',
   'committed-sanitized',
   'ref-based',
 ]);
+
+/** The gate-only prior modes (see `BaselineMode`). */
+export const GATE_ONLY_MODES: ReadonlyArray<BaselineMode> = Object.freeze([
+  'fresh',
+  'tree-baseline',
+]);
+
+/**
+ * How a mode's PRIOR side comes into being — the classification every
+ * engine branch keys on (never the mode strings themselves, so a new
+ * mode declares its semantics once here and every branch follows):
+ *
+ *   - `'committed'` — read from a committed baseline file (anchor
+ *     transport aware). Scheme-guarded; capture-time disclosures
+ *     (deferredCapture, baseline-suspect) apply.
+ *   - `'dir-gathered'` — re-gathered by THIS run from a directory (a
+ *     materialized git ref, or a supplied tree). Same-environment and
+ *     always current-scheme, so scheme/drift guards don't apply — but
+ *     the directory lacks build artifacts, so the artifact-dependent
+ *     kinds are excluded from both sides and DISCLOSED
+ *     (`partitionForRefBasedDiff`).
+ *   - `'empty'` — no prior at all (`fresh`). Nothing is excluded and
+ *     nothing can drift; every finding is `added` by construction and
+ *     the verdict declares it.
+ */
+export type PriorClass = 'committed' | 'dir-gathered' | 'empty';
+
+/** The one mode → prior-class mapping. */
+export function priorClassOf(mode: BaselineMode): PriorClass {
+  switch (mode) {
+    case 'committed-full':
+    case 'committed-sanitized':
+      return 'committed';
+    case 'ref-based':
+    case 'tree-baseline':
+      return 'dir-gathered';
+    case 'fresh':
+      return 'empty';
+  }
+}
 
 /**
  * WHERE a committed baseline's anchor is stored — see
@@ -146,7 +206,8 @@ export type ModeSource =
   | 'auto-public'
   | 'auto-private'
   | 'auto-internal'
-  | 'auto-unknown';
+  | 'auto-unknown'
+  | 'gate';
 
 /** Resolution outcome carrying the chosen mode + the audit trail
  *  + the resolved ref (for ref-based). Consumers read
@@ -161,6 +222,10 @@ export interface ResolvedMode {
    *  policy, or the repo's default-branch upstream tracking ref.
    *  Undefined when mode is not ref-based. */
   readonly ref?: string;
+  /** Directory whose gather is the prior when `mode === 'tree-baseline'`
+   *  (the `gate --baseline <dir>` arm). Absolute path. Undefined for
+   *  every other mode. */
+  readonly baselineDir?: string;
 }
 
 /** Input shape for the resolver. Every field is optional so the
@@ -256,6 +321,30 @@ export function probeOriginHeadRef(cwd: string): string | undefined {
   }
 }
 
+/**
+ * Resolve the prior mode for a `gate` surface run (4.4.0 WP2). Kept
+ * beside `resolveBaselineMode` on purpose — Rule 11: mode picking has
+ * ONE home, and the gate-only priors exist only through this door.
+ * `baselineDir` supplied → `tree-baseline` (generated-vs-edited diff);
+ * absent → `fresh` (the empty prior; everything net-new by
+ * construction).
+ */
+export function resolveGateMode(opts: { readonly baselineDir?: string }): ResolvedMode {
+  if (opts.baselineDir !== undefined) {
+    return {
+      mode: 'tree-baseline',
+      source: 'gate',
+      explanation: `mode=tree-baseline (gate --baseline ${opts.baselineDir})`,
+      baselineDir: opts.baselineDir,
+    };
+  }
+  return {
+    mode: 'fresh',
+    source: 'gate',
+    explanation: 'mode=fresh (gate: empty prior — everything net-new by construction)',
+  };
+}
+
 function explanationFor(mode: BaselineMode, source: ModeSource): string {
   switch (source) {
     case 'cli':
@@ -270,6 +359,10 @@ function explanationFor(mode: BaselineMode, source: ModeSource): string {
       return `mode=${mode} (auto: gh detected an internal repo)`;
     case 'auto-unknown':
       return `mode=${mode} (auto: visibility not detectable via gh; defaulting to private posture)`;
+    case 'gate':
+      // resolveGateMode stamps its own explanation; this arm exists for
+      // exhaustiveness only.
+      return `mode=${mode} (gate surface)`;
   }
 }
 

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -246,6 +246,12 @@ const SECRET_HMAC_PRODUCER: BaselineProducer = {
   name: 'secret-hmac',
   contributes: ['secret-hmac'],
   produce(ctx) {
+    // Salt mode `unavailable` (a bare tree — 4.4.0 WP2): no HMAC can be
+    // computed, so the companion kind is skipped, DECLARED on the
+    // envelope (`saltMode: 'unavailable'`). The located `secret` twin
+    // still gates in full — the companion is cross-file relocation
+    // assist, never the gate itself.
+    if (ctx.salt === '') return [];
     return rawSecretsToBaselineEntries({ rawSecrets: ctx.rawSecrets, salt: ctx.salt });
   },
   recallContexts(ctx) {

--- a/src/gate/context.ts
+++ b/src/gate/context.ts
@@ -11,6 +11,7 @@ import type { SecurityAggregate } from '../analyzers/security/aggregator';
 import type { CurrentScan } from '../baseline/create';
 import type { BaselineFile } from '../baseline/baseline-file';
 import { diffCoverage } from '../baseline/coverage';
+import { priorClassOf } from '../baseline/modes';
 import type { ResolvedMode } from '../baseline/modes';
 import { diffRecall } from '../baseline/recall';
 import { isSanitized } from '../baseline/sanitize';
@@ -127,16 +128,18 @@ export function diffEnvelopes(
     recallDrift,
     ...(baseline.capturedIn ? { baselineCapturedIn: baseline.capturedIn } : {}),
     ...(refreshLaneInstalled !== undefined ? { refreshLaneInstalled } : {}),
-    // Ref-based mode: the prior side is a fresh gather in a bare worktree,
-    // so its "coverage" records artifact-dependent tools (a node_modules
-    // linter, the coverage report) as missing BY CONSTRUCTION — not as a
-    // fact about any capture. Diffing that against the real tree produced a
-    // guaranteed-noise warning ("eslint was NOT available at baseline …
-    // findings may surface as new") for categories the ref-based diff
-    // ALREADY excludes and discloses (REF_UNRELIABLE_KINDS). Committed
-    // modes keep the diff — there it is load-bearing (a baseline captured
-    // without gitleaks genuinely never baselined secrets).
-    coverageDrift: mode === 'ref-based' ? [] : diffCoverage(baseline.coverage, current.coverage),
+    // Non-committed prior classes: the prior side is a fresh gather (a bare
+    // worktree, a supplied tree) or empty, so its "coverage" records
+    // artifact-dependent tools (a node_modules linter, the coverage report)
+    // as missing BY CONSTRUCTION — not as a fact about any capture. Diffing
+    // that against the real tree produced a guaranteed-noise warning
+    // ("eslint was NOT available at baseline … findings may surface as new")
+    // for categories the dir-gathered diff ALREADY excludes and discloses
+    // (REF_UNRELIABLE_KINDS). Committed priors keep the diff — there it is
+    // load-bearing (a baseline captured without gitleaks genuinely never
+    // baselined secrets).
+    coverageDrift:
+      priorClassOf(mode) !== 'committed' ? [] : diffCoverage(baseline.coverage, current.coverage),
   };
 }
 

--- a/src/gate/engine.ts
+++ b/src/gate/engine.ts
@@ -29,6 +29,7 @@ import { gatherCurrentScan } from '../baseline/create';
 import { entriesToLocated } from '../baseline/entry-to-located';
 import { gitAwareMatch } from '../baseline/git-aware-match';
 import type { LocatedIdentity } from '../baseline/git-aware-match';
+import { priorClassOf } from '../baseline/modes';
 import type { ResolvedMode } from '../baseline/modes';
 import type { BrownfieldPolicy } from '../baseline/policy';
 import { FULL_SCOPE, scopeForPolicy, scopeForRefBasedDiff } from '../baseline/gather-scope';
@@ -57,7 +58,7 @@ import { entryToAllowlistable } from '../baseline/allowlist-match';
 import { classifyPairs } from './classify-pairs';
 import { diffEnvelopes, keepUnderChangedOnly, pairBlocks } from './context';
 import { collectNotObservedDisclosures, partitionForRefBasedDiff } from './observation';
-import { acquirePrior, assertPriorSchemeComparable } from './prior';
+import { acquirePrior, assertPriorSchemeComparable, emptyPriorFromScan } from './prior';
 import type { GuardrailCheckResult } from './result';
 import type { GateEngineOptions, GateSubject } from './types';
 
@@ -74,7 +75,16 @@ export async function runGate(
   policy: BrownfieldPolicy,
   options: GateEngineOptions,
 ): Promise<GuardrailCheckResult> {
-  const cwd = subject.cwd;
+  // The analysis root. A `tree` subject is a bare directory: every
+  // git-derived signal below (changed-line attribution, relocation
+  // matching, base-ref gates) degrades DECLARATIVELY — attribution reads
+  // UNKNOWN (never a demotion), the matcher falls back to set-diff, and
+  // the base-ref gates skip with `no-base-ref` disclosed.
+  const cwd = subject.kind === 'repo' ? subject.cwd : subject.dir;
+  // Every prior-semantics branch keys on the declared class of the mode
+  // (committed / dir-gathered / empty), never on mode strings — a new
+  // mode declares its class once in modes.ts and every branch follows.
+  const priorClass = priorClassOf(mode.mode);
 
   // Incremental scanning in ref-based mode: the changed set is the diff of
   // the ref against the working HEAD, known upfront from `mode.ref`. We scope
@@ -131,7 +141,7 @@ export async function runGate(
   // kinds are recorded so the "not gated in ref-based mode" disclosure
   // survives the optimization.
   let refScopeSkippedKinds: ReadonlyArray<BaselineEntry['kind']> = [];
-  if (mode.mode === 'ref-based') {
+  if (priorClass === 'dir-gathered') {
     const adjusted = scopeForRefBasedDiff(gatherScope);
     gatherScope = adjusted.scope;
     refScopeSkippedKinds = adjusted.skippedKinds;
@@ -139,9 +149,14 @@ export async function runGate(
 
   // Acquire the prior side through the ONE seam, then guard comparability
   // (a stale-scheme committed baseline refuses with the remedy named).
-  const prior = await acquirePrior(cwd, mode, options, refIncrementalFiles, gatherScope);
-  const { baseline, baselinePath, anchorSource } = prior;
-  assertPriorSchemeComparable(prior, mode);
+  // The `fresh` (empty) prior is the one arm deferred: it derives from
+  // the current scan, so it's built right after the gather below —
+  // still by prior.ts, the one prior home.
+  const acquired =
+    priorClass === 'empty'
+      ? undefined
+      : await acquirePrior(cwd, mode, options, refIncrementalFiles, gatherScope);
+  if (acquired) assertPriorSchemeComparable(acquired, mode);
 
   const scope = gatherScope;
   // Incremental scanning: scope the current side's semgrep to changed files.
@@ -156,8 +171,8 @@ export async function runGate(
   const incrementalFiles =
     mode.mode === 'ref-based'
       ? refIncrementalFiles
-      : options.incremental && baseline.repo.commitSha
-        ? (computeChangedFiles(cwd, baseline.repo.commitSha) ?? undefined)
+      : options.incremental && acquired?.baseline.repo.commitSha
+        ? (computeChangedFiles(cwd, acquired.baseline.repo.commitSha) ?? undefined)
         : undefined;
   const current = await gatherCurrentScan({
     cwd,
@@ -173,13 +188,22 @@ export async function runGate(
     trust: options.trust,
   });
 
-  // In ref-based mode the prior side came from a detached worktree that
-  // can't gather the build-artifact-dependent kinds; drop them from both
-  // sides so the diff stays symmetric (see partitionForRefBasedDiff).
+  // The empty prior materializes here, from the current scan's own
+  // envelope (recall matches by construction — Rule 19 composes, never
+  // disabled). Every other class arrived through acquirePrior above.
+  const prior = acquired ?? emptyPriorFromScan(current, options.name);
+  const { baseline, baselinePath, anchorSource } = prior;
+
+  // Under a dir-gathered prior (a materialized ref, a supplied tree) the
+  // prior side can't produce the build-artifact-dependent kinds; drop
+  // them from both sides so the diff stays symmetric (see
+  // partitionForRefBasedDiff). An empty prior excludes NOTHING: there is
+  // no prior-side asymmetry to protect against, and the gate's whole
+  // point is full observation of the subject tree.
   const partitioned = partitionForRefBasedDiff(
     baseline.findings,
     current.findings,
-    mode.mode === 'ref-based',
+    priorClass === 'dir-gathered',
   );
   const { diffablePrior, diffableCurrent } = partitioned;
   // Union in the kinds whose analyzers were scope-skipped up front: their
@@ -274,7 +298,16 @@ export async function runGate(
   // committed baseline's anchor SHA in committed mode (flow-binding has no
   // committed prior side — the base flow model is gathered fresh from that
   // commit either way, so the gate works in both modes).
-  const flowBaseRef = mode.mode === 'ref-based' ? mode.ref : baseline.repo.commitSha;
+  // Gate-only priors have no base COMMIT at all (an empty prior, a bare
+  // supplied tree), so the base-ref gates skip with `no-base-ref` —
+  // disclosed by their own outcome shape, never silently run against a
+  // meaningless ref.
+  const flowBaseRef =
+    mode.mode === 'ref-based'
+      ? mode.ref
+      : priorClass === 'committed'
+        ? baseline.repo.commitSha
+        : undefined;
   const flowGate = await evaluateFlowGateForGuardrail({
     cwd,
     ...(flowBaseRef ? { baseRef: flowBaseRef } : {}),
@@ -344,7 +377,7 @@ export async function runGate(
   // mechanically correct either way; this reframes it and names the honest
   // remedy (workflow-aware via the provenance module).
   const baselineSuspect =
-    mode.mode !== 'ref-based'
+    priorClass === 'committed'
       ? detectBaselineSuspect({
           addedFiles: filteredPairs
             .filter((p) => p.classification.status === 'added' && p.file !== undefined)
@@ -412,9 +445,10 @@ export async function runGate(
       ? { commentDeferInstalled: true as const }
       : {}),
     // Capture-deferral (Rule 20): classes the committed baseline could not
-    // observe at capture. Committed modes only — ref-based has no committed
-    // baseline to complete, so the "completing on CI" framing does not apply.
-    ...(mode.mode !== 'ref-based' && baseline.deferred && baseline.deferred.length > 0
+    // observe at capture. Committed prior class only — a re-gathered or
+    // empty prior has no committed baseline to complete, so the
+    // "completing on CI" framing does not apply.
+    ...(priorClass === 'committed' && baseline.deferred && baseline.deferred.length > 0
       ? { deferredCapture: baseline.deferred }
       : {}),
     ...(flowGate.ran || flowGate.skipped !== 'no-base-ref' ? { flowGate } : {}),

--- a/src/gate/observation.ts
+++ b/src/gate/observation.ts
@@ -8,6 +8,7 @@
  */
 
 import type { BaselineEntry, FindingId, FindingSeverity } from '../baseline/types';
+import { priorClassOf } from '../baseline/modes';
 import type { ResolvedMode } from '../baseline/modes';
 import type { GatherScope } from '../baseline/gather-scope';
 import { KIND_OBSERVATION_SCOPE } from '../baseline/gather-scope';
@@ -19,10 +20,12 @@ import type { ClassifiedPair, GuardrailCheckResult, NotObservedDisclosure } from
  * removed-direction attribution reads for scope- and scanner-level causes
  * (`custom-check` has its own richer record at the seam, `CustomChecksUnobserved`).
  *
- * Committed modes only: a ref-based diff gathers BOTH sides in this same
- * environment, so an un-run scanner produces zero findings on each and no
- * removed pair exists to mislabel (and the structurally-excluded kinds carry
- * their own `refExcludedKinds` disclosure).
+ * Committed prior class only: a re-gathered prior (a materialized ref, a
+ * supplied tree) diffs BOTH sides in this same environment, so an un-run
+ * scanner produces zero findings on each and no removed pair exists to
+ * mislabel (and the structurally-excluded kinds carry their own
+ * `refExcludedKinds` disclosure); an empty prior has no removed direction
+ * at all.
  *
  * Two causes, in order:
  *   1. the kind's gather was scoped out (`KIND_OBSERVATION_SCOPE`);
@@ -38,7 +41,7 @@ export function kindNotObservedReason(
     readonly provenance: SecurityAggregate['provenance'];
   },
 ): string | undefined {
-  if (ctx.mode === 'ref-based') return undefined;
+  if (priorClassOf(ctx.mode) !== 'committed') return undefined;
   const offFlag = KIND_OBSERVATION_SCOPE[kind].find((flag) => !ctx.scope[flag]);
   if (offFlag !== undefined) {
     return `not gathered this run (the ${offFlag} gather is outside this run's scope)`;

--- a/src/gate/prior.ts
+++ b/src/gate/prior.ts
@@ -30,14 +30,15 @@
 
 import * as fs from 'fs';
 import { dxkitCli } from '../self-invocation';
-import { scanToBaselineFile } from '../baseline/create';
+import { gatherCurrentScan, scanToBaselineFile } from '../baseline/create';
+import type { CurrentScan } from '../baseline/create';
 import {
   DEFAULT_BASELINE_NAME,
   pathForBaseline,
   readBaselineFile,
 } from '../baseline/baseline-file';
 import type { BaselineFile } from '../baseline/baseline-file';
-import { DEFAULT_ANCHOR_REF } from '../baseline/modes';
+import { DEFAULT_ANCHOR_REF, priorClassOf } from '../baseline/modes';
 import type { ResolvedMode } from '../baseline/modes';
 import { loadPolicyFromCwd } from '../baseline/policy';
 import type { BaselineSection } from '../baseline/policy';
@@ -54,6 +55,26 @@ export interface AcquiredPrior {
   baseline: BaselineFile;
   baselinePath?: string;
   anchorSource?: AnchorSourceDisclosure;
+}
+
+/**
+ * The `fresh` prior (4.4.0 WP2): zero findings, with the CURRENT scan's
+ * own envelope. Built AFTER the current gather (the engine calls this in
+ * place of `acquirePrior` for the empty prior class), through the ONE
+ * `CurrentScan → BaselineFile` converter. Using the current envelope is
+ * the load-bearing choice: recall matches BY CONSTRUCTION (same run,
+ * same environment), so Rule 19 composes — the drift machinery is
+ * inapplicable-by-construction rather than disabled, and every finding
+ * classifies `added` because the prior finding set is empty, never
+ * because attribution was bypassed.
+ */
+export function emptyPriorFromScan(current: CurrentScan, name?: string): AcquiredPrior {
+  return {
+    baseline: scanToBaselineFile(current, {
+      name: name ?? DEFAULT_BASELINE_NAME,
+      findings: [],
+    }),
+  };
 }
 
 /**
@@ -101,7 +122,7 @@ function safeBaselineSection(cwd: string): BaselineSection | undefined {
  * written before this field existed reads as the original 'v1'.)
  */
 export function assertPriorSchemeComparable(prior: AcquiredPrior, mode: ResolvedMode): void {
-  if (mode.mode === 'ref-based') return;
+  if (priorClassOf(mode.mode) !== 'committed') return;
   const baselineScheme = prior.baseline.identityScheme ?? 'v1';
   if (baselineScheme === CURRENT_IDENTITY_SCHEME) return;
   // The remedy must match the STATE (observed on the live migration
@@ -131,7 +152,12 @@ export function assertPriorSchemeComparable(prior: AcquiredPrior, mode: Resolved
   );
 }
 
-/** Acquire the prior side of the gate diff for a resolved mode. */
+/**
+ * Acquire the prior side of the gate diff for a resolved mode. The
+ * `fresh` (empty) prior is the one arm NOT served here — it derives
+ * from the current scan, so the engine calls `emptyPriorFromScan`
+ * after the current gather instead (same module, one prior home).
+ */
 export async function acquirePrior(
   cwd: string,
   mode: ResolvedMode,
@@ -139,6 +165,33 @@ export async function acquirePrior(
   incrementalFiles?: ReadonlyArray<string>,
   scope: GatherScope = FULL_SCOPE,
 ): Promise<AcquiredPrior> {
+  if (mode.mode === 'fresh') {
+    // Programming error, not a user error: the engine owns the ordering.
+    throw new Error('fresh prior derives from the current scan — call emptyPriorFromScan.');
+  }
+  if (mode.mode === 'tree-baseline') {
+    if (!mode.baselineDir) {
+      throw new Error('tree-baseline mode requires a resolved baselineDir; got undefined.');
+    }
+    // The dir-shaped prior collapse (Rule 2): a supplied tree goes through
+    // the SAME two canonical calls the ref arm uses — `gatherCurrentScan`
+    // over a directory, projected by the ONE `scanToBaselineFile`
+    // converter — the only difference being that no worktree needs
+    // materializing first.
+    const treeScan = await gatherCurrentScan({
+      cwd: mode.baselineDir,
+      verbose: options.verbose,
+      scope,
+      skipRemediation: true,
+      trust: options.trust,
+    });
+    return {
+      baseline: scanToBaselineFile(treeScan, {
+        name: options.name ?? DEFAULT_BASELINE_NAME,
+        findings: treeScan.findings,
+      }),
+    };
+  }
   if (mode.mode !== 'ref-based') {
     const baselinePath =
       options.baselinePath ?? pathForBaseline(cwd, options.name ?? DEFAULT_BASELINE_NAME);

--- a/src/gate/types.ts
+++ b/src/gate/types.ts
@@ -37,7 +37,20 @@ export interface RepoSubject {
   readonly cwd: string;
 }
 
-export type GateSubject = RepoSubject;
+/**
+ * A bare directory with no git history (4.4.0 WP2) — a freshly generated
+ * package, an exported tree. Git-derived engine signals degrade
+ * declaratively: changed-line attribution reads UNKNOWN (never a
+ * demotion), the matcher falls back to set-diff, the base-ref additive
+ * gates skip with `no-base-ref` disclosed.
+ */
+export interface TreeSubject {
+  readonly kind: 'tree';
+  /** Absolute path to the tree root. */
+  readonly dir: string;
+}
+
+export type GateSubject = RepoSubject | TreeSubject;
 
 /**
  * Engine-level options — the subset of the guardrail surface's options

--- a/test/gate/modes-prior.test.ts
+++ b/test/gate/modes-prior.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  BASELINE_MODES,
+  GATE_ONLY_MODES,
+  parseBaselineMode,
+  priorClassOf,
+  resolveGateMode,
+} from '../../src/baseline/modes';
+import { runGate } from '../../src/gate/engine';
+import { DEFAULT_BROWNFIELD_POLICY, resolvePolicy } from '../../src/baseline/policy';
+import { policyForPreset } from '../../src/baseline/presets';
+
+const securityOnly = () => policyForPreset('security-only', DEFAULT_BROWNFIELD_POLICY).policy;
+import { trustedLocalContext } from '../../src/analysis-trust';
+import { verdictCounts } from '../../src/baseline/check-renderers';
+
+/**
+ * 4.4.0 WP2a — the gate-only prior modes (`fresh`, `tree-baseline`) and
+ * the prior-class dispatch. Pure layer first; then the engine driven
+ * DIRECTLY (no CLI yet — that's WP2b) over bare, non-git directories:
+ * the exact subject shape the spec's package mode judges.
+ */
+
+describe('mode → prior-class mapping (the one declaration every branch keys on)', () => {
+  it('maps all five modes', () => {
+    expect(priorClassOf('committed-full')).toBe('committed');
+    expect(priorClassOf('committed-sanitized')).toBe('committed');
+    expect(priorClassOf('ref-based')).toBe('dir-gathered');
+    expect(priorClassOf('tree-baseline')).toBe('dir-gathered');
+    expect(priorClassOf('fresh')).toBe('empty');
+  });
+
+  it('keeps the guardrail-facing enumeration at the three repo modes', () => {
+    expect(BASELINE_MODES).toEqual(['committed-full', 'committed-sanitized', 'ref-based']);
+    expect(GATE_ONLY_MODES).toEqual(['fresh', 'tree-baseline']);
+  });
+
+  it('guardrail --mode cannot select a gate-only prior', () => {
+    expect(parseBaselineMode('fresh')).toBeNull();
+    expect(parseBaselineMode('tree-baseline')).toBeNull();
+    expect(parseBaselineMode('ref-based')).toBe('ref-based');
+  });
+
+  it('resolveGateMode: fresh without a baseline dir, tree-baseline with one', () => {
+    const fresh = resolveGateMode({});
+    expect(fresh.mode).toBe('fresh');
+    expect(fresh.source).toBe('gate');
+    expect(fresh.baselineDir).toBeUndefined();
+    const tree = resolveGateMode({ baselineDir: '/some/dir' });
+    expect(tree.mode).toBe('tree-baseline');
+    expect(tree.baselineDir).toBe('/some/dir');
+    expect(tree.explanation).toContain('/some/dir');
+  });
+});
+
+describe('the engine over bare trees (no git, no init)', () => {
+  const HEAVY = 600_000;
+  let savedSalt: string | undefined;
+  const dirs: string[] = [];
+
+  const makeTree = (files: Record<string, string>): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-gate-tree-'));
+    dirs.push(dir);
+    for (const [name, content] of Object.entries(files)) {
+      writeFileSync(join(dir, name), content);
+    }
+    return dir;
+  };
+
+  // Assembled from fragments so no source line here carries a
+  // credential-shaped `password = '...'` adjacency the secret scanners
+  // would flag (the grep-secrets.test.ts discipline, one step further —
+  // the template-literal version still matched on this line itself).
+  const credentialLine = () =>
+    ['const pass', 'word', " = '", ['gate', 'live', '99'].join('-'), "';\n"].join('');
+
+  beforeAll(() => {
+    savedSalt = process.env.DXKIT_BASELINE_SALT;
+    delete process.env.DXKIT_BASELINE_SALT;
+  });
+
+  afterAll(() => {
+    if (savedSalt === undefined) delete process.env.DXKIT_BASELINE_SALT;
+    else process.env.DXKIT_BASELINE_SALT = savedSalt;
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  });
+
+  it(
+    'fresh mode: a clean tree passes under a security posture; a credential-carrying tree blocks',
+    async () => {
+      // Policy is the DoD (P0-3): under the compiled-in DEFAULT policy a
+      // fresh gate blocks on EVERY added finding — including the honest
+      // test-gap a two-file tree carries — so the "clean passes" property
+      // is asserted under the security-only posture, exactly how a
+      // package-mode consumer declares what "done" means.
+      const clean = makeTree({
+        'README.md': '# generated package\n',
+        'index.ts': "export const greeting = 'hello';\n",
+      });
+      const cleanResult = await runGate(
+        { kind: 'tree', dir: clean },
+        resolveGateMode({}),
+        securityOnly(),
+        { trust: trustedLocalContext() },
+      );
+      const cleanCounts = verdictCounts(cleanResult);
+      expect(cleanCounts.verdict).toMatch(/^PASSED/);
+      expect(cleanCounts.exitCode).toBe(0);
+      // Fresh prior: nothing is excluded, nothing drifts, no committed-mode
+      // disclosures apply.
+      expect(cleanResult.refExcludedKinds).toEqual([]);
+      expect(cleanResult.envelopeDrift.recallDrift).toEqual([]);
+      expect(cleanResult.attributionGaps).toEqual([]);
+      expect(cleanResult.mode.mode).toBe('fresh');
+
+      const seeded = makeTree({
+        'README.md': '# generated package\n',
+        'config.ts': credentialLine(),
+      });
+      const seededResult = await runGate(
+        { kind: 'tree', dir: seeded },
+        resolveGateMode({}),
+        securityOnly(),
+        { trust: trustedLocalContext() },
+      );
+      const counts = verdictCounts(seededResult);
+      expect(counts.verdict).toBe('BLOCKED');
+      const secretPairs = seededResult.pairs.filter(
+        (p) => p.kind === 'secret' && p.classification.blocks,
+      );
+      expect(secretPairs.length).toBeGreaterThanOrEqual(1);
+      expect(secretPairs[0].classification.status).toBe('added');
+      expect(secretPairs[0].file).toBe('config.ts');
+      // Rule 9: the identity is minted through the canonical helpers even on
+      // a bare tree — 16-hex, durable.
+      expect(secretPairs[0].pair.currentId).toMatch(/^[0-9a-f]{16}$/);
+    },
+    HEAVY,
+  );
+
+  it(
+    'tree-baseline mode: the same tree on both sides persists; an edit introducing a credential blocks',
+    async () => {
+      const base = makeTree({
+        'README.md': '# generated package\n',
+        'index.ts': "export const greeting = 'hello';\n",
+      });
+      // The "edited" tree: same content plus a net-new credential.
+      const edited = makeTree({
+        'README.md': '# generated package\n',
+        'index.ts': "export const greeting = 'hello';\n",
+        'config.ts': credentialLine(),
+      });
+
+      const same = await runGate(
+        { kind: 'tree', dir: base },
+        resolveGateMode({ baselineDir: base }),
+        resolvePolicy(undefined, base),
+        { trust: trustedLocalContext() },
+      );
+      const sameCounts = verdictCounts(same);
+      expect(sameCounts.verdict).toMatch(/^PASSED/);
+      expect(same.pairs.every((p) => !p.classification.blocks)).toBe(true);
+      expect(same.mode.mode).toBe('tree-baseline');
+
+      const diff = await runGate(
+        { kind: 'tree', dir: edited },
+        resolveGateMode({ baselineDir: base }),
+        resolvePolicy(undefined, edited),
+        { trust: trustedLocalContext() },
+      );
+      const diffCounts = verdictCounts(diff);
+      expect(diffCounts.verdict).toBe('BLOCKED');
+      const added = diff.pairs.filter((p) => p.classification.blocks && p.kind === 'secret');
+      expect(added.length).toBeGreaterThanOrEqual(1);
+      expect(added[0].file).toBe('config.ts');
+    },
+    HEAVY,
+  );
+
+  it(
+    'fresh mode is deterministic across two runs (P0-1 acceptance property)',
+    async () => {
+      const tree = makeTree({
+        'README.md': '# generated package\n',
+        'config.ts': credentialLine(),
+      });
+      const run = async () => {
+        const r = await runGate(
+          { kind: 'tree', dir: tree },
+          resolveGateMode({}),
+          resolvePolicy(undefined, tree),
+          { trust: trustedLocalContext() },
+        );
+        const c = verdictCounts(r);
+        return {
+          verdict: c.verdict,
+          blocking: r.pairs
+            .filter((p) => p.classification.blocks)
+            .map((p) => `${p.kind}:${p.file}:${p.pair.currentId}`)
+            .sort(),
+        };
+      };
+      const a = await run();
+      const b = await run();
+      expect(a).toEqual(b);
+      expect(a.verdict).toBe('BLOCKED');
+    },
+    HEAVY,
+  );
+});


### PR DESCRIPTION
## What

The engine learns the two gate-only priors and the bare-tree subject — the substrate the `gate` command (WP2b) parameterizes.

- **Modes**: `fresh` (empty prior — everything net-new by construction) and `tree-baseline` (prior = gather of a supplied directory) join the ONE mode union, constructible only through `resolveGateMode` (Rule 11). `guardrail check --mode` and repo policy still accept exactly the three repo modes (pinned).
- **Prior-class dispatch**: every engine branch keys on the declared class (`committed` / `dir-gathered` / `empty`) from `priorClassOf`, never mode strings. `tree-baseline` inherits ref-based's exclusion + disclosure semantics; `fresh` excludes NOTHING (no prior asymmetry to protect) and cannot drift by construction — the fresh prior is built from the current scan's own envelope through the ONE `scanToBaselineFile` converter, so Rule 19 composes rather than being disabled.
- **Tree subjects**: a bare directory with no git is judged end to end. Salt resolution gains the DECLARED `unavailable` mode — the scan path is fail-open (located secrets gate in full; only the secret-HMAC companions skip, stamped on the envelope), while `baseline create` keeps its hard error.

## Dogfood note

The local self-guardrail BLOCKED the first version of this change: the engine split moved the grandfathered `secret: 'high'` severity-table line across files (the cross-file cousin of the #271 relocation class — resolved+added split), my test's credential builder matched the scanner on its own source line, and create.ts crossed the large-file threshold. Fixed properly: one reviewed `false-positive` allowlist entry for the moved table line (the existing category for exactly this class), a fragment-assembled test builder, and create.ts back at 500. No baseline refresh.

## Verification

`test/gate/modes-prior.test.ts` (7 tests incl. fresh-mode determinism ×2 — the P0-1 acceptance property, and clean-passes/credential-blocks over bare trees). Full suite 5,473 green; lint/format/arch/slop/xeco green; self-guardrail ref-based vs origin/main PASSED exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)