### PR TITLE
feat(remediate): two-phase landing, credential freshness at push time (4.4.7 D1)

### DIFF
--- a/docs/commands/remediate.md
+++ b/docs/commands/remediate.md
@@ -239,12 +239,22 @@ token through one chain, best tier first:
    to the app's own bot identity, so a maintainer can approve them. A
    configured-but-broken app fails the mint step loudly rather than
    silently degrading a tier. One lifetime fact to know: GitHub caps an
-   installation token at **one hour**, so the remediate lane re-mints
-   immediately before the task step (the hour starts at agent launch,
-   not at job start) and clamps the agent's wall-clock budget to 45
-   minutes on this tier — disclosed in the run's envelope — so the
-   landing push always fits inside the token. Runs that need a longer
-   wall clock should use the PAT tier.
+   installation token at **one hour**, and the remediate task (agent
+   budget plus a verify tail that scales with repo size) can outlive
+   any token minted before it. The workflow therefore lands in TWO
+   PHASES: the task step performs no pushes and instead writes a
+   landing record, and a post-task step mints a fresh token and runs
+   `remediate land`, validating that the checkout's HEAD is still the
+   verified head the record expects (a mismatch refuses with the remedy
+   named; stale or foreign commits are never pushed) before pushing the
+   standing branch, opening/updating the PR, and recording the
+   order-outcome ledger. The step runs even after a failed task, so a
+   salvage draft still lands, and it is idempotent (a re-run with no
+   record is a disclosed no-op). Because the delivery credential is
+   minted at delivery time, the agent budget is no longer clamped to
+   the token lifetime (older installed workflows that still land inline
+   keep the 45-minute clamp until `vyuh-dxkit update` refreshes them;
+   the ledger names the remedy).
 2. **`DXKIT_BOT_TOKEN`** (a PAT with repo scope): works today,
    attributed to the PAT's owner (who then cannot approve the lane's
    PRs), and expires on the PAT's schedule.

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -164,8 +164,8 @@ __DXKIT_LANE_TOKEN_STEPS__
 
       # Working credential for the SETUP phase: dependency install may need
       # authenticated git (a private git-pinned dependency), and the
-      # checkout persisted nothing. Same body as the landing install below;
-      # the landing step REPLACES this value with the fresh task-time token.
+      # checkout persisted nothing. Same body as the task-credential install
+      # below; that step REPLACES this value with the fresh task-time token.
       - name: Install the working credential
         env:
           DXKIT_LANE_TOKEN: __DXKIT_LANE_TOKEN__
@@ -221,23 +221,23 @@ __DXKIT_CI_RUNTIME_SETUP__
 
       # An App installation token is hard-capped at ONE HOUR by GitHub, and
       # the first mint happened before checkout + toolchain install — so a
-      # long agent budget could outlive it and 401 the LANDING push after
-      # the full agent spend. Re-mint here so the token's lifetime starts
-      # at agent launch, not at job start; the CLI additionally clamps the
-      # agent budget on this tier so agent + verify + landing fit inside
-      # the fresh token (disclosed in the ledger, never silent).
+      # long task could outlive it mid-run. Re-mint here so the WORKING
+      # credential's lifetime starts at agent launch, not at job start.
+      # The LANDING does not depend on this token at all: it is deferred to
+      # the post-task step below, which mints its own fresh token, so even
+      # a verify tail longer than an hour cannot expire the delivery.
 __DXKIT_LANE_TOKEN_TASK_STEPS__
 
-      # The ONE landing credential, every tier. The checkout persisted
-      # nothing (persist-credentials: false above), so this step is the
-      # only credential writer: it installs the tier-chain token (the
-      # fresh task-time App mint when configured, else the PAT, else the
-      # default token), asserts exactly one Authorization source exists —
-      # a duplicate makes GitHub 400 the landing push with "Duplicate
-      # header", the class that killed a full agent run — and PROVES the
-      # credential with an ls-remote. A broken landing credential fails
-      # HERE, at $0, before any agent spawns; never at delivery.
-      - name: Install the landing credential
+      # The task-phase working credential, every tier. The checkout
+      # persisted nothing (persist-credentials: false above), so the
+      # credential-install steps are the only writers: each installs the
+      # tier-chain token (the fresh task-time App mint when configured,
+      # else the PAT, else the default token), asserts exactly one
+      # Authorization source exists (a duplicate makes GitHub 400 every
+      # push with "Duplicate header", the class that killed a full agent
+      # run) and PROVES the credential with an ls-remote. A broken
+      # credential fails HERE, at $0, before any agent spawns.
+      - name: Install the task credential
         env:
           DXKIT_LANE_TOKEN: __DXKIT_LANE_TOKEN_TASK__
         run: |
