### PR TITLE
feat(security): offline advisory snapshots — air-gapped dep audits (4.4.0 WP5)

### DIFF
--- a/src/analyzers/health.ts
+++ b/src/analyzers/health.ts
@@ -131,6 +131,13 @@ export interface AnalyzeHealthOptions {
    */
   incrementalFiles?: ReadonlyArray<string>;
   /**
+   * Offline advisory snapshot (4.4.0 P1-4): audit dependencies against this
+   * pre-downloaded local database with zero network egress. Threaded to the
+   * pack seam at the one adapter below; packs without offline support are
+   * skipped with a disclosed cause at the dispatch.
+   */
+  advisoryDb?: { readonly dir: string; readonly version: string };
+  /**
    * When true, skip the Tier-2 dependency *remediation* enrichment (structured
    * `upgradePlan` via `osv-scanner fix`, which runs the package manager). The
    * guardrail/gate path sets this: the verdict and finding identity never read
@@ -310,6 +317,7 @@ export async function gatherAnalysisResultBody(
       // Pack seam stays a boolean (DepVulnGatherOptions is a frozen-in-place
       // pack contract); derived here, at the one adapter.
       untrusted: !options.trust.repoExecutionAllowed,
+      ...(options.advisoryDb ? { advisoryDb: options.advisoryDb } : {}),
     }),
   );
 

--- a/src/analyzers/security/advisory-db.ts
+++ b/src/analyzers/security/advisory-db.ts
@@ -1,0 +1,80 @@
+/**
+ * The offline advisory snapshot (4.4.0 P1-4) — ONE home for what a
+ * `--advisory-db` value means.
+ *
+ * Air-gapped deployments cannot query OSV.dev (or any registry) at gate
+ * time. They ship a pre-downloaded osv-scanner vulnerability database
+ * through their own versioned reference-data channel and point the gate
+ * at it. Two consequences the rest of the machine enforces:
+ *
+ *   - the snapshot VERSION is a Rule 19 RECALL INPUT (a newer snapshot
+ *     sees more advisories — blaming that delta on a developer is the
+ *     exact misattribution Rule 19 exists to kill) and is named in the
+ *     verdict;
+ *   - an ABSENT or unusable snapshot makes the dep-vuln check a
+ *     disclosed SKIP with cause, never a silent pass and never a
+ *     fallback to the network (falling back would silently break the
+ *     air-gap guarantee the flag exists to give).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** A resolved advisory snapshot. */
+export interface AdvisoryDbSpec {
+  /** Absolute directory osv-scanner reads as its local DB cache. */
+  readonly dir: string;
+  /** Snapshot version — the recall input + the verdict's name for the
+   *  feed state. From the `path@version` suffix, else the snapshot's
+   *  `VERSION` file, else `'unversioned'` (still disclosed; drift then
+   *  cannot distinguish snapshot updates — the channel should version). */
+  readonly version: string;
+}
+
+/** Why a supplied advisory-db value is unusable (disclosed cause). */
+export interface AdvisoryDbError {
+  readonly error: string;
+}
+
+/**
+ * Parse `--advisory-db <path>` / `<path>@<version>`. The `@version`
+ * split applies only when the prefix is an existing directory, so a
+ * path that legitimately contains `@` (scoped registries, home dirs)
+ * still resolves whole.
+ */
+export function resolveAdvisoryDb(raw: string, cwd: string): AdvisoryDbSpec | AdvisoryDbError {
+  const abs = (p: string): string => (path.isAbsolute(p) ? p : path.resolve(cwd, p));
+  const at = raw.lastIndexOf('@');
+  if (at > 0) {
+    const dir = abs(raw.slice(0, at));
+    const version = raw.slice(at + 1).trim();
+    if (version.length > 0 && isDir(dir)) {
+      return { dir, version };
+    }
+  }
+  const dir = abs(raw);
+  if (!isDir(dir)) {
+    return {
+      error:
+        `advisory snapshot not found: ${dir} is not a directory. The dep-vuln check is ` +
+        `SKIPPED (never silently run against the network in snapshot mode).`,
+    };
+  }
+  const versionFile = ['VERSION', 'version.txt']
+    .map((f) => path.join(dir, f))
+    .find((f) => fs.existsSync(f));
+  const version = versionFile ? fs.readFileSync(versionFile, 'utf8').trim() : '';
+  return { dir, version: version.length > 0 ? version : 'unversioned' };
+}
+
+export function isAdvisoryDbError(v: AdvisoryDbSpec | AdvisoryDbError): v is AdvisoryDbError {
+  return 'error' in v;
+}
+
+function isDir(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/src/analyzers/security/aggregator.ts
+++ b/src/analyzers/security/aggregator.ts
@@ -158,7 +158,14 @@ export interface AggregateProvenance {
   external?: { tools: string[]; ran: boolean };
   tlsBypass: { ran: boolean; patternCount: number };
   fileFindings: { ran: boolean };
-  depVulns: { tool: string | null; available: boolean; unavailableReason: string };
+  depVulns: {
+    tool: string | null;
+    available: boolean;
+    unavailableReason: string;
+    /** Snapshot version when the audit ran offline (4.4.0 P1-4) — the
+     * dep-vuln recall input + the verdict's name for the feed state. */
+    advisoryDbVersion?: string;
+  };
 }
 
 /**
@@ -302,6 +309,7 @@ export interface SecurityAggregateInput {
     tool: string | null;
     available: boolean;
     unavailableReason: string;
+    advisoryDbVersion?: string;
   };
   /** The repo's allowlist, loaded by the caller (the aggregator stays
    * pure / does no I/O). When present, each code/secret/config finding
@@ -759,6 +767,9 @@ export function buildSecurityAggregate(input: SecurityAggregateInput): SecurityA
       tool: input.depVulns.tool,
       available: input.depVulns.available,
       unavailableReason: input.depVulns.unavailableReason,
+      ...(input.depVulns.advisoryDbVersion !== undefined
+        ? { advisoryDbVersion: input.depVulns.advisoryDbVersion }
+        : {}),
     },
   };
 

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -305,6 +305,24 @@ async function gatherOutcomeWithDeadline(
   opts: DepVulnGatherOptions | undefined,
   label: string,
 ): Promise<DepVulnGatherOutcome> {
+  // Snapshot mode (4.4.0 P1-4) gates HERE, at the one dispatch primitive.
+  // An UNUSABLE snapshot (missing dir) makes every pack's audit unavailable
+  // with the cause — never a fallback to the network, never an empty local
+  // database reading as "no vulnerabilities".
+  if (opts?.advisoryDb?.error) {
+    return { kind: 'unavailable', reason: opts.advisoryDb.error };
+  }
+  // And a provider that has not declared zero-egress snapshot support is
+  // SKIPPED with a disclosed cause — running its networked scanner would
+  // silently break the air-gap guarantee the flag exists to give.
+  if (opts?.advisoryDb && pack.capabilities?.depVulns?.supportsOfflineSnapshot !== true) {
+    return {
+      kind: 'unavailable',
+      reason:
+        `advisory snapshot mode: the ${pack.id} dependency scanner has no offline mode — ` +
+        `audit skipped to preserve zero egress (never run against the network in snapshot mode)`,
+    };
+  }
   const deadlineOutcome = await withDeadline(
     pack.capabilities!.depVulns!.gatherOutcome(dir, opts),
     DEFAULT_PROVIDER_DEADLINE_MS,
@@ -675,6 +693,12 @@ export async function buildSecurityAggregateForHealth(
       tool: depVulnsEnvelope?.tool ?? null,
       available: depVulnsAvailable,
       unavailableReason: depVulnsUnavailableReason,
+      // Snapshot mode (P1-4): which feed state observed the tree. Flows
+      // into the dep-vuln recall input so a snapshot update reads as feed
+      // movement (Rule 19), never a developer's regression.
+      ...(depVulnsEnvelope?.advisoryDbVersion !== undefined
+        ? { advisoryDbVersion: depVulnsEnvelope.advisoryDbVersion }
+        : {}),
     },
     // Loaded here (the aggregator does no I/O) so both the health score
     // and the standalone vuln-scan — which share this one aggregate via

--- a/src/analyzers/tools/osv-scanner-deps.ts
+++ b/src/analyzers/tools/osv-scanner-deps.ts
@@ -34,6 +34,7 @@ import {
 } from './osv';
 import { isMaliciousAdvisory } from '../security/malicious';
 import { fileExists, runWithExit } from './runner';
+import type { AdvisoryDbSpec } from '../security/advisory-db';
 import { findTool, TOOL_DEFS } from './tool-registry';
 import type {
   DepVulnFinding,
@@ -185,11 +186,40 @@ export function parseOsvScannerFindings(
  * `database_specific.severity` strings. resolveCvssScores looks up
  * via CVE alias when the primary record lacks a vector.
  */
+
+/** Options for the shared osv-scanner gather (4.4.0 P1-4). */
+export interface OsvScannerGatherOpts {
+  /** Offline advisory snapshot: scan against this local DB with ALL
+   *  network features disabled (`--offline`), never OSV.dev. */
+  readonly advisoryDb?: AdvisoryDbSpec;
+  /** Test seam — injected exec (mirrors the CommandExec pattern). */
+  readonly exec?: typeof runWithExit;
+}
+
+/**
+ * Build the scan invocation — pure + exported so the offline shape is
+ * unit-testable without a binary. Snapshot mode: `--offline` (the
+ * umbrella flag — vulnerabilities from the local DB, zero network) and
+ * the DB directory via `OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY` (env-only
+ * in v2.4.0; no flag exists).
+ */
+export function buildOsvScannerScanCommand(
+  scannerPath: string,
+  manifest: string,
+  advisoryDb?: AdvisoryDbSpec,
+): { cmd: string; env?: Record<string, string> } {
+  const offline = advisoryDb ? ' --offline' : '';
+  return {
+    cmd: `${scannerPath} scan source --lockfile ${manifest} --format json${offline}`,
+    ...(advisoryDb ? { env: { OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY: advisoryDb.dir } } : {}),
+  };
+}
 export async function gatherOsvScannerDepVulnsResult(
   cwd: string,
   packId: LanguageId,
   ecosystem: string,
   manifestCandidates: string[],
+  opts?: OsvScannerGatherOpts,
 ): Promise<DepVulnGatherOutcome> {
   let manifest: string | null = null;
   for (const rel of manifestCandidates) {
@@ -210,11 +240,9 @@ export async function gatherOsvScannerDepVulnsResult(
     return { kind: 'unavailable', reason: 'osv-scanner not installed' };
   }
 
-  const { code, stdout: raw } = runWithExit(
-    `${scanner.path} scan source --lockfile ${manifest} --format json`,
-    cwd,
-    180000,
-  );
+  const { cmd, env } = buildOsvScannerScanCommand(scanner.path, manifest, opts?.advisoryDb);
+  const exec = opts?.exec ?? runWithExit;
+  const { code, stdout: raw } = exec(cmd, cwd, 180000, env ? { env } : undefined);
   if (code !== 0 && code !== 1) {
     return {
       kind: 'unavailable',
@@ -228,7 +256,11 @@ export async function gatherOsvScannerDepVulnsResult(
 
   const { counts, findings, vulnsForCvss } = parseOsvScannerFindings(raw, ecosystem, packId);
 
-  if (findings.length > 0) {
+  // Snapshot mode is ZERO-egress: the CVSS alias-fallback is an OSV.dev
+  // HTTP lookup, so it is skipped entirely — findings keep the severity
+  // data the local database carried, and the envelope says which feed
+  // state produced them (the enrichment field + snapshot version).
+  if (findings.length > 0 && !opts?.advisoryDb) {
     const resolved = await resolveCvssScores(vulnsForCvss);
     for (const f of findings) {
       const score = resolved.get(f.id);
@@ -239,7 +271,8 @@ export async function gatherOsvScannerDepVulnsResult(
   const envelope: DepVulnResult = {
     schemaVersion: 1,
     tool: 'osv-scanner',
-    enrichment: 'osv.dev',
+    enrichment: opts?.advisoryDb ? `offline-snapshot@${opts.advisoryDb.version}` : 'osv.dev',
+    ...(opts?.advisoryDb ? { advisoryDbVersion: opts.advisoryDb.version } : {}),
     counts,
     findings,
   };

--- a/src/analyzers/tools/runner.ts
+++ b/src/analyzers/tools/runner.ts
@@ -133,6 +133,13 @@ export function runWithExit(
   cmd: string,
   cwd: string,
   timeoutMs = 30000,
+  opts?: {
+    /** Extra environment for the child, merged over process.env. The one
+     *  use today: `OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY` for the offline
+     *  advisory snapshot (4.4.0 P1-4) — the variable is env-only in
+     *  osv-scanner v2.4.0 (no flag exists). */
+    readonly env?: Readonly<Record<string, string>>;
+  },
 ): { code: number | null; stdout: string } {
   try {
     const stdout = execSync(cmd, {
@@ -141,6 +148,7 @@ export function runWithExit(
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: timeoutMs,
       maxBuffer: 64 * 1024 * 1024,
+      ...(opts?.env ? { env: { ...process.env, ...opts.env } } : {}),
     }).trim();
     return { code: 0, stdout };
   } catch (err: unknown) {

--- a/src/baseline/create-write.ts
+++ b/src/baseline/create-write.ts
@@ -1,0 +1,179 @@
+/**
+ * `baseline create` — the committed WRITE orchestrator, split from
+ * `./create` at the large-file bar. `gatherCurrentScan` +
+ * `scanToBaselineFile` (the scan/projection halves) stay in `./create`;
+ * this module owns mode resolution for the write, sanitization, the
+ * salt hard-error, and the file write. Re-exported from `./create` so
+ * consumers keep one import surface.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { DEFAULT_BASELINE_NAME, pathForBaseline, writeBaselineFile } from './baseline-file';
+import type { BaselineFile } from './baseline-file';
+import { resolveBaselineMode } from './modes';
+import type { ResolvedMode } from './modes';
+import { loadPolicyFromCwd } from './policy';
+import { resolveSalt } from '../analyzers/tools/salt';
+import { sanitizeFile } from './sanitize';
+import { resolveEffectiveAllowlist } from '../allowlist/effective';
+import { entryToAllowlistable, partitionByActiveAllowlist } from './allowlist-match';
+import { captureFloorDebt } from './floor-debt';
+import { trustedLocalContext } from '../analysis-trust';
+import { gatherCurrentScan, scanToBaselineFile } from './create';
+
+export interface CreateBaselineOptions {
+  /** Repo root to baseline. Caller should pass an absolute path. */
+  readonly cwd: string;
+  /** Baseline name (becomes the filename stem under `.dxkit/baselines/`).
+   *  Defaults to `'main'`. Different names allow per-branch / per-
+   *  environment baselines to coexist on disk. */
+  readonly name?: string;
+  /** When true, overwrite an existing baseline file at the same path.
+   *  When false (default), an existing file makes `createBaseline`
+   *  throw — guards against accidentally clobbering a committed
+   *  baseline with a fresh capture. */
+  readonly force?: boolean;
+  /** Forwarded to the underlying analyzer for per-tool timing logs. */
+  readonly verbose?: boolean;
+  /** Pre-resolved baseline mode. When supplied, the orchestrator
+   *  skips its own resolution + policy load. Callers wanting
+   *  deterministic behavior (tests, agents) pass this. */
+  readonly resolvedMode?: ResolvedMode;
+  /** Explicit CLI flag value for the mode (`--mode=<X>`). Forwarded
+   *  to `resolveBaselineMode`. Ignored when `resolvedMode` is
+   *  supplied. */
+  readonly cliMode?: ResolvedMode['mode'];
+  /** Explicit CLI flag value for the ref (`--ref=<R>`). Only
+   *  consulted when the resolved mode is `ref-based`. */
+  readonly cliRef?: string;
+  /** Capture the correctness-floor debt envelope (compile + tests, full
+   *  scope, bounded per-check). Default ON — cleanup agents rely on the
+   *  envelope existing — with two opt-outs: pass `false` (the `--no-floor`
+   *  flag) or set DXKIT_BASELINE_NO_FLOOR=1 (the test suite does, so
+   *  hundreds of fixture baselines don't each run a floor pass). An
+   *  explicit option always wins over the env. */
+  readonly floor?: boolean;
+}
+
+/** Outcome of `createBaseline`. `path` and `file` are absent when
+ *  mode resolved to `ref-based` — no file is written, and the
+ *  `mode` field carries the audit trail so callers can surface
+ *  WHY nothing landed on disk. */
+export interface CreateBaselineResult {
+  readonly mode: ResolvedMode;
+  readonly path?: string;
+  readonly file?: BaselineFile;
+  /** How the captured findings split between what was baselined (`live`) and
+   *  what an active allowlist entry suppressed and held OUT of the baseline
+   *  (`allowlisted`, gh #155). Absent for `ref-based` mode (no file written).
+   *  `byCategory` breaks the held-out count down by suppression category so the
+   *  CLI can report an honest `N findings baselined (M allowlisted)` line. */
+  readonly allowlistSplit?: {
+    readonly live: number;
+    readonly allowlisted: number;
+    readonly byCategory: Readonly<Record<string, number>>;
+  };
+}
+
+/**
+ * Run the baseline-create pipeline. Pure-orchestrator: resolve
+ * the baseline mode, gather the current scan, then either:
+ *
+ *   - `committed-full` → write rich entries to disk (today's
+ *     behavior).
+ *   - `committed-sanitized` → sanitize every entry, then write.
+ *     The cross-run matching contract is preserved; locator
+ *     fields are stripped.
+ *   - `ref-based` → no file write. The guardrail check will
+ *     recompute the prior side from a git ref instead.
+ *
+ * In all three cases the returned `CreateBaselineResult` carries
+ * `resolvedMode` so callers can log WHY a given mode was picked
+ * (CLI flag / policy file / visibility auto-detect).
+ */
+export async function createBaseline(
+  options: CreateBaselineOptions,
+): Promise<CreateBaselineResult> {
+  const cwd = path.resolve(options.cwd);
+  const name = options.name ?? DEFAULT_BASELINE_NAME;
+  const mode =
+    options.resolvedMode ??
+    (() => {
+      const policy = loadPolicyFromCwd(cwd);
+      return resolveBaselineMode({
+        cwd,
+        cliMode: options.cliMode,
+        cliRef: options.cliRef,
+        policyMode: policy.baseline?.mode,
+        policyRef: policy.baseline?.ref,
+      });
+    })();
+
+  if (mode.mode === 'ref-based') {
+    // Ref-based mode keeps no committed baseline. We still run no
+    // gather here — the guardrail check does it on demand against
+    // the configured ref. Returning the resolved mode lets the CLI
+    // surface a clear "ref-based mode active; no file written" log.
+    return { mode };
+  }
+
+  resolveSalt(cwd); // a COMMITTED baseline needs a re-derivable salt — hard error kept
+
+  const filePath = pathForBaseline(cwd, name);
+  if (!options.force && fs.existsSync(filePath)) {
+    throw new Error(
+      `baseline already exists at ${filePath}. Pass force: true to overwrite, ` +
+        `or use a different --name to keep both.`,
+    );
+  }
+
+  // Baseline capture runs on the operator's own tree by definition — you do
+  // not baseline untrusted content. Explicit, not defaulted (4.2).
+  const scan = await gatherCurrentScan({
+    cwd,
+    verbose: options.verbose,
+    trust: trustedLocalContext(),
+  });
+
+  // Exclude actively-allowlisted findings from the captured set so a
+  // reviewed-and-accepted finding never grandfathers into the baseline as
+  // `persisted` (gh #155). Grandfathering an allowlisted finding double-
+  // suppresses it AND defeats its expiry — a `persisted` finding never blocks,
+  // so an accepted-risk entry that later lapsed would silently stay suppressed.
+  // Held OUT of the baseline, the allowlist (with its expiry) is the single
+  // source of suppression: an active entry keeps the finding suppressed today,
+  // and when it lapses the finding resurfaces as net-new on the next check.
+  // Resolved through the ONE effective-allowlist constructor + the ONE active-
+  // suppression predicate, so create sees the identical suppression set the
+  // guardrail check and the security score do (Rule 2).
+  const effectiveAllowlist = resolveEffectiveAllowlist({
+    cwd,
+    findings: scan.findings.map(entryToAllowlistable),
+    inlineAnnotations: scan.producerCtx.inlineAllowlistAnnotations,
+  });
+  const { live, suppressions } = partitionByActiveAllowlist(
+    scan.findings,
+    effectiveAllowlist,
+    new Date(),
+  );
+  const byCategory: Record<string, number> = {};
+  for (const s of suppressions) byCategory[s.category] = (byCategory[s.category] ?? 0) + 1;
+
+  // Floor-debt inventory (T2.3 follow-through): record the pre-existing
+  // build/test state WITH details so cleanup agents can prioritize and fix
+  // it (`vyuh-dxkit debt`). Bounded; never gates; explicit option beats env.
+  const captureFloor = options.floor ?? process.env.DXKIT_BASELINE_NO_FLOOR !== '1';
+  const floorDebt = captureFloor ? (captureFloorDebt(cwd) ?? undefined) : undefined;
+
+  const richFile = scanToBaselineFile(scan, { name, findings: live, floorDebt });
+
+  const file = mode.mode === 'committed-sanitized' ? sanitizeFile(richFile) : richFile;
+  writeBaselineFile(filePath, file);
+  return {
+    mode,
+    path: filePath,
+    file,
+    allowlistSplit: { live: live.length, allowlisted: suppressions.length, byCategory },
+  };
+}

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -61,59 +61,11 @@ import { captureFloorDebt, type FloorDebt } from './floor-debt';
 import { hashContent, readRepoState, buildAnalysisMeta } from './envelope-meta';
 import { trustedLocalContext, type AnalysisTrustContext } from '../analysis-trust';
 
-export interface CreateBaselineOptions {
-  /** Repo root to baseline. Caller should pass an absolute path. */
-  readonly cwd: string;
-  /** Baseline name (becomes the filename stem under `.dxkit/baselines/`).
-   *  Defaults to `'main'`. Different names allow per-branch / per-
-   *  environment baselines to coexist on disk. */
-  readonly name?: string;
-  /** When true, overwrite an existing baseline file at the same path.
-   *  When false (default), an existing file makes `createBaseline`
-   *  throw — guards against accidentally clobbering a committed
-   *  baseline with a fresh capture. */
-  readonly force?: boolean;
-  /** Forwarded to the underlying analyzer for per-tool timing logs. */
-  readonly verbose?: boolean;
-  /** Pre-resolved baseline mode. When supplied, the orchestrator
-   *  skips its own resolution + policy load. Callers wanting
-   *  deterministic behavior (tests, agents) pass this. */
-  readonly resolvedMode?: ResolvedMode;
-  /** Explicit CLI flag value for the mode (`--mode=<X>`). Forwarded
-   *  to `resolveBaselineMode`. Ignored when `resolvedMode` is
-   *  supplied. */
-  readonly cliMode?: ResolvedMode['mode'];
-  /** Explicit CLI flag value for the ref (`--ref=<R>`). Only
-   *  consulted when the resolved mode is `ref-based`. */
-  readonly cliRef?: string;
-  /** Capture the correctness-floor debt envelope (compile + tests, full
-   *  scope, bounded per-check). Default ON — cleanup agents rely on the
-   *  envelope existing — with two opt-outs: pass `false` (the `--no-floor`
-   *  flag) or set DXKIT_BASELINE_NO_FLOOR=1 (the test suite does, so
-   *  hundreds of fixture baselines don't each run a floor pass). An
-   *  explicit option always wins over the env. */
-  readonly floor?: boolean;
-}
-
-/** Outcome of `createBaseline`. `path` and `file` are absent when
- *  mode resolved to `ref-based` — no file is written, and the
- *  `mode` field carries the audit trail so callers can surface
- *  WHY nothing landed on disk. */
-export interface CreateBaselineResult {
-  readonly mode: ResolvedMode;
-  readonly path?: string;
-  readonly file?: BaselineFile;
-  /** How the captured findings split between what was baselined (`live`) and
-   *  what an active allowlist entry suppressed and held OUT of the baseline
-   *  (`allowlisted`, gh #155). Absent for `ref-based` mode (no file written).
-   *  `byCategory` breaks the held-out count down by suppression category so the
-   *  CLI can report an honest `N findings baselined (M allowlisted)` line. */
-  readonly allowlistSplit?: {
-    readonly live: number;
-    readonly allowlisted: number;
-    readonly byCategory: Readonly<Record<string, number>>;
-  };
-}
+// The committed WRITE orchestrator (`createBaseline` + its option/result
+// types) lives in `./create-write` — split at the large-file bar; re-
+// exported here so `from './create'` stays the one import surface.
+export { createBaseline } from './create-write';
+export type { CreateBaselineOptions, CreateBaselineResult } from './create-write';
 
 /**
  * Snapshot of one analyzer run, in the exact shape the baseline file
@@ -239,6 +191,8 @@ export async function gatherCurrentScan(options: {
    *  one (--policy override, loop preset) MUST pass it so the custom-check
    *  seam sees the document the verdict is judged under. Default: the tree's. */
   readonly policy?: BrownfieldPolicy;
+  /** Offline advisory snapshot (4.4.0 P1-4) — forwarded to the dep audit. */
+  readonly advisoryDb?: { readonly dir: string; readonly version: string };
   /** Restrict the gather to the analyzers a scope needs (defaults to
    *  `FULL_SCOPE`). Only the loop Stop-gate passes a policy-derived scope;
    *  `createBaseline` / CI gather everything. See `gather-scope.ts`. */
@@ -257,8 +211,13 @@ export async function gatherCurrentScan(options: {
   const scope = options.scope ?? FULL_SCOPE;
   // A scoped OR incrementally-scanned result is partial — it must never
   // enter the shared cache where a later full `health` read would consume
-  // an incomplete codePatterns set.
-  const partial = !isFullScope(scope) || options.incrementalFiles !== undefined;
+  // an incomplete codePatterns set. A snapshot-mode audit (P1-4) is partial
+  // for the same reason: its dep-vuln set reflects the local feed state,
+  // which a later live read must not inherit.
+  const partial =
+    !isFullScope(scope) ||
+    options.incrementalFiles !== undefined ||
+    options.advisoryDb !== undefined;
 
   const analysisResult = await readOrBuildAnalysisResult({
     cwd,
@@ -269,6 +228,7 @@ export async function gatherCurrentScan(options: {
         incrementalFiles: options.incrementalFiles,
         skipRemediation: options.skipRemediation,
         trust: options.trust,
+        ...(options.advisoryDb ? { advisoryDb: options.advisoryDb } : {}),
       }),
     opts: { partial },
   });
@@ -395,106 +355,4 @@ export async function gatherCurrentScan(options: {
 export function gatherScanCoverage(cwd: string): ScanCoverage {
   const resolved = path.resolve(cwd);
   return coverageFromToolStatuses(checkAllTools(detect(resolved).languages, resolved));
-}
-
-/**
- * Run the baseline-create pipeline. Pure-orchestrator: resolve
- * the baseline mode, gather the current scan, then either:
- *
- *   - `committed-full` → write rich entries to disk (today's
- *     behavior).
- *   - `committed-sanitized` → sanitize every entry, then write.
- *     The cross-run matching contract is preserved; locator
- *     fields are stripped.
- *   - `ref-based` → no file write. The guardrail check will
- *     recompute the prior side from a git ref instead.
- *
- * In all three cases the returned `CreateBaselineResult` carries
- * `resolvedMode` so callers can log WHY a given mode was picked
- * (CLI flag / policy file / visibility auto-detect).
- */
-export async function createBaseline(
-  options: CreateBaselineOptions,
-): Promise<CreateBaselineResult> {
-  const cwd = path.resolve(options.cwd);
-  const name = options.name ?? DEFAULT_BASELINE_NAME;
-  const mode =
-    options.resolvedMode ??
-    (() => {
-      const policy = loadPolicyFromCwd(cwd);
-      return resolveBaselineMode({
-        cwd,
-        cliMode: options.cliMode,
-        cliRef: options.cliRef,
-        policyMode: policy.baseline?.mode,
-        policyRef: policy.baseline?.ref,
-      });
-    })();
-
-  if (mode.mode === 'ref-based') {
-    // Ref-based mode keeps no committed baseline. We still run no
-    // gather here — the guardrail check does it on demand against
-    // the configured ref. Returning the resolved mode lets the CLI
-    // surface a clear "ref-based mode active; no file written" log.
-    return { mode };
-  }
-
-  resolveSalt(cwd); // a COMMITTED baseline needs a re-derivable salt — hard error kept
-
-  const filePath = pathForBaseline(cwd, name);
-  if (!options.force && fs.existsSync(filePath)) {
-    throw new Error(
-      `baseline already exists at ${filePath}. Pass force: true to overwrite, ` +
-        `or use a different --name to keep both.`,
-    );
-  }
-
-  // Baseline capture runs on the operator's own tree by definition — you do
-  // not baseline untrusted content. Explicit, not defaulted (4.2).
-  const scan = await gatherCurrentScan({
-    cwd,
-    verbose: options.verbose,
-    trust: trustedLocalContext(),
-  });
-
-  // Exclude actively-allowlisted findings from the captured set so a
-  // reviewed-and-accepted finding never grandfathers into the baseline as
-  // `persisted` (gh #155). Grandfathering an allowlisted finding double-
-  // suppresses it AND defeats its expiry — a `persisted` finding never blocks,
-  // so an accepted-risk entry that later lapsed would silently stay suppressed.
-  // Held OUT of the baseline, the allowlist (with its expiry) is the single
-  // source of suppression: an active entry keeps the finding suppressed today,
-  // and when it lapses the finding resurfaces as net-new on the next check.
-  // Resolved through the ONE effective-allowlist constructor + the ONE active-
-  // suppression predicate, so create sees the identical suppression set the
-  // guardrail check and the security score do (Rule 2).
-  const effectiveAllowlist = resolveEffectiveAllowlist({
-    cwd,
-    findings: scan.findings.map(entryToAllowlistable),
-    inlineAnnotations: scan.producerCtx.inlineAllowlistAnnotations,
-  });
-  const { live, suppressions } = partitionByActiveAllowlist(
-    scan.findings,
-    effectiveAllowlist,
-    new Date(),
-  );
-  const byCategory: Record<string, number> = {};
-  for (const s of suppressions) byCategory[s.category] = (byCategory[s.category] ?? 0) + 1;
-
-  // Floor-debt inventory (T2.3 follow-through): record the pre-existing
-  // build/test state WITH details so cleanup agents can prioritize and fix
-  // it (`vyuh-dxkit debt`). Bounded; never gates; explicit option beats env.
-  const captureFloor = options.floor ?? process.env.DXKIT_BASELINE_NO_FLOOR !== '1';
-  const floorDebt = captureFloor ? (captureFloorDebt(cwd) ?? undefined) : undefined;
-
-  const richFile = scanToBaselineFile(scan, { name, findings: live, floorDebt });
-
-  const file = mode.mode === 'committed-sanitized' ? sanitizeFile(richFile) : richFile;
-  writeBaselineFile(filePath, file);
-  return {
-    mode,
-    path: filePath,
-    file,
-    allowlistSplit: { live: live.length, allowlisted: suppressions.length, byCategory },
-  };
 }

--- a/src/baseline/create.ts
+++ b/src/baseline/create.ts
@@ -19,7 +19,6 @@
  * registering a producer there, never an edit here.
  */
 
-import * as fs from 'fs';
 import * as path from 'path';
 import { gatherAnalysisResultBody } from '../analyzers/health';
 import { readOrBuildAnalysisResult } from '../analyzers/cache';
@@ -31,16 +30,9 @@ import { coverageFromToolStatuses } from './coverage';
 import type { ScanCoverage } from './coverage';
 import { clearToolVersionCache } from './tool-versions';
 export { clearToolVersionCache };
-import {
-  BASELINE_SCHEMA_VERSION,
-  DEFAULT_BASELINE_NAME,
-  pathForBaseline,
-  writeBaselineFile,
-} from './baseline-file';
+import { BASELINE_SCHEMA_VERSION } from './baseline-file';
 import type { BaselineAnalysisMeta, BaselineFile, BaselineRepoState } from './baseline-file';
 import { assessCaptureDeferral, type DeferredCaptureClass } from './deferral';
-import { resolveBaselineMode } from './modes';
-import type { ResolvedMode } from './modes';
 import { loadPolicyFromCwd, prohibitedLicensePatterns, type BrownfieldPolicy } from './policy';
 import { customCheckRecallInputs, gatherCustomChecks } from '../analyzers/custom-checks/gather';
 import type { CustomChecksUnobserved } from '../analyzers/custom-checks/gather';
@@ -49,17 +41,14 @@ import { PRODUCERS, runProducers, runRecallContexts } from './producers';
 import type { ProducerContext } from './producers';
 import { recallInputsUnion } from './recall';
 import type { RecallMap } from './recall';
-import { resolveSalt, resolveSaltOrUnavailable } from '../analyzers/tools/salt';
+import { resolveSaltOrUnavailable } from '../analyzers/tools/salt';
 import type { SaltMode } from '../analyzers/tools/salt';
-import { sanitizeFile } from './sanitize';
-import { resolveEffectiveAllowlist } from '../allowlist/effective';
-import { entryToAllowlistable, partitionByActiveAllowlist } from './allowlist-match';
 import type { RichBaselineEntry } from './types';
 import { CURRENT_IDENTITY_SCHEME } from './types';
 import type { SecurityAggregate } from '../analyzers/security/aggregator';
-import { captureFloorDebt, type FloorDebt } from './floor-debt';
+import { type FloorDebt } from './floor-debt';
 import { hashContent, readRepoState, buildAnalysisMeta } from './envelope-meta';
-import { trustedLocalContext, type AnalysisTrustContext } from '../analysis-trust';
+import { type AnalysisTrustContext } from '../analysis-trust';
 
 // The committed WRITE orchestrator (`createBaseline` + its option/result
 // types) lives in `./create-write` — split at the large-file bar; re-

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -233,11 +233,25 @@ const SECURITY_PRODUCER: BaselineProducer = {
       ...(p?.tlsBypass.ran ? ['tls-bypass-registry'] : []),
       ...(p?.external?.ran ? p.external.tools : []),
     ];
+    // Offline snapshot mode (4.4.0 P1-4): the advisory feed STATE is a
+    // dep-vuln recall input — a newer snapshot sees more advisories, and
+    // that delta is feed movement (Rule 19 cause #5), never the
+    // developer's regression. Live mode contributes nothing here (the
+    // rolling OSV.dev feed is the `newly_published_advisory` machinery's
+    // concern, not a comparable input).
+    const depVulnRecall = toolRecall('dep-vuln', splitTools(p?.depVulns.tool), ctx.cwd);
+    const depVuln: RecallContext =
+      p?.depVulns.advisoryDbVersion !== undefined
+        ? {
+            ...depVulnRecall,
+            inputs: { ...depVulnRecall.inputs, 'osv-advisory-db': p.depVulns.advisoryDbVersion },
+          }
+        : depVulnRecall;
     return new Map<IdentityKind, RecallContext>([
       ['secret', toolRecall('secret', secrets, ctx.cwd)],
       ['code', toolRecall('code', code, ctx.cwd)],
       ['config', toolRecall('config', secrets, ctx.cwd)],
-      ['dep-vuln', toolRecall('dep-vuln', splitTools(p?.depVulns.tool), ctx.cwd)],
+      ['dep-vuln', depVuln],
     ]);
   },
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -432,6 +432,9 @@ export async function run(argv: string[]): Promise<void> {
       // (correctness floor + command-shaped custom checks). Off by default:
       // a gate must not run code from a tree it is merely judging.
       trusted: { type: 'boolean', default: false },
+      // `gate <dir> --advisory-db <path>[@version]` — offline advisory
+      // snapshot (air-gap): dep audit against a local database, zero egress.
+      'advisory-db': { type: 'string' },
       // evaluate: the zero-write trial (ref pair or last-N-landings replay).
       // --base is shared with the reviewers flags below.
       head: { type: 'string' },
@@ -2932,6 +2935,7 @@ export async function run(argv: string[]): Promise<void> {
           policyPath: values.policy as string | undefined,
           json: !!values.json,
           trusted: !!values.trusted,
+          advisoryDb: values['advisory-db'] as string | undefined,
           verbose: !!values.verbose,
         });
         process.stdout.write(renderGateOutcome(outcome, !!values.json) + '\n');

--- a/src/gate-cli.ts
+++ b/src/gate-cli.ts
@@ -30,6 +30,7 @@ import { resolveGateMode } from './baseline/modes';
 import { resolvePolicy } from './baseline/policy';
 import { trustContextFromFlag } from './analysis-trust';
 import { renderConsole, verdictCounts, type VerdictCounts } from './baseline/check-renderers';
+import { isAdvisoryDbError, resolveAdvisoryDb } from './analyzers/security/advisory-db';
 import { buildWireVerdict } from './gate/verdict';
 import {
   describeCorrectnessFloor,
@@ -52,6 +53,10 @@ export interface GateCommandOptions {
   readonly json?: boolean;
   /** Consent to EXECUTE the tree's code (floor + command checks). */
   readonly trusted?: boolean;
+  /** Offline advisory snapshot: `<path>` or `<path>@<version>` (P1-4).
+   *  Air-gap mode — the dep audit reads the local database with zero
+   *  egress; an unusable snapshot is a disclosed dep-vuln skip. */
+  readonly advisoryDb?: string;
   readonly verbose?: boolean;
   /** Test seam: injected floor runner (the ExecutorSeams pattern). */
   readonly seams?: {
@@ -108,8 +113,21 @@ export async function runGateCommand(
   // --trusted is the consent flag; its ABSENCE is the untrusted posture.
   const trust = trustContextFromFlag(!options.trusted);
 
+  // Offline advisory snapshot (P1-4): resolve through the ONE spec module.
+  // An unusable value still travels (with its error), so the dispatch skips
+  // the dep audit WITH the cause disclosed — snapshot mode never silently
+  // falls back to the network the flag exists to avoid.
+  let advisoryDb: { dir: string; version: string; error?: string } | undefined;
+  if (options.advisoryDb !== undefined) {
+    const resolved = resolveAdvisoryDb(options.advisoryDb, subjectDir);
+    advisoryDb = isAdvisoryDbError(resolved)
+      ? { dir: '', version: 'unusable', error: resolved.error }
+      : resolved;
+  }
+
   const result = await runGate({ kind: 'tree', dir: subjectDir }, mode, policy, {
     trust,
+    ...(advisoryDb ? { advisoryDb } : {}),
     ...(options.verbose !== undefined ? { verbose: options.verbose } : {}),
   });
   const counts = verdictCounts(result);

--- a/src/gate/engine.ts
+++ b/src/gate/engine.ts
@@ -191,6 +191,7 @@ export async function runGate(
     // Hosted PR gates set --untrusted so dep audits never execute the scanned
     // source (e.g. Python skips `pip-audit .` project-build).
     trust: options.trust,
+    ...(options.advisoryDb ? { advisoryDb: options.advisoryDb } : {}),
   });
 
   // The empty prior materializes here, from the current scan's own

--- a/src/gate/types.ts
+++ b/src/gate/types.ts
@@ -112,6 +112,14 @@ export interface GateEngineOptions {
    */
   readonly trust: AnalysisTrustContext;
   /**
+   * Offline advisory snapshot (4.4.0 P1-4 — air-gap): audit dependencies
+   * against this pre-downloaded local database with ZERO network egress.
+   * The version is a Rule 19 recall input and is named in the verdict;
+   * packs without offline support are skipped with a disclosed cause at
+   * the one dispatch primitive — never a silent fallback to the network.
+   */
+  readonly advisoryDb?: { readonly dir: string; readonly version: string };
+  /**
    * Loop-seam override for the flow integration gate's posture (`block` /
    * `warn` / `off`), winning over `.dxkit/policy.json:flow.mode`. The loop
    * Stop-gate derives it from the active preset (`security-only` → `warn`,

--- a/src/gate/verdict.ts
+++ b/src/gate/verdict.ts
@@ -159,6 +159,12 @@ export function buildWireVerdict(outcome: GateCommandOutcome, receipt: string): 
       warningCount: counts.warning,
       blockingCount: counts.blocking,
       floorNetNew: outcome.floorNetNew.length,
+      // Snapshot mode (P1-4): the feed state that observed the tree —
+      // "snapshot version named in the verdict" is this field plus the
+      // recall input it mirrors.
+      ...(result.current.aggregate.provenance.depVulns.advisoryDbVersion !== undefined
+        ? { advisoryDb: result.current.aggregate.provenance.depVulns.advisoryDbVersion }
+        : {}),
     },
   };
 }

--- a/src/languages/capabilities/provider.ts
+++ b/src/languages/capabilities/provider.ts
@@ -113,10 +113,34 @@ export interface DepVulnGatherOptions {
    * your own repo) leave it unset and keep full coverage.
    */
   readonly untrusted?: boolean;
+  /**
+   * Offline advisory snapshot (4.4.0 P1-4 — air-gap): audit against this
+   * pre-downloaded local database with ZERO network egress. Only providers
+   * that declare `supportsOfflineSnapshot: true` receive it — the dispatch
+   * SKIPS every other pack's audit with a disclosed cause rather than let
+   * a networked scanner silently break the air-gap guarantee.
+   */
+  readonly advisoryDb?: {
+    readonly dir: string;
+    readonly version: string;
+    /** Set when the supplied snapshot was UNUSABLE (missing directory).
+     *  The dispatch then reports the audit unavailable with this cause
+     *  for every pack — snapshot mode never falls back to the network,
+     *  and never lets an empty database read as "no vulnerabilities". */
+    readonly error?: string;
+  };
 }
 
 export interface DepVulnsProvider extends CapabilityProvider<DepVulnResult> {
   gatherOutcome(cwd: string, opts?: DepVulnGatherOptions): Promise<DepVulnGatherOutcome>;
+  /**
+   * Declares that this provider honors `DepVulnGatherOptions.advisoryDb`
+   * with zero egress (4.4.0 P1-4). Undeclared/false ⇒ in snapshot mode the
+   * dispatch skips this pack's audit with a disclosed cause — the honest
+   * outcome for a scanner with no offline mode (pip-audit, npm audit).
+   * Optional-additive on the frozen-in-place contract (freeze-test pinned).
+   */
+  readonly supportsOfflineSnapshot?: boolean;
   /**
    * What the audit NEEDS from the environment that runs it (CLAUDE.md
    * Rule 20). REQUIRED. Registry tools (osv-scanner, pip-audit) are NOT

--- a/src/languages/capabilities/types.ts
+++ b/src/languages/capabilities/types.ts
@@ -193,8 +193,15 @@ export interface DepVulnFinding {
 export interface DepVulnResult extends CapabilityEnvelope {
   /** Severity-tier counts. Always populated; zeros allowed. */
   counts: SeverityCounts;
-  /** Source of severity classification, when enrichment is involved. */
-  enrichment: 'osv.dev' | null;
+  /** Source of severity classification, when enrichment is involved.
+   *  `'osv.dev'` (live), `offline-snapshot@<version>` (4.4.0 P1-4 —
+   *  air-gap snapshot mode, zero egress), or null. */
+  enrichment: string | null;
+  /** Advisory snapshot version when the scan ran in offline snapshot
+   *  mode (4.4.0 P1-4). Feeds provenance → the dep-vuln recall input →
+   *  the verdict, so a snapshot update is attributed as feed movement,
+   *  never as a developer's regression. */
+  advisoryDbVersion?: string;
   /** Optional per-finding detail. Deep-mode reports populate this. */
   findings?: DepVulnFinding[];
 }

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -426,8 +426,11 @@ const javaDepVulnsProvider: DepVulnsProvider = {
     const outcome = await gatherOsvScannerDepVulnsResult(cwd, 'java', 'Maven', JAVA_DEP_MANIFESTS);
     return outcome.kind === 'success' ? outcome.envelope : null;
   },
-  async gatherOutcome(cwd) {
-    return gatherOsvScannerDepVulnsResult(cwd, 'java', 'Maven', JAVA_DEP_MANIFESTS);
+  supportsOfflineSnapshot: true,
+  async gatherOutcome(cwd, opts) {
+    return gatherOsvScannerDepVulnsResult(cwd, 'java', 'Maven', JAVA_DEP_MANIFESTS, {
+      ...(opts?.advisoryDb ? { advisoryDb: opts.advisoryDb } : {}),
+    });
   },
 };
 

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -319,8 +319,11 @@ const kotlinDepVulnsProvider: DepVulnsProvider = {
     );
     return outcome.kind === 'success' ? outcome.envelope : null;
   },
-  async gatherOutcome(cwd) {
-    return gatherOsvScannerDepVulnsResult(cwd, 'kotlin', 'Maven', KOTLIN_DEP_MANIFESTS);
+  supportsOfflineSnapshot: true,
+  async gatherOutcome(cwd, opts) {
+    return gatherOsvScannerDepVulnsResult(cwd, 'kotlin', 'Maven', KOTLIN_DEP_MANIFESTS, {
+      ...(opts?.advisoryDb ? { advisoryDb: opts.advisoryDb } : {}),
+    });
   },
 };
 

--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -13,6 +13,7 @@ import { walkSourceFiles } from '../analyzers/tools/walk-source-files';
 import type { ExecutionRequirement } from '../execution';
 import type {
   CapabilityProvider,
+  DepVulnGatherOptions,
   DepVulnsProvider,
   RunTestsOutcome,
 } from './capabilities/provider';
@@ -75,12 +76,17 @@ const PHP_LOCKFILE_EXECUTION: ExecutionRequirement = {
 
 // ─── Dep-vulns (osv-scanner over composer.lock, ecosystem Packagist) ────────
 
-async function gatherPhpDepVulnsResult(cwd: string): Promise<DepVulnGatherOutcome> {
+async function gatherPhpDepVulnsResult(
+  cwd: string,
+  opts?: DepVulnGatherOptions,
+): Promise<DepVulnGatherOutcome> {
   // Ecosystem string + extraction verified against a live osv-scanner 2.4.0
   // run on a known-vulnerable lock (guzzle 7.4.0 → 4 GHSAs) before this
   // pack shipped — the swift 2.3.8 lesson (a scanner that parses nothing
   // reads as CLEAN).
-  return gatherOsvScannerDepVulnsResult(cwd, 'php', 'Packagist', ['composer.lock']);
+  return gatherOsvScannerDepVulnsResult(cwd, 'php', 'Packagist', ['composer.lock'], {
+    ...(opts?.advisoryDb ? { advisoryDb: opts.advisoryDb } : {}),
+  });
 }
 
 const phpDepVulnsProvider: DepVulnsProvider = {
@@ -94,8 +100,9 @@ const phpDepVulnsProvider: DepVulnsProvider = {
     const outcome = await gatherPhpDepVulnsResult(cwd);
     return outcome.kind === 'success' ? outcome.envelope : null;
   },
-  async gatherOutcome(cwd) {
-    return gatherPhpDepVulnsResult(cwd);
+  supportsOfflineSnapshot: true,
+  async gatherOutcome(cwd, opts) {
+    return gatherPhpDepVulnsResult(cwd, opts);
   },
 };
 

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -680,8 +680,11 @@ const rubyDepVulnsProvider: DepVulnsProvider = {
     );
     return outcome.kind === 'success' ? outcome.envelope : null;
   },
-  async gatherOutcome(cwd) {
-    return gatherOsvScannerDepVulnsResult(cwd, 'ruby', 'RubyGems', RUBY_DEP_MANIFESTS);
+  supportsOfflineSnapshot: true,
+  async gatherOutcome(cwd, opts) {
+    return gatherOsvScannerDepVulnsResult(cwd, 'ruby', 'RubyGems', RUBY_DEP_MANIFESTS, {
+      ...(opts?.advisoryDb ? { advisoryDb: opts.advisoryDb } : {}),
+    });
   },
 };
 

--- a/src/languages/swift.ts
+++ b/src/languages/swift.ts
@@ -11,6 +11,7 @@ import { walkSourceFiles } from '../analyzers/tools/walk-source-files';
 import type { ExecutionRequirement } from '../execution';
 import type {
   CapabilityProvider,
+  DepVulnGatherOptions,
   DepVulnsProvider,
   RunTestsOutcome,
 } from './capabilities/provider';
@@ -132,7 +133,10 @@ const SWIFTLINT_EXECUTION: ExecutionRequirement = {
  * reason surfaces (docs + runbook). Re-evaluate when an advisory database
  * covers CocoaPods.
  */
-async function gatherSwiftDepVulnsResult(cwd: string): Promise<DepVulnGatherOutcome> {
+async function gatherSwiftDepVulnsResult(
+  cwd: string,
+  opts?: DepVulnGatherOptions,
+): Promise<DepVulnGatherOutcome> {
   const hasSpmLock = fileExists(cwd, 'Package.resolved');
   const hasPodLock = fileExists(cwd, 'Podfile.lock');
   if (!hasSpmLock && !hasPodLock) {
@@ -149,7 +153,9 @@ async function gatherSwiftDepVulnsResult(cwd: string): Promise<DepVulnGatherOutc
         'CocoaPods ecosystem), so pod dependencies are UNAUDITED, not clean',
     };
   }
-  return gatherOsvScannerDepVulnsResult(cwd, 'swift', 'SwiftURL', ['Package.resolved']);
+  return gatherOsvScannerDepVulnsResult(cwd, 'swift', 'SwiftURL', ['Package.resolved'], {
+    ...(opts?.advisoryDb ? { advisoryDb: opts.advisoryDb } : {}),
+  });
 }
 
 const swiftDepVulnsProvider: DepVulnsProvider = {
@@ -173,8 +179,9 @@ const swiftDepVulnsProvider: DepVulnsProvider = {
     const outcome = await gatherSwiftDepVulnsResult(cwd);
     return outcome.kind === 'success' ? outcome.envelope : null;
   },
-  async gatherOutcome(cwd) {
-    return gatherSwiftDepVulnsResult(cwd);
+  supportsOfflineSnapshot: true,
+  async gatherOutcome(cwd, opts) {
+    return gatherSwiftDepVulnsResult(cwd, opts);
   },
 };
 

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -366,6 +366,16 @@ async function gatherTsDepVulnsResult(
         'run your package manager install to generate one',
     };
   }
+  // Offline snapshot mode (4.4.0 P1-4): npm audit is a registry query with
+  // no offline mode, so EVERY lockfile flavor routes to osv-scanner against
+  // the local database — zero egress, including the malicious overlay's
+  // (the snapshot carries the same OSV MAL-* entries).
+  if (opts?.advisoryDb) {
+    return gatherOsvScannerDepVulnsResult(cwd, 'typescript', 'npm', [lock.lockfile], {
+      advisoryDb: opts.advisoryDb,
+    });
+  }
+
   if (lock.pm !== 'npm') {
     // osv-scanner's npm ecosystem covers pnpm/yarn/bun lockfiles. Point it at the
     // detected lockfile only, so a repo with a stray package-lock.json isn't
@@ -614,6 +624,7 @@ const tsDepVulnsProvider: DepVulnsProvider = {
     const outcome = await gatherTsDepVulnsResult(cwd);
     return outcome.kind === 'success' ? outcome.envelope : null;
   },
+  supportsOfflineSnapshot: true,
   async gatherOutcome(cwd, opts) {
     return gatherTsDepVulnsResult(cwd, opts);
   },

--- a/test/advisory-db.test.ts
+++ b/test/advisory-db.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { isAdvisoryDbError, resolveAdvisoryDb } from '../src/analyzers/security/advisory-db';
+import {
+  buildOsvScannerScanCommand,
+  gatherOsvScannerDepVulnsResult,
+} from '../src/analyzers/tools/osv-scanner-deps';
+import { gatherPackDepVulnsAcrossRoots } from '../src/analyzers/security/gather';
+import type { LanguageSupport } from '../src/languages/types';
+
+/**
+ * 4.4.0 WP5 — the offline advisory snapshot (P1-4, air-gap).
+ *
+ * The properties, in dependency order: the ONE spec module resolves a
+ * `--advisory-db` value; the scan invocation is offline-shaped (the
+ * `--offline` umbrella flag + the env-only cache-dir variable); the
+ * gather performs ZERO enrichment egress in snapshot mode; and the one
+ * dispatch primitive skips — with cause — both an unusable snapshot and
+ * any pack whose scanner has no offline mode. Silence is never an
+ * outcome: every skip names why.
+ */
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'dxkit-advisory-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('resolveAdvisoryDb (the one spec module)', () => {
+  it('resolves a bare directory, reading VERSION when present', () => {
+    mkdirSync(join(dir, 'db'));
+    writeFileSync(join(dir, 'db', 'VERSION'), '2026-08-01\n');
+    const spec = resolveAdvisoryDb(join(dir, 'db'), dir);
+    expect(isAdvisoryDbError(spec)).toBe(false);
+    if (!isAdvisoryDbError(spec)) {
+      expect(spec.dir).toBe(join(dir, 'db'));
+      expect(spec.version).toBe('2026-08-01');
+    }
+  });
+
+  it('splits a path@version suffix only when the prefix is a real directory', () => {
+    mkdirSync(join(dir, 'db'));
+    const spec = resolveAdvisoryDb(`${join(dir, 'db')}@snap-42`, dir);
+    if (isAdvisoryDbError(spec)) throw new Error(spec.error);
+    expect(spec.version).toBe('snap-42');
+    // A directory whose NAME contains @ still resolves whole.
+    mkdirSync(join(dir, 'weird@dir'));
+    const whole = resolveAdvisoryDb(join(dir, 'weird@dir'), dir);
+    if (isAdvisoryDbError(whole)) throw new Error(whole.error);
+    expect(whole.dir).toBe(join(dir, 'weird@dir'));
+    expect(whole.version).toBe('unversioned');
+  });
+
+  it('an unversioned snapshot is declared, not invented', () => {
+    mkdirSync(join(dir, 'db'));
+    const spec = resolveAdvisoryDb(join(dir, 'db'), dir);
+    if (isAdvisoryDbError(spec)) throw new Error(spec.error);
+    expect(spec.version).toBe('unversioned');
+  });
+
+  it('a missing directory is a NAMED error — never a silent live fallback', () => {
+    const spec = resolveAdvisoryDb(join(dir, 'nope'), dir);
+    expect(isAdvisoryDbError(spec)).toBe(true);
+    if (isAdvisoryDbError(spec)) {
+      expect(spec.error).toContain('not a directory');
+      expect(spec.error).toContain('SKIPPED');
+    }
+  });
+});
+
+describe('the offline scan invocation', () => {
+  it('snapshot mode adds --offline and the env-only cache dir; live mode adds neither', () => {
+    const offline = buildOsvScannerScanCommand('/bin/osv-scanner', 'package-lock.json', {
+      dir: '/snap/db',
+      version: 'v1',
+    });
+    expect(offline.cmd).toContain(' --offline');
+    expect(offline.env).toEqual({ OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY: '/snap/db' });
+    const live = buildOsvScannerScanCommand('/bin/osv-scanner', 'package-lock.json');
+    expect(live.cmd).not.toContain('--offline');
+    expect(live.env).toBeUndefined();
+  });
+});
+
+describe('the gather in snapshot mode (zero enrichment egress)', () => {
+  const osvJson = JSON.stringify({
+    results: [
+      {
+        source: { path: 'composer.lock', type: 'lockfile' },
+        packages: [
+          {
+            package: { name: 'acme/pkg', version: '1.0.0', ecosystem: 'Packagist' },
+            vulnerabilities: [{ id: 'GHSA-xxxx', aliases: [], severity: [], affected: [] }],
+          },
+        ],
+      },
+    ],
+  });
+
+  it('runs offline, parses findings, names the snapshot in the envelope, and never fetches', async () => {
+    writeFileSync(join(dir, 'composer.lock'), '{}');
+    const seen: Array<{ cmd: string; env?: Record<string, string> }> = [];
+    // Any network attempt in snapshot mode is a test FAILURE.
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (() => {
+      throw new Error('network egress in snapshot mode');
+    }) as typeof fetch;
+    try {
+      const outcome = await gatherOsvScannerDepVulnsResult(
+        dir,
+        'php',
+        'Packagist',
+        ['composer.lock'],
+        {
+          advisoryDb: { dir: '/snap/db', version: 'snap-7' },
+          exec: (cmd, _cwd, _timeout, opts) => {
+            seen.push({ cmd, env: opts?.env as Record<string, string> | undefined });
+            return { code: 1, stdout: osvJson };
+          },
+        },
+      );
+      expect(outcome.kind).toBe('success');
+      if (outcome.kind === 'success') {
+        expect(outcome.envelope.enrichment).toBe('offline-snapshot@snap-7');
+        expect(outcome.envelope.advisoryDbVersion).toBe('snap-7');
+        expect(outcome.envelope.findings?.length).toBe(1);
+      }
+      expect(seen).toHaveLength(1);
+      expect(seen[0].cmd).toContain('--offline');
+      expect(seen[0].env?.OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY).toBe('/snap/db');
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});
+
+describe('the one dispatch primitive', () => {
+  const fakePack = (supportsOffline: boolean): LanguageSupport =>
+    ({
+      id: 'php',
+      capabilities: {
+        depVulns: {
+          source: 'php',
+          execution: () => ({
+            hosts: ['any'],
+            toolchains: [],
+            needsBuild: false,
+            buildTarget: 'none',
+            weight: 'cheap',
+          }),
+          manifestPatterns: ['composer.lock'],
+          lockfilePatterns: [],
+          ...(supportsOffline ? { supportsOfflineSnapshot: true } : {}),
+          gather: async () => null,
+          gatherOutcome: async () => ({
+            kind: 'success',
+            envelope: {
+              schemaVersion: 1,
+              tool: 'osv-scanner',
+              enrichment: 'offline-snapshot@x',
+              counts: { critical: 0, high: 0, medium: 0, low: 0 },
+              findings: [],
+            },
+          }),
+        },
+      },
+    }) as unknown as LanguageSupport;
+
+  it('skips a pack WITHOUT offline support, naming the zero-egress reason', async () => {
+    const outcome = await gatherPackDepVulnsAcrossRoots(fakePack(false), dir, {
+      advisoryDb: { dir: '/snap/db', version: 'v1' },
+    });
+    expect(outcome.kind).toBe('unavailable');
+    if (outcome.kind === 'unavailable') {
+      expect(outcome.reason).toContain('no offline mode');
+      expect(outcome.reason).toContain('zero egress');
+    }
+  });
+
+  it('an unusable snapshot makes the audit unavailable WITH the cause — for every pack', async () => {
+    const outcome = await gatherPackDepVulnsAcrossRoots(fakePack(true), dir, {
+      advisoryDb: { dir: '', version: 'unusable', error: 'advisory snapshot not found: /nope' },
+    });
+    expect(outcome.kind).toBe('unavailable');
+    if (outcome.kind === 'unavailable') {
+      expect(outcome.reason).toContain('advisory snapshot not found');
+    }
+  });
+
+  it('a pack WITH offline support runs in snapshot mode', async () => {
+    const outcome = await gatherPackDepVulnsAcrossRoots(fakePack(true), dir, {
+      advisoryDb: { dir: '/snap/db', version: 'v1' },
+    });
+    expect(outcome.kind).toBe('success');
+  });
+});


### PR DESCRIPTION
## What

P1-4: `gate <dir> --advisory-db <path>[@version]` — the dependency audit runs `osv-scanner --offline` against a pre-downloaded local database (cache dir via the env-only variable the binary supports in the pinned v2.4.0), with the OSV.dev CVSS enrichment skipped entirely. **Zero egress by construction**, pinned by a test that stubs global `fetch` to throw.

- **One spec module** (`advisory-db.ts`): `path@version` suffix parse (only when the prefix is a real directory), VERSION-file probe, declared `unversioned` fallback, NAMED error for a missing directory.
- **Fail-closed on the air-gap promise**: an unusable snapshot travels WITH its error to the one dispatch primitive, which reports the audit unavailable with the cause — never a fallback to the network, never an empty database reading as "no vulnerabilities". Packs declare zero-egress support (`supportsOfflineSnapshot`, optional-additive on the frozen-in-place provider contract); undeclared packs are skipped with a disclosed cause. The TS pack routes every lockfile flavor to osv-scanner in snapshot mode (npm audit has no offline mode).
- **Rule 19**: the snapshot version flows provenance → the `osv-advisory-db` recall input (a snapshot update is feed movement, never a developer's regression) → named in the verdict (`meta.advisoryDb` + the enrichment string). Snapshot scans are cache-partial so later live reads never inherit local feed state.
- **Rider**: `create.ts` got its promised real split — `createBaseline` moved to `create-write.ts` (re-exported; create.ts 359 lines).

## Tests

`test/advisory-db.test.ts` (9): spec resolution incl. @-in-path, offline invocation shape, zero-egress gather with injected exec + throwing fetch, dispatch skip both directions + the unusable-snapshot cause.

## Verification

Full suite 5,502 green; lint/format/arch/slop/xeco/typecheck:test green; self-guardrail ref-based vs origin/main PASSED exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)