### PR TITLE
feat(remediate): guardrail-red containment per order (4.4.7 D2)

### DIFF
--- a/src/lanes/verify.ts
+++ b/src/lanes/verify.ts
@@ -46,6 +46,27 @@ export interface GuardrailGateResult {
    *  ephemeral runner is inspectable from the ledger alone (the
    *  uninspectable-attempt defect). Absent when nothing blocked. */
   readonly blocking?: readonly string[];
+  /**
+   * Structured projections of EVERY blocking finding (uncapped, unlike the
+   * display list above): what the remediate lane's guardrail-red
+   * containment attributes to orders (4.4.7). Attribution is a cause claim
+   * (Rule 19), so it needs the finding's own coordinates (file, package),
+   * never a re-parse of the display string. Absent when nothing blocked or
+   * when the verdict came from a shape with no findings (deferred,
+   * unavailable, not consulted).
+   */
+  readonly blockingFindings?: readonly BlockingFinding[];
+}
+
+/** One blocking finding, projected for per-order attribution. */
+export interface BlockingFinding {
+  readonly kind: string;
+  /** The same compact line the display list carries. */
+  readonly description: string;
+  /** Repo-relative file, when the finding is located. */
+  readonly file?: string;
+  /** Package name, when the finding is package-shaped (dep-vuln, license). */
+  readonly package?: string;
 }
 
 /** Cap on the per-lane blocking-finding list — evidence, not a full report. */
