### PR TITLE
feat(remediate): executable recipe tier inside the frame (4.4.5 recipe-executor)

### DIFF
--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -660,7 +660,10 @@ attributed floor, guardrail) remains the arbiter of the combined result.
 When every selected order is recipe-tier, the run completes with no agent
 spawn at all: a $0 remediate run. A recipe that cannot act refuses with the
 reason in the ledger; a recipe whose own verify does not confirm discards
-its diff, and the order stays open for the agent tier.
+its diff. When such a recipe-only run fixes nothing (every recipe refused
+or failed), the outcome is `recipes-refused`, a non-clean result the
+scheduled lane surfaces, never a green no-op that would quietly starve the
+same orders week after week.
 
 **Default and why.** `true` when remediation is used at all: a deterministic
 fix that verifies is strictly cheaper and more reliable than an agent

--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -47,6 +47,7 @@ stanzas).
 | `remediate.enabled`                 | [#remediate](#remediate)                                 |
 | `remediate.maxDispatchBudget`       | [#remediate-dispatch-budget](#remediate-dispatch-budget) |
 | `remediate.maxSpendPerRun`          | [#remediate-spend-per-run](#remediate-spend-per-run)     |
+| `remediate.recipes.enabled`         | [#remediate-recipes](#remediate-recipes)                 |
 | `remediate.resume`                  | [#remediate-resume](#remediate-resume)                   |
 | `remediate.salvage`                 | [#remediate-salvage](#remediate-salvage)                 |
 | `remediate.schedule`                | [#remediate-schedule](#remediate-schedule)               |
@@ -626,10 +627,10 @@ branch to resume and starts fresh.
 **What it does.** `vyuh-dxkit remediate plan` cuts the finding sets dxkit
 already computes (the entry floor's failures, deferred advisories inside
 their window, the grandfathered lint backlog) into finite work orders and
-lists them with their class, tier, budget, and done criterion. Today this is
-a plan surface: the tasks still run their existing prompts. Task selection
-over orders (each task working only the orders of its classes) arrives with
-the executor unit, which consumes these same orders.
+lists them with their class, tier, budget, and done criterion. The remediate
+run consumes the same plan: recipe-tier orders execute deterministically
+first (see [Remediate recipes](#remediate-recipes)); agent-tier orders still
+run through the task prompts.
 
 **Per parameter.**
 
@@ -641,3 +642,37 @@ the executor unit, which consumes these same orders.
 
 **Default and why.** `25`: a slice one agent session closes with headroom
 in the derived budget.
+
+## Remediate recipes
+
+**What it does.** With `remediate.recipes.enabled` (default `true`), the
+remediate run executes recipe-tier work orders deterministically BEFORE any
+agent spawns: a stale lockfile is re-synced with the repo's own package
+manager and confirmed by the frozen dry-run; a fixable transitive advisory
+is pinned through an npm override (the candidate version is OSV pre-checked,
+and a pin that would leave a block-tier advisory in place is refused with
+the advisory named); a net-new unresolved bare import is declared and
+installed after the same OSV pre-check; a file's located lint findings run
+through the pack linter's own fix mode. Each recipe commits inside its
+order's envelope (out-of-envelope changes are discarded and disclosed), and
+the run's single tree verification (clean worktree, frozen install,
+attributed floor, guardrail) remains the arbiter of the combined result.
+When every selected order is recipe-tier, the run completes with no agent
+spawn at all: a $0 remediate run. A recipe that cannot act refuses with the
+reason in the ledger; a recipe whose own verify does not confirm discards
+its diff, and the order stays open for the agent tier.
+
+**Default and why.** `true` when remediation is used at all: a deterministic
+fix that verifies is strictly cheaper and more reliable than an agent
+attempt at the same order. Set `false` to route every order to the agent
+(for example while evaluating the recipes' behavior on an unusual repo
+layout).
+
+**Interactions.** Recipes run only where the trust context allows repo
+execution (they run package-manager and linter commands); an untrusted tree
+yields disclosed per-order refusals. Recipe availability varies by
+ecosystem this release: lockfile re-sync and dependency declaration cover
+the npm-family package managers (yarn's missing dry-run is a disclosed
+refusal), override pinning is npm only, and lint autofix requires the pack
+to declare a fix mode (TypeScript/JavaScript's eslint today). Everything a
+recipe declines is a named refusal, never a silent skip.

--- a/src/analyzers/correctness/single-checks.ts
+++ b/src/analyzers/correctness/single-checks.ts
@@ -1,0 +1,44 @@
+/**
+ * Single-check entry points for the recipe tier (4.4.5). A pack's floor
+ * builders may only be invoked inside `src/analyzers/correctness/` (the
+ * arch-check's correctness-floor rule), so a recipe that needs ONE check's
+ * verdict ("is the lockfile in sync now?", "does the specifier resolve
+ * now?") asks through these helpers instead of paying a whole
+ * `runCorrectnessFloor` pass or re-implementing the builders' policy.
+ *
+ * Both reuse the exact executors the floor runner uses (`runLockfileCheck`,
+ * `runResolutionCheck`), so a recipe's verify and the floor's verdict can
+ * never diverge (Rule 2.30: one concept, one code path). `null` means the
+ * pack declares no such check, or declined for this repo (no lockfile);
+ * the CALLER decides what an unverifiable state means (the recipes refuse:
+ * they never claim what they cannot confirm).
+ */
+import { getLanguage } from '../../languages';
+import type { LanguageId } from '../../languages/types';
+import type { CommandExec } from '../tools/bounded-exec';
+import { runLockfileCheck } from './lockfile-check';
+import { runResolutionCheck } from './pure-checks';
+import type { CorrectnessCheckResult } from './run';
+
+const FULL_CTX = { changedFiles: [] as const, scope: 'full' as const };
+
+/** Run ONE pack's lockfile-sync check (the frozen dry-run) for `cwd`. */
+export function runSingleLockfileCheck(
+  cwd: string,
+  packId: string,
+  exec: CommandExec,
+): CorrectnessCheckResult | null {
+  const provider = getLanguage(packId as LanguageId)?.correctness;
+  if (!provider?.lockfileCheck) return null;
+  return runLockfileCheck(packId as LanguageId, provider, { cwd, ...FULL_CTX }, exec);
+}
+
+/** Run ONE pack's import-resolution check for `cwd` (pure computation). */
+export function runSingleResolutionCheck(
+  cwd: string,
+  packId: string,
+): CorrectnessCheckResult | null {
+  const provider = getLanguage(packId as LanguageId)?.correctness;
+  if (!provider?.resolutionCheck) return null;
+  return runResolutionCheck(packId as LanguageId, provider, { cwd, ...FULL_CTX });
+}

--- a/src/analyzers/tools/osv.ts
+++ b/src/analyzers/tools/osv.ts
@@ -460,3 +460,41 @@ export async function resolveAliases(
 export function __clearOsvCache(): void {
   cache.clear();
 }
+
+// ---------------------------------------------------------------------------
+// Query-by-package (4.4.5, the recipe tier's pre-check): "which advisories
+// affect pkg@version?" via the OSV /v1/query endpoint, kept in this module so
+// there is exactly ONE OSV client (Rule 2). The recipes use it as a
+// $0 refusal gate BEFORE installing or pinning a candidate version, turning
+// "the agent installed a vulnerable package and the guardrail went red" into
+// "the recipe refused, with the advisory named".
+// ---------------------------------------------------------------------------
+
+/**
+ * The injectable query function. Returns the advisories affecting
+ * `pkg@version` in `ecosystem` (OSV ecosystem name, e.g. `npm`), or `null`
+ * when the query could not be answered (network failure, non-OK response);
+ * callers DISCLOSE a null and fall back to their downstream gate (the
+ * guardrail re-audit), never treat it as "no advisories".
+ */
+export type OsvPackageQuery = (
+  pkg: string,
+  version: string,
+  ecosystem: string,
+) => Promise<OsvVuln[] | null>;
+
+export const queryOsvPackage: OsvPackageQuery = async (pkg, version, ecosystem) => {
+  try {
+    const res = await fetch('https://api.osv.dev/v1/query', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ package: { name: pkg, ecosystem }, version }),
+      signal: AbortSignal.timeout(OSV_REQUEST_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { vulns?: OsvVuln[] };
+    return Array.isArray(body.vulns) ? body.vulns : [];
+  } catch {
+    return null;
+  }
+};

--- a/src/baseline/changed-files.ts
+++ b/src/baseline/changed-files.ts
@@ -25,7 +25,10 @@ import * as path from 'path';
 /** Best-effort git stdout as lines; throws are surfaced to the caller so
  *  it can fail safe. `args` is fixed + caller-controlled (no shell). */
 function gitLines(cwd: string, args: string[]): string[] {
-  const out = execFileSync('git', args, {
+  // core.quotepath=false: git otherwise C-escapes non-ASCII path bytes
+  // ("s\303\244"), and an escaped name matches no real file, so envelope
+  // checks and per-path operations downstream silently miss those paths.
+  const out = execFileSync('git', ['-c', 'core.quotepath=false', ...args], {
     cwd,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'ignore'],

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -257,6 +257,12 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
     summary: 'largest number of findings one debt work order may carry (default 25)',
     anchor: 'remediate-work-orders',
   },
+  {
+    path: 'remediate.recipes.enabled',
+    summary:
+      'run deterministic recipe-tier work orders inside the frame before any agent spawns (default true)',
+    anchor: 'remediate-recipes',
+  },
 ];
 
 const paramByPath = new Map(POLICY_PARAMS.map((p) => [p.path, p]));

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -365,6 +365,13 @@ export function buildPolicySchema(version: string): Schema {
             },
             'Work-order planning: how the backlog is cut into finite, verifiable units.',
           ),
+          recipes: obj(
+            {
+              enabled: boolProp('remediate.recipes.enabled'),
+            },
+            'The deterministic recipe tier: recipe work orders execute in the frame ' +
+              'before any agent spawns.',
+          ),
           resume: boolProp('remediate.resume'),
         },
         'Agentic remediation: a scheduled agent inside the verified frame.',

--- a/src/languages/capabilities/lint-gate.ts
+++ b/src/languages/capabilities/lint-gate.ts
@@ -108,11 +108,33 @@ export interface LintGateRecallContext extends LintGateContext {
 
 import type { ExecutionRequirement } from '../../execution';
 
+/** What the lint-autofix recipe hands a pack's fix builder: the repo and the
+ *  exact files a work order allows the fixer to touch. */
+export interface LintFixContext {
+  readonly cwd: string;
+  /** Repo-relative files the fix run may rewrite: the work order's
+   *  envelope, never the whole tree. */
+  readonly files: readonly string[];
+}
+
 /** A pack's lint-gate provider. Pure command builder — it resolves the linter
  *  and returns the command (or `null` to skip); execution + fail-open policy
  *  live in the custom-check runner (a pack never shells out itself). */
 export interface LintGateProvider {
   lintCommand(ctx: LintGateContext): LintGateCommand | null;
+
+  /**
+   * OPTIONAL (4.4.5, the lint-autofix recipe): the linter's own fix mode,
+   * scoped to `ctx.files`. Same pure-builder contract as `lintCommand`:
+   * the recipe executor runs it through bounded exec under the required
+   * trust context; the pack never shells out. The command's `parse` reads
+   * the REMAINING (unfixed) findings out of the same run, so one execution
+   * both applies the ecosystem's fixes and reports what it could not fix;
+   * that leftover set is the recipe's verify input. A pack without a
+   * stable fix mode omits this; the recipe then refuses its orders with
+   * the reason named (declared absence, never a silent skip).
+   */
+  fixCommand?(ctx: LintFixContext): LintGateCommand | null;
 
   /**
    * What the gate NEEDS from the environment that runs it (CLAUDE.md Rule 20).

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -2372,6 +2372,21 @@ const tsLintGateProvider: LintGateProvider = {
       expectedExit: 0,
     };
   },
+  // The lint-autofix recipe's fix mode (4.4.5): `eslint --fix` scoped to the
+  // work order's files. One run both writes the auto-fixes and reports the
+  // remaining (unfixable) findings through the SAME json parser the gate
+  // uses, so the recipe's verify reads the leftovers of the very command
+  // that fixed. eslint exits 1 when unfixed errors remain; the recipe
+  // parses regardless of exit (the seam's own doctrine).
+  fixCommand(ctx) {
+    if (ctx.files.length === 0 || !hasLocalBin(ctx.cwd, 'eslint')) return null;
+    return {
+      bin: 'npx',
+      args: ['--no-install', 'eslint', '--fix', '--format', 'json', ...ctx.files],
+      parse: { kind: 'structured', label: 'eslint-json', parse: parseEslintJson },
+      expectedExit: 0,
+    };
+  },
   recallInputs(ctx) {
     // eslint sees what its PLUGINS tell it to see, and the argv never mentions
     // them. `eslint-plugin-react-hooks ^7.0.1 -> 7.1.1` adds rules under a

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -390,3 +390,50 @@ export function lockfileSyncCheck(pm: PackageManager): LockfileSyncCheck {
       };
   }
 }
+
+// ---------------------------------------------------------------------------
+// Lock-WRITING install (the recipe tier's resync, 4.4.5): the ONE definition
+// of "make the lockfile record the manifest" per PM, beside the frozen table
+// above so the two cannot drift. A frozen install (`npm ci`) REFUSES an
+// out-of-sync lockfile by design; repairing one needs the ecosystem's
+// re-resolving install. Fabricating a different tree is exactly what the
+// frozen CI install exists to prevent, so this command is only ever run by a
+// surface whose PURPOSE is to update the lockfile (the lockfile-sync /
+// override-pin recipes), never by a verification.
+// ---------------------------------------------------------------------------
+
+/** The install that (re)writes the lockfile from the manifest, with the same
+ *  declared fallback doctrine as the frozen table (`isPeerConflictOnly` is
+ *  the shared gate on when the fallback may run). */
+export interface ResyncInstall {
+  readonly pm: PackageManager;
+  readonly argv: readonly string[];
+  readonly fallback?: { readonly argv: readonly string[]; readonly reason: string };
+}
+
+/**
+ * The lock-writing install per PM. npm re-resolves and writes
+ * `package-lock.json` (`--no-audit --no-fund` keeps it quiet and offline-ish);
+ * its peer-conflict fallback mirrors the frozen install's declared doctrine.
+ * pnpm/yarn/bun re-resolve and write their lockfiles by default; pnpm gets the
+ * explicit flag because a CI environment flips its default to frozen.
+ */
+export function resyncInstallFor(pm: PackageManager): ResyncInstall {
+  switch (pm) {
+    case 'npm':
+      return {
+        pm,
+        argv: ['npm', 'install', '--no-audit', '--no-fund'],
+        fallback: {
+          argv: ['npm', 'install', '--legacy-peer-deps', '--no-audit', '--no-fund'],
+          reason: LEGACY_PEER_DEPS_REASON,
+        },
+      };
+    case 'pnpm':
+      return { pm, argv: ['pnpm', 'install', '--no-frozen-lockfile'] };
+    case 'yarn':
+      return { pm, argv: ['yarn', 'install'] };
+    case 'bun':
+      return { pm, argv: ['bun', 'install'] };
+  }
+}

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -402,21 +402,30 @@ export function lockfileSyncCheck(pm: PackageManager): LockfileSyncCheck {
 // override-pin recipes), never by a verification.
 // ---------------------------------------------------------------------------
 
-/** The install that (re)writes the lockfile from the manifest, with the same
- *  declared fallback doctrine as the frozen table (`isPeerConflictOnly` is
- *  the shared gate on when the fallback may run). */
+/** The install that (re)writes the lockfile from the manifest. A fallback is
+ *  a DECLARED doctrine, never a blanket retry: `matches` names the one
+ *  primary-failure shape the fallback answers (npm's peer conflict via the
+ *  shared `isPeerConflictOnly`; yarn classic rejecting a berry-only flag). */
 export interface ResyncInstall {
   readonly pm: PackageManager;
   readonly argv: readonly string[];
-  readonly fallback?: { readonly argv: readonly string[]; readonly reason: string };
+  readonly fallback?: {
+    readonly argv: readonly string[];
+    readonly reason: string;
+    readonly matches: (output: string) => boolean;
+  };
 }
 
 /**
  * The lock-writing install per PM. npm re-resolves and writes
  * `package-lock.json` (`--no-audit --no-fund` keeps it quiet and offline-ish);
  * its peer-conflict fallback mirrors the frozen install's declared doctrine.
- * pnpm/yarn/bun re-resolve and write their lockfiles by default; pnpm gets the
- * explicit flag because a CI environment flips its default to frozen.
+ * The CI-default trap: pnpm flips to `--frozen-lockfile` and yarn berry to
+ * `--immutable` whenever CI is set, exactly where the scheduled lane runs, so
+ * both carry the explicit mutable flag. yarn classic (v1) does not know
+ * `--no-immutable`; the declared fallback drops to its plain install, which
+ * is already lock-writing. bun has no CI flip (that is what its separate
+ * `bun ci` alias is for), so its plain install stays lock-writing as is.
  */
 export function resyncInstallFor(pm: PackageManager): ResyncInstall {
   switch (pm) {
@@ -427,12 +436,23 @@ export function resyncInstallFor(pm: PackageManager): ResyncInstall {
         fallback: {
           argv: ['npm', 'install', '--legacy-peer-deps', '--no-audit', '--no-fund'],
           reason: LEGACY_PEER_DEPS_REASON,
+          matches: isPeerConflictOnly,
         },
       };
     case 'pnpm':
       return { pm, argv: ['pnpm', 'install', '--no-frozen-lockfile'] };
     case 'yarn':
-      return { pm, argv: ['yarn', 'install'] };
+      return {
+        pm,
+        argv: ['yarn', 'install', '--no-immutable'],
+        fallback: {
+          argv: ['yarn', 'install'],
+          reason:
+            'yarn classic (v1) does not know --no-immutable; its plain install already ' +
+            'writes the lockfile',
+          matches: (output) => /no-immutable|unknown (option|flag)/i.test(output),
+        },
+      };
     case 'bun':
       return { pm, argv: ['bun', 'install'] };
   }

--- a/src/remediate/agent-trust.ts
+++ b/src/remediate/agent-trust.ts
@@ -280,3 +280,18 @@ export function armInLoopGate(
   }
   return probeStopGateWiring(cwd, opts);
 }
+
+import type { AgentDriver } from './driver';
+
+/** The runner's default in-loop-gate probe for a driver: arm the Claude
+ *  Stop-hook mechanism where the driver has one, else an honest
+ *  backstop-only status with the reason. Injectable in the runner via
+ *  `armInLoopGate` (tests); phrased here so the runner stays lean. */
+export function armGateForDriver(driver: AgentDriver, cwd: string): InLoopGateStatus {
+  return driver.inLoopGateMechanism === 'claude-stop-hook'
+    ? armInLoopGate(cwd, { ci: process.env.GITHUB_ACTIONS === 'true' })
+    : {
+        mode: 'backstop-only',
+        reason: `driver ${driver.id} has no in-loop gate mechanism; post-run verification is the gate`,
+      };
+}

--- a/src/remediate/budget-notes.ts
+++ b/src/remediate/budget-notes.ts
@@ -71,3 +71,17 @@ export function unenforceableCapsFor(driver: AgentDriver, budget: RemediateBudge
   }
   return caps;
 }
+
+/** The budget-awareness paragraph appended to every agent prompt: the agent
+ *  is TOLD its caps so it lands work in mergeable increments instead of
+ *  being surprised mid-edit by the kill. Phrased here, the one home of
+ *  budget wording, never baked into the task prompts. */
+export function budgetPromptNote(budget: RemediateBudget): string {
+  return (
+    `\nBudget for this run (runner-enforced): ~${budget.maxMinutes} minutes, ` +
+    `${budget.maxTurns} turns, $${budget.maxUsd}. Commit completed units as you go, and ` +
+    `reserve the final minutes to commit ALL remaining work and record where you stopped ` +
+    `in docs/DXKIT-REMEDIATION-NOTES.md, since work committed before the cap survives ` +
+    `while uncommitted edits are swept into a single unlabeled-context commit.`
+  );
+}

--- a/src/remediate/budget-notes.ts
+++ b/src/remediate/budget-notes.ts
@@ -7,7 +7,7 @@
  */
 
 import { LANE_TOKEN_PAT_SECRET_NAME } from '../lanes/lane-token';
-import type { AgentDriver } from './driver';
+import type { AgentDriver, AgentRunResult } from './driver';
 import type { RemediateBudget } from './config';
 
 /**
@@ -84,4 +84,27 @@ export function budgetPromptNote(budget: RemediateBudget): string {
     `in docs/DXKIT-REMEDIATION-NOTES.md, since work committed before the cap survives ` +
     `while uncommitted edits are swept into a single unlabeled-context commit.`
   );
+}
+
+/** Post-run budget-overrun facts, derived only where dxkit may claim them:
+ *  a reported cost over the advisory cap is an honest post-hoc statement
+ *  for any driver that at least REPORTS cost, while a turn cap counts as
+ *  HIT only when the driver ENFORCES turns (a report-only driver would
+ *  mislabel a natural completion as budget-exhausted while the envelope
+ *  discloses the cap as unenforceable). Lives beside the other budget
+ *  phrasing/derivations, the one home of budget reasoning. */
+export function budgetOverruns(
+  driver: Pick<AgentDriver, 'budgetSupport'>,
+  result: Pick<AgentRunResult, 'timedOut' | 'turns' | 'costUsd'>,
+  budget: RemediateBudget,
+): { overUsd: boolean; overTurns: boolean; partial: boolean } {
+  const overUsd =
+    driver.budgetSupport.cost !== 'none' &&
+    result.costUsd !== undefined &&
+    result.costUsd > budget.maxUsd;
+  const overTurns =
+    driver.budgetSupport.turns === 'enforced' &&
+    result.turns !== undefined &&
+    result.turns >= budget.maxTurns;
+  return { overUsd, overTurns, partial: result.timedOut || overUsd || overTurns };
 }

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -80,6 +80,13 @@ export interface RemediateConfig {
      *  (`remediate.workOrders.maxSliceSize`, default 25). */
     readonly maxSliceSize: number;
   };
+  /** The deterministic recipe tier (`remediate.recipes`). */
+  readonly recipes: {
+    /** Run recipe-tier work orders inside the frame before any agent spawns
+     *  (`remediate.recipes.enabled`, default true: a $0 deterministic fix
+     *  beats an agent run; set false to route every order to the agent). */
+    readonly enabled: boolean;
+  };
 }
 
 /**
@@ -216,6 +223,9 @@ export function resolveRemediateConfig(cwd: string): RemediateConfig {
         ((raw.workOrders ?? {}) as Record<string, unknown>).maxSliceSize,
         DEFAULT_MAX_SLICE_SIZE,
       ),
+    },
+    recipes: {
+      enabled: ((raw.recipes ?? {}) as Record<string, unknown>).enabled !== false,
     },
   };
 }

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -7,7 +7,56 @@
 import { renderFloorVerification, renderGuardrailVerdict } from '../lanes/verification-render';
 import { describeInstall } from '../lanes/verify-tree';
 import { renderScoreHinge } from './score-hinge';
+import { recipeCounts, type RecipePhaseSummary } from './recipes/run-recipes';
 import type { RemediateResult } from './run';
+
+/** The deterministic-recipe section: one line per order (applied / refused /
+ *  failed with the reason), the tier split, and every disclosure: a $0
+ *  refusal is only worth its price if the reader can see WHY. */
+function renderRecipeSection(recipes: RecipePhaseSummary): string[] {
+  const lines: string[] = ['### Deterministic recipes', ''];
+  if (recipes.disabled) {
+    lines.push('Recipes are disabled by policy (`remediate.recipes.enabled: false`).', '');
+    return lines;
+  }
+  if (recipes.planError) {
+    lines.push(
+      `Work-order planning failed (${recipes.planError}); no recipe ran, and the agent path ` +
+        'proceeded as before.',
+      '',
+    );
+    return lines;
+  }
+  const counts = recipeCounts(recipes);
+  lines.push(
+    `Selected orders: ${recipes.selectedRecipeTier} recipe-tier, ` +
+      `${recipes.selectedAgentTier} agent-tier` +
+      (recipes.records.length > 0
+        ? `: ${counts.applied} applied, ${counts.refused} refused, ${counts.failed} failed.`
+        : '.'),
+  );
+  for (const rec of recipes.records) {
+    const o = rec.outcome;
+    if (o.kind === 'applied') {
+      lines.push(
+        `- \`${rec.orderId}\` (${rec.recipe}): APPLIED, changed ${o.changedFiles.join(', ')}` +
+          (o.notes && o.notes.length > 0 ? ` (${o.notes.join('; ')})` : ''),
+      );
+    } else if (o.kind === 'refused') {
+      lines.push(`- \`${rec.orderId}\` (${rec.recipe}): refused, ${o.reason}`);
+    } else {
+      lines.push(`- \`${rec.orderId}\` (${rec.recipe}): FAILED at ${o.step}, ${o.output}`);
+    }
+    if (rec.droppedPaths && rec.droppedPaths.length > 0) {
+      lines.push(
+        `  - discarded out-of-envelope change(s), disclosed: ${rec.droppedPaths.join(', ')}`,
+      );
+    }
+  }
+  for (const d of recipes.disclosures) lines.push(`- plan disclosure: ${d}`);
+  lines.push('');
+  return lines;
+}
 
 export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): string {
   const lines: string[] = ['## dxkit agentic remediation', ''];
@@ -113,6 +162,10 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
       lines.push('', 'Prompt (verbatim):', '', '```', r.dispatch.prompt, '```');
     }
     lines.push('');
+  }
+
+  if (r.recipes && (r.recipes.ran || r.recipes.disabled || r.recipes.planError)) {
+    lines.push(...renderRecipeSection(r.recipes));
   }
 
   lines.push('### Verification', '');

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -15,6 +15,7 @@ import type { DispatchOverrides } from './dispatch';
 import type { HingeEvidence, HingeScores } from './score-hinge';
 import type { RemediateConfig } from './config';
 import type { InLoopGateStatus } from './agent-trust';
+import type { RecipePhaseSummary, runRecipePhaseForTask } from './recipes/run-recipes';
 
 export type RemediateOutcome =
   | 'verified' // diff produced, floor net-new-clean, guardrail PASSED — ready to land
@@ -118,6 +119,10 @@ export interface RemediateResult {
   /** dxkit runtime-artifact paths dropped from the attempt (regenerable
    *  scan state the agent committed mid-run) — disclosed in the ledger. */
   readonly scrubbedArtifacts?: readonly string[];
+  /** The deterministic recipe phase (4.4.5): per-order applied / refused /
+   *  failed records, envelope drops, and the tier split, rendered into the
+   *  ledger whenever the phase was consulted. */
+  readonly recipes?: RecipePhaseSummary;
   /** The verification ledger — PR body / job summary markdown. */
   readonly ledger: string;
 }
@@ -180,11 +185,15 @@ export interface RemediateRunOptions {
    *  optional blockingContext is the prior attempt's guardrail findings
    *  (from its draft-PR ledger) — appended to the prompt, never the ledger. */
   readonly resume?: { readonly attempt: number; readonly blockingContext?: string };
+  /** Injected for tests: replaces the recipe phase (plan + execute the
+   *  deterministic tier), the armInLoopGate seam pattern. */
+  readonly runRecipePhase?: typeof runRecipePhaseForTask;
 }
 
 /** The runner's observable phases, in order. */
 export type RemediatePhase =
   | 'entry-floor'
+  | 'recipes'
   | 'agent'
   | 'sweep'
   | 'verify-install'

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -20,6 +20,7 @@ import type { RecipePhaseSummary, runRecipePhaseForTask } from './recipes/run-re
 export type RemediateOutcome =
   | 'verified' // diff produced, floor net-new-clean, guardrail PASSED — ready to land
   | 'no-op' // agent ran TO COMPLETION, no diff (nothing to fix)
+  | 'recipes-refused' // recipe-only plan, every recipe refused/failed: nothing fixed, NOT clean
   | 'install-failed' // a clean checkout of the diff cannot be installed the way CI installs — never lands
   | 'floor-red' // diff breaks the net-new floor — never lands
   | 'guardrail-red' // guardrail blocked, refused, or could not run — never lands

--- a/src/remediate/recipes/complete.ts
+++ b/src/remediate/recipes/complete.ts
@@ -1,0 +1,140 @@
+/**
+ * Completion of a RECIPE-ONLY remediate run (split from `../run.ts` at the
+ * module-size bar): when every order the task selected was recipe-tier, the
+ * run finishes without any agent spawn, with the ONE tree verification still
+ * arbitrates the combined recipe commits exactly as it would an agent's
+ * (install, diff-scoped floor attributed vs entry, guardrail). A $0 run is
+ * never a self-certified run.
+ */
+import type { CorrectnessFloorResult } from '../../analyzers/correctness/run';
+import type { RemediateGit, RemediateResult, RemediateRunOptions } from '../outcome';
+import type { RemediateTask } from '../tasks';
+import { installFailedNote, verifyCommittedHead } from '../verify';
+import { recipeCounts, runRecipePhaseForTask, type RecipePhaseSummary } from './run-recipes';
+
+type Partial = Omit<RemediateResult, 'ledger' | 'dispatch' | 'resume'>;
+
+/**
+ * The frame's recipe-tier step: run the phase (never throwing past this
+ * function; a broken plan is a disclosed `planError` and the agent path
+ * proceeds), and when EVERY selected order was recipe-tier, complete the
+ * run here. `done` present = the runner finishes with it; absent = the
+ * agent path continues with `recipes` disclosed.
+ */
+export async function recipeTierStep(
+  opts: RemediateRunOptions,
+  args: {
+    readonly task: Pick<RemediateTask, 'id'>;
+    readonly entryFloor: CorrectnessFloorResult;
+    readonly baseHead: string;
+    readonly git: RemediateGit;
+    readonly runFloor: () => CorrectnessFloorResult;
+  },
+): Promise<{ recipes: RecipePhaseSummary; done?: Partial }> {
+  let recipes: RecipePhaseSummary;
+  try {
+    recipes = await (opts.runRecipePhase ?? runRecipePhaseForTask)({
+      cwd: opts.cwd,
+      trust: opts.trust,
+      taskId: args.task.id,
+      config: opts.config,
+      entryFloor: args.entryFloor,
+    });
+  } catch (err) {
+    recipes = {
+      ran: false,
+      planError: err instanceof Error ? err.message : String(err),
+      disclosures: [],
+      selectedRecipeTier: 0,
+      selectedAgentTier: 0,
+      records: [],
+    };
+  }
+  const selected = recipes.selectedRecipeTier + recipes.selectedAgentTier;
+  if (selected === 0 || recipes.selectedAgentTier > 0) return { recipes };
+  const done = await completeRecipeOnlyRun(opts, {
+    taskId: args.task.id,
+    recipes,
+    baseHead: args.baseHead,
+    head: args.git.head(),
+    hasDiff: args.git.hasDiff(args.baseHead),
+    entryFloor: args.entryFloor,
+    runFloor: args.runFloor,
+  });
+  return { recipes, done };
+}
+
+export interface RecipeOnlyArgs {
+  readonly taskId: RemediateTask['id'];
+  readonly recipes: RecipePhaseSummary;
+  readonly baseHead: string;
+  readonly head: string;
+  readonly hasDiff: boolean;
+  readonly entryFloor: CorrectnessFloorResult;
+  readonly runFloor: () => CorrectnessFloorResult;
+}
+
+export async function completeRecipeOnlyRun(
+  opts: RemediateRunOptions,
+  args: RecipeOnlyArgs,
+): Promise<Partial> {
+  const counts = recipeCounts(args.recipes);
+  const zeroDollar = 'No agent was spawned: every selected work order was recipe-tier ($0 run).';
+  if (!args.hasDiff) {
+    return {
+      outcome: 'no-op',
+      task: args.taskId,
+      floor: args.entryFloor,
+      recipes: args.recipes,
+      note:
+        `${zeroDollar} No recipe applied a change (${counts.refused} refused, ` +
+        `${counts.failed} failed); per-order reasons are in the recipe section below.`,
+    };
+  }
+  const { verified, guardrail } = await verifyCommittedHead(opts, {
+    head: args.head,
+    baseHead: args.baseHead,
+    entryFloor: args.entryFloor,
+    runFloor: args.runFloor,
+  });
+  const common = {
+    task: args.taskId,
+    recipes: args.recipes,
+    ...(verified.floor ? { floor: verified.floor } : {}),
+    ...(verified.floorAttribution ? { floorAttribution: verified.floorAttribution } : {}),
+    ...(verified.install ? { install: verified.install } : {}),
+    ...(verified.changedFiles ? { changedFiles: verified.changedFiles } : {}),
+    guardrailVerdict: guardrail.verdict,
+    baseHead: args.baseHead,
+    head: args.head,
+  };
+  if (verified.verdict === 'install-failed') {
+    return { outcome: 'install-failed', ...common, note: installFailedNote(verified) };
+  }
+  if (verified.verdict === 'floor-red') {
+    return {
+      outcome: 'floor-red',
+      ...common,
+      note:
+        'the correctness floor has NET-NEW failures after the recipe commits (the entry ' +
+        'floor did not have them), so nothing lands. A recipe that breaks the build gets the ' +
+        'same truthful failure an agent would.',
+    };
+  }
+  if (!guardrail.ran || !guardrail.passesGate) {
+    return {
+      outcome: 'guardrail-red',
+      ...common,
+      note: guardrail.ran
+        ? `the guardrail did not pass (${guardrail.verdict}), so nothing merges. The recipe ` +
+          'commits stay on the branch for inspection.'
+        : `the guardrail could not run (${guardrail.verdict}), so nothing lands. A recipe ` +
+          'diff is never pushed unverified.',
+    };
+  }
+  return {
+    outcome: 'verified',
+    ...common,
+    note: `${zeroDollar} ${counts.applied} order(s) applied and verified the way CI verifies.`,
+  };
+}

--- a/src/remediate/recipes/complete.ts
+++ b/src/remediate/recipes/complete.ts
@@ -81,14 +81,22 @@ export async function completeRecipeOnlyRun(
   const counts = recipeCounts(args.recipes);
   const zeroDollar = 'No agent was spawned: every selected work order was recipe-tier ($0 run).';
   if (!args.hasDiff) {
+    // NOT a clean no-op: the orders exist, every recipe refused or failed,
+    // and no agent tier exists in a recipe-only run to pick them up; a
+    // green outcome here would let the scheduled lane loop forever over
+    // debt nothing is working. `recipes-refused` is non-clean by
+    // construction (the executor's clean set never contains it), so the
+    // lane surfaces it; the agent-tier fallback within one run is the
+    // scoped-agent unit's job.
     return {
-      outcome: 'no-op',
+      outcome: 'recipes-refused',
       task: args.taskId,
       floor: args.entryFloor,
       recipes: args.recipes,
       note:
-        `${zeroDollar} No recipe applied a change (${counts.refused} refused, ` +
-        `${counts.failed} failed); per-order reasons are in the recipe section below.`,
+        `${zeroDollar} Every recipe declined: ${counts.refused} refused, ${counts.failed} ` +
+        'failed, nothing was fixed, and the orders remain open. Per-order reasons are in ' +
+        'the recipe section below; these orders need the agent tier or a human.',
     };
   }
   const { verified, guardrail } = await verifyCommittedHead(opts, {

--- a/src/remediate/recipes/declare-dependency.ts
+++ b/src/remediate/recipes/declare-dependency.ts
@@ -1,0 +1,185 @@
+/**
+ * The `declare-dependency` recipe: an `unresolved-import` order (a bare
+ * import specifier that resolves against nothing installed) is fixed by
+ * declaring the package in the manifest the importing files imply and
+ * installing it, with the design's load-bearing twist: the candidate is
+ * OSV pre-checked FIRST, and a block-tier advisory refuses at $0 with the
+ * advisory named. That is the live fix-build failure class (an agent
+ * installing a vulnerable phantom dependency and turning the gate red)
+ * converted into a disclosed refusal.
+ *
+ * Scope this round: orders produced by the TypeScript/JavaScript pack. The
+ * resolution-check contract makes bareness a producer fact; a project-path
+ * identity (leading `./`) names a missing FILE, which no install can
+ * declare, so such orders are refused with the reason (the registry's
+ * `matches` already tiers them to the agent).
+ */
+import * as path from 'path';
+import { tail } from '../../analyzers/tools/bounded-exec';
+import { runSingleResolutionCheck } from '../../analyzers/correctness/single-checks';
+import { isProjectPathIdentity } from '../../languages/capabilities/correctness';
+import { isTestSourceFile } from '../../analyzers/tools/walk-source-files';
+import { classifyOsvSeverity } from '../../analyzers/tools/osv';
+import { upgradeArgv, type DependencySection } from '../../package-manager';
+import type { FloorEvidence, WorkOrder } from '../work-orders/types';
+import { nodePmAt, owningManifestRoot } from './shared';
+import type { RecipeExecuteContext, RecipeOutcome } from './types';
+
+/** The pack whose resolution-check evidence this recipe can act on. */
+const SUPPORTED_PACK = 'typescript';
+
+interface Candidate {
+  readonly specifier: string;
+  readonly importingFiles: readonly string[];
+}
+
+function candidates(order: WorkOrder): Candidate[] | null {
+  const out: Candidate[] = [];
+  for (const f of order.findings) {
+    const e = f.evidence;
+    if (e.type !== 'floor' || typeof e.specifier !== 'string') return null;
+    out.push({ specifier: e.specifier, importingFiles: e.importingFiles ?? [] });
+  }
+  return out;
+}
+
+export async function executeDeclareDependency(
+  order: WorkOrder,
+  ctx: RecipeExecuteContext,
+): Promise<RecipeOutcome> {
+  const cands = candidates(order);
+  if (cands === null || cands.length === 0) {
+    return { kind: 'refused', reason: 'the order carries no unresolved-specifier evidence' };
+  }
+  const pack = (order.findings[0].evidence as FloorEvidence).pack;
+  if (pack !== SUPPORTED_PACK) {
+    return {
+      kind: 'refused',
+      reason: `declare-dependency is implemented for the ${SUPPORTED_PACK} pack only this round (order came from '${pack}')`,
+    };
+  }
+  const relative = cands.filter((c) => isProjectPathIdentity(c.specifier));
+  if (relative.length > 0) {
+    return {
+      kind: 'refused',
+      reason:
+        `${relative.map((c) => `'${c.specifier}'`).join(', ')} name missing FILES in the repo ` +
+        'tree, not packages, and no install can declare them; a human or the agent tier must ' +
+        'restore or remove the import',
+    };
+  }
+  const rootDir = owningManifestRoot(order);
+  if (rootDir === null) {
+    return {
+      kind: 'refused',
+      reason:
+        'the envelope does not name exactly one package.json, so the manifest to declare ' +
+        'into is ambiguous',
+    };
+  }
+  const lock = nodePmAt(ctx.cwd, rootDir);
+  if (lock === null) {
+    return {
+      kind: 'refused',
+      reason: `no lockfile exists at ${rootDir || 'the repo root'}, so declaring a dependency here cannot be lockfile-verified`,
+    };
+  }
+  const rootAbs = path.join(ctx.cwd, rootDir);
+
+  // Resolve + pre-check EVERY candidate before installing ANY: a refusal
+  // must cost $0 and leave the tree untouched.
+  const notes: string[] = [];
+  const resolved: Array<Candidate & { version: string; section: DependencySection }> = [];
+  for (const c of cands) {
+    // `npm view` resolves the registry version the install would take,
+    // honoring the repo's own .npmrc (registry, scopes). npm ships with the
+    // Node runtime dxkit requires, so this holds for every node PM.
+    const view = ctx.exec({ bin: 'npm', args: ['view', c.specifier, 'version'] }, rootAbs);
+    if (!view.available) {
+      return { kind: 'failed', step: 'resolve-version', output: 'npm is not available here' };
+    }
+    if (view.timedOut || view.overflowed || view.code !== 0) {
+      return {
+        kind: 'refused',
+        reason:
+          `'${c.specifier}' does not resolve in the package registry: likely a typo, a ` +
+          'private package, or something that should not be a dependency at all. Not installing',
+      };
+    }
+    const version = view.output.trim().split('\n').pop()?.trim() ?? '';
+    if (!/^\d/.test(version)) {
+      return {
+        kind: 'refused',
+        reason: `could not determine a concrete registry version for '${c.specifier}' (got '${version}')`,
+      };
+    }
+    const known = await ctx.queryOsv(c.specifier, version, 'npm');
+    if (known === null) {
+      notes.push(
+        `OSV pre-check for ${c.specifier}@${version} could not be reached; the guardrail verifies`,
+      );
+    } else {
+      const blockTier = known.filter((v) => {
+        const s = classifyOsvSeverity(v);
+        return s === 'high' || s === 'critical';
+      });
+      if (blockTier.length > 0) {
+        const ids = blockTier.map((v) => v.id ?? 'unidentified advisory').join(', ');
+        return {
+          kind: 'refused',
+          reason:
+            `installing ${c.specifier}@${version} would introduce a block-tier advisory: ${ids}. ` +
+            'The import needs a different fix (a maintained alternative, or removing the import)',
+        };
+      }
+    }
+    // Section: a package imported ONLY from test files is a devDependency.
+    const section: DependencySection =
+      c.importingFiles.length > 0 && c.importingFiles.every((f) => isTestSourceFile(f))
+        ? 'devDependencies'
+        : 'dependencies';
+    resolved.push({ ...c, version, section });
+  }
+
+  for (const r of resolved) {
+    const [bin, ...args] = upgradeArgv(lock.pm, r.specifier, r.version, r.section);
+    const install = ctx.exec({ bin, args }, rootAbs);
+    if (!install.available || install.timedOut || install.overflowed || install.code !== 0) {
+      return {
+        kind: 'failed',
+        step: 'install',
+        output: tail(
+          `${[bin, ...args].join(' ')}: ` +
+            (install.available ? install.output || 'non-zero exit' : 'binary not available'),
+        ),
+      };
+    }
+  }
+
+  // Verify with the pack's own resolution check: the ORDER's specifiers must
+  // be gone. Pre-existing unresolved debt elsewhere stays the floor's story.
+  const verify = runSingleResolutionCheck(ctx.cwd, pack);
+  if (verify === null || (verify.status !== 'pass' && verify.status !== 'fail')) {
+    return {
+      kind: 'failed',
+      step: 'verify-resolution',
+      output: verify?.output ?? 'the import-resolution check could not answer here',
+    };
+  }
+  const still = new Set((verify.unresolved ?? []).map((u) => u.specifier));
+  const unfixed = resolved.filter((r) => still.has(r.specifier));
+  if (unfixed.length > 0) {
+    return {
+      kind: 'failed',
+      step: 'verify-resolution',
+      output: `still unresolved after install: ${unfixed.map((r) => `'${r.specifier}'`).join(', ')}`,
+    };
+  }
+  const manifestPath = rootDir ? `${rootDir}/package.json` : 'package.json';
+  const lockPath = rootDir ? `${rootDir}/${lock.lockfile}` : lock.lockfile;
+  return {
+    kind: 'applied',
+    changedFiles: [manifestPath, lockPath],
+    ...(notes.length > 0 ? { notes } : {}),
+  };
+}

--- a/src/remediate/recipes/declare-dependency.ts
+++ b/src/remediate/recipes/declare-dependency.ts
@@ -15,18 +15,24 @@
  * `matches` already tiers them to the agent).
  */
 import * as path from 'path';
-import { tail } from '../../analyzers/tools/bounded-exec';
 import { runSingleResolutionCheck } from '../../analyzers/correctness/single-checks';
 import { isProjectPathIdentity } from '../../languages/capabilities/correctness';
 import { isTestSourceFile } from '../../analyzers/tools/walk-source-files';
-import { classifyOsvSeverity } from '../../analyzers/tools/osv';
 import { upgradeArgv, type DependencySection } from '../../package-manager';
 import type { FloorEvidence, WorkOrder } from '../work-orders/types';
-import { nodePmAt, owningManifestRoot } from './shared';
+import {
+  execStepFailure,
+  isValidNpmPackageName,
+  nodePmAt,
+  osvBlockTier,
+  owningManifestRoot,
+} from './shared';
 import type { RecipeExecuteContext, RecipeOutcome } from './types';
 
-/** The pack whose resolution-check evidence this recipe can act on. */
-const SUPPORTED_PACK = 'typescript';
+/** The packs whose resolution-check evidence this recipe can act on. Read
+ *  by the registry's `matches` too, so an order from any other pack tiers
+ *  to the agent instead of being tiered recipe and refused at runtime. */
+export const DECLARABLE_PACKS: readonly string[] = ['typescript'];
 
 interface Candidate {
   readonly specifier: string;
@@ -52,10 +58,27 @@ export async function executeDeclareDependency(
     return { kind: 'refused', reason: 'the order carries no unresolved-specifier evidence' };
   }
   const pack = (order.findings[0].evidence as FloorEvidence).pack;
-  if (pack !== SUPPORTED_PACK) {
+  if (!DECLARABLE_PACKS.includes(pack)) {
     return {
       kind: 'refused',
-      reason: `declare-dependency is implemented for the ${SUPPORTED_PACK} pack only this round (order came from '${pack}')`,
+      reason: `declare-dependency is implemented for the ${DECLARABLE_PACKS.join('/')} pack only this round (order came from '${pack}')`,
+    };
+  }
+  // Rule 11 argument-injection rail: a specifier is attacker-influencable
+  // source text and flows into package-manager argv below. Anything outside
+  // the strict npm name shape (a leading dash, spaces, a URL) is refused
+  // BEFORE any argv exists; the registry's matches applies the same shape
+  // at planning time, so this is the defense-in-depth boundary.
+  const malformed = cands.filter((c) => !isValidNpmPackageName(c.specifier));
+  if (malformed.length > 0) {
+    return {
+      kind: 'refused',
+      reason:
+        `${malformed.map((c) => `'${c.specifier}'`).join(', ')} ` +
+        (malformed.length === 1
+          ? 'is not a valid npm package name'
+          : 'are not valid npm package names') +
+        '; refusing to hand it to the package manager',
     };
   }
   const relative = cands.filter((c) => isProjectPathIdentity(c.specifier));
@@ -119,10 +142,7 @@ export async function executeDeclareDependency(
         `OSV pre-check for ${c.specifier}@${version} could not be reached; the guardrail verifies`,
       );
     } else {
-      const blockTier = known.filter((v) => {
-        const s = classifyOsvSeverity(v);
-        return s === 'high' || s === 'critical';
-      });
+      const blockTier = osvBlockTier(known, ctx.blockSeverities);
       if (blockTier.length > 0) {
         const ids = blockTier.map((v) => v.id ?? 'unidentified advisory').join(', ');
         return {
@@ -144,21 +164,15 @@ export async function executeDeclareDependency(
   for (const r of resolved) {
     const [bin, ...args] = upgradeArgv(lock.pm, r.specifier, r.version, r.section);
     const install = ctx.exec({ bin, args }, rootAbs);
-    if (!install.available || install.timedOut || install.overflowed || install.code !== 0) {
-      return {
-        kind: 'failed',
-        step: 'install',
-        output: tail(
-          `${[bin, ...args].join(' ')}: ` +
-            (install.available ? install.output || 'non-zero exit' : 'binary not available'),
-        ),
-      };
-    }
+    const failure = execStepFailure('install', [bin, ...args].join(' '), install);
+    if (failure) return failure;
   }
 
-  // Verify with the pack's own resolution check: the ORDER's specifiers must
-  // be gone. Pre-existing unresolved debt elsewhere stays the floor's story.
-  const verify = runSingleResolutionCheck(ctx.cwd, pack);
+  // Verify with the pack's own resolution check AT THE OWNING ROOT (the
+  // tree the install provisioned; a nested workspace's importers resolve
+  // against its own installed tree): the ORDER's specifiers must be gone.
+  // Pre-existing unresolved debt elsewhere stays the floor's story.
+  const verify = runSingleResolutionCheck(rootAbs, pack);
   if (verify === null || (verify.status !== 'pass' && verify.status !== 'fail')) {
     return {
       kind: 'failed',

--- a/src/remediate/recipes/envelope.ts
+++ b/src/remediate/recipes/envelope.ts
@@ -1,0 +1,27 @@
+/**
+ * Envelope containment for recipe diffs: the pure half of the phase
+ * runner's enforcement. An envelope's `paths` speak the planner's language:
+ * `''` means the whole repo, a trailing-`/` entry is a directory prefix,
+ * anything else is one file.
+ */
+import type { WorkOrderEnvelope } from '../work-orders/types';
+
+/** Is a repo-relative path inside the envelope? */
+export function pathInEnvelope(p: string, envelope: WorkOrderEnvelope): boolean {
+  return envelope.paths.some((e) => {
+    if (e === '') return true;
+    if (e.endsWith('/')) return p.startsWith(e);
+    return p === e || p.startsWith(`${e}/`);
+  });
+}
+
+/** Split changed paths into the envelope's and the strays to drop. */
+export function partitionByEnvelope(
+  changed: readonly string[],
+  envelope: WorkOrderEnvelope,
+): { inside: string[]; outside: string[] } {
+  const inside: string[] = [];
+  const outside: string[] = [];
+  for (const p of changed) (pathInEnvelope(p, envelope) ? inside : outside).push(p);
+  return { inside, outside };
+}

--- a/src/remediate/recipes/git.ts
+++ b/src/remediate/recipes/git.ts
@@ -1,0 +1,74 @@
+/**
+ * The recipe phase's git surface: the small set of operations the runner
+ * needs to enforce envelopes and commit per order. Injectable (tests use a
+ * fake); the real implementation shells `git` with the one BOT_IDENTITY,
+ * mirroring `../git-ops.ts` (the agent sweep's sibling, separate because
+ * the recipe phase works the UNCOMMITTED tree, order by order, and must
+ * only ever touch the paths a recipe changed: a locally dirty tree's
+ * pre-existing edits are never staged, committed, or discarded here).
+ */
+import { execFileSync } from 'child_process';
+import { BOT_IDENTITY } from '../../land-refresh';
+
+export interface RecipeGit {
+  /** Repo-relative paths with any uncommitted change (staged, unstaged, or
+   *  untracked). */
+  changedPaths(): string[];
+  /** Discard the uncommitted changes to exactly these paths (restore
+   *  tracked content, delete untracked files). Never wider than `paths`. */
+  discardPaths(paths: readonly string[]): void;
+  /** Stage exactly these paths and commit them with the bot identity. */
+  commitPaths(paths: readonly string[], message: string): void;
+  head(): string;
+}
+
+export function realRecipeGit(cwd: string): RecipeGit {
+  const git = (args: string[]): string =>
+    execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  // Porcelain lines are positional (`XY <path>`): trimming the output would
+  // eat the first line's leading status space and shift its path slice.
+  const gitRaw = (args: string[]): string =>
+    execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  return {
+    changedPaths: () =>
+      gitRaw(['status', '--porcelain'])
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => {
+          // Rename lines read `R  old -> new`; the NEW path is the changed one.
+          const p = l.slice(3);
+          const arrow = p.indexOf(' -> ');
+          return (arrow >= 0 ? p.slice(arrow + 4) : p).trim().replace(/^"|"$/g, '');
+        }),
+    discardPaths(paths) {
+      if (paths.length === 0) return;
+      // Tracked content back to HEAD, one path at a time: a single batched
+      // checkout aborts wholesale when ANY path is untracked ("pathspec did
+      // not match"), leaving tracked edits in place. `--` guards against a
+      // path that looks like a flag; clean removes the untracked strays.
+      for (const p of paths) {
+        try {
+          git(['checkout', 'HEAD', '--', p]);
+        } catch {
+          // Untracked path: checkout has nothing to restore; clean handles it.
+        }
+      }
+      git(['clean', '-fd', '--', ...paths]);
+    },
+    commitPaths(paths, message) {
+      if (paths.length === 0) return;
+      git(['add', '--', ...paths]);
+      git([
+        '-c',
+        `user.name=${BOT_IDENTITY.name}`,
+        '-c',
+        `user.email=${BOT_IDENTITY.email}`,
+        'commit',
+        '-q',
+        '-m',
+        message,
+      ]);
+    },
+    head: () => git(['rev-parse', 'HEAD']),
+  };
+}

--- a/src/remediate/recipes/git.ts
+++ b/src/remediate/recipes/git.ts
@@ -1,56 +1,59 @@
 /**
  * The recipe phase's git surface: the small set of operations the runner
  * needs to enforce envelopes and commit per order. Injectable (tests use a
- * fake); the real implementation shells `git` with the one BOT_IDENTITY,
- * mirroring `../git-ops.ts` (the agent sweep's sibling, separate because
- * the recipe phase works the UNCOMMITTED tree, order by order, and must
- * only ever touch the paths a recipe changed: a locally dirty tree's
- * pre-existing edits are never staged, committed, or discarded here).
+ * fake); the real implementation shells `git` with the one BOT_IDENTITY.
+ *
+ * "What did the working tree change?" is the canonical concept in
+ * `src/baseline/changed-files.ts` (Rule 2.30), so `changedPaths` IS
+ * `computeChangedPaths(cwd, 'HEAD')`: the deletions-inclusive projection,
+ * with unescaped (non-quoted) paths, diffing HEAD against the working tree
+ * (staged + unstaged + untracked), which is exactly the uncommitted set. A `null`
+ * from the canonical helper (git itself failed) THROWS here: the phase
+ * runner must never enforce an envelope against an unknown tree, and the
+ * throw surfaces as a named per-order failure, not a silent pass.
+ *
+ * This surface only ever touches the paths a recipe changed: a locally
+ * dirty tree's pre-existing edits are never staged, committed, or
+ * discarded here.
  */
 import { execFileSync } from 'child_process';
+import { computeChangedPaths } from '../../baseline/changed-files';
 import { BOT_IDENTITY } from '../../land-refresh';
 
 export interface RecipeGit {
   /** Repo-relative paths with any uncommitted change (staged, unstaged, or
-   *  untracked). */
+   *  untracked; deletions included). Throws when the tree state cannot be
+   *  determined; the caller records a named failure. */
   changedPaths(): string[];
   /** Discard the uncommitted changes to exactly these paths (restore
    *  tracked content, delete untracked files). Never wider than `paths`. */
   discardPaths(paths: readonly string[]): void;
   /** Stage exactly these paths and commit them with the bot identity. */
   commitPaths(paths: readonly string[], message: string): void;
-  head(): string;
 }
 
 export function realRecipeGit(cwd: string): RecipeGit {
   const git = (args: string[]): string =>
     execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
-  // Porcelain lines are positional (`XY <path>`): trimming the output would
-  // eat the first line's leading status space and shift its path slice.
-  const gitRaw = (args: string[]): string =>
-    execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
   return {
-    changedPaths: () =>
-      gitRaw(['status', '--porcelain'])
-        .split('\n')
-        .filter((l) => l.trim())
-        .map((l) => {
-          // Rename lines read `R  old -> new`; the NEW path is the changed one.
-          const p = l.slice(3);
-          const arrow = p.indexOf(' -> ');
-          return (arrow >= 0 ? p.slice(arrow + 4) : p).trim().replace(/^"|"$/g, '');
-        }),
+    changedPaths() {
+      const paths = computeChangedPaths(cwd, 'HEAD');
+      if (paths === null) {
+        throw new Error('could not determine the uncommitted working-tree state (git failed)');
+      }
+      return [...paths];
+    },
     discardPaths(paths) {
       if (paths.length === 0) return;
       // Tracked content back to HEAD, one path at a time: a single batched
-      // checkout aborts wholesale when ANY path is untracked ("pathspec did
+      // restore aborts wholesale when ANY path is untracked ("pathspec did
       // not match"), leaving tracked edits in place. `--` guards against a
       // path that looks like a flag; clean removes the untracked strays.
       for (const p of paths) {
         try {
           git(['checkout', 'HEAD', '--', p]);
         } catch {
-          // Untracked path: checkout has nothing to restore; clean handles it.
+          // Untracked path: nothing to restore; clean below handles it.
         }
       }
       git(['clean', '-fd', '--', ...paths]);
@@ -69,6 +72,5 @@ export function realRecipeGit(cwd: string): RecipeGit {
         message,
       ]);
     },
-    head: () => git(['rev-parse', 'HEAD']),
   };
 }

--- a/src/remediate/recipes/lint-autofix.ts
+++ b/src/remediate/recipes/lint-autofix.ts
@@ -1,0 +1,101 @@
+/**
+ * The `lint-autofix` recipe: a `lint-located` order (one file's located lint
+ * findings) is fixed by the PACK linter's own fix mode, scoped to that file
+ * (`LintGateProvider.fixCommand`, Rule 6: the ecosystem's fixer comes from
+ * the pack, never a hardcoded eslint string here). One execution both writes
+ * the fixes and reports the remaining findings through the pack's own
+ * parser, validated by the seam's ONE located-finding boundary
+ * (`parseLocated` / `parseStructuredLocated`, Rule 17), so the recipe's
+ * verify reads the leftovers of the very command that fixed.
+ *
+ * Verify is strict by construction: a single-slice lint order carries the
+ * file's ENTIRE known finding set, so "the order's ids are absent AND no
+ * net-new finding appeared in the envelope" collapses to "the file lints
+ * clean". Anything remaining (an unfixable rule, a finding the fix
+ * introduced) fails the recipe, the diff is discarded, and the order stays
+ * open for the agent tier with the leftover rules named. A sliced order
+ * (the file's findings span several orders) is refused: a file-scoped fix
+ * cannot be verified per slice.
+ */
+import { tail } from '../../analyzers/tools/bounded-exec';
+import { parseLocated, parseStructuredLocated } from '../../analyzers/custom-checks/parse';
+import type { CustomCheckFinding } from '../../analyzers/custom-checks/types';
+import { getLanguage } from '../../languages';
+import type { LanguageId } from '../../languages/types';
+import type { WorkOrder } from '../work-orders/types';
+import type { RecipeExecuteContext, RecipeOutcome } from './types';
+
+/** The pack behind a built-in lint check name (`lint:<pack>`), or null for
+ *  a user-declared check (which has no pack fixer to call). */
+export function lintPackOf(check: string): string | null {
+  return check.startsWith('lint:') ? check.slice('lint:'.length) : null;
+}
+
+export async function executeLintAutofix(
+  order: WorkOrder,
+  ctx: RecipeExecuteContext,
+): Promise<RecipeOutcome> {
+  const first = order.findings[0]?.evidence;
+  if (!first || first.type !== 'custom-check' || !first.file) {
+    return { kind: 'refused', reason: 'the order carries no located custom-check evidence' };
+  }
+  const file = first.file;
+  const pack = lintPackOf(first.check);
+  if (pack === null) {
+    return {
+      kind: 'refused',
+      reason:
+        `'${first.check}' is a user-declared check, and dxkit does not know its fixer; only ` +
+        'pack lint gates have a declared fix mode',
+    };
+  }
+  if (order.provenance.source === 'debt-slice' && order.provenance.of > 1) {
+    return {
+      kind: 'refused',
+      reason:
+        `the file's findings span ${order.provenance.of} sliced orders, and a file-scoped ` +
+        'autofix cannot be verified one slice at a time; raise ' +
+        'remediate.workOrders.maxSliceSize or leave this to the agent tier',
+    };
+  }
+  const provider = getLanguage(pack as LanguageId)?.lintGate;
+  const fix = provider?.fixCommand?.({ cwd: ctx.cwd, files: [file] }) ?? null;
+  if (fix === null) {
+    return {
+      kind: 'refused',
+      reason: provider?.fixCommand
+        ? `the ${pack} pack's linter fix mode is not resolvable in this repo`
+        : `the ${pack} pack declares no linter fix mode`,
+    };
+  }
+
+  const run = ctx.exec({ bin: fix.bin, args: fix.args }, ctx.cwd);
+  if (!run.available) {
+    return { kind: 'failed', step: 'fix', output: `${fix.bin} is not available here` };
+  }
+  if (run.timedOut) return { kind: 'failed', step: 'fix', output: 'the fix run timed out' };
+  if (run.overflowed) {
+    return { kind: 'failed', step: 'fix', output: 'the fix run overflowed the capture buffer' };
+  }
+
+  // The same run's output IS the verify input: remaining findings, through
+  // the seam's validating boundary (repo-relative POSIX file, deduped).
+  const remaining: CustomCheckFinding[] =
+    fix.parse.kind === 'structured'
+      ? parseStructuredLocated(first.check, true, fix.parse.parse, run.output, ctx.cwd)
+      : parseLocated(first.check, true, fix.parse.pattern, run.output, ctx.cwd);
+  const inFile = remaining.filter((f) => f.file === file || f.file === undefined);
+  if (inFile.length > 0) {
+    const rules = [...new Set(inFile.map((f) => f.rule ?? '(unparsed)'))].sort();
+    return {
+      kind: 'failed',
+      step: 'verify-lint',
+      output: tail(
+        `${inFile.length} finding(s) remain in ${file} after the autofix ` +
+          `(rules: ${rules.join(', ')}): not auto-fixable, or introduced by the fix; ` +
+          'leaving the order to the agent tier',
+      ),
+    };
+  }
+  return { kind: 'applied', changedFiles: [file] };
+}

--- a/src/remediate/recipes/lockfile-sync.ts
+++ b/src/remediate/recipes/lockfile-sync.ts
@@ -1,0 +1,76 @@
+/**
+ * The `lockfile-sync` recipe: a `stale-lockfile` order (the lockfile-sync
+ * floor check failed: CI's frozen install cannot load this tree) is fixed
+ * by the ecosystem's lock-WRITING install at the owning root, then verified
+ * by the SAME pack-declared frozen dry-run the floor runs (`lockfileCheck`,
+ * via the correctness module's single-check entry point: one concept, one
+ * code path). A verify the pack cannot give (yarn's declared skip) is a
+ * refusal, never an unconfirmed "applied".
+ */
+import * as path from 'path';
+import { tail } from '../../analyzers/tools/bounded-exec';
+import { runSingleLockfileCheck } from '../../analyzers/correctness/single-checks';
+import type { WorkOrder } from '../work-orders/types';
+import { nodePmAt, owningManifestRoot, resyncInstallFor, runResyncInstall } from './shared';
+import type { RecipeExecuteContext, RecipeOutcome } from './types';
+
+/** The pack that produced the order's floor finding. */
+function producingPack(order: WorkOrder): string | null {
+  const e = order.findings[0]?.evidence;
+  return e && e.type === 'floor' ? e.pack : null;
+}
+
+export async function executeLockfileSync(
+  order: WorkOrder,
+  ctx: RecipeExecuteContext,
+): Promise<RecipeOutcome> {
+  const pack = producingPack(order);
+  if (pack === null) {
+    return { kind: 'refused', reason: 'the order carries no floor evidence naming its pack' };
+  }
+  const rootDir = owningManifestRoot(order);
+  if (rootDir === null) {
+    return {
+      kind: 'refused',
+      reason:
+        'the envelope does not name exactly one package.json, so the owning dependency root ' +
+        'is ambiguous',
+    };
+  }
+  const rootAbs = path.join(ctx.cwd, rootDir);
+  const lock = nodePmAt(ctx.cwd, rootDir);
+  if (lock === null) {
+    return {
+      kind: 'refused',
+      reason: `no lockfile exists at ${rootDir || 'the repo root'}, so there is nothing to re-sync`,
+    };
+  }
+
+  const installFailure = runResyncInstall(resyncInstallFor(lock.pm), rootAbs, ctx.exec);
+  if (installFailure) return installFailure;
+
+  // Verify with the pack's own frozen dry-run, the exact check that minted
+  // the order. Only a real PASS confirms; a skip (yarn's declared no-dry-run,
+  // a missing binary) means the recipe cannot claim the fix and says so.
+  const verify = runSingleLockfileCheck(rootAbs, pack, ctx.exec);
+  if (verify === null) {
+    return {
+      kind: 'refused',
+      reason: `the ${pack} pack declares no lockfile-sync check here, so the resync cannot be verified`,
+    };
+  }
+  if (verify.status !== 'pass') {
+    return {
+      kind: 'failed',
+      step: 'verify-lockfile-sync',
+      output: tail(
+        `${verify.status}: ${verify.output ?? 'the frozen dry-run did not pass after the resync'}`,
+      ),
+    };
+  }
+  return {
+    kind: 'applied',
+    changedFiles: [rootDir ? `${rootDir}/${lock.lockfile}` : lock.lockfile],
+    ...(verify.note ? { notes: [verify.note] } : {}),
+  };
+}

--- a/src/remediate/recipes/override-pin.ts
+++ b/src/remediate/recipes/override-pin.ts
@@ -19,11 +19,17 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { classifyOsvSeverity } from '../../analyzers/tools/osv';
-import { maxSemver } from '../../analyzers/bom/gather';
+import { serializePreservingJson } from '../../files';
 import type { WorkOrder } from '../work-orders/types';
 import type { DepAdvisoryEvidence } from '../work-orders/types';
-import { nodePmAt, owningManifestRoot, resyncInstallFor, runResyncInstall } from './shared';
+import {
+  nodePmAt,
+  osvBlockTier,
+  owningManifestRoot,
+  pickPinVersion,
+  resyncInstallFor,
+  runResyncInstall,
+} from './shared';
 import type { RecipeExecuteContext, RecipeOutcome } from './types';
 
 function advisories(order: WorkOrder): DepAdvisoryEvidence[] {
@@ -61,9 +67,9 @@ function writeNpmOverride(rootAbs: string, pkg: string, version: string): Manife
       : {};
   overrides[pkg] = version;
   manifest.overrides = overrides;
-  const indent = /\n([ \t]+)"/.exec(text)?.[1] ?? '  ';
-  const trailing = text.endsWith('\n') ? '\n' : '';
-  fs.writeFileSync(file, JSON.stringify(manifest, null, indent) + trailing);
+  // The one style-preserving JSON writer (files.ts): indentation, compact
+  // form, and trailing newline survive, so the override is a one-key diff.
+  fs.writeFileSync(file, serializePreservingJson(text, manifest));
   return { file };
 }
 
@@ -108,8 +114,19 @@ export async function executeOverridePin(
     };
   }
 
-  // The pin: the highest known fixed version clears every advisory at once.
-  const pin = maxSemver(fixedVersions);
+  // The pin: the highest known CONCRETE fixed version clears every advisory
+  // at once. Prerelease-aware (1.2.3 outranks 1.2.3-beta.1); a range-shaped
+  // fixed string refuses rather than guesses (the registry's `matches`
+  // already tiers such orders to the agent, so this is the defensive rail).
+  const pin = pickPinVersion(fixedVersions);
+  if (pin === null) {
+    return {
+      kind: 'refused',
+      reason:
+        `the known fixed versions for '${pkg}' are not all concrete semver values ` +
+        `(${fixedVersions.join(', ')}); a range cannot be pinned verbatim`,
+    };
+  }
   const notes: string[] = [];
 
   // $0 pre-check: would the pinned version itself carry a block-tier
@@ -119,10 +136,7 @@ export async function executeOverridePin(
   if (known === null) {
     notes.push(`OSV pre-check for ${pkg}@${pin} could not be reached; the re-audit verifies`);
   } else {
-    const blockTier = known.filter((v) => {
-      const s = classifyOsvSeverity(v);
-      return s === 'high' || s === 'critical';
-    });
+    const blockTier = osvBlockTier(known, ctx.blockSeverities);
     if (blockTier.length > 0) {
       const ids = blockTier.map((v) => v.id ?? 'unidentified advisory').join(', ');
       return {

--- a/src/remediate/recipes/override-pin.ts
+++ b/src/remediate/recipes/override-pin.ts
@@ -1,0 +1,173 @@
+/**
+ * The `override-pin` recipe: a `dep-advisory` order whose every advisory has
+ * a known fixed version, on a package with no direct upgrade path (a
+ * transitive dependency), is fixed by a package-manager override pinning the
+ * fixed version, then a lockfile resync.
+ *
+ * Honesty gates, in order:
+ *   - npm first: pnpm `pnpm.overrides` and yarn `resolutions` are
+ *     DECLARED-REFUSED this round (reason named), never half-implemented;
+ *   - a DIRECT dependency is refused: the honest fix is upgrading the
+ *     declared dep (the dep-bump lane's job), not overriding it;
+ *   - the candidate pin is OSV pre-checked ($0): a block-tier advisory
+ *     against the pinned version refuses with the advisory named, so the
+ *     recipe never trades one red gate for another;
+ *   - verify is a re-audit through the ONE dep-audit dispatch: the order's
+ *     package must audit clean afterwards (its known advisories gone AND
+ *     nothing new minted on it), or the recipe fails and the diff is
+ *     discarded.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { classifyOsvSeverity } from '../../analyzers/tools/osv';
+import { maxSemver } from '../../analyzers/bom/gather';
+import type { WorkOrder } from '../work-orders/types';
+import type { DepAdvisoryEvidence } from '../work-orders/types';
+import { nodePmAt, owningManifestRoot, resyncInstallFor, runResyncInstall } from './shared';
+import type { RecipeExecuteContext, RecipeOutcome } from './types';
+
+function advisories(order: WorkOrder): DepAdvisoryEvidence[] {
+  return order.findings
+    .map((f) => f.evidence)
+    .filter((e): e is DepAdvisoryEvidence => e.type === 'dep-vuln');
+}
+
+interface ManifestEdit {
+  readonly file: string;
+  readonly refused?: string;
+}
+
+/** Write `overrides[pkg] = version` into the root package.json, preserving
+ *  the file's own indentation and trailing newline. Refuses (without
+ *  writing) when the package is a DIRECT dependency there. */
+function writeNpmOverride(rootAbs: string, pkg: string, version: string): ManifestEdit {
+  const file = path.join(rootAbs, 'package.json');
+  const text = fs.readFileSync(file, 'utf8');
+  const manifest = JSON.parse(text) as Record<string, unknown>;
+  for (const section of ['dependencies', 'devDependencies', 'optionalDependencies'] as const) {
+    const deps = manifest[section];
+    if (deps && typeof deps === 'object' && pkg in (deps as Record<string, unknown>)) {
+      return {
+        file,
+        refused:
+          `'${pkg}' is a direct ${section.replace(/ies$/, 'y')} of this manifest; the honest ` +
+          'fix is upgrading the declared dependency (the dep-bump lane), not overriding it',
+      };
+    }
+  }
+  const overrides =
+    manifest.overrides && typeof manifest.overrides === 'object'
+      ? (manifest.overrides as Record<string, unknown>)
+      : {};
+  overrides[pkg] = version;
+  manifest.overrides = overrides;
+  const indent = /\n([ \t]+)"/.exec(text)?.[1] ?? '  ';
+  const trailing = text.endsWith('\n') ? '\n' : '';
+  fs.writeFileSync(file, JSON.stringify(manifest, null, indent) + trailing);
+  return { file };
+}
+
+export async function executeOverridePin(
+  order: WorkOrder,
+  ctx: RecipeExecuteContext,
+): Promise<RecipeOutcome> {
+  const advs = advisories(order);
+  if (advs.length === 0 || advs.length !== order.findings.length) {
+    return { kind: 'refused', reason: 'the order carries non-advisory findings' };
+  }
+  const pkg = advs[0].package;
+  const fixedVersions = advs.map((a) => a.fixedVersion).filter((v): v is string => !!v);
+  if (fixedVersions.length !== advs.length) {
+    return {
+      kind: 'refused',
+      reason: `no fixed version is known for every advisory against '${pkg}'`,
+    };
+  }
+  const rootDir = owningManifestRoot(order);
+  if (rootDir === null) {
+    return {
+      kind: 'refused',
+      reason:
+        'the envelope does not name exactly one package.json, so the owning dependency root ' +
+        'is ambiguous',
+    };
+  }
+  const lock = nodePmAt(ctx.cwd, rootDir);
+  if (lock === null) {
+    return {
+      kind: 'refused',
+      reason: `no lockfile exists at ${rootDir || 'the repo root'}, and an override cannot be verified without one`,
+    };
+  }
+  if (lock.pm !== 'npm') {
+    return {
+      kind: 'refused',
+      reason:
+        `the '${lock.pm}' override mechanism (${lock.pm === 'yarn' ? 'resolutions' : `${lock.pm}.overrides`}) ` +
+        'is not implemented in this recipe yet (npm overrides only this round)',
+    };
+  }
+
+  // The pin: the highest known fixed version clears every advisory at once.
+  const pin = maxSemver(fixedVersions);
+  const notes: string[] = [];
+
+  // $0 pre-check: would the pinned version itself carry a block-tier
+  // advisory? A null answer (network) is disclosed and the re-audit verify
+  // plus the frame's guardrail stay the backstop; it is never read as clean.
+  const known = await ctx.queryOsv(pkg, pin, 'npm');
+  if (known === null) {
+    notes.push(`OSV pre-check for ${pkg}@${pin} could not be reached; the re-audit verifies`);
+  } else {
+    const blockTier = known.filter((v) => {
+      const s = classifyOsvSeverity(v);
+      return s === 'high' || s === 'critical';
+    });
+    if (blockTier.length > 0) {
+      const ids = blockTier.map((v) => v.id ?? 'unidentified advisory').join(', ');
+      return {
+        kind: 'refused',
+        reason:
+          `pinning ${pkg} to ${pin} would leave a block-tier advisory in place: ${ids}. ` +
+          'A higher fixed version (or a different fix) is needed; not applying',
+      };
+    }
+  }
+
+  const rootAbs = path.join(ctx.cwd, rootDir);
+  const edit = writeNpmOverride(rootAbs, pkg, pin);
+  if (edit.refused) return { kind: 'refused', reason: edit.refused };
+
+  const installFailure = runResyncInstall(resyncInstallFor(lock.pm), rootAbs, ctx.exec);
+  if (installFailure) return installFailure;
+
+  // Verify: the ONE dep-audit dispatch, then "the order's package audits
+  // clean": its known advisories are gone and nothing new was minted on it
+  // (an override-pin order carries EVERY advisory of its package, so any
+  // remaining finding on the package is a verify failure either way).
+  const audited = await ctx.auditDepVulns(ctx.cwd);
+  if (audited === null) {
+    return {
+      kind: 'failed',
+      step: 'verify-audit',
+      output: 'the dependency re-audit could not run, so the pin cannot be verified here',
+    };
+  }
+  const remaining = audited.filter((f) => f.package === pkg);
+  if (remaining.length > 0) {
+    return {
+      kind: 'failed',
+      step: 'verify-audit',
+      output:
+        `advisories still reported against ${pkg} after pinning ${pin}: ` +
+        remaining.map((f) => f.id).join(', '),
+    };
+  }
+  const manifestPath = rootDir ? `${rootDir}/package.json` : 'package.json';
+  const lockPath = rootDir ? `${rootDir}/${lock.lockfile}` : lock.lockfile;
+  return {
+    kind: 'applied',
+    changedFiles: [manifestPath, lockPath],
+    ...(notes.length > 0 ? { notes } : {}),
+  };
+}

--- a/src/remediate/recipes/run-recipes.ts
+++ b/src/remediate/recipes/run-recipes.ts
@@ -1,0 +1,263 @@
+/**
+ * The recipe phase runner (remediate rethink, section 3B): execute the
+ * recipe-tier orders of a task's plan INSIDE the remediate frame, before any
+ * agent spawns. The most reliable agent run is the one that never happens:
+ * a plan whose selected orders are all recipe-tier completes at $0.
+ *
+ * Per order, in sequence on the task branch's working tree:
+ *
+ *   1. the registry entry's `execute` runs (bounded exec, trust-gated at
+ *      THIS entry point: an untrusted tree refuses every order before
+ *      anything spawns, disclosed);
+ *   2. the diff the recipe left is measured against the tree state BEFORE it
+ *      ran (a locally dirty tree's pre-existing edits are never touched);
+ *   3. envelope enforcement: paths outside the order's envelope are
+ *      DISCARDED and disclosed (`droppedPaths`): sprawl is unlandable by
+ *      construction, the same doctrine the agent sweep applies;
+ *   4. an applied outcome with an in-envelope diff commits as one
+ *      `fix(<class>): <order id>` commit; a refusal or failure discards the
+ *      recipe's whole diff.
+ *
+ * The frame then runs the ONE tree verification over the combined result:
+ * a recipe never certifies itself past the guardrail.
+ *
+ * The registry is iterated, never hardcoded (`registry` is injectable and
+ * the playbook test injects a synthetic recipe, the Rule 6 discipline).
+ */
+import { makeCommandExec, tail, type CommandExec } from '../../analyzers/tools/bounded-exec';
+import { gatherDepVulnsWithAvailability } from '../../analyzers/security/gather';
+import { queryOsvPackage, type OsvPackageQuery } from '../../analyzers/tools/osv';
+import type { AnalysisTrustContext } from '../../analysis-trust';
+import type { CorrectnessFloorResult } from '../../analyzers/correctness/run';
+import type { DepVulnFinding } from '../../languages/capabilities/types';
+import type { RemediateConfig } from '../config';
+import { planRepoWorkOrders, type GatherWorkOrderOptions } from '../work-orders/gather';
+import { classesSelectedBy } from '../work-orders/types';
+import { selectOrders } from '../work-orders/planner';
+import { RECIPE_REGISTRY, type RecipeDeclaration } from '../work-orders/recipes-registry';
+import type { WorkOrder } from '../work-orders/types';
+import { partitionByEnvelope } from './envelope';
+import { realRecipeGit, type RecipeGit } from './git';
+import type { RecipeOutcome } from './types';
+
+export interface RecipeOrderRecord {
+  readonly orderId: string;
+  readonly class: string;
+  readonly recipe: string;
+  readonly outcome: RecipeOutcome;
+  /** Out-of-envelope paths the enforcement discarded (disclosed). */
+  readonly droppedPaths?: readonly string[];
+}
+
+export interface RecipePhaseSummary {
+  /** Did the phase execute at all? False when disabled, when planning
+   *  failed, or when the task selects no recipe-tier orders. */
+  readonly ran: boolean;
+  /** `remediate.recipes.enabled: false` (disclosed, never silent). */
+  readonly disabled?: boolean;
+  /** Planning broke (fail-open: the agent path proceeds; the ledger says
+   *  why no recipe ran). */
+  readonly planError?: string;
+  /** Degraded gather reads, straight from the ONE gather adapter. */
+  readonly disclosures: readonly string[];
+  /** Orders the task selected, split by tier. Agent-tier orders are NOT
+   *  dispatched by this phase (the scoped-agent unit owns that); the count
+   *  is disclosed so a reader knows what remains. */
+  readonly selectedRecipeTier: number;
+  readonly selectedAgentTier: number;
+  readonly records: readonly RecipeOrderRecord[];
+}
+
+export function emptyRecipePhase(extra?: Partial<RecipePhaseSummary>): RecipePhaseSummary {
+  return {
+    ran: false,
+    disclosures: [],
+    selectedRecipeTier: 0,
+    selectedAgentTier: 0,
+    records: [],
+    ...extra,
+  };
+}
+
+export interface RunRecipeOrdersDeps {
+  readonly cwd: string;
+  readonly trust: AnalysisTrustContext;
+  readonly git: RecipeGit;
+  readonly exec: CommandExec;
+  readonly timeoutMs?: number;
+  readonly registry?: readonly RecipeDeclaration[];
+  readonly queryOsv?: OsvPackageQuery;
+  readonly auditDepVulns?: (cwd: string) => Promise<readonly DepVulnFinding[] | null>;
+}
+
+/** The default re-audit: the ONE dep-audit dispatch primitive; an
+ *  unavailable audit reads as null (cannot verify), never as clean. */
+async function defaultAudit(cwd: string): Promise<readonly DepVulnFinding[] | null> {
+  const result = await gatherDepVulnsWithAvailability(cwd);
+  if (!result.available) return null;
+  return result.envelope?.findings ?? [];
+}
+
+/** Execute the recipe-tier orders, in plan (value) order. */
+export async function runRecipeOrders(
+  orders: readonly WorkOrder[],
+  deps: RunRecipeOrdersDeps,
+): Promise<RecipeOrderRecord[]> {
+  const registry = deps.registry ?? RECIPE_REGISTRY;
+  const records: RecipeOrderRecord[] = [];
+  for (const order of orders) {
+    if (order.tier !== 'recipe' || !order.recipe) continue;
+    const base = { orderId: order.id, class: String(order.class), recipe: order.recipe };
+    // Rule 17, decided at the ONE phase entry point: recipes run installs
+    // and linters, so an untrusted tree refuses every order before any
+    // registry entry executes, disclosed per order, never silent.
+    if (!deps.trust.repoExecutionAllowed) {
+      records.push({
+        ...base,
+        outcome: {
+          kind: 'refused',
+          reason:
+            `repo execution is not allowed under this trust context (${deps.trust.source}); ` +
+            'recipes run package-manager and linter commands, so nothing spawned',
+        },
+      });
+      continue;
+    }
+    const decl = registry.find((r) => r.id === order.recipe);
+    if (!decl?.execute) {
+      records.push({
+        ...base,
+        outcome: {
+          kind: 'refused',
+          reason: `recipe '${order.recipe}' is declared but not executable in this build`,
+        },
+      });
+      continue;
+    }
+    const pre = new Set(deps.git.changedPaths());
+    let outcome: RecipeOutcome;
+    try {
+      outcome = await decl.execute(order, {
+        cwd: deps.cwd,
+        trust: deps.trust,
+        exec: deps.exec,
+        ...(deps.timeoutMs !== undefined ? { timeoutMs: deps.timeoutMs } : {}),
+        queryOsv: deps.queryOsv ?? queryOsvPackage,
+        auditDepVulns: deps.auditDepVulns ?? defaultAudit,
+      });
+    } catch (err) {
+      outcome = {
+        kind: 'failed',
+        step: 'recipe',
+        output: tail(err instanceof Error ? err.message : String(err)),
+      };
+    }
+    // Only the paths THIS recipe dirtied are in play: pre-existing local
+    // edits are never staged, committed, or discarded by the phase.
+    const delta = deps.git.changedPaths().filter((p) => !pre.has(p));
+    if (outcome.kind !== 'applied') {
+      deps.git.discardPaths(delta);
+      records.push({ ...base, outcome });
+      continue;
+    }
+    const { inside, outside } = partitionByEnvelope(delta, order.envelope);
+    if (outside.length > 0) deps.git.discardPaths(outside);
+    if (inside.length === 0) {
+      records.push({
+        ...base,
+        outcome: {
+          kind: 'failed',
+          step: 'envelope',
+          output:
+            'the recipe reported applied but left no change inside the order envelope' +
+            (outside.length > 0 ? ` (out-of-envelope paths were discarded)` : ''),
+        },
+        ...(outside.length > 0 ? { droppedPaths: outside } : {}),
+      });
+      continue;
+    }
+    deps.git.commitPaths(inside, `fix(${order.class}): ${order.id} (${decl.id} recipe)`);
+    records.push({
+      ...base,
+      outcome: { ...outcome, changedFiles: inside },
+      ...(outside.length > 0 ? { droppedPaths: outside } : {}),
+    });
+  }
+  return records;
+}
+
+export interface RecipePhaseOptions {
+  readonly cwd: string;
+  readonly trust: AnalysisTrustContext;
+  readonly taskId: string;
+  readonly config: RemediateConfig;
+  /** The entry floor the frame already captured, reused as the plan's floor
+   *  source so the phase never pays (or diverges from) a second floor run. */
+  readonly entryFloor: CorrectnessFloorResult;
+  /** Injection seams (tests). */
+  readonly git?: RecipeGit;
+  readonly exec?: CommandExec;
+  readonly timeoutMs?: number;
+  readonly registry?: readonly RecipeDeclaration[];
+  readonly gather?: GatherWorkOrderOptions;
+  readonly queryOsv?: OsvPackageQuery;
+  readonly auditDepVulns?: (cwd: string) => Promise<readonly DepVulnFinding[] | null>;
+}
+
+/**
+ * Plan the repo's work orders, select the task's classes, and execute the
+ * recipe tier. Fail-open on planning (a broken plan is a disclosed
+ * `planError`, and the agent path proceeds exactly as before this phase
+ * existed); fail-closed inside each recipe (an unverified diff is
+ * discarded).
+ */
+export async function runRecipePhaseForTask(opts: RecipePhaseOptions): Promise<RecipePhaseSummary> {
+  if (!opts.config.recipes.enabled) {
+    return emptyRecipePhase({ disabled: true });
+  }
+  let plan;
+  try {
+    plan = await planRepoWorkOrders(opts.cwd, opts.config, {
+      runFloor: () => opts.entryFloor,
+      ...opts.gather,
+    });
+  } catch (err) {
+    return emptyRecipePhase({ planError: err instanceof Error ? err.message : String(err) });
+  }
+  const selected = selectOrders(plan.plan, classesSelectedBy(opts.taskId));
+  const recipeTier = selected.filter((o) => o.tier === 'recipe');
+  const summaryBase = {
+    disclosures: plan.disclosures,
+    selectedRecipeTier: recipeTier.length,
+    selectedAgentTier: selected.length - recipeTier.length,
+  };
+  if (recipeTier.length === 0) return { ran: false, records: [], ...summaryBase };
+  const records = await runRecipeOrders(recipeTier, {
+    cwd: opts.cwd,
+    trust: opts.trust,
+    git: opts.git ?? realRecipeGit(opts.cwd),
+    exec: opts.exec ?? makeCommandExec(opts.timeoutMs),
+    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+    ...(opts.registry ? { registry: opts.registry } : {}),
+    ...(opts.queryOsv ? { queryOsv: opts.queryOsv } : {}),
+    ...(opts.auditDepVulns ? { auditDepVulns: opts.auditDepVulns } : {}),
+  });
+  return { ran: true, records, ...summaryBase };
+}
+
+/** Convenience projections for the frame's decision + ledger. */
+export function recipeCounts(summary: RecipePhaseSummary): {
+  applied: number;
+  refused: number;
+  failed: number;
+} {
+  let applied = 0;
+  let refused = 0;
+  let failed = 0;
+  for (const r of summary.records) {
+    if (r.outcome.kind === 'applied') applied += 1;
+    else if (r.outcome.kind === 'refused') refused += 1;
+    else failed += 1;
+  }
+  return { applied, refused, failed };
+}

--- a/src/remediate/recipes/run-recipes.ts
+++ b/src/remediate/recipes/run-recipes.ts
@@ -26,9 +26,12 @@
  */
 import { makeCommandExec, tail, type CommandExec } from '../../analyzers/tools/bounded-exec';
 import { gatherDepVulnsWithAvailability } from '../../analyzers/security/gather';
-import { queryOsvPackage, type OsvPackageQuery } from '../../analyzers/tools/osv';
+import { queryOsvPackage, type OsvPackageQuery, type OsvVuln } from '../../analyzers/tools/osv';
 import type { AnalysisTrustContext } from '../../analysis-trust';
 import type { CorrectnessFloorResult } from '../../analyzers/correctness/run';
+import { newAdvisoryBlockSeverities } from '../../baseline/policy-sections';
+import { readPolicySection } from '../../baseline/policy-text';
+import type { FindingSeverity } from '../../baseline/types';
 import type { DepVulnFinding } from '../../languages/capabilities/types';
 import type { RemediateConfig } from '../config';
 import { planRepoWorkOrders, type GatherWorkOrderOptions } from '../work-orders/gather';
@@ -36,7 +39,7 @@ import { classesSelectedBy } from '../work-orders/types';
 import { selectOrders } from '../work-orders/planner';
 import { RECIPE_REGISTRY, type RecipeDeclaration } from '../work-orders/recipes-registry';
 import type { WorkOrder } from '../work-orders/types';
-import { partitionByEnvelope } from './envelope';
+import { partitionByEnvelope, pathInEnvelope } from './envelope';
 import { realRecipeGit, type RecipeGit } from './git';
 import type { RecipeOutcome } from './types';
 
@@ -84,10 +87,35 @@ export interface RunRecipeOrdersDeps {
   readonly trust: AnalysisTrustContext;
   readonly git: RecipeGit;
   readonly exec: CommandExec;
-  readonly timeoutMs?: number;
   readonly registry?: readonly RecipeDeclaration[];
   readonly queryOsv?: OsvPackageQuery;
   readonly auditDepVulns?: (cwd: string) => Promise<readonly DepVulnFinding[] | null>;
+  /** The advisory block tier for the OSV pre-checks; defaults to the repo's
+   *  policy through the one normalizer (`effectiveBlockSeverities`). */
+  readonly blockSeverities?: ReadonlySet<FindingSeverity>;
+}
+
+/** The repo's effective advisory block tier, through the ONE policy
+ *  normalizer the guardrail's new-advisory classifier reads (Rule 2.30). */
+export function effectiveBlockSeverities(cwd: string): ReadonlySet<FindingSeverity> {
+  return newAdvisoryBlockSeverities({
+    newAdvisories: readPolicySection(cwd, 'newAdvisories') as never,
+  });
+}
+
+/** Wrap an OSV query in a per-run cache: one plan can ask about the same
+ *  candidate from several orders, and a network answer does not change
+ *  mid-run. */
+export function cachedOsvQuery(query: OsvPackageQuery): OsvPackageQuery {
+  const cache = new Map<string, Promise<OsvVuln[] | null>>();
+  return (pkg, version, ecosystem) => {
+    const key = `${ecosystem}\0${pkg}\0${version}`;
+    const hit = cache.get(key);
+    if (hit) return hit;
+    const pending = query(pkg, version, ecosystem);
+    cache.set(key, pending);
+    return pending;
+  };
 }
 
 /** The default re-audit: the ONE dep-audit dispatch primitive; an
@@ -104,6 +132,8 @@ export async function runRecipeOrders(
   deps: RunRecipeOrdersDeps,
 ): Promise<RecipeOrderRecord[]> {
   const registry = deps.registry ?? RECIPE_REGISTRY;
+  const queryOsv = cachedOsvQuery(deps.queryOsv ?? queryOsvPackage);
+  const blockSeverities = deps.blockSeverities ?? effectiveBlockSeverities(deps.cwd);
   const records: RecipeOrderRecord[] = [];
   for (const order of orders) {
     if (order.tier !== 'recipe' || !order.recipe) continue;
@@ -134,15 +164,47 @@ export async function runRecipeOrders(
       });
       continue;
     }
-    const pre = new Set(deps.git.changedPaths());
+    let pre: Set<string>;
+    try {
+      pre = new Set(deps.git.changedPaths());
+    } catch (err) {
+      records.push({
+        ...base,
+        outcome: {
+          kind: 'failed',
+          step: 'working-tree',
+          output: tail(err instanceof Error ? err.message : String(err)),
+        },
+      });
+      continue;
+    }
+    // A pre-existing uncommitted edit INSIDE the envelope makes the recipe's
+    // own diff unattributable: an edit to an already-dirty file would be
+    // neither committed (a partial manifest commit CI cannot install) nor
+    // discarded (leaking the recipe's change into the user's dirt). Refuse
+    // up front, dirty paths named, so both contracts hold exactly.
+    const dirtyInEnvelope = [...pre].filter((path) => pathInEnvelope(path, order.envelope));
+    if (dirtyInEnvelope.length > 0) {
+      records.push({
+        ...base,
+        outcome: {
+          kind: 'refused',
+          reason:
+            'the working tree already has uncommitted changes inside this order envelope ' +
+            `(${dirtyInEnvelope.join(', ')}); commit or stash them so the recipe's own diff ` +
+            'stays attributable',
+        },
+      });
+      continue;
+    }
     let outcome: RecipeOutcome;
     try {
       outcome = await decl.execute(order, {
         cwd: deps.cwd,
         trust: deps.trust,
         exec: deps.exec,
-        ...(deps.timeoutMs !== undefined ? { timeoutMs: deps.timeoutMs } : {}),
-        queryOsv: deps.queryOsv ?? queryOsvPackage,
+        queryOsv,
+        blockSeverities,
         auditDepVulns: deps.auditDepVulns ?? defaultAudit,
       });
     } catch (err) {
@@ -154,7 +216,22 @@ export async function runRecipeOrders(
     }
     // Only the paths THIS recipe dirtied are in play: pre-existing local
     // edits are never staged, committed, or discarded by the phase.
-    const delta = deps.git.changedPaths().filter((p) => !pre.has(p));
+    let delta: string[];
+    try {
+      delta = deps.git.changedPaths().filter((p) => !pre.has(p));
+    } catch (err) {
+      records.push({
+        ...base,
+        outcome: {
+          kind: 'failed',
+          step: 'working-tree',
+          output:
+            'could not read the working tree after the recipe ran, so its diff can be ' +
+            `neither enforced nor committed: ${tail(err instanceof Error ? err.message : String(err))}`,
+        },
+      });
+      continue;
+    }
     if (outcome.kind !== 'applied') {
       deps.git.discardPaths(delta);
       records.push({ ...base, outcome });
@@ -202,6 +279,7 @@ export interface RecipePhaseOptions {
   readonly gather?: GatherWorkOrderOptions;
   readonly queryOsv?: OsvPackageQuery;
   readonly auditDepVulns?: (cwd: string) => Promise<readonly DepVulnFinding[] | null>;
+  readonly blockSeverities?: ReadonlySet<FindingSeverity>;
 }
 
 /**
@@ -237,10 +315,10 @@ export async function runRecipePhaseForTask(opts: RecipePhaseOptions): Promise<R
     trust: opts.trust,
     git: opts.git ?? realRecipeGit(opts.cwd),
     exec: opts.exec ?? makeCommandExec(opts.timeoutMs),
-    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
     ...(opts.registry ? { registry: opts.registry } : {}),
     ...(opts.queryOsv ? { queryOsv: opts.queryOsv } : {}),
     ...(opts.auditDepVulns ? { auditDepVulns: opts.auditDepVulns } : {}),
+    ...(opts.blockSeverities ? { blockSeverities: opts.blockSeverities } : {}),
   });
   return { ran: true, records, ...summaryBase };
 }

--- a/src/remediate/recipes/shared.ts
+++ b/src/remediate/recipes/shared.ts
@@ -1,0 +1,86 @@
+/**
+ * Helpers the recipe executors share: the owning-manifest-root derivation
+ * (from the order's own envelope, never a second discovery walk) and the
+ * one resync-install runner (the lock-writing install with its declared
+ * fallback doctrine, executed through the injected bounded exec).
+ */
+import * as path from 'path';
+import { tail, type CommandExec } from '../../analyzers/tools/bounded-exec';
+import {
+  detectLockfile,
+  isPeerConflictOnly,
+  resyncInstallFor,
+  type ResyncInstall,
+} from '../../package-manager';
+import type { WorkOrder } from '../work-orders/types';
+import type { RecipeOutcome } from './types';
+
+/**
+ * The dependency root an order's fix belongs to, derived from the order's
+ * OWN envelope (the planner already scoped it): the directory of the one
+ * `package.json` the envelope names. Two roots in one envelope means the
+ * planner could not decide (the all-roots fallback); the recipe refuses
+ * rather than guess which manifest to edit.
+ */
+export function owningManifestRoot(order: WorkOrder): string | null {
+  const dirs = new Set(
+    order.envelope.paths
+      .filter((p) => p === 'package.json' || p.endsWith('/package.json'))
+      .map((p) => (p === 'package.json' ? '' : p.slice(0, -'/package.json'.length))),
+  );
+  return dirs.size === 1 ? [...dirs][0] : null;
+}
+
+/** The node package manager owning `rootDir` (repo-relative; '' = repo
+ *  root), from the lockfile actually present (the ONE detector). */
+export function nodePmAt(cwd: string, rootDir: string): ReturnType<typeof detectLockfile> {
+  return detectLockfile(path.join(cwd, rootDir));
+}
+
+/**
+ * Run the lock-writing install at a root, honoring the declared fallback
+ * doctrine (the npm peer-conflict retry, gated by the shared
+ * `isPeerConflictOnly`, never a blanket retry). Returns null on success,
+ * or a `failed` outcome naming the step. Infrastructure (missing binary,
+ * timeout, capture overflow) is a failure of THIS recipe run, named; the
+ * order simply stays open for the agent tier.
+ */
+export function runResyncInstall(
+  plan: ResyncInstall,
+  rootAbs: string,
+  exec: CommandExec,
+): Extract<RecipeOutcome, { kind: 'failed' }> | null {
+  const attempt = (argv: readonly string[]) => {
+    const [bin, ...args] = argv;
+    return exec({ bin, args }, rootAbs);
+  };
+  const primary = attempt(plan.argv);
+  if (!primary.available) {
+    return { kind: 'failed', step: 'install', output: `${plan.argv[0]} is not available here` };
+  }
+  if (primary.timedOut) {
+    return { kind: 'failed', step: 'install', output: `${plan.argv.join(' ')} timed out` };
+  }
+  if (primary.overflowed) {
+    return {
+      kind: 'failed',
+      step: 'install',
+      output: `${plan.argv.join(' ')} overflowed the capture buffer`,
+    };
+  }
+  if (primary.code === 0) return null;
+  if (plan.fallback && isPeerConflictOnly(primary.output)) {
+    const fb = attempt(plan.fallback.argv);
+    if (fb.available && !fb.timedOut && !fb.overflowed && fb.code === 0) return null;
+    return {
+      kind: 'failed',
+      step: 'install',
+      output: tail(
+        `${primary.output}\n--- fallback (${plan.fallback.argv.join(' ')}) ---\n${fb.output}`,
+      ),
+    };
+  }
+  return { kind: 'failed', step: 'install', output: tail(primary.output) };
+}
+
+export { resyncInstallFor };

--- a/src/remediate/recipes/shared.ts
+++ b/src/remediate/recipes/shared.ts
@@ -1,19 +1,131 @@
 /**
  * Helpers the recipe executors share: the owning-manifest-root derivation
- * (from the order's own envelope, never a second discovery walk) and the
- * one resync-install runner (the lock-writing install with its declared
- * fallback doctrine, executed through the injected bounded exec).
+ * (from the order's own envelope, never a second discovery walk), the one
+ * resync-install runner (the lock-writing install with its declared
+ * fallback doctrine, executed through the injected bounded exec), the
+ * strict npm-name and concrete-semver shapes the registry's `matches` and
+ * the executors both read, and the ONE policy-driven block-tier filter for
+ * the OSV pre-checks.
  */
 import * as path from 'path';
-import { tail, type CommandExec } from '../../analyzers/tools/bounded-exec';
-import {
-  detectLockfile,
-  isPeerConflictOnly,
-  resyncInstallFor,
-  type ResyncInstall,
-} from '../../package-manager';
+import { tail, type CommandExec, type CommandOutcome } from '../../analyzers/tools/bounded-exec';
+import { classifyOsvSeverity, type OsvVuln } from '../../analyzers/tools/osv';
+import type { FindingSeverity } from '../../baseline/types';
+import { detectLockfile, resyncInstallFor, type ResyncInstall } from '../../package-manager';
 import type { WorkOrder } from '../work-orders/types';
 import type { RecipeOutcome } from './types';
+
+/**
+ * A strict npm package-name shape (name, or @scope/name): lowercase-biased
+ * URL-safe characters, first character alphanumeric. Load-bearing for the
+ * Rule 11 argument-injection discipline, not just hygiene: an unresolved
+ * "specifier" is attacker-influencable text from source code, and a
+ * leading-dash value handed to a package-manager argv is a flag (a
+ * `--registry=...` import would redirect the install). Everything outside
+ * this shape is refused before any argv is built.
+ */
+const NPM_PACKAGE_NAME = /^(@[a-z0-9][a-z0-9-._~]*\/)?[a-z0-9][a-z0-9-._~]*$/i;
+
+export function isValidNpmPackageName(name: string): boolean {
+  return name.length > 0 && name.length <= 214 && NPM_PACKAGE_NAME.test(name);
+}
+
+/** A CONCRETE semver (x.y.z with optional prerelease/build), never a range.
+ *  A range-shaped "fixed version" (`>=4.1.0`) cannot be pinned verbatim, so
+ *  orders carrying one tier to the agent instead of guessing. */
+const CONCRETE_SEMVER =
+  /^\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+
+export function isConcreteSemver(version: string): boolean {
+  return CONCRETE_SEMVER.test(version);
+}
+
+/** Semver precedence for CONCRETE versions, prerelease rules included: a
+ *  release outranks its prereleases (1.2.3 > 1.2.3-beta.1), prerelease
+ *  identifiers compare numerically when numeric, bytewise otherwise, and a
+ *  longer identifier list wins over its prefix (semver.org section 11). */
+export function compareConcreteSemver(a: string, b: string): number {
+  const parse = (v: string) => {
+    const [core] = v.split('+');
+    const [nums, ...preParts] = core.split('-');
+    return {
+      nums: nums.split('.').map(Number),
+      pre: preParts.length > 0 ? preParts.join('-').split('.') : null,
+    };
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < 3; i++) {
+    if (pa.nums[i] !== pb.nums[i]) return pa.nums[i] - pb.nums[i];
+  }
+  if (pa.pre === null && pb.pre === null) return 0;
+  if (pa.pre === null) return 1;
+  if (pb.pre === null) return -1;
+  for (let i = 0; i < Math.max(pa.pre.length, pb.pre.length); i++) {
+    const x = pa.pre[i];
+    const y = pb.pre[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    const xn = /^\d+$/.test(x);
+    const yn = /^\d+$/.test(y);
+    if (xn && yn) {
+      if (Number(x) !== Number(y)) return Number(x) - Number(y);
+    } else if (xn !== yn) {
+      return xn ? -1 : 1; // numeric identifiers rank below alphanumeric
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/** The pin an override-pin order applies: the highest CONCRETE version among
+ *  the known fixed versions, or null when any is range-shaped (refuse, never
+ *  guess a range's meaning). */
+export function pickPinVersion(versions: readonly string[]): string | null {
+  if (versions.length === 0 || !versions.every(isConcreteSemver)) return null;
+  return versions.reduce((best, v) => (compareConcreteSemver(v, best) > 0 ? v : best));
+}
+
+/**
+ * The ONE policy-driven block-tier filter for the recipes' OSV pre-checks
+ * (Rule 2.30): which advisories on a candidate version REFUSE the recipe is
+ * the same question the guardrail's new-advisory classifier answers, so the
+ * tier comes from the same normalized policy set
+ * (`newAdvisoryBlockSeverities`), never a re-derived high-or-critical
+ * literal. `unknown` OSV severities pass (false-negative bias; the re-audit
+ * and the guardrail stay the backstop).
+ */
+export function osvBlockTier(
+  vulns: readonly OsvVuln[],
+  blockSeverities: ReadonlySet<FindingSeverity>,
+): OsvVuln[] {
+  return vulns.filter((v) => {
+    const s = classifyOsvSeverity(v);
+    return s !== 'unknown' && blockSeverities.has(s);
+  });
+}
+
+/** The one infrastructure-shaped triage of a bounded-exec outcome: null when
+ *  the command ran to completion cleanly; a named `failed` otherwise. The
+ *  resync runner and the declare-dependency install share it. */
+export function execStepFailure(
+  step: string,
+  label: string,
+  outcome: CommandOutcome,
+): Extract<RecipeOutcome, { kind: 'failed' }> | null {
+  if (!outcome.available) {
+    return { kind: 'failed', step, output: `${label}: binary not available here` };
+  }
+  if (outcome.timedOut) return { kind: 'failed', step, output: `${label} timed out` };
+  if (outcome.overflowed) {
+    return { kind: 'failed', step, output: `${label} overflowed the capture buffer` };
+  }
+  if (outcome.code !== 0) {
+    return { kind: 'failed', step, output: tail(`${label}: ${outcome.output || 'non-zero exit'}`) };
+  }
+  return null;
+}
 
 /**
  * The dependency root an order's fix belongs to, derived from the order's
@@ -39,9 +151,9 @@ export function nodePmAt(cwd: string, rootDir: string): ReturnType<typeof detect
 
 /**
  * Run the lock-writing install at a root, honoring the declared fallback
- * doctrine (the npm peer-conflict retry, gated by the shared
- * `isPeerConflictOnly`, never a blanket retry). Returns null on success,
- * or a `failed` outcome naming the step. Infrastructure (missing binary,
+ * doctrine (the PM table's `fallback.matches` names the one failure shape
+ * the fallback answers, never a blanket retry). Returns null on success, or
+ * a `failed` outcome naming the step. Infrastructure (missing binary,
  * timeout, capture overflow) is a failure of THIS recipe run, named; the
  * order simply stays open for the agent tier.
  */
@@ -55,32 +167,24 @@ export function runResyncInstall(
     return exec({ bin, args }, rootAbs);
   };
   const primary = attempt(plan.argv);
-  if (!primary.available) {
-    return { kind: 'failed', step: 'install', output: `${plan.argv[0]} is not available here` };
+  const primaryFailure = execStepFailure('install', plan.argv.join(' '), primary);
+  if (primaryFailure === null) return null;
+  if (primary.available && !primary.timedOut && !primary.overflowed && plan.fallback) {
+    // The declared fallback runs ONLY on the failure shape it answers
+    // (`fallback.matches`, from the one PM table), never as a blanket retry.
+    if (plan.fallback.matches(primary.output)) {
+      const fb = attempt(plan.fallback.argv);
+      if (execStepFailure('install', plan.fallback.argv.join(' '), fb) === null) return null;
+      return {
+        kind: 'failed',
+        step: 'install',
+        output: tail(
+          `${primary.output}\n--- fallback (${plan.fallback.argv.join(' ')}) ---\n${fb.output}`,
+        ),
+      };
+    }
   }
-  if (primary.timedOut) {
-    return { kind: 'failed', step: 'install', output: `${plan.argv.join(' ')} timed out` };
-  }
-  if (primary.overflowed) {
-    return {
-      kind: 'failed',
-      step: 'install',
-      output: `${plan.argv.join(' ')} overflowed the capture buffer`,
-    };
-  }
-  if (primary.code === 0) return null;
-  if (plan.fallback && isPeerConflictOnly(primary.output)) {
-    const fb = attempt(plan.fallback.argv);
-    if (fb.available && !fb.timedOut && !fb.overflowed && fb.code === 0) return null;
-    return {
-      kind: 'failed',
-      step: 'install',
-      output: tail(
-        `${primary.output}\n--- fallback (${plan.fallback.argv.join(' ')}) ---\n${fb.output}`,
-      ),
-    };
-  }
-  return { kind: 'failed', step: 'install', output: tail(primary.output) };
+  return primaryFailure;
 }
 
 export { resyncInstallFor };

--- a/src/remediate/recipes/types.ts
+++ b/src/remediate/recipes/types.ts
@@ -24,6 +24,7 @@
  */
 import type { AnalysisTrustContext } from '../../analysis-trust';
 import type { CommandExec } from '../../analyzers/tools/bounded-exec';
+import type { FindingSeverity } from '../../baseline/types';
 import type { DepVulnFinding } from '../../languages/capabilities/types';
 import type { OsvPackageQuery } from '../../analyzers/tools/osv';
 
@@ -63,11 +64,14 @@ export interface RecipeExecuteContext {
   /** The ONE bounded spawn primitive: every install / linter / registry
    *  probe a recipe runs goes through this. */
   readonly exec: CommandExec;
-  /** Per-command wall-clock budget forwarded to verifies that spawn. */
-  readonly timeoutMs?: number;
-  /** OSV query-by-package (the $0 pre-check). Defaults to the real client;
-   *  injected in tests. `null` results are DISCLOSED, never read as clean. */
+  /** OSV query-by-package (the $0 pre-check). Defaults to the real client
+   *  wrapped in a per-run cache; injected in tests. `null` results are
+   *  DISCLOSED, never read as clean. */
   readonly queryOsv: OsvPackageQuery;
+  /** The advisory severities that REFUSE a candidate version, from the ONE
+   *  policy normalizer (`newAdvisoryBlockSeverities`) so the pre-checks and
+   *  the guardrail's new-advisory tier can never diverge (Rule 2.30). */
+  readonly blockSeverities: ReadonlySet<FindingSeverity>;
   /** Dependency re-audit over the ONE dispatch primitive
    *  (`gatherDepVulnsWithAvailability`). `null` = the audit could not run;
    *  the recipe fails its verify rather than claim an unobserved clean. */

--- a/src/remediate/recipes/types.ts
+++ b/src/remediate/recipes/types.ts
@@ -1,0 +1,75 @@
+/**
+ * The recipe executor contract (remediate rethink, section 3B): the
+ * deterministic tier's execution shapes. A recipe EXECUTES a work order
+ * without an agent (the frame runs it inside the remediate run, before any
+ * driver spawns), and its result is one of exactly three honest outcomes:
+ *
+ *   - `applied`: the fix is on the working tree and the recipe's own verify
+ *     confirmed it (the order's ids are gone). The frame then enforces the
+ *     envelope, commits, and the ONE tree verification remains the final
+ *     arbiter.
+ *   - `refused`: the recipe decided NOT to act, for a named reason, at $0,
+ *     the design's core move (a refusal with the advisory named beats a red
+ *     verification). The tree is untouched (the runner resets defensively).
+ *   - `failed`: the recipe acted but a step broke or its verify did not
+ *     confirm. The step is named, the evidence is the output tail, and the
+ *     runner DISCARDS the partial diff: a recipe never lands unverified
+ *     work.
+ *
+ * SECURITY (Rule 17): recipes spawn installs and linters, so execution is
+ * gated on the REQUIRED typed `AnalysisTrustContext` at the phase entry
+ * point (`run-recipes.ts`): an untrusted tree yields disclosed refusals
+ * before anything spawns. Every spawn goes through the injected bounded
+ * exec; a recipe never `execSync`s on its own.
+ */
+import type { AnalysisTrustContext } from '../../analysis-trust';
+import type { CommandExec } from '../../analyzers/tools/bounded-exec';
+import type { DepVulnFinding } from '../../languages/capabilities/types';
+import type { OsvPackageQuery } from '../../analyzers/tools/osv';
+
+export type RecipeOutcome =
+  | {
+      readonly kind: 'applied';
+      /** Repo-relative files the recipe changed (what it believes; the
+       *  runner's envelope enforcement re-reads git for ground truth). */
+      readonly changedFiles: readonly string[];
+      /** Disclosed side notes (a tolerated fallback that ran, an OSV
+       *  pre-check that could not be reached). */
+      readonly notes?: readonly string[];
+    }
+  | {
+      /** The recipe decided not to act. The reason is a full sentence a
+       *  ledger reader can act on; the tree is untouched. */
+      readonly kind: 'refused';
+      readonly reason: string;
+    }
+  | {
+      /** The recipe acted and a step broke (or its verify did not confirm).
+       *  The runner discards the partial diff. */
+      readonly kind: 'failed';
+      readonly step: string;
+      /** Captured output tail / verify evidence (display-sized). */
+      readonly output: string;
+    };
+
+/** What a recipe executes with. Everything spawnable or network-shaped is
+ *  injected so recipes unit-test against fixture repos with fake exec. */
+export interface RecipeExecuteContext {
+  readonly cwd: string;
+  /** REQUIRED typed trust (Rule 17). The phase runner refuses before any
+   *  execute when repo execution is not allowed; recipes may assume a
+   *  trusted context but never re-derive one. */
+  readonly trust: AnalysisTrustContext;
+  /** The ONE bounded spawn primitive: every install / linter / registry
+   *  probe a recipe runs goes through this. */
+  readonly exec: CommandExec;
+  /** Per-command wall-clock budget forwarded to verifies that spawn. */
+  readonly timeoutMs?: number;
+  /** OSV query-by-package (the $0 pre-check). Defaults to the real client;
+   *  injected in tests. `null` results are DISCLOSED, never read as clean. */
+  readonly queryOsv: OsvPackageQuery;
+  /** Dependency re-audit over the ONE dispatch primitive
+   *  (`gatherDepVulnsWithAvailability`). `null` = the audit could not run;
+   *  the recipe fails its verify rather than claim an unobserved clean. */
+  readonly auditDepVulns: (cwd: string) => Promise<readonly DepVulnFinding[] | null>;
+}

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -35,7 +35,12 @@ import { resolveDispatchedTask } from './dispatch';
 import { resumePromptNote } from './resume';
 import { realGit } from './git-ops';
 import { armGateForDriver } from './agent-trust';
-import { budgetPromptNote, clampBudgetToTokenLifetime, unenforceableCapsFor } from './budget-notes';
+import {
+  budgetOverruns,
+  budgetPromptNote,
+  clampBudgetToTokenLifetime,
+  unenforceableCapsFor,
+} from './budget-notes';
 import { evaluateScoreHinge, healthHingeScores } from './score-hinge';
 import { salvageForTask } from './config';
 import { recipeTierStep } from './recipes/complete';
@@ -184,16 +189,21 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   const entryScores = task.scoreHinge ? await hingeProbe(task.scoreHinge) : undefined;
   const baseHead = git.head();
 
-  // The deterministic recipe tier (section 3B): plan the task's work orders
-  // and execute the recipe-tier ones FIRST, each committed inside its
-  // envelope. When EVERY selected order was recipe-tier the run completes
-  // right here without any agent spawn, with the ONE tree verification
-  // still the arbiter of the combined recipe commits. Fail-open on
-  // planning; the step itself never throws (`recipeTierStep`).
+  // The deterministic recipe tier (section 3B, `recipeTierStep`): execute
+  // recipe-tier orders FIRST, each committed inside its envelope. A
+  // recipe-only plan completes right here with no agent spawn, the ONE
+  // tree verification still arbitrating. Fail-open on planning.
   opts.onPhase?.('recipes');
   const tier = await recipeTierStep(opts, { task, entryFloor, baseHead, git, runFloor });
   const recipesDisclosure = { recipes: tier.recipes };
   if (tier.done) return finish(tier.done);
+  // The agent's OWN base: recipe commits advance the branch first, so every
+  // "did the agent produce work" question measures from here; otherwise a
+  // dead agent wears the recipes' commits and an honest never-ran claim
+  // reads as contradicted. Verification and the lander's range stay
+  // anchored at baseHead so recipe commits are verified and land.
+  const agentBase = git.head();
+  const hasRecipeCommits = agentBase !== baseHead;
 
   opts.onPhase?.('agent');
   // Budget awareness (`budgetPromptNote`): appended by the runner, the one
@@ -224,13 +234,11 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     ? { transcriptTail: agentResult.transcriptTail }
     : {};
 
-  // Sweep uncommitted leftovers into a loudly-labeled commit — work the
-  // budget kill stranded mid-edit is still evidence, and a dirty tree must
-  // never leak into the landing layer unreviewed. The sweep runs BEFORE the
-  // driver's never-ran claim is honored: a classification must never decide
-  // the fate of evidence it has not looked at (#272 — a wall-clock kill the
-  // driver misread as "never ran" returned early here and discarded 30
-  // minutes of stranded work). A genuinely never-ran agent leaves nothing
+  // Sweep uncommitted leftovers into a loudly-labeled commit: stranded
+  // mid-edit work is still evidence, and a dirty tree must never leak into
+  // the landing layer unreviewed. Runs BEFORE the never-ran claim is
+  // honored: a classification must never decide the fate of evidence it
+  // has not looked at (#272). A genuinely never-ran agent leaves nothing
   // to sweep, so this is a no-op on that path.
   opts.onPhase?.('sweep');
   const sweepError = git.sweepLeftovers();
@@ -238,8 +246,8 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // agent committed mid-run) BEFORE the diff question — an attempt whose
   // only content was scan output must read as a no-op, and a real attempt
   // must not carry `.dxkit/reports/*` into its PR. Disclosed below.
-  const scrubbed = git.scrubRuntimeArtifacts(baseHead);
-  const hasDiff = git.hasDiff(baseHead);
+  const scrubbed = git.scrubRuntimeArtifacts(agentBase);
+  const hasDiff = git.hasDiff(agentBase);
 
   if (agentResult.neverRan) {
     // The tree is the arbiter of "ran": commits past baseHead, or leftovers
@@ -269,21 +277,9 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     };
   }
 
-  // Reported spend exceeding the (advisory) cap is an honest post-hoc claim
-  // — "the run overran maxUsd" — for any driver that at least REPORTS cost.
-  const overUsd =
-    driver.budgetSupport.cost !== 'none' &&
-    agentResult.costUsd !== undefined &&
-    agentResult.costUsd > budget.maxUsd;
-  // A cap dxkit cannot enforce is a cap dxkit may not claim was HIT — a
-  // driver that merely reports turns without enforcing them would mislabel
-  // a natural completion as budget-exhausted while the envelope discloses
-  // the cap as unenforceable.
-  const overTurns =
-    driver.budgetSupport.turns === 'enforced' &&
-    agentResult.turns !== undefined &&
-    agentResult.turns >= budget.maxTurns;
-  const partial = agentResult.timedOut || overUsd || overTurns;
+  // Budget-overrun facts, claimed only where dxkit can (`budgetOverruns`:
+  // reported cost vs advisory cap; turns only when the driver enforces).
+  const { overUsd, partial } = budgetOverruns(driver, agentResult, budget);
 
   // A failed sweep is a hard stop REGARDLESS of whether the agent committed
   // work: `git add -A` already staged the leftovers, so proceeding would let
@@ -338,33 +334,40 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
         note:
           `the agent run ended in an error and produced no committed change` +
           `${agentResult.failure ? `: ${agentResult.failure.reason}` : ''}. ` +
-          'Nothing to verify; nothing lands.',
+          'Nothing to verify; nothing lands' +
+          (hasRecipeCommits
+            ? ' (the recipe commits stay on the branch, unlanded, for the next attempt)'
+            : '') +
+          '.',
         baseHead,
         head: git.head(),
       });
     }
-    return finish({
-      outcome: 'no-op',
-      task: task.id,
-      ...recipesDisclosure,
-      envelope,
-      floor: entryFloor,
-      ...evidenceTail,
-      // The agent's own account of why nothing changed (#285): a clean
-      // no-op discards the transcript by design, which made "no-op against
-      // a visibly non-empty inventory" unautopsiable. Attempt-record
-      // evidence only — never the ledger / PR body.
-      ...(agentResult.finalMessage ? { agentFinalMessage: agentResult.finalMessage } : {}),
-      ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
-      ...(partial ? { partial } : {}),
-      note:
-        scrubbed.length > 0
-          ? 'agent ran and produced no committed change beyond regenerable dxkit scan state ' +
-            '(dropped, disclosed below).'
-          : 'agent ran and produced no committed change.',
-      baseHead,
-      head: git.head(),
-    });
+    // The AGENT added nothing, but applied recipe commits are real work:
+    // fall through so the combined head is verified and can land.
+    if (!hasRecipeCommits)
+      return finish({
+        outcome: 'no-op',
+        task: task.id,
+        ...recipesDisclosure,
+        envelope,
+        floor: entryFloor,
+        ...evidenceTail,
+        // The agent's own account of why nothing changed (#285): a clean
+        // no-op discards the transcript by design, which made "no-op against
+        // a visibly non-empty inventory" unautopsiable. Attempt-record
+        // evidence only, never the ledger / PR body.
+        ...(agentResult.finalMessage ? { agentFinalMessage: agentResult.finalMessage } : {}),
+        ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
+        ...(partial ? { partial } : {}),
+        note:
+          scrubbed.length > 0
+            ? 'agent ran and produced no committed change beyond regenerable dxkit scan state ' +
+              '(dropped, disclosed below).'
+            : 'agent ran and produced no committed change.',
+        baseHead,
+        head: git.head(),
+      });
   }
 
   // Verify the committed head the way CI will (the ONE tree verification,

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -34,10 +34,11 @@ import type { RemediateTask } from './tasks';
 import { resolveDispatchedTask } from './dispatch';
 import { resumePromptNote } from './resume';
 import { realGit } from './git-ops';
-import { armInLoopGate, type InLoopGateStatus } from './agent-trust';
-import { clampBudgetToTokenLifetime, unenforceableCapsFor } from './budget-notes';
+import { armGateForDriver } from './agent-trust';
+import { budgetPromptNote, clampBudgetToTokenLifetime, unenforceableCapsFor } from './budget-notes';
 import { evaluateScoreHinge, healthHingeScores } from './score-hinge';
 import { salvageForTask } from './config';
+import { recipeTierStep } from './recipes/complete';
 import type { AgentEnvelope, RemediateResult, RemediateRunOptions } from './outcome';
 
 // The outcome vocabulary lives in `./outcome` and the ledger renderer in
@@ -127,22 +128,10 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     ? 'api-key'
     : 'subscription';
 
-  // The in-loop gate (#305): pre-trust the lane's own CI checkout so the
-  // committed Stop hook can actually LOAD (an untrusted workspace made the
-  // in-loop gate silently absent on every CI lane run ever), then probe the
-  // wiring and disclose the result — armed vs backstop-only, with the
-  // reason, in the envelope. Drivers without an in-loop mechanism are
-  // honestly backstop-only. Injectable for tests (the runFloor seam pattern).
-  const armGate =
-    opts.armInLoopGate ??
-    ((): InLoopGateStatus =>
-      driver.inLoopGateMechanism === 'claude-stop-hook'
-        ? armInLoopGate(opts.cwd, { ci: process.env.GITHUB_ACTIONS === 'true' })
-        : {
-            mode: 'backstop-only',
-            reason: `driver ${driver.id} has no in-loop gate mechanism; post-run verification is the gate`,
-          });
-  const inLoopGate = armGate();
+  // The in-loop gate (#305): probe the wiring and disclose the result,
+  // armed vs backstop-only with the reason, in the envelope
+  // (`armGateForDriver`). Injectable for tests (the runFloor seam pattern).
+  const inLoopGate = (opts.armInLoopGate ?? (() => armGateForDriver(driver, opts.cwd)))();
 
   const envelopeBase = {
     driver: driver.id,
@@ -195,18 +184,21 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   const entryScores = task.scoreHinge ? await hingeProbe(task.scoreHinge) : undefined;
   const baseHead = git.head();
 
+  // The deterministic recipe tier (section 3B): plan the task's work orders
+  // and execute the recipe-tier ones FIRST, each committed inside its
+  // envelope. When EVERY selected order was recipe-tier the run completes
+  // right here without any agent spawn, with the ONE tree verification
+  // still the arbiter of the combined recipe commits. Fail-open on
+  // planning; the step itself never throws (`recipeTierStep`).
+  opts.onPhase?.('recipes');
+  const tier = await recipeTierStep(opts, { task, entryFloor, baseHead, git, runFloor });
+  const recipesDisclosure = { recipes: tier.recipes };
+  if (tier.done) return finish(tier.done);
+
   opts.onPhase?.('agent');
-  // Budget awareness: the agent is TOLD its caps so it lands work in
-  // mergeable increments instead of being surprised mid-edit by the kill —
-  // the difference between a salvageable 90% and a stranded one. Appended by
-  // the runner (the one place the effective budget is known), never baked
-  // into the task prompts.
-  const budgetNote =
-    `\nBudget for this run (runner-enforced): ~${budget.maxMinutes} minutes, ` +
-    `${budget.maxTurns} turns, $${budget.maxUsd}. Commit completed units as you go, and ` +
-    `reserve the final minutes to commit ALL remaining work and record where you stopped ` +
-    `in docs/DXKIT-REMEDIATION-NOTES.md — work committed before the cap survives; ` +
-    `uncommitted edits are swept into a single unlabeled-context commit.`;
+  // Budget awareness (`budgetPromptNote`): appended by the runner, the one
+  // place the effective budget is known, never baked into the task prompts.
+  const budgetNote = budgetPromptNote(budget);
   const resumeNote = opts.resume
     ? resumePromptNote(opts.resume.attempt, opts.resume.blockingContext)
     : '';
@@ -261,6 +253,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
       return finish({
         outcome: 'agent-never-ran',
         task: task.id,
+        ...recipesDisclosure,
         envelope,
         floor: entryFloor,
         ...evidenceTail,
@@ -301,6 +294,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
       return finish({
         outcome: 'agent-never-ran',
         task: task.id,
+        ...recipesDisclosure,
         envelope,
         floor: entryFloor,
         ...evidenceTail,
@@ -310,6 +304,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     return finish({
       outcome: 'sweep-failed',
       task: task.id,
+      ...recipesDisclosure,
       envelope,
       floor: entryFloor,
       ...evidenceTail,
@@ -336,6 +331,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
       return finish({
         outcome: 'agent-failed',
         task: task.id,
+        ...recipesDisclosure,
         envelope,
         floor: entryFloor,
         ...evidenceTail,
@@ -350,6 +346,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     return finish({
       outcome: 'no-op',
       task: task.id,
+      ...recipesDisclosure,
       envelope,
       floor: entryFloor,
       ...evidenceTail,
@@ -386,6 +383,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
 
   const common = {
     task: task.id,
+    ...recipesDisclosure,
     envelope,
     ...(verified.floor ? { floor: verified.floor } : {}),
     ...(verified.floorAttribution ? { floorAttribution: verified.floorAttribution } : {}),

--- a/src/remediate/work-orders/recipes-registry.ts
+++ b/src/remediate/work-orders/recipes-registry.ts
@@ -14,12 +14,44 @@
  * of the recipe's own class.
  */
 import { isProjectPathIdentity } from '../../languages/capabilities/correctness';
-import { executeDeclareDependency } from '../recipes/declare-dependency';
-import { executeLintAutofix } from '../recipes/lint-autofix';
+import { getLanguage } from '../../languages';
+import type { LanguageId } from '../../languages/types';
+import { DECLARABLE_PACKS, executeDeclareDependency } from '../recipes/declare-dependency';
+import { executeLintAutofix, lintPackOf } from '../recipes/lint-autofix';
 import { executeLockfileSync } from '../recipes/lockfile-sync';
 import { executeOverridePin } from '../recipes/override-pin';
+import { isConcreteSemver, isValidNpmPackageName, owningManifestRoot } from '../recipes/shared';
 import type { RecipeExecuteContext, RecipeOutcome } from '../recipes/types';
 import { WORK_ORDER_CLASSES, type WorkOrder, type WorkOrderClass } from './types';
+
+// ---------------------------------------------------------------------------
+// Feasibility predicates for `matches` (4.4.5 review): every fact knowable
+// from the ORDER ITSELF (its evidence, its envelope, the packs' declared
+// capabilities) is decided HERE, so an order a recipe's executor would
+// always refuse tiers `agent` and the plan never renders it as executable
+// determinism. Runtime refusals remain only for repo-state facts (which
+// lockfile is present, whether the package is a direct dependency, what the
+// registry and OSV answer).
+// ---------------------------------------------------------------------------
+
+/** The envelope names exactly one owning package.json root. */
+function hasOneManifestRoot(order: WorkOrder): boolean {
+  return owningManifestRoot(order) !== null;
+}
+
+/** The producing pack, when every finding is floor evidence from one pack. */
+function floorPackOf(order: WorkOrder): string | null {
+  const packs = new Set(
+    order.findings.map((f) => (f.evidence.type === 'floor' ? f.evidence.pack : null)),
+  );
+  return packs.size === 1 ? [...packs][0] : null;
+}
+
+/** Is this a slice of a larger per-file set? A file-scoped fixer cannot be
+ *  verified one slice at a time. */
+function isSlicedOrder(order: WorkOrder): boolean {
+  return order.provenance.source === 'debt-slice' && order.provenance.of > 1;
+}
 
 export interface RecipeDeclaration {
   readonly id: string;
@@ -55,7 +87,17 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     class: classServedBy('lockfile-sync'),
     summary: "reinstall with the repo's package manager so the lockfile follows the manifest",
     implemented: true,
-    matches: (order) => order.constraints.install !== undefined,
+    // The producing pack must declare the frozen dry-run this recipe
+    // verifies with, and the envelope must name one owning root.
+    matches: (order) => {
+      const pack = floorPackOf(order);
+      return (
+        order.constraints.install !== undefined &&
+        hasOneManifestRoot(order) &&
+        pack !== null &&
+        getLanguage(pack as LanguageId)?.correctness?.lockfileCheck !== undefined
+      );
+    },
     execute: executeLockfileSync,
   },
   {
@@ -63,14 +105,19 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     class: classServedBy('override-pin'),
     summary: 'pin a fixed version through a pm-aware override when no direct upgrade path exists',
     implemented: true,
-    // Needs a known fixed version for EVERY advisory in the order, and an
-    // install command the frame can run; an advisory with no fix is agent
-    // (or human) territory.
+    // Needs a known CONCRETE fixed version for EVERY advisory in the order
+    // (a range-shaped fixed string cannot be pinned verbatim), one owning
+    // root, and an install command the frame can run; an advisory with no
+    // fix is agent (or human) territory.
     matches: (order) =>
       order.constraints.install !== undefined &&
+      hasOneManifestRoot(order) &&
       order.findings.length > 0 &&
       order.findings.every(
-        (f) => f.evidence.type === 'dep-vuln' && typeof f.evidence.fixedVersion === 'string',
+        (f) =>
+          f.evidence.type === 'dep-vuln' &&
+          typeof f.evidence.fixedVersion === 'string' &&
+          isConcreteSemver(f.evidence.fixedVersion),
       ),
     execute: executeOverridePin,
   },
@@ -80,21 +127,31 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     summary:
       'declare and install a bare import, refusing with the reason when the candidate carries a block-tier advisory',
     implemented: true,
-    // Every finding must carry the unresolved specifier, and that specifier
-    // must name a PACKAGE. Bareness is a producer fact (the resolutionCheck
+    // Every finding must carry an unresolved specifier that is a VALID npm
+    // package name. Bareness is a producer fact (the resolutionCheck
     // contract): a project-path identity (leading `./`, the ONE canonical
     // discriminator `isProjectPathIdentity`) names a missing FILE, which no
-    // install can declare, so those orders tier to the agent. The frame must
-    // also hold the producing pack's install command.
-    matches: (order) =>
-      order.constraints.install !== undefined &&
-      order.findings.length > 0 &&
-      order.findings.every(
-        (f) =>
-          f.evidence.type === 'floor' &&
-          typeof f.evidence.specifier === 'string' &&
-          !isProjectPathIdentity(f.evidence.specifier),
-      ),
+    // install can declare; the strict name shape additionally keeps a
+    // flag-shaped specifier out of the recipe tier (the executor re-checks
+    // it as the injection rail). Pack support and the owning root are
+    // order-intrinsic too; the frame must hold the install command.
+    matches: (order) => {
+      const pack = floorPackOf(order);
+      return (
+        order.constraints.install !== undefined &&
+        hasOneManifestRoot(order) &&
+        pack !== null &&
+        DECLARABLE_PACKS.includes(pack) &&
+        order.findings.length > 0 &&
+        order.findings.every(
+          (f) =>
+            f.evidence.type === 'floor' &&
+            typeof f.evidence.specifier === 'string' &&
+            !isProjectPathIdentity(f.evidence.specifier) &&
+            isValidNpmPackageName(f.evidence.specifier),
+        )
+      );
+    },
     execute: executeDeclareDependency,
   },
   {
@@ -102,14 +159,23 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     class: classServedBy('lint-autofix'),
     summary: "the pack linter's own autofix, restricted to the order's file and rules",
     implemented: true,
-    // Every finding must carry a rule: an unparsed diagnostic cannot be
-    // scoped to a fixer. Which rules a pack's fixer covers is the executor's
-    // (pack-declared) knowledge, not the registry's.
-    matches: (order) =>
-      order.findings.length > 0 &&
-      order.findings.every(
-        (f) => f.evidence.type === 'custom-check' && typeof f.evidence.rule === 'string',
-      ),
+    // Every finding must carry a rule (an unparsed diagnostic cannot be
+    // scoped to a fixer), the check must be a PACK lint gate whose pack
+    // declares a fix mode, and the order must not be a slice of a larger
+    // per-file set. Which rules the fixer actually closes stays the
+    // executor's runtime verify.
+    matches: (order) => {
+      if (order.findings.length === 0 || isSlicedOrder(order)) return false;
+      const first = order.findings[0].evidence;
+      const pack = first.type === 'custom-check' ? lintPackOf(first.check) : null;
+      return (
+        pack !== null &&
+        getLanguage(pack as LanguageId)?.lintGate?.fixCommand !== undefined &&
+        order.findings.every(
+          (f) => f.evidence.type === 'custom-check' && typeof f.evidence.rule === 'string',
+        )
+      );
+    },
     execute: executeLintAutofix,
   },
 ];

--- a/src/remediate/work-orders/recipes-registry.ts
+++ b/src/remediate/work-orders/recipes-registry.ts
@@ -1,18 +1,24 @@
 /**
  * The recipe registry (remediate rethink, section 3B): the deterministic tier.
  *
- * This module holds ONLY the declarative contract, `{ id, class, matches }`,
- * and the four planned recipes as DECLARED entries. None of them is
- * executable here: `implemented: false` says so, and the planner tiers an
- * order `recipe` on a match so the plan surface shows where determinism WILL
- * apply. The executors (`apply(order) -> diff`, `verify`) land in the next
- * unit and attach to these same ids; nothing is stubbed in their place.
+ * Each entry declares `{ id, class, matches }` for the planner's tier
+ * decision AND (4.4.5) its `execute`, the deterministic executor the
+ * remediate frame runs BEFORE any agent spawns (`src/remediate/recipes/`).
+ * `implemented` and `execute` are one fact stated twice for the plan
+ * surface's benefit; the contract test pins `implemented === (execute !==
+ * undefined)` so they cannot drift.
  *
  * The class each recipe serves is a READ of the class table (`recipe` on
  * `WORK_ORDER_CLASSES`); the contract test pins that every declared recipe
  * id is named there and vice versa. `matches` is consulted only for orders
  * of the recipe's own class.
  */
+import { isProjectPathIdentity } from '../../languages/capabilities/correctness';
+import { executeDeclareDependency } from '../recipes/declare-dependency';
+import { executeLintAutofix } from '../recipes/lint-autofix';
+import { executeLockfileSync } from '../recipes/lockfile-sync';
+import { executeOverridePin } from '../recipes/override-pin';
+import type { RecipeExecuteContext, RecipeOutcome } from '../recipes/types';
 import { WORK_ORDER_CLASSES, type WorkOrder, type WorkOrderClass } from './types';
 
 export interface RecipeDeclaration {
@@ -22,11 +28,16 @@ export interface RecipeDeclaration {
   /** One-line intent, rendered in the plan surface. */
   readonly summary: string;
   /** Whether an executor exists for this id. `false` = declared for tiering
-   *  and planning only; the plan says "recipe (not yet executable)". */
+   *  and planning only; the plan says "recipe (not yet executable)". Must
+   *  equal `execute !== undefined` (pinned by the contract test). */
   readonly implemented: boolean;
   /** Does this recipe apply to THIS order? Pure over the order's findings and
    *  evidence (a recipe never inspects the repo at planning time). */
   readonly matches: (order: WorkOrder) => boolean;
+  /** The deterministic executor (4.4.5), present iff `implemented`. Runs
+   *  inside the remediate frame through the injected bounded exec under the
+   *  required trust context; see `../recipes/types.ts` for the contract. */
+  readonly execute?: (order: WorkOrder, ctx: RecipeExecuteContext) => Promise<RecipeOutcome>;
 }
 
 /** The class a recipe id serves, from the one table. */
@@ -43,14 +54,15 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     id: 'lockfile-sync',
     class: classServedBy('lockfile-sync'),
     summary: "reinstall with the repo's package manager so the lockfile follows the manifest",
-    implemented: false,
+    implemented: true,
     matches: (order) => order.constraints.install !== undefined,
+    execute: executeLockfileSync,
   },
   {
     id: 'override-pin',
     class: classServedBy('override-pin'),
     summary: 'pin a fixed version through a pm-aware override when no direct upgrade path exists',
-    implemented: false,
+    implemented: true,
     // Needs a known fixed version for EVERY advisory in the order, and an
     // install command the frame can run; an advisory with no fix is agent
     // (or human) territory.
@@ -60,30 +72,36 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
       order.findings.every(
         (f) => f.evidence.type === 'dep-vuln' && typeof f.evidence.fixedVersion === 'string',
       ),
+    execute: executeOverridePin,
   },
   {
     id: 'declare-dependency',
     class: classServedBy('declare-dependency'),
     summary:
       'declare and install a bare import, refusing with the reason when the candidate carries a block-tier advisory',
-    implemented: false,
-    // Every finding must carry the unresolved specifier (bare BY THE
-    // resolutionCheck CONTRACT — packs only report bare specifiers, so
-    // bareness is a producer fact, never re-derived here with an
-    // ecosystem-flavored regex), and the frame must have the producing
-    // pack's install command to run the declare + install step.
+    implemented: true,
+    // Every finding must carry the unresolved specifier, and that specifier
+    // must name a PACKAGE. Bareness is a producer fact (the resolutionCheck
+    // contract): a project-path identity (leading `./`, the ONE canonical
+    // discriminator `isProjectPathIdentity`) names a missing FILE, which no
+    // install can declare, so those orders tier to the agent. The frame must
+    // also hold the producing pack's install command.
     matches: (order) =>
       order.constraints.install !== undefined &&
       order.findings.length > 0 &&
       order.findings.every(
-        (f) => f.evidence.type === 'floor' && typeof f.evidence.specifier === 'string',
+        (f) =>
+          f.evidence.type === 'floor' &&
+          typeof f.evidence.specifier === 'string' &&
+          !isProjectPathIdentity(f.evidence.specifier),
       ),
+    execute: executeDeclareDependency,
   },
   {
     id: 'lint-autofix',
     class: classServedBy('lint-autofix'),
     summary: "the pack linter's own autofix, restricted to the order's file and rules",
-    implemented: false,
+    implemented: true,
     // Every finding must carry a rule: an unparsed diagnostic cannot be
     // scoped to a fixer. Which rules a pack's fixer covers is the executor's
     // (pack-declared) knowledge, not the registry's.
@@ -92,6 +110,7 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
       order.findings.every(
         (f) => f.evidence.type === 'custom-check' && typeof f.evidence.rule === 'string',
       ),
+    execute: executeLintAutofix,
   },
 ];
 

--- a/src/remediate/work-orders/render.ts
+++ b/src/remediate/work-orders/render.ts
@@ -9,6 +9,7 @@
  */
 import { describeEntryLocation } from '../../gate/context';
 import { SHARED_RULES } from '../tasks';
+import { RECIPE_REGISTRY } from './recipes-registry';
 import type { WorkOrder, WorkOrderFinding } from './types';
 import { WORK_ORDER_CLASSES, isBuiltinWorkOrderClass } from './types';
 
@@ -132,8 +133,11 @@ export function renderWorkOrderPrompt(order: WorkOrder): string {
 
 /** One line per order for the plan surface. */
 export function renderWorkOrderSummary(order: WorkOrder): string {
+  const executable = RECIPE_REGISTRY.find((r) => r.id === order.recipe)?.implemented === true;
   const tier =
-    order.tier === 'recipe' ? `recipe ${order.recipe} (declared, not yet executable)` : 'agent';
+    order.tier === 'recipe'
+      ? `recipe ${order.recipe}${executable ? '' : ' (declared, not yet executable)'}`
+      : 'agent';
   const attribution = order.findings.some((f) => f.attribution === 'net-new')
     ? 'net-new'
     : order.findings.some((f) => f.attribution === 'deferred')

--- a/test/osv-package-query.test.ts
+++ b/test/osv-package-query.test.ts
@@ -1,0 +1,44 @@
+/**
+ * queryOsvPackage (4.4.5, the recipe tier's pre-check): the /v1/query call
+ * shape, the vulns extraction, and the honesty contract that ANY failure
+ * (network, non-OK, malformed) reads as null, never as "no advisories".
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { queryOsvPackage } from '../src/analyzers/tools/osv';
+
+afterEach(() => vi.unstubAllGlobals());
+
+function stubFetch(impl: (url: string, init?: RequestInit) => Promise<Partial<Response>>) {
+  vi.stubGlobal('fetch', impl as unknown as typeof fetch);
+}
+
+describe('queryOsvPackage', () => {
+  it('POSTs the package + version to /v1/query and returns the vulns array', async () => {
+    let seenBody: unknown;
+    stubFetch(async (url, init) => {
+      expect(url).toBe('https://api.osv.dev/v1/query');
+      seenBody = JSON.parse(String(init?.body));
+      return { ok: true, json: async () => ({ vulns: [{ id: 'GHSA-x' }] }) };
+    });
+    const vulns = await queryOsvPackage('left-pad', '1.3.0', 'npm');
+    expect(vulns).toEqual([{ id: 'GHSA-x' }]);
+    expect(seenBody).toEqual({
+      package: { name: 'left-pad', ecosystem: 'npm' },
+      version: '1.3.0',
+    });
+  });
+
+  it('an empty result body is an EMPTY list (a real "no known advisories")', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({}) }));
+    expect(await queryOsvPackage('left-pad', '1.3.0', 'npm')).toEqual([]);
+  });
+
+  it('a non-OK response or a thrown fetch reads as null (disclosed unknown), never as clean', async () => {
+    stubFetch(async () => ({ ok: false, json: async () => ({}) }));
+    expect(await queryOsvPackage('left-pad', '1.3.0', 'npm')).toBeNull();
+    stubFetch(async () => {
+      throw new Error('offline');
+    });
+    expect(await queryOsvPackage('left-pad', '1.3.0', 'npm')).toBeNull();
+  });
+});

--- a/test/package-manager-frozen-install.test.ts
+++ b/test/package-manager-frozen-install.test.ts
@@ -201,19 +201,34 @@ describe('resyncInstallFor (the lock-writing install, 4.4.5)', () => {
     const plan = resyncInstallFor('npm');
     expect(plan.argv).toEqual(['npm', 'install', '--no-audit', '--no-fund']);
     expect(plan.fallback?.argv).toContain('--legacy-peer-deps');
+    // The fallback fires on the peer-conflict shape ONLY (the shared gate).
+    expect(plan.fallback?.matches('npm error ERESOLVE unable to resolve')).toBe(true);
+    expect(plan.fallback?.matches('EUSAGE lock file out of sync')).toBe(false);
     // The fallback reason is the one shared doctrine string, not a fork of it.
     const dir = repoWith(['package.json', 'package-lock.json']);
     expect(plan.fallback?.reason).toBe(frozenInstallFor(dir)!.fallback!.reason);
     rmSync(dir, { recursive: true, force: true });
   });
 
+  it('the CI-default trap: pnpm and yarn berry flip to frozen under CI, so both carry the mutable flag', () => {
+    expect(resyncInstallFor('pnpm').argv).toEqual(['pnpm', 'install', '--no-frozen-lockfile']);
+    const yarn = resyncInstallFor('yarn');
+    expect(yarn.argv).toEqual(['yarn', 'install', '--no-immutable']);
+    // yarn classic (v1) does not know the berry flag: the declared fallback
+    // drops to the plain (already lock-writing) install, gated on that
+    // exact failure shape, never a blanket retry.
+    expect(yarn.fallback?.argv).toEqual(['yarn', 'install']);
+    expect(yarn.fallback?.matches('error Unknown option: --no-immutable')).toBe(true);
+    expect(yarn.fallback?.matches('YN0028: lockfile would have been modified')).toBe(false);
+  });
+
   it('every PM has a lock-writing form, and none of them is the frozen install', () => {
     for (const pm of ['npm', 'pnpm', 'yarn', 'bun'] as const) {
       const resync = resyncInstallFor(pm);
       expect(resync.argv.length).toBeGreaterThan(1);
-      expect(resync.argv.join(' ')).not.toContain('--frozen-lockfile');
+      expect(resync.argv.join(' ')).not.toContain(' --frozen-lockfile');
+      expect(resync.argv.join(' ')).not.toContain(' --immutable');
       expect(resync.argv).not.toContain('ci');
     }
-    expect(resyncInstallFor('pnpm').argv).toContain('--no-frozen-lockfile');
   });
 });

--- a/test/package-manager-frozen-install.test.ts
+++ b/test/package-manager-frozen-install.test.ts
@@ -8,6 +8,7 @@ import {
   isPeerConflictOnly,
   lockfileSyncCheck,
   renderInstallDependenciesShell,
+  resyncInstallFor,
   LOCKFILES,
   type PackageManager,
 } from '../src/package-manager';
@@ -192,5 +193,27 @@ describe('lockfileSyncCheck', () => {
     const c = lockfileSyncCheck('yarn');
     expect(c.kind).toBe('skipped');
     if (c.kind === 'skipped') expect(c.reason).toContain('immutable');
+  });
+});
+
+describe('resyncInstallFor (the lock-writing install, 4.4.5)', () => {
+  it('npm re-resolves quietly, with the SAME declared peer-conflict fallback doctrine', () => {
+    const plan = resyncInstallFor('npm');
+    expect(plan.argv).toEqual(['npm', 'install', '--no-audit', '--no-fund']);
+    expect(plan.fallback?.argv).toContain('--legacy-peer-deps');
+    // The fallback reason is the one shared doctrine string, not a fork of it.
+    const dir = repoWith(['package.json', 'package-lock.json']);
+    expect(plan.fallback?.reason).toBe(frozenInstallFor(dir)!.fallback!.reason);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('every PM has a lock-writing form, and none of them is the frozen install', () => {
+    for (const pm of ['npm', 'pnpm', 'yarn', 'bun'] as const) {
+      const resync = resyncInstallFor(pm);
+      expect(resync.argv.length).toBeGreaterThan(1);
+      expect(resync.argv.join(' ')).not.toContain('--frozen-lockfile');
+      expect(resync.argv).not.toContain('ci');
+    }
+    expect(resyncInstallFor('pnpm').argv).toContain('--no-frozen-lockfile');
   });
 });

--- a/test/remediate/config-budgets.test.ts
+++ b/test/remediate/config-budgets.test.ts
@@ -46,6 +46,7 @@ function cfg(partial: Partial<RemediateConfig>): RemediateConfig {
     maxDispatchBudget: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
+    recipes: { enabled: true },
     ...partial,
   };
 }

--- a/test/remediate/dispatch.test.ts
+++ b/test/remediate/dispatch.test.ts
@@ -168,6 +168,7 @@ function config(): RemediateConfig {
     maxDispatchBudget: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
+    recipes: { enabled: true },
   };
 }
 

--- a/test/remediate/executor-landing.test.ts
+++ b/test/remediate/executor-landing.test.ts
@@ -45,6 +45,7 @@ function config(salvage: RemediateConfig['salvage'] = 'discard'): RemediateConfi
     maxDispatchBudget: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
+    recipes: { enabled: true },
   };
 }
 

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -213,6 +213,7 @@ function config(): RemediateConfig {
     maxDispatchBudget: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
+    recipes: { enabled: true },
   };
 }
 

--- a/test/remediate/recipes/declare-dependency.test.ts
+++ b/test/remediate/recipes/declare-dependency.test.ts
@@ -108,6 +108,63 @@ describe('declare-dependency recipe', () => {
     expect(calls.every((c) => c.cmd.args[0] === 'view')).toBe(true);
   });
 
+  it('REFUSES a flag-shaped specifier before any argv exists (Rule 11 argument-injection rail)', async () => {
+    const cwd = repoImporting('left-pad');
+    const { exec, calls } = fakeExec();
+    const outcome = await executeDeclareDependency(
+      importOrder('--registry=https://evil.example', ['src/a.ts']),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') {
+      expect(outcome.reason).toContain('--registry=https://evil.example');
+      expect(outcome.reason).toContain('not a valid npm package name');
+    }
+    // The refusal happened BEFORE any command: not even the registry probe ran.
+    expect(calls).toHaveLength(0);
+  });
+
+  it('verifies at the OWNING ROOT: a nested-workspace install resolves against its own tree', async () => {
+    const cwd = tempRepo({
+      'package.json': '{"name":"umbrella"}',
+      'packages/app/package.json': PKG,
+      'packages/app/package-lock.json': '{}',
+      'packages/app/node_modules/.keep': '',
+      'packages/app/src/a.ts': "import x from 'left-pad';\nexport default x;\n",
+    });
+    const { exec, calls } = fakeExec((cmd) => {
+      if (cmd.args[0] === 'view') return { output: '1.3.0\n' };
+      if (cmd.args[0] === 'install') {
+        fs.mkdirSync(path.join(cwd, 'packages/app/node_modules/left-pad'), { recursive: true });
+      }
+      return undefined;
+    });
+    const order = makeOrder({
+      id: 'unresolved-import:typescript:packages/app',
+      class: 'unresolved-import',
+      findings: [
+        floorFinding('typescript/import-resolution#left-pad', 'typescript', 'import-resolution', {
+          specifier: 'left-pad',
+          importingFiles: ['packages/app/src/a.ts'],
+        }),
+      ],
+      envelope: {
+        paths: [
+          'packages/app/src/a.ts',
+          'packages/app/package.json',
+          'packages/app/package-lock.json',
+        ],
+        manifests: true,
+      },
+    });
+    const outcome = await executeDeclareDependency(order, makeCtx(cwd, { exec }));
+    // The repo ROOT has no node_modules at all: only a root-anchored verify
+    // would read "dependencies are not installed" and fail a correct install.
+    expect(outcome.kind).toBe('applied');
+    // Both the registry probe and the install ran at the owning root.
+    for (const c of calls) expect(c.cwd).toBe(path.join(cwd, 'packages/app'));
+  });
+
   it('refuses a project-path identity (a missing file is not a package)', async () => {
     const cwd = repoImporting('left-pad');
     const { exec, calls } = fakeExec();

--- a/test/remediate/recipes/declare-dependency.test.ts
+++ b/test/remediate/recipes/declare-dependency.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The declare-dependency recipe: applied (registry version resolved, OSV
+ * pre-checked, installed into the section the importers imply, resolution
+ * check confirms), the block-tier OSV refusal (the fix-build failure class
+ * turned into a $0 refusal), the project-path refusal (a missing file is
+ * not a package), the unknown-package refusal, and the ts-only scope.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { executeDeclareDependency } from '../../../src/remediate/recipes/declare-dependency';
+import { fakeExec, floorFinding, makeCtx, makeOrder, tempRepo } from './helpers';
+
+const PKG = JSON.stringify({ name: 'fx', version: '1.0.0' });
+
+function importOrder(specifier: string, importingFiles: string[], pack = 'typescript') {
+  return makeOrder({
+    id: `unresolved-import:${pack}:.`,
+    class: 'unresolved-import',
+    findings: [
+      floorFinding(`${pack}/import-resolution#${specifier}`, pack, 'import-resolution', {
+        specifier,
+        importingFiles,
+      }),
+    ],
+    envelope: {
+      paths: [...importingFiles, 'package.json', 'package-lock.json'],
+      manifests: true,
+    },
+  });
+}
+
+/** A fixture whose resolution check sees `src/a.ts` importing left-pad; the
+ *  scripted install materializes node_modules/left-pad so the verify pass
+ *  reflects what a real install changes. */
+function repoImporting(specifier: string): string {
+  return tempRepo({
+    'package.json': PKG,
+    'package-lock.json': '{}',
+    'node_modules/.keep': '',
+    'src/a.ts': `import x from '${specifier}';\nexport default x;\n`,
+  });
+}
+
+describe('declare-dependency recipe', () => {
+  it('applies: npm view resolves the version, install lands it, the resolution check confirms', async () => {
+    const cwd = repoImporting('left-pad');
+    const { exec, calls } = fakeExec((cmd) => {
+      if (cmd.args[0] === 'view') return { output: '1.3.0\n' };
+      if (cmd.args[0] === 'install' && cmd.args[1] === 'left-pad@1.3.0') {
+        fs.mkdirSync(path.join(cwd, 'node_modules', 'left-pad'), { recursive: true });
+        fs.writeFileSync(
+          path.join(cwd, 'node_modules', 'left-pad', 'package.json'),
+          '{"name":"left-pad"}',
+        );
+      }
+      return undefined;
+    });
+    const outcome = await executeDeclareDependency(
+      importOrder('left-pad', ['src/a.ts']),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('applied');
+    // Production importer: plain dependency (npm --save-prod).
+    const install = calls.find((c) => c.cmd.args[0] === 'install');
+    expect(install?.cmd.args).toContain('--save-prod');
+  });
+
+  it('a package imported ONLY from test files installs as a devDependency', async () => {
+    const cwd = tempRepo({
+      'package.json': PKG,
+      'package-lock.json': '{}',
+      'node_modules/.keep': '',
+      'test/a.test.ts': "import x from 'left-pad';\n",
+    });
+    const { exec, calls } = fakeExec((cmd) => {
+      if (cmd.args[0] === 'view') return { output: '1.3.0\n' };
+      if (cmd.args[0] === 'install') {
+        fs.mkdirSync(path.join(cwd, 'node_modules', 'left-pad'), { recursive: true });
+      }
+      return undefined;
+    });
+    const outcome = await executeDeclareDependency(
+      importOrder('left-pad', ['test/a.test.ts']),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('applied');
+    const install = calls.find((c) => c.cmd.args[0] === 'install');
+    expect(install?.cmd.args).toContain('--save-dev');
+  });
+
+  it('REFUSES at $0, advisory named, when the candidate carries a block-tier vuln', async () => {
+    const cwd = repoImporting('evil-pkg');
+    const { exec, calls } = fakeExec((cmd) => {
+      if (cmd.args[0] === 'view') return { output: '9.9.9\n' };
+      return undefined;
+    });
+    const outcome = await executeDeclareDependency(
+      importOrder('evil-pkg', ['src/a.ts']),
+      makeCtx(cwd, {
+        exec,
+        queryOsv: async () => [{ id: 'GHSA-evil', database_specific: { severity: 'CRITICAL' } }],
+      }),
+    );
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('GHSA-evil');
+    // The refusal happened BEFORE any install: only the registry probe ran.
+    expect(calls.every((c) => c.cmd.args[0] === 'view')).toBe(true);
+  });
+
+  it('refuses a project-path identity (a missing file is not a package)', async () => {
+    const cwd = repoImporting('left-pad');
+    const { exec, calls } = fakeExec();
+    const outcome = await executeDeclareDependency(
+      importOrder('./src/missing', ['src/a.ts']),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('./src/missing');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('refuses a specifier the registry does not know (typo or private package)', async () => {
+    const cwd = repoImporting('no-such-pkg');
+    const { exec } = fakeExec((cmd) => {
+      if (cmd.args[0] === 'view') return { code: 1, output: 'npm error 404' };
+      return undefined;
+    });
+    const outcome = await executeDeclareDependency(
+      importOrder('no-such-pkg', ['src/a.ts']),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('no-such-pkg');
+  });
+
+  it('refuses orders from packs other than typescript this round', async () => {
+    const cwd = repoImporting('left-pad');
+    const { exec } = fakeExec();
+    const outcome = await executeDeclareDependency(
+      importOrder('requests', ['app.py'], 'python'),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('python');
+  });
+
+  it('fails verify when the specifier still does not resolve after the install', async () => {
+    const cwd = repoImporting('left-pad');
+    const { exec } = fakeExec((cmd) => {
+      if (cmd.args[0] === 'view') return { output: '1.3.0\n' };
+      // install "succeeds" but materializes nothing
+      return undefined;
+    });
+    const outcome = await executeDeclareDependency(
+      importOrder('left-pad', ['src/a.ts']),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind === 'failed') {
+      expect(outcome.step).toBe('verify-resolution');
+      expect(outcome.output).toContain('left-pad');
+    }
+  });
+});

--- a/test/remediate/recipes/frame.test.ts
+++ b/test/remediate/recipes/frame.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Frame integration: a recipe-only plan completes WITHOUT any agent spawn
+ * (the driver here throws if invoked), the combined result still goes
+ * through the one tree verification, a mixed plan still runs the agent
+ * with the recipe summary disclosed, and the ledger renders the per-order
+ * outcomes with their reasons.
+ */
+import { describe, it, expect } from 'vitest';
+import { runRemediateTask, type RemediateGit } from '../../../src/remediate/run';
+import type { AgentDriver } from '../../../src/remediate/driver';
+import type { RemediateConfig } from '../../../src/remediate/config';
+import { DEFAULT_REMEDIATE_BUDGET } from '../../../src/remediate/config';
+import type { CorrectnessFloorResult } from '../../../src/analyzers/correctness/run';
+import { trustedLocalContext } from '../../../src/analysis-trust';
+import type { RecipePhaseSummary } from '../../../src/remediate/recipes/run-recipes';
+
+const GREEN_FLOOR: CorrectnessFloorResult = { ran: true, checks: [], blocks: false };
+
+function fakeGit(diff: boolean): RemediateGit {
+  return {
+    head: () => (diff ? 'head1111' : 'base0000'),
+    sweepLeftovers: () => undefined,
+    scrubRuntimeArtifacts: () => [],
+    hasDiff: () => diff,
+  };
+}
+
+/** A driver that must never run on a recipe-only plan. */
+function throwingDriver(): AgentDriver {
+  return {
+    id: 'fake-agent',
+    budgetSupport: { turns: 'enforced', cost: 'reported' },
+    credentialEnv: [],
+    cli: null,
+    resolveModel: (tier) => `fake-${tier}`,
+    available: () => ({ ok: true }),
+    run: async () => {
+      throw new Error('the driver must not be invoked on a recipe-only plan');
+    },
+  };
+}
+
+function config(): RemediateConfig {
+  return {
+    enabled: true,
+    tasks: ['fix-vulns'],
+    unknownTasks: [],
+    schedule: 'weekly',
+    salvage: 'discard',
+    agent: { driver: 'fake-agent', model: 'auto', budget: DEFAULT_REMEDIATE_BUDGET },
+    taskBudgets: {},
+    maxSpendPerRun: 0,
+    maxDispatchBudget: 0,
+    resume: false,
+    workOrders: { maxSliceSize: 25 },
+    recipes: { enabled: true },
+  };
+}
+
+function phase(overrides: Partial<RecipePhaseSummary>): RecipePhaseSummary {
+  return {
+    ran: true,
+    disclosures: [],
+    selectedRecipeTier: 1,
+    selectedAgentTier: 0,
+    records: [
+      {
+        orderId: 'dep-advisory:js-yaml',
+        class: 'dep-advisory',
+        recipe: 'override-pin',
+        outcome: { kind: 'applied', changedFiles: ['package.json', 'package-lock.json'] },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function base(diff: boolean, summary: RecipePhaseSummary) {
+  return {
+    cwd: '/tmp/fake',
+    trust: trustedLocalContext(),
+    taskId: 'fix-vulns',
+    config: config(),
+    drivers: [throwingDriver()],
+    git: fakeGit(diff),
+    runFloor: () => GREEN_FLOOR,
+    runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+    verifySeams: {
+      worktree: async <T>(_o: unknown, fn: (p: string) => Promise<T>) => fn('/tmp/fake-wt'),
+      install: () => ({ status: 'nothing-to-install' }) as const,
+      changedFiles: () => ['package.json'],
+    },
+    armInLoopGate: () => ({ mode: 'backstop-only' as const, reason: 'test' }),
+    runRecipePhase: async () => summary,
+  };
+}
+
+describe('recipe-only remediate runs', () => {
+  it('completes VERIFIED with no agent spawn when every selected order was recipe-tier and applied', async () => {
+    const r = await runRemediateTask(base(true, phase({})));
+    expect(r.outcome).toBe('verified');
+    expect(r.envelope).toBeUndefined(); // no agent envelope: nothing spawned
+    expect(r.note).toContain('$0');
+    expect(r.recipes?.records[0].outcome.kind).toBe('applied');
+    expect(r.ledger).toContain('Deterministic recipes');
+    expect(r.ledger).toContain('override-pin');
+  });
+
+  it('completes NO-OP at $0 when every recipe refused (reasons in the ledger)', async () => {
+    const summary = phase({
+      records: [
+        {
+          orderId: 'dep-advisory:js-yaml',
+          class: 'dep-advisory',
+          recipe: 'override-pin',
+          outcome: { kind: 'refused', reason: 'pinning would introduce GHSA-x' },
+        },
+      ],
+    });
+    const r = await runRemediateTask(base(false, summary));
+    expect(r.outcome).toBe('no-op');
+    expect(r.note).toContain('No agent was spawned');
+    expect(r.ledger).toContain('pinning would introduce GHSA-x');
+  });
+
+  it('a recipe-only diff that fails the guardrail is guardrail-red, never landed silently', async () => {
+    const opts = {
+      ...base(true, phase({})),
+      runGuardrail: async () => ({ verdict: 'BLOCKED', ran: true, passesGate: false }),
+    };
+    const r = await runRemediateTask(opts);
+    expect(r.outcome).toBe('guardrail-red');
+  });
+
+  it('a mixed plan (agent-tier orders remain) still runs the agent, with the recipe summary disclosed', async () => {
+    const summary = phase({ selectedAgentTier: 2 });
+    const driver = throwingDriver();
+    let ran = false;
+    driver.run = async () => {
+      ran = true;
+      return { completed: true, timedOut: false, transcriptTail: '' };
+    };
+    const r = await runRemediateTask({ ...base(true, summary), drivers: [driver] });
+    expect(ran).toBe(true);
+    expect(r.recipes?.selectedAgentTier).toBe(2);
+    expect(r.ledger).toContain('Deterministic recipes');
+  });
+
+  it('a plan that selects nothing keeps the pre-recipe behavior byte-for-byte (agent path)', async () => {
+    const summary = phase({ ran: false, selectedRecipeTier: 0, records: [] });
+    const driver = throwingDriver();
+    let ran = false;
+    driver.run = async () => {
+      ran = true;
+      return { completed: true, timedOut: false, transcriptTail: '' };
+    };
+    const r = await runRemediateTask({ ...base(true, summary), drivers: [driver] });
+    expect(ran).toBe(true);
+    expect(r.outcome).toBe('verified');
+    // A phase that never ran renders no recipe section.
+    expect(r.ledger).not.toContain('Deterministic recipes');
+  });
+
+  it('a recipe-phase failure is fail-open: disclosed planError, agent path proceeds', async () => {
+    const driver = throwingDriver();
+    let ran = false;
+    driver.run = async () => {
+      ran = true;
+      return { completed: true, timedOut: false, transcriptTail: '' };
+    };
+    const opts = {
+      ...base(true, phase({})),
+      drivers: [driver],
+      runRecipePhase: async () => {
+        throw new Error('planner exploded');
+      },
+    };
+    const r = await runRemediateTask(opts);
+    expect(ran).toBe(true);
+    expect(r.recipes?.planError).toContain('planner exploded');
+    expect(r.ledger).toContain('planner exploded');
+  });
+});

--- a/test/remediate/recipes/frame.test.ts
+++ b/test/remediate/recipes/frame.test.ts
@@ -95,6 +95,58 @@ function base(diff: boolean, summary: RecipePhaseSummary) {
   };
 }
 
+/** A git whose head advances once (the recipe commit) and whose diff answer
+ *  is per-base: the run's baseHead question and the agent's own-base
+ *  question must be distinguishable. */
+function recipeCommitGit(diffs: Record<string, boolean>): RemediateGit {
+  let calls = 0;
+  return {
+    head: () => (calls++ === 0 ? 'base0000' : 'recipe111'),
+    sweepLeftovers: () => undefined,
+    scrubRuntimeArtifacts: () => [],
+    hasDiff: (base: string) => diffs[base] ?? false,
+  };
+}
+
+describe('the agent diff is measured from the post-recipe head', () => {
+  it('an HONEST never-ran claim is not contradicted by the recipes own commits', async () => {
+    const driver = throwingDriver();
+    driver.run = async () => ({
+      completed: false,
+      timedOut: false,
+      transcriptTail: '',
+      neverRan: { reason: 'credential missing' },
+    });
+    const summary = phase({ selectedAgentTier: 1 }); // mixed plan: agent path runs
+    const r = await runRemediateTask({
+      ...base(true, summary),
+      drivers: [driver],
+      // Recipe committed (base0000 -> recipe111); the agent added NOTHING on
+      // top of recipe111.
+      git: recipeCommitGit({ base0000: true, recipe111: false }),
+    });
+    expect(r.outcome).toBe('agent-never-ran');
+    // The claim stood UNCONTRADICTED: no demotion note about tree evidence.
+    expect(r.envelope?.failure ?? '').not.toContain('contradicted');
+    expect(r.note).toContain('credential missing');
+  });
+
+  it('an agent that cleanly adds nothing on top of applied recipe commits still verifies the combined head', async () => {
+    const driver = throwingDriver();
+    driver.run = async () => ({ completed: true, timedOut: false, transcriptTail: '' });
+    const summary = phase({ selectedAgentTier: 1 });
+    const r = await runRemediateTask({
+      ...base(true, summary),
+      drivers: [driver],
+      git: recipeCommitGit({ base0000: true, recipe111: false }),
+    });
+    // Not a no-op: the recipe commits are real work and go through the one
+    // tree verification, anchored at the PRE-recipe base.
+    expect(r.outcome).toBe('verified');
+    expect(r.baseHead).toBe('base0000');
+  });
+});
+
 describe('recipe-only remediate runs', () => {
   it('completes VERIFIED with no agent spawn when every selected order was recipe-tier and applied', async () => {
     const r = await runRemediateTask(base(true, phase({})));
@@ -106,7 +158,7 @@ describe('recipe-only remediate runs', () => {
     expect(r.ledger).toContain('override-pin');
   });
 
-  it('completes NO-OP at $0 when every recipe refused (reasons in the ledger)', async () => {
+  it('every recipe refused at $0 is recipes-refused (NOT a clean no-op the lane green-loops on)', async () => {
     const summary = phase({
       records: [
         {
@@ -118,8 +170,12 @@ describe('recipe-only remediate runs', () => {
       ],
     });
     const r = await runRemediateTask(base(false, summary));
-    expect(r.outcome).toBe('no-op');
+    // A recipe-only run has no agent tier to fall back to, so all-refused
+    // must surface as a NON-CLEAN outcome; 'no-op' here would starve the
+    // orders forever while the schedule reads green.
+    expect(r.outcome).toBe('recipes-refused');
     expect(r.note).toContain('No agent was spawned');
+    expect(r.note).toContain('orders remain open');
     expect(r.ledger).toContain('pinning would introduce GHSA-x');
   });
 

--- a/test/remediate/recipes/git.test.ts
+++ b/test/remediate/recipes/git.test.ts
@@ -1,0 +1,56 @@
+/**
+ * realRecipeGit against a real temp repository: changed-path reporting
+ * (modified, untracked), path-scoped discard (tracked restored, untracked
+ * removed, everything else untouched), and path-scoped commits under the
+ * bot identity.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { realRecipeGit } from '../../../src/remediate/recipes/git';
+
+function initRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-recipe-git-'));
+  const git = (args: string[]) => execFileSync('git', args, { cwd: dir, stdio: 'pipe' });
+  git(['init', '-q']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['config', 'user.name', 'Test']);
+  fs.writeFileSync(path.join(dir, 'tracked.txt'), 'original\n');
+  fs.writeFileSync(path.join(dir, 'other.txt'), 'keep\n');
+  git(['add', '-A']);
+  git(['commit', '-q', '-m', 'init']);
+  return dir;
+}
+
+describe('realRecipeGit', () => {
+  it('reports modified + untracked paths, discards only what it is told, commits only what it is told', () => {
+    const dir = initRepo();
+    const g = realRecipeGit(dir);
+    expect(g.changedPaths()).toEqual([]);
+
+    fs.writeFileSync(path.join(dir, 'tracked.txt'), 'recipe edit\n');
+    fs.writeFileSync(path.join(dir, 'stray.txt'), 'sprawl\n');
+    fs.writeFileSync(path.join(dir, 'other.txt'), 'user edit\n');
+    expect(g.changedPaths().sort()).toEqual(['other.txt', 'stray.txt', 'tracked.txt']);
+
+    // Discard the recipe's stray + tracked edit; the user's edit survives.
+    g.discardPaths(['stray.txt', 'tracked.txt']);
+    expect(fs.existsSync(path.join(dir, 'stray.txt'))).toBe(false);
+    expect(fs.readFileSync(path.join(dir, 'tracked.txt'), 'utf8')).toBe('original\n');
+    expect(fs.readFileSync(path.join(dir, 'other.txt'), 'utf8')).toBe('user edit\n');
+
+    // Commit only the named path; the user's dirt stays uncommitted.
+    fs.writeFileSync(path.join(dir, 'tracked.txt'), 'fixed\n');
+    const before = g.head();
+    g.commitPaths(['tracked.txt'], 'fix(test): one order');
+    expect(g.head()).not.toBe(before);
+    expect(g.changedPaths()).toEqual(['other.txt']);
+    const log = execFileSync('git', ['log', '-1', '--format=%s %an'], {
+      cwd: dir,
+      encoding: 'utf8',
+    });
+    expect(log).toContain('fix(test): one order');
+  });
+});

--- a/test/remediate/recipes/git.test.ts
+++ b/test/remediate/recipes/git.test.ts
@@ -43,14 +43,22 @@ describe('realRecipeGit', () => {
 
     // Commit only the named path; the user's dirt stays uncommitted.
     fs.writeFileSync(path.join(dir, 'tracked.txt'), 'fixed\n');
-    const before = g.head();
     g.commitPaths(['tracked.txt'], 'fix(test): one order');
-    expect(g.head()).not.toBe(before);
     expect(g.changedPaths()).toEqual(['other.txt']);
     const log = execFileSync('git', ['log', '-1', '--format=%s %an'], {
       cwd: dir,
       encoding: 'utf8',
     });
     expect(log).toContain('fix(test): one order');
+  });
+
+  it('reports a non-ASCII path unescaped (git otherwise C-quotes it, and an escaped name matches no envelope)', () => {
+    const dir = initRepo();
+    const g = realRecipeGit(dir);
+    fs.writeFileSync(path.join(dir, 'sträy.txt'), 'x\n');
+    expect(g.changedPaths()).toEqual(['sträy.txt']);
+    g.discardPaths(['sträy.txt']);
+    expect(fs.existsSync(path.join(dir, 'sträy.txt'))).toBe(false);
+    expect(g.changedPaths()).toEqual([]);
   });
 });

--- a/test/remediate/recipes/helpers.ts
+++ b/test/remediate/recipes/helpers.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { CommandOutcome, RunnableCommand } from '../../../src/analyzers/tools/bounded-exec';
+import { newAdvisoryBlockSeverities } from '../../../src/baseline/policy-sections';
 import { trustedLocalContext } from '../../../src/analysis-trust';
 import type { DepVulnFinding } from '../../../src/languages/capabilities/types';
 import type { RecipeExecuteContext } from '../../../src/remediate/recipes/types';
@@ -59,6 +60,8 @@ export function makeCtx(
     cwd,
     trust: trustedLocalContext(),
     queryOsv: async () => [],
+    // The default policy tier through the ONE normalizer (crit + high).
+    blockSeverities: newAdvisoryBlockSeverities({}),
     auditDepVulns: async () => [],
     ...overrides,
   };

--- a/test/remediate/recipes/helpers.ts
+++ b/test/remediate/recipes/helpers.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared fixtures for the recipe-executor tests: minimal work-order
+ * builders, a temp fixture repo, and a recording fake exec whose behavior
+ * is scripted per command. Everything spawnable is injected, so no test
+ * here runs a real package manager or linter.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { CommandOutcome, RunnableCommand } from '../../../src/analyzers/tools/bounded-exec';
+import { trustedLocalContext } from '../../../src/analysis-trust';
+import type { DepVulnFinding } from '../../../src/languages/capabilities/types';
+import type { RecipeExecuteContext } from '../../../src/remediate/recipes/types';
+import type {
+  WorkOrder,
+  WorkOrderEnvelope,
+  WorkOrderFinding,
+} from '../../../src/remediate/work-orders/types';
+
+export function tempRepo(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-recipes-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const p = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content);
+  }
+  return dir;
+}
+
+export interface ScriptedCall {
+  readonly cmd: RunnableCommand;
+  readonly cwd: string;
+}
+
+export type ExecScript = (cmd: RunnableCommand, cwd: string) => Partial<CommandOutcome> | void;
+
+/** A fake bounded exec: records every call and lets a script override the
+ *  default clean outcome (exit 0, empty output) per command. */
+export function fakeExec(script?: ExecScript): {
+  exec: (cmd: RunnableCommand, cwd: string) => CommandOutcome;
+  calls: ScriptedCall[];
+} {
+  const calls: ScriptedCall[] = [];
+  return {
+    calls,
+    exec: (cmd, cwd) => {
+      calls.push({ cmd, cwd });
+      const overrides = script?.(cmd, cwd) ?? {};
+      return { available: true, code: 0, output: '', ...overrides };
+    },
+  };
+}
+
+export function makeCtx(
+  cwd: string,
+  overrides: Partial<RecipeExecuteContext> & { exec: RecipeExecuteContext['exec'] },
+): RecipeExecuteContext {
+  return {
+    cwd,
+    trust: trustedLocalContext(),
+    queryOsv: async () => [],
+    auditDepVulns: async () => [],
+    ...overrides,
+  };
+}
+
+export function makeOrder(
+  overrides: Partial<WorkOrder> & Pick<WorkOrder, 'id' | 'class'>,
+): WorkOrder {
+  return {
+    findings: [],
+    envelope: { paths: ['package.json', 'package-lock.json'], manifests: true },
+    constraints: { install: { bin: 'npm', args: ['ci'] }, forbidden: [] },
+    done: { absentIds: [], verifier: 'floor', command: 'x' },
+    budget: { turns: 1, minutes: 1, usd: 1, derivation: 'x' },
+    tier: 'recipe',
+    provenance: { source: 'guardrail-blocking' },
+    ...overrides,
+  };
+}
+
+export function floorFinding(
+  id: string,
+  pack: string,
+  label: string,
+  extra?: { specifier?: string; importingFiles?: string[] },
+): WorkOrderFinding {
+  return {
+    kind: 'floor-check',
+    id,
+    attribution: 'pre-existing',
+    evidence: { type: 'floor', pack, label, command: '', ...extra },
+  };
+}
+
+export function advisoryFinding(
+  id: string,
+  pkg: string,
+  advisoryId: string,
+  fixedVersion?: string,
+): WorkOrderFinding {
+  return {
+    kind: 'dep-vuln',
+    id,
+    attribution: 'deferred',
+    evidence: {
+      type: 'dep-vuln',
+      package: pkg,
+      advisoryId,
+      ...(fixedVersion !== undefined ? { fixedVersion } : {}),
+    },
+  };
+}
+
+export function lintFinding(
+  id: string,
+  check: string,
+  file: string,
+  rule: string,
+): WorkOrderFinding {
+  return {
+    kind: 'custom-check',
+    id,
+    attribution: 'pre-existing',
+    evidence: { type: 'custom-check', check, file, rule, line: 1 },
+  };
+}
+
+export function depFinding(pkg: string, advisoryId: string): DepVulnFinding {
+  return { id: advisoryId, package: pkg, tool: 'test', severity: 'high' };
+}
+
+export const ROOT_ENVELOPE: WorkOrderEnvelope = {
+  paths: ['package.json', 'package-lock.json'],
+  manifests: true,
+};

--- a/test/remediate/recipes/lint-autofix.test.ts
+++ b/test/remediate/recipes/lint-autofix.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The lint-autofix recipe: applied (the pack's fix mode runs file-scoped and
+ * the same run's parsed leftovers are empty), failed (unfixable rules remain,
+ * with the rules named), and the declared refusals (user check, sliced
+ * order, pack without a fix mode). Also pins the ts pack's `fixCommand`
+ * shape: file-scoped `eslint --fix`, json output, same parser as the gate.
+ */
+import { describe, it, expect } from 'vitest';
+import { executeLintAutofix } from '../../../src/remediate/recipes/lint-autofix';
+import { getLanguage } from '../../../src/languages';
+import { fakeExec, lintFinding, makeCtx, makeOrder, tempRepo } from './helpers';
+
+function lintOrder(check: string, file: string, overrides: Record<string, unknown> = {}) {
+  return makeOrder({
+    id: `lint-located:${file}`,
+    class: 'lint-located',
+    findings: [lintFinding('l1', check, file, 'prefer-const')],
+    envelope: { paths: [file], manifests: false },
+    provenance: { source: 'debt-slice', file, slice: 1, of: 1 },
+    ...overrides,
+  });
+}
+
+/** A repo where the ts pack's eslint resolves (a local .bin shim exists). */
+function eslintRepo(): string {
+  return tempRepo({
+    'package.json': '{"name":"fx"}',
+    'node_modules/.bin/eslint': '#!/bin/sh\n',
+    'src/a.ts': 'let x = 1;\nexport default x;\n',
+  });
+}
+
+const eslintJson = (cwd: string, messages: Array<{ ruleId: string; message: string }>) =>
+  JSON.stringify([{ filePath: `${cwd}/src/a.ts`, messages }]);
+
+describe('the ts pack fixCommand', () => {
+  it('is file-scoped eslint --fix with the same json parse as the gate', () => {
+    const cwd = eslintRepo();
+    const fix = getLanguage('typescript')!.lintGate!.fixCommand!({ cwd, files: ['src/a.ts'] });
+    expect(fix).not.toBeNull();
+    expect(fix!.args).toContain('--fix');
+    expect(fix!.args).toContain('src/a.ts');
+    expect(fix!.args).not.toContain('.');
+    expect(fix!.parse.kind).toBe('structured');
+  });
+
+  it('returns null with no files or no resolvable eslint', () => {
+    const cwd = eslintRepo();
+    const gate = getLanguage('typescript')!.lintGate!;
+    expect(gate.fixCommand!({ cwd, files: [] })).toBeNull();
+    const bare = tempRepo({ 'package.json': '{}' });
+    expect(gate.fixCommand!({ cwd: bare, files: ['src/a.ts'] })).toBeNull();
+  });
+});
+
+describe('lint-autofix recipe', () => {
+  it('applies when the fix run leaves zero findings in the file', async () => {
+    const cwd = eslintRepo();
+    const { exec, calls } = fakeExec(() => ({ code: 0, output: eslintJson(cwd, []) }));
+    const outcome = await executeLintAutofix(
+      lintOrder('lint:typescript', 'src/a.ts'),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('applied');
+    if (outcome.kind === 'applied') expect(outcome.changedFiles).toEqual(['src/a.ts']);
+    expect(calls[0].cmd.args).toContain('--fix');
+  });
+
+  it('fails with the leftover rules named when the fix cannot close every finding', async () => {
+    const cwd = eslintRepo();
+    const { exec } = fakeExec(() => ({
+      code: 1,
+      output: eslintJson(cwd, [{ ruleId: 'no-unused-vars', message: 'x is unused' }]),
+    }));
+    const outcome = await executeLintAutofix(
+      lintOrder('lint:typescript', 'src/a.ts'),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind === 'failed') {
+      expect(outcome.step).toBe('verify-lint');
+      expect(outcome.output).toContain('no-unused-vars');
+    }
+  });
+
+  it('refuses a user-declared check (no pack fixer exists for it)', async () => {
+    const cwd = eslintRepo();
+    const { exec, calls } = fakeExec();
+    const outcome = await executeLintAutofix(
+      lintOrder('arch-rules', 'src/a.ts'),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('refused');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('refuses a sliced order (a file-scoped fix cannot be verified per slice)', async () => {
+    const cwd = eslintRepo();
+    const { exec } = fakeExec();
+    const outcome = await executeLintAutofix(
+      lintOrder('lint:typescript', 'src/a.ts', {
+        provenance: { source: 'debt-slice', file: 'src/a.ts', slice: 1, of: 3 },
+      }),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('sliced');
+  });
+
+  it('refuses a pack that declares no fix mode, with the pack named', async () => {
+    const cwd = eslintRepo();
+    const { exec } = fakeExec();
+    const outcome = await executeLintAutofix(
+      lintOrder('lint:go', 'src/a.ts'),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('go');
+  });
+});

--- a/test/remediate/recipes/lockfile-sync.test.ts
+++ b/test/remediate/recipes/lockfile-sync.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The lockfile-sync recipe: applied (resync install + the pack's frozen
+ * dry-run confirms), refused (no lockfile, ambiguous root, unverifiable
+ * pack), failed (dry-run still red), and the declared peer-conflict
+ * fallback doctrine.
+ */
+import { describe, it, expect } from 'vitest';
+import { executeLockfileSync } from '../../../src/remediate/recipes/lockfile-sync';
+import { fakeExec, floorFinding, makeCtx, makeOrder, tempRepo } from './helpers';
+
+const PKG = JSON.stringify({ name: 'fx', version: '1.0.0' });
+
+function staleOrder(paths: string[] = ['package.json', 'package-lock.json']) {
+  return makeOrder({
+    id: 'stale-lockfile:typescript',
+    class: 'stale-lockfile',
+    findings: [floorFinding('typescript/lockfile-sync', 'typescript', 'lockfile-sync')],
+    envelope: { paths, manifests: true },
+  });
+}
+
+describe('lockfile-sync recipe', () => {
+  it('applies: runs the lock-writing install, then the frozen dry-run confirms', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec, calls } = fakeExec();
+    const outcome = await executeLockfileSync(staleOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('applied');
+    if (outcome.kind === 'applied') expect(outcome.changedFiles).toEqual(['package-lock.json']);
+    expect(calls[0].cmd.bin).toBe('npm');
+    expect(calls[0].cmd.args).toEqual(['install', '--no-audit', '--no-fund']);
+    // The verify is npm's non-installing frozen dry-run, from the ts pack.
+    const verify = calls[calls.length - 1].cmd;
+    expect(verify.args).toContain('--dry-run');
+    expect(verify.args).toContain('ci');
+  });
+
+  it('retries under --legacy-peer-deps ONLY for a peer-conflict-shaped failure', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec, calls } = fakeExec((cmd) => {
+      if (cmd.args.includes('install') && !cmd.args.includes('--legacy-peer-deps')) {
+        return { code: 1, output: 'npm error ERESOLVE unable to resolve dependency tree' };
+      }
+      return undefined;
+    });
+    const outcome = await executeLockfileSync(staleOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('applied');
+    expect(calls.some((c) => c.cmd.args.includes('--legacy-peer-deps'))).toBe(true);
+  });
+
+  it('a non-peer install failure is a named failure, not a blanket retry', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec, calls } = fakeExec((cmd) => {
+      if (cmd.args.includes('install')) return { code: 1, output: 'EACCES broken cache' };
+      return undefined;
+    });
+    const outcome = await executeLockfileSync(staleOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind === 'failed') expect(outcome.step).toBe('install');
+    expect(calls.some((c) => c.cmd.args.includes('--legacy-peer-deps'))).toBe(false);
+  });
+
+  it('fails (never claims) when the frozen dry-run still rejects the tree', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec } = fakeExec((cmd) => {
+      if (cmd.args.includes('--dry-run')) return { code: 1, output: 'EUSAGE lock out of sync' };
+      return undefined;
+    });
+    const outcome = await executeLockfileSync(staleOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind === 'failed') expect(outcome.step).toBe('verify-lockfile-sync');
+  });
+
+  it('refuses when no lockfile exists (nothing to re-sync)', async () => {
+    const cwd = tempRepo({ 'package.json': PKG });
+    const { exec, calls } = fakeExec();
+    const outcome = await executeLockfileSync(staleOrder(['package.json']), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('refused');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('refuses an envelope naming two roots (ambiguous owner)', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec } = fakeExec();
+    const outcome = await executeLockfileSync(
+      staleOrder(['package.json', 'sub/package.json']),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('exactly one package.json');
+  });
+
+  it('refuses a pack with no lockfile-sync check to verify with', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec } = fakeExec();
+    const order = makeOrder({
+      id: 'stale-lockfile:go',
+      class: 'stale-lockfile',
+      findings: [floorFinding('go/lockfile-sync', 'go', 'lockfile-sync')],
+    });
+    const outcome = await executeLockfileSync(order, makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('go');
+  });
+});

--- a/test/remediate/recipes/override-pin.test.ts
+++ b/test/remediate/recipes/override-pin.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The override-pin recipe: applied (npm override written, resync, re-audit
+ * clean), the OSV pre-check refusal with the advisory named (a fake
+ * fetcher), the direct-dependency refusal, the non-npm declared refusal,
+ * and the verify failure when the re-audit still reports the package.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+import { executeOverridePin } from '../../../src/remediate/recipes/override-pin';
+import { advisoryFinding, depFinding, fakeExec, makeCtx, makeOrder, tempRepo } from './helpers';
+
+const PKG = JSON.stringify({ name: 'fx', version: '1.0.0', dependencies: { top: '^1.0.0' } });
+
+function pinOrder() {
+  return makeOrder({
+    id: 'dep-advisory:js-yaml',
+    class: 'dep-advisory',
+    findings: [
+      advisoryFinding('f1', 'js-yaml', 'GHSA-aaaa', '4.1.0'),
+      advisoryFinding('f2', 'js-yaml', 'GHSA-bbbb', '4.1.1'),
+    ],
+  });
+}
+
+describe('override-pin recipe', () => {
+  it('applies: writes the npm override at the highest fixed version, resyncs, re-audits clean', async () => {
+    const cwd = tempRepo({ 'package.json': PKG + '\n', 'package-lock.json': '{}' });
+    const { exec, calls } = fakeExec();
+    const outcome = await executeOverridePin(pinOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('applied');
+    const manifest = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+    expect(manifest.overrides['js-yaml']).toBe('4.1.1');
+    // Trailing newline preserved; the resync install ran.
+    expect(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8').endsWith('\n')).toBe(true);
+    expect(calls.some((c) => c.cmd.bin === 'npm' && c.cmd.args[0] === 'install')).toBe(true);
+    if (outcome.kind === 'applied') {
+      expect(outcome.changedFiles).toEqual(['package.json', 'package-lock.json']);
+    }
+  });
+
+  it('REFUSES with the advisory named when the pin itself carries a block-tier vuln ($0, tree untouched)', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec, calls } = fakeExec();
+    const outcome = await executeOverridePin(
+      pinOrder(),
+      makeCtx(cwd, {
+        exec,
+        queryOsv: async () => [{ id: 'GHSA-new-block', database_specific: { severity: 'HIGH' } }],
+      }),
+    );
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('GHSA-new-block');
+    expect(calls).toHaveLength(0);
+    expect(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8')).toBe(PKG);
+  });
+
+  it('an unreachable OSV pre-check is a DISCLOSED note, never read as clean', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec } = fakeExec();
+    const outcome = await executeOverridePin(
+      pinOrder(),
+      makeCtx(cwd, { exec, queryOsv: async () => null }),
+    );
+    expect(outcome.kind).toBe('applied');
+    if (outcome.kind === 'applied') {
+      expect(outcome.notes?.join(' ')).toContain('could not be reached');
+    }
+  });
+
+  it('refuses a DIRECT dependency (upgrade it, do not override it)', async () => {
+    const direct = JSON.stringify({ name: 'fx', dependencies: { 'js-yaml': '^3.0.0' } });
+    const cwd = tempRepo({ 'package.json': direct, 'package-lock.json': '{}' });
+    const { exec } = fakeExec();
+    const outcome = await executeOverridePin(pinOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('direct');
+  });
+
+  it('refuses the pnpm/yarn override mechanisms this round, with the reason named', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'pnpm-lock.yaml': '' });
+    const { exec } = fakeExec();
+    const outcome = await executeOverridePin(pinOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('pnpm');
+  });
+
+  it('fails verify when the re-audit still reports the package (diff will be discarded)', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec } = fakeExec();
+    const outcome = await executeOverridePin(
+      pinOrder(),
+      makeCtx(cwd, { exec, auditDepVulns: async () => [depFinding('js-yaml', 'GHSA-cccc')] }),
+    );
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind === 'failed') {
+      expect(outcome.step).toBe('verify-audit');
+      expect(outcome.output).toContain('GHSA-cccc');
+    }
+  });
+
+  it('fails verify when the re-audit cannot run (an unobserved clean is never claimed)', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec } = fakeExec();
+    const outcome = await executeOverridePin(
+      pinOrder(),
+      makeCtx(cwd, { exec, auditDepVulns: async () => null }),
+    );
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind === 'failed') expect(outcome.step).toBe('verify-audit');
+  });
+});

--- a/test/remediate/recipes/override-pin.test.ts
+++ b/test/remediate/recipes/override-pin.test.ts
@@ -8,6 +8,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { describe, it, expect } from 'vitest';
 import { executeOverridePin } from '../../../src/remediate/recipes/override-pin';
+import {
+  compareConcreteSemver,
+  isConcreteSemver,
+  pickPinVersion,
+} from '../../../src/remediate/recipes/shared';
 import { advisoryFinding, depFinding, fakeExec, makeCtx, makeOrder, tempRepo } from './helpers';
 
 const PKG = JSON.stringify({ name: 'fx', version: '1.0.0', dependencies: { top: '^1.0.0' } });
@@ -22,6 +27,23 @@ function pinOrder() {
     ],
   });
 }
+
+describe('the pin choice (semver precedence, prerelease rules included)', () => {
+  it('a release outranks its own prereleases and prerelease identifiers order per semver', () => {
+    expect(pickPinVersion(['1.2.3-beta.1', '1.2.3'])).toBe('1.2.3');
+    expect(pickPinVersion(['1.2.3-alpha', '1.2.3-alpha.1', '1.2.3-beta'])).toBe('1.2.3-beta');
+    expect(pickPinVersion(['4.1.0', '4.1.1'])).toBe('4.1.1');
+    expect(compareConcreteSemver('1.2.3-2', '1.2.3-10')).toBeLessThan(0); // numeric ids
+    expect(compareConcreteSemver('1.2.3-alpha.beta', '1.2.3-alpha.1')).toBeGreaterThan(0);
+    expect(compareConcreteSemver('1.2.3+build.1', '1.2.3')).toBe(0); // build metadata ignored
+  });
+
+  it('a range-shaped fixed string is refused, never guessed at', () => {
+    expect(isConcreteSemver('>=4.1.0')).toBe(false);
+    expect(isConcreteSemver('^4.1.0')).toBe(false);
+    expect(pickPinVersion(['4.1.0', '>=4.1.1'])).toBeNull();
+  });
+});
 
 describe('override-pin recipe', () => {
   it('applies: writes the npm override at the highest fixed version, resyncs, re-audits clean', async () => {
@@ -53,6 +75,45 @@ describe('override-pin recipe', () => {
     if (outcome.kind === 'refused') expect(outcome.reason).toContain('GHSA-new-block');
     expect(calls).toHaveLength(0);
     expect(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8')).toBe(PKG);
+  });
+
+  it('the block tier comes from POLICY through the one normalizer: medium refuses when the repo says so', async () => {
+    const mediumVuln = [{ id: 'GHSA-med', database_specific: { severity: 'MODERATE' } }];
+    // Default tier (critical + high): a medium advisory on the pin does NOT refuse.
+    const cwdA = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec: execA } = fakeExec();
+    const relaxed = await executeOverridePin(
+      pinOrder(),
+      makeCtx(cwdA, { exec: execA, queryOsv: async () => mediumVuln }),
+    );
+    expect(relaxed.kind).toBe('applied');
+    // A repo whose policy blocks medium too: the SAME advisory now refuses.
+    const cwdB = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec: execB, calls } = fakeExec();
+    const strict = await executeOverridePin(
+      pinOrder(),
+      makeCtx(cwdB, {
+        exec: execB,
+        queryOsv: async () => mediumVuln,
+        blockSeverities: new Set(['critical', 'high', 'medium'] as const),
+      }),
+    );
+    expect(strict.kind).toBe('refused');
+    if (strict.kind === 'refused') expect(strict.reason).toContain('GHSA-med');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('a range-shaped fixed version refuses at runtime too (the defensive rail behind matches)', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
+    const { exec } = fakeExec();
+    const order = makeOrder({
+      id: 'dep-advisory:js-yaml',
+      class: 'dep-advisory',
+      findings: [advisoryFinding('f1', 'js-yaml', 'GHSA-aaaa', '>=4.1.0')],
+    });
+    const outcome = await executeOverridePin(order, makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('concrete');
   });
 
   it('an unreachable OSV pre-check is a DISCLOSED note, never read as clean', async () => {

--- a/test/remediate/recipes/run-recipes.test.ts
+++ b/test/remediate/recipes/run-recipes.test.ts
@@ -9,6 +9,8 @@
 import { describe, it, expect } from 'vitest';
 import { partitionByEnvelope, pathInEnvelope } from '../../../src/remediate/recipes/envelope';
 import {
+  cachedOsvQuery,
+  effectiveBlockSeverities,
   recipeCounts,
   runRecipeOrders,
   runRecipePhaseForTask,
@@ -206,6 +208,55 @@ describe('runRecipeOrders', () => {
     expect(git.dirty).toEqual(['user-was-editing.md']);
   });
 
+  it('REFUSES an order whose envelope intersects PRE-DIRTY paths (named), so a recipe edit is never mixed with local dirt', async () => {
+    const git = fakeGit();
+    git.dirty.push('fixed.txt', 'unrelated.md'); // fixed.txt is IN the envelope
+    const { exec } = fakeExec();
+    let executed = false;
+    const registry = [
+      syntheticRecipe(async () => {
+        executed = true;
+        return { kind: 'applied', changedFiles: [] };
+      }),
+    ];
+    const records = await runRecipeOrders([syntheticOrder], {
+      cwd: '/x',
+      trust: trustedLocalContext(),
+      git,
+      exec,
+      registry,
+    });
+    expect(executed).toBe(false);
+    expect(records[0].outcome.kind).toBe('refused');
+    if (records[0].outcome.kind === 'refused') {
+      expect(records[0].outcome.reason).toContain('fixed.txt');
+      expect(records[0].outcome.reason).not.toContain('unrelated.md');
+    }
+    // Nothing was discarded or committed: both contracts hold exactly.
+    expect(git.discarded).toEqual([]);
+    expect(git.commits).toEqual([]);
+  });
+
+  it('an unreadable working tree is a named per-order failure, never an unenforced envelope', async () => {
+    const git = fakeGit();
+    git.changedPaths = () => {
+      throw new Error('git exploded');
+    };
+    const { exec } = fakeExec();
+    const registry = [syntheticRecipe(async () => ({ kind: 'applied', changedFiles: [] }))];
+    const records = await runRecipeOrders([syntheticOrder], {
+      cwd: '/x',
+      trust: trustedLocalContext(),
+      git,
+      exec,
+      registry,
+    });
+    expect(records[0].outcome.kind).toBe('failed');
+    if (records[0].outcome.kind === 'failed') {
+      expect(records[0].outcome.step).toBe('working-tree');
+    }
+  });
+
   it('a declared-but-unimplemented recipe id is a refusal, never a crash', async () => {
     const git = fakeGit();
     const { exec } = fakeExec();
@@ -217,6 +268,32 @@ describe('runRecipeOrders', () => {
     if (records[0].outcome.kind === 'refused') {
       expect(records[0].outcome.reason).toContain('ghost-recipe');
     }
+  });
+});
+
+describe('block-tier plumbing (Rule 2.30: the ONE policy normalizer)', () => {
+  it('effectiveBlockSeverities reads newAdvisories.blockSeverities through the canonical normalizer', () => {
+    const cwd = tempRepo({
+      '.dxkit/policy.json': JSON.stringify({
+        newAdvisories: { blockSeverities: ['critical', 'high', 'medium'] },
+      }),
+    });
+    expect([...effectiveBlockSeverities(cwd)].sort()).toEqual(['critical', 'high', 'medium']);
+    // Absent policy: the same default the guardrail classifier uses.
+    const bare = tempRepo({});
+    expect([...effectiveBlockSeverities(bare)].sort()).toEqual(['critical', 'high']);
+  });
+
+  it('cachedOsvQuery asks the network once per candidate within a run', async () => {
+    let calls = 0;
+    const cached = cachedOsvQuery(async () => {
+      calls += 1;
+      return [];
+    });
+    await cached('left-pad', '1.3.0', 'npm');
+    await cached('left-pad', '1.3.0', 'npm');
+    await cached('left-pad', '1.4.0', 'npm');
+    expect(calls).toBe(2);
   });
 });
 

--- a/test/remediate/recipes/run-recipes.test.ts
+++ b/test/remediate/recipes/run-recipes.test.ts
@@ -1,0 +1,297 @@
+/**
+ * The recipe phase runner: envelope containment (pure + enforced with
+ * disclosure), the trust refusal before any spawn, per-order commits, the
+ * discard-on-failure doctrine, and the synthetic-recipe injection proving
+ * the runner iterates the registry it is handed (the recipe-playbook
+ * discipline). Plus the phase-for-task composition: disabled config, a
+ * plan built from the entry floor, and the tier split.
+ */
+import { describe, it, expect } from 'vitest';
+import { partitionByEnvelope, pathInEnvelope } from '../../../src/remediate/recipes/envelope';
+import {
+  recipeCounts,
+  runRecipeOrders,
+  runRecipePhaseForTask,
+} from '../../../src/remediate/recipes/run-recipes';
+import type { RecipeGit } from '../../../src/remediate/recipes/git';
+import type { RecipeDeclaration } from '../../../src/remediate/work-orders/recipes-registry';
+import type { CorrectnessFloorResult } from '../../../src/analyzers/correctness/run';
+import { resolveRemediateConfig } from '../../../src/remediate/config';
+import { trustedLocalContext, untrustedContentContext } from '../../../src/analysis-trust';
+import { fakeExec, makeOrder, tempRepo } from './helpers';
+
+describe('envelope containment', () => {
+  it('speaks the planner language: root, directory prefix, exact file', () => {
+    expect(pathInEnvelope('anything/x.ts', { paths: [''], manifests: false })).toBe(true);
+    expect(pathInEnvelope('src/a/b.ts', { paths: ['src/a/'], manifests: false })).toBe(true);
+    expect(pathInEnvelope('src/ab/c.ts', { paths: ['src/a/'], manifests: false })).toBe(false);
+    expect(pathInEnvelope('package.json', { paths: ['package.json'], manifests: true })).toBe(true);
+    expect(pathInEnvelope('package.json5', { paths: ['package.json'], manifests: true })).toBe(
+      false,
+    );
+    const split = partitionByEnvelope(['a.ts', 'b.ts'], { paths: ['a.ts'], manifests: false });
+    expect(split).toEqual({ inside: ['a.ts'], outside: ['b.ts'] });
+  });
+});
+
+/** A scripted fake git: `dirty` is what changedPaths reports next; every
+ *  mutation is recorded. */
+function fakeGit(): RecipeGit & {
+  dirty: string[];
+  discarded: string[][];
+  commits: Array<{ paths: readonly string[]; message: string }>;
+} {
+  const state = {
+    dirty: [] as string[],
+    discarded: [] as string[][],
+    commits: [] as Array<{ paths: readonly string[]; message: string }>,
+    changedPaths() {
+      return [...state.dirty];
+    },
+    discardPaths(paths: readonly string[]) {
+      state.discarded.push([...paths]);
+      state.dirty = state.dirty.filter((p) => !paths.includes(p));
+    },
+    commitPaths(paths: readonly string[], message: string) {
+      state.commits.push({ paths, message });
+      state.dirty = state.dirty.filter((p) => !paths.includes(p));
+    },
+    head: () => 'deadbeef',
+  };
+  return state;
+}
+
+function syntheticRecipe(
+  execute: RecipeDeclaration['execute'],
+  id = 'synthetic-fixer',
+): RecipeDeclaration {
+  return {
+    id,
+    class: 'synthetic-class',
+    summary: 't',
+    implemented: true,
+    matches: () => true,
+    execute,
+  };
+}
+
+const syntheticOrder = makeOrder({
+  id: 'synthetic-class:unit',
+  class: 'synthetic-class',
+  recipe: 'synthetic-fixer',
+  envelope: { paths: ['fixed.txt'], manifests: false },
+});
+
+describe('runRecipeOrders', () => {
+  it('a SYNTHETIC recipe injected into the registry executes and commits per order (the runner iterates the registry)', async () => {
+    const git = fakeGit();
+    const { exec } = fakeExec();
+    const registry = [
+      syntheticRecipe(async (_order, ctx) => {
+        git.dirty.push('fixed.txt');
+        expect(ctx.trust.repoExecutionAllowed).toBe(true);
+        return { kind: 'applied', changedFiles: ['fixed.txt'] };
+      }),
+    ];
+    const records = await runRecipeOrders([syntheticOrder], {
+      cwd: '/x',
+      trust: trustedLocalContext(),
+      git,
+      exec,
+      registry,
+    });
+    expect(records).toHaveLength(1);
+    expect(records[0].outcome.kind).toBe('applied');
+    expect(git.commits).toEqual([
+      {
+        paths: ['fixed.txt'],
+        message: 'fix(synthetic-class): synthetic-class:unit (synthetic-fixer recipe)',
+      },
+    ]);
+  });
+
+  it('an UNTRUSTED tree refuses every order before any execute runs (disclosed, nothing spawns)', async () => {
+    const git = fakeGit();
+    const { exec, calls } = fakeExec();
+    let executed = false;
+    const registry = [
+      syntheticRecipe(async () => {
+        executed = true;
+        return { kind: 'applied', changedFiles: [] };
+      }),
+    ];
+    const records = await runRecipeOrders([syntheticOrder], {
+      cwd: '/x',
+      trust: untrustedContentContext(),
+      git,
+      exec,
+      registry,
+    });
+    expect(executed).toBe(false);
+    expect(calls).toHaveLength(0);
+    expect(records[0].outcome.kind).toBe('refused');
+    if (records[0].outcome.kind === 'refused') {
+      expect(records[0].outcome.reason).toContain('untrusted-content');
+    }
+  });
+
+  it('drops an out-of-envelope hunk WITH disclosure and commits only the envelope diff', async () => {
+    const git = fakeGit();
+    const { exec } = fakeExec();
+    const registry = [
+      syntheticRecipe(async () => {
+        git.dirty.push('fixed.txt', 'sprawl/other.txt');
+        return { kind: 'applied', changedFiles: ['fixed.txt', 'sprawl/other.txt'] };
+      }),
+    ];
+    const records = await runRecipeOrders([syntheticOrder], {
+      cwd: '/x',
+      trust: trustedLocalContext(),
+      git,
+      exec,
+      registry,
+    });
+    expect(records[0].droppedPaths).toEqual(['sprawl/other.txt']);
+    expect(git.discarded).toEqual([['sprawl/other.txt']]);
+    expect(records[0].outcome.kind).toBe('applied');
+    if (records[0].outcome.kind === 'applied') {
+      expect(records[0].outcome.changedFiles).toEqual(['fixed.txt']);
+    }
+    expect(git.commits[0].paths).toEqual(['fixed.txt']);
+  });
+
+  it('an applied claim whose whole diff was out-of-envelope becomes a FAILED envelope outcome', async () => {
+    const git = fakeGit();
+    const { exec } = fakeExec();
+    const registry = [
+      syntheticRecipe(async () => {
+        git.dirty.push('sprawl/other.txt');
+        return { kind: 'applied', changedFiles: ['sprawl/other.txt'] };
+      }),
+    ];
+    const records = await runRecipeOrders([syntheticOrder], {
+      cwd: '/x',
+      trust: trustedLocalContext(),
+      git,
+      exec,
+      registry,
+    });
+    expect(records[0].outcome.kind).toBe('failed');
+    if (records[0].outcome.kind === 'failed') expect(records[0].outcome.step).toBe('envelope');
+    expect(git.commits).toHaveLength(0);
+  });
+
+  it('a failed or throwing recipe discards its own diff, and only its own', async () => {
+    const git = fakeGit();
+    git.dirty.push('user-was-editing.md'); // pre-existing local dirt
+    const { exec } = fakeExec();
+    const registry = [
+      syntheticRecipe(async () => {
+        git.dirty.push('half-done.txt');
+        throw new Error('midway explosion');
+      }),
+    ];
+    const records = await runRecipeOrders([syntheticOrder], {
+      cwd: '/x',
+      trust: trustedLocalContext(),
+      git,
+      exec,
+      registry,
+    });
+    expect(records[0].outcome.kind).toBe('failed');
+    if (records[0].outcome.kind === 'failed') {
+      expect(records[0].outcome.output).toContain('midway explosion');
+    }
+    expect(git.discarded).toEqual([['half-done.txt']]);
+    expect(git.dirty).toEqual(['user-was-editing.md']);
+  });
+
+  it('a declared-but-unimplemented recipe id is a refusal, never a crash', async () => {
+    const git = fakeGit();
+    const { exec } = fakeExec();
+    const records = await runRecipeOrders(
+      [makeOrder({ id: 'x:y', class: 'synthetic-class', recipe: 'ghost-recipe' })],
+      { cwd: '/x', trust: trustedLocalContext(), git, exec, registry: [] },
+    );
+    expect(records[0].outcome.kind).toBe('refused');
+    if (records[0].outcome.kind === 'refused') {
+      expect(records[0].outcome.reason).toContain('ghost-recipe');
+    }
+  });
+});
+
+describe('runRecipePhaseForTask', () => {
+  const floorWith = (checks: CorrectnessFloorResult['checks']): CorrectnessFloorResult => ({
+    ran: true,
+    checks,
+    blocks: checks.some((c) => c.status === 'fail'),
+    scope: 'full',
+  });
+
+  it('remediate.recipes.enabled: false is a disclosed no-run', async () => {
+    const cwd = tempRepo({ '.dxkit/policy.json': '{"remediate":{"recipes":{"enabled":false}}}' });
+    const summary = await runRecipePhaseForTask({
+      cwd,
+      trust: trustedLocalContext(),
+      taskId: 'fix-build',
+      config: resolveRemediateConfig(cwd),
+      entryFloor: floorWith([]),
+    });
+    expect(summary.ran).toBe(false);
+    expect(summary.disabled).toBe(true);
+  });
+
+  it('plans from the entry floor and executes the stale-lockfile order end to end', async () => {
+    const cwd = tempRepo({
+      'package.json': '{"name":"fx"}',
+      'package-lock.json': '{}',
+      'src/index.ts': 'export const x = 1;\n',
+      '.dxkit/policy.json': '{}',
+    });
+    const git = fakeGit();
+    const { exec } = fakeExec((cmd) => {
+      if (cmd.args.includes('install')) git.dirty.push('package-lock.json');
+      return undefined;
+    });
+    const entryFloor = floorWith([
+      {
+        pack: 'typescript',
+        label: 'lockfile-sync',
+        bin: 'npm',
+        args: ['ci', '--dry-run'],
+        status: 'fail',
+        output: 'EUSAGE',
+      },
+    ]);
+    const summary = await runRecipePhaseForTask({
+      cwd,
+      trust: trustedLocalContext(),
+      taskId: 'fix-build',
+      config: resolveRemediateConfig(cwd),
+      entryFloor,
+      git,
+      exec,
+    });
+    expect(summary.ran).toBe(true);
+    expect(summary.selectedRecipeTier).toBe(1);
+    expect(summary.selectedAgentTier).toBe(0);
+    expect(summary.records[0].recipe).toBe('lockfile-sync');
+    expect(summary.records[0].outcome.kind).toBe('applied');
+    expect(recipeCounts(summary)).toEqual({ applied: 1, refused: 0, failed: 0 });
+    expect(git.commits[0].message).toContain('fix(stale-lockfile)');
+  });
+
+  it('a task selecting no orders is an honest no-run with the tier split at zero', async () => {
+    const cwd = tempRepo({ '.dxkit/policy.json': '{}' });
+    const summary = await runRecipePhaseForTask({
+      cwd,
+      trust: trustedLocalContext(),
+      taskId: 'fix-lint',
+      config: resolveRemediateConfig(cwd),
+      entryFloor: floorWith([]),
+    });
+    expect(summary.ran).toBe(false);
+    expect(summary.selectedRecipeTier).toBe(0);
+    expect(summary.records).toHaveLength(0);
+  });
+});

--- a/test/remediate/resume.test.ts
+++ b/test/remediate/resume.test.ts
@@ -183,6 +183,7 @@ function config(): RemediateConfig {
     maxDispatchBudget: 0,
     resume: true,
     workOrders: { maxSliceSize: 25 },
+    recipes: { enabled: true },
   };
 }
 

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -95,6 +95,7 @@ function config(
     maxDispatchBudget: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
+    recipes: { enabled: true },
   };
 }
 
@@ -714,6 +715,7 @@ describe('WP5: fast-exit, phases, cap accounting, blocked evidence', () => {
     expect(r.outcome).toBe('verified');
     expect(phases).toEqual([
       'entry-floor',
+      'recipes',
       'agent',
       'sweep',
       'verify-install',

--- a/test/remediate/work-orders/plan-surface.test.ts
+++ b/test/remediate/work-orders/plan-surface.test.ts
@@ -354,6 +354,7 @@ describe('remediate plan --json: work orders', () => {
       remediate: {
         enabled: true,
         workOrders: { maxSliceSize: 2 },
+        recipes: { enabled: true },
         taskBudgets: { 'fix-lint': { maxTurns: 3 } },
       },
     });

--- a/test/remediate/work-orders/planner.test.ts
+++ b/test/remediate/work-orders/planner.test.ts
@@ -257,8 +257,11 @@ describe('planWorkOrders: advisories', () => {
       deferred: 2,
       earliestExpiry: '2026-09-01',
     });
-    expect(axios.tier).toBe('recipe');
-    expect(axios.recipe).toBe('override-pin');
+    // TWO manifest roots and no per-advisory rootDir: the owning manifest is
+    // ambiguous, which the executor could only refuse at runtime, so the
+    // registry's matches tiers the order to the agent (4.4.5 review).
+    expect(axios.tier).toBe('agent');
+    expect(axios.recipe).toBeUndefined();
     // baselined dep-vuln DEBT produces an order too (fix-vulns' backlog)
     const lodash = plan.orders[1];
     expect(lodash.findings[0].attribution).toBe('pre-existing');
@@ -380,8 +383,11 @@ describe('planWorkOrders: lint (one order per file, every source)', () => {
       slice: 1,
       of: 3,
     });
-    expect(plan.orders[0].tier).toBe('recipe');
-    expect(plan.orders[0].recipe).toBe('lint-autofix');
+    // A SLICED order cannot be file-scope autofixed and verified per slice,
+    // so it tiers to the agent by matches (4.4.5 review), not via a runtime
+    // refusal the plan surface would render as executable determinism.
+    expect(plan.orders[0].tier).toBe('agent');
+    expect(plan.orders[0].recipe).toBeUndefined();
   });
 
   it('binary custom-check debt and other kinds land in undispatchable with identity-only evidence', () => {

--- a/test/remediate/work-orders/recipes.test.ts
+++ b/test/remediate/work-orders/recipes.test.ts
@@ -112,7 +112,12 @@ describe('recipe registry drives the tier (synthetic injection)', () => {
       .filter(([, d]) => d.recipe !== null)
       .map(([c, d]) => [d.recipe, c]);
     expect(RECIPE_REGISTRY.map((r) => [r.id, r.class]).sort()).toEqual(fromTable.sort());
-    for (const r of RECIPE_REGISTRY) expect(r.implemented).toBe(false);
+    // `implemented` and `execute` are one fact stated twice (4.4.5): the
+    // plan surface reads the flag, the phase runner calls the function.
+    for (const r of RECIPE_REGISTRY) {
+      expect(r.implemented).toBe(r.execute !== undefined);
+      expect(r.implemented).toBe(true);
+    }
     // a class with no producer carries a reason (the DEFERRED_KINDS discipline)
     for (const d of Object.values(WORK_ORDER_CLASSES) as WorkOrderClassDeclaration[]) {
       if (d.producers.includes('pending')) expect(d.pendingReason).toBeTruthy();

--- a/test/remediate/work-orders/recipes.test.ts
+++ b/test/remediate/work-orders/recipes.test.ts
@@ -125,3 +125,97 @@ describe('recipe registry drives the tier (synthetic injection)', () => {
     }
   });
 });
+
+describe('order-intrinsic feasibility lives in matches (an executor-certain refusal tiers agent)', () => {
+  const draftBase = {
+    findings: [],
+    envelope: { paths: ['package.json', 'package-lock.json'], manifests: true },
+    constraints: { install: NPM_CI, forbidden: [] },
+    done: { absentIds: [], verifier: 'floor' as const, command: 'x' },
+    budget: { turns: 1, minutes: 1, usd: 1, derivation: 'x' },
+    provenance: { source: 'guardrail-blocking' as const },
+  };
+  const floorFinding = (pack: string, specifier?: string) => ({
+    kind: 'floor-check',
+    id: 'f',
+    attribution: 'pre-existing' as const,
+    evidence: {
+      type: 'floor' as const,
+      pack,
+      label: 'x',
+      command: '',
+      ...(specifier !== undefined ? { specifier } : {}),
+    },
+  });
+  const lintFinding = (check: string) => ({
+    kind: 'custom-check',
+    id: 'l',
+    attribution: 'pre-existing' as const,
+    evidence: { type: 'custom-check' as const, check, file: 'src/a.ts', rule: 'eqeqeq' },
+  });
+  const advisoryFinding = (fixedVersion: string) => ({
+    kind: 'dep-vuln',
+    id: 'a',
+    attribution: 'deferred' as const,
+    evidence: { type: 'dep-vuln' as const, package: 'p', advisoryId: 'GHSA-1', fixedVersion },
+  });
+  const tierOf = (partial: Partial<WorkOrder> & Pick<WorkOrder, 'id' | 'class'>) =>
+    assignTier({ ...draftBase, ...partial }).tier;
+
+  it('lockfile-sync: a pack without a lockfileCheck, or an ambiguous root, tiers agent', () => {
+    const ok = { id: 'stale-lockfile:typescript', class: 'stale-lockfile' as const };
+    expect(tierOf({ ...ok, findings: [floorFinding('typescript')] })).toBe('recipe');
+    expect(tierOf({ ...ok, findings: [floorFinding('go')] })).toBe('agent');
+    expect(
+      tierOf({
+        ...ok,
+        findings: [floorFinding('typescript')],
+        envelope: { paths: ['package.json', 'sub/package.json'], manifests: true },
+      }),
+    ).toBe('agent');
+  });
+
+  it('override-pin: a range-shaped fixed version or a two-root envelope tiers agent', () => {
+    const ok = { id: 'dep-advisory:p', class: 'dep-advisory' as const };
+    expect(tierOf({ ...ok, findings: [advisoryFinding('4.1.1')] })).toBe('recipe');
+    expect(tierOf({ ...ok, findings: [advisoryFinding('>=4.1.1')] })).toBe('agent');
+    expect(
+      tierOf({
+        ...ok,
+        findings: [advisoryFinding('4.1.1')],
+        envelope: { paths: ['package.json', 'sub/package.json'], manifests: true },
+      }),
+    ).toBe('agent');
+  });
+
+  it('declare-dependency: an unsupported pack or a flag-shaped specifier tiers agent', () => {
+    const ok = { id: 'unresolved-import:typescript:.', class: 'unresolved-import' as const };
+    expect(tierOf({ ...ok, findings: [floorFinding('typescript', 'left-pad')] })).toBe('recipe');
+    expect(tierOf({ ...ok, findings: [floorFinding('python', 'requests')] })).toBe('agent');
+    expect(tierOf({ ...ok, findings: [floorFinding('typescript', '--registry=https://x')] })).toBe(
+      'agent',
+    );
+    expect(tierOf({ ...ok, findings: [floorFinding('typescript', './src/missing')] })).toBe(
+      'agent',
+    );
+  });
+
+  it('lint-autofix: a user check, a fixCommand-less pack, or a sliced order tiers agent', () => {
+    const ok = {
+      id: 'lint-located:src/a.ts',
+      class: 'lint-located' as const,
+      envelope: { paths: ['src/a.ts'], manifests: false },
+      provenance: { source: 'debt-slice' as const, file: 'src/a.ts', slice: 1, of: 1 },
+    };
+    expect(tierOf({ ...ok, findings: [lintFinding('lint:typescript')] })).toBe('recipe');
+    expect(tierOf({ ...ok, findings: [lintFinding('arch-rules')] })).toBe('agent');
+    expect(tierOf({ ...ok, findings: [lintFinding('lint:go')] })).toBe('agent');
+    expect(
+      tierOf({
+        ...ok,
+        findings: [lintFinding('lint:typescript')],
+        provenance: { source: 'debt-slice', file: 'src/a.ts', slice: 1, of: 3 },
+      }),
+    ).toBe('agent');
+  });
+});

--- a/test/remediate/work-orders/render.test.ts
+++ b/test/remediate/work-orders/render.test.ts
@@ -180,7 +180,8 @@ describe('renderWorkOrderSummary', () => {
     expect(line).toContain('dep-advisory:axios');
     expect(line).toContain('2 finding(s)');
     expect(line).toContain('net-new');
-    expect(line).toContain('recipe override-pin (declared, not yet executable)');
+    expect(line).toContain('recipe override-pin');
+    expect(line).not.toContain('not yet executable');
     expect(line).toContain('16 turns / 9 min / $1');
     expect(line).toContain('done via guardrail');
   });


### PR DESCRIPTION
## What

The recipe executor (remediate rethink, section 3B): the four declared recipes become executable, and the remediate frame runs them BEFORE any agent spawns. The most reliable agent run is the one that never happens; a plan whose selected orders are all recipe-tier now completes as a $0 remediate run, verified the way CI verifies.

`RecipeDeclaration` gains `execute(order, ctx) -> RecipeOutcome` (`applied { changedFiles }` | `refused { reason }` | `failed { step, output }`), and all four registry entries flip `implemented: true`:

- **lockfile-sync**: the owning root's lock-writing install (`resyncInstallFor`, a new canonical entry in `package-manager.ts` beside the frozen table, sharing the `isPeerConflictOnly` fallback doctrine), verified by the pack's own frozen dry-run through a new correctness-module single-check entry point. Refuses: no lockfile, ambiguous root, a pack whose check cannot verify (yarn's declared no-dry-run).
- **override-pin**: npm `overrides` pin at the highest known fixed version, then resync and a re-audit through the one dep-audit dispatch. The candidate pin is OSV pre-checked first via a new `queryOsvPackage` in the one OSV client: a pin that would leave a block-tier advisory in place REFUSES with the advisory named, at $0. Refuses: direct dependencies (upgrade them, do not override; the dep-bump lane's job), pnpm/yarn override mechanisms (declared, not implemented this round).
- **declare-dependency** (TypeScript pack orders): resolve the registry version (`npm view`, honoring the repo's `.npmrc`), OSV pre-check it (the live fix-build failure class, an agent installing a vulnerable phantom dependency, becomes a disclosed refusal), install into the section the importers imply (test-only importers get `devDependencies`), verify with the pack's resolution check. Refuses: project-path identities (a missing file is not a package), unknown packages, non-ts packs.
- **lint-autofix**: the pack linter's own fix mode via the new optional `LintGateProvider.fixCommand` (ts: file-scoped `eslint --fix --format json`); the same run's parsed leftovers, validated through the seam's located-finding boundary, are the verify. Refuses: user-declared checks, sliced orders (a file-scoped fix cannot be verified per slice), packs without a fix mode.

Frame integration (`recipeTierStep` in the runner): recipe-tier orders execute in plan order on the task branch, each diff measured against the pre-recipe tree (local dirt is never staged, committed, or discarded), out-of-envelope paths dropped WITH disclosure, one `fix(<class>): <order id>` commit per applied order, full discard on refusal/failure, then the ONE tree verification over the combined result. Recipe-only plan: no driver invocation at all. Mixed plan: the agent path runs exactly as before with the recipe summary disclosed. Planning failures are fail-open (a disclosed `planError`; the agent path proceeds). Agent-tier orders are NOT dispatched per order here; that is the scoped-agent unit.

Policy: `remediate.recipes.enabled` (default true), documented in the policy guide + metadata table + JSON schema (a tuning field of the already-registered `remediate` capability, so no posture-knob entry per the Rule 16 carve-out). The ledger gains a "Deterministic recipes" section: per-order applied/refused/failed with reasons, envelope drops, tier split, plan disclosures.

## Security

Recipes spawn installs and linters, so the phase entry point gates on the REQUIRED `AnalysisTrustContext`: an untrusted tree yields disclosed per-order refusals before anything spawns (pinned by test with a positive control). Every spawn goes through the injected bounded exec.

## How it is tested

45 new recipe tests plus frame/foundation additions (suite: 5971 passed, 404 files):

- per recipe: applied / refused / failed paths on fixture repos with injected exec; the OSV pre-check refusal with a fake fetcher (both override-pin and declare-dependency, asserting the tree stays untouched); the peer-conflict-only fallback gating both directions.
- phase runner: synthetic-recipe injection (the runner iterates the registry it is handed), the untrusted refusal with nothing spawned, envelope drop with disclosure, applied-but-out-of-envelope demoted to failed, throwing recipes discard only their own diff, real-git integration for the path-scoped commit/discard surface.
- frame: a recipe-only plan completes verified/no-op with a THROWING driver (the agent can never have spawned), guardrail-red on a blocked recipe diff, mixed plans still run the agent, plan errors are fail-open and disclosed, the phase-order pin includes `recipes`.
- registry contract updated: `implemented === (execute !== undefined)`, all four true; the plan surface drops "not yet executable" only for executable recipes.
- foundations: `resyncInstallFor` (lock-writing vs frozen, shared fallback reason), `queryOsvPackage` (request shape; any failure reads null, never clean).

## Sweep + guardrail

- `npm run typecheck && npm run typecheck:test`: clean
- `npx eslint . --max-warnings 0`: clean
- `npx prettier --check .`: clean
- `bash scripts/check-architecture.sh`: clean
- `bash scripts/check-docs-coverage.sh`: clean
- `DXKIT_SLOP_BASE=origin/main bash scripts/check-slop.sh`: clean (advisory size notes only, pre-existing)
- `npm run build && npx vitest run --coverage`: 5971 passed; coverage 73.7% (gate 50%)
- `node dist/index.js guardrail check --mode ref-based --ref origin/main`: **PASSED** (an interim run flagged `run.ts` crossing the large-file floor; fixed by moving the budget prompt note to `budget-notes.ts` and the in-loop-gate default probe to `agent-trust.ts`, both natural homes)

## Deliberately left out (and why)

- pnpm `pnpm.overrides` / yarn `resolutions` writing: declared refusals with the reason named, per the brief (npm first). The refusal text names the mechanism so the escalation evidence is useful.
- Per-order agent dispatch and rendered-order prompts: the scoped-agent unit (U7). A mixed plan still runs today's task prompt after the recipes.
- Driver availability stays a preflight: a repo with no agent CLI still short-circuits to `agent-never-ran` before the recipe phase. Moving that probe behind the tier decision (so a recipe-only plan lands fixes with no driver installed) touches the availability taxonomy several tests and the workflow rely on; it composes cleanly on top of U7's dispatch changes.
- `remediate plan` keeps its $0 default: the plan surface now says which recipes are executable, but does not execute them.

## Review focus

- The envelope-enforcement delta logic in `run-recipes.ts` (pre-status vs post-status; local dirt must never be committed or discarded) and its `git.ts` counterpart (per-path checkout so one untracked path cannot abort a batch restore).
- The override-pin refusal set: is refusing direct dependencies and non-npm PMs the right conservative line for round one?
- The lint-autofix verify (single-slice orders only; the fix run's own leftovers as the verify input) versus re-running the full lint gate.
- `recipeTierStep`'s fail-open contract: a thrown plan must never take down the agent path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
