### PR TITLE
feat(impact): projected + actual dimension scores on the PR surface (4.4.7 I2)

### DIFF
--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -414,7 +414,12 @@ same comment with the actual movement beside the projection.
 (measured around 20ms) plus one shallow fetch of the reports ref. Set
 `false` to drop the projection line and the snapshot read. With no snapshot
 history (reports.onMerge off), the section discloses that no projection was
-made instead of inventing a base.
+made instead of inventing a base. On a ref-based repo the projection is
+structurally unavailable (that mode gathers a trimmed analysis every run), so
+the JSON carries the disclosure quietly and no line is printed per PR. Scores
+are also compared only when the tools behind them match: a snapshot captured
+with a scanner this run lacks (or the reverse) is disclosed as not comparable
+rather than diffed.
 
 ## Graph refresh
 

--- a/docs/configuration/policy-guide.md
+++ b/docs/configuration/policy-guide.md
@@ -33,6 +33,7 @@ stanzas).
 | `flow.mode`                         | [#flow-mode](#flow-mode)                                 |
 | `flow.sources`                      | [#flow-sources](#flow-sources)                           |
 | `graph.refresh`                     | [#graph-refresh](#graph-refresh)                         |
+| `impact.projectScores`              | [#impact-projection](#impact-projection)                 |
 | `licenses.prohibited`               | [#prohibited-licenses](#prohibited-licenses)             |
 | `lint.blocking`                     | [#lint-gate](#lint-gate)                                 |
 | `lint.enabled`                      | [#lint-gate](#lint-gate)                                 |
@@ -397,6 +398,23 @@ on; a notification that could not be posted must never fail a baseline capture.
 every merge — the score-over-time series `vyuh-dxkit metrics` renders.
 
 **Default and why.** Off; enabling installs a managed workflow (`update`).
+
+## Impact projection
+
+**What it does.** `impact.projectScores` controls the projected score line in
+the guardrail PR comment's Impact section ("security 40 -> 46 (projected)").
+The current side is scored from the analysis the guardrail run already
+gathered (never a second gather); the base side is the latest published
+snapshot on the reports ref (the number the org has already seen). The two
+are compared only under the same scoring-methodology version; a mismatch is
+disclosed as not comparable. After the merge, the reports lane updates the
+same comment with the actual movement beside the projection.
+
+**Default and why.** On (`true`): the marginal cost is a cache-hit re-score
+(measured around 20ms) plus one shallow fetch of the reports ref. Set
+`false` to drop the projection line and the snapshot read. With no snapshot
+history (reports.onMerge off), the section discloses that no projection was
+made instead of inventing a base.
 
 ## Graph refresh
 

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -2081,7 +2081,7 @@ fi
 RULE_RECIPE_PM_TOKENS='npm|npx|pnpm|yarn|bun|pip|pip3|poetry|uv|bundler?|gem|composer|cargo|dotnet|nuget|mvn|gradle|gradlew|swift'
 RULE_RECIPE_PM_LITERAL=$({ \
   grep -rnE "'(${RULE_RECIPE_PM_TOKENS})'" src/remediate/recipes/ src/remediate/work-orders/recipes-registry.ts 2>/dev/null; \
-  grep -rnE "`[^`]*(^|[^a-zA-Z0-9_-])(${RULE_RECIPE_PM_TOKENS})([^a-zA-Z0-9_-]|$)" src/remediate/recipes/ src/remediate/work-orders/recipes-registry.ts 2>/dev/null; \
+  grep -rnE "\`[^\`]*(^|[^a-zA-Z0-9_-])(${RULE_RECIPE_PM_TOKENS})([^a-zA-Z0-9_-]|$)" src/remediate/recipes/ src/remediate/work-orders/recipes-registry.ts 2>/dev/null; \
 } | grep -E '\.ts:' | grep -v -E ':[[:space:]]*(//|\*)' | grep -v "// recipe-ecosystem-ok" | sort -u)
 if [ -n "$RULE_RECIPE_PM_LITERAL" ]; then
   echo "❌ Remediation-seam violation: package-manager literal inside the recipe executors:"

--- a/src-templates/.github/workflows/dxkit-reports-refresh.yml
+++ b/src-templates/.github/workflows/dxkit-reports-refresh.yml
@@ -23,8 +23,13 @@ on:
 # `contents: write` is required to push the snapshot to the `dxkit-reports` side
 # ref (never the default branch). The ambient checkout token authenticates the
 # push; the shared anchor writer uses git plumbing, so no branch is checked out.
+# `pull-requests: write` lets the snapshot step update the merged PR's existing
+# guardrail comment with the landed (actual) scores beside the projection it
+# carried. Optional in effect: without the scope the update degrades to a
+# disclosed skip in the step summary and the snapshot still publishes.
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   reports:
@@ -60,10 +65,15 @@ __DXKIT_CI_RUNTIME_SETUP__
           fi
 
       - name: Generate reports + publish the snapshot
-        # No token env needed: the side-ref push authenticates with the credential
-        # actions/checkout already persists (`contents: write` above + the default
+        # The side-ref push authenticates with the credential actions/checkout
+        # already persists (`contents: write` above + the default
         # `persist-credentials: true`). The internal push runs with `--no-verify`
         # so it never fires this repo's own pre-push guardrail hook (dxkit #156).
+        # GH_TOKEN is for the --pr-comment step only (gh api); if the token lacks
+        # `pull-requests: write` the comment update reports a disclosed skip in
+        # the step summary and the job stays green.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -x ./node_modules/.bin/vyuh-dxkit ]; then
             DXKIT=./node_modules/.bin/vyuh-dxkit
@@ -74,8 +84,11 @@ __DXKIT_CI_RUNTIME_SETUP__
           # `report snapshot` maps the scores to a history entry and publishes the
           # appended report-history.jsonl + latest/ dashboard to the dxkit-reports
           # ref. Anchor ref + retention come from .dxkit/policy.json:reports.
+          # --pr-comment then updates the merged PR's guardrail comment with
+          # "Landed: <dim> A -> B (actual; projection was P)": the same comment,
+          # never a new one; every failure is a disclosed skip, never a red job.
           "${DXKIT}" report
-          "${DXKIT}" report snapshot
+          "${DXKIT}" report snapshot --pr-comment
 
       - name: Score-over-time job summary
         # Read the freshly-published trend back off the dxkit-reports ref and

--- a/src/analyzers/cache.ts
+++ b/src/analyzers/cache.ts
@@ -224,6 +224,38 @@ export function clearInMemoryCache(): void {
   inMemoryCache.clear();
 }
 
+/**
+ * Return the shared `AnalysisResult` for this tree WITHOUT ever building one:
+ * the in-memory entry a full-scope gather in this process left behind, or the
+ * disk entry for a clean tree. `null` when nothing full covers the tree: a
+ * scoped/partial gather (a ref-based guardrail's trimmed scope) bypasses the
+ * shared cache by design, so it never shows up here.
+ *
+ * This is the availability probe the score projection (impact surface P2)
+ * uses: projecting dimension scores after a guardrail run must reuse the
+ * envelope that run already gathered (Rule 2) or honestly decline. Building
+ * here would silently pay a full re-gather (measured at 80+ seconds on a
+ * large tree) inside a surface that promised to be free.
+ */
+export async function peekAnalysisResult(
+  cwd: string,
+  opts?: Pick<ReadOrBuildOptions, 'resolveProvenance' | 'cacheDir'>,
+): Promise<AnalysisResult | null> {
+  const provenance = (opts?.resolveProvenance ?? resolveProvenance)(cwd);
+  const inMemory = inMemoryCache.get(buildCacheKey(provenance));
+  if (inMemory) {
+    try {
+      return await inMemory;
+    } catch {
+      return null; // a failed build is not a usable envelope
+    }
+  }
+  if (!provenance.workingTreeDirty) {
+    return readDiskCache(opts?.cacheDir ?? path.join(provenance.cwd, CACHE_SUBDIR), provenance);
+  }
+  return null;
+}
+
 // ─── Internals ────────────────────────────────────────────────────────────
 
 function buildCacheKey(p: ResolvedProvenance): string {

--- a/src/baseline/check-renderers.ts
+++ b/src/baseline/check-renderers.ts
@@ -70,6 +70,11 @@ import {
   formatImpactQuietLine,
 } from './impact';
 import type { ImpactScoreInput, ImpactSummary } from './impact';
+import {
+  formatScoreProjection,
+  impactProjectionMarker,
+  type ScoreProjection,
+} from './impact-projection';
 
 // ─── Shared render options ────────────────────────────────────────────────
 
@@ -83,6 +88,13 @@ import type { ImpactScoreInput, ImpactSummary } from './impact';
  */
 export interface CheckRenderOptions {
   readonly impactScores?: ReadonlyArray<ImpactScoreInput>;
+  /**
+   * The score projection (impact surface P2), computed by the caller from
+   * the run's own shared analysis + the latest snapshot
+   * (`gatherScoreProjection`). Rendered inside the Impact section, always
+   * labeled projected, and carried on the JSON `impact.projection` field.
+   */
+  readonly scoreProjection?: ScoreProjection;
 }
 
 // ─── Shared verdict predicates ────────────────────────────────────────────
@@ -430,7 +442,7 @@ export function renderConsole(result: GuardrailCheckResult, opts?: CheckRenderOp
   // resolved, so a neutral run gets no extra block here (the quiet line is
   // a PR-comment concern).
   {
-    const impact = deriveImpact(result, opts?.impactScores);
+    const impact = deriveImpact(result, opts?.impactScores, opts?.scoreProjection);
     if (!impact.attributable) {
       lines.push(logger.bold('Impact'));
       lines.push(`  ${formatImpactNotAttributable()}`);
@@ -439,6 +451,12 @@ export function renderConsole(result: GuardrailCheckResult, opts?: CheckRenderOp
       lines.push(logger.bold('Impact'));
       lines.push(`  ${formatImpactHeadline(impact)}`);
       for (const note of impact.capNotes) lines.push(`  ${formatImpactCapNote(note)}`);
+      // The projection line (P2): labeled projected, disclosed when absent.
+      // Rendered only inside an attributable section: a refused run may not
+      // claim a score movement any more than a resolved count.
+      const projectionLine =
+        impact.projection !== undefined ? formatScoreProjection(impact.projection) : null;
+      if (projectionLine) lines.push(`  ${projectionLine}`);
       const exclusions = formatImpactExclusions(impact);
       if (exclusions) lines.push(`  ${exclusions}`);
       lines.push('');
@@ -1597,7 +1615,7 @@ export function renderJson(
     // two renderers already print it) — always present, [] when none.
     refExcludedKinds: result.refExcludedKinds,
     // The finding-delta impact, always emitted, zero reported as zero.
-    impact: deriveImpact(result, opts?.impactScores),
+    impact: deriveImpact(result, opts?.impactScores, opts?.scoreProjection),
     ...(result.depVulnsUnmeasured ? { depVulnsUnmeasured: result.depVulnsUnmeasured } : {}),
     ...(result.deferredCapture && result.deferredCapture.length > 0
       ? { deferredCapture: result.deferredCapture }
@@ -1851,7 +1869,7 @@ export function renderMarkdown(result: GuardrailCheckResult, opts?: CheckRenderO
   // CANNOT GATE heading would claim exactly what the refusal says cannot
   // be claimed, so the one-liner defers to the gap banner directly below.
   {
-    const impact = deriveImpact(result, opts?.impactScores);
+    const impact = deriveImpact(result, opts?.impactScores, opts?.scoreProjection);
     if (!impact.attributable) {
       lines.push(`_${escapeMd(formatImpactNotAttributable())}_`);
       lines.push('');
@@ -1862,6 +1880,19 @@ export function renderMarkdown(result: GuardrailCheckResult, opts?: CheckRenderO
       for (const note of impact.capNotes) {
         lines.push('');
         lines.push(escapeMd(formatImpactCapNote(note)));
+      }
+      // The projection line (P2), plus the hidden marker the post-merge
+      // landed update parses back for the "actual; projection was P"
+      // calibration line. Marker and line travel together: no line, no
+      // marker.
+      if (impact.projection !== undefined) {
+        const projectionLine = formatScoreProjection(impact.projection);
+        if (projectionLine) {
+          lines.push('');
+          lines.push(escapeMd(projectionLine));
+          const marker = impactProjectionMarker(impact.projection);
+          if (marker) lines.push(marker);
+        }
       }
       const exclusions = formatImpactExclusions(impact);
       if (exclusions) {

--- a/src/baseline/impact-projection.ts
+++ b/src/baseline/impact-projection.ts
@@ -1,0 +1,327 @@
+/**
+ * The score projection (impact surface P2): "if merged: security 40 -> 46
+ * (projected)" on the guardrail PR surfaces.
+ *
+ * Honesty constraints, implemented as code, not prose:
+ *
+ *   - **No second score computation path (Rule 2).** The current side is
+ *     `scoreAndFormatHealth` over the SAME shared `AnalysisResult` the
+ *     guardrail run already gathered (`peekAnalysisResult`, a probe that
+ *     never builds), mapped through the snapshot publisher's own
+ *     `scoresFromReport`. When no full shared envelope exists (a ref-based
+ *     run's trimmed gather), the projection declines with a disclosed
+ *     reason; it never re-gathers (measured 80+ seconds on a large tree)
+ *     and never approximates from a partial gather.
+ *   - **The base is the number the org has seen.** It comes from the latest
+ *     `report-history.jsonl` snapshot on the reports anchor ref, never a
+ *     local recomputation of the base tree.
+ *   - **Methodology identity (constraint 4).** Both sides must carry the
+ *     same `SCORING_METHODOLOGY_VERSION`; a mismatch, including a
+ *     pre-stamping snapshot with no version at all, is disclosed as "not
+ *     comparable this PR", mirroring the Rule 19 recall discipline (absent
+ *     evidence is not comparable evidence).
+ *   - **A projection is labeled projected**, every dimension delta comes
+ *     from the ONE delta computation (`scoreDeltas` in reports/history),
+ *     and zero movement is reported as zero, never omitted.
+ *
+ * The hidden markdown marker written beside a projected line is the
+ * calibration hand-off: the post-merge landed update (reports lane) parses
+ * it back to render "actual; projection was P". Writer and parser live here
+ * together so the codec cannot fork.
+ */
+
+import { peekAnalysisResult } from '../analyzers/cache';
+import { scoreAndFormatHealth } from '../analyzers/health';
+import type { HealthReport } from '../analyzers/types';
+import { SCORING_METHODOLOGY_VERSION } from '../scoring/methodology';
+import {
+  SCORE_KEYS,
+  scoreDeltas,
+  type ReportHistoryEntry,
+  type ReportScores,
+  type ScoreDelta,
+} from '../reports/history';
+import { readReportHistory, scoresFromReport } from '../reports/snapshot';
+import type { ImpactScoreInput } from './impact';
+import type { ReportsPolicy } from './policy';
+
+// ─── The projection model ─────────────────────────────────────────────────
+
+/**
+ * One projection outcome, total over the four honest states. Rides the
+ * guardrail JSON (`impact.projection`, additive optional) so every surface
+ * and embedder sees the same claim with the same disclosure.
+ *
+ *   - `projected`: both sides comparable; `deltas` carries every dimension
+ *     (zero as zero, unmeasured as null: the ONE `ScoreDelta` shape).
+ *   - `not-comparable`: a base snapshot exists but under a different (or
+ *     absent) scoring methodology; nothing is diffed.
+ *   - `unavailable`: no base snapshot, or no full shared analysis to score
+ *     the current side from. The reason says which.
+ *   - `disabled`: the repo turned the projection off
+ *     (`impact.projectScores: false`); carried so JSON consumers can tell
+ *     "off by choice" from "could not".
+ */
+export type ScoreProjection =
+  | {
+      readonly status: 'projected';
+      /** Per-dimension movement base -> current, from the one delta
+       *  computation (`scoreDeltas`). Includes `overall`. */
+      readonly deltas: ReadonlyArray<ScoreDelta>;
+      readonly methodology: string;
+      /** The snapshot the base side came from. */
+      readonly base: { readonly sha: string; readonly date: string };
+    }
+  | { readonly status: 'not-comparable'; readonly reason: string }
+  | { readonly status: 'unavailable'; readonly reason: string }
+  | { readonly status: 'disabled'; readonly reason: string };
+
+/** The projection plus the same-run score inputs for the cap-aware line
+ *  (I1's `impactScores` slot). `scoreInputs` is present whenever the shared
+ *  envelope could be scored, independent of whether a base snapshot made a
+ *  projection possible (the cap explanation needs no history). */
+export interface ScoreProjectionGather {
+  readonly projection: ScoreProjection;
+  readonly scoreInputs?: ReadonlyArray<ImpactScoreInput>;
+}
+
+// ─── Pure core ────────────────────────────────────────────────────────────
+
+/**
+ * Compare the current side against the latest snapshot, methodology-guarded.
+ * Pure; the IO wrapper below feeds it.
+ */
+export function computeScoreProjection(args: {
+  readonly current: ReportScores;
+  /** The methodology the current side was computed under (the running
+   *  dxkit's `SCORING_METHODOLOGY_VERSION`). */
+  readonly methodology: string;
+  readonly history: ReadonlyArray<ReportHistoryEntry>;
+}): ScoreProjection {
+  const base = args.history[args.history.length - 1];
+  if (!base) {
+    return {
+      status: 'unavailable',
+      reason:
+        'no score history on the reports ref yet (enable reports.onMerge to publish ' +
+        'per-merge snapshots; the first snapshot starts the trend)',
+    };
+  }
+  if (base.methodology === undefined) {
+    return {
+      status: 'not-comparable',
+      reason:
+        `the latest snapshot (${base.sha.slice(0, 12)}) predates scoring-methodology ` +
+        'stamping, so its scores cannot be verified comparable; the next merge snapshot realigns',
+    };
+  }
+  if (base.methodology !== args.methodology) {
+    return {
+      status: 'not-comparable',
+      reason:
+        `the latest snapshot was scored under methodology '${base.methodology}' but this run ` +
+        `scores under '${args.methodology}'; the next merge snapshot realigns`,
+    };
+  }
+  return {
+    status: 'projected',
+    deltas: scoreDeltas(base.scores, args.current),
+    methodology: args.methodology,
+    base: { sha: base.sha, date: base.date },
+  };
+}
+
+// ─── IO wrapper (the guardrail CLI's entry point) ─────────────────────────
+
+/** Injectable seams for tests; production callers omit them. */
+export interface ScoreProjectionSeams {
+  readonly peek?: (cwd: string) => Promise<{ report: HealthReport } | null>;
+  readonly readHistory?: (cwd: string, anchorRef?: string) => ReportHistoryEntry[];
+}
+
+/**
+ * Gather the projection for a guardrail run at `cwd`. Reads the policy knob,
+ * probes the shared analysis envelope (never builds), scores it through the
+ * one evaluator path, and compares against the latest snapshot. Every
+ * non-projected outcome carries its reason; nothing here can throw into the
+ * check (a projection failure must never fail a gate).
+ */
+export async function gatherScoreProjection(
+  cwd: string,
+  policy: {
+    readonly impact?: { readonly projectScores?: boolean };
+    readonly reports?: ReportsPolicy;
+  },
+  seams?: ScoreProjectionSeams,
+): Promise<ScoreProjectionGather> {
+  if (policy.impact?.projectScores === false) {
+    return {
+      projection: {
+        status: 'disabled',
+        reason: 'score projection is off for this repo (impact.projectScores: false)',
+      },
+    };
+  }
+  try {
+    const peek =
+      seams?.peek ??
+      (async (dir: string) => {
+        const envelope = await peekAnalysisResult(dir);
+        return envelope ? { report: scoreAndFormatHealth(envelope) } : null;
+      });
+    const scored = await peek(cwd);
+    if (!scored) {
+      return {
+        projection: {
+          status: 'unavailable',
+          reason:
+            'this run gathered a trimmed analysis (no full shared envelope to score), ' +
+            'so dimension scores were not recomputed',
+        },
+      };
+    }
+    const scoreInputs = impactScoreInputsFromReport(scored.report);
+    const readHistory = seams?.readHistory ?? readReportHistory;
+    const history = readHistory(cwd, policy.reports?.anchorRef);
+    const projection = computeScoreProjection({
+      current: scoresFromReport(scored.report),
+      methodology: SCORING_METHODOLOGY_VERSION,
+      history,
+    });
+    return { projection, scoreInputs };
+  } catch (err) {
+    // Fail open, never silent (the GateFailure discipline): a projection
+    // error degrades to a disclosed unavailable, and the gate is untouched.
+    return {
+      projection: {
+        status: 'unavailable',
+        reason: `score projection failed: ${(err as Error).message}`,
+      },
+    };
+  }
+}
+
+/**
+ * Map a scored report's dimensions to the impact model's score slots
+ * (`ImpactScoreInput`) so the cap-aware line renders from the same-run spec
+ * output (I1 honesty constraint 3). Dimension names use the durable
+ * `ReportScores` keys, the same vocabulary the projection line and the
+ * history surface speak.
+ */
+export function impactScoreInputsFromReport(report: HealthReport): ReadonlyArray<ImpactScoreInput> {
+  const dims: ReadonlyArray<
+    readonly [Exclude<keyof ReportScores, 'overall'>, keyof HealthReport['dimensions']]
+  > = [
+    ['security', 'security'],
+    ['quality', 'quality'],
+    ['tests', 'testing'],
+    ['documentation', 'documentation'],
+    ['maintainability', 'maintainability'],
+    ['developerExperience', 'developerExperience'],
+  ];
+  const out: ImpactScoreInput[] = [];
+  for (const [name, dim] of dims) {
+    const d = report.dimensions[dim];
+    if (!d) continue;
+    out.push({
+      dimension: name,
+      score: d.score,
+      ...(d.capsApplied !== undefined ? { capsApplied: d.capsApplied } : {}),
+      ...(d.topActions !== undefined ? { topActions: d.topActions } : {}),
+    });
+  }
+  return out;
+}
+
+// ─── One phrasing, every surface ──────────────────────────────────────────
+
+/**
+ * The projection line (one phrasing; the three check renderers compose it):
+ *
+ *   - movement: `security 40 -> 46 (projected) · other dimensions unchanged`
+ *   - all flat:  `scores unchanged (projected)` (zero reported as zero)
+ *   - unmeasured dimensions are named, never silently dropped
+ *   - not-comparable / unavailable: the disclosure, prefixed
+ *   - disabled: null, the repo chose no line
+ */
+export function formatScoreProjection(projection: ScoreProjection): string | null {
+  if (projection.status === 'disabled') return null;
+  if (projection.status === 'unavailable') return `scores not projected: ${projection.reason}`;
+  if (projection.status === 'not-comparable') {
+    return `scores not comparable this PR: ${projection.reason}`;
+  }
+  const dims = projection.deltas.filter((d) => d.key !== 'overall');
+  const moved = dims.filter((d) => d.delta !== null && d.delta !== 0);
+  const unmeasured = dims.filter((d) => d.delta === null);
+  const parts: string[] = moved.map((d) => `${d.key} ${d.from} -> ${d.to} (projected)`);
+  if (moved.length === 0) parts.push('scores unchanged (projected)');
+  else if (moved.length < dims.length - unmeasured.length) parts.push('other dimensions unchanged');
+  if (unmeasured.length > 0) {
+    parts.push(`${unmeasured.map((d) => d.key).join(', ')} not projected (unmeasured)`);
+  }
+  return parts.join(' · ');
+}
+
+// ─── The projection marker codec (pre-merge writer + post-merge reader) ──
+
+/** The marker prefix. The whole marker is one HTML comment on its own line
+ *  inside the guardrail PR comment; invisible to readers, parsed back by the
+ *  post-merge landed update. */
+export const IMPACT_PROJECTION_MARKER_PREFIX = '<!-- dxkit-impact-projection ';
+
+/** What the marker carries: per-dimension projected from/to (measured
+ *  dimensions only) plus the methodology they were projected under. */
+export interface ImpactProjectionRecord {
+  readonly methodology: string;
+  readonly scores: Readonly<Record<string, { readonly from: number; readonly to: number }>>;
+}
+
+/** Render the hidden marker for a projected outcome; null otherwise. */
+export function impactProjectionMarker(projection: ScoreProjection): string | null {
+  if (projection.status !== 'projected') return null;
+  const scores: Record<string, { from: number; to: number }> = {};
+  for (const d of projection.deltas) {
+    if (d.key === 'overall') continue;
+    if (typeof d.from === 'number' && typeof d.to === 'number') {
+      scores[d.key] = { from: d.from, to: d.to };
+    }
+  }
+  const record: ImpactProjectionRecord = { methodology: projection.methodology, scores };
+  return `${IMPACT_PROJECTION_MARKER_PREFIX}${JSON.stringify(record)} -->`;
+}
+
+/** Parse the marker back out of a PR comment body. Tolerant: a missing or
+ *  malformed marker reads as "no projection was made" (null), never a throw;
+ *  the landed update then renders actual-only. */
+export function parseImpactProjectionMarker(body: string): ImpactProjectionRecord | null {
+  const start = body.indexOf(IMPACT_PROJECTION_MARKER_PREFIX);
+  if (start === -1) return null;
+  const rest = body.slice(start + IMPACT_PROJECTION_MARKER_PREFIX.length);
+  const end = rest.indexOf(' -->');
+  if (end === -1) return null;
+  try {
+    const parsed: unknown = JSON.parse(rest.slice(0, end));
+    if (!parsed || typeof parsed !== 'object') return null;
+    const o = parsed as Record<string, unknown>;
+    if (typeof o.methodology !== 'string' || !o.scores || typeof o.scores !== 'object') {
+      return null;
+    }
+    const scores: Record<string, { from: number; to: number }> = {};
+    for (const [key, value] of Object.entries(o.scores as Record<string, unknown>)) {
+      if (!value || typeof value !== 'object') continue;
+      const v = value as Record<string, unknown>;
+      if (typeof v.from === 'number' && typeof v.to === 'number') {
+        scores[key] = { from: v.from, to: v.to };
+      }
+    }
+    return { methodology: o.methodology, scores };
+  } catch {
+    return null;
+  }
+}
+
+/** Stable dimension order for landed/projection rendering, derived from the
+ *  ONE key list, never a second ordering. */
+export const PROJECTION_DIMENSION_KEYS: ReadonlyArray<keyof ReportScores> = SCORE_KEYS.filter(
+  (k) => k !== 'overall',
+);

--- a/src/baseline/impact-projection.ts
+++ b/src/baseline/impact-projection.ts
@@ -36,14 +36,22 @@ import type { HealthReport } from '../analyzers/types';
 import { SCORING_METHODOLOGY_VERSION } from '../scoring/methodology';
 import {
   SCORE_KEYS,
+  SCORE_KEY_TO_DIMENSION,
   scoreDeltas,
   type ReportHistoryEntry,
   type ReportScores,
   type ScoreDelta,
+  type ScoreDimensionKey,
 } from '../reports/history';
-import { readReportHistory, scoresFromReport } from '../reports/snapshot';
+import {
+  describeScoreInputsDrift,
+  readReportHistory,
+  scoresFromReport,
+  scoreToolInputs,
+} from '../reports/snapshot';
 import type { ImpactScoreInput } from './impact';
 import type { ReportsPolicy } from './policy';
+import type { BaselineMode } from './modes';
 
 // ─── The projection model ─────────────────────────────────────────────────
 
@@ -73,7 +81,18 @@ export type ScoreProjection =
       readonly base: { readonly sha: string; readonly date: string };
     }
   | { readonly status: 'not-comparable'; readonly reason: string }
-  | { readonly status: 'unavailable'; readonly reason: string }
+  | {
+      readonly status: 'unavailable';
+      readonly reason: string;
+      /**
+       * True when the state is structural to the run's MODE (ref-based mode
+       * gathers a trimmed analysis on every run, so no run of this surface
+       * can ever project): the disclosure lives in the JSON, and the human
+       * line is suppressed instead of repeating a permanent, non-actionable
+       * sentence on every PR. Absent for actionable cases.
+       */
+      readonly quiet?: true;
+    }
   | { readonly status: 'disabled'; readonly reason: string };
 
 /** The projection plus the same-run score inputs for the cap-aware line
@@ -96,6 +115,11 @@ export function computeScoreProjection(args: {
   /** The methodology the current side was computed under (the running
    *  dxkit's `SCORING_METHODOLOGY_VERSION`). */
   readonly methodology: string;
+  /** The current side's score-relevant tool inputs (`scoreToolInputs`).
+   *  Compared against the base snapshot's stamp: drift (a degraded scanner,
+   *  an untrusted-mode skip) is disclosed as not comparable, never diffed
+   *  (Rule 19 cause 5 applied to scores). */
+  readonly inputs?: ReadonlyArray<string>;
   readonly history: ReadonlyArray<ReportHistoryEntry>;
 }): ScoreProjection {
   const base = args.history[args.history.length - 1];
@@ -121,6 +145,13 @@ export function computeScoreProjection(args: {
       reason:
         `the latest snapshot was scored under methodology '${base.methodology}' but this run ` +
         `scores under '${args.methodology}'; the next merge snapshot realigns`,
+    };
+  }
+  const inputsDrift = describeScoreInputsDrift(base.scoreInputs, args.inputs);
+  if (inputsDrift !== null) {
+    return {
+      status: 'not-comparable',
+      reason: `${inputsDrift}, so this run's scores cannot be diffed against the snapshot's; the next merge snapshot realigns`,
     };
   }
   return {
@@ -153,12 +184,29 @@ export async function gatherScoreProjection(
     readonly reports?: ReportsPolicy;
   },
   seams?: ScoreProjectionSeams,
+  mode?: BaselineMode,
 ): Promise<ScoreProjectionGather> {
   if (policy.impact?.projectScores === false) {
     return {
       projection: {
         status: 'disabled',
         reason: 'score projection is off for this repo (impact.projectScores: false)',
+      },
+    };
+  }
+  if (mode === 'ref-based') {
+    // Structural to the mode, quiet by design: ref-based mode trims the
+    // gather on EVERY run, so a per-PR sentence would repeat forever with
+    // nothing the PR author can do. The JSON keeps the disclosure; the
+    // off-switch (impact.projectScores: false) silences even that.
+    return {
+      projection: {
+        status: 'unavailable',
+        reason:
+          'ref-based mode gathers a trimmed analysis each run, so dimension scores are not ' +
+          'recomputed on this surface (committed baseline modes project; ' +
+          'impact.projectScores: false turns the projection off entirely)',
+        quiet: true,
       },
     };
   }
@@ -175,7 +223,7 @@ export async function gatherScoreProjection(
         projection: {
           status: 'unavailable',
           reason:
-            'this run gathered a trimmed analysis (no full shared envelope to score), ' +
+            'this run held no full shared analysis to score (a trimmed or partial gather), ' +
             'so dimension scores were not recomputed',
         },
       };
@@ -186,6 +234,7 @@ export async function gatherScoreProjection(
     const projection = computeScoreProjection({
       current: scoresFromReport(scored.report),
       methodology: SCORING_METHODOLOGY_VERSION,
+      inputs: scoreToolInputs(scored.report),
       history,
     });
     return { projection, scoreInputs };
@@ -209,19 +258,9 @@ export async function gatherScoreProjection(
  * history surface speak.
  */
 export function impactScoreInputsFromReport(report: HealthReport): ReadonlyArray<ImpactScoreInput> {
-  const dims: ReadonlyArray<
-    readonly [Exclude<keyof ReportScores, 'overall'>, keyof HealthReport['dimensions']]
-  > = [
-    ['security', 'security'],
-    ['quality', 'quality'],
-    ['tests', 'testing'],
-    ['documentation', 'documentation'],
-    ['maintainability', 'maintainability'],
-    ['developerExperience', 'developerExperience'],
-  ];
   const out: ImpactScoreInput[] = [];
-  for (const [name, dim] of dims) {
-    const d = report.dimensions[dim];
+  for (const name of Object.keys(SCORE_KEY_TO_DIMENSION) as ScoreDimensionKey[]) {
+    const d = report.dimensions[SCORE_KEY_TO_DIMENSION[name]];
     if (!d) continue;
     out.push({
       dimension: name,
@@ -246,7 +285,9 @@ export function impactScoreInputsFromReport(report: HealthReport): ReadonlyArray
  */
 export function formatScoreProjection(projection: ScoreProjection): string | null {
   if (projection.status === 'disabled') return null;
-  if (projection.status === 'unavailable') return `scores not projected: ${projection.reason}`;
+  if (projection.status === 'unavailable') {
+    return projection.quiet ? null : `scores not projected: ${projection.reason}`;
+  }
   if (projection.status === 'not-comparable') {
     return `scores not comparable this PR: ${projection.reason}`;
   }

--- a/src/baseline/impact.ts
+++ b/src/baseline/impact.ts
@@ -39,6 +39,7 @@
 import type { ClassifiedPair } from '../gate/result';
 import type { BaselineEntry, FindingSeverity, FindingStatus } from './types';
 import type { CapApplied, TopAction } from '../scoring/result';
+import type { ScoreProjection } from './impact-projection';
 
 /** Severity display order, most severe first. */
 const SEVERITY_ORDER: ReadonlyArray<FindingSeverity> = ['critical', 'high', 'medium', 'low'];
@@ -135,6 +136,15 @@ export interface ImpactSummary {
    *  (the section then carries the finding delta alone) or nothing is
    *  capped. */
   readonly capNotes: ReadonlyArray<ImpactCapNote>;
+  /**
+   * The score projection (impact surface P2), when the surface computed one:
+   * projected dimension deltas against the latest snapshot, or the disclosed
+   * reason none was made (`not-comparable` / `unavailable` / `disabled`).
+   * Additive optional: pre-P2 payloads and surfaces without a projection
+   * simply omit it. Never a claim of fact: every rendered form carries the
+   * word "projected" (see `formatScoreProjection`).
+   */
+  readonly projection?: ScoreProjection;
 }
 
 /**
@@ -194,6 +204,7 @@ export function deriveImpact(
     readonly requiredNotObserved?: ReadonlyArray<unknown>;
   },
   scores?: ReadonlyArray<ImpactScoreInput>,
+  projection?: ScoreProjection,
 ): ImpactSummary {
   const priorById = new Map(result.baseline.findings.map((e) => [e.id, e] as const));
 
@@ -280,6 +291,7 @@ export function deriveImpact(
     net: resolved - added,
     excluded,
     capNotes,
+    ...(projection !== undefined ? { projection } : {}),
   };
 }
 

--- a/src/baseline/impact.ts
+++ b/src/baseline/impact.ts
@@ -282,6 +282,19 @@ export function deriveImpact(
     });
   }
 
+  // A refused run (CANNOT GATE) may not carry a projected score claim any
+  // more than a resolved count: the renderers already suppress the line, but
+  // the JSON field would still hand an embedder 'projected' deltas to render
+  // on their own. Neutralize it to a disclosed unavailable instead.
+  const effectiveProjection: ScoreProjection | undefined =
+    projection !== undefined && !attributable
+      ? {
+          status: 'unavailable',
+          reason:
+            'the run could not attribute changes (CANNOT GATE), so no score movement can be claimed',
+        }
+      : projection;
+
   const resolved = resolvedPairs.length;
   return {
     attributable,
@@ -291,7 +304,7 @@ export function deriveImpact(
     net: resolved - added,
     excluded,
     capNotes,
-    ...(projection !== undefined ? { projection } : {}),
+    ...(effectiveProjection !== undefined ? { projection: effectiveProjection } : {}),
   };
 }
 

--- a/src/baseline/policy-metadata.ts
+++ b/src/baseline/policy-metadata.ts
@@ -165,6 +165,11 @@ export const POLICY_PARAMS: readonly PolicyParamMeta[] = [
     anchor: 'reports-on-merge',
   },
   {
+    path: 'impact.projectScores',
+    summary: 'project dimension scores in the PR Impact section (default on)',
+    anchor: 'impact-projection',
+  },
+  {
     // Settable because dxkit's own guidance (docs + the learn assistant)
     // points users at exactly this field — a knob the product recommends
     // must be reachable through `policy set`, not a hand edit (the

--- a/src/baseline/policy-schema.ts
+++ b/src/baseline/policy-schema.ts
@@ -308,6 +308,12 @@ export function buildPolicySchema(version: string): Schema {
         },
         'Report snapshots published on merge.',
       ),
+      impact: obj(
+        {
+          projectScores: boolProp('impact.projectScores'),
+        },
+        'PR Impact surface tuning.',
+      ),
       loop: obj(
         {
           preset: stringProp('loop.preset'),

--- a/src/baseline/policy-stanzas.ts
+++ b/src/baseline/policy-stanzas.ts
@@ -262,4 +262,11 @@ export const SCAFFOLD_EXEMPT_KNOBS: readonly ScaffoldExemptKnob[] = [
       'requires an external engine + token that dxkit never selects for the user; the ingest ' +
       'command + dxkit-ingest skill own setup; a bare stanza without a token would not work.',
   },
+  {
+    path: 'impact.projectScores',
+    reason:
+      'a default-ON off-switch for the PR score projection: the right value needs no teaching ' +
+      'at scaffold time, and a commented stanza would read as an opt-in for behavior that is ' +
+      'already on; documented in the guide (impact-projection) and settable via `policy set`.',
+  },
 ];

--- a/src/baseline/policy.ts
+++ b/src/baseline/policy.ts
@@ -200,6 +200,24 @@ export interface ReportsPolicy {
 }
 
 /**
+ * `.dxkit/policy.json:impact`, tuning for the PR Impact surface. These
+ * refine an already-adopted surface (the guardrail comment); they are not a
+ * capability a repo opts into, so they carry no discovery contract (Rule 16
+ * tuning-field discipline, declared in `POSTURE_KNOBS`).
+ */
+export interface ImpactPolicy {
+  /**
+   * Project dimension scores in the Impact section ("security 40 -> 46
+   * (projected)") from the run's own shared analysis against the latest
+   * snapshot. Default TRUE: the spike measured the marginal cost at ~20ms
+   * (a cache-hit re-score; the run's gather is reused, never repeated) plus
+   * one shallow fetch of the reports ref. Set false to drop the projection
+   * line and the snapshot read entirely.
+   */
+  readonly projectScores?: boolean;
+}
+
+/**
  * Brownfield-mode policy. The product promise — "existing debt is
  * allowed; new regressions are blocked" — flows from these settings.
  */
@@ -275,6 +293,8 @@ export interface BrownfieldPolicy {
   readonly largeFileThreshold?: number;
   /** Opt-in report snapshots on merge (see ReportsPolicy). */
   readonly reports?: ReportsPolicy;
+  /** Impact-surface tuning (see ImpactPolicy). */
+  readonly impact?: ImpactPolicy;
   /**
    * Baseline-mode pinning. When absent, the resolver in `./modes.ts`
    * falls back to visibility-derived defaults

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -547,6 +547,9 @@ export async function run(argv: string[]): Promise<void> {
       refresh: { type: 'boolean', default: false },
       // report snapshot flag: retain the most recent N history entries
       retain: { type: 'string' },
+      // report snapshot flag: update the merged PR's guardrail comment with
+      // landed (actual) scores beside the projection it carried (impact P2)
+      'pr-comment': { type: 'boolean', default: false },
       substring: { type: 'boolean', default: false },
       // pr: skip the structural-duplicate seam pass
       'no-seams': { type: 'boolean', default: false },
@@ -2419,6 +2422,7 @@ export async function run(argv: string[]): Promise<void> {
                 cwd,
                 json: !!values.json,
                 dryRun: !!values['dry-run'],
+                prComment: !!values['pr-comment'],
                 ...(values.ref ? { anchorRef: String(values.ref) } : {}),
                 ...(values.retain ? { retainHistory: Number(values.retain) } : {}),
               })
@@ -3119,6 +3123,17 @@ export async function run(argv: string[]): Promise<void> {
           cliRef: values.ref as string | undefined,
         });
         if (!quiet) logger.info(`Baseline ${result.mode.explanation}`);
+        // Score projection (impact P2): score the shared envelope this run
+        // already gathered against the latest snapshot. Never re-gathers
+        // (peek-only), never throws into the check, and every non-projected
+        // outcome carries its reason. Default on; policy off-switch
+        // `impact.projectScores: false`.
+        const { gatherScoreProjection } = await import('./baseline/impact-projection');
+        const projected = await gatherScoreProjection(targetPath, result.policy);
+        const renderOpts = {
+          scoreProjection: projected.projection,
+          ...(projected.scoreInputs !== undefined ? { impactScores: projected.scoreInputs } : {}),
+        };
         // Cache the verdict so a same-tree replay (the `receipt` command, a
         // second gate this session) reuses it instead of re-gathering. Keyed on
         // a content-complete tree signature + policy hash, so a replay can never
@@ -3130,17 +3145,17 @@ export async function run(argv: string[]): Promise<void> {
           blockingCount: counts.blocking,
           unattributableCount: counts.unattributable,
           warningCount: counts.warning,
-          markdown: renderMarkdown(result),
+          markdown: renderMarkdown(result, renderOpts),
           ranAt: new Date().toISOString(),
           blockingFindings: cacheBlockingFindings(result.pairs),
         });
         const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
         if (values.json) {
-          await emitJson(renderJson(result));
+          await emitJson(renderJson(result, renderOpts));
         } else if (values.markdown) {
-          process.stdout.write(renderMarkdown(result) + '\n');
+          process.stdout.write(renderMarkdown(result, renderOpts) + '\n');
         } else {
-          process.stdout.write(renderConsole(result) + '\n');
+          process.stdout.write(renderConsole(result, renderOpts) + '\n');
           logger.dim(`Completed in ${elapsed}s`);
         }
         // The ONE exit-code derivation (consumes attribution gaps) — never

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3129,7 +3129,12 @@ export async function run(argv: string[]): Promise<void> {
         // outcome carries its reason. Default on; policy off-switch
         // `impact.projectScores: false`.
         const { gatherScoreProjection } = await import('./baseline/impact-projection');
-        const projected = await gatherScoreProjection(targetPath, result.policy);
+        const projected = await gatherScoreProjection(
+          targetPath,
+          result.policy,
+          undefined,
+          result.mode.mode,
+        );
         const renderOpts = {
           scoreProjection: projected.projection,
           ...(projected.scoreInputs !== undefined ? { impactScores: projected.scoreInputs } : {}),

--- a/src/discovery/posture-knobs.ts
+++ b/src/discovery/posture-knobs.ts
@@ -143,6 +143,17 @@ export const POSTURE_KNOBS: readonly PostureKnob[] = [
     note: 'enabling installs the dxkit-reports-refresh managed workflow, which configure’s policy-only merge-write cannot place — so no planConfig; recommendReportsOnMerge surfaces it once the repo is actively gating.',
   },
   {
+    path: 'impact.projectScores',
+    command: 'guardrail',
+    requiresPlan: false,
+    requiresRecommend: false,
+    exemptionReason:
+      'a default-ON off-switch tuning the already-adopted guardrail comment (drop the projected ' +
+      'score line), not a capability a repo opts into (the Rule 16 tuning-field carve-out), ' +
+      'registered here so the exemption is declared, never a silent omission. Documented under ' +
+      '"Impact projection" in policy-guide.md and settable via `policy set`.',
+  },
+  {
     path: 'graph.refresh',
     command: 'update',
     requiresPlan: false,

--- a/src/reports-cli.ts
+++ b/src/reports-cli.ts
@@ -22,6 +22,13 @@ import {
 } from './reports/snapshot';
 import type { ReportHistoryEntry } from './reports/history';
 import { renderHistoryMarkdown } from './reports/render';
+import {
+  defaultGhExec,
+  resolveRepoSlug,
+  updateLandedComment,
+  type GhExec,
+  type LandedCommentOutcome,
+} from './reports/landed-comment';
 import { loadPolicyFromCwd, type ReportsPolicy } from './baseline/policy';
 import { announceAnchorNotPushed } from './baseline/anchor-publish';
 import * as logger from './logger';
@@ -88,6 +95,28 @@ export interface ReportSnapshotOptions {
   readonly dryRun?: boolean;
   /** ISO timestamp override (tests / determinism). */
   readonly now?: string;
+  /**
+   * After a successful publish, update the merged PR's guardrail comment
+   * with the landed (actual) scores beside the projection it carried
+   * (impact surface P2). Best-effort: every failure is a disclosed skip in
+   * the output + step summary, never a non-zero exit: the reports lane
+   * passes this flag; local runs default off.
+   */
+  readonly prComment?: boolean;
+  /** Injected gh executor for the PR-comment update (tests). */
+  readonly ghExec?: GhExec;
+}
+
+/** Append a line to the Actions step summary when running under CI.
+ *  Best-effort decoration, mirroring the remediate lane's helper. */
+function appendStepSummary(line: string): void {
+  const file = process.env.GITHUB_STEP_SUMMARY;
+  if (!file) return;
+  try {
+    fs.appendFileSync(file, line + '\n\n', 'utf8');
+  } catch {
+    /* summary is decoration, never a failure */
+  }
 }
 
 export async function runReportSnapshot(opts: ReportSnapshotOptions): Promise<number> {
@@ -134,6 +163,39 @@ export async function runReportSnapshot(opts: ReportSnapshotOptions): Promise<nu
   // the workflow went green, and no reports ref ever appeared). Announce it the
   // ONE way both publishers do, in JSON and human mode alike.
   const notPushed = !result.publish.pushed && result.publish.reason !== 'no change';
+
+  // The post-merge landed update (impact P2): patch the merged PR's guardrail
+  // comment with actual-vs-projected scores. Only after a publish that stands
+  // ("no change" republishes the same truth, so the comment is still honest);
+  // a REJECTED publish means the entry never landed, so claiming it on a PR
+  // would fabricate history.
+  let prComment: LandedCommentOutcome | undefined;
+  if (opts.prComment) {
+    if (notPushed) {
+      prComment = {
+        status: 'skipped',
+        reason: 'snapshot publish was rejected, so there is no landed entry to report',
+      };
+    } else {
+      const exec = opts.ghExec ?? defaultGhExec;
+      const slug = resolveRepoSlug(exec);
+      prComment = slug
+        ? updateLandedComment({
+            slug,
+            sha,
+            entry,
+            ...(result.previousEntry ? { prev: result.previousEntry } : {}),
+            exec,
+          })
+        : { status: 'skipped', reason: 'could not resolve the repository slug (owner/repo)' };
+    }
+    appendStepSummary(
+      prComment.status === 'updated'
+        ? `dxkit landed scores: updated the guardrail comment on PR #${prComment.prNumber}.`
+        : `dxkit landed scores: PR comment skipped (${prComment.reason}).`,
+    );
+  }
+
   if (opts.json) {
     if (notPushed) announceAnchorNotPushed(result.anchorRef, result.publish.reason);
     process.stdout.write(
@@ -144,6 +206,7 @@ export async function runReportSnapshot(opts: ReportSnapshotOptions): Promise<nu
         anchorRef: result.anchorRef,
         historyCount: result.historyCount,
         overall: entry.scores.overall,
+        ...(prComment !== undefined ? { prComment } : {}),
       }) + '\n',
     );
     return 0;
@@ -157,6 +220,15 @@ export async function runReportSnapshot(opts: ReportSnapshotOptions): Promise<nu
     logger.info('No change since the last snapshot — nothing published.');
   } else {
     announceAnchorNotPushed(result.anchorRef, result.publish.reason);
+  }
+  if (prComment !== undefined) {
+    if (prComment.status === 'updated') {
+      logger.success(
+        `Updated the guardrail comment on PR #${prComment.prNumber} with landed scores.`,
+      );
+    } else {
+      logger.info(`PR comment skipped: ${prComment.reason}`);
+    }
   }
   return 0;
 }

--- a/src/reports/history.ts
+++ b/src/reports/history.ts
@@ -51,6 +51,17 @@ export interface ReportHistoryEntry {
    * on a pre-4.4.7 entry) is disclosed as not comparable, never diffed.
    */
   readonly methodology?: string;
+  /**
+   * The tool inputs the scores were computed from (Rule 19 cause 5 applied
+   * to scores): the sorted tool names that ran, plus `!name` for tools that
+   * were attempted but unavailable, produced by `scoreToolInputs`. Two
+   * snapshots (or a projection against one) are score-comparable only when
+   * these match: a gitleaks-absent grep fallback or an untrusted-mode skip
+   * changes what a score can see, and a delta across that boundary would
+   * attribute tooling drift to the code. Mismatch is disclosed, never
+   * diffed. Absent on pre-4.4.7 entries (which also lack `methodology`).
+   */
+  readonly scoreInputs?: ReadonlyArray<string>;
   readonly scores: ReportScores;
   readonly findings?: ReportFindingCounts;
   /** Extension inventory entity counts (extension name → entity kind →
@@ -72,6 +83,30 @@ export const SCORE_KEYS: ReadonlyArray<keyof ReportScores> = [
   'maintainability',
   'developerExperience',
 ];
+
+/** A durable score key that names a dimension (everything but `overall`). */
+export type ScoreDimensionKey = Exclude<keyof ReportScores, 'overall'>;
+
+/**
+ * The ONE durable-key to report-dimension mapping. Every consumer that
+ * bridges the two vocabularies (the snapshot publisher's `scoresFromReport`,
+ * the projection's `impactScoreInputsFromReport`) iterates THIS record, so a
+ * seventh dimension added to `ReportScores` fails to compile here instead of
+ * silently missing one consumer. The value is the report's dimension name
+ * (`tests` reads the report's `testing` dimension; the entry key stays
+ * `tests` for brevity + JSON stability).
+ */
+export const SCORE_KEY_TO_DIMENSION = {
+  security: 'security',
+  quality: 'quality',
+  tests: 'testing',
+  documentation: 'documentation',
+  maintainability: 'maintainability',
+  developerExperience: 'developerExperience',
+} as const satisfies Record<ScoreDimensionKey, string>;
+
+/** The report-side dimension names the mapping targets. */
+export type ReportDimensionName = (typeof SCORE_KEY_TO_DIMENSION)[ScoreDimensionKey];
 
 function isFiniteNumberOrNull(v: unknown): v is number | null {
   return v === null || (typeof v === 'number' && Number.isFinite(v));
@@ -113,6 +148,9 @@ export function parseHistory(jsonl: string | null | undefined): ReportHistoryEnt
       dxkitVersion: typeof o.dxkitVersion === 'string' ? o.dxkitVersion : 'unknown',
       ...(typeof o.branch === 'string' ? { branch: o.branch } : {}),
       ...(typeof o.methodology === 'string' ? { methodology: o.methodology } : {}),
+      ...(Array.isArray(o.scoreInputs) && o.scoreInputs.every((t) => typeof t === 'string')
+        ? { scoreInputs: o.scoreInputs as string[] }
+        : {}),
       scores,
       ...(o.findings && typeof o.findings === 'object'
         ? { findings: o.findings as ReportFindingCounts }

--- a/src/reports/history.ts
+++ b/src/reports/history.ts
@@ -43,6 +43,14 @@ export interface ReportHistoryEntry {
   readonly dxkitVersion: string;
   /** Branch the merge landed on (default branch), for multi-branch repos. */
   readonly branch?: string;
+  /**
+   * Scoring-methodology identity the scores were computed under
+   * (`SCORING_METHODOLOGY_VERSION` at publish time). Score comparisons
+   * (the guardrail's pre-merge projection and the post-merge landed line)
+   * happen only between matching versions; a mismatch (or an absent stamp
+   * on a pre-4.4.7 entry) is disclosed as not comparable, never diffed.
+   */
+  readonly methodology?: string;
   readonly scores: ReportScores;
   readonly findings?: ReportFindingCounts;
   /** Extension inventory entity counts (extension name → entity kind →
@@ -104,6 +112,7 @@ export function parseHistory(jsonl: string | null | undefined): ReportHistoryEnt
       date: o.date,
       dxkitVersion: typeof o.dxkitVersion === 'string' ? o.dxkitVersion : 'unknown',
       ...(typeof o.branch === 'string' ? { branch: o.branch } : {}),
+      ...(typeof o.methodology === 'string' ? { methodology: o.methodology } : {}),
       scores,
       ...(o.findings && typeof o.findings === 'object'
         ? { findings: o.findings as ReportFindingCounts }

--- a/src/reports/landed-comment.ts
+++ b/src/reports/landed-comment.ts
@@ -26,6 +26,7 @@ import {
   PROJECTION_DIMENSION_KEYS,
   type ImpactProjectionRecord,
 } from '../baseline/impact-projection';
+import { describeScoreInputsDrift } from './snapshot';
 
 /**
  * The guardrail PR comment's identity marker. The rendered workflow template
@@ -109,13 +110,32 @@ export function renderLandedSection(
     );
     return lines.join('\n');
   }
+  const inputsDrift = describeScoreInputsDrift(prev.scoreInputs, entry.scoreInputs);
+  if (inputsDrift !== null) {
+    lines.push(
+      `Scores not comparable across these snapshots: ${inputsDrift}. ` +
+        'The trend realigns from this snapshot on.',
+    );
+    return lines.join('\n');
+  }
   const deltas = scoreDeltas(prev.scores, entry.scores).filter((d) =>
     PROJECTION_DIMENSION_KEYS.includes(d.key),
   );
   const listed = deltas.filter(
     (d) => d.delta !== null && (d.delta !== 0 || projection?.scores[d.key] !== undefined),
   );
-  const parts = listed.map((d) => landedLine(d, projection?.scores[d.key]));
+  // A dimension that was projected but is UNMEASURED at merge keeps its
+  // calibration line: the projection made a claim, so the landed side says
+  // what became of it instead of silently dropping it.
+  const unmeasuredProjected = deltas.filter(
+    (d) => d.delta === null && projection?.scores[d.key] !== undefined,
+  );
+  const parts = [
+    ...listed.map((d) => landedLine(d, projection?.scores[d.key])),
+    ...unmeasuredProjected.map(
+      (d) => `${d.key} not measured at merge (projection was ${projection!.scores[d.key]!.to})`,
+    ),
+  ];
   const measured = deltas.filter((d) => d.delta !== null);
   if (parts.length === 0) parts.push('scores unchanged (actual)');
   else if (listed.length < measured.length) parts.push('other dimensions unchanged');
@@ -136,6 +156,12 @@ function withoutLandedSection(body: string): string {
 
 interface PrRef {
   readonly number: number;
+  readonly merge_commit_sha?: string | null;
+  readonly merged_at?: string | null;
+  readonly base?: {
+    readonly ref?: string;
+    readonly repo?: { readonly default_branch?: string };
+  };
 }
 interface CommentRef {
   readonly id: number;
@@ -150,17 +176,63 @@ interface CommentRef {
  */
 export function updateLandedComment(inputs: LandedCommentInputs): LandedCommentOutcome {
   const { slug, sha, exec } = inputs;
+
+  // Rule 19 cause 5, the cron-rewrite guard: a scheduled re-publish at the
+  // same sha can re-score under DIFFERENT tooling (a scanner gone, a
+  // fallback engaged). A landed line diffed across that boundary would
+  // attribute tooling drift to the merged PR, so the update becomes a
+  // disclosed skip and the comment (including any earlier, honest landed
+  // line) is left untouched.
+  const inputsDrift =
+    inputs.prev !== undefined
+      ? describeScoreInputsDrift(inputs.prev.scoreInputs, inputs.entry.scoreInputs)
+      : null;
+  if (inputsDrift !== null) {
+    return {
+      status: 'skipped',
+      reason:
+        `score inputs drifted between the snapshots (${inputsDrift}); updating the landed ` +
+        'line would attribute tooling drift to the pull request',
+    };
+  }
+
   let prNumber: number;
   try {
     const raw = exec(['api', `repos/${slug}/commits/${sha}/pulls`]);
     const prs = JSON.parse(raw) as ReadonlyArray<PrRef>;
-    if (!Array.isArray(prs) || prs.length === 0 || typeof prs[0]?.number !== 'number') {
+    const list = Array.isArray(prs) ? prs.filter((p) => typeof p?.number === 'number') : [];
+    if (list.length === 0) {
       return {
         status: 'skipped',
         reason: `no merged pull request found for ${sha.slice(0, 12)} (direct push or squash outside a PR)`,
       };
     }
-    prNumber = prs[0].number;
+    // The listing contains every PR whose commits INCLUDE the sha (rebase and
+    // fast-forward flows list several, order unspecified), so `[0]` can be
+    // the wrong PR. The merge-commit match is the authoritative association;
+    // failing that, exactly one merged candidate based on the default branch
+    // is accepted; anything else is a disclosed skip, never a guess.
+    const bySha = list.find((p) => p.merge_commit_sha === sha);
+    if (bySha !== undefined) {
+      prNumber = bySha.number;
+    } else {
+      const merged = list.filter(
+        (p) =>
+          typeof p.merged_at === 'string' &&
+          p.base?.ref !== undefined &&
+          p.base.ref === p.base.repo?.default_branch,
+      );
+      if (merged.length !== 1) {
+        return {
+          status: 'skipped',
+          reason:
+            `ambiguous pull-request association for ${sha.slice(0, 12)}: ${list.length} ` +
+            'containing PRs, no merge-commit match, and not exactly one merged ' +
+            'default-branch candidate',
+        };
+      }
+      prNumber = merged[0]!.number;
+    }
   } catch (err) {
     return {
       status: 'skipped',

--- a/src/reports/landed-comment.ts
+++ b/src/reports/landed-comment.ts
@@ -1,0 +1,223 @@
+/**
+ * The post-merge landed update (impact surface P2): after the reports lane
+ * publishes a merge's snapshot, update the merged PR's EXISTING guardrail
+ * comment with "Landed: security 40 -> 46 (actual; projection was 46)".
+ *
+ * One comment identity: the guardrail workflow finds-and-patches its PR
+ * comment by the `<!-- dxkit-guardrails -->` marker; this update PATCHes the
+ * SAME comment (found by the same marker), appending/replacing a landed
+ * section delimited by its own inner marker so re-runs are idempotent. It
+ * never posts a second comment.
+ *
+ * Calibration is the point: the projection the pre-merge comment carried (in
+ * the hidden `dxkit-impact-projection` marker) is rendered BESIDE the actual,
+ * deliberately: quiet honest calibration over marketing.
+ *
+ * Degradation contract: every failure (no merged PR for the sha, no
+ * guardrail comment, a token without `pull-requests: write`) returns a
+ * disclosed `skipped` outcome the lane surfaces in its summary. This module
+ * never throws and never fails the snapshot lane.
+ */
+
+import { execFileSync } from 'child_process';
+import { scoreDeltas, type ReportHistoryEntry, type ScoreDelta } from './history';
+import {
+  parseImpactProjectionMarker,
+  PROJECTION_DIMENSION_KEYS,
+  type ImpactProjectionRecord,
+} from '../baseline/impact-projection';
+
+/**
+ * The guardrail PR comment's identity marker. The rendered workflow template
+ * (`src-templates/.github/workflows/dxkit-guardrails.yml`) writes the same
+ * literal in shell; `test/reports/landed-comment.test.ts` pins the two equal
+ * so the identities cannot fork.
+ */
+export const GUARDRAIL_COMMENT_MARKER = '<!-- dxkit-guardrails -->';
+
+/** The landed section's inner marker: everything from here to the end of the
+ *  comment is the landed section, replaced whole on a re-run. */
+export const IMPACT_LANDED_MARKER = '<!-- dxkit-impact-landed -->';
+
+/** Injected `gh` executor (tests stub it; production shells out). Must throw
+ *  on a non-zero exit, with the CLI's message on the error. */
+export type GhExec = (args: ReadonlyArray<string>, opts?: { readonly input?: string }) => string;
+
+/** Production executor: `gh` with the ambient GH_TOKEN. */
+export function defaultGhExec(args: ReadonlyArray<string>, opts?: { input?: string }): string {
+  return execFileSync('gh', [...args], {
+    encoding: 'utf8',
+    ...(opts?.input !== undefined ? { input: opts.input } : {}),
+    stdio: [opts?.input !== undefined ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+    maxBuffer: 32 * 1024 * 1024,
+  }).toString();
+}
+
+export interface LandedCommentInputs {
+  /** `owner/repo` slug. */
+  readonly slug: string;
+  /** The merge commit the snapshot was computed at. */
+  readonly sha: string;
+  /** The snapshot just published (the actual). */
+  readonly entry: ReportHistoryEntry;
+  /** The snapshot before it (the base the org had seen). Absent on the
+   *  first-ever snapshot. */
+  readonly prev?: ReportHistoryEntry;
+  readonly exec: GhExec;
+}
+
+export interface LandedCommentOutcome {
+  readonly status: 'updated' | 'skipped';
+  /** Disclosed cause when skipped (the lane summary renders it). */
+  readonly reason?: string;
+  readonly prNumber?: number;
+}
+
+/** One landed line per dimension, one phrasing:
+ *  `security 40 -> 46 (actual; projection was 46)`. */
+function landedLine(delta: ScoreDelta, projected?: { readonly to: number }): string {
+  const suffix = projected !== undefined ? `; projection was ${projected.to}` : '';
+  return `${delta.key} ${delta.from} -> ${delta.to} (actual${suffix})`;
+}
+
+/**
+ * Render the landed section body (pure; exported for tests). Honesty rules
+ * mirror the projection line's: actual labeled actual, zero reported as
+ * zero, cross-methodology disclosed instead of diffed, and a dimension is
+ * listed when it MOVED or when a projection existed for it (a flat actual
+ * against a moving projection is exactly the calibration signal).
+ */
+export function renderLandedSection(
+  entry: ReportHistoryEntry,
+  prev: ReportHistoryEntry | undefined,
+  projection: ImpactProjectionRecord | null,
+): string {
+  const lines: string[] = [IMPACT_LANDED_MARKER, '', '### Landed', ''];
+  if (!prev) {
+    lines.push(
+      `First score snapshot on record at ${entry.sha.slice(0, 12)}` +
+        (typeof entry.scores.overall === 'number' ? ` (overall ${entry.scores.overall})` : '') +
+        '; movement becomes reportable from the next merge.',
+    );
+    return lines.join('\n');
+  }
+  if (prev.methodology === undefined || prev.methodology !== entry.methodology) {
+    lines.push(
+      'Scores not comparable across these snapshots: the prior snapshot was scored under ' +
+        `${prev.methodology !== undefined ? `methodology '${prev.methodology}'` : 'an unstamped methodology'} ` +
+        `and this one under '${entry.methodology ?? 'unstamped'}'. The trend realigns from this snapshot on.`,
+    );
+    return lines.join('\n');
+  }
+  const deltas = scoreDeltas(prev.scores, entry.scores).filter((d) =>
+    PROJECTION_DIMENSION_KEYS.includes(d.key),
+  );
+  const listed = deltas.filter(
+    (d) => d.delta !== null && (d.delta !== 0 || projection?.scores[d.key] !== undefined),
+  );
+  const parts = listed.map((d) => landedLine(d, projection?.scores[d.key]));
+  const measured = deltas.filter((d) => d.delta !== null);
+  if (parts.length === 0) parts.push('scores unchanged (actual)');
+  else if (listed.length < measured.length) parts.push('other dimensions unchanged');
+  lines.push(`Landed: ${parts.join(' · ')}`);
+  const overall = scoreDeltas(prev.scores, entry.scores).find((d) => d.key === 'overall');
+  if (overall && overall.delta !== null && overall.delta !== 0) {
+    lines.push('');
+    lines.push(`Repo overall: ${overall.from} -> ${overall.to}.`);
+  }
+  return lines.join('\n');
+}
+
+/** Strip any previous landed section so a re-run replaces, never stacks. */
+function withoutLandedSection(body: string): string {
+  const at = body.indexOf(IMPACT_LANDED_MARKER);
+  return at === -1 ? body : body.slice(0, at).replace(/\s+$/, '');
+}
+
+interface PrRef {
+  readonly number: number;
+}
+interface CommentRef {
+  readonly id: number;
+  readonly body: string;
+}
+
+/**
+ * Find the merged PR for the sha, find the guardrail comment on it, and
+ * PATCH the landed section into the same comment. Disclosed skip on every
+ * missing precondition or API refusal (a `GITHUB_TOKEN` without
+ * `pull-requests: write` lands here), never a throw.
+ */
+export function updateLandedComment(inputs: LandedCommentInputs): LandedCommentOutcome {
+  const { slug, sha, exec } = inputs;
+  let prNumber: number;
+  try {
+    const raw = exec(['api', `repos/${slug}/commits/${sha}/pulls`]);
+    const prs = JSON.parse(raw) as ReadonlyArray<PrRef>;
+    if (!Array.isArray(prs) || prs.length === 0 || typeof prs[0]?.number !== 'number') {
+      return {
+        status: 'skipped',
+        reason: `no merged pull request found for ${sha.slice(0, 12)} (direct push or squash outside a PR)`,
+      };
+    }
+    prNumber = prs[0].number;
+  } catch (err) {
+    return {
+      status: 'skipped',
+      reason: `could not look up the merged pull request: ${(err as Error).message}`,
+    };
+  }
+
+  let comment: CommentRef | undefined;
+  try {
+    const raw = exec(['api', '--paginate', `repos/${slug}/issues/${prNumber}/comments`]);
+    const comments = JSON.parse(raw) as ReadonlyArray<CommentRef>;
+    comment = comments.find(
+      (c) => typeof c.body === 'string' && c.body.startsWith(GUARDRAIL_COMMENT_MARKER),
+    );
+  } catch (err) {
+    return {
+      status: 'skipped',
+      reason: `could not list PR #${prNumber} comments: ${(err as Error).message}`,
+      prNumber,
+    };
+  }
+  if (!comment) {
+    return {
+      status: 'skipped',
+      reason: `PR #${prNumber} has no dxkit guardrail comment to update`,
+      prNumber,
+    };
+  }
+
+  const projection = parseImpactProjectionMarker(comment.body);
+  const section = renderLandedSection(inputs.entry, inputs.prev, projection);
+  const body = `${withoutLandedSection(comment.body)}\n\n${section}\n`;
+  try {
+    exec(['api', '-X', 'PATCH', `repos/${slug}/issues/comments/${comment.id}`, '-F', 'body=@-'], {
+      input: body,
+    });
+  } catch (err) {
+    return {
+      status: 'skipped',
+      reason:
+        `could not update the guardrail comment on PR #${prNumber}: ${(err as Error).message} ` +
+        `(the reports workflow needs 'pull-requests: write' for this step)`,
+      prNumber,
+    };
+  }
+  return { status: 'updated', prNumber };
+}
+
+/** Resolve the `owner/repo` slug: the Actions env first, else `gh`. Null when
+ *  neither answers (a local run outside any GitHub remote). */
+export function resolveRepoSlug(exec: GhExec, env: NodeJS.ProcessEnv = process.env): string | null {
+  const fromEnv = env.GITHUB_REPOSITORY;
+  if (fromEnv && /^[^/\s]+\/[^/\s]+$/.test(fromEnv)) return fromEnv;
+  try {
+    const slug = exec(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner']).trim();
+    return /^[^/\s]+\/[^/\s]+$/.test(slug) ? slug : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/reports/snapshot.ts
+++ b/src/reports/snapshot.ts
@@ -20,6 +20,7 @@ import {
   publishFilesToAnchorRef,
   type PublishResult,
 } from '../baseline/anchor-publish';
+import { SCORING_METHODOLOGY_VERSION } from '../scoring/methodology';
 
 /** Default side ref for report snapshots (kept distinct from the baseline anchor
  *  `dxkit-baselines` so report churn/retention never touches the baseline). */
@@ -57,11 +58,16 @@ function dimScore(src: SnapshotSource, key: keyof SnapshotSource['dimensions']):
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
 }
 
-/** Pure map from a scored report to the durable history entry. The `tests` field
- *  reads the report's `testing` dimension (the dimension is named `testing`; the
- *  entry field stays `tests` for brevity + JSON stability). */
-export function reportToHistoryEntry(src: SnapshotSource, meta: SnapshotMeta): ReportHistoryEntry {
-  const scores: ReportScores = {
+/**
+ * The ONE map from a scored report's dimensions to the durable `ReportScores`
+ * shape (the `tests` field reads the report's `testing` dimension; the entry
+ * field stays `tests` for brevity + JSON stability). Both the snapshot
+ * publisher and the guardrail's score projection (impact surface P2) read
+ * through this, so "the number the org has seen" and "the number a PR
+ * projects" can never come from two different mappings.
+ */
+export function scoresFromReport(src: SnapshotSource): ReportScores {
+  return {
     overall: typeof src.summary.overallScore === 'number' ? src.summary.overallScore : null,
     security: dimScore(src, 'security'),
     quality: dimScore(src, 'quality'),
@@ -70,12 +76,19 @@ export function reportToHistoryEntry(src: SnapshotSource, meta: SnapshotMeta): R
     maintainability: dimScore(src, 'maintainability'),
     developerExperience: dimScore(src, 'developerExperience'),
   };
+}
+
+/** Pure map from a scored report to the durable history entry. Stamps the
+ *  scoring-methodology identity so later score comparisons can verify they
+ *  compare like with like (impact P2 honesty constraint 4). */
+export function reportToHistoryEntry(src: SnapshotSource, meta: SnapshotMeta): ReportHistoryEntry {
   return {
     sha: meta.sha,
     date: meta.date,
     dxkitVersion: meta.dxkitVersion,
     ...(meta.branch ? { branch: meta.branch } : {}),
-    scores,
+    methodology: SCORING_METHODOLOGY_VERSION,
+    scores: scoresFromReport(src),
     ...(src.findings ? { findings: src.findings } : {}),
   };
 }
@@ -105,6 +118,13 @@ export interface PublishSnapshotResult {
   /** History length after the fold (what was written). */
   readonly historyCount: number;
   readonly anchorRef: string;
+  /**
+   * The most recent PRIOR entry (a different sha than the one just folded):
+   * the base the org had already seen before this snapshot. The post-merge
+   * landed-comment update diffs the new entry against exactly this.
+   * Undefined on the first-ever snapshot.
+   */
+  readonly previousEntry?: ReportHistoryEntry;
 }
 
 /**
@@ -116,6 +136,7 @@ export interface PublishSnapshotResult {
 export function publishReportSnapshot(opts: PublishSnapshotOptions): PublishSnapshotResult {
   const anchorRef = opts.anchorRef ?? DEFAULT_REPORTS_REF;
   const existing = parseHistory(readFromAnchorRef(opts.cwd, anchorRef, REPORT_HISTORY_PATH));
+  const previousEntry = [...existing].reverse().find((e) => e.sha !== opts.entry.sha);
   const folded = foldEntry(existing, opts.entry, opts.retainHistory ?? 0);
 
   const files = [
@@ -131,7 +152,12 @@ export function publishReportSnapshot(opts: PublishSnapshotOptions): PublishSnap
     ...(opts.identity ? { identity: opts.identity } : {}),
     ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
   });
-  return { publish, historyCount: folded.length, anchorRef };
+  return {
+    publish,
+    historyCount: folded.length,
+    anchorRef,
+    ...(previousEntry ? { previousEntry } : {}),
+  };
 }
 
 /** Read the full history back off the anchor (the `report history` consumer). */

--- a/src/reports/snapshot.ts
+++ b/src/reports/snapshot.ts
@@ -11,9 +11,12 @@ import {
   parseHistory,
   serializeHistory,
   foldEntry,
+  SCORE_KEY_TO_DIMENSION,
   type ReportHistoryEntry,
   type ReportScores,
   type ReportFindingCounts,
+  type ScoreDimensionKey,
+  type ReportDimensionName,
 } from './history';
 import {
   readFromAnchorRef,
@@ -33,17 +36,15 @@ export const REPORT_HISTORY_PATH = 'report-history.jsonl';
 export interface SnapshotSource {
   readonly summary: { readonly overallScore: number | null };
   readonly dimensions: Partial<
-    Record<
-      | 'testing'
-      | 'quality'
-      | 'documentation'
-      | 'security'
-      | 'maintainability'
-      | 'developerExperience',
-      { readonly score: number | null } | undefined
-    >
+    Record<ReportDimensionName, { readonly score: number | null } | undefined>
   >;
   readonly findings?: ReportFindingCounts;
+  /** Tools that ran for this report (mirrors `HealthReport.toolsUsed`). */
+  readonly toolsUsed?: ReadonlyArray<string>;
+  /** Tools attempted but unavailable (`HealthReport.toolsUnavailable`);
+   *  entries may carry a machine-phrased reason suffix that is stripped
+   *  before stamping. */
+  readonly toolsUnavailable?: ReadonlyArray<string>;
 }
 
 export interface SnapshotMeta {
@@ -67,20 +68,69 @@ function dimScore(src: SnapshotSource, key: keyof SnapshotSource['dimensions']):
  * projects" can never come from two different mappings.
  */
 export function scoresFromReport(src: SnapshotSource): ReportScores {
-  return {
+  const out = {
     overall: typeof src.summary.overallScore === 'number' ? src.summary.overallScore : null,
-    security: dimScore(src, 'security'),
-    quality: dimScore(src, 'quality'),
-    tests: dimScore(src, 'testing'),
-    documentation: dimScore(src, 'documentation'),
-    maintainability: dimScore(src, 'maintainability'),
-    developerExperience: dimScore(src, 'developerExperience'),
-  };
+  } as Record<keyof ReportScores, number | null>;
+  for (const key of Object.keys(SCORE_KEY_TO_DIMENSION) as ScoreDimensionKey[]) {
+    out[key] = dimScore(src, SCORE_KEY_TO_DIMENSION[key]);
+  }
+  return out as ReportScores;
+}
+
+/**
+ * The score-relevant tool inputs of a report, in the ONE normalized shape
+ * both comparability guards read (`computeScoreProjection` pre-merge,
+ * `renderLandedSection` / the landed skip post-merge): sorted unique tool
+ * names that ran, plus `!name` for a tool attempted but unavailable (the
+ * reason suffix is stripped: it can phrase machine specifics, and Rule 19
+ * bans machine-specific values in comparability inputs). Deterministic per
+ * environment; a difference between two environments is exactly the drift
+ * the guards must disclose.
+ */
+export function scoreToolInputs(src: {
+  readonly toolsUsed?: ReadonlyArray<string>;
+  readonly toolsUnavailable?: ReadonlyArray<string>;
+}): string[] {
+  const names = new Set<string>();
+  for (const tool of src.toolsUsed ?? []) {
+    const name = tool.trim();
+    if (name) names.add(name);
+  }
+  for (const tool of src.toolsUnavailable ?? []) {
+    const name = tool.split(' (')[0]!.trim();
+    if (name) names.add(`!${name}`);
+  }
+  return [...names].sort();
+}
+
+/**
+ * Human-renderable description of score-input drift between two stamped
+ * input lists, or null when they match. Null when EITHER side is unstamped:
+ * a pre-stamping entry also lacks `methodology`, and that guard owns the
+ * disclosure for old entries; this one never claims drift it cannot see.
+ */
+export function describeScoreInputsDrift(
+  base: ReadonlyArray<string> | undefined,
+  current: ReadonlyArray<string> | undefined,
+): string | null {
+  if (base === undefined || current === undefined) return null;
+  const baseSet = new Set(base);
+  const currentSet = new Set(current);
+  const gone = base.filter((t) => !currentSet.has(t));
+  const added = current.filter((t) => !baseSet.has(t));
+  if (gone.length === 0 && added.length === 0) return null;
+  const cap = (list: string[]): string =>
+    list.slice(0, 4).join(', ') + (list.length > 4 ? ` and ${list.length - 4} more` : '');
+  const parts: string[] = [];
+  if (gone.length > 0) parts.push(`at the base but not now: ${cap(gone)}`);
+  if (added.length > 0) parts.push(`now but not at the base: ${cap(added)}`);
+  return `the tools behind the scores differ (${parts.join('; ')})`;
 }
 
 /** Pure map from a scored report to the durable history entry. Stamps the
- *  scoring-methodology identity so later score comparisons can verify they
- *  compare like with like (impact P2 honesty constraint 4). */
+ *  scoring-methodology identity AND the score-input list so later score
+ *  comparisons can verify they compare like with like (impact P2 honesty
+ *  constraint 4 + Rule 19 cause 5). */
 export function reportToHistoryEntry(src: SnapshotSource, meta: SnapshotMeta): ReportHistoryEntry {
   return {
     sha: meta.sha,
@@ -88,6 +138,7 @@ export function reportToHistoryEntry(src: SnapshotSource, meta: SnapshotMeta): R
     dxkitVersion: meta.dxkitVersion,
     ...(meta.branch ? { branch: meta.branch } : {}),
     methodology: SCORING_METHODOLOGY_VERSION,
+    scoreInputs: scoreToolInputs(src),
     scores: scoresFromReport(src),
     ...(src.findings ? { findings: src.findings } : {}),
   };

--- a/src/scoring/index.ts
+++ b/src/scoring/index.ts
@@ -12,6 +12,7 @@ export type { Rating, CapTier, Deduction, CapApplied, TopAction, ScoreResult } f
 export type { PenaltyRule, CapRule, DimensionScoringSpec } from './spec';
 
 export { RATING_THRESHOLDS, CAP_TIERS, ratingFromScore } from './thresholds';
+export { SCORING_METHODOLOGY_VERSION } from './methodology';
 export { evaluateSpec } from './evaluator';
 export { formatTopActionLine, formatTopActionsBlock } from './format';
 export type { ScoreResultLike } from './format';

--- a/src/scoring/methodology.ts
+++ b/src/scoring/methodology.ts
@@ -1,0 +1,28 @@
+/**
+ * The scoring-methodology identity (impact surface P2, honesty constraint 4).
+ *
+ * A score is only comparable to another score computed under the SAME
+ * methodology: the same dimension specs, penalty rules, cap tiers, and
+ * rating thresholds. Comparing across methodology versions produced the
+ * observed 0 -> 20 -> 0 trend blip: the score "moved" because the ruler
+ * changed, not the repo. This is the recall-context discipline (CLAUDE.md
+ * Rule 19) applied to scores: two numbers are diffable only when their
+ * provenance matches, and a mismatch is DISCLOSED as not comparable, never
+ * silently diffed.
+ *
+ * The constant is stamped on every published `ReportHistoryEntry`
+ * (`reportToHistoryEntry`) and checked by the guardrail's score projection
+ * before it renders a "40 -> 46 (projected)" line against a snapshot score.
+ *
+ * BUMP THIS whenever a change to `src/scoring/` (specs, thresholds, cap
+ * tiers, the overall weighting) alters what a score MEANS: after the bump,
+ * projections against pre-bump snapshots disclose "not comparable this PR"
+ * until the next merge snapshot realigns the history. Do not bump for
+ * changes that cannot move any score (comments, refactors, new consumers).
+ *
+ * A snapshot with NO methodology stamp (written by a pre-4.4.7 dxkit)
+ * carries no evidence either way, so it reads as not comparable, mirroring
+ * "absent recall is not comparable": never stamp or assume the current
+ * version onto old data.
+ */
+export const SCORING_METHODOLOGY_VERSION = 'spec-v1';

--- a/test/analysis-result-cache.test.ts
+++ b/test/analysis-result-cache.test.ts
@@ -27,6 +27,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   readOrBuildAnalysisResult,
+  peekAnalysisResult,
   resolveProvenance,
   clearInMemoryCache,
   type ResolvedProvenance,
@@ -94,6 +95,34 @@ function stubBody(): AnalysisResultBody {
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('peekAnalysisResult (the never-build probe)', () => {
+  it('returns the envelope a full-scope gather left behind, without building', async () => {
+    const provenance = makeProvenance();
+    const opts = { resolveProvenance: () => provenance, cacheDir };
+    await readOrBuildAnalysisResult({ cwd: tmp, build: async () => stubBody(), opts });
+    const peeked = await peekAnalysisResult(tmp, opts);
+    expect(peeked?.commitSha).toBe('abc1234');
+  });
+
+  it('returns null when nothing full covers the tree: it NEVER builds', async () => {
+    const provenance = makeProvenance({ workingTreeDirty: true });
+    const opts = { resolveProvenance: () => provenance, cacheDir };
+    expect(await peekAnalysisResult(tmp, opts)).toBeNull();
+  });
+
+  it('a partial (scoped) gather bypasses the shared cache, so peek stays null', async () => {
+    const provenance = makeProvenance();
+    const opts = { resolveProvenance: () => provenance, cacheDir };
+    await readOrBuildAnalysisResult({
+      cwd: tmp,
+      build: async () => stubBody(),
+      opts: { ...opts, partial: true },
+    });
+    // The partial result was never admitted to memory or disk: honest null.
+    expect(await peekAnalysisResult(tmp, opts)).toBeNull();
+  });
+});
 
 describe('readOrBuildAnalysisResult', () => {
   it('builds on first call and stamps provenance fields', async () => {

--- a/test/baseline/impact-projection.test.ts
+++ b/test/baseline/impact-projection.test.ts
@@ -1,0 +1,281 @@
+/**
+ * The score projection (impact surface P2): pure core + IO wrapper seams.
+ *
+ * Pins the honesty constraints as behavior:
+ *
+ *   - methodology guard BOTH directions: same version projects; a different
+ *     or absent version discloses "not comparable" and diffs nothing;
+ *   - base-from-snapshot: the base side is the history's latest entry, and
+ *     a missing/empty history is a disclosed unavailable, never an invented
+ *     base;
+ *   - reuse-first: the wrapper never builds an analysis (peek-only), and
+ *     when there is no shared envelope it does not even read the history
+ *     (no network fetch on the path that cannot project);
+ *   - the policy knob both values (default on; `false` disables with a
+ *     disclosed status);
+ *   - one phrasing: every rendered form labels the number projected, zero
+ *     is reported as zero, unmeasured dimensions are named.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeScoreProjection,
+  formatScoreProjection,
+  gatherScoreProjection,
+  impactProjectionMarker,
+  impactScoreInputsFromReport,
+  parseImpactProjectionMarker,
+  type ScoreProjection,
+} from '../../src/baseline/impact-projection';
+import { SCORING_METHODOLOGY_VERSION } from '../../src/scoring/methodology';
+import type { ReportHistoryEntry, ReportScores } from '../../src/reports/history';
+import type { HealthReport } from '../../src/analyzers/types';
+
+function scores(overrides: Partial<ReportScores> = {}): ReportScores {
+  return {
+    overall: 50,
+    security: 40,
+    quality: 60,
+    tests: 55,
+    documentation: 30,
+    maintainability: 70,
+    developerExperience: 65,
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<ReportHistoryEntry> = {}): ReportHistoryEntry {
+  return {
+    sha: 'aaaabbbbccccdddd',
+    date: '2026-08-20T00:00:00.000Z',
+    dxkitVersion: '4.4.7',
+    methodology: SCORING_METHODOLOGY_VERSION,
+    scores: scores(),
+    ...overrides,
+  };
+}
+
+describe('computeScoreProjection (pure core)', () => {
+  it('projects per-dimension deltas against the latest snapshot under a matching methodology', () => {
+    const projection = computeScoreProjection({
+      current: scores({ security: 46, overall: 52 }),
+      methodology: SCORING_METHODOLOGY_VERSION,
+      history: [entry({ sha: 'older', scores: scores({ security: 10 }) }), entry()],
+    });
+    expect(projection.status).toBe('projected');
+    if (projection.status !== 'projected') return;
+    // The base is the LATEST entry, not an older one.
+    expect(projection.base.sha).toBe('aaaabbbbccccdddd');
+    const security = projection.deltas.find((d) => d.key === 'security');
+    expect(security).toEqual({ key: 'security', from: 40, to: 46, delta: 6 });
+    // Zero movement is present as zero, never dropped.
+    const quality = projection.deltas.find((d) => d.key === 'quality');
+    expect(quality).toEqual({ key: 'quality', from: 60, to: 60, delta: 0 });
+  });
+
+  it('discloses a methodology MISMATCH as not comparable and diffs nothing', () => {
+    const projection = computeScoreProjection({
+      current: scores({ security: 46 }),
+      methodology: SCORING_METHODOLOGY_VERSION,
+      history: [entry({ methodology: 'spec-v0' })],
+    });
+    expect(projection.status).toBe('not-comparable');
+    if (projection.status !== 'not-comparable') return;
+    expect(projection.reason).toContain("'spec-v0'");
+    expect(projection.reason).toContain(`'${SCORING_METHODOLOGY_VERSION}'`);
+  });
+
+  it('treats an UNSTAMPED base snapshot as not comparable (absent evidence is not evidence)', () => {
+    const unstamped: ReportHistoryEntry = {
+      sha: entry().sha,
+      date: entry().date,
+      dxkitVersion: entry().dxkitVersion,
+      scores: scores(),
+    };
+    const projection = computeScoreProjection({
+      current: scores(),
+      methodology: SCORING_METHODOLOGY_VERSION,
+      history: [unstamped],
+    });
+    expect(projection.status).toBe('not-comparable');
+    if (projection.status !== 'not-comparable') return;
+    expect(projection.reason).toContain('predates scoring-methodology stamping');
+  });
+
+  it('discloses an empty history as unavailable, never inventing a base', () => {
+    const projection = computeScoreProjection({
+      current: scores(),
+      methodology: SCORING_METHODOLOGY_VERSION,
+      history: [],
+    });
+    expect(projection.status).toBe('unavailable');
+    if (projection.status !== 'unavailable') return;
+    expect(projection.reason).toContain('no score history');
+  });
+});
+
+describe('gatherScoreProjection (IO wrapper seams)', () => {
+  const report = {
+    dimensions: {
+      security: { score: 46, capsApplied: [], topActions: [] },
+      quality: { score: 60 },
+      testing: { score: 55 },
+      documentation: { score: 30 },
+      maintainability: { score: 70 },
+      developerExperience: { score: 65 },
+    },
+    summary: { overallScore: 52 },
+  } as unknown as HealthReport;
+
+  it('policy knob false => disabled, and neither the envelope nor the history is touched', async () => {
+    let peeked = 0;
+    let read = 0;
+    const out = await gatherScoreProjection(
+      '/nowhere',
+      { impact: { projectScores: false } },
+      {
+        peek: async () => {
+          peeked += 1;
+          return { report };
+        },
+        readHistory: () => {
+          read += 1;
+          return [entry()];
+        },
+      },
+    );
+    expect(out.projection.status).toBe('disabled');
+    expect(out.scoreInputs).toBeUndefined();
+    expect(peeked).toBe(0);
+    expect(read).toBe(0);
+  });
+
+  it('knob absent (default on) => projects when the envelope and a comparable snapshot exist', async () => {
+    const out = await gatherScoreProjection(
+      '/nowhere',
+      {},
+      {
+        peek: async () => ({ report }),
+        readHistory: () => [entry()],
+      },
+    );
+    expect(out.projection.status).toBe('projected');
+    if (out.projection.status !== 'projected') return;
+    const security = out.projection.deltas.find((d) => d.key === 'security');
+    expect(security?.delta).toBe(6);
+    // Same-run score inputs (the cap-aware slot) come out beside it.
+    expect(out.scoreInputs?.map((s) => s.dimension)).toContain('security');
+  });
+
+  it('no shared envelope => disclosed unavailable, and the history is NOT read (no fetch on a path that cannot project)', async () => {
+    let read = 0;
+    const out = await gatherScoreProjection(
+      '/nowhere',
+      {},
+      {
+        peek: async () => null,
+        readHistory: () => {
+          read += 1;
+          return [entry()];
+        },
+      },
+    );
+    expect(out.projection.status).toBe('unavailable');
+    if (out.projection.status !== 'unavailable') return;
+    expect(out.projection.reason).toContain('trimmed analysis');
+    expect(read).toBe(0);
+  });
+
+  it('a throwing seam degrades to a disclosed unavailable, never an exception into the gate', async () => {
+    const out = await gatherScoreProjection(
+      '/nowhere',
+      {},
+      {
+        peek: async () => {
+          throw new Error('boom from the envelope');
+        },
+        readHistory: () => [],
+      },
+    );
+    expect(out.projection.status).toBe('unavailable');
+    if (out.projection.status !== 'unavailable') return;
+    expect(out.projection.reason).toContain('boom from the envelope');
+  });
+});
+
+describe('impactScoreInputsFromReport', () => {
+  it('maps report dimensions onto the durable score-key vocabulary (testing -> tests)', () => {
+    const report = {
+      dimensions: {
+        security: { score: 40, capsApplied: [{ id: 'x' }], topActions: [] },
+        testing: { score: 55 },
+      },
+      summary: { overallScore: 50 },
+    } as unknown as HealthReport;
+    const inputs = impactScoreInputsFromReport(report);
+    expect(inputs.map((i) => i.dimension)).toEqual(['security', 'tests']);
+    expect(inputs[0]?.capsApplied).toHaveLength(1);
+  });
+});
+
+describe('formatScoreProjection (one phrasing)', () => {
+  function projected(current: Partial<ReportScores>): ScoreProjection {
+    return computeScoreProjection({
+      current: scores(current),
+      methodology: SCORING_METHODOLOGY_VERSION,
+      history: [entry()],
+    });
+  }
+
+  it('movement: names the moved dimension, labels it projected, folds the flat rest', () => {
+    const line = formatScoreProjection(projected({ security: 46 }));
+    expect(line).toBe('security 40 -> 46 (projected) · other dimensions unchanged');
+  });
+
+  it('zero movement is reported as zero, still labeled projected', () => {
+    expect(formatScoreProjection(projected({}))).toBe('scores unchanged (projected)');
+  });
+
+  it('an unmeasured dimension is named, never silently dropped', () => {
+    const line = formatScoreProjection(projected({ security: 46, tests: null }));
+    expect(line).toContain('security 40 -> 46 (projected)');
+    expect(line).toContain('tests not projected (unmeasured)');
+  });
+
+  it('not-comparable and unavailable render their disclosure; disabled renders nothing', () => {
+    expect(formatScoreProjection({ status: 'not-comparable', reason: 'versions differ' })).toBe(
+      'scores not comparable this PR: versions differ',
+    );
+    expect(formatScoreProjection({ status: 'unavailable', reason: 'no history' })).toBe(
+      'scores not projected: no history',
+    );
+    expect(formatScoreProjection({ status: 'disabled', reason: 'off' })).toBeNull();
+  });
+});
+
+describe('the projection marker codec', () => {
+  it('round-trips measured dimensions + methodology through the hidden marker', () => {
+    const projection = computeScoreProjection({
+      current: scores({ security: 46, tests: null }),
+      methodology: SCORING_METHODOLOGY_VERSION,
+      history: [entry({ scores: scores({ tests: null }) })],
+    });
+    const marker = impactProjectionMarker(projection);
+    expect(marker).not.toBeNull();
+    const parsed = parseImpactProjectionMarker(`prefix text\n${marker}\nsuffix`);
+    expect(parsed?.methodology).toBe(SCORING_METHODOLOGY_VERSION);
+    expect(parsed?.scores.security).toEqual({ from: 40, to: 46 });
+    // Unmeasured on either side never enters the marker.
+    expect(parsed?.scores.tests).toBeUndefined();
+    // Overall stays out (a P3 concern).
+    expect(parsed?.scores.overall).toBeUndefined();
+  });
+
+  it('non-projected outcomes emit no marker; a malformed marker parses to null', () => {
+    expect(impactProjectionMarker({ status: 'unavailable', reason: 'x' })).toBeNull();
+    expect(parseImpactProjectionMarker('no marker here')).toBeNull();
+    expect(parseImpactProjectionMarker('<!-- dxkit-impact-projection not-json -->')).toBeNull();
+    expect(
+      parseImpactProjectionMarker('<!-- dxkit-impact-projection {"scores":{}} -->'),
+    ).toBeNull();
+  });
+});

--- a/test/baseline/impact-projection.test.ts
+++ b/test/baseline/impact-projection.test.ts
@@ -101,6 +101,48 @@ describe('computeScoreProjection (pure core)', () => {
     expect(projection.reason).toContain('predates scoring-methodology stamping');
   });
 
+  it('score-input drift => not comparable, naming the moved input, both directions', () => {
+    const gone = computeScoreProjection({
+      current: scores({ security: 46 }),
+      methodology: SCORING_METHODOLOGY_VERSION,
+      inputs: ['grep-secrets', 'semgrep'],
+      history: [entry({ scoreInputs: ['gitleaks', 'semgrep'] })],
+    });
+    expect(gone.status).toBe('not-comparable');
+    if (gone.status !== 'not-comparable') return;
+    expect(gone.reason).toContain('gitleaks');
+    expect(gone.reason).toContain('grep-secrets');
+
+    const added = computeScoreProjection({
+      current: scores({ security: 46 }),
+      methodology: SCORING_METHODOLOGY_VERSION,
+      inputs: ['gitleaks', 'semgrep', '!osv-scanner'],
+      history: [entry({ scoreInputs: ['gitleaks', 'semgrep'] })],
+    });
+    expect(added.status).toBe('not-comparable');
+    if (added.status !== 'not-comparable') return;
+    expect(added.reason).toContain('!osv-scanner');
+  });
+
+  it('matching score inputs project; an unstamped side defers to the methodology guard', () => {
+    const matching = computeScoreProjection({
+      current: scores({ security: 46 }),
+      methodology: SCORING_METHODOLOGY_VERSION,
+      inputs: ['gitleaks', 'semgrep'],
+      history: [entry({ scoreInputs: ['gitleaks', 'semgrep'] })],
+    });
+    expect(matching.status).toBe('projected');
+    // A base entry without the stamp (methodology present, inputs absent:
+    // theoretical) never claims drift it cannot see.
+    const unstamped = computeScoreProjection({
+      current: scores({ security: 46 }),
+      methodology: SCORING_METHODOLOGY_VERSION,
+      inputs: ['gitleaks'],
+      history: [entry()],
+    });
+    expect(unstamped.status).toBe('projected');
+  });
+
   it('discloses an empty history as unavailable, never inventing a base', () => {
     const projection = computeScoreProjection({
       current: scores(),
@@ -181,8 +223,45 @@ describe('gatherScoreProjection (IO wrapper seams)', () => {
     );
     expect(out.projection.status).toBe('unavailable');
     if (out.projection.status !== 'unavailable') return;
-    expect(out.projection.reason).toContain('trimmed analysis');
+    expect(out.projection.reason).toContain('no full shared analysis');
     expect(read).toBe(0);
+  });
+
+  it('ref-based mode => quiet structural unavailable: JSON disclosure, no human line, no work', async () => {
+    let peeked = 0;
+    let read = 0;
+    const out = await gatherScoreProjection(
+      '/nowhere',
+      {},
+      {
+        peek: async () => {
+          peeked += 1;
+          return { report };
+        },
+        readHistory: () => {
+          read += 1;
+          return [entry()];
+        },
+      },
+      'ref-based',
+    );
+    expect(out.projection.status).toBe('unavailable');
+    if (out.projection.status !== 'unavailable') return;
+    expect(out.projection.reason).toContain('ref-based mode');
+    expect(out.projection.reason).toContain('impact.projectScores');
+    expect(out.projection.quiet).toBe(true);
+    // The human line is suppressed; the JSON keeps the disclosure.
+    expect(formatScoreProjection(out.projection)).toBeNull();
+    expect(peeked).toBe(0);
+    expect(read).toBe(0);
+    // A committed mode takes the normal path.
+    const committed = await gatherScoreProjection(
+      '/nowhere',
+      {},
+      { peek: async () => ({ report }), readHistory: () => [entry()] },
+      'committed-full',
+    );
+    expect(committed.projection.status).toBe('projected');
   });
 
   it('a throwing seam degrades to a disclosed unavailable, never an exception into the gate', async () => {
@@ -248,6 +327,9 @@ describe('formatScoreProjection (one phrasing)', () => {
     expect(formatScoreProjection({ status: 'unavailable', reason: 'no history' })).toBe(
       'scores not projected: no history',
     );
+    expect(
+      formatScoreProjection({ status: 'unavailable', reason: 'structural', quiet: true }),
+    ).toBeNull();
     expect(formatScoreProjection({ status: 'disabled', reason: 'off' })).toBeNull();
   });
 });

--- a/test/baseline/impact-renderers.test.ts
+++ b/test/baseline/impact-renderers.test.ts
@@ -33,6 +33,8 @@ import type { ClassifiedPair } from '../../src/gate/result';
 import type { BaselineEntry, FindingSeverity, FindingStatus } from '../../src/baseline/types';
 import { trustedLocalContext } from '../../src/analysis-trust';
 import { deriveImpact } from '../../src/baseline/impact';
+import { computeScoreProjection } from '../../src/baseline/impact-projection';
+import { SCORING_METHODOLOGY_VERSION } from '../../src/scoring/methodology';
 import { findTool, TOOL_DEFS } from '../../src/analyzers/tools/tool-registry';
 
 function git(dir: string, args: string[]): void {
@@ -81,6 +83,37 @@ const RESOLVING_PAIRS = [
   pair('removed', { kind: 'dep-vuln', severity: 'high' }),
   pair('removed', { kind: 'dep-vuln', severity: 'medium' }),
 ];
+
+/** A projected outcome (security 40 -> 46 against a comparable snapshot). */
+const PROJECTED = computeScoreProjection({
+  current: {
+    overall: 52,
+    security: 46,
+    quality: 60,
+    tests: 55,
+    documentation: 30,
+    maintainability: 70,
+    developerExperience: 65,
+  },
+  methodology: SCORING_METHODOLOGY_VERSION,
+  history: [
+    {
+      sha: 'baseentrysha0000',
+      date: '2026-08-20T00:00:00.000Z',
+      dxkitVersion: '4.4.7',
+      methodology: SCORING_METHODOLOGY_VERSION,
+      scores: {
+        overall: 50,
+        security: 40,
+        quality: 60,
+        tests: 55,
+        documentation: 30,
+        maintainability: 70,
+        developerExperience: 65,
+      },
+    },
+  ],
+});
 
 const CAPPED_SCORE: ImpactScoreInput = {
   dimension: 'security',
@@ -148,6 +181,35 @@ describe('the Impact section reaches every check surface', () => {
     );
     // Without a score result the section carries the finding delta alone.
     expect(renderMarkdown(withResolved)).not.toContain('capped by');
+  });
+
+  it('markdown: the projection line + hidden marker render inside the section, labeled projected (P2)', () => {
+    const withResolved = { ...base, pairs: [...base.pairs, ...RESOLVING_PAIRS] };
+    const md = renderMarkdown(withResolved, { scoreProjection: PROJECTED });
+    expect(md).toContain('security 40 -> 46 (projected)');
+    expect(md).toContain('<!-- dxkit-impact-projection ');
+    // A non-projected outcome renders its disclosure, and no marker.
+    const disclosed = renderMarkdown(withResolved, {
+      scoreProjection: { status: 'unavailable', reason: 'no score history on the reports ref yet' },
+    });
+    expect(disclosed).toContain('scores not projected: no score history');
+    expect(disclosed).not.toContain('<!-- dxkit-impact-projection ');
+    // Disabled: no line at all, section otherwise intact.
+    const off = renderMarkdown(withResolved, {
+      scoreProjection: { status: 'disabled', reason: 'impact.projectScores is false' },
+    });
+    expect(off).toContain('### Impact');
+    expect(off).not.toContain('(projected)');
+  });
+
+  it('console + json: the projection reaches the other two surfaces (labeled, additive)', () => {
+    const withResolved = { ...base, pairs: [...base.pairs, ...RESOLVING_PAIRS] };
+    const out = renderConsole(withResolved, { scoreProjection: PROJECTED });
+    expect(out).toContain('security 40 -> 46 (projected)');
+    const json = renderJson(withResolved, { scoreProjection: PROJECTED });
+    expect(json.impact?.projection?.status).toBe('projected');
+    // The JSON stays additive: without a projection the field is simply absent.
+    expect(renderJson(withResolved).impact?.projection).toBeUndefined();
   });
 
   it('markdown: an excluded (not_observed / tooling_drift) pair is disclosed, not counted', () => {

--- a/test/baseline/impact-renderers.test.ts
+++ b/test/baseline/impact-renderers.test.ts
@@ -350,6 +350,14 @@ describe('a refused run (CANNOT GATE) never renders a resolved claim (Rule 19 at
     expect(json.verdict.refused).toBe(true);
   });
 
+  it('json: a refused run neutralizes the projection: never projected deltas under CANNOT GATE', () => {
+    const json = renderJson(refused(), { scoreProjection: PROJECTED });
+    expect(json.impact?.projection?.status).toBe('unavailable');
+    expect(
+      json.impact?.projection?.status === 'unavailable' ? json.impact.projection.reason : undefined,
+    ).toContain('could not attribute');
+  });
+
   it('a missing required observation refuses the same way', () => {
     const req = {
       ...base,

--- a/test/reports/history.test.ts
+++ b/test/reports/history.test.ts
@@ -90,6 +90,15 @@ describe('report history codec', () => {
     expect(parsed.map((e) => e.sha)).toEqual(['a', 'b']);
   });
 
+  it('parses the methodology stamp and omits it when absent (pre-4.4.7 lines)', () => {
+    const stamped = parseHistory(
+      JSON.stringify({ sha: 'a', date: 'd', scores, methodology: 'spec-v1' }) + '\n',
+    );
+    expect(stamped[0].methodology).toBe('spec-v1');
+    const unstamped = parseHistory(JSON.stringify({ sha: 'a', date: 'd', scores }) + '\n');
+    expect(unstamped[0].methodology).toBeUndefined();
+  });
+
   it('tolerates + preserves unknown/extra fields on a line', () => {
     const parsed = parseHistory(
       JSON.stringify({ ...entry('a'), futureField: { nested: 1 } }) + '\n',

--- a/test/reports/history.test.ts
+++ b/test/reports/history.test.ts
@@ -99,6 +99,17 @@ describe('report history codec', () => {
     expect(unstamped[0].methodology).toBeUndefined();
   });
 
+  it('parses the scoreInputs stamp; a malformed one is dropped, not fatal', () => {
+    const stamped = parseHistory(
+      JSON.stringify({ sha: 'a', date: 'd', scores, scoreInputs: ['!gitleaks', 'semgrep'] }) + '\n',
+    );
+    expect(stamped[0].scoreInputs).toEqual(['!gitleaks', 'semgrep']);
+    const malformed = parseHistory(
+      JSON.stringify({ sha: 'a', date: 'd', scores, scoreInputs: [1, 'semgrep'] }) + '\n',
+    );
+    expect(malformed[0].scoreInputs).toBeUndefined();
+  });
+
   it('tolerates + preserves unknown/extra fields on a line', () => {
     const parsed = parseHistory(
       JSON.stringify({ ...entry('a'), futureField: { nested: 1 } }) + '\n',

--- a/test/reports/landed-comment.test.ts
+++ b/test/reports/landed-comment.test.ts
@@ -1,0 +1,238 @@
+/**
+ * The post-merge landed update (impact surface P2): the reports lane patches
+ * the merged PR's EXISTING guardrail comment with actual-vs-projected scores.
+ *
+ * Pins:
+ *   - ONE comment identity: the updater finds the comment by the SAME marker
+ *     literal the guardrail workflow template writes (parity-pinned against
+ *     the template so the identities cannot fork), and PATCHes it in place;
+ *   - calibration honesty: the updated comment carries the actual labeled
+ *     actual beside the original projection ("projection was P"); with no
+ *     projection marker, actual only; zero movement reported as zero;
+ *   - idempotence: a re-run replaces the landed section, never stacks;
+ *   - degradation: no merged PR, no guardrail comment, or a token without
+ *     `pull-requests: write` each produce a disclosed skip, never a throw.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  GUARDRAIL_COMMENT_MARKER,
+  IMPACT_LANDED_MARKER,
+  renderLandedSection,
+  updateLandedComment,
+  type GhExec,
+} from '../../src/reports/landed-comment';
+import {
+  computeScoreProjection,
+  impactProjectionMarker,
+} from '../../src/baseline/impact-projection';
+import { SCORING_METHODOLOGY_VERSION } from '../../src/scoring/methodology';
+import type { ReportHistoryEntry, ReportScores } from '../../src/reports/history';
+
+function scores(overrides: Partial<ReportScores> = {}): ReportScores {
+  return {
+    overall: 50,
+    security: 40,
+    quality: 60,
+    tests: 55,
+    documentation: 30,
+    maintainability: 70,
+    developerExperience: 65,
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<ReportHistoryEntry> = {}): ReportHistoryEntry {
+  return {
+    sha: 'feedfacefeedface',
+    date: '2026-08-27T00:00:00.000Z',
+    dxkitVersion: '4.4.7',
+    methodology: SCORING_METHODOLOGY_VERSION,
+    scores: scores(),
+    ...overrides,
+  };
+}
+
+/** A guardrail PR comment body carrying a projection for security 40 -> 46. */
+function guardrailCommentBody(): string {
+  const projection = computeScoreProjection({
+    current: scores({ security: 46 }),
+    methodology: SCORING_METHODOLOGY_VERSION,
+    history: [entry({ sha: 'baseentrysha0000' })],
+  });
+  const marker = impactProjectionMarker(projection);
+  return `${GUARDRAIL_COMMENT_MARKER}\n### dxkit guardrails\n\nsecurity 40 -> 46 (projected)\n${marker}\n`;
+}
+
+/** Injected gh spy: routes api paths to canned JSON, records PATCH bodies. */
+function ghSpy(fixtures: {
+  pulls?: unknown;
+  comments?: unknown;
+  patchError?: string;
+  pullsError?: string;
+}): { exec: GhExec; patched: string[] } {
+  const patched: string[] = [];
+  const exec: GhExec = (args, opts) => {
+    const joined = args.join(' ');
+    if (joined.includes('/commits/')) {
+      if (fixtures.pullsError) throw new Error(fixtures.pullsError);
+      return JSON.stringify(fixtures.pulls ?? []);
+    }
+    if (joined.includes('-X PATCH')) {
+      if (fixtures.patchError) throw new Error(fixtures.patchError);
+      patched.push(opts?.input ?? '');
+      return '';
+    }
+    if (joined.includes('/comments')) {
+      return JSON.stringify(fixtures.comments ?? []);
+    }
+    throw new Error(`unexpected gh call: ${joined}`);
+  };
+  return { exec, patched };
+}
+
+describe('comment-identity parity with the workflow templates', () => {
+  const templates = join(__dirname, '..', '..', 'src-templates', '.github', 'workflows');
+
+  it('the guardrail template writes the SAME marker literal the updater searches for', () => {
+    const yml = readFileSync(join(templates, 'dxkit-guardrails.yml'), 'utf8');
+    expect(yml).toContain(`MARKER='${GUARDRAIL_COMMENT_MARKER}'`);
+  });
+
+  it('the reports template grants pull-requests: write and passes --pr-comment', () => {
+    const yml = readFileSync(join(templates, 'dxkit-reports-refresh.yml'), 'utf8');
+    expect(yml).toContain('pull-requests: write');
+    expect(yml).toContain('report snapshot --pr-comment');
+    expect(yml).toContain('GH_TOKEN');
+  });
+});
+
+describe('renderLandedSection', () => {
+  const prev = entry({ sha: 'baseentrysha0000' });
+
+  it('actual beside the original projection, flat dimensions folded, overall named', () => {
+    const cur = entry({ scores: scores({ security: 46, overall: 52 }) });
+    const projection = {
+      methodology: SCORING_METHODOLOGY_VERSION,
+      scores: { security: { from: 40, to: 46 } },
+    };
+    const section = renderLandedSection(cur, prev, projection);
+    expect(section).toContain(IMPACT_LANDED_MARKER);
+    expect(section).toContain('security 40 -> 46 (actual; projection was 46)');
+    expect(section).toContain('other dimensions unchanged');
+    expect(section).toContain('Repo overall: 50 -> 52.');
+  });
+
+  it('a flat actual against a moving projection is listed (the calibration signal)', () => {
+    const cur = entry({ scores: scores() }); // security stayed 40
+    const projection = {
+      methodology: SCORING_METHODOLOGY_VERSION,
+      scores: { security: { from: 40, to: 46 } },
+    };
+    const section = renderLandedSection(cur, prev, projection);
+    expect(section).toContain('security 40 -> 40 (actual; projection was 46)');
+  });
+
+  it('absent projection => actual only; zero movement reported as zero', () => {
+    const section = renderLandedSection(entry(), prev, null);
+    expect(section).toContain('scores unchanged (actual)');
+    expect(section).not.toContain('projection was');
+  });
+
+  it('a methodology mismatch across snapshots is disclosed, never diffed', () => {
+    const section = renderLandedSection(entry(), entry({ methodology: 'spec-v0' }), null);
+    expect(section).toContain('not comparable across these snapshots');
+    expect(section).toContain("'spec-v0'");
+    expect(section).not.toContain('(actual');
+  });
+
+  it('the first snapshot on record says so instead of inventing a delta', () => {
+    const section = renderLandedSection(entry(), undefined, null);
+    expect(section).toContain('First score snapshot on record');
+    expect(section).toContain('(overall 50)');
+  });
+});
+
+describe('updateLandedComment', () => {
+  const inputs = (exec: GhExec) => ({
+    slug: 'acme/widgets',
+    sha: 'feedfacefeedface',
+    entry: entry({ scores: scores({ security: 46, overall: 52 }) }),
+    prev: entry({ sha: 'baseentrysha0000' }),
+    exec,
+  });
+
+  it('patches the SAME guardrail comment: actual + the original projection, marker retained', () => {
+    const { exec, patched } = ghSpy({
+      pulls: [{ number: 41 }],
+      comments: [
+        { id: 7, body: 'someone elses comment' },
+        { id: 9, body: guardrailCommentBody() },
+      ],
+    });
+    const outcome = updateLandedComment(inputs(exec));
+    expect(outcome).toEqual({ status: 'updated', prNumber: 41 });
+    expect(patched).toHaveLength(1);
+    const body = patched[0]!;
+    // Same identity: the guardrail marker still leads the body.
+    expect(body.startsWith(GUARDRAIL_COMMENT_MARKER)).toBe(true);
+    // The original projection line and its machine marker survive.
+    expect(body).toContain('security 40 -> 46 (projected)');
+    expect(body).toContain('<!-- dxkit-impact-projection ');
+    // The landed section carries actual + the projection it calibrates.
+    expect(body).toContain('security 40 -> 46 (actual; projection was 46)');
+  });
+
+  it('a re-run replaces the landed section instead of stacking a second one', () => {
+    const first = ghSpy({
+      pulls: [{ number: 41 }],
+      comments: [{ id: 9, body: guardrailCommentBody() }],
+    });
+    updateLandedComment(inputs(first.exec));
+    const second = ghSpy({
+      pulls: [{ number: 41 }],
+      comments: [{ id: 9, body: first.patched[0]! }],
+    });
+    updateLandedComment(inputs(second.exec));
+    const body = second.patched[0]!;
+    expect(body.split(IMPACT_LANDED_MARKER)).toHaveLength(2);
+    expect(body.split('### Landed')).toHaveLength(2);
+  });
+
+  it('absent projection marker => actual-only landed line', () => {
+    const { exec, patched } = ghSpy({
+      pulls: [{ number: 41 }],
+      comments: [{ id: 9, body: `${GUARDRAIL_COMMENT_MARKER}\nplain report\n` }],
+    });
+    updateLandedComment(inputs(exec));
+    expect(patched[0]).toContain('security 40 -> 46 (actual)');
+    expect(patched[0]).not.toContain('projection was');
+  });
+
+  it('no merged PR for the sha => disclosed skip', () => {
+    const { exec } = ghSpy({ pulls: [] });
+    const outcome = updateLandedComment(inputs(exec));
+    expect(outcome.status).toBe('skipped');
+    expect(outcome.reason).toContain('no merged pull request');
+  });
+
+  it('no guardrail comment on the PR => disclosed skip', () => {
+    const { exec } = ghSpy({ pulls: [{ number: 41 }], comments: [{ id: 7, body: 'hi' }] });
+    const outcome = updateLandedComment(inputs(exec));
+    expect(outcome.status).toBe('skipped');
+    expect(outcome.reason).toContain('no dxkit guardrail comment');
+  });
+
+  it('a PATCH refusal (missing pull-requests: write) => disclosed skip naming the scope, never a throw', () => {
+    const { exec } = ghSpy({
+      pulls: [{ number: 41 }],
+      comments: [{ id: 9, body: guardrailCommentBody() }],
+      patchError: 'HTTP 403: Resource not accessible by integration',
+    });
+    const outcome = updateLandedComment(inputs(exec));
+    expect(outcome.status).toBe('skipped');
+    expect(outcome.reason).toContain('403');
+    expect(outcome.reason).toContain('pull-requests: write');
+  });
+});

--- a/test/reports/landed-comment.test.ts
+++ b/test/reports/landed-comment.test.ts
@@ -140,6 +140,28 @@ describe('renderLandedSection', () => {
     expect(section).not.toContain('projection was');
   });
 
+  it('score-input drift across snapshots is disclosed, never diffed (Rule 19 cause 5)', () => {
+    const section = renderLandedSection(
+      entry({ scoreInputs: ['!gitleaks', 'grep-secrets', 'semgrep'] }),
+      entry({ sha: 'baseentrysha0000', scoreInputs: ['gitleaks', 'semgrep'] }),
+      null,
+    );
+    expect(section).toContain('not comparable across these snapshots');
+    expect(section).toContain('gitleaks');
+    expect(section).not.toContain('(actual');
+  });
+
+  it('a projected dimension unmeasured at merge keeps its calibration line', () => {
+    const cur = entry({ scores: scores({ tests: null, security: 46, overall: 52 }) });
+    const projection = {
+      methodology: SCORING_METHODOLOGY_VERSION,
+      scores: { security: { from: 40, to: 46 }, tests: { from: 55, to: 60 } },
+    };
+    const section = renderLandedSection(cur, prev, projection);
+    expect(section).toContain('security 40 -> 46 (actual; projection was 46)');
+    expect(section).toContain('tests not measured at merge (projection was 60)');
+  });
+
   it('a methodology mismatch across snapshots is disclosed, never diffed', () => {
     const section = renderLandedSection(entry(), entry({ methodology: 'spec-v0' }), null);
     expect(section).toContain('not comparable across these snapshots');
@@ -165,7 +187,7 @@ describe('updateLandedComment', () => {
 
   it('patches the SAME guardrail comment: actual + the original projection, marker retained', () => {
     const { exec, patched } = ghSpy({
-      pulls: [{ number: 41 }],
+      pulls: [{ number: 41, merge_commit_sha: 'feedfacefeedface' }],
       comments: [
         { id: 7, body: 'someone elses comment' },
         { id: 9, body: guardrailCommentBody() },
@@ -186,12 +208,12 @@ describe('updateLandedComment', () => {
 
   it('a re-run replaces the landed section instead of stacking a second one', () => {
     const first = ghSpy({
-      pulls: [{ number: 41 }],
+      pulls: [{ number: 41, merge_commit_sha: 'feedfacefeedface' }],
       comments: [{ id: 9, body: guardrailCommentBody() }],
     });
     updateLandedComment(inputs(first.exec));
     const second = ghSpy({
-      pulls: [{ number: 41 }],
+      pulls: [{ number: 41, merge_commit_sha: 'feedfacefeedface' }],
       comments: [{ id: 9, body: first.patched[0]! }],
     });
     updateLandedComment(inputs(second.exec));
@@ -202,12 +224,90 @@ describe('updateLandedComment', () => {
 
   it('absent projection marker => actual-only landed line', () => {
     const { exec, patched } = ghSpy({
-      pulls: [{ number: 41 }],
+      pulls: [{ number: 41, merge_commit_sha: 'feedfacefeedface' }],
       comments: [{ id: 9, body: `${GUARDRAIL_COMMENT_MARKER}\nplain report\n` }],
     });
     updateLandedComment(inputs(exec));
     expect(patched[0]).toContain('security 40 -> 46 (actual)');
     expect(patched[0]).not.toContain('projection was');
+  });
+
+  it('the merge-commit match wins over listing order (rebase flows list several PRs)', () => {
+    const { exec, patched } = ghSpy({
+      pulls: [
+        {
+          number: 7,
+          merge_commit_sha: 'someothersha0000',
+          merged_at: '2026-08-27T00:00:00Z',
+          base: { ref: 'main', repo: { default_branch: 'main' } },
+        },
+        { number: 41, merge_commit_sha: 'feedfacefeedface' },
+      ],
+      comments: [{ id: 9, body: guardrailCommentBody() }],
+    });
+    const outcome = updateLandedComment(inputs(exec));
+    expect(outcome).toEqual({ status: 'updated', prNumber: 41 });
+    expect(patched).toHaveLength(1);
+  });
+
+  it('without a merge-commit match, two merged default-branch candidates => disclosed ambiguous skip', () => {
+    const candidate = (n: number) => ({
+      number: n,
+      merge_commit_sha: 'someothersha0000',
+      merged_at: '2026-08-27T00:00:00Z',
+      base: { ref: 'main', repo: { default_branch: 'main' } },
+    });
+    const { exec, patched } = ghSpy({
+      pulls: [candidate(7), candidate(8)],
+      comments: [{ id: 9, body: guardrailCommentBody() }],
+    });
+    const outcome = updateLandedComment(inputs(exec));
+    expect(outcome.status).toBe('skipped');
+    expect(outcome.reason).toContain('ambiguous pull-request association');
+    expect(patched).toHaveLength(0);
+  });
+
+  it('without a merge-commit match, exactly ONE merged default-branch candidate is accepted', () => {
+    const { exec, patched } = ghSpy({
+      pulls: [
+        {
+          number: 7,
+          merge_commit_sha: 'someothersha0000',
+          merged_at: '2026-08-27T00:00:00Z',
+          base: { ref: 'main', repo: { default_branch: 'main' } },
+        },
+        { number: 8, merge_commit_sha: 'unrelatedsha0000' },
+      ],
+      comments: [{ id: 9, body: guardrailCommentBody() }],
+    });
+    const outcome = updateLandedComment(inputs(exec));
+    expect(outcome).toEqual({ status: 'updated', prNumber: 7 });
+    expect(patched).toHaveLength(1);
+  });
+
+  it('the cron re-publish with drifted score inputs => disclosed skip, comment untouched', () => {
+    // Same merged sha, but the scheduled re-run scored under different
+    // tooling (gitleaks gone, the grep fallback engaged): the landed line
+    // must not be rewritten with movement the PR never caused.
+    let ghCalls = 0;
+    const exec: GhExec = () => {
+      ghCalls += 1;
+      throw new Error('gh must not be called on a drifted-inputs skip');
+    };
+    const outcome = updateLandedComment({
+      slug: 'acme/widgets',
+      sha: 'feedfacefeedface',
+      entry: entry({
+        scores: scores({ security: 12, overall: 30 }),
+        scoreInputs: ['!gitleaks', 'grep-secrets', 'semgrep'],
+      }),
+      prev: entry({ sha: 'baseentrysha0000', scoreInputs: ['gitleaks', 'semgrep'] }),
+      exec,
+    });
+    expect(outcome.status).toBe('skipped');
+    expect(outcome.reason).toContain('gitleaks');
+    expect(outcome.reason).toContain('tooling drift');
+    expect(ghCalls).toBe(0);
   });
 
   it('no merged PR for the sha => disclosed skip', () => {
@@ -218,7 +318,10 @@ describe('updateLandedComment', () => {
   });
 
   it('no guardrail comment on the PR => disclosed skip', () => {
-    const { exec } = ghSpy({ pulls: [{ number: 41 }], comments: [{ id: 7, body: 'hi' }] });
+    const { exec } = ghSpy({
+      pulls: [{ number: 41, merge_commit_sha: 'feedfacefeedface' }],
+      comments: [{ id: 7, body: 'hi' }],
+    });
     const outcome = updateLandedComment(inputs(exec));
     expect(outcome.status).toBe('skipped');
     expect(outcome.reason).toContain('no dxkit guardrail comment');
@@ -226,7 +329,7 @@ describe('updateLandedComment', () => {
 
   it('a PATCH refusal (missing pull-requests: write) => disclosed skip naming the scope, never a throw', () => {
     const { exec } = ghSpy({
-      pulls: [{ number: 41 }],
+      pulls: [{ number: 41, merge_commit_sha: 'feedfacefeedface' }],
       comments: [{ id: 9, body: guardrailCommentBody() }],
       patchError: 'HTTP 403: Resource not accessible by integration',
     });

--- a/test/reports/snapshot.test.ts
+++ b/test/reports/snapshot.test.ts
@@ -9,6 +9,7 @@ import {
   readReportHistory,
   type SnapshotSource,
 } from '../../src/reports/snapshot';
+import { SCORING_METHODOLOGY_VERSION } from '../../src/scoring/methodology';
 
 const source: SnapshotSource = {
   summary: { overallScore: 72 },
@@ -35,6 +36,11 @@ describe('reportToHistoryEntry', () => {
       developerExperience: 70,
     });
     expect(e.sha).toBe('abc');
+  });
+
+  it('stamps the scoring-methodology identity on every entry (impact P2)', () => {
+    const e = reportToHistoryEntry(source, { sha: 'abc', date: 'd', dxkitVersion: '4.4.7' });
+    expect(e.methodology).toBe(SCORING_METHODOLOGY_VERSION);
   });
 
   it('maps a missing/unmeasured dimension to null', () => {
@@ -100,6 +106,26 @@ describe('publishReportSnapshot', () => {
     }
     const history = readReportHistory(repo);
     expect(history.map((h) => h.sha)).toEqual(['c', 'd']);
+  });
+
+  it('returns the previous entry (the base the org saw) for the landed update', () => {
+    const first = publishReportSnapshot({
+      cwd: repo,
+      entry: reportToHistoryEntry(source, { sha: 'sha1', date: 'd1', dxkitVersion: '3.0.0' }),
+    });
+    expect(first.previousEntry).toBeUndefined();
+    const second = publishReportSnapshot({
+      cwd: repo,
+      entry: reportToHistoryEntry(source, { sha: 'sha2', date: 'd2', dxkitVersion: '3.0.0' }),
+    });
+    expect(second.previousEntry?.sha).toBe('sha1');
+    // An idempotent re-publish of the same SHA compares against the entry
+    // BEFORE it, never against itself.
+    const replay = publishReportSnapshot({
+      cwd: repo,
+      entry: reportToHistoryEntry(source, { sha: 'sha2', date: 'd2b', dxkitVersion: '3.0.0' }),
+    });
+    expect(replay.previousEntry?.sha).toBe('sha1');
   });
 
   it('re-publishing the same merge SHA replaces (idempotent), no dup line', () => {

--- a/test/reports/snapshot.test.ts
+++ b/test/reports/snapshot.test.ts
@@ -10,6 +10,28 @@ import {
   type SnapshotSource,
 } from '../../src/reports/snapshot';
 import { SCORING_METHODOLOGY_VERSION } from '../../src/scoring/methodology';
+import { describeScoreInputsDrift, scoreToolInputs } from '../../src/reports/snapshot';
+
+describe('score-input comparability primitives (Rule 19 cause 5)', () => {
+  it('scoreToolInputs sorts, dedupes, and strips unavailable reasons', () => {
+    expect(
+      scoreToolInputs({
+        toolsUsed: ['semgrep', 'semgrep', ' cloc '],
+        toolsUnavailable: ['jscpd (timed out after 120s)', 'gitleaks'],
+      }),
+    ).toEqual(['!gitleaks', '!jscpd', 'cloc', 'semgrep']);
+    expect(scoreToolInputs({})).toEqual([]);
+  });
+
+  it('describeScoreInputsDrift names movement both directions, null on match or unstamped', () => {
+    expect(describeScoreInputsDrift(['a', 'b'], ['a', 'b'])).toBeNull();
+    expect(describeScoreInputsDrift(undefined, ['a'])).toBeNull();
+    expect(describeScoreInputsDrift(['a'], undefined)).toBeNull();
+    const drift = describeScoreInputsDrift(['gitleaks', 'semgrep'], ['grep-secrets', 'semgrep']);
+    expect(drift).toContain('at the base but not now: gitleaks');
+    expect(drift).toContain('now but not at the base: grep-secrets');
+  });
+});
 
 const source: SnapshotSource = {
   summary: { overallScore: 72 },
@@ -41,6 +63,18 @@ describe('reportToHistoryEntry', () => {
   it('stamps the scoring-methodology identity on every entry (impact P2)', () => {
     const e = reportToHistoryEntry(source, { sha: 'abc', date: 'd', dxkitVersion: '4.4.7' });
     expect(e.methodology).toBe(SCORING_METHODOLOGY_VERSION);
+  });
+
+  it('stamps the normalized score inputs (used tools + !unavailable, reasons stripped)', () => {
+    const e = reportToHistoryEntry(
+      {
+        ...source,
+        toolsUsed: ['semgrep', 'grep-secrets', 'cloc'],
+        toolsUnavailable: ['gitleaks (not installed on this runner)'],
+      },
+      { sha: 'abc', date: 'd', dxkitVersion: '4.4.7' },
+    );
+    expect(e.scoreInputs).toEqual(['!gitleaks', 'cloc', 'grep-secrets', 'semgrep']);
   });
 
   it('maps a missing/unmeasured dimension to null', () => {


### PR DESCRIPTION
## What

Impact surface phase 2 (4.4.7 I2): projected dimension scores on the guardrail PR surfaces, and the post-merge actual-vs-projected update of the same PR comment.

- **Pre-merge projection.** `guardrail check` now renders "security 40 -> 46 (projected)" inside the Impact section. The current side is scored from the SAME shared `AnalysisResult` the guardrail run already gathered, via a new `peekAnalysisResult` probe that never builds, through `scoreAndFormatHealth` and the snapshot publisher's own `scoresFromReport` (one score computation path, per the reuse-first law). The base side is the latest `report-history.jsonl` snapshot on the reports ref: the number the org has already seen, never recomputed locally.
- **Methodology identity.** New `SCORING_METHODOLOGY_VERSION` constant (`src/scoring/methodology.ts`), stamped on every published history entry. Both sides must match or the surface discloses "scores not comparable this PR" (an unstamped pre-4.4.7 snapshot also reads as not comparable: absent evidence is not comparable evidence, the recall discipline applied to scores). Nothing is diffed across the boundary.
- **Post-merge actual.** `report snapshot --pr-comment` (passed by the reports-refresh workflow template) finds the merged PR for the snapshot sha, locates the existing guardrail comment by its one identity marker, and PATCHes a landed section into the SAME comment: "security 40 -> 46 (actual; projection was 46)". The projection comes back out of a hidden `dxkit-impact-projection` marker the pre-merge comment carries; absent projection renders actual only. Idempotent: an inner landed marker makes re-runs replace, never stack.
- **Honesty constraints (design, non-negotiable).** Projection labeled projected, actual labeled actual, zero movement reported as zero, unmeasured dimensions named, cross-version disclosed not compared, and no score line outside an attributable Impact section (a refused run claims nothing). The guardrail JSON grows the additive optional `impact.projection` field.

## The spike (measured before choosing the default)

What the projection costs after a full-scope guardrail gather in the same process (in-memory cache hit, then a pure re-score):

| tree | cold full gather (for contrast) | projection delta (cache hit) | pure `scoreAndFormatHealth` |
|---|---|---|---|
| dxkit repo itself (the largest tree available, ~430 test files / ~38k statements) | 81.9 s | **18 ms** | ~30 microseconds |
| largest analysis fixture (`test/fixtures/analysis/ts-webapp`) | 3.9 s | **11 ms** | ~25 microseconds |

Plus one shallow `git fetch` of the reports ref for the base side (about a second in CI), performed only when a full envelope exists. The delta is roughly three orders of magnitude under the 30 s bar, so per the resolved UX call the projection is **default ON** with the policy off-switch **`impact.projectScores`** (`false` disables; disclosed as such in the JSON). The cold column is why the projection NEVER re-gathers: when the run held only a trimmed gather (ref-based mode drops duplication/test-gap/custom-check/license analyzers), there is no full shared envelope and the projection declines with a disclosed reason instead of paying 80+ seconds or approximating from a partial gather.

## How the same-comment update works, and the missing-token case

The guardrail workflow already finds-and-patches its PR comment by the `<!-- dxkit-guardrails -->` marker. The landed update reuses exactly that identity (a parity test pins the src constant against the template literal), parses the projection marker out of the comment body, renders the landed section, and PATCHes the comment. The reports-refresh template gains `pull-requests: write` and `GH_TOKEN`. When the token lacks the scope (or there is no merged PR, or no guardrail comment), `updateLandedComment` returns a disclosed `skipped` outcome with the reason; the CLI prints it, appends it to the Actions step summary, and exits 0. The lane never fails for the comment, and a rejected snapshot publish also skips the comment (no landed entry means no landed claim).

## How it is tested

- `test/baseline/impact-projection.test.ts`: methodology guard both directions (match projects; mismatch and unstamped disclose), base-from-snapshot with empty history disclosed, the knob both values, the never-build/never-fetch cost guards (peek null means history not read), throwing seams degrade disclosed, all rendering forms, marker codec round-trip + malformed tolerance.
- `test/reports/landed-comment.test.ts`: injected `gh` exec end to end. Updated comment carries actual + the original projection with the guardrail marker retained; re-run replaces the landed section; absent projection renders actual only; no-PR / no-comment / 403-PATCH each produce the disclosed skip (the 403 path names `pull-requests: write`). Plus the template parity pins (marker literal, `pull-requests: write`, `--pr-comment`).
- `test/baseline/impact-renderers.test.ts` (extended): the projection line + hidden marker reach markdown, console, and the JSON `impact.projection` field, only inside an attributable section, additive when absent.
- `test/reports/history.test.ts` / `snapshot.test.ts` (extended): methodology stamp + tolerant parse, `previousEntry` returned by the publisher (idempotent replay compares against the entry before, never itself).
- `test/analysis-result-cache.test.ts` (extended): `peekAnalysisResult` returns the full envelope, never builds, and stays null after a partial (scoped) gather.

No timing instrumentation ships in product code; the spike script lived outside the repo.

## Sweep + guardrail

- `npm run typecheck` / `typecheck:test`: clean. `eslint --max-warnings 0`: clean. `prettier --check`: clean.
- `check-architecture.sh`: pass (exit 0; the pre-existing `[^: command not found` warning on line 2085 comes from the recipe-seam rule already on the release branch, unrelated to this diff).
- `check-docs-coverage.sh`, `check-slop.sh` (base origin/main): pass.
- Full `npx vitest run --coverage`: 430 files, 6582 tests, all green; coverage 75.42 percent (threshold 50).
- `node dist/index.js guardrail check --mode ref-based --ref origin/main`: **PASSED**, exit 0 (0 blocking, 0 warnings, 88 persisted pairs).

## Review focus

- The Rule 2 seam: the projection consumes `peekAnalysisResult` + `scoreAndFormatHealth` + `scoresFromReport` + `scoreDeltas`, all pre-existing single entry points; confirm no second score path slipped in.
- The comment identity: one marker (`GUARDRAIL_COMMENT_MARKER`) shared by template and updater, pinned by test; the landed section uses an inner marker for idempotence, not a second comment.
- The refusal interaction: the projection line renders only inside an attributable Impact section; a `CANNOT GATE` run keeps the not-attributable one-liner and nothing else.
- `SCORING_METHODOLOGY_VERSION` starts at `spec-v1`; the doc comment states the bump rule (any `src/scoring/` change that can move a score).

## Deliberately left out

- Lane PR ledgers (`verification-render.ts`) do not carry the projection yet: the lane's verify runs the gate engine directly without the CLI's projection wiring, and its base-snapshot semantics (a remediation branch mid-run) deserve their own call rather than a bolt-on here. The seam (`gatherScoreProjection` + `deriveImpact`'s projection slot) is ready for it.
- The trend line and `report trend` command are I3 by design.
- `runReportSnapshot`'s thin CLI glue around the landed update is not separately unit-tested (the module it delegates to is fully covered with injected exec; exercising the glue would mean a full `analyzeHealth` run for a few lines of plumbing, matching the existing coverage posture of that adapter).


## Review round (commits 061fbcc8 + a47a2de7)

1. **Score-input comparability (Rule 19 cause 5).** Snapshots now stamp `scoreInputs` (sorted tool names that ran, `!name` for attempted-but-unavailable, reasons stripped) beside `methodology`; `computeScoreProjection` and `renderLandedSection` both consult the one `describeScoreInputsDrift`, so a degraded-tooling run (gitleaks absent, untrusted-mode skips) is disclosed as not comparable naming the moved input, never diffed. The scheduled re-publish at the same sha under drifted tooling makes the landed update a disclosed skip before any `gh` call: a merged PR's landed line is never rewritten with movement the PR never caused. Tests both directions plus the cron-rewrite scenario.
2. **PR association.** `commits/{sha}/pulls` order is unspecified and rebase/fast-forward flows list every containing PR, so `[0]` could be wrong. The merge-commit match is now authoritative; failing that, exactly one merged default-branch candidate is accepted; anything else is a disclosed ambiguous skip. Tests: match wins over order; two candidates skip; exactly one candidate is accepted.
3. **Refusal JSON.** A CANNOT GATE run now neutralizes the projection in the JSON too (`deriveImpact` replaces a projected outcome with a disclosed unavailable), so an embedder reading `impact.projection` alone can never render a refused claim. Pinned in the refusal suite.
4. **Calibration line survives an unmeasured merge.** A dimension that was projected but unmeasured at merge renders "tests not measured at merge (projection was 60)" instead of vanishing. Test added.
5. **Release-branch defect, own commit (061fbcc8):** the second `RULE_RECIPE_PM_LITERAL` grep in `scripts/check-architecture.sh` carried unescaped backticks inside double quotes: bash ran them as command substitution (the `[^: command not found` noise on every run) and the pattern collapsed to any-PM-token-anywhere. Escaped; verified quiet on a clean tree, still biting on an injected backtick template literal with a PM command, and not firing on a double-quoted error message containing "npm".
6. **One key-to-dimension map.** `SCORE_KEY_TO_DIMENSION` (typed over the score keys, beside `SCORE_KEYS`) now feeds both `scoresFromReport` and `impactScoreInputsFromReport`; a seventh dimension fails to compile rather than silently missing a consumer.
7. **Ref-based standing disclosure: my call is SUPPRESS.** Ref-based mode short-circuits to a structural `unavailable` whose reason names both the cause (the mode gathers a trimmed analysis every run) and the off-switch (`impact.projectScores: false`); the JSON keeps the disclosure, the per-PR human line is suppressed (`quiet`), because the state is permanent to the mode and not actionable per PR. The residual committed-mode no-envelope case keeps its loud line. Documented in the policy guide.

**Release note for the R unit's changelog:** the updated reports-refresh workflow template passes `report snapshot --pr-comment`, which a pre-4.4.7 CLI rejects as an unknown flag (a hard error in the lane). `vyuh-dxkit update` refreshes the CLI pin and the template together, so the skew only arises if one is moved by hand; note it beside the template change.

Post-review sweep: typecheck/typecheck:test/eslint/prettier clean; arch-check exit 0 with zero stderr; docs-coverage + slop pass; full `vitest --coverage` 430 files / 6596 tests green, coverage 75.46 percent; `guardrail check --mode ref-based --ref origin/main` PASSED exit 0. Branch diff re-grepped clean for banned names and em-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

