### PR TITLE
feat(gate): WP9 — learn guides, dxkit-gate skill, committed acceptance matrix

### DIFF
--- a/docs/learn/gate-embedding.md
+++ b/docs/learn/gate-embedding.md
@@ -1,0 +1,156 @@
+# Embedding the gate: one-shot verdicts on trees you did not init
+
+For teams that want dxkit as a **verdict engine** inside their own product:
+a code-generation pipeline that must judge every package it emits, a
+conversion factory that ships a definition-of-done, an on-prem image whose
+every byte is reviewed. No git history required, no repo onboarding, no
+hooks or CI installed. One call in, one machine-readable verdict out.
+
+## The model: subject, prior, policy
+
+Every dxkit gate answers the same question through the same engine:
+
+> Given a **subject** (the tree being judged), a **prior** (what was already
+> known or accepted), and a **policy** (the definition of done), is anything
+> here net-new and blocking?
+
+The `guardrail` command is that engine pointed at a git repo with a
+committed baseline. The `gate` command is the same engine pointed at a bare
+directory, with two priors to choose from:
+
+- **Fresh** (the default): there is no prior, so everything found is
+  net-new by construction. This is the right prior for a freshly generated
+  or converted package: nothing in it is grandfathered, because nothing in
+  it existed before.
+- **Tree baseline** (`--baseline <dir>`): the prior is another directory,
+  typically the generated original before a human or an agent edited it.
+  The gate diffs the two trees with the same finding-identity machinery the
+  repo guardrail uses, so a pre-existing finding in the original never
+  blocks the edit that did not introduce it.
+
+The verdicts, fingerprints, and classification are identical to the repo
+guardrail's. That is a tested invariant, not a goal: the parity suite runs
+both commands over shared fixtures and asserts the verdicts and the
+per-finding fingerprints match.
+
+## Quickstart
+
+```bash
+npm install -D vyuh-dxkit
+npx vyuh-dxkit tools install          # provision scanners (gitleaks, semgrep, osv-scanner...)
+npx vyuh-dxkit init --gate-only       # writes ONLY .dxkit/policy.json, nothing else
+npx vyuh-dxkit gate ./the-package --policy .dxkit/policy.json --json
+```
+
+Exit codes are the contract:
+
+| exit | status        | meaning                                                |
+| ---- | ------------- | ------------------------------------------------------ |
+| 0    | `passed`      | nothing net-new and blocking under this policy         |
+| 1    | `blocked`     | at least one net-new blocking finding (each one named) |
+| 2    | `cannot_gate` | dxkit refuses to certify (and says exactly why)        |
+
+`cannot_gate` is deliberate: when dxkit cannot rule out every non-developer
+cause of a delta, it refuses rather than guessing. A refusal always carries
+the reason and the remedy in the output.
+
+## The policy document is the definition of done
+
+`--policy` names a policy file, and the verdict names it back: `verdict.v1`
+carries the policy `id`, `version`, and a content hash, so a verdict is
+never separable from the rules it was judged under. Version the policy file
+in whatever repo owns your pipeline and treat changes to it like changes to
+a CI workflow.
+
+A conversion-package policy usually combines three layers:
+
+1. **A posture preset** for the scanner findings (`security-only` blocks
+   net-new secrets, critical/high SAST, and reachable dependency
+   vulnerabilities).
+2. **Text rules**: declarative pattern checks that run in-process with no
+   command execution, so they are safe on untrusted trees.
+
+   ```jsonc
+   {
+     "checks": [
+       {
+         "name": "no_placeholder",
+         "pattern": "\\b(TODO|FIXME|XXX)\\b",
+         "globs": ["src/**", "tests/**"],
+         "blocking": true,
+       },
+     ],
+   }
+   ```
+
+3. **Command checks and the correctness floor** (compile + tests), which
+   execute code from the tree and therefore require trust (next section).
+
+## Trust is explicit
+
+By default the gate treats the subject tree as **untrusted**: it scans the
+bytes but never executes anything from the tree. Command checks and the
+correctness floor are skipped with a disclosed `skipped-untrusted` cause in
+the output, never silently.
+
+Pass `--trusted` only when you are prepared to execute the tree's own code
+(its test suite, its build). If your pipeline judges trees from sources you
+do not control, keep the gate untrusted and use the external-wrap pattern
+instead: your sandbox owns execution, the gate owns judgment.
+
+```bash
+docker run --network=none -v "$PKG:/work" your-sandbox-image \
+  sh -c "cd /work && npm ci && npm test"           # execution, isolated by YOU
+vyuh-dxkit gate "$PKG" --policy dod.json --json     # judgment, no execution
+```
+
+dxkit deliberately does not ship its own sandbox. Isolation guarantees
+belong to the layer that already owns your threat model (containers, VMs,
+your CI runner), and a bundled half-sandbox would be a false promise. The
+gate's contribution is that it never _needs_ to execute untrusted code to
+produce the scan verdict, and that every execution-dependent check it
+skipped is named in the verdict rather than silently absent.
+
+## Air-gapped and on-prem operation
+
+Three pieces make the gate reproducible offline:
+
+- **`vyuh-dxkit tools bom --json`** renders the full tool bill of
+  materials from the registry: every scanner, its pinned version, its
+  download sha256, and how it is installed. Feed it to your image review.
+- **`vyuh-dxkit tools install`** provisions those scanners with
+  checksum-verified downloads (fail-closed on mismatch). Run it at image
+  build time so the runtime image needs no network.
+- **`--advisory-db <dir>`** points the dependency audit at an offline OSV
+  advisory snapshot instead of the live feed. The snapshot directory
+  carries a `VERSION` file, and that version is part of the verdict's
+  recall context: two verdicts from different snapshots are never silently
+  compared as if they saw the same advisories.
+
+A minimal embed image:
+
+```dockerfile
+FROM node:22-slim
+RUN npm install -g vyuh-dxkit && vyuh-dxkit tools install
+COPY advisory-db /opt/advisory-db          # your mirrored OSV snapshot
+COPY dod-policy.json /opt/dod-policy.json
+ENTRYPOINT ["vyuh-dxkit", "gate", "/work", \
+  "--policy", "/opt/dod-policy.json", \
+  "--advisory-db", "/opt/advisory-db", "--json"]
+```
+
+## Reading verdict.v1
+
+The `--json` output is the `verdict.v1` wire schema (frozen in the
+extension SDK, additive-only): status and exit code, the policy identity,
+every finding with its stable fingerprint, every check that ran or was
+skipped **with the skip's cause**, the correctness-floor result, any
+refusals, and a receipt block your pipeline can store as evidence. Parse
+the schema, not the human text; the human rendering may improve between
+versions, the wire schema only grows.
+
+## Judging many trees as one estate
+
+When the subject is not one package but a workspace of services that must
+compose (calls resolve, declared end-to-end flows hold), use
+`gate --workspace`. That is its own guide: see **Wave gating**.

