### PR TITLE
feat(remediate,debt): provisional attempt record + deferred-advisory visibility (4.4.1 WP6)

### DIFF
--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -235,18 +235,47 @@ __DXKIT_CI_RUNTIME_SETUP__
 __DXKIT_REMEDIATE_CREDENTIAL_ENV__
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi
+          set +e
           "$DXKIT" remediate --task "${{ matrix.task }}" --land pr
+          EXIT=$?
+          set -e
+          # Kill-shaped death disclosure (dxkit #289): SIGKILL is uncatchable,
+          # so a killed frame cannot write its own obituary — the only layer
+          # that survives is this one. A 137/143 exit with only the
+          # PROVISIONAL record (written before the agent spawned) means the
+          # frame died mid-agent-phase. The cause is a HYPOTHESIS (a runner
+          # OOM is one common producer of SIGKILL) — the disclosure names the
+          # signal and the phase, never invents a cause.
+          if [ "$EXIT" -eq 137 ] || [ "$EXIT" -eq 143 ]; then
+            REC=".dxkit/cache/remediate-${{ matrix.task }}.json"
+            PHASE=$(node -e "try{console.log(require('./' + process.argv[1]).phase||'')}catch{}" "$REC" 2>/dev/null || true)
+            if [ "$PHASE" = "agent" ]; then
+              echo "::warning title=dxkit remediate ${{ matrix.task }}::the frame was KILLED mid-agent-phase (exit $EXIT — kill-shaped; a runner out-of-memory kill is one possible cause). Partial work, if any, is in the attempt artifact."
+              {
+                echo "## dxkit remediate: ${{ matrix.task }} — frame killed mid-agent-phase"
+                echo ""
+                echo "Exit $EXIT (kill-shaped) with only the provisional attempt record present:"
+                echo "the process was killed before it could classify its own death. A runner"
+                echo "out-of-memory kill is one possible cause (hypothesis, not a measurement)."
+                echo "Partial committed work, if any, is preserved in the attempt artifact."
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+          exit "$EXIT"
 
       # A BLOCKED / failed attempt's diff must survive the ephemeral runner:
       # the runner writes a machine-readable attempt record; when nothing
       # landed but commits exist, format-patch them into a run artifact so
       # "stays local for inspection" means something a human can download.
+      # A PROVISIONAL record (the frame died mid-agent-phase, #289) has no
+      # `head` — fall back to the checkout's live HEAD, which carries
+      # whatever the agent committed before death.
       - name: Collect the attempt diff (evidence when nothing landed)
         if: always()
         run: |
           REC=".dxkit/cache/remediate-${{ matrix.task }}.json"
           if [ -f "$REC" ]; then
-            RANGE=$(node -e "const r=require('./' + process.argv[1]); if (!r.landed && r.baseHead && r.head && r.baseHead !== r.head) console.log(r.baseHead + '..' + r.head);" "$REC")
+            RANGE=$(node -e "const r=require('./' + process.argv[1]); if (!r.landed && r.baseHead) { const head = r.head || (r.phase === 'agent' ? 'HEAD' : null); if (head && r.baseHead !== head) console.log(r.baseHead + '..' + head); }" "$REC")
             if [ -n "$RANGE" ]; then
               git format-patch --stdout "$RANGE" > remediate-attempt.patch
               echo "wrote remediate-attempt.patch for $RANGE"

--- a/src/debt-cli.ts
+++ b/src/debt-cli.ts
@@ -30,6 +30,7 @@ import * as logger from './logger';
 import { pathForBaseline, readBaselineFile, type BaselineFile } from './baseline/baseline-file';
 import { captureFloorDebt, failingFloorDebt, type FloorDebt } from './baseline/floor-debt';
 import { checkKey } from './analyzers/correctness/attribution';
+import { daysUntilDate, tryLoadAllowlist } from './allowlist/file';
 import { KIND_DEFAULT_SEVERITY, describeEntryLocation } from './baseline/check';
 import type { BaselineEntry, FindingSeverity } from './baseline/types';
 
@@ -72,6 +73,20 @@ export interface DebtFindingGroup {
   readonly samples: ReadonlyArray<{ fingerprint: string; locator: string }>;
 }
 
+/** An ACTIVE allowlist-deferred finding (#285): suppressed from the verdict
+ *  until `expiresAt`, then it re-blocks — so it belongs in the repair
+ *  inventory NOW. The live class: nine advisories were deferred with "the
+ *  fix-vulns lane will fix them", the lane read this report, the deferrals
+ *  were invisible to it, and the run completed as a no-op with the fix
+ *  window silently wasted. */
+export interface DebtDeferredEntry {
+  readonly fingerprint: string;
+  readonly kind: string;
+  readonly reason: string;
+  readonly expiresAt: string;
+  readonly daysRemaining: number;
+}
+
 export interface DebtReport {
   readonly schema: 'dxkit.debt.v1';
   readonly baselinePresent: boolean;
@@ -89,6 +104,11 @@ export interface DebtReport {
     readonly total: number;
     readonly groups: ReadonlyArray<DebtFindingGroup>;
   };
+  /** Active deferrals (#285) — a DISTINCT section, never merged into the
+   *  baseline groups: deferral means "do not GATE on this now", and must
+   *  not also mean "hide it from the lane whose job is fixing it".
+   *  Gating behavior is untouched (still suppressed until expiry). */
+  readonly deferred: ReadonlyArray<DebtDeferredEntry>;
   readonly plan: ReadonlyArray<string>;
 }
 
@@ -102,6 +122,8 @@ export function buildDebtReport(
     /** Skip the live floor run and read only the baseline's recorded
      *  envelope — instant, honest about its staleness. */
     readonly stored?: boolean;
+    /** The clock for deferral expiry (injectable for tests). */
+    readonly now?: Date;
   } = {},
 ): DebtReport {
   const name = opts.name ?? 'main';
@@ -223,6 +245,35 @@ export function buildDebtReport(
       `Unmeasurable here (install the toolchain or rely on CI): ${unobservable.join('; ')}`,
     );
   }
