### PR TITLE
fix(remediate): recipe feasibility on real estates, fix-version join and grouped lint slices (4.4.5 recipe-feasibility)

### DIFF
--- a/src/remediate/recipes/lint-autofix.ts
+++ b/src/remediate/recipes/lint-autofix.ts
@@ -8,14 +8,14 @@
  * (`parseLocated` / `parseStructuredLocated`, Rule 17), so the recipe's
  * verify reads the leftovers of the very command that fixed.
  *
- * Verify is strict by construction: a single-slice lint order carries the
- * file's ENTIRE known finding set, so "the order's ids are absent AND no
- * net-new finding appeared in the envelope" collapses to "the file lints
- * clean". Anything remaining (an unfixable rule, a finding the fix
- * introduced) fails the recipe, the diff is discarded, and the order stays
- * open for the agent tier with the leftover rules named. A sliced order
- * (the file's findings span several orders) is refused: a file-scoped fix
- * cannot be verified per slice.
+ * Verify: the file must lint clean afterwards for a full apply. When rules
+ * remain and EVERY one of them is among the order's own rules, the failure
+ * carries them structurally (`leftoverRules`) so the grouped runner can
+ * evaluate each slice-order of the file individually: the fix runs ONCE
+ * per file, slices whose rules are all gone apply, and unfixed slices fall
+ * to the agent tier. A leftover rule OUTSIDE the order's own set (net-new,
+ * or unparsed) fails the whole attempt plain, and the runner discards the
+ * diff: a fix that mints findings never lands.
  */
 import { tail } from '../../analyzers/tools/bounded-exec';
 import { parseLocated, parseStructuredLocated } from '../../analyzers/custom-checks/parse';
@@ -49,15 +49,6 @@ export async function executeLintAutofix(
         'pack lint gates have a declared fix mode',
     };
   }