--- a/docs/learn/wave-gating.md
+++ b/docs/learn/wave-gating.md
@@ -1,0 +1,111 @@
+# Wave gating: judging an estate of trees as one composition
+
+For pipelines that emit or convert **many services in one wave** and need a
+verdict on the composition, not just on each member. Every member can pass
+its own gate while the estate is still broken: service A calls an endpoint
+nobody serves, service B serves an endpoint nobody calls anymore, and the
+end-to-end flow the migration was supposed to preserve quietly lost a step.
+The wave gate judges exactly that layer.
+
+## Layout
+
+Point `gate --workspace` at a directory whose immediate subdirectories are
+the member trees, with an optional flows directory of declared expected
+flows:
+
+```
+wave-2026-08/
+├── svc-orders/          # member tree
+├── svc-billing/         # member tree
+├── svc-pricing/         # member tree
+└── flows/               # declared flows (flow.v1)
+    └── order-to-invoice.flow.json
+```
+
+```bash
+vyuh-dxkit gate ./wave-2026-08 --workspace --flows flows --policy dod.json --json
+```
+
+Dot-directories and the flows directory itself are not members. Each member
+is analyzed with the same per-tree machinery the single-tree gate uses;
+the wave layer then composes the results.
+
+## What the composition checks
+
+The gate builds one **served mesh**: the union of every route every member
+serves, resolved with the same catch-all-aware matcher the repo-level flow
+gate uses. Against that mesh it evaluates three finding classes:
+
+- **Unresolved call** (`no-route`, blocks): a member calls a method + path
+  that no member serves. Absolute URLs are matched by path, so
+  `http://pricing.internal/tax` resolves against any member serving
+  `GET /tax`. Low-confidence paths (for example a path that starts with a
+  variable, leaving nothing to anchor on) warn instead of blocking.
+- **Dead route** (`dead-route`, warns): a member serves a route that no
+  member call and no declared flow step consumes. In a conversion wave this
+  is usually carried-over legacy surface; it warns because unused is a
+  cleanup decision, not a defect, and an external caller dxkit cannot see
+  may still depend on it.
+- **Broken flow** (`broken-flow`, blocks): a declared flow has a step the
+  mesh does not serve. This is the estate-level version of the paired
+  change rule: the flow file states an intent ("order to invoice still
+  works end to end"), and the gate holds the wave to it.
+
+Every finding's locator is member-prefixed (`svc-billing/srv/server.js`),
+so a wave verdict tells you which member to open.
+
+## Authoring flows (flow.v1)
+
+A flow file declares an ordered list of steps that must all be served:
+
+```json
+{
+  "schema": "flow.v1",
+  "id": "order-to-invoice",
+  "description": "An order placed in orders must price and invoice.",
+  "steps": [{ "call": "POST /orders" }, { "call": "GET /tax" }, { "call": "POST /invoices" }]
+}
+```
+
+Rules of the format:
+
+- `call` is `"<METHOD> <path>"`. Paths go through the same normalizer the
+  rest of dxkit uses, so `/orders/{id}` and `/orders/:id` are the same step.
+- The flows directory is scanned for `*.flow.json`. Two bare forms are also
+  accepted so hand-written files stay short: a bare array of steps, and a
+  bare `{ id, steps }` object without the `schema` field. Emit the full
+  `flow.v1` form from tooling.
+- A malformed step never silently disappears: it is disclosed in the
+  verdict as unparseable, because a flow file that stops parsing must not
+  read as a flow that passes.
+- Flow findings are identified by flow id, so a broken flow blocks once,
+  stably, rather than once per missing step per run.
+
+Keep flow files in the repo that owns the wave definition and review
+changes to them like contract changes: deleting a flow file is deleting a
+guarantee.
+
+## Reading a wave verdict
+
+The `--json` output is `verdict.v1` with `mode: "wave"`. A typical failing
+wave reads like this in the human rendering:
+
+```
+BLOCKED  wave: 3 members, 2 flows
+  ✗ no-route   GET /tax        called by svc-billing/srv/server.js (no member serves it)
+  ✗ broken-flow rebate-settlement  step GET /tax unserved
+  ⚠ dead-route GET /legacy-rebate  served by svc-pricing, no consumer
+```
+
+Fixing the unresolved call (serve `GET /tax` in the member that owns
+pricing) clears both blocks; removing the dead route clears the warning.
+The wave then exits 0 with the satisfied flows staying quiet.
+
+## Scope
+
+A wave run is **both layers in one verdict**. Each member tree first goes
+through the full single-tree gate under the same policy document (secrets,
+SAST, dependency vulnerabilities, text rules), with its findings
+member-prefixed; then the composition layer adds the mesh, call, and flow
+findings on top. One engine, one policy format, one exit code: a wave
+passes only when every member passes and the composition holds.

--- a/src-templates/.claude/skills/dxkit-gate/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-gate/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: dxkit-gate
+description: Judge a bare directory (a generated package, an exported tree, a workspace of services) with dxkit's one-shot gate — no git, no init — and read the verdict.v1 result. Use when the user asks to "gate this package", "check the generated code", "judge this tree/export against a policy", "gate the workspace/wave", or wants a pass/block verdict on code that is not an onboarded repo.
+---
+
+# dxkit-gate
+
+This skill runs the embeddable tree gate: one call in, one machine-readable
+verdict out. It is the same engine as the repo guardrail pointed at a bare
+directory, so the verdicts and fingerprints match what an onboarded repo
+would see.
+
+## Choosing the prior
+
+- **Fresh tree** (default): `vyuh-dxkit gate <dir> --policy <policy.json>`.
+  Everything found is net-new by construction. Right for a freshly
+  generated or converted package.
+- **Edited tree**: add `--baseline <original-dir>` to diff against the
+  generated original. Only findings the edit introduced can block;
+  pre-existing ones are grandfathered exactly like repo-mode debt.
+- **Workspace / wave**: `vyuh-dxkit gate <dir> --workspace --flows <flowsDir>`
+  judges every immediate subdirectory as a member tree AND the composition:
+  unresolved cross-member calls block, routes nobody consumes warn, and a
+  declared flow (`*.flow.json`, flow.v1) with an unserved step blocks.
+
+Always pass `--json` when a program (including you) reads the result; parse
+the `verdict.v1` document, not the human text.
+
+## Trust: decide it deliberately
+
+The gate treats the tree as untrusted by default: it scans bytes but never
+executes the tree's code, and the correctness floor (compile + tests) plus
+command checks are skipped with a disclosed cause. Pass `--trusted` ONLY
+when the user is prepared to execute the tree's own code. Ask if unclear;
+do not silently add `--trusted` to make skips go away.
+
+## Reading the verdict
+
+- Exit 0 `passed` / 1 `blocked` / 2 `cannot_gate`. Treat `cannot_gate` as a
+  refusal with a named reason and remedy, never as a pass or a failure to
+  fix in the code.
+- Each blocking finding carries a stable fingerprint, a file locator
+  (member-prefixed in wave mode), and the check that produced it.
+- `checks[]` entries with a `skippedWithCause` are disclosures, not errors.
+  Report them to the user (especially untrusted-skips) so "passed" is never
+  read as broader coverage than actually ran.
+- The verdict names the policy (`id`, `version`, content hash). When
+  comparing two verdicts, confirm the policy identity matches first.
+
+## Useful companions
+
+- `vyuh-dxkit init --gate-only` scaffolds just the policy file for an embed
+  (no hooks, CI, or .claude/).
+- `vyuh-dxkit tools bom --json` renders the scanner bill of materials
+  (pins + checksums) for image reviews.
+- `--advisory-db <dir>` points the dependency audit at an offline OSV
+  snapshot for air-gapped runs.
+- The full walkthroughs live in the learn pages "Embedding the gate" and
+  "Wave gating" (`vyuh-dxkit learn --serve`).

--- a/src/discovery/command-defs-gate.ts
+++ b/src/discovery/command-defs-gate.ts
@@ -51,6 +51,7 @@ export const GATE_COMMANDS = [
       'tree it is merely judging. `--workspace` judges N member trees as ONE estate wave: ' +
       'composed served mesh, unresolved cross-member calls, dead routes, and declared ' +
       'flow.v1 flows (`--flows <dir>`). Exit 0 passed / 1 blocked / 2 cannot gate.',
+    skill: 'dxkit-gate',
   },
   {
     id: 'guardrail',

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -212,6 +212,11 @@ export const DXKIT_SKILLS = [
   // enables the scheduled workflow, and reads the outcome ledger. Drives
   // `vyuh-dxkit remediate` + the policy.json:remediate config.
   'dxkit-remediate',
+  // dxkit-gate (4.4.0): the one-shot tree gate. Judges a bare directory
+  // (generated package, exported tree, workspace wave) under fresh or
+  // tree-baseline prior and reads the verdict.v1 result — the agent-facing
+  // surface of the embeddable gate engine.
+  'dxkit-gate',
 ] as const;
 
 interface GenerateResult {

--- a/src/learn/bundle.ts
+++ b/src/learn/bundle.ts
@@ -115,6 +115,8 @@ const DOC_SLUGS = [
   'quickstart-reviewer',
   'quickstart-admin',
   'operating-the-lanes',
+  'gate-embedding',
+  'wave-gating',
   'extending-dxkit',
 ] as const;
 

--- a/test/fixtures/gate/abap/seeded-placeholder/abaplint.json
+++ b/test/fixtures/gate/abap/seeded-placeholder/abaplint.json
@@ -1,0 +1,10 @@
+{
+  "global": { "files": "/**/*.{abap,asddls,acds}" },
+  "syntax": { "version": { "release": "Newest" }, "errorNamespace": "^(Z|Y|LCL_|TY_|LIF_)" },
+  "rules": {
+    "parser_error": true,
+    "structure": true,
+    "check_syntax": true,
+    "cds_parser_error": true
+  }
+}

--- a/test/fixtures/gate/abap/seeded-placeholder/code/zcl_orders_behavior.clas.abap
+++ b/test/fixtures/gate/abap/seeded-placeholder/code/zcl_orders_behavior.clas.abap
@@ -1,0 +1,10 @@
+CLASS zcl_orders_behavior DEFINITION PUBLIC FINAL CREATE PUBLIC.
+  PUBLIC SECTION.
+    METHODS total RETURNING VALUE(rv_result) TYPE i.
+ENDCLASS.
+CLASS zcl_orders_behavior IMPLEMENTATION.
+  METHOD total.
+    " TODO map discount fields
+    rv_result = 1.
+  ENDMETHOD.
+ENDCLASS.

--- a/test/fixtures/gate/abap/seeded-truncated-class/abaplint.json
+++ b/test/fixtures/gate/abap/seeded-truncated-class/abaplint.json
@@ -1,0 +1,10 @@
+{
+  "global": { "files": "/**/*.{abap,asddls,acds}" },
+  "syntax": { "version": { "release": "Newest" }, "errorNamespace": "^(Z|Y|LCL_|TY_|LIF_)" },
+  "rules": {
+    "parser_error": true,
+    "structure": true,
+    "check_syntax": true,
+    "cds_parser_error": true
+  }
+}

--- a/test/fixtures/gate/abap/seeded-truncated-class/code/zcl_orders_behavior.clas.abap
+++ b/test/fixtures/gate/abap/seeded-truncated-class/code/zcl_orders_behavior.clas.abap
@@ -1,0 +1,7 @@
+CLASS zcl_orders_behavior DEFINITION PUBLIC FINAL CREATE PUBLIC.
+  PUBLIC SECTION.
+    METHODS total RETURNING VALUE(rv_result) TYPE i.
+ENDCLASS.
+CLASS zcl_orders_behavior IMPLEMENTATION.
+  METHOD total.
+    rv_result = 1 +

--- a/test/fixtures/gate/package/clean/README.md
+++ b/test/fixtures/gate/package/clean/README.md
@@ -1,0 +1,1 @@
+# generated package (clean)

--- a/test/fixtures/gate/package/clean/code/handlers.js
+++ b/test/fixtures/gate/package/clean/code/handlers.js
@@ -1,0 +1,4 @@
+function orderTotal(items) {
+  return items.reduce((sum, i) => sum + i.price, 0);
+}
+module.exports = { orderTotal };

--- a/test/fixtures/gate/package/seeded-credential/README.md
+++ b/test/fixtures/gate/package/seeded-credential/README.md
@@ -1,0 +1,5 @@
+# generated package (credential seed injected at test time)
+
+The acceptance test writes a scannable credential into `code/service.js`
+in its scratch copy before gating. The committed fixture carries no
+credential bytes, so dxkit's own repo gate stays clean.

--- a/test/fixtures/gate/package/seeded-credential/code/service.js
+++ b/test/fixtures/gate/package/seeded-credential/code/service.js
@@ -1,0 +1,4 @@
+// The acceptance test seeds a scannable credential on the first line of
+// this file in its scratch COPY before gating (the committed fixture
+// carries none, so dxkit's own repo gate stays clean).
+module.exports = {};

--- a/test/fixtures/gate/package/seeded-placeholder/README.md
+++ b/test/fixtures/gate/package/seeded-placeholder/README.md
@@ -1,0 +1,1 @@
+# generated package (clean)

--- a/test/fixtures/gate/package/seeded-placeholder/code/handlers.js
+++ b/test/fixtures/gate/package/seeded-placeholder/code/handlers.js
@@ -1,0 +1,5 @@
+function orderTotal(items) {
+  // TODO wire discount handling
+  return items.reduce((sum, i) => sum + i.price, 0);
+}
+module.exports = { orderTotal };

--- a/test/fixtures/gate/workspace/flows/order-to-invoice.flow.json
+++ b/test/fixtures/gate/workspace/flows/order-to-invoice.flow.json
@@ -1,0 +1,4 @@
+{
+  "id": "order-to-invoice",
+  "steps": [{ "call": "GET /orders" }, { "call": "GET /price" }, { "call": "GET /invoice" }]
+}

--- a/test/fixtures/gate/workspace/flows/rebate-settlement.flow.json
+++ b/test/fixtures/gate/workspace/flows/rebate-settlement.flow.json
@@ -1,0 +1,1 @@
+{ "id": "rebate-settlement", "steps": [{ "call": "GET /invoice" }, { "call": "GET /tax" }] }

--- a/test/fixtures/gate/workspace/svc-billing/srv/server.js
+++ b/test/fixtures/gate/workspace/svc-billing/srv/server.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const app = express();
+app.get('/invoice', async (_req, res) => {
+  const tax = await fetch('http://pricing.internal/tax?amount=10').then((r) => r.json()); // seeded UNRESOLVED
+  res.json({ total: 10 + tax.value });
+});
+module.exports = app;

--- a/test/fixtures/gate/workspace/svc-orders/srv/server.js
+++ b/test/fixtures/gate/workspace/svc-orders/srv/server.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const app = express();
+app.get('/orders', async (_req, res) => {
+  const price = await fetch('http://pricing.internal/price?order=1').then((r) => r.json());
+  res.json({ id: 1, price });
+});
+module.exports = app;

--- a/test/fixtures/gate/workspace/svc-pricing/srv/server.js
+++ b/test/fixtures/gate/workspace/svc-pricing/srv/server.js
@@ -1,0 +1,5 @@
+const express = require('express');
+const app = express();
+app.get('/price', (_req, res) => res.json({ amount: 10 }));
+app.get('/legacy-rebate', (_req, res) => res.json({})); // seeded DEAD ROUTE
+module.exports = app;

--- a/test/gate/gate-acceptance.test.ts
+++ b/test/gate/gate-acceptance.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { cpSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runGateCommand, renderGateOutcome } from '../../src/gate-cli';
+import { runWaveCommand } from '../../src/gate-wave';
+import { DEFAULT_BROWNFIELD_POLICY } from '../../src/baseline/policy';
+import { policyForPreset } from '../../src/baseline/presets';
+
+/**
+ * The GATE ACCEPTANCE MATRIX (4.4.0 WP9) — the committed, neutralized
+ * form of the package-mode expected-verdict table, run as a standing
+ * gate rather than a one-off. Fixtures live in test/fixtures/gate/
+ * (package / abap / workspace); each row states the verdict a
+ * conversion-package DoD must produce. The abap rows need the
+ * registry-pinned abaplint on PATH (CI installs it; locally they skip
+ * with the binary named).
+ *
+ * The floor-tier row (seeded failing test) is covered by the
+ * injected-seam tests in gate-command.test.ts plus the release
+ * rehearsal's local tier — running a real jest install per CI run buys
+ * no additional truth for its cost.
+ */
+
+const FIXTURES = join(__dirname, '..', 'fixtures', 'gate');
+const HEAVY = 900_000;
+
+let hasAbaplint = false;
+try {
+  execSync('abaplint --version', { stdio: ['ignore', 'pipe', 'pipe'] });
+  hasAbaplint = true;
+} catch {
+  /* abap rows skip, named below */
+}
+
+/** The DoD every row runs under: security posture + the placeholder
+ *  text rule (blocking) — the neutral equivalent of a conversion
+ *  package's policy document. */
+function dodPolicyPath(dir: string): string {
+  const { policy } = policyForPreset('security-only', DEFAULT_BROWNFIELD_POLICY);
+  const p = join(dir, 'dod-policy.json');
+  writeFileSync(
+    p,
+    JSON.stringify({
+      ...policy,
+      id: 'acceptance.dod.pkg',
+      version: '1',
+      checks: [
+        {
+          name: 'no_placeholder',
+          pattern: '\\b(TODO|FIXME|XXX)\\b',
+          globs: ['code/**', 'tests/**'],
+          blocking: true,
+        },
+      ],
+    }),
+  );
+  return p;
+}
+
+let scratch: string;
+let policyPath: string;
+let savedSalt: string | undefined;
+
+beforeAll(() => {
+  savedSalt = process.env.DXKIT_BASELINE_SALT;
+  delete process.env.DXKIT_BASELINE_SALT;
+  scratch = mkdtempSync(join(tmpdir(), 'dxkit-acceptance-'));
+  policyPath = dodPolicyPath(scratch);
+});
+
+afterAll(() => {
+  if (savedSalt === undefined) delete process.env.DXKIT_BASELINE_SALT;
+  else process.env.DXKIT_BASELINE_SALT = savedSalt;
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+/** Run a fixture COPY (fixtures stay pristine) through the gate. */
+async function gateRow(
+  fixture: string,
+  opts: { trusted?: boolean; seed?: (copy: string) => void } = {},
+) {
+  const copy = join(scratch, fixture.replace(/\//g, '-'));
+  cpSync(join(FIXTURES, fixture), copy, { recursive: true });
+  opts.seed?.(copy);
+  const outcome = await runGateCommand(copy, { policyPath, trusted: opts.trusted });
+  return { outcome, doc: JSON.parse(renderGateOutcome(outcome, true)) };
+}
+
+/** The credential seed is assembled from fragments AT TEST TIME and written
+ *  only into the scratch copy — neither the committed fixture nor this test
+ *  file carries an adjacent scannable credential, so dxkit's own repo gate
+ *  stays clean while the copied tree scans hot. */
+function seedCredential(copy: string): void {
+  const target = join(copy, 'code', 'service.js');
+  const line = ['const apiKey = ', "'", 'fixt', '-live-', '0123456789abcdef', "'", ';'].join('');
+  writeFileSync(target, line + '\n' + readFileSync(target, 'utf8'));
+}
+
+describe('package rows', () => {
+  it(
+    'clean → passed',
+    async () => {
+      const { doc } = await gateRow('package/clean');
+      expect(doc.status).toBe('passed');
+      expect(doc.exitCode).toBe(0);
+    },
+    HEAVY,
+  );
+
+  it(
+    'seeded-placeholder → blocked by the text rule, fingerprinted',
+    async () => {
+      const { doc } = await gateRow('package/seeded-placeholder');
+      expect(doc.status).toBe('blocked');
+      const f = doc.findings.find(
+        (x: { kind: string; blocking: boolean }) => x.kind === 'custom-check' && x.blocking,
+      );
+      expect(f.file).toBe('code/handlers.js');
+      expect(f.fingerprint).toMatch(/^[0-9a-f]{16}$/);
+    },
+    HEAVY,
+  );
+
+  it(
+    'seeded-credential → blocked as a secret',
+    async () => {
+      const { doc } = await gateRow('package/seeded-credential', { seed: seedCredential });
+      expect(doc.status).toBe('blocked');
+      expect(
+        doc.findings.some(
+          (x: { kind: string; blocking: boolean }) => x.kind === 'secret' && x.blocking,
+        ),
+      ).toBe(true);
+    },
+    HEAVY,
+  );
+});
+
+describe('abap rows (need the registry-pinned abaplint)', () => {
+  it.skipIf(!hasAbaplint)(
+    'seeded-placeholder → blocked by the text rule over .abap',
+    async () => {
+      const { doc } = await gateRow('abap/seeded-placeholder');
+      expect(doc.status).toBe('blocked');
+      const f = doc.findings.find(
+        (x: { kind: string; blocking: boolean }) => x.kind === 'custom-check' && x.blocking,
+      );
+      expect(f.file).toContain('.clas.abap');
+    },
+    HEAVY,
+  );
+
+  it.skipIf(!hasAbaplint)(
+    'seeded-truncated-class → blocked by the abaplint parse floor (--trusted)',
+    async () => {
+      const { outcome, doc } = await gateRow('abap/seeded-truncated-class', { trusted: true });
+      expect(doc.status).toBe('blocked');
+      expect(outcome.floorNetNew.length).toBeGreaterThan(0);
+      const floorCheck = doc.floor.checks.find((c: { id: string }) =>
+        c.id.includes('abaplint-syntax'),
+      );
+      expect(floorCheck.status).toBe('failed');
+    },
+    HEAVY,
+  );
+});
+
+describe('workspace rows (both directions)', () => {
+  it(
+    'seeded estate → blocked: unresolved call + broken flow block, dead route visible',
+    async () => {
+      const copy = join(scratch, 'workspace-seeded');
+      cpSync(join(FIXTURES, 'workspace'), copy, { recursive: true });
+      const outcome = await runWaveCommand(copy, { flowsDir: 'flows', policyPath });
+      expect(outcome.verdict).toBe('blocked');
+      expect(outcome.exitCode).toBe(1);
+      const reasons = outcome.wave.seamFindings.map((f) => `${f.reason}:${f.path}`).sort();
+      expect(reasons).toContain('no-route:/tax');
+      expect(reasons).toContain('dead-route:/legacy-rebate');
+      expect(outcome.wave.flowFindings.map((f) => f.flowId)).toEqual(['rebate-settlement']);
+      // The satisfied flow stays quiet.
+      expect(outcome.wave.flowFindings.some((f) => f.flowId === 'order-to-invoice')).toBe(false);
+    },
+    HEAVY,
+  );
+
+  it(
+    'the SAME estate with the seeds fixed → passed',
+    async () => {
+      const copy = join(scratch, 'workspace-fixed');
+      cpSync(join(FIXTURES, 'workspace'), copy, { recursive: true });
+      const pricing = join(copy, 'svc-pricing', 'srv', 'server.js');
+      const src = readFileSync(pricing, 'utf8')
+        .replace(/app\.get\('\/legacy-rebate'.*\n/, '')
+        .replace(
+          "app.get('/price', (_req, res) => res.json({ amount: 10 }));",
+          "app.get('/price', (_req, res) => res.json({ amount: 10 }));\n" +
+            "app.get('/tax', (_req, res) => res.json({ value: 2 }));",
+        );
+      writeFileSync(pricing, src);
+      const outcome = await runWaveCommand(copy, { flowsDir: 'flows', policyPath });
+      expect(outcome.verdict).toBe('passed');
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.wave.flowFindings).toEqual([]);
+    },
+    HEAVY,
+  );
+});

--- a/test/learn/learn.test.ts
+++ b/test/learn/learn.test.ts
@@ -49,7 +49,7 @@ describe('learn bundle — registry-driven, cannot drift', () => {
     }
   });
 
-  it('carries every posture knob and all seven curated docs with real titles', () => {
+  it('carries every posture knob and all nine curated docs with real titles', () => {
     expect(bundle.knobs.length).toBe(POSTURE_KNOBS.length);
     expect(bundle.docs.map((d) => d.slug)).toEqual([
       'how-dxkit-thinks',
@@ -58,6 +58,8 @@ describe('learn bundle — registry-driven, cannot drift', () => {
       'quickstart-reviewer',
       'quickstart-admin',
       'operating-the-lanes',
+      'gate-embedding',
+      'wave-gating',
       'extending-dxkit',
     ]);
     for (const d of bundle.docs) {


### PR DESCRIPTION
Closes the WP9 slice of the 4.4.0 engine release: discovery + docs + the standing acceptance net for the gate command.

## What changed

**Learn guides** (curated set grows 7 → 9, pinned in the learn bundle test):
- \`docs/learn/gate-embedding.md\`: the embed walkthrough. The subject/prior/policy model, \`init --gate-only\`, exit-code contract, policy-as-DoD (preset + text rules + trusted-only command checks), the external-wrap sandbox pattern (your sandbox owns execution, the gate owns judgment), air-gapped operation (\`tools bom\`, checksum-verified installs, \`--advisory-db\` snapshots), and how to read verdict.v1.
- \`docs/learn/wave-gating.md\`: workspace layout, the three composition finding classes (no-route blocks, dead-route warns, broken-flow blocks), flow.v1 authoring rules, and the both-layers-in-one-verdict scope (verified against the wave runner: members ride the full per-member gate).

**Discovery**: the \`dxkit-gate\` skill ships with the agent pack — \`src-templates/.claude/skills/dxkit-gate/SKILL.md\`, a \`DXKIT_SKILLS\` entry, and \`skill: 'dxkit-gate'\` on the gate descriptor. Skills-parity and discovery-playbook nets stay green.

**The acceptance matrix as CI**: \`test/gate/gate-acceptance.test.ts\` drives neutralized fixtures under \`test/fixtures/gate/\` through \`runGateCommand\` / \`runWaveCommand\`:
- package: clean → PASSED; seeded placeholder → BLOCKED by the text rule (fingerprinted, repo-relative locator); seeded credential → BLOCKED as a secret
- abap (behind \`skipIf(!abaplint)\`, ran live locally): placeholder → BLOCKED by the text rule over \`.clas.abap\`; truncated class → BLOCKED by the abaplint parse floor under \`--trusted\`
- workspace, both directions: seeded estate → BLOCKED (unresolved \`GET /tax\` + broken \`rebate-settlement\` flow, \`dead-route\` warning visible, satisfied flow quiet); the same estate with seeds fixed → PASSED exit 0

The credential seed is assembled at test time into the scratch copy only — the committed tree carries no scannable credential bytes. The first self-guardrail run proved why: it correctly BLOCKED the committed-credential version of the fixture; the runtime-seed shape passes without an allowlist entry.

## Verification

- Full suite green (5,564 tests), plus the new matrix re-run after the credential-seed rework (7/7)
- eslint \`--max-warnings 0\`, format:check, check-architecture, check-slop, cross-ecosystem coverage, \`typecheck:test\` all green
- Self-guardrail \`ref-based\` vs \`origin/main\`: PASSED exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)