### PR TITLE
feat(remediate): scheduler memory, the order ledger + circuit breaker + order-derived matrix (4.4.5 scheduler-memory)

### DIFF
--- a/docs/commands/remediate.md
+++ b/docs/commands/remediate.md
@@ -31,7 +31,14 @@ vyuh-dxkit remediate configured [path] [--land pr] [--json]
   are listed under `undispatchable` with the reason. The floor is read from
   the baseline's recorded envelope (or the loop snapshot) so the plan stays
   cheap; `--with-floor` runs the live floor instead, and the output says
-  which source it used (`workOrderFloorSource`).
+  which source it used (`workOrderFloorSource`). The scheduled matrix
+  (`matrixTasks`) is derived from the OPEN orders in value order: a task
+  with no open orders spawns no scheduled job, open-ended tasks
+  (`improve-tests`, `write-docs`) appear only when policy lists them
+  explicitly (disclosed as the legacy shape), and classes the circuit
+  breaker paused are shown with the reason and the unpause conditions
+  (`pausedClasses`). A dispatch naming a task bypasses the matrix and runs
+  exactly that task.
 - `--task <id>` runs one task. With `--land pr` a `verified` outcome (or a
   `budget-exhausted` one under the `draft-pr` salvage policy) pushes the
   standing branch `dxkit/remediate-<task>` and opens or updates its PR.
@@ -75,6 +82,15 @@ campaigns (below) and can never be scheduled from policy.
   and named. `remediate plan` prints the per-run projection (the sum of
   the matrix tasks' caps) either way — each matrix task is its own
   invocation with its own cap, so one firing may spend the sum.
+- `remediate.pauseAfterFailures` (default 2, 0 = off): the circuit
+  breaker. A work-order class whose last N counted outcomes are failures
+  (guardrail-red, floor-red, install-failed, a failed recipe; refusals and
+  infrastructure never count) is paused: planned but not dispatched,
+  always disclosed. The pause lifts on a remediate policy change, a dxkit
+  upgrade, an explicit dispatch of the owning task, or when the failures
+  age out of the 60-day order-history window. Outcome rows live in
+  `.dxkit/lanes/<lane>-<task>.orders.jsonl` (committed with a landing;
+  pushed as a metadata commit on the standing branch when nothing lands).
 - `remediate.maxDispatchBudget` (0 = undeclared): the dispatch spend
   authority. It clamps the `max_usd` override AND the `max_turns`
   override (proportionally against the policy budget) — turns govern real

--- a/docs/commands/remediate.md
+++ b/docs/commands/remediate.md
@@ -14,7 +14,7 @@ Work lands only as a PR carrying the verification ledger.
 
 ```bash
 vyuh-dxkit remediate plan [path] [--json] [--with-floor]  # dry-run: no key, no spend
-vyuh-dxkit remediate [path] --task <id> [--land pr] [--json]
+vyuh-dxkit remediate [path] --task <id> [--land pr] [--dispatch-override] [--json]
 vyuh-dxkit remediate configured [path] [--land pr] [--json]
 ```
 
@@ -37,8 +37,11 @@ vyuh-dxkit remediate configured [path] [--land pr] [--json]
   (`improve-tests`, `write-docs`) appear only when policy lists them
   explicitly (disclosed as the legacy shape), and classes the circuit
   breaker paused are shown with the reason and the unpause conditions
-  (`pausedClasses`). A dispatch naming a task bypasses the matrix and runs
-  exactly that task.
+  (`pausedClasses`). When the plan's evidence is degraded (an unreadable
+  baseline, no floor evidence anywhere), the matrix falls back to the
+  static policy task list with the reason named, so a fail-open zero can
+  never silently turn the schedule off. A dispatch naming a task bypasses
+  the matrix and runs exactly that task.
 - `--task <id>` runs one task. With `--land pr` a `verified` outcome (or a
   `budget-exhausted` one under the `draft-pr` salvage policy) pushes the
   standing branch `dxkit/remediate-<task>` and opens or updates its PR.
@@ -83,14 +86,17 @@ campaigns (below) and can never be scheduled from policy.
   the matrix tasks' caps) either way — each matrix task is its own
   invocation with its own cap, so one firing may spend the sum.
 - `remediate.pauseAfterFailures` (default 2, 0 = off): the circuit
-  breaker. A work-order class whose last N counted outcomes are failures
-  (guardrail-red, floor-red, install-failed, a failed recipe; refusals and
-  infrastructure never count) is paused: planned but not dispatched,
-  always disclosed. The pause lifts on a remediate policy change, a dxkit
-  upgrade, an explicit dispatch of the owning task, or when the failures
-  age out of the 60-day order-history window. Outcome rows live in
+  breaker. A work-order class whose last N counted FIRINGS are failures
+  (guardrail-red, floor-red, install-failed, a failed recipe; one red run
+  counts once per class; refusals and infrastructure never count) is
+  paused: planned but not dispatched, always disclosed. The pause lifts on
+  a remediate policy change, a dxkit upgrade, an explicit dispatch
+  override (`--dispatch-override`, which the current workflow template
+  passes when a dispatch names the task), or when the failures age out of
+  the 60-day order-history window. Outcome rows live in
   `.dxkit/lanes/<lane>-<task>.orders.jsonl` (committed with a landing;
-  pushed as a metadata commit on the standing branch when nothing lands).
+  pushed as a metadata commit on the standing branch when nothing lands,
+  parented only on the remote branch head, never on local history).
 - `remediate.maxDispatchBudget` (0 = undeclared): the dispatch spend
   authority. It clamps the `max_usd` override AND the `max_turns`
   override (proportionally against the policy budget) — turns govern real

