### PR TITLE
fix(attribution): per-finding advisory demotion + format-aware base resolution evidence (4.4.1 WP2)

### DIFF
--- a/src/analyzers/correctness/lockfile-evidence.ts
+++ b/src/analyzers/correctness/lockfile-evidence.ts
@@ -1,0 +1,169 @@
+/**
+ * Format-aware "which packages could this base-side file have provided?"
+ * evidence (4.4.1 WP2, #284).
+ *
+ * The pre-push resolution refutation used whole-blob textual containment
+ * (`blob.includes(spec)`) as its "maybe provided at base" test. Two live
+ * false blocks showed why that is the wrong instrument: an npm lockfile
+ * MENTIONS package names it does not install — peer-dependency metadata
+ * inside another package's entry (`three` inside `@react-three/fiber`'s
+ * block, under a `--legacy-peer-deps` install that never materializes
+ * peers), and any short name is a substring of longer ones (`three` ⊂
+ * `@react-three/fiber` literally). Both read as "maybe provided", the
+ * refutation declined, and a pre-existing phantom import hard-blocked an
+ * unrelated push.
+ *
+ * This module answers the question the current side actually asks —
+ * "would this specifier have RESOLVED under the base install?" — by
+ * parsing the file's INSTALLED/DECLARED package set per format:
+ *
+ *   - `package-lock.json` / `npm-shrinkwrap.json`: the `packages` map
+ *     keys (v2/v3 — the literal installed tree, nested entries included)
+ *     plus the v1 `dependencies` tree keys. Peer metadata inside entries
+ *     is VALUES, never keys, so it no longer counts as presence.
+ *   - `yarn.lock` (classic + berry): entry-header package names.
+ *   - `pnpm-lock.yaml`: `packages:` section keys.
+ *   - `package.json`: declared dependency names across all four sections
+ *     (peers included — with no lockfile beside it dxkit cannot know the
+ *     install flags, and counting a declaration keeps the block, the
+ *     conservative direction).
+ *
+ * An unrecognized format or a parse failure returns null and the caller
+ * falls back to the old containment probe for that file — non-JS
+ * ecosystems keep their existing behavior byte-for-byte, and every
+ * failure lands on "keep blocking", never on a new refutation.
+ */
+
+import * as path from 'path';
+
+/** The installed/declared package-name set the file evidences, or null
+ *  when the format is not modeled (caller falls back to containment). */
+export function basePackageEvidence(filePath: string, blob: string): ReadonlySet<string> | null {
+  switch (path.posix.basename(filePath.replace(/\\/g, '/'))) {
+    case 'package-lock.json':
+    case 'npm-shrinkwrap.json':
+      return npmLockPackages(blob);
+    case 'yarn.lock':
+      return yarnLockPackages(blob);
+    case 'pnpm-lock.yaml':
+      return pnpmLockPackages(blob);
+    case 'package.json':
+      return packageJsonDeclared(blob);
+    default:
+      return null;
+  }
+}
+
+/** npm v2/v3 `packages` keys (the installed tree) + v1 `dependencies`
+ *  tree keys. Null on unparseable JSON (fail toward keeping the block). */
+function npmLockPackages(blob: string): ReadonlySet<string> | null {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(blob);
+  } catch {
+    return null;
+  }
+  if (typeof doc !== 'object' || doc === null) return null;
+  const names = new Set<string>();
+  const packages = (doc as { packages?: Record<string, unknown> }).packages;
+  if (packages && typeof packages === 'object') {
+    for (const key of Object.keys(packages)) {
+      // "" is the root project; nested keys look like
+      // "node_modules/a/node_modules/@scope/b" — every node_modules
+      // segment names an installed package.
+      const parts = key.split('node_modules/');
+      for (let i = 1; i < parts.length; i++) {
+        const name = parts[i].replace(/\/$/, '');
+        if (name) names.add(name);
+      }
+    }
+  }
+  const addV1Tree = (deps: unknown): void => {
+    if (typeof deps !== 'object' || deps === null) return;
+    for (const [name, entry] of Object.entries(deps as Record<string, unknown>)) {
+      names.add(name);
+      addV1Tree((entry as { dependencies?: unknown })?.dependencies);
+    }
+  };
+  addV1Tree((doc as { dependencies?: unknown }).dependencies);
+  return names;
+}
+
+/** Package names from yarn.lock entry headers — classic
+ *  (`"@scope/a@^1.0", b@^2.0:`) and berry (`"a@npm:^1.0":`). Body lines
+ *  are indented and never parsed, so metadata mentions do not count. */
+function yarnLockPackages(blob: string): ReadonlySet<string> {
+  const names = new Set<string>();
+  for (const line of blob.split('\n')) {
+    // Entry headers start at column 0 and end with ':'; comments start '#'.
+    if (!line || line.startsWith('#') || /^\s/.test(line) || !line.trimEnd().endsWith(':')) {
+      continue;
+    }
+    const header = line.trimEnd().slice(0, -1);
+    for (const rawKey of header.split(',')) {
+      const key = rawKey.trim().replace(/^"|"$/g, '');
+      const name = packageNameOfSpec(key);
+      if (name) names.add(name);
+    }
+  }
+  return names;
+}
+
+/** Package names from pnpm-lock.yaml `packages:` keys, across the key
+ *  dialects: `/name/1.0.0:`, `/@scope/name@1.0.0:`, `'name@1.0.0':`. */
+function pnpmLockPackages(blob: string): ReadonlySet<string> {
+  const names = new Set<string>();
+  let inPackages = false;
+  for (const line of blob.split('\n')) {
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (inPackages && /^\S/.test(line)) inPackages = false; // next top-level section
+    if (!inPackages) continue;
+    const m = line.match(/^ {2}['"]?([^'":]+)['"]?:\s*$/);
+    if (!m) continue;
+    let key = m[1];
+    if (key.startsWith('/')) key = key.slice(1);
+    // `/name/1.0.0` (old) → name is everything before the LAST '/'; the
+    // `name@version` dialects go through the spec parser.
+    const name = key.includes('@', 1)
+      ? packageNameOfSpec(key)
+      : key.split('/').slice(0, -1).join('/');
+    if (name) names.add(name);
+  }
+  return names;
+}
+
+/** Declared dependency names across every package.json section. Null on
+ *  unparseable JSON. */
+function packageJsonDeclared(blob: string): ReadonlySet<string> | null {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(blob);
+  } catch {
+    return null;
+  }
+  if (typeof doc !== 'object' || doc === null) return null;
+  const names = new Set<string>();
+  for (const field of [
+    'dependencies',
+    'devDependencies',
+    'optionalDependencies',
+    'peerDependencies',
+  ]) {
+    const section = (doc as Record<string, unknown>)[field];
+    if (typeof section !== 'object' || section === null) continue;
+    for (const name of Object.keys(section)) names.add(name);
+  }
+  return names;
+}
+
+/** The package name of a `name@range` / `@scope/name@range` /
+ *  `name@npm:range` spec key. Null when the key carries no range
+ *  separator (not a spec). */
+function packageNameOfSpec(spec: string): string | null {
+  const at = spec.indexOf('@', spec.startsWith('@') ? 1 : 0);
+  if (at <= 0) return null;
+  return spec.slice(0, at);
+}

