### PR TITLE
feat(positioning): WP-P — sixty-second front door, embed section, security-only gate fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,35 @@ It works on the repo you have today. Existing debt is baselined and
 attributed on day one, so the gate is green immediately and every verdict
 after that is about what actually changed.
 
+**In controlled agent-loop runs, ungated agents stopped with a seeded
+regression still in the tree in 11 of 16 runs. With the gate armed: 0 of 16.** ([methodology and artifacts](docs/benchmarks.md))
+
 <p align="center">
   <img src=".github/assets/loop-stop-gate-demo.gif" width="820" alt="dxkit blocks a coding-agent loop on a net-new regression, returns the finding to the agent, and allows the stop after the agent repairs it." />
 </p>
 <p align="center"><sub>Recorded from a real run on a synthetic repository, shortened for readability. Blocked and repaired inside the same warm loop.</sub></p>
+
+## Sixty seconds to a verdict
+
+Nothing to install into your project, nothing written, no git required:
+
+```bash
+npx -y @vyuhlabs/dxkit@latest gate .           # one-shot verdict on any directory
+npx -y @vyuhlabs/dxkit@latest learn --serve    # the whole product on one offline page
+```
+
+`gate` judges a bare tree — code an agent just generated, an exported
+package, a whole workspace of services (`--workspace`) — and exits 0
+passed, 1 blocked (each finding named with its durable fingerprint), or 2
+refused-with-reason. It is the same engine as the repo guardrail below,
+pointed at a directory instead of a git history, and it is embeddable: a
+codegen or conversion pipeline can call it on every tree it emits
+([embedding guide](docs/learn/gate-embedding.md),
+[wave gating](docs/learn/wave-gating.md)).
+
+On a repository you already work in, start with `evaluate` (below) instead:
+it replays your recent merges through the gate rather than judging years of
+existing debt as if it were new.
 
 ## Start in one command
 
@@ -83,11 +108,29 @@ agent, and the agent repaired it before stopping clean.
 The gate and the recorded fixtures replay offline without an API key;
 reproducing the original agent runs requires the documented model environment.
 