--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -48,6 +48,7 @@ stanzas).
 | `remediate.maxDispatchBudget`       | [#remediate-dispatch-budget](#remediate-dispatch-budget) |
 | `remediate.maxOrdersPerRun`         | [#remediate-orders-per-run](#remediate-orders-per-run)   |
 | `remediate.maxSpendPerRun`          | [#remediate-spend-per-run](#remediate-spend-per-run)     |
+| `remediate.pauseAfterFailures`      | [#remediate-pause](#remediate-pause)                     |
 | `remediate.recipes.enabled`         | [#remediate-recipes](#remediate-recipes)                 |
 | `remediate.resume`                  | [#remediate-resume](#remediate-resume)                   |
 | `remediate.salvage`                 | [#remediate-salvage](#remediate-salvage)                 |
@@ -707,3 +708,39 @@ prompt (the pre-4.4.5 shape).
 the driver can narrow tools, package-manager install commands are denied
 for order runs (installs are a frame/recipe step) and the applied policy is
 disclosed in the envelope.
+
+## Remediate pause
+
+**What it does.** `remediate.pauseAfterFailures` is the remediate lane's
+circuit breaker. Every remediate run records a per-order outcome row in the
+lane ledger (`.dxkit/lanes/<lane>-<task>.orders.jsonl`): order id, class,
+tier, outcome, spend, and a timestamp written by the runner. When a
+work-order CLASS accumulates this many consecutive failed outcomes
+(guardrail-red, floor-red, install-failed, or a failed recipe; refusals and
+infrastructure failures never count, and a verified outcome, including a
+budget-cut verified partial, resets the streak), the class is PAUSED: the
+planner still plans its orders, but they are marked paused with the reason
+and the unpause conditions, no tier dispatches them, and the plan output,
+the run ledger, and the workflow notices all say so. A paused class stops
+the scheduled lane from re-buying the same failure every firing.
+
+**Unpausing.** A pause lifts on any signal that the next attempt would not
+be a rerun of the same failure: the `remediate` policy section changes,
+dxkit is upgraded, a human dispatches the owning task explicitly (the
+workflow's task input, or a local `vyuh-dxkit remediate --task <t>`), or
+the failures age out of the bounded history window (60 days), which makes
+every pause a retry horizon rather than a permanent off switch. Each lift
+is disclosed in the plan output.
+
+**Default and why.** `2`: one failure can be bad luck; two consecutive
+failures on the same class under the same policy and the same dxkit build
+are evidence the next attempt buys the same result. `0` disables the
+breaker.
+
+**Interactions.** The scheduled matrix derives from OPEN orders, so a task
+whose only orders are paused spawns no job (disclosed in the plan job's
+notices). The [resume](#remediate-resume) attempt cap escalates a single
+salvage branch to a human; the breaker complements it one level up, across
+runs that leave no branch at all (a discarded guardrail-red attempt still
+writes its outcome rows through a metadata commit on the task's standing
+branch, so the memory survives the ephemeral runner).

--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -712,11 +712,15 @@ disclosed in the envelope.
 ## Remediate pause
 
 **What it does.** `remediate.pauseAfterFailures` is the remediate lane's
-circuit breaker. Every remediate run records a per-order outcome row in the
-lane ledger (`.dxkit/lanes/<lane>-<task>.orders.jsonl`): order id, class,
-tier, outcome, spend, and a timestamp written by the runner. When a
-work-order CLASS accumulates this many consecutive failed outcomes
-(guardrail-red, floor-red, install-failed, or a failed recipe; refusals and
+circuit breaker. Every remediate run records one outcome row per order in
+the lane ledger (`.dxkit/lanes/<lane>-<task>.orders.jsonl`): order id,
+class, tier, the terminal outcome (an agent attempt supersedes the recipe
+record it fell through from), spend, and a timestamp written by the
+runner. The breaker counts FIRINGS, not rows: one red run is one failure
+event for a class however many of its orders that run carried, because
+the shared tree verification stamps the same verdict on all of them. When
+a class accumulates this many consecutive failed firings (guardrail-red,
+floor-red, install-failed, or a failed recipe; refusals and
 infrastructure failures never count, and a verified outcome, including a
 budget-cut verified partial, resets the streak), the class is PAUSED: the
 planner still plans its orders, but they are marked paused with the reason
@@ -726,11 +730,15 @@ the scheduled lane from re-buying the same failure every firing.
 
 **Unpausing.** A pause lifts on any signal that the next attempt would not
 be a rerun of the same failure: the `remediate` policy section changes,
-dxkit is upgraded, a human dispatches the owning task explicitly (the
-workflow's task input, or a local `vyuh-dxkit remediate --task <t>`), or
-the failures age out of the bounded history window (60 days), which makes
-every pause a retry horizon rather than a permanent off switch. Each lift
-is disclosed in the plan output.
+dxkit is upgraded, a human dispatches an explicit override, or the
+failures age out of the bounded history window (60 days), which makes
+every pause a retry horizon rather than a permanent off switch (the lift
+is disclosed in the plan output, never silent). The override is an
+EXPLICIT signal, never inferred from the environment: locally,
+`vyuh-dxkit remediate --task <t> --dispatch-override`; from the managed
+workflow, the Run-workflow form naming the task (the current template
+passes the flag through; if a dispatch does not lift a pause, the
+workflow predates the flag, and `vyuh-dxkit update` refreshes it).
 
 **Default and why.** `2`: one failure can be bad luck; two consecutive
 failures on the same class under the same policy and the same dxkit build

--- a/docs/learn/operating-the-lanes.md
+++ b/docs/learn/operating-the-lanes.md
@@ -45,8 +45,10 @@ the remediation workflow, press _Run workflow_, and the typed form offers:
 A custom prompt carries no score hinge, and the PR says so explicitly:
 verification is the floor + the guardrail + your review. Dispatching is
 write-access-gated by GitHub itself. Dispatching a task also overrides a
-circuit-breaker pause on that task's order classes for that one run (see
-below), which is the designed way to say "try again now".
+circuit-breaker pause on that task's order classes for that one run (the
+current workflow template passes the explicit override flag through; run
+`vyuh-dxkit update` if a dispatch does not lift a pause), which is the
+designed way to say "try again now".
 
 ## Orders, recipes, and the circuit breaker
 
@@ -68,15 +70,19 @@ diff, and a run that lands nothing pushes its rows as a metadata commit on
 the task's standing branch, so the memory survives the ephemeral runner.
 
 **The circuit breaker** (`remediate.pauseAfterFailures`, default 2) reads
-that ledger: a class whose last N counted outcomes are failures
-(guardrail-red, floor-red, install-failed, a failed recipe; refusals and
-infrastructure never count) is PAUSED. Paused orders are still planned and
-shown, but nothing dispatches them, and the plan output, the run ledger,
-and the workflow notices all carry the reason plus the unpause conditions.
-A pause lifts when the remediate policy changes, when dxkit is upgraded,
-when you dispatch the owning task explicitly, or when the failures age out
-of the 60-day history window. The weekly lane stops re-buying the same
-failure; you decide when it retries.
+that ledger: a class whose last N counted FIRINGS are failures
+(guardrail-red, floor-red, install-failed, a failed recipe; one red run
+counts once however many orders it carried; refusals and infrastructure
+never count) is PAUSED. Paused orders are still planned and shown, but
+nothing dispatches them, and the plan output, the run ledger, and the
+workflow notices all carry the reason plus the unpause conditions. A
+pause lifts when the remediate policy changes, when dxkit is upgraded,
+when you dispatch an explicit override (the workflow's Run-workflow form
+naming the task, or locally
+`vyuh-dxkit remediate --task <t> --dispatch-override`), or when the
+failures age out of the 60-day history window (disclosed as the retry
+horizon engaging). The weekly lane stops re-buying the same failure; you
+decide when it retries.
 
 ## Budgets, in one place
 

--- a/docs/learn/operating-the-lanes.md
+++ b/docs/learn/operating-the-lanes.md
@@ -22,9 +22,16 @@ from the same registry the lane executes.
 
 ## Scheduled runs vs one-off campaigns
 
-**Scheduled** is the recurring posture: the tasks enabled in
-`.dxkit/policy.json` run on the workflow's cron, under the policy's
-per-task budgets.
+**Scheduled** is the recurring posture, and it is order-driven: each firing
+plans the repo's open WORK ORDERS (finite, verifiable units cut from the
+entry floor's failures, deferred advisories inside their window, and the
+lint backlog), then spawns one job per enabled task that has open orders,
+highest value first, under the policy's budgets. A task with no open orders
+spawns no job at all (a healthy repo's firing costs nothing), and the plan
+job's notices say why each absent task is absent. Open-ended tasks
+(`improve-tests`, `write-docs`) have no orders by nature: they run only
+when policy lists them explicitly, and the plan discloses them as the
+legacy open-ended shape.
 
 **Dispatch campaigns** are one-time runs from the GitHub Actions UI: open
 the remediation workflow, press _Run workflow_, and the typed form offers:
@@ -37,7 +44,39 @@ the remediation workflow, press _Run workflow_, and the typed form offers:
 
 A custom prompt carries no score hinge, and the PR says so explicitly:
 verification is the floor + the guardrail + your review. Dispatching is
-write-access-gated by GitHub itself.
+write-access-gated by GitHub itself. Dispatching a task also overrides a
+circuit-breaker pause on that task's order classes for that one run (see
+below), which is the designed way to say "try again now".
+
+## Orders, recipes, and the circuit breaker
+
+Inside each task run, the frame works the plan in two tiers:
+
+- **Recipes** (deterministic, $0): a registered recipe executes an order
+  inside its envelope with no agent at all (lockfile re-sync, an override
+  pin with an OSV pre-check, declaring a missing dependency, lint autofix).
+  A recipe that cannot act refuses with the reason named; a refused or
+  failed recipe order falls through to the agent tier in the same run.
+- **The scoped agent**: each remaining order is one agent run with the
+  rendered order as its prompt (findings, evidence, envelope, constraints,
+  the done command), a budget derived from the order, and envelope
+  enforcement at the sweep, up to `remediate.maxOrdersPerRun` per firing.
+
+Every order's outcome is recorded in the lane's order ledger
+(`.dxkit/lanes/<lane>-<task>.orders.jsonl`): rows ride a landed PR's own
+diff, and a run that lands nothing pushes its rows as a metadata commit on
+the task's standing branch, so the memory survives the ephemeral runner.
+
+**The circuit breaker** (`remediate.pauseAfterFailures`, default 2) reads
+that ledger: a class whose last N counted outcomes are failures
+(guardrail-red, floor-red, install-failed, a failed recipe; refusals and
+infrastructure never count) is PAUSED. Paused orders are still planned and
+shown, but nothing dispatches them, and the plan output, the run ledger,
+and the workflow notices all carry the reason plus the unpause conditions.
+A pause lifts when the remediate policy changes, when dxkit is upgraded,
+when you dispatch the owning task explicitly, or when the failures age out
+of the 60-day history window. The weekly lane stops re-buying the same
+failure; you decide when it retries.
 
 ## Budgets, in one place
 
@@ -48,7 +87,10 @@ write-access-gated by GitHub itself.
 - A task that hits its cap is "budget-bounded, not finished": nothing lands
   unless the frame verifies, and the attempt is disclosed in the run.
 - With `remediate.resume` enabled, a salvaged attempt can continue in a
-  later run (draft-PR salvage only, attempt-counted, capped).
+  later run. Resume only anchors on a budget-exhausted VERIFIED partial
+  (draft-PR salvage, attempt-counted, capped at 2 per branch); a
+  guardrail-blocked draft is never resumed, and its blocking findings ride
+  the next run's order prompts as a negative constraint instead.
 
 ## Estimating spend
 
@@ -88,9 +130,16 @@ Read the task's job summary first — it names the outcome. The shapes:
   run as an artifact (Actions run page, Artifacts section). Under
   `draft-pr` salvage a guardrail-blocked attempt is additionally pushed as
   a red draft PR titled "do not merge" (its own guardrail check keeps it
-  unmergeable), so the work and the blocking findings survive the runner
-  and a resumed attempt can continue from them. Otherwise no action is
-  required; the next scheduled run retries from a clean tree.
+  unmergeable), so the work and the blocking findings survive the runner;
+  the next run starts fresh with those findings as a negative constraint
+  (a blocked diff is never a resume anchor). Otherwise no action is
+  required; the next scheduled run retries from a clean tree, and after
+  `remediate.pauseAfterFailures` consecutive failures the class is paused
+  instead of retried (see the circuit breaker above).
+- **`recipes-refused`**: every order the task selected was recipe-tier,
+  every recipe refused or failed, and the agent tier landed nothing for
+  them. The orders remain open and the per-order reasons are in the job
+  summary; these orders need a policy change, the agent tier, or a human.
 - **Budget-bounded, not finished** — the task hit its spend / turn / time
   cap mid-work. Also lands nothing. If it happens repeatedly on the same
   task, raise that task's budget (`remediate.taskBudgets`) or enable

--- a/src-templates/.claude/skills/dxkit-remediate/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-remediate/SKILL.md
@@ -77,11 +77,13 @@ is `recipes-refused`, never a green no-op.
 Every order's outcome is recorded in the lane order ledger
 (`.dxkit/lanes/<lane>-<task>.orders.jsonl`). The circuit breaker
 (`remediate.pauseAfterFailures`, default 2) pauses a class whose recent
-counted outcomes are all failures: paused orders stay planned and
+counted firings are all failures (one red run counts once for a class,
+however many of its orders it carried): paused orders stay planned and
 disclosed but are not dispatched, so the scheduled lane stops re-spending
 on the same failure. The pause lifts on a remediate policy change, a dxkit
-upgrade, an explicit dispatch of the owning task, or when the failures age
-out of the 60-day history window.
+upgrade, an explicit dispatch override (the workflow form naming the task,
+or locally `vyuh-dxkit remediate --task <t> --dispatch-override`), or when
+the failures age out of the 60-day history window.
 
 ## Reading an outcome
 

--- a/src-templates/.claude/skills/dxkit-remediate/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-remediate/SKILL.md
@@ -21,7 +21,12 @@ vyuh-dxkit remediate plan
 
 Shows, per configured task, the full model resolution chain (task → tier →
 driver-native model), the budget caps and which ones the driver can enforce,
-and whether the agent CLI resolves here. No key needed, no network, no spend.
+and whether the agent CLI resolves here. It also lists the planned WORK
+ORDERS: the finite units the run would actually work (class, tier, derived
+budget, done criterion), the scheduled matrix derived from them (a task
+with no open orders spawns no scheduled job), any classes the circuit
+breaker has paused (with the reason and the unpause conditions), and the
+spend-ceiling trim. No key needed, no spend.
 
 Model settings (`remediate.agent.model`):
 - `auto` (default) — each task uses its registry tier: light for mechanical
@@ -56,12 +61,39 @@ your `claude` subscription login.
 The workflow triggers on schedule + manual dispatch ONLY, runs against the
 default branch only, with dxkit-authored prompts only.
 
+## How a run works (orders, recipes, the scoped agent)
+
+Each task run plans the repo's open work orders and works them in two
+tiers. Recipe-tier orders execute deterministically inside the frame first
+(lockfile re-sync, an OSV-pre-checked override pin or dependency
+declaration, lint autofix): $0, no agent. Remaining orders are dispatched
+one order per agent run (up to `remediate.maxOrdersPerRun`), each with the
+rendered order as its prompt, a budget derived from the order's findings,
+and envelope enforcement at the sweep (out-of-envelope changes are dropped
+with disclosure). A refused or failed recipe order falls through to the
+agent tier in the same run; when nothing lands for such orders the outcome
+is `recipes-refused`, never a green no-op.
+
+Every order's outcome is recorded in the lane order ledger
+(`.dxkit/lanes/<lane>-<task>.orders.jsonl`). The circuit breaker
+(`remediate.pauseAfterFailures`, default 2) pauses a class whose recent
+counted outcomes are all failures: paused orders stay planned and
+disclosed but are not dispatched, so the scheduled lane stops re-spending
+on the same failure. The pause lifts on a remediate policy change, a dxkit
+upgrade, an explicit dispatch of the owning task, or when the failures age
+out of the 60-day history window.
+
 ## Reading an outcome
 
 - `verified` / a green PR — the diff passed the entry-attributed floor and
   the guardrail. Pre-existing debt listed in the ledger was already failing
   before the agent ran; it is disclosed, not the agent's doing.
 - `no-op` — the agent ran and committed nothing; the job summary says so.
+  A no-op can also mean every selected order is paused by the circuit
+  breaker (the note names the classes and the unpause conditions; $0).
+- `recipes-refused`: a recipe-only plan where every recipe refused or
+  failed and nothing was fixed. Non-clean by design: the orders remain
+  open, and the per-order reasons are in the ledger.
 - `install-failed` — a clean checkout of the agent's commits cannot be
   installed the way CI installs it (the frozen-lockfile install failed, most
   often a manifest edited without re-running the install so the lockfile
@@ -87,6 +119,13 @@ default branch only, with dxkit-authored prompts only.
   hook, a signing requirement). Nothing lands: those files are staged, and
   landing would push them unreviewed. The note names the git error.
 - `refused` — a trust or configuration refusal, with the remedy named.
+
+Resume (`remediate.resume: true`, opt-in) continues a prior salvage branch
+in the next run, but only when that attempt was a budget-exhausted VERIFIED
+partial; a guardrail-blocked draft is never a resume anchor, and its
+blocking findings ride the next run's order prompts as a negative
+constraint instead. Attempts are capped at 2 per branch before the task
+falls back to a fresh run and a human is expected to look at the draft.
 
 ## Tuning the budget
 

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -118,6 +118,15 @@ jobs:
           if (deferred.length > 0) {
             console.log(`::notice title=remediate spend ceiling::deferred to the next firing: ${deferred.join(', ')}`);
           }
+          // Scheduler-memory disclosures (never silent): classes the circuit
+          // breaker paused, tasks with no open orders (no job, $0), and the
+          // matrix derivation notes from the plan.
+          for (const pause of p.pausedClasses ?? []) {
+            console.log(`::notice title=remediate circuit breaker::class '${pause.class}' is PAUSED: ${pause.reason}. Unpause: ${pause.unpause}`);
+          }
+          for (const note of p.matrixDisclosures ?? []) {
+            console.log(`::notice title=remediate matrix::${note}`);
+          }
           console.log('matrix:', JSON.stringify(tasks));
           EOF
 
@@ -260,6 +269,10 @@ __DXKIT_LANE_TOKEN_TASK_STEPS__
           # comment-defer pattern — free text never touches a shell line).
           # Blank on scheduled runs; the CLI clamps budget overrides to the
           # committed remediate.maxDispatchBudget and discloses every clamp.
+          # A dispatch that names a task overrides the circuit breaker for
+          # that task's classes (the pause's documented unpause path); blank
+          # on scheduled runs, so the breaker stands there.
+          DXKIT_DISPATCH_TASK: ${{ github.event.inputs.task || '' }}
           DXKIT_CUSTOM_PROMPT: ${{ github.event.inputs.prompt || '' }}
           DXKIT_DISPATCH_MAX_USD: ${{ github.event.inputs.max_usd || '' }}
           DXKIT_DISPATCH_MAX_TURNS: ${{ github.event.inputs.max_turns || '' }}

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -269,9 +269,10 @@ __DXKIT_LANE_TOKEN_TASK_STEPS__
           # comment-defer pattern — free text never touches a shell line).
           # Blank on scheduled runs; the CLI clamps budget overrides to the
           # committed remediate.maxDispatchBudget and discloses every clamp.
-          # A dispatch that names a task overrides the circuit breaker for
-          # that task's classes (the pause's documented unpause path); blank
-          # on scheduled runs, so the breaker stands there.
+          # The dispatch input, always DEFINED here (blank on scheduled
+          # runs): the run step derives the explicit --dispatch-override
+          # flag from it, and the CLI uses the variable's absence to detect
+          # a pre-flag workflow template (advises `vyuh-dxkit update`).
           DXKIT_DISPATCH_TASK: ${{ github.event.inputs.task || '' }}
           DXKIT_CUSTOM_PROMPT: ${{ github.event.inputs.prompt || '' }}
           DXKIT_DISPATCH_MAX_USD: ${{ github.event.inputs.max_usd || '' }}
@@ -281,8 +282,16 @@ __DXKIT_LANE_TOKEN_TASK_STEPS__
 __DXKIT_REMEDIATE_CREDENTIAL_ENV__
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi
+          # The dispatch override is an EXPLICIT flag, passed only when a
+          # human's workflow_dispatch named exactly this task: it lifts a
+          # circuit-breaker pause on the task's classes for this one run.
+          # Scheduled matrix runs never carry it.
+          OVERRIDE=""
+          if [ -n "$DXKIT_DISPATCH_TASK" ] && [ "$DXKIT_DISPATCH_TASK" = "${{ matrix.task }}" ]; then
+            OVERRIDE="--dispatch-override"
+          fi
           set +e
-          "$DXKIT" remediate --task "${{ matrix.task }}" --land pr
+          "$DXKIT" remediate --task "${{ matrix.task }}" --land pr $OVERRIDE
           EXIT=$?
           set -e
           # Kill-shaped death disclosure (dxkit #289): SIGKILL is uncatchable,

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -263,8 +263,8 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
     path: 'remediate.pauseAfterFailures',
     summary:
       'circuit breaker: pause a work-order class after this many consecutive failed ' +
-      'outcomes (default 2; 0 disables; unpaused by a policy change, a dxkit upgrade, ' +
-      'or an explicit dispatch)',
+      'firings (default 2; 0 disables; unpaused by a policy change, a dxkit upgrade, ' +
+      'or an explicit dispatch override)',
     anchor: 'remediate-pause',
   },
   {

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -260,6 +260,14 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
     anchor: 'remediate-orders-per-run',
   },
   {
+    path: 'remediate.pauseAfterFailures',
+    summary:
+      'circuit breaker: pause a work-order class after this many consecutive failed ' +
+      'outcomes (default 2; 0 disables; unpaused by a policy change, a dxkit upgrade, ' +
+      'or an explicit dispatch)',
+    anchor: 'remediate-pause',
+  },
+  {
     path: 'remediate.workOrders.maxSliceSize',
     summary: 'largest number of findings one debt work order may carry (default 25)',
     anchor: 'remediate-work-orders',

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -357,6 +357,10 @@ export function buildPolicySchema(version: string): Schema {
           maxSpendPerRun: { type: 'number', description: desc('remediate.maxSpendPerRun') },
           maxDispatchBudget: { type: 'number', description: desc('remediate.maxDispatchBudget') },
           maxOrdersPerRun: { type: 'number', description: desc('remediate.maxOrdersPerRun') },
+          pauseAfterFailures: {
+            type: 'number',
+            description: desc('remediate.pauseAfterFailures'),
+          },
           workOrders: obj(
             {
               maxSliceSize: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -404,6 +404,10 @@ export async function run(argv: string[]): Promise<void> {
       default: { type: 'string' },
       // `remediate --task <t>` — which registry task the agent runs.
       task: { type: 'string' },
+      // `remediate --task <t> --dispatch-override` — an explicit human
+      // dispatch: overrides a circuit-breaker pause on the task's classes
+      // for this one run. Never inferred from ambient environment.
+      'dispatch-override': { type: 'boolean', default: false },
       verbose: { type: 'boolean', default: false },
       'no-save': { type: 'boolean', default: false },
       detailed: { type: 'boolean', default: false },
@@ -3205,6 +3209,7 @@ export async function run(argv: string[]): Promise<void> {
         taskId,
         land: landRaw === 'pr' ? 'pr' : 'none',
         json: !!values.json,
+        dispatchOverride: !!values['dispatch-override'],
       });
       break;
     }

--- a/src/land-refresh.ts
+++ b/src/land-refresh.ts
@@ -24,20 +24,39 @@ import { internalGitPushArgs } from './git-internal-push';
 
 export type LandMode = 'pr' | 'push';
 
-export type Exec = (bin: string, args: readonly string[], opts?: { allowFail?: boolean }) => string;
+export type Exec = (
+  bin: string,
+  args: readonly string[],
+  opts?: {
+    allowFail?: boolean;
+    /** Piped to stdin (git plumbing like `hash-object --stdin`). */
+    input?: string;
+    /** Extra env vars layered over the process env (e.g. GIT_INDEX_FILE). */
+    env?: Readonly<Record<string, string>>;
+  },
+) => string;
 
-/** Real exec: capture stdout, tolerate failure only when asked. */
+/** Real exec: capture stdout, tolerate failure only when asked. The ONE
+ *  machine git-exec factory (Rule 2): every lane spawn inherits the
+ *  no-prompt hardening below instead of minting its own wrapper. */
 export function makeExec(cwd: string): Exec {
   return (bin, args, opts = {}) => {
     try {
       return execFileSync(bin, [...args], {
         cwd,
         encoding: 'utf8',
-        // Never hang a refresh on an interactive credential prompt; a bad
-        // remote fails fast and the caller surfaces it.
-        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+        // Never hang a machine spawn on an interactive credential prompt; a
+        // bad remote fails fast and the caller surfaces it. Both prompt
+        // paths are disabled (HTTPS and SSH), the remote-ref discipline.
+        env: {
+          ...process.env,
+          GIT_TERMINAL_PROMPT: '0',
+          GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes',
+          ...(opts.env ?? {}),
+        },
         timeout: 60_000,
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: [opts.input !== undefined ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+        ...(opts.input !== undefined ? { input: opts.input } : {}),
       }).toString();
     } catch (e) {
       if (opts.allowFail) return '';

--- a/src/lanes/order-ledger.ts
+++ b/src/lanes/order-ledger.ts
@@ -1,0 +1,342 @@
+/**
+ * The work-order OUTCOME ledger (remediate rethink, section 3F) — the
+ * scheduler's memory. The delivery ledger beside this module (`ledger.ts`)
+ * answers "what did the lanes LAND"; this one answers "what happened to
+ * each work ORDER the remediate lane dispatched", including the outcomes
+ * that never land (a guardrail-red discard, a failed recipe), because those
+ * are exactly the rows the circuit breaker needs to stop re-buying the same
+ * failure every firing.
+ *
+ * Same mechanism, same directory (`.dxkit/lanes/`), one JSONL file per
+ * standing-PR identity (`remediate-<task>.orders.jsonl`) so concurrent
+ * matrix tasks never touch one file. Rows reach durability on two existing
+ * channels, no new trust surface:
+ *
+ *   - a LANDING commits the file into the standing PR's own diff (the
+ *     delivery-ledger doctrine), so rows reach the default branch on merge;
+ *   - a NON-landing outcome rides a frame-authored metadata commit pushed
+ *     to the task's standing branch (the resume-marker precedent: zero
+ *     agent content, only the lane's own record), written by the remediate
+ *     executor — see `src/remediate/order-outcomes.ts`.
+ *
+ * ONE reader (`orderHistory`) merges both channels — the local checkout's
+ * committed files plus each standing branch's copy, fetched fail-open —
+ * dedupes, and bounds the window (old rows age out, which also gives a
+ * paused class a natural retry horizon instead of a forever-pause).
+ *
+ * Timestamps are written by the RUNNER at row-append time (the delivery
+ * ledger's convention); the planner only ever reads.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { readJsonlFile } from '../jsonl';
+import { LANES_DIR } from './ledger';
+
+/** Bump only on a breaking change to the row shape. */
+export const ORDER_LEDGER_SCHEMA_VERSION = 1;
+
+/**
+ * Per-order outcome vocabulary. Committed-work rows carry the RUN verdict
+ * (one tree verification arbitrates every order that contributed commits);
+ * refusals and infrastructure keep their own words so the breaker can tell
+ * "the work failed" from "nothing was tried".
+ */
+export type OrderRowOutcome =
+  | 'verified'
+  | 'budget-exhausted-verified'
+  | 'guardrail-red'
+  | 'floor-red'
+  | 'install-failed'
+  | 'failed-recipe'
+  | 'refused'
+  | 'agent-failed'
+  | 'never-ran'
+  | 'not-dispatched'
+  | 'sweep-failed'
+  | 'no-op'
+  | 'paused';
+
+/**
+ * The breaker's failure set: outcomes where work was ATTEMPTED and the
+ * verification (or the recipe's own verify) said no. Deliberately narrow —
+ * infrastructure ('never-ran'), refusals ('refused', $0 by design), and
+ * plumbing failures ('sweep-failed') never count: pausing a class because
+ * credits ran out would punish the code for the environment.
+ */
+export const ORDER_FAILURE_OUTCOMES: ReadonlySet<OrderRowOutcome> = new Set([
+  'guardrail-red',
+  'floor-red',
+  'install-failed',
+  'failed-recipe',
+]);
+
+/** The breaker's success set: outcomes that RESET a failure streak — the
+ *  class produced verified work (a budget-cut verified partial counts:
+ *  progress is progress). Everything not in either set is neutral: it
+ *  neither counts as a failure nor resets the streak. */
+export const ORDER_SUCCESS_OUTCOMES: ReadonlySet<OrderRowOutcome> = new Set([
+  'verified',
+  'budget-exhausted-verified',
+]);
+
+export interface OrderOutcomeRow {
+  readonly schema_version: number;
+  /** ISO timestamp, written by the runner at append time. */
+  readonly timestamp: string;
+  readonly lane: 'remediate' | string;
+  readonly task: string;
+  readonly orderId: string;
+  /** The order's work-order class — the breaker's grouping key. */
+  readonly class: string;
+  readonly tier: 'recipe' | 'agent';
+  readonly outcome: OrderRowOutcome;
+  readonly spend?: { readonly turns?: number; readonly costUsd?: number };
+  /** Failure/refusal reason, bounded (evidence pointer, not a transcript). */
+  readonly detail?: string;
+  /** Environment stamps the breaker's unpause conditions compare against:
+   *  a dxkit upgrade or a remediate-policy change lifts a pause. */
+  readonly dxkitVersion: string;
+  readonly policyHash: string;
+}
+
+/** Orders-ledger file for a standing-PR identity, repo-relative POSIX.
+ *  Distinct from the delivery ledger's file so `readLaneEvents` (which
+ *  accepts only landed delivery events) and this reader never mix rows. */
+export function orderLedgerPath(lane: string, task: string): string {
+  return `${LANES_DIR.replace(/\\/g, '/')}/${lane}-${task}.orders.jsonl`;
+}
+
+function isOrderRow(raw: unknown): raw is OrderOutcomeRow {
+  const r = raw as OrderOutcomeRow;
+  return (
+    typeof r?.schema_version === 'number' &&
+    r.schema_version <= ORDER_LEDGER_SCHEMA_VERSION &&
+    typeof r.timestamp === 'string' &&
+    typeof r.lane === 'string' &&
+    typeof r.task === 'string' &&
+    typeof r.orderId === 'string' &&
+    typeof r.class === 'string' &&
+    typeof r.outcome === 'string'
+  );
+}
+
+/** Parse JSONL text into validated rows — fail-open per line, and a row
+ *  from a NEWER schema is skipped (this dxkit cannot interpret it). */
+export function parseOrderRows(text: string): OrderOutcomeRow[] {
+  const rows: OrderOutcomeRow[] = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const raw: unknown = JSON.parse(trimmed);
+      if (isOrderRow(raw)) rows.push(raw);
+    } catch {
+      // a corrupt line is skipped, never a crash
+    }
+  }
+  return rows;
+}
+
+/** Every order row committed in the local checkout's lanes directory. */
+export function readLocalOrderRows(cwd: string): OrderOutcomeRow[] {
+  const dir = path.join(cwd, LANES_DIR);
+  let files: string[];
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith('.orders.jsonl'));
+  } catch {
+    return [];
+  }
+  const rows: OrderOutcomeRow[] = [];
+  for (const file of files) {
+    for (const raw of readJsonlFile(path.join(dir, file))) {
+      if (isOrderRow(raw)) rows.push(raw);
+    }
+  }
+  return rows;
+}
+
+function rowKey(r: OrderOutcomeRow): string {
+  return `${r.task}\0${r.orderId}\0${r.timestamp}`;
+}
+
+/** Union row lists (a row can arrive via both the merged default branch and
+ *  a standing branch), deduped, oldest first. */
+export function mergeOrderRows(
+  ...lists: ReadonlyArray<readonly OrderOutcomeRow[]>
+): OrderOutcomeRow[] {
+  const byKey = new Map<string, OrderOutcomeRow>();
+  for (const list of lists) {
+    for (const row of list) {
+      if (!byKey.has(rowKey(row))) byKey.set(rowKey(row), row);
+    }
+  }
+  return [...byKey.values()].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+}
+
+/** Serialize rows back to the JSONL wire shape (one row per line). */
+export function serializeOrderRows(rows: readonly OrderOutcomeRow[]): string {
+  return rows.map((r) => JSON.stringify(r)).join('\n') + (rows.length > 0 ? '\n' : '');
+}
+
+/** Default reading window: rows older than this age out of the breaker's
+ *  view, so a pause is a retry horizon, never a forever-off switch. */
+export const ORDER_HISTORY_WINDOW_DAYS = 60;
+
+/** Per-class row cap inside the window (newest kept). */
+export const ORDER_HISTORY_MAX_PER_CLASS = 50;
+
+export interface OrderWindowOptions {
+  readonly now?: Date;
+  readonly windowDays?: number;
+  readonly maxPerClass?: number;
+}
+
+/** Apply the bounded window: drop rows older than `windowDays`, keep the
+ *  newest `maxPerClass` rows per class, return oldest first. */
+export function boundOrderWindow(
+  rows: readonly OrderOutcomeRow[],
+  opts: OrderWindowOptions = {},
+): OrderOutcomeRow[] {
+  const now = opts.now ?? new Date();
+  const windowDays = opts.windowDays ?? ORDER_HISTORY_WINDOW_DAYS;
+  const maxPerClass = opts.maxPerClass ?? ORDER_HISTORY_MAX_PER_CLASS;
+  const cutoff = now.getTime() - windowDays * 24 * 60 * 60 * 1000;
+  const inWindow = rows.filter((r) => {
+    const t = Date.parse(r.timestamp);
+    return Number.isFinite(t) && t >= cutoff;
+  });
+  const byClass = new Map<string, OrderOutcomeRow[]>();
+  for (const row of inWindow) {
+    const list = byClass.get(row.class) ?? [];
+    list.push(row);
+    byClass.set(row.class, list);
+  }
+  const kept: OrderOutcomeRow[] = [];
+  for (const list of byClass.values()) {
+    const sorted = [...list].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    kept.push(...sorted.slice(Math.max(0, sorted.length - maxPerClass)));
+  }
+  return kept.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+}
+
+/** Injectable exec for the branch reads (tests; the writer shares it). */
+export type OrderLedgerExec = (bin: string, args: readonly string[]) => string;
+
+export function realOrderLedgerExec(cwd: string): OrderLedgerExec {
+  return (bin, args) =>
+    execFileSync(bin, [...args], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 60_000,
+    }).toString();
+}
+
+/** One standing-branch source: the branch plus the repo-relative ledger
+ *  file the lane writes on it. */
+export interface OrderBranchSource {
+  readonly branch: string;
+  readonly file: string;
+}
+
+/** Rows currently on one standing branch, or null when the branch (or the
+ *  file) is unreachable — the caller decides whether that is a disclosure
+ *  (a fetch failure) or normal (the file simply does not exist yet). */
+export function readBranchOrderRows(
+  source: OrderBranchSource,
+  exec: OrderLedgerExec,
+): { rows: OrderOutcomeRow[]; head: string } | null {
+  try {
+    exec('git', ['fetch', 'origin', source.branch]);
+    const head = exec('git', ['rev-parse', 'FETCH_HEAD']).trim();
+    let text = '';
+    try {
+      text = exec('git', ['show', `FETCH_HEAD:${source.file}`]);
+    } catch {
+      // the branch exists but has no ledger file yet — an empty history
+      return { rows: [], head };
+    }
+    return { rows: parseOrderRows(text), head };
+  } catch {
+    return null;
+  }
+}
+
+export interface OrderHistoryOptions extends OrderWindowOptions {
+  /** Standing-branch sources to merge in (unmerged rows live there).
+   *  Empty/absent = local files only. */
+  readonly branches?: readonly OrderBranchSource[];
+  readonly exec?: OrderLedgerExec;
+}
+
+export interface OrderHistory {
+  /** Deduped, window-bounded rows, oldest first. */
+  readonly rows: readonly OrderOutcomeRow[];
+  /** Degraded reads, phrased for humans (an unreachable branch is a
+   *  disclosed absence, never a silent one). */
+  readonly disclosures: readonly string[];
+}
+
+/** Which of the given branches exist on origin — ONE network probe (an
+ *  absent branch is normal, not a degradation; only an unreachable remote
+ *  is). Null = the probe itself failed (offline, no origin). */
+export function existingRemoteBranches(
+  branches: readonly string[],
+  exec: OrderLedgerExec,
+): Set<string> | null {
+  if (branches.length === 0) return new Set();
+  try {
+    const out = exec('git', ['ls-remote', '--heads', 'origin', ...branches]);
+    const present = new Set<string>();
+    for (const line of out.split('\n')) {
+      const ref = line.split('\t')[1]?.trim();
+      if (ref?.startsWith('refs/heads/')) present.add(ref.slice('refs/heads/'.length));
+    }
+    return present;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The ONE reader (Rule 2.30): local committed rows plus every standing
+ * branch's copy, deduped and window-bounded. Fail-open — an offline plan
+ * still reads its local history and says what it could not.
+ */
+export function orderHistory(cwd: string, opts: OrderHistoryOptions = {}): OrderHistory {
+  const disclosures: string[] = [];
+  const lists: Array<readonly OrderOutcomeRow[]> = [readLocalOrderRows(cwd)];
+  const branches = opts.branches ?? [];
+  if (branches.length > 0) {
+    const exec = opts.exec ?? realOrderLedgerExec(cwd);
+    const present = existingRemoteBranches(
+      branches.map((b) => b.branch),
+      exec,
+    );
+    if (present === null) {
+      disclosures.push(
+        'order history: no remote reachable to read the standing branches; unmerged ' +
+          'outcome rows, if any, are not in view (local committed history only)',
+      );
+    } else {
+      const unreadable: string[] = [];
+      for (const source of branches) {
+        if (!present.has(source.branch)) continue; // never written: empty history
+        const read = readBranchOrderRows(source, exec);
+        if (read === null) unreadable.push(source.branch);
+        else lists.push(read.rows);
+      }
+      if (unreadable.length > 0) {
+        disclosures.push(
+          `order history: standing branch(es) ${unreadable.join(', ')} exist but could not ` +
+            'be fetched; their unmerged outcome rows are not in view',
+        );
+      }
+    }
+  }
+  return {
+    rows: boundOrderWindow(mergeOrderRows(...lists), opts),
+    disclosures,
+  };
+}

--- a/src/lanes/order-ledger.ts
+++ b/src/lanes/order-ledger.ts
@@ -29,7 +29,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { execFileSync } from 'child_process';
+import { makeExec, type Exec } from '../land-refresh';
 import { readJsonlFile } from '../jsonl';
 import { LANES_DIR } from './ledger';
 
@@ -121,21 +121,38 @@ function isOrderRow(raw: unknown): raw is OrderOutcomeRow {
   );
 }
 
-/** Parse JSONL text into validated rows — fail-open per line, and a row
- *  from a NEWER schema is skipped (this dxkit cannot interpret it). */
-export function parseOrderRows(text: string): OrderOutcomeRow[] {
+/** A ledger text split for the WRITER: the rows this dxkit understands,
+ *  plus every other non-empty line VERBATIM (a row a newer schema wrote, a
+ *  corrupt line). Only the reader filters; a writer that rewrites the
+ *  durable file must carry foreign lines through untouched, or an upgrade
+ *  rolls back and silently loses the newer build's memory. */
+export interface LedgerText {
+  readonly rows: OrderOutcomeRow[];
+  readonly foreign: string[];
+}
+
+export function parseLedgerText(text: string): LedgerText {
   const rows: OrderOutcomeRow[] = [];
+  const foreign: string[] = [];
   for (const line of text.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
       const raw: unknown = JSON.parse(trimmed);
       if (isOrderRow(raw)) rows.push(raw);
+      else foreign.push(trimmed);
     } catch {
-      // a corrupt line is skipped, never a crash
+      // a corrupt line never crashes the reader; the writer preserves it
+      foreign.push(trimmed);
     }
   }
-  return rows;
+  return { rows, foreign };
+}
+
+/** Reader-side parse: validated rows only (foreign lines are the writer's
+ *  concern — see `parseLedgerText`). */
+export function parseOrderRows(text: string): OrderOutcomeRow[] {
+  return parseLedgerText(text).rows;
 }
 
 /** Every order row committed in the local checkout's lanes directory. */
@@ -157,7 +174,10 @@ export function readLocalOrderRows(cwd: string): OrderOutcomeRow[] {
 }
 
 function rowKey(r: OrderOutcomeRow): string {
-  return `${r.task}\0${r.orderId}\0${r.timestamp}`;
+  // Tier is part of identity: one run stamps one timestamp, and an order
+  // can legitimately carry a recipe-tier row and an agent-tier row from
+  // the same firing (a failed recipe the agent then picked up).
+  return `${r.task}\0${r.orderId}\0${r.tier}\0${r.timestamp}`;
 }
 
 /** Union row lists (a row can arrive via both the merged default branch and
@@ -192,8 +212,19 @@ export interface OrderWindowOptions {
   readonly maxPerClass?: number;
 }
 
-/** Apply the bounded window: drop rows older than `windowDays`, keep the
- *  newest `maxPerClass` rows per class, return oldest first. */
+/** Is a row a COUNTED outcome (a breaker failure or success)? Everything
+ *  else — paused markers, refusals, infrastructure — is bookkeeping. */
+export function isCountedOutcome(outcome: OrderRowOutcome): boolean {
+  return ORDER_FAILURE_OUTCOMES.has(outcome) || ORDER_SUCCESS_OUTCOMES.has(outcome);
+}
+
+/** Apply the bounded window: drop rows older than `windowDays`, then keep
+ *  the newest `maxPerClass` COUNTED rows and, separately, the newest
+ *  `maxPerClass` bookkeeping rows per class, oldest first. The caps are
+ *  separate on purpose: a weekly stream of neutral 'paused' markers must
+ *  never evict the failure evidence the pause stands on (an evidence-
+ *  evicted lift would be silent; the WINDOW age-out is the only documented
+ *  lift, and the breaker discloses it). */
 export function boundOrderWindow(
   rows: readonly OrderOutcomeRow[],
   opts: OrderWindowOptions = {},
@@ -215,22 +246,22 @@ export function boundOrderWindow(
   const kept: OrderOutcomeRow[] = [];
   for (const list of byClass.values()) {
     const sorted = [...list].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
-    kept.push(...sorted.slice(Math.max(0, sorted.length - maxPerClass)));
+    const counted = sorted.filter((r) => isCountedOutcome(r.outcome));
+    const bookkeeping = sorted.filter((r) => !isCountedOutcome(r.outcome));
+    kept.push(...counted.slice(Math.max(0, counted.length - maxPerClass)));
+    kept.push(...bookkeeping.slice(Math.max(0, bookkeeping.length - maxPerClass)));
   }
   return kept.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
 }
 
-/** Injectable exec for the branch reads (tests; the writer shares it). */
-export type OrderLedgerExec = (bin: string, args: readonly string[]) => string;
+/** Injectable exec for the branch reads and the writer's plumbing: the
+ *  ONE machine git-exec shape (`land-refresh.ts:makeExec` — no-prompt
+ *  hardening, bounded, stdin + env support). Re-exported here so ledger
+ *  consumers need no second import home; never a second factory. */
+export type OrderLedgerExec = Exec;
 
 export function realOrderLedgerExec(cwd: string): OrderLedgerExec {
-  return (bin, args) =>
-    execFileSync(bin, [...args], {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 60_000,
-    }).toString();
+  return makeExec(cwd);
 }
 
 /** One standing-branch source: the branch plus the repo-relative ledger
@@ -240,13 +271,15 @@ export interface OrderBranchSource {
   readonly file: string;
 }
 
-/** Rows currently on one standing branch, or null when the branch (or the
- *  file) is unreachable — the caller decides whether that is a disclosure
- *  (a fetch failure) or normal (the file simply does not exist yet). */
+/** One standing branch's ledger state (rows + foreign lines + head), or
+ *  null when the branch is unreachable — the caller decides whether that
+ *  is a disclosure (a fetch failure) or normal (no branch yet). The ONE
+ *  branch read; the writer's compose consumes the same result (Rule 2.30,
+ *  never a second fetch/show pair). */
 export function readBranchOrderRows(
   source: OrderBranchSource,
   exec: OrderLedgerExec,
-): { rows: OrderOutcomeRow[]; head: string } | null {
+): { rows: OrderOutcomeRow[]; foreign: string[]; head: string } | null {
   try {
     exec('git', ['fetch', 'origin', source.branch]);
     const head = exec('git', ['rev-parse', 'FETCH_HEAD']).trim();
@@ -255,9 +288,10 @@ export function readBranchOrderRows(
       text = exec('git', ['show', `FETCH_HEAD:${source.file}`]);
     } catch {
       // the branch exists but has no ledger file yet — an empty history
-      return { rows: [], head };
+      return { rows: [], foreign: [], head };
     }
-    return { rows: parseOrderRows(text), head };
+    const parsed = parseLedgerText(text);
+    return { rows: parsed.rows, foreign: parsed.foreign, head };
   } catch {
     return null;
   }

--- a/src/remediate/attempt-record.ts
+++ b/src/remediate/attempt-record.ts
@@ -1,0 +1,114 @@
+/**
+ * The machine-readable ATTEMPT RECORD (`.dxkit/cache/remediate-<task>.json`)
+ * — the evidence layer that survives the ephemeral runner. Split from
+ * `execute.ts` purely for module size (the plan-cli / configured-loop
+ * precedent); the executor is its only producer and re-exports
+ * `taskRunJson`, so consumers keep one import surface.
+ *
+ * Two write moments, both best-effort plumbing (never a failure):
+ *
+ *   - PROVISIONAL, before the driver spawns (#289): a SIGKILL (runner OOM)
+ *     is uncatchable, so every disclosure mechanism the frame owns dies
+ *     with it — a record written only at finalize meant a killed frame
+ *     left zero evidence and any committed work evaporated unrecorded.
+ *     The record names how far the run got (`phase: 'agent'`) and carries
+ *     `baseHead`, so the workflow's evidence step can format-patch
+ *     `baseHead..HEAD` of whatever the agent committed before death.
+ *   - FINAL, at every executor exit (pre-push with landed:false, then
+ *     overwritten by finalize), so the workflow's artifact step can upload
+ *     the diff of a blocked or failed attempt.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { remediateBranchFor } from '../lanes/branches';
+import type { TaskRun } from './execute';
+
+/** See the module doc: the pre-spawn record a SIGKILL leaves behind. */
+export function writeProvisionalRecord(cwd: string, taskId: string, baseHead: string): void {
+  try {
+    const dir = path.join(cwd, '.dxkit', 'cache');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `remediate-${taskId}.json`),
+      JSON.stringify(
+        {
+          phase: 'agent',
+          outcome: 'provisional',
+          task: taskId,
+          landed: false,
+          baseHead,
+          head: null,
+          note:
+            'provisional record written before the agent spawned — if this survives the run, ' +
+            'the frame died mid-agent-phase (it could not write its own obituary); partial ' +
+            'work, if any, is in the baseHead..HEAD range of the checkout',
+        },
+        null,
+        2,
+      ) + '\n',
+      'utf8',
+    );
+  } catch {
+    // evidence plumbing, never a failure
+  }
+}
+
+/** HEAD of the checkout, or null (evidence plumbing, never a failure). */
+export function currentHead(cwd: string): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** The final record — written pre-push (landed:false) AND at every
+ *  finalize, so the evidence exists no matter where the landing dies. */
+export function writeAttemptRecord(cwd: string, taskId: string, run: TaskRun): void {
+  try {
+    const dir = path.join(cwd, '.dxkit', 'cache');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `remediate-${taskId}.json`),
+      JSON.stringify(taskRunJson(run), null, 2) + '\n',
+      'utf8',
+    );
+  } catch {
+    // the record is evidence plumbing, never a failure
+  }
+}
+
+export function taskRunJson(run: TaskRun): Record<string, unknown> {
+  const r = run.result;
+  return {
+    // The frame reached finalize — distinguishes this record from the
+    // provisional one a SIGKILL leaves behind (#289).
+    phase: 'final',
+    outcome: r.outcome,
+    task: r.task ?? null,
+    note: r.note ?? null,
+    partial: r.partial ?? false,
+    envelope: r.envelope ?? null,
+    orders: r.orders ?? null,
+    guardrailVerdict: r.guardrailVerdict ?? null,
+    branch: r.task ? remediateBranchFor(r.task) : null,
+    prUrl: run.prUrl ?? null,
+    landRefused: run.landRefused ?? null,
+    landingBlocked: run.landingBlocked ?? null,
+    landed: run.landed,
+    // The commit range of the attempt — what the workflow's evidence step
+    // format-patches into a run artifact when nothing landed.
+    baseHead: r.baseHead ?? null,
+    head: r.head ?? null,
+    // Failure evidence (machine-readable record only — never the PR body).
+    transcriptTail: r.transcriptTail ?? null,
+    // The agent's own account of a no-op (#285) — autopsiable, never rendered.
+    agentFinalMessage: r.agentFinalMessage ?? null,
+    ledger: r.ledger,
+  };
+}

--- a/src/remediate/cli.ts
+++ b/src/remediate/cli.ts
@@ -72,7 +72,22 @@ export interface RemediateOptions {
 export async function runRemediate(cwd: string, opts: RemediateOptions): Promise<void> {
   const config = resolveRemediateConfig(cwd);
   logger.header(`dxkit remediate — ${opts.taskId}`);
-  const run = await executeTask(cwd, config, opts.taskId, opts.land === 'pr' ? 'pr' : 'none');
+  // Explicit-dispatch signal for the circuit breaker: locally, `--task` IS
+  // a human naming the task; under Actions only a workflow_dispatch that
+  // named this task counts (the scheduled matrix also invokes `--task`,
+  // and the workflow passes the dispatch input through DXKIT_DISPATCH_TASK).
+  const explicitDispatch =
+    process.env.GITHUB_ACTIONS === 'true'
+      ? (process.env.DXKIT_DISPATCH_TASK ?? '').trim() === opts.taskId
+      : true;
+  const run = await executeTask(
+    cwd,
+    config,
+    opts.taskId,
+    opts.land === 'pr' ? 'pr' : 'none',
+    {},
+    { explicitDispatch },
+  );
   if (opts.json) {
     process.stdout.write(
       JSON.stringify({ schema: 'remediate.v1', ...taskRunJson(run) }, null, 2) + '\n',

--- a/src/remediate/cli.ts
+++ b/src/remediate/cli.ts
@@ -24,6 +24,7 @@
 import * as fs from 'fs';
 import * as logger from '../logger';
 import { resolveRemediateConfig, tasksWithinSpendCeiling } from './config';
+import { staleDispatchWorkflowNote } from './dispatch';
 import { REMEDIATE_TASKS } from './tasks';
 
 // The executor (run one task + land it) lives in `./execute`, `remediate
@@ -66,27 +67,32 @@ export interface RemediateOptions {
   readonly taskId: string;
   readonly land?: 'pr' | 'none';
   readonly json?: boolean;
+  /** `--dispatch-override`: an explicit human dispatch that lifts a
+   *  circuit-breaker pause on this task's classes for this one run. An
+   *  EXPLICIT signal only — never inferred from ambient environment (an
+   *  inferred override would let any non-Actions automation bypass every
+   *  pause forever). */
+  readonly dispatchOverride?: boolean;
 }
 
 /** `remediate --task <t>` — run one task, verify, optionally land. */
 export async function runRemediate(cwd: string, opts: RemediateOptions): Promise<void> {
   const config = resolveRemediateConfig(cwd);
   logger.header(`dxkit remediate — ${opts.taskId}`);
-  // Explicit-dispatch signal for the circuit breaker: locally, `--task` IS
-  // a human naming the task; under Actions only a workflow_dispatch that
-  // named this task counts (the scheduled matrix also invokes `--task`,
-  // and the workflow passes the dispatch input through DXKIT_DISPATCH_TASK).
-  const explicitDispatch =
-    process.env.GITHUB_ACTIONS === 'true'
-      ? (process.env.DXKIT_DISPATCH_TASK ?? '').trim() === opts.taskId
-      : true;
+  // The circuit-breaker override is the EXPLICIT --dispatch-override flag
+  // and nothing else: the updated workflow passes it when a
+  // workflow_dispatch names this task, and a human passes it at the
+  // terminal. Ambient environment never bypasses a pause. A dispatch on a
+  // pre-flag workflow is detectable and advised, not silently ignored.
+  const staleNote = staleDispatchWorkflowNote(process.env, !!opts.dispatchOverride);
+  if (staleNote) logger.warn(staleNote);
   const run = await executeTask(
     cwd,
     config,
     opts.taskId,
     opts.land === 'pr' ? 'pr' : 'none',
     {},
-    { explicitDispatch },
+    { explicitDispatch: !!opts.dispatchOverride },
   );
   if (opts.json) {
     process.stdout.write(
@@ -172,6 +178,6 @@ export async function runRemediateConfigured(
 export function remediateUsage(): string {
   return (
     `usage: vyuh-dxkit remediate --task <${REMEDIATE_TASKS.map((t) => t.id).join('|')}> ` +
-    `[--land pr] [--json] | remediate configured [--land pr] | remediate plan`
+    `[--land pr] [--dispatch-override] [--json] | remediate configured [--land pr] | remediate plan`
   );
 }

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -33,6 +33,9 @@ export const DEFAULT_REMEDIATE_BUDGET: RemediateBudget = {
 /** Default `remediate.maxOrdersPerRun`. */
 export const DEFAULT_MAX_ORDERS_PER_RUN = 3;
 
+/** Default `remediate.pauseAfterFailures` (the circuit breaker). */
+export const DEFAULT_PAUSE_AFTER_FAILURES = 2;
+
 export interface RemediateConfig {
   readonly enabled: boolean;
   readonly tasks: readonly RemediateTaskId[];
@@ -83,6 +86,13 @@ export interface RemediateConfig {
    *  task prompt). Orders beyond the cap are disclosed, never silently
    *  dropped. */
   readonly maxOrdersPerRun: number;
+  /** The circuit breaker (`remediate.pauseAfterFailures`, default 2;
+   *  0 disables): a work-order class whose last N consecutive counted
+   *  outcomes are failures is PAUSED — planned but not dispatched, with
+   *  the reason and the unpause conditions disclosed — until the policy
+   *  changes, dxkit changes, an explicit dispatch names its task, or the
+   *  failures age out of the history window. */
+  readonly pauseAfterFailures: number;
   /** Work-order planning knobs (`remediate.workOrders`). */
   readonly workOrders: {
     /** Largest number of findings one debt slice may carry
@@ -143,18 +153,24 @@ export function budgetForTask(config: RemediateConfig, taskId: string): Remediat
   };
 }
 
-/** Apply the run-level spend ceiling: tasks whose cumulative per-task maxUsd
- *  fits run now; the rest are deferred to the next firing (deterministic —
- *  declaration order). No ceiling → everything runs. */
-export function tasksWithinSpendCeiling(config: RemediateConfig): {
+/** Apply the run-level spend ceiling to an ordered task list (default: the
+ *  policy's declaration order): tasks whose cumulative per-task maxUsd fits
+ *  run now; the rest are deferred to the next firing (deterministic). No
+ *  ceiling → everything runs. The scheduled matrix passes a VALUE-ordered
+ *  list derived from the open work orders (`deriveScheduledMatrix`), so the
+ *  ceiling trims the lowest-value tasks first there. */
+export function tasksWithinSpendCeiling(
+  config: RemediateConfig,
+  orderedTasks: readonly RemediateTaskId[] = config.tasks,
+): {
   readonly run: readonly RemediateTaskId[];
   readonly deferred: readonly RemediateTaskId[];
 } {
-  if (config.maxSpendPerRun <= 0) return { run: config.tasks, deferred: [] };
+  if (config.maxSpendPerRun <= 0) return { run: orderedTasks, deferred: [] };
   const run: RemediateTaskId[] = [];
   const deferred: RemediateTaskId[] = [];
   let spend = 0;
-  for (const taskId of config.tasks) {
+  for (const taskId of orderedTasks) {
     const usd = budgetForTask(config, taskId).maxUsd;
     if (spend + usd <= config.maxSpendPerRun) {
       spend += usd;
@@ -236,6 +252,13 @@ export function resolveRemediateConfig(cwd: string): RemediateConfig {
       raw.maxOrdersPerRun >= 0
         ? raw.maxOrdersPerRun
         : DEFAULT_MAX_ORDERS_PER_RUN,
+    // 0 is a meaningful value (breaker off), same shape as maxOrdersPerRun.
+    pauseAfterFailures:
+      typeof raw.pauseAfterFailures === 'number' &&
+      Number.isInteger(raw.pauseAfterFailures) &&
+      raw.pauseAfterFailures >= 0
+        ? raw.pauseAfterFailures
+        : DEFAULT_PAUSE_AFTER_FAILURES,
     workOrders: {
       maxSliceSize: positiveNumber(
         ((raw.workOrders ?? {}) as Record<string, unknown>).maxSliceSize,

--- a/src/remediate/config.ts
+++ b/src/remediate/config.ts
@@ -88,10 +88,10 @@ export interface RemediateConfig {
   readonly maxOrdersPerRun: number;
   /** The circuit breaker (`remediate.pauseAfterFailures`, default 2;
    *  0 disables): a work-order class whose last N consecutive counted
-   *  outcomes are failures is PAUSED — planned but not dispatched, with
+   *  FIRINGS are failures is PAUSED — planned but not dispatched, with
    *  the reason and the unpause conditions disclosed — until the policy
-   *  changes, dxkit changes, an explicit dispatch names its task, or the
-   *  failures age out of the history window. */
+   *  changes, dxkit changes, an explicit dispatch override names its
+   *  task, or the failures age out of the history window. */
   readonly pauseAfterFailures: number;
   /** Work-order planning knobs (`remediate.workOrders`). */
   readonly workOrders: {

--- a/src/remediate/dispatch.ts
+++ b/src/remediate/dispatch.ts
@@ -188,3 +188,28 @@ export function readDispatchOverrides(
       customPrompt !== undefined,
   };
 }
+
+/**
+ * Stale-workflow detection for the dispatch override (scheduler memory,
+ * 3F): the UPDATED managed workflow always defines DXKIT_DISPATCH_TASK on
+ * the run step (empty on scheduled runs), and passes --dispatch-override
+ * when the workflow_dispatch input names this task. A workflow_dispatch
+ * run where the variable is entirely ABSENT is therefore running a
+ * template from before the flag existed: its dispatches can never lift a
+ * circuit-breaker pause, and the operator should refresh the workflow.
+ * Pure over the env snapshot; the CLI surfaces the note as a warning.
+ */
+export function staleDispatchWorkflowNote(
+  env: Readonly<Record<string, string | undefined>>,
+  dispatchOverride: boolean,
+): string | undefined {
+  if (dispatchOverride) return undefined;
+  if (env.GITHUB_ACTIONS !== 'true') return undefined;
+  if (env.GITHUB_EVENT_NAME !== 'workflow_dispatch') return undefined;
+  if ('DXKIT_DISPATCH_TASK' in env) return undefined;
+  return (
+    'this looks like a workflow_dispatch run on a workflow template from before the ' +
+    'dispatch-override flag: the dispatch cannot lift a circuit-breaker pause. Run ' +
+    '`vyuh-dxkit update` to refresh the managed workflow.'
+  );
+}

--- a/src/remediate/execute.ts
+++ b/src/remediate/execute.ts
@@ -10,8 +10,6 @@
  * the lander are each unit-tested through their own seams, but the wiring
  * between them was untestable without spawning a real agent.
  */
-import * as fs from 'fs';
-import * as path from 'path';
 import { execFileSync } from 'child_process';
 import { assembleLanePrBody } from '../pr/assemble';
 import * as logger from '../logger';
@@ -29,6 +27,13 @@ import { runRemediateTask, type RemediateResult } from './run';
 import { landRemediateHead, remediateBranchFor } from './land';
 import { describeDeliveryProbe, probeDeliveryPreconditions } from '../lanes/delivery-preconditions';
 import { appendLaneEvent, LANE_LEDGER_SCHEMA_VERSION } from '../lanes/ledger';
+import { orderOutcomeRows, publishOrderRows, writeLocalOrderLedger } from './order-outcomes';
+import { remediateStamp } from './work-orders/breaker';
+import { currentHead, writeAttemptRecord, writeProvisionalRecord } from './attempt-record';
+
+// Attempt-record helpers live in `./attempt-record` (module-size split);
+// re-exported so consumers keep one import surface.
+export { taskRunJson } from './attempt-record';
 
 export interface TaskRun {
   readonly result: RemediateResult;
@@ -95,6 +100,18 @@ export interface ExecutorSeams {
   readonly defaultBranch?: (cwd: string) => string;
   /** Injected for tests: the $0 landing preflight (#286). */
   readonly probeDelivery?: typeof probeDeliveryPreconditions;
+  /** Injected for tests: the order-outcome ledger writers (3F). */
+  readonly writeOrderLedger?: typeof writeLocalOrderLedger;
+  readonly publishOrderRows?: typeof publishOrderRows;
+}
+
+/** Executor extras beyond the positional contract (kept separate from the
+ *  test-only seams: these are production inputs). */
+export interface ExecuteTaskExtras {
+  /** A human explicitly asked for this task (workflow_dispatch naming it,
+   *  or a local `remediate --task`): circuit-breaker pauses on its classes
+   *  are overridden for this run, disclosed. */
+  readonly explicitDispatch?: boolean;
 }
 
 /** Run one task through the runner and (optionally) land it — the ONE
@@ -105,6 +122,7 @@ export async function executeTask(
   taskId: string,
   land: 'pr' | 'none',
   seams: ExecutorSeams = {},
+  extras: ExecuteTaskExtras = {},
 ): Promise<TaskRun> {
   // Per-task budget: the override-merged budget rides a task-scoped config
   // copy, so the runner's enforcement + ledger see the effective caps.
@@ -217,10 +235,32 @@ export async function executeTask(
       ...(!resume.resumed && resume.blockingContext
         ? { priorBlocking: resume.blockingContext }
         : {}),
+      ...(extras.explicitDispatch ? { explicitDispatch: true } : {}),
     });
   } finally {
     reporter.stop();
   }
+
+  // The scheduler's memory (rethink 3F): project this run's per-order
+  // records into order-outcome ledger rows. Timestamps are stamped HERE by
+  // the runner layer (the delivery-ledger convention; the planner only
+  // reads). Rows exist only for landing-intent runs: a local `--land none`
+  // run leaves the tree and the remote untouched.
+  const orderRows =
+    land === 'pr'
+      ? orderOutcomeRows(result, taskId, {
+          timestamp: new Date().toISOString(),
+          stamp: remediateStamp(cwd),
+        })
+      : [];
+  // Non-landing durability: a frame-authored metadata commit on the
+  // standing branch (the resume-marker channel) — without it, the circuit
+  // breaker is blind to exactly the failures it exists to remember.
+  const publishRows = (): void => {
+    if (orderRows.length === 0) return;
+    const pub = (seams.publishOrderRows ?? publishOrderRows)(cwd, taskId, orderRows);
+    if (!pub.published && pub.note) logger.warn(`order ledger: ${pub.note}`);
+  };
 
   const draftSalvage = result.outcome === 'budget-exhausted' && salvage === 'draft-pr';
   // Guardrail-red under draft-pr salvage: the BLOCKED attempt is pushed as a
@@ -232,6 +272,7 @@ export async function executeTask(
   const blockedSalvage = result.outcome === 'guardrail-red' && salvage === 'draft-pr';
   const landEligible = result.outcome === 'verified' || draftSalvage || blockedSalvage;
   if (land !== 'pr' || !landEligible) {
+    publishRows();
     return finalizeTaskRun(cwd, taskId, {
       result,
       landed: false,
@@ -244,6 +285,7 @@ export async function executeTask(
   const defaultBranch = (seams.defaultBranch ?? detectDefaultBranch)(cwd);
   const branch = (seams.branch ?? currentBranch)(cwd);
   if (branch !== 'HEAD' && branch !== defaultBranch) {
+    publishRows();
     return finalizeTaskRun(cwd, taskId, {
       result,
       landed: false,
@@ -271,6 +313,13 @@ export async function executeTask(
       : {}),
     ...(result.envelope ? { driver: result.envelope.driver } : {}),
   });
+  // The order-outcome rows ride the SAME landing commit (composed with any
+  // unmerged standing-branch rows first, so a force-push never erases the
+  // failure history a prior non-landing run recorded).
+  const orderLedgerRel =
+    orderRows.length > 0
+      ? (seams.writeOrderLedger ?? writeLocalOrderLedger)(cwd, taskId, orderRows)
+      : null;
   // Evidence BEFORE delivery (#273): the attempt record — with the commit
   // range the workflow's patch-artifact fallback needs — is written before
   // the push, landed:false, and flipped by the finalize below on success. A
@@ -304,8 +353,12 @@ export async function executeTask(
       }),
       draft: draftSalvage || blockedSalvage,
       ledgerPath,
+      ...(orderLedgerRel ? { orderLedgerPath: orderLedgerRel } : {}),
     });
   } catch (err) {
+    // The landing failed; the outcome rows still matter to next week's
+    // breaker — try the metadata channel before disclosing the failure.
+    publishRows();
     // A landing failure is a DISCLOSED outcome, never a crash: the ledger,
     // record, and step summary all render as usual — the GateFailure
     // discipline applied to the land layer.
@@ -358,107 +411,6 @@ function finalizeTaskRun(cwd: string, taskId: string, run: TaskRun): TaskRun {
     );
   }
   return run;
-}
-
-/** The machine-readable attempt record — written pre-push (landed:false)
- *  AND at every finalize, so the evidence exists no matter where the
- *  landing dies. Best-effort plumbing, never a failure. */
-/**
- * PROVISIONAL attempt record, written BEFORE the driver spawns (#289): a
- * SIGKILL (runner OOM) is uncatchable, so every disclosure mechanism the
- * frame owns dies with it — the record written only at finalize meant a
- * killed frame left zero evidence and any committed work evaporated
- * unrecorded. This is the evidence-before-the-risky-step principle moved
- * one step earlier: the record names how far the run got (`phase:
- * 'agent'`) and carries `baseHead`, so the workflow's evidence step can
- * format-patch `baseHead..HEAD` of whatever the agent had committed
- * before death (falling back to the checkout's live HEAD — the record
- * has no `head` yet). Finalize overwrites it on every normal path.
- */
-function writeProvisionalRecord(cwd: string, taskId: string, baseHead: string): void {
-  try {
-    const dir = path.join(cwd, '.dxkit', 'cache');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, `remediate-${taskId}.json`),
-      JSON.stringify(
-        {
-          phase: 'agent',
-          outcome: 'provisional',
-          task: taskId,
-          landed: false,
-          baseHead,
-          head: null,
-          note:
-            'provisional record written before the agent spawned — if this survives the run, ' +
-            'the frame died mid-agent-phase (it could not write its own obituary); partial ' +
-            'work, if any, is in the baseHead..HEAD range of the checkout',
-        },
-        null,
-        2,
-      ) + '\n',
-      'utf8',
-    );
-  } catch {
-    // evidence plumbing, never a failure
-  }
-}
-
-/** HEAD of the checkout, or null (evidence plumbing, never a failure). */
-function currentHead(cwd: string): string | null {
-  try {
-    return execFileSync('git', ['rev-parse', 'HEAD'], {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
-  } catch {
-    return null;
-  }
-}
-
-function writeAttemptRecord(cwd: string, taskId: string, run: TaskRun): void {
-  try {
-    const dir = path.join(cwd, '.dxkit', 'cache');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, `remediate-${taskId}.json`),
-      JSON.stringify(taskRunJson(run), null, 2) + '\n',
-      'utf8',
-    );
-  } catch {
-    // the record is evidence plumbing, never a failure
-  }
-}
-
-export function taskRunJson(run: TaskRun): Record<string, unknown> {
-  const r = run.result;
-  return {
-    // The frame reached finalize — distinguishes this record from the
-    // provisional one a SIGKILL leaves behind (#289).
-    phase: 'final',
-    outcome: r.outcome,
-    task: r.task ?? null,
-    note: r.note ?? null,
-    partial: r.partial ?? false,
-    envelope: r.envelope ?? null,
-    orders: r.orders ?? null,
-    guardrailVerdict: r.guardrailVerdict ?? null,
-    branch: r.task ? remediateBranchFor(r.task) : null,
-    prUrl: run.prUrl ?? null,
-    landRefused: run.landRefused ?? null,
-    landingBlocked: run.landingBlocked ?? null,
-    landed: run.landed,
-    // The commit range of the attempt — what the workflow's evidence step
-    // format-patches into a run artifact when nothing landed.
-    baseHead: r.baseHead ?? null,
-    head: r.head ?? null,
-    // Failure evidence (machine-readable record only — never the PR body).
-    transcriptTail: r.transcriptTail ?? null,
-    // The agent's own account of a no-op (#285) — autopsiable, never rendered.
-    agentFinalMessage: r.agentFinalMessage ?? null,
-    ledger: r.ledger,
-  };
 }
 
 /** Credentials the configured driver declares, read from THIS process env

--- a/src/remediate/land.ts
+++ b/src/remediate/land.ts
@@ -36,14 +36,21 @@ export interface LandRemediateOptions {
    *  work before the push — the event then rides the PR's own diff, so
    *  "delivered" means MERGED (design §10). */
   readonly ledgerPath?: string;
+  /** Repo-relative order-outcome ledger file (the scheduler's memory,
+   *  rethink 3F), committed in the same path-scoped bookkeeping commit. */
+  readonly orderLedgerPath?: string;
   readonly exec?: Exec;
 }
 
 export function landRemediateHead(opts: LandRemediateOptions): LandRefreshResult {
   const exec = opts.exec ?? makeExec(opts.cwd);
   const branch = remediateBranchFor(opts.taskId);
-  if (opts.ledgerPath) {
-    exec('git', ['add', opts.ledgerPath]);
+  const ledgerPaths = [
+    ...(opts.ledgerPath ? [opts.ledgerPath] : []),
+    ...(opts.orderLedgerPath ? [opts.orderLedgerPath] : []),
+  ];
+  if (ledgerPaths.length > 0) {
+    exec('git', ['add', ...ledgerPaths]);
     // Explicit bot identity: a CI runner has none ambient, and a machine
     // commit should carry machine provenance locally too.
     exec(
@@ -63,13 +70,13 @@ export function landRemediateHead(opts: LandRemediateOptions): LandRefreshResult
         // and force-push unreviewed agent working state under a message that
         // reads as bookkeeping.
         '--',
-        opts.ledgerPath,
+        ...ledgerPaths,
       ],
       { allowFail: true },
     );
     // A bookkeeping failure must not block landing verified work, but a
     // silently lost event undercounts Delivered — say so (X-3).
-    const dirty = exec('git', ['status', '--porcelain', '--', opts.ledgerPath], {
+    const dirty = exec('git', ['status', '--porcelain', '--', ...ledgerPaths], {
       allowFail: true,
     }).trim();
     if (dirty !== '') {

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -25,6 +25,7 @@ function renderRecipeSection(recipes: RecipePhaseSummary): string[] {
           'agent tier.',
       );
     }
+    lines.push(...renderPausedOrders(recipes));
     lines.push('');
     return lines;
   }
@@ -63,7 +64,22 @@ function renderRecipeSection(recipes: RecipePhaseSummary): string[] {
     }
   }
   for (const d of recipes.disclosures) lines.push(`- plan disclosure: ${d}`);
+  lines.push(...renderPausedOrders(recipes));
   lines.push('');
+  return lines;
+}
+
+/** Circuit-breaker pauses (3F): a paused order is planned and selected but
+ *  dispatched by NO tier — the ledger names each one, the reason, and what
+ *  lifts the pause. Never a silent skip. */
+function renderPausedOrders(recipes: RecipePhaseSummary): string[] {
+  const paused = recipes.paused ?? [];
+  if (paused.length === 0) return [];
+  const lines: string[] = ['', '**Paused by the circuit breaker (not dispatched):**'];
+  for (const p of paused) {
+    lines.push(`- \`${p.orderId}\` (${p.class}, ${p.findings} finding(s)): ${p.reason}`);
+  }
+  lines.push(`- unpause: ${paused[0].unpause}`);
   return lines;
 }
 
@@ -236,7 +252,13 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
     lines.push('');
   }
 
-  if (r.recipes && (r.recipes.ran || r.recipes.disabled || r.recipes.planError)) {
+  if (
+    r.recipes &&
+    (r.recipes.ran ||
+      r.recipes.disabled ||
+      r.recipes.planError ||
+      (r.recipes.paused?.length ?? 0) > 0)
+  ) {
     lines.push(...renderRecipeSection(r.recipes));
   }
 

--- a/src/remediate/order-outcomes.ts
+++ b/src/remediate/order-outcomes.ts
@@ -13,14 +13,22 @@
  *     history a prior non-landing run recorded.
  *   - `publishOrderRows` (a NON-landing run): the composed file rides a
  *     frame-authored metadata commit pushed to the task's standing branch —
- *     the resume-marker precedent (zero agent content; built with
- *     plumbing commands, the working tree is never touched). Without this
- *     channel the breaker is blind exactly where it matters: a
- *     guardrail-red discard lands nothing, and its ephemeral runner dies
- *     with the evidence.
+ *     the resume-marker precedent (zero agent content; built with plumbing
+ *     commands, the working tree is never touched). Without this channel
+ *     the breaker is blind exactly where it matters: a guardrail-red
+ *     discard lands nothing, and its ephemeral runner dies with the
+ *     evidence. SECURITY: the metadata commit parents ONLY on the fetched
+ *     REMOTE branch head; when no branch exists it is an ORPHAN commit
+ *     whose tree holds the one ledger file — never the local HEAD, whose
+ *     history on a non-landing path is exactly the unverified content the
+ *     "never push unverified" law exists to keep off the remote.
  *
- * Timestamps are stamped HERE, by the runner layer at record time (the
- * delivery-ledger convention) — the planner never writes a clock.
+ * ONE ROW PER ORDER PER RUN: when the agent tier picks up an order the
+ * recipe tier refused or failed, the agent's terminal outcome is the row
+ * (a first-wins dedupe on a shared run timestamp would otherwise keep the
+ * recipe failure and pause a class that is being fixed). Timestamps are
+ * stamped HERE, by the runner layer at record time (the delivery-ledger
+ * convention) — the planner never writes a clock.
  *
  * A run's committed work is arbitrated by ONE tree verification, so every
  * order that contributed commits carries the RUN verdict as its row
@@ -30,14 +38,15 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { execFileSync } from 'child_process';
 import {
   mergeOrderRows,
   orderLedgerPath,
-  parseOrderRows,
-  readLocalOrderRows,
+  parseLedgerText,
+  readBranchOrderRows,
+  realOrderLedgerExec,
   serializeOrderRows,
   ORDER_LEDGER_SCHEMA_VERSION,
+  type OrderLedgerExec,
   type OrderOutcomeRow,
   type OrderRowOutcome,
 } from '../lanes/order-ledger';
@@ -47,14 +56,19 @@ import { BOT_IDENTITY } from '../land-refresh';
 import type { RemediateStamp } from './work-orders/breaker';
 import type { RemediateOutcome, RemediateResult } from './outcome';
 
-/** Hard cap on rows kept in one task's ledger file (append-only otherwise;
- *  comfortably wider than the reader's window so nothing in view is ever
- *  trimmed by a write). */
+/** Hard cap on recognized rows kept in one task's ledger file (append-only
+ *  otherwise; comfortably wider than the reader's window so nothing in
+ *  view is ever trimmed by a write). Foreign lines (a newer schema's rows)
+ *  are always carried through, never capped by THIS build. */
 export const ORDER_LEDGER_MAX_ROWS = 500;
 
-/** The run-verdict outcome for an order whose work was COMMITTED (one tree
- *  verification arbitrates everything that contributed commits). Outcomes
- *  with no committed-work meaning fold to the neutral 'no-op'. */
+/**
+ * The run-verdict outcome for an order whose work was COMMITTED (one tree
+ * verification arbitrates everything that contributed commits). EXHAUSTIVE
+ * over the run-outcome vocabulary on purpose: a new outcome fails to
+ * compile until someone classifies it for the breaker, instead of folding
+ * silently to neutral.
+ */
 function committedVerdict(outcome: RemediateOutcome): OrderRowOutcome {
   switch (outcome) {
     case 'verified':
@@ -69,8 +83,20 @@ function committedVerdict(outcome: RemediateOutcome): OrderRowOutcome {
       return 'install-failed';
     case 'sweep-failed':
       return 'sweep-failed';
-    default:
+    // The arms below cannot co-occur with a committed order record today
+    // (a no-op / recipes-refused run has no diff; a refusal precedes any
+    // record; order-selecting tasks declare no score hinge, catalog-
+    // pinned). Classified NEUTRAL deliberately: unreachable rows must
+    // never be able to pause or unpause a class.
+    case 'no-op':
+    case 'recipes-refused':
+    case 'score-red':
+    case 'refused':
       return 'no-op';
+    case 'agent-never-ran':
+      return 'never-ran';
+    case 'agent-failed':
+      return 'agent-failed';
   }
 }
 
@@ -81,9 +107,16 @@ function bounded(text: string | undefined): string | undefined {
 }
 
 /**
- * Project one run's result into order-outcome rows. Pure over its inputs;
- * the caller (the executor) supplies the timestamp and the environment
- * stamps every row carries for the breaker's unpause comparison.
+ * Project one run's result into order-outcome rows: ONE row per order,
+ * reflecting the TERMINAL tier's outcome — an agent attempt (completed /
+ * partial / errored) supersedes the recipe record it fell through from; a
+ * neutral agent record (not dispatched, CLI never ran) leaves the recipe
+ * tier's evidence standing. The breaker's pause list is recorded as ONE
+ * bookkeeping marker per class per firing, not a row per paused order (a
+ * weekly stream of paused rows must not drown the outcome evidence).
+ * Pure over its inputs; the caller (the executor) supplies the timestamp
+ * and the environment stamps every row carries for the breaker's unpause
+ * comparison.
  */
 export function orderOutcomeRows(
   result: Pick<RemediateResult, 'outcome' | 'recipes' | 'orders'>,
@@ -98,7 +131,7 @@ export function orderOutcomeRows(
     dxkitVersion: meta.stamp.dxkitVersion,
     policyHash: meta.stamp.policyHash,
   };
-  const rows: OrderOutcomeRow[] = [];
+  const byOrder = new Map<string, OrderOutcomeRow>();
 
   for (const rec of result.recipes?.records ?? []) {
     const o = rec.outcome;
@@ -114,7 +147,7 @@ export function orderOutcomeRows(
         : o.kind === 'failed'
           ? bounded(`${o.step}: ${o.output}`)
           : undefined;
-    rows.push({
+    byOrder.set(rec.orderId, {
       ...base,
       orderId: rec.orderId,
       class: rec.class,
@@ -125,6 +158,11 @@ export function orderOutcomeRows(
   }
 
   for (const rec of result.orders?.records ?? []) {
+    const attempted =
+      rec.outcome === 'completed' || rec.outcome === 'partial' || rec.outcome === 'failed';
+    // A neutral agent record (not-dispatched, never-ran) must not erase a
+    // recipe tier's evidence for the same order; it only stands alone.
+    if (!attempted && byOrder.has(rec.orderId)) continue;
     const outcome: OrderRowOutcome =
       rec.outcome === 'never-ran'
         ? 'never-ran'
@@ -133,7 +171,7 @@ export function orderOutcomeRows(
           : rec.outcome === 'failed'
             ? 'agent-failed'
             : committedVerdict(result.outcome);
-    rows.push({
+    byOrder.set(rec.orderId, {
       ...base,
       orderId: rec.orderId,
       class: rec.class,
@@ -144,73 +182,74 @@ export function orderOutcomeRows(
     });
   }
 
+  const rows = [...byOrder.values()];
+
+  // One paused MARKER per class per firing: bookkeeping, never evidence.
+  const pausedByClass = new Map<string, { first: string; count: number; reason: string }>();
   for (const p of result.recipes?.paused ?? []) {
+    const seen = pausedByClass.get(p.class);
+    if (seen) seen.count += 1;
+    else pausedByClass.set(p.class, { first: p.orderId, count: 1, reason: p.reason });
+  }
+  for (const [cls, p] of pausedByClass) {
     rows.push({
       ...base,
-      orderId: p.orderId,
-      class: p.class,
-      tier: p.tier,
+      orderId: p.first,
+      class: cls,
+      tier: 'recipe',
       outcome: 'paused',
-      detail: bounded(p.reason),
+      detail: bounded(`${p.count} order(s) paused: ${p.reason}`),
     });
   }
 
   return rows;
 }
 
-/** Exec seam for the ledger's git plumbing (tests inject a fake). */
-export type OrderLedgerGitExec = (
-  bin: string,
-  args: readonly string[],
-  opts?: { readonly input?: string; readonly env?: Readonly<Record<string, string>> },
-) => string;
+/** Exec seam for the ledger's git plumbing — the ONE machine git-exec
+ *  shape (`land-refresh.ts:makeExec`), re-exported by the ledger module. */
+export type OrderLedgerGitExec = OrderLedgerExec;
 
 export function realOrderLedgerGitExec(cwd: string): OrderLedgerGitExec {
-  return (bin, args, opts = {}) =>
-    execFileSync(bin, [...args], {
-      cwd,
-      encoding: 'utf8',
-      stdio: [opts.input !== undefined ? 'pipe' : 'ignore', 'pipe', 'pipe'],
-      timeout: 60_000,
-      ...(opts.input !== undefined ? { input: opts.input } : {}),
-      ...(opts.env ? { env: { ...process.env, ...opts.env } } : {}),
-    }).toString();
+  return realOrderLedgerExec(cwd);
 }
 
-/** The standing branch's current rows + head for one task, or null when
- *  unreachable (fail-open; the caller composes without them). */
+/** The one branch read (Rule 2.30: `readBranchOrderRows` in the ledger
+ *  module), keyed by task. Null = branch unreachable or absent. */
 function branchState(
   task: string,
   exec: OrderLedgerGitExec,
-): { head: string; rows: OrderOutcomeRow[] } | null {
-  const branch = remediateBranchFor(task);
-  const file = orderLedgerPath('remediate', task);
-  try {
-    exec('git', ['fetch', 'origin', branch]);
-    const head = exec('git', ['rev-parse', 'FETCH_HEAD']).trim();
-    let rows: OrderOutcomeRow[] = [];
-    try {
-      rows = parseOrderRows(exec('git', ['show', `FETCH_HEAD:${file}`]));
-    } catch {
-      // branch exists, file does not — an empty history
-    }
-    return { head, rows };
-  } catch {
-    return null;
-  }
+): { head: string; rows: OrderOutcomeRow[]; foreign: string[] } | null {
+  return readBranchOrderRows(
+    { branch: remediateBranchFor(task), file: orderLedgerPath('remediate', task) },
+    exec,
+  );
 }
 
 /** Compose the durable file content: branch rows + local rows + this run's
- *  rows, deduped, oldest first, capped so the file cannot grow forever. */
+ *  rows, deduped, oldest first, recognized rows capped so the file cannot
+ *  grow forever — and every FOREIGN line (a newer schema's rows, a corrupt
+ *  line) carried through VERBATIM. This build caps only what it can read;
+ *  dropping what it cannot would silently roll back a newer build's
+ *  memory. */
 function composeLedger(
   cwd: string,
   task: string,
   newRows: readonly OrderOutcomeRow[],
-  branchRows: readonly OrderOutcomeRow[],
+  branch: { readonly rows: readonly OrderOutcomeRow[]; readonly foreign: readonly string[] } | null,
 ): string {
-  const local = readLocalOrderRows(cwd).filter((r) => r.task === task);
-  const merged = mergeOrderRows(branchRows, local, newRows);
-  return serializeOrderRows(merged.slice(Math.max(0, merged.length - ORDER_LEDGER_MAX_ROWS)));
+  let localText = '';
+  try {
+    localText = fs.readFileSync(path.join(cwd, orderLedgerPath('remediate', task)), 'utf8');
+  } catch {
+    // no local file yet
+  }
+  const local = parseLedgerText(localText);
+  const merged = mergeOrderRows(branch?.rows ?? [], local.rows, newRows).filter(
+    (r) => r.task === task,
+  );
+  const capped = merged.slice(Math.max(0, merged.length - ORDER_LEDGER_MAX_ROWS));
+  const foreign = [...new Set([...(branch?.foreign ?? []), ...local.foreign])];
+  return serializeOrderRows(capped) + (foreign.length > 0 ? foreign.join('\n') + '\n' : '');
 }
 
 /**
@@ -227,7 +266,7 @@ export function writeLocalOrderLedger(
   if (newRows.length === 0) return null;
   const rel = orderLedgerPath('remediate', task);
   const branch = branchState(task, exec ?? realOrderLedgerGitExec(cwd));
-  const content = composeLedger(cwd, task, newRows, branch?.rows ?? []);
+  const content = composeLedger(cwd, task, newRows, branch);
   const abs = path.join(cwd, rel);
   fs.mkdirSync(path.dirname(abs), { recursive: true });
   fs.writeFileSync(abs, content, 'utf8');
@@ -242,11 +281,18 @@ export interface PublishOrderRowsResult {
 
 /**
  * Non-landing path: push the composed ledger as a frame-authored metadata
- * commit onto the task's standing branch (created from the checkout's HEAD
- * when no branch exists). Built entirely with plumbing commands — the
- * working tree and index are never touched, and the commit carries exactly
- * one path: the lane's own ledger file. A push race (a concurrent write to
- * the branch) is retried once on a fresh base; failure is a disclosed note,
+ * commit onto the task's standing branch. Built entirely with plumbing
+ * commands — the working tree and index are never touched, and the commit
+ * carries exactly one path: the lane's own ledger file.
+ *
+ * SECURITY (the never-push-unverified law): the commit parents ONLY on the
+ * fetched REMOTE branch head. When no branch is reachable it is an ORPHAN
+ * commit over an empty tree plus the ledger blob — never a child of the
+ * local HEAD, because on every non-landing path the local history past the
+ * base IS the unverified diff (a guardrail-red discard, a wrong-branch
+ * refusal), and a ledger push must not make one unverified commit
+ * reachable from the remote. A push race (a concurrent write to the
+ * branch) is retried once on a fresh base; failure is a disclosed note,
  * never a crash (evidence plumbing, the GateFailure discipline).
  */
 export function publishOrderRows(
@@ -262,14 +308,16 @@ export function publishOrderRows(
 
   const attempt = (): void => {
     const state = branchState(task, run);
-    const base = state?.head ?? run('git', ['rev-parse', 'HEAD']).trim();
-    const content = composeLedger(cwd, task, newRows, state?.rows ?? []);
+    const content = composeLedger(cwd, task, newRows, state);
     const blob = run('git', ['hash-object', '-w', '--stdin'], { input: content }).trim();
     const indexDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-order-ledger-'));
     const indexFile = path.join(indexDir, 'index');
     try {
       const env = { GIT_INDEX_FILE: indexFile };
-      run('git', ['read-tree', base], { env });
+      // With a remote head: start from ITS tree and parent on it. Without
+      // one: a fresh index (the ledger file becomes the whole tree) and no
+      // parent at all — an orphan, so no local commit ever rides along.
+      if (state) run('git', ['read-tree', state.head], { env });
       run('git', ['update-index', '--add', '--cacheinfo', `100644,${blob},${file}`], { env });
       const tree = run('git', ['write-tree'], { env }).trim();
       const commit = run('git', [
@@ -279,8 +327,7 @@ export function publishOrderRows(
         `user.email=${BOT_IDENTITY.email}`,
         'commit-tree',
         tree,
-        '-p',
-        base,
+        ...(state ? ['-p', state.head] : []),
         '-m',
         'chore(dxkit): record remediation order outcomes [skip ci]',
       ]).trim();

--- a/src/remediate/order-outcomes.ts
+++ b/src/remediate/order-outcomes.ts
@@ -1,0 +1,310 @@
+/**
+ * Order-outcome ROWS for the scheduler's memory (remediate rethink, 3F):
+ * the projection from one remediate run's per-order records (the recipe
+ * phase's, the orders phase's, and the circuit breaker's pause list) to
+ * the lane order-ledger rows (`src/lanes/order-ledger.ts`), plus the two
+ * durability channels the executor uses:
+ *
+ *   - `writeLocalOrderLedger` (a LANDING run): the composed file is written
+ *     into the checkout and committed by the lander alongside the delivery
+ *     ledger, so rows ride the standing PR's own diff and reach the default
+ *     branch on merge. Composing merges the standing branch's unmerged rows
+ *     first (fail-open), so a landing force-push never erases the failure
+ *     history a prior non-landing run recorded.
+ *   - `publishOrderRows` (a NON-landing run): the composed file rides a
+ *     frame-authored metadata commit pushed to the task's standing branch —
+ *     the resume-marker precedent (zero agent content; built with
+ *     plumbing commands, the working tree is never touched). Without this
+ *     channel the breaker is blind exactly where it matters: a
+ *     guardrail-red discard lands nothing, and its ephemeral runner dies
+ *     with the evidence.
+ *
+ * Timestamps are stamped HERE, by the runner layer at record time (the
+ * delivery-ledger convention) — the planner never writes a clock.
+ *
+ * A run's committed work is arbitrated by ONE tree verification, so every
+ * order that contributed commits carries the RUN verdict as its row
+ * outcome; refusals, failures-before-commit, and infrastructure keep their
+ * own words (the breaker's counting sets live beside the row vocabulary).
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import {
+  mergeOrderRows,
+  orderLedgerPath,
+  parseOrderRows,
+  readLocalOrderRows,
+  serializeOrderRows,
+  ORDER_LEDGER_SCHEMA_VERSION,
+  type OrderOutcomeRow,
+  type OrderRowOutcome,
+} from '../lanes/order-ledger';
+import { remediateBranchFor } from '../lanes/branches';
+import { internalGitPushArgs } from '../git-internal-push';
+import { BOT_IDENTITY } from '../land-refresh';
+import type { RemediateStamp } from './work-orders/breaker';
+import type { RemediateOutcome, RemediateResult } from './outcome';
+
+/** Hard cap on rows kept in one task's ledger file (append-only otherwise;
+ *  comfortably wider than the reader's window so nothing in view is ever
+ *  trimmed by a write). */
+export const ORDER_LEDGER_MAX_ROWS = 500;
+
+/** The run-verdict outcome for an order whose work was COMMITTED (one tree
+ *  verification arbitrates everything that contributed commits). Outcomes
+ *  with no committed-work meaning fold to the neutral 'no-op'. */
+function committedVerdict(outcome: RemediateOutcome): OrderRowOutcome {
+  switch (outcome) {
+    case 'verified':
+      return 'verified';
+    case 'budget-exhausted':
+      return 'budget-exhausted-verified';
+    case 'guardrail-red':
+      return 'guardrail-red';
+    case 'floor-red':
+      return 'floor-red';
+    case 'install-failed':
+      return 'install-failed';
+    case 'sweep-failed':
+      return 'sweep-failed';
+    default:
+      return 'no-op';
+  }
+}
+
+function bounded(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  const oneLine = text.split('\n')[0];
+  return oneLine.length > 300 ? oneLine.slice(0, 297) + '...' : oneLine;
+}
+
+/**
+ * Project one run's result into order-outcome rows. Pure over its inputs;
+ * the caller (the executor) supplies the timestamp and the environment
+ * stamps every row carries for the breaker's unpause comparison.
+ */
+export function orderOutcomeRows(
+  result: Pick<RemediateResult, 'outcome' | 'recipes' | 'orders'>,
+  task: string,
+  meta: { readonly timestamp: string; readonly stamp: RemediateStamp },
+): OrderOutcomeRow[] {
+  const base = {
+    schema_version: ORDER_LEDGER_SCHEMA_VERSION,
+    timestamp: meta.timestamp,
+    lane: 'remediate' as const,
+    task,
+    dxkitVersion: meta.stamp.dxkitVersion,
+    policyHash: meta.stamp.policyHash,
+  };
+  const rows: OrderOutcomeRow[] = [];
+
+  for (const rec of result.recipes?.records ?? []) {
+    const o = rec.outcome;
+    const outcome: OrderRowOutcome =
+      o.kind === 'applied'
+        ? committedVerdict(result.outcome)
+        : o.kind === 'refused'
+          ? 'refused'
+          : 'failed-recipe';
+    const detail =
+      o.kind === 'refused'
+        ? bounded(o.reason)
+        : o.kind === 'failed'
+          ? bounded(`${o.step}: ${o.output}`)
+          : undefined;
+    rows.push({
+      ...base,
+      orderId: rec.orderId,
+      class: rec.class,
+      tier: 'recipe',
+      outcome,
+      ...(detail ? { detail } : {}),
+    });
+  }
+
+  for (const rec of result.orders?.records ?? []) {
+    const outcome: OrderRowOutcome =
+      rec.outcome === 'never-ran'
+        ? 'never-ran'
+        : rec.outcome === 'not-dispatched'
+          ? 'not-dispatched'
+          : rec.outcome === 'failed'
+            ? 'agent-failed'
+            : committedVerdict(result.outcome);
+    rows.push({
+      ...base,
+      orderId: rec.orderId,
+      class: rec.class,
+      tier: 'agent',
+      outcome,
+      ...(rec.detail ? { detail: bounded(rec.detail) } : {}),
+      ...(rec.spent ? { spend: rec.spent } : {}),
+    });
+  }
+
+  for (const p of result.recipes?.paused ?? []) {
+    rows.push({
+      ...base,
+      orderId: p.orderId,
+      class: p.class,
+      tier: p.tier,
+      outcome: 'paused',
+      detail: bounded(p.reason),
+    });
+  }
+
+  return rows;
+}
+
+/** Exec seam for the ledger's git plumbing (tests inject a fake). */
+export type OrderLedgerGitExec = (
+  bin: string,
+  args: readonly string[],
+  opts?: { readonly input?: string; readonly env?: Readonly<Record<string, string>> },
+) => string;
+
+export function realOrderLedgerGitExec(cwd: string): OrderLedgerGitExec {
+  return (bin, args, opts = {}) =>
+    execFileSync(bin, [...args], {
+      cwd,
+      encoding: 'utf8',
+      stdio: [opts.input !== undefined ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+      timeout: 60_000,
+      ...(opts.input !== undefined ? { input: opts.input } : {}),
+      ...(opts.env ? { env: { ...process.env, ...opts.env } } : {}),
+    }).toString();
+}
+
+/** The standing branch's current rows + head for one task, or null when
+ *  unreachable (fail-open; the caller composes without them). */
+function branchState(
+  task: string,
+  exec: OrderLedgerGitExec,
+): { head: string; rows: OrderOutcomeRow[] } | null {
+  const branch = remediateBranchFor(task);
+  const file = orderLedgerPath('remediate', task);
+  try {
+    exec('git', ['fetch', 'origin', branch]);
+    const head = exec('git', ['rev-parse', 'FETCH_HEAD']).trim();
+    let rows: OrderOutcomeRow[] = [];
+    try {
+      rows = parseOrderRows(exec('git', ['show', `FETCH_HEAD:${file}`]));
+    } catch {
+      // branch exists, file does not — an empty history
+    }
+    return { head, rows };
+  } catch {
+    return null;
+  }
+}
+
+/** Compose the durable file content: branch rows + local rows + this run's
+ *  rows, deduped, oldest first, capped so the file cannot grow forever. */
+function composeLedger(
+  cwd: string,
+  task: string,
+  newRows: readonly OrderOutcomeRow[],
+  branchRows: readonly OrderOutcomeRow[],
+): string {
+  const local = readLocalOrderRows(cwd).filter((r) => r.task === task);
+  const merged = mergeOrderRows(branchRows, local, newRows);
+  return serializeOrderRows(merged.slice(Math.max(0, merged.length - ORDER_LEDGER_MAX_ROWS)));
+}
+
+/**
+ * Landing path: write the composed ledger file into the checkout so the
+ * lander commits it with the delivery ledger and the work. Returns the
+ * repo-relative path, or null when nothing was written.
+ */
+export function writeLocalOrderLedger(
+  cwd: string,
+  task: string,
+  newRows: readonly OrderOutcomeRow[],
+  exec?: OrderLedgerGitExec,
+): string | null {
+  if (newRows.length === 0) return null;
+  const rel = orderLedgerPath('remediate', task);
+  const branch = branchState(task, exec ?? realOrderLedgerGitExec(cwd));
+  const content = composeLedger(cwd, task, newRows, branch?.rows ?? []);
+  const abs = path.join(cwd, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf8');
+  return rel;
+}
+
+export interface PublishOrderRowsResult {
+  readonly published: boolean;
+  /** Why not, when `published` is false — disclosed by the caller. */
+  readonly note?: string;
+}
+
+/**
+ * Non-landing path: push the composed ledger as a frame-authored metadata
+ * commit onto the task's standing branch (created from the checkout's HEAD
+ * when no branch exists). Built entirely with plumbing commands — the
+ * working tree and index are never touched, and the commit carries exactly
+ * one path: the lane's own ledger file. A push race (a concurrent write to
+ * the branch) is retried once on a fresh base; failure is a disclosed note,
+ * never a crash (evidence plumbing, the GateFailure discipline).
+ */
+export function publishOrderRows(
+  cwd: string,
+  task: string,
+  newRows: readonly OrderOutcomeRow[],
+  exec?: OrderLedgerGitExec,
+): PublishOrderRowsResult {
+  if (newRows.length === 0) return { published: false, note: 'no order rows to record' };
+  const run = exec ?? realOrderLedgerGitExec(cwd);
+  const branch = remediateBranchFor(task);
+  const file = orderLedgerPath('remediate', task);
+
+  const attempt = (): void => {
+    const state = branchState(task, run);
+    const base = state?.head ?? run('git', ['rev-parse', 'HEAD']).trim();
+    const content = composeLedger(cwd, task, newRows, state?.rows ?? []);
+    const blob = run('git', ['hash-object', '-w', '--stdin'], { input: content }).trim();
+    const indexDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-order-ledger-'));
+    const indexFile = path.join(indexDir, 'index');
+    try {
+      const env = { GIT_INDEX_FILE: indexFile };
+      run('git', ['read-tree', base], { env });
+      run('git', ['update-index', '--add', '--cacheinfo', `100644,${blob},${file}`], { env });
+      const tree = run('git', ['write-tree'], { env }).trim();
+      const commit = run('git', [
+        '-c',
+        `user.name=${BOT_IDENTITY.name}`,
+        '-c',
+        `user.email=${BOT_IDENTITY.email}`,
+        'commit-tree',
+        tree,
+        '-p',
+        base,
+        '-m',
+        'chore(dxkit): record remediation order outcomes [skip ci]',
+      ]).trim();
+      run('git', internalGitPushArgs(`${commit}:refs/heads/${branch}`));
+    } finally {
+      fs.rmSync(indexDir, { recursive: true, force: true });
+    }
+  };
+
+  try {
+    attempt();
+    return { published: true };
+  } catch {
+    try {
+      attempt(); // one retry on a fresh base (a concurrent push is a race, not a fault)
+      return { published: true };
+    } catch (err) {
+      return {
+        published: false,
+        note:
+          `order-outcome rows could not be recorded on '${branch}' ` +
+          `(${err instanceof Error ? err.message.split('\n')[0] : String(err)}), so the ` +
+          'circuit breaker will not see this run; the job summary remains the evidence',
+      };
+    }
+  }
+}

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -267,6 +267,11 @@ export interface RemediateRunOptions {
    *  resume anchor — the attempt's diff is discarded and this rides the next
    *  run's order prompts as a NEGATIVE constraint ("do not reintroduce"). */
   readonly priorBlocking?: string;
+  /** True when a human explicitly asked for THIS task (a workflow_dispatch
+   *  naming it, or a local `remediate --task`): the circuit breaker's
+   *  pauses on the task's classes are overridden for this run, disclosed.
+   *  Scheduled matrix runs leave it unset. */
+  readonly explicitDispatch?: boolean;
   /** Injected for tests: replaces the recipe phase (plan + execute the
    *  deterministic tier), the armInLoopGate seam pattern. */
   readonly runRecipePhase?: typeof runRecipePhaseForTask;

--- a/src/remediate/plan-cli.ts
+++ b/src/remediate/plan-cli.ts
@@ -116,6 +116,7 @@ export async function runRemediatePlan(
   let depScanSource: DepScanSource | null = null;
   let disclosures: readonly string[] = [];
   let pauses: readonly ClassPause[] = [];
+  let evidenceDegraded: string | null = null;
   let planError: string | null = null;
   try {
     const gathered = await planRepoWorkOrders(cwd, config, {
@@ -127,6 +128,7 @@ export async function runRemediatePlan(
     depScanSource = gathered.depScanSource;
     disclosures = gathered.disclosures;
     pauses = gathered.pauses;
+    evidenceDegraded = gathered.evidenceDegraded;
   } catch (err) {
     planError = err instanceof Error ? err.message : String(err);
   }
@@ -135,7 +137,7 @@ export async function runRemediatePlan(
   // with no open (unpaused) orders spawns no job; the value order comes from
   // the plan; the spend ceiling trims lowest-value first. Falls back to the
   // static policy task list when no plan exists, disclosed.
-  const matrix = deriveScheduledMatrix({ config, plan, planError });
+  const matrix = deriveScheduledMatrix({ config, plan, planError, evidenceDegraded });
   // The disclosed per-RUN spend projection (the undisclosed-4x class): each
   // matrix task is its own invocation with its own maxUsd, so one firing may
   // spend the SUM — a ceiling multiplication the serial shape's coupling
@@ -167,6 +169,7 @@ export async function runRemediatePlan(
           matrixTasks: matrix.run,
           deferredBySpendCeiling: matrix.deferred,
           matrixSource: matrix.source,
+          matrixEvidenceDegraded: evidenceDegraded,
           matrixNoOpenOrders: matrix.noOpenOrders,
           matrixLegacyOpenEnded: matrix.legacyOpenEnded,
           matrixDisclosures: matrix.disclosures,

--- a/src/remediate/plan-cli.ts
+++ b/src/remediate/plan-cli.ts
@@ -5,7 +5,7 @@
  * managed workflow reads. Split from `cli.ts` purely for module size.
  */
 import * as logger from '../logger';
-import { budgetForTask, resolveRemediateConfig, tasksWithinSpendCeiling } from './config';
+import { budgetForTask, resolveRemediateConfig } from './config';
 import { resolveModelSetting } from './driver';
 import { AGENT_DRIVERS, driverById } from './registry';
 import { remediateTaskById } from './tasks';
@@ -19,6 +19,8 @@ import {
 } from './work-orders/gather';
 import { renderWorkOrderSummary } from './work-orders/render';
 import type { WorkOrderPlan } from './work-orders/types';
+import type { ClassPause } from './work-orders/breaker';
+import { deriveScheduledMatrix } from './work-orders/schedule';
 
 export interface RemediatePlanOptions {
   readonly json?: boolean;
@@ -55,6 +57,7 @@ function projectWorkOrders(plan: WorkOrderPlan) {
       recipe: o.recipe ?? null,
       findings: o.findings.length,
       findingIds: o.findings.map((f) => f.id),
+      paused: o.paused ?? null,
       attribution: [...new Set(o.findings.map((f) => f.attribution))],
       envelope: o.envelope,
       install: o.constraints.install ?? null,
@@ -103,27 +106,16 @@ export async function runRemediatePlan(
   });
 
   const availability = driver ? driver.available(cwd) : undefined;
-  // The run-level spend ceiling, applied here so the WORKFLOW's matrix reads
-  // the trimmed list from the plan (one derivation) instead of re-deriving it.
-  const ceiling = tasksWithinSpendCeiling(config);
-  // The disclosed per-RUN spend projection (the undisclosed-4x class): each
-  // matrix task is its own invocation with its own maxUsd, so one firing may
-  // spend the SUM — a ceiling multiplication the serial shape's coupling
-  // used to hide. Derived from the same per-task budgets the runner
-  // enforces, and shown whether or not maxSpendPerRun caps it.
-  const projectedMaxSpendUsd = ceiling.run.reduce(
-    (sum, taskId) => sum + budgetForTask(config, taskId).maxUsd,
-    0,
-  );
 
   // The work-order plan (remediate rethink, section 3A): the finite units the
   // lane would dispatch, from the live entry floor + debt + deferrals via the
-  // ONE gather adapter. Fail-open: a gather failure is disclosed, never a
-  // crashed plan.
+  // ONE gather adapter (circuit-breaker pauses applied there). Fail-open: a
+  // gather failure is disclosed, never a crashed plan.
   let plan: WorkOrderPlan | null = null;
   let floorSource: FloorSource | null = null;
   let depScanSource: DepScanSource | null = null;
   let disclosures: readonly string[] = [];
+  let pauses: readonly ClassPause[] = [];
   let planError: string | null = null;
   try {
     const gathered = await planRepoWorkOrders(cwd, config, {
@@ -134,9 +126,25 @@ export async function runRemediatePlan(
     floorSource = gathered.floorSource;
     depScanSource = gathered.depScanSource;
     disclosures = gathered.disclosures;
+    pauses = gathered.pauses;
   } catch (err) {
     planError = err instanceof Error ? err.message : String(err);
   }
+
+  // The scheduled matrix, derived from the OPEN orders (section 3F): a task
+  // with no open (unpaused) orders spawns no job; the value order comes from
+  // the plan; the spend ceiling trims lowest-value first. Falls back to the
+  // static policy task list when no plan exists, disclosed.
+  const matrix = deriveScheduledMatrix({ config, plan, planError });
+  // The disclosed per-RUN spend projection (the undisclosed-4x class): each
+  // matrix task is its own invocation with its own maxUsd, so one firing may
+  // spend the SUM — a ceiling multiplication the serial shape's coupling
+  // used to hide. Derived from the same per-task budgets the runner
+  // enforces, and shown whether or not maxSpendPerRun caps it.
+  const projectedMaxSpendUsd = matrix.run.reduce(
+    (sum, taskId) => sum + budgetForTask(config, taskId).maxUsd,
+    0,
+  );
 
   if (opts.json) {
     process.stdout.write(
@@ -152,10 +160,19 @@ export async function runRemediatePlan(
           salvage: config.salvage,
           schedule: config.schedule,
           tasks: rows,
-          /** The per-task workflow matrix: enabled tasks within the run's
-           *  spend ceiling, in declaration order. */
-          matrixTasks: ceiling.run,
-          deferredBySpendCeiling: ceiling.deferred,
+          /** The per-task workflow matrix: derived from the OPEN work orders
+           *  (value order, spend ceiling applied); a task with no open
+           *  orders spawns no job. Static policy-list fallback when no plan
+           *  exists (matrixSource says which). */
+          matrixTasks: matrix.run,
+          deferredBySpendCeiling: matrix.deferred,
+          matrixSource: matrix.source,
+          matrixNoOpenOrders: matrix.noOpenOrders,
+          matrixLegacyOpenEnded: matrix.legacyOpenEnded,
+          matrixDisclosures: matrix.disclosures,
+          /** Classes the circuit breaker paused (orders carry per-order
+           *  marks; this is the class-level summary with the reasons). */
+          pausedClasses: pauses,
           maxSpendPerRun: config.maxSpendPerRun,
           /** What one firing may spend: Σ of the matrix tasks' per-task
            *  maxUsd (each matrix job is its own invocation with its own
@@ -216,7 +233,7 @@ export async function runRemediatePlan(
     );
   }
   logger.info(
-    `per-run spend projection: up to $${projectedMaxSpendUsd} across ${ceiling.run.length} ` +
+    `per-run spend projection: up to $${projectedMaxSpendUsd} across ${matrix.run.length} ` +
       `task(s) in one firing` +
       (config.maxSpendPerRun > 0
         ? ` (maxSpendPerRun: $${config.maxSpendPerRun})`
@@ -239,11 +256,20 @@ export async function runRemediatePlan(
   for (const unknown of config.unknownTasks) {
     logger.warn(`  unknown task in policy (ignored): '${unknown}'`);
   }
-  if (ceiling.deferred.length > 0) {
+  if (matrix.deferred.length > 0) {
     logger.warn(
-      `  spend ceiling ($${config.maxSpendPerRun}/run): ${ceiling.deferred.join(', ')} ` +
+      `  spend ceiling ($${config.maxSpendPerRun}/run): ${matrix.deferred.join(', ')} ` +
         'deferred to the next firing (disclosed, never dropped).',
     );
+  }
+  logger.info(
+    `scheduled matrix (${matrix.source}): ` +
+      (matrix.run.length > 0 ? matrix.run.join(', ') : 'no jobs (nothing to spend on)'),
+  );
+  for (const d of matrix.disclosures) logger.dim(`  ${d}`);
+  for (const pause of pauses) {
+    logger.warn(`  circuit breaker: class '${pause.class}' PAUSED: ${pause.reason}`);
+    logger.warn(`    unpause: ${pause.unpause}`);
   }
 
   if (planError) {

--- a/src/remediate/recipes/complete.ts
+++ b/src/remediate/recipes/complete.ts
@@ -39,6 +39,9 @@ export async function recipeTierStep(
       taskId: args.task.id,
       config: opts.config,
       entryFloor: args.entryFloor,
+      // An explicit human dispatch overrides the circuit breaker for this
+      // task's classes (disclosed by the breaker, never silent).
+      ...(opts.explicitDispatch ? { gather: { dispatchedTask: args.task.id } } : {}),
     });
   } catch (err) {
     recipes = {
@@ -51,7 +54,31 @@ export async function recipeTierStep(
     };
   }
   const selected = recipes.selectedRecipeTier + recipes.selectedAgentTier;
-  if (selected === 0) return { recipes };
+  if (selected === 0) {
+    // Every dispatchable order gone but PAUSED orders remain: the circuit
+    // breaker declined the spend. Complete here at $0 with the pause and
+    // its unpause conditions named — falling through would hand the task's
+    // open-ended legacy prompt to an agent, re-buying the exact failure the
+    // pause exists to stop.
+    const pausedClasses = [...new Set((recipes.paused ?? []).map((p) => p.class))];
+    if (pausedClasses.length > 0) {
+      const first = recipes.paused![0];
+      return {
+        recipes,
+        done: {
+          outcome: 'no-op',
+          task: args.task.id,
+          recipes,
+          floor: args.entryFloor,
+          note:
+            `every work order this task selects is PAUSED by the circuit breaker ` +
+            `(class(es): ${pausedClasses.join(', ')}); no agent was spawned, nothing was ` +
+            `spent ($0). Reason: ${first.reason}. Unpause: ${first.unpause}.`,
+        },
+      };
+    }
+    return { recipes };
+  }
   // Order-driven dispatch (the scoped-agent unit): with a plan in hand and a
   // positive per-run order cap, everything the recipe tier left OPEN — the
   // agent-tier orders plus every refused/failed recipe order — goes to the

--- a/src/remediate/recipes/run-recipes.ts
+++ b/src/remediate/recipes/run-recipes.ts
@@ -52,6 +52,17 @@ export interface RecipeOrderRecord {
   readonly droppedPaths?: readonly string[];
 }
 
+/** One order the circuit breaker paused — planned, selected by this task,
+ *  and deliberately NOT dispatched by any tier (disclosed, never silent). */
+export interface PausedOrderRecord {
+  readonly orderId: string;
+  readonly class: string;
+  readonly tier: 'recipe' | 'agent';
+  readonly findings: number;
+  readonly reason: string;
+  readonly unpause: string;
+}
+
 export interface RecipePhaseSummary {
   /** Did the phase execute at all? False when disabled, when planning
    *  failed, or when the task selects no recipe-tier orders. */
@@ -68,6 +79,10 @@ export interface RecipePhaseSummary {
    *  is disclosed so a reader knows what remains. */
   readonly selectedRecipeTier: number;
   readonly selectedAgentTier: number;
+  /** Orders the task selected whose class the circuit breaker PAUSED: in
+   *  neither tier count above, dispatched by nothing, disclosed here and in
+   *  the ledger (remediate rethink 3F — never a silent skip). */
+  readonly paused?: readonly PausedOrderRecord[];
   readonly records: readonly RecipeOrderRecord[];
   /** The orders LEFT for the agent tier after this phase, in plan (value)
    *  order: the selected agent-tier orders, plus every recipe-tier order
@@ -317,7 +332,21 @@ export async function runRecipePhaseForTask(opts: RecipePhaseOptions): Promise<R
       ...(opts.config.recipes.enabled ? {} : { disabled: true }),
     });
   }
-  const selected = selectOrders(plan.plan, classesSelectedBy(opts.taskId));
+  const allSelected = selectOrders(plan.plan, classesSelectedBy(opts.taskId));
+  // The circuit breaker's marks (applied by the ONE gather+plan entry
+  // point): a paused order is dispatched by NO tier — not the recipe tier
+  // here, not the agent queue below — and is disclosed, never dropped.
+  const pausedOrders = allSelected.filter((o) => o.paused);
+  const paused: PausedOrderRecord[] = pausedOrders.map((o) => ({
+    orderId: o.id,
+    class: String(o.class),
+    tier: o.tier,
+    findings: o.findings.length,
+    reason: o.paused!.reason,
+    unpause: o.paused!.unpause,
+  }));
+  const pausedDisclosure = paused.length > 0 ? { paused } : {};
+  const selected = allSelected.filter((o) => !o.paused);
   const recipeTier = selected.filter((o) => o.tier === 'recipe');
   if (!opts.config.recipes.enabled) {
     // The knob's documented meaning: route EVERY selected order to the
@@ -328,6 +357,7 @@ export async function runRecipePhaseForTask(opts: RecipePhaseOptions): Promise<R
       disclosures: plan.disclosures,
       selectedRecipeTier: 0,
       selectedAgentTier: selected.length,
+      ...pausedDisclosure,
       agentOrders: selected,
     });
   }
@@ -335,6 +365,7 @@ export async function runRecipePhaseForTask(opts: RecipePhaseOptions): Promise<R
     disclosures: plan.disclosures,
     selectedRecipeTier: recipeTier.length,
     selectedAgentTier: selected.length - recipeTier.length,
+    ...pausedDisclosure,
   };
   if (recipeTier.length === 0) {
     return { ran: false, records: [], ...summaryBase, agentOrders: selected };

--- a/src/remediate/work-orders/breaker.ts
+++ b/src/remediate/work-orders/breaker.ts
@@ -8,8 +8,9 @@
  * The evidence is the order-outcome ledger (`src/lanes/order-ledger.ts`),
  * read through its ONE reader. The counting rules live beside the row
  * vocabulary there (`ORDER_FAILURE_OUTCOMES` / `ORDER_SUCCESS_OUTCOMES`):
- * walking a class's rows newest-first, a success ends the streak, a failure
- * extends it, and everything else (a refusal, an infra never-ran, a paused
+ * walking a class's FIRINGS newest-first (rows grouped by run timestamp;
+ * one red run is one failure event however many orders it carried), a
+ * success ends the streak, a failure extends it, and everything else (a refusal, an infra never-ran, a paused
  * row this breaker itself wrote) is neutral — it neither counts nor resets,
  * because nothing was actually tried.
  *
@@ -90,9 +91,11 @@ function unpauseConditions(cls: string): string {
   return (
     'the pause lifts when the remediate policy changes, when dxkit is upgraded, ' +
     (task
-      ? `when the '${task}' task is dispatched explicitly (workflow dispatch, or a local ` +
-        `\`vyuh-dxkit remediate --task ${task}\`), `
-      : 'when the owning task is dispatched explicitly, ') +
+      ? `on an explicit dispatch override (locally: \`vyuh-dxkit remediate --task ${task} ` +
+        `--dispatch-override\`; or the managed workflow's Run-workflow form with task ` +
+        `'${task}', which needs the current workflow template, so run \`vyuh-dxkit update\` ` +
+        `first if a dispatch does not lift the pause), `
+      : 'on an explicit dispatch override of the owning task, ') +
     'or when the failures age out of the history window'
   );
 }
@@ -126,22 +129,56 @@ export function evaluateClassPauses(
   }
 
   for (const [cls, list] of byClass) {
-    const newestFirst = [...list].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    // The unit of counting is a FIRING, not a row: one run stamps every
+    // row with one timestamp, and the shared tree verification smears the
+    // run verdict onto every committed order — so a single red firing that
+    // carried two orders of a class is ONE failure event, never two (a
+    // per-row count would let one firing hit the threshold by itself).
+    const firings = new Map<string, OrderOutcomeRow[]>();
+    for (const row of list) {
+      const key = `${row.task}\0${row.timestamp}`;
+      const rowsOf = firings.get(key) ?? [];
+      rowsOf.push(row);
+      firings.set(key, rowsOf);
+    }
+    const newestFirst = [...firings.values()].sort((a, b) =>
+      b[0].timestamp.localeCompare(a[0].timestamp),
+    );
     let failures = 0;
     let latest: OrderOutcomeRow | undefined;
-    for (const row of newestFirst) {
-      const outcome = row.outcome;
-      if (ORDER_SUCCESS_OUTCOMES.has(outcome)) break;
-      if (ORDER_FAILURE_OUTCOMES.has(outcome)) {
-        failures += 1;
-        latest = latest ?? row;
+    let sawSuccess = false;
+    for (const firing of newestFirst) {
+      // A firing with any success row RESETS (the class produced verified
+      // work, whatever else happened alongside); else any failure row
+      // makes it one failure event; else it is neutral (nothing tried).
+      if (firing.some((r) => ORDER_SUCCESS_OUTCOMES.has(r.outcome))) {
+        sawSuccess = true;
+        break;
       }
-      // neutral rows (refused, never-ran, paused, ...) neither count nor reset
+      const failureRow = firing.find((r) => ORDER_FAILURE_OUTCOMES.has(r.outcome));
+      if (failureRow) {
+        failures += 1;
+        latest = latest ?? failureRow;
+      }
+      // neutral firings (refused, never-ran, paused markers) neither count nor reset
     }
-    if (failures < opts.threshold || !latest) continue;
+    if (failures < opts.threshold || !latest) {
+      // The documented age-out lift, DISCLOSED: a paused marker in the
+      // window with the failure streak no longer meeting the threshold
+      // (and no success explaining the reset) means the evidence aged out
+      // of the bounded window — the retry horizon engaging, never silent.
+      if (!sawSuccess && list.some((r) => r.outcome === 'paused')) {
+        disclosures.push(
+          `circuit breaker: class '${cls}' was paused previously and its failure evidence ` +
+            'aged out of the bounded history window, so the pause lifted (the documented ' +
+            'retry horizon): retrying',
+        );
+      }
+      continue;
+    }
 
     const streak =
-      `the last ${failures} counted outcome(s) for this class were failures ` +
+      `the last ${failures} counted firing(s) for this class were failures ` +
       `(latest: ${latest.outcome} at ${latest.timestamp})`;
     if (latest.dxkitVersion !== opts.current.dxkitVersion) {
       disclosures.push(

--- a/src/remediate/work-orders/breaker.ts
+++ b/src/remediate/work-orders/breaker.ts
@@ -1,0 +1,195 @@
+/**
+ * The circuit breaker (remediate rethink, section 3F): a work-order CLASS
+ * whose recent history is an unbroken failure streak is PAUSED — the
+ * planner still plans its orders, every surface still shows them, but no
+ * tier dispatches them, so the scheduled lane stops re-buying the same
+ * failure every firing.
+ *
+ * The evidence is the order-outcome ledger (`src/lanes/order-ledger.ts`),
+ * read through its ONE reader. The counting rules live beside the row
+ * vocabulary there (`ORDER_FAILURE_OUTCOMES` / `ORDER_SUCCESS_OUTCOMES`):
+ * walking a class's rows newest-first, a success ends the streak, a failure
+ * extends it, and everything else (a refusal, an infra never-ran, a paused
+ * row this breaker itself wrote) is neutral — it neither counts nor resets,
+ * because nothing was actually tried.
+ *
+ * A pause LIFTS, by design, on any signal that the next attempt would not
+ * be a rerun of the same failure:
+ *   - the remediate policy changed (every row carries `policyHash`);
+ *   - dxkit changed (every row carries `dxkitVersion`);
+ *   - a human explicitly dispatched the class's task (workflow_dispatch
+ *     naming the task, or a local `remediate --task <t>`);
+ *   - the failures aged out of the bounded history window (the natural
+ *     retry horizon — a pause is never a forever-off switch).
+ * Each lift is DISCLOSED, never silent, same as the pause itself.
+ */
+import {
+  ORDER_FAILURE_OUTCOMES,
+  ORDER_SUCCESS_OUTCOMES,
+  type OrderOutcomeRow,
+} from '../../lanes/order-ledger';
+import { hashRecallInputs } from '../../baseline/recall';
+import { readPolicySection } from '../../baseline/policy-text';
+import { VERSION } from '../../constants';
+import {
+  WORK_ORDER_CLASSES,
+  isBuiltinWorkOrderClass,
+  type WorkOrder,
+  type WorkOrderPause,
+  type WorkOrderPlan,
+} from './types';
+
+/** The environment stamps every ledger row carries and every pause
+ *  evaluation compares against. */
+export interface RemediateStamp {
+  readonly dxkitVersion: string;
+  readonly policyHash: string;
+}
+
+/** The current stamps for a repo: dxkit's own version plus a stable hash of
+ *  the committed `remediate` policy section (through the one policy reader;
+ *  an absent section hashes as the empty object, so adding one IS a policy
+ *  change). Non-identity hashing — Rule 9 does not apply. */
+export function remediateStamp(cwd: string): RemediateStamp {
+  let section: unknown = {};
+  try {
+    section = readPolicySection(cwd, 'remediate') ?? {};
+  } catch {
+    // fail-open: an unreadable policy stamps as empty (and a later readable
+    // one reads as a policy change, which unpauses — the safe direction)
+  }
+  return {
+    dxkitVersion: VERSION,
+    policyHash: hashRecallInputs({ remediate: JSON.stringify(section) }),
+  };
+}
+
+/** One paused class, with everything a surface needs to disclose it. */
+export interface ClassPause {
+  readonly class: string;
+  /** Consecutive counted failures in the streak. */
+  readonly failures: number;
+  /** The newest failure's outcome + timestamp (the evidence pointer). */
+  readonly latestOutcome: string;
+  readonly latestAt: string;
+  readonly reason: string;
+  readonly unpause: string;
+}
+
+export interface BreakerOptions {
+  /** `remediate.pauseAfterFailures`; <= 0 disables the breaker. */
+  readonly threshold: number;
+  readonly current: RemediateStamp;
+  /** A task explicitly named by a human (workflow_dispatch input, or a
+   *  local `remediate --task`): its classes bypass any pause, disclosed. */
+  readonly dispatchedTask?: string;
+}
+
+function unpauseConditions(cls: string): string {
+  const task = isBuiltinWorkOrderClass(cls) ? WORK_ORDER_CLASSES[cls].task : undefined;
+  return (
+    'the pause lifts when the remediate policy changes, when dxkit is upgraded, ' +
+    (task
+      ? `when the '${task}' task is dispatched explicitly (workflow dispatch, or a local ` +
+        `\`vyuh-dxkit remediate --task ${task}\`), `
+      : 'when the owning task is dispatched explicitly, ') +
+    'or when the failures age out of the history window'
+  );
+}
+
+/**
+ * Evaluate the breaker for every class in the history. Returns the paused
+ * classes plus the disclosures for pauses that were LIFTED by an unpause
+ * condition (a lift must be as visible as the pause it replaces).
+ */
+export function evaluateClassPauses(
+  rows: readonly OrderOutcomeRow[],
+  opts: BreakerOptions,
+): { pauses: ReadonlyMap<string, ClassPause>; disclosures: readonly string[] } {
+  const pauses = new Map<string, ClassPause>();
+  const disclosures: string[] = [];
+  if (opts.threshold <= 0) return { pauses, disclosures };
+
+  const dispatchedClasses = new Set<string>(
+    opts.dispatchedTask
+      ? Object.entries(WORK_ORDER_CLASSES)
+          .filter(([, decl]) => decl.task === opts.dispatchedTask)
+          .map(([cls]) => cls)
+      : [],
+  );
+
+  const byClass = new Map<string, OrderOutcomeRow[]>();
+  for (const row of rows) {
+    const list = byClass.get(row.class) ?? [];
+    list.push(row);
+    byClass.set(row.class, list);
+  }
+
+  for (const [cls, list] of byClass) {
+    const newestFirst = [...list].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    let failures = 0;
+    let latest: OrderOutcomeRow | undefined;
+    for (const row of newestFirst) {
+      const outcome = row.outcome;
+      if (ORDER_SUCCESS_OUTCOMES.has(outcome)) break;
+      if (ORDER_FAILURE_OUTCOMES.has(outcome)) {
+        failures += 1;
+        latest = latest ?? row;
+      }
+      // neutral rows (refused, never-ran, paused, ...) neither count nor reset
+    }
+    if (failures < opts.threshold || !latest) continue;
+
+    const streak =
+      `the last ${failures} counted outcome(s) for this class were failures ` +
+      `(latest: ${latest.outcome} at ${latest.timestamp})`;
+    if (latest.dxkitVersion !== opts.current.dxkitVersion) {
+      disclosures.push(
+        `circuit breaker: class '${cls}' would be paused (${streak}), but dxkit changed ` +
+          `since (${latest.dxkitVersion} -> ${opts.current.dxkitVersion}): retrying`,
+      );
+      continue;
+    }
+    if (latest.policyHash !== opts.current.policyHash) {
+      disclosures.push(
+        `circuit breaker: class '${cls}' would be paused (${streak}), but the remediate ` +
+          'policy changed since the failures: retrying',
+      );
+      continue;
+    }
+    if (dispatchedClasses.has(cls)) {
+      disclosures.push(
+        `circuit breaker: class '${cls}' is paused (${streak}), but this run was ` +
+          `dispatched explicitly for its task ('${opts.dispatchedTask}'), so the pause is ` +
+          'overridden for this run',
+      );
+      continue;
+    }
+    pauses.set(cls, {
+      class: cls,
+      failures,
+      latestOutcome: latest.outcome,
+      latestAt: latest.timestamp,
+      reason: `${streak}; paused to stop re-spending on the same failure (remediate.pauseAfterFailures: ${opts.threshold})`,
+      unpause: unpauseConditions(cls),
+    });
+  }
+  return { pauses, disclosures };
+}
+
+/** Mark every order of a paused class. The plan keeps its shape and value
+ *  order; only the `paused` mark is added — planned, disclosed, not
+ *  dispatchable. */
+export function applyClassPauses(
+  plan: WorkOrderPlan,
+  pauses: ReadonlyMap<string, ClassPause>,
+): WorkOrderPlan {
+  if (pauses.size === 0) return plan;
+  const orders: WorkOrder[] = plan.orders.map((o) => {
+    const pause = pauses.get(String(o.class));
+    if (!pause) return o;
+    const mark: WorkOrderPause = { reason: pause.reason, unpause: pause.unpause };
+    return { ...o, paused: mark };
+  });
+  return { ...plan, orders };
+}

--- a/src/remediate/work-orders/deferrals.ts
+++ b/src/remediate/work-orders/deferrals.ts
@@ -1,0 +1,125 @@
+/**
+ * The DEFERRAL JOIN (split from `gather.ts` at the module-size bar): active
+ * deferred allowlist entries joined to what they suppress — a live/BoM/
+ * injected dependency-scan finding first (the richer copy: fixed version,
+ * reachability), the baseline entry as fallback, or nothing (disclosed as
+ * unjoined by the planner). The scan is paid only when a dep-vuln deferral
+ * exists, and a fresh persisted BoM artifact (`.dxkit/bom.json`) is
+ * preferred over a live audit, disclosed either way.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { gatherDepVulnsWithAvailability } from '../../analyzers/security/gather';
+import { activeDeferredEntries, type AllowlistFile } from '../../allowlist/file';
+import type { RichBaselineEntry } from '../../baseline/types';
+import type { DepVulnFinding } from '../../languages/capabilities/types';
+import type { AdvisoryInput, DeferredInput } from './planner';
+import type { GatherWorkOrderOptions } from './gather';
+
+/** Which source answered the deferral join. */
+export type DepScanSource = 'bom-artifact' | 'live-scan' | 'injected' | 'not-needed';
+
+/** How long a persisted BoM artifact counts as fresh for the deferral join.
+ *  Deferral windows are days; a week-old fixed-version fact is still the
+ *  right starting point, and the disclosure names the age either way. */
+export const BOM_FRESHNESS_DAYS = 7;
+
+function advisoryFromLive(f: DepVulnFinding): AdvisoryInput {
+  return {
+    id: f.fingerprint!,
+    package: f.package,
+    ...(f.installedVersion !== undefined ? { installedVersion: f.installedVersion } : {}),
+    advisoryId: f.id,
+    ...(f.severity !== undefined ? { severity: f.severity } : {}),
+    ...(f.fixedVersion !== undefined ? { fixedVersion: f.fixedVersion } : {}),
+    ...(f.reachable !== undefined ? { reachable: f.reachable } : {}),
+    ...(f.packId !== undefined ? { pack: f.packId } : {}),
+  };
+}
+
+function advisoryFromEntry(e: Extract<RichBaselineEntry, { kind: 'dep-vuln' }>): AdvisoryInput {
+  return {
+    id: e.id,
+    package: e.package,
+    ...(e.installedVersion !== undefined ? { installedVersion: e.installedVersion } : {}),
+    advisoryId: e.advisoryId,
+    ...(e.severity !== undefined ? { severity: e.severity } : {}),
+  };
+}
+
+/** A fresh persisted BoM artifact's findings, when one exists (the scan the
+ *  repo already paid for), else null. Defensive: any shape surprise reads as
+ *  absent, never a crash. */
+function bomArtifactFindings(
+  cwd: string,
+  now: Date,
+): { findings: DepVulnFinding[]; ageDays: number } | null {
+  try {
+    const p = path.join(cwd, '.dxkit', 'bom.json');
+    if (!fs.existsSync(p)) return null;
+    const bom = JSON.parse(fs.readFileSync(p, 'utf8')) as {
+      analyzedAt?: string;
+      entries?: ReadonlyArray<{ vulns?: DepVulnFinding[] }>;
+    };
+    if (typeof bom.analyzedAt !== 'string' || !Array.isArray(bom.entries)) return null;
+    const ageDays = (now.getTime() - Date.parse(bom.analyzedAt)) / 86_400_000;
+    if (!Number.isFinite(ageDays) || ageDays < 0 || ageDays > BOM_FRESHNESS_DAYS) return null;
+    const findings = bom.entries.flatMap((e) => e.vulns ?? []).filter((v) => v && v.fingerprint);
+    return { findings, ageDays };
+  } catch {
+    return null;
+  }
+}
+
+export async function joinDeferrals(
+  cwd: string,
+  allowlist: AllowlistFile | null,
+  byId: ReadonlyMap<string, RichBaselineEntry>,
+  opts: GatherWorkOrderOptions,
+  disclosures: string[],
+): Promise<{ deferred: DeferredInput[]; depScanSource: DepScanSource }> {
+  const now = opts.now ?? new Date();
+  const deferred = activeDeferredEntries(allowlist, now);
+  const needsScan = deferred.some((d) => d.kind === 'dep-vuln');
+  const scanned = new Map<string, DepVulnFinding>();
+  let depScanSource: DepScanSource = 'not-needed';
+  if (needsScan) {
+    if (opts.scanDepVulns) {
+      depScanSource = 'injected';
+      for (const f of (await opts.scanDepVulns(cwd)) ?? []) {
+        if (f.fingerprint) scanned.set(f.fingerprint, f);
+      }
+    } else {
+      const bom = bomArtifactFindings(cwd, now);
+      if (bom) {
+        depScanSource = 'bom-artifact';
+        disclosures.push(
+          `deferral join read the persisted BoM artifact (.dxkit/bom.json, ` +
+            `${bom.ageDays.toFixed(1)} day(s) old) instead of paying a live dependency audit`,
+        );
+        for (const f of bom.findings) scanned.set(f.fingerprint!, f);
+      } else {
+        depScanSource = 'live-scan';
+        disclosures.push(
+          'deferral join ran a live dependency audit (no fresh .dxkit/bom.json artifact to read)',
+        );
+        const result = await gatherDepVulnsWithAvailability(cwd);
+        for (const f of result.envelope?.findings ?? []) {
+          if (f.fingerprint) scanned.set(f.fingerprint, f);
+        }
+      }
+    }
+  }
+  const joined = deferred.map((d): DeferredInput => {
+    const base = { fingerprint: d.fingerprint, expiresAt: d.expiresAt! };
+    const hit = scanned.get(d.fingerprint);
+    if (hit) return { ...base, kind: 'dep-vuln', advisory: advisoryFromLive(hit) };
+    const entry = byId.get(d.fingerprint);
+    if (!entry) return { ...base, kind: 'unjoined', declaredKind: d.kind };
+    if (entry.kind === 'dep-vuln')
+      return { ...base, kind: 'dep-vuln', advisory: advisoryFromEntry(entry) };
+    if (entry.kind === 'custom-check') return { ...base, kind: 'custom-check', entry };
+    return { ...base, kind: 'other', entry };
+  });
+  return { deferred: joined, depScanSource };
+}

--- a/src/remediate/work-orders/gather.ts
+++ b/src/remediate/work-orders/gather.ts
@@ -69,6 +69,21 @@ import {
 import type { InstallFor } from './shared';
 import { WORK_ORDER_CLASSES, isBuiltinWorkOrderClass, type WorkOrderPlan } from './types';
 import type { RemediateTaskId } from '../tasks';
+import {
+  orderHistory,
+  orderLedgerPath,
+  type OrderBranchSource,
+  type OrderLedgerExec,
+  type OrderOutcomeRow,
+} from '../../lanes/order-ledger';
+import { remediateBranchFor } from '../../lanes/branches';
+import {
+  applyClassPauses,
+  evaluateClassPauses,
+  remediateStamp,
+  type ClassPause,
+  type RemediateStamp,
+} from './breaker';
 
 export type FloorSource = 'live' | 'baseline-envelope' | 'loop-snapshot' | 'none';
 
@@ -94,6 +109,18 @@ export interface GatherWorkOrderOptions {
   readonly baselineName?: string;
   /** Injected active packs (tests). */
   readonly packs?: readonly LanguageSupport[];
+  /** Injected order-outcome history rows for the circuit breaker (tests /
+   *  a caller that already read them). Default: the ONE ledger reader over
+   *  the local checkout plus the standing branches. */
+  readonly history?: readonly OrderOutcomeRow[];
+  /** Injected exec for the default history read's branch fetches (tests). */
+  readonly historyExec?: OrderLedgerExec;
+  /** Injected environment stamps for the breaker's unpause comparison
+   *  (tests). Default: `remediateStamp(cwd)`. */
+  readonly stamp?: RemediateStamp;
+  /** A task a human explicitly dispatched: its classes bypass any pause,
+   *  disclosed (never silent). */
+  readonly dispatchedTask?: string;
 }
 
 export interface GatheredWorkOrderInputs {
@@ -387,7 +414,20 @@ export async function gatherWorkOrderInputs(
   };
 }
 
-/** Gather + plan in one call: the surface entry point. */
+/** The standing branches where unmerged order-outcome rows can live: one
+ *  per task that owns a work-order class (derived from the ONE class spine,
+ *  never a hand-kept list — a new class's task is covered automatically). */
+export function orderHistoryBranchSources(): OrderBranchSource[] {
+  const tasks = [...new Set(Object.values(WORK_ORDER_CLASSES).map((c) => c.task))].sort();
+  return tasks.map((task) => ({
+    branch: remediateBranchFor(task),
+    file: orderLedgerPath('remediate', task),
+  }));
+}
+
+/** Gather + plan in one call: the surface entry point. Applies the circuit
+ *  breaker here (Rule 2.30: the plan CLI and the recipe phase both call
+ *  this, so neither can see a different pause set). */
 export async function planRepoWorkOrders(
   cwd: string,
   config: RemediateConfig,
@@ -397,12 +437,43 @@ export async function planRepoWorkOrders(
   floorSource: FloorSource;
   depScanSource: DepScanSource;
   disclosures: readonly string[];
+  /** Classes the circuit breaker paused (orders carry the per-order mark). */
+  pauses: readonly ClassPause[];
 }> {
   const gathered = await gatherWorkOrderInputs(cwd, config, opts);
+  const disclosures = [...gathered.disclosures];
+  let plan = planWorkOrders(gathered.input);
+
+  // The circuit breaker (section 3F): evaluated only when the plan has
+  // orders and the knob is armed — a zero-order plan never pays the
+  // history read.
+  let pauses: readonly ClassPause[] = [];
+  if (plan.orders.length > 0 && config.pauseAfterFailures > 0) {
+    let rows = opts.history;
+    if (rows === undefined) {
+      const history = orderHistory(cwd, {
+        branches: orderHistoryBranchSources(),
+        ...(opts.historyExec ? { exec: opts.historyExec } : {}),
+        ...(opts.now ? { now: opts.now } : {}),
+      });
+      rows = history.rows;
+      disclosures.push(...history.disclosures);
+    }
+    const evaluated = evaluateClassPauses(rows, {
+      threshold: config.pauseAfterFailures,
+      current: opts.stamp ?? remediateStamp(cwd),
+      ...(opts.dispatchedTask ? { dispatchedTask: opts.dispatchedTask } : {}),
+    });
+    disclosures.push(...evaluated.disclosures);
+    plan = applyClassPauses(plan, evaluated.pauses);
+    pauses = [...evaluated.pauses.values()];
+  }
+
   return {
-    plan: planWorkOrders(gathered.input),
+    plan,
     floorSource: gathered.floorSource,
     depScanSource: gathered.depScanSource,
-    disclosures: gathered.disclosures,
+    disclosures,
+    pauses,
   };
 }

--- a/src/remediate/work-orders/gather.ts
+++ b/src/remediate/work-orders/gather.ts
@@ -52,16 +52,13 @@ import { failingFloorDebt, floorDebtToBaseChecks, type FloorDebt } from '../../b
 import { readFloorBaseline } from '../../loop/floor-state';
 import { isSanitized } from '../../baseline/sanitize';
 import type { RichBaselineEntry } from '../../baseline/types';
-import { activeDeferredEntries, tryLoadAllowlist, type AllowlistFile } from '../../allowlist/file';
+import { tryLoadAllowlist } from '../../allowlist/file';
 import { partitionByActiveAllowlist } from '../../baseline/allowlist-match';
 import { discoverPackDepRoots } from '../../analyzers/security/nested-dep-roots';
-import { gatherDepVulnsWithAvailability } from '../../analyzers/security/gather';
 import type { DepVulnFinding } from '../../languages/capabilities/types';
 import { budgetForTask, type RemediateConfig } from '../config';
 import {
   planWorkOrders,
-  type AdvisoryInput,
-  type DeferredInput,
   type FloorFailureInput,
   type ManifestRoot,
   type PlannerInput,
@@ -87,13 +84,11 @@ import {
 
 export type FloorSource = 'live' | 'baseline-envelope' | 'loop-snapshot' | 'none';
 
-/** Which source answered the deferral join. */
-export type DepScanSource = 'bom-artifact' | 'live-scan' | 'injected' | 'not-needed';
-
-/** How long a persisted BoM artifact counts as fresh for the deferral join.
- *  Deferral windows are days; a week-old fixed-version fact is still the
- *  right starting point, and the disclosure names the age either way. */
-export const BOM_FRESHNESS_DAYS = 7;
+// The deferral join (deferred allowlist entries joined to a dependency
+// scan) lives in `./deferrals` (module-size split); its public shapes are
+// re-exported here so consumers keep one import surface.
+export { BOM_FRESHNESS_DAYS, type DepScanSource } from './deferrals';
+import { joinDeferrals, type DepScanSource } from './deferrals';
 
 export interface GatherWorkOrderOptions {
   /** Run the live floor (default: read a stored envelope). */
@@ -129,18 +124,27 @@ export interface GatheredWorkOrderInputs {
   readonly depScanSource: DepScanSource;
   /** Degraded reads, phrased for humans; empty when nothing degraded. */
   readonly disclosures: readonly string[];
+  /** STRUCTURAL evidence degradation (an unreadable baseline, no floor
+   *  evidence at all): a zero-order plan built on this cannot claim
+   *  "nothing to do" — the scheduled matrix falls back to the static task
+   *  list instead of silently spawning nothing. Null = evidence healthy. */
+  readonly evidenceDegraded: string | null;
 }
 
-function readBaseline(cwd: string, name: string, disclosures: string[]): BaselineFile | null {
+function readBaseline(
+  cwd: string,
+  name: string,
+  disclosures: string[],
+): { baseline: BaselineFile | null; unreadable: boolean } {
   const p = pathForBaseline(cwd, name);
   try {
-    return fs.existsSync(p) ? readBaselineFile(p) : null;
+    return { baseline: fs.existsSync(p) ? readBaselineFile(p) : null, unreadable: false };
   } catch (err) {
     disclosures.push(
       `baseline '${name}' exists but could not be read (${err instanceof Error ? err.message : String(err)}); ` +
         'the plan proceeds WITHOUT the recorded backlog: floor attribution and debt are incomplete',
     );
-    return null;
+    return { baseline: null, unreadable: true };
   }
 }
 
@@ -263,106 +267,6 @@ function gatherFloor(
   return { failures: [], source: 'none' };
 }
 
-function advisoryFromLive(f: DepVulnFinding): AdvisoryInput {
-  return {
-    id: f.fingerprint!,
-    package: f.package,
-    ...(f.installedVersion !== undefined ? { installedVersion: f.installedVersion } : {}),
-    advisoryId: f.id,
-    ...(f.severity !== undefined ? { severity: f.severity } : {}),
-    ...(f.fixedVersion !== undefined ? { fixedVersion: f.fixedVersion } : {}),
-    ...(f.reachable !== undefined ? { reachable: f.reachable } : {}),
-    ...(f.packId !== undefined ? { pack: f.packId } : {}),
-  };
-}
-
-function advisoryFromEntry(e: Extract<RichBaselineEntry, { kind: 'dep-vuln' }>): AdvisoryInput {
-  return {
-    id: e.id,
-    package: e.package,
-    ...(e.installedVersion !== undefined ? { installedVersion: e.installedVersion } : {}),
-    advisoryId: e.advisoryId,
-    ...(e.severity !== undefined ? { severity: e.severity } : {}),
-  };
-}
-
-/** A fresh persisted BoM artifact's findings, when one exists (the scan the
- *  repo already paid for), else null. Defensive: any shape surprise reads as
- *  absent, never a crash. */
-function bomArtifactFindings(
-  cwd: string,
-  now: Date,
-): { findings: DepVulnFinding[]; ageDays: number } | null {
-  try {
-    const p = path.join(cwd, '.dxkit', 'bom.json');
-    if (!fs.existsSync(p)) return null;
-    const bom = JSON.parse(fs.readFileSync(p, 'utf8')) as {
-      analyzedAt?: string;
-      entries?: ReadonlyArray<{ vulns?: DepVulnFinding[] }>;
-    };
-    if (typeof bom.analyzedAt !== 'string' || !Array.isArray(bom.entries)) return null;
-    const ageDays = (now.getTime() - Date.parse(bom.analyzedAt)) / 86_400_000;
-    if (!Number.isFinite(ageDays) || ageDays < 0 || ageDays > BOM_FRESHNESS_DAYS) return null;
-    const findings = bom.entries.flatMap((e) => e.vulns ?? []).filter((v) => v && v.fingerprint);
-    return { findings, ageDays };
-  } catch {
-    return null;
-  }
-}
-
-async function joinDeferrals(
-  cwd: string,
-  allowlist: AllowlistFile | null,
-  byId: ReadonlyMap<string, RichBaselineEntry>,
-  opts: GatherWorkOrderOptions,
-  disclosures: string[],
-): Promise<{ deferred: DeferredInput[]; depScanSource: DepScanSource }> {
-  const now = opts.now ?? new Date();
-  const deferred = activeDeferredEntries(allowlist, now);
-  const needsScan = deferred.some((d) => d.kind === 'dep-vuln');
-  const scanned = new Map<string, DepVulnFinding>();
-  let depScanSource: DepScanSource = 'not-needed';
-  if (needsScan) {
-    if (opts.scanDepVulns) {
-      depScanSource = 'injected';
-      for (const f of (await opts.scanDepVulns(cwd)) ?? []) {
-        if (f.fingerprint) scanned.set(f.fingerprint, f);
-      }
-    } else {
-      const bom = bomArtifactFindings(cwd, now);
-      if (bom) {
-        depScanSource = 'bom-artifact';
-        disclosures.push(
-          `deferral join read the persisted BoM artifact (.dxkit/bom.json, ` +
-            `${bom.ageDays.toFixed(1)} day(s) old) instead of paying a live dependency audit`,
-        );
-        for (const f of bom.findings) scanned.set(f.fingerprint!, f);
-      } else {
-        depScanSource = 'live-scan';
-        disclosures.push(
-          'deferral join ran a live dependency audit (no fresh .dxkit/bom.json artifact to read)',
-        );
-        const result = await gatherDepVulnsWithAvailability(cwd);
-        for (const f of result.envelope?.findings ?? []) {
-          if (f.fingerprint) scanned.set(f.fingerprint, f);
-        }
-      }
-    }
-  }
-  const joined = deferred.map((d): DeferredInput => {
-    const base = { fingerprint: d.fingerprint, expiresAt: d.expiresAt! };
-    const hit = scanned.get(d.fingerprint);
-    if (hit) return { ...base, kind: 'dep-vuln', advisory: advisoryFromLive(hit) };
-    const entry = byId.get(d.fingerprint);
-    if (!entry) return { ...base, kind: 'unjoined', declaredKind: d.kind };
-    if (entry.kind === 'dep-vuln')
-      return { ...base, kind: 'dep-vuln', advisory: advisoryFromEntry(entry) };
-    if (entry.kind === 'custom-check') return { ...base, kind: 'custom-check', entry };
-    return { ...base, kind: 'other', entry };
-  });
-  return { deferred: joined, depScanSource };
-}
-
 /** Per class, the selecting task's effective budget (one budget per concept). */
 function budgetResolver(config: RemediateConfig): PlannerInput['policy']['budgetFor'] {
   return (cls) => {
@@ -378,8 +282,21 @@ export async function gatherWorkOrderInputs(
 ): Promise<GatheredWorkOrderInputs> {
   const disclosures: string[] = [];
   const packs = opts.packs ?? detectActiveLanguages(cwd);
-  const baseline = readBaseline(cwd, opts.baselineName ?? DEFAULT_BASELINE_NAME, disclosures);
+  const { baseline, unreadable } = readBaseline(
+    cwd,
+    opts.baselineName ?? DEFAULT_BASELINE_NAME,
+    disclosures,
+  );
   const floor = gatherFloor(cwd, baseline, packs, opts);
+  // Evidence health for the scheduled matrix (never for the plan itself:
+  // partial orders are still shown). A stored-floor default with no floor
+  // evidence anywhere ('none'), or a baseline that exists but cannot be
+  // read, means a zero-order plan proves nothing.
+  const evidenceDegraded = unreadable
+    ? 'the baseline exists but could not be read'
+    : floor.source === 'none'
+      ? 'no floor evidence is available (no baseline floor envelope, no loop snapshot; pass --with-floor to measure live)'
+      : null;
 
   const rich = (baseline?.findings ?? []).filter((e): e is RichBaselineEntry => !isSanitized(e));
   const byId = new Map(rich.map((e) => [e.id, e]));
@@ -402,6 +319,7 @@ export async function gatherWorkOrderInputs(
     floorSource: floor.source,
     depScanSource,
     disclosures,
+    evidenceDegraded,
     input: {
       floorFailures: floor.failures,
       blocking: [],
@@ -437,6 +355,8 @@ export async function planRepoWorkOrders(
   floorSource: FloorSource;
   depScanSource: DepScanSource;
   disclosures: readonly string[];
+  /** Structural evidence degradation (see `GatheredWorkOrderInputs`). */
+  evidenceDegraded: string | null;
   /** Classes the circuit breaker paused (orders carry the per-order mark). */
   pauses: readonly ClassPause[];
 }> {
@@ -474,6 +394,7 @@ export async function planRepoWorkOrders(
     floorSource: gathered.floorSource,
     depScanSource: gathered.depScanSource,
     disclosures,
+    evidenceDegraded: gathered.evidenceDegraded,
     pauses,
   };
 }

--- a/src/remediate/work-orders/schedule.ts
+++ b/src/remediate/work-orders/schedule.ts
@@ -1,0 +1,142 @@
+/**
+ * The scheduled task matrix, derived from the OPEN work orders (remediate
+ * rethink, section 3F): a weekly firing spends its bounded budget on the
+ * highest-value open orders, so the matrix a scheduled run spawns comes
+ * from the plan — a task with no open (unpaused) orders spawns NO job —
+ * instead of the static policy task list.
+ *
+ * The static list is still consulted twice, deliberately:
+ *   - only policy-ENABLED tasks may appear (the plan never widens what a
+ *     repo opted into);
+ *   - open-ended tasks (no work-order classes: improve-tests, write-docs)
+ *     cannot have orders by nature, so a policy that explicitly lists them
+ *     keeps them scheduled — the legacy shape, kept working and DISCLOSED
+ *     as such (the default policy task set does not include them).
+ *
+ * The spend ceiling (`remediate.maxSpendPerRun`) applies over the derived
+ * VALUE order through the one ceiling helper, so a trim cuts the
+ * lowest-value tasks first, disclosed. Fail-open: with no plan (planning
+ * failed, or an old caller), the matrix falls back to the static list — a
+ * broken planner must not silently turn the whole schedule off — and says
+ * why. The dispatch-override path is untouched: a workflow_dispatch naming
+ * a task runs exactly that task, bypassing this derivation entirely.
+ */
+import { tasksWithinSpendCeiling, type RemediateConfig } from '../config';
+import { classesSelectedBy, isBuiltinWorkOrderClass, WORK_ORDER_CLASSES } from './types';
+import type { WorkOrderPlan } from './types';
+import type { RemediateTaskId } from '../tasks';
+
+export interface ScheduledMatrix {
+  /** The tasks one scheduled firing runs, value order, ceiling applied. */
+  readonly run: readonly RemediateTaskId[];
+  /** Tasks trimmed by `remediate.maxSpendPerRun`, disclosed. */
+  readonly deferred: readonly RemediateTaskId[];
+  /** Enabled class-selecting tasks with no open orders: no job spawned
+   *  (a paused-only task lands here too — the pause is disclosed). */
+  readonly noOpenOrders: readonly RemediateTaskId[];
+  /** Enabled open-ended tasks kept by explicit policy (legacy shape). */
+  readonly legacyOpenEnded: readonly RemediateTaskId[];
+  /** 'orders' = derived from the plan; 'static-fallback' = no plan was
+   *  available and the policy task list ran the matrix (disclosed). */
+  readonly source: 'orders' | 'static-fallback';
+  readonly disclosures: readonly string[];
+}
+
+export interface ScheduledMatrixInput {
+  readonly config: RemediateConfig;
+  /** The work-order plan with circuit-breaker marks applied, or null when
+   *  planning failed / was unavailable. */
+  readonly plan: WorkOrderPlan | null;
+  readonly planError?: string | null;
+}
+
+/** Derive the scheduled matrix. Pure — every read is from the arguments. */
+export function deriveScheduledMatrix(input: ScheduledMatrixInput): ScheduledMatrix {
+  const { config, plan } = input;
+  const disclosures: string[] = [];
+
+  if (!plan) {
+    const ceiling = tasksWithinSpendCeiling(config);
+    disclosures.push(
+      'matrix: no work-order plan was available' +
+        (input.planError ? ` (${input.planError})` : '') +
+        '; fell back to the static policy task list (a broken planner must not turn the ' +
+        'schedule off silently)',
+    );
+    return {
+      run: ceiling.run,
+      deferred: ceiling.deferred,
+      noOpenOrders: [],
+      legacyOpenEnded: [],
+      source: 'static-fallback',
+      disclosures,
+    };
+  }
+
+  const enabled = new Set<string>(config.tasks);
+
+  // Value-ordered tasks from the OPEN orders: the plan's order IS the value
+  // order, so the first open order of a task fixes the task's rank.
+  const orderedTasks: RemediateTaskId[] = [];
+  const pausedOnly = new Map<string, number>(); // task -> paused order count
+  const unroutableClasses = new Set<string>();
+  for (const order of plan.orders) {
+    const cls = String(order.class);
+    if (!isBuiltinWorkOrderClass(cls)) {
+      // An order whose class is outside the built-in spine cannot be routed
+      // to a scheduled task — disclosed, never silently dropped.
+      unroutableClasses.add(cls);
+      continue;
+    }
+    const task = WORK_ORDER_CLASSES[cls].task as RemediateTaskId;
+    if (!enabled.has(task)) continue;
+    if (order.paused) {
+      pausedOnly.set(task, (pausedOnly.get(task) ?? 0) + 1);
+      continue;
+    }
+    if (!orderedTasks.includes(task)) orderedTasks.push(task);
+  }
+  for (const cls of unroutableClasses) {
+    disclosures.push(
+      `matrix: order class '${cls}' is not in the built-in class registry, so its orders ` +
+        'cannot be routed to a scheduled task (they remain visible in the plan)',
+    );
+  }
+
+  // Enabled class-selecting tasks that earned no matrix slot: no job.
+  const noOpenOrders: RemediateTaskId[] = [];
+  const legacyOpenEnded: RemediateTaskId[] = [];
+  for (const task of config.tasks) {
+    if (classesSelectedBy(task).length === 0) {
+      // Open-ended by nature (improve-tests, write-docs): no orders can
+      // exist, so explicit policy keeps it scheduled — the legacy shape.
+      legacyOpenEnded.push(task);
+      disclosures.push(
+        `matrix: '${task}' is open-ended (no work-order classes) and stays scheduled ` +
+          'because policy lists it explicitly; the default task set does not (legacy shape)',
+      );
+      continue;
+    }
+    if (orderedTasks.includes(task)) continue;
+    noOpenOrders.push(task);
+    const paused = pausedOnly.get(task);
+    disclosures.push(
+      paused !== undefined
+        ? `matrix: '${task}' spawns no job: its only open order(s) are PAUSED by the ` +
+            `circuit breaker (${paused} order(s); see the plan's pause disclosures)`
+        : `matrix: '${task}' spawns no job: no open work orders (nothing to spend on, $0)`,
+    );
+  }
+
+  // Value order first, then the legacy open-ended tail; the ceiling trims
+  // from the end (lowest value first) through the ONE ceiling helper.
+  const ceiling = tasksWithinSpendCeiling(config, [...orderedTasks, ...legacyOpenEnded]);
+  return {
+    run: ceiling.run,
+    deferred: ceiling.deferred,
+    noOpenOrders,
+    legacyOpenEnded,
+    source: 'orders',
+    disclosures,
+  };
+}

--- a/src/remediate/work-orders/schedule.ts
+++ b/src/remediate/work-orders/schedule.ts
@@ -48,6 +48,13 @@ export interface ScheduledMatrixInput {
    *  planning failed / was unavailable. */
   readonly plan: WorkOrderPlan | null;
   readonly planError?: string | null;
+  /** Structural evidence degradation from the gather (an unreadable
+   *  baseline, no floor evidence): a plan built on degraded evidence
+   *  cannot prove "nothing to do", so the matrix falls back to the static
+   *  task list, disclosed — a fail-open zero must never silently turn the
+   *  schedule off. Healthy evidence with zero orders stays a legitimate
+   *  no-job firing. */
+  readonly evidenceDegraded?: string | null;
 }
 
 /** Derive the scheduled matrix. Pure — every read is from the arguments. */
@@ -55,13 +62,16 @@ export function deriveScheduledMatrix(input: ScheduledMatrixInput): ScheduledMat
   const { config, plan } = input;
   const disclosures: string[] = [];
 
-  if (!plan) {
+  const degraded = !plan
+    ? 'no work-order plan was available' + (input.planError ? ` (${input.planError})` : '')
+    : input.evidenceDegraded
+      ? `the plan's evidence is degraded (${input.evidenceDegraded})`
+      : null;
+  if (degraded || !plan) {
     const ceiling = tasksWithinSpendCeiling(config);
     disclosures.push(
-      'matrix: no work-order plan was available' +
-        (input.planError ? ` (${input.planError})` : '') +
-        '; fell back to the static policy task list (a broken planner must not turn the ' +
-        'schedule off silently)',
+      `matrix: ${degraded}; fell back to the static policy task list (a degraded or broken ` +
+        'planner must not turn the schedule off silently)',
     );
     return {
       run: ceiling.run,

--- a/src/remediate/work-orders/types.ts
+++ b/src/remediate/work-orders/types.ts
@@ -239,6 +239,17 @@ export type WorkOrderProvenance =
       readonly deferred?: number;
     };
 
+/** The circuit-breaker mark on a planned order (remediate rethink, 3F):
+ *  the order is still PLANNED (visible, valued, disclosed) but no tier may
+ *  dispatch it. Applied by the gather layer from the order-outcome ledger,
+ *  never by the pure planner. */
+export interface WorkOrderPause {
+  /** Why the class is paused (the failure streak, latest outcome + time). */
+  readonly reason: string;
+  /** What lifts the pause, phrased for a human. */
+  readonly unpause: string;
+}
+
 export interface WorkOrder {
   /** Stable within a plan: `<class>:<natural unit>[#slice]`. */
   readonly id: string;
@@ -255,6 +266,9 @@ export interface WorkOrder {
    *  orders). Structured evidence lives on each finding. */
   readonly outputTail?: string;
   readonly provenance: WorkOrderProvenance;
+  /** Present when the circuit breaker paused this order's class: planned,
+   *  never dispatched, always disclosed. */
+  readonly paused?: WorkOrderPause;
 }
 
 /** A finding the planner could not place in any class, with the reason. */

--- a/test/lanes/ledger.test.ts
+++ b/test/lanes/ledger.test.ts
@@ -149,7 +149,7 @@ describe('the merged-means-delivered write points', () => {
 
   it('the remediate landing commits the ledger before the push', () => {
     const src = readFileSync(join(__dirname, '../../src/remediate/land.ts'), 'utf8');
-    const commitAt = src.indexOf("exec('git', ['add', opts.ledgerPath])");
+    const commitAt = src.indexOf("exec('git', ['add', ...ledgerPaths])");
     expect(commitAt).toBeGreaterThan(-1);
     // the push CALL (not the import line) comes after the ledger commit
     expect(commitAt).toBeLessThan(src.lastIndexOf('internalGitPushArgs('));

--- a/test/lanes/order-ledger.test.ts
+++ b/test/lanes/order-ledger.test.ts
@@ -1,0 +1,217 @@
+/**
+ * The work-order outcome ledger (scheduler memory, remediate rethink 3F):
+ * row parsing is fail-open per line and per schema, the local reader sees
+ * only order files, merging dedupes across channels, the window bounds by
+ * age and per-class count, and the ONE history reader composes local +
+ * standing-branch rows with disclosed (never silent) degradations. Plus
+ * the compatibility pin: the DELIVERY ledger reader never ingests order
+ * rows, and vice versa.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  ORDER_FAILURE_OUTCOMES,
+  ORDER_LEDGER_SCHEMA_VERSION,
+  ORDER_SUCCESS_OUTCOMES,
+  boundOrderWindow,
+  existingRemoteBranches,
+  mergeOrderRows,
+  orderHistory,
+  orderLedgerPath,
+  parseOrderRows,
+  readLocalOrderRows,
+  serializeOrderRows,
+  type OrderOutcomeRow,
+} from '../../src/lanes/order-ledger';
+import { readLaneEvents } from '../../src/lanes/ledger';
+
+function row(overrides: Partial<OrderOutcomeRow> = {}): OrderOutcomeRow {
+  return {
+    schema_version: ORDER_LEDGER_SCHEMA_VERSION,
+    timestamp: '2026-08-20T00:00:00.000Z',
+    lane: 'remediate',
+    task: 'fix-vulns',
+    orderId: 'dep-advisory:lodash',
+    class: 'dep-advisory',
+    tier: 'recipe',
+    outcome: 'guardrail-red',
+    dxkitVersion: '4.4.5',
+    policyHash: 'abc',
+    ...overrides,
+  };
+}
+
+function tempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-order-ledger-test-'));
+}
+
+describe('row parsing and files', () => {
+  it('parses valid rows, skips corrupt lines and rows from a NEWER schema', () => {
+    const text =
+      serializeOrderRows([row()]) +
+      'not json at all\n' +
+      JSON.stringify({ ...row(), schema_version: ORDER_LEDGER_SCHEMA_VERSION + 1 }) +
+      '\n' +
+      JSON.stringify({ hello: 'world' }) +
+      '\n';
+    const rows = parseOrderRows(text);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].orderId).toBe('dep-advisory:lodash');
+  });
+
+  it('readLocalOrderRows reads only *.orders.jsonl files in the lanes dir', () => {
+    const cwd = tempDir();
+    const rel = orderLedgerPath('remediate', 'fix-vulns');
+    expect(rel).toBe('.dxkit/lanes/remediate-fix-vulns.orders.jsonl');
+    fs.mkdirSync(path.join(cwd, '.dxkit', 'lanes'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, rel), serializeOrderRows([row()]));
+    // A delivery-ledger file in the same directory is NOT an order file.
+    fs.writeFileSync(
+      path.join(cwd, '.dxkit', 'lanes', 'remediate-fix-vulns.jsonl'),
+      JSON.stringify({
+        schema_version: 1,
+        timestamp: '2026-08-20T00:00:00.000Z',
+        lane: 'remediate',
+        outcome: 'landed',
+      }) + '\n',
+    );
+    expect(readLocalOrderRows(cwd)).toHaveLength(1);
+    // COMPATIBILITY, both directions: the delivery reader must not ingest
+    // order rows (no order outcome is 'landed'), and the order reader must
+    // not ingest delivery events (file suffix).
+    expect(readLaneEvents(cwd)).toHaveLength(1);
+    expect(readLaneEvents(cwd)[0].outcome).toBe('landed');
+  });
+
+  it('the outcome vocabulary keeps the breaker sets disjoint', () => {
+    for (const o of ORDER_FAILURE_OUTCOMES) expect(ORDER_SUCCESS_OUTCOMES.has(o)).toBe(false);
+  });
+});
+
+describe('merge + window', () => {
+  it('mergeOrderRows dedupes on (task, orderId, timestamp) across channels, oldest first', () => {
+    const a = row({ timestamp: '2026-08-01T00:00:00.000Z' });
+    const b = row({ timestamp: '2026-08-02T00:00:00.000Z', outcome: 'verified' });
+    const merged = mergeOrderRows([b, a], [a], [b]);
+    expect(merged).toHaveLength(2);
+    expect(merged[0].timestamp < merged[1].timestamp).toBe(true);
+  });
+
+  it('boundOrderWindow drops rows older than the window and caps rows per class (newest kept)', () => {
+    const now = new Date('2026-08-25T00:00:00.000Z');
+    const old = row({ timestamp: '2026-01-01T00:00:00.000Z' });
+    const recent = Array.from({ length: 5 }, (_, i) =>
+      row({ timestamp: `2026-08-2${i}T00:00:00.000Z`, orderId: `o${i}` }),
+    );
+    const other = row({ class: 'lint-located', timestamp: '2026-08-24T00:00:00.000Z' });
+    const bounded = boundOrderWindow([old, ...recent, other], {
+      now,
+      windowDays: 60,
+      maxPerClass: 3,
+    });
+    expect(bounded.some((r) => r.timestamp === old.timestamp)).toBe(false);
+    expect(bounded.filter((r) => r.class === 'dep-advisory')).toHaveLength(3);
+    expect(bounded.filter((r) => r.class === 'dep-advisory').map((r) => r.orderId)).toEqual([
+      'o2',
+      'o3',
+      'o4',
+    ]);
+    expect(bounded.filter((r) => r.class === 'lint-located')).toHaveLength(1);
+  });
+
+  it('a row with an unparseable timestamp is dropped by the window, never a crash', () => {
+    const bounded = boundOrderWindow([row({ timestamp: 'not-a-date' })], {
+      now: new Date('2026-08-25T00:00:00.000Z'),
+    });
+    expect(bounded).toHaveLength(0);
+  });
+});
+
+describe('orderHistory (the ONE reader)', () => {
+  const branchSource = {
+    branch: 'dxkit/remediate-fix-vulns',
+    file: orderLedgerPath('remediate', 'fix-vulns'),
+  };
+
+  it('merges local committed rows with a standing branch copy (deduped), bounded', () => {
+    const cwd = tempDir();
+    const localRow = row({ timestamp: '2026-08-20T00:00:00.000Z' });
+    const branchOnly = row({ timestamp: '2026-08-22T00:00:00.000Z', outcome: 'floor-red' });
+    fs.mkdirSync(path.join(cwd, '.dxkit', 'lanes'), { recursive: true });
+    fs.writeFileSync(
+      path.join(cwd, orderLedgerPath('remediate', 'fix-vulns')),
+      serializeOrderRows([localRow]),
+    );
+    const exec = (bin: string, args: readonly string[]): string => {
+      if (args[0] === 'ls-remote') {
+        return `sha\trefs/heads/${branchSource.branch}\n`;
+      }
+      if (args[0] === 'fetch') return '';
+      if (args[0] === 'rev-parse') return 'branchhead\n';
+      if (args[0] === 'show') return serializeOrderRows([localRow, branchOnly]);
+      throw new Error(`unexpected: ${bin} ${args.join(' ')}`);
+    };
+    const history = orderHistory(cwd, {
+      branches: [branchSource],
+      exec,
+      now: new Date('2026-08-25T00:00:00.000Z'),
+    });
+    expect(history.rows).toHaveLength(2);
+    expect(history.disclosures).toEqual([]);
+  });
+
+  it('an unreachable remote is a DISCLOSED absence with local rows still read', () => {
+    const cwd = tempDir();
+    fs.mkdirSync(path.join(cwd, '.dxkit', 'lanes'), { recursive: true });
+    fs.writeFileSync(
+      path.join(cwd, orderLedgerPath('remediate', 'fix-vulns')),
+      serializeOrderRows([row({ timestamp: '2026-08-20T00:00:00.000Z' })]),
+    );
+    const exec = () => {
+      throw new Error('no remote');
+    };
+    const history = orderHistory(cwd, {
+      branches: [branchSource],
+      exec,
+      now: new Date('2026-08-25T00:00:00.000Z'),
+    });
+    expect(history.rows).toHaveLength(1);
+    expect(history.disclosures.some((d) => d.includes('no remote reachable'))).toBe(true);
+  });
+
+  it('an ABSENT standing branch is normal (empty history), not a disclosure', () => {
+    const cwd = tempDir();
+    const exec = (bin: string, args: readonly string[]): string => {
+      if (args[0] === 'ls-remote') return ''; // remote reachable, branch absent
+      throw new Error(`unexpected: ${args.join(' ')}`);
+    };
+    const history = orderHistory(cwd, { branches: [branchSource], exec });
+    expect(history.rows).toEqual([]);
+    expect(history.disclosures).toEqual([]);
+  });
+
+  it('a branch that exists but cannot be fetched is disclosed by name', () => {
+    const cwd = tempDir();
+    const exec = (bin: string, args: readonly string[]): string => {
+      if (args[0] === 'ls-remote') return `sha\trefs/heads/${branchSource.branch}\n`;
+      throw new Error('fetch refused');
+    };
+    const history = orderHistory(cwd, { branches: [branchSource], exec });
+    expect(history.disclosures.some((d) => d.includes(branchSource.branch))).toBe(true);
+  });
+
+  it('existingRemoteBranches parses ls-remote output and null-signals a failed probe', () => {
+    const okExec = () => 'aaa\trefs/heads/dxkit/remediate-fix-vulns\nbbb\trefs/heads/other\n';
+    expect([...existingRemoteBranches(['dxkit/remediate-fix-vulns'], okExec)!]).toContain(
+      'dxkit/remediate-fix-vulns',
+    );
+    expect(
+      existingRemoteBranches(['x'], () => {
+        throw new Error('offline');
+      }),
+    ).toBeNull();
+    expect([...existingRemoteBranches([], okExec)!]).toEqual([]);
+  });
+});

--- a/test/lanes/order-ledger.test.ts
+++ b/test/lanes/order-ledger.test.ts
@@ -20,8 +20,10 @@ import {
   mergeOrderRows,
   orderHistory,
   orderLedgerPath,
+  parseLedgerText,
   parseOrderRows,
   readLocalOrderRows,
+  realOrderLedgerExec,
   serializeOrderRows,
   type OrderOutcomeRow,
 } from '../../src/lanes/order-ledger';
@@ -59,6 +61,12 @@ describe('row parsing and files', () => {
     const rows = parseOrderRows(text);
     expect(rows).toHaveLength(1);
     expect(rows[0].orderId).toBe('dep-advisory:lodash');
+    // The WRITER's view keeps what the reader skipped, verbatim: a newer
+    // schema's row and a corrupt line are foreign lines, never data loss.
+    const split = parseLedgerText(text);
+    expect(split.rows).toHaveLength(1);
+    expect(split.foreign).toHaveLength(3);
+    expect(split.foreign.some((l) => l.includes('"schema_version":2'))).toBe(true);
   });
 
   it('readLocalOrderRows reads only *.orders.jsonl files in the lanes dir', () => {
@@ -91,12 +99,44 @@ describe('row parsing and files', () => {
 });
 
 describe('merge + window', () => {
-  it('mergeOrderRows dedupes on (task, orderId, timestamp) across channels, oldest first', () => {
+  it('mergeOrderRows dedupes on (task, orderId, tier, timestamp) across channels, oldest first', () => {
     const a = row({ timestamp: '2026-08-01T00:00:00.000Z' });
     const b = row({ timestamp: '2026-08-02T00:00:00.000Z', outcome: 'verified' });
     const merged = mergeOrderRows([b, a], [a], [b]);
     expect(merged).toHaveLength(2);
     expect(merged[0].timestamp < merged[1].timestamp).toBe(true);
+  });
+
+  it('TIER is part of the row identity: a recipe row and an agent row for one order in one run both survive', () => {
+    // One run stamps one timestamp; a recipe-failed order the agent then
+    // fixed carries two rows — first-wins on a tier-less key would keep
+    // the failure and lose the fix.
+    const failed = row({ tier: 'recipe', outcome: 'failed-recipe' });
+    const fixed = row({ tier: 'agent', outcome: 'verified' });
+    const merged = mergeOrderRows([failed], [fixed]);
+    expect(merged).toHaveLength(2);
+    expect(merged.map((r) => r.outcome).sort()).toEqual(['failed-recipe', 'verified']);
+  });
+
+  it('bookkeeping rows never evict the failure evidence: the per-class cap counts outcome rows and neutral rows separately', () => {
+    const now = new Date('2026-08-25T00:00:00.000Z');
+    const failure = row({ timestamp: '2026-08-01T00:00:00.000Z', outcome: 'guardrail-red' });
+    const pausedFlood = Array.from({ length: 10 }, (_, i) =>
+      row({
+        timestamp: `2026-08-${String(2 + i).padStart(2, '0')}T00:00:00.000Z`,
+        orderId: `p${i}`,
+        outcome: 'paused',
+      }),
+    );
+    const bounded = boundOrderWindow([failure, ...pausedFlood], {
+      now,
+      windowDays: 60,
+      maxPerClass: 3,
+    });
+    // The single counted failure row survives ANY number of paused
+    // markers; the markers are capped on their own budget.
+    expect(bounded.filter((r) => r.outcome === 'guardrail-red')).toHaveLength(1);
+    expect(bounded.filter((r) => r.outcome === 'paused')).toHaveLength(3);
   });
 
   it('boundOrderWindow drops rows older than the window and caps rows per class (newest kept)', () => {
@@ -200,6 +240,16 @@ describe('orderHistory (the ONE reader)', () => {
     };
     const history = orderHistory(cwd, { branches: [branchSource], exec });
     expect(history.disclosures.some((d) => d.includes(branchSource.branch))).toBe(true);
+  });
+
+  it('the real exec is the ONE hardened machine git-exec factory (no-prompt env, stdin support)', () => {
+    const exec = realOrderLedgerExec(process.cwd());
+    expect(exec('sh', ['-c', 'printf "%s" "$GIT_TERMINAL_PROMPT"'])).toBe('0');
+    expect(exec('sh', ['-c', 'printf "%s" "$GIT_SSH_COMMAND"'])).toContain('BatchMode=yes');
+    expect(exec('cat', [], { input: 'stdin works' })).toBe('stdin works');
+    expect(exec('sh', ['-c', 'printf "%s" "$DXKIT_X"'], { env: { DXKIT_X: 'layered' } })).toBe(
+      'layered',
+    );
   });
 
   it('existingRemoteBranches parses ls-remote output and null-signals a failed probe', () => {

--- a/test/remediate/config-budgets.test.ts
+++ b/test/remediate/config-budgets.test.ts
@@ -45,6 +45,7 @@ function cfg(partial: Partial<RemediateConfig>): RemediateConfig {
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     maxOrdersPerRun: 0,
+    pauseAfterFailures: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },

--- a/test/remediate/dispatch.test.ts
+++ b/test/remediate/dispatch.test.ts
@@ -168,6 +168,7 @@ function config(): RemediateConfig {
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     maxOrdersPerRun: 0,
+    pauseAfterFailures: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },

--- a/test/remediate/dispatch.test.ts
+++ b/test/remediate/dispatch.test.ts
@@ -5,7 +5,13 @@
  * ledger.
  */
 import { describe, it, expect } from 'vitest';
-import { DISPATCH_ENV, readDispatchOverrides } from '../../src/remediate/dispatch';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  DISPATCH_ENV,
+  readDispatchOverrides,
+  staleDispatchWorkflowNote,
+} from '../../src/remediate/dispatch';
 import { customDispatchTask, SHARED_RULES } from '../../src/remediate/tasks';
 import { runRemediateTask, type RemediateGit } from '../../src/remediate/run';
 import type { AgentDriver, AgentRunResult } from '../../src/remediate/driver';
@@ -234,5 +240,35 @@ describe('runRemediateTask — the custom dispatch task', () => {
     expect(r.ledger).toContain('Raise docstring coverage in src/api only.');
     expect(r.ledger).toContain('no score hinge');
     expect(r.ledger).toContain('clamped');
+  });
+});
+
+describe('staleDispatchWorkflowNote (the pre-flag workflow detector)', () => {
+  const base = { GITHUB_ACTIONS: 'true', GITHUB_EVENT_NAME: 'workflow_dispatch' };
+
+  it('advises vyuh-dxkit update on a workflow_dispatch run whose template never defined the dispatch env', () => {
+    const note = staleDispatchWorkflowNote(base, false);
+    expect(note).toContain('vyuh-dxkit update');
+  });
+
+  it('stays silent when the updated template defined the variable (even blank), when the flag was passed, on scheduled runs, and outside Actions', () => {
+    expect(staleDispatchWorkflowNote({ ...base, DXKIT_DISPATCH_TASK: '' }, false)).toBeUndefined();
+    expect(staleDispatchWorkflowNote(base, true)).toBeUndefined();
+    expect(
+      staleDispatchWorkflowNote({ GITHUB_ACTIONS: 'true', GITHUB_EVENT_NAME: 'schedule' }, false),
+    ).toBeUndefined();
+    expect(staleDispatchWorkflowNote({}, false)).toBeUndefined();
+  });
+});
+
+describe('the workflow template carries the explicit override flag', () => {
+  it('derives --dispatch-override from the dispatch input and defines DXKIT_DISPATCH_TASK on the run step', () => {
+    const template = readFileSync(
+      join(__dirname, '..', '..', 'src-templates', '.github', 'workflows', 'dxkit-remediate.yml'),
+      'utf8',
+    );
+    expect(template).toContain('OVERRIDE="--dispatch-override"');
+    expect(template).toContain('--land pr $OVERRIDE');
+    expect(template).toContain("DXKIT_DISPATCH_TASK: ${{ github.event.inputs.task || '' }}");
   });
 });

--- a/test/remediate/executor-landing.test.ts
+++ b/test/remediate/executor-landing.test.ts
@@ -44,6 +44,7 @@ function config(salvage: RemediateConfig['salvage'] = 'discard'): RemediateConfi
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     maxOrdersPerRun: 0,
+    pauseAfterFailures: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },
@@ -309,5 +310,137 @@ describe('executeTask landing layer (#273)', () => {
     expect(run.landed).toBe(false);
     expect(run.landRefused).toContain("HEAD is on 'feat/x'");
     expect(run.landingBlocked).toBeUndefined();
+  });
+});
+
+describe('order-outcome ledger wiring (scheduler memory, 3F)', () => {
+  function resultWithOrders(outcome: RemediateResult['outcome']): RemediateResult {
+    return {
+      outcome,
+      task: 'write-docs',
+      ledger: 'THE VERIFICATION LEDGER',
+      baseHead: 'aaaa1111',
+      head: 'bbbb2222',
+      orders: {
+        cap: 3,
+        queued: 1,
+        records: [
+          {
+            orderId: 'dep-advisory:x',
+            class: 'dep-advisory',
+            findings: 1,
+            budget: { turns: 5, minutes: 5, usd: 1, derivation: 'd' },
+            outcome: 'completed',
+            done: { verifier: 'guardrail', absentIds: 1 },
+          },
+        ],
+      },
+    };
+  }
+
+  it('a LANDING run writes the composed ledger file and hands its path to the lander', async () => {
+    const cwd = tempRepo();
+    let landerPath: string | undefined;
+    let written: unknown[] | undefined;
+    let published = false;
+    const run = await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        runTask: async () => resultWithOrders('verified'),
+        landHead: (opts) => {
+          landerPath = opts.orderLedgerPath;
+          return { outcome: 'pr-opened', mode: 'pr', prUrl: 'https://example.test/pr/3' };
+        },
+        writeOrderLedger: (_cwd, _task, rows) => {
+          written = [...rows];
+          return '.dxkit/lanes/remediate-write-docs.orders.jsonl';
+        },
+        publishOrderRows: () => {
+          published = true;
+          return { published: true };
+        },
+      }),
+    );
+    expect(run.landed).toBe(true);
+    expect(landerPath).toBe('.dxkit/lanes/remediate-write-docs.orders.jsonl');
+    expect(written).toHaveLength(1);
+    expect((written![0] as { outcome: string }).outcome).toBe('verified');
+    expect(published).toBe(false);
+  });
+
+  it('a NON-landing outcome publishes rows to the standing branch (the breaker must see failures)', async () => {
+    const cwd = tempRepo();
+    let publishedRows: unknown[] | undefined;
+    let wroteLocal = false;
+    const run = await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        runTask: async () => resultWithOrders('guardrail-red'),
+        writeOrderLedger: () => {
+          wroteLocal = true;
+          return null;
+        },
+        publishOrderRows: (_cwd, _task, rows) => {
+          publishedRows = [...rows];
+          return { published: true };
+        },
+      }),
+    );
+    expect(run.landed).toBe(false);
+    expect(wroteLocal).toBe(false);
+    expect(publishedRows).toHaveLength(1);
+    expect((publishedRows![0] as { outcome: string }).outcome).toBe('guardrail-red');
+  });
+
+  it('a local --land none run touches neither channel (tree and remote stay clean)', async () => {
+    const cwd = tempRepo();
+    let touched = false;
+    await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'none',
+      seams({
+        runTask: async () => resultWithOrders('guardrail-red'),
+        writeOrderLedger: () => {
+          touched = true;
+          return null;
+        },
+        publishOrderRows: () => {
+          touched = true;
+          return { published: true };
+        },
+      }),
+    );
+    expect(touched).toBe(false);
+  });
+
+  it('a run with no order records writes nothing (legacy path)', async () => {
+    const cwd = tempRepo();
+    let touched = false;
+    await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        runTask: async () => ({ ...verifiedResult() }),
+        writeOrderLedger: () => {
+          touched = true;
+          return null;
+        },
+        publishOrderRows: () => {
+          touched = true;
+          return { published: true };
+        },
+      }),
+    );
+    expect(touched).toBe(false);
   });
 });

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -213,6 +213,7 @@ function config(): RemediateConfig {
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     maxOrdersPerRun: 0,
+    pauseAfterFailures: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },

--- a/test/remediate/order-outcomes.test.ts
+++ b/test/remediate/order-outcomes.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Order-outcome rows (scheduler memory 3F): the projection from a run's
+ * per-order records to ledger rows (committed work carries the RUN verdict;
+ * refusals and infrastructure keep their own words; paused orders are
+ * recorded as neutral rows), and the two durability channels: the landing
+ * path's local composed file and the non-landing metadata commit pushed to
+ * the standing branch with plumbing commands only (retry once on a race,
+ * disclosed note on failure, never a crash).
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  orderOutcomeRows,
+  publishOrderRows,
+  writeLocalOrderLedger,
+  type OrderLedgerGitExec,
+} from '../../src/remediate/order-outcomes';
+import {
+  orderLedgerPath,
+  serializeOrderRows,
+  type OrderOutcomeRow,
+} from '../../src/lanes/order-ledger';
+import type { RemediateResult } from '../../src/remediate/outcome';
+import type { RecipePhaseSummary } from '../../src/remediate/recipes/run-recipes';
+
+const META = {
+  timestamp: '2026-08-25T00:00:00.000Z',
+  stamp: { dxkitVersion: '4.4.5', policyHash: 'abc' },
+};
+
+function recipes(overrides: Partial<RecipePhaseSummary> = {}): RecipePhaseSummary {
+  return {
+    ran: true,
+    disclosures: [],
+    selectedRecipeTier: 0,
+    selectedAgentTier: 0,
+    records: [],
+    ...overrides,
+  };
+}
+
+function orderRecord(
+  orderId: string,
+  outcome: 'completed' | 'partial' | 'failed' | 'never-ran' | 'not-dispatched',
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    orderId,
+    class: 'dep-advisory',
+    findings: 1,
+    budget: { turns: 5, minutes: 5, usd: 1, derivation: 'x' },
+    outcome,
+    done: { verifier: 'guardrail' as const, absentIds: 1 },
+    ...extra,
+  };
+}
+
+describe('orderOutcomeRows (the projection)', () => {
+  it('committed work carries the run verdict; refusals and infra keep their own words', () => {
+    const result: Pick<RemediateResult, 'outcome' | 'recipes' | 'orders'> = {
+      outcome: 'guardrail-red',
+      recipes: recipes({
+        records: [
+          {
+            orderId: 'r1',
+            class: 'stale-lockfile',
+            recipe: 'lockfile-sync',
+            outcome: { kind: 'applied', changedFiles: ['package-lock.json'] },
+          },
+          {
+            orderId: 'r2',
+            class: 'dep-advisory',
+            recipe: 'override-pin',
+            outcome: { kind: 'refused', reason: 'no fixed version' },
+          },
+          {
+            orderId: 'r3',
+            class: 'lint-located',
+            recipe: 'lint-autofix',
+            outcome: { kind: 'failed', step: 'verify', output: 'ids still present' },
+          },
+        ],
+        paused: [
+          {
+            orderId: 'p1',
+            class: 'unresolved-import',
+            tier: 'recipe',
+            findings: 2,
+            reason: 'streak',
+            unpause: 'policy change',
+          },
+        ],
+      }),
+      orders: {
+        cap: 3,
+        queued: 3,
+        records: [
+          orderRecord('a1', 'completed', { spent: { turns: 9, costUsd: 0.5 } }),
+          orderRecord('a2', 'never-ran', { detail: 'credit balance too low' }),
+          orderRecord('a3', 'not-dispatched', { detail: 'beyond the cap' }),
+        ],
+      },
+    };
+    const rows = orderOutcomeRows(result, 'fix-vulns', META);
+    const byId = new Map(rows.map((r) => [r.orderId, r]));
+    expect(byId.get('r1')!.outcome).toBe('guardrail-red'); // applied, run blocked
+    expect(byId.get('r1')!.tier).toBe('recipe');
+    expect(byId.get('r2')!.outcome).toBe('refused');
+    expect(byId.get('r3')!.outcome).toBe('failed-recipe');
+    expect(byId.get('r3')!.detail).toContain('verify');
+    expect(byId.get('a1')!.outcome).toBe('guardrail-red'); // completed, run blocked
+    expect(byId.get('a1')!.spend).toEqual({ turns: 9, costUsd: 0.5 });
+    expect(byId.get('a2')!.outcome).toBe('never-ran');
+    expect(byId.get('a3')!.outcome).toBe('not-dispatched');
+    expect(byId.get('p1')!.outcome).toBe('paused');
+    // Every row carries the runner timestamp and the environment stamps.
+    for (const r of rows) {
+      expect(r.timestamp).toBe(META.timestamp);
+      expect(r.dxkitVersion).toBe('4.4.5');
+      expect(r.policyHash).toBe('abc');
+      expect(r.task).toBe('fix-vulns');
+    }
+  });
+
+  it('a verified run yields verified rows; budget-exhausted yields the verified-partial word', () => {
+    const base = {
+      recipes: recipes({
+        records: [
+          {
+            orderId: 'r1',
+            class: 'stale-lockfile',
+            recipe: 'lockfile-sync',
+            outcome: { kind: 'applied' as const, changedFiles: ['x'] },
+          },
+        ],
+      }),
+    };
+    expect(orderOutcomeRows({ outcome: 'verified', ...base }, 't', META)[0].outcome).toBe(
+      'verified',
+    );
+    expect(orderOutcomeRows({ outcome: 'budget-exhausted', ...base }, 't', META)[0].outcome).toBe(
+      'budget-exhausted-verified',
+    );
+    expect(
+      orderOutcomeRows(
+        {
+          outcome: 'agent-failed',
+          orders: { cap: 1, queued: 1, records: [orderRecord('a1', 'failed')] },
+        },
+        't',
+        META,
+      )[0].outcome,
+    ).toBe('agent-failed');
+  });
+
+  it('a run with no order records yields no rows (legacy path, refusals)', () => {
+    expect(orderOutcomeRows({ outcome: 'refused' }, 't', META)).toEqual([]);
+  });
+});
+
+function tempCwd(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-order-write-'));
+}
+
+const ROW: OrderOutcomeRow = {
+  schema_version: 1,
+  timestamp: '2026-08-25T00:00:00.000Z',
+  lane: 'remediate',
+  task: 'fix-vulns',
+  orderId: 'dep-advisory:x',
+  class: 'dep-advisory',
+  tier: 'agent',
+  outcome: 'guardrail-red',
+  dxkitVersion: '4.4.5',
+  policyHash: 'abc',
+};
+
+const BRANCH_ROW: OrderOutcomeRow = {
+  ...ROW,
+  timestamp: '2026-08-18T00:00:00.000Z',
+  outcome: 'floor-red',
+};
+
+describe('writeLocalOrderLedger (landing channel)', () => {
+  it('composes standing-branch rows + local rows + new rows into the local file', () => {
+    const cwd = tempCwd();
+    const exec: OrderLedgerGitExec = (bin, args) => {
+      if (args[0] === 'fetch') return '';
+      if (args[0] === 'rev-parse') return 'head\n';
+      if (args[0] === 'show') return serializeOrderRows([BRANCH_ROW]);
+      throw new Error(`unexpected ${args.join(' ')}`);
+    };
+    const rel = writeLocalOrderLedger(cwd, 'fix-vulns', [ROW], exec);
+    expect(rel).toBe(orderLedgerPath('remediate', 'fix-vulns'));
+    const text = fs.readFileSync(path.join(cwd, rel!), 'utf8');
+    const lines = text.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    // Oldest first: the branch's unmerged failure row survives the landing.
+    expect(lines[0]).toContain('floor-red');
+    expect(lines[1]).toContain('guardrail-red');
+  });
+
+  it('an unreachable branch composes local + new rows only (fail-open)', () => {
+    const cwd = tempCwd();
+    const exec: OrderLedgerGitExec = () => {
+      throw new Error('offline');
+    };
+    const rel = writeLocalOrderLedger(cwd, 'fix-vulns', [ROW], exec);
+    const text = fs.readFileSync(path.join(cwd, rel!), 'utf8');
+    expect(text.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('no rows means no write', () => {
+    expect(writeLocalOrderLedger(tempCwd(), 'fix-vulns', [])).toBeNull();
+  });
+});
+
+describe('publishOrderRows (non-landing channel)', () => {
+  /** Scripted plumbing exec: answers each git call, records the sequence. */
+  function plumbingExec(opts: { failPushes?: number; branchExists?: boolean }) {
+    const calls: string[][] = [];
+    let pushFailures = opts.failPushes ?? 0;
+    const exec: OrderLedgerGitExec = (bin, args) => {
+      calls.push([...args]);
+      switch (args[0]) {
+        case 'fetch':
+          if (opts.branchExists === false) throw new Error('no such ref');
+          return '';
+        case 'rev-parse':
+          return args[1] === 'FETCH_HEAD' ? 'branchhead\n' : 'checkouthead\n';
+        case 'show':
+          return serializeOrderRows([BRANCH_ROW]);
+        case 'hash-object':
+          return 'blobsha\n';
+        case 'read-tree':
+        case 'update-index':
+          return '';
+        case 'write-tree':
+          return 'treesha\n';
+        default:
+          if (args.includes('commit-tree')) return 'commitsha\n';
+          if (args.includes('push')) {
+            if (pushFailures > 0) {
+              pushFailures -= 1;
+              throw new Error('rejected (fetch first)');
+            }
+            return '';
+          }
+          throw new Error(`unexpected ${args.join(' ')}`);
+      }
+    };
+    return { exec, calls };
+  }
+
+  it('builds a metadata commit on the branch head and pushes it (no working-tree involvement)', () => {
+    const cwd = tempCwd();
+    const { exec, calls } = plumbingExec({});
+    const out = publishOrderRows(cwd, 'fix-vulns', [ROW], exec);
+    expect(out.published).toBe(true);
+    const push = calls.find((c) => c.includes('push'))!;
+    expect(push).toContain('--no-verify');
+    expect(push).toContain('commitsha:refs/heads/dxkit/remediate-fix-vulns');
+    const commitTree = calls.find((c) => c.includes('commit-tree'))!;
+    expect(commitTree).toContain('branchhead'); // parent is the BRANCH head, a draft is preserved
+    const cacheinfo = calls.find((c) => c[0] === 'update-index')!;
+    expect(cacheinfo[3]).toContain(orderLedgerPath('remediate', 'fix-vulns'));
+  });
+
+  it('with no standing branch, the commit bases on the checkout HEAD (branch created)', () => {
+    const cwd = tempCwd();
+    const { exec, calls } = plumbingExec({ branchExists: false });
+    const out = publishOrderRows(cwd, 'fix-vulns', [ROW], exec);
+    expect(out.published).toBe(true);
+    const commitTree = calls.find((c) => c.includes('commit-tree'))!;
+    expect(commitTree).toContain('checkouthead');
+  });
+
+  it('retries ONCE on a push race and succeeds on the fresh base', () => {
+    const cwd = tempCwd();
+    const { exec, calls } = plumbingExec({ failPushes: 1 });
+    const out = publishOrderRows(cwd, 'fix-vulns', [ROW], exec);
+    expect(out.published).toBe(true);
+    expect(calls.filter((c) => c.includes('push'))).toHaveLength(2);
+  });
+
+  it('a persistent failure is a disclosed note, never a crash', () => {
+    const cwd = tempCwd();
+    const { exec } = plumbingExec({ failPushes: 5 });
+    const out = publishOrderRows(cwd, 'fix-vulns', [ROW], exec);
+    expect(out.published).toBe(false);
+    expect(out.note).toContain('dxkit/remediate-fix-vulns');
+    expect(out.note).toContain('circuit breaker');
+  });
+});

--- a/test/remediate/order-outcomes.test.ts
+++ b/test/remediate/order-outcomes.test.ts
@@ -158,6 +158,119 @@ describe('orderOutcomeRows (the projection)', () => {
   it('a run with no order records yields no rows (legacy path, refusals)', () => {
     expect(orderOutcomeRows({ outcome: 'refused' }, 't', META)).toEqual([]);
   });
+
+  it('ONE terminal row per order: an agent attempt supersedes the recipe failure it fell through from', () => {
+    const result: Pick<RemediateResult, 'outcome' | 'recipes' | 'orders'> = {
+      outcome: 'verified',
+      recipes: recipes({
+        records: [
+          {
+            orderId: 'dep-advisory:x',
+            class: 'dep-advisory',
+            recipe: 'override-pin',
+            outcome: { kind: 'failed', step: 'verify', output: 'still present' },
+          },
+        ],
+      }),
+      orders: {
+        cap: 3,
+        queued: 1,
+        records: [
+          {
+            orderId: 'dep-advisory:x',
+            class: 'dep-advisory',
+            findings: 1,
+            budget: { turns: 5, minutes: 5, usd: 1, derivation: 'x' },
+            outcome: 'completed',
+            done: { verifier: 'guardrail', absentIds: 1 },
+          },
+        ],
+      },
+    };
+    const rows = orderOutcomeRows(result, 'fix-vulns', META);
+    // The recipe failed, the agent fixed it in the SAME run: one row, the
+    // terminal tier's verified outcome — a kept failure row would let the
+    // breaker pause a class that is actively being fixed.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].tier).toBe('agent');
+    expect(rows[0].outcome).toBe('verified');
+  });
+
+  it('a NEUTRAL agent record (not dispatched, never ran) leaves the recipe evidence standing', () => {
+    const result: Pick<RemediateResult, 'outcome' | 'recipes' | 'orders'> = {
+      outcome: 'recipes-refused',
+      recipes: recipes({
+        records: [
+          {
+            orderId: 'dep-advisory:x',
+            class: 'dep-advisory',
+            recipe: 'override-pin',
+            outcome: { kind: 'failed', step: 'verify', output: 'still present' },
+          },
+        ],
+      }),
+      orders: {
+        cap: 0,
+        queued: 1,
+        records: [orderRecord('dep-advisory:x', 'not-dispatched', { detail: 'cap 0' })],
+      },
+    };
+    const rows = orderOutcomeRows(result, 'fix-vulns', META);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].tier).toBe('recipe');
+    expect(rows[0].outcome).toBe('failed-recipe');
+  });
+
+  it('paused orders collapse to ONE bookkeeping marker per class per firing', () => {
+    const result: Pick<RemediateResult, 'outcome' | 'recipes' | 'orders'> = {
+      outcome: 'no-op',
+      recipes: recipes({
+        paused: [
+          {
+            orderId: 'lint-located:a',
+            class: 'lint-located',
+            tier: 'recipe',
+            findings: 2,
+            reason: 'streak',
+            unpause: 'x',
+          },
+          {
+            orderId: 'lint-located:b',
+            class: 'lint-located',
+            tier: 'agent',
+            findings: 1,
+            reason: 'streak',
+            unpause: 'x',
+          },
+        ],
+      }),
+    };
+    const rows = orderOutcomeRows(result, 'fix-lint', META);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].outcome).toBe('paused');
+    expect(rows[0].detail).toContain('2 order(s) paused');
+  });
+
+  it("'score-red' (and every unlisted red) is classified breaker-NEUTRAL by the exhaustive verdict switch", () => {
+    const rows = orderOutcomeRows(
+      {
+        outcome: 'score-red',
+        recipes: recipes({
+          records: [
+            {
+              orderId: 'r1',
+              class: 'stale-lockfile',
+              recipe: 'lockfile-sync',
+              outcome: { kind: 'applied', changedFiles: ['x'] },
+            },
+          ],
+        }),
+      },
+      't',
+      META,
+    );
+    expect(rows[0].outcome).toBe('no-op');
+  });
 });
 
 function tempCwd(): string {
@@ -184,9 +297,11 @@ const BRANCH_ROW: OrderOutcomeRow = {
 };
 
 describe('writeLocalOrderLedger (landing channel)', () => {
-  it('composes standing-branch rows + local rows + new rows into the local file', () => {
+  it('composes standing-branch rows + local rows + new rows into the local file, through the ONE branch read', () => {
     const cwd = tempCwd();
+    const seen: string[] = [];
     const exec: OrderLedgerGitExec = (bin, args) => {
+      seen.push(args[0]);
       if (args[0] === 'fetch') return '';
       if (args[0] === 'rev-parse') return 'head\n';
       if (args[0] === 'show') return serializeOrderRows([BRANCH_ROW]);
@@ -200,6 +315,25 @@ describe('writeLocalOrderLedger (landing channel)', () => {
     // Oldest first: the branch's unmerged failure row survives the landing.
     expect(lines[0]).toContain('floor-red');
     expect(lines[1]).toContain('guardrail-red');
+    // The read is the shared fetch/rev-parse/show sequence (Rule 2.30:
+    // one branch-read function, no second fetch/show pair).
+    expect(seen).toEqual(['fetch', 'rev-parse', 'show']);
+  });
+
+  it("carries a NEWER schema's rows through verbatim when rewriting the durable file", () => {
+    const cwd = tempCwd();
+    const futureLine = JSON.stringify({ ...ROW, schema_version: 99, futureField: 'kept' });
+    const exec: OrderLedgerGitExec = (bin, args) => {
+      if (args[0] === 'fetch') return '';
+      if (args[0] === 'rev-parse') return 'head\n';
+      if (args[0] === 'show') return serializeOrderRows([BRANCH_ROW]) + futureLine + '\n';
+      throw new Error(`unexpected ${args.join(' ')}`);
+    };
+    const rel = writeLocalOrderLedger(cwd, 'fix-vulns', [ROW], exec);
+    const text = fs.readFileSync(path.join(cwd, rel!), 'utf8');
+    expect(text).toContain(futureLine);
+    expect(text).toContain('floor-red');
+    expect(text).toContain('guardrail-red');
   });
 
   it('an unreachable branch composes local + new rows only (fail-open)', () => {
@@ -268,13 +402,33 @@ describe('publishOrderRows (non-landing channel)', () => {
     expect(cacheinfo[3]).toContain(orderLedgerPath('remediate', 'fix-vulns'));
   });
 
-  it('with no standing branch, the commit bases on the checkout HEAD (branch created)', () => {
+  it('with no reachable standing branch, the commit is an ORPHAN over the ledger file only: no local commit becomes reachable', () => {
     const cwd = tempCwd();
     const { exec, calls } = plumbingExec({ branchExists: false });
     const out = publishOrderRows(cwd, 'fix-vulns', [ROW], exec);
     expect(out.published).toBe(true);
     const commitTree = calls.find((c) => c.includes('commit-tree'))!;
-    expect(commitTree).toContain('checkouthead');
+    // No parent at all (orphan), and no read of a local ref: the local
+    // history on a non-landing path is unverified content and must never
+    // become reachable from the remote through the ledger push.
+    expect(commitTree).not.toContain('-p');
+    expect(commitTree.join(' ')).not.toContain('checkouthead');
+    expect(calls.some((c) => c[0] === 'rev-parse' && c[1] === 'HEAD')).toBe(false);
+    expect(calls.some((c) => c[0] === 'read-tree')).toBe(false);
+    const push = calls.find((c) => c.includes('push'))!;
+    expect(push).toContain('commitsha:refs/heads/dxkit/remediate-fix-vulns');
+  });
+
+  it('with a standing branch, the commit parents ONLY on the fetched remote head, never local HEAD', () => {
+    const cwd = tempCwd();
+    const { exec, calls } = plumbingExec({});
+    publishOrderRows(cwd, 'fix-vulns', [ROW], exec);
+    const commitTree = calls.find((c) => c.includes('commit-tree'))!;
+    const parents = commitTree.filter((_, i) => commitTree[i - 1] === '-p');
+    expect(parents).toEqual(['branchhead']);
+    expect(calls.some((c) => c[0] === 'rev-parse' && c[1] === 'HEAD')).toBe(false);
+    const readTree = calls.find((c) => c[0] === 'read-tree')!;
+    expect(readTree[1]).toBe('branchhead');
   });
 
   it('retries ONCE on a push race and succeeds on the fresh base', () => {

--- a/test/remediate/orders-phase.test.ts
+++ b/test/remediate/orders-phase.test.ts
@@ -133,6 +133,7 @@ function config(partial: Partial<RemediateConfig> = {}): RemediateConfig {
     maxDispatchBudget: 0,
     resume: false,
     maxOrdersPerRun: 3,
+    pauseAfterFailures: 0,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },
     ...partial,

--- a/test/remediate/recipes/frame.test.ts
+++ b/test/remediate/recipes/frame.test.ts
@@ -53,6 +53,7 @@ function config(): RemediateConfig {
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     maxOrdersPerRun: 0,
+    pauseAfterFailures: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },
@@ -238,5 +239,55 @@ describe('recipe-only remediate runs', () => {
     expect(ran).toBe(true);
     expect(r.recipes?.planError).toContain('planner exploded');
     expect(r.ledger).toContain('planner exploded');
+  });
+});
+
+describe('circuit-breaker pauses inside the frame', () => {
+  it('an all-paused selection completes as a $0 no-op naming the pause, and the ledger renders it (no agent spawn)', async () => {
+    const summary = phase({
+      ran: false,
+      records: [],
+      selectedRecipeTier: 0,
+      selectedAgentTier: 0,
+      paused: [
+        {
+          orderId: 'dep-advisory:js-yaml',
+          class: 'dep-advisory',
+          tier: 'recipe',
+          findings: 2,
+          reason: 'the last 2 counted outcome(s) for this class were failures',
+          unpause: 'change the remediate policy, upgrade dxkit, or dispatch fix-vulns',
+        },
+      ],
+    });
+    const result = await runRemediateTask(base(false, summary));
+    expect(result.outcome).toBe('no-op');
+    expect(result.note).toContain('PAUSED by the circuit breaker');
+    expect(result.note).toContain('dep-advisory');
+    expect(result.note).toContain('Unpause:');
+    expect(result.ledger).toContain('Paused by the circuit breaker');
+    expect(result.ledger).toContain('dep-advisory:js-yaml');
+  });
+
+  it('a selection with one open and one paused order proceeds, with the pause disclosed in the ledger', async () => {
+    const summary = phase({
+      selectedRecipeTier: 1,
+      selectedAgentTier: 0,
+      paused: [
+        {
+          orderId: 'lint-located:src/a.ts',
+          class: 'lint-located',
+          tier: 'recipe',
+          findings: 3,
+          reason: 'streak',
+          unpause: 'policy change',
+        },
+      ],
+      agentOrders: [],
+    });
+    const result = await runRemediateTask(base(true, summary));
+    expect(result.outcome).toBe('verified');
+    expect(result.ledger).toContain('Paused by the circuit breaker');
+    expect(result.ledger).toContain('lint-located:src/a.ts');
   });
 });

--- a/test/remediate/recipes/run-recipes.test.ts
+++ b/test/remediate/recipes/run-recipes.test.ts
@@ -495,3 +495,94 @@ describe('runRecipePhaseForTask', () => {
     expect(summary.records).toHaveLength(0);
   });
 });
+
+describe('circuit-breaker partition (runRecipePhaseForTask)', () => {
+  const failedRow = (n: number) => ({
+    schema_version: 1,
+    timestamp: `2026-08-1${n}T00:00:00.000Z`,
+    lane: 'remediate',
+    task: 'fix-build',
+    orderId: `stale-lockfile:${n}`,
+    class: 'stale-lockfile',
+    tier: 'recipe' as const,
+    outcome: 'guardrail-red' as const,
+    dxkitVersion: '4.4.5',
+    policyHash: 'hash-a',
+  });
+  const STAMP = { dxkitVersion: '4.4.5', policyHash: 'hash-a' };
+  const pausedEntryFloor: CorrectnessFloorResult = {
+    ran: true,
+    blocks: true,
+    scope: 'full',
+    checks: [
+      {
+        pack: 'typescript',
+        label: 'lockfile-sync',
+        bin: 'npm',
+        args: ['ci', '--dry-run'],
+        status: 'fail',
+        output: 'EUSAGE',
+      },
+    ],
+  };
+
+  it('a paused class is in NEITHER tier: no recipe executes, the agent queue excludes it, the pause is disclosed', async () => {
+    const cwd = tempRepo({
+      'package.json': '{"name":"fx"}',
+      'package-lock.json': '{}',
+      'src/index.ts': 'export const x = 1;\n',
+      '.dxkit/policy.json': '{}',
+    });
+    const { exec, calls } = fakeExec();
+    const summary = await runRecipePhaseForTask({
+      cwd,
+      trust: trustedLocalContext(),
+      taskId: 'fix-build',
+      config: resolveRemediateConfig(cwd),
+      entryFloor: pausedEntryFloor,
+      exec,
+      gather: { history: [failedRow(1), failedRow(2)], stamp: STAMP },
+    });
+    expect(summary.ran).toBe(false);
+    expect(summary.records).toEqual([]);
+    expect(calls).toEqual([]); // nothing spawned for a paused order
+    expect(summary.selectedRecipeTier).toBe(0);
+    expect(summary.selectedAgentTier).toBe(0);
+    expect(summary.agentOrders).toEqual([]);
+    expect(summary.paused).toHaveLength(1);
+    expect(summary.paused![0].class).toBe('stale-lockfile');
+    expect(summary.paused![0].reason).toContain('failures');
+    expect(summary.paused![0].unpause).toContain('fix-build');
+  });
+
+  it('an explicit dispatch threaded through gather lifts the pause and the recipe tier runs again', async () => {
+    const cwd = tempRepo({
+      'package.json': '{"name":"fx"}',
+      'package-lock.json': '{}',
+      'src/index.ts': 'export const x = 1;\n',
+      '.dxkit/policy.json': '{}',
+    });
+    const git = fakeGit();
+    const { exec } = fakeExec((cmd) => {
+      if (cmd.args.includes('install')) git.dirty.push('package-lock.json');
+      return undefined;
+    });
+    const summary = await runRecipePhaseForTask({
+      cwd,
+      trust: trustedLocalContext(),
+      taskId: 'fix-build',
+      config: resolveRemediateConfig(cwd),
+      entryFloor: pausedEntryFloor,
+      git,
+      exec,
+      gather: {
+        history: [failedRow(1), failedRow(2)],
+        stamp: STAMP,
+        dispatchedTask: 'fix-build',
+      },
+    });
+    expect(summary.paused ?? []).toEqual([]);
+    expect(summary.selectedRecipeTier).toBe(1);
+    expect(summary.records[0]?.outcome.kind).toBe('applied');
+  });
+});

--- a/test/remediate/resume.test.ts
+++ b/test/remediate/resume.test.ts
@@ -247,6 +247,7 @@ function config(): RemediateConfig {
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     maxOrdersPerRun: 0,
+    pauseAfterFailures: 0,
     resume: true,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -95,6 +95,7 @@ function config(
     maxSpendPerRun: 0,
     maxDispatchBudget: 0,
     maxOrdersPerRun: 0,
+    pauseAfterFailures: 0,
     resume: false,
     workOrders: { maxSliceSize: 25 },
     recipes: { enabled: true },

--- a/test/remediate/work-orders/breaker.test.ts
+++ b/test/remediate/work-orders/breaker.test.ts
@@ -54,14 +54,61 @@ function evaluate(
 }
 
 describe('evaluateClassPauses', () => {
-  it('pauses a class after N consecutive counted failures, with reason + unpause conditions', () => {
+  it('pauses a class after N consecutive counted failures, with reason + the exact override commands', () => {
     const { pauses } = evaluate([row('guardrail-red'), row('failed-recipe')]);
     const pause = pauses.get('dep-advisory');
     expect(pause).toBeDefined();
     expect(pause!.failures).toBe(2);
     expect(pause!.reason).toContain('paused to stop re-spending');
-    expect(pause!.unpause).toContain('fix-vulns');
+    // The remedy is a WORKING command on both paths: the explicit CLI flag
+    // and the workflow dispatch, plus the stale-template advice.
+    expect(pause!.unpause).toContain('vyuh-dxkit remediate --task fix-vulns --dispatch-override');
+    expect(pause!.unpause).toContain('vyuh-dxkit update');
     expect(pause!.unpause).toContain('policy');
+  });
+
+  it('one red FIRING is one failure event, however many orders of the class it carried', () => {
+    // The shared tree verification smears the run verdict onto every
+    // committed order: two orders in one red firing must not hit the
+    // 2-failure threshold by themselves.
+    const ts = '2026-08-20T00:00:00.000Z';
+    const one = evaluate([
+      row('guardrail-red', { timestamp: ts, orderId: 'dep-advisory:a' }),
+      row('guardrail-red', { timestamp: ts, orderId: 'dep-advisory:b' }),
+    ]);
+    expect(one.pauses.size).toBe(0);
+    // A SECOND red firing makes it two events: now the class pauses.
+    const two = evaluate([
+      row('guardrail-red', { timestamp: ts, orderId: 'dep-advisory:a' }),
+      row('guardrail-red', { timestamp: ts, orderId: 'dep-advisory:b' }),
+      row('guardrail-red', { timestamp: '2026-08-21T00:00:00.000Z', orderId: 'dep-advisory:a' }),
+    ]);
+    expect(two.pauses.get('dep-advisory')?.failures).toBe(2);
+  });
+
+  it('a firing with a success row alongside a failure row RESETS (the class produced verified work)', () => {
+    const ts = '2026-08-20T00:00:00.000Z';
+    const { pauses } = evaluate([
+      row('guardrail-red'),
+      row('guardrail-red'),
+      row('failed-recipe', { timestamp: ts, orderId: 'dep-advisory:a' }),
+      row('verified', { timestamp: ts, orderId: 'dep-advisory:b' }),
+    ]);
+    expect(pauses.size).toBe(0);
+  });
+
+  it('an aged-out pause is DISCLOSED as the retry-horizon lift, never silent', () => {
+    // A paused marker is in the window but the failure evidence is not
+    // (it aged past the window boundary): the pause lifts, and the lift
+    // is named — an evidence-free silent unpause must not exist.
+    const { pauses, disclosures } = evaluate([row('paused')]);
+    expect(pauses.size).toBe(0);
+    expect(disclosures.some((d) => d.includes('aged out') && d.includes('retry horizon'))).toBe(
+      true,
+    );
+    // With a success in view, the reset explains itself: no age-out note.
+    const reset = evaluate([row('paused'), row('verified')]);
+    expect(reset.disclosures).toEqual([]);
   });
 
   it('one failure under the default threshold does not pause', () => {

--- a/test/remediate/work-orders/breaker.test.ts
+++ b/test/remediate/work-orders/breaker.test.ts
@@ -1,0 +1,258 @@
+/**
+ * The circuit breaker (remediate rethink 3F), both directions: a class
+ * pauses after N consecutive counted failures, and every unpause condition
+ * lifts it with a disclosure (a policy change, a dxkit change, an explicit
+ * dispatch, a success resetting the streak). Refusals and infrastructure
+ * are neutral: they neither count nor reset, because nothing was tried.
+ * Plus the gather integration: the ONE plan entry point applies the marks,
+ * so the plan CLI and the recipe phase can never see different pause sets.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  applyClassPauses,
+  evaluateClassPauses,
+  remediateStamp,
+  type RemediateStamp,
+} from '../../../src/remediate/work-orders/breaker';
+import {
+  ORDER_LEDGER_SCHEMA_VERSION,
+  type OrderOutcomeRow,
+  type OrderRowOutcome,
+} from '../../../src/lanes/order-ledger';
+import { planRepoWorkOrders } from '../../../src/remediate/work-orders/gather';
+import { resolveRemediateConfig } from '../../../src/remediate/config';
+import type { WorkOrderPlan } from '../../../src/remediate/work-orders/types';
+
+const STAMP: RemediateStamp = { dxkitVersion: '4.4.5', policyHash: 'hash-a' };
+
+let tick = 0;
+function row(outcome: OrderRowOutcome, overrides: Partial<OrderOutcomeRow> = {}): OrderOutcomeRow {
+  tick += 1;
+  return {
+    schema_version: ORDER_LEDGER_SCHEMA_VERSION,
+    timestamp: `2026-08-${String(10 + tick).padStart(2, '0')}T00:00:00.000Z`,
+    lane: 'remediate',
+    task: 'fix-vulns',
+    orderId: `dep-advisory:pkg${tick}`,
+    class: 'dep-advisory',
+    tier: 'recipe',
+    outcome,
+    dxkitVersion: STAMP.dxkitVersion,
+    policyHash: STAMP.policyHash,
+    ...overrides,
+  };
+}
+
+function evaluate(
+  rows: OrderOutcomeRow[],
+  opts: Partial<Parameters<typeof evaluateClassPauses>[1]> = {},
+) {
+  return evaluateClassPauses(rows, { threshold: 2, current: STAMP, ...opts });
+}
+
+describe('evaluateClassPauses', () => {
+  it('pauses a class after N consecutive counted failures, with reason + unpause conditions', () => {
+    const { pauses } = evaluate([row('guardrail-red'), row('failed-recipe')]);
+    const pause = pauses.get('dep-advisory');
+    expect(pause).toBeDefined();
+    expect(pause!.failures).toBe(2);
+    expect(pause!.reason).toContain('paused to stop re-spending');
+    expect(pause!.unpause).toContain('fix-vulns');
+    expect(pause!.unpause).toContain('policy');
+  });
+
+  it('one failure under the default threshold does not pause', () => {
+    const { pauses } = evaluate([row('guardrail-red')]);
+    expect(pauses.size).toBe(0);
+  });
+
+  it('a SUCCESS resets the streak (verified, and a budget-cut verified partial)', () => {
+    for (const success of ['verified', 'budget-exhausted-verified'] as const) {
+      const { pauses } = evaluate([row('guardrail-red'), row('floor-red'), row(success)]);
+      expect(pauses.size).toBe(0);
+    }
+  });
+
+  it('refused / never-ran / not-dispatched / paused rows neither count nor reset', () => {
+    const { pauses } = evaluate([
+      row('guardrail-red'),
+      row('refused'),
+      row('never-ran'),
+      row('paused'),
+      row('not-dispatched'),
+      row('floor-red'),
+    ]);
+    expect(pauses.get('dep-advisory')?.failures).toBe(2);
+    // And neutral-only history never pauses.
+    const neutral = evaluate([row('refused'), row('refused'), row('refused')]);
+    expect(neutral.pauses.size).toBe(0);
+  });
+
+  it('a dxkit version change since the latest failure LIFTS the pause, disclosed', () => {
+    const rows = [row('guardrail-red'), row('guardrail-red')];
+    const { pauses, disclosures } = evaluate(rows, {
+      current: { ...STAMP, dxkitVersion: '4.4.6' },
+    });
+    expect(pauses.size).toBe(0);
+    expect(disclosures.some((d) => d.includes('dxkit changed'))).toBe(true);
+  });
+
+  it('a remediate policy change since the latest failure LIFTS the pause, disclosed', () => {
+    const rows = [row('guardrail-red'), row('guardrail-red')];
+    const { pauses, disclosures } = evaluate(rows, { current: { ...STAMP, policyHash: 'hash-b' } });
+    expect(pauses.size).toBe(0);
+    expect(disclosures.some((d) => d.includes('policy changed'))).toBe(true);
+  });
+
+  it('an explicit dispatch of the owning task overrides the pause for its classes only, disclosed', () => {
+    const rows = [
+      row('guardrail-red'),
+      row('guardrail-red'),
+      row('failed-recipe', { class: 'lint-located', task: 'fix-lint' }),
+      row('failed-recipe', { class: 'lint-located', task: 'fix-lint' }),
+    ];
+    const { pauses, disclosures } = evaluate(rows, { dispatchedTask: 'fix-vulns' });
+    expect(pauses.has('dep-advisory')).toBe(false);
+    expect(pauses.has('lint-located')).toBe(true);
+    expect(disclosures.some((d) => d.includes('dispatched explicitly'))).toBe(true);
+  });
+
+  it('threshold 0 disables the breaker entirely', () => {
+    const { pauses } = evaluate([row('guardrail-red'), row('guardrail-red')], { threshold: 0 });
+    expect(pauses.size).toBe(0);
+  });
+
+  it('classes are independent: an unrelated class failing never pauses a healthy one', () => {
+    const { pauses } = evaluate([
+      row('guardrail-red', { class: 'lint-located' }),
+      row('guardrail-red', { class: 'lint-located' }),
+      row('verified'),
+    ]);
+    expect(pauses.has('lint-located')).toBe(true);
+    expect(pauses.has('dep-advisory')).toBe(false);
+  });
+});
+
+describe('applyClassPauses', () => {
+  it('marks exactly the paused class orders, preserving plan order', () => {
+    const plan: WorkOrderPlan = {
+      orders: [
+        { id: 'a', class: 'dep-advisory' },
+        { id: 'b', class: 'lint-located' },
+      ].map((o) => ({
+        ...o,
+        findings: [],
+        envelope: { paths: ['x'], manifests: false },
+        constraints: { forbidden: [] },
+        done: { absentIds: [], verifier: 'floor' as const, command: 'x' },
+        budget: { turns: 1, minutes: 1, usd: 1, derivation: 'x' },
+        tier: 'agent' as const,
+        provenance: { source: 'guardrail-blocking' as const },
+      })),
+      undispatchable: [],
+    };
+    const { pauses } = evaluate([row('guardrail-red'), row('guardrail-red')]);
+    const marked = applyClassPauses(plan, pauses);
+    expect(marked.orders[0].paused?.reason).toContain('failures');
+    expect(marked.orders[1].paused).toBeUndefined();
+    expect(marked.orders.map((o) => o.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('remediateStamp', () => {
+  it('is deterministic and changes when the remediate policy section changes', () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-stamp-'));
+    fs.mkdirSync(path.join(cwd, '.dxkit'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, '.dxkit', 'policy.json'), '{"remediate":{"enabled":true}}');
+    const a = remediateStamp(cwd);
+    expect(remediateStamp(cwd)).toEqual(a);
+    fs.writeFileSync(
+      path.join(cwd, '.dxkit', 'policy.json'),
+      '{"remediate":{"enabled":true,"tasks":["fix-lint"]}}',
+    );
+    const b = remediateStamp(cwd);
+    expect(b.policyHash).not.toBe(a.policyHash);
+    expect(b.dxkitVersion).toBe(a.dxkitVersion);
+    // A change OUTSIDE the remediate section is not a remediate policy change.
+    fs.writeFileSync(
+      path.join(cwd, '.dxkit', 'policy.json'),
+      '{"remediate":{"enabled":true,"tasks":["fix-lint"]},"loop":{"preset":"security-only"}}',
+    );
+    expect(remediateStamp(cwd).policyHash).toBe(b.policyHash);
+  });
+});
+
+describe('gather integration (the ONE plan entry point applies the marks)', () => {
+  function lintBaselineRepo(): string {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-breaker-gather-'));
+    fs.mkdirSync(path.join(cwd, '.dxkit', 'baselines'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'package.json'), '{"name":"fx","version":"0.0.0"}');
+    fs.writeFileSync(
+      path.join(cwd, '.dxkit', 'baselines', 'main.json'),
+      JSON.stringify({
+        schemaVersion: 'dxkit-baseline/v1',
+        name: 'main',
+        createdAt: '2026-08-01T00:00:00.000Z',
+        repo: { commitSha: 'base', branch: 'main', dirty: false },
+        analysis: { dxkitVersion: 'test', toolchainHash: 'x' },
+        tools: {},
+        saltMode: 'none',
+        findings: [
+          {
+            id: 'lint1',
+            kind: 'custom-check',
+            check: 'lint:typescript',
+            blocking: true,
+            file: 'src/a.ts',
+            line: 3,
+            rule: 'no-unused-vars',
+          },
+        ],
+      }),
+    );
+    return cwd;
+  }
+
+  it('injected failure history pauses the class in the plan; explicit dispatch lifts it', async () => {
+    const cwd = lintBaselineRepo();
+    const config = resolveRemediateConfig(cwd);
+    const history = [
+      row('guardrail-red', { class: 'lint-located', task: 'fix-lint' }),
+      row('guardrail-red', { class: 'lint-located', task: 'fix-lint' }),
+    ];
+    const paused = await planRepoWorkOrders(cwd, config, { history, stamp: STAMP });
+    expect(paused.plan.orders.length).toBeGreaterThan(0);
+    expect(paused.plan.orders.every((o) => o.paused)).toBe(true);
+    expect(paused.pauses.map((p) => p.class)).toEqual(['lint-located']);
+
+    const dispatched = await planRepoWorkOrders(cwd, config, {
+      history,
+      stamp: STAMP,
+      dispatchedTask: 'fix-lint',
+    });
+    expect(dispatched.plan.orders.every((o) => o.paused === undefined)).toBe(true);
+    expect(dispatched.pauses).toEqual([]);
+    expect(dispatched.disclosures.some((d) => d.includes('dispatched explicitly'))).toBe(true);
+  });
+
+  it('remediate.pauseAfterFailures: 0 turns the breaker off at the plan entry point', async () => {
+    const cwd = lintBaselineRepo();
+    fs.writeFileSync(
+      path.join(cwd, '.dxkit', 'policy.json'),
+      '{"remediate":{"pauseAfterFailures":0}}',
+    );
+    const config = resolveRemediateConfig(cwd);
+    expect(config.pauseAfterFailures).toBe(0);
+    const out = await planRepoWorkOrders(cwd, config, {
+      history: [
+        row('guardrail-red', { class: 'lint-located' }),
+        row('guardrail-red', { class: 'lint-located' }),
+      ],
+      stamp: STAMP,
+    });
+    expect(out.plan.orders.every((o) => o.paused === undefined)).toBe(true);
+  });
+});

--- a/test/remediate/work-orders/plan-surface.test.ts
+++ b/test/remediate/work-orders/plan-surface.test.ts
@@ -433,5 +433,70 @@ describe('remediate plan --json: work orders', () => {
     );
     expect(out.workOrderPlanError).toContain('floor exploded');
     expect(out.workOrders).toEqual([]);
+    // Fail-open matrix: the static policy task list still runs, disclosed.
+    expect(out.matrixSource).toBe('static-fallback');
+    expect(out.matrixTasks).toEqual(['fix-vulns']);
+  });
+
+  it('the matrix derives from OPEN orders (value order, no-order tasks spawn no job, legacy open-ended disclosed) and pauses are first-class', async () => {
+    writePolicy({
+      remediate: {
+        enabled: true,
+        tasks: ['fix-build', 'fix-lint', 'fix-vulns', 'write-docs'],
+      },
+    });
+    writeBaseline(
+      [lintEntry('l1', 'src/a.ts', 1, 'eqeqeq'), lintEntry('l2', 'src/b.ts', 2, 'eqeqeq')],
+      FLOOR_DEBT,
+    );
+    writeAllowlist([DEFER_ENTRY]);
+    const stamp = { dxkitVersion: '4.4.5', policyHash: 'h' };
+    const pauseRow = (n: number) => ({
+      schema_version: 1,
+      timestamp: `2026-08-1${n}T00:00:00.000Z`,
+      lane: 'remediate',
+      task: 'fix-lint',
+      orderId: `lint-located:src/a.ts#${n}`,
+      class: 'lint-located',
+      tier: 'agent' as const,
+      outcome: 'guardrail-red' as const,
+      dxkitVersion: stamp.dxkitVersion,
+      policyHash: stamp.policyHash,
+    });
+    const out = await captureJson(() =>
+      runRemediatePlan(repo, {
+        json: true,
+        gather: {
+          packs: TS,
+          scanDepVulns: async () => [SCAN_FINDING],
+          now: NOW,
+          history: [pauseRow(1), pauseRow(2)],
+          stamp,
+        },
+      }),
+    );
+    // Value order: the advisory order ranks first, then the floor order;
+    // fix-lint's only orders are paused, so it spawns no job; write-docs
+    // is open-ended and kept only because policy lists it (legacy).
+    expect(out.matrixSource).toBe('orders');
+    expect(out.matrixTasks).toEqual(['fix-vulns', 'fix-build', 'write-docs']);
+    expect(out.matrixNoOpenOrders).toEqual(['fix-lint']);
+    expect(out.matrixLegacyOpenEnded).toEqual(['write-docs']);
+    const matrixDisclosures = out.matrixDisclosures as string[];
+    expect(matrixDisclosures.some((d) => d.includes('legacy shape'))).toBe(true);
+    expect(matrixDisclosures.some((d) => d.includes('PAUSED by the circuit breaker'))).toBe(true);
+    // Pauses are first-class in the JSON: the class summary and the
+    // per-order marks agree.
+    const paused = out.pausedClasses as Array<Record<string, unknown>>;
+    expect(paused).toHaveLength(1);
+    expect(paused[0].class).toBe('lint-located');
+    expect(String(paused[0].unpause)).toContain('fix-lint');
+    const orders = out.workOrders as Array<Record<string, unknown>>;
+    for (const o of orders) {
+      if (o.class === 'lint-located') expect(o.paused).not.toBeNull();
+      else expect(o.paused).toBeNull();
+    }
+    // The spend projection follows the derived matrix.
+    expect(out.projectedMaxSpendUsd).toBe(15);
   });
 });

--- a/test/remediate/work-orders/plan-surface.test.ts
+++ b/test/remediate/work-orders/plan-surface.test.ts
@@ -438,6 +438,19 @@ describe('remediate plan --json: work orders', () => {
     expect(out.matrixTasks).toEqual(['fix-vulns']);
   });
 
+  it('degraded evidence (no floor source anywhere) falls the matrix back to the static task list, disclosed', async () => {
+    writePolicy({ remediate: { enabled: true, tasks: ['fix-vulns', 'fix-lint'] } });
+    writeBaseline([lintEntry('l1', 'src/a.ts', 1, 'eqeqeq')]); // no floorDebt envelope
+    const out = await captureJson(() =>
+      runRemediatePlan(repo, { json: true, gather: { packs: TS } }),
+    );
+    expect(out.matrixEvidenceDegraded).toContain('no floor evidence');
+    expect(out.matrixSource).toBe('static-fallback');
+    expect(out.matrixTasks).toEqual(['fix-vulns', 'fix-lint']);
+    const disclosures = out.matrixDisclosures as string[];
+    expect(disclosures.some((d) => d.includes('degraded'))).toBe(true);
+  });
+
   it('the matrix derives from OPEN orders (value order, no-order tasks spawn no job, legacy open-ended disclosed) and pauses are first-class', async () => {
     writePolicy({
       remediate: {

--- a/test/remediate/work-orders/schedule.test.ts
+++ b/test/remediate/work-orders/schedule.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The order-derived scheduled matrix (remediate rethink 3F): tasks come
+ * from the OPEN orders in value order, a task with no open orders spawns
+ * no job, a paused-only task spawns no job (with a pause-shaped
+ * disclosure), the spend ceiling trims lowest-value first through the one
+ * ceiling helper, open-ended tasks stay scheduled only by explicit policy
+ * (disclosed as the legacy shape), and a missing plan falls back to the
+ * static list rather than silently turning the schedule off. Plus the
+ * injection guard: an order whose class is outside the built-in registry
+ * is disclosed, never silently dropped.
+ */
+import { describe, it, expect } from 'vitest';
+import { deriveScheduledMatrix } from '../../../src/remediate/work-orders/schedule';
+import type { RemediateConfig } from '../../../src/remediate/config';
+import type { WorkOrder, WorkOrderPlan } from '../../../src/remediate/work-orders/types';
+
+function order(id: string, cls: string, overrides: Partial<WorkOrder> = {}): WorkOrder {
+  return {
+    id,
+    class: cls,
+    findings: [],
+    envelope: { paths: ['x'], manifests: false },
+    constraints: { forbidden: [] },
+    done: { absentIds: [], verifier: 'floor', command: 'x' },
+    budget: { turns: 1, minutes: 1, usd: 1, derivation: 'x' },
+    tier: 'agent',
+    provenance: { source: 'guardrail-blocking' },
+    ...overrides,
+  };
+}
+
+function config(overrides: Partial<RemediateConfig> = {}): RemediateConfig {
+  return {
+    enabled: true,
+    tasks: ['fix-build', 'fix-vulns', 'fix-lint'],
+    unknownTasks: [],
+    schedule: 'weekly',
+    salvage: 'auto',
+    agent: {
+      driver: 'claude-code',
+      model: 'auto',
+      budget: { maxTurns: 80, maxMinutes: 30, maxUsd: 5 },
+    },
+    taskBudgets: {},
+    maxSpendPerRun: 0,
+    maxDispatchBudget: 0,
+    resume: false,
+    maxOrdersPerRun: 3,
+    pauseAfterFailures: 2,
+    workOrders: { maxSliceSize: 25 },
+    recipes: { enabled: true },
+    ...overrides,
+  };
+}
+
+function plan(orders: WorkOrder[]): WorkOrderPlan {
+  return { orders, undispatchable: [] };
+}
+
+describe('deriveScheduledMatrix', () => {
+  it('derives tasks from open orders in value order; a class-selecting task with no orders spawns no job', () => {
+    const m = deriveScheduledMatrix({
+      config: config(),
+      // Value order: an advisory order first, then a floor order.
+      plan: plan([order('a', 'dep-advisory'), order('b', 'stale-lockfile')]),
+    });
+    expect(m.source).toBe('orders');
+    expect(m.run).toEqual(['fix-vulns', 'fix-build']);
+    expect(m.noOpenOrders).toEqual(['fix-lint']);
+    expect(
+      m.disclosures.some((d) => d.includes("'fix-lint'") && d.includes('no open work orders')),
+    ).toBe(true);
+  });
+
+  it('a paused-only task spawns no job, with a pause-shaped disclosure', () => {
+    const m = deriveScheduledMatrix({
+      config: config({ tasks: ['fix-vulns'] }),
+      plan: plan([
+        order('a', 'dep-advisory', { paused: { reason: 'streak', unpause: 'policy change' } }),
+      ]),
+    });
+    expect(m.run).toEqual([]);
+    expect(m.noOpenOrders).toEqual(['fix-vulns']);
+    expect(m.disclosures.some((d) => d.includes('PAUSED by the circuit breaker'))).toBe(true);
+  });
+
+  it('a task with both paused and open orders still spawns (the open ones are worth the job)', () => {
+    const m = deriveScheduledMatrix({
+      config: config({ tasks: ['fix-vulns'] }),
+      plan: plan([
+        order('a', 'dep-advisory', { paused: { reason: 'streak', unpause: 'x' } }),
+        order('b', 'dep-advisory'),
+      ]),
+    });
+    expect(m.run).toEqual(['fix-vulns']);
+  });
+
+  it('the spend ceiling trims from the END of the value order, disclosed as deferred', () => {
+    const m = deriveScheduledMatrix({
+      config: config({ maxSpendPerRun: 5 }),
+      plan: plan([order('a', 'dep-advisory'), order('b', 'lint-located')]),
+    });
+    expect(m.run).toEqual(['fix-vulns']);
+    expect(m.deferred).toEqual(['fix-lint']);
+  });
+
+  it('open-ended tasks stay scheduled only via explicit policy, appended after order tasks, disclosed as legacy', () => {
+    const m = deriveScheduledMatrix({
+      config: config({ tasks: ['improve-tests', 'fix-vulns', 'write-docs'] }),
+      plan: plan([order('a', 'dep-advisory')]),
+    });
+    expect(m.run).toEqual(['fix-vulns', 'improve-tests', 'write-docs']);
+    expect(m.legacyOpenEnded).toEqual(['improve-tests', 'write-docs']);
+    expect(m.disclosures.filter((d) => d.includes('legacy shape'))).toHaveLength(2);
+  });
+
+  it('legacy-policy compatibility: the default policy shape keeps working with zero orders (no jobs, all disclosed)', () => {
+    const m = deriveScheduledMatrix({ config: config({ tasks: ['fix-vulns'] }), plan: plan([]) });
+    expect(m.run).toEqual([]);
+    expect(m.noOpenOrders).toEqual(['fix-vulns']);
+  });
+
+  it('no plan (planning failed) falls back to the static policy list, disclosed, never a silent off-switch', () => {
+    const m = deriveScheduledMatrix({
+      config: config({ maxSpendPerRun: 10 }),
+      plan: null,
+      planError: 'boom',
+    });
+    expect(m.source).toBe('static-fallback');
+    expect(m.run).toEqual(['fix-build', 'fix-vulns']);
+    expect(m.deferred).toEqual(['fix-lint']);
+    expect(m.disclosures.some((d) => d.includes('boom'))).toBe(true);
+  });
+
+  it('an order class outside the built-in registry is DISCLOSED, never silently dropped (injection guard)', () => {
+    const m = deriveScheduledMatrix({
+      config: config(),
+      plan: plan([order('a', 'synthetic-class'), order('b', 'dep-advisory')]),
+    });
+    expect(m.run).toEqual(['fix-vulns']);
+    expect(m.disclosures.some((d) => d.includes("'synthetic-class'"))).toBe(true);
+  });
+
+  it('an order for a task policy did not enable never widens the matrix', () => {
+    const m = deriveScheduledMatrix({
+      config: config({ tasks: ['fix-vulns'] }),
+      plan: plan([order('a', 'lint-located'), order('b', 'dep-advisory')]),
+    });
+    expect(m.run).toEqual(['fix-vulns']);
+  });
+});

--- a/test/remediate/work-orders/schedule.test.ts
+++ b/test/remediate/work-orders/schedule.test.ts
@@ -120,6 +120,28 @@ describe('deriveScheduledMatrix', () => {
     expect(m.noOpenOrders).toEqual(['fix-vulns']);
   });
 
+  it('DEGRADED evidence falls back to the static policy list, disclosed; healthy zero orders stays a legitimate no-job firing', () => {
+    // A fail-open gather (unreadable baseline, no floor evidence) yields
+    // zero orders that prove nothing: spawning nothing weekly on that
+    // basis would be a silent off-switch.
+    const degraded = deriveScheduledMatrix({
+      config: config({ tasks: ['fix-vulns'] }),
+      plan: plan([]),
+      evidenceDegraded: 'the baseline exists but could not be read',
+    });
+    expect(degraded.source).toBe('static-fallback');
+    expect(degraded.run).toEqual(['fix-vulns']);
+    expect(degraded.disclosures.some((d) => d.includes('could not be read'))).toBe(true);
+    // Healthy evidence with zero orders remains the $0 win.
+    const healthy = deriveScheduledMatrix({
+      config: config({ tasks: ['fix-vulns'] }),
+      plan: plan([]),
+      evidenceDegraded: null,
+    });
+    expect(healthy.source).toBe('orders');
+    expect(healthy.run).toEqual([]);
+  });
+
   it('no plan (planning failed) falls back to the static policy list, disclosed, never a silent off-switch', () => {
     const m = deriveScheduledMatrix({
       config: config({ maxSpendPerRun: 10 }),


### PR DESCRIPTION
## What / why

The weekly remediate firing stops being a blind loop (remediate rethink, section 3F). Building on the recipe executor (#339) and the scoped agent (#341), this unit gives the scheduler memory:

1. **Work-order outcome ledger** (`src/lanes/order-ledger.ts`, the lane-ledger mechanism extended). Every run records per-ORDER outcome rows in `.dxkit/lanes/remediate-<task>.orders.jsonl`: order id, class, tier, outcome, spend, a runner-written timestamp, and the environment stamps (dxkit version, remediate policy hash). Committed work carries the run verdict (one tree verification arbitrates every order that contributed commits); refusals and infrastructure keep their own words. Two durability channels, both existing trust surfaces: a landing commits the file in the same path-scoped bookkeeping commit as the delivery event (rows reach the default branch on merge), and a non-landing run pushes the composed file as a frame-authored metadata commit on the task's standing branch (the resume-marker channel, plumbing commands only, zero agent content). One reader, `orderHistory(cwd)`, merges local plus standing-branch rows fail-open with a bounded window (60 days, capped per class), so history degradations are disclosed and old failures age out.

2. **Circuit breaker** (`remediate.pauseAfterFailures`, default 2, 0 off). A class whose last N counted outcomes are failures (guardrail-red / floor-red / install-failed / failed-recipe; refusals, never-ran, and sweep failures never count; a verified outcome, including a budget-cut verified partial, resets the streak) is PAUSED. Applied at the ONE gather+plan entry point so the plan CLI and the recipe phase can never disagree; paused orders stay planned and are disclosed in the plan output, the run ledger, and the workflow notices, but no tier dispatches them, and an all-paused selection completes as a disclosed no-op at zero cost instead of falling through to the open-ended legacy prompt. A pause lifts on a remediate policy change, a dxkit upgrade, an explicit dispatch naming the owning task (workflow input threaded as `DXKIT_DISPATCH_TASK`; a local `--task` run counts), or window age-out; every lift is disclosed.

3. **Value-ordered spend ceiling.** The plan job's matrix derives from the OPEN orders in the planner's value order: a task with no open orders spawns no job, the spend ceiling trims lowest-value first through the one ceiling helper, and the dispatch-override path is unchanged. Open-ended tasks (improve-tests / write-docs) stay scheduled only when policy lists them explicitly, disclosed as the legacy shape (the default task set never included them, so existing policies keep working). A missing plan falls back to the static list with the reason named; an unroutable order class is disclosed, never dropped.

4. **Docs and knob registration.** operating-the-lanes, the remediate skill, and the command doc now describe orders, recipes, pauses, and the resume policy truthfully (resume anchors only on a budget-exhausted verified partial; a blocked draft becomes a negative constraint). The knob is registered in the policy schema, `POLICY_PARAMS`, and the guide (new "Remediate pause" section plus the regenerated index); it is guardrail-tuning-shaped, so it carries no posture-knob probe (the `maxOrdersPerRun` precedent).

## How it is tested

- `test/lanes/order-ledger.test.ts`: row parsing fail-open per line and per schema, local reader scoping, merge dedupe, window bounds (age and per-class), the ONE history reader with scripted git (branch rows merged; unreachable remote and unfetchable branch disclosed; absent branch silent), and the compatibility pin that the delivery reader and the order reader never ingest each other's rows.
- `test/remediate/work-orders/breaker.test.ts`: pauses after N consecutive failures; refused/never-ran/paused rows neither count nor reset; verified and budget-exhausted-verified reset; dxkit-version and policy-hash changes lift with disclosures; explicit dispatch lifts only the owning task's classes; threshold 0 disables; per-class independence; `remediateStamp` determinism and remediate-section scoping; gather integration (injected history pauses the planned orders, dispatch lifts, knob 0 disables at the entry point).
- `test/remediate/work-orders/schedule.test.ts`: order-to-task value order; no-order and paused-only tasks spawn no job (disclosed); ceiling trims disclosed; legacy open-ended kept by explicit policy; static fallback on a missing plan; synthetic unknown-class injection guard; policy-disabled tasks never widen the matrix.
- `test/remediate/order-outcomes.test.ts`: the projection (run-verdict rows, refusal/failed-recipe/never-ran words, paused rows, spend and stamps on every row), the landing channel's compose-with-branch-rows write, and the publish channel's plumbing sequence (branch-head parent so drafts are preserved, checkout-head base when no branch exists, one retry on a push race, disclosed failure note).
- `test/remediate/recipes/run-recipes.test.ts` + `frame.test.ts`: a paused class is in neither tier (nothing spawns, agent queue excludes it, summary discloses it); dispatch threaded through the frame lifts it; an all-paused run is a $0 no-op whose note and ledger name the pause; a mixed run proceeds with the pause rendered.
- `test/remediate/executor-landing.test.ts`: the landing run hands the composed ledger path to the lander; a non-landing outcome publishes rows; `--land none` and a record-less run touch neither channel.
- `test/remediate/work-orders/plan-surface.test.ts`: the plan JSON carries per-order pause marks, `pausedClasses`, the derived matrix fields and disclosures, the static fallback, and the matrix-derived spend projection.

## Sweep + guardrail

Full local sweep green: typecheck, typecheck:test, eslint (0 warnings), prettier, check-architecture, check-docs-coverage, check-slop (base origin/main), build, vitest with coverage (6102 tests passing; 74.18% lines vs 50% floor), check-coverage. Self-guardrail `guardrail check --mode ref-based --ref origin/main`: **PASSED** (88 pairs, 0 blocking). An earlier run flagged a net-new large-file finding on `execute.ts`; fixed at the root by splitting the attempt-record helpers into `src/remediate/attempt-record.ts` rather than allowlisting.

## Review focus

- The non-landing durability channel (`publishOrderRows`): a metadata commit built with git plumbing and pushed to the standing branch through `internalGitPushArgs`. It carries only the lane's own ledger file and parents on the branch head so an open draft is preserved, but it is a new writer to the standing branches; check the trust reasoning against the resume-marker precedent.
- The breaker's counting sets (`ORDER_FAILURE_OUTCOMES` / `ORDER_SUCCESS_OUTCOMES` in `src/lanes/order-ledger.ts`): deliberately narrow failure set, neutral everything else, biased toward retrying rather than over-pausing.
- The explicit-dispatch signal: local `--task` counts as explicit; under Actions only a workflow_dispatch naming the task does (the scheduled matrix also invokes `--task`, distinguished by `DXKIT_DISPATCH_TASK`). `remediate configured` never counts.
- The matrix derivation's legacy arm: open-ended tasks appended after the value-ordered class tasks, so a ceiling trims them first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