--- a/src/analyzers/correctness/resolution-attribution.ts
+++ b/src/analyzers/correctness/resolution-attribution.ts
@@ -14,6 +14,7 @@
 import { execFileSync } from 'child_process';
 
 import { dependencyManifestFilesIn } from '../../languages';
+import { basePackageEvidence } from './lockfile-evidence';
 import type { LanguageSupport } from '../../languages/types';
 import { IMPORT_RESOLUTION_LABEL, type CorrectnessFloorResult } from './run';
 import { attributeFloorFailures, type FloorBaseCheck } from './attribution';
@@ -24,8 +25,14 @@ import { attributeFloorFailures, type FloorBaseCheck } from './attribution';
  * some package by that name was installed there — and every install is
  * recorded in a manifest/lockfile. So:
  *
- *   - the specifier appears in NO base manifest/lockfile blob (conservative
- *     textual containment — a false "present" merely keeps the block), AND
+ *   - NO base manifest/lockfile evidences a package by that name — the
+ *     format-aware installed/declared set where the format is modeled
+ *     (`lockfile-evidence.ts`, #284: a lockfile MENTIONS names it does not
+ *     install, e.g. peer metadata inside another entry, and short names
+ *     are substrings of longer ones — both read as falsely "present" under
+ *     the old whole-blob containment and turned a pre-existing phantom
+ *     into a net-new block), textual containment where it is not (a false
+ *     "present" merely keeps the block), AND
  *   - the base tree already carried the import (the QUOTED specifier appears
  *     in base source — quoting excludes prose mentions, and a false "absent"
  *     merely keeps the block)
