### PR TITLE
feat(lanes,correctness): verify the committed head the way CI does, plus a lockfile-sync floor (4.4.5 verify-tree-parity)

### DIFF
--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -933,12 +933,12 @@ fi
 # builder directly. This mirrors Rule 2 (one gather path) + Rule 12 (one query
 # point): bypassing the runner means re-implementing the fail-open/timeout
 # policy and silently drifting from the pack-driven contract.
-ROGUE_FLOOR=$(grep -rnE "\.(syntaxCheck|affectedTests|resolutionCheck|parseFailures)[[:space:]]*\(" src/ 2>/dev/null \
+ROGUE_FLOOR=$(grep -rnE "\.(syntaxCheck|affectedTests|resolutionCheck|lockfileCheck|parseFailures)[[:space:]]*\(" src/ 2>/dev/null \
   | grep -v "// correctness-runner-ok" \
   | grep -v -E ':[[:space:]]*(//|\*)' \
   | grep -v "^src/analyzers/correctness/")
 if [ -n "$ROGUE_FLOOR" ]; then
-  echo "❌ Correctness-floor rule violation: a pack's syntaxCheck()/affectedTests()/resolutionCheck() builder"
+  echo "❌ Correctness-floor rule violation: a pack's syntaxCheck()/affectedTests()/resolutionCheck()/lockfileCheck() builder"
   echo "   invoked outside the canonical runner src/analyzers/correctness/run.ts:"
   echo "$ROGUE_FLOOR"
   echo "   → Call runCorrectnessFloor() from src/analyzers/correctness/run.ts instead;"

--- a/src-templates/.claude/skills/dxkit-remediate/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-remediate/SKILL.md
@@ -62,6 +62,11 @@ default branch only, with dxkit-authored prompts only.
   the guardrail. Pre-existing debt listed in the ledger was already failing
   before the agent ran; it is disclosed, not the agent's doing.
 - `no-op` — the agent ran and committed nothing; the job summary says so.
+- `install-failed` — a clean checkout of the agent's commits cannot be
+  installed the way CI installs it (the frozen-lockfile install failed, most
+  often a manifest edited without re-running the install so the lockfile
+  records it). Nothing lands: CI would have died before any gate ran. The
+  ledger carries the install output.
 - `floor-red` — the agent's change introduced a net-new floor failure; no
   PR was opened, on purpose. The ledger names the failing checks.
 - `guardrail-red` — the guardrail blocked, refused to gate, or could not

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-branch.yml
@@ -55,27 +55,13 @@ __DXKIT_LANE_TOKEN_STEPS__
 __DXKIT_CI_RUNTIME_SETUP__
       - name: Install dependencies + dxkit
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            # A repo whose tree only resolves under --legacy-peer-deps (a peer
-            # conflict its own install already tolerates) must not fail the gate.
-            # `npm ci` installs the LOCKFILE's tree either way — the flag only
-            # skips the peer check that rejects it — so the audited tree is still
-            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
-            # fallback here: it would fabricate a different tree.
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          # A repo whose tree only resolves under --legacy-peer-deps (a peer
+          # conflict its own install already tolerates) must not fail the gate.
+          # `npm ci` installs the LOCKFILE's tree either way — the flag only
+          # skips the peer check that rejects it — so the audited tree is still
+          # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+          # fallback here: it would fabricate a different tree.
+          __DXKIT_INSTALL_DEPS__
 
       - name: Install scanner tools
         run: |

--- a/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh-cache.yml
@@ -50,27 +50,13 @@ __DXKIT_LANE_TOKEN_STEPS__
 __DXKIT_CI_RUNTIME_SETUP__
       - name: Install dependencies + dxkit
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            # A repo whose tree only resolves under --legacy-peer-deps (a peer
-            # conflict its own install already tolerates) must not fail the gate.
-            # `npm ci` installs the LOCKFILE's tree either way — the flag only
-            # skips the peer check that rejects it — so the audited tree is still
-            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
-            # fallback here: it would fabricate a different tree.
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          # A repo whose tree only resolves under --legacy-peer-deps (a peer
+          # conflict its own install already tolerates) must not fail the gate.
+          # `npm ci` installs the LOCKFILE's tree either way — the flag only
+          # skips the peer check that rejects it — so the audited tree is still
+          # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+          # fallback here: it would fabricate a different tree.
+          __DXKIT_INSTALL_DEPS__
 
       - name: Install scanner tools
         run: |

--- a/src-templates/.github/workflows/dxkit-baseline-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-baseline-refresh.yml
@@ -51,27 +51,13 @@ __DXKIT_LANE_TOKEN_STEPS__
 __DXKIT_CI_RUNTIME_SETUP__
       - name: Install dependencies + dxkit
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            # A repo whose tree only resolves under --legacy-peer-deps (a peer
-            # conflict its own install already tolerates) must not fail the gate.
-            # `npm ci` installs the LOCKFILE's tree either way — the flag only
-            # skips the peer check that rejects it — so the audited tree is still
-            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
-            # fallback here: it would fabricate a different tree.
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          # A repo whose tree only resolves under --legacy-peer-deps (a peer
+          # conflict its own install already tolerates) must not fail the gate.
+          # `npm ci` installs the LOCKFILE's tree either way — the flag only
+          # skips the peer check that rejects it — so the audited tree is still
+          # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+          # fallback here: it would fabricate a different tree.
+          __DXKIT_INSTALL_DEPS__
 
       - name: Install scanner tools
         run: |

--- a/src-templates/.github/workflows/dxkit-comment-defer.yml
+++ b/src-templates/.github/workflows/dxkit-comment-defer.yml
@@ -123,21 +123,7 @@ __DXKIT_CI_RUNTIME_SETUP__
       - name: Install dependencies + dxkit
         if: steps.perm.outputs.authorized == 'true' && steps.pr.outputs.same_repo == 'true'
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          __DXKIT_INSTALL_DEPS__
 
       - name: Install scanner tools
         if: steps.perm.outputs.authorized == 'true' && steps.pr.outputs.same_repo == 'true'

--- a/src-templates/.github/workflows/dxkit-deep-sast-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-deep-sast-refresh.yml
@@ -59,16 +59,10 @@ jobs:
 
       - name: Install dxkit
         run: |
-          if [ -f package-lock.json ]; then
-            # A peer-conflicted tree (one that only installs under
-            # --legacy-peer-deps) must not fail the refresh. `npm ci` installs the
-            # LOCKFILE's tree either way; the flag only skips the peer check.
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          # A peer-conflicted tree (one that only installs under
+          # --legacy-peer-deps) must not fail the refresh. `npm ci` installs the
+          # LOCKFILE's tree either way; the flag only skips the peer check.
+          __DXKIT_INSTALL_DEPS__
 
       - name: Ingest Snyk Code findings
         env:

--- a/src-templates/.github/workflows/dxkit-dep-bump.yml
+++ b/src-templates/.github/workflows/dxkit-dep-bump.yml
@@ -54,21 +54,7 @@ __DXKIT_CI_RUNTIME_SETUP__
       # repo ships).
       - name: Install dependencies + dxkit
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          __DXKIT_INSTALL_DEPS__
 
       - name: Install scanner tools
         run: |

--- a/src-templates/.github/workflows/dxkit-extensions-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-extensions-refresh.yml
@@ -52,27 +52,13 @@ __DXKIT_LANE_TOKEN_STEPS__
 __DXKIT_CI_RUNTIME_SETUP__
       - name: Install dependencies + dxkit
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            # A repo whose tree only resolves under --legacy-peer-deps (a peer
-            # conflict its own install already tolerates) must not fail the gate.
-            # `npm ci` installs the LOCKFILE's tree either way — the flag only
-            # skips the peer check that rejects it — so the audited tree is still
-            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
-            # fallback here: it would fabricate a different tree.
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          # A repo whose tree only resolves under --legacy-peer-deps (a peer
+          # conflict its own install already tolerates) must not fail the gate.
+          # `npm ci` installs the LOCKFILE's tree either way — the flag only
+          # skips the peer check that rejects it — so the audited tree is still
+          # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+          # fallback here: it would fabricate a different tree.
+          __DXKIT_INSTALL_DEPS__
 
       - name: Refresh + land the extension snapshots
         env:

--- a/src-templates/.github/workflows/dxkit-flow-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-flow-refresh.yml
@@ -55,27 +55,13 @@ __DXKIT_LANE_TOKEN_STEPS__
 __DXKIT_CI_RUNTIME_SETUP__
       - name: Install dependencies + dxkit
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            # A repo whose tree only resolves under --legacy-peer-deps (a peer
-            # conflict its own install already tolerates) must not fail the gate.
-            # `npm ci` installs the LOCKFILE's tree either way — the flag only
-            # skips the peer check that rejects it — so the audited tree is still
-            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
-            # fallback here: it would fabricate a different tree.
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          # A repo whose tree only resolves under --legacy-peer-deps (a peer
+          # conflict its own install already tolerates) must not fail the gate.
+          # `npm ci` installs the LOCKFILE's tree either way — the flag only
+          # skips the peer check that rejects it — so the audited tree is still
+          # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+          # fallback here: it would fabricate a different tree.
+          __DXKIT_INSTALL_DEPS__
 
       - name: Refresh + land the flow contract
         env:

--- a/src-templates/.github/workflows/dxkit-graph-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-graph-refresh.yml
@@ -42,27 +42,13 @@ jobs:
 __DXKIT_CI_RUNTIME_SETUP__
       - name: Install dependencies + dxkit
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            # A repo whose tree only resolves under --legacy-peer-deps (a peer
-            # conflict its own install already tolerates) must not fail the gate.
-            # `npm ci` installs the LOCKFILE's tree either way — the flag only
-            # skips the peer check that rejects it — so the audited tree is still
-            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
-            # fallback here: it would fabricate a different tree.
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          # A repo whose tree only resolves under --legacy-peer-deps (a peer
+          # conflict its own install already tolerates) must not fail the gate.
+          # `npm ci` installs the LOCKFILE's tree either way — the flag only
+          # skips the peer check that rejects it — so the audited tree is still
+          # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+          # fallback here: it would fabricate a different tree.
+          __DXKIT_INSTALL_DEPS__
 
       - name: Install scanner tools
         run: |

--- a/src-templates/.github/workflows/dxkit-guardrails.yml
+++ b/src-templates/.github/workflows/dxkit-guardrails.yml
@@ -60,27 +60,13 @@ __DXKIT_CI_RUNTIME_SETUP__
       # present. A project-local dxkit devDependency is installed along the way.
       - name: Install dependencies + dxkit
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            # A repo whose tree only resolves under --legacy-peer-deps (a peer
-            # conflict its own install already tolerates) must not fail the gate.
-            # `npm ci` installs the LOCKFILE's tree either way — the flag only
-            # skips the peer check that rejects it — so the audited tree is still
-            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
-            # fallback here: it would fabricate a different tree.
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          # A repo whose tree only resolves under --legacy-peer-deps (a peer
+          # conflict its own install already tolerates) must not fail the gate.
+          # `npm ci` installs the LOCKFILE's tree either way — the flag only
+          # skips the peer check that rejects it — so the audited tree is still
+          # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+          # fallback here: it would fabricate a different tree.
+          __DXKIT_INSTALL_DEPS__
 
       # Install the scanner toolchain dxkit needs for this stack
       # (gitleaks, semgrep, cloc, jscpd, ruff, osv-scanner, etc.).

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -93,21 +93,7 @@ jobs:
 
       - name: Install dependencies + dxkit
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          __DXKIT_INSTALL_DEPS__
 
       - name: Compute the task matrix
         id: plan
@@ -198,21 +184,7 @@ __DXKIT_CI_RUNTIME_SETUP__
       # be the tree the repo ships).
       - name: Install dependencies + dxkit
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          __DXKIT_INSTALL_DEPS__
 
       - name: Install scanner tools
         run: |

--- a/src-templates/.github/workflows/dxkit-reports-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-reports-refresh.yml
@@ -43,27 +43,13 @@ jobs:
 __DXKIT_CI_RUNTIME_SETUP__
       - name: Install dependencies + dxkit
         run: |
-          corepack enable >/dev/null 2>&1 || true
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          elif [ -f yarn.lock ]; then
-            yarn install --immutable 2>/dev/null || yarn install --frozen-lockfile
-          elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-            npm install -g bun >/dev/null 2>&1 || true
-            bun install --frozen-lockfile
-          elif [ -f package-lock.json ]; then
-            # A repo whose tree only resolves under --legacy-peer-deps (a peer
-            # conflict its own install already tolerates) must not fail the gate.
-            # `npm ci` installs the LOCKFILE's tree either way — the flag only
-            # skips the peer check that rejects it — so the audited tree is still
-            # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
-            # fallback here: it would fabricate a different tree.
-            npm ci || npm ci --legacy-peer-deps
-          elif [ -f package.json ]; then
-            npm install || npm install --legacy-peer-deps
-          else
-            npm install -g @vyuhlabs/dxkit
-          fi
+          # A repo whose tree only resolves under --legacy-peer-deps (a peer
+          # conflict its own install already tolerates) must not fail the gate.
+          # `npm ci` installs the LOCKFILE's tree either way — the flag only
+          # skips the peer check that rejects it — so the audited tree is still
+          # the tree the repo ships. Re-resolving (`npm install`) is NOT a valid
+          # fallback here: it would fabricate a different tree.
+          __DXKIT_INSTALL_DEPS__
 
       - name: Install scanner tools
         run: |

--- a/src/analyzers/correctness/lockfile-check.ts
+++ b/src/analyzers/correctness/lockfile-check.ts
@@ -1,0 +1,79 @@
+/**
+ * The lockfile-sync floor check executor (4.4.5), split from the runner for
+ * module size. Policy lives here exactly as for the other checks: a real
+ * failure blocks, infrastructure is a disclosed skip, a pack-declared
+ * tolerated failure is a PASS that carries its disclosure.
+ */
+import type { LanguageId } from '../../languages/types';
+import {
+  LOCKFILE_SYNC_LABEL,
+  type CorrectnessContext,
+  type CorrectnessProvider,
+} from '../../languages/capabilities/correctness';
+import { tail, type CommandExec } from '../tools/bounded-exec';
+import type { CorrectnessCheckResult } from './run';
+
+/**
+ * Execute a pack's optional lockfile-sync check (4.4.5): the ecosystem's
+ * non-installing frozen-install dry-run. A non-zero exit the pack declared
+ * `tolerated` (npm's peer conflict, which CI's install retries under
+ * `--legacy-peer-deps`) is a PASS carrying the disclosure as `note`; any
+ * other non-zero exit (an out-of-sync lockfile) is a real failure, the exact
+ * shape that killed CI's install before the gate ran. A pack skip and an
+ * unavailable binary are fail-open, disclosed. Returns null when the pack
+ * declined (no lockfile).
+ */
+export function runLockfileCheck(
+  id: LanguageId,
+  provider: CorrectnessProvider,
+  ctx: CorrectnessContext,
+  exec: CommandExec,
+): CorrectnessCheckResult | null {
+  let check;
+  try {
+    check = provider.lockfileCheck!(ctx);
+  } catch (err) {
+    return {
+      pack: id,
+      label: LOCKFILE_SYNC_LABEL,
+      bin: '',
+      status: 'skipped-unavailable',
+      output: `lockfile-sync check errored: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (check === null) return null;
+  if (check.kind === 'skipped') {
+    return {
+      pack: id,
+      label: LOCKFILE_SYNC_LABEL,
+      bin: '',
+      status: 'skipped-unavailable',
+      output: check.reason,
+    };
+  }
+  const cmd = check.command;
+  const base = { pack: id, label: cmd.label, bin: cmd.bin, args: cmd.args };
+  const outcome = exec(cmd, ctx.cwd);
+  if (!outcome.available) {
+    return {
+      ...base,
+      status: 'skipped-unavailable',
+      ...(outcome.output ? { output: outcome.output } : {}),
+    };
+  }
+  if (outcome.timedOut) return { ...base, status: 'skipped-timeout' };
+  if (outcome.overflowed) return { ...base, status: 'skipped-overflow' };
+  if (outcome.code === 0) return { ...base, status: 'pass' };
+  if (check.tolerated && check.tolerated.matches(outcome.output)) {
+    return { ...base, status: 'pass', note: check.tolerated.disclosure };
+  }
+  return {
+    ...base,
+    status: 'fail',
+    output:
+      tail(outcome.output) +
+      '\nThe lockfile does not satisfy the manifest: a frozen install (what CI runs before ' +
+      'any gate) fails on this tree. Re-run the package manager install so the lockfile ' +
+      'records the manifest, and commit both.',
+  };
+}

--- a/src/analyzers/correctness/pure-checks.ts
+++ b/src/analyzers/correctness/pure-checks.ts
@@ -1,0 +1,142 @@
+/**
+ * The IN-PROCESS floor check executors, split from the runner for module
+ * size: the import-resolution and structure checks are pure pack
+ * computations (no spawn, no PATH, no timeout budget), plus the defensive
+ * failure-parser wrapper for command output. Policy is unchanged and stays
+ * one place per concern: a throw is infrastructure (disclosed skip, never a
+ * verdict), findings carry durable per-item identities, and pass-time
+ * disclosures ride the check so a partial answer never hides behind a green
+ * check (Rule 19).
+ */
+import type { LanguageId } from '../../languages/types';
+import {
+  isProjectPathIdentity,
+  type CorrectnessCommand,
+  type CorrectnessContext,
+  type CorrectnessProvider,
+} from '../../languages/capabilities/correctness';
+import type { CorrectnessCheckResult } from './run';
+
+/** The one label the import-resolution check reports under — shared by the
+ *  floor-state snapshot, the attribution comparator's finding-level path, and
+ *  every renderer. */
+export const IMPORT_RESOLUTION_LABEL = 'import-resolution';
+
+/** The remedy line per unresolved-identity class: ONE rendering shared by
+ *  the check's failure output and the pre-push attribution note. */
+export const UNRESOLVED_REMEDY = {
+  package:
+    'An import of an uninstalled/undeclared package fails at build or run time. ' +
+    'Declare it in the dependency manifest and install it (or remove the import).',
+  projectPath:
+    'A relative import of a file the pushed tree does not carry fails at build time. ' +
+    'Commit the missing file (or remove the import).',
+} as const;
+
+/** Run a command's optional failure parser defensively: a parser throw or a
+ *  non-array result is "not parseable" (null → check-level precision), never
+ *  an error that breaks the floor. Results are deduped and order-normalized —
+ *  identity must not depend on output order. */
+export function parseFailuresSafely(cmd: CorrectnessCommand, output: string): string[] | null {
+  try {
+    const raw = cmd.parseFailures!(output);
+    if (raw === null || !Array.isArray(raw)) return null;
+    const cleaned = [...new Set(raw.filter((f) => typeof f === 'string' && f.length > 0))].sort();
+    return cleaned.length > 0 ? cleaned : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Execute a pack's optional import-resolution check (a pure computation, not a
+ * command). Findings are keyed by SPECIFIER — the durable identity of "package
+ * X does not resolve": a second file importing the same missing package is the
+ * same root cause, while a NEW missing package on an already-red repo is a new
+ * finding (the granularity the class fix requires). A throw is infrastructure:
+ * disclosed skip, never a verdict.
+ */
+export function runResolutionCheck(
+  id: LanguageId,
+  provider: CorrectnessProvider,
+  ctx: CorrectnessContext,
+): CorrectnessCheckResult {
+  const base = { pack: id, label: IMPORT_RESOLUTION_LABEL, bin: '' };
+  try {
+    const res = provider.resolutionCheck!(ctx);
+    const disclosed = res.disclosures ?? [];
+    const withDisclosures = disclosed.length > 0 ? { disclosures: disclosed } : {};
+    if (res.kind === 'clean') return { ...base, status: 'pass', ...withDisclosures };
+    if (res.kind === 'unresolved') {
+      const lines = res.unresolved.map((u) =>
+        isProjectPathIdentity(u.specifier)
+          ? `'${u.specifier}' ${u.detail ?? 'does not exist in the repo tree'} (relative import in ${u.file})`
+          : `'${u.specifier}' does not resolve against the installed tree (imported by ${u.file})`,
+      );
+      if (res.unresolved.some((u) => !isProjectPathIdentity(u.specifier))) {
+        lines.push(UNRESOLVED_REMEDY.package);
+      }
+      if (res.unresolved.some((u) => isProjectPathIdentity(u.specifier))) {
+        lines.push(UNRESOLVED_REMEDY.projectPath);
+      }
+      return {
+        ...base,
+        status: 'fail',
+        output: lines.join('\n'),
+        findings: [...new Set(res.unresolved.map((u) => u.specifier))],
+        ...withDisclosures,
+      };
+    }
+    return { ...base, status: 'skipped-unavailable', output: res.reason, ...withDisclosures };
+  } catch (err) {
+    return {
+      ...base,
+      status: 'skipped-unavailable',
+      output: `import-resolution check errored: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/**
+ * Execute a pack's optional STRUCTURE check (#309) — a pure computation
+ * mirroring `runResolutionCheck`. Findings are keyed by FILE (the durable
+ * identity of "this artifact is structurally broken"), so an already-red
+ * tree still blocks on a NEW broken artifact through the one attribution
+ * comparator. `none` returns null (nothing ran, nothing claimed); a throw
+ * is infrastructure — disclosed skip, never a verdict.
+ */
+export function runStructureCheck(
+  id: LanguageId,
+  provider: CorrectnessProvider,
+  ctx: CorrectnessContext,
+): CorrectnessCheckResult | null {
+  try {
+    const res = provider.structureCheck!(ctx);
+    if (res.kind === 'none') return null;
+    const base = { pack: id, label: res.label, bin: '' };
+    if (res.kind === 'clean') return { ...base, status: 'pass' };
+    if (res.kind === 'broken') {
+      const lines = res.findings.map((f) => `${f.file}: ${f.problem}`);
+      lines.push(
+        'A structurally implausible artifact fails downstream consumers at import time. ' +
+          'This is a STRUCTURAL check (no parser covers this artifact class) — shallow by ' +
+          'design, so a pass means "plausible", never "parsed".',
+      );
+      return {
+        ...base,
+        status: 'fail',
+        output: lines.join('\n'),
+        findings: [...new Set(res.findings.map((f) => f.file))],
+      };
+    }
+    return { ...base, status: 'skipped-unavailable', output: res.reason };
+  } catch (err) {
+    return {
+      pack: id,
+      label: 'structure',
+      bin: '',
+      status: 'skipped-unavailable',
+      output: `structure check errored: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -21,14 +21,10 @@ import {
   dependencyManifestFilesIn,
 } from '../../languages';
 import type { LanguageId, LanguageSupport } from '../../languages/types';
-import type {
-  CorrectnessCommand,
-  CorrectnessContext,
-  CorrectnessProvider,
-  CorrectnessScope,
-} from '../../languages/capabilities/correctness';
-import { isProjectPathIdentity } from '../../languages/capabilities/correctness';
+import type { CorrectnessScope } from '../../languages/capabilities/correctness';
 import { runLockfileCheck } from './lockfile-check';
+import { parseFailuresSafely, runResolutionCheck, runStructureCheck } from './pure-checks';
+export { IMPORT_RESOLUTION_LABEL, UNRESOLVED_REMEDY } from './pure-checks';
 import {
   classifyEnvironmentFailure,
   currentEnvironment,
@@ -150,130 +146,6 @@ export interface CorrectnessFloorOptions {
   readonly exec?: CommandExec;
   /** Injected for tests; defaults to the real local host + toolchain probes. */
   readonly env?: ExecutionEnvironment;
-}
-
-/** The one label the import-resolution check reports under — shared by the
- *  floor-state snapshot, the attribution comparator's finding-level path, and
- *  every renderer. */
-export const IMPORT_RESOLUTION_LABEL = 'import-resolution';
-
-/** The remedy line per unresolved-identity class: ONE rendering shared by
- *  the check's failure output and the pre-push attribution note. */
-export const UNRESOLVED_REMEDY = {
-  package:
-    'An import of an uninstalled/undeclared package fails at build or run time. ' +
-    'Declare it in the dependency manifest and install it (or remove the import).',
-  projectPath:
-    'A relative import of a file the pushed tree does not carry fails at build time. ' +
-    'Commit the missing file (or remove the import).',
-} as const;
-
-/** Run a command's optional failure parser defensively: a parser throw or a
- *  non-array result is "not parseable" (null → check-level precision), never
- *  an error that breaks the floor. Results are deduped and order-normalized —
- *  identity must not depend on output order. */
-function parseFailuresSafely(cmd: CorrectnessCommand, output: string): string[] | null {
-  try {
-    const raw = cmd.parseFailures!(output);
-    if (raw === null || !Array.isArray(raw)) return null;
-    const cleaned = [...new Set(raw.filter((f) => typeof f === 'string' && f.length > 0))].sort();
-    return cleaned.length > 0 ? cleaned : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Execute a pack's optional import-resolution check (a pure computation, not a
- * command). Findings are keyed by SPECIFIER — the durable identity of "package
- * X does not resolve": a second file importing the same missing package is the
- * same root cause, while a NEW missing package on an already-red repo is a new
- * finding (the granularity the class fix requires). A throw is infrastructure:
- * disclosed skip, never a verdict.
- */
-function runResolutionCheck(
-  id: LanguageId,
-  provider: CorrectnessProvider,
-  ctx: CorrectnessContext,
-): CorrectnessCheckResult {
-  const base = { pack: id, label: IMPORT_RESOLUTION_LABEL, bin: '' };
-  try {
-    const res = provider.resolutionCheck!(ctx);
-    const disclosed = res.disclosures ?? [];
-    const withDisclosures = disclosed.length > 0 ? { disclosures: disclosed } : {};
-    if (res.kind === 'clean') return { ...base, status: 'pass', ...withDisclosures };
-    if (res.kind === 'unresolved') {
-      const lines = res.unresolved.map((u) =>
-        isProjectPathIdentity(u.specifier)
-          ? `'${u.specifier}' ${u.detail ?? 'does not exist in the repo tree'} (relative import in ${u.file})`
-          : `'${u.specifier}' does not resolve against the installed tree (imported by ${u.file})`,
-      );
-      if (res.unresolved.some((u) => !isProjectPathIdentity(u.specifier))) {
-        lines.push(UNRESOLVED_REMEDY.package);
-      }
-      if (res.unresolved.some((u) => isProjectPathIdentity(u.specifier))) {
-        lines.push(UNRESOLVED_REMEDY.projectPath);
-      }
-      return {
-        ...base,
-        status: 'fail',
-        output: lines.join('\n'),
-        findings: [...new Set(res.unresolved.map((u) => u.specifier))],
-        ...withDisclosures,
-      };
-    }
-    return { ...base, status: 'skipped-unavailable', output: res.reason, ...withDisclosures };
-  } catch (err) {
-    return {
-      ...base,
-      status: 'skipped-unavailable',
-      output: `import-resolution check errored: ${err instanceof Error ? err.message : String(err)}`,
-    };
-  }
-}
-
-/**
- * Execute a pack's optional STRUCTURE check (#309) — a pure computation
- * mirroring `runResolutionCheck`. Findings are keyed by FILE (the durable
- * identity of "this artifact is structurally broken"), so an already-red
- * tree still blocks on a NEW broken artifact through the one attribution
- * comparator. `none` returns null (nothing ran, nothing claimed); a throw
- * is infrastructure — disclosed skip, never a verdict.
- */
-function runStructureCheck(
-  id: LanguageId,
-  provider: CorrectnessProvider,
-  ctx: CorrectnessContext,
-): CorrectnessCheckResult | null {
-  try {
-    const res = provider.structureCheck!(ctx);
-    if (res.kind === 'none') return null;
-    const base = { pack: id, label: res.label, bin: '' };
-    if (res.kind === 'clean') return { ...base, status: 'pass' };
-    if (res.kind === 'broken') {
-      const lines = res.findings.map((f) => `${f.file}: ${f.problem}`);
-      lines.push(
-        'A structurally implausible artifact fails downstream consumers at import time. ' +
-          'This is a STRUCTURAL check (no parser covers this artifact class) — shallow by ' +
-          'design, so a pass means "plausible", never "parsed".',
-      );
-      return {
-        ...base,
-        status: 'fail',
-        output: lines.join('\n'),
-        findings: [...new Set(res.findings.map((f) => f.file))],
-      };
-    }
-    return { ...base, status: 'skipped-unavailable', output: res.reason };
-  } catch (err) {
-    return {
-      pack: id,
-      label: 'structure',
-      bin: '',
-      status: 'skipped-unavailable',
-      output: `structure check errored: ${err instanceof Error ? err.message : String(err)}`,
-    };
-  }
 }
 
 /**

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -125,6 +125,11 @@ export interface CorrectnessFloorResult {
    *  surface can say WHY the full suite ran on a fast surface. `files` names
    *  the matched manifests (empty only in the no-declared-patterns fail-safe
    *  case, where escalation is still the honest default). */
+  /** The EFFECTIVE scope this run executed at (post-escalation), so a
+   *  renderer never has to guess — the ledger once hardcoded "full scope"
+   *  while the verification floor ran `affected`. Optional only for older
+   *  serialized snapshots; every fresh run carries it. */
+  readonly scope?: CorrectnessScope;
   readonly scopeEscalated?: {
     readonly reason: 'dependency-manifest-changed';
     readonly files: readonly string[];
@@ -410,11 +415,16 @@ export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessF
       if (structural !== null) checks.push(structural);
     }
     // The lockfile-sync check (4.4.5): decided ONCE here, like the scope
-    // escalation above, never per pack. It runs at FULL scope only, which
-    // after escalation means "CI's scope, or a diff that touched a dependency
-    // manifest" — the only diffs that can move a lockfile out of sync. A
-    // source-only fast run never pays the dry-run.
-    if (provider.lockfileCheck && scope === 'full') {
+    // escalation above, never per pack. It runs at FULL scope (after
+    // escalation that means "CI's scope, or a diff that touched a dependency
+    // manifest" — the only diffs that can move a lockfile out of sync), and
+    // ALSO on an affected run whose changed set is EMPTY: an undeterminable
+    // diff reads as full for every pack's own builders (the documented
+    // contract), so this check must not silently thin out there — the diff
+    // that drifted the lockfile may simply be invisible. Only a determinate
+    // source-only fast run skips the dry-run.
+    const lockfileDue = scope === 'full' || ctx.changedFiles.length === 0;
+    if (provider.lockfileCheck && lockfileDue) {
       const lock = runLockfileCheck(id, provider, ctx, exec);
       if (lock !== null) checks.push(lock);
     }
@@ -422,7 +432,7 @@ export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessF
 
   const ran = checks.some((c) => c.status === 'pass' || c.status === 'fail');
   const blocks = checks.some((c) => c.status === 'fail');
-  return { ran, checks, blocks, ...(scopeEscalated ? { scopeEscalated } : {}) };
+  return { ran, checks, blocks, scope, ...(scopeEscalated ? { scopeEscalated } : {}) };
 }
 
 /** One-line disclosure of a manifest-driven scope escalation (null when the

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -21,14 +21,14 @@ import {
   dependencyManifestFilesIn,
 } from '../../languages';
 import type { LanguageId, LanguageSupport } from '../../languages/types';
-import {
-  LOCKFILE_SYNC_LABEL,
-  type CorrectnessCommand,
-  type CorrectnessContext,
-  type CorrectnessProvider,
-  type CorrectnessScope,
+import type {
+  CorrectnessCommand,
+  CorrectnessContext,
+  CorrectnessProvider,
+  CorrectnessScope,
 } from '../../languages/capabilities/correctness';
 import { isProjectPathIdentity } from '../../languages/capabilities/correctness';
+import { runLockfileCheck } from './lockfile-check';
 import {
   classifyEnvironmentFailure,
   currentEnvironment,
@@ -269,71 +269,6 @@ function runStructureCheck(
       output: `structure check errored: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
-}
-
-/**
- * Execute a pack's optional lockfile-sync check (4.4.5): the ecosystem's
- * non-installing frozen-install dry-run. A non-zero exit the pack declared
- * `tolerated` (npm's peer conflict, which CI's install retries under
- * `--legacy-peer-deps`) is a PASS carrying the disclosure as `note`; any
- * other non-zero exit (an out-of-sync lockfile) is a real failure, the exact
- * shape that killed CI's install before the gate ran. A pack skip and an
- * unavailable binary are fail-open, disclosed. Returns null when the pack
- * declined (no lockfile).
- */
-function runLockfileCheck(
-  id: LanguageId,
-  provider: CorrectnessProvider,
-  ctx: CorrectnessContext,
-  exec: CommandExec,
-): CorrectnessCheckResult | null {
-  let check;
-  try {
-    check = provider.lockfileCheck!(ctx);
-  } catch (err) {
-    return {
-      pack: id,
-      label: LOCKFILE_SYNC_LABEL,
-      bin: '',
-      status: 'skipped-unavailable',
-      output: `lockfile-sync check errored: ${err instanceof Error ? err.message : String(err)}`,
-    };
-  }
-  if (check === null) return null;
-  if (check.kind === 'skipped') {
-    return {
-      pack: id,
-      label: LOCKFILE_SYNC_LABEL,
-      bin: '',
-      status: 'skipped-unavailable',
-      output: check.reason,
-    };
-  }
-  const cmd = check.command;
-  const base = { pack: id, label: cmd.label, bin: cmd.bin, args: cmd.args };
-  const outcome = exec(cmd, ctx.cwd);
-  if (!outcome.available) {
-    return {
-      ...base,
-      status: 'skipped-unavailable',
-      ...(outcome.output ? { output: outcome.output } : {}),
-    };
-  }
-  if (outcome.timedOut) return { ...base, status: 'skipped-timeout' };
-  if (outcome.overflowed) return { ...base, status: 'skipped-overflow' };
-  if (outcome.code === 0) return { ...base, status: 'pass' };
-  if (check.tolerated && check.tolerated.matches(outcome.output)) {
-    return { ...base, status: 'pass', note: check.tolerated.disclosure };
-  }
-  return {
-    ...base,
-    status: 'fail',
-    output:
-      tail(outcome.output) +
-      '\nThe lockfile does not satisfy the manifest: a frozen install (what CI runs before ' +
-      'any gate) fails on this tree. Re-run the package manager install so the lockfile ' +
-      'records the manifest, and commit both.',
-  };
 }
 
 /**

--- a/src/analyzers/correctness/run.ts
+++ b/src/analyzers/correctness/run.ts
@@ -21,11 +21,12 @@ import {
   dependencyManifestFilesIn,
 } from '../../languages';
 import type { LanguageId, LanguageSupport } from '../../languages/types';
-import type {
-  CorrectnessCommand,
-  CorrectnessContext,
-  CorrectnessProvider,
-  CorrectnessScope,
+import {
+  LOCKFILE_SYNC_LABEL,
+  type CorrectnessCommand,
+  type CorrectnessContext,
+  type CorrectnessProvider,
+  type CorrectnessScope,
 } from '../../languages/capabilities/correctness';
 import { isProjectPathIdentity } from '../../languages/capabilities/correctness';
 import {
@@ -102,6 +103,11 @@ export interface CorrectnessCheckResult {
    *  every surface prints, so a partial answer never hides behind a green
    *  check (Rule 19). */
   readonly disclosures?: readonly string[];
+  /** A disclosure attached to a PASS: the check passed under a condition the
+   *  reader must know about (today: the lockfile-sync check tolerating an
+   *  npm peer conflict because CI's install retries under
+   *  `--legacy-peer-deps`). Never present on a failure. */
+  readonly note?: string;
 }
 
 export interface CorrectnessFloorResult {
@@ -266,6 +272,71 @@ function runStructureCheck(
 }
 
 /**
+ * Execute a pack's optional lockfile-sync check (4.4.5): the ecosystem's
+ * non-installing frozen-install dry-run. A non-zero exit the pack declared
+ * `tolerated` (npm's peer conflict, which CI's install retries under
+ * `--legacy-peer-deps`) is a PASS carrying the disclosure as `note`; any
+ * other non-zero exit (an out-of-sync lockfile) is a real failure, the exact
+ * shape that killed CI's install before the gate ran. A pack skip and an
+ * unavailable binary are fail-open, disclosed. Returns null when the pack
+ * declined (no lockfile).
+ */
+function runLockfileCheck(
+  id: LanguageId,
+  provider: CorrectnessProvider,
+  ctx: CorrectnessContext,
+  exec: CommandExec,
+): CorrectnessCheckResult | null {
+  let check;
+  try {
+    check = provider.lockfileCheck!(ctx);
+  } catch (err) {
+    return {
+      pack: id,
+      label: LOCKFILE_SYNC_LABEL,
+      bin: '',
+      status: 'skipped-unavailable',
+      output: `lockfile-sync check errored: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (check === null) return null;
+  if (check.kind === 'skipped') {
+    return {
+      pack: id,
+      label: LOCKFILE_SYNC_LABEL,
+      bin: '',
+      status: 'skipped-unavailable',
+      output: check.reason,
+    };
+  }
+  const cmd = check.command;
+  const base = { pack: id, label: cmd.label, bin: cmd.bin, args: cmd.args };
+  const outcome = exec(cmd, ctx.cwd);
+  if (!outcome.available) {
+    return {
+      ...base,
+      status: 'skipped-unavailable',
+      ...(outcome.output ? { output: outcome.output } : {}),
+    };
+  }
+  if (outcome.timedOut) return { ...base, status: 'skipped-timeout' };
+  if (outcome.overflowed) return { ...base, status: 'skipped-overflow' };
+  if (outcome.code === 0) return { ...base, status: 'pass' };
+  if (check.tolerated && check.tolerated.matches(outcome.output)) {
+    return { ...base, status: 'pass', note: check.tolerated.disclosure };
+  }
+  return {
+    ...base,
+    status: 'fail',
+    output:
+      tail(outcome.output) +
+      '\nThe lockfile does not satisfy the manifest: a frozen install (what CI runs before ' +
+      'any gate) fails on this tree. Re-run the package manager install so the lockfile ' +
+      'records the manifest, and commit both.',
+  };
+}
+
+/**
  * Run the correctness floor across the active packs. Never throws — an exec
  * error surfaces as a `fail` check (fail-closed), a missing binary as
  * `skipped-unavailable` (fail-open). `blocks` is true iff a check that ran
@@ -403,6 +474,15 @@ export function runCorrectnessFloor(opts: CorrectnessFloorOptions): CorrectnessF
       const structural = runStructureCheck(id, provider, ctx);
       if (structural !== null) checks.push(structural);
     }
+    // The lockfile-sync check (4.4.5): decided ONCE here, like the scope
+    // escalation above, never per pack. It runs at FULL scope only, which
+    // after escalation means "CI's scope, or a diff that touched a dependency
+    // manifest" — the only diffs that can move a lockfile out of sync. A
+    // source-only fast run never pays the dry-run.
+    if (provider.lockfileCheck && scope === 'full') {
+      const lock = runLockfileCheck(id, provider, ctx, exec);
+      if (lock !== null) checks.push(lock);
+    }
   }
 
   const ran = checks.some((c) => c.status === 'pass' || c.status === 'fail');
@@ -437,6 +517,13 @@ export function describeFloorCapturePlan(cwd: string, packs: readonly LanguageSu
       if (cmd !== null) plan.push(`${id} ${cmd.label}: ${[cmd.bin, ...cmd.args].join(' ')}`);
     }
     if (provider.resolutionCheck) plan.push(`${id} import-resolution: read-only, sub-second`);
+    if (provider.lockfileCheck) {
+      const lock = provider.lockfileCheck(ctx);
+      if (lock?.kind === 'command') {
+        const c = lock.command;
+        plan.push(`${id} ${c.label}: ${[c.bin, ...c.args].join(' ')} (dry-run, installs nothing)`);
+      }
+    }
   }
   return plan;
 }

--- a/src/deps-bump/run.ts
+++ b/src/deps-bump/run.ts
@@ -37,6 +37,7 @@ import {
 import { detectActiveLanguages } from '../languages';
 import {
   detectPackageManager,
+  isPeerConflictOnly,
   upgradeArgv,
   type DependencySection,
   type PackageManager,
@@ -314,8 +315,10 @@ export async function runDepsBump(opts: DepsBumpOptions): Promise<DepsBumpResult
     // conflict its own install already tolerates) must not fail the bump —
     // the same fallback doctrine as every shipped `npm ci || npm ci
     // --legacy-peer-deps` install step: the flag only skips the peer check
-    // that rejects the tree, it never fabricates a different resolution.
-    if (!r.ok && pm === 'npm' && /ERESOLVE|peer dep/i.test(r.output)) {
+    // that rejects the tree, it never fabricates a different resolution. The
+    // classifier is the one in package-manager.ts, shared with the lockfile-
+    // sync floor check, so "peer conflict" means the same thing everywhere.
+    if (!r.ok && pm === 'npm' && isPeerConflictOnly(r.output)) {
       r = execBump([...argv, '--legacy-peer-deps']);
     }
     applied.push({

--- a/src/lanes/verification-render.ts
+++ b/src/lanes/verification-render.ts
@@ -9,6 +9,13 @@
 import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
 import type { AttributedFloorFailure } from '../analyzers/correctness/attribution';
 
+/** One check line. A pass that carries a disclosure (a tolerated condition,
+ *  4.4.5) shows it inline: a reader must never mistake "passed under a
+ *  condition" for a plain pass. */
+function renderCheckLine(c: CorrectnessFloorResult['checks'][number]): string {
+  return `- ${c.pack}/${c.label}: ${c.status}${c.note ? ` (${c.note})` : ''}`;
+}
+
 /** The floor verification block: pass/fail led by NET-NEW attribution, with
  *  pre-existing debt and unattributed checks disclosed, never weaponized. */
 export function renderFloorVerification(
@@ -24,7 +31,7 @@ export function renderFloorVerification(
   // "passed" over a red entry floor. Pre-existing debt is disclosed as
   // exactly that — it belongs to the repo, not to this run.
   if (!attribution) {
-    const checks = floor.checks.map((c) => `- ${c.pack}/${c.label}: ${c.status}`).join('\n');
+    const checks = floor.checks.map(renderCheckLine).join('\n');
     return [
       `Correctness floor (entry snapshot — no change to attribute): ` +
         `**${floor.blocks ? 'red (pre-existing debt, not caused by this run)' : 'green'}**`,
@@ -36,7 +43,7 @@ export function renderFloorVerification(
   const netNew = attributed.filter((a) => a.attribution === 'net-new');
   const preExisting = attributed.filter((a) => a.attribution === 'pre-existing');
   const unattributed = attributed.filter((a) => a.attribution === 'unattributed');
-  const checks = floor.checks.map((c) => `- ${c.pack}/${c.label}: ${c.status}`).join('\n');
+  const checks = floor.checks.map(renderCheckLine).join('\n');
   const lines = [
     `Correctness floor (full scope, attributed vs ${entryLabel}): ` +
       `**${netNew.length > 0 ? 'FAILED — net-new failures' : 'passed'}**`,

--- a/src/lanes/verification-render.ts
+++ b/src/lanes/verification-render.ts
@@ -45,7 +45,10 @@ export function renderFloorVerification(
   const unattributed = attributed.filter((a) => a.attribution === 'unattributed');
   const checks = floor.checks.map(renderCheckLine).join('\n');
   const lines = [
-    `Correctness floor (full scope, attributed vs ${entryLabel}): ` +
+    // The ACTUAL scope the run executed at — the verification floor runs
+    // `affected` (escalating on manifests); hardcoding "full" here misstated
+    // what was verified. Older snapshots without the field were full-scope.
+    `Correctness floor (${floor.scope ?? 'full'} scope, attributed vs ${entryLabel}): ` +
       `**${netNew.length > 0 ? 'FAILED — net-new failures' : 'passed'}**`,
     checks,
     '',

--- a/src/lanes/verify-tree.ts
+++ b/src/lanes/verify-tree.ts
@@ -1,0 +1,261 @@
+/**
+ * The ONE tree verification the scheduled lanes share with CI (4.4.5, Rule
+ * 2.30: one concept, one code path).
+ *
+ * The class this module closes: the remediate lane verified the agent's
+ * DIRTY workspace, with whatever `node_modules` the agent last installed,
+ * at full scope with an empty changed-set. CI verifies a different tree: a
+ * clean checkout, a fresh frozen-lockfile install, then the gate. A draft
+ * whose package.json had moved ahead of its lockfile was pushed as
+ * "verified"; CI's `npm ci` died with EUSAGE before any gate ran and the PR
+ * read "NOT gated". Two verifications of one concept, drifted.
+ *
+ * `verifyTree` verifies a candidate head the way CI does, in order:
+ *
+ *   1. a CLEAN worktree of that head (Rule 11's `withRefWorktree`, never a
+ *      second `git worktree add`);
+ *   2. the repo's frozen install with the repo's own fallback
+ *      (`frozenInstallFor`, the same table the CI templates render from);
+ *   3. the correctness floor DIFF-SCOPED against `baseHead` (`changedFiles`
+ *      from the one changed-files primitive; the runner escalates to full on
+ *      a manifest change and runs the lockfile-sync check there);
+ *   4. attribution vs the entry floor through the ONE comparator;
+ *   5. the guardrail.
+ *
+ * Fail-open discipline, the `GateFailure` shape: every infrastructure
+ * failure (a ref that cannot be checked out, a package manager not on PATH,
+ * a throw anywhere) is a DISCLOSED step failure with the step named, never a
+ * silent pass and never a false block. An install that RAN and failed is not
+ * infrastructure: it is the exact defect this module exists to catch, so it
+ * is its own verdict (`install-failed`). The consumer decides what an
+ * unverifiable tree means for landing (the agent lane: nothing lands).
+ *
+ * Every step is injectable (`seams`) so the composition is unit-testable
+ * without a git repo, a package manager, or a scanner toolchain.
+ */
+import type { AnalysisTrustContext } from '../analysis-trust';
+import { runCorrectnessFloor, type CorrectnessFloorResult } from '../analyzers/correctness/run';
+import { makeCommandExec, tail, type CommandExec } from '../analyzers/tools/bounded-exec';
+import {
+  attributeFloorFailures,
+  type AttributedFloorFailure,
+  type FloorBaseCheck,
+} from '../analyzers/correctness/attribution';
+import { computeChangedFiles } from '../baseline/changed-files';
+import { captureGateFailure, type GateFailure } from '../baseline/gate-failopen';
+import { withRefWorktree, type RefWorktreeOptions } from '../baseline/ref-baseline';
+import { detectActiveLanguages } from '../languages';
+import { frozenInstallFor } from '../package-manager';
+import { guardrailVerdictFor, toFloorBaseChecks, type GuardrailGateResult } from './verify';
+
+/** How the frozen install of the candidate tree went. */
+export type InstallOutcome =
+  | {
+      readonly status: 'installed';
+      readonly argv: readonly string[];
+      /** Present when the primary failed and the fallback (the one CI mirrors)
+       *  succeeded, with the reason the fallback exists. Disclosed. */
+      readonly fallback?: { readonly argv: readonly string[]; readonly reason: string };
+    }
+  | { readonly status: 'failed'; readonly argv: readonly string[]; readonly output: string }
+  /** The repo has no package.json: nothing to install, nothing claimed. */
+  | { readonly status: 'nothing-to-install' };
+
+export type VerifyTreeVerdict =
+  /** Clean worktree installs, the floor has no net-new failure, the guardrail passes. */
+  | 'verified'
+  /** The frozen install of the candidate tree FAILED: CI could not install
+   *  this tree, so no gate would ever run on it. */
+  | 'install-failed'
+  /** The floor has a NET-NEW failure vs the entry floor. */
+  | 'floor-red'
+  /** The guardrail ran and did not pass (BLOCKED or the CANNOT-GATE tier). */
+  | 'guardrail-red'
+  /** Verification itself could not run: `failure` names the step. */
+  | 'error';
+
+export interface VerifyTreeResult {
+  readonly verdict: VerifyTreeVerdict;
+  readonly install?: InstallOutcome;
+  /** Repo-relative files the candidate changed vs `baseHead` (empty when the
+   *  diff was undeterminable, which the floor treats as full scope). */
+  readonly changedFiles?: readonly string[];
+  readonly floor?: CorrectnessFloorResult;
+  readonly floorAttribution?: readonly AttributedFloorFailure[];
+  readonly guardrail?: GuardrailGateResult;
+  /** Present on `error`: the step that failed and why. */
+  readonly failure?: GateFailure;
+}
+
+/** Injection points, one per step, so the composition is testable without a
+ *  repo. Production callers omit them all. */
+export interface VerifyTreeSeams {
+  readonly worktree?: <T>(
+    opts: RefWorktreeOptions,
+    fn: (worktreePath: string) => Promise<T>,
+  ) => Promise<T>;
+  readonly install?: (worktreePath: string) => InstallOutcome;
+  readonly changedFiles?: (worktreePath: string, baseHead: string) => readonly string[] | null;
+  readonly runFloor?: (args: {
+    readonly cwd: string;
+    readonly changedFiles: readonly string[];
+  }) => CorrectnessFloorResult;
+  readonly runGuardrail?: (worktreePath: string) => Promise<GuardrailGateResult>;
+}
+
+export interface VerifyTreeOptions {
+  /** The repo whose object database holds `head` (the lane's checkout). */
+  readonly cwd: string;
+  /** The candidate commit to verify. */
+  readonly head: string;
+  /** The commit the candidate is diffed against for floor scope. */
+  readonly baseHead: string;
+  readonly trust: AnalysisTrustContext;
+  /** The entry floor (captured on the pristine base) the candidate's floor is
+   *  attributed against. Absent = every failure is unattributed (disclosed,
+   *  never blocked). */
+  readonly entryFloor?: CorrectnessFloorResult;
+  /** What an ABSENT base check means for attribution (see
+   *  `attributeFloorFailures`); the remediate lane, whose entry floor always
+   *  ran, passes `'net-new'`. */
+  readonly absentMeans: 'net-new' | 'unattributed';
+  /** Per-command budget for the install + floor commands (ms). */
+  readonly timeoutMs?: number;
+  /** Progress hook, called as each step begins (the lane's heartbeat). */
+  readonly onStep?: (step: VerifyTreeStep) => void;
+  readonly seams?: VerifyTreeSeams;
+}
+
+/** The steps, in order; also the `GateFailure.step` vocabulary. */
+export type VerifyTreeStep =
+  | 'worktree'
+  | 'install'
+  | 'changed-files'
+  | 'floor'
+  | 'attribution'
+  | 'guardrail';
+
+/**
+ * Run the repo's frozen install in a worktree: the primary, then the declared
+ * fallback when the primary fails (the CI template's `a || b`). A package
+ * manager that is not on PATH THROWS (infrastructure: the caller's catch
+ * turns it into a disclosed step failure, never an install verdict).
+ */
+export function runFrozenInstall(worktreePath: string, exec: CommandExec): InstallOutcome {
+  const plan = frozenInstallFor(worktreePath);
+  if (plan === null) return { status: 'nothing-to-install' };
+  const [bin, ...args] = plan.argv;
+  const primary = exec({ bin, args }, worktreePath);
+  if (!primary.available) {
+    throw new Error(
+      `${plan.pm} is not available in the verification environment` +
+        (primary.output ? `: ${primary.output}` : ''),
+    );
+  }
+  if (primary.code === 0 && !primary.timedOut && !primary.overflowed) {
+    return { status: 'installed', argv: plan.argv };
+  }
+  if (plan.fallback) {
+    const [fbin, ...fargs] = plan.fallback.argv;
+    const fallback = exec({ bin: fbin, args: fargs }, worktreePath);
+    if (fallback.available && fallback.code === 0 && !fallback.timedOut && !fallback.overflowed) {
+      return { status: 'installed', argv: plan.argv, fallback: plan.fallback };
+    }
+    return {
+      status: 'failed',
+      argv: plan.fallback.argv,
+      output: tail(
+        `${primary.output}\n--- fallback (${plan.fallback.argv.join(' ')}) ---\n${fallback.output}`,
+      ),
+    };
+  }
+  return {
+    status: 'failed',
+    argv: plan.argv,
+    output: tail(primary.timedOut ? `${primary.output}\n(timed out)` : primary.output),
+  };
+}
+
+/** Verify a candidate head the way CI would. Never throws. */
+export async function verifyTree(opts: VerifyTreeOptions): Promise<VerifyTreeResult> {
+  const seams = opts.seams ?? {};
+  const exec = makeCommandExec(opts.timeoutMs);
+  const worktree = seams.worktree ?? withRefWorktree;
+  const install = seams.install ?? ((wt: string) => runFrozenInstall(wt, exec));
+  const changed = seams.changedFiles ?? computeChangedFiles;
+  const runFloor =
+    seams.runFloor ??
+    ((args: { cwd: string; changedFiles: readonly string[] }) =>
+      runCorrectnessFloor({
+        cwd: args.cwd,
+        changedFiles: args.changedFiles,
+        scope: 'affected',
+        packs: detectActiveLanguages(args.cwd),
+        ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+      }));
+  const runGuardrail = seams.runGuardrail ?? ((wt: string) => guardrailVerdictFor(wt, opts.trust));
+  const baseChecks: FloorBaseCheck[] = opts.entryFloor ? toFloorBaseChecks(opts.entryFloor) : [];
+
+  // The step being executed, so a throw anywhere names WHERE it broke.
+  let step: VerifyTreeStep = 'worktree';
+  const enter = (s: VerifyTreeStep): void => {
+    step = s;
+    opts.onStep?.(s);
+  };
+  try {
+    enter('worktree');
+    return await worktree({ cwd: opts.cwd, ref: opts.head }, async (wt) => {
+      enter('install');
+      const installed = install(wt);
+      if (installed.status === 'failed') return { verdict: 'install-failed', install: installed };
+
+      enter('changed-files');
+      const changedFiles = changed(wt, opts.baseHead) ?? [];
+
+      enter('floor');
+      const floor = runFloor({ cwd: wt, changedFiles });
+      enter('attribution');
+      const floorAttribution = attributeFloorFailures(floor, baseChecks, {
+        absentMeans: opts.absentMeans,
+      });
+      const partial = { install: installed, changedFiles, floor, floorAttribution };
+      if (floorAttribution.some((a) => a.attribution === 'net-new')) {
+        return { verdict: 'floor-red', ...partial };
+      }
+
+      enter('guardrail');
+      const guardrail = await runGuardrail(wt);
+      if (!guardrail.ran) {
+        return {
+          verdict: 'error',
+          ...partial,
+          guardrail,
+          failure: { step, message: guardrail.verdict },
+        };
+      }
+      return {
+        verdict: guardrail.passesGate ? 'verified' : 'guardrail-red',
+        ...partial,
+        guardrail,
+      };
+    });
+  } catch (err) {
+    return { verdict: 'error', failure: captureGateFailure(step, err) };
+  }
+}
+
+/** One-line disclosure of the install step for a ledger. */
+export function describeInstall(install: InstallOutcome | undefined): string | null {
+  if (!install) return null;
+  switch (install.status) {
+    case 'nothing-to-install':
+      return 'Install: nothing to install (no package.json).';
+    case 'installed':
+      return install.fallback
+        ? `Install: \`${install.argv.join(' ')}\` failed, \`${install.fallback.argv.join(' ')}\` ` +
+            `succeeded (${install.fallback.reason}).`
+        : `Install: \`${install.argv.join(' ')}\` succeeded on a clean checkout.`;
+    case 'failed':
+      return `Install: \`${install.argv.join(' ')}\` FAILED on a clean checkout (CI cannot install this tree).`;
+  }
+}

--- a/src/lanes/verify-tree.ts
+++ b/src/lanes/verify-tree.ts
@@ -14,21 +14,33 @@
  *
  *   1. a CLEAN worktree of that head (Rule 11's `withRefWorktree`, never a
  *      second `git worktree add`);
- *   2. the repo's frozen install with the repo's own fallback
- *      (`frozenInstallFor`, the same table the CI templates render from);
- *   3. the correctness floor DIFF-SCOPED against `baseHead` (`changedFiles`
- *      from the one changed-files primitive; the runner escalates to full on
- *      a manifest change and runs the lockfile-sync check there);
- *   4. attribution vs the entry floor through the ONE comparator;
- *   5. the guardrail.
+ *   2. the diff vs `baseHead` — computed BEFORE the install, so install
+ *      artifacts (a rewritten lockfile, an unignored node_modules) can never
+ *      read as the agent's changed files;
+ *   3. the repo's frozen install with the repo's own fallback
+ *      (`frozenInstallFor`, the same table the CI templates render from).
+ *      A failed install is ATTRIBUTED like a floor failure: the same install
+ *      is probed at `baseHead`, and a failure that predates the change is
+ *      PRE-EXISTING — disclosed, never blamed on the candidate;
+ *   4. the correctness floor DIFF-SCOPED (the runner escalates to full on a
+ *      manifest change and runs the lockfile-sync check there);
+ *   5. attribution vs the entry floor through the ONE comparator;
+ *   6. the guardrail.
+ *
+ * SECURITY (Rule 17): the install runs the repo's lifecycle scripts and the
+ * floor runs repo-declared commands, so the seam gates on the REQUIRED trust
+ * context itself — an untrusted tree yields a disclosed `skipped-untrusted`
+ * verdict before anything spawns, by design rather than caller convention.
  *
  * Fail-open discipline, the `GateFailure` shape: every infrastructure
  * failure (a ref that cannot be checked out, a package manager not on PATH,
- * a throw anywhere) is a DISCLOSED step failure with the step named, never a
- * silent pass and never a false block. An install that RAN and failed is not
- * infrastructure: it is the exact defect this module exists to catch, so it
- * is its own verdict (`install-failed`). The consumer decides what an
- * unverifiable tree means for landing (the agent lane: nothing lands).
+ * an install that timed out or overflowed the capture buffer, a throw
+ * anywhere) is a DISCLOSED step failure with the step named, never a silent
+ * pass and never a false block. An install that RAN TO COMPLETION and failed
+ * is not infrastructure: it is the exact defect this module exists to catch,
+ * so it is its own verdict (`install-failed`) — once the base probe rules
+ * out a pre-existing break. The consumer decides what an unverifiable tree
+ * means for landing (the agent lane: nothing lands).
  *
  * Every step is injectable (`seams`) so the composition is unit-testable
  * without a git repo, a package manager, or a scanner toolchain.
@@ -57,20 +69,32 @@ export type InstallOutcome =
        *  succeeded, with the reason the fallback exists. Disclosed. */
       readonly fallback?: { readonly argv: readonly string[]; readonly reason: string };
     }
-  | { readonly status: 'failed'; readonly argv: readonly string[]; readonly output: string }
+  | {
+      readonly status: 'failed';
+      readonly argv: readonly string[];
+      readonly output: string;
+      /** True when the SAME frozen install also fails at `baseHead`: the
+       *  break predates the candidate. Disclosed, never blamed on the change
+       *  — verification proceeds (the floor's pre-existing doctrine applied
+       *  to the install). */
+      readonly preExisting?: boolean;
+    }
   /** The repo has no package.json: nothing to install, nothing claimed. */
   | { readonly status: 'nothing-to-install' };
 
 export type VerifyTreeVerdict =
   /** Clean worktree installs, the floor has no net-new failure, the guardrail passes. */
   | 'verified'
-  /** The frozen install of the candidate tree FAILED: CI could not install
-   *  this tree, so no gate would ever run on it. */
+  /** The frozen install of the candidate tree FAILED where the base's did
+   *  not: CI could not install this tree, and the change is the cause. */
   | 'install-failed'
   /** The floor has a NET-NEW failure vs the entry floor. */
   | 'floor-red'
   /** The guardrail ran and did not pass (BLOCKED or the CANNOT-GATE tier). */
   | 'guardrail-red'
+  /** The trust context does not allow repo execution here: nothing spawned,
+   *  nothing verified. `failure` carries the disclosure (step `trust`). */
+  | 'skipped-untrusted'
   /** Verification itself could not run: `failure` names the step. */
   | 'error';
 
@@ -83,7 +107,8 @@ export interface VerifyTreeResult {
   readonly floor?: CorrectnessFloorResult;
   readonly floorAttribution?: readonly AttributedFloorFailure[];
   readonly guardrail?: GuardrailGateResult;
-  /** Present on `error`: the step that failed and why. */
+  /** Present on `error` (the step that failed and why) and on
+   *  `skipped-untrusted` (the trust disclosure, step `trust`). */
   readonly failure?: GateFailure;
 }
 
@@ -126,20 +151,33 @@ export interface VerifyTreeOptions {
   readonly seams?: VerifyTreeSeams;
 }
 
-/** The steps, in order; also the `GateFailure.step` vocabulary. */
+/** The steps, in order; also the `GateFailure.step` vocabulary (plus `trust`,
+ *  the pre-spawn refusal that precedes them all). `base-install` runs only
+ *  when the candidate install failed — the attribution probe. */
 export type VerifyTreeStep =
   | 'worktree'
-  | 'install'
   | 'changed-files'
+  | 'install'
+  | 'base-install'
   | 'floor'
   | 'attribution'
   | 'guardrail';
 
+/** Phrase an infrastructure-shaped exec end (timeout / capture overflow), or
+ *  null when the command ran to completion. */
+function infraEnd(timedOut?: boolean, overflowed?: boolean): string | null {
+  if (timedOut) return 'timed out';
+  if (overflowed) return 'overflowed the capture buffer';
+  return null;
+}
+
 /**
  * Run the repo's frozen install in a worktree: the primary, then the declared
- * fallback when the primary fails (the CI template's `a || b`). A package
- * manager that is not on PATH THROWS (infrastructure: the caller's catch
- * turns it into a disclosed step failure, never an install verdict).
+ * fallback when the primary fails (the CI template's `a || b`). Infrastructure
+ * THROWS — a package manager missing from PATH, a timeout, a capture overflow
+ * (on the primary or the fallback alike) say nothing about the tree, so the
+ * caller's catch turns them into a disclosed step failure, never an install
+ * verdict (the bounded-exec fail-open doctrine).
  */
 export function runFrozenInstall(worktreePath: string, exec: CommandExec): InstallOutcome {
   const plan = frozenInstallFor(worktreePath);
@@ -152,13 +190,30 @@ export function runFrozenInstall(worktreePath: string, exec: CommandExec): Insta
         (primary.output ? `: ${primary.output}` : ''),
     );
   }
-  if (primary.code === 0 && !primary.timedOut && !primary.overflowed) {
-    return { status: 'installed', argv: plan.argv };
+  const primaryInfra = infraEnd(primary.timedOut, primary.overflowed);
+  if (primaryInfra !== null) {
+    throw new Error(
+      `frozen install (\`${plan.argv.join(' ')}\`) ${primaryInfra} — infrastructure, not a verdict on the tree`,
+    );
   }
+  if (primary.code === 0) return { status: 'installed', argv: plan.argv };
   if (plan.fallback) {
     const [fbin, ...fargs] = plan.fallback.argv;
     const fallback = exec({ bin: fbin, args: fargs }, worktreePath);
-    if (fallback.available && fallback.code === 0 && !fallback.timedOut && !fallback.overflowed) {
+    if (!fallback.available) {
+      throw new Error(
+        `${plan.pm} is not available in the verification environment` +
+          (fallback.output ? `: ${fallback.output}` : ''),
+      );
+    }
+    const fallbackInfra = infraEnd(fallback.timedOut, fallback.overflowed);
+    if (fallbackInfra !== null) {
+      throw new Error(
+        `frozen install fallback (\`${plan.fallback.argv.join(' ')}\`) ${fallbackInfra} — ` +
+          'infrastructure, not a verdict on the tree',
+      );
+    }
+    if (fallback.code === 0) {
       return { status: 'installed', argv: plan.argv, fallback: plan.fallback };
     }
     return {
@@ -169,15 +224,26 @@ export function runFrozenInstall(worktreePath: string, exec: CommandExec): Insta
       ),
     };
   }
-  return {
-    status: 'failed',
-    argv: plan.argv,
-    output: tail(primary.timedOut ? `${primary.output}\n(timed out)` : primary.output),
-  };
+  return { status: 'failed', argv: plan.argv, output: tail(primary.output) };
 }
 
 /** Verify a candidate head the way CI would. Never throws. */
 export async function verifyTree(opts: VerifyTreeOptions): Promise<VerifyTreeResult> {
+  // Rule 17, decided by the seam itself: the install runs lifecycle scripts
+  // and the floor runs repo-declared commands, so an untrusted tree gets a
+  // disclosed refusal BEFORE any worktree exists or any command spawns.
+  if (!opts.trust.repoExecutionAllowed) {
+    return {
+      verdict: 'skipped-untrusted',
+      failure: {
+        step: 'trust',
+        message:
+          `repo execution is not allowed under this trust context (${opts.trust.source}) — ` +
+          'the frozen install and the correctness floor execute repo-declared commands, so ' +
+          'an untrusted tree is never verified here',
+      },
+    };
+  }
   const seams = opts.seams ?? {};
   const exec = makeCommandExec(opts.timeoutMs);
   const worktree = seams.worktree ?? withRefWorktree;
@@ -205,12 +271,30 @@ export async function verifyTree(opts: VerifyTreeOptions): Promise<VerifyTreeRes
   try {
     enter('worktree');
     return await worktree({ cwd: opts.cwd, ref: opts.head }, async (wt) => {
-      enter('install');
-      const installed = install(wt);
-      if (installed.status === 'failed') return { verdict: 'install-failed', install: installed };
-
+      // The diff FIRST, on the pristine checkout: an install can rewrite the
+      // lockfile or drop node_modules into an unignored tree, and those
+      // artifacts must never read as the agent's changed files (they would
+      // force a manifest escalation and misattribute the diff).
       enter('changed-files');
       const changedFiles = changed(wt, opts.baseHead) ?? [];
+
+      enter('install');
+      let installed = install(wt);
+      if (installed.status === 'failed') {
+        // Attribute before blaming (the floor's doctrine applied to the
+        // install): probe the SAME frozen install at baseHead. A lockfile
+        // already drifted at the base fails there too — pre-existing debt,
+        // disclosed, never pinned on the candidate; verification proceeds.
+        enter('base-install');
+        const baseOutcome = await worktree({ cwd: opts.cwd, ref: opts.baseHead }, async (bwt) =>
+          install(bwt),
+        );
+        if (baseOutcome.status === 'failed') {
+          installed = { ...installed, preExisting: true };
+        } else {
+          return { verdict: 'install-failed', install: installed, changedFiles };
+        }
+      }
 
       enter('floor');
       const floor = runFloor({ cwd: wt, changedFiles });
@@ -256,6 +340,10 @@ export function describeInstall(install: InstallOutcome | undefined): string | n
             `succeeded (${install.fallback.reason}).`
         : `Install: \`${install.argv.join(' ')}\` succeeded on a clean checkout.`;
     case 'failed':
-      return `Install: \`${install.argv.join(' ')}\` FAILED on a clean checkout (CI cannot install this tree).`;
+      return install.preExisting
+        ? `Install: \`${install.argv.join(' ')}\` fails on a clean checkout of the BASE too — ` +
+            'pre-existing (not caused by this change), disclosed. CI installs will keep failing ' +
+            'until the lockfile is repaired on the default branch.'
+        : `Install: \`${install.argv.join(' ')}\` FAILED on a clean checkout (CI cannot install this tree).`;
   }
 }

--- a/src/languages/capabilities/correctness.ts
+++ b/src/languages/capabilities/correctness.ts
@@ -176,6 +176,30 @@ export type StructureCheckResult =
   | { readonly kind: 'skipped'; readonly label: string; readonly reason: string }
   | { readonly kind: 'none' };
 
+/** The one label the lockfile-sync check reports under, shared by the pack
+ *  that builds it, the runner that executes it, and every renderer. */
+export const LOCKFILE_SYNC_LABEL = 'lockfile-sync';
+
+/**
+ * A pack's answer to "would a frozen-lockfile install of this tree succeed?"
+ * (4.4.5): a non-installing dry-run command, or a DISCLOSED skip for an
+ * ecosystem whose package manager has no reliable dry-run. The command may
+ * name a `tolerated` failure: an exit the check passes WITH a disclosure
+ * because the frozen install's own fallback covers it (npm's peer conflict,
+ * which CI retries under `--legacy-peer-deps`). A tolerated failure is never
+ * silent: the runner attaches the disclosure to the passing check.
+ */
+export type LockfileCheck =
+  | {
+      readonly kind: 'command';
+      readonly command: CorrectnessCommand;
+      readonly tolerated?: {
+        readonly matches: (output: string) => boolean;
+        readonly disclosure: string;
+      };
+    }
+  | { readonly kind: 'skipped'; readonly reason: string };
+
 import type { ExecutionRequirement } from '../../execution';
 
 /**
@@ -239,6 +263,20 @@ export interface CorrectnessProvider {
    * verification, not syntax).
    */
   structureCheck?(ctx: CorrectnessContext): StructureCheckResult;
+  /**
+   * OPTIONAL: the lockfile-sync check (4.4.5), the floor item between
+   * "resolves against the installed tree" and "CI can install this tree at
+   * all". A manifest whose specs moved ahead of its lockfile passes every
+   * other check on the workspace that produced it (its node_modules were
+   * installed by the same edit) and then fails CI's frozen install before any
+   * gate runs. Pure command builder, like the other two: the pack returns the
+   * ecosystem's non-installing dry-run (from `src/package-manager.ts`, the one
+   * home of per-PM install commands), `null` when the repo has no lockfile to
+   * check, or a disclosed skip for a PM without a reliable dry-run. The
+   * runner decides WHEN it runs (full scope, or a diff touching the pack's
+   * manifest patterns), never the pack.
+   */
+  lockfileCheck?(ctx: CorrectnessContext): LockfileCheck | null;
   /**
    * What the floor NEEDS from the environment that runs it (CLAUDE.md Rule 20):
    * host OS, ambient toolchains, whether it builds the project, how its target

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -19,7 +19,7 @@ import {
   gatherOsvScannerDepVulnsResult,
   mergeMaliciousOsvFindings,
 } from '../analyzers/tools/osv-scanner-deps';
-import { detectLockfile } from '../package-manager';
+import { detectLockfile, lockfileSyncCheck } from '../package-manager';
 import { fileExists, run, runJSON } from '../analyzers/tools/runner';
 import { walkPaths } from '../analyzers/tools/walk-paths';
 import { installedNodeMajor, readRepoFile, repoFileExists } from './version-detect';
@@ -34,11 +34,13 @@ import type {
   LintProvider,
   RunTestsOutcome,
 } from './capabilities/provider';
-import type {
-  CorrectnessCommand,
-  CorrectnessContext,
-  CorrectnessProvider,
-  ResolutionCheckResult,
+import {
+  LOCKFILE_SYNC_LABEL,
+  type CorrectnessCommand,
+  type CorrectnessContext,
+  type CorrectnessProvider,
+  type LockfileCheck,
+  type ResolutionCheckResult,
 } from './capabilities/correctness';
 import type { ExecutionRequirement } from '../execution';
 import { projectPathIdentity } from './capabilities/correctness';
@@ -2205,6 +2207,24 @@ const tsCorrectnessProvider: CorrectnessProvider = {
 
   resolutionCheck: tsResolutionCheck,
   relativeImportIdentities: tsRelativeImportIdentities,
+
+  // The lockfile-sync check (4.4.5): would CI's frozen install of this tree
+  // succeed? The command per PM lives in `package-manager.ts` (the one home of
+  // install commands); this builder only picks the lockfile actually present.
+  // No lockfile → nothing to keep in sync → null. A PM with no reliable
+  // dry-run (yarn) is a disclosed skip, never a silent one.
+  lockfileCheck(ctx: CorrectnessContext): LockfileCheck | null {
+    const lock = detectLockfile(ctx.cwd);
+    if (lock === null) return null;
+    const check = lockfileSyncCheck(lock.pm);
+    if (check.kind === 'skipped') return check;
+    const [bin, ...args] = check.argv;
+    return {
+      kind: 'command',
+      command: { label: LOCKFILE_SYNC_LABEL, bin, args },
+      ...(check.tolerated ? { tolerated: check.tolerated } : {}),
+    };
+  },
 
   syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
     // Prefer the project's own typecheck script — it carries their exact

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -177,3 +177,203 @@ export function provisionCommand(pm: PackageManager): string {
       return 'npm ci';
   }
 }
+
+// ---------------------------------------------------------------------------
+// Frozen-lockfile install + lockfile-sync check: the ONE definition CI and the
+// lane's verification share (4.4.5). Before this, every workflow template
+// carried a hand-copied `if [ -f pnpm-lock.yaml ] ... npm ci || npm ci
+// --legacy-peer-deps` block, and the remediate lane verified the agent's
+// dirty workspace with whatever node_modules it last installed. A draft whose
+// package.json had moved ahead of its lockfile was pushed as "verified"; CI's
+// `npm ci` then died with EUSAGE before the gate ran. The table below is what
+// both sides now render from, so the lane cannot certify a tree CI cannot
+// install.
+// ---------------------------------------------------------------------------
+
+/** One branch of the install decision, in PM-priority order (the same order
+ *  `detectLockfile` uses). `argv` is the frozen install; `fallback` is retried
+ *  when it fails, for the one condition named in `fallbackReason`. */
+interface InstallBranch {
+  readonly pm: PackageManager | 'none';
+  /** Files whose presence selects this branch (any-of); `package.json` for
+   *  the no-lockfile branch, empty for the final else. */
+  readonly when: readonly string[];
+  /** Shell-only bootstrap lines rendered before the install (CI provisions
+   *  bun on demand; locally the binary must already be on PATH). */
+  readonly shellSetup?: readonly string[];
+  readonly argv: readonly string[];
+  /** Silence the primary's stderr in the shell rendering (yarn classic rejects
+   *  `--immutable` with a noisy error before the fallback runs). */
+  readonly quietPrimary?: boolean;
+  readonly fallback?: readonly string[];
+  readonly fallbackReason?: string;
+}
+
+const LEGACY_PEER_DEPS_REASON =
+  'the tree only resolves under --legacy-peer-deps (a peer conflict the repo already ' +
+  'tolerates); the flag skips the peer check, it never fabricates a different tree';
+
+const INSTALL_BRANCHES: readonly InstallBranch[] = [
+  { pm: 'pnpm', when: ['pnpm-lock.yaml'], argv: ['pnpm', 'install', '--frozen-lockfile'] },
+  {
+    pm: 'yarn',
+    when: ['yarn.lock'],
+    argv: ['yarn', 'install', '--immutable'],
+    quietPrimary: true,
+    fallback: ['yarn', 'install', '--frozen-lockfile'],
+    fallbackReason: 'yarn classic (v1) spells the immutable install --frozen-lockfile',
+  },
+  {
+    pm: 'bun',
+    when: ['bun.lockb', 'bun.lock'],
+    shellSetup: ['npm install -g bun >/dev/null 2>&1 || true'],
+    argv: ['bun', 'install', '--frozen-lockfile'],
+  },
+  {
+    pm: 'npm',
+    when: ['package-lock.json'],
+    argv: ['npm', 'ci'],
+    fallback: ['npm', 'ci', '--legacy-peer-deps'],
+    fallbackReason: LEGACY_PEER_DEPS_REASON,
+  },
+  {
+    pm: 'npm',
+    when: ['package.json'],
+    argv: ['npm', 'install'],
+    fallback: ['npm', 'install', '--legacy-peer-deps'],
+    fallbackReason: LEGACY_PEER_DEPS_REASON,
+  },
+  // No package.json at all: CI still needs the dxkit CLI on PATH.
+  { pm: 'none', when: [], argv: ['npm', 'install', '-g', '@vyuhlabs/dxkit'] },
+];
+
+/** The frozen (lockfile-exact) install for a repo, with the fallback CI
+ *  mirrors. */
+export interface FrozenInstall {
+  readonly pm: PackageManager;
+  readonly argv: readonly string[];
+  readonly fallback?: { readonly argv: readonly string[]; readonly reason: string };
+}
+
+/**
+ * The frozen install a verification of THIS repo must run: exactly what the
+ * rendered CI step picks on the same tree. Reads the same file presence the
+ * shell `if` chain tests, in the same order. `null` when the repo has no
+ * package.json (nothing to install).
+ */
+export function frozenInstallFor(cwd: string): FrozenInstall | null {
+  for (const b of INSTALL_BRANCHES) {
+    if (b.pm === 'none') return null;
+    if (!b.when.some((f) => existsSync(join(cwd, f)))) continue;
+    return {
+      pm: b.pm,
+      argv: b.argv,
+      ...(b.fallback ? { fallback: { argv: b.fallback, reason: b.fallbackReason ?? '' } } : {}),
+    };
+  }
+  return null;
+}
+
+/** The whole-line placeholder a workflow template carries where its
+ *  dependency install goes; the ONE workflow writer substitutes it with
+ *  `renderInstallDependenciesShell`. */
+export const INSTALL_DEPS_PLACEHOLDER = '__DXKIT_INSTALL_DEPS__';
+
+/**
+ * The shell block that installs a repo's dependencies the frozen way, rendered
+ * from `INSTALL_BRANCHES` at the given indent (a workflow `run: |` body).
+ * corepack provides pnpm/yarn with no extra action, honoring the repo's
+ * `packageManager` field; the chain picks the lockfile-appropriate installer
+ * so the audited tree is the tree the repo ships, never a fabricated npm
+ * resolution of a pnpm workspace.
+ */
+export function renderInstallDependenciesShell(indent: string): string {
+  const lines: string[] = ['corepack enable >/dev/null 2>&1 || true'];
+  INSTALL_BRANCHES.forEach((b, i) => {
+    const cond = b.when.map((f) => `[ -f ${f} ]`).join(' || ');
+    lines.push(cond ? `${i === 0 ? 'if' : 'elif'} ${cond}; then` : 'else');
+    for (const s of b.shellSetup ?? []) lines.push(`  ${s}`);
+    const primary = b.argv.join(' ') + (b.quietPrimary ? ' 2>/dev/null' : '');
+    lines.push(`  ${primary}${b.fallback ? ` || ${b.fallback.join(' ')}` : ''}`);
+  });
+  lines.push('fi');
+  return lines.map((l) => indent + l).join('\n');
+}
+
+/**
+ * Is a failed npm install/ci output a PEER-CONFLICT-ONLY failure, the one
+ * condition `--legacy-peer-deps` legitimately answers? An out-of-sync lockfile
+ * (EUSAGE, "not in sync", "Missing:") is NOT: the flag would not help and the
+ * failure is real. Consulted by every consumer of the legacy-peer-deps
+ * doctrine (the CI install fallback, the dep-bump lane, the lockfile-sync
+ * floor check) so the two failure classes are told apart in one place.
+ */
+export function isPeerConflictOnly(output: string): boolean {
+  if (/EUSAGE|not in sync|Missing: .* from lock file|does not satisfy/.test(output)) return false;
+  return /ERESOLVE|peer dep/i.test(output);
+}
+
+/** A non-installing "is the lockfile in sync with the manifest?" check. */
+export type LockfileSyncCheck =
+  | {
+      readonly kind: 'command';
+      readonly argv: readonly string[];
+      /** A failure this check TOLERATES as pass-with-disclosure, because the
+       *  frozen install's fallback covers it (npm's peer conflict). */
+      readonly tolerated?: {
+        readonly matches: (output: string) => boolean;
+        readonly disclosure: string;
+      };
+    }
+  | { readonly kind: 'skipped'; readonly reason: string };
+
+/**
+ * The dry-run frozen install per PM: fails when the lockfile does not satisfy
+ * the manifest, touches nothing on disk, runs no lifecycle scripts.
+ *
+ *   - npm: `npm ci --dry-run` validates lockfile/manifest sync (EUSAGE) before
+ *     building the ideal tree, so an out-of-sync lockfile fails and a peer
+ *     conflict (ERESOLVE) surfaces the same way the real `npm ci` does. The
+ *     peer conflict is tolerated with a disclosure: CI's install retries with
+ *     `--legacy-peer-deps`. npm 7+ semantics (Node 18+, dxkit's floor, ships
+ *     npm 9).
+ *   - pnpm: `--frozen-lockfile --lockfile-only` fails with
+ *     ERR_PNPM_OUTDATED_LOCKFILE on drift and never touches node_modules.
+ *   - bun: `--frozen-lockfile --dry-run` refuses a lockfile that would change.
+ *   - yarn: no non-installing frozen check holds across classic and berry
+ *     (classic's `--frozen-lockfile` installs for real; berry's
+ *     `--mode=update-lockfile` still fetches), so this is a DISCLOSED skip and
+ *     CI's immutable install stays the backstop.
+ */
+export function lockfileSyncCheck(pm: PackageManager): LockfileSyncCheck {
+  switch (pm) {
+    case 'npm':
+      return {
+        kind: 'command',
+        argv: ['npm', 'ci', '--dry-run', '--ignore-scripts', '--no-audit', '--no-fund'],
+        tolerated: {
+          matches: isPeerConflictOnly,
+          disclosure:
+            'peer conflict only (ERESOLVE): the lockfile is in sync, and the repo installs ' +
+            'under --legacy-peer-deps, which the CI install step mirrors',
+        },
+      };
+    case 'pnpm':
+      return {
+        kind: 'command',
+        argv: ['pnpm', 'install', '--frozen-lockfile', '--lockfile-only', '--ignore-scripts'],
+      };
+    case 'bun':
+      return {
+        kind: 'command',
+        argv: ['bun', 'install', '--frozen-lockfile', '--dry-run', '--ignore-scripts'],
+      };
+    case 'yarn':
+      return {
+        kind: 'skipped',
+        reason:
+          'yarn has no non-installing frozen-lockfile check that holds across classic and ' +
+          "berry; CI's `yarn install --immutable` is the backstop",
+      };
+  }
+}

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -52,7 +52,7 @@ export function detectPackageManager(cwd: string): PackageManager {
 /** The lockfile filename(s) each PM writes, most-specific first. One source of
  *  truth for "the file a lockfile-aware tool should be pointed at" (mirrors the
  *  detection order in `detectPackageManager`). */
-const LOCKFILES: Record<PackageManager, string[]> = {
+export const LOCKFILES: Readonly<Record<PackageManager, readonly string[]>> = {
   pnpm: ['pnpm-lock.yaml'],
   yarn: ['yarn.lock'],
   bun: ['bun.lock', 'bun.lockb'],
@@ -213,11 +213,18 @@ const LEGACY_PEER_DEPS_REASON =
   'the tree only resolves under --legacy-peer-deps (a peer conflict the repo already ' +
   'tolerates); the flag skips the peer check, it never fabricates a different tree';
 
+// Each lockfile-keyed branch reads its trigger set from LOCKFILES — the ONE
+// lockfile-set definition `detectLockfile` also reads — so the two
+// projections cannot disagree (the shipped shape: the npm branch keyed on
+// package-lock.json alone while detectLockfile also accepted
+// npm-shrinkwrap.json, so a shrinkwrap repo's floor dry-ran `npm ci` while
+// its CI ran a plain `npm install`). Pinned by the parity test in
+// test/package-manager-frozen-install.test.ts.
 const INSTALL_BRANCHES: readonly InstallBranch[] = [
-  { pm: 'pnpm', when: ['pnpm-lock.yaml'], argv: ['pnpm', 'install', '--frozen-lockfile'] },
+  { pm: 'pnpm', when: LOCKFILES.pnpm, argv: ['pnpm', 'install', '--frozen-lockfile'] },
   {
     pm: 'yarn',
-    when: ['yarn.lock'],
+    when: LOCKFILES.yarn,
     argv: ['yarn', 'install', '--immutable'],
     quietPrimary: true,
     fallback: ['yarn', 'install', '--frozen-lockfile'],
@@ -225,13 +232,13 @@ const INSTALL_BRANCHES: readonly InstallBranch[] = [
   },
   {
     pm: 'bun',
-    when: ['bun.lockb', 'bun.lock'],
+    when: LOCKFILES.bun,
     shellSetup: ['npm install -g bun >/dev/null 2>&1 || true'],
     argv: ['bun', 'install', '--frozen-lockfile'],
   },
   {
     pm: 'npm',
-    when: ['package-lock.json'],
+    when: LOCKFILES.npm,
     argv: ['npm', 'ci'],
     fallback: ['npm', 'ci', '--legacy-peer-deps'],
     fallbackReason: LEGACY_PEER_DEPS_REASON,

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -5,6 +5,7 @@
  * type dependency is type-only, so there is no runtime cycle.
  */
 import { renderFloorVerification, renderGuardrailVerdict } from '../lanes/verification-render';
+import { describeInstall } from '../lanes/verify-tree';
 import { renderScoreHinge } from './score-hinge';
 import type { RemediateResult } from './run';
 
@@ -115,6 +116,10 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
   }
 
   lines.push('### Verification', '');
+  // The install line comes first: it is what CI's own install step will do
+  // with this tree, verified on a clean checkout (4.4.5).
+  const install = describeInstall(r.install);
+  if (install) lines.push(install, '');
   lines.push(...renderFloorVerification(r.floor, r.floorAttribution, 'the pre-agent entry run'));
   lines.push(...renderGuardrailVerdict(r.guardrailVerdict));
   if (r.scoreHinge) lines.push(renderScoreHinge(r.scoreHinge));

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -8,6 +8,7 @@ import type { AnalysisTrustContext } from '../analysis-trust';
 import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
 import type { AttributedFloorFailure } from '../analyzers/correctness/attribution';
 import type { GuardrailGateResult } from '../lanes/verify';
+import type { InstallOutcome, VerifyTreeSeams } from '../lanes/verify-tree';
 import type { AgentDriver } from './driver';
 import type { RemediateTask } from './tasks';
 import type { DispatchOverrides } from './dispatch';
@@ -18,6 +19,7 @@ import type { InLoopGateStatus } from './agent-trust';
 export type RemediateOutcome =
   | 'verified' // diff produced, floor net-new-clean, guardrail PASSED — ready to land
   | 'no-op' // agent ran TO COMPLETION, no diff (nothing to fix)
+  | 'install-failed' // a clean checkout of the diff cannot be installed the way CI installs — never lands
   | 'floor-red' // diff breaks the net-new floor — never lands
   | 'guardrail-red' // guardrail blocked, refused, or could not run — never lands
   | 'score-red' // the task's score hinge did not hold (goal not met) — never lands
@@ -80,6 +82,11 @@ export interface RemediateResult {
   readonly partial?: boolean;
   readonly floor?: CorrectnessFloorResult;
   readonly floorAttribution?: readonly AttributedFloorFailure[];
+  /** How the frozen install of the candidate went on a CLEAN checkout
+   *  (4.4.5): the ledger says what CI's install step will do. */
+  readonly install?: InstallOutcome;
+  /** Which files the candidate changed vs the base (the floor's diff scope). */
+  readonly changedFiles?: readonly string[];
   readonly guardrailVerdict?: string;
   /** Score-hinge evidence (tasks that declare one): the entry vs post-agent
    *  dimension scores the land decision was made on. Present on success AND
@@ -142,8 +149,15 @@ export interface RemediateRunOptions {
   /** Injected for tests. */
   readonly drivers?: readonly AgentDriver[];
   readonly git?: RemediateGit;
+  /** Injected for tests: the ENTRY floor on the pristine tree, and the
+   *  post-agent floor inside the verification worktree (forwarded to
+   *  `verifyTree`'s floor seam). */
   readonly runFloor?: () => CorrectnessFloorResult;
+  /** Injected for tests: forwarded to `verifyTree`'s guardrail seam. */
   readonly runGuardrail?: () => Promise<GuardrailGateResult>;
+  /** Injected for tests: the worktree / install / changed-files seams of the
+   *  ONE tree verification (`src/lanes/verify-tree.ts`). */
+  readonly verifySeams?: Pick<VerifyTreeSeams, 'worktree' | 'install' | 'changedFiles'>;
   /** Injected for tests: replaces the in-loop gate pre-trust + wiring probe
    *  (`agent-trust.ts:armInLoopGate`). */
   readonly armInLoopGate?: () => InLoopGateStatus;
@@ -173,6 +187,7 @@ export type RemediatePhase =
   | 'entry-floor'
   | 'agent'
   | 'sweep'
+  | 'verify-install'
   | 'verify-floor'
   | 'guardrail'
   | 'score-hinge';

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -3,9 +3,11 @@
  *
  * The agent runs INSIDE the verified frame the deterministic bump lane
  * built (design §2): entry floor snapshot on the pristine tree → agent →
- * leftover sweep → floor at full scope attributed vs entry (only a NET-NEW
- * failure blocks; pre-existing debt is disclosed, never weaponized) → the
- * guardrail as final arbiter. The agent's "completed" claim is NEVER
+ * leftover sweep → the ONE tree verification (`lanes/verify-tree.ts`: a clean
+ * worktree of the committed head, the repo's frozen install, the floor
+ * diff-scoped and attributed vs entry so only a NET-NEW failure blocks and
+ * pre-existing debt is disclosed, never weaponized, then the guardrail as
+ * final arbiter). The agent's "completed" claim is NEVER
  * trusted — an agent that says done with a red net-new floor gets the same
  * treatment as a failed bump: no landing, truthful failure.
  *
@@ -23,10 +25,9 @@
  * CLI/workflow layer on top of this runner's outcome.
  */
 import { runCorrectnessFloor } from '../analyzers/correctness/run';
-import { attributeFloorFailures, type FloorBaseCheck } from '../analyzers/correctness/attribution';
 import { detectActiveLanguages } from '../languages';
 import { renderRemediateLedger } from './ledger-render';
-import { guardrailVerdictFor, toFloorBaseChecks } from '../lanes/verify';
+import { verifyTree, type VerifyTreeStep } from '../lanes/verify-tree';
 import { resolveModelSetting, type AgentRunResult } from './driver';
 import { AGENT_DRIVERS, knownDriverIds } from './registry';
 import type { RemediateTask } from './tasks';
@@ -369,37 +370,78 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     });
   }
 
-  // Verify: floor at full scope attributed vs entry (through the ONE
-  // base-check projection, shared with the bump lane), then the guardrail.
-  opts.onPhase?.('verify-floor');
-  const floor = runFloor();
-  const baseChecks: FloorBaseCheck[] = toFloorBaseChecks(entryFloor);
-  const floorAttribution = attributeFloorFailures(floor, baseChecks, {
-    // The entry floor always ran (just above): an absent base check is a
-    // check the agent's change introduced — net-new (conservative).
+  // Verify the committed head the way CI will (the ONE tree verification,
+  // `lanes/verify-tree.ts`): a clean worktree of HEAD, the repo's frozen
+  // install, the floor diff-scoped vs baseHead and attributed vs entry
+  // (through the ONE comparator, shared with the bump lane), then the
+  // guardrail. Never the agent's dirty workspace: the class this closes was
+  // a "verified" draft whose lockfile CI could not install.
+  const head = git.head();
+  const phaseOf: Partial<Record<VerifyTreeStep, Parameters<NonNullable<typeof opts.onPhase>>[0]>> =
+    { install: 'verify-install', floor: 'verify-floor', guardrail: 'guardrail' };
+  const verified = await verifyTree({
+    cwd: opts.cwd,
+    head,
+    baseHead,
+    trust: opts.trust,
+    entryFloor,
+    // The entry floor always ran (above): an absent base check is a check
+    // the agent's change introduced — net-new (conservative).
     absentMeans: 'net-new',
+    onStep: (step) => {
+      const phase = phaseOf[step];
+      if (phase) opts.onPhase?.(phase);
+    },
+    seams: {
+      ...opts.verifySeams,
+      ...(opts.runFloor ? { runFloor: () => runFloor() } : {}),
+      ...(opts.runGuardrail ? { runGuardrail: () => opts.runGuardrail!() } : {}),
+    },
   });
-  const netNewFloorRed = floorAttribution.some((a) => a.attribution === 'net-new');
 
-  opts.onPhase?.('guardrail');
-  const guardrail = opts.runGuardrail
-    ? await opts.runGuardrail()
-    : await guardrailVerdictFor(opts.cwd, opts.trust);
+  // A verification that could not run at all (a worktree or package manager
+  // failure, the step named by the fail-open capture) reads as an UNRUNNABLE
+  // guardrail: same fail-closed arm below, with the step in the verdict.
+  const guardrail = verified.guardrail ?? {
+    verdict:
+      `unavailable (verification failed at step '${verified.failure?.step ?? 'unknown'}': ` +
+      `${verified.failure?.message ?? 'unknown'})`,
+    ran: false,
+    passesGate: false,
+  };
 
   const common = {
     task: task.id,
     envelope,
-    floor,
-    floorAttribution,
+    ...(verified.floor ? { floor: verified.floor } : {}),
+    ...(verified.floorAttribution ? { floorAttribution: verified.floorAttribution } : {}),
+    ...(verified.install ? { install: verified.install } : {}),
+    ...(verified.changedFiles ? { changedFiles: verified.changedFiles } : {}),
     guardrailVerdict: guardrail.verdict,
     baseHead,
-    head: git.head(),
+    head,
     ...evidenceTail,
     ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
     ...(partial ? { partial } : {}),
   };
 
-  if (netNewFloorRed) {
+  if (verified.verdict === 'install-failed') {
+    return finish({
+      outcome: 'install-failed',
+      ...common,
+      note:
+        "a clean checkout of the agent's commits cannot be installed the way CI installs it " +
+        `(\`${verified.install?.status === 'failed' ? verified.install.argv.join(' ') : 'frozen install'}\` ` +
+        'failed) — nothing lands. CI would have died before any gate ran, so the draft would ' +
+        'read "NOT gated"; the usual cause is a manifest edited without re-running the install ' +
+        'so the lockfile records it.' +
+        (verified.install?.status === 'failed'
+          ? `\n\nInstall output:\n\`\`\`\n${verified.install.output}\n\`\`\``
+          : ''),
+    });
+  }
+
+  if (verified.verdict === 'floor-red') {
     return finish({
       outcome: 'floor-red',
       ...common,
@@ -413,8 +455,9 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // The agent lane fails CLOSED on the guardrail (unlike the bump lane's
   // declared fail-open): an agent-authored diff — including whatever the
   // leftover sweep committed — must never reach the remote unverified. A
-  // BLOCKED verdict, the CANNOT-GATE refusal tier, and an unrunnable check
-  // all land nothing; the ledger says which it was.
+  // BLOCKED verdict, the CANNOT-GATE refusal tier, an unrunnable check, and
+  // a verification that could not run at all (a worktree or package manager
+  // failure, the step named) all land nothing; the ledger says which it was.
   if (!guardrail.ran || !guardrail.passesGate) {
     // Name the blocking findings in the ledger: on an ephemeral runner the
     // diff evaporates with the job, so "did not pass" with no evidence made

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -27,7 +27,7 @@
 import { runCorrectnessFloor } from '../analyzers/correctness/run';
 import { detectActiveLanguages } from '../languages';
 import { renderRemediateLedger } from './ledger-render';
-import { verifyTree, type VerifyTreeStep } from '../lanes/verify-tree';
+import { installFailedNote, verifyCommittedHead } from './verify';
 import { resolveModelSetting, type AgentRunResult } from './driver';
 import { AGENT_DRIVERS, knownDriverIds } from './registry';
 import type { RemediateTask } from './tasks';
@@ -377,38 +377,12 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // guardrail. Never the agent's dirty workspace: the class this closes was
   // a "verified" draft whose lockfile CI could not install.
   const head = git.head();
-  const phaseOf: Partial<Record<VerifyTreeStep, Parameters<NonNullable<typeof opts.onPhase>>[0]>> =
-    { install: 'verify-install', floor: 'verify-floor', guardrail: 'guardrail' };
-  const verified = await verifyTree({
-    cwd: opts.cwd,
+  const { verified, guardrail } = await verifyCommittedHead(opts, {
     head,
     baseHead,
-    trust: opts.trust,
     entryFloor,
-    // The entry floor always ran (above): an absent base check is a check
-    // the agent's change introduced — net-new (conservative).
-    absentMeans: 'net-new',
-    onStep: (step) => {
-      const phase = phaseOf[step];
-      if (phase) opts.onPhase?.(phase);
-    },
-    seams: {
-      ...opts.verifySeams,
-      ...(opts.runFloor ? { runFloor: () => runFloor() } : {}),
-      ...(opts.runGuardrail ? { runGuardrail: () => opts.runGuardrail!() } : {}),
-    },
+    runFloor,
   });
-
-  // A verification that could not run at all (a worktree or package manager
-  // failure, the step named by the fail-open capture) reads as an UNRUNNABLE
-  // guardrail: same fail-closed arm below, with the step in the verdict.
-  const guardrail = verified.guardrail ?? {
-    verdict:
-      `unavailable (verification failed at step '${verified.failure?.step ?? 'unknown'}': ` +
-      `${verified.failure?.message ?? 'unknown'})`,
-    ran: false,
-    passesGate: false,
-  };
 
   const common = {
     task: task.id,
@@ -429,15 +403,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     return finish({
       outcome: 'install-failed',
       ...common,
-      note:
-        "a clean checkout of the agent's commits cannot be installed the way CI installs it " +
-        `(\`${verified.install?.status === 'failed' ? verified.install.argv.join(' ') : 'frozen install'}\` ` +
-        'failed) — nothing lands. CI would have died before any gate ran, so the draft would ' +
-        'read "NOT gated"; the usual cause is a manifest edited without re-running the install ' +
-        'so the lockfile records it.' +
-        (verified.install?.status === 'failed'
-          ? `\n\nInstall output:\n\`\`\`\n${verified.install.output}\n\`\`\``
-          : ''),
+      note: installFailedNote(verified),
     });
   }
 

--- a/src/remediate/verify.ts
+++ b/src/remediate/verify.ts
@@ -1,0 +1,69 @@
+/**
+ * The remediate lane's call into the ONE tree verification
+ * (`lanes/verify-tree.ts`), split from the runner for module size. It maps
+ * the verification's steps onto the lane's phases and folds a verification
+ * that could not run into the fail-closed guardrail shape the runner already
+ * handles: an unrunnable verification IS an unrunnable guardrail, with the
+ * failing step named in the verdict.
+ */
+import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
+import type { GuardrailGateResult } from '../lanes/verify';
+import { verifyTree, type VerifyTreeResult, type VerifyTreeStep } from '../lanes/verify-tree';
+import type { RemediatePhase, RemediateRunOptions } from './outcome';
+
+const PHASE_OF: Partial<Record<VerifyTreeStep, RemediatePhase>> = {
+  install: 'verify-install',
+  floor: 'verify-floor',
+  guardrail: 'guardrail',
+};
+
+export async function verifyCommittedHead(
+  opts: RemediateRunOptions,
+  args: {
+    readonly head: string;
+    readonly baseHead: string;
+    readonly entryFloor: CorrectnessFloorResult;
+    readonly runFloor: () => CorrectnessFloorResult;
+  },
+): Promise<{ verified: VerifyTreeResult; guardrail: GuardrailGateResult }> {
+  const verified = await verifyTree({
+    cwd: opts.cwd,
+    head: args.head,
+    baseHead: args.baseHead,
+    trust: opts.trust,
+    entryFloor: args.entryFloor,
+    // The entry floor always ran: an absent base check is a check the
+    // agent's change introduced, net-new (conservative).
+    absentMeans: 'net-new',
+    onStep: (step) => {
+      const phase = PHASE_OF[step];
+      if (phase) opts.onPhase?.(phase);
+    },
+    seams: {
+      ...opts.verifySeams,
+      ...(opts.runFloor ? { runFloor: () => args.runFloor() } : {}),
+      ...(opts.runGuardrail ? { runGuardrail: () => opts.runGuardrail!() } : {}),
+    },
+  });
+  const guardrail: GuardrailGateResult = verified.guardrail ?? {
+    verdict:
+      `unavailable (verification failed at step '${verified.failure?.step ?? 'unknown'}': ` +
+      `${verified.failure?.message ?? 'unknown'})`,
+    ran: false,
+    passesGate: false,
+  };
+  return { verified, guardrail };
+}
+
+/** The install-failed outcome's note: what failed, why it matters, the
+ *  usual cause, and the install output as evidence. */
+export function installFailedNote(verified: VerifyTreeResult): string {
+  const failed = verified.install?.status === 'failed' ? verified.install : undefined;
+  return (
+    "a clean checkout of the agent's commits cannot be installed the way CI installs it " +
+    `(\`${failed ? failed.argv.join(' ') : 'frozen install'}\` failed) — nothing lands. CI would ` +
+    'have died before any gate ran, so the draft would read "NOT gated"; the usual cause is a ' +
+    'manifest edited without re-running the install so the lockfile records it.' +
+    (failed ? `\n\nInstall output:\n\`\`\`\n${failed.output}\n\`\`\`` : '')
+  );
+}

--- a/src/remediate/verify.ts
+++ b/src/remediate/verify.ts
@@ -45,14 +45,38 @@ export async function verifyCommittedHead(
       ...(opts.runGuardrail ? { runGuardrail: () => opts.runGuardrail!() } : {}),
     },
   });
-  const guardrail: GuardrailGateResult = verified.guardrail ?? {
-    verdict:
-      `unavailable (verification failed at step '${verified.failure?.step ?? 'unknown'}': ` +
-      `${verified.failure?.message ?? 'unknown'})`,
+  return { verified, guardrail: guardrailShapeFor(verified) };
+}
+
+/**
+ * The guardrail shape for a verification that carries no guardrail result.
+ * Two honest cases, never conflated (and never a fabricated failure): the
+ * verification BROKE (a `failure` names the step), or it STOPPED on its own
+ * verdict before the guardrail was due (install-failed / floor-red) — the
+ * gate was deliberately not consulted, and the ledger says so.
+ */
+function guardrailShapeFor(verified: VerifyTreeResult): GuardrailGateResult {
+  if (verified.guardrail) return verified.guardrail;
+  if (verified.failure) {
+    return {
+      verdict:
+        `unavailable (verification failed at step '${verified.failure.step}': ` +
+        `${verified.failure.message})`,
+      ran: false,
+      passesGate: false,
+    };
+  }
+  const stoppedAt =
+    verified.verdict === 'install-failed'
+      ? 'install'
+      : verified.verdict === 'floor-red'
+        ? 'floor'
+        : 'an earlier step';
+  return {
+    verdict: `not consulted (verification stopped at ${stoppedAt})`,
     ran: false,
     passesGate: false,
   };
-  return { verified, guardrail };
 }
 
 /** The install-failed outcome's note: what failed, why it matters, the

--- a/src/ship-installers.ts
+++ b/src/ship-installers.ts
@@ -39,6 +39,7 @@ import { baselineRefreshCron, loadPolicyFromCwd } from './baseline/policy';
 import { cronFromCadence, DEFAULT_DEPBUMP_CRON } from './baseline/policy-sections';
 import { BOT_IDENTITY } from './land-refresh';
 import { LANE_TOKEN_PAT_SECRET_NAME, LANE_TOKEN_SUBSTITUTIONS } from './lanes/lane-token';
+import { INSTALL_DEPS_PLACEHOLDER, renderInstallDependenciesShell } from './package-manager';
 import { resolveRemediateConfig } from './remediate/config';
 import { driverById } from './remediate/registry';
 import { knownTaskIds } from './remediate/tasks';
@@ -557,6 +558,14 @@ function installWorkflow(
   for (const [key, value] of Object.entries(LANE_TOKEN_SUBSTITUTIONS)) {
     content = content.split(key).join(value);
   }
+  // The dependency-install block renders the same way: ONE definition
+  // (src/package-manager.ts, shared with the lane's own verification) through
+  // the ONE writer, so a workflow can never install a tree differently from
+  // the way the remediate lane verified it (4.4.5). Whole-line placeholder at
+  // the `run: |` body indent.
+  content = content
+    .split(`          ${INSTALL_DEPS_PLACEHOLDER}`)
+    .join(renderInstallDependenciesShell('          '));
   for (const [key, value] of Object.entries(substitutions)) {
     content = content.split(key).join(value);
   }

--- a/test/correctness-lockfile-sync.test.ts
+++ b/test/correctness-lockfile-sync.test.ts
@@ -90,6 +90,42 @@ describe('lockfile-sync floor check (typescript pack, npm)', () => {
     try {
       const r = floorOn(dir, 1, EUSAGE, 'affected');
       expect(r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)).toBeUndefined();
+      // The result carries the EFFECTIVE scope, so renderers report what ran.
+      expect(r.scope).toBe('affected');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // An affected run with an EMPTY changed set is an UNDETERMINABLE diff — the
+  // pack contract reads it as full, so the lockfile check must run there too
+  // (a silent skip would re-open the class on any surface that cannot compute
+  // its diff: the change that drifted the lockfile may simply be invisible).
+  it('an affected run with an EMPTY changed set (undeterminable diff) still runs the check', () => {
+    const dir = tsRepo(files);
+    try {
+      const r = runCorrectnessFloor({
+        cwd: dir,
+        changedFiles: [],
+        scope: 'affected',
+        packs: [TS],
+        exec: (cmd) =>
+          cmd.bin === 'npm' && cmd.args.includes('--dry-run')
+            ? { available: true, code: 1, output: EUSAGE }
+            : { available: true, code: 0, output: '' },
+      });
+      const lock = r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)!;
+      expect(lock.status).toBe('fail');
+      expect(r.blocks).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a full run records its scope on the result', () => {
+    const dir = tsRepo(files);
+    try {
+      expect(floorOn(dir, 0, '').scope).toBe('full');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/correctness-lockfile-sync.test.ts
+++ b/test/correctness-lockfile-sync.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCorrectnessFloor, describeFloorCapturePlan } from '../src/analyzers/correctness/run';
+import { LOCKFILE_SYNC_LABEL } from '../src/languages/capabilities/correctness';
+import { getLanguage } from '../src/languages';
+
+const TS = getLanguage('typescript')!;
+
+/**
+ * The lockfile-sync floor check on the REAL TypeScript pack (4.4.5): the
+ * runner schedules it at full scope, the pack builds the npm dry-run from
+ * `package-manager.ts`, and the three outcomes are told apart at the runner:
+ *   - stale lockfile (EUSAGE)       → FAIL (the class CI died on)
+ *   - peer conflict only (ERESOLVE) → PASS with the --legacy-peer-deps disclosure
+ *   - in sync (exit 0)              → PASS
+ * Exec is injected: no package manager runs.
+ */
+
+const EUSAGE =
+  'npm ERR! code EUSAGE\nnpm ERR! `npm ci` can only install packages when your package.json and ' +
+  'package-lock.json are in sync.\nnpm ERR! Missing: left-pad@1.3.0 from lock file';
+const ERESOLVE = 'npm ERR! code ERESOLVE\nnpm ERR! ERESOLVE could not resolve peer react@^18';
+
+function tsRepo(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-locksync-'));
+  for (const [f, c] of Object.entries(files)) writeFileSync(join(dir, f), c);
+  return dir;
+}
+
+function floorOn(dir: string, code: number, output: string, scope: 'full' | 'affected' = 'full') {
+  return runCorrectnessFloor({
+    cwd: dir,
+    changedFiles: scope === 'full' ? [] : ['src/index.ts'],
+    scope,
+    packs: [TS],
+    exec: (cmd) =>
+      cmd.bin === 'npm' && cmd.args[0] === 'ci' && cmd.args.includes('--dry-run')
+        ? { available: true, code, output }
+        : { available: true, code: 0, output: '' },
+  });
+}
+
+describe('lockfile-sync floor check (typescript pack, npm)', () => {
+  const files = { 'package.json': '{"name":"x"}', 'package-lock.json': '{}' };
+
+  it('a stale lockfile FAILS the floor with the remedy named', () => {
+    const dir = tsRepo(files);
+    try {
+      const r = floorOn(dir, 1, EUSAGE);
+      const lock = r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)!;
+      expect(lock.status).toBe('fail');
+      expect(lock.bin).toBe('npm');
+      expect(lock.args).toEqual(['ci', '--dry-run', '--ignore-scripts', '--no-audit', '--no-fund']);
+      expect(lock.output).toContain('EUSAGE');
+      expect(lock.output).toContain('frozen install');
+      expect(r.blocks).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a peer-conflict-only failure PASSES with the --legacy-peer-deps disclosure', () => {
+    const dir = tsRepo(files);
+    try {
+      const r = floorOn(dir, 1, ERESOLVE);
+      const lock = r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)!;
+      expect(lock.status).toBe('pass');
+      expect(lock.note).toContain('--legacy-peer-deps');
+      expect(r.blocks).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('an in-sync lockfile PASSES with no note', () => {
+    const dir = tsRepo(files);
+    try {
+      const lock = floorOn(dir, 0, '').checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)!;
+      expect(lock.status).toBe('pass');
+      expect(lock.note).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a source-only affected run never pays the dry-run', () => {
+    const dir = tsRepo(files);
+    try {
+      const r = floorOn(dir, 1, EUSAGE, 'affected');
+      expect(r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('no lockfile → the pack declines (nothing to keep in sync)', () => {
+    const dir = tsRepo({ 'package.json': '{"name":"x"}' });
+    try {
+      const r = floorOn(dir, 1, EUSAGE);
+      expect(r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('yarn: a disclosed skip, never silent', () => {
+    const dir = tsRepo({ 'package.json': '{"name":"x"}', 'yarn.lock': '' });
+    try {
+      const lock = floorOn(dir, 0, '').checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)!;
+      expect(lock.status).toBe('skipped-unavailable');
+      expect(lock.output).toContain('immutable');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a missing package manager is fail-open (skipped, disclosed)', () => {
+    const dir = tsRepo(files);
+    try {
+      const r = runCorrectnessFloor({
+        cwd: dir,
+        changedFiles: [],
+        scope: 'full',
+        packs: [TS],
+        exec: (cmd) =>
+          cmd.args.includes('--dry-run')
+            ? { available: false, code: -1, output: 'npm: not on PATH' }
+            : { available: true, code: 0, output: '' },
+      });
+      const lock = r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)!;
+      expect(lock.status).toBe('skipped-unavailable');
+      expect(r.blocks).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('the capture plan names the dry-run so an operator sees it before the run', () => {
+    const dir = tsRepo(files);
+    try {
+      const plan = describeFloorCapturePlan(dir, [TS]);
+      expect(plan.some((l) => l.includes('lockfile-sync') && l.includes('npm ci --dry-run'))).toBe(
+        true,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/install-deps-template.test.ts
+++ b/test/install-deps-template.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as yaml from 'js-yaml';
+import { INSTALL_DEPS_PLACEHOLDER, renderInstallDependenciesShell } from '../src/package-manager';
+import { installCiGuardrails } from '../src/ship-installers';
+
+/**
+ * Workflow templates install a repo's dependencies through ONE definition
+ * (4.4.5, Rule 2.30): `src/package-manager.ts` owns the frozen-install table,
+ * the templates carry a whole-line placeholder, and the ONE workflow writer
+ * substitutes the rendered block. Before this, twelve templates carried a
+ * hand-copied shell chain (one of them npm-only, already drifted), and the
+ * remediate lane verified a tree with a different install than CI ran.
+ *
+ * Membership is derived from template CONTENT (a template that invokes the
+ * dxkit CLI from a repo checkout needs the repo's dependencies installed the
+ * frozen way), never from a filename list; deliberate non-members are
+ * declared exemptions with reasons.
+ */
+
+const WORKFLOWS = path.join(__dirname, '..', 'src-templates', '.github', 'workflows');
+
+/** Templates that invoke the CLI from a checkout but DELIBERATELY do not
+ *  install the repo's dependencies. A reason, never an omission. */
+const INSTALL_EXEMPT: Readonly<Record<string, string>> = {
+  'dxkit-gate-host.yml':
+    'the per-host floor job installs only the dxkit CLI; the placed pack’s own ' +
+    'ciSetup provisions the toolchain, and the floor commands install nothing',
+};
+
+function templates(): Array<{ file: string; content: string }> {
+  return fs
+    .readdirSync(WORKFLOWS)
+    .filter((f) => f.endsWith('.yml'))
+    .map((file) => ({ file, content: fs.readFileSync(path.join(WORKFLOWS, file), 'utf8') }));
+}
+
+/** Does this template run dxkit against a repo checkout? Then it must have
+ *  installed that checkout's dependencies the frozen way first. */
+function runsDxkitOnCheckout(content: string): boolean {
+  return content.includes('node_modules/.bin/vyuh-dxkit');
+}
+
+describe('dependency-install block: one definition, rendered into every template', () => {
+  it('no template carries a hand-written frozen-install chain', () => {
+    for (const { file, content } of templates()) {
+      expect(
+        content,
+        `${file}: inline install chain (use ${INSTALL_DEPS_PLACEHOLDER})`,
+      ).not.toMatch(
+        /npm ci( \|\||\n)|pnpm install --frozen-lockfile|yarn install --immutable|bun install --frozen-lockfile/,
+      );
+    }
+  });
+
+  it('every template that runs dxkit on a checkout carries the placeholder, or a declared exemption', () => {
+    for (const { file, content } of templates()) {
+      if (!runsDxkitOnCheckout(content)) continue;
+      const has = content.includes(`          ${INSTALL_DEPS_PLACEHOLDER}\n`);
+      if (file in INSTALL_EXEMPT) {
+        expect(has, `${file}: exempt but carries the placeholder; drop the exemption`).toBe(false);
+        continue;
+      }
+      expect(has, `${file}: runs dxkit on a checkout without the frozen install placeholder`).toBe(
+        true,
+      );
+    }
+  });
+
+  it('every exemption names a real template', () => {
+    const names = templates().map((t) => t.file);
+    for (const f of Object.keys(INSTALL_EXEMPT)) expect(names).toContain(f);
+  });
+
+  it('the writer renders the block from the one definition (the guardrails workflow, end to end)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-install-tpl-'));
+    try {
+      fs.writeFileSync(path.join(tmp, 'package.json'), '{"name":"x"}');
+      installCiGuardrails(tmp);
+      const out = fs.readFileSync(
+        path.join(tmp, '.github', 'workflows', 'dxkit-guardrails.yml'),
+        'utf8',
+      );
+      expect(out).not.toContain(INSTALL_DEPS_PLACEHOLDER);
+      expect(out).toContain(renderInstallDependenciesShell('          '));
+      // And it is still valid YAML with a real `run:` body.
+      const parsed = yaml.load(out) as { jobs: Record<string, { steps: Array<{ run?: string }> }> };
+      const runs = Object.values(parsed.jobs).flatMap((j) => j.steps.map((s) => s.run ?? ''));
+      expect(runs.some((r) => r.includes('npm ci || npm ci --legacy-peer-deps'))).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  // Synthetic injection: the content-derived membership predicate must bite
+  // on a template that runs dxkit without installing.
+  it('the membership predicate bites on a synthetic template', () => {
+    expect(runsDxkitOnCheckout('run: ./node_modules/.bin/vyuh-dxkit guardrail check')).toBe(true);
+    expect(runsDxkitOnCheckout('run: echo nothing')).toBe(false);
+  });
+});

--- a/test/lanes/verification-render.test.ts
+++ b/test/lanes/verification-render.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { renderFloorVerification } from '../../src/lanes/verification-render';
+import type { CorrectnessFloorResult } from '../../src/analyzers/correctness/run';
+
+/**
+ * The shared floor-verification block renders the ACTUAL scope the run
+ * executed at (the verification floor runs `affected`, escalating on
+ * manifests) — a hardcoded "full scope" misstated what was verified. Older
+ * serialized floors without the field render as full (they were).
+ */
+
+function floor(over: Partial<CorrectnessFloorResult> = {}): CorrectnessFloorResult {
+  return { ran: true, checks: [], blocks: false, ...over };
+}
+
+describe('renderFloorVerification scope line', () => {
+  it('renders the recorded affected scope', () => {
+    const lines = renderFloorVerification(floor({ scope: 'affected' }), [], 'the entry run');
+    expect(lines[0]).toContain('(affected scope, attributed vs the entry run)');
+  });
+
+  it('renders the recorded full scope', () => {
+    const lines = renderFloorVerification(floor({ scope: 'full' }), [], 'the entry run');
+    expect(lines[0]).toContain('(full scope,');
+  });
+
+  it('a scope-less legacy floor renders as full (what it was)', () => {
+    const lines = renderFloorVerification(floor(), [], 'the entry run');
+    expect(lines[0]).toContain('(full scope,');
+  });
+
+  it('a pass note (tolerated condition) rides the check line', () => {
+    const lines = renderFloorVerification(
+      floor({
+        checks: [
+          {
+            pack: 'typescript',
+            label: 'lockfile-sync',
+            bin: 'npm',
+            status: 'pass',
+            note: 'peer conflict tolerated',
+          },
+        ],
+      }),
+      [],
+      'the entry run',
+    );
+    expect(lines.join('\n')).toContain('lockfile-sync: pass (peer conflict tolerated)');
+  });
+});

--- a/test/lanes/verify-tree.test.ts
+++ b/test/lanes/verify-tree.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  describeInstall,
+  runFrozenInstall,
+  verifyTree,
+  type InstallOutcome,
+  type VerifyTreeOptions,
+  type VerifyTreeSeams,
+} from '../../src/lanes/verify-tree';
+import type { CorrectnessFloorResult } from '../../src/analyzers/correctness/run';
+import type { AnalysisTrustContext } from '../../src/analysis-trust';
+
+/**
+ * The ONE tree verification (4.4.5): a clean worktree of the candidate, the
+ * repo's frozen install, the diff-scoped floor attributed vs entry, the
+ * guardrail. Every step is injected here so the COMPOSITION is what is
+ * pinned: an install that fails is its own verdict and nothing downstream
+ * runs; an infrastructure failure is a disclosed step failure, never a pass
+ * and never a false block; and the floor sees the worktree + the real diff,
+ * not the lane's dirty cwd with an empty changed-set.
+ */
+
+const TRUSTED = { repoExecutionAllowed: true, source: 'local-workspace' } as AnalysisTrustContext;
+const GREEN: CorrectnessFloorResult = { ran: true, checks: [], blocks: false };
+const RED: CorrectnessFloorResult = {
+  ran: true,
+  checks: [{ pack: 'typescript', label: 'typecheck', bin: 'npx', status: 'fail' }],
+  blocks: true,
+};
+const INSTALLED: InstallOutcome = { status: 'installed', argv: ['npm', 'ci'] };
+
+function seams(over: Partial<VerifyTreeSeams> = {}): VerifyTreeSeams {
+  return {
+    worktree: async (_o, fn) => fn('/tmp/dxkit-fake-worktree'),
+    install: () => INSTALLED,
+    changedFiles: () => ['src/a.ts'],
+    runFloor: () => GREEN,
+    runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+    ...over,
+  };
+}
+
+function opts(over: Partial<VerifyTreeOptions> = {}): VerifyTreeOptions {
+  return {
+    cwd: '/tmp/fake-repo',
+    head: 'head1111',
+    baseHead: 'base0000',
+    trust: TRUSTED,
+    entryFloor: GREEN,
+    absentMeans: 'net-new',
+    seams: seams(),
+    ...over,
+  };
+}
+
+describe('verifyTree', () => {
+  it('verified: install ok, floor net-new-clean, guardrail passes', async () => {
+    const r = await verifyTree(opts());
+    expect(r.verdict).toBe('verified');
+    expect(r.install).toEqual(INSTALLED);
+    expect(r.changedFiles).toEqual(['src/a.ts']);
+    expect(r.guardrail?.verdict).toBe('PASSED');
+    expect(r.failure).toBeUndefined();
+  });
+
+  it('install-failed: a failed frozen install is its own verdict and NOTHING downstream runs', async () => {
+    let floorRan = false;
+    let guardrailRan = false;
+    const r = await verifyTree(
+      opts({
+        seams: seams({
+          install: () => ({
+            status: 'failed',
+            argv: ['npm', 'ci', '--legacy-peer-deps'],
+            output: 'npm ERR! code EUSAGE\nnot in sync',
+          }),
+          runFloor: () => {
+            floorRan = true;
+            return GREEN;
+          },
+          runGuardrail: async () => {
+            guardrailRan = true;
+            return { verdict: 'PASSED', ran: true, passesGate: true };
+          },
+        }),
+      }),
+    );
+    expect(r.verdict).toBe('install-failed');
+    expect(r.install?.status).toBe('failed');
+    expect(floorRan).toBe(false);
+    expect(guardrailRan).toBe(false);
+    expect(describeInstall(r.install)).toContain('FAILED on a clean checkout');
+  });
+
+  it('the fallback install is disclosed, never silent', async () => {
+    const r = await verifyTree(
+      opts({
+        seams: seams({
+          install: () => ({
+            status: 'installed',
+            argv: ['npm', 'ci'],
+            fallback: { argv: ['npm', 'ci', '--legacy-peer-deps'], reason: 'peer conflict' },
+          }),
+        }),
+      }),
+    );
+    expect(r.verdict).toBe('verified');
+    expect(describeInstall(r.install)).toContain('`npm ci --legacy-peer-deps` succeeded');
+    expect(describeInstall(r.install)).toContain('peer conflict');
+  });
+
+  it('floor-red: a NET-NEW failure vs the entry floor blocks; the guardrail is not consulted', async () => {
+    let guardrailRan = false;
+    const r = await verifyTree(
+      opts({
+        seams: seams({
+          runFloor: () => RED,
+          runGuardrail: async () => {
+            guardrailRan = true;
+            return { verdict: 'PASSED', ran: true, passesGate: true };
+          },
+        }),
+      }),
+    );
+    expect(r.verdict).toBe('floor-red');
+    expect(r.floorAttribution?.some((a) => a.attribution === 'net-new')).toBe(true);
+    expect(guardrailRan).toBe(false);
+  });
+
+  it('pre-existing floor debt (red at entry too) does not block', async () => {
+    const r = await verifyTree(opts({ entryFloor: RED, seams: seams({ runFloor: () => RED }) }));
+    expect(r.verdict).toBe('verified');
+    expect(r.floorAttribution?.every((a) => a.attribution === 'pre-existing')).toBe(true);
+  });
+
+  it('the floor runs IN THE WORKTREE with the REAL diff, diff-scoped (never cwd + [])', async () => {
+    let seen: { cwd: string; changedFiles: readonly string[] } | undefined;
+    const r = await verifyTree(
+      opts({
+        seams: seams({
+          worktree: async (o, fn) => {
+            expect(o).toEqual({ cwd: '/tmp/fake-repo', ref: 'head1111' });
+            return fn('/tmp/wt-xyz');
+          },
+          changedFiles: (wt, base) => {
+            expect(wt).toBe('/tmp/wt-xyz');
+            expect(base).toBe('base0000');
+            return ['package.json', 'src/b.ts'];
+          },
+          runFloor: (args) => {
+            seen = args;
+            return GREEN;
+          },
+          runGuardrail: async (wt) => {
+            expect(wt).toBe('/tmp/wt-xyz');
+            return { verdict: 'PASSED', ran: true, passesGate: true };
+          },
+        }),
+      }),
+    );
+    expect(r.verdict).toBe('verified');
+    expect(seen).toEqual({ cwd: '/tmp/wt-xyz', changedFiles: ['package.json', 'src/b.ts'] });
+  });
+
+  it('guardrail-red: a BLOCKED guardrail', async () => {
+    const r = await verifyTree(
+      opts({
+        seams: seams({
+          runGuardrail: async () => ({ verdict: 'BLOCKED', ran: true, passesGate: false }),
+        }),
+      }),
+    );
+    expect(r.verdict).toBe('guardrail-red');
+  });
+
+  it('error: a worktree that cannot be created is a DISCLOSED step failure, never a pass', async () => {
+    const r = await verifyTree(
+      opts({
+        seams: seams({
+          worktree: async () => {
+            throw new Error('Cannot resolve baseline ref head1111.');
+          },
+        }),
+      }),
+    );
+    expect(r.verdict).toBe('error');
+    expect(r.failure).toEqual({
+      step: 'worktree',
+      message: 'Cannot resolve baseline ref head1111.',
+    });
+    expect(r.install).toBeUndefined();
+  });
+
+  it('error: a package manager missing from the environment names the install step', async () => {
+    const r = await verifyTree(
+      opts({
+        seams: seams({
+          install: () => {
+            throw new Error('pnpm is not available in the verification environment');
+          },
+        }),
+      }),
+    );
+    expect(r.verdict).toBe('error');
+    expect(r.failure?.step).toBe('install');
+    expect(r.failure?.message).toContain('pnpm is not available');
+  });
+
+  it('error: an unrunnable guardrail names the guardrail step', async () => {
+    const r = await verifyTree(
+      opts({
+        seams: seams({
+          runGuardrail: async () => ({
+            verdict: 'unavailable (boom)',
+            ran: false,
+            passesGate: false,
+          }),
+        }),
+      }),
+    );
+    expect(r.verdict).toBe('error');
+    expect(r.failure).toEqual({ step: 'guardrail', message: 'unavailable (boom)' });
+  });
+
+  it('reports steps in order through onStep', async () => {
+    const steps: string[] = [];
+    await verifyTree(opts({ onStep: (s) => steps.push(s) }));
+    expect(steps).toEqual([
+      'worktree',
+      'install',
+      'changed-files',
+      'floor',
+      'attribution',
+      'guardrail',
+    ]);
+  });
+});
+
+describe('runFrozenInstall', () => {
+  function repo(files: string[]): string {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-vt-'));
+    for (const f of files) writeFileSync(join(dir, f), '{}');
+    return dir;
+  }
+
+  it('primary succeeds → installed with the primary argv', () => {
+    const dir = repo(['package.json', 'package-lock.json']);
+    try {
+      const argvs: string[] = [];
+      const r = runFrozenInstall(dir, (cmd) => {
+        argvs.push([cmd.bin, ...cmd.args].join(' '));
+        return { available: true, code: 0, output: '' };
+      });
+      expect(r).toEqual({ status: 'installed', argv: ['npm', 'ci'] });
+      expect(argvs).toEqual(['npm ci']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('primary fails, fallback succeeds → installed with the fallback disclosed (the CI `a || b`)', () => {
+    const dir = repo(['package.json', 'package-lock.json']);
+    try {
+      const r = runFrozenInstall(dir, (cmd) =>
+        cmd.args.includes('--legacy-peer-deps')
+          ? { available: true, code: 0, output: '' }
+          : { available: true, code: 1, output: 'npm ERR! code ERESOLVE' },
+      );
+      expect(r.status).toBe('installed');
+      if (r.status === 'installed')
+        expect(r.fallback?.argv).toEqual(['npm', 'ci', '--legacy-peer-deps']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('both fail → failed, both outputs kept (the stale-lockfile class)', () => {
+    const dir = repo(['package.json', 'package-lock.json']);
+    try {
+      const r = runFrozenInstall(dir, () => ({
+        available: true,
+        code: 1,
+        output: 'npm ERR! code EUSAGE\nnpm ERR! package.json and package-lock.json are not in sync',
+      }));
+      expect(r.status).toBe('failed');
+      if (r.status === 'failed') {
+        expect(r.argv).toEqual(['npm', 'ci', '--legacy-peer-deps']);
+        expect(r.output).toContain('EUSAGE');
+        expect(r.output).toContain('--- fallback');
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a package manager not on PATH throws (infrastructure, the caller discloses the step)', () => {
+    const dir = repo(['package.json', 'pnpm-lock.yaml']);
+    try {
+      expect(() =>
+        runFrozenInstall(dir, () => ({ available: false, code: -1, output: 'pnpm: not found' })),
+      ).toThrow(/pnpm is not available/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('no package.json → nothing to install, no command runs', () => {
+    const dir = repo([]);
+    try {
+      let ran = false;
+      const r = runFrozenInstall(dir, () => {
+        ran = true;
+        return { available: true, code: 0, output: '' };
+      });
+      expect(r).toEqual({ status: 'nothing-to-install' });
+      expect(ran).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/lanes/verify-tree.test.ts
+++ b/test/lanes/verify-tree.test.ts
@@ -34,13 +34,24 @@ const INSTALLED: InstallOutcome = { status: 'installed', argv: ['npm', 'ci'] };
 
 function seams(over: Partial<VerifyTreeSeams> = {}): VerifyTreeSeams {
   return {
-    worktree: async (_o, fn) => fn('/tmp/dxkit-fake-worktree'),
+    // Ref-addressed fake paths so the base-attribution probe (which opens a
+    // second worktree at baseHead) is distinguishable in the install seam.
+    worktree: async (o, fn) => fn(`/wt/${o.ref}`),
     install: () => INSTALLED,
     changedFiles: () => ['src/a.ts'],
     runFloor: () => GREEN,
     runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
     ...over,
   };
+}
+
+/** An install seam that fails on the CANDIDATE worktree only (the base
+ *  probe, addressed by baseHead, installs clean). */
+function failsOnCandidate(output: string): (wt: string) => InstallOutcome {
+  return (wt) =>
+    wt.endsWith('head1111')
+      ? { status: 'failed', argv: ['npm', 'ci', '--legacy-peer-deps'], output }
+      : INSTALLED;
 }
 
 function opts(over: Partial<VerifyTreeOptions> = {}): VerifyTreeOptions {
@@ -66,17 +77,13 @@ describe('verifyTree', () => {
     expect(r.failure).toBeUndefined();
   });
 
-  it('install-failed: a failed frozen install is its own verdict and NOTHING downstream runs', async () => {
+  it('install-failed: a NET-NEW install failure (base installs clean) is its own verdict and NOTHING downstream runs', async () => {
     let floorRan = false;
     let guardrailRan = false;
     const r = await verifyTree(
       opts({
         seams: seams({
-          install: () => ({
-            status: 'failed',
-            argv: ['npm', 'ci', '--legacy-peer-deps'],
-            output: 'npm ERR! code EUSAGE\nnot in sync',
-          }),
+          install: failsOnCandidate('npm ERR! code EUSAGE\nnot in sync'),
           runFloor: () => {
             floorRan = true;
             return GREEN;
@@ -90,9 +97,81 @@ describe('verifyTree', () => {
     );
     expect(r.verdict).toBe('install-failed');
     expect(r.install?.status).toBe('failed');
+    expect(r.install?.status === 'failed' && r.install.preExisting).toBeFalsy();
+    // The diff was computed before the install and survives into the result.
+    expect(r.changedFiles).toEqual(['src/a.ts']);
     expect(floorRan).toBe(false);
     expect(guardrailRan).toBe(false);
     expect(describeInstall(r.install)).toContain('FAILED on a clean checkout');
+  });
+
+  // Finding-1 class: a lockfile already drifted at baseHead would fail the
+  // frozen install on EVERY run. The base probe attributes it: pre-existing
+  // debt is disclosed, never blamed, and verification proceeds.
+  it('a PRE-EXISTING install failure (base fails too) is disclosed and verification proceeds', async () => {
+    const probed: string[] = [];
+    const r = await verifyTree(
+      opts({
+        seams: seams({
+          install: (wt) => {
+            probed.push(wt);
+            return { status: 'failed', argv: ['npm', 'ci'], output: 'npm ERR! code EUSAGE' };
+          },
+        }),
+      }),
+    );
+    expect(probed).toEqual(['/wt/head1111', '/wt/base0000']);
+    expect(r.verdict).toBe('verified');
+    expect(r.install?.status === 'failed' && r.install.preExisting).toBe(true);
+    const line = describeInstall(r.install)!;
+    expect(line).toContain('pre-existing');
+    expect(line).toContain('not caused by this change');
+  });
+
+  it('a base probe that cannot run is a disclosed error at step base-install, never a blame', async () => {
+    const r = await verifyTree(
+      opts({
+        seams: seams({
+          worktree: async (o, fn) => {
+            if (o.ref === 'base0000') throw new Error('base ref unreachable');
+            return fn(`/wt/${o.ref}`);
+          },
+          install: () => ({ status: 'failed', argv: ['npm', 'ci'], output: 'EUSAGE' }),
+        }),
+      }),
+    );
+    expect(r.verdict).toBe('error');
+    expect(r.failure).toEqual({ step: 'base-install', message: 'base ref unreachable' });
+  });
+
+  // Finding-4 class (Rule 17): the seam gates on trust ITSELF — the install
+  // runs lifecycle scripts and the floor runs repo-declared commands, so an
+  // untrusted tree must never spawn either, by design not caller convention.
+  it('an untrusted tree is a disclosed skipped-untrusted verdict; nothing spawns', async () => {
+    const touched: string[] = [];
+    const r = await verifyTree(
+      opts({
+        trust: { repoExecutionAllowed: false, source: 'untrusted-content' } as AnalysisTrustContext,
+        seams: seams({
+          worktree: async (o, fn) => {
+            touched.push('worktree');
+            return fn(`/wt/${o.ref}`);
+          },
+          install: () => {
+            touched.push('install');
+            return INSTALLED;
+          },
+          runFloor: () => {
+            touched.push('floor');
+            return GREEN;
+          },
+        }),
+      }),
+    );
+    expect(r.verdict).toBe('skipped-untrusted');
+    expect(touched).toEqual([]);
+    expect(r.failure?.step).toBe('trust');
+    expect(r.failure?.message).toContain('untrusted-content');
   });
 
   it('the fallback install is disclosed, never silent', async () => {
@@ -225,17 +304,39 @@ describe('verifyTree', () => {
     expect(r.failure).toEqual({ step: 'guardrail', message: 'unavailable (boom)' });
   });
 
-  it('reports steps in order through onStep', async () => {
+  it('reports steps in order through onStep — the diff BEFORE the install', async () => {
     const steps: string[] = [];
     await verifyTree(opts({ onStep: (s) => steps.push(s) }));
     expect(steps).toEqual([
       'worktree',
-      'install',
       'changed-files',
+      'install',
       'floor',
       'attribution',
       'guardrail',
     ]);
+  });
+
+  // Finding-6 class: an install can rewrite the lockfile or drop node_modules
+  // into an unignored tree; computed after the install those artifacts read
+  // as the agent's diff and force a bogus manifest escalation.
+  it('changedFiles is computed on the PRISTINE checkout, before the install mutates it', async () => {
+    const order: string[] = [];
+    await verifyTree(
+      opts({
+        seams: seams({
+          changedFiles: () => {
+            order.push('changed-files');
+            return ['src/a.ts'];
+          },
+          install: () => {
+            order.push('install');
+            return INSTALLED;
+          },
+        }),
+      }),
+    );
+    expect(order).toEqual(['changed-files', 'install']);
   });
 });
 
@@ -305,6 +406,63 @@ describe('runFrozenInstall', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  // Finding-3 class (#272 shape): a run that did not finish says nothing
+  // about the tree. A timed-out or overflowed install THROWS (→ a disclosed
+  // error step in verifyTree), never "CI cannot install this tree".
+  it('a timed-out primary install throws as infrastructure, never install-failed', () => {
+    const dir = repo(['package.json', 'package-lock.json']);
+    try {
+      expect(() =>
+        runFrozenInstall(dir, () => ({ available: true, timedOut: true, code: -1, output: '' })),
+      ).toThrow(/timed out — infrastructure, not a verdict on the tree/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a timed-out FALLBACK install throws too (the marker survives the fallback path)', () => {
+    const dir = repo(['package.json', 'package-lock.json']);
+    try {
+      expect(() =>
+        runFrozenInstall(dir, (cmd) =>
+          cmd.args.includes('--legacy-peer-deps')
+            ? { available: true, timedOut: true, code: -1, output: '' }
+            : { available: true, code: 1, output: 'npm ERR! code ERESOLVE' },
+        ),
+      ).toThrow(/fallback \(`npm ci --legacy-peer-deps`\) timed out/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('an overflowed capture is the same infrastructure shape', () => {
+    const dir = repo(['package.json', 'package-lock.json']);
+    try {
+      expect(() =>
+        runFrozenInstall(dir, () => ({ available: true, overflowed: true, code: 1, output: 'x' })),
+      ).toThrow(/overflowed the capture buffer/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('verifyTree surfaces an install timeout as a disclosed error at step install', async () => {
+    const r = await verifyTree(
+      opts({
+        seams: seams({
+          install: () => {
+            throw new Error(
+              'frozen install (`npm ci`) timed out — infrastructure, not a verdict on the tree',
+            );
+          },
+        }),
+      }),
+    );
+    expect(r.verdict).toBe('error');
+    expect(r.failure?.step).toBe('install');
+    expect(r.failure?.message).toContain('timed out');
   });
 
   it('no package.json → nothing to install, no command runs', () => {

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -437,6 +437,26 @@ describe.each(LANGUAGES as LanguageSupport[])('language contract: $id', (lang) =
         ).toBeGreaterThan(0);
       }
     }
+    // The OPTIONAL lockfile-sync check (4.4.5): a pure command BUILDER like
+    // syntaxCheck — null (no lockfile), a well-formed command, or a disclosed
+    // skip with a reason; never a throw, never a spawn. On a nonexistent repo
+    // there is no lockfile to check, so the honest answer is null.
+    if (c.lockfileCheck) {
+      const res = c.lockfileCheck(ctx);
+      if (res !== null) {
+        expect(['command', 'skipped']).toContain(res.kind);
+        if (res.kind === 'command') {
+          expect(typeof res.command.label).toBe('string');
+          expect(typeof res.command.bin).toBe('string');
+          expect(Array.isArray(res.command.args)).toBe(true);
+        } else {
+          expect(
+            res.reason.length,
+            `${lang.id}: a lockfile-check skip must disclose its reason`,
+          ).toBeGreaterThan(0);
+        }
+      }
+    }
     // The OPTIONAL structure check (#309, 4.4.1): same pure-computation
     // contract as resolutionCheck — well-formed result, never a throw, a
     // labeled check id whenever anything ran or was claimed (`none` is the

--- a/test/package-manager-frozen-install.test.ts
+++ b/test/package-manager-frozen-install.test.ts
@@ -3,10 +3,12 @@ import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
+  detectLockfile,
   frozenInstallFor,
   isPeerConflictOnly,
   lockfileSyncCheck,
   renderInstallDependenciesShell,
+  LOCKFILES,
   type PackageManager,
 } from '../src/package-manager';
 
@@ -65,6 +67,36 @@ describe('frozenInstallFor', () => {
       }
     });
   }
+
+  // Rule 2.30 parity (the shrinkwrap class): INSTALL_BRANCHES and
+  // detectLockfile must read ONE lockfile-set definition. For every lockfile
+  // either projection recognizes, both must agree on the PM and the frozen
+  // install must be that PM's — a shrinkwrap-only repo once dry-ran `npm ci`
+  // on the floor while its CI ran a plain `npm install`.
+  it('every lockfile detectLockfile knows selects the SAME pm in frozenInstallFor', () => {
+    const frozenArgv: Record<PackageManager, string> = {
+      pnpm: 'pnpm install --frozen-lockfile',
+      yarn: 'yarn install --immutable',
+      bun: 'bun install --frozen-lockfile',
+      npm: 'npm ci',
+    };
+    const shell = renderInstallDependenciesShell('');
+    for (const [pm, files] of Object.entries(LOCKFILES) as [PackageManager, readonly string[]][]) {
+      for (const file of files) {
+        const dir = repoWith(['package.json', file]);
+        try {
+          expect(detectLockfile(dir)?.pm, `${file} detects as ${pm}`).toBe(pm);
+          const plan = frozenInstallFor(dir)!;
+          expect(plan.pm, `${file} installs with ${pm}`).toBe(pm);
+          expect(plan.argv.join(' ')).toBe(frozenArgv[pm]);
+          // And the rendered CI chain tests for this lockfile too.
+          expect(shell, `rendered shell tests for ${file}`).toContain(`[ -f ${file} ]`);
+        } finally {
+          rmSync(dir, { recursive: true, force: true });
+        }
+      }
+    }
+  });
 
   it('no package.json → nothing to install', () => {
     const dir = repoWith([]);

--- a/test/package-manager-frozen-install.test.ts
+++ b/test/package-manager-frozen-install.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  frozenInstallFor,
+  isPeerConflictOnly,
+  lockfileSyncCheck,
+  renderInstallDependenciesShell,
+  type PackageManager,
+} from '../src/package-manager';
+
+/**
+ * The ONE frozen-install definition (4.4.5): what the CI templates render and
+ * what the lane's verification runs come from the same table. These pin the
+ * table's two projections against each other and the peer-conflict
+ * classifier both directions.
+ */
+
+function repoWith(files: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-frozen-'));
+  for (const f of files) writeFileSync(join(dir, f), '');
+  return dir;
+}
+
+describe('frozenInstallFor', () => {
+  const cases: Array<{ files: string[]; pm: PackageManager; argv: string; fallback?: string }> = [
+    {
+      files: ['package.json', 'pnpm-lock.yaml'],
+      pm: 'pnpm',
+      argv: 'pnpm install --frozen-lockfile',
+    },
+    {
+      files: ['package.json', 'yarn.lock'],
+      pm: 'yarn',
+      argv: 'yarn install --immutable',
+      fallback: 'yarn install --frozen-lockfile',
+    },
+    { files: ['package.json', 'bun.lock'], pm: 'bun', argv: 'bun install --frozen-lockfile' },
+    {
+      files: ['package.json', 'package-lock.json'],
+      pm: 'npm',
+      argv: 'npm ci',
+      fallback: 'npm ci --legacy-peer-deps',
+    },
+    {
+      files: ['package.json'],
+      pm: 'npm',
+      argv: 'npm install',
+      fallback: 'npm install --legacy-peer-deps',
+    },
+  ];
+
+  for (const c of cases) {
+    it(`${c.files.join('+')} → ${c.argv}`, () => {
+      const dir = repoWith(c.files);
+      try {
+        const plan = frozenInstallFor(dir)!;
+        expect(plan.pm).toBe(c.pm);
+        expect(plan.argv.join(' ')).toBe(c.argv);
+        expect(plan.fallback?.argv.join(' ')).toBe(c.fallback);
+        if (plan.fallback) expect(plan.fallback.reason.length).toBeGreaterThan(0);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it('no package.json → nothing to install', () => {
+    const dir = repoWith([]);
+    try {
+      expect(frozenInstallFor(dir)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // The parity pin: every programmatic install the lane can run is a line of
+  // the rendered CI block, primary and fallback alike. If the table ever grows
+  // a branch the renderer does not emit (or vice versa) this fails.
+  it('every install argv the lane runs appears verbatim in the rendered CI shell', () => {
+    const shell = renderInstallDependenciesShell('');
+    for (const c of cases) {
+      const dir = repoWith(c.files);
+      try {
+        const plan = frozenInstallFor(dir)!;
+        const line = plan.fallback
+          ? `${plan.argv.join(' ')}${plan.pm === 'yarn' ? ' 2>/dev/null' : ''} || ${plan.fallback.argv.join(' ')}`
+          : plan.argv.join(' ');
+        expect(shell.split('\n').map((l) => l.trim())).toContain(line);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+});
+
+describe('renderInstallDependenciesShell', () => {
+  it('renders the lockfile-priority chain at the given indent', () => {
+    const shell = renderInstallDependenciesShell('    ');
+    expect(shell.startsWith('    corepack enable')).toBe(true);
+    const order = ['pnpm-lock.yaml', 'yarn.lock', 'bun.lockb', 'package-lock.json', 'package.json'];
+    const positions = order.map((f) => shell.indexOf(`-f ${f}`));
+    expect(positions.every((p) => p >= 0)).toBe(true);
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+    expect(shell.trimEnd().endsWith('    fi')).toBe(true);
+    expect(shell).toContain('npm install -g @vyuhlabs/dxkit');
+  });
+});
+
+describe('isPeerConflictOnly', () => {
+  it('a peer conflict (ERESOLVE) is the one --legacy-peer-deps answers', () => {
+    expect(isPeerConflictOnly('npm ERR! code ERESOLVE\nnpm ERR! ERESOLVE could not resolve')).toBe(
+      true,
+    );
+    expect(isPeerConflictOnly('npm ERR! peer dep missing: react@^18')).toBe(true);
+  });
+  it('an out-of-sync lockfile (EUSAGE) is NOT, even when ERESOLVE text is around', () => {
+    expect(
+      isPeerConflictOnly(
+        'npm ERR! code EUSAGE\nnpm ERR! `npm ci` can only install packages when your package.json and package-lock.json are in sync.\nnpm ERR! Missing: left-pad@1.3.0 from lock file',
+      ),
+    ).toBe(false);
+    expect(isPeerConflictOnly('code EUSAGE ... ERESOLVE')).toBe(false);
+  });
+  it('an unrelated failure is neither', () => {
+    expect(isPeerConflictOnly('npm ERR! code ENOTFOUND')).toBe(false);
+    expect(isPeerConflictOnly('')).toBe(false);
+  });
+});
+
+describe('lockfileSyncCheck', () => {
+  it('npm: a non-installing dry-run that tolerates a peer conflict only', () => {
+    const c = lockfileSyncCheck('npm');
+    expect(c.kind).toBe('command');
+    if (c.kind !== 'command') return;
+    expect(c.argv).toEqual([
+      'npm',
+      'ci',
+      '--dry-run',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+    ]);
+    expect(c.tolerated?.matches('npm ERR! code ERESOLVE')).toBe(true);
+    expect(c.tolerated?.matches('npm ERR! code EUSAGE not in sync')).toBe(false);
+    expect(c.tolerated?.disclosure).toContain('--legacy-peer-deps');
+  });
+  it('pnpm and bun: frozen dry-runs with no tolerated failure', () => {
+    for (const pm of ['pnpm', 'bun'] as const) {
+      const c = lockfileSyncCheck(pm);
+      expect(c.kind).toBe('command');
+      if (c.kind !== 'command') return;
+      expect(c.argv[0]).toBe(pm);
+      expect(c.argv).toContain('--frozen-lockfile');
+      expect(c.tolerated).toBeUndefined();
+    }
+  });
+  it('yarn: a DISCLOSED skip, never a silent one', () => {
+    const c = lockfileSyncCheck('yarn');
+    expect(c.kind).toBe('skipped');
+    if (c.kind === 'skipped') expect(c.reason).toContain('immutable');
+  });
+});

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -225,6 +225,17 @@ const mockPlaybookPack = {
       buildTarget: 'none' as const,
       weight: 'cheap' as const,
     }),
+    // Lockfile-sync floor (4.4.5): a distinctive dry-run command proves the
+    // optional builder flows pack → runner, and that the runner (not the pack)
+    // decides WHEN it runs: full scope / a manifest-touching diff only.
+    lockfileCheck: () => ({
+      kind: 'command' as const,
+      command: { label: 'lockfile-sync', bin: 'playbookc-mock', args: ['lock', '--dry-run'] },
+      tolerated: {
+        matches: (output: string) => output.includes('PLAYBOOK-PEER-ONLY'),
+        disclosure: 'playbook peer conflict tolerated',
+      },
+    }),
   },
   // Lint-GATE contribution (custom-check flagship). Distinctive bin/parse so the
   // assertion verifies the synthetic pack's provider flows through
@@ -540,6 +551,72 @@ describe('recipe playbook — synthetic pack', () => {
       exec: () => ({ available: true, code: 0, output: '' }),
     });
     expect(sourceOnly.scopeEscalated).toBeUndefined();
+  });
+
+  // 4.4.5: the lockfile-sync check is pack-DECLARED but runner-SCHEDULED. The
+  // synthetic pack's distinctive dry-run must run at full scope (and on a
+  // manifest-touching diff, which escalates), and must NOT run on a
+  // source-only fast run — the over-run direction (every Stop paying a
+  // package-manager dry-run) is the regression that would make the fast
+  // surface slow.
+  it('runCorrectnessFloor schedules the mock pack lockfile check at full scope only (4.4.5)', () => {
+    const packs = [...LANGUAGES];
+    const seen: string[][] = [];
+    const exec = (cmd: { readonly bin: string; readonly args: readonly string[] }) => {
+      seen.push([cmd.bin, ...cmd.args]);
+      return { available: true, code: 0, output: '' };
+    };
+    const lockRan = () => seen.some((argv) => argv.join(' ') === 'playbookc-mock lock --dry-run');
+
+    runCorrectnessFloor({
+      cwd: '/nonexistent-repo',
+      changedFiles: ['a.pbk'],
+      scope: 'affected',
+      packs,
+      exec,
+    });
+    expect(lockRan(), 'a source-only affected run must not pay the dry-run').toBe(false);
+
+    seen.length = 0;
+    const full = runCorrectnessFloor({
+      cwd: '/nonexistent-repo',
+      changedFiles: [],
+      scope: 'full',
+      packs,
+      exec,
+    });
+    expect(lockRan()).toBe(true);
+    const lock = full.checks.find(
+      (c) => (c.pack as string) === 'playbook' && c.label === 'lockfile-sync',
+    );
+    expect(lock?.status).toBe('pass');
+
+    seen.length = 0;
+    runCorrectnessFloor({
+      cwd: '/nonexistent-repo',
+      changedFiles: ['playbook.lock'],
+      scope: 'affected',
+      packs,
+      exec,
+    });
+    expect(lockRan(), 'a manifest-touching diff escalates and runs the dry-run').toBe(true);
+
+    // The tolerated condition flows pack → runner: a PASS with the disclosure.
+    const tolerated = runCorrectnessFloor({
+      cwd: '/nonexistent-repo',
+      changedFiles: [],
+      scope: 'full',
+      packs,
+      exec: (cmd) =>
+        cmd.args.includes('--dry-run')
+          ? { available: true, code: 1, output: 'PLAYBOOK-PEER-ONLY' }
+          : { available: true, code: 0, output: '' },
+    });
+    const tol = tolerated.checks.find(
+      (c) => (c.pack as string) === 'playbook' && c.label === 'lockfile-sync',
+    );
+    expect(tol?.status).toBe('pass');
+    expect(tol?.note).toBe('playbook peer conflict tolerated');
   });
 
   // custom-check flagship: the lint gate iterates `activeLintGateProviders`, so a

--- a/test/remediate/dispatch.test.ts
+++ b/test/remediate/dispatch.test.ts
@@ -182,6 +182,12 @@ describe('runRemediateTask — the custom dispatch task', () => {
       git: fakeGit(),
       runFloor: () => GREEN_FLOOR,
       runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+      verifySeams: {
+        worktree: async <T>(_o: unknown, fn: (wt: string) => Promise<T>) =>
+          fn('/tmp/fake-worktree'),
+        install: () => ({ status: 'installed' as const, argv: ['npm', 'ci'] }),
+        changedFiles: () => ['src/a.ts'],
+      },
     });
     expect(r.outcome).toBe('refused');
     expect(r.note).toContain('prompt');
@@ -199,6 +205,12 @@ describe('runRemediateTask — the custom dispatch task', () => {
       git: fakeGit(),
       runFloor: () => GREEN_FLOOR,
       runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+      verifySeams: {
+        worktree: async <T>(_o: unknown, fn: (wt: string) => Promise<T>) =>
+          fn('/tmp/fake-worktree'),
+        install: () => ({ status: 'installed' as const, argv: ['npm', 'ci'] }),
+        changedFiles: () => ['src/a.ts'],
+      },
       dispatch: {
         budget: DEFAULT_REMEDIATE_BUDGET,
         customPrompt: 'Raise docstring coverage in src/api only.',

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -225,6 +225,11 @@ function base(driver: AgentDriver, extra: Partial<Parameters<typeof runRemediate
     git: fakeGit({ diff: true }),
     runFloor: () => RED_FLOOR,
     runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+    verifySeams: {
+      worktree: async <T>(_o: unknown, fn: (wt: string) => Promise<T>) => fn('/tmp/fake-worktree'),
+      install: () => ({ status: 'installed' as const, argv: ['npm', 'ci'] }),
+      changedFiles: () => ['src/a.ts'],
+    },
     ...extra,
   };
 }

--- a/test/remediate/resume.test.ts
+++ b/test/remediate/resume.test.ts
@@ -201,6 +201,12 @@ describe('runRemediateTask — resumed attempts', () => {
       resume: { attempt: 1 },
       runFloor: () => RED, // only the verify side runs — entry came in
       runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+      verifySeams: {
+        worktree: async <T>(_o: unknown, fn: (wt: string) => Promise<T>) =>
+          fn('/tmp/fake-worktree'),
+        install: () => ({ status: 'installed' as const, argv: ['npm', 'ci'] }),
+        changedFiles: () => ['src/a.ts'],
+      },
     });
     expect(r.outcome).toBe('floor-red');
     expect(r.resume).toEqual({ attempt: 1 });
@@ -219,6 +225,12 @@ describe('runRemediateTask — resumed attempts', () => {
       resume: { attempt: 2 },
       runFloor: () => GREEN,
       runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+      verifySeams: {
+        worktree: async <T>(_o: unknown, fn: (wt: string) => Promise<T>) =>
+          fn('/tmp/fake-worktree'),
+        install: () => ({ status: 'installed' as const, argv: ['npm', 'ci'] }),
+        changedFiles: () => ['src/a.ts'],
+      },
     });
     expect(r.outcome).toBe('verified');
     expect(driver.lastRun?.prompt).toContain('RESUMED ATTEMPT #2');

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -116,7 +116,9 @@ function base(driver: AgentDriver, extra: Partial<Parameters<typeof runRemediate
 }
 
 const FAKE_TREE: NonNullable<Parameters<typeof runRemediateTask>[0]['verifySeams']> = {
-  worktree: async (_o, fn) => fn('/tmp/fake-worktree'),
+  // Ref-addressed paths so an install seam can fail the CANDIDATE while the
+  // base-attribution probe (a second worktree at baseHead) installs clean.
+  worktree: async (o, fn) => fn(`/wt/${o.ref}`),
   install: () => ({ status: 'installed', argv: ['npm', 'ci'] }),
   changedFiles: () => ['src/a.ts'],
 };
@@ -283,12 +285,17 @@ describe('the verified frame (the agent is never trusted)', () => {
       base(fakeDriver({ completed: true }), {
         verifySeams: {
           ...FAKE_TREE,
-          install: () => ({
-            status: 'failed',
-            argv: ['npm', 'ci', '--legacy-peer-deps'],
-            output:
-              'npm ERR! code EUSAGE\nnpm ERR! package.json and package-lock.json are not in sync',
-          }),
+          // Fails the candidate only: the base-attribution probe installs
+          // clean, so the failure is NET-NEW and the verdict blames the run.
+          install: (wt) =>
+            wt.endsWith('head1111')
+              ? {
+                  status: 'failed',
+                  argv: ['npm', 'ci', '--legacy-peer-deps'],
+                  output:
+                    'npm ERR! code EUSAGE\nnpm ERR! package.json and package-lock.json are not in sync',
+                }
+              : { status: 'installed', argv: ['npm', 'ci'] },
         },
       }),
     );
@@ -296,6 +303,27 @@ describe('the verified frame (the agent is never trusted)', () => {
     expect(r.note).toContain('EUSAGE');
     expect(r.ledger).toContain('outcome: **install-failed**');
     expect(r.ledger).toContain('FAILED on a clean checkout');
+    // The guardrail was deliberately not consulted — the ledger says so,
+    // never a fabricated failure.
+    expect(r.guardrailVerdict).toBe('not consulted (verification stopped at install)');
+  });
+
+  it('a PRE-EXISTING broken install (base fails too) is disclosed, never blamed — the run still verifies', async () => {
+    const r = await runRemediateTask(
+      base(fakeDriver({}), {
+        verifySeams: {
+          ...FAKE_TREE,
+          install: () => ({
+            status: 'failed',
+            argv: ['npm', 'ci'],
+            output: 'npm ERR! code EUSAGE',
+          }),
+        },
+      }),
+    );
+    expect(r.outcome).toBe('verified');
+    expect(r.ledger).toContain('pre-existing');
+    expect(r.ledger).toContain('not caused by this change');
   });
 
   it('the verification runs against the committed HEAD in a clean worktree, diff-scoped vs base', async () => {

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -107,9 +107,19 @@ function base(driver: AgentDriver, extra: Partial<Parameters<typeof runRemediate
     git: fakeGit({ diff: true }),
     runFloor: () => GREEN_FLOOR,
     runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+    // The ONE tree verification (4.4.5) runs in a clean worktree after a
+    // frozen install; both are seamed here so no git repo or package manager
+    // is needed. The floor + guardrail seams above are forwarded into it.
+    verifySeams: FAKE_TREE,
     ...extra,
   };
 }
+
+const FAKE_TREE: NonNullable<Parameters<typeof runRemediateTask>[0]['verifySeams']> = {
+  worktree: async (_o, fn) => fn('/tmp/fake-worktree'),
+  install: () => ({ status: 'installed', argv: ['npm', 'ci'] }),
+  changedFiles: () => ['src/a.ts'],
+};
 
 describe('refusal + infra arms (each truthful and distinct)', () => {
   it('refuses an untrusted tree before anything spawns', async () => {
@@ -262,6 +272,70 @@ describe('the verified frame (the agent is never trusted)', () => {
     expect(r.outcome).toBe('floor-red');
     expect(r.note).toContain('NET-NEW');
     expect(r.ledger).toContain('FAILED — net-new failures');
+  });
+
+  // 4.4.5: the lane verifies the COMMITTED head on a clean checkout with the
+  // repo's frozen install, exactly as CI will. A tree CI cannot install is
+  // its own outcome and lands nothing; the ledger says what CI's install
+  // step would have done.
+  it('install-failed: a clean checkout CI cannot install lands nothing, even with a green floor', async () => {
+    const r = await runRemediateTask(
+      base(fakeDriver({ completed: true }), {
+        verifySeams: {
+          ...FAKE_TREE,
+          install: () => ({
+            status: 'failed',
+            argv: ['npm', 'ci', '--legacy-peer-deps'],
+            output:
+              'npm ERR! code EUSAGE\nnpm ERR! package.json and package-lock.json are not in sync',
+          }),
+        },
+      }),
+    );
+    expect(r.outcome).toBe('install-failed');
+    expect(r.note).toContain('EUSAGE');
+    expect(r.ledger).toContain('outcome: **install-failed**');
+    expect(r.ledger).toContain('FAILED on a clean checkout');
+  });
+
+  it('the verification runs against the committed HEAD in a clean worktree, diff-scoped vs base', async () => {
+    let ref: string | undefined;
+    let floorArgs: unknown;
+    const r = await runRemediateTask(
+      base(fakeDriver({}), {
+        verifySeams: {
+          ...FAKE_TREE,
+          worktree: async (o, fn) => {
+            ref = o.ref;
+            return fn('/tmp/clean-wt');
+          },
+          changedFiles: (wt, baseHead) => {
+            floorArgs = { wt, baseHead };
+            return ['src/a.ts'];
+          },
+        },
+      }),
+    );
+    expect(r.outcome).toBe('verified');
+    expect(ref).toBe('head1111');
+    expect(floorArgs).toEqual({ wt: '/tmp/clean-wt', baseHead: 'base0000' });
+    expect(r.ledger).toContain('`npm ci` succeeded on a clean checkout');
+  });
+
+  it('a verification that cannot run (worktree failure) fails CLOSED with the step named', async () => {
+    const r = await runRemediateTask(
+      base(fakeDriver({}), {
+        verifySeams: {
+          ...FAKE_TREE,
+          worktree: async () => {
+            throw new Error('Cannot resolve baseline ref head1111.');
+          },
+        },
+      }),
+    );
+    expect(r.outcome).toBe('guardrail-red');
+    expect(r.guardrailVerdict).toContain("step 'worktree'");
+    expect(r.note).toContain('could not run');
   });
 
   it('pre-existing floor debt discloses without blocking', async () => {
@@ -609,7 +683,14 @@ describe('WP5: fast-exit, phases, cap accounting, blocked evidence', () => {
     const phases: string[] = [];
     const r = await runRemediateTask(base(fakeDriver({}), { onPhase: (p) => phases.push(p) }));
     expect(r.outcome).toBe('verified');
-    expect(phases).toEqual(['entry-floor', 'agent', 'sweep', 'verify-floor', 'guardrail']);
+    expect(phases).toEqual([
+      'entry-floor',
+      'agent',
+      'sweep',
+      'verify-install',
+      'verify-floor',
+      'guardrail',
+    ]);
   });
 
   it('a guardrail-red ledger names the blocking findings (evidence survives the runner)', async () => {

--- a/test/templates-lane-tokens.test.ts
+++ b/test/templates-lane-tokens.test.ts
@@ -33,6 +33,7 @@ import {
   LANE_TOKEN_SUBSTITUTIONS,
   LANE_TOKEN_TASK_STEPS,
 } from '../src/lanes/lane-token';
+import { INSTALL_DEPS_PLACEHOLDER, renderInstallDependenciesShell } from '../src/package-manager';
 
 const WORKFLOWS = path.join(__dirname, '..', 'src-templates', '.github', 'workflows');
 
@@ -131,6 +132,11 @@ function renderForParse(content: string): string {
   for (const [key, value] of Object.entries(LANE_TOKEN_SUBSTITUTIONS)) {
     out = out.split(key).join(value);
   }
+  // The dependency-install block renders unconditionally too (4.4.5), so the
+  // parse below sees the real multi-line shell body at the `run: |` indent.
+  out = out
+    .split(`          ${INSTALL_DEPS_PLACEHOLDER}`)
+    .join(renderInstallDependenciesShell('          '));
   // Whole-line placeholders (multi-line slots: runtime setup, fragment jobs)
   // vanish; inline placeholders become inert identifiers.
   out = out.replace(/^__DXKIT_[A-Z_]+__$/gm, '');


### PR DESCRIPTION
## What

The remediate lane certified trees CI could not install. In-lane verification ran on the agent's dirty workspace with whatever `node_modules` the agent last installed, at full scope with an empty changed-set; CI runs a fresh frozen-lockfile install and then the gate. A real run pushed a "verified" draft whose `package.json` was ahead of its lockfile; CI's `npm ci` died with EUSAGE and the PR read "NOT gated". Design doc section D: one verification, shared with CI.

Three pieces, one concept each:

1. **`src/package-manager.ts` owns the frozen install and the lockfile-sync dry-run.** One `INSTALL_BRANCHES` table (pnpm / yarn / bun / npm ci / npm install / no manifest, with the `--legacy-peer-deps` fallback) is rendered two ways: `renderInstallDependenciesShell` for the workflow templates and `frozenInstallFor` for the lane. `lockfileSyncCheck(pm)` gives the non-installing dry-run per PM (npm `ci --dry-run`, pnpm `--frozen-lockfile --lockfile-only`, bun `--frozen-lockfile --dry-run`; yarn is a disclosed skip because neither classic nor berry has a non-installing frozen check). `isPeerConflictOnly` is the one classifier telling ERESOLVE (tolerated, CI retries with the flag) from EUSAGE (a real failure); the dep-bump lane now reads it too instead of its inline regex.

2. **A lockfile-sync floor item (Rule 15).** `CorrectnessProvider.lockfileCheck` is an optional pure builder; the TypeScript pack implements it, the other packs decline by omission. The runner schedules it ONCE: full scope only, which after the existing manifest escalation means "CI, or a diff that touched a manifest". A tolerated failure passes with a `note` every renderer shows; a stale lockfile fails with the remedy. The arch-check's correctness-runner rule now covers `.lockfileCheck(`.

3. **One `verifyTree` (`src/lanes/verify-tree.ts`).** Given a candidate head: a clean worktree via Rule 11's `withRefWorktree`, the repo's frozen install with its fallback, the floor diff-scoped against `baseHead` (`computeChangedFiles`, scope `affected`, the runner escalates on manifests), attribution vs the entry floor through the one comparator, then the guardrail. Every infrastructure failure is a `GateFailure`-shaped step failure (`worktree` / `install` / `changed-files` / `floor` / `attribution` / `guardrail`); an install that ran and failed is its own verdict. The remediate runner calls this instead of running the floor on its cwd; a failed install is the new `install-failed` outcome (nothing lands), a verification that could not run stays in the fail-closed `guardrail-red` arm with the step named. The ledger gains an install line.

The twelve workflow templates that carried a hand-copied install chain now carry `__DXKIT_INSTALL_DEPS__`, substituted unconditionally by the one workflow writer next to the lane-token chain. The deep-SAST refresh template had already drifted (npm-only chain); it now renders the same block as everyone else.

## Rendered-output change (live-fire required before release)

Rendered workflows change in two ways: comment lines that lived inside the install chain are now emitted above it (guardrails, deep-SAST), and `dxkit-deep-sast-refresh.yml` gains the pnpm/yarn/bun branches it was missing. The install commands themselves are byte-identical for every other template (pinned by `test/install-deps-template.test.ts`). Per the standing rule, a live-fire run of the lane templates is required before release; not attempted here.

## Tests

- `test/lanes/verify-tree.test.ts`: install fails → `install-failed`, floor and guardrail never run; fallback disclosed; floor net-new → `floor-red`; pre-existing debt passes; the floor runs in the worktree with the real diff; worktree / package-manager / guardrail infrastructure failures → `error` with the step named; step order.
- `test/package-manager-frozen-install.test.ts`: `frozenInstallFor` per lockfile, the parity pin (every argv the lane runs is a line of the rendered shell), `isPeerConflictOnly` both directions, `lockfileSyncCheck` per PM.
- `test/install-deps-template.test.ts`: no inline chain survives in any template; every template that runs dxkit on a checkout carries the placeholder (content-derived, `dxkit-gate-host.yml` a declared exemption); the writer renders the block end to end and the result parses as YAML.
- `test/correctness-lockfile-sync.test.ts`: on the real TS pack, stale lock fails, ERESOLVE-only passes with the flag disclosed, in-sync passes, source-only affected runs never pay the dry-run, yarn is a disclosed skip, missing PM is fail-open.
- `test/recipe-playbook.test.ts`: the synthetic pack declares `lockfileCheck`; the runner picks it up at full scope and on a manifest diff, not on a source-only run; the tolerated condition flows through.
- `test/languages-contract.test.ts`: `lockfileCheck` shape contract.
- `test/remediate/run.test.ts`: seams for the clean worktree + install; `install-failed`; the verification targets the committed HEAD diff-scoped vs base; an unrunnable verification fails closed with the step named; phase order gains `verify-install`.
- `test/templates-lane-tokens.test.ts`: the YAML-validity render applies the real install substitution.

## Sweep

typecheck, typecheck:test, eslint, prettier, check-architecture, check-docs-coverage, check-slop, build, vitest --coverage, check-coverage: all green (385 files, 5742 tests; coverage 72.8% vs 50% floor)

`guardrail check --mode ref-based --ref origin/main`: PASSED (an interim BLOCKED on two large-file findings was fixed by the size refactor commit, not allowlisted)

## Review focus

- `src/package-manager.ts` `lockfileSyncCheck`: the per-PM dry-run flags and the documented uncertainty (pnpm `--lockfile-only` with `--frozen-lockfile`; yarn deliberately skipped). npm 7+ semantics assumed (Node 18 floor ships npm 9).
- `src/analyzers/correctness/run.ts` `runLockfileCheck`: the tolerated-failure path yields `pass` + `note`, never a silent pass.
- `src/lanes/verify-tree.ts`: fail-open discipline (infrastructure → `error` + step) vs the one real verdict (`install-failed`); the remediate consumer maps `error` into its existing fail-closed arm.
- Template placeholder substitution in `installWorkflow` sits beside the lane-token loop; the comment-hoisting in the guardrails / deep-SAST templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
