### PR TITLE
feat(remediate): pack-declared remediation capabilities + executor inversion (4.4.7 V1)

### DIFF
--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -2075,7 +2075,14 @@ fi
 # package-manager module import in that directory re-hardcodes an ecosystem
 # into the executor, the exact class the seam killed (npm overrides inline
 # in override-pin served only node repos).
-RULE_RECIPE_PM_LITERAL=$(grep -rnE "'(npm|npx|pnpm|yarn|bun|pip|pip3|poetry|uv|bundler?|gem|composer|cargo|dotnet|nuget|mvn|gradle|gradlew|swift)'"   src/remediate/recipes/ src/remediate/work-orders/recipes-registry.ts 2>/dev/null   | grep -E '\.ts:'   | grep -v -E ':[[:space:]]*(//|\*)'   | grep -v "// recipe-ecosystem-ok")
+# Both string shapes count: a quoted bin name ('npm') and a backtick template
+# literal carrying a package-manager word (a template-string npm ci) are the
+# same hardcode; the template form previously escaped the rule.
+RULE_RECIPE_PM_TOKENS='npm|npx|pnpm|yarn|bun|pip|pip3|poetry|uv|bundler?|gem|composer|cargo|dotnet|nuget|mvn|gradle|gradlew|swift'
+RULE_RECIPE_PM_LITERAL=$({ \
+  grep -rnE "'(${RULE_RECIPE_PM_TOKENS})'" src/remediate/recipes/ src/remediate/work-orders/recipes-registry.ts 2>/dev/null; \
+  grep -rnE "`[^`]*(^|[^a-zA-Z0-9_-])(${RULE_RECIPE_PM_TOKENS})([^a-zA-Z0-9_-]|$)" src/remediate/recipes/ src/remediate/work-orders/recipes-registry.ts 2>/dev/null; \
+} | grep -E '\.ts:' | grep -v -E ':[[:space:]]*(//|\*)' | grep -v "// recipe-ecosystem-ok" | sort -u)
 if [ -n "$RULE_RECIPE_PM_LITERAL" ]; then
   echo "❌ Remediation-seam violation: package-manager literal inside the recipe executors:"
   echo "$RULE_RECIPE_PM_LITERAL"

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -2067,6 +2067,36 @@ if [ -n "$ROGUE_POLICY_PATH_WRITE" ]; then
   ERRORS=$((ERRORS + 1))
 fi
 
+# Remediation-capability seam (4.4.7 V1, Rule 6 applied to the recipe
+# executors): the four recipe executors under src/remediate/recipes/ are
+# cross-cutting and consume every ecosystem fact (manifest names, package-
+# manager commands, override mechanisms, OSV ecosystems) from the packs'
+# declared `remediation` capabilities. A package-manager binary literal or a
+# package-manager module import in that directory re-hardcodes an ecosystem
+# into the executor, the exact class the seam killed (npm overrides inline
+# in override-pin served only node repos).
+RULE_RECIPE_PM_LITERAL=$(grep -rnE "'(npm|npx|pnpm|yarn|bun|pip|pip3|poetry|uv|bundler?|gem|composer|cargo|dotnet|nuget|mvn|gradle|gradlew|swift)'"   src/remediate/recipes/ src/remediate/work-orders/recipes-registry.ts 2>/dev/null   | grep -E '\.ts:'   | grep -v -E ':[[:space:]]*(//|\*)'   | grep -v "// recipe-ecosystem-ok")
+if [ -n "$RULE_RECIPE_PM_LITERAL" ]; then
+  echo "❌ Remediation-seam violation: package-manager literal inside the recipe executors:"
+  echo "$RULE_RECIPE_PM_LITERAL"
+  echo "   → Ecosystem facts are pack-declared: extend the owning pack's 'remediation'"
+  echo "     capability (src/languages/capabilities/remediation.ts) and consume it via"
+  echo "     the registry (packDeclaration / resolvePinCapability in recipes/shared.ts)."
+  echo "   → Annotate '// recipe-ecosystem-ok' for a justified exception (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
+RULE_RECIPE_PM_IMPORT=$(grep -rnE "from '[^']*(package-manager|languages/node-install|languages/node-remediation)'"   src/remediate/recipes/ src/remediate/work-orders/ 2>/dev/null   | grep -E '\.ts:'   | grep -v -E ':[[:space:]]*(//|\*)'   | grep -v "// recipe-ecosystem-ok")
+if [ -n "$RULE_RECIPE_PM_IMPORT" ]; then
+  echo "❌ Remediation-seam violation: ecosystem module import inside the order/recipe layer:"
+  echo "$RULE_RECIPE_PM_IMPORT"
+  echo "   → The recipe/order layer consumes ecosystem facts only through the packs'"
+  echo "     declared 'remediation' capabilities and 'installStrategy' (Rule 6);"
+  echo "     node-specific knowledge lives in src/languages/node-remediation.ts."
+  echo "   → Annotate '// recipe-ecosystem-ok' for a justified exception (rare)."
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ $ERRORS -gt 0 ]; then
   echo ""
   echo "Architecture checks failed. See CLAUDE.md for rules."

--- a/scripts/scaffold-language.js
+++ b/scripts/scaffold-language.js
@@ -37,7 +37,13 @@
 const fs = require('fs');
 const path = require('path');
 
