### PR TITLE
feat(lanes): GitHub App token tier — minted per-run, no billed seat (4.4.1 WP7)

### DIFF
--- a/docs/commands/remediate.md
+++ b/docs/commands/remediate.md
@@ -136,6 +136,28 @@ own default applies (subscription mode). `remediate.enabled: true` gates
 the scheduled workflow only; the local CLI runs regardless, since a human
 at a terminal is its own consent.
 
+### The lane token (three tiers)
+
+The lanes push branches and open PRs, and PRs opened with the default
+`GITHUB_TOKEN` run **no checks** (GitHub's robot-loop rule), which makes
+them unmergeable under branch protection. The workflows resolve their
+token through one chain, best tier first:
+
+1. **GitHub App** (preferred): set the `DXKIT_APP_ID` repository (or
+   org) _variable_ and the `DXKIT_APP_PRIVATE_KEY` _secret_, with the
+   app installed on the repo holding contents + pull-requests write. The
+   workflow mints a short-lived installation token per run — no billed
+   seat, the PAT-expiry class cannot recur, and lane PRs are attributed
+   to the app's own bot identity, so a maintainer can approve them. A
+   configured-but-broken app fails the mint step loudly rather than
+   silently degrading a tier.
+2. **`DXKIT_BOT_TOKEN`** (a PAT with repo scope): works today,
+   attributed to the PAT's owner (who then cannot approve the lane's
+   PRs), and expires on the PAT's schedule.
+3. **The default token**: functional, but the lane's PRs run no checks —
+   the workflow says so with a run notice, and `doctor` flags it at
+   setup time.
+
 Exit code is the truthful aggregate: any task that did not end
 `verified`, `no-op`, or a landed salvage draft exits 1.
 

