### PR TITLE
feat(bom): CycloneDX SBOM export with pack-declared purl ecosystems (4.4.7 S1)

### DIFF
--- a/src/analyzers/bom/cyclonedx.ts
+++ b/src/analyzers/bom/cyclonedx.ts
@@ -1,0 +1,242 @@
+/**
+ * CycloneDX SBOM renderer: a PURE projection of the ONE BoM concept
+ * (`BomEntry[]` + report metadata, Rule 2) into the standard interchange
+ * format. No gathering happens here: every fact comes from the joined
+ * license + dep-vuln data the bom gather already produced, and any field
+ * the data cannot back is OMITTED, never padded with a placeholder.
+ *
+ * specVersion: 1.5. Everything this renderer emits (components with
+ * purl + licenses + properties, vulnerabilities with source, ratings,
+ * and affects) is fully expressible in 1.5, and 1.5 has the widest
+ * consumer support (Dependency-Track, osv-scanner, Trivy, Grype all
+ * accept it). The 1.6 additions (cryptographic assets, attestations,
+ * ML-BOM extensions) model data dxkit does not gather, so claiming 1.6
+ * would buy nothing and narrow the consumer set.
+ *
+ * SPDX-format export is deliberately NOT implemented here or elsewhere
+ * yet: CycloneDX was chosen first because it is the vulnerability-
+ * workflow interchange format (a first-class vulnerabilities section,
+ * which SPDX lacks); an SPDX document export lands when a consumer
+ * needs it.
+ *
+ * Determinism: the renderer takes its timestamp as an argument (the
+ * caller passes the report's own `analyzedAt`; there is no inline
+ * Date.now), emits no random serialNumber, and preserves the gather's
+ * stable entry ordering, so identical input renders byte-identical
+ * output, pinned by test.
+ */
+
+import { knownSpdxId, splitLicenseTerms } from '../licenses/detailed';
+import { getLanguage } from '../../languages';
+import { buildPurl } from './purl';
+import type { BomEntry, BomReport } from './types';
+
+/** CycloneDX severity enum values our four-tier severities map onto. */
+export type CycloneDxSeverity = 'critical' | 'high' | 'medium' | 'low';
+
+export interface CycloneDxLicenseEntry {
+  license?: { id?: string; name?: string };
+  expression?: string;
+}
+
+export interface CycloneDxProperty {
+  name: string;
+  value: string;
+}
+
+export interface CycloneDxComponent {
+  'bom-ref': string;
+  type: 'library';
+  name: string;
+  version?: string;
+  purl?: string;
+  licenses?: CycloneDxLicenseEntry[];
+  properties?: CycloneDxProperty[];
+}
+
+export interface CycloneDxRating {
+  severity: CycloneDxSeverity;
+  score?: number;
+}
+
+export interface CycloneDxVulnerability {
+  id: string;
+  source?: { name: string; url?: string };
+  description?: string;
+  ratings: CycloneDxRating[];
+  affects: Array<{ ref: string }>;
+}
+
+export interface CycloneDxDocument {
+  bomFormat: 'CycloneDX';
+  specVersion: '1.5';
+  version: 1;
+  metadata: {
+    timestamp: string;
+    tools: {
+      components: Array<{ type: 'application'; name: string; version: string }>;
+    };
+    component: { 'bom-ref': string; type: 'application'; name: string };
+  };
+  components: CycloneDxComponent[];
+  vulnerabilities?: CycloneDxVulnerability[];
+}
+
+export interface CycloneDxOptions {
+  /** ISO timestamp for metadata.timestamp: injected, never Date.now
+   *  inline. The CLI passes the report's own `analyzedAt` so the SBOM
+   *  is stamped with the same instant as every other rendering of that
+   *  gather. */
+  timestamp: string;
+  /** The generating dxkit version, for metadata.tools. */
+  dxkitVersion: string;
+}
+
+/**
+ * Advisory source derived from the id's namespace, a factual mapping
+ * (GHSA ids ARE GitHub Advisory Database ids), never a guess: an
+ * unrecognized scheme yields no source field at all.
+ */
+export function advisorySource(id: string): { name: string; url?: string } | undefined {
+  if (/^GHSA-/.test(id)) {
+    return { name: 'GitHub Advisory Database', url: `https://github.com/advisories/${id}` };
+  }
+  if (/^CVE-/.test(id)) {
+    return { name: 'NVD', url: `https://nvd.nist.gov/vuln/detail/${id}` };
+  }
+  if (/^RUSTSEC-/.test(id)) {
+    return { name: 'RustSec Advisory Database', url: `https://rustsec.org/advisories/${id}` };
+  }
+  if (/^(PYSEC|OSV)-/.test(id)) {
+    return { name: 'OSV', url: `https://osv.dev/vulnerability/${id}` };
+  }
+  if (/^GO-\d{4}-/.test(id)) {
+    return { name: 'Go Vulnerability Database', url: `https://pkg.go.dev/vuln/${id}` };
+  }
+  return undefined;
+}
+
+/**
+ * License representation for one BoM row, per the honesty rules:
+ * - 'UNKNOWN' / empty → undefined (no license claim at all);
+ * - a single term that IS a known SPDX id → the id form;
+ * - a compound OR/AND expression whose every term is a known SPDX id →
+ *   the SPDX expression form (the string as gathered);
+ * - anything else → the free-form name form (always spec-valid).
+ * Id validity routes through the ONE `knownSpdxId` predicate in the
+ * licenses module (Rule 2): no second SPDX list here.
+ */
+export function cycloneDxLicenses(licenseType: string): CycloneDxLicenseEntry[] | undefined {
+  const raw = licenseType.trim();
+  if (raw.length === 0 || raw === 'UNKNOWN') return undefined;
+  const terms = splitLicenseTerms(raw);
+  if (terms.length === 1) {
+    const id = knownSpdxId(terms[0]);
+    return id ? [{ license: { id } }] : [{ license: { name: raw } }];
+  }
+  const isPureExpression = /^[^,]+$/.test(raw) && /\s(OR|AND)\s/.test(raw);
+  if (isPureExpression && terms.every((t) => knownSpdxId(t) !== null)) {
+    return [{ expression: raw }];
+  }
+  return [{ license: { name: raw } }];
+}
+
+/** Render the CycloneDX document object from the one BoM report. */
+export function toCycloneDx(report: BomReport, opts: CycloneDxOptions): CycloneDxDocument {
+  const usedRefs = new Set<string>();
+  const components: CycloneDxComponent[] = [];
+  const refByEntry = new Map<BomEntry, string>();
+
+  for (const entry of report.entries) {
+    const purlType = entry.packId ? getLanguage(entry.packId)?.purlType : undefined;
+    const purl = purlType ? buildPurl(purlType, entry.package, entry.version) : null;
+
+    // bom-ref: the purl when derivable (globally unique by construction),
+    // else the join key. A collision (two rows reducing to one key) gets
+    // a disambiguating ordinal so refs stay unique (required for
+    // `affects` resolution.
+    let ref = purl ?? `${entry.package}@${entry.version}`;
+    if (usedRefs.has(ref)) {
+      let n = 2;
+      while (usedRefs.has(`${ref}#${n}`)) n++;
+      ref = `${ref}#${n}`;
+    }
+    usedRefs.add(ref);
+    refByEntry.set(entry, ref);
+
+    const properties: CycloneDxProperty[] = [];
+    if (entry.packId) {
+      properties.push({ name: 'dxkit:ecosystem', value: entry.packId });
+    }
+    if (!purl) {
+      // Disclosed, never fabricated: say WHY this row carries no purl.
+      const reason = !entry.packId
+        ? 'ecosystem-unknown'
+        : !purlType
+          ? `no-purl-type-for-${entry.packId}`
+          : `not-derivable-for-${purlType}`;
+      properties.push({ name: 'dxkit:purl-omitted', value: reason });
+    }
+
+    const licenses = cycloneDxLicenses(entry.licenseType);
+    components.push({
+      'bom-ref': ref,
+      type: 'library',
+      name: entry.package,
+      ...(entry.version && entry.version !== 'unknown' ? { version: entry.version } : {}),
+      ...(purl ? { purl } : {}),
+      ...(licenses ? { licenses } : {}),
+      ...(properties.length > 0 ? { properties } : {}),
+    });
+  }
+
+  // One vulnerability per advisory id, with `affects` unioning every
+  // component the advisory was reported against (the same advisory on
+  // two package rows is one CycloneDX vulnerability affecting both).
+  const vulnById = new Map<string, CycloneDxVulnerability>();
+  for (const entry of report.entries) {
+    const ref = refByEntry.get(entry)!;
+    for (const v of entry.vulns) {
+      const existing = vulnById.get(v.id);
+      if (existing) {
+        if (!existing.affects.some((a) => a.ref === ref)) existing.affects.push({ ref });
+        continue;
+      }
+      const source = advisorySource(v.id);
+      const rating: CycloneDxRating = {
+        // Our four-tier severity IS a subset of the CycloneDX enum.
+        severity: v.severity,
+        ...(typeof v.cvssScore === 'number' ? { score: v.cvssScore } : {}),
+      };
+      vulnById.set(v.id, {
+        id: v.id,
+        ...(source ? { source } : {}),
+        ...(v.summary ? { description: v.summary } : {}),
+        ratings: [rating],
+        affects: [{ ref }],
+      });
+    }
+  }
+  const vulnerabilities = [...vulnById.values()].sort((a, b) => a.id.localeCompare(b.id));
+
+  return {
+    bomFormat: 'CycloneDX',
+    specVersion: '1.5',
+    version: 1,
+    metadata: {
+      timestamp: opts.timestamp,
+      tools: {
+        components: [{ type: 'application', name: '@vyuhlabs/dxkit', version: opts.dxkitVersion }],
+      },
+      component: { 'bom-ref': `app:${report.repo}`, type: 'application', name: report.repo },
+    },
+    components,
+    ...(vulnerabilities.length > 0 ? { vulnerabilities } : {}),
+  };
+}
+
+/** Serialize the document with a stable layout (2-space indent, trailing
+ *  newline) so identical input is byte-identical output. */
+export function renderCycloneDx(report: BomReport, opts: CycloneDxOptions): string {
+  return JSON.stringify(toCycloneDx(report, opts), null, 2) + '\n';
+}

