### PR TITLE
feat(remediate): the in-loop Stop-gate actually engages (4.4.1 WP3, #305)

### DIFF
--- a/docs/commands/remediate.md
+++ b/docs/commands/remediate.md
@@ -108,6 +108,25 @@ in committed policy), and the ledger and PR body disclose the dispatcher
 and the verbatim prompt. The work still lands only through the identical
 verified frame.
 
+## The in-loop gate
+
+The claude-code driver arms the dxkit Stop-gate (`DXKIT_LOOP_ACTIVE=1`),
+so an agent's stop attempt re-runs the guardrail inside the session and
+bounces net-new findings back while the working context is warm. For the
+hook to actually load, the checkout must be a trusted workspace: on CI
+runs the lane pre-trusts its own checkout before spawning (a deliberate
+trust decision — the lane checks out the maintainers' default branch,
+the same tree whose npm scripts and workflows CI already executes), then
+probes the wiring end to end. The envelope and ledger disclose the
+result on every run: `in-loop gate: ARMED` or `BACKSTOP-ONLY` with the
+first missing link named, so a run without the in-loop gate never reads
+identically to one with it.
+
+Structural limit, worth knowing: a `max_turns` kill never reaches a
+stop attempt, so even a wired Stop-gate cannot fire at the cap. In-loop
+gating helps every completion attempt before the cap; the post-run
+verified frame remains the final word either way.
+
 ## Credentials and enablement
 
 The default driver is `claude-code`. In CI the workflow injects the

