### PR TITLE
fix(landers): clean PR-mode commits + the one lane PR-body assembler (4.4.1 WP4)

### DIFF
--- a/src/deps-bump/run.ts
+++ b/src/deps-bump/run.ts
@@ -24,6 +24,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
+import { assembleLanePrBody } from '../pr/assemble';
 import type { AnalysisTrustContext } from '../analysis-trust';
 import type { DepVulnFinding } from '../languages/capabilities/types';
 import { gatherDepVulns } from '../analyzers/security/gather';
@@ -377,15 +378,21 @@ export async function runDepsBump(opts: DepsBumpOptions): Promise<DepsBumpResult
     outcome: 'landed',
     findingsClosed: [{ kind: 'dep-vuln', count: advisoriesClosed }],
   });
+  const defaultBranch = detectDefaultBranch(cwd);
   const land = (opts.landPaths ?? landRefreshPaths)({
     cwd,
     mode: 'pr',
     paths: [...bumpArtifactPaths(pm), ledgerRel],
     branchName: DEP_BUMP_BRANCH,
-    defaultBranch: detectDefaultBranch(cwd),
+    defaultBranch,
     commitTitle: 'chore(deps): security bumps (dxkit)',
     prTitle: 'dxkit: dependency security bumps',
-    prBody: renderLedger(partial),
+    // The ONE lane PR-body assembler (#288): labeled generated narrative on
+    // top, the ledger verbatim below. The bump changes are UNCOMMITTED at
+    // assembly time (the lander commits them), so today this renders
+    // ledger-only via the fail-open path — the wiring keeps both landers on
+    // the one assembler, and the ledger already itemizes every bump.
+    prBody: assembleLanePrBody({ cwd, ledger: renderLedger(partial), base: defaultBranch }),
   });
   return finish({
     ...partial,

--- a/src/land-refresh.ts
+++ b/src/land-refresh.ts
@@ -54,10 +54,22 @@ export interface LandRefreshOptions {
   /** The standing refresh branch (`dxkit/<surface>-refresh`). */
   readonly branchName: string;
   readonly defaultBranch: string;
-  /** Commit subject; `[skip ci]` is appended by this module. */
+  /** Commit subject; push mode appends `[skip ci]` (a direct artifact
+   *  refresh on the default branch should not churn CI). */
   readonly commitTitle: string;
   readonly prTitle: string;
   readonly prBody: string;
+  /**
+   * Stamp `[skip ci]` on the PR-mode head commit too (#304). Default FALSE:
+   * GitHub honors the marker for `pull_request` workflows, so a stamped
+   * standing PR can never run a single check — a code-carrying lane PR then
+   * presents with zero CI, silently defeats the DXKIT_BOT_TOKEN's stated
+   * purpose, and under required checks is permanently unmergeable (the
+   * PR-mode sibling of the push-mode deadlock enforcement.ts documents).
+   * Only an artifact-only refresh PR that deliberately wants silent updates
+   * opts in — per consumer, never as the shared default.
+   */
+  readonly prSkipCi?: boolean;
   /**
    * Substance check, run only when git sees a byte diff: return false to
    * REVERT the paths and land nothing (a timestamp-only refresh must not
@@ -125,7 +137,9 @@ export function landRefreshPaths(opts: LandRefreshOptions): LandRefreshResult {
   // human stranded on the bot branch.
   const priorRef = exec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { allowFail: true }).trim();
   exec('git', ['checkout', '-B', opts.branchName]);
-  commit(`${opts.prTitle}\n\n[skip ci]`);
+  // Clean head commit by default (#304): the PR is the review vehicle, and a
+  // PR that runs no checks is not reviewable in any meaningful sense.
+  commit(opts.prSkipCi ? `${opts.prTitle}\n\n[skip ci]` : opts.prTitle);
   // Internal machine push → `--no-verify` (gh #156), same reason as the push mode.
   exec('git', internalGitPushArgs(opts.branchName, { force: true }));
   if (priorRef && priorRef !== 'HEAD' && priorRef !== opts.branchName) {

--- a/src/pr/assemble.ts
+++ b/src/pr/assemble.ts
@@ -1,0 +1,105 @@
+/**
+ * The ONE lane PR-body assembler (#288, 4.4.1 WP4).
+ *
+ * A lane-landed PR's body was the verification ledger alone: strong on
+ * proof, silent on content — a reviewer of a several-thousand-line draft
+ * had to read the raw diff to learn what was written, while the human
+ * flow already had `vyuh-dxkit pr` computing exactly that narrative.
+ * Two PR-composition paths, no shared code: the Rule-2.30 setup.
+ *
+ * This module composes both landers' bodies from the SAME canonical
+ * pieces the human `pr` flow uses (`./commits`: parseCommits +
+ * bucketCommits — never a second commit parser):
+ *
+ *   - a diff-scoped NARRATIVE rides on top, clearly labeled as generated
+ *     prose about the change (regenerated each time a lander rebuilds
+ *     the standing PR, so a reviewer sees what moved since their last
+ *     look);
+ *   - the lane's LEDGER follows VERBATIM, uncut — the prompt disclosure,
+ *     budget/salvage rationale, and verification claims are contractual
+ *     and never paraphrased.
+ *
+ * Fail-open: no commits in range, git unavailable, anything throws → the
+ * body is the ledger alone, byte-identical to the pre-#288 output. The
+ * narrative is additive, never a gate.
+ */
+
+import { execFileSync } from 'child_process';
+import { bucketCommits, parseCommits } from './commits';
+
+export interface LaneBodyOptions {
+  readonly cwd: string;
+  /** The verbatim verification ledger — the contractual section. */
+  readonly ledger: string;
+  /** The PR's target branch; the narrative describes `base..HEAD`. */
+  readonly base: string;
+  /** Injectable for tests: replaces the git-derived narrative. Return
+   *  null to exercise the ledger-only path. */
+  readonly narrative?: (cwd: string, base: string) => string | null;
+}
+
+/** The label the narrative section always carries — a reviewer must never
+ *  mistake generated prose for the lane's contractual claims. */
+const NARRATIVE_HEADER = '## What changed (generated)';
+
+export function assembleLanePrBody(opts: LaneBodyOptions): string {
+  let narrative: string | null = null;
+  try {
+    narrative = (opts.narrative ?? buildLaneNarrative)(opts.cwd, opts.base);
+  } catch {
+    narrative = null; // additive, never a gate
+  }
+  if (!narrative || narrative.trim() === '') return opts.ledger;
+  return [
+    NARRATIVE_HEADER,
+    '',
+    '_Diff-scoped summary computed by dxkit from the branch commits and files.',
+    'The verification ledger below is the contractual record._',
+    '',
+    narrative.trim(),
+    '',
+    '---',
+    '',
+    opts.ledger,
+  ].join('\n');
+}
+
+/** The default narrative: the `pr` pipeline's commit buckets over
+ *  `base..HEAD` plus a one-line files summary. Null when the range is
+ *  empty or unreadable. */
+export function buildLaneNarrative(cwd: string, base: string): string | null {
+  const subjects = gitLines(cwd, ['log', '--format=%s', `${base}..HEAD`]);
+  if (subjects === null || subjects.length === 0) return null;
+  const files = gitLines(cwd, ['diff', '--name-only', `${base}...HEAD`]) ?? [];
+
+  const lines: string[] = [];
+  for (const bucket of bucketCommits(parseCommits(subjects))) {
+    lines.push(`**${bucket.label}**`);
+    for (const c of bucket.commits) lines.push(`- ${c.subject}`);
+    lines.push('');
+  }
+  if (files.length > 0) {
+    const dirs = new Set(files.map((f) => f.split('/')[0]));
+    lines.push(
+      `_${files.length} file${files.length === 1 ? '' : 's'} touched across ` +
+        `${dirs.size} top-level area${dirs.size === 1 ? '' : 's'}._`,
+    );
+  }
+  return lines.join('\n');
+}
+
+function gitLines(cwd: string, args: readonly string[]): string[] | null {
+  try {
+    return execFileSync('git', [...args], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      maxBuffer: 64 * 1024 * 1024,
+    })
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } catch {
+    return null;
+  }
+}

--- a/src/remediate/execute.ts
+++ b/src/remediate/execute.ts
@@ -13,6 +13,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
+import { assembleLanePrBody } from '../pr/assemble';
 import * as logger from '../logger';
 import { trustedLocalContext } from '../analysis-trust';
 import { detectDefaultBranch } from '../ship-installers';
@@ -252,7 +253,17 @@ export async function executeTask(
           : draftSalvage
             ? ' (partial, budget-bounded)'
             : ''),
-      prBody: result.ledger,
+      // The ONE lane PR-body assembler (#288): a generated, labeled
+      // diff-scoped narrative on top; the ledger VERBATIM below (the
+      // contractual record, never paraphrased). Fail-open to ledger-only.
+      // The narrative range is the ATTEMPT's own commits (baseHead..HEAD) —
+      // the lane advances the checked-out default branch, so a
+      // defaultBranch..HEAD range would be empty by construction.
+      prBody: assembleLanePrBody({
+        cwd,
+        ledger: result.ledger,
+        base: result.baseHead ?? defaultBranch,
+      }),
       draft: draftSalvage || blockedSalvage,
       ledgerPath,
     });

