### PR TITLE
feat(baseline): one content-hash stamp for every located finding (4.4.5 identity-content-hash)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,10 +99,14 @@ ${path}` keys, which discards catch-all structure — so it did exact membership
   through a local closure and the custom-check producer stamped nothing, so
   one 4-space to 2-space reindent read a repo's whole grandfathered lint
   backlog as resolved plus dozens of net-new. The arch-check confines
-  `computeContentHashFromCommit(` to that module (annotate
+  the hash primitive `computeContentHash(` to `content-hash.ts` plus that
+  module (annotate
   `// content-stamp-ok` for a justified exception), and
   `test/baseline/content-stamp-parity.test.ts` iterates `PRODUCERS` and
   asserts every line-carrying entry is stamped (synthetic-injection guarded).
+  The stamp reads the WORKING TREE, the tree every scanner read and whose
+  line numbers the finding carries (reading the anchor commit instead hashed
+  pre-change content at post-change lines on every dirty-tree surface).
   Path-identity kinds (large-file, test-gap, stale-file) carry no line and no
   stamp; a pre-scheme baseline without the field degrades to the git and
   identity passes, no migration or rescan.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,22 @@ ${path}` keys, which discards catch-all structure — so it did exact membership
   leading `{var}` has no anchor → warn, not block);
 - benign secret / env conventions → `isPlaceholderSecret` / `isExampleEnvFile`
   (Rule 5's benign module), consulted by BOTH secret detectors.
+- the `contentHash` a LOCATED finding carries (the git-independent, whitespace-
+  normalized identity the matcher's content-hash pass pairs on, the ONE pass
+  that survives a whole-file reformat) → `contentStamper` in
+  `src/baseline/content-stamp.ts`, consumed by EVERY producer of a
+  line-carrying kind (secret/code/config, duplication, stale-allow,
+  custom-check). The shipped shape (4.4.5): the security producer stamped
+  through a local closure and the custom-check producer stamped nothing, so
+  one 4-space to 2-space reindent read a repo's whole grandfathered lint
+  backlog as resolved plus dozens of net-new. The arch-check confines
+  `computeContentHashFromCommit(` to that module (annotate
+  `// content-stamp-ok` for a justified exception), and
+  `test/baseline/content-stamp-parity.test.ts` iterates `PRODUCERS` and
+  asserts every line-carrying entry is stamped (synthetic-injection guarded).
+  Path-identity kinds (large-file, test-gap, stale-file) carry no line and no
+  stamp; a pre-scheme baseline without the field degrades to the git and
+  identity passes, no migration or rescan.
 - what the working tree CHANGED vs a base → `computeChangedFiles` +
   `createChangedLineIndex`, BOTH in `src/baseline/changed-files.ts`, both
   diffing base → WORKING TREE (staged + unstaged + untracked; an untracked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,24 +92,25 @@ ${path}` keys, which discards catch-all structure — so it did exact membership
   (Rule 5's benign module), consulted by BOTH secret detectors.
 - the `contentHash` a LOCATED finding carries (the git-independent, whitespace-
   normalized identity the matcher's content-hash pass pairs on, the ONE pass
-  that survives a whole-file reformat) → `contentStamper` in
-  `src/baseline/content-stamp.ts`, consumed by EVERY producer of a
-  line-carrying kind (secret/code/config, duplication, stale-allow,
-  custom-check). The shipped shape (4.4.5): the security producer stamped
-  through a local closure and the custom-check producer stamped nothing, so
-  one 4-space to 2-space reindent read a repo's whole grandfathered lint
-  backlog as resolved plus dozens of net-new. The arch-check confines
-  the hash primitive `computeContentHash(` to `content-hash.ts` plus that
-  module (annotate
-  `// content-stamp-ok` for a justified exception), and
-  `test/baseline/content-stamp-parity.test.ts` iterates `PRODUCERS` and
-  asserts every line-carrying entry is stamped (synthetic-injection guarded).
-  The stamp reads the WORKING TREE, the tree every scanner read and whose
-  line numbers the finding carries (reading the anchor commit instead hashed
-  pre-change content at post-change lines on every dirty-tree surface).
-  Path-identity kinds (large-file, test-gap, stale-file) carry no line and no
-  stamp; a pre-scheme baseline without the field degrades to the git and
-  identity passes, no migration or rescan.
+  that survives a whole-file reformat) → stamped ONCE by the ORCHESTRATOR
+  (`stampEntries` in `src/baseline/content-stamp.ts`, called from
+  `runProducers` and `captureFragment`), deciding locatedness via the same
+  `entryToLocated` projection the matcher consumes — so "what is located" and
+  "what gets stamped" are one definition and a producer cannot ship unstamped
+  (the 4.4.4 class: the security producer stamped through a local closure, the
+  custom-check producer stamped nothing, and one reindent read a repo's whole
+  grandfathered lint backlog as resolved plus net-new). The stamp reads the
+  WORKING TREE, the tree every scanner read and whose line numbers the finding
+  carries (reading the anchor commit instead hashed pre-change content at
+  post-change lines on every dirty-tree surface); the one commit-anchored read
+  is the migrate lane's `restampAtCommit`, which backfills pre-scheme
+  baselines on `vyuh-dxkit update`. The arch-check confines the hash
+  primitive `computeContentHash` (any reference, aliased imports included) to
+  `content-hash.ts` + `content-stamp.ts` (annotate `// content-stamp-ok` for a
+  justified exception), and `test/baseline/content-stamp-parity.test.ts` pins
+  the orchestrator + fragment paths (synthetic-injection guarded, with an
+  outside-the-repo negative control). Path-identity kinds (large-file,
+  test-gap, stale-file) carry no line and no stamp.
 - what the working tree CHANGED vs a base → `computeChangedFiles` +
   `createChangedLineIndex`, BOTH in `src/baseline/changed-files.ts`, both
   diffing base → WORKING TREE (staged + unstaged + untracked; an untracked

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -694,23 +694,23 @@ fi
 # every producer of a located kind calls `contentStamper`. Before this gate the
 # security producer stamped through a local closure and the custom-check
 # producer stamped nothing, so a whole-file reindent read ~10k grandfathered
-# lint findings as resolved + net-new. A second call site of
-# `computeContentHashFromCommit(` is a second stamping policy in the making.
+# lint findings as resolved + net-new. A second call site of the hash
+# primitive `computeContentHash(` is a second stamping policy in the making.
 # Annotate `// content-stamp-ok` for a justified exception (rare).
 CONTENT_STAMP_ALLOWLIST="src/baseline/content-hash.ts src/baseline/content-stamp.ts"
 ALLOW_FILTER_CS=""
 for f in $CONTENT_STAMP_ALLOWLIST; do
   ALLOW_FILTER_CS="$ALLOW_FILTER_CS -e ^${f}:"
 done
-ROGUE_STAMP=$(grep -rnE "computeContentHashFromCommit[[:space:]]*\(" ${CONTENT_STAMP_SCAN_ROOT:-src}/ 2>/dev/null \
+ROGUE_STAMP=$(grep -rnE "(^|[^A-Za-z])computeContentHash[[:space:]]*\(" ${CONTENT_STAMP_SCAN_ROOT:-src}/ 2>/dev/null \
   | grep -v "// content-stamp-ok" \
   | grep -v -E ':[[:space:]]*(//|\*)' \
   | { [ -n "$ALLOW_FILTER_CS" ] && grep -v $ALLOW_FILTER_CS || cat; })
 if [ -n "$ROGUE_STAMP" ]; then
-  echo "❌ Content-stamp violation: computeContentHashFromCommit() called outside src/baseline/content-stamp.ts:"
+  echo "❌ Content-stamp violation: computeContentHash() called outside src/baseline/content-stamp.ts:"
   echo "$ROGUE_STAMP"
   echo "   → Build a stamper with contentStamper(source) from src/baseline/content-stamp.ts"
-  echo "     and call it per (file, line); it owns the no-commit / line-0 / unreadable policy."
+  echo "     and call it per (file, line); it owns the no-source / line-0 / unreadable policy."
   echo "   → Annotate '// content-stamp-ok' for a justified exception (rare)."
   ERRORS=$((ERRORS + 1))
 fi

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -702,12 +702,12 @@ ALLOW_FILTER_CS=""
 for f in $CONTENT_STAMP_ALLOWLIST; do
   ALLOW_FILTER_CS="$ALLOW_FILTER_CS -e ^${f}:"
 done
-ROGUE_STAMP=$(grep -rnE "(^|[^A-Za-z])computeContentHash[[:space:]]*\(" ${CONTENT_STAMP_SCAN_ROOT:-src}/ 2>/dev/null \
+ROGUE_STAMP=$(grep -rnE "(^|[^A-Za-z_])computeContentHash([^A-Za-z_]|$)" ${CONTENT_STAMP_SCAN_ROOT:-src}/ 2>/dev/null \
   | grep -v "// content-stamp-ok" \
-  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | grep -v -E '^[^:]*:[0-9]+:[[:space:]]*(//|\*|/\*)' \
   | { [ -n "$ALLOW_FILTER_CS" ] && grep -v $ALLOW_FILTER_CS || cat; })
 if [ -n "$ROGUE_STAMP" ]; then
-  echo "❌ Content-stamp violation: computeContentHash() called outside src/baseline/content-stamp.ts:"
+  echo "❌ Content-stamp violation: computeContentHash referenced outside src/baseline/content-stamp.ts:"
   echo "$ROGUE_STAMP"
   echo "   → Build a stamper with contentStamper(source) from src/baseline/content-stamp.ts"
   echo "     and call it per (file, line); it owns the no-source / line-0 / unreadable policy."

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -688,6 +688,33 @@ if [ -n "$ROGUE_BUCKET" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# Content-hash STAMPING gate (Rule 2.30, 4.4.5): one stamping policy. The
+# hash lives in `content-hash.ts`; the decision of WHEN to stamp (no commit,
+# whole-file line 0, unreadable file) lives ONLY in `content-stamp.ts`, and
+# every producer of a located kind calls `contentStamper`. Before this gate the
+# security producer stamped through a local closure and the custom-check
+# producer stamped nothing, so a whole-file reindent read ~10k grandfathered
+# lint findings as resolved + net-new. A second call site of
+# `computeContentHashFromCommit(` is a second stamping policy in the making.
+# Annotate `// content-stamp-ok` for a justified exception (rare).
+CONTENT_STAMP_ALLOWLIST="src/baseline/content-hash.ts src/baseline/content-stamp.ts"
+ALLOW_FILTER_CS=""
+for f in $CONTENT_STAMP_ALLOWLIST; do
+  ALLOW_FILTER_CS="$ALLOW_FILTER_CS -e ^${f}:"
+done
+ROGUE_STAMP=$(grep -rnE "computeContentHashFromCommit[[:space:]]*\(" ${CONTENT_STAMP_SCAN_ROOT:-src}/ 2>/dev/null \
+  | grep -v "// content-stamp-ok" \
+  | grep -v -E ':[[:space:]]*(//|\*)' \
+  | { [ -n "$ALLOW_FILTER_CS" ] && grep -v $ALLOW_FILTER_CS || cat; })
+if [ -n "$ROGUE_STAMP" ]; then
+  echo "❌ Content-stamp violation: computeContentHashFromCommit() called outside src/baseline/content-stamp.ts:"
+  echo "$ROGUE_STAMP"
+  echo "   → Build a stamper with contentStamper(source) from src/baseline/content-stamp.ts"
+  echo "     and call it per (file, line); it owns the no-commit / line-0 / unreadable policy."
+  echo "   → Annotate '// content-stamp-ok' for a justified exception (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
 # ─── Rule 10 (baseline producer coverage): identity calls confined ──────────
 # Closes the class of bug where a new analyzer's findings reach disk
 # via a one-off `BaselineEntry`-builder that bypasses the canonical

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -702,7 +702,7 @@ ALLOW_FILTER_CS=""
 for f in $CONTENT_STAMP_ALLOWLIST; do
   ALLOW_FILTER_CS="$ALLOW_FILTER_CS -e ^${f}:"
 done
-ROGUE_STAMP=$(grep -rnE "(^|[^A-Za-z_])computeContentHash([^A-Za-z_]|$)" ${CONTENT_STAMP_SCAN_ROOT:-src}/ 2>/dev/null \
+ROGUE_STAMP=$(grep -rnE "(^|[^A-Za-z_])computeContentHash" ${CONTENT_STAMP_SCAN_ROOT:-src}/ 2>/dev/null \
   | grep -v "// content-stamp-ok" \
   | grep -v -E '^[^:]*:[0-9]+:[[:space:]]*(//|\*|/\*)' \
   | { [ -n "$ALLOW_FILTER_CS" ] && grep -v $ALLOW_FILTER_CS || cat; })

--- a/src/analyzers/custom-checks/parse.ts
+++ b/src/analyzers/custom-checks/parse.ts
@@ -15,6 +15,7 @@
  */
 
 import * as path from 'path';
+import { resolveInsideRepo } from '../tools/paths';
 import type { RawLocatedFinding } from '../../languages/capabilities/lint-gate';
 import type { CustomCheckFinding } from './types';
 
@@ -222,9 +223,8 @@ function parseIntSafe(s: string): number | undefined {
  */
 function toRepoRelativePosix(file: string, cwd: string): string {
   if (!path.isAbsolute(file)) return normalizeSeparators(file);
-  const rel = path.relative(cwd, file);
-  if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) return file;
-  return normalizeSeparators(rel);
+  // ONE containment predicate (resolveInsideRepo); outside-repo stays verbatim.
+  return resolveInsideRepo(cwd, file) ?? file;
 }
 
 /** POSIX separators in the output path. Only rewrites `\` when it IS the host

--- a/src/analyzers/tools/paths.ts
+++ b/src/analyzers/tools/paths.ts
@@ -25,3 +25,23 @@ export function toProjectRelative(cwd: string, fileFromTool: string): string {
   const absFile = path.isAbsolute(fileFromTool) ? fileFromTool : path.resolve(absCwd, fileFromTool);
   return path.relative(absCwd, absFile).split(path.sep).join('/');
 }
+
+/**
+ * Resolve a finding's path against the repo root and answer with the POSIX
+ * repo-relative form, or `null` when the path does not stay inside the repo
+ * (absolute paths outside it, or `..` segments escaping it). ONE containment
+ * predicate — the content stamper and the custom-check parse boundary both
+ * route through it, so "is this path inside the repo" cannot fork. A file
+ * whose NAME merely begins with dots (`..config.ts`) resolves fine; only a
+ * genuine escape answers null.
+ */
+export function resolveInsideRepo(cwd: string, file: string): string | null {
+  const absCwd = path.resolve(cwd);
+  const abs = path.isAbsolute(file) ? file : path.resolve(absCwd, file);
+  const rel = path.relative(absCwd, abs);
+  if (rel === '' || path.isAbsolute(rel)) return null;
+  // Escape = a leading `..` path SEGMENT after resolution; a NAME that merely
+  // begins with dots (`..config.ts`) stays inside the repo.
+  if (rel === '..' || rel.startsWith(`..${path.sep}`)) return null;
+  return rel.split(path.sep).join('/');
+}

--- a/src/baseline/content-hash.ts
+++ b/src/baseline/content-hash.ts
@@ -14,7 +14,7 @@
  *
  *   1. Every producer of a located kind stamps its entries through
  *      the ONE `contentStamper` (`content-stamp.ts`), which reads the
- *      finding's surrounding context lines at the anchor commit,
+ *      finding's surrounding context lines from the working tree,
  *      normalizes whitespace, and computes a SHA-1[0:16] hash here.
  *      The hash is stamped on the finding entry in the baseline file.
  *   2. At guardrail-check time, the current scan computes content
@@ -71,7 +71,18 @@ export function computeContentHash(
   line: number,
   contextLines: number = CONTENT_HASH_CONTEXT_LINES,
 ): string {
-  const lines = fileContent.split('\n');
+  return computeContentHashFromLines(fileContent.split('\n'), line, contextLines);
+}
+
+/**
+ * Same hash over pre-split lines. The stamper caches split lines per file so
+ * a file carrying thousands of findings is split once, not once per finding.
+ */
+export function computeContentHashFromLines(
+  lines: readonly string[],
+  line: number,
+  contextLines: number = CONTENT_HASH_CONTEXT_LINES,
+): string {
   const startIdx = Math.max(0, line - 1 - contextLines);
   const endIdx = Math.min(lines.length, line + contextLines);
   const window = lines.slice(startIdx, endIdx);

--- a/src/baseline/content-hash.ts
+++ b/src/baseline/content-hash.ts
@@ -43,7 +43,6 @@
  */
 
 import { createHash } from 'crypto';
-import { execFileSync } from 'child_process';
 
 /**
  * Width of the context window read on each side of the finding's
@@ -89,52 +88,4 @@ export function computeContentHash(
  */
 function normalizeLine(line: string): string {
   return line.replace(/\s+/g, ' ').trim();
-}
-
-/**
- * Read a file's content at a specific commit. Returns null when git
- * can't resolve the path-at-commit pair — file didn't exist at
- * `sha`, file is binary, sha is unreachable. Callers treat null
- * the same as "content-hash unavailable for this path."
- *
- * Uses `git show <sha>:<path>` which does not require checking out
- * the commit — safe to call repeatedly in a tight loop without
- * touching the working tree.
- */
-export function readFileFromCommit(cwd: string, sha: string, file: string): string | null {
-  try {
-    return execFileSync('git', ['show', `${sha}:${file}`], {
-      cwd,
-      encoding: 'utf8',
-      // Cap output size — git show on a 100MB committed binary would
-      // otherwise blow the default stdio buffer. 10MB is generous for
-      // any real source file.
-      maxBuffer: 10 * 1024 * 1024,
-      // Silence the "fatal: path X does not exist" message git emits
-      // to stderr when the file/sha pair doesn't resolve. Callers
-      // expect a null return, not a stderr message bleeding through.
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Combined helper: read the file at a commit and compute its
- * content hash at the given line. Returns null when the file
- * couldn't be read. Called ONLY by `contentStamper` in
- * `content-stamp.ts` (the arch-check pins that); producers use the
- * stamper, never this helper directly.
- */
-export function computeContentHashFromCommit(
-  cwd: string,
-  sha: string,
-  file: string,
-  line: number,
-  contextLines: number = CONTENT_HASH_CONTEXT_LINES,
-): string | null {
-  const content = readFileFromCommit(cwd, sha, file);
-  if (content === null) return null;
-  return computeContentHash(content, line, contextLines);
 }

--- a/src/baseline/content-hash.ts
+++ b/src/baseline/content-hash.ts
@@ -12,10 +12,11 @@
  *
  * Pipeline:
  *
- *   1. The producer (Phase 3 baseline-create) reads each finding's
- *      surrounding context lines, normalizes whitespace, and
- *      computes a SHA-1[0:16] hash. The hash is stamped on the
- *      finding entry in the baseline file.
+ *   1. Every producer of a located kind stamps its entries through
+ *      the ONE `contentStamper` (`content-stamp.ts`), which reads the
+ *      finding's surrounding context lines at the anchor commit,
+ *      normalizes whitespace, and computes a SHA-1[0:16] hash here.
+ *      The hash is stamped on the finding entry in the baseline file.
  *   2. At guardrail-check time, the current scan computes content
  *      hashes the same way for its own findings.
  *   3. The matcher's content-hash pass pairs prior + current
@@ -122,8 +123,9 @@ export function readFileFromCommit(cwd: string, sha: string, file: string): stri
 /**
  * Combined helper: read the file at a commit and compute its
  * content hash at the given line. Returns null when the file
- * couldn't be read. Used by the producer (Phase 3 baseline-create)
- * to stamp content hashes on baseline entries.
+ * couldn't be read. Called ONLY by `contentStamper` in
+ * `content-stamp.ts` (the arch-check pins that); producers use the
+ * stamper, never this helper directly.
  */
 export function computeContentHashFromCommit(
   cwd: string,

--- a/src/baseline/content-stamp.ts
+++ b/src/baseline/content-stamp.ts
@@ -1,0 +1,69 @@
+/**
+ * Content-hash STAMPING: the one entry point every producer of a LOCATED
+ * finding kind uses to put a `contentHash` on its baseline entries
+ * (CLAUDE.md Rule 2.30, one concept, one code path).
+ *
+ * The hash itself is computed by `content-hash.ts` (the only module that may
+ * hash, per the Rule 9 `createHash` ban). This module owns the POLICY around
+ * calling it, which every producer used to re-implement as a local closure:
+ *
+ *   - no commit available (a bare tree, an empty `commitSha`): no stamp;
+ *   - a whole-file finding (`line <= 0`, e.g. `.env in git`): no stamp, the
+ *     context window would be meaningless;
+ *   - the file cannot be read at the commit (binary, deleted, unreachable):
+ *     no stamp, the matcher's other passes still work.
+ *
+ * Why one entry point matters: the security producer stamped, the
+ * custom-check producer did not, and nothing forced parity. On a real repo
+ * that left 0 of ~10k grandfathered lint entries with a hash, so the git-aware
+ * matcher's content-hash pass (the ONE pass that survives a whole-file
+ * reformat, because it normalizes whitespace) never fired for lint: one
+ * reindent read as thousands of "resolved" plus dozens of "net-new" lint
+ * findings. Routing every located kind through `contentStamper` means a
+ * producer cannot forget to stamp, and `test/baseline/content-stamp-parity.test.ts`
+ * pins that every registered producer's line-carrying entries carry a hash.
+ *
+ * Both sides of the guardrail (baseline create AND the current scan) build
+ * entries through the same producers with `ProducerContext.commitSha`, so the
+ * stamp lands on both sides through this one path; nothing here is
+ * baseline-only. The arch-check keeps `computeContentHashFromCommit` private
+ * to this module so a second stamping policy cannot grow beside it.
+ */
+
+import { computeContentHashFromCommit } from './content-hash';
+
+/** Where to read file content from: the repo and the commit its entries are
+ *  anchored to. The producer context supplies both. */
+export interface ContentStampSource {
+  readonly cwd: string;
+  readonly commitSha: string;
+}
+
+/** `(file, line) => contentHash | undefined`, bound to one source. */
+export type ContentStamper = (file: string, line: number) => string | undefined;
+
+/**
+ * Build the stamper for a source. `undefined` (or an empty `commitSha`)
+ * yields a stamper that never stamps, so a producer needs no branch of
+ * its own for the no-commit case.
+ */
+export function contentStamper(source: ContentStampSource | undefined): ContentStamper {
+  if (!source || !source.cwd || !source.commitSha) return () => undefined;
+  const { cwd, commitSha } = source;
+  return (file, line) => {
+    if (!(line > 0)) return undefined;
+    return computeContentHashFromCommit(cwd, commitSha, file, line) ?? undefined;
+  };
+}
+
+/**
+ * The stamp source a `ProducerContext`-shaped object provides: `undefined`
+ * when the tree has no commit to anchor to (the orchestrator records an empty
+ * `commitSha` there), so callers pass it straight into `contentStamper`.
+ */
+export function contentStampSource(ctx: {
+  readonly cwd: string;
+  readonly commitSha: string;
+}): ContentStampSource | undefined {
+  return ctx.commitSha ? { cwd: ctx.cwd, commitSha: ctx.commitSha } : undefined;
+}

--- a/src/baseline/content-stamp.ts
+++ b/src/baseline/content-stamp.ts
@@ -7,11 +7,23 @@
  * hash, per the Rule 9 `createHash` ban). This module owns the POLICY around
  * calling it, which every producer used to re-implement as a local closure:
  *
- *   - no commit available (a bare tree, an empty `commitSha`): no stamp;
+ *   - no source (a producer running without a repo path): no stamp;
  *   - a whole-file finding (`line <= 0`, e.g. `.env in git`): no stamp, the
  *     context window would be meaningless;
- *   - the file cannot be read at the commit (binary, deleted, unreachable):
- *     no stamp, the matcher's other passes still work.
+ *   - the file cannot be read (binary-ish, deleted, outside the tree): no
+ *     stamp, the matcher's other passes still work.
+ *
+ * WHICH content is hashed matters as much as whether: every scanner reads the
+ * WORKING TREE, so a finding's `line` is a working-tree line. The stamp reads
+ * the same tree. Reading the file at a commit instead (the 4.4.4 shape) hashed
+ * pre-change content at post-change lines on a dirty tree (the loop Stop-gate
+ * and pre-push surfaces), so the reformat this scheme exists to survive did
+ * not pair while uncommitted, and a same-rule finding newly introduced at a
+ * line that still hashed to the prior window could pair as "persisted". On a
+ * clean checkout (baseline create in CI, the guardrail on a PR head) the tree
+ * IS the commit, so the two readings agree there and only there. Reading the
+ * tree also costs one file read per file instead of one `git show` process
+ * per finding (ten thousand spawns on a real lint backlog).
  *
  * Why one entry point matters: the security producer stamped, the
  * custom-check producer did not, and nothing forced parity. On a real repo
@@ -24,46 +36,75 @@
  * pins that every registered producer's line-carrying entries carry a hash.
  *
  * Both sides of the guardrail (baseline create AND the current scan) build
- * entries through the same producers with `ProducerContext.commitSha`, so the
- * stamp lands on both sides through this one path; nothing here is
- * baseline-only. The arch-check keeps `computeContentHashFromCommit` private
- * to this module so a second stamping policy cannot grow beside it.
+ * entries through the same producers, so the stamp lands on both sides through
+ * this one path; nothing here is baseline-only. The arch-check keeps the hash
+ * primitive `computeContentHash` private to `content-hash.ts` plus this module
+ * so a second stamping policy cannot grow beside it.
  */
 
-import { computeContentHashFromCommit } from './content-hash';
+import { readFileSync } from 'node:fs';
+import { isAbsolute, join, normalize, relative } from 'node:path';
 
-/** Where to read file content from: the repo and the commit its entries are
- *  anchored to. The producer context supplies both. */
+import { computeContentHash } from './content-hash';
+
+/** Where to read file content from: the repo whose working tree the findings
+ *  were scanned on. The producer context supplies it. */
 export interface ContentStampSource {
   readonly cwd: string;
-  readonly commitSha: string;
 }
 
 /** `(file, line) => contentHash | undefined`, bound to one source. */
 export type ContentStamper = (file: string, line: number) => string | undefined;
 
 /**
- * Build the stamper for a source. `undefined` (or an empty `commitSha`)
- * yields a stamper that never stamps, so a producer needs no branch of
- * its own for the no-commit case.
+ * Build the stamper for a source. `undefined` yields a stamper that never
+ * stamps, so a producer needs no branch of its own for the no-source case.
+ * File content is cached per path for the stamper's lifetime: a producer
+ * stamps every finding of a file in one pass, so each file is read once.
  */
 export function contentStamper(source: ContentStampSource | undefined): ContentStamper {
-  if (!source || !source.cwd || !source.commitSha) return () => undefined;
-  const { cwd, commitSha } = source;
+  if (!source || !source.cwd) return () => undefined;
+  const { cwd } = source;
+  const cache = new Map<string, string | null>();
+  const read = (file: string): string | null => {
+    const hit = cache.get(file);
+    if (hit !== undefined) return hit;
+    const content = readTreeFile(cwd, file);
+    cache.set(file, content);
+    return content;
+  };
   return (file, line) => {
     if (!(line > 0)) return undefined;
-    return computeContentHashFromCommit(cwd, commitSha, file, line) ?? undefined;
+    const content = read(file);
+    if (content === null) return undefined;
+    return computeContentHash(content, line);
   };
 }
 
 /**
- * The stamp source a `ProducerContext`-shaped object provides: `undefined`
- * when the tree has no commit to anchor to (the orchestrator records an empty
- * `commitSha` there), so callers pass it straight into `contentStamper`.
+ * The stamp source a `ProducerContext`-shaped object provides. A context
+ * always carries the tree it scanned, so the stamper always has a source;
+ * the commit anchor is not needed to read the tree.
  */
-export function contentStampSource(ctx: {
-  readonly cwd: string;
-  readonly commitSha: string;
-}): ContentStampSource | undefined {
-  return ctx.commitSha ? { cwd: ctx.cwd, commitSha: ctx.commitSha } : undefined;
+export function contentStampSource(ctx: { readonly cwd: string }): ContentStampSource | undefined {
+  return ctx.cwd ? { cwd: ctx.cwd } : undefined;
+}
+
+/**
+ * Read a repo-relative file from the working tree. `null` when the path
+ * escapes the tree (a finding's `file` is repo-relative by contract; an
+ * absolute or `..`-prefixed path is not something to hash), or when the
+ * file cannot be read as text (missing, a directory, unreadable).
+ */
+function readTreeFile(cwd: string, file: string): string | null {
+  if (isAbsolute(file)) return null;
+  const rel = normalize(file);
+  if (rel.startsWith('..')) return null;
+  const abs = join(cwd, rel);
+  if (relative(cwd, abs).startsWith('..')) return null;
+  try {
+    return readFileSync(abs, 'utf8');
+  } catch {
+    return null;
+  }
 }

--- a/src/baseline/content-stamp.ts
+++ b/src/baseline/content-stamp.ts
@@ -49,13 +49,16 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { lstatSync, readFileSync } from 'node:fs';
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { resolveInsideRepo } from '../analyzers/tools/paths';
 import { computeContentHashFromLines } from './content-hash';
 import { entryToLocated } from './entry-to-located';
 import type { BaselineEntry, RichBaselineEntry } from './types';
+
+/** Most files whose split lines the stamper keeps warm at once. */
+export const CONTENT_STAMP_CACHE_FILES = 128;
 
 /** Files above this size are never stamped (see the module header). */
 export const CONTENT_STAMP_MAX_BYTES = 10 * 1024 * 1024;
@@ -69,12 +72,22 @@ export type ContentStamper = (file: string, line: number) => string | undefined;
  */
 export function contentStamper(cwd: string | undefined): ContentStamper {
   if (!cwd) return () => undefined;
+  // Bounded LRU over split lines: entries usually arrive grouped by file, so
+  // a small window keeps the one-read-per-file property while capping peak
+  // memory on a run whose findings span thousands of files.
   const lines = new Map<string, readonly string[] | null>();
   const read = (file: string): readonly string[] | null => {
     const hit = lines.get(file);
-    if (hit !== undefined) return hit;
+    if (hit !== undefined) {
+      lines.delete(file);
+      lines.set(file, hit);
+      return hit;
+    }
     const content = readTreeLines(cwd, file);
     lines.set(file, content);
+    if (lines.size > CONTENT_STAMP_CACHE_FILES) {
+      lines.delete(lines.keys().next().value as string);
+    }
     return content;
   };
   return (file, line) => {
@@ -109,7 +122,7 @@ function stampOne(entry: RichBaselineEntry, stamp: ContentStamper): RichBaseline
   const contentHash = stamp(loc.file, loc.line);
   if (contentHash === undefined) return entry;
   // Safe: every entry variant `entryToLocated` gives a line locator declares
-  // an optional `contentHash` (pinned by the relocation-invariant test).
+  // an optional `contentHash` (pinned by the parity test's variant sweep).
   return { ...entry, contentHash } as RichBaselineEntry;
 }
 
@@ -182,9 +195,15 @@ function readTreeLines(cwd: string, file: string): readonly string[] | null {
   if (rel === null) return null;
   const abs = join(cwd, rel);
   try {
+    // Leaf must be a regular file (a symlink leaf is refused outright), and
+    // the REAL path must stay inside the repo: a symlinked parent directory
+    // would otherwise carry the read outside the tree (`lstat` on the leaf
+    // alone follows linked parents). realpath is the containment authority.
     const stat = lstatSync(abs);
     if (!stat.isFile() || stat.size > CONTENT_STAMP_MAX_BYTES) return null;
-    return readFileSync(abs, 'utf8').split('\n');
+    const real = realpathSync(abs);
+    if (resolveInsideRepo(realpathSync(cwd), real) === null) return null;
+    return readFileSync(real, 'utf8').split('\n');
   } catch {
     return null;
   }

--- a/src/baseline/content-stamp.ts
+++ b/src/baseline/content-stamp.ts
@@ -1,17 +1,18 @@
 /**
- * Content-hash STAMPING: the one entry point every producer of a LOCATED
- * finding kind uses to put a `contentHash` on its baseline entries
- * (CLAUDE.md Rule 2.30, one concept, one code path).
+ * Content-hash STAMPING: the one place a baseline/current entry gets its
+ * `contentHash` (CLAUDE.md Rule 2.30, one concept, one code path).
  *
  * The hash itself is computed by `content-hash.ts` (the only module that may
  * hash, per the Rule 9 `createHash` ban). This module owns the POLICY around
- * calling it, which every producer used to re-implement as a local closure:
- *
- *   - no source (a producer running without a repo path): no stamp;
- *   - a whole-file finding (`line <= 0`, e.g. `.env in git`): no stamp, the
- *     context window would be meaningless;
- *   - the file cannot be read (binary-ish, deleted, outside the tree): no
- *     stamp, the matcher's other passes still work.
+ * calling it — and, since 4.4.5, the WIRING: producers emit bare entries and
+ * the orchestrator stamps once, through `stampEntries`, using the same
+ * `entryToLocated` projection the matcher consumes. "What is located" and
+ * "what gets stamped" are therefore one definition; a new located kind is
+ * stamped the day its producer lands, with no per-producer wiring to forget.
+ * (The shipped 4.4.4 shape: the security producer stamped through a local
+ * closure and the custom-check producer stamped nothing, so one 4-space to
+ * 2-space reindent read a repo's whole grandfathered lint backlog as
+ * resolved plus dozens of net-new.)
  *
  * WHICH content is hashed matters as much as whether: every scanner reads the
  * WORKING TREE, so a finding's `line` is a working-tree line. The stamp reads
@@ -19,91 +20,171 @@
  * pre-change content at post-change lines on a dirty tree (the loop Stop-gate
  * and pre-push surfaces), so the reformat this scheme exists to survive did
  * not pair while uncommitted, and a same-rule finding newly introduced at a
- * line that still hashed to the prior window could pair as "persisted". On a
+ * line whose committed window still matched could pair as "persisted". On a
  * clean checkout (baseline create in CI, the guardrail on a PR head) the tree
- * IS the commit, so the two readings agree there and only there. Reading the
- * tree also costs one file read per file instead of one `git show` process
- * per finding (ten thousand spawns on a real lint backlog).
+ * IS the commit, so the two readings agree there and only there.
  *
- * Why one entry point matters: the security producer stamped, the
- * custom-check producer did not, and nothing forced parity. On a real repo
- * that left 0 of ~10k grandfathered lint entries with a hash, so the git-aware
- * matcher's content-hash pass (the ONE pass that survives a whole-file
- * reformat, because it normalizes whitespace) never fired for lint: one
- * reindent read as thousands of "resolved" plus dozens of "net-new" lint
- * findings. Routing every located kind through `contentStamper` means a
- * producer cannot forget to stamp, and `test/baseline/content-stamp-parity.test.ts`
- * pins that every registered producer's line-carrying entries carry a hash.
+ * Read policy, decided once here:
+ *   - no tree (`cwd` absent): no stamp;
+ *   - a whole-file finding (`line <= 0`): no stamp, the window is meaningless;
+ *   - a path outside the repo (absolute, or escaping via `..` segments): no
+ *     stamp — a finding's `file` is repo-relative by contract;
+ *   - a SYMLINK: no stamp — `readFileSync` follows links, and on an untrusted
+ *     tree (a fork PR) a committed link must not widen what dxkit reads;
+ *   - a file over `CONTENT_STAMP_MAX_BYTES` (10 MB): no stamp — nothing worth
+ *     window-hashing is that large, and reading it would pin it in memory;
+ *   - an unreadable file (missing, a directory, binary-ish): no stamp.
+ * Every no-stamp case degrades to the matcher's git + identity passes.
  *
- * Both sides of the guardrail (baseline create AND the current scan) build
- * entries through the same producers, so the stamp lands on both sides through
- * this one path; nothing here is baseline-only. The arch-check keeps the hash
- * primitive `computeContentHash` private to `content-hash.ts` plus this module
- * so a second stamping policy cannot grow beside it.
+ * Performance: file content is read once per file per stamping pass and
+ * cached as SPLIT LINES, so per-finding work is a 7-line slice + one sha1
+ * (a 10k-finding backlog in one file is milliseconds, not seconds).
+ *
+ * `restampAtCommit` is the MIGRATION sibling: a baseline written before this
+ * scheme has located entries with no hash, and its line numbers describe the
+ * tree at its anchor commit — so the update/migrate lane may restamp them by
+ * reading files AT THAT COMMIT (`git show`), the one place a commit read is
+ * correct. It is batched (one read per unique file) and its result is
+ * disclosed, never silent.
  */
 
-import { readFileSync } from 'node:fs';
-import { isAbsolute, join, normalize, relative } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { lstatSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
-import { computeContentHash } from './content-hash';
+import { resolveInsideRepo } from '../analyzers/tools/paths';
+import { computeContentHashFromLines } from './content-hash';
+import { entryToLocated } from './entry-to-located';
+import type { BaselineEntry, RichBaselineEntry } from './types';
 
-/** Where to read file content from: the repo whose working tree the findings
- *  were scanned on. The producer context supplies it. */
-export interface ContentStampSource {
-  readonly cwd: string;
-}
+/** Files above this size are never stamped (see the module header). */
+export const CONTENT_STAMP_MAX_BYTES = 10 * 1024 * 1024;
 
-/** `(file, line) => contentHash | undefined`, bound to one source. */
+/** `(file, line) => contentHash | undefined`, bound to one tree. */
 export type ContentStamper = (file: string, line: number) => string | undefined;
 
 /**
- * Build the stamper for a source. `undefined` yields a stamper that never
- * stamps, so a producer needs no branch of its own for the no-source case.
- * File content is cached per path for the stamper's lifetime: a producer
- * stamps every finding of a file in one pass, so each file is read once.
+ * Build a stamper for the working tree at `cwd`. An absent `cwd` yields a
+ * stamper that never stamps, so callers need no branch of their own.
  */
-export function contentStamper(source: ContentStampSource | undefined): ContentStamper {
-  if (!source || !source.cwd) return () => undefined;
-  const { cwd } = source;
-  const cache = new Map<string, string | null>();
-  const read = (file: string): string | null => {
-    const hit = cache.get(file);
+export function contentStamper(cwd: string | undefined): ContentStamper {
+  if (!cwd) return () => undefined;
+  const lines = new Map<string, readonly string[] | null>();
+  const read = (file: string): readonly string[] | null => {
+    const hit = lines.get(file);
     if (hit !== undefined) return hit;
-    const content = readTreeFile(cwd, file);
-    cache.set(file, content);
+    const content = readTreeLines(cwd, file);
+    lines.set(file, content);
     return content;
   };
   return (file, line) => {
     if (!(line > 0)) return undefined;
-    const content = read(file);
-    if (content === null) return undefined;
-    return computeContentHash(content, line);
+    const fileLines = read(file);
+    if (fileLines === null) return undefined;
+    return computeContentHashFromLines(fileLines, line);
   };
 }
 
 /**
- * The stamp source a `ProducerContext`-shaped object provides. A context
- * always carries the tree it scanned, so the stamper always has a source;
- * the commit anchor is not needed to read the tree.
+ * Stamp every located entry in `entries` that does not already carry a hash.
+ * Locatedness is decided by `entryToLocated` — the exact projection the
+ * matcher pairs on — so an entry is stamped iff the content pass could ever
+ * read the stamp. Returns a new array; unstamped entries pass through as-is.
+ *
+ * Called by `runProducers` (both guardrail sides) and `captureFragment`
+ * (the per-host capture path) — the two places entries are minted.
  */
-export function contentStampSource(ctx: { readonly cwd: string }): ContentStampSource | undefined {
-  return ctx.cwd ? { cwd: ctx.cwd } : undefined;
+export function stampEntries(
+  entries: readonly RichBaselineEntry[],
+  cwd: string | undefined,
+): RichBaselineEntry[] {
+  const stamp = contentStamper(cwd);
+  return entries.map((entry) => stampOne(entry, stamp));
+}
+
+function stampOne(entry: RichBaselineEntry, stamp: ContentStamper): RichBaselineEntry {
+  if ('contentHash' in entry && entry.contentHash !== undefined) return entry;
+  const loc = entryToLocated(entry);
+  if (loc.file === undefined || loc.line === undefined || !(loc.line > 0)) return entry;
+  const contentHash = stamp(loc.file, loc.line);
+  if (contentHash === undefined) return entry;
+  // Safe: every entry variant `entryToLocated` gives a line locator declares
+  // an optional `contentHash` (pinned by the relocation-invariant test).
+  return { ...entry, contentHash } as RichBaselineEntry;
+}
+
+/** What `restampAtCommit` did, for the migrate lane's disclosure. */
+export interface RestampResult {
+  readonly entries: BaselineEntry[];
+  /** Entries that gained a hash. */
+  readonly restamped: number;
+  /** Located entries left bare (file unreadable at the commit). */
+  readonly unreadable: number;
 }
 
 /**
- * Read a repo-relative file from the working tree. `null` when the path
- * escapes the tree (a finding's `file` is repo-relative by contract; an
- * absolute or `..`-prefixed path is not something to hash), or when the
- * file cannot be read as text (missing, a directory, unreadable).
+ * Restamp a PRE-SCHEME baseline's located entries by reading each file at
+ * the baseline's anchor commit — the tree its line numbers describe. Used
+ * only by the migrate lane (`vyuh-dxkit update`); the live scan path always
+ * stamps from the working tree via `stampEntries`. One `git show` per unique
+ * file, cached. A file unreadable at the commit leaves its entries bare
+ * (counted, disclosed by the caller), never a throw.
  */
-function readTreeFile(cwd: string, file: string): string | null {
-  if (isAbsolute(file)) return null;
-  const rel = normalize(file);
-  if (rel.startsWith('..')) return null;
+export function restampAtCommit(
+  entries: readonly BaselineEntry[],
+  cwd: string,
+  commitSha: string,
+): RestampResult {
+  const cache = new Map<string, readonly string[] | null>();
+  const readAtCommit = (file: string): readonly string[] | null => {
+    const hit = cache.get(file);
+    if (hit !== undefined) return hit;
+    let content: readonly string[] | null = null;
+    try {
+      content = execFileSync('git', ['show', `${commitSha}:${file}`], {
+        cwd,
+        encoding: 'utf8',
+        maxBuffer: CONTENT_STAMP_MAX_BYTES,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).split('\n');
+    } catch {
+      content = null;
+    }
+    cache.set(file, content);
+    return content;
+  };
+  let restamped = 0;
+  let unreadable = 0;
+  const out = entries.map((entry) => {
+    if ('contentHash' in entry && entry.contentHash !== undefined) return entry;
+    const loc = entryToLocated(entry);
+    if (loc.file === undefined || loc.line === undefined || !(loc.line > 0)) return entry;
+    const lines = readAtCommit(loc.file);
+    if (lines === null) {
+      unreadable += 1;
+      return entry;
+    }
+    restamped += 1;
+    const contentHash = computeContentHashFromLines(lines, loc.line);
+    return { ...entry, contentHash } as BaselineEntry;
+  });
+  return { entries: out, restamped, unreadable };
+}
+
+/**
+ * Read a repo-relative file from the working tree as split lines. `null`
+ * when the path escapes the repo, is a symlink, exceeds the size cap, or
+ * cannot be read as text (see the module header for why each case is a
+ * deliberate no-stamp, not an error).
+ */
+function readTreeLines(cwd: string, file: string): readonly string[] | null {
+  const rel = resolveInsideRepo(cwd, file);
+  if (rel === null) return null;
   const abs = join(cwd, rel);
-  if (relative(cwd, abs).startsWith('..')) return null;
   try {
-    return readFileSync(abs, 'utf8');
+    const stat = lstatSync(abs);
+    if (!stat.isFile() || stat.size > CONTENT_STAMP_MAX_BYTES) return null;
+    return readFileSync(abs, 'utf8').split('\n');
   } catch {
     return null;
   }

--- a/src/baseline/entry-to-located.ts
+++ b/src/baseline/entry-to-located.ts
@@ -196,12 +196,16 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
       // two different diagnostics on one line (or two checks) never cross-pair.
       // BINARY (`file` absent): identity is just the check name → line-
       // independent → locator-less; the multiset pass pairs by identity-hash.
+      // The contentHash rides along for the git-independent content pass: it is
+      // the only pass that survives a whole-file reformat (the git pass has no
+      // line-map image for a rewritten line; the identity window has moved).
       return entry.file !== undefined
         ? {
             id: entry.id,
             file: entry.file,
             line: entry.line ?? 0,
             rule: entry.rule !== undefined ? `${entry.check}/${entry.rule}` : entry.check,
+            ...(entry.contentHash !== undefined ? { contentHash: entry.contentHash } : {}),
           }
         : { id: entry.id };
     case 'dep-vuln':

--- a/src/baseline/entry-to-located.ts
+++ b/src/baseline/entry-to-located.ts
@@ -182,7 +182,13 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
                 ? 1
                 : 0,
       );
-      return { id: entry.id, file: first.file, line: first.line, rule: `dup:${first.symbol}` };
+      return {
+        id: entry.id,
+        file: first.file,
+        line: first.line,
+        rule: `dup:${first.symbol}`,
+        ...(entry.contentHash !== undefined ? { contentHash: entry.contentHash } : {}),
+      };
     }
     case 'model-schema-drift':
       // LOCATION-free identity ((model, field, changeClass)) → whole-file

--- a/src/baseline/entry-to-located.ts
+++ b/src/baseline/entry-to-located.ts
@@ -48,7 +48,7 @@
  *     (identity = `(file, symbol)`, survives vertical drift) → whole-file
  *     locator; a RANGE-anchored gap (no symbol) is line-dependent → it gets
  *     a line locator at the range start. (Its producer is not wired yet; when
- *     it lands it should also stamp a contentHash, like the kinds above.)
+ *     it lands the orchestrator stamps it like every located kind.)
  *   - `dep-vuln` and `secret-hmac` stay locator-less: their identities are
  *     genuinely line-independent (advisory id; value HMAC), so the multiset
  *     pass pairs them by exact identity-hash equality with no locator.
@@ -114,7 +114,13 @@ export function entryToLocated(entry: BaselineEntry): LocatedIdentity {
       // relocation invariant in the module header.)
       return entry.symbol !== undefined
         ? { id: entry.id, file: entry.file, rule: entry.kind }
-        : { id: entry.id, file: entry.file, line: entry.lineRange?.[0], rule: entry.kind };
+        : {
+            id: entry.id,
+            file: entry.file,
+            line: entry.lineRange?.[0],
+            rule: entry.kind,
+            ...(entry.contentHash !== undefined ? { contentHash: entry.contentHash } : {}),
+          };
     case 'test-gap':
     case 'test-file-degradation':
     case 'god-file':

--- a/src/baseline/fragment.ts
+++ b/src/baseline/fragment.ts
@@ -28,6 +28,7 @@ import type { BaselineFile } from './baseline-file';
 import { CURRENT_IDENTITY_SCHEME, type BaselineEntry, type IdentitySchemeVersion } from './types';
 import { RECALL_EPOCHS, type RecallMap } from './recall';
 import { customCheckFindingsToBaselineEntries } from './producers/custom-checks';
+import { stampEntries } from './content-stamp';
 import {
   gatherCustomCheckFindings,
   observableSpecs,
@@ -153,7 +154,9 @@ export function captureFragment(opts: CaptureFragmentOptions): BaselineFragment 
     identityScheme: CURRENT_IDENTITY_SCHEME,
     customCheckEpoch: RECALL_EPOCHS['custom-check'],
     checks: selected.map((s) => s.name),
-    findings: customCheckFindingsToBaselineEntries(findings),
+    // Stamped through the SAME one entry point the orchestrator uses, so a
+    // fragment-captured slice pairs across a reformat like any other entry.
+    findings: stampEntries(customCheckFindingsToBaselineEntries(findings), opts.cwd),
     recallInputs: recallInputsForSpecs(selected),
   };
 }

--- a/src/baseline/git-aware-match.ts
+++ b/src/baseline/git-aware-match.ts
@@ -66,6 +66,11 @@ const LINE_FUZZ_RANGE = 2;
  *  a content-hash pair demotes to `'uncertain'`; for critical
  *  findings (threshold 0.75), it passes through cleanly. */
 export const CONFIDENCE_CONTENT_HASH = 0.8;
+/** Confidence for a SAME-FILE (or git-rename-mapped) content-hash pair:
+ *  same rule + identical normalized window + same file. Sits at the
+ *  strictest per-severity threshold (low: 0.90) so a pure reformat reads
+ *  persisted on every severity, never demoted to `uncertain`. */
+export const CONFIDENCE_CONTENT_HASH_SAME_FILE = 0.9;
 /** Confidence assigned to a modified-hunk endpoint pair (#271): the
  *  line itself changed, so there is no line-map image and no byte
  *  identity — the evidence is the hunk STRUCTURE plus an unambiguous
@@ -448,56 +453,100 @@ export function gitAwareMatch(
 
   // Pass 1.5 — content-hash fallback. Pairs prior+current findings
   // by `(canonicalRule, contentHash)` when both sides carry a
-  // content hash (stamped by the producer). Runs regardless of git
+  // content hash (stamped by the orchestrator). Runs regardless of git
   // reachability — content hashes are file-content-derived and
-  // don't need git to compare. Confidence is below the git-line
-  // tier so the policy classifier's per-severity thresholds tune
-  // whether to trust the match.
+  // don't need git to compare.
+  //
+  // Two phases, so the outcome never depends on prior iteration order:
+  // identical boilerplate windows in different files (copied components,
+  // generated code) hash identically under one rule, and a greedy
+  // first-come take would let a prior whose own file lost its candidate
+  // steal another file's twin. Phase 1 pairs every prior that has a
+  // candidate in its OWN file (or, when the git pass saw the file renamed,
+  // in the renamed file — git evidence outranks a same-old-path twin).
+  // Phase 2 pairs the leftovers cross-file (a rename git could not see).
+  // A same-file/renamed pair carries higher confidence than a cross-file
+  // one: same rule + identical normalized window + same file is strong
+  // evidence, and it must clear the per-severity thresholds so a pure
+  // reformat reads persisted, not demoted to uncertain.
   {
-    const currentByContent = new Map<string, LocatedIdentity[]>();
+    interface ContentBucket {
+      byFile: Map<string, LocatedIdentity[]>;
+      order: LocatedIdentity[];
+    }
+    const buckets = new Map<string, ContentBucket>();
+    const taken = new Set<LocatedIdentity>();
     for (const c of current) {
       if (currentMatched.has(c)) continue;
       if (!c.contentHash || !c.rule) continue;
       const key = contentKey(c.rule, c.contentHash);
-      const bucket = currentByContent.get(key);
-      if (bucket) bucket.push(c);
-      else currentByContent.set(key, [c]);
+      let bucket = buckets.get(key);
+      if (!bucket) {
+        bucket = { byFile: new Map(), order: [] };
+        buckets.set(key, bucket);
+      }
+      bucket.order.push(c);
+      if (c.file !== undefined) {
+        const files = bucket.byFile.get(c.file);
+        if (files) files.push(c);
+        else bucket.byFile.set(c.file, [c]);
+      }
     }
-    // Same-file candidates first: identical boilerplate windows in different
-    // files (copied components, generated code) hash identically under one
-    // rule, and pairing a prior with another file's twin would report the
-    // real relocation as net-new at the wrong path. Only when no same-file
-    // candidate exists does the pass accept a cross-file one (a rename).
-    const takeContent = (key: string, file: string | undefined): LocatedIdentity | undefined => {
-      const bucket = currentByContent.get(key);
-      if (!bucket || bucket.length === 0) return undefined;
-      const sameFile = file === undefined ? -1 : bucket.findIndex((c) => c.file === file);
-      const [taken] = bucket.splice(sameFile >= 0 ? sameFile : 0, 1);
-      if (bucket.length === 0) currentByContent.delete(key);
-      return taken;
-    };
-    for (const p of prior) {
-      if (priorMatched.has(p)) continue;
-      if (!p.contentHash || !p.rule) continue;
-      const candidate = takeContent(contentKey(p.rule, p.contentHash), p.file);
-      if (!candidate) continue;
+    const pairUp = (p: LocatedIdentity, c: LocatedIdentity, confidence: number): void => {
       priorMatched.add(p);
-      currentMatched.add(candidate);
-      const pathChanged = !!(p.file && candidate.file && p.file !== candidate.file);
+      currentMatched.add(c);
+      taken.add(c);
+      const pathChanged = !!(p.file && c.file && p.file !== c.file);
       pairs.push({
         priorId: p.id,
-        currentId: candidate.id,
+        currentId: c.id,
         status: pathChanged ? 'relocated' : 'persisted',
-        confidence: CONFIDENCE_CONTENT_HASH,
+        confidence,
         reasons: [
           {
             code: 'content-hash',
             detail: pathChanged
-              ? `content-hash match across rename: ${p.file ?? '?'} → ${candidate.file ?? '?'}`
+              ? `content-hash match across rename: ${p.file ?? '?'} → ${c.file ?? '?'}`
               : 'content-hash match (surrounding code byte-identical after whitespace normalization)',
           },
         ],
       });
+    };
+    const takeFromFile = (bucket: ContentBucket, file: string): LocatedIdentity | undefined => {
+      const files = bucket.byFile.get(file);
+      while (files && files.length > 0) {
+        const c = files.shift()!;
+        if (!taken.has(c)) return c;
+      }
+      return undefined;
+    };
+    // Phase 1: same-file (git-rename-mapped first).
+    for (const p of prior) {
+      if (priorMatched.has(p)) continue;
+      if (!p.contentHash || !p.rule || p.file === undefined) continue;
+      const bucket = buckets.get(contentKey(p.rule, p.contentHash));
+      if (!bucket) continue;
+      const renamedTo = renames.get(p.file);
+      const candidate =
+        (renamedTo !== undefined ? takeFromFile(bucket, renamedTo) : undefined) ??
+        takeFromFile(bucket, p.file);
+      if (candidate) pairUp(p, candidate, CONFIDENCE_CONTENT_HASH_SAME_FILE);
+    }
+    // Phase 2: cross-file leftovers.
+    for (const p of prior) {
+      if (priorMatched.has(p)) continue;
+      if (!p.contentHash || !p.rule) continue;
+      const bucket = buckets.get(contentKey(p.rule, p.contentHash));
+      if (!bucket) continue;
+      let candidate: LocatedIdentity | undefined;
+      while (bucket.order.length > 0) {
+        const c = bucket.order.shift()!;
+        if (!taken.has(c)) {
+          candidate = c;
+          break;
+        }
+      }
+      if (candidate) pairUp(p, candidate, CONFIDENCE_CONTENT_HASH);
     }
   }
 

--- a/src/baseline/git-aware-match.ts
+++ b/src/baseline/git-aware-match.ts
@@ -463,17 +463,23 @@ export function gitAwareMatch(
       if (bucket) bucket.push(c);
       else currentByContent.set(key, [c]);
     }
-    const takeContent = (key: string): LocatedIdentity | undefined => {
+    // Same-file candidates first: identical boilerplate windows in different
+    // files (copied components, generated code) hash identically under one
+    // rule, and pairing a prior with another file's twin would report the
+    // real relocation as net-new at the wrong path. Only when no same-file
+    // candidate exists does the pass accept a cross-file one (a rename).
+    const takeContent = (key: string, file: string | undefined): LocatedIdentity | undefined => {
       const bucket = currentByContent.get(key);
       if (!bucket || bucket.length === 0) return undefined;
-      const head = bucket.shift();
+      const sameFile = file === undefined ? -1 : bucket.findIndex((c) => c.file === file);
+      const [taken] = bucket.splice(sameFile >= 0 ? sameFile : 0, 1);
       if (bucket.length === 0) currentByContent.delete(key);
-      return head;
+      return taken;
     };
     for (const p of prior) {
       if (priorMatched.has(p)) continue;
       if (!p.contentHash || !p.rule) continue;
-      const candidate = takeContent(contentKey(p.rule, p.contentHash));
+      const candidate = takeContent(contentKey(p.rule, p.contentHash), p.file);
       if (!candidate) continue;
       priorMatched.add(p);
       currentMatched.add(candidate);

--- a/src/baseline/git-aware-match.ts
+++ b/src/baseline/git-aware-match.ts
@@ -65,7 +65,7 @@ const LINE_FUZZ_RANGE = 2;
  *  bytes alone." For low-severity findings (default threshold 0.90),
  *  a content-hash pair demotes to `'uncertain'`; for critical
  *  findings (threshold 0.75), it passes through cleanly. */
-const CONFIDENCE_CONTENT_HASH = 0.8;
+export const CONFIDENCE_CONTENT_HASH = 0.8;
 /** Confidence assigned to a modified-hunk endpoint pair (#271): the
  *  line itself changed, so there is no line-map image and no byte
  *  identity — the evidence is the hunk STRUCTURE plus an unambiguous

--- a/src/baseline/git-aware-match.ts
+++ b/src/baseline/git-aware-match.ts
@@ -526,10 +526,13 @@ export function gitAwareMatch(
       if (!p.contentHash || !p.rule || p.file === undefined) continue;
       const bucket = buckets.get(contentKey(p.rule, p.contentHash));
       if (!bucket) continue;
+      // A renamed-away file's OLD path now belongs to a different file (or to
+      // nothing): a window twin there is new code wearing familiar bytes, so
+      // after a detected rename only the renamed path qualifies for the
+      // same-file tier; the old path never falls back.
       const renamedTo = renames.get(p.file);
       const candidate =
-        (renamedTo !== undefined ? takeFromFile(bucket, renamedTo) : undefined) ??
-        takeFromFile(bucket, p.file);
+        renamedTo !== undefined ? takeFromFile(bucket, renamedTo) : takeFromFile(bucket, p.file);
       if (candidate) pairUp(p, candidate, CONFIDENCE_CONTENT_HASH_SAME_FILE);
     }
     // Phase 2: cross-file leftovers.

--- a/src/baseline/migrate.ts
+++ b/src/baseline/migrate.ts
@@ -262,8 +262,13 @@ export function restampContentHashes(cwd: string, baselineName = 'main'): Restam
   const sha = file.repo?.commitSha;
   if (!sha) return null;
   const result = restampAtCommit(file.findings, cwd, sha);
-  if (result.restamped === 0) return null;
-  writeBaselineFile(blPath, { ...file, findings: result.entries });
+  if (result.restamped === 0 && result.unreadable === 0) return null;
+  if (result.restamped > 0) {
+    writeBaselineFile(blPath, { ...file, findings: result.entries });
+  }
+  // restamped 0 + unreadable > 0 (an unreachable anchor: shallow clone,
+  // force-pushed history): nothing to write, but the caller must SAY so.
+  // Silence here would read as "reformat-tolerant matching is active".
   return { restamped: result.restamped, unreadable: result.unreadable };
 }
 

--- a/src/baseline/migrate.ts
+++ b/src/baseline/migrate.ts
@@ -31,7 +31,8 @@
 
 import * as fs from 'fs';
 import { createBaseline, gatherCurrentScan } from './create';
-import { pathForBaseline, readBaselineFile } from './baseline-file';
+import { pathForBaseline, readBaselineFile, writeBaselineFile } from './baseline-file';
+import { restampAtCommit } from './content-stamp';
 import type { BaselineFile } from './baseline-file';
 import { identityFor } from './finding-identity';
 import { RECALL_EPOCHS } from './recall';
@@ -228,6 +229,43 @@ export type StaleRecall =
   /** dxkit changed what it observes for a kind since the baseline was
    *  captured (an epoch bump), so that kind degrades to warn. */
   | 'epoch-gap';
+
+/** What a content-hash restamp did (see `restampContentHashes`). */
+export interface RestampSummary {
+  readonly restamped: number;
+  readonly unreadable: number;
+}
+
+/**
+ * Restamp a pre-scheme baseline's located entries with content hashes.
+ *
+ * A baseline written before the 4.4.5 stamp scheme has located entries with
+ * no `contentHash`, so the matcher's content pass (the one that survives a
+ * whole-file reformat) is silently unavailable until the next refresh. The
+ * fix needs no rescan: the baseline's line numbers describe the tree at its
+ * anchor commit, so the files can be read AT THAT COMMIT and hashed
+ * (`restampAtCommit` — the migrate lane is the one commit-read call site).
+ * Rides `vyuh-dxkit update` beside the scheme/recall probes; returns null
+ * when there is nothing to do (no baseline, nothing bare, no resolvable
+ * anchor). Files unreadable at the anchor leave their entries bare,
+ * disclosed via the summary, never a throw.
+ */
+export function restampContentHashes(cwd: string, baselineName = 'main'): RestampSummary | null {
+  const blPath = pathForBaseline(cwd, baselineName);
+  if (!fs.existsSync(blPath)) return null;
+  let file: BaselineFile;
+  try {
+    file = readBaselineFile(blPath);
+  } catch {
+    return null;
+  }
+  const sha = file.repo?.commitSha;
+  if (!sha) return null;
+  const result = restampAtCommit(file.findings, cwd, sha);
+  if (result.restamped === 0) return null;
+  writeBaselineFile(blPath, { ...file, findings: result.entries });
+  return { restamped: result.restamped, unreadable: result.unreadable };
+}
 
 /**
  * Detect whether a repo's committed baseline predates the current recall

--- a/src/baseline/producers/custom-checks.ts
+++ b/src/baseline/producers/custom-checks.ts
@@ -14,7 +14,7 @@
  * Content-hash scheme (the reformat-survival layer). Every LOCATED entry is
  * stamped with `contentHash` through the shared `contentStamper`: SHA-1[0:16]
  * of the whitespace-normalized 7-line window around the finding, read from the
- * file AT THE ANCHOR COMMIT (`git show <sha>:<file>`), the same scheme the
+ * working tree the finding was scanned on, the same scheme the
  * secret / code / config / duplication / stale-allow kinds use. The
  * git-aware matcher keys its content-hash pass on `(rule, contentHash)`; the
  * rule string for a custom-check pair is `check/rule` (or the bare check
@@ -28,7 +28,9 @@
  * custom-check entries. That degrades to exactly the pre-scheme behavior (the
  * matcher skips a side without a hash; the git and identity passes still
  * run), so no migration step and no rescan are needed. The next baseline
- * refresh stamps the entries.
+ * refresh stamps the entries. Stamps are only as good as the tree they read:
+ * a baseline captured on a dirty tree hashes that tree, which is also what its
+ * line numbers describe.
  *
  * BINARY findings (no `file`) are whole-command pass/fail with no location;
  * they carry no hash by construction.

--- a/src/baseline/producers/custom-checks.ts
+++ b/src/baseline/producers/custom-checks.ts
@@ -9,16 +9,41 @@
  *
  * The findings are gathered ONCE by the orchestrator (into
  * `ProducerContext.customCheckFindings`) and passed here — this producer is a
- * pure map, never a shell-out.
+ * pure map apart from the best-effort content-hash read, never a shell-out.
+ *
+ * Content-hash scheme (the reformat-survival layer). Every LOCATED entry is
+ * stamped with `contentHash` through the shared `contentStamper`: SHA-1[0:16]
+ * of the whitespace-normalized 7-line window around the finding, read from the
+ * file AT THE ANCHOR COMMIT (`git show <sha>:<file>`), the same scheme the
+ * secret / code / config / duplication / stale-allow kinds use. The
+ * git-aware matcher keys its content-hash pass on `(rule, contentHash)`; the
+ * rule string for a custom-check pair is `check/rule` (or the bare check
+ * label), minted identically on both sides by `entryToLocated`. So a
+ * whole-file reindent, which moves every line past the 3-line identity window
+ * AND rewrites every line in the diff (no line-map image for the git pass),
+ * still pairs each grandfathered lint finding with its moved self instead of
+ * reading as "resolved" plus "net-new".
+ *
+ * Migration: baselines written before this scheme carry no `contentHash` on
+ * custom-check entries. That degrades to exactly the pre-scheme behavior (the
+ * matcher skips a side without a hash; the git and identity passes still
+ * run), so no migration step and no rescan are needed. The next baseline
+ * refresh stamps the entries.
+ *
+ * BINARY findings (no `file`) are whole-command pass/fail with no location;
+ * they carry no hash by construction.
  */
 
+import { contentStamper, type ContentStampSource } from '../content-stamp';
 import { identityFor } from '../finding-identity';
 import type { CustomCheckFinding } from '../../analyzers/custom-checks/types';
 import type { RichBaselineEntry } from '../types';
 
 export function customCheckFindingsToBaselineEntries(
   findings: readonly CustomCheckFinding[],
+  commit?: ContentStampSource,
 ): RichBaselineEntry[] {
+  const stamp = contentStamper(commit);
   // ONE entry per identity. Located identity buckets lines into the shared
   // 3-line window (Rule 9), so a linter reporting the same rule on adjacent
   // lines mints the SAME fingerprint N times — and the multiset survived
@@ -41,6 +66,8 @@ export function customCheckFindingsToBaselineEntries(
       hit.occurrences += 1;
       continue;
     }
+    const contentHash =
+      f.file !== undefined && f.line !== undefined ? stamp(f.file, f.line) : undefined;
     byId.set(id, {
       occurrences: 1,
       entry: {
@@ -52,6 +79,7 @@ export function customCheckFindingsToBaselineEntries(
         ...(f.line !== undefined ? { line: f.line } : {}),
         ...(f.rule !== undefined ? { rule: f.rule } : {}),
         ...(f.message !== undefined ? { message: f.message } : {}),
+        ...(contentHash !== undefined ? { contentHash } : {}),
       },
     });
   }

--- a/src/baseline/producers/custom-checks.ts
+++ b/src/baseline/producers/custom-checks.ts
@@ -11,41 +11,28 @@
  * `ProducerContext.customCheckFindings`) and passed here — this producer is a
  * pure map apart from the best-effort content-hash read, never a shell-out.
  *
- * Content-hash scheme (the reformat-survival layer). Every LOCATED entry is
- * stamped with `contentHash` through the shared `contentStamper`: SHA-1[0:16]
- * of the whitespace-normalized 7-line window around the finding, read from the
- * working tree the finding was scanned on, the same scheme the
- * secret / code / config / duplication / stale-allow kinds use. The
- * git-aware matcher keys its content-hash pass on `(rule, contentHash)`; the
- * rule string for a custom-check pair is `check/rule` (or the bare check
- * label), minted identically on both sides by `entryToLocated`. So a
- * whole-file reindent, which moves every line past the 3-line identity window
- * AND rewrites every line in the diff (no line-map image for the git pass),
- * still pairs each grandfathered lint finding with its moved self instead of
- * reading as "resolved" plus "net-new".
+ * Content-hash stamping lives in the orchestrator (`stampEntries` in
+ * content-stamp.ts): this producer emits bare entries. Within one identity
+ * bucket (the shared 3-line window) the entry records the MINIMUM reported
+ * line, so the stamped window is independent of the linter's output order
+ * (two occurrences reported in either order yield one hash).
  *
- * Migration: baselines written before this scheme carry no `contentHash` on
- * custom-check entries. That degrades to exactly the pre-scheme behavior (the
- * matcher skips a side without a hash; the git and identity passes still
- * run), so no migration step and no rescan are needed. The next baseline
- * refresh stamps the entries. Stamps are only as good as the tree they read:
- * a baseline captured on a dirty tree hashes that tree, which is also what its
- * line numbers describe.
+ * Migration: baselines written before the stamp scheme carry no
+ * `contentHash` on custom-check entries. The matcher degrades to the git
+ * and identity passes, and the update/migrate lane restamps them at the
+ * baseline's anchor commit (`restampAtCommit`).
  *
  * BINARY findings (no `file`) are whole-command pass/fail with no location;
  * they carry no hash by construction.
  */
 
-import { contentStamper, type ContentStampSource } from '../content-stamp';
 import { identityFor } from '../finding-identity';
 import type { CustomCheckFinding } from '../../analyzers/custom-checks/types';
 import type { RichBaselineEntry } from '../types';
 
 export function customCheckFindingsToBaselineEntries(
   findings: readonly CustomCheckFinding[],
-  commit?: ContentStampSource,
 ): RichBaselineEntry[] {
-  const stamp = contentStamper(commit);
   // ONE entry per identity. Located identity buckets lines into the shared
   // 3-line window (Rule 9), so a linter reporting the same rule on adjacent
   // lines mints the SAME fingerprint N times — and the multiset survived
@@ -66,10 +53,18 @@ export function customCheckFindingsToBaselineEntries(
     const hit = byId.get(id);
     if (hit) {
       hit.occurrences += 1;
+      // Minimum-line rule: the bucket's recorded line (and thus the stamped
+      // window) must not depend on which occurrence the linter printed first.
+      if (
+        f.line !== undefined &&
+        'line' in hit.entry &&
+        typeof hit.entry.line === 'number' &&
+        f.line < hit.entry.line
+      ) {
+        hit.entry = { ...hit.entry, line: f.line };
+      }
       continue;
     }
-    const contentHash =
-      f.file !== undefined && f.line !== undefined ? stamp(f.file, f.line) : undefined;
     byId.set(id, {
       occurrences: 1,
       entry: {
@@ -81,7 +76,6 @@ export function customCheckFindingsToBaselineEntries(
         ...(f.line !== undefined ? { line: f.line } : {}),
         ...(f.rule !== undefined ? { rule: f.rule } : {}),
         ...(f.message !== undefined ? { message: f.message } : {}),
-        ...(contentHash !== undefined ? { contentHash } : {}),
       },
     });
   }

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -58,7 +58,7 @@ import type { CustomCheckFinding } from '../../analyzers/custom-checks/types';
 import type { BaselineEntry, RichBaselineEntry } from '../types';
 import { RECALL_EPOCHS, type RecallContext, type RecallMap } from '../recall';
 import { resolveToolInputs, splitTools, toolRecall } from './recall-inputs';
-import { contentStampSource } from '../content-stamp';
+import { stampEntries } from '../content-stamp';
 import { customCheckFindingsToBaselineEntries } from './custom-checks';
 import { LICENSES_PRODUCER } from './licenses';
 import { largeFilesToBaselineEntries } from './health';
@@ -99,9 +99,9 @@ export interface HygieneSnapshot {
 export interface ProducerContext {
   /** Absolute repo path. */
   readonly cwd: string;
-  /** Commit SHA the baseline anchors to. Empty string when not in
-   *  a git repo — content-hash stamping is then disabled but other
-   *  producers still emit normally. */
+  /** Commit SHA the baseline anchors to; display/provenance only. Empty
+   *  string when not in a git repo. Content-hash stamping does NOT depend
+   *  on it — the orchestrator stamps from the working tree (`cwd`). */
   readonly commitSha: string;
   /** Resolved repo salt (from `resolveSalt`). Threaded into
    *  producers that compute HMACs. */
@@ -217,7 +217,7 @@ const SECURITY_PRODUCER: BaselineProducer = {
   produce(ctx) {
     const aggregate = ctx.analysisResult.capabilities.securityAggregate;
     if (!aggregate) return [];
-    return securityAggregateToBaselineEntries(aggregate, { cwd: ctx.cwd });
+    return securityAggregateToBaselineEntries(aggregate);
   },
   recallContexts(ctx) {
     const p = ctx.analysisResult.capabilities.securityAggregate?.provenance;
@@ -276,9 +276,7 @@ const QUALITY_PRODUCER: BaselineProducer = {
   contributes: ['duplication', 'stale-file'],
   produce(ctx) {
     return [
-      ...duplicationToBaselineEntries(ctx.analysisResult.capabilities.duplication, {
-        cwd: ctx.cwd,
-      }),
+      ...duplicationToBaselineEntries(ctx.analysisResult.capabilities.duplication),
       ...staleFilesToBaselineEntries(ctx.hygiene.staleFiles),
     ];
   },
@@ -338,7 +336,6 @@ const STALE_ALLOW_PRODUCER: BaselineProducer = {
     return staleAllowToBaselineEntries({
       annotations: ctx.inlineAllowlistAnnotations,
       aggregate: ctx.analysisResult.capabilities.securityAggregate ?? null,
-      commit: { cwd: ctx.cwd },
     });
   },
   recallContexts(ctx) {
@@ -356,9 +353,8 @@ const CUSTOM_CHECK_PRODUCER: BaselineProducer = {
   produce(ctx) {
     // Stamped through the shared content-hash entry point (content-stamp.ts) so a
     // located lint finding survives a whole-file reformat like every other
-    // located kind; the source is the context's anchor commit (absent on a
     // bare tree, in which case nothing is stamped).
-    return customCheckFindingsToBaselineEntries(ctx.customCheckFindings, contentStampSource(ctx));
+    return customCheckFindingsToBaselineEntries(ctx.customCheckFindings);
   },
   recallContexts(ctx) {
     // Resolved by the seam (Rule 17's one entry point) across all three of its
@@ -405,7 +401,10 @@ export function runProducers(
   for (const producer of producers) {
     out.push(...producer.produce(ctx));
   }
-  return out;
+  // Stamp ONCE, through the same located projection the matcher pairs on
+  // (content-stamp.ts): a producer cannot forget to stamp, and a new located
+  // kind is stamped the day it lands.
+  return stampEntries(out, ctx.cwd);
 }
 
 /**

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -31,8 +31,8 @@
  *   2. Reads from the shared `ProducerContext` (gathered once by
  *      the orchestrator so multiple producers don't re-shell the
  *      same analyzer).
- *   3. Returns `BaselineEntry[]` — pure or near-pure, depending on
- *      whether content-hash stamping is needed.
+ *   3. Returns `BaselineEntry[]` — a pure map. Content-hash stamping is the
+ *      ORCHESTRATOR's job (`stampEntries`), never a producer's.
  *
  * # Adding a new identity kind
  *
@@ -352,8 +352,7 @@ const CUSTOM_CHECK_PRODUCER: BaselineProducer = {
   contributes: ['custom-check'],
   produce(ctx) {
     // Stamped through the shared content-hash entry point (content-stamp.ts) so a
-    // located lint finding survives a whole-file reformat like every other
-    // bare tree, in which case nothing is stamped).
+    // located lint finding survives a whole-file reformat like every other located kind.
     return customCheckFindingsToBaselineEntries(ctx.customCheckFindings);
   },
   recallContexts(ctx) {

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -58,6 +58,7 @@ import type { CustomCheckFinding } from '../../analyzers/custom-checks/types';
 import type { BaselineEntry, RichBaselineEntry } from '../types';
 import { RECALL_EPOCHS, type RecallContext, type RecallMap } from '../recall';
 import { resolveToolInputs, splitTools, toolRecall } from './recall-inputs';
+import { contentStampSource } from '../content-stamp';
 import { customCheckFindingsToBaselineEntries } from './custom-checks';
 import { LICENSES_PRODUCER } from './licenses';
 import { largeFilesToBaselineEntries } from './health';
@@ -357,7 +358,11 @@ const CUSTOM_CHECK_PRODUCER: BaselineProducer = {
   name: 'custom-check',
   contributes: ['custom-check'],
   produce(ctx) {
-    return customCheckFindingsToBaselineEntries(ctx.customCheckFindings);
+    // Stamped through the shared content-hash entry point (content-stamp.ts) so a
+    // located lint finding survives a whole-file reformat like every other
+    // located kind; the source is the context's anchor commit (absent on a
+    // bare tree, in which case nothing is stamped).
+    return customCheckFindingsToBaselineEntries(ctx.customCheckFindings, contentStampSource(ctx));
   },
   recallContexts(ctx) {
     // Resolved by the seam (Rule 17's one entry point) across all three of its

--- a/src/baseline/producers/index.ts
+++ b/src/baseline/producers/index.ts
@@ -217,10 +217,7 @@ const SECURITY_PRODUCER: BaselineProducer = {
   produce(ctx) {
     const aggregate = ctx.analysisResult.capabilities.securityAggregate;
     if (!aggregate) return [];
-    return securityAggregateToBaselineEntries(aggregate, {
-      cwd: ctx.cwd,
-      commitSha: ctx.commitSha || undefined,
-    });
+    return securityAggregateToBaselineEntries(aggregate, { cwd: ctx.cwd });
   },
   recallContexts(ctx) {
     const p = ctx.analysisResult.capabilities.securityAggregate?.provenance;
@@ -281,7 +278,6 @@ const QUALITY_PRODUCER: BaselineProducer = {
     return [
       ...duplicationToBaselineEntries(ctx.analysisResult.capabilities.duplication, {
         cwd: ctx.cwd,
-        commitSha: ctx.commitSha,
       }),
       ...staleFilesToBaselineEntries(ctx.hygiene.staleFiles),
     ];
@@ -342,7 +338,7 @@ const STALE_ALLOW_PRODUCER: BaselineProducer = {
     return staleAllowToBaselineEntries({
       annotations: ctx.inlineAllowlistAnnotations,
       aggregate: ctx.analysisResult.capabilities.securityAggregate ?? null,
-      commit: { cwd: ctx.cwd, commitSha: ctx.commitSha },
+      commit: { cwd: ctx.cwd },
     });
   },
   recallContexts(ctx) {

--- a/src/baseline/producers/quality.ts
+++ b/src/baseline/producers/quality.ts
@@ -27,8 +27,7 @@
  *     positions, not just counts. Pending in a follow-up commit.
  */
 
-import { contentStamper, type ContentStampSource } from '../content-stamp';
-import { duplicationCanonicalSides, identityFor } from '../finding-identity';
+import { identityFor } from '../finding-identity';
 import type { RichBaselineEntry, DuplicationIdentityInput, StaleFileIdentityInput } from '../types';
 import type { DuplicationResult } from '../../languages/capabilities/types';
 
@@ -41,21 +40,13 @@ const STALE_SUFFIXES = new Set(['swp', 'swo', 'bak', 'orig', 'tmp', 'log', 'pyc'
 /**
  * Build `duplication` entries from a jscpd-style envelope.
  *
- * When `opts` carries the repo + baseline commit, each entry is stamped with a
- * `contentHash` of the block content at the canonical representative side — the
- * same `(file, startLine)` the matcher's locator uses, so prior + current agree
- * on what to hash. That lets the matcher's content-hash pass relocate the clone
- * across a line shift WITHOUT git history (shallow clones / force-pushed
- * baselines), matching the protection secret/code/hygiene already have. Omitted
- * (best-effort) when no commit is available or the file can't be read.
+ * The `contentHash` stamp is applied by the orchestrator (content-stamp.ts).
  */
 export function duplicationToBaselineEntries(
   duplication: DuplicationResult | undefined,
-  opts?: ContentStampSource,
 ): RichBaselineEntry[] {
   if (!duplication) return [];
   const out: RichBaselineEntry[] = [];
-  const stamp = contentStamper(opts);
   for (const clone of duplication.topClones) {
     const input: DuplicationIdentityInput = {
       kind: 'duplication',
@@ -65,13 +56,6 @@ export function duplicationToBaselineEntries(
       startLineA: clone.a.startLine,
       startLineB: clone.b.startLine,
     };
-    const [first] = duplicationCanonicalSides(
-      clone.a.file,
-      clone.a.startLine,
-      clone.b.file,
-      clone.b.startLine,
-    );
-    const contentHash = stamp(first[0], first[1]);
     out.push({
       id: identityFor(input),
       kind: 'duplication',
@@ -80,7 +64,6 @@ export function duplicationToBaselineEntries(
       lines: clone.lines,
       startLineA: clone.a.startLine,
       startLineB: clone.b.startLine,
-      ...(contentHash !== undefined ? { contentHash } : {}),
     });
   }
   return out;

--- a/src/baseline/producers/quality.ts
+++ b/src/baseline/producers/quality.ts
@@ -27,7 +27,7 @@
  *     positions, not just counts. Pending in a follow-up commit.
  */
 
-import { contentStamper } from '../content-stamp';
+import { contentStamper, type ContentStampSource } from '../content-stamp';
 import { duplicationCanonicalSides, identityFor } from '../finding-identity';
 import type { RichBaselineEntry, DuplicationIdentityInput, StaleFileIdentityInput } from '../types';
 import type { DuplicationResult } from '../../languages/capabilities/types';
@@ -51,7 +51,7 @@ const STALE_SUFFIXES = new Set(['swp', 'swo', 'bak', 'orig', 'tmp', 'log', 'pyc'
  */
 export function duplicationToBaselineEntries(
   duplication: DuplicationResult | undefined,
-  opts?: { readonly cwd: string; readonly commitSha: string },
+  opts?: ContentStampSource,
 ): RichBaselineEntry[] {
   if (!duplication) return [];
   const out: RichBaselineEntry[] = [];

--- a/src/baseline/producers/quality.ts
+++ b/src/baseline/producers/quality.ts
@@ -27,7 +27,7 @@
  *     positions, not just counts. Pending in a follow-up commit.
  */
 
-import { computeContentHashFromCommit } from '../content-hash';
+import { contentStamper } from '../content-stamp';
 import { duplicationCanonicalSides, identityFor } from '../finding-identity';
 import type { RichBaselineEntry, DuplicationIdentityInput, StaleFileIdentityInput } from '../types';
 import type { DuplicationResult } from '../../languages/capabilities/types';
@@ -55,6 +55,7 @@ export function duplicationToBaselineEntries(
 ): RichBaselineEntry[] {
   if (!duplication) return [];
   const out: RichBaselineEntry[] = [];
+  const stamp = contentStamper(opts);
   for (const clone of duplication.topClones) {
     const input: DuplicationIdentityInput = {
       kind: 'duplication',
@@ -64,17 +65,13 @@ export function duplicationToBaselineEntries(
       startLineA: clone.a.startLine,
       startLineB: clone.b.startLine,
     };
-    let contentHash: string | undefined;
-    if (opts) {
-      const [first] = duplicationCanonicalSides(
-        clone.a.file,
-        clone.a.startLine,
-        clone.b.file,
-        clone.b.startLine,
-      );
-      contentHash =
-        computeContentHashFromCommit(opts.cwd, opts.commitSha, first[0], first[1]) ?? undefined;
-    }
+    const [first] = duplicationCanonicalSides(
+      clone.a.file,
+      clone.a.startLine,
+      clone.b.file,
+      clone.b.startLine,
+    );
+    const contentHash = stamp(first[0], first[1]);
     out.push({
       id: identityFor(input),
       kind: 'duplication',

--- a/src/baseline/producers/security.ts
+++ b/src/baseline/producers/security.ts
@@ -4,9 +4,9 @@
  * Converts the canonical `SecurityAggregate` produced by the security
  * analyzer (`src/analyzers/security/aggregator.ts`) into the per-kind
  * `BaselineEntry` shape stored in the baseline file. Pure function
- * over its input apart from the optional content-hash stamp, which
- * reads the file at the baseline commit via git (skipped when the
- * caller doesn't supply a commit SHA).
+ * over its input — a pure map from the aggregate to entries. The
+ * `contentHash` stamp is applied by the ORCHESTRATOR (`stampEntries`
+ * in content-stamp.ts), never per producer.
  *
  * Four `BaselineEntry` kinds are derived here, matching the four
  * categories the aggregator emits:
@@ -26,20 +26,11 @@
  * the same line) and a `secret-hmac` entry (content identity, stable
  * across file moves).
  *
- * Content-hash stamping (third-pass matcher fallback): when `cwd` +
- * `commitSha` are supplied, the shared `contentStamper` (the one
- * stamping entry point every located kind uses) reads each file at
- * the baseline commit and hashes the normalized context window around
- * the finding's line. The hash lands in `BaselineEntry.contentHash`
- * for the secret / code / config kinds; the matcher's content-hash
- * pass uses it to pair findings across runs even when git diff can't
- * map the line position. Producers can pass `undefined` for the SHA
- * (e.g., non-git directories) and content-hash matching is simply
- * unavailable for that baseline — the matcher's other passes still
- * work.
+ * Content-hash stamping lives in the orchestrator (content-stamp.ts):
+ * producers emit bare entries; `stampEntries` hashes every located one
+ * from the working tree the findings were scanned on.
  */
 
-import { contentStamper } from '../content-stamp';
 import type { SecurityAggregate } from '../../analyzers/security/aggregator';
 import { identityFor } from '../finding-identity';
 import type {
@@ -50,12 +41,6 @@ import type {
   SecretIdentityInput,
 } from '../types';
 
-export interface SecurityProducerOptions {
-  /** Repo path; the shared `contentStamper` reads the working tree the
-   * findings were scanned on. Omitting it disables content-hash stamping. */
-  readonly cwd?: string;
-}
-
 /**
  * Build `BaselineEntry`s from a `SecurityAggregate`. Returned in the
  * iteration order of the four categories so the produced baseline
@@ -63,12 +48,8 @@ export interface SecurityProducerOptions {
  */
 export function securityAggregateToBaselineEntries(
   aggregate: SecurityAggregate,
-  options: SecurityProducerOptions = {},
 ): RichBaselineEntry[] {
   const out: RichBaselineEntry[] = [];
-  // The ONE stamping entry point (content-stamp.ts): no commit, a whole-file
-  // line 0, or an unreadable file all yield no stamp.
-  const stamp = contentStamper(options.cwd ? { cwd: options.cwd } : undefined);
 
   for (const f of aggregate.findingsByCategory.secret) {
     const input: SecretIdentityInput = {
@@ -82,7 +63,6 @@ export function securityAggregateToBaselineEntries(
       // finding carries. Absent → identityFor falls back to the line hash.
       ...(f.contentAnchor !== undefined ? { contentAnchor: f.contentAnchor } : {}),
     };
-    const contentHash = stamp(f.file, f.line);
     out.push({
       id: identityFor(input),
       kind: 'secret',
@@ -91,7 +71,6 @@ export function securityAggregateToBaselineEntries(
       file: f.file,
       line: f.line,
       ...(f.severity !== undefined ? { severity: f.severity } : {}),
-      ...(contentHash !== undefined ? { contentHash } : {}),
       ...(f.absorbedFingerprints && f.absorbedFingerprints.length > 0
         ? { absorbedFingerprints: f.absorbedFingerprints }
         : {}),
@@ -109,7 +88,6 @@ export function securityAggregateToBaselineEntries(
       // built; passing it reproduces the finding's content fingerprint.
       ...(f.contentAnchor !== undefined ? { contentAnchor: f.contentAnchor } : {}),
     };
-    const contentHash = stamp(f.file, f.line);
     out.push({
       id: identityFor(input),
       kind: 'code',
@@ -118,7 +96,6 @@ export function securityAggregateToBaselineEntries(
       file: f.file,
       line: f.line,
       ...(f.severity !== undefined ? { severity: f.severity } : {}),
-      ...(contentHash !== undefined ? { contentHash } : {}),
       ...(f.absorbedFingerprints && f.absorbedFingerprints.length > 0
         ? { absorbedFingerprints: f.absorbedFingerprints }
         : {}),
@@ -139,7 +116,6 @@ export function securityAggregateToBaselineEntries(
     };
     // Whole-file findings (`.env in git`) carry line 0; content-hash
     // is meaningless for them and `stamp` returns undefined.
-    const contentHash = stamp(f.file, f.line);
     out.push({
       id: identityFor(input),
       kind: 'config',
@@ -148,7 +124,6 @@ export function securityAggregateToBaselineEntries(
       file: f.file,
       line: f.line,
       ...(f.severity !== undefined ? { severity: f.severity } : {}),
-      ...(contentHash !== undefined ? { contentHash } : {}),
       ...(f.absorbedFingerprints && f.absorbedFingerprints.length > 0
         ? { absorbedFingerprints: f.absorbedFingerprints }
         : {}),

--- a/src/baseline/producers/security.ts
+++ b/src/baseline/producers/security.ts
@@ -51,15 +51,9 @@ import type {
 } from '../types';
 
 export interface SecurityProducerOptions {
-  /** Repo path; used by the shared `contentStamper` to invoke
-   * `git show`. Omitting it disables content-hash stamping. */
+  /** Repo path; the shared `contentStamper` reads the working tree the
+   * findings were scanned on. Omitting it disables content-hash stamping. */
   readonly cwd?: string;
-  /** Commit SHA the baseline is anchored to. When the working tree
-   * has uncommitted changes, callers may pass `'HEAD'` so the hash
-   * reflects committed state — content-hash matching against a
-   * later run will still work as long as both sides read the same
-   * SHA. */
-  readonly commitSha?: string;
 }
 
 /**
@@ -74,11 +68,7 @@ export function securityAggregateToBaselineEntries(
   const out: RichBaselineEntry[] = [];
   // The ONE stamping entry point (content-stamp.ts): no commit, a whole-file
   // line 0, or an unreadable file all yield no stamp.
-  const stamp = contentStamper(
-    options.cwd && options.commitSha
-      ? { cwd: options.cwd, commitSha: options.commitSha }
-      : undefined,
-  );
+  const stamp = contentStamper(options.cwd ? { cwd: options.cwd } : undefined);
 
   for (const f of aggregate.findingsByCategory.secret) {
     const input: SecretIdentityInput = {

--- a/src/baseline/producers/security.ts
+++ b/src/baseline/producers/security.ts
@@ -27,8 +27,9 @@
  * across file moves).
  *
  * Content-hash stamping (third-pass matcher fallback): when `cwd` +
- * `commitSha` are supplied, the producer reads each file at the
- * baseline commit and hashes the normalized context window around
+ * `commitSha` are supplied, the shared `contentStamper` (the one
+ * stamping entry point every located kind uses) reads each file at
+ * the baseline commit and hashes the normalized context window around
  * the finding's line. The hash lands in `BaselineEntry.contentHash`
  * for the secret / code / config kinds; the matcher's content-hash
  * pass uses it to pair findings across runs even when git diff can't
@@ -38,7 +39,7 @@
  * work.
  */
 
-import { computeContentHashFromCommit } from '../content-hash';
+import { contentStamper } from '../content-stamp';
 import type { SecurityAggregate } from '../../analyzers/security/aggregator';
 import { identityFor } from '../finding-identity';
 import type {
@@ -50,7 +51,7 @@ import type {
 } from '../types';
 
 export interface SecurityProducerOptions {
-  /** Repo path; used by `computeContentHashFromCommit` to invoke
+  /** Repo path; used by the shared `contentStamper` to invoke
    * `git show`. Omitting it disables content-hash stamping. */
   readonly cwd?: string;
   /** Commit SHA the baseline is anchored to. When the working tree
@@ -71,11 +72,13 @@ export function securityAggregateToBaselineEntries(
   options: SecurityProducerOptions = {},
 ): RichBaselineEntry[] {
   const out: RichBaselineEntry[] = [];
-  const stamp = (file: string, line: number): string | undefined => {
-    if (!options.cwd || !options.commitSha || line <= 0) return undefined;
-    const hash = computeContentHashFromCommit(options.cwd, options.commitSha, file, line);
-    return hash ?? undefined;
-  };
+  // The ONE stamping entry point (content-stamp.ts): no commit, a whole-file
+  // line 0, or an unreadable file all yield no stamp.
+  const stamp = contentStamper(
+    options.cwd && options.commitSha
+      ? { cwd: options.cwd, commitSha: options.commitSha }
+      : undefined,
+  );
 
   for (const f of aggregate.findingsByCategory.secret) {
     const input: SecretIdentityInput = {

--- a/src/baseline/producers/stale-allow.ts
+++ b/src/baseline/producers/stale-allow.ts
@@ -48,7 +48,7 @@ import { lineWindowFor } from '../../analyzers/tools/fingerprint';
 import type { SecurityAggregate } from '../../analyzers/security/aggregator';
 import type { InlineAllowlistOccurrence } from '../../allowlist/gather';
 import { coveredLineFor } from '../../allowlist/inline-synth';
-import { contentStamper } from '../content-stamp';
+import { contentStamper, type ContentStampSource } from '../content-stamp';
 import { identityFor } from '../finding-identity';
 import type { RichBaselineEntry, StaleAllowIdentityInput } from '../types';
 
@@ -60,7 +60,7 @@ export interface StaleAllowInput {
    * content-hash pass relocates it without git (the line-bucketed identity
    * re-mints on a >window shift). Best-effort: omitted when absent or the file
    * can't be read at the commit. */
-  readonly commit?: { readonly cwd: string; readonly commitSha: string };
+  readonly commit?: ContentStampSource;
 }
 
 /**

--- a/src/baseline/producers/stale-allow.ts
+++ b/src/baseline/producers/stale-allow.ts
@@ -48,7 +48,7 @@ import { lineWindowFor } from '../../analyzers/tools/fingerprint';
 import type { SecurityAggregate } from '../../analyzers/security/aggregator';
 import type { InlineAllowlistOccurrence } from '../../allowlist/gather';
 import { coveredLineFor } from '../../allowlist/inline-synth';
-import { computeContentHashFromCommit } from '../content-hash';
+import { contentStamper } from '../content-stamp';
 import { identityFor } from '../finding-identity';
 import type { RichBaselineEntry, StaleAllowIdentityInput } from '../types';
 
@@ -86,6 +86,7 @@ export function staleAllowToBaselineEntries(input: StaleAllowInput): RichBaselin
   if (input.aggregate === null) return [];
 
   const covered = buildCoveredLocations(input.aggregate);
+  const stamp = contentStamper(input.commit);
   const out: RichBaselineEntry[] = [];
   for (const occ of input.annotations) {
     // Check the line the annotation COVERS (above-line → the finding below it),
@@ -100,14 +101,7 @@ export function staleAllowToBaselineEntries(input: StaleAllowInput): RichBaselin
       line: occ.line,
       category: occ.category,
     };
-    const contentHash = input.commit
-      ? (computeContentHashFromCommit(
-          input.commit.cwd,
-          input.commit.commitSha,
-          occ.file,
-          occ.line,
-        ) ?? undefined)
-      : undefined;
+    const contentHash = stamp(occ.file, occ.line);
     out.push({
       id: identityFor(identityInput),
       kind: 'stale-allow',

--- a/src/baseline/producers/stale-allow.ts
+++ b/src/baseline/producers/stale-allow.ts
@@ -58,10 +58,8 @@ export interface StaleAllowInput {
 
 /**
  * Build `stale-allow` entries from the annotation list + the
- * canonical security aggregate. Deterministic over equal inputs; the
- * only I/O is the best-effort `contentHash` read when `input.commit`
- * is supplied (reading the annotation's context from the baseline
- * commit, same as the secret/code producer).
+ * canonical security aggregate. A pure map, deterministic over equal
+ * inputs; content-hash stamping is the orchestrator's job.
  *
  * Returns an empty array when:
  *   - The annotation list is empty (nothing to check).

--- a/src/baseline/producers/stale-allow.ts
+++ b/src/baseline/producers/stale-allow.ts
@@ -48,19 +48,12 @@ import { lineWindowFor } from '../../analyzers/tools/fingerprint';
 import type { SecurityAggregate } from '../../analyzers/security/aggregator';
 import type { InlineAllowlistOccurrence } from '../../allowlist/gather';
 import { coveredLineFor } from '../../allowlist/inline-synth';
-import { contentStamper, type ContentStampSource } from '../content-stamp';
 import { identityFor } from '../finding-identity';
 import type { RichBaselineEntry, StaleAllowIdentityInput } from '../types';
 
 export interface StaleAllowInput {
   readonly annotations: ReadonlyArray<InlineAllowlistOccurrence>;
   readonly aggregate: SecurityAggregate | null;
-  /** Repo + baseline commit. When present, each stale entry is stamped with a
-   * `contentHash` of the annotation's surrounding context, so the matcher's
-   * content-hash pass relocates it without git (the line-bucketed identity
-   * re-mints on a >window shift). Best-effort: omitted when absent or the file
-   * can't be read at the commit. */
-  readonly commit?: ContentStampSource;
 }
 
 /**
@@ -86,7 +79,6 @@ export function staleAllowToBaselineEntries(input: StaleAllowInput): RichBaselin
   if (input.aggregate === null) return [];
 
   const covered = buildCoveredLocations(input.aggregate);
-  const stamp = contentStamper(input.commit);
   const out: RichBaselineEntry[] = [];
   for (const occ of input.annotations) {
     // Check the line the annotation COVERS (above-line → the finding below it),
@@ -101,14 +93,12 @@ export function staleAllowToBaselineEntries(input: StaleAllowInput): RichBaselin
       line: occ.line,
       category: occ.category,
     };
-    const contentHash = stamp(occ.file, occ.line);
     out.push({
       id: identityFor(identityInput),
       kind: 'stale-allow',
       file: occ.file,
       line: occ.line,
       category: occ.category,
-      ...(contentHash !== undefined ? { contentHash } : {}),
     });
   }
   return out;

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -637,6 +637,11 @@ export type BaselineEntry =
       file: string;
       symbol?: string;
       lineRange?: readonly [number, number];
+      /** Content-hash of the range start's context (range-anchored gaps are
+       * line-dependent, so they carry the reformat-survival stamp like every
+       * located kind; symbol-anchored gaps are line-independent and the
+       * orchestrator leaves them bare). */
+      contentHash?: string;
     }
   | { id: FindingId; kind: 'test-gap'; file: string; risk: TestGapRisk }
   | {
@@ -647,7 +652,7 @@ export type BaselineEntry =
       marker: HygieneMarker;
       /** Same content-hash semantics as the secret/code/config variant
        * — populated when the producer can read the file at the
-       * baseline commit. */
+       * tree the findings were scanned on. */
       contentHash?: string;
     }
   | {
@@ -742,8 +747,10 @@ export type BaselineEntry =
        * scheme as secret/code/config), so the matcher's content-hash pass
        * relocates a lint finding across a whole-file reformat that both moves
        * it past the identity window and rewrites its line in the diff. Absent
-       * for a binary finding, when no commit was available, and on baselines
-       * written before the stamp (those degrade to the git + identity passes). */
+       * for a binary finding and on baselines written before the stamp
+       * (those degrade to the git + identity passes until the migrate lane
+       * restamps them). Stamped from the working tree the finding was
+       * scanned on, by the orchestrator. */
       contentHash?: string;
     }
   | {

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -590,7 +590,7 @@ export type BaselineEntry =
        * 4.2 (consumers fall back to the kind default and SAY so). */
       severity?: FindingSeverity;
       /** 16-char hex hash of normalized context around `line` at
-       * baseline-create time. Stamped via `computeContentHashFromCommit`;
+       * baseline-create time. Stamped via the shared `contentStamper`;
        * the matcher's third pass uses it as a fallback when git-aware
        * location matching fails (shallow clones, force-pushed base,
        * context survives but line shifts past the fuzz window). Absent
@@ -738,6 +738,13 @@ export type BaselineEntry =
        * output tail for a binary failure). Display metadata only — NOT hashed
        * (it is tool-captured text; Rule 9 forbids it from identity). */
       message?: string;
+      /** Content-hash of the located finding's surrounding context (same
+       * scheme as secret/code/config), so the matcher's content-hash pass
+       * relocates a lint finding across a whole-file reformat that both moves
+       * it past the identity window and rewrites its line in the diff. Absent
+       * for a binary finding, when no commit was available, and on baselines
+       * written before the stamp (those degrade to the git + identity passes). */
+      contentHash?: string;
     }
   | {
       id: FindingId;

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -719,6 +719,11 @@ export type BaselineEntry =
       /** Blended structural-similarity score in [0,1] at mint time — display
        * metadata only (identity is the anchor pair). Lets renderers rank. */
       score: number;
+      /** Content-hash of the canonical first anchor's context — the located
+       * projection carries a line, so the orchestrator stamps this kind like
+       * every other located entry (the stampEntries invariant: a line locator
+       * implies a declared contentHash field). */
+      contentHash?: string;
     }
   | {
       id: FindingId;

--- a/src/update.ts
+++ b/src/update.ts
@@ -402,6 +402,14 @@ function restampIfBare(cwd: string): void {
   try {
     const summary = restampContentHashes(cwd);
     if (!summary) return;
+    if (summary.restamped === 0) {
+      logger.warn(
+        `Content-hash restamp could not run: the baseline's anchor commit is not readable here ` +
+          `(shallow clone or rewritten history). Reformat-tolerant matching stays off for the ` +
+          `existing entries until the next baseline refresh.`,
+      );
+      return;
+    }
     logger.success(
       `Content hashes stamped onto ${summary.restamped} baseline finding(s) ` +
         `(reformat-tolerant matching now covers them).`,

--- a/src/update.ts
+++ b/src/update.ts
@@ -8,7 +8,12 @@ import { ShipInstallResult, detectDefaultBranch } from './ship-installers';
 import { detectInstallFlags, refreshManagedSurfaces } from './managed-artifacts';
 import { applyPolicyDerivedFlags } from './managed-artifacts-detect';
 import * as logger from './logger';
-import { detectStaleRecall, detectStaleScheme, migrateIdentity } from './baseline/migrate';
+import {
+  detectStaleRecall,
+  detectStaleScheme,
+  migrateIdentity,
+  restampContentHashes,
+} from './baseline/migrate';
 import { createBaseline, gatherScanCoverage } from './baseline/create';
 import { missingScanners } from './baseline/coverage';
 import { loadPolicyFromCwd } from './baseline/policy';
@@ -260,6 +265,7 @@ export async function runUpdate(cwd: string, force: boolean, rescan = false): Pr
   // manual re-baseline. Fail-soft: a migration error is reported, not fatal
   // to the rest of the update.
   await migrateIdentityIfStale(cwd);
+  restampIfBare(cwd);
 
   // Recall-attribution refresh (CLAUDE.md Rule 19). Runs AFTER the identity
   // migration on purpose: that path already re-baselines, which stamps recall
@@ -387,6 +393,32 @@ function baselineFinishingStep(cwd: string, alsoAllowlist = false): string {
  * throws (a migration failure is surfaced as a warning so the rest of the
  * update still succeeds).
  */
+/**
+ * Restamp content hashes on a baseline written before the stamp scheme, so
+ * the matcher's reformat-surviving content pass works without waiting for
+ * the next refresh. Fail-open with a warning; the rest of the update stands.
+ */
+function restampIfBare(cwd: string): void {
+  try {
+    const summary = restampContentHashes(cwd);
+    if (!summary) return;
+    logger.success(
+      `Content hashes stamped onto ${summary.restamped} baseline finding(s) ` +
+        `(reformat-tolerant matching now covers them).`,
+    );
+    if (summary.unreadable > 0) {
+      logger.warn(
+        `${summary.unreadable} finding(s) reference files unreadable at the baseline's anchor ` +
+          `commit — left unstamped; the next baseline refresh will stamp them.`,
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      `Content-hash restamp skipped: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 async function migrateIdentityIfStale(cwd: string): Promise<void> {
   let from;
   try {

--- a/test/baseline/content-hash.test.ts
+++ b/test/baseline/content-hash.test.ts
@@ -1,14 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { execFileSync } from 'child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
-import {
-  CONTENT_HASH_CONTEXT_LINES,
-  computeContentHash,
-  computeContentHashFromCommit,
-  readFileFromCommit,
-} from '../../src/baseline/content-hash';
+import { describe, it, expect } from 'vitest';
+import { CONTENT_HASH_CONTEXT_LINES, computeContentHash } from '../../src/baseline/content-hash';
 
 function lines(...ls: string[]): string {
   return ls.join('\n') + '\n';
@@ -104,60 +95,5 @@ describe('computeContentHash — pure function', () => {
   it('exposes the default context-line count as a constant', () => {
     expect(CONTENT_HASH_CONTEXT_LINES).toBeGreaterThan(0);
     expect(CONTENT_HASH_CONTEXT_LINES).toBeLessThan(20); // sanity bound
-  });
-});
-
-describe('readFileFromCommit + computeContentHashFromCommit — git I/O', () => {
-  let dir: string;
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), 'dxkit-content-hash-'));
-    execFileSync('git', ['init', '--quiet', '--initial-branch=main'], { cwd: dir });
-    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
-    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
-    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
-  });
-  afterEach(() => {
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  function commit(msg: string): string {
-    execFileSync('git', ['add', '-A'], { cwd: dir });
-    execFileSync('git', ['commit', '--quiet', '-m', msg], { cwd: dir });
-    return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir, encoding: 'utf8' }).trim();
-  }
-
-  it('reads file content from a past commit', () => {
-    writeFileSync(join(dir, 'a.ts'), lines('one', 'two', 'three'));
-    const sha = commit('initial');
-    const content = readFileFromCommit(dir, sha, 'a.ts');
-    expect(content).toBe(lines('one', 'two', 'three'));
-  });
-
-  it('returns null when the file did not exist at the commit', () => {
-    writeFileSync(join(dir, 'a.ts'), lines('one'));
-    const sha = commit('initial');
-    expect(readFileFromCommit(dir, sha, 'b.ts')).toBeNull();
-  });
-
-  it('returns null when the commit SHA is unreachable', () => {
-    writeFileSync(join(dir, 'a.ts'), lines('one'));
-    commit('initial');
-    expect(readFileFromCommit(dir, '0000000000000000000000000000000000000000', 'a.ts')).toBeNull();
-  });
-
-  it('computes a content hash directly from a commit-and-line pair', () => {
-    writeFileSync(join(dir, 'a.ts'), lines('alpha', 'beta', 'gamma', 'delta', 'epsilon'));
-    const sha = commit('initial');
-    const hash = computeContentHashFromCommit(dir, sha, 'a.ts', 3);
-    expect(hash).toMatch(/^[0-9a-f]{16}$/);
-    // Should match the pure-function output on the same content.
-    const expected = computeContentHash(lines('alpha', 'beta', 'gamma', 'delta', 'epsilon'), 3);
-    expect(hash).toBe(expected);
-  });
-
-  it('returns null from computeContentHashFromCommit when the file is missing', () => {
-    writeFileSync(join(dir, 'a.ts'), lines('one'));
-    const sha = commit('initial');
-    expect(computeContentHashFromCommit(dir, sha, 'missing.ts', 1)).toBeNull();
   });
 });

--- a/test/baseline/content-stamp-parity.test.ts
+++ b/test/baseline/content-stamp-parity.test.ts
@@ -170,11 +170,13 @@ describe('content-stamp parity across the producer registry', () => {
     expect(binary && 'contentHash' in binary ? binary.contentHash : undefined).toBeUndefined();
   });
 
-  it('with no commit available nothing is stamped, and nothing throws (a bare tree)', () => {
+  it('with no commit the tree still stamps (an unborn HEAD is not a missing tree), and nothing throws', () => {
     const entries = runProducers(locatedContext(dir, ''), PRODUCERS);
     expect(entries.length).toBeGreaterThan(0);
-    for (const e of entries) {
-      expect('contentHash' in e ? e.contentHash : undefined).toBeUndefined();
+    const located = entries.filter((e) => 'line' in e && typeof e.line === 'number' && e.line > 0);
+    expect(located.length).toBeGreaterThan(0);
+    for (const e of located) {
+      expect('contentHash' in e ? e.contentHash : undefined).toMatch(/^[0-9a-f]{16}$/);
     }
   });
 

--- a/test/baseline/content-stamp-parity.test.ts
+++ b/test/baseline/content-stamp-parity.test.ts
@@ -1,18 +1,17 @@
 /**
  * Content-stamp PARITY across producers (CLAUDE.md Rule 2.30).
  *
- * The invariant: every registered producer whose entries carry a LINE stamps
- * them with a `contentHash` when a commit is available. Path-identity kinds
- * (large-file, test-gap, stale-file, dep-vuln...) carry no line and no stamp.
+ * The invariant: the ORCHESTRATOR stamps every located entry (locatedness
+ * decided by `entryToLocated`, the projection the matcher pairs on), so no
+ * producer can ship unstamped — the 4.4.4 class where the custom-check
+ * producer stamped nothing while the security producer stamped through a
+ * local closure. Path-identity kinds (large-file, test-gap, dep-vuln...)
+ * carry no line and no stamp.
  *
- * Why a parity test and not just the arch-check: the arch-check pins that the
- * hash is computed in ONE module; it cannot see a producer that simply never
- * calls it. That is exactly how the custom-check producer shipped unstamped
- * while the security producer stamped: nothing iterated the registry and
- * asked. This test does, on a real git repo, with every located producer fed
- * a finding, and it is injection-guarded (the checker must flag a synthetic
- * producer that emits a bare line-carrying entry) so a checker that stopped
- * looking would fail here rather than pass silently.
+ * Injection-guarded in the NEW direction: a synthetic producer that emits a
+ * bare located entry must come out of `runProducers` STAMPED (the registry
+ * is covered structurally), and `captureFragment`'s output is pinned too
+ * (the one entry-minting path outside the registry).
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { execFileSync } from 'child_process';
@@ -29,6 +28,7 @@ import {
 import type { RichBaselineEntry } from '../../src/baseline/types';
 import type { SecurityAggregate } from '../../src/analyzers/security/aggregator';
 import { producerFixtureContext } from './producer-fixture';
+import { entryToLocated } from '../../src/baseline/entry-to-located';
 
 /**
  * Every entry the git-aware matcher can relocate by line: it carries a
@@ -36,18 +36,15 @@ import { producerFixtureContext } from './producer-fixture';
  * side). These are the entries that MUST carry a content hash when a commit
  * is available. Returns the offenders; empty means parity holds.
  */
+function isLocated(e: RichBaselineEntry): boolean {
+  const loc = entryToLocated(e);
+  return loc.file !== undefined && typeof loc.line === 'number' && loc.line > 0;
+}
+
 function unstampedLocatedEntries(entries: ReadonlyArray<RichBaselineEntry>): RichBaselineEntry[] {
-  const out: RichBaselineEntry[] = [];
-  for (const e of entries) {
-    const located =
-      e.kind === 'duplication'
-        ? e.startLineA > 0
-        : 'line' in e && typeof e.line === 'number' && e.line > 0 && 'file' in e;
-    if (!located) continue;
-    const hash = 'contentHash' in e ? e.contentHash : undefined;
-    if (hash === undefined) out.push(e);
-  }
-  return out;
+  return entries.filter(
+    (e) => isLocated(e) && ('contentHash' in e ? e.contentHash : undefined) === undefined,
+  );
 }
 
 const SOURCE =
@@ -155,12 +152,7 @@ describe('content-stamp parity across the producer registry', () => {
     const entries = runProducers(locatedContext(dir, sha), PRODUCERS);
     // Not vacuous: each located producer actually contributed a line-carrying
     // entry, so a producer that silently dropped its input would fail here.
-    const locatedKinds = new Set(
-      entries
-        .filter((e) => unstampedLocatedEntries([e]).length === 0)
-        .filter((e) => ('line' in e && typeof e.line === 'number') || e.kind === 'duplication')
-        .map((e) => e.kind),
-    );
+    const locatedKinds = new Set(entries.filter(isLocated).map((e) => e.kind));
     for (const kind of ['code', 'duplication', 'stale-allow', 'custom-check']) {
       expect(locatedKinds, `producer for ${kind} contributed a located entry`).toContain(kind);
     }
@@ -180,7 +172,7 @@ describe('content-stamp parity across the producer registry', () => {
     }
   });
 
-  it('SYNTHETIC INJECTION: the checker flags a producer that emits a bare located entry', () => {
+  it('SYNTHETIC INJECTION: a producer that emits a bare located entry comes out STAMPED', () => {
     const rogue: BaselineProducer = {
       name: 'synthetic-unstamped',
       contributes: ['code'],
@@ -200,8 +192,62 @@ describe('content-stamp parity across the producer registry', () => {
         return new Map([['code', { epoch: 1, inputs: {} }]]);
       },
     };
+    // The orchestrator stamps registry output structurally: a new producer
+    // needs no wiring, so the injected bare entry gains a hash.
     const entries = runProducers(locatedContext(dir, sha), [rogue]);
-    const offenders = unstampedLocatedEntries(entries);
-    expect(offenders.map((e) => e.id)).toEqual(['synth0000feedbeef']);
+    expect(unstampedLocatedEntries(entries)).toEqual([]);
+    const synth = entries.find((e) => e.id === 'synth0000feedbeef');
+    expect(synth && 'contentHash' in synth ? synth.contentHash : undefined).toMatch(
+      /^[0-9a-f]{16}$/,
+    );
+    // The negative control still exists: an entry whose file is OUTSIDE the
+    // repo stays bare (the stamper's containment policy, not a stamping gap).
+    const escapee = runProducers(locatedContext(dir, sha), [
+      {
+        ...rogue,
+        produce() {
+          return [
+            {
+              id: 'synth0000feedbee0',
+              kind: 'code',
+              tool: 'semgrep',
+              rule: 'rule-1',
+              file: '../outside.ts',
+              line: 10,
+            },
+          ];
+        },
+      },
+    ]);
+    expect(unstampedLocatedEntries(escapee).map((e) => e.id)).toEqual(['synth0000feedbee0']);
+  });
+
+  it('captureFragment output is stamped through the same entry point', async () => {
+    const { captureFragment } = await import('../../src/baseline/fragment');
+    const { trustedLocalContext } = await import('../../src/analysis-trust');
+    const { loadPolicyFromCwd } = await import('../../src/baseline/policy');
+    const policyDir = join(dir, '.dxkit');
+    mkdirSync(policyDir, { recursive: true });
+    writeFileSync(
+      join(policyDir, 'policy.json'),
+      JSON.stringify({
+        checks: [
+          {
+            name: 'seed-lint',
+            command: `node -e "console.log('src/a.ts:12: no-x seeded')"`, // slop-ok
+            parse: { regex: '^(?<file>[^:]+):(?<line>\\d+): (?<rule>\\S+)' },
+          },
+        ],
+      }),
+    );
+    const fragment = await captureFragment({
+      cwd: dir,
+      trust: trustedLocalContext(),
+      policy: loadPolicyFromCwd(dir),
+      checks: ['seed-lint'],
+    });
+    const findings = fragment.findings as RichBaselineEntry[];
+    expect(findings.length).toBeGreaterThan(0);
+    expect(unstampedLocatedEntries(findings)).toEqual([]);
   });
 });

--- a/test/baseline/content-stamp-parity.test.ts
+++ b/test/baseline/content-stamp-parity.test.ts
@@ -222,6 +222,85 @@ describe('content-stamp parity across the producer registry', () => {
     expect(unstampedLocatedEntries(escapee).map((e) => e.id)).toEqual(['synth0000feedbee0']);
   });
 
+  it('every entry variant with a line locator declares contentHash (the stampOne cast invariant)', () => {
+    // Compile-time sweep: constructing each line-locator variant with a
+    // contentHash must typecheck. A new located kind without the field breaks
+    // this block before the cast in stampOne can write an undeclared field.
+    const anchors: [
+      { file: string; line: number; symbol: string },
+      { file: string; line: number; symbol: string },
+    ] = [
+      { file: 'a.ts', line: 1, symbol: 'x' },
+      { file: 'b.ts', line: 2, symbol: 'y' },
+    ];
+    const variants: RichBaselineEntry[] = [
+      {
+        id: 'a'.repeat(16),
+        kind: 'code',
+        tool: 't',
+        rule: 'r',
+        file: 'a.ts',
+        line: 1,
+        contentHash: 'f'.repeat(16),
+      },
+      {
+        id: 'b'.repeat(16),
+        kind: 'hygiene',
+        file: 'a.ts',
+        line: 1,
+        marker: 'todo',
+        contentHash: 'f'.repeat(16),
+      },
+      {
+        id: 'c'.repeat(16),
+        kind: 'stale-allow',
+        file: 'a.ts',
+        line: 1,
+        category: 'deferred',
+        contentHash: 'f'.repeat(16),
+      },
+      {
+        id: 'd'.repeat(16),
+        kind: 'custom-check',
+        check: 'lint:x',
+        blocking: true,
+        file: 'a.ts',
+        line: 1,
+        contentHash: 'f'.repeat(16),
+      },
+      {
+        id: 'e'.repeat(16),
+        kind: 'duplication',
+        fileA: 'a.ts',
+        fileB: 'b.ts',
+        lines: 3,
+        startLineA: 1,
+        startLineB: 2,
+        contentHash: 'f'.repeat(16),
+      },
+      {
+        id: 'f'.repeat(16),
+        kind: 'coverage-gap',
+        file: 'a.ts',
+        lineRange: [1, 3],
+        contentHash: 'f'.repeat(16),
+      },
+      {
+        id: 'a1'.repeat(8),
+        kind: 'code-reimplementation',
+        anchors,
+        score: 0.9,
+        contentHash: 'f'.repeat(16),
+      },
+    ];
+    for (const v of variants) {
+      const loc = entryToLocated(v);
+      expect(loc.file, `${v.kind} keeps a file locator`).toBeDefined();
+      expect(loc.line, `${v.kind} keeps a line locator`).toBeGreaterThan(0);
+      expect(loc.contentHash, `${v.kind} forwards contentHash to the matcher`).toBe('f'.repeat(16));
+    }
+  });
+
   it('captureFragment output is stamped through the same entry point', async () => {
     const { captureFragment } = await import('../../src/baseline/fragment');
     const { trustedLocalContext } = await import('../../src/analysis-trust');

--- a/test/baseline/content-stamp-parity.test.ts
+++ b/test/baseline/content-stamp-parity.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Content-stamp PARITY across producers (CLAUDE.md Rule 2.30).
+ *
+ * The invariant: every registered producer whose entries carry a LINE stamps
+ * them with a `contentHash` when a commit is available. Path-identity kinds
+ * (large-file, test-gap, stale-file, dep-vuln...) carry no line and no stamp.
+ *
+ * Why a parity test and not just the arch-check: the arch-check pins that the
+ * hash is computed in ONE module; it cannot see a producer that simply never
+ * calls it. That is exactly how the custom-check producer shipped unstamped
+ * while the security producer stamped: nothing iterated the registry and
+ * asked. This test does, on a real git repo, with every located producer fed
+ * a finding, and it is injection-guarded (the checker must flag a synthetic
+ * producer that emits a bare line-carrying entry) so a checker that stopped
+ * looking would fail here rather than pass silently.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import {
+  PRODUCERS,
+  runProducers,
+  type BaselineProducer,
+  type ProducerContext,
+} from '../../src/baseline/producers';
+import type { RichBaselineEntry } from '../../src/baseline/types';
+import type { SecurityAggregate } from '../../src/analyzers/security/aggregator';
+import { producerFixtureContext } from './producer-fixture';
+
+/**
+ * Every entry the git-aware matcher can relocate by line: it carries a
+ * `(file, line)` locator (or, for a clone pair, a start line on its canonical
+ * side). These are the entries that MUST carry a content hash when a commit
+ * is available. Returns the offenders; empty means parity holds.
+ */
+function unstampedLocatedEntries(entries: ReadonlyArray<RichBaselineEntry>): RichBaselineEntry[] {
+  const out: RichBaselineEntry[] = [];
+  for (const e of entries) {
+    const located =
+      e.kind === 'duplication'
+        ? e.startLineA > 0
+        : 'line' in e && typeof e.line === 'number' && e.line > 0 && 'file' in e;
+    if (!located) continue;
+    const hash = 'contentHash' in e ? e.contentHash : undefined;
+    if (hash === undefined) out.push(e);
+  }
+  return out;
+}
+
+const SOURCE =
+  Array.from({ length: 30 }, (_, i) => `const line${i + 1} = ${i + 1};`).join('\n') + '\n';
+
+function locatedContext(dir: string, commitSha: string): ProducerContext {
+  const base = producerFixtureContext();
+  const aggregate: SecurityAggregate = {
+    codeBySeverity: { critical: 0, high: 1, medium: 0, low: 0 },
+    depBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    secretsBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    scoreableCodeBySeverity: { critical: 0, high: 1, medium: 0, low: 0 },
+    scoreableSecretsBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    scoreableDepBySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    findingsByCategory: {
+      secret: [],
+      code: [
+        {
+          severity: 'high',
+          category: 'code',
+          cwe: 'CWE-1',
+          rule: 'rule-1',
+          title: 'sample',
+          file: 'src/a.ts',
+          line: 10,
+          tool: 'semgrep',
+          fingerprint: '0000000000000001',
+          canonicalRule: 'rule-1',
+          producedBy: ['semgrep'],
+        },
+      ],
+      config: [],
+      dependency: [],
+    },
+    dependencyAdvisoryUniqueCount: 0,
+    dependencyFindingsRawCount: 0,
+    dedupCollisions: [],
+    provenance: {
+      secrets: { tool: null, ran: false },
+      codePatterns: { tool: 'semgrep', ran: true },
+      tlsBypass: { ran: false, patternCount: 0 },
+      fileFindings: { ran: false },
+      depVulns: { tool: null, available: true, unavailableReason: '' },
+    },
+  };
+  return {
+    ...base,
+    cwd: dir,
+    commitSha,
+    analysisResult: {
+      ...base.analysisResult,
+      cwd: dir,
+      commitSha,
+      capabilities: {
+        ...base.analysisResult.capabilities,
+        securityAggregate: aggregate,
+        duplication: {
+          schemaVersion: 1,
+          tool: 'jscpd',
+          totalLines: 30,
+          duplicatedLines: 6,
+          percentage: 20,
+          cloneCount: 1,
+          topClones: [
+            {
+              lines: 3,
+              tokens: 20,
+              a: { file: 'src/a.ts', startLine: 5, endLine: 7 },
+              b: { file: 'src/a.ts', startLine: 20, endLine: 22 },
+            },
+          ],
+        },
+      },
+    },
+    inlineAllowlistAnnotations: [
+      { file: 'src/a.ts', line: 15, category: 'test-fixture', position: 'above' },
+    ],
+    customCheckFindings: [
+      { check: 'lint:typescript', blocking: true, file: 'src/a.ts', line: 25, rule: 'no-x' },
+      { check: 'check:seam', blocking: true, message: 'binary failure' },
+    ],
+  };
+}
+
+describe('content-stamp parity across the producer registry', () => {
+  let dir: string;
+  let sha: string;
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-stamp-parity-'));
+    execFileSync('git', ['init', '--quiet', '--initial-branch=main'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'a.ts'), SOURCE);
+    execFileSync('git', ['add', '-A'], { cwd: dir });
+    execFileSync('git', ['commit', '--quiet', '-m', 'init'], { cwd: dir });
+    sha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir, encoding: 'utf8' }).trim();
+  });
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('every line-carrying entry from every registered producer carries a contentHash', () => {
+    const entries = runProducers(locatedContext(dir, sha), PRODUCERS);
+    // Not vacuous: each located producer actually contributed a line-carrying
+    // entry, so a producer that silently dropped its input would fail here.
+    const locatedKinds = new Set(
+      entries
+        .filter((e) => unstampedLocatedEntries([e]).length === 0)
+        .filter((e) => ('line' in e && typeof e.line === 'number') || e.kind === 'duplication')
+        .map((e) => e.kind),
+    );
+    for (const kind of ['code', 'duplication', 'stale-allow', 'custom-check']) {
+      expect(locatedKinds, `producer for ${kind} contributed a located entry`).toContain(kind);
+    }
+    expect(unstampedLocatedEntries(entries)).toEqual([]);
+    // Path-identity kinds and binary findings stay bare: no line, no hash.
+    const binary = entries.find((e) => e.kind === 'custom-check' && e.file === undefined);
+    expect(binary && 'contentHash' in binary ? binary.contentHash : undefined).toBeUndefined();
+  });
+
+  it('with no commit available nothing is stamped, and nothing throws (a bare tree)', () => {
+    const entries = runProducers(locatedContext(dir, ''), PRODUCERS);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const e of entries) {
+      expect('contentHash' in e ? e.contentHash : undefined).toBeUndefined();
+    }
+  });
+
+  it('SYNTHETIC INJECTION: the checker flags a producer that emits a bare located entry', () => {
+    const rogue: BaselineProducer = {
+      name: 'synthetic-unstamped',
+      contributes: ['code'],
+      produce() {
+        return [
+          {
+            id: 'synth0000feedbeef',
+            kind: 'code',
+            tool: 'semgrep',
+            rule: 'rule-1',
+            file: 'src/a.ts',
+            line: 10,
+          },
+        ];
+      },
+      recallContexts() {
+        return new Map([['code', { epoch: 1, inputs: {} }]]);
+      },
+    };
+    const entries = runProducers(locatedContext(dir, sha), [rogue]);
+    const offenders = unstampedLocatedEntries(entries);
+    expect(offenders.map((e) => e.id)).toEqual(['synth0000feedbeef']);
+  });
+});

--- a/test/baseline/content-stamp.test.ts
+++ b/test/baseline/content-stamp.test.ts
@@ -1,36 +1,50 @@
 /**
- * Content-hash stamping for custom-check findings: identity that survives a
- * whole-file reformat (design section E).
+ * Content-hash stamping (the reformat-survival layer) — unit level.
  *
- * The scenario that shipped: a repo with a grandfathered lint backlog reindents
- * one file from 4 spaces to 2. Every line moves past the 3-line identity
- * window AND every line is rewritten in the diff (so the git-aware line map has
- * no image for it). The only matcher pass that can pair the finding with its
- * moved self is the content-hash pass, which normalizes whitespace, and it
- * never fired for lint because the custom-check producer stamped no hash.
+ * What this file pins:
+ *   1. the ONE stamping policy (`contentStamper`): working-tree read, split-
+ *      lines cache, and every deliberate no-stamp case (no tree, line 0,
+ *      escape, symlink, oversized, unreadable);
+ *   2. the orchestrator-level `stampEntries`: located entries (as decided by
+ *      `entryToLocated`, the projection the matcher pairs on) gain a hash,
+ *      everything else passes through untouched;
+ *   3. the producer's minimum-line rule: a bucket's stamped window does not
+ *      depend on linter output order;
+ *   4. the matcher's two-phase content pass: an uncommitted or committed
+ *      reformat pairs PERSISTED at the same-file confidence tier, a genuinely
+ *      new finding stays `added`, a same-file twin is never stolen cross-file
+ *      regardless of prior order, and a git-detected rename outranks a
+ *      same-old-path shim;
+ *   5. `restampAtCommit`, the migrate lane's commit-anchored restamp for
+ *      pre-scheme baselines;
+ *   6. the arch-check gate on the hash primitive, proven to bite (including
+ *      an aliased import), and proven not to fire on comments.
  *
- * This file pins:
- *   - the producer stamps a located custom-check entry through the shared
- *     `contentStamper` and leaves a binary one unstamped;
- *   - the matcher pairs the reindented finding via `content-hash` at
- *     confidence 0.80 with zero `added`;
- *   - a genuinely new finding on a new line is still `added` (the negative);
- *   - an unstamped (pre-scheme) baseline degrades to the old behavior instead
- *     of throwing (migration contract, no rescan);
- *   - the arch-check rule that keeps stamping to one module actually bites.
+ * The end-to-end guardrail run over a real backlog fixture lives in
+ * `test/fixtures-analysis.test.ts`.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { execFileSync, spawnSync } from 'child_process';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { tmpdir } from 'os';
 
 import { customCheckFindingsToBaselineEntries } from '../../src/baseline/producers/custom-checks';
 import { entriesToLocated } from '../../src/baseline/entry-to-located';
-import { gitAwareMatch, CONFIDENCE_CONTENT_HASH } from '../../src/baseline/git-aware-match';
-import { contentStamper, contentStampSource } from '../../src/baseline/content-stamp';
+import {
+  gitAwareMatch,
+  CONFIDENCE_CONTENT_HASH,
+  CONFIDENCE_CONTENT_HASH_SAME_FILE,
+} from '../../src/baseline/git-aware-match';
+import {
+  contentStamper,
+  restampAtCommit,
+  stampEntries,
+  CONTENT_STAMP_MAX_BYTES,
+} from '../../src/baseline/content-stamp';
 import { computeContentHash } from '../../src/baseline/content-hash';
 import type { CustomCheckFinding } from '../../src/analyzers/custom-checks/types';
+import type { RichBaselineEntry } from '../../src/baseline/types';
 
 function makeRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), 'dxkit-content-stamp-'));
@@ -59,8 +73,6 @@ const FILE = 'src/handlers.ts';
  */
 function fourSpaceSource(): string {
   const out: string[] = [];
-  // Lines 1-40: eight 5-line blocks, each followed by a double blank (which the
-  // reformat collapses to a single blank). 8 blocks x 5 = 40 lines.
   for (let b = 0; b < 8; b++) {
     if (b < 5) {
       out.push(`export function helper${b}(x: number): number {`);
@@ -76,7 +88,6 @@ function fourSpaceSource(): string {
       out.push(``);
     }
   }
-  // Lines 41-50: the function that carries the finding on line 46.
   out.push(`export function handle(req: Request): Response {`); // 41
   out.push(`    const id = req.id;`); // 42
   out.push(`    if (!id) {`); // 43
@@ -111,49 +122,119 @@ function lintFinding(line: number, over: Partial<CustomCheckFinding> = {}): Cust
   };
 }
 
-describe('custom-check content-hash stamping (reformat survival)', () => {
+/** Producer output stamped the way the orchestrator stamps it. */
+function stampedEntries(findings: CustomCheckFinding[], cwd: string): RichBaselineEntry[] {
+  return stampEntries(customCheckFindingsToBaselineEntries(findings), cwd);
+}
+
+describe('contentStamper (the one stamping policy)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-stamper-'));
+    return () => rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('never stamps without a tree, on line 0, outside the repo, or on an unreadable file', () => {
+    writeFileSync(join(dir, 'a.txt'), 'one\ntwo\nthree\n');
+    expect(contentStamper(undefined)('a.txt', 2)).toBeUndefined();
+    expect(contentStamper('')('a.txt', 2)).toBeUndefined();
+    const stamp = contentStamper(dir);
+    expect(stamp('a.txt', 0)).toBeUndefined();
+    expect(stamp('missing.txt', 2)).toBeUndefined();
+    expect(stamp('../outside.txt', 2)).toBeUndefined();
+    expect(stamp(resolve(dir, '..', 'outside.txt'), 2)).toBeUndefined();
+    expect(stamp('a.txt', 2)).toBe(computeContentHash('one\ntwo\nthree\n', 2));
+  });
+
+  it('a file whose NAME begins with dots is inside the repo and stamps', () => {
+    writeFileSync(join(dir, '..config.ts'), 'a\nb\nc\n');
+    expect(contentStamper(dir)('..config.ts', 2)).toBe(computeContentHash('a\nb\nc\n', 2));
+  });
+
+  it('refuses symlinks: a committed link must not widen what dxkit reads', () => {
+    writeFileSync(join(dir, 'real.txt'), 'secret\n');
+    symlinkSync(join(dir, 'real.txt'), join(dir, 'link.txt'));
+    expect(contentStamper(dir)('link.txt', 1)).toBeUndefined();
+    expect(contentStamper(dir)('real.txt', 1)).toBeDefined();
+  });
+
+  it('refuses files over the size cap', () => {
+    writeFileSync(join(dir, 'big.txt'), Buffer.alloc(CONTENT_STAMP_MAX_BYTES + 1, 0x61));
+    expect(contentStamper(dir)('big.txt', 1)).toBeUndefined();
+  });
+
+  it('caches per stamper: one scan reads one tree; the next scan builds a new stamper', () => {
+    writeFileSync(join(dir, 'a.txt'), 'one\ntwo\nthree\n');
+    const stamp = contentStamper(dir);
+    expect(stamp('a.txt', 2)).toBe(computeContentHash('one\ntwo\nthree\n', 2));
+    writeFileSync(join(dir, 'a.txt'), 'changed\ntwo\nthree\n');
+    expect(stamp('a.txt', 2)).toBe(computeContentHash('one\ntwo\nthree\n', 2));
+    expect(contentStamper(dir)('a.txt', 2)).toBe(computeContentHash('changed\ntwo\nthree\n', 2));
+  });
+});
+
+describe('stampEntries (orchestrator stamping via the located projection)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dxkit-stamp-entries-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, FILE), fourSpaceSource());
+    return () => rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('stamps every located entry, passes whole-file / binary / pre-stamped entries through', () => {
+    const [located, binary] = customCheckFindingsToBaselineEntries([
+      lintFinding(46),
+      { check: 'check:seam', blocking: true, message: 'boom' },
+    ]);
+    const wholeFile: RichBaselineEntry = { id: 'f'.repeat(16), kind: 'large-file', file: FILE };
+    const preStamped = {
+      ...located,
+      id: 'a'.repeat(16),
+      contentHash: 'deadbeefdeadbeef',
+    } as RichBaselineEntry;
+    const out = stampEntries([located, binary, wholeFile, preStamped], dir);
+    const hash = (e: RichBaselineEntry) => ('contentHash' in e ? e.contentHash : undefined);
+    expect(hash(out[0])).toBe(computeContentHash(fourSpaceSource(), 46));
+    expect(hash(out[1])).toBeUndefined();
+    expect(hash(out[2])).toBeUndefined();
+    expect(hash(out[3])).toBe('deadbeefdeadbeef');
+    // No tree: everything passes through bare, no branch needed in callers.
+    expect(stampEntries([located], undefined)[0]).toBe(located);
+  });
+});
+
+describe('custom-check minimum-line rule (order-independent stamping window)', () => {
+  it('two occurrences in one identity bucket record the minimum line in either order', () => {
+    const a = customCheckFindingsToBaselineEntries([lintFinding(10), lintFinding(11)]);
+    const b = customCheckFindingsToBaselineEntries([lintFinding(11), lintFinding(10)]);
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+    expect(a[0].kind === 'custom-check' && a[0].line).toBe(10);
+    expect(b[0].kind === 'custom-check' && b[0].line).toBe(10);
+    expect(a[0].id).toBe(b[0].id);
+  });
+});
+
+describe('the content pass across a reformat', () => {
   let dir: string;
   beforeEach(() => {
     dir = makeRepo();
     mkdirSync(join(dir, 'src'), { recursive: true });
-  });
-  afterEach(() => {
-    rmSync(dir, { recursive: true, force: true });
+    return () => rmSync(dir, { recursive: true, force: true });
   });
 
-  it('the producer stamps a located entry through the shared stamper; a binary entry stays bare', () => {
-    const src = fourSpaceSource();
-    writeFileSync(join(dir, FILE), src);
-    commit(dir, 'backlog');
-    const [located, binary] = customCheckFindingsToBaselineEntries(
-      [lintFinding(46), { check: 'check:seam', blocking: true, message: 'boom' }],
-      { cwd: dir },
-    );
-    expect(located.kind === 'custom-check' && located.contentHash).toBe(
-      computeContentHash(src, 46),
-    );
-    expect(binary.kind === 'custom-check' && binary.contentHash).toBeUndefined();
-    // No source (a producer running without a repo path): the same producer
-    // stamps nothing, no branch needed.
-    const [bare] = customCheckFindingsToBaselineEntries([lintFinding(46)]);
-    expect(bare.kind === 'custom-check' && bare.contentHash).toBeUndefined();
-    expect(contentStampSource({ cwd: '' })).toBeUndefined();
-    expect(contentStampSource({ cwd: dir })).toEqual({ cwd: dir });
-  });
-
-  it('a 4-space to 2-space reindent pairs the moved finding via content-hash at 0.80, zero added', () => {
+  it('a committed reindent pairs PERSISTED at the same-file tier, zero added', () => {
     const before = fourSpaceSource();
     writeFileSync(join(dir, FILE), before);
     const base = commit(dir, 'backlog at 4 spaces');
-    // The baseline side stamps the tree it scanned (the 4-space one).
-    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
+    const prior = stampedEntries([lintFinding(46)], dir);
     const after = reformat(before);
     expect(after.split('\n')[40]).toBe('  console.log(id);'); // line 41 now // slop-ok
     writeFileSync(join(dir, FILE), after);
     const head = commit(dir, 'reformat to 2 spaces');
-    const current = customCheckFindingsToBaselineEntries([lintFinding(41)], { cwd: dir });
-    // The shift crossed the 3-line identity window: the fingerprints differ,
-    // so only a locator-aware pass can pair them.
+    const current = stampedEntries([lintFinding(41)], dir);
+    // The shift crossed the 3-line identity window: fingerprints differ.
     expect(prior[0].id).not.toBe(current[0].id);
 
     const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
@@ -164,59 +245,20 @@ describe('custom-check content-hash stamping (reformat survival)', () => {
     expect(result.added).toEqual([]);
     expect(result.removed).toEqual([]);
     expect(result.pairs).toHaveLength(1);
-    const [pair] = result.pairs;
-    expect(pair.status).toBe('persisted');
-    expect(pair.confidence).toBe(CONFIDENCE_CONTENT_HASH);
-    expect(CONFIDENCE_CONTENT_HASH).toBe(0.8);
-    expect(pair.reasons.map((r) => r.code)).toEqual(['content-hash']);
+    expect(result.pairs[0].status).toBe('persisted');
+    expect(result.pairs[0].confidence).toBe(CONFIDENCE_CONTENT_HASH_SAME_FILE);
+    expect(result.pairs[0].reasons.map((r) => r.code)).toEqual(['content-hash']);
   });
 
-  it('a genuinely new finding on a new line after the reformat is still added', () => {
+  it('an UNCOMMITTED reformat (Stop-gate / pre-push tree) still pairs: the stamp reads the scanned tree', () => {
     const before = fourSpaceSource();
     writeFileSync(join(dir, FILE), before);
     const base = commit(dir, 'backlog at 4 spaces');
-    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
-    // Reformat AND introduce a second console.log at the top of `handle`.
-    const after = reformat(before).replace(
-      '  const id = req.id;\n',
-      '  const id = req.id;\n  console.log("entered");\n', // slop-ok
-    );
-    writeFileSync(join(dir, FILE), after);
-    const head = commit(dir, 'reformat + new finding');
-    const newLine = after.split('\n').findIndex((l) => l.includes('"entered"')) + 1;
-    const movedLine = after.split('\n').findIndex((l) => l === '  console.log(id);') + 1; // slop-ok
-    expect(newLine).toBe(38);
-    expect(movedLine).toBe(42);
-
-    const current = customCheckFindingsToBaselineEntries(
-      [lintFinding(newLine), lintFinding(movedLine)],
-      { cwd: dir },
-    );
-    const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
-      cwd: dir,
-      baseSha: base,
-      headSha: head,
-    });
-    const movedId = current.find((e) => e.kind === 'custom-check' && e.line === movedLine)!.id;
-    const newId = current.find((e) => e.kind === 'custom-check' && e.line === newLine)!.id;
-    const matched = result.pairs.filter((p) => p.priorId !== undefined);
-    expect(matched.map((p) => p.currentId)).toEqual([movedId]);
-    expect(matched[0].reasons.map((r) => r.code)).toEqual(['content-hash']);
-    expect(result.added).toEqual([newId]);
-    expect(result.removed).toEqual([]);
-  });
-
-  it('an UNCOMMITTED reformat (the Stop-gate / pre-push tree) still pairs: the stamp reads the tree the scan read', () => {
-    const before = fourSpaceSource();
-    writeFileSync(join(dir, FILE), before);
-    const base = commit(dir, 'backlog at 4 spaces');
-    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
-    // Reformat in place, no commit: the current scan sees line 41 in a dirty tree.
+    const prior = stampedEntries([lintFinding(46)], dir);
     writeFileSync(join(dir, FILE), reformat(before));
-    const current = customCheckFindingsToBaselineEntries([lintFinding(41)], { cwd: dir });
-    expect(current[0].kind === 'custom-check' && current[0].contentHash).toBe(
-      prior[0].kind === 'custom-check' ? prior[0].contentHash : 'unstamped',
-    );
+    const current = stampedEntries([lintFinding(41)], dir);
+    const hash = (e: RichBaselineEntry) => ('contentHash' in e ? e.contentHash : undefined);
+    expect(hash(current[0])).toBe(hash(prior[0]));
     const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
       cwd: dir,
       baseSha: base,
@@ -226,66 +268,164 @@ describe('custom-check content-hash stamping (reformat survival)', () => {
     expect(result.pairs.map((p) => p.reasons.map((r) => r.code))).toEqual([['content-hash']]);
   });
 
-  it('a same-rule finding newly introduced at the old line is NOT paired as persisted on a dirty tree', () => {
+  it('a same-rule finding newly introduced at the old line hashes its OWN window, not the commit', () => {
     const before = fourSpaceSource();
     writeFileSync(join(dir, FILE), before);
     commit(dir, 'backlog at 4 spaces');
-    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
-    // Delete the finding's line and put a DIFFERENT console statement at line 46,
-    // uncommitted. Hashing the committed tree at line 46 would reproduce the prior
-    // stamp and pair a net-new finding as persisted.
-    const lines = before.split('\n');
+    const prior = stampedEntries([lintFinding(46)], dir);
+    // Uncommitted: delete the finding's line, put a DIFFERENT console statement
+    // at line 46, and shift the window content. Hashing the committed tree at
+    // line 46 would reproduce the prior stamp and pair a net-new finding.
+    const lines = fourSpaceSource().split('\n');
     lines[45] = '    console.log("something else entirely", req, id, extra);'; // slop-ok
     lines.splice(30, 0, '    // a comment shifting the window content');
     writeFileSync(join(dir, FILE), lines.join('\n'));
-    const current = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
-    expect(current[0].kind === 'custom-check' && current[0].contentHash).not.toBe(
-      prior[0].kind === 'custom-check' ? prior[0].contentHash : 'unstamped',
-    );
+    const current = stampedEntries([lintFinding(46)], dir);
+    const hash = (e: RichBaselineEntry) => ('contentHash' in e ? e.contentHash : undefined);
+    expect(hash(current[0])).not.toBe(hash(prior[0]));
   });
 
-  it('the content pass prefers a same-file candidate over an identical window in another file', () => {
+  it('a genuinely new finding after the reformat is still added', () => {
     const before = fourSpaceSource();
     writeFileSync(join(dir, FILE), before);
     const base = commit(dir, 'backlog at 4 spaces');
-    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
-    // A copy of the file appears under a new path, and the original is reformatted.
-    const twin = 'src/legacy-copy.ts';
-    writeFileSync(join(dir, twin), reformat(before));
+    const prior = stampedEntries([lintFinding(46)], dir);
+    const after = reformat(before).replace(
+      '  const id = req.id;\n',
+      '  const id = req.id;\n  console.log("entered");\n', // slop-ok
+    );
+    writeFileSync(join(dir, FILE), after);
+    const head = commit(dir, 'reformat + new finding');
+    const newLine = after.split('\n').findIndex((l) => l.includes('"entered"')) + 1;
+    const movedLine = after.split('\n').findIndex((l) => l === '  console.log(id);') + 1; // slop-ok
+    const current = stampedEntries([lintFinding(newLine), lintFinding(movedLine)], dir);
+    const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
+      cwd: dir,
+      baseSha: base,
+      headSha: head,
+    });
+    const movedId = current.find((e) => e.kind === 'custom-check' && e.line === movedLine)!.id;
+    const newId = current.find((e) => e.kind === 'custom-check' && e.line === newLine)!.id;
+    const matched = result.pairs.filter((p) => p.priorId !== undefined);
+    expect(matched.map((p) => p.currentId)).toEqual([movedId]);
+    expect(result.added).toEqual([newId]);
+  });
+
+  it('phase 1 reserves same-file pairs: a deleted twin cannot steal one, in any prior order', () => {
+    const before = fourSpaceSource();
+    writeFileSync(join(dir, FILE), before);
+    writeFileSync(join(dir, 'src/gone.ts'), before);
+    const base = commit(dir, 'backlog in two files');
+    const prior = stampedEntries([lintFinding(46), lintFinding(46, { file: 'src/gone.ts' })], dir);
+    // gone.ts is deleted; handlers.ts is reformatted. The only candidate is
+    // handlers.ts's moved finding: it must pair with the handlers.ts prior
+    // (same file), never with the gone.ts prior (cross-file), regardless of
+    // which prior the matcher iterates first.
+    rmSync(join(dir, 'src/gone.ts'));
     writeFileSync(join(dir, FILE), reformat(before));
-    const head = commit(dir, 'reformat + copy');
-    const current = customCheckFindingsToBaselineEntries(
-      [{ ...lintFinding(41), file: twin }, lintFinding(41)],
-      { cwd: dir },
+    const head = commit(dir, 'reformat + delete twin');
+    const current = stampedEntries([lintFinding(41)], dir);
+    for (const priorOrder of [prior, [...prior].reverse()]) {
+      const result = gitAwareMatch(entriesToLocated(priorOrder), entriesToLocated(current), {
+        cwd: dir,
+        baseSha: base,
+        headSha: head,
+      });
+      const paired = result.pairs.filter(
+        (p) => p.priorId !== undefined && p.currentId !== undefined,
+      );
+      expect(paired).toHaveLength(1);
+      const samePrior = priorOrder.find((e) => e.kind === 'custom-check' && e.file === FILE)!;
+      expect(paired[0].priorId).toBe(samePrior.id);
+      expect(paired[0].status).toBe('persisted');
+      expect(paired[0].confidence).toBe(CONFIDENCE_CONTENT_HASH_SAME_FILE);
+    }
+  });
+
+  it('a git-detected rename outranks a cross-file window twin', () => {
+    const before = fourSpaceSource();
+    writeFileSync(join(dir, FILE), before);
+    const base = commit(dir, 'backlog at 4 spaces');
+    const prior = stampedEntries([lintFinding(46)], dir);
+    // A real rename (old path deleted) plus a reformat. A NEW file shares only
+    // the finding's 7-line window (the rest is unrelated), so git's rename
+    // detection maps the old path to the REFORMATTED file, and the content
+    // pass must follow that evidence rather than the window twin.
+    execFileSync('git', ['mv', FILE, 'src/handlers-v2.ts'], { cwd: dir });
+    writeFileSync(join(dir, 'src/handlers-v2.ts'), reformat(before));
+    const windowOnly = [
+      ...Array.from({ length: 40 }, (_, i) => `const unrelated${i} = ${i};`),
+      ...reformat(before).split('\n').slice(37, 45),
+    ].join('\n');
+    writeFileSync(join(dir, 'src/twin.ts'), windowOnly + '\n');
+    const head = commit(dir, 'rename + reformat + window twin');
+    // git maps the rename to the reformatted file, not the twin.
+    const status = execFileSync('git', ['diff', '--name-status', '--find-renames', base, head], {
+      cwd: dir,
+      encoding: 'utf8',
+    });
+    expect(status).toMatch(/R\d+\tsrc\/handlers\.ts\tsrc\/handlers-v2\.ts/);
+    const twinLine = windowOnly.split('\n').findIndex((l) => l.includes('console.log(id)')) + 1; // slop-ok
+    const current = stampedEntries(
+      [
+        lintFinding(41, { file: 'src/handlers-v2.ts' }),
+        lintFinding(twinLine, { file: 'src/twin.ts' }),
+      ],
+      dir,
     );
     const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
       cwd: dir,
       baseSha: base,
       headSha: head,
     });
-    const paired = result.pairs.find((p) => p.priorId !== undefined)!;
-    const sameFileId = current.find((e) => e.kind === 'custom-check' && e.file === FILE)!.id;
-    expect(paired.currentId).toBe(sameFileId);
-    expect(paired.status).toBe('persisted');
+    const renamedId = current.find(
+      (e) => e.kind === 'custom-check' && e.file === 'src/handlers-v2.ts',
+    )!.id;
+    const twinId = current.find((e) => e.kind === 'custom-check' && e.file === 'src/twin.ts')!.id;
+    const paired = result.pairs.find((p) => p.priorId === prior[0].id);
+    expect(paired?.currentId).toBe(renamedId);
+    expect(result.added).toEqual([twinId]);
+  });
+
+  it('a cross-file pair (no same-file candidate anywhere) keeps the lower confidence tier', () => {
+    const before = fourSpaceSource();
+    writeFileSync(join(dir, FILE), before);
+    const base = commit(dir, 'backlog at 4 spaces');
+    const prior = stampedEntries([lintFinding(46)], dir);
+    // The file's content moves wholesale to a new path git does NOT pair as a
+    // rename (the old path gains unrelated content), so only the content pass
+    // can follow it, cross-file.
+    writeFileSync(join(dir, 'src/relocated.ts'), before);
+    writeFileSync(join(dir, FILE), 'export const nothingHere = true;\n');
+    const head = commit(dir, 'move content to a new path');
+    const current = stampedEntries([lintFinding(46, { file: 'src/relocated.ts' })], dir);
+    const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
+      cwd: dir,
+      baseSha: base,
+      headSha: head,
+    });
+    const paired = result.pairs.find((p) => p.priorId === prior[0].id);
+    expect(paired).toBeDefined();
+    if (paired?.reasons.some((r) => r.code === 'content-hash')) {
+      expect(paired.status).toBe('relocated');
+      expect(paired.confidence).toBe(CONFIDENCE_CONTENT_HASH);
+    }
   });
 
   it('a pre-scheme baseline (no hash on the prior side) degrades to the old behavior, never throws', () => {
     const before = fourSpaceSource();
     writeFileSync(join(dir, FILE), before);
     const base = commit(dir, 'backlog at 4 spaces');
-    writeFileSync(join(dir, FILE), reformat(before));
-    const head = commit(dir, 'reformat to 2 spaces');
-    // An entry written before the stamp existed: same shape, no contentHash.
     const prior = customCheckFindingsToBaselineEntries([lintFinding(46)]);
     expect(prior[0].kind === 'custom-check' && prior[0].contentHash).toBeUndefined();
-    const current = customCheckFindingsToBaselineEntries([lintFinding(41)], { cwd: dir });
+    writeFileSync(join(dir, FILE), reformat(before));
+    const head = commit(dir, 'reformat to 2 spaces');
+    const current = stampedEntries([lintFinding(41)], dir);
     const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
       cwd: dir,
       baseSha: base,
       headSha: head,
     });
-    // Whatever the git passes make of the rewritten line, no pair may claim
-    // the content-hash reason: there was no hash to compare.
     for (const p of result.pairs) {
       expect(p.reasons.map((r) => r.code)).not.toContain('content-hash');
     }
@@ -293,27 +433,28 @@ describe('custom-check content-hash stamping (reformat survival)', () => {
   });
 });
 
-describe('contentStamper (the one stamping policy)', () => {
-  it('never stamps without a source, on a whole-file line 0, outside the tree, or on an unreadable file', () => {
+describe('restampAtCommit (the migrate lane, pre-scheme baselines)', () => {
+  it('stamps bare located entries at the anchor commit; unreadable files are counted, not thrown', () => {
     const dir = makeRepo();
     try {
-      writeFileSync(join(dir, 'a.txt'), 'one\ntwo\nthree\n');
-      expect(contentStamper(undefined)('a.txt', 2)).toBeUndefined();
-      expect(contentStamper({ cwd: '' })('a.txt', 2)).toBeUndefined();
-      // No commit is needed: the tree is the source (an unborn HEAD still stamps).
-      const stamp = contentStamper({ cwd: dir });
-      expect(stamp('a.txt', 0)).toBeUndefined();
-      expect(stamp('missing.txt', 2)).toBeUndefined();
-      expect(stamp('..' + '/outside.txt', 2)).toBeUndefined();
-      expect(stamp(join(dir, 'a.txt'), 2)).toBeUndefined();
-      expect(stamp('a.txt', 2)).toBe(computeContentHash('one\ntwo\nthree\n', 2));
-      // Per-stamper file cache: a rewrite after the first read is not observed
-      // (a producer stamps one scan of one tree; the next scan builds a new stamper).
-      writeFileSync(join(dir, 'a.txt'), 'changed\ntwo\nthree\n');
-      expect(stamp('a.txt', 2)).toBe(computeContentHash('one\ntwo\nthree\n', 2));
-      expect(contentStamper({ cwd: dir })('a.txt', 2)).toBe(
-        computeContentHash('changed\ntwo\nthree\n', 2),
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      const src = fourSpaceSource();
+      writeFileSync(join(dir, FILE), src);
+      const sha = commit(dir, 'anchor');
+      // The tree moves on (reformat), but the baseline's lines describe the anchor.
+      writeFileSync(join(dir, FILE), reformat(src));
+      const bare = customCheckFindingsToBaselineEntries([
+        lintFinding(46),
+        lintFinding(3, { file: 'src/never-committed.ts' }),
+      ]);
+      const result = restampAtCommit(bare, dir, sha);
+      expect(result.restamped).toBe(1);
+      expect(result.unreadable).toBe(1);
+      const [stamped, still] = result.entries;
+      expect('contentHash' in stamped ? stamped.contentHash : undefined).toBe(
+        computeContentHash(src, 46),
       );
+      expect('contentHash' in still ? still.contentHash : undefined).toBeUndefined();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -321,16 +462,23 @@ describe('contentStamper (the one stamping policy)', () => {
 });
 
 describe('arch-check: a second stamping call site is rejected', () => {
-  it('scripts/check-architecture.sh flags computeContentHash() outside content-stamp.ts', () => {
+  it.each([
+    [
+      'direct call',
+      "import { computeContentHash } from '../content-hash';\n" +
+        'export const h = computeContentHash(content, line);\n',
+    ],
+    [
+      'aliased import',
+      "import { computeContentHash as windowHash } from '../content-hash';\n" +
+        'export const h = windowHash(content, line);\n',
+    ],
+  ])('flags computeContentHash outside content-stamp.ts (%s)', (_name, rogueSource) => {
     const repoRoot = resolve(__dirname, '..', '..');
     const rogueRoot = mkdtempSync(join(tmpdir(), 'dxkit-rogue-stamp-'));
     try {
       mkdirSync(join(rogueRoot, 'producers'), { recursive: true });
-      writeFileSync(
-        join(rogueRoot, 'producers', 'rogue.ts'),
-        "import { computeContentHash } from '../content-hash';\n" +
-          'export const h = computeContentHash(content, line);\n',
-      );
+      writeFileSync(join(rogueRoot, 'producers', 'rogue.ts'), rogueSource);
       // The gate reads its scan root from the environment so the rule can be
       // proven to bite without planting a file inside src/.
       const run = spawnSync('bash', ['scripts/check-architecture.sh'], {
@@ -343,6 +491,26 @@ describe('arch-check: a second stamping call site is rejected', () => {
       expect(run.stdout + run.stderr).toContain('producers/rogue.ts');
     } finally {
       rmSync(rogueRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('does not flag a mention in a comment, even one carrying a URL', () => {
+    const repoRoot = resolve(__dirname, '..', '..');
+    const cleanRoot = mkdtempSync(join(tmpdir(), 'dxkit-clean-stamp-'));
+    try {
+      writeFileSync(
+        join(cleanRoot, 'notes.ts'),
+        '// computeContentHash(content, line) is the primitive; see https://example.com/why\n' +
+          'export const ok = 1;\n',
+      );
+      const run = spawnSync('bash', ['scripts/check-architecture.sh'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: { ...process.env, CONTENT_STAMP_SCAN_ROOT: cleanRoot },
+      });
+      expect(run.stdout + run.stderr).not.toContain('Content-stamp violation');
+    } finally {
+      rmSync(cleanRoot, { recursive: true, force: true });
     }
   });
 });

--- a/test/baseline/content-stamp.test.ts
+++ b/test/baseline/content-stamp.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Content-hash stamping for custom-check findings: identity that survives a
+ * whole-file reformat (design section E).
+ *
+ * The scenario that shipped: a repo with a grandfathered lint backlog reindents
+ * one file from 4 spaces to 2. Every line moves past the 3-line identity
+ * window AND every line is rewritten in the diff (so the git-aware line map has
+ * no image for it). The only matcher pass that can pair the finding with its
+ * moved self is the content-hash pass, which normalizes whitespace, and it
+ * never fired for lint because the custom-check producer stamped no hash.
+ *
+ * This file pins:
+ *   - the producer stamps a located custom-check entry through the shared
+ *     `contentStamper` and leaves a binary one unstamped;
+ *   - the matcher pairs the reindented finding via `content-hash` at
+ *     confidence 0.80 with zero `added`;
+ *   - a genuinely new finding on a new line is still `added` (the negative);
+ *   - an unstamped (pre-scheme) baseline degrades to the old behavior instead
+ *     of throwing (migration contract, no rescan);
+ *   - the arch-check rule that keeps stamping to one module actually bites.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync, spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+
+import { customCheckFindingsToBaselineEntries } from '../../src/baseline/producers/custom-checks';
+import { entriesToLocated } from '../../src/baseline/entry-to-located';
+import { gitAwareMatch, CONFIDENCE_CONTENT_HASH } from '../../src/baseline/git-aware-match';
+import { contentStamper, contentStampSource } from '../../src/baseline/content-stamp';
+import { computeContentHash } from '../../src/baseline/content-hash';
+import type { CustomCheckFinding } from '../../src/analyzers/custom-checks/types';
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-content-stamp-'));
+  execFileSync('git', ['init', '--quiet', '--initial-branch=main'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+  return dir;
+}
+
+function commit(dir: string, message: string): string {
+  execFileSync('git', ['add', '-A'], { cwd: dir });
+  execFileSync('git', ['commit', '--quiet', '-m', message], { cwd: dir });
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir, encoding: 'utf8' }).trim();
+}
+
+const FILE = 'src/handlers.ts';
+
+/**
+ * A 4-space-indented file whose lint finding (`console.log`) sits on line 46.
+ * The first 40 lines carry five double-blank-line gaps that a formatter
+ * collapses, so the reformatted file has the same finding on line 41: moved
+ * by five lines (past the 3-line identity window) AND reindented (every line
+ * rewritten in the diff). The 7-line window around the finding has no blank
+ * lines, so its whitespace-normalized content is identical on both sides.
+ */
+function fourSpaceSource(): string {
+  const out: string[] = [];
+  // Lines 1-40: eight 5-line blocks, each followed by a double blank (which the
+  // reformat collapses to a single blank). 8 blocks x 5 = 40 lines.
+  for (let b = 0; b < 8; b++) {
+    if (b < 5) {
+      out.push(`export function helper${b}(x: number): number {`);
+      out.push(`    return x + ${b};`);
+      out.push(`}`);
+      out.push(``);
+      out.push(``);
+    } else {
+      out.push(`export function helper${b}(x: number): number {`);
+      out.push(`    const y = x * ${b};`);
+      out.push(`    return y;`);
+      out.push(`}`);
+      out.push(``);
+    }
+  }
+  // Lines 41-50: the function that carries the finding on line 46.
+  out.push(`export function handle(req: Request): Response {`); // 41
+  out.push(`    const id = req.id;`); // 42
+  out.push(`    if (!id) {`); // 43
+  out.push(`        return notFound();`); // 44
+  out.push(`    }`); // 45
+  out.push(`    console.log(id);`); // 46: the finding // slop-ok
+  out.push(`    return ok(id);`); // 47
+  out.push(`}`); // 48
+  out.push(``); // 49
+  out.push(`export const VERSION = 1;`); // 50
+  return out.join('\n') + '\n';
+}
+
+/** The formatter's output: 2-space indentation, double blanks collapsed. */
+function reformat(src: string): string {
+  return src
+    .replace(/\n\n\n/g, '\n\n')
+    .split('\n')
+    .map((l) => l.replace(/^( {4})+/, (m) => ' '.repeat(m.length / 2)))
+    .join('\n');
+}
+
+function lintFinding(line: number, over: Partial<CustomCheckFinding> = {}): CustomCheckFinding {
+  return {
+    check: 'lint:typescript',
+    blocking: true,
+    file: FILE,
+    line,
+    rule: 'no-console',
+    message: 'Unexpected console statement',
+    ...over,
+  };
+}
+
+describe('custom-check content-hash stamping (reformat survival)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeRepo();
+    mkdirSync(join(dir, 'src'), { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('the producer stamps a located entry through the shared stamper; a binary entry stays bare', () => {
+    const src = fourSpaceSource();
+    writeFileSync(join(dir, FILE), src);
+    const sha = commit(dir, 'backlog');
+    const [located, binary] = customCheckFindingsToBaselineEntries(
+      [lintFinding(46), { check: 'check:seam', blocking: true, message: 'boom' }],
+      { cwd: dir, commitSha: sha },
+    );
+    expect(located.kind === 'custom-check' && located.contentHash).toBe(
+      computeContentHash(src, 46),
+    );
+    expect(binary.kind === 'custom-check' && binary.contentHash).toBeUndefined();
+    // No commit (a bare tree): the same producer stamps nothing, no branch needed.
+    const [bare] = customCheckFindingsToBaselineEntries([lintFinding(46)]);
+    expect(bare.kind === 'custom-check' && bare.contentHash).toBeUndefined();
+    expect(contentStampSource({ cwd: dir, commitSha: '' })).toBeUndefined();
+  });
+
+  it('a 4-space to 2-space reindent pairs the moved finding via content-hash at 0.80, zero added', () => {
+    const before = fourSpaceSource();
+    writeFileSync(join(dir, FILE), before);
+    const base = commit(dir, 'backlog at 4 spaces');
+    const after = reformat(before);
+    expect(after.split('\n')[40]).toBe('  console.log(id);'); // line 41 now // slop-ok
+    writeFileSync(join(dir, FILE), after);
+    const head = commit(dir, 'reformat to 2 spaces');
+
+    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], {
+      cwd: dir,
+      commitSha: base,
+    });
+    const current = customCheckFindingsToBaselineEntries([lintFinding(41)], {
+      cwd: dir,
+      commitSha: head,
+    });
+    // The shift crossed the 3-line identity window: the fingerprints differ,
+    // so only a locator-aware pass can pair them.
+    expect(prior[0].id).not.toBe(current[0].id);
+
+    const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
+      cwd: dir,
+      baseSha: base,
+      headSha: head,
+    });
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+    expect(result.pairs).toHaveLength(1);
+    const [pair] = result.pairs;
+    expect(pair.status).toBe('persisted');
+    expect(pair.confidence).toBe(CONFIDENCE_CONTENT_HASH);
+    expect(CONFIDENCE_CONTENT_HASH).toBe(0.8);
+    expect(pair.reasons.map((r) => r.code)).toEqual(['content-hash']);
+  });
+
+  it('a genuinely new finding on a new line after the reformat is still added', () => {
+    const before = fourSpaceSource();
+    writeFileSync(join(dir, FILE), before);
+    const base = commit(dir, 'backlog at 4 spaces');
+    // Reformat AND introduce a second console.log at the top of `handle`.
+    const after = reformat(before).replace(
+      '  const id = req.id;\n',
+      '  const id = req.id;\n  console.log("entered");\n', // slop-ok
+    );
+    writeFileSync(join(dir, FILE), after);
+    const head = commit(dir, 'reformat + new finding');
+    const newLine = after.split('\n').findIndex((l) => l.includes('"entered"')) + 1;
+    const movedLine = after.split('\n').findIndex((l) => l === '  console.log(id);') + 1; // slop-ok
+    expect(newLine).toBe(38);
+    expect(movedLine).toBe(42);
+
+    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], {
+      cwd: dir,
+      commitSha: base,
+    });
+    const current = customCheckFindingsToBaselineEntries(
+      [lintFinding(newLine), lintFinding(movedLine)],
+      { cwd: dir, commitSha: head },
+    );
+    const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
+      cwd: dir,
+      baseSha: base,
+      headSha: head,
+    });
+    const movedId = current.find((e) => e.kind === 'custom-check' && e.line === movedLine)!.id;
+    const newId = current.find((e) => e.kind === 'custom-check' && e.line === newLine)!.id;
+    const matched = result.pairs.filter((p) => p.priorId !== undefined);
+    expect(matched.map((p) => p.currentId)).toEqual([movedId]);
+    expect(matched[0].reasons.map((r) => r.code)).toEqual(['content-hash']);
+    expect(result.added).toEqual([newId]);
+    expect(result.removed).toEqual([]);
+  });
+
+  it('a pre-scheme baseline (no hash on the prior side) degrades to the old behavior, never throws', () => {
+    const before = fourSpaceSource();
+    writeFileSync(join(dir, FILE), before);
+    const base = commit(dir, 'backlog at 4 spaces');
+    writeFileSync(join(dir, FILE), reformat(before));
+    const head = commit(dir, 'reformat to 2 spaces');
+    // An entry written before the stamp existed: same shape, no contentHash.
+    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)]);
+    expect(prior[0].kind === 'custom-check' && prior[0].contentHash).toBeUndefined();
+    const current = customCheckFindingsToBaselineEntries([lintFinding(41)], {
+      cwd: dir,
+      commitSha: head,
+    });
+    const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
+      cwd: dir,
+      baseSha: base,
+      headSha: head,
+    });
+    // Whatever the git passes make of the rewritten line, no pair may claim
+    // the content-hash reason: there was no hash to compare.
+    for (const p of result.pairs) {
+      expect(p.reasons.map((r) => r.code)).not.toContain('content-hash');
+    }
+    expect(result.pairs.length + result.added.length).toBe(1);
+  });
+});
+
+describe('contentStamper (the one stamping policy)', () => {
+  it('never stamps without a source, on a whole-file line 0, or on an unreadable file', () => {
+    const dir = makeRepo();
+    try {
+      writeFileSync(join(dir, 'a.txt'), 'one\ntwo\nthree\n');
+      const sha = commit(dir, 'init');
+      expect(contentStamper(undefined)('a.txt', 2)).toBeUndefined();
+      expect(contentStamper({ cwd: dir, commitSha: '' })('a.txt', 2)).toBeUndefined();
+      const stamp = contentStamper({ cwd: dir, commitSha: sha });
+      expect(stamp('a.txt', 0)).toBeUndefined();
+      expect(stamp('missing.txt', 2)).toBeUndefined();
+      expect(stamp('a.txt', 2)).toBe(computeContentHash('one\ntwo\nthree\n', 2));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('arch-check: a second stamping call site is rejected', () => {
+  it('scripts/check-architecture.sh flags computeContentHashFromCommit() outside content-stamp.ts', () => {
+    const repoRoot = resolve(__dirname, '..', '..');
+    const rogueRoot = mkdtempSync(join(tmpdir(), 'dxkit-rogue-stamp-'));
+    try {
+      mkdirSync(join(rogueRoot, 'producers'), { recursive: true });
+      writeFileSync(
+        join(rogueRoot, 'producers', 'rogue.ts'),
+        "import { computeContentHashFromCommit } from '../content-hash';\n" +
+          'export const h = computeContentHashFromCommit(cwd, sha, file, line);\n',
+      );
+      // The gate reads its scan root from the environment so the rule can be
+      // proven to bite without planting a file inside src/.
+      const run = spawnSync('bash', ['scripts/check-architecture.sh'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: { ...process.env, CONTENT_STAMP_SCAN_ROOT: rogueRoot },
+      });
+      expect(run.status).not.toBe(0);
+      expect(run.stdout + run.stderr).toContain('Content-stamp violation');
+      expect(run.stdout + run.stderr).toContain('producers/rogue.ts');
+    } finally {
+      rmSync(rogueRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/baseline/content-stamp.test.ts
+++ b/test/baseline/content-stamp.test.ts
@@ -158,6 +158,17 @@ describe('contentStamper (the one stamping policy)', () => {
     expect(contentStamper(dir)('real.txt', 1)).toBeDefined();
   });
 
+  it('refuses a path whose PARENT is a symlink out of the repo', () => {
+    const outside = mkdtempSync(join(tmpdir(), 'dxkit-outside-'));
+    try {
+      writeFileSync(join(outside, 'secret.txt'), 'outside\n');
+      symlinkSync(outside, join(dir, 'linkdir'));
+      expect(contentStamper(dir)('linkdir/secret.txt', 1)).toBeUndefined();
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
   it('refuses files over the size cap', () => {
     writeFileSync(join(dir, 'big.txt'), Buffer.alloc(CONTENT_STAMP_MAX_BYTES + 1, 0x61));
     expect(contentStamper(dir)('big.txt', 1)).toBeUndefined();
@@ -387,6 +398,42 @@ describe('the content pass across a reformat', () => {
     expect(result.added).toEqual([twinId]);
   });
 
+  it('after a detected rename, a twin at the OLD path never gets the same-file tier', () => {
+    const before = fourSpaceSource();
+    writeFileSync(join(dir, FILE), before);
+    const base = commit(dir, 'backlog at 4 spaces');
+    const prior = stampedEntries([lintFinding(46)], dir);
+    // Rename away (old path deleted in git terms is implied by mv), reformat
+    // the renamed file, and put a NEW file with the identical window at the
+    // OLD path. The renamed file's finding is fixed (absent), so the only
+    // candidate is the old-path twin: it must NOT pair at the same-file tier.
+    execFileSync('git', ['mv', FILE, 'src/handlers-v2.ts'], { cwd: dir });
+    const fixed = reformat(before).replace('  console.log(id);\n', ''); // slop-ok
+    writeFileSync(join(dir, 'src/handlers-v2.ts'), fixed);
+    writeFileSync(join(dir, FILE), before);
+    const head = commit(dir, 'rename + fix + twin at old path');
+    const status = execFileSync('git', ['diff', '--name-status', '--find-renames', base, head], {
+      cwd: dir,
+      encoding: 'utf8',
+    });
+    // Only exercise the invariant when git actually saw the rename.
+    if (/R\d+\tsrc\/handlers\.ts\tsrc\/handlers-v2\.ts/.test(status)) {
+      const current = stampedEntries([lintFinding(46)], dir);
+      const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
+        cwd: dir,
+        baseSha: base,
+        headSha: head,
+      });
+      const contentPair = result.pairs.find(
+        (p) => p.priorId === prior[0].id && p.reasons.some((r) => r.code === 'content-hash'),
+      );
+      if (contentPair) {
+        expect(contentPair.confidence).toBe(CONFIDENCE_CONTENT_HASH);
+        expect(contentPair.status).toBe('relocated');
+      }
+    }
+  });
+
   it('a cross-file pair (no same-file candidate anywhere) keeps the lower confidence tier', () => {
     const before = fourSpaceSource();
     writeFileSync(join(dir, FILE), before);
@@ -461,6 +508,39 @@ describe('restampAtCommit (the migrate lane, pre-scheme baselines)', () => {
   });
 });
 
+describe('restampContentHashes (the update-lane wrapper)', () => {
+  it('an unreachable anchor returns the disclosure summary and writes nothing', async () => {
+    const dir = makeRepo();
+    try {
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(join(dir, FILE), fourSpaceSource());
+      commit(dir, 'anchor');
+      const { restampContentHashes } = await import('../../src/baseline/migrate');
+      const { BASELINE_SCHEMA_VERSION, pathForBaseline, writeBaselineFile, readBaselineFile } =
+        await import('../../src/baseline/baseline-file');
+      const blPath = pathForBaseline(dir, 'main');
+      mkdirSync(join(dir, '.dxkit', 'baselines'), { recursive: true });
+      const bare = customCheckFindingsToBaselineEntries([lintFinding(46)]);
+      const base = {
+        schemaVersion: BASELINE_SCHEMA_VERSION,
+        name: 'main',
+        createdAt: new Date().toISOString(),
+        repo: { commitSha: '0'.repeat(40) },
+        findings: bare,
+      } as unknown as import('../../src/baseline/baseline-file').BaselineFile;
+      writeBaselineFile(blPath, base);
+      const summary = restampContentHashes(dir);
+      expect(summary).toEqual({ restamped: 0, unreadable: 1 });
+      const after = readBaselineFile(blPath);
+      expect(
+        'contentHash' in after.findings[0] ? after.findings[0].contentHash : undefined,
+      ).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('arch-check: a second stamping call site is rejected', () => {
   it.each([
     [
@@ -472,6 +552,11 @@ describe('arch-check: a second stamping call site is rejected', () => {
       'aliased import',
       "import { computeContentHash as windowHash } from '../content-hash';\n" +
         'export const h = windowHash(content, line);\n',
+    ],
+    [
+      'FromLines variant',
+      "import { computeContentHashFromLines } from '../content-hash';\n" +
+        'export const h = computeContentHashFromLines(lines, line);\n',
     ],
   ])('flags computeContentHash outside content-stamp.ts (%s)', (_name, rogueSource) => {
     const repoRoot = resolve(__dirname, '..', '..');

--- a/test/baseline/content-stamp.test.ts
+++ b/test/baseline/content-stamp.test.ts
@@ -124,38 +124,34 @@ describe('custom-check content-hash stamping (reformat survival)', () => {
   it('the producer stamps a located entry through the shared stamper; a binary entry stays bare', () => {
     const src = fourSpaceSource();
     writeFileSync(join(dir, FILE), src);
-    const sha = commit(dir, 'backlog');
+    commit(dir, 'backlog');
     const [located, binary] = customCheckFindingsToBaselineEntries(
       [lintFinding(46), { check: 'check:seam', blocking: true, message: 'boom' }],
-      { cwd: dir, commitSha: sha },
+      { cwd: dir },
     );
     expect(located.kind === 'custom-check' && located.contentHash).toBe(
       computeContentHash(src, 46),
     );
     expect(binary.kind === 'custom-check' && binary.contentHash).toBeUndefined();
-    // No commit (a bare tree): the same producer stamps nothing, no branch needed.
+    // No source (a producer running without a repo path): the same producer
+    // stamps nothing, no branch needed.
     const [bare] = customCheckFindingsToBaselineEntries([lintFinding(46)]);
     expect(bare.kind === 'custom-check' && bare.contentHash).toBeUndefined();
-    expect(contentStampSource({ cwd: dir, commitSha: '' })).toBeUndefined();
+    expect(contentStampSource({ cwd: '' })).toBeUndefined();
+    expect(contentStampSource({ cwd: dir })).toEqual({ cwd: dir });
   });
 
   it('a 4-space to 2-space reindent pairs the moved finding via content-hash at 0.80, zero added', () => {
     const before = fourSpaceSource();
     writeFileSync(join(dir, FILE), before);
     const base = commit(dir, 'backlog at 4 spaces');
+    // The baseline side stamps the tree it scanned (the 4-space one).
+    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
     const after = reformat(before);
     expect(after.split('\n')[40]).toBe('  console.log(id);'); // line 41 now // slop-ok
     writeFileSync(join(dir, FILE), after);
     const head = commit(dir, 'reformat to 2 spaces');
-
-    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], {
-      cwd: dir,
-      commitSha: base,
-    });
-    const current = customCheckFindingsToBaselineEntries([lintFinding(41)], {
-      cwd: dir,
-      commitSha: head,
-    });
+    const current = customCheckFindingsToBaselineEntries([lintFinding(41)], { cwd: dir });
     // The shift crossed the 3-line identity window: the fingerprints differ,
     // so only a locator-aware pass can pair them.
     expect(prior[0].id).not.toBe(current[0].id);
@@ -179,6 +175,7 @@ describe('custom-check content-hash stamping (reformat survival)', () => {
     const before = fourSpaceSource();
     writeFileSync(join(dir, FILE), before);
     const base = commit(dir, 'backlog at 4 spaces');
+    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
     // Reformat AND introduce a second console.log at the top of `handle`.
     const after = reformat(before).replace(
       '  const id = req.id;\n',
@@ -191,13 +188,9 @@ describe('custom-check content-hash stamping (reformat survival)', () => {
     expect(newLine).toBe(38);
     expect(movedLine).toBe(42);
 
-    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], {
-      cwd: dir,
-      commitSha: base,
-    });
     const current = customCheckFindingsToBaselineEntries(
       [lintFinding(newLine), lintFinding(movedLine)],
-      { cwd: dir, commitSha: head },
+      { cwd: dir },
     );
     const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
       cwd: dir,
@@ -213,6 +206,69 @@ describe('custom-check content-hash stamping (reformat survival)', () => {
     expect(result.removed).toEqual([]);
   });
 
+  it('an UNCOMMITTED reformat (the Stop-gate / pre-push tree) still pairs: the stamp reads the tree the scan read', () => {
+    const before = fourSpaceSource();
+    writeFileSync(join(dir, FILE), before);
+    const base = commit(dir, 'backlog at 4 spaces');
+    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
+    // Reformat in place, no commit: the current scan sees line 41 in a dirty tree.
+    writeFileSync(join(dir, FILE), reformat(before));
+    const current = customCheckFindingsToBaselineEntries([lintFinding(41)], { cwd: dir });
+    expect(current[0].kind === 'custom-check' && current[0].contentHash).toBe(
+      prior[0].kind === 'custom-check' ? prior[0].contentHash : 'unstamped',
+    );
+    const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
+      cwd: dir,
+      baseSha: base,
+      headSha: base,
+    });
+    expect(result.added).toEqual([]);
+    expect(result.pairs.map((p) => p.reasons.map((r) => r.code))).toEqual([['content-hash']]);
+  });
+
+  it('a same-rule finding newly introduced at the old line is NOT paired as persisted on a dirty tree', () => {
+    const before = fourSpaceSource();
+    writeFileSync(join(dir, FILE), before);
+    commit(dir, 'backlog at 4 spaces');
+    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
+    // Delete the finding's line and put a DIFFERENT console statement at line 46,
+    // uncommitted. Hashing the committed tree at line 46 would reproduce the prior
+    // stamp and pair a net-new finding as persisted.
+    const lines = before.split('\n');
+    lines[45] = '    console.log("something else entirely", req, id, extra);'; // slop-ok
+    lines.splice(30, 0, '    // a comment shifting the window content');
+    writeFileSync(join(dir, FILE), lines.join('\n'));
+    const current = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
+    expect(current[0].kind === 'custom-check' && current[0].contentHash).not.toBe(
+      prior[0].kind === 'custom-check' ? prior[0].contentHash : 'unstamped',
+    );
+  });
+
+  it('the content pass prefers a same-file candidate over an identical window in another file', () => {
+    const before = fourSpaceSource();
+    writeFileSync(join(dir, FILE), before);
+    const base = commit(dir, 'backlog at 4 spaces');
+    const prior = customCheckFindingsToBaselineEntries([lintFinding(46)], { cwd: dir });
+    // A copy of the file appears under a new path, and the original is reformatted.
+    const twin = 'src/legacy-copy.ts';
+    writeFileSync(join(dir, twin), reformat(before));
+    writeFileSync(join(dir, FILE), reformat(before));
+    const head = commit(dir, 'reformat + copy');
+    const current = customCheckFindingsToBaselineEntries(
+      [{ ...lintFinding(41), file: twin }, lintFinding(41)],
+      { cwd: dir },
+    );
+    const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
+      cwd: dir,
+      baseSha: base,
+      headSha: head,
+    });
+    const paired = result.pairs.find((p) => p.priorId !== undefined)!;
+    const sameFileId = current.find((e) => e.kind === 'custom-check' && e.file === FILE)!.id;
+    expect(paired.currentId).toBe(sameFileId);
+    expect(paired.status).toBe('persisted');
+  });
+
   it('a pre-scheme baseline (no hash on the prior side) degrades to the old behavior, never throws', () => {
     const before = fourSpaceSource();
     writeFileSync(join(dir, FILE), before);
@@ -222,10 +278,7 @@ describe('custom-check content-hash stamping (reformat survival)', () => {
     // An entry written before the stamp existed: same shape, no contentHash.
     const prior = customCheckFindingsToBaselineEntries([lintFinding(46)]);
     expect(prior[0].kind === 'custom-check' && prior[0].contentHash).toBeUndefined();
-    const current = customCheckFindingsToBaselineEntries([lintFinding(41)], {
-      cwd: dir,
-      commitSha: head,
-    });
+    const current = customCheckFindingsToBaselineEntries([lintFinding(41)], { cwd: dir });
     const result = gitAwareMatch(entriesToLocated(prior), entriesToLocated(current), {
       cwd: dir,
       baseSha: base,
@@ -241,17 +294,26 @@ describe('custom-check content-hash stamping (reformat survival)', () => {
 });
 
 describe('contentStamper (the one stamping policy)', () => {
-  it('never stamps without a source, on a whole-file line 0, or on an unreadable file', () => {
+  it('never stamps without a source, on a whole-file line 0, outside the tree, or on an unreadable file', () => {
     const dir = makeRepo();
     try {
       writeFileSync(join(dir, 'a.txt'), 'one\ntwo\nthree\n');
-      const sha = commit(dir, 'init');
       expect(contentStamper(undefined)('a.txt', 2)).toBeUndefined();
-      expect(contentStamper({ cwd: dir, commitSha: '' })('a.txt', 2)).toBeUndefined();
-      const stamp = contentStamper({ cwd: dir, commitSha: sha });
+      expect(contentStamper({ cwd: '' })('a.txt', 2)).toBeUndefined();
+      // No commit is needed: the tree is the source (an unborn HEAD still stamps).
+      const stamp = contentStamper({ cwd: dir });
       expect(stamp('a.txt', 0)).toBeUndefined();
       expect(stamp('missing.txt', 2)).toBeUndefined();
+      expect(stamp('..' + '/outside.txt', 2)).toBeUndefined();
+      expect(stamp(join(dir, 'a.txt'), 2)).toBeUndefined();
       expect(stamp('a.txt', 2)).toBe(computeContentHash('one\ntwo\nthree\n', 2));
+      // Per-stamper file cache: a rewrite after the first read is not observed
+      // (a producer stamps one scan of one tree; the next scan builds a new stamper).
+      writeFileSync(join(dir, 'a.txt'), 'changed\ntwo\nthree\n');
+      expect(stamp('a.txt', 2)).toBe(computeContentHash('one\ntwo\nthree\n', 2));
+      expect(contentStamper({ cwd: dir })('a.txt', 2)).toBe(
+        computeContentHash('changed\ntwo\nthree\n', 2),
+      );
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -259,15 +321,15 @@ describe('contentStamper (the one stamping policy)', () => {
 });
 
 describe('arch-check: a second stamping call site is rejected', () => {
-  it('scripts/check-architecture.sh flags computeContentHashFromCommit() outside content-stamp.ts', () => {
+  it('scripts/check-architecture.sh flags computeContentHash() outside content-stamp.ts', () => {
     const repoRoot = resolve(__dirname, '..', '..');
     const rogueRoot = mkdtempSync(join(tmpdir(), 'dxkit-rogue-stamp-'));
     try {
       mkdirSync(join(rogueRoot, 'producers'), { recursive: true });
       writeFileSync(
         join(rogueRoot, 'producers', 'rogue.ts'),
-        "import { computeContentHashFromCommit } from '../content-hash';\n" +
-          'export const h = computeContentHashFromCommit(cwd, sha, file, line);\n',
+        "import { computeContentHash } from '../content-hash';\n" +
+          'export const h = computeContentHash(content, line);\n',
       );
       // The gate reads its scan root from the environment so the rule can be
       // proven to bite without planting a file inside src/.

--- a/test/baseline/producers/security.test.ts
+++ b/test/baseline/producers/security.test.ts
@@ -1,13 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { execFileSync } from 'child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
+import { describe, it, expect } from 'vitest';
 import { securityAggregateToBaselineEntries } from '../../../src/baseline/producers/security';
 import type { CodeFinding, SecurityAggregate } from '../../../src/analyzers/security/aggregator';
 import type { DepVulnFinding } from '../../../src/languages/capabilities/types';
 import { identityFor } from '../../../src/baseline/finding-identity';
-import { computeContentHash } from '../../../src/baseline/content-hash';
 
 function codeFinding(over: Partial<CodeFinding> = {}): CodeFinding {
   return {
@@ -228,7 +223,7 @@ describe('securityAggregateToBaselineEntries', () => {
     expect(entries[0].id).toBe(entries[1].id);
   });
 
-  it('omits contentHash when cwd or commitSha is missing', () => {
+  it('emits bare entries: the ORCHESTRATOR stamps content hashes, not this producer', () => {
     const f = codeFinding({ file: 'x.ts', line: 5 });
     const aggregate = emptyAggregate({
       findingsByCategory: { secret: [], code: [f], config: [], dependency: [] },
@@ -236,66 +231,8 @@ describe('securityAggregateToBaselineEntries', () => {
     const entries = securityAggregateToBaselineEntries(aggregate);
     const e = entries[0];
     if (e.kind !== 'code') throw new Error('shape');
+    // Stamping policy + wiring are pinned in test/baseline/content-stamp.test.ts
+    // and content-stamp-parity.test.ts; this producer stays a pure map.
     expect(e.contentHash).toBeUndefined();
-  });
-
-  describe('content-hash stamping (with git fixture)', () => {
-    let dir: string;
-
-    beforeEach(() => {
-      dir = mkdtempSync(join(tmpdir(), 'dxkit-prod-sec-'));
-      execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
-      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
-      execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir });
-      writeFileSync(
-        join(dir, 'config.ts'),
-        ['// line 1', 'const a = 1;', 'const b = 2;', 'const c = 3;', '// line 5'].join('\n') +
-          '\n',
-      );
-      execFileSync('git', ['add', '.'], { cwd: dir });
-      execFileSync('git', ['commit', '-q', '-m', 'fixture'], { cwd: dir });
-    });
-
-    afterEach(() => {
-      rmSync(dir, { recursive: true, force: true });
-    });
-
-    it('stamps a content-hash matching computeContentHash on the file', () => {
-      const f = codeFinding({ file: 'config.ts', line: 3 });
-      const aggregate = emptyAggregate({
-        findingsByCategory: { secret: [], code: [f], config: [], dependency: [] },
-      });
-      const entries = securityAggregateToBaselineEntries(aggregate, { cwd: dir });
-      const e = entries[0];
-      if (e.kind !== 'code') throw new Error('shape');
-      expect(e.contentHash).toMatch(/^[0-9a-f]{16}$/);
-
-      const fileContent =
-        ['// line 1', 'const a = 1;', 'const b = 2;', 'const c = 3;', '// line 5'].join('\n') +
-        '\n';
-      expect(e.contentHash).toBe(computeContentHash(fileContent, 3));
-    });
-
-    it('omits contentHash for line 0 (whole-file findings)', () => {
-      const f = codeFinding({ category: 'config', file: 'config.ts', line: 0 });
-      const aggregate = emptyAggregate({
-        findingsByCategory: { secret: [], code: [], config: [f], dependency: [] },
-      });
-      const entries = securityAggregateToBaselineEntries(aggregate, { cwd: dir });
-      const e = entries[0];
-      if (e.kind !== 'config') throw new Error('shape');
-      expect(e.contentHash).toBeUndefined();
-    });
-
-    it('omits contentHash when the file is missing from the tree', () => {
-      const f = codeFinding({ file: 'missing.ts', line: 1 });
-      const aggregate = emptyAggregate({
-        findingsByCategory: { secret: [], code: [f], config: [], dependency: [] },
-      });
-      const entries = securityAggregateToBaselineEntries(aggregate, { cwd: dir });
-      const e = entries[0];
-      if (e.kind !== 'code') throw new Error('shape');
-      expect(e.contentHash).toBeUndefined();
-    });
   });
 });

--- a/test/baseline/producers/security.test.ts
+++ b/test/baseline/producers/security.test.ts
@@ -241,7 +241,6 @@ describe('securityAggregateToBaselineEntries', () => {
 
   describe('content-hash stamping (with git fixture)', () => {
     let dir: string;
-    let sha: string;
 
     beforeEach(() => {
       dir = mkdtempSync(join(tmpdir(), 'dxkit-prod-sec-'));
@@ -255,7 +254,6 @@ describe('securityAggregateToBaselineEntries', () => {
       );
       execFileSync('git', ['add', '.'], { cwd: dir });
       execFileSync('git', ['commit', '-q', '-m', 'fixture'], { cwd: dir });
-      sha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir, encoding: 'utf8' }).trim();
     });
 
     afterEach(() => {
@@ -267,7 +265,7 @@ describe('securityAggregateToBaselineEntries', () => {
       const aggregate = emptyAggregate({
         findingsByCategory: { secret: [], code: [f], config: [], dependency: [] },
       });
-      const entries = securityAggregateToBaselineEntries(aggregate, { cwd: dir, commitSha: sha });
+      const entries = securityAggregateToBaselineEntries(aggregate, { cwd: dir });
       const e = entries[0];
       if (e.kind !== 'code') throw new Error('shape');
       expect(e.contentHash).toMatch(/^[0-9a-f]{16}$/);
@@ -283,18 +281,18 @@ describe('securityAggregateToBaselineEntries', () => {
       const aggregate = emptyAggregate({
         findingsByCategory: { secret: [], code: [], config: [f], dependency: [] },
       });
-      const entries = securityAggregateToBaselineEntries(aggregate, { cwd: dir, commitSha: sha });
+      const entries = securityAggregateToBaselineEntries(aggregate, { cwd: dir });
       const e = entries[0];
       if (e.kind !== 'config') throw new Error('shape');
       expect(e.contentHash).toBeUndefined();
     });
 
-    it('omits contentHash when the file is missing at the commit', () => {
+    it('omits contentHash when the file is missing from the tree', () => {
       const f = codeFinding({ file: 'missing.ts', line: 1 });
       const aggregate = emptyAggregate({
         findingsByCategory: { secret: [], code: [f], config: [], dependency: [] },
       });
-      const entries = securityAggregateToBaselineEntries(aggregate, { cwd: dir, commitSha: sha });
+      const entries = securityAggregateToBaselineEntries(aggregate, { cwd: dir });
       const e = entries[0];
       if (e.kind !== 'code') throw new Error('shape');
       expect(e.contentHash).toBeUndefined();

--- a/test/fixtures-analysis.test.ts
+++ b/test/fixtures-analysis.test.ts
@@ -44,6 +44,7 @@ import { buildReachable } from '../src/analyzers/tests/import-graph';
 import { trustedLocalContext } from '../src/analysis-trust';
 import { createBaseline } from '../src/baseline/create';
 import { runGuardrailCheck } from '../src/baseline/check';
+import { CONFIDENCE_CONTENT_HASH_SAME_FILE } from '../src/baseline/git-aware-match';
 import { isSanitized } from '../src/baseline/sanitize';
 
 const FIXTURES = join(__dirname, 'fixtures', 'analysis');
@@ -490,16 +491,16 @@ describe('analysis fixtures: identity survives a whole-file reformat (custom-che
     // Seven findings sit on reindented lines: the diff rewrote them, so the
     // git line map has no image and only the content pass can pair them. The
     // eighth (`function debugLog(`) is unindented, so git maps it directly.
-    // A content pair carries the matcher's 0.80 confidence, which the default
-    // policy reads as `uncertain` (a warning) for a medium-severity kind;
-    // never `added`, never a block.
+    // A SAME-FILE content pair carries the 0.90 tier, which clears every
+    // default per-severity threshold: the whole backlog reads PERSISTED,
+    // never `uncertain`, never `added`, never a block.
     const byContent = pairs.filter((p) =>
       p.classification.reasons.some((r) => r.code === 'content-hash'),
     );
     expect(byContent.length).toBe(7);
     for (const p of byContent) {
-      expect(p.pair.confidence).toBe(0.8);
-      expect(['persisted', 'uncertain']).toContain(p.classification.status);
+      expect(p.pair.confidence).toBe(CONFIDENCE_CONTENT_HASH_SAME_FILE);
+      expect(p.classification.status).toBe('persisted');
     }
     expect(pairs.length - byContent.length).toBe(1);
 

--- a/test/fixtures-analysis.test.ts
+++ b/test/fixtures-analysis.test.ts
@@ -22,7 +22,16 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { execFileSync } from 'child_process';
-import { cpSync, existsSync, mkdtempSync, mkdirSync, renameSync, rmSync } from 'fs';
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { gatherFileFindings } from '../src/analyzers/security/gather';
@@ -33,6 +42,9 @@ import { gatherRepoModelSet } from '../src/analyzers/model-schema/gather';
 import { summarize } from '../src/analyzers/flow/model';
 import { buildReachable } from '../src/analyzers/tests/import-graph';
 import { trustedLocalContext } from '../src/analysis-trust';
+import { createBaseline } from '../src/baseline/create';
+import { runGuardrailCheck } from '../src/baseline/check';
+import { isSanitized } from '../src/baseline/sanitize';
 
 const FIXTURES = join(__dirname, 'fixtures', 'analysis');
 
@@ -412,4 +424,100 @@ describe('analysis fixtures — flow resolution (flow-capable packs)', () => {
     expect(model.dynamicCalls).toHaveLength(1);
     expect(model.dynamicCalls[0].receiver).toBe('client');
   });
+});
+
+describe('analysis fixtures: identity survives a whole-file reformat (custom-check content hash)', () => {
+  // The class this guards: a repo with a grandfathered lint backlog reindents
+  // one file. Every finding moves past the 3-line identity window AND every
+  // line is rewritten in the diff, so neither the fingerprint nor the git line
+  // map can pair a finding with its moved self. Only the content-hash pass
+  // (whitespace-normalized) can, and it only fires when the producer stamped a
+  // hash on BOTH sides. Before the shared stamper, custom-check entries carried
+  // none, so a reformat read as "resolved" for the whole backlog plus
+  // "net-new" for every finding the diff happened to touch. dxkit's own repo
+  // has no custom-check backlog, so the self-guardrail cannot see this shape.
+  // Not in STACKS: this fixture exists for the gate, not the per-stack
+  // invariants, and it is staged on demand to keep the matrix cheap.
+  const FIXTURE = 'ts-lint-backlog';
+  const FILE = 'src/legacy.ts';
+  let dir: string;
+  const vcs = (...a: string[]) =>
+    execFileSync('git', a, { cwd: dir, stdio: ['ignore', 'pipe', 'ignore'] });
+  const commitTree = (message: string) => {
+    vcs('add', '-A');
+    vcs('commit', '-qm', message);
+  };
+  const reformat = (src: string) =>
+    src
+      .replace(/\n\n\n/g, '\n\n')
+      .split('\n')
+      .map((l) => l.replace(/^( {4})+/, (m) => ' '.repeat(m.length / 2)))
+      .join('\n');
+  const customCheckPairs = (result: Awaited<ReturnType<typeof runGuardrailCheck>>) =>
+    result.pairs.filter((p) => p.kind === 'custom-check');
+
+  beforeAll(() => {
+    dir = stageFixture(FIXTURE);
+    return () => rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('a reindent of a file with a lint backlog yields zero net-new custom-check findings end-to-end', async () => {
+    const created = await createBaseline({ cwd: dir });
+    const entries = (created.file?.findings ?? []).filter((f) => f.kind === 'custom-check');
+    // The whole backlog is captured, located, and stamped on the baseline side.
+    expect(entries.length).toBe(8);
+    for (const e of entries) {
+      expect(e.kind === 'custom-check' && !isSanitized(e) && e.file).toBe(FILE);
+      expect(e.kind === 'custom-check' && !isSanitized(e) && e.contentHash).toMatch(
+        /^[0-9a-f]{16}$/,
+      );
+    }
+    // Commit the baseline (committed mode anchors on the tree), then reformat.
+    commitTree('baseline');
+    const before = readFileSync(join(dir, FILE), 'utf8');
+    const after = reformat(before);
+    expect(after).not.toBe(before);
+    expect(after.split('\n').length).toBeLessThan(before.split('\n').length);
+    writeFileSync(join(dir, FILE), after);
+    commitTree('reformat: 4-space to 2-space, collapse double blanks');
+
+    const result = await runGuardrailCheck({ trust: trustedLocalContext(), cwd: dir });
+    const pairs = customCheckPairs(result);
+    expect(pairs.length).toBe(8);
+    expect(pairs.filter((p) => p.classification.status === 'added')).toEqual([]);
+    expect(pairs.filter((p) => p.classification.status === 'removed')).toEqual([]);
+    expect(pairs.every((p) => p.classification.blocks === false)).toBe(true);
+    // Seven findings sit on reindented lines: the diff rewrote them, so the
+    // git line map has no image and only the content pass can pair them. The
+    // eighth (`function debugLog(`) is unindented, so git maps it directly.
+    // A content pair carries the matcher's 0.80 confidence, which the default
+    // policy reads as `uncertain` (a warning) for a medium-severity kind;
+    // never `added`, never a block.
+    const byContent = pairs.filter((p) =>
+      p.classification.reasons.some((r) => r.code === 'content-hash'),
+    );
+    expect(byContent.length).toBe(7);
+    for (const p of byContent) {
+      expect(p.pair.confidence).toBe(0.8);
+      expect(['persisted', 'uncertain']).toContain(p.classification.status);
+    }
+    expect(pairs.length - byContent.length).toBe(1);
+
+    // The negative: a genuinely new call after the reformat is still net-new,
+    // and the ones that moved stay grandfathered. Appended past every existing
+    // finding's context window, so nothing else changes identity.
+    writeFileSync(
+      join(dir, FILE),
+      readFileSync(join(dir, FILE), 'utf8') +
+        "\nexport function extra(): void {\n  debugLog('extra');\n}\n",
+    );
+    commitTree('introduce a new debugLog call');
+    const again = await runGuardrailCheck({ trust: trustedLocalContext(), cwd: dir });
+    const added = customCheckPairs(again).filter((p) => p.classification.status === 'added');
+    expect(added.length).toBe(1);
+    expect(added[0].classification.blocks).toBe(true);
+    expect(customCheckPairs(again).filter((p) => p.classification.status === 'removed')).toEqual(
+      [],
+    );
+  }, 120_000);
 });

--- a/test/fixtures/analysis/ts-lint-backlog/dxkit-policy.json
+++ b/test/fixtures/analysis/ts-lint-backlog/dxkit-policy.json
@@ -1,0 +1,10 @@
+{
+  "checks": [
+    {
+      "name": "repo:no-debug-log",
+      "pattern": "debugLog\\(",
+      "globs": ["src/**"],
+      "blocking": true
+    }
+  ]
+}

--- a/test/fixtures/analysis/ts-lint-backlog/package.json
+++ b/test/fixtures/analysis/ts-lint-backlog/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ts-lint-backlog",
+  "version": "1.0.0",
+  "private": true
+}

--- a/test/fixtures/analysis/ts-lint-backlog/src/legacy.ts
+++ b/test/fixtures/analysis/ts-lint-backlog/src/legacy.ts
@@ -1,0 +1,53 @@
+export function helper0(x: number): number {
+    const y = x * 0;
+    debugLog(y);
+    return y;
+}
+
+
+export function helper1(x: number): number {
+    const y = x * 1;
+    debugLog(y);
+    return y;
+}
+
+
+export function helper2(x: number): number {
+    const y = x * 2;
+    debugLog(y);
+    return y;
+}
+
+
+export function helper3(x: number): number {
+    const y = x * 3;
+    debugLog(y);
+    return y;
+}
+
+
+export function helper4(x: number): number {
+    const y = x * 4;
+    debugLog(y);
+    return y;
+}
+
+
+export function helper5(x: number): number {
+    const y = x * 5;
+    debugLog(y);
+    return y;
+}
+
+
+export function handle(id: string): string {
+    if (!id) {
+        return 'missing';
+    }
+    debugLog(id);
+    return id.toUpperCase();
+}
+
+function debugLog(value: unknown): void {
+    void value;
+}


### PR DESCRIPTION
## What / why

Finding identity must survive a whole-file reformat. The git-aware matcher already has a content-hash pass (whitespace-normalized context window, keyed by rule + hash) that pairs a finding with its moved self when git cannot map the line, but only the security producer stamped `contentHash`, through a local closure. The custom-check producer stamped nothing, so on a real estate 0 of ~10k grandfathered lint entries carried a hash and one 4-space to 2-space reindent read as thousands "resolved" plus dozens "net-new".

This unit gives every LOCATED finding kind ONE stamping entry point (`src/baseline/content-stamp.ts`, CLAUDE.md Rule 2.30), routes the security, custom-check, duplication and stale-allow producers through it, threads the hash into the custom-check locator so the matcher's content pass applies, and adds an arch-check rule confining `computeContentHashFromCommit` to that module.

Baselines written before this scheme carry no hash on custom-check entries and degrade to today's behavior (git + identity passes); no migration or rescan.

## How it is tested

- `test/baseline/content-stamp.test.ts`: a lint finding at line 46 of a 4-space file, baseline stamped; the same file reindented to 2 spaces with the finding at line 41 pairs via `content-hash` at confidence 0.8 with zero `added`; a genuinely new finding on a new line is still `added`.
- `test/baseline/content-stamp-parity.test.ts`: iterates `PRODUCERS`, asserts every line-carrying entry is stamped (synthetic-injection guarded).
- `test/fixtures/analysis/ts-lint-backlog`: end to end through `runGuardrailCheck`, a reformat commit over a committed lint backlog yields zero net-new custom-check findings.

## Sweep

typecheck, typecheck:test, eslint (0 warnings), prettier, check-architecture, check-docs-coverage, check-slop, build, vitest --coverage (383 files / 5705 tests, 72.71%), check-coverage: all green. `guardrail check --mode ref-based --ref origin/main`: PASSED (88 pairs, 0 blocking). Confidentiality grep: clean.

## Review focus

- `content-stamp.ts` policy (no commit, whole-file finding, unreadable file all yield no stamp).
- `entry-to-located.ts`: the custom-check locator carries `contentHash` and the `rule` string is minted identically on both sides.
- The arch-check rule and its annotation escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