+  // Active deferrals (#285): unexpired allowlist entries in the 'deferred'
+  // category. Each returns as a BLOCKER on its expiry, so it is repair
+  // inventory now — the defer's forcing-function design only works if
+  // something works the item during the window.
+  const now = opts.now ?? new Date();
+  const allowlist = tryLoadAllowlist(cwd);
+  const deferred: DebtDeferredEntry[] = (allowlist?.entries ?? [])
+    .filter((e) => e.category === 'deferred' && typeof e.expiresAt === 'string')
+    .map((e) => ({
+      fingerprint: e.fingerprint,
+      kind: e.kind,
+      reason: e.reason ?? '',
+      expiresAt: e.expiresAt!,
+      // The ONE expiry countdown (allowlist/file.ts) — doctor, the audit,
+      // the lapse projection, and this report agree on the same date math.
+      daysRemaining: daysUntilDate(e.expiresAt!, now),
+    }))
+    .filter((e) => e.daysRemaining >= 0)
+    .sort((a, b) => a.daysRemaining - b.daysRemaining);
+  if (deferred.length > 0) {
+    const earliest = deferred[0];
+    plan.push(
+      `Fix the ${deferred.length} DEFERRED finding(s) — suppressed from the verdict until ` +
+        `expiry, then they re-block (earliest: ${earliest.expiresAt}, ` +
+        `${earliest.daysRemaining} day(s) away). Fixing them inside the window is the point ` +
+        `of the defer.`,
+    );
+  }
+
   if (plan.length === 0)
     plan.push('No recorded debt — the floor is green and the baseline is empty.');
 
@@ -232,6 +283,7 @@ export function buildDebtReport(
     floorSource: opts.stored ? 'stored' : 'live',
     floor: { live, baseline: storedFloor, failures, fixedSinceBaseline, unobservable },
     findings: { total: baseline?.findings.length ?? 0, groups },
+    deferred,
     plan,
   };
 }
@@ -284,6 +336,19 @@ export function renderDebtConsole(report: DebtReport): string {
         ? '  none — the baseline is clean'
         : '  no baseline file — run `vyuh-dxkit baseline create` first',
     );