@@ -35,11 +42,12 @@ import { attributeFloorFailures, type FloorBaseCheck } from './attribution';
  *
  * Everything else stays attributable (the un-hoist class the resolution
  * check exists for: a specifier the base lockfile DID provide transitively
- * reads as present and keeps blocking; a newly-added import of an undeclared
- * package is absent from base source and keeps blocking). Every uncertainty
- * lands on "keep blocking" — the refutation only fires when the base
- * evidence is decisive. Returns null when the base side is unreadable (no
- * refutation, behavior unchanged). Exported for tests.
+ * is an installed-tree KEY, reads as present, and keeps blocking; a newly-
+ * added import of an undeclared package is absent from base source and
+ * keeps blocking). Every uncertainty lands on "keep blocking" — the
+ * refutation only fires when the base evidence is decisive. Returns null
+ * when the base side is unreadable (no refutation, behavior unchanged).
+ * Exported for tests.
  */
 export function refutedResolutionSpecifiers(
   cwd: string,
@@ -54,17 +62,25 @@ export function refutedResolutionSpecifiers(
     const treeFiles = git(['ls-tree', '-r', '--name-only', baseSha]).split('\n').filter(Boolean);
     const manifestPaths = dependencyManifestFilesIn(treeFiles, packs);
     const manifestBlobs = manifestPaths.map((p) => {
-      try {
-        return git(['show', `${baseSha}:${p}`]);
-      } catch {
-        // An unreadable manifest blob makes base evidence non-decisive for
-        // every specifier — fail toward keeping the block.
-        throw new Error(`unreadable base manifest ${p}`);
-      }
+      const blob = ((): string => {
+        try {
+          return git(['show', `${baseSha}:${p}`]);
+        } catch {
+          // An unreadable manifest blob makes base evidence non-decisive for
+          // every specifier — fail toward keeping the block.
+          throw new Error(`unreadable base manifest ${p}`);
+        }
+      })();
+      // Format-aware installed/declared set where the format is modeled;
+      // null keeps the containment fallback for that file (#284).
+      return { blob, evidence: basePackageEvidence(p, blob) };
     });
     const refuted: string[] = [];
     for (const spec of specifiers) {
-      if (manifestBlobs.some((blob) => blob.includes(spec))) continue; // maybe provided at base
+      const maybeProvidedAtBase = manifestBlobs.some(({ blob, evidence }) =>
+        evidence !== null ? evidence.has(spec) : blob.includes(spec),
+      );
+      if (maybeProvidedAtBase) continue;
       // Quoted-containment probe for the import existing at base. `git grep`
       // exits 1 on no match — treated as "not imported at base" (keep block).
       const importedAtBase = [`'${spec}'`, `"${spec}"`].some((needle) => {

--- a/src/baseline/block-rules.ts
+++ b/src/baseline/block-rules.ts
@@ -1,0 +1,113 @@
+/**
+ * The ONE block-rule evaluator (CLAUDE.md Rule 19 / 2.30) — split from
+ * `classify.ts` at the large-file bar, semantics unchanged. Both the
+ * classifier's live verdict and the recall-drift refusal path
+ * (`unattributableBlockRule`) call THIS function; `scopeForPolicy`
+ * (`gather-scope.ts`) and `BLOCK_RULE_EVIDENCE` track its predicates.
+ * A new rule lands here, in the evidence table, and nowhere else.
+ */
+
+import type { BrownfieldBlockRules } from './policy';
+import type { FindingStatus } from './types';
+import type { ClassifyContext } from './classify';
+
+/**
+ * Check whether any block-rule fires for the given classified pair.
+ * Returns the matching rule's name (for reason rendering) or null
+ * when no rule fires.
+ *
+ * Block-rules escalate specific kinds of net-new findings beyond the generic
+ * policy. They fire on a matcher-`added` finding INCLUDING one demoted to
+ * `config_drift`: a config / .dxkit-ignore / policy-hash change does not create
+ * phantom findings (the credential or vuln is really in the code — the config
+ * edit only changed the *reason* string), so it must never disable a block for a
+ * net-new blocking-class finding. That closes the bypass where a coincident
+ * policy.json edit — or drift vs a stale baseline — let a net-new critical secret
+ * pass as a warning (feedback #20). `tooling_drift` (a scanner / advisory-DB
+ * version change CAN surface a phantom critical that isn't a real regression) and
+ * `uncertain` (scanner wobble) still suppress block-rules, preserving the
+ * legitimate false-block prevention there — but `tooling_drift` does NOT get to
+ * silently pass a block-rule-class finding: the recall-drift branch above records
+ * `unattributableBlockRule` for it, and the verdict layer refuses to print PASSED
+ * while one exists. Without that, `tooling_drift` is the #20 bypass one status
+ * over: every pre-Rule-19 baseline reads as drifted, so a net-new secret sailed
+ * through as a warning on upgrade day while the banner said PASSED.
+ */
+export function evaluateBlockRules(
+  status: FindingStatus,
+  rules: BrownfieldBlockRules,
+  context: ClassifyContext,
+): string | null {
+  // `newly_published_advisory` never reaches here — its verdict is governed by
+  // the advisory tier (see the early return in `classify`), which owns the
+  // malicious always-block invariant that `newMaliciousDependency` covers for
+  // ordinary `added` findings.
+  if (status !== 'added' && status !== 'config_drift') return null;
+  if (rules.newSecret && context.kind === 'secret') return 'newSecret';
+  if (rules.newCriticalSecurity && context.kind === 'code' && context.severity === 'critical') {
+    return 'newCriticalSecurity';
+  }
+  if (rules.newHighSecurity && context.kind === 'code' && context.severity === 'high') {
+    return 'newHighSecurity';
+  }
+  if (
+    rules.newCriticalDependencyVulnerability &&
+    context.kind === 'dep-vuln' &&
+    context.severity === 'critical'
+  ) {
+    return 'newCriticalDependencyVulnerability';
+  }
+  if (
+    rules.newHighReachableDependencyVulnerability &&
+    context.kind === 'dep-vuln' &&
+    context.severity === 'high' &&
+    context.reachable === true
+  ) {
+    return 'newHighReachableDependencyVulnerability';
+  }
+  // Malicious-code advisories block at ANY severity: install-time malware
+  // executes at install, so CVSS and reachability are the wrong lens. The
+  // `malicious` signal comes from the one canonical predicate
+  // (`src/analyzers/security/malicious.ts`) applied to the current scan.
+  if (rules.newMaliciousDependency && context.kind === 'dep-vuln' && context.malicious === true) {
+    return 'newMaliciousDependency';
+  }
+  // Every minted `license` finding is already a prohibited-list match (the
+  // inventory never becomes findings), so kind alone is the whole predicate.
+  if (rules.newProhibitedLicense && context.kind === 'license') {
+    return 'newProhibitedLicense';
+  }
+  // A custom check the policy declared `blocking: true` (4.4.0): the block
+  // intent rides on the finding itself, threaded here as
+  // `customCheckBlocking`. Only a strict `true` fires — a sanitized entry
+  // (intent stripped) or a `blocking: false` check never does; those keep
+  // the generic `block` list's verdict and applyCustomCheckIntent's
+  // demotion respectively.
+  if (
+    rules.newBlockingCustomCheckFailure &&
+    context.kind === 'custom-check' &&
+    context.customCheckBlocking === true
+  ) {
+    return 'newBlockingCustomCheckFailure';
+  }
+  // A net-new test gap the developer can actually have caused: a file this
+  // diff ADDED, shipping without a test. The rule's original predicate
+  // (`overlapsChangedLines === true`) was structurally DEAD — a test-gap
+  // finding is whole-file and carries no line, so the overlap was always
+  // undefined and the rule could never fire (the T1.2 armed-but-dead class).
+  // The added-file predicate is also the only honest one for a
+  // derived-membership kind: an EDIT never introduces a test gap (see
+  // `derived-membership-shift` above), so firing on edits would misattribute.
+  if (rules.newUntestedChangedSource && context.kind === 'test-gap' && context.fileAddedInDiff) {
+    return 'newUntestedChangedSource';
+  }
+  if (
+    rules.newSevereQualityIssueInChangedFiles &&
+    (context.kind === 'code' || context.kind === 'hygiene') &&
+    (context.severity === 'critical' || context.severity === 'high') &&
+    context.overlapsChangedLines === true
+  ) {
+    return 'newSevereQualityIssueInChangedFiles';
+  }
+  return null;
+}

--- a/src/baseline/changed-files.ts
+++ b/src/baseline/changed-files.ts
@@ -18,6 +18,7 @@
  * return a partial set on error.
  */
 import { execFileSync } from 'child_process';
+import * as fs from 'fs';
 import { existsSync } from 'fs';
 import * as path from 'path';
 
@@ -191,4 +192,60 @@ function readChangedLineSet(cwd: string, baseSha: string, file: string): Set<num
     for (let i = 0; i < newCount; i++) out.add(newStart + i);
   }
   return out;
+}
+
+/**
+ * The CONTENT lines the working tree changed vs `baseSha` across `files`
+ * (added + removed sides of the one-sided base → working-tree diff, staged
+ * + unstaged; an untracked file contributes all of its lines, per the
+ * attribution doctrine above). Null on git failure — attribution
+ * unavailable, callers must read it as UNKNOWN, never as "nothing
+ * changed". Consumed by the per-finding advisory attribution (#283): a
+ * dep-vuln whose package no changed manifest line mentions provably kept
+ * its resolution across the diff.
+ */
+export function changedContentLines(
+  cwd: string,
+  baseSha: string,
+  files: ReadonlyArray<string>,
+): ReadonlyArray<string> | null {
+  if (!baseSha || files.length === 0) return files.length === 0 ? [] : null;
+  let untracked: Set<string>;
+  try {
+    untracked = new Set(
+      gitLines(cwd, ['ls-files', '--others', '--exclude-standard', '--', ...files]),
+    );
+  } catch {
+    return null;
+  }
+  const lines: string[] = [];
+  for (const file of files) {
+    if (untracked.has(file)) {
+      try {
+        lines.push(...fs.readFileSync(path.join(cwd, file), 'utf8').split('\n'));
+      } catch {
+        return null; // listed as untracked but unreadable → unknown
+      }
+      continue;
+    }
+    let diff: string;
+    try {
+      diff = execFileSync('git', ['diff', '--no-color', '--find-renames', baseSha, '--', file], {
+        cwd,
+        encoding: 'utf8',
+        maxBuffer: 128 * 1024 * 1024,
+      });
+    } catch {
+      return null;
+    }
+    for (const raw of diff.split('\n')) {
+      if (
+        (raw.startsWith('+') && !raw.startsWith('+++')) ||
+        (raw.startsWith('-') && !raw.startsWith('---'))
+      ) {
+        lines.push(raw.slice(1));
+      }
+    }
+  }
+  return lines;
 }

--- a/src/baseline/classify.ts
+++ b/src/baseline/classify.ts
@@ -9,10 +9,13 @@
 import type { FindingSeverity, FindingStatus, MatchPair, MatchReason } from './types';
 import {
   type BrownfieldPolicy,
-  type BrownfieldBlockRules,
   DEFAULT_BROWNFIELD_POLICY,
   newAdvisoryBlockSeverities,
 } from './policy';
+// The ONE block-rule evaluator lives in `./block-rules` (split at the
+// large-file bar); re-exported so existing doc references stay truthful.
+import { evaluateBlockRules } from './block-rules';
+export { evaluateBlockRules } from './block-rules';
 
 /**
  * Contextual signals the classifier reads when available. Every field
@@ -93,6 +96,14 @@ export interface ClassifyContext {
    *  Absent (changed files unknowable) ⇒ no relabel: the evidence is missing,
    *  so the finding keeps its `added` attribution. */
   readonly manifestUntouched?: boolean;
+  /** The per-finding sibling of `manifestUntouched` (#283): the diff DID
+   *  touch a manifest, but NO changed manifest line mentions THIS finding's
+   *  package — the diff provably did not change its resolution, so the
+   *  advisory-feed attribution applies to it exactly as under an untouched
+   *  manifest. Set only for `added` dep-vuln pairs, decided by the ONE
+   *  changed-content index in `classify-pairs.ts` (Rule 2.30: never a second
+   *  attribution table). Absent ⇒ no relabel — the finding keeps `added`. */
+  readonly packageUntouchedByDiff?: boolean;
   /** True when an `added` dep-vuln is on a reachable code path. */
   readonly reachable?: boolean;
   /** For a `custom-check` finding: the user/pack-declared block intent
@@ -218,23 +229,34 @@ export function classify(
             `baseline is re-captured`,
         });
       }
-    } else if (context.kind === 'dep-vuln' && context.manifestUntouched) {
-      // D4: the PR changed no dependency manifest, so the dependency set is
-      // identical to the baseline's — the developer cannot be the cause of an
-      // added dep-vuln. The one input that moved is the advisory FEED
-      // (published after baseline capture). Recall is genuinely clean here
-      // (Rule 19's recallDrifted branch above wins when it isn't), so this is
-      // its own status — never "regression", never `tooling_drift`. The
-      // verdict is decided by the advisory TIER below (default: high/critical
-      // block, medium/low warn; malicious always blocks).
+    } else if (
+      context.kind === 'dep-vuln' &&
+      (context.manifestUntouched || context.packageUntouchedByDiff)
+    ) {
+      // D4: the developer cannot be the cause of this added dep-vuln — either
+      // the PR changed no dependency manifest at all (the run-level fast
+      // path), or it did but no changed manifest line mentions THIS package
+      // (#283's per-finding tier: a one-line bump PR must not be blamed for
+      // the whole advisory wave against packages it never touched). Either
+      // way the dependency's resolution is identical to the baseline's and
+      // the one input that moved is the advisory FEED (published after
+      // baseline capture). Recall is genuinely clean here (Rule 19's
+      // recallDrifted branch above wins when it isn't), so this is its own
+      // status — never "regression", never `tooling_drift`. The verdict is
+      // decided by the advisory TIER below (default: high/critical block,
+      // medium/low warn; malicious always blocks).
       status = 'newly_published_advisory';
       reasons.push({
         code: 'newly-published-advisory',
         detail:
-          'not introduced by this PR — the diff touches no dependency manifest, so this ' +
-          'advisory was published after the baseline was captured. Fix the vulnerability to ' +
-          'unblock, or defer time-boxed: vyuh-dxkit allowlist defer --from-last-check ' +
-          '--reason="…"',
+          (context.manifestUntouched
+            ? 'not introduced by this PR — the diff touches no dependency manifest, so this ' +
+              'advisory was published after the baseline was captured. '
+            : 'not introduced by this PR — the diff changes no manifest line mentioning this ' +
+              'package (its resolution is unchanged), so this advisory was published after ' +
+              'the baseline was captured. ') +
+          'Fix the vulnerability to unblock, or defer time-boxed: vyuh-dxkit allowlist defer ' +
+          '--from-last-check --reason="…"',
       });
     } else if (context.derivedMembership && context.fileAddedInDiff === false) {
       // Derived-membership attribution (the #25 class): this kind's per-file
@@ -378,107 +400,6 @@ export function classify(
     reasons,
     ...(unattributableBlockRule !== undefined ? { unattributableBlockRule } : {}),
   };
-}
-
-/**
- * Check whether any block-rule fires for the given classified pair.
- * Returns the matching rule's name (for reason rendering) or null
- * when no rule fires.
- *
- * Block-rules escalate specific kinds of net-new findings beyond the generic
- * policy. They fire on a matcher-`added` finding INCLUDING one demoted to
- * `config_drift`: a config / .dxkit-ignore / policy-hash change does not create
- * phantom findings (the credential or vuln is really in the code — the config
- * edit only changed the *reason* string), so it must never disable a block for a
- * net-new blocking-class finding. That closes the bypass where a coincident
- * policy.json edit — or drift vs a stale baseline — let a net-new critical secret
- * pass as a warning (feedback #20). `tooling_drift` (a scanner / advisory-DB
- * version change CAN surface a phantom critical that isn't a real regression) and
- * `uncertain` (scanner wobble) still suppress block-rules, preserving the
- * legitimate false-block prevention there — but `tooling_drift` does NOT get to
- * silently pass a block-rule-class finding: the recall-drift branch above records
- * `unattributableBlockRule` for it, and the verdict layer refuses to print PASSED
- * while one exists. Without that, `tooling_drift` is the #20 bypass one status
- * over: every pre-Rule-19 baseline reads as drifted, so a net-new secret sailed
- * through as a warning on upgrade day while the banner said PASSED.
- */
-function evaluateBlockRules(
-  status: FindingStatus,
-  rules: BrownfieldBlockRules,
-  context: ClassifyContext,
-): string | null {
-  // `newly_published_advisory` never reaches here — its verdict is governed by
-  // the advisory tier (see the early return in `classify`), which owns the
-  // malicious always-block invariant that `newMaliciousDependency` covers for
-  // ordinary `added` findings.
-  if (status !== 'added' && status !== 'config_drift') return null;
-  if (rules.newSecret && context.kind === 'secret') return 'newSecret';
-  if (rules.newCriticalSecurity && context.kind === 'code' && context.severity === 'critical') {
-    return 'newCriticalSecurity';
-  }
-  if (rules.newHighSecurity && context.kind === 'code' && context.severity === 'high') {
-    return 'newHighSecurity';
-  }
-  if (
-    rules.newCriticalDependencyVulnerability &&
-    context.kind === 'dep-vuln' &&
-    context.severity === 'critical'
-  ) {
-    return 'newCriticalDependencyVulnerability';
-  }
-  if (
-    rules.newHighReachableDependencyVulnerability &&
-    context.kind === 'dep-vuln' &&
-    context.severity === 'high' &&
-    context.reachable === true
-  ) {
-    return 'newHighReachableDependencyVulnerability';
-  }
-  // Malicious-code advisories block at ANY severity: install-time malware
-  // executes at install, so CVSS and reachability are the wrong lens. The
-  // `malicious` signal comes from the one canonical predicate
-  // (`src/analyzers/security/malicious.ts`) applied to the current scan.
-  if (rules.newMaliciousDependency && context.kind === 'dep-vuln' && context.malicious === true) {
-    return 'newMaliciousDependency';
-  }
-  // Every minted `license` finding is already a prohibited-list match (the
-  // inventory never becomes findings), so kind alone is the whole predicate.
-  if (rules.newProhibitedLicense && context.kind === 'license') {
-    return 'newProhibitedLicense';
-  }
-  // A custom check the policy declared `blocking: true` (4.4.0): the block
-  // intent rides on the finding itself, threaded here as
-  // `customCheckBlocking`. Only a strict `true` fires — a sanitized entry
-  // (intent stripped) or a `blocking: false` check never does; those keep
-  // the generic `block` list's verdict and applyCustomCheckIntent's
-  // demotion respectively.
-  if (
-    rules.newBlockingCustomCheckFailure &&
-    context.kind === 'custom-check' &&
-    context.customCheckBlocking === true
-  ) {
-    return 'newBlockingCustomCheckFailure';
-  }
-  // A net-new test gap the developer can actually have caused: a file this
-  // diff ADDED, shipping without a test. The rule's original predicate
-  // (`overlapsChangedLines === true`) was structurally DEAD — a test-gap
-  // finding is whole-file and carries no line, so the overlap was always
-  // undefined and the rule could never fire (the T1.2 armed-but-dead class).
-  // The added-file predicate is also the only honest one for a
-  // derived-membership kind: an EDIT never introduces a test gap (see
-  // `derived-membership-shift` above), so firing on edits would misattribute.
-  if (rules.newUntestedChangedSource && context.kind === 'test-gap' && context.fileAddedInDiff) {
-    return 'newUntestedChangedSource';
-  }
-  if (
-    rules.newSevereQualityIssueInChangedFiles &&
-    (context.kind === 'code' || context.kind === 'hygiene') &&
-    (context.severity === 'critical' || context.severity === 'high') &&
-    context.overlapsChangedLines === true
-  ) {
-    return 'newSevereQualityIssueInChangedFiles';
-  }
-  return null;
 }
 
 /**

--- a/src/gate/classify-pairs.ts
+++ b/src/gate/classify-pairs.ts
@@ -19,11 +19,16 @@ import { allowlistSuppressionFor } from '../baseline/allowlist-match';
 import { DERIVED_MEMBERSHIP_KINDS } from '../baseline/gather-scope';
 import type { GatherScope } from '../baseline/gather-scope';
 import {
+  changedContentLines,
   computeAddedFiles,
   computeChangedFiles,
   createChangedLineIndex,
 } from '../baseline/changed-files';
-import { changedFilesTouchDependencyManifest, detectActiveLanguages } from '../languages';
+import {
+  changedFilesTouchDependencyManifest,
+  dependencyManifestFilesIn,
+  detectActiveLanguages,
+} from '../languages';
 import { describeRecallDrift } from '../baseline/recall';
 import { isSanitized } from '../baseline/sanitize';
 import type { BaselineEntry, FindingId, MatchResult } from '../baseline/types';
@@ -122,6 +127,34 @@ export function classifyPairs(input: ClassifyPairsInput): ClassifyPairsOutput {
         !changedFilesTouchDependencyManifest(changed, detectActiveLanguages(cwd));
     }
     return manifestUntouchedMemo;
+  };
+
+  // The PER-FINDING sibling of the fast path above (#283): when the diff DID
+  // touch a manifest, an added dep-vuln whose package NO changed manifest
+  // line mentions provably kept its resolution across the diff — the diff
+  // did not change that package, so the advisory-feed attribution applies to
+  // it exactly as it would under an untouched manifest. Conservative token
+  // test: any mention (even a substring inside a longer name) reads as
+  // "possibly changed" and keeps developer attribution — a demotion needs
+  // decisive absence. Memoized: one content-line diff over the changed
+  // manifests per run, only when an added dep-vuln pair under a touched
+  // manifest actually asks. `null` (attribution unavailable) → no demotion.
+  let manifestDiffLinesMemo: ReadonlyArray<string> | null | undefined;
+  const packageUntouchedByDiff = (pkg: string): boolean => {
+    if (manifestDiffLinesMemo === undefined) {
+      const changed = baseSha ? computeChangedFiles(cwd, baseSha) : null;
+      manifestDiffLinesMemo =
+        changed === null
+          ? null
+          : changedContentLines(
+              cwd,
+              baseSha,
+              dependencyManifestFilesIn(changed, detectActiveLanguages(cwd)),
+            );
+    }
+    if (manifestDiffLinesMemo === null || pkg.length === 0) return false;
+    const needle = pkg.toLowerCase();
+    return !manifestDiffLinesMemo.some((line) => line.toLowerCase().includes(needle));
   };
 
   // Derived-membership attribution (the #25 class): for a kind whose per-file
@@ -256,9 +289,19 @@ export function classifyPairs(input: ClassifyPairsInput): ClassifyPairsOutput {
       ...(customCheckBlocking !== undefined ? { customCheckBlocking } : {}),
       ...(notObserved !== undefined ? { notObserved } : {}),
       // Only asked for added dep-vuln pairs, so a run with none never pays the
-      // git diff (and other kinds never see the flag).
-      ...(anchorEntry.kind === 'dep-vuln' && pair.status === 'added' && manifestUntouched()
-        ? { manifestUntouched: true }
+      // git diff (and other kinds never see the flags). Two tiers of the ONE
+      // attribution question (#283): the run-level fast path (no manifest
+      // touched at all), then the per-finding fallback (manifests touched,
+      // but no changed manifest line mentions THIS package).
+      ...(anchorEntry.kind === 'dep-vuln' && pair.status === 'added'
+        ? manifestUntouched()
+          ? { manifestUntouched: true }
+          : // A sanitized entry carries no package name — per-finding
+            // attribution then has no subject and the pair keeps `added`
+            // (bias toward the conservative claim, never a blind demotion).
+            'package' in anchorEntry && packageUntouchedByDiff(anchorEntry.package)
+            ? { packageUntouchedByDiff: true }
+            : {}
         : {}),
     };
 

--- a/test/baseline/advisory-attribution.test.ts
+++ b/test/baseline/advisory-attribution.test.ts
@@ -135,6 +135,33 @@ describe('classify — newly_published_advisory (D4 phase 1)', () => {
     expect(out.status).toBe('added');
   });
 
+  it('#283: the per-finding tier — a touched manifest whose diff never mentions THIS package still relabels', () => {
+    const out = classify(
+      addedPair,
+      DEFAULT_BROWNFIELD_POLICY,
+      ctx({ packageUntouchedByDiff: true }),
+    );
+    expect(out.status).toBe('newly_published_advisory');
+    const reason = out.reasons.find((r) => r.code === 'newly-published-advisory');
+    expect(reason!.detail).toContain('no manifest line mentioning this package');
+  });
+
+  it('#283: the tier verdict applies identically on the per-finding path (high blocks, medium warns)', () => {
+    const high = classify(
+      addedPair,
+      DEFAULT_BROWNFIELD_POLICY,
+      ctx({ packageUntouchedByDiff: true, severity: 'high' }),
+    );
+    const medium = classify(
+      addedPair,
+      DEFAULT_BROWNFIELD_POLICY,
+      ctx({ packageUntouchedByDiff: true, severity: 'medium' }),
+    );
+    expect(high.blocks).toBe(true);
+    expect(medium.blocks).toBe(false);
+    expect(medium.warns).toBe(true);
+  });
+
   it('a manifest-TOUCHING diff keeps full added semantics', () => {
     const out = classify(addedPair, DEFAULT_BROWNFIELD_POLICY, ctx({ manifestUntouched: false }));
     expect(out.status).toBe('added');

--- a/test/baseline/changed-files.test.ts
+++ b/test/baseline/changed-files.test.ts
@@ -3,7 +3,11 @@ import { execFileSync } from 'child_process';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { computeChangedFiles, createChangedLineIndex } from '../../src/baseline/changed-files';
+import {
+  changedContentLines,
+  computeChangedFiles,
+  createChangedLineIndex,
+} from '../../src/baseline/changed-files';
 
 /**
  * `computeChangedFiles` is the safety core of incremental scanning (opt 3):
@@ -178,5 +182,54 @@ describe('createChangedLineIndex (line-granularity sibling — same working-tree
       const attributed = lines === 'all' || (lines !== null && lines.size > 0);
       expect(attributed, `no line attribution for changed file ${file}`).toBe(true);
     }
+  });
+});
+
+describe('changedContentLines (#283 — the per-finding advisory attribution basis)', () => {
+  let repo: string;
+  let base: string;
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'dxkit-changed-lines-'));
+    git(repo, ['init', '-q', '-b', 'main']);
+    git(repo, ['config', 'user.email', 't@t.co']);
+    git(repo, ['config', 'user.name', 't']);
+    writeFileSync(
+      join(repo, 'package.json'),
+      JSON.stringify({ dependencies: { 'pkg-a': '^1.0.0', 'pkg-b': '^2.0.0' } }, null, 2) + '\n',
+    );
+    base = commitAll(repo, 'base');
+  });
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("a one-line bump yields exactly that package's changed lines — the untouched package is absent", () => {
+    writeFileSync(
+      join(repo, 'package.json'),
+      JSON.stringify({ dependencies: { 'pkg-a': '^1.1.0', 'pkg-b': '^2.0.0' } }, null, 2) + '\n',
+    );
+    const lines = changedContentLines(repo, base, ['package.json'])!;
+    expect(lines.some((l) => l.includes('pkg-a'))).toBe(true);
+    // The issue's acceptance shape: bump A, and B's resolution provably
+    // unchanged — no changed line mentions it.
+    expect(lines.some((l) => l.includes('pkg-b'))).toBe(false);
+  });
+
+  it('an untracked file reads as fully added (a new manifest must not read as untouched)', () => {
+    mkdirSync(join(repo, 'nested'), { recursive: true });
+    writeFileSync(
+      join(repo, 'nested', 'package.json'),
+      JSON.stringify({ dependencies: { 'pkg-new': '^1.0.0' } }) + '\n',
+    );
+    const lines = changedContentLines(repo, base, ['nested/package.json'])!;
+    expect(lines.some((l) => l.includes('pkg-new'))).toBe(true);
+  });
+
+  it('an empty file list is an empty answer, never null', () => {
+    expect(changedContentLines(repo, base, [])).toEqual([]);
+  });
+
+  it('git failure yields null — unknown, never "nothing changed"', () => {
+    expect(changedContentLines(repo, 'not-a-sha', ['package.json'])).toBeNull();
   });
 });

--- a/test/correctness-lockfile-evidence.test.ts
+++ b/test/correctness-lockfile-evidence.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { basePackageEvidence } from '../src/analyzers/correctness/lockfile-evidence';
+
+/**
+ * #284 — the format-aware "which packages could this file have provided?"
+ * evidence. The contract under test: KEYS (installed/declared names)
+ * count, VALUES (peer metadata, ranges, prose) never do, and anything
+ * unparseable or unmodeled returns null so the caller keeps the
+ * conservative containment fallback.
+ */
+
+describe('basePackageEvidence — npm lockfiles', () => {
+  const lock = JSON.stringify({
+    lockfileVersion: 3,
+    packages: {
+      '': { dependencies: { app: '1.0.0' } },
+      'node_modules/@scope/installed': {
+        version: '1.0.0',
+        peerDependencies: { 'peer-only-pkg': '>=1' },
+      },
+      'node_modules/@scope/installed/node_modules/nested-pkg': { version: '2.0.0' },
+    },
+  });
+
+  it('installed-tree keys count, nested entries included', () => {
+    const set = basePackageEvidence('package-lock.json', lock)!;
+    expect(set.has('@scope/installed')).toBe(true);
+    expect(set.has('nested-pkg')).toBe(true);
+  });
+
+  it('peer metadata inside an entry does NOT count (the three class)', () => {
+    const set = basePackageEvidence('package-lock.json', lock)!;
+    expect(set.has('peer-only-pkg')).toBe(false);
+  });
+
+  it('v1 dependencies-tree keys count recursively', () => {
+    const v1 = JSON.stringify({
+      lockfileVersion: 1,
+      dependencies: { outer: { version: '1.0.0', dependencies: { inner: { version: '2.0.0' } } } },
+    });
+    const set = basePackageEvidence('package-lock.json', v1)!;
+    expect(set.has('outer')).toBe(true);
+    expect(set.has('inner')).toBe(true);
+  });
+
+  it('unparseable JSON → null (containment fallback)', () => {
+    expect(basePackageEvidence('package-lock.json', '{ nope')).toBeNull();
+  });
+});
+
+describe('basePackageEvidence — yarn.lock', () => {
+  it('classic entry headers, scoped + multi-key', () => {
+    const yarn = [
+      '# yarn lockfile v1',
+      '',
+      '"@scope/a@^1.0.0", "@scope/a@^1.1.0":',
+      '  version "1.2.0"',
+      '  dependencies:',
+      '    mentioned-in-body "^3.0.0"',
+      '',
+      'plain-pkg@^2.0.0:',
+      '  version "2.0.1"',
+    ].join('\n');
+    const set = basePackageEvidence('yarn.lock', yarn)!;
+    expect(set.has('@scope/a')).toBe(true);
+    expect(set.has('plain-pkg')).toBe(true);
+    // Body lines are indented and never parsed as names.
+    expect(set.has('mentioned-in-body')).toBe(false);
+  });
+
+  it('berry protocol keys', () => {
+    const berry = ['"berry-pkg@npm:^1.0":', '  version: 1.0.0'].join('\n');
+    expect(basePackageEvidence('yarn.lock', berry)!.has('berry-pkg')).toBe(true);
+  });
+});
+
+describe('basePackageEvidence — pnpm-lock.yaml', () => {
+  it('packages-section keys across dialects; other sections ignored', () => {
+    const pnpm = [
+      'lockfileVersion: 6.0',
+      '',
+      'importers:',
+      '  .:',
+      '    dependencies:',
+      '      importer-mention: 1.0.0',
+      '',
+      'packages:',
+      '  /old-style/1.0.0:',
+      '    resolution: {}',
+      '  /@scope/newer@2.0.0:',
+      '    resolution: {}',
+      "  'quoted-pkg@3.0.0':",
+      '    resolution: {}',
+    ].join('\n');
+    const set = basePackageEvidence('pnpm-lock.yaml', pnpm)!;
+    expect(set.has('old-style')).toBe(true);
+    expect(set.has('@scope/newer')).toBe(true);
+    expect(set.has('quoted-pkg')).toBe(true);
+    expect(set.has('importer-mention')).toBe(false);
+  });
+});
+
+describe('basePackageEvidence — package.json + unmodeled formats', () => {
+  it('declared names across all four sections count (peers included: no lockfile beside a bare manifest means the install flags are unknowable, and counting keeps the block)', () => {
+    const manifest = JSON.stringify({
+      dependencies: { a: '1' },
+      devDependencies: { b: '1' },
+      optionalDependencies: { c: '1' },
+      peerDependencies: { d: '1' },
+    });
+    const set = basePackageEvidence('package.json', manifest)!;
+    for (const name of ['a', 'b', 'c', 'd']) expect(set.has(name)).toBe(true);
+  });
+
+  it('unmodeled formats → null (non-JS ecosystems keep containment byte-for-byte)', () => {
+    expect(basePackageEvidence('Gemfile.lock', 'GEM\n  remote: x')).toBeNull();
+    expect(basePackageEvidence('requirements.txt', 'flask==2.0')).toBeNull();
+    expect(basePackageEvidence('go.sum', 'example.com/m v1.0.0 h1:x')).toBeNull();
+  });
+});

--- a/test/correctness-resolution-attribution.test.ts
+++ b/test/correctness-resolution-attribution.test.ts
@@ -93,7 +93,10 @@ function packWithResolution(
 ): LanguageSupport {
   return {
     id: 'synthetic',
-    depVulns: { manifestPatterns: ['package.json', 'package-lock.json'] },
+    // The probe reads manifest patterns from `capabilities.depVulns` (the
+    // real pack shape) — a top-level `depVulns` here is invisible to
+    // `dependencyManifestFilesIn` and silently empties the base evidence.
+    capabilities: { depVulns: { manifestPatterns: ['package.json', 'package-lock.json'] } },
     correctness: {
       execution: () => ({
         hosts: ['any' as const],
@@ -149,6 +152,91 @@ describe('refutedResolutionSpecifiers — the base probe', () => {
 
   it('yields no refutation at all when the base is unreadable', () => {
     expect(refutedResolutionSpecifiers(dir, 'not-a-sha', packs, ['ghost-pkg'])).toBeNull();
+  });
+});
+
+/**
+ * #284 — the measurement asymmetry, both live shapes: a lockfile MENTIONS
+ * package names it never installed (peer metadata inside another entry,
+ * under a --legacy-peer-deps install), and a short name is a literal
+ * substring of a longer installed one. The old whole-blob containment read
+ * both as "maybe provided at base" and hard-blocked pre-existing phantoms
+ * on manifests-only diffs. The format-aware evidence answers what the
+ * current side asks: was a package by that name INSTALLED at base?
+ */
+describe('refutedResolutionSpecifiers — #284 lockfile evidence (peer metadata, substrings)', () => {
+  let dir: string;
+  let baseSha: string;
+  const packs = [packWithResolution({ kind: 'clean', checkedSpecifiers: 0 })];
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-floor-attrib-peer-'));
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'test@example.com']);
+    git(dir, ['config', 'user.name', 'test']);
+    git(dir, ['config', 'commit.gpgsign', 'false']);
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '1.0' }));
+    // The incident lockfile shape: '@render-three/fiber' is installed and its
+    // entry DECLARES 'three' as a peer — but 'three' has no entry of its own
+    // (--legacy-peer-deps never materialized it). 'three' is also a literal
+    // substring of the installed package's name.
+    writeFileSync(
+      join(dir, 'package-lock.json'),
+      JSON.stringify({
+        name: 'fixture',
+        lockfileVersion: 3,
+        packages: {
+          '': { dependencies: { '@render-three/fiber': '^8.0.0' } },
+          'node_modules/@render-three/fiber': {
+            version: '8.0.0',
+            peerDependencies: { three: '>=0.150' },
+          },
+        },
+      }),
+    );
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(
+      join(dir, 'src', 'scene.js'),
+      "const t = require('three');\nmodule.exports = t;\n",
+    );
+    git(dir, ['add', '.']);
+    git(dir, ['commit', '-q', '-m', 'base']);
+    baseSha = git(dir, ['rev-parse', 'HEAD']).trim();
+    // Allowlist-only change (the live shape: a diff that cannot introduce
+    // an import).
+    writeFileSync(join(dir, 'NOTES.md'), 'defer extended\n');
+    git(dir, ['add', '.']);
+    git(dir, ['commit', '-q', '-m', 'chore: notes']);
+  });
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('refutes a peer-declared-but-never-installed phantom (the three class)', () => {
+    // Old behavior: "three" appears in the lockfile blob (peer metadata AND
+    // as a substring of @render-three/fiber) → kept blocking. New behavior:
+    // no installed-tree entry names it → already unresolvable at base →
+    // pre-existing, refuted.
+    expect(refutedResolutionSpecifiers(dir, baseSha, packs, ['three'])).toEqual(['three']);
+  });
+
+  it('keeps a package with an actual installed-tree entry (nothing over-refutes)', () => {
+    expect(refutedResolutionSpecifiers(dir, baseSha, packs, ['@render-three/fiber'])).toEqual([]);
+  });
+
+  it('an unparseable lockfile falls back to containment (keep the block)', () => {
+    writeFileSync(join(dir, 'package-lock.json'), '{ not json');
+    git(dir, ['add', '.']);
+    git(dir, ['commit', '-q', '-m', 'break lockfile']);
+    const brokenBase = git(dir, ['rev-parse', 'HEAD']).trim();
+    // Containment sees "three" inside the broken blob's text? It does not
+    // here (the broken blob has no such text), so the phantom still refutes;
+    // the fallback path is exercised either way. Keep a mentioned name to
+    // prove the conservative direction:
+    writeFileSync(join(dir, 'package-lock.json'), '{ not json but mentions three somewhere');
+    git(dir, ['add', '.']);
+    git(dir, ['commit', '-q', '-m', 'mention in broken blob']);
+    const mentionedBase = git(dir, ['rev-parse', 'HEAD']).trim();
+    expect(refutedResolutionSpecifiers(dir, brokenBase, packs, ['three'])).toEqual(['three']);
+    expect(refutedResolutionSpecifiers(dir, mentionedBase, packs, ['three'])).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Into `release/4.4.1`. Closes #283 and #284 — two Rule-19 fixes, each with live false blocks on record.

## #283 — per-finding newly-published-advisory demotion

The D4 demotion was gated per-run ("did the diff touch ANY manifest"), so a one-line dependency bump was blamed for the entire advisory wave against packages it never touched (nine advisories on a lockfile-only bump, live). Now a **per-finding tier** backs the run-level fast path: when manifests were touched, an added dep-vuln whose package **no changed manifest line mentions** provably kept its resolution and takes the `newly_published_advisory` path. Tier verdict unchanged (high/critical block, medium/low warn; malicious always blocks).

- One attribution basis: `changedContentLines` in the canonical changed-files module (untracked manifest = all lines added; git failure = UNKNOWN, never "untouched").
- One classify branch — no second attribution table. Conservative bias: any mention (substring included) keeps developer attribution; sanitized entries never demote.

## #284 — the base side now answers the current side's question

The pre-push refutation asked "does the base blob CONTAIN the name?" while the current side asks "does it RESOLVE?". Lockfiles mention names they never install — peer metadata inside another entry's block, and short names as substrings of longer ones — so pre-existing phantoms read as net-new and hard-blocked manifests-only / allowlist-only pushes (two live incidents).

New `lockfile-evidence` module: per-format installed/declared sets — npm packages-map + v1-tree **keys** (nested entries included), yarn entry headers, pnpm packages-section keys, package.json declared names. Values never count. Unparseable/unmodeled formats → null → that file keeps the containment fallback (non-JS ecosystems byte-for-byte unchanged; every failure keeps the block).

## Riders

- `evaluateBlockRules` → `src/baseline/block-rules.ts` (classify.ts crossed the 500-line bar; re-exported, zero consumer churn).
- Latent test bug fixed: the synthetic pack declared `manifestPatterns` at the wrong level (invisible behind an unknown-cast) — the base probe had been tested against ZERO manifests. The un-hoist case now exercises the real manifest path.

## Verification

Suite 5604/5604 (exit unmasked), all static gates clean, self-guardrail PASSED exit 0. New pins: lockfile-evidence units, the #284 incident fixture (peer-declared-never-installed refutes; installed entry keeps blocking; broken lockfile falls back conservatively), `changedContentLines` units, #283 classify fixtures both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)