-const REPO_ROOT = path.resolve(__dirname, '..');
+// DXKIT_SCAFFOLD_ROOT is the test seam: the scaffold-compile pin
+// (test/scaffold-language.test.ts) runs the scaffolder against a temp copy
+// of src/ and typechecks the emitted pack, so a template drifting from the
+// real LanguageSupport contract fails in CI instead of on a contributor.
+const REPO_ROOT = process.env.DXKIT_SCAFFOLD_ROOT
+  ? path.resolve(process.env.DXKIT_SCAFFOLD_ROOT)
+  : path.resolve(__dirname, '..');
 
 // CLI scaffolder — `console.*` is the user-facing output channel, not slop.
 function die(msg) {
@@ -420,6 +426,7 @@ if (!/^[a-z][a-z0-9]*$/.test(id)) {
 
 const PACK_TEMPLATE = `import { fileExists } from '../analyzers/tools/runner';
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
+import { plannedRemediationSupport } from './capabilities/remediation';
 import type { LanguageSupport } from './types';
 
 // TODO(${id}): implement detection logic — return true when this is a
@@ -692,6 +699,20 @@ export const ${id}: LanguageSupport = {
   // appliesWhen(changedPaths), ownedPaths, a reestablish InstallPlan (or
   // null) and a verify check (see src/languages/capabilities/tree-invariants.ts).
   treeInvariants: NO_TREE_INVARIANTS,
+
+  // REQUIRED(${id}): remediation capabilities (4.4.7), how the deterministic
+  // remediation recipes fix findings in this ecosystem: the lockfile resync
+  // (rides installStrategy), the transitive-dependency pin, the dependency
+  // declaration, and the linter autofix (rides lintGate.fixCommand). The
+  // scaffold declares all four as PLANNED exemptions: dormant but honest
+  // (orders tier to the agent with the reason disclosed in plan output), and
+  // the pack compiles (the same optional-then-filled arc as correctness).
+  // TODO(${id}): replace entries with real providers where the ecosystem has
+  // the mechanism; see src/languages/node-remediation.ts for the worked
+  // example and src/languages/capabilities/remediation.ts for the contracts
+  // (an ecosystem that genuinely lacks a mechanism keeps a PERMANENT
+  // exemption with the real reason, like abap.ts).
+  remediation: plannedRemediationSupport('${id}'),
 
   // Lint-GATE provider (custom-check flagship): the linter command that gates
   // NET-NEW lint findings, plus a regex mapping its output to per-location

--- a/src/execution/placement.ts
+++ b/src/execution/placement.ts
@@ -23,7 +23,13 @@ import type { ExecutionHost, ExecutionRequirement } from './requirement';
 export interface CapabilityRequirement {
   /** Pack id (string here, `LanguageId` at the collector — layering). */
   readonly pack: string;
-  readonly capability: 'correctness' | 'lintGate' | 'depVulns' | 'deepSast';
+  readonly capability:
+    | 'correctness'
+    | 'lintGate'
+    | 'depVulns'
+    | 'deepSast'
+    | 'pinTransitive'
+    | 'declareDependency';
   readonly requirement: ExecutionRequirement;
 }
 

--- a/src/languages/abap.ts
+++ b/src/languages/abap.ts
@@ -27,6 +27,8 @@
  */
 
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
+import type { RemediationSupport } from './capabilities/remediation';
+
 import { fileExists } from '../analyzers/tools/runner';
 import { walkPaths } from '../analyzers/tools/walk-paths';
 import { findTool, TOOL_DEFS } from '../analyzers/tools/tool-registry';
@@ -39,6 +41,28 @@ import { abapBdefStructureCheck } from './abap-bdef';
 import type { CapabilityProvider } from './capabilities/provider';
 import type { LintResult, SeverityCounts } from './capabilities/types';
 import type { RawLocatedFinding } from './capabilities/lint-gate';
+
+/** ABAP's remediation answer: the ecosystem genuinely lacks the mechanisms
+ *  (no package manager, no lockfile, no dependency registry), so every
+ *  capability is a PERMANENT reasoned exemption, not a planned one. */
+const abapRemediation: RemediationSupport = {
+  resyncLockfile: {
+    kind: 'exemption',
+    reason: 'ABAP has no package manager or lockfile for dxkit to resync',
+  },
+  pinTransitive: {
+    kind: 'exemption',
+    reason: 'ABAP has no dependency manifest in which a transitive version could be pinned',
+  },
+  declareDependency: {
+    kind: 'exemption',
+    reason: 'ABAP has no package registry to declare and install dependencies from',
+  },
+  lintFix: {
+    kind: 'exemption',
+    reason: 'no ABAP linter with a reliable machine autofix is wired as a lint gate yet',
+  },
+};
 
 /**
  * An ABAP repo: a committed `abaplint.json` (the ecosystem's one config
@@ -159,6 +183,7 @@ export const abap: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
+  remediation: abapRemediation,
   correctness: {
     // abaplint is a registry TOOL running on dxkit's own Node runtime —
     // no ambient toolchain, no build, any host (Rule 20).

--- a/src/languages/capabilities/remediation.ts
+++ b/src/languages/capabilities/remediation.ts
@@ -1,0 +1,223 @@
+/**
+ * The remediation capability seam (Rule 6 applied to the recipe executors,
+ * mirror of `CorrectnessProvider`): every ecosystem fact a deterministic
+ * remediation recipe needs is DECLARED here per language pack, and the four
+ * cross-cutting executors under `src/remediate/recipes/` consume the
+ * declarations through the registry. Nothing in an executor may hardcode an
+ * ecosystem fact (an npm override key, a linter fix flag, a manifest
+ * filename); the arch-check bans package-manager literals there.
+ *
+ * Four capabilities, one per recipe:
+ *
+ *   - `resyncLockfile` (the lockfile-sync recipe): the lock-writing resync
+ *     COMMAND rides the pack's existing `installStrategy` (its `resync`
+ *     mode, executed by the ONE install executor), and the verify rides the
+ *     pack's `correctness.lockfileCheck` (the exact check that minted the
+ *     order). This declaration adds only what neither seam carries: the
+ *     manifest basenames that name the owning root in an order's envelope.
+ *     Rule 2: never a second install path.
+ *   - `pinTransitive` (the override-pin recipe): how this ecosystem pins a
+ *     transitive dependency to a fixed version (npm `overrides`, later
+ *     pnpm.overrides / yarn resolutions / pip constraints), as a PURE
+ *     manifest text edit the executor applies, plus revert prose.
+ *   - `declareDependency` (the declare-dependency recipe): how a bare
+ *     import specifier becomes a declared, installed dependency: the
+ *     specifier validity rail (Rule 11), the registry version probe, and
+ *     the install command.
+ *   - `lintFix` (the lint-autofix recipe): the builder ALREADY lives on
+ *     `lintGate.fixCommand` (Rule 2: one code path); this declaration folds
+ *     it into the same declared-exemption discipline, pinned consistent by
+ *     the languages contract test.
+ *
+ * Every declaration is either a CAPABILITY or an EXEMPTION with a reason
+ * (the DEFERRED_KINDS discipline): a pack that cannot support a capability
+ * says why, the planner tiers its orders to the agent and discloses the
+ * reason in plan output, and nothing is ever silently absent. The field is
+ * REQUIRED on `LanguageSupport`, so a new pack that omits it fails to
+ * compile.
+ *
+ * Providers are pure builders in the correctness-provider sense: they may
+ * READ repo files (is the package a direct dependency here?) but they never
+ * write, never spawn, and never probe PATH or the host. Execution + the
+ * fail-open policy live in the recipe executors, under the required trust
+ * context. These capabilities FIX findings rather than observe them; their
+ * verifies run through seams whose recall inputs are already declared (the
+ * dep-audit dispatch, the resolution check, the lint gate), so they carry
+ * no recall inputs of their own (Rule 19 stays with the observers).
+ */
+import type { ExecutionRequirement } from '../../execution';
+import type { InstallCommand } from './install-strategy';
+
+/** A declared exemption: the pack cannot (or does not yet) support the
+ *  capability, and says why. Rendered in plan output; never silence. */
+export interface RemediationExemption {
+  readonly kind: 'exemption';
+  /** A full sentence a plan reader can act on. */
+  readonly reason: string;
+}
+
+/** A capability with its provider, or a declared exemption. */
+export type RemediationDeclaration<P> =
+  | { readonly kind: 'capability'; readonly provider: P }
+  | RemediationExemption;
+
+/**
+ * A rider declaration: the capability's builder lives on an existing seam
+ * (`lintGate.fixCommand` for `lintFix`), so declaring it here adds only the
+ * exemption discipline. The contract test pins a `capability` rider to the
+ * presence of its underlying builder, so the two facts cannot drift.
+ */
+export type RemediationRider = { readonly kind: 'capability' } | RemediationExemption;
+
+// ── resyncLockfile ─────────────────────────────────────────────────────────
+
+export interface ResyncLockfileProvider {
+  /**
+   * Manifest basenames that name the owning dependency root in an order's
+   * envelope (`package.json`, `pyproject.toml`). The executor derives the
+   * root from the ONE envelope entry matching these; command and verify
+   * come from `installStrategy.strategy(root).modes.resync` and
+   * `correctness.lockfileCheck` respectively (Rule 2: this provider
+   * declares no command of its own).
+   */
+  readonly manifestFiles: readonly string[];
+}
+
+// ── pinTransitive ──────────────────────────────────────────────────────────
+
+export interface PinContext {
+  readonly cwd: string;
+  /** Repo-relative owning dependency root (`''` = the repo root). */
+  readonly rootDir: string;
+  readonly pkg: string;
+  /** The concrete version to pin. */
+  readonly version: string;
+}
+
+/**
+ * A pure manifest edit: the EXECUTOR reads the file and writes the result;
+ * the pack supplies only the text -> text transform (which may refuse with
+ * a reason: a direct dependency, an unparseable manifest). Style
+ * preservation (indentation, trailing newline) is the transform's job.
+ */
+export interface ManifestTextEdit {
+  /** The manifest file the edit rewrites, relative to the owning root. */
+  readonly file: string;
+  readonly transform: (text: string) => { readonly text: string } | { readonly refused: string };
+}
+
+export type PinPlanResult =
+  | {
+      readonly kind: 'plan';
+      readonly edit: ManifestTextEdit;
+      /** How a human undoes the pin, rendered in ledger prose. */
+      readonly revert: string;
+    }
+  | { readonly kind: 'refused'; readonly reason: string };
+
+export interface PinTransitiveProvider {
+  /** Manifest basenames naming the owning root in an envelope (the edit
+   *  surface); drives the same root derivation `resyncLockfile` uses. */
+  readonly manifestFiles: readonly string[];
+  /** OSV ecosystem name for the candidate pre-check (`npm`, `PyPI`, ...). */
+  readonly osvEcosystem: string;
+  /** Plan the pin at a root: a pure decision (may READ repo files, writes
+   *  nothing) yielding the edit + revert prose, or a refusal with the
+   *  reason (an override mechanism the pack does not implement yet). */
+  plan(ctx: PinContext): PinPlanResult;
+  /** What applying the pin needs from the environment (Rule 20). Pure and
+   *  repo-intrinsic, the install-strategy discipline. */
+  execution(cwd: string): ExecutionRequirement;
+}
+
+// ── declareDependency ──────────────────────────────────────────────────────
+
+export interface DeclareContext {
+  readonly cwd: string;
+  /** Repo-relative owning dependency root (`''` = the repo root). */
+  readonly rootDir: string;
+  readonly specifier: string;
+}
+
+export interface DeclareInstallContext extends DeclareContext {
+  /** The concrete registry version the probe resolved. */
+  readonly version: string;
+  /** True when every importer is a test file (a dev dependency). */
+  readonly dev: boolean;
+}
+
+export interface DeclareDependencyProvider {
+  /** Manifest basenames naming the owning root in an envelope. */
+  readonly manifestFiles: readonly string[];
+  /** OSV ecosystem name for the candidate pre-check. */
+  readonly osvEcosystem: string;
+  /** The ecosystem's word for a valid specifier, used in refusal prose
+   *  (`npm package name`). */
+  readonly packageNameLabel: string;
+  /**
+   * The Rule 11 argument-injection rail: is `specifier` a package-name
+   * shape safe to hand to the ecosystem's tools as an argument? A leading
+   * dash, whitespace, or a URL must be rejected BEFORE any argv exists.
+   * Consulted at planning time (the registry's `matches`) AND re-checked by
+   * the executor. Pure.
+   */
+  validSpecifier(specifier: string): boolean;
+  /** The registry version probe for a candidate; the executor runs it
+   *  through bounded exec and reads its output via `parseProbeOutput`. */
+  versionProbe(ctx: DeclareContext): InstallCommand;
+  /** The concrete version out of the probe's output, or null when the
+   *  output does not name one. Pure and total over untrusted output. */
+  parseProbeOutput(output: string): string | null;
+  /** The install command declaring `specifier@version` into the manifest
+   *  (the dev section when `dev`). */
+  installCommand(ctx: DeclareInstallContext): InstallCommand;
+  /** What the declare + install needs from the environment (Rule 20). */
+  execution(cwd: string): ExecutionRequirement;
+}
+
+// ── the pack-level declaration ─────────────────────────────────────────────
+
+/**
+ * A pack's remediation declarations, one per recipe capability. REQUIRED on
+ * `LanguageSupport`: every pack answers every capability, with a provider
+ * or a reasoned exemption.
+ */
+export interface RemediationSupport {
+  readonly resyncLockfile: RemediationDeclaration<ResyncLockfileProvider>;
+  readonly pinTransitive: RemediationDeclaration<PinTransitiveProvider>;
+  readonly declareDependency: RemediationDeclaration<DeclareDependencyProvider>;
+  /** Builder = `lintGate.fixCommand` (Rule 2); this is the exemption
+   *  discipline only. */
+  readonly lintFix: RemediationRider;
+}
+
+export type RemediationCapabilityId = keyof RemediationSupport;
+
+/** Every capability id, in declaration order. */
+export const REMEDIATION_CAPABILITY_IDS: readonly RemediationCapabilityId[] = [
+  'resyncLockfile',
+  'pinTransitive',
+  'declareDependency',
+  'lintFix',
+];
+
+/**
+ * The declaration set for a pack whose ecosystem fills land in a later unit
+ * of this release: every capability an honest planned exemption naming the
+ * ecosystem. Orders of these packs tier to the agent with the reason
+ * disclosed; a pack graduates by replacing entries with real providers.
+ */
+export function plannedRemediationSupport(ecosystem: string): RemediationSupport {
+  const planned = (what: string): RemediationExemption => ({
+    kind: 'exemption',
+    reason:
+      `${what} is not declared for the ${ecosystem} ecosystem yet ` +
+      '(planned); these orders stay on the agent tier',
+  });
+  return {
+    resyncLockfile: planned('the lockfile resync recipe'),
+    pinTransitive: planned('transitive dependency pinning'),
+    declareDependency: planned('dependency declaration'),
+    lintFix: planned('the linter autofix recipe'),
+  };
+}

--- a/src/languages/capabilities/remediation.ts
+++ b/src/languages/capabilities/remediation.ts
@@ -74,9 +74,12 @@ export type RemediationRider = { readonly kind: 'capability' } | RemediationExem
 export interface ResyncLockfileProvider {
   /**
    * Manifest basenames that name the owning dependency root in an order's
-   * envelope (`package.json`, `pyproject.toml`). The executor derives the
-   * root from the ONE envelope entry matching these; command and verify
-   * come from `installStrategy.strategy(root).modes.resync` and
+   * envelope (`package.json`, `pyproject.toml`). Declaration order is the
+   * pack's PREFERENCE order: when several basenames sit at one root, the
+   * first-declared one is the file the recipe reports (never envelope
+   * order). The executor derives the root from the ONE envelope entry
+   * matching these; command and verify come from
+   * `installStrategy.strategy(root).modes.resync` and
    * `correctness.lockfileCheck` respectively (Rule 2: this provider
    * declares no command of its own).
    */
@@ -117,7 +120,8 @@ export type PinPlanResult =
 
 export interface PinTransitiveProvider {
   /** Manifest basenames naming the owning root in an envelope (the edit
-   *  surface); drives the same root derivation `resyncLockfile` uses. */
+   *  surface); drives the same root derivation `resyncLockfile` uses, with
+   *  the same rule: declaration order is preference order at one root. */
   readonly manifestFiles: readonly string[];
   /** OSV ecosystem name for the candidate pre-check (`npm`, `PyPI`, ...). */
   readonly osvEcosystem: string;
@@ -147,7 +151,8 @@ export interface DeclareInstallContext extends DeclareContext {
 }
 
 export interface DeclareDependencyProvider {
-  /** Manifest basenames naming the owning root in an envelope. */
+  /** Manifest basenames naming the owning root in an envelope (declaration
+   *  order is preference order at one root). */
   readonly manifestFiles: readonly string[];
   /** OSV ecosystem name for the candidate pre-check. */
   readonly osvEcosystem: string;

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -1,4 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
+import { plannedRemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -2031,6 +2032,7 @@ export const csharp: LanguageSupport = {
   deepSast: { codeqlLanguage: 'csharp', snykCode: true, execution: csharpBuildExecution },
 
   treeInvariants: NO_TREE_INVARIANTS,
+  remediation: plannedRemediationSupport('dotnet'),
   correctness: csharpCorrectnessProvider,
   lintGate: csharpLintGateProvider,
 

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -1,4 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
+import { plannedRemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -1215,6 +1216,7 @@ export const go: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
+  remediation: plannedRemediationSupport('go'),
   correctness: goCorrectnessProvider,
   lintGate: goLintGateProvider,
 

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -908,6 +908,24 @@ export function collectExecutionRequirements(
         requirement: lang.deepSast.execution(cwd),
       });
     }
+    // Remediation capabilities that spawn (4.4.7): the pin and the declare
+    // carry their own execution declarations, consumed by the executors'
+    // pre-spawn gate AND collected here so placement sees them (the
+    // resync's requirement already rides its install strategy).
+    if (lang.remediation.pinTransitive.kind === 'capability') {
+      out.push({
+        pack: lang.id,
+        capability: 'pinTransitive',
+        requirement: lang.remediation.pinTransitive.provider.execution(cwd),
+      });
+    }
+    if (lang.remediation.declareDependency.kind === 'capability') {
+      out.push({
+        pack: lang.id,
+        capability: 'declareDependency',
+        requirement: lang.remediation.declareDependency.provider.execution(cwd),
+      });
+    }
   }
   return out;
 }

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -12,6 +12,7 @@ import type {
 import type { CorrectnessProvider } from './capabilities/correctness';
 import type { LintGateProvider } from './capabilities/lint-gate';
 import type { InstallStrategy, InstallStrategyProvider } from './capabilities/install-strategy';
+import type { RemediationCapabilityId, RemediationSupport } from './capabilities/remediation';
 import type { CapabilityRequirement } from '../execution';
 import type { ResolvedTolerances } from '../install/tolerances';
 import { dependencyTreeInvariant, type TreeInvariant } from './capabilities/tree-invariants';
@@ -941,6 +942,24 @@ export function activeInstallStrategies(
     if (strategy !== null) out.push({ id, strategy });
   }
   return out;
+}
+
+/**
+ * The remediation declaration set of a pack, by id string (evidence packs
+ * arrive as plain strings). Undefined only for an id no registered pack
+ * carries; every registered pack declares the field (required).
+ */
+export function remediationSupport(pack: string): RemediationSupport | undefined {
+  return LANGUAGES.find((l) => l.id === pack)?.remediation;
+}
+
+/** The packs whose declaration for `capability` is a real provider (not an
+ *  exemption). The recipe registry's tier decision and the executors both
+ *  read this union, so adding a pack extends every consumer (Rule 6). */
+export function languagesDeclaringRemediation(
+  capability: RemediationCapabilityId,
+): readonly LanguageSupport[] {
+  return LANGUAGES.filter((l) => l.remediation[capability].kind === 'capability');
 }
 
 /** What the ONE invariant collector answers: the invariants, plus the

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -1,4 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
+import { plannedRemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -739,6 +740,7 @@ export const java: LanguageSupport = {
   deepSast: { codeqlLanguage: 'java', snykCode: true, execution: jvmBuildExecution },
 
   treeInvariants: NO_TREE_INVARIANTS,
+  remediation: plannedRemediationSupport('java'),
   correctness: javaCorrectnessProvider,
   // Lint gate: DORMANT. Java linters (checkstyle/PMD/SpotBugs) run via the build
   // tool with varied, non-line-oriented output (XML/SARIF), so no stable text

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -1,4 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
+import { plannedRemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -806,6 +807,7 @@ export const kotlin: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
+  remediation: plannedRemediationSupport('kotlin'),
   correctness: kotlinCorrectnessProvider,
   lintGate: kotlinLintGateProvider,
 

--- a/src/languages/node-install.ts
+++ b/src/languages/node-install.ts
@@ -102,8 +102,10 @@ function legacyPeerDeps(bin: string, args: readonly string[]): InstallFallback {
 }
 
 /** A node install needs the node toolchain and nothing else; it never
- *  builds the project (lifecycle scripts are the repo's own business). */
-const NODE_EXECUTION: ExecutionRequirement = {
+ *  builds the project (lifecycle scripts are the repo's own business).
+ *  Shared with the node remediation capabilities (`node-remediation.ts`),
+ *  whose installs and probes need exactly the same environment. */
+export const NODE_EXECUTION: ExecutionRequirement = {
   hosts: ['any'],
   toolchains: ['node'],
   needsBuild: false,

--- a/src/languages/node-install.ts
+++ b/src/languages/node-install.ts
@@ -38,6 +38,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import {
   addDevPrefix,
+  detectLockfile,
   detectPackageManager,
   LOCKFILES,
   upgradeArgv,
@@ -255,7 +256,20 @@ const VARIANTS: readonly InstallVariant[] = [
 
 export const nodeInstallStrategy: InstallStrategyProvider = {
   variants: () => VARIANTS,
-  strategy: (dir) => strategyFromVariants(VARIANTS, dir),
+  // The picked variant's `lockfile` is its canonical basename, but a trigger
+  // set can hold several spellings of one lockfile (npm-shrinkwrap.json for
+  // package-lock.json, bun.lockb for bun.lock). Resolve the file actually
+  // present through the ONE detector so a shrinkwrap-only root reports the
+  // file its installs really rewrite; commands are unaffected (npm and bun
+  // read whichever spelling exists).
+  strategy: (dir) => {
+    const picked = strategyFromVariants(VARIANTS, dir);
+    if (picked === null || picked.lockfile === null) return picked;
+    const present = detectLockfile(dir);
+    return present === null || present.lockfile === picked.lockfile
+      ? picked
+      : { ...picked, lockfile: present.lockfile };
+  },
   ciDependencyInstall: true,
 };
 

--- a/src/languages/node-remediation.ts
+++ b/src/languages/node-remediation.ts
@@ -1,0 +1,145 @@
+/**
+ * The node ecosystem's remediation capabilities (the TypeScript pack's
+ * `remediation`, Rule 6): every npm/pnpm/yarn/bun fact the recipe executors
+ * consume through the capability seam. Before this, the same facts lived
+ * inline in `src/remediate/recipes/` (the npm `overrides` edit, the
+ * `npm view` probe, the npm package-name rail), which is exactly the
+ * hardcoding the seam exists to kill: an executor that knows npm cannot
+ * serve a python repo, and a second ecosystem added inline would fork the
+ * refusal taxonomy.
+ *
+ * Doctrine notes, kept beside the declarations they explain:
+ *   - The pin mechanism implemented this round is npm `overrides`; the
+ *     pnpm (`pnpm.overrides`) and yarn (`resolutions`) mechanisms are
+ *     DECLARED refusals from `plan` (reason named), never half-implemented.
+ *   - A DIRECT dependency refuses the pin: the honest fix is upgrading the
+ *     declared dependency (the dep-bump lane's job), not overriding it.
+ *   - `npm view` resolves the registry version the install would take,
+ *     honoring the repo's own `.npmrc` (registry, scopes). npm ships with
+ *     the Node runtime dxkit requires, so the probe holds for every node
+ *     package manager.
+ */
+import { join } from 'path';
+import { serializePreservingJson } from '../files';
+import { detectLockfile, upgradeArgv } from '../package-manager';
+import type {
+  DeclareDependencyProvider,
+  PinPlanResult,
+  PinTransitiveProvider,
+  RemediationSupport,
+} from './capabilities/remediation';
+import { NODE_EXECUTION } from './node-install';
+
+/**
+ * A strict npm package-name shape (name, or @scope/name): lowercase-biased
+ * URL-safe characters, first character alphanumeric. Load-bearing for the
+ * Rule 11 argument-injection discipline, not just hygiene: an unresolved
+ * "specifier" is attacker-influencable text from source code, and a
+ * leading-dash value handed to a package-manager argv is a flag (a
+ * `--registry=...` import would redirect the install). Everything outside
+ * this shape is refused before any argv is built.
+ */
+const NPM_PACKAGE_NAME = /^(@[a-z0-9][a-z0-9-._~]*\/)?[a-z0-9][a-z0-9-._~]*$/i;
+
+export function isValidNpmPackageName(name: string): boolean {
+  return name.length > 0 && name.length <= 214 && NPM_PACKAGE_NAME.test(name);
+}
+
+/** The `overrides[pkg] = version` edit as a PURE text transform, preserving
+ *  the manifest's own indentation and trailing newline. Refuses when the
+ *  package is a DIRECT dependency of the manifest. */
+function npmOverrideTransform(
+  pkg: string,
+  version: string,
+): (text: string) => { text: string } | { refused: string } {
+  return (text) => {
+    let manifest: Record<string, unknown>;
+    try {
+      const parsed: unknown = JSON.parse(text);
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return { refused: 'the package.json here is not a JSON object, so it cannot be edited' };
+      }
+      manifest = parsed as Record<string, unknown>;
+    } catch {
+      return { refused: 'the package.json here does not parse as JSON, so it cannot be edited' };
+    }
+    for (const section of ['dependencies', 'devDependencies', 'optionalDependencies'] as const) {
+      const deps = manifest[section];
+      if (deps && typeof deps === 'object' && pkg in (deps as Record<string, unknown>)) {
+        return {
+          refused:
+            `'${pkg}' is a direct ${section.replace(/ies$/, 'y')} of this manifest; the honest ` +
+            'fix is upgrading the declared dependency (the dep-bump lane), not overriding it',
+        };
+      }
+    }
+    const overrides =
+      manifest.overrides && typeof manifest.overrides === 'object'
+        ? (manifest.overrides as Record<string, unknown>)
+        : {};
+    overrides[pkg] = version;
+    manifest.overrides = overrides;
+    // The one style-preserving JSON writer (files.ts): indentation, compact
+    // form, and trailing newline survive, so the override is a one-key diff.
+    return { text: serializePreservingJson(text, manifest) };
+  };
+}
+
+const nodePinTransitive: PinTransitiveProvider = {
+  manifestFiles: ['package.json'],
+  osvEcosystem: 'npm',
+  plan(ctx): PinPlanResult {
+    const lock = detectLockfile(join(ctx.cwd, ctx.rootDir));
+    if (lock !== null && lock.pm !== 'npm') {
+      return {
+        kind: 'refused',
+        reason:
+          `the '${lock.pm}' override mechanism (${lock.pm === 'yarn' ? 'resolutions' : `${lock.pm}.overrides`}) ` +
+          'is not implemented in this recipe yet (npm overrides only this round)',
+      };
+    }
+    return {
+      kind: 'plan',
+      edit: { file: 'package.json', transform: npmOverrideTransform(ctx.pkg, ctx.version) },
+      revert:
+        `remove the "overrides" entry for '${ctx.pkg}' from ` +
+        `${ctx.rootDir ? `${ctx.rootDir}/` : ''}package.json and re-run the lock resync`,
+    };
+  },
+  execution: () => NODE_EXECUTION,
+};
+
+const nodeDeclareDependency: DeclareDependencyProvider = {
+  manifestFiles: ['package.json'],
+  osvEcosystem: 'npm',
+  packageNameLabel: 'npm package name',
+  validSpecifier: isValidNpmPackageName,
+  versionProbe: (ctx) => ({ bin: 'npm', args: ['view', ctx.specifier, 'version'] }),
+  parseProbeOutput(output) {
+    const version = output.trim().split('\n').pop()?.trim() ?? '';
+    return /^\d/.test(version) ? version : null;
+  },
+  installCommand(ctx) {
+    // The manager owning this root, from the lockfile actually present (the
+    // ONE detector); a lockfile-less root was already refused upstream.
+    const pm = detectLockfile(join(ctx.cwd, ctx.rootDir))?.pm ?? 'npm';
+    const [bin, ...args] = upgradeArgv(
+      pm,
+      ctx.specifier,
+      ctx.version,
+      ctx.dev ? 'devDependencies' : 'dependencies',
+    );
+    return { bin, args };
+  },
+  execution: () => NODE_EXECUTION,
+};
+
+/** The TypeScript/JavaScript pack's remediation declarations: all four
+ *  capabilities. The resync command rides `nodeInstallStrategy` and the
+ *  lint fix rides the eslint `fixCommand` (Rule 2: one code path each). */
+export const nodeRemediation: RemediationSupport = {
+  resyncLockfile: { kind: 'capability', provider: { manifestFiles: ['package.json'] } },
+  pinTransitive: { kind: 'capability', provider: nodePinTransitive },
+  declareDependency: { kind: 'capability', provider: nodeDeclareDependency },
+  lintFix: { kind: 'capability' },
+};

--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -1,4 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
+import { plannedRemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -771,6 +772,7 @@ export const php: LanguageSupport = {
   callGraphReliability: 'partial',
 
   treeInvariants: NO_TREE_INVARIANTS,
+  remediation: plannedRemediationSupport('php'),
   correctness: phpCorrectnessProvider,
   lintGate: phpLintGateProvider,
 

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1,4 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
+import { plannedRemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -2059,6 +2060,7 @@ export const python: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
+  remediation: plannedRemediationSupport('python'),
   correctness: pyCorrectnessProvider,
   lintGate: pyLintGateProvider,
 

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -1,4 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
+import { plannedRemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -1243,6 +1244,7 @@ export const ruby: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
+  remediation: plannedRemediationSupport('ruby'),
   correctness: rubyCorrectnessProvider,
   lintGate: rubyLintGateProvider,
 

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -1,4 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
+import { plannedRemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -1176,6 +1177,7 @@ export const rust: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
+  remediation: plannedRemediationSupport('rust'),
   correctness: rustCorrectnessProvider,
   lintGate: rustLintGateProvider,
 

--- a/src/languages/swift.ts
+++ b/src/languages/swift.ts
@@ -1,4 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
+import { plannedRemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -729,6 +730,7 @@ export const swift: LanguageSupport = {
   callGraphReliability: 'partial',
 
   treeInvariants: NO_TREE_INVARIANTS,
+  remediation: plannedRemediationSupport('swift'),
   correctness: swiftCorrectnessProvider,
   lintGate: swiftLintGateProvider,
 

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -11,6 +11,7 @@ import type { CorrectnessProvider } from './capabilities/correctness';
 import type { TreeInvariantProvider } from './capabilities/tree-invariants';
 import type { LintGateProvider } from './capabilities/lint-gate';
 import type { InstallStrategyProvider } from './capabilities/install-strategy';
+import type { RemediationSupport } from './capabilities/remediation';
 
 // `LanguageId` lives in `src/types.ts` (where `DetectedStack.languages`
 // references it) to avoid circular imports. Re-exported here for
@@ -455,6 +456,19 @@ export interface LanguageSupport {
    * `test/languages-contract.test.ts`, never a silent omission.
    */
   readonly installStrategy?: InstallStrategyProvider;
+
+  /**
+   * REQUIRED: the pack's remediation capability declarations
+   * (`capabilities/remediation.ts`), one per deterministic recipe: the
+   * lockfile resync, the transitive pin, the dependency declaration, and
+   * the linter autofix. Each entry is a provider or a declared exemption
+   * with a reason (the DEFERRED_KINDS discipline, surfaced in plan
+   * output) - never a silent omission, and a new pack that drops the
+   * field fails to compile. The recipe executors and the planner's tier
+   * decision consume these through the registry; they never hardcode an
+   * ecosystem fact.
+   */
+  readonly remediation: RemediationSupport;
 
   /**
    * REQUIRED: the tree properties the remediate frame OWNS for this

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1,3 +1,4 @@
+import { nodeRemediation } from './node-remediation';
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -3098,6 +3099,7 @@ export const typescript: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
+  remediation: nodeRemediation,
   correctness: tsCorrectnessProvider,
   lintGate: tsLintGateProvider,
 

--- a/src/remediate/ledger-render.ts
+++ b/src/remediate/ledger-render.ts
@@ -52,7 +52,8 @@ function renderRecipeSection(recipes: RecipePhaseSummary): string[] {
     if (o.kind === 'applied') {
       lines.push(
         `- \`${rec.orderId}\` (${rec.recipe}): APPLIED, changed ${o.changedFiles.join(', ')}` +
-          (o.notes && o.notes.length > 0 ? ` (${o.notes.join('; ')})` : ''),
+          (o.notes && o.notes.length > 0 ? ` (${o.notes.join('; ')})` : '') +
+          (o.revert ? `. To revert: ${o.revert}` : ''),
       );
     } else if (o.kind === 'refused') {
       lines.push(`- \`${rec.orderId}\` (${rec.recipe}): refused, ${o.reason}`);

--- a/src/remediate/recipes/declare-dependency.ts
+++ b/src/remediate/recipes/declare-dependency.ts
@@ -8,31 +8,30 @@
  * installing a vulnerable phantom dependency and turning the gate red)
  * converted into a disclosed refusal.
  *