@@ -72,26 +93,45 @@ export async function guardrailVerdictFor(
     const blockingPairs = result.pairs.filter(
       (p) => p.classification.blocks && p.suppressedByAllowlist === undefined,
     );
-    const blocking = blockingPairs.slice(0, BLOCKING_SUMMARY_CAP).map((p) => {
-      // Per-finding reason codes ride the line: the #25 investigation had to
-      // read SOURCE to learn why six findings blocked, because the lane's
-      // list gave a kind + path and nothing else. The codes are the
-      // classifier's own (`no-prior-match`, `block-rule`, …), compact enough
-      // for a ledger row while making the verdict auditable from the run.
+    // Per-finding reason codes ride the line: the #25 investigation had to
+    // read SOURCE to learn why six findings blocked, because the lane's
+    // list gave a kind + path and nothing else. The codes are the
+    // classifier's own (`no-prior-match`, `block-rule`, …), compact enough
+    // for a ledger row while making the verdict auditable from the run.
+    const describeBlockingPair = (p: (typeof blockingPairs)[number]): string => {
       const codes = p.classification.reasons.map((r) => r.code).join(', ');
       return (
         `[${p.kind}] ${p.locator ?? p.file ?? '(no locator)'} — ` +
         `${p.classification.status}${codes ? ` (${codes})` : ''}`
       );
-    });
+    };
+    const blocking = blockingPairs.slice(0, BLOCKING_SUMMARY_CAP).map(describeBlockingPair);
     if (blockingPairs.length > BLOCKING_SUMMARY_CAP) {
       blocking.push(`… and ${blockingPairs.length - BLOCKING_SUMMARY_CAP} more`);
     }
+    // The structured, UNCAPPED projection for guardrail-red containment:
+    // the package comes from the anchor entry itself (the current scan's
+    // finding), never parsed back out of the display locator.
+    const currentById = new Map(result.current.findings.map((f) => [f.id, f] as const));
+    const blockingFindings: BlockingFinding[] = blockingPairs.map((p) => {
+      const entry = p.pair.currentId ? currentById.get(p.pair.currentId) : undefined;
+      const pkg =
+        entry && 'package' in entry && typeof entry.package === 'string'
+          ? entry.package
+          : undefined;
+      return {
+        kind: p.kind,
+        description: describeBlockingPair(p),
+        ...(p.file !== undefined ? { file: p.file } : {}),
+        ...(pkg !== undefined ? { package: pkg } : {}),
+      };
+    });
     return {
       verdict: counts.verdict,
       ran: true,
       passesGate: counts.exitCode === 0,
       ...(blocking.length > 0 ? { blocking } : {}),
+      ...(blockingFindings.length > 0 ? { blockingFindings } : {}),
     };
   } catch (e) {
     return {

--- a/src/remediate/containment-attribution.ts
+++ b/src/remediate/containment-attribution.ts
@@ -1,0 +1,214 @@
+/**
+ * Guardrail-red containment, the ATTRIBUTION half (4.4.7), split from
+ * `containment.ts` at the module-size bar (the orders-phase /
+ * orders-complete precedent): the kept-unit shape, the tiered overlap
+ * evidence, the Rule 19 attribution ladder, and the kept-head chain
+ * reconstruction. The engine (`containment.ts`) is the only production
+ * consumer and re-exports everything, so callers keep one import surface.
+ */
+import type { BlockingFinding, GuardrailGateResult } from '../lanes/verify';
+import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
+import { pathInEnvelope } from './recipes/envelope';
+import type { RecipePhaseSummary } from './recipes/run-recipes';
+import type { OrderRunRecord, RemediateGit } from './outcome';
+import type { WorkOrder, WorkOrderEnvelope } from './work-orders/types';
+import { packagesNamedBy } from './work-orders/shared';
+
+/** One kept unit of the landed head: a kept agent order, or the kept
+ *  recipe group as a whole (the 4.4.6 drop granularity). */
+export interface KeptUnit {
+  readonly unit: 'agent-order' | 'recipe-group';
+  readonly orderIds: readonly string[];
+  /** The unit's commit range on the branch (`from..to`). */
+  readonly from: string;
+  readonly to: string;
+  /** Repo-relative paths the unit's commits changed. */
+  readonly diffPaths: readonly string[];
+  /** The order's envelope (agent orders; the recipe group attributes on
+   *  its committed diff alone). */
+  readonly envelope?: WorkOrderEnvelope;
+  /** Packages the order's findings name (dep-advisory evidence). */
+  readonly packages: ReadonlySet<string>;
+  /** The driver reported this order's run failed or was cut short; its
+   *  committed partial verified, but it is first in line for attribution. */
+  readonly driverFailed: boolean;
+}
+
+export interface ContainmentArgs {
+  readonly git: RemediateGit;
+  readonly baseHead: string;
+  /** HEAD after the recipe tier (the chain sanity check needs it). */
+  readonly agentBase: string;
+  readonly entryFloor: CorrectnessFloorResult;
+  readonly runFloor: () => CorrectnessFloorResult;
+  readonly recipes: RecipePhaseSummary;
+  readonly records: readonly OrderRunRecord[];
+  /** The dispatched work orders, by id (envelope + package evidence). */
+  readonly ordersById: ReadonlyMap<string, WorkOrder>;
+  /** The red final-guardrail result being contained. */
+  readonly guardrail: GuardrailGateResult;
+  readonly isManifestPath: (p: string) => boolean;
+}
+
+/** Overlap evidence between one blocking finding and one kept unit, with
+ *  its STRENGTH tier, or null when they do not overlap. Tier 1 (direct):
+ *  the order names the finding's package, or its committed diff touches
+ *  the finding's file. Tier 2 (circumstantial): the file merely sits
+ *  inside the order envelope, or a package-shaped finding meets the
+ *  manifest heuristic. The tiers exist because a repo-wide envelope (a
+ *  whole-build floor order) overlaps EVERY located finding; without
+ *  ranking, that circumstantial overlap plus the driver tiebreak could
+ *  outvote the order whose diff actually touched the file. */
+export interface OverlapEvidence {
+  /** Lower is stronger: 1 = direct (package name / diff touch), 2 =
+   *  circumstantial (envelope containment / manifest heuristic). */
+  readonly tier: 1 | 2;
+  readonly evidence: string;
+}
+
+export function overlapEvidence(
+  f: BlockingFinding,
+  u: KeptUnit,
+  isManifestPath: (p: string) => boolean,
+): OverlapEvidence | null {
+  if (f.package !== undefined && u.packages.has(f.package)) {
+    return { tier: 1, evidence: `the order names package ${f.package}` };
+  }
+  if (f.file !== undefined) {
+    if (u.diffPaths.includes(f.file)) {
+      return { tier: 1, evidence: `the committed diff touches ${f.file}` };
+    }
+    if (u.envelope && pathInEnvelope(f.file, u.envelope)) {
+      return { tier: 2, evidence: `${f.file} is inside the order envelope` };
+    }
+    return null;
+  }
+  if (f.package !== undefined) {
+    // A package-shaped finding with no file: any unit that changed the
+    // dependency graph is a candidate (a pin can pull a transitive
+    // advisory in). Circumstantial, so a tier-1 package naming anywhere
+    // outranks it.
+    if (u.diffPaths.some(isManifestPath)) {
+      return { tier: 2, evidence: 'the committed diff touches a dependency manifest' };
+    }
+    if (u.envelope?.manifests === true) {
+      return { tier: 2, evidence: 'the order envelope allows manifest changes' };
+    }
+    return null;
+  }
+  return null;
+}
+
+export type FindingAttribution =
+  | { readonly kind: 'attributed'; readonly unit: KeptUnit; readonly evidence: string }
+  | { readonly kind: 'ambiguous'; readonly units: readonly KeptUnit[] }
+  | { readonly kind: 'unattributed' };
+
+/**
+ * Attribute ONE blocking finding to ONE kept unit, or say why it cannot be
+ * (Rule 19). Evidence STRENGTH decides first: when any tier-1 (direct)
+ * candidate exists, every tier-2 (circumstantial) candidate is out of the
+ * running. Only WITHIN the surviving tier do the narrowing steps apply:
+ * the unit(s) naming the finding's package, then a driver-failed unit
+ * over verified ones. A tiebreak must never beat evidence.
+ */
+export function attributeFinding(
+  f: BlockingFinding,
+  units: readonly KeptUnit[],
+  isManifestPath: (p: string) => boolean,
+): FindingAttribution {
+  const candidates = units
+    .map((u) => ({ u, o: overlapEvidence(f, u, isManifestPath) }))
+    .filter((c): c is { u: KeptUnit; o: OverlapEvidence } => c.o !== null);
+  if (candidates.length === 0) return { kind: 'unattributed' };
+  const bestTier = Math.min(...candidates.map((c) => c.o.tier));
+  let pool = candidates.filter((c) => c.o.tier === bestTier);
+  const notes: string[] = [];
+  if (pool.length < candidates.length) {
+    notes.push('direct evidence outranked envelope-level overlap on other orders');
+  }
+  const pkg = f.package;
+  if (pool.length > 1 && pkg !== undefined) {
+    const named = pool.filter((c) => c.u.packages.has(pkg));
+    if (named.length > 0 && named.length < pool.length) {
+      pool = named;
+      notes.push(`narrowed to the order(s) naming package ${pkg}`);
+    }
+  }
+  if (pool.length > 1) {
+    const failed = pool.filter((c) => c.u.driverFailed);
+    if (failed.length > 0 && failed.length < pool.length) {
+      pool = failed;
+      notes.push('driver-failed order preferred over verified ones (the ambiguity tiebreak)');
+    }
+  }
+  if (pool.length === 1) {
+    return {
+      kind: 'attributed',
+      unit: pool[0].u,
+      evidence: [pool[0].o.evidence, ...notes].join('; '),
+    };
+  }
+  return { kind: 'ambiguous', units: pool.map((c) => c.u) };
+}
+
+/**
+ * Reconstruct the kept units' commit ranges from the chained kept
+ * dispositions (each drop reset to the previously verified head, so the
+ * kept heads chain from `baseHead` to the verified head). A chain that
+ * does not close is a string (the refusal reason): containment never
+ * reverts ranges it cannot trust.
+ */
+export function buildKeptUnits(c: ContainmentArgs): KeptUnit[] | string {
+  const units: KeptUnit[] = [];
+  let prev = c.baseHead;
+  const gv = c.recipes.groupVerification;
+  if (gv?.kind === 'kept') {
+    const applied = c.recipes.records.filter((r) => r.outcome.kind === 'applied');
+    units.push({
+      unit: 'recipe-group',
+      orderIds: applied.map((r) => r.orderId),
+      from: prev,
+      to: gv.head,
+      diffPaths: c.git.changedPaths(prev, gv.head),
+      // The packages the group's applied orders name (recorded per record
+      // by the recipe executor): a red on a package the RECIPE pinned must
+      // attribute to the group on tier-1 evidence, never fall through to a
+      // driver tiebreak that blames an innocent agent order.
+      packages: new Set(applied.flatMap((r) => r.packages ?? [])),
+      driverFailed: false,
+    });
+    prev = gv.head;
+  } else if (gv === undefined && c.agentBase !== c.baseHead) {
+    return (
+      'recipe commits exist without a per-group verification record, so the per-order ' +
+      'commit ranges cannot be reconstructed'
+    );
+  }
+  for (const rec of c.records) {
+    if (rec.disposition?.kind !== 'kept') continue;
+    const order = c.ordersById.get(rec.orderId);
+    if (!order) {
+      return `no work order is in scope for kept record ${rec.orderId}, so its range cannot be attributed`;
+    }
+    units.push({
+      unit: 'agent-order',
+      orderIds: [rec.orderId],
+      from: prev,
+      to: rec.disposition.head,
+      diffPaths: c.git.changedPaths(prev, rec.disposition.head),
+      envelope: order.envelope,
+      packages: new Set(packagesNamedBy(order.findings)),
+      driverFailed: rec.outcome === 'failed' || rec.outcome === 'partial',
+    });
+    prev = rec.disposition.head;
+  }
+  const head = c.git.head();
+  if (prev !== head) {
+    return (
+      `the kept orders' commit chain ends at ${prev} but the verified head is ${head}, ` +
+      'so the per-order ranges cannot be trusted'
+    );
+  }
+  return units;
+}

--- a/src/remediate/containment.ts
+++ b/src/remediate/containment.ts
@@ -41,23 +41,47 @@
  * plain guardrail-red path (salvage draft of the full attempt, negative
  * constraints for the next run) sees exactly the tree it always saw.
  */
-import type { BlockingFinding, GuardrailGateResult } from '../lanes/verify';
+import type { GuardrailGateResult } from '../lanes/verify';
 import type { VerifyTreeResult } from '../lanes/verify-tree';
 import { detectActiveLanguages, dependencyManifestFilesIn } from '../languages';
-import { pathInEnvelope } from './recipes/envelope';
 import type { RecipePhaseSummary } from './recipes/run-recipes';
 import { verifyCommittedHead } from './verify';
-import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
 import type {
   ContainedDrop,
   GuardrailContainment,
   OrderRunRecord,
-  RemediateGit,
   RemediateRunOptions,
 } from './outcome';
-import type { WorkOrder, WorkOrderEnvelope } from './work-orders/types';
+import {
+  attributeFinding,
+  buildKeptUnits,
+  type ContainmentArgs,
+  type KeptUnit,
+} from './containment-attribution';
 
-/** The bound on unwind rounds: small and disclosed, never open-ended. */
+// The attribution half lives in `./containment-attribution` (module-size
+// split); re-exported so consumers keep one import surface.
+export {
+  attributeFinding,
+  buildKeptUnits,
+  overlapEvidence,
+  type ContainmentArgs,
+  type FindingAttribution,
+  type KeptUnit,
+  type OverlapEvidence,
+} from './containment-attribution';
+
+/**
+ * The bound on unwind rounds: small and disclosed, never open-ended. A
+ * known consequence of the per-round reverts: two kept units sharing
+ * lockfile hunks will usually CONFLICT on the round-2 revert of the
+ * second unit (round 1 already rewrote the shared hunks), and that
+ * conflict refuses containment honestly, a bounded refusal rather than a
+ * mangled tree. A future refinement could attribute ALL blocking findings
+ * first and drop every attributed unit in a single round across tiers,
+ * avoiding the sequential-revert conflict; deliberately not implemented
+ * here.
+ */
 export const MAX_CONTAINMENT_ROUNDS = 2;
 
 /** Cap on blocking-finding descriptions carried per dropped unit. */
@@ -83,42 +107,6 @@ export function manifestPathProbe(
   };
 }
 
-/** One kept unit of the landed head: a kept agent order, or the kept
- *  recipe group as a whole (the 4.4.6 drop granularity). */
-export interface KeptUnit {
-  readonly unit: 'agent-order' | 'recipe-group';
-  readonly orderIds: readonly string[];
-  /** The unit's commit range on the branch (`from..to`). */
-  readonly from: string;
-  readonly to: string;
-  /** Repo-relative paths the unit's commits changed. */
-  readonly diffPaths: readonly string[];
-  /** The order's envelope (agent orders; the recipe group attributes on
-   *  its committed diff alone). */
-  readonly envelope?: WorkOrderEnvelope;
-  /** Packages the order's findings name (dep-advisory evidence). */
-  readonly packages: ReadonlySet<string>;
-  /** The driver reported this order's run failed or was cut short; its
-   *  committed partial verified, but it is first in line for attribution. */
-  readonly driverFailed: boolean;
-}
-
-export interface ContainmentArgs {
-  readonly git: RemediateGit;
-  readonly baseHead: string;
-  /** HEAD after the recipe tier (the chain sanity check needs it). */
-  readonly agentBase: string;
-  readonly entryFloor: CorrectnessFloorResult;
-  readonly runFloor: () => CorrectnessFloorResult;
-  readonly recipes: RecipePhaseSummary;
-  readonly records: readonly OrderRunRecord[];
-  /** The dispatched work orders, by id (envelope + package evidence). */
-  readonly ordersById: ReadonlyMap<string, WorkOrder>;
-  /** The red final-guardrail result being contained. */
-  readonly guardrail: GuardrailGateResult;
-  readonly isManifestPath: (p: string) => boolean;
-}
-
 export type ContainmentOutcome =
   | {
       readonly kind: 'contained';
@@ -135,147 +123,6 @@ export type ContainmentOutcome =
       readonly head: string;
     }
   | { readonly kind: 'refused'; readonly containment: GuardrailContainment };
-
-/** Overlap evidence between one blocking finding and one kept unit, or
- *  null when they do not overlap. */
-export function overlapEvidence(
-  f: BlockingFinding,
-  u: KeptUnit,
-  isManifestPath: (p: string) => boolean,
-): string | null {
-  if (f.package !== undefined && u.packages.has(f.package)) {
-    return `the order names package ${f.package}`;
-  }
-  if (f.file !== undefined) {
-    if (u.diffPaths.includes(f.file)) return `the committed diff touches ${f.file}`;
-    if (u.envelope && pathInEnvelope(f.file, u.envelope)) {
-      return `${f.file} is inside the order envelope`;
-    }
-    return null;
-  }
-  if (f.package !== undefined) {
-    // A package-shaped finding with no file: any unit that changed the
-    // dependency graph is a candidate (a pin can pull a transitive
-    // advisory in), narrowed below by the package-name and driver tiers.
-    if (u.diffPaths.some(isManifestPath)) return 'the committed diff touches a dependency manifest';
-    if (u.envelope?.manifests === true) return 'the order envelope allows manifest changes';
-    return null;
-  }
-  return null;
-}
-
-export type FindingAttribution =
-  | { readonly kind: 'attributed'; readonly unit: KeptUnit; readonly evidence: string }
-  | { readonly kind: 'ambiguous'; readonly units: readonly KeptUnit[] }
-  | { readonly kind: 'unattributed' };
-
-/**
- * Attribute ONE blocking finding to ONE kept unit, or say why it cannot be
- * (Rule 19). Narrowing ladder on ambiguity: the unit(s) naming the
- * finding's package first, then a driver-failed unit over verified ones.
- */
-export function attributeFinding(
-  f: BlockingFinding,
-  units: readonly KeptUnit[],
-  isManifestPath: (p: string) => boolean,
-): FindingAttribution {
-  const candidates = units
-    .map((u) => ({ u, evidence: overlapEvidence(f, u, isManifestPath) }))
-    .filter((c): c is { u: KeptUnit; evidence: string } => c.evidence !== null);
-  if (candidates.length === 0) return { kind: 'unattributed' };
-  let pool = candidates;
-  const notes: string[] = [];
-  const pkg = f.package;
-  if (pool.length > 1 && pkg !== undefined) {
-    const named = pool.filter((c) => c.u.packages.has(pkg));
-    if (named.length > 0 && named.length < pool.length) {
-      pool = named;
-      notes.push(`narrowed to the order(s) naming package ${pkg}`);
-    }
-  }
-  if (pool.length > 1) {
-    const failed = pool.filter((c) => c.u.driverFailed);
-    if (failed.length > 0 && failed.length < pool.length) {
-      pool = failed;
-      notes.push('driver-failed order preferred over verified ones (the ambiguity tiebreak)');
-    }
-  }
-  if (pool.length === 1) {
-    return {
-      kind: 'attributed',
-      unit: pool[0].u,
-      evidence: [pool[0].evidence, ...notes].join('; '),
-    };
-  }
-  return { kind: 'ambiguous', units: pool.map((c) => c.u) };
-}
-
-function packagesOf(order: WorkOrder): ReadonlySet<string> {
-  const out = new Set<string>();
-  for (const f of order.findings) {
-    if (f.evidence.type === 'dep-vuln') out.add(f.evidence.package);
-  }
-  return out;
-}
-
-/**
- * Reconstruct the kept units' commit ranges from the chained kept
- * dispositions (each drop reset to the previously verified head, so the
- * kept heads chain from `baseHead` to the verified head). A chain that
- * does not close is a string (the refusal reason): containment never
- * reverts ranges it cannot trust.
- */
-export function buildKeptUnits(c: ContainmentArgs): KeptUnit[] | string {
-  const units: KeptUnit[] = [];
-  let prev = c.baseHead;
-  const gv = c.recipes.groupVerification;
-  if (gv?.kind === 'kept') {
-    const appliedIds = c.recipes.records
-      .filter((r) => r.outcome.kind === 'applied')
-      .map((r) => r.orderId);
-    units.push({
-      unit: 'recipe-group',
-      orderIds: appliedIds,
-      from: prev,
-      to: gv.head,
-      diffPaths: c.git.changedPaths(prev, gv.head),
-      packages: new Set(),
-      driverFailed: false,
-    });
-    prev = gv.head;
-  } else if (gv === undefined && c.agentBase !== c.baseHead) {
-    return (
-      'recipe commits exist without a per-group verification record, so the per-order ' +
-      'commit ranges cannot be reconstructed'
-    );
-  }
-  for (const rec of c.records) {
-    if (rec.disposition?.kind !== 'kept') continue;
-    const order = c.ordersById.get(rec.orderId);
-    if (!order) {
-      return `no work order is in scope for kept record ${rec.orderId}, so its range cannot be attributed`;
-    }
-    units.push({
-      unit: 'agent-order',
-      orderIds: [rec.orderId],
-      from: prev,
-      to: rec.disposition.head,
-      diffPaths: c.git.changedPaths(prev, rec.disposition.head),
-      envelope: order.envelope,
-      packages: packagesOf(order),
-      driverFailed: rec.outcome === 'failed' || rec.outcome === 'partial',
-    });
-    prev = rec.disposition.head;
-  }
-  const head = c.git.head();
-  if (prev !== head) {
-    return (
-      `the kept orders' commit chain ends at ${prev} but the verified head is ${head}, ` +
-      'so the per-order ranges cannot be trusted'
-    );
-  }
-  return units;
-}
 
 function containmentReason(blocking: readonly string[], round: number): string {
   const shown = blocking.slice(0, DROP_EVIDENCE_CAP);
@@ -302,10 +149,12 @@ export async function containGuardrailRed(
 
   const refuse = (reason: string): ContainmentOutcome => {
     let restoreNote = '';
+    let restoreFailed = false;
     if (c.git.head() !== originalHead) {
       try {
         c.git.resetTo(originalHead);
       } catch (err) {
+        restoreFailed = true;
         restoreNote =
           `; restoring the branch to ${originalHead} also failed ` +
           `(${err instanceof Error ? err.message.split('\n')[0] : String(err)}), the branch ` +
@@ -319,6 +168,7 @@ export async function containGuardrailRed(
         rounds: roundsRun,
         dropped: [],
         refused: reason + restoreNote,
+        ...(restoreFailed ? { restoreFailed: true } : {}),
       },
     };
   };

--- a/src/remediate/containment.ts
+++ b/src/remediate/containment.ts
@@ -1,0 +1,485 @@
+/**
+ * Guardrail-red containment per order (4.4.7, defect A2).
+ *
+ * Per-order verification (4.4.6) is install + floor only; the guardrail
+ * arbitrates ONCE over the final combined tree. The live class: one
+ * agent-tier order left an in-envelope dependency pin whose advisory
+ * re-keyed as "added", the final guardrail went red, and the WHOLE run
+ * flipped to salvage-draft, dragging nine verified green recipe pins down
+ * with it. The unit of landing is the order, so a run-level guardrail
+ * verdict must not break that containment.
+ *
+ * The engine, invoked by `orders-complete.ts` when the final guardrail RAN
+ * and did not pass:
+ *
+ *   1. ATTRIBUTE each blocking finding to exactly one kept unit (a kept
+ *      agent order, or the kept recipe group as one unit, the 4.4.6 drop
+ *      granularity), on overlap evidence: the unit names the finding's
+ *      package, its committed diff touches the finding's file, the file is
+ *      inside the order's envelope, or (for a package-shaped finding) the
+ *      unit changed a dependency manifest. Ambiguity narrows first to the
+ *      unit(s) naming the package, then to a DRIVER-FAILED unit over
+ *      verified ones (the driver-failure hygiene policy: a driver-failed
+ *      order's committed partial is the first candidate). Rule 19: this is
+ *      a CAUSE claim: a finding that overlaps no unit, or stays ambiguous,
+ *      REFUSES containment for the whole run; an innocent order is never
+ *      dropped on a guess.
+ *   2. UNWIND the attributed units: each unit's commit range is reverted as
+ *      one commit at the tip (`RemediateGit.revertRange`, the per-order
+ *      revert granularity from 4.4.6, lifted off the tip so later kept
+ *      commits survive). A revert conflict refuses containment and
+ *      restores the branch.
+ *   3. RE-VERIFY the remainder through the ONE tree verification
+ *      (`verifyCommittedHead`: install + floor + the guardrail, the same
+ *      seam the run-level check uses, never a second invocation path).
+ *      Verified: contained. Still guardrail-red: another round, bounded by
+ *      `MAX_CONTAINMENT_ROUNDS` (small, disclosed). Anything else
+ *      (install-failed, floor-red, infrastructure): the unwound remainder
+ *      no longer verifies: refuse and restore.
+ *
+ * A refusal ALWAYS restores the branch to the pre-containment head, so the
+ * plain guardrail-red path (salvage draft of the full attempt, negative
+ * constraints for the next run) sees exactly the tree it always saw.
+ */
+import type { BlockingFinding, GuardrailGateResult } from '../lanes/verify';
+import type { VerifyTreeResult } from '../lanes/verify-tree';
+import { detectActiveLanguages, dependencyManifestFilesIn } from '../languages';
+import { pathInEnvelope } from './recipes/envelope';
+import type { RecipePhaseSummary } from './recipes/run-recipes';
+import { verifyCommittedHead } from './verify';
+import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
+import type {
+  ContainedDrop,
+  GuardrailContainment,
+  OrderRunRecord,
+  RemediateGit,
+  RemediateRunOptions,
+} from './outcome';
+import type { WorkOrder, WorkOrderEnvelope } from './work-orders/types';
+
+/** The bound on unwind rounds: small and disclosed, never open-ended. */
+export const MAX_CONTAINMENT_ROUNDS = 2;
+
+/** Cap on blocking-finding descriptions carried per dropped unit. */
+const DROP_EVIDENCE_CAP = 5;
+
+/**
+ * The lazy pack-declared manifest-path probe both the orders phase and the
+ * containment engine consult (Rule 6: manifest patterns come from the
+ * packs). `injected` is the test seam; production derives from the active
+ * packs on first use.
+ */
+export function manifestPathProbe(
+  cwd: string,
+  injected?: (p: string) => boolean,
+): (p: string) => boolean {
+  let probe = injected;
+  return (p: string): boolean => {
+    if (!probe) {
+      const packs = detectActiveLanguages(cwd);
+      probe = (x) => dependencyManifestFilesIn([x], packs).length > 0;
+    }
+    return probe(p);
+  };
+}
+
+/** One kept unit of the landed head: a kept agent order, or the kept
+ *  recipe group as a whole (the 4.4.6 drop granularity). */
+export interface KeptUnit {
+  readonly unit: 'agent-order' | 'recipe-group';
+  readonly orderIds: readonly string[];
+  /** The unit's commit range on the branch (`from..to`). */
+  readonly from: string;
+  readonly to: string;
+  /** Repo-relative paths the unit's commits changed. */
+  readonly diffPaths: readonly string[];
+  /** The order's envelope (agent orders; the recipe group attributes on
+   *  its committed diff alone). */
+  readonly envelope?: WorkOrderEnvelope;
+  /** Packages the order's findings name (dep-advisory evidence). */
+  readonly packages: ReadonlySet<string>;
+  /** The driver reported this order's run failed or was cut short; its
+   *  committed partial verified, but it is first in line for attribution. */
+  readonly driverFailed: boolean;
+}
+
+export interface ContainmentArgs {
+  readonly git: RemediateGit;
+  readonly baseHead: string;
+  /** HEAD after the recipe tier (the chain sanity check needs it). */
+  readonly agentBase: string;
+  readonly entryFloor: CorrectnessFloorResult;
+  readonly runFloor: () => CorrectnessFloorResult;
+  readonly recipes: RecipePhaseSummary;
+  readonly records: readonly OrderRunRecord[];
+  /** The dispatched work orders, by id (envelope + package evidence). */
+  readonly ordersById: ReadonlyMap<string, WorkOrder>;
+  /** The red final-guardrail result being contained. */
+  readonly guardrail: GuardrailGateResult;
+  readonly isManifestPath: (p: string) => boolean;
+}
+
+export type ContainmentOutcome =
+  | {
+      readonly kind: 'contained';
+      readonly containment: GuardrailContainment;
+      /** Records with the attributed orders' dispositions flipped to
+       *  `dropped` at step `guardrail`. */
+      readonly records: readonly OrderRunRecord[];
+      /** The recipe summary, group verification flipped when the group was
+       *  dropped by containment. */
+      readonly recipes: RecipePhaseSummary;
+      /** The final round's verification of the remainder. */
+      readonly verified: VerifyTreeResult;
+      readonly guardrail: GuardrailGateResult;
+      readonly head: string;
+    }
+  | { readonly kind: 'refused'; readonly containment: GuardrailContainment };
+
+/** Overlap evidence between one blocking finding and one kept unit, or
+ *  null when they do not overlap. */
+export function overlapEvidence(
+  f: BlockingFinding,
+  u: KeptUnit,
+  isManifestPath: (p: string) => boolean,
+): string | null {
+  if (f.package !== undefined && u.packages.has(f.package)) {
+    return `the order names package ${f.package}`;
+  }
+  if (f.file !== undefined) {
+    if (u.diffPaths.includes(f.file)) return `the committed diff touches ${f.file}`;
+    if (u.envelope && pathInEnvelope(f.file, u.envelope)) {
+      return `${f.file} is inside the order envelope`;
+    }
+    return null;
+  }
+  if (f.package !== undefined) {
+    // A package-shaped finding with no file: any unit that changed the
+    // dependency graph is a candidate (a pin can pull a transitive
+    // advisory in), narrowed below by the package-name and driver tiers.
+    if (u.diffPaths.some(isManifestPath)) return 'the committed diff touches a dependency manifest';
+    if (u.envelope?.manifests === true) return 'the order envelope allows manifest changes';
+    return null;
+  }
+  return null;
+}
+
+export type FindingAttribution =
+  | { readonly kind: 'attributed'; readonly unit: KeptUnit; readonly evidence: string }
+  | { readonly kind: 'ambiguous'; readonly units: readonly KeptUnit[] }
+  | { readonly kind: 'unattributed' };
+
+/**
+ * Attribute ONE blocking finding to ONE kept unit, or say why it cannot be
+ * (Rule 19). Narrowing ladder on ambiguity: the unit(s) naming the
+ * finding's package first, then a driver-failed unit over verified ones.
+ */
+export function attributeFinding(
+  f: BlockingFinding,
+  units: readonly KeptUnit[],
+  isManifestPath: (p: string) => boolean,
+): FindingAttribution {
+  const candidates = units
+    .map((u) => ({ u, evidence: overlapEvidence(f, u, isManifestPath) }))
+    .filter((c): c is { u: KeptUnit; evidence: string } => c.evidence !== null);
+  if (candidates.length === 0) return { kind: 'unattributed' };
+  let pool = candidates;
+  const notes: string[] = [];
+  const pkg = f.package;
+  if (pool.length > 1 && pkg !== undefined) {
+    const named = pool.filter((c) => c.u.packages.has(pkg));
+    if (named.length > 0 && named.length < pool.length) {
+      pool = named;
+      notes.push(`narrowed to the order(s) naming package ${pkg}`);
+    }
+  }
+  if (pool.length > 1) {
+    const failed = pool.filter((c) => c.u.driverFailed);
+    if (failed.length > 0 && failed.length < pool.length) {
+      pool = failed;
+      notes.push('driver-failed order preferred over verified ones (the ambiguity tiebreak)');
+    }
+  }
+  if (pool.length === 1) {
+    return {
+      kind: 'attributed',
+      unit: pool[0].u,
+      evidence: [pool[0].evidence, ...notes].join('; '),
+    };
+  }
+  return { kind: 'ambiguous', units: pool.map((c) => c.u) };
+}
+
+function packagesOf(order: WorkOrder): ReadonlySet<string> {
+  const out = new Set<string>();
+  for (const f of order.findings) {
+    if (f.evidence.type === 'dep-vuln') out.add(f.evidence.package);
+  }
+  return out;
+}
+
+/**
+ * Reconstruct the kept units' commit ranges from the chained kept
+ * dispositions (each drop reset to the previously verified head, so the
+ * kept heads chain from `baseHead` to the verified head). A chain that
+ * does not close is a string (the refusal reason): containment never
+ * reverts ranges it cannot trust.
+ */
+export function buildKeptUnits(c: ContainmentArgs): KeptUnit[] | string {
+  const units: KeptUnit[] = [];
+  let prev = c.baseHead;
+  const gv = c.recipes.groupVerification;
+  if (gv?.kind === 'kept') {
+    const appliedIds = c.recipes.records
+      .filter((r) => r.outcome.kind === 'applied')
+      .map((r) => r.orderId);
+    units.push({
+      unit: 'recipe-group',
+      orderIds: appliedIds,
+      from: prev,
+      to: gv.head,
+      diffPaths: c.git.changedPaths(prev, gv.head),
+      packages: new Set(),
+      driverFailed: false,
+    });
+    prev = gv.head;
+  } else if (gv === undefined && c.agentBase !== c.baseHead) {
+    return (
+      'recipe commits exist without a per-group verification record, so the per-order ' +
+      'commit ranges cannot be reconstructed'
+    );
+  }
+  for (const rec of c.records) {
+    if (rec.disposition?.kind !== 'kept') continue;
+    const order = c.ordersById.get(rec.orderId);
+    if (!order) {
+      return `no work order is in scope for kept record ${rec.orderId}, so its range cannot be attributed`;
+    }
+    units.push({
+      unit: 'agent-order',
+      orderIds: [rec.orderId],
+      from: prev,
+      to: rec.disposition.head,
+      diffPaths: c.git.changedPaths(prev, rec.disposition.head),
+      envelope: order.envelope,
+      packages: packagesOf(order),
+      driverFailed: rec.outcome === 'failed' || rec.outcome === 'partial',
+    });
+    prev = rec.disposition.head;
+  }
+  const head = c.git.head();
+  if (prev !== head) {
+    return (
+      `the kept orders' commit chain ends at ${prev} but the verified head is ${head}, ` +
+      'so the per-order ranges cannot be trusted'
+    );
+  }
+  return units;
+}
+
+function containmentReason(blocking: readonly string[], round: number): string {
+  const shown = blocking.slice(0, DROP_EVIDENCE_CAP);
+  const more = blocking.length - shown.length;
+  return (
+    `the final guardrail attributed blocking finding(s) to this order ` +
+    `(containment round ${round}): ${shown.join('; ')}` +
+    (more > 0 ? `; and ${more} more` : '')
+  );
+}
+
+/**
+ * Contain a red final guardrail: attribute, unwind, re-verify, bounded.
+ * Never throws; a refusal restores the branch and carries the reason.
+ */
+export async function containGuardrailRed(
+  opts: RemediateRunOptions,
+  c: ContainmentArgs,
+): Promise<ContainmentOutcome> {
+  const originalHead = c.git.head();
+  let roundsRun = 0;
+  const allDrops: ContainedDrop[] = [];
+  let recipeGroupDropped: { reason: string; orderIds: readonly string[] } | undefined;
+
+  const refuse = (reason: string): ContainmentOutcome => {
+    let restoreNote = '';
+    if (c.git.head() !== originalHead) {
+      try {
+        c.git.resetTo(originalHead);
+      } catch (err) {
+        restoreNote =
+          `; restoring the branch to ${originalHead} also failed ` +
+          `(${err instanceof Error ? err.message.split('\n')[0] : String(err)}), the branch ` +
+          'is left as-is for inspection';
+      }
+    }
+    return {
+      kind: 'refused',
+      containment: {
+        maxRounds: MAX_CONTAINMENT_ROUNDS,
+        rounds: roundsRun,
+        dropped: [],
+        refused: reason + restoreNote,
+      },
+    };
+  };
+
+  const built = buildKeptUnits(c);
+  if (typeof built === 'string') return refuse(built);
+  let units = built;
+  if (units.length === 0) return refuse('no kept order exists to attribute the red to');
+
+  let guardrail = c.guardrail;
+  let lastVerified: VerifyTreeResult | undefined;
+  for (let round = 1; round <= MAX_CONTAINMENT_ROUNDS; round++) {
+    const blocking = guardrail.blockingFindings ?? [];
+    if (blocking.length === 0) {
+      return refuse(
+        `the guardrail is red (${guardrail.verdict}) but reported no attributable blocking ` +
+          "findings (a refusal-tier verdict is never an order's fault)",
+      );
+    }
+    // Every blocking finding must attribute to exactly one unit, or the
+    // whole containment refuses: an unattributable finding would keep the
+    // remainder red anyway, and dropping on a guess blames an innocent
+    // order (Rule 19).
+    const perUnit = new Map<KeptUnit, { blocking: string[]; evidence: Set<string> }>();
+    for (const f of blocking) {
+      const a = attributeFinding(f, units, c.isManifestPath);
+      if (a.kind === 'unattributed') {
+        return refuse(
+          `blocking finding ${f.description} overlaps no kept order's envelope or committed ` +
+            'diff, so it cannot be attributed and no order is dropped',
+        );
+      }
+      if (a.kind === 'ambiguous') {
+        const ids = a.units.map((u) => u.orderIds.join('+')).join(', ');
+        return refuse(
+          `blocking finding ${f.description} is ambiguous between ${ids}, so it cannot be attributed ` +
+            'to one order, so none is dropped',
+        );
+      }
+      const bucket = perUnit.get(a.unit) ?? { blocking: [], evidence: new Set<string>() };
+      bucket.blocking.push(f.description);
+      bucket.evidence.add(a.evidence);
+      perUnit.set(a.unit, bucket);
+    }
+    const roundDrops = [...perUnit.keys()];
+    if (roundDrops.length === units.length) {
+      return refuse(
+        'every kept order attributed to the red: nothing would remain to land, so the run ' +
+          'follows the plain guardrail-red policy',
+      );
+    }
+    // Unwind, newest range first (minimizes revert conflicts).
+    const chainIndex = new Map(units.map((u, i) => [u, i] as const));
+    for (const u of [...roundDrops].sort(
+      (a, b) => (chainIndex.get(b) ?? 0) - (chainIndex.get(a) ?? 0),
+    )) {
+      try {
+        c.git.revertRange(
+          u.from,
+          u.to,
+          `revert(containment): drop ${u.orderIds.join(', ')} (final guardrail attributed ` +
+            'blocking findings to this order; see the run ledger)',
+        );
+      } catch (err) {
+        return refuse(
+          `reverting ${u.orderIds.join(', ')} conflicted ` +
+            `(${err instanceof Error ? err.message.split('\n')[0] : String(err)}), so the ` +
+            'unwound remainder cannot be reconstructed',
+        );
+      }
+    }
+    roundsRun = round;
+    for (const u of roundDrops) {
+      const bucket = perUnit.get(u)!;
+      allDrops.push({
+        unit: u.unit,
+        orderIds: u.orderIds,
+        round,
+        blocking: bucket.blocking,
+        evidence: [...bucket.evidence].join('; '),
+      });
+
+      if (u.unit === 'recipe-group') {
+        recipeGroupDropped = {
+          reason: containmentReason(bucket.blocking, round),
+          orderIds: u.orderIds,
+        };
+      }
+    }
+    units = units.filter((u) => !perUnit.has(u));
+
+    // Re-verify the remainder through the ONE tree verification: install +
+    // floor + the guardrail, the same seam the run-level check used.
+    const { verified, guardrail: reGuardrail } = await verifyCommittedHead(opts, {
+      head: c.git.head(),
+      baseHead: c.baseHead,
+      entryFloor: c.entryFloor,
+      runFloor: c.runFloor,
+    });
+    lastVerified = verified;
+    if (verified.verdict === 'verified') {
+      const dropByOrder = new Map<string, ContainedDrop>();
+      for (const d of allDrops) for (const id of d.orderIds) dropByOrder.set(id, d);
+      const records = c.records.map((rec) => {
+        const d = rec.disposition?.kind === 'kept' ? dropByOrder.get(rec.orderId) : undefined;
+        if (!d || d.unit !== 'agent-order') return rec;
+        return {
+          ...rec,
+          disposition: {
+            kind: 'dropped' as const,
+            step: 'guardrail' as const,
+            reason: containmentReason(d.blocking, d.round),
+          },
+        };
+      });
+      const rg = recipeGroupDropped;
+      const recipes: RecipePhaseSummary = rg
+        ? {
+            ...c.recipes,
+            groupVerification: {
+              kind: 'dropped',
+              step: 'guardrail',
+              reason: rg.reason,
+              droppedOrderIds: rg.orderIds,
+            },
+            records: c.recipes.records.map((r) =>
+              r.outcome.kind === 'applied'
+                ? {
+                    ...r,
+                    disposition: {
+                      kind: 'dropped' as const,
+                      step: 'guardrail' as const,
+                      reason: rg.reason,
+                    },
+                  }
+                : r,
+            ),
+          }
+        : c.recipes;
+      return {
+        kind: 'contained',
+        containment: { maxRounds: MAX_CONTAINMENT_ROUNDS, rounds: roundsRun, dropped: allDrops },
+        records,
+        recipes,
+        verified,
+        guardrail: reGuardrail,
+        head: c.git.head(),
+      };
+    }
+    if (verified.verdict === 'guardrail-red' && reGuardrail.ran) {
+      guardrail = reGuardrail;
+      continue;
+    }
+    return refuse(
+      `the remainder no longer verifies after the unwind (verification ended ` +
+        `'${verified.verdict}'${verified.failure ? `: ${verified.failure.message}` : ''})`,
+    );
+  }
+  const lastWord = lastVerified?.guardrail?.verdict ?? 'red';
+  return refuse(
+    `the guardrail stayed red (${lastWord}) after ${MAX_CONTAINMENT_ROUNDS} unwind round(s); ` +
+      'the bound is deliberate; the run follows the plain guardrail-red policy',
+  );
+}

--- a/src/remediate/execute.ts
+++ b/src/remediate/execute.ts
@@ -288,13 +288,17 @@ export async function executeTask(
   // RED draft — its own required guardrail check keeps it unmergeable, so
   // "nothing merges" holds while the work + blocking findings survive the
   // ephemeral runner and the next run can RESUME from them (guardrail-red
-  // was the outcome where the most valuable partial work died). Only a
-  // RAN-and-blocked verdict qualifies; an unrunnable guardrail never pushes.
+  // was the outcome where the most valuable partial work died).
   // Only a guardrail that actually RAN and blocked earns a red draft: an
   // unrunnable verification must never produce a draft PR claiming a
   // guardrail block that never happened (review fix 5).
+  // A failed containment restore leaves HEAD as a half-unwound tree no
+  // verification saw: never pushed as "the blocked attempt" (it stays local).
   const blockedSalvage =
-    result.outcome === 'guardrail-red' && salvage === 'draft-pr' && result.guardrailRan === true;
+    result.outcome === 'guardrail-red' &&
+    salvage === 'draft-pr' &&
+    result.guardrailRan === true &&
+    result.containment?.restoreFailed !== true;
   // Per-order landing (4.4.6): the kept orders of a partially-landed run
   // are verified work and land as a normal PR; the run stays non-clean so
   // the dropped orders (named in the ledger) are never read as done.

--- a/src/remediate/git-ops.ts
+++ b/src/remediate/git-ops.ts
@@ -136,8 +136,8 @@ export function realGit(cwd: string): RemediateGit {
     resetTo(head) {
       git(['reset', '-q', '--hard', head]);
     },
-    changedPaths(baseHead) {
-      return git(['diff', '--no-renames', '--name-only', baseHead, 'HEAD'])
+    changedPaths(baseHead, head) {
+      return git(['diff', '--no-renames', '--name-only', baseHead, head ?? 'HEAD'])
         .split('\n')
         .filter(Boolean);
     },
@@ -148,6 +148,39 @@ export function realGit(cwd: string): RemediateGit {
       // UNTRACKED files among them — never a blanket clean of the tree.
       if (paths.length === 0) return;
       git(['clean', '-f', '-q', '--', ...paths]);
+    },
+    revertRange(from, to, message) {
+      // The containment unwind: revert one unit's committed range as a
+      // single new commit at the tip, so later kept commits are untouched.
+      // A conflicting revert throws AFTER its own in-progress state is
+      // cleaned up (sequencer aborted, tree reset to the tip): the caller
+      // refuses containment; a half-applied revert must never linger.
+      try {
+        git(['revert', '--no-commit', `${from}..${to}`]);
+      } catch (err) {
+        try {
+          git(['revert', '--abort']);
+        } catch {
+          // no revert in progress: nothing to abort
+        }
+        try {
+          git(['reset', '-q', '--hard', 'HEAD']);
+        } catch {
+          // the caller's restore (resetTo) is the backstop
+        }
+        throw err;
+      }
+      git([
+        '-c',
+        `user.name=${BOT_IDENTITY.name}`,
+        '-c',
+        `user.email=${BOT_IDENTITY.email}`,
+        'commit',
+        '-q',
+        '--allow-empty',
+        '-m',
+        message,
+      ]);
     },
     revertPaths(baseHead, paths) {
       // Targeted revert of the branch's own commits: move the branch back

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -10,7 +10,7 @@ import { describeTreeInvariantOutcome, type TreeInvariantOutcome } from '../lane
 import type { OrderDisposition } from './outcome';
 import { renderScoreHinge } from './score-hinge';
 import { recipeCounts, type RecipePhaseSummary } from './recipes/run-recipes';
-import type { OrdersPhaseSummary, RemediateResult } from './outcome';
+import type { GuardrailContainment, OrdersPhaseSummary, RemediateResult } from './outcome';
 
 /** The deterministic-recipe section: one line per order (applied / refused /
  *  failed with the reason), the tier split, and every disclosure: a $0
@@ -165,6 +165,22 @@ function renderOrdersSection(orders: OrdersPhaseSummary): string[] {
       lines.push(...renderInvariants(rec.invariants));
       lines.push(...renderInvariantDisclosures(rec.invariantDisclosures));
       lines.push(...renderDisposition(rec.disposition));
+      if (
+        rec.disposition?.kind === 'kept' &&
+        (rec.outcome === 'failed' || rec.outcome === 'partial')
+      ) {
+        // Driver-failure hygiene (4.4.7): a kept order whose driver failed
+        // or overran its budget lands on the VERIFICATION's evidence, never
+        // on any agent claim, and it is first in line for containment
+        // attribution if the final guardrail goes red. Disclosed per order.
+        lines.push(
+          `  - driver-failure disclosure: the driver reported this order's run ` +
+            (rec.outcome === 'failed' ? 'failed' : 'cut short (budget overrun)') +
+            `, but the committed work passed per-order verification and lands on that ` +
+            `evidence (the agent's claim counts for nothing); if the final guardrail goes ` +
+            `red, this order is first in line for containment attribution.`,
+        );
+      }
       lines.push(
         rec.doneAfterVerify
           ? `  - done (${rec.done.verifier} verifier, ${rec.done.absentIds} target id(s)): ` +
@@ -178,6 +194,36 @@ function renderOrdersSection(orders: OrdersPhaseSummary): string[] {
               `closure is arbitrated by the verification below and the next plan`,
       );
     }
+  }
+  lines.push('');
+  return lines;
+}
+
+/** Guardrail-red containment (4.4.7): what was attributed and dropped, or
+ *  why containment was refused: the reader sees exactly why an order the
+ *  run dispatched is not in the landing set. */
+function renderContainment(c: GuardrailContainment): string[] {
+  const lines: string[] = ['### Guardrail containment', ''];
+  if (c.refused !== undefined) {
+    lines.push(
+      `The final guardrail was red and per-order containment was attempted (bounded at ` +
+        `${c.maxRounds} unwind round(s)) but REFUSED: ${c.refused}. No order was dropped on ` +
+        `a guess; the whole attempt follows the guardrail-red salvage policy.`,
+      '',
+    );
+    return lines;
+  }
+  lines.push(
+    `The final guardrail was red; each blocking finding was attributed to one order ` +
+      `(envelope and committed-diff overlap), the attributed orders were dropped, and the ` +
+      `remainder re-verified green in ${c.rounds} of at most ${c.maxRounds} round(s).`,
+  );
+  for (const d of c.dropped) {
+    lines.push(
+      `- dropped \`${d.orderIds.join('`, `')}\` (${d.unit}, round ${d.round}): ` +
+        `attribution: ${d.evidence}`,
+    );
+    for (const b of d.blocking) lines.push(`  - blocking: ${b}`);
   }
   lines.push('');
   return lines;
@@ -311,6 +357,10 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
 
   if (r.orders) {
     lines.push(...renderOrdersSection(r.orders));
+  }
+
+  if (r.containment) {
+    lines.push(...renderContainment(r.containment));
   }
 
   lines.push('### Verification', '');

--- a/src/remediate/order-outcomes.ts
+++ b/src/remediate/order-outcomes.ts
@@ -119,6 +119,11 @@ function droppedVerdict(d: Extract<OrderDisposition, { kind: 'dropped' }>): Orde
       return 'install-failed';
     case 'floor':
       return 'floor-red';
+    // A containment drop (4.4.7): the final guardrail attributed blocking
+    // findings to THIS order: the breaker counts it as this order's
+    // guardrail failure, never the run's.
+    case 'guardrail':
+      return 'guardrail-red';
   }
 }
 

--- a/src/remediate/orders-complete.ts
+++ b/src/remediate/orders-complete.ts
@@ -9,6 +9,8 @@
  * with the legacy tail via the `verify.ts` phrasing helpers.
  */
 import { floorOrderDone } from '../loop/order-scope';
+import { containGuardrailRed, manifestPathProbe } from './containment';
+import type { GuardrailContainment } from './outcome';
 import type {
   AgentEnvelope,
   OrderDisposition,
@@ -194,6 +196,45 @@ export async function completeOrdersRun(
     runFloor: args.runFloor,
   });
 
+  // Guardrail-red CONTAINMENT (4.4.7): the guardrail RAN and did not pass.
+  // Attribute the blocking findings per order, unwind the attributed
+  // orders, re-verify the remainder (bounded rounds): the contained run
+  // lands its green subset as `partially-landed`; a red that cannot be
+  // attributed refuses honestly and keeps the plain guardrail-red path
+  // (branch restored). An unrunnable guardrail is infrastructure, never
+  // contained; the fail-closed arm below keeps it.
+  let effVerified = verified;
+  let effGuardrail = guardrail;
+  let effRecipes = args.recipes;
+  let effRecords: readonly OrderRunRecord[] = records;
+  let effHead = head;
+  let containment: GuardrailContainment | undefined;
+  let contained = false;
+  if (guardrail.ran && !guardrail.passesGate) {
+    const outcome = await containGuardrailRed(opts, {
+      git: args.git,
+      baseHead: args.baseHead,
+      agentBase: args.agentBase,
+      entryFloor: args.entryFloor,
+      runFloor: args.runFloor,
+      recipes: args.recipes,
+      records,
+      ordersById: new Map(dispatchList.map((o) => [o.id, o] as const)),
+      guardrail,
+      isManifestPath: manifestPathProbe(opts.cwd, args.isManifestPath),
+    });
+    containment = outcome.containment;
+    if (outcome.kind === 'contained') {
+      contained = true;
+      effVerified = outcome.verified;
+      effGuardrail = outcome.guardrail;
+      effRecipes = outcome.recipes;
+      effRecords = outcome.records;
+      effHead = outcome.head;
+    }
+  }
+  const containmentDisclosure = containment !== undefined ? { containment } : {};
+
   // Per-order done, judged from the FINAL verified floor for floor-verifier
   // orders through the ONE `floorOrderDone` computation (the Stop-gate's
   // floor arm reads the same function, so the two cannot drift). Honest in
@@ -201,9 +242,9 @@ export async function completeOrdersRun(
   // absent, or a floor that did not run at all) yields UNDECIDED, never a
   // claimed closure; a guardrail-verifier order's closure is arbitrated by
   // the guardrail verdict below and the next plan — the ledger says so.
-  const verifiedChecks = verified.floor?.checks;
+  const verifiedChecks = effVerified.floor?.checks;
   const byId = new Map(dispatchList.map((o) => [o.id, o] as const));
-  const withDone = records.map((r) => {
+  const withDone = effRecords.map((r) => {
     const order = byId.get(r.orderId);
     if (
       !order ||
@@ -227,12 +268,13 @@ export async function completeOrdersRun(
 
   const common = {
     task: args.taskId,
-    recipes: args.recipes,
+    recipes: effRecipes,
     orders: finalSummary,
     envelope,
-    ...verificationDisclosures(verified, guardrail, opts.cwd),
+    ...verificationDisclosures(effVerified, effGuardrail, opts.cwd),
+    ...containmentDisclosure,
     baseHead: args.baseHead,
-    head,
+    head: effHead,
     ...evidenceTail,
     ...(scrubbed.length > 0 ? { scrubbedArtifacts: scrubbed } : {}),
     ...(partial ? { partial } : {}),
@@ -251,17 +293,39 @@ export async function completeOrdersRun(
         'truthful failure, never a PR.',
     };
   }
-  if (!guardrail.ran || !guardrail.passesGate) {
+  if (!contained && (!guardrail.ran || !guardrail.passesGate)) {
+    const refusalNote =
+      containment?.refused !== undefined
+        ? ` Containment was attempted and refused: ${containment.refused}.`
+        : '';
     return {
       outcome: 'guardrail-red',
       ...common,
-      note: guardrailRedNote(guardrail, args.effectiveSalvage),
+      note: guardrailRedNote(guardrail, args.effectiveSalvage) + refusalNote,
     };
   }
+  // Recomputed over the EFFECTIVE records/recipes: a containment drop is a
+  // dropped order like any other for the note, the ledger, and the rows.
+  const effDroppedOrders = effRecords.filter((r) => r.disposition?.kind === 'dropped');
+  const effDroppedRecipes = effRecipes.records.filter((r) => r.disposition?.kind === 'dropped');
   const droppedNote =
-    droppedOrders.length + droppedRecipes.length > 0
-      ? ` Dropped at their own verification (still open): ${describeDropped([...droppedRecipes, ...droppedOrders])}.`
+    effDroppedOrders.length + effDroppedRecipes.length > 0
+      ? ` Dropped at their own verification (still open): ${describeDropped([...effDroppedRecipes, ...effDroppedOrders])}.`
       : '';
+  if (contained) {
+    // The contained run completes partially-landed EVEN when partial: the
+    // remainder is fully verified and lands; the dropped orders are named
+    // and their rows record the guardrail failure per order.
+    return {
+      outcome: 'partially-landed',
+      ...common,
+      note:
+        'the final guardrail was red; its blocking findings were attributed per order, the ' +
+        'attributed orders were dropped (commits reverted), and the remainder re-verified ' +
+        'green, so the verified remainder lands.' +
+        droppedNote,
+    };
+  }
   if (partial) {
     const salvage =
       args.effectiveSalvage === 'draft-pr'

--- a/src/remediate/orders-phase.ts
+++ b/src/remediate/orders-phase.ts
@@ -46,7 +46,7 @@
  * hinge tail lives only on the legacy path.
  */
 import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
-import { detectActiveLanguages, dependencyManifestFilesIn } from '../languages';
+import { manifestPathProbe } from './containment';
 import {
   ORDER_TOKEN_ENV,
   clearOrderScope,
@@ -142,15 +142,9 @@ export async function runOrdersPhase(
   // scope from a killed or concurrent lane's leftover.
   const orderToken = newOrderScopeToken();
   // The manifests:false gate reads the pack-declared manifest-pattern union
-  // (computed lazily once; injectable for tests).
-  let manifestProbe = args.isManifestPath;
-  const isManifestPath = (p: string): boolean => {
-    if (!manifestProbe) {
-      const packs = detectActiveLanguages(opts.cwd);
-      manifestProbe = (x) => dependencyManifestFilesIn([x], packs).length > 0;
-    }
-    return manifestProbe(p);
-  };
+  // (computed lazily once; injectable for tests): the same probe the
+  // guardrail-red containment consults (`manifestPathProbe`, Rule 2).
+  const isManifestPath = manifestPathProbe(opts.cwd, args.isManifestPath);
   const records: OrderRunRecord[] = [];
   const scrubbed: string[] = [];
   const failures: string[] = [];

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -152,6 +152,11 @@ export interface GuardrailContainment {
   /** Present when containment was attempted and REFUSED, with the reason;
    *  the run then completes guardrail-red exactly as before this feature. */
   readonly refused?: string;
+  /** True when the refusal's branch RESTORE itself failed: HEAD is then a
+   *  half-unwound tree no verification ever saw, so the executor must not
+   *  push it as a salvage draft; the branch stays local for inspection
+   *  (the refusal note says so). */
+  readonly restoreFailed?: true;
 }
 
 export type RemediateOutcome =

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -43,7 +43,10 @@ export type OrderDisposition =
   | { readonly kind: 'kept'; readonly head: string }
   | {
       readonly kind: 'dropped';
-      readonly step: 'tree-invariants' | 'install' | 'floor';
+      /** `guardrail` marks a containment drop (4.4.7): the FINAL guardrail
+       *  was red, its blocking findings attributed to this order, and the
+       *  order's commits were reverted so the remainder could land. */
+      readonly step: 'tree-invariants' | 'install' | 'floor' | 'guardrail';
       readonly reason: string;
     }
   | {
@@ -110,6 +113,45 @@ export interface OrdersPhaseSummary {
    *  order prompt as a negative constraint (resume policy: a guardrail-red
    *  attempt is never a resume anchor). */
   readonly priorBlockingApplied?: boolean;
+}
+
+/** One containment drop (guardrail-red containment, 4.4.7): the unit whose
+ *  commits were reverted because the final guardrail's blocking findings
+ *  attributed to it. */
+export interface ContainedDrop {
+  readonly unit: 'agent-order' | 'recipe-group';
+  readonly orderIds: readonly string[];
+  /** Which unwind round dropped it (1-based). */
+  readonly round: number;
+  /** Compact descriptions of the blocking findings attributed to this unit. */
+  readonly blocking: readonly string[];
+  /** The overlap evidence the attribution stands on, plus any tiebreak used
+   *  (Rule 19: a cause claim always names its evidence). */
+  readonly evidence: string;
+}
+
+/**
+ * Guardrail-red containment (4.4.7): when the FINAL guardrail over the
+ * landed head is red, the runner attributes each blocking finding to the
+ * order whose envelope and committed diff overlap it, reverts the
+ * attributed orders, re-verifies (install + floor) and re-runs the
+ * guardrail on the remainder, bounded to a small disclosed number of
+ * rounds. A red that attributes to NO order, is ambiguous, or survives the
+ * bound REFUSES containment (the branch is restored and the run follows
+ * the plain guardrail-red salvage policy): never a guess, never an
+ * unexplained red landed.
+ */
+export interface GuardrailContainment {
+  /** The disclosed bound on unwind rounds. */
+  readonly maxRounds: number;
+  /** Rounds actually executed (0 when refused before any unwind). */
+  readonly rounds: number;
+  /** The dropped units, empty when containment was refused (any reverts
+   *  already made were restored). */
+  readonly dropped: readonly ContainedDrop[];
+  /** Present when containment was attempted and REFUSED, with the reason;
+   *  the run then completes guardrail-red exactly as before this feature. */
+  readonly refused?: string;
 }
 
 export type RemediateOutcome =
@@ -244,6 +286,11 @@ export interface RemediateResult {
    *  agent run, per-order records with derived budgets, envelope
    *  enforcement drops, and done disclosures — rendered into the ledger. */
   readonly orders?: OrdersPhaseSummary;
+  /** Guardrail-red containment (4.4.7): present whenever the final
+   *  guardrail was red on an order-driven run and containment was
+   *  attempted: successful (the dropped units named) or refused (the
+   *  reason named). Rendered into the ledger either way. */
+  readonly containment?: GuardrailContainment;
   /** The verification ledger — PR body / job summary markdown. */
   readonly ledger: string;
 }
@@ -276,10 +323,12 @@ export interface RemediateGit {
    *  per-order DROP: an order whose commits did not verify is reverted
    *  wholesale, the tree left clean at the previously verified head). */
   resetTo(head: string): void;
-  /** Repo-relative paths the commits in base..HEAD changed (renames as
-   *  both sides): what an order's diff touched, for the frame's invariant
-   *  step. Throws when git cannot answer; the caller drops the order. */
-  changedPaths(baseHead: string): readonly string[];
+  /** Repo-relative paths the commits in base..head changed (renames as
+   *  both sides; `head` defaults to HEAD): what an order's diff touched,
+   *  for the frame's invariant step and containment's per-order ranges.
+   *  Throws when git cannot answer; the caller drops the order (or
+   *  refuses containment). */
+  changedPaths(baseHead: string, head?: string): readonly string[];
   /** Stage exactly these paths and commit them with the bot identity (the
    *  frame's own commit after re-establishing an invariant). */
   commitPaths(paths: readonly string[], message: string): void;
@@ -292,6 +341,12 @@ export interface RemediateGit {
    *  pre-existing dirt) untouched — the targeted revert for a recipe
    *  group's own commits. Never a hard reset over a dirty tree. */
   revertPaths(baseHead: string, paths: readonly string[]): void;
+  /** Revert the committed changes in `from..to` as ONE new commit at the
+   *  tip (bot identity, `message`): the containment unwind for a unit
+   *  that is no longer the tip, so later kept commits survive intact.
+   *  Throws on a conflict (after cleaning up its own in-progress state);
+   *  the caller then refuses containment and restores the branch. */
+  revertRange(from: string, to: string, message: string): void;
 }
 
 export interface RemediateRunOptions {

--- a/src/remediate/recipes/execute-orders.ts
+++ b/src/remediate/recipes/execute-orders.ts
@@ -17,6 +17,7 @@ import { readPolicySection } from '../../baseline/policy-text';
 import type { FindingSeverity } from '../../baseline/types';
 import type { DepVulnFinding } from '../../languages/capabilities/types';
 import { RECIPE_REGISTRY, type RecipeDeclaration } from '../work-orders/recipes-registry';
+import { packagesNamedBy } from '../work-orders/shared';
 import type { WorkOrder } from '../work-orders/types';
 import { partitionByEnvelope, pathInEnvelope } from './envelope';
 import type { RecipeGit } from './git';
@@ -138,11 +139,13 @@ export async function runRecipeOrders(
     extra?: Pick<RecipeOrderRecord, 'droppedPaths' | 'invariants' | 'invariantDisclosures'>,
   ) => {
     for (const order of group) {
+      const packages = packagesNamedBy(order.findings);
       records.push({
         orderId: order.id,
         class: String(order.class),
         recipe: order.recipe!,
         outcome,
+        ...(packages.length > 0 ? { packages } : {}),
         ...(extra ?? {}),
       });
     }

--- a/src/remediate/recipes/phase-summary.ts
+++ b/src/remediate/recipes/phase-summary.ts
@@ -15,6 +15,10 @@ export interface RecipeOrderRecord {
   readonly class: string;
   readonly recipe: string;
   readonly outcome: RecipeOutcome;
+  /** Packages the order's findings name (dep-advisory evidence), recorded
+   *  by the executor so guardrail-red containment can attribute a red on
+   *  a recipe-pinned package to the GROUP on direct evidence (4.4.7). */
+  readonly packages?: readonly string[];
   /** Out-of-envelope paths the enforcement discarded (disclosed). */
   readonly droppedPaths?: readonly string[];
   /** Collector/step disclosures for this order's invariant step. */

--- a/src/remediate/recipes/phase-summary.ts
+++ b/src/remediate/recipes/phase-summary.ts
@@ -36,7 +36,9 @@ export type RecipeGroupVerification =
   | { readonly kind: 'kept'; readonly head: string }
   | {
       readonly kind: 'dropped';
-      readonly step: 'install' | 'floor';
+      /** `guardrail` marks a containment drop (4.4.7): the final guardrail
+       *  attributed blocking findings to the group after it was kept. */
+      readonly step: 'install' | 'floor' | 'guardrail';
       readonly reason: string;
       readonly droppedOrderIds: readonly string[];
     }

--- a/src/remediate/recipes/run-recipes.ts
+++ b/src/remediate/recipes/run-recipes.ts
@@ -35,6 +35,8 @@ import type { RemediateConfig } from '../config';
 import { planRepoWorkOrders, type GatherWorkOrderOptions } from '../work-orders/gather';
 import { classesSelectedBy } from '../work-orders/types';
 import { selectOrders } from '../work-orders/planner';
+import { withRecipeFallthroughBudget } from '../work-orders/shared';
+import { budgetForTask } from '../config';
 import { realRecipeGit, type RecipeGit } from './git';
 // The order executor lives in `./execute-orders` (module-size split);
 // re-exported so consumers keep one import surface.
@@ -159,9 +161,21 @@ export async function runRecipePhaseForTask(opts: RecipePhaseOptions): Promise<R
   // The agent queue, in plan (value) order: agent-tier orders plus every
   // recipe order whose recipe did not APPLY — a refused/failed recipe order
   // falls through to the agent within THIS run instead of dead-ending it.
+  // A fallthrough order's budget is RE-DERIVED with the recipe-fallthrough
+  // floor (4.4.7): the deterministic fix was tried and declined, so the
+  // agent inherits the class's hardest work; the raised derivation is
+  // disclosed on the order and in the ledger. Same cap as the planner's
+  // (the selecting task's effective budget), one formula (`deriveBudget`).
   const applied = new Set(
     records.filter((r) => r.outcome.kind === 'applied').map((r) => r.orderId),
   );
-  const agentOrders = selected.filter((o) => o.tier === 'agent' || !applied.has(o.id));
+  const fallthroughCap = budgetForTask(opts.config, opts.taskId);
+  const agentOrders = selected
+    .filter((o) => o.tier === 'agent' || !applied.has(o.id))
+    .map((o) =>
+      o.tier === 'recipe' && !applied.has(o.id)
+        ? withRecipeFallthroughBudget(o, fallthroughCap)
+        : o,
+    );
   return { ran: true, records, ...summaryBase, agentOrders };
 }

--- a/src/remediate/work-orders/shared.ts
+++ b/src/remediate/work-orders/shared.ts
@@ -187,6 +187,17 @@ export function undispatch(
   if (findings.length > 0) into.push({ reason, findings });
 }
 
+/** The packages a finding set names (dep-advisory evidence): the ONE
+ *  projection both the recipe executor (recording what an applied order
+ *  pinned) and the guardrail-red containment's package tier read. */
+export function packagesNamedBy(findings: readonly WorkOrderFinding[]): string[] {
+  const out = new Set<string>();
+  for (const f of findings) {
+    if (f.evidence.type === 'dep-vuln') out.add(f.evidence.package);
+  }
+  return [...out].sort(byteOrder);
+}
+
 /** A finding carrying only an identity (no class, or nothing to join). */
 export function identityOnly(
   kind: string,

--- a/src/remediate/work-orders/shared.ts
+++ b/src/remediate/work-orders/shared.ts
@@ -98,7 +98,14 @@ export function doneFor(
 /** Default `remediate.workOrders.maxSliceSize`. */
 export const DEFAULT_MAX_SLICE_SIZE = 25;
 
-/** Budget derivation constants, declared once (section 3C). */
+/** Budget derivation constants, declared once (section 3C). The
+ *  recipe-fallthrough multiplier (4.4.7) raises the floor for an agent
+ *  order whose RECIPE already failed: that order inherits the hardest work
+ *  in its class (the deterministic fix was tried and refused, so real
+ *  investigation is left), and the live evidence is two agent orders that
+ *  exhausted their derived 12 turns investigating an audit-vs-advisory
+ *  disagreement. A derivation, not a magic constant: the standard formula
+ *  is scaled, still clamped by the selecting task's budget cap. */
 export const BUDGET_DERIVATION = {
   baseTurns: 8,
   perFindingTurns: 4,
@@ -106,6 +113,7 @@ export const BUDGET_DERIVATION = {
   baseMinutes: 5,
   perFindingMinutes: 2,
   minMinutes: 5,
+  recipeFallthroughMultiplier: 2,
 } as const;
 
 /** `min(cap, max(floor, value))`: the policy cap always wins, even when it
@@ -115,29 +123,58 @@ function bounded(value: number, floor: number, cap: number): number {
 }
 
 /**
- * `turns = min(cap.maxTurns, max(min, base + perFinding * n))`, same shape
- * for minutes; usd scales with the turn fraction of the cap and is capped
- * by it. `cap` is the SELECTING TASK's effective budget (`budgetForTask`),
- * so one plan never shows two budgets for one concept.
+ * `turns = min(cap.maxTurns, m * max(min, base + perFinding * n))`, same
+ * shape for minutes; usd scales with the turn fraction of the cap and is
+ * capped by it. `m` is 1 normally and `recipeFallthroughMultiplier` for an
+ * order whose recipe tier already failed or refused (it inherits the class's
+ * hardest work; the disclosed formula, never a constant). `cap` is the
+ * SELECTING TASK's effective budget (`budgetForTask`), so one plan never
+ * shows two budgets for one concept.
  */
-export function deriveBudget(findingCount: number, cap: RemediateBudget): WorkOrderBudget {
+export function deriveBudget(
+  findingCount: number,
+  cap: RemediateBudget,
+  opts: { readonly recipeFallthrough?: boolean } = {},
+): WorkOrderBudget {
   const d = BUDGET_DERIVATION;
-  const turns = bounded(d.baseTurns + d.perFindingTurns * findingCount, d.minTurns, cap.maxTurns);
-  const minutes = bounded(
-    d.baseMinutes + d.perFindingMinutes * findingCount,
-    d.minMinutes,
+  const m = opts.recipeFallthrough ? d.recipeFallthroughMultiplier : 1;
+  const turns = Math.min(
+    cap.maxTurns,
+    m * bounded(d.baseTurns + d.perFindingTurns * findingCount, d.minTurns, cap.maxTurns),
+  );
+  const minutes = Math.min(
     cap.maxMinutes,
+    m * bounded(d.baseMinutes + d.perFindingMinutes * findingCount, d.minMinutes, cap.maxMinutes),
   );
   const usd = Math.min(cap.maxUsd, Math.max(1, Math.round((cap.maxUsd * turns) / cap.maxTurns)));
+  const factor = m === 1 ? '' : `${m} * `;
+  const why =
+    m === 1
+      ? ''
+      : ` (recipe-fallthrough floor, x${m}: the recipe tier already failed or refused this ` +
+        `order, so the agent inherits the investigation the recipe could not do)`;
   return {
     turns,
     minutes,
     usd,
     derivation:
-      `turns = min(${cap.maxTurns}, max(${d.minTurns}, ${d.baseTurns} + ${d.perFindingTurns} * ` +
-      `${findingCount})) = ${turns}; minutes = min(${cap.maxMinutes}, max(${d.minMinutes}, ` +
-      `${d.baseMinutes} + ${d.perFindingMinutes} * ${findingCount})) = ${minutes}; ` +
-      `usd = min(${cap.maxUsd}, round(${cap.maxUsd} * ${turns} / ${cap.maxTurns})) = ${usd}`,
+      `turns = min(${cap.maxTurns}, ${factor}max(${d.minTurns}, ${d.baseTurns} + ` +
+      `${d.perFindingTurns} * ${findingCount})) = ${turns}; minutes = min(${cap.maxMinutes}, ` +
+      `${factor}max(${d.minMinutes}, ${d.baseMinutes} + ${d.perFindingMinutes} * ` +
+      `${findingCount})) = ${minutes}; ` +
+      `usd = min(${cap.maxUsd}, round(${cap.maxUsd} * ${turns} / ${cap.maxTurns})) = ${usd}` +
+      why,
+  };
+}
+
+/** Re-derive an order's budget with the recipe-fallthrough floor (4.4.7):
+ *  applied by the recipe phase when a recipe-tier order joins the agent
+ *  queue after its recipe failed or refused. ONE formula (`deriveBudget`),
+ *  never a second derivation. */
+export function withRecipeFallthroughBudget(order: WorkOrder, cap: RemediateBudget): WorkOrder {
+  return {
+    ...order,
+    budget: deriveBudget(order.findings.length, cap, { recipeFallthrough: true }),
   };
 }
 

--- a/test/remediate/dispatch.test.ts
+++ b/test/remediate/dispatch.test.ts
@@ -144,6 +144,7 @@ function fakeGit(): RemediateGit {
     commitPaths: () => {},
     cleanPaths: () => {},
     revertPaths: () => {},
+    revertRange: () => {},
     hasDiff: () => {
       head = 'head1111';
       return true;

--- a/test/remediate/failure-taxonomy.test.ts
+++ b/test/remediate/failure-taxonomy.test.ts
@@ -190,6 +190,7 @@ function fakeGit(opts: { diff?: boolean } = {}): RemediateGit {
     commitPaths: () => {},
     cleanPaths: () => {},
     revertPaths: () => {},
+    revertRange: () => {},
     hasDiff: () => !!opts.diff,
   };
 }

--- a/test/remediate/guardrail-containment.test.ts
+++ b/test/remediate/guardrail-containment.test.ts
@@ -1,0 +1,804 @@
+/**
+ * Guardrail-red containment per order (4.4.7, defect A2): the final
+ * guardrail is the run's ONE arbiter, but its red verdict must not drag
+ * verified orders down with the one order that caused it. Pinned here,
+ * both directions per behavior:
+ *
+ *   - contained: blocking findings attribute to one order (package match /
+ *     diff / envelope overlap), the attributed order's commits are
+ *     reverted, the remainder re-verifies green and lands as
+ *     `partially-landed`; the ledger, containment disclosure, and breaker
+ *     rows name the dropped order on its own failure;
+ *   - ambiguity: a driver-failed order is preferred over verified ones;
+ *     ambiguity among verified orders REFUSES;
+ *   - refusal: a finding attributing to NO order refuses; a red that
+ *     survives the bounded rounds refuses and restores the branch; a red
+ *     with no attributable findings (a refusal-tier verdict) refuses; a
+ *     revert conflict refuses; dropping EVERY order refuses (nothing would
+ *     remain);
+ *   - driver-failure hygiene: a driver-failed order's committed partial is
+ *     verified like any order and disclosed in the ledger when kept;
+ *   - the pure attribution ladder and the recipe-fallthrough budget floor.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { executeTask } from '../../src/remediate/cli';
+import { DEFERRED_LANDING_ENV, landingRecordPath } from '../../src/remediate/landing-record';
+import { trustedLocalContext } from '../../src/analysis-trust';
+import { runRemediateTask, type RemediateGit, type RemediateResult } from '../../src/remediate/run';
+import type { AgentDriver, AgentRunResult } from '../../src/remediate/driver';
+import { DEFAULT_REMEDIATE_BUDGET, type RemediateConfig } from '../../src/remediate/config';
+import type { RecipePhaseSummary } from '../../src/remediate/recipes/run-recipes';
+import type { WorkOrder, WorkOrderFinding } from '../../src/remediate/work-orders/types';
+import { deriveBudget, withRecipeFallthroughBudget } from '../../src/remediate/work-orders/shared';
+import type { GuardrailGateResult } from '../../src/lanes/verify';
+import { orderOutcomeRows } from '../../src/remediate/order-outcomes';
+import {
+  attributeFinding,
+  buildKeptUnits,
+  overlapEvidence,
+  MAX_CONTAINMENT_ROUNDS,
+  type KeptUnit,
+} from '../../src/remediate/containment';
+import { GREEN_FLOOR } from './helpers';
+import { makeOrder } from './recipes/helpers';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+function tmpCwd(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-containment-'));
+  dirs.push(d);
+  return d;
+}
+
+/** A head-counting fake with per-range diff paths and a revert log. A
+ *  revert commits at the tip (head advances); a reset moves it back. */
+function fakeGit(rangePaths: Record<string, readonly string[]> = {}) {
+  let commits = 0;
+  const g = {
+    resets: [] as string[],
+    reverts: [] as { from: string; to: string; message: string }[],
+    head: () => `head${commits}`,
+    commit: () => {
+      commits += 1;
+    },
+    sweepLeftovers: () => undefined,
+    scrubRuntimeArtifacts: () => [] as string[],
+    hasDiff: (base: string) => commits > 0 && base !== `head${commits}`,
+    enforceEnvelope: () => {
+      commits += 1;
+      return { dropped: [] };
+    },
+    resetTo: (head: string) => {
+      g.resets.push(head);
+      commits = Number(head.replace('head', ''));
+    },
+    changedPaths: (base: string, head?: string) => [
+      ...(rangePaths[`${base}..${head ?? 'HEAD'}`] ?? ['src/a.ts']),
+    ],
+    commitPaths: () => {
+      commits += 1;
+    },
+    cleanPaths: () => {},
+    revertPaths: () => {},
+    revertRange: (from: string, to: string, message: string) => {
+      g.reverts.push({ from, to, message });
+      commits += 1;
+    },
+  };
+  return g as RemediateGit & typeof g;
+}
+
+/** A driver whose result is scripted per run index (default: completed). */
+function scriptedDriver(results: readonly Partial<AgentRunResult>[] = []): AgentDriver {
+  let i = 0;
+  return {
+    id: 'fake-agent',
+    budgetSupport: { turns: 'enforced', cost: 'reported' },
+    credentialEnv: [],
+    cli: null,
+    resolveModel: (tier: string) => `fake-${tier}`,
+    available: () => ({ ok: true }),
+    run: async () => {
+      const extra = results[i] ?? {};
+      i += 1;
+      return {
+        completed: true,
+        timedOut: false,
+        transcriptTail: '',
+        turns: 2,
+        costUsd: 0.1,
+        ...extra,
+      };
+    },
+  } as unknown as AgentDriver;
+}
+
+function config(): RemediateConfig {
+  return {
+    enabled: true,
+    tasks: ['fix-vulns'],
+    unknownTasks: [],
+    schedule: 'weekly',
+    salvage: 'draft-pr',
+    agent: { driver: 'fake-agent', model: 'auto', budget: DEFAULT_REMEDIATE_BUDGET },
+    taskBudgets: {},
+    maxSpendPerRun: 0,
+    maxDispatchBudget: 0,
+    resume: false,
+    maxOrdersPerRun: 5,
+    pauseAfterFailures: 0,
+    workOrders: { maxSliceSize: 25 },
+    recipes: { enabled: true },
+  };
+}
+
+function floorOrder(id: string, envelopePath: string): WorkOrder {
+  return makeOrder({
+    id,
+    class: 'floor-failure',
+    tier: 'agent',
+    envelope: { paths: [envelopePath], manifests: false },
+    done: { absentIds: [`x#${id}`], verifier: 'floor', command: 'floor check' },
+    budget: { turns: 12, minutes: 6, usd: 2, derivation: 'turns = derived(12)' },
+  });
+}
+
+function depFinding(pkg: string): WorkOrderFinding {
+  return {
+    kind: 'dep-vuln',
+    id: `dep:${pkg}`,
+    attribution: 'net-new',
+    evidence: { type: 'dep-vuln', package: pkg, advisoryId: 'GHSA-test' },
+  };
+}
+
+function depOrder(pkg: string): WorkOrder {
+  return makeOrder({
+    id: `dep-advisory:${pkg}`,
+    class: 'dep-advisory',
+    tier: 'agent',
+    findings: [depFinding(pkg)],
+    envelope: { paths: ['package.json', 'package-lock.json'], manifests: true },
+    done: { absentIds: [`dep:${pkg}`], verifier: 'guardrail', command: 'guardrail check' },
+    budget: { turns: 12, minutes: 6, usd: 2, derivation: 'turns = derived(12)' },
+  });
+}
+
+function summary(
+  orders: readonly WorkOrder[],
+  extra: Partial<RecipePhaseSummary> = {},
+): RecipePhaseSummary {
+  return {
+    ran: false,
+    disclosures: [],
+    selectedRecipeTier: 0,
+    selectedAgentTier: orders.length,
+    records: [],
+    agentOrders: orders,
+    ...extra,
+  };
+}
+
+const GREEN: GuardrailGateResult = { verdict: 'PASSED', ran: true, passesGate: true };
+function red(findings: GuardrailGateResult['blockingFindings']): GuardrailGateResult {
+  return {
+    verdict: 'BLOCKED',
+    ran: true,
+    passesGate: false,
+    blocking: (findings ?? []).map((f) => f.description),
+    ...(findings !== undefined ? { blockingFindings: findings } : {}),
+  };
+}
+
+function runWith(o: {
+  readonly orders: readonly WorkOrder[];
+  readonly git: ReturnType<typeof fakeGit>;
+  readonly driver?: AgentDriver;
+  /** Guardrail results, consumed one per verification pass. */
+  readonly guardrails: readonly GuardrailGateResult[];
+  readonly recipePhase?: () => RecipePhaseSummary;
+}): Promise<RemediateResult> {
+  const gates = [...o.guardrails];
+  return runRemediateTask({
+    cwd: tmpCwd(),
+    trust: trustedLocalContext(),
+    taskId: 'fix-vulns',
+    config: config(),
+    drivers: [o.driver ?? scriptedDriver()],
+    git: o.git,
+    runFloor: () => GREEN_FLOOR,
+    runGuardrail: async () => gates.shift() ?? GREEN,
+    verifySeams: {
+      worktree: async <T>(opts: { ref: string }, fn: (p: string) => Promise<T>) => fn(opts.ref),
+      install: () => ({ status: 'installed', steps: [] }),
+      changedFiles: () => ['src/a.ts'],
+    },
+    armInLoopGate: () => ({ mode: 'backstop-only' as const, reason: 'test' }),
+    runRecipePhase: async () => (o.recipePhase ? o.recipePhase() : summary(o.orders)),
+    frameInvariants: {
+      step: async () => ({
+        applied: [],
+        notApplicable: [],
+        changedPaths: [],
+        disclosures: [],
+        failed: false,
+      }),
+    },
+  });
+}
+
+describe('guardrail-red containment: contained red lands the remainder', () => {
+  it('attributes a package-named dep finding to the order naming it, drops that order, re-verifies, lands partially', async () => {
+    // Order a: head0..head1 (floor, src/); order b: head1..head2 (dep pin,
+    // names tmp). Final guardrail red on tmp; the re-run after the unwind
+    // is green.
+    const git = fakeGit({
+      'head0..head1': ['src/a.ts'],
+      'head1..head2': ['package.json', 'package-lock.json'],
+    });
+    const finding = {
+      kind: 'dep-vuln',
+      description: '[dep-vuln] tmp@0.2.6 · GHSA-test — added (no-prior-match)',
+      package: 'tmp',
+    };
+    const r = await runWith({
+      orders: [floorOrder('floor-failure:a', 'src/'), depOrder('tmp')],
+      git,
+      guardrails: [red([finding]), GREEN],
+    });
+    expect(r.outcome).toBe('partially-landed');
+    const recs = r.orders?.records ?? [];
+    expect(recs[0].disposition).toEqual({ kind: 'kept', head: 'head1' });
+    expect(recs[1].disposition).toEqual({
+      kind: 'dropped',
+      step: 'guardrail',
+      reason: expect.stringContaining('tmp@0.2.6'),
+    });
+    // The unwind reverted exactly the attributed order's range, at the tip.
+    expect(git.reverts).toEqual([
+      {
+        from: 'head1',
+        to: 'head2',
+        message: expect.stringContaining('dep-advisory:tmp'),
+      },
+    ]);
+    expect(r.head).toBe('head3');
+    expect(git.resets).toEqual([]);
+    // The containment disclosure names the drop, its round, and the evidence.
+    expect(r.containment?.refused).toBeUndefined();
+    expect(r.containment?.rounds).toBe(1);
+    expect(r.containment?.dropped).toEqual([
+      {
+        unit: 'agent-order',
+        orderIds: ['dep-advisory:tmp'],
+        round: 1,
+        blocking: [finding.description],
+        evidence: expect.stringContaining('names package tmp'),
+      },
+    ]);
+    expect(r.note).toContain('attributed per order');
+    expect(r.note).toContain('dep-advisory:tmp');
+    expect(r.ledger).toContain('### Guardrail containment');
+    expect(r.ledger).toContain('dep-advisory:tmp');
+    // Breaker rows: the kept order verified; the dropped one carries ITS
+    // OWN guardrail failure, never the run's.
+    const rows = orderOutcomeRows(r, 'fix-vulns', {
+      timestamp: '2026-08-27T00:00:00Z',
+      stamp: { dxkitVersion: 'v', policyHash: 'h' },
+    });
+    expect(rows.map((row) => [row.orderId, row.outcome])).toEqual([
+      ['floor-failure:a', 'verified'],
+      ['dep-advisory:tmp', 'guardrail-red'],
+    ]);
+  });
+
+  it('ambiguity between a driver-failed order and a verified one attributes to the driver-failed one (disclosed tiebreak)', async () => {
+    // Both orders' envelopes cover src/, so a located finding overlaps
+    // both; order d's driver failed, so it is first in line.
+    const git = fakeGit({
+      'head0..head1': ['src/c.ts'],
+      'head1..head2': ['src/d.ts'],
+    });
+    const finding = {
+      kind: 'custom-check',
+      description: '[custom-check] lint · src/x.ts:3 — added (no-prior-match)',
+      file: 'src/x.ts',
+    };
+    const r = await runWith({
+      orders: [floorOrder('floor-failure:c', 'src/'), floorOrder('floor-failure:d', 'src/')],
+      git,
+      driver: scriptedDriver([
+        {},
+        { completed: false, failure: { reason: 'agent exited nonzero' } },
+      ]),
+      guardrails: [red([finding]), GREEN],
+    });
+    expect(r.outcome).toBe('partially-landed');
+    const recs = r.orders?.records ?? [];
+    expect(recs[0].disposition?.kind).toBe('kept');
+    expect(recs[1].outcome).toBe('failed');
+    expect(recs[1].disposition).toEqual({
+      kind: 'dropped',
+      step: 'guardrail',
+      reason: expect.stringContaining('src/x.ts'),
+    });
+    expect(r.containment?.dropped?.[0].evidence).toContain('driver-failed order preferred');
+  });
+});
+
+describe('guardrail-red containment: an unattributable red refuses honestly', () => {
+  it('a finding overlapping no kept order refuses containment, keeps guardrail-red, and reverts nothing', async () => {
+    const git = fakeGit();
+    const finding = {
+      kind: 'secret',
+      description: '[secret] docs/readme.md:1 — added (no-prior-match)',
+      file: 'docs/readme.md',
+    };
+    const r = await runWith({
+      orders: [floorOrder('floor-failure:a', 'src/')],
+      git,
+      guardrails: [red([finding])],
+    });
+    expect(r.outcome).toBe('guardrail-red');
+    expect(git.reverts).toEqual([]);
+    expect(git.resets).toEqual([]);
+    expect(r.containment?.refused).toContain("overlaps no kept order's envelope or committed");
+    expect(r.containment?.dropped).toEqual([]);
+    expect(r.note).toContain('Containment was attempted and refused');
+    expect(r.ledger).toContain('REFUSED');
+    // The salvage phrasing of the plain guardrail-red path is unchanged.
+    expect(r.note).toContain('the guardrail did not pass');
+  });
+
+  it('ambiguity among verified orders refuses (never a guess)', async () => {
+    const git = fakeGit();
+    const finding = {
+      kind: 'custom-check',
+      description: '[custom-check] lint · src/x.ts:3 — added (no-prior-match)',
+      file: 'src/x.ts',
+    };
+    const r = await runWith({
+      orders: [floorOrder('floor-failure:c', 'src/'), floorOrder('floor-failure:d', 'src/')],
+      git,
+      guardrails: [red([finding])],
+    });
+    expect(r.outcome).toBe('guardrail-red');
+    expect(r.containment?.refused).toContain('ambiguous between');
+    expect(git.reverts).toEqual([]);
+  });
+
+  it('a red with no attributable blocking findings (refusal-tier verdict) refuses', async () => {
+    const git = fakeGit();
+    const r = await runWith({
+      orders: [floorOrder('floor-failure:a', 'src/')],
+      git,
+      guardrails: [{ verdict: 'CANNOT GATE', ran: true, passesGate: false }],
+    });
+    expect(r.outcome).toBe('guardrail-red');
+    expect(r.containment?.refused).toContain('no attributable blocking findings');
+  });
+
+  it('a red attributing to EVERY kept order refuses: nothing would remain to land', async () => {
+    const git = fakeGit();
+    const finding = {
+      kind: 'dep-vuln',
+      description: '[dep-vuln] tmp@0.2.6 · GHSA-test — added (no-prior-match)',
+      package: 'tmp',
+    };
+    const r = await runWith({
+      orders: [depOrder('tmp')],
+      git,
+      guardrails: [red([finding])],
+    });
+    expect(r.outcome).toBe('guardrail-red');
+    expect(r.containment?.refused).toContain('nothing would remain to land');
+    expect(git.reverts).toEqual([]);
+  });
+
+  it('a red that survives the bounded unwind rounds refuses and restores the branch', async () => {
+    // Three orders in three envelope zones; every re-verification stays
+    // red on a finding pointing at the next order. After the bounded
+    // rounds the branch is restored to the pre-containment head.
+    const git = fakeGit({
+      'head0..head1': ['src/a/f.ts'],
+      'head1..head2': ['src/b/f.ts'],
+      'head2..head3': ['src/c/f.ts'],
+    });
+    const at = (p: string) => ({
+      kind: 'custom-check',
+      description: `[custom-check] lint · ${p}:1 — added (no-prior-match)`,
+      file: p,
+    });
+    const r = await runWith({
+      orders: [
+        floorOrder('floor-failure:a', 'src/a/'),
+        floorOrder('floor-failure:b', 'src/b/'),
+        floorOrder('floor-failure:c', 'src/c/'),
+      ],
+      git,
+      guardrails: [red([at('src/c/f.ts')]), red([at('src/b/f.ts')]), red([at('src/a/f.ts')])],
+    });
+    expect(r.outcome).toBe('guardrail-red');
+    expect(r.containment?.rounds).toBe(MAX_CONTAINMENT_ROUNDS);
+    expect(r.containment?.refused).toContain(`${MAX_CONTAINMENT_ROUNDS} unwind round(s)`);
+    // Two rounds unwound (newest range first), then the restore.
+    expect(git.reverts.map((x) => [x.from, x.to])).toEqual([
+      ['head2', 'head3'],
+      ['head1', 'head2'],
+    ]);
+    expect(git.resets).toEqual(['head3']);
+    expect(git.head()).toBe('head3');
+    // No drop survives a refusal: the ledger shows the full attempt.
+    expect(r.containment?.dropped).toEqual([]);
+    expect(r.orders?.records.every((x) => x.disposition?.kind === 'kept')).toBe(true);
+  });
+
+  it('a revert conflict refuses containment and restores the branch', async () => {
+    const git = fakeGit({
+      'head0..head1': ['src/a.ts'],
+      'head1..head2': ['package.json', 'package-lock.json'],
+    });
+    git.revertRange = () => {
+      throw new Error('CONFLICT (content): package-lock.json');
+    };
+    const finding = {
+      kind: 'dep-vuln',
+      description: '[dep-vuln] tmp@0.2.6 · GHSA-test — added (no-prior-match)',
+      package: 'tmp',
+    };
+    const r = await runWith({
+      orders: [floorOrder('floor-failure:a', 'src/'), depOrder('tmp')],
+      git,
+      guardrails: [red([finding])],
+    });
+    expect(r.outcome).toBe('guardrail-red');
+    expect(r.containment?.refused).toContain('conflicted');
+  });
+
+  it('the remainder failing its re-verification refuses (the unwound tree no longer verifies)', async () => {
+    const git = fakeGit({
+      'head0..head1': ['src/a.ts'],
+      'head1..head2': ['package.json', 'package-lock.json'],
+    });
+    const finding = {
+      kind: 'dep-vuln',
+      description: '[dep-vuln] tmp@0.2.6 · GHSA-test — added (no-prior-match)',
+      package: 'tmp',
+    };
+    const gates = [red([finding])];
+    const r = await runRemediateTask({
+      cwd: tmpCwd(),
+      trust: trustedLocalContext(),
+      taskId: 'fix-vulns',
+      config: config(),
+      drivers: [scriptedDriver()],
+      git,
+      runFloor: () => GREEN_FLOOR,
+      runGuardrail: async () => gates.shift() ?? GREEN,
+      verifySeams: {
+        worktree: async <T>(opts: { ref: string }, fn: (p: string) => Promise<T>) => fn(opts.ref),
+        // The post-unwind head (head3) no longer installs.
+        install: (head: string) =>
+          head === 'head3'
+            ? {
+                status: 'failed',
+                pack: 'typescript',
+                argv: ['npm', 'ci'],
+                output: 'EUSAGE',
+                classification: 'lockfile-drift',
+              }
+            : { status: 'installed', steps: [] },
+        changedFiles: () => ['src/a.ts'],
+      },
+      armInLoopGate: () => ({ mode: 'backstop-only' as const, reason: 'test' }),
+      runRecipePhase: async () => summary([floorOrder('floor-failure:a', 'src/'), depOrder('tmp')]),
+      frameInvariants: {
+        step: async () => ({
+          applied: [],
+          notApplicable: [],
+          changedPaths: [],
+          disclosures: [],
+          failed: false,
+        }),
+      },
+    });
+    expect(r.outcome).toBe('guardrail-red');
+    expect(r.containment?.refused).toContain('no longer verifies after the unwind');
+    // Restored: the revert commit was reset away.
+    expect(git.resets).toEqual(['head2']);
+  });
+});
+
+describe('guardrail-red containment: the recipe group is one unit', () => {
+  it('a finding overlapping only the recipe group diff drops the GROUP, keeps the agent order, and the rows record it', async () => {
+    const git = fakeGit({
+      'head0..head1': ['package.json', 'package-lock.json'],
+      'head1..head2': ['src/a.ts'],
+    });
+    const appliedRecord = {
+      orderId: 'dep-advisory:js-yaml',
+      class: 'dep-advisory',
+      recipe: 'override-pin',
+      outcome: { kind: 'applied' as const, changedFiles: ['package.json'] },
+    };
+    const finding = {
+      kind: 'config',
+      description: '[config] package.json:4 — added (no-prior-match)',
+      file: 'package.json',
+    };
+    const r = await runWith({
+      orders: [floorOrder('floor-failure:a', 'src/')],
+      git,
+      // The group pre-verification defers the guardrail, so the seam is
+      // consumed only by the final pass (red) and the containment re-run.
+      guardrails: [red([finding]), GREEN],
+      recipePhase: () => {
+        git.commit(); // the recipe tier committed the pin: head0 -> head1
+        return summary([floorOrder('floor-failure:a', 'src/')], {
+          ran: true,
+          selectedRecipeTier: 1,
+          records: [appliedRecord],
+        });
+      },
+    });
+    expect(r.outcome).toBe('partially-landed');
+    expect(r.recipes?.groupVerification).toEqual({
+      kind: 'dropped',
+      step: 'guardrail',
+      reason: expect.stringContaining('package.json'),
+      droppedOrderIds: ['dep-advisory:js-yaml'],
+    });
+    expect(r.recipes?.records[0].disposition?.kind).toBe('dropped');
+    expect(r.orders?.records[0].disposition?.kind).toBe('kept');
+    expect(git.reverts.map((x) => [x.from, x.to])).toEqual([['head0', 'head1']]);
+    const rows = orderOutcomeRows(r, 'fix-vulns', {
+      timestamp: '2026-08-27T00:00:00Z',
+      stamp: { dxkitVersion: 'v', policyHash: 'h' },
+    });
+    expect(rows.map((row) => [row.orderId, row.tier, row.outcome])).toEqual([
+      ['dep-advisory:js-yaml', 'recipe', 'guardrail-red'],
+      ['floor-failure:a', 'agent', 'verified'],
+    ]);
+  });
+});
+
+describe('driver-failure hygiene: verification is the evidence, first in line for attribution', () => {
+  it('a driver-failed order that survives per-order verification is KEPT and disclosed in the ledger', async () => {
+    const git = fakeGit();
+    const r = await runWith({
+      orders: [floorOrder('floor-failure:a', 'src/')],
+      git,
+      driver: scriptedDriver([{ completed: false, failure: { reason: 'max turns exhausted' } }]),
+      guardrails: [GREEN],
+    });
+    expect(r.orders?.records[0].outcome).toBe('failed');
+    expect(r.orders?.records[0].disposition?.kind).toBe('kept');
+    expect(r.ledger).toContain('driver-failure disclosure');
+    expect(r.ledger).toContain('first in line for containment attribution');
+    // The breaker row stays neutral for a kept-but-driver-failed order.
+    const rows = orderOutcomeRows(r, 'fix-vulns', {
+      timestamp: '2026-08-27T00:00:00Z',
+      stamp: { dxkitVersion: 'v', policyHash: 'h' },
+    });
+    expect(rows[0].outcome).toBe('partial-kept');
+  });
+});
+
+describe('composition with the deferred landing record (two-phase landing)', () => {
+  it('a contained run under the lane env writes ONE landing record for the green subset, no push attempted', async () => {
+    const cwd = tmpCwd();
+    execFileSync('git', ['init', '-q'], { cwd });
+    execFileSync('git', ['config', 'user.email', 'test@example.invalid'], { cwd });
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd });
+    fs.writeFileSync(path.join(cwd, 'a.txt'), 'a', 'utf8');
+    execFileSync('git', ['add', 'a.txt'], { cwd });
+    execFileSync('git', ['commit', '-qm', 'base'], { cwd });
+    const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' }).trim();
+
+    const contained: RemediateResult = {
+      outcome: 'partially-landed',
+      task: 'fix-vulns',
+      ledger: 'THE VERIFICATION LEDGER',
+      baseHead: head,
+      head,
+      containment: {
+        maxRounds: MAX_CONTAINMENT_ROUNDS,
+        rounds: 1,
+        dropped: [
+          {
+            unit: 'agent-order',
+            orderIds: ['dep-advisory:tmp'],
+            round: 1,
+            blocking: ['[dep-vuln] tmp@0.2.6'],
+            evidence: 'the order names package tmp',
+          },
+        ],
+      },
+      orders: {
+        cap: 5,
+        queued: 2,
+        records: [
+          {
+            orderId: 'floor-failure:a',
+            class: 'floor-failure',
+            findings: 1,
+            budget: { turns: 12, minutes: 6, usd: 2, derivation: 'd' },
+            outcome: 'completed',
+            done: { verifier: 'floor', absentIds: 1 },
+            disposition: { kind: 'kept', head },
+          },
+          {
+            orderId: 'dep-advisory:tmp',
+            class: 'dep-advisory',
+            findings: 1,
+            budget: { turns: 12, minutes: 6, usd: 2, derivation: 'd' },
+            outcome: 'completed',
+            done: { verifier: 'guardrail', absentIds: 1 },
+            disposition: {
+              kind: 'dropped',
+              step: 'guardrail',
+              reason: 'the final guardrail attributed blocking finding(s) to this order',
+            },
+          },
+        ],
+      },
+    };
+    let pushed = 0;
+    const run = await executeTask(cwd, config(), 'fix-vulns', 'pr', {
+      runTask: async () => contained,
+      branch: () => 'main',
+      defaultBranch: () => 'main',
+      landHead: () => {
+        pushed += 1;
+        return { outcome: 'pr-opened' as const, mode: 'pr' as const, prUrl: 'x' };
+      },
+      probeDelivery: () => ({ probes: [], anyBlocked: false, unverifiable: false }),
+      env: { [DEFERRED_LANDING_ENV]: '1' },
+    });
+    expect(pushed).toBe(0);
+    expect(run.landed).toBe(false);
+    expect(run.landingDeferred).toContain('remediate land');
+    // A partial landing is not clean: the dropped order stays visible.
+    expect(run.clean).toBe(false);
+    const record = JSON.parse(
+      fs.readFileSync(path.join(cwd, landingRecordPath('fix-vulns')), 'utf8'),
+    ) as {
+      action: string;
+      head: string;
+      prTitle: string;
+      orderRows: { orderId: string; outcome: string }[];
+    };
+    expect(record.action).toBe('land');
+    expect(record.head).toBe(head);
+    expect(record.prTitle).toContain('partial');
+    // The rows the record carries name each order's OWN outcome: the kept
+    // one verified, the contained one on its guardrail failure.
+    expect(record.orderRows.map((row) => [row.orderId, row.outcome])).toEqual([
+      ['floor-failure:a', 'verified'],
+      ['dep-advisory:tmp', 'guardrail-red'],
+    ]);
+  });
+});
+
+describe('the pure attribution ladder', () => {
+  const unit = (over: Partial<KeptUnit> & Pick<KeptUnit, 'orderIds'>): KeptUnit => ({
+    unit: 'agent-order',
+    from: 'h0',
+    to: 'h1',
+    diffPaths: [],
+    packages: new Set(),
+    driverFailed: false,
+    ...over,
+  });
+  const noManifest = () => false;
+
+  it('package naming narrows manifest-overlap ambiguity to the order naming the package', () => {
+    const a = unit({ orderIds: ['dep-advisory:a'], diffPaths: ['package-lock.json'] });
+    const b = unit({
+      orderIds: ['dep-advisory:tmp'],
+      diffPaths: ['package-lock.json'],
+      packages: new Set(['tmp']),
+    });
+    const isManifest = (p: string) => p === 'package-lock.json';
+    const res = attributeFinding(
+      { kind: 'dep-vuln', description: 'tmp advisory', package: 'tmp' },
+      [a, b],
+      isManifest,
+    );
+    expect(res).toEqual({
+      kind: 'attributed',
+      unit: b,
+      evidence: expect.stringContaining('names package tmp'),
+    });
+  });
+
+  it('ambiguity among several driver-failed candidates stays ambiguous (never a coin flip)', () => {
+    const a = unit({ orderIds: ['x'], diffPaths: ['src/x.ts'], driverFailed: true });
+    const b = unit({ orderIds: ['y'], diffPaths: ['src/x.ts'], driverFailed: true });
+    const res = attributeFinding(
+      { kind: 'custom-check', description: 'f', file: 'src/x.ts' },
+      [a, b],
+      noManifest,
+    );
+    expect(res.kind).toBe('ambiguous');
+  });
+
+  it('overlap evidence covers diff, envelope, and manifest directions and refuses coordinates it lacks', () => {
+    const u = unit({
+      orderIds: ['o'],
+      diffPaths: ['src/a.ts'],
+      envelope: { paths: ['src/'], manifests: false },
+    });
+    expect(
+      overlapEvidence({ kind: 'code', description: 'f', file: 'src/a.ts' }, u, noManifest),
+    ).toContain('committed diff touches');
+    expect(
+      overlapEvidence({ kind: 'code', description: 'f', file: 'src/b.ts' }, u, noManifest),
+    ).toContain('inside the order envelope');
+    expect(
+      overlapEvidence({ kind: 'code', description: 'f', file: 'docs/x.md' }, u, noManifest),
+    ).toBeNull();
+    // A finding with neither file nor package can never be attributed.
+    expect(overlapEvidence({ kind: 'paired-change', description: 'f' }, u, noManifest)).toBeNull();
+  });
+
+  it('buildKeptUnits refuses a chain that does not close on the verified head', () => {
+    const git = fakeGit();
+    git.commit(); // head1, but no kept disposition accounts for it
+    const res = buildKeptUnits({
+      git,
+      baseHead: 'head0',
+      agentBase: 'head0',
+      entryFloor: GREEN_FLOOR,
+      runFloor: () => GREEN_FLOOR,
+      recipes: summary([]),
+      records: [],
+      ordersById: new Map(),
+      guardrail: GREEN,
+      isManifestPath: noManifest,
+    });
+    expect(typeof res).toBe('string');
+    expect(res).toContain('cannot be trusted');
+  });
+});
+
+describe('the recipe-fallthrough budget floor (derivation, not a constant)', () => {
+  const cap = { maxTurns: 40, maxMinutes: 60, maxUsd: 5 };
+
+  it('doubles the derived floor for a fallthrough order, clamped by the task cap, with the formula disclosed', () => {
+    const standard = deriveBudget(1, cap);
+    expect(standard.turns).toBe(12);
+    expect(standard.derivation).not.toContain('recipe-fallthrough');
+    const raised = deriveBudget(1, cap, { recipeFallthrough: true });
+    expect(raised.turns).toBe(24);
+    expect(raised.minutes).toBe(14);
+    expect(raised.derivation).toContain('recipe-fallthrough floor');
+    expect(raised.derivation).toContain('2 *');
+    // Still clamped by the cap in every dimension.
+    const clamped = deriveBudget(
+      10,
+      { maxTurns: 30, maxMinutes: 20, maxUsd: 3 },
+      {
+        recipeFallthrough: true,
+      },
+    );
+    expect(clamped.turns).toBe(30);
+    expect(clamped.minutes).toBe(20);
+    expect(clamped.usd).toBeLessThanOrEqual(3);
+  });
+
+  it('withRecipeFallthroughBudget re-derives from the order finding count through the ONE formula', () => {
+    const order = depOrder('tmp');
+    const raised = withRecipeFallthroughBudget(order, cap);
+    expect(raised.budget).toEqual(
+      deriveBudget(order.findings.length, cap, { recipeFallthrough: true }),
+    );
+    expect(raised.id).toBe(order.id);
+  });
+});

--- a/test/remediate/guardrail-containment.test.ts
+++ b/test/remediate/guardrail-containment.test.ts
@@ -9,8 +9,12 @@
  *     reverted, the remainder re-verifies green and lands as
  *     `partially-landed`; the ledger, containment disclosure, and breaker
  *     rows name the dropped order on its own failure;
- *   - ambiguity: a driver-failed order is preferred over verified ones;
- *     ambiguity among verified orders REFUSES;
+ *   - evidence strength: direct evidence (package naming, committed-diff
+ *     touch) outranks circumstantial overlap (envelope containment, the
+ *     manifest heuristic), so a repo-wide-envelope order can never absorb
+ *     another order's finding; within one tier a driver-failed order is
+ *     preferred over verified ones; ambiguity among verified orders
+ *     REFUSES;
  *   - refusal: a finding attributing to NO order refuses; a red that
  *     survives the bounded rounds refuses and restores the branch; a red
  *     with no attributable findings (a refusal-tier verdict) refuses; a
@@ -332,6 +336,50 @@ describe('guardrail-red containment: contained red lands the remainder', () => {
   });
 });
 
+describe('guardrail-red containment: evidence strength outranks the driver tiebreak', () => {
+  it("a repo-wide-envelope driver-failed floor order does NOT absorb a finding another order's diff touches", async () => {
+    // Order e carries the explicit repo-wide envelope (a whole-build floor
+    // order) AND its driver failed, so pre-tiering it overlapped every
+    // located finding and the driver tiebreak blamed it. Order f is
+    // verified and its committed diff touches the finding's file: the
+    // direct evidence must win in round 1.
+    const git = fakeGit({
+      'head0..head1': ['src/util.ts'],
+      'head1..head2': ['src/f.ts'],
+    });
+    const finding = {
+      kind: 'custom-check',
+      description: '[custom-check] lint · src/f.ts:3 — added (no-prior-match)',
+      file: 'src/f.ts',
+    };
+    const r = await runWith({
+      orders: [floorOrder('floor-failure:e', '*'), floorOrder('floor-failure:f', 'src/')],
+      git,
+      driver: scriptedDriver([
+        { completed: false, failure: { reason: 'agent exited nonzero' } },
+        {},
+      ]),
+      guardrails: [red([finding]), GREEN],
+    });
+    expect(r.outcome).toBe('partially-landed');
+    const recs = r.orders?.records ?? [];
+    // The driver-failed repo-wide order is KEPT; the diff-touching order is
+    // the attributed drop.
+    expect(recs[0].orderId).toBe('floor-failure:e');
+    expect(recs[0].disposition?.kind).toBe('kept');
+    expect(recs[1].orderId).toBe('floor-failure:f');
+    expect(recs[1].disposition).toEqual({
+      kind: 'dropped',
+      step: 'guardrail',
+      reason: expect.stringContaining('src/f.ts'),
+    });
+    expect(r.containment?.rounds).toBe(1);
+    expect(r.containment?.dropped?.[0].orderIds).toEqual(['floor-failure:f']);
+    expect(r.containment?.dropped?.[0].evidence).toContain('committed diff touches src/f.ts');
+    expect(git.reverts.map((x) => [x.from, x.to])).toEqual([['head1', 'head2']]);
+  });
+});
+
 describe('guardrail-red containment: an unattributable red refuses honestly', () => {
   it('a finding overlapping no kept order refuses containment, keeps guardrail-red, and reverts nothing', async () => {
     const git = fakeGit();
@@ -568,6 +616,63 @@ describe('guardrail-red containment: the recipe group is one unit', () => {
   });
 });
 
+describe('guardrail-red containment: a red on a recipe-pinned package blames the GROUP, not a driver-failed agent order', () => {
+  it('the group unit carries the packages its applied orders pinned, so the package tier attributes to it', async () => {
+    const git = fakeGit({
+      'head0..head1': ['package.json', 'package-lock.json'],
+      'head1..head2': ['package.json', 'package-lock.json'],
+    });
+    const appliedRecord = {
+      orderId: 'dep-advisory:left-pad',
+      class: 'dep-advisory',
+      recipe: 'override-pin',
+      outcome: { kind: 'applied' as const, changedFiles: ['package.json'] },
+      packages: ['left-pad'],
+    };
+    // The red names the package the RECIPE pinned; the driver-failed agent
+    // order for another package also touched the manifests, so pre-fix the
+    // package tier could never match the group and the driver tiebreak
+    // blamed the innocent agent order.
+    const finding = {
+      kind: 'dep-vuln',
+      description: '[dep-vuln] left-pad@1.0.0 · GHSA-test — added (no-prior-match)',
+      package: 'left-pad',
+    };
+    const r = await runWith({
+      orders: [depOrder('tmp')],
+      git,
+      driver: scriptedDriver([{ completed: false, failure: { reason: 'agent exited nonzero' } }]),
+      guardrails: [red([finding]), GREEN],
+      recipePhase: () => {
+        git.commit(); // the recipe tier committed the pin: head0 -> head1
+        return summary([depOrder('tmp')], {
+          ran: true,
+          selectedRecipeTier: 1,
+          records: [appliedRecord],
+        });
+      },
+    });
+    expect(r.outcome).toBe('partially-landed');
+    expect(r.recipes?.groupVerification).toEqual({
+      kind: 'dropped',
+      step: 'guardrail',
+      reason: expect.stringContaining('left-pad'),
+      droppedOrderIds: ['dep-advisory:left-pad'],
+    });
+    // The driver-failed agent order is KEPT: the package evidence names the
+    // group, so no tiebreak ever ran against the innocent order.
+    expect(r.orders?.records[0].disposition?.kind).toBe('kept');
+    expect(r.containment?.dropped?.[0]).toEqual(
+      expect.objectContaining({
+        unit: 'recipe-group',
+        orderIds: ['dep-advisory:left-pad'],
+        evidence: expect.stringContaining('names package left-pad'),
+      }),
+    );
+    expect(git.reverts.map((x) => [x.from, x.to])).toEqual([['head0', 'head1']]);
+  });
+});
+
 describe('driver-failure hygiene: verification is the evidence, first in line for attribution', () => {
   it('a driver-failed order that survives per-order verification is KEPT and disclosed in the ledger', async () => {
     const git = fakeGit();
@@ -589,6 +694,98 @@ describe('driver-failure hygiene: verification is the evidence, first in line fo
     expect(rows[0].outcome).toBe('partial-kept');
   });
 });
+
+describe('a failed branch restore is disclosed and suppresses the salvage draft', () => {
+  it('a refusal whose restore throws sets restoreFailed and says the branch stays local', async () => {
+    // Round 1 attributes and reverts; the re-run stays red on a finding
+    // no remaining order overlaps, so containment refuses AFTER mutating
+    // the branch, and the restore itself throws.
+    const git = fakeGit({
+      'head0..head1': ['src/a.ts'],
+      'head1..head2': ['package.json', 'package-lock.json'],
+    });
+    git.resetTo = () => {
+      throw new Error('reset refused by the filesystem');
+    };
+    const tmpFinding = {
+      kind: 'dep-vuln',
+      description: '[dep-vuln] tmp@0.2.6 · GHSA-test — added (no-prior-match)',
+      package: 'tmp',
+    };
+    const strayFinding = {
+      kind: 'secret',
+      description: '[secret] docs/readme.md:1 — added (no-prior-match)',
+      file: 'docs/readme.md',
+    };
+    const r = await runWith({
+      orders: [floorOrder('floor-failure:a', 'src/'), depOrder('tmp')],
+      git,
+      guardrails: [red([tmpFinding]), red([strayFinding])],
+    });
+    expect(r.outcome).toBe('guardrail-red');
+    expect(r.containment?.restoreFailed).toBe(true);
+    expect(r.containment?.refused).toContain('restoring the branch');
+    expect(r.containment?.refused).toContain('left as-is for inspection');
+  });
+
+  it('executor: a guardrail-red refusal with a CLEAN restore still pushes the blocked salvage draft', async () => {
+    const cwd = tmpCwd();
+    let pushed = 0;
+    const run = await executeTask(cwd, config(), 'fix-vulns', 'pr', {
+      runTask: async () => refusedRedResult(false),
+      branch: () => 'main',
+      defaultBranch: () => 'main',
+      landHead: () => {
+        pushed += 1;
+        return { outcome: 'pr-opened' as const, mode: 'pr' as const, prUrl: 'x' };
+      },
+      probeDelivery: () => ({ probes: [], anyBlocked: false, unverifiable: false }),
+      writeOrderLedger: () => null,
+      publishOrderRows: () => ({ published: true }),
+    });
+    expect(pushed).toBe(1);
+    expect(run.landed).toBe(true);
+    expect(run.clean).toBe(false);
+  });
+
+  it('executor: a guardrail-red refusal whose restore FAILED never pushes (HEAD is a tree no verification saw)', async () => {
+    const cwd = tmpCwd();
+    let pushed = 0;
+    const run = await executeTask(cwd, config(), 'fix-vulns', 'pr', {
+      runTask: async () => refusedRedResult(true),
+      branch: () => 'main',
+      defaultBranch: () => 'main',
+      landHead: () => {
+        pushed += 1;
+        return { outcome: 'pr-opened' as const, mode: 'pr' as const, prUrl: 'x' };
+      },
+      probeDelivery: () => ({ probes: [], anyBlocked: false, unverifiable: false }),
+      writeOrderLedger: () => null,
+      publishOrderRows: () => ({ published: true }),
+    });
+    expect(pushed).toBe(0);
+    expect(run.landed).toBe(false);
+  });
+});
+
+/** A guardrail-red refusal result for the executor's salvage decision. */
+function refusedRedResult(restoreFailed: boolean): RemediateResult {
+  return {
+    outcome: 'guardrail-red',
+    task: 'fix-vulns',
+    ledger: 'THE VERIFICATION LEDGER',
+    baseHead: 'aaaa1111',
+    head: 'bbbb2222',
+    guardrailRan: true,
+    containment: {
+      maxRounds: MAX_CONTAINMENT_ROUNDS,
+      rounds: 1,
+      dropped: [],
+      refused: 'the remainder no longer verifies after the unwind',
+      ...(restoreFailed ? { restoreFailed: true as const } : {}),
+    },
+  };
+}
 
 describe('composition with the deferred landing record (two-phase landing)', () => {
   it('a contained run under the lane env writes ONE landing record for the green subset, no push attempted', async () => {
@@ -729,7 +926,7 @@ describe('the pure attribution ladder', () => {
     expect(res.kind).toBe('ambiguous');
   });
 
-  it('overlap evidence covers diff, envelope, and manifest directions and refuses coordinates it lacks', () => {
+  it('overlap evidence covers diff, envelope, and manifest directions with their tiers, and refuses coordinates it lacks', () => {
     const u = unit({
       orderIds: ['o'],
       diffPaths: ['src/a.ts'],
@@ -737,15 +934,60 @@ describe('the pure attribution ladder', () => {
     });
     expect(
       overlapEvidence({ kind: 'code', description: 'f', file: 'src/a.ts' }, u, noManifest),
-    ).toContain('committed diff touches');
+    ).toEqual({
+      tier: 1,
+      evidence: expect.stringContaining('committed diff touches'),
+    });
     expect(
       overlapEvidence({ kind: 'code', description: 'f', file: 'src/b.ts' }, u, noManifest),
-    ).toContain('inside the order envelope');
+    ).toEqual({
+      tier: 2,
+      evidence: expect.stringContaining('inside the order envelope'),
+    });
     expect(
       overlapEvidence({ kind: 'code', description: 'f', file: 'docs/x.md' }, u, noManifest),
     ).toBeNull();
     // A finding with neither file nor package can never be attributed.
     expect(overlapEvidence({ kind: 'paired-change', description: 'f' }, u, noManifest)).toBeNull();
+    // Package naming is direct; the manifest heuristic is circumstantial.
+    const dep = unit({
+      orderIds: ['d'],
+      packages: new Set(['tmp']),
+      diffPaths: ['package-lock.json'],
+    });
+    const isManifest = (x: string) => x === 'package-lock.json';
+    expect(
+      overlapEvidence({ kind: 'dep-vuln', description: 'f', package: 'tmp' }, dep, isManifest)
+        ?.tier,
+    ).toBe(1);
+    expect(
+      overlapEvidence({ kind: 'dep-vuln', description: 'f', package: 'left-pad' }, dep, isManifest)
+        ?.tier,
+    ).toBe(2);
+  });
+
+  it('tier-1 diff evidence beats a repo-wide-envelope driver-failed candidate (a tiebreak never beats evidence)', () => {
+    const repoWide = unit({
+      orderIds: ['floor-failure:whole-build'],
+      diffPaths: ['src/util.ts'],
+      envelope: { paths: ['*'], manifests: false },
+      driverFailed: true,
+    });
+    const toucher = unit({
+      orderIds: ['floor-failure:f'],
+      diffPaths: ['src/f.ts'],
+      envelope: { paths: ['src/'], manifests: false },
+    });
+    const res = attributeFinding(
+      { kind: 'custom-check', description: 'f', file: 'src/f.ts' },
+      [repoWide, toucher],
+      noManifest,
+    );
+    expect(res).toEqual({
+      kind: 'attributed',
+      unit: toucher,
+      evidence: expect.stringContaining('direct evidence outranked'),
+    });
   });
 
   it('buildKeptUnits refuses a chain that does not close on the verified head', () => {

--- a/test/remediate/orders-phase.test.ts
+++ b/test/remediate/orders-phase.test.ts
@@ -95,6 +95,7 @@ function fakeGit(script: GitScript = {}): RemediateGit & {
     commitPaths: () => {},
     cleanPaths: () => {},
     revertPaths: () => {},
+    revertRange: () => {},
   };
   return g;
 }

--- a/test/remediate/recipes/frame.test.ts
+++ b/test/remediate/recipes/frame.test.ts
@@ -27,6 +27,7 @@ function fakeGit(diff: boolean): RemediateGit {
     commitPaths: () => {},
     cleanPaths: () => {},
     revertPaths: () => {},
+    revertRange: () => {},
     hasDiff: () => diff,
   };
 }
@@ -118,6 +119,7 @@ function recipeCommitGit(diffs: Record<string, boolean>): RemediateGit {
     commitPaths: () => {},
     cleanPaths: () => {},
     revertPaths: () => {},
+    revertRange: () => {},
     hasDiff: (base: string) => diffs[base] ?? false,
   };
 }

--- a/test/remediate/recipes/run-recipes.test.ts
+++ b/test/remediate/recipes/run-recipes.test.ts
@@ -30,7 +30,7 @@ import type { CorrectnessFloorResult } from '../../../src/analyzers/correctness/
 import { budgetForTask, resolveRemediateConfig } from '../../../src/remediate/config';
 import { deriveBudget } from '../../../src/remediate/work-orders/shared';
 import { trustedLocalContext, untrustedContentContext } from '../../../src/analysis-trust';
-import { fakeExec, lintFinding, makeOrder, tempRepo } from './helpers';
+import { advisoryFinding, fakeExec, lintFinding, makeOrder, tempRepo } from './helpers';
 
 describe('envelope containment', () => {
   it('speaks the planner language: explicit repo-wide marker, directory prefix, exact file', () => {
@@ -142,6 +142,48 @@ describe('runRecipeOrders', () => {
         message: 'fix(synthetic-class): synthetic-class:unit (synthetic-fixer recipe)',
       },
     ]);
+  });
+
+  it("an applied record carries the packages the order's findings name (the containment package tier reads them)", async () => {
+    const git = fakeGit();
+    const { exec } = fakeExec();
+    const depOrder = makeOrder({
+      id: 'dep-advisory:tmp',
+      class: 'dep-advisory',
+      recipe: 'synthetic-fixer',
+      envelope: { paths: ['package.json'], manifests: true },
+      findings: [advisoryFinding('f1', 'tmp', 'GHSA-test', '0.2.4')],
+    });
+    const registry = [
+      syntheticRecipe(async () => {
+        git.dirty.push('package.json');
+        return { kind: 'applied' as const, changedFiles: ['package.json'] };
+      }),
+    ];
+    const records = await runRecipeOrders([depOrder], {
+      cwd: '/x',
+      trust: trustedLocalContext(),
+      git,
+      exec,
+      registry,
+    });
+    expect(records[0].outcome.kind).toBe('applied');
+    expect(records[0].packages).toEqual(['tmp']);
+    // An order naming no package records none (the field stays absent).
+    const git2 = fakeGit();
+    const plain = await runRecipeOrders([syntheticOrder], {
+      cwd: '/x',
+      trust: trustedLocalContext(),
+      git: git2,
+      exec,
+      registry: [
+        syntheticRecipe(async () => {
+          git2.dirty.push('fixed.txt');
+          return { kind: 'applied' as const, changedFiles: ['fixed.txt'] };
+        }),
+      ],
+    });
+    expect(plain[0].packages).toBeUndefined();
   });
 
   it('an UNTRUSTED tree refuses every order before any execute runs (disclosed, nothing spawns)', async () => {

--- a/test/remediate/recipes/run-recipes.test.ts
+++ b/test/remediate/recipes/run-recipes.test.ts
@@ -27,7 +27,8 @@ import {
   type RecipeDeclaration,
 } from '../../../src/remediate/work-orders/recipes-registry';
 import type { CorrectnessFloorResult } from '../../../src/analyzers/correctness/run';
-import { resolveRemediateConfig } from '../../../src/remediate/config';
+import { budgetForTask, resolveRemediateConfig } from '../../../src/remediate/config';
+import { deriveBudget } from '../../../src/remediate/work-orders/shared';
 import { trustedLocalContext, untrustedContentContext } from '../../../src/analysis-trust';
 import { fakeExec, lintFinding, makeOrder, tempRepo } from './helpers';
 
@@ -601,6 +602,54 @@ describe('runRecipePhaseForTask', () => {
     // Both the non-applied recipe order and the agent-tier floor order are queued.
     expect(ids.some((id) => id.startsWith('stale-lockfile:'))).toBe(true);
     expect(ids.some((id) => id.startsWith('floor-failure:'))).toBe(true);
+  });
+
+  it('a fallthrough order joins the agent queue with the RAISED recipe-fallthrough budget, disclosed', async () => {
+    const cwd = tempRepo({
+      'package.json': '{"name":"fx"}',
+      'package-lock.json': '{}',
+      'src/index.ts': 'export const x = 1;\n',
+      '.dxkit/policy.json': '{}',
+    });
+    const git = fakeGit();
+    const { exec } = fakeExec(() => undefined);
+    const entryFloor = floorWith([
+      {
+        pack: 'typescript',
+        label: 'lockfile-sync',
+        bin: 'npm',
+        args: ['ci', '--dry-run'],
+        status: 'fail',
+        output: 'EUSAGE',
+      },
+      { pack: 'typescript', label: 'tests', bin: 'npx', args: ['vitest'], status: 'fail' },
+    ] as CorrectnessFloorResult['checks']);
+    const summary = await runRecipePhaseForTask({
+      cwd,
+      trust: trustedLocalContext(),
+      taskId: 'fix-build',
+      config: resolveRemediateConfig(cwd),
+      entryFloor,
+      git,
+      exec,
+    });
+    const queue = summary.agentOrders ?? [];
+    const fallthrough = queue.find((o) => o.id.startsWith('stale-lockfile:'));
+    const native = queue.find((o) => o.id.startsWith('floor-failure:'));
+    expect(fallthrough).toBeDefined();
+    expect(native).toBeDefined();
+    // The fallthrough order's budget is re-derived with the disclosed
+    // recipe-fallthrough floor; a native agent-tier order keeps the
+    // planner's standard derivation.
+    expect(fallthrough!.budget.derivation).toContain('recipe-fallthrough floor');
+    expect(native!.budget.derivation).not.toContain('recipe-fallthrough');
+    const cap = budgetForTask(resolveRemediateConfig(cwd), 'fix-build');
+    expect(fallthrough!.budget).toEqual(
+      deriveBudget(fallthrough!.findings.length, cap, { recipeFallthrough: true }),
+    );
+    expect(fallthrough!.budget.turns).toBeGreaterThan(
+      deriveBudget(fallthrough!.findings.length, cap).turns,
+    );
   });
 
   it('recipes disabled still plans and routes EVERY selected order to the agent queue', async () => {

--- a/test/remediate/resume.test.ts
+++ b/test/remediate/resume.test.ts
@@ -278,6 +278,7 @@ function fakeGit(): RemediateGit {
     commitPaths: () => {},
     cleanPaths: () => {},
     revertPaths: () => {},
+    revertRange: () => {},
     hasDiff: () => {
       head = 'salvage01';
       return true;

--- a/test/remediate/run.test.ts
+++ b/test/remediate/run.test.ts
@@ -48,6 +48,7 @@ function fakeGit(opts: { diff?: boolean; sweepError?: string } = {}): RemediateG
     commitPaths: () => {},
     cleanPaths: () => {},
     revertPaths: () => {},
+    revertRange: () => {},
     hasDiff: () => {
       if (opts.diff) head = 'head1111';
       return !!opts.diff;
@@ -194,6 +195,7 @@ describe('refusal + infra arms (each truthful and distinct)', () => {
       commitPaths: () => {},
       cleanPaths: () => {},
       revertPaths: () => {},
+      revertRange: () => {},
       hasDiff: () => false,
     };
     const driver = fakeDriver({ completed: false, neverRan: { reason: 'exit 143' } });


### PR DESCRIPTION
## What

4.4.7 unit D2 (defect A2, run 33116991323): the final guardrail's red verdict is now contained per order instead of flipping the whole run to salvage-draft. On the live run, one agent-tier order (its driver exhausted max_turns) left an in-envelope dependency pin whose advisory re-keyed as "added"; the run-level red dragged nine verified green recipe pins down with it. The unit of landing is the order, so the guardrail verdict now respects that boundary.

## How

**Containment engine** (`src/remediate/containment.ts`, invoked by `orders-complete.ts` when the final guardrail RAN and did not pass):

1. **Attribute** each blocking finding to exactly one kept unit (a kept agent order, or the kept recipe group as one unit, the 4.4.6 drop granularity) on overlap evidence: the unit names the finding's package, its committed diff touches the finding's file, the file sits inside the order envelope, or (package-shaped finding, no file) the unit touched a dependency manifest. Ambiguity narrows first to the unit(s) naming the package, then to a driver-failed unit over verified ones. Rule 19 discipline: a finding overlapping no unit, or one that stays ambiguous, refuses containment for the whole run; no order is ever dropped on a guess.
2. **Unwind** the attributed units: each unit's commit range is reverted as one commit at the tip (`RemediateGit.revertRange`, so later kept commits survive intact), newest range first. A revert conflict refuses and restores.
3. **Re-verify** the remainder through the ONE tree verification (`verifyCommittedHead`: install + floor + guardrail, the same seam the run-level check already used, no second guardrail invocation path). Verified: the run completes `partially-landed` and the green subset lands. Still red: another round, bounded at `MAX_CONTAINMENT_ROUNDS = 2` (disclosed). Anything else (install-failed / floor-red / infrastructure) refuses.

Every refusal restores the branch to the pre-containment head, so the plain guardrail-red path (salvage draft of the full attempt, negative constraints for the next run) sees exactly the tree it always saw, plus a disclosed refusal reason in the note, the ledger, and the result.

**Outcome shape**: a contained run completes `partially-landed` (even when the run was budget-partial: the remainder is fully verified). The dropped orders carry `disposition: dropped at step guardrail` with the attributed findings in the reason, the ledger gets a "Guardrail containment" section (drops + evidence, or the refusal), the PR body inherits it, and the breaker rows record `guardrail-red` for the dropped order's class while the kept orders record `verified` (the contained drop is that ORDER's failure, never the run's).

**Structured attribution evidence**: `guardrailVerdictFor` (the one lane guardrail seam) now also projects every blocking pair into an uncapped `BlockingFinding { kind, description, file?, package? }`, with the package read from the current scan's anchor entry, never re-parsed from the display locator. Display list + cap unchanged.

**Driver-failure policy** (stated, implemented, tested): an agent order whose driver failed (nonzero exit / reported failure) or overran its budget (max_turns) goes through per-order verification like any order; its committed partial is KEPT only on the verification's evidence (the agent's claim counts for nothing), that fact is disclosed per order in the ledger, and a driver-failed order is FIRST in line for containment attribution on ambiguity with a verified order.

**Turn-budget floor** (evidence: both live agent orders exhausted their 12 derived turns on work whose recipe had already failed): an order that falls through from a failed or refused recipe re-derives its budget through the ONE formula with a declared multiplier:

```
turns   = min(cap.maxTurns,   2 * max(10, 8 + 4 * findings))
minutes = min(cap.maxMinutes, 2 * max(5,  5 + 2 * findings))
usd     = min(cap.maxUsd, round(cap.maxUsd * turns / cap.maxTurns))
```

`recipeFallthroughMultiplier: 2` lives in `BUDGET_DERIVATION`; the raised formula (with the reason) is disclosed in the order's derivation string and rendered in the ledger's budget line. Native agent-tier orders and the recipes-disabled routing keep the standard derivation (no recipe was tried there, so no fallthrough evidence exists).

**Composition with D1 (two-phase landing)**: `partially-landed` was already land-eligible, so a contained run under the lane's deferred-landing env writes ONE landing record for the green subset, order rows included; pinned by test.

## Tests (18 new in `test/remediate/guardrail-containment.test.ts`, 1 in `run-recipes.test.ts`)

- contained red lands the remainder: package-named attribution, revert of exactly the attributed range, `partially-landed`, containment disclosure, ledger section, breaker rows (`verified` / `guardrail-red`);
- ambiguity tiebreak to the driver-failed order (evidence string disclosed);
- refusals, each direction: no-overlap finding; ambiguity among verified orders; red with no attributable findings (refusal-tier verdict); every order attributed (nothing would remain); revert conflict; remainder failing re-verification; red surviving the bounded rounds (branch restored, `resets` asserted);
- recipe group dropped as ONE unit (group verification flipped, recipe row `guardrail-red`, agent order lands);
- driver-failed order kept on verification evidence with the ledger disclosure and the neutral `partial-kept` breaker row;
- pure ladder: package narrowing among manifest-overlap candidates, ambiguous driver-failed pair stays ambiguous, overlap directions incl. the coordinate-less finding, chain-break refusal in `buildKeptUnits`;
- budget floor: formula both modes, cap clamps, `withRecipeFallthroughBudget` identity, and the run-recipes queue applying it to fallthrough orders only;
- deferred-landing composition: contained run under `DXKIT_DEFERRED_LANDING=1` writes one `land` record with the green head and per-order rows, no push attempted.

## Sweep + guardrail

- `npm run typecheck` / `typecheck:test`: clean
- `npx eslint . --max-warnings 0`: clean
- `npx prettier --check .`: clean
- `scripts/check-architecture.sh`, `check-docs-coverage.sh`, `DXKIT_SLOP_BASE=origin/main check-slop.sh`: pass (slop file-size note on a pre-existing file is advisory)
- `npm run build && npx vitest run --coverage`: 422 files, 6367 tests passed; coverage 74.99% (gate 50%)
- `node dist/index.js guardrail check --mode ref-based --ref origin/main`: **PASSED**, exit 0 (0 blocking)

## Review focus

- `containment.ts:buildKeptUnits`: the kept-head chain reconstruction (drops reset to the previously verified head, so kept heads chain from baseHead to the verified head; any mismatch refuses).
- `orders-complete.ts`: the contained arm deliberately precedes the `partial` (budget-exhausted) arm, because the live failure shape IS a partial run; every other precedence is unchanged.
- Rule 19 posture: is the manifest-touch overlap for package-shaped findings (transitive advisory case) acceptable as candidate evidence, given the package-name and driver tiers narrow it and any residual ambiguity refuses?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
