### PR TITLE
feat(tools,init,gate): the enterprise embed tail (4.4.0 WP8)

### DIFF
--- a/src/analyzers/tools/install-exec.ts
+++ b/src/analyzers/tools/install-exec.ts
@@ -32,6 +32,8 @@ import {
 export interface ToolsInstallOptions {
   toolName?: string;
   all?: boolean;
+  /** `tools bom --json`: machine-readable bill of materials. */
+  json?: boolean;
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -386,6 +386,9 @@ export async function run(argv: string[]): Promise<void> {
       help: { type: 'boolean', short: 'h', default: false },
       version: { type: 'boolean', short: 'v', default: false },
       'dx-only': { type: 'boolean', default: false },
+      // `init --gate-only` — the embed profile (4.4.0 WP8 / P3-9): policy
+      // scaffold only; no ship surfaces, no repair lanes, no GitHub wiring.
+      'gate-only': { type: 'boolean', default: false },
       full: { type: 'boolean', default: false },
       detect: { type: 'boolean', default: false },
       yes: { type: 'boolean', short: 'y', default: false },
@@ -601,6 +604,15 @@ export async function run(argv: string[]): Promise<void> {
 
   switch (command) {
     case 'init': {
+      // `--gate-only` (4.4.0 WP8 / P3-9): the embed profile for an on-prem
+      // image — a policy scaffold and NOTHING else. No .claude/, no hooks,
+      // no CI workflows, no repair lanes, no GitHub wiring: the container's
+      // whole dxkit surface is `gate <dir> --policy <file> --json`.
+      if (values['gate-only']) {
+        const { runGateOnlyInit } = await import('./init-gate-only');
+        await runGateOnlyInit(resolveRepoPath(positionals[1]));
+        break;
+      }
       const initStarted = Date.now();
       logger.header('Setting up dxkit');
 
@@ -1432,6 +1444,7 @@ export async function run(argv: string[]): Promise<void> {
       await runToolsCommand(targetPath, subCommand, !!values.yes, {
         toolName,
         all: !!values.all,
+        json: !!values.json,
       });
       break;
     }

--- a/src/gate/verdict.ts
+++ b/src/gate/verdict.ts
@@ -159,6 +159,10 @@ export function buildWireVerdict(outcome: GateCommandOutcome, receipt: string): 
       warningCount: counts.warning,
       blockingCount: counts.blocking,
       floorNetNew: outcome.floorNetNew.length,
+      // Scanner provenance (P2-7): every tool that observed this tree,
+      // name → version — the "scanner@version named in the verdict" ask,
+      // extension engines included (the recall seam collected them).
+      tools: result.current.tools,
       // Snapshot mode (P1-4): the feed state that observed the tree —
       // "snapshot version named in the verdict" is this field plus the
       // recall input it mirrors.

--- a/src/init-gate-only.ts
+++ b/src/init-gate-only.ts
@@ -1,0 +1,48 @@
+/**
+ * `vyuh-dxkit init --gate-only` (4.4.0 WP8 / P3-9) — the embed profile.
+ *
+ * An on-prem image that embeds dxkit as a gate engine needs exactly one
+ * committed artifact: the policy document (the DoD the verdict names).
+ * Everything else the full init ships — .claude/ context, git hooks, CI
+ * workflows, the loop pack, the devcontainer, GitHub integration — is
+ * repo-workflow surface a container image neither wants nor should
+ * carry (their WS6-style review counts every byte). So this profile
+ * writes the policy scaffold and stops, and the managed-surface
+ * registries are deliberately NOT consulted: nothing is installed, so
+ * nothing needs lifecycle management (`uninstall` has nothing to own).
+ *
+ * The BOM companion is `tools bom` (registry-rendered); the embed
+ * walkthrough lives in the learn docs (WP9).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as logger from './logger';
+import { DEFAULT_POLICY_FILENAME } from './baseline/policy';
+import { renderPolicyScaffold } from './baseline/policy-template';
+import { scaffoldCtxFor } from './policy-sync';
+import { VERSION } from './constants';
+
+export async function runGateOnlyInit(cwd: string): Promise<void> {
+  logger.header('dxkit gate-only init (embed profile)');
+  const policyPath = path.join(cwd, DEFAULT_POLICY_FILENAME);
+  if (fs.existsSync(policyPath)) {
+    logger.info(`policy already present: ${DEFAULT_POLICY_FILENAME} — left untouched.`);
+  } else {
+    fs.mkdirSync(path.dirname(policyPath), { recursive: true });
+    const scaffold = renderPolicyScaffold({
+      active: {},
+      ctx: scaffoldCtxFor(cwd),
+      version: VERSION,
+    });
+    fs.writeFileSync(policyPath, scaffold);
+    logger.success(`wrote ${DEFAULT_POLICY_FILENAME} (the DoD your verdicts will name)`);
+  }
+  logger.info('gate-only profile installs NOTHING else — no hooks, CI, lanes, or .claude/.');
+  logger.info('Next steps:');
+  logger.info('  vyuh-dxkit gate <dir> --policy .dxkit/policy.json --json   # one-shot verdict');
+  logger.info(
+    '  vyuh-dxkit tools bom --json                                # image supply-chain BOM',
+  );
+  logger.info('  vyuh-dxkit tools install                                   # provision scanners');
+}

--- a/src/tools-cli.ts
+++ b/src/tools-cli.ts
@@ -346,7 +346,68 @@ export async function runToolsCommand(
     await runInstall(targetPath, autoYes, options);
     return;
   }
+  if (subCommand === 'bom') {
+    renderToolsBom(options.json === true);
+    return;
+  }
   logger.fail(`Unknown tools subcommand: ${subCommand}`);
-  logger.info('Usage: vyuh-dxkit tools [list|install] [<tool-name>] [path] [--all] [--yes]');
+  logger.info('Usage: vyuh-dxkit tools [list|install|bom] [<tool-name>] [path] [--all] [--yes]');
   process.exit(1);
+}
+
+/**
+ * `tools bom [--json]` (4.4.0 WP8 / P3-9): the supply-chain bill of
+ * materials for what a dxkit install can bring into a container —
+ * rendered FROM the registry, never a second list. Per tool: the exact
+ * version pin parsed from its install commands, every pinned sha256
+ * (the dxkit_fetch args), and the install mechanism. An enterprise
+ * image review reads this instead of reverse-engineering the registry.
+ */
+export function renderToolsBom(json: boolean): void {
+  const rows = Object.values(TOOL_DEFS).map((def) => {
+    const installs = [def.install, ...Object.values(def.installCommands ?? {})].filter(
+      (c): c is string => typeof c === 'string' && c.length > 0,
+    );
+    const joined = installs.join('\n');
+    // Version pin: the first @x.y.z / vX.Y.Z / ==x.y.z token in any command.
+    const pin =
+      joined.match(/@[a-z0-9/.-]*?(\d+\.\d+\.\d+)/i)?.[1] ??
+      joined.match(/\bv(\d+\.\d+\.\d+)\b/)?.[1] ??
+      joined.match(/==(\d+\.\d+(?:\.\d+)?)/)?.[1] ??
+      null;
+    const checksums = [...new Set(joined.match(/\b[0-9a-f]{64}\b/g) ?? [])];
+    const via = joined.includes('dxkit_fetch')
+      ? 'pinned download (dxkit_fetch, sha256-verified, fails closed)'
+      : joined.includes('npm install')
+        ? 'npm'
+        : joined.includes('pip')
+          ? 'pip'
+          : joined.includes('brew')
+            ? 'brew/system'
+            : 'system package manager';
+    return {
+      name: def.name,
+      description: def.description,
+      layer: def.layer,
+      appliesTo: def.for,
+      versionPin: pin,
+      sha256: checksums,
+      installVia: via,
+    };
+  });
+  if (json) {
+    process.stdout.write(
+      JSON.stringify({ schema: 'dxkit.tools-bom.v1', tools: rows }, null, 2) + '\n',
+    );
+    return;
+  }
+  logger.header('Tool bill of materials (from the registry)');
+  for (const r of rows) {
+    logger.info(
+      `${r.name}  ${r.versionPin ? 'pin ' + r.versionPin : 'unpinned'}  · ${r.installVia}`,
+    );
+    if (r.sha256.length > 0) logger.dim(`  sha256: ${r.sha256.join(', ')}`);
+  }
+  logger.dim('\nUnpinned tools install via a system package manager the host controls;');
+  logger.dim('pinned downloads verify sha256 and fail closed (CLAUDE.md Rule 1).');
 }

--- a/test/gate/gate-command.test.ts
+++ b/test/gate/gate-command.test.ts
@@ -291,3 +291,20 @@ describe('the floor runs across nested project roots', () => {
     HEAVY,
   );
 });
+
+describe('WP8 — the enterprise tail surfaces', () => {
+  it(
+    'the verdict names every scanner that observed the tree (scanner@version)',
+    async () => {
+      const dir = makeTree({
+        'README.md': '# generated package\n',
+        '.dxkit/policy.json': securityPolicyJson(),
+      });
+      const outcome = await runGateCommand(dir, {});
+      const doc = JSON.parse(renderGateOutcome(outcome, true));
+      expect(doc.meta.tools).toBeDefined();
+      expect(typeof doc.meta.tools).toBe('object');
+    },
+    HEAVY,
+  );
+});


### PR DESCRIPTION
P2-7 + P3-9, each rendered from an existing registry: `tools bom [--json]` (supply-chain BOM from TOOL_DEFS — pins, sha256s, install mechanisms), `init --gate-only` (the embed profile: policy scaffold and nothing else — nothing installed, nothing to lifecycle-manage), and `verdict.v1 meta.tools` (every scanner that observed the tree, name → version — extension engines included). The embed walkthrough + external-wrap sandbox doc land with WP9's docs pass.

Verified live (bare-dir init writes exactly one artifact; BOM renders all 33 tools with abaplint's exact pin + gitleaks' sha). Full suite 5,557 green; all static gates + typecheck:test green; self-guardrail PASSED exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)