### PR TITLE
feat(remediate): the scoped agent, order-driven dispatch with enforced envelope and in-session done (4.4.5 scoped-agent)

### DIFF
--- a/docs/commands/remediate.md
+++ b/docs/commands/remediate.md
@@ -21,8 +21,10 @@ vyuh-dxkit remediate configured [path] [--land pr] [--json]
 - `plan` shows, per enabled task, the task > tier > driver-native model
   resolution, the effective per-task budget, and the spend-ceiling-trimmed
   matrix the managed workflow reads. It also lists the planned WORK ORDERS
-  (`workOrders` in `--json`): the finite units a later executor will
-  dispatch, built from the entry floor, deferred advisories inside their
+  (`workOrders` in `--json`): the finite units the run consumes (recipe-tier
+  orders execute deterministically in the frame; the remaining agent-tier
+  orders are dispatched one order per agent run, up to
+  `remediate.maxOrdersPerRun`), built from the entry floor, deferred advisories inside their
   window (joined to the live dependency scan), and the lint backlog, each
   with its class, tier (`recipe` where a registered recipe matches, else
   `agent`), derived budget, and done criterion. Findings no class can take

--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -46,6 +46,7 @@ stanzas).
 | `remediate.agent.model`             | [#remediate-model](#remediate-model)                     |
 | `remediate.enabled`                 | [#remediate](#remediate)                                 |
 | `remediate.maxDispatchBudget`       | [#remediate-dispatch-budget](#remediate-dispatch-budget) |
+| `remediate.maxOrdersPerRun`         | [#remediate-orders-per-run](#remediate-orders-per-run)   |
 | `remediate.maxSpendPerRun`          | [#remediate-spend-per-run](#remediate-spend-per-run)     |
 | `remediate.recipes.enabled`         | [#remediate-recipes](#remediate-recipes)                 |
 | `remediate.resume`                  | [#remediate-resume](#remediate-resume)                   |
@@ -603,10 +604,11 @@ along with the dispatcher and the verbatim prompt.
 ## Remediate resume
 
 **What it does.** With `remediate.resume: true` the next run of a task
-CONTINUES from its prior salvage branch (a draft PR left by a
-budget-bounded or guardrail-blocked attempt) instead of starting over. A
-resumed attempt after a guardrail block gets the prior blocking findings
-in its prompt. Attempts are capped at 2 per branch (the counter travels
+CONTINUES from its prior salvage branch instead of starting over. Only a
+budget-exhausted VERIFIED partial is a resume anchor: its work passed the
+gate and was only cut short. A guardrail-blocked draft is never resumed;
+its blocking findings ride the next run's order prompts as a negative
+constraint instead. Attempts are capped at 2 per branch (the counter travels
 with the branch, so a no-op resume still consumes one); at the cap the
 task falls back to a fresh run. The entry floor still snapshots the
 pristine default tree first, so a broken partial reads as net-new and can
@@ -629,8 +631,9 @@ already computes (the entry floor's failures, deferred advisories inside
 their window, the grandfathered lint backlog) into finite work orders and
 lists them with their class, tier, budget, and done criterion. The remediate
 run consumes the same plan: recipe-tier orders execute deterministically
-first (see [Remediate recipes](#remediate-recipes)); agent-tier orders still
-run through the task prompts.
+first (see [Remediate recipes](#remediate-recipes)); the remaining agent-tier
+orders are dispatched one order per agent run (see
+[Remediate orders per run](#remediate-orders-per-run)).
 
 **Per parameter.**
 
@@ -679,3 +682,28 @@ the npm-family package managers (yarn's missing dry-run is a disclosed
 refusal), override pinning is npm only, and lint autofix requires the pack
 to declare a fix mode (TypeScript/JavaScript's eslint today). Everything a
 recipe declines is a named refusal, never a silent skip.
+
+## Remediate orders per run
+
+**What it does.** `remediate.maxOrdersPerRun` caps how many agent-tier work
+orders one remediate run dispatches. The agent tier no longer receives an
+open-ended task prompt: each remaining order for the selected task, including
+every recipe-tier order whose recipe refused or failed, is dispatched ONE
+ORDER PER AGENT RUN, highest value first, up to this cap. Each dispatch
+carries the rendered work order (findings with evidence, the attribution
+split, the envelope, the constraints, the done command), the order's derived
+budget as the driver budget, and the order's done criterion for the in-session
+Stop-gate; after the run, committed changes outside the order's envelope are
+dropped with disclosure, so sprawl cannot land. Orders beyond the cap are
+disclosed and deferred to the next firing.
+
+**Default and why.** `3`: enough to close several small orders in one firing
+while keeping each dispatch scoped and the run inside its wall clock. `0`
+turns order-driven dispatch off and restores the single open-ended task
+prompt (the pre-4.4.5 shape).
+
+**Interactions.** Per-order budgets are clamped to the run's remaining
+[budget](#remediate-budget); the total never exceeds the task's caps. Where
+the driver can narrow tools, package-manager install commands are denied
+for order runs (installs are a frame/recipe step) and the applied policy is
+disclosed in the envelope.

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -1279,6 +1279,16 @@ export interface GuardrailJsonPayload {
    *  unobserved" from "nobody said". Their pairs carry status
    *  `not_observed` — excluded from `summary.resolved`. */
   readonly notObserved: ReadonlyArray<NotObservedDisclosure>;
+  /** Kinds ref-based mode did not gate this run (they depend on build
+   *  artifacts absent at a bare git ref). ALWAYS present ([] in committed
+   *  modes and when nothing was excluded) so a consumer judging "is this
+   *  finding kind observed here" (the Stop-gate's order scope) never reads
+   *  an ungated kind as verified-absent. The console and markdown renderers
+   *  already disclosed this; the JSON payload now carries the same fact. */
+  readonly refExcludedKinds: ReadonlyArray<{
+    readonly kind: string;
+    readonly currentCount: number;
+  }>;
   /** Present when the dependency-vuln scan was requested but could not run —
    *  a pass is then NOT a clean bill of dependency health. */
   readonly depVulnsUnmeasured?: { readonly reason: string };
@@ -1527,6 +1537,9 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
     // check, aggregate counts). Always present — an agent reading the JSON
     // must be able to tell "nothing unobserved" from "nobody said".
     notObserved: result.notObserved,
+    // The ref-mode exclusion disclosure, in the JSON payload too (the other
+    // two renderers already print it) — always present, [] when none.
+    refExcludedKinds: result.refExcludedKinds,
     ...(result.depVulnsUnmeasured ? { depVulnsUnmeasured: result.depVulnsUnmeasured } : {}),
     ...(result.deferredCapture && result.deferredCapture.length > 0
       ? { deferredCapture: result.deferredCapture }

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -253,6 +253,13 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
     anchor: 'remediate-resume',
   },
   {
+    path: 'remediate.maxOrdersPerRun',
+    summary:
+      'most agent-tier work orders one run dispatches, one order per agent run, highest ' +
+      'value first (default 3; 0 disables order-driven dispatch)',
+    anchor: 'remediate-orders-per-run',
+  },
+  {
     path: 'remediate.workOrders.maxSliceSize',
     summary: 'largest number of findings one debt work order may carry (default 25)',
     anchor: 'remediate-work-orders',

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -356,6 +356,7 @@ export function buildPolicySchema(version: string): Schema {
           },
           maxSpendPerRun: { type: 'number', description: desc('remediate.maxSpendPerRun') },
           maxDispatchBudget: { type: 'number', description: desc('remediate.maxDispatchBudget') },
+          maxOrdersPerRun: { type: 'number', description: desc('remediate.maxOrdersPerRun') },
           workOrders: obj(
             {
               maxSliceSize: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3610,7 +3610,7 @@ export async function run(argv: string[]): Promise<void> {
       // positionals[1] = hook name (stop-gate | ...).
       const hookName = positionals[1];
       if (hookName === 'stop-gate') {
-        const { runStopGate } = await import('./loop/stop-gate');
+        const { runStopGate } = await import('./loop/stop-gate-cli');
         await runStopGate(cwd);
         break;
       }

--- a/src/loop/demo.ts
+++ b/src/loop/demo.ts
@@ -54,6 +54,7 @@ function illustrativePayload(blocked: boolean): GuardrailJsonPayload {
     attributionGaps: [],
     requiredNotObserved: [],
     notObserved: [],
+    refExcludedKinds: [],
     // The illustration has no allowlist, so nothing is deferred and nothing can
     // lapse. Spelled out rather than omitted — the field is required so a real
     // payload can never quietly lack it.

--- a/src/loop/order-scope.ts
+++ b/src/loop/order-scope.ts
@@ -8,7 +8,7 @@
  * close.
  *
  * One module owns the file's path, shape, writer, and reader (Rule 2: the
- * lane writes what the gate reads, from one definition). Two disciplines
+ * lane writes what the gate reads, from one definition). Three disciplines
  * are load-bearing:
  *
  *   - EXECUTES NOTHING. The scope check post-processes the guardrail
@@ -16,18 +16,38 @@
  *     prompt display text, never executed here — so a hostile or corrupt
  *     order file can never widen execution (Rule 17: the Stop-gate must
  *     not widen execution on untrusted trees).
- *   - FAIL-OPEN, never silent. An unreadable or malformed file reads as
- *     "no order scope" (the gate keeps every pre-existing behavior) and the
- *     reader says so via `problem`, which the gate surfaces.
+ *   - FAIL-OPEN, never silent. An unreadable, malformed, foreign, or stale
+ *     file reads as "no order scope" (the gate keeps every pre-existing
+ *     behavior) and the reader says so via `problem`, which the gate
+ *     surfaces. Likewise, a done question the gate's own data cannot answer
+ *     — an unobserved finding kind, a skipped floor check — is UNDECIDABLE
+ *     with the reason named, never a silent "done" (the Rule 19
+ *     discipline: absence of observation is not absence of findings).
+ *   - SESSION-BOUND. The file is repo-global, so a SIGKILLed lane or a
+ *     concurrent lane must not scope someone else's session: the writer
+ *     stamps a per-run TOKEN (the lane also injects it into the agent's
+ *     env as DXKIT_ORDER_TOKEN, which the Stop hook inherits) plus a
+ *     timestamp; the reader treats a token mismatch, a missing session
+ *     token, or an over-age file as absent-with-disclosure.
  */
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { GuardrailJsonPayload } from '../baseline/check-renderers';
+import type { CorrectnessCheckResult } from '../analyzers/correctness/run';
 import type { FloorGateOutcome } from './floor-gate';
 import { checkKey } from '../analyzers/correctness/attribution';
 import { LEDGER_DIR } from './ledger';
 
 export const ORDER_SCOPE_FILE = 'order.json';
+
+/** Env var carrying the dispatching lane's order token into the agent's
+ *  process tree (the Stop hook inherits it). */
+export const ORDER_TOKEN_ENV = 'DXKIT_ORDER_TOKEN';
+
+/** A scope older than this is stale regardless of token (belt and braces
+ *  over the env binding — no order run may legally outlive it). */
+export const ORDER_SCOPE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 /** The lane→gate contract: the order's done criterion, plus display facts. */
 export interface OrderScope {
@@ -36,18 +56,32 @@ export interface OrderScope {
    *  baseline fingerprints (guardrail verifier) or floor check keys
    *  (`pack:label[#finding]`, floor verifier). */
   readonly absentIds: readonly string[];
+  /** The finding KINDS behind `absentIds` — what the guardrail arm checks
+   *  observation for (an unobserved kind makes the question undecidable,
+   *  never silently done). */
+  readonly kinds: readonly string[];
   readonly envelope: { readonly paths: readonly string[]; readonly manifests: boolean };
   readonly verifier: 'floor' | 'guardrail';
   /** The check command the ORDER PROMPT tells the agent to run. Display
    *  text in the block reason only — the gate never executes it. */
   readonly command: string;
+  /** Session binding: matches the dispatching lane's DXKIT_ORDER_TOKEN. */
+  readonly token: string;
+  /** ISO timestamp of the write (the age bound reads it). */
+  readonly writtenAt: string;
+}
+
+/** A fresh per-run token for the writer + the agent env. */
+export function newOrderScopeToken(): string {
+  return crypto.randomBytes(16).toString('hex');
 }
 
 function scopePath(repoDir: string): string {
   return path.join(repoDir, LEDGER_DIR, ORDER_SCOPE_FILE);
 }
 
-/** The lane's writer: called immediately before each order dispatch. */
+/** The lane's writer: called immediately before each order dispatch
+ *  (overwrites any stale leftover from a killed prior lane). */
 export function writeOrderScope(repoDir: string, scope: OrderScope): void {
   const file = scopePath(repoDir);
   fs.mkdirSync(path.dirname(file), { recursive: true });
@@ -55,8 +89,8 @@ export function writeOrderScope(repoDir: string, scope: OrderScope): void {
 }
 
 /** The lane's cleaner: called after each dispatch (try/finally). Best
- *  effort — a leftover file only scopes the next gate run of the SAME
- *  lane process, and the reader validates shape either way. */
+ *  effort — a leftover file is neutralized by the session binding either
+ *  way. */
 export function clearOrderScope(repoDir: string): void {
   try {
     fs.rmSync(scopePath(repoDir), { force: true });
@@ -65,12 +99,22 @@ export function clearOrderScope(repoDir: string): void {
   }
 }
 
+export interface OrderScopeReadOptions {
+  /** The session's own order token (default: process.env.DXKIT_ORDER_TOKEN).
+   *  A scope whose token does not match — including when the session has
+   *  none — is foreign/stale and reads as absent-with-disclosure. */
+  readonly expectedToken?: string | undefined;
+  /** Clock for the age bound (tests). */
+  readonly now?: () => number;
+}
+
 /** Validating reader. `scope: null` = no order scope (absent file, or a
- *  malformed one — `problem` then says why, so the skip is disclosed). */
-export function readOrderScope(repoDir: string): {
-  readonly scope: OrderScope | null;
-  readonly problem?: string;
-} {
+ *  malformed / foreign / stale one — `problem` then says why, so the skip
+ *  is disclosed). */
+export function readOrderScope(
+  repoDir: string,
+  opts: OrderScopeReadOptions = {},
+): { readonly scope: OrderScope | null; readonly problem?: string } {
   const file = scopePath(repoDir);
   let raw: string;
   try {
@@ -78,31 +122,36 @@ export function readOrderScope(repoDir: string): {
   } catch {
     return { scope: null }; // absent — the ordinary, non-order-scoped gate run
   }
+  let scope: OrderScope;
   try {
     const doc = JSON.parse(raw) as Record<string, unknown>;
     const envelope = doc.envelope as Record<string, unknown> | undefined;
+    const strings = (v: unknown): v is string[] =>
+      Array.isArray(v) && v.every((x): x is string => typeof x === 'string');
     if (
       typeof doc.orderId !== 'string' ||
-      !Array.isArray(doc.absentIds) ||
-      !doc.absentIds.every((id): id is string => typeof id === 'string') ||
+      !strings(doc.absentIds) ||
+      !strings(doc.kinds) ||
       (doc.verifier !== 'floor' && doc.verifier !== 'guardrail') ||
       typeof doc.command !== 'string' ||
+      typeof doc.token !== 'string' ||
+      typeof doc.writtenAt !== 'string' ||
       typeof envelope !== 'object' ||
       envelope === null ||
-      !Array.isArray(envelope.paths) ||
-      !envelope.paths.every((p): p is string => typeof p === 'string') ||
+      !strings(envelope.paths) ||
       typeof envelope.manifests !== 'boolean'
     ) {
       return { scope: null, problem: `order scope at ${file} is malformed — ignoring it` };
     }
-    return {
-      scope: {
-        orderId: doc.orderId,
-        absentIds: doc.absentIds,
-        envelope: { paths: envelope.paths, manifests: envelope.manifests },
-        verifier: doc.verifier,
-        command: doc.command,
-      },
+    scope = {
+      orderId: doc.orderId,
+      absentIds: doc.absentIds,
+      kinds: doc.kinds,
+      envelope: { paths: envelope.paths, manifests: envelope.manifests },
+      verifier: doc.verifier,
+      command: doc.command,
+      token: doc.token,
+      writtenAt: doc.writtenAt,
     };
   } catch (err) {
     return {
@@ -110,26 +159,127 @@ export function readOrderScope(repoDir: string): {
       problem: `order scope at ${file} is unreadable (${err instanceof Error ? err.message : String(err)}) — ignoring it`,
     };
   }
+  // Session binding: the file is repo-global, so a killed lane's leftover
+  // or a concurrent lane's write must not scope THIS session's stops.
+  const expected = 'expectedToken' in opts ? opts.expectedToken : process.env[ORDER_TOKEN_ENV];
+  if (!expected || scope.token !== expected) {
+    return {
+      scope: null,
+      problem:
+        `order scope at ${file} belongs to a different lane session ` +
+        `(${expected ? 'token mismatch' : 'no order token in this session'}) — ignoring it`,
+    };
+  }
+  const writtenAt = Date.parse(scope.writtenAt);
+  const now = (opts.now ?? Date.now)();
+  if (!Number.isFinite(writtenAt) || now - writtenAt > ORDER_SCOPE_MAX_AGE_MS) {
+    return {
+      scope: null,
+      problem: `order scope at ${file} is stale (written ${scope.writtenAt}) — ignoring it`,
+    };
+  }
+  return { scope };
 }
 
-/**
- * Which of the order's ids are STILL PRESENT, judged only from what the
- * gate already computed — no re-gather, no execution:
- *
- *   - guardrail verifier: an id is present when any pair's `currentId`
- *     matches (an allowlist-suppressed pair counts — the order asked for
- *     the finding to be CLOSED, not waived);
- *   - floor verifier: an id (`pack:label[#finding]`) is present when its
- *     check key is among the floor's FAILING checks. A floor that did not
- *     run cannot answer — `undecidable` says so (fail-open: the gate then
- *     allows, disclosed, and the frame's post-run verification arbitrates).
- */
+/** Is any order scope PRESENT on disk (bound to this session or not)? The
+ *  verdict-cache bypass reads this: a cached ALLOW must not replay over a
+ *  pending order, and a malformed/foreign file still means "something is
+ *  scoping stops here" — re-derive rather than replay. */
+export function orderScopePresent(repoDir: string): boolean {
+  try {
+    return fs.existsSync(scopePath(repoDir));
+  } catch {
+    return false;
+  }
+}
+
+/** Per-id floor done-ness, judged at FINDING level where the check carries
+ *  per-finding identities (Rule 2.30: this is the ONE computation — the
+ *  Stop-gate's floor arm and the ledger's per-order done disclosure both
+ *  read it, so they cannot drift). */
+export interface FloorDoneVerdict {
+  /** Ids whose own failure is still observed (check fails and, for a
+   *  finding-level id, its finding is among the check's current ones). */
+  readonly open: readonly string[];
+  /** Ids the floor could not decide (check absent from the run, skipped,
+   *  or failing without the finding decomposition a suffixed id needs). */
+  readonly undecided: readonly string[];
+  /** Ids whose own finding is gone while the shared check still fails on
+   *  OTHER findings (a sibling order's) — done, with disclosure. */
+  readonly siblingOnly: readonly string[];
+}
+
+export function floorOrderDone(
+  absentIds: readonly string[],
+  checks: readonly Pick<CorrectnessCheckResult, 'pack' | 'label' | 'status' | 'findings'>[],
+): FloorDoneVerdict {
+  const byKey = new Map(checks.map((c) => [checkKey(c.pack, c.label), c] as const));
+  const open: string[] = [];
+  const undecided: string[] = [];
+  const siblingOnly: string[] = [];
+  for (const id of absentIds) {
+    const hash = id.indexOf('#');
+    const key = hash === -1 ? id : id.slice(0, hash);
+    const finding = hash === -1 ? undefined : id.slice(hash + 1);
+    const check = byKey.get(key);
+    if (!check || check.status.startsWith('skipped')) {
+      undecided.push(id);
+      continue;
+    }
+    if (check.status === 'pass') continue; // closed
+    // status === 'fail'
+    if (finding === undefined) {
+      open.push(id);
+      continue;
+    }
+    if (!check.findings) {
+      // A finding-level id against a failure that did not decompose: own
+      // vs sibling cannot be told apart — undecided, never silently done.
+      undecided.push(id);
+      continue;
+    }
+    if (check.findings.includes(finding)) open.push(id);
+    else siblingOnly.push(id);
+  }
+  return { open, undecided, siblingOnly };
+}
+
+/** The gate's answer for one scope, judged only from what the gate already
+ *  computed — no re-gather, no execution. */
+export interface OrderScopeVerdict {
+  /** Ids still present: block, naming exactly these. */
+  readonly unresolved: readonly string[];
+  /** The done question could not be answered — allow, disclosed (the
+   *  frame's post-run verification arbitrates). */
+  readonly undecidable?: string;
+  /** Done, but with a fact the operator should see (sibling findings keep
+   *  the shared check red). Rides the allow's stderr. */
+  readonly disclosure?: string;
+}
+
 export function unresolvedOrderIds(
   scope: OrderScope,
   json: GuardrailJsonPayload,
   floor: FloorGateOutcome,
-): { readonly unresolved: readonly string[]; readonly undecidable?: string } {
+): OrderScopeVerdict {
   if (scope.verifier === 'guardrail') {
+    // Observation first (Rule 19): a kind the gate run never observed — a
+    // ref-mode-excluded kind, an unobserved check — cannot be read as
+    // "closed"; absence of a pair is then absence of observation.
+    const unobserved = new Set<string>([
+      ...(json.notObserved ?? []).map((d) => String(d.kind)),
+      ...(json.refExcludedKinds ?? []).map((e) => String(e.kind)),
+    ]);
+    const blind = scope.kinds.filter((k) => unobserved.has(k));
+    if (blind.length > 0) {
+      return {
+        unresolved: [],
+        undecidable:
+          `the gate run did not observe kind(s) ${blind.join(', ')} ` +
+          `(not gated in this mode, or the producing check did not run), so the order's ` +
+          `findings cannot be read as closed`,
+      };
+    }
     const present = new Set(
       json.pairs.map((p) => p.currentId).filter((id): id is string => id !== undefined),
     );
@@ -144,10 +294,26 @@ export function unresolvedOrderIds(
           : `the correctness floor errored (${floor.message})`,
     };
   }
-  const failing = new Set(
-    floor.result.checks.filter((c) => c.status === 'fail').map((c) => checkKey(c.pack, c.label)),
-  );
-  return { unresolved: scope.absentIds.filter((id) => failing.has(id.split('#')[0])) };
+  const done = floorOrderDone(scope.absentIds, floor.result.checks);
+  if (done.open.length > 0) return { unresolved: done.open };
+  if (done.undecided.length > 0) {
+    return {
+      unresolved: [],
+      undecidable:
+        `the floor could not decide ${done.undecided.length} of the order's target ` +
+        `finding(s) (${done.undecided.join(', ')}) — the producing check was skipped, ` +
+        `absent, or failed without its finding decomposition`,
+    };
+  }
+  if (done.siblingOnly.length > 0) {
+    return {
+      unresolved: [],
+      disclosure:
+        `work order ${scope.orderId}: its own target finding(s) are closed; the shared ` +
+        `check still fails on findings outside this order (another order's scope)`,
+    };
+  }
+  return { unresolved: [] };
 }
 
 /** The block reason handed to the model: exactly the ids left to close. */

--- a/src/loop/order-scope.ts
+++ b/src/loop/order-scope.ts
@@ -1,0 +1,162 @@
+/**
+ * The Stop-gate's ORDER SCOPE (remediate rethink, section 3C): when the
+ * remediate lane dispatches ONE work order per agent run, it writes the
+ * order's done criterion to `.dxkit/loop/order.json` before the spawn and
+ * clears it after — and the Stop-gate consumes it, so "done" is verified
+ * IN-SESSION: the agent cannot stop while the order's target findings are
+ * still present, and the block reason hands back exactly the ids left to
+ * close.
+ *
+ * One module owns the file's path, shape, writer, and reader (Rule 2: the
+ * lane writes what the gate reads, from one definition). Two disciplines
+ * are load-bearing:
+ *
+ *   - EXECUTES NOTHING. The scope check post-processes the guardrail
+ *     payload and floor outcome the gate already computed; `command` is
+ *     prompt display text, never executed here — so a hostile or corrupt
+ *     order file can never widen execution (Rule 17: the Stop-gate must
+ *     not widen execution on untrusted trees).
+ *   - FAIL-OPEN, never silent. An unreadable or malformed file reads as
+ *     "no order scope" (the gate keeps every pre-existing behavior) and the
+ *     reader says so via `problem`, which the gate surfaces.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type { GuardrailJsonPayload } from '../baseline/check-renderers';
+import type { FloorGateOutcome } from './floor-gate';
+import { checkKey } from '../analyzers/correctness/attribution';
+import { LEDGER_DIR } from './ledger';
+
+export const ORDER_SCOPE_FILE = 'order.json';
+
+/** The lane→gate contract: the order's done criterion, plus display facts. */
+export interface OrderScope {
+  readonly orderId: string;
+  /** The finding ids that must be ABSENT for the order to be done:
+   *  baseline fingerprints (guardrail verifier) or floor check keys
+   *  (`pack:label[#finding]`, floor verifier). */
+  readonly absentIds: readonly string[];
+  readonly envelope: { readonly paths: readonly string[]; readonly manifests: boolean };
+  readonly verifier: 'floor' | 'guardrail';
+  /** The check command the ORDER PROMPT tells the agent to run. Display
+   *  text in the block reason only — the gate never executes it. */
+  readonly command: string;
+}
+
+function scopePath(repoDir: string): string {
+  return path.join(repoDir, LEDGER_DIR, ORDER_SCOPE_FILE);
+}
+
+/** The lane's writer: called immediately before each order dispatch. */
+export function writeOrderScope(repoDir: string, scope: OrderScope): void {
+  const file = scopePath(repoDir);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(scope, null, 2) + '\n', 'utf8');
+}
+
+/** The lane's cleaner: called after each dispatch (try/finally). Best
+ *  effort — a leftover file only scopes the next gate run of the SAME
+ *  lane process, and the reader validates shape either way. */
+export function clearOrderScope(repoDir: string): void {
+  try {
+    fs.rmSync(scopePath(repoDir), { force: true });
+  } catch {
+    // best-effort cleanup
+  }
+}
+
+/** Validating reader. `scope: null` = no order scope (absent file, or a
+ *  malformed one — `problem` then says why, so the skip is disclosed). */
+export function readOrderScope(repoDir: string): {
+  readonly scope: OrderScope | null;
+  readonly problem?: string;
+} {
+  const file = scopePath(repoDir);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return { scope: null }; // absent — the ordinary, non-order-scoped gate run
+  }
+  try {
+    const doc = JSON.parse(raw) as Record<string, unknown>;
+    const envelope = doc.envelope as Record<string, unknown> | undefined;
+    if (
+      typeof doc.orderId !== 'string' ||
+      !Array.isArray(doc.absentIds) ||
+      !doc.absentIds.every((id): id is string => typeof id === 'string') ||
+      (doc.verifier !== 'floor' && doc.verifier !== 'guardrail') ||
+      typeof doc.command !== 'string' ||
+      typeof envelope !== 'object' ||
+      envelope === null ||
+      !Array.isArray(envelope.paths) ||
+      !envelope.paths.every((p): p is string => typeof p === 'string') ||
+      typeof envelope.manifests !== 'boolean'
+    ) {
+      return { scope: null, problem: `order scope at ${file} is malformed — ignoring it` };
+    }
+    return {
+      scope: {
+        orderId: doc.orderId,
+        absentIds: doc.absentIds,
+        envelope: { paths: envelope.paths, manifests: envelope.manifests },
+        verifier: doc.verifier,
+        command: doc.command,
+      },
+    };
+  } catch (err) {
+    return {
+      scope: null,
+      problem: `order scope at ${file} is unreadable (${err instanceof Error ? err.message : String(err)}) — ignoring it`,
+    };
+  }
+}
+
+/**
+ * Which of the order's ids are STILL PRESENT, judged only from what the
+ * gate already computed — no re-gather, no execution:
+ *
+ *   - guardrail verifier: an id is present when any pair's `currentId`
+ *     matches (an allowlist-suppressed pair counts — the order asked for
+ *     the finding to be CLOSED, not waived);
+ *   - floor verifier: an id (`pack:label[#finding]`) is present when its
+ *     check key is among the floor's FAILING checks. A floor that did not
+ *     run cannot answer — `undecidable` says so (fail-open: the gate then
+ *     allows, disclosed, and the frame's post-run verification arbitrates).
+ */
+export function unresolvedOrderIds(
+  scope: OrderScope,
+  json: GuardrailJsonPayload,
+  floor: FloorGateOutcome,
+): { readonly unresolved: readonly string[]; readonly undecidable?: string } {
+  if (scope.verifier === 'guardrail') {
+    const present = new Set(
+      json.pairs.map((p) => p.currentId).filter((id): id is string => id !== undefined),
+    );
+    return { unresolved: scope.absentIds.filter((id) => present.has(id)) };
+  }
+  if (floor.kind !== 'ran') {
+    return {
+      unresolved: [],
+      undecidable:
+        floor.kind === 'unavailable'
+          ? `the correctness floor did not run here (${floor.reason})`
+          : `the correctness floor errored (${floor.message})`,
+    };
+  }
+  const failing = new Set(
+    floor.result.checks.filter((c) => c.status === 'fail').map((c) => checkKey(c.pack, c.label)),
+  );
+  return { unresolved: scope.absentIds.filter((id) => failing.has(id.split('#')[0])) };
+}
+
+/** The block reason handed to the model: exactly the ids left to close. */
+export function buildOrderRepairMessage(scope: OrderScope, unresolved: readonly string[]): string {
+  return (
+    `dxkit Stop-gate: work order ${scope.orderId} is NOT done — ` +
+    `${unresolved.length} of its target finding(s) are still present:\n` +
+    unresolved.map((id) => `- ${id}`).join('\n') +
+    `\n\nClose exactly these (everything else is out of scope for this order), then try to ` +
+    `stop again. Check with: ${scope.command}`
+  );
+}

--- a/src/loop/stop-gate-cli.ts
+++ b/src/loop/stop-gate-cli.ts
@@ -18,7 +18,7 @@ import {
 } from './gate-cache';
 import { buildFloorGate } from './floor-gate';
 import { readStdinPayload } from './stop-gate-io';
-import { readOrderScope } from './order-scope';
+import { orderScopePresent } from './order-scope';
 import { trustedLocalContext } from '../analysis-trust';
 import { computeStopGate } from './stop-gate';
 
@@ -53,12 +53,13 @@ export async function runStopGate(cwd: string): Promise<void> {
   // signature captures every file the gather would see, so a cache hit is
   // only ever a genuinely-identical tree and the cache can never skip a
   // real net-new finding. Bypass with DXKIT_LOOP_NO_CACHE=1.
-  // An ACTIVE ORDER SCOPE bypasses the verdict cache entirely: the tree
-  // signature deliberately excludes dxkit's own runtime state, so it cannot
-  // see `.dxkit/loop/order.json` appear, change, or clear — a cached ALLOW
-  // from an unscoped stop must never replay over a pending order (and an
-  // order-scoped verdict must never be replayed after the lane clears it).
-  const orderScoped = readOrderScope(repoDir).scope !== null;
+  // ANY order-scope file on disk bypasses the verdict cache entirely: the
+  // tree signature deliberately excludes dxkit's own runtime state, so it
+  // cannot see `.dxkit/loop/order.json` appear, change, or clear — a cached
+  // ALLOW from an unscoped stop must never replay over a pending order, and
+  // a malformed or foreign file still means "something is scoping stops
+  // here": re-derive (which discloses the problem) rather than replay.
+  const orderScoped = orderScopePresent(repoDir);
   const signature =
     process.env.DXKIT_LOOP_NO_CACHE === '1' || orderScoped ? null : workingTreeSignature(repoDir);
   // The environment half of the cache key (T1.3): same tree + DIFFERENT

--- a/src/loop/stop-gate-cli.ts
+++ b/src/loop/stop-gate-cli.ts
@@ -1,0 +1,188 @@
+/**
+ * `vyuh-dxkit hook stop-gate` — the CLI entry wrapper around the pure gate
+ * (`stop-gate.ts:computeStopGate`). Split from the gate at the module-size
+ * bar (the `stop-gate-io` precedent): this side owns the process I/O —
+ * loop-scoped activation, the verdict cache fast path, running the
+ * guardrail in-process, ledger writes, and the exit-code protocol.
+ */
+import type { GuardrailJsonPayload } from '../baseline/check-renderers';
+import { appendLedgerEvent, buildLedgerEvent, LEDGER_DIR } from './ledger';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  loopGateActive,
+  workingTreeSignature,
+  environmentSignature,
+  readStateCache,
+  writeStateCache,
+} from './gate-cache';
+import { buildFloorGate } from './floor-gate';
+import { readStdinPayload } from './stop-gate-io';
+import { readOrderScope } from './order-scope';
+import { trustedLocalContext } from '../analysis-trust';
+import { computeStopGate } from './stop-gate';
+
+/**
+ * CLI entry for `vyuh-dxkit hook stop-gate`. Reads the hook payload from
+ * stdin, runs the guardrail in-process, writes the ledger + last-guardrail
+ * snapshot, then emits the Stop-hook decision and exits.
+ */
+export async function runStopGate(cwd: string): Promise<void> {
+  const payload = readStdinPayload();
+  const repoDir = payload.cwd || cwd;
+
+  // ── Loop-scoped activation. The Stop-gate is for UNATTENDED loops, where
+  // no human is reviewing each stop. An interactive turn — a person present,
+  // the agent stopping to ask a question — must not pay the guardrail cost.
+  // So the hook is an instant no-op allow unless the loop marks itself
+  // active (DXKIT_LOOP_ACTIVE=1, or a `.dxkit/loop/active` sentinel the loop
+  // runner drops). The CI guardrail still gates the branch either way.
+  if (!loopGateActive(repoDir, payload)) {
+    process.exit(0);
+  }
+
+  // Resolve the loop-scoped posture ONCE (preset → policy). This is the
+  // only place the loop preset is read; the CI guardrail never sees it.
+  const { resolveLoopPolicy } = await import('./policy');
+  const { policy, preset, flowMode, schemaMode, duplicationMode } = resolveLoopPolicy(repoDir);
+
+  // ── Fast path: replay the last verdict when the working tree is
+  // byte-identical to what was last gathered (a no-change stop — an
+  // interactive Q&A turn, or a re-stop after a block with no edit). Skips
+  // the full guardrail gather + tests entirely. Safe by construction: the
+  // signature captures every file the gather would see, so a cache hit is
+  // only ever a genuinely-identical tree and the cache can never skip a
+  // real net-new finding. Bypass with DXKIT_LOOP_NO_CACHE=1.
+  // An ACTIVE ORDER SCOPE bypasses the verdict cache entirely: the tree
+  // signature deliberately excludes dxkit's own runtime state, so it cannot
+  // see `.dxkit/loop/order.json` appear, change, or clear — a cached ALLOW
+  // from an unscoped stop must never replay over a pending order (and an
+  // order-scoped verdict must never be replayed after the lane clears it).
+  const orderScoped = readOrderScope(repoDir).scope !== null;
+  const signature =
+    process.env.DXKIT_LOOP_NO_CACHE === '1' || orderScoped ? null : workingTreeSignature(repoDir);
+  // The environment half of the cache key (T1.3): same tree + DIFFERENT
+  // observer (dxkit / policy / test command / scanner binaries) must MISS,
+  // or a scanner upgrade between sessions replays a stale ALLOW.
+  const envSignature = signature
+    ? environmentSignature(repoDir, {
+        preset,
+        policy,
+        modes: { flowMode, schemaMode, duplicationMode },
+      })
+    : null;
+  const agentFields = {
+    ...(payload.agent_id ? { agent_id: payload.agent_id } : {}),
+    ...(payload.agent_type ? { agent_type: payload.agent_type } : {}),
+  };
+  if (signature && envSignature) {
+    const cached = readStateCache(repoDir);
+    if (cached && cached.signature === signature && cached.envSignature === envSignature) {
+      const event = buildLedgerEvent(repoDir, {
+        session_id: payload.session_id || '',
+        ...agentFields,
+        cwd: repoDir,
+        guardrail_status: cached.outcome === 'allow' ? 'pass' : 'fail',
+        net_new_findings: cached.netNew,
+        baseline_findings: cached.baselineFindings,
+        files_changed: 0,
+        allowed: cached.outcome === 'allow',
+        stop_hook_active: !!payload.stop_hook_active,
+        tests_status: 'skipped',
+        lint_status: 'not_configured',
+        typecheck_status: 'not_configured',
+        duration_ms: 0,
+        cached: true,
+      });
+      appendLedgerEvent(repoDir, { ...event, preset });
+      if (cached.outcome === 'block-model') {
+        process.stdout.write(JSON.stringify({ decision: 'block', reason: cached.message }) + '\n');
+        process.exit(0);
+      }
+      process.exit(0); // allow — clean stop replayed from cache
+    }
+  }
+
+  // Scope the gather to the analyzers this posture can actually block on.
+  // A `security-only` loop skips jscpd / lint / coverage / cloc / test-gaps /
+  // graphify — they feed only kinds the policy can't act on, so skipping them
+  // cannot change the verdict (see src/baseline/gather-scope.ts). Both sides
+  // of the diff are scoped identically. `full-debt` derives FULL_SCOPE.
+  const { scopeForPolicy } = await import('../baseline/gather-scope');
+  const scope = scopeForPolicy(policy);
+
+  const runCheck = async (dir: string): Promise<GuardrailJsonPayload> => {
+    const { runGuardrailCheck } = await import('../baseline/check');
+    const { renderJson } = await import('../baseline/check-renderers');
+    // `incremental: true` scopes the current side's semgrep to changed
+    // files (opt 3). Verdict-safe: semgrep is intraprocedural, so a net-new
+    // code finding only appears in a file the diff touched, and the scan
+    // falls back to full whenever the changed set can't be computed.
+    const result = await runGuardrailCheck({
+      trust: trustedLocalContext(),
+      cwd: dir,
+      policy,
+      scope,
+      incremental: true,
+      flowMode,
+      schemaMode,
+      duplicationMode,
+    });
+    const json = renderJson(result);
+    // Persist the full machine-readable verdict so the model (and a human)
+    // can read the exact net-new findings the block message points to.
+    try {
+      const dir2 = path.join(dir, LEDGER_DIR);
+      fs.mkdirSync(dir2, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir2, 'last-guardrail.json'),
+        JSON.stringify(json, null, 2) + '\n',
+        'utf8',
+      );
+    } catch {
+      /* best-effort snapshot */
+    }
+    return json;
+  };
+
+  const decision = await computeStopGate(cwd, payload, runCheck, buildFloorGate);
+  // Stamp the active preset onto the ledger line so the audit trail shows
+  // which posture was in force when the gate allowed/blocked.
+  appendLedgerEvent(repoDir, { ...decision.event, preset });
+
+  // Persist the verdict keyed on the tree signature so the next stop with
+  // an unchanged tree replays it instead of re-gathering. Only the
+  // tree-deterministic outcomes are cached; an operator/preflight failure
+  // is environment-dependent and must be re-tried.
+  if (
+    signature &&
+    envSignature &&
+    (decision.outcome === 'allow' || decision.outcome === 'block-model')
+  ) {
+    writeStateCache(repoDir, {
+      signature,
+      envSignature,
+      outcome: decision.outcome,
+      message: decision.message,
+      netNew: decision.event.net_new_findings,
+      baselineFindings: decision.event.baseline_findings,
+    });
+  }
+
+  if (decision.outcome === 'block-model') {
+    // Exit 0 + decision JSON on stdout → blocks the stop and feeds the
+    // reason to the model so it repairs.
+    process.stdout.write(JSON.stringify({ decision: 'block', reason: decision.message }) + '\n');
+    process.exit(0);
+  }
+  if (decision.outcome === 'block-operator') {
+    // Exit 2 → blocks the stop; stderr reaches the operator (the model
+    // can't fix a preflight problem).
+    process.stderr.write(decision.message + '\n');
+    process.exit(2);
+  }
+  // allow: exit 0 lets the stop proceed. Surface any warning (config
+  // fail-open) on stderr so it isn't a silent skip.
+  if (decision.message) process.stderr.write(decision.message + '\n');
+  process.exit(0);
+}

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -31,31 +31,14 @@
 import type { GuardrailJsonPayload } from '../baseline/check-renderers';
 import { blockingPairs, findingBreakdown, buildRepairMessage } from './repair-message';
 export { buildRepairMessage };
-import {
-  appendLedgerEvent,
-  buildLedgerEvent,
-  LEDGER_DIR,
-  type CheckStatus,
-  type LedgerEvent,
-} from './ledger';
-import * as fs from 'fs';
-import * as path from 'path';
+// The CLI entry (`runStopGate`) lives in `stop-gate-cli.ts` (module-size
+// split; it imports this module's `computeStopGate`, so no re-export here —
+// that would be an import cycle).
+import { buildLedgerEvent, type CheckStatus, type LedgerEvent } from './ledger';
 import { dxkitCli } from '../self-invocation';
-import {
-  loopGateActive,
-  workingTreeSignature,
-  environmentSignature,
-  readStateCache,
-  writeStateCache,
-} from './gate-cache';
-import {
-  buildFloorGate,
-  buildFloorRepairMessage,
-  floorLedgerStatuses,
-  type FloorGateOutcome,
-} from './floor-gate';
-import { readStdinPayload, runConfiguredTests, type StopHookPayload } from './stop-gate-io';
-import { trustedLocalContext } from '../analysis-trust';
+import { buildFloorRepairMessage, floorLedgerStatuses, type FloorGateOutcome } from './floor-gate';
+import { runConfiguredTests, type StopHookPayload } from './stop-gate-io';
+import { buildOrderRepairMessage, readOrderScope, unresolvedOrderIds } from './order-scope';
 
 /** What the gate decided, before any process I/O. */
 export interface StopGateDecision {
@@ -81,6 +64,13 @@ export async function computeStopGate(
     kind: 'unavailable',
     reason: 'floor not wired for this gate run',
   }),
+  // The remediate lane's order scope (section 3C): read from
+  // `.dxkit/loop/order.json` via the ONE order-scope module; injectable so
+  // tests drive the order arm without touching the filesystem. The check
+  // EXECUTES nothing — it post-processes the guardrail payload and floor
+  // outcome already computed above, so a hostile order file can never widen
+  // execution on any tree.
+  readScope: (repoDir: string) => ReturnType<typeof readOrderScope> = readOrderScope,
 ): Promise<StopGateDecision> {
   const start = Date.now();
   const repoDir = payload.cwd || cwd;
@@ -261,6 +251,52 @@ export async function computeStopGate(
           tests_status: 'not_configured' as CheckStatus,
         };
 
+  // The remediate lane's ORDER SCOPE (one-order-per-run dispatch): when the
+  // lane declared the current order's done criterion, "done" is verified
+  // in-session — the stop blocks while any of the order's target findings is
+  // still present, and the block reason hands back exactly the ids left to
+  // close. Judged only from the guardrail payload + floor outcome already
+  // computed above (nothing executes); an absent file keeps every
+  // pre-existing behavior exactly, and a malformed one is a DISCLOSED skip.
+  const orderRead = readScope(repoDir);
+  let orderNote = orderRead.problem ? `dxkit Stop-gate: ${orderRead.problem}` : '';
+  if (orderRead.scope) {
+    const verdict = unresolvedOrderIds(orderRead.scope, json, floor);
+    if (verdict.unresolved.length > 0) {
+      const event = buildLedgerEvent(repoDir, {
+        session_id: session,
+        ...agentFields,
+        cwd: repoDir,
+        branch: json.current.branch,
+        commit: json.current.commitSha,
+        guardrail_status: 'pass',
+        net_new_findings: 0,
+        ...breakdown,
+        baseline_findings: json.baseline.findingsCount,
+        files_changed: 0,
+        allowed: false,
+        stop_hook_active: stopActive,
+        tests_status: 'skipped',
+        lint_status: 'not_configured',
+        typecheck_status: floorStatuses.typecheck_status,
+        ...floorDisclosure,
+        duration_ms: Date.now() - start,
+      });
+      return {
+        outcome: 'block-model',
+        event,
+        message: buildOrderRepairMessage(orderRead.scope, verdict.unresolved),
+      };
+    }
+    if (verdict.undecidable) {
+      // Fail-open, disclosed: the gate cannot answer the order's done
+      // question here — the frame's post-run tree verification arbitrates.
+      orderNote =
+        `dxkit Stop-gate: could not verify work order ${orderRead.scope.orderId} in-session ` +
+        `(${verdict.undecidable}); the frame's post-run verification decides.`;
+    }
+  }
+
   // Guardrail + floor passed — run the optional configured test command.
   const tests = runConfiguredTests(repoDir);
   if (tests.status === 'fail') {
@@ -314,163 +350,8 @@ export async function computeStopGate(
     ...floorDisclosure,
     duration_ms: Date.now() - start,
   });
-  return { outcome: 'allow', event, message: '' };
-}
-
-/**
- * CLI entry for `vyuh-dxkit hook stop-gate`. Reads the hook payload from
- * stdin, runs the guardrail in-process, writes the ledger + last-guardrail
- * snapshot, then emits the Stop-hook decision and exits.
- */
-export async function runStopGate(cwd: string): Promise<void> {
-  const payload = readStdinPayload();
-  const repoDir = payload.cwd || cwd;
-
-  // ── Loop-scoped activation. The Stop-gate is for UNATTENDED loops, where
-  // no human is reviewing each stop. An interactive turn — a person present,
-  // the agent stopping to ask a question — must not pay the guardrail cost.
-  // So the hook is an instant no-op allow unless the loop marks itself
-  // active (DXKIT_LOOP_ACTIVE=1, or a `.dxkit/loop/active` sentinel the loop
-  // runner drops). The CI guardrail still gates the branch either way.
-  if (!loopGateActive(repoDir, payload)) {
-    process.exit(0);
-  }
-
-  // Resolve the loop-scoped posture ONCE (preset → policy). This is the
-  // only place the loop preset is read; the CI guardrail never sees it.
-  const { resolveLoopPolicy } = await import('./policy');
-  const { policy, preset, flowMode, schemaMode, duplicationMode } = resolveLoopPolicy(repoDir);
-
-  // ── Fast path: replay the last verdict when the working tree is
-  // byte-identical to what was last gathered (a no-change stop — an
-  // interactive Q&A turn, or a re-stop after a block with no edit). Skips
-  // the full guardrail gather + tests entirely. Safe by construction: the
-  // signature captures every file the gather would see, so a cache hit is
-  // only ever a genuinely-identical tree and the cache can never skip a
-  // real net-new finding. Bypass with DXKIT_LOOP_NO_CACHE=1.
-  const signature = process.env.DXKIT_LOOP_NO_CACHE === '1' ? null : workingTreeSignature(repoDir);
-  // The environment half of the cache key (T1.3): same tree + DIFFERENT
-  // observer (dxkit / policy / test command / scanner binaries) must MISS,
-  // or a scanner upgrade between sessions replays a stale ALLOW.
-  const envSignature = signature
-    ? environmentSignature(repoDir, {
-        preset,
-        policy,
-        modes: { flowMode, schemaMode, duplicationMode },
-      })
-    : null;
-  const agentFields = {
-    ...(payload.agent_id ? { agent_id: payload.agent_id } : {}),
-    ...(payload.agent_type ? { agent_type: payload.agent_type } : {}),
-  };
-  if (signature && envSignature) {
-    const cached = readStateCache(repoDir);
-    if (cached && cached.signature === signature && cached.envSignature === envSignature) {
-      const event = buildLedgerEvent(repoDir, {
-        session_id: payload.session_id || '',
-        ...agentFields,
-        cwd: repoDir,
-        guardrail_status: cached.outcome === 'allow' ? 'pass' : 'fail',
-        net_new_findings: cached.netNew,
-        baseline_findings: cached.baselineFindings,
-        files_changed: 0,
-        allowed: cached.outcome === 'allow',
-        stop_hook_active: !!payload.stop_hook_active,
-        tests_status: 'skipped',
-        lint_status: 'not_configured',
-        typecheck_status: 'not_configured',
-        duration_ms: 0,
-        cached: true,
-      });
-      appendLedgerEvent(repoDir, { ...event, preset });
-      if (cached.outcome === 'block-model') {
-        process.stdout.write(JSON.stringify({ decision: 'block', reason: cached.message }) + '\n');
-        process.exit(0);
-      }
-      process.exit(0); // allow — clean stop replayed from cache
-    }
-  }
-
-  // Scope the gather to the analyzers this posture can actually block on.
-  // A `security-only` loop skips jscpd / lint / coverage / cloc / test-gaps /
-  // graphify — they feed only kinds the policy can't act on, so skipping them
-  // cannot change the verdict (see src/baseline/gather-scope.ts). Both sides
-  // of the diff are scoped identically. `full-debt` derives FULL_SCOPE.
-  const { scopeForPolicy } = await import('../baseline/gather-scope');
-  const scope = scopeForPolicy(policy);
-
-  const runCheck = async (dir: string): Promise<GuardrailJsonPayload> => {
-    const { runGuardrailCheck } = await import('../baseline/check');
-    const { renderJson } = await import('../baseline/check-renderers');
-    // `incremental: true` scopes the current side's semgrep to changed
-    // files (opt 3). Verdict-safe: semgrep is intraprocedural, so a net-new
-    // code finding only appears in a file the diff touched, and the scan
-    // falls back to full whenever the changed set can't be computed.
-    const result = await runGuardrailCheck({
-      trust: trustedLocalContext(),
-      cwd: dir,
-      policy,
-      scope,
-      incremental: true,
-      flowMode,
-      schemaMode,
-      duplicationMode,
-    });
-    const json = renderJson(result);
-    // Persist the full machine-readable verdict so the model (and a human)
-    // can read the exact net-new findings the block message points to.
-    try {
-      const dir2 = path.join(dir, LEDGER_DIR);
-      fs.mkdirSync(dir2, { recursive: true });
-      fs.writeFileSync(
-        path.join(dir2, 'last-guardrail.json'),
-        JSON.stringify(json, null, 2) + '\n',
-        'utf8',
-      );
-    } catch {
-      /* best-effort snapshot */
-    }
-    return json;
-  };
-
-  const decision = await computeStopGate(cwd, payload, runCheck, buildFloorGate);
-  // Stamp the active preset onto the ledger line so the audit trail shows
-  // which posture was in force when the gate allowed/blocked.
-  appendLedgerEvent(repoDir, { ...decision.event, preset });
-
-  // Persist the verdict keyed on the tree signature so the next stop with
-  // an unchanged tree replays it instead of re-gathering. Only the
-  // tree-deterministic outcomes are cached; an operator/preflight failure
-  // is environment-dependent and must be re-tried.
-  if (
-    signature &&
-    envSignature &&
-    (decision.outcome === 'allow' || decision.outcome === 'block-model')
-  ) {
-    writeStateCache(repoDir, {
-      signature,
-      envSignature,
-      outcome: decision.outcome,
-      message: decision.message,
-      netNew: decision.event.net_new_findings,
-      baselineFindings: decision.event.baseline_findings,
-    });
-  }
-
-  if (decision.outcome === 'block-model') {
-    // Exit 0 + decision JSON on stdout → blocks the stop and feeds the
-    // reason to the model so it repairs.
-    process.stdout.write(JSON.stringify({ decision: 'block', reason: decision.message }) + '\n');
-    process.exit(0);
-  }
-  if (decision.outcome === 'block-operator') {
-    // Exit 2 → blocks the stop; stderr reaches the operator (the model
-    // can't fix a preflight problem).
-    process.stderr.write(decision.message + '\n');
-    process.exit(2);
-  }
-  // allow: exit 0 lets the stop proceed. Surface any warning (config
-  // fail-open) on stderr so it isn't a silent skip.
-  if (decision.message) process.stderr.write(decision.message + '\n');
-  process.exit(0);
+  // An allow's message reaches the operator on stderr — a disclosed
+  // order-scope skip (malformed file, undecidable verifier) rides it so
+  // the skip is never silent.
+  return { outcome: 'allow', event, message: orderNote };
 }

--- a/src/loop/stop-gate.ts
+++ b/src/loop/stop-gate.ts
@@ -294,6 +294,10 @@ export async function computeStopGate(
       orderNote =
         `dxkit Stop-gate: could not verify work order ${orderRead.scope.orderId} in-session ` +
         `(${verdict.undecidable}); the frame's post-run verification decides.`;
+    } else if (verdict.disclosure) {
+      // Done with a fact worth seeing (sibling findings keep the shared
+      // check red) — rides the allow's stderr, never a block.
+      orderNote = `dxkit Stop-gate: ${verdict.disclosure}`;
     }
   }
 

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -184,6 +184,40 @@ export function provisionArgv(pm: PackageManager): [string, ...string[]] {
   }
 }
 
+/**
+ * Command prefixes ("<bin> <verb>", plus the bare-verb aliases each manager
+ * accepts) that install or mutate dependencies, across every package manager
+ * dxkit knows. Derived from the canonical command builders above wherever a
+ * builder exists (provision, add-dev, upgrade), with the short aliases each
+ * ecosystem documents declared HERE, in the one module that owns package
+ * manager vocabulary, never in a consumer.
+ *
+ * Consumers: the remediate order runs forbid agent-run installs (installs are
+ * a frame/recipe step so the lockfile is always re-synced and pre-checked),
+ * and render these prefixes into the driver's tool-deny patterns.
+ */
+export function installCommandPrefixes(): readonly string[] {
+  const prefixes = new Set<string>();
+  const aliases: Record<PackageManager, readonly string[]> = {
+    // `i` is the documented install alias for these three; yarn has none
+    // (bare `yarn` installs, which no prefix pattern can single out).
+    npm: ['npm i'],
+    pnpm: ['pnpm i'],
+    bun: ['bun i'],
+    yarn: [],
+  };
+  for (const pm of Object.keys(LOCKFILES) as PackageManager[]) {
+    const [provisionBin, provisionVerb] = provisionArgv(pm);
+    prefixes.add(`${provisionBin} ${provisionVerb}`);
+    const [addBin, addVerb] = addDevPrefix(pm).split(' ');
+    prefixes.add(`${addBin} ${addVerb}`);
+    const [upgradeBin, upgradeVerb] = upgradeArgv(pm, 'pkg', '0.0.0', 'dependencies');
+    prefixes.add(`${upgradeBin} ${upgradeVerb}`);
+    for (const alias of aliases[pm]) prefixes.add(alias);
+  }
+  return [...prefixes].sort();
+}
+
 // ---------------------------------------------------------------------------
 // Frozen-lockfile install + lockfile-sync check: the ONE definition CI and the
 // lane's verification share (4.4.5). Before this, every workflow template

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -198,13 +198,14 @@ export function provisionArgv(pm: PackageManager): [string, ...string[]] {
  */
 export function installCommandPrefixes(): readonly string[] {
   const prefixes = new Set<string>();
+  // Documented aliases and the other dependency-mutating verbs (update /
+  // remove families) the canonical builders never emit. yarn has no bare
+  // install alias (plain `yarn` installs, which no prefix can single out).
   const aliases: Record<PackageManager, readonly string[]> = {
-    // `i` is the documented install alias for these three; yarn has none
-    // (bare `yarn` installs, which no prefix pattern can single out).
-    npm: ['npm i'],
-    pnpm: ['pnpm i'],
-    bun: ['bun i'],
-    yarn: [],
+    npm: ['npm i', 'npm add', 'npm update', 'npm up', 'npm uninstall', 'npm remove', 'npm rm'],
+    pnpm: ['pnpm i', 'pnpm update', 'pnpm up', 'pnpm remove', 'pnpm rm', 'pnpm uninstall'],
+    bun: ['bun i', 'bun update', 'bun remove', 'bun rm'],
+    yarn: ['yarn up', 'yarn upgrade', 'yarn remove'],
   };
   for (const pm of Object.keys(LOCKFILES) as PackageManager[]) {
     const [provisionBin, provisionVerb] = provisionArgv(pm);

--- a/src/remediate/claude-code-driver.ts
+++ b/src/remediate/claude-code-driver.ts
@@ -194,6 +194,19 @@ export function makeClaudeCodeDriver(exec: AgentExec = realAgentExec): AgentDriv
     // The pinned executor the managed workflow installs. Bump deliberately
     // (one line, one place) — never float `latest` under an unattended lane.
     cli: { package: '@anthropic-ai/claude-code', version: '2.1.222' },
+    // Tool narrowing: `--disallowedTools` deny rules, which the pinned CLI
+    // honors even under `--dangerously-skip-permissions` (deny rules take
+    // precedence over the permission mode). `--permission-mode` plus an
+    // explicit allowlist is deliberately NOT used for headless runs: a tool
+    // outside the allowlist prompts, and a non-interactive prompt is a
+    // denial that dead-ends the run mid-task — so the deny-list is the
+    // mechanism, and the caller discloses it as such.
+    toolPolicy: {
+      mechanism: 'disallowed-tools',
+      cliRequirement:
+        '--disallowedTools / --allowedTools require @anthropic-ai/claude-code >= 1.0 ' +
+        '(pinned: 2.1.222); deny rules apply even under --dangerously-skip-permissions',
+    },
 
     resolveModel(tier: ModelTier): string {
       return TIER_ALIAS[tier];
@@ -242,12 +255,21 @@ export function makeClaudeCodeDriver(exec: AgentExec = realAgentExec): AgentDriv
       });
       const cliVersion = versionProbe.stdout.match(/(\d+\.\d+\.\d+)/)?.[1];
 
+      // Tool narrowing (order-driven runs): each pattern is its own argv
+      // entry after the variadic flag — never a shell-joined string. The
+      // deny rules hold under --dangerously-skip-permissions (see the
+      // toolPolicy declaration above for the pinned-CLI requirement).
+      const toolArgs = [
+        ...(opts.tools?.disallowed?.length ? ['--disallowedTools', ...opts.tools.disallowed] : []),
+        ...(opts.tools?.allowed?.length ? ['--allowedTools', ...opts.tools.allowed] : []),
+      ];
       const outcome = exec(
         'claude',
         [
           '-p',
           opts.prompt,
           '--dangerously-skip-permissions',
+          ...toolArgs,
           '--max-turns',
           String(opts.budget.maxTurns),
           '--output-format',

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -30,6 +30,9 @@ export const DEFAULT_REMEDIATE_BUDGET: RemediateBudget = {
   maxUsd: 5,
 };
 
+/** Default `remediate.maxOrdersPerRun`. */
+export const DEFAULT_MAX_ORDERS_PER_RUN = 3;
+
 export interface RemediateConfig {
   readonly enabled: boolean;
   readonly tasks: readonly RemediateTaskId[];
@@ -74,6 +77,12 @@ export interface RemediateConfig {
    *  partial can never grandfather its own breakage. Hard cap of
    *  MAX_RESUME_ATTEMPTS per branch (resume.ts). */
   readonly resume: boolean;
+  /** Most agent-tier work orders one run dispatches, ONE ORDER PER AGENT
+   *  RUN, highest value first (`remediate.maxOrdersPerRun`, default 3;
+   *  0 turns order-driven dispatch off and restores the single open-ended
+   *  task prompt). Orders beyond the cap are disclosed, never silently
+   *  dropped. */
+  readonly maxOrdersPerRun: number;
   /** Work-order planning knobs (`remediate.workOrders`). */
   readonly workOrders: {
     /** Largest number of findings one debt slice may carry
@@ -218,6 +227,15 @@ export function resolveRemediateConfig(cwd: string): RemediateConfig {
         ? raw.maxDispatchBudget
         : 0,
     resume: raw.resume === true,
+    // 0 is a meaningful value (order dispatch off), so this is NOT
+    // positiveNumber: any non-negative integer stands, anything else
+    // falls back to the default.
+    maxOrdersPerRun:
+      typeof raw.maxOrdersPerRun === 'number' &&
+      Number.isInteger(raw.maxOrdersPerRun) &&
+      raw.maxOrdersPerRun >= 0
+        ? raw.maxOrdersPerRun
+        : DEFAULT_MAX_ORDERS_PER_RUN,
     workOrders: {
       maxSliceSize: positiveNumber(
         ((raw.workOrders ?? {}) as Record<string, unknown>).maxSliceSize,

--- a/src/remediate/driver.ts
+++ b/src/remediate/driver.ts
@@ -38,6 +38,16 @@ export interface AgentRunOptions {
   readonly model: string;
   /** Credentials + task env injected HERE only — never argv, never logged. */
   readonly env: Readonly<Record<string, string>>;
+  /**
+   * Tool narrowing for this run (order-driven runs): permission-rule
+   * patterns the driver renders through its declared `toolPolicy` mechanism.
+   * A driver with no `toolPolicy` declaration ignores this — the CALLER must
+   * disclose that the policy could not be applied (never a silent drop).
+   */
+  readonly tools?: {
+    readonly allowed?: readonly string[];
+    readonly disallowed?: readonly string[];
+  };
 }
 
 export interface AgentRunResult {
@@ -135,6 +145,19 @@ export interface AgentDriver {
    * every run is honestly disclosed `backstop-only`.
    */
   readonly inLoopGateMechanism?: 'claude-stop-hook';
+  /**
+   * The driver's tool-narrowing mechanism, when it has one: how
+   * `AgentRunOptions.tools` reaches the agent CLI, with the CLI requirement
+   * documented against the pinned version. Absent = the driver cannot narrow
+   * tools — a stated fact the runner DISCLOSES (the envelope then says the
+   * tool policy could not be applied and the envelope sweep is the
+   * enforcement), never an omission.
+   */
+  readonly toolPolicy?: {
+    readonly mechanism: 'disallowed-tools';
+    /** The CLI capability this depends on, stated against the pinned CLI. */
+    readonly cliRequirement: string;
+  };
   available(cwd: string): { readonly ok: true } | { readonly ok: false; readonly reason: string };
   run(opts: AgentRunOptions): Promise<AgentRunResult>;
 }

--- a/src/remediate/execute.ts
+++ b/src/remediate/execute.ts
@@ -212,6 +212,11 @@ export async function executeTask(
             },
           }
         : {}),
+      // A guardrail-red draft is never a resume anchor (design F): its
+      // blocking set rides the order prompts as a negative constraint.
+      ...(!resume.resumed && resume.blockingContext
+        ? { priorBlocking: resume.blockingContext }
+        : {}),
     });
   } finally {
     reporter.stop();
@@ -437,6 +442,7 @@ export function taskRunJson(run: TaskRun): Record<string, unknown> {
     note: r.note ?? null,
     partial: r.partial ?? false,
     envelope: r.envelope ?? null,
+    orders: r.orders ?? null,
     guardrailVerdict: r.guardrailVerdict ?? null,
     branch: r.task ? remediateBranchFor(r.task) : null,
     prUrl: run.prUrl ?? null,

--- a/src/remediate/git-ops.ts
+++ b/src/remediate/git-ops.ts
@@ -85,5 +85,45 @@ export function realGit(cwd: string): RemediateGit {
     // changes nothing — reporting it as a diff would verify and land
     // nothing-shaped work.
     hasDiff: (baseHead: string) => git(['diff', '--name-only', baseHead, 'HEAD']) !== '',
+    enforceEnvelope(baseHead, isAllowed) {
+      // The envelope's enforcement half (the order prompt is advisory):
+      // every committed change outside the allowed set is reverted to its
+      // base state — a base-tracked file back to base content, a new file
+      // removed — in ONE disclosure commit, same doctrine as the
+      // runtime-artifact scrub. Runs after the leftover sweep, so the tree
+      // is clean and only commits are in play. Fail-CLOSED: an enforcement
+      // error is returned and the caller must not land the unenforced diff.
+      try {
+        const changed = git(['diff', '--name-only', baseHead, 'HEAD']).split('\n').filter(Boolean);
+        const outside = changed.filter((f) => !isAllowed(f));
+        if (outside.length === 0) return { dropped: [] };
+        const baseTracked = new Set(
+          git(['ls-tree', '-r', '--name-only', baseHead]).split('\n').filter(Boolean),
+        );
+        for (const f of outside) {
+          if (baseTracked.has(f)) {
+            git(['checkout', baseHead, '--', f]);
+          } else {
+            git(['rm', '-f', '-q', '--ignore-unmatch', '--', f]);
+          }
+        }
+        git([
+          '-c',
+          `user.name=${BOT_IDENTITY.name}`,
+          '-c',
+          `user.email=${BOT_IDENTITY.email}`,
+          'commit',
+          '-q',
+          '--allow-empty',
+          '-m',
+          'chore: drop out-of-envelope changes (enforced by the runner, disclosed in the ledger)',
+        ]);
+        return { dropped: outside };
+      } catch (e) {
+        const lines =
+          e instanceof Error ? e.message.split('\n').filter((l) => l.trim()) : [String(e)];
+        return { dropped: [], error: lines[lines.length - 1] ?? String(e) };
+      }
+    },
   };
 }

--- a/src/remediate/git-ops.ts
+++ b/src/remediate/git-ops.ts
@@ -94,7 +94,14 @@ export function realGit(cwd: string): RemediateGit {
       // is clean and only commits are in play. Fail-CLOSED: an enforcement
       // error is returned and the caller must not land the unenforced diff.
       try {
-        const changed = git(['diff', '--name-only', baseHead, 'HEAD']).split('\n').filter(Boolean);
+        // --no-renames: a rename must surface BOTH sides (the old path as a
+        // deletion, the new as an addition). Under rename detection the diff
+        // lists only the post-image, so enforcing an out-of-envelope
+        // `git mv` would DELETE the base file (the restore below never saw
+        // its old path) and land that destructive change undisclosed.
+        const changed = git(['diff', '--no-renames', '--name-only', baseHead, 'HEAD'])
+          .split('\n')
+          .filter(Boolean);
         const outside = changed.filter((f) => !isAllowed(f));
         if (outside.length === 0) return { dropped: [] };
         const baseTracked = new Set(

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -16,7 +16,16 @@ import type { OrdersPhaseSummary, RemediateResult } from './outcome';
 function renderRecipeSection(recipes: RecipePhaseSummary): string[] {
   const lines: string[] = ['### Deterministic recipes', ''];
   if (recipes.disabled) {
-    lines.push('Recipes are disabled by policy (`remediate.recipes.enabled: false`).', '');
+    lines.push('Recipes are disabled by policy (`remediate.recipes.enabled: false`).');
+    if (recipes.planError) {
+      // Disabled AND broken planning: both facts render — the disabled note
+      // must not hide why no order queue exists for the agent tier.
+      lines.push(
+        `Work-order planning failed (${recipes.planError}); no orders were queued for the ` +
+          'agent tier.',
+      );
+    }
+    lines.push('');
     return lines;
   }
   if (recipes.planError) {
@@ -88,15 +97,20 @@ function renderOrdersSection(orders: OrdersPhaseSummary): string[] {
       );
       lines.push(
         rec.droppedPaths && rec.droppedPaths.length > 0
-          ? `  - envelope enforcement DROPPED out-of-envelope change(s), disclosed: ` +
+          ? `  - envelope enforcement DROPPED out-of-envelope or manifest-excluded ` +
+              `change(s), disclosed: ` +
               rec.droppedPaths.join(', ')
           : '  - envelope enforcement: every change stayed inside the order envelope',
       );
       lines.push(
         rec.doneAfterVerify
           ? `  - done (${rec.done.verifier} verifier, ${rec.done.absentIds} target id(s)): ` +
-              `${rec.doneAfterVerify.closed} closed, ${rec.doneAfterVerify.open} still open ` +
-              `per the verified floor`
+              `${rec.doneAfterVerify.closed} closed, ${rec.doneAfterVerify.open} still open` +
+              (rec.doneAfterVerify.undecided > 0
+                ? `, ${rec.doneAfterVerify.undecided} undecided (the producing check was ` +
+                  `not observed by the verification — not claimed closed)`
+                : '') +
+              ` per the verified floor`
           : `  - done (${rec.done.verifier} verifier, ${rec.done.absentIds} target id(s)): ` +
               `closure is arbitrated by the verification below and the next plan`,
       );

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -8,7 +8,7 @@ import { renderFloorVerification, renderGuardrailVerdict } from '../lanes/verifi
 import { describeInstall } from '../lanes/verify-tree';
 import { renderScoreHinge } from './score-hinge';
 import { recipeCounts, type RecipePhaseSummary } from './recipes/run-recipes';
-import type { RemediateResult } from './run';
+import type { OrdersPhaseSummary, RemediateResult } from './outcome';
 
 /** The deterministic-recipe section: one line per order (applied / refused /
  *  failed with the reason), the tier split, and every disclosure: a $0
@@ -54,6 +54,54 @@ function renderRecipeSection(recipes: RecipePhaseSummary): string[] {
     }
   }
   for (const d of recipes.disclosures) lines.push(`- plan disclosure: ${d}`);
+  lines.push('');
+  return lines;
+}
+
+/** The order-driven agent section: one entry per order — derived budget
+ *  (with its derivation) vs spend, envelope enforcement outcomes, and the
+ *  done disclosure. The reviewer sees exactly what each dispatch was scoped
+ *  to and what the runner dropped. */
+function renderOrdersSection(orders: OrdersPhaseSummary): string[] {
+  const lines: string[] = ['### Work-order dispatches (one order per agent run)', ''];
+  lines.push(
+    `Queued ${orders.queued} agent-tier order(s); per-run cap ${orders.cap} ` +
+      `(\`remediate.maxOrdersPerRun\`).`,
+  );
+  if (orders.priorBlockingApplied) {
+    lines.push(
+      'A prior BLOCKED attempt was not resumed; its blocking findings rode every order ' +
+        'prompt as a negative constraint.',
+    );
+  }
+  for (const rec of orders.records) {
+    lines.push('');
+    lines.push(`- \`${rec.orderId}\` (${rec.class}, ${rec.findings} finding(s)): ${rec.outcome}`);
+    if (rec.detail) lines.push(`  - ${rec.detail}`);
+    if (rec.outcome !== 'not-dispatched') {
+      lines.push(`  - budget (derived, became the driver budget): ${rec.budget.derivation}`);
+      if (rec.clamped) lines.push(`  - ${rec.clamped}`);
+      const spent = rec.spent;
+      lines.push(
+        `  - spent: ${spent?.costUsd !== undefined ? `$${spent.costUsd.toFixed(2)}` : 'cost not reported'} over ` +
+          `${spent?.turns !== undefined ? `${spent.turns} turns` : 'an unreported turn count'}`,
+      );
+      lines.push(
+        rec.droppedPaths && rec.droppedPaths.length > 0
+          ? `  - envelope enforcement DROPPED out-of-envelope change(s), disclosed: ` +
+              rec.droppedPaths.join(', ')
+          : '  - envelope enforcement: every change stayed inside the order envelope',
+      );
+      lines.push(
+        rec.doneAfterVerify
+          ? `  - done (${rec.done.verifier} verifier, ${rec.done.absentIds} target id(s)): ` +
+              `${rec.doneAfterVerify.closed} closed, ${rec.doneAfterVerify.open} still open ` +
+              `per the verified floor`
+          : `  - done (${rec.done.verifier} verifier, ${rec.done.absentIds} target id(s)): ` +
+              `closure is arbitrated by the verification below and the next plan`,
+      );
+    }
+  }
   lines.push('');
   return lines;
 }
@@ -113,6 +161,16 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
         ? `- in-loop gate: ARMED — ${e.inLoopGate.reason}`
         : `- in-loop gate: BACKSTOP-ONLY — ${e.inLoopGate.reason}`,
     );
+    // The tool policy applied to order-driven runs — how the driver
+    // narrowed tools, or the disclosed fact that it could not.
+    if (e.toolPolicy) {
+      lines.push(
+        e.toolPolicy.mechanism === 'disallowed-tools'
+          ? `- tool policy: disallowed-tools — denied: ${e.toolPolicy.disallowed.join(', ')} ` +
+              `(${e.toolPolicy.cliRequirement})`
+          : `- tool policy: NOT applied — ${e.toolPolicy.reason}`,
+      );
+    }
     if (e.failure) lines.push(`- driver-reported failure: ${e.failure}`);
     if (e.turns !== undefined && e.turns > e.budget.maxTurns) {
       // The 81-vs-80 confusion: the driver's reported count can exceed the
@@ -166,6 +224,10 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
 
   if (r.recipes && (r.recipes.ran || r.recipes.disabled || r.recipes.planError)) {
     lines.push(...renderRecipeSection(r.recipes));
+  }
+
+  if (r.orders) {
+    lines.push(...renderOrdersSection(r.orders));
   }
 
   lines.push('### Verification', '');

--- a/src/remediate/orders-complete.ts
+++ b/src/remediate/orders-complete.ts
@@ -1,0 +1,218 @@
+/**
+ * Completion of an order-driven agent run — the post-dispatch half of the
+ * orders phase, split from `orders-phase.ts` at the module-size bar
+ * (the recipe tier's `complete.ts` precedent): the no-diff outcome arms
+ * (dead CLI, all-failed, the recipes-refused starvation guard, the honest
+ * no-op), the ONE tree verification of the combined head, the per-order
+ * done disclosure through `floorOrderDone` (the same computation the
+ * Stop-gate's floor arm reads, Rule 2.30), and the verdict mapping shared
+ * with the legacy tail via the `verify.ts` phrasing helpers.
+ */
+import { floorOrderDone } from '../loop/order-scope';
+import type {
+  AgentEnvelope,
+  OrderRunRecord,
+  OrdersPhaseSummary,
+  RemediateResult,
+  RemediateRunOptions,
+} from './outcome';
+import type { OrdersPhaseArgs } from './orders-phase';
+import {
+  guardrailRedNote,
+  installFailedNote,
+  verificationDisclosures,
+  verifyCommittedHead,
+} from './verify';
+import type { WorkOrder } from './work-orders/types';
+
+type Partial_ = Omit<RemediateResult, 'ledger' | 'dispatch' | 'resume'>;
+
+/** What the dispatch loop accumulated — everything the completion needs. */
+export interface OrdersRunState {
+  readonly summary: OrdersPhaseSummary;
+  readonly envelope: AgentEnvelope;
+  readonly records: readonly OrderRunRecord[];
+  readonly dispatchList: readonly WorkOrder[];
+  readonly scrubbed: readonly string[];
+  readonly lastTail: string;
+  readonly partial: boolean;
+  readonly anyCompleted: boolean;
+}
+
+export async function completeOrdersRun(
+  opts: RemediateRunOptions,
+  args: OrdersPhaseArgs,
+  state: OrdersRunState,
+): Promise<Partial_> {
+  const { summary, envelope, records, dispatchList, scrubbed, lastTail, partial, anyCompleted } =
+    state;
+  const evidenceTail = lastTail ? { transcriptTail: lastTail } : {};
+  const hasDiff = args.git.hasDiff(args.baseHead);
+  const hasRecipeCommits = args.agentBase !== args.baseHead;
+  if (!hasDiff) {
+    const neverRanOnly =
+      records.length > 0 &&
+      records.every((r) => r.outcome === 'never-ran' || r.outcome === 'not-dispatched');
+    if (neverRanOnly) {
+      return {
+        outcome: 'agent-never-ran',
+        task: args.taskId,
+        recipes: args.recipes,
+        orders: summary,
+        envelope,
+        floor: args.entryFloor,
+        ...evidenceTail,
+        note: `agent never ran: ${records.find((r) => r.outcome === 'never-ran')?.detail ?? 'see the order records'}`,
+      };
+    }
+    if (!anyCompleted && !partial) {
+      return {
+        outcome: 'agent-failed',
+        task: args.taskId,
+        recipes: args.recipes,
+        orders: summary,
+        envelope,
+        floor: args.entryFloor,
+        ...evidenceTail,
+        note:
+          'every dispatched order ended in an error and produced no committed change. ' +
+          'Nothing to verify; nothing lands' +
+          (hasRecipeCommits
+            ? ' (the recipe commits stay on the branch, unlanded, for the next attempt)'
+            : '') +
+          '.',
+        baseHead: args.baseHead,
+        head: args.git.head(),
+      };
+    }
+    if (!hasRecipeCommits) {
+      // Starvation guard (the recipes-refused contract): when the queue
+      // carried recipe orders the recipe tier already refused or failed,
+      // a no-diff agent fallback must NOT read as a clean no-op — the
+      // orders are still open, and a green outcome would let the
+      // scheduled lane loop over them forever.
+      const fallbackIds = args.queue.filter((o) => o.tier === 'recipe').map((o) => o.id);
+      if (fallbackIds.length > 0) {
+        return {
+          outcome: 'recipes-refused',
+          task: args.taskId,
+          recipes: args.recipes,
+          orders: summary,
+          envelope,
+          floor: args.entryFloor,
+          ...evidenceTail,
+          ...(partial ? { partial } : {}),
+          note:
+            `the recipe tier refused or failed these orders and the agent fallback landed ` +
+            `nothing for them: ${fallbackIds.join(', ')}. The orders remain open — this run ` +
+            'is not clean, so the scheduled lane surfaces it instead of looping green.',
+          baseHead: args.baseHead,
+          head: args.git.head(),
+        };
+      }
+      return {
+        outcome: 'no-op',
+        task: args.taskId,
+        recipes: args.recipes,
+        orders: summary,
+        envelope,
+        floor: args.entryFloor,
+        ...evidenceTail,
+        ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
+        ...(partial ? { partial } : {}),
+        note:
+          scrubbed.length > 0
+            ? 'the dispatched orders produced no committed change beyond regenerable dxkit ' +
+              'scan state (dropped, disclosed below).'
+            : 'the dispatched orders produced no committed change.',
+        baseHead: args.baseHead,
+        head: args.git.head(),
+      };
+    }
+  }
+
+  const head = args.git.head();
+  const { verified, guardrail } = await verifyCommittedHead(opts, {
+    head,
+    baseHead: args.baseHead,
+    entryFloor: args.entryFloor,
+    runFloor: args.runFloor,
+  });
+
+  // Per-order done, judged from the FINAL verified floor for floor-verifier
+  // orders through the ONE `floorOrderDone` computation (the Stop-gate's
+  // floor arm reads the same function, so the two cannot drift). Honest in
+  // both directions: a check the verification did not observe (skipped,
+  // absent, or a floor that did not run at all) yields UNDECIDED, never a
+  // claimed closure; a guardrail-verifier order's closure is arbitrated by
+  // the guardrail verdict below and the next plan — the ledger says so.
+  const verifiedChecks = verified.floor?.checks;
+  const byId = new Map(dispatchList.map((o) => [o.id, o] as const));
+  const withDone = records.map((r) => {
+    const order = byId.get(r.orderId);
+    if (
+      !order ||
+      order.done.verifier !== 'floor' ||
+      r.outcome === 'not-dispatched' ||
+      verifiedChecks === undefined
+    ) {
+      return r;
+    }
+    const done = floorOrderDone(order.done.absentIds, verifiedChecks);
+    return {
+      ...r,
+      doneAfterVerify: {
+        closed: order.done.absentIds.length - done.open.length - done.undecided.length,
+        open: done.open.length,
+        undecided: done.undecided.length,
+      },
+    };
+  });
+  const finalSummary: OrdersPhaseSummary = { ...summary, records: withDone };
+
+  const common = {
+    task: args.taskId,
+    recipes: args.recipes,
+    orders: finalSummary,
+    envelope,
+    ...verificationDisclosures(verified, guardrail),
+    baseHead: args.baseHead,
+    head,
+    ...evidenceTail,
+    ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
+    ...(partial ? { partial } : {}),
+  };
+
+  if (verified.verdict === 'install-failed') {
+    return { outcome: 'install-failed', ...common, note: installFailedNote(verified) };
+  }
+  if (verified.verdict === 'floor-red') {
+    return {
+      outcome: 'floor-red',
+      ...common,
+      note:
+        'the correctness floor has NET-NEW failures after the order dispatches (the entry ' +
+        'floor did not have them) — nothing lands. An agent that breaks the build gets a ' +
+        'truthful failure, never a PR.',
+    };
+  }
+  if (!guardrail.ran || !guardrail.passesGate) {
+    return {
+      outcome: 'guardrail-red',
+      ...common,
+      note: guardrailRedNote(guardrail, args.effectiveSalvage),
+    };
+  }
+  if (partial) {
+    const salvage =
+      args.effectiveSalvage === 'draft-pr'
+        ? 'salvage policy: draft-pr — the verified partial work may land as a DRAFT.'
+        : 'salvage policy: discard — the partial work is not landed (branch left for inspection).';
+    return {
+      outcome: 'budget-exhausted',
+      ...common,
+      note: `a budget cap cut the order dispatches short — the diff is verified. ${salvage}`,
+    };
+  }
+  return { outcome: 'verified', ...common };
+}

--- a/src/remediate/orders-phase.ts
+++ b/src/remediate/orders-phase.ts
@@ -1,0 +1,481 @@
+/**
+ * The order-driven agent phase (remediate rethink, section 3C): the agent
+ * tier stops receiving open-ended task prompts. Each remaining agent-tier
+ * order — including every recipe order the recipe tier refused or failed,
+ * which falls through to here instead of dead-ending the run — is dispatched
+ * ONE ORDER PER AGENT RUN, highest value first, up to
+ * `remediate.maxOrdersPerRun`. Per dispatch:
+ *
+ *   1. the prompt is the rendered work order (findings + evidence +
+ *      attribution split + envelope + constraints + done command;
+ *      `renderWorkOrderPrompt` already appends the shared ground rules),
+ *      plus the runner's budget note — and, when a prior attempt was
+ *      guardrail-BLOCKED, its blocking set as a negative constraint;
+ *   2. the driver budget IS the order's planner-derived budget (disclosed
+ *      with its derivation), clamped to the run's remaining budget;
+ *   3. the order's done criterion is written to `.dxkit/loop/order.json`
+ *      (the ONE order-scope module the Stop-gate reads) before the spawn
+ *      and cleared after, so "done" is verified in-session;
+ *   4. tools are narrowed through the driver's declared mechanism (package
+ *      manager installs are the frame's job), disclosed either way;
+ *   5. after the run: leftover sweep, runtime-artifact scrub, then ENVELOPE
+ *      ENFORCEMENT — committed changes outside the order's envelope (plus
+ *      the always-allowed remediation notes file) are DROPPED WITH
+ *      DISCLOSURE, so sprawl is unlandable by construction.
+ *
+ * The combined head then goes through the ONE tree verification exactly as
+ * the legacy path's does; the outcome mapping shares the runner's phrasing
+ * helpers (`verify.ts`), never a second copy.
+ *
+ * Order-driven tasks are bounded (no score hinge by construction — the
+ * catalog test pins that a class-selecting task declares none), so the
+ * hinge tail lives only on the legacy path.
+ */
+import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
+import { checkKey } from '../analyzers/correctness/attribution';
+import { clearOrderScope, writeOrderScope } from '../loop/order-scope';
+import { budgetOverruns, budgetPromptNote } from './budget-notes';
+import type { AgentRunResult, ResolvedModelChoice } from './driver';
+import type { AgentDriver } from './driver';
+import type {
+  AgentEnvelope,
+  OrderRunRecord,
+  OrdersPhaseSummary,
+  RemediateGit,
+  RemediateResult,
+  RemediateRunOptions,
+} from './outcome';
+import type { RemediateBudget } from './config';
+import type { RecipePhaseSummary } from './recipes/run-recipes';
+import { pathInEnvelope } from './recipes/envelope';
+import { priorBlockingNote, resumePromptNote } from './resume';
+import { REMEDIATION_NOTES_PATH, type RemediateTask } from './tasks';
+import { resolveOrderToolPolicy } from './tool-policy';
+import {
+  guardrailRedNote,
+  installFailedNote,
+  verificationDisclosures,
+  verifyCommittedHead,
+} from './verify';
+import { renderWorkOrderPrompt } from './work-orders/render';
+import type { WorkOrder } from './work-orders/types';
+
+type Partial_ = Omit<RemediateResult, 'ledger' | 'dispatch' | 'resume'>;
+
+export interface OrdersPhaseArgs {
+  readonly taskId: RemediateTask['id'];
+  /** The agent queue, plan (value) order, uncapped. */
+  readonly queue: readonly WorkOrder[];
+  /** Effective `remediate.maxOrdersPerRun` (> 0 here by construction). */
+  readonly cap: number;
+  readonly driver: AgentDriver;
+  readonly choice: ResolvedModelChoice;
+  /** The run-level budget (policy, lifetime-clamped) — the ceiling the
+   *  per-order derived budgets are clamped against. */
+  readonly runBudget: RemediateBudget;
+  readonly envelopeBase: Omit<AgentEnvelope, 'turns' | 'costUsd' | 'failure' | 'toolPolicy'>;
+  readonly git: RemediateGit;
+  readonly baseHead: string;
+  /** HEAD after the recipe commits — the agent tier's own base. */
+  readonly agentBase: string;
+  readonly entryFloor: CorrectnessFloorResult;
+  readonly runFloor: () => CorrectnessFloorResult;
+  readonly recipes: RecipePhaseSummary;
+  readonly effectiveSalvage: 'discard' | 'draft-pr';
+}
+
+/** Injected clock (tests); production uses Date.now. */
+export type Clock = () => number;
+
+/**
+ * The runner's one call: dispatch the agent queue when one exists (a plan
+ * in hand, a positive `remediate.maxOrdersPerRun`), else null — the legacy
+ * task-prompt path is then the runner's. The queue is the agent-tier
+ * orders plus every recipe order the recipe tier refused or failed;
+ * open-ended tasks select no classes, so their queue is always empty.
+ */
+export async function dispatchQueuedOrders(
+  opts: RemediateRunOptions,
+  args: Omit<OrdersPhaseArgs, 'queue' | 'cap'>,
+): Promise<Partial_ | null> {
+  const cap = opts.config.maxOrdersPerRun;
+  const queue = cap > 0 ? (args.recipes.agentOrders ?? []) : [];
+  if (queue.length === 0) return null;
+  return runOrdersPhase(opts, { ...args, queue, cap });
+}
+
+export async function runOrdersPhase(
+  opts: RemediateRunOptions,
+  args: OrdersPhaseArgs,
+  now: Clock = Date.now,
+): Promise<Partial_> {
+  const toolPolicy = resolveOrderToolPolicy(args.driver);
+  const records: OrderRunRecord[] = [];
+  const scrubbed: string[] = [];
+  const failures: string[] = [];
+  let totalTurns: number | undefined;
+  let totalCost: number | undefined;
+  let cliVersion: string | undefined;
+  let resolvedModelId: string | undefined;
+  let lastTail = '';
+  let partial = false;
+  let stopReason: string | undefined;
+  let anyCompleted = false;
+  let terminal: ((summary: OrdersPhaseSummary, envelope: AgentEnvelope) => Partial_) | undefined;
+
+  const resumeNote = opts.resume
+    ? resumePromptNote(opts.resume.attempt, opts.resume.blockingContext)
+    : '';
+  const negativeNote = opts.priorBlocking ? priorBlockingNote(opts.priorBlocking) : '';
+  const startedAt = now();
+
+  const dispatchList = args.queue.slice(0, args.cap);
+  for (const order of args.queue.slice(args.cap)) {
+    records.push(
+      notDispatched(order, `beyond the per-run order cap (remediate.maxOrdersPerRun: ${args.cap})`),
+    );
+  }
+
+  for (const order of dispatchList) {
+    if (terminal) break;
+    if (stopReason) {
+      records.push(notDispatched(order, stopReason));
+      continue;
+    }
+    // Remaining run budget: the per-order derived budget never exceeds what
+    // is left of the run's own caps (wall clock, spend).
+    const elapsedMinutes = (now() - startedAt) / 60_000;
+    const remainingMinutes = args.runBudget.maxMinutes - elapsedMinutes;
+    const remainingUsd = args.runBudget.maxUsd - (totalCost ?? 0);
+    if (remainingMinutes < 1 || remainingUsd <= 0) {
+      partial = true;
+      stopReason =
+        `the run budget is exhausted (` +
+        `${remainingMinutes < 1 ? 'wall clock' : 'spend'} — caps ` +
+        `${args.runBudget.maxMinutes} min / $${args.runBudget.maxUsd}); later orders are ` +
+        'deferred to the next firing';
+      records.push(notDispatched(order, stopReason));
+      continue;
+    }
+    const minutes = Math.min(order.budget.minutes, Math.floor(remainingMinutes));
+    const clamped =
+      minutes < order.budget.minutes
+        ? `minutes clamped ${order.budget.minutes} to ${minutes} (run budget remaining)`
+        : undefined;
+    const orderBudget: RemediateBudget = {
+      maxTurns: order.budget.turns,
+      maxMinutes: minutes,
+      maxUsd: Math.min(order.budget.usd, remainingUsd),
+    };
+    const prompt =
+      renderWorkOrderPrompt(order) +
+      budgetPromptNote(orderBudget) +
+      (clamped ? `\nRun-budget note: ${clamped}.` : '') +
+      resumeNote +
+      negativeNote;
+
+    const orderBase = args.git.head();
+    // The in-session done contract: the Stop-gate reads this file and blocks
+    // the agent's stop while the order's target findings are still present.
+    writeOrderScope(opts.cwd, {
+      orderId: order.id,
+      absentIds: [...order.done.absentIds],
+      envelope: { paths: [...order.envelope.paths], manifests: order.envelope.manifests },
+      verifier: order.done.verifier,
+      command: order.done.command,
+    });
+    let result: AgentRunResult;
+    try {
+      result = await args.driver.run({
+        cwd: opts.cwd,
+        prompt,
+        budget: { maxTurns: orderBudget.maxTurns, maxMinutes: orderBudget.maxMinutes },
+        model: args.choice.native,
+        env: opts.agentEnv ?? {},
+        ...(toolPolicy.tools ? { tools: toolPolicy.tools } : {}),
+      });
+    } finally {
+      clearOrderScope(opts.cwd);
+    }
+
+    if (result.transcriptTail) lastTail = result.transcriptTail;
+    if (result.cliVersion && !cliVersion) cliVersion = result.cliVersion;
+    if (result.resolvedModelId) resolvedModelId = result.resolvedModelId;
+    if (result.turns !== undefined) totalTurns = (totalTurns ?? 0) + result.turns;
+    if (result.costUsd !== undefined) totalCost = (totalCost ?? 0) + result.costUsd;
+
+    // Evidence before classification (#272): sweep + scrub run before any
+    // never-ran claim is honored.
+    const sweepError = args.git.sweepLeftovers();
+    scrubbed.push(...args.git.scrubRuntimeArtifacts(orderBase));
+    const orderHasWork = args.git.hasDiff(orderBase);
+
+    if (result.neverRan && !orderHasWork && !sweepError) {
+      // Uncontradicted never-ran: the CLI itself is dead (auth, credit) —
+      // dispatching further orders would spend nothing but time.
+      const reason = result.neverRan.reason;
+      records.push({ ...recordBase(order), outcome: 'never-ran', detail: reason });
+      stopReason = `the agent CLI did not run (${reason}); later orders were not dispatched`;
+      continue;
+    }
+    if (result.neverRan) {
+      failures.push(
+        `order ${order.id}: driver classified the run as "agent never ran" ` +
+          `(${result.neverRan.reason}), but the tree carries work from this dispatch — the ` +
+          `claim is contradicted by evidence, so verification decides the work's fate`,
+      );
+    }
+
+    if (sweepError) {
+      // Same doctrine as the legacy path: a failed sweep already staged the
+      // leftovers, so nothing may land. Terminal for the whole run.
+      records.push({
+        ...recordBase(order),
+        outcome: 'failed',
+        detail: `the leftover sweep failed: ${sweepError}`,
+      });
+      const anyDiff = args.git.hasDiff(args.baseHead);
+      terminal = (summary, envelope) => ({
+        outcome: anyDiff ? 'sweep-failed' : 'agent-never-ran',
+        task: args.taskId,
+        recipes: args.recipes,
+        orders: summary,
+        envelope,
+        floor: args.entryFloor,
+        ...(lastTail ? { transcriptTail: lastTail } : {}),
+        ...(partial ? { partial } : {}),
+        note: anyDiff
+          ? `the agent committed work, but the runner could not sweep its remaining ` +
+            `uncommitted state into a reviewable commit: ${sweepError}. Nothing lands — the ` +
+            `staged leftovers would otherwise ride the delivery commit unreviewed. The ` +
+            `branch is left for inspection.`
+          : `agent left uncommitted work the sweep could not commit: ${sweepError}`,
+        baseHead: args.baseHead,
+        head: args.git.head(),
+      });
+      continue;
+    }
+
+    // Envelope ENFORCEMENT (the sweep half; the prompt half is advisory):
+    // drop every committed change outside the order's envelope, plus the
+    // always-allowed remediation notes file. Fail-CLOSED on an enforcement
+    // error — an unenforced diff must not land.
+    const enforced = args.git.enforceEnvelope(
+      orderBase,
+      (p) => pathInEnvelope(p, order.envelope) || p === REMEDIATION_NOTES_PATH,
+    );
+    if (enforced.error) {
+      records.push({
+        ...recordBase(order),
+        outcome: 'failed',
+        detail: `envelope enforcement failed: ${enforced.error}`,
+      });
+      terminal = (summary, envelope) => ({
+        outcome: 'sweep-failed',
+        task: args.taskId,
+        recipes: args.recipes,
+        orders: summary,
+        envelope,
+        floor: args.entryFloor,
+        ...(lastTail ? { transcriptTail: lastTail } : {}),
+        ...(partial ? { partial } : {}),
+        note:
+          `the runner could not enforce order ${order.id}'s envelope on the committed diff ` +
+          `(${enforced.error}). Nothing lands — an out-of-envelope change must never ride a ` +
+          `delivery unenforced. The branch is left for inspection.`,
+        baseHead: args.baseHead,
+        head: args.git.head(),
+      });
+      continue;
+    }
+
+    const overruns = budgetOverruns(args.driver, result, orderBudget);
+    partial = partial || overruns.partial;
+    if (result.failure) failures.push(`order ${order.id}: ${result.failure.reason}`);
+    if (result.completed) anyCompleted = true;
+    records.push({
+      ...recordBase(order),
+      ...(clamped ? { clamped } : {}),
+      outcome: result.neverRan
+        ? 'failed'
+        : overruns.partial
+          ? 'partial'
+          : result.completed
+            ? 'completed'
+            : 'failed',
+      ...(result.failure ? { detail: result.failure.reason } : {}),
+      ...(result.turns !== undefined || result.costUsd !== undefined
+        ? {
+            spent: {
+              ...(result.turns !== undefined ? { turns: result.turns } : {}),
+              ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
+            },
+          }
+        : {}),
+      ...(enforced.dropped.length > 0 ? { droppedPaths: enforced.dropped } : {}),
+    });
+  }
+
+  const summary: OrdersPhaseSummary = {
+    cap: args.cap,
+    queued: args.queue.length,
+    records,
+    ...(opts.priorBlocking ? { priorBlockingApplied: true } : {}),
+  };
+  const envelope: AgentEnvelope = {
+    ...args.envelopeBase,
+    toolPolicy: toolPolicy.disclosure,
+    ...(resolvedModelId ? { resolvedModelId } : {}),
+    ...(cliVersion ? { cliVersion } : {}),
+    ...(totalTurns !== undefined ? { turns: totalTurns } : {}),
+    ...(totalCost !== undefined ? { costUsd: totalCost } : {}),
+    ...(failures.length > 0 ? { failure: failures.join('; ') } : {}),
+  };
+  if (terminal) return terminal(summary, envelope);
+
+  const evidenceTail = lastTail ? { transcriptTail: lastTail } : {};
+  const hasDiff = args.git.hasDiff(args.baseHead);
+  const hasRecipeCommits = args.agentBase !== args.baseHead;
+  if (!hasDiff) {
+    const neverRanOnly =
+      records.length > 0 &&
+      records.every((r) => r.outcome === 'never-ran' || r.outcome === 'not-dispatched');
+    if (neverRanOnly) {
+      return {
+        outcome: 'agent-never-ran',
+        task: args.taskId,
+        recipes: args.recipes,
+        orders: summary,
+        envelope,
+        floor: args.entryFloor,
+        ...evidenceTail,
+        note: `agent never ran: ${records.find((r) => r.outcome === 'never-ran')?.detail ?? 'see the order records'}`,
+      };
+    }
+    if (!anyCompleted && !partial) {
+      return {
+        outcome: 'agent-failed',
+        task: args.taskId,
+        recipes: args.recipes,
+        orders: summary,
+        envelope,
+        floor: args.entryFloor,
+        ...evidenceTail,
+        note:
+          'every dispatched order ended in an error and produced no committed change. ' +
+          'Nothing to verify; nothing lands' +
+          (hasRecipeCommits
+            ? ' (the recipe commits stay on the branch, unlanded, for the next attempt)'
+            : '') +
+          '.',
+        baseHead: args.baseHead,
+        head: args.git.head(),
+      };
+    }
+    if (!hasRecipeCommits) {
+      return {
+        outcome: 'no-op',
+        task: args.taskId,
+        recipes: args.recipes,
+        orders: summary,
+        envelope,
+        floor: args.entryFloor,
+        ...evidenceTail,
+        ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
+        ...(partial ? { partial } : {}),
+        note:
+          scrubbed.length > 0
+            ? 'the dispatched orders produced no committed change beyond regenerable dxkit ' +
+              'scan state (dropped, disclosed below).'
+            : 'the dispatched orders produced no committed change.',
+        baseHead: args.baseHead,
+        head: args.git.head(),
+      };
+    }
+  }
+
+  const head = args.git.head();
+  const { verified, guardrail } = await verifyCommittedHead(opts, {
+    head,
+    baseHead: args.baseHead,
+    entryFloor: args.entryFloor,
+    runFloor: args.runFloor,
+  });
+
+  // Per-order done, judged from the FINAL verified floor for floor-verifier
+  // orders (a guardrail-verifier order's closure is arbitrated by the
+  // guardrail verdict below and the next plan — the ledger says so).
+  const failingKeys = new Set(
+    (verified.floor?.checks ?? [])
+      .filter((c) => c.status === 'fail')
+      .map((c) => checkKey(c.pack, c.label)),
+  );
+  const byId = new Map(dispatchList.map((o) => [o.id, o] as const));
+  const withDone = records.map((r) => {
+    const order = byId.get(r.orderId);
+    if (!order || order.done.verifier !== 'floor' || r.outcome === 'not-dispatched') return r;
+    const open = order.done.absentIds.filter((id) => failingKeys.has(id.split('#')[0])).length;
+    return { ...r, doneAfterVerify: { closed: order.done.absentIds.length - open, open } };
+  });
+  const finalSummary: OrdersPhaseSummary = { ...summary, records: withDone };
+
+  const common = {
+    task: args.taskId,
+    recipes: args.recipes,
+    orders: finalSummary,
+    envelope,
+    ...verificationDisclosures(verified, guardrail),
+    baseHead: args.baseHead,
+    head,
+    ...evidenceTail,
+    ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
+    ...(partial ? { partial } : {}),
+  };
+
+  if (verified.verdict === 'install-failed') {
+    return { outcome: 'install-failed', ...common, note: installFailedNote(verified) };
+  }
+  if (verified.verdict === 'floor-red') {
+    return {
+      outcome: 'floor-red',
+      ...common,
+      note:
+        'the correctness floor has NET-NEW failures after the order dispatches (the entry ' +
+        'floor did not have them) — nothing lands. An agent that breaks the build gets a ' +
+        'truthful failure, never a PR.',
+    };
+  }
+  if (!guardrail.ran || !guardrail.passesGate) {
+    return {
+      outcome: 'guardrail-red',
+      ...common,
+      note: guardrailRedNote(guardrail, args.effectiveSalvage),
+    };
+  }
+  if (partial) {
+    const salvage =
+      args.effectiveSalvage === 'draft-pr'
+        ? 'salvage policy: draft-pr — the verified partial work may land as a DRAFT.'
+        : 'salvage policy: discard — the partial work is not landed (branch left for inspection).';
+    return {
+      outcome: 'budget-exhausted',
+      ...common,
+      note: `a budget cap cut the order dispatches short — the diff is verified. ${salvage}`,
+    };
+  }
+  return { outcome: 'verified', ...common };
+}
+
+function recordBase(order: WorkOrder): Omit<OrderRunRecord, 'outcome'> {
+  return {
+    orderId: order.id,
+    class: String(order.class),
+    findings: order.findings.length,
+    budget: order.budget,
+    done: { verifier: order.done.verifier, absentIds: order.done.absentIds.length },
+  };
+}
+
+function notDispatched(order: WorkOrder, reason: string): OrderRunRecord {
+  return { ...recordBase(order), outcome: 'not-dispatched', detail: reason };
+}

--- a/src/remediate/orders-phase.ts
+++ b/src/remediate/orders-phase.ts
@@ -32,8 +32,14 @@
  * hinge tail lives only on the legacy path.
  */
 import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
-import { checkKey } from '../analyzers/correctness/attribution';
-import { clearOrderScope, writeOrderScope } from '../loop/order-scope';
+import { detectActiveLanguages, dependencyManifestFilesIn } from '../languages';
+import {
+  ORDER_TOKEN_ENV,
+  clearOrderScope,
+  newOrderScopeToken,
+  writeOrderScope,
+} from '../loop/order-scope';
+import { completeOrdersRun } from './orders-complete';
 import { budgetOverruns, budgetPromptNote } from './budget-notes';
 import type { AgentRunResult, ResolvedModelChoice } from './driver';
 import type { AgentDriver } from './driver';
@@ -47,16 +53,10 @@ import type {
 } from './outcome';
 import type { RemediateBudget } from './config';
 import type { RecipePhaseSummary } from './recipes/run-recipes';
-import { pathInEnvelope } from './recipes/envelope';
+import { pathAllowedByEnvelope } from './recipes/envelope';
 import { priorBlockingNote, resumePromptNote } from './resume';
 import { REMEDIATION_NOTES_PATH, type RemediateTask } from './tasks';
 import { resolveOrderToolPolicy } from './tool-policy';
-import {
-  guardrailRedNote,
-  installFailedNote,
-  verificationDisclosures,
-  verifyCommittedHead,
-} from './verify';
 import { renderWorkOrderPrompt } from './work-orders/render';
 import type { WorkOrder } from './work-orders/types';
 
@@ -82,6 +82,10 @@ export interface OrdersPhaseArgs {
   readonly runFloor: () => CorrectnessFloorResult;
   readonly recipes: RecipePhaseSummary;
   readonly effectiveSalvage: 'discard' | 'draft-pr';
+  /** Injected for tests: is a path a dependency manifest/lockfile? Default
+   *  derives from the active packs' declared patterns (Rule 6) and backs
+   *  the envelope's `manifests: false` enforcement. */
+  readonly isManifestPath?: (path: string) => boolean;
 }
 
 /** Injected clock (tests); production uses Date.now. */
@@ -110,6 +114,20 @@ export async function runOrdersPhase(
   now: Clock = Date.now,
 ): Promise<Partial_> {
   const toolPolicy = resolveOrderToolPolicy(args.driver);
+  // Session binding for the order scope: one token per run, injected into
+  // the agent env so the Stop hook (which inherits it) can tell THIS lane's
+  // scope from a killed or concurrent lane's leftover.
+  const orderToken = newOrderScopeToken();
+  // The manifests:false gate reads the pack-declared manifest-pattern union
+  // (computed lazily once; injectable for tests).
+  let manifestProbe = args.isManifestPath;
+  const isManifestPath = (p: string): boolean => {
+    if (!manifestProbe) {
+      const packs = detectActiveLanguages(opts.cwd);
+      manifestProbe = (x) => dependencyManifestFilesIn([x], packs).length > 0;
+    }
+    return manifestProbe(p);
+  };
   const records: OrderRunRecord[] = [];
   const scrubbed: string[] = [];
   const failures: string[] = [];
@@ -147,23 +165,33 @@ export async function runOrdersPhase(
     const elapsedMinutes = (now() - startedAt) / 60_000;
     const remainingMinutes = args.runBudget.maxMinutes - elapsedMinutes;
     const remainingUsd = args.runBudget.maxUsd - (totalCost ?? 0);
-    if (remainingMinutes < 1 || remainingUsd <= 0) {
+    const remainingTurns = args.runBudget.maxTurns - (totalTurns ?? 0);
+    if (remainingMinutes < 1 || remainingUsd <= 0 || remainingTurns <= 0) {
       partial = true;
+      const dimension = remainingMinutes < 1 ? 'wall clock' : remainingUsd <= 0 ? 'spend' : 'turns';
       stopReason =
-        `the run budget is exhausted (` +
-        `${remainingMinutes < 1 ? 'wall clock' : 'spend'} — caps ` +
-        `${args.runBudget.maxMinutes} min / $${args.runBudget.maxUsd}); later orders are ` +
-        'deferred to the next firing';
+        `the run budget is exhausted (${dimension} — caps ` +
+        `${args.runBudget.maxTurns} turns / ${args.runBudget.maxMinutes} min / ` +
+        `$${args.runBudget.maxUsd}); later orders are deferred to the next firing`;
       records.push(notDispatched(order, stopReason));
       continue;
     }
+    // The per-order derived budget, clamped to the run's remainder in every
+    // dimension — the run-level caps bound the TOTAL across orders, so three
+    // orders can never spend three times the configured turn cap.
     const minutes = Math.min(order.budget.minutes, Math.floor(remainingMinutes));
-    const clamped =
-      minutes < order.budget.minutes
-        ? `minutes clamped ${order.budget.minutes} to ${minutes} (run budget remaining)`
-        : undefined;
+    const turns = Math.min(order.budget.turns, remainingTurns);
+    const clamps = [
+      ...(minutes < order.budget.minutes
+        ? [`minutes clamped ${order.budget.minutes} to ${minutes} (run budget remaining)`]
+        : []),
+      ...(turns < order.budget.turns
+        ? [`turns clamped ${order.budget.turns} to ${turns} (run budget remaining)`]
+        : []),
+    ];
+    const clamped = clamps.length > 0 ? clamps.join('; ') : undefined;
     const orderBudget: RemediateBudget = {
-      maxTurns: order.budget.turns,
+      maxTurns: turns,
       maxMinutes: minutes,
       maxUsd: Math.min(order.budget.usd, remainingUsd),
     };
@@ -180,9 +208,12 @@ export async function runOrdersPhase(
     writeOrderScope(opts.cwd, {
       orderId: order.id,
       absentIds: [...order.done.absentIds],
+      kinds: [...new Set(order.findings.map((f) => f.kind))],
       envelope: { paths: [...order.envelope.paths], manifests: order.envelope.manifests },
       verifier: order.done.verifier,
       command: order.done.command,
+      token: orderToken,
+      writtenAt: new Date().toISOString(),
     });
     let result: AgentRunResult;
     try {
@@ -191,7 +222,9 @@ export async function runOrdersPhase(
         prompt,
         budget: { maxTurns: orderBudget.maxTurns, maxMinutes: orderBudget.maxMinutes },
         model: args.choice.native,
-        env: opts.agentEnv ?? {},
+        // The order token rides the agent env so the Stop hook, which
+        // inherits it, can bind the scope file to THIS session.
+        env: { ...(opts.agentEnv ?? {}), [ORDER_TOKEN_ENV]: orderToken },
         ...(toolPolicy.tools ? { tools: toolPolicy.tools } : {}),
       });
     } finally {
@@ -262,7 +295,8 @@ export async function runOrdersPhase(
     // error — an unenforced diff must not land.
     const enforced = args.git.enforceEnvelope(
       orderBase,
-      (p) => pathInEnvelope(p, order.envelope) || p === REMEDIATION_NOTES_PATH,
+      (p) =>
+        p === REMEDIATION_NOTES_PATH || pathAllowedByEnvelope(p, order.envelope, isManifestPath),
     );
     if (enforced.error) {
       records.push({
@@ -333,137 +367,16 @@ export async function runOrdersPhase(
   };
   if (terminal) return terminal(summary, envelope);
 
-  const evidenceTail = lastTail ? { transcriptTail: lastTail } : {};
-  const hasDiff = args.git.hasDiff(args.baseHead);
-  const hasRecipeCommits = args.agentBase !== args.baseHead;
-  if (!hasDiff) {
-    const neverRanOnly =
-      records.length > 0 &&
-      records.every((r) => r.outcome === 'never-ran' || r.outcome === 'not-dispatched');
-    if (neverRanOnly) {
-      return {
-        outcome: 'agent-never-ran',
-        task: args.taskId,
-        recipes: args.recipes,
-        orders: summary,
-        envelope,
-        floor: args.entryFloor,
-        ...evidenceTail,
-        note: `agent never ran: ${records.find((r) => r.outcome === 'never-ran')?.detail ?? 'see the order records'}`,
-      };
-    }
-    if (!anyCompleted && !partial) {
-      return {
-        outcome: 'agent-failed',
-        task: args.taskId,
-        recipes: args.recipes,
-        orders: summary,
-        envelope,
-        floor: args.entryFloor,
-        ...evidenceTail,
-        note:
-          'every dispatched order ended in an error and produced no committed change. ' +
-          'Nothing to verify; nothing lands' +
-          (hasRecipeCommits
-            ? ' (the recipe commits stay on the branch, unlanded, for the next attempt)'
-            : '') +
-          '.',
-        baseHead: args.baseHead,
-        head: args.git.head(),
-      };
-    }
-    if (!hasRecipeCommits) {
-      return {
-        outcome: 'no-op',
-        task: args.taskId,
-        recipes: args.recipes,
-        orders: summary,
-        envelope,
-        floor: args.entryFloor,
-        ...evidenceTail,
-        ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
-        ...(partial ? { partial } : {}),
-        note:
-          scrubbed.length > 0
-            ? 'the dispatched orders produced no committed change beyond regenerable dxkit ' +
-              'scan state (dropped, disclosed below).'
-            : 'the dispatched orders produced no committed change.',
-        baseHead: args.baseHead,
-        head: args.git.head(),
-      };
-    }
-  }
-
-  const head = args.git.head();
-  const { verified, guardrail } = await verifyCommittedHead(opts, {
-    head,
-    baseHead: args.baseHead,
-    entryFloor: args.entryFloor,
-    runFloor: args.runFloor,
-  });
-
-  // Per-order done, judged from the FINAL verified floor for floor-verifier
-  // orders (a guardrail-verifier order's closure is arbitrated by the
-  // guardrail verdict below and the next plan — the ledger says so).
-  const failingKeys = new Set(
-    (verified.floor?.checks ?? [])
-      .filter((c) => c.status === 'fail')
-      .map((c) => checkKey(c.pack, c.label)),
-  );
-  const byId = new Map(dispatchList.map((o) => [o.id, o] as const));
-  const withDone = records.map((r) => {
-    const order = byId.get(r.orderId);
-    if (!order || order.done.verifier !== 'floor' || r.outcome === 'not-dispatched') return r;
-    const open = order.done.absentIds.filter((id) => failingKeys.has(id.split('#')[0])).length;
-    return { ...r, doneAfterVerify: { closed: order.done.absentIds.length - open, open } };
-  });
-  const finalSummary: OrdersPhaseSummary = { ...summary, records: withDone };
-
-  const common = {
-    task: args.taskId,
-    recipes: args.recipes,
-    orders: finalSummary,
+  return completeOrdersRun(opts, args, {
+    summary,
     envelope,
-    ...verificationDisclosures(verified, guardrail),
-    baseHead: args.baseHead,
-    head,
-    ...evidenceTail,
-    ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
-    ...(partial ? { partial } : {}),
-  };
-
-  if (verified.verdict === 'install-failed') {
-    return { outcome: 'install-failed', ...common, note: installFailedNote(verified) };
-  }
-  if (verified.verdict === 'floor-red') {
-    return {
-      outcome: 'floor-red',
-      ...common,
-      note:
-        'the correctness floor has NET-NEW failures after the order dispatches (the entry ' +
-        'floor did not have them) — nothing lands. An agent that breaks the build gets a ' +
-        'truthful failure, never a PR.',
-    };
-  }
-  if (!guardrail.ran || !guardrail.passesGate) {
-    return {
-      outcome: 'guardrail-red',
-      ...common,
-      note: guardrailRedNote(guardrail, args.effectiveSalvage),
-    };
-  }
-  if (partial) {
-    const salvage =
-      args.effectiveSalvage === 'draft-pr'
-        ? 'salvage policy: draft-pr — the verified partial work may land as a DRAFT.'
-        : 'salvage policy: discard — the partial work is not landed (branch left for inspection).';
-    return {
-      outcome: 'budget-exhausted',
-      ...common,
-      note: `a budget cap cut the order dispatches short — the diff is verified. ${salvage}`,
-    };
-  }
-  return { outcome: 'verified', ...common };
+    records,
+    dispatchList,
+    scrubbed,
+    lastTail,
+    partial,
+    anyCompleted,
+  });
 }
 
 function recordBase(order: WorkOrder): Omit<OrderRunRecord, 'outcome'> {

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -50,10 +50,17 @@ export interface OrderRunRecord {
    *  line (closure is arbitrated by the one tree verification below). */
   readonly done: { readonly verifier: 'floor' | 'guardrail'; readonly absentIds: number };
   /** For floor-verifier orders, what the FINAL verified floor says about
-   *  the order's target checks (guardrail-verifier closure has no
-   *  per-finding read at this layer — the guardrail verdict + the next
-   *  plan arbitrate, and the ledger says so). */
-  readonly doneAfterVerify?: { readonly closed: number; readonly open: number };
+   *  the order's target findings, through the ONE `floorOrderDone`
+   *  computation the Stop-gate also reads. `undecided` counts ids the
+   *  verification could not observe (skipped/absent check) — never claimed
+   *  closed (guardrail-verifier closure has no per-finding read at this
+   *  layer: the guardrail verdict + the next plan arbitrate, and the
+   *  ledger says so). */
+  readonly doneAfterVerify?: {
+    readonly closed: number;
+    readonly open: number;
+    readonly undecided: number;
+  };
 }
 
 /** The orders phase, disclosed as one summary on the result. */

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -16,6 +16,58 @@ import type { HingeEvidence, HingeScores } from './score-hinge';
 import type { RemediateConfig } from './config';
 import type { InLoopGateStatus } from './agent-trust';
 import type { RecipePhaseSummary, runRecipePhaseForTask } from './recipes/run-recipes';
+import type { WorkOrderBudget } from './work-orders/types';
+
+/** How (whether) the driver applied the run's tool-narrowing policy —
+ *  disclosed in the envelope, never a silent drop. */
+export type ToolPolicyDisclosure =
+  | {
+      readonly mechanism: 'disallowed-tools';
+      readonly disallowed: readonly string[];
+      /** The driver's documented CLI requirement for the mechanism. */
+      readonly cliRequirement: string;
+    }
+  | { readonly mechanism: 'none'; readonly reason: string };
+
+/** One order's dispatch record (the orders phase: one order per agent run). */
+export interface OrderRunRecord {
+  readonly orderId: string;
+  readonly class: string;
+  readonly findings: number;
+  /** The planner-derived budget for this order (with its derivation string),
+   *  which BECAME the driver budget for the run — plus the clamp note when
+   *  the run's remaining budget cut it down. */
+  readonly budget: WorkOrderBudget;
+  readonly clamped?: string;
+  readonly outcome: 'completed' | 'partial' | 'failed' | 'never-ran' | 'not-dispatched';
+  /** Failure/never-ran/not-dispatched reason. */
+  readonly detail?: string;
+  readonly spent?: { readonly turns?: number; readonly costUsd?: number };
+  /** Out-of-envelope paths the sweep DROPPED, disclosed (the enforcement
+   *  half of the envelope; the prompt half is advisory). */
+  readonly droppedPaths?: readonly string[];
+  /** The order's done criterion, echoed for the ledger's per-order done
+   *  line (closure is arbitrated by the one tree verification below). */
+  readonly done: { readonly verifier: 'floor' | 'guardrail'; readonly absentIds: number };
+  /** For floor-verifier orders, what the FINAL verified floor says about
+   *  the order's target checks (guardrail-verifier closure has no
+   *  per-finding read at this layer — the guardrail verdict + the next
+   *  plan arbitrate, and the ledger says so). */
+  readonly doneAfterVerify?: { readonly closed: number; readonly open: number };
+}
+
+/** The orders phase, disclosed as one summary on the result. */
+export interface OrdersPhaseSummary {
+  /** Effective `remediate.maxOrdersPerRun`. */
+  readonly cap: number;
+  /** Orders queued for the agent tier (before the cap). */
+  readonly queued: number;
+  readonly records: readonly OrderRunRecord[];
+  /** True when a prior BLOCKED attempt's findings were rendered into each
+   *  order prompt as a negative constraint (resume policy: a guardrail-red
+   *  attempt is never a resume anchor). */
+  readonly priorBlockingApplied?: boolean;
+}
 
 export type RemediateOutcome =
   | 'verified' // diff produced, floor net-new-clean, guardrail PASSED — ready to land
@@ -62,6 +114,9 @@ export interface AgentEnvelope {
   };
   /** Caps the driver cannot enforce — disclosed, never silent. */
   readonly unenforceableCaps: readonly string[];
+  /** The tool-narrowing policy applied to order-driven runs (absent on the
+   *  legacy task-prompt path, whose permissions are unchanged). */
+  readonly toolPolicy?: ToolPolicyDisclosure;
   /**
    * Was the in-loop Stop-gate actually WIRED for this run (#305)?
    * `in-loop-gated` = the committed Stop hook verifiably loads (settings +
@@ -124,6 +179,10 @@ export interface RemediateResult {
    *  failed records, envelope drops, and the tier split, rendered into the
    *  ledger whenever the phase was consulted. */
   readonly recipes?: RecipePhaseSummary;
+  /** The order-driven agent phase (4.4.5, scoped agent): one order per
+   *  agent run, per-order records with derived budgets, envelope
+   *  enforcement drops, and done disclosures — rendered into the ledger. */
+  readonly orders?: OrdersPhaseSummary;
   /** The verification ledger — PR body / job summary markdown. */
   readonly ledger: string;
 }
@@ -141,6 +200,17 @@ export interface RemediateGit {
   /** Any CONTENT change in base..HEAD? (Commit count is the wrong
    *  question: a resume marker is an empty commit.) */
   hasDiff(baseHead: string): boolean;
+  /** Revert every committed change in base..HEAD whose path `isAllowed`
+   *  rejects — files back to their base state, one disclosure commit — and
+   *  return the dropped paths. The envelope's ENFORCEMENT half (the prompt
+   *  half is advisory): sprawl outside an order's envelope becomes
+   *  unlandable by construction, the runtime-artifact-scrub doctrine.
+   *  `error` set = enforcement could not run; the caller must NOT land the
+   *  unenforced diff. */
+  enforceEnvelope(
+    baseHead: string,
+    isAllowed: (path: string) => boolean,
+  ): { readonly dropped: readonly string[]; readonly error?: string };
 }
 
 export interface RemediateRunOptions {
@@ -186,6 +256,10 @@ export interface RemediateRunOptions {
    *  optional blockingContext is the prior attempt's guardrail findings
    *  (from its draft-PR ledger) — appended to the prompt, never the ledger. */
   readonly resume?: { readonly attempt: number; readonly blockingContext?: string };
+  /** A prior BLOCKED (guardrail-red) attempt's blocking findings. Never a
+   *  resume anchor — the attempt's diff is discarded and this rides the next
+   *  run's order prompts as a NEGATIVE constraint ("do not reintroduce"). */
+  readonly priorBlocking?: string;
   /** Injected for tests: replaces the recipe phase (plan + execute the
    *  deterministic tier), the armInLoopGate seam pattern. */
   readonly runRecipePhase?: typeof runRecipePhaseForTask;

--- a/src/remediate/recipes/complete.ts
+++ b/src/remediate/recipes/complete.ts
@@ -9,7 +9,7 @@
 import type { CorrectnessFloorResult } from '../../analyzers/correctness/run';
 import type { RemediateGit, RemediateResult, RemediateRunOptions } from '../outcome';
 import type { RemediateTask } from '../tasks';
-import { installFailedNote, verifyCommittedHead } from '../verify';
+import { installFailedNote, verificationDisclosures, verifyCommittedHead } from '../verify';
 import { recipeCounts, runRecipePhaseForTask, type RecipePhaseSummary } from './run-recipes';
 
 type Partial = Omit<RemediateResult, 'ledger' | 'dispatch' | 'resume'>;
@@ -51,7 +51,21 @@ export async function recipeTierStep(
     };
   }
   const selected = recipes.selectedRecipeTier + recipes.selectedAgentTier;
-  if (selected === 0 || recipes.selectedAgentTier > 0) return { recipes };
+  if (selected === 0) return { recipes };
+  // Order-driven dispatch (the scoped-agent unit): with a plan in hand and a
+  // positive per-run order cap, everything the recipe tier left OPEN — the
+  // agent-tier orders plus every refused/failed recipe order — goes to the
+  // orders phase ONE ORDER PER AGENT RUN, so a refused recipe never
+  // dead-ends the run. The run completes here only when nothing is left.
+  const orderDispatch = opts.config.maxOrdersPerRun > 0 && recipes.agentOrders !== undefined;
+  if (orderDispatch) {
+    if ((recipes.agentOrders ?? []).length > 0) return { recipes };
+  } else if (recipes.selectedAgentTier > 0) {
+    // No order queue (dispatch off, or a summary without a plan): the
+    // pre-order-dispatch shape — a mixed plan continues on the legacy
+    // task-prompt agent path.
+    return { recipes };
+  }
   const done = await completeRecipeOnlyRun(opts, {
     taskId: args.task.id,
     recipes,
@@ -82,12 +96,13 @@ export async function completeRecipeOnlyRun(
   const zeroDollar = 'No agent was spawned: every selected work order was recipe-tier ($0 run).';
   if (!args.hasDiff) {
     // NOT a clean no-op: the orders exist, every recipe refused or failed,
-    // and no agent tier exists in a recipe-only run to pick them up; a
-    // green outcome here would let the scheduled lane loop forever over
-    // debt nothing is working. `recipes-refused` is non-clean by
-    // construction (the executor's clean set never contains it), so the
-    // lane surfaces it; the agent-tier fallback within one run is the
-    // scoped-agent unit's job.
+    // and no agent dispatch remains in this run to pick them up (the
+    // in-run fallback routes refused orders to the agent tier whenever
+    // `remediate.maxOrdersPerRun` allows it — reaching this arm means it
+    // did not). A green outcome here would let the scheduled lane loop
+    // forever over debt nothing is working; `recipes-refused` is non-clean
+    // by construction (the executor's clean set never contains it).
+    const dispatchOff = opts.config.maxOrdersPerRun <= 0;
     return {
       outcome: 'recipes-refused',
       task: args.taskId,
@@ -96,7 +111,11 @@ export async function completeRecipeOnlyRun(
       note:
         `${zeroDollar} Every recipe declined: ${counts.refused} refused, ${counts.failed} ` +
         'failed, nothing was fixed, and the orders remain open. Per-order reasons are in ' +
-        'the recipe section below; these orders need the agent tier or a human.',
+        'the recipe section below; these orders need the agent tier or a human.' +
+        (dispatchOff
+          ? ' In-run agent dispatch is off (remediate.maxOrdersPerRun: 0); raise it to let ' +
+            'the agent tier pick these orders up.'
+          : ''),
     };
   }
   const { verified, guardrail } = await verifyCommittedHead(opts, {
@@ -108,11 +127,7 @@ export async function completeRecipeOnlyRun(
   const common = {
     task: args.taskId,
     recipes: args.recipes,
-    ...(verified.floor ? { floor: verified.floor } : {}),
-    ...(verified.floorAttribution ? { floorAttribution: verified.floorAttribution } : {}),
-    ...(verified.install ? { install: verified.install } : {}),
-    ...(verified.changedFiles ? { changedFiles: verified.changedFiles } : {}),
-    guardrailVerdict: guardrail.verdict,
+    ...verificationDisclosures(verified, guardrail),
     baseHead: args.baseHead,
     head: args.head,
   };

--- a/src/remediate/recipes/envelope.ts
+++ b/src/remediate/recipes/envelope.ts
@@ -1,18 +1,38 @@
 /**
- * Envelope containment for recipe diffs: the pure half of the phase
- * runner's enforcement. An envelope's `paths` speak the planner's language:
- * `''` means the whole repo, a trailing-`/` entry is a directory prefix,
- * anything else is one file.
+ * Envelope containment: the pure half of both enforcement sweeps (the
+ * recipe phase and the agent orders phase). An envelope's `paths` speak the
+ * planner's language: the explicit `REPO_WIDE_ENVELOPE` marker means the
+ * whole repo, a trailing-`/` entry is a directory prefix, anything else is
+ * one file. An empty string matches NOTHING (the accidental match-all it
+ * used to be is exactly what the explicit marker replaced).
  */
-import type { WorkOrderEnvelope } from '../work-orders/types';
+import { REPO_WIDE_ENVELOPE, type WorkOrderEnvelope } from '../work-orders/types';
 
 /** Is a repo-relative path inside the envelope? */
 export function pathInEnvelope(p: string, envelope: WorkOrderEnvelope): boolean {
   return envelope.paths.some((e) => {
-    if (e === '') return true;
+    if (e === REPO_WIDE_ENVELOPE) return true;
+    if (e === '') return false;
     if (e.endsWith('/')) return p.startsWith(e);
     return p === e || p.startsWith(`${e}/`);
   });
+}
+
+/**
+ * The full allow decision for one changed path under an order's envelope:
+ * containment, PLUS the `manifests: false` gate — an envelope that declares
+ * no manifest changes excludes dependency manifests/lockfiles even inside
+ * its paths (and under the repo-wide marker). `isManifestPath` is the
+ * pack-declared manifest-pattern union, injected by the caller (Rule 6:
+ * language facts come from the packs).
+ */
+export function pathAllowedByEnvelope(
+  p: string,
+  envelope: WorkOrderEnvelope,
+  isManifestPath: (path: string) => boolean,
+): boolean {
+  if (!envelope.manifests && isManifestPath(p)) return false;
+  return pathInEnvelope(p, envelope);
 }
 
 /** Split changed paths into the envelope's and the strays to drop. */

--- a/src/remediate/recipes/run-recipes.ts
+++ b/src/remediate/recipes/run-recipes.ts
@@ -69,6 +69,14 @@ export interface RecipePhaseSummary {
   readonly selectedRecipeTier: number;
   readonly selectedAgentTier: number;
   readonly records: readonly RecipeOrderRecord[];
+  /** The orders LEFT for the agent tier after this phase, in plan (value)
+   *  order: the selected agent-tier orders, plus every recipe-tier order
+   *  whose recipe refused or failed (the in-run fallback — a refused
+   *  recipe order joins the agent queue instead of dead-ending the run).
+   *  Absent when no plan was built (planning failed, or an injected
+   *  summary predates the field) — the runner then keeps the legacy
+   *  task-prompt path. */
+  readonly agentOrders?: readonly WorkOrder[];
 }
 
 export function emptyRecipePhase(extra?: Partial<RecipePhaseSummary>): RecipePhaseSummary {
@@ -290,9 +298,6 @@ export interface RecipePhaseOptions {
  * discarded).
  */
 export async function runRecipePhaseForTask(opts: RecipePhaseOptions): Promise<RecipePhaseSummary> {
-  if (!opts.config.recipes.enabled) {
-    return emptyRecipePhase({ disabled: true });
-  }
   let plan;
   try {
     plan = await planRepoWorkOrders(opts.cwd, opts.config, {
@@ -300,16 +305,34 @@ export async function runRecipePhaseForTask(opts: RecipePhaseOptions): Promise<R
       ...opts.gather,
     });
   } catch (err) {
-    return emptyRecipePhase({ planError: err instanceof Error ? err.message : String(err) });
+    const planError = err instanceof Error ? err.message : String(err);
+    return emptyRecipePhase({
+      planError,
+      ...(opts.config.recipes.enabled ? {} : { disabled: true }),
+    });
   }
   const selected = selectOrders(plan.plan, classesSelectedBy(opts.taskId));
   const recipeTier = selected.filter((o) => o.tier === 'recipe');
+  if (!opts.config.recipes.enabled) {
+    // The knob's documented meaning: route EVERY selected order to the
+    // agent tier. The plan is still built (order-driven dispatch needs it);
+    // no recipe executes.
+    return emptyRecipePhase({
+      disabled: true,
+      disclosures: plan.disclosures,
+      selectedRecipeTier: 0,
+      selectedAgentTier: selected.length,
+      agentOrders: selected,
+    });
+  }
   const summaryBase = {
     disclosures: plan.disclosures,
     selectedRecipeTier: recipeTier.length,
     selectedAgentTier: selected.length - recipeTier.length,
   };
-  if (recipeTier.length === 0) return { ran: false, records: [], ...summaryBase };
+  if (recipeTier.length === 0) {
+    return { ran: false, records: [], ...summaryBase, agentOrders: selected };
+  }
   const records = await runRecipeOrders(recipeTier, {
     cwd: opts.cwd,
     trust: opts.trust,
@@ -320,7 +343,14 @@ export async function runRecipePhaseForTask(opts: RecipePhaseOptions): Promise<R
     ...(opts.auditDepVulns ? { auditDepVulns: opts.auditDepVulns } : {}),
     ...(opts.blockSeverities ? { blockSeverities: opts.blockSeverities } : {}),
   });
-  return { ran: true, records, ...summaryBase };
+  // The agent queue, in plan (value) order: agent-tier orders plus every
+  // recipe order whose recipe did not APPLY — a refused/failed recipe order
+  // falls through to the agent within THIS run instead of dead-ending it.
+  const applied = new Set(
+    records.filter((r) => r.outcome.kind === 'applied').map((r) => r.orderId),
+  );
+  const agentOrders = selected.filter((o) => o.tier === 'agent' || !applied.has(o.id));
+  return { ran: true, records, ...summaryBase, agentOrders };
 }
 
 /** Convenience projections for the frame's decision + ledger. */

--- a/src/remediate/recipes/run-recipes.ts
+++ b/src/remediate/recipes/run-recipes.ts
@@ -298,6 +298,12 @@ export interface RecipePhaseOptions {
  * discarded).
  */
 export async function runRecipePhaseForTask(opts: RecipePhaseOptions): Promise<RecipePhaseSummary> {
+  // Nothing consumes a plan when BOTH consumers are off: recipes disabled
+  // and order dispatch off (maxOrdersPerRun 0) — do not pay the planning
+  // gathers for a result nobody reads.
+  if (!opts.config.recipes.enabled && opts.config.maxOrdersPerRun <= 0) {
+    return emptyRecipePhase({ disabled: true });
+  }
   let plan;
   try {
     plan = await planRepoWorkOrders(opts.cwd, opts.config, {

--- a/src/remediate/resume.ts
+++ b/src/remediate/resume.ts
@@ -50,12 +50,22 @@ export interface ResumeDecision {
   /** 1-based resume attempt number (marker commits + 1). */
   readonly attempt?: number;
   /** The prior attempt's blocking findings (extracted from the open draft
-   *  PR's ledger body, bounded) — carried into the resumed prompt so
-   *  attempt N+1 starts from "close these findings", not from scratch. */
+   *  PR's ledger body, bounded). On a resume: carried into the resumed
+   *  prompt so attempt N+1 starts from "close these findings". On a
+   *  NON-resume caused by a guardrail-red draft: returned so the caller
+   *  renders it into the next run's order prompts as a NEGATIVE constraint
+   *  (a blocked diff is never a resume anchor — design F). */
   readonly blockingContext?: string;
   /** Why no resume happened, when the knob is ON but nothing resumed —
    *  disclosed by the caller, never silent. Absent when the knob is off. */
   readonly note?: string;
+}
+
+/** Extract the ledger's outcome word from a PR body (the ledger's first
+ *  line renders `outcome: **<word>**`) — the fact the resume policy turns
+ *  on. Undefined when the body carries no ledger outcome. */
+export function extractLedgerOutcome(body: string | undefined): string | undefined {
+  return body?.match(/outcome: \*\*([a-z-]+)\*\*/)?.[1];
 }
 
 /** Extract the ledger's "Blocking findings" list from a PR body, bounded —
@@ -115,6 +125,26 @@ export function prepareResume(
       return { resumed: false, note: `no open draft PR for '${branch}' — fresh run` };
     }
     const blockingContext = extractBlockingContext(open[0]?.body);
+    // Resume policy (design F): only a budget-exhausted VERIFIED partial is
+    // a resume anchor — its work passed the gate and was only cut short. A
+    // guardrail-red draft is NOT resumed: continuing a blocked diff anchors
+    // the next attempt on work the gate rejected. Its blocking set instead
+    // becomes a NEGATIVE constraint the next run's order prompts carry
+    // ("do not reintroduce these"). Any other (or unreadable) outcome
+    // conservatively starts fresh, disclosed.
+    const priorOutcome = extractLedgerOutcome(open[0]?.body);
+    if (priorOutcome !== 'budget-exhausted') {
+      return {
+        resumed: false,
+        note:
+          `open draft for '${branch}' records outcome '${priorOutcome ?? 'unknown'}' — resume ` +
+          `only continues budget-exhausted verified partials; starting fresh` +
+          (priorOutcome === 'guardrail-red' && blockingContext
+            ? ', carrying its blocking findings as a negative constraint'
+            : ''),
+        ...(priorOutcome === 'guardrail-red' && blockingContext ? { blockingContext } : {}),
+      };
+    }
     run('git', ['fetch', 'origin', branch]);
     // Count prior resume markers on the salvage head (bounded to the branch's
     // own history vs the current default tree).
@@ -178,6 +208,17 @@ export function prepareResume(
 /** The continuation instruction appended to the task prompt on a resume.
  *  When the prior attempt was BLOCKED, its findings ride along so this
  *  attempt starts from "close these", not from scratch. */
+/** The NEGATIVE-constraint paragraph an order prompt carries when a prior
+ *  attempt was guardrail-BLOCKED (and therefore not resumed): the blocked
+ *  diff was discarded, and this run must not reintroduce its findings. */
+export function priorBlockingNote(blockingContext: string): string {
+  return (
+    `\nNEGATIVE CONSTRAINT from a prior BLOCKED attempt (its diff was discarded, not ` +
+    `resumed): the guardrail blocked that attempt on exactly these findings. Do not ` +
+    `reintroduce any of them:\n${blockingContext}`
+  );
+}
+
 export function resumePromptNote(attempt: number, blockingContext?: string): string {
   return (
     `\nRESUMED ATTEMPT #${attempt}: a previous budget-bounded run already committed real ` +

--- a/src/remediate/resume.ts
+++ b/src/remediate/resume.ts
@@ -61,11 +61,18 @@ export interface ResumeDecision {
   readonly note?: string;
 }
 
-/** Extract the ledger's outcome word from a PR body (the ledger's first
- *  line renders `outcome: **<word>**`) — the fact the resume policy turns
- *  on. Undefined when the body carries no ledger outcome. */
+/** Extract the ledger's outcome word from a PR body — the fact the resume
+ *  policy turns on. Anchored to the ledger's own emitted line shapes (the
+ *  runner's `Task: **<task>** ... outcome: **<word>**` header, or the
+ *  executor's bare `outcome: **<word>**` refusal line), never a prose
+ *  mention of the word elsewhere in the body. Undefined when no ledger
+ *  outcome line exists. */
 export function extractLedgerOutcome(body: string | undefined): string | undefined {
-  return body?.match(/outcome: \*\*([a-z-]+)\*\*/)?.[1];
+  if (!body) return undefined;
+  return (
+    body.match(/^Task: \*\*[^\n]*outcome: \*\*([a-z-]+)\*\*/m)?.[1] ??
+    body.match(/^outcome: \*\*([a-z-]+)\*\*/m)?.[1]
+  );
 }
 
 /** Extract the ledger's "Blocking findings" list from a PR body, bounded —
@@ -125,29 +132,12 @@ export function prepareResume(
       return { resumed: false, note: `no open draft PR for '${branch}' — fresh run` };
     }
     const blockingContext = extractBlockingContext(open[0]?.body);
-    // Resume policy (design F): only a budget-exhausted VERIFIED partial is
-    // a resume anchor — its work passed the gate and was only cut short. A
-    // guardrail-red draft is NOT resumed: continuing a blocked diff anchors
-    // the next attempt on work the gate rejected. Its blocking set instead
-    // becomes a NEGATIVE constraint the next run's order prompts carry
-    // ("do not reintroduce these"). Any other (or unreadable) outcome
-    // conservatively starts fresh, disclosed.
     const priorOutcome = extractLedgerOutcome(open[0]?.body);
-    if (priorOutcome !== 'budget-exhausted') {
-      return {
-        resumed: false,
-        note:
-          `open draft for '${branch}' records outcome '${priorOutcome ?? 'unknown'}' — resume ` +
-          `only continues budget-exhausted verified partials; starting fresh` +
-          (priorOutcome === 'guardrail-red' && blockingContext
-            ? ', carrying its blocking findings as a negative constraint'
-            : ''),
-        ...(priorOutcome === 'guardrail-red' && blockingContext ? { blockingContext } : {}),
-      };
-    }
+    // Attempt accounting happens for ANY open draft, resume or fresh start:
+    // the cap is the human-escalation tripwire, and a guardrail-red chain
+    // that never counted its attempts would re-spend a full budget on the
+    // same unfixable finding forever (the cap unreachable by construction).
     run('git', ['fetch', 'origin', branch]);
-    // Count prior resume markers on the salvage head (bounded to the branch's
-    // own history vs the current default tree).
     const markers = run('git', [
       'rev-list',
       '--count',
@@ -155,12 +145,63 @@ export function prepareResume(
       'HEAD..FETCH_HEAD',
     ]).trim();
     const prior = Number(markers) || 0;
+    const redContext =
+      priorOutcome === 'guardrail-red' && blockingContext ? { blockingContext } : {};
     if (prior >= MAX_RESUME_ATTEMPTS) {
       return {
         resumed: false,
         note:
-          `salvage branch '${branch}' already resumed ${prior}x (cap ${MAX_RESUME_ATTEMPTS}) — ` +
-          'falling back to a fresh run; review or close the draft PR',
+          `the open draft for '${branch}' has consumed ${prior} attempt(s) ` +
+          `(cap ${MAX_RESUME_ATTEMPTS}) — a human must review or close the draft PR before ` +
+          'the lane spends more on this work; falling back to a fresh run',
+        ...redContext,
+      };
+    }
+    // Resume policy (design F): only a budget-exhausted VERIFIED partial is
+    // a resume anchor — its work passed the gate and was only cut short. A
+    // guardrail-red draft is NOT resumed: continuing a blocked diff anchors
+    // the next attempt on work the gate rejected. Its blocking set instead
+    // becomes a NEGATIVE constraint the next run's order prompts carry
+    // ("do not reintroduce these"). Any other (or unreadable) outcome
+    // conservatively starts fresh, disclosed. The attempt counter STILL
+    // advances (an empty commit built with commit-tree and pushed — the
+    // working tree is never touched, and the push carries zero content),
+    // so a repeating non-resumable chain reaches the cap above.
+    if (priorOutcome !== 'budget-exhausted') {
+      let counterNote = '';
+      try {
+        const tree = run('git', ['rev-parse', 'FETCH_HEAD^{tree}']).trim();
+        const marker = run('git', [
+          '-c',
+          `user.name=${BOT_IDENTITY.name}`,
+          '-c',
+          `user.email=${BOT_IDENTITY.email}`,
+          'commit-tree',
+          tree,
+          '-p',
+          'FETCH_HEAD',
+          '-m',
+          `${RESUME_MARKER} [skip ci]`,
+        ]).trim();
+        run('git', internalGitPushArgs(`${marker}:refs/heads/${branch}`));
+      } catch (e) {
+        counterNote =
+          `; the attempt counter could not advance ` +
+          `(${e instanceof Error ? e.message.split('\n')[0] : String(e)}) — the ` +
+          `${MAX_RESUME_ATTEMPTS}-attempt escalation may not engage`;
+      }
+      return {
+        resumed: false,
+        attempt: prior + 1,
+        note:
+          `open draft for '${branch}' records outcome '${priorOutcome ?? 'unknown'}' — resume ` +
+          `only continues budget-exhausted verified partials; starting fresh ` +
+          `(attempt ${prior + 1} of ${MAX_RESUME_ATTEMPTS} against this draft)` +
+          (priorOutcome === 'guardrail-red' && blockingContext
+            ? ', carrying its blocking findings as a negative constraint'
+            : '') +
+          counterNote,
+        ...redContext,
       };
     }
     run('git', ['checkout', '--detach', 'FETCH_HEAD']);

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -37,7 +37,7 @@ import { resolveModelSetting, type AgentRunResult } from './driver';
 import { AGENT_DRIVERS, knownDriverIds } from './registry';
 import type { RemediateTask } from './tasks';
 import { resolveDispatchedTask } from './dispatch';
-import { resumePromptNote } from './resume';
+import { priorBlockingNote, resumePromptNote } from './resume';
 import { realGit } from './git-ops';
 import { armGateForDriver } from './agent-trust';
 import {
@@ -52,9 +52,8 @@ import { recipeTierStep } from './recipes/complete';
 import { dispatchQueuedOrders } from './orders-phase';
 import type { AgentEnvelope, RemediateResult, RemediateRunOptions } from './outcome';
 
-// The outcome vocabulary lives in `./outcome` and the ledger renderer in
-// `./ledger-render` (module-size splits); both are re-exported so consumers
-// keep one import surface.
+// The outcome vocabulary (`./outcome`) and ledger renderer
+// (`./ledger-render`) are re-exported so consumers keep one import surface.
 export type {
   AgentEnvelope,
   RemediateGit,
@@ -125,8 +124,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   const lifetime = clampBudgetToTokenLifetime(opts.config.agent.budget, process.env);
   const budget = lifetime.budget;
   // The ONE salvage resolver (config.ts): explicit policy wins; 'auto'
-  // follows the task's declared completion shape. The CLI's land decision
-  // reads the same function, so the note here and the landing agree.
+  // follows the task's completion shape (the CLI's land decision agrees).
   const effectiveSalvage = salvageForTask(opts.config, task);
   // Budget-envelope disclosures — the ONE phrasing, split to
   // `budget-notes.ts` at the large-file bar.
@@ -212,9 +210,8 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   const hasRecipeCommits = agentBase !== baseHead;
 
   opts.onPhase?.('agent');
-  // Order-driven dispatch (section 3C, the scoped agent): with a queue in
-  // hand the agent tier receives ONE rendered work order per agent run,
-  // never the open-ended task prompt; null keeps the legacy path below.
+  // Order-driven dispatch (section 3C): with a queue in hand the agent tier
+  // receives ONE rendered work order per run; null keeps the legacy path.
   const ordered = await dispatchQueuedOrders(opts, {
     taskId: task.id,
     driver,
@@ -237,9 +234,12 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   const resumeNote = opts.resume
     ? resumePromptNote(opts.resume.attempt, opts.resume.blockingContext)
     : '';
+  // A prior BLOCKED attempt's findings constrain the legacy prompt too:
+  // an empty order queue must not silently drop the negative constraint.
+  const negativeNote = opts.priorBlocking ? priorBlockingNote(opts.priorBlocking) : '';
   const agentResult: AgentRunResult = await driver.run({
     cwd: opts.cwd,
-    prompt: task.prompt + budgetNote + resumeNote,
+    prompt: task.prompt + budgetNote + resumeNote + negativeNote,
     budget: { maxTurns: budget.maxTurns, maxMinutes: budget.maxMinutes },
     model: choice.native,
     env: opts.agentEnv ?? {},

--- a/src/remediate/run.ts
+++ b/src/remediate/run.ts
@@ -27,7 +27,12 @@
 import { runCorrectnessFloor } from '../analyzers/correctness/run';
 import { detectActiveLanguages } from '../languages';
 import { renderRemediateLedger } from './ledger-render';
-import { installFailedNote, verifyCommittedHead } from './verify';
+import {
+  guardrailRedNote,
+  installFailedNote,
+  verificationDisclosures,
+  verifyCommittedHead,
+} from './verify';
 import { resolveModelSetting, type AgentRunResult } from './driver';
 import { AGENT_DRIVERS, knownDriverIds } from './registry';
 import type { RemediateTask } from './tasks';
@@ -44,6 +49,7 @@ import {
 import { evaluateScoreHinge, healthHingeScores } from './score-hinge';
 import { salvageForTask } from './config';
 import { recipeTierStep } from './recipes/complete';
+import { dispatchQueuedOrders } from './orders-phase';
 import type { AgentEnvelope, RemediateResult, RemediateRunOptions } from './outcome';
 
 // The outcome vocabulary lives in `./outcome` and the ledger renderer in
@@ -206,6 +212,25 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   const hasRecipeCommits = agentBase !== baseHead;
 
   opts.onPhase?.('agent');
+  // Order-driven dispatch (section 3C, the scoped agent): with a queue in
+  // hand the agent tier receives ONE rendered work order per agent run,
+  // never the open-ended task prompt; null keeps the legacy path below.
+  const ordered = await dispatchQueuedOrders(opts, {
+    taskId: task.id,
+    driver,
+    choice,
+    runBudget: budget,
+    envelopeBase,
+    git,
+    baseHead,
+    agentBase,
+    entryFloor,
+    runFloor,
+    recipes: tier.recipes,
+    effectiveSalvage,
+  });
+  if (ordered) return finish(ordered);
+
   // Budget awareness (`budgetPromptNote`): appended by the runner, the one
   // place the effective budget is known, never baked into the task prompts.
   const budgetNote = budgetPromptNote(budget);
@@ -388,11 +413,7 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
     task: task.id,
     ...recipesDisclosure,
     envelope,
-    ...(verified.floor ? { floor: verified.floor } : {}),
-    ...(verified.floorAttribution ? { floorAttribution: verified.floorAttribution } : {}),
-    ...(verified.install ? { install: verified.install } : {}),
-    ...(verified.changedFiles ? { changedFiles: verified.changedFiles } : {}),
-    guardrailVerdict: guardrail.verdict,
+    ...verificationDisclosures(verified, guardrail),
     baseHead,
     head,
     ...evidenceTail,
@@ -426,38 +447,18 @@ export async function runRemediateTask(opts: RemediateRunOptions): Promise<Remed
   // a verification that could not run at all (a worktree or package manager
   // failure, the step named) all land nothing; the ledger says which it was.
   if (!guardrail.ran || !guardrail.passesGate) {
-    // Name the blocking findings in the ledger: on an ephemeral runner the
-    // diff evaporates with the job, so "did not pass" with no evidence made
-    // a BLOCKED attempt uninspectable (the workflow additionally uploads the
-    // attempt diff as a run artifact).
-    const evidence =
-      guardrail.blocking && guardrail.blocking.length > 0
-        ? `\n\nBlocking findings:\n${guardrail.blocking.map((b) => `- ${b}`).join('\n')}`
-        : '';
-    // Salvage disposition for a RAN-and-BLOCKED verdict: under draft-pr
-    // salvage the blocked attempt may be pushed as a RED draft (its own
-    // required guardrail check keeps it unmergeable), so the work and the
-    // exact blocking reasons survive the ephemeral runner and the next run
-    // can RESUME from them instead of starting over — guardrail-red is
-    // where the most valuable partial work used to die. An UNRUNNABLE
+    // The ONE guardrail-red phrasing (`guardrailRedNote`): blocking findings
+    // named as evidence (an ephemeral runner's diff evaporates with the
+    // job), and the salvage disposition for a RAN-and-BLOCKED verdict —
+    // under draft-pr salvage the blocked attempt may be pushed as a RED
+    // draft so the work and the exact blocking reasons survive the runner.
+    // A blocked draft is NOT a resume anchor (design F): the next run starts
+    // fresh with the blocking set as a negative constraint. An UNRUNNABLE
     // guardrail stays absolute: an unverified diff is never pushed.
-    const salvageNote =
-      guardrail.ran && effectiveSalvage === 'draft-pr'
-        ? ' Salvage policy: draft-pr — the BLOCKED attempt may be pushed as a red DRAFT ' +
-          '(unmergeable while the guardrail check is red) so the next run can resume from it.'
-        : '';
     return finish({
       outcome: 'guardrail-red',
       ...common,
-      note:
-        (guardrail.ran
-          ? `the guardrail did not pass (${guardrail.verdict}) — nothing merges. The attempt ` +
-            'diff is uploaded as a run artifact when this ran under Actions; locally the ' +
-            'branch stays for inspection.'
-          : `the guardrail could not run (${guardrail.verdict}) — nothing lands. An ` +
-            'agent-authored diff is never pushed unverified.') +
-        salvageNote +
-        evidence,
+      note: guardrailRedNote(guardrail, effectiveSalvage),
     });
   }
 

--- a/src/remediate/tasks.ts
+++ b/src/remediate/tasks.ts
@@ -98,6 +98,11 @@ export interface RemediateTask {
   };
 }
 
+/** The agent's human-handoff notes file — the ONE definition of the path
+ *  (the prompts below spell it out in prose; the orders phase allows it
+ *  through every envelope so a stop-and-explain never reads as sprawl). */
+export const REMEDIATION_NOTES_PATH = 'docs/DXKIT-REMEDIATION-NOTES.md';
+
 /** Ground rules appended to every task prompt — the non-negotiables. */
 export const SHARED_RULES = `
 Ground rules (non-negotiable):

--- a/src/remediate/tool-policy.ts
+++ b/src/remediate/tool-policy.ts
@@ -1,0 +1,51 @@
+/**
+ * The order-run tool policy: what an order-driven agent run may NOT do,
+ * rendered as permission-rule patterns for the driver's declared narrowing
+ * mechanism, with the disclosure every envelope carries.
+ *
+ * Installs are the frame's job (recipes run them pre-checked, with the
+ * lockfile re-synced), so the agent's own package-manager install commands
+ * are denied. The command list derives from `src/package-manager.ts` (the
+ * one home of package-manager vocabulary, Rule 2/5 discipline) — never a
+ * hardcoded list here.
+ */
+import { installCommandPrefixes } from '../package-manager';
+import type { AgentDriver } from './driver';
+import type { ToolPolicyDisclosure } from './outcome';
+
+/** The deny patterns for an order run: every package-manager install
+ *  command, in the agent CLI's `Tool(prefix:*)` permission-rule shape. */
+export function orderRunDisallowedTools(): readonly string[] {
+  return installCommandPrefixes().map((prefix) => `Bash(${prefix}:*)`);
+}
+
+/**
+ * Resolve the policy for one driver: applied through the driver's declared
+ * mechanism, or a DISCLOSED `none` when the driver cannot narrow tools (the
+ * envelope sweep is then the only enforcement — stated, never silent).
+ */
+export function resolveOrderToolPolicy(driver: AgentDriver): {
+  readonly disclosure: ToolPolicyDisclosure;
+  /** What to pass as `AgentRunOptions.tools` (undefined when unsupported). */
+  readonly tools?: { readonly disallowed: readonly string[] };
+} {
+  const disallowed = orderRunDisallowedTools();
+  if (driver.toolPolicy?.mechanism === 'disallowed-tools') {
+    return {
+      disclosure: {
+        mechanism: 'disallowed-tools',
+        disallowed,
+        cliRequirement: driver.toolPolicy.cliRequirement,
+      },
+      tools: { disallowed },
+    };
+  }
+  return {
+    disclosure: {
+      mechanism: 'none',
+      reason:
+        `driver ${driver.id} declares no tool-narrowing mechanism — the install ban is ` +
+        'prompt-advisory only, and the envelope sweep is the enforcement',
+    },
+  };
+}

--- a/src/remediate/verify.ts
+++ b/src/remediate/verify.ts
@@ -79,6 +79,61 @@ function guardrailShapeFor(verified: VerifyTreeResult): GuardrailGateResult {
   };
 }
 
+/** The verification-fact fields every post-verify outcome carries — ONE
+ *  projection (run.ts's agent tail, the recipe-only completion, and the
+ *  orders phase all spread it, so the three ledgers cannot drift). */
+export function verificationDisclosures(
+  verified: VerifyTreeResult,
+  guardrail: GuardrailGateResult,
+): {
+  floor?: VerifyTreeResult['floor'];
+  floorAttribution?: VerifyTreeResult['floorAttribution'];
+  install?: VerifyTreeResult['install'];
+  changedFiles?: VerifyTreeResult['changedFiles'];
+  guardrailVerdict: string;
+} {
+  return {
+    ...(verified.floor ? { floor: verified.floor } : {}),
+    ...(verified.floorAttribution ? { floorAttribution: verified.floorAttribution } : {}),
+    ...(verified.install ? { install: verified.install } : {}),
+    ...(verified.changedFiles ? { changedFiles: verified.changedFiles } : {}),
+    guardrailVerdict: guardrail.verdict,
+  };
+}
+
+/**
+ * The guardrail-red note, phrased once for the agent-diff surfaces (the
+ * legacy task path and the orders phase): the verdict, the blocking
+ * findings as evidence (an ephemeral runner's diff evaporates with the
+ * job), and the salvage disposition for a RAN-and-BLOCKED verdict.
+ */
+export function guardrailRedNote(
+  guardrail: GuardrailGateResult,
+  effectiveSalvage: 'discard' | 'draft-pr',
+): string {
+  const evidence =
+    guardrail.blocking && guardrail.blocking.length > 0
+      ? `\n\nBlocking findings:\n${guardrail.blocking.map((b) => `- ${b}`).join('\n')}`
+      : '';
+  const salvageNote =
+    guardrail.ran && effectiveSalvage === 'draft-pr'
+      ? ' Salvage policy: draft-pr — the BLOCKED attempt may be pushed as a red DRAFT ' +
+        '(unmergeable while the guardrail check is red) so the work and the exact blocking ' +
+        'findings survive the ephemeral runner. A blocked draft is not a resume anchor: the ' +
+        'next run starts fresh, with these findings as a negative constraint.'
+      : '';
+  return (
+    (guardrail.ran
+      ? `the guardrail did not pass (${guardrail.verdict}) — nothing merges. The attempt ` +
+        'diff is uploaded as a run artifact when this ran under Actions; locally the ' +
+        'branch stays for inspection.'
+      : `the guardrail could not run (${guardrail.verdict}) — nothing lands. An ` +
+        'agent-authored diff is never pushed unverified.') +
+    salvageNote +
+    evidence
+  );
+}
+
 /** The install-failed outcome's note: what failed, why it matters, the
  *  usual cause, and the install output as evidence. */
 export function installFailedNote(verified: VerifyTreeResult): string {

--- a/src/remediate/work-orders/floor-orders.ts
+++ b/src/remediate/work-orders/floor-orders.ts
@@ -13,7 +13,12 @@
  */
 import type { AttributedFloorFailure } from '../../analyzers/correctness/attribution';
 import { LOCKFILE_SYNC_LABEL } from '../../languages/capabilities/correctness';
-import { FLOOR_FINDING_KIND, floorFindingId, type WorkOrderFinding } from './types';
+import {
+  FLOOR_FINDING_KIND,
+  REPO_WIDE_ENVELOPE,
+  floorFindingId,
+  type WorkOrderFinding,
+} from './types';
 import {
   INSTALL_FORBIDDEN,
   VALUE_BAND,
@@ -220,7 +225,7 @@ export function floorOrders(
         findings,
         // A generic floor failure names no file; the whole tree minus
         // manifests is the honest envelope (a build/test fix is code).
-        envelope: { paths: [''], manifests: false },
+        envelope: { paths: [REPO_WIDE_ENVELOPE], manifests: false },
         constraints: { ...(install ? { install } : {}), forbidden: [INSTALL_FORBIDDEN] },
         done: doneFor('floor', findings),
         budget: deriveBudget(findings.length, ctx.capFor('floor-failure')),

--- a/src/remediate/work-orders/render.ts
+++ b/src/remediate/work-orders/render.ts
@@ -11,6 +11,7 @@ import { describeEntryLocation } from '../../gate/context';
 import { SHARED_RULES } from '../tasks';
 import { RECIPE_REGISTRY } from './recipes-registry';
 import type { WorkOrder, WorkOrderFinding } from './types';
+import { REPO_WIDE_ENVELOPE } from './types';
 import { WORK_ORDER_CLASSES, isBuiltinWorkOrderClass } from './types';
 
 function describeFinding(f: WorkOrderFinding): string {
@@ -99,7 +100,8 @@ export function renderWorkOrderPrompt(order: WorkOrder): string {
   }
   lines.push('');
   lines.push('Envelope (the only paths you may change):');
-  for (const p of order.envelope.paths) lines.push(`- ${p === '' ? '(repo root)' : p}`);
+  for (const p of order.envelope.paths)
+    lines.push(`- ${p === REPO_WIDE_ENVELOPE ? '(the entire repository)' : p}`);
   lines.push(
     order.envelope.manifests
       ? '- dependency manifests and lockfiles inside the envelope may change'

--- a/src/remediate/work-orders/types.ts
+++ b/src/remediate/work-orders/types.ts
@@ -170,9 +170,18 @@ export function floorFindingId(pack: string, label: string, finding?: string): s
   return finding === undefined ? key : `${key}#${finding}`;
 }
 
+/** The EXPLICIT repo-wide envelope marker (a floor failure with no finer
+ *  surface, e.g. a whole-build break). Deliberate, never an accident: the
+ *  containment predicate treats exactly this token as match-everything —
+ *  an empty-string entry no longer silently matches every path (the class
+ *  where `''` + `startsWith('')` made an envelope vacuous). `manifests`
+ *  still gates dependency files independently of the paths. */
+export const REPO_WIDE_ENVELOPE = '*';
+
 /** What the fix may touch. Derived from the findings, never from the agent. */
 export interface WorkOrderEnvelope {
-  /** Repo-relative paths (files, or directory prefixes ending in `/`). */
+  /** Repo-relative paths (files, or directory prefixes ending in `/`), or
+   *  the explicit `REPO_WIDE_ENVELOPE` marker. */
   readonly paths: readonly string[];
   /** Whether dependency manifests + lockfiles inside `paths` may change. */
   readonly manifests: boolean;

--- a/test/loop/order-scope.test.ts
+++ b/test/loop/order-scope.test.ts
@@ -1,0 +1,218 @@
+/**
+ * The Stop-gate's order scope (section 3C): the remediate lane writes the
+ * current order's done criterion to `.dxkit/loop/order.json`; the gate
+ * consumes it and blocks the agent's stop while the order's target findings
+ * are still present, handing back exactly the ids left to close. Absent
+ * file = every pre-existing gate behavior. Injection-guarded: the file is
+ * repo-local state, the check executes NOTHING (it post-processes the
+ * already-computed guardrail payload + floor outcome), and a malformed or
+ * hostile file degrades to a DISCLOSED skip, never a throw and never a
+ * widened execution.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { computeStopGate } from '../../src/loop/stop-gate';
+import type { FloorGateOutcome } from '../../src/loop/floor-gate';
+import type { GuardrailJsonPayload } from '../../src/baseline/check-renderers';
+import {
+  clearOrderScope,
+  readOrderScope,
+  unresolvedOrderIds,
+  writeOrderScope,
+  type OrderScope,
+} from '../../src/loop/order-scope';
+
+type Pair = GuardrailJsonPayload['pairs'][number];
+
+function payload(pairs: Pair[]): GuardrailJsonPayload {
+  const blocks = pairs.some((p) => p.blocks && !p.suppressedByAllowlist);
+  return {
+    verdict: { blocks, warns: false, refused: false, exitCode: blocks ? 1 : 0 },
+    attributionGaps: [],
+    baseline: { findingsCount: 10 },
+    current: { branch: 'main', commitSha: 'deadbeef', findingsCount: 12 },
+    pairs,
+  } as unknown as GuardrailJsonPayload;
+}
+
+function presentPair(currentId: string, over: Partial<Pair> = {}): Pair {
+  return {
+    status: 'persisted',
+    blocks: false,
+    warns: false,
+    confidence: 1,
+    kind: 'custom-check',
+    currentId,
+    reasons: [],
+    ...over,
+  } as Pair;
+}
+
+function scope(over: Partial<OrderScope> = {}): OrderScope {
+  return {
+    orderId: 'lint-located:src/a.ts',
+    absentIds: ['fp-one', 'fp-two'],
+    envelope: { paths: ['src/a.ts'], manifests: false },
+    verifier: 'guardrail',
+    command: 'npx vyuh-dxkit guardrail check',
+    ...over,
+  };
+}
+
+const NO_FLOOR: FloorGateOutcome = { kind: 'unavailable', reason: 'not wired' };
+const ranFloor = (failing: Array<{ pack: string; label: string }>): FloorGateOutcome => ({
+  kind: 'ran',
+  result: {
+    ran: true,
+    checks: failing.map((f) => ({ ...f, bin: 'x', status: 'fail' })),
+    blocks: failing.length > 0,
+  } as never,
+  netNew: [],
+});
+
+describe('the order-scope module (write / read / clear, validating reader)', () => {
+  it('round-trips a scope and clears it', () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-scope-'));
+    writeOrderScope(cwd, scope());
+    expect(readOrderScope(cwd).scope).toEqual(scope());
+    clearOrderScope(cwd);
+    expect(readOrderScope(cwd).scope).toBeNull();
+  });
+
+  it('absent file reads as no scope, with no problem', () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-scope-'));
+    expect(readOrderScope(cwd)).toEqual({ scope: null });
+  });
+
+  it('a malformed file is a DISCLOSED null, never a throw (injection guard)', () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-scope-'));
+    const file = path.join(cwd, '.dxkit', 'loop', 'order.json');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    for (const hostile of [
+      'not json at all',
+      '{"orderId": 42}',
+      '{"orderId":"x","absentIds":"not-an-array","verifier":"floor","command":"c","envelope":{"paths":[],"manifests":false}}',
+      '{"orderId":"x","absentIds":[],"verifier":"rm -rf /","command":"c","envelope":{"paths":[],"manifests":false}}',
+    ]) {
+      fs.writeFileSync(file, hostile);
+      const read = readOrderScope(cwd);
+      expect(read.scope).toBeNull();
+      expect(read.problem).toBeTruthy();
+    }
+  });
+});
+
+describe('unresolvedOrderIds (judged from computed state only — nothing executes)', () => {
+  it('guardrail verifier: an id is present when any pair carries it as currentId, allowlist-waived included', () => {
+    const json = payload([
+      presentPair('fp-one'),
+      presentPair('fp-waived', {
+        suppressedByAllowlist: { fingerprint: 'fp-waived', category: 'lint' },
+      } as Partial<Pair>),
+    ]);
+    const v = unresolvedOrderIds(
+      scope({ absentIds: ['fp-one', 'fp-waived', 'fp-closed'] }),
+      json,
+      NO_FLOOR,
+    );
+    expect(v.unresolved).toEqual(['fp-one', 'fp-waived']);
+  });
+
+  it('floor verifier: an id is open while its check key still fails; a not-run floor is undecidable (fail-open, disclosed)', () => {
+    const s = scope({
+      verifier: 'floor',
+      absentIds: ['typescript:tests#one', 'go:build'],
+    });
+    const failing = unresolvedOrderIds(
+      s,
+      payload([]),
+      ranFloor([{ pack: 'typescript', label: 'tests' }]),
+    );
+    expect(failing.unresolved).toEqual(['typescript:tests#one']);
+    const undecidable = unresolvedOrderIds(s, payload([]), NO_FLOOR);
+    expect(undecidable.unresolved).toEqual([]);
+    expect(undecidable.undecidable).toContain('did not run');
+  });
+});
+
+describe('computeStopGate with an order scope', () => {
+  it('blocks the stop while the order target findings are still present, naming exactly those ids', async () => {
+    const d = await computeStopGate(
+      '/repo',
+      { session_id: 's' },
+      async () => payload([presentPair('fp-one'), presentPair('unrelated')]),
+      () => NO_FLOOR,
+      () => ({ scope: scope() }),
+    );
+    expect(d.outcome).toBe('block-model');
+    expect(d.message).toContain('lint-located:src/a.ts');
+    expect(d.message).toContain('fp-one');
+    expect(d.message).not.toContain('fp-two\n- unrelated');
+    expect(d.message).not.toContain('unrelated');
+    expect(d.message).toContain('npx vyuh-dxkit guardrail check');
+    expect(d.event.allowed).toBe(false);
+  });
+
+  it('allows the stop once every target id is absent', async () => {
+    const d = await computeStopGate(
+      '/repo',
+      { session_id: 's' },
+      async () => payload([presentPair('unrelated')]),
+      () => NO_FLOOR,
+      () => ({ scope: scope() }),
+    );
+    expect(d.outcome).toBe('allow');
+  });
+
+  it('a floor-verifier scope the floor cannot answer allows, DISCLOSED (never a silent skip)', async () => {
+    const d = await computeStopGate(
+      '/repo',
+      { session_id: 's' },
+      async () => payload([]),
+      () => NO_FLOOR,
+      () => ({ scope: scope({ verifier: 'floor', absentIds: ['typescript:tests'] }) }),
+    );
+    expect(d.outcome).toBe('allow');
+    expect(d.message).toContain('could not verify work order');
+  });
+
+  it('no scope file keeps every pre-existing behavior (legacy allow)', async () => {
+    const d = await computeStopGate(
+      '/repo',
+      { session_id: 's' },
+      async () => payload([]),
+      () => NO_FLOOR,
+      () => ({ scope: null }),
+    );
+    expect(d.outcome).toBe('allow');
+    expect(d.message).toBe('');
+  });
+
+  it('a malformed scope file is a disclosed skip riding the allow (never a block, never a throw)', async () => {
+    const d = await computeStopGate(
+      '/repo',
+      { session_id: 's' },
+      async () => payload([]),
+      () => NO_FLOOR,
+      () => ({ scope: null, problem: 'order scope at /x is malformed — ignoring it' }),
+    );
+    expect(d.outcome).toBe('allow');
+    expect(d.message).toContain('malformed');
+  });
+
+  it('the guardrail net-new block still wins over the order scope (order checked only on an otherwise-allow)', async () => {
+    const d = await computeStopGate(
+      '/repo',
+      { session_id: 's' },
+      async () =>
+        payload([presentPair('fp-one', { blocks: true, status: 'added' } as Partial<Pair>)]),
+      () => NO_FLOOR,
+      () => ({ scope: scope() }),
+    );
+    expect(d.outcome).toBe('block-model');
+    // The net-new repair message, not the order message.
+    expect(d.message).not.toContain('work order');
+  });
+});

--- a/test/loop/order-scope.test.ts
+++ b/test/loop/order-scope.test.ts
@@ -5,9 +5,12 @@
  * are still present, handing back exactly the ids left to close. Absent
  * file = every pre-existing gate behavior. Injection-guarded: the file is
  * repo-local state, the check executes NOTHING (it post-processes the
- * already-computed guardrail payload + floor outcome), and a malformed or
- * hostile file degrades to a DISCLOSED skip, never a throw and never a
- * widened execution.
+ * already-computed guardrail payload + floor outcome), a malformed or
+ * hostile file degrades to a DISCLOSED skip, a foreign or stale file (a
+ * killed or concurrent lane's leftover) is neutralized by the session
+ * token binding, and a done question the gate's data cannot answer — an
+ * unobserved kind, a skipped floor check — is UNDECIDABLE with disclosure,
+ * never a silent done.
  */
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
@@ -17,7 +20,10 @@ import { computeStopGate } from '../../src/loop/stop-gate';
 import type { FloorGateOutcome } from '../../src/loop/floor-gate';
 import type { GuardrailJsonPayload } from '../../src/baseline/check-renderers';
 import {
+  ORDER_SCOPE_MAX_AGE_MS,
   clearOrderScope,
+  floorOrderDone,
+  orderScopePresent,
   readOrderScope,
   unresolvedOrderIds,
   writeOrderScope,
@@ -26,14 +32,20 @@ import {
 
 type Pair = GuardrailJsonPayload['pairs'][number];
 
-function payload(pairs: Pair[]): GuardrailJsonPayload {
+function payload(
+  pairs: Pair[],
+  extra: Partial<Pick<GuardrailJsonPayload, 'notObserved' | 'refExcludedKinds'>> = {},
+): GuardrailJsonPayload {
   const blocks = pairs.some((p) => p.blocks && !p.suppressedByAllowlist);
   return {
     verdict: { blocks, warns: false, refused: false, exitCode: blocks ? 1 : 0 },
     attributionGaps: [],
+    notObserved: [],
+    refExcludedKinds: [],
     baseline: { findingsCount: 10 },
     current: { branch: 'main', commitSha: 'deadbeef', findingsCount: 12 },
     pairs,
+    ...extra,
   } as unknown as GuardrailJsonPayload;
 }
 
@@ -50,40 +62,64 @@ function presentPair(currentId: string, over: Partial<Pair> = {}): Pair {
   } as Pair;
 }
 
+const WRITTEN_AT = new Date().toISOString();
+
 function scope(over: Partial<OrderScope> = {}): OrderScope {
   return {
     orderId: 'lint-located:src/a.ts',
     absentIds: ['fp-one', 'fp-two'],
+    kinds: ['custom-check'],
     envelope: { paths: ['src/a.ts'], manifests: false },
     verifier: 'guardrail',
     command: 'npx vyuh-dxkit guardrail check',
+    token: '<lane-session-token>',
+    writtenAt: WRITTEN_AT,
     ...over,
   };
 }
 
 const NO_FLOOR: FloorGateOutcome = { kind: 'unavailable', reason: 'not wired' };
-const ranFloor = (failing: Array<{ pack: string; label: string }>): FloorGateOutcome => ({
+const ranFloor = (
+  checks: Array<{ pack: string; label: string; status?: string; findings?: string[] }>,
+): FloorGateOutcome => ({
   kind: 'ran',
   result: {
     ran: true,
-    checks: failing.map((f) => ({ ...f, bin: 'x', status: 'fail' })),
-    blocks: failing.length > 0,
+    checks: checks.map((f) => ({ bin: 'x', status: 'fail', ...f })),
+    blocks: checks.some((c) => (c.status ?? 'fail') === 'fail'),
   } as never,
   netNew: [],
 });
 
-describe('the order-scope module (write / read / clear, validating reader)', () => {
-  it('round-trips a scope and clears it', () => {
+describe('the order-scope module (write / read / clear, validating + session-bound reader)', () => {
+  it('round-trips a scope under its own token and clears it', () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-scope-'));
     writeOrderScope(cwd, scope());
-    expect(readOrderScope(cwd).scope).toEqual(scope());
+    expect(orderScopePresent(cwd)).toBe(true);
+    expect(readOrderScope(cwd, { expectedToken: '<lane-session-token>' }).scope).toEqual(scope());
     clearOrderScope(cwd);
-    expect(readOrderScope(cwd).scope).toBeNull();
+    expect(orderScopePresent(cwd)).toBe(false);
+    expect(readOrderScope(cwd, { expectedToken: '<lane-session-token>' })).toEqual({ scope: null });
   });
 
-  it('absent file reads as no scope, with no problem', () => {
+  it('a foreign token, a session with no token, and an over-age file all read absent WITH disclosure (killed/concurrent lane)', () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-scope-'));
-    expect(readOrderScope(cwd)).toEqual({ scope: null });
+    writeOrderScope(cwd, scope());
+    const foreign = readOrderScope(cwd, { expectedToken: '<another-lane-token>' });
+    expect(foreign.scope).toBeNull();
+    expect(foreign.problem).toContain('different lane session');
+    const tokenless = readOrderScope(cwd, { expectedToken: undefined });
+    expect(tokenless.scope).toBeNull();
+    expect(tokenless.problem).toContain('no order token');
+    const stale = readOrderScope(cwd, {
+      expectedToken: '<lane-session-token>',
+      now: () => Date.parse(scope().writtenAt) + ORDER_SCOPE_MAX_AGE_MS + 60_000,
+    });
+    expect(stale.scope).toBeNull();
+    expect(stale.problem).toContain('stale');
+    // The file itself still exists (the cache-bypass question), so a cached
+    // ALLOW is never replayed over it.
+    expect(orderScopePresent(cwd)).toBe(true);
   });
 
   it('a malformed file is a DISCLOSED null, never a throw (injection guard)', () => {
@@ -93,13 +129,16 @@ describe('the order-scope module (write / read / clear, validating reader)', () 
     for (const hostile of [
       'not json at all',
       '{"orderId": 42}',
-      '{"orderId":"x","absentIds":"not-an-array","verifier":"floor","command":"c","envelope":{"paths":[],"manifests":false}}',
-      '{"orderId":"x","absentIds":[],"verifier":"rm -rf /","command":"c","envelope":{"paths":[],"manifests":false}}',
+      '{"orderId":"x","absentIds":"not-an-array","kinds":[],"verifier":"floor","command":"c","token":"<any-token>","writtenAt":"now","envelope":{"paths":[],"manifests":false}}',
+      '{"orderId":"x","absentIds":[],"kinds":[],"verifier":"rm -rf /","command":"c","token":"<any-token>","writtenAt":"now","envelope":{"paths":[],"manifests":false}}',
+      // The pre-session-binding shape (no token/writtenAt) is malformed too.
+      '{"orderId":"x","absentIds":[],"verifier":"floor","command":"c","envelope":{"paths":[],"manifests":false}}',
     ]) {
       fs.writeFileSync(file, hostile);
-      const read = readOrderScope(cwd);
+      const read = readOrderScope(cwd, { expectedToken: '<any-token>' });
       expect(read.scope).toBeNull();
       expect(read.problem).toBeTruthy();
+      expect(orderScopePresent(cwd)).toBe(true);
     }
   });
 });
@@ -120,20 +159,99 @@ describe('unresolvedOrderIds (judged from computed state only — nothing execut
     expect(v.unresolved).toEqual(['fp-one', 'fp-waived']);
   });
 
-  it('floor verifier: an id is open while its check key still fails; a not-run floor is undecidable (fail-open, disclosed)', () => {
-    const s = scope({
-      verifier: 'floor',
-      absentIds: ['typescript:tests#one', 'go:build'],
+  it('guardrail verifier: an UNOBSERVED target kind is undecidable, never silently done (Rule 19)', () => {
+    // The target finding has no pair — but its kind was not observed at all
+    // (custom-check dropped in ref-based mode / the check did not run), so
+    // "no pair" is absence of observation, not absence of the finding.
+    const notObserved = payload([], {
+      notObserved: [{ kind: 'custom-check', reason: 'linter unavailable', count: 3 }] as never,
     });
+    const a = unresolvedOrderIds(scope(), notObserved, NO_FLOOR);
+    expect(a.unresolved).toEqual([]);
+    expect(a.undecidable).toContain('custom-check');
+    const refExcluded = payload([], {
+      refExcludedKinds: [{ kind: 'custom-check', currentCount: 5 }],
+    });
+    const b = unresolvedOrderIds(scope(), refExcluded, NO_FLOOR);
+    expect(b.undecidable).toContain('custom-check');
+    // An observed kind still resolves normally.
+    const observed = unresolvedOrderIds(scope(), payload([]), NO_FLOOR);
+    expect(observed.unresolved).toEqual([]);
+    expect(observed.undecidable).toBeUndefined();
+  });
+
+  it('floor verifier: a SKIPPED or absent target check is undecidable with disclosure, never silently done', () => {
+    const s = scope({ verifier: 'floor', absentIds: ['typescript:tests', 'go:build'] });
+    const skipped = unresolvedOrderIds(
+      s,
+      payload([]),
+      ranFloor([
+        { pack: 'typescript', label: 'tests', status: 'skipped-timeout' },
+        // go:build absent from the run entirely
+      ]),
+    );
+    expect(skipped.unresolved).toEqual([]);
+    expect(skipped.undecidable).toContain('typescript:tests');
+    expect(skipped.undecidable).toContain('go:build');
     const failing = unresolvedOrderIds(
       s,
       payload([]),
-      ranFloor([{ pack: 'typescript', label: 'tests' }]),
+      ranFloor([
+        { pack: 'typescript', label: 'tests', status: 'fail' },
+        { pack: 'go', label: 'build', status: 'pass' },
+      ]),
     );
-    expect(failing.unresolved).toEqual(['typescript:tests#one']);
-    const undecidable = unresolvedOrderIds(s, payload([]), NO_FLOOR);
-    expect(undecidable.unresolved).toEqual([]);
-    expect(undecidable.undecidable).toContain('did not run');
+    expect(failing.unresolved).toEqual(['typescript:tests']);
+    const notRun = unresolvedOrderIds(s, payload([]), NO_FLOOR);
+    expect(notRun.unresolved).toEqual([]);
+    expect(notRun.undecidable).toContain('did not run');
+  });
+
+  it('floor verifier: finding-level done — own findings judged individually; sibling-only failure is done WITH disclosure', () => {
+    const s = scope({
+      orderId: 'unresolved-import:typescript:.',
+      verifier: 'floor',
+      absentIds: ['typescript:import-resolution#left-pad', 'typescript:import-resolution#lodash'],
+    });
+    // Own finding still present → open (exactly it, not the sibling).
+    const stillOpen = unresolvedOrderIds(
+      s,
+      payload([]),
+      ranFloor([
+        { pack: 'typescript', label: 'import-resolution', status: 'fail', findings: ['left-pad'] },
+      ]),
+    );
+    expect(stillOpen.unresolved).toEqual(['typescript:import-resolution#left-pad']);
+    // Own findings gone, check red only on a DIFFERENT order's finding →
+    // done with disclosure (the agent that fixed exactly its order may stop).
+    const siblingOnly = unresolvedOrderIds(
+      s,
+      payload([]),
+      ranFloor([
+        { pack: 'typescript', label: 'import-resolution', status: 'fail', findings: ['chalk'] },
+      ]),
+    );
+    expect(siblingOnly.unresolved).toEqual([]);
+    expect(siblingOnly.undecidable).toBeUndefined();
+    expect(siblingOnly.disclosure).toContain('outside this order');
+    // A finding-level id against a failure with no decomposition → undecided.
+    const noDecomposition = unresolvedOrderIds(
+      s,
+      payload([]),
+      ranFloor([{ pack: 'typescript', label: 'import-resolution', status: 'fail' }]),
+    );
+    expect(noDecomposition.unresolved).toEqual([]);
+    expect(noDecomposition.undecidable).toContain('finding decomposition');
+  });
+
+  it('floorOrderDone is the ONE computation (open / undecided / siblingOnly split)', () => {
+    const verdict = floorOrderDone(['a:b#one', 'a:b#two', 'a:c', 'a:missing'], [
+      { pack: 'a', label: 'b', status: 'fail', findings: ['one'] },
+      { pack: 'a', label: 'c', status: 'pass' },
+    ] as never);
+    expect(verdict.open).toEqual(['a:b#one']);
+    expect(verdict.siblingOnly).toEqual(['a:b#two']);
+    expect(verdict.undecided).toEqual(['a:missing']);
   });
 });
 
@@ -149,13 +267,12 @@ describe('computeStopGate with an order scope', () => {
     expect(d.outcome).toBe('block-model');
     expect(d.message).toContain('lint-located:src/a.ts');
     expect(d.message).toContain('fp-one');
-    expect(d.message).not.toContain('fp-two\n- unrelated');
     expect(d.message).not.toContain('unrelated');
     expect(d.message).toContain('npx vyuh-dxkit guardrail check');
     expect(d.event.allowed).toBe(false);
   });
 
-  it('allows the stop once every target id is absent', async () => {
+  it('allows the stop once every target id is absent (kind observed)', async () => {
     const d = await computeStopGate(
       '/repo',
       { session_id: 's' },
@@ -166,16 +283,45 @@ describe('computeStopGate with an order scope', () => {
     expect(d.outcome).toBe('allow');
   });
 
-  it('a floor-verifier scope the floor cannot answer allows, DISCLOSED (never a silent skip)', async () => {
-    const d = await computeStopGate(
+  it('an unobserved kind or an unanswerable floor allows, DISCLOSED (never a silent done)', async () => {
+    const unobserved = await computeStopGate(
+      '/repo',
+      { session_id: 's' },
+      async () => payload([], { refExcludedKinds: [{ kind: 'custom-check', currentCount: 2 }] }),
+      () => NO_FLOOR,
+      () => ({ scope: scope() }),
+    );
+    expect(unobserved.outcome).toBe('allow');
+    expect(unobserved.message).toContain('could not verify work order');
+    const floorless = await computeStopGate(
       '/repo',
       { session_id: 's' },
       async () => payload([]),
       () => NO_FLOOR,
       () => ({ scope: scope({ verifier: 'floor', absentIds: ['typescript:tests'] }) }),
     );
+    expect(floorless.outcome).toBe('allow');
+    expect(floorless.message).toContain('could not verify work order');
+  });
+
+  it('a sibling-only floor failure allows with the disclosure riding stderr', async () => {
+    const d = await computeStopGate(
+      '/repo',
+      { session_id: 's' },
+      async () => payload([]),
+      () =>
+        ranFloor([
+          { pack: 'typescript', label: 'import-resolution', status: 'fail', findings: ['chalk'] },
+        ]),
+      () => ({
+        scope: scope({
+          verifier: 'floor',
+          absentIds: ['typescript:import-resolution#left-pad'],
+        }),
+      }),
+    );
     expect(d.outcome).toBe('allow');
-    expect(d.message).toContain('could not verify work order');
+    expect(d.message).toContain('outside this order');
   });
 
   it('no scope file keeps every pre-existing behavior (legacy allow)', async () => {
@@ -190,16 +336,16 @@ describe('computeStopGate with an order scope', () => {
     expect(d.message).toBe('');
   });
 
-  it('a malformed scope file is a disclosed skip riding the allow (never a block, never a throw)', async () => {
+  it('a malformed/foreign/stale scope is a disclosed skip riding the allow (never a block, never a throw)', async () => {
     const d = await computeStopGate(
       '/repo',
       { session_id: 's' },
       async () => payload([]),
       () => NO_FLOOR,
-      () => ({ scope: null, problem: 'order scope at /x is malformed — ignoring it' }),
+      () => ({ scope: null, problem: 'order scope at /x belongs to a different lane session' }),
     );
     expect(d.outcome).toBe('allow');
-    expect(d.message).toContain('malformed');
+    expect(d.message).toContain('different lane session');
   });
 
   it('the guardrail net-new block still wins over the order scope (order checked only on an otherwise-allow)', async () => {

--- a/test/package-manager.test.ts
+++ b/test/package-manager.test.ts
@@ -9,6 +9,11 @@ import {
   addDevCommand,
   provisionCommand,
   pmAwareDevInstall,
+  installCommandPrefixes,
+  provisionArgv,
+  upgradeArgv,
+  LOCKFILES,
+  type PackageManager,
 } from '../src/package-manager';
 
 describe('detectPackageManager', () => {
@@ -118,5 +123,27 @@ describe('command builders', () => {
   it('addDevPrefix is the substring pmAwareDevInstall rewrites from', () => {
     expect(addDevPrefix('npm')).toBe('npm install --save-dev');
     expect(addDevPrefix('pnpm')).toBe('pnpm add -D');
+  });
+
+  it('installCommandPrefixes covers every PM, derived from the canonical builders', () => {
+    const prefixes = installCommandPrefixes();
+    // Every PM the lockfile registry knows contributes its provision,
+    // add-dev, and upgrade command prefixes (one source of truth: this is
+    // what the remediate order runs deny, so a builder change flows here
+    // with no consumer edit).
+    for (const pm of Object.keys(LOCKFILES) as PackageManager[]) {
+      const [pBin, pVerb] = provisionArgv(pm);
+      expect(prefixes).toContain(`${pBin} ${pVerb}`);
+      const [aBin, aVerb] = addDevPrefix(pm).split(' ');
+      expect(prefixes).toContain(`${aBin} ${aVerb}`);
+      const [uBin, uVerb] = upgradeArgv(pm, 'x', '1.0.0', 'dependencies');
+      expect(prefixes).toContain(`${uBin} ${uVerb}`);
+    }
+    // The documented short install aliases are included where they exist.
+    expect(prefixes).toContain('npm i');
+    expect(prefixes).toContain('pnpm i');
+    expect(prefixes).toContain('bun i');
+    // Deterministic (sorted, deduplicated).
+    expect([...prefixes]).toEqual([...new Set(prefixes)].sort());
   });
 });

--- a/test/package-manager.test.ts
+++ b/test/package-manager.test.ts
@@ -139,10 +139,24 @@ describe('command builders', () => {
       const [uBin, uVerb] = upgradeArgv(pm, 'x', '1.0.0', 'dependencies');
       expect(prefixes).toContain(`${uBin} ${uVerb}`);
     }
-    // The documented short install aliases are included where they exist.
-    expect(prefixes).toContain('npm i');
-    expect(prefixes).toContain('pnpm i');
-    expect(prefixes).toContain('bun i');
+    // The documented short install aliases and the other dependency-mutating
+    // verb families (update / remove) are included where they exist.
+    for (const alias of [
+      'npm i',
+      'pnpm i',
+      'bun i',
+      'npm update',
+      'pnpm update',
+      'yarn upgrade',
+      'bun update',
+      'npm uninstall',
+      'npm remove',
+      'pnpm remove',
+      'yarn remove',
+      'bun remove',
+    ]) {
+      expect(prefixes).toContain(alias);
+    }
     // Deterministic (sorted, deduplicated).
     expect([...prefixes]).toEqual([...new Set(prefixes)].sort());
   });

--- a/test/remediate/config-budgets.test.ts
+++ b/test/remediate/config-budgets.test.ts
@@ -44,6 +44,7 @@ function cfg(partial: Partial<RemediateConfig>): RemediateConfig {
     taskBudgets: {},
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
+    maxOrdersPerRun: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },
@@ -122,6 +123,22 @@ describe('resolveRemediateConfig parsing', () => {
     const config = resolveRemediateConfig(dir);
     expect(config.maxSpendPerRun).toBe(0);
     expect(config.taskBudgets).toEqual({});
+  });
+
+  it('maxOrdersPerRun defaults to 3, accepts 0 (dispatch off), rejects junk', () => {
+    expect(resolveRemediateConfig(repoWithPolicy({ enabled: true })).maxOrdersPerRun).toBe(3);
+    expect(
+      resolveRemediateConfig(repoWithPolicy({ enabled: true, maxOrdersPerRun: 0 })).maxOrdersPerRun,
+    ).toBe(0);
+    expect(
+      resolveRemediateConfig(repoWithPolicy({ enabled: true, maxOrdersPerRun: 5 })).maxOrdersPerRun,
+    ).toBe(5);
+    for (const junk of [-1, 1.5, 'many', null]) {
+      expect(
+        resolveRemediateConfig(repoWithPolicy({ enabled: true, maxOrdersPerRun: junk }))
+          .maxOrdersPerRun,
+      ).toBe(3);
+    }
   });
 });
 

--- a/test/remediate/dispatch.test.ts
+++ b/test/remediate/dispatch.test.ts
@@ -132,6 +132,7 @@ function fakeGit(): RemediateGit {
     head: () => head,
     sweepLeftovers: () => undefined,
     scrubRuntimeArtifacts: () => [],
+    enforceEnvelope: () => ({ dropped: [] }),
     hasDiff: () => {
       head = 'head1111';
       return true;
@@ -166,6 +167,7 @@ function config(): RemediateConfig {
     taskBudgets: {},
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
+    maxOrdersPerRun: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },

--- a/test/remediate/driver.test.ts
+++ b/test/remediate/driver.test.ts
@@ -180,6 +180,41 @@ describe('claude-code driver (exec injected)', () => {
     ]);
   });
 
+  it('renders tool narrowing as variadic --disallowedTools / --allowedTools argv entries', async () => {
+    const capture: { args?: readonly string[] } = {};
+    const d = runWith({ stdout: '{"num_turns": 2}' }, capture);
+    await d.run({
+      cwd: '/tmp',
+      prompt: 'p',
+      budget,
+      model: 'sonnet',
+      env: {},
+      tools: { disallowed: ['Bash(npm install:*)', 'Bash(pnpm add:*)'], allowed: ['Bash'] },
+    });
+    const args = [...(capture.args ?? [])];
+    const denyIdx = args.indexOf('--disallowedTools');
+    expect(denyIdx).toBeGreaterThan(-1);
+    expect(args.slice(denyIdx + 1, denyIdx + 3)).toEqual([
+      'Bash(npm install:*)',
+      'Bash(pnpm add:*)',
+    ]);
+    const allowIdx = args.indexOf('--allowedTools');
+    expect(args[allowIdx + 1]).toBe('Bash');
+    // Deny rules coexist with the skip-permissions flag (documented against
+    // the pinned CLI on the driver's toolPolicy declaration).
+    expect(args).toContain('--dangerously-skip-permissions');
+    expect(d.toolPolicy?.mechanism).toBe('disallowed-tools');
+    expect(d.toolPolicy?.cliRequirement).toContain('2.1.222');
+  });
+
+  it('omits the tool flags entirely when no tools option is given (legacy path unchanged)', async () => {
+    const capture: { args?: readonly string[] } = {};
+    const d = runWith({ stdout: '{"num_turns": 2}' }, capture);
+    await d.run({ cwd: '/tmp', prompt: 'p', budget, model: 'sonnet', env: {} });
+    expect(capture.args).not.toContain('--disallowedTools');
+    expect(capture.args).not.toContain('--allowedTools');
+  });
+
   it('strips ambient credentials unless explicitly injected, and arms the Stop-gate', async () => {
     const capture: { env?: Record<string, string | undefined> } = {};
     // Bracketed placeholder form: the fixture value carries no semantic weight

--- a/test/remediate/executor-landing.test.ts
+++ b/test/remediate/executor-landing.test.ts
@@ -43,6 +43,7 @@ function config(salvage: RemediateConfig['salvage'] = 'discard'): RemediateConfi
     taskBudgets: {},
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
+    maxOrdersPerRun: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -184,6 +184,7 @@ function fakeGit(opts: { diff?: boolean } = {}): RemediateGit {
     head: () => 'base0000',
     sweepLeftovers: () => undefined,
     scrubRuntimeArtifacts: () => [],
+    enforceEnvelope: () => ({ dropped: [] }),
     hasDiff: () => !!opts.diff,
   };
 }
@@ -211,6 +212,7 @@ function config(): RemediateConfig {
     taskBudgets: {},
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
+    maxOrdersPerRun: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },

--- a/test/remediate/git-ops.test.ts
+++ b/test/remediate/git-ops.test.ts
@@ -140,6 +140,27 @@ describe('enforceEnvelope (the envelope enforcement half — real git)', () => {
     expect(git('status', '--porcelain')).toBe('');
   });
 
+  it('an out-of-envelope RENAME restores the base file AND removes the new path (rename-aware)', () => {
+    // The destructive class: with rename detection, the diff lists only the
+    // rename's post-image, so enforcement deleted the base file and landed
+    // that change undisclosed. Both sides must be reverted.
+    const base = git('rev-parse', 'HEAD');
+    mkdirSync(join(repo, 'src'), { recursive: true });
+    writeFileSync(join(repo, 'src', 'inside.js'), 'ok\n');
+    git('mv', 'src.js', 'moved.js');
+    commitAll('agent renamed a file out of envelope + real work');
+
+    const ops = realGit(repo);
+    const result = ops.enforceEnvelope(base, (p) => p.startsWith('src/'));
+    expect(result.error).toBeUndefined();
+    expect([...result.dropped].sort()).toEqual(['moved.js', 'src.js']);
+    // The base file is BACK, the rename target is gone, in-envelope work kept.
+    expect(git('show', 'HEAD:src.js')).toBe('module.exports = 1;');
+    expect(() => git('show', 'HEAD:moved.js')).toThrow();
+    expect(git('show', 'HEAD:src/inside.js')).toBe('ok');
+    expect(git('status', '--porcelain')).toBe('');
+  });
+
   it('is a no-op (no commit) when everything is inside the envelope', () => {
     const base = git('rev-parse', 'HEAD');
     writeFileSync(join(repo, 'src.js'), 'module.exports = 2;\n');

--- a/test/remediate/git-ops.test.ts
+++ b/test/remediate/git-ops.test.ts
@@ -114,3 +114,47 @@ describe('hasDiff is a CONTENT question', () => {
     expect(ops.hasDiff(base)).toBe(true);
   });
 });
+
+describe('enforceEnvelope (the envelope enforcement half — real git)', () => {
+  it('reverts out-of-envelope commits (edits AND new files) in one disclosure commit, keeps in-envelope work', () => {
+    const base = git('rev-parse', 'HEAD');
+    // The "agent" edits an in-envelope file, an out-of-envelope tracked
+    // file, and adds a new out-of-envelope file.
+    mkdirSync(join(repo, 'src'), { recursive: true });
+    writeFileSync(join(repo, 'src', 'inside.js'), 'ok\n');
+    writeFileSync(join(repo, 'src.js'), 'module.exports = 99;\n');
+    writeFileSync(join(repo, 'stray.md'), 'sprawl\n');
+    commitAll('agent work');
+
+    const ops = realGit(repo);
+    const allowed = (p: string) => p.startsWith('src/');
+    const result = ops.enforceEnvelope(base, allowed);
+    expect(result.error).toBeUndefined();
+    expect([...result.dropped].sort()).toEqual(['src.js', 'stray.md']);
+    // The tree after enforcement: in-envelope work kept, sprawl reverted.
+    expect(git('show', 'HEAD:src/inside.js')).toBe('ok');
+    expect(git('show', 'HEAD:src.js')).toBe('module.exports = 1;');
+    expect(() => git('show', 'HEAD:stray.md')).toThrow();
+    // Disclosed as its own commit; the working tree is clean.
+    expect(git('log', '-1', '--format=%s')).toContain('out-of-envelope');
+    expect(git('status', '--porcelain')).toBe('');
+  });
+
+  it('is a no-op (no commit) when everything is inside the envelope', () => {
+    const base = git('rev-parse', 'HEAD');
+    writeFileSync(join(repo, 'src.js'), 'module.exports = 2;\n');
+    commitAll('agent work');
+    const head = git('rev-parse', 'HEAD');
+    const ops = realGit(repo);
+    const result = ops.enforceEnvelope(base, () => true);
+    expect(result).toEqual({ dropped: [] });
+    expect(git('rev-parse', 'HEAD')).toBe(head);
+  });
+
+  it('returns a named error instead of throwing when git cannot answer (fail-closed at the caller)', () => {
+    const ops = realGit(repo);
+    const result = ops.enforceEnvelope('not-a-ref', () => true);
+    expect(result.dropped).toEqual([]);
+    expect(result.error).toBeTruthy();
+  });
+});

--- a/test/remediate/orders-phase.test.ts
+++ b/test/remediate/orders-phase.test.ts
@@ -1,0 +1,444 @@
+/**
+ * The order-driven agent phase (section 3C): one order per agent run, value
+ * order, cap honored with disclosure; the order's derived budget IS the
+ * driver budget; the order scope file is written before each dispatch and
+ * cleared after (the Stop-gate's in-session done contract); envelope
+ * enforcement drops out-of-envelope commits with disclosure; a dead CLI
+ * stops the queue; the tool policy is applied through the driver's declared
+ * mechanism and disclosed either way; and the ledger renders the per-order
+ * sections. Open-ended tasks and order-less runs keep the legacy
+ * task-prompt path byte-identical (pinned by the existing run tests).
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runRemediateTask, type RemediateGit } from '../../src/remediate/run';
+import type { AgentDriver, AgentRunResult } from '../../src/remediate/driver';
+import type { RemediateConfig } from '../../src/remediate/config';
+import { DEFAULT_REMEDIATE_BUDGET } from '../../src/remediate/config';
+import type { CorrectnessFloorResult } from '../../src/analyzers/correctness/run';
+import { trustedLocalContext } from '../../src/analysis-trust';
+import type { RecipePhaseSummary } from '../../src/remediate/recipes/run-recipes';
+import { makeOrder } from './recipes/helpers';
+import type { WorkOrder } from '../../src/remediate/work-orders/types';
+import { orderRunDisallowedTools } from '../../src/remediate/tool-policy';
+import { installCommandPrefixes } from '../../src/package-manager';
+import { readOrderScope } from '../../src/loop/order-scope';
+
+const GREEN_FLOOR: CorrectnessFloorResult = { ran: true, checks: [], blocks: false };
+
+function tmpCwd(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-orders-'));
+}
+
+function agentOrder(id: string, overrides: Partial<WorkOrder> = {}): WorkOrder {
+  return makeOrder({
+    id,
+    class: 'floor-failure',
+    tier: 'agent',
+    envelope: { paths: ['src/'], manifests: false },
+    done: { absentIds: [`typescript:tests#${id}`], verifier: 'floor', command: 'floor check' },
+    budget: { turns: 12, minutes: 6, usd: 2, derivation: 'turns = derived(12)' },
+    ...overrides,
+  });
+}
+
+function summaryWith(orders: readonly WorkOrder[]): RecipePhaseSummary {
+  return {
+    ran: false,
+    disclosures: [],
+    selectedRecipeTier: 0,
+    selectedAgentTier: orders.length,
+    records: [],
+    agentOrders: orders,
+  };
+}
+
+interface GitScript {
+  diffAfterRuns?: boolean;
+  outside?: string[];
+  enforceError?: string;
+  sweepError?: string;
+}
+
+function fakeGit(script: GitScript = {}): RemediateGit & {
+  enforceCalls: Array<{ base: string; allowed: (p: string) => boolean }>;
+} {
+  let commits = 0;
+  const g = {
+    enforceCalls: [] as Array<{ base: string; allowed: (p: string) => boolean }>,
+    head: () => `head${commits}`,
+    sweepLeftovers: () => script.sweepError,
+    scrubRuntimeArtifacts: () => [] as string[],
+    hasDiff: () => (script.diffAfterRuns ?? true) && commits > 0,
+    enforceEnvelope: (base: string, allowed: (p: string) => boolean) => {
+      g.enforceCalls.push({ base, allowed });
+      commits += 1; // each dispatch that reaches enforcement counts as work
+      if (script.enforceError) return { dropped: [], error: script.enforceError };
+      const dropped = (script.outside ?? []).filter((p) => !allowed(p));
+      return { dropped };
+    },
+  };
+  return g;
+}
+
+function fakeDriver(
+  perRun: (runIndex: number) => Partial<AgentRunResult>,
+  overrides: Partial<AgentDriver> = {},
+): AgentDriver & { runs: Parameters<AgentDriver['run']>[0][]; scopes: unknown[] } {
+  const driver: AgentDriver & { runs: Parameters<AgentDriver['run']>[0][]; scopes: unknown[] } = {
+    id: 'fake-agent',
+    budgetSupport: { turns: 'enforced', cost: 'reported' },
+    credentialEnv: [],
+    cli: null,
+    resolveModel: (tier) => `fake-${tier}`,
+    available: () => ({ ok: true }),
+    run: async (opts) => {
+      driver.runs.push(opts);
+      // Capture the order scope AS SEEN DURING the run (written before,
+      // cleared after — this is the only window it exists in).
+      driver.scopes.push(readOrderScope(opts.cwd).scope);
+      return {
+        completed: true,
+        timedOut: false,
+        transcriptTail: '',
+        ...perRun(driver.runs.length - 1),
+      };
+    },
+    runs: [],
+    scopes: [],
+    ...overrides,
+  };
+  return driver;
+}
+
+function config(partial: Partial<RemediateConfig> = {}): RemediateConfig {
+  return {
+    enabled: true,
+    tasks: ['fix-build'],
+    unknownTasks: [],
+    schedule: 'weekly',
+    salvage: 'discard',
+    agent: { driver: 'fake-agent', model: 'auto', budget: DEFAULT_REMEDIATE_BUDGET },
+    taskBudgets: {},
+    maxSpendPerRun: 0,
+    maxDispatchBudget: 0,
+    resume: false,
+    maxOrdersPerRun: 3,
+    workOrders: { maxSliceSize: 25 },
+    recipes: { enabled: true },
+    ...partial,
+  };
+}
+
+function base(
+  driver: AgentDriver,
+  orders: readonly WorkOrder[],
+  extra: Partial<Parameters<typeof runRemediateTask>[0]> = {},
+) {
+  return {
+    cwd: tmpCwd(),
+    trust: trustedLocalContext(),
+    taskId: 'fix-vulns',
+    config: config(),
+    drivers: [driver],
+    git: fakeGit(),
+    runFloor: () => GREEN_FLOOR,
+    runGuardrail: async () => ({ verdict: 'PASSED', ran: true, passesGate: true }),
+    verifySeams: {
+      worktree: async <T>(_o: unknown, fn: (p: string) => Promise<T>) => fn('/tmp/fake-wt'),
+      install: () => ({ status: 'nothing-to-install' }) as const,
+      changedFiles: () => ['src/a.ts'],
+    },
+    armInLoopGate: () => ({ mode: 'backstop-only' as const, reason: 'test' }),
+    runRecipePhase: async () => summaryWith(orders),
+    ...extra,
+  };
+}
+
+describe('order dispatch: one order per run, value order, cap honored', () => {
+  it('dispatches each queued order in its own driver run, in queue order, with the rendered order prompt', async () => {
+    const driver = fakeDriver(() => ({}));
+    const orders = [agentOrder('floor-failure:a'), agentOrder('floor-failure:b')];
+    const r = await runRemediateTask(base(driver, orders));
+    expect(driver.runs).toHaveLength(2);
+    expect(driver.runs[0].prompt).toContain('Work order floor-failure:a');
+    expect(driver.runs[0].prompt).not.toContain('floor-failure:b');
+    expect(driver.runs[1].prompt).toContain('Work order floor-failure:b');
+    // The rendered order carries the shared ground rules and the budget note.
+    expect(driver.runs[0].prompt).toContain('Ground rules (non-negotiable)');
+    expect(driver.runs[0].prompt).toContain('Budget for this run (runner-enforced)');
+    expect(r.outcome).toBe('verified');
+    expect(r.orders?.records.map((rec) => [rec.orderId, rec.outcome])).toEqual([
+      ['floor-failure:a', 'completed'],
+      ['floor-failure:b', 'completed'],
+    ]);
+  });
+
+  it('honors remediate.maxOrdersPerRun: orders beyond the cap are disclosed, never silently dropped', async () => {
+    const driver = fakeDriver(() => ({}));
+    const orders = ['a', 'b', 'c', 'd', 'e'].map((s) => agentOrder(`floor-failure:${s}`));
+    const r = await runRemediateTask(
+      base(driver, orders, { config: config({ maxOrdersPerRun: 2 }) }),
+    );
+    expect(driver.runs).toHaveLength(2);
+    const notDispatched = (r.orders?.records ?? []).filter((x) => x.outcome === 'not-dispatched');
+    expect(notDispatched).toHaveLength(3);
+    expect(notDispatched[0].detail).toContain('maxOrdersPerRun');
+    expect(r.ledger).toContain('not-dispatched');
+  });
+
+  it('maxOrdersPerRun: 0 keeps the legacy task-prompt path (order dispatch off)', async () => {
+    const driver = fakeDriver(() => ({}));
+    const orders = [agentOrder('floor-failure:a')];
+    const r = await runRemediateTask(
+      base(driver, orders, { config: config({ maxOrdersPerRun: 0 }) }),
+    );
+    expect(driver.runs).toHaveLength(1);
+    // The legacy path sends the TASK prompt, not a work order.
+    expect(driver.runs[0].prompt).not.toContain('Work order');
+    expect(r.orders).toBeUndefined();
+  });
+
+  it('a summary carrying no order queue (no plan) keeps the legacy path under the default cap', async () => {
+    const driver = fakeDriver(() => ({}));
+    const legacySummary: RecipePhaseSummary = {
+      ran: false,
+      disclosures: [],
+      selectedRecipeTier: 0,
+      selectedAgentTier: 1,
+      records: [],
+      // agentOrders absent: planning failed or an older summary shape.
+    };
+    const r = await runRemediateTask(
+      base(driver, [], { runRecipePhase: async () => legacySummary }),
+    );
+    expect(driver.runs).toHaveLength(1);
+    expect(driver.runs[0].prompt).not.toContain('Work order');
+    expect(r.orders).toBeUndefined();
+  });
+});
+
+describe('derived budget reaches the driver, disclosed with its derivation', () => {
+  it("the order's planner-derived budget becomes the driver budget for that run", async () => {
+    const driver = fakeDriver(() => ({ turns: 5, costUsd: 0.5 }));
+    const order = agentOrder('floor-failure:a', {
+      budget: { turns: 17, minutes: 9, usd: 3, derivation: 'turns = derived(17)' },
+    });
+    const r = await runRemediateTask(base(driver, [order]));
+    expect(driver.runs[0].budget).toEqual({ maxTurns: 17, maxMinutes: 9 });
+    expect(r.orders?.records[0].budget.derivation).toBe('turns = derived(17)');
+    expect(r.ledger).toContain('turns = derived(17)');
+    // Envelope totals aggregate the per-order spends.
+    expect(r.envelope?.turns).toBe(5);
+    expect(r.envelope?.costUsd).toBe(0.5);
+  });
+
+  it('per-order minutes are clamped to the run budget remaining, disclosed', async () => {
+    const driver = fakeDriver(() => ({}));
+    const order = agentOrder('floor-failure:a', {
+      budget: { turns: 10, minutes: 500, usd: 1, derivation: 'd' },
+    });
+    const r = await runRemediateTask(base(driver, [order])); // run cap: 30 min
+    expect(driver.runs[0].budget.maxMinutes).toBeLessThanOrEqual(30);
+    expect(r.orders?.records[0].clamped).toContain('clamped');
+  });
+
+  it('run-budget exhaustion (spend) stops dispatch with the later orders deferred, and the verified diff lands as budget-exhausted', async () => {
+    // First order reports spend beyond the whole run cap.
+    const driver = fakeDriver(() => ({ costUsd: 99 }));
+    const orders = [agentOrder('floor-failure:a'), agentOrder('floor-failure:b')];
+    const r = await runRemediateTask(base(driver, orders));
+    expect(driver.runs).toHaveLength(1);
+    const second = r.orders?.records.find((x) => x.orderId === 'floor-failure:b');
+    expect(second?.outcome).toBe('not-dispatched');
+    expect(second?.detail).toContain('run budget is exhausted');
+    expect(r.outcome).toBe('budget-exhausted');
+    expect(r.partial).toBe(true);
+  });
+});
+
+describe('the order scope file (the Stop-gate in-session done contract)', () => {
+  it('is written before each dispatch with the order done criterion, and cleared after', async () => {
+    const driver = fakeDriver(() => ({}));
+    const order = agentOrder('floor-failure:a');
+    const opts = base(driver, [order]);
+    await runRemediateTask(opts);
+    // Seen during the run:
+    const scope = driver.scopes[0] as {
+      orderId: string;
+      absentIds: string[];
+      verifier: string;
+      envelope: { paths: string[] };
+    } | null;
+    expect(scope).not.toBeNull();
+    expect(scope!.orderId).toBe('floor-failure:a');
+    expect(scope!.absentIds).toEqual(['typescript:tests#floor-failure:a']);
+    expect(scope!.verifier).toBe('floor');
+    expect(scope!.envelope.paths).toEqual(['src/']);
+    // Cleared after the dispatch:
+    expect(readOrderScope(opts.cwd).scope).toBeNull();
+  });
+
+  it('is cleared even when the driver throws', async () => {
+    const driver = fakeDriver(() => ({}));
+    driver.run = async (opts) => {
+      driver.runs.push(opts);
+      throw new Error('driver crashed');
+    };
+    const order = agentOrder('floor-failure:a');
+    const opts = base(driver, [order]);
+    await expect(runRemediateTask(opts)).rejects.toThrow('driver crashed');
+    expect(readOrderScope(opts.cwd).scope).toBeNull();
+  });
+});
+
+describe('envelope enforcement at the sweep', () => {
+  it('drops committed out-of-envelope hunks with disclosure in the records and the ledger', async () => {
+    const driver = fakeDriver(() => ({}));
+    const git = fakeGit({ outside: ['README.md', 'src/ok.ts', '.github/workflows/x.yml'] });
+    const order = agentOrder('floor-failure:a');
+    const r = await runRemediateTask(base(driver, [order], { git }));
+    expect(git.enforceCalls).toHaveLength(1);
+    expect(r.orders?.records[0].droppedPaths).toEqual(['README.md', '.github/workflows/x.yml']);
+    expect(r.ledger).toContain('envelope enforcement DROPPED');
+    expect(r.ledger).toContain('README.md');
+    expect(r.outcome).toBe('verified');
+  });
+
+  it('always allows the remediation notes file through the envelope', async () => {
+    const driver = fakeDriver(() => ({}));
+    const git = fakeGit({ outside: ['docs/DXKIT-REMEDIATION-NOTES.md'] });
+    const r = await runRemediateTask(base(driver, [agentOrder('floor-failure:a')], { git }));
+    expect(r.orders?.records[0].droppedPaths).toBeUndefined();
+  });
+
+  it('an enforcement failure is fail-closed: nothing lands, the step named', async () => {
+    const driver = fakeDriver(() => ({}));
+    const git = fakeGit({ enforceError: 'git checkout failed' });
+    const r = await runRemediateTask(base(driver, [agentOrder('floor-failure:a')], { git }));
+    expect(r.outcome).toBe('sweep-failed');
+    expect(r.note).toContain('envelope');
+    expect(r.note).toContain('git checkout failed');
+  });
+});
+
+describe('dead-CLI and failure arms', () => {
+  it('an uncontradicted never-ran stops the queue: later orders are not dispatched, outcome agent-never-ran', async () => {
+    const driver = fakeDriver(() => ({
+      completed: false,
+      neverRan: { reason: 'credit exhausted' },
+    }));
+    const git = fakeGit({ diffAfterRuns: false });
+    // never-ran path skips enforcement, so no commits accrue
+    git.enforceEnvelope = (b, a) => {
+      git.enforceCalls.push({ base: b, allowed: a });
+      return { dropped: [] };
+    };
+    const orders = [agentOrder('floor-failure:a'), agentOrder('floor-failure:b')];
+    const r = await runRemediateTask(base(driver, orders, { git }));
+    expect(driver.runs).toHaveLength(1);
+    expect(r.outcome).toBe('agent-never-ran');
+    expect(r.note).toContain('credit exhausted');
+    const second = r.orders?.records.find((x) => x.orderId === 'floor-failure:b');
+    expect(second?.outcome).toBe('not-dispatched');
+  });
+});
+
+describe('tool policy: narrowed through the driver mechanism, disclosed either way', () => {
+  it('a driver declaring disallowed-tools receives the package-manager deny patterns, disclosed in the envelope', async () => {
+    const driver = fakeDriver(() => ({}), {
+      toolPolicy: { mechanism: 'disallowed-tools', cliRequirement: 'pinned CLI supports it' },
+    });
+    const r = await runRemediateTask(base(driver, [agentOrder('floor-failure:a')]));
+    expect(driver.runs[0].tools?.disallowed).toEqual(orderRunDisallowedTools());
+    expect(r.envelope?.toolPolicy?.mechanism).toBe('disallowed-tools');
+    expect(r.ledger).toContain('tool policy: disallowed-tools');
+    // Derived from package-manager.ts, never hardcoded: every known install
+    // prefix appears as a deny pattern.
+    for (const prefix of installCommandPrefixes()) {
+      expect(driver.runs[0].tools?.disallowed).toContain(`Bash(${prefix}:*)`);
+    }
+  });
+
+  it('a driver with no mechanism gets NO tools option and a disclosed none policy', async () => {
+    const driver = fakeDriver(() => ({}));
+    const r = await runRemediateTask(base(driver, [agentOrder('floor-failure:a')]));
+    expect(driver.runs[0].tools).toBeUndefined();
+    expect(r.envelope?.toolPolicy?.mechanism).toBe('none');
+    expect(r.ledger).toContain('tool policy: NOT applied');
+  });
+});
+
+describe('negative constraint from a prior blocked attempt', () => {
+  it('priorBlocking is rendered into every order prompt and disclosed in the ledger', async () => {
+    const driver = fakeDriver(() => ({}));
+    const orders = [agentOrder('floor-failure:a'), agentOrder('floor-failure:b')];
+    const r = await runRemediateTask(
+      base(driver, orders, { priorBlocking: '- [secret] src/config.ts' }),
+    );
+    for (const run of driver.runs) {
+      expect(run.prompt).toContain('NEGATIVE CONSTRAINT');
+      expect(run.prompt).toContain('src/config.ts');
+    }
+    expect(r.orders?.priorBlockingApplied).toBe(true);
+    expect(r.ledger).toContain('negative constraint');
+  });
+});
+
+describe('refused recipe orders fall through to the agent tier in-run', () => {
+  it('a recipe-only plan whose recipes all refused dispatches those orders to the agent instead of ending recipes-refused', async () => {
+    const driver = fakeDriver(() => ({}));
+    const refusedOrder = agentOrder('stale-lockfile:package.json', {
+      class: 'stale-lockfile',
+      tier: 'recipe',
+      recipe: 'lockfile-sync',
+    });
+    const summary: RecipePhaseSummary = {
+      ran: true,
+      disclosures: [],
+      selectedRecipeTier: 1,
+      selectedAgentTier: 0,
+      records: [
+        {
+          orderId: refusedOrder.id,
+          class: 'stale-lockfile',
+          recipe: 'lockfile-sync',
+          outcome: { kind: 'refused', reason: 'yarn has no dry-run' },
+        },
+      ],
+      agentOrders: [refusedOrder],
+    };
+    const r = await runRemediateTask(base(driver, [], { runRecipePhase: async () => summary }));
+    expect(r.outcome).toBe('verified');
+    expect(driver.runs).toHaveLength(1);
+    expect(driver.runs[0].prompt).toContain('Work order stale-lockfile:package.json');
+    // Both sections render: the recipe refusal AND the order dispatch.
+    expect(r.ledger).toContain('refused, yarn has no dry-run');
+    expect(r.ledger).toContain('Work-order dispatches');
+  });
+});
+
+describe('the per-order done disclosure', () => {
+  it('floor-verifier orders report closed/open against the verified floor', async () => {
+    const driver = fakeDriver(() => ({}));
+    const failing: CorrectnessFloorResult = {
+      ran: true,
+      checks: [
+        { pack: 'typescript', label: 'tests', bin: 'npx', status: 'fail' },
+      ] as unknown as CorrectnessFloorResult['checks'],
+      blocks: true,
+    };
+    // The entry floor already carries the failure (pre-existing), so the
+    // verified outcome is not floor-red; the order's target id stays OPEN.
+    const r = await runRemediateTask(
+      base(driver, [agentOrder('floor-failure:a')], {
+        runFloor: () => failing,
+        entryFloor: failing,
+      }),
+    );
+    expect(r.orders?.records[0].doneAfterVerify).toEqual({ closed: 0, open: 1 });
+    expect(r.ledger).toContain('still open');
+  });
+});

--- a/test/remediate/orders-phase.test.ts
+++ b/test/remediate/orders-phase.test.ts
@@ -13,7 +13,11 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { runRemediateTask, type RemediateGit } from '../../src/remediate/run';
+import {
+  renderRemediateLedger,
+  runRemediateTask,
+  type RemediateGit,
+} from '../../src/remediate/run';
 import type { AgentDriver, AgentRunResult } from '../../src/remediate/driver';
 import type { RemediateConfig } from '../../src/remediate/config';
 import { DEFAULT_REMEDIATE_BUDGET } from '../../src/remediate/config';
@@ -24,7 +28,7 @@ import { makeOrder } from './recipes/helpers';
 import type { WorkOrder } from '../../src/remediate/work-orders/types';
 import { orderRunDisallowedTools } from '../../src/remediate/tool-policy';
 import { installCommandPrefixes } from '../../src/package-manager';
-import { readOrderScope } from '../../src/loop/order-scope';
+import { ORDER_TOKEN_ENV, readOrderScope } from '../../src/loop/order-scope';
 
 const GREEN_FLOOR: CorrectnessFloorResult = { ran: true, checks: [], blocks: false };
 
@@ -97,8 +101,11 @@ function fakeDriver(
     run: async (opts) => {
       driver.runs.push(opts);
       // Capture the order scope AS SEEN DURING the run (written before,
-      // cleared after — this is the only window it exists in).
-      driver.scopes.push(readOrderScope(opts.cwd).scope);
+      // cleared after — this is the only window it exists in), bound by the
+      // session token the runner injected into the agent env.
+      driver.scopes.push(
+        readOrderScope(opts.cwd, { expectedToken: opts.env[ORDER_TOKEN_ENV] }).scope,
+      );
       return {
         completed: true,
         timedOut: false,
@@ -245,6 +252,37 @@ describe('derived budget reaches the driver, disclosed with its derivation', () 
     expect(r.orders?.records[0].clamped).toContain('clamped');
   });
 
+  it('turns accumulate across orders against runBudget.maxTurns: clamped, then exhausted with disclosure', async () => {
+    // Run cap 60 turns; each order derives 50. Order a spends 50, b is
+    // clamped to the remaining 10, c finds the turn budget exhausted.
+    const driver = fakeDriver(() => ({ turns: 50 }));
+    const orders = ['a', 'b', 'c'].map((x) =>
+      agentOrder(`floor-failure:${x}`, {
+        budget: { turns: 50, minutes: 5, usd: 1, derivation: 'd' },
+      }),
+    );
+    const r = await runRemediateTask(
+      base(driver, orders, {
+        config: config({
+          agent: {
+            driver: 'fake-agent',
+            model: 'auto',
+            budget: { ...DEFAULT_REMEDIATE_BUDGET, maxTurns: 60 },
+          },
+        }),
+      }),
+    );
+    expect(driver.runs).toHaveLength(2);
+    expect(driver.runs[0].budget.maxTurns).toBe(50);
+    expect(driver.runs[1].budget.maxTurns).toBe(10);
+    const recB = r.orders?.records.find((x) => x.orderId === 'floor-failure:b');
+    expect(recB?.clamped).toContain('turns clamped 50 to 10');
+    const recC = r.orders?.records.find((x) => x.orderId === 'floor-failure:c');
+    expect(recC?.outcome).toBe('not-dispatched');
+    expect(recC?.detail).toContain('turns');
+    expect(r.outcome).toBe('budget-exhausted');
+  });
+
   it('run-budget exhaustion (spend) stops dispatch with the later orders deferred, and the verified diff lands as budget-exhausted', async () => {
     // First order reports spend beyond the whole run cap.
     const driver = fakeDriver(() => ({ costUsd: 99 }));
@@ -269,13 +307,17 @@ describe('the order scope file (the Stop-gate in-session done contract)', () => 
     const scope = driver.scopes[0] as {
       orderId: string;
       absentIds: string[];
+      kinds: string[];
       verifier: string;
+      token: string;
       envelope: { paths: string[] };
     } | null;
     expect(scope).not.toBeNull();
     expect(scope!.orderId).toBe('floor-failure:a');
     expect(scope!.absentIds).toEqual(['typescript:tests#floor-failure:a']);
+    expect(scope!.kinds).toEqual([]);
     expect(scope!.verifier).toBe('floor');
+    expect(scope!.token).toBeTruthy();
     expect(scope!.envelope.paths).toEqual(['src/']);
     // Cleared after the dispatch:
     expect(readOrderScope(opts.cwd).scope).toBeNull();
@@ -420,25 +462,138 @@ describe('refused recipe orders fall through to the agent tier in-run', () => {
   });
 });
 
-describe('the per-order done disclosure', () => {
-  it('floor-verifier orders report closed/open against the verified floor', async () => {
+describe('manifests: false is ENFORCED at the sweep', () => {
+  it('drops a dependency-manifest change even inside the envelope paths, disclosed', async () => {
     const driver = fakeDriver(() => ({}));
-    const failing: CorrectnessFloorResult = {
-      ran: true,
-      checks: [
-        { pack: 'typescript', label: 'tests', bin: 'npx', status: 'fail' },
-      ] as unknown as CorrectnessFloorResult['checks'],
-      blocks: true,
-    };
+    const cwd = tmpCwd();
+    // A real package.json plus a source file makes the TypeScript pack
+    // active (detection needs manifest AND source), so the DEFAULT manifest
+    // predicate (pack-declared patterns, Rule 6) recognizes the manifest —
+    // no injected probe.
+    fs.writeFileSync(path.join(cwd, 'package.json'), '{"name":"fx"}');
+    fs.mkdirSync(path.join(cwd, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'src', 'index.ts'), 'export const x = 1;\n');
+    const git = fakeGit({ outside: ['package.json', 'src/ok.ts'] });
+    const order = agentOrder('floor-failure:a', {
+      envelope: { paths: ['src/', 'package.json'], manifests: false },
+    });
+    const r = await runRemediateTask(base(driver, [order], { cwd, git }));
+    expect(r.orders?.records[0].droppedPaths).toEqual(['package.json']);
+    expect(r.ledger).toContain('manifest-excluded');
+  });
+
+  it('manifests: true keeps manifest changes inside the envelope', async () => {
+    const driver = fakeDriver(() => ({}));
+    const cwd = tmpCwd();
+    fs.writeFileSync(path.join(cwd, 'package.json'), '{"name":"fx"}');
+    fs.mkdirSync(path.join(cwd, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'src', 'index.ts'), 'export const x = 1;\n');
+    const git = fakeGit({ outside: ['package.json'] });
+    const order = agentOrder('floor-failure:a', {
+      envelope: { paths: ['src/', 'package.json'], manifests: true },
+    });
+    const r = await runRemediateTask(base(driver, [order], { cwd, git }));
+    expect(r.orders?.records[0].droppedPaths).toBeUndefined();
+  });
+});
+
+describe('starvation guard: a no-diff fallback run stays non-clean', () => {
+  it('refused-recipe fallback orders that landed nothing yield recipes-refused (never a green no-op)', async () => {
+    const driver = fakeDriver(() => ({}));
+    const fallback = agentOrder('stale-lockfile:package.json', {
+      class: 'stale-lockfile',
+      tier: 'recipe',
+      recipe: 'lockfile-sync',
+    });
+    const git = fakeGit({ diffAfterRuns: false });
+    const r = await runRemediateTask(base(driver, [fallback], { git }));
+    expect(r.outcome).toBe('recipes-refused');
+    expect(r.note).toContain('stale-lockfile:package.json');
+    expect(r.note).toContain('not clean');
+  });
+
+  it('a pure agent-tier queue with no diff stays an honest no-op', async () => {
+    const driver = fakeDriver(() => ({}));
+    const git = fakeGit({ diffAfterRuns: false });
+    const r = await runRemediateTask(base(driver, [agentOrder('floor-failure:a')], { git }));
+    expect(r.outcome).toBe('no-op');
+  });
+});
+
+describe('the legacy path keeps the negative constraint (maxOrdersPerRun: 0)', () => {
+  it('priorBlocking is rendered into the legacy task prompt too, never silently dropped', async () => {
+    const driver = fakeDriver(() => ({}));
+    const r = await runRemediateTask(
+      base(driver, [], {
+        config: config({ maxOrdersPerRun: 0 }),
+        priorBlocking: '- [secret] src/config.ts',
+      }),
+    );
+    expect(driver.runs).toHaveLength(1);
+    expect(driver.runs[0].prompt).not.toContain('Work order');
+    expect(driver.runs[0].prompt).toContain('NEGATIVE CONSTRAINT');
+    expect(driver.runs[0].prompt).toContain('src/config.ts');
+    // No diff on this fake tree — the legacy no-op arm; the prompt content
+    // above is the assertion that matters.
+    expect(r.outcome).toBe('no-op');
+  });
+});
+
+describe('ledger honesty for the recipe section', () => {
+  it('disabled AND plan-broken renders BOTH facts (the disabled note must not hide the planError)', () => {
+    const ledger = renderRemediateLedger({
+      outcome: 'no-op',
+      task: 'fix-build',
+      recipes: {
+        ran: false,
+        disabled: true,
+        planError: 'gather exploded',
+        disclosures: [],
+        selectedRecipeTier: 0,
+        selectedAgentTier: 0,
+        records: [],
+      },
+    });
+    expect(ledger).toContain('Recipes are disabled by policy');
+    expect(ledger).toContain('gather exploded');
+  });
+});
+
+describe('the per-order done disclosure', () => {
+  const failing: CorrectnessFloorResult = {
+    ran: true,
+    checks: [
+      { pack: 'typescript', label: 'tests', bin: 'npx', status: 'fail' },
+    ] as unknown as CorrectnessFloorResult['checks'],
+    blocks: true,
+  };
+
+  it('floor-verifier orders report closed/open against the verified floor (check-level id)', async () => {
+    const driver = fakeDriver(() => ({}));
+    const order = agentOrder('floor-failure:a', {
+      done: { absentIds: ['typescript:tests'], verifier: 'floor', command: 'floor check' },
+    });
     // The entry floor already carries the failure (pre-existing), so the
     // verified outcome is not floor-red; the order's target id stays OPEN.
     const r = await runRemediateTask(
-      base(driver, [agentOrder('floor-failure:a')], {
-        runFloor: () => failing,
-        entryFloor: failing,
-      }),
+      base(driver, [order], { runFloor: () => failing, entryFloor: failing }),
     );
-    expect(r.orders?.records[0].doneAfterVerify).toEqual({ closed: 0, open: 1 });
+    expect(r.orders?.records[0].doneAfterVerify).toEqual({ closed: 0, open: 1, undecided: 0 });
     expect(r.ledger).toContain('still open');
+  });
+
+  it('a target check the verification did not observe is UNDECIDED, never claimed closed', async () => {
+    const driver = fakeDriver(() => ({}));
+    // The order targets a check the verified floor never ran (absent from
+    // its checks) — the pre-fix ledger claimed it closed.
+    const order = agentOrder('floor-failure:b', {
+      done: { absentIds: ['go:build'], verifier: 'floor', command: 'floor check' },
+    });
+    const r = await runRemediateTask(
+      base(driver, [order], { runFloor: () => failing, entryFloor: failing }),
+    );
+    expect(r.orders?.records[0].doneAfterVerify).toEqual({ closed: 0, open: 0, undecided: 1 });
+    expect(r.ledger).toContain('undecided');
+    expect(r.ledger).toContain('not claimed closed');
   });
 });

--- a/test/remediate/recipes/frame.test.ts
+++ b/test/remediate/recipes/frame.test.ts
@@ -21,6 +21,7 @@ function fakeGit(diff: boolean): RemediateGit {
     head: () => (diff ? 'head1111' : 'base0000'),
     sweepLeftovers: () => undefined,
     scrubRuntimeArtifacts: () => [],
+    enforceEnvelope: () => ({ dropped: [] }),
     hasDiff: () => diff,
   };
 }
@@ -51,6 +52,7 @@ function config(): RemediateConfig {
     taskBudgets: {},
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
+    maxOrdersPerRun: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },
@@ -104,6 +106,7 @@ function recipeCommitGit(diffs: Record<string, boolean>): RemediateGit {
     head: () => (calls++ === 0 ? 'base0000' : 'recipe111'),
     sweepLeftovers: () => undefined,
     scrubRuntimeArtifacts: () => [],
+    enforceEnvelope: () => ({ dropped: [] }),
     hasDiff: (base: string) => diffs[base] ?? false,
   };
 }

--- a/test/remediate/recipes/run-recipes.test.ts
+++ b/test/remediate/recipes/run-recipes.test.ts
@@ -358,6 +358,79 @@ describe('runRecipePhaseForTask', () => {
     expect(git.commits[0].message).toContain('fix(stale-lockfile)');
   });
 
+  it('a refused/failed recipe order JOINS the agent queue (agentOrders), in plan order', async () => {
+    const cwd = tempRepo({
+      'package.json': '{"name":"fx"}',
+      'package-lock.json': '{}',
+      'src/index.ts': 'export const x = 1;\n',
+      '.dxkit/policy.json': '{}',
+    });
+    const git = fakeGit();
+    // The install never dirties the lockfile, so the lockfile-sync recipe
+    // reports applied with no in-envelope change and FAILS at the envelope
+    // step — the class of order the agent tier must pick up in-run.
+    const { exec } = fakeExec(() => undefined);
+    const entryFloor = floorWith([
+      {
+        pack: 'typescript',
+        label: 'lockfile-sync',
+        bin: 'npm',
+        args: ['ci', '--dry-run'],
+        status: 'fail',
+        output: 'EUSAGE',
+      },
+      // A plain failing floor check: the agent-only floor-failure class.
+      { pack: 'typescript', label: 'tests', bin: 'npx', args: ['vitest'], status: 'fail' },
+    ] as CorrectnessFloorResult['checks']);
+    const summary = await runRecipePhaseForTask({
+      cwd,
+      trust: trustedLocalContext(),
+      taskId: 'fix-build',
+      config: resolveRemediateConfig(cwd),
+      entryFloor,
+      git,
+      exec,
+    });
+    expect(summary.ran).toBe(true);
+    expect(summary.records[0].outcome.kind).not.toBe('applied');
+    const ids = (summary.agentOrders ?? []).map((o) => o.id);
+    // Both the non-applied recipe order and the agent-tier floor order are queued.
+    expect(ids.some((id) => id.startsWith('stale-lockfile:'))).toBe(true);
+    expect(ids.some((id) => id.startsWith('floor-failure:'))).toBe(true);
+  });
+
+  it('recipes disabled still plans and routes EVERY selected order to the agent queue', async () => {
+    const cwd = tempRepo({
+      'package.json': '{"name":"fx"}',
+      'package-lock.json': '{}',
+      '.dxkit/policy.json': '{"remediate":{"recipes":{"enabled":false}}}',
+    });
+    const entryFloor = floorWith([
+      {
+        pack: 'typescript',
+        label: 'lockfile-sync',
+        bin: 'npm',
+        args: ['ci', '--dry-run'],
+        status: 'fail',
+        output: 'EUSAGE',
+      },
+    ] as CorrectnessFloorResult['checks']);
+    const summary = await runRecipePhaseForTask({
+      cwd,
+      trust: trustedLocalContext(),
+      taskId: 'fix-build',
+      config: resolveRemediateConfig(cwd),
+      entryFloor,
+    });
+    expect(summary.disabled).toBe(true);
+    expect(summary.ran).toBe(false);
+    expect(summary.records).toHaveLength(0);
+    expect(summary.selectedAgentTier).toBe(1);
+    expect((summary.agentOrders ?? []).map((o) => o.id)).toEqual([
+      expect.stringMatching(/^stale-lockfile:/),
+    ]);
+  });
+
   it('a task selecting no orders is an honest no-run with the tier split at zero', async () => {
     const cwd = tempRepo({ '.dxkit/policy.json': '{}' });
     const summary = await runRecipePhaseForTask({

--- a/test/remediate/recipes/run-recipes.test.ts
+++ b/test/remediate/recipes/run-recipes.test.ts
@@ -7,7 +7,12 @@
  * plan built from the entry floor, and the tier split.
  */
 import { describe, it, expect } from 'vitest';
-import { partitionByEnvelope, pathInEnvelope } from '../../../src/remediate/recipes/envelope';
+import {
+  partitionByEnvelope,
+  pathAllowedByEnvelope,
+  pathInEnvelope,
+} from '../../../src/remediate/recipes/envelope';
+import { REPO_WIDE_ENVELOPE } from '../../../src/remediate/work-orders/types';
 import {
   cachedOsvQuery,
   effectiveBlockSeverities,
@@ -23,8 +28,13 @@ import { trustedLocalContext, untrustedContentContext } from '../../../src/analy
 import { fakeExec, makeOrder, tempRepo } from './helpers';
 
 describe('envelope containment', () => {
-  it('speaks the planner language: root, directory prefix, exact file', () => {
-    expect(pathInEnvelope('anything/x.ts', { paths: [''], manifests: false })).toBe(true);
+  it('speaks the planner language: explicit repo-wide marker, directory prefix, exact file', () => {
+    // The EXPLICIT marker matches everything; a bare empty string matches
+    // NOTHING (the accidental startsWith('') match-all it used to be).
+    expect(pathInEnvelope('anything/x.ts', { paths: [REPO_WIDE_ENVELOPE], manifests: false })).toBe(
+      true,
+    );
+    expect(pathInEnvelope('anything/x.ts', { paths: [''], manifests: false })).toBe(false);
     expect(pathInEnvelope('src/a/b.ts', { paths: ['src/a/'], manifests: false })).toBe(true);
     expect(pathInEnvelope('src/ab/c.ts', { paths: ['src/a/'], manifests: false })).toBe(false);
     expect(pathInEnvelope('package.json', { paths: ['package.json'], manifests: true })).toBe(true);
@@ -33,6 +43,23 @@ describe('envelope containment', () => {
     );
     const split = partitionByEnvelope(['a.ts', 'b.ts'], { paths: ['a.ts'], manifests: false });
     expect(split).toEqual({ inside: ['a.ts'], outside: ['b.ts'] });
+    // manifests: false excludes dependency files even under the repo-wide
+    // marker; manifests: true admits them (the predicate is pack-injected).
+    const isManifest = (p: string) => p === 'package.json';
+    expect(
+      pathAllowedByEnvelope(
+        'package.json',
+        { paths: [REPO_WIDE_ENVELOPE], manifests: false },
+        isManifest,
+      ),
+    ).toBe(false);
+    expect(
+      pathAllowedByEnvelope(
+        'package.json',
+        { paths: [REPO_WIDE_ENVELOPE], manifests: true },
+        isManifest,
+      ),
+    ).toBe(true);
   });
 });
 
@@ -429,6 +456,29 @@ describe('runRecipePhaseForTask', () => {
     expect((summary.agentOrders ?? []).map((o) => o.id)).toEqual([
       expect.stringMatching(/^stale-lockfile:/),
     ]);
+  });
+
+  it('skips planning entirely when BOTH consumers are off (recipes disabled + order dispatch off)', async () => {
+    const cwd = tempRepo({
+      '.dxkit/policy.json': '{"remediate":{"recipes":{"enabled":false},"maxOrdersPerRun":0}}',
+    });
+    const summary = await runRecipePhaseForTask({
+      cwd,
+      trust: trustedLocalContext(),
+      taskId: 'fix-build',
+      config: resolveRemediateConfig(cwd),
+      entryFloor: floorWith([]),
+      // A gather seam that THROWS proves planning never ran: a planned call
+      // would surface as planError.
+      gather: {
+        runFloor: () => {
+          throw new Error('planning must not run when nothing consumes the plan');
+        },
+      },
+    });
+    expect(summary.disabled).toBe(true);
+    expect(summary.planError).toBeUndefined();
+    expect(summary.agentOrders).toBeUndefined();
   });
 
   it('a task selecting no orders is an honest no-run with the tier split at zero', async () => {

--- a/test/remediate/resume.test.ts
+++ b/test/remediate/resume.test.ts
@@ -33,7 +33,11 @@ function fakeExec(opts: {
     calls.push([bin, ...args]);
     if (bin === 'gh') {
       if (!opts.openPr) return '[]';
-      return JSON.stringify([{ url: 'https://x/pr/1', body: opts.prBody ?? '' }]);
+      // Default body: a budget-exhausted verified partial — the ONE outcome
+      // that is a resume anchor (design F).
+      return JSON.stringify([
+        { url: 'https://x/pr/1', body: opts.prBody ?? 'outcome: **budget-exhausted**' },
+      ]);
     }
     if (bin === 'git' && args[0] === 'fetch') {
       if (opts.failFetch) throw new Error('fetch failed');
@@ -113,7 +117,7 @@ describe('prepareResume — the eligibility ladder', () => {
 
   it('carries the prior attempt blocking findings from the draft-PR ledger into the decision', () => {
     const body =
-      'ledger...\n\nBlocking findings:\n- [dep-vuln] form-data GHSA-1\n- [test-gap] src/x.js\n\nrest';
+      'outcome: **budget-exhausted**\n\nBlocking findings:\n- [dep-vuln] form-data GHSA-1\n- [test-gap] src/x.js\n\nrest';
     const { exec } = fakeExec({ openPr: true, markers: 0, prBody: body });
     const d = prepareResume('/repo', 'fix-build', ON, exec);
     expect(d.resumed).toBe(true);
@@ -121,6 +125,30 @@ describe('prepareResume — the eligibility ladder', () => {
     expect(d.blockingContext).toContain('src/x.js');
     // and it reaches the resumed prompt
     expect(resumePromptNote(d.attempt!, d.blockingContext)).toContain('BLOCKED by the guardrail');
+  });
+
+  it('a guardrail-red draft is NOT a resume anchor: fresh run, blocking set carried as a negative constraint', () => {
+    const body =
+      'Task: **fix-vulns** — outcome: **guardrail-red**\n\nBlocking findings:\n- [secret] src/config.ts\n';
+    const { exec, calls } = fakeExec({ openPr: true, markers: 0, prBody: body });
+    const d = prepareResume('/repo', 'fix-vulns', ON, exec);
+    expect(d.resumed).toBe(false);
+    expect(d.note).toContain('guardrail-red');
+    expect(d.note).toContain('budget-exhausted');
+    expect(d.blockingContext).toContain('src/config.ts');
+    // No checkout, no marker: the tree is untouched on a refused resume.
+    expect(calls.some((c) => c[0] === 'git' && c.includes('--detach'))).toBe(false);
+  });
+
+  it('an open PR whose ledger outcome is verified (or unreadable) starts fresh, disclosed', () => {
+    const { exec } = fakeExec({ openPr: true, markers: 0, prBody: 'outcome: **verified**' });
+    const d = prepareResume('/repo', 'fix-vulns', ON, exec);
+    expect(d.resumed).toBe(false);
+    expect(d.note).toContain("'verified'");
+    const unreadable = fakeExec({ openPr: true, markers: 0, prBody: 'no ledger here' });
+    const d2 = prepareResume('/repo', 'fix-vulns', ON, unreadable.exec);
+    expect(d2.resumed).toBe(false);
+    expect(d2.note).toContain('unknown');
   });
 
   it('any git/gh failure → fresh run, never a throw', () => {
@@ -147,6 +175,7 @@ function fakeGit(): RemediateGit {
     head: () => head,
     sweepLeftovers: () => undefined,
     scrubRuntimeArtifacts: () => [],
+    enforceEnvelope: () => ({ dropped: [] }),
     hasDiff: () => {
       head = 'salvage01';
       return true;
@@ -181,6 +210,7 @@ function config(): RemediateConfig {
     taskBudgets: {},
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
+    maxOrdersPerRun: 0,
     resume: true,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },

--- a/test/remediate/resume.test.ts
+++ b/test/remediate/resume.test.ts
@@ -48,6 +48,8 @@ function fakeExec(opts: {
       return '';
     }
     if (bin === 'git' && args[0] === 'rev-list') return String(opts.markers ?? 0);
+    if (bin === 'git' && args.includes('rev-parse')) return 'tree1234';
+    if (bin === 'git' && args.includes('commit-tree')) return 'marker5678';
     return '';
   };
   return { exec, calls };
@@ -127,7 +129,7 @@ describe('prepareResume — the eligibility ladder', () => {
     expect(resumePromptNote(d.attempt!, d.blockingContext)).toContain('BLOCKED by the guardrail');
   });
 
-  it('a guardrail-red draft is NOT a resume anchor: fresh run, blocking set carried as a negative constraint', () => {
+  it('a guardrail-red draft is NOT a resume anchor: fresh run, blocking set carried as a negative constraint, counter ADVANCED', () => {
     const body =
       'Task: **fix-vulns** — outcome: **guardrail-red**\n\nBlocking findings:\n- [secret] src/config.ts\n';
     const { exec, calls } = fakeExec({ openPr: true, markers: 0, prBody: body });
@@ -135,9 +137,32 @@ describe('prepareResume — the eligibility ladder', () => {
     expect(d.resumed).toBe(false);
     expect(d.note).toContain('guardrail-red');
     expect(d.note).toContain('budget-exhausted');
+    expect(d.note).toContain('attempt 1 of');
+    expect(d.attempt).toBe(1);
     expect(d.blockingContext).toContain('src/config.ts');
-    // No checkout, no marker: the tree is untouched on a refused resume.
+    // No checkout: the tree is untouched on a refused resume — but the
+    // attempt counter STILL advances (a content-free commit-tree marker,
+    // pushed), or a guardrail-red chain never reaches the escalation cap
+    // and re-spends a full budget on the same unfixable finding forever.
     expect(calls.some((c) => c[0] === 'git' && c.includes('--detach'))).toBe(false);
+    expect(calls.some((c) => c[0] === 'git' && c.includes('commit-tree'))).toBe(true);
+    const push = calls.find((c) => c[0] === 'git' && c[1] === 'push');
+    expect(push).toBeDefined();
+    expect(push!.join(' ')).toContain('marker5678:refs/heads/');
+  });
+
+  it('a guardrail-red chain reaches the attempt cap: human escalation, no more marker spend', () => {
+    const body = 'Task: **fix-vulns** — outcome: **guardrail-red**\n';
+    const { exec, calls } = fakeExec({
+      openPr: true,
+      markers: MAX_RESUME_ATTEMPTS,
+      prBody: body,
+    });
+    const d = prepareResume('/repo', 'fix-vulns', ON, exec);
+    expect(d.resumed).toBe(false);
+    expect(d.note).toContain('review or close the draft PR');
+    expect(d.note).toContain(`cap ${MAX_RESUME_ATTEMPTS}`);
+    expect(calls.some((c) => c[0] === 'git' && c.includes('commit-tree'))).toBe(false);
   });
 
   it('an open PR whose ledger outcome is verified (or unreadable) starts fresh, disclosed', () => {
@@ -149,6 +174,17 @@ describe('prepareResume — the eligibility ladder', () => {
     const d2 = prepareResume('/repo', 'fix-vulns', ON, unreadable.exec);
     expect(d2.resumed).toBe(false);
     expect(d2.note).toContain('unknown');
+  });
+
+  it('extractLedgerOutcome is anchored to the ledger line, never a prose mention of an outcome word', () => {
+    const prose =
+      '- earlier attempt discussion mentions outcome: **verified** in passing\n' +
+      'Task: **fix-vulns** — outcome: **budget-exhausted**\n';
+    const { exec } = fakeExec({ openPr: true, markers: 0, prBody: prose });
+    // The mid-line prose mention must not win: the real ledger line says
+    // budget-exhausted, so this RESUMES.
+    const d = prepareResume('/repo', 'fix-vulns', ON, exec);
+    expect(d.resumed).toBe(true);
   });
 
   it('any git/gh failure → fresh run, never a throw', () => {

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -42,6 +42,7 @@ function fakeGit(opts: { diff?: boolean; sweepError?: string } = {}): RemediateG
     head: () => head,
     sweepLeftovers: () => opts.sweepError,
     scrubRuntimeArtifacts: () => [],
+    enforceEnvelope: () => ({ dropped: [] }),
     hasDiff: () => {
       if (opts.diff) head = 'head1111';
       return !!opts.diff;
@@ -93,6 +94,7 @@ function config(
     taskBudgets: {},
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
+    maxOrdersPerRun: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },
@@ -180,6 +182,7 @@ describe('refusal + infra arms (each truthful and distinct)', () => {
         return undefined;
       },
       scrubRuntimeArtifacts: () => [],
+      enforceEnvelope: () => ({ dropped: [] }),
       hasDiff: () => false,
     };
     const driver = fakeDriver({ completed: false, neverRan: { reason: 'exit 143' } });

--- a/test/remediate/work-orders/tasks-catalog.test.ts
+++ b/test/remediate/work-orders/tasks-catalog.test.ts
@@ -27,6 +27,20 @@ describe('remediate tasks select work-order classes', () => {
     expect([...new Set(all)].sort()).toEqual(Object.keys(WORK_ORDER_CLASSES).sort());
   });
 
+  it('no class-selecting task declares a score hinge (the orders phase carries no hinge tail)', () => {
+    // Order-driven dispatch verifies through the floor + guardrail; the
+    // score-hinge tail lives only on the legacy open-ended path. A task that
+    // both selects classes and declares a hinge would silently skip its
+    // hinge on the orders path — this pin makes that a deliberate change.
+    for (const task of REMEDIATE_TASKS) {
+      if (classesSelectedBy(task.id).length > 0) {
+        expect(task.scoreHinge, `'${task.id}' selects classes and declares a hinge`).toBe(
+          undefined,
+        );
+      }
+    }
+  });
+
   it('the custom dispatch task is open-ended and selects nothing', () => {
     const custom = customDispatchTask('do a thing');
     expect(custom.completion).toBe('open-ended');


### PR DESCRIPTION
## What

The scoped agent (remediate rethink, section 3C): the agent tier stops receiving open-ended task prompts. It receives ONE rendered work order at a time, with a derived budget, an enforced envelope, and an in-session done verifier. Sprawl becomes structurally impossible to land, not just discouraged.

## Mechanisms

- **Order-driven dispatch** (`src/remediate/orders-phase.ts`, wired from `run.ts` after the recipe phase): the remaining agent-tier orders for the selected task, plus every recipe order whose recipe refused or failed (the in-run fallback: a refused recipe order joins the agent queue instead of dead-ending the run as `recipes-refused`), are dispatched one order per agent run, highest value first, up to the new `remediate.maxOrdersPerRun` knob (default 3; 0 restores the legacy single task prompt; registered in policy metadata + schema + the guide). Open-ended tasks (improve-tests, write-docs, custom) select no classes and keep the legacy path byte-identical.
- **Derived budget**: the order's planner-derived budget becomes the driver budget for that run, clamped to the run's remaining wall clock and spend, and disclosed in the ledger with its derivation string. The run-level policy caps still bound the total; orders beyond them are deferred with disclosure.
- **Envelope enforcement at the sweep**: after each dispatch (leftover sweep, runtime-artifact scrub), committed changes outside the order's envelope, plus the always-allowed `docs/DXKIT-REMEDIATION-NOTES.md`, are dropped with disclosure by the new `RemediateGit.enforceEnvelope` (base-tracked files back to base content, new files removed, one disclosure commit). Fail-closed: an enforcement error lands nothing. The prompt half stays advisory; the sweep half is the enforcement.
- **In-session done**: the lane writes the order's done criterion to `.dxkit/loop/order.json` around each dispatch (one module, `src/loop/order-scope.ts`, owns path + shape + writer + validating reader), and `computeStopGate` consumes it: the agent cannot stop while any of the order's target findings is still present, and the block reason hands back exactly the ids left to close. The check executes nothing (it post-processes the guardrail payload + floor outcome the gate already computed), so a hostile order file cannot widen execution on any tree; malformed files are disclosed skips; an absent file keeps every existing behavior; the verdict cache is bypassed while a scope is active. `runStopGate` moved to `stop-gate-cli.ts` at the module-size bar.
- **Narrowed tools**: the driver seam gains `tools` (allowed/disallowed) plus a declared `toolPolicy` mechanism; claude-code renders variadic `--disallowedTools` / `--allowedTools` (deny rules hold under `--dangerously-skip-permissions` on the pinned CLI 2.1.222, documented on the declaration; a permission-mode allowlist is deliberately not used for headless runs because a non-interactive prompt denial dead-ends the run). Order runs deny the package-manager install commands, derived from `package-manager.ts:installCommandPrefixes()` (the canonical builders plus documented aliases), never hardcoded. The applied policy (or the disclosed fact a driver cannot narrow) rides the envelope and ledger.
- **Resume policy (design F)**: resume continues only budget-exhausted verified partials. A guardrail-red draft is never a resume anchor; its blocking set is carried out of `prepareResume` and rendered into the next run's order prompts as a negative constraint (do not reintroduce). Other/unreadable outcomes start fresh, disclosed.
- **Ledger / PR body**: a per-order section (order id, class, findings, derived budget vs spend, envelope enforcement outcomes, done disclosure; floor orders report closed/open against the verified floor), assembled through the existing pr/assemble path. Verification-tail phrasing is now shared (`verificationDisclosures` / `guardrailRedNote` in `verify.ts`) across the legacy tail, the recipe-only completion, and the orders phase, so the three ledgers cannot drift.

## Tests

- `test/remediate/orders-phase.test.ts` (18): one order per run in value order with the rendered prompt; cap honored with disclosed not-dispatched records; cap 0 and a plan-less summary both keep the legacy path; derived budget reaches the driver and its derivation the ledger; run-budget clamp and exhaustion; order scope written before each dispatch and cleared after (including a throwing driver); envelope drop + disclosure, notes-file allowance, fail-closed enforcement error; uncontradicted never-ran stops the queue; tool policy both directions; negative constraint in every order prompt; refused recipe order dispatched to the agent in-run; per-order done vs the verified floor.
- `test/loop/order-scope.test.ts` (11): write/read/clear round trip; validating reader against hostile content (injection-guarded, never a throw); unresolved-id computation for both verifiers including allowlist-waived findings and the undecidable floor; the gate blocking with exactly the open ids, allowing on closure, disclosed skips, and net-new blocks still winning.
- `test/remediate/resume.test.ts`: both directions of the resume policy (guardrail-red refused with blocking context carried; verified/unreadable outcomes start fresh; budget-exhausted resumes), existing ladder green on the new default body.
- `test/remediate/driver.test.ts`: variadic tool-flag rendering beside `--dangerously-skip-permissions`; flags absent without the option.
- `test/package-manager.test.ts`: `installCommandPrefixes` derived from the canonical builders for every PM, aliases included, deterministic.
- `test/remediate/git-ops.test.ts`: real-git `enforceEnvelope` (revert + remove + disclosure commit, no-op case, named error).
- `test/remediate/recipes/run-recipes.test.ts`: refused/failed recipe orders join `agentOrders`; recipes disabled still plans and routes every order to the agent (the knob's documented meaning).
- `test/remediate/config-budgets.test.ts`: `maxOrdersPerRun` normalization (default 3, 0 accepted, junk rejected). `test/remediate/work-orders/tasks-catalog.test.ts`: no class-selecting task declares a score hinge (the orders phase carries no hinge tail).

## Sweep and guardrail

- `typecheck`, `typecheck:test`, `eslint --max-warnings 0`, `prettier --check`, `check-architecture.sh`, `check-docs-coverage.sh`, `check-slop.sh` (advisory notes only), `build`, `vitest run --coverage` (406 files / 6031 tests passed, coverage 73.88% over the 50% gate): all green.
- `node dist/index.js guardrail check --mode ref-based --ref origin/main`: **PASSED**, exit 0 (an earlier iteration tripped two net-new large-file findings on `stop-gate.ts` and `run.ts`; fixed by splitting `stop-gate-cli.ts` out and moving the dispatch decision into `orders-phase.ts`, not by allowlisting).

## Review focus

- `src/remediate/orders-phase.ts`: the dispatch loop's terminal arms (sweep failure, enforcement failure, uncontradicted never-ran) and the outcome mapping parity with the legacy tail.
- `src/loop/order-scope.ts` + the `computeStopGate` insertion point: the order check runs only on an otherwise-allow, executes nothing, and the cache bypass in `stop-gate-cli.ts`.
- `src/remediate/recipes/run-recipes.ts`: the `agentOrders` queue definition (agent tier + non-applied recipe orders, plan order) and the recipes-disabled route-to-agent change.
- The `recipes-refused` completion now fires only when `maxOrdersPerRun` is 0 (or no plan was handed over); the note says so.

## Deliberately left out

- No per-order re-scan for guardrail-verifier done inside the frame (the one tree verification and the next plan arbitrate; the ledger says so per order): a per-order guardrail run would multiply verification cost by the cap.
- The score-hinge tail stays on the legacy path only; a catalog test pins that no class-selecting task declares a hinge, so this is a compile-adjacent guard rather than dead code in the orders phase.
- `--permission-mode` + explicit allows for order runs: documented decision on the driver declaration (a non-interactive permission prompt is a denial that dead-ends a headless run); deny rules are the mechanism, and the envelope disclosure names it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
