### PR TITLE
feat(impact): finding-delta Impact section, cap-aware, on the guardrail and lane PR surfaces (4.4.7 I1)

### DIFF
--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -66,6 +66,7 @@ import {
   formatImpactCapNote,
   formatImpactExclusions,
   formatImpactHeadline,
+  formatImpactNotAttributable,
   formatImpactQuietLine,
 } from './impact';
 import type { ImpactScoreInput, ImpactSummary } from './impact';
@@ -423,12 +424,18 @@ export function renderConsole(result: GuardrailCheckResult, opts?: CheckRenderOp
 
   // The Impact block (impact surface phase 1): what this change did to the
   // repo's debt, attribution-honest (only classifier-`removed` pairs count
-  // as resolved). Non-zero only: the summary footer already reports zero
+  // as resolved). A run that REFUSED to gate cannot back a resolved claim
+  // either, so it gets the not-attributable one-liner instead of any tally.
+  // Otherwise non-zero only: the summary footer already reports zero
   // resolved, so a neutral run gets no extra block here (the quiet line is
   // a PR-comment concern).
   {
     const impact = deriveImpact(result, opts?.impactScores);
-    if (impact.resolved > 0) {
+    if (!impact.attributable) {
+      lines.push(logger.bold('Impact'));
+      lines.push(`  ${formatImpactNotAttributable()}`);
+      lines.push('');
+    } else if (impact.resolved > 0) {
       lines.push(logger.bold('Impact'));
       lines.push(`  ${formatImpactHeadline(impact)}`);
       for (const note of impact.capNotes) lines.push(`  ${formatImpactCapNote(note)}`);
@@ -1839,10 +1846,16 @@ export function renderMarkdown(result: GuardrailCheckResult, opts?: CheckRenderO
   // change did to the repo's debt, resolved side first. Non-zero only (UX
   // call 1); a change that resolves nothing gets the one quiet line. The
   // added/blocking side stays with the existing finding tables below,
-  // Impact counts it but never re-lists it (one concept, one section).
+  // Impact counts it but never re-lists it (one concept, one section). A
+  // run that REFUSED to gate renders neither: a "-N resolved" beside a
+  // CANNOT GATE heading would claim exactly what the refusal says cannot
+  // be claimed, so the one-liner defers to the gap banner directly below.
   {
     const impact = deriveImpact(result, opts?.impactScores);
-    if (impact.resolved > 0) {
+    if (!impact.attributable) {
+      lines.push(`_${escapeMd(formatImpactNotAttributable())}_`);
+      lines.push('');
+    } else if (impact.resolved > 0) {
       lines.push('### Impact');
       lines.push('');
       lines.push(escapeMd(formatImpactHeadline(impact)));

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -61,6 +61,28 @@ import {
   type DuplicateFinding,
   type DuplicateGroup,
 } from '../analyzers/duplication/findings';
+import {
+  deriveImpact,
+  formatImpactCapNote,
+  formatImpactExclusions,
+  formatImpactHeadline,
+  formatImpactQuietLine,
+} from './impact';
+import type { ImpactScoreInput, ImpactSummary } from './impact';
+
+// ─── Shared render options ────────────────────────────────────────────────
+
+/**
+ * Optional per-render inputs shared by the three surfaces. Phase 1 of the
+ * impact surface: a caller that computed dimension scores in the SAME run
+ * may hand them in so the Impact section can carry the cap-aware
+ * explanation (numbers straight off the spec engine, never recomputed).
+ * Absent scores mean the section carries the finding delta alone; no
+ * current guardrail surface computes scores (that is the phase 2 spike).
+ */
+export interface CheckRenderOptions {
+  readonly impactScores?: ReadonlyArray<ImpactScoreInput>;
+}
 
 // ─── Shared verdict predicates ────────────────────────────────────────────
 
@@ -262,7 +284,7 @@ export function deferredCaptureBannerLines(result: GuardrailCheckResult): string
   ];
 }
 
-export function renderConsole(result: GuardrailCheckResult): string {
+export function renderConsole(result: GuardrailCheckResult, opts?: CheckRenderOptions): string {
   const lines: string[] = [];
 
   // Verdict banner. Single line at the top so a developer skimming
@@ -398,6 +420,23 @@ export function renderConsole(result: GuardrailCheckResult): string {
   lines.push(...formatSchemaDriftGate(result.schemaDriftGate));
   lines.push(...formatDupGate(result.dupGate));
   lines.push(...formatPairedGate(result.pairedGate));
+
+  // The Impact block (impact surface phase 1): what this change did to the
+  // repo's debt, attribution-honest (only classifier-`removed` pairs count
+  // as resolved). Non-zero only: the summary footer already reports zero
+  // resolved, so a neutral run gets no extra block here (the quiet line is
+  // a PR-comment concern).
+  {
+    const impact = deriveImpact(result, opts?.impactScores);
+    if (impact.resolved > 0) {
+      lines.push(logger.bold('Impact'));
+      lines.push(`  ${formatImpactHeadline(impact)}`);
+      for (const note of impact.capNotes) lines.push(`  ${formatImpactCapNote(note)}`);
+      const exclusions = formatImpactExclusions(impact);
+      if (exclusions) lines.push(`  ${exclusions}`);
+      lines.push('');
+    }
+  }
 
   // Always show a summary footer — sets expectations for what
   // happens next (exit code, what to read on a fail).
@@ -1289,6 +1328,13 @@ export interface GuardrailJsonPayload {
     readonly kind: string;
     readonly currentCount: number;
   }>;
+  /** The finding-delta impact of this change (impact surface phase 1):
+   *  attributable resolved/added counts, the Rule 19 exclusions, and the
+   *  cap-aware notes when the caller supplied score results. Additive in
+   *  schema v1 (typed optional so older captured payloads still satisfy
+   *  the interface), but ALWAYS emitted by the current renderer: zero is
+   *  reported as zero, never omitted. */
+  readonly impact?: ImpactSummary;
   /** Present when the dependency-vuln scan was requested but could not run —
    *  a pass is then NOT a clean bill of dependency health. */
   readonly depVulnsUnmeasured?: { readonly reason: string };
@@ -1506,7 +1552,10 @@ export interface GuardrailJsonPayload {
   };
 }
 
-export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
+export function renderJson(
+  result: GuardrailCheckResult,
+  opts?: CheckRenderOptions,
+): GuardrailJsonPayload {
   const blocking = result.pairs.filter(isBlocking).length;
   const suppressed = result.pairs.filter(isAllowlistSuppressed).length;
   const warning = result.pairs.filter(isWarning).length;
@@ -1540,6 +1589,8 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
     // The ref-mode exclusion disclosure, in the JSON payload too (the other
     // two renderers already print it) — always present, [] when none.
     refExcludedKinds: result.refExcludedKinds,
+    // The finding-delta impact, always emitted, zero reported as zero.
+    impact: deriveImpact(result, opts?.impactScores),
     ...(result.depVulnsUnmeasured ? { depVulnsUnmeasured: result.depVulnsUnmeasured } : {}),
     ...(result.deferredCapture && result.deferredCapture.length > 0
       ? { deferredCapture: result.deferredCapture }
@@ -1754,7 +1805,7 @@ export function renderJson(result: GuardrailCheckResult): GuardrailJsonPayload {
  *   <drift signal callout, when envelope drifted>
  *   <provenance footnote>
  */
-export function renderMarkdown(result: GuardrailCheckResult): string {
+export function renderMarkdown(result: GuardrailCheckResult, opts?: CheckRenderOptions): string {
   const lines: string[] = [];
   const blocking = result.pairs.filter(isBlocking);
   const suppressed = result.pairs.filter(isAllowlistSuppressed);
@@ -1783,6 +1834,33 @@ export function renderMarkdown(result: GuardrailCheckResult): string {
     ),
   );
   lines.push('');
+
+  // The Impact section (impact surface phase 1), above the fold: what this
+  // change did to the repo's debt, resolved side first. Non-zero only (UX
+  // call 1); a change that resolves nothing gets the one quiet line. The
+  // added/blocking side stays with the existing finding tables below,
+  // Impact counts it but never re-lists it (one concept, one section).
+  {
+    const impact = deriveImpact(result, opts?.impactScores);
+    if (impact.resolved > 0) {
+      lines.push('### Impact');
+      lines.push('');
+      lines.push(escapeMd(formatImpactHeadline(impact)));
+      for (const note of impact.capNotes) {
+        lines.push('');
+        lines.push(escapeMd(formatImpactCapNote(note)));
+      }
+      const exclusions = formatImpactExclusions(impact);
+      if (exclusions) {
+        lines.push('');
+        lines.push(`_${escapeMd(exclusions)}_`);
+      }
+      lines.push('');
+    } else {
+      lines.push(`_${escapeMd(formatImpactQuietLine(impact))}_`);
+      lines.push('');
+    }
+  }
 
   if (result.attributionGaps.length > 0) {
     lines.push(

--- a/src/baseline/classify.ts
+++ b/src/baseline/classify.ts
@@ -166,7 +166,9 @@ export interface ClassifyResult {
  *      `FindingStatus`.
  *   2. For `added`: check drift context. Scanner-version drift wins
  *      (more specific signal) over config drift; both demote to
- *      drift-bucket statuses regardless of severity.
+ *      drift-bucket statuses regardless of severity. For `removed`:
+ *      not-observed wins (dxkit did not look), then recall drift (the
+ *      tool moved), both meaning the disappearance is not "resolved".
  *   3. For `persisted` / `relocated`: check confidence against the
  *      per-severity threshold. Below threshold demotes to
  *      `'uncertain'`.
@@ -197,6 +199,29 @@ export function classify(
       detail: `${context.notObserved} — this baseline finding was not re-verified this run; not observed is not resolved`,
     });
     return { status: 'not_observed', blocks: false, warns: false, reasons };
+  }
+
+  // Removed-direction recall drift (Rule 19's cause 5/6 in the resolved
+  // direction, the sibling of the `added` demotion below): the kind's recall
+  // inputs moved between baseline and this run, so a disappearance has an
+  // explanation other than "the developer fixed it": a scanner bump that
+  // drops rules makes its findings vanish without anyone touching the code.
+  // "You resolved N findings" is a cause claim too, so the pair demotes to
+  // `tooling_drift` instead of counting as resolved. Fixed verdict like
+  // `not_observed` (never blocks, never warns: there is nothing on the
+  // current side to gate, and warning about an absence would only add noise
+  // on top of the envelope-drift disclosure that already names the kind and
+  // the input that moved). No `unattributableBlockRule` either: block rules
+  // exist to stop net-new findings, and this pair has no current side.
+  if (status === 'removed' && context.recallDrifted) {
+    reasons.push({
+      code: 'tooling-drift',
+      detail:
+        (context.recallDriftDetail ?? 'what dxkit can see for this kind changed between runs') +
+        ', so this baseline finding is gone but the disappearance cannot be attributed to ' +
+        'the diff; demoted, not counted as resolved',
+    });
+    return { status: 'tooling_drift', blocks: false, warns: false, reasons };
   }
 
   // Step 2: drift context can reclassify 'added'.

--- a/src/baseline/impact.ts
+++ b/src/baseline/impact.ts
@@ -14,10 +14,14 @@
  *      why clearing debt did not move a capped dimension.
  *   2. Attribution first (CLAUDE.md Rule 19): "you fixed N findings" is a
  *      cause claim, so the resolved tally counts ONLY pairs the classifier
- *      marked `removed`. A `not_observed` pair (the check never ran on the
- *      current side) and a `tooling_drift` pair (the tool changed what it
- *      can see) are EXCLUDED from both directions and disclosed in
- *      `excluded`, never re-derived from a raw set diff.
+ *      marked `removed`. The classifier itself excludes the unattributable
+ *      causes in both directions (`not_observed` when the check never ran,
+ *      `tooling_drift` when the tool moved, including a matcher-removed
+ *      pair on a recall-drifted kind); this module consumes those verdicts
+ *      through a TOTAL status partition, never a raw set diff. And when the
+ *      run as a whole refused to gate (attribution gaps, missing required
+ *      observations), `attributable` is false and no surface may render a
+ *      resolved claim at all.
  *   3. Cap-aware, always: when a score result is present in the same run
  *      and its dimension is capped, the impact carries the cap and the
  *      unlock, with numbers read straight off the spec engine's output
@@ -95,6 +99,17 @@ export interface ImpactScoreInput {
  * the check payload as an additive field).
  */
 export interface ImpactSummary {
+  /**
+   * False when the run as a whole REFUSED to gate (attribution gaps on
+   * block-rule kinds, or required checks not observed: the `CANNOT GATE`
+   * tier). A refused run cannot back a resolved claim any more than a
+   * clean one, so no renderer may print the headline or the quiet line
+   * over it; every surface renders the not-attributable one-liner instead
+   * (`formatImpactNotAttributable`) and defers to the gap disclosures.
+   * The counts below are still carried (data, plainly flagged), never
+   * fabricated to zero.
+   */
+  readonly attributable: boolean;
   /** Findings this change resolved, counted ONLY from pairs the classifier
    *  marked `removed` (the same predicate the one verdict derivation's
    *  `resolved` tally uses; pinned by parity test). */
@@ -110,10 +125,10 @@ export interface ImpactSummary {
   readonly net: number;
   /** Pairs excluded from the attributable delta (Rule 19), per
    *  classification status. `not_observed` (the resolved direction: the
-   *  check never re-verified them) and `tooling_drift` (the added
-   *  direction: the tool moved, not the code) are the common entries.
-   *  Unchanged debt (`persisted` / `relocated`) is not a delta and is not
-   *  listed. Empty when every delta pair was attributable. */
+   *  check never re-verified them) and `tooling_drift` (either direction:
+   *  the tool moved, not the code) are the common entries. Unchanged debt
+   *  (`persisted` / `relocated`) is not a delta and is not listed. Empty
+   *  when every delta pair was attributable. */
   readonly excluded: ReadonlyArray<{ readonly status: FindingStatus; readonly count: number }>;
   /** Cap-aware explanations, one per capped dimension among the score
    *  results the surface supplied. Empty when no score result was present
@@ -122,41 +137,81 @@ export interface ImpactSummary {
   readonly capNotes: ReadonlyArray<ImpactCapNote>;
 }
 
-/** Delta statuses that may NOT be attributed to the change (Rule 19's
- *  causes 2 through 6). Everything here is excluded from `resolved` and
- *  `added` and disclosed in `excluded`. */
-const UNATTRIBUTABLE_DELTA_STATUSES: ReadonlyArray<FindingStatus> = [
-  'not_observed',
-  'tooling_drift',
-  'config_drift',
-  'newly_detected',
-  'newly_published_advisory',
-  'probable_existing',
-  'uncertain',
-];
+/**
+ * The TOTAL status partition (the `KIND_OBSERVATION_SCOPE` discipline): every
+ * `FindingStatus` declares which side of the impact delta it belongs to, so a
+ * future status fails to COMPILE here instead of silently dropping out of
+ * both the tally and the disclosure.
+ *
+ *   - `resolved`: counts toward the resolved headline. `fixed` is the
+ *     reserved policy-positive spelling of `removed`; the classifier never
+ *     emits it today, and `verdictCounts` counts only `removed`; if the
+ *     classifier ever starts emitting `fixed`, the resolved-parity pin in
+ *     `test/baseline/impact.test.ts` fails loudly and forces the two tallies
+ *     to be reconciled in one deliberate change.
+ *   - `added`: counts toward the attributable added tally.
+ *   - `excluded`: an unattributable delta (Rule 19 causes 2 through 6),
+ *     disclosed and never counted.
+ *   - `neutral`: unchanged debt, not a delta at all.
+ */
+const STATUS_PARTITION: Readonly<
+  Record<FindingStatus, 'resolved' | 'added' | 'excluded' | 'neutral'>
+> = {
+  removed: 'resolved',
+  fixed: 'resolved',
+  added: 'added',
+  persisted: 'neutral',
+  relocated: 'neutral',
+  not_observed: 'excluded',
+  tooling_drift: 'excluded',
+  config_drift: 'excluded',
+  newly_detected: 'excluded',
+  newly_published_advisory: 'excluded',
+  probable_existing: 'excluded',
+  uncertain: 'excluded',
+};
+
+/** The excluded statuses in stable disclosure order (partition insertion
+ *  order), derived from the one partition, never a second list. */
+const EXCLUDED_STATUS_ORDER: ReadonlyArray<FindingStatus> = (
+  Object.keys(STATUS_PARTITION) as FindingStatus[]
+).filter((s) => STATUS_PARTITION[s] === 'excluded');
 
 /**
  * Derive the impact summary from an existing check result. Pure; accepts
  * the structural subset of `GuardrailCheckResult` it reads, so the lane
  * surfaces (which hold the full result) and tests (which build fixtures)
- * share one entry point.
+ * share one entry point. The refusal fields (`attributionGaps`,
+ * `requiredNotObserved`) are optional structurally so fixtures stay small;
+ * a full `GuardrailCheckResult` always carries them, so every real caller
+ * gets the `attributable` answer for free.
  */
 export function deriveImpact(
   result: {
     readonly pairs: ReadonlyArray<ClassifiedPair>;
     readonly baseline: { readonly findings: ReadonlyArray<BaselineEntry> };
+    readonly attributionGaps?: ReadonlyArray<unknown>;
+    readonly requiredNotObserved?: ReadonlyArray<unknown>;
   },
   scores?: ReadonlyArray<ImpactScoreInput>,
 ): ImpactSummary {
   const priorById = new Map(result.baseline.findings.map((e) => [e.id, e] as const));
 
-  // Resolved: the classifier's `removed` status ONLY. `not_observed` pairs
-  // are matcher-removed too, but the classifier already re-labeled them
-  // (Rule 19's removed direction), so consuming the classification here is
-  // what keeps this a claim the run can back. Matches the `resolved` tally
-  // in `verdictCounts` by construction (parity-pinned; if the classifier
-  // ever emits the reserved `fixed` status, both tallies move together).
-  const resolvedPairs = result.pairs.filter((p) => p.classification.status === 'removed');
+  // The whole-run refusal signal (the CANNOT GATE tier): while a gap exists,
+  // the run can neither certify "no net-new" nor back "you fixed N": the
+  // same evidence is missing for both claims.
+  const attributable =
+    (result.attributionGaps?.length ?? 0) === 0 && (result.requiredNotObserved?.length ?? 0) === 0;
+
+  // Resolved: the statuses the partition declares resolved (today `removed`;
+  // `not_observed` and removed-direction `tooling_drift` pairs were already
+  // re-labeled by the ONE classifier (Rule 19's removed direction), so
+  // consuming the classification here is what keeps this a claim the run
+  // can back). Matches the `resolved` tally in `verdictCounts` (pinned by
+  // the parity test; see the partition note on `fixed`).
+  const resolvedPairs = result.pairs.filter(
+    (p) => STATUS_PARTITION[p.classification.status] === 'resolved',
+  );
 
   const byKind = new Map<BaselineEntry['kind'], Map<FindingSeverity, number>>();
   for (const p of resolvedPairs) {
@@ -182,20 +237,22 @@ export function deriveImpact(
     }))
     .sort((a, b) => b.count - a.count || a.kind.localeCompare(b.kind));
 
-  const added = result.pairs.filter((p) => p.classification.status === 'added').length;
+  const added = result.pairs.filter(
+    (p) => STATUS_PARTITION[p.classification.status] === 'added',
+  ).length;
 
   const excludedCounts = new Map<FindingStatus, number>();
   for (const p of result.pairs) {
-    if (UNATTRIBUTABLE_DELTA_STATUSES.includes(p.classification.status)) {
+    if (STATUS_PARTITION[p.classification.status] === 'excluded') {
       excludedCounts.set(
         p.classification.status,
         (excludedCounts.get(p.classification.status) ?? 0) + 1,
       );
     }
   }
-  const excluded = UNATTRIBUTABLE_DELTA_STATUSES.filter(
-    (s) => (excludedCounts.get(s) ?? 0) > 0,
-  ).map((s) => ({ status: s, count: excludedCounts.get(s)! }));
+  const excluded = EXCLUDED_STATUS_ORDER.filter((s) => (excludedCounts.get(s) ?? 0) > 0).map(
+    (s) => ({ status: s, count: excludedCounts.get(s)! }),
+  );
 
   const capNotes: ImpactCapNote[] = [];
   for (const s of scores ?? []) {
@@ -215,21 +272,42 @@ export function deriveImpact(
   }
 
   const resolved = resolvedPairs.length;
-  return { resolved, resolvedByKind, added, net: resolved - added, excluded, capNotes };
+  return {
+    attributable,
+    resolved,
+    resolvedByKind,
+    added,
+    net: resolved - added,
+    excluded,
+    capNotes,
+  };
 }
 
 // ─── One phrasing, every surface ──────────────────────────────────────────
 
-/** Human labels for the excluded statuses (lowercase, sentence-embeddable). */
+/** Human labels for the excluded statuses (lowercase, sentence-embeddable
+ *  after a count). */
 const EXCLUDED_LABEL: Partial<Record<FindingStatus, string>> = {
   not_observed: 'not re-verified this run',
-  tooling_drift: 'tooling drift',
-  config_drift: 'config drift',
+  tooling_drift: 'demoted to tooling drift',
+  config_drift: 'demoted to config drift',
   newly_detected: 'newly detected by a changed scanner',
-  newly_published_advisory: 'advisories published after baseline capture',
+  newly_published_advisory: 'from advisories published after baseline capture',
   probable_existing: 'probably pre-existing',
-  uncertain: 'uncertain match',
+  uncertain: 'uncertain matches',
 };
+
+/** Per-status excluded clauses ("2 demoted to tooling drift"), shared by the
+ *  exclusion disclosure and the quiet line so the wording cannot fork. */
+function excludedParts(impact: ImpactSummary): string[] {
+  return impact.excluded.map(
+    (e) => `${e.count} ${EXCLUDED_LABEL[e.status] ?? e.status.replace(/_/g, ' ')}`,
+  );
+}
+
+function excludedTotal(impact: ImpactSummary): number {
+  return impact.excluded.reduce((n, e) => n + e.count, 0);
+}
 
 function severityClause(delta: ImpactKindDelta): string {
   return delta.bySeverity.map((s) => `${s.count} ${s.severity}`).join(', ');
@@ -238,8 +316,8 @@ function severityClause(delta: ImpactKindDelta): string {
 /**
  * The headline finding delta, findings first (honesty constraint 1):
  * `-5 findings resolved (dep-vuln: 2 high, 3 medium) · +0 added by this change`.
- * Only meaningful when `impact.resolved > 0`; the quiet line below covers
- * the rest.
+ * Only meaningful when `impact.attributable` and `impact.resolved > 0`; the
+ * quiet line and the not-attributable line below cover the rest.
  */
 export function formatImpactHeadline(impact: ImpactSummary): string {
   const kinds = impact.resolvedByKind
@@ -270,23 +348,46 @@ export function formatImpactCapNote(note: ImpactCapNote): string {
 /** The Rule 19 exclusion disclosure, or null when nothing was excluded. */
 export function formatImpactExclusions(impact: ImpactSummary): string | null {
   if (impact.excluded.length === 0) return null;
-  const parts = impact.excluded.map(
-    (e) => `${e.count} ${EXCLUDED_LABEL[e.status] ?? e.status.replace(/_/g, ' ')}`,
-  );
-  return `Not counted (cannot attribute to this change): ${parts.join(', ')}.`;
+  return `Not counted (cannot attribute to this change): ${excludedParts(impact).join(', ')}.`;
 }
 
 /**
- * The quiet line for a change with nothing resolved (UX call 1: neutral
- * changes get one line, never a section). When the change ADDS findings,
- * the line says so and defers to the existing blocking/warning surfaces:
- * Impact never duplicates the regression report (one concept, one section).
+ * The one-liner every surface renders INSTEAD of the section or the quiet
+ * line when the run refused to gate (`attributable === false`): a run that
+ * cannot attribute its delta may not claim any of it, in either direction.
+ */
+export function formatImpactNotAttributable(): string {
+  return (
+    'Impact not attributable this run: the guardrail refused to gate, so no resolved or ' +
+    'added claim is made; see the attribution-gap disclosures.'
+  );
+}
+
+/**
+ * The quiet line for an attributable change with nothing resolved (UX call
+ * 1: neutral changes get one line, never a section). Three honest shapes:
+ *
+ *   - the change ADDS findings: say so and defer to the existing
+ *     blocking/warning surfaces (Impact never duplicates the regression
+ *     report; one concept, one section);
+ *   - nothing attributable moved but delta pairs were EXCLUDED (an advisory
+ *     wave, a tooling-drift demotion): "no debt impact" would over-claim,
+ *     so the line says no ATTRIBUTABLE impact and names what could not be
+ *     attributed;
+ *   - genuinely nothing: plain zero, reported as zero.
  */
 export function formatImpactQuietLine(impact: ImpactSummary): string {
+  const excludedN = excludedTotal(impact);
   if (impact.added > 0) {
-    return (
+    const base =
       `No findings resolved by this change; the +${impact.added} it adds ` +
-      `are reported with the guardrail findings.`
+      `are reported with the guardrail findings.`;
+    return excludedN > 0 ? `${base} ${formatImpactExclusions(impact)!}` : base;
+  }
+  if (excludedN > 0) {
+    return (
+      `No attributable debt impact; ${excludedN} finding${excludedN === 1 ? '' : 's'} could ` +
+      `not be attributed to this change (${excludedParts(impact).join(', ')}).`
     );
   }
   return 'No debt impact: this change neither resolves nor adds findings.';

--- a/src/baseline/impact.ts
+++ b/src/baseline/impact.ts
@@ -1,0 +1,293 @@
+/**
+ * The PR impact model, phase 1 (finding deltas, cap-aware).
+ *
+ * Derives "what did this change do to the repo's debt" from the EXISTING
+ * guardrail pair classifications: findings resolved (by kind and severity),
+ * findings added, and the net delta. Zero new computation: every number here
+ * is a projection of data the check already produced.
+ *
+ * The honesty constraints (the product's soul, from the impact-surface
+ * design) are implemented as code, not prose:
+ *
+ *   1. Findings are the headline. This module carries no score movement at
+ *      all in phase 1; a score enters only as the cap-aware EXPLANATION of
+ *      why clearing debt did not move a capped dimension.
+ *   2. Attribution first (CLAUDE.md Rule 19): "you fixed N findings" is a
+ *      cause claim, so the resolved tally counts ONLY pairs the classifier
+ *      marked `removed`. A `not_observed` pair (the check never ran on the
+ *      current side) and a `tooling_drift` pair (the tool changed what it
+ *      can see) are EXCLUDED from both directions and disclosed in
+ *      `excluded`, never re-derived from a raw set diff.
+ *   3. Cap-aware, always: when a score result is present in the same run
+ *      and its dimension is capped, the impact carries the cap and the
+ *      unlock, with numbers read straight off the spec engine's output
+ *      (`CapApplied.upliftIfRemoved`, `TopAction.upliftIfFixed`), never
+ *      recomputed here.
+ *   4. Zero is reported as zero: `deriveImpact` always returns a complete
+ *      summary; the renderers decide section-vs-quiet-line, and the JSON
+ *      payload always carries the field.
+ *
+ * One phrasing for every surface: the format helpers below are the ONLY
+ * place the impact prose lives. The guardrail's three renderers and the
+ * lane PR ledgers compose these; none writes its own delta sentence.
+ */
+
+import type { ClassifiedPair } from '../gate/result';
+import type { BaselineEntry, FindingSeverity, FindingStatus } from './types';
+import type { CapApplied, TopAction } from '../scoring/result';
+
+/** Severity display order, most severe first. */
+const SEVERITY_ORDER: ReadonlyArray<FindingSeverity> = ['critical', 'high', 'medium', 'low'];
+
+/**
+ * One finding kind's resolved slice, with a severity breakdown. Severity is
+ * display metadata: for a resolved pair it comes from the PRIOR entry's
+ * captured severity where the baseline recorded one (4.2), falling back to
+ * the pair's kind-default severity. Never identity, never a verdict input.
+ */
+export interface ImpactKindDelta {
+  readonly kind: BaselineEntry['kind'];
+  readonly count: number;
+  /** Non-zero severities only, ordered most severe first. */
+  readonly bySeverity: ReadonlyArray<{
+    readonly severity: FindingSeverity;
+    readonly count: number;
+  }>;
+}
+
+/**
+ * The cap-aware explanation for one capped dimension (honesty constraint 3):
+ * debt cleared but the score cannot move while the binding cap holds. Every
+ * number is the spec engine's own output, carried verbatim.
+ */
+export interface ImpactCapNote {
+  readonly dimension: string;
+  /** The dimension's current (capped) score. */
+  readonly score: number;
+  /** The binding cap's ceiling. */
+  readonly ceiling: number;
+  /** The cap's own reason text (`CapApplied.reason`). */
+  readonly reason: string;
+  /** Where the score can go when the cap clears: `score + upliftIfRemoved`,
+   *  both terms from the spec engine. */
+  readonly unlocksUpTo: number;
+  /** The highest-uplift next action (`topActions[0]`), when one exists with
+   *  a positive uplift. */
+  readonly largestUplift?: { readonly reason: string; readonly uplift: number };
+}
+
+/**
+ * The minimum a surface must hold to feed the cap-aware explanation. Both
+ * canonical shapes satisfy it structurally: a `ScoreResult`
+ * (`src/scoring/result.ts`) directly, and a health `DimensionScore` plus its
+ * dimension name. No scoring computation happens here (Rule 7: the spec
+ * engine is the one evaluator); this is a read-only projection.
+ */
+export interface ImpactScoreInput {
+  readonly dimension: string;
+  readonly score: number;
+  readonly capsApplied?: ReadonlyArray<CapApplied>;
+  readonly topActions?: ReadonlyArray<TopAction>;
+}
+
+/**
+ * The finding-delta impact of one guardrail check. JSON-embeddable (rides
+ * the check payload as an additive field).
+ */
+export interface ImpactSummary {
+  /** Findings this change resolved, counted ONLY from pairs the classifier
+   *  marked `removed` (the same predicate the one verdict derivation's
+   *  `resolved` tally uses; pinned by parity test). */
+  readonly resolved: number;
+  readonly resolvedByKind: ReadonlyArray<ImpactKindDelta>;
+  /** Findings ATTRIBUTABLE to this change: pairs classified `added`,
+   *  including allowlist-suppressed ones (accepted is still added). Demoted
+   *  statuses (`tooling_drift`, `newly_published_advisory`, ...) are not the
+   *  change's doing and land in `excluded` instead. */
+  readonly added: number;
+  /** Net debt reduction: `resolved - added`. Positive means the repo ends
+   *  with less attributable debt than it started. */
+  readonly net: number;
+  /** Pairs excluded from the attributable delta (Rule 19), per
+   *  classification status. `not_observed` (the resolved direction: the
+   *  check never re-verified them) and `tooling_drift` (the added
+   *  direction: the tool moved, not the code) are the common entries.
+   *  Unchanged debt (`persisted` / `relocated`) is not a delta and is not
+   *  listed. Empty when every delta pair was attributable. */
+  readonly excluded: ReadonlyArray<{ readonly status: FindingStatus; readonly count: number }>;
+  /** Cap-aware explanations, one per capped dimension among the score
+   *  results the surface supplied. Empty when no score result was present
+   *  (the section then carries the finding delta alone) or nothing is
+   *  capped. */
+  readonly capNotes: ReadonlyArray<ImpactCapNote>;
+}
+
+/** Delta statuses that may NOT be attributed to the change (Rule 19's
+ *  causes 2 through 6). Everything here is excluded from `resolved` and
+ *  `added` and disclosed in `excluded`. */
+const UNATTRIBUTABLE_DELTA_STATUSES: ReadonlyArray<FindingStatus> = [
+  'not_observed',
+  'tooling_drift',
+  'config_drift',
+  'newly_detected',
+  'newly_published_advisory',
+  'probable_existing',
+  'uncertain',
+];
+
+/**
+ * Derive the impact summary from an existing check result. Pure; accepts
+ * the structural subset of `GuardrailCheckResult` it reads, so the lane
+ * surfaces (which hold the full result) and tests (which build fixtures)
+ * share one entry point.
+ */
+export function deriveImpact(
+  result: {
+    readonly pairs: ReadonlyArray<ClassifiedPair>;
+    readonly baseline: { readonly findings: ReadonlyArray<BaselineEntry> };
+  },
+  scores?: ReadonlyArray<ImpactScoreInput>,
+): ImpactSummary {
+  const priorById = new Map(result.baseline.findings.map((e) => [e.id, e] as const));
+
+  // Resolved: the classifier's `removed` status ONLY. `not_observed` pairs
+  // are matcher-removed too, but the classifier already re-labeled them
+  // (Rule 19's removed direction), so consuming the classification here is
+  // what keeps this a claim the run can back. Matches the `resolved` tally
+  // in `verdictCounts` by construction (parity-pinned; if the classifier
+  // ever emits the reserved `fixed` status, both tallies move together).
+  const resolvedPairs = result.pairs.filter((p) => p.classification.status === 'removed');
+
+  const byKind = new Map<BaselineEntry['kind'], Map<FindingSeverity, number>>();
+  for (const p of resolvedPairs) {
+    // Display severity for a resolved finding: the prior entry's captured
+    // severity when the baseline recorded one (4.2), else the pair's
+    // kind-default. Display only; never fed back into any verdict.
+    const prior = p.pair.priorId !== undefined ? priorById.get(p.pair.priorId) : undefined;
+    const captured =
+      prior !== undefined && 'severity' in prior ? (prior.severity as FindingSeverity) : undefined;
+    const severity = captured ?? p.severity;
+    const sevMap = byKind.get(p.kind) ?? new Map<FindingSeverity, number>();
+    if (severity !== undefined) sevMap.set(severity, (sevMap.get(severity) ?? 0) + 1);
+    byKind.set(p.kind, sevMap);
+  }
+  const resolvedByKind: ImpactKindDelta[] = [...byKind.entries()]
+    .map(([kind, sevMap]) => ({
+      kind,
+      count: [...sevMap.values()].reduce((a, b) => a + b, 0),
+      bySeverity: SEVERITY_ORDER.filter((s) => (sevMap.get(s) ?? 0) > 0).map((s) => ({
+        severity: s,
+        count: sevMap.get(s)!,
+      })),
+    }))
+    .sort((a, b) => b.count - a.count || a.kind.localeCompare(b.kind));
+
+  const added = result.pairs.filter((p) => p.classification.status === 'added').length;
+
+  const excludedCounts = new Map<FindingStatus, number>();
+  for (const p of result.pairs) {
+    if (UNATTRIBUTABLE_DELTA_STATUSES.includes(p.classification.status)) {
+      excludedCounts.set(
+        p.classification.status,
+        (excludedCounts.get(p.classification.status) ?? 0) + 1,
+      );
+    }
+  }
+  const excluded = UNATTRIBUTABLE_DELTA_STATUSES.filter(
+    (s) => (excludedCounts.get(s) ?? 0) > 0,
+  ).map((s) => ({ status: s, count: excludedCounts.get(s)! }));
+
+  const capNotes: ImpactCapNote[] = [];
+  for (const s of scores ?? []) {
+    const cap = s.capsApplied?.[0];
+    if (!cap) continue; // Uncapped dimension: nothing to explain in phase 1.
+    const top = s.topActions?.[0];
+    capNotes.push({
+      dimension: s.dimension,
+      score: s.score,
+      ceiling: cap.ceiling,
+      reason: cap.reason,
+      unlocksUpTo: s.score + cap.upliftIfRemoved,
+      ...(top !== undefined && top.upliftIfFixed > 0
+        ? { largestUplift: { reason: top.reason, uplift: top.upliftIfFixed } }
+        : {}),
+    });
+  }
+
+  const resolved = resolvedPairs.length;
+  return { resolved, resolvedByKind, added, net: resolved - added, excluded, capNotes };
+}
+
+// ─── One phrasing, every surface ──────────────────────────────────────────
+
+/** Human labels for the excluded statuses (lowercase, sentence-embeddable). */
+const EXCLUDED_LABEL: Partial<Record<FindingStatus, string>> = {
+  not_observed: 'not re-verified this run',
+  tooling_drift: 'tooling drift',
+  config_drift: 'config drift',
+  newly_detected: 'newly detected by a changed scanner',
+  newly_published_advisory: 'advisories published after baseline capture',
+  probable_existing: 'probably pre-existing',
+  uncertain: 'uncertain match',
+};
+
+function severityClause(delta: ImpactKindDelta): string {
+  return delta.bySeverity.map((s) => `${s.count} ${s.severity}`).join(', ');
+}
+
+/**
+ * The headline finding delta, findings first (honesty constraint 1):
+ * `-5 findings resolved (dep-vuln: 2 high, 3 medium) · +0 added by this change`.
+ * Only meaningful when `impact.resolved > 0`; the quiet line below covers
+ * the rest.
+ */
+export function formatImpactHeadline(impact: ImpactSummary): string {
+  const kinds = impact.resolvedByKind
+    .map((d) => `${d.kind}: ${severityClause(d) || d.count}`)
+    .join('; ');
+  return (
+    `-${impact.resolved} finding${impact.resolved === 1 ? '' : 's'} resolved` +
+    (kinds ? ` (${kinds})` : '') +
+    ` · +${impact.added} added by this change`
+  );
+}
+
+/**
+ * The cap-aware line (honesty constraint 3): the score does not move while
+ * the cap binds, so say the cap and the unlock instead of letting "fixing
+ * did not help" stand.
+ */
+export function formatImpactCapNote(note: ImpactCapNote): string {
+  return (
+    `${note.dimension} stays ${note.score}, capped by ${note.reason} ` +
+    `(clearing that unlocks up to ${note.unlocksUpTo})` +
+    (note.largestUplift !== undefined
+      ? `. Largest available uplift: ${note.largestUplift.reason} (+${note.largestUplift.uplift})`
+      : '')
+  );
+}
+
+/** The Rule 19 exclusion disclosure, or null when nothing was excluded. */
+export function formatImpactExclusions(impact: ImpactSummary): string | null {
+  if (impact.excluded.length === 0) return null;
+  const parts = impact.excluded.map(
+    (e) => `${e.count} ${EXCLUDED_LABEL[e.status] ?? e.status.replace(/_/g, ' ')}`,
+  );
+  return `Not counted (cannot attribute to this change): ${parts.join(', ')}.`;
+}
+
+/**
+ * The quiet line for a change with nothing resolved (UX call 1: neutral
+ * changes get one line, never a section). When the change ADDS findings,
+ * the line says so and defers to the existing blocking/warning surfaces:
+ * Impact never duplicates the regression report (one concept, one section).
+ */
+export function formatImpactQuietLine(impact: ImpactSummary): string {
+  if (impact.added > 0) {
+    return (
+      `No findings resolved by this change; the +${impact.added} it adds ` +
+      `are reported with the guardrail findings.`
+    );
+  }
+  return 'No debt impact: this change neither resolves nor adds findings.';
+}

--- a/src/deps-bump/run.ts
+++ b/src/deps-bump/run.ts
@@ -53,6 +53,7 @@ import { buildBumpPlan, type BumpPlan, type PlannedBump } from './plan';
 import { renderFloorVerification, renderGuardrailVerdict } from '../lanes/verification-render';
 import { appendLaneEvent, LANE_LEDGER_SCHEMA_VERSION } from '../lanes/ledger';
 import { guardrailVerdictFor, toFloorBaseChecks } from '../lanes/verify';
+import type { ImpactSummary } from '../baseline/impact';
 import { landRefreshPaths, type LandRefreshResult } from '../land-refresh';
 import { detectDefaultBranch } from '../ship-installers';
 
@@ -94,6 +95,11 @@ export interface DepsBumpResult {
    *  debt disclosed, never weaponized against the bump. */
   readonly floorAttribution?: readonly AttributedFloorFailure[];
   readonly guardrailVerdict?: string;
+  /** The finding-delta impact from the same guardrail run (impact surface
+   *  phase 1); rendered beside the verdict in the ledger. Absent when the
+   *  check ran through the injected seam (which reports only a verdict
+   *  string) or did not run. */
+  readonly guardrailImpact?: ImpactSummary;
   readonly land?: LandRefreshResult;
   readonly note?: string;
   /** The verification ledger — the PR body / job summary markdown. */
@@ -191,7 +197,7 @@ export function renderLedger(result: Omit<DepsBumpResult, 'ledger'>): string {
   lines.push(
     ...renderFloorVerification(result.floor, result.floorAttribution, 'the pre-bump entry run'),
   );
-  lines.push(...renderGuardrailVerdict(result.guardrailVerdict));
+  lines.push(...renderGuardrailVerdict(result.guardrailVerdict, result.guardrailImpact));
 
   if (result.plan.skipped.length > 0) {
     lines.push('### Not bumped (disclosed)', '');
@@ -384,10 +390,15 @@ export async function runDepsBump(opts: DepsBumpOptions): Promise<DepsBumpResult
   // dxkit-guardrails check is the backstop. The agent lane fails CLOSED —
   // the declared policy difference lives at each consumer.
   let guardrailVerdict: string | undefined;
+  let guardrailImpact: ImpactSummary | undefined;
   if (opts.runGuardrail) {
     guardrailVerdict = await opts.runGuardrail();
   } else {
-    guardrailVerdict = (await guardrailVerdictFor(cwd, opts.trust)).verdict;
+    const gate = await guardrailVerdictFor(cwd, opts.trust);
+    guardrailVerdict = gate.verdict;
+    // The finding-delta impact from the same check (impact surface phase 1):
+    // a bump that closes advisories shows what it closed, in the ledger.
+    guardrailImpact = gate.impact;
   }
 
   if (netNewFloorRed) {
@@ -398,6 +409,7 @@ export async function runDepsBump(opts: DepsBumpOptions): Promise<DepsBumpResult
       floor,
       floorAttribution,
       ...(guardrailVerdict !== undefined ? { guardrailVerdict } : {}),
+      ...(guardrailImpact !== undefined ? { guardrailImpact } : {}),
       note:
         'the correctness floor has NET-NEW failures after applying the bumps (the entry ' +
         'floor did not have them) — nothing was landed. A bump that breaks the build ' +
@@ -413,6 +425,7 @@ export async function runDepsBump(opts: DepsBumpOptions): Promise<DepsBumpResult
       floor,
       floorAttribution,
       ...(guardrailVerdict !== undefined ? { guardrailVerdict } : {}),
+      ...(guardrailImpact !== undefined ? { guardrailImpact } : {}),
     });
   }
 
@@ -423,6 +436,7 @@ export async function runDepsBump(opts: DepsBumpOptions): Promise<DepsBumpResult
     floor,
     floorAttribution,
     ...(guardrailVerdict !== undefined ? { guardrailVerdict } : {}),
+    ...(guardrailImpact !== undefined ? { guardrailImpact } : {}),
   };
   // The delivery-ledger event rides the SAME PR diff as the bumps, so it
   // reaches the default branch exactly when the PR merges — delivered means

--- a/src/gate/classify-pairs.ts
+++ b/src/gate/classify-pairs.ts
@@ -237,7 +237,15 @@ export function classifyPairs(input: ClassifyPairsInput): ClassifyPairsOutput {
         ? changedInFile === 'all' || changedInFile.has(line)
         : undefined;
 
-    const kindDrift = pair.status === 'added' ? driftByKind.get(anchorEntry.kind) : undefined;
+    // Recall drift is consulted for BOTH delta directions (Rule 19): an
+    // `added` pair on a drifted kind cannot be blamed on the developer, and
+    // a `removed` pair on a drifted kind cannot be credited to them either
+    // (a scanner bump that drops rules reads as a wave of "resolved"
+    // findings the tool caused). Persisted/relocated pairs never read it.
+    const kindDrift =
+      pair.status === 'added' || pair.status === 'removed'
+        ? driftByKind.get(anchorEntry.kind)
+        : undefined;
     const configDiffers =
       pair.status === 'added' &&
       (envelopeDrift.configHashChanged ||

--- a/src/lanes/verification-render.ts
+++ b/src/lanes/verification-render.ts
@@ -9,6 +9,13 @@
 import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
 import type { AttributedFloorFailure } from '../analyzers/correctness/attribution';
 import { describeFloorSkip, type FloorSkip } from './verify-tree';
+import {
+  formatImpactCapNote,
+  formatImpactExclusions,
+  formatImpactHeadline,
+  formatImpactQuietLine,
+  type ImpactSummary,
+} from '../baseline/impact';
 
 /** One check line. A pass that carries a disclosure (a tolerated condition,
  *  4.4.5) shows it inline: a reader must never mistake "passed under a
@@ -76,7 +83,31 @@ export function renderFloorVerification(
   return lines;
 }
 
-/** The guardrail verdict line (omitted when the check did not run). */
-export function renderGuardrailVerdict(verdict: string | undefined): string[] {
-  return verdict ? [`Guardrail: **${verdict}**`, ''] : [];
+/**
+ * The guardrail verdict line (omitted when the check did not run), plus the
+ * finding-delta Impact line when the run computed one (impact surface phase
+ * 1). Non-zero only: a run that resolved findings names them (kind and
+ * severity, attribution-honest: the summary comes from the classifier's
+ * pair statuses, never a raw diff); a run that resolved nothing gets the one
+ * quiet line. Both lanes (dep-bump and remediate) render through here, so
+ * the impact grammar cannot fork between robots.
+ */
+export function renderGuardrailVerdict(
+  verdict: string | undefined,
+  impact?: ImpactSummary,
+): string[] {
+  if (!verdict) return [];
+  const lines = [`Guardrail: **${verdict}**`, ''];
+  if (impact) {
+    if (impact.resolved > 0) {
+      lines.push(`Impact: ${formatImpactHeadline(impact)}`);
+      for (const note of impact.capNotes) lines.push(`- ${formatImpactCapNote(note)}`);
+      const exclusions = formatImpactExclusions(impact);
+      if (exclusions) lines.push(`- ${exclusions}`);
+    } else {
+      lines.push(`Impact: ${formatImpactQuietLine(impact)}`);
+    }
+    lines.push('');
+  }
+  return lines;
 }

--- a/src/lanes/verification-render.ts
+++ b/src/lanes/verification-render.ts
@@ -13,6 +13,7 @@ import {
   formatImpactCapNote,
   formatImpactExclusions,
   formatImpactHeadline,
+  formatImpactNotAttributable,
   formatImpactQuietLine,
   type ImpactSummary,
 } from '../baseline/impact';
@@ -99,6 +100,13 @@ export function renderGuardrailVerdict(
   if (!verdict) return [];
   const lines = [`Guardrail: **${verdict}**`, ''];
   if (impact) {
+    if (!impact.attributable) {
+      // A refused run (CANNOT GATE) cannot back a resolved claim: the
+      // one-liner replaces both the headline and the quiet line.
+      lines.push(`Impact: ${formatImpactNotAttributable()}`);
+      lines.push('');
+      return lines;
+    }
     if (impact.resolved > 0) {
       lines.push(`Impact: ${formatImpactHeadline(impact)}`);
       for (const note of impact.capNotes) lines.push(`- ${formatImpactCapNote(note)}`);

--- a/src/lanes/verify.ts
+++ b/src/lanes/verify.ts
@@ -22,6 +22,7 @@
 import type { AnalysisTrustContext } from '../analysis-trust';
 import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
 import type { FloorBaseCheck } from '../analyzers/correctness/attribution';
+import type { ImpactSummary } from '../baseline/impact';
 
 /** Entry-floor run → the attribution comparator's base-check shape. */
 export function toFloorBaseChecks(floor: CorrectnessFloorResult): FloorBaseCheck[] {
@@ -56,6 +57,13 @@ export interface GuardrailGateResult {
    * unavailable, not consulted).
    */
   readonly blockingFindings?: readonly BlockingFinding[];
+  /**
+   * The finding-delta impact of the checked tree vs its baseline (impact
+   * surface phase 1), derived from the SAME check result as the verdict,
+   * zero extra computation. The lane ledgers render it beside the verdict
+   * line. Absent when the check did not run (there is no delta to claim).
+   */
+  readonly impact?: ImpactSummary;
 }
 
 /** One blocking finding, projected for per-order attribution. */
@@ -85,8 +93,12 @@ export async function guardrailVerdictFor(
   try {
     const { runGuardrailCheck } = await import('../baseline/check');
     const { verdictCounts } = await import('../baseline/check-renderers');
+    const { deriveImpact } = await import('../baseline/impact');
     const result = await runGuardrailCheck({ cwd, trust });
     const counts = verdictCounts(result);
+    // The finding-delta impact, from the same result the verdict came from
+    // (impact surface phase 1): the ledger's Impact line beside the verdict.
+    const impact = deriveImpact(result);
     // Name what blocked (capped): a lane's BLOCKED verdict must be
     // inspectable from its ledger — "the guardrail did not pass" with no
     // findings is a diagnosability black hole on an ephemeral runner.
@@ -132,6 +144,7 @@ export async function guardrailVerdictFor(
       passesGate: counts.exitCode === 0,
       ...(blocking.length > 0 ? { blocking } : {}),
       ...(blockingFindings.length > 0 ? { blockingFindings } : {}),
+      impact,
     };
   } catch (e) {
     return {

--- a/src/loop/order-scope.ts
+++ b/src/loop/order-scope.ts
@@ -305,18 +305,27 @@ export function unresolvedOrderIds(
     for (const id of scope.absentIds) {
       const pairs = json.pairs.filter((p) => p.priorId === id || p.currentId === id);
       if (pairs.length === 0) continue; // no pair on an observed kind: closed
-      if (pairs.some((p) => p.status === 'not_observed')) unobservedIds.push(id);
-      else if (pairs.some((p) => !CLOSED_STATUSES.has(p.status))) unresolved.push(id);
+      // Present-side evidence first: a pair carrying the id on the CURRENT
+      // side with a non-closed status means the finding is still here. A
+      // pair with NO current side is gone from the tree, but when its
+      // status is still not a closed one (`not_observed`, or the removed-
+      // direction `tooling_drift` demotion on a recall-drifted kind) the
+      // disappearance is unattributable: undecidable, never "still present".
+      if (pairs.some((p) => p.currentId !== undefined && !CLOSED_STATUSES.has(p.status))) {
+        unresolved.push(id);
+      } else if (pairs.some((p) => !CLOSED_STATUSES.has(p.status))) {
+        unobservedIds.push(id);
+      }
     }
     if (unresolved.length > 0) return { unresolved };
     if (unobservedIds.length > 0) {
       return {
         unresolved: [],
         undecidable:
-          `the gate run did not observe ${unobservedIds.length} of the order's target ` +
+          `the gate run could not verify ${unobservedIds.length} of the order's target ` +
           `finding(s) (${unobservedIds.join(', ')}): their file or check was outside what ` +
-          `this run scanned (an incremental scan covers changed files only), so they ` +
-          `cannot be read as closed`,
+          `this run scanned (an incremental scan covers changed files only), or recall ` +
+          `drift made their disappearance unattributable, so they cannot be read as closed`,
       };
     }
     return { unresolved: [] };

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -406,7 +406,7 @@ export function renderRemediateLedger(r: Omit<RemediateResult, 'ledger'>): strin
       r.floorSkipped,
     ),
   );
-  lines.push(...renderGuardrailVerdict(r.guardrailVerdict));
+  lines.push(...renderGuardrailVerdict(r.guardrailVerdict, r.guardrailImpact));
   if (r.scoreHinge) lines.push(renderScoreHinge(r.scoreHinge));
   lines.push(
     "_Agentic lane inside the verified frame: the agent's own claim of success is never " +

--- a/src/remediate/outcome.ts
+++ b/src/remediate/outcome.ts
@@ -8,6 +8,7 @@ import type { AnalysisTrustContext } from '../analysis-trust';
 import type { CorrectnessFloorResult } from '../analyzers/correctness/run';
 import type { AttributedFloorFailure } from '../analyzers/correctness/attribution';
 import type { GuardrailGateResult } from '../lanes/verify';
+import type { ImpactSummary } from '../baseline/impact';
 import type { FloorSkip, InstallOutcome, VerifyTreeSeams } from '../lanes/verify-tree';
 import type { TreeInvariantOutcome } from '../lanes/tree-invariants';
 import type { FrameInvariantSeams } from './frame-invariants';
@@ -247,6 +248,11 @@ export interface RemediateResult {
    *  The executor's blocked-salvage decision requires a RAN verdict; a
    *  guardrail that never ran must not produce a draft claiming a block. */
   readonly guardrailRan?: boolean;
+  /** The finding-delta impact of the verified tree vs its baseline (impact
+   *  surface phase 1), from the same check that produced the verdict.
+   *  Rendered beside the verdict line in the ledger. Absent when the
+   *  guardrail did not run. */
+  readonly guardrailImpact?: ImpactSummary;
   /** The legacy task path's frame-invariant outcomes (the order paths
    *  carry them per record instead) — rendered in the ledger. */
   readonly frameInvariants?: {

--- a/src/remediate/verify.ts
+++ b/src/remediate/verify.ts
@@ -116,6 +116,7 @@ export function verificationDisclosures(
   changedFiles?: VerifyTreeResult['changedFiles'];
   guardrailVerdict: string;
   guardrailRan: boolean;
+  guardrailImpact?: NonNullable<GuardrailGateResult['impact']>;
 } {
   // The tolerance-resolution warnings (unknown policy entries, a policy
   // opt-out conflicting with observed repo config): the disclosure home the
@@ -130,6 +131,10 @@ export function verificationDisclosures(
     ...(verified.changedFiles ? { changedFiles: verified.changedFiles } : {}),
     guardrailVerdict: guardrail.verdict,
     guardrailRan: guardrail.ran,
+    // The finding-delta impact beside the verdict (impact surface phase 1),
+    // rendered by the shared ledger composer. Absent when the check did not
+    // run: a delta nobody measured is not claimed.
+    ...(guardrail.impact !== undefined ? { guardrailImpact: guardrail.impact } : {}),
   };
 }
 

--- a/test/baseline/impact-renderers.test.ts
+++ b/test/baseline/impact-renderers.test.ts
@@ -17,7 +17,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { execFileSync } from 'child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { createBaseline } from '../../src/baseline/create';
@@ -32,6 +32,8 @@ import type { ImpactScoreInput } from '../../src/baseline/impact';
 import type { ClassifiedPair } from '../../src/gate/result';
 import type { BaselineEntry, FindingSeverity, FindingStatus } from '../../src/baseline/types';
 import { trustedLocalContext } from '../../src/analysis-trust';
+import { deriveImpact } from '../../src/baseline/impact';
+import { findTool, TOOL_DEFS } from '../../src/analyzers/tools/tool-registry';
 
 function git(dir: string, args: string[]): void {
   execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
@@ -115,7 +117,11 @@ describe('the Impact section reaches every check surface', () => {
     expect(md).toContain(
       '-3 findings resolved (dep-vuln: 2 high, 1 medium) · +0 added by this change',
     );
-    // Above the fold: before the collapsed Resolved detail.
+    // Above the fold: directly after the summary sentence (which closes the
+    // heading block) and before the collapsed Resolved detail. This is the
+    // slot the attribution-gap banner also occupies on a refused run, so
+    // the position is part of the contract.
+    expect(md.indexOf('### Impact')).toBeGreaterThan(md.indexOf('3 resolved.'));
     expect(md.indexOf('### Impact')).toBeLessThan(md.indexOf('<summary>Resolved'));
   });
 
@@ -156,7 +162,7 @@ describe('the Impact section reaches every check surface', () => {
     });
     expect(md).toContain('-3 findings resolved');
     expect(md).toContain(
-      'Not counted (cannot attribute to this change): 1 not re-verified this run, 1 tooling drift.',
+      'Not counted (cannot attribute to this change): 1 not re-verified this run, 1 demoted to tooling drift.',
     );
   });
 
@@ -178,6 +184,7 @@ describe('the Impact section reaches every check surface', () => {
   it('json: the impact field is always present, zero reported as zero', () => {
     const neutral = renderJson(base);
     expect(neutral.impact).toEqual({
+      attributable: true,
       resolved: 0,
       resolvedByKind: [],
       added: 0,
@@ -230,4 +237,161 @@ describe('the Impact section reaches every check surface', () => {
     const json = renderJson({ ...base, pairs: [...base.pairs, ...RESOLVING_PAIRS] });
     expect(json.impact?.resolved).toBe(json.summary.resolved);
   });
+});
+
+// A synthetic attribution gap: the shape the refusal tier carries.
+const GAP = { kind: 'secret', rules: ['newSecret'], findingCount: 1 };
+
+describe('a refused run (CANNOT GATE) never renders a resolved claim (Rule 19 at run level)', () => {
+  let base: GuardrailCheckResult;
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = makeRepo();
+    await createBaseline({ cwd: dir });
+    base = await runGuardrailCheck({ trust: trustedLocalContext(), cwd: dir });
+  }, 120_000);
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function refused(): GuardrailCheckResult {
+    return {
+      ...base,
+      pairs: [...base.pairs, ...RESOLVING_PAIRS],
+      attributionGaps: [GAP],
+    } as unknown as GuardrailCheckResult;
+  }
+
+  it('markdown: the one-liner replaces the section, ahead of the gap banner', () => {
+    const md = renderMarkdown(refused());
+    expect(md).not.toContain('findings resolved');
+    expect(md).not.toContain('### Impact');
+    expect(md).toContain('Impact not attributable this run');
+    // Ordering (the slot contract): after the verdict heading, before the
+    // attribution-gap banner it defers to.
+    expect(md.indexOf('Impact not attributable')).toBeGreaterThan(md.indexOf('## Guardrail'));
+    expect(md.indexOf('Impact not attributable')).toBeLessThan(md.indexOf('Cannot attribute'));
+  });
+
+  it('console: same suppression, same one-liner', () => {
+    const out = renderConsole(refused());
+    expect(out).not.toContain('findings resolved');
+    expect(out).toContain('Impact not attributable this run');
+  });
+
+  it('json: the impact field carries the counts flagged not attributable', () => {
+    const json = renderJson(refused());
+    expect(json.impact?.attributable).toBe(false);
+    expect(json.impact?.resolved).toBe(3);
+    expect(json.verdict.refused).toBe(true);
+  });
+
+  it('a missing required observation refuses the same way', () => {
+    const req = {
+      ...base,
+      pairs: [...base.pairs, ...RESOLVING_PAIRS],
+      requiredNotObserved: [{ check: 'x', reason: 'check x not observed', remedy: 'run it' }],
+    } as unknown as GuardrailCheckResult;
+    expect(renderMarkdown(req)).not.toContain('findings resolved');
+    expect(renderJson(req).impact?.attributable).toBe(false);
+  });
+});
+
+describe('the quiet line under unattributable delta pairs (advisory wave, tooling drift)', () => {
+  let base: GuardrailCheckResult;
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = makeRepo();
+    await createBaseline({ cwd: dir });
+    base = await runGuardrailCheck({ trust: trustedLocalContext(), cwd: dir });
+  }, 120_000);
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('an advisory wave never reads as "no debt impact" above its own blocking tables', () => {
+    const wave = {
+      ...base,
+      pairs: [
+        ...base.pairs,
+        pair('newly_published_advisory', { kind: 'dep-vuln', severity: 'high' }),
+        pair('newly_published_advisory', { kind: 'dep-vuln', severity: 'high' }),
+      ],
+    } as unknown as GuardrailCheckResult;
+    const md = renderMarkdown(wave);
+    expect(md).not.toContain('No debt impact');
+    expect(md).toContain('No attributable debt impact; 2 findings could not be attributed');
+    expect(md).toContain('from advisories published after baseline capture');
+  });
+
+  it('a pure tooling-drift run reads the same honest shape', () => {
+    const drift = {
+      ...base,
+      pairs: [...base.pairs, pair('tooling_drift', { kind: 'code' })],
+    } as unknown as GuardrailCheckResult;
+    const md = renderMarkdown(drift);
+    expect(md).not.toContain('No debt impact');
+    expect(md).toContain('No attributable debt impact; 1 finding could not be attributed');
+  });
+});
+
+// The end-to-end pin for the classifier fix (the removed direction of Rule
+// 19): a finding GONE on a kind whose recall drifted must never headline as
+// resolved. Needs a real secret scanner: the fixture plants a secret,
+// baselines it, deletes it, then strips the baseline's recall so every kind
+// drifts (exactly what a pre-Rule-19 baseline looks like).
+const gitleaksAvailable = findTool(TOOL_DEFS.gitleaks, process.cwd()).available;
+// Assembled at runtime so the dxkit repo's own secret scan never sees an
+// AKIA-shaped literal here; the fixture file the test writes carries the
+// full value, which is what the fixture's scan must find.
+const FAKE_AWS_KEY = ['AKIA', 'Q3EGRI', 'J7MZ4KX2B6'].join('');
+
+describe('a drifted kind cannot headline resolved findings (end to end)', () => {
+  it.skipIf(!gitleaksAvailable)(
+    'a secret gone under absent recall reads tooling_drift, never "-1 resolved"',
+    async () => {
+      const dir = makeRepo();
+      writeFileSync(
+        join(dir, 'src', 'config.js'),
+        `const key = '${FAKE_AWS_KEY}';\nmodule.exports = key;\n`,
+      );
+      git(dir, ['add', '.']);
+      git(dir, ['commit', '-q', '-m', 'add config']);
+      await createBaseline({ cwd: dir });
+      // The "fix" that is not a fix: the secret file disappears AND the
+      // baseline loses its recall evidence (a pre-Rule-19 baseline).
+      rmSync(join(dir, 'src', 'config.js'));
+      git(dir, ['add', '.']);
+      git(dir, ['commit', '-q', '-m', 'drop config']);
+      const baselinePath = join(dir, '.dxkit', 'baselines', 'main.json');
+      const file = JSON.parse(readFileSync(baselinePath, 'utf8')) as Record<string, unknown>;
+      delete file.recall;
+      writeFileSync(baselinePath, JSON.stringify(file, null, 2) + '\n');
+
+      const result = await runGuardrailCheck({ trust: trustedLocalContext(), cwd: dir });
+      const goneSecrets = result.pairs.filter(
+        (p) => p.kind === 'secret' && p.pair.currentId === undefined,
+      );
+      expect(goneSecrets.length).toBeGreaterThan(0);
+      // The classifier, not the impact module, makes the call: the pair is
+      // tooling_drift with a fixed verdict, so verdictCounts().resolved and
+      // impact.resolved agree by construction.
+      expect(goneSecrets.every((p) => p.classification.status === 'tooling_drift')).toBe(true);
+      expect(goneSecrets.every((p) => !p.classification.blocks && !p.classification.warns)).toBe(
+        true,
+      );
+      const impact = deriveImpact(result);
+      expect(impact.resolved).toBe(0);
+      expect(impact.excluded.some((e) => e.status === 'tooling_drift')).toBe(true);
+      const md = renderMarkdown(result);
+      expect(md).not.toMatch(/-\d+ findings? resolved/);
+      expect(md).toContain('No attributable debt impact');
+      rmSync(dir, { recursive: true, force: true });
+    },
+    120_000,
+  );
 });

--- a/test/baseline/impact-renderers.test.ts
+++ b/test/baseline/impact-renderers.test.ts
@@ -1,0 +1,233 @@
+/**
+ * DELIVERY: the Impact section reaches all three check surfaces (console /
+ * JSON / markdown), with the design's UX calls implemented as code:
+ *
+ *   - non-zero only: a change that resolves findings gets the section; a
+ *     neutral change gets ONE quiet line on the PR comment (markdown), and
+ *     no extra block on the console (the summary footer already reports
+ *     zero resolved);
+ *   - no duplication with the blocking surface: a regressing change's added
+ *     findings stay in the existing finding tables: Impact counts them in
+ *     the headline and never re-lists them;
+ *   - JSON is additive: the `impact` field joins the v1 payload without
+ *     touching any existing field, and is ALWAYS emitted (zero as zero);
+ *   - the cap-aware line renders when the caller supplies a score result
+ *     from the same run, and only then.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createBaseline } from '../../src/baseline/create';
+import { runGuardrailCheck, type GuardrailCheckResult } from '../../src/baseline/check';
+import {
+  GUARDRAIL_JSON_SCHEMA,
+  renderConsole,
+  renderJson,
+  renderMarkdown,
+} from '../../src/baseline/check-renderers';
+import type { ImpactScoreInput } from '../../src/baseline/impact';
+import type { ClassifiedPair } from '../../src/gate/result';
+import type { BaselineEntry, FindingSeverity, FindingStatus } from '../../src/baseline/types';
+import { trustedLocalContext } from '../../src/analysis-trust';
+
+function git(dir: string, args: string[]): void {
+  execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+}
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dxkit-impact-render-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'test']);
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '0.0.0' }));
+  writeFileSync(join(dir, 'src', 'index.js'), 'module.exports = () => 1;\n');
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '-q', '-m', 'init']);
+  return dir;
+}
+
+let seq = 0;
+
+/** Synthetic classified pair spread onto the real base result. */
+function pair(
+  status: FindingStatus,
+  over: { kind?: BaselineEntry['kind']; severity?: FindingSeverity; priorId?: string } = {},
+): ClassifiedPair {
+  seq += 1;
+  const matcherStatus = status === 'removed' || status === 'not_observed' ? 'removed' : 'added';
+  return {
+    pair: {
+      ...(matcherStatus === 'removed'
+        ? { priorId: over.priorId ?? `prior-${seq}` }
+        : { currentId: `current-${seq}` }),
+      status: matcherStatus,
+      confidence: 1,
+      reasons: [],
+    },
+    classification: { status, blocks: false, warns: false, reasons: [] },
+    kind: over.kind ?? 'dep-vuln',
+    ...(over.severity !== undefined ? { severity: over.severity } : {}),
+  } as unknown as ClassifiedPair;
+}
+
+const RESOLVING_PAIRS = [
+  pair('removed', { kind: 'dep-vuln', severity: 'high' }),
+  pair('removed', { kind: 'dep-vuln', severity: 'high' }),
+  pair('removed', { kind: 'dep-vuln', severity: 'medium' }),
+];
+
+const CAPPED_SCORE: ImpactScoreInput = {
+  dimension: 'security',
+  score: 40,
+  capsApplied: [
+    {
+      id: 'secrets-cap',
+      tier: 'trust-broken',
+      ceiling: 40,
+      reason: '8 baseline secrets committed',
+      upliftIfRemoved: 25,
+    },
+  ],
+  topActions: [],
+};
+
+describe('the Impact section reaches every check surface', () => {
+  let base: GuardrailCheckResult;
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = makeRepo();
+    await createBaseline({ cwd: dir });
+    base = await runGuardrailCheck({ trust: trustedLocalContext(), cwd: dir });
+  }, 120_000);
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('markdown: a resolving change gets the section above the finding tables', () => {
+    const md = renderMarkdown({ ...base, pairs: [...base.pairs, ...RESOLVING_PAIRS] });
+    expect(md).toContain('### Impact');
+    expect(md).toContain(
+      '-3 findings resolved (dep-vuln: 2 high, 1 medium) · +0 added by this change',
+    );
+    // Above the fold: before the collapsed Resolved detail.
+    expect(md.indexOf('### Impact')).toBeLessThan(md.indexOf('<summary>Resolved'));
+  });
+
+  it('markdown: a neutral change gets exactly one quiet line, never a section', () => {
+    const md = renderMarkdown(base);
+    expect(md).not.toContain('### Impact');
+    expect(md).toContain('No debt impact: this change neither resolves nor adds findings.');
+  });
+
+  it('markdown: a regressing change with nothing resolved defers to the finding tables', () => {
+    const md = renderMarkdown({
+      ...base,
+      pairs: [...base.pairs, pair('added', { kind: 'code', severity: 'medium' })],
+    });
+    expect(md).not.toContain('### Impact');
+    expect(md).toContain('No findings resolved by this change; the +1 it adds are reported');
+  });
+
+  it('markdown: the cap-aware line renders when a same-run score result is supplied', () => {
+    const withResolved = { ...base, pairs: [...base.pairs, ...RESOLVING_PAIRS] };
+    const md = renderMarkdown(withResolved, { impactScores: [CAPPED_SCORE] });
+    expect(md).toContain(
+      'security stays 40, capped by 8 baseline secrets committed (clearing that unlocks up to 65)',
+    );
+    // Without a score result the section carries the finding delta alone.
+    expect(renderMarkdown(withResolved)).not.toContain('capped by');
+  });
+
+  it('markdown: an excluded (not_observed / tooling_drift) pair is disclosed, not counted', () => {
+    const md = renderMarkdown({
+      ...base,
+      pairs: [
+        ...base.pairs,
+        ...RESOLVING_PAIRS,
+        pair('not_observed', { kind: 'custom-check' }),
+        pair('tooling_drift', { kind: 'code' }),
+      ],
+    });
+    expect(md).toContain('-3 findings resolved');
+    expect(md).toContain(
+      'Not counted (cannot attribute to this change): 1 not re-verified this run, 1 tooling drift.',
+    );
+  });
+
+  it('console: the Impact block renders for a resolving change and not for a neutral one', () => {
+    const withResolved = renderConsole({ ...base, pairs: [...base.pairs, ...RESOLVING_PAIRS] });
+    expect(withResolved).toContain('Impact');
+    expect(withResolved).toContain('-3 findings resolved (dep-vuln: 2 high, 1 medium)');
+    expect(renderConsole(base)).not.toContain('findings resolved (');
+  });
+
+  it('console: the cap-aware line rides the Impact block when scores are supplied', () => {
+    const out = renderConsole(
+      { ...base, pairs: [...base.pairs, ...RESOLVING_PAIRS] },
+      { impactScores: [CAPPED_SCORE] },
+    );
+    expect(out).toContain('security stays 40, capped by 8 baseline secrets committed');
+  });
+
+  it('json: the impact field is always present, zero reported as zero', () => {
+    const neutral = renderJson(base);
+    expect(neutral.impact).toEqual({
+      resolved: 0,
+      resolvedByKind: [],
+      added: 0,
+      net: 0,
+      excluded: [],
+      capNotes: [],
+    });
+  });
+
+  it('json: a resolving change carries the structured delta and cap notes', () => {
+    const json = renderJson(
+      { ...base, pairs: [...base.pairs, ...RESOLVING_PAIRS] },
+      { impactScores: [CAPPED_SCORE] },
+    );
+    expect(json.impact?.resolved).toBe(3);
+    expect(json.impact?.net).toBe(3);
+    expect(json.impact?.resolvedByKind).toEqual([
+      {
+        kind: 'dep-vuln',
+        count: 3,
+        bySeverity: [
+          { severity: 'high', count: 2 },
+          { severity: 'medium', count: 1 },
+        ],
+      },
+    ]);
+    expect(json.impact?.capNotes).toEqual([
+      {
+        dimension: 'security',
+        score: 40,
+        ceiling: 40,
+        reason: '8 baseline secrets committed',
+        unlocksUpTo: 65,
+      },
+    ]);
+  });
+
+  it('json: the field is additive: schema id and the existing shape are untouched', () => {
+    const json = renderJson(base);
+    expect(json.schema).toBe(GUARDRAIL_JSON_SCHEMA);
+    // The pre-impact contract every embedder reads, unchanged.
+    expect(json.verdict).toEqual({ blocks: false, warns: false, refused: false, exitCode: 0 });
+    expect(json.summary.resolved).toBe(0);
+    expect(Array.isArray(json.pairs)).toBe(true);
+    expect(json.attributionGaps).toEqual([]);
+    expect(json.requiredNotObserved).toEqual([]);
+  });
+
+  it('json: summary.resolved and impact.resolved agree (one resolved concept)', () => {
+    const json = renderJson({ ...base, pairs: [...base.pairs, ...RESOLVING_PAIRS] });
+    expect(json.impact?.resolved).toBe(json.summary.resolved);
+  });
+});

--- a/test/baseline/impact.test.ts
+++ b/test/baseline/impact.test.ts
@@ -1,0 +1,291 @@
+/**
+ * The impact model (impact surface phase 1): finding deltas derived from the
+ * EXISTING pair classifications, attribution-honest by construction.
+ *
+ * The soul of the surface is CLAUDE.md Rule 19: "you fixed N findings" is a
+ * cause claim, so the resolved tally may consume only the classifier's
+ * verdicts (a `not_observed` or `tooling_drift` pair NEVER counts), and the
+ * cap-aware explanation may only carry numbers the spec engine already
+ * computed. Both directions are pinned here, plus the parity with the one
+ * verdict derivation's `resolved` tally.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  deriveImpact,
+  formatImpactCapNote,
+  formatImpactExclusions,
+  formatImpactHeadline,
+  formatImpactQuietLine,
+  type ImpactScoreInput,
+} from '../../src/baseline/impact';
+import { verdictCounts } from '../../src/baseline/check-renderers';
+import type { GuardrailCheckResult } from '../../src/baseline/check';
+import type { ClassifiedPair } from '../../src/gate/result';
+import type { BaselineEntry, FindingSeverity, FindingStatus } from '../../src/baseline/types';
+
+let seq = 0;
+
+/** A synthetic classified pair, the minimum the impact model reads. */
+function pair(
+  status: FindingStatus,
+  over: {
+    kind?: BaselineEntry['kind'];
+    severity?: FindingSeverity;
+    priorId?: string;
+    currentId?: string;
+  } = {},
+): ClassifiedPair {
+  seq += 1;
+  const matcherStatus = status === 'removed' || status === 'not_observed' ? 'removed' : 'added';
+  return {
+    pair: {
+      ...(matcherStatus === 'removed'
+        ? { priorId: over.priorId ?? `prior-${seq}` }
+        : { currentId: over.currentId ?? `current-${seq}` }),
+      status: matcherStatus,
+      confidence: 1,
+      reasons: [],
+    },
+    classification: { status, blocks: status === 'added', warns: false, reasons: [] },
+    kind: over.kind ?? 'dep-vuln',
+    ...(over.severity !== undefined ? { severity: over.severity } : {}),
+  } as unknown as ClassifiedPair;
+}
+
+function input(
+  pairs: ClassifiedPair[],
+  findings: BaselineEntry[] = [],
+): { pairs: ClassifiedPair[]; baseline: { findings: BaselineEntry[] } } {
+  return { pairs, baseline: { findings } };
+}
+
+describe('deriveImpact: the attributable finding delta', () => {
+  it('counts resolved pairs by kind and severity', () => {
+    const impact = deriveImpact(
+      input([
+        pair('removed', { kind: 'dep-vuln', severity: 'high' }),
+        pair('removed', { kind: 'dep-vuln', severity: 'high' }),
+        pair('removed', { kind: 'dep-vuln', severity: 'medium' }),
+        pair('removed', { kind: 'secret', severity: 'high' }),
+      ]),
+    );
+    expect(impact.resolved).toBe(4);
+    expect(impact.added).toBe(0);
+    expect(impact.net).toBe(4);
+    expect(impact.resolvedByKind).toEqual([
+      {
+        kind: 'dep-vuln',
+        count: 3,
+        bySeverity: [
+          { severity: 'high', count: 2 },
+          { severity: 'medium', count: 1 },
+        ],
+      },
+      { kind: 'secret', count: 1, bySeverity: [{ severity: 'high', count: 1 }] },
+    ]);
+    expect(impact.excluded).toEqual([]);
+  });
+
+  it('a mixed change counts both directions and nets them', () => {
+    const impact = deriveImpact(
+      input([
+        pair('removed', { kind: 'dep-vuln', severity: 'high' }),
+        pair('removed', { kind: 'dep-vuln', severity: 'low' }),
+        pair('added', { kind: 'code', severity: 'medium' }),
+      ]),
+    );
+    expect(impact.resolved).toBe(2);
+    expect(impact.added).toBe(1);
+    expect(impact.net).toBe(1);
+  });
+
+  it('a neutral change is all zeros, reported as zeros (never omitted)', () => {
+    const impact = deriveImpact(input([pair('persisted'), pair('relocated')]));
+    expect(impact).toEqual({
+      resolved: 0,
+      resolvedByKind: [],
+      added: 0,
+      net: 0,
+      excluded: [],
+      capNotes: [],
+    });
+  });
+
+  it('Rule 19, removed direction: a not_observed pair never counts as resolved', () => {
+    const impact = deriveImpact(
+      input([
+        pair('removed', { kind: 'custom-check' }),
+        pair('not_observed', { kind: 'custom-check' }),
+      ]),
+    );
+    expect(impact.resolved).toBe(1);
+    expect(impact.excluded).toEqual([{ status: 'not_observed', count: 1 }]);
+  });
+
+  it('Rule 19, added direction: a tooling_drift pair never counts as added', () => {
+    const impact = deriveImpact(input([pair('tooling_drift', { kind: 'code' })]));
+    expect(impact.added).toBe(0);
+    expect(impact.net).toBe(0);
+    expect(impact.excluded).toEqual([{ status: 'tooling_drift', count: 1 }]);
+  });
+
+  it('every unattributable delta status lands in excluded, not in the delta', () => {
+    const impact = deriveImpact(
+      input([
+        pair('config_drift'),
+        pair('newly_published_advisory'),
+        pair('uncertain'),
+        pair('probable_existing'),
+      ]),
+    );
+    expect(impact.added).toBe(0);
+    expect(impact.resolved).toBe(0);
+    expect(impact.excluded.map((e) => e.status).sort()).toEqual([
+      'config_drift',
+      'newly_published_advisory',
+      'probable_existing',
+      'uncertain',
+    ]);
+  });
+
+  it("resolved severity prefers the prior entry's captured severity over the kind default", () => {
+    // The pair carries the kind-default severity (removed pairs have no
+    // current-side aggregate entry), but the baseline captured the advisory
+    // as critical: the impact breakdown must say critical.
+    const prior: BaselineEntry = {
+      id: 'prior-x' as BaselineEntry['id'],
+      kind: 'dep-vuln',
+      package: 'left-pad',
+      advisoryId: 'GHSA-xxxx',
+      severity: 'critical',
+    };
+    const impact = deriveImpact(
+      input(
+        [pair('removed', { kind: 'dep-vuln', severity: 'medium', priorId: 'prior-x' })],
+        [prior],
+      ),
+    );
+    expect(impact.resolvedByKind).toEqual([
+      { kind: 'dep-vuln', count: 1, bySeverity: [{ severity: 'critical', count: 1 }] },
+    ]);
+  });
+
+  it("parity: impact.resolved equals the one verdict derivation's resolved tally", () => {
+    const pairs = [
+      pair('removed'),
+      pair('removed'),
+      pair('not_observed'),
+      pair('tooling_drift'),
+      pair('added'),
+      pair('persisted'),
+    ];
+    const impact = deriveImpact(input(pairs));
+    const minimal = {
+      pairs,
+      blocks: true,
+      warns: false,
+      attributionGaps: [],
+      requiredNotObserved: [],
+    } as unknown as GuardrailCheckResult;
+    expect(impact.resolved).toBe(verdictCounts(minimal).resolved);
+  });
+});
+
+describe('deriveImpact: the cap-aware explanation (spec-engine numbers, never recomputed)', () => {
+  const cappedScore: ImpactScoreInput = {
+    dimension: 'security',
+    score: 40,
+    capsApplied: [
+      {
+        id: 'secrets-cap',
+        tier: 'trust-broken',
+        ceiling: 40,
+        reason: '8 baseline secrets committed',
+        upliftIfRemoved: 25,
+      },
+    ],
+    topActions: [
+      {
+        source: 'cap',
+        id: 'secrets-cap',
+        reason: 'rotate and remove the committed secrets',
+        upliftIfFixed: 25,
+      },
+    ],
+  };
+
+  it('a capped dimension yields a cap note with the unlock from the spec engine', () => {
+    const impact = deriveImpact(input([pair('removed', { severity: 'high' })]), [cappedScore]);
+    expect(impact.capNotes).toEqual([
+      {
+        dimension: 'security',
+        score: 40,
+        ceiling: 40,
+        reason: '8 baseline secrets committed',
+        unlocksUpTo: 65,
+        largestUplift: { reason: 'rotate and remove the committed secrets', uplift: 25 },
+      },
+    ]);
+  });
+
+  it('an uncapped dimension yields no cap note (score projection is phase 2)', () => {
+    const impact = deriveImpact(input([pair('removed')]), [
+      { dimension: 'quality', score: 72, capsApplied: [], topActions: [] },
+    ]);
+    expect(impact.capNotes).toEqual([]);
+  });
+
+  it('no score input means no cap note: the section carries the finding delta alone', () => {
+    expect(deriveImpact(input([pair('removed')])).capNotes).toEqual([]);
+  });
+});
+
+describe('the one impact phrasing', () => {
+  it('headline: findings first, resolved detail, added count', () => {
+    const impact = deriveImpact(
+      input([
+        pair('removed', { kind: 'dep-vuln', severity: 'high' }),
+        pair('removed', { kind: 'dep-vuln', severity: 'high' }),
+        pair('removed', { kind: 'dep-vuln', severity: 'medium' }),
+      ]),
+    );
+    expect(formatImpactHeadline(impact)).toBe(
+      '-3 findings resolved (dep-vuln: 2 high, 1 medium) · +0 added by this change',
+    );
+  });
+
+  it('cap note: names the cap, the unlock, and the largest uplift', () => {
+    const line = formatImpactCapNote({
+      dimension: 'security',
+      score: 40,
+      ceiling: 40,
+      reason: '8 baseline secrets committed',
+      unlocksUpTo: 65,
+      largestUplift: { reason: 'rotate and remove the committed secrets', uplift: 25 },
+    });
+    expect(line).toBe(
+      'security stays 40, capped by 8 baseline secrets committed (clearing that unlocks ' +
+        'up to 65). Largest available uplift: rotate and remove the committed secrets (+25)',
+    );
+  });
+
+  it('exclusions line names each unattributable status; null when nothing was excluded', () => {
+    const impact = deriveImpact(
+      input([pair('removed'), pair('not_observed'), pair('tooling_drift'), pair('tooling_drift')]),
+    );
+    expect(formatImpactExclusions(impact)).toBe(
+      'Not counted (cannot attribute to this change): 1 not re-verified this run, 2 tooling drift.',
+    );
+    expect(formatImpactExclusions(deriveImpact(input([pair('removed')])))).toBeNull();
+  });
+
+  it('quiet line: neutral, and the added-only variant that defers to the findings', () => {
+    expect(formatImpactQuietLine(deriveImpact(input([])))).toBe(
+      'No debt impact: this change neither resolves nor adds findings.',
+    );
+    expect(formatImpactQuietLine(deriveImpact(input([pair('added'), pair('added')])))).toBe(
+      'No findings resolved by this change; the +2 it adds are reported with the guardrail findings.',
+    );
+  });
+});

--- a/test/baseline/impact.test.ts
+++ b/test/baseline/impact.test.ts
@@ -16,6 +16,7 @@ import {
   formatImpactCapNote,
   formatImpactExclusions,
   formatImpactHeadline,
+  formatImpactNotAttributable,
   formatImpactQuietLine,
   type ImpactScoreInput,
 } from '../../src/baseline/impact';
@@ -103,6 +104,7 @@ describe('deriveImpact: the attributable finding delta', () => {
   it('a neutral change is all zeros, reported as zeros (never omitted)', () => {
     const impact = deriveImpact(input([pair('persisted'), pair('relocated')]));
     expect(impact).toEqual({
+      attributable: true,
       resolved: 0,
       resolvedByKind: [],
       added: 0,
@@ -134,6 +136,7 @@ describe('deriveImpact: the attributable finding delta', () => {
     const impact = deriveImpact(
       input([
         pair('config_drift'),
+        pair('newly_detected'),
         pair('newly_published_advisory'),
         pair('uncertain'),
         pair('probable_existing'),
@@ -143,6 +146,7 @@ describe('deriveImpact: the attributable finding delta', () => {
     expect(impact.resolved).toBe(0);
     expect(impact.excluded.map((e) => e.status).sort()).toEqual([
       'config_drift',
+      'newly_detected',
       'newly_published_advisory',
       'probable_existing',
       'uncertain',
@@ -189,6 +193,34 @@ describe('deriveImpact: the attributable finding delta', () => {
       requiredNotObserved: [],
     } as unknown as GuardrailCheckResult;
     expect(impact.resolved).toBe(verdictCounts(minimal).resolved);
+  });
+});
+
+describe('deriveImpact: the whole-run refusal flag (finding-level Rule 19 is not enough)', () => {
+  it('attributable is false while an attribution gap exists', () => {
+    const impact = deriveImpact({
+      ...input([pair('removed'), pair('removed')]),
+      attributionGaps: [{ kind: 'secret', rules: ['newSecret'], findingCount: 1 }],
+    });
+    expect(impact.attributable).toBe(false);
+    // The counts are still data (plainly flagged), never fabricated to zero.
+    expect(impact.resolved).toBe(2);
+  });
+
+  it('attributable is false while a required observation is missing', () => {
+    const impact = deriveImpact({
+      ...input([pair('removed')]),
+      requiredNotObserved: [{ reason: 'check x not observed', remedy: 'run it' }],
+    });
+    expect(impact.attributable).toBe(false);
+  });
+
+  it('attributable is true on a healthy run, gaps present-but-empty included', () => {
+    expect(deriveImpact(input([pair('removed')])).attributable).toBe(true);
+    expect(
+      deriveImpact({ ...input([pair('removed')]), attributionGaps: [], requiredNotObserved: [] })
+        .attributable,
+    ).toBe(true);
   });
 });
 
@@ -275,7 +307,7 @@ describe('the one impact phrasing', () => {
       input([pair('removed'), pair('not_observed'), pair('tooling_drift'), pair('tooling_drift')]),
     );
     expect(formatImpactExclusions(impact)).toBe(
-      'Not counted (cannot attribute to this change): 1 not re-verified this run, 2 tooling drift.',
+      'Not counted (cannot attribute to this change): 1 not re-verified this run, 2 demoted to tooling drift.',
     );
     expect(formatImpactExclusions(deriveImpact(input([pair('removed')])))).toBeNull();
   });
@@ -287,5 +319,35 @@ describe('the one impact phrasing', () => {
     expect(formatImpactQuietLine(deriveImpact(input([pair('added'), pair('added')])))).toBe(
       'No findings resolved by this change; the +2 it adds are reported with the guardrail findings.',
     );
+  });
+
+  it('quiet line: excluded delta pairs forbid the plain "no debt impact" claim', () => {
+    // An advisory wave: every delta pair is newly_published_advisory. The
+    // change did not add them, but "neither resolves nor adds" would read
+    // as a clean bill above blocking tables: say what could not be
+    // attributed instead.
+    const wave = deriveImpact(
+      input([pair('newly_published_advisory'), pair('newly_published_advisory')]),
+    );
+    expect(formatImpactQuietLine(wave)).toBe(
+      'No attributable debt impact; 2 findings could not be attributed to this change ' +
+        '(2 from advisories published after baseline capture).',
+    );
+    // A pure tooling-drift run reads the same shape.
+    const drift = deriveImpact(input([pair('tooling_drift')]));
+    expect(formatImpactQuietLine(drift)).toBe(
+      'No attributable debt impact; 1 finding could not be attributed to this change ' +
+        '(1 demoted to tooling drift).',
+    );
+    // Added-and-excluded: both facts ride the line.
+    const mixed = deriveImpact(input([pair('added'), pair('tooling_drift')]));
+    expect(formatImpactQuietLine(mixed)).toBe(
+      'No findings resolved by this change; the +1 it adds are reported with the guardrail ' +
+        'findings. Not counted (cannot attribute to this change): 1 demoted to tooling drift.',
+    );
+  });
+
+  it('the not-attributable one-liner claims nothing in either direction', () => {
+    expect(formatImpactNotAttributable()).toContain('no resolved or added claim');
   });
 });

--- a/test/baseline/policy.test.ts
+++ b/test/baseline/policy.test.ts
@@ -550,3 +550,44 @@ describe('baselineRefreshCron — the ONE cadence normalizer', () => {
     );
   });
 });
+
+describe('classify - removed-direction recall drift (the resolved side of Rule 19)', () => {
+  it('a removed pair on a drifted kind demotes to tooling_drift with a fixed verdict', () => {
+    // A scanner bump that drops rules makes findings VANISH without anyone
+    // touching the code: "you resolved N findings" is a cause claim, and
+    // this pair cannot back it. Fixed verdict: nothing exists on the current
+    // side to gate, so it neither blocks nor warns, and it never counts as
+    // resolved (the impact surface and verdictCounts both read the status).
+    const ctx: ClassifyContext = {
+      recallDrifted: true,
+      recallDriftDetail: 'semgrep 1.0.0 -> 1.2.0',
+    };
+    const result = classify(pair('removed'), DEFAULT_BROWNFIELD_POLICY, ctx);
+    expect(result.status).toBe('tooling_drift');
+    expect(result.blocks).toBe(false);
+    expect(result.warns).toBe(false);
+    // No refusal marker either: block rules exist to stop net-new findings,
+    // and a removed pair has no current side to certify.
+    expect(result.unattributableBlockRule).toBeUndefined();
+    expect(
+      result.reasons.some(
+        (r) => r.code === 'tooling-drift' && r.detail.includes('not counted as resolved'),
+      ),
+    ).toBe(true);
+    expect(result.reasons.some((r) => r.detail.includes('semgrep 1.0.0 -> 1.2.0'))).toBe(true);
+  });
+
+  it('not-observed outranks recall drift on a removed pair (dxkit did not look at all)', () => {
+    const ctx: ClassifyContext = {
+      recallDrifted: true,
+      notObserved: 'check "lint" was skipped (untrusted tree)',
+    };
+    const result = classify(pair('removed'), DEFAULT_BROWNFIELD_POLICY, ctx);
+    expect(result.status).toBe('not_observed');
+  });
+
+  it('an undrifted removed pair still reads removed (resolved), no over-demotion', () => {
+    const result = classify(pair('removed'), DEFAULT_BROWNFIELD_POLICY, {});
+    expect(result.status).toBe('removed');
+  });
+});

--- a/test/lanes/verification-render.test.ts
+++ b/test/lanes/verification-render.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { renderFloorVerification } from '../../src/lanes/verification-render';
+import {
+  renderFloorVerification,
+  renderGuardrailVerdict,
+} from '../../src/lanes/verification-render';
 import type { CorrectnessFloorResult } from '../../src/analyzers/correctness/run';
+import type { ImpactSummary } from '../../src/baseline/impact';
 
 /**
  * The shared floor-verification block renders the ACTUAL scope the run
@@ -46,5 +50,82 @@ describe('renderFloorVerification scope line', () => {
       'the entry run',
     );
     expect(lines.join('\n')).toContain('lockfile-sync: pass (peer conflict tolerated)');
+  });
+});
+
+/**
+ * The lane ledgers' Impact line (impact surface phase 1): BOTH lanes render
+ * the guardrail verdict through this one composer, so the finding-delta
+ * grammar lands beside the verdict in the dep-bump ledger and the remediate
+ * ledger from one insertion point. Non-zero gets the headline (plus cap
+ * notes and the Rule 19 exclusion disclosure); a run that resolved nothing
+ * gets the one quiet line; a run with no impact summary (an injected seam
+ * that reports only a verdict string, or a check that never ran) renders
+ * exactly what it always did.
+ */
+
+function impact(over: Partial<ImpactSummary> = {}): ImpactSummary {
+  return {
+    resolved: 0,
+    resolvedByKind: [],
+    added: 0,
+    net: 0,
+    excluded: [],
+    capNotes: [],
+    ...over,
+  };
+}
+
+describe('renderGuardrailVerdict impact line', () => {
+  it("renders a resolving run's headline, cap note, and exclusions beside the verdict", () => {
+    const lines = renderGuardrailVerdict(
+      'PASSED',
+      impact({
+        resolved: 3,
+        net: 3,
+        resolvedByKind: [
+          {
+            kind: 'dep-vuln',
+            count: 3,
+            bySeverity: [
+              { severity: 'high', count: 2 },
+              { severity: 'medium', count: 1 },
+            ],
+          },
+        ],
+        excluded: [{ status: 'tooling_drift', count: 2 }],
+        capNotes: [
+          {
+            dimension: 'security',
+            score: 40,
+            ceiling: 40,
+            reason: '8 baseline secrets committed',
+            unlocksUpTo: 65,
+          },
+        ],
+      }),
+    );
+    const text = lines.join('\n');
+    expect(text).toContain('Guardrail: **PASSED**');
+    expect(text).toContain(
+      'Impact: -3 findings resolved (dep-vuln: 2 high, 1 medium) · +0 added by this change',
+    );
+    expect(text).toContain('security stays 40, capped by 8 baseline secrets committed');
+    expect(text).toContain('Not counted (cannot attribute to this change): 2 tooling drift.');
+  });
+
+  it('a run that resolved nothing gets the one quiet line', () => {
+    const text = renderGuardrailVerdict('PASSED', impact()).join('\n');
+    expect(text).toContain(
+      'Impact: No debt impact: this change neither resolves nor adds findings.',
+    );
+  });
+
+  it('no impact summary renders the verdict line alone (backward compatible)', () => {
+    expect(renderGuardrailVerdict('PASSED')).toEqual(['Guardrail: **PASSED**', '']);
+  });
+
+  it('no verdict renders nothing, impact or not', () => {
+    expect(renderGuardrailVerdict(undefined, impact({ resolved: 5 }))).toEqual([]);
   });
 });

--- a/test/lanes/verification-render.test.ts
+++ b/test/lanes/verification-render.test.ts
@@ -66,6 +66,7 @@ describe('renderFloorVerification scope line', () => {
 
 function impact(over: Partial<ImpactSummary> = {}): ImpactSummary {
   return {
+    attributable: true,
     resolved: 0,
     resolvedByKind: [],
     added: 0,
@@ -111,7 +112,9 @@ describe('renderGuardrailVerdict impact line', () => {
       'Impact: -3 findings resolved (dep-vuln: 2 high, 1 medium) · +0 added by this change',
     );
     expect(text).toContain('security stays 40, capped by 8 baseline secrets committed');
-    expect(text).toContain('Not counted (cannot attribute to this change): 2 tooling drift.');
+    expect(text).toContain(
+      'Not counted (cannot attribute to this change): 2 demoted to tooling drift.',
+    );
   });
 
   it('a run that resolved nothing gets the one quiet line', () => {
@@ -119,6 +122,24 @@ describe('renderGuardrailVerdict impact line', () => {
     expect(text).toContain(
       'Impact: No debt impact: this change neither resolves nor adds findings.',
     );
+  });
+
+  it('a refused run (not attributable) gets the one-liner, never a resolved claim', () => {
+    const lines = renderGuardrailVerdict(
+      'CANNOT GATE',
+      impact({
+        attributable: false,
+        resolved: 3,
+        net: 3,
+        resolvedByKind: [
+          { kind: 'dep-vuln', count: 3, bySeverity: [{ severity: 'high', count: 3 }] },
+        ],
+      }),
+    );
+    const text = lines.join('\n');
+    expect(text).toContain('Guardrail: **CANNOT GATE**');
+    expect(text).toContain('Impact: Impact not attributable this run');
+    expect(text).not.toContain('findings resolved');
   });
 
   it('no impact summary renders the verdict line alone (backward compatible)', () => {

--- a/test/loop/order-scope.test.ts
+++ b/test/loop/order-scope.test.ts
@@ -219,6 +219,27 @@ describe('unresolvedOrderIds (judged from computed state only — nothing execut
     expect(w.unresolved).toEqual(['fp-two']);
   });
 
+  it('guardrail verifier: a target GONE on a recall-drifted kind is undecidable, never done (Rule 19)', () => {
+    // The removed-direction drift demotion: the kind's recall inputs moved,
+    // so the classifier labels the disappearance `tooling_drift` instead of
+    // `removed`. The finding is absent from the tree, but the cause may be
+    // the tool, not the fix: the order stays undecided with the reason
+    // named, and it is never reported as "still present" either.
+    const json = payload([
+      {
+        ...presentPair('x'),
+        currentId: undefined,
+        priorId: 'fp-one',
+        kind: 'code',
+        status: 'tooling_drift',
+      } as Pair,
+    ]);
+    const v = unresolvedOrderIds(scope({ absentIds: ['fp-one'], kinds: ['code'] }), json, NO_FLOOR);
+    expect(v.unresolved).toEqual([]);
+    expect(v.undecidable).toContain('fp-one');
+    expect(v.undecidable).toContain('recall drift');
+  });
+
   it('guardrail verifier: an UNOBSERVED target kind is undecidable, never silently done (Rule 19)', () => {
     // The target finding has no pair — but its kind was not observed at all
     // (custom-check dropped in ref-based mode / the check did not run), so

--- a/test/remediate/impact-ledger.test.ts
+++ b/test/remediate/impact-ledger.test.ts
@@ -14,6 +14,7 @@ import type { VerifyTreeResult } from '../../src/lanes/verify-tree';
 import type { ImpactSummary } from '../../src/baseline/impact';
 
 const IMPACT: ImpactSummary = {
+  attributable: true,
   resolved: 2,
   resolvedByKind: [{ kind: 'dep-vuln', count: 2, bySeverity: [{ severity: 'high', count: 2 }] }],
   added: 0,

--- a/test/remediate/impact-ledger.test.ts
+++ b/test/remediate/impact-ledger.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The remediate ledger's Impact line (impact surface phase 1): the impact
+ * summary computed by the lane's guardrail run travels the whole threading
+ * (`GuardrailGateResult.impact` -> `verificationDisclosures` ->
+ * `RemediateResult.guardrailImpact` -> the ledger's shared verdict
+ * composer), and a result without one renders exactly what it always did.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderRemediateLedger } from '../../src/remediate/ledger-render';
+import { verificationDisclosures } from '../../src/remediate/verify';
+import type { GuardrailGateResult } from '../../src/lanes/verify';
+import type { VerifyTreeResult } from '../../src/lanes/verify-tree';
+import type { ImpactSummary } from '../../src/baseline/impact';
+
+const IMPACT: ImpactSummary = {
+  resolved: 2,
+  resolvedByKind: [{ kind: 'dep-vuln', count: 2, bySeverity: [{ severity: 'high', count: 2 }] }],
+  added: 0,
+  net: 2,
+  excluded: [],
+  capNotes: [],
+};
+
+describe('verificationDisclosures forwards the guardrail impact', () => {
+  const verified = { verdict: 'verified', changedFiles: ['a.ts'] } as unknown as VerifyTreeResult;
+
+  it('an impact-bearing gate result reaches the disclosure projection', () => {
+    const gate: GuardrailGateResult = {
+      verdict: 'PASSED',
+      ran: true,
+      passesGate: true,
+      impact: IMPACT,
+    };
+    const disclosures = verificationDisclosures(verified, gate);
+    expect(disclosures.guardrailImpact).toEqual(IMPACT);
+    expect(disclosures.guardrailVerdict).toBe('PASSED');
+  });
+
+  it('a gate that never ran carries no impact (a delta nobody measured is not claimed)', () => {
+    const gate: GuardrailGateResult = {
+      verdict: 'unavailable (boom)',
+      ran: false,
+      passesGate: false,
+    };
+    expect('guardrailImpact' in verificationDisclosures(verified, gate)).toBe(false);
+  });
+});
+
+describe('the remediate ledger renders the impact beside the verdict', () => {
+  it('with an impact: the headline rides the guardrail line', () => {
+    const ledger = renderRemediateLedger({
+      outcome: 'verified',
+      task: 'fix-vulns',
+      guardrailVerdict: 'PASSED',
+      guardrailImpact: IMPACT,
+    });
+    expect(ledger).toContain('Guardrail: **PASSED**');
+    expect(ledger).toContain(
+      'Impact: -2 findings resolved (dep-vuln: 2 high) · +0 added by this change',
+    );
+  });
+
+  it('without an impact: the verdict line renders alone (backward compatible)', () => {
+    const ledger = renderRemediateLedger({
+      outcome: 'verified',
+      task: 'fix-vulns',
+      guardrailVerdict: 'PASSED',
+    });
+    expect(ledger).toContain('Guardrail: **PASSED**');
+    expect(ledger).not.toContain('Impact:');
+  });
+});


### PR DESCRIPTION
## What

Phase 1 of the PR impact surface (4.4.7 unit I1): a finding-delta "Impact" section on the guardrail PR comment and the lane PR ledgers, derived entirely from the existing pair classifications. Zero new computation; findings first, score movement absent by design (the projected-score work is phase 2 behind the measured spike).

The design's honesty constraints are code, not prose:

1. **Findings are the headline.** The section is a finding delta; a score enters only as the cap-aware explanation of why clearing debt did not move a capped dimension, with every number read off the spec engine's existing `ScoreResult` output (`CapApplied.upliftIfRemoved`, `topActions`), never recomputed.
2. **Attribution first (CLAUDE.md Rule 19).** "You fixed N findings" is a cause claim, so the resolved tally counts ONLY classifier-`removed` pairs (parity-pinned against `verdictCounts`); `not_observed`, `tooling_drift`, `config_drift`, `newly_published_advisory`, `uncertain`, `probable_existing` and `newly_detected` pairs are excluded from both directions and disclosed in a "Not counted (cannot attribute)" line.
3. **Non-zero only (UX call 1).** A resolving change gets the section above the fold; a neutral change gets one quiet line on the PR comment; a regressing change with nothing resolved gets the deferring quiet line, and its added findings stay with the existing blocking/warning tables (counted in the headline, never re-listed).
4. **Zero is reported as zero.** The JSON payload always emits the `impact` field, as an additive optional member of the v1 schema.

## Where

- `src/baseline/impact.ts` (new): the one impact model (`deriveImpact`) and the one phrasing (`formatImpactHeadline` / `formatImpactCapNote` / `formatImpactExclusions` / `formatImpactQuietLine`). Every surface composes these; none writes its own delta sentence.
- `src/baseline/check-renderers.ts`: the three guardrail forms. Markdown (the PR comment the guardrails workflow posts, and the verdict cache `receipt` replays) renders `### Impact` after the summary sentence; console renders an Impact block before the summary footer; JSON gains `impact`. All three accept an optional `CheckRenderOptions.impactScores` for the cap-aware line when a caller has a same-run score result.
- `src/lanes/verify.ts` + `src/lanes/verification-render.ts`: `guardrailVerdictFor` derives the impact from the same check result; `renderGuardrailVerdict` (the ONE composer both scheduled lanes render through) prints it beside the verdict.
- Threading: `GuardrailGateResult.impact` -> `verificationDisclosures` -> `RemediateResult.guardrailImpact` -> the remediate ledger; `DepsBumpResult.guardrailImpact` on the dep-bump lane's direct guardrail path.

## Tested

- `test/baseline/impact.test.ts`: derivation fixtures (resolved-only, mixed, neutral, `not_observed` excluded, `tooling_drift` excluded, every unattributable status, prior-entry captured severity for display, capped vs uncapped score inputs, no-score input) plus the resolved-tally parity pin with `verdictCounts`.
- `test/baseline/impact-renderers.test.ts`: all three renderer forms on a real check result; section vs quiet line vs deferring line; cap-aware line only with supplied scores; exclusion disclosure; JSON additive (schema id and pre-impact shape untouched, `summary.resolved == impact.resolved`).
- `test/lanes/verification-render.test.ts`: the lane composer with a resolving impact, a neutral impact, no impact (byte-identical legacy output), and no verdict.
- `test/remediate/impact-ledger.test.ts`: `verificationDisclosures` forwards the impact only when the check ran; the remediate ledger renders it beside the verdict, and renders unchanged without one.

## Sweep + guardrail

- `npm run typecheck`, `npm run typecheck:test`, `npx eslint . --max-warnings 0`, `npx prettier --check .`, `check-architecture.sh`, `check-docs-coverage.sh`, `check-slop.sh` (advisory size notes only), `npm run build`: all green.
- `npx vitest run --coverage`: 425 files, 6408 tests passed; coverage 75.09% (floor 50%).
- `node dist/index.js guardrail check --mode ref-based --ref origin/main`: **PASSED**, exit 0.

## Deliberately left out (and why)

- No live score source is wired to any surface in phase 1: no guardrail or lane run computes a `ScoreResult` today, and computing one on the PR tree is exactly the phase 2 spike (UX call 3). The module and all renderers already accept score inputs and the cap-aware line is fixture-pinned, so phase 2 only threads the data.
- No post-merge comment update, no trend line, no report-history reads (phases 2/3 own those, UX calls 2 and 4).
- The dep-bump lane's injected `runGuardrail` test seam still returns a verdict string only; the seam path simply carries no impact (disclosed in the field's doc comment), while the real path gets it from `guardrailVerdictFor`.

## Review focus

- The Rule 19 exclusion set in `src/baseline/impact.ts` (`UNATTRIBUTABLE_DELTA_STATUSES`): is any status miscategorized?
- The markdown placement and the two quiet-line phrasings in the PR comment.
- The JSON field: additive-optional as intended for embedders reading `dxkit.guardrail-check.v1`.



## Review round (all six findings addressed, second commit)

1. **Removed-direction recall drift is decided at the classifier**, not patched in `deriveImpact`: a matcher-removed pair on a recall-drifted kind now classifies `tooling_drift` with a fixed verdict (never blocks, never warns, never counted as resolved), mirroring the existing `not_observed` treatment; not-observed takes precedence when both apply. `classify-pairs.ts` feeds recall drift to both delta directions. **What changed for non-impact surfaces (guardrail-core disclosure):**
   - every resolved tally (console Resolved list, JSON `summary.resolved`, markdown Resolved table, `verdictCounts().resolved`, the lane ledgers) now excludes disappearances the tool caused; on a drifted kind they surface through the envelope-drift disclosure plus the impact exclusion line instead. The demoted pairs never join the warning wall (fixed verdict), so no verdict word or exit code changes: a pair that was `removed` never blocked or warned before either. No attribution gap is minted (block rules exist to stop net-new findings; a removed pair has no current side), so this can never flip a run to CANNOT GATE.
   - the loop Stop-gate's order-done reader (`src/loop/order-scope.ts`) treats a gone-but-drifted target as **undecidable with the reason named**, never "still present" and never silently closed; present-side evidence still wins.
   - self-guardrail on this repo re-run after the change: PASSED with the identical pair shape (88 persisted, 0 resolved, 0 warnings) as before the change; nothing moved.
2. **A refused run renders no resolved claim anywhere**: `ImpactSummary.attributable` is false while `attributionGaps` / `requiredNotObserved` are non-empty, and all three renderers plus the lane composer replace the section AND the quiet line with one not-attributable line that defers to the gap disclosures (pinned to render before the gap banner). The JSON `impact` field stays present with the flag (counts carried as data, plainly flagged), so an embedder can tell refused from zero.
3. **The quiet line no longer over-claims**: with excluded delta pairs (an advisory wave, a tooling-drift demotion) it reads "No attributable debt impact; N findings could not be attributed to this change (...)", composed from the same exclusion phrasing helper.
4. **Compile-time-total status partition**: `STATUS_PARTITION: Record<FindingStatus, 'resolved' | 'added' | 'excluded' | 'neutral'>`, so `fixed` and any future status fail to compile instead of silently dropping; the misleading parity comment is corrected (if the classifier ever emits `fixed`, the parity pin fails loudly and forces one deliberate reconciliation).
5. **Tests added**: classifier unit tests (demotion, precedence, no over-demotion); an end-to-end fixture (a secret gone under absent recall reads `tooling_drift`, never "-1 resolved", with the repo-side fixture key assembled at runtime so dxkit's own secret gate does not flag the test source); refusal suppression across markdown/console/JSON/lane with the ordering pin; advisory-wave and pure-drift quiet lines; `newly_detected` in the exclusion fixture; the loop order-scope undecidable case.
6. **Ordering pin strengthened**: `### Impact` is asserted after the summary sentence and before the finding detail, and the not-attributable one-liner before the attribution-gap banner.

Fix-round sweep: full suite 425 files / 6425 tests green, coverage 75.1%, typecheck/lint/format/arch/docs/slop green, `guardrail check --mode ref-based --ref origin/main` PASSED exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