- * Scope this round: orders produced by the TypeScript/JavaScript pack. The
- * resolution-check contract makes bareness a producer fact; a project-path
- * identity (leading `./`) names a missing FILE, which no install can
- * declare, so such orders are refused with the reason (the registry's
- * `matches` already tiers them to the agent).
+ * Every ecosystem fact comes from the producing pack's declared
+ * `remediation.declareDependency` capability (Rule 6): the specifier rail,
+ * the registry version probe, the install command, the OSV ecosystem. A
+ * pack without the capability carries a declared exemption whose reason is
+ * this refusal (the registry's `matches` already tiers such orders to the
+ * agent, disclosed). A project-path identity (leading `./`) names a
+ * missing FILE, which no install can declare, so such orders are refused
+ * with the reason.
  */
 import * as path from 'path';
 import { runSingleResolutionCheck } from '../../analyzers/correctness/single-checks';
 import { isProjectPathIdentity } from '../../languages/capabilities/correctness';
 import { isTestSourceFile } from '../../analyzers/tools/walk-source-files';
-import { upgradeArgv, type DependencySection } from '../../package-manager';
 import type { FloorEvidence, WorkOrder } from '../work-orders/types';
 import {
+  ambiguousRootReason,
   execStepFailure,
-  isValidNpmPackageName,
-  nodePmAt,
+  exemptionReason,
   osvBlockTier,
-  owningManifestRoot,
+  owningManifestEntry,
+  packDeclaration,
+  packStrategyAt,
 } from './shared';
 import type { RecipeExecuteContext, RecipeOutcome } from './types';
-
-/** The packs whose resolution-check evidence this recipe can act on. Read
- *  by the registry's `matches` too, so an order from any other pack tiers
- *  to the agent instead of being tiered recipe and refused at runtime. */
-export const DECLARABLE_PACKS: readonly string[] = ['typescript'];
 
 interface Candidate {
   readonly specifier: string;
@@ -58,26 +57,28 @@ export async function executeDeclareDependency(
     return { kind: 'refused', reason: 'the order carries no unresolved-specifier evidence' };
   }
   const pack = (order.findings[0].evidence as FloorEvidence).pack;
-  if (!DECLARABLE_PACKS.includes(pack)) {
-    return {
-      kind: 'refused',
-      reason: `declare-dependency is implemented for the ${DECLARABLE_PACKS.join('/')} pack only this round (order came from '${pack}')`,
-    };
+  const declaration = packDeclaration(pack, 'declareDependency');
+  if (declaration === undefined) {
+    return { kind: 'refused', reason: `no registered language pack has the id '${pack}'` };
   }
+  if (declaration.kind === 'exemption') {
+    return { kind: 'refused', reason: exemptionReason(pack, declaration) };
+  }
+  const provider = declaration.provider;
   // Rule 11 argument-injection rail: a specifier is attacker-influencable
   // source text and flows into package-manager argv below. Anything outside
-  // the strict npm name shape (a leading dash, spaces, a URL) is refused
-  // BEFORE any argv exists; the registry's matches applies the same shape
-  // at planning time, so this is the defense-in-depth boundary.
-  const malformed = cands.filter((c) => !isValidNpmPackageName(c.specifier));
+  // the pack's declared name shape (a leading dash, spaces, a URL) is
+  // refused BEFORE any argv exists; the registry's matches applies the same
+  // shape at planning time, so this is the defense-in-depth boundary.
+  const malformed = cands.filter((c) => !provider.validSpecifier(c.specifier));
   if (malformed.length > 0) {
     return {
       kind: 'refused',
       reason:
         `${malformed.map((c) => `'${c.specifier}'`).join(', ')} ` +
         (malformed.length === 1
-          ? 'is not a valid npm package name'
-          : 'are not valid npm package names') +
+          ? `is not a valid ${provider.packageNameLabel}`
+          : `are not valid ${provider.packageNameLabel}s`) +
         '; refusing to hand it to the package manager',
     };
   }
@@ -91,17 +92,16 @@ export async function executeDeclareDependency(
         'restore or remove the import',
     };
   }