--- a/test/land-refresh-skip-ci.test.ts
+++ b/test/land-refresh-skip-ci.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { landRefreshPaths, type Exec } from '../src/land-refresh';
+
+/**
+ * #304 — the [skip ci] stamp is push-mode ONLY. GitHub honors the marker
+ * on a PR head commit for `pull_request` workflows, so a stamped standing
+ * PR could never run a single check: a code-carrying lane PR presented
+ * with zero CI, silently defeated DXKIT_BOT_TOKEN's stated purpose, and
+ * under required checks was permanently unmergeable. PR-mode commits are
+ * clean by default; an artifact-only refresh PR opts in per consumer.
+ */
+
+function recordingExec(): { exec: Exec; commands: string[][] } {
+  const commands: string[][] = [];
+  const exec: Exec = (bin, args) => {
+    commands.push([bin, ...args]);
+    if (bin === 'git' && args[0] === 'status') return ' M some/file\n';
+    if (bin === 'git' && args[0] === 'rev-parse') return 'main';
+    if (bin === 'gh' && args[0] === 'pr' && args[1] === 'list') return '[]';
+    if (bin === 'gh' && args[0] === 'pr' && args[1] === 'create') return 'https://example/pr/1';
+    return '';
+  };
+  return { exec, commands };
+}
+
+function commitMessageFrom(commands: string[][]): string {
+  const commit = commands.find((c) => c[0] === 'git' && c.includes('commit'));
+  expect(commit, 'a commit must have been issued').toBeDefined();
+  return commit![commit!.indexOf('-m') + 1];
+}
+
+const baseOpts = {
+  cwd: '/fake',
+  paths: ['some/file'],
+  branchName: 'dxkit/test-refresh',
+  defaultBranch: 'main',
+  commitTitle: 'chore: refresh',
+  prTitle: 'dxkit: refresh',
+  prBody: 'body',
+};
+
+describe('landRefreshPaths — the [skip ci] boundary (#304)', () => {
+  it('push mode keeps the [skip ci] stamp (a default-branch artifact refresh must not churn CI)', () => {
+    const { exec, commands } = recordingExec();
+    landRefreshPaths({ ...baseOpts, mode: 'push', exec });
+    expect(commitMessageFrom(commands)).toBe('chore: refresh [skip ci]');
+  });
+
+  it('PR mode commits CLEAN by default — the standing PR must be able to run checks', () => {
+    const { exec, commands } = recordingExec();
+    landRefreshPaths({ ...baseOpts, mode: 'pr', exec });
+    const message = commitMessageFrom(commands);
+    expect(message).toBe('dxkit: refresh');
+    expect(message).not.toContain('[skip ci]');
+  });
+
+  it('an artifact-only consumer can opt back in, explicitly', () => {
+    const { exec, commands } = recordingExec();
+    landRefreshPaths({ ...baseOpts, mode: 'pr', prSkipCi: true, exec });
+    expect(commitMessageFrom(commands)).toContain('[skip ci]');
+  });
+});