@@ -247,11 +247,11 @@ __DXKIT_LANE_TOKEN_TASK_STEPS__
           git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $AUTH"
           COUNT=$(git config --get-all http.https://github.com/.extraheader | wc -l)
           if [ "$COUNT" != "1" ]; then
-            echo "::error title=landing credential::expected exactly 1 auth header config, found $COUNT (a duplicate would 400 the landing push)"
+            echo "::error title=task credential::expected exactly 1 auth header config, found $COUNT (a duplicate would 400 every push)"
             exit 1
           fi
           git ls-remote --heads origin >/dev/null
-          echo "landing credential verified (single auth header, ls-remote OK)"
+          echo "task credential verified (single auth header, ls-remote OK)"
 
       # ONE task per job (this matrix row's own checkout): the CLI verifies
       # inside the frame, opens the task's standing PR, writes the ledger to
@@ -262,9 +262,15 @@ __DXKIT_LANE_TOKEN_TASK_STEPS__
         env:
           GH_TOKEN: __DXKIT_LANE_TOKEN_TASK__
           # The tier the run resolved (mirrors the Disclose step): 'app'
-          # tells the CLI the credential is a one-hour installation token,
-          # so it clamps the agent budget to fit landing inside it.
+          # tells the CLI the credential is a one-hour installation token.
           DXKIT_TOKEN_MODE: __DXKIT_LANE_TOKEN_MODE__
+          # Two-phase landing: the task step performs NO pushes, it writes
+          # a landing record, and the post-task step below lands it under a
+          # freshly minted credential, so the task's duration (agent budget
+          # plus a verify tail that scales with repo size) can never expire
+          # the delivery credential. This also lifts the App-tier agent
+          # budget clamp (the CLI discloses the mode in the ledger).
+          DXKIT_DEFERRED_LANDING: '1'
           # Dispatch-campaign inputs, transported via ENV only (the
           # comment-defer pattern — free text never touches a shell line).
           # Blank on scheduled runs; the CLI clamps budget overrides to the
@@ -317,6 +323,47 @@ __DXKIT_REMEDIATE_CREDENTIAL_ENV__
             fi
           fi
           exit "$EXIT"
+
+      # Phase two of two-phase landing: the delivery credential is minted
+      # HERE, fresh, so its one-hour cap starts at delivery time; the task
+      # above may have run for hours without touching it. Guarded with
+      # always() because a salvage/draft record from a FAILED task step must
+      # still land (the run stays red; the evidence still delivers).
+__DXKIT_LANE_TOKEN_LAND_STEPS__
+
+      # Land what the task step deferred: install the fresh landing
+      # credential (same single-writer discipline as the credential steps
+      # above), then `remediate land` validates the landing record (HEAD
+      # must still be the verified head, it never pushes stale or foreign
+      # commits) and performs every deferred push: the standing branch +
+      # PR, or the order-outcome ledger rows of a non-landing run. One
+      # step, guarded on the record's existence: with no record there is
+      # nothing to deliver and the skip is disclosed, and the guard also
+      # keeps this always() step quiet on a job that died before checkout.
+      - name: Land the deferred work (fresh credential)
+        if: always()
+        env:
+          GH_TOKEN: __DXKIT_LANE_TOKEN_LAND__
+          DXKIT_LANE_TOKEN: __DXKIT_LANE_TOKEN_LAND__
+        run: |
+          REC=".dxkit/cache/remediate-landing-${{ matrix.task }}.json"
+          if [ ! -f "$REC" ]; then
+            echo "no landing record for '${{ matrix.task }}': nothing to land (the task deferred nothing)"
+            exit 0
+          fi
+          AUTH=$(printf 'x-access-token:%s' "$DXKIT_LANE_TOKEN" | base64 -w0)
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --global --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $AUTH"
+          COUNT=$(git config --get-all http.https://github.com/.extraheader | wc -l)
+          if [ "$COUNT" != "1" ]; then
+            echo "::error title=landing credential::expected exactly 1 auth header config, found $COUNT (a duplicate would 400 the landing push)"
+            exit 1
+          fi
+          git ls-remote --heads origin >/dev/null
+          echo "landing credential verified (single auth header, ls-remote OK)"
+          if [ -x ./node_modules/.bin/vyuh-dxkit ]; then DXKIT=./node_modules/.bin/vyuh-dxkit; else DXKIT=vyuh-dxkit; fi
+          "$DXKIT" remediate land --task "${{ matrix.task }}"
 
       # A BLOCKED / failed attempt's diff must survive the ephemeral runner:
       # the runner writes a machine-readable attempt record; when nothing

--- a/src-templates/.github/workflows/dxkit-remediate.yml
+++ b/src-templates/.github/workflows/dxkit-remediate.yml
@@ -327,8 +327,9 @@ __DXKIT_REMEDIATE_CREDENTIAL_ENV__
       # Phase two of two-phase landing: the delivery credential is minted
       # HERE, fresh, so its one-hour cap starts at delivery time; the task
       # above may have run for hours without touching it. Guarded with
-      # always() because a salvage/draft record from a FAILED task step must
-      # still land (the run stays red; the evidence still delivers).
+      # !cancelled() because a salvage/draft record from a FAILED task step
+      # must still land (the run stays red; the evidence still delivers),
+      # while an operator ABORT must not keep minting and pushing.
 __DXKIT_LANE_TOKEN_LAND_STEPS__
 
       # Land what the task step deferred: install the fresh landing
@@ -339,9 +340,14 @@ __DXKIT_LANE_TOKEN_LAND_STEPS__
       # PR, or the order-outcome ledger rows of a non-landing run. One
       # step, guarded on the record's existence: with no record there is
       # nothing to deliver and the skip is disclosed, and the guard also
-      # keeps this always() step quiet on a job that died before checkout.
+      # keeps this post-failure step quiet on a job that died before
+      # checkout. Credential note: if the fresh mint FAILED, that mint step
+      # already reddened the job, but this step still runs and the token
+      # chain silently falls back to the earlier task/job mints or the PAT,
+      # which may be stale by then; a stale fallback fails the push with
+      # its own disclosed error rather than skipping the attempt.
       - name: Land the deferred work (fresh credential)
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: __DXKIT_LANE_TOKEN_LAND__
           DXKIT_LANE_TOKEN: __DXKIT_LANE_TOKEN_LAND__

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3176,8 +3176,27 @@ export async function run(argv: string[]): Promise<void> {
     }
 
     case 'remediate': {
-      const { runRemediate, runRemediatePlan, runRemediateConfigured, remediateUsage } =
-        await import('./remediate/cli');
+      const {
+        runRemediate,
+        runRemediatePlan,
+        runRemediateConfigured,
+        runRemediateLandCli,
+        remediateUsage,
+      } = await import('./remediate/cli');
+      if (positionals[1] === 'land') {
+        // Phase two of two-phase landing (lane plumbing, machine-invoked by
+        // the workflow's fresh-credential step after the task step): push
+        // what the deferred task run recorded. Executes nothing from the
+        // tree; it only replays validated recorded push/PR state.
+        const landTaskId = values.task as string | undefined;
+        if (!landTaskId) {
+          logger.fail(remediateUsage());
+          process.exitCode = 1;
+          break;
+        }
+        runRemediateLandCli(resolveRepoPath(positionals[2]), landTaskId);
+        break;
+      }
       if (positionals[1] === 'plan') {
         await runRemediatePlan(resolveRepoPath(positionals[2]), {
           json: !!values.json,

--- a/src/lanes/lane-token.ts
+++ b/src/lanes/lane-token.ts
@@ -120,13 +120,15 @@ export const LANE_TOKEN_TASK_STEPS = `      - name: Re-mint the lane token befor
  * verify phases scale with repo size and can outlive ANY token minted
  * before the task, so the landing step mints its own: the token's hour
  * starts at delivery time. Runs even after a failed task step (a salvage
- * draft record must still land), hence the always() guard alongside the
- * App-tier condition. Rendered from the same name constants; the template
+ * draft record must still land) but NOT on an operator abort, hence the
+ * !cancelled() guard alongside the App-tier condition (always() would
+ * also fire on a CANCELLED run and push after an abort). Rendered from
+ * the same name constants; the template
  * carries the __DXKIT_LANE_TOKEN_LAND_STEPS__ placeholder.
  */
 export const LANE_TOKEN_LAND_STEPS = `      - name: Mint the landing token (App tier, fresh for delivery)
         id: dxkit-app-token-land
-        if: \${{ always() && vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} != '' }}
+        if: \${{ !cancelled() && vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} != '' }}
         uses: actions/create-github-app-token@v2
         with:
           app-id: \${{ vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} }}

--- a/src/lanes/lane-token.ts
+++ b/src/lanes/lane-token.ts
@@ -57,8 +57,9 @@ export const LANE_TOKEN_CHAIN_TASK =
   `\${{ steps.dxkit-app-token-task.outputs.token || steps.dxkit-app-token.outputs.token || ` +
   `secrets.${LANE_TOKEN_PAT_SECRET_NAME} || github.token }}`;
 
-/** The resolved tier, as an env value the CLI can branch on ('app' clamps
- *  the agent wall clock to the installation token's lifetime). */
+/** The resolved tier, as an env value the CLI can branch on ('app' means a
+ *  one-hour installation token; under inline landing the CLI clamps the
+ *  agent wall clock to it, under deferred landing it only discloses). */
 export const LANE_TOKEN_MODE_EXPR =
   `\${{ vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} != '' && 'app' || ` +
   `(secrets.${LANE_TOKEN_PAT_SECRET_NAME} != '' && 'pat' || 'workflow') }}`;
@@ -115,6 +116,31 @@ export const LANE_TOKEN_TASK_STEPS = `      - name: Re-mint the lane token befor
           private-key: \${{ secrets.${LANE_TOKEN_APP_KEY_SECRET_NAME} }}`;
 
 /**
+ * The landing-time mint (two-phase landing, 4.4.7): the remediate task's
+ * verify phases scale with repo size and can outlive ANY token minted
+ * before the task, so the landing step mints its own: the token's hour
+ * starts at delivery time. Runs even after a failed task step (a salvage
+ * draft record must still land), hence the always() guard alongside the
+ * App-tier condition. Rendered from the same name constants; the template
+ * carries the __DXKIT_LANE_TOKEN_LAND_STEPS__ placeholder.
+ */
+export const LANE_TOKEN_LAND_STEPS = `      - name: Mint the landing token (App tier, fresh for delivery)
+        id: dxkit-app-token-land
+        if: \${{ always() && vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: \${{ vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME} }}
+          private-key: \${{ secrets.${LANE_TOKEN_APP_KEY_SECRET_NAME} }}`;
+
+/**
+ * The landing step's chain: the fresh delivery-time mint first, then the
+ * earlier mints, then the long-lived tiers.
+ */
+export const LANE_TOKEN_CHAIN_LAND =
+  `\${{ steps.dxkit-app-token-land.outputs.token || steps.dxkit-app-token-task.outputs.token || ` +
+  `steps.dxkit-app-token.outputs.token || secrets.${LANE_TOKEN_PAT_SECRET_NAME} || github.token }}`;
+
+/**
  * The substitution map the ONE workflow writer applies to EVERY template,
  * unconditionally — a callsite cannot forget it, and a template without
  * the placeholders is untouched (split/join no-op). Order matters only in
@@ -124,8 +150,10 @@ export const LANE_TOKEN_TASK_STEPS = `      - name: Re-mint the lane token befor
  */
 export const LANE_TOKEN_SUBSTITUTIONS: Readonly<Record<string, string>> = {
   __DXKIT_LANE_TOKEN_TASK_STEPS__: LANE_TOKEN_TASK_STEPS,
+  __DXKIT_LANE_TOKEN_LAND_STEPS__: LANE_TOKEN_LAND_STEPS,
   __DXKIT_LANE_TOKEN_STEPS__: LANE_TOKEN_STEPS,
   __DXKIT_LANE_TOKEN_TASK__: LANE_TOKEN_CHAIN_TASK,
+  __DXKIT_LANE_TOKEN_LAND__: LANE_TOKEN_CHAIN_LAND,
   __DXKIT_LANE_TOKEN_MODE__: LANE_TOKEN_MODE_EXPR,
   __DXKIT_LANE_TOKEN__: LANE_TOKEN_CHAIN,
 };

--- a/src/remediate/attempt-record.ts
+++ b/src/remediate/attempt-record.ts
@@ -100,6 +100,7 @@ export function taskRunJson(run: TaskRun): Record<string, unknown> {
     prUrl: run.prUrl ?? null,
     landRefused: run.landRefused ?? null,
     landingBlocked: run.landingBlocked ?? null,
+    landingDeferred: run.landingDeferred ?? null,
     landed: run.landed,
     // The commit range of the attempt — what the workflow's evidence step
     // format-patches into a run artifact when nothing landed.

--- a/src/remediate/budget-notes.ts
+++ b/src/remediate/budget-notes.ts
@@ -7,44 +7,69 @@
  */
 
 import { LANE_TOKEN_PAT_SECRET_NAME } from '../lanes/lane-token';
+import { deferredLandingRequested } from './landing-record';
 import type { AgentDriver, AgentRunResult } from './driver';
 import type { RemediateBudget } from './config';
 
 /**
- * The minutes ceiling on the GitHub App token tier. An App INSTALLATION
- * token is hard-capped at ONE HOUR by GitHub with no longer-lived form,
- * and the lane's landing push authenticates with it — so the agent run
+ * The minutes ceiling on the GitHub App token tier WHEN the landing still
+ * rides the task step's own credential. An App INSTALLATION token is
+ * hard-capped at ONE HOUR by GitHub with no longer-lived form, so on an
+ * older installed workflow (task-time mint, inline landing) the agent run
  * plus verify plus landing must fit inside the hour or the landing 401s
- * AFTER the full agent spend (the late-delivery death class the
- * delivery-preconditions preflight exists to kill, resurfacing at the
- * credential layer). The workflow re-mints immediately before the task
- * step, so the window starts at agent launch; 45 minutes leaves the
- * verify + landing tail inside it. The PAT and workflow-token tiers are
- * long-lived and never clamped.
+ * AFTER the full agent spend. Under two-phase landing (4.4.7) the clamp's
+ * reason is GONE: the landing step mints its own fresh token, so the agent
+ * budget is decoupled from the credential lifetime (see the resolver
+ * below). The PAT and workflow-token tiers are long-lived and never clamped.
  */
 export const APP_TOKEN_SAFE_MINUTES = 45;
 
 /**
- * Clamp the wall-clock budget to the credential's lifetime, disclosed
- * like every other budget limitation — never silent. The tier arrives
- * via `DXKIT_TOKEN_MODE` (set by the lane workflow's token resolution;
- * absent on local runs, which use the developer's own ambient auth and
- * are never clamped).
+ * Resolve the wall-clock budget against the credential's lifetime,
+ * disclosed like every other budget limitation, never silent. The tier
+ * arrives via `DXKIT_TOKEN_MODE` (set by the lane workflow's token
+ * resolution; absent on local runs, which use the developer's own ambient
+ * auth and are never touched). Honest derivation per landing mode:
+ *
+ *   - deferred landing signaled (the current workflow template): NO clamp.
+ *     The landing pushes under a token minted fresh by its own step, and
+ *     the verify tail was never boundable by an agent clamp anyway (it
+ *     scales with repo size). The tier is still DISCLOSED. In-run git
+ *     fetches (a resume, a private git-pinned install) keep their own
+ *     fail-open disclosures and do not justify capping the agent.
+ *   - no deferred signal on the app tier (an older installed workflow that
+ *     still lands inline with the task-time token): the clamp keeps its
+ *     original reason and stays.
  */
 export function clampBudgetToTokenLifetime(
   budget: RemediateBudget,
   env: Readonly<Record<string, string | undefined>>,
 ): { budget: RemediateBudget; notes: readonly string[] } {
-  if (env.DXKIT_TOKEN_MODE !== 'app' || budget.maxMinutes <= APP_TOKEN_SAFE_MINUTES) {
+  if (env.DXKIT_TOKEN_MODE !== 'app') {
+    return { budget, notes: [] };
+  }
+  if (deferredLandingRequested(env)) {
+    return {
+      budget,
+      notes: [
+        'GitHub App token tier: the landing is deferred to a post-task workflow step that ' +
+          'mints a fresh installation token, so the agent budget is not clamped to the ' +
+          "token's one-hour lifetime.",
+      ],
+    };
+  }
+  if (budget.maxMinutes <= APP_TOKEN_SAFE_MINUTES) {
     return { budget, notes: [] };
   }
   return {
     budget: { ...budget, maxMinutes: APP_TOKEN_SAFE_MINUTES },
     notes: [
-      `maxMinutes ${budget.maxMinutes} clamped to ${APP_TOKEN_SAFE_MINUTES}: this lane pushes ` +
-        `with a GitHub App installation token, which GitHub hard-caps at one hour, and the ` +
-        `landing must fit inside it — a longer run would spend its full agent budget and then ` +
-        `fail to deliver. For longer runs use the ${LANE_TOKEN_PAT_SECRET_NAME} PAT tier or lower the budget.`,
+      `maxMinutes ${budget.maxMinutes} clamped to ${APP_TOKEN_SAFE_MINUTES}: this workflow ` +
+        `lands with a GitHub App installation token minted before the task, which GitHub ` +
+        `hard-caps at one hour, and the landing must fit inside it: a longer run would spend ` +
+        `its full agent budget and then fail to deliver. Run \`vyuh-dxkit update\` to install ` +
+        `the two-phase landing workflow (which lifts this clamp), use the ` +
+        `${LANE_TOKEN_PAT_SECRET_NAME} PAT tier, or lower the budget.`,
     ],
   };
 }

--- a/src/remediate/cli.ts
+++ b/src/remediate/cli.ts
@@ -38,6 +38,15 @@ export {
   type ConfiguredLoopResult,
 } from './configured-loop';
 export { executeTask, taskRunJson, type ExecutorSeams, type TaskRun } from './execute';
+// Phase two of two-phase landing (`remediate land`) lives in `./land-cli`;
+// re-exported so consumers keep one import surface.
+export {
+  landExitClean,
+  runRemediateLand,
+  runRemediateLandCli,
+  type LandCliSeams,
+  type RemediateLandOutcome,
+} from './land-cli';
 import { headCommit, resetHardTo, runConfiguredLoop } from './configured-loop';
 import { executeTask, taskRunJson, type TaskRun } from './execute';
 
@@ -58,6 +67,7 @@ function reportTaskRun(run: TaskRun, json: boolean): void {
   if (run.result.note) logger.info(run.result.note);
   if (run.landRefused) logger.warn(run.landRefused);
   if (run.landingBlocked) logger.warn(run.landingBlocked);
+  if (run.landingDeferred) logger.info(run.landingDeferred);
   if (run.prUrl) logger.success(`standing PR: ${run.prUrl}`);
   console.log(''); // slop-ok
   process.stdout.write(run.result.ledger + '\n');
@@ -178,6 +188,7 @@ export async function runRemediateConfigured(
 export function remediateUsage(): string {
   return (
     `usage: vyuh-dxkit remediate --task <${REMEDIATE_TASKS.map((t) => t.id).join('|')}> ` +
-    `[--land pr] [--dispatch-override] [--json] | remediate configured [--land pr] | remediate plan`
+    `[--land pr] [--dispatch-override] [--json] | remediate configured [--land pr] | ` +
+    `remediate plan | remediate land --task <t>`
   );
 }

--- a/src/remediate/defer.ts
+++ b/src/remediate/defer.ts
@@ -1,0 +1,122 @@
+/**
+ * The executor's DEFERRAL layer for two-phase landing (4.4.7), split from
+ * `execute.ts` at the module-size bar (the plan-cli / attempt-record
+ * precedent). When the lane workflow signals deferred landing, the
+ * executor routes its two push moments here instead of pushing:
+ *
+ *   - `deferPublishRows`: a non-landing outcome's order-outcome rows ride
+ *     a 'publish-rows' landing record instead of the metadata-commit push;
+ *   - `deferLanding`: a land-eligible outcome's push + standing PR ride a
+ *     'land' record carrying the assembled PR title/body, the verified
+ *     head, and this run's rows.
+ *
+ * Both are consumed only by `executeTask`; the record is consumed by
+ * `remediate land` (`land-cli.ts`). Disclosed in output, never silent.
+ */
+import * as logger from '../logger';
+import { remediateBranchFor } from '../lanes/branches';
+import type { OrderOutcomeRow } from '../lanes/order-ledger';
+import { currentHead } from './attempt-record';
+import {
+  clearLandingRecord,
+  landingRecordPath,
+  writeLandingRecord,
+  LANDING_RECORD_SCHEMA,
+} from './landing-record';
+import type { RemediateResult } from './outcome';
+
+/**
+ * Defer a non-landing run's order-outcome rows: the circuit breaker's
+ * evidence must survive, but the metadata-commit push would ride a
+ * possibly-expired task credential, so the rows ride the record for the
+ * fresh-credential land step. No rows clears any stale record so the land
+ * step's existence guard stays truthful.
+ */
+export function deferPublishRows(
+  cwd: string,
+  taskId: string,
+  outcome: RemediateResult['outcome'],
+  orderRows: readonly OrderOutcomeRow[],
+): void {
+  if (orderRows.length === 0) {
+    clearLandingRecord(cwd, taskId);
+    return;
+  }
+  try {
+    writeLandingRecord(cwd, {
+      schema: LANDING_RECORD_SCHEMA,
+      task: taskId,
+      action: 'publish-rows',
+      branch: remediateBranchFor(taskId),
+      head: currentHead(cwd),
+      outcome,
+      orderRows,
+    });
+    logger.info(`order-outcome rows deferred to the landing step (${landingRecordPath(taskId)})`);
+  } catch (err) {
+    logger.warn(
+      `order ledger: the landing record could not be written ` +
+        `(${err instanceof Error ? err.message.split('\n')[0] : String(err)}), so the ` +
+        'circuit breaker will not see this run; the job summary remains the evidence',
+    );
+  }
+}
+
+/** What `deferLanding` hands back for the executor's TaskRun: either the
+ *  deferral disclosure, or the disclosed failure to defer. */
+export type DeferLandingOutcome =
+  | { readonly deferred: true; readonly landingDeferred: string }
+  | { readonly deferred: false; readonly landingBlocked: string };
+
+/**
+ * Defer a land-eligible run: everything up to and including verification
+ * and PR-body assembly already ran; the pushes now ride the landing
+ * record. The order-ledger COMPOSE (which reads the standing branch) also
+ * moves to land time, since a compose here could run against an
+ * already-expired credential and silently drop the branch's prior rows.
+ */
+export function deferLanding(
+  cwd: string,
+  args: {
+    readonly taskId: string;
+    readonly result: RemediateResult;
+    readonly defaultBranch: string;
+    readonly prTitle: string;
+    readonly prBody: string;
+    readonly draft: boolean;
+    readonly ledgerPath: string;
+    readonly orderRows: readonly OrderOutcomeRow[];
+  },
+): DeferLandingOutcome {
+  try {
+    writeLandingRecord(cwd, {
+      schema: LANDING_RECORD_SCHEMA,
+      task: args.taskId,
+      action: 'land',
+      branch: remediateBranchFor(args.taskId),
+      head: currentHead(cwd) ?? args.result.head ?? null,
+      outcome: args.result.outcome,
+      ...(args.result.baseHead ? { baseHead: args.result.baseHead } : {}),
+      defaultBranch: args.defaultBranch,
+      prTitle: args.prTitle,
+      prBody: args.prBody,
+      draft: args.draft,
+      ledgerPath: args.ledgerPath,
+      orderRows: args.orderRows,
+    });
+  } catch (err) {
+    return {
+      deferred: false,
+      landingBlocked:
+        'the landing record could not be written, so the deferred landing step has nothing ' +
+        `to push, and the verified work did NOT land ` +
+        `(${err instanceof Error ? err.message.split('\n')[0] : String(err)})`,
+    };
+  }
+  return {
+    deferred: true,
+    landingDeferred:
+      `landing deferred: the verified work is recorded at ${landingRecordPath(args.taskId)} ` +
+      "for the workflow's `remediate land` step, which pushes under a freshly minted credential.",
+  };
+}

--- a/src/remediate/execute.ts
+++ b/src/remediate/execute.ts
@@ -30,6 +30,8 @@ import { appendLaneEvent, LANE_LEDGER_SCHEMA_VERSION } from '../lanes/ledger';
 import { orderOutcomeRows, publishOrderRows, writeLocalOrderLedger } from './order-outcomes';
 import { remediateStamp } from './work-orders/breaker';
 import { currentHead, writeAttemptRecord, writeProvisionalRecord } from './attempt-record';
+import { deferredLandingRequested } from './landing-record';
+import { deferLanding, deferPublishRows } from './defer';
 
 // Attempt-record helpers live in `./attempt-record` (module-size split);
 // re-exported so consumers keep one import surface.
@@ -47,6 +49,10 @@ export interface TaskRun {
   readonly landingBlocked?: string;
   /** The landing ran (branch pushed, PR opened/updated). */
   readonly landed: boolean;
+  /** Two-phase landing (4.4.7): the pushes were DEFERRED to a landing
+   *  record for the workflow's fresh-credential `remediate land` step:
+   *  disclosed, never silent. */
+  readonly landingDeferred?: string;
   /** Truthful per-task success: verified/no-op, or a landed salvage draft. */
   readonly clean: boolean;
 }
@@ -58,7 +64,7 @@ export interface TaskRun {
  * workflow files is refused without the `workflows` permission), not only
  * where a push ruleset restricts paths.
  */
-function describeLandingFailure(err: unknown): string {
+export function describeLandingFailure(err: unknown): string {
   const e = err as { message?: string; stderr?: string | Buffer };
   const stderr = (e.stderr ?? '').toString().trim();
   const message = (e.message ?? String(err)).split('\n')[0];
@@ -103,6 +109,9 @@ export interface ExecutorSeams {
   /** Injected for tests: the order-outcome ledger writers (3F). */
   readonly writeOrderLedger?: typeof writeLocalOrderLedger;
   readonly publishOrderRows?: typeof publishOrderRows;
+  /** Injected for tests: the environment the deferred-landing signal is
+   *  read from (production reads process.env). */
+  readonly env?: Readonly<Record<string, string | undefined>>;
 }
 
 /** Executor extras beyond the positional contract (kept separate from the
@@ -253,10 +262,22 @@ export async function executeTask(
           stamp: remediateStamp(cwd),
         })
       : [];
+  // Two-phase landing (4.4.7): when the lane workflow signals deferred
+  // landing, this executor performs NO pushes: an App installation token
+  // is hard-capped at one hour and the verify phases scale with repo size,
+  // so every push moves to the workflow's post-task `remediate land` step,
+  // which runs under a FRESHLY minted token. Local/inline runs (no signal)
+  // keep the immediate landing below, through the same landRemediateHead.
+  const deferred = land === 'pr' && deferredLandingRequested(seams.env ?? process.env);
   // Non-landing durability: a frame-authored metadata commit on the
   // standing branch (the resume-marker channel) — without it, the circuit
-  // breaker is blind to exactly the failures it exists to remember.
+  // breaker is blind to exactly the failures it exists to remember. Under
+  // deferred landing the commit's PUSH rides the landing record instead.
   const publishRows = (): void => {
+    if (deferred) {
+      deferPublishRows(cwd, taskId, result.outcome, orderRows);
+      return;
+    }
     if (orderRows.length === 0) return;
     const pub = (seams.publishOrderRows ?? publishOrderRows)(cwd, taskId, orderRows);
     if (!pub.published && pub.note) logger.warn(`order ledger: ${pub.note}`);
@@ -322,6 +343,58 @@ export async function executeTask(
       : {}),
     ...(result.envelope ? { driver: result.envelope.driver } : {}),
   });
+  const prTitle =
+    `dxkit remediate: ${taskId}` +
+    (blockedSalvage
+      ? ' (blocked: guardrail-red — do not merge)'
+      : draftSalvage
+        ? ' (partial, budget-bounded)'
+        : partialLanding
+          ? ' (partial: some orders dropped, see the ledger)'
+          : '');
+  // The ONE lane PR-body assembler (#288): a generated, labeled
+  // diff-scoped narrative on top; the ledger VERBATIM below (the
+  // contractual record, never paraphrased). Fail-open to ledger-only.
+  // The narrative range is the ATTEMPT's own commits (baseHead..HEAD) —
+  // the lane advances the checked-out default branch, so a
+  // defaultBranch..HEAD range would be empty by construction.
+  const prBody = assembleLanePrBody({
+    cwd,
+    ledger: result.ledger,
+    base: result.baseHead ?? defaultBranch,
+  });
+  const draft = draftSalvage || blockedSalvage;
+
+  if (deferred) {
+    // Everything up to and including verification + PR-body assembly ran;
+    // the pushes now ride the landing record for the workflow's
+    // fresh-credential `remediate land` step (`./defer`).
+    const outcome = deferLanding(cwd, {
+      taskId,
+      result,
+      defaultBranch,
+      prTitle,
+      prBody,
+      draft,
+      ledgerPath,
+      orderRows,
+    });
+    if (!outcome.deferred) {
+      return finalizeTaskRun(cwd, taskId, {
+        result,
+        landed: false,
+        clean: false,
+        landingBlocked: outcome.landingBlocked,
+      });
+    }
+    return finalizeTaskRun(cwd, taskId, {
+      result,
+      landed: false,
+      clean: result.outcome === 'verified' || draftSalvage,
+      landingDeferred: outcome.landingDeferred,
+    });
+  }
+
   // The order-outcome rows ride the SAME landing commit (composed with any
   // unmerged standing-branch rows first, so a force-push never erases the
   // failure history a prior non-landing run recorded). Called even with no
@@ -341,27 +414,9 @@ export async function executeTask(
       cwd,
       taskId,
       defaultBranch,
-      prTitle:
-        `dxkit remediate: ${taskId}` +
-        (blockedSalvage
-          ? ' (blocked: guardrail-red — do not merge)'
-          : draftSalvage
-            ? ' (partial, budget-bounded)'
-            : partialLanding
-              ? ' (partial: some orders dropped, see the ledger)'
-              : ''),
-      // The ONE lane PR-body assembler (#288): a generated, labeled
-      // diff-scoped narrative on top; the ledger VERBATIM below (the
-      // contractual record, never paraphrased). Fail-open to ledger-only.
-      // The narrative range is the ATTEMPT's own commits (baseHead..HEAD) —
-      // the lane advances the checked-out default branch, so a
-      // defaultBranch..HEAD range would be empty by construction.
-      prBody: assembleLanePrBody({
-        cwd,
-        ledger: result.ledger,
-        base: result.baseHead ?? defaultBranch,
-      }),
-      draft: draftSalvage || blockedSalvage,
+      prTitle,
+      prBody,
+      draft,
       ledgerPath,
       ...(orderLedgerRel ? { orderLedgerPath: orderLedgerRel } : {}),
     });
@@ -400,6 +455,9 @@ function finalizeTaskRun(cwd: string, taskId: string, run: TaskRun): TaskRun {
   writeAttemptRecord(cwd, taskId, run);
   if (run.landingBlocked) {
     logger.warn(run.landingBlocked);
+  }
+  if (run.landingDeferred) {
+    logger.info(run.landingDeferred);
   }
   if (!run.clean) {
     // A non-clean outcome must be diagnosable from the run page: the agent

--- a/src/remediate/land-cli.ts
+++ b/src/remediate/land-cli.ts
@@ -27,6 +27,7 @@
  * (`readLandingRecord`); the standing-branch name is recomputed from the
  * task id, never trusted from disk.
  */
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as logger from '../logger';
@@ -47,6 +48,41 @@ export interface LandCliSeams {
   readonly publishRows?: typeof publishOrderRows;
   readonly writeOrderLedger?: typeof writeLocalOrderLedger;
   readonly head?: (cwd: string) => string | null;
+}
+
+const HEX_SHA_RE = /^[0-9a-f]{7,64}$/;
+
+/**
+ * Is `observed` exactly ONE commit atop `expected`, touching ONLY the
+ * lander's own bookkeeping paths (the delivery + order ledgers)? Pure git
+ * reads, biased toward false: any doubt (unreadable parent, a merge, an
+ * empty or out-of-scope diff) answers no, and the retry then refuses as
+ * stale, which is the honest outcome for a head this step cannot prove it
+ * authored itself.
+ */
+function isOwnBookkeepingCommit(
+  cwd: string,
+  observed: string,
+  expected: string,
+  allowedPaths: readonly string[],
+): boolean {
+  if (allowedPaths.length === 0) return false;
+  if (!HEX_SHA_RE.test(observed) || !HEX_SHA_RE.test(expected)) return false;
+  const read = (args: readonly string[]): string =>
+    execFileSync('git', [...args], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  try {
+    if (read(['rev-parse', `${observed}^`]) !== read(['rev-parse', expected])) return false;
+    const files = read(['diff-tree', '--no-commit-id', '--name-only', '-r', observed])
+      .split('\n')
+      .filter(Boolean);
+    return files.length > 0 && files.every((f) => allowedPaths.includes(f));
+  } catch {
+    return false;
+  }
 }
 
 export type RemediateLandOutcome =
@@ -110,11 +146,18 @@ export function runRemediateLand(
   if (record.action === 'publish-rows') {
     const pub = (seams.publishRows ?? publishOrderRows)(cwd, taskId, record.orderRows);
     if (!pub.published) {
+      // Honest phrasing for the common (ephemeral-runner) case: the rows
+      // are lost for this run and the next run's plan re-derives from the
+      // repo state; the job summary remains the evidence. The record is
+      // kept only because on a persistent checkout it makes a manual
+      // retry possible.
       return {
         outcome: 'rows-publish-failed',
         note:
-          `${pub.note ?? 'order-outcome rows could not be published'}. The record is kept at ` +
-          `${landingRecordPath(taskId)}; re-run \`remediate land --task ${taskId}\` to retry.`,
+          `${pub.note ?? 'order-outcome rows could not be published'}. The circuit breaker ` +
+          `will not see this run: the rows are lost with this runner (the job summary remains ` +
+          `the evidence, and the next run's plan re-derives from the repo state). The record ` +
+          `is kept at ${landingRecordPath(taskId)} in case this checkout persists for a retry.`,
       };
     }
     clearLandingRecord(cwd, taskId);
@@ -162,31 +205,53 @@ export function runRemediateLand(
     clearLandingRecord(cwd, taskId);
     return { outcome: 'landed', ...(landResult.prUrl ? { prUrl: landResult.prUrl } : {}) };
   } catch (err) {
+    const failure = describeLandingFailure(err);
+    // Inline parity (the executor's landHead catch calls publishRows): a
+    // refused landing must not blind the circuit breaker, so this run's
+    // recorded rows still try the metadata-commit channel. Disclosed
+    // either way; the A1 failure classes are exactly the runs whose rows
+    // the breaker most needs.
+    let rowsDisclosure = '';
+    if (record.orderRows.length > 0) {
+      const pub = (seams.publishRows ?? publishOrderRows)(cwd, taskId, record.orderRows);
+      rowsDisclosure = pub.published
+        ? '\nThe order-outcome rows were still recorded on the standing branch (the metadata ' +
+          'channel), so the circuit breaker sees this run.'
+        : `\nThe order-outcome rows also could not be recorded` +
+          `${pub.note ? ` (${pub.note})` : ''}; the job summary remains the evidence.`;
+    }
     // The lander commits its bookkeeping (delivery + order ledgers) BEFORE
     // the push, so a push failure can leave HEAD one dxkit-authored commit
-    // past the recorded head. Advance the record to the head we observed
-    // ourselves (disclosed), so a retry is not falsely refused as stale.
+    // past the recorded head. Advance the record ONLY when git proves the
+    // delta is that bookkeeping commit: exactly one commit atop the
+    // recorded head, touching nothing beyond the ledger paths this step
+    // itself handed the lander. Anything else leaves the record unchanged,
+    // so the retry refuses as stale instead of blessing a foreign commit.
     const observed = (seams.head ?? currentHead)(cwd);
-    const failure = describeLandingFailure(err);
-    if (observed !== null && observed !== record.head) {
-      const advanced: LandingRecord = {
-        ...record,
-        head: observed,
-        headAdvancedNote:
-          'a prior land attempt created its bookkeeping commit before the push failed; the ' +
-          'expected head was advanced to the observed post-commit head for retry',
-      };
-      try {
-        writeLandingRecord(cwd, advanced);
-      } catch {
-        // retry convenience only; the failure below is the real disclosure
+    if (observed !== null && observed !== record.head && record.head !== null) {
+      const allowedPaths = [record.ledgerPath, orderLedgerRel].filter(
+        (p): p is string => typeof p === 'string' && p.length > 0,
+      );
+      if (isOwnBookkeepingCommit(cwd, observed, record.head, allowedPaths)) {
+        const advanced: LandingRecord = {
+          ...record,
+          head: observed,
+          headAdvancedNote:
+            'a prior land attempt created its bookkeeping commit before the push failed; the ' +
+            'expected head was advanced to the verified post-commit head for retry',
+        };
+        try {
+          writeLandingRecord(cwd, advanced);
+        } catch {
+          // retry convenience only; the failure below is the real disclosure
+        }
       }
     }
     patchAttemptRecord(cwd, taskId, { landingBlocked: failure });
     return {
       outcome: 'landing-failed',
       error:
-        `${failure}\nThe landing record is kept at ${landingRecordPath(taskId)}; ` +
+        `${failure}${rowsDisclosure}\nThe landing record is kept at ${landingRecordPath(taskId)}; ` +
         `re-run \`remediate land --task ${taskId}\` to retry once the cause is fixed.`,
     };
   }

--- a/src/remediate/land-cli.ts
+++ b/src/remediate/land-cli.ts
@@ -1,0 +1,220 @@
+/**
+ * `vyuh-dxkit remediate land --task <t>`: phase two of two-phase landing.
+ *
+ * Runs as a dedicated workflow step AFTER the task step, under a FRESHLY
+ * minted App token (the task's verify phases can outlive the one-hour
+ * installation-token cap; this step's credential starts its hour at
+ * delivery time). It reads the task's landing record (`landing-record.ts`),
+ * validates it, then performs every push the task step deferred:
+ *
+ *   - action 'land': verify the checkout's HEAD still IS the verified head
+ *     the record expects (a mismatch refuses with the remedy named; this
+ *     step never pushes stale or foreign commits), write the composed
+ *     order-outcome ledger (the standing-branch read happens HERE, where
+ *     the credential is fresh), then push + open/update the standing PR
+ *     through the SAME `landRemediateHead` the inline path uses (Rule 2);
+ *   - action 'publish-rows': push only the order-outcome metadata commit
+ *     (`publishOrderRows`), the circuit breaker's memory of a non-landing
+ *     run.
+ *
+ * Idempotent: a successful landing clears the record, so a re-run is a
+ * disclosed no-op. A failed push KEEPS the record (retryable) and exits
+ * non-zero with the disclosed cause.
+ *
+ * SECURITY: this command executes NOTHING from the tree: no agent, no
+ * repo scripts, no policy commands. It only replays recorded push/PR state
+ * through git/gh, and every value read from the record is validated first
+ * (`readLandingRecord`); the standing-branch name is recomputed from the
+ * task id, never trusted from disk.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as logger from '../logger';
+import { landRemediateHead } from './land';
+import { publishOrderRows, writeLocalOrderLedger } from './order-outcomes';
+import { currentHead } from './attempt-record';
+import { describeLandingFailure } from './execute';
+import {
+  clearLandingRecord,
+  landingRecordPath,
+  readLandingRecord,
+  writeLandingRecord,
+  type LandingRecord,
+} from './landing-record';
+
+export interface LandCliSeams {
+  readonly landHead?: typeof landRemediateHead;
+  readonly publishRows?: typeof publishOrderRows;
+  readonly writeOrderLedger?: typeof writeLocalOrderLedger;
+  readonly head?: (cwd: string) => string | null;
+}
+
+export type RemediateLandOutcome =
+  /** No record: nothing was deferred (already landed, or the task had
+   *  nothing to deliver). A disclosed no-op, exit 0. */
+  | { readonly outcome: 'no-record'; readonly note: string }
+  /** The record failed validation: refused, record kept for inspection. */
+  | { readonly outcome: 'invalid-record'; readonly error: string }
+  /** HEAD no longer matches the verified head: refused, never pushed. */
+  | { readonly outcome: 'stale-head'; readonly error: string }
+  | { readonly outcome: 'landed'; readonly prUrl?: string }
+  | { readonly outcome: 'rows-published' }
+  /** Bookkeeping publish failed: disclosed warning, record kept for a
+   *  manual retry; never fails the lane (parity with the inline path). */
+  | { readonly outcome: 'rows-publish-failed'; readonly note: string }
+  /** The push/PR failed: disclosed cause + remedy, record kept (retry). */
+  | { readonly outcome: 'landing-failed'; readonly error: string };
+
+/** Exit-code truth for the CLI wrapper: refusals and push failures are
+ *  non-zero; no-ops and bookkeeping warnings are zero. */
+export function landExitClean(result: RemediateLandOutcome): boolean {
+  return (
+    result.outcome === 'no-record' ||
+    result.outcome === 'landed' ||
+    result.outcome === 'rows-published' ||
+    result.outcome === 'rows-publish-failed'
+  );
+}
+
+/** Best-effort patch of the task's attempt record after the deferred
+ *  landing resolves, so the workflow's evidence step (which uploads the
+ *  attempt diff only when nothing landed) sees the truth. */
+function patchAttemptRecord(cwd: string, taskId: string, patch: Record<string, unknown>): void {
+  try {
+    const abs = path.join(cwd, '.dxkit', 'cache', `remediate-${taskId}.json`);
+    const parsed = JSON.parse(fs.readFileSync(abs, 'utf8')) as Record<string, unknown>;
+    fs.writeFileSync(abs, JSON.stringify({ ...parsed, ...patch }, null, 2) + '\n', 'utf8');
+  } catch {
+    // evidence plumbing, never a failure
+  }
+}
+
+export function runRemediateLand(
+  cwd: string,
+  taskId: string,
+  seams: LandCliSeams = {},
+): RemediateLandOutcome {
+  const read = readLandingRecord(cwd, taskId);
+  if (read === null) {
+    return {
+      outcome: 'no-record',
+      note:
+        `no landing record for '${taskId}' (${landingRecordPath(taskId)}), nothing to land: ` +
+        'the task step either landed inline, already landed on a previous run of this ' +
+        'command, or produced nothing to deliver.',
+    };
+  }
+  if ('error' in read) return { outcome: 'invalid-record', error: read.error };
+  const record = read.record;
+
+  if (record.action === 'publish-rows') {
+    const pub = (seams.publishRows ?? publishOrderRows)(cwd, taskId, record.orderRows);
+    if (!pub.published) {
+      return {
+        outcome: 'rows-publish-failed',
+        note:
+          `${pub.note ?? 'order-outcome rows could not be published'}. The record is kept at ` +
+          `${landingRecordPath(taskId)}; re-run \`remediate land --task ${taskId}\` to retry.`,
+      };
+    }
+    clearLandingRecord(cwd, taskId);
+    return { outcome: 'rows-published' };
+  }
+
+  // action 'land': the head gate. The record's head was validated as hex;
+  // the checkout must still be exactly the verified commit; anything else
+  // (a stray commit, a different checkout, a tampered record) is refused.
+  const head = (seams.head ?? currentHead)(cwd);
+  if (head === null || head !== record.head) {
+    return {
+      outcome: 'stale-head',
+      error:
+        `refusing to land '${taskId}': the checkout's HEAD (${head ?? 'unreadable'}) is not the ` +
+        `verified head this record expects (${record.head ?? 'none recorded'}). The tree moved ` +
+        'after verification, so pushing it would deliver unverified commits. Remedy: re-run the ' +
+        'task (a fresh run re-verifies and writes a fresh record); do not push by hand.',
+    };
+  }
+
+  // The order-ledger compose (standing-branch read) happens HERE, under
+  // the fresh credential; the task step only recorded this run's rows.
+  const orderLedgerRel = (seams.writeOrderLedger ?? writeLocalOrderLedger)(
+    cwd,
+    taskId,
+    record.orderRows,
+  );
+
+  try {
+    const landResult = (seams.landHead ?? landRemediateHead)({
+      cwd,
+      taskId,
+      defaultBranch: record.defaultBranch ?? '',
+      prTitle: record.prTitle ?? '',
+      prBody: record.prBody ?? '',
+      ...(record.draft !== undefined ? { draft: record.draft } : {}),
+      ...(record.ledgerPath ? { ledgerPath: record.ledgerPath } : {}),
+      ...(orderLedgerRel ? { orderLedgerPath: orderLedgerRel } : {}),
+    });
+    patchAttemptRecord(cwd, taskId, {
+      landed: true,
+      ...(landResult.prUrl ? { prUrl: landResult.prUrl } : {}),
+    });
+    clearLandingRecord(cwd, taskId);
+    return { outcome: 'landed', ...(landResult.prUrl ? { prUrl: landResult.prUrl } : {}) };
+  } catch (err) {
+    // The lander commits its bookkeeping (delivery + order ledgers) BEFORE
+    // the push, so a push failure can leave HEAD one dxkit-authored commit
+    // past the recorded head. Advance the record to the head we observed
+    // ourselves (disclosed), so a retry is not falsely refused as stale.
+    const observed = (seams.head ?? currentHead)(cwd);
+    const failure = describeLandingFailure(err);
+    if (observed !== null && observed !== record.head) {
+      const advanced: LandingRecord = {
+        ...record,
+        head: observed,
+        headAdvancedNote:
+          'a prior land attempt created its bookkeeping commit before the push failed; the ' +
+          'expected head was advanced to the observed post-commit head for retry',
+      };
+      try {
+        writeLandingRecord(cwd, advanced);
+      } catch {
+        // retry convenience only; the failure below is the real disclosure
+      }
+    }
+    patchAttemptRecord(cwd, taskId, { landingBlocked: failure });
+    return {
+      outcome: 'landing-failed',
+      error:
+        `${failure}\nThe landing record is kept at ${landingRecordPath(taskId)}; ` +
+        `re-run \`remediate land --task ${taskId}\` to retry once the cause is fixed.`,
+    };
+  }
+}
+
+/** The CLI wrapper: report + truthful exit code. */
+export function runRemediateLandCli(cwd: string, taskId: string): void {
+  logger.header(`dxkit remediate land: ${taskId}`);
+  const result = runRemediateLand(cwd, taskId);
+  switch (result.outcome) {
+    case 'no-record':
+      logger.info(result.note);
+      break;
+    case 'landed':
+      if (result.prUrl) logger.success(`standing PR: ${result.prUrl}`);
+      else logger.success('landed: branch pushed, standing PR updated');
+      break;
+    case 'rows-published':
+      logger.info('order-outcome rows published to the standing branch');
+      break;
+    case 'rows-publish-failed':
+      logger.warn(result.note);
+      break;
+    case 'invalid-record':
+    case 'stale-head':
+    case 'landing-failed':
+      logger.fail(result.error);
+      break;
+  }
+  if (!landExitClean(result)) process.exitCode = 1;
+}

--- a/src/remediate/landing-record.ts
+++ b/src/remediate/landing-record.ts
@@ -1,0 +1,206 @@
+/**
+ * The LANDING RECORD: two-phase landing for the remediate lane (4.4.7).
+ *
+ * The defect this closes: GitHub App installation tokens are hard-capped
+ * at one hour, and the remediate task step's verify phases scale with repo
+ * size (repeated frozen installs + the guardrail on a large tree), so the
+ * landing push could fire long after mint: 401, git prompt fallback, every
+ * push lost (landing, salvage draft, order-outcome ledger: the circuit
+ * breaker went blind). The old mitigation clamped the AGENT wall clock,
+ * which bounds the wrong thing: the verify tail is not under it.
+ *
+ * Root fix: credential freshness is made independent of task duration.
+ * When the lane workflow signals deferred landing (the env var below, set
+ * on the task step by the workflow template), the task step performs
+ * everything up to and including verification + PR-body assembly, then
+ * writes ONE record here instead of pushing. A separate workflow step
+ * AFTER the task re-mints the App token fresh and runs `remediate land`
+ * (`land-cli.ts`), which validates the record and performs every push.
+ * Local/inline runs (no env) keep the immediate landing through the same
+ * `landRemediateHead`, one landing primitive at two moments (Rule 2).
+ *
+ * The record is repo-local MUTABLE state under `.dxkit/cache/` (gitignored
+ * runtime artifact, never committed). Everything read back from it is
+ * VALIDATED before any git/gh spawn: shas must be hex, the branch must be
+ * the task's own standing branch (recomputed, never trusted), ledger paths
+ * must be repo-relative without traversal (the same argument-injection
+ * discipline as `remote-ref.ts`).
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { remediateBranchFor } from '../lanes/branches';
+import type { OrderOutcomeRow } from '../lanes/order-ledger';
+import type { RemediateOutcome } from './outcome';
+
+/**
+ * The deferred-landing signal, set (to '1') on the workflow template's task
+ * step. ONE name: the template, the executor, and the budget clamp all
+ * derive from this constant (pinned by test/templates-lane-tokens.test.ts).
+ */
+export const DEFERRED_LANDING_ENV = 'DXKIT_DEFERRED_LANDING';
+
+/** Is deferred landing requested by this environment? Strictly '1', the
+ *  one value the template sets; anything else reads as "not deferred". */
+export function deferredLandingRequested(
+  env: Readonly<Record<string, string | undefined>>,
+): boolean {
+  return env[DEFERRED_LANDING_ENV] === '1';
+}
+
+export const LANDING_RECORD_SCHEMA = 'remediate-landing.v1';
+
+export interface LandingRecord {
+  readonly schema: typeof LANDING_RECORD_SCHEMA;
+  readonly task: string;
+  /**
+   * What the land step must do:
+   *   - 'land': push the verified HEAD to the standing branch and
+   *     open/update the standing PR (the deferred `landRemediateHead`);
+   *   - 'publish-rows': only the order-outcome ledger rows need durability
+   *     (a non-landing outcome, the deferred `publishOrderRows`).
+   */
+  readonly action: 'land' | 'publish-rows';
+  /** The task's standing branch, recomputed and cross-checked at read
+   *  time, never trusted from disk. */
+  readonly branch: string;
+  /** The verified HEAD the landing push expects (null when the executor
+   *  could not read HEAD; the land step then refuses, remedy named). */
+  readonly head: string | null;
+  readonly outcome: RemediateOutcome;
+  /** Landing fields, present when action is 'land'. */
+  readonly baseHead?: string;
+  readonly defaultBranch?: string;
+  readonly prTitle?: string;
+  readonly prBody?: string;
+  readonly draft?: boolean;
+  /** Repo-relative delivery-ledger file the task step already wrote into
+   *  the working tree (committed by the lander at land time). */
+  readonly ledgerPath?: string;
+  /**
+   * This run's order-outcome rows, carried IN the record: the compose step
+   * (which reads the standing branch) and the push both move to land time,
+   * where the credential is fresh: a task-time compose against an expired
+   * token would silently drop the branch's prior rows.
+   */
+  readonly orderRows: readonly OrderOutcomeRow[];
+  /** Set by a failed land attempt whose bookkeeping commit advanced HEAD,
+   *  disclosed so a retry knows why the expected head moved. */
+  readonly headAdvancedNote?: string;
+}
+
+/** Repo-relative record path for a task. */
+export function landingRecordPath(taskId: string): string {
+  return `.dxkit/cache/remediate-landing-${taskId}.json`;
+}
+
+/** Write the record (the executor's deferred exit). Throws on I/O failure:
+ *  a record that failed to write means the work would never land, so the
+ *  caller discloses it as a landing failure, never a silent success. */
+export function writeLandingRecord(cwd: string, record: LandingRecord): string {
+  const rel = landingRecordPath(record.task);
+  const abs = path.join(cwd, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, JSON.stringify(record, null, 2) + '\n', 'utf8');
+  return rel;
+}
+
+/** Remove the record (after a successful landing, or when a deferred run
+ *  ends with nothing to deliver). Best-effort: the record is runtime
+ *  state, and a leftover no-op record is disclosed, not harmful. */
+export function clearLandingRecord(cwd: string, taskId: string): void {
+  try {
+    fs.rmSync(path.join(cwd, landingRecordPath(taskId)), { force: true });
+  } catch {
+    // runtime-state cleanup, never a failure
+  }
+}
+
+const TASK_ID_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const HEX_SHA_RE = /^[0-9a-f]{7,64}$/;
+// A branch/ref name we are willing to pass to git/gh: no leading '-' (never
+// readable as a flag), no whitespace, no '..' (refname + traversal safety).
+const REF_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+
+/** Is this a repo-relative POSIX path safe to hand to `git add -- <p>`?
+ *  Relative, no traversal, no leading '-'. */
+function safeRepoRelativePath(p: unknown): p is string {
+  if (typeof p !== 'string' || p === '') return false;
+  if (p.startsWith('/') || p.startsWith('-') || p.includes('\\')) return false;
+  return !p.split('/').some((seg) => seg === '..' || seg === '');
+}
+
+export type LandingRecordRead =
+  | { readonly record: LandingRecord }
+  | { readonly error: string }
+  | null;
+
+/**
+ * Read + VALIDATE the record for a task. `null` = no record (nothing was
+ * deferred, the disclosed no-op). An invalid or foreign record is an
+ * `error` with the remedy named; the land step then refuses, and it never
+ * pushes what it cannot validate.
+ */
+export function readLandingRecord(cwd: string, taskId: string): LandingRecordRead {
+  if (!TASK_ID_RE.test(taskId)) {
+    return { error: `invalid task id '${taskId}': expected lowercase letters/digits/dashes` };
+  }
+  const abs = path.join(cwd, landingRecordPath(taskId));
+  let raw: string;
+  try {
+    raw = fs.readFileSync(abs, 'utf8');
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      error: `landing record at ${landingRecordPath(taskId)} is not valid JSON; re-run the task to regenerate it`,
+    };
+  }
+  const r = parsed as Partial<LandingRecord>;
+  const bad = (why: string): { error: string } => ({
+    error:
+      `landing record at ${landingRecordPath(taskId)} failed validation (${why}): ` +
+      `refusing to push from it; re-run the task to regenerate the record`,
+  });
+  if (r.schema !== LANDING_RECORD_SCHEMA) {
+    return bad(
+      `schema '${String(r.schema)}' is not ${LANDING_RECORD_SCHEMA} (written by a different dxkit build)`,
+    );
+  }
+  if (r.task !== taskId) return bad(`record is for task '${String(r.task)}', not '${taskId}'`);
+  if (r.action !== 'land' && r.action !== 'publish-rows') {
+    return bad(`unknown action '${String(r.action)}'`);
+  }
+  // The branch is CROSS-CHECKED against the recomputed name, never taken
+  // from disk on trust, so the record cannot redirect a push.
+  if (r.branch !== remediateBranchFor(taskId)) {
+    return bad(`branch '${String(r.branch)}' is not the task's standing branch`);
+  }
+  if (
+    !Array.isArray(r.orderRows) ||
+    r.orderRows.some((row) => typeof row !== 'object' || row === null)
+  ) {
+    return bad('orderRows is not an array of row objects');
+  }
+  if (r.action === 'land') {
+    if (typeof r.head !== 'string' || !HEX_SHA_RE.test(r.head)) {
+      return bad('no valid verified head sha (hex) recorded');
+    }
+    if (typeof r.defaultBranch !== 'string' || !REF_NAME_RE.test(r.defaultBranch)) {
+      return bad('no valid default branch recorded');
+    }
+    if (typeof r.prTitle !== 'string' || r.prTitle === '') return bad('no PR title recorded');
+    if (typeof r.prBody !== 'string') return bad('no PR body recorded');
+    if (r.ledgerPath !== undefined && !safeRepoRelativePath(r.ledgerPath)) {
+      return bad(`ledger path '${String(r.ledgerPath)}' is not a safe repo-relative path`);
+    }
+    if (r.baseHead !== undefined && !HEX_SHA_RE.test(String(r.baseHead))) {
+      return bad('baseHead is not a hex sha');
+    }
+    if (r.draft !== undefined && typeof r.draft !== 'boolean') return bad('draft is not a boolean');
+  }
+  return { record: r as LandingRecord };
+}

--- a/src/remediate/landing-record.ts
+++ b/src/remediate/landing-record.ts
@@ -93,10 +93,15 @@ export function landingRecordPath(taskId: string): string {
   return `.dxkit/cache/remediate-landing-${taskId}.json`;
 }
 
-/** Write the record (the executor's deferred exit). Throws on I/O failure:
- *  a record that failed to write means the work would never land, so the
- *  caller discloses it as a landing failure, never a silent success. */
+/** Write the record (the executor's deferred exit). Throws on I/O failure
+ *  or an invalid task id (the id shapes the file path, so the write side
+ *  applies the SAME guard the read side does; defense in depth): a record
+ *  that failed to write means the work would never land, so the caller
+ *  discloses it as a landing failure, never a silent success. */
 export function writeLandingRecord(cwd: string, record: LandingRecord): string {
+  if (!TASK_ID_RE.test(record.task)) {
+    throw new Error(`invalid task id '${record.task}': expected lowercase letters/digits/dashes`);
+  }
   const rel = landingRecordPath(record.task);
   const abs = path.join(cwd, rel);
   fs.mkdirSync(path.dirname(abs), { recursive: true });
@@ -106,8 +111,10 @@ export function writeLandingRecord(cwd: string, record: LandingRecord): string {
 
 /** Remove the record (after a successful landing, or when a deferred run
  *  ends with nothing to deliver). Best-effort: the record is runtime
- *  state, and a leftover no-op record is disclosed, not harmful. */
+ *  state, and a leftover no-op record is disclosed, not harmful. An
+ *  invalid task id (same guard as the read/write sides) removes nothing. */
 export function clearLandingRecord(cwd: string, taskId: string): void {
+  if (!TASK_ID_RE.test(taskId)) return;
   try {
     fs.rmSync(path.join(cwd, landingRecordPath(taskId)), { force: true });
   } catch {

--- a/test/remediate/config-budgets.test.ts
+++ b/test/remediate/config-budgets.test.ts
@@ -236,4 +236,27 @@ describe('clampBudgetToTokenLifetime (the App-token 1h hard cap)', () => {
       expect(notes).toEqual([]);
     }
   });
+
+  it('deferred landing lifts the app-tier clamp (fresh delivery token) with the mode disclosed', () => {
+    // Two-phase landing (4.4.7): the landing step mints its own token, so
+    // the agent budget is decoupled from the credential lifetime and the
+    // clamp's stated reason is gone. The tier is still disclosed.
+    const { budget, notes } = clampBudgetToTokenLifetime(base, {
+      DXKIT_TOKEN_MODE: 'app',
+      DXKIT_DEFERRED_LANDING: '1',
+    });
+    expect(budget).toEqual(base);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toContain('deferred');
+    expect(notes[0]).toContain('not clamped');
+  });
+
+  it('an older installed workflow (app tier, no deferred signal) keeps the clamp: inline landing still rides the task token', () => {
+    const { budget, notes } = clampBudgetToTokenLifetime(base, {
+      DXKIT_TOKEN_MODE: 'app',
+      DXKIT_DEFERRED_LANDING: '',
+    });
+    expect(budget.maxMinutes).toBe(APP_TOKEN_SAFE_MINUTES);
+    expect(notes[0]).toContain('vyuh-dxkit update');
+  });
 });

--- a/test/remediate/two-phase-landing.test.ts
+++ b/test/remediate/two-phase-landing.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Two-phase landing (4.4.7): the credential-freshness root fix.
+ *
+ * The live class: App installation tokens are hard-capped at one hour, and
+ * the task's verify phases scale with repo size, so the landing push fired
+ * 68 minutes after mint and 401'd: landing, salvage draft, and the
+ * order-outcome ledger ALL lost. The root fix decouples credential
+ * freshness from task duration: under the workflow's deferred-landing
+ * signal the executor performs NO pushes (it writes ONE landing record),
+ * and `remediate land` (a post-task step under a freshly minted token)
+ * validates the record and performs every deferred push.
+ *
+ * Pinned here, both directions per behavior:
+ *   - deferred: env set → no push attempted, one record written (the
+ *     salvage draft defers through the SAME record, one code path);
+ *   - inline: env absent → the immediate landing is unchanged;
+ *   - the land CLI: validate → push; a stale HEAD refuses (never pushes
+ *     stale or foreign commits); success clears the record (idempotent);
+ *     a tampered record is refused before any spawn.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { executeTask, runRemediateLand, type ExecutorSeams } from '../../src/remediate/cli';
+import { DEFAULT_REMEDIATE_BUDGET, type RemediateConfig } from '../../src/remediate/config';
+import type { RemediateResult } from '../../src/remediate/run';
+import {
+  DEFERRED_LANDING_ENV,
+  LANDING_RECORD_SCHEMA,
+  landingRecordPath,
+  readLandingRecord,
+  writeLandingRecord,
+  type LandingRecord,
+} from '../../src/remediate/landing-record';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+function tempRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-2phase-'));
+  dirs.push(dir);
+  return dir;
+}
+
+function config(salvage: RemediateConfig['salvage'] = 'discard'): RemediateConfig {
+  return {
+    enabled: true,
+    tasks: ['write-docs'],
+    unknownTasks: [],
+    schedule: 'weekly',
+    salvage,
+    agent: { driver: 'claude-code', model: 'auto', budget: DEFAULT_REMEDIATE_BUDGET },
+    taskBudgets: {},
+    maxSpendPerRun: 0,
+    maxDispatchBudget: 0,
+    maxOrdersPerRun: 0,
+    pauseAfterFailures: 0,
+    resume: false,
+    workOrders: { maxSliceSize: 25 },
+    recipes: { enabled: true },
+  };
+}
+
+function result(
+  outcome: RemediateResult['outcome'],
+  extra: Partial<RemediateResult> = {},
+): RemediateResult {
+  return {
+    outcome,
+    task: 'write-docs',
+    ledger: 'THE VERIFICATION LEDGER',
+    baseHead: 'aaaa1111',
+    head: 'bbbb2222',
+    ...extra,
+  };
+}
+
+function resultWithOrders(outcome: RemediateResult['outcome']): RemediateResult {
+  return result(outcome, {
+    orders: {
+      cap: 3,
+      queued: 1,
+      records: [
+        {
+          orderId: 'dep-advisory:x',
+          class: 'dep-advisory',
+          findings: 1,
+          budget: { turns: 5, minutes: 5, usd: 1, derivation: 'd' },
+          outcome: 'completed',
+          done: { verifier: 'guardrail', absentIds: 1 },
+        },
+      ],
+    },
+  });
+}
+
+const DEFERRED_ENV = { [DEFERRED_LANDING_ENV]: '1' };
+
+function seams(overrides: Partial<ExecutorSeams> = {}): ExecutorSeams {
+  return {
+    runTask: async () => result('verified'),
+    branch: () => 'main',
+    defaultBranch: () => 'main',
+    landHead: () => ({
+      outcome: 'pr-opened' as const,
+      mode: 'pr' as const,
+      prUrl: 'https://example.test/pr/1',
+    }),
+    probeDelivery: () => ({ probes: [], anyBlocked: false, unverifiable: false }),
+    ...overrides,
+  };
+}
+
+function readRecordFile(cwd: string): LandingRecord {
+  return JSON.parse(
+    fs.readFileSync(path.join(cwd, landingRecordPath('write-docs')), 'utf8'),
+  ) as LandingRecord;
+}
+
+function attemptRecord(cwd: string): Record<string, unknown> {
+  return JSON.parse(
+    fs.readFileSync(path.join(cwd, '.dxkit', 'cache', 'remediate-write-docs.json'), 'utf8'),
+  ) as Record<string, unknown>;
+}
+
+function validLandRecord(overrides: Partial<LandingRecord> = {}): LandingRecord {
+  return {
+    schema: LANDING_RECORD_SCHEMA,
+    task: 'write-docs',
+    action: 'land',
+    branch: 'dxkit/remediate-write-docs',
+    head: 'bbbb2222',
+    baseHead: 'aaaa1111',
+    outcome: 'verified',
+    defaultBranch: 'main',
+    prTitle: 'dxkit remediate: write-docs',
+    prBody: 'THE BODY',
+    draft: false,
+    ledgerPath: '.dxkit/lanes/remediate-write-docs.jsonl',
+    orderRows: [],
+    ...overrides,
+  };
+}
+
+describe('landing record: write / read / validate', () => {
+  it('round-trips a valid record', () => {
+    const cwd = tempRepo();
+    writeLandingRecord(cwd, validLandRecord());
+    const read = readLandingRecord(cwd, 'write-docs');
+    expect(read).not.toBeNull();
+    expect(read && 'record' in read && read.record.prTitle).toBe('dxkit remediate: write-docs');
+  });
+
+  it('no record file reads as null (nothing was deferred)', () => {
+    expect(readLandingRecord(tempRepo(), 'write-docs')).toBeNull();
+  });
+
+  it('refuses a tampered or foreign record, naming the reason (never pushes what it cannot validate)', () => {
+    const cases: Array<[string, Partial<LandingRecord>]> = [
+      ['a redirected branch', { branch: 'refs/heads/main' }],
+      ['a non-hex head', { head: 'HEAD@{1}' }],
+      ['a missing head', { head: null }],
+      ['a traversal ledger path', { ledgerPath: '../outside/x.jsonl' }],
+      ['an absolute ledger path', { ledgerPath: '/etc/passwd' }],
+      ['a flag-shaped default branch', { defaultBranch: '--force' }],
+      ['an unknown action', { action: 'exec' as unknown as LandingRecord['action'] }],
+      ['a foreign schema', { schema: 'remediate-landing.v9' as typeof LANDING_RECORD_SCHEMA }],
+      ['non-array order rows', { orderRows: 'rows' as unknown as LandingRecord['orderRows'] }],
+    ];
+    for (const [label, bad] of cases) {
+      const cwd = tempRepo();
+      // Written raw: writeLandingRecord types would reject some of these.
+      fs.mkdirSync(path.join(cwd, '.dxkit', 'cache'), { recursive: true });
+      fs.writeFileSync(
+        path.join(cwd, landingRecordPath('write-docs')),
+        JSON.stringify({ ...validLandRecord(), ...bad }),
+        'utf8',
+      );
+      const read = readLandingRecord(cwd, 'write-docs');
+      expect(read && 'error' in read, `${label} must be refused`).toBe(true);
+      if (read && 'error' in read) expect(read.error).toContain('re-run the task');
+    }
+  });
+
+  it("refuses a record written for a DIFFERENT task (a record cannot land under another task's name)", () => {
+    const cwd = tempRepo();
+    fs.mkdirSync(path.join(cwd, '.dxkit', 'cache'), { recursive: true });
+    fs.writeFileSync(
+      path.join(cwd, landingRecordPath('write-docs')),
+      JSON.stringify(validLandRecord({ task: 'fix-lint' })),
+      'utf8',
+    );
+    const read = readLandingRecord(cwd, 'write-docs');
+    expect(read && 'error' in read).toBe(true);
+  });
+
+  it('refuses an invalid requested task id before touching the filesystem', () => {
+    const read = readLandingRecord(tempRepo(), '../evil');
+    expect(read && 'error' in read).toBe(true);
+  });
+});
+
+describe('executor under deferred landing (env set => no push, one record)', () => {
+  it('a verified run defers: no lander call, no row publish, the record carries the assembled PR', async () => {
+    const cwd = tempRepo();
+    let pushed = false;
+    const run = await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        env: DEFERRED_ENV,
+        runTask: async () => resultWithOrders('verified'),
+        landHead: () => {
+          pushed = true;
+          return { outcome: 'pr-opened', mode: 'pr' };
+        },
+        writeOrderLedger: () => {
+          pushed = true; // the compose reads the standing branch, deferred too
+          return null;
+        },
+        publishOrderRows: () => {
+          pushed = true;
+          return { published: true };
+        },
+      }),
+    );
+    expect(pushed).toBe(false);
+    expect(run.landed).toBe(false);
+    expect(run.clean).toBe(true); // verified; the land step carries landing truth
+    expect(run.landingDeferred).toContain('remediate land');
+    const record = readRecordFile(cwd);
+    expect(record.action).toBe('land');
+    expect(record.head).toBe('bbbb2222'); // currentHead falls back to the result head off-git
+    expect(record.prTitle).toBe('dxkit remediate: write-docs');
+    expect(record.prBody).toContain('THE VERIFICATION LEDGER');
+    expect(record.draft).toBe(false);
+    expect(record.defaultBranch).toBe('main');
+    expect(record.orderRows).toHaveLength(1);
+    expect(record.ledgerPath).toContain('.dxkit/lanes/');
+    // The attempt record discloses the deferral and stays landed:false
+    // until the land step flips it.
+    const attempt = attemptRecord(cwd);
+    expect(attempt.landed).toBe(false);
+    expect(String(attempt.landingDeferred)).toContain('remediate land');
+  });
+
+  it('the salvage draft defers through the SAME record (one code path), draft flag carried', async () => {
+    const cwd = tempRepo();
+    let pushed = false;
+    const run = await executeTask(
+      cwd,
+      config('draft-pr'),
+      'write-docs',
+      'pr',
+      seams({
+        env: DEFERRED_ENV,
+        runTask: async () => result('budget-exhausted'),
+        landHead: () => {
+          pushed = true;
+          return { outcome: 'pr-opened', mode: 'pr' };
+        },
+      }),
+    );
+    expect(pushed).toBe(false);
+    expect(run.clean).toBe(true); // a recorded budget-bounded draft, same as a landed one
+    const record = readRecordFile(cwd);
+    expect(record.action).toBe('land');
+    expect(record.draft).toBe(true);
+    expect(record.prTitle).toContain('(partial, budget-bounded)');
+  });
+
+  it('a non-landing outcome defers its order rows instead of pushing the metadata commit', async () => {
+    const cwd = tempRepo();
+    let published = false;
+    const run = await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        env: DEFERRED_ENV,
+        runTask: async () => resultWithOrders('guardrail-red'),
+        publishOrderRows: () => {
+          published = true;
+          return { published: true };
+        },
+      }),
+    );
+    expect(published).toBe(false);
+    expect(run.landed).toBe(false);
+    const record = readRecordFile(cwd);
+    expect(record.action).toBe('publish-rows');
+    expect(record.orderRows).toHaveLength(1);
+    expect((record.orderRows[0] as { outcome: string }).outcome).toBe('guardrail-red');
+  });
+
+  it('inline direction: env absent => the immediate landing is unchanged and no record exists', async () => {
+    const cwd = tempRepo();
+    let pushed = false;
+    const run = await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({
+        env: {},
+        landHead: () => {
+          pushed = true;
+          return { outcome: 'pr-opened', mode: 'pr', prUrl: 'https://example.test/pr/1' };
+        },
+      }),
+    );
+    expect(pushed).toBe(true);
+    expect(run.landed).toBe(true);
+    expect(run.landingDeferred).toBeUndefined();
+    expect(fs.existsSync(path.join(cwd, landingRecordPath('write-docs')))).toBe(false);
+  });
+});
+
+describe('remediate land (phase two)', () => {
+  it('no record is a disclosed no-op', () => {
+    const out = runRemediateLand(tempRepo(), 'write-docs');
+    expect(out.outcome).toBe('no-record');
+    expect('note' in out && out.note).toContain('nothing to land');
+  });
+
+  it('executor record => land: validates HEAD, composes the ledger, pushes, patches the attempt record, clears the record; a re-run is then a no-op', async () => {
+    const cwd = tempRepo();
+    // Phase one: a deferred verified run writes the record.
+    await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({ env: DEFERRED_ENV, runTask: async () => resultWithOrders('verified') }),
+    );
+    // Phase two: the fresh-credential step.
+    let landOpts: Record<string, unknown> | undefined;
+    let composedRows: unknown[] | undefined;
+    const out = runRemediateLand(cwd, 'write-docs', {
+      head: () => 'bbbb2222',
+      writeOrderLedger: (_cwd, _task, rows) => {
+        composedRows = [...rows];
+        return '.dxkit/lanes/remediate-write-docs.orders.jsonl';
+      },
+      landHead: (opts) => {
+        landOpts = { ...opts };
+        return { outcome: 'pr-opened', mode: 'pr', prUrl: 'https://example.test/pr/9' };
+      },
+    });
+    expect(out.outcome).toBe('landed');
+    expect('prUrl' in out && out.prUrl).toBe('https://example.test/pr/9');
+    // The compose (standing-branch read) happened at land time, under the
+    // fresh credential, with this run's recorded rows.
+    expect(composedRows).toHaveLength(1);
+    expect(landOpts!.prTitle).toBe('dxkit remediate: write-docs');
+    expect(String(landOpts!.prBody)).toContain('THE VERIFICATION LEDGER');
+    expect(landOpts!.orderLedgerPath).toBe('.dxkit/lanes/remediate-write-docs.orders.jsonl');
+    expect(landOpts!.defaultBranch).toBe('main');
+    // The workflow's evidence step reads the attempt record: now landed.
+    const attempt = attemptRecord(cwd);
+    expect(attempt.landed).toBe(true);
+    expect(attempt.prUrl).toBe('https://example.test/pr/9');
+    // Idempotent: the record is cleared, a re-run is a disclosed no-op.
+    expect(fs.existsSync(path.join(cwd, landingRecordPath('write-docs')))).toBe(false);
+    const again = runRemediateLand(cwd, 'write-docs', {
+      landHead: () => {
+        throw new Error('must not be called');
+      },
+    });
+    expect(again.outcome).toBe('no-record');
+  });
+
+  it('a moved HEAD refuses with the remedy named: stale or foreign commits are never pushed', () => {
+    const cwd = tempRepo();
+    writeLandingRecord(cwd, validLandRecord());
+    let pushed = false;
+    const out = runRemediateLand(cwd, 'write-docs', {
+      head: () => 'cccc3333',
+      landHead: () => {
+        pushed = true;
+        return { outcome: 'pr-opened', mode: 'pr' };
+      },
+      writeOrderLedger: () => null,
+    });
+    expect(pushed).toBe(false);
+    expect(out.outcome).toBe('stale-head');
+    expect('error' in out && out.error).toContain('re-run the task');
+    // The record survives for inspection.
+    expect(fs.existsSync(path.join(cwd, landingRecordPath('write-docs')))).toBe(true);
+  });
+
+  it('a tampered record refuses before any push', () => {
+    const cwd = tempRepo();
+    fs.mkdirSync(path.join(cwd, '.dxkit', 'cache'), { recursive: true });
+    fs.writeFileSync(
+      path.join(cwd, landingRecordPath('write-docs')),
+      JSON.stringify(validLandRecord({ branch: 'main' })),
+      'utf8',
+    );
+    let pushed = false;
+    const out = runRemediateLand(cwd, 'write-docs', {
+      head: () => 'bbbb2222',
+      landHead: () => {
+        pushed = true;
+        return { outcome: 'pr-opened', mode: 'pr' };
+      },
+    });
+    expect(pushed).toBe(false);
+    expect(out.outcome).toBe('invalid-record');
+  });
+
+  it('a failed push is disclosed, keeps the record for retry, and advances the expected head past its own bookkeeping commit', () => {
+    const cwd = tempRepo();
+    writeLandingRecord(cwd, validLandRecord());
+    // First head read validates; after the throw the observed head has the
+    // lander's ledger commit on top (the lander commits before it pushes).
+    const heads = ['bbbb2222', 'dddd4444'];
+    const out = runRemediateLand(cwd, 'write-docs', {
+      head: () => heads.shift() ?? 'dddd4444',
+      writeOrderLedger: () => null,
+      landHead: () => {
+        throw Object.assign(new Error('git push exited 1'), {
+          stderr: 'remote: error: GH013: Repository rule violations found',
+        });
+      },
+    });
+    expect(out.outcome).toBe('landing-failed');
+    expect('error' in out && out.error).toContain('GH013');
+    expect('error' in out && out.error).toContain('retry');
+    const kept = readRecordFile(cwd);
+    expect(kept.head).toBe('dddd4444');
+    expect(kept.headAdvancedNote).toContain('bookkeeping commit');
+    // The attempt record carries the disclosed failure.
+    // (written best-effort only when an attempt record exists)
+  });
+
+  it('publish-rows records push the metadata commit and clear; a publish failure keeps the record (warn, not a lane failure)', async () => {
+    const cwd = tempRepo();
+    await executeTask(
+      cwd,
+      config(),
+      'write-docs',
+      'pr',
+      seams({ env: DEFERRED_ENV, runTask: async () => resultWithOrders('guardrail-red') }),
+    );
+    let publishedRows: unknown[] | undefined;
+    const out = runRemediateLand(cwd, 'write-docs', {
+      publishRows: (_cwd, _task, rows) => {
+        publishedRows = [...rows];
+        return { published: true };
+      },
+    });
+    expect(out.outcome).toBe('rows-published');
+    expect(publishedRows).toHaveLength(1);
+    expect(fs.existsSync(path.join(cwd, landingRecordPath('write-docs')))).toBe(false);
+
+    // Failure direction: the record survives for a retry.
+    const cwd2 = tempRepo();
+    await executeTask(
+      cwd2,
+      config(),
+      'write-docs',
+      'pr',
+      seams({ env: DEFERRED_ENV, runTask: async () => resultWithOrders('guardrail-red') }),
+    );
+    const failed = runRemediateLand(cwd2, 'write-docs', {
+      publishRows: () => ({ published: false, note: 'remote said no' }),
+    });
+    expect(failed.outcome).toBe('rows-publish-failed');
+    expect('note' in failed && failed.note).toContain('remote said no');
+    expect(fs.existsSync(path.join(cwd2, landingRecordPath('write-docs')))).toBe(true);
+  });
+});

--- a/test/remediate/two-phase-landing.test.ts
+++ b/test/remediate/two-phase-landing.test.ts
@@ -19,6 +19,7 @@
  *     a tampered record is refused before any spawn.
  */
 import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -26,6 +27,7 @@ import { executeTask, runRemediateLand, type ExecutorSeams } from '../../src/rem
 import { DEFAULT_REMEDIATE_BUDGET, type RemediateConfig } from '../../src/remediate/config';
 import type { RemediateResult } from '../../src/remediate/run';
 import {
+  clearLandingRecord,
   DEFERRED_LANDING_ENV,
   LANDING_RECORD_SCHEMA,
   landingRecordPath,
@@ -42,6 +44,27 @@ function tempRepo(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-2phase-'));
   dirs.push(dir);
   return dir;
+}
+
+/** Run git in a fixture repo, trimmed stdout. */
+function git(cwd: string, args: readonly string[]): string {
+  return execFileSync('git', [...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+/** A real single-commit git repo (the head-advance proof needs real git). */
+function gitRepo(): string {
+  const cwd = tempRepo();
+  git(cwd, ['init', '-q']);
+  git(cwd, ['config', 'user.email', 'test@example.invalid']);
+  git(cwd, ['config', 'user.name', 'test']);
+  fs.writeFileSync(path.join(cwd, 'a.txt'), 'a', 'utf8');
+  git(cwd, ['add', 'a.txt']);
+  git(cwd, ['commit', '-qm', 'base']);
+  return cwd;
 }
 
 function config(salvage: RemediateConfig['salvage'] = 'discard'): RemediateConfig {
@@ -199,6 +222,19 @@ describe('landing record: write / read / validate', () => {
   it('refuses an invalid requested task id before touching the filesystem', () => {
     const read = readLandingRecord(tempRepo(), '../evil');
     expect(read && 'error' in read).toBe(true);
+  });
+
+  it('the WRITE side applies the same task-id guard: an invalid id never shapes a path', () => {
+    const cwd = tempRepo();
+    expect(() => writeLandingRecord(cwd, validLandRecord({ task: '../evil' }))).toThrow(
+      /invalid task id/,
+    );
+    // clear with an invalid id is a no-op, never a path build.
+    writeLandingRecord(cwd, validLandRecord());
+    clearLandingRecord(cwd, '../evil');
+    expect(fs.existsSync(path.join(cwd, landingRecordPath('write-docs')))).toBe(true);
+    clearLandingRecord(cwd, 'write-docs');
+    expect(fs.existsSync(path.join(cwd, landingRecordPath('write-docs')))).toBe(false);
   });
 });
 
@@ -414,15 +450,23 @@ describe('remediate land (phase two)', () => {
     expect(out.outcome).toBe('invalid-record');
   });
 
-  it('a failed push is disclosed, keeps the record for retry, and advances the expected head past its own bookkeeping commit', () => {
+  it('a failed push publishes the recorded rows through the metadata channel anyway (the breaker still sees the run), disclosed', () => {
+    // Inline parity: execute.ts calls publishRows() inside its landHead
+    // catch, and the A1 failure classes are exactly the runs whose rows
+    // the breaker most needs. The deferred path must do the same.
     const cwd = tempRepo();
-    writeLandingRecord(cwd, validLandRecord());
-    // First head read validates; after the throw the observed head has the
-    // lander's ledger commit on top (the lander commits before it pushes).
-    const heads = ['bbbb2222', 'dddd4444'];
+    const rows = [
+      { task: 'write-docs', orderId: 'o1' } as unknown as LandingRecord['orderRows'][number],
+    ];
+    writeLandingRecord(cwd, validLandRecord({ orderRows: rows }));
+    let publishedRows: unknown[] | undefined;
     const out = runRemediateLand(cwd, 'write-docs', {
-      head: () => heads.shift() ?? 'dddd4444',
+      head: () => 'bbbb2222',
       writeOrderLedger: () => null,
+      publishRows: (_cwd, _task, r) => {
+        publishedRows = [...r];
+        return { published: true };
+      },
       landHead: () => {
         throw Object.assign(new Error('git push exited 1'), {
           stderr: 'remote: error: GH013: Repository rule violations found',
@@ -430,13 +474,93 @@ describe('remediate land (phase two)', () => {
       },
     });
     expect(out.outcome).toBe('landing-failed');
+    expect(publishedRows).toHaveLength(1);
     expect('error' in out && out.error).toContain('GH013');
-    expect('error' in out && out.error).toContain('retry');
+    expect('error' in out && out.error).toContain('circuit breaker sees this run');
+    // Failure direction: the fallback itself failing is also disclosed.
+    const cwd2 = tempRepo();
+    writeLandingRecord(cwd2, validLandRecord({ orderRows: rows }));
+    const out2 = runRemediateLand(cwd2, 'write-docs', {
+      head: () => 'bbbb2222',
+      writeOrderLedger: () => null,
+      publishRows: () => ({ published: false, note: 'metadata push refused' }),
+      landHead: () => {
+        throw new Error('git push exited 1');
+      },
+    });
+    expect(out2.outcome).toBe('landing-failed');
+    expect('error' in out2 && out2.error).toContain('also could not be recorded');
+    expect('error' in out2 && out2.error).toContain('metadata push refused');
+  });
+
+  it('a failed push advances the expected head ONLY over its own bookkeeping commit (git-proven), and a retry then lands', () => {
+    const cwd = gitRepo();
+    const headA = git(cwd, ['rev-parse', 'HEAD']);
+    const ledgerRel = '.dxkit/lanes/remediate-write-docs.jsonl';
+    writeLandingRecord(cwd, validLandRecord({ head: headA, ledgerPath: ledgerRel }));
+    let attempts = 0;
+    const seamsUsed = {
+      writeOrderLedger: () => null,
+      landHead: () => {
+        attempts += 1;
+        if (attempts === 1) {
+          // The real lander commits its bookkeeping BEFORE the push: one
+          // commit atop the verified head touching only the ledger path.
+          fs.mkdirSync(path.join(cwd, path.dirname(ledgerRel)), { recursive: true });
+          fs.writeFileSync(path.join(cwd, ledgerRel), '{}\n', 'utf8');
+          git(cwd, ['add', ledgerRel]);
+          git(cwd, ['commit', '-qm', 'chore: ledger', '--', ledgerRel]);
+          throw Object.assign(new Error('git push exited 1'), {
+            stderr: 'remote: error: GH013: Repository rule violations found',
+          });
+        }
+        return { outcome: 'pr-opened' as const, mode: 'pr' as const, prUrl: 'https://x/pr/1' };
+      },
+    };
+    const out = runRemediateLand(cwd, 'write-docs', seamsUsed);
+    expect(out.outcome).toBe('landing-failed');
+    const headB = git(cwd, ['rev-parse', 'HEAD']);
     const kept = readRecordFile(cwd);
-    expect(kept.head).toBe('dddd4444');
+    expect(kept.head).toBe(headB);
     expect(kept.headAdvancedNote).toContain('bookkeeping commit');
-    // The attempt record carries the disclosed failure.
-    // (written best-effort only when an attempt record exists)
+    // The retry validates against the advanced head and lands.
+    const retry = runRemediateLand(cwd, 'write-docs', seamsUsed);
+    expect(retry.outcome).toBe('landed');
+  });
+
+  it('a FOREIGN commit never advances the expected head: the record stays put and the retry refuses as stale', () => {
+    const cwd = gitRepo();
+    const headA = git(cwd, ['rev-parse', 'HEAD']);
+    writeLandingRecord(
+      cwd,
+      validLandRecord({ head: headA, ledgerPath: '.dxkit/lanes/remediate-write-docs.jsonl' }),
+    );
+    const seamsUsed = {
+      writeOrderLedger: () => null,
+      landHead: () => {
+        // A commit touching a SOURCE file: not this step's bookkeeping.
+        fs.writeFileSync(path.join(cwd, 'evil.ts'), 'x', 'utf8');
+        git(cwd, ['add', 'evil.ts']);
+        git(cwd, ['commit', '-qm', 'foreign', '--', 'evil.ts']);
+        throw new Error('git push exited 1');
+      },
+    };
+    const out = runRemediateLand(cwd, 'write-docs', seamsUsed);
+    expect(out.outcome).toBe('landing-failed');
+    const kept = readRecordFile(cwd);
+    expect(kept.head).toBe(headA); // unchanged: the delta is not provably ours
+    expect(kept.headAdvancedNote).toBeUndefined();
+    // The retry refuses: HEAD is the foreign commit, not the verified head.
+    let pushed = false;
+    const retry = runRemediateLand(cwd, 'write-docs', {
+      writeOrderLedger: () => null,
+      landHead: () => {
+        pushed = true;
+        return { outcome: 'pr-opened', mode: 'pr' };
+      },
+    });
+    expect(pushed).toBe(false);
+    expect(retry.outcome).toBe('stale-head');
   });
 
   it('publish-rows records push the metadata commit and clear; a publish failure keeps the record (warn, not a lane failure)', async () => {

--- a/test/templates-lane-tokens.test.ts
+++ b/test/templates-lane-tokens.test.ts
@@ -28,11 +28,13 @@ import {
   LANE_TOKEN_APP_ID_VARIABLE_NAME,
   LANE_TOKEN_APP_KEY_SECRET_NAME,
   LANE_TOKEN_CHAIN,
+  LANE_TOKEN_LAND_STEPS,
   LANE_TOKEN_PAT_SECRET_NAME,
   LANE_TOKEN_STEPS,
   LANE_TOKEN_SUBSTITUTIONS,
   LANE_TOKEN_TASK_STEPS,
 } from '../src/lanes/lane-token';
+import { DEFERRED_LANDING_ENV } from '../src/remediate/landing-record';
 import {
   INSTALL_DEPS_PLACEHOLDER,
   defaultResolvedTolerances,
@@ -70,6 +72,7 @@ const GH_SHELLING_COMMANDS = [
   'deps bump',
   'remediate configured',
   'remediate --task',
+  'remediate land',
 ];
 
 interface Step {
@@ -253,6 +256,19 @@ describe('workflow-template token discipline', () => {
     expect(parsed.jobs.j.steps[0].id).toBe('dxkit-app-token');
   });
 
+  it('the landing-mint block is well-formed and runs even after a failed task step', () => {
+    const doc = `jobs:\n  j:\n    steps:\n${LANE_TOKEN_LAND_STEPS}\n`;
+    expect(() => yaml.load(doc)).not.toThrow();
+    const parsed = yaml.load(doc) as {
+      jobs: { j: { steps: Array<Record<string, unknown>> } };
+    };
+    expect(parsed.jobs.j.steps).toHaveLength(1);
+    expect(parsed.jobs.j.steps[0].id).toBe('dxkit-app-token-land');
+    // always(): a salvage/draft record written by a FAILED task step must
+    // still get a fresh credential to land under.
+    expect(String(parsed.jobs.j.steps[0].if)).toContain('always()');
+  });
+
   it('SYNTHETIC INJECTION: the content-derived membership check bites', () => {
     // A hypothetical new lane that opens a PR with no chain — the exact
     // shape that drifted twice. If needsTokenChain stops seeing it, this
@@ -296,11 +312,11 @@ describe('workflow-template token discipline', () => {
     // agent spend, on every tier (not only the App).
     expect(content).toContain('persist-credentials: false');
     // A working credential right after checkout (setup-phase git needs —
-    // a private git-pinned dependency installs before the landing step),
-    // then the landing credential with the FRESH task token replacing it.
+    // a private git-pinned dependency installs before the task), then the
+    // task credential with the FRESH task token replacing it.
     expect(content).toContain('- name: Install the working credential');
     expect(content).toContain('DXKIT_LANE_TOKEN: __DXKIT_LANE_TOKEN__');
-    expect(content).toContain('- name: Install the landing credential');
+    expect(content).toContain('- name: Install the task credential');
     expect(content).toContain('DXKIT_LANE_TOKEN: __DXKIT_LANE_TOKEN_TASK__');
     const checkoutIdx = content.indexOf('persist-credentials: false');
     const workingIdx = content.indexOf('- name: Install the working credential');
@@ -314,8 +330,7 @@ describe('workflow-template token discipline', () => {
     expect(content).toContain('git ls-remote --heads origin');
     expect(content).toContain('expected exactly 1 auth header config');
     // The task step's gh credential prefers the fresh token (the _TASK
-    // placeholder), and the CLI learns the tier so it can clamp the wall
-    // clock to the token lifetime (disclosed, never silent).
+    // placeholder), and the CLI learns the tier for its disclosures.
     expect(content).toContain('GH_TOKEN: __DXKIT_LANE_TOKEN_TASK__');
     expect(content).toContain('DXKIT_TOKEN_MODE: __DXKIT_LANE_TOKEN_MODE__');
     // Ordering: agent-CLI install → re-mint → credential refresh → task, so
@@ -324,12 +339,48 @@ describe('workflow-template token discipline', () => {
     const rendered = renderForParse(content);
     const install = rendered.indexOf('Install the agent CLI');
     const remint = rendered.indexOf('id: dxkit-app-token-task');
-    const refresh = rendered.indexOf('- name: Install the landing credential');
+    const refresh = rendered.indexOf('- name: Install the task credential');
     const task = rendered.indexOf('Run task ${{ matrix.task }}');
     expect(install).toBeGreaterThan(-1);
     expect(remint).toBeGreaterThan(install);
     expect(refresh).toBeGreaterThan(remint);
     expect(task).toBeGreaterThan(refresh);
+  });
+
+  it('the remediate lane lands in two phases: deferred task, fresh-credential land step (4.4.7)', () => {
+    // The A1 class: the task's verify phases scale with repo size, so ANY
+    // token minted before the task can expire before the landing push.
+    // The task step must therefore defer every push (the env signal, ONE
+    // name shared with the CLI), and a post-task step must mint a fresh
+    // token and run `remediate land`, on success AND on task failure (a
+    // salvage draft record must still land), guarded on record existence.
+    const content = fs.readFileSync(path.join(WORKFLOWS, 'dxkit-remediate.yml'), 'utf8');
+    // The deferred-landing signal on the task step, named from the ONE
+    // constant the CLI reads.
+    expect(content).toContain(`${DEFERRED_LANDING_ENV}: '1'`);
+    // The landing mint + chain arrive via the one-definition placeholders,
+    // never hand-copied.
+    expect(content).toContain('__DXKIT_LANE_TOKEN_LAND_STEPS__');
+    expect(content).toContain('GH_TOKEN: __DXKIT_LANE_TOKEN_LAND__');
+    // The land step runs `remediate land`, is always()-guarded (a failed
+    // task's salvage record still lands), and skips disclosed on no record.
+    expect(content).toContain('remediate land --task');
+    expect(content).toContain('no landing record for');
+    // Ordering over the RENDERED content: task step → landing mint →
+    // land step → attempt-diff collection (which must see the patched
+    // attempt record, so it stays AFTER the landing).
+    const rendered = renderForParse(content);
+    const task = rendered.indexOf('Run task ${{ matrix.task }}');
+    const landMint = rendered.indexOf('id: dxkit-app-token-land');
+    const landStep = rendered.indexOf('- name: Land the deferred work (fresh credential)');
+    const collect = rendered.indexOf('- name: Collect the attempt diff');
+    expect(task).toBeGreaterThan(-1);
+    expect(landMint).toBeGreaterThan(task);
+    expect(landStep).toBeGreaterThan(landMint);
+    expect(collect).toBeGreaterThan(landStep);
+    // The fresh mint prefers itself in the landing chain (delivery-time
+    // lifetime), then falls through the earlier tiers.
+    expect(rendered).toContain('steps.dxkit-app-token-land.outputs.token');
   });
 });
 
@@ -358,10 +409,11 @@ describe('lane token NAME discipline (one definition)', () => {
     expect(offenders, offenders.join('\n')).toEqual([]);
   });
 
-  it('the rendered remediate template gets the task re-mint from the one definition', () => {
+  it('the rendered remediate template gets the task re-mint and the landing mint from the one definition', () => {
     const content = fs.readFileSync(path.join(WORKFLOWS, 'dxkit-remediate.yml'), 'utf8');
     const rendered = renderForParse(content);
     expect(rendered).toContain(LANE_TOKEN_TASK_STEPS);
+    expect(rendered).toContain(LANE_TOKEN_LAND_STEPS);
     expect(rendered).toContain(`vars.${LANE_TOKEN_APP_ID_VARIABLE_NAME}`);
     expect(rendered).toContain(`secrets.${LANE_TOKEN_APP_KEY_SECRET_NAME}`);
   });

--- a/test/templates-lane-tokens.test.ts
+++ b/test/templates-lane-tokens.test.ts
@@ -264,9 +264,11 @@ describe('workflow-template token discipline', () => {
     };
     expect(parsed.jobs.j.steps).toHaveLength(1);
     expect(parsed.jobs.j.steps[0].id).toBe('dxkit-app-token-land');
-    // always(): a salvage/draft record written by a FAILED task step must
-    // still get a fresh credential to land under.
-    expect(String(parsed.jobs.j.steps[0].if)).toContain('always()');
+    // !cancelled(): a salvage/draft record written by a FAILED task step
+    // must still get a fresh credential to land under, while an operator
+    // ABORT (cancellation) must not mint and push (always() would).
+    expect(String(parsed.jobs.j.steps[0].if)).toContain('!cancelled()');
+    expect(String(parsed.jobs.j.steps[0].if)).not.toContain('always()');
   });
 
   it('SYNTHETIC INJECTION: the content-derived membership check bites', () => {
@@ -362,8 +364,9 @@ describe('workflow-template token discipline', () => {
     // never hand-copied.
     expect(content).toContain('__DXKIT_LANE_TOKEN_LAND_STEPS__');
     expect(content).toContain('GH_TOKEN: __DXKIT_LANE_TOKEN_LAND__');
-    // The land step runs `remediate land`, is always()-guarded (a failed
-    // task's salvage record still lands), and skips disclosed on no record.
+    // The land step runs `remediate land`, is !cancelled()-guarded (a
+    // failed task's salvage record still lands; an operator abort does not
+    // push), and skips disclosed on no record.
     expect(content).toContain('remediate land --task');
     expect(content).toContain('no landing record for');
     // Ordering over the RENDERED content: task step → landing mint →


### PR DESCRIPTION
## What / why (defect A1, run 33116991323)

GitHub App installation tokens are hard-capped at one hour, and the remediate task's verify phases scale with repo size (repeated frozen installs + the guardrail + import graph took ~50 min on a large tree). On the first organic run the landing push fired 68 minutes after mint: 401, git prompt fallback, "could not read Username". Landing, salvage draft, and the order-outcome ledger pushes all failed, and the circuit breaker went blind. The existing `APP_TOKEN_SAFE_MINUTES=45` clamp bounded only the agent wall clock, which was ~6 of those 68 minutes: it bounds the wrong thing and can never bound the verify tail.

Root fix: **credential freshness becomes independent of task duration** (two-phase landing).

- **Landing record, deferred mode** (`src/remediate/landing-record.ts`, `src/remediate/defer.ts`): when the workflow signals `DXKIT_DEFERRED_LANDING=1` on the task step, the executor performs everything up to and including verification + PR-body assembly, then writes ONE record under `.dxkit/cache/` (task, standing branch, verified head, base branch, PR title/body, draft flag, delivery-ledger path, this run's order-outcome rows) instead of pushing. The salvage draft defers through the SAME record (draft flag), one code path. Non-landing outcomes defer their order rows the same way, so the breaker's evidence also rides the fresh credential. Local/inline runs (no env) keep the current immediate landing through the same `landRemediateHead`. Disclosed in the output, ledger JSON, and attempt record, never silent.
- **`remediate land --task <t>`** (`src/remediate/land-cli.ts`): reads the record, VALIDATES it (schema, task match, recomputed standing branch, hex shas, safe repo-relative ledger paths, ref-shaped base branch: the `remote-ref.ts` argument-injection discipline), refuses when HEAD is not the recorded verified head (never pushes stale or foreign commits, remedy named), composes the order ledger against the standing branch under the fresh credential, then pushes + opens/updates the standing PR through the existing `land.ts` / `openOrUpdateStandingPr` primitives. The order-outcome push (previously `publishOrderRows` at task time) moves under this step for deferred runs: one push home. Idempotent (success clears the record; a re-run is a disclosed no-op); a failed push keeps the record for retry and exits non-zero. It executes NOTHING from the tree.
- **Workflow template** (`src-templates/.github/workflows/dxkit-remediate.yml` via `installWorkflow`, Rule 15): the task step sets the deferred env; a new post-task step mints the App token FRESH (`LANE_TOKEN_LAND_STEPS` + `__DXKIT_LANE_TOKEN_LAND__`, extending the one lane-token definition per its placeholder law), installs the landing credential (same single-writer discipline: unset-all, one-header assertion, ls-remote proof), and runs `remediate land`. It is `always()`-guarded so a failed task's salvage record still lands, and guarded on record existence so the skip is disclosed and a job that died before checkout stays quiet. The attempt-diff artifact upload stays, after the land step, and reads the attempt record the land step patches.
- **Budget clamp re-derived** (`budget-notes.ts`): see below.

## Budget-clamp reasoning (brief item 4)

With landing decoupled, the app-tier 45-minute agent clamp loses its stated reason, so I re-derived it per landing mode rather than deleting it outright:

- **Deferred landing signaled** (the current template): NO clamp. The delivery credential is minted by its own step at delivery time, and the verify tail was never boundable by an agent clamp anyway. Residual in-run credential uses (a resume fetch at run start, a branch-ledger read, a private git-pinned dependency during a verify install) are all fail-open with their own disclosures; none justifies capping the agent. The tier is still disclosed in the ledger via a note.
- **App tier without the signal** (an OLDER installed workflow that still lands inline with the task-time token): the clamp keeps its original reason and stays, with the disclosure now naming `vyuh-dxkit update` (which refreshes the template to two-phase landing) as the first remedy. Retiring it unconditionally would have silently reintroduced the 401-at-landing class on every not-yet-updated install.

## How it is tested

New `test/remediate/two-phase-landing.test.ts` (18 tests, injected exec/seams throughout, no network):

- record write/read/validate round trip; tampered/foreign records refused before any spawn (redirected branch, non-hex head, traversal + absolute ledger paths, flag-shaped base branch, unknown action, foreign schema, wrong task, invalid requested task id);
- executor both directions: env set => no push attempted (lander, row publisher, ledger composer all unspawned), one record written with the assembled PR title/body/draft + rows; env absent => inline landing byte-for-byte unchanged, no record;
- salvage draft defers through the same record with `draft: true`; a non-landing outcome defers its rows as a `publish-rows` record;
- land CLI: full executor-record round trip (validate HEAD, compose rows at land time, push, patch the attempt record, clear the record, idempotent re-run), stale-head refusal (no push, record kept), tampered-record refusal, failed-push disclosure with retryable record + head-advance over the lander's bookkeeping commit, publish-rows success/failure both directions.

Extended pins: `test/remediate/config-budgets.test.ts` (clamp lifted + note under the deferred signal; clamp kept for older workflows) and `test/templates-lane-tokens.test.ts` (content-derived: land placeholders render from the one definition, the land mint parses standalone with its `always()` guard, the deferred env name matches the CLI constant, `remediate land` added to the gh-shelling command set, ordering task -> land mint -> land step -> attempt-diff collection; no filename lists). Existing executor/landing/order-ledger suites unchanged and green.

## Sweep + guardrail

- `npm run typecheck` / `typecheck:test`: PASS
- `npx eslint . --max-warnings 0`: PASS
- `npx prettier --check .`: PASS
- `bash scripts/check-architecture.sh`: PASS
- `bash scripts/check-docs-coverage.sh`: PASS (11 languages x 3 anchors)
- `DXKIT_SLOP_BASE=origin/main bash scripts/check-slop.sh`: PASS
- `npm run build`: PASS
- `npx vitest run --coverage`: 421 files, 6345 tests, all PASS; coverage 74.89% (threshold 50%), `check-coverage.sh` PASS
- `node dist/index.js guardrail check --mode ref-based --ref origin/main`: **PASSED, exit 0** (an interim run flagged `execute.ts` crossing the 500-line large-file bar; resolved by splitting the deferral layer to `src/remediate/defer.ts`, the plan-cli/attempt-record module-size precedent, and the final run is clean)

## Review focus

- `src/remediate/execute.ts`: the deferral seams sit exactly where the inline pushes were; check that every push path (landing, publish-rows in all three call sites, the landing-failure catch) is covered under the deferred flag and that `clean` semantics match the inline path.
- `src/remediate/land-cli.ts` head-gate and the failed-push head-advance: the retry accepts only a head this step itself observed after its own bookkeeping commit; confirm that cannot be used to launder a foreign commit (the record is local mutable state, but writing it requires the same access as pushing).
- `budget-notes.ts`: the mode-conditional clamp (older workflows keep it; is the `vyuh-dxkit update` remedy the right first advice?).
- Template step ordering and the `always()` guards: a job that fails before checkout must stay quiet; a failed task with a salvage record must still land.
- Rule 16: `remediate land` is a subcommand of the already-registered `remediate` command (like `remediate plan` / `configured`), so it rides that descriptor; the registry has no per-subcommand entries and adding a second `remediate` id would break id uniqueness. Kept out of the user-facing docsBlurb deliberately (lane plumbing), documented in the command doc's lane-token section instead.

## Deliberately left out

- No CHANGELOG/version bump (the release-prep unit owns those, per the build brief).
- No live-fire workflow run: the design doc requires the landing leg validated under Actions with the App tier as part of the release proof run; this unit ships the mechanism + local pins.
- `remediate land` takes no `--force`/override for a stale head on purpose: the only honest remedy is a re-verifying re-run, and an override flag would be a standing invitation to push unverified commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
