### PR TITLE
feat(gate,abap): workspace batch + the bdef structural floor (4.4.1 WP8)

### DIFF
--- a/docs/learn/wave-gating.md
+++ b/docs/learn/wave-gating.md
@@ -30,6 +30,33 @@ Dot-directories and the flows directory itself are not members. Each member
 is analyzed with the same per-tree machinery the single-tree gate uses;
 the wave layer then composes the results.
 
+`--flows` resolves **relative to the workspace root**, not your current
+directory. A declared flows directory that does not resolve is a refusal:
+the run answers `cannot_gate` (exit 2) naming the path it tried — never a
+silent skip that renders a verdict with zero flows evaluated (and when the
+path happens to exist relative to your current directory, the refusal says
+so, since that is the usual mistake).
+
+### Declared served surfaces (`dxkit-surface.json`)
+
+A member whose routes live in a DSL or service definition the extractor
+cannot parse would otherwise join the mesh with zero routes, and every
+flow step against it would false-block. Such a member can DECLARE its
+surface in a `dxkit-surface.json` at its root:
+
+```json
+{ "serves": ["GET /api/orders", "POST /api/orders", "ANY /health"] }
+```
+
+Declared entries join the served mesh exactly as extracted routes do —
+same normalizer, same catch-all semantics, full participation in
+no-route / dead-route / flow resolution — but they are labeled and
+disclosed as **declared** (asserted, not observed): the verdict carries a
+`surface:<member>` check row per declaring member, and malformed entries
+are named, never silently dropped. A member with a `.dxkit/policy.json`
+can alternatively point `flow.specs` at an OpenAPI document — the wave
+honors per-member flow config, and a spec is the richer contract.
+
 ## What the composition checks
 
 The gate builds one **served mesh**: the union of every route every member

--- a/src/allowlist/defer-core.ts
+++ b/src/allowlist/defer-core.ts
@@ -25,7 +25,7 @@
  */
 
 import { dxkitCli } from '../self-invocation';