-dxkit also gates its own development. Its CI guardrail
-[blocked PR #134](https://github.com/vyuh-labs/dxkit/pull/134) on real
-findings (three files past the repo's size budget and a test fixture that a
-broken benchmark run had leaked into the tree). The failed and passing runs
-are in that PR's checks history. We fixed the findings, not the gate.
+The middle row is why guidance alone is not enough — and why dxkit is a
+**complement** to agent rulesets and prompt packs, not a replacement.
+Guidance makes agents write better code, and you should keep whatever
+guidance works for you; a self-check prompt still left 9 of 16 regressions
+in the tree, because advice cannot verify itself. The gate is the proof
+half: deterministic, outside the model, and unbribable by a confident
+summary.
+
+### Blocked, for real
+
+- **dxkit gates its own development.** Its CI guardrail
+  [blocked PR #134](https://github.com/vyuh-labs/dxkit/pull/134) on real
+  findings (three files past the repo's size budget and a test fixture a
+  broken benchmark run had leaked into the tree). The failed and passing
+  runs are in that PR's checks history. We fixed the findings, not the gate.
+- **A lint-cleanup agent introduced vulnerabilities; the gate caught it.**
+  In a production remediation run, an agent tasked with cleaning up lint
+  findings shipped security regressions in its "cleanup". The guardrail
+  blocked the PR and returned the exact findings; nothing landed.
+- **Advisories published the same hour.** During one of dxkit's own release
+  checks, the gate flagged two dependency advisories that had been published
+  earlier that day — after the baseline was captured — and routed them to
+  the decision lane instead of silently absorbing or silently blocking.
 
 <p>
   <a href="https://www.npmjs.com/package/@vyuhlabs/dxkit"><img alt="npm" src="https://img.shields.io/npm/v/@vyuhlabs/dxkit"></a>
@@ -319,6 +362,30 @@ npx vyuh-dxkit jobs          # what's installed: triggers, schedules, last runs
 npx vyuh-dxkit policy set    # cadence, budgets, which tasks are enabled
 ```
 
+## Embed it: a verdict engine for pipelines that emit code
+
+Everything above gates a repository over time. The same engine also ships
+as a one-call verdict for systems that produce code: a generation pipeline,
+a conversion factory, an on-prem review image.
+
+```bash
+vyuh-dxkit gate ./emitted-package --policy dod.json --json     # fresh tree: everything is net-new
+vyuh-dxkit gate ./edited --baseline ./original --json          # diff a tree against its original
+vyuh-dxkit gate ./wave --workspace --flows flows --json        # N services judged as one estate
+```
+
+The `--json` output is the frozen `verdict.v1` schema: status, exit code,
+the policy's identity (id, version, content hash), every finding with its
+fingerprint, every skipped check with its cause, and a receipt your
+pipeline can store as evidence. The gate never executes code from a tree it
+is merely judging (`--trusted` is explicit consent), `init --gate-only`
+scaffolds just the policy file, `tools bom` prints the scanner
+bill-of-materials for image review, and `--advisory-db` runs the dependency
+audit against an offline snapshot. The full walkthrough is the
+[embedding guide](docs/learn/gate-embedding.md); judging many trees as one
+composition (unresolved cross-service calls, dead routes, declared
+end-to-end flows) is [wave gating](docs/learn/wave-gating.md).
+
 ## Show your team: the whole product, one page
 
 ```bash
@@ -425,7 +492,7 @@ either kind; `extensions dev` validates in seconds. See
 
 ## Languages
 
-dxkit covers 10 ecosystems. Detection is automatic from your manifests and
+dxkit covers 11 ecosystems. Detection is automatic from your manifests and
 source; each language brings its own native linter, dependency-audit tool, and
 coverage parser, layered on the universal scanners.
 

--- a/src/baseline/policy.ts
+++ b/src/baseline/policy.ts
@@ -421,20 +421,30 @@ export { policyContentHash } from './policy-naming';
  *      path is supplied but unreadable / malformed.
  *   2. `<cwd>/.dxkit/policy.json` (conventional). Silently skipped
  *      when absent so consumers without a policy get the defaults.
- *   3. `DEFAULT_BROWNFIELD_POLICY` (compiled-in fallback).
+ *   3. `fallback` — `DEFAULT_BROWNFIELD_POLICY` unless the surface
+ *      declares a different no-policy posture (the tree gate passes the
+ *      security-only preset: under a fresh prior EVERY finding is
+ *      net-new, so the fully armed compiled default would block any
+ *      real tree on test-gap/quality debt no DoD ever asked about).
+ *      A policy FILE still merges over the compiled default — only the
+ *      nothing-configured arm is surface-tunable.
  *
  * Customer fields shallow-merge over the default. The
  * `confidence` / `blockRules` blocks deep-merge by key. Unknown
  * fields are preserved — the classifier ignores what it doesn't
  * know, so forward-compatible policy files don't break old dxkit.
  */
-export function resolvePolicy(policyPath: string | undefined, cwd: string): BrownfieldPolicy {
+export function resolvePolicy(
+  policyPath: string | undefined,
+  cwd: string,
+  fallback: BrownfieldPolicy = DEFAULT_BROWNFIELD_POLICY,
+): BrownfieldPolicy {
   let resolvedPath: string | undefined = policyPath;
   if (!resolvedPath) {
     const conventional = path.join(cwd, DEFAULT_POLICY_FILENAME);
     if (fs.existsSync(conventional)) resolvedPath = conventional;
   }
-  if (!resolvedPath) return DEFAULT_BROWNFIELD_POLICY;
+  if (!resolvedPath) return fallback;
   const read = readPolicyRoot(resolvedPath);
   if (read.status === 'absent') {
     // Only reachable via an explicit `--policy <p>` pointing at a missing file

--- a/src/gate-cli.ts
+++ b/src/gate-cli.ts
@@ -6,7 +6,7 @@
  * tree, prior = `fresh` (empty — everything net-new by construction) or
  * `tree-baseline` (`--baseline <dir>`, the generated-vs-edited diff),
  * policy = `--policy <file>` or the tree's own `.dxkit/policy.json` or
- * the compiled-in default. On top of the finding diff it runs the
+ * the security-only fallback. On top of the finding diff it runs the
  * correctness floor ("does it compile, do its tests pass") — the part
  * of a verdict findings cannot carry.
  *
@@ -27,7 +27,8 @@ import * as path from 'path';
 import { runGate } from './gate/engine';
 import type { GuardrailCheckResult } from './gate/result';
 import { resolveGateMode } from './baseline/modes';
-import { resolvePolicy } from './baseline/policy';
+import { DEFAULT_BROWNFIELD_POLICY, resolvePolicy } from './baseline/policy';
+import { DEFAULT_LOOP_PRESET, policyForPreset } from './baseline/presets';
 import { trustContextFromFlag } from './analysis-trust';
 import { renderConsole, verdictCounts, type VerdictCounts } from './baseline/check-renderers';
 import { isAdvisoryDbError, resolveAdvisoryDb } from './analyzers/security/advisory-db';
@@ -49,7 +50,8 @@ export interface GateCommandOptions {
   /** Prior tree for the generated-vs-edited diff (H2). Absent = fresh. */
   readonly baselineDir?: string;
   /** Explicit policy document (P0-3). Falls back to the tree's own
-   *  `.dxkit/policy.json`, then the compiled-in default. */
+   *  `.dxkit/policy.json`, then the security-only posture (a fresh
+   *  prior + the fully armed default would block any tree on debt). */
   readonly policyPath?: string;
   readonly json?: boolean;
   /** Consent to EXECUTE the tree's code (floor + command checks). */
@@ -168,7 +170,17 @@ export async function runGateCommand(
   const baselineDir =
     options.baselineDir !== undefined ? path.resolve(options.baselineDir) : undefined;
   const mode = resolveGateMode(baselineDir !== undefined ? { baselineDir } : {});
-  const policy = resolvePolicy(options.policyPath, subjectDir);
+  // The nothing-configured fallback is the SECURITY-ONLY posture, not the
+  // fully armed compiled default: under a fresh prior every finding is
+  // net-new, so armed test-gap/quality rules would block any real tree on
+  // debt no DoD ever asked about. Same cost-bounded default every other
+  // unattended surface gets (loop preset, evaluate trial). An explicit
+  // --policy or a tree-committed policy.json always wins.
+  const policy = resolvePolicy(
+    options.policyPath,
+    subjectDir,
+    policyForPreset(DEFAULT_LOOP_PRESET, DEFAULT_BROWNFIELD_POLICY).policy,
+  );
   // --trusted is the consent flag; its ABSENCE is the untrusted posture.
   const trust = trustContextFromFlag(!options.trusted);
 

--- a/test/gate/gate-command.test.ts
+++ b/test/gate/gate-command.test.ts
@@ -123,6 +123,35 @@ describe('gate <dir> (fresh prior, default untrusted)', () => {
     },
     HEAVY,
   );
+
+  it(
+    'no policy at all → the security-only fallback: an untested source file warns, never blocks (WP-P front door)',
+    async () => {
+      // No --policy and no committed .dxkit/policy.json. Under the fresh
+      // prior every finding is net-new, so the fully armed compiled default
+      // (newUntestedChangedSource et al) would BLOCK this trivial tree on a
+      // test-gap — the shape that made a first-touch `gate .` read as a
+      // false positive. The fallback is the cost-bounded security-only
+      // posture instead; the gap still surfaces, as a warning.
+      const dir = makeTree({
+        'README.md': '# generated package\n',
+        'src/index.js': 'module.exports = (a, b) => a + b;\n',
+      });
+      const outcome = await runGateCommand(dir, {});
+      expect(outcome.verdict).toMatch(/^PASSED/);
+      expect(outcome.exitCode).toBe(0);
+      const gap = outcome.result.pairs.find((p) => p.kind === 'test-gap');
+      expect(gap).toBeDefined();
+      expect(gap?.classification.blocks).toBe(false);
+      // The verdict names the exact fallback policy it judged under.
+      const doc = JSON.parse(renderGateOutcome(outcome, true));
+      const { policyContentHash } = await import('../../src/baseline/policy');
+      expect(doc.policy.hash).toBe(
+        policyContentHash(policyForPreset('security-only', DEFAULT_BROWNFIELD_POLICY).policy),
+      );
+    },
+    HEAVY,
+  );
 });
 
 describe('the correctness floor under --trusted', () => {


### PR DESCRIPTION
The end-of-release positioning rework (WP-P), plus the one product change it exposed.

## README

- **One measured number on the first screen**: 11/16 ungated dirty stops vs 0/16 gated, linked to the methodology page.
- **Front door**: a "Sixty seconds to a verdict" section with two zero-write commands — `gate .` (one-shot verdict on any directory, embeddable) and `learn --serve` — while `evaluate` stays the honest first touch for an existing repo (it replays merges instead of judging old debt as new).
- **Blocked, for real**: three genuine stories — the self-gated PR #134, a production lint-cleanup agent whose security regressions the gate blocked from landing, and two same-hour advisories routed to the decision lane during a release check. No customer or product names.
- **Complement, not competitor**: hung on the benchmark's own middle row (a self-check prompt still left 9/16 regressions) — guidance makes agents write better code; the gate proves what they wrote didn't break anything. No competitor named.
- **Embed section** fronting `gate` / `verdict.v1` / `init --gate-only` / `tools bom` / `--advisory-db`, linking the two WP9 learn guides.
- Ecosystem count corrected to 11 (ABAP landed in WP6).

## The product change: gate's no-policy fallback is security-only

Dogfooding the front-door command found this: `gate .` on a trivial one-file tree returned **BLOCKED** on a medium test-gap, because the no-policy fallback was the fully armed compiled default and a fresh prior makes every finding net-new — so `newUntestedChangedSource` fires on any real tree. That reads as a false positive to a first-touch user and contradicts the cost-bounded default posture every other unattended surface uses.

Fix: `resolvePolicy` gains an optional `fallback` argument (one resolution path, unchanged precedence); the gate passes the security-only preset. A `--policy` flag or tree-committed `policy.json` always wins, and a policy FILE still merges over the compiled default. The wave command inherits the fallback through the per-member gate. The verdict names the fallback policy by content hash.

Pinned in `gate-command.test.ts`: no-policy tree with an untested source file → PASSED with the test-gap as a warning, and `doc.policy.hash` equals the preset policy's content hash. Verified live both directions: the trivial tree passes; a seeded credential still blocks exit 1.

Also decided here: the Claude Code plugin-marketplace entry is deferred to 4.4.1 — a new distribution surface deserving its own validation pass, not a release rider.

## Verification

Full suite green (5,558 tests), eslint `--max-warnings 0`, format, arch, slop, cross-ecosystem, `typecheck:test`, and the self-guardrail (`ref-based` vs `origin/main`) PASSED exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)