### PR TITLE
fix(lanes): self-verifying landing credential + lane-owned in-loop gate — 4.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to `@vyuhlabs/dxkit` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.3] - 2026-08-14
+
+Two root fixes from the first live agent-lane run on 4.4.2. The run
+itself was an honest failure — every gap was disclosed in the envelope
+and the evidence artifact survived — but disclosed is not fixed:
+
+### Fixed
+
+- **The remediate lane's landing credential is now self-verifying.**
+  The 4.4.2 pre-task credential refresh could leave a second
+  Authorization value in another git config scope; git then sent two
+  Authorization headers and GitHub rejected the landing push with HTTP
+  400 ("Duplicate header") — after the full agent spend. The refresh
+  step now replaces the header across every scope, asserts exactly one
+  value remains, and PROVES the credential with a `git ls-remote`
+  inside the step — a broken landing credential now fails the run at
+  $0 setup, before any agent spawns, never at delivery.
+- **The in-loop Stop-gate is now the lane's own guarantee.** Arming
+  previously required the repo to carry a committed Stop hook
+  (`.claude/settings.json`) — so on any repo that never installed the
+  loop pack, every lane run was backstop-only by construction
+  (disclosed, but unfixable from the repo side). The lane now installs
+  the standard Stop-gate hook into the RUNNER's user-scope settings
+  when the checkout has none (CI only, merge-preserving, idempotent) —
+  deliberately never into the worktree, where the agent's work sweep
+  could carry it into the landed commit. The envelope names which
+  scope armed the gate.
+
+`vyuh-dxkit update` refreshes the remediate workflow; no baseline,
+policy, or wire-format changes.
+
 ## [4.4.2] - 2026-08-13
 
 The token-chain root fix, found within hours of 4.4.1 by rolling it out

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vyuhlabs/dxkit",
-      "version": "4.4.2",
+      "version": "4.4.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyuhlabs/dxkit",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "The change-safety layer for AI coding agents: structural context before the edit, a deterministic stop-gate that blocks net-new detector-backed regressions, and autonomous remediation lanes whose work lands only through that same gate. No model in the verdict.",
   "license": "MIT",
   "author": "Vyuh Labs",

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -226,15 +226,29 @@ __DXKIT_CI_RUNTIME_SETUP__
 
       # The checkout persisted the FIRST mint as the repo's git credential
       # (that is what the landing `git push` authenticates with), so the
-      # fresh token must replace it — same extraheader shape
-      # actions/checkout writes.
+      # fresh token must REPLACE it — across every config scope, because a
+      # leftover value in any scope makes git send TWO Authorization
+      # headers and GitHub rejects the push with HTTP 400 "Duplicate
+      # header" (the live class: the landing died AFTER the full agent
+      # spend). The step then PROVES the credential authenticates with an
+      # ls-remote — a broken credential must fail HERE, at $0, before any
+      # agent spawns; never at delivery.
       - name: Refresh the landing credential (App tier)
         if: ${{ vars.DXKIT_APP_ID != '' }}
         env:
           DXKIT_FRESH_TOKEN: ${{ steps.dxkit-app-token-task.outputs.token }}
         run: |
           AUTH=$(printf 'x-access-token:%s' "$DXKIT_FRESH_TOKEN" | base64 -w0)