-import { readVerdictForTree } from '../baseline/verdict-cache';
+import { explainVerdictMiss, readVerdictForTree } from '../baseline/verdict-cache';
 import {
   addEntry,
   daysUntilDate,
@@ -151,12 +151,29 @@ export function executeDefer(cwd: string, req: DeferRequest, now = new Date()): 
   const leftBlocking: string[] = [];
   if (req.fromLastCheck) {
     if (!cachedBlocking) {
+      // The path-level diagnostic (#282): when a cache EXISTS but the tree
+      // moved, name what moved — the class this closes was a workflow's own
+      // scratch files perturbing the signature, undiagnosable from "no
+      // cached verdict" alone.
+      const miss = cached === null ? explainVerdictMiss(cwd) : null;
+      const missDetail =
+        miss !== null && (miss.newPaths.length > 0 || miss.clearedPaths.length > 0)
+          ? ' The tree CHANGED since the last check — paths that differ:' +
+            (miss.newPaths.length > 0
+              ? ` new/modified since the check: ${miss.newPaths.slice(0, 10).join(', ')}${miss.newPaths.length > 10 ? ` (+${miss.newPaths.length - 10} more)` : ''}.`
+              : '') +
+            (miss.clearedPaths.length > 0
+              ? ` no longer dirty: ${miss.clearedPaths.slice(0, 10).join(', ')}${miss.clearedPaths.length > 10 ? ` (+${miss.clearedPaths.length - 10} more)` : ''}.`
+              : '') +
+            ' (Scratch/log files written into the repo between check and defer are the classic cause — write them outside the repo.)'
+          : '';
       return refuse(
         cached
           ? 'The cached verdict has no finding list (written by an older dxkit). ' +
               `Re-run \`${dxkitCli('guardrail check')}\` on this tree, then retry.`
           : 'No cached guardrail verdict for this tree. Run ' +
-              `\`${dxkitCli('guardrail check')}\` first (same tree, no edits in between), then retry.`,
+              `\`${dxkitCli('guardrail check')}\` first (same tree, no edits in between), then retry.` +
+              missDetail,
       );
     }
     for (const f of cachedBlocking) {

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -198,6 +198,50 @@ function runResolutionCheck(
 }
 
 /**
+ * Execute a pack's optional STRUCTURE check (#309) — a pure computation
+ * mirroring `runResolutionCheck`. Findings are keyed by FILE (the durable
+ * identity of "this artifact is structurally broken"), so an already-red
+ * tree still blocks on a NEW broken artifact through the one attribution
+ * comparator. `none` returns null (nothing ran, nothing claimed); a throw
+ * is infrastructure — disclosed skip, never a verdict.
+ */
+function runStructureCheck(
+  id: LanguageId,
+  provider: CorrectnessProvider,
+  ctx: CorrectnessContext,
+): CorrectnessCheckResult | null {
+  try {
+    const res = provider.structureCheck!(ctx);
+    if (res.kind === 'none') return null;
+    const base = { pack: id, label: res.label, bin: '' };
+    if (res.kind === 'clean') return { ...base, status: 'pass' };
+    if (res.kind === 'broken') {
+      const lines = res.findings.map((f) => `${f.file}: ${f.problem}`);
+      lines.push(
+        'A structurally implausible artifact fails downstream consumers at import time. ' +
+          'This is a STRUCTURAL check (no parser covers this artifact class) — shallow by ' +
+          'design, so a pass means "plausible", never "parsed".',
+      );
+      return {
+        ...base,
+        status: 'fail',
+        output: lines.join('\n'),
+        findings: [...new Set(res.findings.map((f) => f.file))],
+      };
+    }
+    return { ...base, status: 'skipped-unavailable', output: res.reason };
+  } catch (err) {
+    return {
+      pack: id,
+      label: 'structure',
+      bin: '',
+      status: 'skipped-unavailable',
+      output: `structure check errored: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/**
  * Run the correctness floor across the active packs. Never throws — an exec
  * error surfaces as a `fail` check (fail-closed), a missing binary as
  * `skipped-unavailable` (fail-open). `blocks` is true iff a check that ran
@@ -326,6 +370,14 @@ export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessF
     // infrastructure, never a verdict: fail-OPEN as a disclosed skip.
     if (provider.resolutionCheck) {
       checks.push(runResolutionCheck(id, provider, ctx));
+    }
+    // The structure check (#309, optional capability): same pure-computation
+    // contract — the tier between "file exists" and "parses" for artifact
+    // classes no parser covers. `none` (no artifacts of the class) pushes
+    // nothing: the check never ran and claims nothing.
+    if (provider.structureCheck) {
+      const structural = runStructureCheck(id, provider, ctx);
+      if (structural !== null) checks.push(structural);
     }
   }
 

--- a/src/analyzers/flow/declared-surface.ts
+++ b/src/analyzers/flow/declared-surface.ts
@@ -1,0 +1,92 @@
+/**
+ * The per-member DECLARED served surface (#308, 4.4.1 WP8).
+ *
+ * A workspace member whose routes live in a framework DSL the mesh
+ * extractor cannot parse reported `routes: 0`, and every `--flows` step
+ * false-blocked against the empty mesh. Framework-specific extraction
+ * would cover one DSL at a time; this is the generic escape hatch: an
+ * optional `dxkit-surface.json` at the member root —
+ *
+ *     { "serves": ["GET /api/orders", "POST /api/orders", "ANY /health"] }
+ *
+ * — whose entries join the served mesh EXACTLY as extracted routes do
+ * (same normalizer, same catch-all semantics, full participation in
+ * no-route / dead-route / flow resolution), labeled as DECLARED rather
+ * than extracted (`via: 'declared-surface'`, and the wave outcome
+ * discloses per-member declared counts) so a verdict reader can tell an
+ * observed surface from an asserted one. Malformed entries are
+ * DISCLOSED, never silently dropped — a typo'd declaration must not
+ * silently shrink the mesh. An OpenAPI document is the richer
+ * alternative: a member's own `.dxkit/policy.json` `flow.specs` already
+ * joins specs into its model, and the wave honors per-member config.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ANY_METHOD, normalizeMethod, normalizePath } from './normalize';
+import type { RouteEndpoint } from './extract';
+
+export const DECLARED_SURFACE_FILENAME = 'dxkit-surface.json';
+
+export interface DeclaredSurface {
+  readonly routes: readonly RouteEndpoint[];
+  /** Entries that could not be parsed — disclosed by every consumer. */
+  readonly malformed: readonly string[];
+}
+
+/** Read a member's declared surface. Null when the file is absent (the
+ *  overwhelmingly common case — nothing is inferred). A present-but-
+ *  unreadable file is a surface with one malformed entry, never a silent
+ *  nothing. */
+export function readDeclaredSurface(memberRoot: string): DeclaredSurface | null {
+  const file = path.join(memberRoot, DECLARED_SURFACE_FILENAME);
+  if (!fs.existsSync(file)) return null;
+  let doc: unknown;
+  try {
+    doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (err) {
+    return { routes: [], malformed: [`${DECLARED_SURFACE_FILENAME}: ${(err as Error).message}`] };
+  }
+  const serves = (doc as { serves?: unknown })?.serves;
+  if (!Array.isArray(serves)) {
+    return {
+      routes: [],
+      malformed: [`${DECLARED_SURFACE_FILENAME}: expected { "serves": ["METHOD /path", …] }`],
+    };
+  }
+  const routes: RouteEndpoint[] = [];
+  const malformed: string[] = [];
+  serves.forEach((entry, i) => {
+    if (typeof entry !== 'string') {
+      malformed.push(`serves[${i}]: expected a "METHOD /path" string`);
+      return;
+    }
+    const m = entry.trim().match(/^(\S+)\s+(\S.*)$/);
+    if (!m) {
+      malformed.push(`serves[${i}] ("${entry}"): expected "METHOD /path"`);
+      return;
+    }
+    const method = m[1].toUpperCase() === 'ANY' ? ANY_METHOD : normalizeMethod(m[1]);
+    if (method === null) {
+      malformed.push(`serves[${i}] ("${entry}"): unknown method "${m[1]}"`);
+      return;
+    }
+    // The ONE normalizer — declared paths get the same {var} folding and
+    // catch-all token treatment extracted routes get, so the mesh join
+    // cannot fork on representation.
+    const normalizedPath = normalizePath(m[2]);
+    if (normalizedPath === null) {
+      malformed.push(`serves[${i}] ("${entry}"): unparseable path "${m[2]}"`);
+      return;
+    }
+    routes.push({
+      method,
+      path: normalizedPath,
+      via: 'declared-surface',
+      handler: null,
+      file: DECLARED_SURFACE_FILENAME,
+      line: i + 1,
+    });
+  });
+  return { routes, malformed };
+}

--- a/src/baseline/verdict-cache.ts
+++ b/src/baseline/verdict-cache.ts
@@ -22,7 +22,7 @@
 import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
-import { workingTreeSignature } from '../loop/gate-cache';
+import { treeStatusPaths, workingTreeSignature } from '../loop/gate-cache';
 import type { BrownfieldPolicy } from './policy';
 import { pairBlocks, type ClassifiedPair } from './check';
 
@@ -94,6 +94,38 @@ export interface CachedVerdict {
    *  from the last same-tree run. Optional: a cache written by an older dxkit
    *  lacks it — defer then asks for a re-run rather than guessing. */
   readonly blockingFindings?: ReadonlyArray<CachedBlockingFinding>;
+  /** The dirty/untracked PATH LIST at cache time (dxkit outputs stripped) —
+   *  the nameable projection of the signature's status input, so a
+   *  same-tree mismatch can say WHICH paths perturbed it (#282). Optional:
+   *  older caches lack it and the diagnostic stays silent. */
+  readonly treePaths?: ReadonlyArray<string>;
+}
+
+/** Why the cached verdict did not match this tree, path-by-path (#282):
+ *  the diagnostic that turns "defer refused, no cached verdict" from a
+ *  workflow autopsy into a 30-second read. Null when there is no cache at
+ *  all, it is unreadable, it MATCHES, or it predates `treePaths`. */
+export function explainVerdictMiss(
+  cwd: string,
+): { newPaths: readonly string[]; clearedPaths: readonly string[] } | null {
+  const sig = workingTreeSignature(cwd);
+  if (!sig) return null;
+  let parsed: CachedVerdict;
+  try {
+    parsed = JSON.parse(fs.readFileSync(path.join(cwd, CACHE_REL), 'utf8')) as CachedVerdict;
+  } catch {
+    return null;
+  }
+  if (typeof parsed.signature !== 'string' || parsed.signature === sig) return null;
+  if (!Array.isArray(parsed.treePaths)) return null;
+  const now = treeStatusPaths(cwd);
+  if (now === null) return null;
+  const cached = new Set(parsed.treePaths);
+  const current = new Set(now);
+  return {
+    newPaths: now.filter((p) => !cached.has(p)),
+    clearedPaths: [...cached].filter((p) => !current.has(p)),
+  };
 }
 
 /** Stable hash of the resolved policy — the block/warn severity routing that
@@ -166,7 +198,13 @@ export function writeVerdict(
   try {
     const sig = workingTreeSignature(cwd);
     if (!sig) return;
-    const entry: CachedVerdict = { ...fields, signature: sig, policyHash: policyHash(policy) };
+    const paths = treeStatusPaths(cwd);
+    const entry: CachedVerdict = {
+      ...fields,
+      signature: sig,
+      policyHash: policyHash(policy),
+      ...(paths !== null ? { treePaths: paths } : {}),
+    };
     const abs = path.join(cwd, CACHE_REL);
     fs.mkdirSync(path.dirname(abs), { recursive: true });
     fs.writeFileSync(abs, JSON.stringify(entry, null, 2) + '\n', 'utf8');

--- a/src/gate-wave.ts
+++ b/src/gate-wave.ts
@@ -22,6 +22,7 @@ import type { WireFlow, WireVerdictCheck, WireVerdictDoc } from '@vyuhlabs/dxkit
 import { evaluateWaveGate, type WaveGateResult } from './analyzers/flow/wave';
 import { gatherFlowModel } from './analyzers/flow/gather';
 import { readFlowConfig } from './analyzers/flow/config';
+import { readDeclaredSurface } from './analyzers/flow/declared-surface';
 import type { RepoFlowModel } from './analyzers/flow/model';
 import { describeBrokenIntegration } from './analyzers/flow/gate';
 import { VERSION } from './constants';
@@ -50,6 +51,20 @@ export interface WaveCommandOutcome {
   /** Flow documents that could not be parsed — disclosed, never silent. */
   readonly malformedFlowDocs: ReadonlyArray<{ readonly file: string; readonly error: string }>;
   readonly flowCount: number;
+  /** Present when a DECLARED --flows dir did not resolve (#307): the run
+   *  refused (`cannot_gate`, exit 2) before gating anything — a gate whose
+   *  job is refusing to certify what it cannot see must not render a
+   *  verdict with zero flows evaluated when flows were declared. */
+  readonly flowsRefusal?: { readonly reason: string; readonly remedy: string };
+  /** Members that DECLARED a served surface (#308): route counts joined
+   *  into the mesh (asserted, not observed) + any malformed entries —
+   *  disclosed so a declared mesh never reads as an extracted one. Empty
+   *  when no member carries a dxkit-surface.json. */
+  readonly declaredSurfaces?: ReadonlyArray<{
+    readonly member: string;
+    readonly routes: number;
+    readonly malformed: readonly string[];
+  }>;
 }
 
 /** Read every declared flow from the `--flows` directory. Accepts a
@@ -105,6 +120,14 @@ export function discoverMembers(dir: string, flowsDir?: string): string[] {
     .sort();
 }
 
+function isDirectory(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 /** Wave URL semantics: an absolute URL's host joins the mesh namespace. */
 function stripAbsoluteHost(rawUrl: string): string | null {
   const m = rawUrl.match(/^https?:\/\/[^/]+(\/.*)?$/i);
@@ -135,6 +158,41 @@ export async function runWaveCommand(
   const root = path.resolve(dir);
   const flowsDir =
     options.flowsDir !== undefined ? path.resolve(root, options.flowsDir) : undefined;
+
+  // A DECLARED flows dir that does not resolve is a REFUSAL, not a skip
+  // (#307): the old behavior skipped the flows check with an ENOENT cause,
+  // gated the real flows directory as a member tree, and rendered a verdict
+  // with zero flows evaluated — a gate whose job is refusing to certify
+  // what it cannot see must not certify around its own declared inputs.
+  // Resolution is WORKSPACE-ROOT-relative (documented); the refusal names
+  // the cwd-relative near-miss when that is what happened.
+  if (flowsDir !== undefined && !isDirectory(flowsDir)) {
+    const cwdCandidate = path.resolve(process.cwd(), options.flowsDir!);
+    const nearMiss =
+      cwdCandidate !== flowsDir && isDirectory(cwdCandidate)
+        ? ` Note: "${options.flowsDir}" DOES exist relative to the current directory — ` +
+          `--flows resolves against the workspace root (${root}).`
+        : '';
+    return {
+      exitCode: 2,
+      verdict: 'cannot_gate',
+      members: [],
+      wave: evaluateWaveGate({ members: [], flows: [] }),
+      malformedFlowDocs: [
+        { file: flowsDir, error: 'declared flows directory not found or not a directory' },
+      ],
+      flowCount: 0,
+      flowsRefusal: {
+        reason:
+          `the declared --flows directory does not resolve: ${flowsDir} is not a ` +
+          `directory, so the declared flows cannot be evaluated.${nearMiss}`,
+        remedy:
+          'point --flows at a directory that exists under the workspace root ' +
+          '(paths resolve workspace-root-relative), or drop --flows to gate without declared flows',
+      },
+    };
+  }
+
   const memberNames = discoverMembers(root, flowsDir);
   if (memberNames.length === 0) {
     throw new Error(
@@ -165,6 +223,11 @@ export async function runWaveCommand(
   // prefixed with the member name so fingerprints are WORKSPACE-relative
   // (environment-independent AND member-unique — Rule 9).
   const waveMembers = [];
+  const declaredSurfaces: Array<{
+    member: string;
+    routes: number;
+    malformed: readonly string[];
+  }> = [];
   for (const name of memberNames) {
     const memberRoot = path.join(root, name);
     const config = readFlowConfig(memberRoot);
@@ -180,7 +243,23 @@ export async function runWaveCommand(
       relativeTo: memberRoot,
       rewriteUrl: stripAbsoluteHost,
     });
-    waveMembers.push({ name, model: prefixMemberFiles(name, model) });
+    // The DECLARED surface (#308): a member whose routes live in a DSL the
+    // extractor cannot parse joins the mesh via dxkit-surface.json — same
+    // normalizer, full no-route/dead-route/flow participation, labeled
+    // `declared-surface` and disclosed per member (asserted, not observed).
+    const surface = readDeclaredSurface(memberRoot);
+    const merged =
+      surface !== null && surface.routes.length > 0
+        ? { ...model, routes: [...model.routes, ...surface.routes] }
+        : model;
+    if (surface !== null) {
+      declaredSurfaces.push({
+        member: name,
+        routes: surface.routes.length,
+        malformed: surface.malformed,
+      });
+    }
+    waveMembers.push({ name, model: prefixMemberFiles(name, merged) });
   }
   const declared =
     flowsDir !== undefined ? readDeclaredFlows(flowsDir) : { flows: [], malformed: [] };
@@ -208,6 +287,7 @@ export async function runWaveCommand(
     wave,
     malformedFlowDocs: declared.malformed,
     flowCount: declared.flows.length,
+    declaredSurfaces,
   };
 }
 
@@ -223,6 +303,18 @@ export function renderWaveOutcome(outcome: WaveCommandOutcome, json: boolean): s
     }));
     for (const d of outcome.malformedFlowDocs) {
       checks.push({ id: `flows:${path.basename(d.file)}`, status: 'skipped', cause: d.error });
+    }
+    // Declared surfaces (#308): the wire says which members joined the mesh
+    // by ASSERTION and names every malformed entry.
+    for (const s of outcome.declaredSurfaces ?? []) {
+      checks.push({
+        id: `surface:${s.member}`,
+        status: s.malformed.length > 0 ? 'skipped' : 'passed',
+        cause:
+          s.malformed.length > 0
+            ? `declared surface has malformed entries: ${s.malformed.join('; ')}`
+            : `${s.routes} route(s) joined the mesh by DECLARATION (asserted, not extracted)`,
+      });
     }
     const doc: WireVerdictDoc = {
       schema: 'verdict.v1',
@@ -249,7 +341,11 @@ export function renderWaveOutcome(outcome: WaveCommandOutcome, json: boolean): s
         })),
         ...outcome.wave.flowFindings.map((f) => ({
           kind: 'broken-flow',
-          rule: 'flow-incomplete',
+          // The wire rule id matches the KIND and the wave-gating guide
+          // (#306): tooling written from the guide filters on `broken-flow`,
+          // and the first 4.4.0 emitter said `flow-incomplete` — a name no
+          // documentation ever promised.
+          rule: 'broken-flow',
           message: `${f.flowId}: ${f.missingSteps.map((s) => `${s.method} ${s.path}`).join(', ')} unresolved`,
           fingerprint: f.id,
           blocking: true,
@@ -260,6 +356,13 @@ export function renderWaveOutcome(outcome: WaveCommandOutcome, json: boolean): s
         ran: false,
         skippedWithCause: 'wave mode: per-member floors ride each member gate (see member checks)',
       },
+      ...(outcome.flowsRefusal !== undefined
+        ? {
+            refusals: [
+              { reason: outcome.flowsRefusal.reason, remedy: outcome.flowsRefusal.remedy },
+            ],
+          }
+        : {}),
       receipt: renderWaveOutcome({ ...outcome }, false),
       meta: {
         members: outcome.wave.members,
@@ -271,11 +374,23 @@ export function renderWaveOutcome(outcome: WaveCommandOutcome, json: boolean): s
   }
 
   const lines: string[] = ['Wave gate — estate composition', ''];
+  if (outcome.flowsRefusal !== undefined) {
+    lines.push(`CANNOT GATE — ${outcome.flowsRefusal.reason}`);
+    lines.push(`  remedy: ${outcome.flowsRefusal.remedy}`);
+    lines.push('', `Wave verdict: cannot_gate (exit ${outcome.exitCode})`);
+    return lines.join('\n');
+  }
   for (const m of outcome.wave.members) {
     lines.push(`  member ${m.name}: ${m.routes} route(s), ${m.calls} call(s)`);
   }
   for (const m of outcome.members) {
     lines.push(`  member ${m.name}: gate ${m.outcome.verdict} (exit ${m.outcome.exitCode})`);
+  }
+  for (const s of outcome.declaredSurfaces ?? []) {
+    lines.push(
+      `  member ${s.member}: +${s.routes} DECLARED route(s) (dxkit-surface.json — asserted, not extracted)`,
+    );
+    for (const bad of s.malformed) lines.push(`    ! ${bad}`);
   }
   if (outcome.wave.seamFindings.length > 0) {
     lines.push('', `Seam findings (${outcome.wave.seamFindings.length}):`);

--- a/src/languages/abap-bdef.ts
+++ b/src/languages/abap-bdef.ts
@@ -1,0 +1,133 @@
+/**
+ * The ABAP pack's `.bdef` STRUCTURAL floor (#309, 4.4.1 WP8.5).
+ *
+ * abaplint (the pack's syntax floor) has no BDL parser, so a truncated or
+ * prose-contaminated behavior definition passed the floor silently —
+ * reported live by an embedder gating LLM-generated RAP trees, with the
+ * failure classes ranked from what they actually catch downstream:
+ *
+ *   1. truncation mid-block (the dominant class): unbalanced `{ }`, or a
+ *      last statement with no terminator — including the sharp shape that
+ *      LOOKS complete (`define behavior` + braces present, block never
+ *      closes);
+ *   2. prose/markup leakage: markdown fences, `**bold**`, narration
+ *      sentences bleeding into the artifact;
+ *   3. header-shape absence: no `managed|unmanaged|abstract …
+ *      implementation in class` header, or no `define behavior for` at
+ *      all;
+ *   4. empty / whitespace-only files.
+ *
+ * Reported under the check's OWN label (`bdef.structure`, rendered as
+ * `floor.abap:bdef.structure`) — distinct from `abaplint-syntax`, so a
+ * verdict reader can tell "structurally plausible" from "parsed". When
+ * upstream abaplint grows BDL parsing, this check retires in its favor.
+ * Cross-artifact consistency (does the entity match a CDS view; do
+ * granted operations match consumers) is explicitly OUT of scope —
+ * contract-level verification a structural floor must not half-claim.
+ *
+ * DISCOVERY covers BOTH serialization conventions — plain `<name>.bdef`
+ * (honestly-named un-parsed trees) AND abapGit `<name>.bdef.asbdef` —
+ * because matching only one silently blinds the floor to the other (the
+ * WP6 abapGit-naming class, mirrored). Bias: false NEGATIVES only — a
+ * legal artifact must never be refused, so every rule is shallow and a
+ * doubtful line is accepted.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { walkPaths } from '../analyzers/tools/walk-paths';
+import type {
+  CorrectnessContext,
+  StructuralFinding,
+  StructureCheckResult,
+} from './capabilities/correctness';
+
+export const BDEF_STRUCTURE_LABEL = 'bdef.structure';
+
+/** Both serialization conventions (see module doc). `.asbdef` files are
+ *  found by extension; plain `.bdef` files by their own extension. */
+function discoverBdefFiles(cwd: string): string[] {
+  return walkPaths(cwd, { extensions: ['.bdef', '.asbdef'] }).filter(
+    (rel) => rel.endsWith('.bdef') || rel.endsWith('.bdef.asbdef'),
+  );
+}
+
+/** Strip line comments (`//`) and block comments; BDL string literals do
+ *  not span the shapes we check, so a plain scan suffices. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, '');
+}
+
+/** The first structural problem in one `.bdef` source, or null (plausible). */
+export function bdefStructuralProblem(source: string): string | null {
+  // Class 4: empty / whitespace-only.
+  if (source.trim() === '') return 'empty or whitespace-only behavior definition';
+
+  const stripped = stripComments(source);
+
+  // Class 2: prose/markup leakage — line-anchored, on NON-comment lines.
+  // Markdown shapes (fences / headings / bold) plus sentence-shaped lines
+  // (ending '.' or ':') — BDL statements end with ';', '{', '}', or continue
+  // bare; no legal line ends with '.' or ':'.
+  for (const rawLine of stripped.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '') continue;
+    if (/^(```|#|\*\*)/.test(line)) {
+      return `markup leaked into the artifact (line starts with "${line.slice(0, 3)}")`;
+    }
+    if (/[.:]$/.test(line) && /\s/.test(line)) {
+      return `prose leaked into the artifact ("${line.slice(0, 60)}${line.length > 60 ? '…' : ''}")`;
+    }
+  }
+
+  // Class 3: header shape — the implementation header (managed / unmanaged /
+  // abstract variants) and at least one `define behavior for`.
+  if (!/^\s*(managed|unmanaged|abstract)\b/m.test(stripped)) {
+    return 'no managed/unmanaged/abstract implementation header';
+  }
+  if (!/\bdefine\s+behavior\s+for\s+\S+/.test(stripped)) {
+    return 'no `define behavior for <entity>` statement';
+  }
+
+  // Class 1: truncation — unbalanced braces, or a final statement with no
+  // terminator (the sharp shape: block opened, never closed, last statement
+  // bare — looks complete to a "has define behavior + braces" check).
+  let braceBalance = 0;
+  for (const ch of stripped) {
+    if (ch === '{') braceBalance++;
+    else if (ch === '}') {
+      braceBalance--;
+      if (braceBalance < 0) return 'unbalanced braces (a `}` closes nothing)';
+    }
+  }
+  if (braceBalance > 0) return 'unbalanced braces (a `{` block never closes — truncated?)';
+  const lastMeaningful = stripped.trim().slice(-1);
+  if (lastMeaningful !== ';' && lastMeaningful !== '}') {
+    return `last statement has no terminator (ends "${stripped.trim().slice(-20)}") — truncated?`;
+  }
+
+  return null;
+}
+
+/** The pack's `structureCheck` implementation. Pure + read-only; `none`
+ *  when the tree carries no behavior definitions at all. */
+export function abapBdefStructureCheck(ctx: CorrectnessContext): StructureCheckResult {
+  const files = discoverBdefFiles(ctx.cwd);
+  if (files.length === 0) return { kind: 'none' };
+  const findings: StructuralFinding[] = [];
+  for (const rel of files) {
+    let source: string;
+    try {
+      source = fs.readFileSync(path.join(ctx.cwd, rel), 'utf8');
+    } catch {
+      // An unreadable artifact is not evidence of broken content — skip it
+      // (false-negative bias), the file-level walk already proved it exists.
+      continue;
+    }
+    const problem = bdefStructuralProblem(source);
+    if (problem !== null) findings.push({ file: rel, problem });
+  }
+  return findings.length === 0
+    ? { kind: 'clean', label: BDEF_STRUCTURE_LABEL, checkedFiles: files.length }
+    : { kind: 'broken', label: BDEF_STRUCTURE_LABEL, findings };
+}

--- a/src/languages/abap.ts
+++ b/src/languages/abap.ts
@@ -34,6 +34,7 @@ import { hashFirstConfig, toolVersionInput } from './capabilities/recall-inputs'
 import { run } from '../analyzers/tools/runner';
 import { readRepoFile } from './version-detect';
 import type { LanguageSupport } from './types';
+import { abapBdefStructureCheck } from './abap-bdef';
 import type { CapabilityProvider } from './capabilities/provider';
 import type { LintResult, SeverityCounts } from './capabilities/types';
 import type { RawLocatedFinding } from './capabilities/lint-gate';
@@ -188,6 +189,10 @@ export const abap: LanguageSupport = {
     affectedTests(_ctx) {
       return null;
     },
+    // The `.bdef` STRUCTURAL floor (#309): abaplint has no BDL parser, so
+    // behavior definitions get the plausibility tier — its own check id,
+    // never presented as "parsed". Retires when upstream parses BDL.
+    structureCheck: abapBdefStructureCheck,
   },
 
   lintGate: {

--- a/src/languages/capabilities/correctness.ts
+++ b/src/languages/capabilities/correctness.ts
@@ -88,6 +88,34 @@ export type ResolutionCheckResult =
   | { readonly kind: 'unresolved'; readonly unresolved: readonly UnresolvedImport[] }
   | { readonly kind: 'skipped'; readonly reason: string };
 
+/** One structurally broken artifact — identity is the FILE (a second
+ *  problem in the same file is the same broken artifact; a NEW broken
+ *  file on an already-red tree is a new finding). */
+export interface StructuralFinding {
+  readonly file: string;
+  readonly problem: string;
+}
+
+/**
+ * Result of a pack's optional STRUCTURE check (#309): the floor tier
+ * between "file exists" and "parses", for artifact classes NO parser
+ * covers (the ABAP pack's `.bdef` behavior definitions — abaplint has no
+ * BDL parser). `label` names the check's own id so a verdict reader can
+ * tell "structurally plausible" from "parsed"; when an upstream parser
+ * lands, the structural check retires in its favor. `none` = the tree
+ * carries no artifacts of the class (the check never ran, nothing is
+ * claimed).
+ */
+export type StructureCheckResult =
+  | { readonly kind: 'clean'; readonly label: string; readonly checkedFiles: number }
+  | {
+      readonly kind: 'broken';
+      readonly label: string;
+      readonly findings: readonly StructuralFinding[];
+    }
+  | { readonly kind: 'skipped'; readonly label: string; readonly reason: string }
+  | { readonly kind: 'none' };
+
 import type { ExecutionRequirement } from '../../execution';
 
 /**
@@ -123,6 +151,19 @@ export interface CorrectnessProvider {
    * runner treats a throw as a disclosed skip (fail-open).
    */
   resolutionCheck?(ctx: CorrectnessContext): ResolutionCheckResult;
+  /**
+   * OPTIONAL: verify artifacts of a class NO parser covers are at least
+   * STRUCTURALLY plausible (#309 — the `.bdef` class: generation cutoffs,
+   * prose/markup leakage, missing header shape, empty files all pass a
+   * parser-less floor silently). Pure, read-only, never spawns; discovery
+   * routes through the canonical walker; bias hard toward false NEGATIVES
+   * (a legal artifact must never be refused — shallow checks only). The
+   * runner treats a throw as a disclosed skip (fail-open). Distinct check
+   * label so "structurally plausible" is never presented as "parsed";
+   * cross-artifact consistency is explicitly OUT of scope (contract-level
+   * verification, not syntax).
+   */
+  structureCheck?(ctx: CorrectnessContext): StructureCheckResult;
   /**
    * What the floor NEEDS from the environment that runs it (CLAUDE.md Rule 20):
    * host OS, ambient toolchains, whether it builds the project, how its target

--- a/src/loop/gate-cache.ts
+++ b/src/loop/gate-cache.ts
@@ -95,6 +95,25 @@ function stripDxkitOutputs(status: string): string {
     .join('\n');
 }
 
+/**
+ * The PATHS the working tree currently differs on (dirty tracked +
+ * untracked, dxkit outputs stripped) — the same view the signature hashes,
+ * as a nameable list. Consumed by the verdict cache's mismatch diagnostic
+ * (#282): a same-tree refusal that cannot say WHICH paths perturbed the
+ * signature turns a 30-second diagnosis into a workflow autopsy. Null when
+ * unreadable (not a git repo).
+ */
+export function treeStatusPaths(repoDir: string): string[] | null {
+  const head = gitCapture(repoDir, 'rev-parse HEAD').trim();
+  if (!head) return null;
+  const status = stripDxkitOutputs(gitCapture(repoDir, 'status --porcelain=v1 -uall'));
+  return status
+    .split('\n')
+    .map((line) => line.slice(3).trim())
+    .filter(Boolean)
+    .sort();
+}
+
 export function workingTreeSignature(repoDir: string): string | null {
   const head = gitCapture(repoDir, 'rev-parse HEAD').trim();
   if (!head) return null; // not a git repo / no commit → never cache

--- a/test/abap-bdef-structure.test.ts
+++ b/test/abap-bdef-structure.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  BDEF_STRUCTURE_LABEL,
+  abapBdefStructureCheck,
+  bdefStructuralProblem,
+} from '../src/languages/abap-bdef';
+import { runCorrectnessFloor } from '../src/analyzers/correctness/run';
+import { getLanguage } from '../src/languages';
+
+/**
+ * #309 — the `.bdef` structural floor, calibrated against the reporter's
+ * real-shaped samples (invented names). The contract: the four broken-file
+ * classes REFUSE; every legal line (including `//` comments and blanks)
+ * is accepted; discovery covers BOTH serialization conventions; and the
+ * check reports under its OWN label — "structurally plausible", never
+ * "parsed".
+ */
+
+const LEGAL = `managed implementation in class zbp_i_order unique;
+strict ( 2 );
+
+// draft is out of scope for this entity
+define behavior for zi_order alias Order
+persistent table zorder
+lock master
+authorization master ( instance )
+{
+  create;
+  update;
+  delete;
+}
+`;
+
+/** Sample A — truncation mid-block (generation cutoff inside the braces). */
+const SAMPLE_A = `managed implementation in class zbp_i_order unique;
+strict ( 2 );
+
+define behavior for zi_order alias Order
+persistent table zorder
+lock master
+authorization master ( instance )
+{
+  create;
+  upd`;
+
+/** Sample B — truncation at the statement boundary: looks complete to a
+ *  naive "has define behavior + braces" check; the block never closes and
+ *  the last statement has no terminator. */
+const SAMPLE_B = `managed implementation in class zbp_i_orderitem unique;
+strict ( 2 );
+
+define behavior for zi_orderitem alias OrderItem
+persistent table zorderitem
+lock master
+authorization master ( instance )
+{
+  create;
+  update;
+  delete`;
+
+describe('bdefStructuralProblem — the four classes', () => {
+  it('a legal behavior definition (comments + blanks included) is PLAUSIBLE', () => {
+    expect(bdefStructuralProblem(LEGAL)).toBeNull();
+  });
+
+  it('class 1a (sample A): mid-block truncation → unbalanced braces', () => {
+    expect(bdefStructuralProblem(SAMPLE_A)).toContain('never closes');
+  });
+
+  it('class 1b (sample B): statement-boundary truncation — the sharp case', () => {
+    // A naive "contains define behavior + braces" check passes this one.
+    expect(bdefStructuralProblem(SAMPLE_B)).toContain('never closes');
+  });
+
+  it('class 2 (sample C): every leak line refused individually; legit neighbors accepted', () => {
+    // The reporter's calibration: the four leak shapes are the prose
+    // sentence, the two fences, and the bold note.
+    const leaks = [
+      'Here is the behavior definition for the order entity:',
+      '```abap',
+      '**Note:** the entity is draft-disabled for simplicity.',
+      'The rest of the implementation follows the same pattern.',
+    ];
+    for (const leak of leaks) {
+      const contaminated = LEGAL.replace('strict ( 2 );', `strict ( 2 );\n${leak}`);
+      expect(bdefStructuralProblem(contaminated), `leak line must refuse: ${leak}`).not.toBeNull();
+    }
+  });
+
+  it('class 3: balanced-but-not-a-behavior-definition → header shape named', () => {
+    expect(bdefStructuralProblem('define view { x; }')).toContain('implementation header');
+    expect(
+      bdefStructuralProblem('managed implementation in class zbp unique;\nstrict ( 2 );'),
+    ).toContain('define behavior for');
+  });
+
+  it('class 4: empty / whitespace-only', () => {
+    expect(bdefStructuralProblem('')).toContain('empty');
+    expect(bdefStructuralProblem('  \n\t\n')).toContain('empty');
+  });
+});
+
+describe('abapBdefStructureCheck — discovery + the runner seam', () => {
+  const dirs: string[] = [];
+  afterAll(() => {
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  });
+  function tree(files: Record<string, string>): string {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-bdef-'));
+    dirs.push(dir);
+    for (const [rel, content] of Object.entries(files)) {
+      mkdirSync(join(dir, rel, '..'), { recursive: true });
+      writeFileSync(join(dir, rel), content);
+    }
+    return dir;
+  }
+
+  it('discovers BOTH conventions — plain .bdef AND abapGit .bdef.asbdef (the mirrored silent-ignore pin)', () => {
+    const plainOnly = abapBdefStructureCheck({
+      cwd: tree({ 'code/bdef/zi_order.bdef': SAMPLE_A }),
+      changedFiles: [],
+      scope: 'full',
+    });
+    expect(plainOnly.kind).toBe('broken');
+    const abapGitOnly = abapBdefStructureCheck({
+      cwd: tree({ 'src/zi_order.bdef.asbdef': SAMPLE_B }),
+      changedFiles: [],
+      scope: 'full',
+    });
+    expect(abapGitOnly.kind).toBe('broken');
+  });
+
+  it('no behavior definitions at all → none (nothing ran, nothing claimed)', () => {
+    const res = abapBdefStructureCheck({
+      cwd: tree({ 'src/zcl_x.clas.abap': 'CLASS zcl_x DEFINITION. ENDCLASS.' }),
+      changedFiles: [],
+      scope: 'full',
+    });
+    expect(res.kind).toBe('none');
+  });
+
+  it('a clean tree reports its own label with the checked count', () => {
+    const res = abapBdefStructureCheck({
+      cwd: tree({ 'code/bdef/zi_order.bdef': LEGAL }),
+      changedFiles: [],
+      scope: 'full',
+    });
+    expect(res).toMatchObject({ kind: 'clean', label: BDEF_STRUCTURE_LABEL, checkedFiles: 1 });
+  });
+
+  it('the floor runner surfaces it as its own check with FILE-keyed findings', () => {
+    const cwd = tree({
+      'code/bdef/zi_order.bdef': SAMPLE_A,
+      'code/bdef/zi_item.bdef': LEGAL,
+    });
+    const abap = getLanguage('abap')!;
+    const floor = runCorrectnessFloor({ cwd, changedFiles: [], scope: 'full', packs: [abap] });
+    const check = floor.checks.find((c) => c.label === BDEF_STRUCTURE_LABEL);
+    expect(check).toBeDefined();
+    expect(check!.status).toBe('fail');
+    expect(check!.findings).toEqual(['code/bdef/zi_order.bdef']);
+    expect(floor.blocks).toBe(true);
+    // Structural honesty in the output: plausible, never parsed.
+    expect(check!.output).toContain('never "parsed"');
+  });
+});

--- a/test/comment-defer-sequence.test.ts
+++ b/test/comment-defer-sequence.test.ts
@@ -80,3 +80,82 @@ describe('comment-defer same-tree sequence (#282)', () => {
     expect(template).toContain('$RUNNER_TEMP/comment-defer.json');
   });
 });
+
+describe('the mismatch diagnostic names the perturbing paths (#282 residual)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-defer-diag-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 't@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: dir });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+    writeFileSync(join(dir, 'README.md'), '# repo\n');
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: dir });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function cacheVerdictNow(): Promise<void> {
+    const { writeVerdict } = await import('../src/baseline/verdict-cache');
+    const { DEFAULT_BROWNFIELD_POLICY } = await import('../src/baseline/policy');
+    writeVerdict(dir, DEFAULT_BROWNFIELD_POLICY, {
+      blocks: true,
+      warns: false,
+      blockingCount: 1,
+      unattributableCount: 0,
+      warningCount: 0,
+      markdown: '## dxkit signals',
+      ranAt: '2026-08-13T00:00:00.000Z',
+      blockingFindings: [{ fingerprint: 'aaaa000011112222', kind: 'dep-vuln', status: 'added' }],
+    });
+  }
+
+  it('a scratch file written after the check is NAMED in the miss explanation', async () => {
+    const { explainVerdictMiss } = await import('../src/baseline/verdict-cache');
+    await cacheVerdictNow();
+    expect(explainVerdictMiss(dir)).toBeNull(); // tree unchanged → no miss
+    writeFileSync(join(dir, 'guardrail-stderr.log'), 'noise\n');
+    const miss = explainVerdictMiss(dir)!;
+    expect(miss).not.toBeNull();
+    expect(miss.newPaths).toEqual(['guardrail-stderr.log']);
+    expect(miss.clearedPaths).toEqual([]);
+  });
+
+  it('the full lifecycle: check → scratch INSIDE the repo → defer refuses NAMING the path', async () => {
+    const { executeDefer } = await import('../src/allowlist/defer-core');
+    await cacheVerdictNow();
+    // The broken workflow sequence: a scratch file lands in the checkout
+    // between check and defer.
+    writeFileSync(join(dir, 'comment-defer.json'), '{}');
+    const result = executeDefer(dir, {
+      reason: 'advisory wave',
+      expires: '+7d',
+      fromLastCheck: true,
+      addedBy: 't@example.com',
+      mode: 'full',
+    });
+    expect(result.ok).toBe(false);
+    const message = result.ok ? '' : result.message;
+    expect(message).toContain('No cached guardrail verdict');
+    // The 30-second diagnosis: the perturbing path is NAMED, with the cause.
+    expect(message).toContain('comment-defer.json');
+    expect(message).toContain('write them outside the repo');
+  });
+
+  it('the fixed lifecycle: check → scratch OUTSIDE → defer succeeds', async () => {
+    const { executeDefer } = await import('../src/allowlist/defer-core');
+    await cacheVerdictNow();
+    const result = executeDefer(dir, {
+      reason: 'advisory wave',
+      expires: '+7d',
+      fromLastCheck: true,
+      addedBy: 't@example.com',
+      mode: 'full',
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/test/gate/wave.test.ts
+++ b/test/gate/wave.test.ts
@@ -184,27 +184,30 @@ describe('runWaveCommand — declared flows dir refusal (#307)', () => {
   it('names the cwd-relative near-miss when that is what happened (the guide-example asymmetry)', async () => {
     const { mkdtempSync, mkdirSync, rmSync } = await import('fs');
     const { tmpdir } = await import('os');
-    const { join, relative } = await import('path');
+    const { join } = await import('path');
     const { runWaveCommand } = await import('../../src/gate-wave');
     const base = mkdtempSync(join(tmpdir(), 'dxkit-wave-nearmiss-'));
-    // Deep nesting so the relative path's `..` arithmetic genuinely
-    // diverges between cwd-resolution and workspace-root-resolution.
-    const ws = join(base, 'deep', 'nested', 'workspace');
-    const elsewhere = mkdtempSync(join(tmpdir(), 'dxkit-wave-cwdflows-'));
+    const ws = join(base, 'workspace');
+    // The cwd is CONTROLLED (forks pool, chdir is safe): a bare relative
+    // path that exists under the current directory but not under the
+    // workspace root — the exact shape the issue reports. Deriving the
+    // divergence from `..` arithmetic instead is depth-coupled: it vanishes
+    // whenever cwd and the fixture workspace sit at the same depth (the CI
+    // runner's checkout is exactly as deep as the old fixture was).
+    const cwdDir = join(base, 'somewhere-else');
+    const prevCwd = process.cwd();
     try {
       mkdirSync(join(ws, 'svc-a'), { recursive: true });
-      mkdirSync(join(elsewhere, 'flows'), { recursive: true });
-      // A path that resolves under the CURRENT directory but not under the
-      // workspace root — the exact shape the issue reports.
-      const cwdRelative = relative(process.cwd(), join(elsewhere, 'flows'));
-      const outcome = await runWaveCommand(ws, { flowsDir: cwdRelative });
+      mkdirSync(join(cwdDir, 'declared-flows'), { recursive: true });
+      process.chdir(cwdDir);
+      const outcome = await runWaveCommand(ws, { flowsDir: 'declared-flows' });
       expect(outcome.verdict).toBe('cannot_gate');
       expect(outcome.flowsRefusal?.reason).toContain(
         'DOES exist relative to the current directory',
       );
     } finally {
+      process.chdir(prevCwd);
       rmSync(base, { recursive: true, force: true });
-      rmSync(elsewhere, { recursive: true, force: true });
     }
   });
 });

--- a/test/gate/wave.test.ts
+++ b/test/gate/wave.test.ts
@@ -150,3 +150,120 @@ describe('the wave surface readers', () => {
     }
   });
 });
+
+describe('runWaveCommand — declared flows dir refusal (#307)', () => {
+  it('a missing --flows dir is CANNOT GATE (exit 2) with the path named — never a skip, never a member', async () => {
+    const { mkdtempSync, mkdirSync, rmSync } = await import('fs');
+    const { tmpdir } = await import('os');
+    const { join } = await import('path');
+    const { runWaveCommand, renderWaveOutcome } = await import('../../src/gate-wave');
+    const ws = mkdtempSync(join(tmpdir(), 'dxkit-wave-refusal-'));
+    try {
+      mkdirSync(join(ws, 'svc-a'));
+      mkdirSync(join(ws, 'svc-b'));
+      const outcome = await runWaveCommand(ws, { flowsDir: 'no-such-flows' });
+      expect(outcome.verdict).toBe('cannot_gate');
+      expect(outcome.exitCode).toBe(2);
+      // The refusal happens BEFORE gating: no member was judged, so the
+      // flows-dir-as-member class cannot occur either.
+      expect(outcome.members).toHaveLength(0);
+      expect(outcome.flowsRefusal?.reason).toContain('no-such-flows');
+      expect(outcome.flowsRefusal?.remedy).toContain('workspace root');
+      const doc = JSON.parse(renderWaveOutcome(outcome, true)) as {
+        status: string;
+        refusals?: Array<{ reason: string; remedy?: string }>;
+      };
+      expect(doc.status).toBe('cannot_gate');
+      expect(doc.refusals?.[0].reason).toContain('does not resolve');
+      expect(renderWaveOutcome(outcome, false)).toContain('CANNOT GATE');
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('names the cwd-relative near-miss when that is what happened (the guide-example asymmetry)', async () => {
+    const { mkdtempSync, mkdirSync, rmSync } = await import('fs');
+    const { tmpdir } = await import('os');
+    const { join, relative } = await import('path');
+    const { runWaveCommand } = await import('../../src/gate-wave');
+    const base = mkdtempSync(join(tmpdir(), 'dxkit-wave-nearmiss-'));
+    // Deep nesting so the relative path's `..` arithmetic genuinely
+    // diverges between cwd-resolution and workspace-root-resolution.
+    const ws = join(base, 'deep', 'nested', 'workspace');
+    const elsewhere = mkdtempSync(join(tmpdir(), 'dxkit-wave-cwdflows-'));
+    try {
+      mkdirSync(join(ws, 'svc-a'), { recursive: true });
+      mkdirSync(join(elsewhere, 'flows'), { recursive: true });
+      // A path that resolves under the CURRENT directory but not under the
+      // workspace root — the exact shape the issue reports.
+      const cwdRelative = relative(process.cwd(), join(elsewhere, 'flows'));
+      const outcome = await runWaveCommand(ws, { flowsDir: cwdRelative });
+      expect(outcome.verdict).toBe('cannot_gate');
+      expect(outcome.flowsRefusal?.reason).toContain(
+        'DOES exist relative to the current directory',
+      );
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+      rmSync(elsewhere, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('declared served surface (#308)', () => {
+  it('dxkit-surface.json routes join the mesh via the one normalizer; malformed entries disclosed', async () => {
+    const { readDeclaredSurface } = await import('../../src/analyzers/flow/declared-surface');
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-surface-'));
+    try {
+      writeFileSync(
+        join(dir, 'dxkit-surface.json'),
+        JSON.stringify({
+          serves: ['GET /api/orders/:id', 'post /api/orders', 'ANY /health', 'garbage', 42],
+        }),
+      );
+      const surface = readDeclaredSurface(dir)!;
+      expect(surface.routes.map((r) => `${r.method} ${r.path}`)).toEqual([
+        'GET /api/orders/{var}', // the ONE normalizer folds params
+        'POST /api/orders', // method case-folded
+        'ANY /health',
+      ]);
+      expect(surface.routes.every((r) => r.via === 'declared-surface')).toBe(true);
+      expect(surface.malformed).toHaveLength(2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('no file → null (nothing inferred); unreadable file → disclosed, never silent', async () => {
+    const { readDeclaredSurface } = await import('../../src/analyzers/flow/declared-surface');
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-surface-none-'));
+    try {
+      expect(readDeclaredSurface(dir)).toBeNull();
+      writeFileSync(join(dir, 'dxkit-surface.json'), '{ nope');
+      const broken = readDeclaredSurface(dir)!;
+      expect(broken.routes).toHaveLength(0);
+      expect(broken.malformed).toHaveLength(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a declared surface resolves another member's calls in the wave mesh (the DSL-tree class)", () => {
+    const result = evaluateWaveGate({
+      members: [
+        // The DSL member: extraction sees nothing, the declaration serves.
+        {
+          name: 'dsl-svc',
+          model: model({
+            routes: [{ method: 'GET', path: '/api/orders', file: 'dxkit-surface.json' }],
+          }),
+        },
+        {
+          name: 'ui',
+          model: model({ calls: [{ method: 'GET', path: '/api/orders', file: 'ui/app.js' }] }),
+        },
+      ],
+    });
+    // The call resolves against the declared route — no false no-route block.
+    expect(result.seamFindings.filter((f) => f.reason === 'no-route')).toHaveLength(0);
+  });
+});

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -437,6 +437,26 @@ describe.each(LANGUAGES as LanguageSupport[])('language contract: $id', (lang) =
         ).toBeGreaterThan(0);
       }
     }
+    // The OPTIONAL structure check (#309, 4.4.1): same pure-computation
+    // contract as resolutionCheck — well-formed result, never a throw, a
+    // labeled check id whenever anything ran or was claimed (`none` is the
+    // only unlabeled arm: nothing ran, nothing is claimed).
+    if (c.structureCheck) {
+      const res = c.structureCheck(ctx);
+      expect(['clean', 'broken', 'skipped', 'none']).toContain(res.kind);
+      if (res.kind !== 'none') {
+        expect(
+          res.label.length,
+          `${lang.id}: a structure check must carry its own check label`,
+        ).toBeGreaterThan(0);
+      }
+      if (res.kind === 'skipped') {
+        expect(
+          res.reason.length,
+          `${lang.id}: a structure-check skip must disclose its reason`,
+        ).toBeGreaterThan(0);
+      }
+    }
   });
 
   // 4.2 (test-gap tooling-config exemption): a pack that declares


### PR DESCRIPTION
Into `release/4.4.1`. Closes #306, #307, #282, #308, #309 — the workspace/embedder batch.

## What

- **#306**: the wave's wire rule for a broken declared flow is `broken-flow` — matching the kind and the wave-gating guide (the 4.4.0 emitter said `flow-incomplete`, which no doc promised).
- **#307**: a declared `--flows` dir that doesn't resolve is a **refusal** (`cannot_gate`, exit 2) before anything is gated — path named, cwd-relative near-miss called out, never a silent skip or a flows-dir-gated-as-member. Resolution rule documented.
- **#282** (residual, closes it): the verdict cache records the dirty-path list; a same-tree defer refusal now **names the perturbing paths** with the scratch-file cause. Full lifecycle pinned in both directions.
- **#308**: `dxkit-surface.json` declared surfaces join the mesh through the one normalizer — full no-route/dead-route/flow participation, labeled + disclosed as **asserted, not observed**, malformed entries named. OpenAPI via per-member `flow.specs` documented as the richer path.
- **#309**: new optional pure `structureCheck` capability (mirrors `resolutionCheck`); the ABAP pack implements the `.bdef` structural floor per the reporter's ranked spec, under its own `bdef.structure` check id ("structurally plausible", never "parsed"; retires on upstream BDL parsing). Both filename conventions discovered (the mirrored silent-ignore pinned both ways); fixtures are the reporter's three calibration samples, including the sharp statement-boundary truncation.

## Verification

Suite 5673/5673 (unmasked, twice), all static gates + `typecheck:test` clean, self-guardrail PASSED exit 0, contract test extended for the new capability, 24 new tests across wave/defer/bdef surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)