--- a/src-templates/.github/workflows/dxkit-baseline-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh.yml
@@ -30,6 +30,25 @@ __DXKIT_REFRESH_NEEDS__
     # above already filters the common case).
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     steps:
+      # Lane token, three tiers (4.4.1 WP7). Preferred: a GitHub App —
+      # no billed seat, a short-lived token minted per run (the PAT-expiry
+      # class cannot recur), and lane activity attributed to the app's own
+      # bot identity, whose PRs a maintainer can approve. Configure: the
+      # repository (or org) VARIABLE DXKIT_APP_ID + the secret
+      # DXKIT_APP_PRIVATE_KEY, with the app installed on this repo holding
+      # contents + pull-requests write. Falls back to the DXKIT_BOT_TOKEN
+      # PAT, then the default token (whose PRs run no checks). A
+      # configured-but-broken App FAILS THIS STEP loudly rather than
+      # silently degrading a tier — a config error must not quietly change
+      # which identity pushes.
+      - name: Mint the lane token (GitHub App, when configured)
+        id: dxkit-app-token
+        if: ${{ vars.DXKIT_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DXKIT_APP_ID }}
+          private-key: ${{ secrets.DXKIT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -38,14 +57,19 @@ __DXKIT_REFRESH_NEEDS__
           # Optional bot PAT (DXKIT_BOT_TOKEN): pushes made with the default
           # GITHUB_TOKEN never trigger workflow runs, so the advisory decision
           # PR this lane can open would show no checks. Falls back cleanly.
-          token: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
+          token: ${{ steps.dxkit-app-token.outputs.token || secrets.DXKIT_BOT_TOKEN || github.token }}
 
       - name: Disclose token mode
         env:
+          DXKIT_APP_SET: ${{ vars.DXKIT_APP_ID != '' }}
           DXKIT_BOT_TOKEN_SET: ${{ secrets.DXKIT_BOT_TOKEN != '' }}
         run: |
-          if [ "${DXKIT_BOT_TOKEN_SET}" != "true" ]; then
-            echo "::notice title=lane PRs run no checks::This lane pushes with the default GITHUB_TOKEN, and GitHub never triggers workflows for such pushes - a PR it opens will show no checks. Set the DXKIT_BOT_TOKEN secret (a PAT with repo scope) to lift this."
+          if [ "${DXKIT_APP_SET}" = "true" ]; then
+            echo "token tier: GitHub App (short-lived, minted this run)"
+          elif [ "${DXKIT_BOT_TOKEN_SET}" = "true" ]; then
+            echo "token tier: DXKIT_BOT_TOKEN (PAT)"
+          else
+            echo "::notice title=lane PRs run no checks::This lane pushes with the default GITHUB_TOKEN, and GitHub never triggers workflows for such pushes - the PR it opens will show no checks. Preferred fix: a GitHub App (set the DXKIT_APP_ID variable + the DXKIT_APP_PRIVATE_KEY secret - no billed seat, short-lived per-run tokens). A DXKIT_BOT_TOKEN PAT secret with repo scope also works."
           fi
 
       - uses: actions/setup-node@v6

--- a/src-templates/.github/workflows/dxkit-dep-bump.yml
+++ b/src-templates/.github/workflows/dxkit-dep-bump.yml
@@ -29,6 +29,25 @@ jobs:
     name: dxkit-dep-bump
     runs-on: ubuntu-latest
     steps:
+      # Lane token, three tiers (4.4.1 WP7). Preferred: a GitHub App —
+      # no billed seat, a short-lived token minted per run (the PAT-expiry
+      # class cannot recur), and lane activity attributed to the app's own
+      # bot identity, whose PRs a maintainer can approve. Configure: the
+      # repository (or org) VARIABLE DXKIT_APP_ID + the secret
+      # DXKIT_APP_PRIVATE_KEY, with the app installed on this repo holding
+      # contents + pull-requests write. Falls back to the DXKIT_BOT_TOKEN
+      # PAT, then the default token (whose PRs run no checks). A
+      # configured-but-broken App FAILS THIS STEP loudly rather than
+      # silently degrading a tier — a config error must not quietly change
+      # which identity pushes.
+      - name: Mint the lane token (GitHub App, when configured)
+        id: dxkit-app-token
+        if: ${{ vars.DXKIT_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DXKIT_APP_ID }}
+          private-key: ${{ secrets.DXKIT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           ref: __DXKIT_DEFAULT_BRANCH__
@@ -38,14 +57,19 @@ jobs:
           # checks (uncheckable under branch protection). Set the
           # DXKIT_BOT_TOKEN secret (a PAT with repo scope) to retire that
           # degradation; absent, the lane still works and discloses it.
-          token: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
+          token: ${{ steps.dxkit-app-token.outputs.token || secrets.DXKIT_BOT_TOKEN || github.token }}
 
       - name: Disclose token mode
         env:
+          DXKIT_APP_SET: ${{ vars.DXKIT_APP_ID != '' }}
           DXKIT_BOT_TOKEN_SET: ${{ secrets.DXKIT_BOT_TOKEN != '' }}
         run: |
-          if [ "${DXKIT_BOT_TOKEN_SET}" != "true" ]; then
-            echo "::notice title=lane PRs run no checks::This lane pushes with the default GITHUB_TOKEN, and GitHub never triggers workflows for such pushes - the PR it opens will show no checks. Set the DXKIT_BOT_TOKEN secret (a PAT with repo scope) to lift this."
+          if [ "${DXKIT_APP_SET}" = "true" ]; then
+            echo "token tier: GitHub App (short-lived, minted this run)"
+          elif [ "${DXKIT_BOT_TOKEN_SET}" = "true" ]; then
+            echo "token tier: DXKIT_BOT_TOKEN (PAT)"
+          else
+            echo "::notice title=lane PRs run no checks::This lane pushes with the default GITHUB_TOKEN, and GitHub never triggers workflows for such pushes - the PR it opens will show no checks. Preferred fix: a GitHub App (set the DXKIT_APP_ID variable + the DXKIT_APP_PRIVATE_KEY secret - no billed seat, short-lived per-run tokens). A DXKIT_BOT_TOKEN PAT secret with repo scope also works."
           fi
 
       - uses: actions/setup-node@v6
@@ -93,7 +117,7 @@ __DXKIT_CI_RUNTIME_SETUP__
       # committed policy opts in.
       - name: Run the bump lane
         env:
-          GH_TOKEN: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.dxkit-app-token.outputs.token || secrets.DXKIT_BOT_TOKEN || github.token }}
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi
           EXTRA=""

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -147,6 +147,25 @@ jobs:
       matrix:
         task: ${{ fromJSON(needs.plan.outputs.tasks) }}
     steps:
+      # Lane token, three tiers (4.4.1 WP7). Preferred: a GitHub App —
+      # no billed seat, a short-lived token minted per run (the PAT-expiry
+      # class cannot recur), and lane activity attributed to the app's own
+      # bot identity, whose PRs a maintainer can approve. Configure: the
+      # repository (or org) VARIABLE DXKIT_APP_ID + the secret
+      # DXKIT_APP_PRIVATE_KEY, with the app installed on this repo holding
+      # contents + pull-requests write. Falls back to the DXKIT_BOT_TOKEN
+      # PAT, then the default token (whose PRs run no checks). A
+      # configured-but-broken App FAILS THIS STEP loudly rather than
+      # silently degrading a tier — a config error must not quietly change
+      # which identity pushes.
+      - name: Mint the lane token (GitHub App, when configured)
+        id: dxkit-app-token
+        if: ${{ vars.DXKIT_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DXKIT_APP_ID }}
+          private-key: ${{ secrets.DXKIT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           ref: __DXKIT_DEFAULT_BRANCH__
@@ -154,14 +173,19 @@ jobs:
           # Optional bot PAT (DXKIT_BOT_TOKEN): branches pushed with the
           # default GITHUB_TOKEN never trigger workflow runs, so the lane's
           # PRs would show no checks. Falls back to the default token.
-          token: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
+          token: ${{ steps.dxkit-app-token.outputs.token || secrets.DXKIT_BOT_TOKEN || github.token }}
 
       - name: Disclose token mode
         env:
+          DXKIT_APP_SET: ${{ vars.DXKIT_APP_ID != '' }}
           DXKIT_BOT_TOKEN_SET: ${{ secrets.DXKIT_BOT_TOKEN != '' }}
         run: |
-          if [ "${DXKIT_BOT_TOKEN_SET}" != "true" ]; then
-            echo "::notice title=lane PRs run no checks::This lane pushes with the default GITHUB_TOKEN, and GitHub never triggers workflows for such pushes - the PR it opens will show no checks. Set the DXKIT_BOT_TOKEN secret (a PAT with repo scope) to lift this."
+          if [ "${DXKIT_APP_SET}" = "true" ]; then
+            echo "token tier: GitHub App (short-lived, minted this run)"
+          elif [ "${DXKIT_BOT_TOKEN_SET}" = "true" ]; then
+            echo "token tier: DXKIT_BOT_TOKEN (PAT)"
+          else
+            echo "::notice title=lane PRs run no checks::This lane pushes with the default GITHUB_TOKEN, and GitHub never triggers workflows for such pushes - the PR it opens will show no checks. Preferred fix: a GitHub App (set the DXKIT_APP_ID variable + the DXKIT_APP_PRIVATE_KEY secret - no billed seat, short-lived per-run tokens). A DXKIT_BOT_TOKEN PAT secret with repo scope also works."
           fi
 
       - uses: actions/setup-node@v6
@@ -222,7 +246,7 @@ __DXKIT_CI_RUNTIME_SETUP__
       # per-task failure, visible on the run page without opening logs.
       - name: Run task ${{ matrix.task }}
         env:
-          GH_TOKEN: ${{ secrets.DXKIT_BOT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.dxkit-app-token.outputs.token || secrets.DXKIT_BOT_TOKEN || github.token }}
           # Dispatch-campaign inputs, transported via ENV only (the
           # comment-defer pattern — free text never touches a shell line).
           # Blank on scheduled runs; the CLI clamps budget overrides to the

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -131,6 +131,43 @@ function botTokenSecretAbsent(cwd: string): boolean | null {
   }
 }
 
+/** Is the GitHub App token tier configured (4.4.1 WP7)? TRUE only when BOTH
+ *  halves exist — the DXKIT_APP_ID variable and the DXKIT_APP_PRIVATE_KEY
+ *  secret; the workflows gate their mint step on the variable and fail
+ *  loudly on a broken key. Tri-state fail-open like its PAT sibling: null
+ *  when the API cannot answer (no admin scope, offline) — never a false
+ *  alarm. */
+function appTokenConfigured(cwd: string): boolean | null {
+  try {
+    const vars = execSync('gh variable list --json name --jq ".[].name"', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+    });
+    if (
+      !vars
+        .split('\n')
+        .map((l) => l.trim())
+        .includes('DXKIT_APP_ID')
+    ) {
+      return false;
+    }
+    const secrets = execSync('gh secret list --json name --jq ".[].name"', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+    });
+    return secrets
+      .split('\n')
+      .map((l) => l.trim())
+      .includes('DXKIT_APP_PRIVATE_KEY');
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Can GitHub Actions create pull requests in this repo? Same tri-state
  * fail-open contract as `botTokenSecretAbsent`: `false` only when the API
@@ -995,18 +1032,25 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
     const prLaneInstalled = ['dxkit-dep-bump.yml', 'dxkit-remediate.yml'].some((f) =>
       fs.existsSync(path.join(cwd, '.github', 'workflows', f)),
     );
-    if (prLaneInstalled && botTokenSecretAbsent(cwd) === true) {
+    // Warn only when NEITHER token tier is configured (4.4.1 WP7): the
+    // GitHub App tier (preferred — no billed seat, short-lived per-run
+    // tokens) or the DXKIT_BOT_TOKEN PAT. A null (unanswerable) App probe
+    // stays fail-open: the PAT check alone decides, exactly as before.
+    if (prLaneInstalled && botTokenSecretAbsent(cwd) === true && appTokenConfigured(cwd) !== true) {
       checks.push({
-        label: 'lane PRs will run no checks — DXKIT_BOT_TOKEN secret is not set',
+        label: 'lane PRs will run no checks — no lane token tier is configured',
         ok: false,
         tier: 'operational',
         fix: {
           hint:
             'The dep-bump / remediate lanes push with the default GITHUB_TOKEN, and GitHub ' +
             'never triggers workflows for such pushes — their PRs arrive with no checks ' +
-            '(unmergeable under branch protection). Create a PAT with repo scope and add it ' +
-            'as the DXKIT_BOT_TOKEN repo secret; the lanes pick it up automatically.',
-          command: 'gh secret set DXKIT_BOT_TOKEN',
+            '(unmergeable under branch protection). Preferred fix: create a GitHub App ' +
+            '(contents + pull-requests write, installed on this repo), then set the ' +
+            'DXKIT_APP_ID variable and DXKIT_APP_PRIVATE_KEY secret — no billed seat, ' +
+            'short-lived per-run tokens, and PRs a maintainer can approve. A PAT in the ' +
+            'DXKIT_BOT_TOKEN secret also works; the lanes pick either up automatically.',
+          command: 'gh variable set DXKIT_APP_ID && gh secret set DXKIT_APP_PRIVATE_KEY',
           skill: 'dxkit-fix',
         },
       });

--- a/test/templates-lane-tokens.test.ts
+++ b/test/templates-lane-tokens.test.ts
@@ -85,16 +85,29 @@ describe('workflow-template token parity', () => {
     ).toEqual([]);
   });
 
-  it('PR-opening lane templates route credentials through the DXKIT_BOT_TOKEN fallback', () => {
+  it('PR-opening lane templates route credentials through the ONE three-tier token chain (4.4.1 WP7)', () => {
     const PR_LANES = ['dxkit-dep-bump.yml', 'dxkit-remediate.yml', 'dxkit-baseline-refresh.yml'];
+    const TIER_CHAIN =
+      'steps.dxkit-app-token.outputs.token || secrets.DXKIT_BOT_TOKEN || github.token';
     for (const file of PR_LANES) {
       const content = fs.readFileSync(path.join(WORKFLOWS, file), 'utf8');
-      expect(content, `${file} must use the DXKIT_BOT_TOKEN fallback`).toContain(
-        'secrets.DXKIT_BOT_TOKEN || github.token',
+      // Tier 1: the App mint step, gated on the DXKIT_APP_ID VARIABLE
+      // (secrets cannot gate an `if:`), pinned action version.
+      expect(content, `${file} must mint the App token when configured`).toContain(
+        'actions/create-github-app-token@v2',
       );
-      // The degraded default is disclosed, not silent.
+      expect(content, `${file} must gate the mint on the App variable`).toContain(
+        "if: ${{ vars.DXKIT_APP_ID != '' }}",
+      );
+      // Tiers 1→2→3 in one expression — App token, then PAT, then default.
+      expect(content, `${file} must use the three-tier token chain`).toContain(TIER_CHAIN);
+      // The degraded default is disclosed, not silent — and the notice
+      // names the App tier as the preferred remedy.
       expect(content, `${file} must disclose the default-token degradation`).toContain(
         'DXKIT_BOT_TOKEN_SET',
+      );
+      expect(content, `${file} degraded-mode notice must name the App remedy`).toContain(
+        'DXKIT_APP_ID variable',
       );
     }
   });


### PR DESCRIPTION
Into `release/4.4.1`. The bot-identity item from the 4.4.1 plan.

## What

One token chain, three tiers, best first — across all three lane workflow templates:

```
steps.dxkit-app-token.outputs.token || secrets.DXKIT_BOT_TOKEN || github.token
```

- **App tier (new, preferred)**: `actions/create-github-app-token@v2` (pinned), gated on the `DXKIT_APP_ID` repository/org **variable** (secrets can't gate `if:`) + `DXKIT_APP_PRIVATE_KEY` secret. Short-lived per-run tokens (the PAT-expiry class that 403'd a landing after full budget spend cannot recur), the app's own bot identity (maintainers can approve lane PRs), no billed seat. A configured-but-broken App fails the mint loudly — a config error must not quietly change which identity pushes.
- **PAT tier**: byte-compatible, unchanged.
- **Default token**: still works; the tier-aware notice names the App as the preferred remedy.

Also: doctor's lane-token check recognizes the App tier (tri-state fail-open) and warns only when neither tier is configured; the `templates-lane-tokens` parity net pins the chain, gate condition, pinned action, and notice per template; `remediate.md` documents the three tiers.

## Operator setup (dormant until done)

Create the App (contents + pull-requests write), install on the repo, `gh variable set DXKIT_APP_ID`, `gh secret set DXKIT_APP_PRIVATE_KEY`.

## Verification

Suite 5655/5655 (unmasked), all static gates clean, self-guardrail PASSED exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)