-  const rootDir = owningManifestRoot(order);
-  if (rootDir === null) {
+  const root = owningManifestEntry(order, provider.manifestFiles);
+  if (root === null) {
     return {
       kind: 'refused',
-      reason:
-        'the envelope does not name exactly one package.json, so the manifest to declare ' +
-        'into is ambiguous',
+      reason: ambiguousRootReason(provider.manifestFiles, 'the manifest to declare into'),
     };
   }
-  const lock = nodePmAt(ctx.cwd, rootDir);
-  if (lock === null) {
+  const rootDir = root.dir;
+  const strategy = packStrategyAt(pack, ctx.cwd, rootDir);
+  if (strategy === null || strategy.lockfile === null) {
     return {
       kind: 'refused',
       reason: `no lockfile exists at ${rootDir || 'the repo root'}, so declaring a dependency here cannot be lockfile-verified`,
@@ -112,14 +112,18 @@ export async function executeDeclareDependency(
   // Resolve + pre-check EVERY candidate before installing ANY: a refusal
   // must cost $0 and leave the tree untouched.
   const notes: string[] = [];
-  const resolved: Array<Candidate & { version: string; section: DependencySection }> = [];
+  const resolved: Array<Candidate & { version: string; dev: boolean }> = [];
   for (const c of cands) {
-    // `npm view` resolves the registry version the install would take,
-    // honoring the repo's own .npmrc (registry, scopes). npm ships with the
-    // Node runtime dxkit requires, so this holds for every node PM.
-    const view = ctx.exec({ bin: 'npm', args: ['view', c.specifier, 'version'] }, rootAbs);
+    // The pack's registry version probe resolves the version the install
+    // would take (honoring the repo's own registry configuration).
+    const probe = provider.versionProbe({ cwd: ctx.cwd, rootDir, specifier: c.specifier });
+    const view = ctx.exec({ bin: probe.bin, args: [...probe.args] }, rootAbs);
     if (!view.available) {
-      return { kind: 'failed', step: 'resolve-version', output: 'npm is not available here' };
+      return {
+        kind: 'failed',
+        step: 'resolve-version',
+        output: `${probe.bin} is not available here`,
+      };
     }
     if (view.timedOut || view.overflowed || view.code !== 0) {
       return {
@@ -129,14 +133,14 @@ export async function executeDeclareDependency(
           'private package, or something that should not be a dependency at all. Not installing',
       };
     }
-    const version = view.output.trim().split('\n').pop()?.trim() ?? '';
-    if (!/^\d/.test(version)) {
+    const version = provider.parseProbeOutput(view.output);
+    if (version === null) {
       return {
         kind: 'refused',
-        reason: `could not determine a concrete registry version for '${c.specifier}' (got '${version}')`,
+        reason: `could not determine a concrete registry version for '${c.specifier}' (got '${view.output.trim().split('\n').pop()?.trim() ?? ''}')`,
       };
     }
-    const known = await ctx.queryOsv(c.specifier, version, 'npm');
+    const known = await ctx.queryOsv(c.specifier, version, provider.osvEcosystem);
     if (known === null) {
       notes.push(
         `OSV pre-check for ${c.specifier}@${version} could not be reached; the guardrail verifies`,
@@ -153,18 +157,21 @@ export async function executeDeclareDependency(
         };
       }
     }
-    // Section: a package imported ONLY from test files is a devDependency.
-    const section: DependencySection =
-      c.importingFiles.length > 0 && c.importingFiles.every((f) => isTestSourceFile(f))
-        ? 'devDependencies'
-        : 'dependencies';
-    resolved.push({ ...c, version, section });
+    // A package imported ONLY from test files is a dev dependency.
+    const dev = c.importingFiles.length > 0 && c.importingFiles.every((f) => isTestSourceFile(f));
+    resolved.push({ ...c, version, dev });
   }
 
   for (const r of resolved) {
-    const [bin, ...args] = upgradeArgv(lock.pm, r.specifier, r.version, r.section);
-    const install = ctx.exec({ bin, args }, rootAbs);
-    const failure = execStepFailure('install', [bin, ...args].join(' '), install);
+    const cmd = provider.installCommand({
+      cwd: ctx.cwd,
+      rootDir,
+      specifier: r.specifier,
+      version: r.version,
+      dev: r.dev,
+    });
+    const install = ctx.exec({ bin: cmd.bin, args: [...cmd.args] }, rootAbs);
+    const failure = execStepFailure('install', [cmd.bin, ...cmd.args].join(' '), install);
     if (failure) return failure;
   }
 
@@ -189,8 +196,8 @@ export async function executeDeclareDependency(
       output: `still unresolved after install: ${unfixed.map((r) => `'${r.specifier}'`).join(', ')}`,
     };
   }
-  const manifestPath = rootDir ? `${rootDir}/package.json` : 'package.json';
-  const lockPath = rootDir ? `${rootDir}/${lock.lockfile}` : lock.lockfile;
+  const manifestPath = rootDir ? `${rootDir}/${root.file}` : root.file;
+  const lockPath = rootDir ? `${rootDir}/${strategy.lockfile}` : strategy.lockfile;
   return {
     kind: 'applied',
     changedFiles: [manifestPath, lockPath],

--- a/src/remediate/recipes/declare-dependency.ts
+++ b/src/remediate/recipes/declare-dependency.ts
@@ -24,6 +24,7 @@ import { isTestSourceFile } from '../../analyzers/tools/walk-source-files';
 import type { FloorEvidence, WorkOrder } from '../work-orders/types';
 import {
   ambiguousRootReason,
+  environmentRefusal,
   execStepFailure,
   exemptionReason,
   osvBlockTier,
@@ -65,6 +66,15 @@ export async function executeDeclareDependency(
     return { kind: 'refused', reason: exemptionReason(pack, declaration) };
   }
   const provider = declaration.provider;
+  // Rule 20, decided before anything spawns: the provider's declared
+  // environment requirement gates the whole attempt with a disclosed
+  // refusal (the runners' skipped-environment doctrine).
+  const envRefusal = environmentRefusal(
+    `the ${pack} pack's dependency declaration`,
+    (cwd) => provider.execution(cwd),
+    ctx.cwd,
+  );
+  if (envRefusal) return envRefusal;
   // Rule 11 argument-injection rail: a specifier is attacker-influencable
   // source text and flows into package-manager argv below. Anything outside
   // the pack's declared name shape (a leading dash, spaces, a URL) is

--- a/src/remediate/recipes/lint-autofix.ts
+++ b/src/remediate/recipes/lint-autofix.ts
@@ -22,6 +22,7 @@ import { parseLocated, parseStructuredLocated } from '../../analyzers/custom-che
 import type { CustomCheckFinding } from '../../analyzers/custom-checks/types';
 import { getLanguage } from '../../languages';
 import type { LanguageId } from '../../languages/types';
+import { exemptionReason, packDeclaration } from './shared';
 import type { WorkOrder } from '../work-orders/types';
 import type { RecipeExecuteContext, RecipeOutcome } from './types';
 
@@ -48,6 +49,13 @@ export async function executeLintAutofix(
         `'${first.check}' is a user-declared check, and dxkit does not know its fixer; only ` +
         'pack lint gates have a declared fix mode',
     };
+  }
+  // The pack's declared lintFix capability (the rider over
+  // `lintGate.fixCommand`, Rule 2): an exemption refuses with the declared
+  // reason; the registry's `matches` already tiers such orders to the agent.
+  const declaration = packDeclaration(pack, 'lintFix');
+  if (declaration !== undefined && declaration.kind === 'exemption') {
+    return { kind: 'refused', reason: exemptionReason(pack, declaration) };
   }
   const provider = getLanguage(pack as LanguageId)?.lintGate;
   const fix = provider?.fixCommand?.({ cwd: ctx.cwd, files: [file] }) ?? null;

--- a/src/remediate/recipes/lockfile-sync.ts
+++ b/src/remediate/recipes/lockfile-sync.ts
@@ -1,17 +1,27 @@
 /**
  * The `lockfile-sync` recipe: a `stale-lockfile` order (the lockfile-sync
  * floor check failed: CI's frozen install cannot load this tree) is fixed
- * by the ecosystem's lock-WRITING install at the owning root, then verified
- * by the SAME pack-declared frozen dry-run the floor runs (`lockfileCheck`,
- * via the correctness module's single-check entry point: one concept, one
- * code path). A verify the pack cannot give (yarn's declared skip) is a
- * refusal, never an unconfirmed "applied".
+ * by the PRODUCING PACK's lock-writing install at the owning root (its
+ * `installStrategy` resync mode, through the ONE install executor; the
+ * pack's `remediation.resyncLockfile` declaration is what admits the order
+ * to this recipe, Rule 6), then verified by the SAME pack-declared frozen
+ * dry-run the floor runs (`lockfileCheck`, via the correctness module's
+ * single-check entry point: one concept, one code path). A verify the pack
+ * cannot give (yarn's declared skip) is a refusal, never an unconfirmed
+ * "applied".
  */
 import * as path from 'path';
 import { tail } from '../../analyzers/tools/bounded-exec';
 import { runSingleLockfileCheck } from '../../analyzers/correctness/single-checks';
 import type { WorkOrder } from '../work-orders/types';
-import { nodePmAt, nodeStrategyAt, owningManifestRoot, runResyncInstall } from './shared';
+import {
+  ambiguousRootReason,
+  exemptionReason,
+  owningManifestRoot,
+  packDeclaration,
+  packStrategyAt,
+  runResyncInstall,
+} from './shared';
 import type { RecipeExecuteContext, RecipeOutcome } from './types';
 
 /** The pack that produced the order's floor finding. */
@@ -28,21 +38,25 @@ export async function executeLockfileSync(
   if (pack === null) {
     return { kind: 'refused', reason: 'the order carries no floor evidence naming its pack' };
   }
-  const rootDir = owningManifestRoot(order);
+  const declaration = packDeclaration(pack, 'resyncLockfile');
+  if (declaration === undefined) {
+    return { kind: 'refused', reason: `no registered language pack has the id '${pack}'` };
+  }
+  if (declaration.kind === 'exemption') {
+    return { kind: 'refused', reason: exemptionReason(pack, declaration) };
+  }
+  const rootDir = owningManifestRoot(order, declaration.provider.manifestFiles);
   if (rootDir === null) {
     return {
       kind: 'refused',
-      reason:
-        'the envelope does not name exactly one package.json, so the owning dependency root ' +
-        'is ambiguous',
+      reason: ambiguousRootReason(declaration.provider.manifestFiles, 'the owning dependency root'),
     };
   }
   const rootAbs = path.join(ctx.cwd, rootDir);
-  const strategy = nodeStrategyAt(ctx.cwd, rootDir);
-  // The lockfile actually present (a shrinkwrap counts), from the same file
-  // presence the strategy keyed on.
-  const lock = nodePmAt(ctx.cwd, rootDir);
-  if (strategy === null || strategy.lockfile === null || lock === null) {
+  // The pack's install strategy at this root (the ONE install seam): its
+  // resync mode is the fix, its lockfile is what the fix rewrites.
+  const strategy = packStrategyAt(pack, ctx.cwd, rootDir);
+  if (strategy === null || strategy.lockfile === null) {
     return {
       kind: 'refused',
       reason: `no lockfile exists at ${rootDir || 'the repo root'}, so there is nothing to re-sync`,
@@ -73,7 +87,7 @@ export async function executeLockfileSync(
   }
   return {
     kind: 'applied',
-    changedFiles: [rootDir ? `${rootDir}/${lock.lockfile}` : lock.lockfile],
+    changedFiles: [rootDir ? `${rootDir}/${strategy.lockfile}` : strategy.lockfile],
     ...(verify.note ? { notes: [verify.note] } : {}),
   };
 }

--- a/src/remediate/recipes/override-pin.ts
+++ b/src/remediate/recipes/override-pin.ts
@@ -27,6 +27,7 @@ import type { WorkOrder } from '../work-orders/types';
 import type { DepAdvisoryEvidence } from '../work-orders/types';
 import {
   ambiguousRootReason,
+  environmentRefusal,
   osvBlockTier,
   packStrategyAt,
   pickPinVersion,
@@ -65,6 +66,16 @@ export async function executeOverridePin(
     return { kind: 'refused', reason: resolved.reason };
   }
   const { pack, provider, rootDir } = resolved;
+  // Rule 20, decided before anything spawns: the provider's declared
+  // environment requirement gates the whole attempt with a disclosed
+  // refusal (the runners' skipped-environment doctrine), never a spawn
+  // that fails in a way that reads as a code finding.
+  const envRefusal = environmentRefusal(
+    `the ${pack} pack's transitive pin`,
+    (cwd) => provider.execution(cwd),
+    ctx.cwd,
+  );
+  if (envRefusal) return envRefusal;
   if (rootDir === null) {
     return {
       kind: 'refused',
@@ -160,6 +171,7 @@ export async function executeOverridePin(
   return {
     kind: 'applied',
     changedFiles: [manifestPath, lockPath],
+    revert: plan.revert,
     ...(notes.length > 0 ? { notes } : {}),
   };
 }

--- a/src/remediate/recipes/override-pin.ts
+++ b/src/remediate/recipes/override-pin.ts
@@ -1,17 +1,21 @@
 /**
  * The `override-pin` recipe: a `dep-advisory` order whose every advisory has
  * a known fixed version, on a package with no direct upgrade path (a
- * transitive dependency), is fixed by a package-manager override pinning the
- * fixed version, then a lockfile resync.
+ * transitive dependency), is fixed by the OWNING PACK's declared pin
+ * mechanism (`remediation.pinTransitive`, Rule 6: the executor knows no
+ * ecosystem; npm overrides live in the ts pack) and a lockfile resync
+ * through the pack's install strategy.
  *
  * Honesty gates, in order:
- *   - npm first: pnpm `pnpm.overrides` and yarn `resolutions` are
- *     DECLARED-REFUSED this round (reason named), never half-implemented;
- *   - a DIRECT dependency is refused: the honest fix is upgrading the
- *     declared dep (the dep-bump lane's job), not overriding it;
- *   - the candidate pin is OSV pre-checked ($0): a block-tier advisory
- *     against the pinned version refuses with the advisory named, so the
- *     recipe never trades one red gate for another;
+ *   - the owning pack's declaration decides: an exemption (or an
+ *     unresolvable pack) refuses with the declared reason; the pack's own
+ *     `plan` may refuse too (a mechanism it does not implement yet, a
+ *     direct dependency: the honest fix is upgrading the declared dep, the
+ *     dep-bump lane's job);
+ *   - the candidate pin is OSV pre-checked ($0) in the pack's declared
+ *     ecosystem: a block-tier advisory against the pinned version refuses
+ *     with the advisory named, so the recipe never trades one red gate for
+ *     another;
  *   - verify is a re-audit through the ONE dep-audit dispatch: the order's
  *     package must audit clean afterwards (its known advisories gone AND
  *     nothing new minted on it), or the recipe fails and the diff is
@@ -19,15 +23,14 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { serializePreservingJson } from '../../files';
 import type { WorkOrder } from '../work-orders/types';
 import type { DepAdvisoryEvidence } from '../work-orders/types';
 import {
-  nodePmAt,
-  nodeStrategyAt,
+  ambiguousRootReason,
   osvBlockTier,
-  owningManifestRoot,
+  packStrategyAt,
   pickPinVersion,
+  resolvePinCapability,
   runResyncInstall,
 } from './shared';
 import type { RecipeExecuteContext, RecipeOutcome } from './types';
@@ -36,41 +39,6 @@ function advisories(order: WorkOrder): DepAdvisoryEvidence[] {
   return order.findings
     .map((f) => f.evidence)
     .filter((e): e is DepAdvisoryEvidence => e.type === 'dep-vuln');
-}
-
-interface ManifestEdit {
-  readonly file: string;
-  readonly refused?: string;
-}
-
-/** Write `overrides[pkg] = version` into the root package.json, preserving
- *  the file's own indentation and trailing newline. Refuses (without
- *  writing) when the package is a DIRECT dependency there. */
-function writeNpmOverride(rootAbs: string, pkg: string, version: string): ManifestEdit {
-  const file = path.join(rootAbs, 'package.json');
-  const text = fs.readFileSync(file, 'utf8');
-  const manifest = JSON.parse(text) as Record<string, unknown>;
-  for (const section of ['dependencies', 'devDependencies', 'optionalDependencies'] as const) {
-    const deps = manifest[section];
-    if (deps && typeof deps === 'object' && pkg in (deps as Record<string, unknown>)) {
-      return {
-        file,
-        refused:
-          `'${pkg}' is a direct ${section.replace(/ies$/, 'y')} of this manifest; the honest ` +
-          'fix is upgrading the declared dependency (the dep-bump lane), not overriding it',
-      };
-    }
-  }
-  const overrides =
-    manifest.overrides && typeof manifest.overrides === 'object'
-      ? (manifest.overrides as Record<string, unknown>)
-      : {};
-  overrides[pkg] = version;
-  manifest.overrides = overrides;
-  // The one style-preserving JSON writer (files.ts): indentation, compact
-  // form, and trailing newline survive, so the override is a one-key diff.
-  fs.writeFileSync(file, serializePreservingJson(text, manifest));
-  return { file };
 }
 
 export async function executeOverridePin(
@@ -89,28 +57,25 @@ export async function executeOverridePin(
       reason: `no fixed version is known for every advisory against '${pkg}'`,
     };
   }
-  const rootDir = owningManifestRoot(order);
+  // The owning pack's declaration (the ONE resolution `matches` and the plan
+  // disclosure also read). At runtime this is the defensive rail: the
+  // planner already tiers exemption / unknown orders to the agent.
+  const resolved = resolvePinCapability(order);
+  if (resolved.kind !== 'capability') {
+    return { kind: 'refused', reason: resolved.reason };
+  }
+  const { pack, provider, rootDir } = resolved;
   if (rootDir === null) {
     return {
       kind: 'refused',
-      reason:
-        'the envelope does not name exactly one package.json, so the owning dependency root ' +
-        'is ambiguous',
+      reason: ambiguousRootReason(provider.manifestFiles, 'the owning dependency root'),
     };
   }
-  const lock = nodePmAt(ctx.cwd, rootDir);
-  if (lock === null) {
+  const strategy = packStrategyAt(pack, ctx.cwd, rootDir);
+  if (strategy === null || strategy.lockfile === null) {
     return {
       kind: 'refused',
       reason: `no lockfile exists at ${rootDir || 'the repo root'}, and an override cannot be verified without one`,
-    };
-  }
-  if (lock.pm !== 'npm') {
-    return {
-      kind: 'refused',
-      reason:
-        `the '${lock.pm}' override mechanism (${lock.pm === 'yarn' ? 'resolutions' : `${lock.pm}.overrides`}) ` +
-        'is not implemented in this recipe yet (npm overrides only this round)',
     };
   }
 
@@ -127,12 +92,18 @@ export async function executeOverridePin(
         `(${fixedVersions.join(', ')}); a range cannot be pinned verbatim`,
     };
   }
+
+  // The pack's pin plan: a pure decision. Refusals here (an override
+  // mechanism not implemented for this manager) cost $0 and touch nothing.
+  const plan = provider.plan({ cwd: ctx.cwd, rootDir, pkg, version: pin });
+  if (plan.kind === 'refused') return { kind: 'refused', reason: plan.reason };
+
   const notes: string[] = [];
 
   // $0 pre-check: would the pinned version itself carry a block-tier
   // advisory? A null answer (network) is disclosed and the re-audit verify
   // plus the frame's guardrail stay the backstop; it is never read as clean.
-  const known = await ctx.queryOsv(pkg, pin, 'npm');
+  const known = await ctx.queryOsv(pkg, pin, provider.osvEcosystem);
   if (known === null) {
     notes.push(`OSV pre-check for ${pkg}@${pin} could not be reached; the re-audit verifies`);
   } else {
@@ -148,16 +119,17 @@ export async function executeOverridePin(
     }
   }
 
+  // Apply the pack's pure manifest edit: the executor owns the read and the
+  // write; the transform owns the format (and may still refuse: a direct
+  // dependency it only sees with the text in hand).
   const rootAbs = path.join(ctx.cwd, rootDir);
-  const edit = writeNpmOverride(rootAbs, pkg, pin);
-  if (edit.refused) return { kind: 'refused', reason: edit.refused };
+  const manifestAbs = path.join(rootAbs, plan.edit.file);
+  const edited = plan.edit.transform(fs.readFileSync(manifestAbs, 'utf8'));
+  if ('refused' in edited) return { kind: 'refused', reason: edited.refused };
+  fs.writeFileSync(manifestAbs, edited.text);
 
-  // The same lockfile presence `nodePmAt` read selects the strategy, so the
-  // resync is the declared one for the manager that owns this root.
-  const strategy = nodeStrategyAt(ctx.cwd, rootDir);
-  if (strategy === null) {
-    return { kind: 'refused', reason: 'no node install strategy applies at this root' };
-  }
+  // The lock resync through the pack's install strategy at the same root
+  // (the ONE install seam; never a second install path).
   const installFailure = runResyncInstall(strategy, rootAbs, ctx);
   if (installFailure) return installFailure;
 
@@ -183,8 +155,8 @@ export async function executeOverridePin(
         remaining.map((f) => f.id).join(', '),
     };
   }
-  const manifestPath = rootDir ? `${rootDir}/package.json` : 'package.json';
-  const lockPath = rootDir ? `${rootDir}/${lock.lockfile}` : lock.lockfile;
+  const manifestPath = rootDir ? `${rootDir}/${plan.edit.file}` : plan.edit.file;
+  const lockPath = rootDir ? `${rootDir}/${strategy.lockfile}` : strategy.lockfile;
   return {
     kind: 'applied',
     changedFiles: [manifestPath, lockPath],

--- a/src/remediate/recipes/shared.ts
+++ b/src/remediate/recipes/shared.ts
@@ -1,18 +1,29 @@
 /**
  * Helpers the recipe executors share: the owning-manifest-root derivation
- * (from the order's own envelope, never a second discovery walk), the one
- * resync-install runner (the lock-writing install with its declared
- * fallback doctrine, executed through the injected bounded exec), the
- * strict npm-name and concrete-semver shapes the registry's `matches` and
- * the executors both read, and the ONE policy-driven block-tier filter for
- * the OSV pre-checks.
+ * (from the order's own envelope and the PACK-DECLARED manifest basenames,
+ * never a second discovery walk), the one resync-install runner (the
+ * lock-writing install with its declared fallback doctrine, executed
+ * through the injected bounded exec), the capability resolution the
+ * registry's `matches`, the plan disclosure, and the executors ALL read
+ * (one code path, Rule 2.30), the concrete-semver shape, and the ONE
+ * policy-driven block-tier filter for the OSV pre-checks.
+ *
+ * Nothing here knows an ecosystem: every manifest name, package-manager
+ * command, and override mechanism comes from the packs' `remediation`
+ * declarations (`src/languages/capabilities/remediation.ts`, Rule 6). The
+ * arch-check bans package-manager literals in this directory.
  */
 import * as path from 'path';
 import { tail, type CommandOutcome } from '../../analyzers/tools/bounded-exec';
 import { classifyOsvSeverity, type OsvVuln } from '../../analyzers/tools/osv';
 import type { FindingSeverity } from '../../baseline/types';
-import { detectLockfile } from '../../package-manager';
-import { nodeInstallStrategy } from '../../languages/node-install';
+import { getLanguage, languagesDeclaringRemediation, remediationSupport } from '../../languages';
+import type { LanguageId } from '../../languages/types';
+import type {
+  PinTransitiveProvider,
+  RemediationCapabilityId,
+  RemediationSupport,
+} from '../../languages/capabilities/remediation';
 import {
   installCommandText,
   type InstallStrategy,
@@ -20,21 +31,6 @@ import {
 import { describeInfrastructure, runInstall } from '../../install/run';
 import type { WorkOrder } from '../work-orders/types';
 import type { RecipeExecuteContext, RecipeOutcome } from './types';
-
-/**
- * A strict npm package-name shape (name, or @scope/name): lowercase-biased
- * URL-safe characters, first character alphanumeric. Load-bearing for the
- * Rule 11 argument-injection discipline, not just hygiene: an unresolved
- * "specifier" is attacker-influencable text from source code, and a
- * leading-dash value handed to a package-manager argv is a flag (a
- * `--registry=...` import would redirect the install). Everything outside
- * this shape is refused before any argv is built.
- */
-const NPM_PACKAGE_NAME = /^(@[a-z0-9][a-z0-9-._~]*\/)?[a-z0-9][a-z0-9-._~]*$/i;
-
-export function isValidNpmPackageName(name: string): boolean {
-  return name.length > 0 && name.length <= 214 && NPM_PACKAGE_NAME.test(name);
-}
 
 /** A CONCRETE semver (x.y.z with optional prerelease/build), never a range.
  *  A range-shaped "fixed version" (`>=4.1.0`) cannot be pinned verbatim, so
@@ -135,30 +131,143 @@ export function execStepFailure(
 
 /**
  * The dependency root an order's fix belongs to, derived from the order's
- * OWN envelope (the planner already scoped it): the directory of the one
- * `package.json` the envelope names. Two roots in one envelope means the
- * planner could not decide (the all-roots fallback); the recipe refuses
- * rather than guess which manifest to edit.
+ * OWN envelope (the planner already scoped it): the directory of the ONE
+ * envelope entry whose basename is among the pack-declared manifest
+ * basenames. Two roots in one envelope means the planner could not decide
+ * (the all-roots fallback); the recipe refuses rather than guess which
+ * manifest to edit.
  */
-export function owningManifestRoot(order: WorkOrder): string | null {
-  const dirs = new Set(
-    order.envelope.paths
-      .filter((p) => p === 'package.json' || p.endsWith('/package.json'))
-      .map((p) => (p === 'package.json' ? '' : p.slice(0, -'/package.json'.length))),
+export function owningManifestRoot(
+  order: WorkOrder,
+  manifestFiles: readonly string[],
+): string | null {
+  return owningManifestEntry(order, manifestFiles)?.dir ?? null;
+}
+
+/** The owning root WITH the manifest basename the envelope matched (the
+ *  file a dependency edit's `changedFiles` names). */
+export function owningManifestEntry(
+  order: WorkOrder,
+  manifestFiles: readonly string[],
+): { dir: string; file: string } | null {
+  const dirs = new Map<string, string>();
+  for (const p of order.envelope.paths) {
+    for (const f of manifestFiles) {
+      if (p === f) dirs.set('', f);
+      else if (p.endsWith(`/${f}`)) dirs.set(p.slice(0, -(f.length + 1)), f);
+    }
+  }
+  if (dirs.size !== 1) return null;
+  const [dir, file] = [...dirs.entries()][0];
+  return { dir, file };
+}
+
+/** The ONE refusal phrasing for an envelope that does not resolve one
+ *  owning root (shared by every dependency-shaped recipe). */
+export function ambiguousRootReason(manifestFiles: readonly string[], what: string): string {
+  return (
+    `the envelope does not name exactly one ${manifestFiles.join(' / ')}, so ` +
+    `${what} is ambiguous`
   );
-  return dirs.size === 1 ? [...dirs][0] : null;
 }
 
-/** The node package manager owning `rootDir` (repo-relative; '' = repo
- *  root), from the lockfile actually present (the ONE detector). */
-export function nodePmAt(cwd: string, rootDir: string): ReturnType<typeof detectLockfile> {
-  return detectLockfile(path.join(cwd, rootDir));
+/** The producing pack's install strategy at `rootDir` (repo-relative;
+ *  '' = repo root), through the pack's ONE install seam (Rule 2: the
+ *  resync command and the lockfile come from `installStrategy`, never a
+ *  second table in a recipe). */
+export function packStrategyAt(pack: string, cwd: string, rootDir: string): InstallStrategy | null {
+  return packInstallStrategy(pack)?.strategy(path.join(cwd, rootDir)) ?? null;
 }
 
-/** The node install strategy that applies at `rootDir` (repo-relative;
- *  '' = repo root), from the same file presence `nodePmAt` reads. */
-export function nodeStrategyAt(cwd: string, rootDir: string): InstallStrategy | null {
-  return nodeInstallStrategy.strategy(path.join(cwd, rootDir));
+/** A pack's install-strategy provider by evidence pack id (a plain string). */
+export function packInstallStrategy(pack: string) {
+  return getLanguage(pack as LanguageId)?.installStrategy;
+}
+
+/** A pack's remediation declaration for one capability, by evidence pack
+ *  id. Undefined only when no registered pack carries the id. */
+export function packDeclaration<K extends RemediationCapabilityId>(
+  pack: string,
+  capability: K,
+): RemediationSupport[K] | undefined {
+  return remediationSupport(pack)?.[capability];
+}
+
+/** How the executors and the registry's `matches` name a pack's declared
+ *  exemption in refusals and plan output (one phrasing). */
+export function exemptionReason(pack: string, exemption: { reason: string }): string {
+  return `the ${pack} pack declares this capability exempt: ${exemption.reason}`;
+}
+
+/**
+ * Resolve the `pinTransitive` capability serving a dependency-advisory
+ * order, the ONE resolution the registry's `matches`, the plan's exemption
+ * disclosure, and the override-pin executor all consume (Rule 2.30):
+ *
+ *   - when the order's dep-vuln evidence names exactly one producing pack,
+ *     that pack's declaration decides (capability or exemption);
+ *   - when the evidence names none (a baseline-debt advisory predating the
+ *     pack stamp), the unique registry pack DECLARING the capability whose
+ *     manifest basenames resolve an owning root in the envelope serves it;
+ *   - anything else is `unknown` (ambiguous evidence, or no declaring pack
+ *     matches the envelope), and the order stays on the agent tier.
+ *
+ * Pure over the order and the pack registry: no repo file is read, so the
+ * planner's tier decision stays order-intrinsic.
+ */
+export type PinResolution =
+  | {
+      readonly kind: 'capability';
+      readonly pack: string;
+      readonly provider: PinTransitiveProvider;
+      readonly rootDir: string | null;
+    }
+  | { readonly kind: 'exemption'; readonly pack: string; readonly reason: string }
+  | { readonly kind: 'unknown'; readonly reason: string };
+
+export function resolvePinCapability(order: WorkOrder): PinResolution {
+  const evidencePacks = new Set<string>();
+  for (const f of order.findings) {
+    if (f.evidence.type === 'dep-vuln' && f.evidence.pack !== undefined) {
+      evidencePacks.add(f.evidence.pack);
+    }
+  }
+  if (evidencePacks.size > 1) {
+    return {
+      kind: 'unknown',
+      reason: `the order's findings name more than one producing pack (${[...evidencePacks].sort().join(', ')})`,
+    };
+  }
+  if (evidencePacks.size === 1) {
+    const pack = [...evidencePacks][0];
+    const declaration = packDeclaration(pack, 'pinTransitive');
+    if (declaration === undefined) {
+      return { kind: 'unknown', reason: `no registered language pack has the id '${pack}'` };
+    }
+    if (declaration.kind === 'exemption') {
+      return { kind: 'exemption', pack, reason: declaration.reason };
+    }
+    return {
+      kind: 'capability',
+      pack,
+      provider: declaration.provider,
+      rootDir: owningManifestRoot(order, declaration.provider.manifestFiles),
+    };
+  }
+  const candidates = languagesDeclaringRemediation('pinTransitive').flatMap((l) => {
+    const declaration = l.remediation.pinTransitive;
+    if (declaration.kind !== 'capability') return [];
+    const rootDir = owningManifestRoot(order, declaration.provider.manifestFiles);
+    return rootDir === null ? [] : [{ pack: l.id, provider: declaration.provider, rootDir }];
+  });
+  if (candidates.length === 1) return { kind: 'capability', ...candidates[0] };
+  return {
+    kind: 'unknown',
+    reason:
+      candidates.length === 0
+        ? 'no pack declaring transitive pinning owns a manifest the envelope names'
+        : `the envelope matches more than one pack's manifest (${candidates.map((c) => c.pack).join(', ')})`,
+  };
 }
 
 /**

--- a/src/remediate/recipes/shared.ts
+++ b/src/remediate/recipes/shared.ts
@@ -29,6 +29,11 @@ import {
   type InstallStrategy,
 } from '../../languages/capabilities/install-strategy';
 import { describeInfrastructure, runInstall } from '../../install/run';
+// exec-requirement-ok: this is the recipe tier's ONE Rule 20 consumption
+// point (environmentRefusal below); both dependency executors route their
+// pre-spawn gate through it, mirroring the runners' disclosed skips.
+import { currentEnvironment, describeUnmetRequirement, unmetRequirement } from '../../execution';
+import type { ExecutionRequirement } from '../../execution';
 import type { WorkOrder } from '../work-orders/types';
 import type { RecipeExecuteContext, RecipeOutcome } from './types';
 
@@ -145,16 +150,19 @@ export function owningManifestRoot(
 }
 
 /** The owning root WITH the manifest basename the envelope matched (the
- *  file a dependency edit's `changedFiles` names). */
+ *  file a dependency edit's `changedFiles` names). When several declared
+ *  basenames sit at ONE root, the FIRST-declared one wins deterministically
+ *  (`manifestFiles` order is the pack's preference order, part of the
+ *  provider contract); envelope order never decides. */
 export function owningManifestEntry(
   order: WorkOrder,
   manifestFiles: readonly string[],
 ): { dir: string; file: string } | null {
   const dirs = new Map<string, string>();
-  for (const p of order.envelope.paths) {
-    for (const f of manifestFiles) {
-      if (p === f) dirs.set('', f);
-      else if (p.endsWith(`/${f}`)) dirs.set(p.slice(0, -(f.length + 1)), f);
+  for (const f of manifestFiles) {
+    for (const p of order.envelope.paths) {
+      const dir = p === f ? '' : p.endsWith(`/${f}`) ? p.slice(0, -(f.length + 1)) : null;
+      if (dir !== null && !dirs.has(dir)) dirs.set(dir, f);
     }
   }
   if (dirs.size !== 1) return null;
@@ -197,6 +205,29 @@ export function packDeclaration<K extends RemediationCapabilityId>(
  *  exemption in refusals and plan output (one phrasing). */
 export function exemptionReason(pack: string, exemption: { reason: string }): string {
   return `the ${pack} pack declares this capability exempt: ${exemption.reason}`;
+}
+
+/**
+ * The Rule 20 gate for a remediation provider's spawns, decided BEFORE
+ * anything runs: the provider's declared `execution(cwd)` against the ONE
+ * environment probe, phrased by the ONE describer (the same disclosed-skip
+ * doctrine the correctness and custom-check runners apply). Null when the
+ * environment satisfies the requirement; a disclosed refusal otherwise, so
+ * an environment boundary reads as routing ("runs where windows is
+ * available"), never as a code failure.
+ */
+export function environmentRefusal(
+  what: string,
+  execution: (cwd: string) => ExecutionRequirement,
+  cwd: string,
+): Extract<RecipeOutcome, { kind: 'refused' }> | null {
+  const env = currentEnvironment();
+  const unmet = unmetRequirement(execution(cwd), env);
+  if (unmet === null) return null;
+  return {
+    kind: 'refused',
+    reason: `${what} cannot run in this environment: ${describeUnmetRequirement(unmet, env.host)}`,
+  };
 }
 
 /**

--- a/src/remediate/recipes/types.ts
+++ b/src/remediate/recipes/types.ts
@@ -38,6 +38,9 @@ export type RecipeOutcome =
       /** Disclosed side notes (a tolerated fallback that ran, an OSV
        *  pre-check that could not be reached). */
       readonly notes?: readonly string[];
+      /** How a human undoes the applied fix (an override-pin's declared
+       *  revert prose), rendered on the ledger's applied-order line. */
+      readonly revert?: string;
     }
   | {
       /** The recipe decided not to act. The reason is a full sentence a

--- a/src/remediate/work-orders/advisory-orders.ts
+++ b/src/remediate/work-orders/advisory-orders.ts
@@ -65,6 +65,7 @@ function evidenceOf(a: AdvisoryInput, expiresAt?: string): DepAdvisoryEvidence {
   return {
     type: 'dep-vuln',
     package: a.package,
+    ...(a.pack !== undefined ? { pack: a.pack } : {}),
     ...(a.installedVersion !== undefined ? { installedVersion: a.installedVersion } : {}),
     advisoryId: a.advisoryId,
     ...(a.fixedVersion !== undefined ? { fixedVersion: a.fixedVersion } : {}),

--- a/src/remediate/work-orders/planner.ts
+++ b/src/remediate/work-orders/planner.ts
@@ -12,7 +12,12 @@
  * (`floor-orders.ts`, `advisory-orders.ts`, `lint-orders.ts`).
  */
 import type { RichBaselineEntry } from '../../baseline/types';
-import { matchRecipe, RECIPE_REGISTRY, type RecipeDeclaration } from './recipes-registry';
+import {
+  matchPackExemption,
+  matchRecipe,
+  RECIPE_REGISTRY,
+  type RecipeDeclaration,
+} from './recipes-registry';
 import { floorOrders, type FloorFailureInput } from './floor-orders';
 import { advisoryOrders, type AdvisoryInput } from './advisory-orders';
 import { lintOrders, type CustomCheckEntry, type LintSource } from './lint-orders';
@@ -120,13 +125,19 @@ export interface PlannerOptions {
   readonly registry?: readonly RecipeDeclaration[];
 }
 
-/** The tier decision: `recipe` when a registry entry matches, else `agent`. */
+/** The tier decision: `recipe` when a registry entry matches, else `agent`.
+ *  An agent tier caused by a pack's DECLARED capability exemption carries
+ *  the exemption on the order, so the plan surface can say why the
+ *  deterministic tier was unavailable (disclosed, never silence). */
 export function assignTier(
   order: Draft,
   registry: readonly RecipeDeclaration[] = RECIPE_REGISTRY,
 ): WorkOrder {
-  const recipe = matchRecipe({ ...order, tier: 'agent' }, registry);
-  return recipe ? { ...order, tier: 'recipe', recipe: recipe.id } : { ...order, tier: 'agent' };
+  const probe: WorkOrder = { ...order, tier: 'agent' };
+  const recipe = matchRecipe(probe, registry);
+  if (recipe) return { ...order, tier: 'recipe', recipe: recipe.id };
+  const exemption = matchPackExemption(probe, registry);
+  return { ...order, tier: 'agent', ...(exemption ? { capabilityExemption: exemption } : {}) };
 }
 
 /** Baseline dep-vuln debt as an advisory input (identity + severity only;

--- a/src/remediate/work-orders/recipes-registry.ts
+++ b/src/remediate/work-orders/recipes-registry.ts
@@ -12,17 +12,35 @@
  * `WORK_ORDER_CLASSES`); the contract test pins that every declared recipe
  * id is named there and vice versa. `matches` is consulted only for orders
  * of the recipe's own class.
+ *
+ * Every ecosystem fact `matches` consults comes from the packs' declared
+ * `remediation` capabilities (Rule 6): which packs can pin, declare, resync
+ * or lint-fix is a registry read, never a hardcoded pack list. When a
+ * recipe declines an order BECAUSE its owning pack declares the capability
+ * exempt, `packExemption` names the pack and the declared reason so the
+ * planner can disclose it on the order (never a silent agent tier).
  */
 import { isProjectPathIdentity } from '../../languages/capabilities/correctness';
 import { getLanguage } from '../../languages';
 import type { LanguageId } from '../../languages/types';
-import { DECLARABLE_PACKS, executeDeclareDependency } from '../recipes/declare-dependency';
+import type { RemediationCapabilityId } from '../../languages/capabilities/remediation';
+import { executeDeclareDependency } from '../recipes/declare-dependency';
 import { executeLintAutofix, lintPackOf } from '../recipes/lint-autofix';
 import { executeLockfileSync } from '../recipes/lockfile-sync';
 import { executeOverridePin } from '../recipes/override-pin';
-import { isConcreteSemver, isValidNpmPackageName, owningManifestRoot } from '../recipes/shared';
+import {
+  isConcreteSemver,
+  owningManifestRoot,
+  packDeclaration,
+  resolvePinCapability,
+} from '../recipes/shared';
 import type { RecipeExecuteContext, RecipeOutcome } from '../recipes/types';
-import { WORK_ORDER_CLASSES, type WorkOrder, type WorkOrderClass } from './types';
+import {
+  WORK_ORDER_CLASSES,
+  type CapabilityExemption,
+  type WorkOrder,
+  type WorkOrderClass,
+} from './types';
 
 // ---------------------------------------------------------------------------
 // Feasibility predicates for `matches` (4.4.5 review): every fact knowable
@@ -33,11 +51,6 @@ import { WORK_ORDER_CLASSES, type WorkOrder, type WorkOrderClass } from './types
 // lockfile is present, whether the package is a direct dependency, what the
 // registry and OSV answer).
 // ---------------------------------------------------------------------------
-
-/** The envelope names exactly one owning package.json root. */
-function hasOneManifestRoot(order: WorkOrder): boolean {
-  return owningManifestRoot(order) !== null;
-}
 
 /** The producing pack, when every finding is floor evidence from one pack. */
 function floorPackOf(order: WorkOrder): string | null {
@@ -53,6 +66,25 @@ function lintFileOf(order: WorkOrder): string | null {
   return first && first.type === 'custom-check' && first.file ? first.file : null;
 }
 
+/** The lint pack behind a lint-located order's check name, or null. */
+function lintOrderPack(order: WorkOrder): string | null {
+  const first = order.findings[0]?.evidence;
+  return first && first.type === 'custom-check' ? lintPackOf(first.check) : null;
+}
+
+/** A pack's declared exemption for one capability, shaped for the order's
+ *  plan disclosure, or null when the pack declares a real provider (or the
+ *  pack cannot be resolved at all). */
+function exemptionOf(
+  pack: string | null,
+  capability: RemediationCapabilityId,
+): CapabilityExemption | null {
+  if (pack === null) return null;
+  const declaration = packDeclaration(pack, capability);
+  if (declaration === undefined || declaration.kind !== 'exemption') return null;
+  return { pack, capability, reason: declaration.reason };
+}
+
 export interface RecipeDeclaration {
   readonly id: string;
   /** The work-order class this recipe serves. */
@@ -64,7 +96,8 @@ export interface RecipeDeclaration {
    *  equal `execute !== undefined` (pinned by the contract test). */
   readonly implemented: boolean;
   /** Does this recipe apply to THIS order? Pure over the order's findings and
-   *  evidence (a recipe never inspects the repo at planning time). */
+   *  evidence plus the packs' declared capabilities (a recipe never inspects
+   *  the repo at planning time). */
   readonly matches: (order: WorkOrder) => boolean;
   /** The deterministic executor (4.4.5), present iff `implemented`. Runs
    *  inside the remediate frame through the injected bounded exec under the
@@ -78,6 +111,12 @@ export interface RecipeDeclaration {
    *  linter runs), and any slice's done criterion is checkable against
    *  the one result. */
   readonly groupKey?: (order: WorkOrder) => string | null;
+  /** OPTIONAL: when `matches` declines an order BECAUSE the owning pack
+   *  declares the needed remediation capability as an exemption, name the
+   *  pack, the capability, and the declared reason (the planner discloses
+   *  it on the order). Null when the declining reason is anything else
+   *  (a range-shaped version, an ambiguous root). Pure. */
+  readonly packExemption?: (order: WorkOrder) => CapabilityExemption | null;
 }
 
 /** The class a recipe id serves, from the one table. */
@@ -95,39 +134,56 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     class: classServedBy('lockfile-sync'),
     summary: "reinstall with the repo's package manager so the lockfile follows the manifest",
     implemented: true,
-    // The producing pack must declare the frozen dry-run this recipe
-    // verifies with, and the envelope must name one owning root.
+    // The producing pack must declare the resync capability (which rides its
+    // install strategy) plus the frozen dry-run this recipe verifies with,
+    // and the envelope must name one owning root under the pack's declared
+    // manifest basenames.
     matches: (order) => {
       const pack = floorPackOf(order);
+      if (pack === null || order.constraints.install === undefined) return false;
+      const declaration = packDeclaration(pack, 'resyncLockfile');
       return (
-        order.constraints.install !== undefined &&
-        hasOneManifestRoot(order) &&
-        pack !== null &&
+        declaration !== undefined &&
+        declaration.kind === 'capability' &&
+        owningManifestRoot(order, declaration.provider.manifestFiles) !== null &&
         getLanguage(pack as LanguageId)?.correctness?.lockfileCheck !== undefined
       );
     },
     execute: executeLockfileSync,
+    packExemption: (order) => exemptionOf(floorPackOf(order), 'resyncLockfile'),
   },
   {
     id: 'override-pin',
     class: classServedBy('override-pin'),
-    summary: 'pin a fixed version through a pm-aware override when no direct upgrade path exists',
+    summary:
+      'pin a fixed version through a pack-declared override when no direct upgrade path exists',
     implemented: true,
     // Needs a known CONCRETE fixed version for EVERY advisory in the order
-    // (a range-shaped fixed string cannot be pinned verbatim), one owning
-    // root, and an install command the frame can run; an advisory with no
-    // fix is agent (or human) territory.
-    matches: (order) =>
-      order.constraints.install !== undefined &&
-      hasOneManifestRoot(order) &&
-      order.findings.length > 0 &&
-      order.findings.every(
-        (f) =>
-          f.evidence.type === 'dep-vuln' &&
-          typeof f.evidence.fixedVersion === 'string' &&
-          isConcreteSemver(f.evidence.fixedVersion),
-      ),
+    // (a range-shaped fixed string cannot be pinned verbatim), an owning
+    // pack that declares the pin capability, one owning root under its
+    // manifests, and an install command the frame can run; an advisory with
+    // no fix is agent (or human) territory.
+    matches: (order) => {
+      if (order.constraints.install === undefined || order.findings.length === 0) return false;
+      const resolved = resolvePinCapability(order);
+      return (
+        resolved.kind === 'capability' &&
+        resolved.rootDir !== null &&
+        order.findings.every(
+          (f) =>
+            f.evidence.type === 'dep-vuln' &&
+            typeof f.evidence.fixedVersion === 'string' &&
+            isConcreteSemver(f.evidence.fixedVersion),
+        )
+      );
+    },
     execute: executeOverridePin,
+    packExemption: (order) => {
+      const resolved = resolvePinCapability(order);
+      return resolved.kind === 'exemption'
+        ? { pack: resolved.pack, capability: 'pinTransitive', reason: resolved.reason }
+        : null;
+    },
   },
   {
     id: 'declare-dependency',
@@ -135,32 +191,35 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     summary:
       'declare and install a bare import, refusing with the reason when the candidate carries a block-tier advisory',
     implemented: true,
-    // Every finding must carry an unresolved specifier that is a VALID npm
-    // package name. Bareness is a producer fact (the resolutionCheck
-    // contract): a project-path identity (leading `./`, the ONE canonical
-    // discriminator `isProjectPathIdentity`) names a missing FILE, which no
-    // install can declare; the strict name shape additionally keeps a
-    // flag-shaped specifier out of the recipe tier (the executor re-checks
-    // it as the injection rail). Pack support and the owning root are
-    // order-intrinsic too; the frame must hold the install command.
+    // Every finding must carry an unresolved specifier that passes the
+    // owning pack's declared specifier rail. Bareness is a producer fact
+    // (the resolutionCheck contract): a project-path identity (leading
+    // `./`, the ONE canonical discriminator `isProjectPathIdentity`) names
+    // a missing FILE, which no install can declare; the pack's name shape
+    // additionally keeps a flag-shaped specifier out of the recipe tier
+    // (the executor re-checks it as the injection rail). Pack support and
+    // the owning root are declaration reads; the frame must hold the
+    // install command.
     matches: (order) => {
       const pack = floorPackOf(order);
+      if (pack === null || order.constraints.install === undefined) return false;
+      const declaration = packDeclaration(pack, 'declareDependency');
+      if (declaration === undefined || declaration.kind !== 'capability') return false;
+      const provider = declaration.provider;
       return (
-        order.constraints.install !== undefined &&
-        hasOneManifestRoot(order) &&
-        pack !== null &&
-        DECLARABLE_PACKS.includes(pack) &&
+        owningManifestRoot(order, provider.manifestFiles) !== null &&
         order.findings.length > 0 &&
         order.findings.every(
           (f) =>
             f.evidence.type === 'floor' &&
             typeof f.evidence.specifier === 'string' &&
             !isProjectPathIdentity(f.evidence.specifier) &&
-            isValidNpmPackageName(f.evidence.specifier),
+            provider.validSpecifier(f.evidence.specifier),
         )
       );
     },
     execute: executeDeclareDependency,
+    packExemption: (order) => exemptionOf(floorPackOf(order), 'declareDependency'),
   },
   {
     id: 'lint-autofix',
@@ -169,17 +228,18 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     implemented: true,
     // Every finding must carry a rule (an unparsed diagnostic cannot be
     // scoped to a fixer) and the check must be a PACK lint gate whose pack
-    // declares a fix mode. Sliced orders ARE eligible: the grouped
-    // execution (groupKey) runs the file-level fix once for all of a
-    // file's slices and evaluates each slice's done individually. Which
-    // rules the fixer actually closes stays the executor's runtime verify.
+    // declares the lintFix capability (the rider over the lint gate's
+    // fixCommand, pinned consistent by the contract test). Sliced orders
+    // ARE eligible: the grouped execution (groupKey) runs the file-level
+    // fix once for all of a file's slices and evaluates each slice's done
+    // individually. Which rules the fixer actually closes stays the
+    // executor's runtime verify.
     matches: (order) => {
       if (order.findings.length === 0) return false;
-      const first = order.findings[0].evidence;
-      const pack = first.type === 'custom-check' ? lintPackOf(first.check) : null;
+      const pack = lintOrderPack(order);
       return (
         pack !== null &&
-        getLanguage(pack as LanguageId)?.lintGate?.fixCommand !== undefined &&
+        packDeclaration(pack, 'lintFix')?.kind === 'capability' &&
         order.findings.every(
           (f) => f.evidence.type === 'custom-check' && typeof f.evidence.rule === 'string',
         )
@@ -187,6 +247,7 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
     },
     execute: executeLintAutofix,
     groupKey: lintFileOf,
+    packExemption: (order) => exemptionOf(lintOrderPack(order), 'lintFix'),
   },
 ];
 
@@ -196,4 +257,19 @@ export function matchRecipe(
   registry: readonly RecipeDeclaration[] = RECIPE_REGISTRY,
 ): RecipeDeclaration | undefined {
   return registry.find((r) => r.class === order.class && r.matches(order));
+}
+
+/** The first declared pack exemption blocking a recipe of the order's
+ *  class, for the plan's disclosure (consulted only when no recipe
+ *  matched). */
+export function matchPackExemption(
+  order: WorkOrder,
+  registry: readonly RecipeDeclaration[] = RECIPE_REGISTRY,
+): CapabilityExemption | null {
+  for (const r of registry) {
+    if (r.class !== order.class || r.packExemption === undefined) continue;
+    const exemption = r.packExemption(order);
+    if (exemption !== null) return exemption;
+  }
+  return null;
 }

--- a/src/remediate/work-orders/render.ts
+++ b/src/remediate/work-orders/render.ts
@@ -153,7 +153,10 @@ export function renderWorkOrderSummary(order: WorkOrder): string {
   const tier =
     order.tier === 'recipe'
       ? `recipe ${order.recipe}${executable ? '' : ' (declared, not yet executable)'}`
-      : 'agent';
+      : order.capabilityExemption
+        ? `agent (no ${order.capabilityExemption.capability} recipe for the ` +
+          `${order.capabilityExemption.pack} pack: ${order.capabilityExemption.reason})`
+        : 'agent';
   const attribution = order.findings.some((f) => f.attribution === 'net-new')
     ? 'net-new'
     : order.findings.some((f) => f.attribution === 'deferred')

--- a/src/remediate/work-orders/types.ts
+++ b/src/remediate/work-orders/types.ts
@@ -112,6 +112,10 @@ export interface FloorEvidence {
 export interface DepAdvisoryEvidence {
   readonly type: 'dep-vuln';
   readonly package: string;
+  /** The producing language pack, when the finding's source records it
+   *  (live scans do; older baseline entries may not). What lets the
+   *  override-pin capability resolution name the owning pack directly. */
+  readonly pack?: string;
   readonly installedVersion?: string;
   readonly advisoryId: string;
   /** From the live scan when available; absent means "not known here". */
@@ -216,6 +220,21 @@ export interface WorkOrderBudget {
 
 export type WorkOrderTier = 'recipe' | 'agent';
 
+/**
+ * A pack's declared remediation exemption, surfaced on an agent-tier order
+ * of a recipe-served class: the deterministic fix exists as a recipe, but
+ * the owning pack declares the capability exempt (with the reason), so the
+ * order went to the agent tier. Disclosed in plan output, never silence
+ * (the DEFERRED_KINDS discipline).
+ */
+export interface CapabilityExemption {
+  readonly pack: string;
+  /** A remediation capability id (`resyncLockfile`, `pinTransitive`,
+   *  `declareDependency`, `lintFix`). */
+  readonly capability: string;
+  readonly reason: string;
+}
+
 export type WorkOrderProvenance =
   | { readonly source: 'entry-floor'; readonly check: string }
   | { readonly source: 'guardrail-blocking' }
@@ -262,6 +281,9 @@ export interface WorkOrder {
   readonly tier: WorkOrderTier;
   /** The matching recipe id when `tier` is `recipe`. */
   readonly recipe?: string;
+  /** Present on an agent-tier order whose class HAS a recipe but whose
+   *  owning pack declares the capability exempt (see the type). */
+  readonly capabilityExemption?: CapabilityExemption;
   /** The failing command's captured output tail, once per order (floor
    *  orders). Structured evidence lives on each finding. */
   readonly outputTail?: string;

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -1178,3 +1178,130 @@ describe('purlType declarations (SBOM export, Rule 6)', () => {
     expect(withoutPurl).toEqual(['abap', 'swift']);
   });
 });
+
+// ─── Remediation capabilities (4.4.7 V1) ────────────────────────────────────
+// Every pack answers every remediation capability: a well-formed provider
+// (pure, total, deterministic, machine-independent, the Rule 19/20
+// discipline) or a declared exemption with a real reason. Never a silent
+// omission. Rider capabilities are pinned to their underlying builders so
+// the two facts cannot drift (lintFix ⇔ lintGate.fixCommand; resyncLockfile
+// ⇒ installStrategy with a resync mode).
+describe('remediation capabilities: a provider or a reasoned exemption, per pack', () => {
+  const CAPABILITY_IDS = [
+    'resyncLockfile',
+    'pinTransitive',
+    'declareDependency',
+    'lintFix',
+  ] as const;
+
+  for (const lang of LANGUAGES) {
+    it(`${lang.id} declares all four capabilities, each a capability or an exemption with a reason`, () => {
+      expect(lang.remediation, `${lang.id}: remediation is required`).toBeDefined();
+      for (const id of CAPABILITY_IDS) {
+        const declaration = lang.remediation[id];
+        expect(declaration, `${lang.id}.${id}`).toBeDefined();
+        expect(['capability', 'exemption']).toContain(declaration.kind);
+        if (declaration.kind === 'exemption') {
+          expect(
+            declaration.reason.length,
+            `${lang.id}.${id}: an exemption carries a real reason`,
+          ).toBeGreaterThan(20);
+        }
+      }
+    });
+
+    it(`${lang.id}: the lintFix rider agrees with lintGate.fixCommand (one fact, two statements)`, () => {
+      const declared = lang.remediation.lintFix.kind === 'capability';
+      const hasBuilder = lang.lintGate?.fixCommand !== undefined;
+      expect(
+        declared,
+        `${lang.id}: lintFix ${declared ? 'declared without' : 'exempt despite'} a lintGate.fixCommand builder`,
+      ).toBe(hasBuilder);
+    });
+
+    it(`${lang.id}: a resyncLockfile capability rides a declared install strategy with a resync mode`, () => {
+      const declaration = lang.remediation.resyncLockfile;
+      if (declaration.kind !== 'capability') return;
+      expect(declaration.provider.manifestFiles.length).toBeGreaterThan(0);
+      for (const f of declaration.provider.manifestFiles) {
+        expect(f, `${lang.id}: manifest basenames only`).not.toContain('/');
+      }
+      expect(
+        lang.installStrategy,
+        `${lang.id}: resyncLockfile declared but no installStrategy to ride (Rule 2)`,
+      ).toBeDefined();
+      expect(
+        lang.installStrategy!.variants().some((v) => v.strategy.modes.resync !== undefined),
+        `${lang.id}: no variant declares a lock-writing resync`,
+      ).toBe(true);
+    });
+
+    it(`${lang.id}: a pinTransitive provider is well-formed, pure, total, machine-independent`, () => {
+      const declaration = lang.remediation.pinTransitive;
+      if (declaration.kind !== 'capability') return;
+      const p = declaration.provider;
+      expect(p.manifestFiles.length).toBeGreaterThan(0);
+      expect(p.osvEcosystem.length).toBeGreaterThan(0);
+      const req = p.execution(os.tmpdir());
+      expect(req.hosts.length).toBeGreaterThan(0);
+      for (const t of req.toolchains) expect(Object.keys(TOOLCHAIN_DEFS)).toContain(t);
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-remediation-pin-'));
+      try {
+        const ctx = { cwd: dir, rootDir: '', pkg: 'sample-pkg', version: '1.2.3' };
+        const first = p.plan(ctx);
+        const second = p.plan(ctx);
+        expect(first.kind).toBe(second.kind);
+        if (first.kind === 'refused') {
+          expect(first.reason.length).toBeGreaterThan(0);
+          expect(first.reason).not.toContain(dir);
+        } else {
+          expect(first.edit.file.length).toBeGreaterThan(0);
+          expect(first.edit.file).not.toContain('..');
+          expect(first.revert.length).toBeGreaterThan(0);
+          expect(first.revert).not.toContain(dir);
+          // The transform is TOTAL over untrusted manifest text: garbage
+          // refuses, it never throws.
+          for (const garbage of ['', 'not a manifest {', '42']) {
+            let out!: ReturnType<typeof first.edit.transform>;
+            expect(() => (out = first.edit.transform(garbage))).not.toThrow();
+            expect('text' in out || 'refused' in out).toBe(true);
+          }
+        }
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it(`${lang.id}: a declareDependency provider is well-formed, with a working injection rail`, () => {
+      const declaration = lang.remediation.declareDependency;
+      if (declaration.kind !== 'capability') return;
+      const p = declaration.provider;
+      expect(p.manifestFiles.length).toBeGreaterThan(0);
+      expect(p.osvEcosystem.length).toBeGreaterThan(0);
+      expect(p.packageNameLabel.length).toBeGreaterThan(0);
+      const req = p.execution(os.tmpdir());
+      expect(req.hosts.length).toBeGreaterThan(0);
+      for (const t of req.toolchains) expect(Object.keys(TOOLCHAIN_DEFS)).toContain(t);
+      // Rule 11: the rail must reject flag-shaped and malformed specifiers.
+      for (const bad of ['', '-x', '--registry=https://evil.example', 'a b', 'a\nb']) {
+        expect(p.validSpecifier(bad), `${lang.id}: validSpecifier(${JSON.stringify(bad)})`).toBe(
+          false,
+        );
+      }
+      const ctx = { cwd: os.tmpdir(), rootDir: '', specifier: 'sample-pkg' };
+      const probe = p.versionProbe(ctx);
+      expect(probe.bin.length).toBeGreaterThan(0);
+      expect(probe.args.join(' ')).not.toContain(os.tmpdir());
+      // parseProbeOutput is TOTAL: garbage yields null, never a throw.
+      for (const garbage of ['', 'npm error 404', '\n\n', 'not-a-version']) {
+        let out: string | null = null;
+        expect(() => (out = p.parseProbeOutput(garbage))).not.toThrow();
+        expect(out).toBeNull();
+      }
+      const install = p.installCommand({ ...ctx, version: '1.2.3', dev: true });
+      expect(install.bin.length).toBeGreaterThan(0);
+      expect(install.args.length).toBeGreaterThan(0);
+      expect(install.args.join(' ')).toContain('sample-pkg');
+    });
+  }
+});

--- a/test/languages/node-install.test.ts
+++ b/test/languages/node-install.test.ts
@@ -110,7 +110,9 @@ describe('nodeInstallStrategy.strategy', () => {
           expect(detectLockfile(dir)?.pm, `${file} detects as ${pm}`).toBe(pm);
           const s = nodeInstallStrategy.strategy(dir)!;
           expect(s.manager, `${file} installs with ${pm}`).toBe(pm);
-          expect(s).toBe(NODE_STRATEGY_BY_PM[pm]);
+          // The canonical per-PM strategy, with `lockfile` resolved to the
+          // spelling actually present (npm-shrinkwrap.json, bun.lockb).
+          expect(s).toEqual({ ...NODE_STRATEGY_BY_PM[pm], lockfile: file });
         } finally {
           rmSync(dir, { recursive: true, force: true });
         }
@@ -303,6 +305,45 @@ describe('the derived lockfile-sync check', () => {
       const c = lockfileCheckFromStrategy(NODE_STRATEGY_BY_PM[pm], defaultResolvedTolerances());
       expect(c?.kind).toBe('skipped');
       if (c?.kind === 'skipped') expect(c.reason).toContain('backstop');
+    }
+  });
+});
+
+describe('the picked strategy reports the lockfile actually present (4.4.7 review fix)', () => {
+  function lockRoot(files: string[]): string {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-node-lock-'));
+    for (const f of files) writeFileSync(join(dir, f), '');
+    return dir;
+  }
+
+  it('a shrinkwrap-only root reports npm-shrinkwrap.json, never the canonical basename', () => {
+    const dir = lockRoot(['package.json', 'npm-shrinkwrap.json']);
+    try {
+      const s = nodeInstallStrategy.strategy(dir);
+      expect(s?.manager).toBe('npm');
+      expect(s?.lockfile).toBe('npm-shrinkwrap.json');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a bun.lockb root reports bun.lockb (the same alternate-spelling class)', () => {
+    const dir = lockRoot(['package.json', 'bun.lockb']);
+    try {
+      const s = nodeInstallStrategy.strategy(dir);
+      expect(s?.manager).toBe('bun');
+      expect(s?.lockfile).toBe('bun.lockb');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('the canonical lockfile keeps the canonical answer', () => {
+    const dir = lockRoot(['package.json', 'package-lock.json']);
+    try {
+      expect(nodeInstallStrategy.strategy(dir)?.lockfile).toBe('package-lock.json');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -69,6 +69,7 @@ import {
   buildDevcontainerFeatures,
   detectActiveLanguages,
   dominantVocabulary,
+  collectExecutionRequirements,
 } from '../src/languages';
 import { runCorrectnessFloor } from '../src/analyzers/correctness/run';
 import { declareInstallStrategy } from '../src/languages/capabilities/install-strategy';
@@ -1907,6 +1908,9 @@ describe('recipe playbook: remediation capability seam (4.4.7 V1)', () => {
     expect(outcome.kind).toBe('applied');
     if (outcome.kind === 'applied') {
       expect(outcome.changedFiles).toEqual(['playbook.toml', 'playbook.lock']);
+      // The pack-declared revert prose rides the applied outcome into the
+      // ledger (the contract's promise, consumed, never inert).
+      expect(outcome.revert).toContain('remove the [pin."vuln-dep"] table');
     }
     // The pack's pure transform wrote the pin; the executor owned the write.
     const manifest = fs.readFileSync(path.join(cwd, 'playbook.toml'), 'utf8');
@@ -1948,6 +1952,62 @@ describe('recipe playbook: remediation capability seam (4.4.7 V1)', () => {
     const rendered = calls.map((c) => `${c.cmd.bin} ${c.cmd.args.join(' ')}`);
     expect(rendered).toContain('playbook-pm-mock install');
     expect(rendered).toContain('playbookc-mock lock --dry-run');
+  });
+
+  it('Rule 20 both directions: an unmet provider requirement is a DISCLOSED refusal BEFORE any spawn; met executes', async () => {
+    // Met => executes is pinned by the applied tests above (the declared
+    // hosts: ['any'] requirement passes on this runner). Unmet: swap the
+    // synthetic providers to a windows-only requirement and both executors
+    // must refuse with the ONE describeUnmetRequirement phrasing, spawning
+    // nothing; restore afterwards.
+    const remediation = mockPlaybookPack.remediation as {
+      pinTransitive: { provider: { execution: (cwd: string) => unknown } };
+      declareDependency: { provider: { execution: (cwd: string) => unknown } };
+    };
+    const savedPin = remediation.pinTransitive.provider.execution;
+    const savedDeclare = remediation.declareDependency.provider.execution;
+    const windowsOnly = () => ({
+      hosts: ['windows' as const],
+      toolchains: [],
+      needsBuild: true,
+      buildTarget: 'configured' as const,
+      weight: 'build' as const,
+    });
+    try {
+      remediation.pinTransitive.provider.execution = windowsOnly;
+      remediation.declareDependency.provider.execution = windowsOnly;
+      const cwd = tempRepo({ 'playbook.toml': '[package]\n', 'playbook.lock': '' });
+      const { exec, calls } = fakeExec();
+      const pin = await executeOverridePin(pinOrder(), makeCtx(cwd, { exec }));
+      expect(pin.kind).toBe('refused');
+      if (pin.kind === 'refused') {
+        expect(pin.reason).toContain('cannot run in this environment');
+        expect(pin.reason).toContain('needs windows');
+      }
+      const declare = await executeDeclareDependency(
+        declareOrder('leftpad'),
+        makeCtx(cwd, { exec }),
+      );
+      expect(declare.kind).toBe('refused');
+      if (declare.kind === 'refused') expect(declare.reason).toContain('needs windows');
+      // Decided BEFORE the spawn: no probe, no install, no resync ran.
+      expect(calls).toHaveLength(0);
+    } finally {
+      remediation.pinTransitive.provider.execution = savedPin;
+      remediation.declareDependency.provider.execution = savedDeclare;
+    }
+  });
+
+  it('collectExecutionRequirements carries the synthetic remediation requirements to placement (Rule 20)', () => {
+    const caps = collectExecutionRequirements(os.tmpdir(), [mockPlaybookPack]);
+    const ids = caps.map((c) => `${c.pack}:${c.capability}`);
+    expect(ids).toContain('playbook:pinTransitive');
+    expect(ids).toContain('playbook:declareDependency');
+    for (const c of caps) {
+      if (c.capability === 'pinTransitive' || c.capability === 'declareDependency') {
+        expect(c.requirement.hosts.length).toBeGreaterThan(0);
+      }
+    }
   });
 
   it('an exempt capability is a DISCLOSED executor refusal carrying the declared reason (never silence)', async () => {

--- a/test/recipe-playbook.test.ts
+++ b/test/recipe-playbook.test.ts
@@ -72,6 +72,22 @@ import {
 } from '../src/languages';
 import { runCorrectnessFloor } from '../src/analyzers/correctness/run';
 import { declareInstallStrategy } from '../src/languages/capabilities/install-strategy';
+import type { RemediationSupport } from '../src/languages/capabilities/remediation';
+import { assignTier } from '../src/remediate/work-orders/planner';
+import { renderWorkOrderSummary } from '../src/remediate/work-orders/render';
+import { executeOverridePin } from '../src/remediate/recipes/override-pin';
+import { executeDeclareDependency } from '../src/remediate/recipes/declare-dependency';
+import { executeLockfileSync } from '../src/remediate/recipes/lockfile-sync';
+import { executeLintAutofix } from '../src/remediate/recipes/lint-autofix';
+import {
+  advisoryFinding,
+  fakeExec,
+  floorFinding,
+  lintFinding,
+  makeCtx,
+  makeOrder,
+  tempRepo,
+} from './remediate/recipes/helpers';
 import { activeInstallStrategies, installStrategyProviders } from '../src/languages';
 import { ciInstallVariants, renderInstallDependenciesShell } from '../src/install/shell';
 import { defaultResolvedTolerances } from '../src/install/tolerances';
@@ -336,6 +352,66 @@ const mockPlaybookPack = {
     ],
     { ciDependencyInstall: true },
   ),
+  // Remediation-capability contribution (4.4.7 V1). Distinctive tokens
+  // (playbook.toml, PlaybookEco, playbook-reg-mock) so the assertions below
+  // prove the seam is pack-driven: the planner tiers this pack's orders
+  // through its declarations and the four cross-cutting executors consume
+  // its builders with no per-ecosystem wiring. `lintFix` is deliberately a
+  // declared EXEMPTION so the disclosure path is provable end to end.
+  remediation: {
+    resyncLockfile: { kind: 'capability', provider: { manifestFiles: ['playbook.toml'] } },
+    pinTransitive: {
+      kind: 'capability',
+      provider: {
+        manifestFiles: ['playbook.toml'],
+        osvEcosystem: 'PlaybookEco',
+        plan: (ctx) => ({
+          kind: 'plan',
+          edit: {
+            file: 'playbook.toml',
+            transform: (text) => ({
+              text: `${text}[pin."${ctx.pkg}"]\nversion = "${ctx.version}"\n`,
+            }),
+          },
+          revert: `remove the [pin."${ctx.pkg}"] table from playbook.toml and re-run the resync`,
+        }),
+        execution: () => ({
+          hosts: ['any' as const],
+          toolchains: [],
+          needsBuild: false,
+          buildTarget: 'none' as const,
+          weight: 'cheap' as const,
+        }),
+      },
+    },
+    declareDependency: {
+      kind: 'capability',
+      provider: {
+        manifestFiles: ['playbook.toml'],
+        osvEcosystem: 'PlaybookEco',
+        packageNameLabel: 'playbook package name',
+        validSpecifier: (spec: string) => /^[a-z][a-z0-9-]*$/.test(spec),
+        versionProbe: (ctx) => ({ bin: 'playbook-reg-mock', args: ['latest', ctx.specifier] }),
+        parseProbeOutput: (output: string) =>
+          /^\d+\.\d+\.\d+$/.test(output.trim()) ? output.trim() : null,
+        installCommand: (ctx) => ({
+          bin: 'playbook-pm-mock',
+          args: ['add', `${ctx.specifier}@${ctx.version}`, ...(ctx.dev ? ['--dev'] : [])],
+        }),
+        execution: () => ({
+          hosts: ['any' as const],
+          toolchains: [],
+          needsBuild: false,
+          buildTarget: 'none' as const,
+          weight: 'cheap' as const,
+        }),
+      },
+    },
+    lintFix: {
+      kind: 'exemption',
+      reason: 'the playbook mock linter has no reliable machine autofix to declare',
+    },
+  } satisfies RemediationSupport,
   detect: vi.fn(() => false),
   tools: [],
   semgrepRulesets: [],
@@ -1715,3 +1791,174 @@ function makeFakeConfig(opts: { playbook: boolean; playbookVersion?: string }) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 }
+
+// ─── Remediation capability seam (4.4.7 V1) ─────────────────────────────────
+// The synthetic pack declares all four remediation capabilities (lintFix as
+// a declared exemption). These assertions prove the whole seam is pack-
+// driven, both directions: the planner tiers the pack's orders RECIPE
+// through its declarations, the cross-cutting executors consume its
+// builders (edit transform, version probe, install command, install-
+// strategy resync) with no per-ecosystem wiring, and an exemption becomes
+// a DISCLOSED agent tier + a disclosed executor refusal, never silence.
+describe('recipe playbook: remediation capability seam (4.4.7 V1)', () => {
+  const PLAYBOOK_ENVELOPE = { paths: ['playbook.toml', 'playbook.lock'], manifests: true };
+  const PLAYBOOK_INSTALL = { bin: 'playbook-pm-mock', args: ['install', '--frozen'] };
+
+  function pinOrder() {
+    return makeOrder({
+      id: 'dep-advisory:vuln-dep',
+      class: 'dep-advisory',
+      findings: [
+        {
+          ...advisoryFinding('f1', 'vuln-dep', 'GHSA-pbk1', '2.0.1'),
+          evidence: {
+            type: 'dep-vuln' as const,
+            package: 'vuln-dep',
+            advisoryId: 'GHSA-pbk1',
+            fixedVersion: '2.0.1',
+            pack: 'playbook',
+          },
+        },
+      ],
+      envelope: PLAYBOOK_ENVELOPE,
+      constraints: { install: PLAYBOOK_INSTALL, forbidden: [] },
+    });
+  }
+
+  function declareOrder(specifier: string) {
+    return makeOrder({
+      id: 'unresolved-import:playbook:.',
+      class: 'unresolved-import',
+      findings: [
+        floorFinding(`playbook/import-resolution#${specifier}`, 'playbook', 'import-resolution', {
+          specifier,
+          importingFiles: ['src/a.pbk'],
+        }),
+      ],
+      envelope: { paths: ['src/a.pbk', ...PLAYBOOK_ENVELOPE.paths], manifests: true },
+      constraints: { install: PLAYBOOK_INSTALL, forbidden: [] },
+    });
+  }
+
+  function staleOrder() {
+    return makeOrder({
+      id: 'stale-lockfile:playbook',
+      class: 'stale-lockfile',
+      findings: [floorFinding('playbook/lockfile-sync', 'playbook', 'lockfile-sync')],
+      envelope: PLAYBOOK_ENVELOPE,
+      constraints: { install: PLAYBOOK_INSTALL, forbidden: [] },
+    });
+  }
+
+  function lintOrder() {
+    return makeOrder({
+      id: 'lint-located:src/a.pbk',
+      class: 'lint-located',
+      findings: [lintFinding('l1', 'lint:playbook', 'src/a.pbk', 'pbk-rule')],
+      envelope: { paths: ['src/a.pbk'], manifests: false },
+    });
+  }
+
+  it('the planner tiers the synthetic pack orders RECIPE through its declared capabilities', () => {
+    const { tier: pinTier, recipe: pinRecipe } = assignTier(pinOrder());
+    expect(pinTier).toBe('recipe');
+    expect(pinRecipe).toBe('override-pin');
+    const declared = assignTier(declareOrder('leftpad'));
+    expect(declared.tier).toBe('recipe');
+    expect(declared.recipe).toBe('declare-dependency');
+    const stale = assignTier(staleOrder());
+    expect(stale.tier).toBe('recipe');
+    expect(stale.recipe).toBe('lockfile-sync');
+  });
+
+  it('a specifier failing the PACK-declared rail tiers agent (the rail is pack-driven)', () => {
+    // Valid npm name, INVALID playbook name (uppercase): only the synthetic
+    // pack rail can reject it, so an agent tier proves the rail dispatch.
+    expect(assignTier(declareOrder('UpperCase')).tier).toBe('agent');
+  });
+
+  it('a declared lintFix EXEMPTION tiers agent WITH the reason on the order and in the plan line', () => {
+    const order = assignTier(lintOrder());
+    expect(order.tier).toBe('agent');
+    expect(order.capabilityExemption).toEqual({
+      pack: 'playbook',
+      capability: 'lintFix',
+      reason: 'the playbook mock linter has no reliable machine autofix to declare',
+    });
+    const line = renderWorkOrderSummary(order);
+    expect(line).toContain('no lintFix recipe for the playbook pack');
+    expect(line).toContain('no reliable machine autofix');
+  });
+
+  it('executeOverridePin consumes the pack edit transform, OSV ecosystem, and install-strategy resync', async () => {
+    const cwd = tempRepo({ 'playbook.toml': '[package]\nname = "fx"\n', 'playbook.lock': '' });
+    const { exec, calls } = fakeExec();
+    const ecosystems: string[] = [];
+    const outcome = await executeOverridePin(
+      pinOrder(),
+      makeCtx(cwd, {
+        exec,
+        queryOsv: async (_pkg, _version, ecosystem) => {
+          ecosystems.push(ecosystem);
+          return [];
+        },
+      }),
+    );
+    expect(outcome.kind).toBe('applied');
+    if (outcome.kind === 'applied') {
+      expect(outcome.changedFiles).toEqual(['playbook.toml', 'playbook.lock']);
+    }
+    // The pack's pure transform wrote the pin; the executor owned the write.
+    const manifest = fs.readFileSync(path.join(cwd, 'playbook.toml'), 'utf8');
+    expect(manifest).toContain('[pin."vuln-dep"]');
+    expect(manifest).toContain('version = "2.0.1"');
+    // The OSV pre-check ran in the PACK's declared ecosystem.
+    expect(ecosystems).toEqual(['PlaybookEco']);
+    // The resync ran the pack's install-strategy resync primary (the ONE
+    // install seam), at the owning root.
+    expect(calls.map((c) => `${c.cmd.bin} ${c.cmd.args.join(' ')}`)).toContain(
+      'playbook-pm-mock install',
+    );
+  });
+
+  it('executeDeclareDependency consumes the pack probe, parser, and install command', async () => {
+    const cwd = tempRepo({ 'playbook.toml': '[package]\n', 'playbook.lock': '' });
+    const { exec, calls } = fakeExec((cmd) => {
+      if (cmd.bin === 'playbook-reg-mock') return { output: '1.4.0\n' };
+      return undefined;
+    });
+    const outcome = await executeDeclareDependency(declareOrder('leftpad'), makeCtx(cwd, { exec }));
+    // The mock resolutionCheck reports only its own distinctive phantom
+    // specifier unresolved, so the order's specifier verifies as resolved.
+    expect(outcome.kind).toBe('applied');
+    if (outcome.kind === 'applied') {
+      expect(outcome.changedFiles).toEqual(['playbook.toml', 'playbook.lock']);
+    }
+    const rendered = calls.map((c) => `${c.cmd.bin} ${c.cmd.args.join(' ')}`);
+    expect(rendered).toContain('playbook-reg-mock latest leftpad');
+    expect(rendered).toContain('playbook-pm-mock add leftpad@1.4.0');
+  });
+
+  it('executeLockfileSync resyncs through the pack install strategy and verifies with its lockfileCheck', async () => {
+    const cwd = tempRepo({ 'playbook.toml': '[package]\n', 'playbook.lock': '' });
+    const { exec, calls } = fakeExec();
+    const outcome = await executeLockfileSync(staleOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('applied');
+    if (outcome.kind === 'applied') expect(outcome.changedFiles).toEqual(['playbook.lock']);
+    const rendered = calls.map((c) => `${c.cmd.bin} ${c.cmd.args.join(' ')}`);
+    expect(rendered).toContain('playbook-pm-mock install');
+    expect(rendered).toContain('playbookc-mock lock --dry-run');
+  });
+
+  it('an exempt capability is a DISCLOSED executor refusal carrying the declared reason (never silence)', async () => {
+    const cwd = tempRepo({ 'src/a.pbk': '' });
+    const { exec, calls } = fakeExec();
+    const outcome = await executeLintAutofix(lintOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') {
+      expect(outcome.reason).toContain('playbook');
+      expect(outcome.reason).toContain('no reliable machine autofix');
+    }
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/test/remediate/orders-phase.test.ts
+++ b/test/remediate/orders-phase.test.ts
@@ -571,6 +571,33 @@ describe('ledger honesty for the recipe section', () => {
     expect(ledger).toContain('Recipes are disabled by policy');
     expect(ledger).toContain('gather exploded');
   });
+
+  it("an applied record's revert prose reaches the ledger line (the pack-declared undo)", () => {
+    const ledger = renderRemediateLedger({
+      outcome: 'no-op',
+      task: 'fix-build',
+      recipes: {
+        ran: true,
+        disclosures: [],
+        selectedRecipeTier: 1,
+        selectedAgentTier: 0,
+        records: [
+          {
+            orderId: 'dep-advisory:js-yaml',
+            class: 'dep-advisory',
+            recipe: 'override-pin',
+            outcome: {
+              kind: 'applied',
+              changedFiles: ['package.json', 'package-lock.json'],
+              revert: 'remove the "overrides" entry for \'js-yaml\' from package.json',
+            },
+          },
+        ],
+      },
+    });
+    expect(ledger).toContain('APPLIED, changed package.json, package-lock.json');
+    expect(ledger).toContain('To revert: remove the "overrides" entry for \'js-yaml\'');
+  });
 });
 
 describe('the per-order done disclosure', () => {

--- a/test/remediate/recipes/lockfile-sync.test.ts
+++ b/test/remediate/recipes/lockfile-sync.test.ts
@@ -89,6 +89,17 @@ describe('lockfile-sync recipe', () => {
     if (outcome.kind === 'refused') expect(outcome.reason).toContain('exactly one package.json');
   });
 
+  it('a shrinkwrap-only root reports npm-shrinkwrap.json in changedFiles (4.4.7 review fix)', async () => {
+    const cwd = tempRepo({ 'package.json': PKG, 'npm-shrinkwrap.json': '{}' });
+    const { exec } = fakeExec();
+    const outcome = await executeLockfileSync(
+      staleOrder(['package.json', 'npm-shrinkwrap.json']),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('applied');
+    if (outcome.kind === 'applied') expect(outcome.changedFiles).toEqual(['npm-shrinkwrap.json']);
+  });
+
   it('refuses a pack with no lockfile-sync check to verify with', async () => {
     const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
     const { exec } = fakeExec();

--- a/test/remediate/recipes/override-pin.test.ts
+++ b/test/remediate/recipes/override-pin.test.ts
@@ -61,6 +61,17 @@ describe('override-pin recipe', () => {
     }
   });
 
+  it('the applied outcome carries the pack-declared revert prose (rendered in the ledger)', async () => {
+    const cwd = tempRepo({ 'package.json': PKG + '\n', 'package-lock.json': '{}' });
+    const { exec } = fakeExec();
+    const outcome = await executeOverridePin(pinOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('applied');
+    if (outcome.kind === 'applied') {
+      expect(outcome.revert).toContain('remove the "overrides" entry for \'js-yaml\'');
+      expect(outcome.revert).toContain('package.json');
+    }
+  });
+
   it('REFUSES with the advisory named when the pin itself carries a block-tier vuln ($0, tree untouched)', async () => {
     const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
     const { exec, calls } = fakeExec();

--- a/test/remediate/recipes/shared.test.ts
+++ b/test/remediate/recipes/shared.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The shared owning-root derivation: pack-declared basenames drive it, and
+ * when a pack declares SEVERAL basenames that sit at one root, the
+ * first-declared one wins deterministically (declaration order is the
+ * provider contract's preference order); envelope order never decides.
+ * The class this pins ahead of the multi-manifest pack fills: a python
+ * provider declaring ['pyproject.toml', 'requirements.txt'] must report
+ * the same file whichever order the planner listed the envelope in.
+ */
+import { describe, it, expect } from 'vitest';
+import { owningManifestEntry, owningManifestRoot } from '../../../src/remediate/recipes/shared';
+import { makeOrder } from './helpers';
+
+function orderWithPaths(paths: string[]) {
+  return makeOrder({
+    id: 'dep-advisory:x',
+    class: 'dep-advisory',
+    envelope: { paths, manifests: true },
+  });
+}
+
+describe('owningManifestEntry (pack-declared basenames, declaration-order preference)', () => {
+  const FILES = ['pyproject.toml', 'requirements.txt'];
+
+  it('two declared basenames at ONE root resolve to the first-declared, regardless of envelope order', () => {
+    const forward = orderWithPaths(['pyproject.toml', 'requirements.txt']);
+    const reversed = orderWithPaths(['requirements.txt', 'pyproject.toml']);
+    expect(owningManifestEntry(forward, FILES)).toEqual({ dir: '', file: 'pyproject.toml' });
+    expect(owningManifestEntry(reversed, FILES)).toEqual({ dir: '', file: 'pyproject.toml' });
+    // Nested root, same rule.
+    const nested = orderWithPaths(['app/requirements.txt', 'app/pyproject.toml']);
+    expect(owningManifestEntry(nested, FILES)).toEqual({ dir: 'app', file: 'pyproject.toml' });
+  });
+
+  it('only the second-declared basename present still resolves (preference, not exclusion)', () => {
+    const order = orderWithPaths(['requirements.txt', 'src/a.py']);
+    expect(owningManifestEntry(order, FILES)).toEqual({ dir: '', file: 'requirements.txt' });
+  });
+
+  it('two distinct roots stay ambiguous (null), whatever basenames matched', () => {
+    const order = orderWithPaths(['pyproject.toml', 'sub/requirements.txt']);
+    expect(owningManifestEntry(order, FILES)).toBeNull();
+    expect(owningManifestRoot(order, FILES)).toBeNull();
+  });
+});

--- a/test/remediate/work-orders/recipes.test.ts
+++ b/test/remediate/work-orders/recipes.test.ts
@@ -191,7 +191,17 @@ describe('order-intrinsic feasibility lives in matches (an executor-certain refu
   it('declare-dependency: an unsupported pack or a flag-shaped specifier tiers agent', () => {
     const ok = { id: 'unresolved-import:typescript:.', class: 'unresolved-import' as const };
     expect(tierOf({ ...ok, findings: [floorFinding('typescript', 'left-pad')] })).toBe('recipe');
-    expect(tierOf({ ...ok, findings: [floorFinding('python', 'requests')] })).toBe('agent');
+    // A pack whose declaration is a (planned) exemption tiers agent AND the
+    // order carries the declared reason for the plan surface (4.4.7 V1).
+    const python = assignTier({
+      ...draftBase,
+      ...ok,
+      findings: [floorFinding('python', 'requests')],
+    });
+    expect(python.tier).toBe('agent');
+    expect(python.capabilityExemption?.pack).toBe('python');
+    expect(python.capabilityExemption?.capability).toBe('declareDependency');
+    expect(python.capabilityExemption?.reason).toContain('python');
     expect(tierOf({ ...ok, findings: [floorFinding('typescript', '--registry=https://x')] })).toBe(
       'agent',
     );

--- a/test/scaffold-language.test.ts
+++ b/test/scaffold-language.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The scaffold-compile pin (4.4.7 review fix): `npm run new-lang` must emit
+ * a pack that COMPILES against the real LanguageSupport contract. The class
+ * this closes: a field going REQUIRED on the contract (correctness in 4.2,
+ * remediation in 4.4.7) without the scaffolder learning it, so every future
+ * `new-lang` emitted a pack that failed to compile and the recipe's
+ * "dormant but compiling" promise silently broke.
+ *
+ * Mechanics: the scaffolder honors DXKIT_SCAFFOLD_ROOT (its test seam), so
+ * this test runs it against a temp copy of `src/` (the scaffolder extends
+ * the copied `LanguageId` union and registry in place), then typechecks the
+ * emitted pack file with the repo's compiler settings. The pack's relative
+ * imports resolve through the copied tree, so the check is against the real
+ * types, not stubs.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { createRequire } from 'module';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const REPO = path.resolve(__dirname, '..');
+// tsc's bin, resolved the way node would from the repo (a git worktree may
+// share the parent checkout's hoisted node_modules, so no path is assumed).
+const TSC = createRequire(path.join(REPO, 'package.json')).resolve('typescript/bin/tsc');
+// The node_modules that resolution actually found, derived from tsc's own
+// location; symlinked into the temp root so the copied tree's bare imports
+// (the SDK bridge, jsonc-parser) typecheck exactly as they do in the repo.
+const NODE_MODULES = path.resolve(TSC, '..', '..', '..');
+
+describe('scaffold-language emits a compiling pack', () => {
+  it('a scaffolded pack declares remediation and typechecks against the real contract', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-scaffold-'));
+    try {
+      fs.cpSync(path.join(REPO, 'src'), path.join(root, 'src'), { recursive: true });
+      fs.symlinkSync(NODE_MODULES, path.join(root, 'node_modules'));
+      fs.writeFileSync(path.join(root, 'CHANGELOG.md'), '# Changelog\n\n## [Unreleased]\n\n');
+      execFileSync(
+        process.execPath,
+        [path.join(REPO, 'scripts', 'scaffold-language.js'), 'zetalang', 'Zeta Lang'],
+        { env: { ...process.env, DXKIT_SCAFFOLD_ROOT: root }, stdio: 'pipe' },
+      );
+      const pack = path.join(root, 'src', 'languages', 'zetalang.ts');
+      expect(fs.existsSync(pack)).toBe(true);
+      const packSrc = fs.readFileSync(pack, 'utf8');
+      // The remediation field is REQUIRED: the scaffold wires the dormant
+      // (planned-exemption) declaration plus its import.
+      expect(packSrc).toContain("remediation: plannedRemediationSupport('zetalang')");
+      expect(packSrc).toContain(
+        "import { plannedRemediationSupport } from './capabilities/remediation';",
+      );
+      // The scaffolder extended the copied union, so `id: 'zetalang'` types.
+      const types = fs.readFileSync(path.join(root, 'src', 'types.ts'), 'utf8');
+      expect(types).toMatch(/LanguageId[^;]*'zetalang'/);
+      // Typecheck the emitted pack with the repo's compiler settings; the
+      // relative-import closure is the copied real contract.
+      execFileSync(
+        process.execPath,
+        [
+          TSC,
+          '--noEmit',
+          '--strict',
+          '--target',
+          'ES2022',
+          '--module',
+          'commonjs',
+          '--lib',
+          'ES2022',
+          '--esModuleInterop',
+          '--skipLibCheck',
+          '--resolveJsonModule',
+          '--forceConsistentCasingInFileNames',
+          pack,
+        ],
+        { stdio: 'pipe' },
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+});


### PR DESCRIPTION
## What

The remediation capability seam plus the executor inversion (4.4.7 V1, the "architectural move" of the language-parity design). Before this, the four deterministic recipes hardcoded the node ecosystem: npm `overrides` syntax and the direct-dependency check lived inside `override-pin`, `npm view` and `upgradeArgv` inside `declare-dependency`, and `nodeStrategyAt`/`detectLockfile` inside the recipe shared helpers, so only TypeScript repos could ever get the recipe tier and a second ecosystem would have forked the refusal taxonomy.

Now every ecosystem fact is a pack declaration, and the executors are cross-cutting:

- New REQUIRED `LanguageSupport.remediation` (`src/languages/capabilities/remediation.ts`), one declaration per recipe capability, each a provider or a reasoned exemption (the DEFERRED_KINDS discipline, never silence):
  - `resyncLockfile`: declares only the owning-root manifest basenames; the resync command rides the pack's existing `installStrategy` and the verify rides `correctness.lockfileCheck` (Rule 2, never a second install path).
  - `pinTransitive`: manifest basenames, the OSV ecosystem, and a pure `plan(ctx)` yielding a pure manifest text transform plus revert prose (the executor owns the file read/write; a direct dependency or an unimplemented override mechanism refuses with the reason).
  - `declareDependency`: the specifier validity rail (Rule 11), the registry version probe plus its total output parser, and the install command; `execution(cwd)` per Rule 20 on both providers.
  - `lintFix`: a rider over the existing `lintGate.fixCommand`, folded into the exemption discipline and pinned consistent by the contract test.
- The node knowledge moved into `src/languages/node-remediation.ts` (the ts pack declares all four). The other ten packs carry declared exemptions: nine "planned" (the later language-parity units of this release fill them), ABAP a permanent reasoned set (no package manager, no registry, no autofix).
- Executor inversion: `override-pin`, `declare-dependency`, `lockfile-sync`, and `lint-autofix` keep only ecosystem-free logic (OSV pre-check, envelope, refusal taxonomy, verification through the existing seams) and consume the pack builders through the registry. `recipes/shared.ts` lost every node import; the ONE capability resolution (`resolvePinCapability`, `packDeclaration`, `owningManifestRoot` over pack-declared basenames) is shared by the registry's `matches`, the plan disclosure, and the executors (Rule 2.30).
- Planner awareness: when a recipe declines an order because the owning pack declares the capability exempt, the order tiers agent and carries `capabilityExemption { pack, capability, reason }`, rendered on the plan summary line. `DepAdvisoryEvidence` now records the producing `pack` so dependency-advisory orders resolve their owning pack directly.
- Arch-check: two new rules ban package-manager binary literals and ecosystem module imports inside `src/remediate/recipes/` and the recipe registry (`// recipe-ecosystem-ok` escape), verified to bite.

## Behavior parity on TypeScript repos

Through the inversion commits, the four executor test files (`override-pin.test.ts`, `declare-dependency.test.ts`, `lockfile-sync.test.ts`, `lint-autofix.test.ts`) were the byte-untouched parity pin: same fixtures, same outcomes, with the npm knowledge now supplied by the ts pack instead of the executors. `test/remediate/work-orders/recipes.test.ts` was modified (assertion-strengthening: the exemption disclosure). The review round then added NEW test cases to two executor files (the shrinkwrap changedFiles pin, the revert threading) without changing any pre-existing assertion.

## How it is tested

- `test/languages-contract.test.ts`: per pack, all four declarations present (capability or exemption with a real reason); the lintFix rider pinned to `fixCommand` in both directions; `resyncLockfile` pinned to an installStrategy with a resync mode; providers well-formed, pure, total, deterministic, machine-independent; the Rule 11 rail rejects flag-shaped specifiers; transforms and parsers total over garbage.
- `test/recipe-playbook.test.ts`: the synthetic pack declares all four (lintFix deliberately exempt). The planner tiers its orders recipe through the declarations; a specifier failing only the synthetic rail tiers agent (rail dispatch proven); all four executors consume the synthetic builders end to end (edit transform written by the executor, OSV queried in the declared ecosystem, resync through the synthetic install strategy, probe/install commands verbatim); the exemption surfaces both as a disclosed agent tier with the reason on the order and plan line AND as a disclosed executor refusal at zero spend.
- Existing suites: full `test/remediate/` (501 tests), contract (472), playbook (57) green.

## Sweep

- typecheck + typecheck:test: green
- eslint --max-warnings 0: green
- prettier --check: green
- check-architecture.sh: green (new rules verified to bite on an injected literal)
- check-docs-coverage.sh: green
- check-slop.sh (base origin/main): green (pre-existing advisory size notes only)
- build: green
- vitest --coverage: 422 files / 6436 tests, all green; check-coverage.sh: 75.04% (threshold 50%), green
- guardrail check (ref-based vs origin/main): PASSED, exit 0 (0 blocking, 88 persisted pairs)

## Review focus

- The capability contract shapes in `src/languages/capabilities/remediation.ts`: are the provider surfaces the right granularity for the upcoming pack fills (python constraints files, cargo precise pins), and is the pure-transform edit model acceptable for non-JSON manifests?
- `resolvePinCapability` in `src/remediate/recipes/shared.ts`: the evidence-pack-first, registry-fallback resolution and its `unknown` refusals.
- The parity claim: `test/remediate/recipes/override-pin.test.ts`, `declare-dependency.test.ts`, `lockfile-sync.test.ts` are byte-unchanged and green.

Deliberately out of scope (per the unit brief): implementing the other packs' capabilities (V2/V3), the scaffold wiring and the generated coverage table (V4), and any SDK exposure of these contracts (Rule 18: internal pack contracts, kept out of packages/dxkit-sdk).

## Review fixes (second push, same branch)

1. The `new-lang` scaffold now emits `remediation: plannedRemediationSupport('<id>')` plus its import (dormant but compiling, TODOs for the author), and a new scaffold-compile pin (`test/scaffold-language.test.ts`) runs the scaffolder against a temp copy of `src/` and typechecks the emitted pack against the real contract. Verified to bite (removing the field fails the test at the tsc leg).
2. The declared-but-inert contract fields are consumed: both the pin and declare executors gate on `unmetRequirement` via the shared `environmentRefusal` (one Rule 20 phrasing, decided before any spawn), `collectExecutionRequirements` now collects `pinTransitive` / `declareDependency` so placement sees them, and the pin plan's `revert` prose rides the applied outcome onto the ledger's applied-order line. Pinned via the synthetic pack in both directions (unmet refuses with zero spawns; met executes) plus a collector-pickup test and a ledger render test.
3. Shrinkwrap parity: the node strategy pick resolves the present lockfile through the one detector, so a shrinkwrap-only (or `bun.lockb`) root reports the file its installs rewrite. Pinned at the strategy level and in the lockfile-sync recipe's `changedFiles`.
4. `owningManifestEntry` prefers the first-declared basename per root (declaration order is the provider contract's documented preference order); pinned with both envelope orders and the two-root ambiguity case.
5. The recipe ecosystem-literal arch rule also matches backtick template literals now (verified to bite on an injected template string; the annotation escape stands).
6. This body's parity statement corrected (above).

Review-round sweep: full suite 424 files / 6448 tests green (plain and under coverage), coverage 75.07% (threshold 50%), typecheck src+test, eslint, prettier, arch-check, docs coverage, slop check all green; guardrail ref-based vs origin/main PASSED exit 0 (0 blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

