### PR TITLE
fix(doctor,docs): tri-state lane token probe (#325) + remediate knob doc drift (4.4.5 doctor-token-tier-and-doc-drift)

### DIFF
--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -16,40 +16,44 @@ stanzas).
 
 <!-- BEGIN GENERATED: knob-index (edit the registry, then: npm run build && npm run docs:policy-guide) -->
 
-| Policy path                         | Guide section                                |
-| ----------------------------------- | -------------------------------------------- |
-| `baseline.anchor`                   | [#baseline-anchor](#baseline-anchor)         |
-| `baseline.mode`                     | [#baseline-mode](#baseline-mode)             |
-| `baseline.refreshCadence`           | [#refresh-cadence](#refresh-cadence)         |
-| `checks`                            | [#custom-checks](#custom-checks)             |
-| `depBump.allowMajor`                | [#dep-bump](#dep-bump)                       |
-| `depBump.enabled`                   | [#dep-bump](#dep-bump)                       |
-| `depBump.schedule`                  | [#dep-bump](#dep-bump)                       |
-| `duplication.mode`                  | [#duplication-mode](#duplication-mode)       |
-| `expiryNotice.enabled`              | [#expiry-notice](#expiry-notice)             |
-| `extends`                           | [#policy-base](#policy-base)                 |
-| `floor.required`                    | [#floor-required](#floor-required)           |
-| `flow.mode`                         | [#flow-mode](#flow-mode)                     |
-| `flow.sources`                      | [#flow-sources](#flow-sources)               |
-| `graph.refresh`                     | [#graph-refresh](#graph-refresh)             |
-| `licenses.prohibited`               | [#prohibited-licenses](#prohibited-licenses) |
-| `lint.blocking`                     | [#lint-gate](#lint-gate)                     |
-| `lint.enabled`                      | [#lint-gate](#lint-gate)                     |
-| `loop.preset`                       | [#loop-preset](#loop-preset)                 |
-| `newAdvisories.blockSeverities`     | [#new-advisories](#new-advisories)           |
-| `newAdvisories.commentCommands`     | [#new-advisories](#new-advisories)           |
-| `pairedChecks`                      | [#paired-change-rules](#paired-change-rules) |
-| `remediate.agent.budget.maxMinutes` | [#remediate-budget](#remediate-budget)       |
-| `remediate.agent.budget.maxTurns`   | [#remediate-budget](#remediate-budget)       |
-| `remediate.agent.budget.maxUsd`     | [#remediate-budget](#remediate-budget)       |
-| `remediate.agent.driver`            | [#remediate-driver](#remediate-driver)       |
-| `remediate.agent.model`             | [#remediate-model](#remediate-model)         |
-| `remediate.enabled`                 | [#remediate](#remediate)                     |
-| `remediate.salvage`                 | [#remediate-salvage](#remediate-salvage)     |
-| `remediate.schedule`                | [#remediate-schedule](#remediate-schedule)   |
-| `remediate.tasks`                   | [#remediate-tasks](#remediate-tasks)         |
-| `reports.onMerge`                   | [#reports-on-merge](#reports-on-merge)       |
-| `schema.mode`                       | [#schema-mode](#schema-mode)                 |
+| Policy path                         | Guide section                                            |
+| ----------------------------------- | -------------------------------------------------------- |
+| `baseline.anchor`                   | [#baseline-anchor](#baseline-anchor)                     |
+| `baseline.mode`                     | [#baseline-mode](#baseline-mode)                         |
+| `baseline.refreshCadence`           | [#refresh-cadence](#refresh-cadence)                     |
+| `checks`                            | [#custom-checks](#custom-checks)                         |
+| `depBump.allowMajor`                | [#dep-bump](#dep-bump)                                   |
+| `depBump.enabled`                   | [#dep-bump](#dep-bump)                                   |
+| `depBump.schedule`                  | [#dep-bump](#dep-bump)                                   |
+| `duplication.mode`                  | [#duplication-mode](#duplication-mode)                   |
+| `expiryNotice.enabled`              | [#expiry-notice](#expiry-notice)                         |
+| `extends`                           | [#policy-base](#policy-base)                             |
+| `floor.required`                    | [#floor-required](#floor-required)                       |
+| `flow.mode`                         | [#flow-mode](#flow-mode)                                 |
+| `flow.sources`                      | [#flow-sources](#flow-sources)                           |
+| `graph.refresh`                     | [#graph-refresh](#graph-refresh)                         |
+| `licenses.prohibited`               | [#prohibited-licenses](#prohibited-licenses)             |
+| `lint.blocking`                     | [#lint-gate](#lint-gate)                                 |
+| `lint.enabled`                      | [#lint-gate](#lint-gate)                                 |
+| `loop.preset`                       | [#loop-preset](#loop-preset)                             |
+| `newAdvisories.blockSeverities`     | [#new-advisories](#new-advisories)                       |
+| `newAdvisories.commentCommands`     | [#new-advisories](#new-advisories)                       |
+| `pairedChecks`                      | [#paired-change-rules](#paired-change-rules)             |
+| `remediate.agent.budget.maxMinutes` | [#remediate-budget](#remediate-budget)                   |
+| `remediate.agent.budget.maxTurns`   | [#remediate-budget](#remediate-budget)                   |
+| `remediate.agent.budget.maxUsd`     | [#remediate-budget](#remediate-budget)                   |
+| `remediate.agent.driver`            | [#remediate-driver](#remediate-driver)                   |
+| `remediate.agent.model`             | [#remediate-model](#remediate-model)                     |
+| `remediate.enabled`                 | [#remediate](#remediate)                                 |
+| `remediate.maxDispatchBudget`       | [#remediate-dispatch-budget](#remediate-dispatch-budget) |
+| `remediate.maxSpendPerRun`          | [#remediate-spend-per-run](#remediate-spend-per-run)     |
+| `remediate.resume`                  | [#remediate-resume](#remediate-resume)                   |
+| `remediate.salvage`                 | [#remediate-salvage](#remediate-salvage)                 |
+| `remediate.schedule`                | [#remediate-schedule](#remediate-schedule)               |
+| `remediate.taskBudgets`             | [#remediate-task-budgets](#remediate-task-budgets)       |
+| `remediate.tasks`                   | [#remediate-tasks](#remediate-tasks)                     |
+| `reports.onMerge`                   | [#reports-on-merge](#reports-on-merge)                   |
+| `schema.mode`                       | [#schema-mode](#schema-mode)                             |
 
 <!-- END GENERATED: knob-index -->
 
@@ -441,13 +445,29 @@ merging boring PRs, not by default.
 
 ## Remediate salvage
 
-**What it does.** The fate of budget-cut partial work: `"discard"` (the
-default — nothing lands; the branch is left for inspection) or
-`"draft-pr"` (the VERIFIED partial work lands as a draft marked
-budget-bounded).
+**What it does.** The fate of budget-cut or guardrail-blocked partial work.
+Three accepted values:
 
-**Default and why.** `discard`. Production experience: partial drafts were
-useful once and noise once — exactly a default-off opt-in.
+- `"auto"` (default): decided PER TASK from its declared completion shape.
+  Open-ended tasks (`write-docs`, `improve-tests`) have no completion test,
+  so every run of theirs ends on a cap; they resolve to `draft-pr` so their
+  verified work is not structurally thrown away. Bounded tasks (`fix-build`,
+  `fix-vulns`, `fix-lint`) can genuinely finish, so they resolve to
+  `discard`.
+- `"discard"`: nothing lands for any task; the branch is left for
+  inspection.
+- `"draft-pr"`: for every task, VERIFIED partial work lands as a draft
+  marked budget-bounded; a guardrail-blocked attempt lands as a red draft
+  titled "do not merge", kept unmergeable by its own guardrail check.
+
+**Default and why.** `auto`. A single default was wrong in one direction
+or the other: `discard` threw away every open-ended run's gate-passing
+work, `draft-pr` turned every bounded run's cut-off into review noise.
+Pin one value only when you want the same fate for every task.
+
+**Interactions.** `vyuh-dxkit remediate plan` prints the effective
+salvage per task. [Resume](#remediate-resume) requires the effective
+per-task salvage to be `draft-pr`.
 
 ## Remediate driver
 
@@ -488,22 +508,114 @@ used.
 
 ## Remediate budget
 
-**What it does.** Hard caps, all enforced by the runner, never the agent's
-self-report.
+**What it does.** The shared caps for every task, read by the runner,
+never from the agent's self-report. Which caps a driver can actually
+ENFORCE mid-run is a per-driver fact (the "Enforces" column of the
+[driver table](#remediate-driver)); a cap the driver cannot enforce is
+disclosed in the plan and the ledger, never silently assumed.
 
 **Per parameter.**
 
-- `maxTurns` — the agent iteration cap (passed to the driver when it
-  supports one). Symptom of too low: repeated `budget-exhausted` outcomes
-  with verified partial work. Symptom of too high: long runs that wander
-  past the task.
-- `maxMinutes` — the wall-clock kill. Work the agent already COMMITTED is
-  salvage territory (see [salvage](#remediate-salvage)); uncommitted work
-  is swept into a loudly-labeled commit for inspection.
-- `maxUsd` — the spend cap, read from the run's spend envelope. A driver
-  that cannot report spend makes this cap unenforceable — the ledger says
-  so explicitly rather than pretending.
+- `maxTurns`: the agent iteration cap, passed to the driver when it
+  supports one (the shipped driver enforces it). Symptom of too low:
+  repeated `budget-exhausted` outcomes with verified partial work. Symptom
+  of too high: long runs that wander past the task.
+- `maxMinutes`: the wall-clock kill, enforced by the runner as the process
+  timeout. Work the agent already COMMITTED is salvage territory (see
+  [salvage](#remediate-salvage)); uncommitted work is swept into a
+  loudly-labeled commit for inspection.
+- `maxUsd`: the spend cap. Enforced only where the driver can stop a run
+  on cost. The shipped driver REPORTS spend after the run and cannot stop
+  mid-run, so there `maxUsd` is advisory: an overrun is disclosed and the
+  attempt marked partial, and real spend is bounded by `maxTurns` and
+  `maxMinutes` (which is why the dispatch authority clamps turns, see
+  [dispatch budget](#remediate-dispatch-budget)). A driver that cannot
+  report spend at all makes the cap unenforceable, and the ledger says so.
 
 **Default and why.** `80 turns / 30 min / $5` — conservative on purpose.
 Widen a cap only for a task that keeps producing verified-but-cut-short
 work; the progression is conservative → confident, never the reverse.
+Per-task headroom belongs in [task budgets](#remediate-task-budgets), not
+in a wider shared cap.
+
+## Remediate task budgets
+
+**What it does.** `remediate.taskBudgets.<task-id>` is a partial
+`{ maxTurns, maxMinutes, maxUsd }` merged over the shared
+[agent budget](#remediate-budget) for that one task. Unset fields inherit;
+a non-positive value is ignored, not zeroed. Only registered task ids take
+an override; the `custom` dispatch task always runs on the shared budget.
+
+**Default and why.** Empty: every task runs on the shared caps. Use it to
+give a diagnosis-heavy task (`fix-build`) headroom without widening a
+mechanical one (`fix-lint`).
+
+**Example.**
+
+```jsonc
+"remediate": {
+  "agent": { "budget": { "maxTurns": 60, "maxMinutes": 20, "maxUsd": 3 } },
+  "taskBudgets": { "fix-build": { "maxTurns": 120, "maxUsd": 8 } }
+}
+```
+
+**Interactions.** The per-task effective budget is what
+[spend per run](#remediate-spend-per-run) sums and what
+`vyuh-dxkit remediate plan` prints.
+
+## Remediate spend per run
+
+**What it does.** `remediate.maxSpendPerRun` is a run-level USD ceiling
+over the per-task matrix: each enabled task is its own job with its own
+cap, so one scheduled firing may spend the SUM of the effective per-task
+`maxUsd` values. Tasks are admitted in declaration order while their caps
+still fit under the ceiling; the rest are deferred to the next firing and
+named in the run output, never silently dropped.
+
+**Default and why.** `0` (no ceiling). The per-task caps already bound each
+job; set a ceiling when the sum across tasks is what your budget owner
+cares about. Because the sum uses the caps (not actual spend), a ceiling
+below the first task's cap defers everything.
+
+**Interactions.** Sums the effective per-task budget after
+[task budgets](#remediate-task-budgets). The ceiling reads the `maxUsd`
+CAPS, so it holds even where the driver cannot enforce spend mid-run.
+
+## Remediate dispatch budget
+
+**What it does.** `remediate.maxDispatchBudget` is the spend authority for
+one-off `workflow_dispatch` campaigns: the most a dispatch override may
+raise `maxUsd` to. The same authority clamps a `max_turns` override
+proportionally against the policy budget, because turns are what bound
+real spend when the driver only reports cost after the run (see
+[budget](#remediate-budget)); an unclamped turn override would be a back
+door around the ceiling.
+
+**Default and why.** `0` (undeclared): a dispatch can LOWER budgets but
+never raise them beyond the committed policy caps. Spend authority grows
+only in a reviewed policy change, never in a workflow form field.
+
+**Interactions.** Clamping is disclosed in the run output and the PR body
+along with the dispatcher and the verbatim prompt.
+
+## Remediate resume
+
+**What it does.** With `remediate.resume: true` the next run of a task
+CONTINUES from its prior salvage branch (a draft PR left by a
+budget-bounded or guardrail-blocked attempt) instead of starting over. A
+resumed attempt after a guardrail block gets the prior blocking findings
+in its prompt. Attempts are capped at 2 per branch (the counter travels
+with the branch, so a no-op resume still consumes one); at the cap the
+task falls back to a fresh run. The entry floor still snapshots the
+pristine default tree first, so a broken partial reads as net-new and can
+never grandfather its own breakage.
+
+**Default and why.** `false`. Resume only helps when the prior attempt
+left verified, reviewable progress; on a run that sprawled, it re-anchors
+on the sprawl. Enable it per repo once a task is producing partial drafts
+worth continuing.
+
+**Interactions.** Requires the effective per-task
+[salvage](#remediate-salvage) to be `draft-pr` (the default for
+open-ended tasks under `auto`); a task whose salvage is `discard` has no
+branch to resume and starts fresh.

--- a/src-templates/.claude/skills/dxkit-remediate/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-remediate/SKILL.md
@@ -68,9 +68,13 @@ default branch only, with dxkit-authored prompts only.
   run. Nothing lands (the agent lane fails CLOSED on verification: an
   agent-authored diff is never pushed unverified); the change stays local
   for inspection and the ledger says which case it was.
-- `budget-exhausted` — a cap hit (wall-clock, turns, or spend). Under the
-  default `salvage: "discard"` nothing lands; with `"draft-pr"` the
-  verified partial work lands as a DRAFT marked budget-bounded.
+- `budget-exhausted`: a cap hit (wall-clock, turns, or spend). What
+  lands follows the effective salvage for the task: `salvage` defaults to
+  `auto`, which resolves open-ended tasks (`write-docs`, `improve-tests`)
+  to `draft-pr` (verified partial work lands as a DRAFT marked
+  budget-bounded) and bounded tasks (`fix-build`, `fix-vulns`, `fix-lint`)
+  to `discard` (nothing lands; the branch stays for inspection). Pin
+  `"discard"` or `"draft-pr"` in policy to force one fate for every task.
 - `agent-never-ran` — infrastructure (auth, missing CLI); the reason is in
   the note. Fix the secret/install, re-dispatch.
 - `sweep-failed` — the agent committed work, but the leftovers it left
@@ -81,7 +85,14 @@ default branch only, with dxkit-authored prompts only.
 
 ## Tuning the budget
 
-`remediate.agent.budget`: `maxTurns` caps agent iterations, `maxMinutes` is
-the wall-clock kill (salvage applies), `maxUsd` is enforced from the spend
-envelope after the run. Start conservative (the defaults), widen only for a
-task that keeps hitting `budget-exhausted` while producing verified work.
+`remediate.agent.budget`: `maxTurns` caps agent iterations (enforced by the
+shipped driver), `maxMinutes` is the wall-clock kill (enforced by the
+runner; salvage applies), `maxUsd` is the spend cap. The shipped driver only
+REPORTS spend after the run and cannot stop mid-run on cost, so there
+`maxUsd` is advisory: an overrun is disclosed and the attempt marked
+partial, and real spend is bounded by turns and wall-clock. `remediate plan`
+lists which caps the configured driver cannot enforce. Start conservative
+(the defaults), widen only for a task that keeps hitting `budget-exhausted`
+while producing verified work; give one task headroom with
+`remediate.taskBudgets.<id>` rather than widening the shared cap, and bound
+a whole firing with `remediate.maxSpendPerRun`.

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -245,13 +245,7 @@ __DXKIT_CI_RUNTIME_SETUP__
       # at agent launch, not at job start; the CLI additionally clamps the
       # agent budget on this tier so agent + verify + landing fit inside
       # the fresh token (disclosed in the ledger, never silent).
-      - name: Re-mint the lane token before the task (App tier)
-        id: dxkit-app-token-task
-        if: ${{ vars.DXKIT_APP_ID != '' }}
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.DXKIT_APP_ID }}
-          private-key: ${{ secrets.DXKIT_APP_PRIVATE_KEY }}
+__DXKIT_LANE_TOKEN_TASK_STEPS__
 
       # The ONE landing credential, every tier. The checkout persisted
       # nothing (persist-credentials: false above), so this step is the

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -258,9 +258,38 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
     anchor: 'remediate-budget',
   },
   {
+    // Honest about enforcement: the shipped driver REPORTS spend after the
+    // run (budgetSupport.cost = 'reported'), so this cap is advisory there;
+    // turns + wall clock are what bound real spend. See the guide.
     path: 'remediate.agent.budget.maxUsd',
-    summary: 'spend cap, enforced by the runner from the spend envelope',
+    summary:
+      'spend cap; advisory where the driver only reports spend post-run (the shipped ' +
+      'driver), enforced where it can stop mid-run',
     anchor: 'remediate-budget',
+  },
+  {
+    path: 'remediate.taskBudgets',
+    summary: 'per-task {maxTurns, maxMinutes, maxUsd} overrides merged over agent.budget',
+    anchor: 'remediate-task-budgets',
+  },
+  {
+    path: 'remediate.maxSpendPerRun',
+    summary: 'run-level USD ceiling over the per-task caps; tasks beyond it defer (0 = none)',
+    anchor: 'remediate-spend-per-run',
+  },
+  {
+    path: 'remediate.maxDispatchBudget',
+    summary:
+      'the most a workflow_dispatch override may raise maxUsd to; clamps max_turns ' +
+      'proportionally (0 = dispatch can only lower)',
+    anchor: 'remediate-dispatch-budget',
+  },
+  {
+    path: 'remediate.resume',
+    summary:
+      'opt-in: continue a prior draft-PR salvage branch instead of starting over ' +
+      '(needs an effective draft-pr salvage; capped attempts)',
+    anchor: 'remediate-resume',
   },
 ];
 
@@ -271,213 +300,7 @@ export function paramMetaFor(path: string): PolicyParamMeta | undefined {
   return paramByPath.get(path);
 }
 
-export const POLICY_STANZAS: readonly PolicyStanzaMeta[] = [
-  {
-    key: 'extends',
-    coversKnobs: ['extends'],
-    title: 'Policy base',
-    blurb: [
-      'The posture this file REFINES. Without it, a minimal file silently',
-      'inherits every armed rule of the fully armed compiled default.',
-    ],
-    anchor: 'policy-base',
-    example: () => 'security-only',
-  },
-  {
-    key: 'baseline',
-    coversKnobs: ['baseline.mode', 'baseline.refreshCadence'],
-    title: 'Baseline mode',
-    blurb: [
-      'Pin how the guardrail finds its "before" side. Usually set by init/',
-      'configure from repo visibility; tune refreshCadence via policy-guide#refresh-cadence.',
-    ],
-    anchor: 'baseline-mode',
-    example: () => ({ mode: 'committed-full' }),
-  },
-  {
-    key: 'flow',
-    coversKnobs: ['flow.mode', 'flow.sources'],
-    title: 'UI-to-API integration gate',
-    blurb: [
-      'Blocks a change that breaks a consumed route (catch-all-aware).',
-      'Extension call sources join via flow.sources → policy-guide#flow-sources.',
-    ],
-    anchor: 'flow-mode',
-    example: () => ({ mode: 'warn' }),
-  },
-  {
-    key: 'schema',
-    coversKnobs: ['schema.mode'],
-    title: 'Data-model drift gate',
-    blurb: ['Blocks a model change that breaks the declared wire contract.'],
-    anchor: 'schema-mode',
-    example: () => ({ mode: 'warn' }),
-  },
-  {
-    key: 'duplication',
-    coversKnobs: ['duplication.mode'],
-    title: 'Copy-paste seam gate',
-    blurb: ['Flags net-new duplicated blocks across the change.'],
-    anchor: 'duplication-mode',
-    example: () => ({ mode: 'warn' }),
-  },
-  {
-    key: 'lint',
-    coversKnobs: ['lint'],
-    title: 'Lint gate',
-    blurb: [
-      "Runs the pack's own linter as a gate: net-new errors surface, the",
-      'pre-existing backlog stays grandfathered.',
-    ],
-    anchor: 'lint-gate',
-    example: () => ({ enabled: true, blocking: false }),
-    appliesWhen: (ctx) => ctx.lintCapable,
-  },
-  {
-    key: 'checks',
-    coversKnobs: ['checks'],
-    title: 'Custom checks',
-    blurb: [
-      'Your own invariants as gate citizens. Commands run from THIS committed',
-      'file only; review edits here like CI config.',
-    ],
-    anchor: 'custom-checks',
-    example: () => [
-      {
-        name: 'architecture',
-        command: 'bash scripts/check-architecture.sh',
-        parse: 'exit',
-      },
-    ],
-  },
-  {
-    key: 'pairedChecks',
-    coversKnobs: ['pairedChecks'],
-    title: 'Paired-change rules',
-    blurb: [
-      'Blocks a change to X that ships without its Y (deletions count).',
-      'Declarative; nothing is spawned, so it gates on every surface.',
-    ],
-    anchor: 'paired-change-rules',
-    example: () => [
-      {
-        name: 'model-needs-migration',
-        if: ['src/models/**'],
-        then: ['migrations/**'],
-        message: 'a data-model change ships with its migration',
-      },
-    ],
-  },
-  {
-    key: 'licenses',
-    coversKnobs: ['licenses.prohibited'],
-    title: 'Prohibited licenses',
-    blurb: [
-      'Blocks a net-new dependency whose license matches a prefix here.',
-      'Which licenses your business prohibits is a legal posture; yours.',
-    ],
-    anchor: 'prohibited-licenses',
-    example: () => ({ prohibited: ['GPL-', 'AGPL-'] }),
-  },
-  {
-    key: 'newAdvisories',
-    coversKnobs: ['newAdvisories.blockSeverities', 'newAdvisories.commentCommands'],
-    title: 'Newly published advisories',
-    blurb: ['Posture for advisories published AFTER your baseline was captured.'],
-    anchor: 'new-advisories',
-    example: () => ({ blockSeverities: ['critical', 'high'], commentCommands: true }),
-    followUp: ['commentCommands installs a managed workflow: run `vyuh-dxkit update` after.'],
-  },
-  {
-    key: 'depBump',
-    coversKnobs: ['depBump.enabled'],
-    title: 'Scheduled dependency bumps',
-    blurb: [
-      'Deterministic, floor-verified bump PRs for version-solvable advisories.',
-      'No LLM, no key; the agentic remediate lane handles what bumps cannot.',
-    ],
-    anchor: 'dep-bump',
-    example: () => ({ enabled: true }),
-    followUp: ['Installs a managed workflow: run `vyuh-dxkit update` after enabling.'],
-  },
-  {
-    key: 'expiryNotice',
-    coversKnobs: ['expiryNotice.enabled'],
-    title: 'Expiring-suppression notice',
-    blurb: [
-      'A deferral is a promise with a date on it. The guardrail check already',
-      'warns every PR while the window is open — this covers the quiet week:',
-      'the scheduled refresh maintains ONE issue naming what lapses, who',
-      'accepted it, and when, and closes it once nothing is lapsing.',
-      'Never blocks; the expiry itself stays the forcing function.',
-    ],
-    anchor: 'expiry-notice',
-    example: () => ({ enabled: true }),
-    followUp: [
-      'Grants the refresh workflow `issues: write`: run `vyuh-dxkit update` after enabling.',
-    ],
-  },
-  {
-    key: 'reports',
-    coversKnobs: ['reports.onMerge'],
-    title: 'Report snapshots on merge',
-    blurb: ['Publishes score history to the dxkit-reports ref; feeds `vyuh-dxkit metrics`.'],
-    anchor: 'reports-on-merge',
-    example: () => ({ onMerge: true }),
-    followUp: ['Installs a managed workflow: run `vyuh-dxkit update` after enabling.'],
-  },
-  {
-    key: 'loop',
-    coversKnobs: ['loop.preset'],
-    title: 'Autonomous-loop Stop-gate posture',
-    blurb: ['What blocks an unattended coding loop from declaring done.'],
-    anchor: 'loop-preset',
-    example: () => ({ preset: 'security-only' }),
-  },
-  {
-    key: 'remediate',
-    coversKnobs: ['remediate.enabled'],
-    title: 'Agentic remediation (scheduled agent inside the verified frame)',
-    blurb: [
-      'An agent works the debt the deterministic lanes cannot close; every run',
-      "is floor-attributed + guardrail-verified before a PR opens (the agent's",
-      'word is never trusted). Credentials come from repo secrets, never here.',
-    ],
-    anchor: 'remediate',
-    example: () => ({
-      enabled: true,
-      tasks: ['fix-vulns'],
-      schedule: 'weekly',
-      agent: {
-        driver: 'claude-code',
-        model: 'auto',
-        budget: { maxTurns: 80, maxMinutes: 30, maxUsd: 5 },
-      },
-    }),
-    followUp: [
-      'Installs a managed workflow: run `vyuh-dxkit update` after enabling, and set',
-      'the ANTHROPIC_API_KEY repo secret (a scoped key with a spend limit).',
-    ],
-  },
-];
-
-export const SCAFFOLD_EXEMPT_KNOBS: readonly ScaffoldExemptKnob[] = [
-  {
-    path: 'baseline.anchor',
-    reason:
-      'auto-derived from effective branch protection at publish time; a hand-set value is ' +
-      'the exception; documented in the guide (baseline-anchor), not taught by the scaffold.',
-  },
-  {
-    path: 'graph.refresh',
-    reason:
-      'a CI-performance transport set by init/update when applicable, not a posture a human ' +
-      'tunes; a commented stanza would invite cargo-cult enabling.',
-  },
-  {
-    path: 'deepSast',
-    reason:
-      'requires an external engine + token that dxkit never selects for the user; the ingest ' +
-      'command + dxkit-ingest skill own setup; a bare stanza without a token would not work.',
-  },
-];
+// The stanza + scaffold-exemption tables live in policy-stanzas.ts (split at
+// the large-file bar); re-exported here so this module stays the ONE import
+// path for policy metadata.
+export { POLICY_STANZAS, SCAFFOLD_EXEMPT_KNOBS } from './policy-stanzas';

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -39,45 +39,6 @@ export interface PolicyParamMeta {
   readonly enumValues?: readonly string[];
 }
 
-/** Repo facts the scaffold tailors on. Plain data (no registry imports) so
- *  the metadata module stays a leaf; the caller builds it from the language
- *  registry. */
-export interface ScaffoldCtx {
-  readonly packIds: readonly string[];
-  /** Does any active pack declare a `lintGate`? */
-  readonly lintCapable: boolean;
-}
-
-/** One commented-out opt-in stanza in the generated scaffold. */
-export interface PolicyStanzaMeta {
-  /** Top-level policy key the stanza teaches (`pairedChecks`, `depBump`, …).
-   *  A key already active in the rendered policy suppresses its stanza. */
-  readonly key: string;
-  /** `POSTURE_KNOBS` paths this stanza covers; the scaffold-coverage test
-   *  resolves every knob through these. */
-  readonly coversKnobs: readonly string[];
-  /** Section title rendered in the stanza's header comment. */
-  readonly title: string;
-  /** Teaching lines rendered as comments above the stanza. */
-  readonly blurb: readonly string[];
-  /** Guide anchor for the whole stanza. */
-  readonly anchor: string;
-  /** The syntactically-complete example value; uncommenting it IS activation
-   *  (E3). A function of ctx so examples can tailor per stack. */
-  readonly example: (ctx: ScaffoldCtx) => unknown;
-  /** Extra comment lines after the stanza (e.g. "then run: vyuh-dxkit update"). */
-  readonly followUp?: readonly string[];
-  /** Omit the stanza entirely when false (per-stack tailoring). */
-  readonly appliesWhen?: (ctx: ScaffoldCtx) => boolean;
-}
-
-/** A `POSTURE_KNOBS` path deliberately absent from the scaffold; a declared
- *  exemption with a reason, never a silent omission. */
-export interface ScaffoldExemptKnob {
-  readonly path: string;
-  readonly reason: string;
-}
-
 export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
   {
     path: 'baseline.mode',
@@ -300,7 +261,9 @@ export function paramMetaFor(path: string): PolicyParamMeta | undefined {
   return paramByPath.get(path);
 }
 
-// The stanza + scaffold-exemption tables live in policy-stanzas.ts (split at
-// the large-file bar); re-exported here so this module stays the ONE import
-// path for policy metadata.
+// The stanza + scaffold-exemption tables and their types live in
+// policy-stanzas.ts (split at the large-file bar; the types live in the LEAF
+// so no import edge points back here); re-exported so this module stays the
+// ONE import path for policy metadata.
 export { POLICY_STANZAS, SCAFFOLD_EXEMPT_KNOBS } from './policy-stanzas';
+export type { ScaffoldCtx, PolicyStanzaMeta, ScaffoldExemptKnob } from './policy-stanzas';

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -334,17 +334,17 @@ export function buildPolicySchema(version: string): Schema {
                   },
                   maxUsd: { type: 'number', description: desc('remediate.agent.budget.maxUsd') },
                 },
-                "Hard caps, all enforced by the runner (never the agent's self-report).",
+                'Caps read by the runner, never from the agent self-report. Turns and ' +
+                  'wall-clock are enforced; maxUsd is enforced only where the driver can ' +
+                  'stop mid-run on cost (the shipped driver reports spend after the run, ' +
+                  'so there it is advisory and disclosed).',
               ),
             },
             'Which agent runs, at which capability tier, under which caps.',
           ),
           taskBudgets: {
             type: 'object',
-            description:
-              'Per-task budget overrides merged over agent.budget (e.g. give fix-build ' +
-              'more headroom than fix-lint). Keys are task ids; values are partial ' +
-              '{maxTurns, maxMinutes, maxUsd}.',
+            description: desc('remediate.taskBudgets'),
             additionalProperties: {
               type: 'object',
               properties: {
@@ -354,28 +354,9 @@ export function buildPolicySchema(version: string): Schema {
               },
             },
           },
-          maxSpendPerRun: {
-            type: 'number',
-            description:
-              'Run-level USD ceiling across the per-task matrix (0/absent = none). Tasks ' +
-              'beyond it are deferred to the next firing, in order, and disclosed.',
-          },
-          maxDispatchBudget: {
-            type: 'number',
-            description:
-              'The dispatch spend authority: the most a workflow_dispatch campaign may raise ' +
-              'maxUsd to, and the same authority clamps max_turns proportionally (turns govern ' +
-              'real spend when the driver cannot enforce cost mid-run). 0/absent = dispatch ' +
-              'can lower budgets but never raise them beyond the policy caps.',
-          },
-          resume: {
-            type: 'boolean',
-            description:
-              'Opt-in: continue a prior budget-bounded or guardrail-blocked attempt from its ' +
-              'draft-PR salvage branch instead of starting over (requires the effective ' +
-              'per-task salvage to be draft-pr; capped resumes with a durable attempt ' +
-              'counter; entry floor stays anchored to the pristine base).',
-          },
+          maxSpendPerRun: { type: 'number', description: desc('remediate.maxSpendPerRun') },
+          maxDispatchBudget: { type: 'number', description: desc('remediate.maxDispatchBudget') },
+          resume: boolProp('remediate.resume'),
         },
         'Agentic remediation: a scheduled agent inside the verified frame.',
       ),

--- a/src/baseline/policy-stanzas.ts
+++ b/src/baseline/policy-stanzas.ts
@@ -1,0 +1,220 @@
+/**
+ * The scaffold's commented opt-in STANZAS and the declared scaffold
+ * exemptions: the second half of the one policy metadata table
+ * (`policy-metadata.ts`), split at the large-file bar and re-exported
+ * there so `from './policy-metadata'` stays the one import path. The
+ * per-parameter rows (`POLICY_PARAMS`) live in the sibling; the types
+ * these tables conform to are declared there too.
+ */
+import type { PolicyStanzaMeta, ScaffoldExemptKnob } from './policy-metadata';
+
+export const POLICY_STANZAS: readonly PolicyStanzaMeta[] = [
+  {
+    key: 'extends',
+    coversKnobs: ['extends'],
+    title: 'Policy base',
+    blurb: [
+      'The posture this file REFINES. Without it, a minimal file silently',
+      'inherits every armed rule of the fully armed compiled default.',
+    ],
+    anchor: 'policy-base',
+    example: () => 'security-only',
+  },
+  {
+    key: 'baseline',
+    coversKnobs: ['baseline.mode', 'baseline.refreshCadence'],
+    title: 'Baseline mode',
+    blurb: [
+      'Pin how the guardrail finds its "before" side. Usually set by init/',
+      'configure from repo visibility; tune refreshCadence via policy-guide#refresh-cadence.',
+    ],
+    anchor: 'baseline-mode',
+    example: () => ({ mode: 'committed-full' }),
+  },
+  {
+    key: 'flow',
+    coversKnobs: ['flow.mode', 'flow.sources'],
+    title: 'UI-to-API integration gate',
+    blurb: [
+      'Blocks a change that breaks a consumed route (catch-all-aware).',
+      'Extension call sources join via flow.sources → policy-guide#flow-sources.',
+    ],
+    anchor: 'flow-mode',
+    example: () => ({ mode: 'warn' }),
+  },
+  {
+    key: 'schema',
+    coversKnobs: ['schema.mode'],
+    title: 'Data-model drift gate',
+    blurb: ['Blocks a model change that breaks the declared wire contract.'],
+    anchor: 'schema-mode',
+    example: () => ({ mode: 'warn' }),
+  },
+  {
+    key: 'duplication',
+    coversKnobs: ['duplication.mode'],
+    title: 'Copy-paste seam gate',
+    blurb: ['Flags net-new duplicated blocks across the change.'],
+    anchor: 'duplication-mode',
+    example: () => ({ mode: 'warn' }),
+  },
+  {
+    key: 'lint',
+    coversKnobs: ['lint'],
+    title: 'Lint gate',
+    blurb: [
+      "Runs the pack's own linter as a gate: net-new errors surface, the",
+      'pre-existing backlog stays grandfathered.',
+    ],
+    anchor: 'lint-gate',
+    example: () => ({ enabled: true, blocking: false }),
+    appliesWhen: (ctx) => ctx.lintCapable,
+  },
+  {
+    key: 'checks',
+    coversKnobs: ['checks'],
+    title: 'Custom checks',
+    blurb: [
+      'Your own invariants as gate citizens. Commands run from THIS committed',
+      'file only; review edits here like CI config.',
+    ],
+    anchor: 'custom-checks',
+    example: () => [
+      {
+        name: 'architecture',
+        command: 'bash scripts/check-architecture.sh',
+        parse: 'exit',
+      },
+    ],
+  },
+  {
+    key: 'pairedChecks',
+    coversKnobs: ['pairedChecks'],
+    title: 'Paired-change rules',
+    blurb: [
+      'Blocks a change to X that ships without its Y (deletions count).',
+      'Declarative; nothing is spawned, so it gates on every surface.',
+    ],
+    anchor: 'paired-change-rules',
+    example: () => [
+      {
+        name: 'model-needs-migration',
+        if: ['src/models/**'],
+        then: ['migrations/**'],
+        message: 'a data-model change ships with its migration',
+      },
+    ],
+  },
+  {
+    key: 'licenses',
+    coversKnobs: ['licenses.prohibited'],
+    title: 'Prohibited licenses',
+    blurb: [
+      'Blocks a net-new dependency whose license matches a prefix here.',
+      'Which licenses your business prohibits is a legal posture; yours.',
+    ],
+    anchor: 'prohibited-licenses',
+    example: () => ({ prohibited: ['GPL-', 'AGPL-'] }),
+  },
+  {
+    key: 'newAdvisories',
+    coversKnobs: ['newAdvisories.blockSeverities', 'newAdvisories.commentCommands'],
+    title: 'Newly published advisories',
+    blurb: ['Posture for advisories published AFTER your baseline was captured.'],
+    anchor: 'new-advisories',
+    example: () => ({ blockSeverities: ['critical', 'high'], commentCommands: true }),
+    followUp: ['commentCommands installs a managed workflow: run `vyuh-dxkit update` after.'],
+  },
+  {
+    key: 'depBump',
+    coversKnobs: ['depBump.enabled'],
+    title: 'Scheduled dependency bumps',
+    blurb: [
+      'Deterministic, floor-verified bump PRs for version-solvable advisories.',
+      'No LLM, no key; the agentic remediate lane handles what bumps cannot.',
+    ],
+    anchor: 'dep-bump',
+    example: () => ({ enabled: true }),
+    followUp: ['Installs a managed workflow: run `vyuh-dxkit update` after enabling.'],
+  },
+  {
+    key: 'expiryNotice',
+    coversKnobs: ['expiryNotice.enabled'],
+    title: 'Expiring-suppression notice',
+    blurb: [
+      'A deferral is a promise with a date on it. The guardrail check already',
+      'warns every PR while the window is open — this covers the quiet week:',
+      'the scheduled refresh maintains ONE issue naming what lapses, who',
+      'accepted it, and when, and closes it once nothing is lapsing.',
+      'Never blocks; the expiry itself stays the forcing function.',
+    ],
+    anchor: 'expiry-notice',
+    example: () => ({ enabled: true }),
+    followUp: [
+      'Grants the refresh workflow `issues: write`: run `vyuh-dxkit update` after enabling.',
+    ],
+  },
+  {
+    key: 'reports',
+    coversKnobs: ['reports.onMerge'],
+    title: 'Report snapshots on merge',
+    blurb: ['Publishes score history to the dxkit-reports ref; feeds `vyuh-dxkit metrics`.'],
+    anchor: 'reports-on-merge',
+    example: () => ({ onMerge: true }),
+    followUp: ['Installs a managed workflow: run `vyuh-dxkit update` after enabling.'],
+  },
+  {
+    key: 'loop',
+    coversKnobs: ['loop.preset'],
+    title: 'Autonomous-loop Stop-gate posture',
+    blurb: ['What blocks an unattended coding loop from declaring done.'],
+    anchor: 'loop-preset',
+    example: () => ({ preset: 'security-only' }),
+  },
+  {
+    key: 'remediate',
+    coversKnobs: ['remediate.enabled'],
+    title: 'Agentic remediation (scheduled agent inside the verified frame)',
+    blurb: [
+      'An agent works the debt the deterministic lanes cannot close; every run',
+      "is floor-attributed + guardrail-verified before a PR opens (the agent's",
+      'word is never trusted). Credentials come from repo secrets, never here.',
+    ],
+    anchor: 'remediate',
+    example: () => ({
+      enabled: true,
+      tasks: ['fix-vulns'],
+      schedule: 'weekly',
+      agent: {
+        driver: 'claude-code',
+        model: 'auto',
+        budget: { maxTurns: 80, maxMinutes: 30, maxUsd: 5 },
+      },
+    }),
+    followUp: [
+      'Installs a managed workflow: run `vyuh-dxkit update` after enabling, and set',
+      'the ANTHROPIC_API_KEY repo secret (a scoped key with a spend limit).',
+    ],
+  },
+];
+
+export const SCAFFOLD_EXEMPT_KNOBS: readonly ScaffoldExemptKnob[] = [
+  {
+    path: 'baseline.anchor',
+    reason:
+      'auto-derived from effective branch protection at publish time; a hand-set value is ' +
+      'the exception; documented in the guide (baseline-anchor), not taught by the scaffold.',
+  },
+  {
+    path: 'graph.refresh',
+    reason:
+      'a CI-performance transport set by init/update when applicable, not a posture a human ' +
+      'tunes; a commented stanza would invite cargo-cult enabling.',
+  },
+  {
+    path: 'deepSast',
+    reason:
+      'requires an external engine + token that dxkit never selects for the user; the ingest ' +
+      'command + dxkit-ingest skill own setup; a bare stanza without a token would not work.',
+  },
+];

--- a/src/baseline/policy-stanzas.ts
+++ b/src/baseline/policy-stanzas.ts
@@ -3,10 +3,49 @@
  * exemptions: the second half of the one policy metadata table
  * (`policy-metadata.ts`), split at the large-file bar and re-exported
  * there so `from './policy-metadata'` stays the one import path. The
- * per-parameter rows (`POLICY_PARAMS`) live in the sibling; the types
- * these tables conform to are declared there too.
+ * per-parameter rows (`POLICY_PARAMS`) live in the sibling; the stanza
+ * types are declared HERE, in the leaf, so the import edge runs one way
+ * (metadata re-exports from this module, this module imports nothing).
  */
-import type { PolicyStanzaMeta, ScaffoldExemptKnob } from './policy-metadata';
+
+/** Repo facts the scaffold tailors on. Plain data (no registry imports) so
+ *  the metadata modules stay leaves; the caller builds it from the language
+ *  registry. */
+export interface ScaffoldCtx {
+  readonly packIds: readonly string[];
+  /** Does any active pack declare a `lintGate`? */
+  readonly lintCapable: boolean;
+}
+
+/** One commented-out opt-in stanza in the generated scaffold. */
+export interface PolicyStanzaMeta {
+  /** Top-level policy key the stanza teaches (`pairedChecks`, `depBump`, …).
+   *  A key already active in the rendered policy suppresses its stanza. */
+  readonly key: string;
+  /** `POSTURE_KNOBS` paths this stanza covers; the scaffold-coverage test
+   *  resolves every knob through these. */
+  readonly coversKnobs: readonly string[];
+  /** Section title rendered in the stanza's header comment. */
+  readonly title: string;
+  /** Teaching lines rendered as comments above the stanza. */
+  readonly blurb: readonly string[];
+  /** Guide anchor for the whole stanza. */
+  readonly anchor: string;
+  /** The syntactically-complete example value; uncommenting it IS activation
+   *  (E3). A function of ctx so examples can tailor per stack. */
+  readonly example: (ctx: ScaffoldCtx) => unknown;
+  /** Extra comment lines after the stanza (e.g. "then run: vyuh-dxkit update"). */
+  readonly followUp?: readonly string[];
+  /** Omit the stanza entirely when false (per-stack tailoring). */
+  readonly appliesWhen?: (ctx: ScaffoldCtx) => boolean;
+}
+
+/** A `POSTURE_KNOBS` path deliberately absent from the scaffold; a declared
+ *  exemption with a reason, never a silent omission. */
+export interface ScaffoldExemptKnob {
+  readonly path: string;
+  readonly reason: string;
+}
 
 export const POLICY_STANZAS: readonly PolicyStanzaMeta[] = [
   {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -23,6 +23,16 @@ import { diagnoseFlow, type FlowDiagnosis } from './analyzers/flow/diagnose';
 import { gatherRecommendations, type CommandRecommendation } from './discovery/commands';
 import { trustedLocalContext } from './analysis-trust';
 import { probeDeliveryPreconditions } from './lanes/delivery-preconditions';
+import {
+  LANE_TOKEN_REMEDY_COMMAND,
+  probeLaneTokenTierHere,
+  type LaneTokenTierProbe,
+} from './lanes/lane-token-probe';
+import {
+  LANE_TOKEN_APP_ID_VARIABLE_NAME,
+  LANE_TOKEN_APP_KEY_SECRET_NAME,
+  LANE_TOKEN_PAT_SECRET_NAME,
+} from './lanes/lane-token';
 
 /**
  * Three-tier doctor:
@@ -109,62 +119,50 @@ export interface DoctorReport {
 }
 
 /**
- * Is the DXKIT_BOT_TOKEN repo secret absent? Tri-state and fail-open:
- * `true` only when `gh secret list` SUCCEEDED and the name is not there;
- * `false` when present; `null` when unknowable (no gh, no admin scope,
- * offline) — the caller stays silent on null, never a false alarm.
+ * The 6d lane-token check for a probe result (dxkit #325). Pure so every
+ * state is pinned by test: a genuine absence is the red finding with the
+ * remedy; an UNOBSERVABLE scope (org-level names this token cannot list)
+ * is advice that says what could not be verified and where the truth is,
+ * never the negative assertion; a configured tier is no finding at all.
  */
-function botTokenSecretAbsent(cwd: string): boolean | null {
-  try {
-    const out = execSync('gh secret list --json name --jq ".[].name"', {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 15_000,
-    });
-    return !out
-      .split('\n')
-      .map((l) => l.trim())
-      .includes('DXKIT_BOT_TOKEN');
-  } catch {
-    return null;
-  }
-}
-
-/** Is the GitHub App token tier configured (4.4.1 WP7)? TRUE only when BOTH
- *  halves exist — the DXKIT_APP_ID variable and the DXKIT_APP_PRIVATE_KEY
- *  secret; the workflows gate their mint step on the variable and fail
- *  loudly on a broken key. Tri-state fail-open like its PAT sibling: null
- *  when the API cannot answer (no admin scope, offline) — never a false
- *  alarm. */
-function appTokenConfigured(cwd: string): boolean | null {
-  try {
-    const vars = execSync('gh variable list --json name --jq ".[].name"', {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 15_000,
-    });
-    if (
-      !vars
-        .split('\n')
-        .map((l) => l.trim())
-        .includes('DXKIT_APP_ID')
-    ) {
-      return false;
-    }
-    const secrets = execSync('gh secret list --json name --jq ".[].name"', {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 15_000,
-    });
-    return secrets
-      .split('\n')
-      .map((l) => l.trim())
-      .includes('DXKIT_APP_PRIVATE_KEY');
-  } catch {
-    return null;
+export function laneTokenTierCheck(result: LaneTokenTierProbe): CheckResult | null {
+  switch (result.state) {
+    case 'configured':
+      return null;
+    case 'not-configured':
+      return {
+        label: 'lane PRs will run no checks: no lane token tier is configured',
+        ok: false,
+        tier: 'operational',
+        fix: {
+          hint:
+            'The dep-bump / remediate lanes push with the default GITHUB_TOKEN, and GitHub ' +
+            'never triggers workflows for such pushes, so their PRs arrive with no checks ' +
+            '(unmergeable under branch protection). Preferred fix: create a GitHub App ' +
+            '(contents + pull-requests write, installed on this repo), then set the ' +
+            `${LANE_TOKEN_APP_ID_VARIABLE_NAME} variable and ${LANE_TOKEN_APP_KEY_SECRET_NAME} secret (no billed seat, ` +
+            'short-lived per-run tokens, and PRs a maintainer can approve). A PAT in the ' +
+            `${LANE_TOKEN_PAT_SECRET_NAME} secret also works; the lanes pick either up automatically. ` +
+            `Probed: ${result.evidence}.`,
+          command: LANE_TOKEN_REMEDY_COMMAND,
+          skill: 'dxkit-fix',
+        },
+      };
+    case 'unobservable':
+      return {
+        label: 'lane token tier could not be verified from here',
+        ok: false,
+        tier: 'operational',
+        advisory: true,
+        fix: {
+          hint:
+            `Doctor ${result.reason}. This is not a finding: an org-level tier is ` +
+            'common and works without being visible to a repo-scoped token. To verify, ' +
+            'open a recent dep-bump / remediate run and read its "Disclose token mode" ' +
+            `step, or re-run doctor with a token that can list org Actions variables and secrets.`,
+          skill: 'dxkit-fix',
+        },
+      };
   }
 }
 
@@ -1025,35 +1023,20 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
   // that pushes with the default GITHUB_TOKEN opens PRs that trigger NO
   // workflow runs (GitHub's own robot-loop rule) — uncheckable under branch
   // protection. The lanes disclose this per run, but a run notice is
-  // reactive; doctor is where setup gaps are FOUND. Advisory + fail-open:
-  // when `gh` can't list secrets (no admin scope, offline), stay silent —
-  // never a false alarm.
+  // reactive; doctor is where setup gaps are FOUND. Tri-state: a scope the
+  // token cannot list (org-level names, no admin scope, offline) is
+  // "could not verify", disclosed as advice, never a false alarm.
   {
     const prLaneInstalled = ['dxkit-dep-bump.yml', 'dxkit-remediate.yml'].some((f) =>
       fs.existsSync(path.join(cwd, '.github', 'workflows', f)),
     );
-    // Warn only when NEITHER token tier is configured (4.4.1 WP7): the
-    // GitHub App tier (preferred — no billed seat, short-lived per-run
-    // tokens) or the DXKIT_BOT_TOKEN PAT. A null (unanswerable) App probe
-    // stays fail-open: the PAT check alone decides, exactly as before.
-    if (prLaneInstalled && botTokenSecretAbsent(cwd) === true && appTokenConfigured(cwd) !== true) {
-      checks.push({
-        label: 'lane PRs will run no checks — no lane token tier is configured',
-        ok: false,
-        tier: 'operational',
-        fix: {
-          hint:
-            'The dep-bump / remediate lanes push with the default GITHUB_TOKEN, and GitHub ' +
-            'never triggers workflows for such pushes — their PRs arrive with no checks ' +
-            '(unmergeable under branch protection). Preferred fix: create a GitHub App ' +
-            '(contents + pull-requests write, installed on this repo), then set the ' +
-            'DXKIT_APP_ID variable and DXKIT_APP_PRIVATE_KEY secret — no billed seat, ' +
-            'short-lived per-run tokens, and PRs a maintainer can approve. A PAT in the ' +
-            'DXKIT_BOT_TOKEN secret also works; the lanes pick either up automatically.',
-          command: 'gh variable set DXKIT_APP_ID && gh secret set DXKIT_APP_PRIVATE_KEY',
-          skill: 'dxkit-fix',
-        },
-      });
+    // Red only when NEITHER tier is configured AND every scope the lane
+    // reads (repo + org variables/secrets) was actually enumerated. An
+    // org-level tier a repo-scoped token cannot list is UNOBSERVABLE, and
+    // reads as "could not verify" advice, never as absent (dxkit #325).
+    if (prLaneInstalled) {
+      const check = laneTokenTierCheck(probeLaneTokenTierHere(cwd));
+      if (check) checks.push(check);
     }
 
     // 6e. Lane-PR creation permission. Same class as 6d, earlier in the

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -22,16 +22,21 @@ import { EXTERNAL_SNAPSHOT_STALE_DAYS, snapshotAgeDays } from './ingest/engine-f
 import { diagnoseFlow, type FlowDiagnosis } from './analyzers/flow/diagnose';
 import { gatherRecommendations, type CommandRecommendation } from './discovery/commands';
 import { trustedLocalContext } from './analysis-trust';
-import { probeDeliveryPreconditions } from './lanes/delivery-preconditions';
 import {
-  LANE_TOKEN_REMEDY_COMMAND,
-  probeLaneTokenTierHere,
-  type LaneTokenTierProbe,
-} from './lanes/lane-token-probe';
+  makeGhApiProbe,
+  probeDeliveryPreconditions,
+  probeJson,
+  repoView,
+  type ApiProbe,
+} from './lanes/delivery-preconditions';
+import { probeLaneTokenTierHere, type LaneTokenTierProbe } from './lanes/lane-token-probe';
 import {
+  LANE_TOKEN_APP_ID_REMEDY_COMMAND,
   LANE_TOKEN_APP_ID_VARIABLE_NAME,
+  LANE_TOKEN_APP_KEY_REMEDY_COMMAND,
   LANE_TOKEN_APP_KEY_SECRET_NAME,
   LANE_TOKEN_PAT_SECRET_NAME,
+  LANE_TOKEN_REMEDY_COMMAND,
 } from './lanes/lane-token';
 
 /**
@@ -121,14 +126,48 @@ export interface DoctorReport {
 /**
  * The 6d lane-token check for a probe result (dxkit #325). Pure so every
  * state is pinned by test: a genuine absence is the red finding with the
- * remedy; an UNOBSERVABLE scope (org-level names this token cannot list)
- * is advice that says what could not be verified and where the truth is,
- * never the negative assertion; a configured tier is no finding at all.
+ * remedy; a HALF-configured App tier is a red finding naming exactly the
+ * missing half (in either direction); an UNOBSERVABLE scope (org-level
+ * names this token cannot list) is advice that says what could not be
+ * verified and where the truth is, never the negative assertion; the
+ * no-GitHub / no-gh case stays SILENT (the pre-#325 fail-open contract);
+ * a configured tier is no finding at all.
  */
 export function laneTokenTierCheck(result: LaneTokenTierProbe): CheckResult | null {
   switch (result.state) {
     case 'configured':
       return null;
+    case 'half-configured':
+      return result.missing === 'app-private-key-secret'
+        ? {
+            label: `lane token App tier is half-configured: the ${LANE_TOKEN_APP_ID_VARIABLE_NAME} variable is set but the ${LANE_TOKEN_APP_KEY_SECRET_NAME} secret is missing`,
+            ok: false,
+            tier: 'operational',
+            fix: {
+              hint:
+                `The lane workflows pick App mode on the ${LANE_TOKEN_APP_ID_VARIABLE_NAME} ` +
+                'variable alone, and their mint step fails loudly without the private key, so ' +
+                `every lane run dies before doing any work. Probed: ${result.evidence}. Set the ` +
+                `${LANE_TOKEN_APP_KEY_SECRET_NAME} secret (the App's PEM private key), or unset ` +
+                `the variable to fall back to another tier.`,
+              command: LANE_TOKEN_APP_KEY_REMEDY_COMMAND,
+              skill: 'dxkit-fix',
+            },
+          }
+        : {
+            label: `lane token App tier is half-configured: the ${LANE_TOKEN_APP_KEY_SECRET_NAME} secret is set but the ${LANE_TOKEN_APP_ID_VARIABLE_NAME} variable is missing`,
+            ok: false,
+            tier: 'operational',
+            fix: {
+              hint:
+                `Without the ${LANE_TOKEN_APP_ID_VARIABLE_NAME} variable the lane workflows ` +
+                'never pick App mode: they silently fall back to the PAT or the default token ' +
+                `and the configured key is dead weight. Probed: ${result.evidence}. Set the ` +
+                `variable to the GitHub App's id.`,
+              command: LANE_TOKEN_APP_ID_REMEDY_COMMAND,
+              skill: 'dxkit-fix',
+            },
+          };
     case 'not-configured':
       return {
         label: 'lane PRs will run no checks: no lane token tier is configured',
@@ -149,6 +188,11 @@ export function laneTokenTierCheck(result: LaneTokenTierProbe): CheckResult | nu
         },
       };
     case 'unobservable':
+      // No GitHub repo / no gh CLI: the environment cannot answer at all,
+      // so stay silent (the pre-#325 fail-open contract). Only a
+      // permissions-shaped gap (GitHub answered for some scopes but not
+      // all) is worth a line of advice.
+      if (result.cause === 'no-github') return null;
       return {
         label: 'lane token tier could not be verified from here',
         ok: false,
@@ -156,10 +200,11 @@ export function laneTokenTierCheck(result: LaneTokenTierProbe): CheckResult | nu
         advisory: true,
         fix: {
           hint:
-            `Doctor ${result.reason}. This is not a finding: an org-level tier is ` +
-            'common and works without being visible to a repo-scoped token. To verify, ' +
-            'open a recent dep-bump / remediate run and read its "Disclose token mode" ' +
-            `step, or re-run doctor with a token that can list org Actions variables and secrets.`,
+            `Could not verify the lane token tier: ${result.reason}. This is not a ` +
+            'finding: an org-level tier is common and works without being visible to a ' +
+            'repo-scoped token. To verify, open a recent dep-bump / remediate run and read ' +
+            'its "Disclose token mode" step, or re-run doctor with a token that can list ' +
+            'org Actions variables and secrets.',
           skill: 'dxkit-fix',
         },
       };
@@ -167,22 +212,18 @@ export function laneTokenTierCheck(result: LaneTokenTierProbe): CheckResult | nu
 }
 
 /**
- * Can GitHub Actions create pull requests in this repo? Same tri-state
- * fail-open contract as `botTokenSecretAbsent`: `false` only when the API
- * answered and the setting is off; `true` when on; `null` when unknowable
- * (no gh, no access, offline) — the caller stays silent on null.
+ * Can GitHub Actions create pull requests in this repo? Tri-state and
+ * fail-open: `false` only when the API answered and the setting is off;
+ * `true` when on; `null` when unknowable (no slug, no access, offline);
+ * the caller stays silent on null. Reads through the caller's shared
+ * ApiProbe + already-resolved slug (one `gh repo view` for all of 6d-6f).
  */
-function actionsCanCreatePrs(cwd: string): boolean | null {
-  try {
-    const out = execSync(
-      'gh api repos/{owner}/{repo}/actions/permissions/workflow --jq .can_approve_pull_request_reviews',
-      { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 15_000 },
-    );
-    const v = out.trim();
-    return v === 'true' ? true : v === 'false' ? false : null;
-  } catch {
-    return null;
-  }
+function actionsCanCreatePrs(probe: ApiProbe, slug: string | null): boolean | null {
+  if (slug === null) return null;
+  const parsed = probeJson(probe, `repos/${slug}/actions/permissions/workflow`);
+  const v = (parsed as { can_approve_pull_request_reviews?: unknown } | null)
+    ?.can_approve_pull_request_reviews;
+  return typeof v === 'boolean' ? v : null;
 }
 
 function commandAvailable(cmd: string): boolean {
@@ -1030,12 +1071,24 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
     const prLaneInstalled = ['dxkit-dep-bump.yml', 'dxkit-remediate.yml'].some((f) =>
       fs.existsSync(path.join(cwd, '.github', 'workflows', f)),
     );
+    // ONE `gh repo view` and ONE ApiProbe shared by 6d/6e/6f: each check
+    // used to shell its own slug resolution, tripling the startup cost of
+    // this block for identical answers.
+    const repo = prLaneInstalled ? repoView(cwd) : null;
+    const apiProbe = makeGhApiProbe(cwd);
     // Red only when NEITHER tier is configured AND every scope the lane
-    // reads (repo + org variables/secrets) was actually enumerated. An
-    // org-level tier a repo-scoped token cannot list is UNOBSERVABLE, and
-    // reads as "could not verify" advice, never as absent (dxkit #325).
+    // reads (repo + org variables/secrets) was actually enumerated in
+    // full. An org-level tier a repo-scoped token cannot list is
+    // UNOBSERVABLE, and reads as "could not verify" advice, never as
+    // absent (dxkit #325).
     if (prLaneInstalled) {
-      const check = laneTokenTierCheck(probeLaneTokenTierHere(cwd));
+      const check = laneTokenTierCheck(
+        probeLaneTokenTierHere(cwd, {
+          probe: apiProbe,
+          slug: repo?.slug ?? null,
+          ownerInOrganization: repo?.inOrganization ?? null,
+        }),
+      );
       if (check) checks.push(check);
     }
 
@@ -1045,7 +1098,7 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
     // fails to open the PR (the run log names this setting; the onboard
     // preflight probes it too — this is the local-doctor sibling of that
     // probe). Tri-state fail-open: silent unless the API said "off".
-    if (prLaneInstalled && actionsCanCreatePrs(cwd) === false) {
+    if (prLaneInstalled && actionsCanCreatePrs(apiProbe, repo?.slug ?? null) === false) {
       checks.push({
         label:
           "lane PRs cannot be opened — 'Allow GitHub Actions to create and approve pull requests' is off",
@@ -1071,7 +1124,10 @@ function runOperationalChecks(cwd: string, hasManifest: boolean): CheckResult[] 
     // consumes the same module. Fail-open: an unanswerable probe stays
     // silent here — doctor never invents a refusal.
     if (prLaneInstalled) {
-      const delivery = probeDeliveryPreconditions(cwd);
+      const delivery = probeDeliveryPreconditions(cwd, {
+        slug: repo?.slug ?? null,
+        probe: apiProbe,
+      });
       for (const p of delivery.probes.filter((p) => p.verdict === 'blocked')) {
         checks.push({
           label: `lanes cannot deliver here — branch creation is blocked for ${p.branch}`,

--- a/src/land-refresh.ts
+++ b/src/land-refresh.ts
@@ -63,7 +63,7 @@ export interface LandRefreshOptions {
    * Stamp `[skip ci]` on the PR-mode head commit too (#304). Default FALSE:
    * GitHub honors the marker for `pull_request` workflows, so a stamped
    * standing PR can never run a single check — a code-carrying lane PR then
-   * presents with zero CI, silently defeats the DXKIT_BOT_TOKEN's stated
+   * presents with zero CI, silently defeats the lane PAT tier's stated
    * purpose, and under required checks is permanently unmergeable (the
    * PR-mode sibling of the push-mode deadlock enforcement.ts documents).
    * Only an artifact-only refresh PR that deliberately wants silent updates

--- a/src/lanes/delivery-preconditions.ts
+++ b/src/lanes/delivery-preconditions.ts
@@ -57,6 +57,19 @@ export function standingLaneBranches(): string[] {
 
 export type ApiProbe = (path: string) => string | null;
 
+/** Probe + parse in one place: null when the read failed OR the payload is
+ *  not JSON. The one home of the null-guard + JSON.parse/catch boilerplate
+ *  every ApiProbe consumer used to repeat. */
+export function probeJson(probe: ApiProbe, apiPath: string): unknown {
+  const raw = probe(apiPath);
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
 /** Real probe via the gh CLI (the ambient token). Null = unanswerable. */
 export function makeGhApiProbe(cwd: string): ApiProbe {
   return (apiPath) => {
@@ -73,20 +86,40 @@ export function makeGhApiProbe(cwd: string): ApiProbe {
   };
 }
 
-/** `owner/repo` for the checkout, or null (not GitHub / no gh). */
-export function repoSlug(cwd: string): string | null {
+/** What one `gh repo view` call can tell every probe: the slug plus the
+ *  owner shape. Resolved ONCE per consumer surface (doctor resolves it a
+ *  single time and shares it across 6d/6e/6f), never re-shelled per probe. */
+export interface RepoView {
+  readonly slug: string;
+  /** Org-owned repo? null when gh did not answer the field, so a consumer
+   *  must not assume "no org" from silence. */
+  readonly inOrganization: boolean | null;
+}
+
+/** The slug + owner shape for the checkout, or null (not GitHub / no gh). */
+export function repoView(cwd: string): RepoView | null {
   try {
-    const out = execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner'], {
+    const out = execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner,isInOrganization'], {
       cwd,
       encoding: 'utf8',
       timeout: 30_000,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    const slug = (JSON.parse(out) as { nameWithOwner?: string }).nameWithOwner;
-    return typeof slug === 'string' && slug.includes('/') ? slug : null;
+    const parsed = JSON.parse(out) as { nameWithOwner?: string; isInOrganization?: boolean };
+    const slug = parsed.nameWithOwner;
+    if (typeof slug !== 'string' || !slug.includes('/')) return null;
+    return {
+      slug,
+      inOrganization: typeof parsed.isInOrganization === 'boolean' ? parsed.isInOrganization : null,
+    };
   } catch {
     return null;
   }
+}
+
+/** `owner/repo` for the checkout, or null (not GitHub / no gh). */
+export function repoSlug(cwd: string): string | null {
+  return repoView(cwd)?.slug ?? null;
 }
 
 /**
@@ -99,20 +132,17 @@ export function probeBranchDelivery(
   slug: string,
   branch: string,
 ): BranchDeliveryProbe {
-  const raw = probe(`repos/${slug}/rules/branches/${encodeURIComponent(branch)}`);
-  if (raw === null) {
+  const parsed = probeJson(probe, `repos/${slug}/rules/branches/${encodeURIComponent(branch)}`);
+  if (parsed === null || !Array.isArray(parsed)) {
     return {
       branch,
       verdict: 'unknown',
-      evidence: 'could not verify: the branch-rules API was unreachable with the ambient token',
+      evidence:
+        'could not verify: the branch-rules API was unreachable with the ambient token, ' +
+        'or answered with an unparseable payload',
     };
   }
-  let rules: Array<{ type?: string }> = [];
-  try {
-    rules = JSON.parse(raw) as Array<{ type?: string }>;
-  } catch {
-    return { branch, verdict: 'unknown', evidence: 'could not verify: unparseable rules payload' };
-  }
+  const rules = parsed as Array<{ type?: string }>;
   const types = rules.map((r) => r.type).filter((t): t is string => typeof t === 'string');
   // Positive refusal evidence: an active `creation` rule on a branch the
   // lane must CREATE means the push 403s (the live class). The bypass list
@@ -154,12 +184,14 @@ export function probeDeliveryPreconditions(
   opts: {
     readonly branches?: readonly string[];
     readonly probe?: ApiProbe;
-    /** Injectable for tests: the `owner/repo` slug (skips the gh probe). */
-    readonly slug?: string;
+    /** Injectable: the `owner/repo` slug (skips the gh probe). An explicit
+     *  null means "already resolved, and there is none": the caller that
+     *  resolved it once (doctor) must not trigger a second gh shell here. */
+    readonly slug?: string | null;
   } = {},
 ): DeliveryPreconditions {
   const branches = opts.branches ?? standingLaneBranches();
-  const slug = opts.slug ?? repoSlug(cwd);
+  const slug = opts.slug !== undefined ? opts.slug : repoSlug(cwd);
   if (slug === null) {
     return {
       probes: branches.map((branch) => ({

--- a/src/lanes/lane-token-probe.ts
+++ b/src/lanes/lane-token-probe.ts
@@ -13,23 +13,35 @@
  * "token tier: GitHub App" the same day) was told by `doctor` to go
  * configure it.
  *
- * So the answer is a TRI-STATE, and the negative is asserted only when
- * every scope the lane could read was actually read:
+ * So the answer mirrors the workflow's own precedence (the App id
+ * variable decides the mode, then the PAT, then the default token), and
+ * a negative is asserted only when every scope the lane could read was
+ * actually ENUMERATED IN FULL. The list endpoints paginate (GitHub caps
+ * the variables endpoints at 30 per page), so enumeration follows pages
+ * until `total_count` is accounted for and a truncated listing reads as
+ * unreadable, never as absence:
  *
- *   - `configured`      a tier was seen (with which tier and in which scope);
- *   - `not-configured`  every applicable scope was enumerated and none of
- *                       the names is present: the remedy is honest;
- *   - `unobservable`    some applicable scope could not be enumerated (a
- *                       403/404 on the org endpoints, no admin scope, no
- *                       gh, offline): "could not verify", with the scopes
- *                       that were unreadable named, never a negative.
+ *   - `configured`       a tier was seen (which tier, in which scope);
+ *   - `half-configured`  the App tier has exactly one of its two halves,
+ *                        in either direction: the id without the key
+ *                        makes the mint step die loudly on every run, the
+ *                        key without the id silently never picks App mode;
+ *   - `not-configured`   every applicable scope was fully enumerated and
+ *                        none of the names is present: the remedy is honest;
+ *   - `unobservable`     some applicable scope could not be enumerated
+ *                        (a 403/404 on the org endpoints, no admin scope,
+ *                        a truncated listing, no gh, offline): "could not
+ *                        verify", with the unreadable scopes named, never
+ *                        a negative. `cause` separates "no GitHub here"
+ *                        (the caller stays silent, the old fail-open
+ *                        contract) from a permissions gap (advice).
  *
  * The names probed come from lane-token.ts: this module holds no second
  * tier table. Consumers: `doctor` (6d). The probe is injected so every
  * state is testable without a network.
  */
 
-import { type ApiProbe, makeGhApiProbe, repoSlug } from './delivery-preconditions';
+import { type ApiProbe, makeGhApiProbe, probeJson, repoView } from './delivery-preconditions';
 import {
   LANE_TOKEN_APP_ID_VARIABLE_NAME,
   LANE_TOKEN_APP_KEY_SECRET_NAME,
@@ -47,6 +59,11 @@ export type LaneTokenTierProbe =
       readonly tier: LaneTokenTier;
       /** The scope the deciding name was found in (`app`: the App id variable). */
       readonly scope: LaneTokenScope;
+    }
+  | {
+      readonly state: 'half-configured';
+      /** Which App-tier half is definitively absent. */
+      readonly missing: 'app-id-variable' | 'app-private-key-secret';
       readonly evidence: string;
     }
   | {
@@ -55,74 +72,97 @@ export type LaneTokenTierProbe =
     }
   | {
       readonly state: 'unobservable';
-      /** Which scopes could not be enumerated, and so why no negative is asserted. */
+      /** `no-github`: not a GitHub checkout / no gh CLI, the caller stays
+       *  silent (fail-open, the pre-#325 contract). `permissions`: GitHub
+       *  answered for some scopes but not all, advice, never a negative. */
+      readonly cause: 'no-github' | 'permissions';
+      /** Which scopes could not be enumerated, so why no negative is asserted. */
       readonly reason: string;
     };
 
-/** The remedy for a genuinely absent tier, derived from the one name set. */
-export const LANE_TOKEN_REMEDY_COMMAND = `gh variable set ${LANE_TOKEN_APP_ID_VARIABLE_NAME} && gh secret set ${LANE_TOKEN_APP_KEY_SECRET_NAME}`;
-
-/** One scope's enumeration: the names seen, or null when unreadable. */
+/** One scope's full enumeration: the names, or null when unreadable. */
 type ScopeRead = ReadonlySet<string> | null;
 
-/** Names from an Actions list payload (`{ variables: [...] }` or
- *  `{ secrets: [...] }`); null when the read failed or is unparseable. */
-function namesFrom(raw: string | null, key: 'variables' | 'secrets'): ScopeRead {
-  if (raw === null) return null;
-  try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const list = parsed[key];
+/** Follow-the-pages ceiling: 20 pages of 30 covers 600 variables, far past
+ *  any real Actions configuration; beyond it the scope reads as unreadable
+ *  (never as absence). */
+const MAX_SCOPE_PAGES = 20;
+
+/**
+ * Fully enumerate one Actions list endpoint (`{ total_count, variables|
+ * secrets: [{ name }] }`), following pagination. GitHub caps the variables
+ * endpoints at 30 per page (secrets at 100). Returns null when the scope
+ * cannot be READ IN FULL (an error, an unparseable payload, or a listing
+ * that never accounts for `total_count`), because a partial listing cannot
+ * back an absence claim (the #325 class, one page deeper).
+ */
+function readScope(probe: ApiProbe, basePath: string, key: 'variables' | 'secrets'): ScopeRead {
+  const perPage = key === 'variables' ? 30 : 100;
+  const names = new Set<string>();
+  let total = 0;
+  for (let page = 1; page <= MAX_SCOPE_PAGES; page++) {
+    const parsed = probeJson(probe, `${basePath}?per_page=${perPage}&page=${page}`);
+    if (parsed === null || typeof parsed !== 'object') return null;
+    const rec = parsed as Record<string, unknown>;
+    if (typeof rec.total_count !== 'number') return null;
+    total = rec.total_count;
+    const list = rec[key];
     if (!Array.isArray(list)) return null;
-    const names = new Set<string>();
     for (const item of list) {
       const name = (item as { name?: unknown })?.name;
       if (typeof name === 'string') names.add(name);
     }
-    return names;
-  } catch {
-    return null;
+    if (names.size >= total || list.length === 0) break;
   }
+  return names.size >= total ? names : null;
 }
 
-/** Is the repo owned by an organization? null when the API could not say
- *  (then the org scopes are treated as applicable: the probe must not
- *  assume "no org" to reach a negative). */
-function ownerIsOrganization(probe: ApiProbe, slug: string): boolean | null {
-  const raw = probe(`repos/${slug}`);
-  if (raw === null) return null;
-  try {
-    const type = (JSON.parse(raw) as { owner?: { type?: unknown } })?.owner?.type;
-    return typeof type === 'string' ? type === 'Organization' : null;
-  } catch {
-    return null;
-  }
-}
+const EMPTY_SCOPE: ReadonlySet<string> = new Set();
 
 /**
- * Probe the tier against the repo AND org scopes. Pure over the injected
- * probe: every state is reachable from fixture payloads.
+ * Probe the tier against the repo AND org scopes, mirroring the workflow
+ * chain's precedence. Pure over the injected probe: every state is
+ * reachable from fixture payloads.
+ *
+ * `ownerInOrganization` comes from the caller's one `gh repo view` call
+ * (`repoView`): `false` confirms a user-owned repo (no org scope exists,
+ * so empty repo scopes ARE a genuine absence); `true` or null keeps the
+ * org scopes applicable, the probe never assumes "no org" to reach a
+ * negative.
  */
-export function probeLaneTokenTier(probe: ApiProbe, slug: string): LaneTokenTierProbe {
-  const page = '?per_page=100';
-  const repoVars = namesFrom(probe(`repos/${slug}/actions/variables${page}`), 'variables');
-  const repoSecrets = namesFrom(probe(`repos/${slug}/actions/secrets${page}`), 'secrets');
+export function probeLaneTokenTier(
+  probe: ApiProbe,
+  slug: string,
+  ownerInOrganization: boolean | null,
+): LaneTokenTierProbe {
+  const repoVars = readScope(probe, `repos/${slug}/actions/variables`, 'variables');
+  const repoSecrets = readScope(probe, `repos/${slug}/actions/secrets`, 'secrets');
 
-  // A user-owned repo has no org scope: an unreadable org endpoint there is
-  // expected, not a gap. Only a CONFIRMED user owner narrows the scopes.
-  const orgApplies = ownerIsOrganization(probe, slug) !== false;
+  // Short-circuit: a fully-configured App tier in the repo scope needs no
+  // org reads (positive evidence already decides the mode).
+  if (
+    repoVars?.has(LANE_TOKEN_APP_ID_VARIABLE_NAME) === true &&
+    repoSecrets?.has(LANE_TOKEN_APP_KEY_SECRET_NAME) === true
+  ) {
+    return { state: 'configured', tier: 'app', scope: 'repo' };
+  }
+
+  const orgApplies = ownerInOrganization !== false;
   const orgVars: ScopeRead = orgApplies
-    ? namesFrom(probe(`repos/${slug}/actions/organization-variables${page}`), 'variables')
-    : new Set();
+    ? readScope(probe, `repos/${slug}/actions/organization-variables`, 'variables')
+    : EMPTY_SCOPE;
   const orgSecrets: ScopeRead = orgApplies
-    ? namesFrom(probe(`repos/${slug}/actions/organization-secrets${page}`), 'secrets')
-    : new Set();
+    ? readScope(probe, `repos/${slug}/actions/organization-secrets`, 'secrets')
+    : EMPTY_SCOPE;
 
   const appIdScope: LaneTokenScope | null = repoVars?.has(LANE_TOKEN_APP_ID_VARIABLE_NAME)
     ? 'repo'
     : orgVars?.has(LANE_TOKEN_APP_ID_VARIABLE_NAME)
       ? 'org'
       : null;
-  const appKeySeen =
+  const varsFullyRead = repoVars !== null && orgVars !== null;
+  const secretsFullyRead = repoSecrets !== null && orgSecrets !== null;
+  const keySeen =
     repoSecrets?.has(LANE_TOKEN_APP_KEY_SECRET_NAME) === true ||
     orgSecrets?.has(LANE_TOKEN_APP_KEY_SECRET_NAME) === true;
   const patScope: LaneTokenScope | null = repoSecrets?.has(LANE_TOKEN_PAT_SECRET_NAME)
@@ -131,63 +171,110 @@ export function probeLaneTokenTier(probe: ApiProbe, slug: string): LaneTokenTier
       ? 'org'
       : null;
 
-  // Positive evidence wins regardless of what else was unreadable: a tier
-  // seen is a tier the lane will use (the mint step keys on the same names).
-  if (appIdScope !== null && appKeySeen) {
+  // The workflow's mode expression picks App mode on the id ALONE, so the
+  // id's presence decides first, exactly as at runtime.
+  if (appIdScope !== null) {
+    if (keySeen) return { state: 'configured', tier: 'app', scope: appIdScope };
+    if (secretsFullyRead) {
+      return {
+        state: 'half-configured',
+        missing: 'app-private-key-secret',
+        evidence:
+          `the ${LANE_TOKEN_APP_ID_VARIABLE_NAME} variable is set (${appIdScope}-level) but no ` +
+          `${LANE_TOKEN_APP_KEY_SECRET_NAME} secret exists in the repo or org scope`,
+      };
+    }
     return {
-      state: 'configured',
-      tier: 'app',
-      scope: appIdScope,
-      evidence: `GitHub App tier: ${LANE_TOKEN_APP_ID_VARIABLE_NAME} (${appIdScope}-level) + ${LANE_TOKEN_APP_KEY_SECRET_NAME}`,
-    };
-  }
-  if (patScope !== null) {
-    return {
-      state: 'configured',
-      tier: 'pat',
-      scope: patScope,
-      evidence: `PAT tier: ${LANE_TOKEN_PAT_SECRET_NAME} (${patScope}-level secret)`,
+      state: 'unobservable',
+      cause: 'permissions',
+      reason:
+        `the ${LANE_TOKEN_APP_ID_VARIABLE_NAME} variable is set (${appIdScope}-level) but ` +
+        `${unreadableScopes(repoVars, repoSecrets, orgVars, orgSecrets)} could not be ` +
+        `enumerated with this token, so the ${LANE_TOKEN_APP_KEY_SECRET_NAME} secret ` +
+        `cannot be verified`,
     };
   }
 
+  // No id seen. A PAT is positive evidence of a working tier.
+  if (patScope !== null) return { state: 'configured', tier: 'pat', scope: patScope };
+
+  // The other half-configured direction: the key exists but the id is
+  // definitively absent, so the workflow never picks App mode.
+  if (keySeen && varsFullyRead) {
+    return {
+      state: 'half-configured',
+      missing: 'app-id-variable',
+      evidence:
+        `a ${LANE_TOKEN_APP_KEY_SECRET_NAME} secret exists but the ` +
+        `${LANE_TOKEN_APP_ID_VARIABLE_NAME} variable is absent from the repo and org scope`,
+    };
+  }
+
+  if (varsFullyRead && secretsFullyRead) {
+    return {
+      state: 'not-configured',
+      evidence:
+        `neither ${LANE_TOKEN_APP_ID_VARIABLE_NAME} + ${LANE_TOKEN_APP_KEY_SECRET_NAME} nor ` +
+        `${LANE_TOKEN_PAT_SECRET_NAME} is present in the repo or org scope`,
+    };
+  }
+
+  return {
+    state: 'unobservable',
+    cause: 'permissions',
+    reason:
+      `${unreadableScopes(repoVars, repoSecrets, orgVars, orgSecrets)} could not be enumerated ` +
+      `with this token (an org-level ${LANE_TOKEN_APP_ID_VARIABLE_NAME} / ` +
+      `${LANE_TOKEN_APP_KEY_SECRET_NAME} or ${LANE_TOKEN_PAT_SECRET_NAME} would be invisible here)`,
+  };
+}
+
+function unreadableScopes(
+  repoVars: ScopeRead,
+  repoSecrets: ScopeRead,
+  orgVars: ScopeRead,
+  orgSecrets: ScopeRead,
+): string {
   const unreadable: string[] = [];
   if (repoVars === null) unreadable.push('repo variables');
   if (repoSecrets === null) unreadable.push('repo secrets');
   if (orgVars === null) unreadable.push('org variables');
   if (orgSecrets === null) unreadable.push('org secrets');
-  if (unreadable.length > 0) {
-    return {
-      state: 'unobservable',
-      reason:
-        `could not enumerate ${unreadable.join(', ')} with this token (an org-level ` +
-        `${LANE_TOKEN_APP_ID_VARIABLE_NAME} / ${LANE_TOKEN_APP_KEY_SECRET_NAME} or ${LANE_TOKEN_PAT_SECRET_NAME} ` +
-        `would be invisible here); the lane run's "Disclose token mode" step shows the tier ` +
-        `actually used`,
-    };
-  }
-  return {
-    state: 'not-configured',
-    evidence:
-      `neither ${LANE_TOKEN_APP_ID_VARIABLE_NAME} + ${LANE_TOKEN_APP_KEY_SECRET_NAME} nor ` +
-      `${LANE_TOKEN_PAT_SECRET_NAME} is present in the repo or org scope`,
-  };
+  return unreadable.join(', ');
 }
 
 /**
- * The probe for a checkout: resolves the slug and the gh-backed probe,
- * both injectable. No GitHub repo or no gh CLI is `unobservable`, never a
+ * The probe for a checkout. `slug` / `ownerInOrganization` are injectable
+ * so a caller that already ran `repoView` (doctor resolves it once and
+ * shares it across its lane checks) never triggers a second gh shell; an
+ * explicit `slug: null` means "resolved, and there is none". No GitHub
+ * repo or no gh CLI is `unobservable` with cause `no-github`, never a
  * negative.
  */
 export function probeLaneTokenTierHere(
   cwd: string,
-  opts: { readonly probe?: ApiProbe; readonly slug?: string } = {},
+  opts: {
+    readonly probe?: ApiProbe;
+    readonly slug?: string | null;
+    readonly ownerInOrganization?: boolean | null;
+  } = {},
 ): LaneTokenTierProbe {
-  const slug = opts.slug ?? repoSlug(cwd);
+  let slug: string | null;
+  let ownerInOrganization: boolean | null;
+  if (opts.slug !== undefined) {
+    slug = opts.slug;
+    ownerInOrganization = opts.ownerInOrganization ?? null;
+  } else {
+    const view = repoView(cwd);
+    slug = view?.slug ?? null;
+    ownerInOrganization = opts.ownerInOrganization ?? view?.inOrganization ?? null;
+  }
   if (slug === null) {
     return {
       state: 'unobservable',
+      cause: 'no-github',
       reason: 'not a GitHub repo here, or the gh CLI is unavailable',
     };
   }
-  return probeLaneTokenTier(opts.probe ?? makeGhApiProbe(cwd), slug);
+  return probeLaneTokenTier(opts.probe ?? makeGhApiProbe(cwd), slug, ownerInOrganization);
 }

--- a/src/lanes/lane-token-probe.ts
+++ b/src/lanes/lane-token-probe.ts
@@ -1,0 +1,193 @@
+/**
+ * The ONE "is a lane token tier configured here?" probe (dxkit #325).
+ *
+ * The lanes resolve their tier at runtime from whatever GitHub exposes to
+ * the workflow (`LANE_TOKEN_MODE_EXPR` in lane-token.ts), and GitHub
+ * exposes BOTH repo-level and org-level Actions variables/secrets to a
+ * run. A local probe that lists only the repo scope therefore sees a
+ * strict subset of what the lane sees, and a probe whose token cannot
+ * enumerate a scope sees nothing at all. Folding either gap into "not
+ * configured" is the Rule 19 mistake applied to setup advice: an
+ * unobserved input cannot back a negative claim. The shipped symptom: an
+ * org that configured the App tier (and whose lane runs disclosed
+ * "token tier: GitHub App" the same day) was told by `doctor` to go
+ * configure it.
+ *
+ * So the answer is a TRI-STATE, and the negative is asserted only when
+ * every scope the lane could read was actually read:
+ *
+ *   - `configured`      a tier was seen (with which tier and in which scope);
+ *   - `not-configured`  every applicable scope was enumerated and none of
+ *                       the names is present: the remedy is honest;
+ *   - `unobservable`    some applicable scope could not be enumerated (a
+ *                       403/404 on the org endpoints, no admin scope, no
+ *                       gh, offline): "could not verify", with the scopes
+ *                       that were unreadable named, never a negative.
+ *
+ * The names probed come from lane-token.ts: this module holds no second
+ * tier table. Consumers: `doctor` (6d). The probe is injected so every
+ * state is testable without a network.
+ */
+
+import { type ApiProbe, makeGhApiProbe, repoSlug } from './delivery-preconditions';
+import {
+  LANE_TOKEN_APP_ID_VARIABLE_NAME,
+  LANE_TOKEN_APP_KEY_SECRET_NAME,
+  LANE_TOKEN_PAT_SECRET_NAME,
+} from './lane-token';
+
+export type LaneTokenTier = 'app' | 'pat';
+
+/** Where a configuration name lives; a run sees both. */
+export type LaneTokenScope = 'repo' | 'org';
+
+export type LaneTokenTierProbe =
+  | {
+      readonly state: 'configured';
+      readonly tier: LaneTokenTier;
+      /** The scope the deciding name was found in (`app`: the App id variable). */
+      readonly scope: LaneTokenScope;
+      readonly evidence: string;
+    }
+  | {
+      readonly state: 'not-configured';
+      readonly evidence: string;
+    }
+  | {
+      readonly state: 'unobservable';
+      /** Which scopes could not be enumerated, and so why no negative is asserted. */
+      readonly reason: string;
+    };
+
+/** The remedy for a genuinely absent tier, derived from the one name set. */
+export const LANE_TOKEN_REMEDY_COMMAND = `gh variable set ${LANE_TOKEN_APP_ID_VARIABLE_NAME} && gh secret set ${LANE_TOKEN_APP_KEY_SECRET_NAME}`;
+
+/** One scope's enumeration: the names seen, or null when unreadable. */
+type ScopeRead = ReadonlySet<string> | null;
+
+/** Names from an Actions list payload (`{ variables: [...] }` or
+ *  `{ secrets: [...] }`); null when the read failed or is unparseable. */
+function namesFrom(raw: string | null, key: 'variables' | 'secrets'): ScopeRead {
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const list = parsed[key];
+    if (!Array.isArray(list)) return null;
+    const names = new Set<string>();
+    for (const item of list) {
+      const name = (item as { name?: unknown })?.name;
+      if (typeof name === 'string') names.add(name);
+    }
+    return names;
+  } catch {
+    return null;
+  }
+}
+
+/** Is the repo owned by an organization? null when the API could not say
+ *  (then the org scopes are treated as applicable: the probe must not
+ *  assume "no org" to reach a negative). */
+function ownerIsOrganization(probe: ApiProbe, slug: string): boolean | null {
+  const raw = probe(`repos/${slug}`);
+  if (raw === null) return null;
+  try {
+    const type = (JSON.parse(raw) as { owner?: { type?: unknown } })?.owner?.type;
+    return typeof type === 'string' ? type === 'Organization' : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Probe the tier against the repo AND org scopes. Pure over the injected
+ * probe: every state is reachable from fixture payloads.
+ */
+export function probeLaneTokenTier(probe: ApiProbe, slug: string): LaneTokenTierProbe {
+  const page = '?per_page=100';
+  const repoVars = namesFrom(probe(`repos/${slug}/actions/variables${page}`), 'variables');
+  const repoSecrets = namesFrom(probe(`repos/${slug}/actions/secrets${page}`), 'secrets');
+
+  // A user-owned repo has no org scope: an unreadable org endpoint there is
+  // expected, not a gap. Only a CONFIRMED user owner narrows the scopes.
+  const orgApplies = ownerIsOrganization(probe, slug) !== false;
+  const orgVars: ScopeRead = orgApplies
+    ? namesFrom(probe(`repos/${slug}/actions/organization-variables${page}`), 'variables')
+    : new Set();
+  const orgSecrets: ScopeRead = orgApplies
+    ? namesFrom(probe(`repos/${slug}/actions/organization-secrets${page}`), 'secrets')
+    : new Set();
+
+  const appIdScope: LaneTokenScope | null = repoVars?.has(LANE_TOKEN_APP_ID_VARIABLE_NAME)
+    ? 'repo'
+    : orgVars?.has(LANE_TOKEN_APP_ID_VARIABLE_NAME)
+      ? 'org'
+      : null;
+  const appKeySeen =
+    repoSecrets?.has(LANE_TOKEN_APP_KEY_SECRET_NAME) === true ||
+    orgSecrets?.has(LANE_TOKEN_APP_KEY_SECRET_NAME) === true;
+  const patScope: LaneTokenScope | null = repoSecrets?.has(LANE_TOKEN_PAT_SECRET_NAME)
+    ? 'repo'
+    : orgSecrets?.has(LANE_TOKEN_PAT_SECRET_NAME)
+      ? 'org'
+      : null;
+
+  // Positive evidence wins regardless of what else was unreadable: a tier
+  // seen is a tier the lane will use (the mint step keys on the same names).
+  if (appIdScope !== null && appKeySeen) {
+    return {
+      state: 'configured',
+      tier: 'app',
+      scope: appIdScope,
+      evidence: `GitHub App tier: ${LANE_TOKEN_APP_ID_VARIABLE_NAME} (${appIdScope}-level) + ${LANE_TOKEN_APP_KEY_SECRET_NAME}`,
+    };
+  }
+  if (patScope !== null) {
+    return {
+      state: 'configured',
+      tier: 'pat',
+      scope: patScope,
+      evidence: `PAT tier: ${LANE_TOKEN_PAT_SECRET_NAME} (${patScope}-level secret)`,
+    };
+  }
+
+  const unreadable: string[] = [];
+  if (repoVars === null) unreadable.push('repo variables');
+  if (repoSecrets === null) unreadable.push('repo secrets');
+  if (orgVars === null) unreadable.push('org variables');
+  if (orgSecrets === null) unreadable.push('org secrets');
+  if (unreadable.length > 0) {
+    return {
+      state: 'unobservable',
+      reason:
+        `could not enumerate ${unreadable.join(', ')} with this token (an org-level ` +
+        `${LANE_TOKEN_APP_ID_VARIABLE_NAME} / ${LANE_TOKEN_APP_KEY_SECRET_NAME} or ${LANE_TOKEN_PAT_SECRET_NAME} ` +
+        `would be invisible here); the lane run's "Disclose token mode" step shows the tier ` +
+        `actually used`,
+    };
+  }
+  return {
+    state: 'not-configured',
+    evidence:
+      `neither ${LANE_TOKEN_APP_ID_VARIABLE_NAME} + ${LANE_TOKEN_APP_KEY_SECRET_NAME} nor ` +
+      `${LANE_TOKEN_PAT_SECRET_NAME} is present in the repo or org scope`,
+  };
+}
+
+/**
+ * The probe for a checkout: resolves the slug and the gh-backed probe,
+ * both injectable. No GitHub repo or no gh CLI is `unobservable`, never a
+ * negative.
+ */
+export function probeLaneTokenTierHere(
+  cwd: string,
+  opts: { readonly probe?: ApiProbe; readonly slug?: string } = {},
+): LaneTokenTierProbe {
+  const slug = opts.slug ?? repoSlug(cwd);
+  if (slug === null) {
+    return {
+      state: 'unobservable',
+      reason: 'not a GitHub repo here, or the gh CLI is unavailable',
+    };
+  }
+  return probeLaneTokenTier(opts.probe ?? makeGhApiProbe(cwd), slug);
+}

--- a/src/lanes/lane-token.ts
+++ b/src/lanes/lane-token.ts
@@ -24,9 +24,18 @@
  * declared exemptions, never a filename list.
  */
 
+/**
+ * The configuration NAMES each tier reads. One definition: the workflow
+ * text below, the doctor probe (`lane-token-probe.ts`) and every remedy
+ * string derive from these, so a rename cannot leave a consumer probing
+ * or advising a stale name.
+ */
+export const LANE_TOKEN_APP_ID_VARIABLE_NAME = 'DXKIT_APP_ID';
+export const LANE_TOKEN_APP_KEY_SECRET_NAME = 'DXKIT_APP_PRIVATE_KEY';
+export const LANE_TOKEN_PAT_SECRET_NAME = 'DXKIT_BOT_TOKEN';
+
 /** Tier chain for checkout credentials and gh calls: App → PAT → default. */
-export const LANE_TOKEN_CHAIN =
-  '${{ steps.dxkit-app-token.outputs.token || secrets.DXKIT_BOT_TOKEN || github.token }}';
+export const LANE_TOKEN_CHAIN = `\${{ steps.dxkit-app-token.outputs.token || secrets.${LANE_TOKEN_PAT_SECRET_NAME} || github.token }}`;
 
 /**
  * The remediate task step's chain: prefers the token re-minted immediately
@@ -35,13 +44,14 @@ export const LANE_TOKEN_CHAIN =
  * then falls through the standard tiers.
  */
 export const LANE_TOKEN_CHAIN_TASK =
-  '${{ steps.dxkit-app-token-task.outputs.token || steps.dxkit-app-token.outputs.token || ' +
-  'secrets.DXKIT_BOT_TOKEN || github.token }}';
+  `\${{ steps.dxkit-app-token-task.outputs.token || steps.dxkit-app-token.outputs.token || ` +
+  `secrets.${LANE_TOKEN_PAT_SECRET_NAME} || github.token }}`;
 
 /** The resolved tier, as an env value the CLI can branch on ('app' clamps
  *  the agent wall clock to the installation token's lifetime). */
 export const LANE_TOKEN_MODE_EXPR =
-  "${{ vars.DXKIT_APP_ID != '' && 'app' || (secrets.DXKIT_BOT_TOKEN != '' && 'pat' || 'workflow') }}";
+  `\${{ vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} != '' && 'app' || ` +
+  `(secrets.${LANE_TOKEN_PAT_SECRET_NAME} != '' && 'pat' || 'workflow') }}`;
 
 /**
  * The mint + disclose steps, placed before checkout in every chain-carrying
@@ -51,29 +61,29 @@ export const LANE_TOKEN_MODE_EXPR =
  */
 export const LANE_TOKEN_STEPS = `      # The lane token, tier chain: GitHub App installation token (minted
       # per run — no billed seat, one-hour lifetime), then the optional
-      # DXKIT_BOT_TOKEN PAT, then the default token (whose PRs and pushes
+      # ${LANE_TOKEN_PAT_SECRET_NAME} PAT, then the default token (whose PRs and pushes
       # never trigger workflow runs — disclosed below, never silent).
       # ONE definition: src/lanes/lane-token.ts substitutes this block and
       # every __DXKIT_LANE_TOKEN__ reference at install time.
       - name: Mint the lane token (GitHub App, when configured)
         id: dxkit-app-token
-        if: \${{ vars.DXKIT_APP_ID != '' }}
+        if: \${{ vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} != '' }}
         uses: actions/create-github-app-token@v2
         with:
-          app-id: \${{ vars.DXKIT_APP_ID }}
-          private-key: \${{ secrets.DXKIT_APP_PRIVATE_KEY }}
+          app-id: \${{ vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} }}
+          private-key: \${{ secrets.${LANE_TOKEN_APP_KEY_SECRET_NAME} }}
 
       - name: Disclose token mode
         env:
-          DXKIT_APP_SET: \${{ vars.DXKIT_APP_ID != '' }}
-          DXKIT_BOT_TOKEN_SET: \${{ secrets.DXKIT_BOT_TOKEN != '' }}
+          DXKIT_APP_SET: \${{ vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} != '' }}
+          ${LANE_TOKEN_PAT_SECRET_NAME}_SET: \${{ secrets.${LANE_TOKEN_PAT_SECRET_NAME} != '' }}
         run: |
           if [ "\${DXKIT_APP_SET}" = "true" ]; then
             echo "token tier: GitHub App (short-lived, minted this run)"
-          elif [ "\${DXKIT_BOT_TOKEN_SET}" = "true" ]; then
-            echo "token tier: DXKIT_BOT_TOKEN (PAT)"
+          elif [ "\${${LANE_TOKEN_PAT_SECRET_NAME}_SET}" = "true" ]; then
+            echo "token tier: ${LANE_TOKEN_PAT_SECRET_NAME} (PAT)"
           else
-            echo "::notice title=lane PRs run no checks::This lane pushes with the default GITHUB_TOKEN, and GitHub never triggers workflows for such pushes - the PR it opens will show no checks. Preferred fix: a GitHub App (set the DXKIT_APP_ID variable + the DXKIT_APP_PRIVATE_KEY secret - no billed seat, short-lived per-run tokens). A DXKIT_BOT_TOKEN PAT secret with repo scope also works."
+            echo "::notice title=lane PRs run no checks::This lane pushes with the default GITHUB_TOKEN, and GitHub never triggers workflows for such pushes - the PR it opens will show no checks. Preferred fix: a GitHub App (set the ${LANE_TOKEN_APP_ID_VARIABLE_NAME} variable + the ${LANE_TOKEN_APP_KEY_SECRET_NAME} secret - no billed seat, short-lived per-run tokens). A ${LANE_TOKEN_PAT_SECRET_NAME} PAT secret with repo scope also works."
           fi`;
 
 /**

--- a/src/lanes/lane-token.ts
+++ b/src/lanes/lane-token.ts
@@ -34,6 +34,16 @@ export const LANE_TOKEN_APP_ID_VARIABLE_NAME = 'DXKIT_APP_ID';
 export const LANE_TOKEN_APP_KEY_SECRET_NAME = 'DXKIT_APP_PRIVATE_KEY';
 export const LANE_TOKEN_PAT_SECRET_NAME = 'DXKIT_BOT_TOKEN';
 
+/**
+ * The remedy for a genuinely absent tier, and the per-half remedies for a
+ * half-configured App tier. Co-located with the names so every consumer
+ * (doctor, install notes, disclosures) derives its advice from the one
+ * definition instead of restating the names.
+ */
+export const LANE_TOKEN_REMEDY_COMMAND = `gh variable set ${LANE_TOKEN_APP_ID_VARIABLE_NAME} && gh secret set ${LANE_TOKEN_APP_KEY_SECRET_NAME}`;
+export const LANE_TOKEN_APP_ID_REMEDY_COMMAND = `gh variable set ${LANE_TOKEN_APP_ID_VARIABLE_NAME}`;
+export const LANE_TOKEN_APP_KEY_REMEDY_COMMAND = `gh secret set ${LANE_TOKEN_APP_KEY_SECRET_NAME}`;
+
 /** Tier chain for checkout credentials and gh calls: App → PAT → default. */
 export const LANE_TOKEN_CHAIN = `\${{ steps.dxkit-app-token.outputs.token || secrets.${LANE_TOKEN_PAT_SECRET_NAME} || github.token }}`;
 
@@ -87,13 +97,33 @@ export const LANE_TOKEN_STEPS = `      # The lane token, tier chain: GitHub App 
           fi`;
 
 /**
+ * The task-time RE-MINT step (the remediate lane): an App installation
+ * token is hard-capped at one hour by GitHub and the first mint happens
+ * before checkout + toolchain install, so a long agent budget could
+ * outlive it and 401 the landing push after the full agent spend.
+ * Rendered from the same name constants as the first mint; the template
+ * carries the __DXKIT_LANE_TOKEN_TASK_STEPS__ placeholder (it hardcoded
+ * these names once, which is exactly the drift this module exists to
+ * prevent). 6-space indentation matches the templates' step nesting.
+ */
+export const LANE_TOKEN_TASK_STEPS = `      - name: Re-mint the lane token before the task (App tier)
+        id: dxkit-app-token-task
+        if: \${{ vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: \${{ vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} }}
+          private-key: \${{ secrets.${LANE_TOKEN_APP_KEY_SECRET_NAME} }}`;
+
+/**
  * The substitution map the ONE workflow writer applies to EVERY template,
  * unconditionally — a callsite cannot forget it, and a template without
  * the placeholders is untouched (split/join no-op). Order matters only in
- * that keys never overlap; _TASK and _MODE sort before the bare token key
- * here so the bare key can never eat their prefixes.
+ * that keys never overlap; the longer _TASK_STEPS / _TASK / _MODE keys
+ * sort before the bare token key here so the bare key can never eat
+ * their prefixes.
  */
 export const LANE_TOKEN_SUBSTITUTIONS: Readonly<Record<string, string>> = {
+  __DXKIT_LANE_TOKEN_TASK_STEPS__: LANE_TOKEN_TASK_STEPS,
   __DXKIT_LANE_TOKEN_STEPS__: LANE_TOKEN_STEPS,
   __DXKIT_LANE_TOKEN_TASK__: LANE_TOKEN_CHAIN_TASK,
   __DXKIT_LANE_TOKEN_MODE__: LANE_TOKEN_MODE_EXPR,

--- a/src/remediate/budget-notes.ts
+++ b/src/remediate/budget-notes.ts
@@ -6,6 +6,7 @@
  * max_turns silently governed real spend).
  */
 
+import { LANE_TOKEN_PAT_SECRET_NAME } from '../lanes/lane-token';
 import type { AgentDriver } from './driver';
 import type { RemediateBudget } from './config';
 
@@ -43,7 +44,7 @@ export function clampBudgetToTokenLifetime(
       `maxMinutes ${budget.maxMinutes} clamped to ${APP_TOKEN_SAFE_MINUTES}: this lane pushes ` +
         `with a GitHub App installation token, which GitHub hard-caps at one hour, and the ` +
         `landing must fit inside it — a longer run would spend its full agent budget and then ` +
-        `fail to deliver. For longer runs use the DXKIT_BOT_TOKEN PAT tier or lower the budget.`,
+        `fail to deliver. For longer runs use the ${LANE_TOKEN_PAT_SECRET_NAME} PAT tier or lower the budget.`,
     ],
   };
 }

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -38,7 +38,7 @@ import {
 import { baselineRefreshCron, loadPolicyFromCwd } from './baseline/policy';
 import { cronFromCadence, DEFAULT_DEPBUMP_CRON } from './baseline/policy-sections';
 import { BOT_IDENTITY } from './land-refresh';
-import { LANE_TOKEN_SUBSTITUTIONS } from './lanes/lane-token';
+import { LANE_TOKEN_PAT_SECRET_NAME, LANE_TOKEN_SUBSTITUTIONS } from './lanes/lane-token';
 import { resolveRemediateConfig } from './remediate/config';
 import { driverById } from './remediate/registry';
 import { knownTaskIds } from './remediate/tasks';
@@ -1118,9 +1118,9 @@ export function installCiRemediate(cwd: string, opts: InstallerOpts = {}): ShipI
         `lands one standing PR per task. Set the ${
           driver?.credentialEnv.join(', ') || 'driver credential'
         } repo secret (a scoped key with a spend limit) before the first run. ` +
-        'Recommended: also set a DXKIT_BOT_TOKEN secret (a PAT with repo scope) — PRs ' +
-        'opened with the default GITHUB_TOKEN trigger no workflow runs, so they arrive ' +
-        'with no checks. See docs/getting-started.md "Lane credentials".',
+        `Recommended: also set a ${LANE_TOKEN_PAT_SECRET_NAME} secret (a PAT with repo scope), ` +
+        'since PRs opened with the default GITHUB_TOKEN trigger no workflow runs, so they ' +
+        'arrive with no checks. See docs/getting-started.md "Lane credentials".',
     );
   }
   return result;
@@ -1153,9 +1153,9 @@ export function installCiDepBump(cwd: string, opts: InstallerOpts = {}): ShipIns
         'Monday 07:00 UTC) it turns the fixable subset of dependency vulnerabilities into ' +
         'one standing PR (dxkit/dep-bump) — bumps from the scanners’ own fix versions, ' +
         'verified by the correctness floor + guardrail before opening. Majors are skipped ' +
-        'unless depBump.allowMajor. Recommended: set a DXKIT_BOT_TOKEN secret (a PAT with ' +
-        'repo scope) so the lane PR runs checks — default-token pushes trigger no ' +
-        'workflows. See docs/getting-started.md "Lane credentials".',
+        `unless depBump.allowMajor. Recommended: set a ${LANE_TOKEN_PAT_SECRET_NAME} secret ` +
+        '(a PAT with repo scope) so the lane PR runs checks; default-token pushes trigger ' +
+        'no workflows. See docs/getting-started.md "Lane credentials".',
     );
   }
   return result;

--- a/test/baseline/policy-schema.test.ts
+++ b/test/baseline/policy-schema.test.ts
@@ -96,17 +96,44 @@ describe('the generated scaffold conforms to the generated schema', () => {
 });
 
 /**
- * The reverse direction for the remediate block (4.4.5): every KNOB the
- * schema teaches has a row in the one metadata table, so `policy set`'s
- * knob index and the guide cannot silently miss a knob the editor shows.
- * The class this closes: taskBudgets / maxSpendPerRun / maxDispatchBudget /
+ * The reverse direction, whole schema (4.4.5): every KNOB the schema
+ * teaches has a row in the one metadata table, so `policy set`'s knob
+ * index and the guide cannot silently miss a knob the editor shows. The
+ * class this closes: taskBudgets / maxSpendPerRun / maxDispatchBudget /
  * resume shipped in the schema with hand-written descriptions and no
  * metadata row, invisible to the knob index and the guide.
  *
  * A leaf is a property node with no `properties` of its own; a container
  * whose shape is free-form (`additionalProperties` as a schema, e.g. the
  * per-task budget map) is a leaf too: the knob is the map, not its rows.
+ *
+ * A leaf deliberately absent from the table is a DECLARED exemption with a
+ * reason (the DEFERRED_KINDS discipline), never a silent omission.
  */
+const KNOB_INDEX_EXEMPT: Readonly<Record<string, string>> = {
+  $schema: 'editor-schema stamp written by the scaffold, not a knob',
+  id: 'policy identity name carried on verdict documents; file metadata, not a posture knob',
+  version: 'policy version stamp for verdict provenance; file metadata, not a posture knob',
+  'baseline.ref':
+    'companion ref for ref-based mode, taught inside the baseline-mode guide section; a ' +
+    'tuning detail of that knob, not an independent one',
+  'flow.specs':
+    'extension descriptor wiring for the flow gate; guardrail tuning of an adopted gate ' +
+    '(the Rule 16 carve-out), documented in the flow docs',
+  'flow.stripUrlPrefixes': 'flow-gate tuning of an adopted gate (the Rule 16 carve-out)',
+  'flow.blockThreshold': 'flow-gate tuning of an adopted gate (the Rule 16 carve-out)',
+  'flow.onMergeRefresh': 'flow-gate tuning of an adopted gate (the Rule 16 carve-out)',
+  'flow.refreshMode': 'flow-gate tuning of an adopted gate (the Rule 16 carve-out)',
+  'schema.specs':
+    'extension descriptor wiring for the schema-drift gate; tuning of an adopted gate',
+  'schema.blockThreshold': 'schema-drift-gate tuning of an adopted gate (the Rule 16 carve-out)',
+  'duplication.minScore': 'seam-gate tuning of an adopted gate (the Rule 16 carve-out)',
+  'duplication.minBodyTokens': 'seam-gate tuning of an adopted gate (the Rule 16 carve-out)',
+  'duplication.loneSeams': 'seam-gate tuning of an adopted gate (the Rule 16 carve-out)',
+  'loop.testCommand':
+    'postflight command override with per-pack defaults; tuning of the adopted loop gate',
+};
+
 function schemaLeafPaths(node: SchemaNode | undefined, prefix: string): string[] {
   if (!node?.properties) return prefix ? [prefix] : [];
   const out: string[] = [];
@@ -117,24 +144,41 @@ function schemaLeafPaths(node: SchemaNode | undefined, prefix: string): string[]
   return out;
 }
 
-function remediateKnobsMissingFrom(
+function knobsMissingFromIndex(
   schemaRoot: SchemaNode,
   params: readonly { readonly path: string }[],
+  exempt: Readonly<Record<string, string>>,
 ): string[] {
   const known = new Set(params.map((p) => p.path));
-  return schemaLeafPaths(schemaRoot.properties?.remediate, 'remediate').filter(
-    (p) => !known.has(p),
-  );
+  return schemaLeafPaths(schemaRoot, '').filter((p) => !known.has(p) && !(p in exempt));
 }
 
-describe('every remediate knob in the schema has a metadata row (knob index + guide parity)', () => {
-  it('no schema leaf under remediate is missing from POLICY_PARAMS', () => {
-    expect(remediateKnobsMissingFrom(schema, POLICY_PARAMS)).toEqual([]);
+describe('every schema knob has a metadata row or a declared exemption (knob index + guide parity)', () => {
+  it('no schema leaf is missing from POLICY_PARAMS without a reason', () => {
+    expect(knobsMissingFromIndex(schema, POLICY_PARAMS, KNOB_INDEX_EXEMPT)).toEqual([]);
+  });
+
+  it('exemptions are honest: each names a real schema leaf with a non-empty reason', () => {
+    const leaves = new Set(schemaLeafPaths(schema, ''));
+    for (const [path, reason] of Object.entries(KNOB_INDEX_EXEMPT)) {
+      expect(leaves.has(path), `KNOB_INDEX_EXEMPT names '${path}' which is not a schema leaf`).toBe(
+        true,
+      );
+      expect(reason.length, `empty reason for '${path}'`).toBeGreaterThan(10);
+    }
+  });
+
+  it('never both: an exempt path must not also carry a POLICY_PARAMS row', () => {
+    const known = new Set(POLICY_PARAMS.map((p) => p.path));
+    for (const path of Object.keys(KNOB_INDEX_EXEMPT)) {
+      expect(known.has(path), `'${path}' is both exempt and in POLICY_PARAMS`).toBe(false);
+    }
   });
 
   it('the parity check bites: an injected schema-only knob is reported', () => {
     const injected: SchemaNode = {
       properties: {
+        ...schema.properties,
         remediate: {
           properties: {
             ...schema.properties?.remediate?.properties,
@@ -143,6 +187,8 @@ describe('every remediate knob in the schema has a metadata row (knob index + gu
         },
       },
     };
-    expect(remediateKnobsMissingFrom(injected, POLICY_PARAMS)).toEqual(['remediate.syntheticKnob']);
+    expect(knobsMissingFromIndex(injected, POLICY_PARAMS, KNOB_INDEX_EXEMPT)).toEqual([
+      'remediate.syntheticKnob',
+    ]);
   });
 });

--- a/test/baseline/policy-schema.test.ts
+++ b/test/baseline/policy-schema.test.ts
@@ -94,3 +94,55 @@ describe('the generated scaffold conforms to the generated schema', () => {
     walk(parsed, '');
   });
 });
+
+/**
+ * The reverse direction for the remediate block (4.4.5): every KNOB the
+ * schema teaches has a row in the one metadata table, so `policy set`'s
+ * knob index and the guide cannot silently miss a knob the editor shows.
+ * The class this closes: taskBudgets / maxSpendPerRun / maxDispatchBudget /
+ * resume shipped in the schema with hand-written descriptions and no
+ * metadata row, invisible to the knob index and the guide.
+ *
+ * A leaf is a property node with no `properties` of its own; a container
+ * whose shape is free-form (`additionalProperties` as a schema, e.g. the
+ * per-task budget map) is a leaf too: the knob is the map, not its rows.
+ */
+function schemaLeafPaths(node: SchemaNode | undefined, prefix: string): string[] {
+  if (!node?.properties) return prefix ? [prefix] : [];
+  const out: string[] = [];
+  for (const [key, child] of Object.entries(node.properties)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    out.push(...schemaLeafPaths(child, path));
+  }
+  return out;
+}
+
+function remediateKnobsMissingFrom(
+  schemaRoot: SchemaNode,
+  params: readonly { readonly path: string }[],
+): string[] {
+  const known = new Set(params.map((p) => p.path));
+  return schemaLeafPaths(schemaRoot.properties?.remediate, 'remediate').filter(
+    (p) => !known.has(p),
+  );
+}
+
+describe('every remediate knob in the schema has a metadata row (knob index + guide parity)', () => {
+  it('no schema leaf under remediate is missing from POLICY_PARAMS', () => {
+    expect(remediateKnobsMissingFrom(schema, POLICY_PARAMS)).toEqual([]);
+  });
+
+  it('the parity check bites: an injected schema-only knob is reported', () => {
+    const injected: SchemaNode = {
+      properties: {
+        remediate: {
+          properties: {
+            ...schema.properties?.remediate?.properties,
+            syntheticKnob: { description: 'a knob with no metadata row' },
+          },
+        },
+      },
+    };
+    expect(remediateKnobsMissingFrom(injected, POLICY_PARAMS)).toEqual(['remediate.syntheticKnob']);
+  });
+});

--- a/test/lanes/lane-token-probe.test.ts
+++ b/test/lanes/lane-token-probe.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from 'vitest';
+import { probeLaneTokenTier, probeLaneTokenTierHere } from '../../src/lanes/lane-token-probe';
 import {
-  probeLaneTokenTier,
-  probeLaneTokenTierHere,
-  LANE_TOKEN_REMEDY_COMMAND,
-} from '../../src/lanes/lane-token-probe';
-import {
+  LANE_TOKEN_APP_ID_REMEDY_COMMAND,
   LANE_TOKEN_APP_ID_VARIABLE_NAME,
+  LANE_TOKEN_APP_KEY_REMEDY_COMMAND,
   LANE_TOKEN_APP_KEY_SECRET_NAME,
-  LANE_TOKEN_PAT_SECRET_NAME,
   LANE_TOKEN_MODE_EXPR,
+  LANE_TOKEN_PAT_SECRET_NAME,
+  LANE_TOKEN_REMEDY_COMMAND,
   LANE_TOKEN_STEPS,
+  LANE_TOKEN_TASK_STEPS,
 } from '../../src/lanes/lane-token';
 import { laneTokenTierCheck } from '../../src/doctor';
 import type { ApiProbe } from '../../src/lanes/delivery-preconditions';
@@ -17,48 +17,49 @@ import type { ApiProbe } from '../../src/lanes/delivery-preconditions';
 /**
  * dxkit #325: doctor asserted "no lane token tier is configured" when the
  * tier lived at the ORG level (or the token could not list it). The probe
- * is tri-state; these tests pin every state from fixture payloads and both
- * directions of the doctor rendering: configured-but-unreadable yields the
- * "could not verify" advice, genuinely absent yields the remedy.
+ * mirrors the workflow chain's precedence and answers configured /
+ * half-configured / not-configured / unobservable; these tests pin every
+ * state from fixture payloads, the pagination-honesty rule (a truncated
+ * listing can never back a negative), and both directions of the doctor
+ * rendering.
  */
 
 const SLUG = 'acme/widgets';
 
 type Payloads = Partial<Record<string, string | null>>;
 
-/** A gh-api stand-in: unlisted paths are unreachable (null), like a 403/404. */
+/** A gh-api stand-in keyed by path (query string stripped); unlisted paths
+ *  are unreachable (null), like a 403/404. */
 function fakeProbe(payloads: Payloads): ApiProbe {
   return (apiPath) => {
-    const key = apiPath.replace(/\?per_page=\d+$/, '');
+    const key = apiPath.replace(/\?.*$/, '');
     return key in payloads ? (payloads[key] ?? null) : null;
   };
 }
 
-const vars = (...names: string[]) => JSON.stringify({ variables: names.map((name) => ({ name })) });
+const vars = (...names: string[]) =>
+  JSON.stringify({ total_count: names.length, variables: names.map((name) => ({ name })) });
 const secrets = (...names: string[]) =>
-  JSON.stringify({ secrets: names.map((name) => ({ name })) });
-const orgOwner = JSON.stringify({ owner: { type: 'Organization' } });
-const userOwner = JSON.stringify({ owner: { type: 'User' } });
+  JSON.stringify({ total_count: names.length, secrets: names.map((name) => ({ name })) });
 
 const P = {
-  repo: `repos/${SLUG}`,
   repoVars: `repos/${SLUG}/actions/variables`,
   repoSecrets: `repos/${SLUG}/actions/secrets`,
   orgVars: `repos/${SLUG}/actions/organization-variables`,
   orgSecrets: `repos/${SLUG}/actions/organization-secrets`,
 };
 
-describe('probeLaneTokenTier: the three states', () => {
+describe('probeLaneTokenTier: the states', () => {
   it('org-level App tier reads as configured (the #325 repro)', () => {
     const r = probeLaneTokenTier(
       fakeProbe({
-        [P.repo]: orgOwner,
         [P.repoVars]: vars(),
         [P.repoSecrets]: secrets(),
         [P.orgVars]: vars(LANE_TOKEN_APP_ID_VARIABLE_NAME),
         [P.orgSecrets]: secrets(LANE_TOKEN_APP_KEY_SECRET_NAME),
       }),
       SLUG,
+      true,
     );
     expect(r).toMatchObject({ state: 'configured', tier: 'app', scope: 'org' });
   });
@@ -66,54 +67,56 @@ describe('probeLaneTokenTier: the three states', () => {
   it('repo-level PAT tier reads as configured', () => {
     const r = probeLaneTokenTier(
       fakeProbe({
-        [P.repo]: orgOwner,
         [P.repoVars]: vars(),
         [P.repoSecrets]: secrets(LANE_TOKEN_PAT_SECRET_NAME),
         [P.orgVars]: vars(),
         [P.orgSecrets]: secrets(),
       }),
       SLUG,
+      true,
     );
     expect(r).toMatchObject({ state: 'configured', tier: 'pat', scope: 'repo' });
+  });
+
+  it('a repo-level App tier short-circuits the org reads', () => {
+    let orgReads = 0;
+    const probe: ApiProbe = (apiPath) => {
+      if (apiPath.includes('organization-')) {
+        orgReads++;
+        return null;
+      }
+      if (apiPath.includes('/variables')) return vars(LANE_TOKEN_APP_ID_VARIABLE_NAME);
+      return secrets(LANE_TOKEN_APP_KEY_SECRET_NAME);
+    };
+    const r = probeLaneTokenTier(probe, SLUG, true);
+    expect(r).toMatchObject({ state: 'configured', tier: 'app', scope: 'repo' });
+    expect(orgReads).toBe(0);
   });
 
   it('the App id split across scopes (org variable, repo secret) still reads as configured', () => {
     const r = probeLaneTokenTier(
       fakeProbe({
-        [P.repo]: orgOwner,
         [P.repoVars]: vars(),
         [P.repoSecrets]: secrets(LANE_TOKEN_APP_KEY_SECRET_NAME),
         [P.orgVars]: vars(LANE_TOKEN_APP_ID_VARIABLE_NAME),
         [P.orgSecrets]: secrets(),
       }),
       SLUG,
+      true,
     );
     expect(r).toMatchObject({ state: 'configured', tier: 'app', scope: 'org' });
   });
 
-  it('a configured tier wins even when another scope is unreadable', () => {
+  it('every applicable scope fully enumerated and empty is the only way to reach not-configured', () => {
     const r = probeLaneTokenTier(
       fakeProbe({
-        [P.repo]: orgOwner,
-        [P.repoVars]: vars(LANE_TOKEN_APP_ID_VARIABLE_NAME),
-        [P.repoSecrets]: secrets(LANE_TOKEN_APP_KEY_SECRET_NAME),
-        // org endpoints 403 (unlisted)
-      }),
-      SLUG,
-    );
-    expect(r).toMatchObject({ state: 'configured', tier: 'app', scope: 'repo' });
-  });
-
-  it('every applicable scope enumerated and empty is the only way to reach not-configured', () => {
-    const r = probeLaneTokenTier(
-      fakeProbe({
-        [P.repo]: orgOwner,
         [P.repoVars]: vars('OTHER'),
         [P.repoSecrets]: secrets('NPM_TOKEN'),
         [P.orgVars]: vars(),
         [P.orgSecrets]: secrets(),
       }),
       SLUG,
+      true,
     );
     expect(r.state).toBe('not-configured');
   });
@@ -121,111 +124,191 @@ describe('probeLaneTokenTier: the three states', () => {
   it('repo scopes empty + org scopes unreadable is UNOBSERVABLE, never absent (the #325 bug)', () => {
     const r = probeLaneTokenTier(
       fakeProbe({
-        [P.repo]: orgOwner,
         [P.repoVars]: vars(),
         [P.repoSecrets]: secrets(),
         // org endpoints 403/404 (unlisted)
       }),
       SLUG,
+      true,
     );
     expect(r.state).toBe('unobservable');
     if (r.state === 'unobservable') {
+      expect(r.cause).toBe('permissions');
       expect(r.reason).toContain('org variables');
       expect(r.reason).toContain('org secrets');
       expect(r.reason).not.toContain('repo variables');
     }
   });
 
-  it('an unknown owner type keeps the org scopes applicable (no negative from an assumption)', () => {
+  it('an unknown owner shape keeps the org scopes applicable (no negative from an assumption)', () => {
     const r = probeLaneTokenTier(
-      fakeProbe({
-        // repos/{slug} unreachable
-        [P.repoVars]: vars(),
-        [P.repoSecrets]: secrets(),
-      }),
+      fakeProbe({ [P.repoVars]: vars(), [P.repoSecrets]: secrets() }),
       SLUG,
+      null,
     );
     expect(r.state).toBe('unobservable');
   });
 
   it('a user-owned repo has no org scope: empty repo scopes are a genuine absence', () => {
     const r = probeLaneTokenTier(
-      fakeProbe({
-        [P.repo]: userOwner,
-        [P.repoVars]: vars(),
-        [P.repoSecrets]: secrets(),
-      }),
+      fakeProbe({ [P.repoVars]: vars(), [P.repoSecrets]: secrets() }),
       SLUG,
+      false,
     );
     expect(r.state).toBe('not-configured');
-  });
-
-  it('the App id without its key, with secrets unreadable, is unobservable', () => {
-    const r = probeLaneTokenTier(
-      fakeProbe({
-        [P.repo]: orgOwner,
-        [P.repoVars]: vars(LANE_TOKEN_APP_ID_VARIABLE_NAME),
-        [P.orgVars]: vars(),
-      }),
-      SLUG,
-    );
-    expect(r.state).toBe('unobservable');
   });
 
   it('an unparseable payload counts as unreadable', () => {
     const r = probeLaneTokenTier(
       fakeProbe({
-        [P.repo]: orgOwner,
         [P.repoVars]: 'not json',
         [P.repoSecrets]: secrets(),
         [P.orgVars]: vars(),
         [P.orgSecrets]: secrets(),
       }),
       SLUG,
+      true,
     );
-    expect(r).toMatchObject({ state: 'unobservable' });
+    expect(r).toMatchObject({ state: 'unobservable', cause: 'permissions' });
     if (r.state === 'unobservable') expect(r.reason).toContain('repo variables');
   });
+});
 
-  it('no GitHub repo / no gh is unobservable', () => {
-    const r = probeLaneTokenTierHere('/nonexistent', {
-      probe: () => null,
-      slug: undefined,
-    });
-    // repoSlug on a nonexistent dir fails -> null slug
-    expect(r.state).toBe('unobservable');
+describe('half-configured App tier, both directions', () => {
+  it('the id without the key is half-configured (the mint step dies loudly)', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repoVars]: vars(LANE_TOKEN_APP_ID_VARIABLE_NAME),
+        [P.repoSecrets]: secrets(),
+        [P.orgVars]: vars(),
+        [P.orgSecrets]: secrets(),
+      }),
+      SLUG,
+      true,
+    );
+    expect(r).toMatchObject({ state: 'half-configured', missing: 'app-private-key-secret' });
   });
 
-  it('probeLaneTokenTierHere routes an injected slug + probe to the pure probe', () => {
-    const r = probeLaneTokenTierHere('/nonexistent', {
-      slug: SLUG,
-      probe: fakeProbe({
-        [P.repo]: orgOwner,
-        [P.repoVars]: vars(),
+  it('the id wins over a present PAT, mirroring the mode expression precedence', () => {
+    // The workflow picks App mode on the id alone: a half-configured App
+    // tier breaks lane runs even when a PAT is also set.
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repoVars]: vars(LANE_TOKEN_APP_ID_VARIABLE_NAME),
         [P.repoSecrets]: secrets(LANE_TOKEN_PAT_SECRET_NAME),
         [P.orgVars]: vars(),
         [P.orgSecrets]: secrets(),
+      }),
+      SLUG,
+      true,
+    );
+    expect(r).toMatchObject({ state: 'half-configured', missing: 'app-private-key-secret' });
+  });
+
+  it('the key without the id is half-configured (App mode is never picked)', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repoVars]: vars(),
+        [P.repoSecrets]: secrets(LANE_TOKEN_APP_KEY_SECRET_NAME),
+        [P.orgVars]: vars(),
+        [P.orgSecrets]: secrets(),
+      }),
+      SLUG,
+      true,
+    );
+    expect(r).toMatchObject({ state: 'half-configured', missing: 'app-id-variable' });
+  });
+
+  it('the id with UNREADABLE secret scopes is unobservable, not half-configured', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repoVars]: vars(LANE_TOKEN_APP_ID_VARIABLE_NAME),
+        [P.orgVars]: vars(),
+        // both secret scopes unreadable
+      }),
+      SLUG,
+      true,
+    );
+    expect(r).toMatchObject({ state: 'unobservable', cause: 'permissions' });
+    if (r.state === 'unobservable') expect(r.reason).toContain(LANE_TOKEN_APP_KEY_SECRET_NAME);
+  });
+});
+
+describe('pagination honesty (the #325 class one page deeper)', () => {
+  const fill = (n: number, prefix: string) => Array.from({ length: n }, (_, i) => `${prefix}_${i}`);
+
+  it('a name past the first variables page (GitHub caps at 30) is still found', () => {
+    const all = [...fill(30, 'V'), LANE_TOKEN_APP_ID_VARIABLE_NAME];
+    const probe: ApiProbe = (apiPath) => {
+      if (apiPath.startsWith(`${P.repoVars}?`)) {
+        const page = Number(/page=(\d+)$/.exec(apiPath)?.[1] ?? '1');
+        const slice = all.slice((page - 1) * 30, page * 30);
+        return JSON.stringify({
+          total_count: all.length,
+          variables: slice.map((name) => ({ name })),
+        });
+      }
+      if (apiPath.startsWith(`${P.repoSecrets}?`)) return secrets(LANE_TOKEN_APP_KEY_SECRET_NAME);
+      return null;
+    };
+    const r = probeLaneTokenTier(probe, SLUG, true);
+    expect(r).toMatchObject({ state: 'configured', tier: 'app', scope: 'repo' });
+  });
+
+  it('a TRUNCATED listing (total_count never accounted for) reads as unobservable, never as absence', () => {
+    const probe: ApiProbe = (apiPath) => {
+      if (apiPath.startsWith(`${P.repoVars}?`)) {
+        // Claims 31 variables but only ever serves the same first page.
+        return JSON.stringify({
+          total_count: 31,
+          variables: fill(30, 'V').map((name) => ({ name })),
+        });
+      }
+      if (apiPath.startsWith(`${P.repoSecrets}?`)) return secrets();
+      if (apiPath.includes('organization-variables')) return vars();
+      if (apiPath.includes('organization-secrets')) return secrets();
+      return null;
+    };
+    const r = probeLaneTokenTier(probe, SLUG, true);
+    expect(r).toMatchObject({ state: 'unobservable', cause: 'permissions' });
+    if (r.state === 'unobservable') expect(r.reason).toContain('repo variables');
+  });
+});
+
+describe('probeLaneTokenTierHere', () => {
+  it('an explicit null slug (no GitHub repo resolved) is unobservable with cause no-github', () => {
+    const r = probeLaneTokenTierHere('/nonexistent', { probe: () => null, slug: null });
+    expect(r).toMatchObject({ state: 'unobservable', cause: 'no-github' });
+  });
+
+  it('routes an injected slug + owner shape + probe to the pure probe', () => {
+    const r = probeLaneTokenTierHere('/nonexistent', {
+      slug: SLUG,
+      ownerInOrganization: false,
+      probe: fakeProbe({
+        [P.repoVars]: vars(),
+        [P.repoSecrets]: secrets(LANE_TOKEN_PAT_SECRET_NAME),
       }),
     });
     expect(r).toMatchObject({ state: 'configured', tier: 'pat' });
   });
 });
 
-describe('one name set: the probe and the workflow chain read the same names', () => {
-  it('the mode expression and mint step use the constants the probe reads', () => {
+describe('one name set: probe, workflow chain, and remedies read the same names', () => {
+  it('the mode expression and mint steps use the constants the probe reads', () => {
     expect(LANE_TOKEN_MODE_EXPR).toContain(`vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME}`);
     expect(LANE_TOKEN_MODE_EXPR).toContain(`secrets.${LANE_TOKEN_PAT_SECRET_NAME}`);
     expect(LANE_TOKEN_STEPS).toContain(`secrets.${LANE_TOKEN_APP_KEY_SECRET_NAME}`);
+    expect(LANE_TOKEN_TASK_STEPS).toContain(`vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME}`);
+    expect(LANE_TOKEN_TASK_STEPS).toContain(`secrets.${LANE_TOKEN_APP_KEY_SECRET_NAME}`);
     expect(LANE_TOKEN_REMEDY_COMMAND).toContain(LANE_TOKEN_APP_ID_VARIABLE_NAME);
     expect(LANE_TOKEN_REMEDY_COMMAND).toContain(LANE_TOKEN_APP_KEY_SECRET_NAME);
   });
 });
 
-describe('doctor rendering (laneTokenTierCheck), both directions', () => {
+describe('doctor rendering (laneTokenTierCheck), every state', () => {
   it('configured: no finding', () => {
-    expect(
-      laneTokenTierCheck({ state: 'configured', tier: 'app', scope: 'org', evidence: 'x' }),
-    ).toBeNull();
+    expect(laneTokenTierCheck({ state: 'configured', tier: 'app', scope: 'org' })).toBeNull();
   });
 
   it('not-configured: the red finding with the remedy command', () => {
@@ -237,10 +320,35 @@ describe('doctor rendering (laneTokenTierCheck), both directions', () => {
     expect(c!.fix?.command).toBe(LANE_TOKEN_REMEDY_COMMAND);
   });
 
-  it('unobservable: "could not be verified" advice, never the negative assertion', () => {
+  it('half-configured (missing key): red, names the missing half, remedies the key', () => {
+    const c = laneTokenTierCheck({
+      state: 'half-configured',
+      missing: 'app-private-key-secret',
+      evidence: 'id set, key absent',
+    });
+    expect(c).not.toBeNull();
+    expect(c!.ok).toBe(false);
+    expect(c!.advisory).toBeUndefined();
+    expect(c!.label).toContain(`${LANE_TOKEN_APP_KEY_SECRET_NAME} secret is missing`);
+    expect(c!.fix?.command).toBe(LANE_TOKEN_APP_KEY_REMEDY_COMMAND);
+  });
+
+  it('half-configured (missing id): red, names the missing half, remedies the variable', () => {
+    const c = laneTokenTierCheck({
+      state: 'half-configured',
+      missing: 'app-id-variable',
+      evidence: 'key set, id absent',
+    });
+    expect(c).not.toBeNull();
+    expect(c!.label).toContain(`${LANE_TOKEN_APP_ID_VARIABLE_NAME} variable is missing`);
+    expect(c!.fix?.command).toBe(LANE_TOKEN_APP_ID_REMEDY_COMMAND);
+  });
+
+  it('unobservable (permissions): "could not be verified" advice, never the negative assertion', () => {
     const c = laneTokenTierCheck({
       state: 'unobservable',
-      reason: 'could not enumerate org variables',
+      cause: 'permissions',
+      reason: 'org variables, org secrets could not be enumerated with this token',
     });
     expect(c).not.toBeNull();
     expect(c!.advisory).toBe(true);
@@ -250,5 +358,15 @@ describe('doctor rendering (laneTokenTierCheck), both directions', () => {
     expect(c!.fix?.hint).toContain('Disclose token mode');
     // Advice carries no "go configure it" command: the tier may already exist.
     expect(c!.fix?.command).toBeUndefined();
+  });
+
+  it('unobservable (no-github): SILENT, the pre-#325 fail-open contract', () => {
+    expect(
+      laneTokenTierCheck({
+        state: 'unobservable',
+        cause: 'no-github',
+        reason: 'not a GitHub repo here, or the gh CLI is unavailable',
+      }),
+    ).toBeNull();
   });
 });

--- a/test/lanes/lane-token-probe.test.ts
+++ b/test/lanes/lane-token-probe.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest';
+import {
+  probeLaneTokenTier,
+  probeLaneTokenTierHere,
+  LANE_TOKEN_REMEDY_COMMAND,
+} from '../../src/lanes/lane-token-probe';
+import {
+  LANE_TOKEN_APP_ID_VARIABLE_NAME,
+  LANE_TOKEN_APP_KEY_SECRET_NAME,
+  LANE_TOKEN_PAT_SECRET_NAME,
+  LANE_TOKEN_MODE_EXPR,
+  LANE_TOKEN_STEPS,
+} from '../../src/lanes/lane-token';
+import { laneTokenTierCheck } from '../../src/doctor';
+import type { ApiProbe } from '../../src/lanes/delivery-preconditions';
+
+/**
+ * dxkit #325: doctor asserted "no lane token tier is configured" when the
+ * tier lived at the ORG level (or the token could not list it). The probe
+ * is tri-state; these tests pin every state from fixture payloads and both
+ * directions of the doctor rendering: configured-but-unreadable yields the
+ * "could not verify" advice, genuinely absent yields the remedy.
+ */
+
+const SLUG = 'acme/widgets';
+
+type Payloads = Partial<Record<string, string | null>>;
+
+/** A gh-api stand-in: unlisted paths are unreachable (null), like a 403/404. */
+function fakeProbe(payloads: Payloads): ApiProbe {
+  return (apiPath) => {
+    const key = apiPath.replace(/\?per_page=\d+$/, '');
+    return key in payloads ? (payloads[key] ?? null) : null;
+  };
+}
+
+const vars = (...names: string[]) => JSON.stringify({ variables: names.map((name) => ({ name })) });
+const secrets = (...names: string[]) =>
+  JSON.stringify({ secrets: names.map((name) => ({ name })) });
+const orgOwner = JSON.stringify({ owner: { type: 'Organization' } });
+const userOwner = JSON.stringify({ owner: { type: 'User' } });
+
+const P = {
+  repo: `repos/${SLUG}`,
+  repoVars: `repos/${SLUG}/actions/variables`,
+  repoSecrets: `repos/${SLUG}/actions/secrets`,
+  orgVars: `repos/${SLUG}/actions/organization-variables`,
+  orgSecrets: `repos/${SLUG}/actions/organization-secrets`,
+};
+
+describe('probeLaneTokenTier: the three states', () => {
+  it('org-level App tier reads as configured (the #325 repro)', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repo]: orgOwner,
+        [P.repoVars]: vars(),
+        [P.repoSecrets]: secrets(),
+        [P.orgVars]: vars(LANE_TOKEN_APP_ID_VARIABLE_NAME),
+        [P.orgSecrets]: secrets(LANE_TOKEN_APP_KEY_SECRET_NAME),
+      }),
+      SLUG,
+    );
+    expect(r).toMatchObject({ state: 'configured', tier: 'app', scope: 'org' });
+  });
+
+  it('repo-level PAT tier reads as configured', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repo]: orgOwner,
+        [P.repoVars]: vars(),
+        [P.repoSecrets]: secrets(LANE_TOKEN_PAT_SECRET_NAME),
+        [P.orgVars]: vars(),
+        [P.orgSecrets]: secrets(),
+      }),
+      SLUG,
+    );
+    expect(r).toMatchObject({ state: 'configured', tier: 'pat', scope: 'repo' });
+  });
+
+  it('the App id split across scopes (org variable, repo secret) still reads as configured', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repo]: orgOwner,
+        [P.repoVars]: vars(),
+        [P.repoSecrets]: secrets(LANE_TOKEN_APP_KEY_SECRET_NAME),
+        [P.orgVars]: vars(LANE_TOKEN_APP_ID_VARIABLE_NAME),
+        [P.orgSecrets]: secrets(),
+      }),
+      SLUG,
+    );
+    expect(r).toMatchObject({ state: 'configured', tier: 'app', scope: 'org' });
+  });
+
+  it('a configured tier wins even when another scope is unreadable', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repo]: orgOwner,
+        [P.repoVars]: vars(LANE_TOKEN_APP_ID_VARIABLE_NAME),
+        [P.repoSecrets]: secrets(LANE_TOKEN_APP_KEY_SECRET_NAME),
+        // org endpoints 403 (unlisted)
+      }),
+      SLUG,
+    );
+    expect(r).toMatchObject({ state: 'configured', tier: 'app', scope: 'repo' });
+  });
+
+  it('every applicable scope enumerated and empty is the only way to reach not-configured', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repo]: orgOwner,
+        [P.repoVars]: vars('OTHER'),
+        [P.repoSecrets]: secrets('NPM_TOKEN'),
+        [P.orgVars]: vars(),
+        [P.orgSecrets]: secrets(),
+      }),
+      SLUG,
+    );
+    expect(r.state).toBe('not-configured');
+  });
+
+  it('repo scopes empty + org scopes unreadable is UNOBSERVABLE, never absent (the #325 bug)', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repo]: orgOwner,
+        [P.repoVars]: vars(),
+        [P.repoSecrets]: secrets(),
+        // org endpoints 403/404 (unlisted)
+      }),
+      SLUG,
+    );
+    expect(r.state).toBe('unobservable');
+    if (r.state === 'unobservable') {
+      expect(r.reason).toContain('org variables');
+      expect(r.reason).toContain('org secrets');
+      expect(r.reason).not.toContain('repo variables');
+    }
+  });
+
+  it('an unknown owner type keeps the org scopes applicable (no negative from an assumption)', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        // repos/{slug} unreachable
+        [P.repoVars]: vars(),
+        [P.repoSecrets]: secrets(),
+      }),
+      SLUG,
+    );
+    expect(r.state).toBe('unobservable');
+  });
+
+  it('a user-owned repo has no org scope: empty repo scopes are a genuine absence', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repo]: userOwner,
+        [P.repoVars]: vars(),
+        [P.repoSecrets]: secrets(),
+      }),
+      SLUG,
+    );
+    expect(r.state).toBe('not-configured');
+  });
+
+  it('the App id without its key, with secrets unreadable, is unobservable', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repo]: orgOwner,
+        [P.repoVars]: vars(LANE_TOKEN_APP_ID_VARIABLE_NAME),
+        [P.orgVars]: vars(),
+      }),
+      SLUG,
+    );
+    expect(r.state).toBe('unobservable');
+  });
+
+  it('an unparseable payload counts as unreadable', () => {
+    const r = probeLaneTokenTier(
+      fakeProbe({
+        [P.repo]: orgOwner,
+        [P.repoVars]: 'not json',
+        [P.repoSecrets]: secrets(),
+        [P.orgVars]: vars(),
+        [P.orgSecrets]: secrets(),
+      }),
+      SLUG,
+    );
+    expect(r).toMatchObject({ state: 'unobservable' });
+    if (r.state === 'unobservable') expect(r.reason).toContain('repo variables');
+  });
+
+  it('no GitHub repo / no gh is unobservable', () => {
+    const r = probeLaneTokenTierHere('/nonexistent', {
+      probe: () => null,
+      slug: undefined,
+    });
+    // repoSlug on a nonexistent dir fails -> null slug
+    expect(r.state).toBe('unobservable');
+  });
+
+  it('probeLaneTokenTierHere routes an injected slug + probe to the pure probe', () => {
+    const r = probeLaneTokenTierHere('/nonexistent', {
+      slug: SLUG,
+      probe: fakeProbe({
+        [P.repo]: orgOwner,
+        [P.repoVars]: vars(),
+        [P.repoSecrets]: secrets(LANE_TOKEN_PAT_SECRET_NAME),
+        [P.orgVars]: vars(),
+        [P.orgSecrets]: secrets(),
+      }),
+    });
+    expect(r).toMatchObject({ state: 'configured', tier: 'pat' });
+  });
+});
+
+describe('one name set: the probe and the workflow chain read the same names', () => {
+  it('the mode expression and mint step use the constants the probe reads', () => {
+    expect(LANE_TOKEN_MODE_EXPR).toContain(`vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME}`);
+    expect(LANE_TOKEN_MODE_EXPR).toContain(`secrets.${LANE_TOKEN_PAT_SECRET_NAME}`);
+    expect(LANE_TOKEN_STEPS).toContain(`secrets.${LANE_TOKEN_APP_KEY_SECRET_NAME}`);
+    expect(LANE_TOKEN_REMEDY_COMMAND).toContain(LANE_TOKEN_APP_ID_VARIABLE_NAME);
+    expect(LANE_TOKEN_REMEDY_COMMAND).toContain(LANE_TOKEN_APP_KEY_SECRET_NAME);
+  });
+});
+
+describe('doctor rendering (laneTokenTierCheck), both directions', () => {
+  it('configured: no finding', () => {
+    expect(
+      laneTokenTierCheck({ state: 'configured', tier: 'app', scope: 'org', evidence: 'x' }),
+    ).toBeNull();
+  });
+
+  it('not-configured: the red finding with the remedy command', () => {
+    const c = laneTokenTierCheck({ state: 'not-configured', evidence: 'nothing present' });
+    expect(c).not.toBeNull();
+    expect(c!.ok).toBe(false);
+    expect(c!.advisory).toBeUndefined();
+    expect(c!.label).toContain('no lane token tier is configured');
+    expect(c!.fix?.command).toBe(LANE_TOKEN_REMEDY_COMMAND);
+  });
+
+  it('unobservable: "could not be verified" advice, never the negative assertion', () => {
+    const c = laneTokenTierCheck({
+      state: 'unobservable',
+      reason: 'could not enumerate org variables',
+    });
+    expect(c).not.toBeNull();
+    expect(c!.advisory).toBe(true);
+    expect(c!.label).toContain('could not be verified');
+    expect(c!.label).not.toContain('no lane token tier is configured');
+    expect(c!.fix?.hint).toContain('org variables');
+    expect(c!.fix?.hint).toContain('Disclose token mode');
+    // Advice carries no "go configure it" command: the tier may already exist.
+    expect(c!.fix?.command).toBeUndefined();
+  });
+});

--- a/test/templates-lane-tokens.test.ts
+++ b/test/templates-lane-tokens.test.ts
@@ -25,9 +25,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
 import {
+  LANE_TOKEN_APP_ID_VARIABLE_NAME,
+  LANE_TOKEN_APP_KEY_SECRET_NAME,
   LANE_TOKEN_CHAIN,
+  LANE_TOKEN_PAT_SECRET_NAME,
   LANE_TOKEN_STEPS,
   LANE_TOKEN_SUBSTITUTIONS,
+  LANE_TOKEN_TASK_STEPS,
 } from '../src/lanes/lane-token';
 
 const WORKFLOWS = path.join(__dirname, '..', 'src-templates', '.github', 'workflows');
@@ -262,8 +266,12 @@ describe('workflow-template token discipline', () => {
     // keep the single top-of-job mint.
     const content = fs.readFileSync(path.join(WORKFLOWS, 'dxkit-remediate.yml'), 'utf8');
     // A fresh mint gated on the same App variable, immediately before the
-    // task step — the hour starts at agent launch, not at job start.
-    expect(content).toContain('id: dxkit-app-token-task');
+    // task step (the hour starts at agent launch, not at job start). The
+    // step arrives via the __DXKIT_LANE_TOKEN_TASK_STEPS__ placeholder
+    // (the raw template holds no hand-copied mint), so assert on the
+    // RENDERED content.
+    expect(content).toContain('__DXKIT_LANE_TOKEN_TASK_STEPS__');
+    expect(renderForParse(content)).toContain('id: dxkit-app-token-task');
     // ONE credential writer (the live 4.4.3 class): checkout v6 persists
     // its credential where `git config --unset-all` cannot reliably reach,
     // and a second Authorization source makes GitHub 400 the landing push
@@ -296,14 +304,73 @@ describe('workflow-template token discipline', () => {
     expect(content).toContain('GH_TOKEN: __DXKIT_LANE_TOKEN_TASK__');
     expect(content).toContain('DXKIT_TOKEN_MODE: __DXKIT_LANE_TOKEN_MODE__');
     // Ordering: agent-CLI install → re-mint → credential refresh → task, so
-    // setup time cannot eat the token's hour.
-    const install = content.indexOf('Install the agent CLI');
-    const remint = content.indexOf('id: dxkit-app-token-task');
-    const refresh = content.indexOf('- name: Install the landing credential');
-    const task = content.indexOf('Run task ${{ matrix.task }}');
+    // setup time cannot eat the token's hour. The re-mint step exists only
+    // after substitution, so order over the RENDERED content.
+    const rendered = renderForParse(content);
+    const install = rendered.indexOf('Install the agent CLI');
+    const remint = rendered.indexOf('id: dxkit-app-token-task');
+    const refresh = rendered.indexOf('- name: Install the landing credential');
+    const task = rendered.indexOf('Run task ${{ matrix.task }}');
     expect(install).toBeGreaterThan(-1);
     expect(remint).toBeGreaterThan(install);
     expect(refresh).toBeGreaterThan(remint);
     expect(task).toBeGreaterThan(refresh);
+  });
+});
+
+/**
+ * ONE definition of the tier NAMES (4.4.5, dxkit #325 round 2). The three
+ * configuration names live as constants in src/lanes/lane-token.ts; every
+ * workflow reference arrives via a __DXKIT_LANE_TOKEN_*__ substitution and
+ * every src consumer (the doctor probe, install notes, disclosures)
+ * imports the constants, so a rename cannot leave a template, a probe,
+ * or a remedy on a stale name.
+ */
+describe('lane token NAME discipline (one definition)', () => {
+  const NAME_LITERALS = [
+    LANE_TOKEN_APP_ID_VARIABLE_NAME,
+    LANE_TOKEN_APP_KEY_SECRET_NAME,
+    LANE_TOKEN_PAT_SECRET_NAME,
+  ];
+
+  it('raw templates carry NO tier-name literals (names arrive only via substitution)', () => {
+    const offenders: string[] = [];
+    for (const { file, content } of templates()) {
+      for (const name of NAME_LITERALS) {
+        if (content.includes(name)) offenders.push(`${file}: literal ${name}`);
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([]);
+  });
+
+  it('the rendered remediate template gets the task re-mint from the one definition', () => {
+    const content = fs.readFileSync(path.join(WORKFLOWS, 'dxkit-remediate.yml'), 'utf8');
+    const rendered = renderForParse(content);
+    expect(rendered).toContain(LANE_TOKEN_TASK_STEPS);
+    expect(rendered).toContain(`vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME}`);
+    expect(rendered).toContain(`secrets.${LANE_TOKEN_APP_KEY_SECRET_NAME}`);
+  });
+
+  it('within src/, the raw name literals appear ONLY in lane-token.ts', () => {
+    const SRC = path.join(__dirname, '..', 'src');
+    const offenders: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(p);
+          continue;
+        }
+        if (!entry.name.endsWith('.ts')) continue;
+        const rel = path.relative(SRC, p).split(path.sep).join('/');
+        if (rel === 'lanes/lane-token.ts') continue;
+        const content = fs.readFileSync(p, 'utf8');
+        for (const name of NAME_LITERALS) {
+          if (content.includes(name)) offenders.push(`src/${rel}: literal ${name}`);
+        }
+      }
+    };
+    walk(SRC);
+    expect(offenders, offenders.join('\n')).toEqual([]);
   });
 });


### PR DESCRIPTION
Two small, independent Phase 0 fixes from the remediate rethink (the nets that also serve humans): the doctor lane-token probe stops asserting a negative it cannot observe, and the remediate policy knobs are documented truthfully and completely.

Closes #325

## A. doctor: the lane token tier probe is tri-state (#325)

**What was wrong.** `doctor` listed repo-level variables/secrets with `gh variable list` / `gh secret list` and, when neither `DXKIT_APP_ID` + `DXKIT_APP_PRIVATE_KEY` nor `DXKIT_BOT_TOKEN` showed up, asserted "lane PRs will run no checks: no lane token tier is configured". A tier configured at the ORG level (which the lane run itself resolves and discloses correctly) is invisible to that listing, and so is any tier a repo-scoped token cannot enumerate. "I could not see it" was folded into "it is not configured": the Rule 19 mistake applied to setup advice.

**What changed.**
- New `src/lanes/lane-token-probe.ts`: ONE probe, `probeLaneTokenTier`, reads BOTH scopes the lane reads (`repos/{r}/actions/variables`, `.../organization-variables`, `.../secrets`, `.../organization-secrets`) and answers `configured` (tier + scope), `not-configured` (only when every applicable scope was actually enumerated), or `unobservable` (which scopes could not be read, and where the truth is: the run's "Disclose token mode" step). A 403/404 on the org endpoints is unobservable, never absent. Owner type is checked so a user-owned repo (no org scope) can still reach a genuine negative; an unknown owner keeps the org scopes applicable.
- `doctor` 6d routes through it (`laneTokenTierCheck`, pure): absent yields the existing red finding + remedy command; unobservable yields an advisory "could not be verified from here" line with the reason and how to verify, no "go configure it" command; configured yields nothing.
- The three names now live once as exported constants (`LANE_TOKEN_APP_ID_VARIABLE_NAME`, `LANE_TOKEN_APP_KEY_SECRET_NAME`, `LANE_TOKEN_PAT_SECRET_NAME`) in `src/lanes/lane-token.ts` and the workflow chain text, the mint step, the probe and the remedy command all derive from them. No second tier table.

## B. Remediate knob documentation and metadata drift

- `docs/configuration/policy-guide.md` "Remediate salvage" described a `discard` default; the code (`salvageForTask`) defaults to `auto` (open-ended tasks draft-pr, bounded tasks discard). The section now describes `auto` truthfully.
- `maxUsd` was described as "enforced from the spend envelope" in the guide, the skill and the schema; the shipped driver declares `budgetSupport.cost: 'reported'` (spend read after the run, advisory). The guide, `SKILL.md`, the metadata summary and the schema's budget description now say so, and point at turns + wall-clock as what bounds real spend.
- `taskBudgets`, `maxSpendPerRun`, `maxDispatchBudget`, `resume` were in the schema with hand-written descriptions but absent from `POLICY_PARAMS` (the `policy set` knob index) and from the guide. Each now has a metadata row, a guide section (`#remediate-task-budgets`, `#remediate-spend-per-run`, `#remediate-dispatch-budget`, `#remediate-resume`), and the schema descriptions derive from the one table via `desc()`. Knob index regenerated.
- New parity test in `test/baseline/policy-schema.test.ts`: every schema leaf under `remediate` has a `POLICY_PARAMS` row, injection-guarded (a synthetic schema-only knob is reported).
- `src/baseline/policy-metadata.ts` crossed the 500-line large-file bar with the four new rows, so the stanza + scaffold-exemption tables moved to `src/baseline/policy-stanzas.ts` and are re-exported from `policy-metadata.ts` (the same split-at-the-bar pattern `policy.ts` uses; every importer is unchanged).
- Nothing about the work-order redesign is pre-documented.

## Tests

- `test/lanes/lane-token-probe.test.ts` (new, injected gh probe): all three states, the #325 repro (org-level App tier configured), repo-empty + org-unreadable is unobservable, user-owned repo reaches a genuine negative, unknown owner does not, split-scope App halves, unparseable payloads, `probeLaneTokenTierHere` routing, the one-name-set pin, and the doctor rendering in both directions.
- `test/baseline/policy-schema.test.ts`: remediate schema leaf <-> POLICY_PARAMS parity + injection guard; existing table-derivation tests now cover the four new rows.
- `test/policy-guide.test.ts` (existing) pins the new anchors resolve and the regenerated knob index matches a fresh render.

## Sweep

Full local sweep green: typecheck, typecheck:test, eslint (0 warnings), prettier, check-architecture, check-docs-coverage, check-slop vs origin/main, build, vitest --coverage (382 files, 5721 tests, coverage 72.8% over the 50% bar), check-coverage.

Self-guardrail `guardrail check --mode ref-based --ref origin/main`: PASSED (88 pairs, 0 blocking).

The first guardrail run BLOCKED on two net-new findings this PR introduced; both were fixed at the root, nothing allowlisted:
- grep-secrets `hardcoded-secret` matched `LANE_TOKEN_APP_KEY_SECRET = 'DXKIT_APP_PRIVATE_KEY'` (an identifier ending in a keyword, holding a config NAME). Fixed by naming the constants `*_NAME`, which is also the truthful name for what they hold.
- large-file on `policy-metadata.ts`. Fixed by the module split above.

## Review focus

- `src/lanes/lane-token-probe.ts`: the state decision (positive evidence wins; negative only when every applicable scope was read; owner-type handling).
- `src/doctor.ts` `laneTokenTierCheck`: the unobservable wording (advisory, no remedy command).
- `docs/configuration/policy-guide.md`: the four new sections describe only behavior that exists today (`config.ts`, `dispatch.ts`, `resume.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
