### PR TITLE
feat(lanes): delivery-preconditions prober — $0 preflight, doctor, plan (4.4.1 WP5)

### DIFF
--- a/src/deps-bump/run.ts
+++ b/src/deps-bump/run.ts
@@ -47,7 +47,11 @@ import { guardrailVerdictFor, toFloorBaseChecks } from '../lanes/verify';
 import { landRefreshPaths, type LandRefreshResult } from '../land-refresh';
 import { detectDefaultBranch } from '../ship-installers';
 
-export const DEP_BUMP_BRANCH = 'dxkit/dep-bump';
+// The standing-branch name lives in the ONE leaf home the delivery
+// prober also reads (`lanes/branches.ts`); re-exported for consumers.
+export { DEP_BUMP_BRANCH } from '../lanes/branches';
+import { DEP_BUMP_BRANCH } from '../lanes/branches';
+import { describeDeliveryProbe, probeDeliveryPreconditions } from '../lanes/delivery-preconditions';
 
 export interface AppliedBump extends PlannedBump {
   readonly applied: boolean;
@@ -107,6 +111,8 @@ export interface DepsBumpOptions {
   readonly landPaths?: typeof landRefreshPaths;
   /** Injected for tests: the findings source. */
   readonly gather?: (cwd: string) => Promise<{ findings: readonly DepVulnFinding[] }>;
+  /** Injected for tests: the $0 landing preflight (#286). */
+  readonly probeDelivery?: typeof probeDeliveryPreconditions;
 }
 
 /** package.json section a direct dependency lives in ('dependencies' when
@@ -257,6 +263,28 @@ export async function runDepsBump(opts: DepsBumpOptions): Promise<DepsBumpResult
       applied: [],
       note: 'refused: no package.json at the repo root — the apply lane is node-first.',
     });
+  }
+
+  // The $0 landing preflight (#286): when this run intends to LAND, probe
+  // the standing branch's delivery preconditions BEFORE applying anything —
+  // a branch-creation ruleset that will 403 the push is knowable from one
+  // API read. Only POSITIVE refusal evidence refuses; an unanswerable probe
+  // proceeds (the preflight never invents a refusal).
+  if (opts.land === 'pr') {
+    const preflight = (opts.probeDelivery ?? probeDeliveryPreconditions)(cwd, {
+      branches: [DEP_BUMP_BRANCH],
+    });
+    const blocked = preflight.probes.find((p) => p.verdict === 'blocked');
+    if (blocked) {
+      return finish({
+        outcome: 'refused',
+        plan,
+        applied: [],
+        note:
+          `landing-unavailable (preflight, $0 — nothing was applied): ` +
+          `${describeDeliveryProbe(blocked)}`,
+      });
+    }
   }
 
   const pm = detectPackageManager(cwd);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -22,6 +22,7 @@ import { EXTERNAL_SNAPSHOT_STALE_DAYS, snapshotAgeDays } from './ingest/engine-f
 import { diagnoseFlow, type FlowDiagnosis } from './analyzers/flow/diagnose';
 import { gatherRecommendations, type CommandRecommendation } from './discovery/commands';
 import { trustedLocalContext } from './analysis-trust';
+import { probeDeliveryPreconditions } from './lanes/delivery-preconditions';
 
 /**
  * Three-tier doctor:
@@ -1034,6 +1035,28 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
           skill: 'dxkit-fix',
         },
       });
+    }
+
+    // 6f. Lane DELIVERY preconditions (#287): a branch-creation ruleset whose
+    // exclusion misses the lanes' standing-branch pattern makes every landing
+    // 403 AFTER the full agent budget is spent — knowable from three API
+    // reads at setup time. The ONE prober; the lanes' $0 preflight (#286)
+    // consumes the same module. Fail-open: an unanswerable probe stays
+    // silent here — doctor never invents a refusal.
+    if (prLaneInstalled) {
+      const delivery = probeDeliveryPreconditions(cwd);
+      for (const p of delivery.probes.filter((p) => p.verdict === 'blocked')) {
+        checks.push({
+          label: `lanes cannot deliver here — branch creation is blocked for ${p.branch}`,
+          ok: false,
+          tier: 'operational',
+          fix: {
+            hint: `${p.evidence}. ${p.remedy ?? ''} Every lane run on this repo will spend its full agent budget and then fail to land until this is fixed.`,
+            command: 'gh api repos/{owner}/{repo}/rulesets',
+            skill: 'dxkit-fix',
+          },
+        });
+      }
     }
   }
 

--- a/src/lanes/branches.ts
+++ b/src/lanes/branches.ts
@@ -1,0 +1,15 @@
+/**
+ * The lanes' standing-branch NAMES — one home (Rule 2), imported by the
+ * landers that push them AND the delivery-preconditions prober that
+ * probes them (#286/#287), so the probed set can never drift from the
+ * pushed set. Leaf module by design: nothing here may import from the
+ * lanes, or the prober's imports cycle.
+ */
+
+/** The dep-bump lane's one standing branch. */
+export const DEP_BUMP_BRANCH = 'dxkit/dep-bump';
+
+/** The remediate lane's standing branch for a task. */
+export function remediateBranchFor(taskId: string): string {
+  return `dxkit/remediate-${taskId}`;
+}

--- a/src/lanes/delivery-preconditions.ts
+++ b/src/lanes/delivery-preconditions.ts
@@ -1,0 +1,189 @@
+/**
+ * The ONE delivery-preconditions prober (#286 / #287, 4.4.1 WP5).
+ *
+ * A repo's org configuration can make lane DELIVERY structurally
+ * impossible while every agent-side step works: a branch-creation
+ * ruleset whose exclusion covers `dxkit-**` (the hyphen artifact
+ * branches) but not `dxkit/**` (the lanes' standing branches) 403s
+ * every landing — observed live, where each of two stacked blockers
+ * cost a full paid agent run plus an autopsy, though both were knowable
+ * from three API reads before any agent existed.
+ *
+ * One module probes; many consumers read (Rule 2):
+ *   - the LANE PREFLIGHT (remediate + dep-bump, land=pr): a
+ *     refusal-shaped answer becomes a disclosed refusal BEFORE any
+ *     spend, naming the ruleset and the remedy — Rule 20's
+ *     skipped-environment discipline applied to the deliver layer;
+ *   - `doctor`: a red "lanes cannot deliver here" finding at
+ *     onboarding, day one;
+ *   - `remediate plan` / `deps bump` plan surfaces: a per-branch
+ *     delivery line.
+ *
+ * Fail-open discipline throughout: an unanswerable probe (no gh, API
+ * error, insufficient scope) is `unknown` — disclosed as "could not
+ * verify", and the caller PROCEEDS. The preflight must never invent a
+ * refusal; only positive refusal evidence (an active `creation` rule on
+ * a branch the lane must create) blocks before spend.
+ */
+
+import { execFileSync } from 'child_process';
+import { DEP_BUMP_BRANCH, remediateBranchFor } from './branches';
+import { REMEDIATE_TASKS } from '../remediate/tasks';
+
+export type DeliveryVerdict = 'ok' | 'blocked' | 'restricted-paths' | 'unknown';
+
+export interface BranchDeliveryProbe {
+  readonly branch: string;
+  readonly verdict: DeliveryVerdict;
+  /** What the API said (rule types), or why the probe could not answer. */
+  readonly evidence: string;
+  /** Present on a refusal: the concrete config change that unblocks. */
+  readonly remedy?: string;
+}
+
+export interface DeliveryPreconditions {
+  readonly probes: readonly BranchDeliveryProbe[];
+  /** True iff at least one standing branch has POSITIVE refusal evidence. */
+  readonly anyBlocked: boolean;
+  /** True iff nothing could be verified at all (no gh / API unreachable). */
+  readonly unverifiable: boolean;
+}
+
+/** The standing branch names the lanes deliver on — derived from the same
+ *  canonical constants the landers use, never a second list. */
+export function standingLaneBranches(): string[] {
+  return [...REMEDIATE_TASKS.map((t) => remediateBranchFor(t.id)), DEP_BUMP_BRANCH];
+}
+
+export type ApiProbe = (path: string) => string | null;
+
+/** Real probe via the gh CLI (the ambient token). Null = unanswerable. */
+export function makeGhApiProbe(cwd: string): ApiProbe {
+  return (apiPath) => {
+    try {
+      return execFileSync('gh', ['api', apiPath], {
+        cwd,
+        encoding: 'utf8',
+        timeout: 30_000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch {
+      return null;
+    }
+  };
+}
+
+/** `owner/repo` for the checkout, or null (not GitHub / no gh). */
+export function repoSlug(cwd: string): string | null {
+  try {
+    const out = execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner'], {
+      cwd,
+      encoding: 'utf8',
+      timeout: 30_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const slug = (JSON.parse(out) as { nameWithOwner?: string }).nameWithOwner;
+    return typeof slug === 'string' && slug.includes('/') ? slug : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Probe one branch name against the repo's effective rules
+ * (`GET /repos/{slug}/rules/branches/{branch}` — rulesets evaluate by
+ * name pattern, so a branch that does not exist yet still answers).
+ */
+export function probeBranchDelivery(
+  probe: ApiProbe,
+  slug: string,
+  branch: string,
+): BranchDeliveryProbe {
+  const raw = probe(`repos/${slug}/rules/branches/${encodeURIComponent(branch)}`);
+  if (raw === null) {
+    return {
+      branch,
+      verdict: 'unknown',
+      evidence: 'could not verify: the branch-rules API was unreachable with the ambient token',
+    };
+  }
+  let rules: Array<{ type?: string }> = [];
+  try {
+    rules = JSON.parse(raw) as Array<{ type?: string }>;
+  } catch {
+    return { branch, verdict: 'unknown', evidence: 'could not verify: unparseable rules payload' };
+  }
+  const types = rules.map((r) => r.type).filter((t): t is string => typeof t === 'string');
+  // Positive refusal evidence: an active `creation` rule on a branch the
+  // lane must CREATE means the push 403s (the live class). The bypass list
+  // is not visible from this endpoint, so the remedy names both outs.
+  if (types.includes('creation')) {
+    return {
+      branch,
+      verdict: 'blocked',
+      evidence: `an active branch-creation ruleset covers "${branch}" (rules: ${types.join(', ')})`,
+      remedy:
+        `exclude the lane branches from the ruleset (add "refs/heads/dxkit/**" to its ` +
+        `exclusion patterns) or grant the delivering identity a ruleset bypass`,
+    };
+  }
+  if (types.includes('file_path_restriction')) {
+    return {
+      branch,
+      verdict: 'restricted-paths',
+      evidence:
+        `a file-path-restriction rule applies to "${branch}" — a landing touching the ` +
+        `restricted paths will be refused (rules: ${types.join(', ')})`,
+      remedy: 'keep lane tasks away from the restricted paths, or exclude the lane branches',
+    };
+  }
+  return {
+    branch,
+    verdict: 'ok',
+    evidence:
+      types.length > 0
+        ? `rules present, none delivery-blocking: ${types.join(', ')}`
+        : 'no rules apply',
+  };
+}
+
+/** Probe every standing lane branch. `branches` overrides for consumers
+ *  that care about one lane (the dep-bump plan) or for tests. */
+export function probeDeliveryPreconditions(
+  cwd: string,
+  opts: {
+    readonly branches?: readonly string[];
+    readonly probe?: ApiProbe;
+    /** Injectable for tests: the `owner/repo` slug (skips the gh probe). */
+    readonly slug?: string;
+  } = {},
+): DeliveryPreconditions {
+  const branches = opts.branches ?? standingLaneBranches();
+  const slug = opts.slug ?? repoSlug(cwd);
+  if (slug === null) {
+    return {
+      probes: branches.map((branch) => ({
+        branch,
+        verdict: 'unknown' as const,
+        evidence: 'could not verify: not a GitHub repo here, or the gh CLI is unavailable',
+      })),
+      anyBlocked: false,
+      unverifiable: true,
+    };
+  }
+  const probe = opts.probe ?? makeGhApiProbe(cwd);
+  const probes = branches.map((branch) => probeBranchDelivery(probe, slug, branch));
+  return {
+    probes,
+    anyBlocked: probes.some((p) => p.verdict === 'blocked'),
+    unverifiable: probes.every((p) => p.verdict === 'unknown'),
+  };
+}
+
+/** One human line per probe — shared by doctor, the plan surfaces, and the
+ *  preflight disclosure (one phrasing, every consumer). */
+export function describeDeliveryProbe(p: BranchDeliveryProbe): string {
+  const head = `${p.branch}: ${p.verdict === 'ok' ? 'can deliver' : p.verdict.toUpperCase()}`;
+  const remedy = p.remedy ? ` Remedy: ${p.remedy}.` : '';
+  return `${head} — ${p.evidence}.${remedy}`;
+}

--- a/src/remediate/execute.ts
+++ b/src/remediate/execute.ts
@@ -26,6 +26,7 @@ import { driverById } from './registry';
 import { remediateTaskById } from './tasks';
 import { runRemediateTask, type RemediateResult } from './run';
 import { landRemediateHead, remediateBranchFor } from './land';
+import { describeDeliveryProbe, probeDeliveryPreconditions } from '../lanes/delivery-preconditions';
 import { appendLaneEvent, LANE_LEDGER_SCHEMA_VERSION } from '../lanes/ledger';
 
 export interface TaskRun {
@@ -91,6 +92,8 @@ export interface ExecutorSeams {
   readonly landHead?: typeof landRemediateHead;
   readonly branch?: (cwd: string) => string;
   readonly defaultBranch?: (cwd: string) => string;
+  /** Injected for tests: the $0 landing preflight (#286). */
+  readonly probeDelivery?: typeof probeDeliveryPreconditions;
 }
 
 /** Run one task through the runner and (optionally) land it — the ONE
@@ -157,6 +160,32 @@ export async function executeTask(
     }
   }
   const reporter = startPhaseReporter(`remediate:${taskId}`);
+  // The $0 landing preflight (#286): when this run intends to LAND, probe
+  // the standing branch's delivery preconditions BEFORE any agent spawns —
+  // a branch-creation ruleset that will 403 the landing is knowable from
+  // one API read, and the live class spent full agent budgets discovering
+  // it at push time. Only POSITIVE refusal evidence blocks; an
+  // unanswerable probe proceeds (the preflight never invents a refusal).
+  if (land === 'pr') {
+    const preflight = (seams.probeDelivery ?? probeDeliveryPreconditions)(cwd, {
+      branches: [remediateBranchFor(taskId)],
+    });
+    const blocked = preflight.probes.find((p) => p.verdict === 'blocked');
+    if (blocked) {
+      const note =
+        `landing-unavailable (preflight, $0 — no agent was spawned): ` +
+        `${describeDeliveryProbe(blocked)}`;
+      // `task` is omitted: the preflight runs before task-id resolution
+      // narrows the raw string; the note + ledger name it.
+      const refusal: RemediateResult = {
+        outcome: 'refused',
+        note,
+        ledger: `## dxkit remediate: ${taskId}\n\noutcome: **refused**\n\n${note}\n`,
+      };
+      return finalizeTaskRun(cwd, taskId, { result: refusal, landed: false, clean: false });
+    }
+  }
+
   let result: RemediateResult;
   try {
     result = await (seams.runTask ?? runRemediateTask)({

--- a/src/remediate/land.ts
+++ b/src/remediate/land.ts
@@ -20,9 +20,10 @@ import {
 import { internalGitPushArgs } from '../git-internal-push';
 import * as logger from '../logger';
 
-export function remediateBranchFor(taskId: string): string {
-  return `dxkit/remediate-${taskId}`;
-}
+// The standing-branch name lives in the ONE leaf home the delivery
+// prober also reads (`lanes/branches.ts`); re-exported for consumers.
+import { remediateBranchFor } from '../lanes/branches';
+export { remediateBranchFor } from '../lanes/branches';
 
 export interface LandRemediateOptions {
   readonly cwd: string;

--- a/src/remediate/plan-cli.ts
+++ b/src/remediate/plan-cli.ts
@@ -9,6 +9,8 @@ import { budgetForTask, resolveRemediateConfig, tasksWithinSpendCeiling } from '
 import { resolveModelSetting } from './driver';
 import { AGENT_DRIVERS, driverById } from './registry';
 import { remediateTaskById } from './tasks';
+import { remediateBranchFor } from '../lanes/branches';
+import { describeDeliveryProbe, probeDeliveryPreconditions } from '../lanes/delivery-preconditions';
 
 export interface RemediatePlanOptions {
   readonly json?: boolean;
@@ -147,5 +149,24 @@ export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): 
       `  spend ceiling ($${config.maxSpendPerRun}/run): ${ceiling.deferred.join(', ')} ` +
         'deferred to the next firing (disclosed, never dropped).',
     );
+  }
+
+  // The delivery line (#287): can the lanes actually LAND here? The ONE
+  // prober the $0 preflight and doctor consume. Fail-open: an unverifiable
+  // probe is one dim line, never a warning — the plan must not invent a
+  // refusal it cannot evidence.
+  const delivery = probeDeliveryPreconditions(process.cwd(), {
+    branches: config.tasks.map((t) => remediateBranchFor(t)),
+  });
+  if (delivery.unverifiable) {
+    logger.dim(
+      'delivery: could not verify branch rules here (no gh / not GitHub) — probes run in CI too.',
+    );
+  } else {
+    for (const p of delivery.probes) {
+      if (p.verdict === 'ok') logger.info(`  delivery ${p.branch}: OK`);
+      else if (p.verdict === 'blocked') logger.fail(`  delivery ${describeDeliveryProbe(p)}`);
+      else logger.warn(`  delivery ${describeDeliveryProbe(p)}`);
+    }
   }
 }

--- a/test/deps-bump/run.test.ts
+++ b/test/deps-bump/run.test.ts
@@ -91,6 +91,41 @@ describe('runDepsBump', () => {
     }
   });
 
+  it('#286: a blocked landing preflight refuses at $0 — nothing is applied', async () => {
+    const dir = repoWithManifest({ devDependencies: { axios: '^1.7.0' } });
+    const calls: string[][] = [];
+    try {
+      const r = await runDepsBump({
+        cwd: dir,
+        trust: trustedLocalContext(),
+        apply: true,
+        land: 'pr',
+        gather,
+        execBump: (argv) => {
+          calls.push([...argv]);
+          return { ok: true, output: '' };
+        },
+        probeDelivery: () => ({
+          probes: [
+            {
+              branch: 'dxkit/dep-bump',
+              verdict: 'blocked' as const,
+              evidence: 'an active branch-creation ruleset covers "dxkit/dep-bump"',
+              remedy: 'add "refs/heads/dxkit/**" to its exclusion patterns',
+            },
+          ],
+          anyBlocked: true,
+          unverifiable: false,
+        }),
+      });
+      expect(r.outcome).toBe('refused');
+      expect(r.note).toContain('landing-unavailable');
+      expect(calls).toHaveLength(0); // the package manager never ran
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('applies with the PM section preserved and lands via the shared lander on a green floor', async () => {
     const dir = repoWithManifest({ devDependencies: { axios: '^1.7.0' } });
     const calls: string[][] = [];

--- a/test/lanes/delivery-preconditions.test.ts
+++ b/test/lanes/delivery-preconditions.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  describeDeliveryProbe,
+  probeBranchDelivery,
+  probeDeliveryPreconditions,
+  standingLaneBranches,
+  type ApiProbe,
+} from '../../src/lanes/delivery-preconditions';
+import { DEP_BUMP_BRANCH, remediateBranchFor } from '../../src/lanes/branches';
+import { REMEDIATE_TASKS } from '../../src/remediate/tasks';
+
+/**
+ * #286/#287 — the ONE delivery-preconditions prober. The contract under
+ * test: only POSITIVE refusal evidence (an active `creation` rule) reads
+ * as blocked; every unanswerable probe is `unknown` and never invents a
+ * refusal; the probed branch set derives from the same constants the
+ * landers push.
+ */
+
+const rules =
+  (byBranch: Record<string, unknown>): ApiProbe =>
+  (path) => {
+    const branch = decodeURIComponent(path.split('/rules/branches/')[1] ?? '');
+    const answer = byBranch[branch];
+    return answer === undefined ? null : JSON.stringify(answer);
+  };
+
+describe('standingLaneBranches', () => {
+  it('derives from the landers’ own constants — never a second list', () => {
+    const branches = standingLaneBranches();
+    expect(branches).toContain(DEP_BUMP_BRANCH);
+    for (const t of REMEDIATE_TASKS) expect(branches).toContain(remediateBranchFor(t.id));
+  });
+});
+
+describe('probeBranchDelivery', () => {
+  it('an active creation rule is POSITIVE refusal evidence, with the exact remedy (the live class)', () => {
+    const p = probeBranchDelivery(
+      rules({ 'dxkit/dep-bump': [{ type: 'creation' }, { type: 'non_fast_forward' }] }),
+      'acme/repo',
+      'dxkit/dep-bump',
+    );
+    expect(p.verdict).toBe('blocked');
+    expect(p.evidence).toContain('creation');
+    expect(p.remedy).toContain('refs/heads/dxkit/**');
+  });
+
+  it('a file-path restriction is disclosed, not blocked (the diff may not touch it)', () => {
+    const p = probeBranchDelivery(
+      rules({ b: [{ type: 'file_path_restriction' }] }),
+      'acme/repo',
+      'b',
+    );
+    expect(p.verdict).toBe('restricted-paths');
+    expect(p.remedy).toBeTruthy();
+  });
+
+  it('benign rules read as ok, named', () => {
+    const p = probeBranchDelivery(rules({ b: [{ type: 'non_fast_forward' }] }), 'acme/repo', 'b');
+    expect(p.verdict).toBe('ok');
+    expect(p.evidence).toContain('non_fast_forward');
+  });
+
+  it('an unreachable API is UNKNOWN — the probe never invents a refusal', () => {
+    const p = probeBranchDelivery(() => null, 'acme/repo', 'b');
+    expect(p.verdict).toBe('unknown');
+    expect(p.evidence).toContain('could not verify');
+  });
+
+  it('an unparseable payload is UNKNOWN', () => {
+    const p = probeBranchDelivery(() => '<html>', 'acme/repo', 'b');
+    expect(p.verdict).toBe('unknown');
+  });
+});
+
+describe('describeDeliveryProbe', () => {
+  it('one phrasing for every consumer, remedy included when present', () => {
+    const line = describeDeliveryProbe({
+      branch: 'dxkit/dep-bump',
+      verdict: 'blocked',
+      evidence: 'a ruleset covers it',
+      remedy: 'add the exclusion',
+    });
+    expect(line).toContain('dxkit/dep-bump: BLOCKED');
+    expect(line).toContain('Remedy: add the exclusion');
+  });
+});
+
+describe('probeDeliveryPreconditions', () => {
+  it('aggregates: anyBlocked on one refusal; unverifiable only when NOTHING answered', () => {
+    const out = probeDeliveryPreconditions(process.cwd(), {
+      branches: ['a', 'b'],
+      slug: 'acme/repo',
+      probe: rules({ a: [{ type: 'creation' }], b: [] }),
+    });
+    expect(out.anyBlocked).toBe(true);
+    expect(out.unverifiable).toBe(false);
+  });
+});

--- a/test/remediate/executor-landing.test.ts
+++ b/test/remediate/executor-landing.test.ts
@@ -75,6 +75,8 @@ function seams(overrides: Partial<ExecutorSeams> = {}): ExecutorSeams {
       mode: 'pr' as const,
       prUrl: 'https://example.test/pr/1',
     }),
+    // A clean $0 preflight by default (#286) — tests never shell gh.
+    probeDelivery: () => ({ probes: [], anyBlocked: false, unverifiable: false }),
     ...overrides,
   };
 }
@@ -84,6 +86,67 @@ function readRecord(cwd: string): Record<string, unknown> {
     fs.readFileSync(path.join(cwd, '.dxkit', 'cache', 'remediate-write-docs.json'), 'utf8'),
   ) as Record<string, unknown>;
 }
+
+describe('executeTask $0 landing preflight (#286)', () => {
+  it('positive refusal evidence refuses BEFORE any agent spawns, with the remedy named', async () => {
+    const cwd = tempRepo();
+    let agentSpawned = false;
+    const run = await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        runTask: async () => {
+          agentSpawned = true;
+          return verifiedResult();
+        },
+        probeDelivery: () => ({
+          probes: [
+            {
+              branch: 'dxkit/remediate-write-docs',
+              verdict: 'blocked' as const,
+              evidence: 'an active branch-creation ruleset covers "dxkit/remediate-write-docs"',
+              remedy: 'add "refs/heads/dxkit/**" to its exclusion patterns',
+            },
+          ],
+          anyBlocked: true,
+          unverifiable: false,
+        }),
+      }),
+    );
+    expect(agentSpawned).toBe(false); // the whole point: $0, no spend
+    expect(run.result.outcome).toBe('refused');
+    expect(run.result.note).toContain('landing-unavailable');
+    expect(run.result.note).toContain('refs/heads/dxkit/**');
+    expect(run.clean).toBe(false);
+  });
+
+  it('an unverifiable probe PROCEEDS — the preflight never invents a refusal', async () => {
+    const cwd = tempRepo();
+    const run = await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        probeDelivery: () => ({
+          probes: [
+            {
+              branch: 'dxkit/remediate-write-docs',
+              verdict: 'unknown' as const,
+              evidence: 'could not verify: API unreachable',
+            },
+          ],
+          anyBlocked: false,
+          unverifiable: true,
+        }),
+      }),
+    );
+    expect(run.result.outcome).toBe('verified');
+    expect(run.landed).toBe(true);
+  });
+});
 
 describe('executeTask landing layer (#273)', () => {
   it('a rules-shaped push refusal is a DISCLOSED outcome with the git stderr and the remedy', async () => {


### PR DESCRIPTION
Into `release/4.4.1`. Closes #286 and #287.

## What

**One prober** (`src/lanes/delivery-preconditions.ts`), consumed everywhere the question "can the lanes actually LAND here?" matters:

- **Lane preflight (#286)**: remediate probes its standing branch before the agent spawns; dep-bump before applying anything. Positive refusal evidence (an active `creation` rule from `GET /repos/{r}/rules/branches/{b}` — rulesets evaluate by name pattern, so a not-yet-existing branch still answers) becomes a disclosed `landing-unavailable` refusal at **$0 spend**, naming the ruleset and the exact remedy (`refs/heads/dxkit/**` exclusion or a bot bypass).
- **doctor (#287)**: a red "lanes cannot deliver here" check at setup time, beside the existing bot-token / Actions-settings checks.
- **remediate plan**: per-branch delivery lines.

**Fail-open, pinned in both directions**: an unanswerable probe is `unknown` — disclosed, and the caller proceeds. The preflight never invents a refusal. Path-restriction rules disclose without blocking.

## Rider

Standing-branch names moved to the leaf `src/lanes/branches.ts` (re-exported; zero consumer churn) — the probed set derives from the same constants the landers push, and the import cycle a lander-importing prober would create is structurally impossible.

## Verification

Suite 5647/5647 (unmasked), all static gates clean, self-guardrail PASSED exit 0. New pins: prober verdict taxonomy, branch-set derivation, executor $0 preflight (agent not spawned on refusal; unverifiable proceeds), dep-bump preflight (nothing applied on refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)