### PR TITLE
feat(remediate): work-order model, planner, and plan surface (4.4.5 work-orders)

### DIFF
--- a/docs/commands/remediate.md
+++ b/docs/commands/remediate.md
@@ -20,7 +20,12 @@ vyuh-dxkit remediate configured [path] [--land pr] [--json]
 
 - `plan` shows, per enabled task, the task > tier > driver-native model
   resolution, the effective per-task budget, and the spend-ceiling-trimmed
-  matrix the managed workflow reads.
+  matrix the managed workflow reads. It also lists the planned WORK ORDERS
+  (`workOrders` in `--json`): the finite units the lane would dispatch, built
+  from the live entry floor, deferred advisories inside their window, and the
+  lint backlog, each with its class, tier (`recipe` where a registered recipe
+  matches, else `agent`), derived budget, and done criterion. Findings no
+  class can take are listed under `undispatchable` with the reason.
 - `--task <id>` runs one task. With `--land pr` a `verified` outcome (or a
   `budget-exhausted` one under the `draft-pr` salvage policy) pushes the
   standing branch `dxkit/remediate-<task>` and opens or updates its PR.

--- a/docs/commands/remediate.md
+++ b/docs/commands/remediate.md
@@ -13,7 +13,7 @@ Work lands only as a PR carrying the verification ledger.
 ## Usage
 
 ```bash
-vyuh-dxkit remediate plan [path] [--json]              # dry-run: no key, no spend
+vyuh-dxkit remediate plan [path] [--json] [--with-floor]  # dry-run: no key, no spend
 vyuh-dxkit remediate [path] --task <id> [--land pr] [--json]
 vyuh-dxkit remediate configured [path] [--land pr] [--json]
 ```
@@ -21,11 +21,15 @@ vyuh-dxkit remediate configured [path] [--land pr] [--json]
 - `plan` shows, per enabled task, the task > tier > driver-native model
   resolution, the effective per-task budget, and the spend-ceiling-trimmed
   matrix the managed workflow reads. It also lists the planned WORK ORDERS
-  (`workOrders` in `--json`): the finite units the lane would dispatch, built
-  from the live entry floor, deferred advisories inside their window, and the
-  lint backlog, each with its class, tier (`recipe` where a registered recipe
-  matches, else `agent`), derived budget, and done criterion. Findings no
-  class can take are listed under `undispatchable` with the reason.
+  (`workOrders` in `--json`): the finite units a later executor will
+  dispatch, built from the entry floor, deferred advisories inside their
+  window (joined to the live dependency scan), and the lint backlog, each
+  with its class, tier (`recipe` where a registered recipe matches, else
+  `agent`), derived budget, and done criterion. Findings no class can take
+  are listed under `undispatchable` with the reason. The floor is read from
+  the baseline's recorded envelope (or the loop snapshot) so the plan stays
+  cheap; `--with-floor` runs the live floor instead, and the output says
+  which source it used (`workOrderFloorSource`).
 - `--task <id>` runs one task. With `--land pr` a `verified` outcome (or a
   `budget-exhausted` one under the `draft-pr` salvage policy) pushes the
   standing branch `dxkit/remediate-<task>` and opens or updates its PR.

--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -52,6 +52,7 @@ stanzas).
 | `remediate.schedule`                | [#remediate-schedule](#remediate-schedule)               |
 | `remediate.taskBudgets`             | [#remediate-task-budgets](#remediate-task-budgets)       |
 | `remediate.tasks`                   | [#remediate-tasks](#remediate-tasks)                     |
+| `remediate.workOrders.maxSliceSize` | [#remediate-work-orders](#remediate-work-orders)         |
 | `reports.onMerge`                   | [#reports-on-merge](#reports-on-merge)                   |
 | `schema.mode`                       | [#schema-mode](#schema-mode)                             |
 

--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -619,3 +619,24 @@ worth continuing.
 [salvage](#remediate-salvage) to be `draft-pr` (the default for
 open-ended tasks under `auto`); a task whose salvage is `discard` has no
 branch to resume and starts fresh.
+
+## Remediate work orders
+
+**What it does.** `vyuh-dxkit remediate plan` cuts the finding sets dxkit
+already computes (the entry floor's failures, deferred advisories inside
+their window, the grandfathered lint backlog) into finite work orders and
+lists them with their class, tier, budget, and done criterion. Today this is
+a plan surface: the tasks still run their existing prompts. Task selection
+over orders (each task working only the orders of its classes) arrives with
+the executor unit, which consumes these same orders.
+
+**Per parameter.**
+
+- `maxSliceSize`: the largest number of findings one debt work order may
+  carry. Lint debt is cut by file, then by rule, into slices of at most this
+  size, and each slice's budget derives from its size. Symptom of too high:
+  orders whose derived budget hits the task cap. Symptom of too low: many
+  tiny orders, each paying the fixed cost of an agent turn-up.
+
+**Default and why.** `25`: a slice one agent session closes with headroom
+in the derived budget.

--- a/src/allowlist/file.ts
+++ b/src/allowlist/file.ts
@@ -373,6 +373,22 @@ export function isEntryActive(entry: AllowlistEntry, now: Date = new Date()): bo
 }
 
 /**
+ * The ACTIVE `deferred` entries, soonest expiry first: the findings a lane
+ * must work inside their window (they re-block on expiry). The ONE selector
+ * both `debt` and the remediation planner read, so the two surfaces cannot
+ * disagree about what is deferred.
+ */
+export function activeDeferredEntries(
+  file: AllowlistFile | null,
+  now: Date = new Date(),
+): AllowlistEntry[] {
+  return (file?.entries ?? [])
+    .filter((e) => e.category === 'deferred' && typeof e.expiresAt === 'string')
+    .filter((e) => isEntryActive(e, now))
+    .sort((a, b) => (a.expiresAt! < b.expiresAt! ? -1 : a.expiresAt! > b.expiresAt! ? 1 : 0));
+}
+
+/**
  * Days remaining until an ISO `YYYY-MM-DD` expiry date, counted in whole
  * UTC days from today. Negative means already expired by that many days.
  *

--- a/src/analyzers/correctness/pure-checks.ts
+++ b/src/analyzers/correctness/pure-checks.ts
@@ -84,6 +84,7 @@ export function runResolutionCheck(
         status: 'fail',
         output: lines.join('\n'),
         findings: [...new Set(res.unresolved.map((u) => u.specifier))],
+        unresolved: res.unresolved.map((u) => ({ specifier: u.specifier, file: u.file })),
         ...withDisclosures,
       };
     }

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -104,6 +104,11 @@ export interface CorrectnessCheckResult {
    *  npm peer conflict because CI's install retries under
    *  `--legacy-peer-deps`). Never present on a failure. */
   readonly note?: string;
+  /** The import-resolution check's structured `{ specifier, file }` pairs
+   *  (one per unresolved import, every importer the check saw). `findings`
+   *  is the identity projection of this; consumers that need the importing
+   *  file read THIS, never the prose in `output`. */
+  readonly unresolved?: readonly { readonly specifier: string; readonly file: string }[];
 }
 
 export interface CorrectnessFloorResult {

--- a/src/analyzers/correctness/surface-run.ts
+++ b/src/analyzers/correctness/surface-run.ts
@@ -58,7 +58,7 @@ import {
   readBaselineFile,
 } from '../../baseline/baseline-file';
 import { loadAnchorFromBranch } from '../../baseline/anchor';
-import { floorDebtToBaseChecks } from '../../baseline/floor-debt';
+import { failingFloorDebt, floorDebtToBaseChecks } from '../../baseline/floor-debt';
 import { readPolicySection } from '../../baseline/policy-text';
 
 /** The surfaces this runner serves (the loop-stop surface has its own runner). */
@@ -283,9 +283,11 @@ function loadFloorDebtEvidence(cwd: string): PrePushDebtEvidence | null {
     if (!file) return null;
     const debt = readBaselineFile(file).floorDebt;
     if (!debt) return null;
-    const rows = floorDebtToBaseChecks(debt)
-      .filter((c) => c.status === 'fail')
-      .map((c) => ({ pack: c.pack, label: c.label, status: 'fail' as const }));
+    const rows = failingFloorDebt({ checks: floorDebtToBaseChecks(debt) }).map((c) => ({
+      pack: c.pack,
+      label: c.label,
+      status: 'fail' as const,
+    }));
     if (rows.length === 0) return null;
     return {
       rows,

--- a/src/analyzers/correctness/surface-run.ts
+++ b/src/analyzers/correctness/surface-run.ts
@@ -58,6 +58,7 @@ import {
   readBaselineFile,
 } from '../../baseline/baseline-file';
 import { loadAnchorFromBranch } from '../../baseline/anchor';
+import { floorDebtToBaseChecks } from '../../baseline/floor-debt';
 import { readPolicySection } from '../../baseline/policy-text';
 
 /** The surfaces this runner serves (the loop-stop surface has its own runner). */
@@ -282,7 +283,7 @@ function loadFloorDebtEvidence(cwd: string): PrePushDebtEvidence | null {
     if (!file) return null;
     const debt = readBaselineFile(file).floorDebt;
     if (!debt) return null;
-    const rows = debt.checks
+    const rows = floorDebtToBaseChecks(debt)
       .filter((c) => c.status === 'fail')
       .map((c) => ({ pack: c.pack, label: c.label, status: 'fail' as const }));
     if (rows.length === 0) return null;

--- a/src/analyzers/security/gather.ts
+++ b/src/analyzers/security/gather.ts
@@ -26,7 +26,7 @@ import { walkSourceFiles, commentSyntaxFor, isCommentLine } from '../tools/walk-
 import * as path from 'path';
 import { SecurityFinding, DepVulnSummary, Severity } from './types';
 import { buildSecurityAggregate, type SecurityAggregate } from './aggregator';
-import { discoverNestedDepRoots, mergeDepVulnOutcomes } from './nested-dep-roots';
+import { discoverPackDepRoots, mergeDepVulnOutcomes } from './nested-dep-roots';
 import { loadAllowlist } from '../../allowlist/file';
 import { gatherInlineAllowlistAnnotations } from '../../allowlist/gather';
 import { defaultDispatcher } from '../dispatcher';
@@ -356,9 +356,8 @@ export async function gatherPackDepVulnsAcrossRoots(
   opts: DepVulnGatherOptions | undefined,
 ): Promise<DepVulnGatherOutcome> {
   const root = await gatherOutcomeWithDeadline(pack, cwd, opts, '');
-  const patterns = pack.capabilities!.depVulns!.lockfilePatterns ?? [];
-  if (patterns.length === 0) return root;
-  const discovery = discoverNestedDepRoots(cwd, patterns);
+  if ((pack.capabilities!.depVulns!.lockfilePatterns ?? []).length === 0) return root;
+  const discovery = discoverPackDepRoots(cwd, pack);
   if (discovery.roots.length === 0) return root;
   if (discovery.dropped.length > 0) {
     process.stderr.write(

--- a/src/analyzers/security/nested-dep-roots.ts
+++ b/src/analyzers/security/nested-dep-roots.ts
@@ -40,6 +40,23 @@ export interface NestedRootDiscovery {
 }
 
 /**
+ * ONE pack's independent dependency roots, derived from its declared
+ * `lockfilePatterns` (Rule 6). THE derivation both the dep audit
+ * (`gatherPackDepVulnsAcrossRoots`) and the work-order gather read, so the
+ * two can never disagree about which sub-projects independently resolve.
+ */
+export function discoverPackDepRoots(
+  cwd: string,
+  pack: {
+    readonly capabilities?: {
+      readonly depVulns?: { readonly lockfilePatterns?: readonly string[] };
+    };
+  },
+): NestedRootDiscovery {
+  return discoverNestedDepRoots(cwd, [...(pack.capabilities?.depVulns?.lockfilePatterns ?? [])]);
+}
+
+/**
  * Directories below `cwd` (never the root itself — the root audit already
  * runs) containing one of the pack's independent-resolution lockfiles.
  * Exclusion-aware and deterministic (sorted by path, cap applied after).

--- a/src/baseline/floor-debt.ts
+++ b/src/baseline/floor-debt.ts
@@ -26,6 +26,7 @@
  * cannot hang on a pathological suite; a check that exceeds it records
  * honestly as `skipped-timeout`, never as pass or fail.
  */
+import type { FloorBaseCheck } from '../analyzers/correctness/attribution';
 import { execFileSync } from 'child_process';
 import { detectActiveLanguages } from '../languages';
 import type { LanguageSupport } from '../languages/types';
@@ -62,6 +63,19 @@ export interface FloorDebt {
   readonly capturedAtCommit: string | null;
   readonly capturedAt: string;
   readonly checks: ReadonlyArray<FloorDebtCheck>;
+}
+
+/** The ONE projection of a committed floor envelope onto the attribution
+ *  comparator's base-check shape. The envelope records check status only
+ *  (no finding-level identities), so the comparator works at CHECK precision
+ *  and says so. Every consumer that attributes a floor against the baseline
+ *  (the pre-push surface, the remediation planner) reads this. */
+export function floorDebtToBaseChecks(debt: FloorDebt): FloorBaseCheck[] {
+  return debt.checks.map((c) => ({
+    pack: c.pack,
+    label: c.label,
+    status: c.status === 'pass' ? 'pass' : c.status === 'fail' ? 'fail' : 'skipped',
+  }));
 }
 
 /** The failing subset — the debt itself. Generic over the check shape so

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -252,6 +252,11 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
       '(needs an effective draft-pr salvage; capped attempts)',
     anchor: 'remediate-resume',
   },
+  {
+    path: 'remediate.workOrders.maxSliceSize',
+    summary: 'largest number of findings one debt work order may carry (default 25)',
+    anchor: 'remediate-work-orders',
+  },
 ];
 
 const paramByPath = new Map(POLICY_PARAMS.map((p) => [p.path, p]));

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -356,6 +356,15 @@ export function buildPolicySchema(version: string): Schema {
           },
           maxSpendPerRun: { type: 'number', description: desc('remediate.maxSpendPerRun') },
           maxDispatchBudget: { type: 'number', description: desc('remediate.maxDispatchBudget') },
+          workOrders: obj(
+            {
+              maxSliceSize: {
+                type: 'number',
+                description: desc('remediate.workOrders.maxSliceSize'),
+              },
+            },
+            'Work-order planning: how the backlog is cut into finite, verifiable units.',
+          ),
           resume: boolProp('remediate.resume'),
         },
         'Agentic remediation: a scheduled agent inside the verified frame.',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -398,6 +398,7 @@ export async function run(argv: string[]): Promise<void> {
       'no-scan': { type: 'boolean', default: false },
       rescan: { type: 'boolean', default: false },
       json: { type: 'boolean', default: false },
+      'with-floor': { type: 'boolean', default: false },
       since: { type: 'string' },
       // `policy get <path> --default <v>` — fallback value for scripts.
       default: { type: 'string' },
@@ -3171,7 +3172,10 @@ export async function run(argv: string[]): Promise<void> {
       const { runRemediate, runRemediatePlan, runRemediateConfigured, remediateUsage } =
         await import('./remediate/cli');
       if (positionals[1] === 'plan') {
-        runRemediatePlan(resolveRepoPath(positionals[2]), { json: !!values.json });
+        await runRemediatePlan(resolveRepoPath(positionals[2]), {
+          json: !!values.json,
+          withFloor: !!values['with-floor'],
+        });
         break;
       }
       if (positionals[1] === 'configured') {

--- a/src/debt-cli.ts
+++ b/src/debt-cli.ts
@@ -30,7 +30,7 @@ import * as logger from './logger';
 import { pathForBaseline, readBaselineFile, type BaselineFile } from './baseline/baseline-file';
 import { captureFloorDebt, failingFloorDebt, type FloorDebt } from './baseline/floor-debt';
 import { checkKey } from './analyzers/correctness/attribution';
-import { daysUntilDate, tryLoadAllowlist } from './allowlist/file';
+import { activeDeferredEntries, daysUntilDate, tryLoadAllowlist } from './allowlist/file';
 import { KIND_DEFAULT_SEVERITY, describeEntryLocation } from './baseline/check';
 import type { BaselineEntry, FindingSeverity } from './baseline/types';
 
@@ -251,8 +251,7 @@ export function buildDebtReport(
   // something works the item during the window.
   const now = opts.now ?? new Date();
   const allowlist = tryLoadAllowlist(cwd);
-  const deferred: DebtDeferredEntry[] = (allowlist?.entries ?? [])
-    .filter((e) => e.category === 'deferred' && typeof e.expiresAt === 'string')
+  const deferred: DebtDeferredEntry[] = activeDeferredEntries(allowlist, now)
     .map((e) => ({
       fingerprint: e.fingerprint,
       kind: e.kind,

--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -700,6 +700,12 @@ export const php: LanguageSupport = {
     '[\'"]verify_peer[\'"][[:space:]]*=>[[:space:]]*(false|FALSE)',
   ],
 
+  provision(cwd) {
+    if (fs.existsSync(path.join(cwd, 'composer.lock')))
+      return { bin: 'composer', args: ['install'] };
+    return null;
+  },
+
   upgradeCommand(name, version) {
     return `composer require ${name}:^${version}`;
   },

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1762,6 +1762,16 @@ export const python: LanguageSupport = {
   // env-var convention in Django/Flask configs.
   tlsBypassPatterns: ['verify[[:space:]]*=[[:space:]]*False', 'VERIFY_SSL.*[Ff]alse'],
 
+  provision(cwd) {
+    // The ecosystem's own provision step, keyed on the artifact present.
+    if (fs.existsSync(path.join(cwd, 'poetry.lock'))) return { bin: 'poetry', args: ['install'] };
+    if (fs.existsSync(path.join(cwd, 'uv.lock'))) return { bin: 'uv', args: ['sync'] };
+    if (fs.existsSync(path.join(cwd, 'Pipfile.lock'))) return { bin: 'pipenv', args: ['install'] };
+    if (fs.existsSync(path.join(cwd, 'requirements.txt')))
+      return { bin: 'pip', args: ['install', '-r', 'requirements.txt'] };
+    return null;
+  },
+
   upgradeCommand(name, version) {
     return `pip install '${name}==${version}'`;
   },

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -1099,6 +1099,11 @@ export const ruby: LanguageSupport = {
     'verify_mode[[:space:]]*=[[:space:]]*.*VERIFY_NONE',
   ],
 
+  provision(cwd) {
+    if (fs.existsSync(path.join(cwd, 'Gemfile.lock'))) return { bin: 'bundle', args: ['install'] };
+    return null;
+  },
+
   upgradeCommand(name, version) {
     return `# Edit Gemfile: \`gem '${name}', '${version}'\`, then \`bundle install\``;
   },

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -422,6 +422,16 @@ export interface LanguageSupport {
   upgradeCommand?(name: string, version: string): string | null;
 
   /**
+   * OPTIONAL: the command that (re)provisions this ecosystem's dependency
+   * tree from its manifest + lockfile in `cwd` (`npm ci`, `pnpm install`).
+   * Consumed by the remediation frame as the ONE install a work order may
+   * run (the agent never installs itself). Returns null when the pack cannot
+   * name one for this repo; a consumer then discloses "no install command"
+   * rather than guessing another ecosystem's tool.
+   */
+  provision?(cwd: string): { readonly bin: string; readonly args: readonly string[] } | null;
+
+  /**
    * Per-stack architectural vocabulary + path conventions. Drives the
    * test-gap risk taxonomy, the Maintainability prose ("controllers"
    * vs "components" vs "Forms"), and the gate on the "Add API

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -19,7 +19,7 @@ import {
   gatherOsvScannerDepVulnsResult,
   mergeMaliciousOsvFindings,
 } from '../analyzers/tools/osv-scanner-deps';
-import { detectLockfile, detectPackageManager, lockfileSyncCheck, provisionArgv } from '../package-manager';
+import { detectLockfile, lockfileSyncCheck, provisionArgv } from '../package-manager';
 import { fileExists, run, runJSON } from '../analyzers/tools/runner';
 import { walkPaths } from '../analyzers/tools/walk-paths';
 import { installedNodeMajor, readRepoFile, repoFileExists } from './version-detect';
@@ -2863,7 +2863,11 @@ export const typescript: LanguageSupport = {
   },
 
   provision(cwd) {
-    const [bin, ...args] = provisionArgv(detectPackageManager(cwd));
+    // A lockfile-less repo has nothing `npm ci` (or a frozen install) can
+    // provision from: return null per the contract, disclosed downstream.
+    const lock = detectLockfile(cwd);
+    if (!lock) return null;
+    const [bin, ...args] = provisionArgv(lock.pm);
     return { bin, args };
   },
 

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -19,7 +19,7 @@ import {
   gatherOsvScannerDepVulnsResult,
   mergeMaliciousOsvFindings,
 } from '../analyzers/tools/osv-scanner-deps';
-import { detectLockfile, lockfileSyncCheck } from '../package-manager';
+import { detectLockfile, detectPackageManager, lockfileSyncCheck, provisionArgv } from '../package-manager';
 import { fileExists, run, runJSON } from '../analyzers/tools/runner';
 import { walkPaths } from '../analyzers/tools/walk-paths';
 import { installedNodeMajor, readRepoFile, repoFileExists } from './version-detect';
@@ -2860,6 +2860,11 @@ export const typescript: LanguageSupport = {
 
   upgradeCommand(name, version) {
     return `npm install ${name}@${version}`;
+  },
+
+  provision(cwd) {
+    const [bin, ...args] = provisionArgv(detectPackageManager(cwd));
+    return { bin, args };
   },
 
   // Path conventions span both backend Node frameworks (Express,

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -166,15 +166,21 @@ export function upgradeArgv(
 /** The command to (re)provision `node_modules` from the manifest + lockfile —
  *  the "your project-local tools aren't installed, run this" hint. */
 export function provisionCommand(pm: PackageManager): string {
+  return provisionArgv(pm).join(' ');
+}
+
+/** The same provision command as an argv (`[bin, ...args]`), for callers
+ *  that execFile it. `provisionCommand` is the display projection of this. */
+export function provisionArgv(pm: PackageManager): [string, ...string[]] {
   switch (pm) {
     case 'pnpm':
-      return 'pnpm install';
+      return ['pnpm', 'install'];
     case 'yarn':
-      return 'yarn install';
+      return ['yarn', 'install'];
     case 'bun':
-      return 'bun install';
+      return ['bun', 'install'];
     case 'npm':
-      return 'npm ci';
+      return ['npm', 'ci'];
   }
 }
 

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -16,7 +16,7 @@
  */
 import { readPolicySection } from '../baseline/policy-text';
 import { knownTaskIds, remediateTaskById, type RemediateTask, type RemediateTaskId } from './tasks';
-import { DEFAULT_MAX_SLICE_SIZE } from './work-orders/planner';
+import { DEFAULT_MAX_SLICE_SIZE } from './work-orders/shared';
 
 export interface RemediateBudget {
   readonly maxTurns: number;

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -16,6 +16,7 @@
  */
 import { readPolicySection } from '../baseline/policy-text';
 import { knownTaskIds, remediateTaskById, type RemediateTask, type RemediateTaskId } from './tasks';
+import { DEFAULT_MAX_SLICE_SIZE } from './work-orders/planner';
 
 export interface RemediateBudget {
   readonly maxTurns: number;
@@ -73,6 +74,12 @@ export interface RemediateConfig {
    *  partial can never grandfather its own breakage. Hard cap of
    *  MAX_RESUME_ATTEMPTS per branch (resume.ts). */
   readonly resume: boolean;
+  /** Work-order planning knobs (`remediate.workOrders`). */
+  readonly workOrders: {
+    /** Largest number of findings one debt slice may carry
+     *  (`remediate.workOrders.maxSliceSize`, default 25). */
+    readonly maxSliceSize: number;
+  };
 }
 
 /**
@@ -204,5 +211,11 @@ export function resolveRemediateConfig(cwd: string): RemediateConfig {
         ? raw.maxDispatchBudget
         : 0,
     resume: raw.resume === true,
+    workOrders: {
+      maxSliceSize: positiveNumber(
+        ((raw.workOrders ?? {}) as Record<string, unknown>).maxSliceSize,
+        DEFAULT_MAX_SLICE_SIZE,
+      ),
+    },
   };
 }

--- a/src/remediate/plan-cli.ts
+++ b/src/remediate/plan-cli.ts
@@ -11,9 +11,39 @@ import { AGENT_DRIVERS, driverById } from './registry';
 import { remediateTaskById } from './tasks';
 import { remediateBranchFor } from '../lanes/branches';
 import { describeDeliveryProbe, probeDeliveryPreconditions } from '../lanes/delivery-preconditions';
+import { planRepoWorkOrders, type GatherWorkOrderOptions } from './work-orders/gather';
+import { renderWorkOrderSummary } from './work-orders/render';
+import type { WorkOrderPlan } from './work-orders/types';
 
 export interface RemediatePlanOptions {
   readonly json?: boolean;
+  /** Injected for tests (a fake floor run, a fixed clock). */
+  readonly gather?: GatherWorkOrderOptions;
+}
+
+/** The plan surface's projection of one order: what a reader needs to see
+ *  where determinism applies and what each unit costs, without the full
+ *  evidence payload. */
+function projectWorkOrders(plan: WorkOrderPlan) {
+  return {
+    workOrders: plan.orders.map((o) => ({
+      id: o.id,
+      class: o.class,
+      tier: o.tier,
+      recipe: o.recipe ?? null,
+      findings: o.findings.length,
+      findingIds: o.findings.map((f) => f.id),
+      attribution: [...new Set(o.findings.map((f) => f.attribution))],
+      envelope: o.envelope,
+      budget: o.budget,
+      done: { verifier: o.done.verifier, command: o.done.command, absent: o.done.absentIds.length },
+      provenance: o.provenance,
+    })),
+    undispatchable: plan.undispatchable.map((u) => ({
+      reason: u.reason,
+      findings: u.findings.map((f) => ({ kind: f.kind, id: f.id })),
+    })),
+  };
 }
 
 /** `remediate plan` — the resolution chain, computed not narrated. */
@@ -49,6 +79,19 @@ export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): 
     0,
   );
 
+  // The work-order plan (remediate rethink, section 3A): the finite units the
+  // lane would dispatch, from the live entry floor + debt + deferrals via the
+  // ONE gather adapter. Fail-open: a gather failure is disclosed, never a
+  // crashed plan.
+  let plan: WorkOrderPlan | null = null;
+  let planError: string | null = null;
+  try {
+    plan = planRepoWorkOrders(cwd, config, opts.gather);
+  } catch (err) {
+    planError = err instanceof Error ? err.message : String(err);
+  }
+  const projected = plan ? projectWorkOrders(plan) : { workOrders: [], undispatchable: [] };
+
   if (opts.json) {
     process.stdout.write(
       JSON.stringify(
@@ -74,6 +117,11 @@ export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): 
            *  budgetSupport. */
           projectedMaxSpendUsd,
           unknownTasks: config.unknownTasks,
+          /** The planned work orders (tier / recipe / budget / done summary)
+           *  and the findings no class could take, with the reason. */
+          workOrders: projected.workOrders,
+          undispatchable: projected.undispatchable,
+          workOrderPlanError: planError,
           /** Per-dimension driver capability: 'enforced' | 'reported' |
            *  'none'. A dimension below 'enforced' also appears in
            *  unenforceableCaps. */
@@ -149,6 +197,21 @@ export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): 
       `  spend ceiling ($${config.maxSpendPerRun}/run): ${ceiling.deferred.join(', ')} ` +
         'deferred to the next firing (disclosed, never dropped).',
     );
+  }
+
+  if (planError) {
+    logger.warn(`work orders: could not plan (${planError})`);
+  } else if (plan) {
+    logger.info(
+      `work orders: ${plan.orders.length} planned` +
+        (plan.undispatchable.length > 0
+          ? `, ${plan.undispatchable.reduce((n, u) => n + u.findings.length, 0)} finding(s) undispatchable`
+          : ''),
+    );
+    for (const order of plan.orders) logger.info(`  ${renderWorkOrderSummary(order)}`);
+    for (const u of plan.undispatchable) {
+      logger.dim(`  undispatchable (${u.findings.length}): ${u.reason}`);
+    }
   }
 
   // The delivery line (#287): can the lanes actually LAND here? The ONE

--- a/src/remediate/plan-cli.ts
+++ b/src/remediate/plan-cli.ts
@@ -11,14 +11,35 @@ import { AGENT_DRIVERS, driverById } from './registry';
 import { remediateTaskById } from './tasks';
 import { remediateBranchFor } from '../lanes/branches';
 import { describeDeliveryProbe, probeDeliveryPreconditions } from '../lanes/delivery-preconditions';
-import { planRepoWorkOrders, type GatherWorkOrderOptions } from './work-orders/gather';
+import {
+  planRepoWorkOrders,
+  type FloorSource,
+  type GatherWorkOrderOptions,
+} from './work-orders/gather';
 import { renderWorkOrderSummary } from './work-orders/render';
 import type { WorkOrderPlan } from './work-orders/types';
 
 export interface RemediatePlanOptions {
   readonly json?: boolean;
+  /** Run the live correctness floor for the work-order plan (default: read
+   *  the baseline's recorded envelope, so the plan stays a $0 dry-run). */
+  readonly withFloor?: boolean;
   /** Injected for tests (a fake floor run, a fixed clock). */
   readonly gather?: GatherWorkOrderOptions;
+}
+
+/** Human phrasing of which floor source the work-order plan read. */
+function describeFloorSource(source: FloorSource): string {
+  switch (source) {
+    case 'live':
+      return 'live floor run (--with-floor)';
+    case 'baseline-envelope':
+      return "the baseline's recorded floor envelope (pass --with-floor to re-run it)";
+    case 'loop-snapshot':
+      return "the loop's floor snapshot (pass --with-floor to re-run it)";
+    case 'none':
+      return 'no floor source (no baseline envelope, no loop snapshot; pass --with-floor)';
+  }
 }
 
 /** The plan surface's projection of one order: what a reader needs to see
@@ -35,6 +56,7 @@ function projectWorkOrders(plan: WorkOrderPlan) {
       findingIds: o.findings.map((f) => f.id),
       attribution: [...new Set(o.findings.map((f) => f.attribution))],
       envelope: o.envelope,
+      install: o.constraints.install ?? null,
       budget: o.budget,
       done: { verifier: o.done.verifier, command: o.done.command, absent: o.done.absentIds.length },
       provenance: o.provenance,
@@ -47,7 +69,10 @@ function projectWorkOrders(plan: WorkOrderPlan) {
 }
 
 /** `remediate plan` — the resolution chain, computed not narrated. */
-export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): void {
+export async function runRemediatePlan(
+  cwd: string,
+  opts: RemediatePlanOptions = {},
+): Promise<void> {
   const config = resolveRemediateConfig(cwd);
   const driver = driverById(config.agent.driver);
 
@@ -84,9 +109,15 @@ export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): 
   // ONE gather adapter. Fail-open: a gather failure is disclosed, never a
   // crashed plan.
   let plan: WorkOrderPlan | null = null;
+  let floorSource: FloorSource | null = null;
   let planError: string | null = null;
   try {
-    plan = planRepoWorkOrders(cwd, config, opts.gather);
+    const gathered = await planRepoWorkOrders(cwd, config, {
+      ...(opts.withFloor ? { withFloor: true } : {}),
+      ...opts.gather,
+    });
+    plan = gathered.plan;
+    floorSource = gathered.floorSource;
   } catch (err) {
     planError = err instanceof Error ? err.message : String(err);
   }
@@ -121,6 +152,8 @@ export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): 
            *  and the findings no class could take, with the reason. */
           workOrders: projected.workOrders,
           undispatchable: projected.undispatchable,
+          /** Which floor source the plan read: 'live' only with --with-floor. */
+          workOrderFloorSource: floorSource,
           workOrderPlanError: planError,
           /** Per-dimension driver capability: 'enforced' | 'reported' |
            *  'none'. A dimension below 'enforced' also appears in
@@ -202,6 +235,7 @@ export function runRemediatePlan(cwd: string, opts: RemediatePlanOptions = {}): 
   if (planError) {
     logger.warn(`work orders: could not plan (${planError})`);
   } else if (plan) {
+    logger.dim(`work orders: floor read from ${describeFloorSource(floorSource ?? 'none')}`);
     logger.info(
       `work orders: ${plan.orders.length} planned` +
         (plan.undispatchable.length > 0

--- a/src/remediate/plan-cli.ts
+++ b/src/remediate/plan-cli.ts
@@ -13,6 +13,7 @@ import { remediateBranchFor } from '../lanes/branches';
 import { describeDeliveryProbe, probeDeliveryPreconditions } from '../lanes/delivery-preconditions';
 import {
   planRepoWorkOrders,
+  type DepScanSource,
   type FloorSource,
   type GatherWorkOrderOptions,
 } from './work-orders/gather';
@@ -75,6 +76,17 @@ export async function runRemediatePlan(
 ): Promise<void> {
   const config = resolveRemediateConfig(cwd);
   const driver = driverById(config.agent.driver);
+  // Validate the driver BEFORE any gathering: an unknown driver is a config
+  // error the human surface reports without paying a scan.
+  if (!opts.json && !driver) {
+    logger.header('dxkit remediate plan');
+    logger.fail(
+      `unknown agent driver '${config.agent.driver}' — known drivers: ` +
+        AGENT_DRIVERS.map((d) => d.id).join(', '),
+    );
+    process.exitCode = 1;
+    return;
+  }
 
   const rows = config.tasks.map((taskId) => {
     const task = remediateTaskById(taskId)!;
@@ -110,6 +122,8 @@ export async function runRemediatePlan(
   // crashed plan.
   let plan: WorkOrderPlan | null = null;
   let floorSource: FloorSource | null = null;
+  let depScanSource: DepScanSource | null = null;
+  let disclosures: readonly string[] = [];
   let planError: string | null = null;
   try {
     const gathered = await planRepoWorkOrders(cwd, config, {
@@ -118,10 +132,11 @@ export async function runRemediatePlan(
     });
     plan = gathered.plan;
     floorSource = gathered.floorSource;
+    depScanSource = gathered.depScanSource;
+    disclosures = gathered.disclosures;
   } catch (err) {
     planError = err instanceof Error ? err.message : String(err);
   }
-  const projected = plan ? projectWorkOrders(plan) : { workOrders: [], undispatchable: [] };
 
   if (opts.json) {
     process.stdout.write(
@@ -150,10 +165,15 @@ export async function runRemediatePlan(
           unknownTasks: config.unknownTasks,
           /** The planned work orders (tier / recipe / budget / done summary)
            *  and the findings no class could take, with the reason. */
-          workOrders: projected.workOrders,
-          undispatchable: projected.undispatchable,
+          ...(plan ? projectWorkOrders(plan) : { workOrders: [], undispatchable: [] }),
           /** Which floor source the plan read: 'live' only with --with-floor. */
           workOrderFloorSource: floorSource,
+          /** Which source answered the deferral join (bom-artifact / live-scan
+           *  / injected / not-needed). */
+          workOrderDepScanSource: depScanSource,
+          /** Degraded gather reads, phrased for humans (corrupt baseline,
+           *  capped roots, which scan was paid). Empty = nothing degraded. */
+          workOrderDisclosures: disclosures,
           workOrderPlanError: planError,
           /** Per-dimension driver capability: 'enforced' | 'reported' |
            *  'none'. A dimension below 'enforced' also appears in
@@ -174,30 +194,24 @@ export async function runRemediatePlan(
   }
 
   logger.header('dxkit remediate plan');
-  if (!driver) {
-    logger.fail(
-      `unknown agent driver '${config.agent.driver}' — known drivers: ` +
-        AGENT_DRIVERS.map((d) => d.id).join(', '),
-    );
-    process.exitCode = 1;
-    return;
-  }
+  // The early return above guarantees a known driver on this path.
+  const d = driver!;
   logger.info(
-    `driver: ${driver.id}` +
+    `driver: ${d.id}` +
       (availability && !availability.ok ? ` (NOT available here: ${availability.reason})` : ''),
   );
   logger.info(
     `budget: ${config.agent.budget.maxTurns} turns, ${config.agent.budget.maxMinutes} min, ` +
       `$${config.agent.budget.maxUsd} — salvage: ${config.salvage}`,
   );
-  if (driver.budgetSupport.turns !== 'enforced') {
-    logger.warn(`maxTurns is not enforceable by ${driver.id}`);
+  if (d.budgetSupport.turns !== 'enforced') {
+    logger.warn(`maxTurns is not enforceable by ${d.id}`);
   }
-  if (driver.budgetSupport.cost === 'none') {
-    logger.warn(`maxUsd is not enforceable by ${driver.id} (no spend reporting)`);
-  } else if (driver.budgetSupport.cost === 'reported') {
+  if (d.budgetSupport.cost === 'none') {
+    logger.warn(`maxUsd is not enforceable by ${d.id} (no spend reporting)`);
+  } else if (d.budgetSupport.cost === 'reported') {
     logger.warn(
-      `maxUsd is ADVISORY for ${driver.id} (cost is reported after the run, not enforced ` +
+      `maxUsd is ADVISORY for ${d.id} (cost is reported after the run, not enforced ` +
         `mid-run) — the enforced turn cap and wall clock bound real spend`,
     );
   }
@@ -236,6 +250,7 @@ export async function runRemediatePlan(
     logger.warn(`work orders: could not plan (${planError})`);
   } else if (plan) {
     logger.dim(`work orders: floor read from ${describeFloorSource(floorSource ?? 'none')}`);
+    for (const d of disclosures) logger.dim(`work orders: ${d}`);
     logger.info(
       `work orders: ${plan.orders.length} planned` +
         (plan.undispatchable.length > 0

--- a/src/remediate/tasks.ts
+++ b/src/remediate/tasks.ts
@@ -12,7 +12,7 @@
  */
 import type { ModelTier } from './driver';
 import { dxkitCli } from '../self-invocation';
-import type { WorkOrderClass } from './work-orders/types';
+import { classesSelectedBy, type WorkOrderClass } from './work-orders/types';
 
 /** How a prompt tells the agent to invoke dxkit inside the TARGET repo:
  *  the local install first, the canonical binary invocation as fallback
@@ -57,10 +57,12 @@ export interface RemediateTask {
   readonly verify: 'floor' | 'guardrail';
   /**
    * The work-order classes this task SELECTS (remediate rethink, section 3A):
+   * a READ of `WORK_ORDER_CLASSES` (each class names its selecting task), so
    * a task is a selector over the planner's orders, not an open goal. An
    * open-ended task (docs, tests) selects nothing and says so via
    * `openEnded`; every bounded task selects at least one class (pinned by
-   * the task-catalog test).
+   * the task-catalog test). Selection is consumed by the executor unit; this
+   * unit declares it.
    */
   readonly selects: readonly WorkOrderClass[];
   /** True for a task with no finite finding set to close (score-hinged,
@@ -140,7 +142,7 @@ Ground rules (non-negotiable):
 export const REMEDIATE_TASKS: readonly RemediateTask[] = [
   {
     id: 'fix-build',
-    selects: ['unresolved-import', 'stale-lockfile', 'floor-failure'],
+    selects: classesSelectedBy('fix-build'),
     openEnded: false,
     summary: 'fix the grandfathered broken build / failing tests (floor debt)',
     tier: 'standard',
@@ -160,7 +162,7 @@ message. When you believe you are done, re-run the failing commands and then
   },
   {
     id: 'fix-vulns',
-    selects: ['dep-advisory'],
+    selects: classesSelectedBy('fix-vulns'),
     openEnded: false,
     summary: 'remediate baselined dependency vulnerabilities the bump lane could not close',
     tier: 'standard',
@@ -188,7 +190,7 @@ in docs/DXKIT-REMEDIATION-NOTES.md so the reviewer sees what was compared.` + SH
   },
   {
     id: 'fix-lint',
-    selects: ['lint-located'],
+    selects: classesSelectedBy('fix-lint'),
     openEnded: false,
     summary: 'burn down the grandfathered lint backlog, oldest and highest-signal first',
     tier: 'light',

--- a/src/remediate/tasks.ts
+++ b/src/remediate/tasks.ts
@@ -12,7 +12,6 @@
  */
 import type { ModelTier } from './driver';
 import { dxkitCli } from '../self-invocation';
-import { classesSelectedBy, type WorkOrderClass } from './work-orders/types';
 
 /** How a prompt tells the agent to invoke dxkit inside the TARGET repo:
  *  the local install first, the canonical binary invocation as fallback
@@ -55,19 +54,6 @@ export interface RemediateTask {
   /** Which verification the outcome hinges on (both always run; this names
    *  the primary signal for the ledger). */
   readonly verify: 'floor' | 'guardrail';
-  /**
-   * The work-order classes this task SELECTS (remediate rethink, section 3A):
-   * a READ of `WORK_ORDER_CLASSES` (each class names its selecting task), so
-   * a task is a selector over the planner's orders, not an open goal. An
-   * open-ended task (docs, tests) selects nothing and says so via
-   * `openEnded`; every bounded task selects at least one class (pinned by
-   * the task-catalog test). Selection is consumed by the executor unit; this
-   * unit declares it.
-   */
-  readonly selects: readonly WorkOrderClass[];
-  /** True for a task with no finite finding set to close (score-hinged,
-   *  opt-in, never scheduled by default). */
-  readonly openEnded: boolean;
   /**
    * The task's completion SHAPE — it decides the default salvage posture
    * (`salvageForTask`), because the two shapes need opposite defaults:
@@ -142,8 +128,6 @@ Ground rules (non-negotiable):
 export const REMEDIATE_TASKS: readonly RemediateTask[] = [
   {
     id: 'fix-build',
-    selects: classesSelectedBy('fix-build'),
-    openEnded: false,
     summary: 'fix the grandfathered broken build / failing tests (floor debt)',
     tier: 'standard',
     tierWhy: 'real diagnosis + repair across build config and test code',
@@ -162,8 +146,6 @@ message. When you believe you are done, re-run the failing commands and then
   },
   {
     id: 'fix-vulns',
-    selects: classesSelectedBy('fix-vulns'),
-    openEnded: false,
     summary: 'remediate baselined dependency vulnerabilities the bump lane could not close',
     tier: 'standard',
     tierWhy: 'cross-file reasoning; majors can require real code changes',
@@ -190,8 +172,6 @@ in docs/DXKIT-REMEDIATION-NOTES.md so the reviewer sees what was compared.` + SH
   },
   {
     id: 'fix-lint',
-    selects: classesSelectedBy('fix-lint'),
-    openEnded: false,
     summary: 'burn down the grandfathered lint backlog, oldest and highest-signal first',
     tier: 'light',
     tierWhy: 'mechanical, pattern-per-finding work',
@@ -210,8 +190,6 @@ is a bug, not a cleanup.` + SHARED_RULES,
   },
   {
     id: 'improve-tests',
-    selects: [],
-    openEnded: true,
     summary: 'add real behavioral tests for the highest-risk untested surfaces',
     tier: 'standard',
     tierWhy: 'design judgment about behavior worth pinning, not boilerplate',
@@ -230,8 +208,6 @@ coverage thresholds or edit test configuration to inflate numbers.` + SHARED_RUL
   },
   {
     id: 'write-docs',
-    selects: [],
-    openEnded: true,
     summary: 'write the documentation the repo is missing, verified by the score',
     tier: 'standard',
     tierWhy: 'grounded technical writing over real code, not boilerplate',
@@ -266,8 +242,6 @@ not drop — cosmetic edits that move nothing are rejected, not landed.` + SHARE
 export function customDispatchTask(prompt: string): RemediateTask {
   return {
     id: 'custom',
-    selects: [],
-    openEnded: true,
     summary: 'one-time dispatch campaign (custom prompt)',
     tier: 'standard',
     tierWhy: 'human-dispatched; pin agent.model (or the dispatch model input) to change',

--- a/src/remediate/tasks.ts
+++ b/src/remediate/tasks.ts
@@ -12,6 +12,7 @@
  */
 import type { ModelTier } from './driver';
 import { dxkitCli } from '../self-invocation';
+import type { WorkOrderClass } from './work-orders/types';
 
 /** How a prompt tells the agent to invoke dxkit inside the TARGET repo:
  *  the local install first, the canonical binary invocation as fallback
@@ -54,6 +55,17 @@ export interface RemediateTask {
   /** Which verification the outcome hinges on (both always run; this names
    *  the primary signal for the ledger). */
   readonly verify: 'floor' | 'guardrail';
+  /**
+   * The work-order classes this task SELECTS (remediate rethink, section 3A):
+   * a task is a selector over the planner's orders, not an open goal. An
+   * open-ended task (docs, tests) selects nothing and says so via
+   * `openEnded`; every bounded task selects at least one class (pinned by
+   * the task-catalog test).
+   */
+  readonly selects: readonly WorkOrderClass[];
+  /** True for a task with no finite finding set to close (score-hinged,
+   *  opt-in, never scheduled by default). */
+  readonly openEnded: boolean;
   /**
    * The task's completion SHAPE — it decides the default salvage posture
    * (`salvageForTask`), because the two shapes need opposite defaults:
@@ -128,6 +140,8 @@ Ground rules (non-negotiable):
 export const REMEDIATE_TASKS: readonly RemediateTask[] = [
   {
     id: 'fix-build',
+    selects: ['unresolved-import', 'stale-lockfile', 'floor-failure'],
+    openEnded: false,
     summary: 'fix the grandfathered broken build / failing tests (floor debt)',
     tier: 'standard',
     tierWhy: 'real diagnosis + repair across build config and test code',
@@ -146,6 +160,8 @@ message. When you believe you are done, re-run the failing commands and then
   },
   {
     id: 'fix-vulns',
+    selects: ['dep-advisory'],
+    openEnded: false,
     summary: 'remediate baselined dependency vulnerabilities the bump lane could not close',
     tier: 'standard',
     tierWhy: 'cross-file reasoning; majors can require real code changes',
@@ -172,6 +188,8 @@ in docs/DXKIT-REMEDIATION-NOTES.md so the reviewer sees what was compared.` + SH
   },
   {
     id: 'fix-lint',
+    selects: ['lint-located'],
+    openEnded: false,
     summary: 'burn down the grandfathered lint backlog, oldest and highest-signal first',
     tier: 'light',
     tierWhy: 'mechanical, pattern-per-finding work',
@@ -190,6 +208,8 @@ is a bug, not a cleanup.` + SHARED_RULES,
   },
   {
     id: 'improve-tests',
+    selects: [],
+    openEnded: true,
     summary: 'add real behavioral tests for the highest-risk untested surfaces',
     tier: 'standard',
     tierWhy: 'design judgment about behavior worth pinning, not boilerplate',
@@ -208,6 +228,8 @@ coverage thresholds or edit test configuration to inflate numbers.` + SHARED_RUL
   },
   {
     id: 'write-docs',
+    selects: [],
+    openEnded: true,
     summary: 'write the documentation the repo is missing, verified by the score',
     tier: 'standard',
     tierWhy: 'grounded technical writing over real code, not boilerplate',
@@ -242,6 +264,8 @@ not drop — cosmetic edits that move nothing are rejected, not landed.` + SHARE
 export function customDispatchTask(prompt: string): RemediateTask {
   return {
     id: 'custom',
+    selects: [],
+    openEnded: true,
     summary: 'one-time dispatch campaign (custom prompt)',
     tier: 'standard',
     tierWhy: 'human-dispatched; pin agent.model (or the dispatch model input) to change',

--- a/src/remediate/work-orders/advisory-orders.ts
+++ b/src/remediate/work-orders/advisory-orders.ts
@@ -1,24 +1,35 @@
 /**
  * Dependency-advisory orders: ONE order per package, unioning the guardrail's
- * blocking advisories and the active deferred advisories that name it
- * (a package both blocking and deferred is one unit of work, never two ids
- * that dedupe one away). Envelope = the root manifest + lockfile only.
+ * blocking advisories, the active deferred advisories, and the baselined
+ * dep-vuln debt that name it (a package in two sources is one unit of work,
+ * never two ids). An advisory both blocking and deferred keeps BOTH facts:
+ * it blocks now (attribution net-new) and its expiry window still counts
+ * toward the order's expiring rank.
+ *
+ * Envelope: the owning dependency root's manifests when every finding agrees
+ * on one, else every discovered root's manifests (a nested-root advisory must
+ * never get an envelope excluding the files its fix edits: the root-only
+ * class CLAUDE.md records).
  */
 import { SEVERITY_RANK } from '../../fail-on';
 import type { FindingSeverity } from '../../baseline/types';
 import type { DepAdvisoryEvidence, WorkOrderFinding } from './types';
 import {
+  INSTALL_FORBIDDEN,
   VALUE_BAND,
+  allManifestPaths,
   byteOrder,
   deriveBudget,
   doneFor,
+  manifestPaths,
   type BudgetCapFor,
+  type InstallFor,
+  type ManifestRoot,
   type Ranked,
 } from './shared';
-import type { ManifestRoot } from './floor-orders';
 
 /** One advisory as the planner reads it: from the live scan (fixed version /
- *  reachability known) or the baseline entry (identity + severity only). */
+ *  reachability known) or a baseline entry (identity + severity only). */
 export interface AdvisoryInput {
   readonly id: string;
   readonly package: string;
@@ -27,23 +38,31 @@ export interface AdvisoryInput {
   readonly severity?: FindingSeverity;
   readonly fixedVersion?: string;
   readonly reachable?: boolean;
+  /** The producing language pack, when the source records it (live scan). */
+  readonly pack?: string;
+  /** The dependency root that owns the vulnerable lockfile, when the source
+   *  records it. Absent -> the envelope falls back to every root. */
+  readonly rootDir?: string;
 }
 
 export interface AdvisoryOrderContext {
   readonly manifests: readonly ManifestRoot[];
-  readonly install?: { readonly bin: string; readonly args: readonly string[] };
+  readonly installFor: InstallFor;
   readonly capFor: BudgetCapFor;
 }
 
-const INSTALL_FORBIDDEN =
-  'installing, adding, or removing packages yourself (the frame runs the install command)';
+interface Bucket {
+  findings: Map<string, WorkOrderFinding>;
+  blocking: number;
+  deferred: number;
+  earliest?: string;
+  packs: Set<string>;
+  rootDirs: Set<string>;
+  rootUnknown: boolean;
+}
 
-function toFinding(
-  a: AdvisoryInput,
-  attribution: WorkOrderFinding['attribution'],
-  expiresAt?: string,
-): WorkOrderFinding {
-  const evidence: DepAdvisoryEvidence = {
+function evidenceOf(a: AdvisoryInput, expiresAt?: string): DepAdvisoryEvidence {
+  return {
     type: 'dep-vuln',
     package: a.package,
     ...(a.installedVersion !== undefined ? { installedVersion: a.installedVersion } : {}),
@@ -53,7 +72,6 @@ function toFinding(
     ...(a.severity !== undefined ? { severity: a.severity } : {}),
     ...(expiresAt !== undefined ? { expiresAt } : {}),
   };
-  return { kind: 'dep-vuln', id: a.id, attribution, evidence };
 }
 
 function reachableSevere(findings: readonly WorkOrderFinding[]): boolean {
@@ -66,8 +84,8 @@ function reachableSevere(findings: readonly WorkOrderFinding[]): boolean {
   );
 }
 
-/** Highest severity in the set as a sort key (lower first): the exported
- *  rank counts UP with severity, so it is negated here. */
+/** Highest severity in the set as a sort key (lower sorts first): the
+ *  exported rank counts UP with severity, so it is negated here. */
 function severityKey(findings: readonly WorkOrderFinding[]): number {
   let best = Number.POSITIVE_INFINITY;
   for (const f of findings) {
@@ -80,53 +98,101 @@ function severityKey(findings: readonly WorkOrderFinding[]): number {
 export function advisoryOrders(
   blocking: readonly AdvisoryInput[],
   deferred: ReadonlyArray<{ readonly advisory: AdvisoryInput; readonly expiresAt: string }>,
+  debt: readonly AdvisoryInput[],
   ctx: AdvisoryOrderContext,
 ): Ranked[] {
-  const byPackage = new Map<
-    string,
-    { findings: WorkOrderFinding[]; blocking: number; deferred: number; earliest?: string }
-  >();
-  const bucket = (pkg: string) => {
-    const b = byPackage.get(pkg) ?? { findings: [], blocking: 0, deferred: 0 };
+  const byPackage = new Map<string, Bucket>();
+  const bucket = (pkg: string): Bucket => {
+    const b = byPackage.get(pkg) ?? {
+      findings: new Map<string, WorkOrderFinding>(),
+      blocking: 0,
+      deferred: 0,
+      packs: new Set<string>(),
+      rootDirs: new Set<string>(),
+      rootUnknown: false,
+    };
     byPackage.set(pkg, b);
     return b;
   };
+  const note = (b: Bucket, a: AdvisoryInput) => {
+    if (a.pack !== undefined) b.packs.add(a.pack);
+    if (a.rootDir !== undefined) b.rootDirs.add(a.rootDir);
+    else b.rootUnknown = true;
+  };
   for (const a of blocking) {
     const b = bucket(a.package);
-    b.findings.push(toFinding(a, 'net-new'));
+    b.findings.set(a.id, {
+      kind: 'dep-vuln',
+      id: a.id,
+      attribution: 'net-new',
+      evidence: evidenceOf(a),
+    });
     b.blocking += 1;
+    note(b, a);
   }
-  for (const { advisory, expiresAt } of deferred) {
-    const b = bucket(advisory.package);
-    if (b.findings.some((f) => f.id === advisory.id)) continue; // blocking already carries it
-    b.findings.push(toFinding(advisory, 'deferred', expiresAt));
+  for (const { advisory: a, expiresAt } of deferred) {
+    const b = bucket(a.package);
     b.deferred += 1;
     if (b.earliest === undefined || expiresAt < b.earliest) b.earliest = expiresAt;
+    const existing = b.findings.get(a.id);
+    if (existing) {
+      // Both blocking and deferred: it blocks NOW (attribution stays
+      // net-new) and the expiry window is recorded on the evidence.
+      const evidence = { ...(existing.evidence as DepAdvisoryEvidence), expiresAt };
+      b.findings.set(a.id, { ...existing, evidence });
+    } else {
+      b.findings.set(a.id, {
+        kind: 'dep-vuln',
+        id: a.id,
+        attribution: 'deferred',
+        evidence: evidenceOf(a, expiresAt),
+      });
+      note(b, a);
+    }
   }
-  const root = ctx.manifests.find((m) => m.dir === '') ?? { dir: '', files: [] };
+  for (const a of debt) {
+    const b = bucket(a.package);
+    if (b.findings.has(a.id)) continue; // a blocking/deferred copy is richer
+    b.findings.set(a.id, {
+      kind: 'dep-vuln',
+      id: a.id,
+      attribution: 'pre-existing',
+      evidence: evidenceOf(a),
+    });
+    note(b, a);
+  }
+
   const out: Ranked[] = [];
   for (const [pkg, b] of [...byPackage.entries()].sort(([x], [y]) => byteOrder(x, y))) {
-    const findings = [...b.findings].sort((x, y) => byteOrder(x.id, y.id));
+    const findings = [...b.findings.values()].sort((x, y) => byteOrder(x.id, y.id));
+    // Owning root: when every finding that knows its root agrees (and none
+    // is unknown), scope the envelope to it; else every discovered root.
+    const paths =
+      !b.rootUnknown && b.rootDirs.size === 1
+        ? manifestPaths(
+            ctx.manifests.find((m) => m.dir === [...b.rootDirs][0]) ?? {
+              dir: [...b.rootDirs][0],
+              files: [],
+            },
+          )
+        : allManifestPaths(ctx.manifests);
+    const install = ctx.installFor(b.packs.size === 1 ? [...b.packs][0] : undefined);
     const rank: Ranked['rank'] =
       b.earliest !== undefined
         ? [VALUE_BAND.expiringDeferral, b.earliest]
-        : reachableSevere(findings)
-          ? [VALUE_BAND.reachableSevere, severityKey(findings)]
-          : [VALUE_BAND.otherBlocking, severityKey(findings)];
+        : b.blocking > 0
+          ? reachableSevere(findings)
+            ? [VALUE_BAND.reachableSevere, severityKey(findings)]
+            : [VALUE_BAND.otherBlocking, severityKey(findings)]
+          : [VALUE_BAND.debt, severityKey(findings)];
     out.push({
       rank,
       draft: {
         id: `dep-advisory:${pkg}`,
         class: 'dep-advisory',
         findings,
-        envelope: {
-          paths: root.files.map((f) => (root.dir ? `${root.dir}/${f}` : f)),
-          manifests: true,
-        },
-        constraints: {
-          ...(ctx.install ? { install: ctx.install } : {}),
-          forbidden: [INSTALL_FORBIDDEN],
-        },
+        envelope: { paths, manifests: true },
+        constraints: { ...(install ? { install } : {}), forbidden: [INSTALL_FORBIDDEN] },
         done: doneFor('guardrail', findings),
         budget: deriveBudget(findings.length, ctx.capFor('dep-advisory')),
         provenance: {

--- a/src/remediate/work-orders/advisory-orders.ts
+++ b/src/remediate/work-orders/advisory-orders.ts
@@ -1,0 +1,142 @@
+/**
+ * Dependency-advisory orders: ONE order per package, unioning the guardrail's
+ * blocking advisories and the active deferred advisories that name it
+ * (a package both blocking and deferred is one unit of work, never two ids
+ * that dedupe one away). Envelope = the root manifest + lockfile only.
+ */
+import { SEVERITY_RANK } from '../../fail-on';
+import type { FindingSeverity } from '../../baseline/types';
+import type { DepAdvisoryEvidence, WorkOrderFinding } from './types';
+import {
+  VALUE_BAND,
+  byteOrder,
+  deriveBudget,
+  doneFor,
+  type BudgetCapFor,
+  type Ranked,
+} from './shared';
+import type { ManifestRoot } from './floor-orders';
+
+/** One advisory as the planner reads it: from the live scan (fixed version /
+ *  reachability known) or the baseline entry (identity + severity only). */
+export interface AdvisoryInput {
+  readonly id: string;
+  readonly package: string;
+  readonly installedVersion?: string;
+  readonly advisoryId: string;
+  readonly severity?: FindingSeverity;
+  readonly fixedVersion?: string;
+  readonly reachable?: boolean;
+}
+
+export interface AdvisoryOrderContext {
+  readonly manifests: readonly ManifestRoot[];
+  readonly install?: { readonly bin: string; readonly args: readonly string[] };
+  readonly capFor: BudgetCapFor;
+}
+
+const INSTALL_FORBIDDEN =
+  'installing, adding, or removing packages yourself (the frame runs the install command)';
+
+function toFinding(
+  a: AdvisoryInput,
+  attribution: WorkOrderFinding['attribution'],
+  expiresAt?: string,
+): WorkOrderFinding {
+  const evidence: DepAdvisoryEvidence = {
+    type: 'dep-vuln',
+    package: a.package,
+    ...(a.installedVersion !== undefined ? { installedVersion: a.installedVersion } : {}),
+    advisoryId: a.advisoryId,
+    ...(a.fixedVersion !== undefined ? { fixedVersion: a.fixedVersion } : {}),
+    ...(a.reachable !== undefined ? { reachable: a.reachable } : {}),
+    ...(a.severity !== undefined ? { severity: a.severity } : {}),
+    ...(expiresAt !== undefined ? { expiresAt } : {}),
+  };
+  return { kind: 'dep-vuln', id: a.id, attribution, evidence };
+}
+
+function reachableSevere(findings: readonly WorkOrderFinding[]): boolean {
+  return findings.some(
+    (f) =>
+      f.evidence.type === 'dep-vuln' &&
+      f.evidence.reachable === true &&
+      f.evidence.severity !== undefined &&
+      SEVERITY_RANK[f.evidence.severity] >= SEVERITY_RANK.high,
+  );
+}
+
+/** Highest severity in the set as a sort key (lower first): the exported
+ *  rank counts UP with severity, so it is negated here. */
+function severityKey(findings: readonly WorkOrderFinding[]): number {
+  let best = Number.POSITIVE_INFINITY;
+  for (const f of findings) {
+    if (f.evidence.type === 'dep-vuln' && f.evidence.severity !== undefined)
+      best = Math.min(best, -SEVERITY_RANK[f.evidence.severity]);
+  }
+  return best;
+}
+
+export function advisoryOrders(
+  blocking: readonly AdvisoryInput[],
+  deferred: ReadonlyArray<{ readonly advisory: AdvisoryInput; readonly expiresAt: string }>,
+  ctx: AdvisoryOrderContext,
+): Ranked[] {
+  const byPackage = new Map<
+    string,
+    { findings: WorkOrderFinding[]; blocking: number; deferred: number; earliest?: string }
+  >();
+  const bucket = (pkg: string) => {
+    const b = byPackage.get(pkg) ?? { findings: [], blocking: 0, deferred: 0 };
+    byPackage.set(pkg, b);
+    return b;
+  };
+  for (const a of blocking) {
+    const b = bucket(a.package);
+    b.findings.push(toFinding(a, 'net-new'));
+    b.blocking += 1;
+  }
+  for (const { advisory, expiresAt } of deferred) {
+    const b = bucket(advisory.package);
+    if (b.findings.some((f) => f.id === advisory.id)) continue; // blocking already carries it
+    b.findings.push(toFinding(advisory, 'deferred', expiresAt));
+    b.deferred += 1;
+    if (b.earliest === undefined || expiresAt < b.earliest) b.earliest = expiresAt;
+  }
+  const root = ctx.manifests.find((m) => m.dir === '') ?? { dir: '', files: [] };
+  const out: Ranked[] = [];
+  for (const [pkg, b] of [...byPackage.entries()].sort(([x], [y]) => byteOrder(x, y))) {
+    const findings = [...b.findings].sort((x, y) => byteOrder(x.id, y.id));
+    const rank: Ranked['rank'] =
+      b.earliest !== undefined
+        ? [VALUE_BAND.expiringDeferral, b.earliest]
+        : reachableSevere(findings)
+          ? [VALUE_BAND.reachableSevere, severityKey(findings)]
+          : [VALUE_BAND.otherBlocking, severityKey(findings)];
+    out.push({
+      rank,
+      draft: {
+        id: `dep-advisory:${pkg}`,
+        class: 'dep-advisory',
+        findings,
+        envelope: {
+          paths: root.files.map((f) => (root.dir ? `${root.dir}/${f}` : f)),
+          manifests: true,
+        },
+        constraints: {
+          ...(ctx.install ? { install: ctx.install } : {}),
+          forbidden: [INSTALL_FORBIDDEN],
+        },
+        done: doneFor('guardrail', findings),
+        budget: deriveBudget(findings.length, ctx.capFor('dep-advisory')),
+        provenance: {
+          source: 'advisories',
+          blocking: b.blocking,
+          deferred: b.deferred,
+          ...(b.earliest !== undefined ? { earliestExpiry: b.earliest } : {}),
+        },
+      },
+    });
+  }
+  return out;
+}

--- a/src/remediate/work-orders/floor-orders.ts
+++ b/src/remediate/work-orders/floor-orders.ts
@@ -1,0 +1,180 @@
+/**
+ * Entry-floor orders: one `unresolved-import` order per manifest root the
+ * importing files share (envelope = every importer + that root's manifest and
+ * lockfile), and one `floor-failure` order per failing check with no finer
+ * identity. Findings come pre-attributed from the one comparator
+ * (`attributeFloorFailures`); this module never re-derives attribution.
+ */
+import { IMPORT_RESOLUTION_LABEL } from '../../analyzers/correctness/run';
+import type { AttributedFloorFailure } from '../../analyzers/correctness/attribution';
+import { FLOOR_FINDING_KIND, floorFindingId, type WorkOrderFinding } from './types';
+import {
+  VALUE_BAND,
+  byteOrder,
+  deriveBudget,
+  doneFor,
+  type BudgetCapFor,
+  type Ranked,
+} from './shared';
+
+/** One failing floor check as the planner reads it: attribution already
+ *  decided, the command as one string, the structured unresolved pairs when
+ *  the check decomposes. Built by `gather.ts` from whichever floor source it
+ *  used (live run, baseline envelope, loop snapshot). */
+export interface FloorFailureInput {
+  readonly pack: string;
+  readonly label: string;
+  readonly command: string;
+  readonly output?: string;
+  readonly attribution: AttributedFloorFailure['attribution'];
+  readonly precision?: AttributedFloorFailure['precision'];
+  readonly netNewFindings?: readonly string[];
+  readonly unresolved?: readonly { readonly specifier: string; readonly file: string }[];
+}
+
+/** A dependency root: the manifest and lockfile an unresolved import's fix
+ *  touches. `dir` is repo-relative (`''` for the root), files are relative. */
+export interface ManifestRoot {
+  readonly dir: string;
+  readonly files: readonly string[];
+}
+
+export interface FloorOrderContext {
+  readonly manifests: readonly ManifestRoot[];
+  readonly install?: { readonly bin: string; readonly args: readonly string[] };
+  readonly capFor: BudgetCapFor;
+}
+
+/** The dependency root whose directory is the longest prefix of `file`. */
+function manifestRootFor(file: string, manifests: readonly ManifestRoot[]): ManifestRoot {
+  let best: ManifestRoot = manifests.find((m) => m.dir === '') ?? { dir: '', files: [] };
+  for (const m of manifests) {
+    if (m.dir === '') continue;
+    const prefix = m.dir.endsWith('/') ? m.dir : `${m.dir}/`;
+    if (file.startsWith(prefix) && prefix.length > best.dir.length) best = m;
+  }
+  return best;
+}
+
+function manifestPaths(root: ManifestRoot): string[] {
+  return root.files.map((f) => (root.dir ? `${root.dir}/${f}` : f));
+}
+
+const INSTALL_FORBIDDEN =
+  'installing, adding, or removing packages yourself (the frame runs the install command)';
+
+function unresolvedImportOrders(check: FloorFailureInput, ctx: FloorOrderContext): Ranked[] {
+  const pairs = check.unresolved ?? [];
+  const netNew = new Set(check.netNewFindings ?? []);
+  // specifier -> every importer, then group specifiers by the manifest root
+  // the importers share (a specifier imported from two roots is one finding
+  // in the first root it is seen in; the fix declares it there).
+  const importersOf = new Map<string, string[]>();
+  for (const { specifier, file } of pairs) {
+    const list = importersOf.get(specifier) ?? [];
+    if (!list.includes(file)) list.push(file);
+    importersOf.set(specifier, list);
+  }
+  const byRoot = new Map<string, { root: ManifestRoot; findings: WorkOrderFinding[] }>();
+  for (const [specifier, importers] of importersOf) {
+    const root = manifestRootFor(importers[0], ctx.manifests);
+    const bucket = byRoot.get(root.dir) ?? { root, findings: [] };
+    bucket.findings.push({
+      kind: FLOOR_FINDING_KIND,
+      id: floorFindingId(check.pack, check.label, specifier),
+      attribution:
+        check.precision === 'finding'
+          ? netNew.has(specifier)
+            ? 'net-new'
+            : 'pre-existing'
+          : check.attribution,
+      evidence: {
+        type: 'floor',
+        pack: check.pack,
+        label: check.label,
+        command: check.command,
+        specifier,
+        importingFiles: [...importers].sort(byteOrder),
+      },
+    });
+    byRoot.set(root.dir, bucket);
+  }
+  const out: Ranked[] = [];
+  for (const { root, findings } of byRoot.values()) {
+    const importers = [
+      ...new Set(
+        findings.flatMap((f) =>
+          f.evidence.type === 'floor' ? (f.evidence.importingFiles ?? []) : [],
+        ),
+      ),
+    ].sort(byteOrder);
+    const anyNetNew = findings.some((f) => f.attribution === 'net-new');
+    out.push({
+      rank: [
+        anyNetNew ? VALUE_BAND.netNewFloor : VALUE_BAND.preExistingFloor,
+        `${check.pack}/${check.label}/${root.dir}`,
+      ],
+      draft: {
+        id: `unresolved-import:${check.pack}:${root.dir || '.'}`,
+        class: 'unresolved-import',
+        findings,
+        envelope: { paths: [...importers, ...manifestPaths(root)], manifests: true },
+        constraints: {
+          ...(ctx.install ? { install: ctx.install } : {}),
+          forbidden: [INSTALL_FORBIDDEN],
+        },
+        done: doneFor('floor', findings),
+        budget: deriveBudget(findings.length, ctx.capFor('unresolved-import')),
+        ...(check.output !== undefined ? { outputTail: check.output } : {}),
+        provenance: { source: 'entry-floor', check: `${check.pack}/${check.label}` },
+      },
+    });
+  }
+  return out;
+}
+
+export function floorOrders(
+  failures: readonly FloorFailureInput[],
+  ctx: FloorOrderContext,
+): Ranked[] {
+  const out: Ranked[] = [];
+  for (const check of failures) {
+    if (
+      check.label === IMPORT_RESOLUTION_LABEL &&
+      check.unresolved &&
+      check.unresolved.length > 0
+    ) {
+      out.push(...unresolvedImportOrders(check, ctx));
+      continue;
+    }
+    const finding: WorkOrderFinding = {
+      kind: FLOOR_FINDING_KIND,
+      id: floorFindingId(check.pack, check.label),
+      attribution: check.attribution,
+      evidence: { type: 'floor', pack: check.pack, label: check.label, command: check.command },
+    };
+    out.push({
+      rank: [
+        check.attribution === 'net-new' ? VALUE_BAND.netNewFloor : VALUE_BAND.preExistingFloor,
+        `${check.pack}/${check.label}`,
+      ],
+      draft: {
+        id: `floor-failure:${check.pack}:${check.label}`,
+        class: 'floor-failure',
+        findings: [finding],
+        // A generic floor failure names no file; the whole tree minus
+        // manifests is the honest envelope (a build/test fix is code).
+        envelope: { paths: [''], manifests: false },
+        constraints: {
+          ...(ctx.install ? { install: ctx.install } : {}),
+          forbidden: [INSTALL_FORBIDDEN],
+        },
+        done: doneFor('floor', [finding]),
+        budget: deriveBudget(1, ctx.capFor('floor-failure')),
+        ...(check.output !== undefined ? { outputTail: check.output } : {}),
+        provenance: { source: 'entry-floor', check: `${check.pack}/${check.label}` },
+      },
+    });
+  }
+  return out;
+}

--- a/src/remediate/work-orders/floor-orders.ts
+++ b/src/remediate/work-orders/floor-orders.ts
@@ -12,6 +12,7 @@
  * order, so a grandfathered failure is never blamed on the agent.
  */
 import type { AttributedFloorFailure } from '../../analyzers/correctness/attribution';
+import { LOCKFILE_SYNC_LABEL } from '../../languages/capabilities/correctness';
 import { FLOOR_FINDING_KIND, floorFindingId, type WorkOrderFinding } from './types';
 import {
   INSTALL_FORBIDDEN,
@@ -132,12 +133,48 @@ function unresolvedImportOrders(check: FloorFailureInput, ctx: FloorOrderContext
   return out;
 }
 
+/** A failing lockfile-sync check: the `stale-lockfile` class. The envelope
+ *  is the owning dependency root's manifest + lockfile (the check runs at
+ *  the repo root today, so that root owns it); the fix is a reinstall, so
+ *  manifests may change and the lockfile-sync recipe serves it. */
+function staleLockfileOrder(check: FloorFailureInput, ctx: FloorOrderContext): Ranked {
+  const root = ctx.manifests.find((m) => m.dir === '') ?? { dir: '', files: [] };
+  const finding: WorkOrderFinding = {
+    kind: FLOOR_FINDING_KIND,
+    id: floorFindingId(check.pack, check.label),
+    attribution: check.attribution,
+    evidence: { type: 'floor', pack: check.pack, label: check.label, command: check.command },
+  };
+  const install = ctx.installFor(check.pack);
+  return {
+    rank: [
+      check.attribution === 'net-new' ? VALUE_BAND.netNewFloor : VALUE_BAND.preExistingFloor,
+      `${check.pack}/${check.label}`,
+    ],
+    draft: {
+      id: `stale-lockfile:${check.pack}`,
+      class: 'stale-lockfile',
+      findings: [finding],
+      envelope: { paths: manifestPaths(root), manifests: true },
+      constraints: { ...(install ? { install } : {}), forbidden: [INSTALL_FORBIDDEN] },
+      done: doneFor('floor', [finding]),
+      budget: deriveBudget(1, ctx.capFor('stale-lockfile')),
+      ...(check.output !== undefined ? { outputTail: check.output } : {}),
+      provenance: { source: 'entry-floor', check: floorFindingId(check.pack, check.label) },
+    },
+  };
+}
+
 export function floorOrders(
   failures: readonly FloorFailureInput[],
   ctx: FloorOrderContext,
 ): Ranked[] {
   const out: Ranked[] = [];
   for (const check of failures) {
+    if (check.label === LOCKFILE_SYNC_LABEL) {
+      out.push(staleLockfileOrder(check, ctx));
+      continue;
+    }
     if (check.unresolved && check.unresolved.length > 0) {
       out.push(...unresolvedImportOrders(check, ctx));
       continue;

--- a/src/remediate/work-orders/floor-orders.ts
+++ b/src/remediate/work-orders/floor-orders.ts
@@ -1,25 +1,34 @@
 /**
  * Entry-floor orders: one `unresolved-import` order per manifest root the
  * importing files share (envelope = every importer + that root's manifest and
- * lockfile), and one `floor-failure` order per failing check with no finer
- * identity. Findings come pre-attributed from the one comparator
+ * lockfile), and one `floor-failure` order per remaining failing check.
+ * Findings come pre-attributed from the one comparator
  * (`attributeFloorFailures`); this module never re-derives attribution.
+ *
+ * Decomposition is keyed on the STRUCTURED data a check carries, never on a
+ * label literal: `unresolved` pairs mint the unresolved-import class, and any
+ * check with finding-level identities (`findings`, e.g. parsed test
+ * failures) decomposes into per-finding attribution inside its floor-failure
+ * order, so a grandfathered failure is never blamed on the agent.
  */
-import { IMPORT_RESOLUTION_LABEL } from '../../analyzers/correctness/run';
 import type { AttributedFloorFailure } from '../../analyzers/correctness/attribution';
 import { FLOOR_FINDING_KIND, floorFindingId, type WorkOrderFinding } from './types';
 import {
+  INSTALL_FORBIDDEN,
   VALUE_BAND,
   byteOrder,
   deriveBudget,
   doneFor,
+  manifestPaths,
   type BudgetCapFor,
+  type InstallFor,
+  type ManifestRoot,
   type Ranked,
 } from './shared';
 
 /** One failing floor check as the planner reads it: attribution already
- *  decided, the command as one string, the structured unresolved pairs when
- *  the check decomposes. Built by `gather.ts` from whichever floor source it
+ *  decided, the command as one string, structured per-finding data when the
+ *  check decomposes. Built by `gather.ts` from whichever floor source it
  *  used (live run, baseline envelope, loop snapshot). */
 export interface FloorFailureInput {
   readonly pack: string;
@@ -29,19 +38,15 @@ export interface FloorFailureInput {
   readonly attribution: AttributedFloorFailure['attribution'];
   readonly precision?: AttributedFloorFailure['precision'];
   readonly netNewFindings?: readonly string[];
+  /** Finding-level identities when the check decomposes (Rule 9's floor
+   *  sibling: unresolved specifiers, parsed test-failure ids). */
+  readonly findings?: readonly string[];
   readonly unresolved?: readonly { readonly specifier: string; readonly file: string }[];
-}
-
-/** A dependency root: the manifest and lockfile an unresolved import's fix
- *  touches. `dir` is repo-relative (`''` for the root), files are relative. */
-export interface ManifestRoot {
-  readonly dir: string;
-  readonly files: readonly string[];
 }
 
 export interface FloorOrderContext {
   readonly manifests: readonly ManifestRoot[];
-  readonly install?: { readonly bin: string; readonly args: readonly string[] };
+  readonly installFor: InstallFor;
   readonly capFor: BudgetCapFor;
 }
 
@@ -56,21 +61,22 @@ function manifestRootFor(file: string, manifests: readonly ManifestRoot[]): Mani
   return best;
 }
 
-function manifestPaths(root: ManifestRoot): string[] {
-  return root.files.map((f) => (root.dir ? `${root.dir}/${f}` : f));
+/** Per-finding attribution inside a decomposed check: net-new exactly when
+ *  the comparator worked at finding precision and named it. */
+function findingAttribution(
+  check: FloorFailureInput,
+  finding: string,
+): WorkOrderFinding['attribution'] {
+  if (check.precision !== 'finding') return check.attribution;
+  return (check.netNewFindings ?? []).includes(finding) ? 'net-new' : 'pre-existing';
 }
 
-const INSTALL_FORBIDDEN =
-  'installing, adding, or removing packages yourself (the frame runs the install command)';
-
 function unresolvedImportOrders(check: FloorFailureInput, ctx: FloorOrderContext): Ranked[] {
-  const pairs = check.unresolved ?? [];
-  const netNew = new Set(check.netNewFindings ?? []);
   // specifier -> every importer, then group specifiers by the manifest root
   // the importers share (a specifier imported from two roots is one finding
   // in the first root it is seen in; the fix declares it there).
   const importersOf = new Map<string, string[]>();
-  for (const { specifier, file } of pairs) {
+  for (const { specifier, file } of check.unresolved ?? []) {
     const list = importersOf.get(specifier) ?? [];
     if (!list.includes(file)) list.push(file);
     importersOf.set(specifier, list);
@@ -82,12 +88,7 @@ function unresolvedImportOrders(check: FloorFailureInput, ctx: FloorOrderContext
     bucket.findings.push({
       kind: FLOOR_FINDING_KIND,
       id: floorFindingId(check.pack, check.label, specifier),
-      attribution:
-        check.precision === 'finding'
-          ? netNew.has(specifier)
-            ? 'net-new'
-            : 'pre-existing'
-          : check.attribution,
+      attribution: findingAttribution(check, specifier),
       evidence: {
         type: 'floor',
         pack: check.pack,
@@ -100,6 +101,7 @@ function unresolvedImportOrders(check: FloorFailureInput, ctx: FloorOrderContext
     byRoot.set(root.dir, bucket);
   }
   const out: Ranked[] = [];
+  const install = ctx.installFor(check.pack);
   for (const { root, findings } of byRoot.values()) {
     const importers = [
       ...new Set(
@@ -119,14 +121,11 @@ function unresolvedImportOrders(check: FloorFailureInput, ctx: FloorOrderContext
         class: 'unresolved-import',
         findings,
         envelope: { paths: [...importers, ...manifestPaths(root)], manifests: true },
-        constraints: {
-          ...(ctx.install ? { install: ctx.install } : {}),
-          forbidden: [INSTALL_FORBIDDEN],
-        },
+        constraints: { ...(install ? { install } : {}), forbidden: [INSTALL_FORBIDDEN] },
         done: doneFor('floor', findings),
         budget: deriveBudget(findings.length, ctx.capFor('unresolved-import')),
         ...(check.output !== undefined ? { outputTail: check.output } : {}),
-        provenance: { source: 'entry-floor', check: `${check.pack}/${check.label}` },
+        provenance: { source: 'entry-floor', check: floorFindingId(check.pack, check.label) },
       },
     });
   }
@@ -139,40 +138,57 @@ export function floorOrders(
 ): Ranked[] {
   const out: Ranked[] = [];
   for (const check of failures) {
-    if (
-      check.label === IMPORT_RESOLUTION_LABEL &&
-      check.unresolved &&
-      check.unresolved.length > 0
-    ) {
+    if (check.unresolved && check.unresolved.length > 0) {
       out.push(...unresolvedImportOrders(check, ctx));
       continue;
     }
-    const finding: WorkOrderFinding = {
-      kind: FLOOR_FINDING_KIND,
-      id: floorFindingId(check.pack, check.label),
-      attribution: check.attribution,
-      evidence: { type: 'floor', pack: check.pack, label: check.label, command: check.command },
-    };
+    // A check with finding-level identities decomposes into one finding per
+    // identity (per-finding attribution); otherwise the check IS the finding.
+    const findings: WorkOrderFinding[] =
+      check.findings && check.findings.length > 0
+        ? check.findings.map((f) => ({
+            kind: FLOOR_FINDING_KIND,
+            id: floorFindingId(check.pack, check.label, f),
+            attribution: findingAttribution(check, f),
+            evidence: {
+              type: 'floor',
+              pack: check.pack,
+              label: check.label,
+              command: check.command,
+            },
+          }))
+        : [
+            {
+              kind: FLOOR_FINDING_KIND,
+              id: floorFindingId(check.pack, check.label),
+              attribution: check.attribution,
+              evidence: {
+                type: 'floor',
+                pack: check.pack,
+                label: check.label,
+                command: check.command,
+              },
+            },
+          ];
+    const install = ctx.installFor(check.pack);
+    const anyNetNew = findings.some((f) => f.attribution === 'net-new');
     out.push({
       rank: [
-        check.attribution === 'net-new' ? VALUE_BAND.netNewFloor : VALUE_BAND.preExistingFloor,
+        anyNetNew ? VALUE_BAND.netNewFloor : VALUE_BAND.preExistingFloor,
         `${check.pack}/${check.label}`,
       ],
       draft: {
         id: `floor-failure:${check.pack}:${check.label}`,
         class: 'floor-failure',
-        findings: [finding],
+        findings,
         // A generic floor failure names no file; the whole tree minus
         // manifests is the honest envelope (a build/test fix is code).
         envelope: { paths: [''], manifests: false },
-        constraints: {
-          ...(ctx.install ? { install: ctx.install } : {}),
-          forbidden: [INSTALL_FORBIDDEN],
-        },
-        done: doneFor('floor', [finding]),
-        budget: deriveBudget(1, ctx.capFor('floor-failure')),
+        constraints: { ...(install ? { install } : {}), forbidden: [INSTALL_FORBIDDEN] },
+        done: doneFor('floor', findings),
+        budget: deriveBudget(findings.length, ctx.capFor('floor-failure')),
         ...(check.output !== undefined ? { outputTail: check.output } : {}),
-        provenance: { source: 'entry-floor', check: `${check.pack}/${check.label}` },
+        provenance: { source: 'entry-floor', check: floorFindingId(check.pack, check.label) },
       },
     });
   }

--- a/src/remediate/work-orders/gather.ts
+++ b/src/remediate/work-orders/gather.ts
@@ -1,0 +1,142 @@
+/**
+ * The ONE I/O adapter that assembles planner inputs from a repo (Rule 2.30:
+ * one concept, one code path). Every surface that wants a work-order plan
+ * for a repo (the plan CLI today; the executor in a later unit) calls
+ * `gatherWorkOrderInputs` / `planRepoWorkOrders`, so no surface can forget a
+ * source or join it differently.
+ *
+ * Sources it reads:
+ *   - the entry floor: `runCorrectnessFloor` on the pristine tree, attributed
+ *     against the baseline's recorded floor-debt envelope through the one
+ *     comparator (`attributeFloorFailures`; an absent envelope reads as
+ *     unattributed, never as net-new);
+ *   - the committed baseline's custom-check entries (the lint backlog);
+ *   - active allowlist deferrals joined by fingerprint to baseline entries;
+ *   - repo facts: the package manager's provision command and the root
+ *     dependency root (manifest + lockfile).
+ *
+ * Guardrail blocking pairs are NOT gathered here: they exist only inside a
+ * verify step (post-agent). The executor unit passes them into the planner
+ * from the verify result it already holds.
+ */
+import * as fs from 'fs';
+import { runCorrectnessFloor, type CorrectnessFloorResult } from '../../analyzers/correctness/run';
+import {
+  attributeFloorFailures,
+  type FloorBaseCheck,
+} from '../../analyzers/correctness/attribution';
+import { detectActiveLanguages } from '../../languages';
+import { pathForBaseline, readBaselineFile, type BaselineFile } from '../../baseline/baseline-file';
+import { isSanitized } from '../../baseline/sanitize';
+import type { RichBaselineEntry } from '../../baseline/types';
+import { daysUntilDate, tryLoadAllowlist } from '../../allowlist/file';
+import { detectLockfile, detectPackageManager, provisionCommand } from '../../package-manager';
+import type { RemediateConfig } from '../config';
+import { planWorkOrders, type ManifestRoot, type PlannerInput } from './planner';
+import type { WorkOrderPlan } from './types';
+
+export interface GatherWorkOrderOptions {
+  /** Injected floor run (tests); defaults to the real full-scope floor. */
+  readonly runFloor?: (cwd: string) => CorrectnessFloorResult;
+  /** The clock for deferral expiry (injectable for tests). */
+  readonly now?: Date;
+  readonly baselineName?: string;
+}
+
+/** The baseline's recorded floor envelope as the comparator's base side. The
+ *  envelope records check status only (no finding-level identities), so the
+ *  comparator works at CHECK precision and says so. */
+function baseChecksFrom(baseline: BaselineFile | null): FloorBaseCheck[] | null {
+  const debt = baseline?.floorDebt;
+  if (!debt) return null;
+  return debt.checks.map((c) => ({
+    pack: c.pack,
+    label: c.label,
+    status: c.status === 'pass' ? 'pass' : c.status === 'fail' ? 'fail' : 'skipped',
+  }));
+}
+
+function readBaseline(cwd: string, name: string): BaselineFile | null {
+  try {
+    const p = pathForBaseline(cwd, name);
+    return fs.existsSync(p) ? readBaselineFile(p) : null;
+  } catch {
+    return null; // unreadable baseline: the plan proceeds without it, disclosed by emptiness
+  }
+}
+
+/** The pm's provision command as `{ bin, args }` (the frame execFiles it). */
+export function installCommandFor(cwd: string): { bin: string; args: string[] } {
+  const [bin, ...args] = provisionCommand(detectPackageManager(cwd)).split(' ');
+  return { bin, args };
+}
+
+/** The root dependency root: manifest + lockfile when a lockfile is present,
+ *  else the manifest alone. */
+export function rootManifest(cwd: string): ManifestRoot {
+  const lock = detectLockfile(cwd);
+  const files = ['package.json'];
+  if (lock) files.push(lock.lockfile);
+  return { dir: '', files: files.filter((f) => fs.existsSync(`${cwd}/${f}`)) };
+}
+
+export function gatherWorkOrderInputs(
+  cwd: string,
+  config: RemediateConfig,
+  opts: GatherWorkOrderOptions = {},
+): PlannerInput {
+  const baseline = readBaseline(cwd, opts.baselineName ?? 'main');
+  const runFloor =
+    opts.runFloor ??
+    ((dir: string) =>
+      runCorrectnessFloor({
+        cwd: dir,
+        changedFiles: [],
+        scope: 'full',
+        packs: detectActiveLanguages(dir),
+      }));
+  const floor = runFloor(cwd);
+  const entryFloor =
+    floor.checks.length > 0
+      ? {
+          result: floor,
+          attributed: attributeFloorFailures(floor, baseChecksFrom(baseline), {
+            absentMeans: 'unattributed',
+          }),
+        }
+      : null;
+
+  const rich = (baseline?.findings ?? []).filter((e): e is RichBaselineEntry => !isSanitized(e));
+  const byId = new Map(rich.map((e) => [e.id, e]));
+  const now = opts.now ?? new Date();
+  const allowlist = tryLoadAllowlist(cwd);
+  const deferred = (allowlist?.entries ?? [])
+    .filter(
+      (e) =>
+        e.category === 'deferred' &&
+        typeof e.expiresAt === 'string' &&
+        daysUntilDate(e.expiresAt, now) >= 0,
+    )
+    .map((allow) => ({ allow, entry: byId.get(allow.fingerprint) ?? null }));
+  const deferredIds = new Set(deferred.map((d) => d.allow.fingerprint));
+  const debt = rich.filter((e) => e.kind === 'custom-check' && !deferredIds.has(e.id));
+
+  return {
+    entryFloor,
+    blocking: [],
+    deferred,
+    debt,
+    manifests: [rootManifest(cwd)],
+    install: installCommandFor(cwd),
+    policy: { maxSliceSize: config.workOrders.maxSliceSize, budget: config.agent.budget },
+  };
+}
+
+/** Gather + plan in one call: the surface entry point. */
+export function planRepoWorkOrders(
+  cwd: string,
+  config: RemediateConfig,
+  opts: GatherWorkOrderOptions = {},
+): WorkOrderPlan {
+  return planWorkOrders(gatherWorkOrderInputs(cwd, config, opts));
+}

--- a/src/remediate/work-orders/gather.ts
+++ b/src/remediate/work-orders/gather.ts
@@ -5,55 +5,84 @@
  * `gatherWorkOrderInputs` / `planRepoWorkOrders`, so no surface can forget a
  * source or join it differently.
  *
- * Sources it reads:
- *   - the entry floor: `runCorrectnessFloor` on the pristine tree, attributed
- *     against the baseline's recorded floor-debt envelope through the one
- *     comparator (`attributeFloorFailures`; an absent envelope reads as
- *     unattributed, never as net-new);
- *   - the committed baseline's custom-check entries (the lint backlog);
- *   - active allowlist deferrals joined by fingerprint to baseline entries;
- *   - repo facts: the package manager's provision command and the root
- *     dependency root (manifest + lockfile).
+ * Sources, each through its canonical entry point:
+ *   - the entry floor, CHEAP by default: the baseline's recorded floor-debt
+ *     envelope, else the loop's floor snapshot; the live floor only behind
+ *     `withFloor` (bounded by `timeoutMs`). Which source was used is
+ *     disclosed (`floorSource`). A live floor is attributed against the
+ *     envelope through the one comparator (`attributeFloorFailures` over
+ *     `floorDebtToBaseChecks`); a stored source is by definition
+ *     pre-existing.
+ *   - active deferrals (`activeDeferredEntries`, the same selector `debt`
+ *     reads), joined by fingerprint to the LIVE dependency scan first (the
+ *     producers of a deferral keep its finding OUT of the baseline) and to
+ *     the baseline entry as a fallback. The live scan runs only when a
+ *     deferred dep-vuln exists.
+ *   - grandfathered debt: baseline entries NOT under any active allowlist
+ *     entry (`partitionByActiveAllowlist`).
+ *   - repo facts from the packs: the first pack-declared `provision`
+ *     command (undefined when none, disclosed) and the dependency roots
+ *     (the root plus `discoverNestedDepRoots` over the packs' lockfile
+ *     patterns, matched against the pack-declared manifest patterns).
  *
  * Guardrail blocking pairs are NOT gathered here: they exist only inside a
- * verify step (post-agent). The executor unit passes them into the planner
- * from the verify result it already holds.
+ * verify step (post-agent). The executor unit passes them in from the verify
+ * result it already holds.
  */
 import * as fs from 'fs';
+import * as path from 'path';
 import { runCorrectnessFloor, type CorrectnessFloorResult } from '../../analyzers/correctness/run';
+import { attributeFloorFailures } from '../../analyzers/correctness/attribution';
+import { detectActiveLanguages, allDependencyManifestPatterns } from '../../languages';
+import type { LanguageSupport } from '../../languages/types';
 import {
-  attributeFloorFailures,
-  type FloorBaseCheck,
-} from '../../analyzers/correctness/attribution';
-import { detectActiveLanguages } from '../../languages';
-import { pathForBaseline, readBaselineFile, type BaselineFile } from '../../baseline/baseline-file';
+  DEFAULT_BASELINE_NAME,
+  pathForBaseline,
+  readBaselineFile,
+  type BaselineFile,
+} from '../../baseline/baseline-file';
+import { floorDebtToBaseChecks, type FloorDebt } from '../../baseline/floor-debt';
+import { readFloorBaseline } from '../../loop/floor-state';
 import { isSanitized } from '../../baseline/sanitize';
 import type { RichBaselineEntry } from '../../baseline/types';
-import { daysUntilDate, tryLoadAllowlist } from '../../allowlist/file';
-import { detectLockfile, detectPackageManager, provisionCommand } from '../../package-manager';
-import type { RemediateConfig } from '../config';
-import { planWorkOrders, type ManifestRoot, type PlannerInput } from './planner';
-import type { WorkOrderPlan } from './types';
+import { activeDeferredEntries, tryLoadAllowlist, type AllowlistFile } from '../../allowlist/file';
+import { partitionByActiveAllowlist } from '../../baseline/allowlist-match';
+import { discoverNestedDepRoots } from '../../analyzers/security/nested-dep-roots';
+import { gatherDepVulnsWithAvailability } from '../../analyzers/security/gather';
+import type { DepVulnFinding } from '../../languages/capabilities/types';
+import { budgetForTask, type RemediateConfig } from '../config';
+import {
+  planWorkOrders,
+  type AdvisoryInput,
+  type DeferredInput,
+  type FloorFailureInput,
+  type ManifestRoot,
+  type PlannerInput,
+} from './planner';
+import { WORK_ORDER_CLASSES, isBuiltinWorkOrderClass, type WorkOrderPlan } from './types';
+import type { RemediateTaskId } from '../tasks';
+
+export type FloorSource = 'live' | 'baseline-envelope' | 'loop-snapshot' | 'none';
 
 export interface GatherWorkOrderOptions {
-  /** Injected floor run (tests); defaults to the real full-scope floor. */
+  /** Run the live floor (default: read a stored envelope). */
+  readonly withFloor?: boolean;
+  /** Per-command timeout for the live floor. */
+  readonly timeoutMs?: number;
+  /** Injected floor run (tests); implies `withFloor`. */
   readonly runFloor?: (cwd: string) => CorrectnessFloorResult;
+  /** Injected live dependency scan (tests). */
+  readonly scanDepVulns?: (cwd: string) => Promise<readonly DepVulnFinding[] | null>;
   /** The clock for deferral expiry (injectable for tests). */
   readonly now?: Date;
   readonly baselineName?: string;
+  /** Injected active packs (tests). */
+  readonly packs?: readonly LanguageSupport[];
 }
 
-/** The baseline's recorded floor envelope as the comparator's base side. The
- *  envelope records check status only (no finding-level identities), so the
- *  comparator works at CHECK precision and says so. */
-function baseChecksFrom(baseline: BaselineFile | null): FloorBaseCheck[] | null {
-  const debt = baseline?.floorDebt;
-  if (!debt) return null;
-  return debt.checks.map((c) => ({
-    pack: c.pack,
-    label: c.label,
-    status: c.status === 'pass' ? 'pass' : c.status === 'fail' ? 'fail' : 'skipped',
-  }));
+export interface GatheredWorkOrderInputs {
+  readonly input: PlannerInput;
+  readonly floorSource: FloorSource;
 }
 
 function readBaseline(cwd: string, name: string): BaselineFile | null {
@@ -65,78 +94,206 @@ function readBaseline(cwd: string, name: string): BaselineFile | null {
   }
 }
 
-/** The pm's provision command as `{ bin, args }` (the frame execFiles it). */
-export function installCommandFor(cwd: string): { bin: string; args: string[] } {
-  const [bin, ...args] = provisionCommand(detectPackageManager(cwd)).split(' ');
-  return { bin, args };
+/** The first pack-declared provision command, or undefined (disclosed). */
+export function installCommandFor(
+  cwd: string,
+  packs: readonly LanguageSupport[],
+): { bin: string; args: readonly string[] } | undefined {
+  for (const pack of packs) {
+    const cmd = pack.provision?.(cwd);
+    if (cmd) return cmd;
+  }
+  return undefined;
 }
 
-/** The root dependency root: manifest + lockfile when a lockfile is present,
- *  else the manifest alone. */
-export function rootManifest(cwd: string): ManifestRoot {
-  const lock = detectLockfile(cwd);
-  const files = ['package.json'];
-  if (lock) files.push(lock.lockfile);
-  return { dir: '', files: files.filter((f) => fs.existsSync(`${cwd}/${f}`)) };
+/** Dependency roots: the repo root plus every nested lockfile root the ONE
+ *  discovery primitive finds, each listing the pack-declared manifest files
+ *  present in it. */
+export function manifestRoots(cwd: string, packs: readonly LanguageSupport[]): ManifestRoot[] {
+  const patterns = allDependencyManifestPatterns(packs);
+  const lockfiles = [
+    ...new Set(packs.flatMap((p) => p.capabilities?.depVulns?.lockfilePatterns ?? [])),
+  ];
+  const dirs = [
+    '',
+    ...discoverNestedDepRoots(cwd, lockfiles).roots.map((r) => r.replace(/\\/g, '/')),
+  ];
+  return dirs.map((dir) => ({
+    dir,
+    files: patterns.filter((f) => fs.existsSync(path.join(cwd, dir, f))).sort(),
+  }));
 }
 
-export function gatherWorkOrderInputs(
+/** Stored floor envelope -> failing checks, attributed pre-existing. */
+function storedFloorFailures(debt: FloorDebt): FloorFailureInput[] {
+  return debt.checks
+    .filter((c) => c.status === 'fail')
+    .map((c) => ({
+      pack: c.pack,
+      label: c.label,
+      command: c.command,
+      ...(c.output !== undefined ? { output: c.output } : {}),
+      attribution: 'pre-existing' as const,
+    }));
+}
+
+function liveFloorFailures(
+  floor: CorrectnessFloorResult,
+  baseline: BaselineFile | null,
+): FloorFailureInput[] {
+  const base = baseline?.floorDebt ? floorDebtToBaseChecks(baseline.floorDebt) : null;
+  return attributeFloorFailures(floor, base, { absentMeans: 'unattributed' })
+    .filter((a) => a.check.status === 'fail')
+    .map((a) => ({
+      pack: a.check.pack,
+      label: a.check.label,
+      command: [a.check.bin, ...(a.check.args ?? [])].filter(Boolean).join(' ').trim(),
+      ...(a.check.output !== undefined ? { output: a.check.output } : {}),
+      attribution: a.attribution,
+      ...(a.precision !== undefined ? { precision: a.precision } : {}),
+      ...(a.netNewFindings !== undefined ? { netNewFindings: a.netNewFindings } : {}),
+      ...(a.check.unresolved !== undefined ? { unresolved: a.check.unresolved } : {}),
+    }));
+}
+
+function gatherFloor(
+  cwd: string,
+  baseline: BaselineFile | null,
+  packs: readonly LanguageSupport[],
+  opts: GatherWorkOrderOptions,
+): { failures: FloorFailureInput[]; source: FloorSource } {
+  if (opts.withFloor || opts.runFloor) {
+    const run =
+      opts.runFloor ??
+      ((dir: string) =>
+        runCorrectnessFloor({
+          cwd: dir,
+          changedFiles: [],
+          scope: 'full',
+          packs,
+          ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+        }));
+    return { failures: liveFloorFailures(run(cwd), baseline), source: 'live' };
+  }
+  if (baseline?.floorDebt) {
+    return { failures: storedFloorFailures(baseline.floorDebt), source: 'baseline-envelope' };
+  }
+  const snapshot = readFloorBaseline(cwd);
+  if (snapshot) {
+    return {
+      failures: snapshot.checks
+        .filter((c) => c.status === 'fail')
+        .map((c) => ({
+          pack: c.pack,
+          label: c.label,
+          command: '',
+          attribution: 'pre-existing' as const,
+        })),
+      source: 'loop-snapshot',
+    };
+  }
+  return { failures: [], source: 'none' };
+}
+
+function advisoryFromLive(f: DepVulnFinding): AdvisoryInput {
+  return {
+    id: f.fingerprint!,
+    package: f.package,
+    ...(f.installedVersion !== undefined ? { installedVersion: f.installedVersion } : {}),
+    advisoryId: f.id,
+    ...(f.severity !== undefined ? { severity: f.severity } : {}),
+    ...(f.fixedVersion !== undefined ? { fixedVersion: f.fixedVersion } : {}),
+    ...(f.reachable !== undefined ? { reachable: f.reachable } : {}),
+  };
+}
+
+function advisoryFromEntry(e: Extract<RichBaselineEntry, { kind: 'dep-vuln' }>): AdvisoryInput {
+  return {
+    id: e.id,
+    package: e.package,
+    ...(e.installedVersion !== undefined ? { installedVersion: e.installedVersion } : {}),
+    advisoryId: e.advisoryId,
+    ...(e.severity !== undefined ? { severity: e.severity } : {}),
+  };
+}
+
+async function joinDeferrals(
+  cwd: string,
+  allowlist: AllowlistFile | null,
+  byId: ReadonlyMap<string, RichBaselineEntry>,
+  opts: GatherWorkOrderOptions,
+): Promise<DeferredInput[]> {
+  const now = opts.now ?? new Date();
+  const deferred = activeDeferredEntries(allowlist, now);
+  const needsScan = deferred.some((d) => d.kind === 'dep-vuln');
+  const live = new Map<string, DepVulnFinding>();
+  if (needsScan) {
+    const scan =
+      opts.scanDepVulns ??
+      (async (dir: string) =>
+        (await gatherDepVulnsWithAvailability(dir)).envelope?.findings ?? null);
+    for (const f of (await scan(cwd)) ?? []) if (f.fingerprint) live.set(f.fingerprint, f);
+  }
+  return deferred.map((d): DeferredInput => {
+    const base = { fingerprint: d.fingerprint, expiresAt: d.expiresAt! };
+    const liveHit = live.get(d.fingerprint);
+    if (liveHit) return { ...base, kind: 'dep-vuln', advisory: advisoryFromLive(liveHit) };
+    const entry = byId.get(d.fingerprint);
+    if (!entry) return { ...base, kind: 'unjoined', declaredKind: d.kind };
+    if (entry.kind === 'dep-vuln')
+      return { ...base, kind: 'dep-vuln', advisory: advisoryFromEntry(entry) };
+    if (entry.kind === 'custom-check') return { ...base, kind: 'custom-check', entry };
+    return { ...base, kind: 'other', entry };
+  });
+}
+
+/** Per class, the selecting task's effective budget (one budget per concept). */
+function budgetResolver(config: RemediateConfig): PlannerInput['policy']['budgetFor'] {
+  return (cls) => {
+    const task = isBuiltinWorkOrderClass(cls) ? WORK_ORDER_CLASSES[cls].task : undefined;
+    return task ? budgetForTask(config, task as RemediateTaskId) : config.agent.budget;
+  };
+}
+
+export async function gatherWorkOrderInputs(
   cwd: string,
   config: RemediateConfig,
   opts: GatherWorkOrderOptions = {},
-): PlannerInput {
-  const baseline = readBaseline(cwd, opts.baselineName ?? 'main');
-  const runFloor =
-    opts.runFloor ??
-    ((dir: string) =>
-      runCorrectnessFloor({
-        cwd: dir,
-        changedFiles: [],
-        scope: 'full',
-        packs: detectActiveLanguages(dir),
-      }));
-  const floor = runFloor(cwd);
-  const entryFloor =
-    floor.checks.length > 0
-      ? {
-          result: floor,
-          attributed: attributeFloorFailures(floor, baseChecksFrom(baseline), {
-            absentMeans: 'unattributed',
-          }),
-        }
-      : null;
+): Promise<GatheredWorkOrderInputs> {
+  const packs = opts.packs ?? detectActiveLanguages(cwd);
+  const baseline = readBaseline(cwd, opts.baselineName ?? DEFAULT_BASELINE_NAME);
+  const floor = gatherFloor(cwd, baseline, packs, opts);
 
   const rich = (baseline?.findings ?? []).filter((e): e is RichBaselineEntry => !isSanitized(e));
   const byId = new Map(rich.map((e) => [e.id, e]));
-  const now = opts.now ?? new Date();
   const allowlist = tryLoadAllowlist(cwd);
-  const deferred = (allowlist?.entries ?? [])
-    .filter(
-      (e) =>
-        e.category === 'deferred' &&
-        typeof e.expiresAt === 'string' &&
-        daysUntilDate(e.expiresAt, now) >= 0,
-    )
-    .map((allow) => ({ allow, entry: byId.get(allow.fingerprint) ?? null }));
-  const deferredIds = new Set(deferred.map((d) => d.allow.fingerprint));
-  const debt = rich.filter((e) => e.kind === 'custom-check' && !deferredIds.has(e.id));
+  const now = opts.now ?? new Date();
+  const deferred = await joinDeferrals(cwd, allowlist, byId, opts);
+  const debt = partitionByActiveAllowlist(rich, allowlist, now).live.filter(
+    (e) => e.kind === 'custom-check',
+  );
+  const install = installCommandFor(cwd, packs);
 
   return {
-    entryFloor,
-    blocking: [],
-    deferred,
-    debt,
-    manifests: [rootManifest(cwd)],
-    install: installCommandFor(cwd),
-    policy: { maxSliceSize: config.workOrders.maxSliceSize, budget: config.agent.budget },
+    floorSource: floor.source,
+    input: {
+      floorFailures: floor.failures,
+      blocking: [],
+      deferred,
+      debt,
+      manifests: manifestRoots(cwd, packs),
+      ...(install ? { install } : {}),
+      policy: { maxSliceSize: config.workOrders.maxSliceSize, budgetFor: budgetResolver(config) },
+    },
   };
 }
 
 /** Gather + plan in one call: the surface entry point. */
-export function planRepoWorkOrders(
+export async function planRepoWorkOrders(
   cwd: string,
   config: RemediateConfig,
   opts: GatherWorkOrderOptions = {},
-): WorkOrderPlan {
-  return planWorkOrders(gatherWorkOrderInputs(cwd, config, opts));
+): Promise<{ plan: WorkOrderPlan; floorSource: FloorSource }> {
+  const gathered = await gatherWorkOrderInputs(cwd, config, opts);
+  return { plan: planWorkOrders(gathered.input), floorSource: gathered.floorSource };
 }

--- a/src/remediate/work-orders/gather.ts
+++ b/src/remediate/work-orders/gather.ts
@@ -40,6 +40,7 @@ import * as path from 'path';
 import { runCorrectnessFloor, type CorrectnessFloorResult } from '../../analyzers/correctness/run';
 import { attributeFloorFailures } from '../../analyzers/correctness/attribution';
 import { detectActiveLanguages, matchesManifestPattern } from '../../languages';
+import { LOCKFILE_SYNC_LABEL } from '../../languages/capabilities/correctness';
 import type { LanguageSupport } from '../../languages/types';
 import {
   DEFAULT_BASELINE_NAME,
@@ -365,7 +366,7 @@ export async function gatherWorkOrderInputs(
   const needsManifests =
     deferred.some((d) => d.kind === 'dep-vuln') ||
     debt.some((e) => e.kind === 'dep-vuln') ||
-    floor.failures.some((f) => (f.unresolved?.length ?? 0) > 0);
+    floor.failures.some((f) => (f.unresolved?.length ?? 0) > 0 || f.label === LOCKFILE_SYNC_LABEL);
   const manifests: ManifestRoot[] = needsManifests
     ? manifestRoots(cwd, packs, disclosures)
     : [{ dir: '', files: [] }];

--- a/src/remediate/work-orders/gather.ts
+++ b/src/remediate/work-orders/gather.ts
@@ -3,7 +3,10 @@
  * one concept, one code path). Every surface that wants a work-order plan
  * for a repo (the plan CLI today; the executor in a later unit) calls
  * `gatherWorkOrderInputs` / `planRepoWorkOrders`, so no surface can forget a
- * source or join it differently.
+ * source or join it differently. Every degraded read is DISCLOSED
+ * (`disclosures`): a corrupt baseline, capped dependency roots, which scan
+ * source answered the deferral join. The GateFailure discipline: fail open,
+ * always say why.
  *
  * Sources, each through its canonical entry point:
  *   - the entry floor, CHEAP by default: the baseline's recorded floor-debt
@@ -14,16 +17,19 @@
  *     `floorDebtToBaseChecks`); a stored source is by definition
  *     pre-existing.
  *   - active deferrals (`activeDeferredEntries`, the same selector `debt`
- *     reads), joined by fingerprint to the LIVE dependency scan first (the
- *     producers of a deferral keep its finding OUT of the baseline) and to
- *     the baseline entry as a fallback. The live scan runs only when a
- *     deferred dep-vuln exists.
- *   - grandfathered debt: baseline entries NOT under any active allowlist
- *     entry (`partitionByActiveAllowlist`).
- *   - repo facts from the packs: the first pack-declared `provision`
- *     command (undefined when none, disclosed) and the dependency roots
- *     (the root plus `discoverNestedDepRoots` over the packs' lockfile
- *     patterns, matched against the pack-declared manifest patterns).
+ *     reads), joined by fingerprint to a dependency scan (the deferral
+ *     producers keep the finding OUT of the baseline), with the baseline
+ *     entry as a fallback. The scan prefers a fresh persisted BoM artifact
+ *     (`.dxkit/bom.json`) and pays a live audit only when none exists; it
+ *     runs at all only when a dep-vuln deferral exists.
+ *   - grandfathered debt: ALL baseline entries not under any active
+ *     allowlist entry (`partitionByActiveAllowlist`); the planner
+ *     classifies kinds and discloses the classless ones.
+ *   - repo facts from the packs: per-pack `provision` commands (an order
+ *     resolves its own ecosystem's; none = disclosed) and the dependency
+ *     roots (the ONE per-pack derivation `discoverPackDepRoots`, shared
+ *     with the audit, dropped roots disclosed), with the manifest files
+ *     matched through the canonical glob-aware `matchesManifestPattern`.
  *
  * Guardrail blocking pairs are NOT gathered here: they exist only inside a
  * verify step (post-agent). The executor unit passes them in from the verify
@@ -33,7 +39,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { runCorrectnessFloor, type CorrectnessFloorResult } from '../../analyzers/correctness/run';
 import { attributeFloorFailures } from '../../analyzers/correctness/attribution';
-import { detectActiveLanguages, allDependencyManifestPatterns } from '../../languages';
+import { detectActiveLanguages, matchesManifestPattern } from '../../languages';
 import type { LanguageSupport } from '../../languages/types';
 import {
   DEFAULT_BASELINE_NAME,
@@ -41,13 +47,13 @@ import {
   readBaselineFile,
   type BaselineFile,
 } from '../../baseline/baseline-file';
-import { floorDebtToBaseChecks, type FloorDebt } from '../../baseline/floor-debt';
+import { failingFloorDebt, floorDebtToBaseChecks, type FloorDebt } from '../../baseline/floor-debt';
 import { readFloorBaseline } from '../../loop/floor-state';
 import { isSanitized } from '../../baseline/sanitize';
 import type { RichBaselineEntry } from '../../baseline/types';
 import { activeDeferredEntries, tryLoadAllowlist, type AllowlistFile } from '../../allowlist/file';
 import { partitionByActiveAllowlist } from '../../baseline/allowlist-match';
-import { discoverNestedDepRoots } from '../../analyzers/security/nested-dep-roots';
+import { discoverPackDepRoots } from '../../analyzers/security/nested-dep-roots';
 import { gatherDepVulnsWithAvailability } from '../../analyzers/security/gather';
 import type { DepVulnFinding } from '../../languages/capabilities/types';
 import { budgetForTask, type RemediateConfig } from '../config';
@@ -59,10 +65,19 @@ import {
   type ManifestRoot,
   type PlannerInput,
 } from './planner';
+import type { InstallFor } from './shared';
 import { WORK_ORDER_CLASSES, isBuiltinWorkOrderClass, type WorkOrderPlan } from './types';
 import type { RemediateTaskId } from '../tasks';
 
 export type FloorSource = 'live' | 'baseline-envelope' | 'loop-snapshot' | 'none';
+
+/** Which source answered the deferral join. */
+export type DepScanSource = 'bom-artifact' | 'live-scan' | 'injected' | 'not-needed';
+
+/** How long a persisted BoM artifact counts as fresh for the deferral join.
+ *  Deferral windows are days; a week-old fixed-version fact is still the
+ *  right starting point, and the disclosure names the age either way. */
+export const BOM_FRESHNESS_DAYS = 7;
 
 export interface GatherWorkOrderOptions {
   /** Run the live floor (default: read a stored envelope). */
@@ -71,9 +86,9 @@ export interface GatherWorkOrderOptions {
   readonly timeoutMs?: number;
   /** Injected floor run (tests); implies `withFloor`. */
   readonly runFloor?: (cwd: string) => CorrectnessFloorResult;
-  /** Injected live dependency scan (tests). */
+  /** Injected dependency scan (tests / the executor's already-run scan). */
   readonly scanDepVulns?: (cwd: string) => Promise<readonly DepVulnFinding[] | null>;
-  /** The clock for deferral expiry (injectable for tests). */
+  /** The clock for deferral expiry + artifact freshness (injectable). */
   readonly now?: Date;
   readonly baselineName?: string;
   /** Injected active packs (tests). */
@@ -83,58 +98,84 @@ export interface GatherWorkOrderOptions {
 export interface GatheredWorkOrderInputs {
   readonly input: PlannerInput;
   readonly floorSource: FloorSource;
+  readonly depScanSource: DepScanSource;
+  /** Degraded reads, phrased for humans; empty when nothing degraded. */
+  readonly disclosures: readonly string[];
 }
 
-function readBaseline(cwd: string, name: string): BaselineFile | null {
+function readBaseline(cwd: string, name: string, disclosures: string[]): BaselineFile | null {
+  const p = pathForBaseline(cwd, name);
   try {
-    const p = pathForBaseline(cwd, name);
     return fs.existsSync(p) ? readBaselineFile(p) : null;
-  } catch {
-    return null; // unreadable baseline: the plan proceeds without it, disclosed by emptiness
+  } catch (err) {
+    disclosures.push(
+      `baseline '${name}' exists but could not be read (${err instanceof Error ? err.message : String(err)}); ` +
+        'the plan proceeds WITHOUT the recorded backlog: floor attribution and debt are incomplete',
+    );
+    return null;
   }
 }
 
-/** The first pack-declared provision command, or undefined (disclosed). */
-export function installCommandFor(
-  cwd: string,
-  packs: readonly LanguageSupport[],
-): { bin: string; args: readonly string[] } | undefined {
+/** Per producing pack, its declared install command. A finding that does not
+ *  name its pack falls back to the single unambiguous declared command when
+ *  exactly one active pack declares any. */
+export function installResolver(cwd: string, packs: readonly LanguageSupport[]): InstallFor {
+  const byPack = new Map<string, { bin: string; args: readonly string[] }>();
   for (const pack of packs) {
     const cmd = pack.provision?.(cwd);
-    if (cmd) return cmd;
+    if (cmd) byPack.set(pack.id, cmd);
   }
-  return undefined;
+  const single = byPack.size === 1 ? [...byPack.values()][0] : undefined;
+  return (pack) => (pack !== undefined ? byPack.get(pack) : single);
 }
 
-/** Dependency roots: the repo root plus every nested lockfile root the ONE
- *  discovery primitive finds, each listing the pack-declared manifest files
- *  present in it. */
-export function manifestRoots(cwd: string, packs: readonly LanguageSupport[]): ManifestRoot[] {
-  const patterns = allDependencyManifestPatterns(packs);
-  const lockfiles = [
-    ...new Set(packs.flatMap((p) => p.capabilities?.depVulns?.lockfilePatterns ?? [])),
+/** Dependency roots: the repo root plus every nested root the ONE per-pack
+ *  discovery (`discoverPackDepRoots`, shared with the audit) finds; each
+ *  root lists the files the pack-declared manifest patterns match, through
+ *  the canonical glob-aware matcher. Dropped (capped) roots are disclosed. */
+export function manifestRoots(
+  cwd: string,
+  packs: readonly LanguageSupport[],
+  disclosures: string[],
+): ManifestRoot[] {
+  const patterns = [
+    ...new Set(packs.flatMap((p) => p.capabilities?.depVulns?.manifestPatterns ?? [])),
   ];
-  const dirs = [
-    '',
-    ...discoverNestedDepRoots(cwd, lockfiles).roots.map((r) => r.replace(/\\/g, '/')),
-  ];
-  return dirs.map((dir) => ({
-    dir,
-    files: patterns.filter((f) => fs.existsSync(path.join(cwd, dir, f))).sort(),
-  }));
+  const dirs = new Set<string>(['']);
+  for (const pack of packs) {
+    const discovery = discoverPackDepRoots(cwd, pack);
+    for (const r of discovery.roots) dirs.add(r);
+    if (discovery.dropped.length > 0) {
+      disclosures.push(
+        `dependency-root discovery (${pack.id}) capped: not auditing ${discovery.dropped.join(', ')}`,
+      );
+    }
+  }
+  return [...dirs].sort().map((dir) => {
+    let files: string[] = [];
+    try {
+      files = fs
+        .readdirSync(path.join(cwd, dir), { withFileTypes: true })
+        .filter((d) => d.isFile())
+        .map((d) => d.name)
+        .filter((name) => patterns.some((p) => matchesManifestPattern(name, p)))
+        .sort();
+    } catch {
+      /* unreadable root: empty file list, the envelope falls back to others */
+    }
+    return { dir, files };
+  });
 }
 
 /** Stored floor envelope -> failing checks, attributed pre-existing. */
 function storedFloorFailures(debt: FloorDebt): FloorFailureInput[] {
-  return debt.checks
-    .filter((c) => c.status === 'fail')
-    .map((c) => ({
-      pack: c.pack,
-      label: c.label,
-      command: c.command,
-      ...(c.output !== undefined ? { output: c.output } : {}),
-      attribution: 'pre-existing' as const,
-    }));
+  return failingFloorDebt(debt).map((c) => ({
+    pack: c.pack,
+    label: c.label,
+    command: c.command,
+    ...(c.output !== undefined ? { output: c.output } : {}),
+    attribution: 'pre-existing' as const,
+  }));
 }
 
 function liveFloorFailures(
@@ -142,18 +183,18 @@ function liveFloorFailures(
   baseline: BaselineFile | null,
 ): FloorFailureInput[] {
   const base = baseline?.floorDebt ? floorDebtToBaseChecks(baseline.floorDebt) : null;
-  return attributeFloorFailures(floor, base, { absentMeans: 'unattributed' })
-    .filter((a) => a.check.status === 'fail')
-    .map((a) => ({
-      pack: a.check.pack,
-      label: a.check.label,
-      command: [a.check.bin, ...(a.check.args ?? [])].filter(Boolean).join(' ').trim(),
-      ...(a.check.output !== undefined ? { output: a.check.output } : {}),
-      attribution: a.attribution,
-      ...(a.precision !== undefined ? { precision: a.precision } : {}),
-      ...(a.netNewFindings !== undefined ? { netNewFindings: a.netNewFindings } : {}),
-      ...(a.check.unresolved !== undefined ? { unresolved: a.check.unresolved } : {}),
-    }));
+  // attributeFloorFailures returns only the FAILING checks.
+  return attributeFloorFailures(floor, base, { absentMeans: 'unattributed' }).map((a) => ({
+    pack: a.check.pack,
+    label: a.check.label,
+    command: [a.check.bin, ...(a.check.args ?? [])].filter(Boolean).join(' ').trim(),
+    ...(a.check.output !== undefined ? { output: a.check.output } : {}),
+    attribution: a.attribution,
+    ...(a.precision !== undefined ? { precision: a.precision } : {}),
+    ...(a.netNewFindings !== undefined ? { netNewFindings: a.netNewFindings } : {}),
+    ...(a.check.findings !== undefined ? { findings: a.check.findings } : {}),
+    ...(a.check.unresolved !== undefined ? { unresolved: a.check.unresolved } : {}),
+  }));
 }
 
 function gatherFloor(
@@ -181,14 +222,13 @@ function gatherFloor(
   const snapshot = readFloorBaseline(cwd);
   if (snapshot) {
     return {
-      failures: snapshot.checks
-        .filter((c) => c.status === 'fail')
-        .map((c) => ({
-          pack: c.pack,
-          label: c.label,
-          command: '',
-          attribution: 'pre-existing' as const,
-        })),
+      failures: failingFloorDebt(snapshot).map((c) => ({
+        pack: c.pack,
+        label: c.label,
+        command: '',
+        attribution: 'pre-existing' as const,
+        ...(c.findings !== undefined ? { findings: c.findings } : {}),
+      })),
       source: 'loop-snapshot',
     };
   }
@@ -204,6 +244,7 @@ function advisoryFromLive(f: DepVulnFinding): AdvisoryInput {
     ...(f.severity !== undefined ? { severity: f.severity } : {}),
     ...(f.fixedVersion !== undefined ? { fixedVersion: f.fixedVersion } : {}),
     ...(f.reachable !== undefined ? { reachable: f.reachable } : {}),
+    ...(f.packId !== undefined ? { pack: f.packId } : {}),
   };
 }
 
@@ -217,27 +258,73 @@ function advisoryFromEntry(e: Extract<RichBaselineEntry, { kind: 'dep-vuln' }>):
   };
 }
 
+/** A fresh persisted BoM artifact's findings, when one exists (the scan the
+ *  repo already paid for), else null. Defensive: any shape surprise reads as
+ *  absent, never a crash. */
+function bomArtifactFindings(
+  cwd: string,
+  now: Date,
+): { findings: DepVulnFinding[]; ageDays: number } | null {
+  try {
+    const p = path.join(cwd, '.dxkit', 'bom.json');
+    if (!fs.existsSync(p)) return null;
+    const bom = JSON.parse(fs.readFileSync(p, 'utf8')) as {
+      analyzedAt?: string;
+      entries?: ReadonlyArray<{ vulns?: DepVulnFinding[] }>;
+    };
+    if (typeof bom.analyzedAt !== 'string' || !Array.isArray(bom.entries)) return null;
+    const ageDays = (now.getTime() - Date.parse(bom.analyzedAt)) / 86_400_000;
+    if (!Number.isFinite(ageDays) || ageDays < 0 || ageDays > BOM_FRESHNESS_DAYS) return null;
+    const findings = bom.entries.flatMap((e) => e.vulns ?? []).filter((v) => v && v.fingerprint);
+    return { findings, ageDays };
+  } catch {
+    return null;
+  }
+}
+
 async function joinDeferrals(
   cwd: string,
   allowlist: AllowlistFile | null,
   byId: ReadonlyMap<string, RichBaselineEntry>,
   opts: GatherWorkOrderOptions,
-): Promise<DeferredInput[]> {
+  disclosures: string[],
+): Promise<{ deferred: DeferredInput[]; depScanSource: DepScanSource }> {
   const now = opts.now ?? new Date();
   const deferred = activeDeferredEntries(allowlist, now);
   const needsScan = deferred.some((d) => d.kind === 'dep-vuln');
-  const live = new Map<string, DepVulnFinding>();
+  const scanned = new Map<string, DepVulnFinding>();
+  let depScanSource: DepScanSource = 'not-needed';
   if (needsScan) {
-    const scan =
-      opts.scanDepVulns ??
-      (async (dir: string) =>
-        (await gatherDepVulnsWithAvailability(dir)).envelope?.findings ?? null);
-    for (const f of (await scan(cwd)) ?? []) if (f.fingerprint) live.set(f.fingerprint, f);
+    if (opts.scanDepVulns) {
+      depScanSource = 'injected';
+      for (const f of (await opts.scanDepVulns(cwd)) ?? []) {
+        if (f.fingerprint) scanned.set(f.fingerprint, f);
+      }
+    } else {
+      const bom = bomArtifactFindings(cwd, now);
+      if (bom) {
+        depScanSource = 'bom-artifact';
+        disclosures.push(
+          `deferral join read the persisted BoM artifact (.dxkit/bom.json, ` +
+            `${bom.ageDays.toFixed(1)} day(s) old) instead of paying a live dependency audit`,
+        );
+        for (const f of bom.findings) scanned.set(f.fingerprint!, f);
+      } else {
+        depScanSource = 'live-scan';
+        disclosures.push(
+          'deferral join ran a live dependency audit (no fresh .dxkit/bom.json artifact to read)',
+        );
+        const result = await gatherDepVulnsWithAvailability(cwd);
+        for (const f of result.envelope?.findings ?? []) {
+          if (f.fingerprint) scanned.set(f.fingerprint, f);
+        }
+      }
+    }
   }
-  return deferred.map((d): DeferredInput => {
+  const joined = deferred.map((d): DeferredInput => {
     const base = { fingerprint: d.fingerprint, expiresAt: d.expiresAt! };
-    const liveHit = live.get(d.fingerprint);
-    if (liveHit) return { ...base, kind: 'dep-vuln', advisory: advisoryFromLive(liveHit) };
+    const hit = scanned.get(d.fingerprint);
+    if (hit) return { ...base, kind: 'dep-vuln', advisory: advisoryFromLive(hit) };
     const entry = byId.get(d.fingerprint);
     if (!entry) return { ...base, kind: 'unjoined', declaredKind: d.kind };
     if (entry.kind === 'dep-vuln')
@@ -245,6 +332,7 @@ async function joinDeferrals(
     if (entry.kind === 'custom-check') return { ...base, kind: 'custom-check', entry };
     return { ...base, kind: 'other', entry };
   });
+  return { deferred: joined, depScanSource };
 }
 
 /** Per class, the selecting task's effective budget (one budget per concept). */
@@ -260,29 +348,39 @@ export async function gatherWorkOrderInputs(
   config: RemediateConfig,
   opts: GatherWorkOrderOptions = {},
 ): Promise<GatheredWorkOrderInputs> {
+  const disclosures: string[] = [];
   const packs = opts.packs ?? detectActiveLanguages(cwd);
-  const baseline = readBaseline(cwd, opts.baselineName ?? DEFAULT_BASELINE_NAME);
+  const baseline = readBaseline(cwd, opts.baselineName ?? DEFAULT_BASELINE_NAME, disclosures);
   const floor = gatherFloor(cwd, baseline, packs, opts);
 
   const rich = (baseline?.findings ?? []).filter((e): e is RichBaselineEntry => !isSanitized(e));
   const byId = new Map(rich.map((e) => [e.id, e]));
   const allowlist = tryLoadAllowlist(cwd);
   const now = opts.now ?? new Date();
-  const deferred = await joinDeferrals(cwd, allowlist, byId, opts);
-  const debt = partitionByActiveAllowlist(rich, allowlist, now).live.filter(
-    (e) => e.kind === 'custom-check',
-  );
-  const install = installCommandFor(cwd, packs);
+  const { deferred, depScanSource } = await joinDeferrals(cwd, allowlist, byId, opts, disclosures);
+  const debt = partitionByActiveAllowlist(rich, allowlist, now).live;
+
+  // Manifest roots are consulted only by dependency-shaped orders; skip the
+  // walk entirely when nothing will read them.
+  const needsManifests =
+    deferred.some((d) => d.kind === 'dep-vuln') ||
+    debt.some((e) => e.kind === 'dep-vuln') ||
+    floor.failures.some((f) => (f.unresolved?.length ?? 0) > 0);
+  const manifests: ManifestRoot[] = needsManifests
+    ? manifestRoots(cwd, packs, disclosures)
+    : [{ dir: '', files: [] }];
 
   return {
     floorSource: floor.source,
+    depScanSource,
+    disclosures,
     input: {
       floorFailures: floor.failures,
       blocking: [],
       deferred,
       debt,
-      manifests: manifestRoots(cwd, packs),
-      ...(install ? { install } : {}),
+      manifests,
+      installFor: installResolver(cwd, packs),
       policy: { maxSliceSize: config.workOrders.maxSliceSize, budgetFor: budgetResolver(config) },
     },
   };
@@ -293,7 +391,17 @@ export async function planRepoWorkOrders(
   cwd: string,
   config: RemediateConfig,
   opts: GatherWorkOrderOptions = {},
-): Promise<{ plan: WorkOrderPlan; floorSource: FloorSource }> {
+): Promise<{
+  plan: WorkOrderPlan;
+  floorSource: FloorSource;
+  depScanSource: DepScanSource;
+  disclosures: readonly string[];
+}> {
   const gathered = await gatherWorkOrderInputs(cwd, config, opts);
-  return { plan: planWorkOrders(gathered.input), floorSource: gathered.floorSource };
+  return {
+    plan: planWorkOrders(gathered.input),
+    floorSource: gathered.floorSource,
+    depScanSource: gathered.depScanSource,
+    disclosures: gathered.disclosures,
+  };
 }

--- a/src/remediate/work-orders/lint-orders.ts
+++ b/src/remediate/work-orders/lint-orders.ts
@@ -1,0 +1,145 @@
+/**
+ * Located lint orders (`lint-located`): one order per file. Blocking and
+ * deferred custom-check findings arrive attributed; grandfathered debt is cut
+ * by file, then by rule and line, into slices of at most `maxSliceSize`.
+ * Binary (whole-command) custom-check findings carry no file to scope an
+ * order to and are reported undispatchable with that reason.
+ */
+import type { RichBaselineEntry } from '../../baseline/types';
+import type { UndispatchableGroup, WorkOrderFinding, WorkOrderProvenance } from './types';
+import {
+  VALUE_BAND,
+  byteOrder,
+  deriveBudget,
+  doneFor,
+  undispatch,
+  type BudgetCapFor,
+  type Draft,
+  type Ranked,
+} from './shared';
+
+export type CustomCheckEntry = Extract<RichBaselineEntry, { kind: 'custom-check' }>;
+
+export interface LintOrderContext {
+  readonly maxSliceSize: number;
+  readonly capFor: BudgetCapFor;
+}
+
+export function lintFinding(
+  entry: CustomCheckEntry,
+  attribution: WorkOrderFinding['attribution'],
+): WorkOrderFinding {
+  return {
+    kind: 'custom-check',
+    id: entry.id,
+    attribution,
+    evidence: {
+      type: 'custom-check',
+      check: entry.check,
+      ...(entry.rule !== undefined ? { rule: entry.rule } : {}),
+      ...(entry.file !== undefined ? { file: entry.file } : {}),
+      ...(entry.line !== undefined ? { line: entry.line } : {}),
+      ...(entry.message !== undefined ? { message: entry.message } : {}),
+    },
+  };
+}
+
+function lintDraft(
+  file: string,
+  findings: readonly WorkOrderFinding[],
+  ctx: LintOrderContext,
+  provenance: WorkOrderProvenance,
+  idSuffix = '',
+): Draft {
+  return {
+    id: `lint-located:${file}${idSuffix}`,
+    class: 'lint-located',
+    findings,
+    envelope: { paths: [file], manifests: false },
+    constraints: { forbidden: [] },
+    done: doneFor('guardrail', findings),
+    budget: deriveBudget(findings.length, ctx.capFor('lint-located')),
+    provenance,
+  };
+}
+
+/** Attributed (blocking / deferred) located findings: one order per file. */
+export function attributedLintOrders(
+  entries: ReadonlyArray<{
+    readonly entry: CustomCheckEntry;
+    readonly attribution: WorkOrderFinding['attribution'];
+  }>,
+  ctx: LintOrderContext,
+  into: UndispatchableGroup[],
+): Ranked[] {
+  const byFile = new Map<string, WorkOrderFinding[]>();
+  const binary: WorkOrderFinding[] = [];
+  for (const { entry, attribution } of entries) {
+    const f = lintFinding(entry, attribution);
+    if (!entry.file) {
+      binary.push(f);
+      continue;
+    }
+    const list = byFile.get(entry.file) ?? [];
+    list.push(f);
+    byFile.set(entry.file, list);
+  }
+  undispatch(
+    into,
+    'binary (whole-command) custom-check findings carry no file to scope an order to',
+    binary,
+  );
+  return [...byFile.entries()]
+    .sort(([a], [b]) => byteOrder(a, b))
+    .map(([file, findings]) => ({
+      rank: [VALUE_BAND.otherBlocking, file],
+      draft: lintDraft(file, findings, ctx, { source: 'guardrail-blocking' }),
+    }));
+}
+
+/** Grandfathered debt: by file, then by rule and line, sliced. */
+export function debtLintOrders(
+  entries: readonly CustomCheckEntry[],
+  ctx: LintOrderContext,
+  into: UndispatchableGroup[],
+): Ranked[] {
+  const byFile = new Map<string, CustomCheckEntry[]>();
+  const binary: WorkOrderFinding[] = [];
+  for (const entry of entries) {
+    if (!entry.file) {
+      binary.push(lintFinding(entry, 'pre-existing'));
+      continue;
+    }
+    const list = byFile.get(entry.file) ?? [];
+    list.push(entry);
+    byFile.set(entry.file, list);
+  }
+  undispatch(
+    into,
+    'binary (whole-command) custom-check findings carry no file to scope an order to',
+    binary,
+  );
+  const max = Math.max(1, ctx.maxSliceSize);
+  const out: Ranked[] = [];
+  for (const [file, list] of [...byFile.entries()].sort(([a], [b]) => byteOrder(a, b))) {
+    const sorted = [...list].sort(
+      (a, b) => byteOrder(a.rule ?? '', b.rule ?? '') || (a.line ?? 0) - (b.line ?? 0),
+    );
+    const slices: CustomCheckEntry[][] = [];
+    for (let i = 0; i < sorted.length; i += max) slices.push(sorted.slice(i, i + max));
+    slices.forEach((slice, index) => {
+      const findings = slice.map((e) => lintFinding(e, 'pre-existing'));
+      out.push({
+        rank: [VALUE_BAND.debt, `${file}#${index + 1}`],
+        draft: lintDraft(
+          file,
+          findings,
+          ctx,
+          { source: 'debt-slice', file, slice: index + 1, of: slices.length },
+          slices.length > 1 ? `#${index + 1}` : '',
+        ),
+      });
+    });
+  }
+  return out;
+}

--- a/src/remediate/work-orders/lint-orders.ts
+++ b/src/remediate/work-orders/lint-orders.ts
@@ -1,20 +1,25 @@
 /**
- * Located lint orders (`lint-located`): one order per file. Blocking and
- * deferred custom-check findings arrive attributed; grandfathered debt is cut
- * by file, then by rule and line, into slices of at most `maxSliceSize`.
+ * Located lint orders (`lint-located`): ONE order per file, unioning
+ * blocking, deferred, and grandfathered findings (a file in two sources is
+ * one unit of work; per-finding attribution records which is which). Large
+ * sets are cut into slices of at most `maxSliceSize` (suffix `#n` from the
+ * second slice, so ids never collide). Rank: a slice carrying a deferral
+ * sits in the expiring band by soonest expiry; one carrying a net-new
+ * finding in the blocking band; pure debt in the debt band.
+ *
  * Binary (whole-command) custom-check findings carry no file to scope an
- * order to and are reported undispatchable with that reason.
+ * order to and are reported undispatchable with the one shared reason.
  */
 import type { RichBaselineEntry } from '../../baseline/types';
-import type { UndispatchableGroup, WorkOrderFinding, WorkOrderProvenance } from './types';
+import type { UndispatchableGroup, WorkOrderFinding } from './types';
 import {
+  BINARY_CUSTOM_CHECK_REASON,
   VALUE_BAND,
   byteOrder,
   deriveBudget,
   doneFor,
   undispatch,
   type BudgetCapFor,
-  type Draft,
   type Ranked,
 } from './shared';
 
@@ -25,14 +30,19 @@ export interface LintOrderContext {
   readonly capFor: BudgetCapFor;
 }
 
-export function lintFinding(
-  entry: CustomCheckEntry,
-  attribution: WorkOrderFinding['attribution'],
-): WorkOrderFinding {
+export interface LintSource {
+  readonly entry: CustomCheckEntry;
+  readonly attribution: WorkOrderFinding['attribution'];
+  /** Present for a deferred finding: the day it re-blocks. */
+  readonly expiresAt?: string;
+}
+
+export function lintFinding(src: LintSource): WorkOrderFinding {
+  const { entry } = src;
   return {
     kind: 'custom-check',
     id: entry.id,
-    attribution,
+    attribution: src.attribution,
     evidence: {
       type: 'custom-check',
       check: entry.check,
@@ -40,104 +50,88 @@ export function lintFinding(
       ...(entry.file !== undefined ? { file: entry.file } : {}),
       ...(entry.line !== undefined ? { line: entry.line } : {}),
       ...(entry.message !== undefined ? { message: entry.message } : {}),
+      ...(src.expiresAt !== undefined ? { expiresAt: src.expiresAt } : {}),
     },
   };
 }
 
-function lintDraft(
+const ATTRIBUTION_ORDER: Record<WorkOrderFinding['attribution'], number> = {
+  'net-new': 0,
+  deferred: 1,
+  unattributed: 2,
+  'pre-existing': 3,
+};
+
+function sliceRank(
   file: string,
+  index: number,
   findings: readonly WorkOrderFinding[],
-  ctx: LintOrderContext,
-  provenance: WorkOrderProvenance,
-  idSuffix = '',
-): Draft {
-  return {
-    id: `lint-located:${file}${idSuffix}`,
-    class: 'lint-located',
-    findings,
-    envelope: { paths: [file], manifests: false },
-    constraints: { forbidden: [] },
-    done: doneFor('guardrail', findings),
-    budget: deriveBudget(findings.length, ctx.capFor('lint-located')),
-    provenance,
-  };
+): Ranked['rank'] {
+  const expiries = findings
+    .map((f) => (f.evidence.type === 'custom-check' ? f.evidence.expiresAt : undefined))
+    .filter((e): e is string => typeof e === 'string')
+    .sort(byteOrder);
+  if (expiries.length > 0) return [VALUE_BAND.expiringDeferral, expiries[0]];
+  if (findings.some((f) => f.attribution === 'net-new'))
+    return [VALUE_BAND.otherBlocking, `${file}#${index}`];
+  return [VALUE_BAND.debt, `${file}#${index}`];
 }
 
-/** Attributed (blocking / deferred) located findings: one order per file. */
-export function attributedLintOrders(
-  entries: ReadonlyArray<{
-    readonly entry: CustomCheckEntry;
-    readonly attribution: WorkOrderFinding['attribution'];
-  }>,
+/** One order per file over every source; slices capped by `maxSliceSize`. */
+export function lintOrders(
+  sources: readonly LintSource[],
   ctx: LintOrderContext,
   into: UndispatchableGroup[],
 ): Ranked[] {
-  const byFile = new Map<string, WorkOrderFinding[]>();
+  const byFile = new Map<string, LintSource[]>();
   const binary: WorkOrderFinding[] = [];
-  for (const { entry, attribution } of entries) {
-    const f = lintFinding(entry, attribution);
-    if (!entry.file) {
-      binary.push(f);
+  for (const src of sources) {
+    if (!src.entry.file) {
+      binary.push(lintFinding(src));
       continue;
     }
-    const list = byFile.get(entry.file) ?? [];
-    list.push(f);
-    byFile.set(entry.file, list);
+    const list = byFile.get(src.entry.file) ?? [];
+    list.push(src);
+    byFile.set(src.entry.file, list);
   }
-  undispatch(
-    into,
-    'binary (whole-command) custom-check findings carry no file to scope an order to',
-    binary,
-  );
-  return [...byFile.entries()]
-    .sort(([a], [b]) => byteOrder(a, b))
-    .map(([file, findings]) => ({
-      rank: [VALUE_BAND.otherBlocking, file],
-      draft: lintDraft(file, findings, ctx, { source: 'guardrail-blocking' }),
-    }));
-}
+  undispatch(into, BINARY_CUSTOM_CHECK_REASON, binary);
 
-/** Grandfathered debt: by file, then by rule and line, sliced. */
-export function debtLintOrders(
-  entries: readonly CustomCheckEntry[],
-  ctx: LintOrderContext,
-  into: UndispatchableGroup[],
-): Ranked[] {
-  const byFile = new Map<string, CustomCheckEntry[]>();
-  const binary: WorkOrderFinding[] = [];
-  for (const entry of entries) {
-    if (!entry.file) {
-      binary.push(lintFinding(entry, 'pre-existing'));
-      continue;
-    }
-    const list = byFile.get(entry.file) ?? [];
-    list.push(entry);
-    byFile.set(entry.file, list);
-  }
-  undispatch(
-    into,
-    'binary (whole-command) custom-check findings carry no file to scope an order to',
-    binary,
-  );
   const max = Math.max(1, ctx.maxSliceSize);
   const out: Ranked[] = [];
   for (const [file, list] of [...byFile.entries()].sort(([a], [b]) => byteOrder(a, b))) {
+    // Attributed findings first (they are the order's point), then debt by
+    // rule + line so a slice is one rule's worth of work wherever possible.
     const sorted = [...list].sort(
-      (a, b) => byteOrder(a.rule ?? '', b.rule ?? '') || (a.line ?? 0) - (b.line ?? 0),
+      (a, b) =>
+        ATTRIBUTION_ORDER[a.attribution] - ATTRIBUTION_ORDER[b.attribution] ||
+        byteOrder(a.entry.rule ?? '', b.entry.rule ?? '') ||
+        (a.entry.line ?? 0) - (b.entry.line ?? 0),
     );
-    const slices: CustomCheckEntry[][] = [];
+    const slices: LintSource[][] = [];
     for (let i = 0; i < sorted.length; i += max) slices.push(sorted.slice(i, i + max));
     slices.forEach((slice, index) => {
-      const findings = slice.map((e) => lintFinding(e, 'pre-existing'));
+      const findings = slice.map(lintFinding);
+      const blocking = findings.filter((f) => f.attribution === 'net-new').length;
+      const deferredCount = findings.filter((f) => f.attribution === 'deferred').length;
       out.push({
-        rank: [VALUE_BAND.debt, `${file}#${index + 1}`],
-        draft: lintDraft(
-          file,
+        rank: sliceRank(file, index + 1, findings),
+        draft: {
+          id: `lint-located:${file}${slices.length > 1 ? `#${index + 1}` : ''}`,
+          class: 'lint-located',
           findings,
-          ctx,
-          { source: 'debt-slice', file, slice: index + 1, of: slices.length },
-          slices.length > 1 ? `#${index + 1}` : '',
-        ),
+          envelope: { paths: [file], manifests: false },
+          constraints: { forbidden: [] },
+          done: doneFor('guardrail', findings),
+          budget: deriveBudget(findings.length, ctx.capFor('lint-located')),
+          provenance: {
+            source: 'debt-slice',
+            file,
+            slice: index + 1,
+            of: slices.length,
+            ...(blocking > 0 ? { blocking } : {}),
+            ...(deferredCount > 0 ? { deferred: deferredCount } : {}),
+          },
+        },
       });
     });
   }

--- a/src/remediate/work-orders/planner.ts
+++ b/src/remediate/work-orders/planner.ts
@@ -11,12 +11,11 @@
  * and debt slices. The per-source builders live beside this module
  * (`floor-orders.ts`, `advisory-orders.ts`, `lint-orders.ts`).
  */
-import type { RemediateBudget } from '../config';
 import type { RichBaselineEntry } from '../../baseline/types';
 import { matchRecipe, RECIPE_REGISTRY, type RecipeDeclaration } from './recipes-registry';
-import { floorOrders, type FloorFailureInput, type ManifestRoot } from './floor-orders';
+import { floorOrders, type FloorFailureInput } from './floor-orders';
 import { advisoryOrders, type AdvisoryInput } from './advisory-orders';
-import { attributedLintOrders, debtLintOrders, type CustomCheckEntry } from './lint-orders';
+import { lintOrders, type CustomCheckEntry, type LintSource } from './lint-orders';
 import {
   compareRank,
   identityOnly,
@@ -24,6 +23,8 @@ import {
   undispatch,
   type BudgetCapFor,
   type Draft,
+  type InstallFor,
+  type ManifestRoot,
   type Ranked,
 } from './shared';
 import type {
@@ -34,8 +35,9 @@ import type {
   WorkOrderPlan,
 } from './types';
 
-export type { FloorFailureInput, ManifestRoot } from './floor-orders';
+export type { FloorFailureInput } from './floor-orders';
 export type { AdvisoryInput } from './advisory-orders';
+export type { ManifestRoot } from './shared';
 export { BUDGET_DERIVATION, DEFAULT_MAX_SLICE_SIZE, deriveBudget } from './shared';
 
 /** A finding of the guardrail's blocking set, already joined to its entry. */
@@ -78,12 +80,13 @@ export interface PlannerInput {
   readonly floorFailures: readonly FloorFailureInput[];
   readonly blocking: readonly BlockingInput[];
   readonly deferred: readonly DeferredInput[];
-  /** Grandfathered entries NOT under any active allowlist entry. */
+  /** Grandfathered entries NOT under any active allowlist entry, every kind
+   *  (the planner classifies and discloses; callers never pre-filter). */
   readonly debt: readonly RichBaselineEntry[];
   /** Dependency roots for envelope derivation (the root has `dir: ''`). */
   readonly manifests: readonly ManifestRoot[];
-  /** The pack-declared install command; undefined = none known (disclosed). */
-  readonly install?: { readonly bin: string; readonly args: readonly string[] };
+  /** Per producing pack, its declared install command (see `InstallFor`). */
+  readonly installFor: InstallFor;
   readonly policy: {
     readonly maxSliceSize: number;
     /** Per class, the selecting task's effective budget (`budgetForTask`). */
@@ -104,10 +107,16 @@ export function assignTier(
   return recipe ? { ...order, tier: 'recipe', recipe: recipe.id } : { ...order, tier: 'agent' };
 }
 
-/** A budget resolver that gives every class the same cap (tests, callers
- *  without a task catalog). */
-export function uniformBudget(cap: RemediateBudget): BudgetCapFor {
-  return () => cap;
+/** Baseline dep-vuln debt as an advisory input (identity + severity only;
+ *  the richer live-scan copy wins where both exist). */
+function advisoryFromDebt(e: Extract<RichBaselineEntry, { kind: 'dep-vuln' }>): AdvisoryInput {
+  return {
+    id: e.id,
+    package: e.package,
+    ...(e.installedVersion !== undefined ? { installedVersion: e.installedVersion } : {}),
+    advisoryId: e.advisoryId,
+    ...(e.severity !== undefined ? { severity: e.severity } : {}),
+  };
 }
 
 export function planWorkOrders(input: PlannerInput, opts: PlannerOptions = {}): WorkOrderPlan {
@@ -115,18 +124,18 @@ export function planWorkOrders(input: PlannerInput, opts: PlannerOptions = {}): 
   const undispatchable: UndispatchableGroup[] = [];
   const ctx = {
     manifests: input.manifests,
-    ...(input.install ? { install: input.install } : {}),
+    installFor: input.installFor,
     capFor: input.policy.budgetFor,
     maxSliceSize: input.policy.maxSliceSize,
   };
 
   const blockingAdvisories: AdvisoryInput[] = [];
-  const blockingLint: Array<{ entry: CustomCheckEntry; attribution: 'net-new' }> = [];
+  const lintSources: LintSource[] = [];
   const noClass: WorkOrderFinding[] = [];
   for (const b of input.blocking) {
     if (b.kind === 'dep-vuln') blockingAdvisories.push(b.advisory);
     else if (b.kind === 'custom-check')
-      blockingLint.push({ entry: b.entry, attribution: 'net-new' });
+      lintSources.push({ entry: b.entry, attribution: 'net-new' });
     else noClass.push(identityOnly(b.entry.kind, b.entry.id, 'net-new'));
   }
   undispatch(
@@ -136,14 +145,13 @@ export function planWorkOrders(input: PlannerInput, opts: PlannerOptions = {}): 
   );
 
   const deferredAdvisories: Array<{ advisory: AdvisoryInput; expiresAt: string }> = [];
-  const deferredLint: Array<{ entry: CustomCheckEntry; attribution: 'deferred' }> = [];
   const unjoined: WorkOrderFinding[] = [];
   const deferredNoClass: WorkOrderFinding[] = [];
   for (const d of input.deferred) {
     if (d.kind === 'dep-vuln')
       deferredAdvisories.push({ advisory: d.advisory, expiresAt: d.expiresAt });
     else if (d.kind === 'custom-check')
-      deferredLint.push({ entry: d.entry, attribution: 'deferred' });
+      lintSources.push({ entry: d.entry, attribution: 'deferred', expiresAt: d.expiresAt });
     else if (d.kind === 'unjoined')
       unjoined.push(identityOnly(d.declaredKind, d.fingerprint, 'deferred'));
     else deferredNoClass.push(identityOnly(d.entry.kind, d.entry.id, 'deferred'));
@@ -160,10 +168,11 @@ export function planWorkOrders(input: PlannerInput, opts: PlannerOptions = {}): 
     deferredNoClass,
   );
 
-  const debtLint: CustomCheckEntry[] = [];
+  const debtAdvisories: AdvisoryInput[] = [];
   const debtNoClass: WorkOrderFinding[] = [];
   for (const e of input.debt) {
-    if (e.kind === 'custom-check') debtLint.push(e);
+    if (e.kind === 'custom-check') lintSources.push({ entry: e, attribution: 'pre-existing' });
+    else if (e.kind === 'dep-vuln') debtAdvisories.push(advisoryFromDebt(e));
     else debtNoClass.push(identityOnly(e.kind, e.id, 'pre-existing'));
   }
   undispatch(
@@ -174,21 +183,41 @@ export function planWorkOrders(input: PlannerInput, opts: PlannerOptions = {}): 
 
   const ranked: Ranked[] = [
     ...floorOrders(input.floorFailures, ctx),
-    ...advisoryOrders(blockingAdvisories, deferredAdvisories, ctx),
-    ...attributedLintOrders([...blockingLint, ...deferredLint], ctx, undispatchable),
-    ...debtLintOrders(debtLint, ctx, undispatchable),
+    ...advisoryOrders(blockingAdvisories, deferredAdvisories, debtAdvisories, ctx),
+    ...lintOrders(lintSources, ctx, undispatchable),
   ].sort(compareRank);
 
   // Ids are unique by construction (one builder per class, one order per
-  // natural unit); a collision would be a builder bug, so it is surfaced,
-  // never silently deduplicated.
-  const seen = new Set<string>();
+  // natural unit). Defensively, a collision merges findings into the earlier
+  // (higher-value) order and is disclosed — a duplicate must never destroy
+  // the plan.
+  const byId = new Map<string, { order: WorkOrder; index: number }>();
   const orders: WorkOrder[] = [];
+  const collisions: WorkOrderFinding[] = [];
   for (const { draft } of ranked) {
-    if (seen.has(draft.id)) throw new Error(`work-order planner produced duplicate id ${draft.id}`);
-    seen.add(draft.id);
-    orders.push(assignTier(draft, registry));
+    const existing = byId.get(draft.id);
+    if (existing) {
+      const known = new Set(existing.order.findings.map((f) => f.id));
+      const extra = draft.findings.filter((f) => !known.has(f.id));
+      const merged = assignTier(
+        { ...existing.order, findings: [...existing.order.findings, ...extra] },
+        registry,
+      );
+      orders[existing.index] = merged;
+      byId.set(draft.id, { order: merged, index: existing.index });
+      collisions.push(...draft.findings);
+      continue;
+    }
+    const order = assignTier(draft, registry);
+    byId.set(draft.id, { order, index: orders.length });
+    orders.push(order);
   }
+  undispatch(
+    undispatchable,
+    'planner produced a duplicate order id (a builder bug — findings were merged into the ' +
+      'earlier order, nothing was dropped; please report this)',
+    collisions,
+  );
   return { orders, undispatchable };
 }
 

--- a/src/remediate/work-orders/planner.ts
+++ b/src/remediate/work-orders/planner.ts
@@ -1,0 +1,637 @@
+/**
+ * The ONE planner (`planWorkOrders`): builds work orders from the finding
+ * sets dxkit already computes. PURE over injected inputs: no I/O, no clock
+ * read, no registry probe beyond the recipe registry it is handed. The I/O
+ * adapter that assembles its inputs from a repo is `gather.ts` (Rule 2.30:
+ * one place assembles planner inputs).
+ *
+ * Sources, in value order (section 3A):
+ *   1. entry-floor failures, attributed (net-new first);
+ *   2. the guardrail's blocking pairs, joined to their current entries;
+ *   3. active allowlist deferrals, joined to their baseline entries
+ *      (soonest expiry first);
+ *   4. debt slices: custom-check entries by file, then by rule, capped by
+ *      `maxSliceSize`.
+ *
+ * Grouping: one order per (class, natural unit). Unresolved imports group by
+ * the manifest their importing files share; advisories group by package;
+ * lint groups by file; a floor failure with no finer identity is one order
+ * per check. A finding with no class lands in `undispatchable` with the
+ * reason, never silently dropped.
+ */
+import type { CorrectnessFloorResult } from '../../analyzers/correctness/run';
+import { IMPORT_RESOLUTION_LABEL } from '../../analyzers/correctness/run';
+import type { AttributedFloorFailure } from '../../analyzers/correctness/attribution';
+import type { ClassifiedPair } from '../../gate/result';
+import type { AllowlistEntry } from '../../allowlist/file';
+import type { FindingSeverity, RichBaselineEntry } from '../../baseline/types';
+import { CURRENT_IDENTITY_SCHEME } from '../../baseline/types';
+import type { RemediateBudget } from '../config';
+import { dxkitCli } from '../../self-invocation';
+import { matchRecipe, RECIPE_REGISTRY, type RecipeDeclaration } from './recipes-registry';
+import {
+  FLOOR_FINDING_KIND,
+  floorFindingId,
+  type DoneCriterion,
+  type UndispatchableGroup,
+  type WorkOrder,
+  type WorkOrderBudget,
+  type WorkOrderClass,
+  type WorkOrderEnvelope,
+  type WorkOrderFinding,
+  type WorkOrderPlan,
+  type WorkOrderProvenance,
+} from './types';
+
+/** Live-scan details a baseline entry does not carry (fixed version,
+ *  reachability), keyed by fingerprint. Optional: absent reads as unknown. */
+export interface AdvisoryDetail {
+  readonly fixedVersion?: string;
+  readonly reachable?: boolean;
+}
+
+/** A dependency root: the manifest and lockfile an unresolved import's fix
+ *  touches. `dir` is repo-relative (`''` for the root), files are relative. */
+export interface ManifestRoot {
+  readonly dir: string;
+  readonly files: readonly string[];
+}
+
+export interface PlannerInput {
+  /** The entry floor with its attribution (null when no floor ran). */
+  readonly entryFloor: {
+    readonly result: CorrectnessFloorResult;
+    readonly attributed: readonly AttributedFloorFailure[];
+  } | null;
+  /** Blocking guardrail pairs joined by `currentId` to their entries. */
+  readonly blocking: ReadonlyArray<{
+    readonly pair: ClassifiedPair;
+    readonly entry: RichBaselineEntry;
+  }>;
+  /** Active deferrals joined to their baseline entries (null = no entry). */
+  readonly deferred: ReadonlyArray<{
+    readonly allow: AllowlistEntry;
+    readonly entry: RichBaselineEntry | null;
+  }>;
+  /** Grandfathered custom-check entries (the lint backlog). */
+  readonly debt: readonly RichBaselineEntry[];
+  readonly advisoryDetails?: Readonly<Record<string, AdvisoryDetail>>;
+  /** Dependency roots for envelope derivation; the first is the repo root. */
+  readonly manifests: readonly ManifestRoot[];
+  readonly install?: { readonly bin: string; readonly args: readonly string[] };
+  readonly policy: {
+    /** Largest number of findings one debt slice may carry. */
+    readonly maxSliceSize: number;
+    /** The policy caps every derived budget clamps to. */
+    readonly budget: RemediateBudget;
+  };
+}
+
+export interface PlannerOptions {
+  readonly registry?: readonly RecipeDeclaration[];
+}
+
+/** Budget derivation constants, declared once (section 3C):
+ *  `turns = clamp(base + perFinding * n, min, policy.max)`, same shape for
+ *  minutes; usd scales with the turn fraction of the policy cap. */
+export const BUDGET_DERIVATION = {
+  baseTurns: 8,
+  perFindingTurns: 4,
+  minTurns: 10,
+  baseMinutes: 5,
+  perFindingMinutes: 2,
+  minMinutes: 5,
+} as const;
+
+export const DEFAULT_MAX_SLICE_SIZE = 25;
+
+/** Actions every order forbids, in the agent's own vocabulary. */
+const SHARED_FORBIDDEN: readonly string[] = [
+  'installing, adding, or removing packages yourself (the frame runs the install command)',
+  'editing anything outside the envelope',
+  'refreshing the baseline or editing .dxkit/baselines/ or .dxkit/allowlist.json',
+  'disabling a rule, adding a suppression, or weakening a test to make a finding disappear',
+];
+
+const SEVERITY_RANK: Record<FindingSeverity, number> = { critical: 0, high: 1, medium: 2, low: 3 };
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function deriveBudget(findingCount: number, policy: RemediateBudget): WorkOrderBudget {
+  const d = BUDGET_DERIVATION;
+  const turns = clamp(d.baseTurns + d.perFindingTurns * findingCount, d.minTurns, policy.maxTurns);
+  const minutes = clamp(
+    d.baseMinutes + d.perFindingMinutes * findingCount,
+    d.minMinutes,
+    policy.maxMinutes,
+  );
+  const usd = Math.round((policy.maxUsd * turns) / policy.maxTurns) || 1;
+  return {
+    turns,
+    minutes,
+    usd: Math.min(usd, policy.maxUsd),
+    derivation:
+      `turns = clamp(${d.baseTurns} + ${d.perFindingTurns} * ${findingCount}, ${d.minTurns}, ` +
+      `${policy.maxTurns}) = ${turns}; minutes = clamp(${d.baseMinutes} + ${d.perFindingMinutes} * ` +
+      `${findingCount}, ${d.minMinutes}, ${policy.maxMinutes}) = ${minutes}; ` +
+      `usd = round(${policy.maxUsd} * ${turns} / ${policy.maxTurns}) = ${usd}`,
+  };
+}
+
+/** The tier decision: `recipe` when a registry entry matches, else `agent`. */
+export function assignTier(
+  order: Omit<WorkOrder, 'tier' | 'recipe'>,
+  registry: readonly RecipeDeclaration[] = RECIPE_REGISTRY,
+): WorkOrder {
+  const recipe = matchRecipe({ ...order, tier: 'agent' }, registry);
+  return recipe ? { ...order, tier: 'recipe', recipe: recipe.id } : { ...order, tier: 'agent' };
+}
+
+function doneFor(
+  verifier: DoneCriterion['verifier'],
+  findings: readonly WorkOrderFinding[],
+): DoneCriterion {
+  return {
+    absentIds: findings.map((f) => f.id),
+    verifier,
+    command: dxkitCli(verifier === 'floor' ? 'floor check' : 'guardrail check'),
+    noNetNewInsideEnvelope: true,
+    identityScheme: CURRENT_IDENTITY_SCHEME,
+  };
+}
+
+/** The importing file the import-resolution check names in its output line
+ *  for `specifier`. The check reports the file only in prose today; this is
+ *  the ONE reader of that line shape. */
+function importingFileFor(output: string | undefined, specifier: string): string | undefined {
+  if (!output) return undefined;
+  const escaped = specifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = new RegExp(`'${escaped}' does not resolve[^\\n]*\\(imported by ([^)]+)\\)`).exec(
+    output,
+  );
+  return m?.[1]?.trim();
+}
+
+/** The dependency root whose directory is the longest prefix of `file`. */
+function manifestRootFor(
+  file: string | undefined,
+  manifests: readonly ManifestRoot[],
+): ManifestRoot {
+  const root = manifests[0] ?? { dir: '', files: [] };
+  if (!file) return root;
+  let best = root;
+  for (const m of manifests) {
+    if (m.dir === '') continue;
+    const prefix = m.dir.endsWith('/') ? m.dir : `${m.dir}/`;
+    if (file.startsWith(prefix) && prefix.length > (best.dir ? best.dir.length + 1 : 0)) best = m;
+  }
+  return best;
+}
+
+function manifestPaths(root: ManifestRoot): string[] {
+  return root.files.map((f) => (root.dir ? `${root.dir}/${f}` : f));
+}
+
+function truncateTail(output: string | undefined, lines = 20): string | undefined {
+  if (!output) return undefined;
+  const all = output.split('\n');
+  return all.length <= lines ? output : all.slice(-lines).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Per-source builders. Each returns partial orders (everything but tier).
+
+type Draft = Omit<WorkOrder, 'tier' | 'recipe'>;
+
+interface Ranked {
+  readonly draft: Draft;
+  /** Lower sorts first. Band, then a within-band key. */
+  readonly rank: readonly [number, number | string];
+}
+
+function floorOrders(input: PlannerInput): Ranked[] {
+  const out: Ranked[] = [];
+  if (!input.entryFloor) return out;
+  for (const attributed of input.entryFloor.attributed) {
+    const check = attributed.check;
+    if (check.status !== 'fail') continue;
+    const command = [check.bin, ...(check.args ?? [])].filter(Boolean).join(' ').trim();
+    const tail = truncateTail(check.output);
+    const band = attributed.attribution === 'net-new' ? 0 : 4;
+
+    if (check.label === IMPORT_RESOLUTION_LABEL && check.findings && check.findings.length > 0) {
+      const netNew = new Set(attributed.netNewFindings ?? []);
+      // Group specifiers by the manifest root their importing files share.
+      const byRoot = new Map<string, { root: ManifestRoot; findings: WorkOrderFinding[] }>();
+      for (const specifier of check.findings) {
+        const importingFile = importingFileFor(check.output, specifier);
+        const root = manifestRootFor(importingFile, input.manifests);
+        const key = root.dir;
+        const bucket = byRoot.get(key) ?? { root, findings: [] };
+        bucket.findings.push({
+          kind: FLOOR_FINDING_KIND,
+          id: floorFindingId(check.pack, check.label, specifier),
+          attribution:
+            attributed.precision === 'finding'
+              ? netNew.has(specifier)
+                ? 'net-new'
+                : 'pre-existing'
+              : attributed.attribution,
+          evidence: {
+            type: 'floor',
+            pack: check.pack,
+            label: check.label,
+            command,
+            ...(tail !== undefined ? { outputTail: tail } : {}),
+            specifier,
+            ...(importingFile !== undefined ? { importingFile } : {}),
+          },
+        });
+        byRoot.set(key, bucket);
+      }
+      for (const { root, findings } of byRoot.values()) {
+        const importers = [
+          ...new Set(
+            findings
+              .map((f) => (f.evidence.type === 'floor' ? f.evidence.importingFile : undefined))
+              .filter((f): f is string => typeof f === 'string'),
+          ),
+        ];
+        const envelope: WorkOrderEnvelope = {
+          paths: [...importers, ...manifestPaths(root)],
+          manifests: true,
+        };
+        const anyNetNew = findings.some((f) => f.attribution === 'net-new');
+        out.push({
+          rank: [anyNetNew ? 0 : 4, `${check.pack}/${check.label}/${root.dir}`],
+          draft: {
+            id: `unresolved-import:${check.pack}:${root.dir || '.'}`,
+            class: 'unresolved-import',
+            findings,
+            envelope,
+            constraints: {
+              ...(input.install ? { install: input.install } : {}),
+              forbidden: SHARED_FORBIDDEN,
+            },
+            done: doneFor('floor', findings),
+            budget: deriveBudget(findings.length, input.policy.budget),
+            evidence: tail ? [tail] : [],
+            provenance: { source: 'entry-floor', check: `${check.pack}/${check.label}` },
+          },
+        });
+      }
+      continue;
+    }
+
+    const finding: WorkOrderFinding = {
+      kind: FLOOR_FINDING_KIND,
+      id: floorFindingId(check.pack, check.label),
+      attribution: attributed.attribution,
+      evidence: {
+        type: 'floor',
+        pack: check.pack,
+        label: check.label,
+        command,
+        ...(tail !== undefined ? { outputTail: tail } : {}),
+      },
+    };
+    out.push({
+      rank: [band, `${check.pack}/${check.label}`],
+      draft: {
+        id: `floor-failure:${check.pack}:${check.label}`,
+        class: 'floor-failure',
+        findings: [finding],
+        // A generic floor failure names no file; the whole tree minus
+        // manifests is the honest envelope (a build/test fix is code).
+        envelope: { paths: [''], manifests: false },
+        constraints: {
+          ...(input.install ? { install: input.install } : {}),
+          forbidden: SHARED_FORBIDDEN,
+        },
+        done: doneFor('floor', [finding]),
+        budget: deriveBudget(1, input.policy.budget),
+        evidence: tail ? [tail] : [],
+        provenance: { source: 'entry-floor', check: `${check.pack}/${check.label}` },
+      },
+    });
+  }
+  return out;
+}
+
+function advisoryFinding(
+  entry: Extract<RichBaselineEntry, { kind: 'dep-vuln' }>,
+  attribution: WorkOrderFinding['attribution'],
+  detail: AdvisoryDetail | undefined,
+  expiresAt: string | undefined,
+): WorkOrderFinding {
+  return {
+    kind: 'dep-vuln',
+    id: entry.id,
+    attribution,
+    evidence: {
+      type: 'dep-vuln',
+      package: entry.package,
+      ...(entry.installedVersion !== undefined ? { installedVersion: entry.installedVersion } : {}),
+      advisoryId: entry.advisoryId,
+      ...(detail?.fixedVersion !== undefined ? { fixedVersion: detail.fixedVersion } : {}),
+      ...(detail?.reachable !== undefined ? { reachable: detail.reachable } : {}),
+      ...(entry.severity !== undefined ? { severity: entry.severity } : {}),
+      ...(expiresAt !== undefined ? { expiresAt } : {}),
+    },
+  };
+}
+
+function advisoryOrder(
+  pkg: string,
+  findings: readonly WorkOrderFinding[],
+  input: PlannerInput,
+  provenance: WorkOrderProvenance,
+): Draft {
+  const root = input.manifests[0] ?? { dir: '', files: [] };
+  return {
+    id: `dep-advisory:${pkg}`,
+    class: 'dep-advisory',
+    findings,
+    envelope: { paths: manifestPaths(root), manifests: true },
+    constraints: {
+      ...(input.install ? { install: input.install } : {}),
+      forbidden: SHARED_FORBIDDEN,
+    },
+    done: doneFor('guardrail', findings),
+    budget: deriveBudget(findings.length, input.policy.budget),
+    evidence: findings.map((f) => {
+      const e = f.evidence as Extract<WorkOrderFinding['evidence'], { type: 'dep-vuln' }>;
+      return (
+        `${e.package}${e.installedVersion ? `@${e.installedVersion}` : ''}: ${e.advisoryId}` +
+        (e.severity ? ` (${e.severity})` : '') +
+        (e.fixedVersion ? `, fixed in ${e.fixedVersion}` : ', no fixed version known here') +
+        (e.reachable === true ? ', reachable' : '') +
+        (e.expiresAt ? `, deferred until ${e.expiresAt}` : '')
+      );
+    }),
+    provenance,
+  };
+}
+
+function lintFinding(
+  entry: Extract<RichBaselineEntry, { kind: 'custom-check' }>,
+  attribution: WorkOrderFinding['attribution'],
+): WorkOrderFinding {
+  return {
+    kind: 'custom-check',
+    id: entry.id,
+    attribution,
+    evidence: {
+      type: 'custom-check',
+      check: entry.check,
+      ...(entry.rule !== undefined ? { rule: entry.rule } : {}),
+      ...(entry.file !== undefined ? { file: entry.file } : {}),
+      ...(entry.line !== undefined ? { line: entry.line } : {}),
+      ...(entry.message !== undefined ? { message: entry.message } : {}),
+    },
+  };
+}
+
+function lintOrder(
+  file: string,
+  findings: readonly WorkOrderFinding[],
+  input: PlannerInput,
+  provenance: WorkOrderProvenance,
+  idSuffix = '',
+): Draft {
+  return {
+    id: `lint-located:${file}${idSuffix}`,
+    class: 'lint-located',
+    findings,
+    envelope: { paths: [file], manifests: false },
+    constraints: { forbidden: SHARED_FORBIDDEN },
+    done: doneFor('guardrail', findings),
+    budget: deriveBudget(findings.length, input.policy.budget),
+    evidence: findings.map((f) => {
+      const e = f.evidence as Extract<WorkOrderFinding['evidence'], { type: 'custom-check' }>;
+      return `${e.file}${e.line !== undefined ? `:${e.line}` : ''} ${e.rule ?? e.check}${e.message ? `: ${e.message}` : ''}`;
+    }),
+    provenance,
+  };
+}
+
+function reachableSevere(findings: readonly WorkOrderFinding[]): boolean {
+  return findings.some(
+    (f) =>
+      f.evidence.type === 'dep-vuln' &&
+      f.evidence.reachable === true &&
+      (f.evidence.severity === 'critical' || f.evidence.severity === 'high'),
+  );
+}
+
+function bestSeverity(findings: readonly WorkOrderFinding[]): number {
+  let best = 9;
+  for (const f of findings) {
+    if (f.evidence.type === 'dep-vuln' && f.evidence.severity)
+      best = Math.min(best, SEVERITY_RANK[f.evidence.severity]);
+  }
+  return best;
+}
+
+function blockingOrders(input: PlannerInput, undispatchable: UndispatchableGroup[]): Ranked[] {
+  const out: Ranked[] = [];
+  const byPackage = new Map<string, WorkOrderFinding[]>();
+  const byFile = new Map<string, WorkOrderFinding[]>();
+  const noClass: WorkOrderFinding[] = [];
+  for (const { entry } of input.blocking) {
+    if (entry.kind === 'dep-vuln') {
+      const list = byPackage.get(entry.package) ?? [];
+      list.push(advisoryFinding(entry, 'net-new', input.advisoryDetails?.[entry.id], undefined));
+      byPackage.set(entry.package, list);
+    } else if (entry.kind === 'custom-check' && entry.file) {
+      const list = byFile.get(entry.file) ?? [];
+      list.push(lintFinding(entry, 'net-new'));
+      byFile.set(entry.file, list);
+    } else {
+      noClass.push({
+        kind: entry.kind,
+        id: entry.id,
+        attribution: 'net-new',
+        evidence:
+          entry.kind === 'custom-check'
+            ? lintFinding(entry, 'net-new').evidence
+            : { type: 'custom-check', check: entry.kind },
+      });
+    }
+  }
+  for (const [pkg, findings] of byPackage) {
+    const draft = advisoryOrder(pkg, findings, input, { source: 'guardrail-blocking' });
+    out.push({ draft, rank: [reachableSevere(findings) ? 2 : 3, bestSeverity(findings)] });
+  }
+  for (const [file, findings] of byFile) {
+    out.push({
+      draft: lintOrder(file, findings, input, { source: 'guardrail-blocking' }),
+      rank: [3, file],
+    });
+  }
+  if (noClass.length > 0) {
+    undispatchable.push({
+      reason:
+        'blocking findings whose kind has no work-order class yet ' +
+        `(${[...new Set(noClass.map((f) => f.kind))].join(', ')})`,
+      findings: noClass,
+    });
+  }
+  return out;
+}
+
+function deferredOrders(input: PlannerInput, undispatchable: UndispatchableGroup[]): Ranked[] {
+  const out: Ranked[] = [];
+  const byPackage = new Map<string, { findings: WorkOrderFinding[]; earliest: string }>();
+  const unjoined: WorkOrderFinding[] = [];
+  const noClass: WorkOrderFinding[] = [];
+  for (const { allow, entry } of input.deferred) {
+    const expiresAt = allow.expiresAt ?? '';
+    if (!entry) {
+      unjoined.push({
+        kind: allow.kind,
+        id: allow.fingerprint,
+        attribution: 'deferred',
+        evidence: { type: 'custom-check', check: allow.kind },
+      });
+      continue;
+    }
+    if (entry.kind !== 'dep-vuln') {
+      noClass.push({
+        kind: entry.kind,
+        id: entry.id,
+        attribution: 'deferred',
+        evidence: { type: 'custom-check', check: entry.kind },
+      });
+      continue;
+    }
+    const bucket = byPackage.get(entry.package) ?? { findings: [], earliest: expiresAt };
+    bucket.findings.push(
+      advisoryFinding(entry, 'deferred', input.advisoryDetails?.[entry.id], expiresAt),
+    );
+    if (expiresAt < bucket.earliest) bucket.earliest = expiresAt;
+    byPackage.set(entry.package, bucket);
+  }
+  for (const [pkg, { findings, earliest }] of byPackage) {
+    out.push({
+      draft: advisoryOrder(pkg, findings, input, {
+        source: 'deferred-advisory',
+        earliestExpiry: earliest,
+      }),
+      rank: [1, earliest],
+    });
+  }
+  if (unjoined.length > 0) {
+    undispatchable.push({
+      reason:
+        'deferred allowlist entries whose fingerprint is not in the baseline (nothing to join)',
+      findings: unjoined,
+    });
+  }
+  if (noClass.length > 0) {
+    undispatchable.push({
+      reason: `deferred findings whose kind has no work-order class yet (${[...new Set(noClass.map((f) => f.kind))].join(', ')})`,
+      findings: noClass,
+    });
+  }
+  return out;
+}
+
+function debtOrders(input: PlannerInput, undispatchable: UndispatchableGroup[]): Ranked[] {
+  const out: Ranked[] = [];
+  const byFile = new Map<string, Extract<RichBaselineEntry, { kind: 'custom-check' }>[]>();
+  const binary: WorkOrderFinding[] = [];
+  const otherKinds: WorkOrderFinding[] = [];
+  for (const entry of input.debt) {
+    if (entry.kind !== 'custom-check') {
+      otherKinds.push({
+        kind: entry.kind,
+        id: entry.id,
+        attribution: 'pre-existing',
+        evidence: { type: 'custom-check', check: entry.kind },
+      });
+      continue;
+    }
+    if (!entry.file) {
+      binary.push(lintFinding(entry, 'pre-existing'));
+      continue;
+    }
+    const list = byFile.get(entry.file) ?? [];
+    list.push(entry);
+    byFile.set(entry.file, list);
+  }
+  const max = Math.max(1, input.policy.maxSliceSize);
+  for (const [file, entries] of [...byFile.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    // Within a file, order by rule then line so a slice is one rule's worth
+    // of work wherever possible.
+    const sorted = [...entries].sort(
+      (a, b) => (a.rule ?? '').localeCompare(b.rule ?? '') || (a.line ?? 0) - (b.line ?? 0),
+    );
+    const slices: (typeof sorted)[] = [];
+    for (let i = 0; i < sorted.length; i += max) slices.push(sorted.slice(i, i + max));
+    slices.forEach((slice, index) => {
+      const findings = slice.map((e) => lintFinding(e, 'pre-existing'));
+      out.push({
+        draft: lintOrder(
+          file,
+          findings,
+          input,
+          { source: 'debt-slice', file, slice: index + 1, of: slices.length },
+          slices.length > 1 ? `#${index + 1}` : '',
+        ),
+        rank: [5, `${file}#${index + 1}`],
+      });
+    });
+  }
+  if (binary.length > 0) {
+    undispatchable.push({
+      reason: 'binary (whole-command) custom-check findings carry no file to scope an order to',
+      findings: binary,
+    });
+  }
+  if (otherKinds.length > 0) {
+    undispatchable.push({
+      reason: `debt entries whose kind has no work-order class yet (${[...new Set(otherKinds.map((f) => f.kind))].join(', ')})`,
+      findings: otherKinds,
+    });
+  }
+  return out;
+}
+
+function compareRank(a: Ranked, b: Ranked): number {
+  if (a.rank[0] !== b.rank[0]) return a.rank[0] - b.rank[0];
+  const x = a.rank[1];
+  const y = b.rank[1];
+  if (typeof x === 'number' && typeof y === 'number') return x - y;
+  return String(x).localeCompare(String(y));
+}
+
+/** Build the plan. Pure; deterministic for the same input. */
+export function planWorkOrders(input: PlannerInput, opts: PlannerOptions = {}): WorkOrderPlan {
+  const registry = opts.registry ?? RECIPE_REGISTRY;
+  const undispatchable: UndispatchableGroup[] = [];
+  const ranked = [
+    ...floorOrders(input),
+    ...blockingOrders(input, undispatchable),
+    ...deferredOrders(input, undispatchable),
+    ...debtOrders(input, undispatchable),
+  ].sort(compareRank);
+  // One order per id: a package both blocking and deferred keeps the
+  // higher-value (earlier) one.
+  const seen = new Set<string>();
+  const orders: WorkOrder[] = [];
+  for (const { draft } of ranked) {
+    if (seen.has(draft.id)) continue;
+    seen.add(draft.id);
+    orders.push(assignTier(draft, registry));
+  }
+  return { orders, undispatchable };
+}
+
+/** The orders a task selects, by class. Open-ended tasks select nothing. */
+export function selectOrders(plan: WorkOrderPlan, classes: readonly WorkOrderClass[]): WorkOrder[] {
+  const wanted = new Set<string>(classes);
+  return plan.orders.filter((o) => wanted.has(o.class));
+}

--- a/src/remediate/work-orders/planner.ts
+++ b/src/remediate/work-orders/planner.ts
@@ -5,85 +5,89 @@
  * adapter that assembles its inputs from a repo is `gather.ts` (Rule 2.30:
  * one place assembles planner inputs).
  *
- * Sources, in value order (section 3A):
- *   1. entry-floor failures, attributed (net-new first);
- *   2. the guardrail's blocking pairs, joined to their current entries;
- *   3. active allowlist deferrals, joined to their baseline entries
- *      (soonest expiry first);
- *   4. debt slices: custom-check entries by file, then by rule, capped by
- *      `maxSliceSize`.
- *
- * Grouping: one order per (class, natural unit). Unresolved imports group by
- * the manifest their importing files share; advisories group by package;
- * lint groups by file; a floor failure with no finer identity is one order
- * per check. A finding with no class lands in `undispatchable` with the
- * reason, never silently dropped.
+ * Sources, in value order (section 3A): net-new entry-floor failures, then
+ * active deferrals (soonest expiry first), then reachable high/critical
+ * blocking advisories, other blocking findings, pre-existing floor failures,
+ * and debt slices. The per-source builders live beside this module
+ * (`floor-orders.ts`, `advisory-orders.ts`, `lint-orders.ts`).
  */
-import type { CorrectnessFloorResult } from '../../analyzers/correctness/run';
-import { IMPORT_RESOLUTION_LABEL } from '../../analyzers/correctness/run';
-import type { AttributedFloorFailure } from '../../analyzers/correctness/attribution';
-import type { ClassifiedPair } from '../../gate/result';
-import type { AllowlistEntry } from '../../allowlist/file';
-import type { FindingSeverity, RichBaselineEntry } from '../../baseline/types';
-import { CURRENT_IDENTITY_SCHEME } from '../../baseline/types';
 import type { RemediateBudget } from '../config';
-import { dxkitCli } from '../../self-invocation';
+import type { RichBaselineEntry } from '../../baseline/types';
 import { matchRecipe, RECIPE_REGISTRY, type RecipeDeclaration } from './recipes-registry';
+import { floorOrders, type FloorFailureInput, type ManifestRoot } from './floor-orders';
+import { advisoryOrders, type AdvisoryInput } from './advisory-orders';
+import { attributedLintOrders, debtLintOrders, type CustomCheckEntry } from './lint-orders';
 import {
-  FLOOR_FINDING_KIND,
-  floorFindingId,
-  type DoneCriterion,
-  type UndispatchableGroup,
-  type WorkOrder,
-  type WorkOrderBudget,
-  type WorkOrderClass,
-  type WorkOrderEnvelope,
-  type WorkOrderFinding,
-  type WorkOrderPlan,
-  type WorkOrderProvenance,
+  compareRank,
+  identityOnly,
+  kindsOf,
+  undispatch,
+  type BudgetCapFor,
+  type Draft,
+  type Ranked,
+} from './shared';
+import type {
+  UndispatchableGroup,
+  WorkOrder,
+  WorkOrderClass,
+  WorkOrderFinding,
+  WorkOrderPlan,
 } from './types';
 
-/** Live-scan details a baseline entry does not carry (fixed version,
- *  reachability), keyed by fingerprint. Optional: absent reads as unknown. */
-export interface AdvisoryDetail {
-  readonly fixedVersion?: string;
-  readonly reachable?: boolean;
-}
+export type { FloorFailureInput, ManifestRoot } from './floor-orders';
+export type { AdvisoryInput } from './advisory-orders';
+export { BUDGET_DERIVATION, DEFAULT_MAX_SLICE_SIZE, deriveBudget } from './shared';
 
-/** A dependency root: the manifest and lockfile an unresolved import's fix
- *  touches. `dir` is repo-relative (`''` for the root), files are relative. */
-export interface ManifestRoot {
-  readonly dir: string;
-  readonly files: readonly string[];
-}
+/** A finding of the guardrail's blocking set, already joined to its entry. */
+export type BlockingInput =
+  | { readonly kind: 'dep-vuln'; readonly advisory: AdvisoryInput }
+  | { readonly kind: 'custom-check'; readonly entry: CustomCheckEntry }
+  | { readonly kind: 'other'; readonly entry: RichBaselineEntry };
+
+/** An active deferral joined to what it suppresses: a live/baseline advisory,
+ *  a baseline custom-check entry, or nothing (the fingerprint joined to no
+ *  finding dxkit can see). */
+export type DeferredInput =
+  | {
+      readonly fingerprint: string;
+      readonly expiresAt: string;
+      readonly kind: 'dep-vuln';
+      readonly advisory: AdvisoryInput;
+    }
+  | {
+      readonly fingerprint: string;
+      readonly expiresAt: string;
+      readonly kind: 'custom-check';
+      readonly entry: CustomCheckEntry;
+    }
+  | {
+      readonly fingerprint: string;
+      readonly expiresAt: string;
+      readonly kind: 'unjoined';
+      readonly declaredKind: string;
+    }
+  | {
+      readonly fingerprint: string;
+      readonly expiresAt: string;
+      readonly kind: 'other';
+      readonly entry: RichBaselineEntry;
+    };
 
 export interface PlannerInput {
-  /** The entry floor with its attribution (null when no floor ran). */
-  readonly entryFloor: {
-    readonly result: CorrectnessFloorResult;
-    readonly attributed: readonly AttributedFloorFailure[];
-  } | null;
-  /** Blocking guardrail pairs joined by `currentId` to their entries. */
-  readonly blocking: ReadonlyArray<{
-    readonly pair: ClassifiedPair;
-    readonly entry: RichBaselineEntry;
-  }>;
-  /** Active deferrals joined to their baseline entries (null = no entry). */
-  readonly deferred: ReadonlyArray<{
-    readonly allow: AllowlistEntry;
-    readonly entry: RichBaselineEntry | null;
-  }>;
-  /** Grandfathered custom-check entries (the lint backlog). */
+  /** Failing entry-floor checks, attributed (empty when no floor source). */
+  readonly floorFailures: readonly FloorFailureInput[];
+  readonly blocking: readonly BlockingInput[];
+  readonly deferred: readonly DeferredInput[];
+  /** Grandfathered entries NOT under any active allowlist entry. */
   readonly debt: readonly RichBaselineEntry[];
-  readonly advisoryDetails?: Readonly<Record<string, AdvisoryDetail>>;
-  /** Dependency roots for envelope derivation; the first is the repo root. */
+  /** Dependency roots for envelope derivation (the root has `dir: ''`). */
   readonly manifests: readonly ManifestRoot[];
+  /** The pack-declared install command; undefined = none known (disclosed). */
   readonly install?: { readonly bin: string; readonly args: readonly string[] };
   readonly policy: {
-    /** Largest number of findings one debt slice may carry. */
     readonly maxSliceSize: number;
-    /** The policy caps every derived budget clamps to. */
-    readonly budget: RemediateBudget;
+    /** Per class, the selecting task's effective budget (`budgetForTask`). */
+    readonly budgetFor: BudgetCapFor;
   };
 }
 
@@ -91,539 +95,97 @@ export interface PlannerOptions {
   readonly registry?: readonly RecipeDeclaration[];
 }
 
-/** Budget derivation constants, declared once (section 3C):
- *  `turns = clamp(base + perFinding * n, min, policy.max)`, same shape for
- *  minutes; usd scales with the turn fraction of the policy cap. */
-export const BUDGET_DERIVATION = {
-  baseTurns: 8,
-  perFindingTurns: 4,
-  minTurns: 10,
-  baseMinutes: 5,
-  perFindingMinutes: 2,
-  minMinutes: 5,
-} as const;
-
-export const DEFAULT_MAX_SLICE_SIZE = 25;
-
-/** Actions every order forbids, in the agent's own vocabulary. */
-const SHARED_FORBIDDEN: readonly string[] = [
-  'installing, adding, or removing packages yourself (the frame runs the install command)',
-  'editing anything outside the envelope',
-  'refreshing the baseline or editing .dxkit/baselines/ or .dxkit/allowlist.json',
-  'disabling a rule, adding a suppression, or weakening a test to make a finding disappear',
-];
-
-const SEVERITY_RANK: Record<FindingSeverity, number> = { critical: 0, high: 1, medium: 2, low: 3 };
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
-
-export function deriveBudget(findingCount: number, policy: RemediateBudget): WorkOrderBudget {
-  const d = BUDGET_DERIVATION;
-  const turns = clamp(d.baseTurns + d.perFindingTurns * findingCount, d.minTurns, policy.maxTurns);
-  const minutes = clamp(
-    d.baseMinutes + d.perFindingMinutes * findingCount,
-    d.minMinutes,
-    policy.maxMinutes,
-  );
-  const usd = Math.round((policy.maxUsd * turns) / policy.maxTurns) || 1;
-  return {
-    turns,
-    minutes,
-    usd: Math.min(usd, policy.maxUsd),
-    derivation:
-      `turns = clamp(${d.baseTurns} + ${d.perFindingTurns} * ${findingCount}, ${d.minTurns}, ` +
-      `${policy.maxTurns}) = ${turns}; minutes = clamp(${d.baseMinutes} + ${d.perFindingMinutes} * ` +
-      `${findingCount}, ${d.minMinutes}, ${policy.maxMinutes}) = ${minutes}; ` +
-      `usd = round(${policy.maxUsd} * ${turns} / ${policy.maxTurns}) = ${usd}`,
-  };
-}
-
 /** The tier decision: `recipe` when a registry entry matches, else `agent`. */
 export function assignTier(
-  order: Omit<WorkOrder, 'tier' | 'recipe'>,
+  order: Draft,
   registry: readonly RecipeDeclaration[] = RECIPE_REGISTRY,
 ): WorkOrder {
   const recipe = matchRecipe({ ...order, tier: 'agent' }, registry);
   return recipe ? { ...order, tier: 'recipe', recipe: recipe.id } : { ...order, tier: 'agent' };
 }
 
-function doneFor(
-  verifier: DoneCriterion['verifier'],
-  findings: readonly WorkOrderFinding[],
-): DoneCriterion {
-  return {
-    absentIds: findings.map((f) => f.id),
-    verifier,
-    command: dxkitCli(verifier === 'floor' ? 'floor check' : 'guardrail check'),
-    noNetNewInsideEnvelope: true,
-    identityScheme: CURRENT_IDENTITY_SCHEME,
-  };
+/** A budget resolver that gives every class the same cap (tests, callers
+ *  without a task catalog). */
+export function uniformBudget(cap: RemediateBudget): BudgetCapFor {
+  return () => cap;
 }
 
-/** The importing file the import-resolution check names in its output line
- *  for `specifier`. The check reports the file only in prose today; this is
- *  the ONE reader of that line shape. */
-function importingFileFor(output: string | undefined, specifier: string): string | undefined {
-  if (!output) return undefined;
-  const escaped = specifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const m = new RegExp(`'${escaped}' does not resolve[^\\n]*\\(imported by ([^)]+)\\)`).exec(
-    output,
-  );
-  return m?.[1]?.trim();
-}
-
-/** The dependency root whose directory is the longest prefix of `file`. */
-function manifestRootFor(
-  file: string | undefined,
-  manifests: readonly ManifestRoot[],
-): ManifestRoot {
-  const root = manifests[0] ?? { dir: '', files: [] };
-  if (!file) return root;
-  let best = root;
-  for (const m of manifests) {
-    if (m.dir === '') continue;
-    const prefix = m.dir.endsWith('/') ? m.dir : `${m.dir}/`;
-    if (file.startsWith(prefix) && prefix.length > (best.dir ? best.dir.length + 1 : 0)) best = m;
-  }
-  return best;
-}
-
-function manifestPaths(root: ManifestRoot): string[] {
-  return root.files.map((f) => (root.dir ? `${root.dir}/${f}` : f));
-}
-
-function truncateTail(output: string | undefined, lines = 20): string | undefined {
-  if (!output) return undefined;
-  const all = output.split('\n');
-  return all.length <= lines ? output : all.slice(-lines).join('\n');
-}
-
-// ---------------------------------------------------------------------------
-// Per-source builders. Each returns partial orders (everything but tier).
-
-type Draft = Omit<WorkOrder, 'tier' | 'recipe'>;
-
-interface Ranked {
-  readonly draft: Draft;
-  /** Lower sorts first. Band, then a within-band key. */
-  readonly rank: readonly [number, number | string];
-}
-
-function floorOrders(input: PlannerInput): Ranked[] {
-  const out: Ranked[] = [];
-  if (!input.entryFloor) return out;
-  for (const attributed of input.entryFloor.attributed) {
-    const check = attributed.check;
-    if (check.status !== 'fail') continue;
-    const command = [check.bin, ...(check.args ?? [])].filter(Boolean).join(' ').trim();
-    const tail = truncateTail(check.output);
-    const band = attributed.attribution === 'net-new' ? 0 : 4;
-
-    if (check.label === IMPORT_RESOLUTION_LABEL && check.findings && check.findings.length > 0) {
-      const netNew = new Set(attributed.netNewFindings ?? []);
-      // Group specifiers by the manifest root their importing files share.
-      const byRoot = new Map<string, { root: ManifestRoot; findings: WorkOrderFinding[] }>();
-      for (const specifier of check.findings) {
-        const importingFile = importingFileFor(check.output, specifier);
-        const root = manifestRootFor(importingFile, input.manifests);
-        const key = root.dir;
-        const bucket = byRoot.get(key) ?? { root, findings: [] };
-        bucket.findings.push({
-          kind: FLOOR_FINDING_KIND,
-          id: floorFindingId(check.pack, check.label, specifier),
-          attribution:
-            attributed.precision === 'finding'
-              ? netNew.has(specifier)
-                ? 'net-new'
-                : 'pre-existing'
-              : attributed.attribution,
-          evidence: {
-            type: 'floor',
-            pack: check.pack,
-            label: check.label,
-            command,
-            ...(tail !== undefined ? { outputTail: tail } : {}),
-            specifier,
-            ...(importingFile !== undefined ? { importingFile } : {}),
-          },
-        });
-        byRoot.set(key, bucket);
-      }
-      for (const { root, findings } of byRoot.values()) {
-        const importers = [
-          ...new Set(
-            findings
-              .map((f) => (f.evidence.type === 'floor' ? f.evidence.importingFile : undefined))
-              .filter((f): f is string => typeof f === 'string'),
-          ),
-        ];
-        const envelope: WorkOrderEnvelope = {
-          paths: [...importers, ...manifestPaths(root)],
-          manifests: true,
-        };
-        const anyNetNew = findings.some((f) => f.attribution === 'net-new');
-        out.push({
-          rank: [anyNetNew ? 0 : 4, `${check.pack}/${check.label}/${root.dir}`],
-          draft: {
-            id: `unresolved-import:${check.pack}:${root.dir || '.'}`,
-            class: 'unresolved-import',
-            findings,
-            envelope,
-            constraints: {
-              ...(input.install ? { install: input.install } : {}),
-              forbidden: SHARED_FORBIDDEN,
-            },
-            done: doneFor('floor', findings),
-            budget: deriveBudget(findings.length, input.policy.budget),
-            evidence: tail ? [tail] : [],
-            provenance: { source: 'entry-floor', check: `${check.pack}/${check.label}` },
-          },
-        });
-      }
-      continue;
-    }
-
-    const finding: WorkOrderFinding = {
-      kind: FLOOR_FINDING_KIND,
-      id: floorFindingId(check.pack, check.label),
-      attribution: attributed.attribution,
-      evidence: {
-        type: 'floor',
-        pack: check.pack,
-        label: check.label,
-        command,
-        ...(tail !== undefined ? { outputTail: tail } : {}),
-      },
-    };
-    out.push({
-      rank: [band, `${check.pack}/${check.label}`],
-      draft: {
-        id: `floor-failure:${check.pack}:${check.label}`,
-        class: 'floor-failure',
-        findings: [finding],
-        // A generic floor failure names no file; the whole tree minus
-        // manifests is the honest envelope (a build/test fix is code).
-        envelope: { paths: [''], manifests: false },
-        constraints: {
-          ...(input.install ? { install: input.install } : {}),
-          forbidden: SHARED_FORBIDDEN,
-        },
-        done: doneFor('floor', [finding]),
-        budget: deriveBudget(1, input.policy.budget),
-        evidence: tail ? [tail] : [],
-        provenance: { source: 'entry-floor', check: `${check.pack}/${check.label}` },
-      },
-    });
-  }
-  return out;
-}
-
-function advisoryFinding(
-  entry: Extract<RichBaselineEntry, { kind: 'dep-vuln' }>,
-  attribution: WorkOrderFinding['attribution'],
-  detail: AdvisoryDetail | undefined,
-  expiresAt: string | undefined,
-): WorkOrderFinding {
-  return {
-    kind: 'dep-vuln',
-    id: entry.id,
-    attribution,
-    evidence: {
-      type: 'dep-vuln',
-      package: entry.package,
-      ...(entry.installedVersion !== undefined ? { installedVersion: entry.installedVersion } : {}),
-      advisoryId: entry.advisoryId,
-      ...(detail?.fixedVersion !== undefined ? { fixedVersion: detail.fixedVersion } : {}),
-      ...(detail?.reachable !== undefined ? { reachable: detail.reachable } : {}),
-      ...(entry.severity !== undefined ? { severity: entry.severity } : {}),
-      ...(expiresAt !== undefined ? { expiresAt } : {}),
-    },
-  };
-}
-
-function advisoryOrder(
-  pkg: string,
-  findings: readonly WorkOrderFinding[],
-  input: PlannerInput,
-  provenance: WorkOrderProvenance,
-): Draft {
-  const root = input.manifests[0] ?? { dir: '', files: [] };
-  return {
-    id: `dep-advisory:${pkg}`,
-    class: 'dep-advisory',
-    findings,
-    envelope: { paths: manifestPaths(root), manifests: true },
-    constraints: {
-      ...(input.install ? { install: input.install } : {}),
-      forbidden: SHARED_FORBIDDEN,
-    },
-    done: doneFor('guardrail', findings),
-    budget: deriveBudget(findings.length, input.policy.budget),
-    evidence: findings.map((f) => {
-      const e = f.evidence as Extract<WorkOrderFinding['evidence'], { type: 'dep-vuln' }>;
-      return (
-        `${e.package}${e.installedVersion ? `@${e.installedVersion}` : ''}: ${e.advisoryId}` +
-        (e.severity ? ` (${e.severity})` : '') +
-        (e.fixedVersion ? `, fixed in ${e.fixedVersion}` : ', no fixed version known here') +
-        (e.reachable === true ? ', reachable' : '') +
-        (e.expiresAt ? `, deferred until ${e.expiresAt}` : '')
-      );
-    }),
-    provenance,
-  };
-}
-
-function lintFinding(
-  entry: Extract<RichBaselineEntry, { kind: 'custom-check' }>,
-  attribution: WorkOrderFinding['attribution'],
-): WorkOrderFinding {
-  return {
-    kind: 'custom-check',
-    id: entry.id,
-    attribution,
-    evidence: {
-      type: 'custom-check',
-      check: entry.check,
-      ...(entry.rule !== undefined ? { rule: entry.rule } : {}),
-      ...(entry.file !== undefined ? { file: entry.file } : {}),
-      ...(entry.line !== undefined ? { line: entry.line } : {}),
-      ...(entry.message !== undefined ? { message: entry.message } : {}),
-    },
-  };
-}
-
-function lintOrder(
-  file: string,
-  findings: readonly WorkOrderFinding[],
-  input: PlannerInput,
-  provenance: WorkOrderProvenance,
-  idSuffix = '',
-): Draft {
-  return {
-    id: `lint-located:${file}${idSuffix}`,
-    class: 'lint-located',
-    findings,
-    envelope: { paths: [file], manifests: false },
-    constraints: { forbidden: SHARED_FORBIDDEN },
-    done: doneFor('guardrail', findings),
-    budget: deriveBudget(findings.length, input.policy.budget),
-    evidence: findings.map((f) => {
-      const e = f.evidence as Extract<WorkOrderFinding['evidence'], { type: 'custom-check' }>;
-      return `${e.file}${e.line !== undefined ? `:${e.line}` : ''} ${e.rule ?? e.check}${e.message ? `: ${e.message}` : ''}`;
-    }),
-    provenance,
-  };
-}
-
-function reachableSevere(findings: readonly WorkOrderFinding[]): boolean {
-  return findings.some(
-    (f) =>
-      f.evidence.type === 'dep-vuln' &&
-      f.evidence.reachable === true &&
-      (f.evidence.severity === 'critical' || f.evidence.severity === 'high'),
-  );
-}
-
-function bestSeverity(findings: readonly WorkOrderFinding[]): number {
-  let best = 9;
-  for (const f of findings) {
-    if (f.evidence.type === 'dep-vuln' && f.evidence.severity)
-      best = Math.min(best, SEVERITY_RANK[f.evidence.severity]);
-  }
-  return best;
-}
-
-function blockingOrders(input: PlannerInput, undispatchable: UndispatchableGroup[]): Ranked[] {
-  const out: Ranked[] = [];
-  const byPackage = new Map<string, WorkOrderFinding[]>();
-  const byFile = new Map<string, WorkOrderFinding[]>();
-  const noClass: WorkOrderFinding[] = [];
-  for (const { entry } of input.blocking) {
-    if (entry.kind === 'dep-vuln') {
-      const list = byPackage.get(entry.package) ?? [];
-      list.push(advisoryFinding(entry, 'net-new', input.advisoryDetails?.[entry.id], undefined));
-      byPackage.set(entry.package, list);
-    } else if (entry.kind === 'custom-check' && entry.file) {
-      const list = byFile.get(entry.file) ?? [];
-      list.push(lintFinding(entry, 'net-new'));
-      byFile.set(entry.file, list);
-    } else {
-      noClass.push({
-        kind: entry.kind,
-        id: entry.id,
-        attribution: 'net-new',
-        evidence:
-          entry.kind === 'custom-check'
-            ? lintFinding(entry, 'net-new').evidence
-            : { type: 'custom-check', check: entry.kind },
-      });
-    }
-  }
-  for (const [pkg, findings] of byPackage) {
-    const draft = advisoryOrder(pkg, findings, input, { source: 'guardrail-blocking' });
-    out.push({ draft, rank: [reachableSevere(findings) ? 2 : 3, bestSeverity(findings)] });
-  }
-  for (const [file, findings] of byFile) {
-    out.push({
-      draft: lintOrder(file, findings, input, { source: 'guardrail-blocking' }),
-      rank: [3, file],
-    });
-  }
-  if (noClass.length > 0) {
-    undispatchable.push({
-      reason:
-        'blocking findings whose kind has no work-order class yet ' +
-        `(${[...new Set(noClass.map((f) => f.kind))].join(', ')})`,
-      findings: noClass,
-    });
-  }
-  return out;
-}
-
-function deferredOrders(input: PlannerInput, undispatchable: UndispatchableGroup[]): Ranked[] {
-  const out: Ranked[] = [];
-  const byPackage = new Map<string, { findings: WorkOrderFinding[]; earliest: string }>();
-  const unjoined: WorkOrderFinding[] = [];
-  const noClass: WorkOrderFinding[] = [];
-  for (const { allow, entry } of input.deferred) {
-    const expiresAt = allow.expiresAt ?? '';
-    if (!entry) {
-      unjoined.push({
-        kind: allow.kind,
-        id: allow.fingerprint,
-        attribution: 'deferred',
-        evidence: { type: 'custom-check', check: allow.kind },
-      });
-      continue;
-    }
-    if (entry.kind !== 'dep-vuln') {
-      noClass.push({
-        kind: entry.kind,
-        id: entry.id,
-        attribution: 'deferred',
-        evidence: { type: 'custom-check', check: entry.kind },
-      });
-      continue;
-    }
-    const bucket = byPackage.get(entry.package) ?? { findings: [], earliest: expiresAt };
-    bucket.findings.push(
-      advisoryFinding(entry, 'deferred', input.advisoryDetails?.[entry.id], expiresAt),
-    );
-    if (expiresAt < bucket.earliest) bucket.earliest = expiresAt;
-    byPackage.set(entry.package, bucket);
-  }
-  for (const [pkg, { findings, earliest }] of byPackage) {
-    out.push({
-      draft: advisoryOrder(pkg, findings, input, {
-        source: 'deferred-advisory',
-        earliestExpiry: earliest,
-      }),
-      rank: [1, earliest],
-    });
-  }
-  if (unjoined.length > 0) {
-    undispatchable.push({
-      reason:
-        'deferred allowlist entries whose fingerprint is not in the baseline (nothing to join)',
-      findings: unjoined,
-    });
-  }
-  if (noClass.length > 0) {
-    undispatchable.push({
-      reason: `deferred findings whose kind has no work-order class yet (${[...new Set(noClass.map((f) => f.kind))].join(', ')})`,
-      findings: noClass,
-    });
-  }
-  return out;
-}
-
-function debtOrders(input: PlannerInput, undispatchable: UndispatchableGroup[]): Ranked[] {
-  const out: Ranked[] = [];
-  const byFile = new Map<string, Extract<RichBaselineEntry, { kind: 'custom-check' }>[]>();
-  const binary: WorkOrderFinding[] = [];
-  const otherKinds: WorkOrderFinding[] = [];
-  for (const entry of input.debt) {
-    if (entry.kind !== 'custom-check') {
-      otherKinds.push({
-        kind: entry.kind,
-        id: entry.id,
-        attribution: 'pre-existing',
-        evidence: { type: 'custom-check', check: entry.kind },
-      });
-      continue;
-    }
-    if (!entry.file) {
-      binary.push(lintFinding(entry, 'pre-existing'));
-      continue;
-    }
-    const list = byFile.get(entry.file) ?? [];
-    list.push(entry);
-    byFile.set(entry.file, list);
-  }
-  const max = Math.max(1, input.policy.maxSliceSize);
-  for (const [file, entries] of [...byFile.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-    // Within a file, order by rule then line so a slice is one rule's worth
-    // of work wherever possible.
-    const sorted = [...entries].sort(
-      (a, b) => (a.rule ?? '').localeCompare(b.rule ?? '') || (a.line ?? 0) - (b.line ?? 0),
-    );
-    const slices: (typeof sorted)[] = [];
-    for (let i = 0; i < sorted.length; i += max) slices.push(sorted.slice(i, i + max));
-    slices.forEach((slice, index) => {
-      const findings = slice.map((e) => lintFinding(e, 'pre-existing'));
-      out.push({
-        draft: lintOrder(
-          file,
-          findings,
-          input,
-          { source: 'debt-slice', file, slice: index + 1, of: slices.length },
-          slices.length > 1 ? `#${index + 1}` : '',
-        ),
-        rank: [5, `${file}#${index + 1}`],
-      });
-    });
-  }
-  if (binary.length > 0) {
-    undispatchable.push({
-      reason: 'binary (whole-command) custom-check findings carry no file to scope an order to',
-      findings: binary,
-    });
-  }
-  if (otherKinds.length > 0) {
-    undispatchable.push({
-      reason: `debt entries whose kind has no work-order class yet (${[...new Set(otherKinds.map((f) => f.kind))].join(', ')})`,
-      findings: otherKinds,
-    });
-  }
-  return out;
-}
-
-function compareRank(a: Ranked, b: Ranked): number {
-  if (a.rank[0] !== b.rank[0]) return a.rank[0] - b.rank[0];
-  const x = a.rank[1];
-  const y = b.rank[1];
-  if (typeof x === 'number' && typeof y === 'number') return x - y;
-  return String(x).localeCompare(String(y));
-}
-
-/** Build the plan. Pure; deterministic for the same input. */
 export function planWorkOrders(input: PlannerInput, opts: PlannerOptions = {}): WorkOrderPlan {
   const registry = opts.registry ?? RECIPE_REGISTRY;
   const undispatchable: UndispatchableGroup[] = [];
-  const ranked = [
-    ...floorOrders(input),
-    ...blockingOrders(input, undispatchable),
-    ...deferredOrders(input, undispatchable),
-    ...debtOrders(input, undispatchable),
+  const ctx = {
+    manifests: input.manifests,
+    ...(input.install ? { install: input.install } : {}),
+    capFor: input.policy.budgetFor,
+    maxSliceSize: input.policy.maxSliceSize,
+  };
+
+  const blockingAdvisories: AdvisoryInput[] = [];
+  const blockingLint: Array<{ entry: CustomCheckEntry; attribution: 'net-new' }> = [];
+  const noClass: WorkOrderFinding[] = [];
+  for (const b of input.blocking) {
+    if (b.kind === 'dep-vuln') blockingAdvisories.push(b.advisory);
+    else if (b.kind === 'custom-check')
+      blockingLint.push({ entry: b.entry, attribution: 'net-new' });
+    else noClass.push(identityOnly(b.entry.kind, b.entry.id, 'net-new'));
+  }
+  undispatch(
+    undispatchable,
+    `blocking findings whose kind has no work-order class yet (${kindsOf(noClass)})`,
+    noClass,
+  );
+
+  const deferredAdvisories: Array<{ advisory: AdvisoryInput; expiresAt: string }> = [];
+  const deferredLint: Array<{ entry: CustomCheckEntry; attribution: 'deferred' }> = [];
+  const unjoined: WorkOrderFinding[] = [];
+  const deferredNoClass: WorkOrderFinding[] = [];
+  for (const d of input.deferred) {
+    if (d.kind === 'dep-vuln')
+      deferredAdvisories.push({ advisory: d.advisory, expiresAt: d.expiresAt });
+    else if (d.kind === 'custom-check')
+      deferredLint.push({ entry: d.entry, attribution: 'deferred' });
+    else if (d.kind === 'unjoined')
+      unjoined.push(identityOnly(d.declaredKind, d.fingerprint, 'deferred'));
+    else deferredNoClass.push(identityOnly(d.entry.kind, d.entry.id, 'deferred'));
+  }
+  undispatch(
+    undispatchable,
+    'deferred allowlist entries whose fingerprint matches no finding dxkit can see here ' +
+      '(not in the live scan, not in the baseline)',
+    unjoined,
+  );
+  undispatch(
+    undispatchable,
+    `deferred findings whose kind has no work-order class yet (${kindsOf(deferredNoClass)})`,
+    deferredNoClass,
+  );
+
+  const debtLint: CustomCheckEntry[] = [];
+  const debtNoClass: WorkOrderFinding[] = [];
+  for (const e of input.debt) {
+    if (e.kind === 'custom-check') debtLint.push(e);
+    else debtNoClass.push(identityOnly(e.kind, e.id, 'pre-existing'));
+  }
+  undispatch(
+    undispatchable,
+    `debt entries whose kind has no work-order class yet (${kindsOf(debtNoClass)})`,
+    debtNoClass,
+  );
+
+  const ranked: Ranked[] = [
+    ...floorOrders(input.floorFailures, ctx),
+    ...advisoryOrders(blockingAdvisories, deferredAdvisories, ctx),
+    ...attributedLintOrders([...blockingLint, ...deferredLint], ctx, undispatchable),
+    ...debtLintOrders(debtLint, ctx, undispatchable),
   ].sort(compareRank);
-  // One order per id: a package both blocking and deferred keeps the
-  // higher-value (earlier) one.
+
+  // Ids are unique by construction (one builder per class, one order per
+  // natural unit); a collision would be a builder bug, so it is surfaced,
+  // never silently deduplicated.
   const seen = new Set<string>();
   const orders: WorkOrder[] = [];
   for (const { draft } of ranked) {
-    if (seen.has(draft.id)) continue;
+    if (seen.has(draft.id)) throw new Error(`work-order planner produced duplicate id ${draft.id}`);
     seen.add(draft.id);
     orders.push(assignTier(draft, registry));
   }

--- a/src/remediate/work-orders/recipes-registry.ts
+++ b/src/remediate/work-orders/recipes-registry.ts
@@ -10,7 +10,8 @@
  *
  * The class each recipe serves is a READ of the class table (`recipe` on
  * `WORK_ORDER_CLASSES`); the contract test pins that every declared recipe
- * id is named there and vice versa.
+ * id is named there and vice versa. `matches` is consulted only for orders
+ * of the recipe's own class.
  */
 import { WORK_ORDER_CLASSES, type WorkOrder, type WorkOrderClass } from './types';
 
@@ -24,15 +25,8 @@ export interface RecipeDeclaration {
    *  and planning only; the plan says "recipe (not yet executable)". */
   readonly implemented: boolean;
   /** Does this recipe apply to THIS order? Pure over the order's findings and
-   *  evidence (a recipe never inspects the repo at planning time). Called only
-   *  for orders of the recipe's own class. */
+   *  evidence (a recipe never inspects the repo at planning time). */
   readonly matches: (order: WorkOrder) => boolean;
-}
-
-/** A bare specifier: not relative, not absolute, not a URL scheme. */
-const NOT_BARE = /^(\.{1,2}\/|\/|[a-z]+:)/i;
-function isBareSpecifier(specifier: string): boolean {
-  return !NOT_BARE.test(specifier);
 }
 
 /** The class a recipe id serves, from the one table. */
@@ -50,16 +44,18 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     class: classServedBy('lockfile-sync'),
     summary: "reinstall with the repo's package manager so the lockfile follows the manifest",
     implemented: false,
-    matches: () => true,
+    matches: (order) => order.constraints.install !== undefined,
   },
   {
     id: 'override-pin',
     class: classServedBy('override-pin'),
     summary: 'pin a fixed version through a pm-aware override when no direct upgrade path exists',
     implemented: false,
-    // Needs a known fixed version for EVERY advisory in the order; an
-    // advisory with no fix is agent (or human) territory.
+    // Needs a known fixed version for EVERY advisory in the order, and an
+    // install command the frame can run; an advisory with no fix is agent
+    // (or human) territory.
     matches: (order) =>
+      order.constraints.install !== undefined &&
       order.findings.length > 0 &&
       order.findings.every(
         (f) => f.evidence.type === 'dep-vuln' && typeof f.evidence.fixedVersion === 'string',
@@ -71,13 +67,16 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     summary:
       'declare and install a bare import, refusing with the reason when the candidate carries a block-tier advisory',
     implemented: false,
+    // Every finding must carry the unresolved specifier (bare BY THE
+    // resolutionCheck CONTRACT — packs only report bare specifiers, so
+    // bareness is a producer fact, never re-derived here with an
+    // ecosystem-flavored regex), and the frame must have the producing
+    // pack's install command to run the declare + install step.
     matches: (order) =>
+      order.constraints.install !== undefined &&
       order.findings.length > 0 &&
       order.findings.every(
-        (f) =>
-          f.evidence.type === 'floor' &&
-          typeof f.evidence.specifier === 'string' &&
-          isBareSpecifier(f.evidence.specifier),
+        (f) => f.evidence.type === 'floor' && typeof f.evidence.specifier === 'string',
       ),
   },
   {
@@ -96,26 +95,10 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
   },
 ];
 
-const byClassCache = new WeakMap<readonly RecipeDeclaration[], Map<string, RecipeDeclaration[]>>();
-
-function indexByClass(registry: readonly RecipeDeclaration[]): Map<string, RecipeDeclaration[]> {
-  let index = byClassCache.get(registry);
-  if (!index) {
-    index = new Map();
-    for (const r of registry) {
-      const list = index.get(r.class) ?? [];
-      list.push(r);
-      index.set(r.class, list);
-    }
-    byClassCache.set(registry, index);
-  }
-  return index;
-}
-
 /** The first recipe of the order's class whose `matches` accepts it. */
 export function matchRecipe(
   order: WorkOrder,
   registry: readonly RecipeDeclaration[] = RECIPE_REGISTRY,
 ): RecipeDeclaration | undefined {
-  return (indexByClass(registry).get(order.class) ?? []).find((r) => r.matches(order));
+  return registry.find((r) => r.class === order.class && r.matches(order));
 }

--- a/src/remediate/work-orders/recipes-registry.ts
+++ b/src/remediate/work-orders/recipes-registry.ts
@@ -8,12 +8,11 @@
  * apply. The executors (`apply(order) -> diff`, `verify`) land in the next
  * unit and attach to these same ids; nothing is stubbed in their place.
  *
- * Mirrors the pack/capability architecture: the registry is the one place a
- * class is mapped to a recipe, and the planner reads it (a synthetic entry
- * injected in tests must flip the tier, or the planner has stopped reading
- * the registry).
+ * The class each recipe serves is a READ of the class table (`recipe` on
+ * `WORK_ORDER_CLASSES`); the contract test pins that every declared recipe
+ * id is named there and vice versa.
  */
-import type { WorkOrder, WorkOrderClass } from './types';
+import { WORK_ORDER_CLASSES, type WorkOrder, type WorkOrderClass } from './types';
 
 export interface RecipeDeclaration {
   readonly id: string;
@@ -25,32 +24,42 @@ export interface RecipeDeclaration {
    *  and planning only; the plan says "recipe (not yet executable)". */
   readonly implemented: boolean;
   /** Does this recipe apply to THIS order? Pure over the order's findings and
-   *  evidence (a recipe never inspects the repo at planning time). */
+   *  evidence (a recipe never inspects the repo at planning time). Called only
+   *  for orders of the recipe's own class. */
   readonly matches: (order: WorkOrder) => boolean;
 }
 
 /** A bare specifier: not relative, not absolute, not a URL scheme. */
+const NOT_BARE = /^(\.{1,2}\/|\/|[a-z]+:)/i;
 function isBareSpecifier(specifier: string): boolean {
-  return !/^(\.{1,2}\/|\/|[a-z]+:)/i.test(specifier);
+  return !NOT_BARE.test(specifier);
+}
+
+/** The class a recipe id serves, from the one table. */
+function classServedBy(recipeId: string): WorkOrderClass {
+  const found = (Object.keys(WORK_ORDER_CLASSES) as Array<keyof typeof WORK_ORDER_CLASSES>).find(
+    (c) => WORK_ORDER_CLASSES[c].recipe === recipeId,
+  );
+  if (!found) throw new Error(`recipe '${recipeId}' is not named by any work-order class`);
+  return found;
 }
 
 export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
   {
     id: 'lockfile-sync',
-    class: 'stale-lockfile',
+    class: classServedBy('lockfile-sync'),
     summary: "reinstall with the repo's package manager so the lockfile follows the manifest",
     implemented: false,
-    matches: (order) => order.class === 'stale-lockfile',
+    matches: () => true,
   },
   {
     id: 'override-pin',
-    class: 'dep-advisory',
+    class: classServedBy('override-pin'),
     summary: 'pin a fixed version through a pm-aware override when no direct upgrade path exists',
     implemented: false,
     // Needs a known fixed version for EVERY advisory in the order; an
     // advisory with no fix is agent (or human) territory.
     matches: (order) =>
-      order.class === 'dep-advisory' &&
       order.findings.length > 0 &&
       order.findings.every(
         (f) => f.evidence.type === 'dep-vuln' && typeof f.evidence.fixedVersion === 'string',
@@ -58,12 +67,11 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
   },
   {
     id: 'declare-dependency',
-    class: 'unresolved-import',
+    class: classServedBy('declare-dependency'),
     summary:
       'declare and install a bare import, refusing with the reason when the candidate carries a block-tier advisory',
     implemented: false,
     matches: (order) =>
-      order.class === 'unresolved-import' &&
       order.findings.length > 0 &&
       order.findings.every(
         (f) =>
@@ -74,14 +82,13 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
   },
   {
     id: 'lint-autofix',
-    class: 'lint-located',
+    class: classServedBy('lint-autofix'),
     summary: "the pack linter's own autofix, restricted to the order's file and rules",
     implemented: false,
     // Every finding must carry a rule: an unparsed diagnostic cannot be
     // scoped to a fixer. Which rules a pack's fixer covers is the executor's
     // (pack-declared) knowledge, not the registry's.
     matches: (order) =>
-      order.class === 'lint-located' &&
       order.findings.length > 0 &&
       order.findings.every(
         (f) => f.evidence.type === 'custom-check' && typeof f.evidence.rule === 'string',
@@ -89,17 +96,26 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
   },
 ];
 
-/** The first registry entry that matches the order, or undefined. */
+const byClassCache = new WeakMap<readonly RecipeDeclaration[], Map<string, RecipeDeclaration[]>>();
+
+function indexByClass(registry: readonly RecipeDeclaration[]): Map<string, RecipeDeclaration[]> {
+  let index = byClassCache.get(registry);
+  if (!index) {
+    index = new Map();
+    for (const r of registry) {
+      const list = index.get(r.class) ?? [];
+      list.push(r);
+      index.set(r.class, list);
+    }
+    byClassCache.set(registry, index);
+  }
+  return index;
+}
+
+/** The first recipe of the order's class whose `matches` accepts it. */
 export function matchRecipe(
   order: WorkOrder,
   registry: readonly RecipeDeclaration[] = RECIPE_REGISTRY,
 ): RecipeDeclaration | undefined {
-  return registry.find((r) => r.matches(order));
-}
-
-export function recipeById(
-  id: string,
-  registry: readonly RecipeDeclaration[] = RECIPE_REGISTRY,
-): RecipeDeclaration | undefined {
-  return registry.find((r) => r.id === id);
+  return (indexByClass(registry).get(order.class) ?? []).find((r) => r.matches(order));
 }

--- a/src/remediate/work-orders/recipes-registry.ts
+++ b/src/remediate/work-orders/recipes-registry.ts
@@ -1,0 +1,105 @@
+/**
+ * The recipe registry (remediate rethink, section 3B): the deterministic tier.
+ *
+ * This module holds ONLY the declarative contract, `{ id, class, matches }`,
+ * and the four planned recipes as DECLARED entries. None of them is
+ * executable here: `implemented: false` says so, and the planner tiers an
+ * order `recipe` on a match so the plan surface shows where determinism WILL
+ * apply. The executors (`apply(order) -> diff`, `verify`) land in the next
+ * unit and attach to these same ids; nothing is stubbed in their place.
+ *
+ * Mirrors the pack/capability architecture: the registry is the one place a
+ * class is mapped to a recipe, and the planner reads it (a synthetic entry
+ * injected in tests must flip the tier, or the planner has stopped reading
+ * the registry).
+ */
+import type { WorkOrder, WorkOrderClass } from './types';
+
+export interface RecipeDeclaration {
+  readonly id: string;
+  /** The work-order class this recipe serves. */
+  readonly class: WorkOrderClass;
+  /** One-line intent, rendered in the plan surface. */
+  readonly summary: string;
+  /** Whether an executor exists for this id. `false` = declared for tiering
+   *  and planning only; the plan says "recipe (not yet executable)". */
+  readonly implemented: boolean;
+  /** Does this recipe apply to THIS order? Pure over the order's findings and
+   *  evidence (a recipe never inspects the repo at planning time). */
+  readonly matches: (order: WorkOrder) => boolean;
+}
+
+/** A bare specifier: not relative, not absolute, not a URL scheme. */
+function isBareSpecifier(specifier: string): boolean {
+  return !/^(\.{1,2}\/|\/|[a-z]+:)/i.test(specifier);
+}
+
+export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
+  {
+    id: 'lockfile-sync',
+    class: 'stale-lockfile',
+    summary: "reinstall with the repo's package manager so the lockfile follows the manifest",
+    implemented: false,
+    matches: (order) => order.class === 'stale-lockfile',
+  },
+  {
+    id: 'override-pin',
+    class: 'dep-advisory',
+    summary: 'pin a fixed version through a pm-aware override when no direct upgrade path exists',
+    implemented: false,
+    // Needs a known fixed version for EVERY advisory in the order; an
+    // advisory with no fix is agent (or human) territory.
+    matches: (order) =>
+      order.class === 'dep-advisory' &&
+      order.findings.length > 0 &&
+      order.findings.every(
+        (f) => f.evidence.type === 'dep-vuln' && typeof f.evidence.fixedVersion === 'string',
+      ),
+  },
+  {
+    id: 'declare-dependency',
+    class: 'unresolved-import',
+    summary:
+      'declare and install a bare import, refusing with the reason when the candidate carries a block-tier advisory',
+    implemented: false,
+    matches: (order) =>
+      order.class === 'unresolved-import' &&
+      order.findings.length > 0 &&
+      order.findings.every(
+        (f) =>
+          f.evidence.type === 'floor' &&
+          typeof f.evidence.specifier === 'string' &&
+          isBareSpecifier(f.evidence.specifier),
+      ),
+  },
+  {
+    id: 'lint-autofix',
+    class: 'lint-located',
+    summary: "the pack linter's own autofix, restricted to the order's file and rules",
+    implemented: false,
+    // Every finding must carry a rule: an unparsed diagnostic cannot be
+    // scoped to a fixer. Which rules a pack's fixer covers is the executor's
+    // (pack-declared) knowledge, not the registry's.
+    matches: (order) =>
+      order.class === 'lint-located' &&
+      order.findings.length > 0 &&
+      order.findings.every(
+        (f) => f.evidence.type === 'custom-check' && typeof f.evidence.rule === 'string',
+      ),
+  },
+];
+
+/** The first registry entry that matches the order, or undefined. */
+export function matchRecipe(
+  order: WorkOrder,
+  registry: readonly RecipeDeclaration[] = RECIPE_REGISTRY,
+): RecipeDeclaration | undefined {
+  return registry.find((r) => r.matches(order));
+}
+
+export function recipeById(
+  id: string,
+  registry: readonly RecipeDeclaration[] = RECIPE_REGISTRY,
+): RecipeDeclaration | undefined {
+  return registry.find((r) => r.id === id);
+}

--- a/src/remediate/work-orders/render.ts
+++ b/src/remediate/work-orders/render.ts
@@ -1,15 +1,12 @@
 /**
  * Work-order rendering: the agent-facing prompt (section 3C) and the
- * one-line plan summary. Prose here is human-toned and uses no em-dashes.
+ * one-line plan summary. The shared ground rules every remediation prompt
+ * carries (`SHARED_RULES`) are appended here, never restated. Prose here is
+ * human-toned and uses no em-dashes.
  */
+import { SHARED_RULES } from '../tasks';
 import type { WorkOrder, WorkOrderFinding } from './types';
 import { WORK_ORDER_CLASSES, isBuiltinWorkOrderClass } from './types';
-
-/** Repo facts the prompt needs that the order itself does not carry. */
-export interface RepoFacts {
-  /** The pm-aware install command as one string (`npm ci`, `pnpm install`). */
-  readonly installCommand?: string;
-}
 
 function describeFinding(f: WorkOrderFinding): string {
   const e = f.evidence;
@@ -17,7 +14,9 @@ function describeFinding(f: WorkOrderFinding): string {
     case 'floor':
       return e.specifier
         ? `${f.id}: '${e.specifier}' does not resolve` +
-            (e.importingFile ? ` (imported by ${e.importingFile})` : '')
+            (e.importingFiles && e.importingFiles.length > 0
+              ? ` (imported by ${e.importingFiles.join(', ')})`
+              : '')
         : `${f.id}: ${e.pack} ${e.label} fails (repro: ${e.command || 'see the floor check'})`;
     case 'dep-vuln':
       return (
@@ -32,6 +31,8 @@ function describeFinding(f: WorkOrderFinding): string {
         `${f.id}: ${e.file ?? e.check}${e.line !== undefined ? `:${e.line}` : ''} ` +
         `${e.rule ?? e.check}${e.message ? `: ${e.message}` : ''}`
       );
+    case 'none':
+      return `${f.id} (${f.kind}; identity only)`;
   }
 }
 
@@ -56,7 +57,7 @@ export function attributionSentence(order: WorkOrder): string {
 }
 
 /** The agent-facing prompt for one order. */
-export function renderWorkOrderPrompt(order: WorkOrder, repo: RepoFacts = {}): string {
+export function renderWorkOrderPrompt(order: WorkOrder): string {
   const classSummary = isBuiltinWorkOrderClass(order.class)
     ? WORK_ORDER_CLASSES[order.class].summary
     : order.class;
@@ -67,10 +68,10 @@ export function renderWorkOrderPrompt(order: WorkOrder, repo: RepoFacts = {}): s
   for (const f of order.findings) lines.push(`- ${describeFinding(f)}`);
   lines.push('');
   lines.push(`Attribution: ${attributionSentence(order)}`);
-  if (order.evidence.length > 0) {
+  if (order.outputTail) {
     lines.push('');
-    lines.push('Evidence dxkit already holds:');
-    for (const e of order.evidence) lines.push(e);
+    lines.push('Captured output of the failing command:');
+    lines.push(order.outputTail);
   }
   lines.push('');
   lines.push('Envelope (the only paths you may change):');
@@ -82,13 +83,16 @@ export function renderWorkOrderPrompt(order: WorkOrder, repo: RepoFacts = {}): s
   );
   lines.push('');
   lines.push('Constraints:');
-  const install =
-    repo.installCommand ??
-    (order.constraints.install
-      ? [order.constraints.install.bin, ...order.constraints.install.args].join(' ')
-      : undefined);
-  if (install) {
-    lines.push(`- the repo installs with: ${install} (use exactly this, never another form)`);
+  if (order.constraints.install) {
+    const { bin, args } = order.constraints.install;
+    lines.push(
+      `- the repo installs with: ${[bin, ...args].join(' ')} (the frame runs it; use exactly this form if you must reproduce)`,
+    );
+  } else if (order.envelope.manifests) {
+    lines.push(
+      '- no install command is known for this repo (no active language pack declares one); ' +
+        'do not install anything, write what a human must run in docs/DXKIT-REMEDIATION-NOTES.md',
+    );
   }
   for (const f of order.constraints.forbidden) lines.push(`- do not: ${f}`);
   lines.push('');
@@ -100,7 +104,7 @@ export function renderWorkOrderPrompt(order: WorkOrder, repo: RepoFacts = {}): s
     `Budget: ${order.budget.turns} turns, ${order.budget.minutes} minutes, ` +
       `$${order.budget.usd} (${order.budget.derivation}). Hitting the cap early is a signal, not a spend.`,
   );
-  return lines.join('\n');
+  return lines.join('\n') + '\n' + SHARED_RULES;
 }
 
 /** One line per order for the plan surface. */

--- a/src/remediate/work-orders/render.ts
+++ b/src/remediate/work-orders/render.ts
@@ -1,0 +1,120 @@
+/**
+ * Work-order rendering: the agent-facing prompt (section 3C) and the
+ * one-line plan summary. Prose here is human-toned and uses no em-dashes.
+ */
+import type { WorkOrder, WorkOrderFinding } from './types';
+import { WORK_ORDER_CLASSES, isBuiltinWorkOrderClass } from './types';
+
+/** Repo facts the prompt needs that the order itself does not carry. */
+export interface RepoFacts {
+  /** The pm-aware install command as one string (`npm ci`, `pnpm install`). */
+  readonly installCommand?: string;
+}
+
+function describeFinding(f: WorkOrderFinding): string {
+  const e = f.evidence;
+  switch (e.type) {
+    case 'floor':
+      return e.specifier
+        ? `${f.id}: '${e.specifier}' does not resolve` +
+            (e.importingFile ? ` (imported by ${e.importingFile})` : '')
+        : `${f.id}: ${e.pack} ${e.label} fails (repro: ${e.command || 'see the floor check'})`;
+    case 'dep-vuln':
+      return (
+        `${f.id}: ${e.package}${e.installedVersion ? `@${e.installedVersion}` : ''} ${e.advisoryId}` +
+        (e.severity ? ` (${e.severity})` : '') +
+        (e.fixedVersion ? `, fixed in ${e.fixedVersion}` : ', no fixed version known here') +
+        (e.reachable === true ? ', reachable from your code' : '') +
+        (e.expiresAt ? `, deferred until ${e.expiresAt}` : '')
+      );
+    case 'custom-check':
+      return (
+        `${f.id}: ${e.file ?? e.check}${e.line !== undefined ? `:${e.line}` : ''} ` +
+        `${e.rule ?? e.check}${e.message ? `: ${e.message}` : ''}`
+      );
+  }
+}
+
+/** The attribution split sentence: which findings are the change's own,
+ *  which are grandfathered, which are deferred. */
+export function attributionSentence(order: WorkOrder): string {
+  const counts = { 'net-new': 0, 'pre-existing': 0, unattributed: 0, deferred: 0 };
+  for (const f of order.findings) counts[f.attribution] += 1;
+  const parts: string[] = [];
+  if (counts['net-new'] > 0)
+    parts.push(`${counts['net-new']} of these are net-new (introduced by the current change)`);
+  if (counts.deferred > 0)
+    parts.push(`${counts.deferred} are deferred advisories that re-block on their expiry date`);
+  if (counts['pre-existing'] > 0)
+    parts.push(`${counts['pre-existing']} are pre-existing debt this order asks you to close`);
+  if (counts.unattributed > 0)
+    parts.push(`${counts.unattributed} could not be attributed (no base to compare against)`);
+  return (
+    parts.join('; ') +
+    '. Everything else in the repo is grandfathered: do not touch findings outside this list.'
+  );
+}
+
+/** The agent-facing prompt for one order. */
+export function renderWorkOrderPrompt(order: WorkOrder, repo: RepoFacts = {}): string {
+  const classSummary = isBuiltinWorkOrderClass(order.class)
+    ? WORK_ORDER_CLASSES[order.class].summary
+    : order.class;
+  const lines: string[] = [];
+  lines.push(`Work order ${order.id} (${order.class}: ${classSummary}).`);
+  lines.push('');
+  lines.push(`Findings to close (${order.findings.length}):`);
+  for (const f of order.findings) lines.push(`- ${describeFinding(f)}`);
+  lines.push('');
+  lines.push(`Attribution: ${attributionSentence(order)}`);
+  if (order.evidence.length > 0) {
+    lines.push('');
+    lines.push('Evidence dxkit already holds:');
+    for (const e of order.evidence) lines.push(e);
+  }
+  lines.push('');
+  lines.push('Envelope (the only paths you may change):');
+  for (const p of order.envelope.paths) lines.push(`- ${p === '' ? '(repo root)' : p}`);
+  lines.push(
+    order.envelope.manifests
+      ? '- dependency manifests and lockfiles inside the envelope may change'
+      : '- dependency manifests and lockfiles must NOT change',
+  );
+  lines.push('');
+  lines.push('Constraints:');
+  const install =
+    repo.installCommand ??
+    (order.constraints.install
+      ? [order.constraints.install.bin, ...order.constraints.install.args].join(' ')
+      : undefined);
+  if (install) {
+    lines.push(`- the repo installs with: ${install} (use exactly this, never another form)`);
+  }
+  for (const f of order.constraints.forbidden) lines.push(`- do not: ${f}`);
+  lines.push('');
+  lines.push(
+    `Done when: every id above is absent and no net-new finding appears inside the envelope. ` +
+      `Check with: ${order.done.command}`,
+  );
+  lines.push(
+    `Budget: ${order.budget.turns} turns, ${order.budget.minutes} minutes, ` +
+      `$${order.budget.usd} (${order.budget.derivation}). Hitting the cap early is a signal, not a spend.`,
+  );
+  return lines.join('\n');
+}
+
+/** One line per order for the plan surface. */
+export function renderWorkOrderSummary(order: WorkOrder): string {
+  const tier =
+    order.tier === 'recipe' ? `recipe ${order.recipe} (declared, not yet executable)` : 'agent';
+  const attribution = order.findings.some((f) => f.attribution === 'net-new')
+    ? 'net-new'
+    : order.findings.some((f) => f.attribution === 'deferred')
+      ? 'deferred'
+      : 'debt';
+  return (
+    `${order.id}: ${order.findings.length} finding(s), ${attribution}, tier ${tier}, ` +
+    `${order.budget.turns} turns / ${order.budget.minutes} min / $${order.budget.usd}, ` +
+    `done via ${order.done.verifier}`
+  );
+}

--- a/src/remediate/work-orders/render.ts
+++ b/src/remediate/work-orders/render.ts
@@ -1,9 +1,13 @@
 /**
  * Work-order rendering: the agent-facing prompt (section 3C) and the
- * one-line plan summary. The shared ground rules every remediation prompt
- * carries (`SHARED_RULES`) are appended here, never restated. Prose here is
- * human-toned and uses no em-dashes.
+ * one-line plan summary. Location text comes from the ONE kind-aware
+ * descriptor (`describeEntryLocation` — "never re-derive location text in a
+ * renderer"); this module only appends the remediation tail. The shared
+ * ground rules every remediation prompt carries (`SHARED_RULES`) are
+ * appended here, never restated. Prose here is human-toned and uses no
+ * em-dashes.
  */
+import { describeEntryLocation } from '../../gate/context';
 import { SHARED_RULES } from '../tasks';
 import type { WorkOrder, WorkOrderFinding } from './types';
 import { WORK_ORDER_CLASSES, isBuiltinWorkOrderClass } from './types';
@@ -18,19 +22,38 @@ function describeFinding(f: WorkOrderFinding): string {
               ? ` (imported by ${e.importingFiles.join(', ')})`
               : '')
         : `${f.id}: ${e.pack} ${e.label} fails (repro: ${e.command || 'see the floor check'})`;
-    case 'dep-vuln':
+    case 'dep-vuln': {
+      const location = describeEntryLocation({
+        id: f.id,
+        kind: 'dep-vuln',
+        package: e.package,
+        ...(e.installedVersion !== undefined ? { installedVersion: e.installedVersion } : {}),
+        advisoryId: e.advisoryId,
+      });
       return (
-        `${f.id}: ${e.package}${e.installedVersion ? `@${e.installedVersion}` : ''} ${e.advisoryId}` +
+        `${f.id}: ${location}` +
         (e.severity ? ` (${e.severity})` : '') +
         (e.fixedVersion ? `, fixed in ${e.fixedVersion}` : ', no fixed version known here') +
         (e.reachable === true ? ', reachable from your code' : '') +
         (e.expiresAt ? `, deferred until ${e.expiresAt}` : '')
       );
-    case 'custom-check':
+    }
+    case 'custom-check': {
+      const location = describeEntryLocation({
+        id: f.id,
+        kind: 'custom-check',
+        check: e.check,
+        blocking: true,
+        ...(e.file !== undefined ? { file: e.file } : {}),
+        ...(e.line !== undefined ? { line: e.line } : {}),
+        ...(e.rule !== undefined ? { rule: e.rule } : {}),
+      });
       return (
-        `${f.id}: ${e.file ?? e.check}${e.line !== undefined ? `:${e.line}` : ''} ` +
-        `${e.rule ?? e.check}${e.message ? `: ${e.message}` : ''}`
+        `${f.id}: ${location}` +
+        (e.message ? `: ${e.message}` : '') +
+        (e.expiresAt ? ` (deferred until ${e.expiresAt})` : '')
       );
+    }
     case 'none':
       return `${f.id} (${f.kind}; identity only)`;
   }
@@ -45,7 +68,7 @@ export function attributionSentence(order: WorkOrder): string {
   if (counts['net-new'] > 0)
     parts.push(`${counts['net-new']} of these are net-new (introduced by the current change)`);
   if (counts.deferred > 0)
-    parts.push(`${counts.deferred} are deferred advisories that re-block on their expiry date`);
+    parts.push(`${counts.deferred} are deferred findings that re-block on their expiry date`);
   if (counts['pre-existing'] > 0)
     parts.push(`${counts['pre-existing']} are pre-existing debt this order asks you to close`);
   if (counts.unattributed > 0)
@@ -90,7 +113,7 @@ export function renderWorkOrderPrompt(order: WorkOrder): string {
     );
   } else if (order.envelope.manifests) {
     lines.push(
-      '- no install command is known for this repo (no active language pack declares one); ' +
+      '- no install command is known for this ecosystem (no active language pack declares one); ' +
         'do not install anything, write what a human must run in docs/DXKIT-REMEDIATION-NOTES.md',
     );
   }

--- a/src/remediate/work-orders/shared.ts
+++ b/src/remediate/work-orders/shared.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared shapes and helpers for the planner's per-source builders: the draft
+ * order (everything but tier), the ranked wrapper the planner sorts, the
+ * done-criterion builder, the budget derivation, and the one `undispatch`
+ * helper. Kept beside the builders so each stays small.
+ */
+import { dxkitCli } from '../../self-invocation';
+import type { RemediateBudget } from '../config';
+import type {
+  DoneCriterion,
+  UndispatchableGroup,
+  WorkOrder,
+  WorkOrderBudget,
+  WorkOrderClass,
+  WorkOrderFinding,
+} from './types';
+
+export type Draft = Omit<WorkOrder, 'tier' | 'recipe'>;
+
+/** Value bands (lower sorts first): net-new floor, expiring deferrals,
+ *  reachable high/critical advisories, other blocking, pre-existing floor,
+ *  debt. The within-band key breaks ties deterministically (byte order). */
+export const VALUE_BAND = {
+  netNewFloor: 0,
+  expiringDeferral: 1,
+  reachableSevere: 2,
+  otherBlocking: 3,
+  preExistingFloor: 4,
+  debt: 5,
+} as const;
+
+export interface Ranked {
+  readonly draft: Draft;
+  readonly rank: readonly [number, number | string];
+}
+
+export function compareRank(a: Ranked, b: Ranked): number {
+  if (a.rank[0] !== b.rank[0]) return a.rank[0] - b.rank[0];
+  const x = a.rank[1];
+  const y = b.rank[1];
+  if (typeof x === 'number' && typeof y === 'number') return x - y;
+  const xs = String(x);
+  const ys = String(y);
+  return xs < ys ? -1 : xs > ys ? 1 : 0;
+}
+
+/** Byte-order string comparison (deterministic across locales). */
+export function byteOrder(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export function doneFor(
+  verifier: DoneCriterion['verifier'],
+  findings: readonly WorkOrderFinding[],
+): DoneCriterion {
+  return {
+    absentIds: findings.map((f) => f.id),
+    verifier,
+    command: dxkitCli(verifier === 'floor' ? 'floor check' : 'guardrail check'),
+  };
+}
+
+/** Default `remediate.workOrders.maxSliceSize`. */
+export const DEFAULT_MAX_SLICE_SIZE = 25;
+
+/** Budget derivation constants, declared once (section 3C). */
+export const BUDGET_DERIVATION = {
+  baseTurns: 8,
+  perFindingTurns: 4,
+  minTurns: 10,
+  baseMinutes: 5,
+  perFindingMinutes: 2,
+  minMinutes: 5,
+} as const;
+
+/** `min(cap, max(floor, base + per * n))`: the policy cap always wins, even
+ *  when it sits below the derivation's own minimum. */
+function bounded(value: number, floor: number, cap: number): number {
+  return Math.min(cap, Math.max(floor, value));
+}
+
+/**
+ * `turns = min(cap.maxTurns, max(min, base + perFinding * n))`, same shape
+ * for minutes; usd scales with the turn fraction of the cap and is capped
+ * by it. `cap` is the SELECTING TASK's effective budget (`budgetForTask`),
+ * so one plan never shows two budgets for one concept.
+ */
+export function deriveBudget(findingCount: number, cap: RemediateBudget): WorkOrderBudget {
+  const d = BUDGET_DERIVATION;
+  const turns = bounded(d.baseTurns + d.perFindingTurns * findingCount, d.minTurns, cap.maxTurns);
+  const minutes = bounded(
+    d.baseMinutes + d.perFindingMinutes * findingCount,
+    d.minMinutes,
+    cap.maxMinutes,
+  );
+  const usd = Math.min(cap.maxUsd, Math.max(1, Math.round((cap.maxUsd * turns) / cap.maxTurns)));
+  return {
+    turns,
+    minutes,
+    usd,
+    derivation:
+      `turns = min(${cap.maxTurns}, max(${d.minTurns}, ${d.baseTurns} + ${d.perFindingTurns} * ` +
+      `${findingCount})) = ${turns}; minutes = min(${cap.maxMinutes}, max(${d.minMinutes}, ` +
+      `${d.baseMinutes} + ${d.perFindingMinutes} * ${findingCount})) = ${minutes}; ` +
+      `usd = min(${cap.maxUsd}, round(${cap.maxUsd} * ${turns} / ${cap.maxTurns})) = ${usd}`,
+  };
+}
+
+/** The one way a builder records findings it cannot place. */
+export function undispatch(
+  into: UndispatchableGroup[],
+  reason: string,
+  findings: readonly WorkOrderFinding[],
+): void {
+  if (findings.length > 0) into.push({ reason, findings });
+}
+
+/** A finding carrying only an identity (no class, or nothing to join). */
+export function identityOnly(
+  kind: string,
+  id: string,
+  attribution: WorkOrderFinding['attribution'],
+): WorkOrderFinding {
+  return { kind, id, attribution, evidence: { type: 'none' } };
+}
+
+/** The budget cap resolver every builder receives: per class, the selecting
+ *  task's effective budget. */
+export type BudgetCapFor = (cls: WorkOrderClass) => RemediateBudget;
+
+/** Distinct kinds among findings, byte-ordered, for reason strings. */
+export function kindsOf(findings: readonly WorkOrderFinding[]): string {
+  return [...new Set(findings.map((f) => f.kind))].sort(byteOrder).join(', ');
+}

--- a/src/remediate/work-orders/shared.ts
+++ b/src/remediate/work-orders/shared.ts
@@ -1,8 +1,10 @@
 /**
  * Shared shapes and helpers for the planner's per-source builders: the draft
  * order (everything but tier), the ranked wrapper the planner sorts, the
- * done-criterion builder, the budget derivation, and the one `undispatch`
- * helper. Kept beside the builders so each stays small.
+ * done-criterion builder, the budget derivation, the one `undispatch`
+ * helper, and the single definitions of the install-forbidden line, the
+ * manifest-path projection, and the binary-custom-check reason. Kept beside
+ * the builders so each stays small.
  */
 import { dxkitCli } from '../../self-invocation';
 import type { RemediateBudget } from '../config';
@@ -39,15 +41,48 @@ export function compareRank(a: Ranked, b: Ranked): number {
   const x = a.rank[1];
   const y = b.rank[1];
   if (typeof x === 'number' && typeof y === 'number') return x - y;
-  const xs = String(x);
-  const ys = String(y);
-  return xs < ys ? -1 : xs > ys ? 1 : 0;
+  return byteOrder(String(x), String(y));
 }
 
 /** Byte-order string comparison (deterministic across locales). */
 export function byteOrder(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
+
+/** The ONE phrasing of the install ban every order carries (the frame runs
+ *  the install; the agent never does). */
+export const INSTALL_FORBIDDEN =
+  'installing, adding, or removing packages yourself (the frame runs the install command)';
+
+/** The ONE reason a binary custom-check finding cannot be ordered. */
+export const BINARY_CUSTOM_CHECK_REASON =
+  'binary (whole-command) custom-check findings carry no file to scope an order to';
+
+/** A dependency root: the manifest and lockfile files a dependency fix
+ *  touches. `dir` is repo-relative (`''` for the root), files are relative
+ *  to `dir`. */
+export interface ManifestRoot {
+  readonly dir: string;
+  readonly files: readonly string[];
+}
+
+/** The ONE ManifestRoot -> repo-relative-paths projection. */
+export function manifestPaths(root: ManifestRoot): string[] {
+  return root.files.map((f) => (root.dir ? `${root.dir}/${f}` : f));
+}
+
+/** Every discovered root's manifest paths, deduplicated, byte-ordered. */
+export function allManifestPaths(roots: readonly ManifestRoot[]): string[] {
+  return [...new Set(roots.flatMap(manifestPaths))].sort(byteOrder);
+}
+
+/** Resolve an install command per producing ecosystem: the owning pack's
+ *  declared provision command when the finding names its pack; the single
+ *  unambiguous one when exactly one active pack declares any; else
+ *  undefined (disclosed at render, never guessed). */
+export type InstallFor = (
+  pack: string | undefined,
+) => { readonly bin: string; readonly args: readonly string[] } | undefined;
 
 export function doneFor(
   verifier: DoneCriterion['verifier'],
@@ -73,8 +108,8 @@ export const BUDGET_DERIVATION = {
   minMinutes: 5,
 } as const;
 
-/** `min(cap, max(floor, base + per * n))`: the policy cap always wins, even
- *  when it sits below the derivation's own minimum. */
+/** `min(cap, max(floor, value))`: the policy cap always wins, even when it
+ *  sits below the derivation's own minimum. */
 function bounded(value: number, floor: number, cap: number): number {
   return Math.min(cap, Math.max(floor, value));
 }

--- a/src/remediate/work-orders/types.ts
+++ b/src/remediate/work-orders/types.ts
@@ -52,11 +52,10 @@ export const WORK_ORDER_CLASSES = {
   },
   'stale-lockfile': {
     summary: 'a dependency manifest whose lockfile no longer matches it',
-    producers: ['pending'],
-    pendingReason:
-      'the lockfile-sync floor check (a correctness check with its own label) lands with the ' +
-      'verify-tree-parity unit; until it is on the entry floor there is no structured signal ' +
-      'to mint this class from, and guessing one from prose would be a lossy second producer',
+    // The lockfile-sync floor check (pack-declared `lockfileCheck`, label
+    // `LOCKFILE_SYNC_LABEL`) is the structured signal this class minted
+    // `pending` until it landed.
+    producers: ['entry-floor'],
     recipe: 'lockfile-sync',
     task: 'fix-build',
   },

--- a/src/remediate/work-orders/types.ts
+++ b/src/remediate/work-orders/types.ts
@@ -16,7 +16,7 @@
  * mapping are READS of this one table, so the three lists cannot drift.
  */
 import type { FindingSeverity } from '../../baseline/types';
-import type { FloorAttribution } from '../../analyzers/correctness/attribution';
+import { checkKey, type FloorAttribution } from '../../analyzers/correctness/attribution';
 
 /** Where a class's findings are produced from. `pending` is a declared,
  *  reasoned absence (the `DEFERRED_KINDS` discipline), never a silent one. */
@@ -131,6 +131,8 @@ export interface CustomCheckEvidence {
   readonly file?: string;
   readonly line?: number;
   readonly message?: string;
+  /** Present for a deferred finding: the day it re-blocks. */
+  readonly expiresAt?: string;
 }
 
 /** A finding dxkit holds only an identity for (an undispatchable entry of a
@@ -160,10 +162,13 @@ export interface WorkOrderFinding {
 
 export const FLOOR_FINDING_KIND = 'floor-check' as const;
 
-/** The one id formula for a floor finding: `pack/label`, plus the finding-level
- *  identity where the check decomposes (the import-resolution specifier). */
+/** The one id formula for a floor finding: the canonical `checkKey` (the
+ *  same key the floor snapshot and the attribution comparator join on),
+ *  plus a `#finding` suffix where the check decomposes (an unresolved
+ *  specifier, a parsed test-failure identity). */
 export function floorFindingId(pack: string, label: string, finding?: string): string {
-  return finding === undefined ? `${pack}/${label}` : `${pack}/${label}#${finding}`;
+  const key = checkKey(pack, label);
+  return finding === undefined ? key : `${key}#${finding}`;
 }
 
 /** What the fix may touch. Derived from the findings, never from the agent. */
@@ -220,6 +225,10 @@ export type WorkOrderProvenance =
       /** 1-based slice index and count when a unit was split by size. */
       readonly slice: number;
       readonly of: number;
+      /** How many of the slice's findings were blocking / deferred (a file
+       *  order unions every source; zero counts are omitted). */
+      readonly blocking?: number;
+      readonly deferred?: number;
     };
 
 export interface WorkOrder {

--- a/src/remediate/work-orders/types.ts
+++ b/src/remediate/work-orders/types.ts
@@ -10,51 +10,90 @@
  * finding sets dxkit already computes; the executors (recipes, the scoped
  * agent) consume them in later units.
  *
- * The class union is OPEN by design: the built-in classes are a registry
- * constant (one place), and a future unit may add a class without touching
- * every consumer. Consumers switch on the constant's keys, never on scattered
- * string literals.
+ * `WORK_ORDER_CLASSES` is the SPINE: each class declares where its findings
+ * come from (its producers), which recipe serves it (or none), and which task
+ * selects it. The task catalog's `selects` and the recipe registry's class
+ * mapping are READS of this one table, so the three lists cannot drift.
  */
-import type { FindingSeverity, IdentitySchemeVersion } from '../../baseline/types';
+import type { FindingSeverity } from '../../baseline/types';
 import type { FloorAttribution } from '../../analyzers/correctness/attribution';
 
-/**
- * The built-in work-order classes. Each names a natural unit of repair with
- * its own envelope rule and (eventually) its own recipe.
- */
+/** Where a class's findings are produced from. `pending` is a declared,
+ *  reasoned absence (the `DEFERRED_KINDS` discipline), never a silent one. */
+export type WorkOrderProducer =
+  | 'entry-floor'
+  | 'guardrail-blocking'
+  | 'advisories'
+  | 'debt-slice'
+  | 'pending';
+
+export interface WorkOrderClassDeclaration {
+  readonly summary: string;
+  /** Which source(s) mint findings of this class today. */
+  readonly producers: readonly WorkOrderProducer[];
+  /** Required when `producers` is `['pending']`: why there is no producer yet
+   *  and what lands it. */
+  readonly pendingReason?: string;
+  /** The recipe id that serves this class, or null (agent only). */
+  readonly recipe: string | null;
+  /** The remediate task that selects this class. A string here so the type
+   *  module stays a leaf; `tasks.ts` reads it through `classesSelectedBy`. */
+  readonly task: string;
+}
+
+/** The built-in work-order classes: the one table the tasks, the recipes,
+ *  and the planner's per-source builders read. */
 export const WORK_ORDER_CLASSES = {
-  /** A bare import that does not resolve against the installed tree. */
   'unresolved-import': {
     summary: 'an import specifier that does not resolve against the installed dependency tree',
+    producers: ['entry-floor'],
+    recipe: 'declare-dependency',
+    task: 'fix-build',
   },
-  /** A manifest changed but the lockfile did not follow it. */
   'stale-lockfile': {
     summary: 'a dependency manifest whose lockfile no longer matches it',
+    producers: ['pending'],
+    pendingReason:
+      'the lockfile-sync floor check (a correctness check with its own label) lands with the ' +
+      'verify-tree-parity unit; until it is on the entry floor there is no structured signal ' +
+      'to mint this class from, and guessing one from prose would be a lossy second producer',
+    recipe: 'lockfile-sync',
+    task: 'fix-build',
   },
-  /** A dependency advisory (all advisories of one package). */
   'dep-advisory': {
     summary: 'a vulnerable dependency, with every advisory that names it',
+    producers: ['guardrail-blocking', 'advisories'],
+    recipe: 'override-pin',
+    task: 'fix-vulns',
   },
-  /** Located lint findings in one file. */
   'lint-located': {
     summary: 'located lint findings in one file',
+    producers: ['guardrail-blocking', 'advisories', 'debt-slice'],
+    recipe: 'lint-autofix',
+    task: 'fix-lint',
   },
-  /** A failing correctness-floor check with no finer identity. */
   'floor-failure': {
-    summary: 'a failing correctness-floor check',
+    summary: 'a failing correctness-floor check with no finer identity',
+    producers: ['entry-floor'],
+    recipe: null,
+    task: 'fix-build',
   },
-} as const;
+} as const satisfies Record<string, WorkOrderClassDeclaration>;
 
 export type BuiltinWorkOrderClass = keyof typeof WORK_ORDER_CLASSES;
 
-/** Open union: the built-ins plus any class a later unit registers. The
- *  intersection keeps autocomplete for the built-ins while admitting a
- *  registered extension class. */
+/** Open union: the built-ins plus any class a later unit registers. */
 export type WorkOrderClass = BuiltinWorkOrderClass | (string & Record<never, never>);
 
-/** Is this one of the built-in classes (a type guard over the registry)? */
 export function isBuiltinWorkOrderClass(value: string): value is BuiltinWorkOrderClass {
   return Object.prototype.hasOwnProperty.call(WORK_ORDER_CLASSES, value);
+}
+
+/** The classes a task selects: a READ of the spine. */
+export function classesSelectedBy(task: string): BuiltinWorkOrderClass[] {
+  return (Object.keys(WORK_ORDER_CLASSES) as BuiltinWorkOrderClass[]).filter(
+    (c) => WORK_ORDER_CLASSES[c].task === task,
+  );
 }
 
 /** Evidence for a correctness-floor failure (the entry floor's own record). */
@@ -62,18 +101,15 @@ export interface FloorEvidence {
   readonly type: 'floor';
   readonly pack: string;
   readonly label: string;
-  /** The failing command (bin + args) the agent re-runs to see the failure. */
+  /** The failing command the agent re-runs to see the failure. */
   readonly command: string;
-  /** Captured output tail (already bounded by the runner). */
-  readonly outputTail?: string;
-  /** For the import-resolution check: the unresolved specifier. */
+  /** For the import-resolution check: the unresolved specifier and every
+   *  file the check saw importing it. */
   readonly specifier?: string;
-  /** For the import-resolution check: the file that imports it, when the
-   *  check's output named one. */
-  readonly importingFile?: string;
+  readonly importingFiles?: readonly string[];
 }
 
-/** Evidence for a dependency advisory (baseline entry + allowlist + scan). */
+/** Evidence for a dependency advisory (live scan first, baseline fallback). */
 export interface DepAdvisoryEvidence {
   readonly type: 'dep-vuln';
   readonly package: string;
@@ -97,19 +133,24 @@ export interface CustomCheckEvidence {
   readonly message?: string;
 }
 
-export type WorkOrderEvidence = FloorEvidence | DepAdvisoryEvidence | CustomCheckEvidence;
+/** A finding dxkit holds only an identity for (an undispatchable entry of a
+ *  kind with no class, an allowlist fingerprint with nothing to join). */
+export interface NoEvidence {
+  readonly type: 'none';
+}
 
-/**
- * Attribution of one finding relative to the developer / the run. The floor
- * vocabulary is reused as-is (Rule 2: one attribution vocabulary); `deferred`
- * names an allowlist-deferred finding inside its window, which is neither
- * net-new nor grandfathered debt: it re-blocks on a date.
- */
+export type WorkOrderEvidence =
+  | FloorEvidence
+  | DepAdvisoryEvidence
+  | CustomCheckEvidence
+  | NoEvidence;
+
+/** The floor vocabulary reused as-is (Rule 2: one attribution vocabulary);
+ *  `deferred` names an allowlist-deferred finding inside its window. */
 export type WorkOrderAttribution = FloorAttribution | 'deferred';
 
 export interface WorkOrderFinding {
-  /** The identity kind (a `BaselineEntry['kind']`, or a floor check's label
-   *  namespace for floor findings, see `FLOOR_FINDING_KIND`). */
+  /** A `BaselineEntry['kind']`, or `FLOOR_FINDING_KIND` for floor findings. */
   readonly kind: string;
   /** The durable identity (Rule 9), or a floor finding id (`floorFindingId`). */
   readonly id: string;
@@ -117,11 +158,9 @@ export interface WorkOrderFinding {
   readonly evidence: WorkOrderEvidence;
 }
 
-/** Floor findings carry no baseline identity; they are keyed by check (and
- *  specifier where the check decomposes). This is the `kind` they carry. */
 export const FLOOR_FINDING_KIND = 'floor-check' as const;
 
-/** The one id formula for a floor finding: `pack/label` plus the finding-level
+/** The one id formula for a floor finding: `pack/label`, plus the finding-level
  *  identity where the check decomposes (the import-resolution specifier). */
 export function floorFindingId(pack: string, label: string, finding?: string): string {
   return finding === undefined ? `${pack}/${label}` : `${pack}/${label}#${finding}`;
@@ -129,44 +168,36 @@ export function floorFindingId(pack: string, label: string, finding?: string): s
 
 /** What the fix may touch. Derived from the findings, never from the agent. */
 export interface WorkOrderEnvelope {
-  /** Repo-relative paths (files or directory prefixes ending in `/`). */
+  /** Repo-relative paths (files, or directory prefixes ending in `/`). */
   readonly paths: readonly string[];
   /** Whether dependency manifests + lockfiles inside `paths` may change. */
   readonly manifests: boolean;
 }
 
 export interface WorkOrderConstraints {
-  /** The repo's own install command (pm-aware), for the frame to run; the
-   *  agent is told to use exactly this and nothing else. */
+  /** The pack-declared install command, for the FRAME to run. Undefined when
+   *  no active pack could name one: disclosed in the prompt, never guessed. */
   readonly install?: { readonly bin: string; readonly args: readonly string[] };
-  /** Actions the order forbids, rendered verbatim into the prompt. */
+  /** Order-specific forbidden actions. The shared ground rules every agent
+   *  prompt carries (`SHARED_RULES` in tasks.ts) are appended at render time,
+   *  never restated here. */
   readonly forbidden: readonly string[];
 }
 
-/**
- * The done criterion: the ids that must be ABSENT after the fix, plus "no
- * net-new finding inside the envelope". Renderable as prose for the agent and
- * consumable as a structured check by the frame (same object, two readers).
- */
+/** The done criterion: the ids that must be ABSENT after the fix, checked by
+ *  `verifier`, plus (always) "no net-new finding inside the envelope". */
 export interface DoneCriterion {
   readonly absentIds: readonly string[];
-  /** The verifier that decides absence. */
   readonly verifier: 'floor' | 'guardrail';
   /** The command the agent runs (and the frame re-runs) to check. */
   readonly command: string;
-  /** Always true today; declared so the frame's check is explicit. */
-  readonly noNetNewInsideEnvelope: true;
-  /** The identity scheme the ids were minted under (so a later scheme bump
-   *  can migrate an in-flight order the same way a baseline is migrated). */
-  readonly identityScheme: IdentitySchemeVersion;
 }
 
 export interface WorkOrderBudget {
   readonly turns: number;
   readonly minutes: number;
   readonly usd: number;
-  /** The formula with its numbers, recorded so every budget decision is
-   *  disclosed (the envelope discipline). */
+  /** The formula with its numbers, so every budget decision is disclosed. */
   readonly derivation: string;
 }
 
@@ -175,10 +206,17 @@ export type WorkOrderTier = 'recipe' | 'agent';
 export type WorkOrderProvenance =
   | { readonly source: 'entry-floor'; readonly check: string }
   | { readonly source: 'guardrail-blocking' }
-  | { readonly source: 'deferred-advisory'; readonly earliestExpiry: string }
+  | {
+      /** A per-package advisory order: how many of its findings came from
+       *  the guardrail's blocking set and how many from active deferrals. */
+      readonly source: 'advisories';
+      readonly blocking: number;
+      readonly deferred: number;
+      readonly earliestExpiry?: string;
+    }
   | {
       readonly source: 'debt-slice';
-      readonly file?: string;
+      readonly file: string;
       /** 1-based slice index and count when a unit was split by size. */
       readonly slice: number;
       readonly of: number;
@@ -196,9 +234,9 @@ export interface WorkOrder {
   readonly tier: WorkOrderTier;
   /** The matching recipe id when `tier` is `recipe`. */
   readonly recipe?: string;
-  /** Free-text evidence lines (the failing output, the advisory summary),
-   *  rendered verbatim to the agent. */
-  readonly evidence: readonly string[];
+  /** The failing command's captured output tail, once per order (floor
+   *  orders). Structured evidence lives on each finding. */
+  readonly outputTail?: string;
   readonly provenance: WorkOrderProvenance;
 }
 

--- a/src/remediate/work-orders/types.ts
+++ b/src/remediate/work-orders/types.ts
@@ -1,0 +1,214 @@
+/**
+ * The work order: the ONE unit of remediation (remediate rethink, section 3A).
+ *
+ * A task is a goal ("fix lint"); a work order is a finite, verifiable,
+ * product-scoped unit: the finding identities it must close (Rule 9), the
+ * evidence dxkit already holds for each, the envelope the fix may touch, the
+ * constraints the repo imposes, a done criterion the agent can run and the
+ * frame re-runs, a budget derived from the finding set, and a tier decided by
+ * the recipe registry. The planner (`planner.ts`) builds orders from the
+ * finding sets dxkit already computes; the executors (recipes, the scoped
+ * agent) consume them in later units.
+ *
+ * The class union is OPEN by design: the built-in classes are a registry
+ * constant (one place), and a future unit may add a class without touching
+ * every consumer. Consumers switch on the constant's keys, never on scattered
+ * string literals.
+ */
+import type { FindingSeverity, IdentitySchemeVersion } from '../../baseline/types';
+import type { FloorAttribution } from '../../analyzers/correctness/attribution';
+
+/**
+ * The built-in work-order classes. Each names a natural unit of repair with
+ * its own envelope rule and (eventually) its own recipe.
+ */
+export const WORK_ORDER_CLASSES = {
+  /** A bare import that does not resolve against the installed tree. */
+  'unresolved-import': {
+    summary: 'an import specifier that does not resolve against the installed dependency tree',
+  },
+  /** A manifest changed but the lockfile did not follow it. */
+  'stale-lockfile': {
+    summary: 'a dependency manifest whose lockfile no longer matches it',
+  },
+  /** A dependency advisory (all advisories of one package). */
+  'dep-advisory': {
+    summary: 'a vulnerable dependency, with every advisory that names it',
+  },
+  /** Located lint findings in one file. */
+  'lint-located': {
+    summary: 'located lint findings in one file',
+  },
+  /** A failing correctness-floor check with no finer identity. */
+  'floor-failure': {
+    summary: 'a failing correctness-floor check',
+  },
+} as const;
+
+export type BuiltinWorkOrderClass = keyof typeof WORK_ORDER_CLASSES;
+
+/** Open union: the built-ins plus any class a later unit registers. The
+ *  intersection keeps autocomplete for the built-ins while admitting a
+ *  registered extension class. */
+export type WorkOrderClass = BuiltinWorkOrderClass | (string & Record<never, never>);
+
+/** Is this one of the built-in classes (a type guard over the registry)? */
+export function isBuiltinWorkOrderClass(value: string): value is BuiltinWorkOrderClass {
+  return Object.prototype.hasOwnProperty.call(WORK_ORDER_CLASSES, value);
+}
+
+/** Evidence for a correctness-floor failure (the entry floor's own record). */
+export interface FloorEvidence {
+  readonly type: 'floor';
+  readonly pack: string;
+  readonly label: string;
+  /** The failing command (bin + args) the agent re-runs to see the failure. */
+  readonly command: string;
+  /** Captured output tail (already bounded by the runner). */
+  readonly outputTail?: string;
+  /** For the import-resolution check: the unresolved specifier. */
+  readonly specifier?: string;
+  /** For the import-resolution check: the file that imports it, when the
+   *  check's output named one. */
+  readonly importingFile?: string;
+}
+
+/** Evidence for a dependency advisory (baseline entry + allowlist + scan). */
+export interface DepAdvisoryEvidence {
+  readonly type: 'dep-vuln';
+  readonly package: string;
+  readonly installedVersion?: string;
+  readonly advisoryId: string;
+  /** From the live scan when available; absent means "not known here". */
+  readonly fixedVersion?: string;
+  readonly reachable?: boolean;
+  readonly severity?: FindingSeverity;
+  /** Present for a deferred advisory: the day it re-blocks. */
+  readonly expiresAt?: string;
+}
+
+/** Evidence for a custom-check (lint) finding. */
+export interface CustomCheckEvidence {
+  readonly type: 'custom-check';
+  readonly check: string;
+  readonly rule?: string;
+  readonly file?: string;
+  readonly line?: number;
+  readonly message?: string;
+}
+
+export type WorkOrderEvidence = FloorEvidence | DepAdvisoryEvidence | CustomCheckEvidence;
+
+/**
+ * Attribution of one finding relative to the developer / the run. The floor
+ * vocabulary is reused as-is (Rule 2: one attribution vocabulary); `deferred`
+ * names an allowlist-deferred finding inside its window, which is neither
+ * net-new nor grandfathered debt: it re-blocks on a date.
+ */
+export type WorkOrderAttribution = FloorAttribution | 'deferred';
+
+export interface WorkOrderFinding {
+  /** The identity kind (a `BaselineEntry['kind']`, or a floor check's label
+   *  namespace for floor findings, see `FLOOR_FINDING_KIND`). */
+  readonly kind: string;
+  /** The durable identity (Rule 9), or a floor finding id (`floorFindingId`). */
+  readonly id: string;
+  readonly attribution: WorkOrderAttribution;
+  readonly evidence: WorkOrderEvidence;
+}
+
+/** Floor findings carry no baseline identity; they are keyed by check (and
+ *  specifier where the check decomposes). This is the `kind` they carry. */
+export const FLOOR_FINDING_KIND = 'floor-check' as const;
+
+/** The one id formula for a floor finding: `pack/label` plus the finding-level
+ *  identity where the check decomposes (the import-resolution specifier). */
+export function floorFindingId(pack: string, label: string, finding?: string): string {
+  return finding === undefined ? `${pack}/${label}` : `${pack}/${label}#${finding}`;
+}
+
+/** What the fix may touch. Derived from the findings, never from the agent. */
+export interface WorkOrderEnvelope {
+  /** Repo-relative paths (files or directory prefixes ending in `/`). */
+  readonly paths: readonly string[];
+  /** Whether dependency manifests + lockfiles inside `paths` may change. */
+  readonly manifests: boolean;
+}
+
+export interface WorkOrderConstraints {
+  /** The repo's own install command (pm-aware), for the frame to run; the
+   *  agent is told to use exactly this and nothing else. */
+  readonly install?: { readonly bin: string; readonly args: readonly string[] };
+  /** Actions the order forbids, rendered verbatim into the prompt. */
+  readonly forbidden: readonly string[];
+}
+
+/**
+ * The done criterion: the ids that must be ABSENT after the fix, plus "no
+ * net-new finding inside the envelope". Renderable as prose for the agent and
+ * consumable as a structured check by the frame (same object, two readers).
+ */
+export interface DoneCriterion {
+  readonly absentIds: readonly string[];
+  /** The verifier that decides absence. */
+  readonly verifier: 'floor' | 'guardrail';
+  /** The command the agent runs (and the frame re-runs) to check. */
+  readonly command: string;
+  /** Always true today; declared so the frame's check is explicit. */
+  readonly noNetNewInsideEnvelope: true;
+  /** The identity scheme the ids were minted under (so a later scheme bump
+   *  can migrate an in-flight order the same way a baseline is migrated). */
+  readonly identityScheme: IdentitySchemeVersion;
+}
+
+export interface WorkOrderBudget {
+  readonly turns: number;
+  readonly minutes: number;
+  readonly usd: number;
+  /** The formula with its numbers, recorded so every budget decision is
+   *  disclosed (the envelope discipline). */
+  readonly derivation: string;
+}
+
+export type WorkOrderTier = 'recipe' | 'agent';
+
+export type WorkOrderProvenance =
+  | { readonly source: 'entry-floor'; readonly check: string }
+  | { readonly source: 'guardrail-blocking' }
+  | { readonly source: 'deferred-advisory'; readonly earliestExpiry: string }
+  | {
+      readonly source: 'debt-slice';
+      readonly file?: string;
+      /** 1-based slice index and count when a unit was split by size. */
+      readonly slice: number;
+      readonly of: number;
+    };
+
+export interface WorkOrder {
+  /** Stable within a plan: `<class>:<natural unit>[#slice]`. */
+  readonly id: string;
+  readonly class: WorkOrderClass;
+  readonly findings: readonly WorkOrderFinding[];
+  readonly envelope: WorkOrderEnvelope;
+  readonly constraints: WorkOrderConstraints;
+  readonly done: DoneCriterion;
+  readonly budget: WorkOrderBudget;
+  readonly tier: WorkOrderTier;
+  /** The matching recipe id when `tier` is `recipe`. */
+  readonly recipe?: string;
+  /** Free-text evidence lines (the failing output, the advisory summary),
+   *  rendered verbatim to the agent. */
+  readonly evidence: readonly string[];
+  readonly provenance: WorkOrderProvenance;
+}
+
+/** A finding the planner could not place in any class, with the reason. */
+export interface UndispatchableGroup {
+  readonly reason: string;
+  readonly findings: readonly WorkOrderFinding[];
+}
+
+export interface WorkOrderPlan {
+  readonly orders: readonly WorkOrder[];
+  readonly undispatchable: readonly UndispatchableGroup[];
+}

--- a/test/remediate/config-budgets.test.ts
+++ b/test/remediate/config-budgets.test.ts
@@ -45,6 +45,7 @@ function cfg(partial: Partial<RemediateConfig>): RemediateConfig {
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     resume: false,
+    workOrders: { maxSliceSize: 25 },
     ...partial,
   };
 }

--- a/test/remediate/dispatch.test.ts
+++ b/test/remediate/dispatch.test.ts
@@ -167,6 +167,7 @@ function config(): RemediateConfig {
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     resume: false,
+    workOrders: { maxSliceSize: 25 },
   };
 }
 

--- a/test/remediate/executor-landing.test.ts
+++ b/test/remediate/executor-landing.test.ts
@@ -44,6 +44,7 @@ function config(salvage: RemediateConfig['salvage'] = 'discard'): RemediateConfi
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     resume: false,
+    workOrders: { maxSliceSize: 25 },
   };
 }
 

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -212,6 +212,7 @@ function config(): RemediateConfig {
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     resume: false,
+    workOrders: { maxSliceSize: 25 },
   };
 }
 

--- a/test/remediate/resume.test.ts
+++ b/test/remediate/resume.test.ts
@@ -182,6 +182,7 @@ function config(): RemediateConfig {
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     resume: true,
+    workOrders: { maxSliceSize: 25 },
   };
 }
 

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -94,6 +94,7 @@ function config(
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     resume: false,
+    workOrders: { maxSliceSize: 25 },
   };
 }
 

--- a/test/remediate/work-orders/plan-surface.test.ts
+++ b/test/remediate/work-orders/plan-surface.test.ts
@@ -1,0 +1,235 @@
+/**
+ * `remediate plan --json` on a fixture repo: the work orders come from the
+ * ONE gather adapter (entry floor attributed against the baseline's floor
+ * envelope, lint debt from the baseline, active deferrals joined to their
+ * entries), the policy knob caps slice size, and a gather failure is
+ * disclosed rather than crashing the plan.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runRemediatePlan } from '../../../src/remediate/plan-cli';
+import {
+  gatherWorkOrderInputs,
+  planRepoWorkOrders,
+} from '../../../src/remediate/work-orders/gather';
+import { resolveRemediateConfig } from '../../../src/remediate/config';
+import type { CorrectnessFloorResult } from '../../../src/analyzers/correctness/run';
+
+let repo: string;
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), 'dxkit-work-orders-'));
+  mkdirSync(join(repo, '.dxkit', 'baselines'), { recursive: true });
+  writeFileSync(join(repo, 'package.json'), '{"name":"fixture","version":"0.0.0"}');
+  writeFileSync(join(repo, 'package-lock.json'), '{"lockfileVersion":3}');
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+function writePolicy(policy: object): void {
+  writeFileSync(join(repo, '.dxkit', 'policy.json'), JSON.stringify(policy));
+}
+
+function writeBaseline(findings: object[], floorDebt?: object): void {
+  writeFileSync(
+    join(repo, '.dxkit', 'baselines', 'main.json'),
+    JSON.stringify({
+      schemaVersion: 'dxkit-baseline/v1',
+      name: 'main',
+      createdAt: '2026-08-01T00:00:00.000Z',
+      repo: { commitSha: 'base', branch: 'main', dirty: false },
+      analysis: { dxkitVersion: 'test', toolchainHash: 'x' },
+      tools: {},
+      saltMode: 'none',
+      findings,
+      ...(floorDebt ? { floorDebt } : {}),
+    }),
+  );
+}
+
+function writeAllowlist(entries: object[]): void {
+  writeFileSync(
+    join(repo, '.dxkit', 'allowlist.json'),
+    JSON.stringify({
+      schemaVersion: 'dxkit-allowlist/v1',
+      mode: 'full',
+      identityScheme: 'v3',
+      entries,
+    }),
+  );
+}
+
+const lintEntry = (id: string, file: string, line: number, rule: string) => ({
+  id,
+  kind: 'custom-check',
+  check: 'lint:typescript',
+  blocking: true,
+  file,
+  line,
+  rule,
+});
+
+const FAILING_FLOOR: CorrectnessFloorResult = {
+  ran: true,
+  blocks: true,
+  checks: [
+    {
+      pack: 'typescript',
+      label: 'typecheck',
+      bin: 'npx',
+      args: ['tsc', '--noEmit'],
+      status: 'fail',
+      output: 'src/a.ts(1,1): error TS1',
+    },
+  ],
+};
+
+function captureJson(run: () => void): Record<string, unknown> {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  try {
+    run();
+  } finally {
+    spy.mockRestore();
+  }
+  return JSON.parse(chunks.join('')) as Record<string, unknown>;
+}
+
+describe('remediate plan --json: work orders', () => {
+  it('lists orders from the entry floor + lint debt + deferrals, with tier/budget/done and undispatchable', () => {
+    writePolicy({ remediate: { enabled: true, tasks: ['fix-build', 'fix-lint', 'fix-vulns'] } });
+    writeBaseline(
+      [
+        lintEntry('l1', 'src/a.ts', 1, 'eqeqeq'),
+        lintEntry('l2', 'src/a.ts', 9, 'eqeqeq'),
+        lintEntry('l3', 'src/b.ts', 2, 'no-unused-vars'),
+        { id: 'v1', kind: 'dep-vuln', package: 'js-yaml', advisoryId: 'GHSA-1', severity: 'high' },
+        { id: 'bin1', kind: 'custom-check', check: 'arch-check', blocking: true },
+      ],
+      // The recorded floor envelope says typecheck was already failing:
+      // the live failure attributes pre-existing, not net-new.
+      {
+        capturedAtCommit: 'base',
+        capturedAt: '2026-08-01T00:00:00.000Z',
+        checks: [
+          { pack: 'typescript', label: 'typecheck', command: 'npx tsc --noEmit', status: 'fail' },
+        ],
+      },
+    );
+    writeAllowlist([
+      {
+        fingerprint: 'v1',
+        kind: 'dep-vuln',
+        category: 'deferred',
+        reason: 'lane will fix',
+        addedBy: 't',
+        addedAt: '2026-08-01',
+        expiresAt: '2026-09-15',
+      },
+    ]);
+    const out = captureJson(() =>
+      runRemediatePlan(repo, {
+        json: true,
+        gather: { runFloor: () => FAILING_FLOOR, now: new Date('2026-08-25T00:00:00Z') },
+      }),
+    );
+    expect(out.schema).toBe('remediate-plan.v1');
+    expect(out.workOrderPlanError).toBeNull();
+    const orders = out.workOrders as Array<Record<string, unknown>>;
+    expect(orders.map((o) => o.id)).toEqual([
+      'dep-advisory:js-yaml',
+      'floor-failure:typescript:typecheck',
+      'lint-located:src/a.ts',
+      'lint-located:src/b.ts',
+    ]);
+    const floorOrder = orders[1];
+    expect(floorOrder.attribution).toEqual(['pre-existing']);
+    expect(floorOrder.tier).toBe('agent');
+    expect(floorOrder.done).toMatchObject({ verifier: 'floor', absent: 1 });
+    expect((floorOrder.budget as { derivation: string }).derivation).toContain('clamp(');
+    const advisory = orders[0];
+    expect(advisory.attribution).toEqual(['deferred']);
+    expect(advisory.provenance).toEqual({
+      source: 'deferred-advisory',
+      earliestExpiry: '2026-09-15',
+    });
+    expect(advisory.envelope).toEqual({
+      paths: ['package.json', 'package-lock.json'],
+      manifests: true,
+    });
+    const lintA = orders[2];
+    expect(lintA.findings).toBe(2);
+    expect(lintA.tier).toBe('recipe');
+    expect(lintA.recipe).toBe('lint-autofix');
+    // the binary custom-check has no file to scope to: disclosed, not dropped
+    const undispatchable = out.undispatchable as Array<{ reason: string; findings: unknown[] }>;
+    expect(undispatchable).toHaveLength(1);
+    expect(undispatchable[0].reason).toContain('binary');
+    expect(undispatchable[0].findings).toEqual([{ kind: 'custom-check', id: 'bin1' }]);
+  });
+
+  it('an absent floor envelope attributes a live failure unattributed (never net-new by default)', () => {
+    writePolicy({ remediate: { enabled: true } });
+    writeBaseline([]);
+    const plan = planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
+      runFloor: () => FAILING_FLOOR,
+    });
+    expect(plan.orders).toHaveLength(1);
+    expect(plan.orders[0].findings[0].attribution).toBe('unattributed');
+  });
+
+  it('remediate.workOrders.maxSliceSize caps a debt slice and reaches the planner through the config', () => {
+    writePolicy({ remediate: { enabled: true, workOrders: { maxSliceSize: 2 } } });
+    writeBaseline([1, 2, 3, 4, 5].map((n) => lintEntry(`l${n}`, 'src/a.ts', n, 'eqeqeq')));
+    const config = resolveRemediateConfig(repo);
+    expect(config.workOrders.maxSliceSize).toBe(2);
+    const plan = planRepoWorkOrders(repo, config, {
+      runFloor: () => ({ ran: false, blocks: false, checks: [] }),
+    });
+    expect(plan.orders.map((o) => o.id)).toEqual([
+      'lint-located:src/a.ts#1',
+      'lint-located:src/a.ts#2',
+      'lint-located:src/a.ts#3',
+    ]);
+    expect(plan.orders.map((o) => o.findings.length)).toEqual([2, 2, 1]);
+  });
+
+  it('the default slice size is 25 and an invalid knob falls back to it', () => {
+    writePolicy({ remediate: { workOrders: { maxSliceSize: -3 } } });
+    expect(resolveRemediateConfig(repo).workOrders.maxSliceSize).toBe(25);
+  });
+
+  it('gathers the repo facts once: pm install command and the root manifest + lockfile', () => {
+    writePolicy({});
+    const input = gatherWorkOrderInputs(repo, resolveRemediateConfig(repo), {
+      runFloor: () => ({ ran: false, blocks: false, checks: [] }),
+    });
+    expect(input.install).toEqual({ bin: 'npm', args: ['ci'] });
+    expect(input.manifests).toEqual([{ dir: '', files: ['package.json', 'package-lock.json'] }]);
+    expect(input.entryFloor).toBeNull();
+    expect(input.blocking).toEqual([]);
+  });
+
+  it('a gather failure is disclosed in the JSON, never a crashed plan', () => {
+    writePolicy({ remediate: { enabled: true } });
+    const out = captureJson(() =>
+      runRemediatePlan(repo, {
+        json: true,
+        gather: {
+          runFloor: () => {
+            throw new Error('floor exploded');
+          },
+        },
+      }),
+    );
+    expect(out.workOrderPlanError).toContain('floor exploded');
+    expect(out.workOrders).toEqual([]);
+  });
+});

--- a/test/remediate/work-orders/plan-surface.test.ts
+++ b/test/remediate/work-orders/plan-surface.test.ts
@@ -22,6 +22,7 @@ import {
 import { resolveRemediateConfig } from '../../../src/remediate/config';
 import { getLanguage } from '../../../src/languages';
 import type { CorrectnessFloorResult } from '../../../src/analyzers/correctness/run';
+import { LOCKFILE_SYNC_LABEL } from '../../../src/languages/capabilities/correctness';
 import type { DepVulnFinding } from '../../../src/languages/capabilities/types';
 
 let repo: string;
@@ -254,6 +255,36 @@ describe('remediate plan --json: work orders', () => {
     const none = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), { packs: TS });
     expect(none.floorSource).toBe('none');
     expect(none.plan.orders).toEqual([]);
+  });
+
+  it('a floor envelope carrying a failing lockfile-sync check yields the stale-lockfile order; a passing one yields none', async () => {
+    writePolicy({ remediate: { enabled: true } });
+    const lockCheck = (status: string) => ({
+      capturedAtCommit: 'base',
+      capturedAt: '2026-08-01T00:00:00.000Z',
+      checks: [
+        {
+          pack: 'typescript',
+          label: LOCKFILE_SYNC_LABEL,
+          command: 'npm ci --dry-run --ignore-scripts --no-audit --no-fund',
+          status,
+          ...(status === 'fail' ? { output: 'npm error Missing: left-pad@1.3.0' } : {}),
+        },
+      ],
+    });
+    writeBaseline([], lockCheck('fail'));
+    const failing = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), { packs: TS });
+    expect(failing.floorSource).toBe('baseline-envelope');
+    expect(failing.plan.orders.map((o) => [o.id, o.class, o.tier, o.recipe])).toEqual([
+      ['stale-lockfile:typescript', 'stale-lockfile', 'recipe', 'lockfile-sync'],
+    ]);
+    expect(failing.plan.orders[0].envelope).toEqual({
+      paths: ['package-lock.json', 'package.json'],
+      manifests: true,
+    });
+    writeBaseline([], lockCheck('pass'));
+    const passing = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), { packs: TS });
+    expect(passing.plan.orders).toEqual([]);
   });
 
   it('a corrupt baseline is a DISCLOSURE, never a silent "backlog clear"', async () => {

--- a/test/remediate/work-orders/plan-surface.test.ts
+++ b/test/remediate/work-orders/plan-surface.test.ts
@@ -1,10 +1,11 @@
 /**
  * `remediate plan --json` on a fixture repo: the work orders come from the
  * ONE gather adapter (a cheap stored floor by default, the live floor only
- * behind --with-floor; deferrals joined to the live dependency scan with the
- * baseline as fallback; debt excludes every active allowlist entry; repo
- * facts from the packs), the policy knob caps slice size, and a gather
- * failure is disclosed rather than crashing the plan.
+ * behind --with-floor; deferrals joined to a dependency scan with the
+ * baseline as fallback, preferring a fresh persisted BoM artifact over a
+ * live audit; debt excludes every active allowlist entry; repo facts from
+ * the packs), the policy knob caps slice size, and every degraded read is
+ * disclosed rather than crashing or silently emptying the plan.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
@@ -12,13 +13,14 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { runRemediatePlan } from '../../../src/remediate/plan-cli';
 import {
+  BOM_FRESHNESS_DAYS,
   gatherWorkOrderInputs,
-  installCommandFor,
+  installResolver,
   manifestRoots,
   planRepoWorkOrders,
 } from '../../../src/remediate/work-orders/gather';
 import { resolveRemediateConfig } from '../../../src/remediate/config';
-import { LANGUAGES, getLanguage } from '../../../src/languages';
+import { getLanguage } from '../../../src/languages';
 import type { CorrectnessFloorResult } from '../../../src/analyzers/correctness/run';
 import type { DepVulnFinding } from '../../../src/languages/capabilities/types';
 
@@ -37,6 +39,9 @@ afterEach(() => {
 
 const TS = [getLanguage('typescript')!];
 const NO_FLOOR: CorrectnessFloorResult = { ran: false, blocks: false, checks: [] };
+const THROWING_FLOOR = () => {
+  throw new Error('live floor must not run by default');
+};
 
 function writePolicy(policy: object): void {
   writeFileSync(join(repo, '.dxkit', 'policy.json'), JSON.stringify(policy));
@@ -110,20 +115,31 @@ const FAILING_FLOOR: CorrectnessFloorResult = {
   ],
 };
 
-/** The shape the deferral producers emit: the deferred advisory is NOT in the
- *  baseline; it exists in the live scan (fingerprint-stamped). */
-const LIVE_SCAN: DepVulnFinding[] = [
-  {
-    id: 'GHSA-1',
-    package: 'js-yaml',
-    installedVersion: '3.13.0',
-    tool: 'osv-scanner',
-    severity: 'high',
-    fixedVersion: '4.1.0',
-    reachable: true,
-    fingerprint: 'dead000011112222',
-  },
-];
+/** The shape the deferral producers emit: the deferred advisory is NOT in
+ *  the baseline; it exists only in a scan (fingerprint-stamped). */
+const SCAN_FINDING: DepVulnFinding = {
+  id: 'GHSA-1',
+  package: 'js-yaml',
+  installedVersion: '3.13.0',
+  tool: 'osv-scanner',
+  packId: 'typescript',
+  severity: 'high',
+  fixedVersion: '4.1.0',
+  reachable: true,
+  fingerprint: 'dead000011112222',
+};
+
+const DEFER_ENTRY = {
+  fingerprint: 'dead000011112222',
+  kind: 'dep-vuln',
+  category: 'deferred',
+  reason: 'lane will fix',
+  addedBy: 't',
+  addedAt: '2026-08-01',
+  expiresAt: '2026-09-15',
+};
+
+const NOW = new Date('2026-08-25T00:00:00Z');
 
 async function captureJson(run: () => Promise<void>): Promise<Record<string, unknown>> {
   const chunks: string[] = [];
@@ -140,7 +156,7 @@ async function captureJson(run: () => Promise<void>): Promise<Record<string, unk
 }
 
 describe('remediate plan --json: work orders', () => {
-  it('reads the stored floor envelope by default (no live floor), joins deferrals to the live scan, excludes every active allowlist entry from debt', async () => {
+  it('reads the stored floor by default (a live runFloor would throw), joins deferrals to the scan, excludes active allowlist entries from debt', async () => {
     writePolicy({ remediate: { enabled: true, tasks: ['fix-build', 'fix-lint', 'fix-vulns'] } });
     writeBaseline(
       [
@@ -153,15 +169,7 @@ describe('remediate plan --json: work orders', () => {
       FLOOR_DEBT,
     );
     writeAllowlist([
-      {
-        fingerprint: 'dead000011112222',
-        kind: 'dep-vuln',
-        category: 'deferred',
-        reason: 'lane will fix',
-        addedBy: 't',
-        addedAt: '2026-08-01',
-        expiresAt: '2026-09-15',
-      },
+      DEFER_ENTRY,
       // an accepted false positive: NOT debt to close
       {
         fingerprint: 'fp1',
@@ -172,23 +180,15 @@ describe('remediate plan --json: work orders', () => {
         addedAt: '2026-08-01',
       },
     ]);
-    let liveFloorRan = false;
     const out = await captureJson(() =>
       runRemediatePlan(repo, {
         json: true,
-        gather: {
-          packs: TS,
-          runFloor: undefined,
-          scanDepVulns: async () => LIVE_SCAN,
-          now: new Date('2026-08-25T00:00:00Z'),
-        },
-      }).then(() => {
-        liveFloorRan = false;
+        gather: { packs: TS, scanDepVulns: async () => [SCAN_FINDING], now: NOW },
       }),
     );
-    expect(liveFloorRan).toBe(false);
     expect(out.workOrderPlanError).toBeNull();
     expect(out.workOrderFloorSource).toBe('baseline-envelope');
+    expect(out.workOrderDepScanSource).toBe('injected');
     const orders = out.workOrders as Array<Record<string, unknown>>;
     expect(orders.map((o) => o.id)).toEqual([
       'dep-advisory:js-yaml',
@@ -209,13 +209,9 @@ describe('remediate plan --json: work orders', () => {
       deferred: 1,
       earliestExpiry: '2026-09-15',
     });
-    // joined to the live scan: fixed version known, so override-pin tiers recipe
+    // joined to the scan: fixed version known, so override-pin tiers recipe
     expect(advisory.tier).toBe('recipe');
     expect(advisory.recipe).toBe('override-pin');
-    expect(advisory.envelope).toEqual({
-      paths: ['package-lock.json', 'package.json'],
-      manifests: true,
-    });
     expect(orders[2].findings).toBe(2);
     // fp1 (false-positive, active) is not planned anywhere
     expect(JSON.stringify(out)).not.toContain('"fp1"');
@@ -224,62 +220,102 @@ describe('remediate plan --json: work orders', () => {
     expect(undispatchable[0].reason).toContain('binary');
   });
 
+  it('no live floor runs by default: a throwing runFloor injected as scanless default is never called without --with-floor', async () => {
+    writePolicy({ remediate: { enabled: true } });
+    writeBaseline([], FLOOR_DEBT);
+    // withFloor absent + runFloor absent: gatherFloor must read the envelope.
+    const stored = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), { packs: TS });
+    expect(stored.floorSource).toBe('baseline-envelope');
+    expect(stored.plan.orders[0].outputTail).toBe('stored tail');
+    // proving the pin bites: an injected runFloor IS used (throw surfaces)
+    await expect(
+      planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
+        packs: TS,
+        runFloor: THROWING_FLOOR,
+      }),
+    ).rejects.toThrow('live floor must not run by default');
+  });
+
   it('--with-floor runs the live floor, attributed against the envelope through the one comparator', async () => {
     writePolicy({ remediate: { enabled: true } });
     writeBaseline([], FLOOR_DEBT);
-    const withEnvelope = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
+    const live = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
       packs: TS,
       runFloor: () => FAILING_FLOOR,
     });
-    expect(withEnvelope.floorSource).toBe('live');
-    expect(withEnvelope.plan.orders[0].findings[0].attribution).toBe('pre-existing');
-    expect(withEnvelope.plan.orders[0].outputTail).toBe('src/a.ts(1,1): error TS1');
+    expect(live.floorSource).toBe('live');
+    expect(live.plan.orders[0].findings[0].attribution).toBe('pre-existing');
     writeBaseline([]);
     const noEnvelope = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
       packs: TS,
       runFloor: () => FAILING_FLOOR,
     });
     expect(noEnvelope.plan.orders[0].findings[0].attribution).toBe('unattributed');
-    // and without a stored source or --with-floor there is simply no floor, disclosed
     const none = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), { packs: TS });
     expect(none.floorSource).toBe('none');
     expect(none.plan.orders).toEqual([]);
   });
 
-  it('a deferral joined to neither the live scan nor the baseline is undispatchable, and the scan runs only when a dep-vuln deferral exists', async () => {
+  it('a corrupt baseline is a DISCLOSURE, never a silent "backlog clear"', async () => {
+    writePolicy({ remediate: { enabled: true } });
+    writeFileSync(join(repo, '.dxkit', 'baselines', 'main.json'), '{ not json');
+    const out = await captureJson(() =>
+      runRemediatePlan(repo, { json: true, gather: { packs: TS } }),
+    );
+    const disclosures = out.workOrderDisclosures as string[];
+    expect(disclosures.some((d) => d.includes('could not be read'))).toBe(true);
+    expect(out.workOrderPlanError).toBeNull();
+  });
+
+  it('prefers a fresh persisted BoM artifact over a live audit for the deferral join, disclosed; a stale one is ignored', async () => {
     writePolicy({ remediate: { enabled: true } });
     writeBaseline([]);
-    writeAllowlist([
-      {
-        fingerprint: 'gone',
-        kind: 'dep-vuln',
-        category: 'deferred',
-        reason: 'r',
-        addedBy: 't',
-        addedAt: '2026-08-01',
-        expiresAt: '2026-09-15',
-      },
-    ]);
-    let scans = 0;
-    const joined = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
+    writeAllowlist([DEFER_ENTRY]);
+    const freshDate = new Date(NOW.getTime() - 86_400_000).toISOString();
+    writeFileSync(
+      join(repo, '.dxkit', 'bom.json'),
+      JSON.stringify({ analyzedAt: freshDate, entries: [{ vulns: [SCAN_FINDING] }] }),
+    );
+    const fresh = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
       packs: TS,
-      scanDepVulns: async () => {
-        scans += 1;
-        return [];
-      },
-      now: new Date('2026-08-25T00:00:00Z'),
+      now: NOW,
+      runFloor: () => NO_FLOOR,
     });
-    expect(scans).toBe(1);
-    expect(joined.plan.undispatchable[0].findings[0].id).toBe('gone');
+    expect(fresh.depScanSource).toBe('bom-artifact');
+    expect(fresh.disclosures.some((d) => d.includes('bom.json'))).toBe(true);
+    expect(fresh.plan.orders[0].id).toBe('dep-advisory:js-yaml');
+    expect(fresh.plan.orders[0].tier).toBe('recipe');
+    // stale artifact: not read (the source would be the live audit)
+    const staleDate = new Date(NOW.getTime() - (BOM_FRESHNESS_DAYS + 1) * 86_400_000).toISOString();
+    writeFileSync(
+      join(repo, '.dxkit', 'bom.json'),
+      JSON.stringify({ analyzedAt: staleDate, entries: [{ vulns: [SCAN_FINDING] }] }),
+    );
+    const stale = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
+      packs: TS,
+      now: NOW,
+      runFloor: () => NO_FLOOR,
+      // injected scan stands in for the live audit path's result
+      scanDepVulns: async () => [],
+    });
+    expect(stale.depScanSource).toBe('injected');
+    expect(stale.plan.undispatchable[0].findings[0].id).toBe('dead000011112222');
+  });
+
+  it('the scan runs only when a dep-vuln deferral exists', async () => {
+    writePolicy({ remediate: { enabled: true } });
+    writeBaseline([]);
     writeAllowlist([]);
+    let scans = 0;
     await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
       packs: TS,
+      runFloor: () => NO_FLOOR,
       scanDepVulns: async () => {
         scans += 1;
         return [];
       },
     });
-    expect(scans).toBe(1);
+    expect(scans).toBe(0);
   });
 
   it('remediate.workOrders.maxSliceSize caps a debt slice, and each class is capped by its task budget', async () => {
@@ -293,7 +329,10 @@ describe('remediate plan --json: work orders', () => {
     writeBaseline([1, 2, 3, 4, 5].map((n) => lintEntry(`l${n}`, 'src/a.ts', n, 'eqeqeq')));
     const config = resolveRemediateConfig(repo);
     expect(config.workOrders.maxSliceSize).toBe(2);
-    const { plan } = await planRepoWorkOrders(repo, config, { packs: TS });
+    const { plan } = await planRepoWorkOrders(repo, config, {
+      packs: TS,
+      runFloor: () => NO_FLOOR,
+    });
     expect(plan.orders.map((o) => o.id)).toEqual([
       'lint-located:src/a.ts#1',
       'lint-located:src/a.ts#2',
@@ -308,27 +347,43 @@ describe('remediate plan --json: work orders', () => {
     expect(resolveRemediateConfig(repo).workOrders.maxSliceSize).toBe(25);
   });
 
-  it('repo facts come from the packs: install = the first pack-declared provision, roots from the manifest-pattern union + nested discovery', async () => {
+  it('repo facts come from the packs: per-ecosystem install commands, glob-aware manifest roots via the shared per-pack discovery', async () => {
     writePolicy({});
     mkdirSync(join(repo, 'packages', 'api'), { recursive: true });
     writeFileSync(join(repo, 'packages', 'api', 'package.json'), '{}');
     writeFileSync(join(repo, 'packages', 'api', 'pnpm-lock.yaml'), '');
-    expect(installCommandFor(repo, TS)).toEqual({ bin: 'npm', args: ['ci'] });
-    expect(manifestRoots(repo, TS)).toEqual([
+    const installFor = installResolver(repo, TS);
+    expect(installFor('typescript')).toEqual({ bin: 'npm', args: ['ci'] });
+    // single-ecosystem repo: an unattributed finding still gets the one command
+    expect(installFor(undefined)).toEqual({ bin: 'npm', args: ['ci'] });
+    const disclosures: string[] = [];
+    expect(manifestRoots(repo, TS, disclosures)).toEqual([
       { dir: '', files: ['package-lock.json', 'package.json'] },
       { dir: 'packages/api', files: ['package.json', 'pnpm-lock.yaml'] },
     ]);
-    // a stack whose packs declare no provision command: install is UNDEFINED, never npm
+    expect(disclosures).toEqual([]);
+    // a GLOB-pattern ecosystem: requirements*.txt must match via the
+    // canonical matcher, not fs.existsSync on the literal
+    const py = [getLanguage('python')!];
+    writeFileSync(join(repo, 'requirements-dev.txt'), '');
+    writeFileSync(join(repo, 'requirements.txt'), '');
+    const pyRoots = manifestRoots(repo, py, []);
+    expect(pyRoots[0].files).toContain('requirements-dev.txt');
+    expect(pyRoots[0].files).toContain('requirements.txt');
+    // python's own provision command, per ecosystem, never npm
+    expect(installResolver(repo, py)('python')).toEqual({
+      bin: 'pip',
+      args: ['install', '-r', 'requirements.txt'],
+    });
+    // a pack with no derivable provision: undefined, disclosed at render
     const go = [getLanguage('go')!];
-    expect(installCommandFor(repo, go)).toBeUndefined();
+    expect(installResolver(repo, go)('go')).toBeUndefined();
     const { input } = await gatherWorkOrderInputs(repo, resolveRemediateConfig(repo), {
       packs: go,
       runFloor: () => NO_FLOOR,
     });
-    expect(input.install).toBeUndefined();
-    expect(input.manifests[0].files).not.toContain('package.json');
+    expect(input.installFor('go')).toBeUndefined();
     expect(input.blocking).toEqual([]);
-    expect(LANGUAGES.length).toBeGreaterThan(0);
   });
 
   it('a gather failure is disclosed in the JSON, never a crashed plan', async () => {

--- a/test/remediate/work-orders/plan-surface.test.ts
+++ b/test/remediate/work-orders/plan-surface.test.ts
@@ -1,9 +1,10 @@
 /**
  * `remediate plan --json` on a fixture repo: the work orders come from the
- * ONE gather adapter (entry floor attributed against the baseline's floor
- * envelope, lint debt from the baseline, active deferrals joined to their
- * entries), the policy knob caps slice size, and a gather failure is
- * disclosed rather than crashing the plan.
+ * ONE gather adapter (a cheap stored floor by default, the live floor only
+ * behind --with-floor; deferrals joined to the live dependency scan with the
+ * baseline as fallback; debt excludes every active allowlist entry; repo
+ * facts from the packs), the policy knob caps slice size, and a gather
+ * failure is disclosed rather than crashing the plan.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
@@ -12,10 +13,14 @@ import { tmpdir } from 'os';
 import { runRemediatePlan } from '../../../src/remediate/plan-cli';
 import {
   gatherWorkOrderInputs,
+  installCommandFor,
+  manifestRoots,
   planRepoWorkOrders,
 } from '../../../src/remediate/work-orders/gather';
 import { resolveRemediateConfig } from '../../../src/remediate/config';
+import { LANGUAGES, getLanguage } from '../../../src/languages';
 import type { CorrectnessFloorResult } from '../../../src/analyzers/correctness/run';
+import type { DepVulnFinding } from '../../../src/languages/capabilities/types';
 
 let repo: string;
 
@@ -29,6 +34,9 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(repo, { recursive: true, force: true });
 });
+
+const TS = [getLanguage('typescript')!];
+const NO_FLOOR: CorrectnessFloorResult = { ran: false, blocks: false, checks: [] };
 
 function writePolicy(policy: object): void {
   writeFileSync(join(repo, '.dxkit', 'policy.json'), JSON.stringify(policy));
@@ -73,6 +81,20 @@ const lintEntry = (id: string, file: string, line: number, rule: string) => ({
   rule,
 });
 
+const FLOOR_DEBT = {
+  capturedAtCommit: 'base',
+  capturedAt: '2026-08-01T00:00:00.000Z',
+  checks: [
+    {
+      pack: 'typescript',
+      label: 'typecheck',
+      command: 'npx tsc --noEmit',
+      status: 'fail',
+      output: 'stored tail',
+    },
+  ],
+};
+
 const FAILING_FLOOR: CorrectnessFloorResult = {
   ran: true,
   blocks: true,
@@ -88,14 +110,29 @@ const FAILING_FLOOR: CorrectnessFloorResult = {
   ],
 };
 
-function captureJson(run: () => void): Record<string, unknown> {
+/** The shape the deferral producers emit: the deferred advisory is NOT in the
+ *  baseline; it exists in the live scan (fingerprint-stamped). */
+const LIVE_SCAN: DepVulnFinding[] = [
+  {
+    id: 'GHSA-1',
+    package: 'js-yaml',
+    installedVersion: '3.13.0',
+    tool: 'osv-scanner',
+    severity: 'high',
+    fixedVersion: '4.1.0',
+    reachable: true,
+    fingerprint: 'dead000011112222',
+  },
+];
+
+async function captureJson(run: () => Promise<void>): Promise<Record<string, unknown>> {
   const chunks: string[] = [];
   const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
     chunks.push(String(chunk));
     return true;
   });
   try {
-    run();
+    await run();
   } finally {
     spy.mockRestore();
   }
@@ -103,29 +140,21 @@ function captureJson(run: () => void): Record<string, unknown> {
 }
 
 describe('remediate plan --json: work orders', () => {
-  it('lists orders from the entry floor + lint debt + deferrals, with tier/budget/done and undispatchable', () => {
+  it('reads the stored floor envelope by default (no live floor), joins deferrals to the live scan, excludes every active allowlist entry from debt', async () => {
     writePolicy({ remediate: { enabled: true, tasks: ['fix-build', 'fix-lint', 'fix-vulns'] } });
     writeBaseline(
       [
         lintEntry('l1', 'src/a.ts', 1, 'eqeqeq'),
         lintEntry('l2', 'src/a.ts', 9, 'eqeqeq'),
         lintEntry('l3', 'src/b.ts', 2, 'no-unused-vars'),
-        { id: 'v1', kind: 'dep-vuln', package: 'js-yaml', advisoryId: 'GHSA-1', severity: 'high' },
+        lintEntry('fp1', 'src/c.ts', 2, 'eqeqeq'),
         { id: 'bin1', kind: 'custom-check', check: 'arch-check', blocking: true },
       ],
-      // The recorded floor envelope says typecheck was already failing:
-      // the live failure attributes pre-existing, not net-new.
-      {
-        capturedAtCommit: 'base',
-        capturedAt: '2026-08-01T00:00:00.000Z',
-        checks: [
-          { pack: 'typescript', label: 'typecheck', command: 'npx tsc --noEmit', status: 'fail' },
-        ],
-      },
+      FLOOR_DEBT,
     );
     writeAllowlist([
       {
-        fingerprint: 'v1',
+        fingerprint: 'dead000011112222',
         kind: 'dep-vuln',
         category: 'deferred',
         reason: 'lane will fix',
@@ -133,15 +162,33 @@ describe('remediate plan --json: work orders', () => {
         addedAt: '2026-08-01',
         expiresAt: '2026-09-15',
       },
+      // an accepted false positive: NOT debt to close
+      {
+        fingerprint: 'fp1',
+        kind: 'custom-check',
+        category: 'false-positive',
+        reason: 'not real',
+        addedBy: 't',
+        addedAt: '2026-08-01',
+      },
     ]);
-    const out = captureJson(() =>
+    let liveFloorRan = false;
+    const out = await captureJson(() =>
       runRemediatePlan(repo, {
         json: true,
-        gather: { runFloor: () => FAILING_FLOOR, now: new Date('2026-08-25T00:00:00Z') },
+        gather: {
+          packs: TS,
+          runFloor: undefined,
+          scanDepVulns: async () => LIVE_SCAN,
+          now: new Date('2026-08-25T00:00:00Z'),
+        },
+      }).then(() => {
+        liveFloorRan = false;
       }),
     );
-    expect(out.schema).toBe('remediate-plan.v1');
+    expect(liveFloorRan).toBe(false);
     expect(out.workOrderPlanError).toBeNull();
+    expect(out.workOrderFloorSource).toBe('baseline-envelope');
     const orders = out.workOrders as Array<Record<string, unknown>>;
     expect(orders.map((o) => o.id)).toEqual([
       'dep-advisory:js-yaml',
@@ -152,53 +199,108 @@ describe('remediate plan --json: work orders', () => {
     const floorOrder = orders[1];
     expect(floorOrder.attribution).toEqual(['pre-existing']);
     expect(floorOrder.tier).toBe('agent');
+    expect(floorOrder.install).toEqual({ bin: 'npm', args: ['ci'] });
     expect(floorOrder.done).toMatchObject({ verifier: 'floor', absent: 1 });
-    expect((floorOrder.budget as { derivation: string }).derivation).toContain('clamp(');
     const advisory = orders[0];
     expect(advisory.attribution).toEqual(['deferred']);
     expect(advisory.provenance).toEqual({
-      source: 'deferred-advisory',
+      source: 'advisories',
+      blocking: 0,
+      deferred: 1,
       earliestExpiry: '2026-09-15',
     });
+    // joined to the live scan: fixed version known, so override-pin tiers recipe
+    expect(advisory.tier).toBe('recipe');
+    expect(advisory.recipe).toBe('override-pin');
     expect(advisory.envelope).toEqual({
-      paths: ['package.json', 'package-lock.json'],
+      paths: ['package-lock.json', 'package.json'],
       manifests: true,
     });
-    const lintA = orders[2];
-    expect(lintA.findings).toBe(2);
-    expect(lintA.tier).toBe('recipe');
-    expect(lintA.recipe).toBe('lint-autofix');
-    // the binary custom-check has no file to scope to: disclosed, not dropped
+    expect(orders[2].findings).toBe(2);
+    // fp1 (false-positive, active) is not planned anywhere
+    expect(JSON.stringify(out)).not.toContain('"fp1"');
     const undispatchable = out.undispatchable as Array<{ reason: string; findings: unknown[] }>;
     expect(undispatchable).toHaveLength(1);
     expect(undispatchable[0].reason).toContain('binary');
-    expect(undispatchable[0].findings).toEqual([{ kind: 'custom-check', id: 'bin1' }]);
   });
 
-  it('an absent floor envelope attributes a live failure unattributed (never net-new by default)', () => {
+  it('--with-floor runs the live floor, attributed against the envelope through the one comparator', async () => {
     writePolicy({ remediate: { enabled: true } });
-    writeBaseline([]);
-    const plan = planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
+    writeBaseline([], FLOOR_DEBT);
+    const withEnvelope = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
+      packs: TS,
       runFloor: () => FAILING_FLOOR,
     });
-    expect(plan.orders).toHaveLength(1);
-    expect(plan.orders[0].findings[0].attribution).toBe('unattributed');
+    expect(withEnvelope.floorSource).toBe('live');
+    expect(withEnvelope.plan.orders[0].findings[0].attribution).toBe('pre-existing');
+    expect(withEnvelope.plan.orders[0].outputTail).toBe('src/a.ts(1,1): error TS1');
+    writeBaseline([]);
+    const noEnvelope = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
+      packs: TS,
+      runFloor: () => FAILING_FLOOR,
+    });
+    expect(noEnvelope.plan.orders[0].findings[0].attribution).toBe('unattributed');
+    // and without a stored source or --with-floor there is simply no floor, disclosed
+    const none = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), { packs: TS });
+    expect(none.floorSource).toBe('none');
+    expect(none.plan.orders).toEqual([]);
   });
 
-  it('remediate.workOrders.maxSliceSize caps a debt slice and reaches the planner through the config', () => {
-    writePolicy({ remediate: { enabled: true, workOrders: { maxSliceSize: 2 } } });
+  it('a deferral joined to neither the live scan nor the baseline is undispatchable, and the scan runs only when a dep-vuln deferral exists', async () => {
+    writePolicy({ remediate: { enabled: true } });
+    writeBaseline([]);
+    writeAllowlist([
+      {
+        fingerprint: 'gone',
+        kind: 'dep-vuln',
+        category: 'deferred',
+        reason: 'r',
+        addedBy: 't',
+        addedAt: '2026-08-01',
+        expiresAt: '2026-09-15',
+      },
+    ]);
+    let scans = 0;
+    const joined = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
+      packs: TS,
+      scanDepVulns: async () => {
+        scans += 1;
+        return [];
+      },
+      now: new Date('2026-08-25T00:00:00Z'),
+    });
+    expect(scans).toBe(1);
+    expect(joined.plan.undispatchable[0].findings[0].id).toBe('gone');
+    writeAllowlist([]);
+    await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
+      packs: TS,
+      scanDepVulns: async () => {
+        scans += 1;
+        return [];
+      },
+    });
+    expect(scans).toBe(1);
+  });
+
+  it('remediate.workOrders.maxSliceSize caps a debt slice, and each class is capped by its task budget', async () => {
+    writePolicy({
+      remediate: {
+        enabled: true,
+        workOrders: { maxSliceSize: 2 },
+        taskBudgets: { 'fix-lint': { maxTurns: 3 } },
+      },
+    });
     writeBaseline([1, 2, 3, 4, 5].map((n) => lintEntry(`l${n}`, 'src/a.ts', n, 'eqeqeq')));
     const config = resolveRemediateConfig(repo);
     expect(config.workOrders.maxSliceSize).toBe(2);
-    const plan = planRepoWorkOrders(repo, config, {
-      runFloor: () => ({ ran: false, blocks: false, checks: [] }),
-    });
+    const { plan } = await planRepoWorkOrders(repo, config, { packs: TS });
     expect(plan.orders.map((o) => o.id)).toEqual([
       'lint-located:src/a.ts#1',
       'lint-located:src/a.ts#2',
       'lint-located:src/a.ts#3',
     ]);
     expect(plan.orders.map((o) => o.findings.length)).toEqual([2, 2, 1]);
+    expect(plan.orders.every((o) => o.budget.turns === 3)).toBe(true);
   });
 
   it('the default slice size is 25 and an invalid knob falls back to it', () => {
@@ -206,23 +308,36 @@ describe('remediate plan --json: work orders', () => {
     expect(resolveRemediateConfig(repo).workOrders.maxSliceSize).toBe(25);
   });
 
-  it('gathers the repo facts once: pm install command and the root manifest + lockfile', () => {
+  it('repo facts come from the packs: install = the first pack-declared provision, roots from the manifest-pattern union + nested discovery', async () => {
     writePolicy({});
-    const input = gatherWorkOrderInputs(repo, resolveRemediateConfig(repo), {
-      runFloor: () => ({ ran: false, blocks: false, checks: [] }),
+    mkdirSync(join(repo, 'packages', 'api'), { recursive: true });
+    writeFileSync(join(repo, 'packages', 'api', 'package.json'), '{}');
+    writeFileSync(join(repo, 'packages', 'api', 'pnpm-lock.yaml'), '');
+    expect(installCommandFor(repo, TS)).toEqual({ bin: 'npm', args: ['ci'] });
+    expect(manifestRoots(repo, TS)).toEqual([
+      { dir: '', files: ['package-lock.json', 'package.json'] },
+      { dir: 'packages/api', files: ['package.json', 'pnpm-lock.yaml'] },
+    ]);
+    // a stack whose packs declare no provision command: install is UNDEFINED, never npm
+    const go = [getLanguage('go')!];
+    expect(installCommandFor(repo, go)).toBeUndefined();
+    const { input } = await gatherWorkOrderInputs(repo, resolveRemediateConfig(repo), {
+      packs: go,
+      runFloor: () => NO_FLOOR,
     });
-    expect(input.install).toEqual({ bin: 'npm', args: ['ci'] });
-    expect(input.manifests).toEqual([{ dir: '', files: ['package.json', 'package-lock.json'] }]);
-    expect(input.entryFloor).toBeNull();
+    expect(input.install).toBeUndefined();
+    expect(input.manifests[0].files).not.toContain('package.json');
     expect(input.blocking).toEqual([]);
+    expect(LANGUAGES.length).toBeGreaterThan(0);
   });
 
-  it('a gather failure is disclosed in the JSON, never a crashed plan', () => {
+  it('a gather failure is disclosed in the JSON, never a crashed plan', async () => {
     writePolicy({ remediate: { enabled: true } });
-    const out = captureJson(() =>
+    const out = await captureJson(() =>
       runRemediatePlan(repo, {
         json: true,
         gather: {
+          packs: TS,
           runFloor: () => {
             throw new Error('floor exploded');
           },

--- a/test/remediate/work-orders/planner.test.ts
+++ b/test/remediate/work-orders/planner.test.ts
@@ -1,29 +1,23 @@
 /**
  * The work-order planner: grouping per (class, natural unit), envelope
  * derivation per class, budget derivation from the finding set and the
- * selecting task's cap, value ordering, the undispatchable bucket, blocking +
- * deferred advisories merging into ONE order per package, and the recipe
- * registry driving the tier decision (synthetic-injection guarded).
+ * selecting task's cap, value ordering, the undispatchable bucket, the
+ * per-package advisory union across every source, the per-file lint union,
+ * and the recipe registry driving the tier decision (synthetic-injection
+ * guarded).
  */
 import { describe, it, expect } from 'vitest';
 import {
   BUDGET_DERIVATION,
-  assignTier,
   deriveBudget,
   planWorkOrders,
   selectOrders,
-  uniformBudget,
   type AdvisoryInput,
   type FloorFailureInput,
   type PlannerInput,
 } from '../../../src/remediate/work-orders/planner';
-import { RECIPE_REGISTRY, matchRecipe } from '../../../src/remediate/work-orders/recipes-registry';
-import { WORK_ORDER_CLASSES, floorFindingId } from '../../../src/remediate/work-orders/types';
-import type {
-  WorkOrder,
-  WorkOrderClassDeclaration,
-} from '../../../src/remediate/work-orders/types';
-import { IMPORT_RESOLUTION_LABEL } from '../../../src/analyzers/correctness/run';
+import { floorFindingId } from '../../../src/remediate/work-orders/types';
+import { checkKey } from '../../../src/analyzers/correctness/attribution';
 import type { RichBaselineEntry } from '../../../src/baseline/types';
 import { DEFAULT_REMEDIATE_BUDGET } from '../../../src/remediate/config';
 
@@ -32,6 +26,8 @@ const MANIFESTS = [
   { dir: 'packages/api', files: ['package.json'] },
 ];
 
+const NPM_CI = { bin: 'npm', args: ['ci'] };
+
 function empty(): PlannerInput {
   return {
     floorFailures: [],
@@ -39,19 +35,20 @@ function empty(): PlannerInput {
     deferred: [],
     debt: [],
     manifests: MANIFESTS,
-    install: { bin: 'npm', args: ['ci'] },
-    policy: { maxSliceSize: 25, budgetFor: uniformBudget(DEFAULT_REMEDIATE_BUDGET) },
+    installFor: () => NPM_CI,
+    policy: { maxSliceSize: 25, budgetFor: () => DEFAULT_REMEDIATE_BUDGET },
   };
 }
 
 const IMPORT_FAILURE: FloorFailureInput = {
   pack: 'typescript',
-  label: IMPORT_RESOLUTION_LABEL,
+  label: 'import-resolution',
   command: '',
   output: 'three unresolved',
   attribution: 'net-new',
   precision: 'finding',
   netNewFindings: ['left-pad'],
+  findings: ['lodash', 'left-pad', 'zod'],
   unresolved: [
     { specifier: 'lodash', file: 'src/a.ts' },
     { specifier: 'lodash', file: 'src/z.ts' },
@@ -96,8 +93,8 @@ describe('planWorkOrders: entry floor', () => {
     ]);
     const root = imports.find((o) => o.id.endsWith(':.'))!;
     expect(root.findings.map((f) => f.id).sort()).toEqual([
-      floorFindingId('typescript', IMPORT_RESOLUTION_LABEL, 'left-pad'),
-      floorFindingId('typescript', IMPORT_RESOLUTION_LABEL, 'lodash'),
+      floorFindingId('typescript', 'import-resolution', 'left-pad'),
+      floorFindingId('typescript', 'import-resolution', 'lodash'),
     ]);
     // both importers of lodash, not only the first
     expect(root.envelope).toEqual({
@@ -117,12 +114,15 @@ describe('planWorkOrders: entry floor', () => {
     expect(root.done.verifier).toBe('floor');
     expect(root.done.absentIds).toEqual(root.findings.map((f) => f.id));
     expect(root.outputTail).toBe('three unresolved');
-    expect(root.provenance).toEqual({
-      source: 'entry-floor',
-      check: `typescript/${IMPORT_RESOLUTION_LABEL}`,
-    });
     expect(root.tier).toBe('recipe');
     expect(root.recipe).toBe('declare-dependency');
+  });
+
+  it('floor finding ids build on the canonical checkKey (pack:label), never a second formula', () => {
+    expect(floorFindingId('typescript', 'typecheck')).toBe(checkKey('typescript', 'typecheck'));
+    expect(floorFindingId('typescript', 'typecheck', 'x')).toBe(
+      `${checkKey('typescript', 'typecheck')}#x`,
+    );
   });
 
   it('a floor failure with no finer identity is one order per check, class floor-failure, agent tier, command carried', () => {
@@ -132,24 +132,48 @@ describe('planWorkOrders: entry floor', () => {
     expect(order.class).toBe('floor-failure');
     expect(order.id).toBe('floor-failure:typescript:typecheck');
     expect(order.tier).toBe('agent');
+    expect(order.findings[0].id).toBe(checkKey('typescript', 'typecheck'));
     expect(order.findings[0].evidence).toMatchObject({
       type: 'floor',
       command: 'npx tsc --noEmit',
     });
     expect(order.outputTail).toBe('src/c.ts(3,1): error TS2304');
     expect(order.envelope.manifests).toBe(false);
-    expect(order.constraints.install).toEqual({ bin: 'npm', args: ['ci'] });
+    expect(order.constraints.install).toEqual(NPM_CI);
+  });
+
+  it('a check with finding-level identities decomposes generically (not keyed on a label): per-finding attribution', () => {
+    const tests: FloorFailureInput = {
+      pack: 'typescript',
+      label: 'affected-tests',
+      command: 'npx vitest run',
+      attribution: 'net-new',
+      precision: 'finding',
+      netNewFindings: ['suite/b'],
+      findings: ['suite/a', 'suite/b'],
+    };
+    const plan = planWorkOrders({ ...empty(), floorFailures: [tests] });
+    expect(plan.orders).toHaveLength(1);
+    const order = plan.orders[0];
+    expect(order.class).toBe('floor-failure');
+    expect(order.findings.map((f) => [f.id, f.attribution])).toEqual([
+      [`${checkKey('typescript', 'affected-tests')}#suite/a`, 'pre-existing'],
+      [`${checkKey('typescript', 'affected-tests')}#suite/b`, 'net-new'],
+    ]);
   });
 
   it('no install command known: the order carries none (disclosed at render), never a guessed one', () => {
-    const input: PlannerInput = { ...empty(), floorFailures: [BUILD_FAILURE] };
-    delete (input as { install?: unknown }).install;
+    const input: PlannerInput = {
+      ...empty(),
+      floorFailures: [BUILD_FAILURE],
+      installFor: () => undefined,
+    };
     expect(planWorkOrders(input).orders[0].constraints.install).toBeUndefined();
   });
 });
 
 describe('planWorkOrders: advisories', () => {
-  it('ONE order per package unions blocking + deferred advisories (never drops either), envelope = manifests only', () => {
+  it('ONE order per package unions blocking + deferred + debt advisories; both facts survive on a doubly-sourced advisory', () => {
     const plan = planWorkOrders({
       ...empty(),
       blocking: [
@@ -161,21 +185,24 @@ describe('planWorkOrders: advisories', () => {
             reachable: true,
           }),
         },
-        { kind: 'dep-vuln', advisory: advisory('b1', 'lodash', 'GHSA-3', { severity: 'low' }) },
       ],
       deferred: [
-        {
-          fingerprint: 'a2',
-          expiresAt: '2026-09-10',
-          kind: 'dep-vuln',
-          advisory: advisory('a2', 'axios', 'GHSA-2', { fixedVersion: '1.7.0' }),
-        },
+        // the SAME advisory is also deferred: expiry must still count
         {
           fingerprint: 'a1',
           expiresAt: '2026-09-01',
           kind: 'dep-vuln',
           advisory: advisory('a1', 'axios', 'GHSA-1'),
         },
+        {
+          fingerprint: 'a2',
+          expiresAt: '2026-09-10',
+          kind: 'dep-vuln',
+          advisory: advisory('a2', 'axios', 'GHSA-2', { fixedVersion: '1.7.0' }),
+        },
+      ],
+      debt: [
+        { id: 'b1', kind: 'dep-vuln', package: 'lodash', advisoryId: 'GHSA-3', severity: 'low' },
       ],
     });
     expect(plan.undispatchable).toEqual([]);
@@ -185,29 +212,52 @@ describe('planWorkOrders: advisories', () => {
       ['a1', 'net-new'],
       ['a2', 'deferred'],
     ]);
-    expect(axios.provenance).toEqual({
-      source: 'advisories',
-      blocking: 1,
-      deferred: 1,
-      earliestExpiry: '2026-09-10',
-    });
-    expect(axios.envelope).toEqual({
-      paths: ['package-lock.json', 'package.json'],
-      manifests: true,
-    });
+    // the blocking copy keeps its richness AND gains the expiry window
     expect(axios.findings[0].evidence).toMatchObject({
-      type: 'dep-vuln',
       fixedVersion: '1.7.0',
       reachable: true,
       severity: 'high',
+      expiresAt: '2026-09-01',
     });
-    expect(axios.done.verifier).toBe('guardrail');
+    expect(axios.provenance).toEqual({
+      source: 'advisories',
+      blocking: 1,
+      deferred: 2,
+      earliestExpiry: '2026-09-01',
+    });
     expect(axios.tier).toBe('recipe');
     expect(axios.recipe).toBe('override-pin');
-    expect(plan.orders[1].tier).toBe('agent');
+    // baselined dep-vuln DEBT produces an order too (fix-vulns' backlog)
+    const lodash = plan.orders[1];
+    expect(lodash.findings[0].attribution).toBe('pre-existing');
+    expect(lodash.tier).toBe('agent');
+    expect(lodash.provenance).toEqual({ source: 'advisories', blocking: 0, deferred: 0 });
   });
 
-  it('a deferral joined to nothing is undispatchable with the reason, never dropped', () => {
+  it('envelope scopes to the owning nested root when every finding knows it, else every discovered root', () => {
+    const nested = planWorkOrders({
+      ...empty(),
+      blocking: [
+        {
+          kind: 'dep-vuln',
+          advisory: advisory('n1', 'inner', 'GHSA-N', { rootDir: 'packages/api' }),
+        },
+      ],
+    });
+    expect(nested.orders[0].envelope.paths).toEqual(['packages/api/package.json']);
+    const unknown = planWorkOrders({
+      ...empty(),
+      blocking: [{ kind: 'dep-vuln', advisory: advisory('u1', 'outer', 'GHSA-U') }],
+    });
+    // root unknown: every root's manifests, so the fix's files are inside
+    expect(unknown.orders[0].envelope.paths).toEqual([
+      'package-lock.json',
+      'package.json',
+      'packages/api/package.json',
+    ]);
+  });
+
+  it('a deferral joined to nothing is undispatchable with identity-only evidence, never dropped', () => {
     const plan = planWorkOrders({
       ...empty(),
       deferred: [
@@ -229,59 +279,77 @@ describe('planWorkOrders: advisories', () => {
       evidence: { type: 'none' },
     });
   });
+});
 
-  it('a deferred located custom-check is a lint-located order (its class), attributed deferred', () => {
+describe('planWorkOrders: lint (one order per file, every source)', () => {
+  it('a file with a deferred finding AND grandfathered debt is ONE order (the duplicate-id plan-killer), ranked by expiry', () => {
     const plan = planWorkOrders({
       ...empty(),
       deferred: [
         {
-          fingerprint: 'l1',
-          expiresAt: '2026-09-01',
+          fingerprint: 'd1',
+          expiresAt: '2026-09-05',
           kind: 'custom-check',
-          entry: lint('l1', 'src/a.ts', 'eqeqeq', 3),
+          entry: lint('d1', 'src/a.ts', 'eqeqeq', 3),
         },
       ],
+      debt: [lint('l1', 'src/a.ts', 'no-unused-vars', 9), lint('l2', 'src/b.ts', 'eqeqeq', 1)],
     });
-    expect(plan.undispatchable).toEqual([]);
-    expect(plan.orders.map((o) => [o.id, o.class])).toEqual([
-      ['lint-located:src/a.ts', 'lint-located'],
+    expect(plan.orders.map((o) => o.id)).toEqual([
+      'lint-located:src/a.ts',
+      'lint-located:src/b.ts',
     ]);
-    expect(plan.orders[0].findings[0].attribution).toBe('deferred');
+    const merged = plan.orders[0];
+    expect(merged.findings.map((f) => [f.id, f.attribution])).toEqual([
+      ['d1', 'deferred'],
+      ['l1', 'pre-existing'],
+    ]);
+    expect(merged.provenance).toMatchObject({
+      source: 'debt-slice',
+      file: 'src/a.ts',
+      deferred: 1,
+    });
+    // ranked in the expiring band, ahead of the pure-debt file
+    expect(plan.orders[1].findings[0].id).toBe('l2');
+    expect(plan.undispatchable).toEqual([]);
   });
-});
 
-describe('planWorkOrders: debt slices', () => {
-  it('groups lint debt by file, then by rule + line, capped by maxSliceSize with slice provenance', () => {
+  it('blocking lint findings join the same per-file order and rank in the blocking band', () => {
+    const plan = planWorkOrders({
+      ...empty(),
+      blocking: [{ kind: 'custom-check', entry: lint('b1', 'src/a.ts', 'eqeqeq', 2) }],
+      debt: [lint('l1', 'src/a.ts', 'eqeqeq', 9)],
+    });
+    expect(plan.orders).toHaveLength(1);
+    expect(plan.orders[0].findings.map((f) => f.attribution)).toEqual(['net-new', 'pre-existing']);
+    expect(plan.orders[0].provenance).toMatchObject({ blocking: 1 });
+  });
+
+  it('slices by maxSliceSize with #n suffixes (no id collision) and slice provenance', () => {
     const debt: RichBaselineEntry[] = [];
     for (let i = 0; i < 7; i++)
       debt.push(lint(`f${i}`, 'src/big.ts', i % 2 === 0 ? 'no-unused-vars' : 'eqeqeq', i + 1));
-    debt.push(lint('g1', 'src/small.ts', 'eqeqeq', 4));
     const plan = planWorkOrders({
       ...empty(),
       debt,
-      policy: { maxSliceSize: 3, budgetFor: uniformBudget(DEFAULT_REMEDIATE_BUDGET) },
+      policy: { maxSliceSize: 3, budgetFor: () => DEFAULT_REMEDIATE_BUDGET },
     });
     expect(plan.orders.map((o) => o.id)).toEqual([
       'lint-located:src/big.ts#1',
       'lint-located:src/big.ts#2',
       'lint-located:src/big.ts#3',
-      'lint-located:src/small.ts',
     ]);
-    const first = plan.orders[0];
-    expect(first.findings).toHaveLength(3);
-    expect(first.findings.every((f) => (f.evidence as { rule?: string }).rule === 'eqeqeq')).toBe(
-      true,
-    );
-    expect(first.envelope).toEqual({ paths: ['src/big.ts'], manifests: false });
-    expect(first.provenance).toEqual({ source: 'debt-slice', file: 'src/big.ts', slice: 1, of: 3 });
-    expect(first.tier).toBe('recipe');
-    expect(first.recipe).toBe('lint-autofix');
-    expect(plan.orders[3].provenance).toEqual({
+    expect(
+      plan.orders[0].findings.every((f) => (f.evidence as { rule?: string }).rule === 'eqeqeq'),
+    ).toBe(true);
+    expect(plan.orders[0].provenance).toEqual({
       source: 'debt-slice',
-      file: 'src/small.ts',
+      file: 'src/big.ts',
       slice: 1,
-      of: 1,
+      of: 3,
     });
+    expect(plan.orders[0].tier).toBe('recipe');
+    expect(plan.orders[0].recipe).toBe('lint-autofix');
   });
 
   it('binary custom-check debt and other kinds land in undispatchable with identity-only evidence', () => {
@@ -351,7 +419,7 @@ describe('planWorkOrders: value ordering + budget', () => {
     ]);
   });
 
-  it('derives the budget from the finding count, capped by the task budget, formula recorded with CAPPED numbers', () => {
+  it('derives the budget from the finding count, capped by the task budget; the cap wins below the minimum and the derivation records capped numbers', () => {
     const d = BUDGET_DERIVATION;
     const one = deriveBudget(1, DEFAULT_REMEDIATE_BUDGET);
     expect(one.turns).toBe(Math.max(d.minTurns, d.baseTurns + d.perFindingTurns));
@@ -360,7 +428,6 @@ describe('planWorkOrders: value ordering + budget', () => {
     expect(many.turns).toBe(DEFAULT_REMEDIATE_BUDGET.maxTurns);
     expect(many.minutes).toBe(DEFAULT_REMEDIATE_BUDGET.maxMinutes);
     expect(many.usd).toBe(DEFAULT_REMEDIATE_BUDGET.maxUsd);
-    // a cap BELOW the derivation minimum wins, and the derivation says so
     const tiny = deriveBudget(0, { maxTurns: 4, maxMinutes: 2, maxUsd: 1 });
     expect(tiny).toMatchObject({ turns: 4, minutes: 2, usd: 1 });
     expect(tiny.derivation).toContain('= 4;');
@@ -402,66 +469,5 @@ describe('planWorkOrders: value ordering + budget', () => {
     ]);
     expect(selectOrders(plan, []).length).toBe(0);
     expect(planWorkOrders(input)).toEqual(plan);
-  });
-});
-
-describe('recipe registry drives the tier (synthetic injection)', () => {
-  const draft: Omit<WorkOrder, 'tier' | 'recipe'> = {
-    id: 'synthetic-class:unit',
-    class: 'synthetic-class',
-    findings: [],
-    envelope: { paths: ['x'], manifests: false },
-    constraints: { forbidden: [] },
-    done: { absentIds: [], verifier: 'guardrail', command: 'x' },
-    budget: { turns: 1, minutes: 1, usd: 1, derivation: 'x' },
-    provenance: { source: 'guardrail-blocking' },
-  };
-
-  it('an order of an unregistered class tiers agent under the built-in registry', () => {
-    expect(assignTier(draft).tier).toBe('agent');
-    expect(matchRecipe({ ...draft, tier: 'agent' })).toBeUndefined();
-  });
-
-  it('a fake recipe for a fake class, injected into the registry, tiers the order recipe', () => {
-    const fake = {
-      id: 'synthetic-fixer',
-      class: 'synthetic-class',
-      summary: 't',
-      implemented: false,
-      matches: () => true,
-    };
-    const tiered = assignTier(draft, [...RECIPE_REGISTRY, fake]);
-    expect(tiered.tier).toBe('recipe');
-    expect(tiered.recipe).toBe('synthetic-fixer');
-  });
-
-  it('the planner reads the registry it is handed (a fake recipe flips a real order)', () => {
-    const input: PlannerInput = { ...empty(), floorFailures: [BUILD_FAILURE] };
-    expect(planWorkOrders(input).orders[0].tier).toBe('agent');
-    const fake = {
-      id: 'floor-fixer',
-      class: 'floor-failure',
-      summary: 't',
-      implemented: false,
-      matches: () => true,
-    };
-    const flipped = planWorkOrders(input, { registry: [...RECIPE_REGISTRY, fake] }).orders[0];
-    expect(flipped.tier).toBe('recipe');
-    expect(flipped.recipe).toBe('floor-fixer');
-  });
-
-  it('the class table is the spine: every declared recipe is named by exactly its class, and vice versa', () => {
-    const ids = RECIPE_REGISTRY.map((r) => r.id);
-    expect(new Set(ids).size).toBe(ids.length);
-    const fromTable = Object.entries(WORK_ORDER_CLASSES)
-      .filter(([, d]) => d.recipe !== null)
-      .map(([c, d]) => [d.recipe, c]);
-    expect(RECIPE_REGISTRY.map((r) => [r.id, r.class]).sort()).toEqual(fromTable.sort());
-    for (const r of RECIPE_REGISTRY) expect(r.implemented).toBe(false);
-    // a class with no producer carries a reason (the DEFERRED_KINDS discipline)
-    for (const d of Object.values(WORK_ORDER_CLASSES) as WorkOrderClassDeclaration[]) {
-      if (d.producers.includes('pending')) expect(d.pendingReason).toBeTruthy();
-      else expect(d.producers.length).toBeGreaterThan(0);
-    }
   });
 });

--- a/test/remediate/work-orders/planner.test.ts
+++ b/test/remediate/work-orders/planner.test.ts
@@ -1,8 +1,9 @@
 /**
  * The work-order planner: grouping per (class, natural unit), envelope
- * derivation per class, budget derivation from the finding set, value
- * ordering, the undispatchable bucket, and the recipe registry driving the
- * tier decision (synthetic-injection guarded).
+ * derivation per class, budget derivation from the finding set and the
+ * selecting task's cap, value ordering, the undispatchable bucket, blocking +
+ * deferred advisories merging into ONE order per package, and the recipe
+ * registry driving the tier decision (synthetic-injection guarded).
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -11,85 +12,69 @@ import {
   deriveBudget,
   planWorkOrders,
   selectOrders,
+  uniformBudget,
+  type AdvisoryInput,
+  type FloorFailureInput,
   type PlannerInput,
 } from '../../../src/remediate/work-orders/planner';
 import { RECIPE_REGISTRY, matchRecipe } from '../../../src/remediate/work-orders/recipes-registry';
 import { WORK_ORDER_CLASSES, floorFindingId } from '../../../src/remediate/work-orders/types';
-import type { WorkOrder } from '../../../src/remediate/work-orders/types';
-import { IMPORT_RESOLUTION_LABEL } from '../../../src/analyzers/correctness/run';
 import type {
-  CorrectnessCheckResult,
-  CorrectnessFloorResult,
-} from '../../../src/analyzers/correctness/run';
-import type { AttributedFloorFailure } from '../../../src/analyzers/correctness/attribution';
-import type { ClassifiedPair } from '../../../src/gate/result';
+  WorkOrder,
+  WorkOrderClassDeclaration,
+} from '../../../src/remediate/work-orders/types';
+import { IMPORT_RESOLUTION_LABEL } from '../../../src/analyzers/correctness/run';
 import type { RichBaselineEntry } from '../../../src/baseline/types';
-import type { AllowlistEntry } from '../../../src/allowlist/file';
 import { DEFAULT_REMEDIATE_BUDGET } from '../../../src/remediate/config';
 
-const POLICY = { maxSliceSize: 25, budget: DEFAULT_REMEDIATE_BUDGET };
 const MANIFESTS = [
-  { dir: '', files: ['package.json', 'package-lock.json'] },
+  { dir: '', files: ['package-lock.json', 'package.json'] },
   { dir: 'packages/api', files: ['package.json'] },
 ];
 
 function empty(): PlannerInput {
   return {
-    entryFloor: null,
+    floorFailures: [],
     blocking: [],
     deferred: [],
     debt: [],
     manifests: MANIFESTS,
     install: { bin: 'npm', args: ['ci'] },
-    policy: POLICY,
+    policy: { maxSliceSize: 25, budgetFor: uniformBudget(DEFAULT_REMEDIATE_BUDGET) },
   };
 }
 
-function floor(
-  checks: CorrectnessCheckResult[],
-  attributed: AttributedFloorFailure[],
-): PlannerInput['entryFloor'] {
-  const result: CorrectnessFloorResult = { ran: true, checks, blocks: true };
-  return { result, attributed };
-}
-
-const IMPORT_CHECK: CorrectnessCheckResult = {
+const IMPORT_FAILURE: FloorFailureInput = {
   pack: 'typescript',
   label: IMPORT_RESOLUTION_LABEL,
-  bin: '',
-  status: 'fail',
-  output: [
-    "'lodash' does not resolve against the installed tree (imported by src/a.ts)",
-    "'left-pad' does not resolve against the installed tree (imported by src/b.ts)",
-    "'zod' does not resolve against the installed tree (imported by packages/api/src/x.ts)",
-    'An import of an uninstalled/undeclared package fails at build or run time.',
-  ].join('\n'),
-  findings: ['lodash', 'left-pad', 'zod'],
+  command: '',
+  output: 'three unresolved',
+  attribution: 'net-new',
+  precision: 'finding',
+  netNewFindings: ['left-pad'],
+  unresolved: [
+    { specifier: 'lodash', file: 'src/a.ts' },
+    { specifier: 'lodash', file: 'src/z.ts' },
+    { specifier: 'left-pad', file: 'src/b.ts' },
+    { specifier: 'zod', file: 'packages/api/src/x.ts' },
+  ],
 };
 
-const BUILD_CHECK: CorrectnessCheckResult = {
+const BUILD_FAILURE: FloorFailureInput = {
   pack: 'typescript',
   label: 'typecheck',
-  bin: 'npx',
-  args: ['tsc', '--noEmit'],
-  status: 'fail',
+  command: 'npx tsc --noEmit',
   output: 'src/c.ts(3,1): error TS2304',
+  attribution: 'pre-existing',
 };
 
-function depVuln(
+function advisory(
   id: string,
   pkg: string,
   advisoryId: string,
-  severity?: 'critical' | 'high' | 'medium' | 'low',
-): Extract<RichBaselineEntry, { kind: 'dep-vuln' }> {
-  return {
-    id,
-    kind: 'dep-vuln',
-    package: pkg,
-    installedVersion: '1.0.0',
-    advisoryId,
-    ...(severity ? { severity } : {}),
-  };
+  extra: Partial<AdvisoryInput> = {},
+): AdvisoryInput {
+  return { id, package: pkg, installedVersion: '1.0.0', advisoryId, ...extra };
 }
 
 function lint(
@@ -101,49 +86,9 @@ function lint(
   return { id, kind: 'custom-check', check: 'lint:typescript', blocking: true, file, line, rule };
 }
 
-function blockingPair(entry: RichBaselineEntry): {
-  pair: ClassifiedPair;
-  entry: RichBaselineEntry;
-} {
-  return {
-    entry,
-    pair: {
-      pair: { currentId: entry.id, status: 'added', confidence: 1, reasons: [] },
-      classification: { status: 'added', blocks: true, warns: false, reasons: [] },
-      kind: entry.kind,
-    },
-  };
-}
-
-function deferred(fingerprint: string, expiresAt: string): AllowlistEntry {
-  return {
-    fingerprint,
-    kind: 'dep-vuln',
-    category: 'deferred',
-    reason: 'lane will fix',
-    addedBy: 't',
-    addedAt: '2026-08-01',
-    expiresAt,
-  };
-}
-
 describe('planWorkOrders: entry floor', () => {
-  it('groups unresolved imports by the manifest root their importing files share, with the envelope = importers + manifest + lockfile', () => {
-    const input: PlannerInput = {
-      ...empty(),
-      entryFloor: floor(
-        [IMPORT_CHECK],
-        [
-          {
-            check: IMPORT_CHECK,
-            attribution: 'net-new',
-            precision: 'finding',
-            netNewFindings: ['left-pad'],
-          },
-        ],
-      ),
-    };
-    const plan = planWorkOrders(input);
+  it('groups unresolved imports by the manifest root their importers share; envelope = EVERY importer + manifest + lockfile', () => {
+    const plan = planWorkOrders({ ...empty(), floorFailures: [IMPORT_FAILURE] });
     const imports = plan.orders.filter((o) => o.class === 'unresolved-import');
     expect(imports.map((o) => o.id).sort()).toEqual([
       'unresolved-import:typescript:.',
@@ -154,44 +99,34 @@ describe('planWorkOrders: entry floor', () => {
       floorFindingId('typescript', IMPORT_RESOLUTION_LABEL, 'left-pad'),
       floorFindingId('typescript', IMPORT_RESOLUTION_LABEL, 'lodash'),
     ]);
+    // both importers of lodash, not only the first
     expect(root.envelope).toEqual({
-      paths: ['src/a.ts', 'src/b.ts', 'package.json', 'package-lock.json'],
+      paths: ['src/a.ts', 'src/b.ts', 'src/z.ts', 'package-lock.json', 'package.json'],
       manifests: true,
     });
-    // finding-level attribution: only left-pad is the change's own
-    const byId = new Map(root.findings.map((f) => [f.id, f.attribution]));
-    expect(byId.get(floorFindingId('typescript', IMPORT_RESOLUTION_LABEL, 'left-pad'))).toBe(
-      'net-new',
-    );
-    expect(byId.get(floorFindingId('typescript', IMPORT_RESOLUTION_LABEL, 'lodash'))).toBe(
-      'pre-existing',
-    );
+    const lodash = root.findings.find((f) => f.id.endsWith('#lodash'))!;
+    expect(lodash.evidence).toMatchObject({
+      type: 'floor',
+      specifier: 'lodash',
+      importingFiles: ['src/a.ts', 'src/z.ts'],
+    });
+    expect(lodash.attribution).toBe('pre-existing');
+    expect(root.findings.find((f) => f.id.endsWith('#left-pad'))!.attribution).toBe('net-new');
     const nested = imports.find((o) => o.id.endsWith('packages/api'))!;
     expect(nested.envelope.paths).toEqual(['packages/api/src/x.ts', 'packages/api/package.json']);
-    // the importing file is carried as structured evidence
-    const zod = nested.findings[0];
-    expect(zod.evidence).toMatchObject({
-      type: 'floor',
-      specifier: 'zod',
-      importingFile: 'packages/api/src/x.ts',
-    });
     expect(root.done.verifier).toBe('floor');
     expect(root.done.absentIds).toEqual(root.findings.map((f) => f.id));
+    expect(root.outputTail).toBe('three unresolved');
     expect(root.provenance).toEqual({
       source: 'entry-floor',
       check: `typescript/${IMPORT_RESOLUTION_LABEL}`,
     });
-    // bare specifiers: the declare-dependency recipe matches
     expect(root.tier).toBe('recipe');
     expect(root.recipe).toBe('declare-dependency');
   });
 
-  it('a floor failure with no finer identity is one order per check, class floor-failure, agent tier, with the failing command', () => {
-    const input: PlannerInput = {
-      ...empty(),
-      entryFloor: floor([BUILD_CHECK], [{ check: BUILD_CHECK, attribution: 'pre-existing' }]),
-    };
-    const plan = planWorkOrders(input);
+  it('a floor failure with no finer identity is one order per check, class floor-failure, agent tier, command carried', () => {
+    const plan = planWorkOrders({ ...empty(), floorFailures: [BUILD_FAILURE] });
     expect(plan.orders).toHaveLength(1);
     const order = plan.orders[0];
     expect(order.class).toBe('floor-failure');
@@ -200,100 +135,133 @@ describe('planWorkOrders: entry floor', () => {
     expect(order.findings[0].evidence).toMatchObject({
       type: 'floor',
       command: 'npx tsc --noEmit',
-      outputTail: 'src/c.ts(3,1): error TS2304',
     });
+    expect(order.outputTail).toBe('src/c.ts(3,1): error TS2304');
     expect(order.envelope.manifests).toBe(false);
-    expect(order.evidence).toEqual(['src/c.ts(3,1): error TS2304']);
+    expect(order.constraints.install).toEqual({ bin: 'npm', args: ['ci'] });
   });
 
-  it('a passing check yields no order', () => {
-    const pass: CorrectnessCheckResult = { ...BUILD_CHECK, status: 'pass' };
-    const input: PlannerInput = { ...empty(), entryFloor: floor([pass], []) };
-    expect(planWorkOrders(input).orders).toEqual([]);
+  it('no install command known: the order carries none (disclosed at render), never a guessed one', () => {
+    const input: PlannerInput = { ...empty(), floorFailures: [BUILD_FAILURE] };
+    delete (input as { install?: unknown }).install;
+    expect(planWorkOrders(input).orders[0].constraints.install).toBeUndefined();
   });
 });
 
 describe('planWorkOrders: advisories', () => {
-  it('groups blocking advisories per package (all its advisories), envelope = manifests only', () => {
-    const input: PlannerInput = {
+  it('ONE order per package unions blocking + deferred advisories (never drops either), envelope = manifests only', () => {
+    const plan = planWorkOrders({
       ...empty(),
       blocking: [
-        blockingPair(depVuln('a1', 'axios', 'GHSA-1', 'high')),
-        blockingPair(depVuln('a2', 'axios', 'GHSA-2', 'medium')),
-        blockingPair(depVuln('b1', 'lodash', 'GHSA-3', 'low')),
+        {
+          kind: 'dep-vuln',
+          advisory: advisory('a1', 'axios', 'GHSA-1', {
+            severity: 'high',
+            fixedVersion: '1.7.0',
+            reachable: true,
+          }),
+        },
+        { kind: 'dep-vuln', advisory: advisory('b1', 'lodash', 'GHSA-3', { severity: 'low' }) },
       ],
-      advisoryDetails: {
-        a1: { fixedVersion: '1.7.0', reachable: true },
-        a2: { fixedVersion: '1.7.0' },
-      },
-    };
-    const plan = planWorkOrders(input);
+      deferred: [
+        {
+          fingerprint: 'a2',
+          expiresAt: '2026-09-10',
+          kind: 'dep-vuln',
+          advisory: advisory('a2', 'axios', 'GHSA-2', { fixedVersion: '1.7.0' }),
+        },
+        {
+          fingerprint: 'a1',
+          expiresAt: '2026-09-01',
+          kind: 'dep-vuln',
+          advisory: advisory('a1', 'axios', 'GHSA-1'),
+        },
+      ],
+    });
+    expect(plan.undispatchable).toEqual([]);
     expect(plan.orders.map((o) => o.id)).toEqual(['dep-advisory:axios', 'dep-advisory:lodash']);
     const axios = plan.orders[0];
-    expect(axios.findings).toHaveLength(2);
+    expect(axios.findings.map((f) => [f.id, f.attribution])).toEqual([
+      ['a1', 'net-new'],
+      ['a2', 'deferred'],
+    ]);
+    expect(axios.provenance).toEqual({
+      source: 'advisories',
+      blocking: 1,
+      deferred: 1,
+      earliestExpiry: '2026-09-10',
+    });
     expect(axios.envelope).toEqual({
-      paths: ['package.json', 'package-lock.json'],
+      paths: ['package-lock.json', 'package.json'],
       manifests: true,
     });
     expect(axios.findings[0].evidence).toMatchObject({
       type: 'dep-vuln',
-      package: 'axios',
-      advisoryId: 'GHSA-1',
       fixedVersion: '1.7.0',
       reachable: true,
       severity: 'high',
     });
     expect(axios.done.verifier).toBe('guardrail');
-    expect(axios.provenance).toEqual({ source: 'guardrail-blocking' });
-    // every advisory has a fixed version: override-pin matches
     expect(axios.tier).toBe('recipe');
     expect(axios.recipe).toBe('override-pin');
-    // no fixed version known: agent
     expect(plan.orders[1].tier).toBe('agent');
-    expect(plan.orders[1].evidence[0]).toContain('no fixed version known here');
   });
 
-  it('deferred advisories join their baseline entry, carry expiresAt, and are attributed deferred', () => {
-    const input: PlannerInput = {
+  it('a deferral joined to nothing is undispatchable with the reason, never dropped', () => {
+    const plan = planWorkOrders({
       ...empty(),
       deferred: [
-        { allow: deferred('d1', '2026-09-10'), entry: depVuln('d1', 'js-yaml', 'GHSA-9', 'high') },
-        { allow: deferred('d2', '2026-09-01'), entry: depVuln('d2', 'js-yaml', 'GHSA-8', 'high') },
+        {
+          fingerprint: 'gone',
+          expiresAt: '2026-09-01',
+          kind: 'unjoined',
+          declaredKind: 'dep-vuln',
+        },
       ],
-    };
-    const plan = planWorkOrders(input);
-    expect(plan.orders).toHaveLength(1);
-    const order = plan.orders[0];
-    expect(order.id).toBe('dep-advisory:js-yaml');
-    expect(order.findings.every((f) => f.attribution === 'deferred')).toBe(true);
-    expect(order.provenance).toEqual({ source: 'deferred-advisory', earliestExpiry: '2026-09-01' });
-    expect(
-      order.findings.map((f) => (f.evidence as { expiresAt?: string }).expiresAt).sort(),
-    ).toEqual(['2026-09-01', '2026-09-10']);
-  });
-
-  it('a deferred entry with no baseline join is undispatchable with the reason, never dropped', () => {
-    const input: PlannerInput = {
-      ...empty(),
-      deferred: [{ allow: deferred('gone', '2026-09-01'), entry: null }],
-    };
-    const plan = planWorkOrders(input);
+    });
     expect(plan.orders).toEqual([]);
     expect(plan.undispatchable).toHaveLength(1);
-    expect(plan.undispatchable[0].reason).toContain('not in the baseline');
-    expect(plan.undispatchable[0].findings[0].id).toBe('gone');
+    expect(plan.undispatchable[0].reason).toContain('matches no finding dxkit can see');
+    expect(plan.undispatchable[0].findings[0]).toEqual({
+      kind: 'dep-vuln',
+      id: 'gone',
+      attribution: 'deferred',
+      evidence: { type: 'none' },
+    });
+  });
+
+  it('a deferred located custom-check is a lint-located order (its class), attributed deferred', () => {
+    const plan = planWorkOrders({
+      ...empty(),
+      deferred: [
+        {
+          fingerprint: 'l1',
+          expiresAt: '2026-09-01',
+          kind: 'custom-check',
+          entry: lint('l1', 'src/a.ts', 'eqeqeq', 3),
+        },
+      ],
+    });
+    expect(plan.undispatchable).toEqual([]);
+    expect(plan.orders.map((o) => [o.id, o.class])).toEqual([
+      ['lint-located:src/a.ts', 'lint-located'],
+    ]);
+    expect(plan.orders[0].findings[0].attribution).toBe('deferred');
   });
 });
 
 describe('planWorkOrders: debt slices', () => {
-  it('groups lint debt by file, then by rule, capped by maxSliceSize with slice provenance', () => {
+  it('groups lint debt by file, then by rule + line, capped by maxSliceSize with slice provenance', () => {
     const debt: RichBaselineEntry[] = [];
     for (let i = 0; i < 7; i++)
       debt.push(lint(`f${i}`, 'src/big.ts', i % 2 === 0 ? 'no-unused-vars' : 'eqeqeq', i + 1));
     debt.push(lint('g1', 'src/small.ts', 'eqeqeq', 4));
-    const plan = planWorkOrders({ ...empty(), debt, policy: { ...POLICY, maxSliceSize: 3 } });
-    const ids = plan.orders.map((o) => o.id);
-    expect(ids).toEqual([
+    const plan = planWorkOrders({
+      ...empty(),
+      debt,
+      policy: { maxSliceSize: 3, budgetFor: uniformBudget(DEFAULT_REMEDIATE_BUDGET) },
+    });
+    expect(plan.orders.map((o) => o.id)).toEqual([
       'lint-located:src/big.ts#1',
       'lint-located:src/big.ts#2',
       'lint-located:src/big.ts#3',
@@ -301,17 +269,11 @@ describe('planWorkOrders: debt slices', () => {
     ]);
     const first = plan.orders[0];
     expect(first.findings).toHaveLength(3);
-    // rule-sorted within the file: the eqeqeq findings come first
     expect(first.findings.every((f) => (f.evidence as { rule?: string }).rule === 'eqeqeq')).toBe(
       true,
     );
     expect(first.envelope).toEqual({ paths: ['src/big.ts'], manifests: false });
-    expect(first.provenance).toEqual({
-      source: 'debt-slice',
-      file: 'src/big.ts',
-      slice: 1,
-      of: 3,
-    });
+    expect(first.provenance).toEqual({ source: 'debt-slice', file: 'src/big.ts', slice: 1, of: 3 });
     expect(first.tier).toBe('recipe');
     expect(first.recipe).toBe('lint-autofix');
     expect(plan.orders[3].provenance).toEqual({
@@ -322,7 +284,7 @@ describe('planWorkOrders: debt slices', () => {
     });
   });
 
-  it('binary custom-check debt and other kinds land in undispatchable with reasons', () => {
+  it('binary custom-check debt and other kinds land in undispatchable with identity-only evidence', () => {
     const binary: RichBaselineEntry = {
       id: 'bin1',
       kind: 'custom-check',
@@ -342,62 +304,104 @@ describe('planWorkOrders: debt slices', () => {
     const reasons = plan.undispatchable.map((u) => u.reason);
     expect(reasons.some((r) => r.includes('binary'))).toBe(true);
     expect(reasons.some((r) => r.includes('secret'))).toBe(true);
+    const s = plan.undispatchable.flatMap((u) => u.findings).find((f) => f.id === 's1')!;
+    expect(s.evidence).toEqual({ type: 'none' });
   });
 });
 
 describe('planWorkOrders: value ordering + budget', () => {
-  it('orders net-new floor > expiring defers (soonest first) > reachable high/critical > debt', () => {
-    const input: PlannerInput = {
+  it('orders net-new floor > expiring defers (soonest first) > reachable high/critical > other blocking > pre-existing floor > debt', () => {
+    const plan = planWorkOrders({
       ...empty(),
-      entryFloor: floor([BUILD_CHECK], [{ check: BUILD_CHECK, attribution: 'net-new' }]),
-      blocking: [blockingPair(depVuln('r1', 'reach', 'GHSA-R', 'critical'))],
-      advisoryDetails: { r1: { reachable: true } },
+      floorFailures: [
+        { ...BUILD_FAILURE, attribution: 'net-new' },
+        { ...BUILD_FAILURE, label: 'tests' },
+      ],
+      blocking: [
+        {
+          kind: 'dep-vuln',
+          advisory: advisory('r1', 'reach', 'GHSA-R', { severity: 'critical', reachable: true }),
+        },
+        { kind: 'dep-vuln', advisory: advisory('o1', 'other', 'GHSA-O', { severity: 'medium' }) },
+      ],
       deferred: [
-        { allow: deferred('d1', '2026-09-10'), entry: depVuln('d1', 'late', 'GHSA-L', 'low') },
-        { allow: deferred('d2', '2026-09-01'), entry: depVuln('d2', 'soon', 'GHSA-S', 'low') },
+        {
+          fingerprint: 'd1',
+          expiresAt: '2026-09-10',
+          kind: 'dep-vuln',
+          advisory: advisory('d1', 'late', 'GHSA-L'),
+        },
+        {
+          fingerprint: 'd2',
+          expiresAt: '2026-09-01',
+          kind: 'dep-vuln',
+          advisory: advisory('d2', 'soon', 'GHSA-S'),
+        },
       ],
       debt: [lint('l1', 'src/a.ts', 'eqeqeq', 1)],
-    };
-    const ids = planWorkOrders(input).orders.map((o) => o.id);
-    expect(ids).toEqual([
+    });
+    expect(plan.orders.map((o) => o.id)).toEqual([
       'floor-failure:typescript:typecheck',
       'dep-advisory:soon',
       'dep-advisory:late',
       'dep-advisory:reach',
+      'dep-advisory:other',
+      'floor-failure:typescript:tests',
       'lint-located:src/a.ts',
     ]);
   });
 
-  it('derives the budget from the finding count, clamped to policy, with the formula recorded', () => {
-    const one = deriveBudget(1, DEFAULT_REMEDIATE_BUDGET);
+  it('derives the budget from the finding count, capped by the task budget, formula recorded with CAPPED numbers', () => {
     const d = BUDGET_DERIVATION;
+    const one = deriveBudget(1, DEFAULT_REMEDIATE_BUDGET);
     expect(one.turns).toBe(Math.max(d.minTurns, d.baseTurns + d.perFindingTurns));
-    expect(one.derivation).toContain(`clamp(${d.baseTurns} + ${d.perFindingTurns} * 1`);
+    expect(one.derivation).toContain(`${d.baseTurns} + ${d.perFindingTurns} * 1`);
     const many = deriveBudget(1000, DEFAULT_REMEDIATE_BUDGET);
     expect(many.turns).toBe(DEFAULT_REMEDIATE_BUDGET.maxTurns);
     expect(many.minutes).toBe(DEFAULT_REMEDIATE_BUDGET.maxMinutes);
     expect(many.usd).toBe(DEFAULT_REMEDIATE_BUDGET.maxUsd);
-    const zero = deriveBudget(0, DEFAULT_REMEDIATE_BUDGET);
-    expect(zero.turns).toBe(d.minTurns);
-    expect(zero.usd).toBeGreaterThan(0);
+    // a cap BELOW the derivation minimum wins, and the derivation says so
+    const tiny = deriveBudget(0, { maxTurns: 4, maxMinutes: 2, maxUsd: 1 });
+    expect(tiny).toMatchObject({ turns: 4, minutes: 2, usd: 1 });
+    expect(tiny.derivation).toContain('= 4;');
+    expect(tiny.derivation).toContain('= 1');
+    expect(deriveBudget(0, DEFAULT_REMEDIATE_BUDGET).usd).toBeGreaterThan(0);
   });
 
-  it('selectOrders filters by class (a task is a selector over orders)', () => {
+  it('each class is capped by ITS selecting task budget (budgetFor is consulted per class)', () => {
+    const asked: string[] = [];
     const plan = planWorkOrders({
       ...empty(),
-      entryFloor: floor([BUILD_CHECK], [{ check: BUILD_CHECK, attribution: 'net-new' }]),
+      floorFailures: [BUILD_FAILURE],
       debt: [lint('l1', 'src/a.ts', 'eqeqeq', 1)],
+      policy: {
+        maxSliceSize: 25,
+        budgetFor: (cls) => {
+          asked.push(cls);
+          return cls === 'lint-located'
+            ? { maxTurns: 3, maxMinutes: 3, maxUsd: 1 }
+            : DEFAULT_REMEDIATE_BUDGET;
+        },
+      },
     });
-    expect(selectOrders(plan, ['lint-located']).map((o) => o.class)).toEqual(['lint-located']);
-    expect(selectOrders(plan, []).length).toBe(0);
+    expect(asked.sort()).toEqual(['floor-failure', 'lint-located']);
+    expect(plan.orders.find((o) => o.class === 'lint-located')!.budget.turns).toBe(3);
+    expect(plan.orders.find((o) => o.class === 'floor-failure')!.budget.turns).toBeGreaterThan(3);
   });
 
-  it('is deterministic for the same input', () => {
+  it('selectOrders filters by class; deterministic for the same input', () => {
     const input: PlannerInput = {
       ...empty(),
+      floorFailures: [BUILD_FAILURE],
       debt: [lint('l2', 'src/b.ts', 'eqeqeq', 1), lint('l1', 'src/a.ts', 'eqeqeq', 1)],
     };
-    expect(planWorkOrders(input)).toEqual(planWorkOrders(input));
+    const plan = planWorkOrders(input);
+    expect(selectOrders(plan, ['lint-located']).map((o) => o.class)).toEqual([
+      'lint-located',
+      'lint-located',
+    ]);
+    expect(selectOrders(plan, []).length).toBe(0);
+    expect(planWorkOrders(input)).toEqual(plan);
   });
 });
 
@@ -408,15 +412,8 @@ describe('recipe registry drives the tier (synthetic injection)', () => {
     findings: [],
     envelope: { paths: ['x'], manifests: false },
     constraints: { forbidden: [] },
-    done: {
-      absentIds: [],
-      verifier: 'guardrail',
-      command: 'x',
-      noNetNewInsideEnvelope: true,
-      identityScheme: 'v3',
-    },
+    done: { absentIds: [], verifier: 'guardrail', command: 'x' },
     budget: { turns: 1, minutes: 1, usd: 1, derivation: 'x' },
-    evidence: [],
     provenance: { source: 'guardrail-blocking' },
   };
 
@@ -429,9 +426,9 @@ describe('recipe registry drives the tier (synthetic injection)', () => {
     const fake = {
       id: 'synthetic-fixer',
       class: 'synthetic-class',
-      summary: 'test',
+      summary: 't',
       implemented: false,
-      matches: (o: WorkOrder) => o.class === 'synthetic-class',
+      matches: () => true,
     };
     const tiered = assignTier(draft, [...RECIPE_REGISTRY, fake]);
     expect(tiered.tier).toBe('recipe');
@@ -439,32 +436,32 @@ describe('recipe registry drives the tier (synthetic injection)', () => {
   });
 
   it('the planner reads the registry it is handed (a fake recipe flips a real order)', () => {
-    const input: PlannerInput = {
-      ...empty(),
-      entryFloor: floor([BUILD_CHECK], [{ check: BUILD_CHECK, attribution: 'net-new' }]),
-    };
+    const input: PlannerInput = { ...empty(), floorFailures: [BUILD_FAILURE] };
     expect(planWorkOrders(input).orders[0].tier).toBe('agent');
     const fake = {
       id: 'floor-fixer',
       class: 'floor-failure',
-      summary: 'test',
+      summary: 't',
       implemented: false,
-      matches: (o: WorkOrder) => o.class === 'floor-failure',
+      matches: () => true,
     };
     const flipped = planWorkOrders(input, { registry: [...RECIPE_REGISTRY, fake] }).orders[0];
     expect(flipped.tier).toBe('recipe');
     expect(flipped.recipe).toBe('floor-fixer');
   });
 
-  it('every declared recipe names a built-in class, is not yet executable, and ids are unique', () => {
+  it('the class table is the spine: every declared recipe is named by exactly its class, and vice versa', () => {
     const ids = RECIPE_REGISTRY.map((r) => r.id);
     expect(new Set(ids).size).toBe(ids.length);
-    expect(ids.sort()).toEqual(
-      ['declare-dependency', 'lint-autofix', 'lockfile-sync', 'override-pin'].sort(),
-    );
-    for (const r of RECIPE_REGISTRY) {
-      expect(Object.keys(WORK_ORDER_CLASSES)).toContain(r.class);
-      expect(r.implemented).toBe(false);
+    const fromTable = Object.entries(WORK_ORDER_CLASSES)
+      .filter(([, d]) => d.recipe !== null)
+      .map(([c, d]) => [d.recipe, c]);
+    expect(RECIPE_REGISTRY.map((r) => [r.id, r.class]).sort()).toEqual(fromTable.sort());
+    for (const r of RECIPE_REGISTRY) expect(r.implemented).toBe(false);
+    // a class with no producer carries a reason (the DEFERRED_KINDS discipline)
+    for (const d of Object.values(WORK_ORDER_CLASSES) as WorkOrderClassDeclaration[]) {
+      if (d.producers.includes('pending')) expect(d.pendingReason).toBeTruthy();
+      else expect(d.producers.length).toBeGreaterThan(0);
     }
   });
 });

--- a/test/remediate/work-orders/planner.test.ts
+++ b/test/remediate/work-orders/planner.test.ts
@@ -1,0 +1,470 @@
+/**
+ * The work-order planner: grouping per (class, natural unit), envelope
+ * derivation per class, budget derivation from the finding set, value
+ * ordering, the undispatchable bucket, and the recipe registry driving the
+ * tier decision (synthetic-injection guarded).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  BUDGET_DERIVATION,
+  assignTier,
+  deriveBudget,
+  planWorkOrders,
+  selectOrders,
+  type PlannerInput,
+} from '../../../src/remediate/work-orders/planner';
+import { RECIPE_REGISTRY, matchRecipe } from '../../../src/remediate/work-orders/recipes-registry';
+import { WORK_ORDER_CLASSES, floorFindingId } from '../../../src/remediate/work-orders/types';
+import type { WorkOrder } from '../../../src/remediate/work-orders/types';
+import { IMPORT_RESOLUTION_LABEL } from '../../../src/analyzers/correctness/run';
+import type {
+  CorrectnessCheckResult,
+  CorrectnessFloorResult,
+} from '../../../src/analyzers/correctness/run';
+import type { AttributedFloorFailure } from '../../../src/analyzers/correctness/attribution';
+import type { ClassifiedPair } from '../../../src/gate/result';
+import type { RichBaselineEntry } from '../../../src/baseline/types';
+import type { AllowlistEntry } from '../../../src/allowlist/file';
+import { DEFAULT_REMEDIATE_BUDGET } from '../../../src/remediate/config';
+
+const POLICY = { maxSliceSize: 25, budget: DEFAULT_REMEDIATE_BUDGET };
+const MANIFESTS = [
+  { dir: '', files: ['package.json', 'package-lock.json'] },
+  { dir: 'packages/api', files: ['package.json'] },
+];
+
+function empty(): PlannerInput {
+  return {
+    entryFloor: null,
+    blocking: [],
+    deferred: [],
+    debt: [],
+    manifests: MANIFESTS,
+    install: { bin: 'npm', args: ['ci'] },
+    policy: POLICY,
+  };
+}
+
+function floor(
+  checks: CorrectnessCheckResult[],
+  attributed: AttributedFloorFailure[],
+): PlannerInput['entryFloor'] {
+  const result: CorrectnessFloorResult = { ran: true, checks, blocks: true };
+  return { result, attributed };
+}
+
+const IMPORT_CHECK: CorrectnessCheckResult = {
+  pack: 'typescript',
+  label: IMPORT_RESOLUTION_LABEL,
+  bin: '',
+  status: 'fail',
+  output: [
+    "'lodash' does not resolve against the installed tree (imported by src/a.ts)",
+    "'left-pad' does not resolve against the installed tree (imported by src/b.ts)",
+    "'zod' does not resolve against the installed tree (imported by packages/api/src/x.ts)",
+    'An import of an uninstalled/undeclared package fails at build or run time.',
+  ].join('\n'),
+  findings: ['lodash', 'left-pad', 'zod'],
+};
+
+const BUILD_CHECK: CorrectnessCheckResult = {
+  pack: 'typescript',
+  label: 'typecheck',
+  bin: 'npx',
+  args: ['tsc', '--noEmit'],
+  status: 'fail',
+  output: 'src/c.ts(3,1): error TS2304',
+};
+
+function depVuln(
+  id: string,
+  pkg: string,
+  advisoryId: string,
+  severity?: 'critical' | 'high' | 'medium' | 'low',
+): Extract<RichBaselineEntry, { kind: 'dep-vuln' }> {
+  return {
+    id,
+    kind: 'dep-vuln',
+    package: pkg,
+    installedVersion: '1.0.0',
+    advisoryId,
+    ...(severity ? { severity } : {}),
+  };
+}
+
+function lint(
+  id: string,
+  file: string,
+  rule: string,
+  line: number,
+): Extract<RichBaselineEntry, { kind: 'custom-check' }> {
+  return { id, kind: 'custom-check', check: 'lint:typescript', blocking: true, file, line, rule };
+}
+
+function blockingPair(entry: RichBaselineEntry): {
+  pair: ClassifiedPair;
+  entry: RichBaselineEntry;
+} {
+  return {
+    entry,
+    pair: {
+      pair: { currentId: entry.id, status: 'added', confidence: 1, reasons: [] },
+      classification: { status: 'added', blocks: true, warns: false, reasons: [] },
+      kind: entry.kind,
+    },
+  };
+}
+
+function deferred(fingerprint: string, expiresAt: string): AllowlistEntry {
+  return {
+    fingerprint,
+    kind: 'dep-vuln',
+    category: 'deferred',
+    reason: 'lane will fix',
+    addedBy: 't',
+    addedAt: '2026-08-01',
+    expiresAt,
+  };
+}
+
+describe('planWorkOrders: entry floor', () => {
+  it('groups unresolved imports by the manifest root their importing files share, with the envelope = importers + manifest + lockfile', () => {
+    const input: PlannerInput = {
+      ...empty(),
+      entryFloor: floor(
+        [IMPORT_CHECK],
+        [
+          {
+            check: IMPORT_CHECK,
+            attribution: 'net-new',
+            precision: 'finding',
+            netNewFindings: ['left-pad'],
+          },
+        ],
+      ),
+    };
+    const plan = planWorkOrders(input);
+    const imports = plan.orders.filter((o) => o.class === 'unresolved-import');
+    expect(imports.map((o) => o.id).sort()).toEqual([
+      'unresolved-import:typescript:.',
+      'unresolved-import:typescript:packages/api',
+    ]);
+    const root = imports.find((o) => o.id.endsWith(':.'))!;
+    expect(root.findings.map((f) => f.id).sort()).toEqual([
+      floorFindingId('typescript', IMPORT_RESOLUTION_LABEL, 'left-pad'),
+      floorFindingId('typescript', IMPORT_RESOLUTION_LABEL, 'lodash'),
+    ]);
+    expect(root.envelope).toEqual({
+      paths: ['src/a.ts', 'src/b.ts', 'package.json', 'package-lock.json'],
+      manifests: true,
+    });
+    // finding-level attribution: only left-pad is the change's own
+    const byId = new Map(root.findings.map((f) => [f.id, f.attribution]));
+    expect(byId.get(floorFindingId('typescript', IMPORT_RESOLUTION_LABEL, 'left-pad'))).toBe(
+      'net-new',
+    );
+    expect(byId.get(floorFindingId('typescript', IMPORT_RESOLUTION_LABEL, 'lodash'))).toBe(
+      'pre-existing',
+    );
+    const nested = imports.find((o) => o.id.endsWith('packages/api'))!;
+    expect(nested.envelope.paths).toEqual(['packages/api/src/x.ts', 'packages/api/package.json']);
+    // the importing file is carried as structured evidence
+    const zod = nested.findings[0];
+    expect(zod.evidence).toMatchObject({
+      type: 'floor',
+      specifier: 'zod',
+      importingFile: 'packages/api/src/x.ts',
+    });
+    expect(root.done.verifier).toBe('floor');
+    expect(root.done.absentIds).toEqual(root.findings.map((f) => f.id));
+    expect(root.provenance).toEqual({
+      source: 'entry-floor',
+      check: `typescript/${IMPORT_RESOLUTION_LABEL}`,
+    });
+    // bare specifiers: the declare-dependency recipe matches
+    expect(root.tier).toBe('recipe');
+    expect(root.recipe).toBe('declare-dependency');
+  });
+
+  it('a floor failure with no finer identity is one order per check, class floor-failure, agent tier, with the failing command', () => {
+    const input: PlannerInput = {
+      ...empty(),
+      entryFloor: floor([BUILD_CHECK], [{ check: BUILD_CHECK, attribution: 'pre-existing' }]),
+    };
+    const plan = planWorkOrders(input);
+    expect(plan.orders).toHaveLength(1);
+    const order = plan.orders[0];
+    expect(order.class).toBe('floor-failure');
+    expect(order.id).toBe('floor-failure:typescript:typecheck');
+    expect(order.tier).toBe('agent');
+    expect(order.findings[0].evidence).toMatchObject({
+      type: 'floor',
+      command: 'npx tsc --noEmit',
+      outputTail: 'src/c.ts(3,1): error TS2304',
+    });
+    expect(order.envelope.manifests).toBe(false);
+    expect(order.evidence).toEqual(['src/c.ts(3,1): error TS2304']);
+  });
+
+  it('a passing check yields no order', () => {
+    const pass: CorrectnessCheckResult = { ...BUILD_CHECK, status: 'pass' };
+    const input: PlannerInput = { ...empty(), entryFloor: floor([pass], []) };
+    expect(planWorkOrders(input).orders).toEqual([]);
+  });
+});
+
+describe('planWorkOrders: advisories', () => {
+  it('groups blocking advisories per package (all its advisories), envelope = manifests only', () => {
+    const input: PlannerInput = {
+      ...empty(),
+      blocking: [
+        blockingPair(depVuln('a1', 'axios', 'GHSA-1', 'high')),
+        blockingPair(depVuln('a2', 'axios', 'GHSA-2', 'medium')),
+        blockingPair(depVuln('b1', 'lodash', 'GHSA-3', 'low')),
+      ],
+      advisoryDetails: {
+        a1: { fixedVersion: '1.7.0', reachable: true },
+        a2: { fixedVersion: '1.7.0' },
+      },
+    };
+    const plan = planWorkOrders(input);
+    expect(plan.orders.map((o) => o.id)).toEqual(['dep-advisory:axios', 'dep-advisory:lodash']);
+    const axios = plan.orders[0];
+    expect(axios.findings).toHaveLength(2);
+    expect(axios.envelope).toEqual({
+      paths: ['package.json', 'package-lock.json'],
+      manifests: true,
+    });
+    expect(axios.findings[0].evidence).toMatchObject({
+      type: 'dep-vuln',
+      package: 'axios',
+      advisoryId: 'GHSA-1',
+      fixedVersion: '1.7.0',
+      reachable: true,
+      severity: 'high',
+    });
+    expect(axios.done.verifier).toBe('guardrail');
+    expect(axios.provenance).toEqual({ source: 'guardrail-blocking' });
+    // every advisory has a fixed version: override-pin matches
+    expect(axios.tier).toBe('recipe');
+    expect(axios.recipe).toBe('override-pin');
+    // no fixed version known: agent
+    expect(plan.orders[1].tier).toBe('agent');
+    expect(plan.orders[1].evidence[0]).toContain('no fixed version known here');
+  });
+
+  it('deferred advisories join their baseline entry, carry expiresAt, and are attributed deferred', () => {
+    const input: PlannerInput = {
+      ...empty(),
+      deferred: [
+        { allow: deferred('d1', '2026-09-10'), entry: depVuln('d1', 'js-yaml', 'GHSA-9', 'high') },
+        { allow: deferred('d2', '2026-09-01'), entry: depVuln('d2', 'js-yaml', 'GHSA-8', 'high') },
+      ],
+    };
+    const plan = planWorkOrders(input);
+    expect(plan.orders).toHaveLength(1);
+    const order = plan.orders[0];
+    expect(order.id).toBe('dep-advisory:js-yaml');
+    expect(order.findings.every((f) => f.attribution === 'deferred')).toBe(true);
+    expect(order.provenance).toEqual({ source: 'deferred-advisory', earliestExpiry: '2026-09-01' });
+    expect(
+      order.findings.map((f) => (f.evidence as { expiresAt?: string }).expiresAt).sort(),
+    ).toEqual(['2026-09-01', '2026-09-10']);
+  });
+
+  it('a deferred entry with no baseline join is undispatchable with the reason, never dropped', () => {
+    const input: PlannerInput = {
+      ...empty(),
+      deferred: [{ allow: deferred('gone', '2026-09-01'), entry: null }],
+    };
+    const plan = planWorkOrders(input);
+    expect(plan.orders).toEqual([]);
+    expect(plan.undispatchable).toHaveLength(1);
+    expect(plan.undispatchable[0].reason).toContain('not in the baseline');
+    expect(plan.undispatchable[0].findings[0].id).toBe('gone');
+  });
+});
+
+describe('planWorkOrders: debt slices', () => {
+  it('groups lint debt by file, then by rule, capped by maxSliceSize with slice provenance', () => {
+    const debt: RichBaselineEntry[] = [];
+    for (let i = 0; i < 7; i++)
+      debt.push(lint(`f${i}`, 'src/big.ts', i % 2 === 0 ? 'no-unused-vars' : 'eqeqeq', i + 1));
+    debt.push(lint('g1', 'src/small.ts', 'eqeqeq', 4));
+    const plan = planWorkOrders({ ...empty(), debt, policy: { ...POLICY, maxSliceSize: 3 } });
+    const ids = plan.orders.map((o) => o.id);
+    expect(ids).toEqual([
+      'lint-located:src/big.ts#1',
+      'lint-located:src/big.ts#2',
+      'lint-located:src/big.ts#3',
+      'lint-located:src/small.ts',
+    ]);
+    const first = plan.orders[0];
+    expect(first.findings).toHaveLength(3);
+    // rule-sorted within the file: the eqeqeq findings come first
+    expect(first.findings.every((f) => (f.evidence as { rule?: string }).rule === 'eqeqeq')).toBe(
+      true,
+    );
+    expect(first.envelope).toEqual({ paths: ['src/big.ts'], manifests: false });
+    expect(first.provenance).toEqual({
+      source: 'debt-slice',
+      file: 'src/big.ts',
+      slice: 1,
+      of: 3,
+    });
+    expect(first.tier).toBe('recipe');
+    expect(first.recipe).toBe('lint-autofix');
+    expect(plan.orders[3].provenance).toEqual({
+      source: 'debt-slice',
+      file: 'src/small.ts',
+      slice: 1,
+      of: 1,
+    });
+  });
+
+  it('binary custom-check debt and other kinds land in undispatchable with reasons', () => {
+    const binary: RichBaselineEntry = {
+      id: 'bin1',
+      kind: 'custom-check',
+      check: 'arch-check',
+      blocking: true,
+    };
+    const secret: RichBaselineEntry = {
+      id: 's1',
+      kind: 'secret',
+      tool: 'gitleaks',
+      rule: 'generic',
+      file: 'x',
+      line: 1,
+    };
+    const plan = planWorkOrders({ ...empty(), debt: [binary, secret] });
+    expect(plan.orders).toEqual([]);
+    const reasons = plan.undispatchable.map((u) => u.reason);
+    expect(reasons.some((r) => r.includes('binary'))).toBe(true);
+    expect(reasons.some((r) => r.includes('secret'))).toBe(true);
+  });
+});
+
+describe('planWorkOrders: value ordering + budget', () => {
+  it('orders net-new floor > expiring defers (soonest first) > reachable high/critical > debt', () => {
+    const input: PlannerInput = {
+      ...empty(),
+      entryFloor: floor([BUILD_CHECK], [{ check: BUILD_CHECK, attribution: 'net-new' }]),
+      blocking: [blockingPair(depVuln('r1', 'reach', 'GHSA-R', 'critical'))],
+      advisoryDetails: { r1: { reachable: true } },
+      deferred: [
+        { allow: deferred('d1', '2026-09-10'), entry: depVuln('d1', 'late', 'GHSA-L', 'low') },
+        { allow: deferred('d2', '2026-09-01'), entry: depVuln('d2', 'soon', 'GHSA-S', 'low') },
+      ],
+      debt: [lint('l1', 'src/a.ts', 'eqeqeq', 1)],
+    };
+    const ids = planWorkOrders(input).orders.map((o) => o.id);
+    expect(ids).toEqual([
+      'floor-failure:typescript:typecheck',
+      'dep-advisory:soon',
+      'dep-advisory:late',
+      'dep-advisory:reach',
+      'lint-located:src/a.ts',
+    ]);
+  });
+
+  it('derives the budget from the finding count, clamped to policy, with the formula recorded', () => {
+    const one = deriveBudget(1, DEFAULT_REMEDIATE_BUDGET);
+    const d = BUDGET_DERIVATION;
+    expect(one.turns).toBe(Math.max(d.minTurns, d.baseTurns + d.perFindingTurns));
+    expect(one.derivation).toContain(`clamp(${d.baseTurns} + ${d.perFindingTurns} * 1`);
+    const many = deriveBudget(1000, DEFAULT_REMEDIATE_BUDGET);
+    expect(many.turns).toBe(DEFAULT_REMEDIATE_BUDGET.maxTurns);
+    expect(many.minutes).toBe(DEFAULT_REMEDIATE_BUDGET.maxMinutes);
+    expect(many.usd).toBe(DEFAULT_REMEDIATE_BUDGET.maxUsd);
+    const zero = deriveBudget(0, DEFAULT_REMEDIATE_BUDGET);
+    expect(zero.turns).toBe(d.minTurns);
+    expect(zero.usd).toBeGreaterThan(0);
+  });
+
+  it('selectOrders filters by class (a task is a selector over orders)', () => {
+    const plan = planWorkOrders({
+      ...empty(),
+      entryFloor: floor([BUILD_CHECK], [{ check: BUILD_CHECK, attribution: 'net-new' }]),
+      debt: [lint('l1', 'src/a.ts', 'eqeqeq', 1)],
+    });
+    expect(selectOrders(plan, ['lint-located']).map((o) => o.class)).toEqual(['lint-located']);
+    expect(selectOrders(plan, []).length).toBe(0);
+  });
+
+  it('is deterministic for the same input', () => {
+    const input: PlannerInput = {
+      ...empty(),
+      debt: [lint('l2', 'src/b.ts', 'eqeqeq', 1), lint('l1', 'src/a.ts', 'eqeqeq', 1)],
+    };
+    expect(planWorkOrders(input)).toEqual(planWorkOrders(input));
+  });
+});
+
+describe('recipe registry drives the tier (synthetic injection)', () => {
+  const draft: Omit<WorkOrder, 'tier' | 'recipe'> = {
+    id: 'synthetic-class:unit',
+    class: 'synthetic-class',
+    findings: [],
+    envelope: { paths: ['x'], manifests: false },
+    constraints: { forbidden: [] },
+    done: {
+      absentIds: [],
+      verifier: 'guardrail',
+      command: 'x',
+      noNetNewInsideEnvelope: true,
+      identityScheme: 'v3',
+    },
+    budget: { turns: 1, minutes: 1, usd: 1, derivation: 'x' },
+    evidence: [],
+    provenance: { source: 'guardrail-blocking' },
+  };
+
+  it('an order of an unregistered class tiers agent under the built-in registry', () => {
+    expect(assignTier(draft).tier).toBe('agent');
+    expect(matchRecipe({ ...draft, tier: 'agent' })).toBeUndefined();
+  });
+
+  it('a fake recipe for a fake class, injected into the registry, tiers the order recipe', () => {
+    const fake = {
+      id: 'synthetic-fixer',
+      class: 'synthetic-class',
+      summary: 'test',
+      implemented: false,
+      matches: (o: WorkOrder) => o.class === 'synthetic-class',
+    };
+    const tiered = assignTier(draft, [...RECIPE_REGISTRY, fake]);
+    expect(tiered.tier).toBe('recipe');
+    expect(tiered.recipe).toBe('synthetic-fixer');
+  });
+
+  it('the planner reads the registry it is handed (a fake recipe flips a real order)', () => {
+    const input: PlannerInput = {
+      ...empty(),
+      entryFloor: floor([BUILD_CHECK], [{ check: BUILD_CHECK, attribution: 'net-new' }]),
+    };
+    expect(planWorkOrders(input).orders[0].tier).toBe('agent');
+    const fake = {
+      id: 'floor-fixer',
+      class: 'floor-failure',
+      summary: 'test',
+      implemented: false,
+      matches: (o: WorkOrder) => o.class === 'floor-failure',
+    };
+    const flipped = planWorkOrders(input, { registry: [...RECIPE_REGISTRY, fake] }).orders[0];
+    expect(flipped.tier).toBe('recipe');
+    expect(flipped.recipe).toBe('floor-fixer');
+  });
+
+  it('every declared recipe names a built-in class, is not yet executable, and ids are unique', () => {
+    const ids = RECIPE_REGISTRY.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.sort()).toEqual(
+      ['declare-dependency', 'lint-autofix', 'lockfile-sync', 'override-pin'].sort(),
+    );
+    for (const r of RECIPE_REGISTRY) {
+      expect(Object.keys(WORK_ORDER_CLASSES)).toContain(r.class);
+      expect(r.implemented).toBe(false);
+    }
+  });
+});

--- a/test/remediate/work-orders/planner.test.ts
+++ b/test/remediate/work-orders/planner.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../src/remediate/work-orders/planner';
 import { floorFindingId } from '../../../src/remediate/work-orders/types';
 import { checkKey } from '../../../src/analyzers/correctness/attribution';
+import { LOCKFILE_SYNC_LABEL } from '../../../src/languages/capabilities/correctness';
 import type { RichBaselineEntry } from '../../../src/baseline/types';
 import { DEFAULT_REMEDIATE_BUDGET } from '../../../src/remediate/config';
 
@@ -160,6 +161,37 @@ describe('planWorkOrders: entry floor', () => {
       [`${checkKey('typescript', 'affected-tests')}#suite/a`, 'pre-existing'],
       [`${checkKey('typescript', 'affected-tests')}#suite/b`, 'net-new'],
     ]);
+  });
+
+  it('a failing lockfile-sync check mints the stale-lockfile class: root manifest envelope, floor done, the lockfile-sync recipe', () => {
+    const lockfile: FloorFailureInput = {
+      pack: 'typescript',
+      label: LOCKFILE_SYNC_LABEL,
+      command: 'npm ci --dry-run --ignore-scripts --no-audit --no-fund',
+      output: 'npm error Missing: left-pad@1.3.0 from lock file',
+      attribution: 'net-new',
+    };
+    const plan = planWorkOrders({ ...empty(), floorFailures: [lockfile] });
+    expect(plan.orders).toHaveLength(1);
+    const order = plan.orders[0];
+    expect(order.id).toBe('stale-lockfile:typescript');
+    expect(order.class).toBe('stale-lockfile');
+    expect(order.findings[0].id).toBe(checkKey('typescript', LOCKFILE_SYNC_LABEL));
+    expect(order.envelope).toEqual({
+      paths: ['package-lock.json', 'package.json'],
+      manifests: true,
+    });
+    expect(order.done.verifier).toBe('floor');
+    expect(order.outputTail).toContain('Missing: left-pad');
+    expect(order.tier).toBe('recipe');
+    expect(order.recipe).toBe('lockfile-sync');
+    // without an install command the recipe cannot run its reinstall: agent
+    const noInstall = planWorkOrders({
+      ...empty(),
+      floorFailures: [lockfile],
+      installFor: () => undefined,
+    });
+    expect(noInstall.orders[0].tier).toBe('agent');
   });
 
   it('no install command known: the order carries none (disclosed at render), never a guessed one', () => {

--- a/test/remediate/work-orders/recipes.test.ts
+++ b/test/remediate/work-orders/recipes.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The recipe registry as the tier decider, synthetic-injection guarded, and
+ * the class table as the spine (recipes and pending producers pinned).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  assignTier,
+  planWorkOrders,
+  type FloorFailureInput,
+  type PlannerInput,
+} from '../../../src/remediate/work-orders/planner';
+import { RECIPE_REGISTRY, matchRecipe } from '../../../src/remediate/work-orders/recipes-registry';
+import {
+  WORK_ORDER_CLASSES,
+  type WorkOrderClassDeclaration,
+} from '../../../src/remediate/work-orders/types';
+import type { WorkOrder } from '../../../src/remediate/work-orders/types';
+import { DEFAULT_REMEDIATE_BUDGET } from '../../../src/remediate/config';
+
+const NPM_CI = { bin: 'npm', args: ['ci'] };
+
+function empty(): PlannerInput {
+  return {
+    floorFailures: [],
+    blocking: [],
+    deferred: [],
+    debt: [],
+    manifests: [{ dir: '', files: ['package-lock.json', 'package.json'] }],
+    installFor: () => NPM_CI,
+    policy: { maxSliceSize: 25, budgetFor: () => DEFAULT_REMEDIATE_BUDGET },
+  };
+}
+
+const BUILD_FAILURE: FloorFailureInput = {
+  pack: 'typescript',
+  label: 'typecheck',
+  command: 'npx tsc --noEmit',
+  attribution: 'pre-existing',
+};
+
+const IMPORT_FAILURE: FloorFailureInput = {
+  pack: 'typescript',
+  label: 'import-resolution',
+  command: '',
+  attribution: 'net-new',
+  precision: 'finding',
+  netNewFindings: ['left-pad'],
+  findings: ['left-pad'],
+  unresolved: [{ specifier: 'left-pad', file: 'src/b.ts' }],
+};
+
+describe('recipe registry drives the tier (synthetic injection)', () => {
+  const draft: Omit<WorkOrder, 'tier' | 'recipe'> = {
+    id: 'synthetic-class:unit',
+    class: 'synthetic-class',
+    findings: [],
+    envelope: { paths: ['x'], manifests: false },
+    constraints: { forbidden: [] },
+    done: { absentIds: [], verifier: 'guardrail', command: 'x' },
+    budget: { turns: 1, minutes: 1, usd: 1, derivation: 'x' },
+    provenance: { source: 'guardrail-blocking' },
+  };
+
+  it('an order of an unregistered class tiers agent under the built-in registry', () => {
+    expect(assignTier(draft).tier).toBe('agent');
+    expect(matchRecipe({ ...draft, tier: 'agent' })).toBeUndefined();
+  });
+
+  it('a fake recipe for a fake class, injected into the registry, tiers the order recipe', () => {
+    const fake = {
+      id: 'synthetic-fixer',
+      class: 'synthetic-class',
+      summary: 't',
+      implemented: false,
+      matches: () => true,
+    };
+    const tiered = assignTier(draft, [...RECIPE_REGISTRY, fake]);
+    expect(tiered.tier).toBe('recipe');
+    expect(tiered.recipe).toBe('synthetic-fixer');
+  });
+
+  it('the planner reads the registry it is handed (a fake recipe flips a real order)', () => {
+    const input: PlannerInput = { ...empty(), floorFailures: [BUILD_FAILURE] };
+    expect(planWorkOrders(input).orders[0].tier).toBe('agent');
+    const fake = {
+      id: 'floor-fixer',
+      class: 'floor-failure',
+      summary: 't',
+      implemented: false,
+      matches: () => true,
+    };
+    const flipped = planWorkOrders(input, { registry: [...RECIPE_REGISTRY, fake] }).orders[0];
+    expect(flipped.tier).toBe('recipe');
+    expect(flipped.recipe).toBe('floor-fixer');
+  });
+
+  it('a recipe needing the install step declines an order without one (a python-shaped repo never tiers an npm recipe)', () => {
+    const noInstall = planWorkOrders({
+      ...empty(),
+      floorFailures: [IMPORT_FAILURE],
+      installFor: () => undefined,
+    });
+    for (const o of noInstall.orders.filter((x) => x.class === 'unresolved-import')) {
+      expect(o.tier).toBe('agent');
+    }
+  });
+
+  it('the class table is the spine: every declared recipe is named by exactly its class, and vice versa', () => {
+    const ids = RECIPE_REGISTRY.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    const fromTable = Object.entries(WORK_ORDER_CLASSES)
+      .filter(([, d]) => d.recipe !== null)
+      .map(([c, d]) => [d.recipe, c]);
+    expect(RECIPE_REGISTRY.map((r) => [r.id, r.class]).sort()).toEqual(fromTable.sort());
+    for (const r of RECIPE_REGISTRY) expect(r.implemented).toBe(false);
+    // a class with no producer carries a reason (the DEFERRED_KINDS discipline)
+    for (const d of Object.values(WORK_ORDER_CLASSES) as WorkOrderClassDeclaration[]) {
+      if (d.producers.includes('pending')) expect(d.pendingReason).toBeTruthy();
+      else expect(d.producers.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/test/remediate/work-orders/render.test.ts
+++ b/test/remediate/work-orders/render.test.ts
@@ -11,6 +11,7 @@ import {
   renderWorkOrderSummary,
 } from '../../../src/remediate/work-orders/render';
 import { SHARED_RULES } from '../../../src/remediate/tasks';
+import { describeEntryLocation } from '../../../src/gate/context';
 import type { WorkOrder } from '../../../src/remediate/work-orders/types';
 
 const ORDER: WorkOrder = {
@@ -62,6 +63,46 @@ const ORDER: WorkOrder = {
 describe('renderWorkOrderPrompt', () => {
   const text = renderWorkOrderPrompt(ORDER);
 
+  it('location text comes from the ONE kind-aware descriptor (describeEntryLocation), remediation tail appended', () => {
+    const lintOrder: WorkOrder = {
+      ...ORDER,
+      findings: [
+        {
+          kind: 'custom-check',
+          id: 'cccc000011112222',
+          attribution: 'pre-existing',
+          evidence: {
+            type: 'custom-check',
+            check: 'lint:typescript',
+            rule: 'eqeqeq',
+            file: 'src/a.ts',
+            line: 4,
+            message: 'use ===',
+          },
+        },
+      ],
+    };
+    const t = renderWorkOrderPrompt(lintOrder);
+    const location = describeEntryLocation({
+      id: 'cccc000011112222',
+      kind: 'custom-check',
+      check: 'lint:typescript',
+      blocking: true,
+      file: 'src/a.ts',
+      line: 4,
+      rule: 'eqeqeq',
+    });
+    expect(t).toContain(`cccc000011112222: ${location}: use ===`);
+    const depLocation = describeEntryLocation({
+      id: 'aaaa000011112222',
+      kind: 'dep-vuln',
+      package: 'axios',
+      installedVersion: '1.6.0',
+      advisoryId: 'GHSA-1',
+    });
+    expect(text).toContain(`aaaa000011112222: ${depLocation}`);
+  });
+
   it('names every finding id and its structured evidence', () => {
     expect(text).toContain('aaaa000011112222');
     expect(text).toContain('bbbb000011112222');
@@ -73,7 +114,7 @@ describe('renderWorkOrderPrompt', () => {
 
   it('carries the attribution split sentence', () => {
     expect(text).toContain('1 of these are net-new');
-    expect(text).toContain('1 are deferred advisories');
+    expect(text).toContain('1 are deferred findings');
     expect(text).toContain('Everything else in the repo is grandfathered');
   });
 
@@ -87,7 +128,7 @@ describe('renderWorkOrderPrompt', () => {
 
   it('discloses a missing install command instead of guessing one', () => {
     const none = renderWorkOrderPrompt({ ...ORDER, constraints: { forbidden: [] } });
-    expect(none).toContain('no install command is known for this repo');
+    expect(none).toContain('no install command is known for this ecosystem');
     expect(none).not.toContain('npm ci');
   });
 

--- a/test/remediate/work-orders/render.test.ts
+++ b/test/remediate/work-orders/render.test.ts
@@ -1,7 +1,8 @@
 /**
  * Work-order rendering: the agent prompt carries the ids, the attribution
- * split, the envelope, the pm install command, and the done command; the
- * summary line carries tier + budget; neither uses an em-dash.
+ * split, the envelope, the install command (or its disclosed absence), the
+ * done command, and the ONE shared ground-rules list; the summary line
+ * carries tier + budget; neither uses an em-dash.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -9,6 +10,7 @@ import {
   renderWorkOrderPrompt,
   renderWorkOrderSummary,
 } from '../../../src/remediate/work-orders/render';
+import { SHARED_RULES } from '../../../src/remediate/tasks';
 import type { WorkOrder } from '../../../src/remediate/work-orders/types';
 
 const ORDER: WorkOrder = {
@@ -50,20 +52,17 @@ const ORDER: WorkOrder = {
     absentIds: ['aaaa000011112222', 'bbbb000011112222'],
     verifier: 'guardrail',
     command: 'npx vyuh-dxkit guardrail check',
-    noNetNewInsideEnvelope: true,
-    identityScheme: 'v3',
   },
-  budget: { turns: 16, minutes: 9, usd: 1, derivation: 'turns = clamp(8 + 4 * 2, 10, 80) = 16' },
+  budget: { turns: 16, minutes: 9, usd: 1, derivation: 'turns = min(80, max(10, 8 + 4 * 2)) = 16' },
   tier: 'recipe',
   recipe: 'override-pin',
-  evidence: ['axios@1.6.0: GHSA-1 (high), fixed in 1.7.0, reachable'],
-  provenance: { source: 'guardrail-blocking' },
+  provenance: { source: 'advisories', blocking: 1, deferred: 1, earliestExpiry: '2026-09-01' },
 };
 
 describe('renderWorkOrderPrompt', () => {
-  const text = renderWorkOrderPrompt(ORDER, { installCommand: 'pnpm install --frozen-lockfile' });
+  const text = renderWorkOrderPrompt(ORDER);
 
-  it('names every finding id and its evidence', () => {
+  it('names every finding id and its structured evidence', () => {
     expect(text).toContain('aaaa000011112222');
     expect(text).toContain('bbbb000011112222');
     expect(text).toContain('GHSA-1');
@@ -78,26 +77,56 @@ describe('renderWorkOrderPrompt', () => {
     expect(text).toContain('Everything else in the repo is grandfathered');
   });
 
-  it('carries the envelope, the injected pm install command, and the constraints', () => {
+  it('carries the envelope, the pack-declared install command, and the constraints', () => {
     expect(text).toContain('- package.json');
     expect(text).toContain('- pnpm-lock.yaml');
     expect(text).toContain('manifests and lockfiles inside the envelope may change');
-    expect(text).toContain('pnpm install --frozen-lockfile');
+    expect(text).toContain('installs with: pnpm install');
     expect(text).toContain('do not: editing anything outside the envelope');
   });
 
-  it("falls back to the order's own install constraint when no repo fact is injected", () => {
-    expect(renderWorkOrderPrompt(ORDER)).toContain('installs with: pnpm install');
+  it('discloses a missing install command instead of guessing one', () => {
+    const none = renderWorkOrderPrompt({ ...ORDER, constraints: { forbidden: [] } });
+    expect(none).toContain('no install command is known for this repo');
+    expect(none).not.toContain('npm ci');
   });
 
-  it('carries the done command and the budget derivation', () => {
+  it('carries the done command, the budget derivation, and the ONE shared ground rules list', () => {
     expect(text).toContain('Check with: npx vyuh-dxkit guardrail check');
     expect(text).toContain('16 turns, 9 minutes, $1');
-    expect(text).toContain('turns = clamp(8 + 4 * 2, 10, 80) = 16');
+    expect(text).toContain('turns = min(80, max(10, 8 + 4 * 2)) = 16');
+    expect(text.endsWith(SHARED_RULES)).toBe(true);
   });
 
-  it('uses no em-dash anywhere', () => {
-    expect(text).not.toContain('—');
+  it('renders the captured output tail once per order and every importer of a floor finding', () => {
+    const floor: WorkOrder = {
+      ...ORDER,
+      id: 'unresolved-import:typescript:.',
+      class: 'unresolved-import',
+      outputTail: 'the tail',
+      findings: [
+        {
+          kind: 'floor-check',
+          id: 'typescript/import-resolution#lodash',
+          attribution: 'net-new',
+          evidence: {
+            type: 'floor',
+            pack: 'typescript',
+            label: 'import-resolution',
+            command: '',
+            specifier: 'lodash',
+            importingFiles: ['src/a.ts', 'src/z.ts'],
+          },
+        },
+      ],
+    };
+    const t = renderWorkOrderPrompt(floor);
+    expect(t).toContain('imported by src/a.ts, src/z.ts');
+    expect(t.split('the tail')).toHaveLength(2);
+  });
+
+  it('uses no em-dash in the order prose (the appended shared rules are the existing task constant)', () => {
+    expect(text.slice(0, text.length - SHARED_RULES.length)).not.toContain('—');
     expect(renderWorkOrderSummary(ORDER)).not.toContain('—');
     expect(attributionSentence(ORDER)).not.toContain('—');
   });

--- a/test/remediate/work-orders/render.test.ts
+++ b/test/remediate/work-orders/render.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Work-order rendering: the agent prompt carries the ids, the attribution
+ * split, the envelope, the pm install command, and the done command; the
+ * summary line carries tier + budget; neither uses an em-dash.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  attributionSentence,
+  renderWorkOrderPrompt,
+  renderWorkOrderSummary,
+} from '../../../src/remediate/work-orders/render';
+import type { WorkOrder } from '../../../src/remediate/work-orders/types';
+
+const ORDER: WorkOrder = {
+  id: 'dep-advisory:axios',
+  class: 'dep-advisory',
+  findings: [
+    {
+      kind: 'dep-vuln',
+      id: 'aaaa000011112222',
+      attribution: 'net-new',
+      evidence: {
+        type: 'dep-vuln',
+        package: 'axios',
+        installedVersion: '1.6.0',
+        advisoryId: 'GHSA-1',
+        fixedVersion: '1.7.0',
+        reachable: true,
+        severity: 'high',
+      },
+    },
+    {
+      kind: 'dep-vuln',
+      id: 'bbbb000011112222',
+      attribution: 'deferred',
+      evidence: {
+        type: 'dep-vuln',
+        package: 'axios',
+        advisoryId: 'GHSA-2',
+        expiresAt: '2026-09-01',
+      },
+    },
+  ],
+  envelope: { paths: ['package.json', 'pnpm-lock.yaml'], manifests: true },
+  constraints: {
+    install: { bin: 'pnpm', args: ['install'] },
+    forbidden: ['editing anything outside the envelope'],
+  },
+  done: {
+    absentIds: ['aaaa000011112222', 'bbbb000011112222'],
+    verifier: 'guardrail',
+    command: 'npx vyuh-dxkit guardrail check',
+    noNetNewInsideEnvelope: true,
+    identityScheme: 'v3',
+  },
+  budget: { turns: 16, minutes: 9, usd: 1, derivation: 'turns = clamp(8 + 4 * 2, 10, 80) = 16' },
+  tier: 'recipe',
+  recipe: 'override-pin',
+  evidence: ['axios@1.6.0: GHSA-1 (high), fixed in 1.7.0, reachable'],
+  provenance: { source: 'guardrail-blocking' },
+};
+
+describe('renderWorkOrderPrompt', () => {
+  const text = renderWorkOrderPrompt(ORDER, { installCommand: 'pnpm install --frozen-lockfile' });
+
+  it('names every finding id and its evidence', () => {
+    expect(text).toContain('aaaa000011112222');
+    expect(text).toContain('bbbb000011112222');
+    expect(text).toContain('GHSA-1');
+    expect(text).toContain('fixed in 1.7.0');
+    expect(text).toContain('reachable from your code');
+    expect(text).toContain('deferred until 2026-09-01');
+  });
+
+  it('carries the attribution split sentence', () => {
+    expect(text).toContain('1 of these are net-new');
+    expect(text).toContain('1 are deferred advisories');
+    expect(text).toContain('Everything else in the repo is grandfathered');
+  });
+
+  it('carries the envelope, the injected pm install command, and the constraints', () => {
+    expect(text).toContain('- package.json');
+    expect(text).toContain('- pnpm-lock.yaml');
+    expect(text).toContain('manifests and lockfiles inside the envelope may change');
+    expect(text).toContain('pnpm install --frozen-lockfile');
+    expect(text).toContain('do not: editing anything outside the envelope');
+  });
+
+  it("falls back to the order's own install constraint when no repo fact is injected", () => {
+    expect(renderWorkOrderPrompt(ORDER)).toContain('installs with: pnpm install');
+  });
+
+  it('carries the done command and the budget derivation', () => {
+    expect(text).toContain('Check with: npx vyuh-dxkit guardrail check');
+    expect(text).toContain('16 turns, 9 minutes, $1');
+    expect(text).toContain('turns = clamp(8 + 4 * 2, 10, 80) = 16');
+  });
+
+  it('uses no em-dash anywhere', () => {
+    expect(text).not.toContain('—');
+    expect(renderWorkOrderSummary(ORDER)).not.toContain('—');
+    expect(attributionSentence(ORDER)).not.toContain('—');
+  });
+});
+
+describe('renderWorkOrderSummary', () => {
+  it('is one line with id, count, attribution, tier + recipe, budget, verifier', () => {
+    const line = renderWorkOrderSummary(ORDER);
+    expect(line.split('\n')).toHaveLength(1);
+    expect(line).toContain('dep-advisory:axios');
+    expect(line).toContain('2 finding(s)');
+    expect(line).toContain('net-new');
+    expect(line).toContain('recipe override-pin (declared, not yet executable)');
+    expect(line).toContain('16 turns / 9 min / $1');
+    expect(line).toContain('done via guardrail');
+  });
+
+  it('says agent for an agent-tier order and debt for a pre-existing-only order', () => {
+    const debt: WorkOrder = {
+      ...ORDER,
+      tier: 'agent',
+      recipe: undefined,
+      findings: ORDER.findings.map((f) => ({ ...f, attribution: 'pre-existing' })),
+    };
+    const line = renderWorkOrderSummary(debt);
+    expect(line).toContain('tier agent');
+    expect(line).toContain('debt');
+  });
+});

--- a/test/remediate/work-orders/shared-seams.test.ts
+++ b/test/remediate/work-orders/shared-seams.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The seams this unit routed through ONE entry point each (Rule 2.30):
+ * the import-resolution check carries structured `{ specifier, file }` pairs;
+ * `provisionArgv` and `provisionCommand` agree; `floorDebtToBaseChecks` is
+ * the one envelope projection; `activeDeferredEntries` is what both `debt`
+ * and the planner read; the typescript pack declares `provision`.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  runCorrectnessFloor,
+  IMPORT_RESOLUTION_LABEL,
+} from '../../../src/analyzers/correctness/run';
+import type { LanguageSupport } from '../../../src/languages/types';
+import { getLanguage } from '../../../src/languages';
+import { provisionArgv, provisionCommand, type PackageManager } from '../../../src/package-manager';
+import { floorDebtToBaseChecks } from '../../../src/baseline/floor-debt';
+import { activeDeferredEntries, type AllowlistFile } from '../../../src/allowlist/file';
+import { buildDebtReport } from '../../../src/debt-cli';
+
+describe('import-resolution check carries structured unresolved pairs', () => {
+  it('every importer reaches the result beside the identity projection', () => {
+    const ts = getLanguage('typescript')!;
+    const pack: LanguageSupport = {
+      ...ts,
+      correctness: {
+        ...ts.correctness,
+        syntaxCheck: () => null,
+        affectedTests: () => null,
+        resolutionCheck: () => ({
+          kind: 'unresolved',
+          unresolved: [
+            { specifier: 'lodash', file: 'src/a.ts' },
+            { specifier: 'lodash', file: 'src/z.ts' },
+          ],
+        }),
+      },
+    };
+    const result = runCorrectnessFloor({
+      cwd: process.cwd(),
+      changedFiles: [],
+      scope: 'full',
+      packs: [pack],
+      exec: () => ({ available: true, code: 0, output: '' }),
+    });
+    const check = result.checks.find((c) => c.label === IMPORT_RESOLUTION_LABEL)!;
+    expect(check.status).toBe('fail');
+    expect(check.findings).toEqual(['lodash']);
+    expect(check.unresolved).toEqual([
+      { specifier: 'lodash', file: 'src/a.ts' },
+      { specifier: 'lodash', file: 'src/z.ts' },
+    ]);
+  });
+});
+
+describe('provisionArgv is the one provision command', () => {
+  for (const pm of ['npm', 'pnpm', 'yarn', 'bun'] as PackageManager[]) {
+    it(`${pm}: the display command is the argv joined`, () => {
+      expect(provisionCommand(pm)).toBe(provisionArgv(pm).join(' '));
+      expect(provisionArgv(pm)[0]).toBe(pm);
+    });
+  }
+
+  it('the typescript pack declares provision from the repo package manager', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-provision-'));
+    try {
+      writeFileSync(join(dir, 'package.json'), '{}');
+      writeFileSync(join(dir, 'pnpm-lock.yaml'), '');
+      expect(getLanguage('typescript')!.provision!(dir)).toEqual({
+        bin: 'pnpm',
+        args: ['install'],
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('floorDebtToBaseChecks', () => {
+  it('projects every status onto the comparator vocabulary', () => {
+    expect(
+      floorDebtToBaseChecks({
+        capturedAtCommit: null,
+        capturedAt: 'x',
+        checks: [
+          { pack: 'p', label: 'a', command: '', status: 'pass' },
+          { pack: 'p', label: 'b', command: '', status: 'fail' },
+          { pack: 'p', label: 'c', command: '', status: 'skipped-environment' },
+        ],
+      }),
+    ).toEqual([
+      { pack: 'p', label: 'a', status: 'pass' },
+      { pack: 'p', label: 'b', status: 'fail' },
+      { pack: 'p', label: 'c', status: 'skipped' },
+    ]);
+  });
+});
+
+describe('activeDeferredEntries is what debt reads too (parity)', () => {
+  const now = new Date('2026-08-25T00:00:00Z');
+  const file: AllowlistFile = {
+    schemaVersion: 'dxkit-allowlist/v1',
+    mode: 'full',
+    entries: [
+      {
+        fingerprint: 'late',
+        kind: 'dep-vuln',
+        category: 'deferred',
+        addedAt: '2026-08-01',
+        expiresAt: '2026-09-20',
+      },
+      {
+        fingerprint: 'soon',
+        kind: 'dep-vuln',
+        category: 'deferred',
+        addedAt: '2026-08-01',
+        expiresAt: '2026-09-01',
+      },
+      {
+        fingerprint: 'expired',
+        kind: 'dep-vuln',
+        category: 'deferred',
+        addedAt: '2026-07-01',
+        expiresAt: '2026-08-01',
+      },
+      { fingerprint: 'fp', kind: 'code', category: 'false-positive', addedAt: '2026-08-01' },
+    ],
+  };
+
+  it('active deferred only, soonest first', () => {
+    expect(activeDeferredEntries(file, now).map((e) => e.fingerprint)).toEqual(['soon', 'late']);
+    expect(activeDeferredEntries(null, now)).toEqual([]);
+  });
+
+  it('the debt report lists exactly the same deferrals in the same order', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-defer-parity-'));
+    try {
+      mkdirSync(join(dir, '.dxkit'), { recursive: true });
+      writeFileSync(join(dir, '.dxkit', 'allowlist.json'), JSON.stringify(file));
+      const report = buildDebtReport(dir, { stored: true, now });
+      expect(report.deferred.map((d) => d.fingerprint)).toEqual(
+        activeDeferredEntries(file, now).map((e) => e.fingerprint),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/remediate/work-orders/shared-seams.test.ts
+++ b/test/remediate/work-orders/shared-seams.test.ts
@@ -63,15 +63,38 @@ describe('provisionArgv is the one provision command', () => {
     });
   }
 
-  it('the typescript pack declares provision from the repo package manager', () => {
+  it('the typescript pack declares provision from the repo lockfile, null without one (npm ci would always fail)', () => {
     const dir = mkdtempSync(join(tmpdir(), 'dxkit-provision-'));
     try {
       writeFileSync(join(dir, 'package.json'), '{}');
+      expect(getLanguage('typescript')!.provision!(dir)).toBeNull();
       writeFileSync(join(dir, 'pnpm-lock.yaml'), '');
       expect(getLanguage('typescript')!.provision!(dir)).toEqual({
         bin: 'pnpm',
         args: ['install'],
       });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('the interpreted packs declare their own ecosystem provision commands (never npm)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-provision-eco-'));
+    try {
+      expect(getLanguage('python')!.provision!(dir)).toBeNull();
+      writeFileSync(join(dir, 'requirements.txt'), '');
+      expect(getLanguage('python')!.provision!(dir)).toEqual({
+        bin: 'pip',
+        args: ['install', '-r', 'requirements.txt'],
+      });
+      writeFileSync(join(dir, 'poetry.lock'), '');
+      expect(getLanguage('python')!.provision!(dir)).toEqual({ bin: 'poetry', args: ['install'] });
+      expect(getLanguage('ruby')!.provision!(dir)).toBeNull();
+      writeFileSync(join(dir, 'Gemfile.lock'), '');
+      expect(getLanguage('ruby')!.provision!(dir)).toEqual({ bin: 'bundle', args: ['install'] });
+      expect(getLanguage('php')!.provision!(dir)).toBeNull();
+      writeFileSync(join(dir, 'composer.lock'), '');
+      expect(getLanguage('php')!.provision!(dir)).toEqual({ bin: 'composer', args: ['install'] });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/remediate/work-orders/tasks-catalog.test.ts
+++ b/test/remediate/work-orders/tasks-catalog.test.ts
@@ -1,10 +1,11 @@
 /**
- * The task catalog as selectors: every bounded task selects at least one
- * registered work-order class; open-ended tasks select nothing and say so.
+ * The task catalog as selectors: `selects` is a READ of the class table, so
+ * every bounded task selects at least one class, the bounded tasks cover
+ * every class with no overlap, and open-ended tasks select nothing.
  */
 import { describe, it, expect } from 'vitest';
 import { REMEDIATE_TASKS, customDispatchTask } from '../../../src/remediate/tasks';
-import { WORK_ORDER_CLASSES } from '../../../src/remediate/work-orders/types';
+import { WORK_ORDER_CLASSES, classesSelectedBy } from '../../../src/remediate/work-orders/types';
 
 describe('remediate tasks select work-order classes', () => {
   for (const task of REMEDIATE_TASKS) {
@@ -14,14 +15,15 @@ describe('remediate tasks select work-order classes', () => {
         expect(task.completion).toBe('open-ended');
       } else {
         expect(task.selects.length).toBeGreaterThan(0);
-        for (const c of task.selects) expect(Object.keys(WORK_ORDER_CLASSES)).toContain(c);
+        expect([...task.selects]).toEqual(classesSelectedBy(task.id));
       }
     });
   }
 
-  it('the three bounded tasks cover every built-in class between them, with no overlap', () => {
-    const bounded = REMEDIATE_TASKS.filter((t) => !t.openEnded);
-    const all = bounded.flatMap((t) => [...t.selects]);
+  it('every class names a real bounded task, and the bounded tasks cover every class with no overlap', () => {
+    const bounded = REMEDIATE_TASKS.filter((t) => !t.openEnded).map((t) => t.id);
+    for (const [, d] of Object.entries(WORK_ORDER_CLASSES)) expect(bounded).toContain(d.task);
+    const all = REMEDIATE_TASKS.flatMap((t) => [...t.selects]);
     expect(new Set(all).size).toBe(all.length);
     expect([...new Set(all)].sort()).toEqual(Object.keys(WORK_ORDER_CLASSES).sort());
   });

--- a/test/remediate/work-orders/tasks-catalog.test.ts
+++ b/test/remediate/work-orders/tasks-catalog.test.ts
@@ -1,0 +1,34 @@
+/**
+ * The task catalog as selectors: every bounded task selects at least one
+ * registered work-order class; open-ended tasks select nothing and say so.
+ */
+import { describe, it, expect } from 'vitest';
+import { REMEDIATE_TASKS, customDispatchTask } from '../../../src/remediate/tasks';
+import { WORK_ORDER_CLASSES } from '../../../src/remediate/work-orders/types';
+
+describe('remediate tasks select work-order classes', () => {
+  for (const task of REMEDIATE_TASKS) {
+    it(`'${task.id}' is a selector (bounded) or declared open-ended`, () => {
+      if (task.openEnded) {
+        expect(task.selects).toEqual([]);
+        expect(task.completion).toBe('open-ended');
+      } else {
+        expect(task.selects.length).toBeGreaterThan(0);
+        for (const c of task.selects) expect(Object.keys(WORK_ORDER_CLASSES)).toContain(c);
+      }
+    });
+  }
+
+  it('the three bounded tasks cover every built-in class between them, with no overlap', () => {
+    const bounded = REMEDIATE_TASKS.filter((t) => !t.openEnded);
+    const all = bounded.flatMap((t) => [...t.selects]);
+    expect(new Set(all).size).toBe(all.length);
+    expect([...new Set(all)].sort()).toEqual(Object.keys(WORK_ORDER_CLASSES).sort());
+  });
+
+  it('the custom dispatch task is open-ended and selects nothing', () => {
+    const custom = customDispatchTask('do a thing');
+    expect(custom.openEnded).toBe(true);
+    expect(custom.selects).toEqual([]);
+  });
+});

--- a/test/remediate/work-orders/tasks-catalog.test.ts
+++ b/test/remediate/work-orders/tasks-catalog.test.ts
@@ -1,7 +1,8 @@
 /**
- * The task catalog as selectors: `selects` is a READ of the class table, so
- * every bounded task selects at least one class, the bounded tasks cover
- * every class with no overlap, and open-ended tasks select nothing.
+ * The task catalog as selectors: selection is DERIVED from the class table
+ * (`classesSelectedBy`), never stored on the task, so every bounded task
+ * selects at least one class, the bounded tasks cover every class with no
+ * overlap, and open-ended tasks (completion shape) select nothing.
  */
 import { describe, it, expect } from 'vitest';
 import { REMEDIATE_TASKS, customDispatchTask } from '../../../src/remediate/tasks';
@@ -9,28 +10,26 @@ import { WORK_ORDER_CLASSES, classesSelectedBy } from '../../../src/remediate/wo
 
 describe('remediate tasks select work-order classes', () => {
   for (const task of REMEDIATE_TASKS) {
-    it(`'${task.id}' is a selector (bounded) or declared open-ended`, () => {
-      if (task.openEnded) {
-        expect(task.selects).toEqual([]);
-        expect(task.completion).toBe('open-ended');
+    it(`'${task.id}' is a selector (bounded) or open-ended by completion shape`, () => {
+      if (task.completion === 'open-ended') {
+        expect(classesSelectedBy(task.id)).toEqual([]);
       } else {
-        expect(task.selects.length).toBeGreaterThan(0);
-        expect([...task.selects]).toEqual(classesSelectedBy(task.id));
+        expect(classesSelectedBy(task.id).length).toBeGreaterThan(0);
       }
     });
   }
 
   it('every class names a real bounded task, and the bounded tasks cover every class with no overlap', () => {
-    const bounded = REMEDIATE_TASKS.filter((t) => !t.openEnded).map((t) => t.id);
+    const bounded = REMEDIATE_TASKS.filter((t) => t.completion === 'bounded').map((t) => t.id);
     for (const [, d] of Object.entries(WORK_ORDER_CLASSES)) expect(bounded).toContain(d.task);
-    const all = REMEDIATE_TASKS.flatMap((t) => [...t.selects]);
+    const all = REMEDIATE_TASKS.flatMap((t) => classesSelectedBy(t.id));
     expect(new Set(all).size).toBe(all.length);
     expect([...new Set(all)].sort()).toEqual(Object.keys(WORK_ORDER_CLASSES).sort());
   });
 
   it('the custom dispatch task is open-ended and selects nothing', () => {
     const custom = customDispatchTask('do a thing');
-    expect(custom.openEnded).toBe(true);
-    expect(custom.selects).toEqual([]);
+    expect(custom.completion).toBe('open-ended');
+    expect(classesSelectedBy(custom.id)).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

The remediate lane certified trees CI could not install. In-lane verification ran on the agent's dirty workspace with whatever `node_modules` the agent last installed, at full scope with an empty changed-set; CI runs a fresh frozen-lockfile install and then the gate. A real run pushed a "verified" draft whose `package.json` was ahead of its lockfile; CI's `npm ci` died with EUSAGE and the PR read "NOT gated". Design doc section D: one verification, shared with CI.

Three pieces, one concept each:

1. **`src/package-manager.ts` owns the frozen install and the lockfile-sync dry-run.** One `INSTALL_BRANCHES` table (pnpm / yarn / bun / npm ci / npm install / no manifest, with the `--legacy-peer-deps` fallback) is rendered two ways: `renderInstallDependenciesShell` for the workflow templates and `frozenInstallFor` for the lane. `lockfileSyncCheck(pm)` gives the non-installing dry-run per PM (npm `ci --dry-run`, pnpm `--frozen-lockfile --lockfile-only`, bun `--frozen-lockfile --dry-run`; yarn is a disclosed skip because neither classic nor berry has a non-installing frozen check). `isPeerConflictOnly` is the one classifier telling ERESOLVE (tolerated, CI retries with the flag) from EUSAGE (a real failure); the dep-bump lane now reads it too instead of its inline regex.

2. **A lockfile-sync floor item (Rule 15).** `CorrectnessProvider.lockfileCheck` is an optional pure builder; the TypeScript pack implements it, the other packs decline by omission. The runner schedules it ONCE: full scope only, which after the existing manifest escalation means "CI, or a diff that touched a manifest". A tolerated failure passes with a `note` every renderer shows; a stale lockfile fails with the remedy. The arch-check's correctness-runner rule now covers `.lockfileCheck(`.

3. **One `verifyTree` (`src/lanes/verify-tree.ts`).** Given a candidate head: a clean worktree via Rule 11's `withRefWorktree`, the repo's frozen install with its fallback, the floor diff-scoped against `baseHead` (`computeChangedFiles`, scope `affected`, the runner escalates on manifests), attribution vs the entry floor through the one comparator, then the guardrail. Every infrastructure failure is a `GateFailure`-shaped step failure (`worktree` / `install` / `changed-files` / `floor` / `attribution` / `guardrail`); an install that ran and failed is its own verdict. The remediate runner calls this instead of running the floor on its cwd; a failed install is the new `install-failed` outcome (nothing lands), a verification that could not run stays in the fail-closed `guardrail-red` arm with the step named. The ledger gains an install line.

The twelve workflow templates that carried a hand-copied install chain now carry `__DXKIT_INSTALL_DEPS__`, substituted unconditionally by the one workflow writer next to the lane-token chain. The deep-SAST refresh template had already drifted (npm-only chain); it now renders the same block as everyone else.

## Rendered-output change (live-fire required before release)

Rendered workflows change in two ways: comment lines that lived inside the install chain are now emitted above it (guardrails, deep-SAST), and `dxkit-deep-sast-refresh.yml` gains the pnpm/yarn/bun branches it was missing. The install commands themselves are byte-identical for every other template (pinned by `test/install-deps-template.test.ts`). Per the standing rule, a live-fire run of the lane templates is required before release; not attempted here.

## Tests

- `test/lanes/verify-tree.test.ts`: install fails → `install-failed`, floor and guardrail never run; fallback disclosed; floor net-new → `floor-red`; pre-existing debt passes; the floor runs in the worktree with the real diff; worktree / package-manager / guardrail infrastructure failures → `error` with the step named; step order.
- `test/package-manager-frozen-install.test.ts`: `frozenInstallFor` per lockfile, the parity pin (every argv the lane runs is a line of the rendered shell), `isPeerConflictOnly` both directions, `lockfileSyncCheck` per PM.
- `test/install-deps-template.test.ts`: no inline chain survives in any template; every template that runs dxkit on a checkout carries the placeholder (content-derived, `dxkit-gate-host.yml` a declared exemption); the writer renders the block end to end and the result parses as YAML.
- `test/correctness-lockfile-sync.test.ts`: on the real TS pack, stale lock fails, ERESOLVE-only passes with the flag disclosed, in-sync passes, source-only affected runs never pay the dry-run, yarn is a disclosed skip, missing PM is fail-open.
- `test/recipe-playbook.test.ts`: the synthetic pack declares `lockfileCheck`; the runner picks it up at full scope and on a manifest diff, not on a source-only run; the tolerated condition flows through.
- `test/languages-contract.test.ts`: `lockfileCheck` shape contract.
- `test/remediate/run.test.ts`: seams for the clean worktree + install; `install-failed`; the verification targets the committed HEAD diff-scoped vs base; an unrunnable verification fails closed with the step named; phase order gains `verify-install`.
- `test/templates-lane-tokens.test.ts`: the YAML-validity render applies the real install substitution.

## Sweep

typecheck, typecheck:test, eslint, prettier, check-architecture, check-docs-coverage, check-slop, build, vitest --coverage, check-coverage: all green (385 files, 5742 tests; coverage 72.8% vs 50% floor)

`guardrail check --mode ref-based --ref origin/main`: PASSED (an interim BLOCKED on two large-file findings was fixed by the size refactor commit, not allowlisted)

## Review focus

- `src/package-manager.ts` `lockfileSyncCheck`: the per-PM dry-run flags and the documented uncertainty (pnpm `--lockfile-only` with `--frozen-lockfile`; yarn deliberately skipped). npm 7+ semantics assumed (Node 18 floor ships npm 9).
- `src/analyzers/correctness/run.ts` `runLockfileCheck`: the tolerated-failure path yields `pass` + `note`, never a silent pass.
- `src/lanes/verify-tree.ts`: fail-open discipline (infrastructure → `error` + step) vs the one real verdict (`install-failed`); the remediate consumer maps `error` into its existing fail-closed arm.
- Template placeholder substitution in `installWorkflow` sits beside the lane-token loop; the comment-hoisting in the guardrails / deep-SAST templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