+  }
+  if (report.deferred.length > 0) {
+    lines.push('');
+    lines.push(
+      `DEFERRED (${report.deferred.length} — suppressed until expiry, then they RE-BLOCK)`,
+    );
+    for (const d of report.deferred) {
+      lines.push(
+        `  ${d.kind.padEnd(12)} ${d.fingerprint}  returns ${d.expiresAt} ` +
+          `(${d.daysRemaining} day(s)) — ${d.reason}`,
+      );
+    }
+    lines.push('  Fixing these inside the window is the point of the defer.');
   }
   lines.push('');
   lines.push('SUGGESTED ORDER');

--- a/src/remediate/budget-notes.ts
+++ b/src/remediate/budget-notes.ts
@@ -1,0 +1,33 @@
+/**
+ * Budget-envelope disclosures — split from `run.ts` at the large-file
+ * bar, semantics unchanged. A cap below 'enforced' is a DISCLOSED
+ * limitation phrased by what the driver CAN do: claiming an unenforced
+ * cap as a cap is the $14.71 class (maxUsd read post-hoc while
+ * max_turns silently governed real spend).
+ */
+
+import type { AgentDriver } from './driver';
+import type { RemediateBudget } from './config';
+
+/** The per-driver unenforceable-cap disclosures for a budget. */
+export function unenforceableCapsFor(driver: AgentDriver, budget: RemediateBudget): string[] {
+  const caps: string[] = [];
+  if (driver.budgetSupport.turns !== 'enforced') {
+    caps.push(
+      `maxTurns is not enforceable by ${driver.id}; the wall-clock cap (${budget.maxMinutes} min) applies`,
+    );
+  }
+  if (driver.budgetSupport.cost === 'none') {
+    caps.push(
+      `maxUsd is not enforceable by ${driver.id} (no spend reporting); the wall-clock cap applies`,
+    );
+  } else if (driver.budgetSupport.cost === 'reported') {
+    caps.push(
+      `maxUsd ($${budget.maxUsd}) is ADVISORY for ${driver.id}: the CLI reports spend only ` +
+        `after the run and cannot stop mid-run on cost. Real spend is bounded by the ` +
+        `enforced turn cap (${budget.maxTurns}) and the wall clock (${budget.maxMinutes} min); ` +
+        `an overrun is disclosed and the attempt marked partial`,
+    );
+  }
+  return caps;
+}

--- a/src/remediate/claude-code-driver.ts
+++ b/src/remediate/claude-code-driver.ts
@@ -315,6 +315,11 @@ export function makeClaudeCodeDriver(exec: AgentExec = realAgentExec): AgentDriv
         resolvedModelId: resolvedModelFrom(result),
         timedOut: false,
         transcriptTail: tail,
+        // On a COMPLETED run `result` is the agent's final message (#285) —
+        // bounded here; the runner records it only for no-op outcomes.
+        ...(completed && typeof result.result === 'string' && result.result.trim()
+          ? { finalMessage: result.result.trim().slice(0, 4000) }
+          : {}),
         ...provenance,
         ...failure,
       };

--- a/src/remediate/driver.ts
+++ b/src/remediate/driver.ts
@@ -67,6 +67,13 @@ export interface AgentRunResult {
    *  runner verifies whatever was committed and DISCLOSES this; a no-diff
    *  errored run is a failure outcome, never a benign no-op. */
   readonly failure?: { readonly reason: string };
+  /** The agent's FINAL MESSAGE on a completed run, when the driver reports
+   *  one (#285): a clean no-op outcome discards the transcript by design,
+   *  which made "no-op against a visibly non-empty inventory" unautopsiable
+   *  — the runner records this in the attempt record for no-op outcomes so
+   *  the agent's own account of why nothing changed survives. Bounded by
+   *  the driver; never rendered into a PR body. */
+  readonly finalMessage?: string;
   /** For the failure taxonomy only — never rendered into a PR body. */
   readonly transcriptTail: string;
 }

--- a/src/remediate/execute.ts
+++ b/src/remediate/execute.ts
@@ -160,6 +160,10 @@ export async function executeTask(
       logger.info(`resuming budget-bounded attempt #${resume.attempt} from the salvage branch`);
     }
   }
