### PR TITLE
fix(lanes): fit the App-token lifetime — re-mint before the task, clamp the wall clock (4.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,11 @@ silent skips, one code path per concept, disclosures on every verdict.
   billed bot seat and no long-lived PAT. Fully additive: the chain is
   App token, then `DXKIT_BOT_TOKEN`, then the workflow token, and
   existing PAT setups keep working unchanged. `doctor` reports which
-  tier a repo will use.
+  tier a repo will use. Because GitHub caps an installation token at
+  one hour, the remediate lane re-mints immediately before the task
+  step and clamps the agent's wall clock to 45 minutes on this tier
+  (disclosed in the envelope) so the landing push always fits inside
+  the token's lifetime; longer runs belong on the PAT tier.
 - **In-loop gate arming for agent lanes.** The remediation lane
   pre-trusts its own checkout (CI only), probes that the agent's
   Stop-gate wiring actually resolves, and the envelope now states

--- a/docs/commands/remediate.md
+++ b/docs/commands/remediate.md
@@ -150,7 +150,13 @@ token through one chain, best tier first:
    seat, the PAT-expiry class cannot recur, and lane PRs are attributed
    to the app's own bot identity, so a maintainer can approve them. A
    configured-but-broken app fails the mint step loudly rather than
-   silently degrading a tier.
+   silently degrading a tier. One lifetime fact to know: GitHub caps an
+   installation token at **one hour**, so the remediate lane re-mints
+   immediately before the task step (the hour starts at agent launch,
+   not at job start) and clamps the agent's wall-clock budget to 45
+   minutes on this tier — disclosed in the run's envelope — so the
+   landing push always fits inside the token. Runs that need a longer
+   wall clock should use the PAT tier.
 2. **`DXKIT_BOT_TOKEN`** (a PAT with repo scope): works today,
    attributed to the PAT's owner (who then cannot approve the lane's
    PRs), and expires on the PAT's schedule.

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -239,6 +239,33 @@ __DXKIT_CI_RUNTIME_SETUP__
           git config user.name "__DXKIT_BOT_NAME__"
           git config user.email "__DXKIT_BOT_EMAIL__"
 
+      # An App installation token is hard-capped at ONE HOUR by GitHub, and
+      # the first mint happened before checkout + toolchain install — so a
+      # long agent budget could outlive it and 401 the LANDING push after
+      # the full agent spend. Re-mint here so the token's lifetime starts
+      # at agent launch, not at job start; the CLI additionally clamps the
+      # agent budget on this tier so agent + verify + landing fit inside
+      # the fresh token (disclosed in the ledger, never silent).
+      - name: Re-mint the lane token before the task (App tier)
+        id: dxkit-app-token-task
+        if: ${{ vars.DXKIT_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DXKIT_APP_ID }}
+          private-key: ${{ secrets.DXKIT_APP_PRIVATE_KEY }}
+
+      # The checkout persisted the FIRST mint as the repo's git credential
+      # (that is what the landing `git push` authenticates with), so the
+      # fresh token must replace it — same extraheader shape
+      # actions/checkout writes.
+      - name: Refresh the landing credential (App tier)
+        if: ${{ vars.DXKIT_APP_ID != '' }}
+        env:
+          DXKIT_FRESH_TOKEN: ${{ steps.dxkit-app-token-task.outputs.token }}
+        run: |
+          AUTH=$(printf 'x-access-token:%s' "$DXKIT_FRESH_TOKEN" | base64 -w0)
+          git config http.https://github.com/.extraheader "AUTHORIZATION: basic $AUTH"
+
       # ONE task per job (this matrix row's own checkout): the CLI verifies
       # inside the frame, opens the task's standing PR, writes the ledger to
       # THIS job's step summary, streams per-phase log groups + heartbeats,
@@ -246,7 +273,11 @@ __DXKIT_CI_RUNTIME_SETUP__
       # per-task failure, visible on the run page without opening logs.
       - name: Run task ${{ matrix.task }}
         env:
-          GH_TOKEN: ${{ steps.dxkit-app-token.outputs.token || secrets.DXKIT_BOT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.dxkit-app-token-task.outputs.token || steps.dxkit-app-token.outputs.token || secrets.DXKIT_BOT_TOKEN || github.token }}
+          # The tier the run resolved (mirrors the Disclose step): 'app'
+          # tells the CLI the credential is a one-hour installation token,
+          # so it clamps the agent budget to fit landing inside it.
+          DXKIT_TOKEN_MODE: ${{ vars.DXKIT_APP_ID != '' && 'app' || (secrets.DXKIT_BOT_TOKEN != '' && 'pat' || 'workflow') }}
           # Dispatch-campaign inputs, transported via ENV only (the
           # comment-defer pattern — free text never touches a shell line).
           # Blank on scheduled runs; the CLI clamps budget overrides to the

--- a/src/remediate/budget-notes.ts
+++ b/src/remediate/budget-notes.ts
@@ -9,6 +9,45 @@
 import type { AgentDriver } from './driver';
 import type { RemediateBudget } from './config';
 
+/**
+ * The minutes ceiling on the GitHub App token tier. An App INSTALLATION
+ * token is hard-capped at ONE HOUR by GitHub with no longer-lived form,
+ * and the lane's landing push authenticates with it — so the agent run
+ * plus verify plus landing must fit inside the hour or the landing 401s
+ * AFTER the full agent spend (the late-delivery death class the
+ * delivery-preconditions preflight exists to kill, resurfacing at the
+ * credential layer). The workflow re-mints immediately before the task
+ * step, so the window starts at agent launch; 45 minutes leaves the
+ * verify + landing tail inside it. The PAT and workflow-token tiers are
+ * long-lived and never clamped.
+ */
+export const APP_TOKEN_SAFE_MINUTES = 45;
+
+/**
+ * Clamp the wall-clock budget to the credential's lifetime, disclosed
+ * like every other budget limitation — never silent. The tier arrives
+ * via `DXKIT_TOKEN_MODE` (set by the lane workflow's token resolution;
+ * absent on local runs, which use the developer's own ambient auth and
+ * are never clamped).
+ */
+export function clampBudgetToTokenLifetime(
+  budget: RemediateBudget,
+  env: Readonly<Record<string, string | undefined>>,
+): { budget: RemediateBudget; notes: readonly string[] } {
+  if (env.DXKIT_TOKEN_MODE !== 'app' || budget.maxMinutes <= APP_TOKEN_SAFE_MINUTES) {
+    return { budget, notes: [] };
+  }
+  return {
+    budget: { ...budget, maxMinutes: APP_TOKEN_SAFE_MINUTES },
+    notes: [
+      `maxMinutes ${budget.maxMinutes} clamped to ${APP_TOKEN_SAFE_MINUTES}: this lane pushes ` +
+        `with a GitHub App installation token, which GitHub hard-caps at one hour, and the ` +
+        `landing must fit inside it — a longer run would spend its full agent budget and then ` +
+        `fail to deliver. For longer runs use the DXKIT_BOT_TOKEN PAT tier or lower the budget.`,
+    ],
+  };
+}
+
 /** The per-driver unenforceable-cap disclosures for a budget. */
 export function unenforceableCapsFor(driver: AgentDriver, budget: RemediateBudget): string[] {
   const caps: string[] = [];

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -34,7 +34,7 @@ import { resolveDispatchedTask } from './dispatch';
 import { resumePromptNote } from './resume';
 import { realGit } from './git-ops';
 import { armInLoopGate, type InLoopGateStatus } from './agent-trust';
-import { unenforceableCapsFor } from './budget-notes';
+import { clampBudgetToTokenLifetime, unenforceableCapsFor } from './budget-notes';
 import { evaluateScoreHinge, healthHingeScores } from './score-hinge';
 import { salvageForTask } from './config';
 import type { AgentEnvelope, RemediateResult, RemediateRunOptions } from './outcome';
@@ -106,14 +106,18 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   }
 
   const choice = resolveModelSetting(driver, opts.config.agent.model, task.tier);