-          git config http.https://github.com/.extraheader "AUTHORIZATION: basic $AUTH"
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --global --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $AUTH"
+          COUNT=$(git config --get-all http.https://github.com/.extraheader | wc -l)
+          if [ "$COUNT" != "1" ]; then
+            echo "::error title=landing credential::expected exactly 1 auth header config after refresh, found $COUNT (a duplicate would 400 the landing push)"
+            exit 1
+          fi
+          git ls-remote --heads origin >/dev/null
+          echo "landing credential verified (single auth header, ls-remote OK)"
 
       # ONE task per job (this matrix row's own checkout): the CLI verifies
       # inside the frame, opens the task's standing PR, writes the ledger to

--- a/src/remediate/agent-trust.ts
+++ b/src/remediate/agent-trust.ts
@@ -14,7 +14,10 @@
  * its first completion attempt in-session with the findings and turns left
  * to repair.
  *
- * Three duties, one module:
+ * Four duties, one module (the fourth added in 4.4.3 — the live class:
+ * a repo that never installed the loop pack has no committed Stop hook, so
+ * every lane run on it was backstop-only by construction; the gate is the
+ * LANE's requirement, so the lane installs it at runner scope itself):
  *
  * 1. PRE-TRUST (`preTrustAgentCheckout`): before spawning, the lane marks
  *    its own checkout trusted in the runner's `~/.claude.json`
@@ -43,6 +46,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { resolveDxkitCli } from '../self-invocation';
+import { STOP_HOOK_COMMAND, STOP_HOOK_TIMEOUT_SECONDS } from '../loop/scaffold';
 
 /** The envelope disclosure: was the in-loop Stop-gate actually wired? */
 export interface InLoopGateStatus {
@@ -109,11 +113,11 @@ export function checkoutTrusted(cwd: string, opts: AgentTrustOptions = {}): bool
   }
 }
 
-/** The committed Stop-hook commands in `.claude/settings.json`, or null when
- *  the file/hook is absent or unparseable. */
-function stopHookCommands(cwd: string): string[] | null {
+/** The Stop-hook commands declared in one settings file, or null when the
+ *  file/hook is absent or unparseable. */
+function stopHookCommandsIn(settingsPath: string): string[] | null {
   try {
-    const raw = fs.readFileSync(path.join(cwd, '.claude', 'settings.json'), 'utf8');
+    const raw = fs.readFileSync(settingsPath, 'utf8');
     const doc = JSON.parse(raw) as {
       hooks?: { Stop?: Array<{ hooks?: Array<{ command?: unknown }> }> };
     };
@@ -127,6 +131,82 @@ function stopHookCommands(cwd: string): string[] | null {
   }
 }
 
+/** Where the agent CLI reads Stop hooks for a spawn in `cwd`: the checkout's
+ *  committed settings AND the runner's user-scope settings (both merge at
+ *  runtime). Returns the commands plus which scope supplied them. */
+function stopHookCommands(
+  cwd: string,
+  opts: AgentTrustOptions = {},
+): { commands: string[]; scope: 'project' | 'runner' | 'both' } | null {
+  const home = opts.home ?? os.homedir();
+  const project = stopHookCommandsIn(path.join(cwd, '.claude', 'settings.json'));
+  const runner = stopHookCommandsIn(path.join(home, '.claude', 'settings.json'));
+  if (project && runner) return { commands: [...project, ...runner], scope: 'both' };
+  if (project) return { commands: project, scope: 'project' };
+  if (runner) return { commands: runner, scope: 'runner' };
+  return null;
+}
+
+/**
+ * The lane-owned arming half (4.4.3): when the CHECKOUT carries no Stop
+ * hook, install the standard dxkit Stop-gate into the RUNNER's user-scope
+ * `~/.claude/settings.json`. The in-loop gate is the LANE's requirement —
+ * the lane is the party spawning an agent that must be gated — so it must
+ * not depend on whether the repo opted into the loop pack (the live class:
+ * every lane run on a repo without committed loop hooks was silently
+ * backstop-only, disclosed but unfixable from the repo side).
+ *
+ * User scope deliberately, not the checkout: the runner sweeps the agent's
+ * uncommitted work into the landing/salvage commit, so a hook injected
+ * into the WORKTREE could leak into the landed PR. The runner's own home
+ * is ephemeral CI state, invisible to the landed diff, and merges into the
+ * spawned agent's settings exactly like a developer's user settings. CI
+ * runs only — a maintainer's local `~/.claude/settings.json` is theirs.
+ *
+ * Merge-preserving and idempotent, same discipline as the scaffold's
+ * project-settings writer; the ONE hook body (`STOP_HOOK_COMMAND`, Rule 2).
+ */
+export function ensureRunnerStopHook(
+  cwd: string,
+  opts: AgentTrustOptions = {},
+): { readonly applied: boolean; readonly reason?: string } {
+  const existing = stopHookCommands(cwd, opts);
+  if (existing !== null) return { applied: false, reason: 'a Stop hook is already declared' };
+  const home = opts.home ?? os.homedir();
+  const settingsPath = path.join(home, '.claude', 'settings.json');
+  try {
+    let doc: Record<string, unknown> = {};
+    if (fs.existsSync(settingsPath)) {
+      const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as unknown;
+      if (typeof parsed === 'object' && parsed !== null) doc = parsed as Record<string, unknown>;
+    }
+    const hooks =
+      typeof doc.hooks === 'object' && doc.hooks !== null
+        ? (doc.hooks as Record<string, unknown>)
+        : {};
+    const stop = Array.isArray(hooks.Stop) ? (hooks.Stop as unknown[]) : [];
+    doc.hooks = {
+      ...hooks,
+      Stop: [
+        ...stop,
+        {
+          hooks: [
+            { type: 'command', command: STOP_HOOK_COMMAND, timeout: STOP_HOOK_TIMEOUT_SECONDS },
+          ],
+        },
+      ],
+    };
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify(doc, null, 2) + '\n');
+    return { applied: true };
+  } catch (err) {
+    return {
+      applied: false,
+      reason: `could not write ${settingsPath}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
 /**
  * Positive-evidence probe: would the Stop-gate actually load for a spawn in
  * `cwd`? Claims `in-loop-gated` only when every verifiable link holds; the
@@ -134,15 +214,16 @@ function stopHookCommands(cwd: string): string[] | null {
  * label this exists to kill is "armed" without evidence.
  */
 export function probeStopGateWiring(cwd: string, opts: AgentTrustOptions = {}): InLoopGateStatus {
-  const commands = stopHookCommands(cwd);
-  if (commands === null) {
+  const declared = stopHookCommands(cwd, opts);
+  if (declared === null) {
     return {
       mode: 'backstop-only',
       reason:
-        'no Stop hook in the checkout’s .claude/settings.json — the loop cannot self-verify; ' +
-        'post-run verification is the gate',
+        'no Stop hook in the checkout’s .claude/settings.json or the runner’s user settings — ' +
+        'the loop cannot self-verify; post-run verification is the gate',
     };
   }
+  const commands = declared.commands;
   if (!checkoutTrusted(cwd, opts)) {
     return {
       mode: 'backstop-only',
@@ -168,7 +249,13 @@ export function probeStopGateWiring(cwd: string, opts: AgentTrustOptions = {}): 
   return {
     mode: 'in-loop-gated',
     reason:
-      'Stop hook declared in committed settings, workspace trusted, hook command resolves — ' +
+      `Stop hook declared (${
+        declared.scope === 'project'
+          ? 'committed settings'
+          : declared.scope === 'runner'
+            ? 'installed by the lane at runner scope'
+            : 'committed settings + runner scope'
+      }), workspace trusted, hook command resolves — ` +
       'stop attempts re-run the guardrail in-session (a max_turns kill still never reaches a ' +
       'stop attempt; the post-run frame remains the final word)',
   };
@@ -183,6 +270,13 @@ export function armInLoopGate(
   cwd: string,
   opts: AgentTrustOptions & { readonly ci: boolean },
 ): InLoopGateStatus {
-  if (opts.ci) preTrustAgentCheckout(cwd, opts);
+  if (opts.ci) {
+    preTrustAgentCheckout(cwd, opts);
+    // The gate is the lane's own guarantee (4.4.3): a repo that never
+    // installed the loop pack still gets an armed Stop-gate, via the
+    // runner's user-scope settings. A failed injection is not fatal here —
+    // the probe below then honestly reports backstop-only with the gap.
+    ensureRunnerStopHook(cwd, opts);
+  }
   return probeStopGateWiring(cwd, opts);
 }

--- a/test/remediate/agent-trust.test.ts
+++ b/test/remediate/agent-trust.test.ts
@@ -136,3 +136,68 @@ describe('armInLoopGate — the lane entry point', () => {
     expect(checkoutTrusted(checkout, { home })).toBe(false);
   });
 });
+
+describe('lane-owned arming (4.4.3) — the gate is the lane’s guarantee, not a repo opt-in', () => {
+  it('CI + no committed Stop hook → the lane installs it at runner scope and arms', () => {
+    // The live class: every lane run on a repo without the loop pack was
+    // backstop-only by construction, disclosed but unfixable repo-side.
+    installLocalCli();
+    const status = armInLoopGate(checkout, { home, ci: true });
+    expect(status.mode).toBe('in-loop-gated');
+    expect(status.reason).toContain('runner scope');
+    const runner = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf8')) as {
+      hooks: { Stop: Array<{ hooks: Array<{ command: string }> }> };
+    };
+    expect(runner.hooks.Stop).toHaveLength(1);
+    expect(runner.hooks.Stop[0].hooks[0].command).toContain('hook stop-gate');
+  });
+
+  it('idempotent: a second arming never duplicates the runner-scope hook', () => {
+    installLocalCli();
+    armInLoopGate(checkout, { home, ci: true });
+    armInLoopGate(checkout, { home, ci: true });
+    const runner = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf8')) as {
+      hooks: { Stop: unknown[] };
+    };
+    expect(runner.hooks.Stop).toHaveLength(1);
+  });
+
+  it('a committed Stop hook wins: nothing is installed at runner scope', () => {
+    writeStopHook();
+    installLocalCli();
+    const status = armInLoopGate(checkout, { home, ci: true });
+    expect(status.mode).toBe('in-loop-gated');
+    expect(status.reason).toContain('committed settings');
+    expect(() => readFileSync(join(home, '.claude', 'settings.json'), 'utf8')).toThrow();
+  });
+
+  it('existing runner-scope settings are merge-preserved, never clobbered', () => {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    writeFileSync(
+      join(home, '.claude', 'settings.json'),
+      JSON.stringify({ permissions: { allow: ['Bash(ls:*)'] }, hooks: { PreToolUse: [] } }),
+    );
+    installLocalCli();
+    armInLoopGate(checkout, { home, ci: true });
+    const runner = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf8')) as {
+      permissions: { allow: string[] };
+      hooks: { PreToolUse: unknown[]; Stop: unknown[] };
+    };
+    expect(runner.permissions.allow).toEqual(['Bash(ls:*)']);
+    expect(runner.hooks.PreToolUse).toEqual([]);
+    expect(runner.hooks.Stop).toHaveLength(1);
+  });
+
+  it('WORKTREE PURITY: arming writes nothing under the checkout — an injected hook must never leak into the landed commit via the work sweep', () => {
+    installLocalCli();
+    armInLoopGate(checkout, { home, ci: true });
+    expect(() => readFileSync(join(checkout, '.claude', 'settings.json'), 'utf8')).toThrow();
+  });
+
+  it('non-CI: no runner-scope installation either — backstop-only stays honest', () => {
+    installLocalCli();
+    const status = armInLoopGate(checkout, { home, ci: false });
+    expect(status.mode).toBe('backstop-only');
+    expect(() => readFileSync(join(home, '.claude', 'settings.json'), 'utf8')).toThrow();
+  });
+});

--- a/test/templates-lane-tokens.test.ts
+++ b/test/templates-lane-tokens.test.ts
@@ -265,9 +265,16 @@ describe('workflow-template token discipline', () => {
     // task step — the hour starts at agent launch, not at job start.
     expect(content).toContain('id: dxkit-app-token-task');
     // The checkout persisted the FIRST mint as the git credential (what the
-    // landing push authenticates with); it must be REWRITTEN with the fresh
-    // token, in the same extraheader shape actions/checkout writes.
+    // landing push authenticates with); it must be REPLACED across scopes —
+    // a leftover value in any scope makes git send two Authorization
+    // headers and GitHub 400s the push ("Duplicate header", the live
+    // class) — and then PROVEN with an ls-remote at $0, before any agent
+    // spend.
     expect(content).toContain('http.https://github.com/.extraheader');
+    expect(content).toContain('--unset-all http.https://github.com/.extraheader');
+    expect(content).toContain('git config --global --unset-all');
+    expect(content).toContain('git ls-remote --heads origin');
+    expect(content).toContain('expected exactly 1 auth header config');
     // The task step's gh credential prefers the fresh token (the _TASK
     // placeholder), and the CLI learns the tier so it can clamp the wall
     // clock to the token lifetime (disclosed, never silent).


### PR DESCRIPTION
Two root fixes from tonight's first live lane run on 4.4.2.

1. **Landing credential proves itself at $0.** The pre-task refresh could leave a duplicate Authorization value in another config scope; GitHub 400'd the landing push after the full agent spend. Now: unset across scopes, set once, assert the count, and `git ls-remote` inside the step — a broken credential fails before the agent spawns, never at delivery.
2. **The in-loop gate is the lane's own guarantee.** Arming depended on the repo's committed Stop hook, so repos without the loop pack were backstop-only on every run by construction. The lane now installs the canonical Stop-gate hook at RUNNER scope when the checkout has none (CI-only, merge-preserving, idempotent, never the worktree — worktree-purity pinned so the injected hook can never leak into a landed commit). The envelope names the arming scope.

Version 4.4.3 + changelog. Suite 5695/5695, all gates, self-guardrail PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)