+  // Evidence before the agent phase (#289): a SIGKILLed frame cannot write
+  // its own record, so it exists BEFORE the spawn.
+  writeProvisionalRecord(cwd, taskId, currentHead(cwd) ?? '');
+
   const reporter = startPhaseReporter(`remediate:${taskId}`);
   // The $0 landing preflight (#286): when this run intends to LAND, probe
   // the standing branch's delivery preconditions BEFORE any agent spawns —
@@ -354,6 +358,60 @@ function finalizeTaskRun(cwd: string, taskId: string, run: TaskRun): TaskRun {
 /** The machine-readable attempt record — written pre-push (landed:false)
  *  AND at every finalize, so the evidence exists no matter where the
  *  landing dies. Best-effort plumbing, never a failure. */
+/**
+ * PROVISIONAL attempt record, written BEFORE the driver spawns (#289): a
+ * SIGKILL (runner OOM) is uncatchable, so every disclosure mechanism the
+ * frame owns dies with it — the record written only at finalize meant a
+ * killed frame left zero evidence and any committed work evaporated
+ * unrecorded. This is the evidence-before-the-risky-step principle moved
+ * one step earlier: the record names how far the run got (`phase:
+ * 'agent'`) and carries `baseHead`, so the workflow's evidence step can
+ * format-patch `baseHead..HEAD` of whatever the agent had committed
+ * before death (falling back to the checkout's live HEAD — the record
+ * has no `head` yet). Finalize overwrites it on every normal path.
+ */
+function writeProvisionalRecord(cwd: string, taskId: string, baseHead: string): void {
+  try {
+    const dir = path.join(cwd, '.dxkit', 'cache');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `remediate-${taskId}.json`),
+      JSON.stringify(
+        {
+          phase: 'agent',
+          outcome: 'provisional',
+          task: taskId,
+          landed: false,
+          baseHead,
+          head: null,
+          note:
+            'provisional record written before the agent spawned — if this survives the run, ' +
+            'the frame died mid-agent-phase (it could not write its own obituary); partial ' +
+            'work, if any, is in the baseHead..HEAD range of the checkout',
+        },
+        null,
+        2,
+      ) + '\n',
+      'utf8',
+    );
+  } catch {
+    // evidence plumbing, never a failure
+  }
+}
+
+/** HEAD of the checkout, or null (evidence plumbing, never a failure). */
+function currentHead(cwd: string): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
 function writeAttemptRecord(cwd: string, taskId: string, run: TaskRun): void {
   try {
     const dir = path.join(cwd, '.dxkit', 'cache');
@@ -371,6 +429,9 @@ function writeAttemptRecord(cwd: string, taskId: string, run: TaskRun): void {
 export function taskRunJson(run: TaskRun): Record<string, unknown> {
   const r = run.result;
   return {
+    // The frame reached finalize — distinguishes this record from the
+    // provisional one a SIGKILL leaves behind (#289).
+    phase: 'final',
     outcome: r.outcome,
     task: r.task ?? null,
     note: r.note ?? null,
@@ -388,6 +449,8 @@ export function taskRunJson(run: TaskRun): Record<string, unknown> {
     head: r.head ?? null,
     // Failure evidence (machine-readable record only — never the PR body).
     transcriptTail: r.transcriptTail ?? null,
+    // The agent's own account of a no-op (#285) — autopsiable, never rendered.
+    agentFinalMessage: r.agentFinalMessage ?? null,
     ledger: r.ledger,
   };
 }

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -103,6 +103,11 @@ export interface RemediateResult {
    *  non-clean outcome (the run page must be diagnosable without reading
    *  source). Never rendered into the ledger / PR body. */
   readonly transcriptTail?: string;
+  /** The agent's final message, recorded for NO-OP outcomes only (#285):
+   *  the agent's own account of why nothing changed, so a no-op against a
+   *  non-empty inventory is autopsiable. Attempt-record evidence — never
+   *  the ledger / PR body. */
+  readonly agentFinalMessage?: string;
   /** dxkit runtime-artifact paths dropped from the attempt (regenerable
    *  scan state the agent committed mid-run) — disclosed in the ledger. */
   readonly scrubbedArtifacts?: readonly string[];

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -34,6 +34,7 @@ import { resolveDispatchedTask } from './dispatch';
 import { resumePromptNote } from './resume';
 import { realGit } from './git-ops';
 import { armInLoopGate, type InLoopGateStatus } from './agent-trust';
+import { unenforceableCapsFor } from './budget-notes';
 import { evaluateScoreHinge, healthHingeScores } from './score-hinge';
 import { salvageForTask } from './config';
 import type { AgentEnvelope, RemediateResult, RemediateRunOptions } from './outcome';
@@ -110,27 +111,9 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // follows the task's declared completion shape. The CLI's land decision
   // reads the same function, so the note here and the landing agree.
   const effectiveSalvage = salvageForTask(opts.config, task);
-  // A cap below 'enforced' is a DISCLOSED limitation, phrased by what the
-  // driver CAN do. Claiming an unenforced cap as a cap is the $14.71 class:
-  // maxUsd read post-hoc while max_turns silently governed real spend.
-  const unenforceableCaps: string[] = [];
-  if (driver.budgetSupport.turns !== 'enforced') {
-    unenforceableCaps.push(
-      `maxTurns is not enforceable by ${driver.id}; the wall-clock cap (${budget.maxMinutes} min) applies`,
-    );
-  }
-  if (driver.budgetSupport.cost === 'none') {
-    unenforceableCaps.push(
-      `maxUsd is not enforceable by ${driver.id} (no spend reporting); the wall-clock cap applies`,
-    );
-  } else if (driver.budgetSupport.cost === 'reported') {
-    unenforceableCaps.push(
-      `maxUsd ($${budget.maxUsd}) is ADVISORY for ${driver.id}: the CLI reports spend only ` +
-        `after the run and cannot stop mid-run on cost. Real spend is bounded by the ` +
-        `enforced turn cap (${budget.maxTurns}) and the wall clock (${budget.maxMinutes} min); ` +
-        `an overrun is disclosed and the attempt marked partial`,
-    );
-  }
+  // Budget-envelope disclosures — the ONE phrasing, split to
+  // `budget-notes.ts` at the large-file bar.
+  const unenforceableCaps = unenforceableCapsFor(driver, budget);
 
   // Auth-path disclosure (driver-generic): a declared credential the runner
   // actually injected = billed API spend; none = the CLI's stored login
@@ -365,6 +348,11 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
       envelope,
       floor: entryFloor,
       ...evidenceTail,
+      // The agent's own account of why nothing changed (#285): a clean
+      // no-op discards the transcript by design, which made "no-op against
+      // a visibly non-empty inventory" unautopsiable. Attempt-record
+      // evidence only — never the ledger / PR body.
+      ...(agentResult.finalMessage ? { agentFinalMessage: agentResult.finalMessage } : {}),
       ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
       ...(partial ? { partial } : {}),
       note:

--- a/src/remediate/tasks.ts
+++ b/src/remediate/tasks.ts
@@ -154,7 +154,10 @@ message. When you believe you are done, re-run the failing commands and then
     prompt:
       `Run \`./node_modules/.bin/vyuh-dxkit debt --json\` and \`vyuh-dxkit vulnerabilities\`.
 Your task is the dependency-vulnerability findings: upgrade or patch the
-affected dependencies, preferring the smallest safe version bumps. After each
+affected dependencies, preferring the smallest safe version bumps. The debt
+report's DEFERRED section lists advisories suppressed until an expiry date,
+when they RE-BLOCK — they are first-class targets for this run (fixing them
+inside the window is the point of the defer), alongside the baselined groups. After each
 bump, run the repo's install and its tests (or the affected subset) to prove
 no behavior broke. Prefer fixing reachable + high/critical advisories first.
 If an advisory has no fixed release, note it in docs/DXKIT-REMEDIATION-NOTES.md

--- a/test/debt-cli.test.ts
+++ b/test/debt-cli.test.ts
@@ -247,3 +247,90 @@ describe('floorDebtNotice (guardrail renderers surface grandfathered floor debt)
     expect(floorDebtNotice({})).toBeNull();
   });
 });
+
+describe('deferred visibility (#285 — the defer must not hide its subjects from the fixer)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-debt-defer-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function writeAllowlist(entries: object[]): void {
+    mkdirSync(join(dir, '.dxkit'), { recursive: true });
+    writeFileSync(
+      join(dir, '.dxkit', 'allowlist.json'),
+      JSON.stringify({
+        schemaVersion: 'dxkit-allowlist/v1',
+        mode: 'full',
+        identityScheme: 'v3',
+        entries,
+      }),
+    );
+  }
+
+  it('active deferrals surface as a DISTINCT section with expiry, and join the plan', () => {
+    writeBaseline(dir, undefined, []);
+    writeAllowlist([
+      {
+        fingerprint: 'aaaa000011112222',
+        kind: 'dep-vuln',
+        category: 'deferred',
+        reason: 'published after baseline capture; fix scheduled',
+        addedBy: 't@e.c',
+        addedAt: '2026-08-08',
+        expiresAt: '2026-08-29',
+      },
+      {
+        fingerprint: 'bbbb000011112222',
+        kind: 'dep-vuln',
+        category: 'false-positive',
+        reason: 'not a real credential',
+        addedBy: 't@e.c',
+        addedAt: '2026-08-08',
+      },
+    ]);
+    const report = buildDebtReport(dir, {
+      liveFloor: () => null,
+      now: new Date('2026-08-14T00:00:00Z'),
+    });
+    // Only the deferred CATEGORY — a false-positive is not repair inventory.
+    expect(report.deferred).toHaveLength(1);
+    expect(report.deferred[0]).toMatchObject({
+      fingerprint: 'aaaa000011112222',
+      kind: 'dep-vuln',
+      expiresAt: '2026-08-29',
+      daysRemaining: 15,
+    });
+    expect(report.plan.some((p) => p.includes('DEFERRED'))).toBe(true);
+    const console = renderDebtConsole(report);
+    expect(console).toContain('DEFERRED (1');
+    expect(console).toContain('RE-BLOCK');
+    expect(console).toContain('2026-08-29');
+  });
+
+  it('an EXPIRED deferral is not listed — it already re-blocks (the gate owns it now)', () => {
+    writeBaseline(dir, undefined, []);
+    writeAllowlist([
+      {
+        fingerprint: 'cccc000011112222',
+        kind: 'dep-vuln',
+        category: 'deferred',
+        reason: 'lapsed',
+        addedBy: 't@e.c',
+        addedAt: '2026-07-01',
+        expiresAt: '2026-07-08',
+      },
+    ]);
+    const report = buildDebtReport(dir, {
+      liveFloor: () => null,
+      now: new Date('2026-08-14T00:00:00Z'),
+    });
+    expect(report.deferred).toHaveLength(0);
+  });
+
+  it('no allowlist at all → an empty section, never a crash', () => {
+    writeBaseline(dir, undefined, []);
+    const report = buildDebtReport(dir, { liveFloor: () => null });
+    expect(report.deferred).toEqual([]);
+  });
+});

--- a/test/remediate/executor-landing.test.ts
+++ b/test/remediate/executor-landing.test.ts
@@ -148,6 +148,33 @@ describe('executeTask $0 landing preflight (#286)', () => {
   });
 });
 
+describe('executeTask provisional record (#289)', () => {
+  it('the record exists BEFORE the agent phase — a SIGKILLed frame still leaves evidence', async () => {
+    const cwd = tempRepo();
+    let recordAtAgentTime: Record<string, unknown> | undefined;
+    await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        runTask: async () => {
+          recordAtAgentTime = readRecord(cwd);
+          return verifiedResult();
+        },
+      }),
+    );
+    expect(recordAtAgentTime).toBeDefined();
+    expect(recordAtAgentTime!.phase).toBe('agent');
+    expect(recordAtAgentTime!.landed).toBe(false);
+    expect(recordAtAgentTime!.outcome).toBe('provisional');
+    // Finalize overwrites it on the normal path.
+    const final = readRecord(cwd);
+    expect(final.phase).toBe('final');
+    expect(final.outcome).toBe('verified');
+  });
+});
+
 describe('executeTask landing layer (#273)', () => {
   it('a rules-shaped push refusal is a DISCLOSED outcome with the git stderr and the remedy', async () => {
     const cwd = tempRepo();

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -239,6 +239,16 @@ describe('the verified frame (the agent is never trusted)', () => {
     expect(r.ledger).toContain('in-loop gate: ARMED');
   });
 
+  it('#285: a no-op records the agent FINAL MESSAGE — the account of why nothing changed', async () => {
+    const r = await runRemediateTask(
+      base(fakeDriver({ finalMessage: 'inventory shows only deferred items I cannot see' }), {
+        git: fakeGit({ diff: false }),
+      }),
+    );
+    expect(r.outcome).toBe('no-op');
+    expect(r.agentFinalMessage).toBe('inventory shows only deferred items I cannot see');
+  });
+
   it('no-op: an agent run with no committed change opens nothing', async () => {
     const r = await runRemediateTask(base(fakeDriver({}), { git: fakeGit({ diff: false }) }));
     expect(r.outcome).toBe('no-op');

--- a/test/remediate/surface.test.ts
+++ b/test/remediate/surface.test.ts
@@ -81,6 +81,20 @@ describe('installCiRemediate (the managed workflow)', () => {
     expect(readFileSync(workflowPath(), 'utf8')).toContain("cron: '0 6 * * *'");
   });
 
+  it('#289: kill-shaped exits are disclosed and the evidence step falls back to live HEAD on a provisional record', () => {
+    writeFileSync(join(repo, '.dxkit', 'policy.json'), '{"remediate": {"enabled": true}}', 'utf8');
+    installCiRemediate(repo);
+    const text = readFileSync(workflowPath(), 'utf8');
+    // The workflow layer is the only one that survives a SIGKILL: it
+    // distinguishes a kill-shaped exit with only the provisional record
+    // present, and phrases the cause as a HYPOTHESIS.
+    expect(text).toContain('137');
+    expect(text).toContain('KILLED mid-agent-phase');
+    expect(text).toContain('possible cause');
+    // The evidence step reads the provisional record's live-HEAD fallback.
+    expect(text).toContain("r.phase === 'agent' ? 'HEAD'");
+  });
+
   it('triggers stay schedule + workflow_dispatch only — never PR or comment events', () => {
     writeFileSync(join(repo, '.dxkit', 'policy.json'), '{"remediate": {"enabled": true}}', 'utf8');
     installCiRemediate(repo);


### PR DESCRIPTION
Into `release/4.4.1`. Closes #289 and #285.

## #289 — evidence survives a SIGKILL

A killed frame (runner OOM, exit 137) left zero evidence — no record, no ledger, committed work evaporating with the runner. Now:

- a **provisional attempt record** (`phase: 'agent'`, baseHead, landed: false) is written **before** the driver spawns; finalize overwrites it (`phase: 'final'`) on every normal path;
- the workflow's evidence step falls back to the checkout's **live HEAD** on a provisional record, so a mid-phase death still format-patches whatever the agent committed;
- the workflow task step distinguishes a kill-shaped exit (137/143) with only the provisional record present and annotates the run page + step summary — cause phrased as a **hypothesis** (a runner OOM is one possible producer of SIGKILL), never invented.

## #285 — the defer must not hide its subjects from the fixer

Deferral means "do not GATE on this now", not "hide it from the lane whose job is fixing it" (live: nine deferred advisories invisible to fix-vulns; the run no-op'd and the window was silently wasted). Now:

- the debt report gains a **distinct DEFERRED section** (active deferrals with expiry + countdown via the one canonical `daysUntilDate`), joined into the suggested order; gating untouched;
- the fix-vulns prompt names the section as first-class targets;
- a completed run's **final message** is recorded in the attempt record for no-op outcomes (driver-bounded) — "no-op against a non-empty inventory" is now autopsiable.

## Riders

- `run.ts` crossed the 500-line bar → budget-envelope disclosures split to `budget-notes.ts`, semantics unchanged.
- The self-gate caught a hand-rolled expiry countdown → routed through the canonical `daysUntilDate`.
- Rebased over WP5 (one test-file conflict resolved; both new describe blocks kept).

## Verification

Suite 5661/5661 on the rebased tree (exit unmasked), all static gates + typecheck:test clean, self-guardrail PASSED exit 0, confidentiality grep clean. New pins: deferred section (active-only / expired-excluded / no-allowlist-safe / console + plan), template-level kill-disclosure + live-HEAD fallback, provisional-before-agent at the executor seam, no-op final message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)