--- a/src/remediate/agent-trust.ts
+++ b/src/remediate/agent-trust.ts
@@ -1,0 +1,188 @@
+/**
+ * The in-loop Stop-gate wiring (#305, 4.4.1 WP3).
+ *
+ * The lane's flagship design is the gate INSIDE the loop: the driver arms
+ * `DXKIT_LOOP_ACTIVE=1` so any stop attempt re-runs the guardrail and
+ * bounces net-new findings back into the live session. What actually
+ * happened on every CI lane run ever: the Stop hook lives in the repo's
+ * committed `.claude/settings.json`, a fresh runner checkout is an
+ * UNTRUSTED workspace, and the agent CLI ignores project settings there —
+ * so the in-loop gate was silently absent and only the post-run frame
+ * verification (the backstop, never the primary) gated. Live consequence:
+ * an agent installed dependencies carrying twelve known vulnerabilities
+ * and burned its whole turn budget; a working Stop-gate would have blocked
+ * its first completion attempt in-session with the findings and turns left
+ * to repair.
+ *
+ * Three duties, one module:
+ *
+ * 1. PRE-TRUST (`preTrustAgentCheckout`): before spawning, the lane marks
+ *    its own checkout trusted in the runner's `~/.claude.json`
+ *    (`projects[<abs cwd>].hasTrustDialogAccepted: true`). This is a
+ *    deliberate, documented trust decision on the Rule-17 doctrine: the
+ *    lane checks out the maintainers' own default branch — the same tree
+ *    whose npm scripts and workflows CI already executes — so its
+ *    committed `.claude/settings.json` is inside that trust boundary. CI
+ *    runs only (`ci: true`): a maintainer's local `~/.claude.json` is
+ *    theirs, and dxkit never modifies it uninvited.
+ * 2. PROBE (`probeStopGateWiring`): positive evidence, pre-spawn, that the
+ *    hook would actually LOAD — the committed settings declare a Stop
+ *    hook, the workspace reads as trusted, and (for the standard dxkit
+ *    hook body) the CLI it invokes resolves here.
+ * 3. DISCLOSE (`armInLoopGate` → `InLoopGateStatus`): the envelope carries
+ *    `in-loop-gated` vs `backstop-only` with the reason — a run without
+ *    the in-loop gate must never read identically to one with it.
+ *
+ * Structural limit, disclosed rather than hidden: a `max_turns` kill never
+ * reaches a stop attempt, so even a wired Stop-gate cannot fire AT the
+ * cap — in-loop gating helps every completion attempt before it, and the
+ * post-run frame remains the final word.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveDxkitCli } from '../self-invocation';
+
+/** The envelope disclosure: was the in-loop Stop-gate actually wired? */
+export interface InLoopGateStatus {
+  readonly mode: 'in-loop-gated' | 'backstop-only';
+  /** Why (both modes): what was verified, or the first missing link. */
+  readonly reason: string;
+}
+
+export interface AgentTrustOptions {
+  /** The runner's home dir (injectable for tests). Default: os.homedir(). */
+  readonly home?: string;
+  /** Injectable for tests: does `vyuh-dxkit` resolve in this checkout?
+   *  Default: the ONE Rule-14 resolver (`resolveDxkitCli`). */
+  readonly cliResolves?: (cwd: string) => boolean;
+}
+
+/**
+ * Mark `cwd` trusted in `<home>/.claude.json`, preserving everything else
+ * in the file. Returns whether the write applied; a failure is a reason,
+ * never a throw (the probe will then honestly report backstop-only).
+ */
+export function preTrustAgentCheckout(
+  cwd: string,
+  opts: AgentTrustOptions = {},
+): { readonly applied: boolean; readonly reason?: string } {
+  const home = opts.home ?? os.homedir();
+  const configPath = path.join(home, '.claude.json');
+  const projectKey = path.resolve(cwd);
+  try {
+    let doc: Record<string, unknown> = {};
+    if (fs.existsSync(configPath)) {
+      doc = JSON.parse(fs.readFileSync(configPath, 'utf8')) as Record<string, unknown>;
+      if (typeof doc !== 'object' || doc === null) doc = {};
+    }
+    const projects =
+      typeof doc.projects === 'object' && doc.projects !== null
+        ? (doc.projects as Record<string, unknown>)
+        : {};
+    const existing =
+      typeof projects[projectKey] === 'object' && projects[projectKey] !== null
+        ? (projects[projectKey] as Record<string, unknown>)
+        : {};
+    doc.projects = { ...projects, [projectKey]: { ...existing, hasTrustDialogAccepted: true } };
+    fs.writeFileSync(configPath, JSON.stringify(doc, null, 2) + '\n');
+    return { applied: true };
+  } catch (err) {
+    return {
+      applied: false,
+      reason: `could not write ${configPath}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/** Does `<home>/.claude.json` mark `cwd` trusted? */
+export function checkoutTrusted(cwd: string, opts: AgentTrustOptions = {}): boolean {
+  const home = opts.home ?? os.homedir();
+  try {
+    const doc = JSON.parse(fs.readFileSync(path.join(home, '.claude.json'), 'utf8')) as {
+      projects?: Record<string, { hasTrustDialogAccepted?: unknown }>;
+    };
+    return doc.projects?.[path.resolve(cwd)]?.hasTrustDialogAccepted === true;
+  } catch {
+    return false;
+  }
+}
+
+/** The committed Stop-hook commands in `.claude/settings.json`, or null when
+ *  the file/hook is absent or unparseable. */
+function stopHookCommands(cwd: string): string[] | null {
+  try {
+    const raw = fs.readFileSync(path.join(cwd, '.claude', 'settings.json'), 'utf8');
+    const doc = JSON.parse(raw) as {
+      hooks?: { Stop?: Array<{ hooks?: Array<{ command?: unknown }> }> };
+    };
+    const commands = (doc.hooks?.Stop ?? [])
+      .flatMap((m) => m.hooks ?? [])
+      .map((h) => h.command)
+      .filter((c): c is string => typeof c === 'string');
+    return commands.length > 0 ? commands : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Positive-evidence probe: would the Stop-gate actually load for a spawn in
+ * `cwd`? Claims `in-loop-gated` only when every verifiable link holds; the
+ * first missing link is the reason. Biased toward `backstop-only` — the
+ * label this exists to kill is "armed" without evidence.
+ */
+export function probeStopGateWiring(cwd: string, opts: AgentTrustOptions = {}): InLoopGateStatus {
+  const commands = stopHookCommands(cwd);
+  if (commands === null) {
+    return {
+      mode: 'backstop-only',
+      reason:
+        'no Stop hook in the checkout’s .claude/settings.json — the loop cannot self-verify; ' +
+        'post-run verification is the gate',
+    };
+  }
+  if (!checkoutTrusted(cwd, opts)) {
+    return {
+      mode: 'backstop-only',
+      reason:
+        'the checkout is not a trusted workspace, so the agent CLI ignores its committed ' +
+        '.claude/settings.json and the Stop hook never loads — post-run verification is the gate',
+    };
+  }
+  // For the standard dxkit hook body, verify the CLI it invokes resolves
+  // here; a custom command is present-but-not-probed (still armed — the
+  // settings + trust links are verified, and inventing a refusal for a
+  // command dxkit does not own would be a false backstop label).
+  const usesDxkitCli = commands.some((c) => c.includes('vyuh-dxkit'));
+  const cliResolves = opts.cliResolves ?? ((dir: string) => resolveDxkitCli(dir).ok);
+  if (usesDxkitCli && !cliResolves(cwd)) {
+    return {
+      mode: 'backstop-only',
+      reason:
+        'the Stop hook invokes vyuh-dxkit but it does not resolve here (no project-local or ' +
+        'global install) — the hook would 404 at fire time; post-run verification is the gate',
+    };
+  }
+  return {
+    mode: 'in-loop-gated',
+    reason:
+      'Stop hook declared in committed settings, workspace trusted, hook command resolves — ' +
+      'stop attempts re-run the guardrail in-session (a max_turns kill still never reaches a ' +
+      'stop attempt; the post-run frame remains the final word)',
+  };
+}
+
+/**
+ * The lane's one entry point, called by the runner before the driver
+ * spawns: pre-trust the checkout (CI runs only — the #305 trust doctrine),
+ * then probe and return the envelope disclosure.
+ */
+export function armInLoopGate(
+  cwd: string,
+  opts: AgentTrustOptions & { readonly ci: boolean },
+): InLoopGateStatus {
+  if (opts.ci) preTrustAgentCheckout(cwd, opts);
+  return probeStopGateWiring(cwd, opts);
+}

--- a/src/remediate/claude-code-driver.ts
+++ b/src/remediate/claude-code-driver.ts
@@ -188,6 +188,9 @@ export function makeClaudeCodeDriver(exec: AgentExec = realAgentExec): AgentDriv
     // that actually bounds spend here.
     budgetSupport: { turns: 'enforced', cost: 'reported' },
     credentialEnv: ['ANTHROPIC_API_KEY'],
+    // The Stop hook is this driver's in-loop gate; the runner pre-trusts +
+    // probes the wiring pre-spawn and the envelope discloses the result.
+    inLoopGateMechanism: 'claude-stop-hook',
     // The pinned executor the managed workflow installs. Bump deliberately
     // (one line, one place) — never float `latest` under an unattended lane.
     cli: { package: '@anthropic-ai/claude-code', version: '2.1.222' },

--- a/src/remediate/driver.ts
+++ b/src/remediate/driver.ts
@@ -118,6 +118,16 @@ export interface AgentDriver {
    * stated fact, never an omission.
    */
   readonly cli: { readonly package: string; readonly version: string } | null;
+  /**
+   * The driver's in-loop gate mechanism, when it has one (#305):
+   * `'claude-stop-hook'` = the repo's committed `.claude/settings.json`
+   * Stop hook re-runs the guardrail on every stop attempt, provided the
+   * workspace is trusted and the hook command resolves — the runner
+   * pre-trusts its own CI checkout and probes the wiring before spawning
+   * (`agent-trust.ts`). Absent = the driver has no in-loop mechanism and
+   * every run is honestly disclosed `backstop-only`.
+   */
+  readonly inLoopGateMechanism?: 'claude-stop-hook';
   available(cwd: string): { readonly ok: true } | { readonly ok: false; readonly reason: string };
   run(opts: AgentRunOptions): Promise<AgentRunResult>;
 }

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -55,6 +55,14 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
         `${e.turns !== undefined ? `${e.turns} turns` : 'an unreported turn count'} ` +
         `(caps: ${e.budget.maxTurns} turns, ${e.budget.maxMinutes} min, $${e.budget.maxUsd})`,
     );
+    // The in-loop gate disclosure (#305): a run whose Stop-gate never loaded
+    // must not read identically to one where it did — the burn-budget-then-
+    // red shape starts exactly here.
+    lines.push(
+      e.inLoopGate.mode === 'in-loop-gated'
+        ? `- in-loop gate: ARMED — ${e.inLoopGate.reason}`
+        : `- in-loop gate: BACKSTOP-ONLY — ${e.inLoopGate.reason}`,
+    );
     if (e.failure) lines.push(`- driver-reported failure: ${e.failure}`);
     if (e.turns !== undefined && e.turns > e.budget.maxTurns) {
       // The 81-vs-80 confusion: the driver's reported count can exceed the

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -13,6 +13,7 @@ import type { RemediateTask } from './tasks';
 import type { DispatchOverrides } from './dispatch';
 import type { HingeEvidence, HingeScores } from './score-hinge';
 import type { RemediateConfig } from './config';
+import type { InLoopGateStatus } from './agent-trust';
 
 export type RemediateOutcome =
   | 'verified' // diff produced, floor net-new-clean, guardrail PASSED — ready to land
@@ -57,6 +58,16 @@ export interface AgentEnvelope {
   };
   /** Caps the driver cannot enforce — disclosed, never silent. */
   readonly unenforceableCaps: readonly string[];
+  /**
+   * Was the in-loop Stop-gate actually WIRED for this run (#305)?
+   * `in-loop-gated` = the committed Stop hook verifiably loads (settings +
+   * trusted workspace + resolvable hook command), so stop attempts re-run
+   * the guardrail inside the session; `backstop-only` = it cannot load
+   * (reason named) and only post-run frame verification gates. REQUIRED so
+   * a run without the in-loop gate can never read identically to one with
+   * it. Decided by the ONE prober (`agent-trust.ts:armInLoopGate`).
+   */
+  readonly inLoopGate: InLoopGateStatus;
 }
 
 export interface RemediateResult {
@@ -128,6 +139,9 @@ export interface RemediateRunOptions {
   readonly git?: RemediateGit;
   readonly runFloor?: () => CorrectnessFloorResult;
   readonly runGuardrail?: () => Promise<GuardrailGateResult>;
+  /** Injected for tests: replaces the in-loop gate pre-trust + wiring probe
+   *  (`agent-trust.ts:armInLoopGate`). */
+  readonly armInLoopGate?: () => InLoopGateStatus;
   /** Injected for tests: replaces the health-score probe behind a task's
    *  score hinge. */
   readonly hingeScores?: (hinge: NonNullable<RemediateTask['scoreHinge']>) => Promise<HingeScores>;

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -33,6 +33,7 @@ import type { RemediateTask } from './tasks';
 import { resolveDispatchedTask } from './dispatch';
 import { resumePromptNote } from './resume';
 import { realGit } from './git-ops';
+import { armInLoopGate, type InLoopGateStatus } from './agent-trust';
 import { evaluateScoreHinge, healthHingeScores } from './score-hinge';
 import { salvageForTask } from './config';
 import type { AgentEnvelope, RemediateResult, RemediateRunOptions } from './outcome';
@@ -138,6 +139,23 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     ? 'api-key'
     : 'subscription';
 
+  // The in-loop gate (#305): pre-trust the lane's own CI checkout so the
+  // committed Stop hook can actually LOAD (an untrusted workspace made the
+  // in-loop gate silently absent on every CI lane run ever), then probe the
+  // wiring and disclose the result — armed vs backstop-only, with the
+  // reason, in the envelope. Drivers without an in-loop mechanism are
+  // honestly backstop-only. Injectable for tests (the runFloor seam pattern).
+  const armGate =
+    opts.armInLoopGate ??
+    ((): InLoopGateStatus =>
+      driver.inLoopGateMechanism === 'claude-stop-hook'
+        ? armInLoopGate(opts.cwd, { ci: process.env.GITHUB_ACTIONS === 'true' })
+        : {
+            mode: 'backstop-only',
+            reason: `driver ${driver.id} has no in-loop gate mechanism; post-run verification is the gate`,
+          });
+  const inLoopGate = armGate();
+
   const envelopeBase = {
     driver: driver.id,
     model: choice.native,
@@ -146,6 +164,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     auth,
     budget,
     unenforceableCaps,
+    inLoopGate,
   };
 
   const git = opts.git ?? realGit(opts.cwd);

--- a/test/remediate/agent-trust.test.ts
+++ b/test/remediate/agent-trust.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+import {
+  armInLoopGate,
+  checkoutTrusted,
+  preTrustAgentCheckout,
+  probeStopGateWiring,
+} from '../../src/remediate/agent-trust';
+
+/**
+ * #305 — the in-loop Stop-gate wiring. The class under test: the driver
+ * armed DXKIT_LOOP_ACTIVE while the CI checkout was an untrusted
+ * workspace, so the committed Stop hook never loaded and the in-loop
+ * gate was silently absent on every lane run ever. These tests pin the
+ * three duties: the pre-trust write (merge-preserving, CI-gated), the
+ * positive-evidence probe (armed only when every verifiable link holds),
+ * and the disclosure (backstop-only always carries the first missing
+ * link as its reason).
+ */
+
+let home: string;
+let checkout: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'dxkit-agent-home-'));
+  checkout = mkdtempSync(join(tmpdir(), 'dxkit-agent-checkout-'));
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  rmSync(checkout, { recursive: true, force: true });
+});
+
+function writeStopHook(cmd = 'npx vyuh-dxkit hook stop-gate'): void {
+  mkdirSync(join(checkout, '.claude'), { recursive: true });
+  writeFileSync(
+    join(checkout, '.claude', 'settings.json'),
+    JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: 'command', command: cmd }] }] } }),
+  );
+}
+
+function installLocalCli(): void {
+  // resolveDxkitCli probes the project-local .bin shim first.
+  const bin = join(checkout, 'node_modules', '.bin');
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(join(bin, 'vyuh-dxkit'), '#!/bin/sh\n', { mode: 0o755 });
+}
+
+describe('preTrustAgentCheckout', () => {
+  it('creates ~/.claude.json with the project trusted', () => {
+    const res = preTrustAgentCheckout(checkout, { home });
+    expect(res.applied).toBe(true);
+    expect(checkoutTrusted(checkout, { home })).toBe(true);
+  });
+
+  it('merges into an existing config without clobbering other keys or projects', () => {
+    writeFileSync(
+      join(home, '.claude.json'),
+      JSON.stringify({
+        theme: 'dark',
+        projects: { '/other/repo': { hasTrustDialogAccepted: true, allowedTools: ['x'] } },
+      }),
+    );
+    preTrustAgentCheckout(checkout, { home });
+    const doc = JSON.parse(readFileSync(join(home, '.claude.json'), 'utf8'));
+    expect(doc.theme).toBe('dark');
+    expect(doc.projects['/other/repo']).toEqual({
+      hasTrustDialogAccepted: true,
+      allowedTools: ['x'],
+    });
+    expect(doc.projects[resolve(checkout)].hasTrustDialogAccepted).toBe(true);
+  });
+
+  it('reports (never throws) when the home config is unwritable', () => {
+    const res = preTrustAgentCheckout(checkout, { home: join(home, 'missing', 'nested') });
+    expect(res.applied).toBe(false);
+    expect(res.reason).toBeTruthy();
+  });
+});
+
+describe('probeStopGateWiring — positive evidence only', () => {
+  it('no Stop hook in the checkout → backstop-only naming the missing link', () => {
+    const status = probeStopGateWiring(checkout, { home });
+    expect(status.mode).toBe('backstop-only');
+    expect(status.reason).toContain('no Stop hook');
+  });
+
+  it('hook present but the workspace untrusted → backstop-only (THE #305 shape)', () => {
+    writeStopHook();
+    const status = probeStopGateWiring(checkout, { home });
+    expect(status.mode).toBe('backstop-only');
+    expect(status.reason).toContain('not a trusted workspace');
+  });
+
+  it('hook + trust but vyuh-dxkit does not resolve → backstop-only (the 404 class)', () => {
+    writeStopHook();
+    preTrustAgentCheckout(checkout, { home });
+    // Injected resolver: a dev machine's global install must not leak in.
+    const status = probeStopGateWiring(checkout, { home, cliResolves: () => false });
+    expect(status.mode).toBe('backstop-only');
+    expect(status.reason).toContain('does not resolve');
+  });
+
+  it('every link verified → in-loop-gated, with the max_turns limit still named', () => {
+    writeStopHook();
+    preTrustAgentCheckout(checkout, { home });
+    installLocalCli();
+    const status = probeStopGateWiring(checkout, { home, cliResolves: () => true });
+    expect(status.mode).toBe('in-loop-gated');
+    expect(status.reason).toContain('max_turns');
+  });
+
+  it('a non-dxkit hook command with settings + trust counts as armed (dxkit does not invent refusals for commands it does not own)', () => {
+    writeStopHook('node scripts/my-own-stop-gate.js');
+    preTrustAgentCheckout(checkout, { home });
+    const status = probeStopGateWiring(checkout, { home });
+    expect(status.mode).toBe('in-loop-gated');
+  });
+});
+
+describe('armInLoopGate — the lane entry point', () => {
+  it('CI: pre-trusts the checkout, then probes (the untrusted link closes)', () => {
+    writeStopHook();
+    installLocalCli();
+    const status = armInLoopGate(checkout, { home, ci: true });
+    expect(status.mode).toBe('in-loop-gated');
+    expect(checkoutTrusted(checkout, { home })).toBe(true);
+  });
+
+  it('non-CI: never touches the home config — a local ~/.claude.json is the maintainer’s', () => {
+    writeStopHook();
+    installLocalCli();
+    const status = armInLoopGate(checkout, { home, ci: false });
+    expect(status.mode).toBe('backstop-only');
+    expect(checkoutTrusted(checkout, { home })).toBe(false);
+  });
+});

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -396,11 +396,18 @@ describe('ledger: the failure ledger is complete without leaking evidence', () =
         costUsd: 0,
         budget: { maxTurns: 80, maxMinutes: 30, maxUsd: 5 },
         unenforceableCaps: [],
+        inLoopGate: {
+          mode: 'backstop-only',
+          reason: 'the checkout is not a trusted workspace, so the Stop hook never loads',
+        },
       },
     });
     expect(ledger).toContain('outcome: **agent-failed**');
     expect(ledger).toContain('Credit balance is too low');
     expect(ledger).toContain('agent CLI 2.1.222');
     expect(ledger).toContain('api-key (billed API spend)');
+    // #305: a run without the in-loop gate must say so in the ledger.
+    expect(ledger).toContain('in-loop gate: BACKSTOP-ONLY');
+    expect(ledger).toContain('not a trusted workspace');
   });
 });

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -217,8 +217,26 @@ describe('the verified frame (the agent is never trusted)', () => {
       turns: 12,
       costUsd: 0.8,
     });
+    // #305: the envelope always answers whether the in-loop gate was wired.
+    // The fake driver declares no mechanism → honestly backstop-only, and
+    // the ledger says so.
+    expect(r.envelope?.inLoopGate.mode).toBe('backstop-only');
+    expect(r.envelope?.inLoopGate.reason).toContain('no in-loop gate mechanism');
+    expect(r.ledger).toContain('in-loop gate: BACKSTOP-ONLY');
     expect(r.ledger).toContain('never');
     expect(r.ledger).toContain('trusted');
+  });
+
+  it('#305: an injected in-loop-gate probe reaches the envelope and the ledger', async () => {
+    const r = await runRemediateTask({
+      ...base(fakeDriver({ turns: 3 })),
+      armInLoopGate: () => ({
+        mode: 'in-loop-gated' as const,
+        reason: 'Stop hook declared, workspace trusted, command resolves',
+      }),
+    });
+    expect(r.envelope?.inLoopGate.mode).toBe('in-loop-gated');
+    expect(r.ledger).toContain('in-loop gate: ARMED');
   });
 
   it('no-op: an agent run with no committed change opens nothing', async () => {


### PR DESCRIPTION
Into `release/4.4.1`. Closes #305 — the root cause of the lane's burn-budget-then-red shape.

## What

The driver armed `DXKIT_LOOP_ACTIVE=1` but the CI checkout was an **untrusted workspace**, so the committed Stop hook never loaded — the in-loop gate has been silently absent on every CI lane run ever, and only post-run frame verification gated. One module (`src/remediate/agent-trust.ts`) now owns the three duties:

1. **Pre-trust** (CI runs only): the lane marks its own checkout trusted in the runner's `~/.claude.json` before spawning — merge-preserving, never a maintainer's local config. Deliberate Rule-17 doctrine: the lane checks out the maintainers' own default branch, the same tree whose npm scripts and workflows CI already executes. Fork/PR trees unaffected (the lane never executes them).
2. **Wiring probe** (positive evidence, pre-spawn): committed settings declare a Stop hook + the workspace reads as trusted + the standard dxkit hook command resolves. Armed only when every verifiable link holds; the first missing link is the reason. A custom hook command with settings + trust counts as armed — no invented refusals for commands dxkit does not own.
3. **Disclosure**: `AgentEnvelope` gains **required** `inLoopGate` (`in-loop-gated` / `backstop-only` + reason), rendered in the ledger — a run without the in-loop gate never reads identically to one with it. `AgentDriver` declares its mechanism (`inLoopGateMechanism`; claude-code = `'claude-stop-hook'`); mechanism-less drivers are honestly backstop-only.

The `max_turns` structural limit is named in the probe reason and the remediate docs: a turn-cap kill never reaches a stop attempt; the post-run frame remains the final word.

## Verification

Suite 5597/5597 (exit unmasked), all static gates clean, self-guardrail PASSED exit 0. New pins: trust write/merge preserving other projects, all four probe outcomes including the exact #305 shape, the 404 class with an injected resolver, CI vs non-CI gating, envelope + ledger disclosure at the runner level.

**Live acceptance** (post-release, per the release plan): a fix-build dispatch on the canary repo whose envelope shows `in-loop gate: ARMED` and which lands green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)