-  const budget = opts.config.agent.budget;
+  // The credential-lifetime clamp applies at the ONE budget read, so
+  // enforcement (the process timeout), the agent's prompt, and the
+  // envelope disclosure all see the same effective wall clock.
+  const lifetime = clampBudgetToTokenLifetime(opts.config.agent.budget, process.env);
+  const budget = lifetime.budget;
   // The ONE salvage resolver (config.ts): explicit policy wins; 'auto'
   // follows the task's declared completion shape. The CLI's land decision
   // reads the same function, so the note here and the landing agree.
   const effectiveSalvage = salvageForTask(opts.config, task);
   // Budget-envelope disclosures — the ONE phrasing, split to
   // `budget-notes.ts` at the large-file bar.
-  const unenforceableCaps = unenforceableCapsFor(driver, budget);
+  const unenforceableCaps = [...lifetime.notes, ...unenforceableCapsFor(driver, budget)];
 
   // Auth-path disclosure (driver-generic): a declared credential the runner
   // actually injected = billed API spend; none = the CLI's stored login

--- a/test/remediate/config-budgets.test.ts
+++ b/test/remediate/config-budgets.test.ts
@@ -16,6 +16,10 @@ import {
   DEFAULT_REMEDIATE_BUDGET,
   type RemediateConfig,
 } from '../../src/remediate/config';
+import {
+  APP_TOKEN_SAFE_MINUTES,
+  clampBudgetToTokenLifetime,
+} from '../../src/remediate/budget-notes';
 
 const dirs: string[] = [];
 afterEach(() => {
@@ -179,6 +183,37 @@ describe('salvageForTask — the one salvage resolver (task-shape defaults)', ()
     // IS a completion test.
     for (const t of REMEDIATE_TASKS) {
       if (t.skipWhenEntryFloorGreen) expect(t.completion).toBe('bounded');
+    }
+  });
+});
+
+describe('clampBudgetToTokenLifetime (the App-token 1h hard cap)', () => {
+  const base = { maxTurns: 80, maxMinutes: 90, maxUsd: 5 };
+
+  it('clamps the wall clock on the app tier and discloses the remedy', () => {
+    const { budget, notes } = clampBudgetToTokenLifetime(base, { DXKIT_TOKEN_MODE: 'app' });
+    expect(budget.maxMinutes).toBe(APP_TOKEN_SAFE_MINUTES);
+    // Only the wall clock moves — turns and spend are untouched.
+    expect(budget.maxTurns).toBe(base.maxTurns);
+    expect(budget.maxUsd).toBe(base.maxUsd);
+    expect(notes).toHaveLength(1);
+    // The disclosure names the cause and BOTH remedies (never silent).
+    expect(notes[0]).toContain('one hour');
+    expect(notes[0]).toContain('DXKIT_BOT_TOKEN');
+  });
+
+  it('a budget already inside the lifetime is untouched, no note', () => {
+    const small = { ...base, maxMinutes: 30 };
+    const { budget, notes } = clampBudgetToTokenLifetime(small, { DXKIT_TOKEN_MODE: 'app' });
+    expect(budget).toEqual(small);
+    expect(notes).toEqual([]);
+  });
+
+  it('long-lived tiers (pat, workflow) and local runs (env absent) are never clamped', () => {
+    for (const env of [{ DXKIT_TOKEN_MODE: 'pat' }, { DXKIT_TOKEN_MODE: 'workflow' }, {}]) {
+      const { budget, notes } = clampBudgetToTokenLifetime(base, env);
+      expect(budget).toEqual(base);
+      expect(notes).toEqual([]);
     }
   });
 });

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -331,6 +331,27 @@ describe('the budget envelope (runner-enforced, disclosed)', () => {
     expect(r.note).toContain('draft-pr');
   });
 
