### PR TITLE
ci: allow manual dispatch of the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Manual re-runs on an exact ref: the release preflight needs a green CI run
+  # on the tagged SHA, and outage-corrupted run records cannot be re-run.
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
One-line trigger addition so a fresh CI run can be dispatched on an exact ref. Needed now: the 4.4.5 release commit on main only has outage-corrupted run records (listed queued, API says completed and not re-runnable), and publish.yml requires a green CI run on the tagged SHA.

No behavior change to any job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)