### PR TITLE
fix(correctness): a tolerated lockfile-check failure is confirmed under the fallback, never assumed (4.4.6 tolerated-drift-check)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,18 @@ were discarded with a message that read as "the fallback is missing".
   never run. The CI shell chain keeps its unconditional retry, which is
   outcome-equivalent because every declared fallback only relaxes the one
   check its class names.
+- **A tolerated failure of the lockfile-sync check is confirmed, never
+  assumed.** On a tree whose pre-existing peer conflict is tolerated, the
+  bare `npm ci --dry-run` fails ERESOLVE before it ever validates the
+  lock, and the check used to pass on that match alone: real drift from
+  an agent's manifest edit read as "already consistent", the frame never
+  resynced it, and the orders died at the landing install. The check now
+  re-runs the dry-run under the authorized fallback's own flags and
+  judges on that result: pass means in sync (tolerance disclosed), drift
+  fails the check so the invariant resyncs, and only a further
+  tolerated-class failure with no retry left keeps the disclosed pass.
+  One definition for every consumer: the floor, the frame's invariant
+  step, and the lockfile-sync recipe's verify.
 - **Install attribution names its evidence.** The verification's base
   probe now records what the base did (installed, through which fallback,
   or failed with which classification). A failure with the identical

--- a/src/analyzers/correctness/lockfile-check.ts
+++ b/src/analyzers/correctness/lockfile-check.ts
@@ -132,11 +132,26 @@ export function runLockfileCheck(
 
 /**
  * Execute an already-derived lockfile-sync check at `cwd`: the ONE
- * execution of the check shape, shared by the floor (above) and the frame's
- * tree-invariant step (`lanes/tree-invariants.ts`), so "the lockfile is in
- * sync" is judged by one policy wherever it is asked. A skip and an
- * unavailable binary are fail-open, disclosed; a tolerated failure passes
- * with its disclosure as `note`; any other non-zero exit fails.
+ * execution of the check shape, shared by the floor (above), the frame's
+ * tree-invariant step (`lanes/tree-invariants.ts`) and the lockfile-sync
+ * recipe's verify, so "the lockfile is in sync" is judged by one policy
+ * wherever it is asked. A skip and an unavailable binary are fail-open,
+ * disclosed; any non-tolerated non-zero exit fails.
+ *
+ * A tolerated-class failure of the primary is NEVER a verdict by itself
+ * (4.4.6). The live class: on a tree whose pre-existing peer conflict is
+ * tolerated, `npm ci --dry-run` fails ERESOLVE before it ever validates
+ * the lock, so the pre-fix pass-on-match reported "in sync" over a lock an
+ * agent's manifest edit had drifted, the frame's invariant never resynced
+ * it, and the orders died at the landing install. The executor now walks
+ * the tolerated retries like the install executor walks its fallback
+ * ladder: it re-runs the dry-run UNDER the fallback's flags and judges on
+ * THAT result. Pass = in sync, with the tolerance disclosed; drift = a
+ * real FAIL (so the invariant resyncs); a further tolerated-class failure
+ * with no retry left, or a retry with no composable command, keeps the
+ * disclosed pass with CI's real install as the backstop; a retry that
+ * cannot run (infrastructure) is a disclosed pass too, never a false
+ * block.
  */
 export function executeLockfileCheck(
   id: LanguageId,
@@ -155,27 +170,55 @@ export function executeLockfileCheck(
   }
   const cmd = check.command;
   const base = { pack: id, label: cmd.label, bin: cmd.bin, args: cmd.args };
-  const outcome = exec(cmd, cwd);
-  if (!outcome.available) {
+  let attempt = exec(cmd, cwd);
+  // Infrastructure on the PRIMARY: the check could not run at all.
+  if (!attempt.available) {
     return {
       ...base,
       status: 'skipped-unavailable',
-      ...(outcome.output ? { output: outcome.output } : {}),
+      ...(attempt.output ? { output: attempt.output } : {}),
     };
   }
-  if (outcome.timedOut) return { ...base, status: 'skipped-timeout' };
-  if (outcome.overflowed) return { ...base, status: 'skipped-overflow' };
-  if (outcome.code === 0) return { ...base, status: 'pass' };
-  if (check.tolerated && check.tolerated.matches(outcome.output)) {
-    return { ...base, status: 'pass', note: check.tolerated.disclosure };
+  if (attempt.timedOut) return { ...base, status: 'skipped-timeout' };
+  if (attempt.overflowed) return { ...base, status: 'skipped-overflow' };
+
+  const retries = check.tolerated ?? [];
+  const remaining = [...retries];
+  const notes: string[] = [];
+  const pass = (): CorrectnessCheckResult =>
+    notes.length > 0
+      ? { ...base, status: 'pass', note: notes.join('; ') }
+      : { ...base, status: 'pass' };
+  for (;;) {
+    if (attempt.code === 0) return pass();
+    const idx = remaining.findIndex((r) => r.matches(attempt.output));
+    if (idx === -1) {
+      // A further tolerated-class failure with the ladder exhausted keeps
+      // the disclosed pass (the pre-fix semantics, now the LAST resort).
+      if (notes.length > 0 && retries.some((r) => r.matches(attempt.output))) return pass();
+      return {
+        ...base,
+        status: 'fail',
+        output:
+          tail(attempt.output) +
+          '\nThe lockfile does not satisfy the manifest: a frozen install (what CI runs before ' +
+          'any gate) fails on this tree. Re-run the package manager install so the lockfile ' +
+          'records the manifest, and commit both.',
+      };
+    }
+    const [retry] = remaining.splice(idx, 1);
+    notes.push(retry.disclosure);
+    // No composable dry-run under this fallback: the disclosed pass, with
+    // CI's real install (which runs the actual fallback) as the backstop.
+    if (retry.command === undefined) return pass();
+    attempt = exec(retry.command, cwd);
+    if (!attempt.available || attempt.timedOut || attempt.overflowed) {
+      // The confirming dry-run could not run: fail-open, disclosed, never
+      // a false block; CI's install remains the backstop.
+      notes.push(
+        "the confirming dry-run under the fallback could not run; CI's install is the backstop",
+      );
+      return pass();
+    }
   }
-  return {
-    ...base,
-    status: 'fail',
-    output:
-      tail(outcome.output) +
-      '\nThe lockfile does not satisfy the manifest: a frozen install (what CI runs before ' +
-      'any gate) fails on this tree. Re-run the package manager install so the lockfile ' +
-      'records the manifest, and commit both.',
-  };
 }

--- a/src/languages/capabilities/correctness.ts
+++ b/src/languages/capabilities/correctness.ts
@@ -191,22 +191,37 @@ export type StructureCheckResult =
 export const LOCKFILE_SYNC_LABEL = 'lockfile-sync';
 
 /**
+ * One tolerated retry of the lockfile-sync check: when the primary dry-run
+ * fails with the shape `matches` recognizes (npm's peer conflict, which
+ * CI's install retries under `--legacy-peer-deps`), the check re-runs
+ * UNDER THE FALLBACK (`command`: the dry-run composed with the fallback's
+ * own flags) and judges on ITS result. A tolerated-class failure is never
+ * a verdict by itself (4.4.6): the live class was a pre-existing peer
+ * conflict masking real lockfile drift, because the pre-fix check passed
+ * on the match alone and the drift only surfaced once `--legacy-peer-deps`
+ * silenced the peer check. `command` is absent only when the fallback has
+ * no composable dry-run form (no `viaFlags`); the check then keeps the
+ * disclosed pass, with CI's real install as the backstop.
+ */
+export interface ToleratedCheckRetry {
+  readonly matches: (output: string) => boolean;
+  readonly disclosure: string;
+  readonly command?: CorrectnessCommand;
+}
+
+/**
  * A pack's answer to "would a frozen-lockfile install of this tree succeed?"
  * (4.4.5): a non-installing dry-run command, or a DISCLOSED skip for an
  * ecosystem whose package manager has no reliable dry-run. The command may
- * name a `tolerated` failure: an exit the check passes WITH a disclosure
- * because the frozen install's own fallback covers it (npm's peer conflict,
- * which CI retries under `--legacy-peer-deps`). A tolerated failure is never
- * silent: the runner attaches the disclosure to the passing check.
+ * carry `tolerated` retries, one per authorized install fallback: the
+ * executor walks them like the install executor walks its fallback ladder,
+ * and a tolerance is always disclosed, never silent.
  */
 export type LockfileCheck =
   | {
       readonly kind: 'command';
       readonly command: CorrectnessCommand;
-      readonly tolerated?: {
-        readonly matches: (output: string) => boolean;
-        readonly disclosure: string;
-      };
+      readonly tolerated?: readonly ToleratedCheckRetry[];
     }
   | { readonly kind: 'skipped'; readonly reason: string };
 
@@ -233,12 +248,24 @@ export function lockfileCheckFromStrategy(
     command: { label: LOCKFILE_SYNC_LABEL, bin: check.command.bin, args: check.command.args },
     ...(fallbacks.length > 0
       ? {
-          tolerated: {
-            matches: (output: string) => fallbacks.some((f) => f.matches(output)),
-            disclosure: fallbacks
-              .map((f) => `${f.when} only: ${f.disclosure}; CI's install fallback covers it`)
-              .join('; '),
-          },
+          // One retry per authorized fallback, its command the dry-run
+          // composed under the fallback's own flags (the same viaFlags
+          // composition the install executor's `composePlan` reads), so
+          // the check confirms sync THROUGH the tolerance instead of
+          // passing on the failure shape alone.
+          tolerated: fallbacks.map((f) => ({
+            matches: f.matches,
+            disclosure: `${f.when} only: ${f.disclosure}; CI's install fallback covers it`,
+            ...(f.viaFlags !== undefined
+              ? {
+                  command: {
+                    label: LOCKFILE_SYNC_LABEL,
+                    bin: check.command.bin,
+                    args: [...check.command.args, ...f.viaFlags],
+                  },
+                }
+              : {}),
+          })),
         }
       : {}),
   };

--- a/test/correctness-lockfile-sync.test.ts
+++ b/test/correctness-lockfile-sync.test.ts
@@ -101,7 +101,99 @@ describe('lockfile-sync floor check (typescript pack, npm)', () => {
     }
   });
 
-  it('a peer-conflict-only failure PASSES with the --legacy-peer-deps disclosure', () => {
+  /** Split exec: the bare dry-run and the dry-run under --legacy-peer-deps
+   *  answer differently (the live 4.4.6 defect shape: a pre-existing peer
+   *  conflict fails the primary before it ever validates the lock). */
+  function floorSplit(
+    dir: string,
+    primary: { code: number; output: string },
+    fallback: { code: number; output: string; available?: boolean },
+  ) {
+    const calls: string[] = [];
+    const r = runCorrectnessFloor({
+      cwd: dir,
+      changedFiles: [],
+      scope: 'full',
+      packs: [TS],
+      exec: (cmd) => {
+        calls.push([cmd.bin, ...cmd.args].join(' '));
+        if (cmd.bin !== 'npm' || cmd.args[0] !== 'ci' || !cmd.args.includes('--dry-run')) {
+          return { available: true, code: 0, output: '' };
+        }
+        return cmd.args.includes('--legacy-peer-deps')
+          ? { available: fallback.available ?? true, code: fallback.code, output: fallback.output }
+          : { available: true, code: primary.code, output: primary.output };
+      },
+    });
+    return { r, calls };
+  }
+
+  it('the live 4.4.6 shape: a tolerated peer conflict never masks drift — the fallback dry-run runs and its EUSAGE FAILS the check', () => {
+    const dir = tsRepo(files);
+    try {
+      const { r, calls } = floorSplit(
+        dir,
+        { code: 1, output: ERESOLVE },
+        { code: 1, output: EUSAGE },
+      );
+      const lock = r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)!;
+      // The confirming dry-run under the fallback actually ran.
+      expect(calls.some((c) => c.includes('--legacy-peer-deps'))).toBe(true);
+      // Its EUSAGE is the verdict: the lock drifted; the check FAILS so the
+      // frame's invariant resyncs instead of reporting "already consistent".
+      expect(lock.status).toBe('fail');
+      expect(lock.output).toContain('Missing: left-pad');
+      expect(r.blocks).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a peer conflict over an IN-SYNC lock passes on the fallback dry-run result, with the tolerance disclosed', () => {
+    const dir = tsRepo(files);
+    try {
+      const { r, calls } = floorSplit(dir, { code: 1, output: ERESOLVE }, { code: 0, output: '' });
+      const lock = r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)!;
+      expect(calls.some((c) => c.includes('--legacy-peer-deps'))).toBe(true);
+      expect(lock.status).toBe('pass');
+      expect(lock.note).toContain('--legacy-peer-deps');
+      expect(r.blocks).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a fallback dry-run that cannot run keeps the disclosed pass, backstop named, never a false block', () => {
+    const dir = tsRepo(files);
+    try {
+      const { r } = floorSplit(
+        dir,
+        { code: 1, output: ERESOLVE },
+        { code: 127, output: '', available: false },
+      );
+      const lock = r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)!;
+      expect(lock.status).toBe('pass');
+      expect(lock.note).toContain('backstop');
+      expect(r.blocks).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a further tolerated-class failure with the ladder exhausted keeps the disclosed pass (peer conflict on both runs)', () => {
+    const dir = tsRepo(files);
+    try {
+      const { r } = floorSplit(dir, { code: 1, output: ERESOLVE }, { code: 1, output: ERESOLVE });
+      const lock = r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)!;
+      expect(lock.status).toBe('pass');
+      expect(lock.note).toContain('--legacy-peer-deps');
+      expect(r.blocks).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a peer-conflict-only failure on both dry-runs PASSES with the --legacy-peer-deps disclosure', () => {
     const dir = tsRepo(files);
     try {
       const r = floorOn(dir, 1, ERESOLVE);

--- a/test/languages/node-install.test.ts
+++ b/test/languages/node-install.test.ts
@@ -265,9 +265,21 @@ describe('the derived lockfile-sync check', () => {
       '--no-audit',
       '--no-fund',
     ]);
-    expect(c.tolerated?.matches('npm ERR! code ERESOLVE')).toBe(true);
-    expect(c.tolerated?.matches('npm ERR! code EUSAGE not in sync')).toBe(false);
-    expect(c.tolerated?.disclosure).toContain('peer-conflict');
+    expect(c.tolerated).toHaveLength(1);
+    expect(c.tolerated?.[0].matches('npm ERR! code ERESOLVE')).toBe(true);
+    expect(c.tolerated?.[0].matches('npm ERR! code EUSAGE not in sync')).toBe(false);
+    expect(c.tolerated?.[0].disclosure).toContain('peer-conflict');
+    // The retry carries the CONFIRMING dry-run under the fallback's flags
+    // (4.4.6): the check judges on its result, never on the match alone.
+    expect(c.tolerated?.[0].command?.bin).toBe('npm');
+    expect(c.tolerated?.[0].command?.args).toEqual([
+      'ci',
+      '--dry-run',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--legacy-peer-deps',
+    ]);
   });
   it('npm: with the peer-conflict tolerance withdrawn, the dry-run tolerates nothing', () => {
     const c = lockfileCheckFromStrategy(NODE_STRATEGY_BY_PM.npm, {

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -236,10 +236,12 @@ const mockPlaybookPack = {
     lockfileCheck: () => ({
       kind: 'command' as const,
       command: { label: 'lockfile-sync', bin: 'playbookc-mock', args: ['lock', '--dry-run'] },
-      tolerated: {
-        matches: (output: string) => output.includes('PLAYBOOK-PEER-ONLY'),
-        disclosure: 'playbook peer conflict tolerated',
-      },
+      tolerated: [
+        {
+          matches: (output: string) => output.includes('PLAYBOOK-PEER-ONLY'),
+          disclosure: 'playbook peer conflict tolerated',
+        },
+      ],
     }),
   },
   // Lint-GATE contribution (custom-check flagship). Distinctive bin/parse so the

--- a/test/remediate/e2e-rethink.test.ts
+++ b/test/remediate/e2e-rethink.test.ts
@@ -480,6 +480,38 @@ function liveExec(repo: string, resyncFails: boolean): ReturnType<typeof fakeExe
   });
 }
 
+/** The live 4.4.6 defect estate: a PRE-EXISTING peer conflict fails the
+ *  bare dry-run (ERESOLVE) before it ever validates the lock; only the
+ *  dry-run under --legacy-peer-deps can see drift (EUSAGE on a
+ *  hand-edited lock). The pre-fix check passed on the ERESOLVE match
+ *  alone and reported "already consistent" over the drift. */
+function peerConflictExec(repo: string): ReturnType<typeof fakeExec> {
+  return fakeExec((cmd, execCwd) => {
+    if (cmd.bin !== 'npm') return undefined;
+    const lock = path.join(execCwd ?? repo, 'package-lock.json');
+    const content = fs.existsSync(lock) ? fs.readFileSync(lock, 'utf8') : '';
+    if (cmd.args[0] === 'ci' && cmd.args.includes('--dry-run')) {
+      if (!cmd.args.includes('--legacy-peer-deps')) {
+        return {
+          code: 1,
+          output: 'npm error code ERESOLVE\nnpm error ERESOLVE could not resolve peer react@^18',
+        };
+      }
+      return content.includes('HAND-EDITED')
+        ? {
+            code: 1,
+            output: 'npm error code EUSAGE\nnpm error Missing: lodash@4.17.21 from lock file',
+          }
+        : undefined;
+    }
+    if (cmd.args[0] === 'install') {
+      fs.writeFileSync(lock, TOOL_TRUTH);
+      return undefined;
+    }
+    return undefined;
+  });
+}
+
 describe('e2e d: the live shape, nine pins then a hand-edited lockfile', () => {
   it("the frame replaces the hand edit with the resync: pin and agent order both land, the lockfile is the tool's truth", async () => {
     const repo = estate({ '.dxkit/allowlist.json': TWO_DEFERRED_ALLOWLIST });
@@ -523,6 +555,47 @@ describe('e2e d: the live shape, nine pins then a hand-edited lockfile', () => {
     >;
     expect(manifest.overrides).toEqual({ 'js-yaml': '4.1.0', lodash: '4.17.21' });
     expect(r.ledger).toContain('RE-ESTABLISHED');
+  });
+
+  it('the live 4.4.6 defect shape: a tolerated peer conflict never masks drift — the invariant verify FAILS through the fallback dry-run, the resync repairs the lock, the order lands', async () => {
+    const repo = estate({ '.dxkit/allowlist.json': TWO_DEFERRED_ALLOWLIST });
+    const { driver, runs } = handEditingDriver();
+    const exec = peerConflictExec(repo);
+    const r = await runOnEstate({
+      repo,
+      taskId: 'fix-vulns',
+      driver,
+      scan: [scanFinding('4.1.0'), LODASH],
+      exec,
+      frameExec: exec,
+    });
+
+    expect(runs).toHaveLength(1);
+    // The confirming dry-run under the fallback RAN (the pre-fix executor
+    // never spawned it, and reported "already consistent" over the drift).
+    const dryRuns = exec.calls
+      .map((c) => [c.cmd.bin, ...c.cmd.args].join(' '))
+      .filter((c) => c.includes('--dry-run'));
+    expect(dryRuns.some((c) => c.includes('--legacy-peer-deps'))).toBe(true);
+    // The invariant saw the drift, resynced, and re-verified through the
+    // tolerance: the order is KEPT and the landed lock is the tool's.
+    const rec = r.orders?.records[0];
+    expect(rec?.invariants?.map((o) => [o.id, o.status])).toEqual([
+      ['lockfile-sync', 'reestablished'],
+    ]);
+    expect(rec?.disposition?.kind).toBe('kept');
+    expect(r.outcome).toBe('verified');
+    expect(git(repo, ['show', 'HEAD:package-lock.json'])).toContain('resynced');
+    expect(git(repo, ['show', 'HEAD:package-lock.json'])).not.toContain('HAND-EDITED');
+    expect(git(repo, ['log', '--oneline'])).toContain('re-establish lockfile-sync');
+    const manifest = JSON.parse(git(repo, ['show', 'HEAD:package.json'])) as Record<
+      string,
+      Record<string, string>
+    >;
+    expect(manifest.overrides).toEqual({ 'js-yaml': '4.1.0', lodash: '4.17.21' });
+    // The tolerance is disclosed on the re-verification, never silent.
+    expect(r.ledger).toContain('RE-ESTABLISHED');
+    expect(r.ledger).toContain('--legacy-peer-deps');
   });
 
   it('the resync cannot re-establish the tree: the pin lands, the agent order is dropped at tree-invariants, partially-landed', async () => {


### PR DESCRIPTION
## What

Root fix for the live 4.4.6 validation defect: the lockfile-sync check reported "already consistent" on trees where an agent's manifest edit HAD drifted the lock. On a repo whose pre-existing peer conflict is tolerated, the bare `npm ci --dry-run` fails ERESOLVE before it ever validates the lock, and the check passed on that tolerated-class match alone, so the drift only CI's real install would see stayed invisible: the frame's invariant never resynced, and three agent orders that should have been repaired and landed dropped at the landing install (contained by per-order landing, but lost work).

**The rule now: a tolerated-class failure of the check's primary is never a verdict by itself.** The check's `tolerated` entries are a retry ladder, one per authorized install fallback, each carrying the CONFIRMING dry-run composed under the fallback's own flags (`npm ci --dry-run --legacy-peer-deps`, from the fallback's declared `viaFlags`, the same composition the install executor reads). The executor walks the ladder and judges on the retry's result:

- retry passes: in sync, the tolerance disclosed (never silent);
- retry shows drift (EUSAGE): a real FAIL, so the frame's invariant resyncs and the floor blocks honestly;
- a further tolerated-class failure with no retry left, a fallback with no composable dry-run form, or a retry that cannot run (infrastructure): the pre-fix disclosed pass, now the LAST resort, with CI's real install as the backstop (never a false block).

**One definition (Rule 2.30).** The retry shape is built in one place, `lockfileCheckFromStrategy` (`ToleratedCheckRetry` in `capabilities/correctness.ts`), and walked in one place, `executeLockfileCheck` (`analyzers/correctness/lockfile-check.ts`), so every consumer inherits it: the floor's lockfile check, the frame's tree-invariant verify (`lanes/tree-invariants.ts`), and the lockfile-sync recipe's verify (`runSingleLockfileCheck`).

## How it is tested

- `test/correctness-lockfile-sync.test.ts`, the exact live shape at the floor with a split exec (bare dry-run vs the dry-run under `--legacy-peer-deps`): peer-conflict primary + drifted lock under the fallback = FAIL with the remedy and `blocks: true`, and the confirming dry-run provably RAN; peer-conflict primary + in-sync lock = pass with the disclosure; an unrunnable retry = disclosed pass naming the backstop; peer conflict on both runs (ladder exhausted) = the disclosed pass.
- `test/languages/node-install.test.ts`: the derived retry carries the composed confirming command (`npm ci --dry-run --ignore-scripts --no-audit --no-fund --legacy-peer-deps`).
- `test/remediate/e2e-rethink.test.ts` scenario d, the invariant end to end on a real git estate: the agent pins the manifest and hand-edits the lock behind a pre-existing peer conflict; the invariant verify FAILS through the fallback dry-run (pre-fix it reported already-consistent, which is exactly what this test would catch regressing), the resync repairs the lock, the re-verify passes through the tolerance (disclosed in the ledger), and the order LANDS with the tool's lockfile, the hand edit gone.
- CHANGELOG line added under the 4.4.6 entry.

## Sweep

Foreground: typecheck, typecheck:test, eslint 0 warnings, prettier, check-architecture, docs-coverage, slop (advisory only), build, vitest split 3033 + 3293 = 6326 tests across 420 files, all passing; coverage gate met. Guardrail vs `origin/main` (ref-based): PASSED (88 pairs, 0 blocking). Diff grepped clean for the excluded names and for em-dashes in the CHANGELOG addition.

## Review focus

- `executeLockfileCheck`'s ladder termination: a retry is consumed once (`remaining.splice`), the exhausted-ladder pass requires a tolerated-shape output plus at least one consumed retry, and every other non-zero exit fails.
- `lockfileCheckFromStrategy`: the retry command exists only when the fallback declares `viaFlags`; the disclosure phrasing is unchanged, so existing ledger readers see the same note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