+  it('the App-tier token lifetime clamps the wall clock, disclosed in the envelope', async () => {
+    process.env.DXKIT_TOKEN_MODE = 'app';
+    try {
+      const driver = fakeDriver({});
+      const r = await runRemediateTask(
+        base(driver, {
+          config: {
+            ...config(),
+            agent: { ...config().agent, budget: { maxTurns: 80, maxMinutes: 90, maxUsd: 5 } },
+          },
+        }),
+      );
+      // The driver's enforced wall clock IS the clamped value — enforcement
+      // and disclosure read the same budget.
+      expect(driver.lastRun?.budget.maxMinutes).toBe(45);
+      expect(r.envelope!.unenforceableCaps.join(' ')).toContain('one hour');
+    } finally {
+      delete process.env.DXKIT_TOKEN_MODE;
+    }
+  });
+
   it('a driver that cannot enforce a cap yields a DISCLOSED limitation, never silence', async () => {
     const driver = fakeDriver({ costUsd: 99 }, { budgetSupport: { turns: 'none', cost: 'none' } });
     const r = await runRemediateTask(base(driver));

--- a/test/templates-lane-tokens.test.ts
+++ b/test/templates-lane-tokens.test.ts
@@ -111,4 +111,37 @@ describe('workflow-template token parity', () => {
       );
     }
   });
+
+  it('the remediate lane re-mints before the task and refreshes the landing credential (App-token 1h cap)', () => {
+    // App INSTALLATION tokens are hard-capped at one hour by GitHub. Only
+    // the remediate lane runs long enough to outlive one (an agent budget
+    // plus setup); dep-bump and baseline-refresh are minutes-long jobs and
+    // deliberately keep the single top-of-job mint.
+    const content = fs.readFileSync(path.join(WORKFLOWS, 'dxkit-remediate.yml'), 'utf8');
+    // A fresh mint gated on the same App variable, immediately before the
+    // task step — the hour starts at agent launch, not at job start.
+    expect(content).toContain('id: dxkit-app-token-task');
+    // The checkout persisted the FIRST mint as the git credential (what the
+    // landing push authenticates with); it must be REWRITTEN with the fresh
+    // token, in the same extraheader shape actions/checkout writes.
+    expect(content).toContain('http.https://github.com/.extraheader');
+    // The task step's gh credential prefers the fresh token, keeping the
+    // full four-tier fallback.
+    expect(content).toContain(
+      'steps.dxkit-app-token-task.outputs.token || steps.dxkit-app-token.outputs.token',
+    );
+    // The CLI learns the tier so it can clamp the wall clock to the token
+    // lifetime (disclosed in the envelope, never silent).
+    expect(content).toContain('DXKIT_TOKEN_MODE');
+    // Ordering: agent-CLI install → re-mint → credential refresh → task, so
+    // setup time cannot eat the token's hour.
+    const install = content.indexOf('Install the agent CLI');
+    const remint = content.indexOf('id: dxkit-app-token-task');
+    const refresh = content.indexOf('Refresh the landing credential');
+    const task = content.indexOf('Run task ${{ matrix.task }}');
+    expect(install).toBeGreaterThan(-1);
+    expect(remint).toBeGreaterThan(install);
+    expect(refresh).toBeGreaterThan(remint);
+    expect(task).toBeGreaterThan(refresh);
+  });
 });


### PR DESCRIPTION
Rides into the still-untagged 4.4.1 (tag after this merges).

GitHub hard-caps an App installation token at **one hour**. The remediate lane minted once at job start, checkout persisted that token as the landing credential, and the agent's minutes budget is deliberately unclamped — so a run past ~50 minutes of agent budget would spend everything and then 401 at the landing push. That is the late-delivery death class this release closes, resurfacing at the credential layer of its own new token tier.

## Fix

- **Workflow**: re-mint immediately before the task step and rewrite the persisted git credential with the fresh token; the task step's `GH_TOKEN` prefers it through the full fallback chain and exports `DXKIT_TOKEN_MODE`.
- **CLI**: `clampBudgetToTokenLifetime` clamps `maxMinutes` to 45 on the app tier at the one budget read, so enforcement, the agent prompt, and the envelope disclosure agree. The clamp note joins `unenforceableCaps` naming the cause and both remedies. PAT / workflow tiers and local runs are never clamped.

## Verification

Suite 5684/5684, all static gates, self-guardrail PASSED, template ordering + chain pinned in `templates-lane-tokens`, clamp pinned both directions in `config-budgets` + `run.test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)