### PR TITLE
feat(gate): required-observation semantics (4.4.1 WP1a)

### DIFF
--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -27,6 +27,7 @@ stanzas).
 | `depBump.schedule`                  | [#dep-bump](#dep-bump)                       |
 | `duplication.mode`                  | [#duplication-mode](#duplication-mode)       |
 | `expiryNotice.enabled`              | [#expiry-notice](#expiry-notice)             |
+| `floor.required`                    | [#floor-required](#floor-required)           |
 | `flow.mode`                         | [#flow-mode](#flow-mode)                     |
 | `flow.sources`                      | [#flow-sources](#flow-sources)               |
 | `graph.refresh`                     | [#graph-refresh](#graph-refresh)             |
@@ -180,6 +181,34 @@ review comment. Prefer `parse: { regex }` for linter-shaped output.
 
 **Security.** Commands run from THIS committed file only — review edits to
 `checks[].command` like CI config changes.
+
+**Required observation.** `checks[].required: true` makes a check's
+OBSERVATION part of the verdict contract: if the check did not run
+(untrusted tree, missing toolchain, ref-based mode), the verdict is
+`CANNOT GATE` with the cause and remedy named — never a disclosed skip
+under a PASSED banner. Orthogonal to `blocking`, which decides what a
+net-new FAILURE does once the check ran. Default false: an optional
+check that cannot run keeps the skip-and-disclose behavior.
+
+## Floor required
+
+**What it does.** Makes the correctness floor ("does it compile, do its
+tests pass") a verdict REQUIREMENT on the `gate` command family. When the
+floor cannot run — the tree is untrusted and `--trusted` was not passed —
+the gate answers `CANNOT GATE` (exit 2) instead of certifying a tree whose
+compile and tests it never saw.
+
+**Default and why.** `true` on the gate surface — the gate's product
+promise is refusing to certify what it did not observe, and the one-shot
+gate has no CI backstop behind it. The loop Stop-gate, pre-push, and CI
+floor surfaces are NOT governed by this knob: they keep their declared
+fail-open-on-infrastructure doctrine, because a slow or missing toolchain
+must not wedge an unattended loop and CI is their backstop.
+
+**When you would change it.** Set `"floor": { "required": false }` in an
+embedding pipeline that gates untrusted trees on findings only and runs
+the compile/test floor elsewhere — the skip stays disclosed in the verdict
+either way.
 
 ## Paired change rules
 

--- a/docs/configuration/policy.md
+++ b/docs/configuration/policy.md
@@ -68,6 +68,7 @@ tuning belongs here.
 | `licenses`                  | `object`       | License posture: `prohibited` lists SPDX ids/prefixes that block on new dependencies. See "Prohibited licenses" below.                                                                                                                                                                                              |
 | `depBump`                   | `object`       | Scheduled deterministic dependency-bump lane (`enabled`, `allowMajor`). See the `depBump` section below.                                                                                                                                                                                                            |
 | `lint`                      | `object`       | Enable the pack-declared built-in lint gate. `{ enabled, blocking }`, both default `false`.                                                                                                                                                                                                                         |
+| `floor`                     | `object`       | Correctness-floor posture for the `gate` command family. `{ "required": true }` (the default) makes a floor that could not run a `CANNOT GATE` refusal instead of a disclosed skip; `{ "required": false }` restores skip-and-disclose. Loop/pre-push/CI floor surfaces are not governed by this key.               |
 | `largeFileThreshold`        | `number`       | Line count above which a source file is flagged `large-file` (default `500`). Applied once at gather time, so it drives the guardrail `large-file` finding, the "files over N lines" count, and the Quality + Maintainability scores together. A non-positive / non-numeric value is ignored (falls back to `500`). |
 | `reports`                   | `object`       | Opt-in report snapshots on merge. See "Report snapshots on merge" below.                                                                                                                                                                                                                                            |
 | `graph`                     | `object`       | Code-graph freshness transport. `{ "refresh": "cache" \| "off" }` (default `off`). See "Code-graph refresh transport" below.                                                                                                                                                                                        |
@@ -189,7 +190,11 @@ sources feed one seam:
 ```
 
 - **`checks[]`** — user-declared invariants. `command` is a string or argv
-  array; `blocking` (default `true`) sets block-vs-warn; `expectedExit`
+  array; `blocking` (default `true`) sets block-vs-warn; `required` (default
+  `false`) makes the check's OBSERVATION part of the verdict contract — a
+  required check that did not run (untrusted tree, missing toolchain,
+  ref-based mode) turns the verdict into `CANNOT GATE` with the cause and
+  remedy named, instead of a disclosed skip under PASSED; `expectedExit`
   (default `0`) sets the passing exit code; `parse` is `"exit"` (BINARY — the
   whole command passes or fails) or `{ "regex": "…" }` (LOCATED — each matching
   line is a finding keyed on `file+line+rule`, so net-new lint errors block

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -36,6 +36,7 @@ import type {
 } from './check';
 import { attributionGapRemedy, describeAttributionGap } from './attribution-gap';
 import type { AttributionGap } from './attribution-gap';
+import type { RequiredObservationGap } from '../gate/required-observation';
 import {
   EXPIRY_PROJECTION_REMEDY,
   describeExpiryProjection,
@@ -122,6 +123,9 @@ export interface VerdictCounts {
   readonly blocking: number;
   /** Unattributable block-rule-class findings (the `CANNOT GATE` tier). */
   readonly unattributable: number;
+  /** Policy-declared REQUIRED checks whose observation is missing — the
+   *  refusal tier's observation sibling (WP1, §7.1). */
+  readonly requiredMissing: number;
   readonly warning: number;
   readonly resolved: number;
 }
@@ -138,9 +142,15 @@ export function verdictWordFrom(v: {
   readonly blocks: boolean;
   readonly warns: boolean;
   readonly unattributable: number;
+  /** Missing required-check observations (WP1) — joins the refusal tier
+   *  exactly as attribution gaps do. Optional so pre-WP1 callers keep
+   *  compiling; absent means zero. */
+  readonly requiredMissing?: number;
 }): { verdict: VerdictWord; exitCode: 0 | 1 } {
   if (v.blocks) return { verdict: 'BLOCKED', exitCode: 1 };
-  if (v.unattributable > 0) return { verdict: 'CANNOT GATE', exitCode: 1 };
+  if (v.unattributable > 0 || (v.requiredMissing ?? 0) > 0) {
+    return { verdict: 'CANNOT GATE', exitCode: 1 };
+  }
   return v.warns
     ? { verdict: 'PASSED (with warnings)', exitCode: 0 }
     : { verdict: 'PASSED', exitCode: 0 };
@@ -186,16 +196,19 @@ export function verdictCounts(result: GuardrailCheckResult): VerdictCounts {
   // and the per-pair markers come from the same classifier output, so the
   // counts agree by construction.
   const unattributable = result.attributionGaps.reduce((n, g) => n + g.findingCount, 0);
+  const requiredMissing = result.requiredNotObserved.length;
   const word = verdictWordFrom({
     blocks: result.blocks,
     warns: result.warns,
     unattributable,
+    requiredMissing,
   });
   return {
     verdict: word.verdict,
     exitCode: word.exitCode,
     blocking: result.pairs.filter(isBlocking).length + extra.block,
     unattributable,
+    requiredMissing,
     warning: result.pairs.filter(isWarning).length + extra.warn,
     resolved: result.pairs.filter((p) => p.classification.status === 'removed').length,
   };
@@ -327,6 +340,18 @@ export function renderConsole(result: GuardrailCheckResult): string {
       lines.push(`  · ${describeAttributionGap(gap)}`);
     }
     lines.push(`  · ${attributionGapRemedy(result.envelopeDrift.refreshLaneInstalled)}`);
+    lines.push('');
+  }
+  if (result.requiredNotObserved.length > 0) {
+    lines.push(
+      logger.bold(
+        `Required checks not observed — refusing to pass (${result.requiredNotObserved.length})`,
+      ),
+    );
+    for (const gap of result.requiredNotObserved) {
+      lines.push(`  · ${gap.reason}`);
+      lines.push(`    remedy: ${gap.remedy}`);
+    }
     lines.push('');
   }
   if (suppressed.length > 0) {
@@ -903,6 +928,16 @@ function verdictBanner(result: GuardrailCheckResult): string {
         `block-rule kind${result.attributionGaps.length === 1 ? '' : 's'} (${kinds}) cannot be attributed`,
     );
   }
+  if (result.requiredNotObserved.length > 0) {
+    // The observation refusal (WP1, §7.1): a policy-declared required check
+    // did not run. Same tier as the attribution refusal — never PASSED over
+    // missing required evidence.
+    const n = result.requiredNotObserved.length;
+    const ids = result.requiredNotObserved.map((g) => g.checkId).join(', ');
+    return logger.bold(
+      `Guardrail CANNOT GATE — ${n} required check${n === 1 ? '' : 's'} not observed (${ids})`,
+    );
+  }
   if (result.warns) {
     const count = result.pairs.filter(isWarning).length + extra.warn;
     return logger.bold(`Guardrail PASSED — ${count} warning${count === 1 ? '' : 's'}`);
@@ -1226,6 +1261,11 @@ export interface GuardrailJsonPayload {
    *  disarmed, how many findings, and which recall input moved. Empty on a
    *  healthy run. */
   readonly attributionGaps: ReadonlyArray<AttributionGap>;
+  /** The refusal tier's observation sibling (WP1, §7.1): policy-declared
+   *  REQUIRED checks whose observation is missing this run, each with its
+   *  reason + remedy. ALWAYS present (`[]` when nothing required was
+   *  missed); non-empty makes the verdict `CANNOT GATE`. */
+  readonly requiredNotObserved: ReadonlyArray<RequiredObservationGap>;
   /** What this run's ACTIVE allowlist suppressions will do when their windows
    *  close: how many would block, how many would warn, and how soon. ALWAYS
    *  present (`lapsing: []` when nothing expires inside the horizon), so an
@@ -1478,6 +1518,10 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
       exitCode: counts.exitCode,
     },
     attributionGaps: result.attributionGaps,
+    // Required checks whose observation is missing (WP1, §7.1). Always
+    // present — an agent must be able to tell "nothing required was missed"
+    // from "nobody said".
+    requiredNotObserved: result.requiredNotObserved,
     suppressionExpiry: result.suppressionExpiry,
     // Baseline findings the current side never re-verified (per unobserved
     // check, aggregate counts). Always present — an agent reading the JSON
@@ -1748,6 +1792,20 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
       for (const p of unattributable) lines.push(markdownPairRow(p));
       lines.push('');
     }
+  }
+
+  if (result.requiredNotObserved.length > 0) {
+    const n = result.requiredNotObserved.length;
+    lines.push(
+      `> ⚠️ **${n} required check${n === 1 ? '' : 's'} not observed** — the verdict is ` +
+        `CANNOT GATE: the policy declares the check${n === 1 ? '' : 's'} required, and the run ` +
+        `cannot certify what it did not see.`,
+    );
+    for (const gap of result.requiredNotObserved) {
+      lines.push(`> - ${escapeMd(gap.reason)}`);
+      lines.push(`>   - Remedy: ${escapeMd(gap.remedy)}`);
+    }
+    lines.push('');
   }
 
   if (result.depVulnsUnmeasured) {
@@ -2316,6 +2374,10 @@ function summarySentence(
     parts.push(
       `${unattributableCount} unattributable finding${unattributableCount === 1 ? '' : 's'} on block-rule kinds`,
     );
+  }
+  if (result.requiredNotObserved.length > 0) {
+    const n = result.requiredNotObserved.length;
+    parts.push(`${n} required check${n === 1 ? '' : 's'} not observed`);
   }
   if (warningCount > 0) parts.push(`${warningCount} warning${warningCount === 1 ? '' : 's'}`);
   if (resolvedCount > 0) parts.push(`${resolvedCount} resolved`);

--- a/src/baseline/policy-checks.ts
+++ b/src/baseline/policy-checks.ts
@@ -52,6 +52,14 @@ export interface CustomCheckConfig {
   readonly globs?: readonly string[];
   /** Net-new failure blocks (default true) or only warns (false). */
   readonly blocking?: boolean;
+  /** The check's OBSERVATION is required for a certifiable verdict
+   *  (default false). A required check that did not run — untrusted
+   *  tree, missing toolchain, ref-based mode — turns the verdict into
+   *  `CANNOT GATE` with the cause and remedy named, instead of a
+   *  disclosed skip under a PASSED banner. Orthogonal to `blocking`
+   *  (which decides what a net-new FAILURE does once observed). One
+   *  evaluator: `src/gate/required-observation.ts`. */
+  readonly required?: boolean;
   /** Exit code meaning "pass" (default 0). Command checks only. */
   readonly expectedExit?: number;
   /** Output→findings extraction. `'exit'` (default): one binary finding per

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -137,6 +137,11 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
     anchor: 'custom-checks',
   },
   {
+    path: 'floor.required',
+    summary: 'a gate verdict requires the correctness floor to have run (default true)',
+    anchor: 'floor-required',
+  },
+  {
     path: 'pairedChecks',
     summary: 'changing X requires also changing Y; declarative, nothing spawned',
     anchor: 'paired-change-rules',

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -171,6 +171,13 @@ export function buildPolicySchema(version: string): Schema {
         },
         'Pack-declared linter as a gate citizen.',
       ),
+      floor: obj(
+        {
+          required: boolProp('floor.required'),
+        },
+        'Correctness-floor posture for the gate command family (compile + tests as a ' +
+          'verdict requirement).',
+      ),
       checks: {
         type: 'array',
         description: desc('checks'),
@@ -200,6 +207,14 @@ export function buildPolicySchema(version: string): Schema {
                 'paths. Absent scans every non-excluded file.',
             },
             blocking: { type: 'boolean', description: 'Net-new failure blocks (default true).' },
+            required: {
+              type: 'boolean',
+              description:
+                'The check must be OBSERVED for a certifiable verdict (default false). A ' +
+                'required check that did not run (untrusted tree, missing toolchain, ' +
+                'ref-based mode) turns the verdict into CANNOT GATE with the cause and ' +
+                'remedy named, instead of a disclosed skip under PASSED.',
+            },
             expectedExit: { type: 'number', description: 'Exit code meaning pass (default 0).' },
             parse: {
               description:

--- a/src/baseline/policy-sections.ts
+++ b/src/baseline/policy-sections.ts
@@ -184,3 +184,17 @@ export function prohibitedLicensePatterns(policy: {
     ),
   ].sort();
 }
+
+/** `floor.*` block in `.dxkit/policy.json` (see `BrownfieldPolicy.floor`). */
+export interface FloorPolicy {
+  /** The floor's observation is required for a certifiable gate verdict
+   *  (default true on the gate surface). */
+  readonly required?: boolean;
+}
+
+/** `graph.*` block in `.dxkit/policy.json`. */
+export interface GraphSection {
+  /** `'cache'` → install the graph-refresh workflow (Actions-cache transport);
+   *  `'off'`/absent → rebuild on demand (the default). */
+  readonly refresh?: 'cache' | 'off';
+}

--- a/src/baseline/policy.ts
+++ b/src/baseline/policy.ts
@@ -31,7 +31,13 @@ export type { CustomCheckConfig, LintPolicy } from './policy-checks';
 import { readPolicyRoot } from './policy-text';
 import type { BaselineMode, BaselineAnchor } from './modes';
 import type { FindingSeverity, FindingStatus } from './types';
-import type { LicensesPolicy, NewAdvisoriesPolicy, PairedCheckConfig } from './policy-sections';
+import type {
+  FloorPolicy,
+  GraphSection,
+  LicensesPolicy,
+  NewAdvisoriesPolicy,
+  PairedCheckConfig,
+} from './policy-sections';
 
 // The newer section shapes + their ONE normalizers live in
 // `policy-sections.ts` (split at the large-file bar); re-exported here so
@@ -42,6 +48,8 @@ export {
   baselineRefreshCron,
   newAdvisoryBlockSeverities,
   prohibitedLicensePatterns,
+  type FloorPolicy,
+  type GraphSection,
   type LicensesPolicy,
   type NewAdvisoriesPolicy,
   type PairedCheckConfig,
@@ -344,6 +352,17 @@ export interface BrownfieldPolicy {
    */
   readonly recall?: RecallPolicy;
   /**
+   * Correctness-floor posture for the surfaces that own tree-level floor
+   * execution (the `gate` command family). `required` defaults TRUE there:
+   * a floor that cannot run (untrusted tree) makes the verdict `CANNOT
+   * GATE` instead of a disclosed skip under PASSED. `{ "required": false }`
+   * restores skip-and-disclose. Loop / pre-push / CI floor surfaces are NOT
+   * governed by this field — they keep the declared Rule-15 fail-open-on-
+   * infrastructure doctrine (CI is their backstop; the one-shot gate has
+   * none).
+   */
+  readonly floor?: FloorPolicy;
+  /**
    * Code-graph freshness transport. Absent/`'off'` ⟹ the graph is rebuilt on
    * demand by each consumer (the default). `'cache'` installs the
    * `dxkit-graph-refresh` workflow, which rebuilds `graph.json` on merge to the
@@ -352,13 +371,6 @@ export interface BrownfieldPolicy {
    * because it's a CI-performance optimization, not a correctness gate.
    */
   readonly graph?: GraphSection;
-}
-
-/** `graph.*` block in `.dxkit/policy.json`. */
-export interface GraphSection {
-  /** `'cache'` → install the graph-refresh workflow (Actions-cache transport);
-   *  `'off'`/absent → rebuild on demand (the default). */
-  readonly refresh?: 'cache' | 'off';
 }
 
 /**

--- a/src/gate-cli.ts
+++ b/src/gate-cli.ts
@@ -26,6 +26,7 @@
 import * as path from 'path';
 import { runGate } from './gate/engine';
 import type { GuardrailCheckResult } from './gate/result';
+import { floorRequiredGap, type RequiredObservationGap } from './gate/required-observation';
 import { resolveGateMode } from './baseline/modes';
 import { DEFAULT_BROWNFIELD_POLICY, resolvePolicy } from './baseline/policy';
 import { DEFAULT_LOOP_PRESET, policyForPreset } from './baseline/presets';
@@ -86,6 +87,10 @@ export interface GateCommandOutcome {
   readonly floorNetNew: ReadonlyArray<AttributedFloorFailure>;
   /** Present when the floor was skipped, with the declared cause. */
   readonly floorSkipped?: FloorSkip;
+  /** Present when the skipped floor was REQUIRED (WP1, §7.1 —
+   *  `policy.floor.required`, default true): the gate refuses
+   *  (`CANNOT GATE`, exit 2) instead of passing over the skip. */
+  readonly floorRequiredGap?: RequiredObservationGap;
 }
 
 /** Map a floor check status onto the attribution comparator's base shape. */
@@ -236,18 +241,26 @@ export async function runGateCommand(
     };
   }
 
+  // The floor's required-observation gap (WP1, §7.1): a skipped floor
+  // under `floor.required` (the default) is a REFUSAL, not a disclosed
+  // pass — the gate will not certify a tree whose compile + tests it was
+  // told to require but could not run. ONE evaluator decides
+  // (`required-observation.ts`); the engine already folded required
+  // CUSTOM checks into `counts` the same way.
+  const floorGap = floorRequiredGap(policy, floorSkipped);
+
   // Exit-code derivation: the one verdict derivation first, then the
   // floor. A net-new floor failure is a BLOCK (fail-closed on a real
   // failure — Rule 15); a refusal (CANNOT GATE) maps to the gate's own
   // exit 2. Precedence mirrors verdictWordFrom: a definite regression
-  // outranks a refusal.
+  // outranks a refusal, a refusal outranks any pass.
   const floorBlocks = floorNetNew.length > 0;
   let exitCode: 0 | 1 | 2;
   let verdict: string;
   if (counts.verdict === 'BLOCKED' || floorBlocks) {
     exitCode = 1;
     verdict = 'BLOCKED';
-  } else if (counts.verdict === 'CANNOT GATE') {
+  } else if (counts.verdict === 'CANNOT GATE' || floorGap !== undefined) {
     exitCode = 2;
     verdict = 'CANNOT GATE';
   } else {
@@ -263,6 +276,7 @@ export async function runGateCommand(
     ...(floor !== undefined ? { floor } : {}),
     floorNetNew,
     ...(floorSkipped !== undefined ? { floorSkipped } : {}),
+    ...(floorGap !== undefined ? { floorRequiredGap: floorGap } : {}),
   };
 }
 
@@ -294,6 +308,12 @@ function renderGateReceipt(outcome: GateCommandOutcome): string {
       '',
       `Floor: SKIPPED (${outcome.floorSkipped.cause}) — ${outcome.floorSkipped.detail}`,
     );
+    if (outcome.floorRequiredGap) {
+      lines.push(
+        `Floor: REQUIRED but not observed — the gate CANNOT GATE rather than certify it.`,
+        `  remedy: ${outcome.floorRequiredGap.remedy}`,
+      );
+    }
   }
   lines.push('', `Gate verdict: ${outcome.verdict} (exit ${outcome.exitCode})`);
   return lines.join('\n');

--- a/src/gate/disclosures.ts
+++ b/src/gate/disclosures.ts
@@ -1,0 +1,120 @@
+/**
+ * Verdict-adjacent disclosure collection — the block of `runGate` that
+ * turns the classified pair set into the disclosures the renderers and
+ * the verdict derivation consume: attribution gaps (Rule 19), required-
+ * observation gaps (WP1 §7.1), the baseline-suspect staleness signature
+ * (#222), the not-observed aggregate (Rule 19's REMOVED direction), and
+ * the suppression-lapse projection.
+ *
+ * Split from `engine.ts` for module size, not semantics: every input is
+ * the SAME pair set / clock the verdict reads (post `--changed-only`
+ * filter), so a filtered-out pair can neither block, refuse, nor lapse —
+ * that invariant is this module's contract, and new disclosure kinds
+ * belong here so they inherit it.
+ */
+
+import type { BaselineFile } from '../baseline/baseline-file';
+import type { CurrentScan } from '../baseline/create';
+import type { BrownfieldPolicy } from '../baseline/policy';
+import { collectAttributionGaps } from '../baseline/attribution-gap';
+import { collectExpiryProjection } from '../baseline/expiry-projection';
+import { computeChangedFiles } from '../baseline/changed-files';
+import { detectBaselineSuspect, readBaselineProvenance } from '../baseline/provenance';
+import type { PriorClass } from '../baseline/modes';
+import type { FlowGateOutcome } from '../baseline/flow-gate-check';
+import type { SchemaDriftGateOutcome } from '../baseline/schema-drift-gate-check';
+import type { DupGateOutcome } from '../baseline/dup-gate-check';
+import type { PairedGateOutcome } from '../baseline/paired-gate-check';
+import type { ClassifiedPair, EnvelopeDrift, GuardrailCheckResult } from './result';
+import type { BaselineEntry } from '../baseline/types';
+import { collectNotObservedDisclosures } from './observation';
+import { requiredCustomCheckGaps } from './required-observation';
+
+export interface DisclosureInputs {
+  readonly cwd: string;
+  readonly policy: BrownfieldPolicy;
+  readonly priorClass: PriorClass;
+  readonly baseline: BaselineFile;
+  readonly current: CurrentScan;
+  /** The post-filter pair set the verdict reads — never the raw pairs. */
+  readonly filteredPairs: ReadonlyArray<ClassifiedPair>;
+  readonly envelopeDrift: EnvelopeDrift;
+  readonly refExcludedKinds: GuardrailCheckResult['refExcludedKinds'];
+  readonly priorById: ReadonlyMap<string, BaselineEntry>;
+  readonly notObservedReasonFor: (entry: BaselineEntry) => string | undefined;
+  readonly flowGate: FlowGateOutcome;
+  readonly schemaDriftGate: SchemaDriftGateOutcome;
+  readonly dupGate: DupGateOutcome;
+  readonly pairedGate: PairedGateOutcome;
+  /** The one clock of the run — the same `now` the suppression decision used. */
+  readonly now: Date;
+}
+
+export interface VerdictDisclosures {
+  readonly attributionGaps: GuardrailCheckResult['attributionGaps'];
+  readonly requiredNotObserved: GuardrailCheckResult['requiredNotObserved'];
+  readonly baselineSuspect: GuardrailCheckResult['baselineSuspect'] | null;
+  readonly notObserved: GuardrailCheckResult['notObserved'];
+  readonly suppressionExpiry: GuardrailCheckResult['suppressionExpiry'];
+}
+
+export function collectVerdictDisclosures(inputs: DisclosureInputs): VerdictDisclosures {
+  const { cwd, policy, priorClass, baseline, current, filteredPairs, envelopeDrift } = inputs;
+
+  // Attribution gaps: block-rule-class findings recall drift demoted out of
+  // block-rule reach. While one exists the run cannot render PASSED.
+  const attributionGaps = collectAttributionGaps(filteredPairs, envelopeDrift.recallDrift);
+
+  // Required-observation gaps (WP1, §7.1): policy-declared `required: true`
+  // checks whose observation is missing this run — the observation sibling
+  // of the attribution gaps. Empty for every policy without a required check.
+  const requiredNotObserved = requiredCustomCheckGaps(
+    policy,
+    current.customChecksUnobserved,
+    inputs.refExcludedKinds,
+  );
+
+  // Baseline-suspect staleness disclosure (#222): a large share of ADDED
+  // findings in files the diff never touched is a stale-anchor signature,
+  // not developer fault. Committed modes only — ref-based re-gathers the
+  // prior at the PR's own base, so there is no stale-anchor concept.
+  // Disclosure only: reframes a mechanically-correct BLOCKED with the
+  // workflow-aware re-anchor remedy.
+  const baselineSuspect =
+    priorClass === 'committed'
+      ? detectBaselineSuspect({
+          addedFiles: filteredPairs
+            .filter((p) => p.classification.status === 'added' && p.file !== undefined)
+            .map((p) => p.file!),
+          changedFiles: baseline.repo.commitSha
+            ? computeChangedFiles(cwd, baseline.repo.commitSha)
+            : null,
+          provenance: readBaselineProvenance(cwd, baseline),
+        })
+      : null;
+
+  // The not-observed AGGREGATE (one line per unobserved check, with counts)
+  // — never per-finding rows: a repo-scale lint backlog is tens of
+  // thousands of entries, and listing them is both a lie ("Resolved
+  // (18406)") and a comment-size failure. Same reason function the
+  // classifier consumed, so counts and phrasing agree by construction.
+  const notObserved = collectNotObservedDisclosures(
+    filteredPairs,
+    inputs.priorById,
+    inputs.notObservedReasonFor,
+  );
+
+  // The lapse projection: what today's active suppressions will cost when
+  // their windows close. Disclosure only — deliberately absent from
+  // `blocks` / `warns`.
+  const suppressionExpiry = collectExpiryProjection({
+    pairs: filteredPairs,
+    flowGate: inputs.flowGate,
+    schemaDriftGate: inputs.schemaDriftGate,
+    dupGate: inputs.dupGate,
+    pairedGate: inputs.pairedGate,
+    now: inputs.now,
+  });
+
+  return { attributionGaps, requiredNotObserved, baselineSuspect, notObserved, suppressionExpiry };
+}

--- a/src/gate/engine.ts
+++ b/src/gate/engine.ts
@@ -35,18 +35,12 @@ import type { BrownfieldPolicy } from '../baseline/policy';
 import { FULL_SCOPE, scopeForPolicy, scopeForRefBasedDiff } from '../baseline/gather-scope';
 import { computeChangedFiles } from '../baseline/changed-files';
 import { changedFilesTouchDependencyManifest, detectActiveLanguages } from '../languages';
-import { collectAttributionGaps } from '../baseline/attribution-gap';
-import { collectExpiryProjection } from '../baseline/expiry-projection';
 import { evaluateFlowGateForGuardrail } from '../baseline/flow-gate-check';
 import { evaluateSchemaDriftGateForGuardrail } from '../baseline/schema-drift-gate-check';
 import { evaluateDupGateForGuardrail } from '../baseline/dup-gate-check';
 import { evaluatePairedGateForGuardrail } from '../baseline/paired-gate-check';
 import type { BaselineEntry } from '../baseline/types';
-import {
-  refreshWorkflowInstalled,
-  detectBaselineSuspect,
-  readBaselineProvenance,
-} from '../baseline/provenance';
+import { refreshWorkflowInstalled } from '../baseline/provenance';
 import { MANAGED_SHIP_SURFACES } from '../managed-artifacts';
 import {
   computeAllowlistDelta,
@@ -57,7 +51,8 @@ import { resolveEffectiveAllowlist } from '../allowlist/effective';
 import { entryToAllowlistable } from '../baseline/allowlist-match';
 import { classifyPairs } from './classify-pairs';
 import { diffEnvelopes, keepUnderChangedOnly, pairBlocks } from './context';
-import { collectNotObservedDisclosures, partitionForRefBasedDiff } from './observation';
+import { partitionForRefBasedDiff } from './observation';
+import { collectVerdictDisclosures } from './disclosures';
 import { acquirePrior, assertPriorSchemeComparable, emptyPriorFromScan } from './prior';
 import type { GuardrailCheckResult } from './result';
 import type { GateEngineOptions, GateSubject } from './types';
@@ -368,54 +363,29 @@ export async function runGate(
   const baseBlocks = options.changedOnly ? filteredBlocks : blocks;
   const baseWarns = options.changedOnly ? filteredWarns : warns;
 
-  // Attribution gaps: block-rule-class findings recall drift demoted out of
-  // block-rule reach. Computed from the SAME pair set the verdict reads
-  // (post --changed-only filter), so a filtered-out pair can neither block
-  // nor refuse. The verdict derivation (`verdictCounts`) consumes these —
-  // while one exists the run cannot render PASSED.
-  const attributionGaps = collectAttributionGaps(filteredPairs, envelopeDrift.recallDrift);
-
-  // Baseline-suspect staleness disclosure (#222): a large share of ADDED
-  // findings in files the diff never touched is a stale-anchor signature (the
-  // baseline predates the base branch's recent history), not developer fault.
-  // Committed modes only — ref-based re-gathers the prior side at the PR's own
-  // base, so there is no stale-anchor concept. Disclosure only: the verdict is
-  // mechanically correct either way; this reframes it and names the honest
-  // remedy (workflow-aware via the provenance module).
-  const baselineSuspect =
-    priorClass === 'committed'
-      ? detectBaselineSuspect({
-          addedFiles: filteredPairs
-            .filter((p) => p.classification.status === 'added' && p.file !== undefined)
-            .map((p) => p.file!),
-          changedFiles: baseline.repo.commitSha
-            ? computeChangedFiles(cwd, baseline.repo.commitSha)
-            : null,
-          provenance: readBaselineProvenance(cwd, baseline),
-        })
-      : null;
-
-  // Aggregate the not-observed pairs into per-reason disclosures for the
-  // renderers. Aggregate ON PURPOSE: a repo-scale lint backlog is tens of
-  // thousands of entries, and listing them (the "Resolved (18406)" table this
-  // fixes) is both a lie and a comment-size failure — the honest output is one
-  // line per unobserved check with its count. Computed from the SAME pair set
-  // the verdict reads (post --changed-only filter), through the same reason
-  // function the classifier consumed, so the counts and phrasing agree by
-  // construction.
-  const notObservedDisclosures = collectNotObservedDisclosures(
+  // Every verdict-adjacent disclosure — attribution gaps (Rule 19),
+  // required-observation gaps (WP1 §7.1), the baseline-suspect signature
+  // (#222), the not-observed aggregate, the suppression-lapse projection —
+  // is collected in ONE module from the SAME post-filter pair set and clock
+  // the verdict reads, so a filtered-out pair can neither block, refuse,
+  // nor lapse. See `disclosures.ts`.
+  const {
+    attributionGaps,
+    requiredNotObserved,
+    baselineSuspect,
+    notObserved: notObservedDisclosures,
+    suppressionExpiry,
+  } = collectVerdictDisclosures({
+    cwd,
+    policy,
+    priorClass,
+    baseline,
+    current,
     filteredPairs,
+    envelopeDrift,
+    refExcludedKinds,
     priorById,
     notObservedReasonFor,
-  );
-
-  // The lapse projection: what today's active suppressions will cost when their
-  // windows close. Reads the same pair set the verdict reads (post
-  // --changed-only filter) and the same `now` the suppression decision used, so
-  // a pair cannot be treated as suppressed here and lapsing on a different day.
-  // Disclosure only — it is deliberately absent from `blocks` / `warns` below.
-  const suppressionExpiry = collectExpiryProjection({
-    pairs: filteredPairs,
     flowGate,
     schemaDriftGate,
     dupGate,
@@ -442,6 +412,7 @@ export async function runGate(
     warns:
       baseWarns || flowGate.warns || schemaDriftGate.warns || dupGate.warns || pairedGate.warns,
     attributionGaps,
+    requiredNotObserved,
     ...(baselineSuspect ? { baselineSuspect } : {}),
     suppressionExpiry,
     notObserved: notObservedDisclosures,

--- a/src/gate/required-observation.ts
+++ b/src/gate/required-observation.ts
@@ -1,0 +1,182 @@
+/**
+ * Required-observation semantics (4.4.1 WP1, strategy §7.1).
+ *
+ * The gate's product promise is "refuse to certify what was not seen".
+ * Before this module, that held for attribution (Rule 19's refusal tier)
+ * but not for OBSERVATION: a check that never ran was disclosed as a
+ * skip, yet the verdict word stayed whatever the findings earned — a
+ * skipped correctness floor was arithmetically indistinguishable from a
+ * passing one at the exit code.
+ *
+ * This module is the ONE evaluator of the question "was every REQUIRED
+ * check observed?", answered as a list of `RequiredObservationGap`s.
+ * A non-empty answer joins the existing refusal tier: the one verdict
+ * derivation (`verdictWordFrom` in `check-renderers.ts`) turns any gap
+ * into `CANNOT GATE`, exactly as it does for attribution gaps — never a
+ * silent pass, never a false BLOCK (the developer is not blamed; the
+ * missing evidence is named, with its remedy).
+ *
+ * What can be required, and who evaluates it (ownership, not surface
+ * forks — a surface only answers for checks it OWNS the execution of):
+ *
+ * - `custom:<name>` — a policy-declared check with `required: true`.
+ *   Evaluated by the gate ENGINE (both `gate` and `guardrail check`
+ *   run user checks through the Rule-17 seam). Default: not required —
+ *   an unavailable optional check keeps today's behavior (disclosed
+ *   skip, `not_observed` classification, verdict untouched).
+ * - `floor` — the correctness floor, `policy.floor.required` (default
+ *   TRUE). Evaluated by the surfaces that OWN floor execution over a
+ *   whole tree: the `gate` CLI (and through it `gate --workspace`).
+ *   The loop Stop-gate / pre-push / CI floor surfaces deliberately keep
+ *   their Rule-15 doctrine (fail-open on infrastructure, CI as the
+ *   backstop) — a slow toolchain must not wedge an unattended loop, and
+ *   those surfaces have a backstop behind them; the one-shot gate has
+ *   none, which is why it defaults to refusal.
+ *
+ * Bias discipline: a gap is only minted for a check that was DECLARED
+ * required and demonstrably not observed. A floor that ran and found
+ * zero applicable checks (a docs-only tree, no pack declares a
+ * runnable floor) counts as OBSERVED-vacuous — refusing there would
+ * false-refuse trivial trees. dxkit never invents a requirement.
+ */
+
+import type { BrownfieldPolicy } from '../baseline/policy';
+import type { CustomChecksUnobserved } from '../analyzers/custom-checks/gather';
+import { normalizeCustomChecks } from '../analyzers/custom-checks/config';
+
+/** One required check whose observation is missing — the refusal unit.
+ *  Consumed by the verdict derivation, all three renderers, and the
+ *  verdict.v1 `refusals` array. */
+export interface RequiredObservationGap {
+  /** `'floor'` or `custom:<name>` — the required-check vocabulary. */
+  readonly checkId: string;
+  /** Why the observation is missing (embeds the recorded skip cause). */
+  readonly reason: string;
+  /** The named way out — consent, config, or mode change. */
+  readonly remedy: string;
+}
+
+/** Names of policy checks declared `required: true` (trimmed, in policy
+ *  order). Pure over the policy document. */
+export function requiredCustomCheckNames(policy: BrownfieldPolicy): readonly string[] {
+  return (policy.checks ?? [])
+    .filter((c) => c.required === true)
+    .map((c) => (typeof c.name === 'string' ? c.name.trim() : ''))
+    .filter((n) => n.length > 0);
+}
+
+/**
+ * Gaps for required CUSTOM checks. Sound because the three ways a
+ * declared check can go unobserved are all visible from the inputs:
+ *
+ * 1. it never became a runnable spec (invalid entry dropped by the ONE
+ *    normalizer — a config typo must not silently disarm a required
+ *    check);
+ * 2. the seam recorded it unobserved (skipped-untrusted / -environment
+ *    / -unavailable / -timeout / -overflow), or the gather itself did
+ *    not run;
+ * 3. the mode excluded the `custom-check` kind from gating entirely
+ *    (ref-based — the throwaway prior worktree lacks the toolchain, so
+ *    the kind cannot be diffed honestly).
+ *
+ * A required check that is a valid spec, not recorded unobserved, and
+ * whose kind gates in this mode was observed (pass or fail — either
+ * way the gate SAW it), so no gap is minted.
+ */
+export function requiredCustomCheckGaps(
+  policy: BrownfieldPolicy,
+  unobserved: CustomChecksUnobserved | undefined,
+  refExcludedKinds: ReadonlyArray<{ readonly kind: string }>,
+): RequiredObservationGap[] {
+  const required = requiredCustomCheckNames(policy);
+  if (required.length === 0) return [];
+
+  // Ref-based mode cannot gate the kind at all: every required check is a
+  // structural gap, remedy = the mode that can.
+  if (refExcludedKinds.some((k) => k.kind === 'custom-check')) {
+    return required.map((name) => ({
+      checkId: `custom:${name}`,
+      reason: `required check "${name}" cannot be gated in ref-based mode (the prior side is a bare worktree without the repo's toolchain)`,
+      remedy:
+        'switch to a committed baseline mode (`baseline.mode: "committed-full"`) to gate required checks, or drop `required: true`',
+    }));
+  }
+
+  // The ONE normalizer decides which declared entries are runnable specs —
+  // the same adapter the seam itself uses, so this cannot diverge from
+  // what actually ran.
+  const specNames = new Set(normalizeCustomChecks(policy.checks).specs.map((s) => s.name));
+  const gaps: RequiredObservationGap[] = [];
+  for (const name of required) {
+    if (!specNames.has(name)) {
+      gaps.push({
+        checkId: `custom:${name}`,
+        reason: `required check "${name}" is not a runnable check (the entry is invalid and was dropped at normalization)`,
+        remedy: 'fix the check entry in `.dxkit/policy.json` (see `vyuh-dxkit checks list`)',
+      });
+      continue;
+    }
+    if (unobserved === undefined || !unobserved.gathered) {
+      gaps.push({
+        checkId: `custom:${name}`,
+        reason: `required check "${name}" was not observed: ${
+          unobserved && !unobserved.gathered ? unobserved.reason : 'custom checks did not run'
+        }`,
+        remedy: 'run in a mode/scope that executes custom checks, or drop `required: true`',
+      });
+      continue;
+    }
+    const record = unobserved.checks.find((c) => c.name === name);
+    if (record !== undefined) {
+      gaps.push({
+        checkId: `custom:${name}`,
+        reason: `required check "${name}" was not observed (${record.status}${
+          record.reason ? `: ${record.reason}` : ''
+        })`,
+        remedy: remedyForSkipStatus(record.status),
+      });
+    }
+  }
+  return gaps;
+}
+
+/** The per-cause way out, phrased once. */
+function remedyForSkipStatus(status: string): string {
+  switch (status) {
+    case 'skipped-untrusted':
+      return 'pass --trusted to consent to executing the tree’s declared commands, or drop `required: true`';
+    case 'skipped-environment':
+      return 'provision the toolchain the check declares (see the disclosed requirement), or drop `required: true`';
+    case 'skipped-unavailable':
+      return 'install the check’s command so it resolves on this machine, or drop `required: true`';
+    default:
+      return 'make the check observable on this surface (see its disclosed skip cause), or drop `required: true`';
+  }
+}
+
+/** Is the correctness floor required for a certifiable verdict on the
+ *  surfaces that own tree-level floor execution? Default TRUE — the
+ *  §7.1 reversal. A policy opts out with `floor: { required: false }`. */
+export function floorRequired(policy: BrownfieldPolicy): boolean {
+  return policy.floor?.required ?? true;
+}
+
+/**
+ * The floor's gap, minted by the gate CLI when the floor was SKIPPED
+ * with a cause (untrusted today) while `floor.required` holds. A floor
+ * that ran — even vacuously — is observed and mints nothing.
+ */
+export function floorRequiredGap(
+  policy: BrownfieldPolicy,
+  skip: { readonly cause: string; readonly detail: string } | undefined,
+): RequiredObservationGap | undefined {
+  if (skip === undefined || !floorRequired(policy)) return undefined;
+  return {
+    checkId: 'floor',
+    reason: `the correctness floor is required but did not run (${skip.cause}): ${skip.detail}`,
+    remedy:
+      skip.cause === 'untrusted'
+        ? 'pass --trusted to consent to running the tree’s compile + tests, or set `floor: { "required": false }` in the policy'
+        : 'make the floor runnable here (see the disclosed cause), or set `floor: { "required": false }` in the policy',
+  };
+}

--- a/src/gate/result.ts
+++ b/src/gate/result.ts
@@ -18,6 +18,7 @@ import type { BaselineEntry, FindingSeverity, MatchPair, MatchResult } from '../
 import type { CoverageDrift } from '../baseline/coverage';
 import type { RecallDrift } from '../baseline/recall';
 import type { AttributionGap } from '../baseline/attribution-gap';
+import type { RequiredObservationGap } from './required-observation';
 import type { ExpiryProjection } from '../baseline/expiry-projection';
 import type { FlowGateOutcome } from '../baseline/flow-gate-check';
 import type { SchemaDriftGateOutcome } from '../baseline/schema-drift-gate-check';
@@ -171,6 +172,19 @@ export interface GuardrailCheckResult {
    * mismatch gets. Empty on a healthy run. See `src/baseline/attribution-gap.ts`.
    */
   readonly attributionGaps: ReadonlyArray<AttributionGap>;
+  /**
+   * Policy-declared REQUIRED checks whose observation is missing this run
+   * (4.4.1 WP1, strategy §7.1 — the observation sibling of
+   * `attributionGaps`). REQUIRED, and consumed by the one verdict
+   * derivation: while a gap exists the run cannot render PASSED — it
+   * refuses (`CANNOT GATE`) and names the missing evidence + remedy.
+   * Empty for every policy that declares no `required: true` check (all
+   * pre-4.4.1 policies), so existing repos see no behavior change. ONE
+   * evaluator: `src/gate/required-observation.ts`. The floor's own gap is
+   * surface-owned (`GateCommandOutcome.floorRequiredGap`) — the engine
+   * does not run the floor.
+   */
+  readonly requiredNotObserved: ReadonlyArray<RequiredObservationGap>;
   /** Present when the ADDED-finding pattern matches the stale-anchor
    *  signature (most net-new findings in files the diff never touched —
    *  #222). Disclosure only: reframes a mechanically-correct BLOCKED as

--- a/src/gate/verdict.ts
+++ b/src/gate/verdict.ts
@@ -127,13 +127,23 @@ export function buildWireVerdict(outcome: GateCommandOutcome, receipt: string): 
         skippedWithCause: outcome.floorSkipped?.detail ?? 'floor did not run',
       };
 
-  const refusals =
-    result.attributionGaps.length > 0
-      ? result.attributionGaps.map((gap) => ({
-          reason: describeAttributionGap(gap),
-          remedy: attributionGapRemedy(result.envelopeDrift.refreshLaneInstalled),
-        }))
-      : undefined;
+  // Every refusal source feeds the ONE wire array: attribution gaps (Rule
+  // 19), required custom checks not observed, and the required floor's own
+  // gap (WP1, §7.1) — a cannot_gate verdict always names its evidence.
+  const refusalRows = [
+    ...result.attributionGaps.map((gap) => ({
+      reason: describeAttributionGap(gap),
+      remedy: attributionGapRemedy(result.envelopeDrift.refreshLaneInstalled),
+    })),
+    ...result.requiredNotObserved.map((gap) => ({
+      reason: gap.reason,
+      remedy: gap.remedy,
+    })),
+    ...(outcome.floorRequiredGap !== undefined
+      ? [{ reason: outcome.floorRequiredGap.reason, remedy: outcome.floorRequiredGap.remedy }]
+      : []),
+  ];
+  const refusals = refusalRows.length > 0 ? refusalRows : undefined;
 
   return {
     schema: 'verdict.v1',

--- a/src/loop/demo.ts
+++ b/src/loop/demo.ts
@@ -52,6 +52,7 @@ function illustrativePayload(blocked: boolean): GuardrailJsonPayload {
     schema: GUARDRAIL_JSON_SCHEMA,
     verdict: { blocks: blocked, warns: false, refused: false, exitCode: blocked ? 1 : 0 },
     attributionGaps: [],
+    requiredNotObserved: [],
     notObserved: [],
     // The illustration has no allowlist, so nothing is deferred and nothing can
     // lapse. Spelled out rather than omitted — the field is required so a real

--- a/test/gate/gate-acceptance.test.ts
+++ b/test/gate/gate-acceptance.test.ts
@@ -46,6 +46,11 @@ function dodPolicyPath(dir: string): string {
       ...policy,
       id: 'acceptance.dod.pkg',
       version: '1',
+      // The matrix's embed scenario gates UNTRUSTED trees on findings; the
+      // compile/test floor is exercised by its own --trusted rows, so the
+      // DoD opts out of the default-required floor (WP1 §7.1). The default
+      // refusal has its own dedicated row below.
+      floor: { required: false },
       checks: [
         {
           name: 'no_placeholder',
@@ -105,6 +110,25 @@ describe('package rows', () => {
       const { doc } = await gateRow('package/clean');
       expect(doc.status).toBe('passed');
       expect(doc.exitCode).toBe(0);
+    },
+    HEAVY,
+  );
+
+  it(
+    'clean, untrusted, no floor opt-out → cannot_gate: the required floor did not run (WP1 §7.1)',
+    async () => {
+      // The default posture (no --policy, no tree policy) REQUIRES the
+      // floor: an untrusted run that cannot execute compile + tests refuses
+      // to certify the tree instead of passing over the skip. Exit 2, and
+      // the wire refusal names the floor with both remedies.
+      const copy = join(scratch, 'package-clean-required-floor');
+      cpSync(join(FIXTURES, 'package/clean'), copy, { recursive: true });
+      const outcome = await runGateCommand(copy, {});
+      const doc = JSON.parse(renderGateOutcome(outcome, true));
+      expect(doc.status).toBe('cannot_gate');
+      expect(doc.exitCode).toBe(2);
+      expect(doc.floor.ran).toBe(false);
+      expect(doc.refusals.some((r: { reason: string }) => r.reason.includes('floor'))).toBe(true);
     },
     HEAVY,
   );

--- a/test/gate/gate-command.test.ts
+++ b/test/gate/gate-command.test.ts
@@ -103,7 +103,11 @@ describe('gate <dir> (fresh prior, default untrusted)', () => {
       const dir = makeTree({
         'README.md': '# generated package\n',
         'code/handlers.js': 'function total() {\n  return 1;\n}\n',
+        // This row pins finding-diff determinism, not floor posture — the
+        // policy opts out of the required floor so the untrusted run stays
+        // a clean PASSED (the default-required refusal has its own rows).
         '.dxkit/policy.json': securityPolicyJson({
+          floor: { required: false },
           checks: [{ name: 'no_placeholder', pattern: '\\b(TODO|FIXME|XXX)\\b' }],
         }),
       });
@@ -125,30 +129,80 @@ describe('gate <dir> (fresh prior, default untrusted)', () => {
   );
 
   it(
-    'no policy at all → the security-only fallback: an untested source file warns, never blocks (WP-P front door)',
+    'no policy, untrusted → CANNOT GATE exit 2: the required floor did not run (WP1 §7.1)',
     async () => {
-      // No --policy and no committed .dxkit/policy.json. Under the fresh
-      // prior every finding is net-new, so the fully armed compiled default
-      // (newUntestedChangedSource et al) would BLOCK this trivial tree on a
-      // test-gap — the shape that made a first-touch `gate .` read as a
-      // false positive. The fallback is the cost-bounded security-only
-      // posture instead; the gap still surfaces, as a warning.
+      // No --policy and no committed .dxkit/policy.json, and no --trusted.
+      // The security-only fallback still governs FINDINGS (the untested
+      // source warns, never blocks — the WP-P front-door fix), but the
+      // correctness floor is REQUIRED by default and could not run on an
+      // untrusted tree — so the gate refuses to certify instead of passing
+      // over the skip. The refusal names the cause and both remedies.
       const dir = makeTree({
         'README.md': '# generated package\n',
         'src/index.js': 'module.exports = (a, b) => a + b;\n',
       });
       const outcome = await runGateCommand(dir, {});
-      expect(outcome.verdict).toMatch(/^PASSED/);
-      expect(outcome.exitCode).toBe(0);
+      expect(outcome.verdict).toBe('CANNOT GATE');
+      expect(outcome.exitCode).toBe(2);
+      expect(outcome.floorRequiredGap?.checkId).toBe('floor');
+      // Findings posture is unchanged underneath the refusal: the test-gap
+      // is a warning, not a block, under the security-only fallback.
       const gap = outcome.result.pairs.find((p) => p.kind === 'test-gap');
       expect(gap).toBeDefined();
       expect(gap?.classification.blocks).toBe(false);
-      // The verdict names the exact fallback policy it judged under.
+      // The verdict names the exact fallback policy it judged under, and
+      // the wire refusal carries the floor gap with its remedy.
       const doc = JSON.parse(renderGateOutcome(outcome, true));
+      expect(doc.status).toBe('cannot_gate');
+      expect(doc.floor.ran).toBe(false);
+      expect(doc.refusals.some((r: { reason: string }) => r.reason.includes('floor'))).toBe(true);
+      expect(doc.refusals.every((r: { remedy?: string }) => r.remedy)).toBe(true);
       const { policyContentHash } = await import('../../src/baseline/policy');
       expect(doc.policy.hash).toBe(
         policyContentHash(policyForPreset('security-only', DEFAULT_BROWNFIELD_POLICY).policy),
       );
+    },
+    HEAVY,
+  );
+
+  it(
+    'the same tree with the floor observed (injected pass) → PASSED: the refusal is about observation, not posture',
+    async () => {
+      const dir = makeTree({
+        'README.md': '# generated package\n',
+        'src/index.js': 'module.exports = (a, b) => a + b;\n',
+      });
+      const outcome = await runGateCommand(dir, {
+        trusted: true,
+        seams: {
+          runFloor: () => ({
+            ran: true,
+            blocks: false,
+            checks: [{ pack: 'typescript', label: 'syntax', bin: 'tsc', status: 'pass' }],
+          }),
+        },
+      });
+      expect(outcome.verdict).toMatch(/^PASSED/);
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.floorRequiredGap).toBeUndefined();
+    },
+    HEAVY,
+  );
+
+  it(
+    'floor: { required: false } restores skip-and-disclose: untrusted clean tree passes with the skip named',
+    async () => {
+      const dir = makeTree({
+        'README.md': '# generated package\n',
+        'src/index.js': 'module.exports = (a, b) => a + b;\n',
+        '.dxkit/policy.json': securityPolicyJson({ floor: { required: false } }),
+      });
+      const outcome = await runGateCommand(dir, {});
+      expect(outcome.verdict).toMatch(/^PASSED/);
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.floorSkipped?.cause).toBe('untrusted');
+      expect(outcome.floorRequiredGap).toBeUndefined();
+      expect(renderGateOutcome(outcome, false)).toContain('SKIPPED (untrusted)');
     },
     HEAVY,
   );

--- a/test/gate/policy-identity.test.ts
+++ b/test/gate/policy-identity.test.ts
@@ -35,7 +35,14 @@ function makeTree(files: Record<string, string>): string {
 
 function dodPolicy(version: string, extra: Record<string, unknown> = {}): string {
   const { policy } = policyForPreset('security-only', DEFAULT_BROWNFIELD_POLICY);
-  return JSON.stringify({ ...policy, id: 'acme.dod.pkg', version, ...extra }, null, 2);
+  // These rows pin policy NAMING (hash/id/version), not floor posture — the
+  // untrusted runs opt out of the default-required floor so verdicts stay
+  // driven by the findings the rows seed (WP1 §7.1 has its own pins).
+  return JSON.stringify(
+    { ...policy, id: 'acme.dod.pkg', version, floor: { required: false }, ...extra },
+    null,
+    2,
+  );
 }
 
 beforeAll(() => {

--- a/test/gate/required-observation.test.ts
+++ b/test/gate/required-observation.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import {
+  floorRequired,
+  floorRequiredGap,
+  requiredCustomCheckGaps,
+  requiredCustomCheckNames,
+} from '../../src/gate/required-observation';
+import { verdictWordFrom } from '../../src/baseline/check-renderers';
+import { DEFAULT_BROWNFIELD_POLICY, type BrownfieldPolicy } from '../../src/baseline/policy';
+import type { CustomChecksUnobserved } from '../../src/analyzers/custom-checks/gather';
+
+/**
+ * WP1 (§7.1) — the ONE required-observation evaluator. The refusal
+ * discipline under test: a gap is minted ONLY for a declared-required
+ * check that was demonstrably not observed (never invented), and any
+ * gap makes PASSED unconstructible through the one verdict derivation.
+ */
+
+function policyWith(overrides: Partial<BrownfieldPolicy>): BrownfieldPolicy {
+  return { ...DEFAULT_BROWNFIELD_POLICY, ...overrides } as BrownfieldPolicy;
+}
+
+const NOTHING_UNOBSERVED: CustomChecksUnobserved = { gathered: true, checks: [] };
+
+describe('floorRequired / floorRequiredGap', () => {
+  it('defaults to required — the §7.1 reversal', () => {
+    expect(floorRequired(DEFAULT_BROWNFIELD_POLICY)).toBe(true);
+  });
+
+  it('a policy opts out with floor.required: false', () => {
+    expect(floorRequired(policyWith({ floor: { required: false } }))).toBe(false);
+  });
+
+  it('mints a gap for a skipped floor under the default, with cause and remedy', () => {
+    const gap = floorRequiredGap(DEFAULT_BROWNFIELD_POLICY, {
+      cause: 'untrusted',
+      detail: 'tree is untrusted',
+    });
+    expect(gap?.checkId).toBe('floor');
+    expect(gap?.reason).toContain('untrusted');
+    expect(gap?.remedy).toContain('--trusted');
+  });
+
+  it('mints nothing when the floor ran (no skip), and nothing under the opt-out', () => {
+    expect(floorRequiredGap(DEFAULT_BROWNFIELD_POLICY, undefined)).toBeUndefined();
+    expect(
+      floorRequiredGap(policyWith({ floor: { required: false } }), {
+        cause: 'untrusted',
+        detail: 'tree is untrusted',
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('requiredCustomCheckGaps', () => {
+  const requiredCheckPolicy = policyWith({
+    checks: [
+      { name: 'arch', command: 'scripts/check-arch.sh', required: true },
+      { name: 'optional-audit', command: 'scripts/audit.sh' },
+    ],
+  });
+
+  it('names only required: true checks', () => {
+    expect(requiredCustomCheckNames(requiredCheckPolicy)).toEqual(['arch']);
+    expect(requiredCustomCheckNames(DEFAULT_BROWNFIELD_POLICY)).toEqual([]);
+  });
+
+  it('no required checks → no gaps regardless of skips (nothing is invented)', () => {
+    const skipped: CustomChecksUnobserved = {
+      gathered: true,
+      checks: [{ name: 'optional-audit', status: 'skipped-untrusted' }],
+    };
+    expect(requiredCustomCheckGaps(DEFAULT_BROWNFIELD_POLICY, skipped, [])).toEqual([]);
+  });
+
+  it('a required check recorded unobserved gaps, with the per-cause remedy', () => {
+    const skipped: CustomChecksUnobserved = {
+      gathered: true,
+      checks: [{ name: 'arch', status: 'skipped-untrusted', reason: 'untrusted tree' }],
+    };
+    const gaps = requiredCustomCheckGaps(requiredCheckPolicy, skipped, []);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].checkId).toBe('custom:arch');
+    expect(gaps[0].reason).toContain('skipped-untrusted');
+    expect(gaps[0].remedy).toContain('--trusted');
+  });
+
+  it('a required check that RAN mints nothing — pass or fail, it was observed', () => {
+    expect(requiredCustomCheckGaps(requiredCheckPolicy, NOTHING_UNOBSERVED, [])).toEqual([]);
+  });
+
+  it('an optional check skipped beside a required one that ran mints nothing', () => {
+    const skipped: CustomChecksUnobserved = {
+      gathered: true,
+      checks: [{ name: 'optional-audit', status: 'skipped-environment' }],
+    };
+    expect(requiredCustomCheckGaps(requiredCheckPolicy, skipped, [])).toEqual([]);
+  });
+
+  it('an invalid required entry gaps — a config typo must not silently disarm it', () => {
+    const invalid = policyWith({
+      // no command and no pattern → dropped by the ONE normalizer
+      checks: [{ name: 'broken', required: true }],
+    });
+    const gaps = requiredCustomCheckGaps(invalid, NOTHING_UNOBSERVED, []);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].reason).toContain('not a runnable check');
+  });
+
+  it('the gather itself not running gaps every required check', () => {
+    const gaps = requiredCustomCheckGaps(
+      requiredCheckPolicy,
+      { gathered: false, reason: 'scope excluded custom checks' },
+      [],
+    );
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].reason).toContain('scope excluded custom checks');
+  });
+
+  it('ref-based mode gaps every required check with the mode remedy', () => {
+    const gaps = requiredCustomCheckGaps(requiredCheckPolicy, NOTHING_UNOBSERVED, [
+      { kind: 'custom-check' },
+    ]);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].reason).toContain('ref-based');
+    expect(gaps[0].remedy).toContain('committed');
+  });
+
+  it('every gap carries a non-empty remedy — a refusal always names the way out', () => {
+    const shapes: Array<CustomChecksUnobserved> = [
+      { gathered: false, reason: 'x' },
+      { gathered: true, checks: [{ name: 'arch', status: 'skipped-environment' }] },
+      { gathered: true, checks: [{ name: 'arch', status: 'skipped-unavailable' }] },
+      { gathered: true, checks: [{ name: 'arch', status: 'skipped-timeout' }] },
+    ];
+    for (const shape of shapes) {
+      for (const gap of requiredCustomCheckGaps(requiredCheckPolicy, shape, [])) {
+        expect(gap.remedy.trim().length).toBeGreaterThan(10);
+      }
+    }
+  });
+});
+
+describe('the verdict derivation folds required gaps into the refusal tier', () => {
+  it('a required gap makes PASSED unconstructible', () => {
+    const word = verdictWordFrom({
+      blocks: false,
+      warns: false,
+      unattributable: 0,
+      requiredMissing: 1,
+    });
+    expect(word.verdict).toBe('CANNOT GATE');
+    expect(word.exitCode).toBe(1);
+  });
+
+  it('a definite regression still outranks the refusal (both non-zero exits)', () => {
+    const word = verdictWordFrom({
+      blocks: true,
+      warns: false,
+      unattributable: 0,
+      requiredMissing: 1,
+    });
+    expect(word.verdict).toBe('BLOCKED');
+  });
+
+  it('zero gaps leaves the pass tiers untouched (absent means zero for old callers)', () => {
+    expect(verdictWordFrom({ blocks: false, warns: true, unattributable: 0 }).verdict).toBe(
+      'PASSED (with warnings)',
+    );
+    expect(
+      verdictWordFrom({ blocks: false, warns: false, unattributable: 0, requiredMissing: 0 })
+        .verdict,
+    ).toBe('PASSED');
+  });
+});


### PR DESCRIPTION
Into `release/4.4.1`. First WP of the 4.4.1 batch — the strategy doc's 7.1 gap.

## What

A policy-declared REQUIRED check that did not run now makes the verdict **CANNOT GATE** instead of a disclosed skip under a PASSED banner.

- **One evaluator**: `src/gate/required-observation.ts` answers "was every required check observed?" for both check families:
  - **`floor`** (`policy.floor.required`, default **true** on the `gate` command family): an untrusted-tree floor skip is now a refusal, exit 2, with the cause and both remedies named (`--trusted`, or `floor: {"required": false}`). Before this, `gate` returned PASSED exit 0 while the floor never ran — a skipped floor was arithmetically indistinguishable from a passing one.
  - **`custom:<name>`** (`checks[].required`, default false): evaluated by the engine on both `gate` and `guardrail check`. Sound across all three unobserved shapes — invalid entry dropped at normalization (a typo cannot silently disarm a required check), recorded runtime skip (untrusted / environment / unavailable / timeout), and ref-based kind exclusion — each with a per-cause remedy.
- **One verdict derivation**: gaps fold into the existing refusal tier (`verdictWordFrom` / `verdictCounts` gain `requiredMissing`), so PASSED is unconstructible over a missing required observation, exactly as over an attribution gap. Console banner, summary sentence, JSON payload, markdown, and verdict.v1 `refusals` all surface each gap. `gate --workspace` inherits through the member gates.
- **Scope boundaries kept**: the loop Stop-gate / pre-push / CI floor surfaces keep their declared Rule-15 fail-open-on-infrastructure doctrine — this knob does not govern them (they have CI as backstop; the one-shot gate has none).

## Behavior deltas

- **Guardrail surface: zero change for existing repos** — no pre-4.4.1 policy declares a required check, and `requiredNotObserved` is empty by construction then.
- **Gate surface: deliberate delta** — untrusted `gate <dir>` runs now refuse (exit 2) instead of passing over the floor skip. Pinned in `gate-command.test.ts` (both directions + the opt-out) and a new acceptance-matrix row; CHANGELOG upgrade note lands with release-prep.

## Rider

The self-gate blocked its own change (policy.ts / engine.ts crossed the 500-line bar) — split properly per doctrine: verdict-adjacent disclosure collection → `src/gate/disclosures.ts` (one module, same post-filter pair set + one clock), section interfaces → `policy-sections.ts`.

## Verification

Full suite 5586/5586 green (exit read unmasked), eslint `--max-warnings 0`, format, arch, slop, cross-ecosystem, `typecheck:test`, self-guardrail ref-based vs origin/main **PASSED exit 0**, policy guide/schema regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)