### PR TITLE
fix(templates): comment-defer scratch output moves to $RUNNER_TEMP (#282)

### DIFF
--- a/src-templates/.github/workflows/dxkit-comment-defer.yml
+++ b/src-templates/.github/workflows/dxkit-comment-defer.yml
@@ -153,7 +153,11 @@ __DXKIT_CI_RUNTIME_SETUP__
         if: steps.perm.outputs.authorized == 'true' && steps.pr.outputs.same_repo == 'true'
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi
-          "$DXKIT" guardrail check --untrusted --json > /dev/null 2>guardrail-stderr.log || true
+          # Scratch output goes OUTSIDE the repo ($RUNNER_TEMP): the defer's
+          # same-tree contract hashes every untracked file, so a stray log or
+          # redirect target inside the checkout perturbs the working-tree
+          # signature and makes the defer refuse structurally (#282).
+          "$DXKIT" guardrail check --untrusted --json > /dev/null 2>"$RUNNER_TEMP/guardrail-stderr.log" || true
 
       - name: Apply the comment command
         if: steps.perm.outputs.authorized == 'true' && steps.pr.outputs.same_repo == 'true'
@@ -166,9 +170,9 @@ __DXKIT_CI_RUNTIME_SETUP__
           DXKIT_COMMENT_PR: ${{ github.event.issue.number }}
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi
-          "$DXKIT" allowlist comment-defer > comment-defer.json
-          echo "action=$(jq -r .action comment-defer.json)" >> "$GITHUB_OUTPUT"
-          jq -r .replyMarkdown comment-defer.json > comment-defer-reply.md
+          "$DXKIT" allowlist comment-defer > "$RUNNER_TEMP/comment-defer.json"
+          echo "action=$(jq -r .action "$RUNNER_TEMP/comment-defer.json")" >> "$GITHUB_OUTPUT"
+          jq -r .replyMarkdown "$RUNNER_TEMP/comment-defer.json" > "$RUNNER_TEMP/comment-defer-reply.md"
 
       - name: Commit the allowlist to the PR branch
         if: steps.apply.outputs.action == 'deferred'
@@ -193,4 +197,4 @@ __DXKIT_CI_RUNTIME_SETUP__
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file comment-defer-reply.md
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$RUNNER_TEMP/comment-defer-reply.md"

--- a/test/comment-defer-sequence.test.ts
+++ b/test/comment-defer-sequence.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { workingTreeSignature } from '../src/loop/gate-cache';
+
+/**
+ * #282 — the comment-defer workflow defeated its own same-tree contract:
+ * its steps redirected scratch output (a stderr log, the defer JSON) into
+ * the repo root, and the defer's freshness key (`workingTreeSignature`)
+ * is deliberately content-complete over untracked files — so the check's
+ * own scratch files perturbed the signature and the defer refused
+ * STRUCTURALLY, every run. Two pins:
+ *
+ *   1. the workflow-sequence property, on the signature itself: writing
+ *      scratch OUTSIDE the repo leaves it stable (the shipped sequence
+ *      can defer); an untracked file INSIDE still perturbs it (a
+ *      genuinely edited tree still refuses — the contract is intact);
+ *   2. the shipped template's redirects all target $RUNNER_TEMP — no
+ *      bare redirect into the checkout can return.
+ */
+
+describe('comment-defer same-tree sequence (#282)', () => {
+  let dir: string;
+  let outside: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-defer-seq-'));
+    outside = mkdtempSync(join(tmpdir(), 'dxkit-defer-tmp-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 't@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: dir });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+    writeFileSync(join(dir, 'README.md'), '# repo\n');
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: dir });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  it('scratch files OUTSIDE the repo leave the signature stable; INSIDE perturbs it', () => {
+    const before = workingTreeSignature(dir);
+    expect(before).not.toBeNull();
+
+    // The FIXED sequence: check writes stderr + JSON to $RUNNER_TEMP.
+    writeFileSync(join(outside, 'guardrail-stderr.log'), 'noise\n');
+    writeFileSync(join(outside, 'comment-defer.json'), '{}');
+    expect(workingTreeSignature(dir)).toBe(before);
+
+    // The BROKEN sequence (and any genuine edit): an untracked file in
+    // the checkout MUST still change the signature — the same-tree
+    // contract is the point, not the casualty.
+    writeFileSync(join(dir, 'guardrail-stderr.log'), 'noise\n');
+    expect(workingTreeSignature(dir)).not.toBe(before);
+  });
+
+  it('the shipped template writes ALL scratch output to $RUNNER_TEMP', () => {
+    const template = readFileSync(
+      join(__dirname, '..', 'src-templates', '.github', 'workflows', 'dxkit-comment-defer.yml'),
+      'utf8',
+    );
+    // Every redirect of the two scratch names targets $RUNNER_TEMP.
+    for (const line of template.split('\n')) {
+      if (
+        /[>]\s*"?[^"]*guardrail-stderr\.log/.test(line) ||
+        /[>]\s*"?[^"]*comment-defer/.test(line)
+      ) {
+        expect(line).toContain('$RUNNER_TEMP');
+      }
+    }
+    // And the reply body is read back from the same place.
+    expect(template).toContain('--body-file "$RUNNER_TEMP/comment-defer-reply.md"');
+    // Positive control: the redirects still exist at all (the loop above
+    // must have had something to check).
+    expect(template).toContain('$RUNNER_TEMP/guardrail-stderr.log');
+    expect(template).toContain('$RUNNER_TEMP/comment-defer.json');
+  });
+});


### PR DESCRIPTION
The WP-R rider. The comment-defer workflow defeated its own same-tree contract: its steps redirected scratch output into the repo root, and the defer's freshness key deliberately hashes every untracked file — so the check's own scratch made every CI defer refuse, structurally (#282).

Fix: all scratch (`guardrail-stderr.log`, `comment-defer.json`, the reply body) targets `$RUNNER_TEMP`. `test/comment-defer-sequence.test.ts` pins the sequence property both directions (outside scratch → signature stable → defer can proceed; in-repo untracked file → still refuses) and greps the shipped template so a bare in-repo redirect cannot return.

Full suite 5,495 green; all static gates + typecheck:test green; self-guardrail PASSED exit 0.

Closes #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)