-  if (order.provenance.source === 'debt-slice' && order.provenance.of > 1) {
-    return {
-      kind: 'refused',
-      reason:
-        `the file's findings span ${order.provenance.of} sliced orders, and a file-scoped ` +
-        'autofix cannot be verified one slice at a time; raise ' +
-        'remediate.workOrders.maxSliceSize or leave this to the agent tier',
-    };
-  }
   const provider = getLanguage(pack as LanguageId)?.lintGate;
   const fix = provider?.fixCommand?.({ cwd: ctx.cwd, files: [file] }) ?? null;
   if (fix === null) {
@@ -87,14 +78,25 @@ export async function executeLintAutofix(
   const inFile = remaining.filter((f) => f.file === file || f.file === undefined);
   if (inFile.length > 0) {
     const rules = [...new Set(inFile.map((f) => f.rule ?? '(unparsed)'))].sort();
+    const known = new Set(
+      order.findings.map((f) => (f.evidence.type === 'custom-check' ? f.evidence.rule : undefined)),
+    );
+    // Structured leftovers ONLY when every remaining rule is one the order
+    // already knew about: an unknown or unparsed rule is net-new (or
+    // unattributable), and the whole attempt must fail plain so the runner
+    // discards the diff.
+    const allKnown = rules.every((r) => known.has(r));
     return {
       kind: 'failed',
       step: 'verify-lint',
       output: tail(
         `${inFile.length} finding(s) remain in ${file} after the autofix ` +
-          `(rules: ${rules.join(', ')}): not auto-fixable, or introduced by the fix; ` +
-          'leaving the order to the agent tier',
+          `(rules: ${rules.join(', ')}): ` +
+          (allKnown
+            ? 'not auto-fixable; the unfixed orders fall to the agent tier'
+            : 'not all among the order findings (net-new or unparsed); discarding the fix'),
       ),
+      ...(allKnown ? { leftoverRules: rules } : {}),
     };
   }
   return { kind: 'applied', changedFiles: [file] };

--- a/src/remediate/recipes/run-recipes.ts
+++ b/src/remediate/recipes/run-recipes.ts
@@ -149,6 +149,48 @@ async function defaultAudit(cwd: string): Promise<readonly DepVulnFinding[] | nu
   return result.envelope?.findings ?? [];
 }
 
+/** Orders sharing a recipe + a non-null `groupKey` collapse into ONE
+ *  execution attempt (positioned at the first member): a file's lint
+ *  slices pay one `--fix` run, not one per slice. Everything else stays a
+ *  singleton group, byte-identical to the ungrouped behavior. */
+export function groupRecipeOrders(
+  orders: readonly WorkOrder[],
+  registry: readonly RecipeDeclaration[],
+): WorkOrder[][] {
+  const groups: WorkOrder[][] = [];
+  const byKey = new Map<string, number>();
+  for (const order of orders) {
+    if (order.tier !== 'recipe' || !order.recipe) continue;
+    const key = registry.find((r) => r.id === order.recipe)?.groupKey?.(order) ?? null;
+    if (key !== null) {
+      const groupKey = `${order.recipe}\0${key}`;
+      const at = byKey.get(groupKey);
+      if (at !== undefined) {
+        groups[at].push(order);
+        continue;
+      }
+      byKey.set(groupKey, groups.length);
+    }
+    groups.push([order]);
+  }
+  return groups;
+}
+
+/** The commit-message order list, capped so a 40-slice file does not write
+ *  a paragraph-long subject. */
+function nameOrders(ids: readonly string[]): string {
+  return ids.length <= 6 ? ids.join(', ') : `${ids.slice(0, 6).join(', ')} +${ids.length - 6} more`;
+}
+
+/** The rules a lint order's findings carry. */
+function orderRules(order: WorkOrder): Set<string> {
+  return new Set(
+    order.findings.flatMap((f) =>
+      f.evidence.type === 'custom-check' && f.evidence.rule !== undefined ? [f.evidence.rule] : [],
+    ),
+  );
+}
+
 /** Execute the recipe-tier orders, in plan (value) order. */
 export async function runRecipeOrders(
   orders: readonly WorkOrder[],
@@ -158,32 +200,40 @@ export async function runRecipeOrders(
   const queryOsv = cachedOsvQuery(deps.queryOsv ?? queryOsvPackage);
   const blockSeverities = deps.blockSeverities ?? effectiveBlockSeverities(deps.cwd);
   const records: RecipeOrderRecord[] = [];
-  for (const order of orders) {
-    if (order.tier !== 'recipe' || !order.recipe) continue;
-    const base = { orderId: order.id, class: String(order.class), recipe: order.recipe };
+  const recordAll = (
+    group: readonly WorkOrder[],
+    outcome: RecipeOutcome,
+    extra?: Pick<RecipeOrderRecord, 'droppedPaths'>,
+  ) => {
+    for (const order of group) {
+      records.push({
+        orderId: order.id,
+        class: String(order.class),
+        recipe: order.recipe!,
+        outcome,
+        ...(extra ?? {}),
+      });
+    }
+  };
+  for (const group of groupRecipeOrders(orders, registry)) {
+    const first = group[0];
     // Rule 17, decided at the ONE phase entry point: recipes run installs
     // and linters, so an untrusted tree refuses every order before any
     // registry entry executes, disclosed per order, never silent.
     if (!deps.trust.repoExecutionAllowed) {
-      records.push({
-        ...base,
-        outcome: {
-          kind: 'refused',
-          reason:
-            `repo execution is not allowed under this trust context (${deps.trust.source}); ` +
-            'recipes run package-manager and linter commands, so nothing spawned',
-        },
+      recordAll(group, {
+        kind: 'refused',
+        reason:
+          `repo execution is not allowed under this trust context (${deps.trust.source}); ` +
+          'recipes run package-manager and linter commands, so nothing spawned',
       });
       continue;
     }
-    const decl = registry.find((r) => r.id === order.recipe);
+    const decl = registry.find((r) => r.id === first.recipe);
     if (!decl?.execute) {
-      records.push({
-        ...base,
-        outcome: {
-          kind: 'refused',
-          reason: `recipe '${order.recipe}' is declared but not executable in this build`,
-        },
+      recordAll(group, {
+        kind: 'refused',
+        reason: `recipe '${first.recipe}' is declared but not executable in this build`,
       });
       continue;
     }
@@ -191,13 +241,10 @@ export async function runRecipeOrders(
     try {
       pre = new Set(deps.git.changedPaths());
     } catch (err) {
-      records.push({
-        ...base,
-        outcome: {
-          kind: 'failed',
-          step: 'working-tree',
-          output: tail(err instanceof Error ? err.message : String(err)),
-        },
+      recordAll(group, {
+        kind: 'failed',
+        step: 'working-tree',
+        output: tail(err instanceof Error ? err.message : String(err)),
       });
       continue;
     }
@@ -205,24 +252,28 @@ export async function runRecipeOrders(
     // own diff unattributable: an edit to an already-dirty file would be
     // neither committed (a partial manifest commit CI cannot install) nor
     // discarded (leaking the recipe's change into the user's dirt). Refuse
-    // up front, dirty paths named, so both contracts hold exactly.
-    const dirtyInEnvelope = [...pre].filter((path) => pathInEnvelope(path, order.envelope));
+    // up front, dirty paths named, so both contracts hold exactly. Group
+    // members share one envelope (the group key IS the file), so the first
+    // member's answers for all.
+    const dirtyInEnvelope = [...pre].filter((path) => pathInEnvelope(path, first.envelope));
     if (dirtyInEnvelope.length > 0) {
-      records.push({
-        ...base,
-        outcome: {
-          kind: 'refused',
-          reason:
-            'the working tree already has uncommitted changes inside this order envelope ' +
-            `(${dirtyInEnvelope.join(', ')}); commit or stash them so the recipe's own diff ` +
-            'stays attributable',
-        },
+      recordAll(group, {
+        kind: 'refused',
+        reason:
+          'the working tree already has uncommitted changes inside this order envelope ' +
+          `(${dirtyInEnvelope.join(', ')}); commit or stash them so the recipe's own diff ` +
+          'stays attributable',
       });
       continue;
     }
+    // One attempt for the whole group: the merged findings tell the
+    // executor everything the group's orders know (its verify treats their
+    // union as the known set).
+    const merged: WorkOrder =
+      group.length === 1 ? first : { ...first, findings: group.flatMap((o) => o.findings) };
     let outcome: RecipeOutcome;
     try {
-      outcome = await decl.execute(order, {
+      outcome = await decl.execute(merged, {
         cwd: deps.cwd,
         trust: deps.trust,
         exec: deps.exec,
@@ -243,45 +294,75 @@ export async function runRecipeOrders(
     try {
       delta = deps.git.changedPaths().filter((p) => !pre.has(p));
     } catch (err) {
-      records.push({
-        ...base,
-        outcome: {
-          kind: 'failed',
-          step: 'working-tree',
-          output:
-            'could not read the working tree after the recipe ran, so its diff can be ' +
-            `neither enforced nor committed: ${tail(err instanceof Error ? err.message : String(err))}`,
-        },
+      recordAll(group, {
+        kind: 'failed',
+        step: 'working-tree',
+        output:
+          'could not read the working tree after the recipe ran, so its diff can be ' +
+          `neither enforced nor committed: ${tail(err instanceof Error ? err.message : String(err))}`,
       });
       continue;
     }
-    if (outcome.kind !== 'applied') {
+    // Per-order done inside a partly-fixed group: when the verify handed
+    // back STRUCTURED leftovers (every remaining rule known to the merged
+    // order), each member whose own rules are all gone is done; the rest
+    // stay open and fall to the agent queue. The partial fix is real work
+    // and commits; the leftover findings are the grandfathered debt of the
+    // still-open orders, and the tree verification stays the arbiter.
+    const leftoverRules =
+      outcome.kind === 'failed' && outcome.step === 'verify-lint'
+        ? outcome.leftoverRules
+        : undefined;
+    const closed =
+      leftoverRules !== undefined
+        ? group.filter((o) => [...orderRules(o)].every((r) => !leftoverRules.includes(r)))
+        : [];
+    if (outcome.kind !== 'applied' && closed.length === 0) {
       deps.git.discardPaths(delta);
-      records.push({ ...base, outcome });
+      recordAll(group, outcome);
       continue;
     }
-    const { inside, outside } = partitionByEnvelope(delta, order.envelope);
+    const applying = outcome.kind === 'applied' ? [...group] : closed;
+    const open = group.filter((o) => !applying.includes(o));
+    const { inside, outside } = partitionByEnvelope(delta, first.envelope);
     if (outside.length > 0) deps.git.discardPaths(outside);
+    const dropped = outside.length > 0 ? { droppedPaths: outside } : {};
     if (inside.length === 0) {
-      records.push({
-        ...base,
-        outcome: {
+      recordAll(
+        applying,
+        {
           kind: 'failed',
           step: 'envelope',
           output:
-            'the recipe reported applied but left no change inside the order envelope' +
+            'the recipe reported this order done but left no change inside the order envelope' +
             (outside.length > 0 ? ` (out-of-envelope paths were discarded)` : ''),
         },
-        ...(outside.length > 0 ? { droppedPaths: outside } : {}),
-      });
-      continue;
+        dropped,
+      );
+    } else {
+      deps.git.commitPaths(
+        inside,
+        `fix(${first.class}): ${nameOrders(applying.map((o) => o.id))} (${decl.id} recipe)`,
+      );
+      recordAll(applying, { kind: 'applied', changedFiles: inside }, dropped);
     }
-    deps.git.commitPaths(inside, `fix(${order.class}): ${order.id} (${decl.id} recipe)`);
-    records.push({
-      ...base,
-      outcome: { ...outcome, changedFiles: inside },
-      ...(outside.length > 0 ? { droppedPaths: outside } : {}),
-    });
+    if (open.length > 0 && outcome.kind === 'failed') {
+      for (const o of open) {
+        const remain = [...orderRules(o)].filter((r) => leftoverRules!.includes(r)).sort();
+        records.push({
+          orderId: o.id,
+          class: String(o.class),
+          recipe: o.recipe!,
+          outcome: {
+            kind: 'failed',
+            step: 'verify-lint',
+            output:
+              `rules remain after the file-level autofix (${remain.join(', ')}); ` +
+              'not auto-fixable; this order falls to the agent tier',
+          },
+        });
+      }
+    }
   }
   return records;
 }

--- a/src/remediate/recipes/types.ts
+++ b/src/remediate/recipes/types.ts
@@ -46,11 +46,19 @@ export type RecipeOutcome =
     }
   | {
       /** The recipe acted and a step broke (or its verify did not confirm).
-       *  The runner discards the partial diff. */
+       *  The runner discards the partial diff (unless a grouped execution
+       *  can salvage per-order slices; see `leftoverRules`). */
       readonly kind: 'failed';
       readonly step: string;
       /** Captured output tail / verify evidence (display-sized). */
       readonly output: string;
+      /** lint-autofix verify only: the rules still reported in the file
+       *  after the fix, EVERY one of them among the order's own rules (an
+       *  unknown or unparsed leftover never sets this; that is the
+       *  net-new guard, and the whole attempt fails plain). Lets the
+       *  grouped runner evaluate each slice-order's done individually:
+       *  slices whose rules are all gone applied, the rest stay open. */
+      readonly leftoverRules?: readonly string[];
     };
 
 /** What a recipe executes with. Everything spawnable or network-shaped is

--- a/src/remediate/work-orders/deferrals.ts
+++ b/src/remediate/work-orders/deferrals.ts
@@ -77,7 +77,14 @@ export async function joinDeferrals(
   byId: ReadonlyMap<string, RichBaselineEntry>,
   opts: GatherWorkOrderOptions,
   disclosures: string[],
-): Promise<{ deferred: DeferredInput[]; depScanSource: DepScanSource }> {
+): Promise<{
+  deferred: DeferredInput[];
+  depScanSource: DepScanSource;
+  /** The scan findings the join read, by fingerprint, handed onward so the
+   *  advisory-detail join can enrich baseline DEBT from the same paid scan
+   *  (one scan, every consumer). */
+  scanned: ReadonlyMap<string, DepVulnFinding>;
+}> {
   const now = opts.now ?? new Date();
   const deferred = activeDeferredEntries(allowlist, now);
   const needsScan = deferred.some((d) => d.kind === 'dep-vuln');
@@ -121,5 +128,5 @@ export async function joinDeferrals(
     if (entry.kind === 'custom-check') return { ...base, kind: 'custom-check', entry };
     return { ...base, kind: 'other', entry };
   });
-  return { deferred: joined, depScanSource };
+  return { deferred: joined, depScanSource, scanned };
 }

--- a/src/remediate/work-orders/fix-versions.ts
+++ b/src/remediate/work-orders/fix-versions.ts
@@ -1,0 +1,130 @@
+/**
+ * The advisory-detail join for the work-order plan (4.4.5 estate fix): the
+ * override-pin recipe's `matches` needs a CONCRETE `fixedVersion` on every
+ * finding, but the sources the planner reads often cannot carry one — a
+ * baseline debt entry stores identity only, and a raw dependency-scan
+ * finding gets its fix version from OSV enrichment the plan path never paid
+ * for. On the rehearsal estate that tiered EVERY dep-advisory order to the
+ * agent, deferrals with known pins included: determinism lost to a missing
+ * join, not to a missing fact.
+ *
+ * This module builds the `advisoryDetails` map the planner fills from:
+ *
+ *   1. the live/BoM/injected scan the deferral join already paid for — its
+ *      findings enrich BASELINE DEBT entries by fingerprint (the deferral
+ *      side already prefers the live copy at join time);
+ *   2. the ONE OSV client's `resolveFixVersions` (session-cached,
+ *      alias-aware, installed-version-correct) for advisories STILL missing
+ *      a fix version, deferrals first then debt (value order), capped and
+ *      disclosed.
+ *
+ * Fail-open throughout: an unreachable OSV leaves fields absent (the order
+ * honestly stays agent-tier), disclosed, never a crash and never a guess.
+ */
+import { resolveFixVersions, type OsvFetcher } from '../../analyzers/tools/osv';
+import type { RichBaselineEntry } from '../../baseline/types';
+import type { DepVulnFinding } from '../../languages/capabilities/types';
+import type { AdvisoryDetail, DeferredInput } from './planner';
+
+/** The most advisories one plan pays OSV fix resolution for (each id is one
+ *  cached HTTP lookup). Deferrals outrank debt; a capped tail is disclosed
+ *  and simply stays agent-tier. */
+export const OSV_FIX_RESOLUTION_CAP = 100;
+
+interface NeedsFix {
+  /** The finding id the detail map is keyed by. */
+  readonly id: string;
+  readonly advisoryId: string;
+  readonly aliases: string[];
+  readonly installedVersion?: string;
+}
+
+export interface AdvisoryDetailArgs {
+  readonly deferred: readonly DeferredInput[];
+  readonly debt: readonly RichBaselineEntry[];
+  /** The dependency-scan findings the deferral join read, by fingerprint. */
+  readonly scanned: ReadonlyMap<string, DepVulnFinding>;
+  /** Injected in tests; defaults to the OSV client's session-cached fetch. */
+  readonly osvFetcher?: OsvFetcher;
+  readonly disclosures: string[];
+}
+
+/**
+ * Build the planner's `advisoryDetails` join. Pays OSV lookups only for
+ * dep-vuln findings still missing a fix version after the scan join, and
+ * only up to the cap.
+ */
+export async function advisoryDetailMap(
+  args: AdvisoryDetailArgs,
+): Promise<Map<string, AdvisoryDetail>> {
+  const details = new Map<string, AdvisoryDetail>();
+  const needsFix: NeedsFix[] = [];
+
+  // Deferrals first (value order): the join already preferred the live
+  // copy, so only a fix-less advisory needs OSV.
+  for (const d of args.deferred) {
+    if (d.kind !== 'dep-vuln' || d.advisory.fixedVersion !== undefined) continue;
+    const scanned = args.scanned.get(d.advisory.id);
+    needsFix.push({
+      id: d.advisory.id,
+      advisoryId: d.advisory.advisoryId,
+      aliases: scanned?.aliases ?? [],
+      ...(d.advisory.installedVersion !== undefined
+        ? { installedVersion: d.advisory.installedVersion }
+        : {}),
+    });
+  }
+
+  // Baseline debt: enrich from the scan the deferral join already paid for
+  // (fingerprints share the one identity scheme), then OSV for the rest.
+  for (const e of args.debt) {
+    if (e.kind !== 'dep-vuln') continue;
+    const scanned = args.scanned.get(e.id);
+    if (scanned) {
+      details.set(e.id, {
+        ...(scanned.fixedVersion !== undefined ? { fixedVersion: scanned.fixedVersion } : {}),
+        ...(scanned.reachable !== undefined ? { reachable: scanned.reachable } : {}),
+        ...(scanned.installedVersion !== undefined
+          ? { installedVersion: scanned.installedVersion }
+          : {}),
+        ...(scanned.packId !== undefined ? { pack: scanned.packId } : {}),
+      });
+    }
+    if (scanned?.fixedVersion !== undefined) continue;
+    needsFix.push({
+      id: e.id,
+      advisoryId: e.advisoryId,
+      aliases: scanned?.aliases ?? [],
+      ...(e.installedVersion !== undefined ? { installedVersion: e.installedVersion } : {}),
+    });
+  }
+
+  if (needsFix.length === 0) return details;
+  const within = needsFix.slice(0, OSV_FIX_RESOLUTION_CAP);
+  if (needsFix.length > within.length) {
+    args.disclosures.push(
+      `fix-version resolution capped at ${OSV_FIX_RESOLUTION_CAP} advisories ` +
+        `(${needsFix.length - within.length} more stay without one and tier to the agent)`,
+    );
+  }
+  const resolved = await resolveFixVersions(
+    within.map((n) => ({
+      primaryId: n.advisoryId,
+      aliases: n.aliases,
+      ...(n.installedVersion !== undefined ? { installedVersion: n.installedVersion } : {}),
+    })),
+    ...(args.osvFetcher ? [args.osvFetcher] : []),
+  );
+  let hits = 0;
+  for (const n of within) {
+    const fixedVersion = resolved.get(n.advisoryId);
+    if (fixedVersion === undefined) continue;
+    hits += 1;
+    details.set(n.id, { ...details.get(n.id), fixedVersion });
+  }
+  args.disclosures.push(
+    `fix-version resolution: ${hits} of ${within.length} advisories resolved via OSV ` +
+      '(an unresolved advisory keeps its order agent-tier)',
+  );
+  return details;
+}

--- a/src/remediate/work-orders/gather.ts
+++ b/src/remediate/work-orders/gather.ts
@@ -89,6 +89,8 @@ export type FloorSource = 'live' | 'baseline-envelope' | 'loop-snapshot' | 'none
 // re-exported here so consumers keep one import surface.
 export { BOM_FRESHNESS_DAYS, type DepScanSource } from './deferrals';
 import { joinDeferrals, type DepScanSource } from './deferrals';
+import { advisoryDetailMap } from './fix-versions';
+import type { OsvFetcher } from '../../analyzers/tools/osv';
 
 export interface GatherWorkOrderOptions {
   /** Run the live floor (default: read a stored envelope). */
@@ -104,6 +106,8 @@ export interface GatherWorkOrderOptions {
   readonly baselineName?: string;
   /** Injected active packs (tests). */
   readonly packs?: readonly LanguageSupport[];
+  /** Injected OSV fetch for the advisory fix-version join (tests). */
+  readonly osvFetcher?: OsvFetcher;
   /** Injected order-outcome history rows for the circuit breaker (tests /
    *  a caller that already read them). Default: the ONE ledger reader over
    *  the local checkout plus the standing branches. */
@@ -302,8 +306,25 @@ export async function gatherWorkOrderInputs(
   const byId = new Map(rich.map((e) => [e.id, e]));
   const allowlist = tryLoadAllowlist(cwd);
   const now = opts.now ?? new Date();
-  const { deferred, depScanSource } = await joinDeferrals(cwd, allowlist, byId, opts, disclosures);
+  const { deferred, depScanSource, scanned } = await joinDeferrals(
+    cwd,
+    allowlist,
+    byId,
+    opts,
+    disclosures,
+  );
   const debt = partitionByActiveAllowlist(rich, allowlist, now).live;
+  // The advisory-detail join (fix-versions.ts): thread the paid scan's
+  // fixed versions into baseline debt, and resolve the still-missing ones
+  // through the ONE OSV client; an advisory without a knowable fix
+  // honestly stays agent-tier, disclosed.
+  const advisoryDetails = await advisoryDetailMap({
+    deferred,
+    debt,
+    scanned,
+    ...(opts.osvFetcher ? { osvFetcher: opts.osvFetcher } : {}),
+    disclosures,
+  });
 
   // Manifest roots are consulted only by dependency-shaped orders; skip the
   // walk entirely when nothing will read them.
@@ -324,6 +345,7 @@ export async function gatherWorkOrderInputs(
       floorFailures: floor.failures,
       blocking: [],
       deferred,
+      advisoryDetails,
       debt,
       manifests,
       installFor: installResolver(cwd, packs),

--- a/src/remediate/work-orders/planner.ts
+++ b/src/remediate/work-orders/planner.ts
@@ -75,11 +75,30 @@ export type DeferredInput =
       readonly entry: RichBaselineEntry;
     };
 
+/**
+ * Per-finding advisory facts dxkit knows from OUTSIDE the finding's own
+ * source, keyed by finding id: the live scan's copy for a baseline entry,
+ * or an OSV-resolved fix version for a finding whose scanner never carried
+ * one. Filled into `AdvisoryInput`s at the ONE application point in
+ * `planWorkOrders`, missing fields only: a value the finding's own source
+ * stated always wins. This is what lets a deferral or a debt advisory tier
+ * `recipe` (the override-pin matches needs a concrete `fixedVersion`)
+ * wherever dxkit can actually know the fix.
+ */
+export interface AdvisoryDetail {
+  readonly fixedVersion?: string;
+  readonly reachable?: boolean;
+  readonly installedVersion?: string;
+  readonly pack?: string;
+}
+
 export interface PlannerInput {
   /** Failing entry-floor checks, attributed (empty when no floor source). */
   readonly floorFailures: readonly FloorFailureInput[];
   readonly blocking: readonly BlockingInput[];
   readonly deferred: readonly DeferredInput[];
+  /** Advisory facts joined from richer sources (see `AdvisoryDetail`). */
+  readonly advisoryDetails?: ReadonlyMap<string, AdvisoryDetail>;
   /** Grandfathered entries NOT under any active allowlist entry, every kind
    *  (the planner classifies and discloses; callers never pre-filter). */
   readonly debt: readonly RichBaselineEntry[];
@@ -116,6 +135,27 @@ function advisoryFromDebt(e: Extract<RichBaselineEntry, { kind: 'dep-vuln' }>): 
     ...(e.installedVersion !== undefined ? { installedVersion: e.installedVersion } : {}),
     advisoryId: e.advisoryId,
     ...(e.severity !== undefined ? { severity: e.severity } : {}),
+  };
+}
+
+/** Fill an advisory's MISSING fields from the detail join (never
+ *  overwrite: the finding's own source is the closer witness). */
+function withAdvisoryDetail(
+  a: AdvisoryInput,
+  details: ReadonlyMap<string, AdvisoryDetail> | undefined,
+): AdvisoryInput {
+  const d = details?.get(a.id);
+  if (!d) return a;
+  return {
+    ...a,
+    ...(a.fixedVersion === undefined && d.fixedVersion !== undefined
+      ? { fixedVersion: d.fixedVersion }
+      : {}),
+    ...(a.reachable === undefined && d.reachable !== undefined ? { reachable: d.reachable } : {}),
+    ...(a.installedVersion === undefined && d.installedVersion !== undefined
+      ? { installedVersion: d.installedVersion }
+      : {}),
+    ...(a.pack === undefined && d.pack !== undefined ? { pack: d.pack } : {}),
   };
 }
 
@@ -181,9 +221,18 @@ export function planWorkOrders(input: PlannerInput, opts: PlannerOptions = {}): 
     debtNoClass,
   );
 
+  // The ONE detail-application point: every advisory bucket passes through
+  // the same fill before the builder, so a deferral, a blocking pair, and a
+  // debt entry all see the identical join (Rule 2.30).
+  const detail = (a: AdvisoryInput) => withAdvisoryDetail(a, input.advisoryDetails);
   const ranked: Ranked[] = [
     ...floorOrders(input.floorFailures, ctx),
-    ...advisoryOrders(blockingAdvisories, deferredAdvisories, debtAdvisories, ctx),
+    ...advisoryOrders(
+      blockingAdvisories.map(detail),
+      deferredAdvisories.map((d) => ({ ...d, advisory: detail(d.advisory) })),
+      debtAdvisories.map(detail),
+      ctx,
+    ),
     ...lintOrders(lintSources, ctx, undispatchable),
   ].sort(compareRank);
 

--- a/src/remediate/work-orders/recipes-registry.ts
+++ b/src/remediate/work-orders/recipes-registry.ts
@@ -47,10 +47,10 @@ function floorPackOf(order: WorkOrder): string | null {
   return packs.size === 1 ? [...packs][0] : null;
 }
 
-/** Is this a slice of a larger per-file set? A file-scoped fixer cannot be
- *  verified one slice at a time. */
-function isSlicedOrder(order: WorkOrder): boolean {
-  return order.provenance.source === 'debt-slice' && order.provenance.of > 1;
+/** The file a located-lint order fixes (its grouping key). */
+function lintFileOf(order: WorkOrder): string | null {
+  const first = order.findings[0]?.evidence;
+  return first && first.type === 'custom-check' && first.file ? first.file : null;
 }
 
 export interface RecipeDeclaration {
@@ -70,6 +70,14 @@ export interface RecipeDeclaration {
    *  inside the remediate frame through the injected bounded exec under the
    *  required trust context; see `../recipes/types.ts` for the contract. */
   readonly execute?: (order: WorkOrder, ctx: RecipeExecuteContext) => Promise<RecipeOutcome>;
+  /** OPTIONAL: orders of this recipe with the same non-null key execute as
+   *  ONE attempt (the runner merges their findings, runs `execute` once,
+   *  and evaluates each order's done individually). Today: lint-autofix
+   *  keys by file, because `eslint --fix` on the whole file is one run
+   *  whatever slice asked for it (40 slices of one file must not pay 40
+   *  linter runs), and any slice's done criterion is checkable against
+   *  the one result. */
+  readonly groupKey?: (order: WorkOrder) => string | null;
 }
 
 /** The class a recipe id serves, from the one table. */
@@ -160,12 +168,13 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     summary: "the pack linter's own autofix, restricted to the order's file and rules",
     implemented: true,
     // Every finding must carry a rule (an unparsed diagnostic cannot be
-    // scoped to a fixer), the check must be a PACK lint gate whose pack
-    // declares a fix mode, and the order must not be a slice of a larger
-    // per-file set. Which rules the fixer actually closes stays the
-    // executor's runtime verify.
+    // scoped to a fixer) and the check must be a PACK lint gate whose pack
+    // declares a fix mode. Sliced orders ARE eligible: the grouped
+    // execution (groupKey) runs the file-level fix once for all of a
+    // file's slices and evaluates each slice's done individually. Which
+    // rules the fixer actually closes stays the executor's runtime verify.
     matches: (order) => {
-      if (order.findings.length === 0 || isSlicedOrder(order)) return false;
+      if (order.findings.length === 0) return false;
       const first = order.findings[0].evidence;
       const pack = first.type === 'custom-check' ? lintPackOf(first.check) : null;
       return (
@@ -177,6 +186,7 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
       );
     },
     execute: executeLintAutofix,
+    groupKey: lintFileOf,
   },
 ];
 

--- a/test/remediate/recipes/lint-autofix.test.ts
+++ b/test/remediate/recipes/lint-autofix.test.ts
@@ -94,17 +94,44 @@ describe('lint-autofix recipe', () => {
     expect(calls).toHaveLength(0);
   });
 
-  it('refuses a sliced order (a file-scoped fix cannot be verified per slice)', async () => {
+  it('a sliced order executes like any other (the runner groups a file into one fix attempt)', async () => {
     const cwd = eslintRepo();
-    const { exec } = fakeExec();
+    const { exec } = fakeExec(() => ({ code: 0, output: eslintJson(cwd, []) }));
     const outcome = await executeLintAutofix(
       lintOrder('lint:typescript', 'src/a.ts', {
         provenance: { source: 'debt-slice', file: 'src/a.ts', slice: 1, of: 3 },
       }),
       makeCtx(cwd, { exec }),
     );
-    expect(outcome.kind).toBe('refused');
-    if (outcome.kind === 'refused') expect(outcome.reason).toContain('sliced');
+    expect(outcome.kind).toBe('applied');
+  });
+
+  it('KNOWN leftover rules come back structurally (the grouped runner splits per slice); an unknown rule fails plain', async () => {
+    const cwd = eslintRepo();
+    // The order knows prefer-const (its own finding rule): a prefer-const
+    // leftover is structured.
+    const { exec: execA } = fakeExec(() => ({
+      code: 1,
+      output: eslintJson(cwd, [{ ruleId: 'prefer-const', message: 'x' }]),
+    }));
+    const known = await executeLintAutofix(
+      lintOrder('lint:typescript', 'src/a.ts'),
+      makeCtx(cwd, { exec: execA }),
+    );
+    expect(known.kind).toBe('failed');
+    if (known.kind === 'failed') expect(known.leftoverRules).toEqual(['prefer-const']);
+    // A rule the order never carried is net-new (or unparsed): plain
+    // failure, no structured leftovers, so the runner discards the diff.
+    const { exec: execB } = fakeExec(() => ({
+      code: 1,
+      output: eslintJson(cwd, [{ ruleId: 'no-debugger', message: 'x' }]),
+    }));
+    const unknown = await executeLintAutofix(
+      lintOrder('lint:typescript', 'src/a.ts'),
+      makeCtx(cwd, { exec: execB }),
+    );
+    expect(unknown.kind).toBe('failed');
+    if (unknown.kind === 'failed') expect(unknown.leftoverRules).toBeUndefined();
   });
 
   it('refuses a pack that declares no fix mode, with the pack named', async () => {

--- a/test/remediate/recipes/run-recipes.test.ts
+++ b/test/remediate/recipes/run-recipes.test.ts
@@ -16,16 +16,20 @@ import { REPO_WIDE_ENVELOPE } from '../../../src/remediate/work-orders/types';
 import {
   cachedOsvQuery,
   effectiveBlockSeverities,
+  groupRecipeOrders,
   recipeCounts,
   runRecipeOrders,
   runRecipePhaseForTask,
 } from '../../../src/remediate/recipes/run-recipes';
 import type { RecipeGit } from '../../../src/remediate/recipes/git';
-import type { RecipeDeclaration } from '../../../src/remediate/work-orders/recipes-registry';
+import {
+  RECIPE_REGISTRY,
+  type RecipeDeclaration,
+} from '../../../src/remediate/work-orders/recipes-registry';
 import type { CorrectnessFloorResult } from '../../../src/analyzers/correctness/run';
 import { resolveRemediateConfig } from '../../../src/remediate/config';
 import { trustedLocalContext, untrustedContentContext } from '../../../src/analysis-trust';
-import { fakeExec, makeOrder, tempRepo } from './helpers';
+import { fakeExec, lintFinding, makeOrder, tempRepo } from './helpers';
 
 describe('envelope containment', () => {
   it('speaks the planner language: explicit repo-wide marker, directory prefix, exact file', () => {
@@ -295,6 +299,179 @@ describe('runRecipeOrders', () => {
     if (records[0].outcome.kind === 'refused') {
       expect(records[0].outcome.reason).toContain('ghost-recipe');
     }
+  });
+});
+
+describe('grouped execution (a file of lint slices is ONE fix attempt)', () => {
+  const sliceOrder = (id: string, rule: string, slice: number) =>
+    makeOrder({
+      id,
+      class: 'lint-located',
+      recipe: 'grouped-fixer',
+      findings: [lintFinding(`f-${id}`, 'lint:typescript', 'src/big.ts', rule)],
+      envelope: { paths: ['src/big.ts'], manifests: false },
+      provenance: { source: 'debt-slice', file: 'src/big.ts', slice, of: 3 },
+    });
+  const slices = [
+    sliceOrder('lint-located:src/big.ts#1', 'prefer-const', 1),
+    sliceOrder('lint-located:src/big.ts#2', 'no-unused-vars', 2),
+    sliceOrder('lint-located:src/big.ts#3', 'quotes', 3),
+  ];
+  function groupedRecipe(execute: RecipeDeclaration['execute']): RecipeDeclaration {
+    return {
+      id: 'grouped-fixer',
+      class: 'lint-located',
+      summary: 't',
+      implemented: true,
+      matches: () => true,
+      execute,
+      groupKey: (order) => {
+        const first = order.findings[0]?.evidence;
+        return first && first.type === 'custom-check' && first.file ? first.file : null;
+      },
+    };
+  }
+
+  it('a 3-slice file fixes in ONE execution: all three applied, one commit naming them all', async () => {
+    const git = fakeGit();
+    let executions = 0;
+    const registry = [
+      groupedRecipe(async (order) => {
+        executions += 1;
+        // The merged attempt carries EVERY slice's findings.
+        expect(order.findings).toHaveLength(3);
+        git.dirty.push('src/big.ts');
+        return { kind: 'applied', changedFiles: ['src/big.ts'] };
+      }),
+    ];
+    const records = await runRecipeOrders(slices, {
+      cwd: '/x',
+      trust: trustedLocalContext(),
+      git,
+      exec: fakeExec().exec,
+      registry,
+    });
+    expect(executions).toBe(1);
+    expect(records.map((r) => r.outcome.kind)).toEqual(['applied', 'applied', 'applied']);
+    expect(git.commits).toHaveLength(1);
+    expect(git.commits[0].message).toContain('lint-located:src/big.ts#1');
+    expect(git.commits[0].message).toContain('#2');
+    expect(git.commits[0].message).toContain('#3');
+  });
+
+  it('KNOWN leftovers split per slice: fixed slices apply and COMMIT, the unfixed slice falls to the agent', async () => {
+    const git = fakeGit();
+    const registry = [
+      groupedRecipe(async () => {
+        git.dirty.push('src/big.ts');
+        return {
+          kind: 'failed',
+          step: 'verify-lint',
+          output: 'no-unused-vars remains',
+          leftoverRules: ['no-unused-vars'],
+        };
+      }),
+    ];
+    const records = await runRecipeOrders(slices, {
+      cwd: '/x',
+      trust: trustedLocalContext(),
+      git,
+      exec: fakeExec().exec,
+      registry,
+    });
+    const byId = new Map(records.map((r) => [r.orderId, r.outcome]));
+    expect(byId.get('lint-located:src/big.ts#1')?.kind).toBe('applied');
+    expect(byId.get('lint-located:src/big.ts#3')?.kind).toBe('applied');
+    const open = byId.get('lint-located:src/big.ts#2');
+    expect(open?.kind).toBe('failed');
+    if (open?.kind === 'failed') {
+      expect(open.step).toBe('verify-lint');
+      expect(open.output).toContain('no-unused-vars');
+    }
+    // The partial fix is real work: committed (naming only the closed
+    // slices), never discarded.
+    expect(git.commits).toHaveLength(1);
+    expect(git.commits[0].message).toContain('#1');
+    expect(git.commits[0].message).not.toContain('#2');
+    expect(git.discarded).toEqual([]);
+  });
+
+  it('a plain failure (no structured leftovers, the net-new guard) discards the diff for every slice', async () => {
+    const git = fakeGit();
+    const registry = [
+      groupedRecipe(async () => {
+        git.dirty.push('src/big.ts');
+        return { kind: 'failed', step: 'verify-lint', output: 'net-new rule appeared' };
+      }),
+    ];
+    const records = await runRecipeOrders(slices, {
+      cwd: '/x',
+      trust: trustedLocalContext(),
+      git,
+      exec: fakeExec().exec,
+      registry,
+    });
+    expect(records.every((r) => r.outcome.kind === 'failed')).toBe(true);
+    expect(git.commits).toHaveLength(0);
+    expect(git.discarded).toEqual([['src/big.ts']]);
+  });
+
+  it('end to end with the REAL lint-autofix: three slices, ONE eslint --fix run, all applied', async () => {
+    const cwd = tempRepo({
+      'package.json': '{"name":"fx"}',
+      'node_modules/.bin/eslint': '#!/bin/sh\n',
+      'src/big.ts': 'let x = 1;\nexport default x;\n',
+    });
+    const realSlices = slices.map((o) => ({
+      ...o,
+      recipe: 'lint-autofix',
+      findings: o.findings.map((f) => ({
+        ...f,
+        evidence: { ...f.evidence, file: 'src/big.ts' },
+      })),
+      envelope: { paths: ['src/big.ts'], manifests: false },
+    }));
+    const git = fakeGit();
+    let fixRuns = 0;
+    const { exec } = (() => {
+      const inner = fakeExec((cmd) => {
+        if (cmd.args.includes('--fix')) {
+          fixRuns += 1;
+          git.dirty.push('src/big.ts');
+        }
+        return {
+          code: 0,
+          output: JSON.stringify([{ filePath: `${cwd}/src/big.ts`, messages: [] }]),
+        };
+      });
+      return inner;
+    })();
+    const records = await runRecipeOrders(realSlices, {
+      cwd,
+      trust: trustedLocalContext(),
+      git,
+      exec,
+    });
+    expect(fixRuns).toBe(1);
+    expect(records.map((r) => r.outcome.kind)).toEqual(['applied', 'applied', 'applied']);
+    expect(git.commits).toHaveLength(1);
+  });
+
+  it('the REAL registry groups lint slices by file, and everything else stays singleton', () => {
+    const realSlices = slices.map((o) => ({ ...o, recipe: 'lint-autofix' }));
+    const other = makeOrder({
+      id: 'dep-advisory:js-yaml',
+      class: 'dep-advisory',
+      recipe: 'override-pin',
+    });
+    const groups = groupRecipeOrders(
+      [realSlices[0], other, realSlices[1], realSlices[2]],
+      [...RECIPE_REGISTRY],
+    );
+    expect(groups.map((g) => g.map((o) => o.id))).toEqual([
+      ['lint-located:src/big.ts#1', 'lint-located:src/big.ts#2', 'lint-located:src/big.ts#3'],
+      ['dep-advisory:js-yaml'],
+    ]);
   });
 });
 

--- a/test/remediate/work-orders/fix-versions.test.ts
+++ b/test/remediate/work-orders/fix-versions.test.ts
@@ -1,0 +1,223 @@
+/**
+ * The advisory fix-version join (4.4.5 estate fix): the rehearsal estate
+ * tiered EVERY dep-advisory order to the agent because nothing threaded a
+ * concrete fixed version into the planner's evidence. These pin the three
+ * shapes that must tier `recipe` now — a deferral joined from a live-scan
+ * finding that carries the fix, a deferral or debt advisory whose fix OSV
+ * can resolve, and the fill-missing-only discipline — plus the honest
+ * negative: no knowable fix stays agent-tier, disclosed.
+ */
+import { beforeEach, describe, it, expect } from 'vitest';
+import {
+  advisoryDetailMap,
+  OSV_FIX_RESOLUTION_CAP,
+} from '../../../src/remediate/work-orders/fix-versions';
+import {
+  planWorkOrders,
+  type DeferredInput,
+  type PlannerInput,
+} from '../../../src/remediate/work-orders/planner';
+import type { RichBaselineEntry } from '../../../src/baseline/types';
+import type { DepVulnFinding } from '../../../src/languages/capabilities/types';
+import { __clearOsvCache, type OsvFetcher, type OsvVuln } from '../../../src/analyzers/tools/osv';
+import { DEFAULT_REMEDIATE_BUDGET } from '../../../src/remediate/config';
+
+const NPM_CI = { bin: 'npm', args: ['ci'] };
+
+/** Single-root manifests: the owning root is unambiguous, so tier depends
+ *  only on the advisory evidence (the estate's layout). */
+function input(partial: Partial<PlannerInput>): PlannerInput {
+  return {
+    floorFailures: [],
+    blocking: [],
+    deferred: [],
+    debt: [],
+    manifests: [{ dir: '', files: ['package-lock.json', 'package.json'] }],
+    installFor: () => NPM_CI,
+    policy: { maxSliceSize: 25, budgetFor: () => DEFAULT_REMEDIATE_BUDGET },
+    ...partial,
+  };
+}
+
+function debtEntry(
+  id: string,
+  pkg: string,
+  advisoryId: string,
+  installedVersion?: string,
+): Extract<RichBaselineEntry, { kind: 'dep-vuln' }> {
+  return {
+    id,
+    kind: 'dep-vuln',
+    package: pkg,
+    ...(installedVersion !== undefined ? { installedVersion } : {}),
+    advisoryId,
+    severity: 'high',
+  } as Extract<RichBaselineEntry, { kind: 'dep-vuln' }>;
+}
+
+function deferredAdvisory(
+  id: string,
+  pkg: string,
+  advisoryId: string,
+  extra: Record<string, unknown> = {},
+): DeferredInput {
+  return {
+    fingerprint: id,
+    expiresAt: '2026-09-15',
+    kind: 'dep-vuln',
+    advisory: { id, package: pkg, advisoryId, installedVersion: '3.13.0', ...extra },
+  } as DeferredInput;
+}
+
+function scannedFinding(fingerprint: string, extra: Partial<DepVulnFinding> = {}): DepVulnFinding {
+  return {
+    id: 'GHSA-1',
+    package: 'js-yaml',
+    installedVersion: '3.13.0',
+    tool: 'osv-scanner',
+    severity: 'high',
+    fingerprint,
+    ...extra,
+  };
+}
+
+/** An OSV record whose ranges declare the given fixed events. */
+function osvRecord(fixed: string[]): OsvVuln {
+  return { affected: [{ ranges: [{ type: 'SEMVER', events: fixed.map((f) => ({ fixed: f })) }] }] };
+}
+
+function fetcherWith(records: Record<string, OsvVuln>): { fetcher: OsvFetcher; asked: string[] } {
+  const asked: string[] = [];
+  return {
+    asked,
+    fetcher: async (id) => {
+      asked.push(id);
+      return records[id] ?? null;
+    },
+  };
+}
+
+describe('advisoryDetailMap', () => {
+  // resolveFixVersions rides the OSV client's process-wide session cache;
+  // isolate the tests from each other's records.
+  beforeEach(() => __clearOsvCache());
+
+  it('threads the PAID scan into baseline debt (fix, reachability, pack) with no OSV call', async () => {
+    const disclosures: string[] = [];
+    const { fetcher, asked } = fetcherWith({});
+    const details = await advisoryDetailMap({
+      deferred: [],
+      debt: [debtEntry('d1', 'js-yaml', 'GHSA-1')],
+      scanned: new Map([
+        [
+          'd1',
+          scannedFinding('d1', { fixedVersion: '4.1.0', reachable: true, packId: 'typescript' }),
+        ],
+      ]),
+      osvFetcher: fetcher,
+      disclosures,
+    });
+    expect(details.get('d1')).toMatchObject({
+      fixedVersion: '4.1.0',
+      reachable: true,
+      pack: 'typescript',
+    });
+    expect(asked).toEqual([]);
+  });
+
+  it('resolves a missing fix via OSV, installed-version-correct (the minimal safe move)', async () => {
+    const disclosures: string[] = [];
+    const { fetcher } = fetcherWith({ 'GHSA-1': osvRecord(['3.14.1', '4.1.0']) });
+    const details = await advisoryDetailMap({
+      deferred: [deferredAdvisory('a1', 'js-yaml', 'GHSA-1')],
+      debt: [],
+      scanned: new Map(),
+      osvFetcher: fetcher,
+      disclosures,
+    });
+    // installed 3.13.0: the backport branch fix (3.14.1), never a surprise major.
+    expect(details.get('a1')).toEqual({ fixedVersion: '3.14.1' });
+    expect(disclosures.join(' ')).toContain('1 of 1 advisories resolved via OSV');
+  });
+
+  it('an unreachable OSV is fail-open and DISCLOSED: no fix, no crash, no guess', async () => {
+    const disclosures: string[] = [];
+    const details = await advisoryDetailMap({
+      deferred: [deferredAdvisory('a1', 'js-yaml', 'GHSA-1')],
+      debt: [debtEntry('d1', 'lodash', 'GHSA-2')],
+      scanned: new Map(),
+      osvFetcher: async () => null,
+      disclosures,
+    });
+    expect(details.get('a1')).toBeUndefined();
+    expect(details.get('d1')).toBeUndefined();
+    expect(disclosures.join(' ')).toContain('0 of 2 advisories resolved via OSV');
+  });
+
+  it('caps the OSV spend, deferrals first, and discloses the capped tail', async () => {
+    const disclosures: string[] = [];
+    const debt = Array.from({ length: OSV_FIX_RESOLUTION_CAP + 5 }, (_, i) =>
+      debtEntry(`d${i}`, `pkg${i}`, `GHSA-${i}`),
+    );
+    await advisoryDetailMap({
+      deferred: [],
+      debt,
+      scanned: new Map(),
+      osvFetcher: async () => null,
+      disclosures,
+    });
+    expect(disclosures.join(' ')).toContain(`capped at ${OSV_FIX_RESOLUTION_CAP}`);
+    expect(disclosures.join(' ')).toContain('5 more');
+  });
+});
+
+describe('the estate shape: dep-advisory orders tier recipe wherever the fix is knowable', () => {
+  it('a deferral joined from a live-scan finding WITH fixedVersion tiers recipe (no details needed)', () => {
+    const plan = planWorkOrders(
+      input({
+        deferred: [deferredAdvisory('a1', 'js-yaml', 'GHSA-1', { fixedVersion: '4.1.0' })],
+      }),
+    );
+    expect(plan.orders[0].tier).toBe('recipe');
+    expect(plan.orders[0].recipe).toBe('override-pin');
+  });
+
+  it('a deferral whose scan carried no fix tiers recipe once the detail join supplies one', () => {
+    const bare = planWorkOrders(input({ deferred: [deferredAdvisory('a1', 'js-yaml', 'GHSA-1')] }));
+    expect(bare.orders[0].tier).toBe('agent');
+    const joined = planWorkOrders(
+      input({
+        deferred: [deferredAdvisory('a1', 'js-yaml', 'GHSA-1')],
+        advisoryDetails: new Map([['a1', { fixedVersion: '4.1.0' }]]),
+      }),
+    );
+    expect(joined.orders[0].tier).toBe('recipe');
+    expect(joined.orders[0].recipe).toBe('override-pin');
+    const evidence = joined.orders[0].findings[0].evidence;
+    expect(evidence.type === 'dep-vuln' && evidence.fixedVersion).toBe('4.1.0');
+  });
+
+  it('a baseline DEBT advisory with an OSV-resolvable fix tiers recipe; no knowable fix stays agent', () => {
+    const debt = [debtEntry('d1', 'js-yaml', 'GHSA-1'), debtEntry('d2', 'left-pad', 'GHSA-2')];
+    const plan = planWorkOrders(
+      input({ debt, advisoryDetails: new Map([['d1', { fixedVersion: '4.1.0' }]]) }),
+    );
+    const jsYaml = plan.orders.find((o) => o.id === 'dep-advisory:js-yaml')!;
+    const leftPad = plan.orders.find((o) => o.id === 'dep-advisory:left-pad')!;
+    expect(jsYaml.tier).toBe('recipe');
+    expect(jsYaml.recipe).toBe('override-pin');
+    expect(leftPad.tier).toBe('agent');
+  });
+
+  it('the detail join fills MISSING fields only: the finding source always wins', () => {
+    const plan = planWorkOrders(
+      input({
+        deferred: [deferredAdvisory('a1', 'js-yaml', 'GHSA-1', { fixedVersion: '4.1.1' })],
+        advisoryDetails: new Map([['a1', { fixedVersion: '9.9.9', reachable: true }]]),
+      }),
+    );
+    const evidence = plan.orders[0].findings[0].evidence;
+    expect(evidence.type === 'dep-vuln' && evidence.fixedVersion).toBe('4.1.1');
+    expect(evidence.type === 'dep-vuln' && evidence.reachable).toBe(true);
+  });
+});

--- a/test/remediate/work-orders/plan-surface.test.ts
+++ b/test/remediate/work-orders/plan-surface.test.ts
@@ -333,6 +333,30 @@ describe('remediate plan --json: work orders', () => {
     expect(stale.plan.undispatchable[0].findings[0].id).toBe('dead000011112222');
   });
 
+  it('the estate shape end to end: a fix-less scan join is OSV-resolved and the deferral order tiers recipe', async () => {
+    writePolicy({ remediate: { enabled: true } });
+    writeBaseline([]);
+    writeAllowlist([DEFER_ENTRY]);
+    const fixless = { ...SCAN_FINDING };
+    delete (fixless as { fixedVersion?: string }).fixedVersion;
+    const { plan, disclosures } = await planRepoWorkOrders(repo, resolveRemediateConfig(repo), {
+      packs: TS,
+      now: NOW,
+      runFloor: () => NO_FLOOR,
+      scanDepVulns: async () => [fixless],
+      osvFetcher: async (id) =>
+        id === 'GHSA-1'
+          ? { affected: [{ ranges: [{ type: 'SEMVER', events: [{ fixed: '4.1.0' }] }] }] }
+          : null,
+    });
+    const order = plan.orders.find((o) => o.id === 'dep-advisory:js-yaml')!;
+    expect(order.tier).toBe('recipe');
+    expect(order.recipe).toBe('override-pin');
+    const evidence = order.findings[0].evidence;
+    expect(evidence.type === 'dep-vuln' && evidence.fixedVersion).toBe('4.1.0');
+    expect(disclosures.join(' ')).toContain('1 of 1 advisories resolved via OSV');
+  });
+
   it('the scan runs only when a dep-vuln deferral exists', async () => {
     writePolicy({ remediate: { enabled: true } });
     writeBaseline([]);

--- a/test/remediate/work-orders/planner.test.ts
+++ b/test/remediate/work-orders/planner.test.ts
@@ -383,11 +383,11 @@ describe('planWorkOrders: lint (one order per file, every source)', () => {
       slice: 1,
       of: 3,
     });
-    // A SLICED order cannot be file-scope autofixed and verified per slice,
-    // so it tiers to the agent by matches (4.4.5 review), not via a runtime
-    // refusal the plan surface would render as executable determinism.
-    expect(plan.orders[0].tier).toBe('agent');
-    expect(plan.orders[0].recipe).toBeUndefined();
+    // Sliced orders are recipe-eligible (4.4.5 estate fix): the runner
+    // groups a file's slices into ONE fix attempt and evaluates each
+    // slice's done individually, so big files keep deterministic economics.
+    expect(plan.orders[0].tier).toBe('recipe');
+    expect(plan.orders[0].recipe).toBe('lint-autofix');
   });
 
   it('binary custom-check debt and other kinds land in undispatchable with identity-only evidence', () => {

--- a/test/remediate/work-orders/recipes.test.ts
+++ b/test/remediate/work-orders/recipes.test.ts
@@ -200,7 +200,7 @@ describe('order-intrinsic feasibility lives in matches (an executor-certain refu
     );
   });
 
-  it('lint-autofix: a user check, a fixCommand-less pack, or a sliced order tiers agent', () => {
+  it('lint-autofix: a user check or a fixCommand-less pack tiers agent; a SLICED order stays recipe (grouped fix)', () => {
     const ok = {
       id: 'lint-located:src/a.ts',
       class: 'lint-located' as const,
@@ -210,12 +210,14 @@ describe('order-intrinsic feasibility lives in matches (an executor-certain refu
     expect(tierOf({ ...ok, findings: [lintFinding('lint:typescript')] })).toBe('recipe');
     expect(tierOf({ ...ok, findings: [lintFinding('arch-rules')] })).toBe('agent');
     expect(tierOf({ ...ok, findings: [lintFinding('lint:go')] })).toBe('agent');
+    // The estate fix: 700 sliced orders on big files must not all go to the
+    // agent at full budgets when one file-level --fix answers them.
     expect(
       tierOf({
         ...ok,
         findings: [lintFinding('lint:typescript')],
         provenance: { source: 'debt-slice', file: 'src/a.ts', slice: 1, of: 3 },
       }),
-    ).toBe('agent');
+    ).toBe('recipe');
   });
 });


### PR DESCRIPTION
## What

Two feasibility defects the tarball rehearsal of release/4.4.5 exposed on a real estate (large CRA-style npm repo, committed baseline, two dep-vuln deferrals with known pins, ~10k lint backlog), fixed at the root.

### 1. dep-advisory orders never tiered `recipe` (missing `fixedVersion`)

Root cause: the override-pin `matches` requires a concrete `fixedVersion` on every finding, but the planner's sources rarely carry one. A baseline debt entry stores identity only, and a raw dependency-scan finding gets its fix version from OSV enrichment that the plan path never paid for. Deferrals joined from the live scan looked enriched but were not, so every order tiered agent.

Fix: the planner gains an `advisoryDetails` join (fill missing fields only; the finding's own source always wins), applied at ONE point before the advisory builder so deferrals, blocking pairs, and debt see the identical enrichment. `gather` builds it in the new `work-orders/fix-versions.ts` from two sources: the dependency scan the deferral join already paid for (now also enriching baseline debt by fingerprint), and the ONE OSV client's existing `resolveFixVersions` (session-cached, alias-aware, installed-version-correct) for advisories still missing a fix, deferrals first, capped at 100 and disclosed. Fail-open: an unreachable OSV leaves the order honestly agent-tier with the count disclosed. `osvFetcher` is injectable through `GatherWorkOrderOptions`.

Direct-dep exclusion checked: the override-pin refusal reads the root manifest's dependency sections for the pinned package only; a transitive package is not listed there, so it does not fire (the existing applied test pins a transitive package against a manifest with other direct deps).

### 2. Sliced lint orders were feasibility-excluded from lint-autofix

Root cause: `matches` refused any slice of a larger per-file set, sending the biggest files (700+ orders on the estate) to the agent at full budgets.

Implemented shape (the per-slice variant): sliced orders match again; `RecipeDeclaration` gains an optional `groupKey` and lint-autofix keys by file. The phase runner groups orders sharing a recipe and key into ONE attempt: merged findings, one execute (one `eslint --fix`), one envelope enforcement, one commit naming every satisfied order (list capped). Per-slice done: when the lint verify hands back structured leftovers (`leftoverRules`, only when every remaining rule is among the merged order's own rules), each slice whose rules are all gone applies and the partial fix commits; unfixed slices record a named `verify-lint` failure and fall to the agent queue through the existing `agentOrders` derivation. A leftover rule outside the known set (net-new or unparsed) fails the attempt plain and the diff is discarded. Singleton groups behave exactly as before.

## Tests

- `test/remediate/work-orders/fix-versions.test.ts` (new): scan-into-debt threading with no OSV call; OSV resolution picks the installed-version-correct fix; unreachable OSV is fail-open and disclosed; the cap; the estate shapes at the planner (deferral with a live fix, deferral needing the join, debt with a resolvable fix, no-fix stays agent, fill-missing-only).
- `plan-surface.test.ts`: end to end through `planRepoWorkOrders`, a fix-less scan join is OSV-resolved and the deferral order tiers `recipe` with `override-pin`.
- `run-recipes.test.ts`: 3-slice file in one execution (all applied, one commit naming all three); known leftovers split per slice (fixed slices commit, the open slice falls to the agent); plain failure discards for every slice; real-registry grouping by file with other recipes singleton; end to end with the real lint-autofix paying exactly one `eslint --fix` for three slices.
- `lint-autofix.test.ts`: sliced orders execute; the structured-versus-plain leftover contract.
- Updated pins: sliced orders tier `recipe` again (planner + feasibility matrix).

## Sweep + guardrail (foreground)

typecheck + test typecheck clean, eslint 0 warnings, prettier clean, arch-check clean, docs coverage clean, slop clean, build clean; vitest by directory then full: **6134 passed / 411 files**, coverage 74.24% (gate 50%); `guardrail check --mode ref-based --ref origin/main`: **PASSED**.

## Deliberately left out

- No cap on how many recipe-tier orders one firing executes: with grouping, a 10k-backlog estate collapses to one fix run per file, but a very wide estate still pays one linter run per file per firing. That is an economics knob for the scheduler unit, not a correctness fix.
- No OSV network avoidance at plan time beyond the cap: the deferral join already pays a live dependency audit on the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