--- a/src/analyzers/bom/cyclonedx.ts
+++ b/src/analyzers/bom/cyclonedx.ts
@@ -144,6 +144,11 @@ export function cycloneDxLicenses(licenseType: string): CycloneDxLicenseEntry[] 
 /** Render the CycloneDX document object from the one BoM report. */
 export function toCycloneDx(report: BomReport, opts: CycloneDxOptions): CycloneDxDocument {
   const usedRefs = new Set<string>();
+  // The root application's own bom-ref participates in the same
+  // uniqueness domain as the component refs, so it is claimed first: a
+  // library that happened to reduce to the same key gets the ordinal.
+  const rootRef = `app:${report.repo}`;
+  usedRefs.add(rootRef);
   const components: CycloneDxComponent[] = [];
   const refByEntry = new Map<BomEntry, string>();
 
@@ -154,7 +159,7 @@ export function toCycloneDx(report: BomReport, opts: CycloneDxOptions): CycloneD
     // bom-ref: the purl when derivable (globally unique by construction),
     // else the join key. A collision (two rows reducing to one key) gets
     // a disambiguating ordinal so refs stay unique (required for
-    // `affects` resolution.
+    // `affects` resolution).
     let ref = purl ?? `${entry.package}@${entry.version}`;
     if (usedRefs.has(ref)) {
       let n = 2;
@@ -197,17 +202,25 @@ export function toCycloneDx(report: BomReport, opts: CycloneDxOptions): CycloneD
   for (const entry of report.entries) {
     const ref = refByEntry.get(entry)!;
     for (const v of entry.vulns) {
-      const existing = vulnById.get(v.id);
-      if (existing) {
-        if (!existing.affects.some((a) => a.ref === ref)) existing.affects.push({ ref });
-        continue;
-      }
-      const source = advisorySource(v.id);
       const rating: CycloneDxRating = {
         // Our four-tier severity IS a subset of the CycloneDX enum.
         severity: v.severity,
         ...(typeof v.cvssScore === 'number' ? { score: v.cvssScore } : {}),
       };
+      const existing = vulnById.get(v.id);
+      if (existing) {
+        if (!existing.affects.some((a) => a.ref === ref)) existing.affects.push({ ref });
+        // Distinct ratings union: another scan of the same advisory may
+        // carry a different severity or score (a fact, so it is kept),
+        // while an identical rating is not repeated.
+        if (
+          !existing.ratings.some((r) => r.severity === rating.severity && r.score === rating.score)
+        ) {
+          existing.ratings.push(rating);
+        }
+        continue;
+      }
+      const source = advisorySource(v.id);
       vulnById.set(v.id, {
         id: v.id,
         ...(source ? { source } : {}),
@@ -217,7 +230,12 @@ export function toCycloneDx(report: BomReport, opts: CycloneDxOptions): CycloneD
       });
     }
   }
-  const vulnerabilities = [...vulnById.values()].sort((a, b) => a.id.localeCompare(b.id));
+  // Plain codepoint comparison, not localeCompare: the anchor writer's
+  // unchanged-skip depends on byte-identical output across hosts, and
+  // localeCompare answers per the host locale.
+  const vulnerabilities = [...vulnById.values()].sort((a, b) =>
+    a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+  );
 
   return {
     bomFormat: 'CycloneDX',
@@ -228,7 +246,7 @@ export function toCycloneDx(report: BomReport, opts: CycloneDxOptions): CycloneD
       tools: {
         components: [{ type: 'application', name: '@vyuhlabs/dxkit', version: opts.dxkitVersion }],
       },
-      component: { 'bom-ref': `app:${report.repo}`, type: 'application', name: report.repo },
+      component: { 'bom-ref': rootRef, type: 'application', name: report.repo },
     },
     components,
     ...(vulnerabilities.length > 0 ? { vulnerabilities } : {}),

--- a/src/analyzers/bom/gather.ts
+++ b/src/analyzers/bom/gather.ts
@@ -287,6 +287,11 @@ function buildEntry(
   if (isTopLevel === undefined && !joinedFromBoth && vulns.length > 0) {
     isTopLevel = vulns.some((v) => !v.topLevelDep || v.topLevelDep.includes(lic.package));
   }
+  // Ecosystem provenance: the license row's stamped packId wins (the
+  // package universe comes from the license inventory); a vuln-only row
+  // falls back to the advisory's packId. Left unset when neither side
+  // carried provenance: consumers must treat unset as unknown.
+  const packId = lic.packId ?? vulns.map((v) => v.packId).find((p) => p !== undefined);
   return {
     package: lic.package,
     version: lic.version,
@@ -301,5 +306,6 @@ function buildEntry(
     upgradeAdvice: tieredAdvice ?? deriveTier1Resolution(vulns),
     joinedFromBoth,
     isTopLevel,
+    ...(packId !== undefined ? { packId } : {}),
   };
 }

--- a/src/analyzers/bom/purl.ts
+++ b/src/analyzers/bom/purl.ts
@@ -1,0 +1,107 @@
+/**
+ * Package-url (purl) derivation for the SBOM export, the ONE home of
+ * purl-spec encoding knowledge (Rule 2). The purl TYPE for a BoM row
+ * comes from the owning language pack's `purlType` declaration (Rule 6);
+ * this module only knows the purl spec's per-type shape rules: which
+ * types put what in the namespace, and how segments percent-encode.
+ *
+ * Honesty contract: `buildPurl` returns null whenever a valid purl
+ * cannot be derived from the `(package, version)` pair the gathers
+ * carry: an unknown type, or a name that lacks the structure the type
+ * requires (a maven name with no `group:artifact` colon, a composer
+ * name with no `vendor/name` slash). Callers disclose the omission;
+ * they never fabricate a lookalike purl.
+ */
+
+/**
+ * The purl types this builder can derive from a bare (package, version)
+ * pair. Every pack-declared `LanguageSupport.purlType` must appear here,
+ * pinned by `test/languages-contract.test.ts` so a pack cannot declare a
+ * type the builder would silently fail closed on.
+ */
+export const SUPPORTED_PURL_TYPES: ReadonlySet<string> = new Set([
+  'npm',
+  'pypi',
+  'golang',
+  'cargo',
+  'nuget',
+  'maven',
+  'gem',
+  'composer',
+]);
+
+/** Percent-encode one purl segment. Everything encodeURIComponent leaves
+ *  bare is purl-safe; '@' (npm scopes) and '+' (build metadata in
+ *  versions) are the load-bearing encodings. */
+function seg(s: string): string {
+  return encodeURIComponent(s);
+}
+
+/**
+ * Derive a purl string, or null when the type is unknown or the package
+ * name lacks the structure the type requires. Per-type rules (purl spec):
+ *
+ * - npm: scoped names split at the '/'; `@scope` is the namespace
+ *   (encoded, so `@` becomes `%40`); unscoped names have none.
+ * - pypi: PEP 503 normalization (lowercase, `_`/`.` runs fold to `-`).
+ * - golang: the module path's last segment is the name, the rest the
+ *   namespace (slashes between namespace segments stay literal);
+ *   lowercased per spec.
+ * - maven: `group:artifact` splits at the colon into namespace + name;
+ *   a name with no colon cannot yield a valid maven purl.
+ * - composer: `vendor/name` splits at the slash; vendor-less names
+ *   cannot yield a valid composer purl.
+ * - cargo / gem / nuget: plain name, no namespace.
+ */
+export function buildPurl(type: string, pkg: string, version: string): string | null {
+  if (!pkg || !version || version === 'unknown') return null;
+  switch (type) {
+    case 'npm': {
+      if (pkg.startsWith('@')) {
+        const slash = pkg.indexOf('/');
+        if (slash <= 1 || slash === pkg.length - 1) return null;
+        const scope = pkg.slice(0, slash);
+        const name = pkg.slice(slash + 1);
+        return `pkg:npm/${seg(scope)}/${seg(name)}@${seg(version)}`;
+      }
+      return `pkg:npm/${seg(pkg)}@${seg(version)}`;
+    }
+    case 'pypi': {
+      const name = pkg.toLowerCase().replace(/[._]+/g, '-');
+      return `pkg:pypi/${seg(name)}@${seg(version)}`;
+    }
+    case 'golang': {
+      const parts = pkg.toLowerCase().split('/').filter(Boolean);
+      if (parts.length === 0) return null;
+      const name = parts.pop()!;
+      const ns = parts.map(seg).join('/');
+      return ns
+        ? `pkg:golang/${ns}/${seg(name)}@${seg(version)}`
+        : `pkg:golang/${seg(name)}@${seg(version)}`;
+    }
+    case 'maven': {
+      const colon = pkg.indexOf(':');
+      if (colon <= 0 || colon === pkg.length - 1) return null;
+      const group = pkg.slice(0, colon);
+      const artifact = pkg.slice(colon + 1);
+      if (artifact.includes(':')) return null;
+      return `pkg:maven/${seg(group)}/${seg(artifact)}@${seg(version)}`;
+    }
+    case 'composer': {
+      const slash = pkg.indexOf('/');
+      if (slash <= 0 || slash === pkg.length - 1) return null;
+      const vendor = pkg.slice(0, slash);
+      const name = pkg.slice(slash + 1);
+      if (name.includes('/')) return null;
+      return `pkg:composer/${seg(vendor)}/${seg(name)}@${seg(version)}`;
+    }
+    case 'cargo':
+    case 'gem':
+    case 'nuget':
+      return `pkg:${type}/${seg(pkg)}@${seg(version)}`;
+    default:
+      // Fail closed on a type this builder does not model: never emit
+      // a guessed shape for an unmodeled ecosystem.
+      return null;
+  }
+}

--- a/src/analyzers/bom/types.ts
+++ b/src/analyzers/bom/types.ts
@@ -9,6 +9,7 @@
  * can render col 12 (Vulnerability Issues) as an enumerated list.
  */
 import type { DepVulnFinding } from '../../languages/capabilities/types';
+import type { LanguageId } from '../../types';
 
 export type BomSeverity = 'critical' | 'high' | 'medium' | 'low';
 
@@ -54,6 +55,16 @@ export interface BomEntry {
    *  this is `false` — undefined passes through so degraded gathers
    *  don't accidentally filter the whole report down to zero. */
   isTopLevel?: boolean;
+
+  /** The language pack (ecosystem) this row came from, threaded from
+   *  `LicenseFinding.packId` (stamped by the cross-pack licenses
+   *  aggregation) or, for vuln-only rows, from the advisory's
+   *  `DepVulnFinding.packId`. Drives ecosystem-dependent rendering
+   *  (the CycloneDX export derives the purl type from the owning
+   *  pack's declaration, never from a hardcoded npm assumption).
+   *  Unset when neither source carried provenance: renderers must
+   *  treat unset as "ecosystem unknown", never guess. */
+  packId?: LanguageId;
 
   /** Reserved for per-row sub-root attribution. Currently unset under
    *  the canonical-cache gather path (one inventory at the repo

--- a/src/analyzers/licenses/detailed.ts
+++ b/src/analyzers/licenses/detailed.ts
@@ -39,13 +39,127 @@ const WEAK_COPYLEFT_PREFIXES: ReadonlyArray<string> = ['LGPL-', 'MPL-', 'EPL-', 
  * ("AGPL-3.0") matches itself.
  */
 export function licenseMatchesAny(licenseType: string, prefixes: ReadonlyArray<string>): boolean {
-  const terms = licenseType.split(/\s+OR\s+|\s+AND\s+|,\s*/);
-  for (const term of terms) {
+  for (const term of splitLicenseTerms(licenseType)) {
     for (const p of prefixes) {
       if (term.startsWith(p)) return true;
     }
   }
   return false;
+}
+
+/**
+ * The ONE compound-license-expression splitter (Rule 2). "GPL-3.0 OR MIT",
+ * "X AND Y" and comma lists split to their individual terms; both the risk
+ * matcher above and the CycloneDX SBOM export's license rendering route
+ * through it, so a second expression parser never grows elsewhere.
+ */
+export function splitLicenseTerms(licenseType: string): string[] {
+  return licenseType.split(/\s+OR\s+|\s+AND\s+|,\s*/).filter((t) => t.length > 0);
+}
+
+/**
+ * SPDX ids the license gathers are known to emit, for exact-id claims
+ * (the CycloneDX `license.id` field is schema-restricted to the SPDX
+ * enum, so a wrong claim makes the document invalid). This is a curated
+ * subset of the SPDX list, deliberately biased toward false NEGATIVES:
+ * a valid id missing here renders as the license NAME form instead,
+ * which stays spec-valid and honest; an id present here but wrong
+ * would not. Extend the set here (never a second list elsewhere) when
+ * a gather starts emitting an id it lacks.
+ */
+const KNOWN_SPDX_IDS: ReadonlySet<string> = new Set([
+  '0BSD',
+  'AFL-3.0',
+  'AGPL-1.0-only',
+  'AGPL-1.0-or-later',
+  'AGPL-3.0-only',
+  'AGPL-3.0-or-later',
+  'Apache-1.1',
+  'Apache-2.0',
+  'Artistic-1.0',
+  'Artistic-2.0',
+  'BlueOak-1.0.0',
+  'BSD-1-Clause',
+  'BSD-2-Clause',
+  'BSD-2-Clause-Patent',
+  'BSD-3-Clause',
+  'BSD-3-Clause-Clear',
+  'BSD-4-Clause',
+  'BSL-1.0',
+  'CC-BY-3.0',
+  'CC-BY-4.0',
+  'CC-BY-SA-3.0',
+  'CC-BY-SA-4.0',
+  'CC0-1.0',
+  'CDDL-1.0',
+  'CDDL-1.1',
+  'ECL-2.0',
+  'EPL-1.0',
+  'EPL-2.0',
+  'EUPL-1.1',
+  'EUPL-1.2',
+  'GPL-1.0-only',
+  'GPL-1.0-or-later',
+  'GPL-2.0-only',
+  'GPL-2.0-or-later',
+  'GPL-3.0-only',
+  'GPL-3.0-or-later',
+  'ISC',
+  'LGPL-2.0-only',
+  'LGPL-2.0-or-later',
+  'LGPL-2.1-only',
+  'LGPL-2.1-or-later',
+  'LGPL-3.0-only',
+  'LGPL-3.0-or-later',
+  'MIT',
+  'MIT-0',
+  'MPL-1.1',
+  'MPL-2.0',
+  'MS-PL',
+  'MS-RL',
+  'OFL-1.1',
+  'OSL-3.0',
+  'PostgreSQL',
+  'PSF-2.0',
+  'Python-2.0',
+  'Ruby',
+  'Unicode-DFS-2016',
+  'Unlicense',
+  'UPL-1.0',
+  'WTFPL',
+  'Zlib',
+  'ZPL-2.1',
+]);
+
+/**
+ * Deprecated-but-ubiquitous SPDX ids the ecosystems still ship (npm
+ * metadata predates the `-only`/`-or-later` split). Still valid ids in
+ * the SPDX list (marked deprecated), so claiming them is honest.
+ */
+const KNOWN_DEPRECATED_SPDX_IDS: ReadonlySet<string> = new Set([
+  'AGPL-1.0',
+  'AGPL-3.0',
+  'GPL-1.0',
+  'GPL-2.0',
+  'GPL-2.0+',
+  'GPL-3.0',
+  'GPL-3.0+',
+  'LGPL-2.0',
+  'LGPL-2.1',
+  'LGPL-2.1+',
+  'LGPL-3.0',
+  'LGPL-3.0+',
+]);
+
+/**
+ * The ONE "is this string a known SPDX id?" predicate (Rule 2). Returns
+ * the id itself for a single term found in the curated set, else null
+ * (compound expressions, unknown ids, and 'UNKNOWN' all return null;
+ * callers fall back to the free-form name representation).
+ */
+export function knownSpdxId(term: string): string | null {
+  const t = term.trim();
+  return KNOWN_SPDX_IDS.has(t) || KNOWN_DEPRECATED_SPDX_IDS.has(t) ? t : null;
 }
 
 const matchesAny = licenseMatchesAny;

--- a/src/analyzers/licenses/gather.ts
+++ b/src/analyzers/licenses/gather.ts
@@ -19,7 +19,23 @@
 import { detectActiveLanguages } from '../../languages';
 import { PER_PACK_REGISTRY } from '../../languages/capabilities/descriptors';
 import type { LicensesResult } from '../../languages/capabilities/types';
+import type { LanguageId } from '../../types';
 import { DEFAULT_PROVIDER_DEADLINE_MS, withDeadline } from '../tools/deadline';
+
+/**
+ * Stamp the producing pack's id onto every finding in a per-pack success
+ * envelope. The ONE place ecosystem provenance attaches to license
+ * findings (providers never populate `packId`, the same aggregation-owns-
+ * the-stamp discipline as the dep-vuln `fingerprint`). Pure; exported for
+ * tests. A finding that already carries a packId keeps it (idempotent on
+ * re-aggregation of an already-stamped envelope).
+ */
+export function stampLicensePackId(envelope: LicensesResult, packId: LanguageId): LicensesResult {
+  return {
+    ...envelope,
+    findings: envelope.findings.map((f) => (f.packId ? f : { ...f, packId })),
+  };
+}
 
 /**
  * Shared primitive for availability-aware licenses aggregation. Used
@@ -81,7 +97,7 @@ export async function gatherLicensesWithAvailability(cwd: string): Promise<{
     }
     const outcome = r.value;
     if (outcome.kind === 'success') {
-      successEnvelopes.push(outcome.envelope);
+      successEnvelopes.push(stampLicensePackId(outcome.envelope, activePacks[i].id));
     } else if (outcome.kind === 'unavailable' && !firstUnavailable) {
       firstUnavailable = { pack: activePacks[i].id, reason: outcome.reason };
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2095,6 +2095,24 @@ export async function run(argv: string[]): Promise<void> {
         logger.fail(`Invalid --format value: ${rawFormat}. Expected 'cyclonedx'.`);
         process.exit(1);
       }
+      // Two output-shape flags cannot share one stdout: fail fast
+      // instead of silently privileging one document.
+      if (rawFormat === 'cyclonedx' && values.json) {
+        logger.fail(
+          'Cannot combine --json with --format cyclonedx: each defines the output document. ' +
+            'Use --format cyclonedx alone for the CycloneDX SBOM, or --json alone for the bom report schema.',
+        );
+        process.exit(1);
+      }
+      // Same for one --output path claimed by two writers: the xlsx
+      // export and the SBOM export would clobber each other.
+      if (rawFormat === 'cyclonedx' && values.xlsx && values.output) {
+        logger.fail(
+          'Cannot combine --xlsx and --format cyclonedx with one --output path: both would write it. ' +
+            'Run the two exports separately.',
+        );
+        process.exit(1);
+      }
       // `--format cyclonedx` without --output streams the document to
       // stdout, so progress chatter must ride stderr (same contract as
       // --json output).
@@ -2182,7 +2200,10 @@ export async function run(argv: string[]): Promise<void> {
         const reportPath = path.join(reportDir, `bom-${date}.md`);
         fs.mkdirSync(reportDir, { recursive: true });
         fs.writeFileSync(reportPath, formatBomReport(report, elapsed));
-        if (!values.json) console.log(''); // slop-ok
+        // In cyclonedx stdout mode the document must stay the ONLY
+        // stdout, so the cosmetic spacer is suppressed with the rest
+        // of the chatter.
+        if (!values.json && !cycloneDxToStdout) console.log(''); // slop-ok
         logger.success(`Report saved to ${path.relative(targetPath, reportPath)}`);
 
         // D032 (2.4.7): detailed JSON + MD always written so dashboard finds fresh inputs.
@@ -2229,7 +2250,14 @@ export async function run(argv: string[]): Promise<void> {
       // the lane surface; this one is the user's).
       if (rawFormat === 'cyclonedx' && values.output) {
         const sbomOutPath = path.resolve(values.output as string);
-        fs.writeFileSync(sbomOutPath, cycloneDxJson);
+        try {
+          fs.writeFileSync(sbomOutPath, cycloneDxJson);
+        } catch (err) {
+          logger.fail(
+            `Could not write CycloneDX SBOM to ${sbomOutPath}: ${(err as Error).message}`,
+          );
+          process.exit(1);
+        }
         logger.success(`CycloneDX SBOM written to ${sbomOutPath}`);
       }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -414,6 +414,8 @@ export async function run(argv: string[]): Promise<void> {
       output: { type: 'string', short: 'o' },
       xlsx: { type: 'boolean', default: false },
       filter: { type: 'string' },
+      // `bom --format cyclonedx`: SBOM interchange export.
+      format: { type: 'string' },
       all: { type: 'boolean', default: false },
       // learn: local assistant server + its port
       serve: { type: 'boolean', default: false },
@@ -2084,9 +2086,20 @@ export async function run(argv: string[]): Promise<void> {
       break;
     }
 
-    case 'bom': {
+    case 'bom':
+    case 'sbom': {
       const targetPath = resolveRepoPath(positionals[1]);
       const { analyzeBom, formatBomReport } = await import('./analyzers/bom');
+      const rawFormat = values.format as string | undefined;
+      if (rawFormat !== undefined && rawFormat !== 'cyclonedx') {
+        logger.fail(`Invalid --format value: ${rawFormat}. Expected 'cyclonedx'.`);
+        process.exit(1);
+      }
+      // `--format cyclonedx` without --output streams the document to
+      // stdout, so progress chatter must ride stderr (same contract as
+      // --json output).
+      const cycloneDxToStdout = rawFormat === 'cyclonedx' && !values.output;
+      if (cycloneDxToStdout) logger.setJsonMode(true);
       logger.header('vyuh-dxkit bom');
       logger.info(`Analyzing ${targetPath}...`);
       const rawFilter = values.filter;
@@ -2102,7 +2115,23 @@ export async function run(argv: string[]): Promise<void> {
       });
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 
-      if (values.json) {
+      // The CycloneDX SBOM is a pure projection of the SAME report (a
+      // renderer, not a second gather). Rendered once here: the disk
+      // side always persists it beside the markdown report (so the
+      // reports-snapshot lane publishes it with the other artifacts),
+      // `--format cyclonedx --output <file>` additionally writes it to
+      // an explicit path, and `--format cyclonedx` without --output
+      // streams it as the stdout (pipe-friendly, summary suppressed).
+      // Timestamp is the report's own analyzedAt (injected), so the
+      // same gather renders byte-identical output.
+      const { renderCycloneDx } = await import('./analyzers/bom/cyclonedx');
+      const cycloneDxJson = renderCycloneDx(report, {
+        timestamp: report.analyzedAt,
+        dxkitVersion: VERSION,
+      });
+      if (cycloneDxToStdout) {
+        process.stdout.write(cycloneDxJson);
+      } else if (values.json) {
         await emitJson(stampSchema(report, 'bom')); // slop-ok
       } else {
         const s = report.summary;
@@ -2165,6 +2194,16 @@ export async function run(argv: string[]): Promise<void> {
         fs.writeFileSync(bomDetailedJsonPath, JSON.stringify(bomDetailed, null, 2));
         fs.writeFileSync(bomDetailedMdPath, formatBomDetailedMarkdown(bomDetailed, elapsed));
 
+        // CycloneDX SBOM: always persisted beside the markdown report
+        // (the D032 discipline: the reports-snapshot lane picks up the
+        // newest bom-*.cdx.json and publishes it as latest/sbom.cdx.json
+        // on the dxkit-reports ref).
+        const cycloneDxPath = path.join(reportDir, `bom-${date}.cdx.json`);
+        fs.writeFileSync(cycloneDxPath, cycloneDxJson);
+        if (rawFormat === 'cyclonedx') {
+          logger.success(`CycloneDX SBOM saved to ${path.relative(targetPath, cycloneDxPath)}`);
+        }
+
         if (values.detailed) {
           logger.success(
             `Detailed report saved to ${path.relative(targetPath, bomDetailedMdPath)}`,
@@ -2183,6 +2222,15 @@ export async function run(argv: string[]): Promise<void> {
           fs.writeFileSync(xlsxPath, buf);
           logger.success(`XLSX saved to ${path.relative(targetPath, xlsxPath)}`);
         }
+      }
+
+      // `--format cyclonedx --output <file>`: explicit export path,
+      // honored regardless of --no-save (the reports-dir copy above is
+      // the lane surface; this one is the user's).
+      if (rawFormat === 'cyclonedx' && values.output) {
+        const sbomOutPath = path.resolve(values.output as string);
+        fs.writeFileSync(sbomOutPath, cycloneDxJson);
+        logger.success(`CycloneDX SBOM written to ${sbomOutPath}`);
       }
 
       // --fail-on-severity: BomReport.summary.bySeverity carries

--- a/src/discovery/command-defs.ts
+++ b/src/discovery/command-defs.ts
@@ -272,11 +272,15 @@ export const COMMANDS = [
   },
   {
     id: 'bom',
+    aliases: ['sbom'],
     audience: 'user',
     group: 'assess',
     summary: 'Bill of Materials (licenses + vulnerabilities joined)',
     typicalRuntime: '1-3 min',
-    docsBlurb: 'Join the license inventory with the vulnerability scan into one dependency BOM.',
+    docsBlurb:
+      'Join the license inventory with the vulnerability scan into one dependency BOM. ' +
+      '`--format cyclonedx` exports the standard CycloneDX JSON SBOM (purls, SPDX licenses, ' +
+      'per-advisory vulnerabilities); the reports snapshot lane publishes it as latest/sbom.cdx.json.',
   },
   {
     id: 'coverage',

--- a/src/languages/abap.ts
+++ b/src/languages/abap.ts
@@ -114,6 +114,8 @@ const abapLintProvider: CapabilityProvider<LintResult> = {
 export const abap: LanguageSupport = {
   id: 'abap',
   displayName: 'ABAP',
+  // purlType deliberately omitted: the purl spec's type registry has no
+  // ABAP ecosystem; the SBOM export discloses the omission per row.
 
   // ABAP's inline comment is `"` (everything after it on the line).
   // Full-line `*` comments exist only in column 1 — the inline form is

--- a/src/languages/capabilities/types.ts
+++ b/src/languages/capabilities/types.ts
@@ -270,6 +270,15 @@ export interface LicenseFinding {
    * can't read the manifest/lockfile — the bom filter treats unset as
    * "don't know" and passes the row through rather than dropping it. */
   isTopLevel?: boolean;
+
+  /** The language pack whose licenses provider produced this finding,
+   * the row's ecosystem provenance (mirror of `DepVulnFinding.packId`).
+   * Stamped ONCE by the cross-pack licenses aggregation in
+   * `gatherLicensesWithAvailability`: providers never populate it, the
+   * same discipline as the dep-vuln `fingerprint`. Consumers (the BoM
+   * join, the CycloneDX SBOM export's purl derivation) read it to know
+   * which ecosystem a package name belongs to without guessing. */
+  packId?: LanguageId;
 }
 
 /**

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -1762,6 +1762,7 @@ function detectCsharpVersion(cwd: string): string | undefined {
 export const csharp: LanguageSupport = {
   id: 'csharp',
   displayName: 'C#',
+  purlType: 'nuget',
   commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
   sourceExtensions: ['.cs'],
   // Fixes the pattern gap: previously C# tests named `FooTests.cs` were missed

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -1038,6 +1038,7 @@ function detectGoVersion(cwd: string): string | undefined {
 export const go: LanguageSupport = {
   id: 'go',
   displayName: 'Go',
+  purlType: 'golang',
   commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
   sourceExtensions: ['.go'],
   testFilePatterns: ['*_test.go'],

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -482,6 +482,7 @@ function detectJavaVersion(cwd: string): string | undefined {
 export const java: LanguageSupport = {
   id: 'java',
   displayName: 'Java',
+  purlType: 'maven',
   commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
 
   sourceExtensions: ['.java'],

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -530,6 +530,7 @@ const kotlinLintGateProvider: LintGateProvider = {
 export const kotlin: LanguageSupport = {
   id: 'kotlin',
   displayName: 'Kotlin (Android)',
+  purlType: 'maven',
   commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
 
   // `.kts` covers both Gradle build scripts and Kotlin scratch files; the

--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -698,6 +698,7 @@ const phpInstallStrategy = declareInstallStrategy(
 export const php: LanguageSupport = {
   id: 'php',
   displayName: 'PHP',
+  purlType: 'composer',
   commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
   sourceExtensions: ['.php'],
   testFilePatterns: [...PHP_TEST_FILE_PATTERNS],

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1796,6 +1796,7 @@ const pythonInstallStrategy = declareInstallStrategy(
 export const python: LanguageSupport = {
   id: 'python',
   displayName: 'Python',
+  purlType: 'pypi',
   commentSyntax: { lineComment: '#' },
   sourceExtensions: ['.py'],
   testFilePatterns: [...PY_TEST_FILE_PATTERNS],

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -1094,6 +1094,7 @@ const rubyInstallStrategy = declareInstallStrategy(
 export const ruby: LanguageSupport = {
   id: 'ruby',
   displayName: 'Ruby',
+  purlType: 'gem',
   commentSyntax: { lineComment: '#', blockCommentStart: '=begin', blockCommentEnd: '=end' },
 
   sourceExtensions: ['.rb'],

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -1060,6 +1060,7 @@ function detectRustVersion(cwd: string): string | undefined {
 export const rust: LanguageSupport = {
   id: 'rust',
   displayName: 'Rust',
+  purlType: 'cargo',
   commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
   sourceExtensions: ['.rs'],
   // Rust convention: tests live in the same file via #[cfg(test)] / #[test],

--- a/src/languages/swift.ts
+++ b/src/languages/swift.ts
@@ -630,6 +630,9 @@ function detectSwiftToolchainVersion(cwd: string): string | undefined {
 export const swift: LanguageSupport = {
   id: 'swift',
   displayName: 'Swift',
+  // purlType deliberately omitted: a `pkg:swift/...` purl requires the
+  // source-host namespace (e.g. github.com/org) which our gathers do not
+  // carry; the SBOM export discloses the omission per row instead.
   commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
   sourceExtensions: ['.swift'],
   testFilePatterns: ['*Tests.swift', '*Test.swift'],

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -233,6 +233,24 @@ export interface LanguageSupport {
   id: LanguageId;
   displayName: string;
 
+  /**
+   * The package-url (purl) type for this pack's package ecosystem, per the
+   * purl spec's type registry: 'npm', 'pypi', 'golang', 'cargo', 'nuget',
+   * 'maven', 'gem', 'composer', ... Consumed by the CycloneDX SBOM export
+   * to derive a `pkg:<type>/...` purl for each BoM row from the row's
+   * `packId` provenance (Rule 6: the ecosystem fact lives on the pack,
+   * never a hardcoded npm assumption in a renderer).
+   *
+   * OMIT when no purl can be derived honestly from a bare
+   * `(package, version)` pair: swift purls need the source-host namespace
+   * (which our gathers do not carry) and ABAP has no registered purl type.
+   * A pack without `purlType` yields components with a bom-ref only, and
+   * the omission is disclosed in a component property, never fabricated.
+   * Every declared value must be supported by the ONE purl builder
+   * (`src/analyzers/bom/purl.ts`), pinned by the contract test.
+   */
+  purlType?: string;
+
   sourceExtensions: string[];
   /**
    * jscpd `--formats-exts` entries this pack needs (e.g. `'abap:abap'`)

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -2812,6 +2812,7 @@ function detectNodeVersion(cwd: string): string | undefined {
 export const typescript: LanguageSupport = {
   id: 'typescript',
   displayName: 'TypeScript / JavaScript',
+  purlType: 'npm',
   commentSyntax: { lineComment: '//', blockCommentStart: '/*', blockCommentEnd: '*/' },
   sourceExtensions: [...TS_JS_EXT],
   // Filename conventions for the JS/TS ecosystem. The `__tests__/`

--- a/src/reports-cli.ts
+++ b/src/reports-cli.ts
@@ -42,22 +42,37 @@ function gitLine(cwd: string, args: string[]): string {
   }
 }
 
-/** Collect the `latest/` artifacts already rendered under `.dxkit/reports/`. */
-function collectArtifacts(cwd: string): SnapshotArtifact[] {
+/** Collect the `latest/` artifacts already rendered under `.dxkit/reports/`.
+ *  Exported for tests (the publish path itself is exercised via
+ *  `runReportSnapshot`). */
+export function collectArtifacts(cwd: string): SnapshotArtifact[] {
   const reportsDir = path.join(cwd, '.dxkit', 'reports');
   const out: SnapshotArtifact[] = [];
   const dash = path.join(reportsDir, 'dashboard.html');
   if (fs.existsSync(dash))
     out.push({ path: 'dashboard.html', content: fs.readFileSync(dash, 'utf8') });
-  // Newest health-audit markdown, if any.
   try {
-    const md = fs
-      .readdirSync(reportsDir)
+    const files = fs.readdirSync(reportsDir);
+    // Newest health-audit markdown, if any.
+    const md = files
       .filter((f) => /^health-audit-.*\.md$/.test(f) && !f.includes('detailed'))
       .sort()
       .pop();
     if (md)
       out.push({ path: 'health.md', content: fs.readFileSync(path.join(reportsDir, md), 'utf8') });
+    // Newest CycloneDX SBOM (the bom command always writes one beside its
+    // markdown report), published under a stable name so consumers can
+    // fetch `latest/sbom.cdx.json` off the reports ref without knowing
+    // the run date.
+    const sbom = files
+      .filter((f) => /^bom-.*\.cdx\.json$/.test(f))
+      .sort()
+      .pop();
+    if (sbom)
+      out.push({
+        path: 'sbom.cdx.json',
+        content: fs.readFileSync(path.join(reportsDir, sbom), 'utf8'),
+      });
   } catch {
     /* no reports dir */
   }

--- a/test/bom-cyclonedx.test.ts
+++ b/test/bom-cyclonedx.test.ts
@@ -10,6 +10,7 @@
  * gather, and the reports-snapshot pickup of the persisted SBOM file.
  */
 import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -427,4 +428,133 @@ describe('discovery + snapshot pickup', () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+});
+
+describe('review fixes (ratings union, deterministic sort, root ref uniqueness)', () => {
+  it('unions distinct ratings when one advisory carries different facts on two rows', () => {
+    const a = entry({
+      package: 'liba',
+      version: '1.0.0',
+      packId: 'rust',
+      vulns: [vuln({ id: 'RUSTSEC-2024-0002', package: 'liba', severity: 'high', cvssScore: 8.1 })],
+    });
+    const b = entry({
+      package: 'libb',
+      version: '2.0.0',
+      packId: 'rust',
+      vulns: [
+        vuln({ id: 'RUSTSEC-2024-0002', package: 'libb', severity: 'medium', cvssScore: 5.0 }),
+      ],
+    });
+    const d = toCycloneDx(report([a, b]), OPTS);
+    expect(d.vulnerabilities).toHaveLength(1);
+    expect(d.vulnerabilities![0].ratings).toEqual([
+      { severity: 'high', score: 8.1 },
+      { severity: 'medium', score: 5.0 },
+    ]);
+  });
+
+  it('does not repeat an identical rating across rows', () => {
+    const mk = (pkg: string) =>
+      entry({
+        package: pkg,
+        version: '1.0.0',
+        packId: 'rust',
+        vulns: [vuln({ id: 'RUSTSEC-2024-0003', package: pkg, severity: 'low' })],
+      });
+    const d = toCycloneDx(report([mk('liba'), mk('libb')]), OPTS);
+    expect(d.vulnerabilities![0].ratings).toEqual([{ severity: 'low' }]);
+  });
+
+  it('sorts vulnerabilities by codepoint, not host locale', () => {
+    const mk = (pkg: string, id: string) =>
+      entry({
+        package: pkg,
+        version: '1.0.0',
+        packId: 'rust',
+        vulns: [vuln({ id, package: pkg, severity: 'low' })],
+      });
+    const d = toCycloneDx(report([mk('liba', 'a-vuln'), mk('libb', 'B-vuln')]), OPTS);
+    // Codepoint order puts uppercase B (0x42) before lowercase a (0x61);
+    // a locale-collated sort would answer the other way on most hosts.
+    expect(d.vulnerabilities!.map((v) => v.id)).toEqual(['B-vuln', 'a-vuln']);
+  });
+
+  it("the root application's bom-ref shares the components' uniqueness domain", () => {
+    const d = toCycloneDx(report([entry({ package: 'x', version: '1.0.0' })]), OPTS);
+    const refs = d.components.map((c) => c['bom-ref']);
+    expect(refs).not.toContain(d.metadata.component['bom-ref']);
+  });
+});
+
+describe('CLI flag guards (integration over dist)', () => {
+  const CLI = path.resolve(__dirname, '..', 'dist', 'index.js');
+
+  function runCli(args: string[], cwd: string): { status: number; output: string } {
+    try {
+      const out = execFileSync('node', [CLI, ...args], { cwd, stdio: 'pipe', encoding: 'utf8' });
+      return { status: 0, output: out };
+    } catch (err) {
+      const e = err as { status?: number; stdout?: string; stderr?: string };
+      return { status: e.status ?? -1, output: `${e.stdout ?? ''}${e.stderr ?? ''}` };
+    }
+  }
+
+  it('rejects --json with --format cyclonedx (two stdout documents)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-sbom-guard-'));
+    try {
+      const r = runCli(['bom', '.', '--json', '--format', 'cyclonedx'], tmp);
+      expect(r.status).toBe(1);
+      expect(r.output).toContain('Cannot combine --json with --format cyclonedx');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects --xlsx plus --format cyclonedx sharing one --output path', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-sbom-guard2-'));
+    try {
+      const r = runCli(['bom', '.', '--xlsx', '--format', 'cyclonedx', '--output', 'f.xlsx'], tmp);
+      expect(r.status).toBe(1);
+      expect(r.output).toContain('one --output path');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('still rejects an unknown --format value', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-sbom-guard3-'));
+    try {
+      const r = runCli(['bom', '.', '--format', 'spdx'], tmp);
+      expect(r.status).toBe(1);
+      expect(r.output).toContain('Invalid --format value');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('cyclonedx stdout mode emits the document and nothing else on stdout', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-sbom-stdout-'));
+    try {
+      fs.writeFileSync(
+        path.join(tmp, 'package.json'),
+        JSON.stringify({ name: 'sbom-stdout-smoke', version: '0.0.1' }),
+      );
+      execFileSync('git', ['init', '-q'], { cwd: tmp });
+      const out = execFileSync('node', [CLI, 'bom', '.', '--format', 'cyclonedx', '--no-save'], {
+        cwd: tmp,
+        stdio: 'pipe',
+        encoding: 'utf8',
+      });
+      const doc = JSON.parse(out) as { bomFormat: string };
+      expect(doc.bomFormat).toBe('CycloneDX');
+      // The document is the WHOLE stdout: exactly one trailing newline,
+      // no spacer lines after it (the pipe-corruption regression).
+      expect(out.endsWith('}\n')).toBe(true);
+      expect(out.endsWith('\n\n')).toBe(false);
+      expect(out.startsWith('{')).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 180000);
 });

--- a/test/bom-cyclonedx.test.ts
+++ b/test/bom-cyclonedx.test.ts
@@ -1,0 +1,430 @@
+/**
+ * CycloneDX SBOM export (4.4.7 S1).
+ *
+ * Pins the renderer's honesty contract (fields come from gathered data
+ * or are omitted; purls are derived from pack-declared ecosystems or
+ * disclosed as omitted, never fabricated), the structural validity of
+ * the document (unique bom-refs, affects references resolve), purl
+ * derivation per ecosystem, license representation through the ONE
+ * SPDX helper, byte determinism, ecosystem threading through the bom
+ * gather, and the reports-snapshot pickup of the persisted SBOM file.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { buildPurl, SUPPORTED_PURL_TYPES } from '../src/analyzers/bom/purl';
+import {
+  advisorySource,
+  cycloneDxLicenses,
+  renderCycloneDx,
+  toCycloneDx,
+} from '../src/analyzers/bom/cyclonedx';
+import { gatherBomEntries } from '../src/analyzers/bom/gather';
+import { stampLicensePackId } from '../src/analyzers/licenses/gather';
+import { knownSpdxId, splitLicenseTerms } from '../src/analyzers/licenses/detailed';
+import { getCommand } from '../src/discovery/commands';
+import { collectArtifacts } from '../src/reports-cli';
+import type { BomEntry, BomReport, BomSeverity } from '../src/analyzers/bom/types';
+import type { DepVulnFinding, LicensesResult } from '../src/languages/capabilities/types';
+import type { DepVulnSummary } from '../src/analyzers/security/types';
+
+function vuln(over: Partial<DepVulnFinding> & { id: string; package: string }): DepVulnFinding {
+  return { severity: 'high', tool: 'osv-scanner', ...over };
+}
+
+function entry(over: Partial<BomEntry> & { package: string; version: string }): BomEntry {
+  return {
+    licenseType: 'MIT',
+    vulns: [],
+    maxSeverity: null,
+    upgradeAdvice: '',
+    joinedFromBoth: true,
+    ...over,
+  };
+}
+
+function report(entries: BomEntry[]): BomReport {
+  const bySeverity: Record<BomSeverity, number> = { critical: 0, high: 0, medium: 0, low: 0 };
+  return {
+    repo: 'sample-repo',
+    analyzedAt: '2026-08-28T00:00:00.000Z',
+    commitSha: 'abc1234',
+    branch: 'main',
+    schemaVersion: '1',
+    summary: {
+      totalPackages: entries.length,
+      bySeverity,
+      vulnerablePackages: 0,
+      actionableVulns: 0,
+      totalAdvisories: 0,
+      allowlistedAdvisories: 0,
+      vulnOnlyPackages: 0,
+      byTopLevelDep: {},
+      filter: 'all',
+      unfilteredTotalPackages: entries.length,
+      projectRoots: ['.'],
+      fingerprints: [],
+    },
+    entries,
+    toolsUsed: [],
+    toolsUnavailable: [],
+  };
+}
+
+const OPTS = { timestamp: '2026-08-28T00:00:00.000Z', dxkitVersion: '4.4.7-test' };
+
+describe('buildPurl (per-ecosystem derivation)', () => {
+  it('npm: unscoped and scoped (scope percent-encoded into the namespace)', () => {
+    expect(buildPurl('npm', 'lodash', '4.17.21')).toBe('pkg:npm/lodash@4.17.21');
+    expect(buildPurl('npm', '@scope/pkg', '1.0.0')).toBe('pkg:npm/%40scope/pkg@1.0.0');
+  });
+
+  it('pypi: PEP 503 normalization (lowercase, underscore and dot fold to hyphen)', () => {
+    expect(buildPurl('pypi', 'Typing_Extensions', '4.8.0')).toBe(
+      'pkg:pypi/typing-extensions@4.8.0',
+    );
+    expect(buildPurl('pypi', 'zope.interface', '6.0')).toBe('pkg:pypi/zope-interface@6.0');
+  });
+
+  it('golang: module path splits into namespace + name, lowercased', () => {
+    expect(buildPurl('golang', 'github.com/BurntSushi/toml', 'v1.2.0')).toBe(
+      'pkg:golang/github.com/burntsushi/toml@v1.2.0',
+    );
+    expect(buildPurl('golang', 'gopkg.in/yaml.v3', 'v3.0.1')).toBe(
+      'pkg:golang/gopkg.in/yaml.v3@v3.0.1',
+    );
+  });
+
+  it('maven: group:artifact splits at the colon; colon-less names cannot derive', () => {
+    expect(buildPurl('maven', 'org.apache.commons:commons-lang3', '3.12.0')).toBe(
+      'pkg:maven/org.apache.commons/commons-lang3@3.12.0',
+    );
+    expect(buildPurl('maven', 'commons-lang3', '3.12.0')).toBeNull();
+  });
+
+  it('composer: vendor/name splits at the slash; vendor-less names cannot derive', () => {
+    expect(buildPurl('composer', 'guzzlehttp/guzzle', '7.8.0')).toBe(
+      'pkg:composer/guzzlehttp/guzzle@7.8.0',
+    );
+    expect(buildPurl('composer', 'guzzle', '7.8.0')).toBeNull();
+  });
+
+  it('cargo / gem / nuget: plain name, no namespace', () => {
+    expect(buildPurl('cargo', 'serde', '1.0.190')).toBe('pkg:cargo/serde@1.0.190');
+    expect(buildPurl('gem', 'rails', '7.1.2')).toBe('pkg:gem/rails@7.1.2');
+    expect(buildPurl('nuget', 'Newtonsoft.Json', '13.0.3')).toBe(
+      'pkg:nuget/Newtonsoft.Json@13.0.3',
+    );
+  });
+
+  it('percent-encodes version metadata (+ becomes %2B)', () => {
+    expect(buildPurl('cargo', 'openssl', '0.10.55+echo.1')).toBe(
+      'pkg:cargo/openssl@0.10.55%2Becho.1',
+    );
+  });
+
+  it('fails closed on unknown types and unusable inputs', () => {
+    expect(buildPurl('swiftpm-made-up', 'x', '1.0.0')).toBeNull();
+    expect(buildPurl('npm', '', '1.0.0')).toBeNull();
+    expect(buildPurl('npm', 'x', '')).toBeNull();
+    expect(buildPurl('npm', 'x', 'unknown')).toBeNull();
+  });
+
+  it('supported-type set matches the switch (every listed type derives something)', () => {
+    for (const type of SUPPORTED_PURL_TYPES) {
+      const name = type === 'maven' ? 'g:a' : type === 'composer' ? 'v/n' : 'name';
+      expect(buildPurl(type, name, '1.0.0'), type).not.toBeNull();
+    }
+  });
+});
+
+describe('license representation (through the ONE SPDX helper)', () => {
+  it('splitLicenseTerms splits OR / AND / comma forms', () => {
+    expect(splitLicenseTerms('MIT OR Apache-2.0')).toEqual(['MIT', 'Apache-2.0']);
+    expect(splitLicenseTerms('MIT, ISC')).toEqual(['MIT', 'ISC']);
+    expect(splitLicenseTerms('MIT')).toEqual(['MIT']);
+  });
+
+  it('knownSpdxId answers known, deprecated-known, and unknown ids', () => {
+    expect(knownSpdxId('MIT')).toBe('MIT');
+    expect(knownSpdxId('GPL-3.0')).toBe('GPL-3.0');
+    expect(knownSpdxId('Custom Corp License')).toBeNull();
+  });
+
+  it('a known single id renders as the SPDX id form', () => {
+    expect(cycloneDxLicenses('MIT')).toEqual([{ license: { id: 'MIT' } }]);
+  });
+
+  it('an unknown license string renders as the name form (never a fake id)', () => {
+    expect(cycloneDxLicenses('Custom Corp License')).toEqual([
+      { license: { name: 'Custom Corp License' } },
+    ]);
+  });
+
+  it('a compound expression of known ids renders as an SPDX expression', () => {
+    expect(cycloneDxLicenses('MIT OR Apache-2.0')).toEqual([{ expression: 'MIT OR Apache-2.0' }]);
+  });
+
+  it('a compound with an unknown term falls back to the name form', () => {
+    expect(cycloneDxLicenses('MIT OR SeenNowhere-1.0')).toEqual([
+      { license: { name: 'MIT OR SeenNowhere-1.0' } },
+    ]);
+  });
+
+  it('UNKNOWN and empty make no license claim at all', () => {
+    expect(cycloneDxLicenses('UNKNOWN')).toBeUndefined();
+    expect(cycloneDxLicenses('')).toBeUndefined();
+  });
+});
+
+describe('toCycloneDx (document structure + honesty)', () => {
+  const fullEntry = entry({
+    package: '@scope/web',
+    version: '2.0.0',
+    packId: 'typescript',
+    licenseType: 'MIT',
+    maxSeverity: 'high',
+    vulns: [
+      vuln({
+        id: 'GHSA-aaaa-bbbb-cccc',
+        package: '@scope/web',
+        installedVersion: '2.0.0',
+        severity: 'high',
+        cvssScore: 8.1,
+        summary: 'Prototype pollution',
+        packId: 'typescript',
+      }),
+    ],
+  });
+  const pyEntry = entry({
+    package: 'requests',
+    version: '2.31.0',
+    packId: 'python',
+    licenseType: 'Apache-2.0',
+  });
+  const noEcosystem = entry({
+    package: 'mystery',
+    version: '1.0.0',
+    licenseType: 'UNKNOWN',
+    joinedFromBoth: false,
+  });
+
+  const doc = toCycloneDx(report([fullEntry, pyEntry, noEcosystem]), OPTS);
+
+  it('carries the required top-level fields', () => {
+    expect(doc.bomFormat).toBe('CycloneDX');
+    expect(doc.specVersion).toBe('1.5');
+    expect(doc.version).toBe(1);
+    expect(doc.metadata.timestamp).toBe(OPTS.timestamp);
+    expect(doc.metadata.tools.components[0]).toEqual({
+      type: 'application',
+      name: '@vyuhlabs/dxkit',
+      version: '4.4.7-test',
+    });
+    expect(doc.metadata.component).toEqual({
+      'bom-ref': 'app:sample-repo',
+      type: 'application',
+      name: 'sample-repo',
+    });
+  });
+
+  it('derives purls from the pack-declared ecosystem', () => {
+    const [ts, py] = doc.components;
+    expect(ts.purl).toBe('pkg:npm/%40scope/web@2.0.0');
+    expect(py.purl).toBe('pkg:pypi/requests@2.31.0');
+  });
+
+  it('a row with no ecosystem carries bom-ref only, with the omission disclosed', () => {
+    const c = doc.components[2];
+    expect(c.purl).toBeUndefined();
+    expect(c['bom-ref']).toBe('mystery@1.0.0');
+    expect(c.properties).toContainEqual({ name: 'dxkit:purl-omitted', value: 'ecosystem-unknown' });
+  });
+
+  it('a known ecosystem is disclosed as a property', () => {
+    expect(doc.components[0].properties).toContainEqual({
+      name: 'dxkit:ecosystem',
+      value: 'typescript',
+    });
+  });
+
+  it('bom-refs are unique and every affects ref resolves', () => {
+    const refs = doc.components.map((c) => c['bom-ref']);
+    expect(new Set(refs).size).toBe(refs.length);
+    for (const v of doc.vulnerabilities ?? []) {
+      for (const a of v.affects) {
+        expect(refs, `unresolved affects ref ${a.ref}`).toContain(a.ref);
+      }
+    }
+  });
+
+  it('renders vulnerabilities with source, rating, and description from gathered facts', () => {
+    expect(doc.vulnerabilities).toHaveLength(1);
+    const v = doc.vulnerabilities![0];
+    expect(v.id).toBe('GHSA-aaaa-bbbb-cccc');
+    expect(v.source).toEqual({
+      name: 'GitHub Advisory Database',
+      url: 'https://github.com/advisories/GHSA-aaaa-bbbb-cccc',
+    });
+    expect(v.ratings).toEqual([{ severity: 'high', score: 8.1 }]);
+    expect(v.description).toBe('Prototype pollution');
+    expect(v.affects).toEqual([{ ref: 'pkg:npm/%40scope/web@2.0.0' }]);
+  });
+
+  it('omits the vulnerabilities section entirely when there are none', () => {
+    const clean = toCycloneDx(report([pyEntry]), OPTS);
+    expect(clean.vulnerabilities).toBeUndefined();
+  });
+
+  it('a rating without a cvssScore carries severity only (no invented score)', () => {
+    const e = entry({
+      package: 'x',
+      version: '1.0.0',
+      packId: 'ruby',
+      vulns: [vuln({ id: 'CVE-2024-0001', package: 'x', severity: 'low' })],
+    });
+    const d = toCycloneDx(report([e]), OPTS);
+    expect(d.vulnerabilities![0].ratings).toEqual([{ severity: 'low' }]);
+  });
+
+  it('one advisory across two packages becomes one vulnerability affecting both', () => {
+    const a = entry({
+      package: 'liba',
+      version: '1.0.0',
+      packId: 'rust',
+      vulns: [vuln({ id: 'RUSTSEC-2024-0001', package: 'liba', severity: 'medium' })],
+    });
+    const b = entry({
+      package: 'libb',
+      version: '2.0.0',
+      packId: 'rust',
+      vulns: [vuln({ id: 'RUSTSEC-2024-0001', package: 'libb', severity: 'medium' })],
+    });
+    const d = toCycloneDx(report([a, b]), OPTS);
+    expect(d.vulnerabilities).toHaveLength(1);
+    expect(d.vulnerabilities![0].affects).toEqual([
+      { ref: 'pkg:cargo/liba@1.0.0' },
+      { ref: 'pkg:cargo/libb@2.0.0' },
+    ]);
+  });
+
+  it('a colliding fallback ref is disambiguated so refs stay unique', () => {
+    const a = entry({ package: 'dup', version: '1.0.0' });
+    const b = entry({ package: 'dup', version: '1.0.0' });
+    const d = toCycloneDx(report([a, b]), OPTS);
+    const refs = d.components.map((c) => c['bom-ref']);
+    expect(new Set(refs).size).toBe(2);
+  });
+
+  it('an entry with version "unknown" omits the version field', () => {
+    const e = entry({ package: 'ghost', version: 'unknown', joinedFromBoth: false });
+    const d = toCycloneDx(report([e]), OPTS);
+    expect(d.components[0].version).toBeUndefined();
+    expect(d.components[0].purl).toBeUndefined();
+  });
+
+  it('is byte-deterministic: same input + same injected timestamp', () => {
+    const r = report([fullEntry, pyEntry, noEcosystem]);
+    expect(renderCycloneDx(r, OPTS)).toBe(renderCycloneDx(r, OPTS));
+    expect(renderCycloneDx(r, OPTS).endsWith('\n')).toBe(true);
+  });
+});
+
+describe('advisorySource', () => {
+  it('maps known id schemes and stays silent on unknown ones', () => {
+    expect(advisorySource('CVE-2024-1234')?.name).toBe('NVD');
+    expect(advisorySource('PYSEC-2024-1')?.name).toBe('OSV');
+    expect(advisorySource('GO-2024-1234')?.name).toBe('Go Vulnerability Database');
+    expect(advisorySource('VENDOR-XYZ-1')).toBeUndefined();
+  });
+});
+
+describe('ecosystem threading (gather to entry)', () => {
+  it('stampLicensePackId stamps every finding once, idempotently', () => {
+    const env: LicensesResult = {
+      schemaVersion: 1,
+      tool: 'license-checker',
+      findings: [
+        { package: 'a', version: '1.0.0', licenseType: 'MIT' },
+        { package: 'b', version: '2.0.0', licenseType: 'ISC', packId: 'python' },
+      ],
+    };
+    const stamped = stampLicensePackId(env, 'typescript');
+    expect(stamped.findings[0].packId).toBe('typescript');
+    // An already-stamped finding keeps its provenance.
+    expect(stamped.findings[1].packId).toBe('python');
+  });
+
+  it('gatherBomEntries threads packId from the license row, and from vulns for vuln-only rows', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-bom-eco-'));
+    try {
+      const licenses: LicensesResult = {
+        schemaVersion: 1,
+        tool: 'license-checker',
+        findings: [
+          { package: 'left-pad', version: '1.3.0', licenseType: 'MIT', packId: 'typescript' },
+        ],
+      };
+      const depVulns: DepVulnSummary = {
+        critical: 0,
+        high: 1,
+        medium: 0,
+        low: 0,
+        total: 1,
+        tool: 'osv-scanner',
+        findings: [
+          vuln({
+            id: 'GHSA-vuln-only-0001',
+            package: 'orphan-pkg',
+            installedVersion: '0.1.0',
+            packId: 'python',
+          }),
+        ],
+      } as DepVulnSummary;
+      const { entries } = await gatherBomEntries(tmp, {
+        licensesOverride: licenses,
+        depVulnsOverride: depVulns,
+      });
+      const licensed = entries.find((e) => e.package === 'left-pad');
+      const vulnOnly = entries.find((e) => e.package === 'orphan-pkg');
+      expect(licensed?.packId).toBe('typescript');
+      expect(vulnOnly?.packId).toBe('python');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('discovery + snapshot pickup', () => {
+  it('sbom resolves as an alias of bom', () => {
+    const cmd = getCommand('sbom');
+    expect(cmd?.id).toBe('bom');
+  });
+
+  it('collectArtifacts publishes the newest bom-*.cdx.json as sbom.cdx.json', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-sbom-artifacts-'));
+    try {
+      const reportsDir = path.join(tmp, '.dxkit', 'reports');
+      fs.mkdirSync(reportsDir, { recursive: true });
+      fs.writeFileSync(path.join(reportsDir, 'bom-2026-01-01.cdx.json'), '{"old":true}');
+      fs.writeFileSync(path.join(reportsDir, 'bom-2026-08-28.cdx.json'), '{"new":true}');
+      const artifacts = collectArtifacts(tmp);
+      const sbom = artifacts.find((a) => a.path === 'sbom.cdx.json');
+      expect(sbom?.content).toBe('{"new":true}');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('collectArtifacts emits no sbom artifact when none was rendered', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-sbom-none-'));
+    try {
+      fs.mkdirSync(path.join(tmp, '.dxkit', 'reports'), { recursive: true });
+      const artifacts = collectArtifacts(tmp);
+      expect(artifacts.find((a) => a.path === 'sbom.cdx.json')).toBeUndefined();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -1147,3 +1147,34 @@ describe('tree invariants: every pack declares its frame-owned invariants', () =
     });
   }
 });
+
+describe('purlType declarations (SBOM export, Rule 6)', () => {
+  it('every declared purlType is supported by the ONE purl builder', async () => {
+    const { SUPPORTED_PURL_TYPES, buildPurl } = await import('../src/analyzers/bom/purl');
+    for (const lang of LANGUAGES) {
+      if (lang.purlType === undefined) continue;
+      expect(
+        SUPPORTED_PURL_TYPES.has(lang.purlType),
+        `${lang.id} declares purlType '${lang.purlType}' which src/analyzers/bom/purl.ts cannot build; ` +
+          'extend buildPurl (and SUPPORTED_PURL_TYPES) or drop the declaration',
+      ).toBe(true);
+      // A well-shaped sample name must actually derive: the declaration is
+      // a promise the builder keeps (two projections of one concept, pinned).
+      const sample = lang.purlType === 'maven' ? 'com.example:artifact' : 'vendor/example';
+      const derived =
+        buildPurl(lang.purlType, sample, '1.0.0') ?? buildPurl(lang.purlType, 'example', '1.0.0');
+      expect(derived, `${lang.id}: buildPurl returned null for a well-shaped name`).toMatch(
+        new RegExp(`^pkg:${lang.purlType}/`),
+      );
+    }
+  });
+
+  it('packs without a purlType are the declared exemptions only', () => {
+    const withoutPurl = LANGUAGES.filter((l) => l.purlType === undefined)
+      .map((l) => l.id)
+      .sort();
+    // swift: a swift purl needs the source-host namespace we do not gather.
+    // abap: the purl spec has no ABAP type. Both disclosed in the pack files.
+    expect(withoutPurl).toEqual(['abap', 'swift']);
+  });
+});


### PR DESCRIPTION
## What

CycloneDX SBOM export for the BoM surface (4.4.7 unit S1). The `bom` command already joins the license inventory with the dependency vulnerability scan into one report; this unit adds a pure renderer of that ONE report into the standard CycloneDX 1.5 JSON interchange format, plus the wiring to get it into users' hands: a CLI flag, an `sbom` alias, an always-persisted reports-dir copy, and publication on the reports snapshot ref.

## How it works

- **Renderer** (`src/analyzers/bom/cyclonedx.ts`): `BomEntry[]` plus report metadata in, a CycloneDX document out. No gathering happens in the renderer (Rule 2). specVersion is **1.5**: everything we emit (components with purl, licenses, properties; vulnerabilities with source, ratings, affects) is fully expressible in 1.5, and 1.5 has the widest consumer support (Dependency-Track, Trivy, Grype, osv-scanner). The 1.6 additions model data dxkit does not gather, so claiming 1.6 would narrow the consumer set for nothing.
- **Honesty contract**: every field comes from gathered data or is omitted. No serialNumber (would break byte determinism and adds no fact), no invented CVSS vectors (severity always, numeric score only when the scan carried one), no license claim for `UNKNOWN`, and never a fabricated purl.
- **Ecosystem provenance, threaded not guessed**: `LicenseFinding` gains `packId`, stamped once by the cross-pack licenses aggregation (`stampLicensePackId` in `gatherLicensesWithAvailability`; providers never populate it, mirroring the dep-vuln fingerprint discipline). The BoM join carries it onto `BomEntry` (license row wins; vuln-only rows fall back to the advisory's `packId`). The purl TYPE comes from the owning pack's new `LanguageSupport.purlType` declaration (Rule 6): npm, pypi, golang, cargo, nuget, maven (java + kotlin), gem, composer. swift and abap deliberately omit it (a swift purl needs the source-host namespace we do not gather; the purl spec has no ABAP type); such rows carry a bom-ref only plus a disclosed `dxkit:purl-omitted` property.
- **One purl builder** (`src/analyzers/bom/purl.ts`): per-type namespace and encoding rules (npm scope percent-encoding, PEP 503 normalization for pypi, golang path namespaces, maven `group:artifact` and composer `vendor/name` splits, fail-closed on unmodeled shapes). The contract test pins that every pack-declared type is one the builder supports.
- **One license classifier**: the licenses module (`src/analyzers/licenses/detailed.ts`) grows `splitLicenseTerms` (the existing matcher now routes through it too) and `knownSpdxId`, a curated id set biased toward false negatives: a known single id renders as the SPDX `id` form, a known compound as an SPDX `expression`, anything else as the always-valid `name` form. A wrong id claim would make the document schema-invalid; a missed id only downgrades to name form.
- **CLI**: `vyuh-dxkit bom --format cyclonedx` streams the document to stdout (chatter moves to stderr, pipe-friendly); `--output <file>` writes it to an explicit path instead. Default output is unchanged. `sbom` is registered as an alias of `bom` in the capability registry (Rule 16; the arch-check parity covers aliases), and the descriptor's docsBlurb names the export.
- **Reports-branch storage**: the bom disk side now always writes `.dxkit/reports/bom-<date>.cdx.json` (the same always-write discipline as the detailed JSON), and `collectArtifacts` in the report snapshot publisher picks up the newest one and publishes it as `latest/sbom.cdx.json` on the `dxkit-reports` anchor ref. The existing reports refresh lane (`report` then `report snapshot`) therefore ships the SBOM on every merge with zero workflow-template changes. Consumer retrieval: `git fetch origin dxkit-reports && git show FETCH_HEAD:latest/sbom.cdx.json`.
- **Determinism**: the timestamp is injected (the report's own `analyzedAt`, the same instant every other rendering of that gather carries), ordering is stable, and byte-identity is pinned by test.

## Deliberately left out

- **SPDX-format export**: declared in the module doc. CycloneDX first because it is the vulnerability-workflow interchange format (first-class vulnerabilities section, which SPDX lacks); an SPDX document export lands when a consumer needs it.
- **A vendored full SPDX id list**: the curated `knownSpdxId` set covers what our license tools actually emit and fails toward the spec-valid name form. Extending the set is a one-line change in the one module.

## Tests

`test/bom-cyclonedx.test.ts` (renderer structure and honesty, purl derivation per ecosystem including the fail-closed cases, license forms, vulnerability merge and affects resolution, byte determinism, ecosystem threading through `gatherBomEntries`, alias discovery, snapshot artifact pickup both directions) plus `test/languages-contract.test.ts` additions (every declared `purlType` is supported by the one builder; the no-purl packs are exactly the declared exemptions). CLI smoke-tested end to end on a fixture repo: stdout mode, `--output` mode, alias dispatch, persisted `.cdx.json`.

## Sweep + guardrail

- typecheck / typecheck:test: clean
- eslint --max-warnings 0: clean
- prettier --check: clean
- check-architecture.sh: exit 0
- check-docs-coverage.sh: exit 0
- check-slop.sh (base origin/main): exit 0 (advisory size notes on pre-existing remediate tests only)
- build: clean
- vitest run --coverage: 423 files, 6410 tests, all passed; coverage 75.22% (floor 50%): exit 0
- `guardrail check --mode ref-based --ref origin/main`: **PASSED**, exit 0

## Review focus

- The stdout contract in the `bom` CLI case: `--format cyclonedx` without `--output` flips the logger to stderr before the header prints, so the document is the only stdout.
- `stampLicensePackId` placement: stamped per success envelope before the descriptor aggregate, so every consumer of the aggregated inventory (health cache, bom, licenses report) sees the same provenance.
- The curated SPDX id set's false-negative bias: is name-form fallback acceptable for ids not in the set (it stays spec-valid), or should the full SPDX list be vendored now?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