--- a/test/pr-assemble.test.ts
+++ b/test/pr-assemble.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { assembleLanePrBody, buildLaneNarrative } from '../src/pr/assemble';
+
+/**
+ * #288 — the ONE lane PR-body assembler. The contract under test: the
+ * ledger section is BYTE-IDENTICAL to the input (contractual, never
+ * paraphrased), the narrative is labeled as generated, and every failure
+ * of the narrative path yields the ledger alone — additive, never a gate.
+ */
+
+const LEDGER = '## dxkit remediation ledger\n\n- floor: passed\n- guardrail: PASSED\n';
+
+let repo: string;
+let baseSha: string;
+
+function git(args: string[]): string {
+  return execFileSync('git', args, { cwd: repo, encoding: 'utf8' }).trim();
+}
+
+beforeAll(() => {
+  repo = mkdtempSync(join(tmpdir(), 'dxkit-assemble-'));
+  git(['init', '-q', '-b', 'main']);
+  git(['config', 'user.email', 't@e.c']);
+  git(['config', 'user.name', 't']);
+  writeFileSync(join(repo, 'a.txt'), 'base\n');
+  git(['add', '.']);
+  git(['commit', '-qm', 'base']);
+  baseSha = git(['rev-parse', 'HEAD']);
+  writeFileSync(join(repo, 'src.js'), 'fixed\n');
+  git(['add', '.']);
+  git(['commit', '-qm', 'fix(build): declare the missing dependency']);
+  writeFileSync(join(repo, 'dead.js'), '');
+  git(['add', '.']);
+  git(['commit', '-qm', 'chore: remove the dead consumer']);
+});
+afterAll(() => rmSync(repo, { recursive: true, force: true }));
+
+describe('assembleLanePrBody', () => {
+  it('composes: labeled generated narrative on top, the ledger VERBATIM below', () => {
+    const body = assembleLanePrBody({ cwd: repo, ledger: LEDGER, base: baseSha });
+    expect(body).toContain('## What changed (generated)');
+    expect(body).toContain('declare the missing dependency');
+    expect(body).toContain('remove the dead consumer');
+    // The contractual section: byte-identical, at the end.
+    expect(body.endsWith(LEDGER)).toBe(true);
+  });
+
+  it('an empty commit range yields the ledger alone, byte-identical', () => {
+    const head = git(['rev-parse', 'HEAD']);
+    expect(assembleLanePrBody({ cwd: repo, ledger: LEDGER, base: head })).toBe(LEDGER);
+  });
+
+  it('a throwing narrative yields the ledger alone (additive, never a gate)', () => {
+    const body = assembleLanePrBody({
+      cwd: repo,
+      ledger: LEDGER,
+      base: baseSha,
+      narrative: () => {
+        throw new Error('describe unavailable');
+      },
+    });
+    expect(body).toBe(LEDGER);
+  });
+
+  it('outside a git repo the body is the ledger alone', () => {
+    const plain = mkdtempSync(join(tmpdir(), 'dxkit-assemble-nogit-'));
+    try {
+      expect(assembleLanePrBody({ cwd: plain, ledger: LEDGER, base: 'main' })).toBe(LEDGER);
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('buildLaneNarrative — composed from the pr pipeline pieces', () => {
+  it('buckets the range commits through the ONE conventional-commit parser', () => {
+    const narrative = buildLaneNarrative(repo, baseSha)!;
+    // bucketCommits ordering: fixes and chores land under their buckets.
+    expect(narrative).toContain('declare the missing dependency');
+    expect(narrative).toContain('remove the dead consumer');
+    expect(narrative).toMatch(/files? touched across/);
+  });
+});


### PR DESCRIPTION
Into `release/4.4.1`. Closes #304 and #288.

## #304 — `[skip ci]` is push-mode only

The shared refresh lander stamped the marker on both modes. PR-mode commits are now **clean by default** — a standing PR must be able to run checks (it presented with zero CI, defeated `DXKIT_BOT_TOKEN`'s stated purpose, and under required checks was permanently unmergeable; observed live). An artifact-only refresh PR can opt back in per consumer (`prSkipCi`); no consumer does today.

## #288 — one lane PR-body assembler

`src/pr/assemble.ts` composes both landers' bodies from the same canonical pieces the human `pr` flow uses (`parseCommits` + `bucketCommits`): a **labeled generated narrative** on top (regenerated per standing-PR rebuild), the **ledger verbatim** below (contractual, never paraphrased), fail-open to ledger-only byte-identical output. Remediate ranges over the attempt's own `baseHead..HEAD`; dep-bump routes through the same assembler (ledger-only today via fail-open — its changes are uncommitted at assembly time and its ledger itemizes every bump).

## Verification

Suite 5594/5594 (unmasked), all static gates clean, self-guardrail PASSED exit 0. New pins: the [skip ci] boundary in all three directions via the injectable exec; the assembler contract (byte-identical ledger, labeled narrative, three fail-open paths, pr-pipeline reuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)